### PR TITLE
[SSE] Trim group when orderBy key is same as groupBy key, ConcurrentSkipListMap version

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/ConcurrentSortedIndexedTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/ConcurrentSortedIndexedTable.java
@@ -1,0 +1,104 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.data.table;
+
+import java.util.Comparator;
+import java.util.TreeMap;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.locks.ReadWriteLock;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import javax.annotation.concurrent.NotThreadSafe;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.core.query.request.context.QueryContext;
+
+
+/**
+ * {@link Table} thread-safe implementation for orderby group key case, sorted on group keys and only `trimSize` groups
+ * are kept
+ */
+@NotThreadSafe
+public class ConcurrentSortedIndexedTable extends IndexedTable {
+  Comparator<Key> _keyComparator;
+  ReadWriteLock _lock = new ReentrantReadWriteLock();
+
+  public ConcurrentSortedIndexedTable(DataSchema dataSchema, boolean hasFinalInput,
+      QueryContext queryContext, int resultSize, ExecutorService executorService, Comparator<Key> keyComparator) {
+    super(dataSchema, hasFinalInput, queryContext, resultSize, resultSize, Integer.MAX_VALUE,
+        new TreeMap<>(keyComparator),
+        executorService);
+    _keyComparator = keyComparator;
+  }
+
+  @Override
+  public boolean upsert(Key key, Record record) {
+    _lock.readLock().lock();
+    TreeMap<Key, Record> map = (TreeMap<Key, Record>) _lookupMap;
+    if (map.size() < _resultSize) {
+      _lock.readLock().unlock();
+      _lock.writeLock().lock();
+      if (map.size() < _resultSize) {
+        addOrUpdateRecord(key, record);
+        _lock.writeLock().unlock();
+        return true;
+      }
+      Key lastKey = map.lastKey();
+      if (lastKey == null || _keyComparator.compare(key, lastKey) > 0) {
+        // check lastKey should not be null unless _resultSize = 0;
+        assert (lastKey != null || _resultSize == 0);
+        _lock.writeLock().unlock();
+        return true;
+      }
+      addOrUpdateRecord(key, record);
+      if (map.size() > _resultSize) {
+        map.remove(map.lastKey());
+      }
+      _lock.writeLock().unlock();
+      return true;
+    }
+    // if size is full, evict the smallest key
+    Key lastKey = map.lastKey();
+    if (lastKey == null || _keyComparator.compare(key, lastKey) > 0) {
+      // check lastKey should not be null unless _resultSize = 0;
+      assert (lastKey != null || _resultSize == 0);
+      _lock.readLock().unlock();
+      return true;
+    }
+    _lock.readLock().unlock();
+    _lock.writeLock().lock();
+    lastKey = map.lastKey();
+    if (lastKey == null || _keyComparator.compare(key, lastKey) > 0) {
+      // check lastKey should not be null unless _resultSize = 0;
+      assert (lastKey != null || _resultSize == 0);
+      _lock.writeLock().unlock();
+      return true;
+    }
+    addOrUpdateRecord(key, record);
+    if (map.size() > _resultSize) {
+      map.remove(map.lastKey());
+    }
+    _lock.writeLock().unlock();
+    return true;
+  }
+
+  @Override
+  public void finish(boolean sort) {
+    // don't sort again since the map itself is sorted
+    super.finish(false);
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/ConcurrentSortedIndexedTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/ConcurrentSortedIndexedTable.java
@@ -19,7 +19,7 @@
 package org.apache.pinot.core.data.table;
 
 import java.util.Comparator;
-import java.util.TreeMap;
+import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -34,71 +34,86 @@ import org.apache.pinot.core.query.request.context.QueryContext;
  */
 @NotThreadSafe
 public class ConcurrentSortedIndexedTable extends IndexedTable {
-  Comparator<Key> _keyComparator;
-  ReadWriteLock _lock = new ReentrantReadWriteLock();
+  private final ReadWriteLock _lock = new ReentrantReadWriteLock();
+  /**
+   * resizeThreshold controls when does the resize triggers. Once triggered, resize will always resize to
+   * {@code resultSize}. Using a larger threshold reduces frequency of holding the write lock but increases intermediate
+   * result size. This is defaulted to min(2 * limit, trimSize).
+   */
+  private final int _resizeThreshold;
 
   public ConcurrentSortedIndexedTable(DataSchema dataSchema, boolean hasFinalInput,
-      QueryContext queryContext, int resultSize, ExecutorService executorService, Comparator<Key> keyComparator) {
+      QueryContext queryContext, int resultSize, int trimSize, ExecutorService executorService,
+      Comparator<Key> keyComparator) {
     super(dataSchema, hasFinalInput, queryContext, resultSize, resultSize, Integer.MAX_VALUE,
-        new TreeMap<>(keyComparator),
+        new ConcurrentSkipListMap<>(keyComparator),
         executorService);
-    _keyComparator = keyComparator;
+    /// default to 2 * resultSize
+    _resizeThreshold = Math.min(2 * resultSize, trimSize);
+  }
+
+  public ConcurrentSortedIndexedTable(DataSchema dataSchema, boolean hasFinalInput,
+      QueryContext queryContext, int resultSize, ExecutorService executorService,
+      Comparator<Key> keyComparator) {
+    super(dataSchema, hasFinalInput, queryContext, resultSize, resultSize, Integer.MAX_VALUE,
+        new ConcurrentSkipListMap<>(keyComparator),
+        executorService);
+    /// default to 2 * resultSize
+    _resizeThreshold = 2 * resultSize;
   }
 
   @Override
   public boolean upsert(Key key, Record record) {
-    // TODO: short-circuit LIMIT 0 case
-    if (_resultSize == 0) {
-      return true;
-    }
     _lock.readLock().lock();
-    TreeMap<Key, Record> map = (TreeMap<Key, Record>) _lookupMap;
-    if (map.size() < _resultSize) {
-      _lock.readLock().unlock();
-      _lock.writeLock().lock();
-      if (map.size() < _resultSize) {
-        addOrUpdateRecord(key, record);
-        _lock.writeLock().unlock();
-        return true;
-      }
-      Key lastKey = map.lastKey();
-      if (_keyComparator.compare(key, lastKey) > 0) {
-        // check lastKey should not be null unless _resultSize = 0;
-        _lock.writeLock().unlock();
-        return true;
-      }
+    try {
       addOrUpdateRecord(key, record);
-      if (map.size() > _resultSize) {
-        map.remove(map.lastKey());
-      }
-      _lock.writeLock().unlock();
-      return true;
-    }
-    // if size is full, evict the smallest key
-    Key lastKey = map.lastKey();
-    if (_keyComparator.compare(key, lastKey) > 0) {
-      // check lastKey should not be null unless _resultSize = 0;
+    } finally {
       _lock.readLock().unlock();
-      return true;
     }
-    _lock.readLock().unlock();
-    _lock.writeLock().lock();
-    lastKey = map.lastKey();
-    if (_keyComparator.compare(key, lastKey) > 0) {
-      // check lastKey should not be null unless _resultSize = 0;
-      _lock.writeLock().unlock();
-      return true;
+    // trim when result size is too large
+    if (_lookupMap.size() > _resizeThreshold) {
+      _lock.writeLock().lock();
+      try {
+        if (_lookupMap.size() > _resizeThreshold) {
+          _numResizes++;
+          while (_lookupMap.size() > _resultSize) {
+            ((ConcurrentSkipListMap<Key, Record>) _lookupMap).pollLastEntry();
+          }
+        }
+      } finally {
+        _lock.writeLock().unlock();
+      }
     }
-    addOrUpdateRecord(key, record);
-    if (map.size() > _resultSize) {
-      map.remove(map.lastKey());
-    }
-    _lock.writeLock().unlock();
     return true;
+  }
+
+  /**
+   * Adds a record with new key or updates a record with existing key.
+   * NOTE: {@code compute} method of {@code ConcurrentSkipListMap} is not atomic, thus it's not used
+   */
+  protected void addOrUpdateRecord(Key key, Record newRecord) {
+    Record existingRecord = _lookupMap.putIfAbsent(key, newRecord);
+    if (existingRecord == null) {
+      // if no key was associated
+      return;
+    }
+    while (true) {
+      Record oldRecord = _lookupMap.get(key);
+      Record updatedRecord = updateRecord(oldRecord.copy(), newRecord);
+      if (_lookupMap.replace(key, oldRecord, updatedRecord)) {
+        return;
+      }
+    }
   }
 
   @Override
   public void finish(boolean sort) {
+    if (_lookupMap.size() > _resultSize) {
+      _numResizes++;
+      while (_lookupMap.size() > _resultSize) {
+        ((ConcurrentSkipListMap<Key, Record>) _lookupMap).pollLastEntry();
+      }
+    }
     // don't sort again since the map itself is sorted
     super.finish(false);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/IndexedTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/IndexedTable.java
@@ -58,7 +58,7 @@ public abstract class IndexedTable extends BaseTable {
   protected final int _chunkSizeExtractFinalResult;
 
   protected Collection<Record> _topRecords;
-  private int _numResizes;
+  protected int _numResizes;
   private long _resizeTimeNs;
 
   /**
@@ -123,7 +123,10 @@ public abstract class IndexedTable extends BaseTable {
     _lookupMap.computeIfPresent(key, (k, v) -> updateRecord(v, newRecord));
   }
 
-  private Record updateRecord(Record existingRecord, Record newRecord) {
+  /**
+   * update existingRecord in-place with newRecord
+   */
+  protected Record updateRecord(Record existingRecord, Record newRecord) {
     Object[] existingValues = existingRecord.getValues();
     Object[] newValues = newRecord.getValues();
     int numAggregations = _aggregationFunctions.length;

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/Record.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/Record.java
@@ -53,6 +53,12 @@ public class Record {
     return _values;
   }
 
+  ///  deepcopy of the record
+  public Record copy() {
+    Object[] copied = Arrays.copyOf(_values, _values.length);
+    return new Record(copied);
+  }
+
   // NOTE: Not check class for performance concern
   @SuppressWarnings("EqualsWhichDoesntCheckParameterClass")
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/SimpleSortedIndexedTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/SimpleSortedIndexedTable.java
@@ -1,0 +1,70 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.data.table;
+
+import java.util.Comparator;
+import java.util.TreeMap;
+import java.util.concurrent.ExecutorService;
+import javax.annotation.concurrent.NotThreadSafe;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.core.query.request.context.QueryContext;
+
+
+/**
+ * {@link Table} implementations for orderby group key case, sorted on group keys and only `trimSize` groups are kept
+ */
+@NotThreadSafe
+public class SimpleSortedIndexedTable extends IndexedTable {
+  Comparator<Key> _keyComparator;
+
+  public SimpleSortedIndexedTable(DataSchema dataSchema, boolean hasFinalInput,
+      QueryContext queryContext, int resultSize, ExecutorService executorService, Comparator<Key> keyComparator) {
+    super(dataSchema, hasFinalInput, queryContext, resultSize, resultSize, Integer.MAX_VALUE,
+        new TreeMap<>(keyComparator),
+        executorService);
+    _keyComparator = keyComparator;
+  }
+
+  @Override
+  public boolean upsert(Key key, Record record) {
+    TreeMap<Key, Record> map = (TreeMap<Key, Record>) _lookupMap;
+    if (map.size() < _resultSize) {
+      addOrUpdateRecord(key, record);
+      return true;
+    }
+    // if size is full, evict the smallest key
+    Key lastKey = map.lastKey();
+    if (lastKey == null || _keyComparator.compare(key, lastKey) < 0) {
+      // check lastKey should not be null unless _resultSize = 0;
+      assert (lastKey != null || _resultSize == 0);
+      return true;
+    }
+    addOrUpdateRecord(key, record);
+    if (map.size() > _resultSize) {
+      map.remove(map.lastKey());
+    }
+    return true;
+  }
+
+  @Override
+  public void finish(boolean sort) {
+    // don't sort again since the map itself is sorted
+    super.finish(false);
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/SimpleSortedIndexedTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/SimpleSortedIndexedTable.java
@@ -43,6 +43,10 @@ public class SimpleSortedIndexedTable extends IndexedTable {
 
   @Override
   public boolean upsert(Key key, Record record) {
+    // TODO: short-circuit LIMIT 0 case
+    if (_resultSize == 0) {
+      return true;
+    }
     TreeMap<Key, Record> map = (TreeMap<Key, Record>) _lookupMap;
     if (map.size() < _resultSize) {
       addOrUpdateRecord(key, record);
@@ -50,9 +54,8 @@ public class SimpleSortedIndexedTable extends IndexedTable {
     }
     // if size is full, evict the smallest key
     Key lastKey = map.lastKey();
-    if (lastKey == null || _keyComparator.compare(key, lastKey) < 0) {
+    if (_keyComparator.compare(key, lastKey) > 0) {
       // check lastKey should not be null unless _resultSize = 0;
-      assert (lastKey != null || _resultSize == 0);
       return true;
     }
     addOrUpdateRecord(key, record);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/GroupByOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/GroupByOperator.java
@@ -142,8 +142,8 @@ public class GroupByOperator extends BaseOperator<GroupByResultsBlock> {
     int minGroupTrimSize = _queryContext.getMinSegmentGroupTrimSize();
     int trimSize = -1;
     List<OrderByExpressionContext> orderByExpressions = _queryContext.getOrderByExpressions();
-    if (GroupByUtils.isOrderByOnGroupByKeys(orderByExpressions, _queryContext.getGroupByExpressions())) {
-      // if orderby key is groupby key, keep at most `limit` rows only
+    if (QueryContext.isSameOrderAndGroupByColumns(_queryContext) && _queryContext.getHavingFilter() == null) {
+      // if orderby key is groupby key and there's no having filter, it's safe to keep at most `limit` rows only
       trimSize = _queryContext.getLimit();
     } else if (orderByExpressions != null && minGroupTrimSize > 0) {
       // max(minSegmentGroupTrimSize, 5 * LIMIT)

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/GroupByOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/GroupByOperator.java
@@ -1,14 +1,20 @@
 /**
- * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.  See the NOTICE
- * file distributed with this work for additional information regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
- * License.  You may obtain a copy of the License at
- * <p>
- * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
- * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations under the License.
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
  */
 package org.apache.pinot.core.operator.query;
 
@@ -101,7 +107,6 @@ public class GroupByOperator extends BaseOperator<GroupByResultsBlock> {
   protected GroupByResultsBlock getNextBlock() {
     // Perform aggregation group-by on all the blocks
     GroupByExecutor groupByExecutor;
-    // TODO: pass trimGroupSize to executor, who creates the result holder
     if (_useStarTree) {
       groupByExecutor = new StarTreeGroupByExecutor(_queryContext, _groupByExpressions, _projectOperator);
     } else {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GroupByDataTableReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GroupByDataTableReducer.java
@@ -90,7 +90,6 @@ public class GroupByDataTableReducer implements DataTableReducer {
     _numGroupByExpressions = groupByExpressions.size();
     _numColumns = _numAggregationFunctions + _numGroupByExpressions;
   }
-
   /**
    * Reduces and sets group by results into ResultTable.
    */

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/QueryContext.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/QueryContext.java
@@ -165,7 +165,7 @@ public class QueryContext {
     _explain = explain;
   }
 
-  private boolean isSameOrderAndGroupByColumns(QueryContext context) {
+  public static boolean isSameOrderAndGroupByColumns(QueryContext context) {
     List<ExpressionContext> groupByKeys = context.getGroupByExpressions();
     List<OrderByExpressionContext> orderByKeys = context.getOrderByExpressions();
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/GroupByUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/GroupByUtils.java
@@ -1,26 +1,26 @@
 /**
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *   http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing,
- * software distributed under the License is distributed on an
- * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
- * KIND, either express or implied.  See the License for the
- * specific language governing permissions and limitations
- * under the License.
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license agreements.  See the NOTICE
+ * file distributed with this work for additional information regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with the
+ * License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations under the License.
  */
 package org.apache.pinot.core.util;
 
 import com.google.common.annotations.VisibleForTesting;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.concurrent.ExecutorService;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.datatable.DataTable;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.common.request.context.OrderByExpressionContext;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.HashUtil;
 import org.apache.pinot.core.data.table.ConcurrentIndexedTable;
@@ -56,6 +56,21 @@ public final class GroupByUtils {
   public static int getTableCapacity(int limit, int minNumGroups) {
     long capacityByLimit = limit * 5L;
     return capacityByLimit > Integer.MAX_VALUE ? Integer.MAX_VALUE : Math.max((int) capacityByLimit, minNumGroups);
+  }
+
+  /**
+   * Returns whether the order by key is the group by key
+   */
+  public static boolean isOrderByOnGroupByKeys(@Nullable List<OrderByExpressionContext> orderByExpressions,
+      List<ExpressionContext> groupByExpressions) {
+    if (orderByExpressions == null) {
+      return false;
+    }
+    Set<String> orderByIdentifiers = new HashSet<>();
+    orderByExpressions.forEach(expr -> orderByIdentifiers.add(expr.getExpression().getIdentifier()));
+    Set<String> groupByIdentifiers = new HashSet<>();
+    groupByExpressions.forEach(expr -> groupByIdentifiers.add(expr.getIdentifier()));
+    return orderByIdentifiers.equals(groupByIdentifiers);
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/GroupByUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/GroupByUtils.java
@@ -78,6 +78,9 @@ public final class GroupByUtils {
     if (orderByExpressions == null) {
       return false;
     }
+    if (orderByExpressions.size() != groupByExpressions.size()) {
+      return false;
+    }
     Set<String> orderByIdentifiers = new HashSet<>();
     orderByExpressions.forEach(expr -> orderByIdentifiers.add(expr.getExpression().getIdentifier()));
     Set<String> groupByIdentifiers = new HashSet<>();

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/table/ConcurrentSortedIndexedTableTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/table/ConcurrentSortedIndexedTableTest.java
@@ -47,7 +47,7 @@ public class ConcurrentSortedIndexedTableTest {
     Comparator<Key> comparator = OrderByComparatorFactory.getGroupKeyComparator(queryContext.getOrderByExpressions(),
         queryContext.getGroupByExpressions(), queryContext.isNullHandlingEnabled());
     ConcurrentSortedIndexedTable table =
-        new ConcurrentSortedIndexedTable(dataSchema, false, queryContext, 10, executor, comparator);
+        new ConcurrentSortedIndexedTable(dataSchema, false, queryContext, 3, executor, comparator);
 
     // Insert out-of-order keys
     upsert(table, new Object[]{"zebra", 1L});

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/table/ConcurrentSortedIndexedTableTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/table/ConcurrentSortedIndexedTableTest.java
@@ -1,0 +1,214 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.data.table;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+import org.apache.pinot.core.query.request.context.QueryContext;
+import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
+import org.apache.pinot.core.query.utils.OrderByComparatorFactory;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class ConcurrentSortedIndexedTableTest {
+
+  @Test
+  public void testSingleValueAsc() {
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContext(
+        "SELECT COUNT(*) FROM testTable GROUP BY d1 ORDER BY d1 LIMIT 3");
+    DataSchema dataSchema = new DataSchema(new String[]{"d1", "count(*)"}, new ColumnDataType[]{
+        ColumnDataType.STRING, ColumnDataType.LONG
+    });
+
+    ExecutorService executor = Executors.newCachedThreadPool();
+    Comparator<Key> comparator = OrderByComparatorFactory.getGroupKeyComparator(queryContext.getOrderByExpressions(),
+        queryContext.getGroupByExpressions(), queryContext.isNullHandlingEnabled());
+    ConcurrentSortedIndexedTable table =
+        new ConcurrentSortedIndexedTable(dataSchema, false, queryContext, 10, executor, comparator);
+
+    // Insert out-of-order keys
+    upsert(table, new Object[]{"zebra", 1L});
+    upsert(table, new Object[]{"apple", 1L});
+    upsert(table, new Object[]{"applee", 1L});
+    upsert(table, new Object[]{"banana", 1L});
+    upsert(table, new Object[]{"cherry", 1L});
+    upsert(table, new Object[]{"yak", 1L});
+
+    table.finish(false);
+
+    Iterator<Record> it = table.iterator();
+    String[] expected = {"apple", "applee", "banana"};
+    int i = 0;
+    while (it.hasNext()) {
+      Record r = it.next();
+      Assert.assertEquals(r.getValues()[0], expected[i]);
+      i++;
+    }
+    Assert.assertEquals(i, 3);
+  }
+
+  @Test
+  public void testMultiThreadedWritersTop5000Asc()
+      throws Exception {
+    for (int i = 0; i < 5; i++) {
+      testMultiThreadedWritersTop5000AscInternal();
+    }
+  }
+
+  public void testMultiThreadedWritersTop5000AscInternal()
+      throws Exception {
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContext(
+        "SELECT COUNT(*) FROM testTable GROUP BY d1 ORDER BY d1 LIMIT 5000");
+    DataSchema dataSchema = new DataSchema(new String[]{"d1", "count(*)"}, new ColumnDataType[]{
+        ColumnDataType.INT, ColumnDataType.LONG
+    });
+
+    ExecutorService executor = Executors.newCachedThreadPool();
+    Comparator<Key> comparator = OrderByComparatorFactory.getGroupKeyComparator(
+        queryContext.getOrderByExpressions(),
+        queryContext.getGroupByExpressions(),
+        queryContext.isNullHandlingEnabled()
+    );
+
+    int numThreads = 5;
+    int max = 10000;
+
+    ConcurrentSortedIndexedTable table = new ConcurrentSortedIndexedTable(
+        dataSchema, false, queryContext, 5000, executor, comparator);
+
+    Runnable writerTask = () -> {
+      for (int i = max; i >= 1; i--) {
+        Object[] row = new Object[]{i, 1L};
+        table.upsert(new Record(row));
+      }
+    };
+
+    // Launch writer threads
+    List<Thread> threads = new ArrayList<>();
+    for (int t = 0; t < numThreads; t++) {
+      Thread thread = new Thread(writerTask);
+      thread.start();
+      threads.add(thread);
+    }
+
+    // Wait for all threads to finish
+    for (Thread thread : threads) {
+      thread.join();
+    }
+
+    // Finalize table
+    table.finish(false);
+
+    Iterator<Record> it = table.iterator();
+    int curVal = 1;
+    long count = 5;
+    while (it.hasNext()) {
+      Record record = it.next();
+      Assert.assertEquals(record.getValues()[0], curVal++);
+      Assert.assertEquals(record.getValues()[1], count);
+    }
+  }
+
+  @Test
+  public void testMultiValueAscDescOrderFlipped()
+      throws Exception {
+    for (int i = 0; i < 5; i++) {
+      testMultiValueAscDescOrderFlippedInternal();
+    }
+  }
+
+  public void testMultiValueAscDescOrderFlippedInternal()
+      throws Exception {
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContext(
+        "SELECT COUNT(*) FROM testTable GROUP BY d1, d2 ORDER BY d2 DESC, d1 LIMIT 5000");
+    DataSchema dataSchema = new DataSchema(new String[]{"d1", "d2", "count(*)"}, new ColumnDataType[]{
+        ColumnDataType.STRING, ColumnDataType.STRING, ColumnDataType.LONG
+    });
+
+    ExecutorService executor = Executors.newCachedThreadPool();
+    Comparator<Key> comparator = OrderByComparatorFactory.getGroupKeyComparator(queryContext.getOrderByExpressions(),
+        queryContext.getGroupByExpressions(), queryContext.isNullHandlingEnabled());
+    ConcurrentSortedIndexedTable table =
+        new ConcurrentSortedIndexedTable(dataSchema, false, queryContext, 5000, executor, comparator);
+
+    int numThreads = 5;
+    int max = 100;
+
+    Runnable writerTask = () -> {
+      for (int i = max; i >= 1; i--) {
+        for (int j = 1; j <= max; j++) {
+          Object[] row = new Object[]{i, j, 1L};
+          table.upsert(new Record(row));
+        }
+      }
+    };
+
+    // Launch writer threads
+    List<Thread> threads = new ArrayList<>();
+    for (int t = 0; t < numThreads; t++) {
+      Thread thread = new Thread(writerTask);
+      thread.start();
+      threads.add(thread);
+    }
+
+    // Wait for all threads to finish
+    for (Thread thread : threads) {
+      thread.join();
+    }
+
+    table.finish(false);
+
+    Iterator<Record> it = table.iterator();
+    int i = 1;
+    int j = max;
+    while (it.hasNext()) {
+      Record r = it.next();
+      Assert.assertEquals(r.getValues()[0], i);
+      Assert.assertEquals(r.getValues()[1], j);
+      Assert.assertEquals(r.getValues()[2], 5L);
+      if (i++ == max) {
+        i = 1;
+        j--;
+      }
+    }
+  }
+
+  private void upsert(ConcurrentSortedIndexedTable table, Object[] row) {
+    upsert(table, row, 1);
+  }
+
+  private void upsert2cols(ConcurrentSortedIndexedTable table, Object[] row) {
+    upsert(table, row, 2);
+  }
+
+  private void upsert(ConcurrentSortedIndexedTable table, Object[] row, int numKeyCols) {
+    Object[] key = new Object[numKeyCols];
+    for (int i = 0; i < numKeyCols; i++) {
+      key[i] = row[i];
+    }
+    table.upsert(new Key(key), new Record(row));
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/table/SimpleSortedIndexedTableTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/table/SimpleSortedIndexedTableTest.java
@@ -302,7 +302,7 @@ public class SimpleSortedIndexedTableTest {
     Comparator<Key> comparator = OrderByComparatorFactory.getGroupKeyComparator(queryContext.getOrderByExpressions(),
         queryContext.getGroupByExpressions(), queryContext.isNullHandlingEnabled());
     SimpleSortedIndexedTable table =
-        new SimpleSortedIndexedTable(dataSchema, false, queryContext, 3, executor, comparator);
+        new SimpleSortedIndexedTable(dataSchema, false, queryContext, 0, executor, comparator);
 
     // Insert out-of-order keys
     upsert2cols(table, new Object[]{"zebra", "z", 1L});

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/table/SimpleSortedIndexedTableTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/table/SimpleSortedIndexedTableTest.java
@@ -1,0 +1,377 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.data.table;
+
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+import org.apache.pinot.core.query.request.context.QueryContext;
+import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
+import org.apache.pinot.core.query.utils.OrderByComparatorFactory;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class SimpleSortedIndexedTableTest {
+
+  @Test
+  public void testSingleValueAsc() {
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContext(
+        "SELECT COUNT(*) FROM testTable GROUP BY d1 ORDER BY d1 LIMIT 3");
+    DataSchema dataSchema = new DataSchema(new String[]{"d1", "count(*)"}, new ColumnDataType[]{
+        ColumnDataType.STRING, ColumnDataType.LONG
+    });
+
+    ExecutorService executor = Executors.newCachedThreadPool();
+    Comparator<Key> comparator = OrderByComparatorFactory.getGroupKeyComparator(queryContext.getOrderByExpressions(),
+        queryContext.getGroupByExpressions(), queryContext.isNullHandlingEnabled());
+    SimpleSortedIndexedTable table =
+        new SimpleSortedIndexedTable(dataSchema, false, queryContext, 3, executor, comparator);
+
+    // Insert out-of-order keys
+    upsert(table, new Object[]{"zebra", 1L});
+    upsert(table, new Object[]{"apple", 1L});
+    upsert(table, new Object[]{"applee", 1L});
+    upsert(table, new Object[]{"banana", 1L});
+    upsert(table, new Object[]{"cherry", 1L});
+    upsert(table, new Object[]{"yak", 1L});
+
+    table.finish(false);
+
+    Iterator<Record> it = table.iterator();
+    String[] expected = {"apple", "applee", "banana"};
+    int i = 0;
+    while (it.hasNext()) {
+      Record r = it.next();
+      Assert.assertEquals(r.getValues()[0], expected[i]);
+      i++;
+    }
+    Assert.assertEquals(i, 3);
+  }
+
+  @Test
+  public void testSingleValueDesc() {
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContext(
+        "SELECT COUNT(*) FROM testTable GROUP BY d1 ORDER BY d1 DESC LIMIT 3");
+    DataSchema dataSchema = new DataSchema(new String[]{"d1", "count(*)"}, new ColumnDataType[]{
+        ColumnDataType.STRING, ColumnDataType.LONG
+    });
+
+    ExecutorService executor = Executors.newCachedThreadPool();
+    Comparator<Key> comparator = OrderByComparatorFactory.getGroupKeyComparator(queryContext.getOrderByExpressions(),
+        queryContext.getGroupByExpressions(), queryContext.isNullHandlingEnabled());
+    SimpleSortedIndexedTable table =
+        new SimpleSortedIndexedTable(dataSchema, false, queryContext, 3, executor, comparator);
+
+    // Insert out-of-order keys
+    upsert(table, new Object[]{"zebra", 1L});
+    upsert(table, new Object[]{"apple", 1L});
+    upsert(table, new Object[]{"applee", 1L});
+    upsert(table, new Object[]{"banana", 1L});
+    upsert(table, new Object[]{"cherry", 1L});
+    upsert(table, new Object[]{"yak", 1L});
+
+    table.finish(false);
+
+    Iterator<Record> it = table.iterator();
+    String[] expected = {"zebra", "yak", "cherry"};
+    int i = 0;
+    while (it.hasNext()) {
+      Record r = it.next();
+      Assert.assertEquals(r.getValues()[0], expected[i]);
+      i++;
+    }
+    Assert.assertEquals(i, 3);
+  }
+
+  @Test
+  public void testSingleValueAscNullEnabled() {
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContext(
+        "SELECT COUNT(*) FROM testTable GROUP BY d1 ORDER BY d1 LIMIT 3");
+    queryContext.setNullHandlingEnabled(true);
+    DataSchema dataSchema = new DataSchema(new String[]{"d1", "count(*)"}, new ColumnDataType[]{
+        ColumnDataType.STRING, ColumnDataType.LONG
+    });
+
+    ExecutorService executor = Executors.newCachedThreadPool();
+    Comparator<Key> comparator = OrderByComparatorFactory.getGroupKeyComparator(queryContext.getOrderByExpressions(),
+        queryContext.getGroupByExpressions(), queryContext.isNullHandlingEnabled());
+    SimpleSortedIndexedTable table =
+        new SimpleSortedIndexedTable(dataSchema, false, queryContext, 3, executor, comparator);
+
+    // Insert out-of-order keys
+    upsert(table, new Object[]{"zebra", 1L});
+    upsert(table, new Object[]{"apple", 1L});
+    upsert(table, new Object[]{"applee", 1L});
+    upsert(table, new Object[]{"null", 1L});
+    upsert(table, new Object[]{"banana", 1L});
+    upsert(table, new Object[]{"cherry", 1L});
+    upsert(table, new Object[]{"yak", 1L});
+
+    table.finish(false);
+
+    Iterator<Record> it = table.iterator();
+    String[] expected = {"apple", "applee", "banana"};
+    int i = 0;
+    while (it.hasNext()) {
+      Record r = it.next();
+      Assert.assertEquals(r.getValues()[0], expected[i]);
+      i++;
+    }
+    Assert.assertEquals(i, 3);
+  }
+
+  @Test
+  public void testMultiValueAscDesc() {
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContext(
+        "SELECT COUNT(*) FROM testTable GROUP BY d1, d2 ORDER BY d1, d2 DESC LIMIT 3");
+    DataSchema dataSchema = new DataSchema(new String[]{"d1", "d2", "count(*)"}, new ColumnDataType[]{
+        ColumnDataType.STRING, ColumnDataType.STRING, ColumnDataType.LONG
+    });
+
+    ExecutorService executor = Executors.newCachedThreadPool();
+    Comparator<Key> comparator = OrderByComparatorFactory.getGroupKeyComparator(queryContext.getOrderByExpressions(),
+        queryContext.getGroupByExpressions(), queryContext.isNullHandlingEnabled());
+    SimpleSortedIndexedTable table =
+        new SimpleSortedIndexedTable(dataSchema, false, queryContext, 3, executor, comparator);
+
+    // Insert out-of-order keys
+    upsert2cols(table, new Object[]{"zebra", "z", 1L});
+    upsert2cols(table, new Object[]{"apple", "z", 1L});
+    upsert2cols(table, new Object[]{"apple", "a", 1L});
+    upsert2cols(table, new Object[]{"applee", "z", 1L});
+    upsert2cols(table, new Object[]{"banana", "b", 1L});
+    upsert2cols(table, new Object[]{"cherry", "c", 1L});
+    upsert2cols(table, new Object[]{"yak", "y", 1L});
+
+    table.finish(false);
+
+    Iterator<Record> it = table.iterator();
+    String[][] expected = {{"apple", "z"}, {"apple", "a"}, {"applee", "z"}};
+    int i = 0;
+    while (it.hasNext()) {
+      Record r = it.next();
+      Assert.assertEquals(r.getValues()[0], expected[i][0]);
+      Assert.assertEquals(r.getValues()[1], expected[i][1]);
+      i++;
+    }
+    Assert.assertEquals(i, 3);
+  }
+
+  @Test
+  public void testMultiValueAscDescOrderFlipped() {
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContext(
+        "SELECT COUNT(*) FROM testTable GROUP BY d1, d2 ORDER BY d2 DESC, d1 LIMIT 3");
+    DataSchema dataSchema = new DataSchema(new String[]{"d1", "d2", "count(*)"}, new ColumnDataType[]{
+        ColumnDataType.STRING, ColumnDataType.STRING, ColumnDataType.LONG
+    });
+
+    ExecutorService executor = Executors.newCachedThreadPool();
+    Comparator<Key> comparator = OrderByComparatorFactory.getGroupKeyComparator(queryContext.getOrderByExpressions(),
+        queryContext.getGroupByExpressions(), queryContext.isNullHandlingEnabled());
+    SimpleSortedIndexedTable table =
+        new SimpleSortedIndexedTable(dataSchema, false, queryContext, 3, executor, comparator);
+
+    // Insert out-of-order keys
+    upsert2cols(table, new Object[]{"zebra", "z", 1L});
+    upsert2cols(table, new Object[]{"apple", "z", 1L});
+    upsert2cols(table, new Object[]{"apple", "a", 1L});
+    upsert2cols(table, new Object[]{"applee", "z", 1L});
+    upsert2cols(table, new Object[]{"banana", "b", 1L});
+    upsert2cols(table, new Object[]{"cherry", "c", 1L});
+    upsert2cols(table, new Object[]{"yak", "y", 1L});
+
+    table.finish(false);
+
+    Iterator<Record> it = table.iterator();
+    String[][] expected = {{"apple", "z"}, {"applee", "z"}, {"zebra", "z"}};
+    int i = 0;
+    while (it.hasNext()) {
+      Record r = it.next();
+      Assert.assertEquals(r.getValues()[0], expected[i][0]);
+      Assert.assertEquals(r.getValues()[1], expected[i][1]);
+      i++;
+    }
+    Assert.assertEquals(i, 3);
+  }
+
+  @Test
+  public void testMultiValueGroupKeyOrderFlipped() {
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContext(
+        "SELECT COUNT(*) FROM testTable GROUP BY d2, d1 ORDER BY d1, d2 DESC LIMIT 3");
+    DataSchema dataSchema = new DataSchema(new String[]{"d1", "d2", "count(*)"}, new ColumnDataType[]{
+        ColumnDataType.STRING, ColumnDataType.STRING, ColumnDataType.LONG
+    });
+
+    ExecutorService executor = Executors.newCachedThreadPool();
+    Comparator<Key> comparator = OrderByComparatorFactory.getGroupKeyComparator(queryContext.getOrderByExpressions(),
+        queryContext.getGroupByExpressions(), queryContext.isNullHandlingEnabled());
+    SimpleSortedIndexedTable table =
+        new SimpleSortedIndexedTable(dataSchema, false, queryContext, 3, executor, comparator);
+
+    // Insert out-of-order keys
+    upsert2cols(table, new Object[]{"z", "zebra", 1L});
+    upsert2cols(table, new Object[]{"z", "apple", 1L});
+    upsert2cols(table, new Object[]{"a", "apple", 1L});
+    upsert2cols(table, new Object[]{"z", "applee", 1L});
+    upsert2cols(table, new Object[]{"b", "banana", 1L});
+    upsert2cols(table, new Object[]{"c", "cherry", 1L});
+    upsert2cols(table, new Object[]{"y", "yak", 1L});
+
+    table.finish(false);
+
+    Iterator<Record> it = table.iterator();
+    String[][] expected = {{"z", "apple"}, {"a", "apple"}, {"z", "applee"}};
+    int i = 0;
+    while (it.hasNext()) {
+      Record r = it.next();
+      Assert.assertEquals(r.getValues()[0], expected[i][0]);
+      Assert.assertEquals(r.getValues()[1], expected[i][1]);
+      i++;
+    }
+    Assert.assertEquals(i, 3);
+  }
+
+  @Test
+  public void testMultiValueAscDescNullEnabled() {
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContext(
+        "SELECT COUNT(*) FROM testTable GROUP BY d1, d2 ORDER BY d1, d2 DESC LIMIT 3");
+    queryContext.setNullHandlingEnabled(true);
+    DataSchema dataSchema = new DataSchema(new String[]{"d1", "d2", "count(*)"}, new ColumnDataType[]{
+        ColumnDataType.STRING, ColumnDataType.STRING, ColumnDataType.LONG
+    });
+
+    ExecutorService executor = Executors.newCachedThreadPool();
+    Comparator<Key> comparator = OrderByComparatorFactory.getGroupKeyComparator(queryContext.getOrderByExpressions(),
+        queryContext.getGroupByExpressions(), queryContext.isNullHandlingEnabled());
+    SimpleSortedIndexedTable table =
+        new SimpleSortedIndexedTable(dataSchema, false, queryContext, 3, executor, comparator);
+
+    // Insert out-of-order keys
+    upsert2cols(table, new Object[]{"zebra", "z", 1L});
+    upsert2cols(table, new Object[]{"apple", null, 1L});
+    upsert2cols(table, new Object[]{"apple", "a", 1L});
+    upsert2cols(table, new Object[]{"applee", "z", 1L});
+    upsert2cols(table, new Object[]{"banana", "b", 1L});
+    upsert2cols(table, new Object[]{"cherry", "c", 1L});
+    upsert2cols(table, new Object[]{"yak", "y", 1L});
+
+    table.finish(false);
+
+    Iterator<Record> it = table.iterator();
+    String[][] expected = {{"apple", null}, {"apple", "a"}, {"applee", "z"}};
+    int i = 0;
+    while (it.hasNext()) {
+      Record r = it.next();
+      Assert.assertEquals(r.getValues()[0], expected[i][0]);
+      Assert.assertEquals(r.getValues()[1], expected[i][1]);
+      i++;
+    }
+    Assert.assertEquals(i, 3);
+  }
+
+  @Test
+  public void testMultiValueLimit0() {
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContext(
+        "SELECT COUNT(*) FROM testTable GROUP BY d1, d2 ORDER BY d1, d2 DESC LIMIT 0");
+    queryContext.setNullHandlingEnabled(true);
+    DataSchema dataSchema = new DataSchema(new String[]{"d1", "d2", "count(*)"}, new ColumnDataType[]{
+        ColumnDataType.STRING, ColumnDataType.STRING, ColumnDataType.LONG
+    });
+
+    ExecutorService executor = Executors.newCachedThreadPool();
+    Comparator<Key> comparator = OrderByComparatorFactory.getGroupKeyComparator(queryContext.getOrderByExpressions(),
+        queryContext.getGroupByExpressions(), queryContext.isNullHandlingEnabled());
+    SimpleSortedIndexedTable table =
+        new SimpleSortedIndexedTable(dataSchema, false, queryContext, 3, executor, comparator);
+
+    // Insert out-of-order keys
+    upsert2cols(table, new Object[]{"zebra", "z", 1L});
+    upsert2cols(table, new Object[]{"apple", null, 1L});
+    upsert2cols(table, new Object[]{"apple", "a", 1L});
+    upsert2cols(table, new Object[]{"applee", "z", 1L});
+    upsert2cols(table, new Object[]{"banana", "b", 1L});
+    upsert2cols(table, new Object[]{"cherry", "c", 1L});
+    upsert2cols(table, new Object[]{"yak", "y", 1L});
+
+    table.finish(false);
+
+    Iterator<Record> it = table.iterator();
+    Assert.assertFalse(it.hasNext());
+  }
+
+  @Test
+  public void testMultiValueAscDescMerge() {
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContext(
+        "SELECT COUNT(*) FROM testTable GROUP BY d1, d2 ORDER BY d1, d2 DESC LIMIT 3");
+    DataSchema dataSchema = new DataSchema(new String[]{"d1", "d2", "count(*)"}, new ColumnDataType[]{
+        ColumnDataType.STRING, ColumnDataType.STRING, ColumnDataType.LONG
+    });
+
+    ExecutorService executor = Executors.newCachedThreadPool();
+    Comparator<Key> comparator = OrderByComparatorFactory.getGroupKeyComparator(queryContext.getOrderByExpressions(),
+        queryContext.getGroupByExpressions(), queryContext.isNullHandlingEnabled());
+    SimpleSortedIndexedTable table =
+        new SimpleSortedIndexedTable(dataSchema, false, queryContext, 3, executor, comparator);
+
+    // Insert out-of-order keys
+    upsert2cols(table, new Object[]{"zebra", "z", 1L});
+    upsert2cols(table, new Object[]{"apple", "z", 1L});
+    upsert2cols(table, new Object[]{"apple", "a", 1L});
+    upsert2cols(table, new Object[]{"applee", "z", 1L});
+    upsert2cols(table, new Object[]{"banana", "b", 1L});
+    upsert2cols(table, new Object[]{"cherry", "c", 1L});
+    upsert2cols(table, new Object[]{"apple", "a", 1L});
+    upsert2cols(table, new Object[]{"yak", "y", 1L});
+
+    table.finish(false);
+
+    Iterator<Record> it = table.iterator();
+    String[][] expected = {{"apple", "z"}, {"apple", "a"}, {"applee", "z"}};
+    long[] expectedCount = {1, 2, 1};
+    int i = 0;
+    while (it.hasNext()) {
+      Record r = it.next();
+      Assert.assertEquals(r.getValues()[0], expected[i][0]);
+      Assert.assertEquals(r.getValues()[1], expected[i][1]);
+      Assert.assertEquals(r.getValues()[2], expectedCount[i]);
+      i++;
+    }
+    Assert.assertEquals(i, 3);
+  }
+
+  private void upsert(SimpleSortedIndexedTable table, Object[] row) {
+    upsert(table, row, 1);
+  }
+
+  private void upsert2cols(SimpleSortedIndexedTable table, Object[] row) {
+    upsert(table, row, 2);
+  }
+
+  private void upsert(SimpleSortedIndexedTable table, Object[] row, int numKeyCols) {
+    Object[] key = new Object[numKeyCols];
+    for (int i = 0; i < numKeyCols; i++) {
+      key[i] = row[i];
+    }
+    table.upsert(new Key(key), new Record(row));
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/GroupByOrderByTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/GroupByOrderByTest.java
@@ -1,0 +1,226 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.aggregation;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.common.datatable.DataTable;
+import org.apache.pinot.common.metrics.BrokerMetrics;
+import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.common.response.broker.BrokerResponseNative;
+import org.apache.pinot.common.response.broker.ResultTable;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.core.query.reduce.BrokerReduceService;
+import org.apache.pinot.core.query.selection.SelectionOperatorUtils;
+import org.apache.pinot.core.transport.ServerRoutingInstance;
+import org.apache.pinot.queries.FluentQueryTest;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.apache.pinot.sql.parsers.CalciteSqlCompiler;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.mock;
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/** query-based tests for groupby-orderby */
+public class GroupByOrderByTest {
+  @Test
+  public void testSingleTableWithNullHandlingEnabled()
+      throws IOException {
+    BrokerReduceService brokerReduceService =
+        new BrokerReduceService(
+            new PinotConfiguration(Map.of(CommonConstants.Broker.CONFIG_OF_MAX_REDUCE_THREADS_PER_QUERY, 2)));
+    BrokerRequest brokerRequest =
+        CalciteSqlCompiler.compileToBrokerRequest(
+            "SET enableNullHandling=true; SELECT col1 FROM testTable ORDER BY col1");
+    DataSchema dataSchema =
+        new DataSchema(new String[]{"col1"}, new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.INT});
+
+    List<Object[]> unsortedRows = new ArrayList<>();
+    unsortedRows.add(new Object[]{1});
+    unsortedRows.add(new Object[]{2});
+    unsortedRows.add(new Object[]{3});
+    unsortedRows.add(new Object[]{4});
+
+    DataTable dataTable = SelectionOperatorUtils.getDataTableFromRows(unsortedRows, dataSchema, false);
+    Map<ServerRoutingInstance, DataTable> dataTableMap = new HashMap<>();
+    int numSortedInstances = 1;
+    for (int i = 0; i < numSortedInstances; i++) {
+      ServerRoutingInstance instance = new ServerRoutingInstance("localhost", i, TableType.OFFLINE);
+      dataTableMap.put(instance, dataTable);
+    }
+    long reduceTimeoutMs = 100000;
+    BrokerResponseNative brokerResponse =
+        brokerReduceService.reduceOnDataTable(brokerRequest, brokerRequest, dataTableMap, reduceTimeoutMs,
+            mock(BrokerMetrics.class));
+    brokerReduceService.shutDown();
+
+    ResultTable resultTable = brokerResponse.getResultTable();
+  }
+
+  @Test
+  public void list() {
+    FluentQueryTest.withBaseDir(_baseDir)
+        .withNullHandling(false)
+        .givenTable(SINGLE_FIELD_NULLABLE_DIMENSION_SCHEMAS.get(FieldSpec.DataType.INT), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(
+            new Object[]{1},
+            new Object[]{2},
+            new Object[]{3},
+            new Object[]{4},
+            new Object[]{5},
+            new Object[]{6},
+            new Object[]{7}
+        )
+        .andOnSecondInstance(
+            new Object[]{2},
+            new Object[]{3},
+            new Object[]{4},
+            new Object[]{5},
+            new Object[]{6},
+            new Object[]{7},
+            new Object[]{8}
+        )
+        .whenQuery("select COUNT(1) from testTable group by myField order by myField limit 1")
+        .thenResultIs("LONG",
+            "1"
+        );
+  }
+
+  @Test
+  public void listNullHandlingEnabled() {
+    FluentQueryTest.withBaseDir(_baseDir)
+        .withNullHandling(true)
+        .givenTable(SINGLE_FIELD_NULLABLE_DIMENSION_SCHEMAS.get(FieldSpec.DataType.INT), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(
+            new Object[]{1},
+            new Object[]{3}
+        )
+        .andOnSecondInstance(
+            new Object[]{2},
+            new Object[]{null}
+        )
+        .whenQuery("select myField from testTable order by myField")
+        .thenResultIs("INTEGER",
+            "1",
+            "2",
+            "3",
+            "null"
+        );
+  }
+
+  // utils ---
+
+  @DataProvider(name = "nullHandlingEnabled")
+  public Object[][] nullHandlingEnabled() {
+    return new Object[][]{
+        {false}, {true}
+    };
+  }
+
+  private static final FieldSpec.DataType[] VALID_DATA_TYPES = new FieldSpec.DataType[]{
+      FieldSpec.DataType.INT,
+      FieldSpec.DataType.LONG,
+      FieldSpec.DataType.FLOAT,
+      FieldSpec.DataType.DOUBLE,
+      FieldSpec.DataType.STRING,
+      FieldSpec.DataType.BYTES,
+      FieldSpec.DataType.BIG_DECIMAL,
+      FieldSpec.DataType.TIMESTAMP,
+      FieldSpec.DataType.BOOLEAN
+  };
+
+  protected static final Map<FieldSpec.DataType, Schema> SINGLE_FIELD_NULLABLE_DIMENSION_SCHEMAS =
+      Arrays.stream(VALID_DATA_TYPES)
+          .collect(Collectors.toMap(dt -> dt, dt -> new Schema.SchemaBuilder()
+              .setSchemaName("testTable")
+              .setEnableColumnBasedNullHandling(true)
+              .addDimensionField("myField", dt, f -> f.setNullable(true))
+              .build()));
+
+  protected static final Map<FieldSpec.DataType, Schema> TWO_FIELDS_NULLABLE_DIMENSION_SCHEMAS =
+      Arrays.stream(VALID_DATA_TYPES)
+          .collect(Collectors.toMap(dt -> dt, dt -> new Schema.SchemaBuilder()
+              .setSchemaName("testTable2")
+              .setEnableColumnBasedNullHandling(true)
+              .addDimensionField("field1", dt, f -> f.setNullable(true))
+              .addDimensionField("field2", dt, f -> f.setNullable(true))
+              .build()));
+
+  protected static final TableConfig SINGLE_FIELD_TABLE_CONFIG = new TableConfigBuilder(TableType.OFFLINE)
+      .setTableName("testTable")
+      .build();
+
+  protected static final TableConfig TWO_FIELDS_TABLE_CONFIG = new TableConfigBuilder(TableType.OFFLINE)
+      .setTableName("testTable")
+      .build();
+
+  protected File _baseDir;
+
+  @BeforeClass
+  void createBaseDir() {
+    try {
+      _baseDir = Files.createTempDirectory(getClass().getSimpleName()).toFile();
+    } catch (IOException ex) {
+      throw new UncheckedIOException(ex);
+    }
+  }
+
+  @AfterClass
+  void destroyBaseDir()
+      throws IOException {
+    if (_baseDir != null) {
+      FileUtils.deleteDirectory(_baseDir);
+    }
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/groupby/GroupByOrderByKeyTrimTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/groupby/GroupByOrderByKeyTrimTest.java
@@ -1,0 +1,269 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.aggregation.groupby;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.pinot.core.common.Operator;
+import org.apache.pinot.core.data.table.Record;
+import org.apache.pinot.core.data.table.Table;
+import org.apache.pinot.core.operator.blocks.results.GroupByResultsBlock;
+import org.apache.pinot.core.operator.combine.GroupByCombineOperator;
+import org.apache.pinot.core.plan.GroupByPlanNode;
+import org.apache.pinot.core.query.request.context.QueryContext;
+import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
+import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
+import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.SegmentContext;
+import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.MetricFieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.ReadMode;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+
+/**
+ * Unit test for GroupBy Trim functionalities.
+ * - Builds a segment with random data.
+ * - Uses AggregationGroupByOrderByPlanNode class to construct an AggregationGroupByOrderByOperator
+ * - Perform aggregationGroupBy and OrderBy on the data
+ * - Also computes those results itself.
+ * - Asserts that the aggregation results returned by the class are the same as
+ *   returned by the local computations.
+ *
+ * Currently tests 'max' functions, and can be easily extended to
+ * test other conditions such as GroupBy without OrderBy
+ */
+public class GroupByOrderByKeyTrimTest {
+  private static final File INDEX_DIR = new File(FileUtils.getTempDirectory(), "GroupByTrimTest");
+  private static final String SEGMENT_NAME = "testSegment";
+  private static final String METRIC_PREFIX = "metric_";
+  private static final int NUM_COLUMNS = 2;
+  private static final int NUM_ROWS = 10000;
+
+  private final ExecutorService _executorService = Executors.newCachedThreadPool();
+  private IndexSegment _indexSegment;
+  private String[] _columns;
+  private double[][] _inputData;
+  private Map<Double, Double> _resultMap;
+
+  /**
+   * Initializations prior to the test:
+   * - Build a segment with metric columns (that will be aggregated and grouped) containing
+   *  randomly generated data.
+   *
+   * @throws Exception
+   */
+  @BeforeClass
+  public void setUp()
+      throws Exception {
+    FileUtils.deleteQuietly(INDEX_DIR);
+    _resultMap = new HashMap<>();
+    // Current Schema: Columns: metrics_0(double), metrics_1(double)
+    _inputData = new double[NUM_COLUMNS][NUM_ROWS];
+    _columns = new String[NUM_COLUMNS];
+    setupSegment();
+  }
+
+  @AfterClass
+  public void tearDown() {
+    _indexSegment.destroy();
+    _executorService.shutdown();
+    FileUtils.deleteQuietly(INDEX_DIR);
+  }
+
+  /**
+   * Test the GroupBy OrderBy query and compute the expected results to match
+   */
+  @Test(dataProvider = "groupByTrimTestDataProvider")
+  void testGroupByTrim(QueryContext queryContext, int minSegmentGroupTrimSize, int minServerGroupTrimSize,
+      List<Pair<Double, Double>> expectedResult)
+      throws Exception {
+    queryContext.setEndTimeMs(System.currentTimeMillis() + CommonConstants.Server.DEFAULT_QUERY_EXECUTOR_TIMEOUT_MS);
+    queryContext.setMinSegmentGroupTrimSize(minSegmentGroupTrimSize);
+    queryContext.setMinServerGroupTrimSize(minServerGroupTrimSize);
+
+    // Create a query operator
+    Operator<GroupByResultsBlock> groupByOperator =
+        new GroupByPlanNode(new SegmentContext(_indexSegment), queryContext).run();
+    GroupByCombineOperator combineOperator =
+        new GroupByCombineOperator(Collections.singletonList(groupByOperator), queryContext, _executorService);
+
+    // Execute the query
+    GroupByResultsBlock resultsBlock = (GroupByResultsBlock) combineOperator.nextBlock();
+
+    // Extract the execution result
+    List<Pair<Double, Double>> extractedResult = extractTestResult(resultsBlock.getTable());
+
+    Assert.assertEquals(extractedResult, expectedResult);
+  }
+
+  /**
+   * Helper method to setup the index segment on which to perform aggregation tests.
+   * - Generates a segment with {@link #NUM_COLUMNS} and {@link #NUM_ROWS}
+   * - Random 'double' data filled in the metric columns. The data is also populated
+   *   into the _inputData[], so it can be used to test the results.
+   *
+   * @throws Exception
+   */
+  private void setupSegment()
+      throws Exception {
+    // Segment Config
+    SegmentGeneratorConfig config =
+        new SegmentGeneratorConfig(new TableConfigBuilder(TableType.OFFLINE).setTableName("test").build(),
+            buildSchema());
+    config.setSegmentName(SEGMENT_NAME);
+    config.setOutDir(INDEX_DIR.getAbsolutePath());
+
+    // Fill the data table
+    List<GenericRow> rows = new ArrayList<>(NUM_ROWS);
+    int baseValue = 10;
+    for (int i = 0; i < NUM_ROWS; i++) {
+      GenericRow genericRow = new GenericRow();
+
+      for (int j = 0; j < NUM_COLUMNS; j++) {
+        double value = baseValue + i + j;
+        _inputData[j][i] = value;
+        genericRow.putValue(_columns[j], value);
+      }
+      // Compute the max result and insert into a grouped map
+      computeMaxResult(_inputData[0][i], _inputData[1][i]);
+      rows.add(genericRow);
+      baseValue += 10;
+    }
+
+    SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+    driver.init(config, new GenericRowRecordReader(rows));
+    driver.build();
+
+    _indexSegment = ImmutableSegmentLoader.load(new File(INDEX_DIR, driver.getSegmentName()), ReadMode.heap);
+  }
+
+  /**
+   * Helper method to build schema for the segment on which aggregation tests will be run.
+   *
+   * @return table schema
+   */
+  private Schema buildSchema() {
+    Schema schema = new Schema();
+
+    for (int i = 0; i < NUM_COLUMNS; i++) {
+      String metricName = METRIC_PREFIX + i;
+      MetricFieldSpec metricFieldSpec = new MetricFieldSpec(metricName, FieldSpec.DataType.DOUBLE);
+      schema.addField(metricFieldSpec);
+      _columns[i] = metricName;
+    }
+    return schema;
+  }
+
+  /**
+   * Helper method to compute the aggregation result grouped by the key
+   *
+   */
+  private void computeMaxResult(double key, double value) {
+    Double currentValue = _resultMap.get(key);
+    if (currentValue == null || currentValue < value) {
+      _resultMap.put(key, value);
+    }
+  }
+
+  /**
+   * Helper method to extract the result from IntermediateResultsBlock
+   *
+   * @return A list of expected results
+   */
+  private List<Pair<Double, Double>> extractTestResult(Table table) {
+    int numRows = table.size();
+    List<Pair<Double, Double>> result = new ArrayList<>(numRows);
+    Iterator<Record> iterator = table.iterator();
+    while (iterator.hasNext()) {
+      Object[] values = iterator.next().getValues();
+      result.add(Pair.of((Double) values[0], (Double) values[1]));
+    }
+    result.sort(Comparator.comparingDouble(Pair::getLeft));
+    return result;
+  }
+
+  @DataProvider
+  public Object[][] groupByTrimTestDataProvider() {
+    List<Object[]> data = new ArrayList<>();
+    List<Pair<Double, Double>> expectedResult = computeExpectedResult();
+
+    // Testcase1: low limit + high min trim size. Segment trim size should not have any effect
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContext(
+        "SELECT metric_0, max(metric_1) FROM testTable GROUP BY metric_0 ORDER BY metric_0 LIMIT 1");
+    List<Pair<Double, Double>> top1 = expectedResult.subList(0, 1);
+    data.add(new Object[]{queryContext, 100, 5000, top1});
+    data.add(new Object[]{queryContext, 100, -1, top1});
+    data.add(new Object[]{queryContext, -1, 100, top1});
+    data.add(new Object[]{queryContext, 5000, 100, top1});
+
+    // Testcase2: high limit + low min trim size
+    queryContext = QueryContextConverterUtils.getQueryContext(
+        "SELECT metric_0, max(metric_1) FROM testTable GROUP BY metric_0 ORDER BY metric_0 LIMIT 250");
+    List<Pair<Double, Double>> top250 = expectedResult.subList(0, 250);
+    data.add(new Object[]{queryContext, 50, 5000, top250});
+    data.add(new Object[]{queryContext, 200, -1, top250});
+    data.add(new Object[]{queryContext, -1, 150, top250});
+    data.add(new Object[]{queryContext, 5000, 10, top250});
+    data.add(new Object[]{queryContext, 20, 30, top250});
+
+    // Testcase3: disable trim
+    queryContext = QueryContextConverterUtils.getQueryContext(
+        "SELECT metric_0, max(metric_1) FROM testTable GROUP BY metric_0 ORDER BY max(metric_1) LIMIT 10000");
+    data.add(new Object[]{queryContext, -1, -1, expectedResult});
+
+    return data.toArray(new Object[data.size()][]);
+  }
+
+  /**
+   * Helper method to compute the expected result
+   *
+   * @return A list of expected results
+   */
+  private List<Pair<Double, Double>> computeExpectedResult() {
+    List<Pair<Double, Double>> result = new ArrayList<>(_resultMap.size());
+    for (Map.Entry<Double, Double> entry : _resultMap.entrySet()) {
+      result.add(Pair.of(entry.getKey(), entry.getValue()));
+    }
+    result.sort(Comparator.comparingDouble(Pair::getLeft));
+    return result;
+  }
+}


### PR DESCRIPTION
#16277 but using a ConcurrentSkipListMap for less contention when merging segment results