### PR TITLE
[timeseries] Adding table level access control check for timeseries queries

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotClientRequest.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotClientRequest.java
@@ -294,7 +294,7 @@ public class PinotClientRequest {
       try (RequestScope requestContext = Tracing.getTracer().createRequestScope()) {
         String queryString = requestCtx.getQueryString();
         PinotBrokerTimeSeriesResponse response = executeTimeSeriesQuery(language, queryString, requestContext,
-          makeHttpIdentity(requestCtx));
+          makeHttpIdentity(requestCtx), httpHeaders);
         if (response.getErrorType() != null && !response.getErrorType().isEmpty()) {
           asyncResponse.resume(Response.serverError().entity(response).build());
           return;
@@ -538,8 +538,9 @@ public class PinotClientRequest {
   }
 
   private PinotBrokerTimeSeriesResponse executeTimeSeriesQuery(String language, String queryString,
-    RequestContext requestContext, RequesterIdentity requesterIdentity) {
-    return _requestHandler.handleTimeSeriesRequest(language, queryString, requestContext, requesterIdentity);
+    RequestContext requestContext, RequesterIdentity requesterIdentity, HttpHeaders httpHeaders) {
+    return _requestHandler.handleTimeSeriesRequest(language, queryString, requestContext, requesterIdentity,
+      httpHeaders);
   }
 
   public static HttpRequesterIdentity makeHttpIdentity(org.glassfish.grizzly.http.server.Request context) {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BrokerRequestHandler.java
@@ -65,7 +65,7 @@ public interface BrokerRequestHandler {
    * Run a query and use the time-series engine.
    */
   default PinotBrokerTimeSeriesResponse handleTimeSeriesRequest(String lang, String rawQueryParamString,
-      RequestContext requestContext, @Nullable RequesterIdentity requesterIdentity) {
+      RequestContext requestContext, @Nullable RequesterIdentity requesterIdentity, HttpHeaders httpHeaders) {
     throw new UnsupportedOperationException("Handler does not support Time Series requests");
   }
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BrokerRequestHandlerDelegate.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BrokerRequestHandlerDelegate.java
@@ -125,10 +125,10 @@ public class BrokerRequestHandlerDelegate implements BrokerRequestHandler {
 
   @Override
   public PinotBrokerTimeSeriesResponse handleTimeSeriesRequest(String lang, String rawQueryParamString,
-      RequestContext requestContext, RequesterIdentity requesterIdentity) {
+      RequestContext requestContext, RequesterIdentity requesterIdentity, HttpHeaders httpHeaders) {
     if (_timeSeriesRequestHandler != null) {
       return _timeSeriesRequestHandler.handleTimeSeriesRequest(lang, rawQueryParamString, requestContext,
-        requesterIdentity);
+        requesterIdentity, httpHeaders);
     }
     return new PinotBrokerTimeSeriesResponse("error", null, "error", "Time series query engine not enabled.");
   }

--- a/pinot-timeseries/pinot-timeseries-planner/src/main/java/org/apache/pinot/tsdb/planner/TimeSeriesQueryEnvironment.java
+++ b/pinot-timeseries/pinot-timeseries-planner/src/main/java/org/apache/pinot/tsdb/planner/TimeSeriesQueryEnvironment.java
@@ -105,7 +105,8 @@ public class TimeSeriesQueryEnvironment {
         fragments, scanVisitorContext.getLeafIdToSegmentsByInstanceId());
     return new TimeSeriesDispatchablePlan(timeSeriesRequest.getLanguage(), serverInstances, fragments.get(0),
         fragments.subList(1, fragments.size()), logicalPlan.getTimeBuckets(),
-        scanVisitorContext.getLeafIdToSegmentsByInstanceId(), numServersForExchangePlanNode);
+        scanVisitorContext.getLeafIdToSegmentsByInstanceId(), numServersForExchangePlanNode,
+      scanVisitorContext.getTableName());
   }
 
   private Map<String, Integer> computeNumServersForExchangePlanNode(List<TimeSeriesQueryServerInstance> serverInstances,

--- a/pinot-timeseries/pinot-timeseries-planner/src/main/java/org/apache/pinot/tsdb/planner/TimeSeriesQueryEnvironment.java
+++ b/pinot-timeseries/pinot-timeseries-planner/src/main/java/org/apache/pinot/tsdb/planner/TimeSeriesQueryEnvironment.java
@@ -106,7 +106,7 @@ public class TimeSeriesQueryEnvironment {
     return new TimeSeriesDispatchablePlan(timeSeriesRequest.getLanguage(), serverInstances, fragments.get(0),
         fragments.subList(1, fragments.size()), logicalPlan.getTimeBuckets(),
         scanVisitorContext.getLeafIdToSegmentsByInstanceId(), numServersForExchangePlanNode,
-      scanVisitorContext.getTableName());
+      scanVisitorContext.getTableNames());
   }
 
   private Map<String, Integer> computeNumServersForExchangePlanNode(List<TimeSeriesQueryServerInstance> serverInstances,

--- a/pinot-timeseries/pinot-timeseries-planner/src/main/java/org/apache/pinot/tsdb/planner/physical/TableScanVisitor.java
+++ b/pinot-timeseries/pinot-timeseries-planner/src/main/java/org/apache/pinot/tsdb/planner/physical/TableScanVisitor.java
@@ -130,7 +130,7 @@ public class TableScanVisitor {
   public static class Context {
     private final Map<ServerInstance, Map<String, List<String>>> _leafIdToSegmentsByServer = new HashMap<>();
     private final Long _requestId;
-    private List<String> _tableNames;
+    private final List<String> _tableNames = new ArrayList<>();
 
     public Context(Long requestId) {
       _requestId = requestId;
@@ -158,9 +158,6 @@ public class TableScanVisitor {
     }
 
     public void addTableName(String tableName) {
-      if (_tableNames == null) {
-        _tableNames = new ArrayList<>();
-      }
       _tableNames.add(tableName);
     }
   }

--- a/pinot-timeseries/pinot-timeseries-planner/src/main/java/org/apache/pinot/tsdb/planner/physical/TableScanVisitor.java
+++ b/pinot-timeseries/pinot-timeseries-planner/src/main/java/org/apache/pinot/tsdb/planner/physical/TableScanVisitor.java
@@ -61,7 +61,7 @@ public class TableScanVisitor {
     if (planNode instanceof LeafTimeSeriesPlanNode) {
       LeafTimeSeriesPlanNode sfpNode = (LeafTimeSeriesPlanNode) planNode;
       Expression filterExpression = CalciteSqlParser.compileToExpression(sfpNode.getEffectiveFilter(timeBuckets));
-      context.setTableName(sfpNode.getTableName());
+      context.addTableName(sfpNode.getTableName());
       RoutingTable routingTable = _routingManager.getRoutingTable(
           compileBrokerRequest(sfpNode.getTableName(), filterExpression),
           context._requestId);
@@ -130,7 +130,7 @@ public class TableScanVisitor {
   public static class Context {
     private final Map<ServerInstance, Map<String, List<String>>> _leafIdToSegmentsByServer = new HashMap<>();
     private final Long _requestId;
-    private String _tableName;
+    private List<String> _tableNames;
 
     public Context(Long requestId) {
       _requestId = requestId;
@@ -153,12 +153,15 @@ public class TableScanVisitor {
       return _leafIdToSegmentsByServer;
     }
 
-    public String getTableName() {
-      return _tableName;
+    public List<String> getTableNames() {
+      return _tableNames;
     }
 
-    public void setTableName(String tableName) {
-      _tableName = tableName;
+    public void addTableName(String tableName) {
+      if (_tableNames == null) {
+        _tableNames = new ArrayList<>();
+      }
+      _tableNames.add(tableName);
     }
   }
 

--- a/pinot-timeseries/pinot-timeseries-planner/src/main/java/org/apache/pinot/tsdb/planner/physical/TableScanVisitor.java
+++ b/pinot-timeseries/pinot-timeseries-planner/src/main/java/org/apache/pinot/tsdb/planner/physical/TableScanVisitor.java
@@ -61,6 +61,7 @@ public class TableScanVisitor {
     if (planNode instanceof LeafTimeSeriesPlanNode) {
       LeafTimeSeriesPlanNode sfpNode = (LeafTimeSeriesPlanNode) planNode;
       Expression filterExpression = CalciteSqlParser.compileToExpression(sfpNode.getEffectiveFilter(timeBuckets));
+      context.setTableName(sfpNode.getTableName());
       RoutingTable routingTable = _routingManager.getRoutingTable(
           compileBrokerRequest(sfpNode.getTableName(), filterExpression),
           context._requestId);
@@ -129,6 +130,7 @@ public class TableScanVisitor {
   public static class Context {
     private final Map<ServerInstance, Map<String, List<String>>> _leafIdToSegmentsByServer = new HashMap<>();
     private final Long _requestId;
+    private String _tableName;
 
     public Context(Long requestId) {
       _requestId = requestId;
@@ -149,6 +151,14 @@ public class TableScanVisitor {
 
     Map<ServerInstance, Map<String, List<String>>> getLeafIdToSegmentsByServer() {
       return _leafIdToSegmentsByServer;
+    }
+
+    public String getTableName() {
+      return _tableName;
+    }
+
+    public void setTableName(String tableName) {
+      _tableName = tableName;
     }
   }
 

--- a/pinot-timeseries/pinot-timeseries-planner/src/main/java/org/apache/pinot/tsdb/planner/physical/TimeSeriesDispatchablePlan.java
+++ b/pinot-timeseries/pinot-timeseries-planner/src/main/java/org/apache/pinot/tsdb/planner/physical/TimeSeriesDispatchablePlan.java
@@ -35,11 +35,12 @@ public class TimeSeriesDispatchablePlan {
   private final Map<String, Map<String, List<String>>> _leafIdToSegmentsByInstanceId;
   private final Map<String, Integer> _numInputServersForExchangePlanNode;
   private final List<String> _serializedServerFragments;
+  private final String _tableName;
 
   public TimeSeriesDispatchablePlan(String language, List<TimeSeriesQueryServerInstance> queryServerInstances,
       BaseTimeSeriesPlanNode brokerFragment, List<BaseTimeSeriesPlanNode> serverFragments,
       TimeBuckets initialTimeBuckets, Map<String, Map<String, List<String>>> leafIdToSegmentsByInstanceId,
-      Map<String, Integer> numInputServersForExchangePlanNode) {
+      Map<String, Integer> numInputServersForExchangePlanNode, String tableName) {
     _language = language;
     _queryServerInstances = queryServerInstances;
     _brokerFragment = brokerFragment;
@@ -49,6 +50,7 @@ public class TimeSeriesDispatchablePlan {
     _numInputServersForExchangePlanNode = numInputServersForExchangePlanNode;
     _serializedServerFragments = serverFragments.stream().map(TimeSeriesPlanSerde::serialize).collect(
         Collectors.toList());
+    _tableName = tableName;
   }
 
   public String getLanguage() {
@@ -81,5 +83,9 @@ public class TimeSeriesDispatchablePlan {
 
   public Map<String, Integer> getNumInputServersForExchangePlanNode() {
     return _numInputServersForExchangePlanNode;
+  }
+
+  public String getTableName() {
+    return _tableName;
   }
 }

--- a/pinot-timeseries/pinot-timeseries-planner/src/main/java/org/apache/pinot/tsdb/planner/physical/TimeSeriesDispatchablePlan.java
+++ b/pinot-timeseries/pinot-timeseries-planner/src/main/java/org/apache/pinot/tsdb/planner/physical/TimeSeriesDispatchablePlan.java
@@ -35,12 +35,12 @@ public class TimeSeriesDispatchablePlan {
   private final Map<String, Map<String, List<String>>> _leafIdToSegmentsByInstanceId;
   private final Map<String, Integer> _numInputServersForExchangePlanNode;
   private final List<String> _serializedServerFragments;
-  private final String _tableName;
+  private final List<String> _tableNames;
 
   public TimeSeriesDispatchablePlan(String language, List<TimeSeriesQueryServerInstance> queryServerInstances,
       BaseTimeSeriesPlanNode brokerFragment, List<BaseTimeSeriesPlanNode> serverFragments,
       TimeBuckets initialTimeBuckets, Map<String, Map<String, List<String>>> leafIdToSegmentsByInstanceId,
-      Map<String, Integer> numInputServersForExchangePlanNode, String tableName) {
+      Map<String, Integer> numInputServersForExchangePlanNode, List<String> tableNames) {
     _language = language;
     _queryServerInstances = queryServerInstances;
     _brokerFragment = brokerFragment;
@@ -50,7 +50,7 @@ public class TimeSeriesDispatchablePlan {
     _numInputServersForExchangePlanNode = numInputServersForExchangePlanNode;
     _serializedServerFragments = serverFragments.stream().map(TimeSeriesPlanSerde::serialize).collect(
         Collectors.toList());
-    _tableName = tableName;
+    _tableNames = tableNames;
   }
 
   public String getLanguage() {
@@ -85,7 +85,7 @@ public class TimeSeriesDispatchablePlan {
     return _numInputServersForExchangePlanNode;
   }
 
-  public String getTableName() {
-    return _tableName;
+  public List<String> getTableNames() {
+    return _tableNames;
   }
 }


### PR DESCRIPTION
## Summary

This PR adds table-level access control to the time series query path in Pinot. The main change involves threading `HttpHeaders` from the client request all the way down to the `TimeSeriesRequestHandler`, enabling it to perform authorization checks using Pinot's `AccessControl` framework.

To support this, the `TimeSeriesDispatchablePlan` now includes the queried table name, which is extracted during physical plan construction in TableScanVisitor. With the table name available, a new `tableLevelAccessControlCheck` method verifies whether the requester has permission to query the table. If not, the request is rejected with a 403 error.

Overall, this ensures that time series queries enforce the same fine-grained table access policies as other query types, closing a security gap and aligning with Pinot’s broader access control mechanisms.

## Testing

Successfully validated that integration tests run correctly, also tested by modifying the `TimeSeriesEngineQuickStart` to support auth. Will created a separate PR to handle `TimeSeriesEngineAuthQuickStart`.