### PR TITLE
Fix: Handle null values in ZooKeeper node metadata in Pinot UI #14216

### DIFF
--- a/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
+++ b/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
@@ -737,16 +737,25 @@ const getZookeeperData = (path, count) => {
     isLeafNode: false,
     hasChildRendered: true
   }];
-  return getNodeData(path).then((obj)=>{
+
+  return getNodeData(path).then((obj) => {
     const { currentNodeData, currentNodeMetadata, currentNodeListStat } = obj;
-    const pathNames = Object.keys(currentNodeListStat);
-    pathNames.map((pathName)=>{
+    const pathNames = Object.keys(currentNodeListStat || {});
+
+    pathNames.forEach((pathName) => {
+      const nodeStat = currentNodeListStat[pathName];
+
+      // Skip if nodeStat is null or undefined
+      if (!nodeStat) {
+        console.warn(`Skipping null node for path: ${pathName}`);
+        return;
+      }
       newTreeData[0].child.push({
         nodeId: `${counter++}`,
         label: pathName,
-        fullPath: path === '/' ? path+pathName : `${path}/${pathName}`,
+        fullPath: path === '/' ? path + pathName : `${path}/${pathName}`,
         child: [],
-        isLeafNode: currentNodeListStat[pathName].numChildren === 0,
+        isLeafNode: nodeStat.numChildren === 0,
         hasChildRendered: false
       });
     });


### PR DESCRIPTION
#### **Issue**

When browsing ZooKeeper nodes via the Pinot Controller UI (`Zookeeper Browser` tab), the UI crashes with the following error in the console:

Related to #14216


```
Uncaught (in promise) TypeError: Cannot read properties of null (reading 'numChildren')
```

This issue occurs when `currentNodeListStat[pathName]` is `null` or `undefined`, which can happen for certain ZNodes that exist but don’t have associated stat metadata (e.g., if there was a permission issue or deletion in progress).

This results in a **blank screen** and an unusable UI in certain scenarios. Screenshots showing the behavior:

* Working cluster shows a warning for `null` nodes:

* Failing cluster crashes on the same condition:

---

#### **Root Cause**

The existing logic assumes all `currentNodeListStat[pathName]` values are valid objects, and directly accesses `numChildren`. However, in real-world deployments, `null` values can be returned by ZooKeeper API due to inconsistent state or authorization limitations.

---

#### **Fix**

Updated the `getZookeeperData` function in `PinotMethodUtils.ts` to:

* Check if `currentNodeListStat[pathName]` is `null` or `undefined`
* Gracefully skip such nodes while logging a warning for visibility
* Avoids UI crashes and ensures the rest of the node tree loads properly

**Updated code snippet:**

```js
pathNames.forEach((pathName) => {
  const nodeStat = currentNodeListStat[pathName];

  // Skip if nodeStat is null or undefined
  if (!nodeStat) {
    console.warn(`Skipping null node for path: ${pathName}`);
    return;
  }

  newTreeData[0].child.push({
    nodeId: `${counter++}`,
    label: pathName,
    fullPath: path === '/' ? path + pathName : `${path}/${pathName}`,
    child: [],
    isLeafNode: nodeStat.numChildren === 0,
    hasChildRendered: false
  });
});
```

---

#### **Impact**

* Prevents UI from crashing on malformed or permission-limited ZooKeeper nodes
* Allows continued navigation of valid nodes
* Adds debug logging for `null` node cases to aid further troubleshooting

#### **Issue Screenshot**
<img width="1512" height="903" alt="image" src="https://github.com/user-attachments/assets/40e505ba-78fb-4674-ab56-a9583939745f" />

#### **After Fix Screenshot**
<img width="1512" height="904" alt="image" src="https://github.com/user-attachments/assets/15394423-d61e-41d6-b3a4-f8a9a505fa6a" />

