### PR TITLE
Use Broker's accountant to sample in the request handler.

### DIFF
--- a/pinot-spi/src/main/java/org/apache/pinot/spi/trace/Tracing.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/trace/Tracing.java
@@ -391,6 +391,13 @@ public class Tracing {
       sample();
     }
 
+    public static void sampleAndCheckInterruption(ThreadResourceUsageAccountant accountant) {
+      if (Thread.interrupted() || accountant.isAnchorThreadInterrupted() || accountant.isQueryTerminated()) {
+        throw new EarlyTerminationException("Interrupted while merging records");
+      }
+      accountant.sampleUsage();
+    }
+
     @Deprecated
     public static void updateQueryUsageConcurrently(String queryId) {
     }


### PR DESCRIPTION
#16360 changed Broker code to use the resource accountant stored in the broker object. This is required in tests where server and broker are run in the same JVM and both cannot use the same global resource accountant. The broker had a few calls that tried to use the global resource accountant. These calls have been changed.

Note that this is an issue specific to tests and quick starts as brokers and servers run in the same JVM.  