### PR TITLE
[multistage] Fix Bug in MailboxInfo Ordering

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/PlanFragmentAndMailboxAssignment.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/PlanFragmentAndMailboxAssignment.java
@@ -21,6 +21,7 @@ package org.apache.pinot.query.planner.physical.v2;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -253,6 +254,14 @@ public class PlanFragmentAndMailboxAssignment {
     for (var entry : workersByUniqueHostPort.entrySet()) {
       result.add(new MailboxInfo(entry.getKey().getHostname(), entry.getKey().getQueryMailboxPort(), entry.getValue()));
     }
+    // IMP: Return mailbox info sorted by workerIds. This is because SendingMailbox are created in this order, and
+    // record assignment for hash exchange follows modulo arithmetic. e.g. if we have sending mailbox in order:
+    // [worker-1, worker-0], then records with modulo 0 hash would end up in worker-1.
+    // Note that the workerIds list will be >1 in length only when there's a parallelism change. It's important to
+    // also know that MailboxSendOperator will iterate over this List<MailboxInfo> in order, and within each iteration
+    // iterate over all the workerIds of that MailboxInfo. The result List<SendingMailbox> is used for modulo
+    // arithmetic for any partitioning exchange strategy.
+    result.sort(Comparator.comparingInt(info -> info.getWorkerIds().get(0)));
     return result;
   }
 


### PR DESCRIPTION
fixes #16213

I had made an assumption that the Runtime would sort the `List<SendingMailbox>` used for modulo arithmetic in `HashExchange`, so I was creating `List<MailboxInfo>` without regard to ordering.

But that isn't the case, as can be seen here: https://github.com/apache/pinot/blob/7122e24e9cde07461d84c8584302f6d7ec80c441/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java#L164-L173

While this PR should fix the flaky test and also the bug with v2 optimizer, I want to revisit this when I am implementing parallelism.

**Test Plan:** I built a custom test to reproduce the error with very high probability, but I can't really check that code in. So skipping UTs. But this patch has been manually verified with that custom test and the test had passed on 10 consecutive runs.