### PR TITLE
[Bug fix] Update logic that determines if a table is associated with a tenant

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTenantRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTenantRestletResource.java
@@ -409,8 +409,11 @@ public class PinotTenantRestletResource {
         LOGGER.error("Unable to retrieve table config for table: {}", tableNameWithType);
         continue;
       }
-      Set<String> relevantTags = TableConfigUtils.getRelevantTags(tableConfig);
-      if (relevantTags.contains(TagNameUtils.getServerTagForTenant(tenantName, tableConfig.getTableType()))) {
+      Set<String> relevantTenants = TableConfigUtils.getRelevantTags(tableConfig)
+          .stream()
+          .map(TagNameUtils::getTenantFromTag)
+          .collect(Collectors.toSet());
+      if (relevantTenants.contains(tenantName)) {
         tables.add(tableNameWithType);
         if (withTableProperties) {
           IdealState idealState = _pinotHelixResourceManager.getTableIdealState(tableNameWithType);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/tenant/DefaultTenantRebalancer.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/tenant/DefaultTenantRebalancer.java
@@ -29,6 +29,7 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pinot.common.exception.TableNotFoundException;
@@ -186,8 +187,10 @@ public class DefaultTenantRebalancer implements TenantRebalancer {
         LOGGER.error("Unable to retrieve table config for table: {}", table);
         continue;
       }
-      Set<String> relevantTags = TableConfigUtils.getRelevantTags(tableConfig);
-      if (relevantTags.contains(TagNameUtils.getServerTagForTenant(tenantName, tableConfig.getTableType()))) {
+      Set<String> relevantTenants =
+          TableConfigUtils.getRelevantTags(tableConfig).stream().map(TagNameUtils::getTenantFromTag).collect(
+              Collectors.toSet());
+      if (relevantTenants.contains(tenantName)) {
         tables.add(table);
       }
     }


### PR DESCRIPTION
## Description
With the original logic, if a table has a config:
```
{
  ...
  "tableType": "REALTIME",
  "tenants": {
    "tagOverride": {
      "realtimeCompleted": "DefaultTenant_OFFLINE"
    }
  ...
```
Then this table will not be included for APIs
`GET /tenants/DefaultTenant/tables`
and 
`POST /tenants/DefaultTenant/rebalance`, which is not correct.