### PR TITLE
Fixing typo CONFIG_OF_ZOOKEEPER_SERVER in the codebase

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
@@ -161,7 +161,7 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
       throws Exception {
     _brokerConf = brokerConf;
     // Remove all white-spaces from the list of zkServers (if any).
-    _zkServers = brokerConf.getProperty(Helix.CONFIG_OF_ZOOKEEPR_SERVER).replaceAll("\\s+", "");
+    _zkServers = brokerConf.getProperty(Helix.CONFIG_OF_ZOOKEEPER_SERVER).replaceAll("\\s+", "");
     _clusterName = brokerConf.getProperty(Helix.CONFIG_OF_CLUSTER_NAME);
     ServiceStartableUtils.applyClusterConfig(_brokerConf, _zkServers, _clusterName, ServiceRole.BROKER);
     applyCustomConfigs(brokerConf);

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/HelixBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/HelixBrokerStarter.java
@@ -53,7 +53,7 @@ public class HelixBrokerStarter extends BaseBrokerStarter {
   private static PinotConfiguration applyBrokerConfigs(PinotConfiguration brokerConf, String clusterName,
       String zkServers, @Nullable String brokerHost) {
     brokerConf.setProperty(Helix.CONFIG_OF_CLUSTER_NAME, clusterName);
-    brokerConf.setProperty(Helix.CONFIG_OF_ZOOKEEPR_SERVER, zkServers);
+    brokerConf.setProperty(Helix.CONFIG_OF_ZOOKEEPER_SERVER, zkServers);
     if (brokerHost == null) {
       brokerConf.clearProperty(Broker.CONFIG_OF_BROKER_HOSTNAME);
     } else {
@@ -75,7 +75,7 @@ public class HelixBrokerStarter extends BaseBrokerStarter {
     properties.put(Helix.KEY_OF_BROKER_QUERY_PORT, 5001);
     properties.put(Broker.CONFIG_OF_BROKER_TIMEOUT_MS, 60 * 1000L);
     properties.put(Helix.CONFIG_OF_CLUSTER_NAME, "quickstart");
-    properties.put(Helix.CONFIG_OF_ZOOKEEPR_SERVER, "localhost:2122");
+    properties.put(Helix.CONFIG_OF_ZOOKEEPER_SERVER, "localhost:2122");
     HelixBrokerStarter helixBrokerStarter = new HelixBrokerStarter();
     helixBrokerStarter.init(new PinotConfiguration(properties));
     return helixBrokerStarter;

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/broker/HelixBrokerStarterHostnamePortTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/broker/HelixBrokerStarterHostnamePortTest.java
@@ -33,7 +33,7 @@ import static org.apache.pinot.spi.utils.CommonConstants.Broker.CONFIG_OF_BROKER
 import static org.apache.pinot.spi.utils.CommonConstants.Broker.CONFIG_OF_BROKER_ID;
 import static org.apache.pinot.spi.utils.CommonConstants.Broker.CONFIG_OF_DELAY_SHUTDOWN_TIME_MS;
 import static org.apache.pinot.spi.utils.CommonConstants.Helix.CONFIG_OF_CLUSTER_NAME;
-import static org.apache.pinot.spi.utils.CommonConstants.Helix.CONFIG_OF_ZOOKEEPR_SERVER;
+import static org.apache.pinot.spi.utils.CommonConstants.Helix.CONFIG_OF_ZOOKEEPER_SERVER;
 import static org.apache.pinot.spi.utils.CommonConstants.Helix.Instance.INSTANCE_ID_KEY;
 import static org.apache.pinot.spi.utils.CommonConstants.Helix.KEY_OF_BROKER_QUERY_PORT;
 import static org.testng.Assert.assertEquals;
@@ -52,7 +52,7 @@ public class HelixBrokerStarterHostnamePortTest extends ControllerTest {
   public void testHostnamePortOverride()
       throws Exception {
     Map<String, Object> properties = new HashMap<>();
-    properties.put(CONFIG_OF_ZOOKEEPR_SERVER, getZkUrl());
+    properties.put(CONFIG_OF_ZOOKEEPER_SERVER, getZkUrl());
     properties.put(CONFIG_OF_CLUSTER_NAME, getHelixClusterName());
     properties.put(INSTANCE_ID_KEY, "Broker_myInstance");
     properties.put(CONFIG_OF_BROKER_HOSTNAME, "myHost");
@@ -77,7 +77,7 @@ public class HelixBrokerStarterHostnamePortTest extends ControllerTest {
   public void testInvalidInstanceId()
       throws Exception {
     Map<String, Object> properties = new HashMap<>();
-    properties.put(CONFIG_OF_ZOOKEEPR_SERVER, getZkUrl());
+    properties.put(CONFIG_OF_ZOOKEEPER_SERVER, getZkUrl());
     properties.put(CONFIG_OF_CLUSTER_NAME, getHelixClusterName());
     properties.put(INSTANCE_ID_KEY, "myInstance");
     properties.put(CONFIG_OF_BROKER_HOSTNAME, "myHost");
@@ -91,7 +91,7 @@ public class HelixBrokerStarterHostnamePortTest extends ControllerTest {
   public void testDefaultInstanceId()
       throws Exception {
     Map<String, Object> properties = new HashMap<>();
-    properties.put(CONFIG_OF_ZOOKEEPR_SERVER, getZkUrl());
+    properties.put(CONFIG_OF_ZOOKEEPER_SERVER, getZkUrl());
     properties.put(CONFIG_OF_CLUSTER_NAME, getHelixClusterName());
     properties.put(CONFIG_OF_BROKER_HOSTNAME, "myHost");
     properties.put(KEY_OF_BROKER_QUERY_PORT, 1234);
@@ -116,7 +116,7 @@ public class HelixBrokerStarterHostnamePortTest extends ControllerTest {
       throws Exception {
     // Ensures that pinot.broker.instance.id has higher precedence compared to instanceId
     Map<String, Object> properties = new HashMap<>();
-    properties.put(CONFIG_OF_ZOOKEEPR_SERVER, getZkUrl());
+    properties.put(CONFIG_OF_ZOOKEEPER_SERVER, getZkUrl());
     properties.put(CONFIG_OF_CLUSTER_NAME, getHelixClusterName());
     properties.put(CONFIG_OF_BROKER_ID, "Broker_morePrecedence");
     properties.put(INSTANCE_ID_KEY, "Broker_lessPrecedence");

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/broker/HelixBrokerStarterTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/broker/HelixBrokerStarterTest.java
@@ -84,7 +84,7 @@ public class HelixBrokerStarterTest extends ControllerTest {
     Map<String, Object> properties = new HashMap<>();
     properties.put(Helix.KEY_OF_BROKER_QUERY_PORT, 18099);
     properties.put(Helix.CONFIG_OF_CLUSTER_NAME, getHelixClusterName());
-    properties.put(Helix.CONFIG_OF_ZOOKEEPR_SERVER, getZkUrl());
+    properties.put(Helix.CONFIG_OF_ZOOKEEPER_SERVER, getZkUrl());
     properties.put(Broker.CONFIG_OF_ENABLE_QUERY_LIMIT_OVERRIDE, true);
     properties.put(Broker.CONFIG_OF_DELAY_SHUTDOWN_TIME_MS, 0);
     properties.put(Broker.CONFIG_OF_BROKER_DEFAULT_QUERY_LIMIT, 1000);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -485,7 +485,7 @@ public class ControllerConf extends PinotConfiguration {
   }
 
   public void setZkStr(String zkStr) {
-    setProperty(CommonConstants.Helix.CONFIG_OF_ZOOKEEPR_SERVER, zkStr);
+    setProperty(CommonConstants.Helix.CONFIG_OF_ZOOKEEPER_SERVER, zkStr);
   }
 
   public void setDimTableMaxSize(String size) {
@@ -565,8 +565,8 @@ public class ControllerConf extends PinotConfiguration {
   }
 
   public String getZkStr() {
-    String zkAddress = containsKey(CommonConstants.Helix.CONFIG_OF_ZOOKEEPR_SERVER) ? getProperty(
-        CommonConstants.Helix.CONFIG_OF_ZOOKEEPR_SERVER) : getProperty(ZK_STR);
+    String zkAddress = containsKey(CommonConstants.Helix.CONFIG_OF_ZOOKEEPER_SERVER) ? getProperty(
+        CommonConstants.Helix.CONFIG_OF_ZOOKEEPER_SERVER) : getProperty(ZK_STR);
     Preconditions.checkState(zkAddress != null,
         "ZK address is not configured. Please configure it using the config: 'pinot.zk.server'");
     return zkAddress;

--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
@@ -173,7 +173,7 @@ public abstract class ClusterTest extends ControllerTest {
 
   protected PinotConfiguration getBrokerConf(int brokerId) {
     PinotConfiguration brokerConf = new PinotConfiguration();
-    brokerConf.setProperty(Helix.CONFIG_OF_ZOOKEEPR_SERVER, getZkUrl());
+    brokerConf.setProperty(Helix.CONFIG_OF_ZOOKEEPER_SERVER, getZkUrl());
     brokerConf.setProperty(Helix.CONFIG_OF_CLUSTER_NAME, getHelixClusterName());
     brokerConf.setProperty(Broker.CONFIG_OF_BROKER_HOSTNAME, LOCAL_HOST);
     int brokerPort = NetUtils.findOpenPort(_nextBrokerPort);
@@ -240,7 +240,7 @@ public abstract class ClusterTest extends ControllerTest {
 
   protected PinotConfiguration getServerConf(int serverId) {
     PinotConfiguration serverConf = new PinotConfiguration();
-    serverConf.setProperty(Helix.CONFIG_OF_ZOOKEEPR_SERVER, getZkUrl());
+    serverConf.setProperty(Helix.CONFIG_OF_ZOOKEEPER_SERVER, getZkUrl());
     serverConf.setProperty(Helix.CONFIG_OF_CLUSTER_NAME, getHelixClusterName());
     serverConf.setProperty(Helix.KEY_OF_SERVER_NETTY_HOST, LOCAL_HOST);
     serverConf.setProperty(Server.CONFIG_OF_INSTANCE_DATA_DIR,
@@ -315,7 +315,7 @@ public abstract class ClusterTest extends ControllerTest {
 
   protected PinotConfiguration getMinionConf() {
     PinotConfiguration minionConf = new PinotConfiguration();
-    minionConf.setProperty(Helix.CONFIG_OF_ZOOKEEPR_SERVER, getZkUrl());
+    minionConf.setProperty(Helix.CONFIG_OF_ZOOKEEPER_SERVER, getZkUrl());
     minionConf.setProperty(Helix.CONFIG_OF_CLUSTER_NAME, getHelixClusterName());
     minionConf.setProperty(Helix.KEY_OF_MINION_HOST, LOCAL_HOST);
     int minionPort = NetUtils.findOpenPort(_nextMinionPort);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ServerStarterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ServerStarterIntegrationTest.java
@@ -56,7 +56,7 @@ public class ServerStarterIntegrationTest extends ControllerTest {
       int expectedPort)
       throws Exception {
     serverConf.setProperty(CONFIG_OF_CLUSTER_NAME, getHelixClusterName());
-    serverConf.setProperty(CONFIG_OF_ZOOKEEPR_SERVER, getZkUrl());
+    serverConf.setProperty(CONFIG_OF_ZOOKEEPER_SERVER, getZkUrl());
     HelixServerStarter helixServerStarter = new HelixServerStarter();
     helixServerStarter.init(serverConf);
     helixServerStarter.start();

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/MinionConf.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/MinionConf.java
@@ -51,7 +51,7 @@ public class MinionConf extends PinotConfiguration {
   }
 
   public String getZkAddress() {
-    return getProperty(CommonConstants.Helix.CONFIG_OF_ZOOKEEPR_SERVER);
+    return getProperty(CommonConstants.Helix.CONFIG_OF_ZOOKEEPER_SERVER);
   }
 
   public String getHostName()

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/MinionStarter.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/MinionStarter.java
@@ -41,7 +41,7 @@ public class MinionStarter extends BaseMinionStarter {
   private static PinotConfiguration applyMinionConfigs(PinotConfiguration minionConfig, String clusterName,
       String zkServers) {
     minionConfig.setProperty(CommonConstants.Helix.CONFIG_OF_CLUSTER_NAME, clusterName);
-    minionConfig.setProperty(CommonConstants.Helix.CONFIG_OF_ZOOKEEPR_SERVER, zkServers);
+    minionConfig.setProperty(CommonConstants.Helix.CONFIG_OF_ZOOKEEPER_SERVER, zkServers);
     return minionConfig;
   }
 

--- a/pinot-server/src/main/java/org/apache/pinot/server/predownload/PredownloadScheduler.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/predownload/PredownloadScheduler.java
@@ -84,7 +84,7 @@ public class PredownloadScheduler {
       throws Exception {
     _properties = properties;
     _clusterName = properties.getString(CommonConstants.Helix.CONFIG_OF_CLUSTER_NAME);
-    _zkAddress = properties.getString(CommonConstants.Helix.CONFIG_OF_ZOOKEEPR_SERVER);
+    _zkAddress = properties.getString(CommonConstants.Helix.CONFIG_OF_ZOOKEEPER_SERVER);
     _instanceId = properties.getString(CommonConstants.Server.CONFIG_OF_INSTANCE_ID);
     _pinotConfig = new PinotConfiguration(properties);
     _instanceDataManagerConfig =

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
@@ -179,7 +179,7 @@ public abstract class BaseServerStarter implements ServiceStartable {
       throws Exception {
     // Make a clone so that changes to the config won't propagate to the caller
     _serverConf = serverConf.clone();
-    _zkAddress = _serverConf.getProperty(CommonConstants.Helix.CONFIG_OF_ZOOKEEPR_SERVER);
+    _zkAddress = _serverConf.getProperty(CommonConstants.Helix.CONFIG_OF_ZOOKEEPER_SERVER);
     _helixClusterName = _serverConf.getProperty(CommonConstants.Helix.CONFIG_OF_CLUSTER_NAME);
     ServiceStartableUtils.applyClusterConfig(_serverConf, _zkAddress, _helixClusterName, ServiceRole.SERVER);
     applyCustomConfigs(_serverConf);

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixServerStarter.java
@@ -59,7 +59,7 @@ public class HelixServerStarter extends BaseServerStarter {
   private static PinotConfiguration applyServerConfig(PinotConfiguration serverConf, String helixClusterName,
       String zkAddress) {
     serverConf.setProperty(Helix.CONFIG_OF_CLUSTER_NAME, helixClusterName);
-    serverConf.setProperty(Helix.CONFIG_OF_ZOOKEEPR_SERVER, zkAddress);
+    serverConf.setProperty(Helix.CONFIG_OF_ZOOKEEPER_SERVER, zkAddress);
     return serverConf;
   }
 
@@ -77,7 +77,7 @@ public class HelixServerStarter extends BaseServerStarter {
     Map<String, Object> properties = new HashMap<>();
     int port = 8003;
     properties.put(Helix.CONFIG_OF_CLUSTER_NAME, "quickstart");
-    properties.put(Helix.CONFIG_OF_ZOOKEEPR_SERVER, "localhost:2191");
+    properties.put(Helix.CONFIG_OF_ZOOKEEPER_SERVER, "localhost:2191");
     properties.put(Helix.KEY_OF_SERVER_NETTY_PORT, port);
     properties.put(Server.CONFIG_OF_INSTANCE_DATA_DIR, "/tmp/PinotServer/test" + port + "/index");
     properties.put(Server.CONFIG_OF_INSTANCE_SEGMENT_TAR_DIR, "/tmp/PinotServer/test" + port + "/segmentTar");

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -241,6 +241,8 @@ public class CommonConstants {
     public static final String DEFAULT_FLAPPING_TIME_WINDOW_MS = "1";
     public static final String PINOT_SERVICE_ROLE = "pinot.service.role";
     public static final String CONFIG_OF_CLUSTER_NAME = "pinot.cluster.name";
+    public static final String CONFIG_OF_ZOOKEEPER_SERVER = "pinot.zk.server";
+    @Deprecated(since = "1.5.0", forRemoval = true)
     public static final String CONFIG_OF_ZOOKEEPR_SERVER = "pinot.zk.server";
 
     public static final String CONFIG_OF_PINOT_CONTROLLER_STARTABLE_CLASS = "pinot.controller.startable.class";

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartBrokerCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartBrokerCommand.java
@@ -176,7 +176,7 @@ public class StartBrokerCommand extends AbstractBaseAdminCommand implements Comm
       properties.putAll(PinotConfigUtils.readConfigFromFile(_configFileName));
       // Override the zkAddress and clusterName to ensure ServiceManager is connecting to the right Zookeeper and
       // Cluster.
-      _zkAddress = MapUtils.getString(properties, CommonConstants.Helix.CONFIG_OF_ZOOKEEPR_SERVER, _zkAddress);
+      _zkAddress = MapUtils.getString(properties, CommonConstants.Helix.CONFIG_OF_ZOOKEEPER_SERVER, _zkAddress);
       _clusterName = MapUtils.getString(properties, CommonConstants.Helix.CONFIG_OF_CLUSTER_NAME, _clusterName);
     } else {
       properties.putAll(PinotConfigUtils.generateBrokerConf(_clusterName, _zkAddress, _brokerHost, _brokerPort,

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartMinionCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartMinionCommand.java
@@ -136,7 +136,7 @@ public class StartMinionCommand extends AbstractBaseAdminCommand implements Comm
       properties.putAll(PinotConfigUtils.readConfigFromFile(_configFileName));
       // Override the zkAddress and clusterName to ensure ServiceManager is connecting to the right Zookeeper and
       // Cluster.
-      _zkAddress = MapUtils.getString(properties, CommonConstants.Helix.CONFIG_OF_ZOOKEEPR_SERVER, _zkAddress);
+      _zkAddress = MapUtils.getString(properties, CommonConstants.Helix.CONFIG_OF_ZOOKEEPER_SERVER, _zkAddress);
       _clusterName = MapUtils.getString(properties, CommonConstants.Helix.CONFIG_OF_CLUSTER_NAME, _clusterName);
     } else {
       properties.putAll(PinotConfigUtils.generateMinionConf(_clusterName, _zkAddress, _minionHost, _minionPort));

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartServerCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartServerCommand.java
@@ -246,7 +246,7 @@ public class StartServerCommand extends AbstractBaseAdminCommand implements Comm
       properties.putAll(PinotConfigUtils.readConfigFromFile(_configFileName));
       // Override the zkAddress and clusterName to ensure ServiceManager is connecting to the right Zookeeper and
       // Cluster.
-      _zkAddress = MapUtils.getString(properties, CommonConstants.Helix.CONFIG_OF_ZOOKEEPR_SERVER, _zkAddress);
+      _zkAddress = MapUtils.getString(properties, CommonConstants.Helix.CONFIG_OF_ZOOKEEPER_SERVER, _zkAddress);
       _clusterName = MapUtils.getString(properties, CommonConstants.Helix.CONFIG_OF_CLUSTER_NAME, _clusterName);
     } else {
       properties.putAll(PinotConfigUtils

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/perf/PerfBenchmarkDriver.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/perf/PerfBenchmarkDriver.java
@@ -212,7 +212,7 @@ public class PerfBenchmarkDriver {
   private Map<String, Object> getControllerProperties() {
     Map<String, Object> properties = new HashMap<>();
     properties.put(CommonConstants.Helix.CONFIG_OF_CLUSTER_NAME, _clusterName);
-    properties.put(CommonConstants.Helix.CONFIG_OF_ZOOKEEPR_SERVER, _zkAddress);
+    properties.put(CommonConstants.Helix.CONFIG_OF_ZOOKEEPER_SERVER, _zkAddress);
     properties.put(ControllerConf.CONTROLLER_HOST, _controllerHost);
     properties.put(ControllerConf.CONTROLLER_PORT, String.valueOf(_controllerPort));
     properties.put(ControllerConf.DATA_DIR, _controllerDataDir);
@@ -247,7 +247,7 @@ public class PerfBenchmarkDriver {
     properties.put(CommonConstants.Broker.CONFIG_OF_BROKER_ID, brokerInstanceName);
     properties.put(CommonConstants.Broker.CONFIG_OF_BROKER_TIMEOUT_MS, BROKER_TIMEOUT_MS);
     properties.put(CommonConstants.Helix.CONFIG_OF_CLUSTER_NAME, _clusterName);
-    properties.put(CommonConstants.Helix.CONFIG_OF_ZOOKEEPR_SERVER, _zkAddress);
+    properties.put(CommonConstants.Helix.CONFIG_OF_ZOOKEEPER_SERVER, _zkAddress);
 
     LOGGER.info("Starting broker instance: {}", brokerInstanceName);
 
@@ -269,7 +269,7 @@ public class PerfBenchmarkDriver {
     properties.put(CommonConstants.Helix.KEY_OF_SERVER_NETTY_HOST, "localhost");
     properties.put(CommonConstants.Server.CONFIG_OF_INSTANCE_ID, _serverInstanceName);
     properties.put(CommonConstants.Helix.CONFIG_OF_CLUSTER_NAME, _clusterName);
-    properties.put(CommonConstants.Helix.CONFIG_OF_ZOOKEEPR_SERVER, _zkAddress);
+    properties.put(CommonConstants.Helix.CONFIG_OF_ZOOKEEPER_SERVER, _zkAddress);
     if (_segmentFormatVersion != null) {
       properties.put(CommonConstants.Server.CONFIG_OF_SEGMENT_FORMAT_VERSION, _segmentFormatVersion);
     }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/service/PinotServiceManager.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/service/PinotServiceManager.java
@@ -110,8 +110,8 @@ public class PinotServiceManager {
     if (!controllerConf.containsKey(CommonConstants.Helix.CONFIG_OF_CLUSTER_NAME)) {
       controllerConf.setProperty(CommonConstants.Helix.CONFIG_OF_CLUSTER_NAME, _clusterName);
     }
-    if (!controllerConf.containsKey(CommonConstants.Helix.CONFIG_OF_ZOOKEEPR_SERVER)) {
-      controllerConf.setProperty(CommonConstants.Helix.CONFIG_OF_ZOOKEEPR_SERVER, _zkAddress);
+    if (!controllerConf.containsKey(CommonConstants.Helix.CONFIG_OF_ZOOKEEPER_SERVER)) {
+      controllerConf.setProperty(CommonConstants.Helix.CONFIG_OF_ZOOKEEPER_SERVER, _zkAddress);
     }
     ServiceStartable controllerStarter = getServiceStartable(controllerStarterClassName);
     controllerStarter.init(controllerConf);
@@ -128,8 +128,8 @@ public class PinotServiceManager {
     if (!brokerConf.containsKey(CommonConstants.Helix.CONFIG_OF_CLUSTER_NAME)) {
       brokerConf.setProperty(CommonConstants.Helix.CONFIG_OF_CLUSTER_NAME, _clusterName);
     }
-    if (!brokerConf.containsKey(CommonConstants.Helix.CONFIG_OF_ZOOKEEPR_SERVER)) {
-      brokerConf.setProperty(CommonConstants.Helix.CONFIG_OF_ZOOKEEPR_SERVER, _zkAddress);
+    if (!brokerConf.containsKey(CommonConstants.Helix.CONFIG_OF_ZOOKEEPER_SERVER)) {
+      brokerConf.setProperty(CommonConstants.Helix.CONFIG_OF_ZOOKEEPER_SERVER, _zkAddress);
     }
     ServiceStartable brokerStarter;
     try {
@@ -159,8 +159,8 @@ public class PinotServiceManager {
       serverConf.setProperty(CommonConstants.Helix.CONFIG_OF_CLUSTER_NAME, _clusterName);
     }
 
-    if (!serverConf.containsKey(CommonConstants.Helix.CONFIG_OF_ZOOKEEPR_SERVER)) {
-      serverConf.setProperty(CommonConstants.Helix.CONFIG_OF_ZOOKEEPR_SERVER, _zkAddress);
+    if (!serverConf.containsKey(CommonConstants.Helix.CONFIG_OF_ZOOKEEPER_SERVER)) {
+      serverConf.setProperty(CommonConstants.Helix.CONFIG_OF_ZOOKEEPER_SERVER, _zkAddress);
     }
     ServiceStartable serverStarter = getServiceStartable(serverStarterClassName);
     serverStarter.init(serverConf);
@@ -178,8 +178,8 @@ public class PinotServiceManager {
     if (!minionConf.containsKey(CommonConstants.Helix.CONFIG_OF_CLUSTER_NAME)) {
       minionConf.setProperty(CommonConstants.Helix.CONFIG_OF_CLUSTER_NAME, _clusterName);
     }
-    if (!minionConf.containsKey(CommonConstants.Helix.CONFIG_OF_ZOOKEEPR_SERVER)) {
-      minionConf.setProperty(CommonConstants.Helix.CONFIG_OF_ZOOKEEPR_SERVER, _zkAddress);
+    if (!minionConf.containsKey(CommonConstants.Helix.CONFIG_OF_ZOOKEEPER_SERVER)) {
+      minionConf.setProperty(CommonConstants.Helix.CONFIG_OF_ZOOKEEPER_SERVER, _zkAddress);
     }
     ServiceStartable minionStarter = getServiceStartable(minionStarterClassName);
     minionStarter.init(minionConf);

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/utils/PinotConfigUtils.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/utils/PinotConfigUtils.java
@@ -156,7 +156,7 @@ public class PinotConfigUtils {
       throws SocketException, UnknownHostException {
     Map<String, Object> properties = new HashMap<>();
     properties.put(CommonConstants.Helix.CONFIG_OF_CLUSTER_NAME, clusterName);
-    properties.put(CommonConstants.Helix.CONFIG_OF_ZOOKEEPR_SERVER, zkAddress);
+    properties.put(CommonConstants.Helix.CONFIG_OF_ZOOKEEPER_SERVER, zkAddress);
     properties.put(CommonConstants.Broker.CONFIG_OF_BROKER_HOSTNAME,
         !StringUtils.isEmpty(brokerHost) ? brokerHost : NetUtils.getHostAddress());
     properties.put(CommonConstants.Helix.KEY_OF_BROKER_QUERY_PORT, brokerPort != 0 ? brokerPort : getAvailablePort());
@@ -186,7 +186,7 @@ public class PinotConfigUtils {
     }
     Map<String, Object> properties = new HashMap<>();
     properties.put(CommonConstants.Helix.CONFIG_OF_CLUSTER_NAME, clusterName);
-    properties.put(CommonConstants.Helix.CONFIG_OF_ZOOKEEPR_SERVER, zkAddress);
+    properties.put(CommonConstants.Helix.CONFIG_OF_ZOOKEEPER_SERVER, zkAddress);
     properties.put(CommonConstants.Helix.KEY_OF_SERVER_NETTY_HOST, serverHost);
     properties.put(CommonConstants.Helix.KEY_OF_SERVER_NETTY_PORT, serverPort);
     properties.put(CommonConstants.MultiStageQueryRunner.KEY_OF_QUERY_SERVER_PORT, serverMultiStageServerPort != 0
@@ -209,7 +209,7 @@ public class PinotConfigUtils {
     }
     Map<String, Object> properties = new HashMap<>();
     properties.put(CommonConstants.Helix.CONFIG_OF_CLUSTER_NAME, clusterName);
-    properties.put(CommonConstants.Helix.CONFIG_OF_ZOOKEEPR_SERVER, zkAddress);
+    properties.put(CommonConstants.Helix.CONFIG_OF_ZOOKEEPER_SERVER, zkAddress);
     properties.put(CommonConstants.Helix.KEY_OF_MINION_HOST, minionHost);
     properties.put(CommonConstants.Helix.KEY_OF_MINION_PORT, minionPort != 0 ? minionPort : getAvailablePort());
 


### PR DESCRIPTION
fix typo `CONFIG_OF_ZOOKEEPER_SERVER` to `CONFIG_OF_ZOOKEEPR_SERVER`
Keep it only for backward compatibility.