### PR TITLE
Start thread accountant just before serving queries

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
@@ -418,6 +418,7 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
     Tracing.ThreadAccountantOps.initializeThreadAccountant(
         _brokerConf.subset(CommonConstants.PINOT_QUERY_SCHEDULER_PREFIX), _instanceId,
         org.apache.pinot.spi.config.instance.InstanceType.BROKER);
+    Tracing.ThreadAccountantOps.startThreadAccountant();
 
     String controllerUrl = _brokerConf.getProperty(Broker.CONTROLLER_URL);
     if (controllerUrl != null) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/accounting/ResourceManagerAccountingTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/accounting/ResourceManagerAccountingTest.java
@@ -105,6 +105,7 @@ public class ResourceManagerAccountingTest {
     PinotConfiguration pinotCfg = new PinotConfiguration(configs);
     Tracing.ThreadAccountantOps.initializeThreadAccountant(pinotCfg, "testCPUtimeProvider",
         InstanceType.SERVER);
+    Tracing.ThreadAccountantOps.startThreadAccountant();
 
     for (int k = 0; k < 30; k++) {
       int finalK = k;
@@ -167,6 +168,7 @@ public class ResourceManagerAccountingTest {
     PinotConfiguration pinotCfg = new PinotConfiguration(configs);
     Tracing.ThreadAccountantOps.initializeThreadAccountant(pinotCfg, "testCPUtimeProvider",
         InstanceType.SERVER);
+    Tracing.ThreadAccountantOps.startThreadAccountant();
 
     for (int k = 0; k < 30; k++) {
       int finalK = k;
@@ -241,6 +243,7 @@ public class ResourceManagerAccountingTest {
     PinotConfiguration pinotCfg = new PinotConfiguration(configs);
     Tracing.ThreadAccountantOps.initializeThreadAccountant(pinotCfg, "testWorkloadMemoryAccounting",
         InstanceType.SERVER);
+    Tracing.ThreadAccountantOps.startThreadAccountant();
     WorkloadBudgetManager workloadBudgetManager =
         Tracing.ThreadAccountantOps.getWorkloadBudgetManager();
     workloadBudgetManager.addOrUpdateWorkload(workloadName, 88_000_000, 27_000_000);
@@ -379,6 +382,7 @@ public class ResourceManagerAccountingTest {
     ResourceManager rm = getResourceManager(20, 2, 1, 1, configs);
     // init accountant and start watcher task
     Tracing.ThreadAccountantOps.initializeThreadAccountant(config, "testSelect", InstanceType.SERVER);
+    Tracing.ThreadAccountantOps.startThreadAccountant();
 
     CountDownLatch latch = new CountDownLatch(100);
     AtomicBoolean earlyTerminationOccurred = new AtomicBoolean(false);
@@ -449,6 +453,7 @@ public class ResourceManagerAccountingTest {
     ResourceManager rm = getResourceManager(20, 2, 1, 1, configs);
     // init accountant and start watcher task
     Tracing.ThreadAccountantOps.initializeThreadAccountant(config, "testGroupBy", InstanceType.SERVER);
+    Tracing.ThreadAccountantOps.startThreadAccountant();
 
     CountDownLatch latch = new CountDownLatch(100);
     AtomicBoolean earlyTerminationOccurred = new AtomicBoolean(false);
@@ -506,6 +511,7 @@ public class ResourceManagerAccountingTest {
     // init accountant and start watcher task
     Tracing.ThreadAccountantOps.initializeThreadAccountant(config, "testJsonIndexExtractMapOOM",
         InstanceType.SERVER);
+    Tracing.ThreadAccountantOps.startThreadAccountant();
 
     Supplier<String> randomJsonValue = () -> {
       Random random = new Random();

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MultiStageAccountingTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MultiStageAccountingTest.java
@@ -93,6 +93,7 @@ public class MultiStageAccountingTest implements ITest {
     // init accountant and start watcher task
     Tracing.ThreadAccountantOps.initializeThreadAccountant(new PinotConfiguration(configs), "testGroupBy",
         InstanceType.SERVER);
+    Tracing.ThreadAccountantOps.startThreadAccountant();
 
     // Setup Thread Context
     Tracing.ThreadAccountantOps.setupRunner("MultiStageAccountingTest", ThreadExecutionContext.TaskType.MSE, null);

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MultistageResourceUsageAccountingTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MultistageResourceUsageAccountingTest.java
@@ -92,6 +92,7 @@ public class MultistageResourceUsageAccountingTest implements ITest {
     // init accountant and start watcher task
     PinotConfiguration pinotCfg = new PinotConfiguration(configs);
     Tracing.ThreadAccountantOps.initializeThreadAccountant(pinotCfg, "testGroupBy", InstanceType.SERVER);
+    Tracing.ThreadAccountantOps.startThreadAccountant();
 
     // Setup Thread Context
     Tracing.ThreadAccountantOps.setupRunner("MultiStageAccountingTest", ThreadExecutionContext.TaskType.MSE, null);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/trace/Tracing.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/trace/Tracing.java
@@ -342,6 +342,9 @@ public class Tracing {
               + "due to invalid thread accountant factory {} provided, exception:", factoryName, exception);
         }
       }
+    }
+
+    public static void startThreadAccountant() {
       Tracing.getThreadAccountant().startWatcherTask();
     }
 


### PR DESCRIPTION
Address #15100 

As described in the issue, thread accountant shouldn't track the heavy segment load activity. Start the thread accountant just before server serving queries.