### PR TITLE
Bug: Field shadowing in SparkSegmentTarPushJobRunner causes _spec to be null

### DIFF
--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark3/SparkSegmentTarPushJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark3/SparkSegmentTarPushJobRunner.java
@@ -36,8 +36,7 @@ import org.apache.spark.api.java.JavaSparkContext;
 import org.apache.spark.api.java.function.VoidFunction;
 
 public class SparkSegmentTarPushJobRunner extends BaseSparkSegmentTarPushJobRunner {
-  private SegmentGenerationJobSpec _spec;
-
+  
   public SparkSegmentTarPushJobRunner() {
     super();
   }


### PR DESCRIPTION
**Description**
The SparkSegmentTarPushJobRunner class has a field shadowing issue where the _spec field is declared in both the parent class (BaseSparkSegmentTarPushJobRunner) and child class, causing the child class to access an uninitialized null field instead of the properly initialised parent field.

**Steps to Reproduce**

1.  Instantiate SparkSegmentTarPushJobRunner with a SegmentGenerationJobSpec
2. Access the _spec field from within the child class
3. Observe that _spec is null despite being passed to the constructor

**Expected Behaviour**
The _spec field should be properly initialised and accessible in the child class.
**Actual Behaviour**
The _spec field is null in the child class due to field shadowing.
**Root Cause**
The issue occurs because:

1. BaseSparkSegmentTarPushJobRunner declares protected SegmentGenerationJobSpec _spec.
2. SparkSegmentTarPushJobRunner redeclares private SegmentGenerationJobSpec _spec.
3. When super(spec) is called, it initialises the parent's _spec field.
4. The child class accesses its own uninitialised _spec field instead of the parent's initialised field.