### PR TITLE
feat: Mask sensitive task configuration values in logs

### DIFF
--- a/pinot-minion/src/main/java/org/apache/pinot/minion/taskfactory/TaskFactoryRegistry.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/taskfactory/TaskFactoryRegistry.java
@@ -47,6 +47,7 @@ import org.apache.pinot.minion.exception.TaskCancelledException;
 import org.apache.pinot.minion.executor.PinotTaskExecutor;
 import org.apache.pinot.minion.executor.PinotTaskExecutorFactory;
 import org.apache.pinot.minion.executor.TaskExecutorFactoryRegistry;
+import org.apache.pinot.spi.utils.Obfuscator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -145,8 +146,10 @@ public class TaskFactoryRegistry {
               String tableName = pinotTaskConfig.getTableName();
 
               _eventObserver.notifyTaskStart(pinotTaskConfig);
-              LOGGER.info("Start running {}: {} with configs: {}", pinotTaskConfig.getTaskType(), _taskConfig.getId(),
-                  pinotTaskConfig.getConfigs());
+              if (LOGGER.isInfoEnabled()) {
+                LOGGER.info("Start running {}: {} with configs: {}", pinotTaskConfig.getTaskType(), _taskConfig.getId(),
+                    new Obfuscator().toJsonString(pinotTaskConfig.getConfigs()));
+              }
 
               try {
                 Object executionResult = _taskExecutor.executeTask(pinotTaskConfig);

--- a/pinot-minion/src/test/java/org/apache/pinot/minion/taskfactory/TaskFactoryRegistryTest.java
+++ b/pinot-minion/src/test/java/org/apache/pinot/minion/taskfactory/TaskFactoryRegistryTest.java
@@ -1,0 +1,77 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.minion.taskfactory;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.pinot.spi.utils.Obfuscator;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class TaskFactoryRegistryTest {
+
+  @Test
+  public void testObfuscatorMasksSensitiveConfigs() {
+    // Test that the Obfuscator properly masks sensitive configuration values
+    Map<String, String> configs = new HashMap<>();
+    configs.put("tableName", "myTable");
+    configs.put("authToken", "Basic YWRtaW46dmVyeXNlY3JldA");
+    configs.put("password", "verysecret");
+    configs.put("secretKey", "mySecretKey123");
+    configs.put("apiKey", "sk-1234567890abcdef");
+    configs.put("normalConfig", "normalValue");
+
+    Obfuscator obfuscator = new Obfuscator();
+    String obfuscatedJson = obfuscator.toJsonString(configs);
+
+    // Verify that sensitive values are masked
+    Assert.assertTrue(obfuscatedJson.contains("tableName"));
+    Assert.assertTrue(obfuscatedJson.contains("normalConfig"));
+    Assert.assertTrue(obfuscatedJson.contains("normalValue"));
+
+    // Verify that sensitive values are masked with "*****"
+    Assert.assertTrue(obfuscatedJson.contains("\"authToken\":\"*****\""));
+    Assert.assertTrue(obfuscatedJson.contains("\"password\":\"*****\""));
+    Assert.assertTrue(obfuscatedJson.contains("\"secretKey\":\"*****\""));
+    Assert.assertTrue(obfuscatedJson.contains("\"apiKey\":\"*****\""));
+
+    // Verify that the original sensitive values are not present
+    Assert.assertFalse(obfuscatedJson.contains("Basic YWRtaW46dmVyeXNlY3JldA"));
+    Assert.assertFalse(obfuscatedJson.contains("verysecret"));
+    Assert.assertFalse(obfuscatedJson.contains("mySecretKey123"));
+    Assert.assertFalse(obfuscatedJson.contains("sk-1234567890abcdef"));
+  }
+
+  @Test
+  public void testObfuscatorHandlesNullAndEmptyValues() {
+    Map<String, String> configs = new HashMap<>();
+    configs.put("authToken", null);
+    configs.put("password", "");
+    configs.put("normalConfig", "value");
+
+    Obfuscator obfuscator = new Obfuscator();
+    String obfuscatedJson = obfuscator.toJsonString(configs);
+
+    // Verify that null and empty values are handled properly
+    Assert.assertTrue(obfuscatedJson.contains("\"authToken\":\"*****\""));
+    Assert.assertTrue(obfuscatedJson.contains("\"password\":\"*****\""));
+    Assert.assertTrue(obfuscatedJson.contains("\"normalConfig\":\"value\""));
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/Obfuscator.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/Obfuscator.java
@@ -58,7 +58,8 @@ import java.util.stream.Stream;
 public final class Obfuscator {
   private static final String DEFAULT_MASKED_VALUE = "*****";
   private static final List<Pattern> DEFAULT_PATTERNS =
-      Stream.of("(?i).*secret$", "(?i).*secret[\\s_-]*key$", "(?i).*password$", "(?i).*keytab$", "(?i).*token$")
+      Stream.of("(?i).*secret$", "(?i).*secret[\\s_-]*key$", "(?i).*api[\\s_-]*key$", "(?i).*password$",
+              "(?i).*keytab$", "(?i).*token$")
           .map(Pattern::compile).collect(Collectors.toList());
 
   private final String _maskedValue;


### PR DESCRIPTION

This change prevents sensitive credentials from being exposed in task execution logs while preserving all non-sensitive configuration information for debugging purposes.

- Integrate existing Obfuscator utility to mask sensitive config values in TaskFactoryRegistry logs
- Replace direct logging of pinotTaskConfig.getConfigs() with obfuscated JSON output
- Add comprehensive test coverage for Obfuscator functionality
- Enhance Obfuscator patterns to include 'api_key' variations
- Ensure sensitive values like authToken, password, secretKey, apiKey are masked as '*****'
- Maintain existing functionality while improving security in log output
