### PR TITLE
Handle null values appropriately for AND / OR / NOT in InbuiltFunctionEvaluator

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/function/InbuiltFunctionEvaluator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/function/InbuiltFunctionEvaluator.java
@@ -141,12 +141,22 @@ public class InbuiltFunctionEvaluator implements FunctionEvaluator {
 
     @Override
     public Object execute(GenericRow row) {
-      return !((Boolean) _argumentNode.execute(row));
+      Boolean res = (Boolean) _argumentNode.execute(row);
+      if (res == null) {
+        return null;
+      } else {
+        return !res;
+      }
     }
 
     @Override
     public Object execute(Object[] values) {
-      return !((Boolean) _argumentNode.execute(values));
+      Boolean res = (Boolean) _argumentNode.execute(values);
+      if (res == null) {
+        return null;
+      } else {
+        return !res;
+      }
     }
   }
 
@@ -159,24 +169,38 @@ public class InbuiltFunctionEvaluator implements FunctionEvaluator {
 
     @Override
     public Object execute(GenericRow row) {
+      boolean hasNull = false;
+
       for (ExecutableNode executableNode : _argumentNodes) {
         Boolean res = (Boolean) executableNode.execute(row);
+        if (res == null) {
+          hasNull = true;
+          continue;
+        }
         if (res) {
           return true;
         }
       }
-      return false;
+
+      return hasNull ? null : false;
     }
 
     @Override
     public Object execute(Object[] values) {
+      boolean hasNull = false;
+
       for (ExecutableNode executableNode : _argumentNodes) {
         Boolean res = (Boolean) executableNode.execute(values);
+        if (res == null) {
+          hasNull = true;
+          continue;
+        }
         if (res) {
           return true;
         }
       }
-      return false;
+
+      return hasNull ? null : false;
     }
   }
 
@@ -189,24 +213,38 @@ public class InbuiltFunctionEvaluator implements FunctionEvaluator {
 
     @Override
     public Object execute(GenericRow row) {
+      boolean hasNull = false;
+
       for (ExecutableNode executableNode : _argumentNodes) {
         Boolean res = (Boolean) executableNode.execute(row);
+        if (res == null) {
+          hasNull = true;
+          continue;
+        }
         if (!res) {
           return false;
         }
       }
-      return true;
+
+      return hasNull ? null : true;
     }
 
     @Override
     public Object execute(Object[] values) {
+      boolean hasNull = false;
+
       for (ExecutableNode executableNode : _argumentNodes) {
         Boolean res = (Boolean) executableNode.execute(values);
+        if (res == null) {
+          hasNull = true;
+          continue;
+        }
         if (!res) {
           return false;
         }
       }
-      return true;
+
+      return hasNull ? null : true;
     }
   }
 

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/function/InbuiltFunctionEvaluatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/function/InbuiltFunctionEvaluatorTest.java
@@ -25,6 +25,7 @@ import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 
 
 public class InbuiltFunctionEvaluatorTest {
@@ -37,6 +38,67 @@ public class InbuiltFunctionEvaluatorTest {
     checkBooleanLiteralExpression("False", 0);
     checkBooleanLiteralExpression("1", 1);
     checkBooleanLiteralExpression("0", 0);
+  }
+
+  @Test
+  public void testOrWithNulls() {
+    InbuiltFunctionEvaluator evaluator = new InbuiltFunctionEvaluator("or(null, false, true)");
+    Object output = evaluator.evaluate(new GenericRow());
+    assertEquals(output, true);
+
+    evaluator = new InbuiltFunctionEvaluator("or(null, false, null)");
+    output = evaluator.evaluate(new GenericRow());
+    assertNull(output);
+
+    evaluator = new InbuiltFunctionEvaluator("or(null, null, null)");
+    output = evaluator.evaluate(new Object[]{});
+    assertNull(output);
+
+    evaluator = new InbuiltFunctionEvaluator("or(null, true, null)");
+    output = evaluator.evaluate(new Object[]{});
+    assertEquals(output, true);
+
+    evaluator = new InbuiltFunctionEvaluator("or(true, false)");
+    output = evaluator.evaluate(new GenericRow());
+    assertEquals(output, true);
+  }
+
+  @Test
+  public void testAndWithNulls() {
+    InbuiltFunctionEvaluator evaluator = new InbuiltFunctionEvaluator("and(null, false, true)");
+    Object output = evaluator.evaluate(new GenericRow());
+    assertEquals(output, false);
+
+    evaluator = new InbuiltFunctionEvaluator("and(null, false, null)");
+    output = evaluator.evaluate(new GenericRow());
+    assertEquals(output, false);
+
+    evaluator = new InbuiltFunctionEvaluator("and(null, null, null)");
+    output = evaluator.evaluate(new Object[]{});
+    assertNull(output);
+
+    evaluator = new InbuiltFunctionEvaluator("and(null, true, null)");
+    output = evaluator.evaluate(new Object[]{});
+    assertNull(output);
+
+    evaluator = new InbuiltFunctionEvaluator("and(true, false)");
+    output = evaluator.evaluate(new GenericRow());
+    assertEquals(output, false);
+  }
+
+  @Test
+  public void testNotWithNulls() {
+    InbuiltFunctionEvaluator evaluator = new InbuiltFunctionEvaluator("not(null)");
+    Object output = evaluator.evaluate(new GenericRow());
+    assertNull(output);
+
+    evaluator = new InbuiltFunctionEvaluator("not(false)");
+    output = evaluator.evaluate(new Object[]{});
+    assertEquals(output, true);
+
+    evaluator = new InbuiltFunctionEvaluator("not(true)");
+    output = evaluator.evaluate(new GenericRow());
+    assertEquals(output, false);
   }
 
   private void checkBooleanLiteralExpression(String expression, int value) {


### PR DESCRIPTION
- Fixes https://github.com/apache/pinot/issues/16228.
- `OR` returns `true` if any value is `true` (regardless of `null` presence / absence), `false` if there are no `true` or `null` values, `null` otherwise.
- `AND` returns `false` if any value is `false` (regardless of `null` presence / absence), `true` if there are no `false` or `null` values, `null` otherwise.
- `NOT` returns `null` if the value is `null`, else returns the inverted boolean value.