### PR TITLE
Removes Ingestion Metrics of Inactive Partitions from the Committing Server

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -965,6 +965,15 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
       if (!_shouldStop) {
         _serverMetrics.setValueOfTableGauge(_clientId, ServerGauge.LLC_PARTITION_CONSUMING, 0);
       }
+
+      if ((_stopReason != null) && (_stopReason.equals(SegmentCompletionProtocol.REASON_END_OF_PARTITION_GROUP)
+          || _stopReason.equals(SegmentCompletionProtocol.REASON_FORCE_COMMIT_MESSAGE_RECEIVED))) {
+        // If consumer is ending its execution and stop reason is either reached end of partition or force commit of the
+        // segment, There is a possibility that this server is not going to host the next consuming segment. Hence,
+        // mark this segment for verification so that the ingestionDelayTracker can remove ingestion metrics from
+        // this server no new consuming segment exists.
+        _realtimeTableDataManager.getIngestionDelayTracker().markPartitionForVerification(_segmentNameStr);
+      }
     }
 
     private void handleSegmentBuildFailure() {

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -1564,8 +1564,8 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
     } catch (Exception e) {
       _segmentLogger.error("Caught exception while stopping the consumer thread", e);
     }
-    _realtimeTableDataManager.getIngestionDelayTracker().markPartitionForVerification(_segmentNameStr);
     closeStreamConsumer();
+    _realtimeTableDataManager.getIngestionDelayTracker().markPartitionForVerification(_segmentNameStr);
     cleanupMetrics();
     _realtimeSegment.offload();
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -1565,7 +1565,6 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
       _segmentLogger.error("Caught exception while stopping the consumer thread", e);
     }
     closeStreamConsumer();
-    _realtimeTableDataManager.getIngestionDelayTracker().markPartitionForVerification(_segmentNameStr);
     cleanupMetrics();
     _realtimeSegment.offload();
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -965,15 +965,6 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
       if (!_shouldStop) {
         _serverMetrics.setValueOfTableGauge(_clientId, ServerGauge.LLC_PARTITION_CONSUMING, 0);
       }
-
-      if ((_stopReason != null) && (_stopReason.equals(SegmentCompletionProtocol.REASON_END_OF_PARTITION_GROUP)
-          || _stopReason.equals(SegmentCompletionProtocol.REASON_FORCE_COMMIT_MESSAGE_RECEIVED))) {
-        // If consumer is ending its execution and stop reason is either reached end of partition or force commit of the
-        // segment, There is a possibility that this server is not going to host the next consuming segment. Hence,
-        // mark this segment for verification so that the ingestionDelayTracker can remove ingestion metrics from
-        // this server no new consuming segment exists.
-        _realtimeTableDataManager.getIngestionDelayTracker().markPartitionForVerification(_segmentNameStr);
-      }
     }
 
     private void handleSegmentBuildFailure() {
@@ -1573,6 +1564,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
     } catch (Exception e) {
       _segmentLogger.error("Caught exception while stopping the consumer thread", e);
     }
+    _realtimeTableDataManager.getIngestionDelayTracker().markPartitionForVerification(_segmentNameStr);
     closeStreamConsumer();
     cleanupMetrics();
     _realtimeSegment.offload();

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -902,6 +902,10 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
     return Collections.emptyMap();
   }
 
+  public IngestionDelayTracker getIngestionDelayTracker() {
+    return _ingestionDelayTracker;
+  }
+
   @Nullable
   public StreamIngestionConfig getStreamIngestionConfig() {
     IngestionConfig ingestionConfig = getCachedTableConfigAndSchema().getLeft().getIngestionConfig();

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -839,6 +839,7 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
     IndexLoadingConfig indexLoadingConfig = fetchIndexLoadingConfig();
     indexLoadingConfig.setSegmentTier(zkMetadata.getTier());
     addSegment(ImmutableSegmentLoader.load(indexDir, indexLoadingConfig, _segmentOperationsThrottler), zkMetadata);
+    _ingestionDelayTracker.markPartitionForVerification(segmentName);
     _logger.info("Downloaded and replaced CONSUMING segment: {}", segmentName);
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -890,10 +890,6 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
     return Collections.emptyMap();
   }
 
-  public IngestionDelayTracker getIngestionDelayTracker() {
-    return _ingestionDelayTracker;
-  }
-
   @Nullable
   public StreamIngestionConfig getStreamIngestionConfig() {
     IngestionConfig ingestionConfig = getCachedTableConfigAndSchema().getLeft().getIngestionConfig();

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -458,7 +458,6 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
     } else if (segmentDataManager instanceof RealtimeSegmentDataManager) {
       _logger.info("Changing segment: {} from CONSUMING to ONLINE", segmentName);
       ((RealtimeSegmentDataManager) segmentDataManager).goOnlineFromConsuming(zkMetadata);
-      onConsumingToOnline(segmentName);
     } else if (zkMetadata.getStatus().isCompleted()) {
       // For pauseless ingestion, the segment is marked ONLINE before it's built and before the COMMIT_END_METADATA
       // call completes.

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -866,6 +866,7 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
         ImmutableSegmentLoader.load(indexDir, indexLoadingConfig, _segmentOperationsThrottler);
 
     addSegment(immutableSegment, zkMetadata);
+    _ingestionDelayTracker.markPartitionForVerification(segmentName);
     _logger.info("Replaced CONSUMING segment: {}", segmentName);
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -335,18 +335,6 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
     _ingestionDelayTracker.stopTrackingPartitionIngestionDelay(new LLCSegmentName(segmentName).getPartitionGroupId());
   }
 
-  /**
-   * Method to handle CONSUMING -> ONLINE segment state transitions:
-   * We mark partitions for verification against ideal state when we do not see a consuming segment for some time
-   * for that partition. The idea is to remove the related metrics when the partition moves from the current server.
-   *
-   * @param segmentName name of segment which is transitioning state.
-   */
-  @Override
-  public void onConsumingToOnline(String segmentName) {
-    _ingestionDelayTracker.markPartitionForVerification(segmentName);
-  }
-
   @Override
   public List<SegmentContext> getSegmentContexts(List<IndexSegment> selectedSegments,
       Map<String, String> queryOptions) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManager.java
@@ -333,14 +333,6 @@ public interface TableDataManager {
   }
 
   /**
-   * Interface to handle segment state transitions from CONSUMING to ONLINE
-   *
-   * @param segmentNameStr name of segment for which the state change is being handled
-   */
-  default void onConsumingToOnline(String segmentNameStr) {
-  }
-
-  /**
    * Return list of segment names that are stale along with reason.
    *
    * @return List of {@link StaleSegment} with segment names and reason why it is stale


### PR DESCRIPTION
**Problem:**
There are quite a few edge-cases where ingestion metrics needs to be removed and for the missed edge-cases, Currently there is a backup solution: An async thread which checks for inactive partitions on the server and removes their ingestion metrics. 

This async check does not remove ingestion metrics of inactive partitions from the server which commits the segment.

For example: Currently if table is paused or the consumer ends consumption due to partition reached its endlife, Ingestion metrics are not removed from all servers.

**PR:**
For short term quick fix, This PR uses the above backup solution to remove ingestion metrics. 
The partitions is marked for verification when consuming segment is replaced with online segment.