### PR TITLE
Enhance REGEXP_LIKE to scan dictionary when dictionary is small

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/FilterOperatorUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/FilterOperatorUtils.java
@@ -23,7 +23,7 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.OptionalInt;
 import org.apache.pinot.common.request.context.predicate.Predicate;
-import org.apache.pinot.common.request.context.predicate.RegexpLikePredicate;
+import org.apache.pinot.core.operator.filter.predicate.BaseDictIdBasedRegexpLikePredicateEvaluator;
 import org.apache.pinot.core.operator.filter.predicate.PredicateEvaluator;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.segment.spi.datasource.DataSource;
@@ -54,20 +54,19 @@ public class FilterOperatorUtils {
     /**
      * Returns the AND filter operator or equivalent filter operator.
      */
-    BaseFilterOperator getAndFilterOperator(QueryContext queryContext,
-        List<BaseFilterOperator> filterOperators, int numDocs);
+    BaseFilterOperator getAndFilterOperator(QueryContext queryContext, List<BaseFilterOperator> filterOperators,
+        int numDocs);
 
     /**
      * Returns the OR filter operator or equivalent filter operator.
      */
-    BaseFilterOperator getOrFilterOperator(QueryContext queryContext,
-        List<BaseFilterOperator> filterOperators, int numDocs);
+    BaseFilterOperator getOrFilterOperator(QueryContext queryContext, List<BaseFilterOperator> filterOperators,
+        int numDocs);
 
     /**
      * Returns the NOT filter operator or equivalent filter operator.
      */
-    BaseFilterOperator getNotFilterOperator(QueryContext queryContext, BaseFilterOperator filterOperator,
-        int numDocs);
+    BaseFilterOperator getNotFilterOperator(QueryContext queryContext, BaseFilterOperator filterOperator, int numDocs);
   }
 
   public static class DefaultImplementation implements Implementation {
@@ -107,24 +106,12 @@ public class FilterOperatorUtils {
         }
         return new ScanBasedFilterOperator(queryContext, predicateEvaluator, dataSource, numDocs);
       } else if (predicateType == Predicate.Type.REGEXP_LIKE) {
-        // Check if case-insensitive flag is present
-        RegexpLikePredicate regexpLikePredicate = (RegexpLikePredicate) predicateEvaluator.getPredicate();
-        boolean caseInsensitive = regexpLikePredicate.isCaseInsensitive();
-        if (caseInsensitive) {
-          if (dataSource.getIFSTIndex() != null && dataSource.getDataSourceMetadata().isSorted()
+        if (predicateEvaluator instanceof BaseDictIdBasedRegexpLikePredicateEvaluator) {
+          if (dataSource.getDataSourceMetadata().isSorted()
               && queryContext.isIndexUseAllowed(dataSource, FieldConfig.IndexType.SORTED)) {
             return new SortedIndexBasedFilterOperator(queryContext, predicateEvaluator, dataSource, numDocs);
           }
-          if (dataSource.getIFSTIndex() != null && dataSource.getInvertedIndex() != null
-              && queryContext.isIndexUseAllowed(dataSource, FieldConfig.IndexType.INVERTED)) {
-            return new InvertedIndexFilterOperator(queryContext, predicateEvaluator, dataSource, numDocs);
-          }
-        } else {
-          if (dataSource.getFSTIndex() != null && dataSource.getDataSourceMetadata().isSorted()
-              && queryContext.isIndexUseAllowed(dataSource, FieldConfig.IndexType.SORTED)) {
-            return new SortedIndexBasedFilterOperator(queryContext, predicateEvaluator, dataSource, numDocs);
-          }
-          if (dataSource.getFSTIndex() != null && dataSource.getInvertedIndex() != null
+          if (dataSource.getInvertedIndex() != null
               && queryContext.isIndexUseAllowed(dataSource, FieldConfig.IndexType.INVERTED)) {
             return new InvertedIndexFilterOperator(queryContext, predicateEvaluator, dataSource, numDocs);
           }
@@ -174,8 +161,8 @@ public class FilterOperatorUtils {
     }
 
     @Override
-    public BaseFilterOperator getOrFilterOperator(QueryContext queryContext,
-        List<BaseFilterOperator> filterOperators, int numDocs) {
+    public BaseFilterOperator getOrFilterOperator(QueryContext queryContext, List<BaseFilterOperator> filterOperators,
+        int numDocs) {
       List<BaseFilterOperator> childFilterOperators = new ArrayList<>(filterOperators.size());
       for (BaseFilterOperator filterOperator : filterOperators) {
         if (filterOperator.isResultMatchingAll()) {
@@ -209,7 +196,6 @@ public class FilterOperatorUtils {
 
       return new NotFilterOperator(filterOperator, numDocs, queryContext.isNullHandlingEnabled());
     }
-
 
     /**
      * For AND filter operator, reorders its child filter operators based on their cost and puts the ones with

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/BaseDictIdBasedRegexpLikePredicateEvaluator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/BaseDictIdBasedRegexpLikePredicateEvaluator.java
@@ -1,0 +1,31 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.filter.predicate;
+
+import org.apache.pinot.common.request.context.predicate.Predicate;
+import org.apache.pinot.segment.spi.index.reader.Dictionary;
+
+
+/// Base class for dictionary-based REGEXP_LIKE predicate evaluators that use dictionary IDs for matching.
+public abstract class BaseDictIdBasedRegexpLikePredicateEvaluator extends BaseDictionaryBasedPredicateEvaluator {
+
+  protected BaseDictIdBasedRegexpLikePredicateEvaluator(Predicate predicate, Dictionary dictionary) {
+    super(predicate, dictionary);
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/FSTBasedRegexpPredicateEvaluatorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/FSTBasedRegexpPredicateEvaluatorFactory.java
@@ -49,7 +49,7 @@ public class FSTBasedRegexpPredicateEvaluatorFactory {
   /**
    * Matches regexp query using FSTIndexReader.
    */
-  private static class FSTBasedRegexpPredicateEvaluator extends BaseDictionaryBasedPredicateEvaluator {
+  private static class FSTBasedRegexpPredicateEvaluator extends BaseDictIdBasedRegexpLikePredicateEvaluator {
     final ImmutableRoaringBitmap _matchingDictIdBitmap;
 
     public FSTBasedRegexpPredicateEvaluator(RegexpLikePredicate regexpLikePredicate, TextIndexReader fstIndexReader,

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/IFSTBasedRegexpPredicateEvaluatorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/IFSTBasedRegexpPredicateEvaluatorFactory.java
@@ -45,7 +45,7 @@ public class IFSTBasedRegexpPredicateEvaluatorFactory {
     return new IFSTBasedRegexpPredicateEvaluator(regexpLikePredicate, ifstIndexReader, dictionary);
   }
 
-  private static class IFSTBasedRegexpPredicateEvaluator extends BaseDictionaryBasedPredicateEvaluator {
+  private static class IFSTBasedRegexpPredicateEvaluator extends BaseDictIdBasedRegexpLikePredicateEvaluator {
     final ImmutableRoaringBitmap _matchingDictIdBitmap;
 
     public IFSTBasedRegexpPredicateEvaluator(RegexpLikePredicate regexpLikePredicate,


### PR DESCRIPTION
Currently REGEXP_LIKE without FST/IFST index always performs raw value scan even with dictionary. We don't match on dictionary id to avoid scanning the entire dictionary.
This is not efficient when the dictionary is small, where we prefer scanning the dictionary and perform matches on dictionary ids. This is particularly useful for new added columns/virtual columns with single element dictionary.
This PR adds a threshold (10000) to decide whether to scan the dictionary when evaluating `REGEXP_LIKE` predicate.