### PR TITLE
Fix var-length dictionary validation on BIG_DECIMAL

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/dictionary/DictionaryIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/dictionary/DictionaryIndexType.java
@@ -108,9 +108,9 @@ public class DictionaryIndexType
     DictionaryIndexConfig dictionaryConfig = indexConfigs.getConfig(StandardIndexes.dictionary());
     if (dictionaryConfig.isEnabled() && dictionaryConfig.getUseVarLengthDictionary()) {
       DataType storedType = fieldSpec.getDataType().getStoredType();
-      Preconditions.checkState(storedType == DataType.STRING || storedType == DataType.BYTES,
-          "Cannot create var-length dictionary on column: %s of stored type other than STRING or BYTES",
-          fieldSpec.getName());
+      Preconditions.checkState(!storedType.isFixedWidth(),
+          "Cannot create var-length dictionary on column: %s of fixed-width stored type: %s", fieldSpec.getName(),
+          storedType);
     }
   }
 

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -1441,6 +1441,7 @@ public class TableConfigUtilsTest {
         .addSingleValueDimension("myCol", FieldSpec.DataType.STRING)
         .addSingleValueDimension("bytesCol", FieldSpec.DataType.BYTES)
         .addSingleValueDimension("intCol", FieldSpec.DataType.INT)
+        .addSingleValueDimension("bigDecimalCol", FieldSpec.DataType.BIG_DECIMAL)
         .addMultiValueDimension("multiValCol", FieldSpec.DataType.STRING)
         .build();
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
@@ -1708,11 +1709,16 @@ public class TableConfigUtilsTest {
     }
 
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
+        .setVarLengthDictionaryColumns(Arrays.asList("myCol", "bytesCol", "bigDecimalCol", "multiValCol"))
+        .build();
+    TableConfigUtils.validate(tableConfig, schema);
+
+    tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setVarLengthDictionaryColumns(Arrays.asList("intCol"))
         .build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
-      fail("Should fail for Var length dictionary defined for non string/bytes column");
+      fail("Should fail for Var length dictionary defined for fixed-width column");
     } catch (Exception e) {
       // expected
     }


### PR DESCRIPTION
Fix the bug introduced in #16025 which doesn't allow var-length dictionary on `BIG_DECIMAL`