### PR TITLE
ThrottleOnCriticalHeapUsageExecutor throws QueryErrorCode exception

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterCPUTimeResourceUsageAccountantTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterCPUTimeResourceUsageAccountantTest.java
@@ -28,6 +28,7 @@ import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.IntStream;
 import org.apache.avro.file.DataFileWriter;
@@ -99,9 +100,9 @@ public class OfflineClusterCPUTimeResourceUsageAccountantTest extends BaseCluste
     startZk();
     startController();
     startServers();
-    while (!Tracing.isAccountantRegistered()) {
-      Thread.sleep(100L);
-    }
+    TestUtils.waitForCondition(aVoid -> Tracing.isAccountantRegistered(), 100L, 60000L,
+        "ThreadResourceUsageAccountant did not register");
+
     startBrokers();
 
 
@@ -258,7 +259,7 @@ public class OfflineClusterCPUTimeResourceUsageAccountantTest extends BaseCluste
           }
         }
     );
-    countDownLatch.await();
+    Assert.assertTrue(countDownLatch.await(1, TimeUnit.MINUTES));
     Assert.assertTrue(queryResponse1.get().get("exceptions").toString().contains("got killed on SERVER"));
     Assert.assertTrue(queryResponse1.get().get("exceptions").toString().contains("CPU time exceeding limit of"));
     Assert.assertFalse(StringUtils.isEmpty(queryResponse2.get().get("exceptions").toString()));

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/executor/ThrottleOnCriticalHeapUsageExecutor.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/executor/ThrottleOnCriticalHeapUsageExecutor.java
@@ -21,6 +21,7 @@ package org.apache.pinot.spi.executor;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import org.apache.pinot.spi.accounting.ThreadResourceUsageAccountant;
+import org.apache.pinot.spi.exception.QueryErrorCode;
 
 
 /**
@@ -38,7 +39,7 @@ public class ThrottleOnCriticalHeapUsageExecutor extends DecoratorExecutorServic
 
   protected void checkTaskAllowed() {
     if (_threadResourceUsageAccountant.throttleQuerySubmission()) {
-      throw new IllegalStateException("Tasks throttled due to high heap usage.");
+      throw QueryErrorCode.SERVER_RESOURCE_LIMIT_EXCEEDED.asException("Tasks throttled due to high heap usage.");
     }
   }
 

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/executor/ThrottleOnCriticalHeapUsageExecutorTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/executor/ThrottleOnCriticalHeapUsageExecutorTest.java
@@ -32,6 +32,8 @@ import org.apache.pinot.spi.accounting.ThreadResourceTracker;
 import org.apache.pinot.spi.accounting.ThreadResourceUsageAccountant;
 import org.apache.pinot.spi.accounting.ThreadResourceUsageProvider;
 import org.apache.pinot.spi.accounting.TrackingScope;
+import org.apache.pinot.spi.exception.QueryErrorCode;
+import org.apache.pinot.spi.exception.QueryException;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
@@ -148,8 +150,9 @@ public class ThrottleOnCriticalHeapUsageExecutorTest {
           // do nothing
         });
         fail("Should not allow more than 1 task");
-      } catch (Exception e) {
+      } catch (QueryException e) {
         // as expected
+        assertEquals(e.getErrorCode(), QueryErrorCode.SERVER_RESOURCE_LIMIT_EXCEEDED);
         assertEquals(e.getMessage(), "Tasks throttled due to high heap usage.");
       }
     } catch (BrokenBarrierException | InterruptedException e) {


### PR DESCRIPTION
This is a simple PR that changes the exception from a generic `IllegalStateException` to a more meaningful `QueryErrorCode` exception.
