### PR TITLE
Make VARIANT/UUID non reserved keyword

### DIFF
--- a/pinot-common/src/main/codegen/config.fmpp
+++ b/pinot-common/src/main/codegen/config.fmpp
@@ -44,10 +44,15 @@ data: {
     keywords: [
       "FILE"
       "ARCHIVE"
-      "BIG_DECIMAL"
-      "BYTES"
+      # Pinot types allowed in CAST function
+      # LONG - for BIGINT
+      # BIG_DECIMAL - for DECIMAL
+      # STRING - for VARCHAR
+      # BYTES - for VARBINARY
       "LONG"
+      "BIG_DECIMAL"
       "STRING"
+      "BYTES"
     ]
 
     # List of non-reserved keywords to add;
@@ -55,14 +60,16 @@ data: {
     nonReservedKeywordsToAdd: [
       "FILE"
       "ARCHIVE"
-      "BIG_DECIMAL"
-      "BYTES"
-      "LONG"
-      "STRING"
       # Pinot allows using DEFAULT as the catalog name
       "DEFAULT_"
-      # Pinot allows using DATETIME as column name
+      # Pinot allows using LONG/BIG_DECIMAL/STRING/BYTES/DATETIME/VARIANT/UUID as column name
+      "LONG"
+      "BIG_DECIMAL"
+      "STRING"
+      "BYTES"
       "DATETIME"
+      "VARIANT"
+      "UUID"
 
       # The following keywords are reserved in core Calcite,
       # are reserved in some version of SQL,

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CastTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CastTransformFunction.java
@@ -57,10 +57,6 @@ public class CastTransformFunction extends BaseTransformFunction {
     if (castFormatTransformFunction instanceof LiteralTransformFunction) {
       String targetType = ((LiteralTransformFunction) castFormatTransformFunction).getStringLiteral().toUpperCase();
       switch (targetType) {
-        case "BYTES":
-        case "VARBINARY":
-          _resultMetadata = sourceSV ? BYTES_SV_NO_DICTIONARY_METADATA : BYTES_MV_NO_DICTIONARY_METADATA;
-          break;
         case "INT":
         case "INTEGER":
           _resultMetadata = sourceSV ? INT_SV_NO_DICTIONARY_METADATA : INT_MV_NO_DICTIONARY_METADATA;
@@ -93,6 +89,13 @@ public class CastTransformFunction extends BaseTransformFunction {
         case "VARCHAR":
           _resultMetadata = sourceSV ? STRING_SV_NO_DICTIONARY_METADATA : STRING_MV_NO_DICTIONARY_METADATA;
           break;
+        case "JSON":
+          _resultMetadata = sourceSV ? JSON_SV_NO_DICTIONARY_METADATA : JSON_MV_NO_DICTIONARY_METADATA;
+          break;
+        case "BYTES":
+        case "VARBINARY":
+          _resultMetadata = sourceSV ? BYTES_SV_NO_DICTIONARY_METADATA : BYTES_MV_NO_DICTIONARY_METADATA;
+          break;
         case "INT_ARRAY":
         case "INTEGER_ARRAY":
           _resultMetadata = INT_MV_NO_DICTIONARY_METADATA;
@@ -109,9 +112,6 @@ public class CastTransformFunction extends BaseTransformFunction {
         case "STRING_ARRAY":
         case "VARCHAR_ARRAY":
           _resultMetadata = STRING_MV_NO_DICTIONARY_METADATA;
-          break;
-        case "JSON":
-          _resultMetadata = sourceSV ? JSON_SV_NO_DICTIONARY_METADATA : JSON_MV_NO_DICTIONARY_METADATA;
           break;
         default:
           throw new IllegalArgumentException("Unable to cast expression to type - " + targetType);


### PR DESCRIPTION
`VARIANT` and `UUID` were introduced in Calcite `1.39.0`
Mark them as non reserved keyword to maintain backward compatibility