### PR TITLE
Add Reverse Ordering Support for Time Predicate Filter Optimizer

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/TimePredicateFilterOptimizer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/TimePredicateFilterOptimizer.java
@@ -92,6 +92,28 @@ public class TimePredicateFilterOptimizer implements FilterOptimizer {
       }
     } else if (filterKind.isRange() || filterKind == FilterKind.EQUALS) {
       Expression expression = operands.get(0);
+      if (expression.getType() == ExpressionType.LITERAL) {
+        switch (filterKind) {
+          case GREATER_THAN:
+            filterFunction.setOperator(FilterKind.LESS_THAN.name());
+            break;
+          case GREATER_THAN_OR_EQUAL:
+            filterFunction.setOperator(FilterKind.LESS_THAN_OR_EQUAL.name());
+            break;
+          case LESS_THAN:
+            filterFunction.setOperator(FilterKind.GREATER_THAN.name());
+            break;
+          case LESS_THAN_OR_EQUAL:
+            filterFunction.setOperator(FilterKind.GREATER_THAN_OR_EQUAL.name());
+            break;
+          default:
+            break;
+        }
+        filterKind = FilterKind.valueOf(filterFunction.getOperator());
+        operands.set(0, operands.get(1));
+        operands.set(1, expression);
+        expression = operands.get(0);
+      }
       if (expression.getType() == ExpressionType.FUNCTION) {
         Function expressionFunction = expression.getFunctionCall();
         String functionName = StringUtils.remove(expressionFunction.getOperator(), '_');

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/TimePredicateFilterOptimizer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/TimePredicateFilterOptimizer.java
@@ -92,6 +92,7 @@ public class TimePredicateFilterOptimizer implements FilterOptimizer {
       }
     } else if (filterKind.isRange() || filterKind == FilterKind.EQUALS) {
       Expression expression = operands.get(0);
+      // Switch the operand
       if (expression.getType() == ExpressionType.LITERAL) {
         switch (filterKind) {
           case GREATER_THAN:

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/optimizer/filter/TimePredicateFilterOptimizerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/optimizer/filter/TimePredicateFilterOptimizerTest.java
@@ -50,13 +50,15 @@ public class TimePredicateFilterOptimizerTest {
 
     // Other input format
     testTimeConvert("timeConvert(col, 'MINUTES', 'SECONDS') > 1620830760", new Range(27013846L, false, null, false));
-    testTimeConvertReverse("1620830760 < timeConvert(col, 'MINUTES', 'SECONDS')", new Range(27013846L, false, null, false));
+    testTimeConvertReverse("1620830760 < timeConvert(col, 'MINUTES', 'SECONDS')", new Range(27013846L, false, null,
+        false));
     testTimeConvert("timeConvert(col, 'HOURS', 'MINUTES') < 27015286", new Range(null, false, 450254L, true));
     testTimeConvertReverse("27015286 > timeConvert(col, 'HOURS', 'MINUTES')", new Range(null, false, 450254L, true));
     testTimeConvert("timeConvert(col, 'DAYS', 'HOURS') BETWEEN 450230 AND 450254",
         new Range(18759L, false, 18760L, true));
     testTimeConvert("timeConvert(col, 'SECONDS', 'DAYS') = 18759", new Range(1620777600L, true, 1620864000L, false));
-    testTimeConvertReverse("18759 = timeConvert(col, 'SECONDS', 'DAYS')", new Range(1620777600L, true, 1620864000L, false));
+    testTimeConvertReverse("18759 = timeConvert(col, 'SECONDS', 'DAYS')", new Range(1620777600L, true, 1620864000L,
+        false));
 
     // Invalid time
     testInvalidFilterOptimizer("timeConvert(col, 'MINUTES', 'SECONDS') > 1620830760.5");
@@ -164,16 +166,21 @@ public class TimePredicateFilterOptimizerTest {
   @Test
   public void testDateTruncOptimizer() {
     testDateTrunc("datetrunc('DAY', col) = 1620777600000", new Range("1620777600000", true, "1620863999999", true));
-    testDateTruncReverse("1620777600000 = datetrunc('DAY', col)", new Range("1620777600000", true, "1620863999999", true));
+    testDateTruncReverse("1620777600000 = datetrunc('DAY', col)", new Range("1620777600000", true, "1620863999999",
+        true));
     testDateTrunc("dateTrunc('DAY', col) = 1620777600001", new Range(Long.MAX_VALUE, true, Long.MIN_VALUE, true));
-    testDateTruncReverse("1620777600001 = dateTrunc('DAY', col)", new Range(Long.MAX_VALUE, true, Long.MIN_VALUE, true));
+    testDateTruncReverse("1620777600001 = dateTrunc('DAY', col)", new Range(Long.MAX_VALUE, true, Long.MIN_VALUE,
+        true));
 
     testDateTrunc("datetrunc('DAY', col) < 1620777600000", new Range(Long.MIN_VALUE, true, "1620777600000", false));
-    testDateTruncReverse("1620777600000 > datetrunc('DAY', col)", new Range(Long.MIN_VALUE, true, "1620777600000", false));
+    testDateTruncReverse("1620777600000 > datetrunc('DAY', col)", new Range(Long.MIN_VALUE, true, "1620777600000",
+        false));
     testDateTrunc("DATETRUNC('DAY', col) < 1620777600010", new Range(Long.MIN_VALUE, true, "1620863999999", true));
-    testDateTruncReverse("1620777600010 > DATETRUNC('DAY', col)", new Range(Long.MIN_VALUE, true, "1620863999999", true));
+    testDateTruncReverse("1620777600010 > DATETRUNC('DAY', col)", new Range(Long.MIN_VALUE, true, "1620863999999",
+        true));
     testDateTrunc("DATE_TRUNC('DAY', col) < 1620863999999", new Range(Long.MIN_VALUE, true, "1620863999999", true));
-    testDateTruncReverse("1620863999999 > DATE_TRUNC('DAY', col)", new Range(Long.MIN_VALUE, true, "1620863999999", true));
+    testDateTruncReverse("1620863999999 > DATE_TRUNC('DAY', col)", new Range(Long.MIN_VALUE, true, "1620863999999",
+        true));
 
     testDateTrunc("datetrunc('DAY', col) <= 1620777600000", new Range(Long.MIN_VALUE, true, "1620863999999", true));
     testDateTrunc("datetrunc('DAY', col) <= 1620777600010", new Range(Long.MIN_VALUE, true, "1620863999999", true));
@@ -209,8 +216,6 @@ public class TimePredicateFilterOptimizerTest {
         new Range("1620777600000", true, "1621036799999", true));
     testDateTrunc("datetrunc('DAY', col, 'DAYS', 'UTC', 'DAYS') BETWEEN 453630 AND 453632",
         new Range("453630", true, "453632", true));
-
-
   }
 
   /**


### PR DESCRIPTION
## Summary
Currently, the time predicate filter optimizer only optimizes queries in the form `func(x) = literal`, where `=` could be any comparative operator. This PR allows the time predicate filter optimizer to function on query filters with the form `literal = func(x)` by doing the following prior to running any specific optimizer:
1. Switches the operands of the comparative statement
2. Switches the operand direction (i.e. `LESS_THAN` -> `GREATER_THAN`, `LESS_THAN_OR_EQUALS` -> `GREATER_THAN_OR_EQUAL`)
3. Runs the optimizer on this reversed comparator filter

## Testing
- Added relevant unit tests to `TimePredicateFilterOptimizerTest` by swapping existing tests' orders

## Related
- Enhances: https://github.com/apache/pinot/pull/14385