### PR TITLE
[BugFix] Serialize TlsSpec when executing DataIngestion backfill job

### DIFF
--- a/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/spec/TlsSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/spec/TlsSpec.java
@@ -18,11 +18,14 @@
  */
 package org.apache.pinot.spi.ingestion.batch.spec;
 
+import java.io.Serializable;
+
+
 /**
  * TLS key and trust-store specification for ingestion jobs
  * (Enables access to TLS-protected controller APIs, etc.)
  */
-public class TlsSpec {
+public class TlsSpec implements Serializable {
   private String _keyStorePath;
   private String _keyStorePassword;
   private String _trustStoreType;


### PR DESCRIPTION
Fixes a NotSerializableException caused by TlsSpec not implementing Serializable.
Added implements Serializable to TlsSpec to allow objects containing it to be serialized properly during DataIngestion Backfill job execution.


