### PR TITLE
Gracefully handle bad segment time data during ingestion if continueOnError is true

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -558,29 +558,28 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
         } catch (Exception e) {
           if (!_config.isContinueOnError()) {
             throw e;
-          } else {
-            TimeUnit timeUnit;
-            long now = System.currentTimeMillis();
-            long convertedStartTime;
-            long convertedEndTime;
-            if (_config.getTimeColumnType() == SegmentGeneratorConfig.TimeColumnType.SIMPLE_DATE) {
-              convertedEndTime = now;
-              convertedStartTime = TimeUtils.getValidMinTimeMillis();
-              timeUnit = TimeUnit.MILLISECONDS;
-            } else {
-              timeUnit = Preconditions.checkNotNull(_config.getSegmentTimeUnit());
-              convertedEndTime = timeUnit.convert(now, TimeUnit.MILLISECONDS);
-              convertedStartTime = timeUnit.convert(TimeUtils.getValidMinTimeMillis(), TimeUnit.MILLISECONDS);
-            }
-            LOGGER.warn(
-                "Caught exception while writing time metadata for segment: {}, time column: {}, total docs: {}. "
-                    + "Continuing using current time ({}) as the end time, and min valid time ({}) as the start time "
-                    + "for the segment (time unit: {}).",
-                _segmentName, timeColumnName, _totalDocs, convertedEndTime, convertedStartTime, timeUnit, e);
-            properties.setProperty(SEGMENT_START_TIME, convertedStartTime);
-            properties.setProperty(SEGMENT_END_TIME, convertedEndTime);
-            properties.setProperty(TIME_UNIT, timeUnit);
           }
+          TimeUnit timeUnit;
+          long now = System.currentTimeMillis();
+          long convertedStartTime;
+          long convertedEndTime;
+          if (_config.getTimeColumnType() == SegmentGeneratorConfig.TimeColumnType.SIMPLE_DATE) {
+            convertedEndTime = now;
+            convertedStartTime = TimeUtils.getValidMinTimeMillis();
+            timeUnit = TimeUnit.MILLISECONDS;
+          } else {
+            timeUnit = Preconditions.checkNotNull(_config.getSegmentTimeUnit());
+            convertedEndTime = timeUnit.convert(now, TimeUnit.MILLISECONDS);
+            convertedStartTime = timeUnit.convert(TimeUtils.getValidMinTimeMillis(), TimeUnit.MILLISECONDS);
+          }
+          LOGGER.warn(
+              "Caught exception while writing time metadata for segment: {}, time column: {}, total docs: {}. "
+                  + "Continuing using current time ({}) as the end time, and min valid time ({}) as the start time "
+                  + "for the segment (time unit: {}).",
+              _segmentName, timeColumnName, _totalDocs, convertedEndTime, convertedStartTime, timeUnit, e);
+          properties.setProperty(SEGMENT_START_TIME, convertedStartTime);
+          properties.setProperty(SEGMENT_END_TIME, convertedEndTime);
+          properties.setProperty(TIME_UNIT, timeUnit);
         }
       }
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -569,10 +569,12 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
               timeUnit = Preconditions.checkNotNull(_config.getSegmentTimeUnit());
               convertedTime = timeUnit.convert(now, TimeUnit.MILLISECONDS);
             }
-            LOGGER.warn("Caught exception while writing time metadata for segment: {}, time column: {}, "
-                    + "total docs: {}. Continuing using current time ({}) as the start / end time for the segment.",
+            LOGGER.warn(
+                "Caught exception while writing time metadata for segment: {}, time column: {}, total docs: {}. "
+                    + "Continuing using current time ({}) as the end time, and Unix epoch as the start time for the "
+                    + "segment.",
                 _segmentName, timeColumnName, _totalDocs, now, e);
-            properties.setProperty(SEGMENT_START_TIME, convertedTime);
+            properties.setProperty(SEGMENT_START_TIME, 0);
             properties.setProperty(SEGMENT_END_TIME, convertedTime);
             properties.setProperty(TIME_UNIT, timeUnit);
           }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -498,62 +498,85 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
     if (timeColumnName != null) {
       ColumnIndexCreationInfo timeColumnIndexCreationInfo = _indexCreationInfoMap.get(timeColumnName);
       if (timeColumnIndexCreationInfo != null) {
-        long startTime;
-        long endTime;
-        TimeUnit timeUnit;
+        try {
+          long startTime;
+          long endTime;
+          TimeUnit timeUnit;
 
-        // Use start/end time in config if defined
-        if (_config.getStartTime() != null) {
-          startTime = Long.parseLong(_config.getStartTime());
-          endTime = Long.parseLong(_config.getEndTime());
-          timeUnit = Preconditions.checkNotNull(_config.getSegmentTimeUnit());
-        } else {
-          if (_totalDocs > 0) {
-            String startTimeStr = timeColumnIndexCreationInfo.getMin().toString();
-            String endTimeStr = timeColumnIndexCreationInfo.getMax().toString();
-
-            if (_config.getTimeColumnType() == SegmentGeneratorConfig.TimeColumnType.SIMPLE_DATE) {
-              // For TimeColumnType.SIMPLE_DATE_FORMAT, convert time value into millis since epoch
-              // Use DateTimeFormatter from DateTimeFormatSpec to handle default time zone consistently.
-              DateTimeFormatSpec formatSpec = _config.getDateTimeFormatSpec();
-              Preconditions.checkNotNull(formatSpec, "DateTimeFormatSpec must exist for SimpleDate");
-              DateTimeFormatter dateTimeFormatter = formatSpec.getDateTimeFormatter();
-              startTime = dateTimeFormatter.parseMillis(startTimeStr);
-              endTime = dateTimeFormatter.parseMillis(endTimeStr);
-              timeUnit = TimeUnit.MILLISECONDS;
-            } else {
-              // by default, time column type is TimeColumnType.EPOCH
-              startTime = Long.parseLong(startTimeStr);
-              endTime = Long.parseLong(endTimeStr);
-              timeUnit = Preconditions.checkNotNull(_config.getSegmentTimeUnit());
-            }
+          // Use start/end time in config if defined
+          if (_config.getStartTime() != null) {
+            startTime = Long.parseLong(_config.getStartTime());
+            endTime = Long.parseLong(_config.getEndTime());
+            timeUnit = Preconditions.checkNotNull(_config.getSegmentTimeUnit());
           } else {
-            // No records in segment. Use current time as start/end
-            long now = System.currentTimeMillis();
-            if (_config.getTimeColumnType() == SegmentGeneratorConfig.TimeColumnType.SIMPLE_DATE) {
-              startTime = now;
-              endTime = now;
-              timeUnit = TimeUnit.MILLISECONDS;
+            if (_totalDocs > 0) {
+              String startTimeStr = timeColumnIndexCreationInfo.getMin().toString();
+              String endTimeStr = timeColumnIndexCreationInfo.getMax().toString();
+
+              if (_config.getTimeColumnType() == SegmentGeneratorConfig.TimeColumnType.SIMPLE_DATE) {
+                // For TimeColumnType.SIMPLE_DATE_FORMAT, convert time value into millis since epoch
+                // Use DateTimeFormatter from DateTimeFormatSpec to handle default time zone consistently.
+                DateTimeFormatSpec formatSpec = _config.getDateTimeFormatSpec();
+                Preconditions.checkNotNull(formatSpec, "DateTimeFormatSpec must exist for SimpleDate");
+                DateTimeFormatter dateTimeFormatter = formatSpec.getDateTimeFormatter();
+                startTime = dateTimeFormatter.parseMillis(startTimeStr);
+                endTime = dateTimeFormatter.parseMillis(endTimeStr);
+                timeUnit = TimeUnit.MILLISECONDS;
+              } else {
+                // by default, time column type is TimeColumnType.EPOCH
+                startTime = Long.parseLong(startTimeStr);
+                endTime = Long.parseLong(endTimeStr);
+                timeUnit = Preconditions.checkNotNull(_config.getSegmentTimeUnit());
+              }
             } else {
-              timeUnit = Preconditions.checkNotNull(_config.getSegmentTimeUnit());
-              startTime = timeUnit.convert(now, TimeUnit.MILLISECONDS);
-              endTime = timeUnit.convert(now, TimeUnit.MILLISECONDS);
+              // No records in segment. Use current time as start/end
+              long now = System.currentTimeMillis();
+              if (_config.getTimeColumnType() == SegmentGeneratorConfig.TimeColumnType.SIMPLE_DATE) {
+                startTime = now;
+                endTime = now;
+                timeUnit = TimeUnit.MILLISECONDS;
+              } else {
+                timeUnit = Preconditions.checkNotNull(_config.getSegmentTimeUnit());
+                startTime = timeUnit.convert(now, TimeUnit.MILLISECONDS);
+                endTime = timeUnit.convert(now, TimeUnit.MILLISECONDS);
+              }
             }
           }
-        }
 
-        if (!_config.isSkipTimeValueCheck()) {
-          Interval timeInterval =
-              new Interval(timeUnit.toMillis(startTime), timeUnit.toMillis(endTime), DateTimeZone.UTC);
-          Preconditions.checkState(TimeUtils.isValidTimeInterval(timeInterval),
-              "Invalid segment start/end time: %s (in millis: %s/%s) for time column: %s, must be between: %s",
-              timeInterval, timeInterval.getStartMillis(), timeInterval.getEndMillis(), timeColumnName,
-              TimeUtils.VALID_TIME_INTERVAL);
-        }
+          if (!_config.isSkipTimeValueCheck()) {
+            Interval timeInterval =
+                new Interval(timeUnit.toMillis(startTime), timeUnit.toMillis(endTime), DateTimeZone.UTC);
+            Preconditions.checkState(TimeUtils.isValidTimeInterval(timeInterval),
+                "Invalid segment start/end time: %s (in millis: %s/%s) for time column: %s, must be between: %s",
+                timeInterval, timeInterval.getStartMillis(), timeInterval.getEndMillis(), timeColumnName,
+                TimeUtils.VALID_TIME_INTERVAL);
+          }
 
-        properties.setProperty(SEGMENT_START_TIME, startTime);
-        properties.setProperty(SEGMENT_END_TIME, endTime);
-        properties.setProperty(TIME_UNIT, timeUnit);
+          properties.setProperty(SEGMENT_START_TIME, startTime);
+          properties.setProperty(SEGMENT_END_TIME, endTime);
+          properties.setProperty(TIME_UNIT, timeUnit);
+        } catch (Exception e) {
+          if (!_config.isContinueOnError()) {
+            throw e;
+          } else {
+            TimeUnit timeUnit;
+            long now = System.currentTimeMillis();
+            long convertedTime;
+            if (_config.getTimeColumnType() == SegmentGeneratorConfig.TimeColumnType.SIMPLE_DATE) {
+              convertedTime = now;
+              timeUnit = TimeUnit.MILLISECONDS;
+            } else {
+              timeUnit = Preconditions.checkNotNull(_config.getSegmentTimeUnit());
+              convertedTime = timeUnit.convert(now, TimeUnit.MILLISECONDS);
+            }
+            LOGGER.warn("Caught exception while writing time metadata for segment: {}, time column: {}, "
+                    + "total docs: {}. Continuing using current time ({}) as the start / end time for the segment.",
+                _segmentName, timeColumnName, _totalDocs, now, e);
+            properties.setProperty(SEGMENT_START_TIME, convertedTime);
+            properties.setProperty(SEGMENT_END_TIME, convertedTime);
+            properties.setProperty(TIME_UNIT, timeUnit);
+          }
+        }
       }
     }
 

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/ColumnMetadataTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/ColumnMetadataTest.java
@@ -297,8 +297,8 @@ public class ColumnMetadataTest {
     SegmentMetadata segmentMetadata = new SegmentMetadataImpl(INDEX_DIR.listFiles()[0]);
     // The time unit being used is hours since epoch.
     long hoursSinceEpoch = System.currentTimeMillis() / TimeUnit.HOURS.toMillis(1);
-    // Use tolerance of 1 hour to eliminate any flakiness in the test.
-    Assert.assertTrue(hoursSinceEpoch - segmentMetadata.getStartTime() <= 1);
-    Assert.assertTrue(hoursSinceEpoch - segmentMetadata.getStartTime() <= 1);
+    // Use tolerance of 1 hour to eliminate any flakiness in the test due to time boundaries.
+    Assert.assertTrue(hoursSinceEpoch - segmentMetadata.getEndTime() <= 1);
+    Assert.assertEquals(segmentMetadata.getStartTime(), 0);
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/ColumnMetadataTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/ColumnMetadataTest.java
@@ -51,6 +51,7 @@ import org.apache.pinot.spi.data.DimensionFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.env.CommonsConfigurationUtils;
+import org.apache.pinot.spi.utils.TimeUtils;
 import org.apache.pinot.util.TestUtils;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
@@ -299,6 +300,7 @@ public class ColumnMetadataTest {
     long hoursSinceEpoch = System.currentTimeMillis() / TimeUnit.HOURS.toMillis(1);
     // Use tolerance of 1 hour to eliminate any flakiness in the test due to time boundaries.
     Assert.assertTrue(hoursSinceEpoch - segmentMetadata.getEndTime() <= 1);
-    Assert.assertEquals(segmentMetadata.getStartTime(), 0);
+    Assert.assertEquals(segmentMetadata.getStartTime(),
+        TimeUnit.MILLISECONDS.toHours(TimeUtils.getValidMinTimeMillis()));
   }
 }


### PR DESCRIPTION
- This PR will be trivial to review with GitHub's hide whitespace option - all it does is gracefully handle any time parsing issue during segment creation if `continueOnError` is `true` and use the current time as the start time / end time in the segment metadata (similar to the case where a segment has 0 docs).