### PR TITLE
[timeseries] Returning empty timeseries response for empty time buckets

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/TimeSeriesRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/TimeSeriesRequestHandler.java
@@ -119,6 +119,10 @@ public class TimeSeriesRequestHandler extends BaseBrokerRequestHandler {
         return PinotBrokerTimeSeriesResponse.newErrorResponse("BAD_REQUEST", "Error building RangeTimeSeriesRequest");
       }
       TimeSeriesLogicalPlanResult logicalPlanResult = _queryEnvironment.buildLogicalPlan(timeSeriesRequest);
+      // If there are no buckets in the logical plan, return an empty response.
+      if (logicalPlanResult.getTimeBuckets().getNumBuckets() == 0) {
+        return PinotBrokerTimeSeriesResponse.newEmptyResponse();
+      }
       TimeSeriesDispatchablePlan dispatchablePlan =
           _queryEnvironment.buildPhysicalPlan(timeSeriesRequest, requestContext, logicalPlanResult);
       timeSeriesResponse = _queryDispatcher.submitAndGet(requestContext, dispatchablePlan,

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/PinotBrokerTimeSeriesResponse.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/PinotBrokerTimeSeriesResponse.java
@@ -89,6 +89,10 @@ public class PinotBrokerTimeSeriesResponse {
     return OBJECT_MAPPER.writeValueAsString(this);
   }
 
+  public static PinotBrokerTimeSeriesResponse newEmptyResponse() {
+    return new PinotBrokerTimeSeriesResponse(SUCCESS_STATUS, Data.EMPTY, null, null);
+  }
+
   public static PinotBrokerTimeSeriesResponse newSuccessResponse(Data data) {
     return new PinotBrokerTimeSeriesResponse(SUCCESS_STATUS, data, null, null);
   }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/TimeSeriesIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/TimeSeriesIntegrationTest.java
@@ -166,6 +166,19 @@ public class TimeSeriesIntegrationTest extends BaseClusterIntegrationTest {
     );
   }
 
+  @Test
+  public void testStartTimeEqualsEndTimeQuery() {
+    String query = String.format(
+      "fetch{table=\"mytable_OFFLINE\",filter=\"\",ts_column=\"%s\",ts_unit=\"MILLISECONDS\",value=\"%s\"}"
+        + " | max{%s} | transformNull{0} | keepLastValue{}",
+      TS_COLUMN, TOTAL_TRIPS_COLUMN, DEVICE_OS_COLUMN
+    );
+    JsonNode result = getTimeseriesQuery(query, QUERY_START_TIME_SEC, QUERY_START_TIME_SEC, getHeaders());
+    assertEquals(result.get("status").asText(), "success");
+    JsonNode series = result.get("data").get("result");
+    assertEquals(series.size(), 0);
+  }
+
   protected Map<String, String> getHeaders() {
     return Collections.emptyMap();
   }


### PR DESCRIPTION
## Summary

Currently, the timeseries engine returns 
```
"{"status":"error","data":null,"errorType":"ArrayIndexOutOfBoundsException","error":"Index 0 out of bounds for length 0"}"
```
when the `start` and `end` times are equal, which is cryptic and does not readily highlight the root cause.
This PR fixes this to return an empty success timeseries response in this scenario since there is no data included when `start` and `end` are equal.

## Testing
Added a `testStartTimeEqualsEndTime` integration test to cover this scenario.