### PR TITLE
Add broker metrics to count segments that are not zone failure tolerant

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/BalancedInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/BalancedInstanceSelector.java
@@ -51,9 +51,8 @@ public class BalancedInstanceSelector extends BaseInstanceSelector {
 
   public BalancedInstanceSelector(String tableNameWithType, ZkHelixPropertyStore<ZNRecord> propertyStore,
       BrokerMetrics brokerMetrics, @Nullable AdaptiveServerSelector adaptiveServerSelector, Clock clock,
-      boolean useFixedReplica, long newSegmentExpirationTimeInSeconds) {
-    super(tableNameWithType, propertyStore, brokerMetrics, adaptiveServerSelector, clock, useFixedReplica,
-        newSegmentExpirationTimeInSeconds);
+      InstanceSelectorConfig config) {
+    super(tableNameWithType, propertyStore, brokerMetrics, adaptiveServerSelector, clock, config);
   }
 
   @Override

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/BaseInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/BaseInstanceSelector.java
@@ -260,8 +260,17 @@ abstract class BaseInstanceSelector implements InstanceSelector {
 
     Map<String, Map<String, String>> idealStateAssignment = idealState.getRecord().getMapFields();
     Map<String, Map<String, String>> externalViewAssignment = externalView.getRecord().getMapFields();
+    int count = 0;
+    Set<Integer> pools = new HashSet<>();
     for (String segment : onlineSegments) {
       Map<String, String> idealStateInstanceStateMap = idealStateAssignment.get(segment);
+      pools.clear();
+      for (String instance : idealStateInstanceStateMap.keySet()) {
+        pools.add(getPool(instance));
+      }
+      if (pools.size() < 2) {
+        count++;
+      }
       Long newSegmentCreationTimeMs = newSegmentCreationTimeMap.get(segment);
       Map<String, String> externalViewInstanceStateMap = externalViewAssignment.get(segment);
       if (externalViewInstanceStateMap == null) {
@@ -302,6 +311,7 @@ abstract class BaseInstanceSelector implements InstanceSelector {
         }
       }
     }
+    _brokerMetrics.addMeteredTableValue(_tableNameWithType, BrokerMeter.SINGLE_POOL_SEGMENTS, count);
     if (LOGGER.isDebugEnabled()) {
       LOGGER.debug("Got _newSegmentStateMap: {}, _oldSegmentCandidatesMap: {}", _newSegmentStateMap.keySet(),
           _oldSegmentCandidatesMap.keySet());

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/BaseInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/BaseInstanceSelector.java
@@ -122,7 +122,7 @@ abstract class BaseInstanceSelector implements InstanceSelector {
     _clock = clock;
     _useFixedReplica = config.isUseFixedReplica();
     _newSegmentExpirationTimeInSeconds = config.getNewSegmentExpirationTimeInSeconds();
-    _emitSinglePoolSegmentsMetric = config.shouldEmitSinglePoolSegments();
+    _emitSinglePoolSegmentsMetric = config.shouldEmitSinglePoolSegmentsMetrics();
     // Using raw table name to ensure queries spanning across REALTIME and OFFLINE tables are routed to the same
     // instance
     // Math.abs(Integer.MIN_VALUE) = Integer.MIN_VALUE, so we use & 0x7FFFFFFF to get a positive value
@@ -305,8 +305,8 @@ abstract class BaseInstanceSelector implements InstanceSelector {
           _oldSegmentCandidatesMap.put(segment, candidates);
         }
       }
-      pools.clear();
       if (_emitSinglePoolSegmentsMetric) {
+        pools.clear();
         for (String instance : idealStateInstanceStateMap.keySet()) {
           pools.add(getPool(instance));
         }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorConfig.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorConfig.java
@@ -21,13 +21,13 @@ package org.apache.pinot.broker.routing.instanceselector;
 public class InstanceSelectorConfig {
   private final boolean _useFixedReplica;
   private final long _newSegmentExpirationTimeInSeconds;
-  private final boolean _emitSinglePoolSegments;
+  private final boolean _emitSinglePoolSegmentsMetrics;
 
   public InstanceSelectorConfig(boolean useFixedReplica, long newSegmentExpirationTimeInSeconds,
-      boolean emitSinglePoolSegments) {
+      boolean emitSinglePoolSegmentsMetrics) {
     _useFixedReplica = useFixedReplica;
     _newSegmentExpirationTimeInSeconds = newSegmentExpirationTimeInSeconds;
-    _emitSinglePoolSegments = emitSinglePoolSegments;
+    _emitSinglePoolSegmentsMetrics = emitSinglePoolSegmentsMetrics;
   }
 
   public boolean isUseFixedReplica() {
@@ -38,7 +38,7 @@ public class InstanceSelectorConfig {
     return _newSegmentExpirationTimeInSeconds;
   }
 
-  public boolean shouldEmitSinglePoolSegments() {
-    return _emitSinglePoolSegments;
+  public boolean shouldEmitSinglePoolSegmentsMetrics() {
+    return _emitSinglePoolSegmentsMetrics;
   }
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorConfig.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorConfig.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.routing.instanceselector;
+
+public class InstanceSelectorConfig {
+  private final boolean _useFixedReplica;
+  private final long _newSegmentExpirationTimeInSeconds;
+  private final boolean _emitSinglePoolSegments;
+
+  public InstanceSelectorConfig(boolean useFixedReplica, long newSegmentExpirationTimeInSeconds,
+      boolean emitSinglePoolSegments) {
+    _useFixedReplica = useFixedReplica;
+    _newSegmentExpirationTimeInSeconds = newSegmentExpirationTimeInSeconds;
+    _emitSinglePoolSegments = emitSinglePoolSegments;
+  }
+
+  public boolean isUseFixedReplica() {
+    return _useFixedReplica;
+  }
+
+  public long getNewSegmentExpirationTimeInSeconds() {
+    return _newSegmentExpirationTimeInSeconds;
+  }
+
+  public boolean shouldEmitSinglePoolSegments() {
+    return _emitSinglePoolSegments;
+  }
+}

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorFactory.java
@@ -63,36 +63,40 @@ public class InstanceSelectorFactory {
     RoutingConfig routingConfig = tableConfig.getRoutingConfig();
     boolean useFixedReplica = brokerConfig.getProperty(CommonConstants.Broker.CONFIG_OF_USE_FIXED_REPLICA,
         CommonConstants.Broker.DEFAULT_USE_FIXED_REPLICA);
+    if (routingConfig != null && routingConfig.getUseFixedReplica() != null) {
+      useFixedReplica = routingConfig.getUseFixedReplica();
+    }
     long newSegmentExpirationTimeInSeconds =
         brokerConfig.getProperty(CommonConstants.Broker.CONFIG_OF_NEW_SEGMENT_EXPIRATION_SECONDS,
         CommonConstants.Broker.DEFAULT_VALUE_OF_NEW_SEGMENT_EXPIRATION_SECONDS);
+    boolean emitSinglePoolSegments = brokerConfig.getProperty(
+            CommonConstants.Broker.CONFIG_OF_BROKER_ENABLE_SINGLE_POOL_SEGMENTS_METRIC,
+            CommonConstants.Broker.DEFAULT_ENABLE_SINGLE_POOL_SEGMENTS_METRIC);
+    InstanceSelectorConfig config = new InstanceSelectorConfig(useFixedReplica, newSegmentExpirationTimeInSeconds,
+            emitSinglePoolSegments);
     if (routingConfig != null) {
-      if (routingConfig.getUseFixedReplica() != null) {
-        // table config overrides broker config
-        useFixedReplica = routingConfig.getUseFixedReplica();
-      }
       if (RoutingConfig.REPLICA_GROUP_INSTANCE_SELECTOR_TYPE.equalsIgnoreCase(routingConfig.getInstanceSelectorType())
           || (tableConfig.getTableType() == TableType.OFFLINE && LEGACY_REPLICA_GROUP_OFFLINE_ROUTING.equalsIgnoreCase(
           routingConfig.getRoutingTableBuilderName())) || (tableConfig.getTableType() == TableType.REALTIME
           && LEGACY_REPLICA_GROUP_REALTIME_ROUTING.equalsIgnoreCase(routingConfig.getRoutingTableBuilderName()))) {
         LOGGER.info("Using ReplicaGroupInstanceSelector for table: {}", tableNameWithType);
         return new ReplicaGroupInstanceSelector(tableNameWithType, propertyStore, brokerMetrics, adaptiveServerSelector,
-            clock, useFixedReplica, newSegmentExpirationTimeInSeconds);
+            clock, config);
       }
       if (RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE.equalsIgnoreCase(
           routingConfig.getInstanceSelectorType())) {
         LOGGER.info("Using StrictReplicaGroupInstanceSelector for table: {}", tableNameWithType);
         return new StrictReplicaGroupInstanceSelector(tableNameWithType, propertyStore, brokerMetrics,
-            adaptiveServerSelector, clock, useFixedReplica, newSegmentExpirationTimeInSeconds);
+            adaptiveServerSelector, clock, config);
       }
       if (RoutingConfig.MULTI_STAGE_REPLICA_GROUP_SELECTOR_TYPE.equalsIgnoreCase(
           routingConfig.getInstanceSelectorType())) {
         LOGGER.info("Using {} for table: {}", routingConfig.getInstanceSelectorType(), tableNameWithType);
         return new MultiStageReplicaGroupSelector(tableNameWithType, propertyStore, brokerMetrics,
-            adaptiveServerSelector, clock, useFixedReplica, newSegmentExpirationTimeInSeconds);
+            adaptiveServerSelector, clock, config);
       }
     }
     return new BalancedInstanceSelector(tableNameWithType, propertyStore, brokerMetrics, adaptiveServerSelector, clock,
-        useFixedReplica, newSegmentExpirationTimeInSeconds);
+       config);
   }
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/MultiStageReplicaGroupSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/MultiStageReplicaGroupSelector.java
@@ -61,9 +61,8 @@ public class MultiStageReplicaGroupSelector extends BaseInstanceSelector {
 
   public MultiStageReplicaGroupSelector(String tableNameWithType, ZkHelixPropertyStore<ZNRecord> propertyStore,
       BrokerMetrics brokerMetrics, @Nullable AdaptiveServerSelector adaptiveServerSelector, Clock clock,
-      boolean useFixedReplica, long newSegmentExpirationTimeInSeconds) {
-    super(tableNameWithType, propertyStore, brokerMetrics, adaptiveServerSelector, clock, useFixedReplica,
-        newSegmentExpirationTimeInSeconds);
+      InstanceSelectorConfig config) {
+    super(tableNameWithType, propertyStore, brokerMetrics, adaptiveServerSelector, clock, config);
   }
 
   @Override

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupInstanceSelector.java
@@ -66,9 +66,8 @@ public class ReplicaGroupInstanceSelector extends BaseInstanceSelector {
 
   public ReplicaGroupInstanceSelector(String tableNameWithType, ZkHelixPropertyStore<ZNRecord> propertyStore,
       BrokerMetrics brokerMetrics, @Nullable AdaptiveServerSelector adaptiveServerSelector, Clock clock,
-      boolean useFixedReplica, long newSegmentExpirationTimeInSeconds) {
-    super(tableNameWithType, propertyStore, brokerMetrics, adaptiveServerSelector, clock, useFixedReplica,
-        newSegmentExpirationTimeInSeconds);
+      InstanceSelectorConfig config) {
+    super(tableNameWithType, propertyStore, brokerMetrics, adaptiveServerSelector, clock, config);
   }
 
   @Override

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/StrictReplicaGroupInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/StrictReplicaGroupInstanceSelector.java
@@ -72,9 +72,8 @@ public class StrictReplicaGroupInstanceSelector extends ReplicaGroupInstanceSele
 
   public StrictReplicaGroupInstanceSelector(String tableNameWithType, ZkHelixPropertyStore<ZNRecord> propertyStore,
       BrokerMetrics brokerMetrics, @Nullable AdaptiveServerSelector adaptiveServerSelector, Clock clock,
-      boolean useFixedReplica, long newSegmentExpirationTimeInSeconds) {
-    super(tableNameWithType, propertyStore, brokerMetrics, adaptiveServerSelector, clock, useFixedReplica,
-        newSegmentExpirationTimeInSeconds);
+      InstanceSelectorConfig config) {
+    super(tableNameWithType, propertyStore, brokerMetrics, adaptiveServerSelector, clock, config);
   }
 
   /**

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorTest.java
@@ -238,13 +238,13 @@ public class InstanceSelectorTest {
     BrokerMetrics brokerMetrics = mock(BrokerMetrics.class);
     BalancedInstanceSelector balancedInstanceSelector =
         new BalancedInstanceSelector(offlineTableName, propertyStore, brokerMetrics, null,
-                Clock.systemUTC(), INSTANCE_SELECTOR_CONFIG);
+            Clock.systemUTC(), INSTANCE_SELECTOR_CONFIG);
     ReplicaGroupInstanceSelector replicaGroupInstanceSelector =
         new ReplicaGroupInstanceSelector(offlineTableName, propertyStore, brokerMetrics, null,
-                Clock.systemUTC(), INSTANCE_SELECTOR_CONFIG);
+            Clock.systemUTC(), INSTANCE_SELECTOR_CONFIG);
     StrictReplicaGroupInstanceSelector strictReplicaGroupInstanceSelector =
         new StrictReplicaGroupInstanceSelector(offlineTableName, propertyStore, brokerMetrics, null,
-                Clock.systemUTC(), INSTANCE_SELECTOR_CONFIG);
+            Clock.systemUTC(), INSTANCE_SELECTOR_CONFIG);
 
     Set<String> enabledInstances = new HashSet<>();
     IdealState idealState = new IdealState(offlineTableName);
@@ -766,7 +766,7 @@ public class InstanceSelectorTest {
 
     ReplicaGroupInstanceSelector replicaGroupInstanceSelector =
         new ReplicaGroupInstanceSelector(offlineTableName, propertyStore, brokerMetrics, null,
-                Clock.systemUTC(), INSTANCE_SELECTOR_CONFIG);
+            Clock.systemUTC(), INSTANCE_SELECTOR_CONFIG);
 
     Set<String> enabledInstances = new HashSet<>();
     IdealState idealState = new IdealState(offlineTableName);
@@ -849,7 +849,7 @@ public class InstanceSelectorTest {
 
     ReplicaGroupInstanceSelector replicaGroupInstanceSelector =
         new ReplicaGroupInstanceSelector(offlineTableName, propertyStore, brokerMetrics, null,
-                Clock.systemUTC(), INSTANCE_SELECTOR_CONFIG);
+            Clock.systemUTC(), INSTANCE_SELECTOR_CONFIG);
 
     Set<String> enabledInstances = new HashSet<>();
     IdealState idealState = new IdealState(offlineTableName);
@@ -932,7 +932,7 @@ public class InstanceSelectorTest {
 
     ReplicaGroupInstanceSelector replicaGroupInstanceSelector =
         new ReplicaGroupInstanceSelector(offlineTableName, propertyStore, brokerMetrics, null,
-                Clock.systemUTC(), INSTANCE_SELECTOR_CONFIG);
+            Clock.systemUTC(), INSTANCE_SELECTOR_CONFIG);
 
     Set<String> enabledInstances = new HashSet<>();
     IdealState idealState = new IdealState(offlineTableName);
@@ -993,11 +993,11 @@ public class InstanceSelectorTest {
     BrokerMetrics brokerMetrics = mock(BrokerMetrics.class);
     BalancedInstanceSelector balancedInstanceSelector =
         new BalancedInstanceSelector(offlineTableName, propertyStore, brokerMetrics, null,
-                Clock.systemUTC(), INSTANCE_SELECTOR_CONFIG);
+            Clock.systemUTC(), INSTANCE_SELECTOR_CONFIG);
     // ReplicaGroupInstanceSelector has the same behavior as BalancedInstanceSelector for the unavailable segments
     StrictReplicaGroupInstanceSelector strictReplicaGroupInstanceSelector =
         new StrictReplicaGroupInstanceSelector(offlineTableName, propertyStore, brokerMetrics, null,
-                Clock.systemUTC(), INSTANCE_SELECTOR_CONFIG);
+            Clock.systemUTC(), INSTANCE_SELECTOR_CONFIG);
 
     Set<String> enabledInstances = new HashSet<>();
     IdealState idealState = new IdealState(offlineTableName);

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorTest.java
@@ -111,6 +111,7 @@ public class InstanceSelectorTest {
   private final static List<String> SEGMENTS =
       Arrays.asList("segment0", "segment1", "segment2", "segment3", "segment4", "segment5", "segment6", "segment7",
           "segment8", "segment9", "segment10", "segment11");
+  private final static InstanceSelectorConfig INSTANCE_SELECTOR_CONFIG = new InstanceSelectorConfig(false, 300, false);
 
   private void createSegments(List<Pair<String, Long>> segmentCreationTimeMsPairs) {
     List<String> segmentZKMetadataPaths = new ArrayList<>();
@@ -236,14 +237,14 @@ public class InstanceSelectorTest {
     ZkHelixPropertyStore<ZNRecord> propertyStore = mock(ZkHelixPropertyStore.class);
     BrokerMetrics brokerMetrics = mock(BrokerMetrics.class);
     BalancedInstanceSelector balancedInstanceSelector =
-        new BalancedInstanceSelector(offlineTableName, propertyStore, brokerMetrics, null, Clock.systemUTC(), false,
-            300);
+        new BalancedInstanceSelector(offlineTableName, propertyStore, brokerMetrics, null,
+                Clock.systemUTC(), INSTANCE_SELECTOR_CONFIG);
     ReplicaGroupInstanceSelector replicaGroupInstanceSelector =
-        new ReplicaGroupInstanceSelector(offlineTableName, propertyStore, brokerMetrics, null, Clock.systemUTC(), false,
-            300);
+        new ReplicaGroupInstanceSelector(offlineTableName, propertyStore, brokerMetrics, null,
+                Clock.systemUTC(), INSTANCE_SELECTOR_CONFIG);
     StrictReplicaGroupInstanceSelector strictReplicaGroupInstanceSelector =
-        new StrictReplicaGroupInstanceSelector(offlineTableName, propertyStore, brokerMetrics, null, Clock.systemUTC(),
-            false, 300);
+        new StrictReplicaGroupInstanceSelector(offlineTableName, propertyStore, brokerMetrics, null,
+                Clock.systemUTC(), INSTANCE_SELECTOR_CONFIG);
 
     Set<String> enabledInstances = new HashSet<>();
     IdealState idealState = new IdealState(offlineTableName);
@@ -764,8 +765,8 @@ public class InstanceSelectorTest {
     when(pinotQuery.getQueryOptions()).thenReturn(queryOptions);
 
     ReplicaGroupInstanceSelector replicaGroupInstanceSelector =
-        new ReplicaGroupInstanceSelector(offlineTableName, propertyStore, brokerMetrics, null, Clock.systemUTC(), false,
-            300);
+        new ReplicaGroupInstanceSelector(offlineTableName, propertyStore, brokerMetrics, null,
+                Clock.systemUTC(), INSTANCE_SELECTOR_CONFIG);
 
     Set<String> enabledInstances = new HashSet<>();
     IdealState idealState = new IdealState(offlineTableName);
@@ -847,8 +848,8 @@ public class InstanceSelectorTest {
     when(pinotQuery.getQueryOptions()).thenReturn(queryOptions);
 
     ReplicaGroupInstanceSelector replicaGroupInstanceSelector =
-        new ReplicaGroupInstanceSelector(offlineTableName, propertyStore, brokerMetrics, null, Clock.systemUTC(), false,
-            300);
+        new ReplicaGroupInstanceSelector(offlineTableName, propertyStore, brokerMetrics, null,
+                Clock.systemUTC(), INSTANCE_SELECTOR_CONFIG);
 
     Set<String> enabledInstances = new HashSet<>();
     IdealState idealState = new IdealState(offlineTableName);
@@ -930,8 +931,8 @@ public class InstanceSelectorTest {
     when(pinotQuery.getQueryOptions()).thenReturn(queryOptions);
 
     ReplicaGroupInstanceSelector replicaGroupInstanceSelector =
-        new ReplicaGroupInstanceSelector(offlineTableName, propertyStore, brokerMetrics, null, Clock.systemUTC(), false,
-            300);
+        new ReplicaGroupInstanceSelector(offlineTableName, propertyStore, brokerMetrics, null,
+                Clock.systemUTC(), INSTANCE_SELECTOR_CONFIG);
 
     Set<String> enabledInstances = new HashSet<>();
     IdealState idealState = new IdealState(offlineTableName);
@@ -991,12 +992,12 @@ public class InstanceSelectorTest {
     ZkHelixPropertyStore<ZNRecord> propertyStore = mock(ZkHelixPropertyStore.class);
     BrokerMetrics brokerMetrics = mock(BrokerMetrics.class);
     BalancedInstanceSelector balancedInstanceSelector =
-        new BalancedInstanceSelector(offlineTableName, propertyStore, brokerMetrics, null, Clock.systemUTC(), false,
-            300);
+        new BalancedInstanceSelector(offlineTableName, propertyStore, brokerMetrics, null,
+                Clock.systemUTC(), INSTANCE_SELECTOR_CONFIG);
     // ReplicaGroupInstanceSelector has the same behavior as BalancedInstanceSelector for the unavailable segments
     StrictReplicaGroupInstanceSelector strictReplicaGroupInstanceSelector =
-        new StrictReplicaGroupInstanceSelector(offlineTableName, propertyStore, brokerMetrics, null, Clock.systemUTC(),
-            false, 300);
+        new StrictReplicaGroupInstanceSelector(offlineTableName, propertyStore, brokerMetrics, null,
+                Clock.systemUTC(), INSTANCE_SELECTOR_CONFIG);
 
     Set<String> enabledInstances = new HashSet<>();
     IdealState idealState = new IdealState(offlineTableName);
@@ -1860,7 +1861,7 @@ public class InstanceSelectorTest {
     HybridSelector hybridSelector = mock(HybridSelector.class);
     ReplicaGroupInstanceSelector instanceSelector =
         new ReplicaGroupInstanceSelector(offlineTableName, propertyStore, brokerMetrics, hybridSelector,
-            Clock.systemUTC(), false, 300);
+            Clock.systemUTC(), INSTANCE_SELECTOR_CONFIG);
 
     // Define instances and segments
     String instance0 = "instance0";

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/MultiStageReplicaGroupSelectorTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/MultiStageReplicaGroupSelectorTest.java
@@ -212,7 +212,7 @@ public class MultiStageReplicaGroupSelectorTest {
   private MultiStageReplicaGroupSelector createMultiStageSelector(InstancePartitions instancePartitions) {
     MultiStageReplicaGroupSelector multiStageSelector =
         new MultiStageReplicaGroupSelector(TABLE_NAME, _propertyStore, _brokerMetrics, null, Clock.systemUTC(),
-            false, 300);
+            new InstanceSelectorConfig(false, 300, false));
     multiStageSelector = spy(multiStageSelector);
     doReturn(instancePartitions).when(multiStageSelector).getInstancePartitions();
     return multiStageSelector;

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerMeter.java
@@ -69,6 +69,12 @@ public class BrokerMeter implements AbstractMetrics.Meter {
    */
   public static final BrokerMeter POOL_SEG_QUERIES = create("POOL_SEG_QUERIES", "routing", false);
   /**
+   * Number of segments whose replicas are not distributed into multiple pools in ideal state.
+   * <p>
+   * This metric is not global and is attached to a particular table
+   */
+  public static final BrokerMeter SINGLE_POOL_SEGMENTS = create("SINGLE_POOL_SEGMENTS", "segments", false);
+  /**
    * Number of multi-stage queries that have been started.
    * <p>
    * Unlike {@link #MULTI_STAGE_QUERIES}, this metric is global and not attached to a particular table.

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -543,6 +543,11 @@ public class CommonConstants {
     public static final String CONFIG_OF_BROKER_DEFAULT_HASH_FUNCTION = "pinot.broker.multistage.default.hash.function";
     public static final String DEFAULT_BROKER_DEFAULT_HASH_FUNCTION = "absHashCode";
 
+    // Config for default single pool segments metric
+    public static final String CONFIG_OF_BROKER_ENABLE_SINGLE_POOL_SEGMENTS_METRIC =
+        "pinot.broker.enable.single.pool.segments.metric";
+    public static final boolean DEFAULT_ENABLE_SINGLE_POOL_SEGMENTS_METRIC = false;
+
     // When the server instance's pool field is null or the pool contains multi distinguished group value, the broker
     // would set the pool to -1 in the routing table for that server.
     public static final int FALLBACK_POOL_ID = -1;


### PR DESCRIPTION
Add a metric to track the number of segments whose replicas are colocated within the same server pool. To simplify integration, a server pool can be treated as equivalent to a failure domain or availability zone. Each pool is represented by an integer, allowing companies to define a 1:1 mapping between their failure domains (or zones) and pool IDs, which can then be injected when provisioning the Pinot Pod.

For example: the failure domain `isolation-group-100` (covering zones west-a and west-b) can be mapped to pool 0, the failure domain `isolation-group-101` (covering zone west-c) can be mapped to pool 1.

The method `updateSegmentMaps` will be called for every IdealState or ExternalView change. 
```
  public synchronized void processClusterChange(ChangeType changeType) {
    if (changeType == ChangeType.IDEAL_STATE || changeType == ChangeType.EXTERNAL_VIEW) {
      processSegmentAssignmentChange(); /*the updateSegmentMaps will be called by this method*/
    } else if (changeType == ChangeType.INSTANCE_CONFIG) {
      processInstanceConfigChange();
    } else {
      // NOTE: We don't track live instances change because that will be reflected through the external view change
      throw new IllegalArgumentException("Illegal change type: " + changeType);
    }
  }
```
The metric will be emitted only when pinot.broker.enable.single.pool.segments.metric=true
