### PR TITLE
Add min2 and max2 to support min and max using other types (like Strings)

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactory.java
@@ -217,14 +217,14 @@ public class AggregationFunctionFactory {
           case MIN2: {
             ExpressionContext dataTypeExp = arguments.get(1);
             Preconditions.checkArgument(dataTypeExp.getType() == ExpressionContext.Type.LITERAL,
-                "MIN expects the 2rd argument to be literal, got: %s. The function can be used as "
+                "MIN expects the 2nd argument to be literal, got: %s. The function can be used as "
                     + "min(dataColumn, 'dataType')", dataTypeExp.getType());
             DataType dataType;
+            String typeLiteral = dataTypeExp.getLiteral().getStringValue().toUpperCase();
             try {
-              String upperCase = dataTypeExp.getLiteral().getStringValue().toUpperCase();
-              dataType = DataType.valueOf(upperCase);
+              dataType = DataType.valueOf(typeLiteral);
             } catch (IllegalArgumentException e) {
-              throw new IllegalArgumentException("Unsupported data type for MIN: " + upperCaseFunctionName);
+              throw new IllegalArgumentException("Unsupported data type for MIN: " + typeLiteral);
             }
             switch (dataType) {
               case INT:
@@ -243,14 +243,14 @@ public class AggregationFunctionFactory {
           case MAX2: {
             ExpressionContext dataTypeExp = arguments.get(1);
             Preconditions.checkArgument(dataTypeExp.getType() == ExpressionContext.Type.LITERAL,
-                "MAX expects the 2rd argument to be literal, got: %s. The function can be used as "
+                "MAX expects the 2nd argument to be literal, got: %s. The function can be used as "
                     + "max(dataColumn, 'dataType')", dataTypeExp.getType());
             DataType dataType;
+            String typeLiteral = dataTypeExp.getLiteral().getStringValue().toUpperCase();
             try {
-              String upperCase = dataTypeExp.getLiteral().getStringValue().toUpperCase();
-              dataType = DataType.valueOf(upperCase);
+              dataType = DataType.valueOf(typeLiteral);
             } catch (IllegalArgumentException e) {
-              throw new IllegalArgumentException("Unsupported data type for MAX: " + upperCaseFunctionName);
+              throw new IllegalArgumentException("Unsupported data type for MAX: " + typeLiteral);
             }
             switch (dataType) {
               case INT:

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactory.java
@@ -214,8 +214,56 @@ public class AggregationFunctionFactory {
             return new CountAggregationFunction(arguments, nullHandlingEnabled);
           case MIN:
             return new MinAggregationFunction(arguments, nullHandlingEnabled);
+          case MIN2: {
+            ExpressionContext dataTypeExp = arguments.get(1);
+            Preconditions.checkArgument(dataTypeExp.getType() == ExpressionContext.Type.LITERAL,
+                "MIN expects the 2rd argument to be literal, got: %s. The function can be used as "
+                    + "min(dataColumn, 'dataType')", dataTypeExp.getType());
+            DataType dataType;
+            try {
+              String upperCase = dataTypeExp.getLiteral().getStringValue().toUpperCase();
+              dataType = DataType.valueOf(upperCase);
+            } catch (IllegalArgumentException e) {
+              throw new IllegalArgumentException("Unsupported data type for MIN: " + upperCaseFunctionName);
+            }
+            switch (dataType) {
+              case INT:
+              case LONG:
+              case FLOAT:
+              case DOUBLE:
+                return new MinAggregationFunction(firstArgument, nullHandlingEnabled);
+              case STRING:
+                return new MinStringAggregationFunction(firstArgument, nullHandlingEnabled);
+              default:
+                throw new IllegalArgumentException("Unsupported data type for MIN: " + dataType);
+            }
+          }
           case MAX:
             return new MaxAggregationFunction(arguments, nullHandlingEnabled);
+          case MAX2: {
+            ExpressionContext dataTypeExp = arguments.get(1);
+            Preconditions.checkArgument(dataTypeExp.getType() == ExpressionContext.Type.LITERAL,
+                "MAX expects the 2rd argument to be literal, got: %s. The function can be used as "
+                    + "max(dataColumn, 'dataType')", dataTypeExp.getType());
+            DataType dataType;
+            try {
+              String upperCase = dataTypeExp.getLiteral().getStringValue().toUpperCase();
+              dataType = DataType.valueOf(upperCase);
+            } catch (IllegalArgumentException e) {
+              throw new IllegalArgumentException("Unsupported data type for MAX: " + upperCaseFunctionName);
+            }
+            switch (dataType) {
+              case INT:
+              case LONG:
+              case FLOAT:
+              case DOUBLE:
+                return new MaxAggregationFunction(firstArgument, nullHandlingEnabled);
+              case STRING:
+                return new MaxStringAggregationFunction(firstArgument, nullHandlingEnabled);
+              default:
+                throw new IllegalArgumentException("Unsupported data type for MAX: " + dataType);
+            }
+          }
           case SUM:
           case SUM0:
             return new SumAggregationFunction(arguments, nullHandlingEnabled);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MaxStringAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MaxStringAggregationFunction.java
@@ -1,0 +1,202 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.aggregation.function;
+
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.apache.pinot.common.CustomObject;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.common.ObjectSerDeUtils;
+import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
+import org.apache.pinot.core.query.aggregation.ObjectAggregationResultHolder;
+import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
+import org.apache.pinot.core.query.aggregation.groupby.ObjectGroupByResultHolder;
+import org.apache.pinot.segment.spi.AggregationFunctionType;
+
+
+public class MaxStringAggregationFunction extends NullableSingleInputAggregationFunction<String, String> {
+
+  public MaxStringAggregationFunction(ExpressionContext expression, boolean nullHandlingEnabled) {
+    super(expression, nullHandlingEnabled);
+  }
+
+  @Override
+  public AggregationFunctionType getType() {
+    return AggregationFunctionType.MAX2;
+  }
+
+  @Override
+  public AggregationResultHolder createAggregationResultHolder() {
+    return new ObjectAggregationResultHolder();
+  }
+
+  @Override
+  public GroupByResultHolder createGroupByResultHolder(int initialCapacity, int maxCapacity) {
+    return new ObjectGroupByResultHolder(initialCapacity, maxCapacity);
+  }
+
+  @Override
+  public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
+    BlockValSet blockValSet = blockValSetMap.get(_expression);
+    String[] values = blockValSet.getStringValuesSV();
+
+    String max = foldNotNull(length, blockValSet, null, (accum, from, to) -> {
+      String innerMax = values[from];
+      for (int i = from + 1; i < to; i++) {
+        innerMax = innerMax.compareTo(values[i]) < 0 ? values[i] : innerMax;
+      }
+      return accum == null ? innerMax : innerMax.compareTo(accum) < 0 ? accum : innerMax;
+    });
+
+    updateAggregationResultHolder(aggregationResultHolder, max);
+  }
+
+  protected void updateAggregationResultHolder(AggregationResultHolder aggregationResultHolder, String  max) {
+    if (max != null) {
+      if (_nullHandlingEnabled) {
+        String otherMax = aggregationResultHolder.getResult();
+        if (otherMax == null) {
+          // If the other max is null, we set the value directly
+          aggregationResultHolder.setValue(max);
+        } else {
+          // Compare and set the maximum value
+          aggregationResultHolder.setValue(max.compareTo(otherMax) < 0 ? otherMax : max);
+        }
+      } else {
+        String otherMax = aggregationResultHolder.getResult();
+        aggregationResultHolder.setValue(max.compareTo(otherMax) < 0 ? otherMax : max);
+      }
+    }
+  }
+
+  @Override
+  public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
+    BlockValSet blockValSet = blockValSetMap.get(_expression);
+    String[] valueArray = blockValSet.getStringValuesSV();
+
+    if (_nullHandlingEnabled) {
+      forEachNotNull(length, blockValSet, (from, to) -> {
+        for (int i = from; i < to; i++) {
+          String value = valueArray[i];
+          int groupKey = groupKeyArray[i];
+          String result = groupByResultHolder.getResult(groupKey);
+          if (result == null || value.compareTo(result) > 0) {
+            groupByResultHolder.setValueForKey(groupKey, value);
+          }
+        }
+      });
+    } else {
+      for (int i = 0; i < length; i++) {
+        String value = valueArray[i];
+        int groupKey = groupKeyArray[i];
+        if (value.compareTo(groupByResultHolder.getResult(groupKey)) > 0) {
+          groupByResultHolder.setValueForKey(groupKey, value);
+        }
+      }
+    }
+  }
+
+  @Override
+  public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
+    BlockValSet blockValSet = blockValSetMap.get(_expression);
+    String[] valueArray = blockValSet.getStringValuesSV();
+
+    if (_nullHandlingEnabled) {
+      forEachNotNull(length, blockValSet, (from, to) -> {
+        for (int i = from; i < to; i++) {
+          String value = valueArray[i];
+          for (int groupKey : groupKeysArray[i]) {
+            String result = groupByResultHolder.getResult(groupKey);
+            if (result == null || value.compareTo(result) > 0) {
+              groupByResultHolder.setValueForKey(groupKey, value);
+            }
+          }
+        }
+      });
+    } else {
+      for (int i = 0; i < length; i++) {
+        String value = valueArray[i];
+        for (int groupKey : groupKeysArray[i]) {
+          if (value.compareTo(groupByResultHolder.getResult(groupKey)) > 0) {
+            groupByResultHolder.setValueForKey(groupKey, value);
+          }
+        }
+      }
+    }
+  }
+
+  @Nullable
+  @Override
+  public String extractAggregationResult(AggregationResultHolder aggregationResultHolder) {
+    return aggregationResultHolder.getResult();
+  }
+
+  @Nullable
+  @Override
+  public String extractGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey) {
+    return groupByResultHolder.getResult(groupKey);
+  }
+
+  @Nullable
+  @Override
+  public String merge(@Nullable String intermediateResult1, @Nullable String intermediateResult2) {
+    if (intermediateResult1 == null) {
+      return intermediateResult2;
+    }
+    if (intermediateResult2 == null) {
+      return intermediateResult1;
+    }
+    if (intermediateResult1.compareTo(intermediateResult2) > 0) {
+      return intermediateResult1;
+    }
+    return intermediateResult2;
+  }
+
+  @Override
+  public DataSchema.ColumnDataType getIntermediateResultColumnType() {
+    return DataSchema.ColumnDataType.STRING;
+  }
+
+  @Override
+  public DataSchema.ColumnDataType getFinalResultColumnType() {
+    return DataSchema.ColumnDataType.STRING;
+  }
+
+  @Nullable
+  @Override
+  public String extractFinalResult(@Nullable String s) {
+    return s;
+  }
+
+  @Override
+  public SerializedIntermediateResult serializeIntermediateResult(String s) {
+    return new SerializedIntermediateResult(ObjectSerDeUtils.ObjectType.String.getValue(),
+        ObjectSerDeUtils.STRING_SER_DE.serialize(s));
+  }
+
+  @Override
+  public String deserializeIntermediateResult(CustomObject customObject) {
+    return ObjectSerDeUtils.STRING_SER_DE.deserialize(customObject.getBuffer());
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MaxStringAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MaxStringAggregationFunction.java
@@ -72,7 +72,7 @@ public class MaxStringAggregationFunction extends NullableSingleInputAggregation
       if (otherMax == null) {
         // If the other max is null, we set the value directly
         aggregationResultHolder.setValue(max);
-      } else if (max.compareTo(otherMax) < 0) {
+      } else if (max.compareTo(otherMax) > 0) {
         aggregationResultHolder.setValue(max);
       }
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MaxStringAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MaxStringAggregationFunction.java
@@ -67,23 +67,13 @@ public class MaxStringAggregationFunction extends NullableSingleInputAggregation
       return accum == null ? innerMax : innerMax.compareTo(accum) < 0 ? accum : innerMax;
     });
 
-    updateAggregationResultHolder(aggregationResultHolder, max);
-  }
-
-  protected void updateAggregationResultHolder(AggregationResultHolder aggregationResultHolder, String max) {
     if (max != null) {
-      if (_nullHandlingEnabled) {
-        String otherMax = aggregationResultHolder.getResult();
-        if (otherMax == null) {
-          // If the other max is null, we set the value directly
-          aggregationResultHolder.setValue(max);
-        } else {
-          // Compare and set the maximum value
-          aggregationResultHolder.setValue(max.compareTo(otherMax) < 0 ? otherMax : max);
-        }
-      } else {
-        String otherMax = aggregationResultHolder.getResult();
-        aggregationResultHolder.setValue(max.compareTo(otherMax) < 0 ? otherMax : max);
+      String otherMax = aggregationResultHolder.getResult();
+      if (otherMax == null) {
+        // If the other max is null, we set the value directly
+        aggregationResultHolder.setValue(max);
+      } else if (max.compareTo(otherMax) < 0) {
+        aggregationResultHolder.setValue(max);
       }
     }
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MaxStringAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MaxStringAggregationFunction.java
@@ -70,7 +70,7 @@ public class MaxStringAggregationFunction extends NullableSingleInputAggregation
     updateAggregationResultHolder(aggregationResultHolder, max);
   }
 
-  protected void updateAggregationResultHolder(AggregationResultHolder aggregationResultHolder, String  max) {
+  protected void updateAggregationResultHolder(AggregationResultHolder aggregationResultHolder, String max) {
     if (max != null) {
       if (_nullHandlingEnabled) {
         String otherMax = aggregationResultHolder.getResult();

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinStringAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinStringAggregationFunction.java
@@ -70,7 +70,7 @@ public class MinStringAggregationFunction extends NullableSingleInputAggregation
     if (min != null) {
       String otherMax = aggregationResultHolder.getResult();
       if (otherMax == null) {
-        // If the other max is null, we set the value directly
+        // If the other min is null, we set the value directly
         aggregationResultHolder.setValue(min);
       } else if (min.compareTo(otherMax) < 0) {
         aggregationResultHolder.setValue(min);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinStringAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinStringAggregationFunction.java
@@ -95,23 +95,21 @@ public class MinStringAggregationFunction extends NullableSingleInputAggregation
     String[] valueArray = blockValSet.getStringValuesSV();
 
     if (_nullHandlingEnabled) {
-      forEachNotNull(length, blockValSet, (from, to) -> {
-        for (int i = from; i < to; i++) {
-          String value = valueArray[i];
-          int groupKey = groupKeyArray[i];
-          String result = groupByResultHolder.getResult(groupKey);
-          if (result == null || value.compareTo(result) < 0) {
-            groupByResultHolder.setValueForKey(groupKey, value);
-          }
-        }
-      });
+      forEachNotNull(length, blockValSet, (from, to) ->
+          aggregateBySV(valueArray, groupKeyArray, groupByResultHolder, from, to));
     } else {
-      for (int i = 0; i < length; i++) {
-        String value = valueArray[i];
-        int groupKey = groupKeyArray[i];
-        if (value.compareTo(groupByResultHolder.getResult(groupKey)) < 0) {
-          groupByResultHolder.setValueForKey(groupKey, value);
-        }
+      aggregateBySV(valueArray, groupKeyArray, groupByResultHolder, 0, length);
+    }
+  }
+
+  private void aggregateBySV(
+      String[] valueArray, int[] groupKeyArray, GroupByResultHolder groupByResultHolder, int from, int to) {
+    for (int i = from; i < to; i++) {
+      String value = valueArray[i];
+      int groupKey = groupKeyArray[i];
+      String result = groupByResultHolder.getResult(groupKey);
+      if (result == null || value.compareTo(result) < 0) {
+        groupByResultHolder.setValueForKey(groupKey, value);
       }
     }
   }
@@ -123,24 +121,21 @@ public class MinStringAggregationFunction extends NullableSingleInputAggregation
     String[] valueArray = blockValSet.getStringValuesSV();
 
     if (_nullHandlingEnabled) {
-      forEachNotNull(length, blockValSet, (from, to) -> {
-        for (int i = from; i < to; i++) {
-          String value = valueArray[i];
-          for (int groupKey : groupKeysArray[i]) {
-            String result = groupByResultHolder.getResult(groupKey);
-            if (result == null || value.compareTo(result) < 0) {
-              groupByResultHolder.setValueForKey(groupKey, value);
-            }
-          }
-        }
-      });
+      forEachNotNull(length, blockValSet, (from, to) ->
+        aggregateByMV(groupKeysArray, groupByResultHolder, valueArray, from, to));
     } else {
-      for (int i = 0; i < length; i++) {
-        String value = valueArray[i];
-        for (int groupKey : groupKeysArray[i]) {
-          if (value.compareTo(groupByResultHolder.getResult(groupKey)) < 0) {
-            groupByResultHolder.setValueForKey(groupKey, value);
-          }
+      aggregateByMV(groupKeysArray, groupByResultHolder, valueArray, 0, length);
+    }
+  }
+
+  private static void aggregateByMV(
+      int[][] groupKeysArray, GroupByResultHolder groupByResultHolder, String[] valueArray, int from, int to) {
+    for (int i = from; i < to; i++) {
+      String value = valueArray[i];
+      for (int groupKey : groupKeysArray[i]) {
+        String result = groupByResultHolder.getResult(groupKey);
+        if (result == null || value.compareTo(result) < 0) {
+          groupByResultHolder.setValueForKey(groupKey, value);
         }
       }
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinStringAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinStringAggregationFunction.java
@@ -67,23 +67,13 @@ public class MinStringAggregationFunction extends NullableSingleInputAggregation
       return accum == null ? innerMin : innerMin.compareTo(accum) > 0 ? accum : innerMin;
     });
 
-    updateAggregationResultHolder(aggregationResultHolder, min);
-  }
-
-  protected void updateAggregationResultHolder(AggregationResultHolder aggregationResultHolder, String min) {
     if (min != null) {
-      if (_nullHandlingEnabled) {
-        String otherMin = aggregationResultHolder.getResult();
-        if (otherMin == null) {
-          // If the other min is null, we set the value directly
-          aggregationResultHolder.setValue(min);
-        } else {
-          // Compare and set the minimum value
-          aggregationResultHolder.setValue(min.compareTo(otherMin) > 0 ? otherMin : min);
-        }
-      } else {
-        String otherMin = aggregationResultHolder.getResult();
-        aggregationResultHolder.setValue(min.compareTo(otherMin) > 0 ? otherMin : min);
+      String otherMax = aggregationResultHolder.getResult();
+      if (otherMax == null) {
+        // If the other max is null, we set the value directly
+        aggregationResultHolder.setValue(min);
+      } else if (min.compareTo(otherMax) < 0) {
+        aggregationResultHolder.setValue(min);
       }
     }
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinStringAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinStringAggregationFunction.java
@@ -1,0 +1,202 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.aggregation.function;
+
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.apache.pinot.common.CustomObject;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.common.ObjectSerDeUtils;
+import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
+import org.apache.pinot.core.query.aggregation.ObjectAggregationResultHolder;
+import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
+import org.apache.pinot.core.query.aggregation.groupby.ObjectGroupByResultHolder;
+import org.apache.pinot.segment.spi.AggregationFunctionType;
+
+
+public class MinStringAggregationFunction extends NullableSingleInputAggregationFunction<String, String> {
+
+  public MinStringAggregationFunction(ExpressionContext expression, boolean nullHandlingEnabled) {
+    super(expression, nullHandlingEnabled);
+  }
+
+  @Override
+  public AggregationFunctionType getType() {
+    return AggregationFunctionType.MIN2;
+  }
+
+  @Override
+  public AggregationResultHolder createAggregationResultHolder() {
+    return new ObjectAggregationResultHolder();
+  }
+
+  @Override
+  public GroupByResultHolder createGroupByResultHolder(int initialCapacity, int maxCapacity) {
+    return new ObjectGroupByResultHolder(initialCapacity, maxCapacity);
+  }
+
+  @Override
+  public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
+    BlockValSet blockValSet = blockValSetMap.get(_expression);
+    String[] values = blockValSet.getStringValuesSV();
+
+    String min = foldNotNull(length, blockValSet, null, (accum, from, to) -> {
+      String innerMin = values[from];
+      for (int i = from + 1; i < to; i++) {
+        innerMin = innerMin.compareTo(values[i]) > 0 ? values[i] : innerMin;
+      }
+      return accum == null ? innerMin : innerMin.compareTo(accum) > 0 ? accum : innerMin;
+    });
+
+    updateAggregationResultHolder(aggregationResultHolder, min);
+  }
+
+  protected void updateAggregationResultHolder(AggregationResultHolder aggregationResultHolder, String min) {
+    if (min != null) {
+      if (_nullHandlingEnabled) {
+        String otherMin = aggregationResultHolder.getResult();
+        if (otherMin == null) {
+          // If the other min is null, we set the value directly
+          aggregationResultHolder.setValue(min);
+        } else {
+          // Compare and set the minimum value
+          aggregationResultHolder.setValue(min.compareTo(otherMin) > 0 ? otherMin : min);
+        }
+      } else {
+        String otherMin = aggregationResultHolder.getResult();
+        aggregationResultHolder.setValue(min.compareTo(otherMin) > 0 ? otherMin : min);
+      }
+    }
+  }
+
+  @Override
+  public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
+    BlockValSet blockValSet = blockValSetMap.get(_expression);
+    String[] valueArray = blockValSet.getStringValuesSV();
+
+    if (_nullHandlingEnabled) {
+      forEachNotNull(length, blockValSet, (from, to) -> {
+        for (int i = from; i < to; i++) {
+          String value = valueArray[i];
+          int groupKey = groupKeyArray[i];
+          String result = groupByResultHolder.getResult(groupKey);
+          if (result == null || value.compareTo(result) < 0) {
+            groupByResultHolder.setValueForKey(groupKey, value);
+          }
+        }
+      });
+    } else {
+      for (int i = 0; i < length; i++) {
+        String value = valueArray[i];
+        int groupKey = groupKeyArray[i];
+        if (value.compareTo(groupByResultHolder.getResult(groupKey)) < 0) {
+          groupByResultHolder.setValueForKey(groupKey, value);
+        }
+      }
+    }
+  }
+
+  @Override
+  public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
+    BlockValSet blockValSet = blockValSetMap.get(_expression);
+    String[] valueArray = blockValSet.getStringValuesSV();
+
+    if (_nullHandlingEnabled) {
+      forEachNotNull(length, blockValSet, (from, to) -> {
+        for (int i = from; i < to; i++) {
+          String value = valueArray[i];
+          for (int groupKey : groupKeysArray[i]) {
+            String result = groupByResultHolder.getResult(groupKey);
+            if (result == null || value.compareTo(result) < 0) {
+              groupByResultHolder.setValueForKey(groupKey, value);
+            }
+          }
+        }
+      });
+    } else {
+      for (int i = 0; i < length; i++) {
+        String value = valueArray[i];
+        for (int groupKey : groupKeysArray[i]) {
+          if (value.compareTo(groupByResultHolder.getResult(groupKey)) < 0) {
+            groupByResultHolder.setValueForKey(groupKey, value);
+          }
+        }
+      }
+    }
+  }
+
+  @Nullable
+  @Override
+  public String extractAggregationResult(AggregationResultHolder aggregationResultHolder) {
+    return aggregationResultHolder.getResult();
+  }
+
+  @Nullable
+  @Override
+  public String extractGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey) {
+    return groupByResultHolder.getResult(groupKey);
+  }
+
+  @Nullable
+  @Override
+  public String merge(@Nullable String intermediateResult1, @Nullable String intermediateResult2) {
+    if (intermediateResult1 == null) {
+      return intermediateResult2;
+    }
+    if (intermediateResult2 == null) {
+      return intermediateResult1;
+    }
+    if (intermediateResult1.compareTo(intermediateResult2) < 0) {
+      return intermediateResult1;
+    }
+    return intermediateResult2;
+  }
+
+  @Override
+  public DataSchema.ColumnDataType getIntermediateResultColumnType() {
+    return DataSchema.ColumnDataType.STRING;
+  }
+
+  @Override
+  public DataSchema.ColumnDataType getFinalResultColumnType() {
+    return DataSchema.ColumnDataType.STRING;
+  }
+
+  @Nullable
+  @Override
+  public String extractFinalResult(@Nullable String s) {
+    return s;
+  }
+
+  @Override
+  public SerializedIntermediateResult serializeIntermediateResult(String s) {
+    return new SerializedIntermediateResult(ObjectSerDeUtils.ObjectType.String.getValue(),
+        ObjectSerDeUtils.STRING_SER_DE.serialize(s));
+  }
+
+  @Override
+  public String deserializeIntermediateResult(CustomObject customObject) {
+    return ObjectSerDeUtils.STRING_SER_DE.deserialize(customObject.getBuffer());
+  }
+}

--- a/pinot-query-runtime/src/test/resources/queries/Aggregates.json
+++ b/pinot-query-runtime/src/test/resources/queries/Aggregates.json
@@ -44,7 +44,8 @@
       {
         "psql": "4.2.7",
         "description": "aggregations on string column",
-        "sql": "SELECT count(string_col), count(distinct(string_col)), count(*) FROM {tbl}"
+        "sql": "SELECT min2(string_col, 'STRING'), max2(string_col, 'STRING'), count(string_col), count(distinct(string_col)), count(*) FROM {tbl}",
+        "h2Sql": "SELECT min(string_col), max(string_col), count(string_col), count(distinct(string_col)), count(*) FROM {tbl}"
       },
       {
         "psql": "4.2.7",

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/AggregationFunctionType.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/AggregationFunctionType.java
@@ -52,11 +52,11 @@ public enum AggregationFunctionType {
   COUNT("count"),
   // TODO: min/max only supports NUMERIC in Pinot, where Calcite supports COMPARABLE_ORDERED
   MIN("min", SqlTypeName.DOUBLE, SqlTypeName.DOUBLE),
-  /// An alternative to MIN to support other types
+  // An alternative to MIN to support other types
   MIN2("min2", ReturnTypes.ARG0,
       OperandTypes.family(SqlTypeFamily.ANY, SqlTypeFamily.CHARACTER), SqlTypeName.OTHER),
   MAX("max", SqlTypeName.DOUBLE, SqlTypeName.DOUBLE),
-  /// An alternative to MAX to support other types
+  // An alternative to MAX to support other types
   MAX2("max2", ReturnTypes.ARG0,
       OperandTypes.family(SqlTypeFamily.ANY, SqlTypeFamily.CHARACTER), SqlTypeName.OTHER),
   SUM("sum", SqlTypeName.DOUBLE, SqlTypeName.DOUBLE),

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/AggregationFunctionType.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/AggregationFunctionType.java
@@ -52,7 +52,13 @@ public enum AggregationFunctionType {
   COUNT("count"),
   // TODO: min/max only supports NUMERIC in Pinot, where Calcite supports COMPARABLE_ORDERED
   MIN("min", SqlTypeName.DOUBLE, SqlTypeName.DOUBLE),
+  /// An alternative to MIN to support other types
+  MIN2("min2", ReturnTypes.ARG0,
+      OperandTypes.family(SqlTypeFamily.ANY, SqlTypeFamily.CHARACTER), SqlTypeName.OTHER),
   MAX("max", SqlTypeName.DOUBLE, SqlTypeName.DOUBLE),
+  /// An alternative to MAX to support other types
+  MAX2("max2", ReturnTypes.ARG0,
+      OperandTypes.family(SqlTypeFamily.ANY, SqlTypeFamily.CHARACTER), SqlTypeName.OTHER),
   SUM("sum", SqlTypeName.DOUBLE, SqlTypeName.DOUBLE),
   SUM0("$sum0", SqlTypeName.DOUBLE, SqlTypeName.DOUBLE),
   SUMPRECISION("sumPrecision", ReturnTypes.explicit(SqlTypeName.DECIMAL), OperandTypes.ANY, SqlTypeName.OTHER),


### PR DESCRIPTION
Pinot supports max and min for numbers, but not for other comparable types like Strings. The main reason is that aggregate functions are not polymorphic, and SSE doesn't keep types at runtime. This is why, for example, functions like `last_with_time` require an extra argument indicating the type of the projected column.

Here I'm using the same technique, adding two new aggregate functions: min2 and max2, which expect 2 arguments:
1. The first argument is the expression to minimize/maximize (same as used by min and max)
2. The second is the type of that expression. Right now, only number type literals (`'int'`, `'double'`, etc) and `'string'` are accepted. In case of a number, we use the same code used in min and max. In case `'string'` is used, a newly introduced aggregation function is used.

This is a hack. It is not great to force clients to specify a type Pinot should know. In the future, we should modify aggregate functions to be polymorphic, similar to what we did with scalar functions.