### PR TITLE
Enhanced Tenant Rebalance Result with Aggregated Summary and Pre-check Result

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceSummaryResult.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceSummaryResult.java
@@ -69,13 +69,13 @@ public class RebalanceSummaryResult {
 
   @JsonInclude(JsonInclude.Include.NON_NULL)
   public static class ServerSegmentChangeInfo {
-    private final ServerStatus _serverStatus;
-    private final int _totalSegmentsAfterRebalance;
-    private final int _totalSegmentsBeforeRebalance;
-    private final int _segmentsAdded;
-    private final int _segmentsDeleted;
-    private final int _segmentsUnchanged;
-    private final List<String> _tagList;
+    protected ServerStatus _serverStatus;
+    protected int _totalSegmentsAfterRebalance;
+    protected int _totalSegmentsBeforeRebalance;
+    protected int _segmentsAdded;
+    protected int _segmentsDeleted;
+    protected int _segmentsUnchanged;
+    protected List<String> _tagList;
 
     /**
      * Constructor for ServerSegmentChangeInfo
@@ -189,10 +189,10 @@ public class RebalanceSummaryResult {
 
   public static class TagInfo {
     public static final String TAG_FOR_OUTDATED_SERVERS = "OUTDATED_SERVERS";
-    private final String _tagName;
-    private int _numSegmentsUnchanged;
-    private int _numSegmentsToDownload;
-    private int _numServerParticipants;
+    protected final String _tagName;
+    protected int _numSegmentsUnchanged;
+    protected int _numSegmentsToDownload;
+    protected int _numServerParticipants;
 
     @JsonCreator
     public TagInfo(
@@ -256,13 +256,13 @@ public class RebalanceSummaryResult {
 
   @JsonInclude(JsonInclude.Include.NON_NULL)
   public static class ServerInfo {
-    private final int _numServersGettingNewSegments;
-    private final RebalanceChangeInfo _numServers;
-    private final Set<String> _serversAdded;
-    private final Set<String> _serversRemoved;
-    private final Set<String> _serversUnchanged;
-    private final Set<String> _serversGettingNewSegments;
-    private final Map<String, ServerSegmentChangeInfo> _serverSegmentChangeInfo;
+    protected int _numServersGettingNewSegments;
+    protected RebalanceChangeInfo _numServers;
+    protected Set<String> _serversAdded;
+    protected Set<String> _serversRemoved;
+    protected Set<String> _serversUnchanged;
+    protected Set<String> _serversGettingNewSegments;
+    protected Map<String, ServerSegmentChangeInfo> _serverSegmentChangeInfo;
 
     /**
      * Constructor for ServerInfo
@@ -419,8 +419,8 @@ public class RebalanceSummaryResult {
     }
 
     public static class ConsumingSegmentSummaryPerServer {
-      private final int _numConsumingSegmentsToBeAdded;
-      private final int _totalOffsetsToCatchUpAcrossAllConsumingSegments;
+      protected int _numConsumingSegmentsToBeAdded;
+      protected int _totalOffsetsToCatchUpAcrossAllConsumingSegments;
 
       /**
        * Constructor for ConsumingSegmentSummaryPerServer
@@ -477,15 +477,15 @@ public class RebalanceSummaryResult {
   @JsonInclude(JsonInclude.Include.NON_NULL)
   public static class SegmentInfo {
     // TODO: Add a metric to estimate the total time it will take to rebalance
-    private final int _totalSegmentsToBeMoved;
-    private final int _totalSegmentsToBeDeleted;
-    private final int _maxSegmentsAddedToASingleServer;
-    private final long _estimatedAverageSegmentSizeInBytes;
-    private final long _totalEstimatedDataToBeMovedInBytes;
-    private final RebalanceChangeInfo _replicationFactor;
-    private final RebalanceChangeInfo _numSegmentsInSingleReplica;
-    private final RebalanceChangeInfo _numSegmentsAcrossAllReplicas;
-    private final ConsumingSegmentToBeMovedSummary _consumingSegmentToBeMovedSummary;
+    protected int _totalSegmentsToBeMoved;
+    protected int _totalSegmentsToBeDeleted;
+    protected int _maxSegmentsAddedToASingleServer;
+    protected long _estimatedAverageSegmentSizeInBytes;
+    protected long _totalEstimatedDataToBeMovedInBytes;
+    protected RebalanceChangeInfo _replicationFactor;
+    protected RebalanceChangeInfo _numSegmentsInSingleReplica;
+    protected RebalanceChangeInfo _numSegmentsAcrossAllReplicas;
+    protected ConsumingSegmentToBeMovedSummary _consumingSegmentToBeMovedSummary;
 
     /**
      * Constructor for SegmentInfo

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/tenant/TenantRebalanceResult.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/tenant/TenantRebalanceResult.java
@@ -21,7 +21,6 @@ package org.apache.pinot.controller.helix.core.rebalance.tenant;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -123,6 +122,8 @@ public class TenantRebalanceResult {
             case ERROR:
               erroredTablesByCheck.get(checkName).put(tableName, message);
               break;
+            default:
+              break; // Ignore unknown statuses
           }
         }
       }
@@ -270,8 +271,9 @@ public class TenantRebalanceResult {
 
     for (RebalanceSummaryResult summary : summaryResults) {
       if (summary.getServerInfo() != null && summary.getServerInfo().getServerSegmentChangeInfo() != null) {
-        for (Map.Entry<String, RebalanceSummaryResult.ServerSegmentChangeInfo> entry :
-            summary.getServerInfo().getServerSegmentChangeInfo().entrySet()) {
+        for (Map.Entry<String, RebalanceSummaryResult.ServerSegmentChangeInfo> entry : summary.getServerInfo()
+            .getServerSegmentChangeInfo()
+            .entrySet()) {
           String serverName = entry.getKey();
           RebalanceSummaryResult.ServerSegmentChangeInfo changeInfo = entry.getValue();
 
@@ -372,11 +374,11 @@ public class TenantRebalanceResult {
       // Set the computed values using reflection or by updating the parent constructor call
       _numServersGettingNewSegments = numServersGettingNewSegments;
       _numServers = aggregatedNumServers;
-      _serversAdded = serversAdded.isEmpty() ? null : serversAdded;
-      _serversRemoved = serversRemoved.isEmpty() ? null : serversRemoved;
-      _serversUnchanged = serversUnchanged.isEmpty() ? null : serversUnchanged;
-      _serversGettingNewSegments = serversGettingNewSegments.isEmpty() ? null : serversGettingNewSegments;
-      _serverSegmentChangeInfo = finalServerSegmentChangeInfo.isEmpty() ? null : finalServerSegmentChangeInfo;
+      _serversAdded = serversAdded;
+      _serversRemoved = serversRemoved;
+      _serversUnchanged = serversUnchanged;
+      _serversGettingNewSegments = serversGettingNewSegments;
+      _serverSegmentChangeInfo = finalServerSegmentChangeInfo;
     }
   }
 
@@ -450,8 +452,9 @@ public class TenantRebalanceResult {
       }
 
       // Calculate average segment size
-      long estimatedAverageSegmentSizeInBytes = totalEstimatedDataToBeMovedInBytes >= 0 && totalSegmentsToBeMoved > 0 ?
-          totalEstimatedDataToBeMovedInBytes / totalSegmentsToBeMoved : 0;
+      long estimatedAverageSegmentSizeInBytes =
+          totalEstimatedDataToBeMovedInBytes >= 0 && totalSegmentsToBeMoved > 0 ? totalEstimatedDataToBeMovedInBytes
+              / totalSegmentsToBeMoved : 0;
 
       // Create aggregated RebalanceChangeInfo objects
       RebalanceSummaryResult.RebalanceChangeInfo aggregatedNumSegmentsInSingleReplica =
@@ -525,8 +528,9 @@ public class TenantRebalanceResult {
       // Aggregate server consuming segment summaries by server name
       if (summary.getServerConsumingSegmentSummary() != null) {
         for (Map.Entry<String,
-            RebalanceSummaryResult.ConsumingSegmentToBeMovedSummary.ConsumingSegmentSummaryPerServer> entry :
-            summary.getServerConsumingSegmentSummary().entrySet()) {
+            RebalanceSummaryResult.ConsumingSegmentToBeMovedSummary.ConsumingSegmentSummaryPerServer> entry
+            : summary.getServerConsumingSegmentSummary()
+            .entrySet()) {
           String serverName = entry.getKey();
           RebalanceSummaryResult.ConsumingSegmentToBeMovedSummary.ConsumingSegmentSummaryPerServer serverSummary =
               entry.getValue();
@@ -649,4 +653,3 @@ public class TenantRebalanceResult {
     }
   }
 }
-

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/tenant/TenantRebalanceResult.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/tenant/TenantRebalanceResult.java
@@ -36,8 +36,7 @@ import org.apache.pinot.controller.helix.core.rebalance.RebalanceSummaryResult;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
 @JsonPropertyOrder({
-    "jobId", "overallStatus", "totalTables", "statusSummary", "description",
-    "aggregatedPreChecksResult", "aggregatedSegmentCounts", "aggregatedInstanceCounts",
+    "jobId", "totalTables", "statusSummary", "aggregatedPreChecksResult",
     "aggregatedRebalanceSummary", "rebalanceTableResults"
 })
 public class TenantRebalanceResult {
@@ -47,8 +46,17 @@ public class TenantRebalanceResult {
   @JsonCreator
   public TenantRebalanceResult(
       @JsonProperty("jobId") String jobId,
-      @JsonProperty("rebalanceTableResults") Map<String, RebalanceResult> rebalanceTableResults) {
-    this(jobId, rebalanceTableResults, true);
+      @JsonProperty("rebalanceTableResults") Map<String, RebalanceResult> rebalanceTableResults,
+      @JsonProperty("totalTables") int totalTables,
+      @JsonProperty("statusSummary") Map<RebalanceResult.Status, Integer> statusSummary,
+      @JsonProperty("aggregatedPreChecksResult") Map<String, AggregatedPrecheckResult> aggregatedPreChecksResult,
+      @JsonProperty("aggregatedRebalanceSummary") RebalanceSummaryResult aggregatedRebalanceSummary) {
+    _jobId = jobId;
+    _rebalanceTableResults = rebalanceTableResults;
+    _totalTables = totalTables;
+    _statusSummary = statusSummary;
+    _aggregatedPreChecksResult = aggregatedPreChecksResult;
+    _aggregatedRebalanceSummary = aggregatedRebalanceSummary;
   }
 
   // Aggregated view fields

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/tenant/TenantRebalanceResult.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/tenant/TenantRebalanceResult.java
@@ -21,11 +21,26 @@ package org.apache.pinot.controller.helix.core.rebalance.tenant;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.pinot.controller.helix.core.rebalance.RebalancePreCheckerResult;
 import org.apache.pinot.controller.helix.core.rebalance.RebalanceResult;
+import org.apache.pinot.controller.helix.core.rebalance.RebalanceSummaryResult;
+
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonPropertyOrder({
+    "jobId", "overallStatus", "totalTables", "statusSummary", "description",
+    "aggregatedPreChecksResult", "aggregatedSegmentCounts", "aggregatedInstanceCounts",
+    "aggregatedRebalanceSummary", "rebalanceTableResults"
+})
 public class TenantRebalanceResult {
   private String _jobId;
   private Map<String, RebalanceResult> _rebalanceTableResults;
@@ -37,8 +52,23 @@ public class TenantRebalanceResult {
     this(jobId, rebalanceTableResults, true);
   }
 
+  // Aggregated view fields
+  private final int _totalTables;
+  private Map<RebalanceResult.Status, Integer> _statusSummary;
+
+  // Aggregated details from RebalanceResult fields
+  private Map<String, AggregatedPrecheckResult> _aggregatedPreChecksResult;
+  private RebalanceSummaryResult _aggregatedRebalanceSummary;
+
   public TenantRebalanceResult(String jobId, Map<String, RebalanceResult> rebalanceTableResults, boolean verbose) {
     _jobId = jobId;
+    _totalTables = rebalanceTableResults.size();
+
+    // Compute aggregated information
+    computeStatusSummary(rebalanceTableResults);
+    computeAggregatedPreChecks(rebalanceTableResults);
+    computeAggregatedRebalanceSummary(rebalanceTableResults);
+
     if (verbose) {
       _rebalanceTableResults = rebalanceTableResults;
     } else {
@@ -50,10 +80,121 @@ public class TenantRebalanceResult {
     }
   }
 
+  private void computeStatusSummary(Map<String, RebalanceResult> rebalanceTableResults) {
+    _statusSummary = new HashMap<>();
+    for (RebalanceResult result : rebalanceTableResults.values()) {
+      RebalanceResult.Status status = result.getStatus();
+      _statusSummary.put(status, _statusSummary.getOrDefault(status, 0) + 1);
+    }
+  }
+
+  private void computeAggregatedPreChecks(Map<String, RebalanceResult> rebalanceTableResults) {
+    _aggregatedPreChecksResult = new HashMap<>();
+
+    // Organize pre-check results by pre-check name
+    Map<String, Map<String, String>> passedTablesByCheck = new HashMap<>();
+    Map<String, Map<String, String>> warnedTablesByCheck = new HashMap<>();
+    Map<String, Map<String, String>> erroredTablesByCheck = new HashMap<>();
+
+    // Process each table's pre-check results
+    for (Map.Entry<String, RebalanceResult> entry : rebalanceTableResults.entrySet()) {
+      String tableName = entry.getKey();
+      RebalanceResult result = entry.getValue();
+
+      if (result.getPreChecksResult() != null) {
+        for (Map.Entry<String, RebalancePreCheckerResult> checkEntry : result.getPreChecksResult().entrySet()) {
+          String checkName = checkEntry.getKey();
+          RebalancePreCheckerResult checkResult = checkEntry.getValue();
+
+          // Initialize maps for this check if not present
+          passedTablesByCheck.computeIfAbsent(checkName, k -> new HashMap<>());
+          warnedTablesByCheck.computeIfAbsent(checkName, k -> new HashMap<>());
+          erroredTablesByCheck.computeIfAbsent(checkName, k -> new HashMap<>());
+
+          // Categorize table based on this specific check's status
+          String message = checkResult.getMessage() != null ? checkResult.getMessage() : "";
+          switch (checkResult.getPreCheckStatus()) {
+            case PASS:
+              passedTablesByCheck.get(checkName).put(tableName, message);
+              break;
+            case WARN:
+              warnedTablesByCheck.get(checkName).put(tableName, message);
+              break;
+            case ERROR:
+              erroredTablesByCheck.get(checkName).put(tableName, message);
+              break;
+          }
+        }
+      }
+    }
+
+    // Create AggregatedPrecheckResult for each pre-check type
+    for (String checkName : passedTablesByCheck.keySet()) {
+      Map<String, String> passedTables = passedTablesByCheck.get(checkName);
+      Map<String, String> warnedTables = warnedTablesByCheck.get(checkName);
+      Map<String, String> erroredTables = erroredTablesByCheck.get(checkName);
+
+      _aggregatedPreChecksResult.put(checkName, new AggregatedPrecheckResult(
+          passedTables.size(),
+          warnedTables.size(),
+          erroredTables.size(),
+          passedTables,
+          warnedTables,
+          erroredTables
+      ));
+    }
+  }
+
+  private void computeAggregatedRebalanceSummary(Map<String, RebalanceResult> rebalanceTableResults) {
+    List<RebalanceSummaryResult> summaryResults = new ArrayList<>();
+
+    for (RebalanceResult result : rebalanceTableResults.values()) {
+      if (result.getRebalanceSummaryResult() != null) {
+        summaryResults.add(result.getRebalanceSummaryResult());
+      }
+    }
+
+    // Step 1: Aggregate server change info across all tables first
+    Map<String, AggregatedServerSegmentChangeInfo> serverAggregates = aggregateServerSegmentChangeInfo(summaryResults);
+
+    // Step 2: Use aggregated server data to create both ServerInfo and SegmentInfo
+    AggregatedServerInfo aggregatedServerInfo = new AggregatedServerInfo(serverAggregates);
+    AggregatedSegmentInfo aggregatedSegmentInfo = new AggregatedSegmentInfo(summaryResults, serverAggregates);
+    List<RebalanceSummaryResult.TagInfo> aggregatedTagsInfo =
+        createAggregatedTagsInfo(summaryResults, serverAggregates);
+    _aggregatedRebalanceSummary = new RebalanceSummaryResult(
+        aggregatedServerInfo,
+        aggregatedSegmentInfo,
+        aggregatedTagsInfo
+    );
+  }
+
+  @JsonProperty
   public String getJobId() {
     return _jobId;
   }
 
+  @JsonProperty
+  public int getTotalTables() {
+    return _totalTables;
+  }
+
+  @JsonProperty
+  public Map<RebalanceResult.Status, Integer> getStatusSummary() {
+    return _statusSummary;
+  }
+
+  @JsonProperty
+  public Map<String, AggregatedPrecheckResult> getAggregatedPreChecksResult() {
+    return _aggregatedPreChecksResult;
+  }
+
+  @JsonProperty
+  public RebalanceSummaryResult getAggregatedRebalanceSummary() {
+    return _aggregatedRebalanceSummary;
+  }
+
+  @JsonProperty
   public Map<String, RebalanceResult> getRebalanceTableResults() {
     return _rebalanceTableResults;
   }
@@ -65,4 +206,447 @@ public class TenantRebalanceResult {
   public void setRebalanceTableResults(Map<String, RebalanceResult> rebalanceTableResults) {
     _rebalanceTableResults = rebalanceTableResults;
   }
+
+  /**
+   * Aggregated pre-check result that provides table-level pre-check status counts and message mappings
+   */
+  @JsonInclude(JsonInclude.Include.NON_NULL)
+  public static class AggregatedPrecheckResult {
+    private final int _tablesPassedCount;
+    private final int _tablesWarnedCount;
+    private final int _tablesErroredCount;
+    private final Map<String, String> _passedTables;
+    private final Map<String, String> _warnedTables;
+    private final Map<String, String> _erroredTables;
+
+    public AggregatedPrecheckResult(int tablesPassedCount, int tablesWarnedCount, int tablesErroredCount,
+        Map<String, String> passedTables, Map<String, String> warnedTables,
+        Map<String, String> erroredTables) {
+      _tablesPassedCount = tablesPassedCount;
+      _tablesWarnedCount = tablesWarnedCount;
+      _tablesErroredCount = tablesErroredCount;
+      _passedTables = passedTables;
+      _warnedTables = warnedTables;
+      _erroredTables = erroredTables;
+    }
+
+    @JsonProperty
+    public int getTablesPassedCount() {
+      return _tablesPassedCount;
+    }
+
+    @JsonProperty
+    public int getTablesWarnedCount() {
+      return _tablesWarnedCount;
+    }
+
+    @JsonProperty
+    public int getTablesErroredCount() {
+      return _tablesErroredCount;
+    }
+
+    @JsonProperty
+    public Map<String, String> getPassedTables() {
+      return _passedTables;
+    }
+
+    @JsonProperty
+    public Map<String, String> getWarnedTables() {
+      return _warnedTables;
+    }
+
+    @JsonProperty
+    public Map<String, String> getErroredTables() {
+      return _erroredTables;
+    }
+  }
+
+  /**
+   * Step 1: Aggregate ServerSegmentChangeInfo across all tables for each server
+   */
+  private static Map<String, AggregatedServerSegmentChangeInfo> aggregateServerSegmentChangeInfo(
+      List<RebalanceSummaryResult> summaryResults) {
+    Map<String, AggregatedServerSegmentChangeInfo> serverAggregates = new HashMap<>();
+
+    for (RebalanceSummaryResult summary : summaryResults) {
+      if (summary.getServerInfo() != null && summary.getServerInfo().getServerSegmentChangeInfo() != null) {
+        for (Map.Entry<String, RebalanceSummaryResult.ServerSegmentChangeInfo> entry :
+            summary.getServerInfo().getServerSegmentChangeInfo().entrySet()) {
+          String serverName = entry.getKey();
+          RebalanceSummaryResult.ServerSegmentChangeInfo changeInfo = entry.getValue();
+
+          serverAggregates.computeIfAbsent(serverName, k -> new AggregatedServerSegmentChangeInfo())
+              .merge(changeInfo);
+        }
+      }
+    }
+
+    return serverAggregates;
+  }
+
+  /**
+   * Helper class to aggregate ServerSegmentChangeInfo across multiple tables
+   */
+  private static class AggregatedServerSegmentChangeInfo extends RebalanceSummaryResult.ServerSegmentChangeInfo {
+
+    AggregatedServerSegmentChangeInfo() {
+      super(RebalanceSummaryResult.ServerStatus.UNCHANGED, 0, 0, 0, 0, 0, null);
+    }
+
+    void merge(RebalanceSummaryResult.ServerSegmentChangeInfo changeInfo) {
+      _totalSegmentsAfterRebalance += changeInfo.getTotalSegmentsAfterRebalance();
+      _totalSegmentsBeforeRebalance += changeInfo.getTotalSegmentsBeforeRebalance();
+      _segmentsAdded += changeInfo.getSegmentsAdded();
+      _segmentsDeleted += changeInfo.getSegmentsDeleted();
+      _segmentsUnchanged += changeInfo.getSegmentsUnchanged();
+
+      // Use tag list from any of the change infos (should be consistent)
+      if (_tagList == null && changeInfo.getTagList() != null) {
+        _tagList = changeInfo.getTagList();
+      }
+      if (_totalSegmentsAfterRebalance == 0) {
+        _serverStatus = RebalanceSummaryResult.ServerStatus.REMOVED;
+      } else if (_totalSegmentsBeforeRebalance == 0) {
+        _serverStatus = RebalanceSummaryResult.ServerStatus.ADDED;
+      } else {
+        _serverStatus = RebalanceSummaryResult.ServerStatus.UNCHANGED;
+      }
+    }
+  }
+
+  /**
+   * Aggregated ServerInfo that extends RebalanceSummaryResult.ServerInfo
+   */
+  private static class AggregatedServerInfo extends RebalanceSummaryResult.ServerInfo {
+    AggregatedServerInfo(Map<String, AggregatedServerSegmentChangeInfo> serverAggregates) {
+      super(0, null, null, null, null, null, null);
+
+      if (serverAggregates.isEmpty()) {
+        return;
+      }
+
+      Set<String> serversAdded = new HashSet<>();
+      Set<String> serversRemoved = new HashSet<>();
+      Set<String> serversUnchanged = new HashSet<>();
+      Set<String> serversGettingNewSegments = new HashSet<>();
+      Map<String, RebalanceSummaryResult.ServerSegmentChangeInfo> finalServerSegmentChangeInfo = new HashMap<>();
+
+      int numServersGettingNewSegments = 0;
+      int totalServersBefore = 0;
+      int totalServersAfter = 0;
+
+      for (Map.Entry<String, AggregatedServerSegmentChangeInfo> entry : serverAggregates.entrySet()) {
+        String serverName = entry.getKey();
+        AggregatedServerSegmentChangeInfo aggregate = entry.getValue();
+
+        // Determine server status based on aggregated segment counts
+        if (aggregate.getServerStatus() == RebalanceSummaryResult.ServerStatus.REMOVED) {
+          serversRemoved.add(serverName);
+        } else if (aggregate.getServerStatus() == RebalanceSummaryResult.ServerStatus.ADDED) {
+          serversAdded.add(serverName);
+        } else if (aggregate.getServerStatus() == RebalanceSummaryResult.ServerStatus.UNCHANGED) {
+          serversUnchanged.add(serverName);
+        }
+
+        // Track servers getting new segments
+        if (aggregate.getSegmentsAdded() > 0) {
+          serversGettingNewSegments.add(serverName);
+          numServersGettingNewSegments++;
+        }
+
+        // Create final ServerSegmentChangeInfo with determined status
+        finalServerSegmentChangeInfo.put(serverName, aggregate);
+
+        // Count servers for before/after totals
+        if (aggregate.getTotalSegmentsBeforeRebalance() > 0) {
+          totalServersBefore++;
+        }
+        if (aggregate.getTotalSegmentsAfterRebalance() > 0) {
+          totalServersAfter++;
+        }
+      }
+
+      RebalanceSummaryResult.RebalanceChangeInfo
+          aggregatedNumServers = new RebalanceSummaryResult.RebalanceChangeInfo(totalServersBefore, totalServersAfter);
+
+      // Set the computed values using reflection or by updating the parent constructor call
+      _numServersGettingNewSegments = numServersGettingNewSegments;
+      _numServers = aggregatedNumServers;
+      _serversAdded = serversAdded.isEmpty() ? null : serversAdded;
+      _serversRemoved = serversRemoved.isEmpty() ? null : serversRemoved;
+      _serversUnchanged = serversUnchanged.isEmpty() ? null : serversUnchanged;
+      _serversGettingNewSegments = serversGettingNewSegments.isEmpty() ? null : serversGettingNewSegments;
+      _serverSegmentChangeInfo = finalServerSegmentChangeInfo.isEmpty() ? null : finalServerSegmentChangeInfo;
+    }
+  }
+
+  /**
+   * Aggregated SegmentInfo that extends RebalanceSummaryResult.SegmentInfo
+   */
+  private static class AggregatedSegmentInfo extends RebalanceSummaryResult.SegmentInfo {
+    AggregatedSegmentInfo(List<RebalanceSummaryResult> summaryResults,
+        Map<String, AggregatedServerSegmentChangeInfo> serverAggregates) {
+      super(0, 0, 0, 0, 0, null, null, null, null);
+
+      if (summaryResults.isEmpty()) {
+        return;
+      }
+
+      int totalSegmentsToBeMoved = 0;
+      int totalSegmentsToBeDeleted = 0;
+      long totalEstimatedDataToBeMovedInBytes = 0;
+
+      int beforeRebalanceReplicationFactor = 0;
+      int afterRebalanceReplicationFactor = 0;
+      int beforeRebalanceSegmentsInSingleReplica = 0;
+      int afterRebalanceSegmentsInSingleReplica = 0;
+      int beforeRebalanceSegmentsAcrossAllReplicas = 0;
+      int afterRebalanceSegmentsAcrossAllReplicas = 0;
+
+      // Track consuming segment summaries for realtime tables
+      List<RebalanceSummaryResult.ConsumingSegmentToBeMovedSummary> consumingSummaries = new ArrayList<>();
+      int validSummariesCount = 0;
+
+      // Aggregate data from individual table summaries
+      for (RebalanceSummaryResult summary : summaryResults) {
+        if (summary.getSegmentInfo() != null) {
+          RebalanceSummaryResult.SegmentInfo segmentInfo = summary.getSegmentInfo();
+          validSummariesCount++;
+
+          totalSegmentsToBeMoved += segmentInfo.getTotalSegmentsToBeMoved();
+          totalSegmentsToBeDeleted += segmentInfo.getTotalSegmentsToBeDeleted();
+          if (totalEstimatedDataToBeMovedInBytes >= 0) {
+            totalEstimatedDataToBeMovedInBytes = segmentInfo.getTotalEstimatedDataToBeMovedInBytes() < 0 ? -1
+                : totalEstimatedDataToBeMovedInBytes + segmentInfo.getTotalEstimatedDataToBeMovedInBytes();
+          }
+
+          if (segmentInfo.getNumSegmentsInSingleReplica() != null) {
+            beforeRebalanceSegmentsInSingleReplica +=
+                segmentInfo.getNumSegmentsInSingleReplica().getValueBeforeRebalance();
+            afterRebalanceSegmentsInSingleReplica +=
+                segmentInfo.getNumSegmentsInSingleReplica().getExpectedValueAfterRebalance();
+          }
+
+          if (segmentInfo.getNumSegmentsAcrossAllReplicas() != null) {
+            beforeRebalanceSegmentsAcrossAllReplicas +=
+                segmentInfo.getNumSegmentsAcrossAllReplicas().getValueBeforeRebalance();
+            afterRebalanceSegmentsAcrossAllReplicas +=
+                segmentInfo.getNumSegmentsAcrossAllReplicas().getExpectedValueAfterRebalance();
+          }
+
+          if (segmentInfo.getConsumingSegmentToBeMovedSummary() != null) {
+            consumingSummaries.add(segmentInfo.getConsumingSegmentToBeMovedSummary());
+          }
+        }
+      }
+
+      if (validSummariesCount == 0) {
+        return;
+      }
+
+      int maxSegmentsAddedToASingleServer = 0;
+      for (AggregatedServerSegmentChangeInfo aggregate : serverAggregates.values()) {
+        maxSegmentsAddedToASingleServer = Math.max(maxSegmentsAddedToASingleServer, aggregate.getSegmentsAdded());
+      }
+
+      // Calculate average segment size
+      long estimatedAverageSegmentSizeInBytes = totalEstimatedDataToBeMovedInBytes >= 0 && totalSegmentsToBeMoved > 0 ?
+          totalEstimatedDataToBeMovedInBytes / totalSegmentsToBeMoved : 0;
+
+      // Create aggregated RebalanceChangeInfo objects
+      RebalanceSummaryResult.RebalanceChangeInfo aggregatedNumSegmentsInSingleReplica =
+          new RebalanceSummaryResult.RebalanceChangeInfo(
+              beforeRebalanceSegmentsInSingleReplica, afterRebalanceSegmentsInSingleReplica);
+      RebalanceSummaryResult.RebalanceChangeInfo aggregatedNumSegmentsAcrossAllReplicas =
+          new RebalanceSummaryResult.RebalanceChangeInfo(
+              beforeRebalanceSegmentsAcrossAllReplicas, afterRebalanceSegmentsAcrossAllReplicas);
+
+      // Aggregate consuming segment summaries
+      RebalanceSummaryResult.ConsumingSegmentToBeMovedSummary aggregatedConsumingSummary =
+          aggregateConsumingSegmentSummary(consumingSummaries);
+
+      // Set the computed values
+      _totalSegmentsToBeMoved = totalSegmentsToBeMoved;
+      _totalSegmentsToBeDeleted = totalSegmentsToBeDeleted;
+      _maxSegmentsAddedToASingleServer = maxSegmentsAddedToASingleServer;
+      _estimatedAverageSegmentSizeInBytes = estimatedAverageSegmentSizeInBytes;
+      _totalEstimatedDataToBeMovedInBytes = totalEstimatedDataToBeMovedInBytes;
+      _replicationFactor = null; // This is irrelevant for tenant rebalance
+      _numSegmentsInSingleReplica = aggregatedNumSegmentsInSingleReplica;
+      _numSegmentsAcrossAllReplicas = aggregatedNumSegmentsAcrossAllReplicas;
+      _consumingSegmentToBeMovedSummary = aggregatedConsumingSummary;
+    }
+  }
+
+  /**
+   * Aggregates consuming segment summaries for realtime tables
+   */
+  private static RebalanceSummaryResult.ConsumingSegmentToBeMovedSummary aggregateConsumingSegmentSummary(
+      List<RebalanceSummaryResult.ConsumingSegmentToBeMovedSummary> summaries) {
+    if (summaries.isEmpty()) {
+      return null;
+    }
+
+    int totalNumConsumingSegmentsToBeMoved = 0;
+    // Find the maximum size of offset and age maps across all tables
+    int maxOffsetMapSize = 0;
+    int maxAgeMapSize = 0;
+    for (RebalanceSummaryResult.ConsumingSegmentToBeMovedSummary summary : summaries) {
+      if (summary.getConsumingSegmentsToBeMovedWithMostOffsetsToCatchUp() != null) {
+        maxOffsetMapSize = Math.max(maxOffsetMapSize,
+            summary.getConsumingSegmentsToBeMovedWithMostOffsetsToCatchUp().size());
+      }
+      if (summary.getConsumingSegmentsToBeMovedWithOldestAgeInMinutes() != null) {
+        maxAgeMapSize = Math.max(maxAgeMapSize,
+            summary.getConsumingSegmentsToBeMovedWithOldestAgeInMinutes().size());
+      }
+    }
+
+    // Create maps to store all segments by offset and age
+    Map<String, Integer> allConsumingSegmentsWithOffsets = new HashMap<>();
+    Map<String, Integer> allConsumingSegmentsWithAges = new HashMap<>();
+
+    // Aggregate ConsumingSegmentSummaryPerServer by server name across all tables
+    Map<String, AggregatedConsumingSegmentSummaryPerServer> serverAggregates = new HashMap<>();
+
+    for (RebalanceSummaryResult.ConsumingSegmentToBeMovedSummary summary : summaries) {
+      totalNumConsumingSegmentsToBeMoved += summary.getNumConsumingSegmentsToBeMoved();
+
+      // Add all segments with offsets
+      if (summary.getConsumingSegmentsToBeMovedWithMostOffsetsToCatchUp() != null) {
+        allConsumingSegmentsWithOffsets.putAll(summary.getConsumingSegmentsToBeMovedWithMostOffsetsToCatchUp());
+      }
+
+      // Add all segments with ages
+      if (summary.getConsumingSegmentsToBeMovedWithOldestAgeInMinutes() != null) {
+        allConsumingSegmentsWithAges.putAll(summary.getConsumingSegmentsToBeMovedWithOldestAgeInMinutes());
+      }
+
+      // Aggregate server consuming segment summaries by server name
+      if (summary.getServerConsumingSegmentSummary() != null) {
+        for (Map.Entry<String,
+            RebalanceSummaryResult.ConsumingSegmentToBeMovedSummary.ConsumingSegmentSummaryPerServer> entry :
+            summary.getServerConsumingSegmentSummary().entrySet()) {
+          String serverName = entry.getKey();
+          RebalanceSummaryResult.ConsumingSegmentToBeMovedSummary.ConsumingSegmentSummaryPerServer serverSummary =
+              entry.getValue();
+
+          serverAggregates.computeIfAbsent(serverName, k -> new AggregatedConsumingSegmentSummaryPerServer())
+              .merge(serverSummary);
+        }
+      }
+    }
+
+    // Keep only top k segments with the highest offsets
+    Map<String, Integer> topKConsumingSegmentsWithOffsets = allConsumingSegmentsWithOffsets.entrySet().stream()
+        .sorted(Map.Entry.<String, Integer>comparingByValue().reversed())
+        .limit(maxOffsetMapSize)
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e1, HashMap::new));
+
+    // Keep only top k segments with the oldest ages
+    Map<String, Integer> topKConsumingSegmentsWithAges = allConsumingSegmentsWithAges.entrySet().stream()
+        .sorted(Map.Entry.<String, Integer>comparingByValue().reversed())
+        .limit(maxAgeMapSize)
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue, (e1, e2) -> e1, HashMap::new));
+
+    // Replace the original maps with the top k versions
+    allConsumingSegmentsWithOffsets = topKConsumingSegmentsWithOffsets;
+    allConsumingSegmentsWithAges = topKConsumingSegmentsWithAges;
+
+    // Convert aggregated server data to final ConsumingSegmentSummaryPerServer map
+    Map<String, RebalanceSummaryResult.ConsumingSegmentToBeMovedSummary.ConsumingSegmentSummaryPerServer>
+        finalServerConsumingSummary = new HashMap<>(serverAggregates);
+
+    int totalNumServersGettingConsumingSegmentsAdded = finalServerConsumingSummary.size();
+
+    return new RebalanceSummaryResult.ConsumingSegmentToBeMovedSummary(
+        totalNumConsumingSegmentsToBeMoved,
+        totalNumServersGettingConsumingSegmentsAdded,
+        allConsumingSegmentsWithOffsets.isEmpty() ? null : allConsumingSegmentsWithOffsets,
+        allConsumingSegmentsWithAges.isEmpty() ? null : allConsumingSegmentsWithAges,
+        finalServerConsumingSummary.isEmpty() ? null : finalServerConsumingSummary
+    );
+  }
+
+  /**
+   * Helper class to aggregate ConsumingSegmentSummaryPerServer across multiple tables
+   */
+  private static class AggregatedConsumingSegmentSummaryPerServer
+      extends RebalanceSummaryResult.ConsumingSegmentToBeMovedSummary.ConsumingSegmentSummaryPerServer {
+    AggregatedConsumingSegmentSummaryPerServer() {
+      super(0, 0);
+    }
+
+    void merge(
+        RebalanceSummaryResult.ConsumingSegmentToBeMovedSummary.ConsumingSegmentSummaryPerServer serverSummary) {
+      _numConsumingSegmentsToBeAdded += serverSummary.getNumConsumingSegmentsToBeAdded();
+
+      // Handle offset aggregation - if any table has invalid offset data (-1), mark the aggregate as invalid
+      if (serverSummary.getTotalOffsetsToCatchUpAcrossAllConsumingSegments() == -1) {
+        _totalOffsetsToCatchUpAcrossAllConsumingSegments = -1;
+      } else if (_totalOffsetsToCatchUpAcrossAllConsumingSegments != -1) {
+        // Only add to total if we haven't encountered invalid data yet
+        _totalOffsetsToCatchUpAcrossAllConsumingSegments +=
+            serverSummary.getTotalOffsetsToCatchUpAcrossAllConsumingSegments();
+      }
+    }
+  }
+
+  /**
+   * Aggregates TagInfo across multiple RebalanceSummaryResults
+   */
+  private static List<RebalanceSummaryResult.TagInfo> createAggregatedTagsInfo(
+      List<RebalanceSummaryResult> summaryResults,
+      Map<String, AggregatedServerSegmentChangeInfo> serverAggregates) {
+    Map<String, AggregatedTagInfo> tagAggregates = new HashMap<>();
+
+    // First, aggregate numeric fields from table-level TagInfo
+    for (RebalanceSummaryResult summary : summaryResults) {
+      if (summary.getTagsInfo() != null) {
+        for (RebalanceSummaryResult.TagInfo tagInfo : summary.getTagsInfo()) {
+          String tagName = tagInfo.getTagName();
+          tagAggregates.computeIfAbsent(tagName, k -> new AggregatedTagInfo(tagName))
+              .merge(tagInfo);
+        }
+      }
+    }
+
+    // Second, calculate totalNumServerParticipants from server aggregates
+    for (Map.Entry<String, AggregatedServerSegmentChangeInfo> entry : serverAggregates.entrySet()) {
+      AggregatedServerSegmentChangeInfo aggregate = entry.getValue();
+
+      // Only count servers with status UNCHANGED or ADDED (not REMOVED)
+      boolean isActiveServer = aggregate.getTotalSegmentsAfterRebalance() > 0;
+      if (isActiveServer && aggregate.getTagList() != null) {
+        for (String tag : aggregate.getTagList()) {
+          if (tagAggregates.containsKey(tag)) {
+            tagAggregates.get(tag).increaseNumServerParticipants(1);
+          }
+        }
+      }
+    }
+
+    if (tagAggregates.isEmpty()) {
+      return null;
+    }
+
+    return new ArrayList<>(tagAggregates.values());
+  }
+
+  /**
+   * Helper class to aggregate TagInfo across multiple tables
+   */
+  private static class AggregatedTagInfo extends RebalanceSummaryResult.TagInfo {
+
+    AggregatedTagInfo(String tagName) {
+      super(tagName);
+    }
+
+    void merge(RebalanceSummaryResult.TagInfo tagInfo) {
+      increaseNumSegmentsUnchanged(tagInfo.getNumSegmentsUnchanged());
+      increaseNumSegmentsToDownload(tagInfo.getNumSegmentsToDownload());
+      // Note: Do NOT add numServerParticipants here - it will be derived from the aggregated ServerSegmentChangeInfo
+    }
+  }
 }
+

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/tenant/TenantRebalanceResult.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/tenant/TenantRebalanceResult.java
@@ -379,7 +379,6 @@ public class TenantRebalanceResult {
       RebalanceSummaryResult.RebalanceChangeInfo
           aggregatedNumServers = new RebalanceSummaryResult.RebalanceChangeInfo(totalServersBefore, totalServersAfter);
 
-      // Set the computed values using reflection or by updating the parent constructor call
       _numServersGettingNewSegments = numServersGettingNewSegments;
       _numServers = aggregatedNumServers;
       _serversAdded = serversAdded;
@@ -406,8 +405,6 @@ public class TenantRebalanceResult {
       int totalSegmentsToBeDeleted = 0;
       long totalEstimatedDataToBeMovedInBytes = 0;
 
-      int beforeRebalanceReplicationFactor = 0;
-      int afterRebalanceReplicationFactor = 0;
       int beforeRebalanceSegmentsInSingleReplica = 0;
       int afterRebalanceSegmentsInSingleReplica = 0;
       int beforeRebalanceSegmentsAcrossAllReplicas = 0;


### PR DESCRIPTION
# Enhanced Tenant Rebalance Result with Aggregated Summary and Pre-check Result

## Summary

This PR enhances the tenant rebalance API to provide aggregated summaries and pre-check result across all tables within a tenant, giving users a comprehensive view of the rebalance operation's impact at the tenant level. Previously, the API only returned individual table rebalance results, making it difficult to understand the overall tenant-level changes.

## Changes

### 🔧 Core Enhancements

   - `totalTables`: Total number of tables processed
   - `statusSummary`: Count of tables by status (DONE, NO_OP, FAILED)
   - `aggregatedPreChecksResult`: Aggregated pre-check results across all tables
   - `aggregatedRebalanceSummary`: Consolidated rebalance summary with server and segment information


### 📊 New Output Format

The enhanced API now returns both individual table results and aggregated tenant-level summaries:
The following JSON is the result of dry-run rebalancing DefaultTenant, which originally had 4 servers but now 2.

```json
{
  "totalTables": 9,
  "statusSummary": {
    "NO_OP": 1,
    "DONE": 8
  },
  "aggregatedPreChecksResult": {
    "isMinimizeDataMovement": {
      "tablesPassedCount": 9,
      "tablesWarnedCount": 0,
      "tablesErroredCount": 0,
      "passedTables": {
        "meetupRsvpJson_REALTIME": "Instance assignment not allowed, no need for minimizeDataMovement",
        "meetupRsvp_REALTIME": "Instance assignment not allowed, no need for minimizeDataMovement",
        "upsertMeetupRsvp_REALTIME": "minimizeDataMovement is enabled",
        "githubEvents_REALTIME": "Instance assignment not allowed, no need for minimizeDataMovement",
        "upsertPartialMeetupRsvp_REALTIME": "minimizeDataMovement is enabled",
        "upsertJsonMeetupRsvp_REALTIME": "minimizeDataMovement is enabled",
        "dailySales_REALTIME": "Instance assignment not allowed, no need for minimizeDataMovement",
        "meetupRsvpComplexType_REALTIME": "Instance assignment not allowed, no need for minimizeDataMovement",
        "airlineStats_REALTIME": "Instance assignment not allowed, no need for minimizeDataMovement"
      },
      "warnedTables": {},
      "erroredTables": {}
    },
    "diskUtilizationDuringRebalance": {
      "tablesPassedCount": 9,
      "tablesWarnedCount": 0,
      "tablesErroredCount": 0,
      "passedTables": {
        "meetupRsvpJson_REALTIME": "Within threshold (<90%)",
        "meetupRsvp_REALTIME": "Within threshold (<90%)",
        "upsertMeetupRsvp_REALTIME": "Within threshold (<90%)",
        "githubEvents_REALTIME": "Within threshold (<90%)",
        "upsertPartialMeetupRsvp_REALTIME": "Within threshold (<90%)",
        "upsertJsonMeetupRsvp_REALTIME": "Within threshold (<90%)",
        "dailySales_REALTIME": "Within threshold (<90%)",
        "meetupRsvpComplexType_REALTIME": "Within threshold (<90%)",
        "airlineStats_REALTIME": "Within threshold (<90%)"
      },
      "warnedTables": {},
      "erroredTables": {}
    },
    ... more pre-checks
  },
  "aggregatedRebalanceSummary": {
    "serverInfo": {
      "serverSegmentChangeInfo": {
        "Server_<REDACTED>_7051": {
          "serverStatus": "UNCHANGED",
          "segmentsAdded": 23,
          "segmentsDeleted": 8,
          "segmentsUnchanged": 5,
          "totalSegmentsAfterRebalance": 28,
          "totalSegmentsBeforeRebalance": 13,
          "tagList": [
            "DefaultTenant_OFFLINE",
            "DefaultTenant_REALTIME"
          ]
        },
        "Server_<REDACTED>_7052": {
          "serverStatus": "REMOVED",
          "segmentsAdded": 0,
          "segmentsDeleted": 14,
          "segmentsUnchanged": 0,
          "totalSegmentsAfterRebalance": 0,
          "totalSegmentsBeforeRebalance": 14,
          "tagList": [
            "new_REALTIME"
          ]
        },
        "Server_<REDACTED>_7050": {
          "serverStatus": "REMOVED",
          "segmentsAdded": 0,
          "segmentsDeleted": 9,
          "segmentsUnchanged": 0,
          "totalSegmentsAfterRebalance": 0,
          "totalSegmentsBeforeRebalance": 9,
          "tagList": [
            "new_REALTIME"
          ]
        },
        "Server_<REDACTED>_7053": {
          "serverStatus": "UNCHANGED",
          "segmentsAdded": 8,
          "segmentsDeleted": 0,
          "segmentsUnchanged": 21,
          "totalSegmentsAfterRebalance": 29,
          "totalSegmentsBeforeRebalance": 21,
          "tagList": [
            "DefaultTenant_OFFLINE",
            "DefaultTenant_REALTIME"
          ]
        }
      },
      "numServers": {
        "valueBeforeRebalance": 4,
        "expectedValueAfterRebalance": 2
      },
      "serversUnchanged": [
        "Server_<REDACTED>_7051",
        "Server_<REDACTED>_7053"
      ],
      "serversRemoved": [
        "Server_<REDACTED>_7052",
        "Server_<REDACTED>_7050"
      ],
      "serversAdded": [],
      "numServersGettingNewSegments": 2,
      "serversGettingNewSegments": [
        "Server_<REDACTED>_7051",
        "Server_<REDACTED>_7053"
      ]
    },
    "segmentInfo": {
      "totalSegmentsToBeMoved": 31,
      "maxSegmentsAddedToASingleServer": 23,
      "totalSegmentsToBeDeleted": 31,
      "estimatedAverageSegmentSizeInBytes": 0,
      "totalEstimatedDataToBeMovedInBytes": -1,
      "numSegmentsInSingleReplica": {
        "valueBeforeRebalance": 57,
        "expectedValueAfterRebalance": 57
      },
      "numSegmentsAcrossAllReplicas": {
        "valueBeforeRebalance": 57,
        "expectedValueAfterRebalance": 57
      },
      "consumingSegmentToBeMovedSummary": {
        "numConsumingSegmentsToBeMoved": 27,
        "numServersGettingConsumingSegmentsAdded": 2,
        "consumingSegmentsToBeMovedWithMostOffsetsToCatchUp": {
          "upsertMeetupRsvp__0__0__20250620T2326Z": 402,
          "upsertJsonMeetupRsvp__0__0__20250620T2326Z": 394,
          "upsertPartialMeetupRsvp__1__0__20250620T2326Z": 371,
          "meetupRsvp__3__0__20250620T2326Z": 105,
          "meetupRsvpJson__9__0__20250620T2326Z": 88,
          "meetupRsvpComplexType__1__0__20250620T2326Z": 85,
          "dailySales__0__0__20250620T2326Z": 10,
          "githubEvents__0__4__20250620T2326Z": 0
        },
        "consumingSegmentsToBeMovedWithOldestAgeInMinutes": {
          "meetupRsvpComplexType__9__0__20250620T2326Z": 12,
          "meetupRsvpJson__1__0__20250620T2326Z": 12,
          "meetupRsvp__4__0__20250620T2326Z": 12,
          "upsertJsonMeetupRsvp__0__0__20250620T2326Z": 12,
          "githubEvents__0__4__20250620T2326Z": 12,
          "dailySales__0__0__20250620T2326Z": 12,
          "upsertPartialMeetupRsvp__1__0__20250620T2326Z": 12,
          "upsertMeetupRsvp__0__0__20250620T2326Z": 12
        },
        "serverConsumingSegmentSummary": {
          "Server_<REDACTED>_7051": {
            "totalOffsetsToCatchUpAcrossAllConsumingSegments": 2272,
            "numConsumingSegmentsToBeAdded": 19
          },
          "Server_<REDACTED>_7053": {
            "totalOffsetsToCatchUpAcrossAllConsumingSegments": 529,
            "numConsumingSegmentsToBeAdded": 8
          }
        }
      }
    },
    "tagsInfo": [
      {
        "tagName": "DefaultTenant_REALTIME",
        "numSegmentsUnchanged": 26,
        "numSegmentsToDownload": 31,
        "numServerParticipants": 2
      }
    ]
  },
  "rebalanceTableResults": {
    "meetupRsvpJson_REALTIME": {
      "jobId": "f097be29-6ad2-4849-a5f7-4761cef6f450",
      "status": "DONE",
      "description": "Dry-run mode"
    },
    "meetupRsvp_REALTIME": {
      "jobId": "98281d96-3fbd-4ec8-8731-3a5879cf4017",
      "status": "DONE",
      "description": "Dry-run mode"
    },
    ...more tables
  }
}
```

## 🏗️ Aggregation Rules


### ServerSegmentChangeInfo (group by server)
* **serverStatus** - 
  * `REMOVED` if sum(totalSegmentsAfterRebalance) == 0
  * `ADDED` if sum(totalSegmentsBeforeRebalance) == 0
  * `UNCHANGED` otherwise
* **totalSegmentsAfterRebalance** - sum
* **totalSegmentsBeforeRebalance** - sum
* **segmentsAdded** - sum
* **segmentsDeleted** - sum
* **segmentsUnchanged** - sum
* **tagList** - first

### ServerInfo
* **numServersGettingNewSegments** - count of servers where segmentsAdded > 0 in aggregated `ServerSegmentChangeInfo`
* **numServers** (RebalanceChangeInfo) - 
  * `valueBeforeRebalance`: count of servers with totalSegmentsBeforeRebalance > 0
  * `expectedValueAfterRebalance`: count of servers with totalSegmentsAfterRebalance > 0
* **serversAdded** - set of servers with serverStatus == `ADDED`
* **serversRemoved** - set of servers with serverStatus == `REMOVED`
* **serversUnchanged** - set of servers with serverStatus == `UNCHANGED`
* **serversGettingNewSegments** - set of servers where segmentsAdded > 0
* **serverSegmentChangeInfo** - map of aggregated `ServerSegmentChangeInfo` per server

### SegmentInfo
* **totalSegmentsToBeMoved** - sum across all tables
* **totalSegmentsToBeDeleted** - sum across all tables
* **totalEstimatedDataToBeMovedInBytes** - sum across all tables (or -1 if any table has -1)
* **maxSegmentsAddedToASingleServer** - max(segmentsAdded) across all servers from aggregated `ServerSegmentChangeInfo`
* **estimatedAverageSegmentSizeInBytes** - totalEstimatedDataToBeMovedInBytes / totalSegmentsToBeMoved (or 0 if division by zero or totalEstimatedDataToBeMovedInBytes=-1)
* **numSegmentsInSingleReplica** (RebalanceChangeInfo) -
  * `valueBeforeRebalance`: sum across all tables
  * `expectedValueAfterRebalance`: sum across all tables
* **numSegmentsAcrossAllReplicas** (RebalanceChangeInfo) -
  * `valueBeforeRebalance`: sum across all tables
  * `expectedValueAfterRebalance`: sum across all tables
* **replicationFactor** - `null` (irrelevant for tenant rebalance)

### ConsumingSegmentSummaryPerServer (group by server)
* **numConsumingSegmentsToBeAdded** - sum across all tables for this server
* **totalOffsetsToCatchUpAcrossAllConsumingSegments** - sum across all tables for this server (or -1 if any table has -1)

### ConsumingSegmentToBeMovedSummary
* **numConsumingSegmentsToBeMoved** - sum across all tables
* **numServersGettingConsumingSegmentsAdded** - count of unique servers in aggregated `ConsumingSegmentSummaryPerServer`
* **consumingSegmentsToBeMovedWithMostOffsetsToCatchUp** - top K segments with highest offsets across all tables (K = max map size from individual tables)
* **consumingSegmentsToBeMovedWithOldestAgeInMinutes** - top K segments with oldest ages across all tables (K = max map size from individual tables)
* **serverConsumingSegmentSummary** - aggregated `ConsumingSegmentSummaryPerServer` per server

### TagInfo
* **numSegmentsUnchanged** - sum across all tables for this tag
* **numSegmentsToDownload** - sum across all tables for this tag
* **numServerParticipants** - count of active servers (totalSegmentsAfterRebalance > 0) that contain this tag from aggregated `ServerSegmentChangeInfo`

## 🧪 Testing

Added comprehensive test coverage including:

1. **`testTenantRebalanceResultAggregation()`**
   - Basic aggregation across different table types (offline/realtime)
   - Scale-out, scale-in, and no-op scenarios
   - Status summary validation

2. **`testTenantRebalanceResultAggregationWithOverlappingServers()`**
   - Complex scenario with servers appearing in multiple tables
   - Validates correct handling of server status precedence
   - Tests derived calculations with overlapping resources
