### PR TITLE
Add tests for OOM Termination of MSE queries.

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterMemBasedServerQueryKillingTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterMemBasedServerQueryKillingTest.java
@@ -109,7 +109,8 @@ public class OfflineClusterMemBasedServerQueryKillingTest extends BaseClusterInt
    */
   public static class TestAccountantFactory extends PerQueryCPUMemAccountantFactory {
     @Override
-    public PerQueryCPUMemResourceUsageAccountant init(PinotConfiguration config, String instanceId, InstanceType instanceType) {
+    public PerQueryCPUMemResourceUsageAccountant init(PinotConfiguration config, String instanceId,
+        InstanceType instanceType) {
       return new TestAccountant(config, instanceId, instanceType);
     }
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterMemBasedServerQueryKillingTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterMemBasedServerQueryKillingTest.java
@@ -103,6 +103,10 @@ public class OfflineClusterMemBasedServerQueryKillingTest extends BaseClusterInt
     return NUM_SERVERS;
   }
 
+  /**
+   * Keeps track of metadata of queries that have been terminated due to OOM.
+   * This is used to verify that the query was killed and the method used to kill the query.
+   */
   public static class TestAccountantFactory extends PerQueryCPUMemAccountantFactory {
     @Override
     public PerQueryCPUMemResourceUsageAccountant init(PinotConfiguration config, String instanceId, InstanceType instanceType) {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterMemBasedServerQueryKillingTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterMemBasedServerQueryKillingTest.java
@@ -37,7 +37,9 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.log4j.Level;
 import org.apache.log4j.LogManager;
 import org.apache.pinot.core.accounting.PerQueryCPUMemAccountantFactory;
+import org.apache.pinot.spi.accounting.QueryResourceTracker;
 import org.apache.pinot.spi.accounting.ThreadResourceUsageProvider;
+import org.apache.pinot.spi.config.instance.InstanceType;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.FieldSpec;
@@ -48,6 +50,7 @@ import org.apache.pinot.spi.trace.Tracing;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.apache.pinot.util.TestUtils;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -100,6 +103,52 @@ public class OfflineClusterMemBasedServerQueryKillingTest extends BaseClusterInt
     return NUM_SERVERS;
   }
 
+  public static class TestAccountantFactory extends PerQueryCPUMemAccountantFactory {
+    @Override
+    public PerQueryCPUMemResourceUsageAccountant init(PinotConfiguration config, String instanceId, InstanceType instanceType) {
+      return new TestAccountant(config, instanceId, instanceType);
+    }
+
+    public static class TestAccountant extends PerQueryCPUMemAccountantFactory.PerQueryCPUMemResourceUsageAccountant {
+      private QueryResourceTracker _queryResourceTracker = null;
+      private long _totalHeapMemoryUsage = 0L;
+      private boolean _hasCallback = false;
+
+      public TestAccountant(PinotConfiguration config, String instanceId, InstanceType instanceType) {
+        super(config, instanceId, instanceType);
+      }
+
+      @Override
+      public void logTerminatedQuery(QueryResourceTracker queryResourceTracker, long totalHeapMemoryUsage,
+          boolean hasCallback) {
+        super.logTerminatedQuery(queryResourceTracker, totalHeapMemoryUsage, hasCallback);
+        _queryResourceTracker = queryResourceTracker;
+        _totalHeapMemoryUsage = totalHeapMemoryUsage;
+        _hasCallback = hasCallback;
+      }
+
+      public void reset() {
+        _queryResourceTracker = null;
+        _totalHeapMemoryUsage = 0L;
+        _hasCallback = false;
+      }
+
+      public QueryResourceTracker getQueryResourceTracker() {
+        return _queryResourceTracker;
+      }
+
+      public long getTotalHeapMemoryUsage() {
+        return _totalHeapMemoryUsage;
+      }
+
+      public boolean hasCallback() {
+        return _hasCallback;
+      }
+    }
+  }
+
+  private TestAccountantFactory.TestAccountant _testAccountant = null;
+
   @BeforeClass
   public void setUp()
       throws Exception {
@@ -114,9 +163,9 @@ public class OfflineClusterMemBasedServerQueryKillingTest extends BaseClusterInt
     startZk();
     startController();
     startServers();
-    while (!Tracing.isAccountantRegistered()) {
-      Thread.sleep(100L);
-    }
+    TestUtils.waitForCondition(aVoid -> Tracing.isAccountantRegistered(), 100L, 60_000L,
+        "Waiting for accountant to be registered");
+    _testAccountant = (TestAccountantFactory.TestAccountant) Tracing.getThreadAccountant();
     startBrokers();
 
 
@@ -158,6 +207,13 @@ public class OfflineClusterMemBasedServerQueryKillingTest extends BaseClusterInt
     startServers(getNumServers());
   }
 
+  @AfterMethod
+  public void resetTestAccountant() {
+    if (_testAccountant != null) {
+      _testAccountant.reset();
+    }
+  }
+
   protected void overrideServerConf(PinotConfiguration serverConf) {
     serverConf.setProperty(CommonConstants.PINOT_QUERY_SCHEDULER_PREFIX + "."
         + CommonConstants.Accounting.CONFIG_OF_ALARMING_LEVEL_HEAP_USAGE_RATIO, 0.0f);
@@ -165,7 +221,7 @@ public class OfflineClusterMemBasedServerQueryKillingTest extends BaseClusterInt
         + CommonConstants.Accounting.CONFIG_OF_CRITICAL_LEVEL_HEAP_USAGE_RATIO, 0.15f);
     serverConf.setProperty(
         CommonConstants.PINOT_QUERY_SCHEDULER_PREFIX + "." + CommonConstants.Accounting.CONFIG_OF_FACTORY_NAME,
-        "org.apache.pinot.core.accounting.PerQueryCPUMemAccountantFactory");
+        TestAccountantFactory.class.getName());
     serverConf.setProperty(CommonConstants.PINOT_QUERY_SCHEDULER_PREFIX + "."
         + CommonConstants.Accounting.CONFIG_OF_ENABLE_THREAD_MEMORY_SAMPLING, true);
     serverConf.setProperty(
@@ -185,7 +241,7 @@ public class OfflineClusterMemBasedServerQueryKillingTest extends BaseClusterInt
         + CommonConstants.Accounting.CONFIG_OF_PANIC_LEVEL_HEAP_USAGE_RATIO, 1.1f);
     brokerConf.setProperty(CommonConstants.PINOT_QUERY_SCHEDULER_PREFIX + "."
             + CommonConstants.Accounting.CONFIG_OF_FACTORY_NAME,
-        "org.apache.pinot.core.accounting.PerQueryCPUMemAccountantFactory");
+        TestAccountantFactory.class.getName());
     brokerConf.setProperty(CommonConstants.PINOT_QUERY_SCHEDULER_PREFIX + "."
         + CommonConstants.Accounting.CONFIG_OF_ENABLE_THREAD_MEMORY_SAMPLING, true);
     brokerConf.setProperty(CommonConstants.PINOT_QUERY_SCHEDULER_PREFIX + "."
@@ -214,22 +270,30 @@ public class OfflineClusterMemBasedServerQueryKillingTest extends BaseClusterInt
         .build();
   }
 
-  @Test(dataProvider = "useBothQueryEngines")
-  public void testDigestOOM(boolean useMultiStageQueryEngine)
+  @Test
+  public void testDigestOOM()
       throws Exception {
-    setUseMultiStageQueryEngine(useMultiStageQueryEngine);
-    notSupportedInV2();
     JsonNode queryResponse = postQuery(OOM_QUERY);
     String exceptionsNode = queryResponse.get("exceptions").toString();
     assertTrue(exceptionsNode.contains("\"errorCode\":" + QueryErrorCode.QUERY_CANCELLATION.getId()), exceptionsNode);
     assertTrue(exceptionsNode.contains("got killed because"), exceptionsNode);
   }
 
-  @Test(dataProvider = "useBothQueryEngines")
-  public void testMemoryAllocationStats(boolean useMultiStageQueryEngine)
+  @Test
+  public void testDigestOOMMSE()
       throws Exception {
-    setUseMultiStageQueryEngine(useMultiStageQueryEngine);
-    notSupportedInV2();
+    setUseMultiStageQueryEngine(true);
+    JsonNode queryResponse = postQuery(OOM_QUERY);
+    String exceptionsNode = queryResponse.get("exceptions").toString();
+    assertTrue(exceptionsNode.contains("\"errorCode\":" + QueryErrorCode.INTERNAL.getId()), exceptionsNode);
+    assertTrue(exceptionsNode.contains("Received 1 error from stage 1"), exceptionsNode);
+    assertTrue(_testAccountant.hasCallback());
+    assertEquals(queryResponse.get("requestId").asText(), _testAccountant.getQueryResourceTracker().getQueryId());
+  }
+
+  @Test
+  public void testMemoryAllocationStats()
+      throws Exception {
     JsonNode queryResponse = postQuery(COUNT_STAR_QUERY);
     long offlineThreadMemAllocatedBytes = queryResponse.get("offlineThreadMemAllocatedBytes").asLong();
     long offlineResponseSerMemAllocatedBytes = queryResponse.get("offlineResponseSerMemAllocatedBytes").asLong();
@@ -240,11 +304,9 @@ public class OfflineClusterMemBasedServerQueryKillingTest extends BaseClusterInt
     assertEquals(offlineThreadMemAllocatedBytes + offlineResponseSerMemAllocatedBytes, offlineTotalMemAllocatedBytes);
   }
 
-  @Test(dataProvider = "useBothQueryEngines")
-  public void testSelectionOnlyOOM(boolean useMultiStageQueryEngine)
+  @Test
+  public void testSelectionOnlyOOM()
       throws Exception {
-    setUseMultiStageQueryEngine(useMultiStageQueryEngine);
-    notSupportedInV2();
     JsonNode queryResponse = postQuery(OOM_QUERY_SELECTION_ONLY);
 
     String exceptionsNode = queryResponse.get("exceptions").toString();
@@ -252,21 +314,42 @@ public class OfflineClusterMemBasedServerQueryKillingTest extends BaseClusterInt
     assertTrue(exceptionsNode.contains("got killed because"), exceptionsNode);
   }
 
-  @Test(dataProvider = "useBothQueryEngines")
-  public void testDigestOOM2(boolean useMultiStageQueryEngine)
+  @Test
+  public void testSelectionOnlyOOMMSE()
       throws Exception {
-    setUseMultiStageQueryEngine(useMultiStageQueryEngine);
-    notSupportedInV2();
+    setUseMultiStageQueryEngine(true);
+    JsonNode queryResponse = postQuery(OOM_QUERY_SELECTION_ONLY);
+
+    String exceptionsNode = queryResponse.get("exceptions").toString();
+    assertTrue(exceptionsNode.contains("\"errorCode\":" + QueryErrorCode.INTERNAL.getId()), exceptionsNode);
+    assertTrue(exceptionsNode.contains("Received 1 error from stage 1"), exceptionsNode);
+    assertTrue(_testAccountant.hasCallback());
+    assertEquals(queryResponse.get("requestId").asText(), _testAccountant.getQueryResourceTracker().getQueryId());
+  }
+
+  @Test
+  public void testDigestOOM2()
+      throws Exception {
     JsonNode queryResponse = postQuery(OOM_QUERY_2);
     String exceptionsNode = queryResponse.get("exceptions").toString();
     assertTrue(exceptionsNode.contains("got killed because"), exceptionsNode);
   }
 
-  @Test(dataProvider = "useBothQueryEngines")
-  public void testDigestOOMMultipleQueries(boolean useMultiStageQueryEngine)
+  @Test
+  public void testDigestOOM2MSE()
       throws Exception {
-    setUseMultiStageQueryEngine(useMultiStageQueryEngine);
-    notSupportedInV2();
+    setUseMultiStageQueryEngine(true);
+    JsonNode queryResponse = postQuery(OOM_QUERY_2);
+    String exceptionsNode = queryResponse.get("exceptions").toString();
+    assertTrue(exceptionsNode.contains("\"errorCode\":" + QueryErrorCode.INTERNAL.getId()), exceptionsNode);
+    assertTrue(exceptionsNode.contains("Received 1 error from stage 1"), exceptionsNode);
+    assertTrue(_testAccountant.hasCallback());
+    assertEquals(queryResponse.get("requestId").asText(), _testAccountant.getQueryResourceTracker().getQueryId());
+  }
+
+  @Test
+  public void testDigestOOMMultipleQueries()
+      throws Exception {
     AtomicReference<JsonNode> queryResponse1 = new AtomicReference<>();
     AtomicReference<JsonNode> queryResponse2 = new AtomicReference<>();
     AtomicReference<JsonNode> queryResponse3 = new AtomicReference<>();


### PR DESCRIPTION
Run integration tests to check for MSE query termination using callbacks. The tests do not use `useBothQueryEngines` data provider as the checks are different for SSE and MSE.
