### PR TITLE
Remove unnecessary methods and config for ThreadResourceUsageAccountant

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/accounting/PerQueryCPUMemAccountantFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/accounting/PerQueryCPUMemAccountantFactory.java
@@ -127,9 +127,6 @@ public class PerQueryCPUMemAccountantFactory implements ThreadAccountantFactory 
     // track memory usage
     protected final boolean _isThreadMemorySamplingEnabled;
 
-    // is sampling allowed for MSE queries
-    protected final boolean _isThreadSamplingEnabledForMSE;
-
     protected final Set<String> _inactiveQuery;
 
     protected Set<String> _cancelSentQueries;
@@ -148,7 +145,6 @@ public class PerQueryCPUMemAccountantFactory implements ThreadAccountantFactory 
       _config = config;
       _isThreadCPUSamplingEnabled = isThreadCPUSamplingEnabled;
       _isThreadMemorySamplingEnabled = isThreadMemorySamplingEnabled;
-      _isThreadSamplingEnabledForMSE = isThreadSamplingEnabledForMSE;
       _inactiveQuery = inactiveQuery;
       _instanceId = instanceId;
       _instanceType = instanceType;
@@ -183,11 +179,6 @@ public class PerQueryCPUMemAccountantFactory implements ThreadAccountantFactory 
       _isThreadMemorySamplingEnabled = memorySamplingConfig && threadMemoryMeasurementEnabled;
       LOGGER.info("_isThreadCPUSamplingEnabled: {}, _isThreadMemorySamplingEnabled: {}", _isThreadCPUSamplingEnabled,
           _isThreadMemorySamplingEnabled);
-
-      _isThreadSamplingEnabledForMSE =
-          config.getProperty(CommonConstants.Accounting.CONFIG_OF_ENABLE_THREAD_SAMPLING_MSE,
-              CommonConstants.Accounting.DEFAULT_ENABLE_THREAD_SAMPLING_MSE);
-      LOGGER.info("_isThreadSamplingEnabledForMSE: {}", _isThreadSamplingEnabledForMSE);
 
       _queryCancelCallbacks = CacheBuilder.newBuilder().maximumSize(
               config.getProperty(CommonConstants.Accounting.CONFIG_OF_CANCEL_CALLBACK_CACHE_MAX_SIZE,
@@ -272,17 +263,6 @@ public class PerQueryCPUMemAccountantFactory implements ThreadAccountantFactory 
     public void sampleUsage() {
       sampleThreadBytesAllocated();
       sampleThreadCPUTime();
-    }
-
-    /**
-     * Sample Usage for Multi-stage engine queries
-     */
-    @Override
-    public void sampleUsageMSE() {
-      if (_isThreadSamplingEnabledForMSE) {
-        sampleThreadBytesAllocated();
-        sampleThreadCPUTime();
-      }
     }
 
     @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/accounting/ResourceUsageAccountantFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/accounting/ResourceUsageAccountantFactory.java
@@ -82,9 +82,6 @@ public class ResourceUsageAccountantFactory implements ThreadAccountantFactory {
     // track memory usage
     private final boolean _isThreadMemorySamplingEnabled;
 
-    // is sampling allowed for MSE queries
-    private final boolean _isThreadSamplingEnabledForMSE;
-
     private final WatcherTask _watcherTask;
 
     private final EnumMap<TrackingScope, ResourceAggregator> _resourceAggregators;
@@ -109,11 +106,6 @@ public class ResourceUsageAccountantFactory implements ThreadAccountantFactory {
       LOGGER.info("_isThreadCPUSamplingEnabled: {}, _isThreadMemorySamplingEnabled: {}", _isThreadCPUSamplingEnabled,
           _isThreadMemorySamplingEnabled);
 
-      _isThreadSamplingEnabledForMSE =
-          config.getProperty(CommonConstants.Accounting.CONFIG_OF_ENABLE_THREAD_SAMPLING_MSE,
-              CommonConstants.Accounting.DEFAULT_ENABLE_THREAD_SAMPLING_MSE);
-      LOGGER.info("_isThreadSamplingEnabledForMSE: {}", _isThreadSamplingEnabledForMSE);
-
       _watcherTask = new WatcherTask();
 
       _resourceAggregators = new EnumMap<>(TrackingScope.class);
@@ -136,14 +128,6 @@ public class ResourceUsageAccountantFactory implements ThreadAccountantFactory {
     public void sampleUsage() {
       sampleThreadBytesAllocated();
       sampleThreadCPUTime();
-    }
-
-    @Override
-    public void sampleUsageMSE() {
-      if (_isThreadSamplingEnabledForMSE) {
-        sampleThreadBytesAllocated();
-        sampleThreadCPUTime();
-      }
     }
 
     @Override

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java
@@ -97,7 +97,7 @@ public abstract class MultiStageOperator
       earlyTerminate();
       throw QueryErrorCode.EXECUTION_TIMEOUT.asException("Timing out on " + getExplainName());
     }
-    Tracing.ThreadAccountantOps.sampleMSE();
+    Tracing.ThreadAccountantOps.sample();
     if (Tracing.ThreadAccountantOps.isInterrupted()) {
       earlyTerminate();
       throw QueryErrorCode.SERVER_RESOURCE_LIMIT_EXCEEDED.asException("Resource limit exceeded for operator: "

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MultiStageAccountingTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MultiStageAccountingTest.java
@@ -92,7 +92,7 @@ public class MultiStageAccountingTest implements ITest {
     configs.put(CommonConstants.Accounting.CONFIG_OF_OOM_PROTECTION_KILLING_QUERY, true);
     // init accountant and start watcher task
     Tracing.unregisterThreadAccountant();
-    Tracing.ThreadAccountantOps.initializeThreadAccountant(new PinotConfiguration(configs), "testGroupBy",
+    Tracing.ThreadAccountantOps.createThreadAccountant(new PinotConfiguration(configs), "testGroupBy",
         InstanceType.SERVER);
     Tracing.ThreadAccountantOps.startThreadAccountant();
 

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MultistageResourceUsageAccountingTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MultistageResourceUsageAccountingTest.java
@@ -92,7 +92,7 @@ public class MultistageResourceUsageAccountingTest implements ITest {
     // init accountant and start watcher task
     PinotConfiguration pinotCfg = new PinotConfiguration(configs);
     Tracing.unregisterThreadAccountant();
-    Tracing.ThreadAccountantOps.initializeThreadAccountant(pinotCfg, "testGroupBy", InstanceType.SERVER);
+    Tracing.ThreadAccountantOps.createThreadAccountant(pinotCfg, "testGroupBy", InstanceType.SERVER);
     Tracing.ThreadAccountantOps.startThreadAccountant();
 
     // Setup Thread Context

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/accounting/ThreadResourceUsageAccountant.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/accounting/ThreadResourceUsageAccountant.java
@@ -75,11 +75,6 @@ public interface ThreadResourceUsageAccountant {
    */
   void sampleUsage();
 
-  /**
-   * Sample Usage for Multi-stage engine queries
-   */
-  void sampleUsageMSE();
-
   default boolean throttleQuerySubmission() {
     return false;
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/trace/Tracing.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/trace/Tracing.java
@@ -207,10 +207,6 @@ public class Tracing {
     }
 
     @Override
-    public void sampleUsageMSE() {
-    }
-
-    @Override
     public void updateQueryUsageConcurrently(String queryId, long cpuTimeNs, long allocatedBytes,
         TrackingScope trackingScope) {
       // No-op for default accountant
@@ -301,11 +297,6 @@ public class Tracing {
 
     public static void clear() {
       Tracing.getThreadAccountant().clear();
-    }
-
-    public static void initializeThreadAccountant(PinotConfiguration config, String instanceId,
-        InstanceType instanceType) {
-      createThreadAccountant(config, instanceId, instanceType);
     }
 
     public static ThreadResourceUsageAccountant createThreadAccountant(PinotConfiguration config, String instanceId,

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/trace/Tracing.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/trace/Tracing.java
@@ -291,10 +291,6 @@ public class Tracing {
       Tracing.getThreadAccountant().sampleUsage();
     }
 
-    public static void sampleMSE() {
-      Tracing.getThreadAccountant().sampleUsageMSE();
-    }
-
     public static void clear() {
       Tracing.getThreadAccountant().clear();
     }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -1538,9 +1538,6 @@ public class CommonConstants {
     public static final String CONFIG_OF_QUERY_KILLED_METRIC_ENABLED = "accounting.query.killed.metric.enabled";
     public static final boolean DEFAULT_QUERY_KILLED_METRIC_ENABLED = false;
 
-    public static final String CONFIG_OF_ENABLE_THREAD_SAMPLING_MSE = "accounting.enable.thread.sampling.mse.debug";
-    public static final Boolean DEFAULT_ENABLE_THREAD_SAMPLING_MSE = true;
-
     public static final String CONFIG_OF_CANCEL_CALLBACK_CACHE_MAX_SIZE = "accounting.cancel.callback.cache.max.size";
     public static final int DEFAULT_CANCEL_CALLBACK_CACHE_MAX_SIZE = 500;
 

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/executor/ThrottleOnCriticalHeapUsageExecutorTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/executor/ThrottleOnCriticalHeapUsageExecutorTest.java
@@ -76,10 +76,6 @@ public class ThrottleOnCriticalHeapUsageExecutorTest {
       }
 
       @Override
-      public void sampleUsageMSE() {
-      }
-
-      @Override
       public boolean throttleQuerySubmission() {
         return _numCalls.getAndIncrement() > 1;
       }


### PR DESCRIPTION
Remove:
* `Tracing.ThreadAccountantOps.initializeThreadAccountant`
* `Tracing.ThreadAccountatOps.sampleMSE` and related functions and tests. MSE operators now use the the sample method