### PR TITLE
Support GrpcRequesterIdentity in ZkBasicAuthAccessControlFactory

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BasicAuthAccessControlFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BasicAuthAccessControlFactory.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.broker.broker;
 
-import com.google.common.base.Preconditions;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Map;
@@ -28,8 +27,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import javax.ws.rs.NotAuthorizedException;
 import org.apache.pinot.broker.api.AccessControl;
-import org.apache.pinot.broker.api.HttpRequesterIdentity;
-import org.apache.pinot.broker.grpc.GrpcRequesterIdentity;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.core.auth.BasicAuthPrincipal;
 import org.apache.pinot.core.auth.BasicAuthUtils;
@@ -52,8 +49,6 @@ import org.apache.pinot.spi.env.PinotConfiguration;
  */
 public class BasicAuthAccessControlFactory extends AccessControlFactory {
   private static final String PREFIX = "principals";
-
-  private static final String HEADER_AUTHORIZATION = "authorization";
 
   private AccessControl _accessControl;
 
@@ -137,25 +132,8 @@ public class BasicAuthAccessControlFactory extends AccessControlFactory {
     }
 
     private Optional<BasicAuthPrincipal> getPrincipalOpt(RequesterIdentity requesterIdentity) {
-      Preconditions.checkArgument(
-          requesterIdentity instanceof HttpRequesterIdentity || requesterIdentity instanceof GrpcRequesterIdentity,
-          "BasicAuthAccessControl only supports HttpRequesterIdentity or GrpcRequesterIdentity, got %s",
-          requesterIdentity == null ? "null" : requesterIdentity.getClass().getName());
-      Collection<String> tokens = null;
-      if (requesterIdentity instanceof HttpRequesterIdentity) {
-        HttpRequesterIdentity identity = (HttpRequesterIdentity) requesterIdentity;
-        tokens = identity.getHttpHeaders().get(HEADER_AUTHORIZATION);
-      }
-      if (requesterIdentity instanceof GrpcRequesterIdentity) {
-        GrpcRequesterIdentity identity = (GrpcRequesterIdentity) requesterIdentity;
-        for (String key : identity.getMetadata().keySet()) {
-          if (HEADER_AUTHORIZATION.equalsIgnoreCase(key)) {
-            tokens = identity.getMetadata().get(key);
-            break;
-          }
-        }
-      }
-      if (tokens == null || tokens.isEmpty()) {
+      Collection<String> tokens = extractAuthorizationTokens(requesterIdentity);
+      if (tokens.isEmpty()) {
         return Optional.empty();
       }
       return tokens.stream().map(org.apache.pinot.common.auth.BasicAuthUtils::normalizeBase64Token)


### PR DESCRIPTION
This pull request refactors the authorization token extraction logic in the `AccessControlFactory` class and its subclasses (`BasicAuthAccessControlFactory` and `ZkBasicAuthAccessControlFactory`) to improve code reuse and maintainability. The changes include introducing a new method for token extraction and removing redundant code from subclasses.