### PR TITLE
Add new parameter in Table Rebalance API: Disk Utilization Pre-check Threshold Override

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -673,6 +673,9 @@ public class PinotTableRestletResource {
       @QueryParam("retryInitialDelayInMs") long retryInitialDelayInMs,
       @ApiParam(value = "Whether to update segment target tier as part of the rebalance") @DefaultValue("false")
       @QueryParam("updateTargetTier") boolean updateTargetTier,
+      @ApiParam(value = "Disk utilization threshold override (0.0 to 1.0, e.g., 0.85 for 85%). "
+          + "If not provided, uses the controller's default threshold") @DefaultValue("-1.0")
+      @QueryParam("diskUtilizationThreshold") double diskUtilizationThreshold,
       @ApiParam(value = "Whether to force commit consuming segments for a REALTIME table before they are rebalanced.")
       @DefaultValue("false")
       @QueryParam("forceCommit") boolean forceCommit,
@@ -715,6 +718,7 @@ public class PinotTableRestletResource {
     rebalanceConfig.setMaxAttempts(maxAttempts);
     rebalanceConfig.setRetryInitialDelayInMs(retryInitialDelayInMs);
     rebalanceConfig.setUpdateTargetTier(updateTargetTier);
+    rebalanceConfig.setDiskUtilizationThreshold(diskUtilizationThreshold);
     String rebalanceJobId = TableRebalancer.createUniqueRebalanceJobIdentifier();
 
     try {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -673,7 +673,7 @@ public class PinotTableRestletResource {
       @QueryParam("retryInitialDelayInMs") long retryInitialDelayInMs,
       @ApiParam(value = "Whether to update segment target tier as part of the rebalance") @DefaultValue("false")
       @QueryParam("updateTargetTier") boolean updateTargetTier,
-      @ApiParam(value = "Disk utilization threshold override (0.0 to 1.0, e.g., 0.85 for 85%). "
+      @ApiParam(value = "Disk utilization threshold override used in pre-check (0.0 to 1.0, e.g., 0.85 for 85%). "
           + "If not provided, uses the controller's default threshold") @DefaultValue("-1.0")
       @QueryParam("diskUtilizationThreshold") double diskUtilizationThreshold,
       @ApiParam(value = "Whether to force commit consuming segments for a REALTIME table before they are rebalanced.")

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -674,7 +674,8 @@ public class PinotTableRestletResource {
       @ApiParam(value = "Whether to update segment target tier as part of the rebalance") @DefaultValue("false")
       @QueryParam("updateTargetTier") boolean updateTargetTier,
       @ApiParam(value = "Disk utilization threshold override used in pre-check (0.0 to 1.0, e.g., 0.85 for 85%). "
-          + "If not provided, uses the controller's default threshold") @DefaultValue("-1.0")
+          + "If not provided, uses " + ControllerConf.REBALANCE_DISK_UTILIZATION_THRESHOLD + " in the controller config")
+      @DefaultValue("-1.0")
       @QueryParam("diskUtilizationThreshold") double diskUtilizationThreshold,
       @ApiParam(value = "Whether to force commit consuming segments for a REALTIME table before they are rebalanced.")
       @DefaultValue("false")

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -674,7 +674,8 @@ public class PinotTableRestletResource {
       @ApiParam(value = "Whether to update segment target tier as part of the rebalance") @DefaultValue("false")
       @QueryParam("updateTargetTier") boolean updateTargetTier,
       @ApiParam(value = "Disk utilization threshold override used in pre-check (0.0 to 1.0, e.g., 0.85 for 85%). "
-          + "If not provided, uses " + ControllerConf.REBALANCE_DISK_UTILIZATION_THRESHOLD + " in the controller config")
+          + "If not provided, uses " + ControllerConf.REBALANCE_DISK_UTILIZATION_THRESHOLD
+          + " in the controller config")
       @DefaultValue("-1.0")
       @QueryParam("diskUtilizationThreshold") double diskUtilizationThreshold,
       @ApiParam(value = "Whether to force commit consuming segments for a REALTIME table before they are rebalanced.")

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/DefaultRebalancePreChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/DefaultRebalancePreChecker.java
@@ -95,6 +95,8 @@ public class DefaultRebalancePreChecker implements RebalancePreChecker {
     // Determine the disk utilization threshold to use - either from rebalance config override or default
     double diskUtilizationThreshold = rebalanceConfig.getDiskUtilizationThreshold() >= 0.0
         ? rebalanceConfig.getDiskUtilizationThreshold() : _defaultDiskUtilizationThreshold;
+    // clip the disk utilization threshold to [0.0, 1.0]
+    diskUtilizationThreshold = Math.min(1.0, diskUtilizationThreshold);
 
     // Check if all servers involved in the rebalance have enough disk space for rebalance operation.
     // Notice this check could have false positives (disk utilization is subject to change by other operations anytime)

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/DefaultRebalancePreChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/DefaultRebalancePreChecker.java
@@ -93,9 +93,9 @@ public class DefaultRebalancePreChecker implements RebalancePreChecker {
     preCheckResult.put(IS_MINIMIZE_DATA_MOVEMENT,
         checkIsMinimizeDataMovement(tableConfig, rebalanceConfig, tableRebalanceLogger));
     // Determine the disk utilization threshold to use - either from rebalance config override or default
-    double diskUtilizationThreshold = rebalanceConfig.getDiskUtilizationThreshold() >= 0.0 
+    double diskUtilizationThreshold = rebalanceConfig.getDiskUtilizationThreshold() >= 0.0
         ? rebalanceConfig.getDiskUtilizationThreshold() : _defaultDiskUtilizationThreshold;
-    
+
     // Check if all servers involved in the rebalance have enough disk space for rebalance operation.
     // Notice this check could have false positives (disk utilization is subject to change by other operations anytime)
     preCheckResult.put(DISK_UTILIZATION_DURING_REBALANCE,

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/DefaultRebalancePreChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/DefaultRebalancePreChecker.java
@@ -62,7 +62,7 @@ public class DefaultRebalancePreChecker implements RebalancePreChecker {
   public static final int SEGMENT_ADD_THRESHOLD = 200;
   public static final int RECOMMENDED_BATCH_SIZE = 200;
 
-  private static double _diskUtilizationThreshold;
+  private static double _defaultDiskUtilizationThreshold;
 
   protected PinotHelixResourceManager _pinotHelixResourceManager;
   protected ExecutorService _executorService;
@@ -72,7 +72,7 @@ public class DefaultRebalancePreChecker implements RebalancePreChecker {
       double diskUtilizationThreshold) {
     _pinotHelixResourceManager = pinotHelixResourceManager;
     _executorService = executorService;
-    _diskUtilizationThreshold = diskUtilizationThreshold;
+    _defaultDiskUtilizationThreshold = diskUtilizationThreshold;
   }
 
   @Override
@@ -92,17 +92,19 @@ public class DefaultRebalancePreChecker implements RebalancePreChecker {
     // Check whether minimizeDataMovement is set in TableConfig
     preCheckResult.put(IS_MINIMIZE_DATA_MOVEMENT,
         checkIsMinimizeDataMovement(tableConfig, rebalanceConfig, tableRebalanceLogger));
+    // Determine the disk utilization threshold to use - either from rebalance config override or default
+    double diskUtilizationThreshold = rebalanceConfig.getDiskUtilizationThreshold() >= 0.0 
+        ? rebalanceConfig.getDiskUtilizationThreshold() : _defaultDiskUtilizationThreshold;
+    
     // Check if all servers involved in the rebalance have enough disk space for rebalance operation.
     // Notice this check could have false positives (disk utilization is subject to change by other operations anytime)
     preCheckResult.put(DISK_UTILIZATION_DURING_REBALANCE,
         checkDiskUtilization(preCheckContext.getCurrentAssignment(), preCheckContext.getTargetAssignment(),
-            preCheckContext.getTableSubTypeSizeDetails(), _diskUtilizationThreshold, true));
+            preCheckContext.getTableSubTypeSizeDetails(), diskUtilizationThreshold, true));
     // Check if all servers involved in the rebalance will have enough disk space after the rebalance.
-    // TODO: Add the option to take disk utilization threshold as a RebalanceConfig option and use that to override
-    //       the default config
     preCheckResult.put(DISK_UTILIZATION_AFTER_REBALANCE,
         checkDiskUtilization(preCheckContext.getCurrentAssignment(), preCheckContext.getTargetAssignment(),
-            preCheckContext.getTableSubTypeSizeDetails(), _diskUtilizationThreshold, false));
+            preCheckContext.getTableSubTypeSizeDetails(), diskUtilizationThreshold, false));
 
     preCheckResult.put(REBALANCE_CONFIG_OPTIONS, checkRebalanceConfig(rebalanceConfig, tableConfig,
         preCheckContext.getCurrentAssignment(), preCheckContext.getTargetAssignment(),

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/DefaultRebalancePreChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/DefaultRebalancePreChecker.java
@@ -96,7 +96,11 @@ public class DefaultRebalancePreChecker implements RebalancePreChecker {
     double diskUtilizationThreshold = rebalanceConfig.getDiskUtilizationThreshold() >= 0.0
         ? rebalanceConfig.getDiskUtilizationThreshold() : _defaultDiskUtilizationThreshold;
     // clip the disk utilization threshold to [0.0, 1.0]
-    diskUtilizationThreshold = Math.min(1.0, diskUtilizationThreshold);
+    if (diskUtilizationThreshold > 1.0) {
+      tableRebalanceLogger.warn("Provided disk utilization threshold {} is greater than 1.0, clipping to 1.0",
+          diskUtilizationThreshold);
+      diskUtilizationThreshold = 1.0;
+    }
 
     // Check if all servers involved in the rebalance have enough disk space for rebalance operation.
     // Notice this check could have false positives (disk utilization is subject to change by other operations anytime)

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceConfig.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceConfig.java
@@ -138,10 +138,12 @@ public class RebalanceConfig {
   private long _retryInitialDelayInMs = 300000L;
 
   // Disk utilization threshold override. If set, this will override the default disk utilization threshold
-  // configured at the controller level. Value should be between 0.0 and 1.0 (e.g., 0.85 for 85%)
+  // configured at the controller level. Value should be between 0.0 and 1.0 (e.g., 0.85 for 85%) or -1.0, which means
+  // no override. In the latter case the pre-checker will use the default disk utilization threshold from the controller
+  // config.
   @JsonProperty("diskUtilizationThreshold")
   @ApiModelProperty(example = "0.85")
-  private double _diskUtilizationThreshold = -1.0; // -1.0 means not set, use default
+  private double _diskUtilizationThreshold = -1.0;
 
   @JsonProperty("forceCommit")
   @ApiModelProperty(example = "false")

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceConfig.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceConfig.java
@@ -357,9 +357,9 @@ public class RebalanceConfig {
         + ", _externalViewStabilizationTimeoutInMs=" + _externalViewStabilizationTimeoutInMs
         + ", _updateTargetTier=" + _updateTargetTier + ", _heartbeatIntervalInMs=" + _heartbeatIntervalInMs
         + ", _heartbeatTimeoutInMs=" + _heartbeatTimeoutInMs + ", _maxAttempts=" + _maxAttempts
-        + ", _retryInitialDelayInMs=" + _retryInitialDelayInMs + ", _diskUtilizationThreshold=" + _diskUtilizationThreshold
-        + ", _forceCommit=" + _forceCommit + ", _forceCommitBatchSize=" + _forceCommitBatchSize
-        + ", _forceCommitBatchStatusCheckIntervalMs=" + _forceCommitBatchStatusCheckIntervalMs
+        + ", _retryInitialDelayInMs=" + _retryInitialDelayInMs + ", _diskUtilizationThreshold="
+        + _diskUtilizationThreshold + ", _forceCommit=" + _forceCommit + ", _forceCommitBatchSize="
+        + _forceCommitBatchSize + ", _forceCommitBatchStatusCheckIntervalMs=" + _forceCommitBatchStatusCheckIntervalMs
         + ", _forceCommitBatchStatusCheckTimeoutMs=" + _forceCommitBatchStatusCheckTimeoutMs + '}';
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceConfig.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceConfig.java
@@ -137,6 +137,12 @@ public class RebalanceConfig {
   @ApiModelProperty(example = "300000")
   private long _retryInitialDelayInMs = 300000L;
 
+  // Disk utilization threshold override. If set, this will override the default disk utilization threshold
+  // configured at the controller level. Value should be between 0.0 and 1.0 (e.g., 0.85 for 85%)
+  @JsonProperty("diskUtilizationThreshold")
+  @ApiModelProperty(example = "0.85")
+  private double _diskUtilizationThreshold = -1.0; // -1.0 means not set, use default
+
   @JsonProperty("forceCommit")
   @ApiModelProperty(example = "false")
   private boolean _forceCommit = false;
@@ -331,6 +337,14 @@ public class RebalanceConfig {
     _minimizeDataMovement = minimizeDataMovement;
   }
 
+  public double getDiskUtilizationThreshold() {
+    return _diskUtilizationThreshold;
+  }
+
+  public void setDiskUtilizationThreshold(double diskUtilizationThreshold) {
+    _diskUtilizationThreshold = diskUtilizationThreshold;
+  }
+
   @Override
   public String toString() {
     return "RebalanceConfig{" + "_dryRun=" + _dryRun + ", preChecks=" + _preChecks + ", _reassignInstances="
@@ -341,7 +355,7 @@ public class RebalanceConfig {
         + ", _externalViewStabilizationTimeoutInMs=" + _externalViewStabilizationTimeoutInMs
         + ", _updateTargetTier=" + _updateTargetTier + ", _heartbeatIntervalInMs=" + _heartbeatIntervalInMs
         + ", _heartbeatTimeoutInMs=" + _heartbeatTimeoutInMs + ", _maxAttempts=" + _maxAttempts
-        + ", _retryInitialDelayInMs=" + _retryInitialDelayInMs
+        + ", _retryInitialDelayInMs=" + _retryInitialDelayInMs + ", _diskUtilizationThreshold=" + _diskUtilizationThreshold
         + ", _forceCommit=" + _forceCommit + ", _forceCommitBatchSize=" + _forceCommitBatchSize
         + ", _forceCommitBatchStatusCheckIntervalMs=" + _forceCommitBatchStatusCheckIntervalMs
         + ", _forceCommitBatchStatusCheckTimeoutMs=" + _forceCommitBatchStatusCheckTimeoutMs + '}';
@@ -382,6 +396,7 @@ public class RebalanceConfig {
     rc._heartbeatTimeoutInMs = cfg._heartbeatTimeoutInMs;
     rc._maxAttempts = cfg._maxAttempts;
     rc._retryInitialDelayInMs = cfg._retryInitialDelayInMs;
+    rc._diskUtilizationThreshold = cfg._diskUtilizationThreshold;
     rc._forceCommit = cfg._forceCommit;
     rc._forceCommitBatchSize = cfg._forceCommitBatchSize;
     rc._forceCommitBatchStatusCheckIntervalMs = cfg._forceCommitBatchStatusCheckIntervalMs;

--- a/pinot-controller/src/main/resources/app/components/Homepage/Operations/RebalanceServer/RebalanceServerConfigurationOption.tsx
+++ b/pinot-controller/src/main/resources/app/components/Homepage/Operations/RebalanceServer/RebalanceServerConfigurationOption.tsx
@@ -27,6 +27,9 @@ import {
 import {
     RebalanceServerConfigurationOptionSelect
 } from "./RebalanceServerConfigurationOptions/RebalanceServerConfigurationOptionSelect";
+import {
+    RebalanceServerConfigurationOptionDouble
+} from "./RebalanceServerConfigurationOptions/RebalanceServerConfigurationOptionDouble";
 
 export const RebalanceServerConfigurationOption = (
     {
@@ -45,6 +48,8 @@ export const RebalanceServerConfigurationOption = (
             return <RebalanceServerConfigurationOptionInteger rebalanceConfig={rebalanceConfig} option={option} handleConfigChange={handleConfigChange} />;
         case "SELECT":
             return <RebalanceServerConfigurationOptionSelect rebalanceConfig={rebalanceConfig} option={option} handleConfigChange={handleConfigChange} />;
+        case "DOUBLE":
+            return <RebalanceServerConfigurationOptionDouble rebalanceConfig={rebalanceConfig} option={option} handleConfigChange={handleConfigChange} />;
         default:
             return null;
     }

--- a/pinot-controller/src/main/resources/app/components/Homepage/Operations/RebalanceServer/RebalanceServerConfigurationOptions/RebalanceServerConfigurationOptionDouble.tsx
+++ b/pinot-controller/src/main/resources/app/components/Homepage/Operations/RebalanceServer/RebalanceServerConfigurationOptions/RebalanceServerConfigurationOptionDouble.tsx
@@ -1,0 +1,66 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import {Box, FormControl, TextField, Typography} from "@material-ui/core";
+import React, {useState} from "react";
+import {RebalanceServerOption} from "../RebalanceServerOptions";
+import {
+    RebalanceServerConfigurationOptionLabel
+} from "./RebalanceServerConfigurationOptionLabel/RebalanceServerConfigurationOptionLabel";
+import Utils from "../../../../../utils/Utils";
+
+type RebalanceServerConfigurationOptionDoubleProps = {
+    option: RebalanceServerOption;
+    handleConfigChange: (config: { [key: string]: string | number | boolean }) => void;
+    rebalanceConfig: { [optionName: string]: string | boolean | number };
+}
+export const RebalanceServerConfigurationOptionDouble = (
+    { option, handleConfigChange, rebalanceConfig }: RebalanceServerConfigurationOptionDoubleProps
+) => {
+    const [value, setValue] = useState<number>(
+        Utils.getRebalanceConfigValue(rebalanceConfig, option) as number
+    );
+    return (
+        <Box display='flex' flexDirection='column'>
+            <FormControl fullWidth>
+                <RebalanceServerConfigurationOptionLabel option={option} />
+                <TextField
+                    variant='outlined'
+                    fullWidth
+                    style={{ width: '100%' }}
+                    size='small'
+                    id={`rebalance-server-double-input-${option.name}`}
+                    type='number'
+                    inputProps={{
+                        step: 0.01,
+                        min: -1,
+                        max: 1
+                    }}
+                    value={value}
+                    onChange={(e) => {
+                        handleConfigChange(
+                            {
+                                [option.name]: parseFloat(e.target.value)
+                            });
+                        setValue(parseFloat(e.target.value));
+                    }}/>
+                <Typography variant='caption'>{option.description}</Typography>
+            </FormControl>
+        </Box>
+    );
+} 

--- a/pinot-controller/src/main/resources/app/components/Homepage/Operations/RebalanceServer/RebalanceServerConfigurationOptions/RebalanceServerConfigurationOptionDouble.tsx
+++ b/pinot-controller/src/main/resources/app/components/Homepage/Operations/RebalanceServer/RebalanceServerConfigurationOptions/RebalanceServerConfigurationOptionDouble.tsx
@@ -47,9 +47,9 @@ export const RebalanceServerConfigurationOptionDouble = (
                     id={`rebalance-server-double-input-${option.name}`}
                     type='number'
                     inputProps={{
-                        step: 0.01,
-                        min: -1,
-                        max: 1
+                        step: option.valueStep,
+                        min: option.valueMin,
+                        max: option.valueMax
                     }}
                     value={value}
                     onChange={(e) => {

--- a/pinot-controller/src/main/resources/app/components/Homepage/Operations/RebalanceServer/RebalanceServerOptions.ts
+++ b/pinot-controller/src/main/resources/app/components/Homepage/Operations/RebalanceServer/RebalanceServerOptions.ts
@@ -27,6 +27,9 @@ export type RebalanceServerOption = {
     markWithWarningIcon: boolean;
     allowedValues?: string[];
     toolTip?: string;
+    valueStep?: number;
+    valueMin?: number;
+    valueMax?: number;
 }
 
 export const rebalanceServerOptions: RebalanceServerOption[] = [
@@ -180,9 +183,13 @@ export const rebalanceServerOptions: RebalanceServerOption[] = [
         "defaultValue": -1.0,
         "type": "DOUBLE",
         "label": "Disk Utilization Threshold",
-        "description": "Override disk utilization threshold used in pre-check (0.0 to 1.0, e.g., 0.85 for 85%). If not provided (or -1.0), uses the controller's default threshold",
+        "description": "Override disk utilization threshold used in pre-check (0.0 to 1.0, e.g., 0.85 for 85%). If not provided (or any negative value), uses the controller's default threshold",
         "isAdvancedConfig": true,
         "isStatsGatheringConfig": false,
+        "markWithWarningIcon": false,
+        "valueStep": 0.05,
+        "valueMin": -1.0,
+        "valueMax": 1.0
         "markWithWarningIcon": false
     },
     {

--- a/pinot-controller/src/main/resources/app/components/Homepage/Operations/RebalanceServer/RebalanceServerOptions.ts
+++ b/pinot-controller/src/main/resources/app/components/Homepage/Operations/RebalanceServer/RebalanceServerOptions.ts
@@ -189,8 +189,7 @@ export const rebalanceServerOptions: RebalanceServerOption[] = [
         "markWithWarningIcon": false,
         "valueStep": 0.05,
         "valueMin": -1.0,
-        "valueMax": 1.0
-        "markWithWarningIcon": false
+        "valueMax": 1.0,
     },
     {
         "name": "forceCommit",

--- a/pinot-controller/src/main/resources/app/components/Homepage/Operations/RebalanceServer/RebalanceServerOptions.ts
+++ b/pinot-controller/src/main/resources/app/components/Homepage/Operations/RebalanceServer/RebalanceServerOptions.ts
@@ -180,7 +180,7 @@ export const rebalanceServerOptions: RebalanceServerOption[] = [
         "defaultValue": -1.0,
         "type": "DOUBLE",
         "label": "Disk Utilization Threshold",
-        "description": "Override disk utilization threshold (0.0 to 1.0, e.g., 0.85 for 85%). If not provided (or -1.0), uses the controller's default threshold",
+        "description": "Override disk utilization threshold used in pre-check (0.0 to 1.0, e.g., 0.85 for 85%). If not provided (or -1.0), uses the controller's default threshold",
         "isAdvancedConfig": true,
         "isStatsGatheringConfig": false,
         "markWithWarningIcon": false

--- a/pinot-controller/src/main/resources/app/components/Homepage/Operations/RebalanceServer/RebalanceServerOptions.ts
+++ b/pinot-controller/src/main/resources/app/components/Homepage/Operations/RebalanceServer/RebalanceServerOptions.ts
@@ -189,7 +189,7 @@ export const rebalanceServerOptions: RebalanceServerOption[] = [
         "markWithWarningIcon": false,
         "valueStep": 0.05,
         "valueMin": -1.0,
-        "valueMax": 1.0,
+        "valueMax": 1.0
     },
     {
         "name": "forceCommit",

--- a/pinot-controller/src/main/resources/app/components/Homepage/Operations/RebalanceServer/RebalanceServerOptions.ts
+++ b/pinot-controller/src/main/resources/app/components/Homepage/Operations/RebalanceServer/RebalanceServerOptions.ts
@@ -19,7 +19,7 @@
 export type RebalanceServerOption = {
     name: string;
     label: string;
-    type: "BOOL" | "INTEGER" | "SELECT";
+    type: "BOOL" | "INTEGER" | "SELECT" | "DOUBLE";
     description: string;
     defaultValue: string | boolean | number;
     isAdvancedConfig: boolean;
@@ -171,6 +171,16 @@ export const rebalanceServerOptions: RebalanceServerOption[] = [
         "type": "BOOL",
         "label": "Update Target Tier",
         "description": "If enabled, update segment target tier as part of the rebalance",
+        "isAdvancedConfig": true,
+        "isStatsGatheringConfig": false,
+        "markWithWarningIcon": false
+    },
+    {
+        "name": "diskUtilizationThreshold",
+        "defaultValue": -1.0,
+        "type": "DOUBLE",
+        "label": "Disk Utilization Threshold",
+        "description": "Override disk utilization threshold (0.0 to 1.0, e.g., 0.85 for 85%). If not provided (or -1.0), uses the controller's default threshold",
         "isAdvancedConfig": true,
         "isStatsGatheringConfig": false,
         "markWithWarningIcon": false


### PR DESCRIPTION
## Overview
Added support for overriding the default disk utilization threshold during table rebalance operations, allowing users to customize disk space checks on a per-rebalance basis.

### Backend Changes
- **RebalanceConfig**: Added `diskUtilizationThreshold` field (double, default: -1.0)
- **Rebalance API**: New query parameter `diskUtilizationThreshold` in `POST /tables/{tableName}/rebalance`
- **Pre-checker**: Updated `DefaultRebalancePreChecker` to use override threshold when provided
- **Variable Rename**: `_diskUtilizationThreshold` → `_defaultDiskUtilizationThreshold` for clarity in `DefaultRebalancePreChecker`

### API Usage
```bash
POST /tables/myTable/rebalance?type=OFFLINE&diskUtilizationThreshold=0.85
```

### UI Changes
- Added "Disk Utilization Threshold" field to Advanced Options in rebalance dialog
- New DOUBLE input component for decimal values (0.0-1.0 range)

### Behavior
- **Default (-1.0)**: Uses controller's configured threshold (the approach before this PR)
- **Override (>=0.0)**: Uses specified threshold (e.g., 0.85 = 85%)

## Rebalance UI
![image](https://github.com/user-attachments/assets/248b276d-49fb-458e-9696-cbb9a40028ae)
When the value is default (-1.0)
<img width="224" alt="image" src="https://github.com/user-attachments/assets/b65eb0cc-3360-41bc-bd79-045b48fae263" />
When the value is 0.2
![image](https://github.com/user-attachments/assets/392fec4d-9b58-4089-b57e-96f5f8573db6)
When the value is 15 (no check on this value, though)
![image](https://github.com/user-attachments/assets/68045a7f-faf5-4d9a-a168-1366c5c0ca0c)
