### PR TITLE
Fix DeterministicConcurrentIndexedMap not thread-safe

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/IndexedTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/IndexedTable.java
@@ -123,7 +123,8 @@ public abstract class IndexedTable extends BaseTable {
     _lookupMap.computeIfPresent(key, (k, v) -> updateRecord(v, newRecord));
   }
 
-  private Record updateRecord(Record existingRecord, Record newRecord) {
+  /// update existingRecord in-place with newRecord
+  protected Record updateRecord(Record existingRecord, Record newRecord) {
     Object[] existingValues = existingRecord.getValues();
     Object[] newValues = newRecord.getValues();
     int numAggregations = _aggregationFunctions.length;

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/Record.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/Record.java
@@ -49,6 +49,11 @@ public class Record {
     _values = values;
   }
 
+  ///  deep copy
+  public Record copy() {
+    return new Record(Arrays.copyOf(_values, _values.length));
+  }
+
   public Object[] getValues() {
     return _values;
   }


### PR DESCRIPTION
Fix #16290 . ConcurrentSkipListMap's [compute](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ConcurrentSkipListMap.html#compute-K-java.util.function.BiFunction-) method is not thread-safe. Instead this PR uses [putIfAbsent](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ConcurrentSkipListMap.html#putIfAbsent-K-V-) and 
 [replace](https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ConcurrentSkipListMap.html#replace-K-V-V-) methods in a compare-and-swap manner to fix it.

A test is supplied that the original impl fails upon.

The performance penalty is not significant when testing locally. 
Benchmark                                                     Mode  Cnt     Score      Error  Units
before                                                              avgt    3  7365.805 ± 1578.375  us/op
after                                                                 avgt    3  7062.490 ± 4415.175  us/op