### PR TITLE
Add Obfuscator for task configs in minion task loggers

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/PinotAppConfigs.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/PinotAppConfigs.java
@@ -340,7 +340,7 @@ public class PinotAppConfigs {
 
   public String toJSONString() {
     try {
-      return JsonUtils.objectToPrettyString(new Obfuscator().toJson(this));
+      return JsonUtils.objectToPrettyString(Obfuscator.DEFAULT.toJson(this));
     } catch (JsonProcessingException e) {
       return e.getMessage();
     }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotControllerAppConfigsTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotControllerAppConfigsTest.java
@@ -69,8 +69,7 @@ public class PinotControllerAppConfigsTest {
     assertEquals(actualSystemConfig.getTotalSwapSpace(), expectedSystemConfig.getTotalSwapSpace());
 
     // tests Equals on obfuscated expected and actual
-    Obfuscator obfuscator = new Obfuscator();
-    String obfuscatedExpectedJson = obfuscator.toJsonString(expected);
+    String obfuscatedExpectedJson = Obfuscator.DEFAULT.toJsonString(expected);
     PinotAppConfigs obfuscatedExpected = JsonUtils.stringToObject(obfuscatedExpectedJson, PinotAppConfigs.class);
     assertEquals(actual.getJvmConfig(), obfuscatedExpected.getJvmConfig());
     assertEquals(actual.getPinotConfig(), obfuscatedExpected.getPinotConfig());

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/taskfactory/TaskFactoryRegistry.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/taskfactory/TaskFactoryRegistry.java
@@ -148,7 +148,7 @@ public class TaskFactoryRegistry {
               _eventObserver.notifyTaskStart(pinotTaskConfig);
               if (LOGGER.isInfoEnabled()) {
                 LOGGER.info("Start running {}: {} with configs: {}", pinotTaskConfig.getTaskType(), _taskConfig.getId(),
-                    new Obfuscator().toJsonString(pinotTaskConfig.getConfigs()));
+                    Obfuscator.DEFAULT.toJsonString(pinotTaskConfig.getConfigs()));
               }
 
               try {

--- a/pinot-minion/src/test/java/org/apache/pinot/minion/taskfactory/TaskFactoryRegistryTest.java
+++ b/pinot-minion/src/test/java/org/apache/pinot/minion/taskfactory/TaskFactoryRegistryTest.java
@@ -38,8 +38,7 @@ public class TaskFactoryRegistryTest {
     configs.put("apiKey", "sk-1234567890abcdef");
     configs.put("normalConfig", "normalValue");
 
-    Obfuscator obfuscator = new Obfuscator();
-    String obfuscatedJson = obfuscator.toJsonString(configs);
+    String obfuscatedJson = Obfuscator.DEFAULT.toJsonString(configs);
 
     // Verify that sensitive values are masked
     Assert.assertTrue(obfuscatedJson.contains("tableName"));
@@ -66,8 +65,7 @@ public class TaskFactoryRegistryTest {
     configs.put("password", "");
     configs.put("normalConfig", "value");
 
-    Obfuscator obfuscator = new Obfuscator();
-    String obfuscatedJson = obfuscator.toJsonString(configs);
+    String obfuscatedJson = Obfuscator.DEFAULT.toJsonString(configs);
 
     // Verify that null and empty values are handled properly
     Assert.assertTrue(obfuscatedJson.contains("\"authToken\":\"*****\""));

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskExecutor.java
@@ -39,6 +39,7 @@ import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.RecordReader;
 import org.apache.pinot.spi.recordtransformer.RecordTransformer;
+import org.apache.pinot.spi.utils.Obfuscator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -61,7 +62,9 @@ public class MergeRollupTaskExecutor extends BaseMultipleSegmentsConversionExecu
     _eventObserver.notifyProgress(pinotTaskConfig, "Converting segments: " + numInputSegments);
     String taskType = pinotTaskConfig.getTaskType();
     Map<String, String> configs = pinotTaskConfig.getConfigs();
-    LOGGER.info("Starting task: {} with configs: {}", taskType, configs);
+    if (LOGGER.isInfoEnabled()) {
+      LOGGER.info("Starting task: {} with configs: {}", taskType, Obfuscator.DEFAULT.toJsonString(configs));
+    }
     long startMillis = System.currentTimeMillis();
 
     String tableNameWithType = configs.get(MinionConstants.TABLE_NAME_KEY);
@@ -130,7 +133,10 @@ public class MergeRollupTaskExecutor extends BaseMultipleSegmentsConversionExecu
     }
 
     long endMillis = System.currentTimeMillis();
-    LOGGER.info("Finished task: {} with configs: {}. Total time: {}ms", taskType, configs, (endMillis - startMillis));
+    if (LOGGER.isInfoEnabled()) {
+      LOGGER.info("Finished task: {} with configs: {}. Total time: {}ms", taskType,
+          Obfuscator.DEFAULT.toJsonString(configs), (endMillis - startMillis));
+    }
     List<SegmentConversionResult> results = new ArrayList<>();
     for (File outputSegmentDir : outputSegmentDirs) {
       String outputSegmentName = outputSegmentDir.getName();

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskExecutor.java
@@ -43,6 +43,7 @@ import org.apache.pinot.segment.local.segment.readers.PinotSegmentRecordReader;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.RecordReader;
+import org.apache.pinot.spi.utils.Obfuscator;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -116,7 +117,9 @@ public class RealtimeToOfflineSegmentsTaskExecutor extends BaseMultipleSegmentsC
     _eventObserver.notifyProgress(pinotTaskConfig, "Converting segments: " + numInputSegments);
     String taskType = pinotTaskConfig.getTaskType();
     Map<String, String> configs = pinotTaskConfig.getConfigs();
-    LOGGER.info("Starting task: {} with configs: {}", taskType, configs);
+    if (LOGGER.isInfoEnabled()) {
+      LOGGER.info("Starting task: {} with configs: {}", taskType, Obfuscator.DEFAULT.toJsonString(configs));
+    }
     long startMillis = System.currentTimeMillis();
 
     String realtimeTableName = configs.get(MinionConstants.TABLE_NAME_KEY);
@@ -188,7 +191,10 @@ public class RealtimeToOfflineSegmentsTaskExecutor extends BaseMultipleSegmentsC
     }
 
     long endMillis = System.currentTimeMillis();
-    LOGGER.info("Finished task: {} with configs: {}. Total time: {}ms", taskType, configs, (endMillis - startMillis));
+    if (LOGGER.isInfoEnabled()) {
+      LOGGER.info("Finished task: {} with configs: {}. Total time: {}ms", taskType,
+          Obfuscator.DEFAULT.toJsonString(configs), (endMillis - startMillis));
+    }
     List<SegmentConversionResult> results = new ArrayList<>();
     for (File outputSegmentDir : outputSegmentDirs) {
       String outputSegmentName = outputSegmentDir.getName();

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/refreshsegment/RefreshSegmentTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/refreshsegment/RefreshSegmentTaskExecutor.java
@@ -43,6 +43,7 @@ import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.utils.Obfuscator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -72,7 +73,9 @@ public class RefreshSegmentTaskExecutor extends BaseSingleSegmentConversionExecu
     String segmentName = configs.get(MinionConstants.SEGMENT_NAME_KEY);
     String taskType = pinotTaskConfig.getTaskType();
 
-    LOGGER.info("Starting task: {} with configs: {}", taskType, configs);
+    if (LOGGER.isInfoEnabled()) {
+      LOGGER.info("Starting task: {} with configs: {}", taskType, Obfuscator.DEFAULT.toJsonString(configs));
+    }
 
     TableConfig tableConfig = getTableConfig(tableNameWithType);
     Schema schema = getSchema(tableNameWithType);
@@ -160,8 +163,10 @@ public class RefreshSegmentTaskExecutor extends BaseSingleSegmentConversionExecu
         .build();
 
     long endMillis = System.currentTimeMillis();
-    LOGGER.info("Finished task: {} with configs: {}. Total time: {}ms", taskType, configs,
-        (endMillis - _taskStartTime));
+    if (LOGGER.isInfoEnabled()) {
+      LOGGER.info("Finished task: {} with configs: {}. Total time: {}ms", taskType,
+          Obfuscator.DEFAULT.toJsonString(configs), (endMillis - _taskStartTime));
+    }
 
     return result;
   }

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segmentgenerationandpush/SegmentGenerationAndPushTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segmentgenerationandpush/SegmentGenerationAndPushTaskExecutor.java
@@ -54,6 +54,7 @@ import org.apache.pinot.spi.ingestion.batch.spec.TableSpec;
 import org.apache.pinot.spi.utils.DataSizeUtils;
 import org.apache.pinot.spi.utils.IngestionConfigUtils;
 import org.apache.pinot.spi.utils.JsonUtils;
+import org.apache.pinot.spi.utils.Obfuscator;
 import org.apache.pinot.spi.utils.retry.AttemptsExceededException;
 import org.apache.pinot.spi.utils.retry.RetriableOperationException;
 import org.slf4j.Logger;
@@ -114,7 +115,10 @@ public class SegmentGenerationAndPushTaskExecutor extends BaseTaskExecutor {
   @Override
   public Object executeTask(PinotTaskConfig pinotTaskConfig)
       throws Exception {
-    LOGGER.info("Executing SegmentGenerationAndPushTask with task config: {}", pinotTaskConfig);
+    if (LOGGER.isInfoEnabled()) {
+      LOGGER.info("Executing SegmentGenerationAndPushTask with task config: {}",
+          Obfuscator.DEFAULT.toJsonString(pinotTaskConfig));
+    }
     Map<String, String> taskConfigs = pinotTaskConfig.getConfigs();
     SegmentGenerationAndPushResult.Builder resultBuilder = new SegmentGenerationAndPushResult.Builder();
     File localTempDir = new File(new File(MinionContext.getInstance().getDataDir(), "SegmentGenerationAndPushResult"),

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segmentgenerationandpush/SegmentGenerationAndPushTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segmentgenerationandpush/SegmentGenerationAndPushTaskGenerator.java
@@ -50,6 +50,7 @@ import org.apache.pinot.spi.filesystem.PinotFS;
 import org.apache.pinot.spi.ingestion.batch.BatchConfigProperties;
 import org.apache.pinot.spi.plugin.PluginManager;
 import org.apache.pinot.spi.utils.IngestionConfigUtils;
+import org.apache.pinot.spi.utils.Obfuscator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -169,8 +170,11 @@ public class SegmentGenerationAndPushTaskGenerator extends BaseTaskGenerator {
             }
           }
         } catch (Exception e) {
-          LOGGER.error("Unable to generate the SegmentGenerationAndPush task. [ table configs: {}, task configs: {} ]",
-              tableConfig, taskConfigs, e);
+          if (LOGGER.isErrorEnabled()) {
+            LOGGER.error(
+                "Unable to generate the SegmentGenerationAndPush task. [ table configs: {}, task configs: {} ]",
+                Obfuscator.DEFAULT.toJsonString(tableConfig), Obfuscator.DEFAULT.toJsonString(taskConfigs), e);
+          }
         }
       }
     }
@@ -224,8 +228,10 @@ public class SegmentGenerationAndPushTaskGenerator extends BaseTaskGenerator {
       }
       return pinotTaskConfigs;
     } catch (Exception e) {
-      LOGGER.error("Unable to generate the SegmentGenerationAndPush task. [ table configs: {}, task configs: {} ]",
-          tableConfig, taskConfigs, e);
+      if (LOGGER.isErrorEnabled()) {
+        LOGGER.error("Unable to generate the SegmentGenerationAndPush task. [ table configs: {}, task configs: {} ]",
+            Obfuscator.DEFAULT.toJsonString(tableConfig), Obfuscator.DEFAULT.toJsonString(taskConfigs), e);
+      }
       throw e;
     }
   }

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskExecutor.java
@@ -37,6 +37,7 @@ import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
 import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.Obfuscator;
 import org.roaringbitmap.RoaringBitmap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,7 +53,9 @@ public class UpsertCompactionTaskExecutor extends BaseSingleSegmentConversionExe
     Map<String, String> configs = pinotTaskConfig.getConfigs();
     String segmentName = configs.get(MinionConstants.SEGMENT_NAME_KEY);
     String taskType = pinotTaskConfig.getTaskType();
-    LOGGER.info("Starting task: {} with configs: {}", taskType, configs);
+    if (LOGGER.isInfoEnabled()) {
+      LOGGER.info("Starting task: {} with configs: {}", taskType, Obfuscator.DEFAULT.toJsonString(configs));
+    }
     long startMillis = System.currentTimeMillis();
 
     String tableNameWithType = configs.get(MinionConstants.TABLE_NAME_KEY);
@@ -118,9 +121,11 @@ public class UpsertCompactionTaskExecutor extends BaseSingleSegmentConversionExe
             segmentMetadata.getTotalDocs() - totalDocsAfterCompaction);
 
     long endMillis = System.currentTimeMillis();
-    LOGGER.info("Finished task: {} with configs: {}. Total time: {}ms. Total docs before compaction: {}. "
-            + "Total docs after compaction: {}.", taskType, configs, (endMillis - startMillis),
-            segmentMetadata.getTotalDocs(), totalDocsAfterCompaction);
+    if (LOGGER.isInfoEnabled()) {
+      LOGGER.info("Finished task: {} with configs: {}. Total time: {}ms. Total docs before compaction: {}. "
+              + "Total docs after compaction: {}.", taskType, Obfuscator.DEFAULT.toJsonString(configs),
+          (endMillis - startMillis), segmentMetadata.getTotalDocs(), totalDocsAfterCompaction);
+    }
 
     return result;
   }

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompactmerge/UpsertCompactMergeTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompactmerge/UpsertCompactMergeTaskExecutor.java
@@ -46,6 +46,7 @@ import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.RecordReader;
 import org.apache.pinot.spi.data.readers.RecordReaderFileConfig;
+import org.apache.pinot.spi.utils.Obfuscator;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.roaringbitmap.RoaringBitmap;
 import org.slf4j.Logger;
@@ -73,7 +74,9 @@ public class UpsertCompactMergeTaskExecutor extends BaseMultipleSegmentsConversi
     _eventObserver.notifyProgress(pinotTaskConfig, "Converting segments: " + numInputSegments);
     String taskType = pinotTaskConfig.getTaskType();
     Map<String, String> configs = pinotTaskConfig.getConfigs();
-    LOGGER.info("Starting task: {} with configs: {}", taskType, configs);
+    if (LOGGER.isInfoEnabled()) {
+      LOGGER.info("Starting task: {} with configs: {}", taskType, Obfuscator.DEFAULT.toJsonString(configs));
+    }
     long startMillis = System.currentTimeMillis();
 
     String tableNameWithType = configs.get(MinionConstants.TABLE_NAME_KEY);
@@ -146,7 +149,10 @@ public class UpsertCompactMergeTaskExecutor extends BaseMultipleSegmentsConversi
             .getSkippedRowsFound() + ", sanitized:" + framework.getSanitizedRowsFound());
 
     long endMillis = System.currentTimeMillis();
-    LOGGER.info("Finished task: {} with configs: {}. Total time: {}ms", taskType, configs, (endMillis - startMillis));
+    if (LOGGER.isInfoEnabled()) {
+      LOGGER.info("Finished task: {} with configs: {}. Total time: {}ms", taskType,
+          Obfuscator.DEFAULT.toJsonString(configs), (endMillis - startMillis));
+    }
 
     List<SegmentConversionResult> results = new ArrayList<>();
     for (File outputSegmentDir : outputSegmentDirs) {

--- a/pinot-server/src/test/java/org/apache/pinot/server/api/PinotServerAppConfigsTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/api/PinotServerAppConfigsTest.java
@@ -71,8 +71,7 @@ public class PinotServerAppConfigsTest extends BaseResourceTest {
     Assert.assertEquals(actualSystemConfig.getTotalSwapSpace(), expectedSystemConfig.getTotalSwapSpace());
 
     // tests Equals on obfuscated expected and actual
-    Obfuscator obfuscator = new Obfuscator();
-    String obfuscatedExpectedJson = obfuscator.toJsonString(expected);
+    String obfuscatedExpectedJson = Obfuscator.DEFAULT.toJsonString(expected);
     PinotAppConfigs obfuscatedExpected = JsonUtils.stringToObject(obfuscatedExpectedJson, PinotAppConfigs.class);
     Assert.assertEquals(actual.getJvmConfig(), obfuscatedExpected.getJvmConfig());
     Assert.assertEquals(actual.getPinotConfig(), obfuscatedExpected.getPinotConfig());

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/env/PinotConfiguration.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/env/PinotConfiguration.java
@@ -500,7 +500,7 @@ public class PinotConfiguration {
 
   @Override
   public String toString() {
-    return new Obfuscator().toJsonString(toMap());
+    return Obfuscator.DEFAULT.toJsonString(toMap());
   }
 
   public boolean isEmpty() {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/Obfuscator.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/Obfuscator.java
@@ -56,11 +56,13 @@ import java.util.stream.Stream;
  * </pre>
  */
 public final class Obfuscator {
+
   private static final String DEFAULT_MASKED_VALUE = "*****";
   private static final List<Pattern> DEFAULT_PATTERNS =
       Stream.of("(?i).*secret$", "(?i).*secret[\\s_-]*key$", "(?i).*api[\\s_-]*key$", "(?i).*password$",
               "(?i).*keytab$", "(?i).*token$")
           .map(Pattern::compile).collect(Collectors.toList());
+  public static final Obfuscator DEFAULT = new Obfuscator();
 
   private final String _maskedValue;
   private final List<Pattern> _patterns;
@@ -70,8 +72,7 @@ public final class Obfuscator {
    * values with '*****'
    */
   public Obfuscator() {
-    _maskedValue = DEFAULT_MASKED_VALUE;
-    _patterns = DEFAULT_PATTERNS;
+    this(DEFAULT_MASKED_VALUE, DEFAULT_PATTERNS);
   }
 
   /**


### PR DESCRIPTION
This PR adds security and performance improvements to minion task loggers by obfuscating sensitive task configurations and adding logger level checks for better performance.