### PR TITLE
Avoid bytes copy in MessageDecoder

### DIFF
--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
@@ -80,8 +80,6 @@ import org.apache.pinot.spi.utils.CommonConstants.Server;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.NetUtils;
 import org.intellij.lang.annotations.Language;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.SkipException;
 import org.testng.annotations.DataProvider;
@@ -496,7 +494,6 @@ public abstract class ClusterTest extends ControllerTest {
   }
 
   public static class AvroFileSchemaKafkaAvroMessageDecoder implements StreamMessageDecoder<byte[]> {
-    private static final Logger LOGGER = LoggerFactory.getLogger(AvroFileSchemaKafkaAvroMessageDecoder.class);
     public static File _avroFile;
     private RecordExtractor<GenericRecord> _recordExtractor;
     private final DecoderFactory _decoderFactory = new DecoderFactory();
@@ -509,9 +506,6 @@ public abstract class ClusterTest extends ControllerTest {
       org.apache.avro.Schema avroSchema;
       try (DataFileStream<GenericRecord> reader = AvroUtils.getAvroReader(_avroFile)) {
         avroSchema = reader.getSchema();
-      } catch (Exception ex) {
-        LOGGER.error("Caught exception", ex);
-        throw new RuntimeException(ex);
       }
       AvroRecordExtractorConfig config = new AvroRecordExtractorConfig();
       config.init(props);
@@ -532,7 +526,6 @@ public abstract class ClusterTest extends ControllerTest {
             _reader.read(null, _decoderFactory.binaryDecoder(payload, offset, length, null));
         return _recordExtractor.extract(avroRecord, destination);
       } catch (Exception e) {
-        LOGGER.error("Caught exception", e);
         throw new RuntimeException(e);
       }
     }

--- a/pinot-plugins/pinot-input-format/pinot-avro/src/main/java/org/apache/pinot/plugin/inputformat/avro/SimpleAvroMessageDecoder.java
+++ b/pinot-plugins/pinot-input-format/pinot-avro/src/main/java/org/apache/pinot/plugin/inputformat/avro/SimpleAvroMessageDecoder.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.plugin.inputformat.avro;
 
 import com.google.common.base.Preconditions;
-import java.io.IOException;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.concurrent.NotThreadSafe;
@@ -33,8 +32,6 @@ import org.apache.pinot.spi.data.readers.RecordExtractor;
 import org.apache.pinot.spi.data.readers.RecordExtractorConfig;
 import org.apache.pinot.spi.plugin.PluginManager;
 import org.apache.pinot.spi.stream.StreamMessageDecoder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 /**
@@ -43,8 +40,6 @@ import org.slf4j.LoggerFactory;
  */
 @NotThreadSafe
 public class SimpleAvroMessageDecoder implements StreamMessageDecoder<byte[]> {
-  private static final Logger LOGGER = LoggerFactory.getLogger(SimpleAvroMessageDecoder.class);
-
   private static final String SCHEMA = "schema";
 
   private org.apache.avro.Schema _avroSchema;
@@ -95,9 +90,8 @@ public class SimpleAvroMessageDecoder implements StreamMessageDecoder<byte[]> {
     _binaryDecoderToReuse = DecoderFactory.get().binaryDecoder(payload, offset, length, _binaryDecoderToReuse);
     try {
       _avroRecordToReuse = _datumReader.read(_avroRecordToReuse, _binaryDecoderToReuse);
-    } catch (IOException e) {
-      LOGGER.error("Caught exception while reading message using schema: {}", _avroSchema, e);
-      return null;
+    } catch (Exception e) {
+      throw new RuntimeException("Caught exception while reading message using schema: " + _avroSchema, e);
     }
     return _avroRecordExtractor.extract(_avroRecordToReuse, destination);
   }

--- a/pinot-plugins/pinot-input-format/pinot-confluent-avro/src/main/java/org/apache/pinot/plugin/inputformat/avro/confluent/KafkaConfluentSchemaRegistryAvroMessageDecoder.java
+++ b/pinot-plugins/pinot-input-format/pinot-confluent-avro/src/main/java/org/apache/pinot/plugin/inputformat/avro/confluent/KafkaConfluentSchemaRegistryAvroMessageDecoder.java
@@ -27,6 +27,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nullable;
 import org.apache.avro.generic.GenericData.Record;
 import org.apache.kafka.common.config.ConfigDef;
 import org.apache.kafka.common.config.SslConfigs;
@@ -105,6 +106,7 @@ public class KafkaConfluentSchemaRegistryAvroMessageDecoder implements StreamMes
     _avroRecordExtractor.init(fieldsToRead, config);
   }
 
+  @Nullable
   @Override
   public GenericRow decode(byte[] payload, GenericRow destination) {
     try {
@@ -116,9 +118,13 @@ public class KafkaConfluentSchemaRegistryAvroMessageDecoder implements StreamMes
     }
   }
 
+  @Nullable
   @Override
   public GenericRow decode(byte[] payload, int offset, int length, GenericRow destination) {
-    return decode(Arrays.copyOfRange(payload, offset, offset + length), destination);
+    if (offset != 0 || payload.length > length) {
+      payload = Arrays.copyOfRange(payload, offset, offset + length);
+    }
+    return decode(payload, destination);
   }
 
   /**

--- a/pinot-plugins/pinot-input-format/pinot-confluent-json/src/main/java/org/apache/pinot/plugin/inputformat/json/confluent/KafkaConfluentSchemaRegistryJsonMessageDecoder.java
+++ b/pinot-plugins/pinot-input-format/pinot-confluent-json/src/main/java/org/apache/pinot/plugin/inputformat/json/confluent/KafkaConfluentSchemaRegistryJsonMessageDecoder.java
@@ -128,6 +128,7 @@ public class KafkaConfluentSchemaRegistryJsonMessageDecoder implements StreamMes
     _jsonRecordExtractor.init(fieldsToRead, null);
   }
 
+  @Nullable
   @Override
   public GenericRow decode(byte[] payload, GenericRow destination) {
     try {
@@ -140,9 +141,13 @@ public class KafkaConfluentSchemaRegistryJsonMessageDecoder implements StreamMes
     }
   }
 
+  @Nullable
   @Override
   public GenericRow decode(byte[] payload, int offset, int length, GenericRow destination) {
-    return decode(Arrays.copyOfRange(payload, offset, offset + length), destination);
+    if (offset != 0 || payload.length > length) {
+      payload = Arrays.copyOfRange(payload, offset, offset + length);
+    }
+    return decode(payload, destination);
   }
 
   /**

--- a/pinot-plugins/pinot-input-format/pinot-confluent-protobuf/src/main/java/org/apache/pinot/plugin/inputformat/protobuf/KafkaConfluentSchemaRegistryProtoBufMessageDecoder.java
+++ b/pinot-plugins/pinot-input-format/pinot-confluent-protobuf/src/main/java/org/apache/pinot/plugin/inputformat/protobuf/KafkaConfluentSchemaRegistryProtoBufMessageDecoder.java
@@ -126,6 +126,7 @@ public class KafkaConfluentSchemaRegistryProtoBufMessageDecoder implements Strea
     _protoBufRecordExtractor.init(fieldsToRead, null);
   }
 
+  @Nullable
   @Override
   public GenericRow decode(byte[] payload, GenericRow destination) {
     try {
@@ -140,9 +141,13 @@ public class KafkaConfluentSchemaRegistryProtoBufMessageDecoder implements Strea
     }
   }
 
+  @Nullable
   @Override
   public GenericRow decode(byte[] payload, int offset, int length, GenericRow destination) {
-    return decode(Arrays.copyOfRange(payload, offset, offset + length), destination);
+    if (offset != 0 || payload.length > length) {
+      payload = Arrays.copyOfRange(payload, offset, offset + length);
+    }
+    return decode(payload, destination);
   }
 
   /**

--- a/pinot-plugins/pinot-input-format/pinot-csv/src/test/java/org/apache/pinot/plugin/inputformat/csv/CSVMessageDecoderTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-csv/src/test/java/org/apache/pinot/plugin/inputformat/csv/CSVMessageDecoderTest.java
@@ -73,7 +73,7 @@ public class CSVMessageDecoderTest {
     assertEquals(destination.getValue("subjects"), new String[]{"maths", "German", "history"});
   }
 
-  @Test(expectedExceptions = java.util.NoSuchElementException.class)
+  @Test(expectedExceptions = RuntimeException.class)
   public void testCommentMarker()
       throws Exception {
     Map<String, String> decoderProps = getStandardDecoderProps();

--- a/pinot-plugins/pinot-input-format/pinot-json/src/main/java/org/apache/pinot/plugin/inputformat/json/JSONMessageDecoder.java
+++ b/pinot-plugins/pinot-input-format/pinot-json/src/main/java/org/apache/pinot/plugin/inputformat/json/JSONMessageDecoder.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.plugin.inputformat.json;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import java.util.Arrays;
 import java.util.Map;
 import java.util.Set;
 import org.apache.pinot.spi.data.readers.GenericRow;
@@ -27,15 +26,12 @@ import org.apache.pinot.spi.data.readers.RecordExtractor;
 import org.apache.pinot.spi.plugin.PluginManager;
 import org.apache.pinot.spi.stream.StreamMessageDecoder;
 import org.apache.pinot.spi.utils.JsonUtils;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 /**
  * An implementation of StreamMessageDecoder to read JSON records from a stream.
  */
 public class JSONMessageDecoder implements StreamMessageDecoder<byte[]> {
-  private static final Logger LOGGER = LoggerFactory.getLogger(JSONMessageDecoder.class);
   private static final String JSON_RECORD_EXTRACTOR_CLASS =
       "org.apache.pinot.plugin.inputformat.json.JSONRecordExtractor";
 
@@ -57,19 +53,17 @@ public class JSONMessageDecoder implements StreamMessageDecoder<byte[]> {
 
   @Override
   public GenericRow decode(byte[] payload, GenericRow destination) {
-    try {
-      JsonNode message = JsonUtils.bytesToJsonNode(payload);
-      Map<String, Object> from = JsonUtils.jsonNodeToMap(message);
-      _jsonRecordExtractor.extract(from, destination);
-      return destination;
-    } catch (Exception e) {
-      LOGGER.error("Caught exception while decoding row, discarding row. Payload is {}", new String(payload), e);
-      return null;
-    }
+    return decode(payload, 0, payload.length, destination);
   }
 
   @Override
   public GenericRow decode(byte[] payload, int offset, int length, GenericRow destination) {
-    return decode(Arrays.copyOfRange(payload, offset, offset + length), destination);
+    try {
+      JsonNode message = JsonUtils.bytesToJsonNode(payload, offset, length);
+      return _jsonRecordExtractor.extract(JsonUtils.jsonNodeToMap(message), destination);
+    } catch (Exception e) {
+      throw new RuntimeException(
+          "Caught exception while decoding JSON record with payload: " + new String(payload, offset, length), e);
+    }
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.BiConsumer;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.tier.TierFactory;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.segment.spi.Constants;
@@ -3099,11 +3100,13 @@ public class TableConfigUtilsTest {
     public void init(Map<String, String> props, Set<String> fieldsToRead, String topicName) {
     }
 
+    @Nullable
     @Override
     public GenericRow decode(byte[] payload, GenericRow destination) {
       return null;
     }
 
+    @Nullable
     @Override
     public GenericRow decode(byte[] payload, int offset, int length, GenericRow destination) {
       return null;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamDataDecoderImpl.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamDataDecoderImpl.java
@@ -19,11 +19,13 @@
 package org.apache.pinot.spi.stream;
 
 import java.nio.charset.StandardCharsets;
+import java.util.Map;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class StreamDataDecoderImpl implements StreamDataDecoder {
   private static final Logger LOGGER = LoggerFactory.getLogger(StreamDataDecoderImpl.class);
 
@@ -48,25 +50,27 @@ public class StreamDataDecoderImpl implements StreamDataDecoder {
 
   @Override
   public StreamDataDecoderResult decode(StreamMessage message) {
-    assert message.getValue() != null;
-
     try {
       _reuse.clear();
-      GenericRow row = _valueDecoder.decode(message.getValue(), 0, message.getLength(), _reuse);
+      Object value = message.getValue();
+      assert value != null;
+      int length = message.getLength();
+      GenericRow row = _valueDecoder.decode(value, 0, length, _reuse);
       if (row != null) {
         if (message.getKey() != null) {
           row.putValue(KEY, new String(message.getKey(), StandardCharsets.UTF_8));
         }
         StreamMessageMetadata metadata = message.getMetadata();
         if (metadata != null) {
-          if (metadata.getHeaders() != null) {
-            metadata.getHeaders().getFieldToValueMap()
-                .forEach((key, value) -> row.putValue(HEADER_KEY_PREFIX + key, value));
+          GenericRow headers = metadata.getHeaders();
+          if (headers != null) {
+            headers.getFieldToValueMap().forEach((k, v) -> row.putValue(HEADER_KEY_PREFIX + k, v));
           }
-          if (metadata.getRecordMetadata() != null) {
-            metadata.getRecordMetadata().forEach((key, value) -> row.putValue(METADATA_KEY_PREFIX + key, value));
+          Map<String, String> recordMetadata = metadata.getRecordMetadata();
+          if (recordMetadata != null) {
+            recordMetadata.forEach((k, v) -> row.putValue(METADATA_KEY_PREFIX + k, v));
           }
-          row.putValue(RECORD_SERIALIZED_VALUE_SIZE_KEY, message.getLength());
+          row.putValue(RECORD_SERIALIZED_VALUE_SIZE_KEY, length);
         }
         return new StreamDataDecoderResult(row, null);
       } else {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/JsonUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/JsonUtils.java
@@ -223,6 +223,11 @@ public class JsonUtils {
     return DEFAULT_READER.readTree(new ByteArrayInputStream(jsonBytes));
   }
 
+  public static JsonNode bytesToJsonNode(byte[] jsonBytes, int offset, int length)
+      throws IOException {
+    return DEFAULT_READER.readTree(new ByteArrayInputStream(jsonBytes, offset, length));
+  }
+
   public static <T> T jsonNodeToObject(JsonNode jsonNode, Class<T> valueType)
       throws IOException {
     return DEFAULT_READER.forType(valueType).readValue(jsonNode);

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/stream/StreamDataDecoderImplTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/stream/StreamDataDecoderImplTest.java
@@ -35,8 +35,7 @@ public class StreamDataDecoderImplTest {
   private static final String SEQNO_RECORD_METADATA = "seqNo";
 
   @Test
-  public void testDecodeValueOnly()
-      throws Exception {
+  public void testDecodeValueOnly() {
     TestDecoder messageDecoder = new TestDecoder();
     messageDecoder.init(Collections.emptyMap(), ImmutableSet.of(NAME_FIELD), "");
     String value = "Alice";
@@ -52,8 +51,7 @@ public class StreamDataDecoderImplTest {
   }
 
   @Test
-  public void testDecodeKeyAndHeaders()
-      throws Exception {
+  public void testDecodeKeyAndHeaders() {
     TestDecoder messageDecoder = new TestDecoder();
     messageDecoder.init(Collections.emptyMap(), ImmutableSet.of(NAME_FIELD), "");
     String value = "Alice";
@@ -80,8 +78,7 @@ public class StreamDataDecoderImplTest {
   }
 
   @Test
-  public void testNoExceptionIsThrown()
-      throws Exception {
+  public void testNoExceptionIsThrown() {
     ThrowingDecoder messageDecoder = new ThrowingDecoder();
     messageDecoder.init(Collections.emptyMap(), ImmutableSet.of(NAME_FIELD), "");
     String value = "Alice";
@@ -92,11 +89,10 @@ public class StreamDataDecoderImplTest {
     Assert.assertNull(result.getResult());
   }
 
-  class ThrowingDecoder implements StreamMessageDecoder<byte[]> {
+  private static class ThrowingDecoder implements StreamMessageDecoder<byte[]> {
 
     @Override
-    public void init(Map<String, String> props, Set<String> fieldsToRead, String topicName)
-        throws Exception {
+    public void init(Map<String, String> props, Set<String> fieldsToRead, String topicName) {
     }
 
     @Nullable
@@ -108,24 +104,21 @@ public class StreamDataDecoderImplTest {
     @Nullable
     @Override
     public GenericRow decode(byte[] payload, int offset, int length, GenericRow destination) {
-      return decode(payload, destination);
+      throw new RuntimeException("something failed during decoding");
     }
   }
 
-  class TestDecoder implements StreamMessageDecoder<byte[]> {
+  private static class TestDecoder implements StreamMessageDecoder<byte[]> {
     @Override
-    public void init(Map<String, String> props, Set<String> fieldsToRead, String topicName)
-        throws Exception {
+    public void init(Map<String, String> props, Set<String> fieldsToRead, String topicName) {
     }
 
-    @Nullable
     @Override
     public GenericRow decode(byte[] payload, GenericRow destination) {
       destination.putValue(NAME_FIELD, new String(payload, StandardCharsets.UTF_8));
       return destination;
     }
 
-    @Nullable
     @Override
     public GenericRow decode(byte[] payload, int offset, int length, GenericRow destination) {
       return decode(payload, destination);


### PR DESCRIPTION
Avoid bytes copy in `StreamMessageDecoder` when payload length matches passed in length.
Also improve the exception handling for some decoders.

TODO: Revisit consumer implementations to see if we can ever generate `StreamMessage`s with different payload length and message length