### PR TITLE
[Auto reset 2/3]Introduce ephemeral topic type into multi-topic ingestion

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/LLCSegmentName.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/LLCSegmentName.java
@@ -29,7 +29,7 @@ import org.joda.time.format.DateTimeFormatter;
 
 
 public class LLCSegmentName implements Comparable<LLCSegmentName> {
-  private static final String SEPARATOR = "__";
+  public static final String SEPARATOR = "__";
   private static final String DATE_FORMAT = "yyyyMMdd'T'HHmm'Z'";
   private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormat.forPattern(DATE_FORMAT).withZoneUTC();
 
@@ -38,25 +38,62 @@ public class LLCSegmentName implements Comparable<LLCSegmentName> {
   private final int _sequenceNumber;
   private final String _creationTime;
   private final String _segmentName;
+  private final String _topicName;
 
   public LLCSegmentName(String segmentName) {
     String[] parts = StringUtils.splitByWholeSeparator(segmentName, SEPARATOR);
-    Preconditions.checkArgument(parts.length == 4, "Invalid LLC segment name: %s", segmentName);
+    // Validate the segment name format should have 4 or 5 parts:
+    // e.g. tableName__partitionGroupId__sequenceNumber__creationTime
+    // or tableName__topicName__partitionGroupId__sequenceNumber__creationTime
+    Preconditions.checkArgument(
+        parts.length >= 4 && parts.length <= 5, "Invalid LLC segment name: %s", segmentName);
     _tableName = parts[0];
-    _partitionGroupId = Integer.parseInt(parts[1]);
-    _sequenceNumber = Integer.parseInt(parts[2]);
-    _creationTime = parts[3];
+    if (parts.length == 4) {
+      _topicName = "";
+      _partitionGroupId = Integer.parseInt(parts[1]);
+      _sequenceNumber = Integer.parseInt(parts[2]);
+      _creationTime = parts[3];
+    } else {
+      _topicName = parts[1];
+      _partitionGroupId = Integer.parseInt(parts[2]);
+      _sequenceNumber = Integer.parseInt(parts[3]);
+      _creationTime = parts[4];
+    }
     _segmentName = segmentName;
   }
 
   public LLCSegmentName(String tableName, int partitionGroupId, int sequenceNumber, long msSinceEpoch) {
+    this(tableName, "", partitionGroupId, sequenceNumber, msSinceEpoch);
+  }
+
+  public LLCSegmentName(
+      String tableName, String topicName, int partitionGroupId, int sequenceNumber, long msSinceEpoch) {
     Preconditions.checkArgument(!tableName.contains(SEPARATOR), "Illegal table name: %s", tableName);
+    Preconditions.checkArgument(topicName == null || !topicName.contains(SEPARATOR),
+        "Illegal topic name: %s", tableName);
     _tableName = tableName;
+    _topicName = topicName;
     _partitionGroupId = partitionGroupId;
     _sequenceNumber = sequenceNumber;
     // ISO8601 date: 20160120T1234Z
     _creationTime = DATE_FORMATTER.print(msSinceEpoch);
-    _segmentName = tableName + SEPARATOR + partitionGroupId + SEPARATOR + sequenceNumber + SEPARATOR + _creationTime;
+    if ("".equals(topicName)) {
+      _segmentName = tableName + SEPARATOR + partitionGroupId + SEPARATOR + sequenceNumber + SEPARATOR + _creationTime;
+    } else {
+      _segmentName =
+          tableName + SEPARATOR + topicName + SEPARATOR + partitionGroupId + SEPARATOR + sequenceNumber + SEPARATOR
+              + _creationTime;
+    }
+  }
+
+  private LLCSegmentName(String tableName, int partitionGroupId, int sequenceNumber, String creationTime,
+      String segmentName) {
+    _tableName = tableName;
+    _topicName = "";
+    _partitionGroupId = partitionGroupId;
+    _sequenceNumber = sequenceNumber;
+    _creationTime = creationTime;
+    _segmentName = segmentName;
   }
 
   /**
@@ -65,6 +102,10 @@ public class LLCSegmentName implements Comparable<LLCSegmentName> {
    */
   @Nullable
   public static LLCSegmentName of(String segmentName) {
+    String[] parts = StringUtils.splitByWholeSeparator(segmentName, SEPARATOR);
+    if (parts.length < 4 || parts.length > 5) {
+      return null;
+    }
     try {
       return new LLCSegmentName(segmentName);
     } catch (Exception e) {
@@ -76,13 +117,7 @@ public class LLCSegmentName implements Comparable<LLCSegmentName> {
    * Returns whether the given segment name represents an LLC segment.
    */
   public static boolean isLLCSegment(String segmentName) {
-    int numSeparators = 0;
-    int index = 0;
-    while ((index = segmentName.indexOf(SEPARATOR, index)) != -1) {
-      numSeparators++;
-      index += 2; // SEPARATOR.length()
-    }
-    return numSeparators == 3;
+    return of(segmentName) != null;
   }
 
   @Deprecated
@@ -94,15 +129,32 @@ public class LLCSegmentName implements Comparable<LLCSegmentName> {
    * Returns the sequence number of the given segment name.
    */
   public static int getSequenceNumber(String segmentName) {
-    return Integer.parseInt(StringUtils.splitByWholeSeparator(segmentName, SEPARATOR)[2]);
+    String[] parts = StringUtils.splitByWholeSeparator(segmentName, SEPARATOR);
+    if (parts.length == 4) {
+      return Integer.parseInt(parts[2]);
+    } else {
+      return Integer.parseInt(parts[3]);
+    }
   }
 
   public String getTableName() {
     return _tableName;
   }
 
+  public String getTopicName() {
+    return _topicName;
+  }
+
   public int getPartitionGroupId() {
     return _partitionGroupId;
+  }
+
+  public String getPartitionGroupInfo() {
+    if (_topicName.isEmpty()) {
+      return String.valueOf(_partitionGroupId);
+    } else {
+      return _topicName + SEPARATOR + _partitionGroupId;
+    }
   }
 
   public int getSequenceNumber() {
@@ -127,6 +179,9 @@ public class LLCSegmentName implements Comparable<LLCSegmentName> {
   public int compareTo(LLCSegmentName other) {
     Preconditions.checkArgument(_tableName.equals(other._tableName),
         "Cannot compare segment names from different table: %s, %s", _segmentName, other.getSegmentName());
+    if (!_topicName.equals(other._topicName)) {
+      return StringUtils.compare(_topicName, other._topicName);
+    }
     if (_partitionGroupId != other._partitionGroupId) {
       return Integer.compare(_partitionGroupId, other._partitionGroupId);
     }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/LLCSegmentName.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/LLCSegmentName.java
@@ -67,11 +67,11 @@ public class LLCSegmentName implements Comparable<LLCSegmentName> {
     this(tableName, null, partitionGroupId, sequenceNumber, msSinceEpoch);
   }
 
-  public LLCSegmentName(
-      String tableName, @Nullable String topicName, int partitionGroupId, int sequenceNumber, long msSinceEpoch) {
+  public LLCSegmentName(String tableName, @Nullable String topicName, int partitionGroupId, int sequenceNumber,
+      long msSinceEpoch) {
     Preconditions.checkArgument(!tableName.contains(SEPARATOR), "Illegal table name: %s", tableName);
-    Preconditions.checkArgument(topicName == null || !topicName.contains(SEPARATOR),
-        "Illegal topic name: %s", tableName);
+    Preconditions.checkArgument(topicName == null || (!"".equals(topicName) && !topicName.contains(SEPARATOR)),
+        "Illegal topic name: %s", topicName);
     _tableName = tableName;
     _topicName = topicName;
     _partitionGroupId = partitionGroupId;
@@ -87,26 +87,12 @@ public class LLCSegmentName implements Comparable<LLCSegmentName> {
     }
   }
 
-  private LLCSegmentName(String tableName, int partitionGroupId, int sequenceNumber, String creationTime,
-      String segmentName) {
-    _tableName = tableName;
-    _topicName = "";
-    _partitionGroupId = partitionGroupId;
-    _sequenceNumber = sequenceNumber;
-    _creationTime = creationTime;
-    _segmentName = segmentName;
-  }
-
   /**
    * Returns the {@link LLCSegmentName} for the given segment name, or {@code null} if the given segment name does not
    * represent an LLC segment.
    */
   @Nullable
   public static LLCSegmentName of(String segmentName) {
-    String[] parts = StringUtils.splitByWholeSeparator(segmentName, SEPARATOR);
-    if (parts.length < 4 || parts.length > 5) {
-      return null;
-    }
     try {
       return new LLCSegmentName(segmentName);
     } catch (Exception e) {
@@ -118,7 +104,13 @@ public class LLCSegmentName implements Comparable<LLCSegmentName> {
    * Returns whether the given segment name represents an LLC segment.
    */
   public static boolean isLLCSegment(String segmentName) {
-    return of(segmentName) != null;
+    int numSeparators = 0;
+    int index = 0;
+    while ((index = segmentName.indexOf(SEPARATOR, index)) != -1) {
+      numSeparators++;
+      index += 2; // SEPARATOR.length()
+    }
+    return numSeparators == 3 || numSeparators == 4;
   }
 
   @Deprecated

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/LLCSegmentNameTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/LLCSegmentNameTest.java
@@ -42,6 +42,15 @@ public class LLCSegmentNameTest {
     assertEquals(llcSegmentName.getPartitionGroupId(), 0);
     assertEquals(llcSegmentName.getSequenceNumber(), 1);
 
+    LLCSegmentName llcSegmentNameWithTopicName = new LLCSegmentName("myTable", "myTopic", 0, 1, 1465508537069L);
+    String segmentNameWithTopicName = llcSegmentNameWithTopicName.getSegmentName();
+    assertEquals(segmentNameWithTopicName, "myTable__myTopic__0__1__20160609T2142Z");
+    assertTrue(LLCSegmentName.isLLCSegment(segmentName));
+    assertEquals(llcSegmentNameWithTopicName.getTableName(), "myTable");
+    assertEquals(llcSegmentNameWithTopicName.getTopicName(), "myTopic");
+    assertEquals(llcSegmentNameWithTopicName.getPartitionGroupId(), 0);
+    assertEquals(llcSegmentNameWithTopicName.getSequenceNumber(), 1);
+
     // Invalid segment name
     assertFalse(LLCSegmentName.isLLCSegment("a__abc__1__3__4__54__g__gg___h"));
   }
@@ -85,6 +94,63 @@ public class LLCSegmentNameTest {
 
     LLCSegmentName segName7 =
         new LLCSegmentName(tableName + "NotGood", partitionGroupId, sequenceNumber + 1, msSinceEpoch);
+    try {
+      segName1.compareTo(segName7);
+      Assert.fail("Not failing when comparing " + segName1.getSegmentName() + " and " + segName7.getSegmentName());
+    } catch (Exception e) {
+      // expected
+    }
+    LLCSegmentName[] testSorted = new LLCSegmentName[]{segName3, segName1, segName4, segName5, segName6};
+    Arrays.sort(testSorted);
+    Assert.assertEquals(testSorted, new LLCSegmentName[]{segName5, segName1, segName6, segName3, segName4});
+  }
+
+  @Test
+  public void testLLCSegmentNameWithTopicName() {
+    String tableName = "myTable";
+    String topicName = "myTopic";
+    final int partitionGroupId = 4;
+    final int sequenceNumber = 27;
+    final long msSinceEpoch = 1466200248000L;
+    final String creationTime = "20160617T2150Z";
+    final long creationTimeInMs = 1466200200000L;
+    final String segmentName = "myTable__myTopic__4__27__" + creationTime;
+
+    LLCSegmentName segName1 = new LLCSegmentName(tableName, topicName, partitionGroupId, sequenceNumber, msSinceEpoch);
+    Assert.assertEquals(segName1.getSegmentName(), segmentName);
+    Assert.assertEquals(segName1.getPartitionGroupId(), partitionGroupId);
+    Assert.assertEquals(segName1.getCreationTime(), creationTime);
+    Assert.assertEquals(segName1.getCreationTimeMs(), creationTimeInMs);
+    Assert.assertEquals(segName1.getSequenceNumber(), sequenceNumber);
+    Assert.assertEquals(segName1.getTableName(), tableName);
+    Assert.assertEquals(segName1.getTopicName(), topicName);
+
+    LLCSegmentName segName2 = new LLCSegmentName(segmentName);
+    Assert.assertEquals(segName2.getSegmentName(), segmentName);
+    Assert.assertEquals(segName2.getPartitionGroupId(), partitionGroupId);
+    Assert.assertEquals(segName2.getCreationTime(), creationTime);
+    Assert.assertEquals(segName2.getCreationTimeMs(), creationTimeInMs);
+    Assert.assertEquals(segName2.getSequenceNumber(), sequenceNumber);
+    Assert.assertEquals(segName2.getTableName(), tableName);
+    Assert.assertEquals(segName2.getTopicName(), topicName);
+
+    Assert.assertEquals(segName1, segName2);
+
+    LLCSegmentName segName3 =
+        new LLCSegmentName(tableName, topicName, partitionGroupId + 1, sequenceNumber - 1, msSinceEpoch);
+    Assert.assertTrue(segName1.compareTo(segName3) < 0);
+    LLCSegmentName segName4 =
+        new LLCSegmentName(tableName, topicName, partitionGroupId + 1, sequenceNumber + 1, msSinceEpoch);
+    Assert.assertTrue(segName1.compareTo(segName4) < 0);
+    LLCSegmentName segName5 =
+        new LLCSegmentName(tableName, topicName, partitionGroupId - 1, sequenceNumber + 1, msSinceEpoch);
+    Assert.assertTrue(segName1.compareTo(segName5) > 0);
+    LLCSegmentName segName6 =
+        new LLCSegmentName(tableName, topicName, partitionGroupId, sequenceNumber + 1, msSinceEpoch);
+    Assert.assertTrue(segName1.compareTo(segName6) < 0);
+
+    LLCSegmentName segName7 =
+        new LLCSegmentName(tableName + "NotGood", topicName, partitionGroupId, sequenceNumber + 1, msSinceEpoch);
     try {
       segName1.compareTo(segName7);
       Assert.fail("Not failing when comparing " + segName1.getSegmentName() + " and " + segName7.getSegmentName());

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/MissingConsumingSegmentFinder.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/MissingConsumingSegmentFinder.java
@@ -83,7 +83,7 @@ public class MissingConsumingSegmentFinder {
     try {
       PinotTableIdealStateBuilder.getPartitionGroupMetadataList(streamConfigs, Collections.emptyList(), false)
           .forEach(metadata -> {
-            _partitionGroupInfoToLargestStreamOffsetMap.put(metadata.getPartitionGroupInfo(),
+            _partitionGroupInfoToLargestStreamOffsetMap.put(metadata.getPartitionGroupTopicAndId(),
                 metadata.getStartOffset());
           });
     } catch (Exception e) {
@@ -182,7 +182,7 @@ public class MissingConsumingSegmentFinder {
 
   private void updateMap(Map<String, LLCSegmentName> partitionGroupInfoToLatestSegmentMap,
       LLCSegmentName llcSegmentName) {
-    partitionGroupInfoToLatestSegmentMap.compute(llcSegmentName.getPartitionGroupInfo(), (pid, existingSegment) -> {
+    partitionGroupInfoToLatestSegmentMap.compute(llcSegmentName.getPartitionGroupTopicAndId(), (pid, existingSegment) -> {
       if (existingSegment == null) {
         return llcSegmentName;
       } else {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/MissingConsumingSegmentFinder.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/MissingConsumingSegmentFinder.java
@@ -182,7 +182,8 @@ public class MissingConsumingSegmentFinder {
 
   private void updateMap(Map<String, LLCSegmentName> partitionGroupInfoToLatestSegmentMap,
       LLCSegmentName llcSegmentName) {
-    partitionGroupInfoToLatestSegmentMap.compute(llcSegmentName.getPartitionGroupTopicAndId(), (pid, existingSegment) -> {
+    partitionGroupInfoToLatestSegmentMap.compute(llcSegmentName.getPartitionGroupTopicAndId(),
+        (pid, existingSegment) -> {
       if (existingSegment == null) {
         return llcSegmentName;
       } else {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -1348,8 +1348,9 @@ public class PinotLLCRealtimeSegmentManager {
     Map<String, LLCSegmentName> latestLLCSegmentNameMap = new HashMap<>();
     for (String segmentName : segments) {
       LLCSegmentName llcSegmentName = new LLCSegmentName(segmentName);
-      latestLLCSegmentNameMap.compute(llcSegmentName.getPartitionGroupTopicAndId(), (partitionInfo, latestLLCSegmentName) -> {
-        if (latestLLCSegmentName == null) {
+      latestLLCSegmentNameMap.compute(llcSegmentName.getPartitionGroupTopicAndId(),
+          (partitionInfo, latestLLCSegmentName) -> {
+            if (latestLLCSegmentName == null) {
           return llcSegmentName;
         } else {
           if (llcSegmentName.getSequenceNumber() > latestLLCSegmentName.getSequenceNumber()) {
@@ -1910,8 +1911,8 @@ public class PinotLLCRealtimeSegmentManager {
     int partitionGroupId = partitionGroupMetadata.getPartitionGroupId();
     String topicName = partitionGroupMetadata.getTopicName();
     String startOffset = partitionGroupMetadata.getStartOffset().toString();
-    LOGGER.info("Setting up new partition group: {} for table: {}", partitionGroupMetadata.getPartitionGroupTopicAndId(),
-        realtimeTableName);
+    LOGGER.info("Setting up new partition group: {} for table: {}",
+        partitionGroupMetadata.getPartitionGroupTopicAndId(), realtimeTableName);
 
     String rawTableName = TableNameBuilder.extractRawTableName(realtimeTableName);
     LLCSegmentName newLLCSegmentName =
@@ -2422,7 +2423,8 @@ public class PinotLLCRealtimeSegmentManager {
         .map(Integer::parseInt)
         .collect(Collectors.toSet());
     Set<String> targetSegments = allConsumingSegments.stream()
-        .filter(segmentName -> partitionsToCommit.contains(new LLCSegmentName(segmentName).getPartitionGroupTopicAndId()))
+        .filter(
+            segmentName -> partitionsToCommit.contains(new LLCSegmentName(segmentName).getPartitionGroupTopicAndId()))
         .collect(Collectors.toSet());
     Preconditions.checkState(!targetSegments.isEmpty(), "Cannot find segments to commit for partitions: %s",
         partitionGroupInfosToCommitStr);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/MissingConsumingSegmentFinderTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/MissingConsumingSegmentFinderTest.java
@@ -91,11 +91,11 @@ public class MissingConsumingSegmentFinderTest {
     idealStateMap.put("tableA__3__1__20220601T1200Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
     idealStateMap.put("tableA__3__2__20220601T1500Z", ImmutableMap.of("ServerX", "CONSUMING", "ServerY", "CONSUMING"));
 
-    Map<Integer, StreamPartitionMsgOffset> partitionGroupIdToLargestStreamOffsetMap = ImmutableMap.of(
-        0, new LongMsgOffset(1000),
-        1, new LongMsgOffset(1001),
-        2, new LongMsgOffset(1002),
-        3, new LongMsgOffset(1003)
+    Map<String, StreamPartitionMsgOffset> partitionGroupIdToLargestStreamOffsetMap = ImmutableMap.of(
+        "0", new LongMsgOffset(1000),
+        "1", new LongMsgOffset(1001),
+        "2", new LongMsgOffset(1002),
+        "3", new LongMsgOffset(1003)
     );
 
     Instant now = Instant.parse("2022-06-01T18:00:00.00Z");
@@ -128,11 +128,11 @@ public class MissingConsumingSegmentFinderTest {
     idealStateMap.put("tableA__3__0__20220601T0900Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
     idealStateMap.put("tableA__3__1__20220601T1200Z", ImmutableMap.of("ServerX", "ONLINE", "ServerY", "ONLINE"));
 
-    Map<Integer, StreamPartitionMsgOffset> partitionGroupIdToLargestStreamOffsetMap = ImmutableMap.of(
-        0, new LongMsgOffset(1000),
-        1, new LongMsgOffset(701),
-        2, new LongMsgOffset(1002),
-        3, new LongMsgOffset(703)
+    Map<String, StreamPartitionMsgOffset> partitionGroupIdToLargestStreamOffsetMap = ImmutableMap.of(
+        "0", new LongMsgOffset(1000),
+        "1", new LongMsgOffset(701),
+        "2", new LongMsgOffset(1002),
+        "3", new LongMsgOffset(703)
     );
 
     // setup segment metadata fetcher
@@ -229,14 +229,14 @@ public class MissingConsumingSegmentFinderTest {
     idealStateMap.put("tableA__5__2__20220601T1500Z", ImmutableMap.of("ServerX", "CONSUMING", "ServerY", "CONSUMING"));
     // partition 6 is a new partition and there's no consuming segment in ideal states for it
 
-    Map<Integer, StreamPartitionMsgOffset> partitionGroupIdToLargestStreamOffsetMap = new HashMap<>();
-    partitionGroupIdToLargestStreamOffsetMap.put(0, new LongMsgOffset(1000));
-    partitionGroupIdToLargestStreamOffsetMap.put(1, new LongMsgOffset(1001));
-    partitionGroupIdToLargestStreamOffsetMap.put(2, new LongMsgOffset(1002));
-    partitionGroupIdToLargestStreamOffsetMap.put(3, new LongMsgOffset(1003));
-    partitionGroupIdToLargestStreamOffsetMap.put(4, new LongMsgOffset(1004));
-    partitionGroupIdToLargestStreamOffsetMap.put(5, new LongMsgOffset(1005));
-    partitionGroupIdToLargestStreamOffsetMap.put(6, new LongMsgOffset(16));
+    Map<String, StreamPartitionMsgOffset> partitionGroupIdToLargestStreamOffsetMap = new HashMap<>();
+    partitionGroupIdToLargestStreamOffsetMap.put("0", new LongMsgOffset(1000));
+    partitionGroupIdToLargestStreamOffsetMap.put("1", new LongMsgOffset(1001));
+    partitionGroupIdToLargestStreamOffsetMap.put("2", new LongMsgOffset(1002));
+    partitionGroupIdToLargestStreamOffsetMap.put("3", new LongMsgOffset(1003));
+    partitionGroupIdToLargestStreamOffsetMap.put("4", new LongMsgOffset(1004));
+    partitionGroupIdToLargestStreamOffsetMap.put("5", new LongMsgOffset(1005));
+    partitionGroupIdToLargestStreamOffsetMap.put("6", new LongMsgOffset(16));
 
     // setup segment metadata fetcher
     SegmentZKMetadata m1 = mock(SegmentZKMetadata.class);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
@@ -1513,7 +1513,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
     segmentManager._numPartitions = 2;
 
     // Test empty ideal state
-    Set<Integer> partitionIds = segmentManager.getPartitionIds(streamConfigs, idealState);
+    Set<String> partitionIds = segmentManager.getPartitionIds(streamConfigs, idealState);
     Assert.assertEquals(partitionIds.size(), 2);
     partitionIds.clear();
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -642,14 +642,17 @@ public final class TableConfigUtils {
       // 2. Ensure segment flush parameters consistent across all streamConfigs. We need this because Pinot is
       // predefining the values before fetching stream partition info from stream. At the construction time, we don't
       // know the value extracted from a streamConfig would be applied to which segment.
+      // 3. There should not be duplicate topic names across streamConfigs.
       // TODO: Remove these limitations
       StreamConfig firstStreamConfig = streamConfigs.get(0);
+      Set<String> topicNames = new HashSet<>();
       String streamType = firstStreamConfig.getType();
       int flushThresholdRows = firstStreamConfig.getFlushThresholdRows();
       long flushThresholdTimeMillis = firstStreamConfig.getFlushThresholdTimeMillis();
       double flushThresholdVarianceFraction = firstStreamConfig.getFlushThresholdVarianceFraction();
       long flushThresholdSegmentSizeBytes = firstStreamConfig.getFlushThresholdSegmentSizeBytes();
       int flushThresholdSegmentRows = firstStreamConfig.getFlushThresholdSegmentRows();
+      topicNames.add(firstStreamConfig.getTopicName());
       for (int i = 1; i < numStreamConfigs; i++) {
         StreamConfig streamConfig = streamConfigs.get(i);
         Preconditions.checkState(streamConfig.getType().equals(streamType),
@@ -660,6 +663,8 @@ public final class TableConfigUtils {
                 && streamConfig.getFlushThresholdSegmentSizeBytes() == flushThresholdSegmentSizeBytes
                 && streamConfig.getFlushThresholdSegmentRows() == flushThresholdSegmentRows,
             "Segment flush parameters must be consistent across all streamConfigs");
+        Preconditions.checkState(topicNames.add(streamConfig.getTopicName()),
+            "Duplicate topic names found in streamConfigs: %s", streamConfig.getTopicName());
       }
     }
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/StreamIngestionConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/StreamIngestionConfig.java
@@ -59,6 +59,9 @@ public class StreamIngestionConfig extends BaseJsonConfig {
       + " completed (immutable) replica on any server in pause-less ingestion")
   private DisasterRecoveryMode _disasterRecoveryMode = DisasterRecoveryMode.DEFAULT;
 
+  @JsonPropertyDescription("Class to handle realtime offset auto reset")
+  private String _realtimeOffsetAutoResetHandlerClass;
+
   @JsonCreator
   public StreamIngestionConfig(@JsonProperty("streamConfigMaps") List<Map<String, String>> streamConfigMaps) {
     _streamConfigMaps = streamConfigMaps;
@@ -123,5 +126,14 @@ public class StreamIngestionConfig extends BaseJsonConfig {
 
   public void setDisasterRecoveryMode(DisasterRecoveryMode disasterRecoveryMode) {
     _disasterRecoveryMode = disasterRecoveryMode;
+  }
+
+  @Nullable
+  public String getRealtimeOffsetAutoResetHandlerClass() {
+    return _realtimeOffsetAutoResetHandlerClass;
+  }
+
+  public void setRealtimeOffsetAutoResetHandlerClass(String realtimeOffsetAutoResetHandlerClass) {
+    _realtimeOffsetAutoResetHandlerClass = realtimeOffsetAutoResetHandlerClass;
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionGroupConsumptionStatus.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionGroupConsumptionStatus.java
@@ -35,6 +35,8 @@ package org.apache.pinot.spi.stream;
  * This information is needed by the stream, when grouping the partitions/shards into new partition groups.
  */
 public class PartitionGroupConsumptionStatus {
+
+  private final String _topicName;
   private final int _partitionGroupId;
   private final int _streamPartitionId;
   private int _sequenceNumber;
@@ -42,8 +44,9 @@ public class PartitionGroupConsumptionStatus {
   private StreamPartitionMsgOffset _endOffset;
   private String _status;
 
-  public PartitionGroupConsumptionStatus(int partitionGroupId, int streamPartitionId, int sequenceNumber,
-      StreamPartitionMsgOffset startOffset, StreamPartitionMsgOffset endOffset, String status) {
+  public PartitionGroupConsumptionStatus(String topicName, int partitionGroupId, int streamPartitionId,
+      int sequenceNumber, StreamPartitionMsgOffset startOffset, StreamPartitionMsgOffset endOffset, String status) {
+    _topicName = topicName;
     _partitionGroupId = partitionGroupId;
     _streamPartitionId = streamPartitionId;
     _sequenceNumber = sequenceNumber;
@@ -52,9 +55,18 @@ public class PartitionGroupConsumptionStatus {
     _status = status;
   }
 
-  public PartitionGroupConsumptionStatus(int partitionGroupId, int sequenceNumber, StreamPartitionMsgOffset startOffset,
-      StreamPartitionMsgOffset endOffset, String status) {
-    this(partitionGroupId, partitionGroupId, sequenceNumber, startOffset, endOffset, status);
+  public PartitionGroupConsumptionStatus(int partitionGroupId, int streamPartitionId,
+      int sequenceNumber, StreamPartitionMsgOffset startOffset, StreamPartitionMsgOffset endOffset, String status) {
+    this("", partitionGroupId, streamPartitionId, sequenceNumber, startOffset, endOffset, status);
+  }
+
+  public PartitionGroupConsumptionStatus(int partitionGroupId, int sequenceNumber,
+      StreamPartitionMsgOffset startOffset, StreamPartitionMsgOffset endOffset, String status) {
+    this("", partitionGroupId, partitionGroupId, sequenceNumber, startOffset, endOffset, status);
+  }
+
+  public String getTopicName() {
+    return _topicName;
   }
 
   public int getPartitionGroupId() {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionGroupConsumptionStatus.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionGroupConsumptionStatus.java
@@ -18,6 +18,9 @@
  */
 package org.apache.pinot.spi.stream;
 
+import javax.annotation.Nullable;
+
+
 /**
  * A PartitionGroup is a group of partitions/shards that the same consumer should consume from.
  * This class contains all information which describes the latest state of a partition group.
@@ -36,6 +39,7 @@ package org.apache.pinot.spi.stream;
  */
 public class PartitionGroupConsumptionStatus {
 
+  @Nullable
   private final String _topicName;
   private final int _partitionGroupId;
   private final int _streamPartitionId;
@@ -57,15 +61,18 @@ public class PartitionGroupConsumptionStatus {
 
   public PartitionGroupConsumptionStatus(int partitionGroupId, int streamPartitionId,
       int sequenceNumber, StreamPartitionMsgOffset startOffset, StreamPartitionMsgOffset endOffset, String status) {
-    this("", partitionGroupId, streamPartitionId, sequenceNumber, startOffset, endOffset, status);
+    this(null, partitionGroupId, streamPartitionId, sequenceNumber, startOffset, endOffset, status);
   }
 
   public PartitionGroupConsumptionStatus(int partitionGroupId, int sequenceNumber,
       StreamPartitionMsgOffset startOffset, StreamPartitionMsgOffset endOffset, String status) {
-    this("", partitionGroupId, partitionGroupId, sequenceNumber, startOffset, endOffset, status);
+    this(null, partitionGroupId, partitionGroupId, sequenceNumber, startOffset, endOffset, status);
   }
 
   public String getTopicName() {
+    if (_topicName == null || _topicName.isEmpty()) {
+      return null;
+    }
     return _topicName;
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionGroupMetadata.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionGroupMetadata.java
@@ -18,6 +18,9 @@
  */
 package org.apache.pinot.spi.stream;
 
+import javax.annotation.Nullable;
+
+
 /**
  * A PartitionGroup is a group of partitions/shards that the same consumer should consume from.
  * This class is a container for the metadata regarding a partition group, that is needed by a consumer to start
@@ -30,14 +33,15 @@ public class PartitionGroupMetadata {
 
   private static final String SEPARATOR = "__";
   private final int _partitionGroupId;
+  @Nullable
   private final String _topicName;
   private final StreamPartitionMsgOffset _startOffset;
 
   public PartitionGroupMetadata(int partitionGroupId, StreamPartitionMsgOffset startOffset) {
-    this("", partitionGroupId, startOffset);
+    this(null, partitionGroupId, startOffset);
   }
 
-  public PartitionGroupMetadata(String topicName, int partitionGroupId, StreamPartitionMsgOffset startOffset) {
+  public PartitionGroupMetadata(@Nullable String topicName, int partitionGroupId, StreamPartitionMsgOffset startOffset) {
     _topicName = topicName;
     _partitionGroupId = partitionGroupId;
     _startOffset = startOffset;
@@ -51,8 +55,8 @@ public class PartitionGroupMetadata {
     return _topicName;
   }
 
-  public String getPartitionGroupInfo() {
-    if (_topicName.isEmpty()) {
+  public String getPartitionGroupTopicAndId() {
+    if (_topicName == null) {
       return String.valueOf(_partitionGroupId);
     } else {
       return _topicName + SEPARATOR + _partitionGroupId;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionGroupMetadata.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionGroupMetadata.java
@@ -41,7 +41,8 @@ public class PartitionGroupMetadata {
     this(null, partitionGroupId, startOffset);
   }
 
-  public PartitionGroupMetadata(@Nullable String topicName, int partitionGroupId, StreamPartitionMsgOffset startOffset) {
+  public PartitionGroupMetadata(@Nullable String topicName, int partitionGroupId,
+      StreamPartitionMsgOffset startOffset) {
     _topicName = topicName;
     _partitionGroupId = partitionGroupId;
     _startOffset = startOffset;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionGroupMetadata.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionGroupMetadata.java
@@ -53,11 +53,14 @@ public class PartitionGroupMetadata {
   }
 
   public String getTopicName() {
+    if (_topicName == null || _topicName.isEmpty()) {
+      return null;
+    }
     return _topicName;
   }
 
   public String getPartitionGroupTopicAndId() {
-    if (_topicName == null) {
+    if (_topicName == null || _topicName.isEmpty()) {
       return String.valueOf(_partitionGroupId);
     } else {
       return _topicName + SEPARATOR + _partitionGroupId;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionGroupMetadata.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionGroupMetadata.java
@@ -28,16 +28,35 @@ package org.apache.pinot.spi.stream;
  */
 public class PartitionGroupMetadata {
 
+  private static final String SEPARATOR = "__";
   private final int _partitionGroupId;
+  private final String _topicName;
   private final StreamPartitionMsgOffset _startOffset;
 
   public PartitionGroupMetadata(int partitionGroupId, StreamPartitionMsgOffset startOffset) {
+    this("", partitionGroupId, startOffset);
+  }
+
+  public PartitionGroupMetadata(String topicName, int partitionGroupId, StreamPartitionMsgOffset startOffset) {
+    _topicName = topicName;
     _partitionGroupId = partitionGroupId;
     _startOffset = startOffset;
   }
 
   public int getPartitionGroupId() {
     return _partitionGroupId;
+  }
+
+  public String getTopicName() {
+    return _topicName;
+  }
+
+  public String getPartitionGroupInfo() {
+    if (_topicName.isEmpty()) {
+      return String.valueOf(_partitionGroupId);
+    } else {
+      return _topicName + SEPARATOR + _partitionGroupId;
+    }
   }
 
   public StreamPartitionMsgOffset getStartOffset() {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfig.java
@@ -78,6 +78,7 @@ public class StreamConfig {
   private final boolean _enableOffsetAutoReset;
   private final int _offsetAutoResetOffsetThreshold;
   private final long _offsetAutoResetTimeSecThreshold;
+  private final Boolean _ephemeralBackfillTopic;
 
   private final Map<String, String> _streamConfigMap = new HashMap<>();
 
@@ -206,6 +207,9 @@ public class StreamConfig {
     _enableOffsetAutoReset = Boolean.parseBoolean(streamConfigMap.get(StreamConfigProperties.ENABLE_OFFSET_AUTO_RESET));
     _offsetAutoResetOffsetThreshold = parseOffsetAutoResetOffsetThreshold(streamConfigMap);
     _offsetAutoResetTimeSecThreshold = parseOffsetAutoResetTimeSecThreshold(streamConfigMap);
+    _ephemeralBackfillTopic = streamConfigMap.containsKey(StreamConfigProperties.EPHEMERAL_BACKFILL_TOPIC)
+        ? Boolean.parseBoolean(streamConfigMap.get(StreamConfigProperties.EPHEMERAL_BACKFILL_TOPIC))
+        : false;
 
     _streamConfigMap.putAll(streamConfigMap);
   }
@@ -431,6 +435,10 @@ public class StreamConfig {
     return _offsetAutoResetTimeSecThreshold;
   }
 
+  public Boolean isEphemeralBackfillTopic() {
+    return Boolean.TRUE.equals(_ephemeralBackfillTopic);
+  }
+
   public String getTableNameWithType() {
     return _tableNameWithType;
   }
@@ -454,6 +462,7 @@ public class StreamConfig {
         + ", _enableOffsetAutoReset=" + _enableOffsetAutoReset
         + ", _offsetAutoResetOffsetThreshold" + _offsetAutoResetOffsetThreshold
         + ", _offSetAutoResetTimeSecThreshold" + _offsetAutoResetTimeSecThreshold
+        + ", _ephemeralBackfillTopic" + _ephemeralBackfillTopic
         + ", _streamConfigMap=" + _streamConfigMap
         + ", _offsetCriteria=" + _offsetCriteria + ", _serverUploadToDeepStore=" + _serverUploadToDeepStore + '}';
   }
@@ -482,7 +491,8 @@ public class StreamConfig {
         that._offsetCriteria) && Objects.equals(_flushThresholdVarianceFraction, that._flushThresholdVarianceFraction)
         && _enableOffsetAutoReset == that._enableOffsetAutoReset
         && _offsetAutoResetOffsetThreshold == that._offsetAutoResetOffsetThreshold
-        && _offsetAutoResetTimeSecThreshold == that._offsetAutoResetTimeSecThreshold;
+        && _offsetAutoResetTimeSecThreshold == that._offsetAutoResetTimeSecThreshold
+        && Objects.equals(_ephemeralBackfillTopic, that._ephemeralBackfillTopic);
   }
 
   @Override
@@ -491,7 +501,7 @@ public class StreamConfig {
         _decoderProperties, _connectionTimeoutMillis, _fetchTimeoutMillis, _idleTimeoutMillis, _flushThresholdRows,
         _flushThresholdSegmentRows, _flushThresholdTimeMillis, _flushThresholdSegmentSizeBytes,
         _flushAutotuneInitialRows, _groupId, _topicConsumptionRateLimit, _streamConfigMap, _offsetCriteria,
-        _serverUploadToDeepStore, _flushThresholdVarianceFraction, _offsetAutoResetOffsetThreshold,
-        _enableOffsetAutoReset, _offsetAutoResetTimeSecThreshold);
+        _serverUploadToDeepStore, _flushThresholdVarianceFraction, _enableOffsetAutoReset,
+        _offsetAutoResetOffsetThreshold, _offsetAutoResetTimeSecThreshold, _ephemeralBackfillTopic);
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfigProperties.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfigProperties.java
@@ -163,6 +163,11 @@ public class StreamConfigProperties {
       "realtime.segment.offsetAutoReset.timeThresholdSeconds";
 
   /**
+   * Config used to indicate whether the topic is a temporary topic for offset auto reset backfilling
+   */
+  public static final String EPHEMERAL_BACKFILL_TOPIC = "realtime.segment.isBackfillTopic";
+
+  /**
    * Helper method to create a stream specific property
    */
   public static String constructStreamProperty(String streamType, String property) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/IngestionConfigUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/IngestionConfigUtils.java
@@ -55,6 +55,8 @@ public final class IngestionConfigUtils {
   // For partition from different topics, we pad then with an offset to avoid collision. The offset is far higher
   // than the normal max number of partitions on stream (e.g. 512).
   public static final int PARTITION_PADDING_OFFSET = 10000;
+  // For runtime generated ephemeral topics, we pad with additional offset.
+  public static final int EPHEMERAL_TOPIC_PARTITION_PADDING_OFFSET = 10_000_000;
 
   /**
    * Fetches the streamConfig from the given realtime table.
@@ -122,6 +124,25 @@ public final class IngestionConfigUtils {
    */
   public static int getStreamConfigIndexFromPinotPartitionId(int partitionId) {
     return partitionId / PARTITION_PADDING_OFFSET;
+  }
+
+  /**
+   * Getting the StreamConfig from StreamConfigs list based on topicName and partitionId.
+   * @param partitionId the segment partition id on Pinot
+   */
+  public static StreamConfig getStreamConfigFromStreamConfigList(
+      int partitionId, String topicName, List<StreamConfig> streamConfigs) {
+    int rawTopicIndex = getStreamConfigIndexFromPinotPartitionId(partitionId);
+    if (topicName != null && !topicName.isEmpty()) {
+      return streamConfigs.stream().filter(c -> topicName.equals(c.getTopicName()))
+          .findFirst()
+          .orElseThrow(() -> new IllegalArgumentException("No matching StreamConfig found for topic: " + topicName));
+    } else {
+      return streamConfigs.stream()
+          .filter(c -> !c.isEphemeralBackfillTopic()).skip(rawTopicIndex)
+          .findFirst()
+          .orElseThrow(() -> new IllegalArgumentException("Not enough non-ephemeral StreamConfigs"));
+    }
   }
 
   /**

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/IngestionConfigUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/IngestionConfigUtils.java
@@ -55,8 +55,6 @@ public final class IngestionConfigUtils {
   // For partition from different topics, we pad then with an offset to avoid collision. The offset is far higher
   // than the normal max number of partitions on stream (e.g. 512).
   public static final int PARTITION_PADDING_OFFSET = 10000;
-  // For runtime generated ephemeral topics, we pad with additional offset.
-  public static final int EPHEMERAL_TOPIC_PARTITION_PADDING_OFFSET = 10_000_000;
 
   /**
    * Fetches the streamConfig from the given realtime table.

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/stream/PartitionGroupMetadataFetcherTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/stream/PartitionGroupMetadataFetcherTest.java
@@ -1,10 +1,27 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.spi.stream;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.apache.pinot.spi.utils.IngestionConfigUtils;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 import org.testng.Assert;
@@ -153,7 +170,8 @@ public class PartitionGroupMetadataFetcherTest {
     StreamConfig ephemeralStream1 = createMockStreamConfig("ephemeral-topic1", "test-table", true);
     StreamConfig permanentStream2 = createMockStreamConfig("permanent-topic2", "test-table", false);
     StreamConfig ephemeralStream2 = createMockStreamConfig("ephemeral-topic2", "test-table", true);
-    List<StreamConfig> streamConfigs = Arrays.asList(permanentStream1, ephemeralStream1, permanentStream2, ephemeralStream2);
+    List<StreamConfig> streamConfigs =
+        Arrays.asList(permanentStream1, ephemeralStream1, permanentStream2, ephemeralStream2);
 
     // Mock consumption status for all topics
     PartitionGroupConsumptionStatus statusPer1 = new PartitionGroupConsumptionStatus(0, 0, null, null, "IN_PROGRESS");

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/stream/PartitionGroupMetadataFetcherTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/stream/PartitionGroupMetadataFetcherTest.java
@@ -1,0 +1,216 @@
+package org.apache.pinot.spi.stream;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.pinot.spi.utils.IngestionConfigUtils;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+public class PartitionGroupMetadataFetcherTest {
+
+  @Test
+  public void testFetchSingleStreamSuccess()
+      throws Exception {
+    // Setup
+    StreamConfig streamConfig = createMockStreamConfig("test-topic", "test-table", false);
+    List<StreamConfig> streamConfigs = Collections.singletonList(streamConfig);
+
+    PartitionGroupConsumptionStatus status = mock(PartitionGroupConsumptionStatus.class);
+    when(status.getPartitionGroupId()).thenReturn(0);
+    List<PartitionGroupConsumptionStatus> statusList = Collections.singletonList(status);
+
+    PartitionGroupMetadata metadata = new PartitionGroupMetadata("", 0, mock(StreamPartitionMsgOffset.class));
+    List<PartitionGroupMetadata> metadataList = Collections.singletonList(metadata);
+
+    StreamMetadataProvider metadataProvider = mock(StreamMetadataProvider.class);
+    when(metadataProvider.computePartitionGroupMetadata(anyString(), any(StreamConfig.class),
+        any(List.class), anyInt(), anyBoolean())).thenReturn(metadataList);
+
+    StreamConsumerFactory factory = mock(StreamConsumerFactory.class);
+    when(factory.createStreamMetadataProvider(anyString())).thenReturn(metadataProvider);
+
+    try (MockedStatic<StreamConsumerFactoryProvider> mockedProvider = Mockito.mockStatic(
+        StreamConsumerFactoryProvider.class)) {
+      mockedProvider.when(() -> StreamConsumerFactoryProvider.create(any(StreamConfig.class))).thenReturn(factory);
+
+      PartitionGroupMetadataFetcher fetcher = new PartitionGroupMetadataFetcher(
+          streamConfigs, statusList, false);
+
+      // Execute
+      Boolean result = fetcher.call();
+
+      // Verify
+      Assert.assertTrue(result);
+      Assert.assertEquals(fetcher.getPartitionGroupMetadataList().size(), 1);
+      Assert.assertNull(fetcher.getException());
+    }
+  }
+
+  @Test
+  public void testFetchSingleStreamTransientException()
+      throws Exception {
+    // Setup
+    StreamConfig streamConfig = createMockStreamConfig("test-topic", "test-table", false);
+    List<StreamConfig> streamConfigs = Collections.singletonList(streamConfig);
+
+    List<PartitionGroupConsumptionStatus> statusList = Collections.emptyList();
+
+    StreamMetadataProvider metadataProvider = mock(StreamMetadataProvider.class);
+    when(metadataProvider.computePartitionGroupMetadata(anyString(), any(StreamConfig.class),
+        any(List.class), anyInt(), anyBoolean()))
+        .thenThrow(new TransientConsumerException(new RuntimeException("Transient error")));
+
+    StreamConsumerFactory factory = mock(StreamConsumerFactory.class);
+    when(factory.createStreamMetadataProvider(anyString())).thenReturn(metadataProvider);
+
+    try (MockedStatic<StreamConsumerFactoryProvider> mockedProvider = Mockito.mockStatic(
+        StreamConsumerFactoryProvider.class)) {
+      mockedProvider.when(() -> StreamConsumerFactoryProvider.create(any(StreamConfig.class))).thenReturn(factory);
+
+      PartitionGroupMetadataFetcher fetcher = new PartitionGroupMetadataFetcher(
+          streamConfigs, statusList, false);
+
+      // Execute
+      Boolean result = fetcher.call();
+
+      // Verify
+      Assert.assertFalse(result);
+      Assert.assertTrue(fetcher.getException() instanceof TransientConsumerException);
+    }
+  }
+
+  @Test
+  public void testFetchMultipleStreamsWithoutEphemeralTopics()
+      throws Exception {
+    // Setup
+    StreamConfig streamConfig1 = createMockStreamConfig("topic1", "test-table", false);
+    StreamConfig streamConfig2 = createMockStreamConfig("topic2", "test-table", false);
+    List<StreamConfig> streamConfigs = Arrays.asList(streamConfig1, streamConfig2);
+
+    PartitionGroupConsumptionStatus status1 = new PartitionGroupConsumptionStatus(0, 0, null, null, "IN_PROGRESS");
+    PartitionGroupConsumptionStatus status2 = new PartitionGroupConsumptionStatus(1, 1, null, null, "IN_PROGRESS");
+    List<PartitionGroupConsumptionStatus> statusList = Arrays.asList(status1, status2);
+
+    PartitionGroupMetadata mockedMetadata1 = new PartitionGroupMetadata(0, mock(StreamPartitionMsgOffset.class));
+    PartitionGroupMetadata mockedMetadata2 = new PartitionGroupMetadata(1, mock(StreamPartitionMsgOffset.class));
+
+    StreamMetadataProvider metadataProvider = mock(StreamMetadataProvider.class);
+    when(metadataProvider.computePartitionGroupMetadata(anyString(), any(StreamConfig.class),
+        any(List.class), anyInt(), anyBoolean()))
+        .thenReturn(Arrays.asList(mockedMetadata1, mockedMetadata2));
+
+    StreamConsumerFactory factory = mock(StreamConsumerFactory.class);
+    when(factory.createStreamMetadataProvider(anyString())).thenReturn(metadataProvider);
+
+    try (MockedStatic<StreamConsumerFactoryProvider> mockedProvider = Mockito.mockStatic(
+        StreamConsumerFactoryProvider.class)) {
+      mockedProvider.when(() -> StreamConsumerFactoryProvider.create(any(StreamConfig.class))).thenReturn(factory);
+
+      PartitionGroupMetadataFetcher fetcher = new PartitionGroupMetadataFetcher(
+          streamConfigs, statusList, false);
+
+      // Execute
+      Boolean result = fetcher.call();
+
+      // Verify
+      Assert.assertTrue(result);
+      Assert.assertEquals(fetcher.getPartitionGroupMetadataList().size(), 4);
+      Assert.assertNull(fetcher.getException());
+
+      // Verify the correct partition group IDs: 0, 1, 10000, 10001
+      List<PartitionGroupMetadata> resultMetadata = fetcher.getPartitionGroupMetadataList();
+      List<Integer> partitionIds = resultMetadata.stream()
+          .map(PartitionGroupMetadata::getPartitionGroupId)
+          .sorted()
+          .collect(Collectors.toList());
+
+      List<String> partitionTopicsAndIds = resultMetadata.stream()
+          .map(PartitionGroupMetadata::getPartitionGroupTopicAndId)
+          .sorted()
+          .collect(Collectors.toList());
+
+      Assert.assertEquals(partitionTopicsAndIds, Arrays.asList("0", "1", "10000", "10001"));
+    }
+  }
+
+  @Test
+  public void testFetchMultipleStreamsWithEphemeralTopics()
+      throws Exception {
+    // Setup - mix of permanent and ephemeral topics
+    StreamConfig permanentStream1 = createMockStreamConfig("permanent-topic1", "test-table", false);
+    StreamConfig ephemeralStream1 = createMockStreamConfig("ephemeral-topic1", "test-table", true);
+    StreamConfig permanentStream2 = createMockStreamConfig("permanent-topic2", "test-table", false);
+    StreamConfig ephemeralStream2 = createMockStreamConfig("ephemeral-topic2", "test-table", true);
+    List<StreamConfig> streamConfigs = Arrays.asList(permanentStream1, ephemeralStream1, permanentStream2, ephemeralStream2);
+
+    // Mock consumption status for all topics
+    PartitionGroupConsumptionStatus statusPer1 = new PartitionGroupConsumptionStatus(0, 0, null, null, "IN_PROGRESS");
+    PartitionGroupConsumptionStatus statusPer2 = new PartitionGroupConsumptionStatus(
+        10000, 0, 1, null, null, "IN_PROGRESS");
+    PartitionGroupConsumptionStatus statusEph1 = new PartitionGroupConsumptionStatus(
+        "ephemeral-topic1", 0, 0, 1, null, null, "IN_PROGRESS");
+
+    List<PartitionGroupConsumptionStatus> statusList = Arrays.asList(statusPer1, statusPer2, statusEph1);
+
+    // Mock metadata returned by stream providers, all topics are with 2 partitions
+    PartitionGroupMetadata metadata1 = new PartitionGroupMetadata("", 0, mock(StreamPartitionMsgOffset.class));
+    PartitionGroupMetadata metadata2 = new PartitionGroupMetadata("", 1, mock(StreamPartitionMsgOffset.class));
+
+    StreamMetadataProvider metadataProvider = mock(StreamMetadataProvider.class);
+    when(metadataProvider.computePartitionGroupMetadata(anyString(), any(StreamConfig.class),
+        any(List.class), anyInt(), anyBoolean()))
+        .thenReturn(Arrays.asList(metadata1, metadata2));
+
+    StreamConsumerFactory factory = mock(StreamConsumerFactory.class);
+    when(factory.createStreamMetadataProvider(anyString())).thenReturn(metadataProvider);
+
+    try (MockedStatic<StreamConsumerFactoryProvider> mockedProvider = Mockito.mockStatic(
+        StreamConsumerFactoryProvider.class)) {
+
+      mockedProvider.when(() -> StreamConsumerFactoryProvider.create(any(StreamConfig.class))).thenReturn(factory);
+
+      PartitionGroupMetadataFetcher fetcher = new PartitionGroupMetadataFetcher(
+          streamConfigs, statusList, false);
+
+      // Execute
+      Boolean result = fetcher.call();
+
+      // Verify
+      Assert.assertTrue(result);
+      Assert.assertEquals(fetcher.getPartitionGroupMetadataList().size(), 8);
+      Assert.assertNull(fetcher.getException());
+
+      // Verify the correct partition group IDs
+      List<PartitionGroupMetadata> resultMetadata = fetcher.getPartitionGroupMetadataList();
+
+      List<String> partitionTopicsAndIds = resultMetadata.stream()
+          .map(PartitionGroupMetadata::getPartitionGroupTopicAndId)
+          .sorted()
+          .collect(Collectors.toList());
+
+      Assert.assertEquals(partitionTopicsAndIds,
+          Arrays.asList("0", "1", "10000", "10001", "ephemeral-topic1__0", "ephemeral-topic1__1", "ephemeral-topic2__0",
+              "ephemeral-topic2__1"));
+    }
+  }
+
+  private StreamConfig createMockStreamConfig(String topicName, String tableName, boolean isEphemeral) {
+    StreamConfig streamConfig = mock(StreamConfig.class);
+    when(streamConfig.getTopicName()).thenReturn(topicName);
+    when(streamConfig.getTableNameWithType()).thenReturn(tableName);
+    when(streamConfig.isEphemeralBackfillTopic()).thenReturn(isEphemeral);
+    return streamConfig;
+  }
+}


### PR DESCRIPTION
`real-time` `ingestion` `feature`
Part 2 of https://github.com/apache/pinot/pull/15782, but this is independent from part 1
Issue https://github.com/apache/pinot/issues/14815
Design doc https://docs.google.com/document/d/1NKPeNh6V2ctaQ4T_X3OKJ6Gcy5TRanLiU1uIDT8_9UA/edit?usp=sharing

Introduce the new ephemeral type of topic in multi-topic ingestion. The main difference would be the segment name. **For such type of topic, the segment name would be `tableName__topicName__partitionGroupId__sequenceNumber__creationTime` instead of `tableName__partitionGroupId__sequenceNumber__creationTime`.**
This change is supposed to be **no-op at the moment because such naming would not be applied to any ingestions**. Afterwards, this would be used to:

- [Short-term]Support skip interval backfill for offset auto reset during real-time ingestion lag (configurable).
- [Mid/Long-term]Replace the existing multi-topic ingestion naming format. So that it would be easy to remove topics from multi-topic table.

Other changes:

- Ensure each stream could use their own streamConfig instead of sharing the configs from the first streamConfig. Removing the streamConfigs.get(0) usage.
- Does not allow duplicate stream (same stream type with same topic name)
- [Tentative] Does not allow deleting topics. Deleting topics is not banned currently, but it is not a safe operation as segment metadata mapping would be messed.


E.g. when we have streamConfigMaps like
```
"streamConfigMaps": [
          {
            "realtime.segment.flush.threshold.rows": "0",
            "stream.kafka.decoder.prop.fieldsForClpEncoding": "message",
            "realtime.segment.flush.autotune.initialRows": "2000",
            "stream.kafka.decoder.prop.errorSamplingPeriod": "100000000",
            "stream.kafka.decoder.prop.unencodableFieldSuffix": "_noindex",
            "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.inputformat.clplog.CLPLogMessageDecoder",
            "streamType": "kafka",
            "stream.kafka.consumer.type": "lowlevel",
            "realtime.segment.flush.threshold.segment.size": "200MB",
            "stream.kafka.broker.list": "<broker>",
            "realtime.segment.flush.threshold.time": "9000000",
            "stream.kafka.consumer.prop.auto.offset.reset": "smallest",
            "realtime.segment.offsetAutoReset.timeSecThreshold": "1800",
            "stream.kafka.topic.name": "topic1"
          },
          {
            "realtime.segment.flush.threshold.rows": "0",
            "stream.kafka.decoder.prop.fieldsForClpEncoding": "message",
            "realtime.segment.flush.autotune.initialRows": "2000",
            "stream.kafka.decoder.prop.errorSamplingPeriod": "100000000",
            "stream.kafka.decoder.prop.unencodableFieldSuffix": "_noindex",
            "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.inputformat.clplog.CLPLogMessageDecoder",
            "streamType": "kafka",
            "stream.kafka.consumer.type": "lowlevel",
            "realtime.segment.flush.threshold.segment.size": "200MB",
            "stream.kafka.broker.list": "<broker>",
            "realtime.segment.flush.threshold.time": "9000000",
            "stream.kafka.consumer.prop.auto.offset.reset": "smallest",
            "realtime.segment.offsetAutoReset.timeSecThreshold": "1800",
            "stream.kafka.topic.name": "topic2"
          },
          {
            "realtime.segment.flush.threshold.rows": "0",
            "stream.kafka.decoder.prop.fieldsForClpEncoding": "message",
            "realtime.segment.isBackfillTopic": "true",
            "realtime.segment.flush.autotune.initialRows": "2000",
            "stream.kafka.decoder.prop.errorSamplingPeriod": "100000000",
            "stream.kafka.decoder.prop.unencodableFieldSuffix": "_noindex",
            "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.inputformat.clplog.CLPLogMessageDecoder",
            "streamType": "kafka",
            "stream.kafka.consumer.type": "lowlevel",
            "realtime.segment.flush.threshold.segment.size": "200MB",
            "stream.kafka.broker.list": "<broker>",
            "realtime.segment.flush.threshold.time": "9000000",
            "realtime.segment.offsetAutoReset.timeSecThreshold": "1800",
            "stream.kafka.consumer.prop.auto.offset.reset": "smallest",
            "stream.kafka.topic.name": "topic1_backfill"
          }
]
```
With `"realtime.segment.isBackfillTopic": "true",` in one of the topic, then the segment name would be (assuming 2 partitions per topic)

```
table1__0__1__20250101T0000Z
table1__1__1__20250101T0001Z
table1__10000__1__20250101T0000Z
table1__10001__1__20250101T0001Z
table1__topic1_backfill__0__1__20250101T0010Z
table1__topic1_backfill__1__1__20250101T0010Z
```
Right now, we are not able to remove `topic1` because `topic2`'s corresponding PinotPartitionId would become 10000 -> 0, 10001- > 1, and inherit topic1's segment commit info. 
But for this new type of topic, it is safe to remove `topic1_backfill` because it would not mess up `topic1` and `topic2`'s PinotPartitionId mapping.
