### PR TITLE
Fail task cleanup validation only upon active subtasks

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -524,7 +524,8 @@ public class PinotTableRestletResource {
         continue;
       }
       for (String taskName : taskStates.keySet()) {
-        if (TaskState.IN_PROGRESS.equals(taskStates.get(taskName))) {
+        if (TaskState.IN_PROGRESS.equals(taskStates.get(taskName))
+            && pinotHelixTaskResourceManager.getTaskCount(taskName).getRunning() > 0) {
           pendingTasks.add(taskName);
         } else {
           pinotHelixTaskResourceManager.deleteTask(taskName, true);


### PR DESCRIPTION
## Description

There was an edge case that was missed for task cleanup validation during table deletion [ref](https://github.com/apache/pinot/pull/16307).
When a task queue is stopped and resumed, the subtask ends up in STOPPED state but the task state goes back into IN_PROGRESS state. This case was getting marked as active execution as the code was only looking at task state.
Fixed the handling by adding a task count check on inProgress subtasks a well to only flag the actual active subtasks.