### PR TITLE
[SSE] Remove redundant sorting when broker receives sorted block

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/datatable/DataTable.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/datatable/DataTable.java
@@ -144,11 +144,13 @@ public interface DataTable {
     MAX_ROWS_IN_JOIN_REACHED(34, "maxRowsInJoinReached", MetadataValueType.STRING),
     NUM_GROUPS_WARNING_LIMIT_REACHED(35, "numGroupsWarningLimitReached", MetadataValueType.STRING),
     THREAD_MEM_ALLOCATED_BYTES(36, "threadMemAllocatedBytes", MetadataValueType.LONG),
-    RESPONSE_SER_MEM_ALLOCATED_BYTES(37, "responseSerMemAllocatedBytes", MetadataValueType.LONG);
+    RESPONSE_SER_MEM_ALLOCATED_BYTES(37, "responseSerMemAllocatedBytes", MetadataValueType.LONG),
+    // expressions that the result block is sorted on
+    ORDER_BY_EXPRESSIONS(38, "orderByExpressions", MetadataValueType.STRING);
 
     // We keep this constant to track the max id added so far for backward compatibility.
     // Increase it when adding new keys, but NEVER DECREASE IT!!!
-    private static final int MAX_ID = 37;
+    private static final int MAX_ID = 38;
 
     private static final MetadataKey[] ID_TO_ENUM_KEY_MAP = new MetadataKey[MAX_ID + 1];
     private static final Map<String, MetadataKey> NAME_TO_ENUM_KEY_MAP = new HashMap<>();

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/SelectionResultsBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/SelectionResultsBlock.java
@@ -21,8 +21,10 @@ package org.apache.pinot.core.operator.blocks.results;
 import java.io.IOException;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.datatable.DataTable;
+import org.apache.pinot.common.request.context.OrderByExpressionContext;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.selection.SelectionOperatorUtils;
@@ -36,12 +38,25 @@ public class SelectionResultsBlock extends BaseResultsBlock {
   private final Comparator<? super Object[]> _comparator;
   private final QueryContext _queryContext;
   private List<Object[]> _rows;
+  @Nullable
+  private final List<OrderByExpressionContext> _orderByExpressions;
 
   public SelectionResultsBlock(DataSchema dataSchema, List<Object[]> rows,
       @Nullable Comparator<? super Object[]> comparator, QueryContext queryContext) {
     _dataSchema = dataSchema;
     _rows = rows;
     _comparator = comparator;
+    _queryContext = queryContext;
+    _orderByExpressions = null;
+  }
+
+  public SelectionResultsBlock(DataSchema dataSchema, List<Object[]> rows,
+      @Nullable Comparator<? super Object[]> comparator, List<OrderByExpressionContext> orderByExpressions,
+      QueryContext queryContext) {
+    _dataSchema = dataSchema;
+    _rows = rows;
+    _comparator = comparator;
+    _orderByExpressions = orderByExpressions;
     _queryContext = queryContext;
   }
 
@@ -82,5 +97,13 @@ public class SelectionResultsBlock extends BaseResultsBlock {
   public DataTable getDataTable()
       throws IOException {
     return SelectionOperatorUtils.getDataTableFromRows(_rows, _dataSchema, _queryContext.isNullHandlingEnabled());
+  }
+
+  // metadata of select block that has sort information
+  @Override
+  public Map<String, String> getResultsMetadata() {
+    Map<String, String> metadata = super.getResultsMetadata();
+    metadata.put(DataTable.MetadataKey.ORDER_BY_EXPRESSIONS.getName(), String.valueOf(_orderByExpressions));
+    return metadata;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/LinearSelectionOrderByOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/LinearSelectionOrderByOperator.java
@@ -244,7 +244,8 @@ public abstract class LinearSelectionOrderByOperator extends BaseOperator<Select
 
   @Override
   protected SelectionResultsBlock getNextBlock() {
-    return new SelectionResultsBlock(createDataSchema(), fetch(_listBuilderSupplier), _comparator, _queryContext);
+    return new SelectionResultsBlock(createDataSchema(), fetch(_listBuilderSupplier), _comparator, _orderByExpressions,
+        _queryContext);
   }
 
   protected DataSchema createDataSchema() {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/SelectionOrderByOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/SelectionOrderByOperator.java
@@ -202,7 +202,8 @@ public class SelectionOrderByOperator extends BaseOperator<SelectionResultsBlock
     }
     DataSchema dataSchema = new DataSchema(columnNames, columnDataTypes);
 
-    return new SelectionResultsBlock(dataSchema, getSortedRows(), _comparator, _queryContext);
+    // add _orderByExpressions to the constructed results block as metadata
+    return new SelectionResultsBlock(dataSchema, getSortedRows(), _comparator, _orderByExpressions, _queryContext);
   }
 
   /**
@@ -337,7 +338,8 @@ public class SelectionOrderByOperator extends BaseOperator<SelectionResultsBlock
       }
       DataSchema dataSchema = new DataSchema(columnNames, columnDataTypes);
 
-      return new SelectionResultsBlock(dataSchema, getSortedRows(), _comparator, _queryContext);
+      // add _orderByExpressions to result block
+      return new SelectionResultsBlock(dataSchema, getSortedRows(), _comparator, _orderByExpressions, _queryContext);
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/selection/SelectionOperatorService.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/selection/SelectionOperatorService.java
@@ -18,10 +18,14 @@
  */
 package org.apache.pinot.core.query.selection;
 
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.LinkedList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
 import java.util.PriorityQueue;
 import org.apache.pinot.common.datatable.DataTable;
+import org.apache.pinot.common.request.context.OrderByExpressionContext;
 import org.apache.pinot.common.response.broker.ResultTable;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.query.request.context.QueryContext;
@@ -62,6 +66,11 @@ public class SelectionOperatorService {
   private final int _offset;
   private final int _numRowsToKeep;
   private final PriorityQueue<Object[]> _rows;
+  private final Comparator<Object[]> _comparator;
+  // list used to merge and store already-sorted input
+  private final List<OrderByExpressionContext> _orderByExpressions;
+  // pq for sorted unsorted inputs
+  private List<Object[]> _sortedRows;
 
   public SelectionOperatorService(QueryContext queryContext, DataSchema dataSchema, int[] columnIndices) {
     _queryContext = queryContext;
@@ -71,18 +80,30 @@ public class SelectionOperatorService {
     _offset = queryContext.getOffset();
     _numRowsToKeep = _offset + queryContext.getLimit();
     assert queryContext.getOrderByExpressions() != null;
+    _comparator = OrderByComparatorFactory.getComparator(queryContext.getOrderByExpressions(),
+        _queryContext.isNullHandlingEnabled());
     _rows = new PriorityQueue<>(Math.min(_numRowsToKeep, SelectionOperatorUtils.MAX_ROW_HOLDER_INITIAL_CAPACITY),
         OrderByComparatorFactory.getComparator(queryContext.getOrderByExpressions(),
             _queryContext.isNullHandlingEnabled()).reversed());
+
+    _orderByExpressions = _queryContext.getOrderByExpressions();
+    _sortedRows = new ArrayList<>();
   }
 
   /**
    * Reduces a collection of {@link DataTable}s to selection rows for selection queries with <code>ORDER BY</code>.
-   * TODO: Do merge sort after releasing 0.13.0 when server side results are sorted
-   *       Can also consider adding a data table metadata to indicate whether the server side results are sorted
+   * Do merge sort when server side results are sorted
    */
   public void reduceWithOrdering(Collection<DataTable> dataTables) {
     for (DataTable dataTable : dataTables) {
+      // if dataTable is sorted, merge it into _sortedRow directly without sorting again
+      // the metadata originates from LinearSelectionOrderByOperator and SelectionOrderByOperator
+      if (String.valueOf(_orderByExpressions).equals(dataTable.getMetadata().get(
+          DataTable.MetadataKey.ORDER_BY_EXPRESSIONS.getName()))) {
+        _sortedRows = mergeSortedDataTable(_sortedRows, dataTable);
+        continue;
+      }
+      // else add it to priority queue for sorting
       int numRows = dataTable.getNumberOfRows();
       if (_queryContext.isNullHandlingEnabled()) {
         RoaringBitmap[] nullBitmaps = new RoaringBitmap[dataTable.getDataSchema().size()];
@@ -113,11 +134,15 @@ public class SelectionOperatorService {
    * Renders the selection rows to a {@link ResultTable} object for selection queries with <code>ORDER BY</code>.
    */
   public ResultTable renderResultTableWithOrdering() {
-    LinkedList<Object[]> resultRows = new LinkedList<>();
     DataSchema.ColumnDataType[] columnDataTypes = _dataSchema.getColumnDataTypes();
     int numColumns = columnDataTypes.length;
-    while (_rows.size() > _offset) {
-      Object[] row = _rows.poll();
+    // merge _sortedRow and _rows into single result, both are ordered
+    List<Object[]> rows = mergeResult(_sortedRows, _rows);
+    if (rows.size() < _offset) {
+      return new ResultTable(_dataSchema, Collections.emptyList());
+    }
+    List<Object[]> resultRows = new ArrayList<>();
+    for (Object[] row : rows.subList(_offset, rows.size())) {
       assert row != null;
       Object[] resultRow = new Object[numColumns];
       for (int i = 0; i < numColumns; i++) {
@@ -126,8 +151,44 @@ public class SelectionOperatorService {
           resultRow[i] = columnDataTypes[i].convertAndFormat(value);
         }
       }
-      resultRows.addFirst(resultRow);
+      resultRows.add(resultRow);
     }
     return new ResultTable(_dataSchema, resultRows);
+  }
+
+  /** merge sorted dataTable with sorted sortedRows list, keeping at most _numRowsToKeep elements*/
+  private List<Object[]> mergeSortedDataTable(List<Object[]> sortedRows, DataTable dataTable) {
+
+    List<Object[]> rightRows = new ArrayList<>();
+    int numRows = dataTable.getNumberOfRows();
+    if (_queryContext.isNullHandlingEnabled()) {
+      RoaringBitmap[] nullBitmaps = new RoaringBitmap[dataTable.getDataSchema().size()];
+      for (int colId = 0; colId < nullBitmaps.length; colId++) {
+        nullBitmaps[colId] = dataTable.getNullRowIds(colId);
+      }
+      for (int rowId = 0; rowId < numRows; rowId++) {
+        Object[] row = SelectionOperatorUtils.extractRowFromDataTable(dataTable, rowId);
+        for (int colId = 0; colId < nullBitmaps.length; colId++) {
+          if (nullBitmaps[colId] != null && nullBitmaps[colId].contains(rowId)) {
+            row[colId] = null;
+          }
+        }
+        rightRows.add(row);
+        Tracing.ThreadAccountantOps.sampleAndCheckInterruptionPeriodically(rowId);
+      }
+    } else {
+      for (int rowId = 0; rowId < numRows; rowId++) {
+        Object[] row = SelectionOperatorUtils.extractRowFromDataTable(dataTable, rowId);
+        rightRows.add(row);
+        Tracing.ThreadAccountantOps.sampleAndCheckInterruptionPeriodically(rowId);
+      }
+    }
+    return SelectionOperatorUtils.mergeWithOrderingList(sortedRows, rightRows, _comparator, _numRowsToKeep);
+  }
+
+  /** merge sortedRows list and rows priority queue, keeping at most _numRowsToKeep elements */
+  private List<Object[]> mergeResult(List<Object[]> sortedRows1, PriorityQueue<Object[]> pq) {
+    List<Object[]> sortedRow2 = new ArrayList<>(pq);
+    return SelectionOperatorUtils.mergeWithOrderingList(sortedRows1, sortedRow2, _comparator, _numRowsToKeep);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/selection/SelectionOperatorUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/selection/SelectionOperatorUtils.java
@@ -313,16 +313,21 @@ public class SelectionOperatorUtils {
     List<Object[]> sortedRows1 = mergedBlock.getRows();
     List<Object[]> sortedRows2 = blockToMerge.getRows();
     Comparator<? super Object[]> comparator = mergedBlock.getComparator();
+    List<Object[]> mergedRows = mergeWithOrderingList(sortedRows1, sortedRows2, comparator, maxNumRows);
+    mergedBlock.setRows(mergedRows);
+  }
+
+  public static List<Object[]> mergeWithOrderingList(List<Object[]> sortedRows1, List<Object[]> sortedRows2,
+      Comparator<? super Object[]> comparator, int maxNumRows) {
     assert comparator != null;
     int numSortedRows1 = sortedRows1.size();
     int numSortedRows2 = sortedRows2.size();
     if (numSortedRows1 == 0) {
-      mergedBlock.setRows(sortedRows2);
-      return;
+      return sortedRows2;
     }
     if (numSortedRows2 == 0 || (numSortedRows1 == maxNumRows
         && comparator.compare(sortedRows1.get(numSortedRows1 - 1), sortedRows2.get(0)) <= 0)) {
-      return;
+      return sortedRows1;
     }
     int numRowsToMerge = Math.min(numSortedRows1 + numSortedRows2, maxNumRows);
     List<Object[]> mergedRows = new ArrayList<>(numRowsToMerge);
@@ -350,7 +355,7 @@ public class SelectionOperatorUtils {
         mergedRows.addAll(sortedRows2.subList(i2, i2 + numRowsToMerge - numMergedRows));
       }
     }
-    mergedBlock.setRows(mergedRows);
+    return mergedRows;
   }
 
   /**

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/selection/SelectionOrderByTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/selection/SelectionOrderByTest.java
@@ -1,0 +1,390 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.core.query.selection;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.core.query.aggregation.function.AbstractAggregationFunctionTest;
+import org.apache.pinot.queries.FluentQueryTest;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+
+public class SelectionOrderByTest extends AbstractAggregationFunctionTest {
+
+  @Test
+  public void list() {
+    FluentQueryTest.withBaseDir(_baseDir)
+        .withNullHandling(false)
+        .givenTable(SINGLE_FIELD_NULLABLE_DIMENSION_SCHEMAS.get(FieldSpec.DataType.INT), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(
+            new Object[]{1},
+            new Object[]{3}
+        )
+        .andOnSecondInstance(
+            new Object[]{2},
+            new Object[]{null}
+        )
+        .whenQuery("select myField from testTable order by myField")
+        .thenResultIs("INTEGER",
+            "-2147483648",
+            "1",
+            "2",
+            "3"
+        );
+  }
+
+  @Test
+  public void listNullHandlingEnabled() {
+    FluentQueryTest.withBaseDir(_baseDir)
+        .withNullHandling(true)
+        .givenTable(SINGLE_FIELD_NULLABLE_DIMENSION_SCHEMAS.get(FieldSpec.DataType.INT), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(
+            new Object[]{1},
+            new Object[]{3}
+        )
+        .andOnSecondInstance(
+            new Object[]{2},
+            new Object[]{null}
+        )
+        .whenQuery("select myField from testTable order by myField")
+        .thenResultIs("INTEGER",
+            "1",
+            "2",
+            "3",
+            "null"
+        );
+  }
+
+  @Test
+  public void listTwoFields() {
+    FluentQueryTest.withBaseDir(_baseDir)
+        .withNullHandling(false)
+        .givenTable(TWO_FIELDS_NULLABLE_DIMENSION_SCHEMAS.get(FieldSpec.DataType.INT), TWO_FIELDS_TABLE_CONFIG)
+        .onFirstInstance(
+            new Object[]{1, 5},
+            new Object[]{3, 4}
+        )
+        .andOnSecondInstance(
+            new Object[]{2, 3},
+            new Object[]{null, null}
+        )
+        .whenQuery("select field1, field2 from testTable2 order by field1")
+        .thenResultIs("INTEGER|INTEGER",
+            "-2147483648|-2147483648",
+            "1|5",
+            "2|3",
+            "3|4"
+        );
+  }
+
+  @Test
+  public void listTwoFieldsNullHandlingEnabled() {
+    FluentQueryTest.withBaseDir(_baseDir)
+        .withNullHandling(true)
+        .givenTable(TWO_FIELDS_NULLABLE_DIMENSION_SCHEMAS.get(FieldSpec.DataType.INT), TWO_FIELDS_TABLE_CONFIG)
+        .onFirstInstance(
+            new Object[]{1, 5},
+            new Object[]{3, 4}
+        )
+        .andOnSecondInstance(
+            new Object[]{2, 3},
+            new Object[]{null, 2}
+        )
+        .whenQuery("select field1, field2 from testTable2 order by field1")
+        .thenResultIs("INTEGER|INTEGER",
+            "1|5",
+            "2|3",
+            "3|4",
+            "null|2"
+        );
+  }
+
+  @Test
+  public void listTwoFieldsNullHandlingEnabledNullsFirst() {
+    FluentQueryTest.withBaseDir(_baseDir)
+        .withNullHandling(true)
+        .givenTable(TWO_FIELDS_NULLABLE_DIMENSION_SCHEMAS.get(FieldSpec.DataType.INT), TWO_FIELDS_TABLE_CONFIG)
+        .onFirstInstance(
+            new Object[]{1, 5},
+            new Object[]{3, 4}
+        )
+        .andOnSecondInstance(
+            new Object[]{2, 3},
+            new Object[]{null, 2}
+        )
+        .whenQuery("select field1, field2 from testTable2 order by field1 nulls first")
+        .thenResultIs("INTEGER|INTEGER",
+            "null|2",
+            "1|5",
+            "2|3",
+            "3|4"
+        );
+  }
+
+  @Test
+  public void listTwoFieldsDesc() {
+    FluentQueryTest.withBaseDir(_baseDir)
+        .withNullHandling(false)
+        .givenTable(TWO_FIELDS_NULLABLE_DIMENSION_SCHEMAS.get(FieldSpec.DataType.INT), TWO_FIELDS_TABLE_CONFIG)
+        .onFirstInstance(
+            new Object[]{1, 5},
+            new Object[]{3, 4}
+        )
+        .andOnSecondInstance(
+            new Object[]{2, 3},
+            new Object[]{null, null}
+        )
+        .whenQuery("select field1, field2 from testTable2 order by field1 desc")
+        .thenResultIs("INTEGER|INTEGER",
+            "3|4",
+            "2|3",
+            "1|5",
+            "-2147483648|-2147483648"
+        );
+  }
+
+  @Test
+  public void listTwoFieldsNullHandlingEnabledDesc() {
+    FluentQueryTest.withBaseDir(_baseDir)
+        .withNullHandling(true)
+        .givenTable(TWO_FIELDS_NULLABLE_DIMENSION_SCHEMAS.get(FieldSpec.DataType.INT), TWO_FIELDS_TABLE_CONFIG)
+        .onFirstInstance(
+            new Object[]{1, 5},
+            new Object[]{4, 4}
+        )
+        .andOnSecondInstance(
+            new Object[]{2, 3},
+            new Object[]{3, 0},
+            new Object[]{null, 2}
+        )
+        .whenQuery("select field1, field2 from testTable2 order by field1 desc")
+        .thenResultIs("INTEGER|INTEGER",
+            "null|2",
+            "4|4",
+            "3|0",
+            "2|3",
+            "1|5"
+        );
+  }
+
+  @Test
+  public void listTwoFieldsNullHandlingEnabledDescNullsLast() {
+    FluentQueryTest.withBaseDir(_baseDir)
+        .withNullHandling(true)
+        .givenTable(TWO_FIELDS_NULLABLE_DIMENSION_SCHEMAS.get(FieldSpec.DataType.INT), TWO_FIELDS_TABLE_CONFIG)
+        .onFirstInstance(
+            new Object[]{1, 5},
+            new Object[]{4, 4}
+        )
+        .andOnSecondInstance(
+            new Object[]{2, 3},
+            new Object[]{3, 0},
+            new Object[]{null, 2}
+        )
+        .whenQuery("select field1, field2 from testTable2 order by field1 desc nulls last")
+        .thenResultIs("INTEGER|INTEGER",
+            "4|4",
+            "3|0",
+            "2|3",
+            "1|5",
+            "null|2"
+        );
+  }
+
+  @Test
+  public void listSortonTwoFields() {
+    FluentQueryTest.withBaseDir(_baseDir)
+        .withNullHandling(false)
+        .givenTable(TWO_FIELDS_NULLABLE_DIMENSION_SCHEMAS.get(FieldSpec.DataType.INT), TWO_FIELDS_TABLE_CONFIG)
+        .onFirstInstance(
+            new Object[]{1, 5},
+            new Object[]{3, 4},
+            new Object[]{2, 4}
+        )
+        .andOnSecondInstance(
+            new Object[]{2, 3},
+            new Object[]{null, 2}
+        )
+        .whenQuery("select field1, field2 from testTable2 order by field1, field2")
+        .thenResultIs("INTEGER|INTEGER",
+            "-2147483648|2",
+            "1|5",
+            "2|3",
+            "2|4",
+            "3|4"
+        );
+  }
+
+  @Test
+  public void listSortonTwoFieldsNullHandlingEnabled() {
+    FluentQueryTest.withBaseDir(_baseDir)
+        .withNullHandling(true)
+        .givenTable(TWO_FIELDS_NULLABLE_DIMENSION_SCHEMAS.get(FieldSpec.DataType.INT), TWO_FIELDS_TABLE_CONFIG)
+        .onFirstInstance(
+            new Object[]{1, 5},
+            new Object[]{3, 4},
+            new Object[]{2, 4},
+            new Object[]{null, 4}
+        )
+        .andOnSecondInstance(
+            new Object[]{2, 3},
+            new Object[]{null, 2}
+        )
+        .whenQuery("select field1, field2 from testTable2 order by field1, field2")
+        .thenResultIs("INTEGER|INTEGER",
+            "1|5",
+            "2|3",
+            "2|4",
+            "3|4",
+            "null|2",
+            "null|4"
+        );
+  }
+
+  @Test
+  public void listSortonTwoFieldsOneDesc() {
+    FluentQueryTest.withBaseDir(_baseDir)
+        .withNullHandling(false)
+        .givenTable(TWO_FIELDS_NULLABLE_DIMENSION_SCHEMAS.get(FieldSpec.DataType.INT), TWO_FIELDS_TABLE_CONFIG)
+        .onFirstInstance(
+            new Object[]{1, 5},
+            new Object[]{3, 4},
+            new Object[]{2, 4},
+            new Object[]{null, 4}
+        )
+        .andOnSecondInstance(
+            new Object[]{2, 3},
+            new Object[]{null, 2}
+        )
+        .whenQuery("select field1, field2 from testTable2 order by field1 desc, field2")
+        .thenResultIs("INTEGER|INTEGER",
+            "3|4",
+            "2|3",
+            "2|4",
+            "1|5",
+            "-2147483648|2",
+            "-2147483648|4"
+        );
+  }
+
+  @Test
+  public void listSortonTwoFieldsNullHandlingEnabledOneDesc() {
+    FluentQueryTest.withBaseDir(_baseDir)
+        .withNullHandling(true)
+        .givenTable(TWO_FIELDS_NULLABLE_DIMENSION_SCHEMAS.get(FieldSpec.DataType.INT), TWO_FIELDS_TABLE_CONFIG)
+        .onFirstInstance(
+            new Object[]{1, 5},
+            new Object[]{3, 4},
+            new Object[]{2, 4},
+            new Object[]{null, 4}
+        )
+        .andOnSecondInstance(
+            new Object[]{2, 3},
+            new Object[]{null, 2}
+        )
+        .whenQuery("select field1, field2 from testTable2 order by field1 desc, field2")
+        .thenResultIs("INTEGER|INTEGER",
+            "null|2",
+            "null|4",
+            "3|4",
+            "2|3",
+            "2|4",
+            "1|5"
+        );
+  }
+
+  // TODO: test ordered index scans
+
+  // utils ---
+
+  @DataProvider(name = "nullHandlingEnabled")
+  public Object[][] nullHandlingEnabled() {
+    return new Object[][]{
+        {false}, {true}
+    };
+  }
+
+  private static final FieldSpec.DataType[] VALID_DATA_TYPES = new FieldSpec.DataType[]{
+      FieldSpec.DataType.INT,
+      FieldSpec.DataType.LONG,
+      FieldSpec.DataType.FLOAT,
+      FieldSpec.DataType.DOUBLE,
+      FieldSpec.DataType.STRING,
+      FieldSpec.DataType.BYTES,
+      FieldSpec.DataType.BIG_DECIMAL,
+      FieldSpec.DataType.TIMESTAMP,
+      FieldSpec.DataType.BOOLEAN
+  };
+
+  protected static final Map<FieldSpec.DataType, Schema> SINGLE_FIELD_NULLABLE_DIMENSION_SCHEMAS =
+      Arrays.stream(VALID_DATA_TYPES)
+          .collect(Collectors.toMap(dt -> dt, dt -> new Schema.SchemaBuilder()
+              .setSchemaName("testTable")
+              .setEnableColumnBasedNullHandling(true)
+              .addDimensionField("myField", dt, f -> f.setNullable(true))
+              .build()));
+
+  protected static final Map<FieldSpec.DataType, Schema> TWO_FIELDS_NULLABLE_DIMENSION_SCHEMAS =
+      Arrays.stream(VALID_DATA_TYPES)
+          .collect(Collectors.toMap(dt -> dt, dt -> new Schema.SchemaBuilder()
+              .setSchemaName("testTable2")
+              .setEnableColumnBasedNullHandling(true)
+              .addDimensionField("field1", dt, f -> f.setNullable(true))
+              .addDimensionField("field2", dt, f -> f.setNullable(true))
+              .build()));
+
+  protected static final TableConfig SINGLE_FIELD_TABLE_CONFIG = new TableConfigBuilder(TableType.OFFLINE)
+      .setTableName("testTable")
+      .build();
+
+  protected static final TableConfig TWO_FIELDS_TABLE_CONFIG = new TableConfigBuilder(TableType.OFFLINE)
+      .setTableName("testTable")
+      .build();
+
+  @BeforeClass
+  void createBaseDir() {
+    try {
+      _baseDir = Files.createTempDirectory(getClass().getSimpleName()).toFile();
+    } catch (IOException ex) {
+      throw new UncheckedIOException(ex);
+    }
+  }
+
+  @AfterClass
+  void destroyBaseDir()
+      throws IOException {
+    if (_baseDir != null) {
+      FileUtils.deleteDirectory(_baseDir);
+    }
+  }
+}


### PR DESCRIPTION
Previously, the `SelectionDataTableReducer` is blind to server's output sorting. It performs redundant sort when merging multiple dataTables.

This PR introduces a metadata of block sorting. When a SelectionResultBlock is created, the `orderByExpressions` metadata is supplied if it is sorted. The value of this metadata is simply the string representation of the orderby expressions.

Then in SelectionOperatorService [here](https://github.com/apache/pinot/compare/master...songwdfu:sort-merge-server-results?expand=1#:~:text=if%20(String,%2C%20dataTable)%3B), the broker checks for this metadata and perform mergeWithOrdering on sorted output. If the server output is not sorted, the broker sorts it as before.
