### PR TITLE
Enhance and unify JSON index reader

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/BitmapInvertedIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/BitmapInvertedIndexReader.java
@@ -49,7 +49,6 @@ public class BitmapInvertedIndexReader implements InvertedIndexReader<ImmutableR
     _firstOffset = getOffset(0);
   }
 
-  @SuppressWarnings("unchecked")
   @Override
   public ImmutableRoaringBitmap getDocIds(int dictId) {
     long offset = getOffset(dictId);


### PR DESCRIPTION
Enhance and unify JSON index reader logic:
- Enhance empty bitmap check to reduce unnecessary computation
- Reduce unnecessary `null` checks
- Introduce helper method to simplify handling
- Make the logic the same for mutable and immutable