### PR TITLE
[BugFix] Add auth for revert replace segment

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
@@ -517,6 +517,13 @@ public class FileUploadDownloadClient implements AutoCloseable {
     return requestBuilder.build();
   }
 
+  private static ClassicHttpRequest getRevertReplaceSegmentRequest(URI uri, @Nullable AuthProvider authProvider) {
+    ClassicRequestBuilder requestBuilder = ClassicRequestBuilder.post(uri).setVersion(HttpVersion.HTTP_1_1)
+        .setHeader(HttpHeaders.CONTENT_TYPE, HttpClient.JSON_CONTENT_TYPE);
+    AuthProviderUtils.toRequestHeaders(authProvider).forEach(requestBuilder::addHeader);
+    return requestBuilder.build();
+  }
+
   private static ClassicHttpRequest getSegmentCompletionProtocolRequest(URI uri, @Nullable List<Header> headers,
       @Nullable List<NameValuePair> parameters) {
     ClassicRequestBuilder requestBuilder = ClassicRequestBuilder.get(uri).setVersion(HttpVersion.HTTP_1_1);
@@ -1174,7 +1181,22 @@ public class FileUploadDownloadClient implements AutoCloseable {
    */
   public SimpleHttpResponse revertReplaceSegments(URI uri)
       throws IOException, HttpErrorStatusException {
-    return HttpClient.wrapAndThrowHttpException(_httpClient.sendRequest(getRevertReplaceSegmentRequest(uri)));
+    return revertReplaceSegments(uri, null);
+  }
+
+  /**
+   * Revert replace segments with default settings.
+   *
+   * @param uri URI
+   * @param authProvider auth provider
+   * @return Response
+   * @throws IOException
+   * @throws HttpErrorStatusException
+   */
+  public SimpleHttpResponse revertReplaceSegments(URI uri, @Nullable AuthProvider authProvider)
+      throws IOException, HttpErrorStatusException {
+    return HttpClient.wrapAndThrowHttpException(_httpClient.sendRequest(
+        getRevertReplaceSegmentRequest(uri, authProvider)));
   }
 
   /**

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/ConsistentDataPushUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/ConsistentDataPushUtils.java
@@ -197,12 +197,13 @@ public class ConsistentDataPushUtils {
     if (uriToLineageEntryIdMap != null) {
       LOGGER.error("Exception when pushing segments. Marking segment lineage entry to 'REVERTED'.", exception);
       String rawTableName = spec.getTableSpec().getTableName();
+      AuthProvider authProvider = AuthProviderUtils.makeAuthProvider(spec.getAuthToken());
       for (Map.Entry<URI, String> entry : uriToLineageEntryIdMap.entrySet()) {
         String segmentLineageEntryId = entry.getValue();
         try {
           URI uri = FileUploadDownloadClient.getRevertReplaceSegmentsURI(entry.getKey(), rawTableName,
               TableType.OFFLINE.name(), segmentLineageEntryId, true);
-          SimpleHttpResponse response = FILE_UPLOAD_DOWNLOAD_CLIENT.revertReplaceSegments(uri);
+          SimpleHttpResponse response = FILE_UPLOAD_DOWNLOAD_CLIENT.revertReplaceSegments(uri, authProvider);
           LOGGER.info("Got response {}: {} while sending revert replace segment request for table: {}, uploadURI: {}",
               response.getStatusCode(), response.getResponse(), rawTableName, entry.getKey());
         } catch (URISyntaxException | HttpErrorStatusException | IOException e) {


### PR DESCRIPTION
The "Revert segments replacement" API requires update permission, so authentication information must be provided when invoking it. This PR adds the missing part; otherwise, an error will be thrown during the revert operation.
```
25/07/24 12:39:39 INFO HttpClient: Sending request: https://pinot-controller-prod****.com/segments/wme_***/revertReplaceSegments?type=OFFLINE&segmentLineageEntryId=69210297-16a5-4641-bb86-bb32c13d3247&forceRevert=true to controller: pinot-controller-1.pinot-controller-headless.wap-pinot-prod-***fkgen-p-2, version: Unknown
org.apache.pinot.common.exception.HttpErrorStatusException: Got error status code: 403 (Forbidden) with reason: "Permission is denied for UPDATE '/segments/wme_***/revertReplaceSegments' for table 'wme_mqsr_participant'" while sending request: https://pinot-controller-prod****.com/segments/wme_mqsr_participant/revertReplaceSegments?type=OFFLINE&segmentLineageEntryId=69210297-16a5-4641-bb86-bb32c13d3247&forceRevert=true to controller:  pinot-controller-1.pinot-controller-headless.wap-pinot-prod-***fkgen-p-2, version: Unknown
at org.apache.pinot.common.utils.http.HttpClient.wrapAndThrowHttpException(HttpClient.java:448)
at org.apache.pinot.common.utils.FileUploadDownloadClient.revertReplaceSegments(FileUploadDownloadClient.java:1093)
at org.apache.pinot.segment.local.utils.SegmentPushUtils.revertReplaceSegments(SegmentPushUtils.java:436)
at org.apache.pinot.tools.admin.command.LaunchBackfillIngestionJobCommand.execute(LaunchBackfillIngestionJobCommand.java:180)
```