### PR TITLE
Fix SSE subquery handling and clarify query start semantics

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -396,7 +396,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
 
   /**
    * Called when a query starts
-   * TODO: This method was crated to keep track of running queries for cancellation, but it is useful for other uses.
+   * TODO: This method was created to keep track of running queries for cancellation, but it is useful for other uses.
    *   But right now the semantics are not clear. For example, while MSE calls this method once, SSE calls it once per
    *   query AND subquery, which means this method is called multiple times for the same query.
    */

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -394,6 +394,12 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
         ? sqlNodeAndOptions.getOptions().get(Broker.Request.QueryOptionKey.CLIENT_QUERY_ID) : null;
   }
 
+  /**
+   * Called when a query starts
+   * TODO: This method was crated to keep track of running queries for cancellation, but it is useful for other uses.
+   *   But right now the semantics are not clear. For example, while MSE calls this method once, SSE calls it once per
+   *   query AND subquery, which means this method is called multiple times for the same query.
+   */
   protected void onQueryStart(long requestId, String clientRequestId, String query, Object... extras) {
     if (isQueryCancellationEnabled()) {
       _queriesById.put(requestId, query);

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
@@ -321,6 +321,7 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
       JsonNode request, @Nullable RequesterIdentity requesterIdentity, RequestContext requestContext,
       @Nullable HttpHeaders httpHeaders, AccessControl accessControl)
       throws Exception {
+    QueryThreadContext.setQueryEngine("sse");
     _queryLogger.log(requestId, query);
 
     //Start instrumentation context. This must not be moved further below interspersed into the code.
@@ -1042,7 +1043,6 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
   @Override
   protected void onQueryStart(long requestId, String clientRequestId, String query, Object... extras) {
     super.onQueryStart(requestId, clientRequestId, query, extras);
-    QueryThreadContext.setQueryEngine("sse");
     if (isQueryCancellationEnabled() && extras.length > 0 && extras[0] instanceof QueryServers) {
       _serversById.put(requestId, (QueryServers) extras[0]);
     }


### PR DESCRIPTION
We have detected a regression when SSE uses subqueries. These subqueries failed because we were setting the engine type on `onQueryStart`, which should be called only once, but SSE calls it once per subquery as well.

This PR moves that thread local set to `BaseBrokerRequestHandler.handleRequest`, which is called only once.