### PR TITLE
Reduce logs and improve logging when queries are terminated due to OOM.

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/accounting/PerQueryCPUMemAccountantFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/accounting/PerQueryCPUMemAccountantFactory.java
@@ -109,7 +109,7 @@ public class PerQueryCPUMemAccountantFactory implements ThreadAccountantFactory 
           CPUMemThreadLevelAccountingObjects.ThreadEntry ret =
               new CPUMemThreadLevelAccountingObjects.ThreadEntry();
           _threadEntriesMap.put(Thread.currentThread(), ret);
-          LOGGER.info("Adding thread to _threadLocalEntry: {}", Thread.currentThread().getName());
+          LOGGER.debug("Adding thread to _threadLocalEntry: {}", Thread.currentThread().getName());
           return ret;
         }
     );
@@ -456,7 +456,7 @@ public class PerQueryCPUMemAccountantFactory implements ThreadAccountantFactory 
 
         if (!thread.isAlive()) {
           _threadEntriesMap.remove(thread);
-          LOGGER.info("Removing thread from _threadLocalEntry: {}", thread.getName());
+          LOGGER.debug("Removing thread from _threadLocalEntry: {}", thread.getName());
         }
       }
 
@@ -480,6 +480,11 @@ public class PerQueryCPUMemAccountantFactory implements ThreadAccountantFactory 
     }
 
     public void postAggregation(Map<String, AggregatedStats> aggregatedUsagePerActiveQuery) {
+    }
+
+    protected void logQueryResourceUsage(Map<String, AggregatedStats> aggregatedUsagePerActiveQuery) {
+      LOGGER.warn("Current task status recorded is {}", _threadEntriesMap);
+      LOGGER.warn("Query aggregation results {} for the previous kill.", aggregatedUsagePerActiveQuery.toString());
     }
 
     @Override
@@ -894,7 +899,6 @@ public class PerQueryCPUMemAccountantFactory implements ThreadAccountantFactory 
             interruptRunnerThread(maxUsageTuple.getAnchorThread());
             LOGGER.error("Query {} got picked because using {} bytes of memory, actual kill committed true}",
                 maxUsageTuple._queryId, maxUsageTuple._allocatedBytes);
-            LOGGER.error("Current task status recorded is {}", _threadEntriesMap);
           } else if (!_oomKillQueryEnabled) {
             LOGGER.warn("Query {} got picked because using {} bytes of memory, actual kill committed false "
                     + "because oomKillQueryEnabled is false",
@@ -902,25 +906,8 @@ public class PerQueryCPUMemAccountantFactory implements ThreadAccountantFactory 
           } else {
             LOGGER.warn("But all queries are below quota, no query killed");
           }
-        } else {
-          maxUsageTuple = Collections.max(_aggregatedUsagePerActiveQuery.values(),
-              Comparator.comparing(AggregatedStats::getCpuTimeNs));
-          if (_oomKillQueryEnabled) {
-            maxUsageTuple._exceptionAtomicReference
-                .set(new RuntimeException(String.format(
-                    " Query %s got killed because memory pressure, using %d ns of CPU time on %s: %s",
-                    maxUsageTuple._queryId, maxUsageTuple.getAllocatedBytes(), _instanceType, _instanceId)));
-            interruptRunnerThread(maxUsageTuple.getAnchorThread());
-            LOGGER.error("Query {} got picked because using {} ns of cpu time, actual kill committed true",
-                maxUsageTuple._allocatedBytes, maxUsageTuple._queryId);
-            LOGGER.error("Current task status recorded is {}", _threadEntriesMap);
-          } else {
-            LOGGER.warn("Query {} got picked because using {} bytes of memory, actual kill committed false "
-                    + "because oomKillQueryEnabled is false",
-                maxUsageTuple._queryId, maxUsageTuple._allocatedBytes);
-          }
         }
-        LOGGER.warn("Query aggregation results {} for the previous kill.", _aggregatedUsagePerActiveQuery.toString());
+        logQueryResourceUsage(_aggregatedUsagePerActiveQuery);
       }
 
       private void killCPUTimeExceedQueries() {


### PR DESCRIPTION
The following logging improvements have been made to the OOM Protection module:
* Convert thread registration & de-registration logs to DEBUG
* Add a log function to take snapshot of the state when queries are killed. Previously these logs were inline. Also the snapshot was not logged in `PerQueryCPUMemAccountant.WatcherTask.killAllQueries`.

An unrelated improvement is that in the `else` block of `PerQueryCPUMemAccountant.WatcherTask.killMostExpensiveQuery`, cpu time was considered if memory sampling is off. This can lead to serious jeopardy. The block is executed if `accounting.oom.enable.killing.query` is true AND `accounting.enable.thread.memory.sampling`. Rather this invalid configuration should be ignored or handled correctly. So the if block has been removed.

Closes #16111 