### PR TITLE
Optimize QueryContext.isUnsafeTrim

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/QueryContext.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/QueryContext.java
@@ -88,7 +88,6 @@ public class QueryContext {
   private final Map<String, String> _queryOptions;
   private final Map<ExpressionContext, ExpressionContext> _expressionOverrideHints;
   private final ExplainMode _explain;
-  private Boolean _isUnsafeTrim = null;
 
   private final Function<Class<?>, Map<?, ?>> _sharedValues = MemoizedClassAssociation.of(ConcurrentHashMap::new);
 
@@ -140,6 +139,7 @@ public class QueryContext {
   // Whether server returns the final result with unpartitioned group key
   private boolean _serverReturnFinalResultKeyUnpartitioned;
   private boolean _accurateGroupByWithoutOrderBy;
+  private boolean _isUnsafeTrim;
   // Collection of index types to skip per column
   private Map<String, Set<FieldConfig.IndexType>> _skipIndexes;
 
@@ -538,10 +538,6 @@ public class QueryContext {
   }
 
   public boolean isUnsafeTrim() {
-    if (_isUnsafeTrim != null) {
-      return _isUnsafeTrim;
-    }
-    _isUnsafeTrim = !isSameOrderAndGroupByColumns(this) || getHavingFilter() != null;
     return _isUnsafeTrim;
   }
 
@@ -658,6 +654,9 @@ public class QueryContext {
       // Pre-calculate the aggregation functions and columns for the query
       generateAggregationFunctions(queryContext);
       extractColumns(queryContext);
+
+      queryContext._isUnsafeTrim =
+          !queryContext.isSameOrderAndGroupByColumns(queryContext) || queryContext.getHavingFilter() != null;
 
       return queryContext;
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/QueryContext.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/QueryContext.java
@@ -175,10 +175,9 @@ public class QueryContext {
       return false;
     }
 
-    Set<String> groupByKeyIdentSet = new HashSet<>();
-    groupByKeys.forEach(key -> groupByKeyIdentSet.add(key.getIdentifier()));
-    Set<String> orderByKeyIdentSet = new HashSet<>();
-    orderByKeys.forEach(key -> orderByKeyIdentSet.add(key.getExpression().getIdentifier()));
+    Set<ExpressionContext> groupByKeyIdentSet = new HashSet<>(groupByKeys);
+    Set<ExpressionContext> orderByKeyIdentSet = new HashSet<>();
+    orderByKeys.forEach(key -> orderByKeyIdentSet.add(key.getExpression()));
     return groupByKeyIdentSet.equals(orderByKeyIdentSet);
   }
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/GroupByTrimmingIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/GroupByTrimmingIntegrationTest.java
@@ -498,6 +498,39 @@ public class GroupByTrimmingIntegrationTest extends BaseClusterIntegrationTestSe
   }
 
   @Test
+  public void testSSQEGroupsTrimmedAtSegmentLevelWithOrderByAllGroupByKeysDuplicateKeyIsSafe()
+      throws Exception {
+    setUseMultiStageQueryEngine(false);
+
+    // trimming is safe on rows ordered by all group by keys (regardless of key order, direction or duplications)
+    String query = "SELECT i, j, COUNT(*) FROM mytable GROUP BY i, i, j ORDER BY j ASC, i DESC, j ASC LIMIT 5";
+
+    Connection conn = getPinotConnection();
+    assertTrimFlagNotSet(conn.execute(query));
+
+    ResultSetGroup result = conn.execute("SET minSegmentGroupTrimSize=5; " + query);
+    assertTrimFlagNotSet(result);
+
+    assertEquals(toResultStr(result),
+        "\"i\"[\"INT\"],\t\"j\"[\"LONG\"],\t\"count(*)\"[\"LONG\"]\n"
+            + "0,\t0,\t4\n"
+            + "1,\t1,\t4\n"
+            + "2,\t2,\t4\n"
+            + "3,\t3,\t4\n"
+            + "4,\t4,\t4");
+
+    assertEquals(toExplainStr(postQuery("EXPLAIN PLAN FOR " + query), false),
+        "BROKER_REDUCE(sort:[j ASC, i DESC],limit:5),\t1,\t0\n"
+            + "COMBINE_GROUP_BY,\t2,\t1\n"
+            + "PLAN_START(numSegmentsForThisPlan:4),\t-1,\t-1\n"
+            + "GROUP_BY(groupKeys:i, i, j, aggregations:count(*)),\t3,\t2\n"
+            + "PROJECT(i, j),\t4,\t3\n"
+            + "DOC_ID_SET,\t5,\t4\n"
+            + "FILTER_MATCH_ENTIRE_SEGMENT(docs:1000),\t6,\t5\n");
+  }
+
+
+  @Test
   public void testSSQEGroupsTrimmedAtSegmentLevelWithOrderByAggregateIsNotSafe()
       throws Exception {
     setUseMultiStageQueryEngine(false);


### PR DESCRIPTION
change implementation to comparing set of expressions. cache after first call to the function.