### PR TITLE
Eliminate duplicate cancel attempts in PerQueryCPUMemAccountant

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/accounting/PerQueryCPUMemAccountantFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/accounting/PerQueryCPUMemAccountantFactory.java
@@ -115,7 +115,7 @@ public class PerQueryCPUMemAccountantFactory implements ThreadAccountantFactory 
         = ThreadLocal.withInitial(() -> {
           CPUMemThreadLevelAccountingObjects.ThreadEntry ret =
               new CPUMemThreadLevelAccountingObjects.ThreadEntry();
-          _threadEntriesMap.put(Thread.currentThread(), ret);
+          addThreadEntry(Thread.currentThread(), ret);
           LOGGER.debug("Adding thread to _threadLocalEntry: {}", Thread.currentThread().getName());
           return ret;
         }
@@ -379,6 +379,10 @@ public class PerQueryCPUMemAccountantFactory implements ThreadAccountantFactory 
       return _threadLocalEntry.get();
     }
 
+    public void addThreadEntry(Thread thread, CPUMemThreadLevelAccountingObjects.ThreadEntry threadEntry) {
+      _threadEntriesMap.put(thread, threadEntry);
+    }
+
     /**
      * clears thread accounting info once a runner/worker thread has finished a particular run
      */
@@ -427,6 +431,10 @@ public class PerQueryCPUMemAccountantFactory implements ThreadAccountantFactory 
         _inactiveQuery.addAll(_finishedTaskMemStatsAggregator.keySet());
         _inactiveQuery.addAll(_concurrentTaskMemStatsAggregator.keySet());
       }
+    }
+
+    public Set<String> getInactiveQueries() {
+      return Collections.unmodifiableSet(_inactiveQuery);
     }
 
     /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/accounting/PerQueryCPUMemAccountantFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/accounting/PerQueryCPUMemAccountantFactory.java
@@ -892,7 +892,7 @@ public class PerQueryCPUMemAccountantFactory implements ThreadAccountantFactory 
        */
       private void killMostExpensiveQuery() {
         if (!_isThreadMemorySamplingEnabled) {
-          LOGGER.warn("But unable to kill query memory tracking is enabled");
+          LOGGER.warn("Unable to terminate queries as  memory tracking is not enabled");
           return;
         }
         QueryMonitorConfig config = _queryMonitorConfig.get();
@@ -932,8 +932,6 @@ public class PerQueryCPUMemAccountantFactory implements ThreadAccountantFactory 
             } else {
               LOGGER.warn("But all queries are below quota, no query killed");
             }
-          } else {
-            LOGGER.warn("No query found to kill based on memory usage");
           }
           logQueryResourceUsage(_aggregatedUsagePerActiveQuery);
         } else {

--- a/pinot-core/src/test/java/org/apache/pinot/core/accounting/PerQueryCPUMemAccountCancelTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/accounting/PerQueryCPUMemAccountCancelTest.java
@@ -1,0 +1,190 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.accounting;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import org.apache.pinot.spi.accounting.QueryResourceTracker;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.util.TestUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+
+public class PerQueryCPUMemAccountCancelTest {
+  static class AlwaysTerminateMostExpensiveQueryAccountant extends TestResourceAccountant {
+    private static final Logger LOGGER = LoggerFactory.getLogger(AlwaysTerminateMostExpensiveQueryAccountant.class);
+    private final List<String> _cancelLog = new ArrayList<>();
+
+    AlwaysTerminateMostExpensiveQueryAccountant(
+        Map<Thread, CPUMemThreadLevelAccountingObjects.ThreadEntry> threadEntries) {
+      super(threadEntries);
+    }
+
+    @Override
+    public WatcherTask initWatcherTask() {
+      return new TerminatingWatcherTask();
+    }
+
+    @Override
+    public void cancelQuery(AggregatedStats queryResourceTracker) {
+      _cancelSentQueries.add(queryResourceTracker.getQueryId());
+      _cancelLog.add(queryResourceTracker.getQueryId());
+    }
+
+    public List<String> getCancelLog() {
+      return _cancelLog;
+    }
+
+    class TerminatingWatcherTask extends WatcherTask {
+      TerminatingWatcherTask() {
+        PinotConfiguration config = new PinotConfiguration();
+
+        config.setProperty(CommonConstants.Accounting.CONFIG_OF_MIN_MEMORY_FOOTPRINT_TO_KILL_RATIO, 0.01);
+
+        config.setProperty(CommonConstants.Accounting.CONFIG_OF_PANIC_LEVEL_HEAP_USAGE_RATIO,
+            CommonConstants.Accounting.DFAULT_PANIC_LEVEL_HEAP_USAGE_RATIO);
+
+        config.setProperty(CommonConstants.Accounting.CONFIG_OF_CRITICAL_LEVEL_HEAP_USAGE_RATIO,
+            CommonConstants.Accounting.DEFAULT_CRITICAL_LEVEL_HEAP_USAGE_RATIO);
+
+        config.setProperty(CommonConstants.Accounting.CONFIG_OF_CRITICAL_LEVEL_HEAP_USAGE_RATIO_DELTA_AFTER_GC,
+            CommonConstants.Accounting.DEFAULT_CONFIG_OF_CRITICAL_LEVEL_HEAP_USAGE_RATIO_DELTA_AFTER_GC);
+
+        config.setProperty(CommonConstants.Accounting.CONFIG_OF_GC_BACKOFF_COUNT,
+            CommonConstants.Accounting.DEFAULT_GC_BACKOFF_COUNT);
+
+        config.setProperty(CommonConstants.Accounting.CONFIG_OF_ALARMING_LEVEL_HEAP_USAGE_RATIO,
+            CommonConstants.Accounting.DEFAULT_ALARMING_LEVEL_HEAP_USAGE_RATIO);
+
+        config.setProperty(CommonConstants.Accounting.CONFIG_OF_SLEEP_TIME_MS,
+            CommonConstants.Accounting.DEFAULT_SLEEP_TIME_MS);
+
+        config.setProperty(CommonConstants.Accounting.CONFIG_OF_GC_WAIT_TIME_MS,
+            CommonConstants.Accounting.DEFAULT_CONFIG_OF_GC_WAIT_TIME_MS);
+
+        config.setProperty(CommonConstants.Accounting.CONFIG_OF_SLEEP_TIME_DENOMINATOR,
+            CommonConstants.Accounting.DEFAULT_SLEEP_TIME_DENOMINATOR);
+
+        config.setProperty(CommonConstants.Accounting.CONFIG_OF_OOM_PROTECTION_KILLING_QUERY, true);
+
+        config.setProperty(CommonConstants.Accounting.CONFIG_OF_PUBLISHING_JVM_USAGE,
+            CommonConstants.Accounting.DEFAULT_PUBLISHING_JVM_USAGE);
+
+        config.setProperty(CommonConstants.Accounting.CONFIG_OF_CPU_TIME_BASED_KILLING_ENABLED,
+            CommonConstants.Accounting.DEFAULT_CPU_TIME_BASED_KILLING_ENABLED);
+
+        config.setProperty(CommonConstants.Accounting.CONFIG_OF_CPU_TIME_BASED_KILLING_THRESHOLD_MS,
+            CommonConstants.Accounting.DEFAULT_CPU_TIME_BASED_KILLING_THRESHOLD_MS);
+
+        config.setProperty(CommonConstants.Accounting.CONFIG_OF_QUERY_KILLED_METRIC_ENABLED,
+            CommonConstants.Accounting.DEFAULT_QUERY_KILLED_METRIC_ENABLED);
+
+        QueryMonitorConfig queryMonitorConfig = new QueryMonitorConfig(config, 1000);
+        _queryMonitorConfig.set(queryMonitorConfig);
+      }
+
+      @Override
+      public void runOnce() {
+        _aggregatedUsagePerActiveQuery = null;
+        try {
+          evalTriggers();
+          reapFinishedTasks();
+          _aggregatedUsagePerActiveQuery = getQueryResourcesImpl();
+          triggeredActions();
+        } catch (Exception e) {
+          LOGGER.error("Caught exception while executing stats aggregation and query kill", e);
+        } finally {
+          // Clean inactive query stats
+          cleanInactive();
+        }
+      }
+
+      @Override
+      public void evalTriggers() {
+        _triggeringLevel = TriggeringLevel.HeapMemoryCritical;
+      }
+    }
+  }
+
+  @Test
+  void testCancelSingleQuery() {
+    Map<Thread, CPUMemThreadLevelAccountingObjects.ThreadEntry> threadEntries = new HashMap<>();
+    CountDownLatch threadLatch = new CountDownLatch(1);
+    String queryId = "testQueryAggregation";
+    TestResourceAccountant.getQueryThreadEntries(queryId, threadLatch, threadEntries);
+
+    AlwaysTerminateMostExpensiveQueryAccountant accountant =
+        new AlwaysTerminateMostExpensiveQueryAccountant(threadEntries);
+    Map<String, ? extends QueryResourceTracker> queryResourceTrackerMap = accountant.getQueryResources();
+    assertEquals(queryResourceTrackerMap.size(), 1);
+    QueryResourceTracker queryResourceTracker = queryResourceTrackerMap.get(queryId);
+    assertEquals(queryResourceTracker.getAllocatedBytes(), 5500);
+
+    // Cancel a query.
+    accountant.getWatcherTask().runOnce();
+    assertEquals(accountant.getCancelLog().size(), 1);
+
+    // Try once more. There should still be only one cancel.
+    accountant.getWatcherTask().runOnce();
+    assertEquals(accountant.getCancelLog().size(), 1);
+    threadLatch.countDown();
+    TestUtils.waitForCondition(aVoid -> {
+      accountant.reapFinishedTasks();
+      return accountant.getCancelSentQueries().isEmpty();
+    }, 100L, 1000L, "CancelSentList was not cleared");
+  }
+
+  @Test
+  void testCancelTwoQuery() {
+    Map<Thread, CPUMemThreadLevelAccountingObjects.ThreadEntry> threadEntries = new HashMap<>();
+    CountDownLatch threadLatch = new CountDownLatch(1);
+    String queryId = "testQueryOne";
+    TestResourceAccountant.getQueryThreadEntries(queryId, threadLatch, threadEntries);
+    String queryId2 = "testQueryTwo";
+    TestResourceAccountant.getQueryThreadEntries(queryId2, threadLatch, threadEntries);
+
+    AlwaysTerminateMostExpensiveQueryAccountant accountant =
+        new AlwaysTerminateMostExpensiveQueryAccountant(threadEntries);
+    Map<String, ? extends QueryResourceTracker> queryResourceTrackerMap = accountant.getQueryResources();
+    assertEquals(queryResourceTrackerMap.size(), 2);
+    assertEquals(queryResourceTrackerMap.get(queryId).getAllocatedBytes(), 5500);
+    assertEquals(queryResourceTrackerMap.get(queryId2).getAllocatedBytes(), 5500);
+
+    // Cancel a query.
+    accountant.getWatcherTask().runOnce();
+    assertEquals(accountant.getCancelLog().size(), 1);
+
+    // Try once more. There should still be only one cancel.
+    accountant.getWatcherTask().runOnce();
+    assertEquals(accountant.getCancelLog().size(), 2);
+    threadLatch.countDown();
+    TestUtils.waitForCondition(aVoid -> {
+      accountant.reapFinishedTasks();
+      return accountant.getCancelSentQueries().isEmpty();
+    }, 100L, 1000L, "CancelSentList was not cleared");
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/accounting/PerQueryCPUMemAccountCancelTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/accounting/PerQueryCPUMemAccountCancelTest.java
@@ -178,7 +178,6 @@ public class PerQueryCPUMemAccountCancelTest {
     accountant.getWatcherTask().runOnce();
     assertEquals(accountant.getCancelLog().size(), 1);
 
-    // Try once more. There should still be only one cancel.
     accountant.getWatcherTask().runOnce();
     assertEquals(accountant.getCancelLog().size(), 2);
     threadLatch.countDown();

--- a/pinot-core/src/test/java/org/apache/pinot/core/accounting/PerQueryCPUMemAccountCancelTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/accounting/PerQueryCPUMemAccountCancelTest.java
@@ -45,7 +45,7 @@ public class PerQueryCPUMemAccountCancelTest {
     }
 
     @Override
-    public WatcherTask initWatcherTask() {
+    public WatcherTask createWatcherTask() {
       return new TerminatingWatcherTask();
     }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/accounting/PerQueryCPUMemAccountantTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/accounting/PerQueryCPUMemAccountantTest.java
@@ -72,7 +72,7 @@ public class PerQueryCPUMemAccountantTest {
     CPUMemThreadLevelAccountingObjects.ThreadEntry threadEntry = workerEntry._threadEntry;
     threadEntry._currentThreadTaskStatus.set(
         new CPUMemThreadLevelAccountingObjects.TaskEntry(queryId, 5, ThreadExecutionContext.TaskType.SSE,
-            anchorThread._workerThread));
+            anchorThread._workerThread, CommonConstants.Accounting.DEFAULT_WORKLOAD_NAME));
     threadEntry._currentThreadMemoryAllocationSampleBytes = 1500;
 
     Map<String, ? extends QueryResourceTracker> queryResourceTrackerMap = accountant.getQueryResources();
@@ -102,7 +102,7 @@ public class PerQueryCPUMemAccountantTest {
     CPUMemThreadLevelAccountingObjects.ThreadEntry threadEntry = workerEntry._threadEntry;
     threadEntry._currentThreadTaskStatus.set(
         new CPUMemThreadLevelAccountingObjects.TaskEntry(queryId, 5, ThreadExecutionContext.TaskType.SSE,
-            anchorThread._workerThread));
+            anchorThread._workerThread, CommonConstants.Accounting.DEFAULT_WORKLOAD_NAME));
     threadEntry.setToIdle();
 
     Map<String, ? extends QueryResourceTracker> queryResourceTrackerMap = accountant.getQueryResources();
@@ -137,7 +137,7 @@ public class PerQueryCPUMemAccountantTest {
     CPUMemThreadLevelAccountingObjects.ThreadEntry threadEntry = workerEntry._threadEntry;
     threadEntry._currentThreadTaskStatus.set(
         new CPUMemThreadLevelAccountingObjects.TaskEntry(queryId, 5, ThreadExecutionContext.TaskType.SSE,
-            anchorThread._workerThread));
+            anchorThread._workerThread, CommonConstants.Accounting.DEFAULT_WORKLOAD_NAME));
     threadEntry._currentThreadMemoryAllocationSampleBytes = 1500;
 
     accountant.reapFinishedTasks();
@@ -205,7 +205,7 @@ public class PerQueryCPUMemAccountantTest {
     CPUMemThreadLevelAccountingObjects.ThreadEntry threadEntry = workerEntry._threadEntry;
     threadEntry._currentThreadTaskStatus.set(
         new CPUMemThreadLevelAccountingObjects.TaskEntry(queryId, 5, ThreadExecutionContext.TaskType.SSE,
-            anchorThread._workerThread));
+            anchorThread._workerThread, CommonConstants.Accounting.DEFAULT_WORKLOAD_NAME));
     threadEntry._currentThreadMemoryAllocationSampleBytes = 1500;
 
     accountant.reapFinishedTasks();
@@ -251,7 +251,7 @@ public class PerQueryCPUMemAccountantTest {
     CPUMemThreadLevelAccountingObjects.ThreadEntry threadEntry = workerEntry._threadEntry;
     threadEntry._currentThreadTaskStatus.set(
         new CPUMemThreadLevelAccountingObjects.TaskEntry(newQueryId, 5, ThreadExecutionContext.TaskType.SSE,
-            anchorThread._workerThread));
+            anchorThread._workerThread, CommonConstants.Accounting.DEFAULT_WORKLOAD_NAME));
     threadEntry._currentThreadMemoryAllocationSampleBytes = 3500;
 
     accountant.reapFinishedTasks();

--- a/pinot-core/src/test/java/org/apache/pinot/core/accounting/PerQueryCPUMemAccountantTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/accounting/PerQueryCPUMemAccountantTest.java
@@ -1,0 +1,252 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.accounting;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.stream.Collectors;
+import org.apache.pinot.spi.accounting.QueryResourceTracker;
+import org.apache.pinot.spi.accounting.ThreadExecutionContext;
+import org.apache.pinot.spi.accounting.ThreadResourceUsageAccountant;
+import org.apache.pinot.spi.config.instance.InstanceType;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+
+public class PerQueryCPUMemAccountantTest {
+  static class TestResourceAccountant extends PerQueryCPUMemAccountantFactory.PerQueryCPUMemResourceUsageAccountant {
+    TestResourceAccountant(Map<Thread, CPUMemThreadLevelAccountingObjects.ThreadEntry> threadEntries) {
+      super(new PinotConfiguration(), false, true, true, new HashSet<>(), "test", InstanceType.SERVER);
+      _threadEntriesMap.putAll(threadEntries);
+    }
+  }
+
+  @Test
+  void testQueryAggregation() {
+    Map<Thread, CPUMemThreadLevelAccountingObjects.ThreadEntry> threadEntries = new HashMap<>();
+    CountDownLatch threadLatch = new CountDownLatch(1);
+    String queryId = "testQueryAggregation";
+    getQueryThreadEntries(queryId, threadLatch, threadEntries);
+
+    ThreadResourceUsageAccountant accountant = new TestResourceAccountant(threadEntries);
+    Map<String, ? extends QueryResourceTracker> queryResourceTrackerMap = accountant.getQueryResources();
+    assertEquals(queryResourceTrackerMap.size(), 1);
+    QueryResourceTracker queryResourceTracker = queryResourceTrackerMap.get(queryId);
+    assertEquals(queryResourceTracker.getAllocatedBytes(), 5500);
+    threadLatch.countDown();
+  }
+
+  /*
+   * @link{PerQueryCPUMemAccountantFactory.PerQueryCPUMemResourceUsageAccountant#reapFinishedTask} stores the previous
+   * task's status. If it is not called, then the current task info is lost.
+   */
+  @Test
+  void testQueryAggregationCreateNewTask() {
+    Map<Thread, CPUMemThreadLevelAccountingObjects.ThreadEntry> threadEntries = new HashMap<>();
+    CountDownLatch threadLatch = new CountDownLatch(1);
+    String queryId = "testQueryAggregationCreateNewTask";
+    getQueryThreadEntries(queryId, threadLatch, threadEntries);
+    ThreadResourceUsageAccountant accountant = new TestResourceAccountant(threadEntries);
+
+    Thread anchorThread =
+        threadEntries.entrySet().stream().filter(e -> e.getValue()._currentThreadTaskStatus.get().isAnchorThread())
+            .collect(Collectors.toList()).get(0).getKey();
+    assertNotNull(anchorThread);
+
+    // Replace task id = 3 (2500 bytes) with a new task id 5 (1500 bytes)
+    Map.Entry<Thread, CPUMemThreadLevelAccountingObjects.ThreadEntry> workerEntry =
+        threadEntries.entrySet().stream().filter(e -> e.getValue()._currentThreadTaskStatus.get().getTaskId() == 3)
+            .collect(Collectors.toList()).get(0);
+    assertNotNull(workerEntry);
+
+    // New Task
+    CPUMemThreadLevelAccountingObjects.ThreadEntry threadEntry = workerEntry.getValue();
+    threadEntry._currentThreadTaskStatus.set(
+        new CPUMemThreadLevelAccountingObjects.TaskEntry(queryId, 5, ThreadExecutionContext.TaskType.SSE,
+            anchorThread));
+    threadEntry._currentThreadMemoryAllocationSampleBytes = 1500;
+
+    Map<String, ? extends QueryResourceTracker> queryResourceTrackerMap = accountant.getQueryResources();
+    assertEquals(queryResourceTrackerMap.size(), 1);
+    QueryResourceTracker queryResourceTracker = queryResourceTrackerMap.get(queryId);
+    assertEquals(queryResourceTracker.getAllocatedBytes(), 4500);
+    threadLatch.countDown();
+  }
+
+  @Test
+  void testQueryAggregationSetToIdle() {
+    Map<Thread, CPUMemThreadLevelAccountingObjects.ThreadEntry> threadEntries = new HashMap<>();
+    CountDownLatch threadLatch = new CountDownLatch(1);
+    String queryId = "testQueryAggregationSetToIdle";
+    getQueryThreadEntries(queryId, threadLatch, threadEntries);
+    ThreadResourceUsageAccountant accountant = new TestResourceAccountant(threadEntries);
+
+    Thread anchorThread =
+        threadEntries.entrySet().stream().filter(e -> e.getValue()._currentThreadTaskStatus.get().isAnchorThread())
+            .collect(Collectors.toList()).get(0).getKey();
+    assertNotNull(anchorThread);
+
+    // Replace task id = 3 (2500 bytes) with a new task id 5 (1500 bytes)
+    Map.Entry<Thread, CPUMemThreadLevelAccountingObjects.ThreadEntry> workerEntry =
+        threadEntries.entrySet().stream().filter(e -> e.getValue()._currentThreadTaskStatus.get().getTaskId() == 3)
+            .collect(Collectors.toList()).get(0);
+    assertNotNull(workerEntry);
+
+    // New Task
+    CPUMemThreadLevelAccountingObjects.ThreadEntry threadEntry = workerEntry.getValue();
+    threadEntry._currentThreadTaskStatus.set(
+        new CPUMemThreadLevelAccountingObjects.TaskEntry(queryId, 5, ThreadExecutionContext.TaskType.SSE,
+            anchorThread));
+    threadEntry.setToIdle();
+
+    Map<String, ? extends QueryResourceTracker> queryResourceTrackerMap = accountant.getQueryResources();
+    assertEquals(queryResourceTrackerMap.size(), 1);
+    QueryResourceTracker queryResourceTracker = queryResourceTrackerMap.get(queryId);
+    assertEquals(queryResourceTracker.getAllocatedBytes(), 3000);
+    threadLatch.countDown();
+  }
+
+  /*
+   * @link{PerQueryCPUMemAccountantFactory.PerQueryCPUMemResourceUsageAccountant#reapFinishedTask} stores the previous
+   * task's status. If it is called, then the resources of finished tasks should also be provided.
+   */
+  @Test
+  void testQueryAggregationReapAndCreateNewTask() {
+    Map<Thread, CPUMemThreadLevelAccountingObjects.ThreadEntry> threadEntries = new HashMap<>();
+    CountDownLatch threadLatch = new CountDownLatch(1);
+    String queryId = "testQueryAggregationReapAndCreateNewTask";
+    getQueryThreadEntries(queryId, threadLatch, threadEntries);
+    TestResourceAccountant accountant = new TestResourceAccountant(threadEntries);
+    accountant.reapFinishedTasks();
+
+    Thread anchorThread =
+        threadEntries.entrySet().stream().filter(e -> e.getValue()._currentThreadTaskStatus.get().isAnchorThread())
+            .collect(Collectors.toList()).get(0).getKey();
+    assertNotNull(anchorThread);
+
+    // Replace task id = 3 (2500 bytes) with a new task id 5 (1500 bytes)
+    Map.Entry<Thread, CPUMemThreadLevelAccountingObjects.ThreadEntry> workerEntry =
+        threadEntries.entrySet().stream().filter(e -> e.getValue()._currentThreadTaskStatus.get().getTaskId() == 3)
+            .collect(Collectors.toList()).get(0);
+    assertNotNull(workerEntry);
+
+    // New Task
+    CPUMemThreadLevelAccountingObjects.ThreadEntry threadEntry = workerEntry.getValue();
+    threadEntry._currentThreadTaskStatus.set(
+        new CPUMemThreadLevelAccountingObjects.TaskEntry(queryId, 5, ThreadExecutionContext.TaskType.SSE,
+            anchorThread));
+    threadEntry._currentThreadMemoryAllocationSampleBytes = 1500;
+
+    accountant.reapFinishedTasks();
+
+    Map<String, ? extends QueryResourceTracker> queryResourceTrackerMap = accountant.getQueryResources();
+    assertEquals(queryResourceTrackerMap.size(), 1);
+    QueryResourceTracker queryResourceTracker = queryResourceTrackerMap.get(queryId);
+    assertEquals(queryResourceTracker.getAllocatedBytes(), 7000);
+    threadLatch.countDown();
+  }
+
+  @Test
+  void testQueryAggregationReapAndSetToIdle() {
+    Map<Thread, CPUMemThreadLevelAccountingObjects.ThreadEntry> threadEntries = new HashMap<>();
+    CountDownLatch threadLatch = new CountDownLatch(1);
+    String queryId = "testQueryAggregationReapAndSetToIdle";
+    getQueryThreadEntries(queryId, threadLatch, threadEntries);
+    TestResourceAccountant accountant = new TestResourceAccountant(threadEntries);
+    accountant.reapFinishedTasks();
+
+    Thread anchorThread =
+        threadEntries.entrySet().stream().filter(e -> e.getValue()._currentThreadTaskStatus.get().isAnchorThread())
+            .collect(Collectors.toList()).get(0).getKey();
+    assertNotNull(anchorThread);
+
+    // Replace task id = 3 (2500 bytes) with null
+    Map.Entry<Thread, CPUMemThreadLevelAccountingObjects.ThreadEntry> workerEntry =
+        threadEntries.entrySet().stream().filter(e -> e.getValue()._currentThreadTaskStatus.get().getTaskId() == 3)
+            .collect(Collectors.toList()).get(0);
+    assertNotNull(workerEntry);
+
+    // New Task
+    CPUMemThreadLevelAccountingObjects.ThreadEntry threadEntry = workerEntry.getValue();
+    threadEntry.setToIdle();
+
+    accountant.reapFinishedTasks();
+
+    Map<String, ? extends QueryResourceTracker> queryResourceTrackerMap = accountant.getQueryResources();
+    assertEquals(queryResourceTrackerMap.size(), 1);
+    QueryResourceTracker queryResourceTracker = queryResourceTrackerMap.get(queryId);
+    assertEquals(queryResourceTracker.getAllocatedBytes(), 5500);
+    threadLatch.countDown();
+  }
+
+  private void getQueryThreadEntries(String queryId, CountDownLatch threadLatch,
+      Map<Thread, CPUMemThreadLevelAccountingObjects.ThreadEntry> threadEntries) {
+    Thread anchorThread = new Thread(() -> {
+      try {
+        threadLatch.await();
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    });
+    anchorThread.start();
+
+    CPUMemThreadLevelAccountingObjects.ThreadEntry anchorEntry = new CPUMemThreadLevelAccountingObjects.ThreadEntry();
+    anchorEntry._currentThreadTaskStatus.set(
+        new CPUMemThreadLevelAccountingObjects.TaskEntry(queryId, CommonConstants.Accounting.ANCHOR_TASK_ID,
+            ThreadExecutionContext.TaskType.SSE, anchorThread));
+    anchorEntry._currentThreadMemoryAllocationSampleBytes = 1000;
+    threadEntries.put(anchorThread, anchorEntry);
+
+    CPUMemThreadLevelAccountingObjects.ThreadEntry worker1 = new CPUMemThreadLevelAccountingObjects.ThreadEntry();
+    worker1._currentThreadTaskStatus.set(
+        new CPUMemThreadLevelAccountingObjects.TaskEntry(queryId, 2, ThreadExecutionContext.TaskType.SSE,
+            anchorThread));
+    worker1._currentThreadMemoryAllocationSampleBytes = 2000;
+    Thread workerThread1 = new Thread(() -> {
+      try {
+        threadLatch.await();
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    });
+    workerThread1.start();
+    threadEntries.put(workerThread1, worker1);
+
+    CPUMemThreadLevelAccountingObjects.ThreadEntry worker2 = new CPUMemThreadLevelAccountingObjects.ThreadEntry();
+    worker2._currentThreadTaskStatus.set(
+        new CPUMemThreadLevelAccountingObjects.TaskEntry(queryId, 3, ThreadExecutionContext.TaskType.SSE,
+            anchorThread));
+    worker2._currentThreadMemoryAllocationSampleBytes = 2500;
+    Thread workerThread2 = new Thread(() -> {
+      try {
+        threadLatch.await();
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    });
+    workerThread2.start();
+    threadEntries.put(workerThread2, worker2);
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/accounting/PerQueryCPUMemAccountantTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/accounting/PerQueryCPUMemAccountantTest.java
@@ -19,15 +19,10 @@
 package org.apache.pinot.core.accounting;
 
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
-import java.util.stream.Collectors;
 import org.apache.pinot.spi.accounting.QueryResourceTracker;
 import org.apache.pinot.spi.accounting.ThreadExecutionContext;
-import org.apache.pinot.spi.config.instance.InstanceType;
-import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.testng.annotations.Test;
 
@@ -37,38 +32,13 @@ import static org.testng.Assert.assertTrue;
 
 
 public class PerQueryCPUMemAccountantTest {
-  public static class TaskThread {
-    public final CPUMemThreadLevelAccountingObjects.ThreadEntry _threadEntry;
-    public final Thread _workerThread;
-
-    public TaskThread(CPUMemThreadLevelAccountingObjects.ThreadEntry _threadEntry, Thread _workerThread) {
-      this._threadEntry = _threadEntry;
-      this._workerThread = _workerThread;
-    }
-  }
-
-  static class TestResourceAccountant extends PerQueryCPUMemAccountantFactory.PerQueryCPUMemResourceUsageAccountant {
-    TestResourceAccountant(Map<Thread, CPUMemThreadLevelAccountingObjects.ThreadEntry> threadEntries) {
-      super(new PinotConfiguration(), false, true, true, new HashSet<>(), "test", InstanceType.SERVER);
-      _threadEntriesMap.putAll(threadEntries);
-    }
-
-    public TaskThread getTaskThread(String queryId, int taskId) {
-      Map.Entry<Thread, CPUMemThreadLevelAccountingObjects.ThreadEntry> workerEntry =
-          _threadEntriesMap.entrySet().stream().filter(
-                  e -> e.getValue()._currentThreadTaskStatus.get().getTaskId() == 3 && Objects.equals(
-                      e.getValue()._currentThreadTaskStatus.get().getQueryId(), queryId)).collect(Collectors.toList())
-              .get(0);
-      return new TaskThread(workerEntry.getValue(), workerEntry.getKey());
-    }
-  }
 
   @Test
   void testQueryAggregation() {
     Map<Thread, CPUMemThreadLevelAccountingObjects.ThreadEntry> threadEntries = new HashMap<>();
     CountDownLatch threadLatch = new CountDownLatch(1);
     String queryId = "testQueryAggregation";
-    getQueryThreadEntries(queryId, threadLatch, threadEntries);
+    TestResourceAccountant.getQueryThreadEntries(queryId, threadLatch, threadEntries);
 
     TestResourceAccountant accountant = new TestResourceAccountant(threadEntries);
     Map<String, ? extends QueryResourceTracker> queryResourceTrackerMap = accountant.getQueryResources();
@@ -87,14 +57,15 @@ public class PerQueryCPUMemAccountantTest {
     Map<Thread, CPUMemThreadLevelAccountingObjects.ThreadEntry> threadEntries = new HashMap<>();
     CountDownLatch threadLatch = new CountDownLatch(1);
     String queryId = "testQueryAggregationCreateNewTask";
-    getQueryThreadEntries(queryId, threadLatch, threadEntries);
+    TestResourceAccountant.getQueryThreadEntries(queryId, threadLatch, threadEntries);
     TestResourceAccountant accountant = new TestResourceAccountant(threadEntries);
 
-    TaskThread anchorThread = accountant.getTaskThread(queryId, CommonConstants.Accounting.ANCHOR_TASK_ID);
+    TestResourceAccountant.TaskThread anchorThread =
+        accountant.getTaskThread(queryId, CommonConstants.Accounting.ANCHOR_TASK_ID);
     assertNotNull(anchorThread);
 
     // Replace task id = 3 (2500 bytes) with a new task id 5 (1500 bytes)
-    TaskThread workerEntry = accountant.getTaskThread(queryId, 3);
+    TestResourceAccountant.TaskThread workerEntry = accountant.getTaskThread(queryId, 3);
     assertNotNull(workerEntry);
 
     // New Task
@@ -116,14 +87,15 @@ public class PerQueryCPUMemAccountantTest {
     Map<Thread, CPUMemThreadLevelAccountingObjects.ThreadEntry> threadEntries = new HashMap<>();
     CountDownLatch threadLatch = new CountDownLatch(1);
     String queryId = "testQueryAggregationSetToIdle";
-    getQueryThreadEntries(queryId, threadLatch, threadEntries);
+    TestResourceAccountant.getQueryThreadEntries(queryId, threadLatch, threadEntries);
     TestResourceAccountant accountant = new TestResourceAccountant(threadEntries);
 
-    TaskThread anchorThread = accountant.getTaskThread(queryId, CommonConstants.Accounting.ANCHOR_TASK_ID);
+    TestResourceAccountant.TaskThread anchorThread =
+        accountant.getTaskThread(queryId, CommonConstants.Accounting.ANCHOR_TASK_ID);
     assertNotNull(anchorThread);
 
     // Replace task id = 3 (2500 bytes) with a new task id 5 (1500 bytes)
-    TaskThread workerEntry = accountant.getTaskThread(queryId, 3);
+    TestResourceAccountant.TaskThread workerEntry = accountant.getTaskThread(queryId, 3);
     assertNotNull(workerEntry);
 
     // New Task
@@ -149,15 +121,16 @@ public class PerQueryCPUMemAccountantTest {
     Map<Thread, CPUMemThreadLevelAccountingObjects.ThreadEntry> threadEntries = new HashMap<>();
     CountDownLatch threadLatch = new CountDownLatch(1);
     String queryId = "testQueryAggregationReapAndCreateNewTask";
-    getQueryThreadEntries(queryId, threadLatch, threadEntries);
+    TestResourceAccountant.getQueryThreadEntries(queryId, threadLatch, threadEntries);
     TestResourceAccountant accountant = new TestResourceAccountant(threadEntries);
     accountant.reapFinishedTasks();
 
-    TaskThread anchorThread = accountant.getTaskThread(queryId, CommonConstants.Accounting.ANCHOR_TASK_ID);
+    TestResourceAccountant.TaskThread anchorThread =
+        accountant.getTaskThread(queryId, CommonConstants.Accounting.ANCHOR_TASK_ID);
     assertNotNull(anchorThread);
 
     // Replace task id = 3 (2500 bytes) with a new task id 5 (1500 bytes)
-    TaskThread workerEntry = accountant.getTaskThread(queryId, 3);
+    TestResourceAccountant.TaskThread workerEntry = accountant.getTaskThread(queryId, 3);
     assertNotNull(workerEntry);
 
     // New Task
@@ -181,15 +154,16 @@ public class PerQueryCPUMemAccountantTest {
     Map<Thread, CPUMemThreadLevelAccountingObjects.ThreadEntry> threadEntries = new HashMap<>();
     CountDownLatch threadLatch = new CountDownLatch(1);
     String queryId = "testQueryAggregationReapAndSetToIdle";
-    getQueryThreadEntries(queryId, threadLatch, threadEntries);
+    TestResourceAccountant.getQueryThreadEntries(queryId, threadLatch, threadEntries);
     TestResourceAccountant accountant = new TestResourceAccountant(threadEntries);
     accountant.reapFinishedTasks();
 
-    TaskThread anchorThread = accountant.getTaskThread(queryId, CommonConstants.Accounting.ANCHOR_TASK_ID);
+    TestResourceAccountant.TaskThread anchorThread =
+        accountant.getTaskThread(queryId, CommonConstants.Accounting.ANCHOR_TASK_ID);
     assertNotNull(anchorThread);
 
     // Replace task id = 3 (2500 bytes) with null
-    TaskThread workerEntry = accountant.getTaskThread(queryId, 3);
+    TestResourceAccountant.TaskThread workerEntry = accountant.getTaskThread(queryId, 3);
     assertNotNull(workerEntry);
 
     // Set to Idle
@@ -210,7 +184,7 @@ public class PerQueryCPUMemAccountantTest {
     Map<Thread, CPUMemThreadLevelAccountingObjects.ThreadEntry> threadEntries = new HashMap<>();
     CountDownLatch threadLatch = new CountDownLatch(1);
     String queryId = "testQueryAggregation";
-    getQueryThreadEntries(queryId, threadLatch, threadEntries);
+    TestResourceAccountant.getQueryThreadEntries(queryId, threadLatch, threadEntries);
 
     TestResourceAccountant accountant = new TestResourceAccountant(threadEntries);
     Map<String, ? extends QueryResourceTracker> queryResourceTrackerMap = accountant.getQueryResources();
@@ -219,11 +193,12 @@ public class PerQueryCPUMemAccountantTest {
     accountant.reapFinishedTasks();
 
     // Pick up a new task. This will add entries to _finishedMemAggregator
-    TaskThread anchorThread = accountant.getTaskThread(queryId, CommonConstants.Accounting.ANCHOR_TASK_ID);
+    TestResourceAccountant.TaskThread anchorThread =
+        accountant.getTaskThread(queryId, CommonConstants.Accounting.ANCHOR_TASK_ID);
     assertNotNull(anchorThread);
 
     // Replace task id = 3 (2500 bytes) with a new task id 5 (1500 bytes)
-    TaskThread workerEntry = accountant.getTaskThread(queryId, 3);
+    TestResourceAccountant.TaskThread workerEntry = accountant.getTaskThread(queryId, 3);
     assertNotNull(workerEntry);
 
     // New Task
@@ -250,7 +225,7 @@ public class PerQueryCPUMemAccountantTest {
     Map<Thread, CPUMemThreadLevelAccountingObjects.ThreadEntry> threadEntries = new HashMap<>();
     CountDownLatch threadLatch = new CountDownLatch(1);
     String queryId = "testQueryAggregationAddNewQueryTask";
-    getQueryThreadEntries(queryId, threadLatch, threadEntries);
+    TestResourceAccountant.getQueryThreadEntries(queryId, threadLatch, threadEntries);
     TestResourceAccountant accountant = new TestResourceAccountant(threadEntries);
     accountant.reapFinishedTasks();
 
@@ -258,17 +233,18 @@ public class PerQueryCPUMemAccountantTest {
     CountDownLatch newQueryThreadLatch = new CountDownLatch(1);
     String newQueryId = "newQuery";
     Map<Thread, CPUMemThreadLevelAccountingObjects.ThreadEntry> newQueryThreadEntries = new HashMap<>();
-    getQueryThreadEntries(newQueryId, newQueryThreadLatch, newQueryThreadEntries);
+    TestResourceAccountant.getQueryThreadEntries(newQueryId, newQueryThreadLatch, newQueryThreadEntries);
     for (Map.Entry<Thread, CPUMemThreadLevelAccountingObjects.ThreadEntry> entry : newQueryThreadEntries.entrySet()) {
       accountant.addThreadEntry(entry.getKey(), entry.getValue());
     }
 
     // Create a new task for newQuery
-    TaskThread anchorThread = accountant.getTaskThread(newQueryId, CommonConstants.Accounting.ANCHOR_TASK_ID);
+    TestResourceAccountant.TaskThread anchorThread =
+        accountant.getTaskThread(newQueryId, CommonConstants.Accounting.ANCHOR_TASK_ID);
     assertNotNull(anchorThread);
 
     // Replace task id = 3 (2500 bytes) of first query with a new task id 5 of new query (3500 bytes)
-    TaskThread workerEntry = accountant.getTaskThread(queryId, 3);
+    TestResourceAccountant.TaskThread workerEntry = accountant.getTaskThread(queryId, 3);
     assertNotNull(workerEntry);
 
     // New Task
@@ -288,43 +264,5 @@ public class PerQueryCPUMemAccountantTest {
     assertEquals(newQueryResourceTracker.getAllocatedBytes(), 9000);
     threadLatch.countDown();
     newQueryThreadLatch.countDown();
-  }
-
-  private static void getQueryThreadEntries(String queryId, CountDownLatch threadLatch,
-      Map<Thread, CPUMemThreadLevelAccountingObjects.ThreadEntry> threadEntries) {
-    TaskThread anchorThread = getTaskThread(queryId, CommonConstants.Accounting.ANCHOR_TASK_ID, threadLatch, null);
-    threadEntries.put(anchorThread._workerThread, anchorThread._threadEntry);
-    anchorThread._threadEntry._currentThreadMemoryAllocationSampleBytes = 1000;
-
-    CPUMemThreadLevelAccountingObjects.ThreadEntry anchorEntry = new CPUMemThreadLevelAccountingObjects.ThreadEntry();
-    anchorEntry._currentThreadTaskStatus.set(
-        new CPUMemThreadLevelAccountingObjects.TaskEntry(queryId, CommonConstants.Accounting.ANCHOR_TASK_ID,
-            ThreadExecutionContext.TaskType.SSE, anchorThread._workerThread));
-    anchorEntry._currentThreadMemoryAllocationSampleBytes = 1000;
-    threadEntries.put(anchorThread._workerThread, anchorEntry);
-
-    TaskThread taskThread2 = getTaskThread(queryId, 2, threadLatch, anchorThread._workerThread);
-    threadEntries.put(taskThread2._workerThread, taskThread2._threadEntry);
-    taskThread2._threadEntry._currentThreadMemoryAllocationSampleBytes = 2000;
-
-    TaskThread taskThread3 = getTaskThread(queryId, 3, threadLatch, anchorThread._workerThread);
-    threadEntries.put(taskThread3._workerThread, taskThread3._threadEntry);
-    taskThread3._threadEntry._currentThreadMemoryAllocationSampleBytes = 2500;
-  }
-
-  private static TaskThread getTaskThread(String queryId, int taskId, CountDownLatch threadLatch, Thread anchorThread) {
-    CPUMemThreadLevelAccountingObjects.ThreadEntry worker1 = new CPUMemThreadLevelAccountingObjects.ThreadEntry();
-    worker1._currentThreadTaskStatus.set(
-        new CPUMemThreadLevelAccountingObjects.TaskEntry(queryId, taskId, ThreadExecutionContext.TaskType.SSE,
-            anchorThread));
-    Thread workerThread1 = new Thread(() -> {
-      try {
-        threadLatch.await();
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-      }
-    });
-    workerThread1.start();
-    return new TaskThread(worker1, workerThread1);
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/accounting/QueryMonitorConfigTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/accounting/QueryMonitorConfigTest.java
@@ -32,7 +32,7 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 
-public class PerQueryCPUMemAccountantFactoryTest {
+public class QueryMonitorConfigTest {
   private static final double EXPECTED_MIN_MEMORY_FOOTPRINT_FOR_KILL = 0.05;
   private static final double EXPECTED_PANIC_LEVEL = 0.9f;
   private static final double EXPECTED_CRITICAL_LEVEL = 0.95f;

--- a/pinot-core/src/test/java/org/apache/pinot/core/accounting/TestResourceAccountant.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/accounting/TestResourceAccountant.java
@@ -1,0 +1,94 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.accounting;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.CountDownLatch;
+import java.util.stream.Collectors;
+import org.apache.pinot.spi.accounting.ThreadExecutionContext;
+import org.apache.pinot.spi.config.instance.InstanceType;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.utils.CommonConstants;
+
+
+class TestResourceAccountant extends PerQueryCPUMemAccountantFactory.PerQueryCPUMemResourceUsageAccountant {
+  TestResourceAccountant(Map<Thread, CPUMemThreadLevelAccountingObjects.ThreadEntry> threadEntries) {
+    super(new PinotConfiguration(), false, true, true, new HashSet<>(), "test", InstanceType.SERVER);
+    _threadEntriesMap.putAll(threadEntries);
+  }
+
+  static void getQueryThreadEntries(String queryId, CountDownLatch threadLatch,
+      Map<Thread, CPUMemThreadLevelAccountingObjects.ThreadEntry> threadEntries) {
+    TaskThread
+        anchorThread = getTaskThread(queryId, CommonConstants.Accounting.ANCHOR_TASK_ID, threadLatch, null);
+    threadEntries.put(anchorThread._workerThread, anchorThread._threadEntry);
+    anchorThread._threadEntry._currentThreadMemoryAllocationSampleBytes = 1000;
+
+    CPUMemThreadLevelAccountingObjects.ThreadEntry anchorEntry = new CPUMemThreadLevelAccountingObjects.ThreadEntry();
+    anchorEntry._currentThreadTaskStatus.set(
+        new CPUMemThreadLevelAccountingObjects.TaskEntry(queryId, CommonConstants.Accounting.ANCHOR_TASK_ID,
+            ThreadExecutionContext.TaskType.SSE, anchorThread._workerThread));
+    anchorEntry._currentThreadMemoryAllocationSampleBytes = 1000;
+    threadEntries.put(anchorThread._workerThread, anchorEntry);
+
+    TaskThread taskThread2 = getTaskThread(queryId, 2, threadLatch, anchorThread._workerThread);
+    threadEntries.put(taskThread2._workerThread, taskThread2._threadEntry);
+    taskThread2._threadEntry._currentThreadMemoryAllocationSampleBytes = 2000;
+
+    TaskThread taskThread3 = getTaskThread(queryId, 3, threadLatch, anchorThread._workerThread);
+    threadEntries.put(taskThread3._workerThread, taskThread3._threadEntry);
+    taskThread3._threadEntry._currentThreadMemoryAllocationSampleBytes = 2500;
+  }
+
+  private static TaskThread getTaskThread(String queryId, int taskId, CountDownLatch threadLatch, Thread anchorThread) {
+    CPUMemThreadLevelAccountingObjects.ThreadEntry worker1 = new CPUMemThreadLevelAccountingObjects.ThreadEntry();
+    worker1._currentThreadTaskStatus.set(
+        new CPUMemThreadLevelAccountingObjects.TaskEntry(queryId, taskId, ThreadExecutionContext.TaskType.SSE,
+            anchorThread));
+    Thread workerThread1 = new Thread(() -> {
+      try {
+        threadLatch.await();
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+    });
+    workerThread1.start();
+    return new TaskThread(worker1, workerThread1);
+  }
+
+  public TaskThread getTaskThread(String queryId, int taskId) {
+    Map.Entry<Thread, CPUMemThreadLevelAccountingObjects.ThreadEntry> workerEntry =
+        _threadEntriesMap.entrySet().stream().filter(
+            e -> e.getValue()._currentThreadTaskStatus.get().getTaskId() == 3 && Objects.equals(
+                e.getValue()._currentThreadTaskStatus.get().getQueryId(), queryId)).collect(Collectors.toList()).get(0);
+    return new TaskThread(workerEntry.getValue(), workerEntry.getKey());
+  }
+
+  public static class TaskThread {
+    public final CPUMemThreadLevelAccountingObjects.ThreadEntry _threadEntry;
+    public final Thread _workerThread;
+
+    public TaskThread(CPUMemThreadLevelAccountingObjects.ThreadEntry threadEntry, Thread workerThread) {
+      _threadEntry = threadEntry;
+      _workerThread = workerThread;
+    }
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/accounting/TestResourceAccountant.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/accounting/TestResourceAccountant.java
@@ -45,7 +45,8 @@ class TestResourceAccountant extends PerQueryCPUMemAccountantFactory.PerQueryCPU
     CPUMemThreadLevelAccountingObjects.ThreadEntry anchorEntry = new CPUMemThreadLevelAccountingObjects.ThreadEntry();
     anchorEntry._currentThreadTaskStatus.set(
         new CPUMemThreadLevelAccountingObjects.TaskEntry(queryId, CommonConstants.Accounting.ANCHOR_TASK_ID,
-            ThreadExecutionContext.TaskType.SSE, anchorThread._workerThread));
+            ThreadExecutionContext.TaskType.SSE, anchorThread._workerThread,
+            CommonConstants.Accounting.DEFAULT_WORKLOAD_NAME));
     anchorEntry._currentThreadMemoryAllocationSampleBytes = 1000;
     threadEntries.put(anchorThread._workerThread, anchorEntry);
 
@@ -62,7 +63,7 @@ class TestResourceAccountant extends PerQueryCPUMemAccountantFactory.PerQueryCPU
     CPUMemThreadLevelAccountingObjects.ThreadEntry worker1 = new CPUMemThreadLevelAccountingObjects.ThreadEntry();
     worker1._currentThreadTaskStatus.set(
         new CPUMemThreadLevelAccountingObjects.TaskEntry(queryId, taskId, ThreadExecutionContext.TaskType.SSE,
-            anchorThread));
+            anchorThread, CommonConstants.Accounting.DEFAULT_WORKLOAD_NAME));
     Thread workerThread1 = new Thread(() -> {
       try {
         threadLatch.await();


### PR DESCRIPTION
In critical mode, the accountant sends a cancel to the most expensive query. This query may not terminate immediately. So the accountant will attempt multiple times to cancel the query. A sinister side effect is that it also increments `_numQueriesKilledConsecutively` and calls GC when the value is above a config. Note that the GC call is useless as the query hasnt cancelled yet and released the memory allocations.

The accountant now remembers the queries that have been cancelled in `_cancelSentQueries`. **It finds the most expensive query which hasn't been cancelled.**

```
          maxUsageTuple = _aggregatedUsagePerActiveQuery.values().stream()
              .filter(stats -> !_cancelSentQueries.contains(stats.getQueryId()))
              .max(Comparator.comparing(AggregatedStats::getAllocatedBytes))
              .orElse(null);
```

There are a few more changes that was required to safely add this feature. 
`PerQueryCPUMemAccountantFactory.aggregate(boolean triggered)` performs two functions:
* It reaps finished tasks and associated metadata - this is relevant to this feature. `_cancelledSentQueries` entries also have to be reaped. 
* If triggered, it also aggregates resource usage from `_threadEntriesMap` to a `Map<String, AggregatedStats>`.

The dual functionality made it hard to write unit tests. So the function has been split into: 
* `reapFinishedTasks`
* `getQueryResources` - this already existed.
The main change is that `if (isTriggered) { ... }` blocks have been removed.

Another change to help with testing is that `PerQueryCPUMemAccountant.WatcherTask.run()` has been extracted to `PerQueryCPUMemAccountant.WatcherTask.runOnce()`. This helps to run one iteration at a time in tests. Also it is possible to override this function in a test to only focus on relevant operations.

There are other minor changes to change member visibility to `protected` and new getter functions to also help with testing.

Consequently, the other major contribution of this PR is unit tests for reap/aggregate functions as well as testing for duplicate cancel attempts.

Closes #16110 