### PR TITLE
Add new configuration for refreshed segment expiration time in instance selectors

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/BalancedInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/BalancedInstanceSelector.java
@@ -51,9 +51,10 @@ public class BalancedInstanceSelector extends BaseInstanceSelector {
 
   public BalancedInstanceSelector(String tableNameWithType, ZkHelixPropertyStore<ZNRecord> propertyStore,
       BrokerMetrics brokerMetrics, @Nullable AdaptiveServerSelector adaptiveServerSelector, Clock clock,
-      boolean useFixedReplica, long newSegmentExpirationTimeInSeconds) {
+      boolean useFixedReplica, long newSegmentExpirationTimeInSeconds,
+      long newRefreshedSegmentExpirationTimeInSeconds) {
     super(tableNameWithType, propertyStore, brokerMetrics, adaptiveServerSelector, clock, useFixedReplica,
-        newSegmentExpirationTimeInSeconds);
+        newSegmentExpirationTimeInSeconds, newRefreshedSegmentExpirationTimeInSeconds);
   }
 
   @Override

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorFactory.java
@@ -66,6 +66,9 @@ public class InstanceSelectorFactory {
     long newSegmentExpirationTimeInSeconds =
         brokerConfig.getProperty(CommonConstants.Broker.CONFIG_OF_NEW_SEGMENT_EXPIRATION_SECONDS,
         CommonConstants.Broker.DEFAULT_VALUE_OF_NEW_SEGMENT_EXPIRATION_SECONDS);
+    long newRefreshedSegmentExpirationTimeInSeconds =
+        brokerConfig.getProperty(CommonConstants.Broker.CONFIG_OF_NEW_REFRESHED_SEGMENT_EXPIRATION_SECONDS,
+            CommonConstants.Broker.DEFAULT_VALUE_OF_NEW_REFRESHED_SEGMENT_EXPIRATION_SECONDS);
     if (routingConfig != null) {
       if (routingConfig.getUseFixedReplica() != null) {
         // table config overrides broker config
@@ -77,22 +80,24 @@ public class InstanceSelectorFactory {
           && LEGACY_REPLICA_GROUP_REALTIME_ROUTING.equalsIgnoreCase(routingConfig.getRoutingTableBuilderName()))) {
         LOGGER.info("Using ReplicaGroupInstanceSelector for table: {}", tableNameWithType);
         return new ReplicaGroupInstanceSelector(tableNameWithType, propertyStore, brokerMetrics, adaptiveServerSelector,
-            clock, useFixedReplica, newSegmentExpirationTimeInSeconds);
+            clock, useFixedReplica, newSegmentExpirationTimeInSeconds, newRefreshedSegmentExpirationTimeInSeconds);
       }
       if (RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE.equalsIgnoreCase(
           routingConfig.getInstanceSelectorType())) {
         LOGGER.info("Using StrictReplicaGroupInstanceSelector for table: {}", tableNameWithType);
         return new StrictReplicaGroupInstanceSelector(tableNameWithType, propertyStore, brokerMetrics,
-            adaptiveServerSelector, clock, useFixedReplica, newSegmentExpirationTimeInSeconds);
+            adaptiveServerSelector, clock, useFixedReplica, newSegmentExpirationTimeInSeconds,
+            newRefreshedSegmentExpirationTimeInSeconds);
       }
       if (RoutingConfig.MULTI_STAGE_REPLICA_GROUP_SELECTOR_TYPE.equalsIgnoreCase(
           routingConfig.getInstanceSelectorType())) {
         LOGGER.info("Using {} for table: {}", routingConfig.getInstanceSelectorType(), tableNameWithType);
         return new MultiStageReplicaGroupSelector(tableNameWithType, propertyStore, brokerMetrics,
-            adaptiveServerSelector, clock, useFixedReplica, newSegmentExpirationTimeInSeconds);
+            adaptiveServerSelector, clock, useFixedReplica, newSegmentExpirationTimeInSeconds,
+            newRefreshedSegmentExpirationTimeInSeconds);
       }
     }
     return new BalancedInstanceSelector(tableNameWithType, propertyStore, brokerMetrics, adaptiveServerSelector, clock,
-        useFixedReplica, newSegmentExpirationTimeInSeconds);
+        useFixedReplica, newSegmentExpirationTimeInSeconds, newRefreshedSegmentExpirationTimeInSeconds);
   }
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/MultiStageReplicaGroupSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/MultiStageReplicaGroupSelector.java
@@ -61,9 +61,10 @@ public class MultiStageReplicaGroupSelector extends BaseInstanceSelector {
 
   public MultiStageReplicaGroupSelector(String tableNameWithType, ZkHelixPropertyStore<ZNRecord> propertyStore,
       BrokerMetrics brokerMetrics, @Nullable AdaptiveServerSelector adaptiveServerSelector, Clock clock,
-      boolean useFixedReplica, long newSegmentExpirationTimeInSeconds) {
+      boolean useFixedReplica, long newSegmentExpirationTimeInSeconds,
+      long newRefreshedSegmentExpirationTimeInSeconds) {
     super(tableNameWithType, propertyStore, brokerMetrics, adaptiveServerSelector, clock, useFixedReplica,
-        newSegmentExpirationTimeInSeconds);
+        newSegmentExpirationTimeInSeconds, newRefreshedSegmentExpirationTimeInSeconds);
   }
 
   @Override

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupInstanceSelector.java
@@ -66,9 +66,10 @@ public class ReplicaGroupInstanceSelector extends BaseInstanceSelector {
 
   public ReplicaGroupInstanceSelector(String tableNameWithType, ZkHelixPropertyStore<ZNRecord> propertyStore,
       BrokerMetrics brokerMetrics, @Nullable AdaptiveServerSelector adaptiveServerSelector, Clock clock,
-      boolean useFixedReplica, long newSegmentExpirationTimeInSeconds) {
+      boolean useFixedReplica, long newSegmentExpirationTimeInSeconds,
+      long newRefreshedSegmentExpirationTimeInSeconds) {
     super(tableNameWithType, propertyStore, brokerMetrics, adaptiveServerSelector, clock, useFixedReplica,
-        newSegmentExpirationTimeInSeconds);
+        newSegmentExpirationTimeInSeconds, newRefreshedSegmentExpirationTimeInSeconds);
   }
 
   @Override

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/StrictReplicaGroupInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/StrictReplicaGroupInstanceSelector.java
@@ -72,9 +72,10 @@ public class StrictReplicaGroupInstanceSelector extends ReplicaGroupInstanceSele
 
   public StrictReplicaGroupInstanceSelector(String tableNameWithType, ZkHelixPropertyStore<ZNRecord> propertyStore,
       BrokerMetrics brokerMetrics, @Nullable AdaptiveServerSelector adaptiveServerSelector, Clock clock,
-      boolean useFixedReplica, long newSegmentExpirationTimeInSeconds) {
+      boolean useFixedReplica, long newSegmentExpirationTimeInSeconds,
+      long newRefreshedSegmentExpirationTimeInSeconds) {
     super(tableNameWithType, propertyStore, brokerMetrics, adaptiveServerSelector, clock, useFixedReplica,
-        newSegmentExpirationTimeInSeconds);
+        newSegmentExpirationTimeInSeconds, newRefreshedSegmentExpirationTimeInSeconds);
   }
 
   /**

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorTest.java
@@ -237,13 +237,13 @@ public class InstanceSelectorTest {
     BrokerMetrics brokerMetrics = mock(BrokerMetrics.class);
     BalancedInstanceSelector balancedInstanceSelector =
         new BalancedInstanceSelector(offlineTableName, propertyStore, brokerMetrics, null, Clock.systemUTC(), false,
-            300);
+            300, 300);
     ReplicaGroupInstanceSelector replicaGroupInstanceSelector =
         new ReplicaGroupInstanceSelector(offlineTableName, propertyStore, brokerMetrics, null, Clock.systemUTC(), false,
-            300);
+            300, 300);
     StrictReplicaGroupInstanceSelector strictReplicaGroupInstanceSelector =
         new StrictReplicaGroupInstanceSelector(offlineTableName, propertyStore, brokerMetrics, null, Clock.systemUTC(),
-            false, 300);
+            false, 300, 300);
 
     Set<String> enabledInstances = new HashSet<>();
     IdealState idealState = new IdealState(offlineTableName);
@@ -765,7 +765,7 @@ public class InstanceSelectorTest {
 
     ReplicaGroupInstanceSelector replicaGroupInstanceSelector =
         new ReplicaGroupInstanceSelector(offlineTableName, propertyStore, brokerMetrics, null, Clock.systemUTC(), false,
-            300);
+            300, 300);
 
     Set<String> enabledInstances = new HashSet<>();
     IdealState idealState = new IdealState(offlineTableName);
@@ -848,7 +848,7 @@ public class InstanceSelectorTest {
 
     ReplicaGroupInstanceSelector replicaGroupInstanceSelector =
         new ReplicaGroupInstanceSelector(offlineTableName, propertyStore, brokerMetrics, null, Clock.systemUTC(), false,
-            300);
+            300, 300);
 
     Set<String> enabledInstances = new HashSet<>();
     IdealState idealState = new IdealState(offlineTableName);
@@ -931,7 +931,7 @@ public class InstanceSelectorTest {
 
     ReplicaGroupInstanceSelector replicaGroupInstanceSelector =
         new ReplicaGroupInstanceSelector(offlineTableName, propertyStore, brokerMetrics, null, Clock.systemUTC(), false,
-            300);
+            300, 300);
 
     Set<String> enabledInstances = new HashSet<>();
     IdealState idealState = new IdealState(offlineTableName);
@@ -992,11 +992,11 @@ public class InstanceSelectorTest {
     BrokerMetrics brokerMetrics = mock(BrokerMetrics.class);
     BalancedInstanceSelector balancedInstanceSelector =
         new BalancedInstanceSelector(offlineTableName, propertyStore, brokerMetrics, null, Clock.systemUTC(), false,
-            300);
+            300, 300);
     // ReplicaGroupInstanceSelector has the same behavior as BalancedInstanceSelector for the unavailable segments
     StrictReplicaGroupInstanceSelector strictReplicaGroupInstanceSelector =
         new StrictReplicaGroupInstanceSelector(offlineTableName, propertyStore, brokerMetrics, null, Clock.systemUTC(),
-            false, 300);
+            false, 300, 300);
 
     Set<String> enabledInstances = new HashSet<>();
     IdealState idealState = new IdealState(offlineTableName);
@@ -1860,7 +1860,7 @@ public class InstanceSelectorTest {
     HybridSelector hybridSelector = mock(HybridSelector.class);
     ReplicaGroupInstanceSelector instanceSelector =
         new ReplicaGroupInstanceSelector(offlineTableName, propertyStore, brokerMetrics, hybridSelector,
-            Clock.systemUTC(), false, 300);
+            Clock.systemUTC(), false, 300, 300);
 
     // Define instances and segments
     String instance0 = "instance0";

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/MultiStageReplicaGroupSelectorTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/MultiStageReplicaGroupSelectorTest.java
@@ -212,7 +212,7 @@ public class MultiStageReplicaGroupSelectorTest {
   private MultiStageReplicaGroupSelector createMultiStageSelector(InstancePartitions instancePartitions) {
     MultiStageReplicaGroupSelector multiStageSelector =
         new MultiStageReplicaGroupSelector(TABLE_NAME, _propertyStore, _brokerMetrics, null, Clock.systemUTC(),
-            false, 300);
+            false, 300, 300);
     multiStageSelector = spy(multiStageSelector);
     doReturn(instancePartitions).when(multiStageSelector).getInstancePartitions();
     return multiStageSelector;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -76,6 +76,7 @@ public class CommonConstants {
     public static final String CONFIG_OF_LUCENE_MAX_CLAUSE_COUNT = "pinot.lucene.max.clause.count";
     public static final int DEFAULT_LUCENE_MAX_CLAUSE_COUNT = 1024;
   }
+
   public static final String JFR = "pinot.jfr";
 
   public static final String RLS_FILTERS = "rlsFilters";
@@ -489,6 +490,10 @@ public class CommonConstants {
 
     public static final String CONFIG_OF_NEW_SEGMENT_EXPIRATION_SECONDS = "pinot.broker.new.segment.expiration.seconds";
     public static final long DEFAULT_VALUE_OF_NEW_SEGMENT_EXPIRATION_SECONDS = TimeUnit.MINUTES.toSeconds(5);
+
+    public static final String CONFIG_OF_NEW_REFRESHED_SEGMENT_EXPIRATION_SECONDS =
+        "pinot.broker.new.refreshed.segment.expiration.seconds";
+    public static final long DEFAULT_VALUE_OF_NEW_REFRESHED_SEGMENT_EXPIRATION_SECONDS = TimeUnit.HOURS.toSeconds(1);
 
     // If this config is set to true, the broker will check every query executed using the v1 query engine and attempt
     // to determine whether the query could have successfully been run on the v2 / multi-stage query engine. If not,
@@ -1610,7 +1615,7 @@ public class CommonConstants {
       public enum Status {
         IN_PROGRESS, // The segment is still consuming data
         COMMITTING, // This state will only be utilised by pauseless ingestion when the segment has been consumed but
-                    // is yet to be build and uploaded by the server.
+        // is yet to be build and uploaded by the server.
         DONE, // The segment has finished consumption and has been committed to the segment store
         UPLOADED; // The segment is uploaded by an external party
 


### PR DESCRIPTION
This pull request introduces support for a new configuration to handle expiration times for "refreshed" segments in the Pinot broker's instance selector logic. The changes primarily involve adding a new parameter for refreshed segment expiration and updating the related logic, constructors, and tests.

Note: New unit tests are pending.

label: configuration