### PR TITLE
Simplify TableRebalanceManager API

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/relocation/SegmentRelocator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/relocation/SegmentRelocator.java
@@ -236,7 +236,7 @@ public class SegmentRelocator extends ControllerPeriodicTask<Void> {
       // Retries are disabled because SegmentRelocator itself is a periodic controller task, so we don't want the
       // RebalanceChecker to unnecessarily retry any such failed rebalances.
       RebalanceResult rebalance = _tableRebalanceManager.rebalanceTable(tableNameWithType, rebalanceConfig,
-          TableRebalancer.createUniqueRebalanceJobIdentifier(), true, false);
+          TableRebalancer.createUniqueRebalanceJobIdentifier(), false);
       switch (rebalance.getStatus()) {
         case NO_OP:
           LOGGER.info("All segments are already relocated for table: {}", tableNameWithType);


### PR DESCRIPTION
- Currently, dry-run table rebalances also go through the regular rebalance API in `TableRebalanceManager`. There are a couple of issues with this:
  - Parameters like `trackRebalanceProgress` and `allowRetries` are not relevant for dry run rebalances.
  - Dry-run rebalances can't result in `RebalanceInProgressException`, but the callers would be forced to handle the checked exception anyway.
  - (minor) For the sync API, the Javadoc states that the caller should ensure that the rebalance is being run on the controller's rebalance specific thread pool - this isn't relevant for dry runs.
- `trackRebalanceProgress` is no longer really needed after https://github.com/apache/pinot/pull/16008. The `TableRebalanceManager` can itself decide whether to track the rebalance progress in ZK based on the rebalance config (the only cases where it's not tracked are downtime rebalances and dry-run rebalances).