### PR TITLE
Revert "Allow CI unit test set 1 to run multi-threaded"

### DIFF
--- a/.github/workflows/scripts/pr-tests/.pinot_tests_unit.sh
+++ b/.github/workflows/scripts/pr-tests/.pinot_tests_unit.sh
@@ -28,6 +28,7 @@ netstat -i
 # Unit Tests
 #   - TEST_SET#1 runs install and test together so the module list must ensure no additional modules were tested
 #     due to the -am flag (include dependency modules)
+#   - tests for pinot-plugins should not be ran multi-threaded
 if [ "$RUN_TEST_SET" == "1" ]; then
   mvn test \
       -pl 'pinot-spi' \

--- a/.github/workflows/scripts/pr-tests/.pinot_tests_unit.sh
+++ b/.github/workflows/scripts/pr-tests/.pinot_tests_unit.sh
@@ -29,27 +29,25 @@ netstat -i
 #   - TEST_SET#1 runs install and test together so the module list must ensure no additional modules were tested
 #     due to the -am flag (include dependency modules)
 if [ "$RUN_TEST_SET" == "1" ]; then
-  mvn test -T 16 \
-      -am \
+  mvn test \
       -pl 'pinot-spi' \
       -pl 'pinot-segment-spi' \
       -pl 'pinot-common' \
+      -pl ':pinot-yammer' \
       -pl 'pinot-core' \
       -pl 'pinot-query-planner' \
       -pl 'pinot-query-runtime' \
       -P github-actions,codecoverage,no-integration-tests || exit 1
-
 fi
 if [ "$RUN_TEST_SET" == "2" ]; then
-  # These tests, if run multi-threaded, causes Develocity errors in CI
   mvn test \
-    -am \
     -pl '!pinot-spi' \
     -pl '!pinot-segment-spi' \
     -pl '!pinot-common' \
     -pl '!pinot-core' \
     -pl '!pinot-query-planner' \
     -pl '!pinot-query-runtime' \
+    -pl '!:pinot-yammer' \
     -P github-actions,codecoverage,no-integration-tests || exit 1
 fi
 


### PR DESCRIPTION
Reverts apache/pinot#16099, since it causes some redundant unit tests to be ran across both unit test sets. #16269 
