### PR TITLE
[MSE] Merge join operator - Part I

### DIFF
--- a/pinot-common/src/main/proto/plan.proto
+++ b/pinot-common/src/main/proto/plan.proto
@@ -92,6 +92,7 @@ enum JoinStrategy {
   HASH = 0;
   LOOKUP = 1;
   AS_OF = 2;
+  MERGE = 3;
 }
 
 message JoinNode {
@@ -101,6 +102,7 @@ message JoinNode {
   repeated Expression nonEquiConditions = 4;
   JoinStrategy joinStrategy = 5;
   Expression matchCondition = 6;
+  repeated Collation collations = 7;
 }
 
 enum ExchangeType {

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/hint/PinotHintOptions.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/hint/PinotHintOptions.java
@@ -87,6 +87,8 @@ public class PinotHintOptions {
     public static final String DYNAMIC_BROADCAST_JOIN_STRATEGY = "dynamic_broadcast";
     // "lookup" can be used when the right table is a dimension table replicated to all workers
     public static final String LOOKUP_JOIN_STRATEGY = "lookup";
+    // "merge" can be used when both inputs are sorted on the same collation on a superset of the join keys
+    public static final String MERGE_JOIN_STRATEGY = "merge";
 
     public static final String LEFT_DISTRIBUTION_TYPE = "left_distribution_type";
     public static final String RIGHT_DISTRIBUTION_TYPE = "right_distribution_type";
@@ -126,6 +128,10 @@ public class PinotHintOptions {
     // TODO: Consider adding a Join implementation with join strategy.
     public static boolean useLookupJoinStrategy(Join join) {
       return LOOKUP_JOIN_STRATEGY.equalsIgnoreCase(getJoinStrategyHint(join));
+    }
+
+    public static boolean useMergeJoin(Join join) {
+      return MERGE_JOIN_STRATEGY.equalsIgnoreCase(getJoinStrategyHint(join));
     }
 
     @Nullable

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/explain/PlanNodeMerger.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/explain/PlanNodeMerger.java
@@ -196,6 +196,9 @@ class PlanNodeMerger {
       if (!node.getNonEquiConditions().equals(otherNode.getNonEquiConditions())) {
         return null;
       }
+      if (!Objects.equals(node.getCollations(), otherNode.getCollations())) {
+        return null;
+      }
       List<PlanNode> children = mergeChildren(node, context);
       if (children == null) {
         return null;

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/EquivalentStagesFinder.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/EquivalentStagesFinder.java
@@ -255,6 +255,7 @@ public class EquivalentStagesFinder {
             && Objects.equals(node1.getLeftKeys(), that.getLeftKeys())
             && Objects.equals(node1.getRightKeys(), that.getRightKeys())
             && Objects.equals(node1.getNonEquiConditions(), that.getNonEquiConditions())
+            && Objects.equals(node1.getCollations(), that.getCollations())
             && node1.getJoinStrategy() == that.getJoinStrategy();
       }
 

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/PRelToPlanNodeConverter.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/PRelToPlanNodeConverter.java
@@ -272,7 +272,7 @@ public class PRelToPlanNodeConverter {
         "ASOF_JOIN only supports match conditions with a comparison between two columns of the same type");
     return new JoinNode(DEFAULT_STAGE_ID, dataSchema, NodeHint.fromRelHints(join.getHints()), inputs, joinType,
         joinInfo.leftKeys, joinInfo.rightKeys, RexExpressionUtils.fromRexNodes(joinInfo.nonEquiConditions),
-        JoinNode.JoinStrategy.ASOF, RexExpressionUtils.fromRexNode(join.getMatchCondition()));
+        JoinNode.JoinStrategy.ASOF, RexExpressionUtils.fromRexNode(join.getMatchCondition()), null);
   }
 
   public static DataSchema toDataSchema(RelDataType rowType) {

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/plannode/JoinNode.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/plannode/JoinNode.java
@@ -21,6 +21,7 @@ package org.apache.pinot.query.planner.plannode;
 import java.util.List;
 import java.util.Objects;
 import javax.annotation.Nullable;
+import org.apache.calcite.rel.RelFieldCollation;
 import org.apache.calcite.rel.core.JoinRelType;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.query.planner.logical.RexExpression;
@@ -34,16 +35,19 @@ public class JoinNode extends BasePlanNode {
   private final JoinStrategy _joinStrategy;
   @Nullable
   private final RexExpression _matchCondition;
+  @Nullable
+  private final List<RelFieldCollation> _collations;
 
   public JoinNode(int stageId, DataSchema dataSchema, NodeHint nodeHint, List<PlanNode> inputs, JoinRelType joinType,
       List<Integer> leftKeys, List<Integer> rightKeys, List<RexExpression> nonEquiConditions,
       JoinStrategy joinStrategy) {
-    this(stageId, dataSchema, nodeHint, inputs, joinType, leftKeys, rightKeys, nonEquiConditions, joinStrategy, null);
+    this(stageId, dataSchema, nodeHint, inputs, joinType, leftKeys, rightKeys, nonEquiConditions, joinStrategy, null,
+        null);
   }
 
   public JoinNode(int stageId, DataSchema dataSchema, NodeHint nodeHint, List<PlanNode> inputs, JoinRelType joinType,
       List<Integer> leftKeys, List<Integer> rightKeys, List<RexExpression> nonEquiConditions,
-      JoinStrategy joinStrategy, RexExpression matchCondition) {
+      JoinStrategy joinStrategy, RexExpression matchCondition, List<RelFieldCollation> collations) {
     super(stageId, dataSchema, nodeHint, inputs);
     _joinType = joinType;
     _leftKeys = leftKeys;
@@ -51,6 +55,7 @@ public class JoinNode extends BasePlanNode {
     _nonEquiConditions = nonEquiConditions;
     _joinStrategy = joinStrategy;
     _matchCondition = matchCondition;
+    _collations = collations;
   }
 
   public JoinRelType getJoinType() {
@@ -74,6 +79,11 @@ public class JoinNode extends BasePlanNode {
   }
 
   @Nullable
+  public List<RelFieldCollation> getCollations() {
+    return _collations;
+  }
+
+  @Nullable
   public RexExpression getMatchCondition() {
     return _matchCondition;
   }
@@ -91,7 +101,7 @@ public class JoinNode extends BasePlanNode {
   @Override
   public PlanNode withInputs(List<PlanNode> inputs) {
     return new JoinNode(_stageId, _dataSchema, _nodeHint, inputs, _joinType, _leftKeys, _rightKeys, _nonEquiConditions,
-        _joinStrategy, _matchCondition);
+        _joinStrategy, _matchCondition, _collations);
   }
 
   @Override
@@ -118,6 +128,6 @@ public class JoinNode extends BasePlanNode {
   }
 
   public enum JoinStrategy {
-    HASH, LOOKUP, ASOF
+    HASH, LOOKUP, ASOF, MERGE
   }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/serde/PlanNodeDeserializer.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/serde/PlanNodeDeserializer.java
@@ -104,7 +104,8 @@ public class PlanNodeDeserializer {
         protoJoinNode.getRightKeysList(), convertExpressions(protoJoinNode.getNonEquiConditionsList()),
         convertJoinStrategy(protoJoinNode.getJoinStrategy()),
         protoJoinNode.hasMatchCondition() ? ProtoExpressionToRexExpression.convertExpression(
-            protoJoinNode.getMatchCondition()) : null);
+            protoJoinNode.getMatchCondition()) : null,
+        protoJoinNode.getCollationsList().isEmpty() ? null : convertCollations(protoJoinNode.getCollationsList()));
   }
 
   private static MailboxReceiveNode deserializeMailboxReceiveNode(Plan.PlanNode protoNode) {

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/serde/PlanNodeSerializer.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/serde/PlanNodeSerializer.java
@@ -126,6 +126,9 @@ public class PlanNodeSerializer {
       if (node.getMatchCondition() != null) {
         joinNode.setMatchCondition(RexExpressionToProtoExpression.convertExpression(node.getMatchCondition()));
       }
+      if (node.getCollations() != null) {
+        joinNode.addAllCollations(convertCollations(node.getCollations()));
+      }
       builder.setJoinNode(joinNode.build());
       return null;
     }
@@ -309,6 +312,8 @@ public class PlanNodeSerializer {
           return Plan.JoinStrategy.LOOKUP;
         case ASOF:
           return Plan.JoinStrategy.AS_OF;
+        case MERGE:
+          return Plan.JoinStrategy.MERGE;
         default:
           throw new IllegalStateException("Unsupported JoinStrategy: " + joinStrategy);
       }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MergeJoinOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MergeJoinOperator.java
@@ -1,0 +1,225 @@
+package org.apache.pinot.query.runtime.operator;
+
+import com.google.common.base.Preconditions;
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Objects;
+import javax.annotation.Nullable;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.query.planner.partitioning.KeySelector;
+import org.apache.pinot.query.planner.partitioning.KeySelectorFactory;
+import org.apache.pinot.query.planner.plannode.JoinNode;
+import org.apache.pinot.query.runtime.blocks.MseBlock;
+import org.apache.pinot.query.runtime.blocks.RowHeapDataBlock;
+import org.apache.pinot.query.runtime.blocks.SuccessMseBlock;
+import org.apache.pinot.query.runtime.operator.utils.SortUtils;
+import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
+
+
+// TODO: implement
+// TODO: whether to sort in this operator? or require input to be sorted?
+public class MergeJoinOperator extends BaseJoinOperator {
+  private static final String EXPLAIN_NAME = "MERGE_JOIN";
+
+  // Placeholder for BitSet in _matchedRightRows when all keys are unique in the right table.
+  private static final BitSet BIT_SET_PLACEHOLDER = new BitSet(0);
+
+  private LinkedList<Object[]> _rightTable;
+  private LinkedList<Object[]> _rightLookahead;
+
+  private LinkedList<Object[]> _leftTable;
+  private LinkedList<Object[]> _leftLookahead;
+
+  private final KeySelector<?> _leftKeySelector;
+  private final KeySelector<?> _rightKeySelector;
+
+  private final Comparator<Object[]> _comparator;
+
+  private MseBlock.Eos _leftEos;
+  private MseBlock.Eos _rightEos;
+
+  private int _numRowsJoined;
+
+  public MergeJoinOperator(OpChainExecutionContext context,
+      MultiStageOperator leftInput, DataSchema leftSchema, MultiStageOperator rightInput,
+      JoinNode node) {
+    super(context, leftInput, leftSchema, rightInput, node);
+
+    List<Integer> leftKeys = node.getLeftKeys();
+    Preconditions.checkState(!leftKeys.isEmpty(), "Merge join operator requires join keys");
+    _leftKeySelector = KeySelectorFactory.getKeySelector(leftKeys);
+    List<Integer> rightKeys = node.getRightKeys();
+    Preconditions.checkState(!rightKeys.isEmpty(), "Merge join operator requires join keys");
+    _rightKeySelector = KeySelectorFactory.getKeySelector(rightKeys);
+
+    _comparator = SortUtils.SortComparator(node.getCollations(), false);
+
+    _numRowsJoined = 0;
+  }
+
+  @Override
+  protected MseBlock getNextBlock() {
+    while (true) {
+      if (_eos != null) {
+        onEosProduced();
+        return _eos;
+      }
+      getNextKeyGroup(_leftLookahead, _leftKeySelector, _leftTable, _leftInput, true);
+      // either side produce EOS.Error, terminate
+      if (_leftEos != null && _leftEos.isError()) {
+        onEosProduced();
+        return _leftEos;
+      }
+      getNextKeyGroup(_rightLookahead, _rightKeySelector, _rightTable, _rightInput, false);
+      if (_rightEos != null && _rightEos.isError()) {
+        onEosProduced();
+        return _rightEos;
+      }
+      // if either side is empty we are done
+      if (_leftTable.isEmpty() || _rightTable.isEmpty()) {
+        onEosProduced();
+        return SuccessMseBlock.INSTANCE;
+      }
+      List<Object[]> resultRows = joinKeyGroup();
+      // either side produce EOS.Success, join current group with rest of the other
+      if (!resultRows.isEmpty()) {
+        return new RowHeapDataBlock(resultRows, _resultSchema);
+      }
+    }
+  }
+
+  /**
+   * propagate key group with the next group of rows to be joined
+   * @param lookahead buffer for keeping fetched but not processed rows
+   * @param keySelector join key selector
+   * @param keyGroup buffer for next group of rows to be joined, should be of the same key
+   * @param input input operator
+   * @param leftEos whether to propagate _leftEos or _rightEos
+   */
+  protected void getNextKeyGroup(LinkedList<Object[]> lookahead, KeySelector<?> keySelector,
+      LinkedList<Object[]> keyGroup, MultiStageOperator input, boolean leftEos) {
+    // if current keyGroup is not advanced, no-op
+    if (!keyGroup.isEmpty()) {
+      return;
+    }
+    Object groupKey = null;
+    MseBlock.Eos eos = leftEos ? _leftEos : _rightEos;
+    while (true) {
+      while (!lookahead.isEmpty()) {
+        if (groupKey == null) {
+          Object[] row = lookahead.pollFirst();
+          groupKey = keySelector.getKey(row);
+          keyGroup.add(row);
+          continue;
+        }
+        // if next key is not in the same group, group is done
+        if (!groupKey.equals(keySelector.getKey(lookahead.getFirst()))) {
+          return;
+        }
+        keyGroup.add(lookahead.pollFirst());
+      }
+      Preconditions.checkState(eos == null); // this should be unreachable if this side already Eos
+      // lookahead is done but group is not, fetch more
+      MseBlock nextBlock = input.nextBlock();
+      // if we can't fetch, either error or done, at this time lookahead is also cleared
+      // but there might be a group to join in keyGroup
+      if (nextBlock.isEos()) {
+        if (leftEos) {
+          _leftEos = (MseBlock.Eos) nextBlock;
+        } else {
+          _rightEos = (MseBlock.Eos) nextBlock;
+        }
+        return;
+      }
+      // if we can fetch, continue building
+      MseBlock.Data dataBlock = (MseBlock.Data) nextBlock;
+      lookahead.addAll(dataBlock.asRowHeap().getRows());
+    }
+  }
+
+  protected List<Object[]> joinKeyGroup() {
+    Object[] leftFirstRow = _leftTable.getFirst();
+    Object[] rightFirstRow = _rightTable.getFirst();
+    Object leftKey = _leftKeySelector.getKey(leftFirstRow);
+    Object rightKey = _rightKeySelector.getKey(rightFirstRow);
+    if (!Objects.equals(leftKey, rightKey)) {
+      // advance the smaller or equal group (collation is subset of join key)
+      if (_comparator.compare(leftFirstRow, rightFirstRow) <= 0) {
+        _leftTable.clear();
+      } else {
+        _rightTable.clear();
+      }
+      return Collections.emptyList();
+    }
+    // key matches, return cartesian product
+    List<Object[]> resultRows = new ArrayList<>();
+    for (Object[] leftRow : _leftTable) {
+      for (Object[] rightRow : _rightTable) {
+        List<Object> joinedRowView = joinRowView(leftRow, rightRow);
+        if (matchNonEquiConditions(joinedRowView)) {
+          if (isMaxRowsLimitReached(_numRowsJoined++)) {
+            // if overflow break, return current joined rows
+            // left is terminated in isMaxRowsLimitReached, also terminate right input
+            earlyTerminateRightInput();
+            return resultRows;
+          }
+          resultRows.add(joinedRowView.toArray());
+        }
+      }
+    }
+    // advance both sides
+    _leftTable.clear();
+    _rightTable.clear();
+    return resultRows;
+  }
+
+  protected void earlyTerminateRightInput() {
+    _rightInput.earlyTerminate();
+    MseBlock rightBlock = _rightInput.nextBlock();
+
+    while (rightBlock.isData()) {
+      rightBlock = _rightInput.nextBlock();
+    }
+    _rightEos = (MseBlock.Eos) rightBlock;
+  }
+
+  @Override
+  protected void onEosProduced() {
+    // clear cached rows
+    _leftLookahead = null;
+    _leftTable = null;
+    _rightLookahead = null;
+    _rightTable = null;
+  }
+
+  // unused
+  @Override
+  protected void addRowsToRightTable(List<Object[]> rows) {
+  }
+
+  // unused
+  @Override
+  protected void finishBuildingRightTable() {
+  }
+
+  // unused
+  @Override
+  protected List<Object[]> buildJoinedRows(MseBlock.Data leftBlock) {
+    return List.of();
+  }
+
+  // unused
+  @Override
+  protected List<Object[]> buildNonMatchRightRows() {
+    return List.of();
+  }
+
+  @Override
+  public @Nullable String toExplainString() {
+    return EXPLAIN_NAME;
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/PlanNodeToOpChain.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/PlanNodeToOpChain.java
@@ -182,8 +182,6 @@ public class PlanNodeToOpChain {
       MultiStageOperator rightOperator = visit(right, context);
       JoinNode.JoinStrategy joinStrategy = node.getJoinStrategy();
       switch (joinStrategy) {
-        case MERGE:
-          // TODO: create MergeJoin operator
         case HASH:
           if (node.getLeftKeys().isEmpty()) {
             // TODO: Consider adding non-equi as a separate join strategy.

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/PlanNodeToOpChain.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/PlanNodeToOpChain.java
@@ -182,6 +182,8 @@ public class PlanNodeToOpChain {
       MultiStageOperator rightOperator = visit(right, context);
       JoinNode.JoinStrategy joinStrategy = node.getJoinStrategy();
       switch (joinStrategy) {
+        case MERGE:
+          // TODO: create MergeJoin operator
         case HASH:
           if (node.getLeftKeys().isEmpty()) {
             // TODO: Consider adding non-equi as a separate join strategy.

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MergeJoinOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MergeJoinOperatorTest.java
@@ -1,0 +1,696 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.operator;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.apache.calcite.rel.RelFieldCollation;
+import org.apache.calcite.rel.core.JoinRelType;
+import org.apache.pinot.calcite.rel.hint.PinotHintOptions;
+import org.apache.pinot.common.datatable.StatMap;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.query.planner.logical.RexExpression;
+import org.apache.pinot.query.planner.plannode.JoinNode;
+import org.apache.pinot.query.planner.plannode.PlanNode;
+import org.apache.pinot.query.routing.VirtualServerAddress;
+import org.apache.pinot.query.runtime.blocks.ErrorMseBlock;
+import org.apache.pinot.query.runtime.blocks.MseBlock;
+import org.apache.pinot.spi.exception.QueryErrorCode;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.openMocks;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.internal.junit.ArrayAsserts.assertArrayEquals;
+
+
+public class MergeJoinOperatorTest {
+  private AutoCloseable _mocks;
+  private MultiStageOperator _leftInput;
+  private MultiStageOperator _rightInput;
+  @Mock
+  private VirtualServerAddress _serverAddress;
+
+  private static final DataSchema DEFAULT_CHILD_SCHEMA = new DataSchema(new String[]{"int_col", "string_col"},
+      new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING});
+
+  @BeforeMethod
+  public void setUp() {
+    _mocks = openMocks(this);
+    when(_serverAddress.toString()).thenReturn(new VirtualServerAddress("mock", 80, 0).toString());
+  }
+
+  @AfterMethod
+  public void tearDown()
+      throws Exception {
+    _mocks.close();
+  }
+
+  @Test
+  public void shouldHandleLeftSideEmpty() {
+    _leftInput = new BlockListMultiStageOperator.Builder(DEFAULT_CHILD_SCHEMA)
+        .buildWithEos();
+
+    _rightInput = new BlockListMultiStageOperator.Builder(DEFAULT_CHILD_SCHEMA)
+        .addRow(2, "Aa")
+        .addRow(2, "BB")
+        .addRow(3, "BB")
+        .buildWithEos();
+    DataSchema resultSchema = new DataSchema(
+        new String[]{"int_col1", "string_col1", "int_col2", "string_col2"},
+        new DataSchema.ColumnDataType[]{
+            DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING,
+            DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING
+        });
+    MergeJoinOperator operator = getOperator(resultSchema, JoinRelType.INNER, List.of(1), List.of(1), List.of(),
+        List.of(new RelFieldCollation(0)));
+    MseBlock block;
+    block = operator.nextBlock();
+    assertTrue(block.isSuccess());
+  }
+
+  @Test
+  public void shouldHandleRightSideEmpty() {
+    _leftInput = new BlockListMultiStageOperator.Builder(DEFAULT_CHILD_SCHEMA)
+        .addRow(2, "Aa")
+        .addRow(2, "BB")
+        .addRow(3, "BB")
+        .buildWithEos();
+
+    _rightInput = new BlockListMultiStageOperator.Builder(DEFAULT_CHILD_SCHEMA)
+        .buildWithEos();
+    DataSchema resultSchema = new DataSchema(
+        new String[]{"int_col1", "string_col1", "int_col2", "string_col2"},
+        new DataSchema.ColumnDataType[]{
+            DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING,
+            DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING
+        });
+    MergeJoinOperator operator = getOperator(resultSchema, JoinRelType.INNER, List.of(1), List.of(1), List.of(),
+        List.of(new RelFieldCollation(0)));
+    MseBlock block;
+    block = operator.nextBlock();
+    assertTrue(block.isSuccess());
+  }
+
+  @Test
+  public void shouldHandleBothSideEmpty() {
+    _leftInput = new BlockListMultiStageOperator.Builder(DEFAULT_CHILD_SCHEMA)
+        .buildWithEos();
+
+    _rightInput = new BlockListMultiStageOperator.Builder(DEFAULT_CHILD_SCHEMA)
+        .buildWithEos();
+    DataSchema resultSchema = new DataSchema(
+        new String[]{"int_col1", "string_col1", "int_col2", "string_col2"},
+        new DataSchema.ColumnDataType[]{
+            DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING,
+            DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING
+        });
+    MergeJoinOperator operator = getOperator(resultSchema, JoinRelType.INNER, List.of(1), List.of(1), List.of(),
+        List.of(new RelFieldCollation(0)));
+    MseBlock block;
+    block = operator.nextBlock();
+    assertTrue(block.isSuccess());
+  }
+
+  @Test
+  public void shouldHandleMergeJoinDupKeyInnerJoin() {
+    _leftInput = new BlockListMultiStageOperator.Builder(DEFAULT_CHILD_SCHEMA)
+        .addRow(1, "Aa")
+        .addRow(2, "Aa")
+        .addRow(2, "BB")
+        .buildWithEos();
+
+    _rightInput = new BlockListMultiStageOperator.Builder(DEFAULT_CHILD_SCHEMA)
+        .addRow(2, "Aa")
+        .addRow(2, "BB")
+        .addRow(3, "BB")
+        .buildWithEos();
+    DataSchema resultSchema = new DataSchema(
+        new String[]{"int_col1", "string_col1", "int_col2", "string_col2"},
+        new DataSchema.ColumnDataType[]{
+            DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING,
+            DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING
+        });
+    MergeJoinOperator operator = getOperator(resultSchema, JoinRelType.INNER, List.of(1), List.of(1), List.of(),
+        List.of(new RelFieldCollation(0)));
+    List<Object[]> resultRows = new ArrayList<>();
+    MseBlock block;
+    block = operator.nextBlock();
+    while (block.isData()) {
+      resultRows.addAll(((MseBlock.Data) block).asRowHeap().getRows());
+      block = operator.nextBlock();
+    }
+    assertEquals(resultRows.size(), 4);
+    assertEquals(resultRows.get(0), new Object[]{1, "Aa", 2, "Aa"});
+    assertEquals(resultRows.get(1), new Object[]{2, "Aa", 2, "Aa"});
+    assertEquals(resultRows.get(2), new Object[]{2, "BB", 2, "BB"});
+    assertEquals(resultRows.get(3), new Object[]{2, "BB", 3, "BB"});
+  }
+
+  @Test
+  public void shouldHandleMergeJoinUniqueKeyInnerJoin() {
+    _leftInput = new BlockListMultiStageOperator.Builder(DEFAULT_CHILD_SCHEMA)
+        .addRow(1, "Aa")
+        .addRow(2, "BB")
+        .addRow(1, "BC")
+        .addRow(2, "BD")
+        .buildWithEos();
+
+    _rightInput = new BlockListMultiStageOperator.Builder(DEFAULT_CHILD_SCHEMA)
+        .addRow(2, "Aa")
+        .addRow(3, "BB")
+        .addRow(3, "BD")
+        .buildWithEos();
+    DataSchema resultSchema = new DataSchema(
+        new String[]{"int_col1", "string_col1", "int_col2", "string_col2"},
+        new DataSchema.ColumnDataType[]{
+            DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING,
+            DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING
+        });
+    MergeJoinOperator operator = getOperator(resultSchema, JoinRelType.INNER, List.of(1), List.of(1), List.of(),
+        List.of(new RelFieldCollation(0)));
+    List<Object[]> resultRows = new ArrayList<>();
+    MseBlock block;
+    block = operator.nextBlock();
+    while (block.isData()) {
+      resultRows.addAll(((MseBlock.Data) block).asRowHeap().getRows());
+      block = operator.nextBlock();
+    }
+    assertEquals(resultRows.size(), 3);
+    assertEquals(resultRows.get(0), new Object[]{1, "Aa", 2, "Aa"});
+    assertEquals(resultRows.get(1), new Object[]{2, "BB", 3, "BB"});
+    assertEquals(resultRows.get(2), new Object[]{2, "BD", 3, "BD"});
+  }
+
+  @Test
+  public void shouldHandleMergeJoinRightEmptyTwoInputBlockInnerJoin() {
+    _leftInput = new BlockListMultiStageOperator.Builder(DEFAULT_CHILD_SCHEMA)
+        .addBlock(new Object[]{1, "Aa"},
+            new Object[]{2, "BB"})
+        .addBlock(new Object[]{1, "BC"},
+            new Object[]{2, "BD"})
+        .buildWithEos();
+
+    _rightInput = new BlockListMultiStageOperator.Builder(DEFAULT_CHILD_SCHEMA)
+        .buildWithEos();
+    DataSchema resultSchema = new DataSchema(
+        new String[]{"int_col1", "string_col1", "int_col2", "string_col2"},
+        new DataSchema.ColumnDataType[]{
+            DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING,
+            DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING
+        });
+    MergeJoinOperator operator = getOperator(resultSchema, JoinRelType.INNER, List.of(1), List.of(1), List.of(),
+        List.of(new RelFieldCollation(0)));
+    MseBlock block;
+    block = operator.nextBlock();
+    assertTrue(block.isSuccess());
+  }
+
+  @Test
+  public void shouldHandleMergeJoinLeftEmptyTwoInputBlockInnerJoin() {
+    _leftInput = new BlockListMultiStageOperator.Builder(DEFAULT_CHILD_SCHEMA)
+        .buildWithEos();
+
+    _rightInput = new BlockListMultiStageOperator.Builder(DEFAULT_CHILD_SCHEMA)
+        .addBlock(new Object[]{1, "Aa"},
+            new Object[]{2, "BB"})
+        .addBlock(new Object[]{1, "BC"},
+            new Object[]{2, "BD"})
+        .buildWithEos();
+    DataSchema resultSchema = new DataSchema(
+        new String[]{"int_col1", "string_col1", "int_col2", "string_col2"},
+        new DataSchema.ColumnDataType[]{
+            DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING,
+            DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING
+        });
+    MergeJoinOperator operator = getOperator(resultSchema, JoinRelType.INNER, List.of(1), List.of(1), List.of(),
+        List.of(new RelFieldCollation(0)));
+    MseBlock block;
+    block = operator.nextBlock();
+    assertTrue(block.isSuccess());
+  }
+
+  @Test
+  public void shouldHandleMergeJoinUniqueKeyTwoInputBlockInnerJoin() {
+    _leftInput = new BlockListMultiStageOperator.Builder(DEFAULT_CHILD_SCHEMA)
+        .addBlock(new Object[]{1, "Aa"},
+            new Object[]{2, "BB"})
+        .addBlock(new Object[]{1, "BC"},
+            new Object[]{2, "BD"})
+        .buildWithEos();
+
+    _rightInput = new BlockListMultiStageOperator.Builder(DEFAULT_CHILD_SCHEMA)
+        .addRow(2, "Aa")
+        .addRow(3, "BB")
+        .addRow(3, "BD")
+        .buildWithEos();
+    DataSchema resultSchema = new DataSchema(
+        new String[]{"int_col1", "string_col1", "int_col2", "string_col2"},
+        new DataSchema.ColumnDataType[]{
+            DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING,
+            DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING
+        });
+    MergeJoinOperator operator = getOperator(resultSchema, JoinRelType.INNER, List.of(1), List.of(1), List.of(),
+        List.of(new RelFieldCollation(0)));
+    List<Object[]> resultRows = new ArrayList<>();
+    MseBlock block;
+    block = operator.nextBlock();
+    while (block.isData()) {
+      resultRows.addAll(((MseBlock.Data) block).asRowHeap().getRows());
+      block = operator.nextBlock();
+    }
+    assertEquals(resultRows.size(), 3);
+    assertEquals(resultRows.get(0), new Object[]{1, "Aa", 2, "Aa"});
+    assertEquals(resultRows.get(1), new Object[]{2, "BB", 3, "BB"});
+    assertEquals(resultRows.get(2), new Object[]{2, "BD", 3, "BD"});
+  }
+
+  @Test
+  public void shouldHandleMergeJoinUniqueKeyLastDoesNotMatchTwoInputBlockInnerJoin() {
+    _leftInput = new BlockListMultiStageOperator.Builder(DEFAULT_CHILD_SCHEMA)
+        .addBlock(new Object[]{1, "Aa"},
+            new Object[]{2, "BB"})
+        .addBlock(new Object[]{1, "BC"})
+        .buildWithEos();
+
+    _rightInput = new BlockListMultiStageOperator.Builder(DEFAULT_CHILD_SCHEMA)
+        .addRow(2, "Aa")
+        .addRow(3, "BB")
+        .addRow(3, "BD")
+        .buildWithEos();
+    DataSchema resultSchema = new DataSchema(
+        new String[]{"int_col1", "string_col1", "int_col2", "string_col2"},
+        new DataSchema.ColumnDataType[]{
+            DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING,
+            DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING
+        });
+    MergeJoinOperator operator = getOperator(resultSchema, JoinRelType.INNER, List.of(1), List.of(1), List.of(),
+        List.of(new RelFieldCollation(0)));
+    List<Object[]> resultRows = new ArrayList<>();
+    MseBlock block;
+    block = operator.nextBlock();
+    while (block.isData()) {
+      resultRows.addAll(((MseBlock.Data) block).asRowHeap().getRows());
+      block = operator.nextBlock();
+    }
+    assertEquals(resultRows.size(), 2);
+    assertEquals(resultRows.get(0), new Object[]{1, "Aa", 2, "Aa"});
+    assertEquals(resultRows.get(1), new Object[]{2, "BB", 3, "BB"});
+  }
+
+  @Test
+  public void shouldHandleMergeJoinDupKeySpanTwoInputBlockInnerJoin() {
+    _leftInput = new BlockListMultiStageOperator.Builder(DEFAULT_CHILD_SCHEMA)
+        .addBlock(new Object[]{1, "Aa"},
+            new Object[]{2, "BB"})
+        .addBlock(new Object[]{3, "BB"},
+            new Object[]{2, "BD"})
+        .buildWithEos();
+
+    _rightInput = new BlockListMultiStageOperator.Builder(DEFAULT_CHILD_SCHEMA)
+        .addRow(2, "Aa")
+        .addRow(3, "BB")
+        .addRow(3, "BD")
+        .buildWithEos();
+    DataSchema resultSchema = new DataSchema(
+        new String[]{"int_col1", "string_col1", "int_col2", "string_col2"},
+        new DataSchema.ColumnDataType[]{
+            DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING,
+            DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING
+        });
+    MergeJoinOperator operator = getOperator(resultSchema, JoinRelType.INNER, List.of(1), List.of(1), List.of(),
+        List.of(new RelFieldCollation(0)));
+    List<Object[]> resultRows = new ArrayList<>();
+    MseBlock block;
+    block = operator.nextBlock();
+    while (block.isData()) {
+      resultRows.addAll(((MseBlock.Data) block).asRowHeap().getRows());
+      block = operator.nextBlock();
+    }
+    assertEquals(resultRows.size(), 4);
+    assertEquals(resultRows.get(0), new Object[]{1, "Aa", 2, "Aa"});
+    assertEquals(resultRows.get(1), new Object[]{2, "BB", 3, "BB"});
+    assertEquals(resultRows.get(2), new Object[]{3, "BB", 3, "BB"});
+    assertEquals(resultRows.get(3), new Object[]{2, "BD", 3, "BD"});
+  }
+
+  @Test
+  public void shouldHandleMergeJoinDupKeyBothSideSpanTwoInputBlockInnerJoin() {
+    _leftInput = new BlockListMultiStageOperator.Builder(DEFAULT_CHILD_SCHEMA)
+        .addBlock(new Object[]{1, "Aa"},
+            new Object[]{2, "BB"})
+        .addBlock(new Object[]{3, "BB"},
+            new Object[]{2, "BD"})
+        .buildWithEos();
+
+    _rightInput = new BlockListMultiStageOperator.Builder(DEFAULT_CHILD_SCHEMA)
+        .addBlock(new Object[]{2, "Aa"},
+            new Object[]{2, "BB"})
+        .addBlock(new Object[]{3, "BB"},
+            new Object[]{3, "BD"})
+        .buildWithEos();
+    DataSchema resultSchema = new DataSchema(
+        new String[]{"int_col1", "string_col1", "int_col2", "string_col2"},
+        new DataSchema.ColumnDataType[]{
+            DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING,
+            DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING
+        });
+    MergeJoinOperator operator = getOperator(resultSchema, JoinRelType.INNER, List.of(1), List.of(1), List.of(),
+        List.of(new RelFieldCollation(0)));
+    List<Object[]> resultRows = new ArrayList<>();
+    MseBlock block;
+    block = operator.nextBlock();
+    while (block.isData()) {
+      resultRows.addAll(((MseBlock.Data) block).asRowHeap().getRows());
+      block = operator.nextBlock();
+    }
+    assertEquals(resultRows.size(), 6);
+    assertEquals(resultRows.get(0), new Object[]{1, "Aa", 2, "Aa"});
+    assertEquals(resultRows.get(1), new Object[]{2, "BB", 2, "BB"});
+    assertEquals(resultRows.get(2), new Object[]{2, "BB", 3, "BB"});
+    assertEquals(resultRows.get(3), new Object[]{3, "BB", 2, "BB"});
+    assertEquals(resultRows.get(4), new Object[]{3, "BB", 3, "BB"});
+    assertEquals(resultRows.get(5), new Object[]{2, "BD", 3, "BD"});
+  }
+
+  @Test
+  public void shouldHandleCompositeKeyInnerJoin() {
+    // Test composite key join (multi-column) with null values
+    // This should expose the bug in isNullKey method where it checks for Object[] instead of Key
+
+    DataSchema compositeSchema = new DataSchema(
+        new String[]{"int_col", "string_col", "double_col"},
+        new DataSchema.ColumnDataType[]{
+            DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING,
+            DataSchema.ColumnDataType.DOUBLE
+        });
+
+    _leftInput = new BlockListMultiStageOperator.Builder(compositeSchema)
+        .addRow(1, "Aa", 1.0)
+        .addRow(2, "Cc", 3.0)
+        .addRow(4, "Dd", 4.0)
+        .buildWithEos();
+
+    _rightInput = new BlockListMultiStageOperator.Builder(compositeSchema)
+        .addRow(1, "Aa", 1.0)
+        .addRow(2, "Bb", 2.0)
+        .addRow(3, "Cc", 3.0)
+        .addRow(5, "Ee", 5.0)
+        .buildWithEos();
+
+    DataSchema resultSchema = new DataSchema(
+        new String[]{"int_col1", "string_col1", "double_col1", "int_col2", "string_col2", "double_col2"},
+        new DataSchema.ColumnDataType[]{
+            DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE,
+            DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE
+        });
+
+    // Composite key join on columns 1 and 2 (string_col and double_col)
+    MergeJoinOperator operator = getOperator(compositeSchema, resultSchema, JoinRelType.INNER,
+        List.of(1, 2), List.of(1, 2), List.of(), PlanNode.NodeHint.EMPTY,
+        List.of(new RelFieldCollation(0), new RelFieldCollation(1)));
+
+    List<Object[]> resultRows = new ArrayList<>();
+    MseBlock block;
+    block = operator.nextBlock();
+    while (block.isData()) {
+      resultRows.addAll(((MseBlock.Data) block).asRowHeap().getRows());
+      block = operator.nextBlock();
+    }
+    assertEquals(resultRows.size(), 2);
+    assertEquals(resultRows.get(0), new Object[]{1, "Aa", 1.0, 1, "Aa", 1.0});
+    assertEquals(resultRows.get(1), new Object[]{2, "Cc", 3.0, 3, "Cc", 3.0});
+  }
+
+  @Test
+  public void shouldPropagateRightTableError() {
+    _leftInput = new BlockListMultiStageOperator.Builder(DEFAULT_CHILD_SCHEMA)
+        .addRow(1, "BB")
+        .addRow(1, "CC")
+        .addRow(3, "BB")
+        .buildWithEos();
+    _rightInput = new BlockListMultiStageOperator.Builder(DEFAULT_CHILD_SCHEMA)
+        .buildWithError(ErrorMseBlock.fromException(new Exception("testInnerJoinRightError")));
+    DataSchema resultSchema = new DataSchema(new String[]{"int_col1", "string_col1", "int_co2", "string_col2"},
+        new DataSchema.ColumnDataType[]{
+            DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING,
+            DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING
+        });
+    MergeJoinOperator operator = getOperator(resultSchema, JoinRelType.INNER, List.of(0), List.of(0), List.of(),
+        List.of(new RelFieldCollation(0)));
+    MseBlock block = operator.nextBlock();
+    assertTrue(block.isError());
+    assertTrue(((ErrorMseBlock) block).getErrorMessages()
+        .get(QueryErrorCode.UNKNOWN).contains("testInnerJoinRightError"));
+  }
+
+  @Test
+  public void shouldPropagateLeftTableError() {
+    _rightInput = new BlockListMultiStageOperator.Builder(DEFAULT_CHILD_SCHEMA)
+        .addRow(1, "BB")
+        .addRow(1, "CC")
+        .addRow(3, "BB")
+        .buildWithEos();
+    _leftInput = new BlockListMultiStageOperator.Builder(DEFAULT_CHILD_SCHEMA)
+        .buildWithError(ErrorMseBlock.fromException(new Exception("testInnerJoinLeftError")));
+    DataSchema resultSchema = new DataSchema(new String[]{"int_col1", "string_col1", "int_co2", "string_col2"},
+        new DataSchema.ColumnDataType[]{
+            DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING,
+            DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING
+        });
+    MergeJoinOperator operator = getOperator(resultSchema, JoinRelType.INNER, List.of(0), List.of(0), List.of(),
+        List.of(new RelFieldCollation(0)));
+    MseBlock block = operator.nextBlock();
+    assertTrue(block.isError());
+    assertTrue(((ErrorMseBlock) block).getErrorMessages()
+        .get(QueryErrorCode.UNKNOWN).contains("testInnerJoinLeftError"));
+  }
+
+  @Test
+  public void shouldPropagateRightInputJoinLimitError() {
+    _leftInput = new BlockListMultiStageOperator.Builder(DEFAULT_CHILD_SCHEMA)
+        .addRow(1, "Aa")
+        .addRow(2, "BB")
+        .buildWithEos();
+    _rightInput = new BlockListMultiStageOperator.Builder(DEFAULT_CHILD_SCHEMA)
+        .addRow(2, "Aa")
+        .addRow(2, "BB")
+        .addRow(3, "BB")
+        .buildWithEos();
+    DataSchema resultSchema =
+        new DataSchema(new String[]{"int_col1", "string_col1", "int_co2", "string_col2"},
+            new DataSchema.ColumnDataType[]{
+                DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT,
+                DataSchema.ColumnDataType.STRING
+            });
+    PlanNode.NodeHint nodeHint = new PlanNode.NodeHint(Map.of(PinotHintOptions.JOIN_HINT_OPTIONS,
+        Map.of(PinotHintOptions.JoinHintOptions.JOIN_OVERFLOW_MODE, "THROW",
+            PinotHintOptions.JoinHintOptions.MAX_ROWS_IN_JOIN, "1")));
+    MergeJoinOperator operator =
+        getOperator(DEFAULT_CHILD_SCHEMA, resultSchema, JoinRelType.INNER, List.of(0), List.of(0), List.of(), nodeHint,
+            List.of(new RelFieldCollation(0)));
+    MseBlock block = operator.nextBlock();
+    assertTrue(block.isError());
+    assertTrue(((ErrorMseBlock) block).getErrorMessages().get(QueryErrorCode.SERVER_RESOURCE_LIMIT_EXCEEDED)
+        .contains("reached number of rows limit"));
+    assertTrue(((ErrorMseBlock) block).getErrorMessages().get(QueryErrorCode.SERVER_RESOURCE_LIMIT_EXCEEDED)
+        .contains("Cannot process join"));
+  }
+
+  @Test
+  public void shouldHandleJoinWithPartialResultsWhenHitDataRowsLimitOnRightInput() {
+    _leftInput = new BlockListMultiStageOperator.Builder(DEFAULT_CHILD_SCHEMA)
+        .addRow(1, "Aa")
+        .addRow(2, "BB")
+        .buildWithEos();
+    _rightInput = new BlockListMultiStageOperator.Builder(DEFAULT_CHILD_SCHEMA)
+        .spied()
+        .addRow(2, "Aa")
+        .addRow(2, "BB")
+        .addRow(3, "BB")
+        .buildWithEos();
+    DataSchema resultSchema = new DataSchema(new String[]{"int_col1", "string_col1", "int_co2", "string_col2"},
+        new DataSchema.ColumnDataType[]{
+            DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING,
+            DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING
+        });
+    PlanNode.NodeHint nodeHint = new PlanNode.NodeHint(Map.of(PinotHintOptions.JOIN_HINT_OPTIONS,
+        Map.of(PinotHintOptions.JoinHintOptions.JOIN_OVERFLOW_MODE, "BREAK",
+            PinotHintOptions.JoinHintOptions.MAX_ROWS_IN_JOIN, "1")));
+    MergeJoinOperator operator =
+        getOperator(DEFAULT_CHILD_SCHEMA, resultSchema, JoinRelType.INNER, List.of(0), List.of(0), List.of(), nodeHint,
+            List.of(new RelFieldCollation(0)));
+    List<Object[]> resultRows1 = ((MseBlock.Data) operator.nextBlock()).asRowHeap().getRows();
+    Mockito.verify(_rightInput).earlyTerminate();
+    assertEquals(resultRows1.size(), 1);
+    MseBlock block2 = operator.nextBlock();
+    assertTrue(block2.isSuccess());
+  }
+
+  @Test
+  public void shouldHandleJoinWithPartialResultsWhenHitDataRowsLimitOnLeftInput() {
+    _leftInput = new BlockListMultiStageOperator.Builder(DEFAULT_CHILD_SCHEMA)
+        .spied()
+        .addRow(1, "Aa")
+        .addRow(2, "Aa")
+        .addRow(3, "Aa")
+        .finishBlock()
+        .addRow(4, "Aa")
+        .addRow(5, "Aa")
+        .buildWithEos();
+    _rightInput = new BlockListMultiStageOperator.Builder(DEFAULT_CHILD_SCHEMA)
+        .spied()
+        .addRow(2, "Aa")
+        .addRow(2, "BB")
+        .addRow(3, "BB")
+        .buildWithEos();
+
+    DataSchema resultSchema =
+        new DataSchema(new String[]{"int_col1", "string_col1", "int_co2", "string_col2"},
+            new DataSchema.ColumnDataType[]{
+                DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT,
+                DataSchema.ColumnDataType.STRING
+            });
+    PlanNode.NodeHint nodeHint = new PlanNode.NodeHint(Map.of(PinotHintOptions.JOIN_HINT_OPTIONS,
+        Map.of(PinotHintOptions.JoinHintOptions.JOIN_OVERFLOW_MODE, "BREAK",
+            PinotHintOptions.JoinHintOptions.MAX_ROWS_IN_JOIN, "2")));
+    MergeJoinOperator operator =
+        getOperator(DEFAULT_CHILD_SCHEMA, resultSchema, JoinRelType.INNER, List.of(1), List.of(1), List.of(), nodeHint,
+            List.of(new RelFieldCollation(1)));
+
+    // When
+    List<Object[]> resultRows = ((MseBlock.Data) operator.nextBlock()).asRowHeap().getRows();
+
+    // Then
+    Mockito.verify(_leftInput).earlyTerminate();
+    assertEquals(resultRows.size(), 2);
+    MseBlock block2 = operator.nextBlock();
+    assertTrue(block2.isSuccess());
+    StatMap<HashJoinOperator.StatKey> statMap =
+        OperatorTestUtil.getStatMap(HashJoinOperator.StatKey.class, operator.calculateStats());
+    assertTrue(statMap.getBoolean(HashJoinOperator.StatKey.MAX_ROWS_IN_JOIN_REACHED),
+        "Max rows in join should be reached");
+  }
+
+  @Test
+  public void shouldHandleCompositeKeyInnerJoinWithNulls() {
+    // Test that composite keys with nulls are properly excluded from INNER join
+
+    DataSchema compositeSchema = new DataSchema(
+        new String[]{"int_col", "string_col", "double_col"},
+        new DataSchema.ColumnDataType[]{
+            DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING,
+            DataSchema.ColumnDataType.DOUBLE
+        });
+
+    _leftInput = new BlockListMultiStageOperator.Builder(compositeSchema)
+        .addRow(1, "Aa", 1.0)      // Should match
+        .addRow(2, null, 2.0)      // Should be excluded (null key)
+        .addRow(3, "Cc", 3.0)      // No match in right
+        .buildWithEos();
+
+    _rightInput = new BlockListMultiStageOperator.Builder(compositeSchema)
+        .addRow(1, "Aa", 1.0)      // Match
+        .addRow(2, null, 2.0)      // Should be excluded (null key)
+        .addRow(4, "Dd", 4.0)      // No match in left
+        .buildWithEos();
+
+    DataSchema resultSchema = new DataSchema(
+        new String[]{"int_col1", "string_col1", "double_col1", "int_col2", "string_col2", "double_col2"},
+        new DataSchema.ColumnDataType[]{
+            DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE,
+            DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE
+        });
+
+    // Composite key join on columns 1 and 2 (string_col and double_col)
+    MergeJoinOperator operator = getOperator(compositeSchema, resultSchema, JoinRelType.INNER,
+        List.of(1, 2), List.of(1, 2), List.of(), PlanNode.NodeHint.EMPTY,
+        List.of(new RelFieldCollation(1), new RelFieldCollation(2)));
+
+    List<Object[]> resultRows = ((MseBlock.Data) operator.nextBlock()).asRowHeap().getRows();
+    // Only the non-null key match should be returned
+    assertEquals(resultRows.size(), 1);
+    assertArrayEquals(resultRows.get(0), new Object[]{1, "Aa", 1.0, 1, "Aa", 1.0});
+  }
+
+  @Test
+  public void shouldHandleCompositeKeyInnerJoinWithNullsDupKeyTwoBlocks() {
+    // Test that composite keys with nulls are properly excluded from INNER join
+
+    DataSchema compositeSchema = new DataSchema(
+        new String[]{"int_col", "string_col", "double_col"},
+        new DataSchema.ColumnDataType[]{
+            DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING,
+            DataSchema.ColumnDataType.DOUBLE
+        });
+
+    _leftInput = new BlockListMultiStageOperator.Builder(compositeSchema)
+        .addBlock(new Object[]{1, "Aa", 1.0})
+        .addBlock(new Object[]{2, "Aa", 1.0}, new Object[]{3, "Cc", 3.0}, new Object[]{2, null, 2.0})
+        .buildWithEos();
+
+    _rightInput = new BlockListMultiStageOperator.Builder(compositeSchema)
+        .addBlock(new Object[]{1, "Aa", 1.0})
+        .addBlock(new Object[]{2, "Aa", 1.0}, new Object[]{4, "Dd", 4.0}, new Object[]{2, null, 2.0})
+        .buildWithEos();
+
+    DataSchema resultSchema = new DataSchema(
+        new String[]{"int_col1", "string_col1", "double_col1", "int_col2", "string_col2", "double_col2"},
+        new DataSchema.ColumnDataType[]{
+            DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE,
+            DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.DOUBLE
+        });
+
+    // Composite key join on columns 1 and 2 (string_col and double_col)
+    MergeJoinOperator operator = getOperator(compositeSchema, resultSchema, JoinRelType.INNER,
+        List.of(1, 2), List.of(1, 2), List.of(), PlanNode.NodeHint.EMPTY,
+        List.of(new RelFieldCollation(1), new RelFieldCollation(2)));
+
+    List<Object[]> resultRows = ((MseBlock.Data) operator.nextBlock()).asRowHeap().getRows();
+    // Only the non-null key match should be returned
+    assertEquals(resultRows.size(), 4);
+    assertArrayEquals(resultRows.get(0), new Object[]{1, "Aa", 1.0, 1, "Aa", 1.0});
+    assertArrayEquals(resultRows.get(1), new Object[]{1, "Aa", 1.0, 2, "Aa", 1.0});
+    assertArrayEquals(resultRows.get(2), new Object[]{2, "Aa", 1.0, 1, "Aa", 1.0});
+    assertArrayEquals(resultRows.get(3), new Object[]{2, "Aa", 1.0, 2, "Aa", 1.0});
+  }
+
+  // TODO: test null handling enabled vs disabled, and non-equi conditions!
+
+  private MergeJoinOperator getOperator(DataSchema leftSchema, DataSchema resultSchema, JoinRelType joinType,
+      List<Integer> leftKeys, List<Integer> rightKeys, List<RexExpression> nonEquiConditions,
+      PlanNode.NodeHint nodeHint, List<RelFieldCollation> collations) {
+    return new MergeJoinOperator(OperatorTestUtil.getTracingContext(), _leftInput, leftSchema, _rightInput,
+        new JoinNode(-1, resultSchema, nodeHint, List.of(), joinType, leftKeys, rightKeys, nonEquiConditions,
+            JoinNode.JoinStrategy.MERGE, null, collations));
+  }
+
+  private MergeJoinOperator getOperator(DataSchema resultSchema, JoinRelType joinType,
+      List<Integer> leftKeys, List<Integer> rightKeys, List<RexExpression> nonEquiConditions,
+      List<RelFieldCollation> collations) {
+    return getOperator(DEFAULT_CHILD_SCHEMA, resultSchema, joinType, leftKeys, rightKeys, nonEquiConditions,
+        PlanNode.NodeHint.EMPTY, collations);
+  }
+}


### PR DESCRIPTION
Staging the MSE MergeJoinOperator implementation, this is supposed to be the first of several PRs to support MergeJoin in MSE.

Changes in this PR include: 
- Added collations field in JoinNode plan node, and proto
- Added join strategy MERGE. Intention is to use RelOptRule to add this hint if conditions match, users can also add this hint. Then conditions are checked in RelToPlanNodeConverter 
- Implemented the MergeJoin operator for inner equi-join
- Added tests for MergeJoinOperator

The operator impl will be perf'd

Next PR will support full conversion from Rel -> PlanNode -> Operator