### PR TITLE
[Query Resource Isolation] Additonal Sampling for Broker and Server

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
@@ -652,6 +652,8 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
     long routingEndTimeNs = System.nanoTime();
     _brokerMetrics.addPhaseTiming(rawTableName, BrokerQueryPhase.QUERY_ROUTING,
         routingEndTimeNs - routingStartTimeNs);
+    // Account the resource used for routing phase
+    Tracing.ThreadAccountantOps.sample();
 
     // Set timeout in the requests
     long timeSpentMs = TimeUnit.NANOSECONDS.toMillis(routingEndTimeNs - compilationStartTimeNs);

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -63,6 +63,7 @@ import org.apache.pinot.common.request.PinotQuery;
 import org.apache.pinot.common.utils.config.QueryOptionsUtils;
 import org.apache.pinot.common.utils.request.RequestUtils;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
+import org.apache.pinot.spi.trace.Tracing;
 import org.apache.pinot.sql.FilterKind;
 import org.apache.pinot.sql.parsers.parser.SqlInsertFromFile;
 import org.apache.pinot.sql.parsers.parser.SqlParserImpl;
@@ -176,6 +177,8 @@ public class CalciteSqlParser {
     PinotQuery pinotQuery = compileSqlNodeToPinotQuery(sqlNodeAndOptions.getSqlNode());
     // Set query options into PinotQuery
     pinotQuery.setQueryOptions(sqlNodeAndOptions.getOptions());
+    // Account the resources used for query compilation
+    Tracing.ThreadAccountantOps.sample();
     return pinotQuery;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/InstancePlanMakerImplV2.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/InstancePlanMakerImplV2.java
@@ -56,6 +56,7 @@ import org.apache.pinot.segment.spi.FetchContext;
 import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.SegmentContext;
 import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.trace.Tracing;
 import org.apache.pinot.spi.utils.CommonConstants.Server;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -305,6 +306,8 @@ public class InstancePlanMakerImplV2 implements PlanMaker {
   @Override
   public PlanNode makeSegmentPlanNode(SegmentContext segmentContext, QueryContext queryContext) {
     rewriteQueryContextWithHints(queryContext, segmentContext.getIndexSegment());
+    // Sample to track usage of query planning
+    Tracing.ThreadAccountantOps.sample();
     if (QueryContextUtils.isAggregationQuery(queryContext)) {
       List<ExpressionContext> groupByExpressions = queryContext.getGroupByExpressions();
       if (groupByExpressions != null) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
@@ -580,7 +580,6 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
     }
     InstanceResponseBlock instanceResponse;
     Plan queryPlan = planCombineQuery(queryContext, timerContext, executorService, streamer, selectedSegmentContexts);
-
     TimerContext.Timer planExecTimer = timerContext.startNewPhaseTimer(ServerQueryPhase.QUERY_PLAN_EXECUTION);
     instanceResponse = queryPlan.execute();
     planExecTimer.stopAndRecord();

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/TableRebalanceIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/TableRebalanceIntegrationTest.java
@@ -597,7 +597,13 @@ public class TableRebalanceIntegrationTest extends BaseHybridClusterIntegrationT
         60_000L, "Failed to drop added server");
 
     // Add a schema change. Notice that this may affect other following tests
-    Schema schema = getSchema(getTableName());
+
+    Schema originalSchema = getSchema(getTableName());
+    Schema schema = new Schema();
+    schema.setSchemaName(getTableName());
+    for (FieldSpec fieldSpec : originalSchema.getAllFieldSpecs()) {
+      schema.addField(fieldSpec);
+    }
     schema.addField(new MetricFieldSpec("NewAddedIntMetricB", FieldSpec.DataType.INT, 1));
     updateSchema(schema);
     response = sendPostRequest(getRebalanceUrl(rebalanceConfig, TableType.REALTIME));
@@ -697,6 +703,7 @@ public class TableRebalanceIntegrationTest extends BaseHybridClusterIntegrationT
         aVoid -> getHelixResourceManager().dropInstance(serverStarter1.getInstanceId()).isSuccessful(),
         60_000L, "Failed to drop added server");
     updateTableConfig(originalTableConfig);
+    forceUpdateSchema(originalSchema);
   }
 
   @Test


### PR DESCRIPTION
## Summary
We have seen in few cases where lack of sampling has contributed to queries not getting killed sooner, adding sampling for

### Broker
1. Compilation
2. Routing

### Server
1. Planning phase


