### PR TITLE
Introduce rlsFiltersApplied in the broker response

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/querylog/QueryLogger.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/querylog/QueryLogger.java
@@ -338,9 +338,7 @@ public class QueryLogger {
     RLS_FILTERS_APPLIED("rlsFiltersApplied") {
       @Override
       void doFormat(StringBuilder builder, QueryLogger logger, QueryLogParams params) {
-        if (params._response.getRLSFiltersApplied()) {
-          builder.append(params._response.getRLSFiltersApplied());
-        }
+        builder.append(params._response.getRLSFiltersApplied());
       }
     };
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/querylog/QueryLogger.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/querylog/QueryLogger.java
@@ -334,6 +334,14 @@ public class QueryLogger {
       void doFormat(StringBuilder builder, QueryLogger logger, QueryLogParams params) {
           builder.append(params._response.getPools());
       }
+    },
+    RLS_FILTERS_APPLIED("rlsFiltersApplied") {
+      @Override
+      void doFormat(StringBuilder builder, QueryLogger logger, QueryLogParams params) {
+        if (params._response.getRLSFiltersApplied()) {
+          builder.append(params._response.getRLSFiltersApplied());
+        }
+      }
     };
 
     public final String _entryName;

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
@@ -456,6 +456,7 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
           try {
             CalciteSqlParser.queryRewrite(pinotQuery, RlsFiltersRewriter.class);
             rlsFiltersApplied.set(true);
+            _brokerMetrics.addMeteredTableValue(rawTableName, BrokerMeter.RLS_FILTERS_APPLIED, 1);
           } catch (Exception e) {
             LOGGER.error(
                 "Unable to apply RLS filter: {}. Row-level security filtering will be disabled for this query.",

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -356,6 +356,7 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
                     rowFilters.stream().map(filter -> "( " + filter + " )").collect(Collectors.joining(" AND "));
                 String key = RlsUtils.buildRlsFilterKey(tableName);
                 compiledQuery.getOptions().put(key, combinedFilters);
+                _brokerMetrics.addMeteredTableValue(tableName, BrokerMeter.RLS_FILTERS_APPLIED, 1);
               });
         }
       }

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/querylog/QueryLoggerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/querylog/QueryLoggerTest.java
@@ -116,6 +116,7 @@ public class QueryLoggerTest {
         + "offlineMemAllocatedBytes(total/thread/resSer):0/0/0,"
         + "realtimeMemAllocatedBytes(total/thread/resSer):0/0/0,"
         + "pools=[],"
+        + "rlsFiltersApplied=true,"
         + "query=SELECT * FROM foo");
     //@formatter:on
   }
@@ -278,6 +279,7 @@ public class QueryLoggerTest {
     response.setRealtimeSystemActivitiesCpuTimeNs(18);
     response.setRealtimeResponseSerializationCpuTimeNs(19);
     response.setBrokerReduceTimeMs(20);
+    response.setRLSFiltersApplied(true);
 
     RequesterIdentity identity = new RequesterIdentity() {
       @Override

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerMeter.java
@@ -256,6 +256,8 @@ public class BrokerMeter implements AbstractMetrics.Meter {
   public static final BrokerMeter GRPC_TRANSPORT_TERMINATED = create(
       "GRPC_TRANSPORT_TERMINATED", "grpcTransport", true);
 
+  public static final BrokerMeter RLS_FILTERS_APPLIED = create("RLS_FILTERS_APPLIED", "queries", false);
+
   private static final Map<QueryErrorCode, BrokerMeter> QUERY_ERROR_CODE_METER_MAP;
 
   // Iterate through all query error codes from QueryErrorCode.getAllValues() and create a metric for each

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/BrokerResponse.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/BrokerResponse.java
@@ -406,4 +406,16 @@ public interface BrokerResponse {
    * @return
    */
   Set<Integer> getPools();
+
+  /**
+   * Set whether RLS (row level security) filters were applied to the query.
+   * @param rlsFiltersApplied true if RLS filters were applied, false otherwise
+   */
+  void setRLSFiltersApplied(boolean rlsFiltersApplied);
+
+  /**
+   * Get whether RLS (row level security) filters were applied to the query.
+   * @return true if RLS filters were applied, false otherwise
+   */
+  boolean getRLSFiltersApplied();
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNative.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNative.java
@@ -56,7 +56,7 @@ import org.apache.pinot.spi.utils.JsonUtils;
     "explainPlanNumEmptyFilterSegments", "explainPlanNumMatchAllFilterSegments", "traceInfo", "tablesQueried",
     "offlineThreadMemAllocatedBytes", "realtimeThreadMemAllocatedBytes", "offlineResponseSerMemAllocatedBytes",
     "realtimeResponseSerMemAllocatedBytes", "offlineTotalMemAllocatedBytes", "realtimeTotalMemAllocatedBytes",
-    "pools"
+    "pools", "rlsFiltersApplied"
 })
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class BrokerResponseNative implements BrokerResponse {
@@ -115,6 +115,7 @@ public class BrokerResponseNative implements BrokerResponse {
   private Set<String> _tablesQueried = Set.of();
 
   private Set<Integer> _pools = Set.of();
+  private boolean _rlsFiltersApplied = false;
 
   public BrokerResponseNative() {
   }
@@ -578,5 +579,15 @@ public class BrokerResponseNative implements BrokerResponse {
   @NotNull
   public Set<Integer> getPools() {
     return _pools;
+  }
+
+  @Override
+  public void setRLSFiltersApplied(boolean rlsFiltersApplied) {
+    _rlsFiltersApplied = rlsFiltersApplied;
+  }
+
+  @Override
+  public boolean getRLSFiltersApplied() {
+    return _rlsFiltersApplied;
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNativeV2.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNativeV2.java
@@ -51,7 +51,7 @@ import org.apache.pinot.common.response.ProcessingException;
     "explainPlanNumEmptyFilterSegments", "explainPlanNumMatchAllFilterSegments", "traceInfo", "tablesQueried",
     "offlineThreadMemAllocatedBytes", "realtimeThreadMemAllocatedBytes", "offlineResponseSerMemAllocatedBytes",
     "realtimeResponseSerMemAllocatedBytes", "offlineTotalMemAllocatedBytes", "realtimeTotalMemAllocatedBytes",
-    "pools"
+    "pools", "rlsFiltersApplied"
 })
 public class BrokerResponseNativeV2 implements BrokerResponse {
   private final StatMap<StatKey> _brokerStats = new StatMap<>(StatKey.class);
@@ -83,6 +83,7 @@ public class BrokerResponseNativeV2 implements BrokerResponse {
   private Set<String> _tablesQueried = Set.of();
 
   private Set<Integer> _pools = Set.of();
+  private boolean _rlsFiltersApplied = false;
 
   @JsonInclude(JsonInclude.Include.NON_NULL)
   @Nullable
@@ -403,6 +404,16 @@ public class BrokerResponseNativeV2 implements BrokerResponse {
   @NotNull
   public Set<Integer> getPools() {
     return _pools;
+  }
+
+  @Override
+  public void setRLSFiltersApplied(boolean rlsFiltersApplied) {
+    _rlsFiltersApplied = rlsFiltersApplied;
+  }
+
+  @Override
+  public boolean getRLSFiltersApplied() {
+    return _rlsFiltersApplied;
   }
 
   public void addBrokerStats(StatMap<StatKey> brokerStats) {


### PR DESCRIPTION
This PR introduces a new rlsFiltersApplied field in the broker response to provide visibility into whether Row Level Security (RLS) filters were applied during query execution. It adds metrics and improves logging for better debugging. 

## Changes in broker response

 - Adds rlsFiltersApplied boolean field to broker response metadata
 - Indicates to clients whether RLS policies filtered the query results
 
 
 ## Metric
 - RLS_FILTERS_APPLIED to track the count of queries that have filters applied. 

### How to use the metric
 - We can track the rate(RLS_FILTERS_APPLIED{table = "tableName}[5m]) to know whether queries have filter applied or not. 

### Why not use gauge
 - Gauge problems: A gauge that flips between 0/1 on each query would fluctuate rapidly in high-QPS environments where some users have RLS filters while others don't, making the metric unusable for analysis
 - Counter advantages: Provides cumulative data that can be used with rate() functions to calculate meaningful per-second metrics and percentage calculations (using query count on the table)