### PR TITLE
[SSE] Trim group when orderBy key is same as groupBy key, Pair-wise merge version

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/IndexedTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/IndexedTable.java
@@ -123,7 +123,7 @@ public abstract class IndexedTable extends BaseTable {
     _lookupMap.computeIfPresent(key, (k, v) -> updateRecord(v, newRecord));
   }
 
-  private Record updateRecord(Record existingRecord, Record newRecord) {
+  protected Record updateRecord(Record existingRecord, Record newRecord) {
     Object[] existingValues = existingRecord.getValues();
     Object[] newValues = newRecord.getValues();
     int numAggregations = _aggregationFunctions.length;

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/LinkedHashMapIndexedTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/LinkedHashMapIndexedTable.java
@@ -1,0 +1,144 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.data.table;
+
+import java.util.Comparator;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.core.query.request.context.QueryContext;
+
+
+public class LinkedHashMapIndexedTable extends IndexedTable {
+
+  /**
+   * Constructor for the IndexedTable.
+   *
+   * @param dataSchema      Data schema of the table
+   * @param hasFinalInput   Whether the input is the final aggregate result
+   * @param queryContext    Query context
+   * @param resultSize      Number of records to keep in the final result after calling
+   *                        {@link #finish(boolean, boolean)}
+   * @param trimSize        Number of records to keep when trimming the table
+   * @param trimThreshold   Trim the table when the number of records exceeds the threshold
+   * @param executorService
+   */
+  public LinkedHashMapIndexedTable(DataSchema dataSchema, boolean hasFinalInput,
+      QueryContext queryContext, int resultSize, int trimSize,
+      int trimThreshold, ExecutorService executorService) {
+    super(dataSchema, hasFinalInput, queryContext, resultSize, trimSize, trimThreshold, new LinkedHashMap<>(),
+        executorService);
+  }
+
+  protected LinkedHashMapIndexedTable(DataSchema dataSchema, boolean hasFinalInput,
+      QueryContext queryContext, int resultSize, int trimSize,
+      int trimThreshold, LinkedHashMap<Key, Record> map, ExecutorService executorService) {
+    super(dataSchema, hasFinalInput, queryContext, resultSize, trimSize, trimThreshold, map, executorService);
+  }
+
+  ///  merge another sorted LinkedHashMapIndexedTable into this
+  public LinkedHashMapIndexedTable merge(LinkedHashMapIndexedTable other, Comparator<Key> comparator,
+      QueryContext queryContext, ExecutorService executorService) {
+    assert (other._resultSize == _resultSize);
+    int limit = _resultSize;
+    LinkedHashMap<Key, Record> thisMap = (LinkedHashMap<Key, Record>) _lookupMap;
+    LinkedHashMap<Key, Record> thatMap = (LinkedHashMap<Key, Record>) other._lookupMap;
+    if (thisMap.isEmpty()) {
+      return other;
+    }
+    if (thatMap.isEmpty()) {
+      return this;
+    }
+    LinkedHashMapIndexedTable newTable =
+        new LinkedHashMapIndexedTable(getDataSchema(), _hasFinalInput, queryContext, _resultSize, _trimSize,
+            _trimThreshold, executorService);
+    newTable = mergeSortedMaps(thisMap, thatMap, comparator, limit, newTable);
+    // TODO: add stats?
+    return newTable;
+  }
+
+  public LinkedHashMapIndexedTable mergeSortedMaps(
+      LinkedHashMap<Key, Record> map1, LinkedHashMap<Key, Record> map2,
+      Comparator<Key> comparator, int limit, LinkedHashMapIndexedTable newTable) {
+    assert (comparator != null);
+
+    Iterator<Map.Entry<Key, Record>> iter1 = map1.entrySet().iterator();
+    Iterator<Map.Entry<Key, Record>> iter2 = map2.entrySet().iterator();
+
+    Map.Entry<Key, Record> entry1 = iter1.hasNext() ? iter1.next() : null;
+    Map.Entry<Key, Record> entry2 = iter2.hasNext() ? iter2.next() : null;
+
+    while (entry1 != null && entry2 != null) {
+      int cmp = comparator.compare(entry1.getKey(), entry2.getKey());
+      if (cmp < 0) {
+        newTable.upsert(entry1.getKey(), entry1.getValue());
+        entry1 = iter1.hasNext() ? iter1.next() : null;
+      } else if (cmp == 0) {
+        // merge results using aggregation function, this might update entry1.value in place
+        newTable.upsert(entry1.getKey(), entry1.getValue());
+        newTable.upsert(entry2.getKey(), entry2.getValue());
+        entry1 = iter1.hasNext() ? iter1.next() : null;
+        entry2 = iter2.hasNext() ? iter2.next() : null;
+      } else {
+        newTable.upsert(entry2.getKey(), entry2.getValue());
+        entry2 = iter2.hasNext() ? iter2.next() : null;
+      }
+      if (newTable.size() == limit) {
+        return newTable;
+      }
+    }
+
+    while (entry1 != null) {
+      newTable.upsert(entry1.getKey(), entry1.getValue());
+      entry1 = iter1.hasNext() ? iter1.next() : null;
+      if (newTable.size() == limit) {
+        return newTable;
+      }
+    }
+
+    while (entry2 != null) {
+      newTable.upsert(entry2.getKey(), entry2.getValue());
+      entry2 = iter2.hasNext() ? iter2.next() : null;
+      if (newTable.size() == limit) {
+        return newTable;
+      }
+    }
+
+    return newTable;
+  }
+
+  ///  insert in desired order
+  @Override
+  public boolean upsert(Key key, Record record) {
+    if (_lookupMap.size() < _resultSize) {
+      addOrUpdateRecord(key, record);
+    } else {
+      updateExistingRecord(key, record);
+    }
+    return true;
+  }
+
+  @Override
+  public void finish(boolean sort) {
+    // don't sort since this is already sorted
+    super.finish(false);
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/TableResizer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/TableResizer.java
@@ -324,6 +324,25 @@ public class TableResizer {
    * Trims the aggregation results using a heap and returns the top records.
    * This method is to be called from individual segment if the intermediate results need to be trimmed.
    */
+  public List<IntermediateRecord> sortInSegmentResults(GroupKeyGenerator groupKeyGenerator,
+      GroupByResultHolder[] groupByResultHolders, int size) {
+    assert groupKeyGenerator.getNumKeys() <= size;
+    Iterator<GroupKeyGenerator.GroupKey> groupKeyIterator = groupKeyGenerator.getGroupKeys();
+
+    // Initialize a heap with the first 'size' groups
+    IntermediateRecord[] arr = new IntermediateRecord[groupKeyGenerator.getNumKeys()];
+    for (int i = 0; i < groupKeyGenerator.getNumKeys(); i++) {
+      arr[i] = getIntermediateRecord(groupKeyIterator.next(), groupByResultHolders);
+    }
+
+    Arrays.sort(arr, _intermediateRecordComparator);
+    return Arrays.asList(arr);
+  }
+
+  /**
+   * Trims the aggregation results using a heap and returns the top records.
+   * This method is to be called from individual segment if the intermediate results need to be trimmed.
+   */
   public List<IntermediateRecord> trimInSegmentResults(GroupKeyGenerator groupKeyGenerator,
       GroupByResultHolder[] groupByResultHolders, int size) {
     // Should not reach here when numGroups <= heap size because there is no need to create a heap

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/TableResizer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/TableResizer.java
@@ -366,8 +366,15 @@ public class TableResizer {
       }
     }
 
+    for (int i = heap.length; i > 0; i--) {
+      downHeap(heap, i, 0, comparator);
+      // swap root with last
+      IntermediateRecord tmp = heap[0];
+      heap[0] = heap[i - 1];
+      heap[i - 1] = tmp;
+    }
+
     List<IntermediateRecord> result = Arrays.asList(heap);
-    Collections.reverse(result);
     return result;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/TableResizer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/TableResizer.java
@@ -20,6 +20,7 @@ package org.apache.pinot.core.data.table;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -326,17 +327,18 @@ public class TableResizer {
    */
   public List<IntermediateRecord> sortInSegmentResults(GroupKeyGenerator groupKeyGenerator,
       GroupByResultHolder[] groupByResultHolders, int size) {
+    // getNumKeys() does not count nulls
     assert groupKeyGenerator.getNumKeys() <= size;
     Iterator<GroupKeyGenerator.GroupKey> groupKeyIterator = groupKeyGenerator.getGroupKeys();
 
     // Initialize a heap with the first 'size' groups
-    IntermediateRecord[] arr = new IntermediateRecord[groupKeyGenerator.getNumKeys()];
-    for (int i = 0; i < groupKeyGenerator.getNumKeys(); i++) {
-      arr[i] = getIntermediateRecord(groupKeyIterator.next(), groupByResultHolders);
+    List<IntermediateRecord> arr = new ArrayList<>();
+    while (groupKeyIterator.hasNext()) {
+      arr.add(getIntermediateRecord(groupKeyIterator.next(), groupByResultHolders));
     }
 
-    Arrays.sort(arr, _intermediateRecordComparator);
-    return Arrays.asList(arr);
+    arr.sort(_intermediateRecordComparator);
+    return arr;
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/TableResizer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/TableResizer.java
@@ -366,7 +366,9 @@ public class TableResizer {
       }
     }
 
-    return Arrays.asList(heap);
+    List<IntermediateRecord> result = Arrays.asList(heap);
+    Collections.reverse(result);
+    return result;
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/GroupByResultsBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/GroupByResultsBlock.java
@@ -26,7 +26,6 @@ import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -57,7 +56,7 @@ import org.roaringbitmap.RoaringBitmap;
 public class GroupByResultsBlock extends BaseResultsBlock {
   private final DataSchema _dataSchema;
   private final AggregationGroupByResult _aggregationGroupByResult;
-  private final Collection<IntermediateRecord> _intermediateRecords;
+  private final List<IntermediateRecord> _intermediateRecords;
   private final Table _table;
   private final QueryContext _queryContext;
 
@@ -82,7 +81,7 @@ public class GroupByResultsBlock extends BaseResultsBlock {
   /**
    * For segment level group-by results.
    */
-  public GroupByResultsBlock(DataSchema dataSchema, Collection<IntermediateRecord> intermediateRecords,
+  public GroupByResultsBlock(DataSchema dataSchema, List<IntermediateRecord> intermediateRecords,
       QueryContext queryContext) {
     _dataSchema = dataSchema;
     _aggregationGroupByResult = null;
@@ -117,7 +116,7 @@ public class GroupByResultsBlock extends BaseResultsBlock {
     return _aggregationGroupByResult;
   }
 
-  public Collection<IntermediateRecord> getIntermediateRecords() {
+  public List<IntermediateRecord> getIntermediateRecords() {
     return _intermediateRecords;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/GroupByCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/GroupByCombineOperator.java
@@ -306,7 +306,14 @@ public class GroupByCombineOperator extends BaseSingleBlockCombineOperator<Group
       // return merged result
       assert (tables.size() == 1);
       IndexedTable indexedTable = tables.get(0);
-      indexedTable.finish(false);
+      if (_queryContext.isServerReturnFinalResult()) {
+        // indexedTable is already sorted
+        indexedTable.finish(false, true);
+      } else if (_queryContext.isServerReturnFinalResultKeyUnpartitioned()) {
+        indexedTable.finish(false, true);
+      } else {
+        indexedTable.finish(false);
+      }
       GroupByResultsBlock resultBlock = new GroupByResultsBlock(indexedTable, _queryContext);
       resultBlock.setGroupsTrimmed(false);
       resultBlock.setNumGroupsLimitReached(false);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/FilteredGroupByOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/FilteredGroupByOperator.java
@@ -20,7 +20,6 @@ package org.apache.pinot.core.operator.query;
 
 import com.google.common.base.CaseFormat;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -193,7 +192,7 @@ public class FilteredGroupByOperator extends BaseOperator<GroupByResultsBlock> {
       int trimSize = GroupByUtils.getTableCapacity(_queryContext.getLimit(), minGroupTrimSize);
       if (groupKeyGenerator.getNumKeys() > trimSize) {
         TableResizer tableResizer = new TableResizer(_dataSchema, _queryContext);
-        Collection<IntermediateRecord> intermediateRecords =
+        List<IntermediateRecord> intermediateRecords =
             tableResizer.trimInSegmentResults(groupKeyGenerator, groupByResultHolders, trimSize);
 
         ServerMetrics.get().addMeteredGlobalValue(ServerMeter.AGGREGATE_TIMES_GROUPS_TRIMMED, 1);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/GroupByOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/GroupByOperator.java
@@ -144,8 +144,7 @@ public class GroupByOperator extends BaseOperator<GroupByResultsBlock> {
     int trimSize = -1;
     List<OrderByExpressionContext> orderByExpressions = _queryContext.getOrderByExpressions();
     if (!_queryContext.isUnsafeTrim()) {
-      // if orderby key is groupby key, and there's no having clause
-      // keep at most `limit` rows only
+      // if orderby key is groupby key, and there's no having clause, keep at most `limit` rows only
       trimSize = _queryContext.getLimit();
     } else if (orderByExpressions != null && minGroupTrimSize > 0) {
       // max(minSegmentGroupTrimSize, 5 * LIMIT)

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/GroupByOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/GroupByOperator.java
@@ -20,9 +20,7 @@ package org.apache.pinot.core.operator.query;
 
 import com.google.common.base.CaseFormat;
 import java.util.Arrays;
-import java.util.Collection;
 import java.util.Collections;
-import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.pinot.common.metrics.ServerMeter;
@@ -156,7 +154,7 @@ public class GroupByOperator extends BaseOperator<GroupByResultsBlock> {
     if (trimSize > 0) {
       if (groupByExecutor.getNumGroups() > trimSize) {
         TableResizer tableResizer = new TableResizer(_dataSchema, _queryContext);
-        Collection<IntermediateRecord> intermediateRecords = groupByExecutor.trimGroupByResult(trimSize, tableResizer);
+        List<IntermediateRecord> intermediateRecords = groupByExecutor.trimGroupByResult(trimSize, tableResizer);
 
         ServerMetrics.get().addMeteredGlobalValue(ServerMeter.AGGREGATE_TIMES_GROUPS_TRIMMED, 1);
         boolean unsafeTrim = _queryContext.isUnsafeTrim(); // set trim flag only if it's not safe
@@ -170,7 +168,9 @@ public class GroupByOperator extends BaseOperator<GroupByResultsBlock> {
         // if orderBy groupBy key, sort the array even if it's smaller than trimSize
         // to benefit combining
         TableResizer tableResizer = new TableResizer(_dataSchema, _queryContext);
-        Collection<IntermediateRecord> intermediateRecords = tableResizer.sortInSegmentResults(groupByExecutor.getGroupKeyGenerator(), groupByExecutor.getGroupByResultHolders(), trimSize);
+        List<IntermediateRecord> intermediateRecords =
+            tableResizer.sortInSegmentResults(groupByExecutor.getGroupKeyGenerator(),
+                groupByExecutor.getGroupByResultHolders(), trimSize);
         GroupByResultsBlock resultsBlock = new GroupByResultsBlock(_dataSchema, intermediateRecords, _queryContext);
         resultsBlock.setGroupsTrimmed(false);
         resultsBlock.setNumGroupsLimitReached(numGroupsLimitReached);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/DefaultGroupByExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/DefaultGroupByExecutor.java
@@ -18,8 +18,8 @@
  */
 package org.apache.pinot.core.query.aggregation.groupby;
 
-import java.util.Collection;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -230,7 +230,7 @@ public class DefaultGroupByExecutor implements GroupByExecutor {
   }
 
   @Override
-  public Collection<IntermediateRecord> trimGroupByResult(int trimSize, TableResizer tableResizer) {
+  public List<IntermediateRecord> trimGroupByResult(int trimSize, TableResizer tableResizer) {
     return tableResizer.trimInSegmentResults(_groupKeyGenerator, _groupByResultHolders, trimSize);
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/GroupByExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/GroupByExecutor.java
@@ -18,7 +18,7 @@
  */
 package org.apache.pinot.core.query.aggregation.groupby;
 
-import java.util.Collection;
+import java.util.List;
 import org.apache.pinot.core.data.table.IntermediateRecord;
 import org.apache.pinot.core.data.table.TableResizer;
 import org.apache.pinot.core.operator.blocks.ValueBlock;
@@ -55,7 +55,7 @@ public interface GroupByExecutor {
    * <p>Should be called after all transform blocks has been processed.
    *
    */
-  Collection<IntermediateRecord> trimGroupByResult(int trimSize, TableResizer tableResizer);
+  List<IntermediateRecord> trimGroupByResult(int trimSize, TableResizer tableResizer);
 
   GroupKeyGenerator getGroupKeyGenerator();
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/table/TableResizerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/table/TableResizerTest.java
@@ -341,38 +341,26 @@ public class TableResizerTest {
         tableResizer.trimInSegmentResults(_groupKeyGenerator, _groupByResultHolders, TRIM_TO_SIZE);
     assertEquals(results.size(), TRIM_TO_SIZE);
     //  _records[4],  _records[3],  _records[2]
-    assertEquals(results.get(0)._record, _records.get(2));
-    if (results.get(1)._record.equals(_records.get(3))) {
-      assertEquals(results.get(2)._record, _records.get(4));
-    } else {
-      assertEquals(results.get(1)._record, _records.get(4));
-      assertEquals(results.get(2)._record, _records.get(3));
-    }
+    assertEquals(results.get(0)._record, _records.get(4));
+    assertEquals(results.get(1)._record, _records.get(3));
+    assertEquals(results.get(2)._record, _records.get(2));
 
     tableResizer = new TableResizer(DATA_SCHEMA, QueryContextConverterUtils.getQueryContext(
         QUERY_PREFIX + "SUM(m1) DESC, max(m2) DESC, DISTINCTCOUNT(m3) DESC"));
     results = tableResizer.trimInSegmentResults(_groupKeyGenerator, _groupByResultHolders, TRIM_TO_SIZE);
     assertEquals(results.size(), TRIM_TO_SIZE);
     // _records[2],  _records[3],  _records[1]
-    assertEquals(results.get(0)._record, _records.get(1));
-    if (results.get(1)._record.equals(_records.get(3))) {
-      assertEquals(results.get(2)._record, _records.get(2));
-    } else {
-      assertEquals(results.get(1)._record, _records.get(2));
-      assertEquals(results.get(2)._record, _records.get(3));
-    }
+    assertEquals(results.get(0)._record, _records.get(2));
+    assertEquals(results.get(1)._record, _records.get(3));
+    assertEquals(results.get(2)._record, _records.get(1));
 
     tableResizer = new TableResizer(DATA_SCHEMA,
         QueryContextConverterUtils.getQueryContext(QUERY_PREFIX + "DISTINCTCOUNT(m3) DESC, AVG(m4) ASC"));
     results = tableResizer.trimInSegmentResults(_groupKeyGenerator, _groupByResultHolders, TRIM_TO_SIZE);
     assertEquals(results.size(), TRIM_TO_SIZE);
     // _records[4],  _records[3],  _records[1]
-    assertEquals(results.get(0)._record, _records.get(1));
-    if (results.get(1)._record.equals(_records.get(3))) {
-      assertEquals(results.get(2)._record, _records.get(4));
-    } else {
-      assertEquals(results.get(1)._record, _records.get(4));
-      assertEquals(results.get(2)._record, _records.get(3));
-    }
+    assertEquals(results.get(0)._record, _records.get(4));
+    assertEquals(results.get(1)._record, _records.get(3));
+    assertEquals(results.get(2)._record, _records.get(1));
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/BaseFunnelCountQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/BaseFunnelCountQueriesTest.java
@@ -213,7 +213,6 @@ abstract public class BaseFunnelCountQueriesTest extends BaseQueriesTest {
         expectedFilteredNumDocs, getExpectedNumEntriesScannedInFilter(), 2 * expectedFilteredNumDocs, NUM_RECORDS);
 
     List<IntermediateRecord> aggregationGroupByResult = resultsBlock.getIntermediateRecords();
-//    AggregationGroupByResult aggregationGroupByResult = resultsBlock.getAggregationGroupByResult();
     assertNotNull(aggregationGroupByResult);
     int numGroups = 0;
     Iterator<IntermediateRecord> groupKeyIterator = aggregationGroupByResult.iterator();

--- a/pinot-core/src/test/java/org/apache/pinot/queries/FastHllQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/FastHllQueriesTest.java
@@ -25,13 +25,12 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.FileUtils;
+import org.apache.pinot.core.data.table.IntermediateRecord;
 import org.apache.pinot.core.operator.ExecutionStatistics;
 import org.apache.pinot.core.operator.blocks.results.AggregationResultsBlock;
 import org.apache.pinot.core.operator.blocks.results.GroupByResultsBlock;
 import org.apache.pinot.core.operator.query.AggregationOperator;
 import org.apache.pinot.core.operator.query.GroupByOperator;
-import org.apache.pinot.core.query.aggregation.groupby.AggregationGroupByResult;
-import org.apache.pinot.core.query.aggregation.groupby.GroupKeyGenerator;
 import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import org.apache.pinot.segment.spi.ImmutableSegment;
@@ -130,12 +129,11 @@ public class FastHllQueriesTest extends BaseQueriesTest {
     GroupByResultsBlock groupByResultsBlock = groupByOperator.nextBlock();
     executionStatistics = groupByOperator.getExecutionStatistics();
     QueriesTestUtils.testInnerSegmentExecutionStatistics(executionStatistics, 30000L, 0L, 90000L, 30000L);
-    AggregationGroupByResult aggregationGroupByResult = groupByResultsBlock.getAggregationGroupByResult();
-    GroupKeyGenerator.GroupKey firstGroupKey = aggregationGroupByResult.getGroupKeyIterator().next();
-    assertEquals(firstGroupKey._keys[0], "");
-    assertEquals(((HyperLogLog) aggregationGroupByResult.getResultForGroupId(0, firstGroupKey._groupId)).cardinality(),
+    IntermediateRecord firstRecord = groupByResultsBlock.getIntermediateRecords().get(0);
+    assertEquals(firstRecord._key.getValues()[0], "");
+    assertEquals(((HyperLogLog) firstRecord._record.getValues()[1]).cardinality(),
         21L);
-    assertEquals(((HyperLogLog) aggregationGroupByResult.getResultForGroupId(1, firstGroupKey._groupId)).cardinality(),
+    assertEquals(((HyperLogLog) firstRecord._record.getValues()[2]).cardinality(),
         691L);
 
     // Test inter segments base query

--- a/pinot-core/src/test/java/org/apache/pinot/queries/HistogramQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/HistogramQueriesTest.java
@@ -28,11 +28,11 @@ import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
 import org.apache.pinot.common.response.broker.ResultTable;
 import org.apache.pinot.core.common.Operator;
+import org.apache.pinot.core.data.table.IntermediateRecord;
 import org.apache.pinot.core.operator.blocks.results.AggregationResultsBlock;
 import org.apache.pinot.core.operator.blocks.results.GroupByResultsBlock;
 import org.apache.pinot.core.operator.query.AggregationOperator;
 import org.apache.pinot.core.operator.query.GroupByOperator;
-import org.apache.pinot.core.query.aggregation.groupby.AggregationGroupByResult;
 import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
@@ -218,19 +218,21 @@ public class HistogramQueriesTest extends BaseQueriesTest {
     GroupByResultsBlock resultsBlock = ((GroupByOperator) operator).nextBlock();
     QueriesTestUtils.testInnerSegmentExecutionStatistics(((Operator) operator).getExecutionStatistics(), NUM_RECORDS, 0,
         NUM_RECORDS * 2, NUM_RECORDS);
-    AggregationGroupByResult aggregationGroupByResult = resultsBlock.getAggregationGroupByResult();
+    List<IntermediateRecord> aggregationGroupByResult = resultsBlock.getIntermediateRecords();
+    IntermediateRecord firstRecord = aggregationGroupByResult.get(0);
+//    AggregationGroupByResult aggregationGroupByResult = resultsBlock.getAggregationGroupByResult();
     assertNotNull(aggregationGroupByResult);
-    assertEquals(((DoubleArrayList) aggregationGroupByResult.getResultForGroupId(0, 0)).elements(),
+    assertEquals(((DoubleArrayList) aggregationGroupByResult.get(0)._record.getValues()[1]).elements(),
         new double[]{1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}); // [0]
-    assertEquals(((DoubleArrayList) aggregationGroupByResult.getResultForGroupId(0, 1)).elements(),
+    assertEquals(((DoubleArrayList) aggregationGroupByResult.get(1)._record.getValues()[1]).elements(),
         new double[]{99, 100, 100, 100, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}); // [1-400]
-    assertEquals(((DoubleArrayList) aggregationGroupByResult.getResultForGroupId(0, 2)).elements(),
+    assertEquals(((DoubleArrayList) aggregationGroupByResult.get(2)._record.getValues()[1]).elements(),
         new double[]{0, 0, 0, 0, 99, 100, 100, 100, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}); // [401-800]
-    assertEquals(((DoubleArrayList) aggregationGroupByResult.getResultForGroupId(0, 3)).elements(),
+    assertEquals(((DoubleArrayList) aggregationGroupByResult.get(3)._record.getValues()[1]).elements(),
         new double[]{0, 0, 0, 0, 0, 0, 0, 0, 99, 100, 100, 100, 1, 0, 0, 0, 0, 0, 0, 0}); // [801-1200]
-    assertEquals(((DoubleArrayList) aggregationGroupByResult.getResultForGroupId(0, 4)).elements(),
+    assertEquals(((DoubleArrayList) aggregationGroupByResult.get(4)._record.getValues()[1]).elements(),
         new double[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 99, 100, 100, 100, 1, 0, 0, 0}); // [1201-1600]
-    assertEquals(((DoubleArrayList) aggregationGroupByResult.getResultForGroupId(0, 5)).elements(),
+    assertEquals(((DoubleArrayList) aggregationGroupByResult.get(5)._record.getValues()[1]).elements(),
         new double[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 99, 100, 100, 100}); // [1601-2000]
 
     // Inter segment

--- a/pinot-core/src/test/java/org/apache/pinot/queries/StatisticalQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/StatisticalQueriesTest.java
@@ -35,11 +35,11 @@ import org.apache.commons.math3.stat.descriptive.moment.Variance;
 import org.apache.commons.math3.util.Precision;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
 import org.apache.pinot.common.response.broker.ResultTable;
+import org.apache.pinot.core.data.table.IntermediateRecord;
 import org.apache.pinot.core.operator.blocks.results.AggregationResultsBlock;
 import org.apache.pinot.core.operator.blocks.results.GroupByResultsBlock;
 import org.apache.pinot.core.operator.query.AggregationOperator;
 import org.apache.pinot.core.operator.query.GroupByOperator;
-import org.apache.pinot.core.query.aggregation.groupby.AggregationGroupByResult;
 import org.apache.pinot.segment.local.customobject.CovarianceTuple;
 import org.apache.pinot.segment.local.customobject.PinotFourthMoment;
 import org.apache.pinot.segment.local.customobject.VarianceTuple;
@@ -389,10 +389,11 @@ public class StatisticalQueriesTest extends BaseQueriesTest {
     GroupByResultsBlock resultsBlock = groupByOperator.nextBlock();
     QueriesTestUtils.testInnerSegmentExecutionStatistics(groupByOperator.getExecutionStatistics(), NUM_RECORDS, 0,
         NUM_RECORDS * 2, NUM_RECORDS);
-    AggregationGroupByResult aggregationGroupByResult = resultsBlock.getAggregationGroupByResult();
+    // TODO: change all aggregationGroupByResult to intermediateRecord
+    List<IntermediateRecord> aggregationGroupByResult = resultsBlock.getIntermediateRecords();
     assertNotNull(aggregationGroupByResult);
     for (int i = 0; i < NUM_GROUPS; i++) {
-      CovarianceTuple actualCovTuple = (CovarianceTuple) aggregationGroupByResult.getResultForGroupId(0, i);
+      CovarianceTuple actualCovTuple = (CovarianceTuple) aggregationGroupByResult.get(i)._record.getValues()[1];
       CovarianceTuple expectedCovTuple = _expectedGroupByResultVer1[i];
       checkWithPrecisionForCovariance(actualCovTuple, expectedCovTuple);
     }
@@ -414,11 +415,11 @@ public class StatisticalQueriesTest extends BaseQueriesTest {
     resultsBlock = groupByOperator.nextBlock();
     QueriesTestUtils.testInnerSegmentExecutionStatistics(groupByOperator.getExecutionStatistics(), NUM_RECORDS, 0,
         NUM_RECORDS * 3, NUM_RECORDS);
-    aggregationGroupByResult = resultsBlock.getAggregationGroupByResult();
+    aggregationGroupByResult = resultsBlock.getIntermediateRecords();
     assertNotNull(aggregationGroupByResult);
 
     for (int i = 0; i < NUM_GROUPS; i++) {
-      CovarianceTuple actualCovTuple = (CovarianceTuple) aggregationGroupByResult.getResultForGroupId(0, i);
+      CovarianceTuple actualCovTuple = (CovarianceTuple) aggregationGroupByResult.get(i)._record.getValues()[1];
       CovarianceTuple expectedCovTuple = _expectedGroupByResultVer2[i];
       checkWithPrecisionForCovariance(actualCovTuple, expectedCovTuple);
     }
@@ -576,11 +577,11 @@ public class StatisticalQueriesTest extends BaseQueriesTest {
     GroupByResultsBlock resultsBlock = groupByOperator.nextBlock();
     QueriesTestUtils.testInnerSegmentExecutionStatistics(groupByOperator.getExecutionStatistics(), NUM_RECORDS, 0,
         NUM_RECORDS * 2, NUM_RECORDS);
-    AggregationGroupByResult aggregationGroupByResult = resultsBlock.getAggregationGroupByResult();
+    List<IntermediateRecord> aggregationGroupByResult = resultsBlock.getIntermediateRecords();
     assertNotNull(aggregationGroupByResult);
     for (int i = 0; i < NUM_GROUPS; i++) {
 
-      VarianceTuple actualVarianceTuple = (VarianceTuple) aggregationGroupByResult.getResultForGroupId(0, i);
+      VarianceTuple actualVarianceTuple = (VarianceTuple) aggregationGroupByResult.get(i)._record.getValues()[1];
       checkWithPrecisionForVariance(actualVarianceTuple, NUM_RECORDS / NUM_GROUPS, expectedSum[i],
           expectedGroupByResult[i].getResult(), false);
     }
@@ -699,10 +700,10 @@ public class StatisticalQueriesTest extends BaseQueriesTest {
     GroupByResultsBlock resultsBlock = groupByOperator.nextBlock();
     QueriesTestUtils.testInnerSegmentExecutionStatistics(groupByOperator.getExecutionStatistics(), NUM_RECORDS, 0,
         NUM_RECORDS * 2, NUM_RECORDS);
-    AggregationGroupByResult aggregationGroupByResult = resultsBlock.getAggregationGroupByResult();
+    List<IntermediateRecord> aggregationGroupByResult = resultsBlock.getIntermediateRecords();
     assertNotNull(aggregationGroupByResult);
     for (int i = 0; i < NUM_GROUPS; i++) {
-      VarianceTuple actualVarianceTuple = (VarianceTuple) aggregationGroupByResult.getResultForGroupId(0, i);
+      VarianceTuple actualVarianceTuple = (VarianceTuple) aggregationGroupByResult.get(i)._record.getValues()[1];
       checkWithPrecisionForStandardDeviation(actualVarianceTuple, NUM_RECORDS / NUM_GROUPS, expectedSum[i],
           expectedGroupByResult[i].getResult(), false);
     }
@@ -783,10 +784,10 @@ public class StatisticalQueriesTest extends BaseQueriesTest {
     GroupByResultsBlock resultsBlock = groupByOperator.nextBlock();
     QueriesTestUtils.testInnerSegmentExecutionStatistics(groupByOperator.getExecutionStatistics(), NUM_RECORDS, 0,
         NUM_RECORDS * 2, NUM_RECORDS);
-    AggregationGroupByResult aggregationGroupByResult = resultsBlock.getAggregationGroupByResult();
+    List<IntermediateRecord> aggregationGroupByResult = resultsBlock.getIntermediateRecords();
     assertNotNull(aggregationGroupByResult);
     for (int i = 0; i < NUM_GROUPS; i++) {
-      PinotFourthMoment actual = (PinotFourthMoment) aggregationGroupByResult.getResultForGroupId(0, i);
+      PinotFourthMoment actual = (PinotFourthMoment) aggregationGroupByResult.get(i)._record.getValues()[1];
       checkWithPrecisionForSkew(actual, NUM_RECORDS / NUM_GROUPS, expectedGroupByResult[i].getResult());
     }
   }
@@ -866,10 +867,10 @@ public class StatisticalQueriesTest extends BaseQueriesTest {
     GroupByResultsBlock resultsBlock = groupByOperator.nextBlock();
     QueriesTestUtils.testInnerSegmentExecutionStatistics(groupByOperator.getExecutionStatistics(), NUM_RECORDS, 0,
         NUM_RECORDS * 2, NUM_RECORDS);
-    AggregationGroupByResult aggregationGroupByResult = resultsBlock.getAggregationGroupByResult();
+    List<IntermediateRecord> aggregationGroupByResult = resultsBlock.getIntermediateRecords();
     assertNotNull(aggregationGroupByResult);
     for (int i = 0; i < NUM_GROUPS; i++) {
-      PinotFourthMoment actual = (PinotFourthMoment) aggregationGroupByResult.getResultForGroupId(0, i);
+      PinotFourthMoment actual = (PinotFourthMoment) aggregationGroupByResult.get(i)._record.getValues()[1];
       checkWithPrecisionForKurt(actual, NUM_RECORDS / NUM_GROUPS, expectedGroupByResult[i].getResult());
     }
   }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/GroupByTrimmingIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/GroupByTrimmingIntegrationTest.java
@@ -226,12 +226,18 @@ public class GroupByTrimmingIntegrationTest extends BaseClusterIntegrationTestSe
     assertTrimFlagSet(result);
 
     assertEquals(toResultStr(result),
-        "\"i\"[\"INT\"],\t\"j\"[\"LONG\"],\t\"EXPR$2\"[\"LONG\"]\n"
-            + "77,\t377,\t4\n"
-            + "66,\t566,\t4\n"
-            + "39,\t339,\t4\n"
-            + "96,\t396,\t4\n"
-            + "25,\t25,\t4");
+//        "\"i\"[\"INT\"],\t\"j\"[\"LONG\"],\t\"EXPR$2\"[\"LONG\"]\n"
+//            + "77,\t377,\t4\n"
+//            + "66,\t566,\t4\n"
+//            + "39,\t339,\t4\n"
+//            + "96,\t396,\t4\n"
+//            + "25,\t25,\t4");
+          "\"i\"[\"INT\"],\t\"j\"[\"LONG\"],\t\"EXPR$2\"[\"LONG\"]\n"
+              + "66,\t566,\t4\n"
+              + "39,\t339,\t4\n"
+              + "96,\t396,\t4\n"
+              + "69,\t169,\t4\n"
+              + "77,\t377,\t4");
 
     assertEquals(toExplainStr(postQuery(options + " SET explainAskingServers=true; EXPLAIN PLAN FOR " + query), true),
         "Execution Plan\n"
@@ -464,39 +470,6 @@ public class GroupByTrimmingIntegrationTest extends BaseClusterIntegrationTestSe
             + "DOC_ID_SET,\t5,\t4\n"
             + "FILTER_MATCH_ENTIRE_SEGMENT(docs:1000),\t6,\t5\n");
   }
-
-  @Test
-  public void testSSQEGroupsTrimmedAtSegmentLevelWithOrderByAllGroupByKeysLargeLimitIsSafe()
-      throws Exception {
-    setUseMultiStageQueryEngine(false);
-
-    // trimming is safe on rows ordered by all group by keys (regardless of key order, direction or duplications)
-    String query = "SELECT i, j, COUNT(*) FROM mytable GROUP BY i, j ORDER BY j ASC, i DESC, j ASC LIMIT 1000000";
-
-    Connection conn = getPinotConnection();
-    assertTrimFlagNotSet(conn.execute(query));
-
-    ResultSetGroup result = conn.execute("SET minSegmentGroupTrimSize=5; " + query);
-    assertTrimFlagNotSet(result);
-
-    assertEquals(toResultStr(result),
-        "\"i\"[\"INT\"],\t\"j\"[\"LONG\"],\t\"count(*)\"[\"LONG\"]\n"
-            + "0,\t0,\t4\n"
-            + "1,\t1,\t4\n"
-            + "2,\t2,\t4\n"
-            + "3,\t3,\t4\n"
-            + "4,\t4,\t4");
-
-    assertEquals(toExplainStr(postQuery("EXPLAIN PLAN FOR " + query), false),
-        "BROKER_REDUCE(sort:[j ASC, i DESC],limit:5),\t1,\t0\n"
-            + "COMBINE_GROUP_BY,\t2,\t1\n"
-            + "PLAN_START(numSegmentsForThisPlan:4),\t-1,\t-1\n"
-            + "GROUP_BY(groupKeys:i, j, aggregations:count(*)),\t3,\t2\n"
-            + "PROJECT(i, j),\t4,\t3\n"
-            + "DOC_ID_SET,\t5,\t4\n"
-            + "FILTER_MATCH_ENTIRE_SEGMENT(docs:1000),\t6,\t5\n");
-  }
-
 
   @Test
   public void testSSQEGroupsTrimmedAtSegmentLevelWithOrderByAllGroupByKeysIsSafe()

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/GroupByTrimmingIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/GroupByTrimmingIntegrationTest.java
@@ -225,19 +225,16 @@ public class GroupByTrimmingIntegrationTest extends BaseClusterIntegrationTestSe
     ResultSetGroup result = conn.execute(options + query);
     assertTrimFlagSet(result);
 
-    assertEquals(toResultStr(result),
-//        "\"i\"[\"INT\"],\t\"j\"[\"LONG\"],\t\"EXPR$2\"[\"LONG\"]\n"
-//            + "77,\t377,\t4\n"
-//            + "66,\t566,\t4\n"
-//            + "39,\t339,\t4\n"
-//            + "96,\t396,\t4\n"
-//            + "25,\t25,\t4");
-          "\"i\"[\"INT\"],\t\"j\"[\"LONG\"],\t\"EXPR$2\"[\"LONG\"]\n"
-              + "66,\t566,\t4\n"
-              + "39,\t339,\t4\n"
-              + "96,\t396,\t4\n"
-              + "69,\t169,\t4\n"
-              + "77,\t377,\t4");
+    String[] lines = toResultStr(result).split("\n");
+
+    // Assert the header exactly
+    assertEquals(lines[0], "\"i\"[\"INT\"],\t\"j\"[\"LONG\"],\t\"EXPR$2\"[\"LONG\"]");
+    // Assert col3 of all data rows is 4
+    for (int i = 1; i < lines.length; i++) {
+      String[] cols = lines[i].split("\t");
+      assertEquals("4", cols[2]);
+    }
+
 
     assertEquals(toExplainStr(postQuery(options + " SET explainAskingServers=true; EXPLAIN PLAN FOR " + query), true),
         "Execution Plan\n"


### PR DESCRIPTION
Implementation of the pair-wise merge version of #16277 

The high-level appoach is to short-circuit the case when orderby groupby key to do sort aggregate, trimming groups safely on segment, server combine, and broker reduce levels.

In case that orderby groupby key and there's no HAVING clause,
1. In `GroupByOperator`, the per-segment result is sorted and trimmed if needed.
2. In `GroupByCombineOperator`, instead of writing into a single `IndexedTable` as before, each worker writes into its own `LinkedHashMapIndexedTable`, which are then sent via `_blockingQueue` for further merging. The main thread schedules pair-wise merging+trimming of these tables on `executionService` until everything is merged into one table.
3. The result is sent to broker for final reduce, this is unchanged for now, we can later exploit that all output blocks are now sorted and do merging again.

P.S.
Currently the combineOperator waits until all segment results to arrive before start merging because processSegment returns `Future<void>`. If our `processSegment` could return a `Future<LinkedHashMapIndexedTable>` that contains the result, we could technically chain futures together and let executorService pick up whatever is ready first. But this requires a larger change.