### PR TITLE
Cleanup deprecated GenericRow methods

### DIFF
--- a/pinot-core/src/test/java/org/apache/pinot/core/geospatial/transform/GeoFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/geospatial/transform/GeoFunctionTest.java
@@ -142,13 +142,10 @@ public abstract class GeoFunctionTest {
     }
     Schema schema = sb.build();
     for (int i = 0; i < length; i++) {
-
-      Map<String, Object> map = new HashMap<>();
-      for (Column column : columns) {
-        map.put(column._name, column._values[i]);
-      }
       GenericRow row = new GenericRow();
-      row.init(map);
+      for (Column column : columns) {
+        row.putValue(column._name, column._values[i]);
+      }
       rows.add(row);
     }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/BaseTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/BaseTransformFunctionTest.java
@@ -272,7 +272,7 @@ public abstract class BaseTransformFunctionTest {
       map.put(DOUBLE_MV_COLUMN_2, ArrayUtils.toObject(_doubleMV2Values[i]));
       map.put(JSON_STRING_SV_COLUMN, _jsonSVValues[i]);
       GenericRow row = new GenericRow();
-      row.init(map);
+      row.putValues(map);
       rows.add(row);
     }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/DateTruncTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/DateTruncTransformFunctionTest.java
@@ -18,8 +18,6 @@
  */
 package org.apache.pinot.core.operator.transform.function;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import java.io.File;
 import java.nio.file.Files;
 import java.nio.file.Paths;
@@ -82,8 +80,8 @@ public class DateTruncTransformFunctionTest {
       throws Exception {
     long zmillisInput = iso8601ToUtcEpochMillis(literalInput);
     GenericRow row = new GenericRow();
-    row.init(ImmutableMap.of(TIME_COLUMN, zmillisInput));
-    List<GenericRow> rows = ImmutableList.of(row);
+    row.putValue(TIME_COLUMN, zmillisInput);
+    List<GenericRow> rows = List.of(row);
     TableConfig tableConfig =
         new TableConfigBuilder(TableType.OFFLINE).setTableName("test").setTimeColumnName(TIME_COLUMN).build();
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/DistinctFromTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/DistinctFromTransformFunctionTest.java
@@ -123,17 +123,15 @@ public abstract class DistinctFromTransformFunctionTest {
     }
     List<GenericRow> rows = new ArrayList<>(NUM_ROWS);
     for (int i = 0; i < NUM_ROWS; i++) {
-      Map<String, Object> map = new HashMap<>();
-      map.put(INT_SV_COLUMN, _intSVValues[i]);
-      if (isEqualRow(i)) {
-        map.put(INT_SV_NULL_COLUMN, _intSVValues[i]);
-      } else if (isNotEqualRow(i)) {
-        map.put(INT_SV_NULL_COLUMN, _intSVValues[i] + 1);
-      } else if (isNullRow(i)) {
-        map.put(INT_SV_NULL_COLUMN, null);
-      }
       GenericRow row = new GenericRow();
-      row.init(map);
+      row.putValue(INT_SV_COLUMN, _intSVValues[i]);
+      if (isEqualRow(i)) {
+        row.putValue(INT_SV_NULL_COLUMN, _intSVValues[i]);
+      } else if (isNotEqualRow(i)) {
+        row.putValue(INT_SV_NULL_COLUMN, _intSVValues[i] + 1);
+      } else if (isNullRow(i)) {
+        row.putValue(INT_SV_NULL_COLUMN, null);
+      }
       rows.add(row);
     }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/NullHandlingTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/NullHandlingTransformFunctionTest.java
@@ -113,26 +113,24 @@ public class NullHandlingTransformFunctionTest {
 
     List<GenericRow> rows = new ArrayList<>(NUM_ROWS);
     for (int i = 0; i < NUM_ROWS; i++) {
-      Map<String, Object> map = new HashMap<>();
-      if (!_nullValues[i]) {
-        map.put(INT_SV_COLUMN, _intSVValues[i]);
-        map.put(LONG_SV_COLUMN, _longSVValues[i]);
-        map.put(FLOAT_SV_COLUMN, _floatSVValues[i]);
-        map.put(DOUBLE_SV_COLUMN, _doubleSVValues[i]);
-        map.put(STRING_SV_COLUMN, _stringSVValues[i]);
-        map.put(BYTES_SV_COLUMN, _bytesSVValues[i]);
-      } else {
-        map.put(INT_SV_COLUMN, null);
-        map.put(LONG_SV_COLUMN, null);
-        map.put(FLOAT_SV_COLUMN, null);
-        map.put(DOUBLE_SV_COLUMN, null);
-        map.put(STRING_SV_COLUMN, null);
-        map.put(BYTES_SV_COLUMN, null);
-      }
-      map.put(TIMESTAMP_COLUMN, _timeValues[i]);
-      map.put(TIME_COLUMN, _timeValues[i]);
       GenericRow row = new GenericRow();
-      row.init(map);
+      if (!_nullValues[i]) {
+        row.putValue(INT_SV_COLUMN, _intSVValues[i]);
+        row.putValue(LONG_SV_COLUMN, _longSVValues[i]);
+        row.putValue(FLOAT_SV_COLUMN, _floatSVValues[i]);
+        row.putValue(DOUBLE_SV_COLUMN, _doubleSVValues[i]);
+        row.putValue(STRING_SV_COLUMN, _stringSVValues[i]);
+        row.putValue(BYTES_SV_COLUMN, _bytesSVValues[i]);
+      } else {
+        row.putValue(INT_SV_COLUMN, null);
+        row.putValue(LONG_SV_COLUMN, null);
+        row.putValue(FLOAT_SV_COLUMN, null);
+        row.putValue(DOUBLE_SV_COLUMN, null);
+        row.putValue(STRING_SV_COLUMN, null);
+        row.putValue(BYTES_SV_COLUMN, null);
+      }
+      row.putValue(TIMESTAMP_COLUMN, _timeValues[i]);
+      row.putValue(TIME_COLUMN, _timeValues[i]);
       rows.add(row);
     }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/DefaultAggregationExecutorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/DefaultAggregationExecutorTest.java
@@ -168,18 +168,14 @@ public class DefaultAggregationExecutorTest {
 
     List<GenericRow> rows = new ArrayList<>(NUM_ROWS);
     for (int i = 0; i < NUM_ROWS; i++) {
-      Map<String, Object> map = new HashMap<>();
-
+      GenericRow row = new GenericRow();
       for (int j = 0; j < _columns.length; j++) {
         String metricName = _columns[j];
         double value = _random.nextDouble() * MAX_VALUE;
         _inputData[j][i] = value;
-        map.put(metricName, value);
+        row.putValue(metricName, value);
       }
-
-      GenericRow genericRow = new GenericRow();
-      genericRow.init(map);
-      rows.add(genericRow);
+      rows.add(row);
     }
 
     SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/groupby/DictionaryBasedGroupKeyGeneratorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/groupby/DictionaryBasedGroupKeyGeneratorTest.java
@@ -21,11 +21,9 @@ package org.apache.pinot.core.query.aggregation.groupby;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import org.apache.commons.io.FileUtils;
@@ -93,10 +91,10 @@ public class DictionaryBasedGroupKeyGeneratorTest {
 
     // Generate random values for the segment
     for (int i = 0; i < UNIQUE_ROWS; i++) {
-      Map<String, Object> map = new HashMap<>();
-      map.put(FILTER_COLUMN, i);
+      GenericRow row = new GenericRow();
+      row.putValue(FILTER_COLUMN, i);
       for (String svColumn : SV_COLUMNS) {
-        map.put(svColumn, value);
+        row.putValue(svColumn, value);
         value += 1 + _random.nextInt(MAX_STEP_LENGTH);
       }
       for (String mvColumn : MV_COLUMNS) {
@@ -106,10 +104,8 @@ public class DictionaryBasedGroupKeyGeneratorTest {
           values[k] = value;
           value += 1 + _random.nextInt(MAX_STEP_LENGTH);
         }
-        map.put(mvColumn, values);
+        row.putValue(mvColumn, values);
       }
-      GenericRow row = new GenericRow();
-      row.init(map);
       rows.add(row);
     }
     for (int i = UNIQUE_ROWS; i < NUM_ROWS; i++) {

--- a/pinot-core/src/test/java/org/apache/pinot/queries/SegmentWithNullValueVectorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/SegmentWithNullValueVectorTest.java
@@ -161,7 +161,6 @@ public class SegmentWithNullValueVectorTest {
    * @return Array of string values for the rows in the generated index.
    * @throws Exception
    */
-
   private void buildIndex(TableConfig tableConfig, Schema schema)
       throws Exception {
     SegmentGeneratorConfig config = new SegmentGeneratorConfig(tableConfig, schema);
@@ -183,9 +182,7 @@ public class SegmentWithNullValueVectorTest {
         map.put(fieldSpec.getName(), value);
       }
 
-      GenericRow genericRow = new GenericRow();
-      //Remove some values to simulate null
-      int rowId = i;
+      // Remove some values to simulate null
       Iterator<Map.Entry<String, Object>> iterator = map.entrySet().iterator();
       while (iterator.hasNext()) {
         Map.Entry<String, Object> entry = iterator.next();
@@ -196,20 +193,21 @@ public class SegmentWithNullValueVectorTest {
           } else {
             entry.setValue(null);
           }
-          _actualNullVectorMap.get(key)[rowId] = true;
+          _actualNullVectorMap.get(key)[i] = true;
         }
       }
 
-      if (_actualNullVectorMap.get(INT_COLUMN)[rowId]) {
+      if (_actualNullVectorMap.get(INT_COLUMN)[i]) {
         _nullIntKeyCount++;
-      } else if (!_actualNullVectorMap.get(LONG_COLUMN)[rowId]) {
+      } else if (!_actualNullVectorMap.get(LONG_COLUMN)[i]) {
         if ((long) map.get(LONG_COLUMN) > LONG_VALUE_THRESHOLD) {
           _longKeyCount++;
         }
       }
 
-      genericRow.init(map);
-      rows.add(genericRow);
+      GenericRow row = new GenericRow();
+      row.putValues(map);
+      rows.add(row);
     }
 
     RecordReader recordReader = new GenericRowRecordReader(rows);

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkNativeAndLuceneBasedLike.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkNativeAndLuceneBasedLike.java
@@ -131,10 +131,10 @@ public class BenchmarkNativeAndLuceneBasedLike {
       String domain = domainNames[i % domainNames.length];
       String url = domain + urlSuffixes[i % urlSuffixes.length];
       GenericRow row = new GenericRow();
-      row.putField(INT_COL_NAME, _intBaseValue + i);
-      row.putField(NO_INDEX_STRING_COL_NAME, noIndexData[i % noIndexData.length]);
-      row.putField(DOMAIN_NAMES_COL, domain);
-      row.putField(URL_COL, url);
+      row.putValue(INT_COL_NAME, _intBaseValue + i);
+      row.putValue(NO_INDEX_STRING_COL_NAME, noIndexData[i % noIndexData.length]);
+      row.putValue(DOMAIN_NAMES_COL, domain);
+      row.putValue(URL_COL, url);
       rows.add(row);
     }
     return rows;

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkNativeVsLuceneTextIndex.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkNativeVsLuceneTextIndex.java
@@ -138,8 +138,8 @@ public class BenchmarkNativeVsLuceneTextIndex {
     for (int i = 0; i < numRows; i++) {
       String domain = domainNames.get(i % domainNames.size());
       GenericRow row = new GenericRow();
-      row.putField(DOMAIN_NAMES_COL, domain);
-      row.putField(INT_COL, i);
+      row.putValue(DOMAIN_NAMES_COL, domain);
+      row.putValue(INT_COL, i);
       rows.add(row);
     }
     return rows;

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/RawIndexBenchmark.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/RawIndexBenchmark.java
@@ -150,15 +150,11 @@ public class RawIndexBenchmark {
 
     System.out.println("Reading data...");
     while ((value = reader.readLine()) != null) {
-      HashMap<String, Object> map = new HashMap<>();
-
+      GenericRow row = new GenericRow();
       for (FieldSpec fieldSpec : schema.getAllFieldSpecs()) {
-        map.put(fieldSpec.getName(), value);
+        row.putValue(fieldSpec.getName(), value);
       }
-
-      GenericRow genericRow = new GenericRow();
-      genericRow.init(map);
-      rows.add(genericRow);
+      rows.add(row);
       _numRows++;
 
       if (_numRows % 1000000 == 0) {

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/StringDictionaryPerfTest.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/StringDictionaryPerfTest.java
@@ -21,7 +21,6 @@ package org.apache.pinot.perf;
 import com.google.common.base.Joiner;
 import java.io.File;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Random;
@@ -101,23 +100,16 @@ public class StringDictionaryPerfTest {
 
     int i = 0;
     while (i < dictLength) {
-      HashMap<String, Object> map = new HashMap<>();
-      String randomString = RandomStringUtils
-          .randomAlphanumeric(USE_FIXED_SIZE_STRING ? MAX_STRING_LENGTH : (1 + random.nextInt(MAX_STRING_LENGTH)));
-
-      if (uniqueStrings.contains(randomString)) {
+      String randomString = RandomStringUtils.randomAlphanumeric(
+          USE_FIXED_SIZE_STRING ? MAX_STRING_LENGTH : (1 + random.nextInt(MAX_STRING_LENGTH)));
+      if (!uniqueStrings.add(randomString)) {
         continue;
       }
-
-      _inputStrings[i] = randomString;
-      if (uniqueStrings.add(randomString)) {
-        _statistics.addValue(randomString.length());
-      }
-      map.put("test", _inputStrings[i++]);
-
-      GenericRow genericRow = new GenericRow();
-      genericRow.init(map);
-      rows.add(genericRow);
+      _inputStrings[i++] = randomString;
+      _statistics.addValue(randomString.length());
+      GenericRow row = new GenericRow();
+      row.putValue(COLUMN_NAME, randomString);
+      rows.add(row);
     }
 
     long start = System.currentTimeMillis();

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplAggregateMetricsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplAggregateMetricsTest.java
@@ -104,15 +104,15 @@ public class MutableSegmentImplAggregateMetricsTest {
       int hoursSinceEpoch = random.nextInt(10);
       int daysSinceEpoch = random.nextInt(5);
       GenericRow row = new GenericRow();
-      row.putField(DIMENSION_1, random.nextInt(10));
-      row.putField(DIMENSION_2, stringValues[random.nextInt(stringValues.length)]);
-      row.putField(TIME_COLUMN1, daysSinceEpoch);
-      row.putField(TIME_COLUMN2, hoursSinceEpoch);
+      row.putValue(DIMENSION_1, random.nextInt(10));
+      row.putValue(DIMENSION_2, stringValues[random.nextInt(stringValues.length)]);
+      row.putValue(TIME_COLUMN1, daysSinceEpoch);
+      row.putValue(TIME_COLUMN2, hoursSinceEpoch);
       // Generate random int to prevent overflow
       long metricValue = random.nextInt();
-      row.putField(METRIC, metricValue);
+      row.putValue(METRIC, metricValue);
       float metricValueFloat = floatValues[random.nextInt(floatValues.length)];
-      row.putField(METRIC_2, metricValueFloat);
+      row.putValue(METRIC_2, metricValueFloat);
 
       mutableSegmentImpl.index(row, defaultMetadata);
 

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/OnHeapDictionariesTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/OnHeapDictionariesTest.java
@@ -21,7 +21,6 @@ package org.apache.pinot.segment.local.segment.creator;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Random;
 import org.apache.commons.io.FileUtils;
@@ -179,17 +178,13 @@ public class OnHeapDictionariesTest implements PinotBuffersAfterClassCheckRule {
     List<GenericRow> rows = new ArrayList<>(NUM_ROWS);
 
     for (int rowId = 0; rowId < NUM_ROWS; rowId++) {
-      HashMap<String, Object> map = new HashMap<>();
-
-      map.put(INT_COLUMN, random.nextInt());
-      map.put(LONG_COLUMN, random.nextLong());
-      map.put(FLOAT_COLUMN, random.nextFloat());
-      map.put(DOUBLE_COLUMN, random.nextDouble());
-      map.put(STRING_COLUMN, RandomStringUtils.randomAscii(100));
-
-      GenericRow genericRow = new GenericRow();
-      genericRow.init(map);
-      rows.add(genericRow);
+      GenericRow row = new GenericRow();
+      row.putValue(INT_COLUMN, random.nextInt());
+      row.putValue(LONG_COLUMN, random.nextLong());
+      row.putValue(FLOAT_COLUMN, random.nextFloat());
+      row.putValue(DOUBLE_COLUMN, random.nextDouble());
+      row.putValue(STRING_COLUMN, RandomStringUtils.randomAscii(100));
+      rows.add(row);
     }
 
     SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/SegmentGenerationWithTimeColumnTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/SegmentGenerationWithTimeColumnTest.java
@@ -21,7 +21,6 @@ package org.apache.pinot.segment.local.segment.index.creator;
 import com.google.common.base.Preconditions;
 import java.io.File;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
@@ -248,18 +247,12 @@ public class SegmentGenerationWithTimeColumnTest implements PinotBuffersAfterMet
 
     List<GenericRow> rows = new ArrayList<>(NUM_ROWS);
     for (int i = 0; i < NUM_ROWS; i++) {
-      HashMap<String, Object> map = new HashMap<>();
-
+      GenericRow row = new GenericRow();
       for (FieldSpec fieldSpec : schema.getAllFieldSpecs()) {
-        Object value;
-
-        value = getRandomValueForColumn(fieldSpec, isSimpleDate, isInvalidDate, timeZoneSuffix);
-        map.put(fieldSpec.getName(), value);
+        row.putValue(fieldSpec.getName(),
+            getRandomValueForColumn(fieldSpec, isSimpleDate, isInvalidDate, timeZoneSuffix));
       }
-
-      GenericRow genericRow = new GenericRow();
-      genericRow.init(map);
-      rows.add(genericRow);
+      rows.add(row);
     }
 
     SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/SegmentPartitionTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/SegmentPartitionTest.java
@@ -193,17 +193,13 @@ public class SegmentPartitionTest implements PinotBuffersAfterClassCheckRule {
 
     List<GenericRow> rows = new ArrayList<>(NUM_ROWS);
     for (int i = 0; i < NUM_ROWS; i++) {
-      HashMap<String, Object> map = new HashMap<>();
-
+      GenericRow row = new GenericRow();
       int partition = random.nextInt(PARTITION_DIVISOR);
       int validPartitionedValue = random.nextInt(100) * 20 + partition;
       _expectedPartitions.add(partition);
-      map.put(PARTITIONED_COLUMN_NAME, validPartitionedValue);
-      map.put(NON_PARTITIONED_COLUMN_NAME, validPartitionedValue);
-
-      GenericRow genericRow = new GenericRow();
-      genericRow.init(map);
-      rows.add(genericRow);
+      row.putValue(PARTITIONED_COLUMN_NAME, validPartitionedValue);
+      row.putValue(NON_PARTITIONED_COLUMN_NAME, validPartitionedValue);
+      rows.add(row);
     }
 
     SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/readers/PinotSegmentUtil.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/readers/PinotSegmentUtil.java
@@ -21,10 +21,8 @@ package org.apache.pinot.segment.local.segment.readers;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
@@ -46,29 +44,21 @@ import org.apache.pinot.spi.utils.TimeUtils;
  * Util class for pinot segment
  */
 public class PinotSegmentUtil {
-  private static final int DEFAULT_NUM_MULTIVALUE = 5;
-  private static final int DEFAULT_STRING_VALUE_LENGTH = 2;
-
   private PinotSegmentUtil() {
   }
 
+  private static final int DEFAULT_NUM_MULTIVALUE = 5;
+  private static final int DEFAULT_STRING_VALUE_LENGTH = 2;
+
   public static List<GenericRow> createTestData(Schema schema, int numRows) {
     List<GenericRow> rows = new ArrayList<>();
-    final ThreadLocalRandom random = ThreadLocalRandom.current();
-    Map<String, Object> fields;
+    ThreadLocalRandom random = ThreadLocalRandom.current();
     for (int i = 0; i < numRows; i++) {
-      fields = new HashMap<>();
-      for (FieldSpec fieldSpec : schema.getAllFieldSpecs()) {
-        Object value;
-        if (fieldSpec.isSingleValueField()) {
-          value = generateSingleValue(random, fieldSpec);
-        } else {
-          value = generateMultiValue(random, fieldSpec);
-        }
-        fields.put(fieldSpec.getName(), value);
-      }
       GenericRow row = new GenericRow();
-      row.init(fields);
+      for (FieldSpec fieldSpec : schema.getAllFieldSpecs()) {
+        row.putValue(fieldSpec.getName(), fieldSpec.isSingleValueField() ? generateSingleValue(random, fieldSpec)
+            : generateMultiValue(random, fieldSpec));
+      }
       rows.add(row);
     }
     return rows;


### PR DESCRIPTION
These methods were deprecated in 2019 when adding the null support (#4671)

- Remove the following unused methods:
  - getEntrySet()
  - getFieldNames()
  - fromBytes(byte[] buffer)
  - toBytes()
  - createOrReuseRow(GenericRow row)
- Remove the usage of the following deprecated methods:
  - init(Map<String, Object> fieldToValueMap): replaced with `putValues(Map<String, Object> fieldToValueMap)`
  - putField(String fieldName, @Nullable Object value): replaced with `putValue(String fieldName, @Nullable Object value)`