### PR TITLE
[UI] Reset table pagination on data, search, and sort changes to fix bug in Controller UI

### DIFF
--- a/pinot-controller/src/main/resources/app/components/Table.tsx
+++ b/pinot-controller/src/main/resources/app/components/Table.tsx
@@ -303,6 +303,8 @@ export default function CustomizedTables({
   const [finalData, setFinalData] = React.useState(Utils.tableFormat(data));
   React.useEffect( () => {
     setInitialData(data);
+    // Reset pagination when data changes
+    setPage(0);
   }, [data]);
   // We do not use data.isLoading directly in the renderer because there's a gap between data
   // changing and finalData being set. Without this, there's a flicker where we go from
@@ -368,6 +370,8 @@ export default function CustomizedTables({
       // Table.tsx currently doesn't support sorting after filtering. So for now, we just
       // remove the visual indicator of the sorted column until users sort again.
       setColumnClicked('')
+      // Reset pagination to first page when search changes
+      setPage(0);
     }, 200);
 
     return () => {
@@ -521,6 +525,8 @@ export default function CustomizedTables({
                       }
                       setOrder(!order);
                       setColumnClicked(column);
+                      // Reset pagination when sorting
+                      setPage(0);
                     }}
                   >
                     <>


### PR DESCRIPTION
## Summary

There is a bug in the current search functionality in the table columns component where the pagination is retained even after changes like user performing a search or sorting the table column component, which results in empty search even though the column exists.

https://github.com/user-attachments/assets/89ce3c8e-450b-484e-9c21-825dd364a63e

This PR fixes it by resetting the page to 0 after each interaction to eliminate this bug.

## Testing

Validated on Quickstart that the issue is fixed.


https://github.com/user-attachments/assets/822d2ddc-2ae6-41b1-ac26-ecc895bd4ef7

