### PR TITLE
Add JsonProperty to correctly serialized and deserialize `rlsFiltersApplied`

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNative.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNative.java
@@ -581,11 +581,13 @@ public class BrokerResponseNative implements BrokerResponse {
     return _pools;
   }
 
+  @JsonProperty("rlsFiltersApplied")
   @Override
   public void setRLSFiltersApplied(boolean rlsFiltersApplied) {
     _rlsFiltersApplied = rlsFiltersApplied;
   }
 
+  @JsonProperty("rlsFiltersApplied")
   @Override
   public boolean getRLSFiltersApplied() {
     return _rlsFiltersApplied;

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNativeV2.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNativeV2.java
@@ -406,11 +406,13 @@ public class BrokerResponseNativeV2 implements BrokerResponse {
     return _pools;
   }
 
+  @JsonProperty("rlsFiltersApplied")
   @Override
   public void setRLSFiltersApplied(boolean rlsFiltersApplied) {
     _rlsFiltersApplied = rlsFiltersApplied;
   }
 
+  @JsonProperty("rlsFiltersApplied")
   @Override
   public boolean getRLSFiltersApplied() {
     return _rlsFiltersApplied;

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/RowLevelSecurityIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/RowLevelSecurityIntegrationTest.java
@@ -301,9 +301,14 @@ public class RowLevelSecurityIntegrationTest extends BaseClusterIntegrationTest 
     return response;
   }
 
-  private boolean compareRows(JsonNode expectedResponse, JsonNode response) {
-    JsonNode responseRow = response.get("resultTable").get("rows").get(0);
-    JsonNode expectedRow = expectedResponse.get("resultTable").get("rows").get(0);
+  private boolean compareRows(JsonNode adminQueryResponse, JsonNode userQueryResponse) {
+    // No filters should get applied for admin response
+    Assert.assertFalse(adminQueryResponse.get("rlsFiltersApplied").asBoolean());
+    // Filters are always applied in case of users
+    Assert.assertTrue(userQueryResponse.get("rlsFiltersApplied").asBoolean());
+
+    JsonNode responseRow = userQueryResponse.get("resultTable").get("rows").get(0);
+    JsonNode expectedRow = adminQueryResponse.get("resultTable").get("rows").get(0);
 
     // Compare each column
     for (int i = 0; i < responseRow.size(); i++) {


### PR DESCRIPTION

## Scope of the PR
1. Add JsonProperty to correctly serialized and deserialize `rlsFiltersApplied`.
    - The default serialization is converting the field to `rlsfiltersApplied` instead of expected `rlsFiltersApplied`
2. Add test case to ensure the property is correctly set in the response

## Testing 
1. Ensure response contains the right field name and value.
2. The value should be `true` when the filters are applied, and `false` otherwise.
