### PR TITLE
Reduce array copying for non-equi join condition evaluation

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
@@ -143,12 +143,13 @@ public class HashJoinOperator extends BaseJoinOperator {
       if (rightRow == null) {
         handleUnmatchedLeftRow(leftRow, rows);
       } else {
-        Object[] resultRow = joinRow(leftRow, rightRow);
-        if (matchNonEquiConditions(resultRow)) {
+        List<Object> resultRowView = joinRowView(leftRow, rightRow);
+        if (matchNonEquiConditions(resultRowView)) {
           if (isMaxRowsLimitReached(rows.size())) {
             break;
           }
-          rows.add(resultRow);
+          // defer copying of the content until row matches
+          rows.add(resultRowView.toArray());
           if (_matchedRightRows != null) {
             _matchedRightRows.put(key, BIT_SET_PLACEHOLDER);
           }
@@ -176,13 +177,13 @@ public class HashJoinOperator extends BaseJoinOperator {
         boolean hasMatchForLeftRow = false;
         int numRightRows = rightRows.size();
         for (int i = 0; i < numRightRows; i++) {
-          Object[] resultRow = joinRow(leftRow, rightRows.get(i));
-          if (matchNonEquiConditions(resultRow)) {
+          List<Object> resultRowView = joinRowView(leftRow, rightRows.get(i));
+          if (matchNonEquiConditions(resultRowView)) {
             if (isMaxRowsLimitReached(rows.size())) {
               maxRowsLimitReached = true;
               break;
             }
-            rows.add(resultRow);
+            rows.add(resultRowView.toArray());
             hasMatchForLeftRow = true;
             if (_matchedRightRows != null) {
               _matchedRightRows.computeIfAbsent(key, k -> new BitSet(numRightRows)).set(i);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/NonEquiJoinOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/NonEquiJoinOperator.java
@@ -84,14 +84,13 @@ public class NonEquiJoinOperator extends BaseJoinOperator {
       boolean maxRowsLimitReached = false;
       for (int i = 0; i < numRightRows; i++) {
         Object[] rightRow = _rightTable.get(i);
-        // TODO: Optimize this to avoid unnecessary object copy.
-        Object[] resultRow = joinRow(leftRow, rightRow);
-        if (matchNonEquiConditions(resultRow)) {
+        List<Object> joinRowView = joinRowView(leftRow, rightRow);
+        if (matchNonEquiConditions(joinRowView)) {
           if (isMaxRowsLimitReached(rows.size())) {
             maxRowsLimitReached = true;
             break;
           }
-          rows.add(resultRow);
+          rows.add(joinRowView.toArray());
           hasMatchForLeftRow = true;
           if (_matchedRightRows != null) {
             _matchedRightRows.set(i);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/operands/FilterOperand.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/operands/FilterOperand.java
@@ -41,10 +41,6 @@ public abstract class FilterOperand implements TransformOperand {
 
   @Nullable
   @Override
-  public abstract Integer apply(Object[] row);
-
-  @Nullable
-  @Override
   public abstract Integer apply(List<Object> row);
 
   public static class And extends FilterOperand {
@@ -55,21 +51,6 @@ public abstract class FilterOperand implements TransformOperand {
       for (RexExpression child : children) {
         _childOperands.add(TransformOperandFactory.getTransformOperand(child, dataSchema));
       }
-    }
-
-    @Nullable
-    @Override
-    public Integer apply(Object[] row) {
-      boolean hasNull = false;
-      for (TransformOperand child : _childOperands) {
-        Object result = child.apply(row);
-        if (result == null) {
-          hasNull = true;
-        } else if ((int) result == 0) {
-          return 0;
-        }
-      }
-      return hasNull ? null : 1;
     }
 
     @Nullable
@@ -100,21 +81,6 @@ public abstract class FilterOperand implements TransformOperand {
 
     @Nullable
     @Override
-    public Integer apply(Object[] row) {
-      boolean hasNull = false;
-      for (TransformOperand child : _childOperands) {
-        Object result = child.apply(row);
-        if (result == null) {
-          hasNull = true;
-        } else if ((int) result == 1) {
-          return 1;
-        }
-      }
-      return hasNull ? null : 0;
-    }
-
-    @Nullable
-    @Override
     public Integer apply(List<Object> row) {
       boolean hasNull = false;
       for (TransformOperand child : _childOperands) {
@@ -138,13 +104,6 @@ public abstract class FilterOperand implements TransformOperand {
 
     @Nullable
     @Override
-    public Integer apply(Object[] row) {
-      Object result = _childOperand.apply(row);
-      return result != null ? 1 - (int) result : null;
-    }
-
-    @Nullable
-    @Override
     public Integer apply(List<Object> row) {
       Object result = _childOperand.apply(row);
       return result != null ? 1 - (int) result : null;
@@ -161,25 +120,6 @@ public abstract class FilterOperand implements TransformOperand {
         _childOperands.add(TransformOperandFactory.getTransformOperand(child, dataSchema));
       }
       _isNotIn = isNotIn;
-    }
-
-    @Nullable
-    @Override
-    public Integer apply(Object[] row) {
-      Object firstResult = _childOperands.get(0).apply(row);
-      if (firstResult == null) {
-        return null;
-      }
-      for (int i = 1; i < _childOperands.size(); i++) {
-        Object result = _childOperands.get(i).apply(row);
-        if (result == null) {
-          return null;
-        }
-        if (firstResult.equals(result)) {
-          return _isNotIn ? 0 : 1;
-        }
-      }
-      return _isNotIn ? 1 : 0;
     }
 
     @Nullable
@@ -210,12 +150,6 @@ public abstract class FilterOperand implements TransformOperand {
     }
 
     @Override
-    public Integer apply(Object[] row) {
-      Object result = _childOperand.apply(row);
-      return result != null ? (Integer) result : 0;
-    }
-
-    @Override
     public Integer apply(List<Object> row) {
       Object result = _childOperand.apply(row);
       return result != null ? (Integer) result : 0;
@@ -227,12 +161,6 @@ public abstract class FilterOperand implements TransformOperand {
 
     public IsNotTrue(RexExpression child, DataSchema dataSchema) {
       _childOperand = TransformOperandFactory.getTransformOperand(child, dataSchema);
-    }
-
-    @Override
-    public Integer apply(Object[] row) {
-      Object result = _childOperand.apply(row);
-      return result != null ? 1 - (int) result : 1;
     }
 
     @Override
@@ -283,25 +211,6 @@ public abstract class FilterOperand implements TransformOperand {
               String.format("Cannot compare incompatible type: %s and: %s", lhsType, rhsType));
         }
       }
-    }
-
-    @SuppressWarnings({"rawtypes", "unchecked"})
-    @Nullable
-    @Override
-    public Integer apply(Object[] row) {
-      Comparable v1 = (Comparable) _lhs.apply(row);
-      if (v1 == null) {
-        return null;
-      }
-      Comparable v2 = (Comparable) _rhs.apply(row);
-      if (v2 == null) {
-        return null;
-      }
-      if (_requireCasting) {
-        v1 = cast(v1, _commonCastType);
-        v2 = cast(v2, _commonCastType);
-      }
-      return _comparisonResultPredicate.test(v1.compareTo(v2)) ? 1 : 0;
     }
 
     @SuppressWarnings({"rawtypes", "unchecked"})

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/operands/FilterOperand.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/operands/FilterOperand.java
@@ -43,6 +43,10 @@ public abstract class FilterOperand implements TransformOperand {
   @Override
   public abstract Integer apply(Object[] row);
 
+  @Nullable
+  @Override
+  public abstract Integer apply(List<Object> row);
+
   public static class And extends FilterOperand {
     List<TransformOperand> _childOperands;
 
@@ -67,6 +71,22 @@ public abstract class FilterOperand implements TransformOperand {
       }
       return hasNull ? null : 1;
     }
+
+    @Nullable
+    @Override
+    public Integer apply(List<Object> row) {
+      boolean hasNull = false;
+      for (TransformOperand child : _childOperands) {
+        Object result = child.apply(row);
+        if (result == null) {
+          hasNull = true;
+        } else if ((int) result == 0) {
+          return 0;
+        }
+      }
+      return hasNull ? null : 1;
+    }
+
   }
 
   public static class Or extends FilterOperand {
@@ -93,6 +113,21 @@ public abstract class FilterOperand implements TransformOperand {
       }
       return hasNull ? null : 0;
     }
+
+    @Nullable
+    @Override
+    public Integer apply(List<Object> row) {
+      boolean hasNull = false;
+      for (TransformOperand child : _childOperands) {
+        Object result = child.apply(row);
+        if (result == null) {
+          hasNull = true;
+        } else if ((int) result == 1) {
+          return 1;
+        }
+      }
+      return hasNull ? null : 0;
+    }
   }
 
   public static class Not extends FilterOperand {
@@ -105,6 +140,13 @@ public abstract class FilterOperand implements TransformOperand {
     @Nullable
     @Override
     public Integer apply(Object[] row) {
+      Object result = _childOperand.apply(row);
+      return result != null ? 1 - (int) result : null;
+    }
+
+    @Nullable
+    @Override
+    public Integer apply(List<Object> row) {
       Object result = _childOperand.apply(row);
       return result != null ? 1 - (int) result : null;
     }
@@ -140,6 +182,25 @@ public abstract class FilterOperand implements TransformOperand {
       }
       return _isNotIn ? 1 : 0;
     }
+
+    @Nullable
+    @Override
+    public Integer apply(List<Object> row) {
+      Object firstResult = _childOperands.get(0).apply(row);
+      if (firstResult == null) {
+        return null;
+      }
+      for (int i = 1; i < _childOperands.size(); i++) {
+        Object result = _childOperands.get(i).apply(row);
+        if (result == null) {
+          return null;
+        }
+        if (firstResult.equals(result)) {
+          return _isNotIn ? 0 : 1;
+        }
+      }
+      return _isNotIn ? 1 : 0;
+    }
   }
 
   public static class IsTrue extends FilterOperand {
@@ -154,6 +215,12 @@ public abstract class FilterOperand implements TransformOperand {
       Object result = _childOperand.apply(row);
       return result != null ? (Integer) result : 0;
     }
+
+    @Override
+    public Integer apply(List<Object> row) {
+      Object result = _childOperand.apply(row);
+      return result != null ? (Integer) result : 0;
+    }
   }
 
   public static class IsNotTrue extends FilterOperand {
@@ -165,6 +232,12 @@ public abstract class FilterOperand implements TransformOperand {
 
     @Override
     public Integer apply(Object[] row) {
+      Object result = _childOperand.apply(row);
+      return result != null ? 1 - (int) result : 1;
+    }
+
+    @Override
+    public Integer apply(List<Object> row) {
       Object result = _childOperand.apply(row);
       return result != null ? 1 - (int) result : 1;
     }
@@ -217,6 +290,25 @@ public abstract class FilterOperand implements TransformOperand {
     @Nullable
     @Override
     public Integer apply(Object[] row) {
+      Comparable v1 = (Comparable) _lhs.apply(row);
+      if (v1 == null) {
+        return null;
+      }
+      Comparable v2 = (Comparable) _rhs.apply(row);
+      if (v2 == null) {
+        return null;
+      }
+      if (_requireCasting) {
+        v1 = cast(v1, _commonCastType);
+        v2 = cast(v2, _commonCastType);
+      }
+      return _comparisonResultPredicate.test(v1.compareTo(v2)) ? 1 : 0;
+    }
+
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    @Nullable
+    @Override
+    public Integer apply(List<Object> row) {
       Comparable v1 = (Comparable) _lhs.apply(row);
       if (v1 == null) {
         return null;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/operands/FilterOperand.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/operands/FilterOperand.java
@@ -86,7 +86,6 @@ public abstract class FilterOperand implements TransformOperand {
       }
       return hasNull ? null : 1;
     }
-
   }
 
   public static class Or extends FilterOperand {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/operands/FunctionOperand.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/operands/FunctionOperand.java
@@ -100,26 +100,6 @@ public class FunctionOperand implements TransformOperand {
 
   @Nullable
   @Override
-  public Object apply(Object[] row) {
-    for (int i = 0; i < _operands.size(); i++) {
-      TransformOperand operand = _operands.get(i);
-      Object value = operand.apply(row);
-      _reusableOperandHolder[i] = value != null ? operand.getResultType().toExternal(value) : null;
-    }
-    // TODO: Optimize per record conversion
-    Object result;
-    if (_functionInvoker.getMethod().isVarArgs()) {
-      result = _functionInvoker.invoke(new Object[]{_reusableOperandHolder});
-    } else {
-      _functionInvoker.convertTypes(_reusableOperandHolder);
-      result = _functionInvoker.invoke(_reusableOperandHolder);
-    }
-    return result != null ? TypeUtils.convert(_functionInvokerResultType.toInternal(result),
-        _resultType.getStoredType()) : null;
-  }
-
-  @Nullable
-  @Override
   public Object apply(List<Object> row) {
     for (int i = 0; i < _operands.size(); i++) {
       TransformOperand operand = _operands.get(i);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/operands/LiteralOperand.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/operands/LiteralOperand.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.query.runtime.operator.operands;
 
+import java.util.List;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.query.planner.logical.RexExpression;
 
@@ -38,6 +39,11 @@ public class LiteralOperand implements TransformOperand {
 
   @Override
   public Object apply(Object[] row) {
+    return _value;
+  }
+
+  @Override
+  public Object apply(List<Object> row) {
     return _value;
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/operands/LiteralOperand.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/operands/LiteralOperand.java
@@ -38,11 +38,6 @@ public class LiteralOperand implements TransformOperand {
   }
 
   @Override
-  public Object apply(Object[] row) {
-    return _value;
-  }
-
-  @Override
   public Object apply(List<Object> row) {
     return _value;
   }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/operands/ReferenceOperand.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/operands/ReferenceOperand.java
@@ -40,12 +40,6 @@ public class ReferenceOperand implements TransformOperand {
 
   @Nullable
   @Override
-  public Object apply(Object[] row) {
-    return row[_index];
-  }
-
-  @Nullable
-  @Override
   public Object apply(List<Object> row) {
     return row.get(_index);
   }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/operands/ReferenceOperand.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/operands/ReferenceOperand.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.query.runtime.operator.operands;
 
+import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
@@ -41,5 +42,11 @@ public class ReferenceOperand implements TransformOperand {
   @Override
   public Object apply(Object[] row) {
     return row[_index];
+  }
+
+  @Nullable
+  @Override
+  public Object apply(List<Object> row) {
+    return row.get(_index);
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/operands/TransformOperand.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/operands/TransformOperand.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.query.runtime.operator.operands;
 
+import java.util.Arrays;
 import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
@@ -27,8 +28,9 @@ public interface TransformOperand {
 
   ColumnDataType getResultType();
 
-  @Nullable
-  Object apply(Object[] row);
+  default Object apply(Object[] row) {
+    return apply(Arrays.asList(row));
+  };
 
   @Nullable
   Object apply(List<Object> row);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/operands/TransformOperand.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/operands/TransformOperand.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.query.runtime.operator.operands;
 
+import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 
@@ -28,4 +29,7 @@ public interface TransformOperand {
 
   @Nullable
   Object apply(Object[] row);
+
+  @Nullable
+  Object apply(List<Object> row);
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/operands/TransformOperand.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/operands/TransformOperand.java
@@ -30,7 +30,7 @@ public interface TransformOperand {
 
   default Object apply(Object[] row) {
     return apply(Arrays.asList(row));
-  };
+  }
 
   @Nullable
   Object apply(List<Object> row);


### PR DESCRIPTION
Previously we copy the left and right input of join before evaluating the non-equi join condition that touches both sides. 
This PR introduces a List that serves as a ["view"](https://github.com/apache/pinot/pull/16152/files#:~:text=abstract%20static%20class-,JoinedRowView,-extends%20AbstractList%3C) over the left and right input, allowing join condition evaluation before arraycopy. Then array copy only happens if join condition evaluates to true.

Testing with a simple query on TPC-H
```
 SET maxRowsInJoin=2147483647; 
 SET useMultistageEngine=true; 
 SET timeoutMs=100000; 
 SELECT c_custkey, o_orderkey, c_acctbal, o_totalprice 
 FROM customer c 
 JOIN orders o 
 ON o_custkey = c_custkey AND o_totalprice <= c_acctbal * {};
 
-- param = 0.0, 0.2, 0.4, 0.6, 0.8, 1.0 
``` 
execution time result (ms, 10-time avg): 
| query | before | after |
| test1 | 601.2ms | 559.6ms |
| test2 | 655.4ms | 547.4ms |
| test3 | 651.8ms | 534.6ms |
| test4 | 644.1ms | 548.3ms |
| test5 | 619.5ms | 528.9ms |
| test6 | 636.7ms | 538.8ms |

Alloc profiling for test1 (with high-selectivity join condition), join alloc memory percentage drops from 41% to 25%, that is 39% reduction.:
Before:
![before](https://github.com/user-attachments/assets/70366ead-5577-4e1d-9e96-9b0db126d760)
After:
![after](https://github.com/user-attachments/assets/fa90fe36-47a4-472d-8eba-8e8d0c64a97f)

