### PR TITLE
Throttle based on unfiltered messages

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -571,8 +571,8 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
    */
   private boolean processStreamEvents(MessageBatch messageBatch, long idlePipeSleepTimeMillis) {
     int messageCount = messageBatch.getMessageCount();
-    _partitionRateLimiter.throttle(messageCount);
-    _serverRateLimiter.throttle(messageCount);
+    _partitionRateLimiter.throttle(messageBatch.getUnfilteredMessageCount());
+    _serverRateLimiter.throttle(messageBatch.getUnfilteredMessageCount());
 
     PinotMeter realtimeBytesIngestedMeter = null;
     PinotMeter realtimeBytesDroppedMeter = null;


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Throttle now uses unfiltered message count for both partition and server rate limiters\.

```mermaid
flowchart TD
  N0["Get unfiltered message count #40;F1#41;"]:::stAdded
  N1["Throttle partition rate limiter #40;F1#41;"]:::stModified
  N2["Throttle server rate limiter #40;F1#41;"]:::stModified
  N0 -->|"value passed"| N1
  N0 -->|"value passed"| N2
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager\.java — [before](https://github.com/apache/pinot/blob/acbc35b463d09ee164899730dc0b16ec8641a342/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java) · [after](https://github.com/apache/pinot/blob/db61812bccf4d6b21ba8657c1b046b3bd24b8d53/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImFjYmMzNWI0NjNkMDllZTE2NDg5OTczMGRjMGIxNmVjODY0MWEzNDIiLCJjb250ZXh0X2hhc2giOiIyZTU1ZmMwOGE4YTVmZmZkMDJiNTU2MzU5OTMyMjg4NDVmMWNmZmE0NmM1YzFiZmExMmVkNjVjNWU1MjJkYjYwIiwiZ2VuZXJhdGVkX2F0IjoxNzg5NTMzMzA4LCJoZWFkX3NoYSI6ImRiNjE4MTJiY2NmNGQ2YjIxYmE4NjU3YzFiMDQ2YjNiZDI0YjhkNTMiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiI4NDU4MjkxMTJmZjUzZGUxYWVmMDUyYTFiNTZmZDRmZTI3NTk2ODgyIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature c0ca8f0cc3ff1f5c69ec332f75cf8e997ae0930c6d8d4eb5275f7c6e14c067c7 -->
<!-- pinot-pr-flow:end -->

`backward-incompat`

**Problem:**
Currently the Rate Limiters don't throttle based on the actual numbers of rows fetched. The rate limiter ignores the tombstone messages, which might not be ideal considering that users refer to `REALTIME_ROWS_FETCHED` metric and then set the rate limit accordingly. `REALTIME_ROWS_FETCHED` is the actual count of consumer records fetched which is `messageBatch.getUnfilteredMessageCount()`.

**Solution:**
Minor change to throttle based on `messageBatch.getUnfilteredMessageCount()` instead of `messageBatch.getMessageCount()`.