### PR TITLE
[timeseries] Adding working E2E quickstart for TimeSeriesEngineAuth

### DIFF
--- a/pinot-tools/src/main/java/org/apache/pinot/tools/AuthQuickstart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/AuthQuickstart.java
@@ -43,7 +43,7 @@ public class AuthQuickstart extends Quickstart {
   @Override
   public Map<String, Object> getConfigOverrides() {
     Map<String, Object> properties = new HashMap<>(super.getConfigOverrides());
-    properties.putAll(AuthUtils.getAuthConfigs());
+    properties.putAll(AuthUtils.getAuthQuickStartDefaultConfigs());
     return properties;
   }
 

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/TimeSeriesEngineAuthQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/TimeSeriesEngineAuthQuickStart.java
@@ -29,6 +29,12 @@ import org.apache.pinot.spi.plugin.PluginManager;
 import org.apache.pinot.tools.utils.AuthUtils;
 
 
+/**
+ * Quick start for Time Series Engine with authentication.
+ *
+ * To test this quick start, you can run the following command in pinot-tools/src/main/resources/scripts/timeseries/
+ * python3 run_ts_query.py --auth
+ */
 public class TimeSeriesEngineAuthQuickStart extends TimeSeriesEngineQuickStart {
 
   @Override

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/TimeSeriesEngineAuthQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/TimeSeriesEngineAuthQuickStart.java
@@ -29,10 +29,11 @@ import org.apache.pinot.spi.plugin.PluginManager;
 import org.apache.pinot.tools.utils.AuthUtils;
 
 
-public class AuthQuickstart extends Quickstart {
+public class TimeSeriesEngineAuthQuickStart extends TimeSeriesEngineQuickStart {
+
   @Override
   public List<String> types() {
-    return Collections.singletonList("AUTH");
+    return Collections.singletonList("TIME_SERIES_AUTH");
   }
 
   @Override
@@ -47,9 +48,9 @@ public class AuthQuickstart extends Quickstart {
     return properties;
   }
 
-  public static void main(String[] args)
-      throws Exception {
+  public static void main(String[] args) throws Exception {
     PluginManager.get().init();
-    new AuthQuickstart().execute();
+    new TimeSeriesEngineAuthQuickStart().execute();
+    printStatus(Color.GREEN, "Default login credential to login controller is admin/verysecret.");
   }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/TimeSeriesEngineAuthQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/TimeSeriesEngineAuthQuickStart.java
@@ -50,7 +50,7 @@ public class TimeSeriesEngineAuthQuickStart extends TimeSeriesEngineQuickStart {
   @Override
   public Map<String, Object> getConfigOverrides() {
     Map<String, Object> properties = new HashMap<>(super.getConfigOverrides());
-    properties.putAll(AuthUtils.getAuthConfigs());
+    properties.putAll(AuthUtils.getAuthQuickStartDefaultConfigs());
     return properties;
   }
 

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/TimeSeriesEngineQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/TimeSeriesEngineQuickStart.java
@@ -29,7 +29,12 @@ import org.apache.pinot.tools.admin.command.QuickstartRunner;
 import org.apache.pinot.tsdb.spi.PinotTimeSeriesConfiguration;
 import org.apache.pinot.tsdb.spi.series.SimpleTimeSeriesBuilderFactory;
 
-
+/**
+ * Quick start for Time Series Engine.
+ *
+ * To test this quick start, you can run the following command in pinot-tools/src/main/resources/scripts/timeseries/
+ * python3 run_ts_query.py
+ */
 public class TimeSeriesEngineQuickStart extends Quickstart {
   private static final String[] TIME_SERIES_TABLE_DIRECTORIES = new String[]{
       "examples/batch/airlineStats",

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/TimeSeriesEngineQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/TimeSeriesEngineQuickStart.java
@@ -77,7 +77,8 @@ public class TimeSeriesEngineQuickStart extends Quickstart {
     Preconditions.checkState(quickstartRunnerDir.mkdirs());
     List<QuickstartTableRequest> quickstartTableRequests = bootstrapStreamTableDirectories(quickstartTmpDir);
     final QuickstartRunner runner =
-        new QuickstartRunner(quickstartTableRequests, 1, 1, 2, 1, quickstartRunnerDir, getConfigOverrides());
+        new QuickstartRunner(quickstartTableRequests, 1, 1, 2, 1, quickstartRunnerDir, getConfigOverrides(),
+          getAuthProvider());
 
     startKafka();
     startAllDataStreams(_kafkaStarter, quickstartTmpDir);

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/QuickstartRunner.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/QuickstartRunner.java
@@ -92,6 +92,13 @@ public class QuickstartRunner {
   }
 
   public QuickstartRunner(List<QuickstartTableRequest> tableRequests, int numControllers, int numBrokers,
+    int numServers, int numMinions, File tempDir, Map<String, Object> configOverrides, AuthProvider authProvider)
+    throws Exception {
+    this(tableRequests, numControllers, numBrokers, numServers, numMinions, tempDir, true, authProvider,
+      configOverrides, null, true, Map.of());
+  }
+
+  public QuickstartRunner(List<QuickstartTableRequest> tableRequests, int numControllers, int numBrokers,
       int numServers, int numMinions, File tempDir, boolean enableIsolation, AuthProvider authProvider,
       Map<String, Object> configOverrides, String zkExternalAddress, boolean deleteExistingData,
       Map<String, String> clusterConfigOverrides)

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/utils/AuthUtils.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/utils/AuthUtils.java
@@ -23,14 +23,15 @@ import java.util.Map;
 
 
 public class AuthUtils {
+  private static final String DEFAULT_AUTH_TOKEN = "Basic YWRtaW46dmVyeXNlY3JldA==";
 
   private AuthUtils() {
   }
 
-  public static Map<String, Object> getAuthConfigs() {
+  public static Map<String, Object> getAuthQuickStartDefaultConfigs() {
     Map<String, Object> properties = new HashMap<>();
     // controller
-    properties.put("pinot.controller.segment.fetcher.auth.token", "Basic YWRtaW46dmVyeXNlY3JldA==");
+    properties.put("pinot.controller.segment.fetcher.auth.token", DEFAULT_AUTH_TOKEN);
     properties.put("controller.admin.access.control.factory.class",
       "org.apache.pinot.controller.api.access.BasicAuthAccessControlFactory");
     properties.put("controller.admin.access.control.principals", "admin, user, service, tableonly");
@@ -52,13 +53,13 @@ public class AuthUtils {
     properties.put("pinot.broker.access.control.principals.tableonly.tables", "baseballStats");
 
     // server
-    properties.put("pinot.server.segment.fetcher.auth.token", "Basic YWRtaW46dmVyeXNlY3JldA==");
-    properties.put("pinot.server.segment.uploader.auth.token", "Basic YWRtaW46dmVyeXNlY3JldA==");
-    properties.put("pinot.server.instance.auth.token", "Basic YWRtaW46dmVyeXNlY3JldA==");
+    properties.put("pinot.server.segment.fetcher.auth.token", DEFAULT_AUTH_TOKEN);
+    properties.put("pinot.server.segment.uploader.auth.token", DEFAULT_AUTH_TOKEN);
+    properties.put("pinot.server.instance.auth.token", DEFAULT_AUTH_TOKEN);
 
     // minion
-    properties.put("segment.fetcher.auth.token", "Basic YWRtaW46dmVyeXNlY3JldA==");
-    properties.put("task.auth.token", "Basic YWRtaW46dmVyeXNlY3JldA==");
+    properties.put("segment.fetcher.auth.token", DEFAULT_AUTH_TOKEN);
+    properties.put("task.auth.token", DEFAULT_AUTH_TOKEN);
 
     // loggers
     properties.put("pinot.controller.logger.root.dir", "logs");

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/utils/AuthUtils.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/utils/AuthUtils.java
@@ -1,0 +1,70 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.tools.utils;
+
+import java.util.HashMap;
+import java.util.Map;
+
+
+public class AuthUtils {
+
+  private AuthUtils() {
+  }
+
+  public static Map<String, Object> getAuthConfigs() {
+    Map<String, Object> properties = new HashMap<>();
+    // controller
+    properties.put("pinot.controller.segment.fetcher.auth.token", "Basic YWRtaW46dmVyeXNlY3JldA==");
+    properties.put("controller.admin.access.control.factory.class",
+      "org.apache.pinot.controller.api.access.BasicAuthAccessControlFactory");
+    properties.put("controller.admin.access.control.principals", "admin, user, service, tableonly");
+    properties.put("controller.admin.access.control.principals.admin.password", "verysecret");
+    properties.put("controller.admin.access.control.principals.service.password", "verysecrettoo");
+    properties.put("controller.admin.access.control.principals.user.password", "secret");
+    properties.put("controller.admin.access.control.principals.user.permissions", "READ");
+    properties.put("controller.admin.access.control.principals.tableonly.password", "secrettoo");
+    properties.put("controller.admin.access.control.principals.tableonly.permissions", "READ");
+    properties.put("controller.admin.access.control.principals.tableonly.tables", "baseballStats");
+
+    // broker
+    properties.put("pinot.broker.access.control.class", "org.apache.pinot.broker.broker.BasicAuthAccessControlFactory");
+    properties.put("pinot.broker.access.control.principals", "admin, user, service, tableonly");
+    properties.put("pinot.broker.access.control.principals.admin.password", "verysecret");
+    properties.put("pinot.broker.access.control.principals.service.password", "verysecrettoo");
+    properties.put("pinot.broker.access.control.principals.user.password", "secret");
+    properties.put("pinot.broker.access.control.principals.tableonly.password", "secrettoo");
+    properties.put("pinot.broker.access.control.principals.tableonly.tables", "baseballStats");
+
+    // server
+    properties.put("pinot.server.segment.fetcher.auth.token", "Basic YWRtaW46dmVyeXNlY3JldA==");
+    properties.put("pinot.server.segment.uploader.auth.token", "Basic YWRtaW46dmVyeXNlY3JldA==");
+    properties.put("pinot.server.instance.auth.token", "Basic YWRtaW46dmVyeXNlY3JldA==");
+
+    // minion
+    properties.put("segment.fetcher.auth.token", "Basic YWRtaW46dmVyeXNlY3JldA==");
+    properties.put("task.auth.token", "Basic YWRtaW46dmVyeXNlY3JldA==");
+
+    // loggers
+    properties.put("pinot.controller.logger.root.dir", "logs");
+    properties.put("pinot.broker.logger.root.dir", "logs");
+    properties.put("pinot.server.logger.root.dir", "logs");
+    properties.put("pinot.minion.logger.root.dir", "logs");
+    return properties;
+  }
+}

--- a/pinot-tools/src/main/resources/scripts/timeseries/query.txt
+++ b/pinot-tools/src/main/resources/scripts/timeseries/query.txt
@@ -1,0 +1,4 @@
+fetch{table="meetupRsvp_REALTIME",filter="",ts_column="__metadata$recordTimestamp",ts_unit="MILLISECONDS",value="1"}
+  | max{group_city}
+  | transformNull{0}
+  | keepLastValue{}

--- a/pinot-tools/src/main/resources/scripts/timeseries/run_ts_query.py
+++ b/pinot-tools/src/main/resources/scripts/timeseries/run_ts_query.py
@@ -1,0 +1,74 @@
+import argparse
+import requests
+import time
+import logging
+import sys
+
+# === Constants ===
+DEFAULT_QUERY_FILE = "query.txt"
+DEFAULT_API_URL = "http://localhost:8000/timeseries/api/v1/query_range"
+DEFAULT_DURATION_SECONDS = 3600
+AUTH_TOKEN = "Basic YWRtaW46dmVyeXNlY3JldA=="
+
+# === Logger Setup ===
+def setup_logger():
+    logger = logging.getLogger("TimeseriesQuery")
+    handler = logging.StreamHandler(sys.stdout)
+    formatter = logging.Formatter('%(asctime)s - %(levelname)s - %(message)s')
+    handler.setFormatter(formatter)
+    logger.setLevel(logging.INFO)
+    logger.addHandler(handler)
+    return logger
+
+# === File Reader ===
+def read_query_file(path, logger):
+    try:
+        with open(path, 'r') as f:
+            return f.read()
+    except Exception as e:
+        logger.error(f"Failed to read query file '{path}': {e}")
+        sys.exit(1)
+
+# === Request Builder ===
+def build_request(query, start, end, token=None):
+    params = {
+        'language': 'm3ql',
+        'start': start,
+        'end': end,
+        'query': query
+    }
+    headers = {}
+    if token:
+        headers['Authorization'] = token
+    return params, headers
+
+# === Main Entry ===
+def main():
+    parser = argparse.ArgumentParser(description="Query a time series API endpoint.")
+    parser.add_argument('--query-file', default=DEFAULT_QUERY_FILE, help=f'Path to the query file (default: {DEFAULT_QUERY_FILE})')
+    parser.add_argument('--url', default=DEFAULT_API_URL, help=f'API endpoint URL (default: {DEFAULT_API_URL})')
+    parser.add_argument('--auth', action='store_true', help='Enable Authorization header using default token')
+    parser.add_argument('--duration', type=int, default=DEFAULT_DURATION_SECONDS, help=f'Query time range duration in seconds (default: {DEFAULT_DURATION_SECONDS})')
+    args = parser.parse_args()
+
+    logger = setup_logger()
+    logger.info(f"Using query file: {args.query_file}")
+    query = read_query_file(args.query_file, logger)
+
+    start_time = int(time.time())
+    end_time = start_time + args.duration
+
+    token = AUTH_TOKEN if args.auth else None
+    params, headers = build_request(query, start_time, end_time, token)
+
+    try:
+        logger.info(f"Sending request to {args.url}")
+        response = requests.get(args.url, params=params, headers=headers)
+        logger.info(f"Response text: {response.text}")
+        response.raise_for_status()
+    except requests.RequestException as e:
+        logger.error(f"Request failed: {e}")
+        sys.exit(1)
+
+if __name__ == '__main__':
+    main()

--- a/pinot-tools/src/main/resources/scripts/timeseries/run_ts_query.py
+++ b/pinot-tools/src/main/resources/scripts/timeseries/run_ts_query.py
@@ -1,3 +1,23 @@
+#!/usr/bin/env python
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
 import argparse
 import requests
 import time


### PR DESCRIPTION
This PR adds a new `TimeSeriesEngineAuthQuickStart` to easily spin up a time series setup with basic auth enabled. Auth config has been centralized into a reusable `AuthUtils` helper, replacing hardcoded values and making the setup cleaner and more consistent across QuickStarts.

It also adds a sample time series query (`query.txt`) and a Python script (`run_ts_query.py`) to test the API with optional auth. Overall, this makes it easier to demo and test Pinot's time series engine in a secure, out-of-the-box way.