### PR TITLE
Revert "Bug fix: close admin client on consumer close in Kafka 3.0"

### DIFF
--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/main/java/org/apache/pinot/plugin/stream/kafka30/KafkaPartitionLevelConnectionHandler.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/main/java/org/apache/pinot/plugin/stream/kafka30/KafkaPartitionLevelConnectionHandler.java
@@ -115,7 +115,6 @@ public abstract class KafkaPartitionLevelConnectionHandler {
   public void close()
       throws IOException {
     _consumer.close();
-    _adminClient.close();
   }
 
   @VisibleForTesting


### PR DESCRIPTION
Reverts apache/pinot#16227
because https://github.com/apache/pinot/pull/16230