### PR TITLE
Allow and Initialise Server Rate Limiter before server starts consuming

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeConsumptionRateManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeConsumptionRateManager.java
@@ -84,7 +84,7 @@ public class RealtimeConsumptionRateManager {
     return InstanceHolder.INSTANCE;
   }
 
-  public void enableThrottling() {
+  public void enablePartitionRateLimiter() {
     _isThrottlingAllowed = true;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeConsumptionRateManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeConsumptionRateManager.java
@@ -307,11 +307,9 @@ public class RealtimeConsumptionRateManager {
     }
 
     public void throttle(int numMsgsConsumed) {
-      if (InstanceHolder.INSTANCE._isThrottlingAllowed) {
-        _metricEmitter.record(numMsgsConsumed); // just incrementing counter (non-blocking)
-        if (numMsgsConsumed > 0) {
-          _rateLimiter.acquire(numMsgsConsumed); // blocks if needed
-        }
+      _metricEmitter.record(numMsgsConsumed); // just incrementing counter (non-blocking)
+      if (numMsgsConsumed > 0) {
+        _rateLimiter.acquire(numMsgsConsumed); // blocks if needed
       }
     }
 

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
@@ -797,7 +797,7 @@ public abstract class BaseServerStarter implements ServiceStartable {
         Collections.singletonMap(Helix.IS_SHUTDOWN_IN_PROGRESS, Boolean.toString(false)));
     _isServerReadyToServeQueries = true;
     // Throttling for realtime consumption is disabled up to this point to allow maximum consumption during startup time
-    RealtimeConsumptionRateManager.getInstance().enableThrottling();
+    RealtimeConsumptionRateManager.getInstance().enablePartitionRateLimiter();
 
     LOGGER.info("Pinot server ready");
 

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
@@ -685,6 +685,12 @@ public abstract class BaseServerStarter implements ServiceStartable {
     InstanceDataManager instanceDataManager = _serverInstance.getInstanceDataManager();
     instanceDataManager.setSupplierOfIsServerReadyToServeQueries(() -> _isServerReadyToServeQueries);
 
+    // Enable Server level realtime ingestion rate limier
+    RealtimeConsumptionRateManager.getInstance().createServerRateLimiter(_serverConf, serverMetrics);
+    PinotClusterConfigChangeListener serverRateLimitConfigChangeListener =
+        new ServerRateLimitConfigChangeListener(serverMetrics);
+    _clusterConfigChangeHandler.registerClusterConfigChangeListener(serverRateLimitConfigChangeListener);
+
     initSegmentFetcher(_serverConf);
     StateModelFactory<?> stateModelFactory =
         new SegmentOnlineOfflineStateModelFactory(_instanceId, instanceDataManager);
@@ -775,12 +781,6 @@ public abstract class BaseServerStarter implements ServiceStartable {
         _serverConf.getProperty(Server.CONFIG_OF_SERVER_QUERY_REGEX_CLASS, Server.DEFAULT_SERVER_QUERY_REGEX_CLASS));
 
     preServeQueries();
-
-    // Enable Server level realtime ingestion rate limier
-    RealtimeConsumptionRateManager.getInstance().createServerRateLimiter(_serverConf, serverMetrics);
-    PinotClusterConfigChangeListener serverRateLimitConfigChangeListener =
-        new ServerRateLimitConfigChangeListener(serverMetrics);
-    _clusterConfigChangeHandler.registerClusterConfigChangeListener(serverRateLimitConfigChangeListener);
 
     // Start the thread accountant
     Tracing.ThreadAccountantOps.startThreadAccountant();


### PR DESCRIPTION
**Problem**:
We see some instances of server OOM during startup. The reason is due to the spike in rate of consumption when the server tries to catchup when it starts. The increase in memory comes from the byte arrays the Kafka consumer uses to hold messages at very high rate. Currently the server rate limiter only works after server startup is completed (i.e. server is marked ready for queries).

**Solution**:
To avoid OOM during startup, Server Rate Limiter should be enabled and initialised before any offline -> consuming transition comes in.