### PR TITLE
Add withTableProperties to Get Tenant Table API

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTenantRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTenantRestletResource.java
@@ -394,7 +394,8 @@ public class PinotTenantRestletResource {
     }
   }
 
-  private String getTablesServedFromServerTenant(String tenantName, @Nullable String database, boolean withTableProperties) {
+  private String getTablesServedFromServerTenant(String tenantName, @Nullable String database,
+      boolean withTableProperties) {
     Set<String> tables = new HashSet<>();
     Set<TenantTableWithProperties> tablePropertiesMap = withTableProperties ? new HashSet<>() : null;
     ObjectNode resourceGetRet = JsonUtils.newObjectNode();

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTenantRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTenantRestletResource.java
@@ -32,6 +32,7 @@ import io.swagger.annotations.SecurityDefinition;
 import io.swagger.annotations.SwaggerDefinition;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -129,6 +130,7 @@ public class PinotTenantRestletResource {
   private static final Logger LOGGER = LoggerFactory.getLogger(PinotTenantRestletResource.class);
   private static final String TENANT_NAME = "tenantName";
   private static final String TABLES = "tables";
+  public static final String TABLES_WITH_PROPERTIES = "tablesWithProperties";
 
   @Inject
   PinotHelixResourceManager _pinotHelixResourceManager;
@@ -397,7 +399,7 @@ public class PinotTenantRestletResource {
   private String getTablesServedFromServerTenant(String tenantName, @Nullable String database,
       boolean withTableProperties) {
     Set<String> tables = new HashSet<>();
-    Set<TenantTableWithProperties> tablePropertiesMap = withTableProperties ? new HashSet<>() : null;
+    Map<String, TenantTableWithProperties> tablePropertiesMap = withTableProperties ? new HashMap<>() : null;
     ObjectNode resourceGetRet = JsonUtils.newObjectNode();
 
     for (String tableNameWithType : _pinotHelixResourceManager.getAllTables(database)) {
@@ -417,14 +419,14 @@ public class PinotTenantRestletResource {
           }
           TenantTableWithProperties tableWithProperties = new TenantTableWithProperties(tableConfig,
               idealState.getRecord().getMapFields(), _tableSizeReader);
-          tablePropertiesMap.add(tableWithProperties);
+          tablePropertiesMap.put(tableConfig.getTableName(), tableWithProperties);
         }
       }
     }
 
     resourceGetRet.set(TABLES, JsonUtils.objectToJsonNode(tables));
     if (withTableProperties) {
-      resourceGetRet.set("tablesWithProperties", JsonUtils.objectToJsonNode(tablePropertiesMap));
+      resourceGetRet.set(TABLES_WITH_PROPERTIES, JsonUtils.objectToJsonNode(tablePropertiesMap.values()));
     }
     return resourceGetRet.toString();
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTenantRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTenantRestletResource.java
@@ -53,6 +53,7 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
+import org.apache.helix.model.IdealState;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.pinot.common.assignment.InstancePartitions;
 import org.apache.pinot.common.assignment.InstancePartitionsUtils;
@@ -70,6 +71,8 @@ import org.apache.pinot.controller.helix.core.rebalance.tenant.TenantRebalanceCo
 import org.apache.pinot.controller.helix.core.rebalance.tenant.TenantRebalanceProgressStats;
 import org.apache.pinot.controller.helix.core.rebalance.tenant.TenantRebalanceResult;
 import org.apache.pinot.controller.helix.core.rebalance.tenant.TenantRebalancer;
+import org.apache.pinot.controller.helix.core.rebalance.tenant.TenantTableWithProperties;
+import org.apache.pinot.controller.util.TableSizeReader;
 import org.apache.pinot.core.auth.Actions;
 import org.apache.pinot.core.auth.Authorize;
 import org.apache.pinot.core.auth.TargetType;
@@ -135,6 +138,9 @@ public class PinotTenantRestletResource {
 
   @Inject
   TenantRebalancer _tenantRebalancer;
+
+  @Inject
+  TableSizeReader _tableSizeReader;
 
   @POST
   @Path("/tenants")
@@ -295,9 +301,11 @@ public class PinotTenantRestletResource {
       @ApiParam(value = "Tenant name", required = true) @PathParam("tenantName") String tenantName,
       @ApiParam(value = "Tenant type (server|broker)",
           required = false, allowableValues = "BROKER, SERVER", defaultValue = "SERVER")
-      @QueryParam("type") String tenantType, @Context HttpHeaders headers) {
+      @QueryParam("type") String tenantType,
+      @QueryParam("withTableProperties") @DefaultValue("false") boolean withTableProperties,
+      @Context HttpHeaders headers) {
     if (tenantType == null || tenantType.isEmpty() || tenantType.equalsIgnoreCase("server")) {
-      return getTablesServedFromServerTenant(tenantName, headers.getHeaderString(DATABASE));
+      return getTablesServedFromServerTenant(tenantName, headers.getHeaderString(DATABASE), withTableProperties);
     } else if (tenantType.equalsIgnoreCase("broker")) {
       return getTablesServedFromBrokerTenant(tenantName, headers.getHeaderString(DATABASE));
     } else {
@@ -386,23 +394,37 @@ public class PinotTenantRestletResource {
     }
   }
 
-  private String getTablesServedFromServerTenant(String tenantName, @Nullable String database) {
+  private String getTablesServedFromServerTenant(String tenantName, @Nullable String database, boolean withTableProperties) {
     Set<String> tables = new HashSet<>();
+    Set<TenantTableWithProperties> tablePropertiesMap = withTableProperties ? new HashSet<>() : null;
     ObjectNode resourceGetRet = JsonUtils.newObjectNode();
 
-    for (String table : _pinotHelixResourceManager.getAllTables(database)) {
-      TableConfig tableConfig = _pinotHelixResourceManager.getTableConfig(table);
+    for (String tableNameWithType : _pinotHelixResourceManager.getAllTables(database)) {
+      TableConfig tableConfig = _pinotHelixResourceManager.getTableConfig(tableNameWithType);
       if (tableConfig == null) {
-        LOGGER.error("Unable to retrieve table config for table: {}", table);
+        LOGGER.error("Unable to retrieve table config for table: {}", tableNameWithType);
         continue;
       }
       Set<String> relevantTags = TableConfigUtils.getRelevantTags(tableConfig);
       if (relevantTags.contains(TagNameUtils.getServerTagForTenant(tenantName, tableConfig.getTableType()))) {
-        tables.add(table);
+        tables.add(tableNameWithType);
+        if (withTableProperties) {
+          IdealState idealState = _pinotHelixResourceManager.getTableIdealState(tableNameWithType);
+          if (idealState == null) {
+            LOGGER.error("Unable to retrieve ideal state for table: {}", tableNameWithType);
+            continue;
+          }
+          TenantTableWithProperties tableWithProperties = new TenantTableWithProperties(tableConfig,
+              idealState.getRecord().getMapFields(), _tableSizeReader);
+          tablePropertiesMap.add(tableWithProperties);
+        }
       }
     }
 
     resourceGetRet.set(TABLES, JsonUtils.objectToJsonNode(tables));
+    if (withTableProperties) {
+      resourceGetRet.set("tablesWithProperties", JsonUtils.objectToJsonNode(tablePropertiesMap));
+    }
     return resourceGetRet.toString();
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTenantRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTenantRestletResource.java
@@ -32,7 +32,6 @@ import io.swagger.annotations.SecurityDefinition;
 import io.swagger.annotations.SwaggerDefinition;
 import java.io.IOException;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTenantRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTenantRestletResource.java
@@ -399,7 +399,7 @@ public class PinotTenantRestletResource {
   private String getTablesServedFromServerTenant(String tenantName, @Nullable String database,
       boolean withTableProperties) {
     Set<String> tables = new HashSet<>();
-    Map<String, TenantTableWithProperties> tablePropertiesMap = withTableProperties ? new HashMap<>() : null;
+    Set<TenantTableWithProperties> tablePropertiesSet = withTableProperties ? new HashSet<>() : null;
     ObjectNode resourceGetRet = JsonUtils.newObjectNode();
 
     for (String tableNameWithType : _pinotHelixResourceManager.getAllTables(database)) {
@@ -419,14 +419,14 @@ public class PinotTenantRestletResource {
           }
           TenantTableWithProperties tableWithProperties = new TenantTableWithProperties(tableConfig,
               idealState.getRecord().getMapFields(), _tableSizeReader);
-          tablePropertiesMap.put(tableConfig.getTableName(), tableWithProperties);
+          tablePropertiesSet.add(tableWithProperties);
         }
       }
     }
 
     resourceGetRet.set(TABLES, JsonUtils.objectToJsonNode(tables));
     if (withTableProperties) {
-      resourceGetRet.set(TABLES_WITH_PROPERTIES, JsonUtils.objectToJsonNode(tablePropertiesMap.values()));
+      resourceGetRet.set(TABLES_WITH_PROPERTIES, JsonUtils.objectToJsonNode(tablePropertiesSet));
     }
     return resourceGetRet.toString();
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/tenant/TenantTableWithProperties.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/tenant/TenantTableWithProperties.java
@@ -26,7 +26,6 @@ import org.apache.pinot.common.exception.InvalidConfigException;
 import org.apache.pinot.controller.util.TableSizeReader;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
-import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/tenant/TenantTableWithProperties.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/tenant/TenantTableWithProperties.java
@@ -1,0 +1,166 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core.rebalance.tenant;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Map;
+import org.apache.pinot.common.exception.InvalidConfigException;
+import org.apache.pinot.controller.util.TableSizeReader;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Class to hold table properties when listing tables for a tenant during rebalancing.
+ * This class contains pre-defined properties of a table that are relevant
+ * for making include/exclude decisions during tenant rebalance operations.
+ * The properties focus on factors that could impact rebalance performance and stability.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class TenantTableWithProperties {
+  // Basic table identification
+  private static final Logger LOGGER = LoggerFactory.getLogger(TenantTableWithProperties.class);
+
+  private String _tableNameWithType;
+  private TableType _tableType;
+  private boolean _isDimTable;
+  private int _replication;
+  private int _totalSegments;
+  private long _estimatedTableSizeInBytes;
+  private boolean _isUpsertEnabled;
+  private boolean _isDedupEnabled;
+
+  private static final int TABLE_SIZE_READER_TIMEOUT_MS = 10000; // 10 seconds
+
+  @JsonCreator
+  public TenantTableWithProperties(
+      @JsonProperty("tableNameWithType") String tableNameWithType,
+      @JsonProperty("tableType") TableType tableType,
+      @JsonProperty("isDimTable") boolean isDimTable,
+      @JsonProperty("replication") int replication,
+      @JsonProperty("totalSegments") int totalSegments,
+      @JsonProperty("estimatedTableSizeInBytes") long estimatedTableSizeInBytes,
+      @JsonProperty("isUpsertEnabled") boolean isUpsertEnabled,
+      @JsonProperty("isDedupEnabled") boolean isDedupEnabled) {
+    _tableNameWithType = tableNameWithType;
+    _tableType = tableType;
+    _isDimTable = isDimTable;
+    _replication = replication;
+    _totalSegments = totalSegments;
+    _estimatedTableSizeInBytes = estimatedTableSizeInBytes;
+    _isUpsertEnabled = isUpsertEnabled;
+    _isDedupEnabled = isDedupEnabled;
+  }
+
+  public TenantTableWithProperties(TableConfig tableConfig, Map<String, Map<String, String>> idealStateInstanceStateMap,
+      TableSizeReader tableSizeReader) {
+    _tableNameWithType = tableConfig.getTableName();
+    _tableType = tableConfig.getTableType();
+    _isDimTable = tableConfig.isDimTable();
+    _replication = Integer.MAX_VALUE;
+    for (Map<String, String> instanceState : idealStateInstanceStateMap.values()) {
+      _replication = Math.min(instanceState.size(), _replication);
+    }
+    if (_replication == Integer.MAX_VALUE) {
+      _replication = 0; // No instances available
+    }
+    try {
+      _totalSegments = idealStateInstanceStateMap.size();
+      TableSizeReader.TableSubTypeSizeDetails sizeDetails =
+          tableSizeReader.getTableSubtypeSize(_tableNameWithType, TABLE_SIZE_READER_TIMEOUT_MS, false);
+      _estimatedTableSizeInBytes = sizeDetails._estimatedSizeInBytes;
+    } catch (InvalidConfigException e) {
+      LOGGER.warn("Failed to read table size for table: {}", _tableNameWithType, e);
+      _estimatedTableSizeInBytes = -1; // Indicate failure to read size
+    }
+    _isUpsertEnabled = tableConfig.isUpsertEnabled();
+    _isDedupEnabled = tableConfig.isDedupEnabled();
+  }
+
+  // Basic table identification getters/setters
+  public String getTableNameWithType() {
+    return _tableNameWithType;
+  }
+
+  public void setTableNameWithType(String tableNameWithType) {
+    _tableNameWithType = tableNameWithType;
+  }
+
+  public TableType getTableType() {
+    return _tableType;
+  }
+
+  public void setTableType(TableType tableType) {
+    _tableType = tableType;
+  }
+
+  public boolean isDimTable() {
+    return _isDimTable;
+  }
+
+  public void setDimTable(boolean dimTable) {
+    _isDimTable = dimTable;
+  }
+
+  // Rebalance impact indicators getters/setters
+  public int getReplication() {
+    return _replication;
+  }
+
+  public void setReplication(int replication) {
+    _replication = replication;
+  }
+
+  public int getTotalSegments() {
+    return _totalSegments;
+  }
+
+  public void setTotalSegments(int totalSegments) {
+    _totalSegments = totalSegments;
+  }
+
+  public long getEstimatedTableSizeInBytes() {
+    return _estimatedTableSizeInBytes;
+  }
+
+  public void setEstimatedTableSizeInBytes(long estimatedTableSizeInBytes) {
+    _estimatedTableSizeInBytes = estimatedTableSizeInBytes;
+  }
+
+  public boolean isUpsertEnabled() {
+    return _isUpsertEnabled;
+  }
+
+  public void setUpsertEnabled(boolean upsertEnabled) {
+    _isUpsertEnabled = upsertEnabled;
+  }
+
+  public boolean isDedupEnabled() {
+    return _isDedupEnabled;
+  }
+
+  public void setDedupEnabled(boolean dedupEnabled) {
+    _isDedupEnabled = dedupEnabled;
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/tenant/TenantTableWithProperties.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/tenant/TenantTableWithProperties.java
@@ -41,14 +41,22 @@ public class TenantTableWithProperties {
   // Basic table identification
   private static final Logger LOGGER = LoggerFactory.getLogger(TenantTableWithProperties.class);
 
-  private String _tableNameWithType;
-  private TableType _tableType;
-  private boolean _isDimTable;
-  private int _replication;
-  private int _totalSegments;
-  private long _estimatedTableSizeInBytes;
-  private boolean _isUpsertEnabled;
-  private boolean _isDedupEnabled;
+  @JsonProperty("tableNameWithType")
+  private final String _tableNameWithType;
+  @JsonProperty("tableType")
+  private final TableType _tableType;
+  @JsonProperty("isDimTable")
+  private final boolean _isDimTable;
+  @JsonProperty("replication")
+  private final int _replication;
+  @JsonProperty("totalSegments")
+  private final int _totalSegments;
+  @JsonProperty("estimatedTableSizeInBytes")
+  private final long _estimatedTableSizeInBytes;
+  @JsonProperty("isUpsertEnabled")
+  private final boolean _isUpsertEnabled;
+  @JsonProperty("isDedupEnabled")
+  private final boolean _isDedupEnabled;
 
   private static final int TABLE_SIZE_READER_TIMEOUT_MS = 10000; // 10 seconds
 
@@ -74,92 +82,22 @@ public class TenantTableWithProperties {
 
   public TenantTableWithProperties(TableConfig tableConfig, Map<String, Map<String, String>> idealStateInstanceStateMap,
       TableSizeReader tableSizeReader) {
+    long estimatedTableSizeInBytes;
     _tableNameWithType = tableConfig.getTableName();
     _tableType = tableConfig.getTableType();
     _isDimTable = tableConfig.isDimTable();
-    _replication = Integer.MAX_VALUE;
-    for (Map<String, String> instanceState : idealStateInstanceStateMap.values()) {
-      _replication = Math.min(instanceState.size(), _replication);
-    }
-    if (_replication == Integer.MAX_VALUE) {
-      _replication = 0; // No instances available
-    }
+    _replication = tableConfig.getReplication();
+    _totalSegments = idealStateInstanceStateMap.size();
     try {
-      _totalSegments = idealStateInstanceStateMap.size();
       TableSizeReader.TableSubTypeSizeDetails sizeDetails =
           tableSizeReader.getTableSubtypeSize(_tableNameWithType, TABLE_SIZE_READER_TIMEOUT_MS, false);
-      _estimatedTableSizeInBytes = sizeDetails._estimatedSizeInBytes;
+      estimatedTableSizeInBytes = sizeDetails._estimatedSizeInBytes;
     } catch (InvalidConfigException e) {
       LOGGER.warn("Failed to read table size for table: {}", _tableNameWithType, e);
-      _estimatedTableSizeInBytes = -1; // Indicate failure to read size
+      estimatedTableSizeInBytes = -1; // Indicate failure to read size
     }
+    _estimatedTableSizeInBytes = estimatedTableSizeInBytes;
     _isUpsertEnabled = tableConfig.isUpsertEnabled();
     _isDedupEnabled = tableConfig.isDedupEnabled();
-  }
-
-  // Basic table identification getters/setters
-  public String getTableNameWithType() {
-    return _tableNameWithType;
-  }
-
-  public void setTableNameWithType(String tableNameWithType) {
-    _tableNameWithType = tableNameWithType;
-  }
-
-  public TableType getTableType() {
-    return _tableType;
-  }
-
-  public void setTableType(TableType tableType) {
-    _tableType = tableType;
-  }
-
-  public boolean isDimTable() {
-    return _isDimTable;
-  }
-
-  public void setDimTable(boolean dimTable) {
-    _isDimTable = dimTable;
-  }
-
-  // Rebalance impact indicators getters/setters
-  public int getReplication() {
-    return _replication;
-  }
-
-  public void setReplication(int replication) {
-    _replication = replication;
-  }
-
-  public int getTotalSegments() {
-    return _totalSegments;
-  }
-
-  public void setTotalSegments(int totalSegments) {
-    _totalSegments = totalSegments;
-  }
-
-  public long getEstimatedTableSizeInBytes() {
-    return _estimatedTableSizeInBytes;
-  }
-
-  public void setEstimatedTableSizeInBytes(long estimatedTableSizeInBytes) {
-    _estimatedTableSizeInBytes = estimatedTableSizeInBytes;
-  }
-
-  public boolean isUpsertEnabled() {
-    return _isUpsertEnabled;
-  }
-
-  public void setUpsertEnabled(boolean upsertEnabled) {
-    _isUpsertEnabled = upsertEnabled;
-  }
-
-  public boolean isDedupEnabled() {
-    return _isDedupEnabled;
-  }
-
-  public void setDedupEnabled(boolean dedupEnabled) {
-    _isDedupEnabled = dedupEnabled;
   }
 }


### PR DESCRIPTION
# Add withTableProperties to Get Tenant Table API

## Summary

Adds `withTableProperties` query parameter to `/tenants/{tenantName}/tables` API to support Tenant Rebalance UI. When enabled, returns table properties (replication, segments, size, upsert status) needed for users to make include/exclude decisions during tenant rebalance operations.

## Changes

- Added `withTableProperties` parameter (default: false) to existing API
- Returns `tablesWithProperties` array with table metadata when enabled
- Includes: replication, totalSegments, estimatedTableSizeInBytes, upsertEnabled, dimTable, dedupEnabled
- Fully backward compatible

## Example Response

```json
{
  "tables": [
    "meetupRsvpJson_REALTIME",
    "meetupRsvp_REALTIME"
  ],
  "tablesWithProperties": [
    {
      "tableNameWithType": "meetupRsvpJson_REALTIME",
      "tableType": "REALTIME",
      "replication": 1,
      "totalSegments": 17,
      "estimatedTableSizeInBytes": 339089,
      "upsertEnabled": false,
      "dimTable": false,
      "dedupEnabled": false
    },
    {
      "tableNameWithType": "meetupRsvp_REALTIME",
      "tableType": "REALTIME",
      "replication": 1,
      "totalSegments": 18,
      "estimatedTableSizeInBytes": 212912,
      "upsertEnabled": false,
      "dimTable": false,
      "dedupEnabled": false
    },
  ]
}
```

## API Usage

```
GET /tenants/{tenantName}/tables?type=SERVER&withTableProperties=true
```

