### PR TITLE
Upgrade Helix version to 1.3.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -142,7 +142,7 @@
     <parquet.version>1.15.2</parquet.version>
     <orc.version>1.9.6</orc.version>
     <hive.version>2.8.1</hive.version>
-    <helix.version>1.3.1</helix.version>
+    <helix.version>1.3.2</helix.version>
     <zkclient.version>0.11</zkclient.version>
     <jackson.version>2.19.1</jackson.version>
     <zookeeper.version>3.9.3</zookeeper.version>


### PR DESCRIPTION
Upgrade the Helix version to 1.3.2

Helix 1.3.2 branch: https://github.com/apache/helix/tree/helix-1.3.2
Helix 1.3.2 commits: https://github.com/apache/helix/commits/helix-1.3.2/

The main motivation for making this update is to pull in this fix from the Helix side: https://github.com/apache/helix/pull/2976

Today we see an issue with Minions where if the Minion is not gracefully shutdown (even if the tag is removed), Helix can drop the tasks assigned to that minion. With the above changes, Helix will wait for the tasks to complete.

Testing done:
- Ran the build locally and validated that the build passes: `mvn clean install -DskipTests -Pbin-dist`
- Validated in the IDE that the correct 1.3.2 jar is used for the Helix related classes