### PR TITLE
Perform task data cleanup as part of table deletion

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -72,6 +72,7 @@ import org.apache.hc.client5.http.io.HttpClientConnectionManager;
 import org.apache.helix.AccessOption;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.apache.helix.task.TaskState;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.pinot.common.exception.InvalidConfigException;
 import org.apache.pinot.common.exception.RebalanceInProgressException;
@@ -207,8 +208,9 @@ public class PinotTableRestletResource {
   @ManualAuthorization // performed after parsing table configs
   public ConfigSuccessResponse addTable(String tableConfigStr,
       @ApiParam(value = "comma separated list of validation type(s) to skip. supported types: (ALL|TASK|UPSERT)")
-      @QueryParam("validationTypesToSkip") @Nullable String typesToSkip, @Context HttpHeaders httpHeaders,
-      @Context Request request) {
+      @QueryParam("validationTypesToSkip") @Nullable String typesToSkip,
+      @ApiParam(defaultValue = "false") @QueryParam("ignoreActiveTasks") boolean ignoreActiveTasks,
+      @Context HttpHeaders httpHeaders, @Context Request request) {
     // TODO introduce a table config ctor with json string.
     Pair<TableConfig, Map<String, Object>> tableConfigAndUnrecognizedProperties;
     TableConfig tableConfig;
@@ -245,6 +247,9 @@ public class PinotTableRestletResource {
         validateInstanceAssignment(tableConfig);
       } catch (Exception e) {
         throw new InvalidTableConfigException(e);
+      }
+      if (!ignoreActiveTasks) {
+        tableTasksValidation(tableConfig, _pinotHelixTaskResourceManager);
       }
       _pinotHelixResourceManager.addTable(tableConfig);
       // TODO: validate that table was created successfully
@@ -426,6 +431,7 @@ public class PinotTableRestletResource {
       @ApiParam(value = "Retention period for the table segments (e.g. 12h, 3d); If not set, the retention period "
           + "will default to the first config that's not null: the cluster setting, then '7d'. Using 0d or -1d will "
           + "instantly delete segments without retention") @QueryParam("retention") String retentionPeriod,
+      @ApiParam(defaultValue = "false") @QueryParam("ignoreActiveTasks") boolean ignoreActiveTasks,
       @Context HttpHeaders headers) {
     TableType tableType = Constants.validateTableType(tableTypeStr);
 
@@ -435,21 +441,25 @@ public class PinotTableRestletResource {
       validateLogicalTableReference(tableName, tableType);
       boolean tableExist = false;
       if (verifyTableType(tableName, tableType, TableType.OFFLINE)) {
+        String tableWithType = TableNameBuilder.OFFLINE.tableNameWithType(tableName);
+        tableTasksCleanup(tableWithType, ignoreActiveTasks, _pinotHelixResourceManager, _pinotHelixTaskResourceManager);
         tableExist = _pinotHelixResourceManager.hasOfflineTable(tableName);
         // Even the table name does not exist, still go on to delete remaining table metadata in case a previous delete
         // did not complete.
         _pinotHelixResourceManager.deleteOfflineTable(tableName, retentionPeriod);
         if (tableExist) {
-          tablesDeleted.add(TableNameBuilder.OFFLINE.tableNameWithType(tableName));
+          tablesDeleted.add(tableWithType);
         }
       }
       if (verifyTableType(tableName, tableType, TableType.REALTIME)) {
+        String tableWithType = TableNameBuilder.REALTIME.tableNameWithType(tableName);
+        tableTasksCleanup(tableWithType, ignoreActiveTasks, _pinotHelixResourceManager, _pinotHelixTaskResourceManager);
         tableExist = _pinotHelixResourceManager.hasRealtimeTable(tableName);
         // Even the table name does not exist, still go on to delete remaining table metadata in case a previous delete
         // did not complete.
         _pinotHelixResourceManager.deleteRealtimeTable(tableName, retentionPeriod);
         if (tableExist) {
-          tablesDeleted.add(TableNameBuilder.REALTIME.tableNameWithType(tableName));
+          tablesDeleted.add(tableWithType);
         }
       }
       if (!tablesDeleted.isEmpty()) {
@@ -461,6 +471,68 @@ public class PinotTableRestletResource {
     }
     throw new ControllerApplicationException(LOGGER,
         "Table '" + tableName + "' with type " + tableType + " does not exist", Response.Status.NOT_FOUND);
+  }
+
+  public static void tableTasksValidation(TableConfig tableConfig,
+      PinotHelixTaskResourceManager pinotHelixTaskResourceManager) {
+    if (tableConfig.getTaskConfig() == null) {
+      return;
+    }
+    String tableWithType = tableConfig.getTableName();
+    Map<String, Map<String, String>> taskTypeConfigsMap = tableConfig.getTaskConfig().getTaskTypeConfigsMap();
+    for (String taskType : taskTypeConfigsMap.keySet()) {
+      Map<String, TaskState> taskStates;
+      try {
+        taskStates = pinotHelixTaskResourceManager.getTaskStatesByTable(taskType, tableWithType);
+      } catch (IllegalArgumentException e) {
+        LOGGER.info(e.getMessage());
+        return;
+      }
+      if (!taskStates.isEmpty()) {
+        throw new RuntimeException("The table has dangling task data, try performing table delete operation in case "
+            + "the delete operation was not completed successfully, else delete the tasks manually through "
+            + "DELETE /tasks/task/{taskName} endpoint."
+            + "Please try again once the dangling tasks are cleaned up");
+      }
+    }
+  }
+
+  public static void tableTasksCleanup(String tableWithType, boolean ignoreActiveTasks,
+      PinotHelixResourceManager pinotHelixResourceManager, PinotHelixTaskResourceManager pinotHelixTaskResourceManager)
+      throws IOException {
+    TableConfig tableConfig = pinotHelixResourceManager.getTableConfig(tableWithType);
+    if (tableConfig == null || tableConfig.getTaskConfig() == null) {
+      return;
+    }
+    Map<String, Map<String, String>> taskTypeConfigsMap = tableConfig.getTaskConfig().getTaskTypeConfigsMap();
+    Set<String> taskTypes = taskTypeConfigsMap.keySet();
+    for (String taskType : taskTypes) {
+      // remove the task schedules to avoid task being scheduled during table deletion
+      taskTypeConfigsMap.get(taskType).remove(PinotTaskManager.SCHEDULE_KEY);
+    }
+    pinotHelixResourceManager.updateTableConfig(tableConfig);
+    List<String> pendingTasks = new ArrayList<>();
+    for (String taskType : taskTypes) {
+      Map<String, TaskState> taskStates;
+      try {
+        taskStates = pinotHelixTaskResourceManager.getTaskStatesByTable(taskType, tableWithType);
+      } catch (IllegalArgumentException e) {
+        LOGGER.info(e.getMessage());
+        continue;
+      }
+      for (String taskName : taskStates.keySet()) {
+        if (TaskState.IN_PROGRESS.equals(taskStates.get(taskName))) {
+          pendingTasks.add(taskName);
+        } else {
+          pinotHelixTaskResourceManager.deleteTask(taskName, true);
+        }
+      }
+    }
+    if (!ignoreActiveTasks && !pendingTasks.isEmpty()) {
+      throw new RuntimeException("The table has " + pendingTasks.size() + " active running tasks : " + pendingTasks
+          + ". The task schedules have been cleared, so no new task should be generated by pinot. "
+          + "Please try again once there are no more active tasks");
+    }
   }
 
   //   Return true iff the table is of the expectedType based on the given tableName and tableType. The truth table:


### PR DESCRIPTION
## Description

Currently the minion task data is not cleaned up during table deletion. This leads to unpredictable behaviour when a table is deleted and recreated right away as tasks that are generated based on old table end up operating on the new table.

To avoid this situation this PR tries to clean up the task data during table deletion

Table deletion request:
- Delete tasks that are not in IN_PROGRESS state
- Fail table deletion operation with the appropriate error message if there are IN_PROGRESS tasks

Table creation operation:

- Check for dangling task data for the task types that are present in the new table to be created
- Fail the table create operation with proper error message explaining to either perform the delete operation again if it has not went all the way through or delete tasks manually if they were skipped earlier.