### PR TITLE
[Auto reset 1/3]Auto reset offset during ingestion lag

### DIFF
--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
@@ -333,7 +333,8 @@ public class PinotLLCRealtimeSegmentManagerTest {
   }
 
   @Test
-  public void testCommitSegmentWithOffsetAutoReset() throws Exception {
+  public void testCommitSegmentWithOffsetAutoReset()
+      throws Exception {
     // Set up a new table with 2 replicas, 5 instances, 4 partition
     PinotHelixResourceManager mockHelixResourceManager = mock(PinotHelixResourceManager.class);
     FakePinotLLCRealtimeSegmentManager segmentManager =
@@ -341,19 +342,16 @@ public class PinotLLCRealtimeSegmentManagerTest {
     setUpNewTable(segmentManager, 2, 5, 4);
     Map<String, Map<String, String>> instanceStatesMap = segmentManager._idealState.getRecord().getMapFields();
     Map<String, String> streamConfigMap = IngestionConfigUtils.getStreamConfigMaps(segmentManager._tableConfig).get(0);
-    streamConfigMap.put(
-        StreamConfigProperties.OFFSET_AUTO_RESET_OFFSET_THRESHOLD_KEY, "100"
-    );
+    streamConfigMap.put(StreamConfigProperties.ENABLE_OFFSET_AUTO_RESET, String.valueOf(true));
+    streamConfigMap.put(StreamConfigProperties.OFFSET_AUTO_RESET_OFFSET_THRESHOLD_KEY, "100");
     segmentManager.makeTableConfig(streamConfigMap);
 
     StreamConsumerFactory mockConsumerFactory = mock(StreamConsumerFactory.class);
     StreamMetadataProvider mockMetadataProvider = mock(StreamMetadataProvider.class);
-    when(mockConsumerFactory.createPartitionMetadataProvider(anyString(), anyInt()))
-        .thenReturn(mockMetadataProvider);
-    when(mockMetadataProvider.fetchStreamPartitionOffset(eq(OffsetCriteria.LARGEST_OFFSET_CRITERIA), anyLong()))
-        .thenReturn(new LongMsgOffset(LATEST_OFFSET));
-    when(mockMetadataProvider.getOffsetAtTimestamp(eq(0), anyLong()))
-        .thenReturn(PARTITION_OFFSET);
+    when(mockConsumerFactory.createPartitionMetadataProvider(anyString(), anyInt())).thenReturn(mockMetadataProvider);
+    when(mockMetadataProvider.fetchStreamPartitionOffset(eq(OffsetCriteria.LARGEST_OFFSET_CRITERIA),
+        anyLong())).thenReturn(new LongMsgOffset(LATEST_OFFSET));
+    when(mockMetadataProvider.getOffsetAtTimestamp(eq(0), anyLong())).thenReturn(PARTITION_OFFSET);
 
     try (MockedStatic<StreamConsumerFactoryProvider> mockedStaticProvider = mockStatic(
         StreamConsumerFactoryProvider.class)) {

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
@@ -353,7 +353,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
     when(mockConsumerFactory.createStreamMsgOffsetFactory()).thenReturn(new LongMsgOffsetFactory());
     when(mockMetadataProvider.fetchStreamPartitionOffset(eq(OffsetCriteria.LARGEST_OFFSET_CRITERIA),
         anyLong())).thenReturn(new LongMsgOffset(LATEST_OFFSET));
-    when(mockMetadataProvider.getOffsetAtTimestamp(eq(0), anyLong())).thenReturn(PARTITION_OFFSET);
+    when(mockMetadataProvider.getOffsetAtTimestamp(eq(0), anyLong(), anyLong())).thenReturn(PARTITION_OFFSET);
 
     try (MockedStatic<StreamConsumerFactoryProvider> mockedStaticProvider = mockStatic(
         StreamConsumerFactoryProvider.class)) {
@@ -419,7 +419,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
     when(mockConsumerFactory.createStreamMsgOffsetFactory()).thenReturn(new LongMsgOffsetFactory());
     when(mockMetadataProvider.fetchStreamPartitionOffset(eq(OffsetCriteria.LARGEST_OFFSET_CRITERIA),
         anyLong())).thenReturn(new LongMsgOffset(LATEST_OFFSET));
-    when(mockMetadataProvider.getOffsetAtTimestamp(eq(0), anyLong())).thenReturn(
+    when(mockMetadataProvider.getOffsetAtTimestamp(eq(0), anyLong(), anyLong())).thenReturn(
         new LongMsgOffset(PARTITION_OFFSET.getOffset() + 1L));
 
     try (MockedStatic<StreamConsumerFactoryProvider> mockedStaticProvider = mockStatic(

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
@@ -77,9 +77,14 @@ import org.apache.pinot.spi.config.table.assignment.InstancePartitionsType;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.filesystem.PinotFSFactory;
 import org.apache.pinot.spi.stream.LongMsgOffset;
+import org.apache.pinot.spi.stream.OffsetCriteria;
 import org.apache.pinot.spi.stream.PartitionGroupConsumptionStatus;
 import org.apache.pinot.spi.stream.PartitionGroupMetadata;
 import org.apache.pinot.spi.stream.StreamConfig;
+import org.apache.pinot.spi.stream.StreamConfigProperties;
+import org.apache.pinot.spi.stream.StreamConsumerFactory;
+import org.apache.pinot.spi.stream.StreamConsumerFactoryProvider;
+import org.apache.pinot.spi.stream.StreamMetadataProvider;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.CommonConstants.Helix;
 import org.apache.pinot.spi.utils.CommonConstants.Helix.Instance;
@@ -91,6 +96,7 @@ import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.util.TestUtils;
 import org.apache.zookeeper.data.Stat;
 import org.joda.time.Interval;
+import org.mockito.MockedStatic;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
@@ -122,6 +128,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
   static final String CRC = Long.toString(RANDOM.nextLong() & 0xFFFFFFFFL);
   static final SegmentVersion SEGMENT_VERSION = RANDOM.nextBoolean() ? SegmentVersion.v1 : SegmentVersion.v3;
   static final int NUM_DOCS = RANDOM.nextInt(Integer.MAX_VALUE) + 1;
+  static final long LATEST_OFFSET = PARTITION_OFFSET.getOffset() * 2 + NUM_DOCS;
   static final int SEGMENT_SIZE_IN_BYTES = 100000000;
   @AfterClass
   public void tearDown()
@@ -323,6 +330,73 @@ public class PinotLLCRealtimeSegmentManagerTest {
 
     consumingSegmentZKMetadata = segmentManager._segmentZKMetadataMap.get(consumingSegment);
     assertNull(consumingSegmentZKMetadata);
+  }
+
+  @Test
+  public void testCommitSegmentWithOffsetAutoReset() throws Exception {
+    // Set up a new table with 2 replicas, 5 instances, 4 partition
+    PinotHelixResourceManager mockHelixResourceManager = mock(PinotHelixResourceManager.class);
+    FakePinotLLCRealtimeSegmentManager segmentManager =
+        new FakePinotLLCRealtimeSegmentManager(mockHelixResourceManager);
+    setUpNewTable(segmentManager, 2, 5, 4);
+    Map<String, Map<String, String>> instanceStatesMap = segmentManager._idealState.getRecord().getMapFields();
+    Map<String, String> streamConfigMap = IngestionConfigUtils.getStreamConfigMaps(segmentManager._tableConfig).get(0);
+    streamConfigMap.put(
+        StreamConfigProperties.OFFSET_AUTO_RESET_OFFSET_THRESHOLD_KEY, "100"
+    );
+    segmentManager.makeTableConfig(streamConfigMap);
+
+    StreamConsumerFactory mockConsumerFactory = mock(StreamConsumerFactory.class);
+    StreamMetadataProvider mockMetadataProvider = mock(StreamMetadataProvider.class);
+    when(mockConsumerFactory.createPartitionMetadataProvider(anyString(), anyInt()))
+        .thenReturn(mockMetadataProvider);
+    when(mockMetadataProvider.fetchStreamPartitionOffset(eq(OffsetCriteria.LARGEST_OFFSET_CRITERIA), anyLong()))
+        .thenReturn(new LongMsgOffset(LATEST_OFFSET));
+    when(mockMetadataProvider.getOffsetAtTimestamp(eq(0), anyLong()))
+        .thenReturn(PARTITION_OFFSET);
+
+    try (MockedStatic<StreamConsumerFactoryProvider> mockedStaticProvider = mockStatic(
+        StreamConsumerFactoryProvider.class)) {
+
+      mockedStaticProvider.when(() -> StreamConsumerFactoryProvider.create(segmentManager._streamConfigs.get(0)))
+          .thenReturn(mockConsumerFactory);
+
+      // Commit a segment for partition group 0
+      String committingSegment = new LLCSegmentName(RAW_TABLE_NAME, 0, 0, CURRENT_TIME_MS).getSegmentName();
+      String endOffset = new LongMsgOffset(PARTITION_OFFSET.getOffset() + NUM_DOCS).toString();
+      CommittingSegmentDescriptor committingSegmentDescriptor =
+          new CommittingSegmentDescriptor(committingSegment, endOffset, SEGMENT_SIZE_IN_BYTES);
+      committingSegmentDescriptor.setSegmentMetadata(mockSegmentMetadata());
+      segmentManager.commitSegmentMetadata(REALTIME_TABLE_NAME, committingSegmentDescriptor);
+
+      // Verify instance states for committed segment and new consuming segment
+      Map<String, String> committedSegmentInstanceStateMap = instanceStatesMap.get(committingSegment);
+      assertNotNull(committedSegmentInstanceStateMap);
+      assertEquals(new HashSet<>(committedSegmentInstanceStateMap.values()),
+          Collections.singleton(SegmentStateModel.ONLINE));
+
+      String consumingSegment = new LLCSegmentName(RAW_TABLE_NAME, 0, 1, CURRENT_TIME_MS).getSegmentName();
+      Map<String, String> consumingSegmentInstanceStateMap = instanceStatesMap.get(consumingSegment);
+      assertNotNull(consumingSegmentInstanceStateMap);
+      assertEquals(new HashSet<>(consumingSegmentInstanceStateMap.values()),
+          Collections.singleton(SegmentStateModel.CONSUMING));
+
+      // Verify segment ZK metadata for committed segment and new consuming segment
+      SegmentZKMetadata committedSegmentZKMetadata = segmentManager._segmentZKMetadataMap.get(committingSegment);
+      assertEquals(committedSegmentZKMetadata.getStatus(), Status.DONE);
+      assertEquals(committedSegmentZKMetadata.getStartOffset(), PARTITION_OFFSET.toString());
+      assertEquals(committedSegmentZKMetadata.getEndOffset(), endOffset);
+      assertEquals(committedSegmentZKMetadata.getCreationTime(), CURRENT_TIME_MS);
+      assertEquals(committedSegmentZKMetadata.getCrc(), Long.parseLong(CRC));
+      assertEquals(committedSegmentZKMetadata.getIndexVersion(), SEGMENT_VERSION.name());
+      assertEquals(committedSegmentZKMetadata.getTotalDocs(), NUM_DOCS);
+      assertEquals(committedSegmentZKMetadata.getSizeInBytes(), SEGMENT_SIZE_IN_BYTES);
+
+      SegmentZKMetadata consumingSegmentZKMetadata = segmentManager._segmentZKMetadataMap.get(consumingSegment);
+      assertEquals(consumingSegmentZKMetadata.getStatus(), Status.IN_PROGRESS);
+      assertEquals(consumingSegmentZKMetadata.getStartOffset(), String.valueOf(LATEST_OFFSET));
+      assertEquals(committedSegmentZKMetadata.getCreationTime(), CURRENT_TIME_MS);
+    }
   }
 
   /**
@@ -1722,6 +1796,13 @@ public class PinotLLCRealtimeSegmentManagerTest {
       _tableConfig =
           new TableConfigBuilder(TableType.REALTIME).setTableName(RAW_TABLE_NAME).setNumReplicas(_numReplicas)
               .setStreamConfigs(streamConfigs).build();
+      _streamConfigs = IngestionConfigUtils.getStreamConfigs(_tableConfig);
+    }
+
+    void makeTableConfig(Map<String, String> streamConfigMap) {
+      _tableConfig =
+          new TableConfigBuilder(TableType.REALTIME).setTableName(RAW_TABLE_NAME).setNumReplicas(_numReplicas)
+              .setStreamConfigs(streamConfigMap).build();
       _streamConfigs = IngestionConfigUtils.getStreamConfigs(_tableConfig);
     }
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
@@ -77,6 +77,7 @@ import org.apache.pinot.spi.config.table.assignment.InstancePartitionsType;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.filesystem.PinotFSFactory;
 import org.apache.pinot.spi.stream.LongMsgOffset;
+import org.apache.pinot.spi.stream.LongMsgOffsetFactory;
 import org.apache.pinot.spi.stream.OffsetCriteria;
 import org.apache.pinot.spi.stream.PartitionGroupConsumptionStatus;
 import org.apache.pinot.spi.stream.PartitionGroupMetadata;
@@ -333,7 +334,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
   }
 
   @Test
-  public void testCommitSegmentWithOffsetAutoReset()
+  public void testCommitSegmentWithOffsetAutoResetOnOffset()
       throws Exception {
     // Set up a new table with 2 replicas, 5 instances, 4 partition
     PinotHelixResourceManager mockHelixResourceManager = mock(PinotHelixResourceManager.class);
@@ -349,9 +350,77 @@ public class PinotLLCRealtimeSegmentManagerTest {
     StreamConsumerFactory mockConsumerFactory = mock(StreamConsumerFactory.class);
     StreamMetadataProvider mockMetadataProvider = mock(StreamMetadataProvider.class);
     when(mockConsumerFactory.createPartitionMetadataProvider(anyString(), anyInt())).thenReturn(mockMetadataProvider);
+    when(mockConsumerFactory.createStreamMsgOffsetFactory()).thenReturn(new LongMsgOffsetFactory());
     when(mockMetadataProvider.fetchStreamPartitionOffset(eq(OffsetCriteria.LARGEST_OFFSET_CRITERIA),
         anyLong())).thenReturn(new LongMsgOffset(LATEST_OFFSET));
     when(mockMetadataProvider.getOffsetAtTimestamp(eq(0), anyLong())).thenReturn(PARTITION_OFFSET);
+
+    try (MockedStatic<StreamConsumerFactoryProvider> mockedStaticProvider = mockStatic(
+        StreamConsumerFactoryProvider.class)) {
+
+      mockedStaticProvider.when(() -> StreamConsumerFactoryProvider.create(segmentManager._streamConfigs.get(0)))
+          .thenReturn(mockConsumerFactory);
+
+      // Commit a segment for partition group 0
+      String committingSegment = new LLCSegmentName(RAW_TABLE_NAME, 0, 0, CURRENT_TIME_MS).getSegmentName();
+      String endOffset = new LongMsgOffset(PARTITION_OFFSET.getOffset() + NUM_DOCS).toString();
+      CommittingSegmentDescriptor committingSegmentDescriptor =
+          new CommittingSegmentDescriptor(committingSegment, endOffset, SEGMENT_SIZE_IN_BYTES);
+      committingSegmentDescriptor.setSegmentMetadata(mockSegmentMetadata());
+      segmentManager.commitSegmentMetadata(REALTIME_TABLE_NAME, committingSegmentDescriptor);
+
+      // Verify instance states for committed segment and new consuming segment
+      Map<String, String> committedSegmentInstanceStateMap = instanceStatesMap.get(committingSegment);
+      assertNotNull(committedSegmentInstanceStateMap);
+      assertEquals(new HashSet<>(committedSegmentInstanceStateMap.values()),
+          Collections.singleton(SegmentStateModel.ONLINE));
+
+      String consumingSegment = new LLCSegmentName(RAW_TABLE_NAME, 0, 1, CURRENT_TIME_MS).getSegmentName();
+      Map<String, String> consumingSegmentInstanceStateMap = instanceStatesMap.get(consumingSegment);
+      assertNotNull(consumingSegmentInstanceStateMap);
+      assertEquals(new HashSet<>(consumingSegmentInstanceStateMap.values()),
+          Collections.singleton(SegmentStateModel.CONSUMING));
+
+      // Verify segment ZK metadata for committed segment and new consuming segment
+      SegmentZKMetadata committedSegmentZKMetadata = segmentManager._segmentZKMetadataMap.get(committingSegment);
+      assertEquals(committedSegmentZKMetadata.getStatus(), Status.DONE);
+      assertEquals(committedSegmentZKMetadata.getStartOffset(), PARTITION_OFFSET.toString());
+      assertEquals(committedSegmentZKMetadata.getEndOffset(), endOffset);
+      assertEquals(committedSegmentZKMetadata.getCreationTime(), CURRENT_TIME_MS);
+      assertEquals(committedSegmentZKMetadata.getCrc(), Long.parseLong(CRC));
+      assertEquals(committedSegmentZKMetadata.getIndexVersion(), SEGMENT_VERSION.name());
+      assertEquals(committedSegmentZKMetadata.getTotalDocs(), NUM_DOCS);
+      assertEquals(committedSegmentZKMetadata.getSizeInBytes(), SEGMENT_SIZE_IN_BYTES);
+
+      SegmentZKMetadata consumingSegmentZKMetadata = segmentManager._segmentZKMetadataMap.get(consumingSegment);
+      assertEquals(consumingSegmentZKMetadata.getStatus(), Status.IN_PROGRESS);
+      assertEquals(consumingSegmentZKMetadata.getStartOffset(), String.valueOf(LATEST_OFFSET));
+      assertEquals(committedSegmentZKMetadata.getCreationTime(), CURRENT_TIME_MS);
+    }
+  }
+
+  @Test
+  public void testCommitSegmentWithOffsetAutoResetOnTime()
+      throws Exception {
+    // Set up a new table with 2 replicas, 5 instances, 4 partition
+    PinotHelixResourceManager mockHelixResourceManager = mock(PinotHelixResourceManager.class);
+    FakePinotLLCRealtimeSegmentManager segmentManager =
+        new FakePinotLLCRealtimeSegmentManager(mockHelixResourceManager);
+    setUpNewTable(segmentManager, 2, 5, 4);
+    Map<String, Map<String, String>> instanceStatesMap = segmentManager._idealState.getRecord().getMapFields();
+    Map<String, String> streamConfigMap = IngestionConfigUtils.getStreamConfigMaps(segmentManager._tableConfig).get(0);
+    streamConfigMap.put(StreamConfigProperties.ENABLE_OFFSET_AUTO_RESET, String.valueOf(true));
+    streamConfigMap.put(StreamConfigProperties.OFFSET_AUTO_RESET_TIMESEC_THRESHOLD_KEY, "1800");
+    segmentManager.makeTableConfig(streamConfigMap);
+
+    StreamConsumerFactory mockConsumerFactory = mock(StreamConsumerFactory.class);
+    StreamMetadataProvider mockMetadataProvider = mock(StreamMetadataProvider.class);
+    when(mockConsumerFactory.createPartitionMetadataProvider(anyString(), anyInt())).thenReturn(mockMetadataProvider);
+    when(mockConsumerFactory.createStreamMsgOffsetFactory()).thenReturn(new LongMsgOffsetFactory());
+    when(mockMetadataProvider.fetchStreamPartitionOffset(eq(OffsetCriteria.LARGEST_OFFSET_CRITERIA),
+        anyLong())).thenReturn(new LongMsgOffset(LATEST_OFFSET));
+    when(mockMetadataProvider.getOffsetAtTimestamp(eq(0), anyLong())).thenReturn(
+        new LongMsgOffset(PARTITION_OFFSET.getOffset() + 1L));
 
     try (MockedStatic<StreamConsumerFactoryProvider> mockedStaticProvider = mockStatic(
         StreamConsumerFactoryProvider.class)) {

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaStreamMetadataProvider.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaStreamMetadataProvider.java
@@ -187,6 +187,12 @@ public class KafkaStreamMetadataProvider extends KafkaPartitionLevelConnectionHa
     }
   }
 
+  @Override
+  public StreamPartitionMsgOffset getOffsetAtTimestamp(int partitionId, long timestampMillis) {
+    return new LongMsgOffset(
+        _consumer.offsetsForTimes(Map.of(_topicPartition, timestampMillis)).get(_topicPartition).offset());
+  }
+
   public static class KafkaTopicMetadata implements TopicMetadata {
     private String _name;
 

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaStreamMetadataProvider.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaStreamMetadataProvider.java
@@ -188,10 +188,11 @@ public class KafkaStreamMetadataProvider extends KafkaPartitionLevelConnectionHa
   }
 
   @Override
-  public StreamPartitionMsgOffset getOffsetAtTimestamp(int partitionId, long timestampMillis) {
-    return new LongMsgOffset(
-        _consumer.offsetsForTimes(Map.of(_topicPartition, timestampMillis)).get(_topicPartition).offset());
-  }
+  public StreamPartitionMsgOffset getOffsetAtTimestamp(int partitionId, long timestampMillis, long timeoutMillis) {
+      return new LongMsgOffset(
+          _consumer.offsetsForTimes(Map.of(_topicPartition, timestampMillis), Duration.ofMillis(timeoutMillis))
+              .get(_topicPartition).offset());
+    }
 
   public static class KafkaTopicMetadata implements TopicMetadata {
     private String _name;

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaStreamMetadataProvider.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaStreamMetadataProvider.java
@@ -189,10 +189,9 @@ public class KafkaStreamMetadataProvider extends KafkaPartitionLevelConnectionHa
 
   @Override
   public StreamPartitionMsgOffset getOffsetAtTimestamp(int partitionId, long timestampMillis, long timeoutMillis) {
-      return new LongMsgOffset(
-          _consumer.offsetsForTimes(Map.of(_topicPartition, timestampMillis), Duration.ofMillis(timeoutMillis))
-              .get(_topicPartition).offset());
-    }
+    return new LongMsgOffset(_consumer.offsetsForTimes(Map.of(_topicPartition, timestampMillis),
+            Duration.ofMillis(timeoutMillis)).get(_topicPartition).offset());
+  }
 
   public static class KafkaTopicMetadata implements TopicMetadata {
     private String _name;

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/main/java/org/apache/pinot/plugin/stream/kafka30/KafkaStreamMetadataProvider.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/main/java/org/apache/pinot/plugin/stream/kafka30/KafkaStreamMetadataProvider.java
@@ -201,9 +201,10 @@ public class KafkaStreamMetadataProvider extends KafkaPartitionLevelConnectionHa
   }
 
   @Override
-  public StreamPartitionMsgOffset getOffsetAtTimestamp(int partitionId, long timestampMillis) {
-    return new LongMsgOffset(
-            _consumer.offsetsForTimes(Map.of(_topicPartition, timestampMillis)).get(_topicPartition).offset());
+  public StreamPartitionMsgOffset getOffsetAtTimestamp(int partitionId, long timestampMillis, long timeoutMillis) {
+      return new LongMsgOffset(
+          _consumer.offsetsForTimes(Map.of(_topicPartition, timestampMillis), Duration.ofMillis(timeoutMillis))
+              .get(_topicPartition).offset());
   }
 
   @Override

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/main/java/org/apache/pinot/plugin/stream/kafka30/KafkaStreamMetadataProvider.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/main/java/org/apache/pinot/plugin/stream/kafka30/KafkaStreamMetadataProvider.java
@@ -199,6 +199,13 @@ public class KafkaStreamMetadataProvider extends KafkaPartitionLevelConnectionHa
       return this;
     }
   }
+
+  @Override
+  public StreamPartitionMsgOffset getOffsetAtTimestamp(int partitionId, long timestampMillis) {
+    return new LongMsgOffset(
+            _consumer.offsetsForTimes(Map.of(_topicPartition, timestampMillis)).get(_topicPartition).offset());
+  }
+
   @Override
   public void close()
       throws IOException {

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/main/java/org/apache/pinot/plugin/stream/kafka30/KafkaStreamMetadataProvider.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/main/java/org/apache/pinot/plugin/stream/kafka30/KafkaStreamMetadataProvider.java
@@ -202,9 +202,8 @@ public class KafkaStreamMetadataProvider extends KafkaPartitionLevelConnectionHa
 
   @Override
   public StreamPartitionMsgOffset getOffsetAtTimestamp(int partitionId, long timestampMillis, long timeoutMillis) {
-      return new LongMsgOffset(
-          _consumer.offsetsForTimes(Map.of(_topicPartition, timestampMillis), Duration.ofMillis(timeoutMillis))
-              .get(_topicPartition).offset());
+      return new LongMsgOffset(_consumer.offsetsForTimes(Map.of(_topicPartition, timestampMillis),
+              Duration.ofMillis(timeoutMillis)).get(_topicPartition).offset());
   }
 
   @Override

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfig.java
@@ -204,10 +204,8 @@ public class StreamConfig {
     _topicConsumptionRateLimit = rate != null ? Double.parseDouble(rate) : CONSUMPTION_RATE_LIMIT_NOT_SPECIFIED;
 
     _enableOffsetAutoReset = Boolean.parseBoolean(streamConfigMap.get(StreamConfigProperties.ENABLE_OFFSET_AUTO_RESET));
-    String offsetThreshold = streamConfigMap.get(StreamConfigProperties.OFFSET_AUTO_RESET_OFFSET_THRESHOLD_KEY);
-    _offsetAutoResetOffsetThreshold = offsetThreshold != null ? Integer.valueOf(offsetThreshold) : -1;
-    String timeSecThreshold = streamConfigMap.get(StreamConfigProperties.OFFSET_AUTO_RESET_TIMESEC_THRESHOLD_KEY);
-    _offsetAutoResetTimeSecThreshold = timeSecThreshold != null ? Integer.valueOf(timeSecThreshold) : -1;
+    _offsetAutoResetOffsetThreshold = parseOffsetAutoResetOffsetThreshold(streamConfigMap);
+    _offsetAutoResetTimeSecThreshold = parseOffsetAutoResetTimeSecThreshold(streamConfigMap);
 
     _streamConfigMap.putAll(streamConfigMap);
   }
@@ -320,6 +318,34 @@ public class StreamConfig {
     }
   }
 
+  public static int parseOffsetAutoResetOffsetThreshold(Map<String, String> streamConfigMap) {
+    String key = StreamConfigProperties.OFFSET_AUTO_RESET_OFFSET_THRESHOLD_KEY;
+    String offsetAutoResetOffsetThresholdStr = streamConfigMap.get(key);
+    if (offsetAutoResetOffsetThresholdStr != null) {
+      try {
+        return Integer.parseInt(offsetAutoResetOffsetThresholdStr);
+      } catch (Exception e) {
+        throw new IllegalArgumentException("Invalid config " + key + ": " + offsetAutoResetOffsetThresholdStr);
+      }
+    } else {
+      return -1; // Default value indicating disabled
+    }
+  }
+
+  public static long parseOffsetAutoResetTimeSecThreshold(Map<String, String> streamConfigMap) {
+    String key = StreamConfigProperties.OFFSET_AUTO_RESET_TIMESEC_THRESHOLD_KEY;
+    String offsetAutoResetTimeSecThresholdStr = streamConfigMap.get(key);
+    if (offsetAutoResetTimeSecThresholdStr != null) {
+      try {
+        return Long.parseLong(offsetAutoResetTimeSecThresholdStr);
+      } catch (Exception e) {
+        throw new IllegalArgumentException("Invalid config " + key + ": " + offsetAutoResetTimeSecThresholdStr);
+      }
+    } else {
+      return -1; // Default value indicating disabled
+    }
+  }
+
   public String getType() {
     return _type;
   }
@@ -425,6 +451,7 @@ public class StreamConfig {
         + ", _flushThresholdVarianceFraction=" + _flushThresholdVarianceFraction
         + ", _flushAutotuneInitialRows=" + _flushAutotuneInitialRows + ", _groupId='" + _groupId + '\''
         + ", _topicConsumptionRateLimit=" + _topicConsumptionRateLimit
+        + ", _enableOffsetAutoReset=" + _enableOffsetAutoReset
         + ", _offsetAutoResetOffsetThreshold" + _offsetAutoResetOffsetThreshold
         + ", _offSetAutoResetTimeSecThreshold" + _offsetAutoResetTimeSecThreshold
         + ", _streamConfigMap=" + _streamConfigMap

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfig.java
@@ -75,6 +75,9 @@ public class StreamConfig {
 
   private final double _topicConsumptionRateLimit;
 
+  private final int _offsetAutoResetOffsetThreshold;
+  private final long _offsetAutoResetTimeSecThreshold;
+
   private final Map<String, String> _streamConfigMap = new HashMap<>();
 
   // Allow overriding it to use different offset criteria
@@ -198,6 +201,11 @@ public class StreamConfig {
 
     String rate = streamConfigMap.get(StreamConfigProperties.TOPIC_CONSUMPTION_RATE_LIMIT);
     _topicConsumptionRateLimit = rate != null ? Double.parseDouble(rate) : CONSUMPTION_RATE_LIMIT_NOT_SPECIFIED;
+
+    String offsetThreshold = streamConfigMap.get(StreamConfigProperties.OFFSET_AUTO_RESET_OFFSET_THRESHOLD_KEY);
+    _offsetAutoResetOffsetThreshold = offsetThreshold != null ? Integer.valueOf(offsetThreshold) : -1;
+    String timeSecThreshold = streamConfigMap.get(StreamConfigProperties.OFFSET_AUTO_RESET_TIMESEC_THRESHOLD_KEY);
+    _offsetAutoResetTimeSecThreshold = timeSecThreshold != null ? Integer.valueOf(timeSecThreshold) : -1;
 
     _streamConfigMap.putAll(streamConfigMap);
   }
@@ -383,6 +391,14 @@ public class StreamConfig {
         : Optional.of(_topicConsumptionRateLimit);
   }
 
+  public int getOffsetAutoResetOffsetThreshold() {
+    return _offsetAutoResetOffsetThreshold;
+  }
+
+  public long getOffsetAutoResetTimeSecThreshold() {
+    return _offsetAutoResetTimeSecThreshold;
+  }
+
   public String getTableNameWithType() {
     return _tableNameWithType;
   }
@@ -402,7 +418,10 @@ public class StreamConfig {
         + _flushThresholdTimeMillis + ", _flushThresholdSegmentSizeBytes=" + _flushThresholdSegmentSizeBytes
         + ", _flushThresholdVarianceFraction=" + _flushThresholdVarianceFraction
         + ", _flushAutotuneInitialRows=" + _flushAutotuneInitialRows + ", _groupId='" + _groupId + '\''
-        + ", _topicConsumptionRateLimit=" + _topicConsumptionRateLimit + ", _streamConfigMap=" + _streamConfigMap
+        + ", _topicConsumptionRateLimit=" + _topicConsumptionRateLimit
+        + ", _offsetAutoResetOffsetThreshold" + _offsetAutoResetOffsetThreshold
+        + ", _offSetAutoResetTimeSecThreshold" + _offsetAutoResetTimeSecThreshold
+        + ", _streamConfigMap=" + _streamConfigMap
         + ", _offsetCriteria=" + _offsetCriteria + ", _serverUploadToDeepStore=" + _serverUploadToDeepStore + '}';
   }
 
@@ -427,7 +446,9 @@ public class StreamConfig {
         && Objects.equals(_consumerFactoryClassName, that._consumerFactoryClassName) && Objects.equals(_decoderClass,
         that._decoderClass) && Objects.equals(_decoderProperties, that._decoderProperties) && Objects.equals(_groupId,
         that._groupId) && Objects.equals(_streamConfigMap, that._streamConfigMap) && Objects.equals(_offsetCriteria,
-        that._offsetCriteria) && Objects.equals(_flushThresholdVarianceFraction, that._flushThresholdVarianceFraction);
+        that._offsetCriteria) && Objects.equals(_flushThresholdVarianceFraction, that._flushThresholdVarianceFraction)
+        && _offsetAutoResetOffsetThreshold == that._offsetAutoResetOffsetThreshold
+        && _offsetAutoResetTimeSecThreshold == that._offsetAutoResetTimeSecThreshold;
   }
 
   @Override
@@ -436,6 +457,7 @@ public class StreamConfig {
         _decoderProperties, _connectionTimeoutMillis, _fetchTimeoutMillis, _idleTimeoutMillis, _flushThresholdRows,
         _flushThresholdSegmentRows, _flushThresholdTimeMillis, _flushThresholdSegmentSizeBytes,
         _flushAutotuneInitialRows, _groupId, _topicConsumptionRateLimit, _streamConfigMap, _offsetCriteria,
-        _serverUploadToDeepStore, _flushThresholdVarianceFraction);
+        _serverUploadToDeepStore, _flushThresholdVarianceFraction, _offsetAutoResetOffsetThreshold,
+        _offsetAutoResetTimeSecThreshold);
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfig.java
@@ -75,6 +75,7 @@ public class StreamConfig {
 
   private final double _topicConsumptionRateLimit;
 
+  private final boolean _enableOffsetAutoReset;
   private final int _offsetAutoResetOffsetThreshold;
   private final long _offsetAutoResetTimeSecThreshold;
 
@@ -202,6 +203,7 @@ public class StreamConfig {
     String rate = streamConfigMap.get(StreamConfigProperties.TOPIC_CONSUMPTION_RATE_LIMIT);
     _topicConsumptionRateLimit = rate != null ? Double.parseDouble(rate) : CONSUMPTION_RATE_LIMIT_NOT_SPECIFIED;
 
+    _enableOffsetAutoReset = Boolean.parseBoolean(streamConfigMap.get(StreamConfigProperties.ENABLE_OFFSET_AUTO_RESET));
     String offsetThreshold = streamConfigMap.get(StreamConfigProperties.OFFSET_AUTO_RESET_OFFSET_THRESHOLD_KEY);
     _offsetAutoResetOffsetThreshold = offsetThreshold != null ? Integer.valueOf(offsetThreshold) : -1;
     String timeSecThreshold = streamConfigMap.get(StreamConfigProperties.OFFSET_AUTO_RESET_TIMESEC_THRESHOLD_KEY);
@@ -391,6 +393,10 @@ public class StreamConfig {
         : Optional.of(_topicConsumptionRateLimit);
   }
 
+  public boolean isEnableOffsetAutoReset() {
+    return _enableOffsetAutoReset;
+  }
+
   public int getOffsetAutoResetOffsetThreshold() {
     return _offsetAutoResetOffsetThreshold;
   }
@@ -447,6 +453,7 @@ public class StreamConfig {
         that._decoderClass) && Objects.equals(_decoderProperties, that._decoderProperties) && Objects.equals(_groupId,
         that._groupId) && Objects.equals(_streamConfigMap, that._streamConfigMap) && Objects.equals(_offsetCriteria,
         that._offsetCriteria) && Objects.equals(_flushThresholdVarianceFraction, that._flushThresholdVarianceFraction)
+        && _enableOffsetAutoReset == that._enableOffsetAutoReset
         && _offsetAutoResetOffsetThreshold == that._offsetAutoResetOffsetThreshold
         && _offsetAutoResetTimeSecThreshold == that._offsetAutoResetTimeSecThreshold;
   }
@@ -458,6 +465,6 @@ public class StreamConfig {
         _flushThresholdSegmentRows, _flushThresholdTimeMillis, _flushThresholdSegmentSizeBytes,
         _flushAutotuneInitialRows, _groupId, _topicConsumptionRateLimit, _streamConfigMap, _offsetCriteria,
         _serverUploadToDeepStore, _flushThresholdVarianceFraction, _offsetAutoResetOffsetThreshold,
-        _offsetAutoResetTimeSecThreshold);
+        _enableOffsetAutoReset, _offsetAutoResetTimeSecThreshold);
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfigProperties.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfigProperties.java
@@ -144,6 +144,20 @@ public class StreamConfigProperties {
       "realtime.segment.pauseless.download.timeoutSeconds";
 
   /**
+   * During segment commit, the new segment startOffset would skip to the latest offset if thisValue is set as positive
+   * and (latestStreamOffset - latestIngestedOffset > thisValue)
+   */
+  public static final String OFFSET_AUTO_RESET_OFFSET_THRESHOLD_KEY =
+      "realtime.segment.offsetAutoReset.offsetThreshold";
+
+  /**
+   * During segment commit, the new segment startOffset would skip to the latest offset if thisValue is set as positive
+   * and (latestStreamOffset's timestamp - latestIngestedOffset's timestamp > thisValue)
+   */
+  public static final String OFFSET_AUTO_RESET_TIMESEC_THRESHOLD_KEY =
+      "realtime.segment.offsetAutoReset.timeSecThreshold";
+
+  /**
    * Helper method to create a stream specific property
    */
   public static String constructStreamProperty(String streamType, String property) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfigProperties.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfigProperties.java
@@ -160,7 +160,7 @@ public class StreamConfigProperties {
    * and (latestStreamOffset's timestamp - latestIngestedOffset's timestamp > thisValue)
    */
   public static final String OFFSET_AUTO_RESET_TIMESEC_THRESHOLD_KEY =
-      "realtime.segment.offsetAutoReset.timeSecThreshold";
+      "realtime.segment.offsetAutoReset.timeThresholdSeconds";
 
   /**
    * Helper method to create a stream specific property

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfigProperties.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfigProperties.java
@@ -144,6 +144,11 @@ public class StreamConfigProperties {
       "realtime.segment.pauseless.download.timeoutSeconds";
 
   /**
+   * Config used to enable offset auto reset during segment commit.
+   */
+  public static final String ENABLE_OFFSET_AUTO_RESET = "realtime.segment.offsetAutoReset.enable";
+
+  /**
    * During segment commit, the new segment startOffset would skip to the latest offset if thisValue is set as positive
    * and (latestStreamOffset - latestIngestedOffset > thisValue)
    */

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamMetadataProvider.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamMetadataProvider.java
@@ -129,7 +129,7 @@ public interface StreamMetadataProvider extends Closeable {
   }
 
   @Nullable
-  default StreamPartitionMsgOffset getOffsetAtTimestamp(int partitionId, long timestampMillis) {
+  default StreamPartitionMsgOffset getOffsetAtTimestamp(int partitionId, long timestampMillis, long timeoutMillis) {
     return null;
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamMetadataProvider.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamMetadataProvider.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeoutException;
+import javax.annotation.Nullable;
 import org.apache.pinot.spi.annotations.InterfaceAudience;
 import org.apache.pinot.spi.annotations.InterfaceStability;
 
@@ -125,6 +126,11 @@ public interface StreamMetadataProvider extends Closeable {
     PartitionLagState unknownLagState = new UnknownLagState();
     currentPartitionStateMap.forEach((k, v) -> result.put(k, unknownLagState));
     return result;
+  }
+
+  @Nullable
+  default StreamPartitionMsgOffset getOffsetAtTimestamp(int partitionId, long timestampMillis) {
+    return null;
   }
 
   /**


### PR DESCRIPTION
`real-time` `ingestion` `feature` 
Part 1 of https://github.com/apache/pinot/pull/15782
Issue https://github.com/apache/pinot/issues/14815
Design doc https://docs.google.com/document/d/1NKPeNh6V2ctaQ4T_X3OKJ6Gcy5TRanLiU1uIDT8_9UA/edit?usp=sharing

Reset offset during ingestion lag. The change would only skip the offset by configs. The backfill on the interval would be introduced in a separate patch.
2 new and optional config could be used `realtime.segment.offsetAutoReset.offsetThreshold` and `realtime.segment.offsetAutoReset.timeSecThreshold`.
During segment commit time, if the lag (by offset or time) is over the threshold in the config, the new segment's startOffset would be "latest offset" instead of the "next offset".