### PR TITLE
Remove usages of 'schemaName' from example and test table configs

### DIFF
--- a/compatibility-verifier/multi-stage-query-engine-test-suite/config/feature-test-2-realtime.json
+++ b/compatibility-verifier/multi-stage-query-engine-test-suite/config/feature-test-2-realtime.json
@@ -20,7 +20,6 @@
     "replication": "1",
     "retentionTimeUnit": "",
     "retentionTimeValue": "",
-    "schemaName": "FeatureTest2",
     "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
     "segmentPushFrequency": "daily",
     "segmentPushType": "APPEND",

--- a/compatibility-verifier/sample-test-suite/config/feature-test-2-realtime.json
+++ b/compatibility-verifier/sample-test-suite/config/feature-test-2-realtime.json
@@ -20,7 +20,6 @@
     "replication": "1",
     "retentionTimeUnit": "",
     "retentionTimeValue": "",
-    "schemaName": "FeatureTest2",
     "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
     "segmentPushFrequency": "daily",
     "segmentPushType": "APPEND",

--- a/compatibility-verifier/sample-test-suite/config/feature-test-3-realtime.json
+++ b/compatibility-verifier/sample-test-suite/config/feature-test-3-realtime.json
@@ -42,7 +42,6 @@
     "replication": "1",
     "retentionTimeUnit": "",
     "retentionTimeValue": "",
-    "schemaName": "FeatureTest3",
     "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
     "segmentPushFrequency": "daily",
     "segmentPushType": "APPEND",

--- a/contrib/pinot-druid-benchmark/README.md
+++ b/contrib/pinot-druid-benchmark/README.md
@@ -114,7 +114,6 @@ For this command above you'll need the following configuration files:
   "tableName": "tpch_lineitem",
   "segmentsConfig" : {
     "replication" : "1",
-    "schemaName" : "tpch_lineitem",
     "segmentAssignmentStrategy" : "BalanceNumSegmentAssignmentStrategy"
   },
   "tenants" : {

--- a/contrib/pinot-druid-benchmark/src/main/resources/config/pinot_table.json
+++ b/contrib/pinot-druid-benchmark/src/main/resources/config/pinot_table.json
@@ -2,7 +2,6 @@
   "tableName": "tpch_lineitem",
   "segmentsConfig" : {
     "replication" : "1",
-    "schemaName" : "tpch_lineitem",
     "segmentAssignmentStrategy" : "BalanceNumSegmentAssignmentStrategy"
   },
   "tenants" : {

--- a/docker/images/pinot/examples/docker/table-configs/airlineStats_realtime_table_config.json
+++ b/docker/images/pinot/examples/docker/table-configs/airlineStats_realtime_table_config.json
@@ -8,7 +8,6 @@
     "retentionTimeValue": "5",
     "segmentPushType": "APPEND",
     "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
-    "schemaName": "airlineStats",
     "replication": "1",
     "replicasPerPartition": "1"
   },

--- a/docker/images/pinot/examples/docker/table-configs/meetupRsvp_realtime_table_config.json
+++ b/docker/images/pinot/examples/docker/table-configs/meetupRsvp_realtime_table_config.json
@@ -6,7 +6,6 @@
     "timeType": "MILLISECONDS",
     "segmentPushType": "APPEND",
     "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
-    "schemaName": "meetupRsvp",
     "replication": "1",
     "replicasPerPartition": "1"
   },

--- a/helm/pinot/pinot-github-events-setup.yml
+++ b/helm/pinot/pinot-github-events-setup.yml
@@ -32,7 +32,6 @@ data:
         "timeType": "MILLISECONDS",
         "retentionTimeUnit": "DAYS",
         "retentionTimeValue": "60",
-        "schemaName": "pullRequestMergedEvents",
         "replication": "1",
         "replicasPerPartition": "1"
       },

--- a/helm/pinot/pinot-realtime-quickstart.yml
+++ b/helm/pinot/pinot-realtime-quickstart.yml
@@ -34,7 +34,6 @@ data:
         "retentionTimeValue": "3650",
         "segmentPushType": "APPEND",
         "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
-        "schemaName": "airlineStats",
         "replication": "1",
         "replicasPerPartition": "1"
       },
@@ -70,7 +69,6 @@ data:
         "retentionTimeValue": "3650",
         "segmentPushType": "APPEND",
         "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
-        "schemaName": "airlineStatsAvro",
         "replication": "1",
         "replicasPerPartition": "1"
       },

--- a/pinot-common/src/test/resources/testConfigs/jsonIndexConfig.json
+++ b/pinot-common/src/test/resources/testConfigs/jsonIndexConfig.json
@@ -2,7 +2,6 @@
   "tableName": "testTable",
   "segmentsConfig": {
     "replication": "1",
-    "schemaName": "testTable",
     "timeColumnName": "time"
   },
   "fieldConfigList": [

--- a/pinot-common/src/test/resources/testConfigs/multipleIndexConfig.json
+++ b/pinot-common/src/test/resources/testConfigs/multipleIndexConfig.json
@@ -2,7 +2,6 @@
   "tableName": "testTable",
   "segmentsConfig": {
     "replication": "1",
-    "schemaName": "testTable",
     "timeColumnName": "time"
   },
   "fieldConfigList": [

--- a/pinot-common/src/test/resources/testConfigs/multipleIndexPartialUpsertConfig.json
+++ b/pinot-common/src/test/resources/testConfigs/multipleIndexPartialUpsertConfig.json
@@ -2,7 +2,6 @@
   "tableName": "testTableUpsert",
   "segmentsConfig": {
     "replication": "1",
-    "schemaName": "testTable",
     "timeColumnName": "time"
   },
   "fieldConfigList": [

--- a/pinot-common/src/test/resources/testConfigs/multipleIndexPartialUpsertMultipleComparisonColumnConfig.json
+++ b/pinot-common/src/test/resources/testConfigs/multipleIndexPartialUpsertMultipleComparisonColumnConfig.json
@@ -2,7 +2,6 @@
   "tableName": "testTableUpsertMultiComparison",
   "segmentsConfig": {
     "replication": "1",
-    "schemaName": "testTable",
     "timeColumnName": "time"
   },
   "fieldConfigList": [

--- a/pinot-common/src/test/resources/testConfigs/noIndexConfig.json
+++ b/pinot-common/src/test/resources/testConfigs/noIndexConfig.json
@@ -2,7 +2,6 @@
   "tableName": "testTable",
   "segmentsConfig": {
     "replication": "1",
-    "schemaName": "testTable",
     "timeColumnName": "time"
   },
   "fieldConfigList": [

--- a/pinot-common/src/test/resources/testConfigs/rangeIndexConfig.json
+++ b/pinot-common/src/test/resources/testConfigs/rangeIndexConfig.json
@@ -2,7 +2,6 @@
   "tableName": "testTable",
   "segmentsConfig": {
     "replication": "1",
-    "schemaName": "testTable",
     "timeColumnName": "time"
   },
   "fieldConfigList": [

--- a/pinot-common/src/test/resources/testConfigs/textIndexConfig.json
+++ b/pinot-common/src/test/resources/testConfigs/textIndexConfig.json
@@ -2,7 +2,6 @@
   "tableName": "testTable",
   "segmentsConfig": {
     "replication": "1",
-    "schemaName": "testTable",
     "timeColumnName": "time"
   },
   "fieldConfigList": [

--- a/pinot-connectors/pinot-flink-connector/src/test/resources/fixtures/pinotTableConfigLowLevel.json
+++ b/pinot-connectors/pinot-flink-connector/src/test/resources/fixtures/pinotTableConfigLowLevel.json
@@ -7,7 +7,6 @@
     "segmentPushFrequency" : null,
     "segmentPushType" : "APPEND",
     "replication" : "2",
-    "schemaName" : "demand",
     "timeColumnName" : "timestamp",
     "segmentAssignmentStrategy" : "BalanceNumSegmentAssignmentStrategy",
     "replicaGroupStrategyConfig" : null,

--- a/pinot-controller/src/main/resources/app/components/Homepage/Operations/AddOfflineTableOp.tsx
+++ b/pinot-controller/src/main/resources/app/components/Homepage/Operations/AddOfflineTableOp.tsx
@@ -65,7 +65,6 @@ const defaultTableObj = {
     "server": "DefaultTenant"
   },
   "segmentsConfig": {
-    "schemaName": "",
     "timeColumnName": null,
     "replication": "1",
     "replicasPerPartition": "1",

--- a/pinot-controller/src/main/resources/app/components/Homepage/Operations/AddRealtimeTableOp.tsx
+++ b/pinot-controller/src/main/resources/app/components/Homepage/Operations/AddRealtimeTableOp.tsx
@@ -68,7 +68,6 @@ const defaultTableObj = {
     "tagOverrideConfig": {}
   },
   "segmentsConfig": {
-    "schemaName": "",
     "timeColumnName": null,
     "replication": "1",
     "replicasPerPartition": "1",

--- a/pinot-controller/src/test/resources/memory_estimation/table-config-for-upsert.json
+++ b/pinot-controller/src/test/resources/memory_estimation/table-config-for-upsert.json
@@ -13,7 +13,6 @@
     "replication": "3",
     "retentionTimeUnit": "DAYS",
     "retentionTimeValue": "5",
-    "schemaName": "restletTable_UPSERT",
     "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
     "segmentPushFrequency": "daily",
     "segmentPushType": "APPEND",

--- a/pinot-controller/src/test/resources/memory_estimation/table-config.json
+++ b/pinot-controller/src/test/resources/memory_estimation/table-config.json
@@ -9,7 +9,6 @@
     "replication": "3",
     "retentionTimeUnit": "DAYS",
     "retentionTimeValue": "5",
-    "schemaName": "testTable",
     "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
     "segmentPushFrequency": "daily",
     "segmentPushType": "APPEND",

--- a/pinot-integration-tests/src/test/resources/simpleMeetup_realtime_table_config.json
+++ b/pinot-integration-tests/src/test/resources/simpleMeetup_realtime_table_config.json
@@ -6,7 +6,6 @@
     "timeType": "MILLISECONDS",
     "segmentPushType": "APPEND",
     "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
-    "schemaName": "upsertMeetupRsvp",
     "replicasPerPartition": "1",
     "replicaGroupStrategyConfig": {
       "partitionColumn": "event_id",

--- a/pinot-tools/src/main/resources/conf/sample_realtime_table_config.json
+++ b/pinot-tools/src/main/resources/conf/sample_realtime_table_config.json
@@ -8,7 +8,6 @@
     "retentionTimeValue": "5",
     "segmentPushType": "APPEND",
     "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
-    "schemaName": "schemaName",
     "replication": "3",
     "replicasPerPartition": "1"
   },

--- a/pinot-tools/src/main/resources/examples/batch/baseballStats/baseballStats_offline_table_config.json
+++ b/pinot-tools/src/main/resources/examples/batch/baseballStats/baseballStats_offline_table_config.json
@@ -4,7 +4,6 @@
   "segmentsConfig": {
     "segmentPushType": "APPEND",
     "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
-    "schemaName": "baseballStats",
     "replication": "1"
   },
   "tenants": {

--- a/pinot-tools/src/main/resources/examples/batch/billing/billing_offline_table_config.json
+++ b/pinot-tools/src/main/resources/examples/batch/billing/billing_offline_table_config.json
@@ -1,8 +1,7 @@
 {
   "tableName": "billing",
   "segmentsConfig" : {
-    "replication" : "1",
-    "schemaName" : "billing"
+    "replication" : "1"
   },
   "tableIndexConfig" : {
     "invertedIndexColumns" : [],

--- a/pinot-tools/src/main/resources/examples/batch/clientSalaryNulls/clientSalaryNulls_offline_table_config.json
+++ b/pinot-tools/src/main/resources/examples/batch/clientSalaryNulls/clientSalaryNulls_offline_table_config.json
@@ -1,8 +1,7 @@
 {
   "tableName": "clientSalaryNulls",
   "segmentsConfig" : {
-    "replication" : "1",
-    "schemaName" : "clientSalaryNulls"
+    "replication" : "1"
   },
   "tableIndexConfig" : {
     "invertedIndexColumns" : [],

--- a/pinot-tools/src/main/resources/examples/batch/fineFoodReviews/fineFoodReviews_offline_table_config.json
+++ b/pinot-tools/src/main/resources/examples/batch/fineFoodReviews/fineFoodReviews_offline_table_config.json
@@ -4,7 +4,6 @@
   "segmentsConfig": {
     "segmentPushType": "APPEND",
     "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
-    "schemaName": "fineFoodReviews",
     "replication": "1"
   },
   "tenants": {

--- a/pinot-tools/src/main/resources/examples/batch/ssb/customer/customer_offline_table_config.json
+++ b/pinot-tools/src/main/resources/examples/batch/ssb/customer/customer_offline_table_config.json
@@ -5,8 +5,7 @@
   },
   "segmentsConfig": {
     "segmentPushType": "REFRESH",
-    "replication": "1",
-    "schemaName": "customer"
+    "replication": "1"
   },
   "tableIndexConfig": {
     "loadMode": "MMAP"

--- a/pinot-tools/src/main/resources/examples/batch/ssb/dates/dates_offline_table_config.json
+++ b/pinot-tools/src/main/resources/examples/batch/ssb/dates/dates_offline_table_config.json
@@ -5,8 +5,7 @@
   },
   "segmentsConfig": {
     "segmentPushType": "REFRESH",
-    "replication": "1",
-    "schemaName": "dates"
+    "replication": "1"
   },
   "tableIndexConfig": {
     "loadMode": "MMAP"

--- a/pinot-tools/src/main/resources/examples/batch/ssb/lineorder/lineorder_offline_table_config.json
+++ b/pinot-tools/src/main/resources/examples/batch/ssb/lineorder/lineorder_offline_table_config.json
@@ -5,8 +5,7 @@
   },
   "segmentsConfig": {
     "segmentPushType": "REFRESH",
-    "replication": "1",
-    "schemaName": "lineorder"
+    "replication": "1"
   },
   "tableIndexConfig": {
     "loadMode": "MMAP"

--- a/pinot-tools/src/main/resources/examples/batch/ssb/part/part_offline_table_config.json
+++ b/pinot-tools/src/main/resources/examples/batch/ssb/part/part_offline_table_config.json
@@ -5,8 +5,7 @@
   },
   "segmentsConfig": {
     "segmentPushType": "REFRESH",
-    "replication": "1",
-    "schemaName": "part"
+    "replication": "1"
   },
   "tableIndexConfig": {
     "loadMode": "MMAP"

--- a/pinot-tools/src/main/resources/examples/batch/ssb/supplier/supplier_offline_table_config.json
+++ b/pinot-tools/src/main/resources/examples/batch/ssb/supplier/supplier_offline_table_config.json
@@ -5,8 +5,7 @@
   },
   "segmentsConfig": {
     "segmentPushType": "REFRESH",
-    "replication": "1",
-    "schemaName": "supplier"
+    "replication": "1"
   },
   "tableIndexConfig": {
     "loadMode": "MMAP"

--- a/pinot-tools/src/main/resources/examples/batch/starbucksStores/starbucksStores_offline_table_config.json
+++ b/pinot-tools/src/main/resources/examples/batch/starbucksStores/starbucksStores_offline_table_config.json
@@ -6,7 +6,6 @@
     "retentionTimeValue": "1",
     "segmentPushType": "APPEND",
     "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
-    "schemaName": "starbucksStores",
     "replication": "1"
   },
   "tenants": {

--- a/pinot-tools/src/main/resources/examples/batch/tpch/customer/customer_offline_table_config.json
+++ b/pinot-tools/src/main/resources/examples/batch/tpch/customer/customer_offline_table_config.json
@@ -5,8 +5,7 @@
   },
   "segmentsConfig": {
     "segmentPushType": "REFRESH",
-    "replication": "1",
-    "schemaName": "customer"
+    "replication": "1"
   },
   "tableIndexConfig": {
     "loadMode": "MMAP",

--- a/pinot-tools/src/main/resources/examples/batch/tpch/lineitem/lineitem_offline_table_config.json
+++ b/pinot-tools/src/main/resources/examples/batch/tpch/lineitem/lineitem_offline_table_config.json
@@ -5,8 +5,7 @@
   },
   "segmentsConfig": {
     "segmentPushType": "REFRESH",
-    "replication": "1",
-    "schemaName": "lineitem"
+    "replication": "1"
   },
   "tableIndexConfig": {
     "loadMode": "MMAP",

--- a/pinot-tools/src/main/resources/examples/batch/tpch/nation/nation_offline_table_config.json
+++ b/pinot-tools/src/main/resources/examples/batch/tpch/nation/nation_offline_table_config.json
@@ -5,8 +5,7 @@
   },
   "segmentsConfig": {
     "segmentPushType": "REFRESH",
-    "replication": "1",
-    "schemaName": "nation"
+    "replication": "1"
   },
   "tableIndexConfig": {
     "loadMode": "MMAP",

--- a/pinot-tools/src/main/resources/examples/batch/tpch/orders/orders_offline_table_config.json
+++ b/pinot-tools/src/main/resources/examples/batch/tpch/orders/orders_offline_table_config.json
@@ -5,8 +5,7 @@
   },
   "segmentsConfig": {
     "segmentPushType": "REFRESH",
-    "replication": "1",
-    "schemaName": "orders"
+    "replication": "1"
   },
   "tableIndexConfig": {
     "loadMode": "MMAP",

--- a/pinot-tools/src/main/resources/examples/batch/tpch/part/part_offline_table_config.json
+++ b/pinot-tools/src/main/resources/examples/batch/tpch/part/part_offline_table_config.json
@@ -5,8 +5,7 @@
   },
   "segmentsConfig": {
     "segmentPushType": "REFRESH",
-    "replication": "1",
-    "schemaName": "part"
+    "replication": "1"
   },
   "tableIndexConfig": {
     "loadMode": "MMAP",

--- a/pinot-tools/src/main/resources/examples/batch/tpch/partsupp/partsupp_offline_table_config.json
+++ b/pinot-tools/src/main/resources/examples/batch/tpch/partsupp/partsupp_offline_table_config.json
@@ -5,8 +5,7 @@
   },
   "segmentsConfig": {
     "segmentPushType": "REFRESH",
-    "replication": "1",
-    "schemaName": "partsupp"
+    "replication": "1"
   },
   "tableIndexConfig": {
     "loadMode": "MMAP",

--- a/pinot-tools/src/main/resources/examples/batch/tpch/region/region_offline_table_config.json
+++ b/pinot-tools/src/main/resources/examples/batch/tpch/region/region_offline_table_config.json
@@ -5,8 +5,7 @@
   },
   "segmentsConfig": {
     "segmentPushType": "REFRESH",
-    "replication": "1",
-    "schemaName": "region"
+    "replication": "1"
   },
   "tableIndexConfig": {
     "loadMode": "MMAP",

--- a/pinot-tools/src/main/resources/examples/batch/tpch/supplier/supplier_offline_table_config.json
+++ b/pinot-tools/src/main/resources/examples/batch/tpch/supplier/supplier_offline_table_config.json
@@ -5,8 +5,7 @@
   },
   "segmentsConfig": {
     "segmentPushType": "REFRESH",
-    "replication": "1",
-    "schemaName": "supplier"
+    "replication": "1"
   },
   "tableIndexConfig": {
     "loadMode": "MMAP",

--- a/pinot-tools/src/main/resources/examples/minions/batch/baseballStats/baseballStats_offline_table_config.json
+++ b/pinot-tools/src/main/resources/examples/minions/batch/baseballStats/baseballStats_offline_table_config.json
@@ -4,7 +4,6 @@
   "segmentsConfig": {
     "segmentPushType": "APPEND",
     "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
-    "schemaName": "baseballStats",
     "replication": "1"
   },
   "tenants": {

--- a/pinot-tools/src/main/resources/examples/minions/stream/githubEvents/githubEvents_offline_table_config.json
+++ b/pinot-tools/src/main/resources/examples/minions/stream/githubEvents/githubEvents_offline_table_config.json
@@ -5,7 +5,6 @@
     "timeColumnName": "created_at_timestamp",
     "segmentPushType": "APPEND",
     "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
-    "schemaName": "githubEvents",
     "replication": "1"
   },
   "tenants": {

--- a/pinot-tools/src/main/resources/examples/minions/stream/githubEvents/githubEvents_realtime_table_config.json
+++ b/pinot-tools/src/main/resources/examples/minions/stream/githubEvents/githubEvents_realtime_table_config.json
@@ -5,7 +5,6 @@
     "timeColumnName": "created_at_timestamp",
     "segmentPushType": "APPEND",
     "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
-    "schemaName": "githubEvents",
     "replication": "1",
     "replicasPerPartition": "1"
   },

--- a/pinot-tools/src/main/resources/examples/stream/airlineStats/docker/airlineStats_realtime_table_config.json
+++ b/pinot-tools/src/main/resources/examples/stream/airlineStats/docker/airlineStats_realtime_table_config.json
@@ -8,7 +8,6 @@
     "retentionTimeValue": "5",
     "segmentPushType": "APPEND",
     "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
-    "schemaName": "airlineStats",
     "replication": "1",
     "replicasPerPartition": "1"
   },

--- a/pinot-tools/src/main/resources/generator/complexWebsite_config.json
+++ b/pinot-tools/src/main/resources/generator/complexWebsite_config.json
@@ -2,7 +2,6 @@
   "tableName": "complexWebsite",
   "segmentsConfig": {
     "replication": "1",
-    "schemaName": "complexWebsite",
     "timeColumnName": "hoursSinceEpoch"
   },
   "tableIndexConfig": {

--- a/pinot-tools/src/main/resources/generator/simpleWebsite_config.json
+++ b/pinot-tools/src/main/resources/generator/simpleWebsite_config.json
@@ -2,7 +2,6 @@
   "tableName": "simpleWebsite",
   "segmentsConfig": {
     "replication": "1",
-    "schemaName": "simpleWebsite",
     "timeColumnName": "hoursSinceEpoch"
   },
   "tableIndexConfig": {


### PR DESCRIPTION
- This property was deprecated a while ago and removed completely in https://github.com/apache/pinot/pull/15333.
- This patch cleans up dangling usages in example and test table configs.