### PR TITLE
fix: Add macOS ARM64 profiles for protobuf-maven-plugin with Homebrew support

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,27 +145,29 @@ More detailed instructions can be found at [Quick Demo](https://docs.pinot.apach
 
 If you're building Pinot on macOS and encounter issues with the gRPC Java plugin during the build process, you may need to configure the protobuf Maven plugin to use a specific executable path. This is a known issue on macOS ARM (Apple Silicon) systems.
 
-To resolve this, you can install the protobuf compiler and gRPC Java plugin globally:
+#### Automatic Profile Activation (macOS ARM64)
 
+Pinot's Maven build now includes dedicated profiles for Apple Silicon (ARM64) Macs to ensure reliable protobuf compilation with Homebrew-installed binaries:
+
+- **Primary profile:** Activates automatically if `/opt/homebrew/bin/protoc-gen-grpc-java` exists (default for Apple Silicon Macs).
+- **Fallback profile:** Activates if `/usr/local/bin/protoc-gen-grpc-java` exists and the primary path does not (for Intel Macs or custom Homebrew setups).
+
+You do **not** need to manually edit the `pom.xml` or set the plugin executable path. The correct profile will be selected based on your system and Homebrew installation.
+
+##### To install the required tools:
 ```bash
-# Install protobuf compiler
 brew install protobuf
 brew install protoc-gen-grpc-java
-sudo cp /opt/homebrew/bin/protoc-gen-grpc-java /usr/local/bin/protoc-gen-grpc-java
 ```
 
-Then add the following configuration to the `protobuf-maven-plugin` in the `pom.xml` file:
+If you installed Homebrew to a non-default location, ensure the `protoc-gen-grpc-java` binary is available in either `/opt/homebrew/bin/` or `/usr/local/bin/`.
 
-```xml
-<plugin>
-  <groupId>org.xolstice.maven.plugins</groupId>
-  <artifactId>protobuf-maven-plugin</artifactId>
-  <configuration>
-    ...
-    <pluginExecutable>/usr/local/bin/protoc-gen-grpc-java</pluginExecutable>
-  </configuration>
-</plugin>
+To verify which profile is active, run:
+```bash
+./mvnw help:active-profiles
 ```
+
+If you encounter issues, check that the `protoc-gen-grpc-java` binary is present in one of the expected locations and is executable.
 
 ## Deploying Pinot to Kubernetes
 Please refer to [Running Pinot on Kubernetes](https://docs.pinot.apache.org/basics/getting-started/kubernetes-quickstart) in our project documentation. Pinot also provides Kubernetes integrations with the interactive query engine, [Trino](https://docs.pinot.apache.org/integrations/trino) [Presto](https://docs.pinot.apache.org/integrations/presto), and the data visualization tool, [Apache Superset](helm/superset.yaml).

--- a/pom.xml
+++ b/pom.xml
@@ -421,6 +421,56 @@
         </plugins>
       </build>
     </profile>
+    <!-- Apple Silicon Mac with Homebrew for protoc -->
+    <profile>
+      <id>macos-arm64-protobuf-homebrew</id>
+      <activation>
+        <os>
+          <family>mac</family>
+          <arch>aarch64</arch>
+        </os>
+        <file>
+          <exists>/opt/homebrew/bin/protoc-gen-grpc-java</exists>
+        </file>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.xolstice.maven.plugins</groupId>
+            <artifactId>protobuf-maven-plugin</artifactId>
+            <configuration>
+              <pluginExecutable>/opt/homebrew/bin/protoc-gen-grpc-java</pluginExecutable>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
+    <!-- Apple Silicon Mac with Homebrew (fallback path) -->
+    <profile>
+      <id>macos-arm64-protobuf-homebrew-fallback</id>
+      <activation>
+        <os>
+          <family>mac</family>
+          <arch>aarch64</arch>
+        </os>
+        <file>
+          <exists>/usr/local/bin/protoc-gen-grpc-java</exists>
+          <missing>/opt/homebrew/bin/protoc-gen-grpc-java</missing>
+        </file>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.xolstice.maven.plugins</groupId>
+            <artifactId>protobuf-maven-plugin</artifactId>
+            <configuration>
+              <pluginExecutable>/usr/local/bin/protoc-gen-grpc-java</pluginExecutable>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
     <profile>
       <id>github-actions</id>
       <activation>
@@ -2323,14 +2373,6 @@
             <protocArtifact>com.google.protobuf:protoc:${protobuf.version}:exe:${os.detected.classifier}</protocArtifact>
             <pluginId>grpc-java</pluginId>
             <pluginArtifact>io.grpc:protoc-gen-grpc-java:${grpc.version}:exe:${os.detected.classifier}</pluginArtifact>
-            <!-- For macOS users: If you encounter gRPC Java plugin issues during build, install protobuf and gRPC Java plugin globally, then uncomment the line below:
-              ```bash
-              brew install protobuf
-              brew install protoc-gen-grpc-java
-              sudo cp /opt/homebrew/bin/protoc-gen-grpc-java /usr/local/bin/protoc-gen-grpc-java
-              ```
-            -->
-            <!-- <pluginExecutable>/usr/local/bin/protoc-gen-grpc-java</pluginExecutable> -->
           </configuration>
           <executions>
             <execution>


### PR DESCRIPTION
- Add dedicated Maven profiles for Apple Silicon Macs (ARM64) to handle protobuf compilation
- Configure separate profiles for different Homebrew installation paths:
  - Primary: /opt/homebrew/bin/protoc-gen-grpc-java (Apple Silicon default)
  - Fallback: /usr/local/bin/protoc-gen-grpc-java (Intel Mac or custom install)
- Remove outdated manual installation comments from main plugin configuration
- Fixes issue where Maven-downloaded gRPC Java plugin executable fails on macOS
- Ensures reliable protobuf compilation on macOS by using Homebrew-installed binaries

The profiles automatically activate when:
1. Running on macOS with ARM64 architecture
2. The corresponding protoc-gen-grpc-java executable exists in the expected path
