### PR TITLE
Update the UtilizationChecker and ResourceUtilizationManager to return an enum instead of boolean

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
@@ -224,7 +224,7 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
       LOGGER.info("Trying to create tasks of type: {}, table: {}", taskType, tableNameWithType);
       try {
         if (_resourceUtilizationManager.isResourceUtilizationWithinLimits(tableNameWithType,
-            UtilizationChecker.CheckPurpose.TASK_GENERATION).equals(UtilizationChecker.CheckResult.FAIL)) {
+            UtilizationChecker.CheckPurpose.TASK_GENERATION) == UtilizationChecker.CheckResult.FAIL) {
           LOGGER.warn("Resource utilization is above threshold, skipping task creation for table: {}", tableName);
           _controllerMetrics.setOrUpdateTableGauge(tableName, ControllerGauge.RESOURCE_UTILIZATION_LIMIT_EXCEEDED, 1L);
           continue;
@@ -724,7 +724,7 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
       String tableName = tableConfig.getTableName();
       try {
         if (_resourceUtilizationManager.isResourceUtilizationWithinLimits(tableName,
-            UtilizationChecker.CheckPurpose.TASK_GENERATION).equals(UtilizationChecker.CheckResult.FAIL)) {
+            UtilizationChecker.CheckPurpose.TASK_GENERATION) == UtilizationChecker.CheckResult.FAIL) {
           String message = String.format("Skipping tasks generation as resource utilization is not within limits for "
               + "table: %s. Disk utilization for one or more servers hosting this table has exceeded the threshold. "
               + "Tasks won't be generated until the issue is mitigated.", tableName);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
@@ -223,8 +223,8 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
       TableConfig tableConfig = _pinotHelixResourceManager.getTableConfig(tableNameWithType);
       LOGGER.info("Trying to create tasks of type: {}, table: {}", taskType, tableNameWithType);
       try {
-        if (!_resourceUtilizationManager.isResourceUtilizationWithinLimits(tableNameWithType,
-            UtilizationChecker.CheckPurpose.TASK_GENERATION)) {
+        if (_resourceUtilizationManager.isResourceUtilizationWithinLimits(tableNameWithType,
+            UtilizationChecker.CheckPurpose.TASK_GENERATION).equals(UtilizationChecker.CheckResult.FALSE)) {
           LOGGER.warn("Resource utilization is above threshold, skipping task creation for table: {}", tableName);
           _controllerMetrics.setOrUpdateTableGauge(tableName, ControllerGauge.RESOURCE_UTILIZATION_LIMIT_EXCEEDED, 1L);
           continue;
@@ -723,8 +723,8 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
     for (TableConfig tableConfig : enabledTableConfigs) {
       String tableName = tableConfig.getTableName();
       try {
-        if (!_resourceUtilizationManager.isResourceUtilizationWithinLimits(tableName,
-            UtilizationChecker.CheckPurpose.TASK_GENERATION)) {
+        if (_resourceUtilizationManager.isResourceUtilizationWithinLimits(tableName,
+            UtilizationChecker.CheckPurpose.TASK_GENERATION).equals(UtilizationChecker.CheckResult.FALSE)) {
           String message = String.format("Skipping tasks generation as resource utilization is not within limits for "
               + "table: %s. Disk utilization for one or more servers hosting this table has exceeded the threshold. "
               + "Tasks won't be generated until the issue is mitigated.", tableName);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
@@ -224,7 +224,7 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
       LOGGER.info("Trying to create tasks of type: {}, table: {}", taskType, tableNameWithType);
       try {
         if (_resourceUtilizationManager.isResourceUtilizationWithinLimits(tableNameWithType,
-            UtilizationChecker.CheckPurpose.TASK_GENERATION).equals(UtilizationChecker.CheckResult.FALSE)) {
+            UtilizationChecker.CheckPurpose.TASK_GENERATION).equals(UtilizationChecker.CheckResult.FAIL)) {
           LOGGER.warn("Resource utilization is above threshold, skipping task creation for table: {}", tableName);
           _controllerMetrics.setOrUpdateTableGauge(tableName, ControllerGauge.RESOURCE_UTILIZATION_LIMIT_EXCEEDED, 1L);
           continue;
@@ -724,7 +724,7 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
       String tableName = tableConfig.getTableName();
       try {
         if (_resourceUtilizationManager.isResourceUtilizationWithinLimits(tableName,
-            UtilizationChecker.CheckPurpose.TASK_GENERATION).equals(UtilizationChecker.CheckResult.FALSE)) {
+            UtilizationChecker.CheckPurpose.TASK_GENERATION).equals(UtilizationChecker.CheckResult.FAIL)) {
           String message = String.format("Skipping tasks generation as resource utilization is not within limits for "
               + "table: %s. Disk utilization for one or more servers hosting this table has exceeded the threshold. "
               + "Tasks won't be generated until the issue is mitigated.", tableName);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/validation/DiskUtilizationChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/validation/DiskUtilizationChecker.java
@@ -71,7 +71,7 @@ public class DiskUtilizationChecker implements UtilizationChecker {
     TableConfig tableConfig = _helixResourceManager.getTableConfig(tableNameWithType);
     if (tableConfig == null) {
       LOGGER.warn("Table config for table: {} is null", tableNameWithType);
-      return CheckResult.TRUE; // table does not exist
+      return CheckResult.PASS; // table does not exist
     }
     List<String> instances;
     if (TableNameBuilder.isOfflineTableResource(tableNameWithType)) {
@@ -103,7 +103,7 @@ public class DiskUtilizationChecker implements UtilizationChecker {
         LOGGER.warn("Disk utilization for server: {} is above threshold: {}%. UsedBytes: {}, TotalBytes: {}",
             instance, diskUsageInfo.getUsedSpaceBytes() * 100 / diskUsageInfo.getTotalSpaceBytes(), diskUsageInfo
                 .getUsedSpaceBytes(), diskUsageInfo.getTotalSpaceBytes());
-        return CheckResult.FALSE;
+        return CheckResult.FAIL;
       }
     }
     // If results for all servers is null or stale, return the status as STALE to indicate that the status cannot be
@@ -112,7 +112,7 @@ public class DiskUtilizationChecker implements UtilizationChecker {
     //       STALE, and these are the ones that may have a resource utilization breach, but we return TRUE here.
     //       Eventually when the status is updated, the correct value will be returned and the correct action can be
     //       taken based on that. Temporarily the action taken may be the wrong one.
-    return numInstancesWithStaleOrNullResults == instances.size() ? CheckResult.STALE : CheckResult.TRUE;
+    return numInstancesWithStaleOrNullResults == instances.size() ? CheckResult.UNDETERMINED : CheckResult.PASS;
   }
 
   /**

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/validation/DiskUtilizationChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/validation/DiskUtilizationChecker.java
@@ -63,14 +63,15 @@ public class DiskUtilizationChecker implements UtilizationChecker {
    * Check if disk utilization for the requested table is within the configured limits.
    */
   @Override
-  public boolean isResourceUtilizationWithinLimits(String tableNameWithType, UtilizationChecker.CheckPurpose purpose) {
+  public CheckResult isResourceUtilizationWithinLimits(String tableNameWithType,
+      UtilizationChecker.CheckPurpose purpose) {
     if (StringUtils.isEmpty(tableNameWithType)) {
       throw new IllegalArgumentException("Table name found to be null or empty while computing disk utilization.");
     }
     TableConfig tableConfig = _helixResourceManager.getTableConfig(tableNameWithType);
     if (tableConfig == null) {
       LOGGER.warn("Table config for table: {} is null", tableNameWithType);
-      return true; // table does not exist
+      return CheckResult.TRUE; // table does not exist
     }
     List<String> instances;
     if (TableNameBuilder.isOfflineTableResource(tableNameWithType)) {
@@ -81,10 +82,12 @@ public class DiskUtilizationChecker implements UtilizationChecker {
     return isDiskUtilizationWithinLimits(instances);
   }
 
-  private boolean isDiskUtilizationWithinLimits(List<String> instances) {
+  private CheckResult isDiskUtilizationWithinLimits(List<String> instances) {
+    int numInstancesWithStaleOrNullResults = 0;
     for (String instance : instances) {
       DiskUsageInfo diskUsageInfo = ResourceUtilizationInfo.getDiskUsageInfo(instance);
       if (diskUsageInfo == null) {
+        numInstancesWithStaleOrNullResults++;
         LOGGER.warn("Disk utilization info for server: {} is null", instance);
         continue;
       }
@@ -92,6 +95,7 @@ public class DiskUtilizationChecker implements UtilizationChecker {
       // ResourceUtilizationChecker tasks frequency.
       if (diskUsageInfo.getLastUpdatedTimeInEpochMs()
           < System.currentTimeMillis() - _resourceUtilizationCheckerFrequencyMs) {
+        numInstancesWithStaleOrNullResults++;
         LOGGER.warn("Disk utilization info for server: {} is stale", instance);
         continue;
       }
@@ -99,10 +103,16 @@ public class DiskUtilizationChecker implements UtilizationChecker {
         LOGGER.warn("Disk utilization for server: {} is above threshold: {}%. UsedBytes: {}, TotalBytes: {}",
             instance, diskUsageInfo.getUsedSpaceBytes() * 100 / diskUsageInfo.getTotalSpaceBytes(), diskUsageInfo
                 .getUsedSpaceBytes(), diskUsageInfo.getTotalSpaceBytes());
-        return false;
+        return CheckResult.FALSE;
       }
     }
-    return true;
+    // If results for all servers is null or stale, return the status as STALE to indicate that the status cannot be
+    // determined.
+    // TODO: Have better handling for partial STALE results from servers. It is possible that a subset of servers are
+    //       STALE, and these are the ones that may have a resource utilization breach, but we return TRUE here.
+    //       Eventually when the status is updated, the correct value will be returned and the correct action can be
+    //       taken based on that. Temporarily the action taken may be the wrong one.
+    return numInstancesWithStaleOrNullResults == instances.size() ? CheckResult.STALE : CheckResult.TRUE;
   }
 
   /**

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/validation/DiskUtilizationChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/validation/DiskUtilizationChecker.java
@@ -63,8 +63,7 @@ public class DiskUtilizationChecker implements UtilizationChecker {
    * Check if disk utilization for the requested table is within the configured limits.
    */
   @Override
-  public CheckResult isResourceUtilizationWithinLimits(String tableNameWithType,
-      UtilizationChecker.CheckPurpose purpose) {
+  public CheckResult isResourceUtilizationWithinLimits(String tableNameWithType, CheckPurpose purpose) {
     if (StringUtils.isEmpty(tableNameWithType)) {
       throw new IllegalArgumentException("Table name found to be null or empty while computing disk utilization.");
     }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeSegmentValidationManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeSegmentValidationManager.java
@@ -159,7 +159,7 @@ public class RealtimeSegmentValidationManager extends ControllerPeriodicTask<Rea
     UtilizationChecker.CheckResult isResourceUtilizationWithinLimits =
         _resourceUtilizationManager.isResourceUtilizationWithinLimits(tableNameWithType,
             UtilizationChecker.CheckPurpose.REALTIME_INGESTION);
-    if (isResourceUtilizationWithinLimits.equals(UtilizationChecker.CheckResult.FAIL)) {
+    if (isResourceUtilizationWithinLimits == UtilizationChecker.CheckResult.FAIL) {
       LOGGER.warn("Resource utilization limit exceeded for table: {}", tableNameWithType);
       _controllerMetrics.setOrUpdateTableGauge(tableNameWithType, ControllerGauge.RESOURCE_UTILIZATION_LIMIT_EXCEEDED,
           1L);
@@ -170,7 +170,7 @@ public class RealtimeSegmentValidationManager extends ControllerPeriodicTask<Rea
             PauseState.ReasonCode.RESOURCE_UTILIZATION_LIMIT_EXCEEDED, "Resource utilization limit exceeded.");
       }
       return false; // if resource utilization check failed, then skip subsequent checks
-    } else if (isResourceUtilizationWithinLimits.equals(UtilizationChecker.CheckResult.PASS) && isTablePaused
+    } else if ((isResourceUtilizationWithinLimits == UtilizationChecker.CheckResult.PASS) && isTablePaused
         && pauseStatus.getReasonCode().equals(PauseState.ReasonCode.RESOURCE_UTILIZATION_LIMIT_EXCEEDED)) {
       // within limits and table previously paused by resource utilization --> unpause
       LOGGER.info("Resource utilization limit is back within limits for table: {}", tableNameWithType);
@@ -179,7 +179,7 @@ public class RealtimeSegmentValidationManager extends ControllerPeriodicTask<Rea
           PauseState.ReasonCode.RESOURCE_UTILIZATION_LIMIT_EXCEEDED, "Resource utilization within limits");
       pauseStatus = _llcRealtimeSegmentManager.getPauseStatusDetails(tableNameWithType);
       isTablePaused = pauseStatus.getPauseFlag();
-    } else if (isResourceUtilizationWithinLimits.equals(UtilizationChecker.CheckResult.UNDETERMINED) && isTablePaused
+    } else if ((isResourceUtilizationWithinLimits == UtilizationChecker.CheckResult.UNDETERMINED) && isTablePaused
         && pauseStatus.getReasonCode().equals(PauseState.ReasonCode.RESOURCE_UTILIZATION_LIMIT_EXCEEDED)) {
       // The table was previously paused due to exceeding resource utilization, but the current status cannot be
       // determined. To be safe, leave it as paused and once the status is available take the correct action

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeSegmentValidationManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeSegmentValidationManager.java
@@ -159,7 +159,7 @@ public class RealtimeSegmentValidationManager extends ControllerPeriodicTask<Rea
     UtilizationChecker.CheckResult isResourceUtilizationWithinLimits =
         _resourceUtilizationManager.isResourceUtilizationWithinLimits(tableNameWithType,
             UtilizationChecker.CheckPurpose.REALTIME_INGESTION);
-    if (isResourceUtilizationWithinLimits.equals(UtilizationChecker.CheckResult.FALSE)) {
+    if (isResourceUtilizationWithinLimits.equals(UtilizationChecker.CheckResult.FAIL)) {
       LOGGER.warn("Resource utilization limit exceeded for table: {}", tableNameWithType);
       _controllerMetrics.setOrUpdateTableGauge(tableNameWithType, ControllerGauge.RESOURCE_UTILIZATION_LIMIT_EXCEEDED,
           1L);
@@ -170,7 +170,7 @@ public class RealtimeSegmentValidationManager extends ControllerPeriodicTask<Rea
             PauseState.ReasonCode.RESOURCE_UTILIZATION_LIMIT_EXCEEDED, "Resource utilization limit exceeded.");
       }
       return false; // if resource utilization check failed, then skip subsequent checks
-    } else if (isResourceUtilizationWithinLimits.equals(UtilizationChecker.CheckResult.TRUE) && isTablePaused
+    } else if (isResourceUtilizationWithinLimits.equals(UtilizationChecker.CheckResult.PASS) && isTablePaused
         && pauseStatus.getReasonCode().equals(PauseState.ReasonCode.RESOURCE_UTILIZATION_LIMIT_EXCEEDED)) {
       // within limits and table previously paused by resource utilization --> unpause
       LOGGER.info("Resource utilization limit is back within limits for table: {}", tableNameWithType);
@@ -179,7 +179,7 @@ public class RealtimeSegmentValidationManager extends ControllerPeriodicTask<Rea
           PauseState.ReasonCode.RESOURCE_UTILIZATION_LIMIT_EXCEEDED, "Resource utilization within limits");
       pauseStatus = _llcRealtimeSegmentManager.getPauseStatusDetails(tableNameWithType);
       isTablePaused = pauseStatus.getPauseFlag();
-    } else if (isResourceUtilizationWithinLimits.equals(UtilizationChecker.CheckResult.STALE) && isTablePaused
+    } else if (isResourceUtilizationWithinLimits.equals(UtilizationChecker.CheckResult.UNDETERMINED) && isTablePaused
         && pauseStatus.getReasonCode().equals(PauseState.ReasonCode.RESOURCE_UTILIZATION_LIMIT_EXCEEDED)) {
       // The table was previously paused due to exceeding resource utilization, but the current status cannot be
       // determined. To be safe, leave it as paused and once the status is available take the correct action

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/validation/ResourceUtilizationManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/validation/ResourceUtilizationManager.java
@@ -61,12 +61,12 @@ public class ResourceUtilizationManager {
           utilizationChecker.isResourceUtilizationWithinLimits(tableNameWithType, purpose);
       LOGGER.info("For utilization checker: {}, isResourceUtilizationWithinLimits: {}, purpose: {}",
           utilizationChecker.getName(), isResourceUtilizationWithinLimits, purpose);
-      if (isResourceUtilizationWithinLimits.equals(UtilizationChecker.CheckResult.FAIL)) {
+      if (isResourceUtilizationWithinLimits == UtilizationChecker.CheckResult.FAIL) {
         // If any UtilizationChecker returns FAIL, we should mark the overall as FAIL. FAIL should always have
         // priority over other results
         overallIsResourceUtilizationWithinLimits = UtilizationChecker.CheckResult.FAIL;
-      } else if (overallIsResourceUtilizationWithinLimits.equals(UtilizationChecker.CheckResult.PASS)
-          && isResourceUtilizationWithinLimits.equals(UtilizationChecker.CheckResult.UNDETERMINED)) {
+      } else if ((overallIsResourceUtilizationWithinLimits == UtilizationChecker.CheckResult.PASS)
+          && (isResourceUtilizationWithinLimits == UtilizationChecker.CheckResult.UNDETERMINED)) {
         // If we haven't already updated the overall to a value other than PASS, and we get an UNDETERMINED result,
         // update the overall to UNDETERMINED. Should not update to UNDETERMINED if we have set the overall to FAIL
         overallIsResourceUtilizationWithinLimits = UtilizationChecker.CheckResult.UNDETERMINED;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/validation/ResourceUtilizationManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/validation/ResourceUtilizationManager.java
@@ -42,34 +42,34 @@ public class ResourceUtilizationManager {
    * Returns the status of the resource utilization check across all UtilizationCheckers
    * @param tableNameWithType table name with type
    * @param purpose the purpose of the utilization check
-   * @return CheckResult, FALSE if even one resource utilization checker has returned FALSE, STALE if the result cannot
-   *         be determined for even one UtilizationChecker and all the others are also STALE or TRUE, and TRUE if
-   *         resource utilization is within limits for all UtilizationCheckers
+   * @return CheckResult, FAIL if even one resource utilization checker has returned FALSE, UNDETERMINED if the result
+   *         cannot be determined for even one UtilizationChecker and all the others are also UNDETERMINED or PASS,
+   *         and PASS if resource utilization is within limits for all UtilizationCheckers
    */
   public UtilizationChecker.CheckResult isResourceUtilizationWithinLimits(String tableNameWithType,
       UtilizationChecker.CheckPurpose purpose) {
     if (!_isResourceUtilizationCheckEnabled) {
-      return UtilizationChecker.CheckResult.TRUE;
+      return UtilizationChecker.CheckResult.PASS;
     }
     if (StringUtils.isEmpty(tableNameWithType)) {
       throw new IllegalArgumentException("Table name found to be null or empty while checking resource utilization.");
     }
     LOGGER.info("Checking resource utilization for table: {}", tableNameWithType);
-    UtilizationChecker.CheckResult overallIsResourceUtilizationWithinLimits = UtilizationChecker.CheckResult.TRUE;
+    UtilizationChecker.CheckResult overallIsResourceUtilizationWithinLimits = UtilizationChecker.CheckResult.PASS;
     for (UtilizationChecker utilizationChecker : _utilizationCheckers) {
       UtilizationChecker.CheckResult isResourceUtilizationWithinLimits =
           utilizationChecker.isResourceUtilizationWithinLimits(tableNameWithType, purpose);
       LOGGER.info("For utilization checker: {}, isResourceUtilizationWithinLimits: {}, purpose: {}",
           utilizationChecker.getName(), isResourceUtilizationWithinLimits, purpose);
-      if (isResourceUtilizationWithinLimits.equals(UtilizationChecker.CheckResult.FALSE)) {
-        // If any UtilizationChecker returns FALSE, we should mark the overall as FALSE. FALSE should always have
+      if (isResourceUtilizationWithinLimits.equals(UtilizationChecker.CheckResult.FAIL)) {
+        // If any UtilizationChecker returns FAIL, we should mark the overall as FAIL. FAIL should always have
         // priority over other results
-        overallIsResourceUtilizationWithinLimits = UtilizationChecker.CheckResult.FALSE;
-      } else if (overallIsResourceUtilizationWithinLimits.equals(UtilizationChecker.CheckResult.TRUE)
-          && isResourceUtilizationWithinLimits.equals(UtilizationChecker.CheckResult.STALE)) {
-        // If we haven't already updated the overall to a value other than TRUE, and we get a STALE result,
-        // update the overall to STALE. Should not update to STALE if we have set the overall to FALSE.
-        overallIsResourceUtilizationWithinLimits = UtilizationChecker.CheckResult.STALE;
+        overallIsResourceUtilizationWithinLimits = UtilizationChecker.CheckResult.FAIL;
+      } else if (overallIsResourceUtilizationWithinLimits.equals(UtilizationChecker.CheckResult.PASS)
+          && isResourceUtilizationWithinLimits.equals(UtilizationChecker.CheckResult.UNDETERMINED)) {
+        // If we haven't already updated the overall to a value other than PASS, and we get an UNDETERMINED result,
+        // update the overall to UNDETERMINED. Should not update to UNDETERMINED if we have set the overall to FAIL
+        overallIsResourceUtilizationWithinLimits = UtilizationChecker.CheckResult.UNDETERMINED;
       }
     }
     return overallIsResourceUtilizationWithinLimits;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/validation/UtilizationChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/validation/UtilizationChecker.java
@@ -32,11 +32,12 @@ public interface UtilizationChecker {
   String getName();
 
   /**
-   * Returns true if the resource's utilization is within limits
+   * Returns whether the resource's utilization is within limits
    * @param tableNameWithType table name with type
    * @param purpose purpose of this check
+   * @return CheckResult, STALE if result cannot be determined, TRUE if within limits, FALSE if not within limits
    */
-  boolean isResourceUtilizationWithinLimits(String tableNameWithType, CheckPurpose purpose);
+  CheckResult isResourceUtilizationWithinLimits(String tableNameWithType, CheckPurpose purpose);
 
   /**
    * Computes the resource's utilization
@@ -54,5 +55,12 @@ public interface UtilizationChecker {
     // REALTIME_INGESTION if the check is performed from the realtime ingestion code path to pause ingestion
     // TASK_GENERATION if the check is performed from the task generation framework to pause creation of new tasks
     REALTIME_INGESTION, TASK_GENERATION
+  }
+
+  enum CheckResult {
+    // STALE if the result cannot be determined due to not having sufficient information
+    // TRUE if the resource's utilization is within limits
+    // FALSE if the resource's utilization is not within limits
+    STALE, TRUE, FALSE
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/validation/UtilizationChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/validation/UtilizationChecker.java
@@ -35,7 +35,7 @@ public interface UtilizationChecker {
    * Returns whether the resource's utilization is within limits
    * @param tableNameWithType table name with type
    * @param purpose purpose of this check
-   * @return CheckResult, STALE if result cannot be determined, TRUE if within limits, FALSE if not within limits
+   * @return CheckResult, UNDETERMINED if result cannot be determined, PASS if within limits, FAIL if not within limits
    */
   CheckResult isResourceUtilizationWithinLimits(String tableNameWithType, CheckPurpose purpose);
 
@@ -58,9 +58,9 @@ public interface UtilizationChecker {
   }
 
   enum CheckResult {
-    // STALE if the result cannot be determined due to not having sufficient information
-    // TRUE if the resource's utilization is within limits
-    // FALSE if the resource's utilization is not within limits
-    STALE, TRUE, FALSE
+    // PASS if the resource's utilization is within limits
+    // FAIL if the resource's utilization is not within limits
+    // UNDETERMINED if the result cannot be determined due to not having sufficient information
+    PASS, FAIL, UNDETERMINED
   }
 }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/validation/DiskUtilizationCheckerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/validation/DiskUtilizationCheckerTest.java
@@ -82,11 +82,11 @@ public class DiskUtilizationCheckerTest {
 
     UtilizationChecker.CheckResult result = _diskUtilizationChecker.isResourceUtilizationWithinLimits(tableName,
         UtilizationChecker.CheckPurpose.REALTIME_INGESTION);
-    Assert.assertEquals(result, UtilizationChecker.CheckResult.TRUE);
+    Assert.assertEquals(result, UtilizationChecker.CheckResult.PASS);
 
     result = _diskUtilizationChecker.isResourceUtilizationWithinLimits(tableName,
         UtilizationChecker.CheckPurpose.TASK_GENERATION);
-    Assert.assertEquals(result, UtilizationChecker.CheckResult.TRUE);
+    Assert.assertEquals(result, UtilizationChecker.CheckResult.PASS);
   }
 
   @Test
@@ -96,11 +96,11 @@ public class DiskUtilizationCheckerTest {
 
     UtilizationChecker.CheckResult result = _diskUtilizationChecker.isResourceUtilizationWithinLimits(tableName,
         UtilizationChecker.CheckPurpose.REALTIME_INGESTION);
-    Assert.assertEquals(result, UtilizationChecker.CheckResult.TRUE);
+    Assert.assertEquals(result, UtilizationChecker.CheckResult.PASS);
 
     result = _diskUtilizationChecker.isResourceUtilizationWithinLimits(tableName,
         UtilizationChecker.CheckPurpose.TASK_GENERATION);
-    Assert.assertEquals(result, UtilizationChecker.CheckResult.TRUE);
+    Assert.assertEquals(result, UtilizationChecker.CheckResult.PASS);
   }
 
   @Test
@@ -124,11 +124,11 @@ public class DiskUtilizationCheckerTest {
 
     UtilizationChecker.CheckResult result = _diskUtilizationChecker.isResourceUtilizationWithinLimits(tableName,
         UtilizationChecker.CheckPurpose.REALTIME_INGESTION);
-    Assert.assertEquals(result, UtilizationChecker.CheckResult.STALE);
+    Assert.assertEquals(result, UtilizationChecker.CheckResult.UNDETERMINED);
 
     result = _diskUtilizationChecker.isResourceUtilizationWithinLimits(tableName,
         UtilizationChecker.CheckPurpose.TASK_GENERATION);
-    Assert.assertEquals(result, UtilizationChecker.CheckResult.STALE);
+    Assert.assertEquals(result, UtilizationChecker.CheckResult.UNDETERMINED);
   }
 
   @Test
@@ -154,11 +154,11 @@ public class DiskUtilizationCheckerTest {
 
     UtilizationChecker.CheckResult result = _diskUtilizationChecker.isResourceUtilizationWithinLimits(tableName,
         UtilizationChecker.CheckPurpose.REALTIME_INGESTION);
-    Assert.assertEquals(result, UtilizationChecker.CheckResult.TRUE);
+    Assert.assertEquals(result, UtilizationChecker.CheckResult.PASS);
 
     result = _diskUtilizationChecker.isResourceUtilizationWithinLimits(tableName,
         UtilizationChecker.CheckPurpose.TASK_GENERATION);
-    Assert.assertEquals(result, UtilizationChecker.CheckResult.TRUE);
+    Assert.assertEquals(result, UtilizationChecker.CheckResult.PASS);
   }
 
   @Test
@@ -184,11 +184,11 @@ public class DiskUtilizationCheckerTest {
 
     UtilizationChecker.CheckResult result = _diskUtilizationChecker.isResourceUtilizationWithinLimits(tableName,
         UtilizationChecker.CheckPurpose.REALTIME_INGESTION);
-    Assert.assertEquals(result, UtilizationChecker.CheckResult.FALSE);
+    Assert.assertEquals(result, UtilizationChecker.CheckResult.FAIL);
 
     result = _diskUtilizationChecker.isResourceUtilizationWithinLimits(tableName,
         UtilizationChecker.CheckPurpose.TASK_GENERATION);
-    Assert.assertEquals(result, UtilizationChecker.CheckResult.FALSE);
+    Assert.assertEquals(result, UtilizationChecker.CheckResult.FAIL);
   }
 
   @Test

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/validation/DiskUtilizationCheckerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/validation/DiskUtilizationCheckerTest.java
@@ -80,27 +80,55 @@ public class DiskUtilizationCheckerTest {
     String tableName = "test_OFFLINE";
     when(_helixResourceManager.getOfflineTableConfig(tableName)).thenReturn(null);
 
-    boolean result = _diskUtilizationChecker.isResourceUtilizationWithinLimits(tableName,
+    UtilizationChecker.CheckResult result = _diskUtilizationChecker.isResourceUtilizationWithinLimits(tableName,
         UtilizationChecker.CheckPurpose.REALTIME_INGESTION);
-    Assert.assertTrue(result);
+    Assert.assertEquals(result, UtilizationChecker.CheckResult.TRUE);
 
     result = _diskUtilizationChecker.isResourceUtilizationWithinLimits(tableName,
         UtilizationChecker.CheckPurpose.TASK_GENERATION);
-    Assert.assertTrue(result);
+    Assert.assertEquals(result, UtilizationChecker.CheckResult.TRUE);
   }
 
   @Test
   public void testIsDiskUtilizationWithinLimitsNonExistentRealtimeTable() {
     String tableName = "test_REALTIME";
-    when(_helixResourceManager.getRealtimeTableConfig(tableName)).thenReturn(null);
+    when(_helixResourceManager.getTableConfig(tableName)).thenReturn(null);
 
-    boolean result = _diskUtilizationChecker.isResourceUtilizationWithinLimits(tableName,
+    UtilizationChecker.CheckResult result = _diskUtilizationChecker.isResourceUtilizationWithinLimits(tableName,
         UtilizationChecker.CheckPurpose.REALTIME_INGESTION);
-    Assert.assertTrue(result);
+    Assert.assertEquals(result, UtilizationChecker.CheckResult.TRUE);
 
     result = _diskUtilizationChecker.isResourceUtilizationWithinLimits(tableName,
         UtilizationChecker.CheckPurpose.TASK_GENERATION);
-    Assert.assertTrue(result);
+    Assert.assertEquals(result, UtilizationChecker.CheckResult.TRUE);
+  }
+
+  @Test
+  public void testIsDiskUtilizationStale() {
+    String tableName = "test_OFFLINE";
+
+    TableConfig mockTableConfig = mock(TableConfig.class);
+    when(_helixResourceManager.getTableConfig(tableName)).thenReturn(mockTableConfig);
+
+    List<String> mockInstances = Arrays.asList("server1", "server2");
+    when(_helixResourceManager.getServerInstancesForTable(tableName, TableType.OFFLINE)).thenReturn(mockInstances);
+
+    // Mock disk usage
+    Map<String, DiskUsageInfo> diskUsageInfoMap = new HashMap<>();
+    DiskUsageInfo diskUsageInfo1 = new DiskUsageInfo("server1");
+    diskUsageInfoMap.put("server1", diskUsageInfo1);
+
+    DiskUsageInfo diskUsageInfo2 = new DiskUsageInfo("server2");
+    diskUsageInfoMap.put("server2", diskUsageInfo2);
+    ResourceUtilizationInfo.setDiskUsageInfo(diskUsageInfoMap);
+
+    UtilizationChecker.CheckResult result = _diskUtilizationChecker.isResourceUtilizationWithinLimits(tableName,
+        UtilizationChecker.CheckPurpose.REALTIME_INGESTION);
+    Assert.assertEquals(result, UtilizationChecker.CheckResult.STALE);
+
+    result = _diskUtilizationChecker.isResourceUtilizationWithinLimits(tableName,
+        UtilizationChecker.CheckPurpose.TASK_GENERATION);
+    Assert.assertEquals(result, UtilizationChecker.CheckResult.STALE);
   }
 
   @Test
@@ -108,7 +136,7 @@ public class DiskUtilizationCheckerTest {
     String tableName = "test_OFFLINE";
 
     TableConfig mockTableConfig = mock(TableConfig.class);
-    when(_helixResourceManager.getOfflineTableConfig(tableName)).thenReturn(mockTableConfig);
+    when(_helixResourceManager.getTableConfig(tableName)).thenReturn(mockTableConfig);
 
     List<String> mockInstances = Arrays.asList("server1", "server2");
     when(_helixResourceManager.getServerInstancesForTable(tableName, TableType.OFFLINE)).thenReturn(mockInstances);
@@ -124,13 +152,13 @@ public class DiskUtilizationCheckerTest {
     diskUsageInfoMap.put("server2", diskUsageInfo2);
     ResourceUtilizationInfo.setDiskUsageInfo(diskUsageInfoMap);
 
-    boolean result = _diskUtilizationChecker.isResourceUtilizationWithinLimits(tableName,
+    UtilizationChecker.CheckResult result = _diskUtilizationChecker.isResourceUtilizationWithinLimits(tableName,
         UtilizationChecker.CheckPurpose.REALTIME_INGESTION);
-    Assert.assertTrue(result);
+    Assert.assertEquals(result, UtilizationChecker.CheckResult.TRUE);
 
     result = _diskUtilizationChecker.isResourceUtilizationWithinLimits(tableName,
         UtilizationChecker.CheckPurpose.TASK_GENERATION);
-    Assert.assertTrue(result);
+    Assert.assertEquals(result, UtilizationChecker.CheckResult.TRUE);
   }
 
   @Test
@@ -154,13 +182,13 @@ public class DiskUtilizationCheckerTest {
     diskUsageInfoMap.put("server2", diskUsageInfo2);
     ResourceUtilizationInfo.setDiskUsageInfo(diskUsageInfoMap);
 
-    boolean result = _diskUtilizationChecker.isResourceUtilizationWithinLimits(tableName,
+    UtilizationChecker.CheckResult result = _diskUtilizationChecker.isResourceUtilizationWithinLimits(tableName,
         UtilizationChecker.CheckPurpose.REALTIME_INGESTION);
-    Assert.assertFalse(result);
+    Assert.assertEquals(result, UtilizationChecker.CheckResult.FALSE);
 
     result = _diskUtilizationChecker.isResourceUtilizationWithinLimits(tableName,
         UtilizationChecker.CheckPurpose.TASK_GENERATION);
-    Assert.assertFalse(result);
+    Assert.assertEquals(result, UtilizationChecker.CheckResult.FALSE);
   }
 
   @Test

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/validation/RealtimeSegmentValidationManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/validation/RealtimeSegmentValidationManagerTest.java
@@ -74,29 +74,40 @@ public class RealtimeSegmentValidationManagerTest {
   public Object[][] testCases() {
     return new Object[][]{
         // Table is paused due to admin intervention, should return false
-        {true, PauseState.ReasonCode.ADMINISTRATIVE, false, false, false},
+        {true, PauseState.ReasonCode.ADMINISTRATIVE, UtilizationChecker.CheckResult.TRUE, false, false},
 
         // Resource utilization exceeded and pause state is updated, should return false
-        {false, PauseState.ReasonCode.RESOURCE_UTILIZATION_LIMIT_EXCEEDED, true, false, false},
+        {false, PauseState.ReasonCode.RESOURCE_UTILIZATION_LIMIT_EXCEEDED, UtilizationChecker.CheckResult.FALSE, false,
+            false},
 
         // Resource utilization is within limits but was previously paused due to resource utilization,
         // should return true
-        {true, PauseState.ReasonCode.RESOURCE_UTILIZATION_LIMIT_EXCEEDED, false, false, true},
+        {true, PauseState.ReasonCode.RESOURCE_UTILIZATION_LIMIT_EXCEEDED, UtilizationChecker.CheckResult.TRUE, false,
+            true},
+
+        // Resource utilization is STALE but was previously paused due to resource utilization, should return false
+        {true, PauseState.ReasonCode.RESOURCE_UTILIZATION_LIMIT_EXCEEDED, UtilizationChecker.CheckResult.STALE, false,
+            false},
+
+        // Resource utilization is STALE but was not previously paused due to resource utilization, should return true
+        {false, PauseState.ReasonCode.RESOURCE_UTILIZATION_LIMIT_EXCEEDED, UtilizationChecker.CheckResult.STALE, false,
+            true},
 
         // Resource utilization is within limits but was previously paused due to storage quota exceeded,
         // should return false
-        {true, PauseState.ReasonCode.STORAGE_QUOTA_EXCEEDED, false, true, false},
+        {true, PauseState.ReasonCode.STORAGE_QUOTA_EXCEEDED, UtilizationChecker.CheckResult.TRUE, true, false},
 
         // Storage quota exceeded, should return false
-        {false, PauseState.ReasonCode.STORAGE_QUOTA_EXCEEDED, false, true, false},
+        {false, PauseState.ReasonCode.STORAGE_QUOTA_EXCEEDED, UtilizationChecker.CheckResult.TRUE, true, false},
 
         // Storage quota within limits but was previously paused due to storage quota exceeded, should return true
-        {true, PauseState.ReasonCode.STORAGE_QUOTA_EXCEEDED, false, false, true}};
+        {true, PauseState.ReasonCode.STORAGE_QUOTA_EXCEEDED, UtilizationChecker.CheckResult.TRUE, false, true}};
   }
 
   @Test(dataProvider = "testCases")
   public void testShouldEnsureConsuming(boolean isTablePaused, PauseState.ReasonCode reasonCode,
-      boolean isResourceUtilizationExceeded, boolean isQuotaExceeded, boolean expectedResult) {
+      UtilizationChecker.CheckResult isResourceUtilizationWithinLimits, boolean isQuotaExceeded,
+      boolean expectedResult) {
     String tableName = "testTable_REALTIME";
     PauseStatusDetails pauseStatus = mock(PauseStatusDetails.class);
     TableConfig tableConfig = mock(TableConfig.class);
@@ -105,7 +116,7 @@ public class RealtimeSegmentValidationManagerTest {
     when(pauseStatus.getReasonCode()).thenReturn(reasonCode);
     when(_llcRealtimeSegmentManager.getPauseStatusDetails(tableName)).thenReturn(pauseStatus);
     when(_resourceUtilizationManager.isResourceUtilizationWithinLimits(tableName,
-        UtilizationChecker.CheckPurpose.REALTIME_INGESTION)).thenReturn(!isResourceUtilizationExceeded);
+        UtilizationChecker.CheckPurpose.REALTIME_INGESTION)).thenReturn(isResourceUtilizationWithinLimits);
     when(_pinotHelixResourceManager.getTableConfig(tableName)).thenReturn(tableConfig);
     when(_storageQuotaChecker.isTableStorageQuotaExceeded(tableConfig)).thenReturn(isQuotaExceeded);
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/validation/RealtimeSegmentValidationManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/validation/RealtimeSegmentValidationManagerTest.java
@@ -86,12 +86,12 @@ public class RealtimeSegmentValidationManagerTest {
             true},
 
         // Resource utilization is STALE but was previously paused due to resource utilization, should return false
-        {true, PauseState.ReasonCode.RESOURCE_UTILIZATION_LIMIT_EXCEEDED, UtilizationChecker.CheckResult.UNDETERMINED, false,
-            false},
+        {true, PauseState.ReasonCode.RESOURCE_UTILIZATION_LIMIT_EXCEEDED, UtilizationChecker.CheckResult.UNDETERMINED,
+            false, false},
 
         // Resource utilization is STALE but was not previously paused due to resource utilization, should return true
-        {false, PauseState.ReasonCode.RESOURCE_UTILIZATION_LIMIT_EXCEEDED, UtilizationChecker.CheckResult.UNDETERMINED, false,
-            true},
+        {false, PauseState.ReasonCode.RESOURCE_UTILIZATION_LIMIT_EXCEEDED, UtilizationChecker.CheckResult.UNDETERMINED,
+            false, true},
 
         // Resource utilization is within limits but was previously paused due to storage quota exceeded,
         // should return false

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/validation/RealtimeSegmentValidationManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/validation/RealtimeSegmentValidationManagerTest.java
@@ -74,34 +74,34 @@ public class RealtimeSegmentValidationManagerTest {
   public Object[][] testCases() {
     return new Object[][]{
         // Table is paused due to admin intervention, should return false
-        {true, PauseState.ReasonCode.ADMINISTRATIVE, UtilizationChecker.CheckResult.TRUE, false, false},
+        {true, PauseState.ReasonCode.ADMINISTRATIVE, UtilizationChecker.CheckResult.PASS, false, false},
 
         // Resource utilization exceeded and pause state is updated, should return false
-        {false, PauseState.ReasonCode.RESOURCE_UTILIZATION_LIMIT_EXCEEDED, UtilizationChecker.CheckResult.FALSE, false,
+        {false, PauseState.ReasonCode.RESOURCE_UTILIZATION_LIMIT_EXCEEDED, UtilizationChecker.CheckResult.FAIL, false,
             false},
 
         // Resource utilization is within limits but was previously paused due to resource utilization,
         // should return true
-        {true, PauseState.ReasonCode.RESOURCE_UTILIZATION_LIMIT_EXCEEDED, UtilizationChecker.CheckResult.TRUE, false,
+        {true, PauseState.ReasonCode.RESOURCE_UTILIZATION_LIMIT_EXCEEDED, UtilizationChecker.CheckResult.PASS, false,
             true},
 
         // Resource utilization is STALE but was previously paused due to resource utilization, should return false
-        {true, PauseState.ReasonCode.RESOURCE_UTILIZATION_LIMIT_EXCEEDED, UtilizationChecker.CheckResult.STALE, false,
+        {true, PauseState.ReasonCode.RESOURCE_UTILIZATION_LIMIT_EXCEEDED, UtilizationChecker.CheckResult.UNDETERMINED, false,
             false},
 
         // Resource utilization is STALE but was not previously paused due to resource utilization, should return true
-        {false, PauseState.ReasonCode.RESOURCE_UTILIZATION_LIMIT_EXCEEDED, UtilizationChecker.CheckResult.STALE, false,
+        {false, PauseState.ReasonCode.RESOURCE_UTILIZATION_LIMIT_EXCEEDED, UtilizationChecker.CheckResult.UNDETERMINED, false,
             true},
 
         // Resource utilization is within limits but was previously paused due to storage quota exceeded,
         // should return false
-        {true, PauseState.ReasonCode.STORAGE_QUOTA_EXCEEDED, UtilizationChecker.CheckResult.TRUE, true, false},
+        {true, PauseState.ReasonCode.STORAGE_QUOTA_EXCEEDED, UtilizationChecker.CheckResult.PASS, true, false},
 
         // Storage quota exceeded, should return false
-        {false, PauseState.ReasonCode.STORAGE_QUOTA_EXCEEDED, UtilizationChecker.CheckResult.TRUE, true, false},
+        {false, PauseState.ReasonCode.STORAGE_QUOTA_EXCEEDED, UtilizationChecker.CheckResult.PASS, true, false},
 
         // Storage quota within limits but was previously paused due to storage quota exceeded, should return true
-        {true, PauseState.ReasonCode.STORAGE_QUOTA_EXCEEDED, UtilizationChecker.CheckResult.TRUE, false, true}};
+        {true, PauseState.ReasonCode.STORAGE_QUOTA_EXCEEDED, UtilizationChecker.CheckResult.PASS, false, true}};
   }
 
   @Test(dataProvider = "testCases")

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/validation/ResourceUtilizationManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/validation/ResourceUtilizationManagerTest.java
@@ -48,12 +48,12 @@ public class ResourceUtilizationManagerTest {
 
     UtilizationChecker.CheckResult result = _resourceUtilizationManager.isResourceUtilizationWithinLimits(_testTable,
         UtilizationChecker.CheckPurpose.REALTIME_INGESTION);
-    Assert.assertEquals(result, UtilizationChecker.CheckResult.TRUE,
+    Assert.assertEquals(result, UtilizationChecker.CheckResult.PASS,
         "Resource utilization should be within limits when the check is disabled");
 
     result = _resourceUtilizationManager.isResourceUtilizationWithinLimits(_testTable,
         UtilizationChecker.CheckPurpose.TASK_GENERATION);
-    Assert.assertEquals(result, UtilizationChecker.CheckResult.TRUE,
+    Assert.assertEquals(result, UtilizationChecker.CheckResult.PASS,
         "Resource utilization should be within limits when the check is disabled");
   }
 
@@ -97,19 +97,19 @@ public class ResourceUtilizationManagerTest {
   public void testIsResourceUtilizationWithinLimitsWhenCheckIsEnabled() {
     Mockito.when(_controllerConf.isResourceUtilizationCheckEnabled()).thenReturn(true);
     Mockito.when(_diskUtilizationChecker.isResourceUtilizationWithinLimits(_testTable,
-        UtilizationChecker.CheckPurpose.REALTIME_INGESTION)).thenReturn(UtilizationChecker.CheckResult.TRUE);
+        UtilizationChecker.CheckPurpose.REALTIME_INGESTION)).thenReturn(UtilizationChecker.CheckResult.PASS);
     _resourceUtilizationManager = new ResourceUtilizationManager(_controllerConf, _utilizationCheckers);
 
     UtilizationChecker.CheckResult result = _resourceUtilizationManager.isResourceUtilizationWithinLimits(_testTable,
         UtilizationChecker.CheckPurpose.REALTIME_INGESTION);
-    Assert.assertEquals(result, UtilizationChecker.CheckResult.TRUE,
+    Assert.assertEquals(result, UtilizationChecker.CheckResult.PASS,
         "Resource utilization should be within limits when disk check and primary key count check returns true");
 
     Mockito.when(_diskUtilizationChecker.isResourceUtilizationWithinLimits(_testTable,
-        UtilizationChecker.CheckPurpose.TASK_GENERATION)).thenReturn(UtilizationChecker.CheckResult.TRUE);
+        UtilizationChecker.CheckPurpose.TASK_GENERATION)).thenReturn(UtilizationChecker.CheckResult.PASS);
     result = _resourceUtilizationManager.isResourceUtilizationWithinLimits(_testTable,
         UtilizationChecker.CheckPurpose.TASK_GENERATION);
-    Assert.assertEquals(result, UtilizationChecker.CheckResult.TRUE,
+    Assert.assertEquals(result, UtilizationChecker.CheckResult.PASS,
         "Resource utilization should be within limits when disk check and primary key count check returns true");
   }
 
@@ -117,19 +117,19 @@ public class ResourceUtilizationManagerTest {
   public void testIsResourceUtilizationWithinLimitsWhenCheckFails() {
     Mockito.when(_controllerConf.isResourceUtilizationCheckEnabled()).thenReturn(true);
     Mockito.when(_diskUtilizationChecker.isResourceUtilizationWithinLimits(_testTable,
-        UtilizationChecker.CheckPurpose.REALTIME_INGESTION)).thenReturn(UtilizationChecker.CheckResult.FALSE);
+        UtilizationChecker.CheckPurpose.REALTIME_INGESTION)).thenReturn(UtilizationChecker.CheckResult.FAIL);
     Mockito.when(_diskUtilizationChecker.isResourceUtilizationWithinLimits(_testTable,
-        UtilizationChecker.CheckPurpose.TASK_GENERATION)).thenReturn(UtilizationChecker.CheckResult.FALSE);
+        UtilizationChecker.CheckPurpose.TASK_GENERATION)).thenReturn(UtilizationChecker.CheckResult.FAIL);
     _resourceUtilizationManager = new ResourceUtilizationManager(_controllerConf, _utilizationCheckers);
 
     UtilizationChecker.CheckResult result = _resourceUtilizationManager.isResourceUtilizationWithinLimits(_testTable,
         UtilizationChecker.CheckPurpose.REALTIME_INGESTION);
-    Assert.assertEquals(result, UtilizationChecker.CheckResult.FALSE,
+    Assert.assertEquals(result, UtilizationChecker.CheckResult.FAIL,
         "Resource utilization should not be within limits when disk check returns false");
 
     result = _resourceUtilizationManager.isResourceUtilizationWithinLimits(_testTable,
         UtilizationChecker.CheckPurpose.TASK_GENERATION);
-    Assert.assertEquals(result, UtilizationChecker.CheckResult.FALSE,
+    Assert.assertEquals(result, UtilizationChecker.CheckResult.FAIL,
         "Resource utilization should not be within limits when disk check returns false");
   }
 
@@ -137,19 +137,19 @@ public class ResourceUtilizationManagerTest {
   public void testIsResourceUtilizationWithinLimitsWhenCheckStale() {
     Mockito.when(_controllerConf.isResourceUtilizationCheckEnabled()).thenReturn(true);
     Mockito.when(_diskUtilizationChecker.isResourceUtilizationWithinLimits(_testTable,
-        UtilizationChecker.CheckPurpose.REALTIME_INGESTION)).thenReturn(UtilizationChecker.CheckResult.STALE);
+        UtilizationChecker.CheckPurpose.REALTIME_INGESTION)).thenReturn(UtilizationChecker.CheckResult.UNDETERMINED);
     Mockito.when(_diskUtilizationChecker.isResourceUtilizationWithinLimits(_testTable,
-        UtilizationChecker.CheckPurpose.TASK_GENERATION)).thenReturn(UtilizationChecker.CheckResult.STALE);
+        UtilizationChecker.CheckPurpose.TASK_GENERATION)).thenReturn(UtilizationChecker.CheckResult.UNDETERMINED);
     _resourceUtilizationManager = new ResourceUtilizationManager(_controllerConf, _utilizationCheckers);
 
     UtilizationChecker.CheckResult result = _resourceUtilizationManager.isResourceUtilizationWithinLimits(_testTable,
         UtilizationChecker.CheckPurpose.REALTIME_INGESTION);
-    Assert.assertEquals(result, UtilizationChecker.CheckResult.STALE,
+    Assert.assertEquals(result, UtilizationChecker.CheckResult.UNDETERMINED,
         "Resource utilization should return STALE when the diskUtilization returns STALE");
 
     result = _resourceUtilizationManager.isResourceUtilizationWithinLimits(_testTable,
         UtilizationChecker.CheckPurpose.TASK_GENERATION);
-    Assert.assertEquals(result, UtilizationChecker.CheckResult.STALE,
+    Assert.assertEquals(result, UtilizationChecker.CheckResult.UNDETERMINED,
         "Resource utilization should return STALE when the diskUtilization returns STALE");
   }
 }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/validation/ResourceUtilizationManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/validation/ResourceUtilizationManagerTest.java
@@ -46,13 +46,15 @@ public class ResourceUtilizationManagerTest {
     Mockito.when(_controllerConf.isResourceUtilizationCheckEnabled()).thenReturn(false);
     _resourceUtilizationManager = new ResourceUtilizationManager(_controllerConf, _utilizationCheckers);
 
-    boolean result = _resourceUtilizationManager.isResourceUtilizationWithinLimits(_testTable,
+    UtilizationChecker.CheckResult result = _resourceUtilizationManager.isResourceUtilizationWithinLimits(_testTable,
         UtilizationChecker.CheckPurpose.REALTIME_INGESTION);
-    Assert.assertTrue(result, "Resource utilization should be within limits when the check is disabled");
+    Assert.assertEquals(result, UtilizationChecker.CheckResult.TRUE,
+        "Resource utilization should be within limits when the check is disabled");
 
     result = _resourceUtilizationManager.isResourceUtilizationWithinLimits(_testTable,
         UtilizationChecker.CheckPurpose.TASK_GENERATION);
-    Assert.assertTrue(result, "Resource utilization should be within limits when the check is disabled");
+    Assert.assertEquals(result, UtilizationChecker.CheckResult.TRUE,
+        "Resource utilization should be within limits when the check is disabled");
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class)
@@ -95,35 +97,59 @@ public class ResourceUtilizationManagerTest {
   public void testIsResourceUtilizationWithinLimitsWhenCheckIsEnabled() {
     Mockito.when(_controllerConf.isResourceUtilizationCheckEnabled()).thenReturn(true);
     Mockito.when(_diskUtilizationChecker.isResourceUtilizationWithinLimits(_testTable,
-        UtilizationChecker.CheckPurpose.REALTIME_INGESTION)).thenReturn(true);
+        UtilizationChecker.CheckPurpose.REALTIME_INGESTION)).thenReturn(UtilizationChecker.CheckResult.TRUE);
     _resourceUtilizationManager = new ResourceUtilizationManager(_controllerConf, _utilizationCheckers);
 
-    boolean result = _resourceUtilizationManager.isResourceUtilizationWithinLimits(_testTable,
+    UtilizationChecker.CheckResult result = _resourceUtilizationManager.isResourceUtilizationWithinLimits(_testTable,
         UtilizationChecker.CheckPurpose.REALTIME_INGESTION);
-    Assert.assertTrue(result, "Resource utilization should be within limits when disk check and primary key count "
-        + "check returns true");
+    Assert.assertEquals(result, UtilizationChecker.CheckResult.TRUE,
+        "Resource utilization should be within limits when disk check and primary key count check returns true");
 
     Mockito.when(_diskUtilizationChecker.isResourceUtilizationWithinLimits(_testTable,
-        UtilizationChecker.CheckPurpose.TASK_GENERATION)).thenReturn(true);
+        UtilizationChecker.CheckPurpose.TASK_GENERATION)).thenReturn(UtilizationChecker.CheckResult.TRUE);
     result = _resourceUtilizationManager.isResourceUtilizationWithinLimits(_testTable,
         UtilizationChecker.CheckPurpose.TASK_GENERATION);
-    Assert.assertTrue(result, "Resource utilization should be within limits when disk check and primary key count "
-        + "check returns true");
+    Assert.assertEquals(result, UtilizationChecker.CheckResult.TRUE,
+        "Resource utilization should be within limits when disk check and primary key count check returns true");
   }
 
   @Test
   public void testIsResourceUtilizationWithinLimitsWhenCheckFails() {
     Mockito.when(_controllerConf.isResourceUtilizationCheckEnabled()).thenReturn(true);
     Mockito.when(_diskUtilizationChecker.isResourceUtilizationWithinLimits(_testTable,
-        UtilizationChecker.CheckPurpose.REALTIME_INGESTION)).thenReturn(false);
+        UtilizationChecker.CheckPurpose.REALTIME_INGESTION)).thenReturn(UtilizationChecker.CheckResult.FALSE);
+    Mockito.when(_diskUtilizationChecker.isResourceUtilizationWithinLimits(_testTable,
+        UtilizationChecker.CheckPurpose.TASK_GENERATION)).thenReturn(UtilizationChecker.CheckResult.FALSE);
     _resourceUtilizationManager = new ResourceUtilizationManager(_controllerConf, _utilizationCheckers);
 
-    boolean result = _resourceUtilizationManager.isResourceUtilizationWithinLimits(_testTable,
+    UtilizationChecker.CheckResult result = _resourceUtilizationManager.isResourceUtilizationWithinLimits(_testTable,
         UtilizationChecker.CheckPurpose.REALTIME_INGESTION);
-    Assert.assertFalse(result, "Resource utilization should not be within limits when disk check returns false");
+    Assert.assertEquals(result, UtilizationChecker.CheckResult.FALSE,
+        "Resource utilization should not be within limits when disk check returns false");
 
     result = _resourceUtilizationManager.isResourceUtilizationWithinLimits(_testTable,
         UtilizationChecker.CheckPurpose.TASK_GENERATION);
-    Assert.assertFalse(result, "Resource utilization should not be within limits when disk check returns false");
+    Assert.assertEquals(result, UtilizationChecker.CheckResult.FALSE,
+        "Resource utilization should not be within limits when disk check returns false");
+  }
+
+  @Test
+  public void testIsResourceUtilizationWithinLimitsWhenCheckStale() {
+    Mockito.when(_controllerConf.isResourceUtilizationCheckEnabled()).thenReturn(true);
+    Mockito.when(_diskUtilizationChecker.isResourceUtilizationWithinLimits(_testTable,
+        UtilizationChecker.CheckPurpose.REALTIME_INGESTION)).thenReturn(UtilizationChecker.CheckResult.STALE);
+    Mockito.when(_diskUtilizationChecker.isResourceUtilizationWithinLimits(_testTable,
+        UtilizationChecker.CheckPurpose.TASK_GENERATION)).thenReturn(UtilizationChecker.CheckResult.STALE);
+    _resourceUtilizationManager = new ResourceUtilizationManager(_controllerConf, _utilizationCheckers);
+
+    UtilizationChecker.CheckResult result = _resourceUtilizationManager.isResourceUtilizationWithinLimits(_testTable,
+        UtilizationChecker.CheckPurpose.REALTIME_INGESTION);
+    Assert.assertEquals(result, UtilizationChecker.CheckResult.STALE,
+        "Resource utilization should return STALE when the diskUtilization returns STALE");
+
+    result = _resourceUtilizationManager.isResourceUtilizationWithinLimits(_testTable,
+        UtilizationChecker.CheckPurpose.TASK_GENERATION);
+    Assert.assertEquals(result, UtilizationChecker.CheckResult.STALE,
+        "Resource utilization should return STALE when the diskUtilization returns STALE");
   }
 }


### PR DESCRIPTION
Today the `UtilizationChecker` and `ResourceUtilizationManager` return a boolean for the resource utilization check. For scenarios where the controller is restarted, for some time it is possible that no cached resource utilization data exists on the controller (e.g. disk utilization information has to be fetched from servers and then cached in the controller by the `ResourceUtilizationChecker` periodic task). Today for such scenarios, the resource utilization check returns `true`. This can lead to weird behavior where a previously paused table may be un-paused for a short period of time, and then be paused again once the information has been fetched correctly.

To get around the above, this PR handles this scenario by:
- Adding a new enum, `CheckResult` with three values: UNDETERMINED, PASS, FAIL
- The resource utilization check will now return a `CheckResult` enum
- The `DiskUtilizationChecker` returns the UNDETERMINED status when all the server instances for that table are UNDETERMINED (or stale)
- If only a subset are stale, the `DiskUtilizationChecker` will return FAIL if any of the known servers breach utilization, otherwise PASS
- For the RealtimeSegmentValidation code path, the table is not un-paused if a UNDETERMINED status is returned
- For the TaskGeneration code path, no change (UNDETERMINED is ignored) **[let me know if we should skip task creation in this case as well]**

This PR does not address the following limitation:
- A server's status may be UNDETERMINED for reasons such as server restart taking longer than the utilization check frequency. In such cases, a subset of servers may have a UNDETERMINED status, but other's do not. If only the servers breaching the resource utilization limit are UNDETERMINED, it is possible that the table may be temporarily un-paused and re-paused later when the server status is updated correctly. This PR does not address this. We also need to look into scenarios like a server getting removed which may result in UNDETERMINED status indefinitely and this needs to be handled correctly before we can prevent this scenario from occurring.