### PR TITLE
Allow skip CRC check during segment load when server starting.

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -1205,6 +1205,7 @@ public abstract class BaseTableDataManager implements TableDataManager {
        - The "DONE" status confirms the COMMIT_END_METADATA call succeeded,
          and the segment is available either in deep storage or with a peer
          before discarding the local copy.
+       The only exception is if the server does not check CRC on segment load.
 
     Then:
     We need to fall back to downloading the segment from deep storage to load it.
@@ -1212,12 +1213,16 @@ public abstract class BaseTableDataManager implements TableDataManager {
     if (segmentMetadata == null || (isSegmentStatusCompleted(zkMetadata) && !hasSameCRC(zkMetadata, segmentMetadata))) {
       if (segmentMetadata == null) {
         _logger.info("Segment: {} does not exist", segmentName);
-      } else if (!hasSameCRC(zkMetadata, segmentMetadata)) {
-        _logger.info("Segment: {} has CRC changed from: {} to: {}", segmentName, segmentMetadata.getCrc(),
-            zkMetadata.getCrc());
+        closeSegmentDirectoryQuietly(segmentDirectory);
+        return false;
       }
-      closeSegmentDirectoryQuietly(segmentDirectory);
-      return false;
+      _logger.warn("Segment: {} has CRC changed from: {} to: {}", segmentName, segmentMetadata.getCrc(),
+          zkMetadata.getCrc());
+      if (_instanceDataManagerConfig.shouldCheckCRCOnSegmentLoad()) {
+        closeSegmentDirectoryQuietly(segmentDirectory);
+        return false;
+      }
+      _logger.info("Skipping CRC check for segment: {} as configured. Proceed to load segment.", segmentName);
     }
 
     try {

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
@@ -119,6 +119,9 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
   private static final int DEFAULT_DELETED_TABLES_CACHE_TTL_MINUTES = 60;
   private static final int DEFAULT_DELETED_SEGMENTS_CACHE_SIZE = 10_000;
   private static final int DEFAULT_DELETED_SEGMENTS_CACHE_TTL_MINUTES = 2;
+  // By default, check CRC matching when loading segments.
+  private static final boolean DEFAULT_CHECK_CRC_ON_SEGMENT_LOAD = true;
+  private static final String CHECK_CRC_ON_SEGMENT_LOAD = "check.crc.on.segment.load";
 
   private final PinotConfiguration _serverConfig;
   private final PinotConfiguration _upsertConfig;
@@ -330,5 +333,10 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
   @Override
   public boolean isUploadSegmentToDeepStore() {
     return _serverConfig.getProperty(UPLOAD_SEGMENT_TO_DEEP_STORE, DEFAULT_UPLOAD_SEGMENT_TO_DEEP_STORE);
+  }
+
+  @Override
+  public boolean shouldCheckCRCOnSegmentLoad() {
+    return _serverConfig.getProperty(CHECK_CRC_ON_SEGMENT_LOAD, DEFAULT_CHECK_CRC_ON_SEGMENT_LOAD);
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/instance/InstanceDataManagerConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/instance/InstanceDataManagerConfig.java
@@ -86,4 +86,6 @@ public interface InstanceDataManagerConfig {
   Map<String, Map<String, String>> getTierConfigs();
 
   boolean isUploadSegmentToDeepStore();
+
+  boolean shouldCheckCRCOnSegmentLoad();
 }


### PR DESCRIPTION
Add a configuration option to skip segment CRC check when load a segment during server start or pre-downloading.  The default value is still true to check segment CRC so there is no back compatibility issues.

As Pinot segment today include many variety of indexes and data, it become increasingly hard to use CRC to verify segment consistency across replicas. Examples include Lucene text index which has by design non-deterministic behavior during indexing. There should be a revamp on how to use and create CRC when loading segments. This PR just creates option for users to opt out. It has been tested in our production env for a while for Pinot table with text index without issues.