### PR TITLE
[timeseries] Introducing POST /query/timeseries as a BrokerResponse compatible timeseries API

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BrokerRequestHandler.java
@@ -65,7 +65,8 @@ public interface BrokerRequestHandler {
    * Run a query and use the time-series engine.
    */
   default PinotBrokerTimeSeriesResponse handleTimeSeriesRequest(String lang, String rawQueryParamString,
-      RequestContext requestContext, @Nullable RequesterIdentity requesterIdentity, HttpHeaders httpHeaders) {
+      Map<String, String> queryParams, RequestContext requestContext, @Nullable RequesterIdentity requesterIdentity,
+      HttpHeaders httpHeaders) {
     throw new UnsupportedOperationException("Handler does not support Time Series requests");
   }
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BrokerRequestHandlerDelegate.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BrokerRequestHandlerDelegate.java
@@ -125,10 +125,11 @@ public class BrokerRequestHandlerDelegate implements BrokerRequestHandler {
 
   @Override
   public PinotBrokerTimeSeriesResponse handleTimeSeriesRequest(String lang, String rawQueryParamString,
-      RequestContext requestContext, RequesterIdentity requesterIdentity, HttpHeaders httpHeaders) {
+      Map<String, String> queryParams, RequestContext requestContext, RequesterIdentity requesterIdentity,
+      HttpHeaders httpHeaders) {
     if (_timeSeriesRequestHandler != null) {
-      return _timeSeriesRequestHandler.handleTimeSeriesRequest(lang, rawQueryParamString, requestContext,
-        requesterIdentity, httpHeaders);
+      return _timeSeriesRequestHandler.handleTimeSeriesRequest(lang, rawQueryParamString, queryParams, requestContext,
+          requesterIdentity, httpHeaders);
     }
     return new PinotBrokerTimeSeriesResponse("error", null, "error", "Time series query engine not enabled.");
   }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/TimeSeriesRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/TimeSeriesRequestHandler.java
@@ -34,7 +34,6 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hc.client5.http.io.HttpClientConnectionManager;
-import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;
 import org.apache.pinot.broker.api.AccessControl;
 import org.apache.pinot.broker.broker.AccessControlFactory;
@@ -107,7 +106,8 @@ public class TimeSeriesRequestHandler extends BaseBrokerRequestHandler {
 
   @Override
   public PinotBrokerTimeSeriesResponse handleTimeSeriesRequest(String lang, String rawQueryParamString,
-      RequestContext requestContext, RequesterIdentity requesterIdentity, HttpHeaders httpHeaders) {
+      Map<String, String> queryParams, RequestContext requestContext, RequesterIdentity requesterIdentity,
+      HttpHeaders httpHeaders) {
     PinotBrokerTimeSeriesResponse timeSeriesResponse = null;
     long queryStartTime = System.currentTimeMillis();
     try {
@@ -117,7 +117,7 @@ public class TimeSeriesRequestHandler extends BaseBrokerRequestHandler {
       RangeTimeSeriesRequest timeSeriesRequest = null;
       firstStageAccessControlCheck(requesterIdentity);
       try {
-        timeSeriesRequest = buildRangeTimeSeriesRequest(lang, rawQueryParamString);
+        timeSeriesRequest = buildRangeTimeSeriesRequest(lang, rawQueryParamString, queryParams);
       } catch (URISyntaxException e) {
         return PinotBrokerTimeSeriesResponse.newErrorResponse("BAD_REQUEST", "Error building RangeTimeSeriesRequest");
       }
@@ -169,57 +169,41 @@ public class TimeSeriesRequestHandler extends BaseBrokerRequestHandler {
     return false;
   }
 
-  private RangeTimeSeriesRequest buildRangeTimeSeriesRequest(String language, String queryParamString)
+  private RangeTimeSeriesRequest buildRangeTimeSeriesRequest(String language, String queryParamString,
+      Map<String, String> queryParams)
       throws URISyntaxException {
-    List<NameValuePair> pairs = URLEncodedUtils.parse(
-        new URI("http://localhost?" + queryParamString), "UTF-8");
-    String query = null;
-    Long startTs = null;
-    Long endTs = null;
-    String step = null;
-    String timeoutStr = null;
-    int limit = RangeTimeSeriesRequest.DEFAULT_SERIES_LIMIT;
-    int numGroupsLimit = RangeTimeSeriesRequest.DEFAULT_NUM_GROUPS_LIMIT;
-    for (NameValuePair nameValuePair : pairs) {
-      switch (nameValuePair.getName()) {
-        case "query":
-          query = nameValuePair.getValue();
-          break;
-        case "start":
-          startTs = Long.parseLong(nameValuePair.getValue());
-          break;
-        case "end":
-          endTs = Long.parseLong(nameValuePair.getValue());
-          break;
-        case "step":
-          step = nameValuePair.getValue();
-          break;
-        case "timeout":
-          timeoutStr = nameValuePair.getValue();
-          break;
-        case "limit":
-          limit = Integer.parseInt(nameValuePair.getValue());
-          break;
-        case "numGroupsLimit":
-          numGroupsLimit = Integer.parseInt(nameValuePair.getValue());
-          break;
-        default:
-          /* Okay to ignore unknown parameters since the language implementor may be using them. */
-          break;
-      }
+    Map<String, String> mergedParams = new HashMap<>(queryParams);
+    // If queryParams is empty, parse the queryParamString to extract parameters.
+    if (queryParams.isEmpty()) {
+      URLEncodedUtils.parse(new URI("http://localhost?" + queryParamString), "UTF-8")
+          .forEach(pair -> mergedParams.putIfAbsent(pair.getName(), pair.getValue()));
     }
-    Long stepSeconds = getStepSeconds(step);
+
+    String query = mergedParams.get("query");
+    Long startTs = parseLong(mergedParams.get("start"));
+    Long endTs = parseLong(mergedParams.get("end"));
+    Long stepSeconds = getStepSeconds(mergedParams.get("step"));
+    Duration timeout = StringUtils.isNotBlank(mergedParams.get("timeout"))
+        ? HumanReadableDuration.from(mergedParams.get("timeout")) : Duration.ofMillis(_brokerTimeoutMs);
+
     Preconditions.checkNotNull(query, "Query cannot be null");
     Preconditions.checkNotNull(startTs, "Start time cannot be null");
     Preconditions.checkNotNull(endTs, "End time cannot be null");
     Preconditions.checkState(stepSeconds != null && stepSeconds > 0, "Step must be a positive integer");
-    Duration timeout = Duration.ofMillis(_brokerTimeoutMs);
-    if (StringUtils.isNotBlank(timeoutStr)) {
-      timeout = HumanReadableDuration.from(timeoutStr);
-    }
-    // TODO: Pass full raw query param string to the request
-    return new RangeTimeSeriesRequest(language, query, startTs, endTs, stepSeconds, timeout, limit, numGroupsLimit,
-        queryParamString);
+
+    return new RangeTimeSeriesRequest(language, query, startTs, endTs, stepSeconds, timeout,
+        parseIntOrDefault(mergedParams.get("limit"), RangeTimeSeriesRequest.DEFAULT_SERIES_LIMIT),
+        parseIntOrDefault(mergedParams.get("numGroupsLimit"), RangeTimeSeriesRequest.DEFAULT_NUM_GROUPS_LIMIT),
+        queryParamString
+    );
+  }
+
+  private Long parseLong(String value) {
+    return value != null ? Long.parseLong(value) : null;
+  }
+
+  private int parseIntOrDefault(String value, int defaultValue) {
+    return value != null ? Integer.parseInt(value) : defaultValue;
   }
 
   public static Long getStepSeconds(@Nullable String step) {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/TimeSeriesRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/TimeSeriesRequestHandler.java
@@ -180,8 +180,8 @@ public class TimeSeriesRequestHandler extends BaseBrokerRequestHandler {
     }
 
     String query = mergedParams.get("query");
-    Long startTs = parseLong(mergedParams.get("start"));
-    Long endTs = parseLong(mergedParams.get("end"));
+    Long startTs = parseLongSafe(mergedParams.get("start"));
+    Long endTs = parseLongSafe(mergedParams.get("end"));
     Long stepSeconds = getStepSeconds(mergedParams.get("step"));
     Duration timeout = StringUtils.isNotBlank(mergedParams.get("timeout"))
         ? HumanReadableDuration.from(mergedParams.get("timeout")) : Duration.ofMillis(_brokerTimeoutMs);
@@ -198,7 +198,7 @@ public class TimeSeriesRequestHandler extends BaseBrokerRequestHandler {
     );
   }
 
-  private Long parseLong(String value) {
+  private Long parseLongSafe(String value) {
     return value != null ? Long.parseLong(value) : null;
   }
 

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/PinotBrokerTimeSeriesResponse.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/PinotBrokerTimeSeriesResponse.java
@@ -25,10 +25,14 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Preconditions;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import org.apache.pinot.common.response.broker.BrokerResponseNativeV2;
+import org.apache.pinot.common.response.broker.ResultTable;
+import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.spi.annotations.InterfaceStability;
 import org.apache.pinot.tsdb.spi.series.TimeSeries;
 import org.apache.pinot.tsdb.spi.series.TimeSeriesBlock;
@@ -106,6 +110,55 @@ public class PinotBrokerTimeSeriesResponse {
       throw new UnsupportedOperationException("Non-bucketed series block not supported yet");
     }
     return convertBucketedSeriesBlock(seriesBlock);
+  }
+
+  public BrokerResponse toBrokerResponse() {
+    DataSchema dataSchema = deriveBrokerResponseDataSchema(_data);
+    ResultTable resultTable = new ResultTable(dataSchema, deriveBrokerResponseRows(_data, dataSchema.getColumnNames()));
+    BrokerResponseNativeV2 brokerResponse = new BrokerResponseNativeV2();
+    brokerResponse.setResultTable(resultTable);
+    return brokerResponse;
+  }
+
+  private List<Object[]> deriveBrokerResponseRows(Data data, String[] columnNames) {
+    List<Object[]> rows = new ArrayList<>();
+    if (columnNames.length == 0) {
+      return rows;
+    }
+    for (Value value : data.getResult()) {
+      Long[] ts = Arrays.stream(value.getValues()).map(entry -> (Long) entry[0]).toArray(Long[]::new);
+      Double[] values = Arrays.stream(value.getValues())
+          .map(entry -> entry[1] == null ? null : Double.valueOf(String.valueOf(entry[1])))
+          .toArray(Double[]::new);
+
+      Object[] row = new Object[columnNames.length];
+      int index = 0;
+      for (String columnName : columnNames) {
+        if ("ts".equals(columnName)) {
+          row[index] = ts;
+        } else if ("values".equals(columnName)) {
+          row[index] = values;
+        } else {
+          row[index] = value.getMetric().getOrDefault(columnName, null);
+        }
+        index++;
+      }
+      rows.add(row);
+    }
+    return rows;
+  }
+
+  private DataSchema deriveBrokerResponseDataSchema(Data data) {
+    List<String> columnNames = new ArrayList<>(List.of("ts", "values", "__name__"));
+    List<DataSchema.ColumnDataType> columnTypes = new ArrayList<>(List.of(
+        DataSchema.ColumnDataType.LONG_ARRAY, DataSchema.ColumnDataType.DOUBLE_ARRAY));
+    if (!data.getResult().isEmpty()) {
+      data.getResult().get(0).getMetric().forEach((key, value) -> {
+        columnNames.add(key);
+        columnTypes.add(DataSchema.ColumnDataType.STRING);
+      });
+    }
+    return new DataSchema(columnNames.toArray(new String[0]), columnTypes.toArray(new DataSchema.ColumnDataType[0]));
   }
 
   private static PinotBrokerTimeSeriesResponse convertBucketedSeriesBlock(TimeSeriesBlock seriesBlock) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/PinotBrokerTimeSeriesResponse.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/PinotBrokerTimeSeriesResponse.java
@@ -31,9 +31,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import org.apache.pinot.common.response.broker.BrokerResponseNativeV2;
+import org.apache.pinot.common.response.broker.QueryProcessingException;
 import org.apache.pinot.common.response.broker.ResultTable;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.spi.annotations.InterfaceStability;
+import org.apache.pinot.spi.exception.QueryErrorCode;
 import org.apache.pinot.tsdb.spi.series.TimeSeries;
 import org.apache.pinot.tsdb.spi.series.TimeSeriesBlock;
 
@@ -113,9 +115,15 @@ public class PinotBrokerTimeSeriesResponse {
   }
 
   public BrokerResponse toBrokerResponse() {
+    BrokerResponseNativeV2 brokerResponse = new BrokerResponseNativeV2();
+    if (_errorType != null) {
+      // TODO: Introduce proper error code based exception handling for timeseries.
+      brokerResponse.addException(new QueryProcessingException(QueryErrorCode.UNKNOWN, _errorType + ": "
+          + _error));
+      return brokerResponse;
+    }
     DataSchema dataSchema = deriveBrokerResponseDataSchema(_data);
     ResultTable resultTable = new ResultTable(dataSchema, deriveBrokerResponseRows(_data, dataSchema.getColumnNames()));
-    BrokerResponseNativeV2 brokerResponse = new BrokerResponseNativeV2();
     brokerResponse.setResultTable(resultTable);
     return brokerResponse;
   }

--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
@@ -580,6 +580,18 @@ public abstract class ClusterTest extends ControllerTest {
     }
   }
 
+  public JsonNode postTimeseriesQuery(String baseUrl, String query, long startTime, long endTime,
+      Map<String, String> headers) {
+    try {
+      Map<String, String> payload = Map.of("language", "m3ql", "query", query, "start",
+          String.valueOf(startTime), "end", String.valueOf(endTime));
+      return JsonUtils.stringToJsonNode(
+          sendPostRequest(baseUrl + "/query/timeseries", JsonUtils.objectToString(payload), headers));
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to post timeseries query: " + query, e);
+    }
+  }
+
   /**
    * Queries the broker's query endpoint (/query/sql)
    */

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -557,6 +557,7 @@ public class CommonConstants {
       public static final String TRACE = "trace";
       public static final String QUERY_OPTIONS = "queryOptions";
       public static final String LANGUAGE = "language";
+      public static final String QUERY = "query";
 
       public static class QueryOptionKey {
         public static final String TIMEOUT_MS = "timeoutMs";

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -556,6 +556,7 @@ public class CommonConstants {
       public static final String SQL_V2 = "sqlV2";
       public static final String TRACE = "trace";
       public static final String QUERY_OPTIONS = "queryOptions";
+      public static final String LANGUAGE = "language";
 
       public static class QueryOptionKey {
         public static final String TIMEOUT_MS = "timeoutMs";

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/JsonUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/JsonUtils.java
@@ -158,6 +158,11 @@ public class JsonUtils {
     return DEFAULT_READER.readTree(jsonString);
   }
 
+  public static Map<String, String> jsonNodeToStringMap(JsonNode jsonNode)
+      throws IOException {
+    return DEFAULT_READER.forType(MAP_TYPE_REFERENCE).readValue(jsonNode);
+  }
+
   public static JsonNode stringToJsonNodeWithBigDecimal(String jsonString)
       throws IOException {
     return READER_WITH_BIG_DECIMAL.readTree(jsonString);


### PR DESCRIPTION
## Summary

This PR introduces a new `/query/timeseries` POST endpoint and enhances the time series query flow by allowing JSON-based input (instead of the GET url encoded) and adds support for returning results in the standard `BrokerResponse` format. 
Key changes include:
- Refactored `handleTimeSeriesRequest` to accept both raw query strings and parsed query parameters
- Broker response conversion logic in `PinotBrokerTimeSeriesResponse`
- Improved parameter parsing in `TimeSeriesRequestHandler`.

### Note:
Currently, `PinotBrokerTimeSeriesResponse` is returned from the `executeTimeSeriesQuery` methods. It would be subsequently replaced by the standard `BrokerResponse`, and `PinotBrokerTimeSeriesResponse` would be constructed from it for `GET /timeseries/api/v1/query_range` in subsequent PRs to enforce the unification of `BrokerResponse` as the standard response object for timeseries.

## Testing

Enhanced integration tests with dual-mode validation (original and broker-compatible responses).

