### PR TITLE
Fix unnesting of non-Map value collections.

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformer.java
@@ -201,7 +201,14 @@ public class ComplexTypeTransformer implements RecordTransformer {
           for (String field : _fieldsToUnnest) {
             unnestedRecords = unnestCollection(unnestedRecords, field);
           }
-          unnestedRecords.forEach(unnestedRecord -> unnestedRecord.getFieldToValueMap().putAll(originalValues));
+          unnestedRecords.forEach(unnestedRecord -> {
+            Map<String, Object> unnestedFieldValues = unnestedRecord.getFieldToValueMap();
+            for (Map.Entry<String, Object> entry : originalValues.entrySet()) {
+              if (!unnestedFieldValues.containsKey(entry.getKey())) {
+                unnestedFieldValues.put(entry.getKey(), entry.getValue());
+              }
+            }
+          });
           if (record.isIncomplete()) {
             unnestedRecords.forEach(GenericRow::markIncomplete);
           }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformer.java
@@ -202,11 +202,9 @@ public class ComplexTypeTransformer implements RecordTransformer {
             unnestedRecords = unnestCollection(unnestedRecords, field);
           }
           unnestedRecords.forEach(unnestedRecord -> {
-            Map<String, Object> unnestedFieldValues = unnestedRecord.getFieldToValueMap();
+            Map<String, Object> values = unnestedRecord.getFieldToValueMap();
             for (Map.Entry<String, Object> entry : originalValues.entrySet()) {
-              if (!unnestedFieldValues.containsKey(entry.getKey())) {
-                unnestedFieldValues.put(entry.getKey(), entry.getValue());
-              }
+              values.putIfAbsent(entry.getKey(), entry.getValue());
             }
           });
           if (record.isIncomplete()) {
@@ -253,6 +251,8 @@ public class ComplexTypeTransformer implements RecordTransformer {
         // use the record itself
         list.add(record);
       } else {
+        // Remove the value before flattening since we are going to add the flattened items
+        record.removeValue(column);
         for (Object obj : (Collection) value) {
           GenericRow copy = flattenCollectionItem(record, obj, column);
           list.add(copy);
@@ -263,6 +263,8 @@ public class ComplexTypeTransformer implements RecordTransformer {
         // use the record itself
         list.add(record);
       } else {
+        // Remove the value before flattening since we are going to add the flattened items
+        record.removeValue(column);
         for (Object obj : (Object[]) value) {
           GenericRow copy = flattenCollectionItem(record, obj, column);
           list.add(copy);

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformerTest.java
@@ -252,6 +252,41 @@ public class ComplexTypeTransformerTest {
     assertEquals(transformedRows.get(0).getValue("array.a"), "v1");
     assertEquals(transformedRows.get(0).getValue("array.array2"), "[{\"b\":\"v3\"},{\"b\":\"v4\"}]");
     assertEquals(transformedRows.get(1).getValue("array.a"), "v2");
+
+    // unnest root level collection with simple non-primitive values
+    //    {
+    //      "a": "value",
+    //      "b": "another",
+    //      "array":["x", "y"]
+    //    }
+    //  ->
+    //    [{
+    //      "a": "value",
+    //      "b": "another",
+    //      "array":"x"
+    //    },
+    //    {
+    //      "a": "value",
+    //      "b": "another",
+    //      "array":"y"
+    //    }]
+    genericRow = new GenericRow();
+    genericRow.putValue("a", "value");
+    genericRow.putValue("b", "another");
+    array = new Object[2];
+    array[0] = "x";
+    array[1] = "y";
+    genericRow.putValue("array", array);
+    transformer =
+        new ComplexTypeTransformer.Builder().setFieldsToUnnest(List.of("array")).build();
+    transformedRows = transformer.transform(List.of(genericRow));
+    assertEquals(transformedRows.size(), 2);
+    assertEquals(transformedRows.get(0).getValue("a"), "value");
+    assertEquals(transformedRows.get(0).getValue("b"), "another");
+    assertEquals(transformedRows.get(0).getValue("array"), "x");
+    assertEquals(transformedRows.get(1).getValue("a"), "value");
+    assertEquals(transformedRows.get(1).getValue("b"), "another");
+    assertEquals(transformedRows.get(1).getValue("array"), "y");
   }
 
   @Test

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformerTest.java
@@ -131,7 +131,9 @@ public class ComplexTypeTransformerTest {
     transformedRows = transformer.transform(List.of(genericRow));
     assertEquals(transformedRows.size(), 2);
     assertEquals(transformedRows.get(0).getValue("array.a"), "v1");
+    assertEquals(transformedRows.get(0).getValue("array"), array);
     assertEquals(transformedRows.get(1).getValue("array.a"), "v2");
+    assertEquals(transformedRows.get(1).getValue("array"), array);
 
     // unnest sibling collections
     //    {
@@ -180,12 +182,20 @@ public class ComplexTypeTransformerTest {
     assertEquals(transformedRows.size(), 4);
     assertEquals(transformedRows.get(0).getValue("array.a"), "v1");
     assertEquals(transformedRows.get(0).getValue("array2.b"), "v3");
+    assertEquals(transformedRows.get(0).getValue("array"), array);
+    assertEquals(transformedRows.get(0).getValue("array2"), array2);
     assertEquals(transformedRows.get(1).getValue("array.a"), "v1");
     assertEquals(transformedRows.get(1).getValue("array2.b"), "v4");
+    assertEquals(transformedRows.get(1).getValue("array"), array);
+    assertEquals(transformedRows.get(1).getValue("array2"), array2);
     assertEquals(transformedRows.get(2).getValue("array.a"), "v2");
     assertEquals(transformedRows.get(2).getValue("array2.b"), "v3");
+    assertEquals(transformedRows.get(2).getValue("array"), array);
+    assertEquals(transformedRows.get(2).getValue("array2"), array2);
     assertEquals(transformedRows.get(3).getValue("array.a"), "v2");
     assertEquals(transformedRows.get(3).getValue("array2.b"), "v4");
+    assertEquals(transformedRows.get(3).getValue("array"), array);
+    assertEquals(transformedRows.get(3).getValue("array2"), array2);
 
     // unnest nested collection
     // {


### PR DESCRIPTION
### Why:

Collections and arrays containing only non-Map values are already being unnested into multiple result rows. But the result leaf values are lost after unnesting.
Example:
```
{
   "array": ["x", "y"]
}
```
will be unnested into
```
[
   {
      "array": ["x", "y"]
   },
   {
      "array": ["x", "y"]
   }
]
```

Which is not very helpful as it loses the original association of the actual unnested value with the corresponding record.

### What:

Current implementation replaces the unnested field values with the original ones. 
Which is unnecessary since the original field value is already preserved in the copy of the record regardless (as demonstrated by the tests).

The only reason this replacement would be needed is to explicitly disallow the logic described here: to avoid losing that original array. 
But that doesn't sound very convincing, as the unnested version in this particular scenario is much more useful, in my opinion.

### Use cases:

One that comes to mind is:
- Create multiple copies of a row based on a field like "client ID": you get 2 rows with everything the same except the client ID.

### Summary:

All in all, the feature seems to be supported already but is just being negated by that replacement logic. If there is any particular reason I've missed, please let me know.