### PR TITLE
Updated README.md - added deepwiki label, so it enables auto refresh of the…

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@
 [![Join the chat at https://communityinviter.com/apps/apache-pinot/apache-pinot](https://img.shields.io/badge/slack-apache--pinot-brightgreen?logo=slack)](https://communityinviter.com/apps/apache-pinot/apache-pinot)
 [![Twitter Follow](https://img.shields.io/twitter/follow/apachepinot.svg?label=Follow&style=social)](https://twitter.com/intent/follow?screen_name=apachepinot)
 [![License](https://img.shields.io/github/license/apache/pinot.svg)](LICENSE)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/apache/pinot)
+
 
 </div>
 


### PR DESCRIPTION
DeepWiki has become a valuable tool for Apache Pinot users by indexing code directly from the GitHub repository and dynamically generating up-to-date documentation.

Until now, someone had to trigger a manual refresh to capture new code changes. Applying this label to the repo enables automatic refresh, so all future updates are indexed without manual intervention.