### PR TITLE
Add the continueOnError flag to the IndexCreationContext

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -168,6 +168,7 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
           .withRealtimeConversion(segmentCreationSpec.isRealtimeConversion())
           .withConsumerDir(segmentCreationSpec.getConsumerDir())
           .withTableNameWithType(_config.getTableConfig().getTableName())
+          .withContinueOnError(_config.isContinueOnError())
           .build();
       //@formatter:on
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/BaseIndexHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/BaseIndexHandler.java
@@ -115,7 +115,8 @@ public abstract class BaseIndexHandler implements IndexHandler {
 
     InvertedIndexAndDictionaryBasedForwardIndexCreator creator =
         new InvertedIndexAndDictionaryBasedForwardIndexCreator(columnName, _segmentDirectory, dictionaryEnabled,
-            forwardIndexConfig, segmentWriter, isTemporaryForwardIndex, _tableConfig.getTableName());
+            forwardIndexConfig, segmentWriter, isTemporaryForwardIndex, _tableConfig.getTableName(),
+            _tableConfig.getIngestionConfig() != null && _tableConfig.getIngestionConfig().isContinueOnError());
     creator.regenerateForwardIndex();
     // Validate that the forward index is created.
     if (!segmentWriter.hasIndexFor(columnName, StandardIndexes.forward())) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/ForwardIndexHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/ForwardIndexHandler.java
@@ -463,7 +463,9 @@ public class ForwardIndexHandler extends BaseIndexHandler {
     try (ForwardIndexReader<?> reader = ForwardIndexType.read(segmentWriter, columnMetadata)) {
       IndexCreationContext.Builder builder =
           IndexCreationContext.builder().withIndexDir(indexDir).withColumnMetadata(columnMetadata)
-              .withTableNameWithType(_tableConfig.getTableName());
+              .withTableNameWithType(_tableConfig.getTableName())
+              .withContinueOnError(_tableConfig.getIngestionConfig() != null
+                  && _tableConfig.getIngestionConfig().isContinueOnError());
       // Set entry length info for raw index creators. No need to set this when changing dictionary id compression type.
       if (!reader.isDictionaryEncoded() && !columnMetadata.getDataType().getStoredType().isFixedWidth()) {
         int lengthOfLongestEntry = reader.getLengthOfLongestEntry();
@@ -889,7 +891,9 @@ public class ForwardIndexHandler extends BaseIndexHandler {
     try (ForwardIndexReader<?> reader = ForwardIndexType.read(segmentWriter, existingColMetadata)) {
       IndexCreationContext.Builder builder =
           IndexCreationContext.builder().withIndexDir(indexDir).withColumnMetadata(existingColMetadata)
-              .withTableNameWithType(_tableConfig.getTableName());
+              .withTableNameWithType(_tableConfig.getTableName())
+              .withContinueOnError(_tableConfig.getIngestionConfig() != null
+                  && _tableConfig.getIngestionConfig().isContinueOnError());
       // existingColMetadata has dictEnable=false. Overwrite the value.
       builder.withDictionary(true);
       IndexCreationContext context = builder.build();
@@ -964,7 +968,9 @@ public class ForwardIndexHandler extends BaseIndexHandler {
       Dictionary dictionary = DictionaryIndexType.read(segmentWriter, columnMetadata);
       IndexCreationContext.Builder builder =
           IndexCreationContext.builder().withIndexDir(indexDir).withColumnMetadata(columnMetadata)
-              .withTableNameWithType(_tableConfig.getTableName());
+              .withTableNameWithType(_tableConfig.getTableName())
+              .withContinueOnError(_tableConfig.getIngestionConfig() != null
+                  && _tableConfig.getIngestionConfig().isContinueOnError());
       builder.withDictionary(false);
       if (!columnMetadata.getDataType().getStoredType().isFixedWidth()) {
         if (columnMetadata.isSingleValue()) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/InvertedIndexAndDictionaryBasedForwardIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/InvertedIndexAndDictionaryBasedForwardIndexCreator.java
@@ -83,6 +83,7 @@ public class InvertedIndexAndDictionaryBasedForwardIndexCreator implements AutoC
   private final SegmentDirectory.Writer _segmentWriter;
   private final boolean _isTemporaryForwardIndex;
   private final String _tableNameWithType;
+  private final boolean _continueOnError;
 
   // Metadata
   private final SegmentDirectory _segmentDirectory;
@@ -115,7 +116,7 @@ public class InvertedIndexAndDictionaryBasedForwardIndexCreator implements AutoC
 
   public InvertedIndexAndDictionaryBasedForwardIndexCreator(String columnName, SegmentDirectory segmentDirectory,
       boolean dictionaryEnabled, ForwardIndexConfig fwdConf, SegmentDirectory.Writer segmentWriter,
-      boolean isTemporaryForwardIndex, String tableNameWithType)
+      boolean isTemporaryForwardIndex, String tableNameWithType, boolean continueOnError)
       throws IOException {
     _columnName = columnName;
     _segmentDirectory = segmentDirectory;
@@ -123,6 +124,7 @@ public class InvertedIndexAndDictionaryBasedForwardIndexCreator implements AutoC
     _segmentWriter = segmentWriter;
     _isTemporaryForwardIndex = isTemporaryForwardIndex;
     _tableNameWithType = tableNameWithType;
+    _continueOnError = continueOnError;
 
     _columnMetadata = _segmentMetadata.getColumnMetadataFor(columnName);
     _singleValue = _columnMetadata.isSingleValue();
@@ -271,6 +273,7 @@ public class InvertedIndexAndDictionaryBasedForwardIndexCreator implements AutoC
           .withDictionary(_dictionaryEnabled)
           .withLengthOfLongestEntry(lengthOfLongestEntry)
           .withTableNameWithType(_tableNameWithType)
+          .withContinueOnError(_continueOnError)
           .build();
 
       // note: this method closes buffers and removes files
@@ -358,6 +361,7 @@ public class InvertedIndexAndDictionaryBasedForwardIndexCreator implements AutoC
           .withMaxRowLengthInBytes(maxRowLengthInBytes[0])
           .withLengthOfLongestEntry(lengthOfLongestEntry)
           .withTableNameWithType(_tableNameWithType)
+          .withContinueOnError(_continueOnError)
           .build();
 
       writeToForwardIndex(dictionary, context);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/bloomfilter/BloomFilterHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/bloomfilter/BloomFilterHandler.java
@@ -118,6 +118,8 @@ public class BloomFilterHandler extends BaseIndexHandler {
         .withIndexDir(indexDir)
         .withColumnMetadata(columnMetadata)
         .withTableNameWithType(_tableConfig.getTableName())
+        .withContinueOnError(_tableConfig.getIngestionConfig() != null
+            && _tableConfig.getIngestionConfig().isContinueOnError())
         .build();
     try (BloomFilterCreator bloomFilterCreator =
         StandardIndexes.bloomFilter().createIndexCreator(context, bloomFilterConfig);
@@ -138,6 +140,8 @@ public class BloomFilterHandler extends BaseIndexHandler {
         .withIndexDir(indexDir)
         .withColumnMetadata(columnMetadata)
         .withTableNameWithType(_tableConfig.getTableName())
+        .withContinueOnError(_tableConfig.getIngestionConfig() != null
+            && _tableConfig.getIngestionConfig().isContinueOnError())
         .build();
     try (BloomFilterCreator bloomFilterCreator = StandardIndexes.bloomFilter()
         .createIndexCreator(context, bloomFilterConfig);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/defaultcolumn/BaseDefaultColumnHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/defaultcolumn/BaseDefaultColumnHandler.java
@@ -1200,6 +1200,8 @@ public abstract class BaseDefaultColumnHandler implements DefaultColumnHandler {
         .withTotalDocs(numDocs)
         .withDictionary(hasDictionary)
         .withTableNameWithType(_tableConfig.getTableName())
+        .withContinueOnError(_tableConfig.getIngestionConfig() != null
+            && _tableConfig.getIngestionConfig().isContinueOnError())
         .build();
 
     ForwardIndexConfig forwardIndexConfig = null;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/FSTIndexHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/FSTIndexHandler.java
@@ -173,6 +173,8 @@ public class FSTIndexHandler extends BaseIndexHandler {
         .withIndexDir(indexDir)
         .withColumnMetadata(columnMetadata)
         .withTableNameWithType(_tableConfig.getTableName())
+        .withContinueOnError(_tableConfig.getIngestionConfig() != null
+            && _tableConfig.getIngestionConfig().isContinueOnError())
         .build();
     FstIndexConfig config = _fieldIndexConfigs.get(columnName).getConfig(StandardIndexes.fst());
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/H3IndexHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/H3IndexHandler.java
@@ -163,6 +163,8 @@ public class H3IndexHandler extends BaseIndexHandler {
         .withIndexDir(indexDir)
         .withColumnMetadata(columnMetadata)
         .withTableNameWithType(_tableConfig.getTableName())
+        .withContinueOnError(_tableConfig.getIngestionConfig() != null
+            && _tableConfig.getIngestionConfig().isContinueOnError())
         .build();
     H3IndexConfig config = colIndexConf.getConfig(StandardIndexes.h3());
 
@@ -189,6 +191,8 @@ public class H3IndexHandler extends BaseIndexHandler {
         .withIndexDir(indexDir)
         .withColumnMetadata(columnMetadata)
         .withTableNameWithType(_tableConfig.getTableName())
+        .withContinueOnError(_tableConfig.getIngestionConfig() != null
+            && _tableConfig.getIngestionConfig().isContinueOnError())
         .build();
     H3IndexConfig config = _fieldIndexConfigs.get(columnName).getConfig(StandardIndexes.h3());
     try (ForwardIndexReader forwardIndexReader = ForwardIndexType.read(segmentWriter, columnMetadata);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/InvertedIndexHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/InvertedIndexHandler.java
@@ -140,6 +140,8 @@ public class InvertedIndexHandler extends BaseIndexHandler {
         .withIndexDir(indexDir)
         .withColumnMetadata(columnMetadata)
         .withTableNameWithType(_tableConfig.getTableName())
+        .withContinueOnError(_tableConfig.getIngestionConfig() != null
+            && _tableConfig.getIngestionConfig().isContinueOnError())
         .build();
 
     try (DictionaryBasedInvertedIndexCreator creator = StandardIndexes.inverted()

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/JsonIndexHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/JsonIndexHandler.java
@@ -161,6 +161,8 @@ public class JsonIndexHandler extends BaseIndexHandler {
         .withIndexDir(indexDir)
         .withColumnMetadata(columnMetadata)
         .withTableNameWithType(_tableConfig.getTableName())
+        .withContinueOnError(_tableConfig.getIngestionConfig() != null
+            && _tableConfig.getIngestionConfig().isContinueOnError())
         .build();
     JsonIndexConfig config = _jsonIndexConfigs.get(columnName);
     try (ForwardIndexReader forwardIndexReader = ForwardIndexType.read(segmentWriter, columnMetadata);
@@ -184,6 +186,8 @@ public class JsonIndexHandler extends BaseIndexHandler {
         .withIndexDir(indexDir)
         .withColumnMetadata(columnMetadata)
         .withTableNameWithType(_tableConfig.getTableName())
+        .withContinueOnError(_tableConfig.getIngestionConfig() != null
+            && _tableConfig.getIngestionConfig().isContinueOnError())
         .build();
     JsonIndexConfig config = _jsonIndexConfigs.get(columnName);
     try (ForwardIndexReader forwardIndexReader = ForwardIndexType.read(segmentWriter, columnMetadata);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/RangeIndexHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/RangeIndexHandler.java
@@ -261,6 +261,8 @@ public class RangeIndexHandler extends BaseIndexHandler {
         .withIndexDir(indexDir)
         .withColumnMetadata(columnMetadata)
         .withTableNameWithType(_tableConfig.getTableName())
+        .withContinueOnError(_tableConfig.getIngestionConfig() != null
+            && _tableConfig.getIngestionConfig().isContinueOnError())
         .build();
     RangeIndexConfig config = _fieldIndexConfigs.get(columnMetadata.getColumnName())
         .getConfig(StandardIndexes.range());

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/TextIndexHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/TextIndexHandler.java
@@ -175,6 +175,8 @@ public class TextIndexHandler extends BaseIndexHandler {
         .withIndexDir(segmentDirectory)
         .withTextCommitOnClose(true)
         .withTableNameWithType(_tableConfig.getTableName())
+        .withContinueOnError(_tableConfig.getIngestionConfig() != null
+            && _tableConfig.getIngestionConfig().isContinueOnError())
         .build();
     TextIndexConfig config = _fieldIndexConfigs.get(columnName).getConfig(StandardIndexes.text());
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/VectorIndexHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/VectorIndexHandler.java
@@ -168,6 +168,8 @@ public class VectorIndexHandler extends BaseIndexHandler {
         .withIndexDir(segmentDirectory)
         .withColumnMetadata(columnMetadata)
         .withTableNameWithType(_tableConfig.getTableName())
+        .withContinueOnError(_tableConfig.getIngestionConfig() != null
+            && _tableConfig.getIngestionConfig().isContinueOnError())
         .build();
     VectorIndexConfig config = colIndexConf.getConfig(StandardIndexes.vector());
 
@@ -202,6 +204,8 @@ public class VectorIndexHandler extends BaseIndexHandler {
         .withIndexDir(segmentDirectory)
         .withColumnMetadata(columnMetadata)
         .withTableNameWithType(_tableConfig.getTableName())
+        .withContinueOnError(_tableConfig.getIngestionConfig() != null
+            && _tableConfig.getIngestionConfig().isContinueOnError())
         .build();
     VectorIndexConfig config = _fieldIndexConfigs.get(columnName).getConfig(StandardIndexes.vector());
     try (ForwardIndexReader forwardIndexReader = ForwardIndexType.read(segmentWriter, columnMetadata);

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/IndexCreationContext.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/IndexCreationContext.java
@@ -113,6 +113,8 @@ public interface IndexCreationContext {
 
   String getTableNameWithType();
 
+  boolean isContinueOnError();
+
   final class Builder {
     private ColumnStatistics _columnStatistics;
     private File _indexDir;
@@ -137,6 +139,7 @@ public interface IndexCreationContext {
     private File _consumerDir;
     private int[] _immutableToMutableIdMap;
     private String _tableNameWithType;
+    private boolean _continueOnError;
 
     public Builder withColumnIndexCreationInfo(ColumnIndexCreationInfo columnIndexCreationInfo) {
       return withLengthOfLongestEntry(columnIndexCreationInfo.getLengthOfLongestEntry())
@@ -274,12 +277,17 @@ public interface IndexCreationContext {
       return this;
     }
 
+    public Builder withContinueOnError(boolean continueOnError) {
+      _continueOnError = continueOnError;
+      return this;
+    }
+
     public Common build() {
       return new Common(Objects.requireNonNull(_indexDir), _lengthOfLongestEntry, _maxNumberOfMultiValueElements,
           _maxRowLengthInBytes, _onHeap, Objects.requireNonNull(_fieldSpec), _sorted, _cardinality,
           _totalNumberOfEntries, _totalDocs, _hasDictionary, _minValue, _maxValue, _forwardIndexDisabled,
           _sortedUniqueElementsArray, _optimizedDictionary, _fixedLength, _textCommitOnClose, _columnStatistics,
-          _realtimeConversion, _consumerDir, _immutableToMutableIdMap, _tableNameWithType);
+          _realtimeConversion, _consumerDir, _immutableToMutableIdMap, _tableNameWithType, _continueOnError);
     }
 
     public Builder withSortedUniqueElementsArray(Object sortedUniqueElementsArray) {
@@ -317,6 +325,7 @@ public interface IndexCreationContext {
     private final File _consumerDir;
     private final int[] _immutableToMutableIdMap;
     private final String _tableNameWithType;
+    private final boolean _continueOnError;
 
     private Common(File indexDir, int lengthOfLongestEntry,
         int maxNumberOfMultiValueElements, int maxRowLengthInBytes, boolean onHeap,
@@ -324,7 +333,7 @@ public interface IndexCreationContext {
         int totalDocs, boolean hasDictionary, Comparable<?> minValue, Comparable<?> maxValue,
         boolean forwardIndexDisabled, Object sortedUniqueElementsArray, boolean optimizeDictionary, boolean fixedLength,
         boolean textCommitOnClose, ColumnStatistics columnStatistics, boolean realtimeConversion, File consumerDir,
-        int[] immutableToMutableIdMap, String tableNameWithType) {
+        int[] immutableToMutableIdMap, String tableNameWithType, boolean continueOnError) {
       _indexDir = indexDir;
       _lengthOfLongestEntry = lengthOfLongestEntry;
       _maxNumberOfMultiValueElements = maxNumberOfMultiValueElements;
@@ -348,6 +357,7 @@ public interface IndexCreationContext {
       _consumerDir = consumerDir;
       _immutableToMutableIdMap = immutableToMutableIdMap;
       _tableNameWithType = tableNameWithType;
+      _continueOnError = continueOnError;
     }
 
     public FieldSpec getFieldSpec() {
@@ -452,6 +462,11 @@ public interface IndexCreationContext {
     @Override
     public String getTableNameWithType() {
       return _tableNameWithType;
+    }
+
+    @Override
+    public boolean isContinueOnError() {
+      return _continueOnError;
     }
   }
 }


### PR DESCRIPTION
Add the `continueOnError` flag to the `IndexCreationContext`. This is helpful for the scenario where we may want to continue processing records during segment build even if an error occurs.