### PR TITLE
[index] Fix legacy deserializers for Dictionary and JSON indexes

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/dictionary/DictionaryIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/dictionary/DictionaryIndexType.java
@@ -127,12 +127,6 @@ public class DictionaryIndexType
     ColumnConfigDeserializer<DictionaryIndexConfig> fromNoDictionaryColumns =
         IndexConfigDeserializer.fromCollection(tableConfig -> tableConfig.getIndexingConfig().getNoDictionaryColumns(),
             (accum, column) -> accum.put(column, DictionaryIndexConfig.DISABLED));
-    ColumnConfigDeserializer<DictionaryIndexConfig> fromFieldConfigs =
-        IndexConfigDeserializer.fromCollection(TableConfig::getFieldConfigList, (accum, fieldConfig) -> {
-          if (fieldConfig.getEncodingType() == FieldConfig.EncodingType.RAW) {
-            accum.put(fieldConfig.getName(), DictionaryIndexConfig.DISABLED);
-          }
-        });
     ColumnConfigDeserializer<DictionaryIndexConfig> fromIndexingConfig = (tableConfig, schema) -> {
       IndexingConfig indexingConfig = tableConfig.getIndexingConfig();
       Set<String> onHeapDictionaryColumns = indexingConfig.getOnHeapDictionaryColumns() != null ? new HashSet<>(
@@ -150,7 +144,6 @@ public class DictionaryIndexType
       return dictionaryIndexConfigMap;
     };
     return fromNoDictionaryConfigs.withFallbackAlternative(fromNoDictionaryColumns)
-        .withFallbackAlternative(fromFieldConfigs)
         .withFallbackAlternative(fromIndexingConfig);
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/json/JsonIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/json/JsonIndexType.java
@@ -100,10 +100,7 @@ public class JsonIndexType extends AbstractIndexType<JsonIndexConfig, JsonIndexR
     ColumnConfigDeserializer<JsonIndexConfig> fromJsonIndexColumns =
         IndexConfigDeserializer.fromCollection(tableConfig -> tableConfig.getIndexingConfig().getJsonIndexColumns(),
             (accum, column) -> accum.put(column, JsonIndexConfig.DEFAULT));
-    ColumnConfigDeserializer<JsonIndexConfig> fromFieldConfigs =
-        IndexConfigDeserializer.fromIndexTypes(FieldConfig.IndexType.JSON,
-            (tableConfig, fieldConfig) -> JsonIndexConfig.DEFAULT);
-    return fromJsonIndexConfigs.withFallbackAlternative(fromJsonIndexColumns).withFallbackAlternative(fromFieldConfigs);
+    return fromJsonIndexConfigs.withFallbackAlternative(fromJsonIndexColumns);
   }
 
   @Override

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/creator/VectorIndexConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/creator/VectorIndexConfig.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pinot.segment.spi.index.creator;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -65,6 +67,21 @@ public class VectorIndexConfig extends IndexConfig {
     _vectorDistanceFunction = properties.containsKey(VECTOR_DISTANCE_FUNCTION) ? VectorDistanceFunction.valueOf(
         properties.get(VECTOR_DISTANCE_FUNCTION)) : DEFAULT_VECTOR_DISTANCE_FUNCTION;
     _version = Integer.parseInt(properties.getOrDefault(VERSION, DEFAULT_VERSION));
+    _properties = properties;
+  }
+
+  @JsonCreator
+  public VectorIndexConfig(@JsonProperty("disabled") Boolean disabled,
+      @JsonProperty("vectorIndexType") @Nullable String vectorIndexType,
+      @JsonProperty("vectorDimension") @Nullable int vectorDimension,
+      @JsonProperty("version") @Nullable int version,
+      @JsonProperty("vectorDistanceFunction") @Nullable VectorDistanceFunction vectorDistanceFunction,
+      @JsonProperty("properties") @Nullable Map<String, String> properties) {
+    super(disabled);
+    _vectorIndexType = vectorIndexType;
+    _vectorDimension = vectorDimension;
+    _version = version;
+    _vectorDistanceFunction = vectorDistanceFunction;
     _properties = properties;
   }
 


### PR DESCRIPTION
## Issue

[createTableConfigFromOldFormat](https://github.com/startreedata/pinot/blob/5d7fab1cc3177ce21fa2da1e1287f17c461c7df3/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java#L1449) util method fails for a valid tableConfig

## Description

In a [recent change](https://github.com/startreedata/pinot/commit/c96c318ef8b9897b04d6f4afe709b1f09fd33cec#diff-ac7ba46a862780f8f703c30869b17418a6d3e6f729e507b18044933a24588438L31-L44), logic for [creating deserializers](https://github.com/startreedata/pinot/blob/5d7fab1cc3177ce21fa2da1e1287f17c461c7df3/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/AbstractIndexType.java#L45) for all IndexTypes was changed to
```
  protected ColumnConfigDeserializer<C> createDeserializer() {
    ColumnConfigDeserializer<C> fromIndexes =
        IndexConfigDeserializer.fromIndexes(getPrettyName(), getIndexConfigClass());
    ColumnConfigDeserializer<C> fromLegacyConfigs = createDeserializerForLegacyConfigs();
    return fromLegacyConfigs != null ? fromIndexes.withExclusiveAlternative(fromLegacyConfigs) : fromIndexes;
  }
```
This creates two deserializers:
1. one for indexes in new format
2. one for legacy format

and combined desirealizer has `FAIL` _onConfict_ property, so if both the deserializers detect the same config, it'll result in error like following:
```
Configuration is declared in two different ways for index dictionary on column address
```
example valid table config for which it fails:
[example_table_config.json](https://github.com/user-attachments/files/20887301/example_table_config.json)
```
{
    "tableConfig": {
        "tableIndexConfig": {
            ...
            "varLengthDictionaryColumns": null
            ...
        },
        ...
        "fieldConfigList": [
            ...
            {
                "name": "address",
                "encodingType": "RAW",
                "indexTypes": [],
                "indexes": {
                    "dictionary": {
                        "disabled": false,
                        "onHeap": false,
                        "useVarLengthDictionary": true
                    },
                    "inverted": {
                        "disabled": false
                    }
                },
                "tierOverwrites": null
            }
            ...
        ]
        ...
    },
    "schema": {
       ...
    }
}
```

The logic of `createDeserializerForLegacyConfigs()`
for Dictionary index and Json index reads from new format as well, 
which is incorrect and leads to above mentioned issue

Legacy deserializer logic should not infer indexes from new format now
This PR fixes that

It also adds missing json initializer for VectorIndexConfig
