### PR TITLE
Remove all calls to System.gc() in PerQueryCPUMemAccountantFactory

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/accounting/PerQueryCPUMemAccountantFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/accounting/PerQueryCPUMemAccountantFactory.java
@@ -160,6 +160,7 @@ public class PerQueryCPUMemAccountantFactory implements ThreadAccountantFactory 
       _instanceType = instanceType;
       _cancelSentQueries = new HashSet<>();
       _watcherTask = createWatcherTask();
+      _queryCancelCallbacks = CacheBuilder.newBuilder().build();
     }
 
     public PerQueryCPUMemResourceUsageAccountant(PinotConfiguration config, String instanceId,

--- a/pinot-core/src/main/java/org/apache/pinot/core/accounting/QueryMonitorConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/accounting/QueryMonitorConfig.java
@@ -36,27 +36,11 @@ public class QueryMonitorConfig {
   // kill the most expensive query if heap usage exceeds this
   private final long _criticalLevel;
 
-  // if after gc the heap usage is still above this, kill the most expensive query
-  // use this to prevent heap size oscillation and repeatedly triggering gc
-  private final long _criticalLevelAfterGC;
-
-  // trigger gc if consecutively kill more than some number of queries
-  // set this to 0 to always trigger gc before killing a query to give gc a second chance
-  // as would minimize the chance of false positive killing in some usecases
-  // should consider use -XX:+ExplicitGCInvokesConcurrent to avoid STW for some gc algorithms
-  private final int _gcBackoffCount;
-
   // start to sample more frequently if heap usage exceeds this
   private final long _alarmingLevel;
 
   // normal sleep time
   private final int _normalSleepTime;
-
-  // wait for gc to complete, according to system.gc() javadoc, when control returns from the method call,
-  // the Java Virtual Machine has made a best effort to reclaim space from all discarded objects.
-  // Therefore, we default this to 0.
-  // Tested with Shenandoah GC and G1GC, with -XX:+ExplicitGCInvokesConcurrent
-  private final int _gcWaitTime;
 
   // alarming sleep time denominator, should be > 1 to sample more frequent at alarming level
   private final int _alarmingSleepTimeDenominator;
@@ -94,22 +78,12 @@ public class QueryMonitorConfig {
         (long) (maxHeapSize * config.getProperty(CommonConstants.Accounting.CONFIG_OF_CRITICAL_LEVEL_HEAP_USAGE_RATIO,
             CommonConstants.Accounting.DEFAULT_CRITICAL_LEVEL_HEAP_USAGE_RATIO));
 
-    _criticalLevelAfterGC = _criticalLevel - (long) (maxHeapSize * config.getProperty(
-        CommonConstants.Accounting.CONFIG_OF_CRITICAL_LEVEL_HEAP_USAGE_RATIO_DELTA_AFTER_GC,
-        CommonConstants.Accounting.DEFAULT_CONFIG_OF_CRITICAL_LEVEL_HEAP_USAGE_RATIO_DELTA_AFTER_GC));
-
-    _gcBackoffCount = config.getProperty(CommonConstants.Accounting.CONFIG_OF_GC_BACKOFF_COUNT,
-        CommonConstants.Accounting.DEFAULT_GC_BACKOFF_COUNT);
-
     _alarmingLevel =
         (long) (maxHeapSize * config.getProperty(CommonConstants.Accounting.CONFIG_OF_ALARMING_LEVEL_HEAP_USAGE_RATIO,
             CommonConstants.Accounting.DEFAULT_ALARMING_LEVEL_HEAP_USAGE_RATIO));
 
     _normalSleepTime = config.getProperty(CommonConstants.Accounting.CONFIG_OF_SLEEP_TIME_MS,
         CommonConstants.Accounting.DEFAULT_SLEEP_TIME_MS);
-
-    _gcWaitTime = config.getProperty(CommonConstants.Accounting.CONFIG_OF_GC_WAIT_TIME_MS,
-        CommonConstants.Accounting.DEFAULT_CONFIG_OF_GC_WAIT_TIME_MS);
 
     _alarmingSleepTimeDenominator = config.getProperty(CommonConstants.Accounting.CONFIG_OF_SLEEP_TIME_DENOMINATOR,
         CommonConstants.Accounting.DEFAULT_SLEEP_TIME_DENOMINATOR);
@@ -174,30 +148,6 @@ public class QueryMonitorConfig {
       _criticalLevel = oldConfig._criticalLevel;
     }
 
-    if (changedConfigs.contains(CommonConstants.Accounting.CONFIG_OF_CRITICAL_LEVEL_HEAP_USAGE_RATIO_DELTA_AFTER_GC)) {
-      if (clusterConfigs == null || !clusterConfigs.containsKey(
-          CommonConstants.Accounting.CONFIG_OF_CRITICAL_LEVEL_HEAP_USAGE_RATIO_DELTA_AFTER_GC)) {
-        _criticalLevelAfterGC = _criticalLevel - (long) (_maxHeapSize
-            * CommonConstants.Accounting.DEFAULT_CONFIG_OF_CRITICAL_LEVEL_HEAP_USAGE_RATIO_DELTA_AFTER_GC);
-      } else {
-        _criticalLevelAfterGC = _criticalLevel - (long) (_maxHeapSize * Double.parseDouble(
-            clusterConfigs.get(CommonConstants.Accounting.CONFIG_OF_CRITICAL_LEVEL_HEAP_USAGE_RATIO_DELTA_AFTER_GC)));
-      }
-    } else {
-      _criticalLevelAfterGC = oldConfig._criticalLevelAfterGC;
-    }
-
-    if (changedConfigs.contains(CommonConstants.Accounting.CONFIG_OF_GC_BACKOFF_COUNT)) {
-      if (clusterConfigs == null || !clusterConfigs.containsKey(
-          CommonConstants.Accounting.CONFIG_OF_GC_BACKOFF_COUNT)) {
-        _gcBackoffCount = CommonConstants.Accounting.DEFAULT_GC_BACKOFF_COUNT;
-      } else {
-        _gcBackoffCount = Integer.parseInt(clusterConfigs.get(CommonConstants.Accounting.CONFIG_OF_GC_BACKOFF_COUNT));
-      }
-    } else {
-      _gcBackoffCount = oldConfig._gcBackoffCount;
-    }
-
     if (changedConfigs.contains(CommonConstants.Accounting.CONFIG_OF_ALARMING_LEVEL_HEAP_USAGE_RATIO)) {
       if (clusterConfigs == null || !clusterConfigs.containsKey(
           CommonConstants.Accounting.CONFIG_OF_ALARMING_LEVEL_HEAP_USAGE_RATIO)) {
@@ -218,16 +168,6 @@ public class QueryMonitorConfig {
       }
     } else {
       _normalSleepTime = oldConfig._normalSleepTime;
-    }
-
-    if (changedConfigs.contains(CommonConstants.Accounting.CONFIG_OF_GC_WAIT_TIME_MS)) {
-      if (clusterConfigs == null || !clusterConfigs.containsKey(CommonConstants.Accounting.CONFIG_OF_GC_WAIT_TIME_MS)) {
-        _gcWaitTime = CommonConstants.Accounting.DEFAULT_CONFIG_OF_GC_WAIT_TIME_MS;
-      } else {
-        _gcWaitTime = Integer.parseInt(clusterConfigs.get(CommonConstants.Accounting.CONFIG_OF_GC_WAIT_TIME_MS));
-      }
-    } else {
-      _gcWaitTime = oldConfig._gcWaitTime;
     }
 
     if (changedConfigs.contains(CommonConstants.Accounting.CONFIG_OF_SLEEP_TIME_DENOMINATOR)) {
@@ -323,24 +263,12 @@ public class QueryMonitorConfig {
     return _criticalLevel;
   }
 
-  public long getCriticalLevelAfterGC() {
-    return _criticalLevelAfterGC;
-  }
-
-  public int getGcBackoffCount() {
-    return _gcBackoffCount;
-  }
-
   public long getAlarmingLevel() {
     return _alarmingLevel;
   }
 
   public int getNormalSleepTime() {
     return _normalSleepTime;
-  }
-
-  public int getGcWaitTime() {
-    return _gcWaitTime;
   }
 
   public int getAlarmingSleepTime() {

--- a/pinot-core/src/test/java/org/apache/pinot/core/accounting/QueryMonitorConfigTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/accounting/QueryMonitorConfigTest.java
@@ -36,11 +36,8 @@ public class QueryMonitorConfigTest {
   private static final double EXPECTED_MIN_MEMORY_FOOTPRINT_FOR_KILL = 0.05;
   private static final double EXPECTED_PANIC_LEVEL = 0.9f;
   private static final double EXPECTED_CRITICAL_LEVEL = 0.95f;
-  private static final double EXPECTED_CRITICAL_LEVEL_AFTER_GC = 0.05f;
-  private static final int EXPECTED_GC_BACKOFF_COUNT = 3;
   private static final double EXPECTED_ALARMING_LEVEL = 0.8f;
   private static final int EXPECTED_NORMAL_SLEEP_TIME = 50;
-  private static final int EXPECTED_GC_WAIT_TIME = 1000;
   private static final int EXPECTED_ALARMING_SLEEP_TIME_DENOMINATOR = 2;
   private static final boolean EXPECTED_OOM_KILL_QUERY_ENABLED = true;
   private static final boolean EXPECTED_PUBLISH_HEAP_USAGE_METRIC = true;
@@ -70,9 +67,6 @@ public class QueryMonitorConfigTest {
     CLUSTER_CONFIGS.put(
         getFullyQualifiedConfigName(CommonConstants.Accounting.CONFIG_OF_CRITICAL_LEVEL_HEAP_USAGE_RATIO),
         Double.toString(EXPECTED_CRITICAL_LEVEL));
-    CLUSTER_CONFIGS.put(getFullyQualifiedConfigName(
-            CommonConstants.Accounting.CONFIG_OF_CRITICAL_LEVEL_HEAP_USAGE_RATIO_DELTA_AFTER_GC),
-        Double.toString(EXPECTED_CRITICAL_LEVEL_AFTER_GC));
     CLUSTER_CONFIGS.put(
         getFullyQualifiedConfigName(CommonConstants.Accounting.CONFIG_OF_ALARMING_LEVEL_HEAP_USAGE_RATIO),
         Double.toString(EXPECTED_ALARMING_LEVEL));
@@ -83,10 +77,6 @@ public class QueryMonitorConfigTest {
     CLUSTER_CONFIGS.put(
         getFullyQualifiedConfigName(CommonConstants.Accounting.CONFIG_OF_MIN_MEMORY_FOOTPRINT_TO_KILL_RATIO),
         Double.toString(EXPECTED_MIN_MEMORY_FOOTPRINT_FOR_KILL));
-    CLUSTER_CONFIGS.put(getFullyQualifiedConfigName(CommonConstants.Accounting.CONFIG_OF_GC_BACKOFF_COUNT),
-        Integer.toString(EXPECTED_GC_BACKOFF_COUNT));
-    CLUSTER_CONFIGS.put(getFullyQualifiedConfigName(CommonConstants.Accounting.CONFIG_OF_GC_WAIT_TIME_MS),
-        Integer.toString(EXPECTED_GC_WAIT_TIME));
     CLUSTER_CONFIGS.put(getFullyQualifiedConfigName(CommonConstants.Accounting.CONFIG_OF_QUERY_KILLED_METRIC_ENABLED),
         Boolean.toString(EXPECTED_IS_QUERY_KILLED_METRIC_ENABLED));
   }
@@ -178,23 +168,6 @@ public class QueryMonitorConfigTest {
   }
 
   @Test
-  void testCriticalLevelHeapUsageRatioDeltaAfterGCConfigChange() {
-    PerQueryCPUMemAccountantFactory.PerQueryCPUMemResourceUsageAccountant accountant =
-        new PerQueryCPUMemAccountantFactory.PerQueryCPUMemResourceUsageAccountant(new PinotConfiguration(), "test",
-            InstanceType.SERVER);
-
-    assertEquals(accountant.getWatcherTask().getQueryMonitorConfig().getCriticalLevelAfterGC(),
-        accountant.getWatcherTask().getQueryMonitorConfig().getCriticalLevel()
-            - CommonConstants.Accounting.DEFAULT_CONFIG_OF_CRITICAL_LEVEL_HEAP_USAGE_RATIO_DELTA_AFTER_GC
-            * accountant.getWatcherTask().getQueryMonitorConfig().getMaxHeapSize());
-    accountant.getWatcherTask().onChange(Set.of(getFullyQualifiedConfigName(
-        CommonConstants.Accounting.CONFIG_OF_CRITICAL_LEVEL_HEAP_USAGE_RATIO_DELTA_AFTER_GC)), CLUSTER_CONFIGS);
-    assertEquals(accountant.getWatcherTask().getQueryMonitorConfig().getCriticalLevelAfterGC(),
-        accountant.getWatcherTask().getQueryMonitorConfig().getCriticalLevel()
-            - EXPECTED_CRITICAL_LEVEL_AFTER_GC * accountant.getWatcherTask().getQueryMonitorConfig().getMaxHeapSize());
-  }
-
-  @Test
   void testAlarmingLevelHeapUsageRatioConfigChange() {
     PerQueryCPUMemAccountantFactory.PerQueryCPUMemResourceUsageAccountant accountant =
         new PerQueryCPUMemAccountantFactory.PerQueryCPUMemResourceUsageAccountant(new PinotConfiguration(), "test",
@@ -256,34 +229,6 @@ public class QueryMonitorConfigTest {
     assertEquals(accountant.getWatcherTask().getQueryMonitorConfig().getMinMemoryFootprintForKill(),
         (long) (EXPECTED_MIN_MEMORY_FOOTPRINT_FOR_KILL * accountant.getWatcherTask().getQueryMonitorConfig()
             .getMaxHeapSize()));
-  }
-
-  @Test
-  void testGCBackoffCountConfigChange() {
-    PerQueryCPUMemAccountantFactory.PerQueryCPUMemResourceUsageAccountant accountant =
-        new PerQueryCPUMemAccountantFactory.PerQueryCPUMemResourceUsageAccountant(new PinotConfiguration(), "test",
-            InstanceType.SERVER);
-
-    assertEquals(accountant.getWatcherTask().getQueryMonitorConfig().getGcBackoffCount(),
-        CommonConstants.Accounting.DEFAULT_GC_BACKOFF_COUNT);
-    accountant.getWatcherTask()
-        .onChange(Set.of(getFullyQualifiedConfigName(CommonConstants.Accounting.CONFIG_OF_GC_BACKOFF_COUNT)),
-            CLUSTER_CONFIGS);
-    assertEquals(accountant.getWatcherTask().getQueryMonitorConfig().getGcBackoffCount(), EXPECTED_GC_BACKOFF_COUNT);
-  }
-
-  @Test
-  void testGCWaitTimeConfigChange() {
-    PerQueryCPUMemAccountantFactory.PerQueryCPUMemResourceUsageAccountant accountant =
-        new PerQueryCPUMemAccountantFactory.PerQueryCPUMemResourceUsageAccountant(new PinotConfiguration(), "test",
-            InstanceType.SERVER);
-
-    assertEquals(accountant.getWatcherTask().getQueryMonitorConfig().getGcWaitTime(),
-        CommonConstants.Accounting.DEFAULT_CONFIG_OF_GC_WAIT_TIME_MS);
-    accountant.getWatcherTask()
-        .onChange(Set.of(getFullyQualifiedConfigName(CommonConstants.Accounting.CONFIG_OF_GC_WAIT_TIME_MS)),
-            CLUSTER_CONFIGS);
-    assertEquals(accountant.getWatcherTask().getQueryMonitorConfig().getGcWaitTime(), EXPECTED_GC_WAIT_TIME);
   }
 
   @Test


### PR DESCRIPTION
Calls to System.gc() force a GC pause and is not recommended. From experience such a call can worsen the state of the system rather than help.

A small unrelated changed to log if the accountant used a callback to cancel is also in this PR.

Closes #16373