### PR TITLE
Fix rebalance logic to treat COMMITTING segments as CONSUMING

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/SegmentAssignmentUtils.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/SegmentAssignmentUtils.java
@@ -29,6 +29,8 @@ import java.util.Map;
 import java.util.PriorityQueue;
 import java.util.Set;
 import java.util.TreeMap;
+import javax.annotation.Nullable;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.helix.HelixManager;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
@@ -37,6 +39,7 @@ import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.tier.Tier;
 import org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.SegmentStateModel;
+import org.apache.pinot.spi.utils.CommonConstants.Segment.Realtime.Status;
 import org.apache.pinot.spi.utils.Pairs;
 
 
@@ -387,19 +390,38 @@ public class SegmentAssignmentUtils {
     private final Map<String, Map<String, String>> _offlineSegmentAssignment = new TreeMap<>();
 
     // NOTE: split the segments based on the following criteria:
-    //       1. At least one instance ONLINE -> COMPLETED segment
-    //       2. At least one instance CONSUMING -> CONSUMING segment
+    //       1. At least one instance ONLINE && segment is not COMMITTING -> COMPLETED segment
+    //       2. At least one instance CONSUMING || segment is COMMITTING -> CONSUMING segment
     //       3. All instances OFFLINE (all instances encountered error while consuming) -> OFFLINE segment
-    CompletedConsumingOfflineSegmentAssignment(Map<String, Map<String, String>> segmentAssignment) {
-      for (Map.Entry<String, Map<String, String>> entry : segmentAssignment.entrySet()) {
-        String segmentName = entry.getKey();
-        Map<String, String> instanceStateMap = entry.getValue();
-        if (instanceStateMap.containsValue(SegmentStateModel.ONLINE)) {
-          _completedSegmentAssignment.put(segmentName, instanceStateMap);
-        } else if (instanceStateMap.containsValue(SegmentStateModel.CONSUMING)) {
-          _consumingSegmentAssignment.put(segmentName, instanceStateMap);
-        } else {
-          _offlineSegmentAssignment.put(segmentName, instanceStateMap);
+    CompletedConsumingOfflineSegmentAssignment(Map<String, Map<String, String>> segmentAssignment,
+        @Nullable Set<String> committingSegments) {
+      if (CollectionUtils.isEmpty(committingSegments)) {
+        for (Map.Entry<String, Map<String, String>> entry : segmentAssignment.entrySet()) {
+          String segmentName = entry.getKey();
+          Map<String, String> instanceStateMap = entry.getValue();
+          if (instanceStateMap.containsValue(SegmentStateModel.ONLINE)) {
+            _completedSegmentAssignment.put(segmentName, instanceStateMap);
+          } else if (instanceStateMap.containsValue(SegmentStateModel.CONSUMING)) {
+            _consumingSegmentAssignment.put(segmentName, instanceStateMap);
+          } else {
+            _offlineSegmentAssignment.put(segmentName, instanceStateMap);
+          }
+        }
+      } else {
+        for (Map.Entry<String, Map<String, String>> entry : segmentAssignment.entrySet()) {
+          String segmentName = entry.getKey();
+          Map<String, String> instanceStateMap = entry.getValue();
+          if (instanceStateMap.containsValue(SegmentStateModel.ONLINE)) {
+            if (committingSegments.contains(segmentName)) {
+              _consumingSegmentAssignment.put(segmentName, instanceStateMap);
+            } else {
+              _completedSegmentAssignment.put(segmentName, instanceStateMap);
+            }
+          } else if (instanceStateMap.containsValue(SegmentStateModel.CONSUMING)) {
+            _consumingSegmentAssignment.put(segmentName, instanceStateMap);
+          } else {
+            _offlineSegmentAssignment.put(segmentName, instanceStateMap);
+          }
         }
       }
     }
@@ -452,7 +474,8 @@ public class SegmentAssignmentUtils {
           // find an eligible tier for the segment, from the ordered list of tiers
           SegmentZKMetadata segmentZKMetadata =
               ZKMetadataProvider.getSegmentZKMetadata(propertyStore, tableNameWithType, segmentName);
-          if (segmentZKMetadata != null) {
+          // Skip COMMITTING segments
+          if (segmentZKMetadata != null && segmentZKMetadata.getStatus() != Status.COMMITTING) {
             for (Tier tier : sortedTiers) {
               if (tier.getSegmentSelector().selectSegment(tableNameWithType, segmentZKMetadata)) {
                 _tierNameToSegmentAssignmentMap.get(tier.getName()).put(segmentName, instanceStateMap);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionManager.java
@@ -127,7 +127,6 @@ public class SegmentCompletionManager {
     String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(llcSegmentName.getTableName());
     String segmentName = llcSegmentName.getSegmentName();
     SegmentZKMetadata segmentMetadata = _segmentManager.getSegmentZKMetadata(realtimeTableName, segmentName, null);
-    Preconditions.checkState(segmentMetadata != null, "Failed to find ZK metadata for segment: %s", segmentName);
 
     TableConfig tableConfig = _segmentManager.getTableConfig(realtimeTableName);
     String factoryName = null;


### PR DESCRIPTION
For pauseless table, COMMITTING segment will be in ONLINE state.
This PR fixes the rebalance logic by treating COMMITTING segments as CONSUMING to avoid relocating COMMITTING segments because that can cause segments to be unavailable.