### PR TITLE
[Enhance] Support backfill on clusters with self-signed certificates

### DIFF
--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-2.4/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark/SparkSegmentGenerationJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-2.4/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark/SparkSegmentGenerationJobRunner.java
@@ -269,9 +269,11 @@ public class SparkSegmentGenerationJobRunner implements IngestionJobRunner, Seri
           taskSpec.setOutputDirectoryPath(localOutputTempDir.getAbsolutePath());
           taskSpec.setRecordReaderSpec(_spec.getRecordReaderSpec());
           taskSpec
-              .setSchema(SegmentGenerationUtils.getSchema(_spec.getTableSpec().getSchemaURI(), _spec.getAuthToken()));
+              .setSchema(SegmentGenerationUtils.getSchema(_spec.getTableSpec().getSchemaURI(), _spec.getAuthToken(),
+                  _spec.getTlsSpec()));
           taskSpec.setTableConfig(
-              SegmentGenerationUtils.getTableConfig(_spec.getTableSpec().getTableConfigURI(), _spec.getAuthToken()));
+              SegmentGenerationUtils.getTableConfig(_spec.getTableSpec().getTableConfigURI(), _spec.getAuthToken(),
+                  _spec.getTlsSpec()));
           taskSpec.setSequenceId(idx);
           taskSpec.setSegmentNameGeneratorSpec(_spec.getSegmentNameGeneratorSpec());
           taskSpec.setFailOnEmptySegment(_spec.isFailOnEmptySegment());

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark3/SparkSegmentGenerationJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark3/SparkSegmentGenerationJobRunner.java
@@ -278,9 +278,11 @@ public class SparkSegmentGenerationJobRunner implements IngestionJobRunner, Seri
           taskSpec.setOutputDirectoryPath(localOutputTempDir.getAbsolutePath());
           taskSpec.setRecordReaderSpec(_spec.getRecordReaderSpec());
           taskSpec.setSchema(
-              SegmentGenerationUtils.getSchema(_spec.getTableSpec().getSchemaURI(), _spec.getAuthToken()));
+              SegmentGenerationUtils.getSchema(_spec.getTableSpec().getSchemaURI(), _spec.getAuthToken(),
+                  _spec.getTlsSpec()));
           taskSpec.setTableConfig(
-              SegmentGenerationUtils.getTableConfig(_spec.getTableSpec().getTableConfigURI(), _spec.getAuthToken()));
+              SegmentGenerationUtils.getTableConfig(_spec.getTableSpec().getTableConfigURI(), _spec.getAuthToken(),
+                  _spec.getTlsSpec()));
           taskSpec.setSequenceId(idx);
           taskSpec.setSegmentNameGeneratorSpec(_spec.getSegmentNameGeneratorSpec());
           taskSpec.setFailOnEmptySegment(_spec.isFailOnEmptySegment());

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/spec/TlsSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/spec/TlsSpec.java
@@ -32,6 +32,8 @@ public class TlsSpec implements Serializable {
   private String _trustStorePath;
   private String _trustStorePassword;
   private String _keyStoreType;
+  private int _connectTimeout = 5000;
+  private int _readTimeout = 5000;
 
   public String getKeyStorePath() {
     return _keyStorePath;
@@ -79,5 +81,21 @@ public class TlsSpec implements Serializable {
 
   public void setKeyStoreType(String keyStoreType) {
     _keyStoreType = keyStoreType;
+  }
+
+  public int getConnectTimeout() {
+    return _connectTimeout;
+  }
+
+  public void setConnectTimeout(int connectTimeout) {
+    _connectTimeout = connectTimeout;
+  }
+
+  public int getReadTimeout() {
+    return _readTimeout;
+  }
+
+  public void setReadTimeout(int readTimeout) {
+    _readTimeout = readTimeout;
   }
 }


### PR DESCRIPTION
This PR allows backfill jobs to run on clusters with self-signed certificates by relaxing SSL checks.

While `SegmentApiClient` already supports TLS, methods like `getSchema` and `getTableConfig` do not. As a result, `LaunchDataIngestionJob` previously could not write to Pinot/StarTree clusters using self-signed certificates. This change ensures consistent TLS handling across all relevant API calls.
