### PR TITLE
Queries now self terminate if in panic mode.

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/accounting/PerQueryCPUMemAccountantFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/accounting/PerQueryCPUMemAccountantFactory.java
@@ -322,12 +322,6 @@ public class PerQueryCPUMemAccountantFactory implements ThreadAccountantFactory 
 
     @Override
     public boolean isQueryTerminated() {
-      if (isAnchorThreadInterrupted()) {
-        // If the anchor thread is interrupted, then terminate
-        LOGGER.warn("Anchor thread is interrupted, self-terminating");
-        return true;
-      }
-
       QueryMonitorConfig config = _watcherTask.getQueryMonitorConfig();
       // Short-circuit when not in critical stage.
       if (!config.isThreadSelfTerminate() || _watcherTask.getHeapUsageBytes() < config.getCriticalLevel()) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/accounting/PerQueryCPUMemAccountantFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/accounting/PerQueryCPUMemAccountantFactory.java
@@ -317,6 +317,13 @@ public class PerQueryCPUMemAccountantFactory implements ThreadAccountantFactory 
     }
 
     @Override
+    public boolean isQueryTerminated() {
+      QueryMonitorConfig config = _watcherTask.getQueryMonitorConfig();
+      return isAnchorThreadInterrupted() ||
+          (config.isThreadSelfTerminateOnPanic() && _watcherTask.getHeapUsageBytes() > config.getPanicLevel());
+    }
+
+    @Override
     @Deprecated
     public void createExecutionContext(String queryId, int taskId, ThreadExecutionContext.TaskType taskType,
         @Nullable ThreadExecutionContext parentContext) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/accounting/QueryMonitorConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/accounting/QueryMonitorConfig.java
@@ -62,6 +62,8 @@ public class QueryMonitorConfig {
 
   private final boolean _isQueryKilledMetricEnabled;
 
+  private final boolean _isThreadSelfTerminateOnPanic;
+
   public QueryMonitorConfig(PinotConfiguration config, long maxHeapSize) {
     _maxHeapSize = maxHeapSize;
 
@@ -106,6 +108,9 @@ public class QueryMonitorConfig {
 
     _isQueryKilledMetricEnabled = config.getProperty(CommonConstants.Accounting.CONFIG_OF_QUERY_KILLED_METRIC_ENABLED,
         CommonConstants.Accounting.DEFAULT_QUERY_KILLED_METRIC_ENABLED);
+
+    _isThreadSelfTerminateOnPanic = config.getProperty(CommonConstants.Accounting.CONFIG_OF_THREAD_SELF_TERMINATE_IN_PANIC_MODE,
+        CommonConstants.Accounting.DEFAULT_THREAD_SELF_TERMINATE_IN_PANIC_MODE);
   }
 
   QueryMonitorConfig(QueryMonitorConfig oldConfig, Set<String> changedConfigs, Map<String, String> clusterConfigs) {
@@ -245,6 +250,18 @@ public class QueryMonitorConfig {
     } else {
       _isQueryKilledMetricEnabled = oldConfig._isQueryKilledMetricEnabled;
     }
+
+    if (changedConfigs.contains(CommonConstants.Accounting.CONFIG_OF_THREAD_SELF_TERMINATE_IN_PANIC_MODE)) {
+      if (clusterConfigs == null || !clusterConfigs.containsKey(
+          CommonConstants.Accounting.CONFIG_OF_THREAD_SELF_TERMINATE_IN_PANIC_MODE)) {
+        _isThreadSelfTerminateOnPanic = CommonConstants.Accounting.DEFAULT_THREAD_SELF_TERMINATE_IN_PANIC_MODE;
+      } else {
+        _isThreadSelfTerminateOnPanic =
+            Boolean.parseBoolean(clusterConfigs.get(CommonConstants.Accounting.CONFIG_OF_THREAD_SELF_TERMINATE_IN_PANIC_MODE));
+      }
+    } else {
+      _isThreadSelfTerminateOnPanic = oldConfig._isThreadSelfTerminateOnPanic;
+    }
   }
 
   public long getMaxHeapSize() {
@@ -293,5 +310,9 @@ public class QueryMonitorConfig {
 
   public boolean isQueryKilledMetricEnabled() {
     return _isQueryKilledMetricEnabled;
+  }
+
+  public boolean isThreadSelfTerminateOnPanic() {
+    return _isThreadSelfTerminateOnPanic;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/accounting/QueryMonitorConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/accounting/QueryMonitorConfig.java
@@ -62,7 +62,7 @@ public class QueryMonitorConfig {
 
   private final boolean _isQueryKilledMetricEnabled;
 
-  private final boolean _isThreadSelfTerminateOnPanic;
+  private final boolean _isThreadSelfTerminate;
 
   public QueryMonitorConfig(PinotConfiguration config, long maxHeapSize) {
     _maxHeapSize = maxHeapSize;
@@ -109,8 +109,8 @@ public class QueryMonitorConfig {
     _isQueryKilledMetricEnabled = config.getProperty(CommonConstants.Accounting.CONFIG_OF_QUERY_KILLED_METRIC_ENABLED,
         CommonConstants.Accounting.DEFAULT_QUERY_KILLED_METRIC_ENABLED);
 
-    _isThreadSelfTerminateOnPanic = config.getProperty(CommonConstants.Accounting.CONFIG_OF_THREAD_SELF_TERMINATE_IN_PANIC_MODE,
-        CommonConstants.Accounting.DEFAULT_THREAD_SELF_TERMINATE_IN_PANIC_MODE);
+    _isThreadSelfTerminate = config.getProperty(CommonConstants.Accounting.CONFIG_OF_THREAD_SELF_TERMINATE,
+        CommonConstants.Accounting.DEFAULT_THREAD_SELF_TERMINATE);
   }
 
   QueryMonitorConfig(QueryMonitorConfig oldConfig, Set<String> changedConfigs, Map<String, String> clusterConfigs) {
@@ -251,16 +251,16 @@ public class QueryMonitorConfig {
       _isQueryKilledMetricEnabled = oldConfig._isQueryKilledMetricEnabled;
     }
 
-    if (changedConfigs.contains(CommonConstants.Accounting.CONFIG_OF_THREAD_SELF_TERMINATE_IN_PANIC_MODE)) {
+    if (changedConfigs.contains(CommonConstants.Accounting.CONFIG_OF_THREAD_SELF_TERMINATE)) {
       if (clusterConfigs == null || !clusterConfigs.containsKey(
-          CommonConstants.Accounting.CONFIG_OF_THREAD_SELF_TERMINATE_IN_PANIC_MODE)) {
-        _isThreadSelfTerminateOnPanic = CommonConstants.Accounting.DEFAULT_THREAD_SELF_TERMINATE_IN_PANIC_MODE;
+          CommonConstants.Accounting.CONFIG_OF_THREAD_SELF_TERMINATE)) {
+        _isThreadSelfTerminate = CommonConstants.Accounting.DEFAULT_THREAD_SELF_TERMINATE;
       } else {
-        _isThreadSelfTerminateOnPanic =
-            Boolean.parseBoolean(clusterConfigs.get(CommonConstants.Accounting.CONFIG_OF_THREAD_SELF_TERMINATE_IN_PANIC_MODE));
+        _isThreadSelfTerminate =
+            Boolean.parseBoolean(clusterConfigs.get(CommonConstants.Accounting.CONFIG_OF_THREAD_SELF_TERMINATE));
       }
     } else {
-      _isThreadSelfTerminateOnPanic = oldConfig._isThreadSelfTerminateOnPanic;
+      _isThreadSelfTerminate = oldConfig._isThreadSelfTerminate;
     }
   }
 
@@ -312,7 +312,7 @@ public class QueryMonitorConfig {
     return _isQueryKilledMetricEnabled;
   }
 
-  public boolean isThreadSelfTerminateOnPanic() {
-    return _isThreadSelfTerminateOnPanic;
+  public boolean isThreadSelfTerminate() {
+    return _isThreadSelfTerminate;
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/accounting/QueryMonitorConfigTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/accounting/QueryMonitorConfigTest.java
@@ -81,7 +81,7 @@ public class QueryMonitorConfigTest {
     CLUSTER_CONFIGS.put(getFullyQualifiedConfigName(CommonConstants.Accounting.CONFIG_OF_QUERY_KILLED_METRIC_ENABLED),
         Boolean.toString(EXPECTED_IS_QUERY_KILLED_METRIC_ENABLED));
     CLUSTER_CONFIGS.put(
-        getFullyQualifiedConfigName(CommonConstants.Accounting.CONFIG_OF_THREAD_SELF_TERMINATE_IN_PANIC_MODE),
+        getFullyQualifiedConfigName(CommonConstants.Accounting.CONFIG_OF_THREAD_SELF_TERMINATE),
         Boolean.toString(EXPECTED_IS_THREAD_SELF_TERMINATE_IN_PANIC_MODE));
   }
 
@@ -254,10 +254,10 @@ public class QueryMonitorConfigTest {
         new PerQueryCPUMemAccountantFactory.PerQueryCPUMemResourceUsageAccountant(new PinotConfiguration(), "test",
             InstanceType.SERVER);
 
-    assertFalse(accountant.getWatcherTask().getQueryMonitorConfig().isThreadSelfTerminateOnPanic());
+    assertFalse(accountant.getWatcherTask().getQueryMonitorConfig().isThreadSelfTerminate());
     accountant.getWatcherTask().onChange(
-        Set.of(getFullyQualifiedConfigName(CommonConstants.Accounting.CONFIG_OF_THREAD_SELF_TERMINATE_IN_PANIC_MODE)),
+        Set.of(getFullyQualifiedConfigName(CommonConstants.Accounting.CONFIG_OF_THREAD_SELF_TERMINATE)),
         CLUSTER_CONFIGS);
-    assertTrue(accountant.getWatcherTask().getQueryMonitorConfig().isThreadSelfTerminateOnPanic());
+    assertTrue(accountant.getWatcherTask().getQueryMonitorConfig().isThreadSelfTerminate());
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/accounting/QueryMonitorConfigTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/accounting/QueryMonitorConfigTest.java
@@ -44,6 +44,7 @@ public class QueryMonitorConfigTest {
   private static final boolean EXPECTED_IS_CPU_TIME_BASED_KILLING_ENABLED = true;
   private static final long EXPECTED_CPU_TIME_BASED_KILLING_THRESHOLD_NS = 1000;
   private static final boolean EXPECTED_IS_QUERY_KILLED_METRIC_ENABLED = true;
+  private static final boolean EXPECTED_IS_THREAD_SELF_TERMINATE_IN_PANIC_MODE = true;
   private static final Map<String, String> CLUSTER_CONFIGS = new HashMap<>();
 
   private static String getFullyQualifiedConfigName(String config) {
@@ -79,6 +80,9 @@ public class QueryMonitorConfigTest {
         Double.toString(EXPECTED_MIN_MEMORY_FOOTPRINT_FOR_KILL));
     CLUSTER_CONFIGS.put(getFullyQualifiedConfigName(CommonConstants.Accounting.CONFIG_OF_QUERY_KILLED_METRIC_ENABLED),
         Boolean.toString(EXPECTED_IS_QUERY_KILLED_METRIC_ENABLED));
+    CLUSTER_CONFIGS.put(
+        getFullyQualifiedConfigName(CommonConstants.Accounting.CONFIG_OF_THREAD_SELF_TERMINATE_IN_PANIC_MODE),
+        Boolean.toString(EXPECTED_IS_THREAD_SELF_TERMINATE_IN_PANIC_MODE));
   }
 
   @Test
@@ -242,5 +246,18 @@ public class QueryMonitorConfigTest {
         .onChange(Set.of(getFullyQualifiedConfigName(CommonConstants.Accounting.CONFIG_OF_QUERY_KILLED_METRIC_ENABLED)),
             CLUSTER_CONFIGS);
     assertTrue(accountant.getWatcherTask().getQueryMonitorConfig().isQueryKilledMetricEnabled());
+  }
+
+  @Test
+  void testThreadSelfTerminateInPanicMode() {
+    PerQueryCPUMemAccountantFactory.PerQueryCPUMemResourceUsageAccountant accountant =
+        new PerQueryCPUMemAccountantFactory.PerQueryCPUMemResourceUsageAccountant(new PinotConfiguration(), "test",
+            InstanceType.SERVER);
+
+    assertFalse(accountant.getWatcherTask().getQueryMonitorConfig().isThreadSelfTerminateOnPanic());
+    accountant.getWatcherTask().onChange(
+        Set.of(getFullyQualifiedConfigName(CommonConstants.Accounting.CONFIG_OF_THREAD_SELF_TERMINATE_IN_PANIC_MODE)),
+        CLUSTER_CONFIGS);
+    assertTrue(accountant.getWatcherTask().getQueryMonitorConfig().isThreadSelfTerminateOnPanic());
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/accounting/ThreadResourceUsageAccountant.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/accounting/ThreadResourceUsageAccountant.java
@@ -38,6 +38,15 @@ public interface ThreadResourceUsageAccountant {
   boolean isAnchorThreadInterrupted();
 
   /**
+   * This function is expected to be called by threads in query engine. The query id of the task will be available in
+   * the thread execution context stored in a thread local. Therefore it does not accept any parameters.
+   * @return true if the query is terminated, false otherwise
+   */
+  default boolean isQueryTerminated() {
+    return false;
+  }
+
+  /**
    * This method has been deprecated and replaced by {@link setupRunner(String, int, ThreadExecutionContext.TaskType)}
    * and {@link setupWorker(int, ThreadExecutionContext.TaskType, ThreadExecutionContext)}.
    */

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/trace/Tracing.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/trace/Tracing.java
@@ -380,7 +380,8 @@ public class Tracing {
     }
 
     public static boolean isInterrupted() {
-      return Thread.interrupted() || Tracing.getThreadAccountant().isQueryTerminated();
+      return Thread.interrupted() || Tracing.getThreadAccountant().isAnchorThreadInterrupted() ||
+          Tracing.getThreadAccountant().isQueryTerminated();
     }
 
     public static void sampleAndCheckInterruption() {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/trace/Tracing.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/trace/Tracing.java
@@ -380,7 +380,7 @@ public class Tracing {
     }
 
     public static boolean isInterrupted() {
-      return Thread.interrupted() || Tracing.getThreadAccountant().isAnchorThreadInterrupted();
+      return Thread.interrupted() || Tracing.getThreadAccountant().isQueryTerminated();
     }
 
     public static void sampleAndCheckInterruption() {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/trace/Tracing.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/trace/Tracing.java
@@ -380,8 +380,8 @@ public class Tracing {
     }
 
     public static boolean isInterrupted() {
-      return Thread.interrupted() || Tracing.getThreadAccountant().isAnchorThreadInterrupted() ||
-          Tracing.getThreadAccountant().isQueryTerminated();
+      return Thread.interrupted() || Tracing.getThreadAccountant().isAnchorThreadInterrupted()
+          || Tracing.getThreadAccountant().isQueryTerminated();
     }
 
     public static void sampleAndCheckInterruption() {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -1548,6 +1548,10 @@ public class CommonConstants {
         "accounting.cancel.callback.cache.expiry.seconds";
     public static final int DEFAULT_CANCEL_CALLBACK_CACHE_EXPIRY_SECONDS = 1200;
 
+    public static final String CONFIG_OF_THREAD_SELF_TERMINATE_IN_PANIC_MODE =
+        "accounting.thread.self.terminate.in.panic.mode";
+    public static final boolean DEFAULT_THREAD_SELF_TERMINATE_IN_PANIC_MODE = false;
+
     /**
      * QUERY WORKLOAD ISOLATION Configs
      *

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -1548,9 +1548,9 @@ public class CommonConstants {
         "accounting.cancel.callback.cache.expiry.seconds";
     public static final int DEFAULT_CANCEL_CALLBACK_CACHE_EXPIRY_SECONDS = 1200;
 
-    public static final String CONFIG_OF_THREAD_SELF_TERMINATE_IN_PANIC_MODE =
-        "accounting.thread.self.terminate.in.panic.mode";
-    public static final boolean DEFAULT_THREAD_SELF_TERMINATE_IN_PANIC_MODE = false;
+    public static final String CONFIG_OF_THREAD_SELF_TERMINATE =
+        "accounting.thread.self.terminate";
+    public static final boolean DEFAULT_THREAD_SELF_TERMINATE = false;
 
     /**
      * QUERY WORKLOAD ISOLATION Configs


### PR DESCRIPTION
Queries will pro-actively terminate if heap usage is in panic mode in the `ThreadResourceUsageAccountant`. 

Note that #16040 is required for this feature to work correctly. 

To support this feature, the thread accountant with the unmentionable name adds `isQueryTerminated()`
This function is also checked in `Tracing.ThreadAccountantOps.isInterrupted`
