### PR TITLE
[pinot-adls] Add SAS token authentication support in ADLSGen2PinotFS

### DIFF
--- a/pinot-plugins/pinot-file-system/pinot-adls/src/test/java/org/apache/pinot/plugin/filesystem/test/ADLSGen2PinotFSTest.java
+++ b/pinot-plugins/pinot-file-system/pinot-adls/src/test/java/org/apache/pinot/plugin/filesystem/test/ADLSGen2PinotFSTest.java
@@ -116,6 +116,54 @@ public class ADLSGen2PinotFSTest {
   }
 
   @Test
+  public void testSasTokenAuthentication() {
+    PinotConfiguration pinotConfiguration = new PinotConfiguration();
+    pinotConfiguration.setProperty("authenticationType", "SAS_TOKEN");
+    pinotConfiguration.setProperty("sasToken", "sp=rwdl&se=2025-12-31T23:59:59Z&sv=2022-11-02&sr=c&sig=test");
+    pinotConfiguration.setProperty("accountName", "testaccount");
+    pinotConfiguration.setProperty("fileSystemName", "testcontainer");
+
+    when(_mockServiceClient.getFileSystemClient("testcontainer")).thenReturn(_mockFileSystemClient);
+    when(_mockFileSystemClient.getProperties()).thenReturn(null);
+
+    // Mock the creation of the service client
+    ADLSGen2PinotFS sasTokenFS = new ADLSGen2PinotFS() {
+      @Override
+      public DataLakeFileSystemClient getOrCreateClientWithFileSystem(DataLakeServiceClient serviceClient,
+          String fileSystemName) {
+        return _mockFileSystemClient;
+      }
+    };
+
+    sasTokenFS.init(pinotConfiguration);
+
+    // Verify that the filesystem client was set properly
+    assertTrue(sasTokenFS != null);
+  }
+
+  @Test(expectedExceptions = NullPointerException.class)
+  public void testSasTokenMissingToken() {
+    PinotConfiguration pinotConfiguration = new PinotConfiguration();
+    pinotConfiguration.setProperty("authenticationType", "SAS_TOKEN");
+    pinotConfiguration.setProperty("accountName", "testaccount");
+    pinotConfiguration.setProperty("fileSystemName", "testcontainer");
+    // Missing sasToken property
+
+    _adlsGen2PinotFsUnderTest.init(pinotConfiguration);
+  }
+
+  @Test(expectedExceptions = NullPointerException.class)
+  public void testSasTokenNullToken() {
+    PinotConfiguration pinotConfiguration = new PinotConfiguration();
+    pinotConfiguration.setProperty("authenticationType", "SAS_TOKEN");
+    pinotConfiguration.setProperty("sasToken", (String) null);
+    pinotConfiguration.setProperty("accountName", "testaccount");
+    pinotConfiguration.setProperty("fileSystemName", "testcontainer");
+
+    _adlsGen2PinotFsUnderTest.init(pinotConfiguration);
+  }
+
+  @Test
   public void testGetOrCreateClientWithFileSystemGet() {
     when(_mockServiceClient.getFileSystemClient(MOCK_FILE_SYSTEM_NAME)).thenReturn(_mockFileSystemClient);
     when(_mockFileSystemClient.getProperties()).thenReturn(null);


### PR DESCRIPTION
This PR adds support for SAS (Shared Access Signature) token authentication in the ADLSGen2PinotFS plugin, providing an additional authentication method for Azure Data Lake Storage Gen2.

  Changes Made:
  - Enhanced Authentication Options: Added SAS token authentication as a new authentication type alongside existing methods (default
  credential, client secret)
  - Configuration Support: Added sasToken configuration property to specify the SAS token
  - Added unit tests to verify SAS token authentication functionality and error handling


  Configuration Usage:

  To use SAS token authentication, configure the following properties:
```
  # Authentication type
  authenticationType=SAS_TOKEN

  # Required: SAS token for authentication
  sasToken=sp=rwdl&se=2025-12-31T23:59:59Z&sv=2022-11-02&sr=c&sig=your-signature-here

  # Required: Azure storage account name
  accountName=your-storage-account-name

  # Required: File system/container name
  fileSystemName=your-container-name

  # Optional: Proxy configuration (if needed)
  proxyHost=proxy.company.com
  proxyPort=8080
  proxyUsername=proxy-user
  proxyPassword=proxy-pass
```
  Example SAS Token Format:
```
  sp=rwdl&se=2025-12-31T23:59:59Z&sv=2022-11-02&sr=c&sig=abcdef123456...
```

  Where:
  - sp=rwdl - Permissions (read, write, delete, list)
  - se= - Expiry date/time
  - sv= - API version
  - sr=c - Resource type (container)
  - sig= - Signature

  Benefits:

  - Simplified Authentication: No need to manage service principal credentials or client secrets
  - Fine-grained Access: SAS tokens can be scoped to specific containers and operations
  - Time-bound Access: Built-in expiration for enhanced security
  - Corporate Friendly: Easier to integrate with corporate security policies

  Validation:

  The implementation includes proper validation to ensure required parameters (accountName, sasToken) are provided and throws appropriate
  exceptions when missing.