### PR TITLE
add latency metric for multistage queries

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerTimer.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerTimer.java
@@ -30,6 +30,7 @@ public enum BrokerTimer implements AbstractMetrics.Timer {
   CLUSTER_CHANGE_QUEUE_TIME(true), // metric tracking the freshness lag for consuming segments
   FRESHNESS_LAG_MS(false),
   QUERY_TOTAL_TIME_MS(true),
+  MULTI_STAGE_QUERY_TOTAL_TIME_MS(true),
 
   SECONDARY_WORKLOAD_QUERY_TOTAL_TIME_MS(true),
 


### PR DESCRIPTION
This adds a latency metric for v2 engine queries. It follows the existing pattern of reusing the same "global" metric name for both global and per-table latencies. This is unlikely to be ideal or useful in every case for tracking latency for v2 engine queries, but it 1) follows the pattern set for other metrics and 2) is strictly better than what we have today which is no metrics

the change looks a little weird because I also refactored the other metrics to only iterate the tables once.