### PR TITLE
Misc bugfix/cleanup for thread accountant

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
@@ -325,8 +325,8 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
 
     //Start instrumentation context. This must not be moved further below interspersed into the code.
     String workloadName = QueryOptionsUtils.getWorkloadName(sqlNodeAndOptions.getOptions());
-    _resourceUsageAccountant.setupRunner(QueryThreadContext.getCid(), CommonConstants.Accounting.ANCHOR_TASK_ID,
-        ThreadExecutionContext.TaskType.SSE, workloadName);
+    _resourceUsageAccountant.setupRunner(QueryThreadContext.getCid(), ThreadExecutionContext.TaskType.SSE,
+        workloadName);
 
     try {
       return doHandleRequest(requestId, query, sqlNodeAndOptions, request, requesterIdentity, requestContext,

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -530,8 +530,8 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
 
     try {
       String workloadName = QueryOptionsUtils.getWorkloadName(query.getOptions());
-      _resourceUsageAccountant.setupRunner(QueryThreadContext.getCid(), CommonConstants.Accounting.ANCHOR_TASK_ID,
-          ThreadExecutionContext.TaskType.MSE, workloadName);
+      _resourceUsageAccountant.setupRunner(QueryThreadContext.getCid(), ThreadExecutionContext.TaskType.MSE,
+          workloadName);
 
       long executionStartTimeNs = System.nanoTime();
       QueryDispatcher.QueryResult queryResults;

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/InternalFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/InternalFunctions.java
@@ -63,7 +63,7 @@ public class InternalFunctions {
     return QueryThreadContext.getStartTimeMs();
   }
 
-  /// Returns the [deadline][QueryThreadContext#getDeadlineMs] of the query.
+  /// Returns the [deadline][QueryThreadContext#getActiveDeadlineMs()] of the query.
   ///
   /// The input value is not directly used. Instead it is here to control whether the function is called during query
   /// optimization or execution. In order to do the latter, a non-constant value (like a column) should be passed as
@@ -72,7 +72,7 @@ public class InternalFunctions {
   /// This is mostly useful for test and internal usage
   @ScalarFunction
   public static long endTime(String input) {
-    return QueryThreadContext.getDeadlineMs();
+    return QueryThreadContext.getActiveDeadlineMs();
   }
 
   ///  Returns the [broker id][QueryThreadContext#getBrokerId] of the query.

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
@@ -547,7 +547,6 @@ public class QueryOptionsUtils {
   }
 
   public static String getWorkloadName(Map<String, String> queryOptions) {
-    return queryOptions.get(QueryOptionKey.WORKLOAD_NAME) != null ? queryOptions.get(QueryOptionKey.WORKLOAD_NAME)
-        : CommonConstants.Accounting.DEFAULT_WORKLOAD_NAME;
+    return queryOptions.getOrDefault(QueryOptionKey.WORKLOAD_NAME, CommonConstants.Accounting.DEFAULT_WORKLOAD_NAME);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/accounting/PerQueryCPUMemAccountantFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/accounting/PerQueryCPUMemAccountantFactory.java
@@ -84,7 +84,8 @@ public class PerQueryCPUMemAccountantFactory implements ThreadAccountantFactory 
      */
     private static final String ACCOUNTANT_TASK_NAME = "CPUMemThreadAccountant";
     private static final int ACCOUNTANT_PRIORITY = 4;
-    private final ExecutorService _executorService = Executors.newFixedThreadPool(1, r -> {
+
+    private final ExecutorService _executorService = Executors.newSingleThreadExecutor(r -> {
       Thread thread = new Thread(r);
       thread.setPriority(ACCOUNTANT_PRIORITY);
       thread.setDaemon(true);
@@ -360,7 +361,7 @@ public class PerQueryCPUMemAccountantFactory implements ThreadAccountantFactory 
     }
 
     @Override
-    public void setupRunner(@Nullable String queryId, int taskId, ThreadExecutionContext.TaskType taskType,
+    public void setupRunner(String queryId, ThreadExecutionContext.TaskType taskType,
         String workloadName) {
       _threadLocalEntry.get()._errorStatus.set(null);
       if (queryId != null) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/accounting/ResourceUsageAccountantFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/accounting/ResourceUsageAccountantFactory.java
@@ -54,7 +54,7 @@ public class ResourceUsageAccountantFactory implements ThreadAccountantFactory {
     private static final String ACCOUNTANT_TASK_NAME = "ResourceUsageAccountant";
     private static final int ACCOUNTANT_PRIORITY = 4;
 
-    private final ExecutorService _executorService = Executors.newFixedThreadPool(1, r -> {
+    private final ExecutorService _executorService = Executors.newSingleThreadExecutor(r -> {
       Thread thread = new Thread(r);
       thread.setPriority(ACCOUNTANT_PRIORITY);
       thread.setDaemon(true);
@@ -157,7 +157,7 @@ public class ResourceUsageAccountantFactory implements ThreadAccountantFactory {
     }
 
     @Override
-    public void setupRunner(String queryId, int taskId, ThreadExecutionContext.TaskType taskType, String workloadName) {
+    public void setupRunner(String queryId, ThreadExecutionContext.TaskType taskType, String workloadName) {
       _threadLocalEntry.get()._errorStatus.set(null);
       if (queryId != null) {
         _threadLocalEntry.get()

--- a/pinot-core/src/test/java/org/apache/pinot/core/accounting/TestResourceAccountant.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/accounting/TestResourceAccountant.java
@@ -20,9 +20,7 @@ package org.apache.pinot.core.accounting;
 
 import java.util.HashSet;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
-import java.util.stream.Collectors;
 import org.apache.pinot.spi.accounting.ThreadExecutionContext;
 import org.apache.pinot.spi.config.instance.InstanceType;
 import org.apache.pinot.spi.env.PinotConfiguration;
@@ -76,11 +74,13 @@ class TestResourceAccountant extends PerQueryCPUMemAccountantFactory.PerQueryCPU
   }
 
   public TaskThread getTaskThread(String queryId, int taskId) {
-    Map.Entry<Thread, CPUMemThreadLevelAccountingObjects.ThreadEntry> workerEntry =
-        _threadEntriesMap.entrySet().stream().filter(
-            e -> e.getValue()._currentThreadTaskStatus.get().getTaskId() == 3 && Objects.equals(
-                e.getValue()._currentThreadTaskStatus.get().getQueryId(), queryId)).collect(Collectors.toList()).get(0);
-    return new TaskThread(workerEntry.getValue(), workerEntry.getKey());
+    for (Map.Entry<Thread, CPUMemThreadLevelAccountingObjects.ThreadEntry> entry : _threadEntriesMap.entrySet()) {
+      CPUMemThreadLevelAccountingObjects.ThreadEntry threadEntry = entry.getValue();
+      if (queryId.equals(threadEntry.getQueryId()) && taskId == threadEntry.getTaskId()) {
+        return new TaskThread(threadEntry, entry.getKey());
+      }
+    }
+    throw new IllegalStateException("Failed to find thread for queryId: " + queryId + ", taskId: " + taskId);
   }
 
   public static class TaskThread {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/OpChainExecutionContext.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/OpChainExecutionContext.java
@@ -39,7 +39,6 @@ import org.apache.pinot.spi.utils.CommonConstants;
  *  This information is then used by the OpChain to create the Operators for a query.
  */
 public class OpChainExecutionContext {
-
   private final MailboxService _mailboxService;
   private final long _requestId;
   private final long _activeDeadlineMs;
@@ -58,20 +57,10 @@ public class OpChainExecutionContext {
   private ServerPlanRequestContext _leafStageContext;
   private final boolean _sendStats;
 
-  @Deprecated
-  public OpChainExecutionContext(MailboxService mailboxService, long requestId, long deadlineMs,
-      Map<String, String> opChainMetadata, StageMetadata stageMetadata, WorkerMetadata workerMetadata,
-      @Nullable PipelineBreakerResult pipelineBreakerResult, @Nullable ThreadExecutionContext parentContext,
-      boolean sendStats) {
-    this(mailboxService, requestId, deadlineMs, deadlineMs, opChainMetadata, stageMetadata, workerMetadata,
-        pipelineBreakerResult, parentContext, sendStats);
-  }
-
-  public OpChainExecutionContext(MailboxService mailboxService, long requestId,
-      long activeDeadlineMs, long passiveDeadlineMs,
-      Map<String, String> opChainMetadata, StageMetadata stageMetadata, WorkerMetadata workerMetadata,
-      @Nullable PipelineBreakerResult pipelineBreakerResult, @Nullable ThreadExecutionContext parentContext,
-      boolean sendStats) {
+  public OpChainExecutionContext(MailboxService mailboxService, long requestId, long activeDeadlineMs,
+      long passiveDeadlineMs, Map<String, String> opChainMetadata, StageMetadata stageMetadata,
+      WorkerMetadata workerMetadata, @Nullable PipelineBreakerResult pipelineBreakerResult,
+      @Nullable ThreadExecutionContext parentContext, boolean sendStats) {
     _mailboxService = mailboxService;
     _requestId = requestId;
     _activeDeadlineMs = activeDeadlineMs;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/server/QueryServer.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/server/QueryServer.java
@@ -42,6 +42,7 @@ import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.proto.PinotQueryWorkerGrpc;
 import org.apache.pinot.common.proto.Worker;
 import org.apache.pinot.common.utils.NamedThreadFactory;
+import org.apache.pinot.common.utils.config.QueryOptionsUtils;
 import org.apache.pinot.core.transport.grpc.GrpcQueryServer;
 import org.apache.pinot.query.MseWorkerThreadContext;
 import org.apache.pinot.query.planner.serde.PlanNodeSerializer;
@@ -284,7 +285,7 @@ public class QueryServer extends PinotQueryWorkerGrpc.PinotQueryWorkerImplBase {
   /// (normally cancelling other already started workers and sending the error through GRPC)
   private CompletableFuture<Void> submitWorker(WorkerMetadata workerMetadata, StagePlan stagePlan,
       Map<String, String> reqMetadata) {
-    String workloadName = reqMetadata.get(CommonConstants.Broker.Request.QueryOptionKey.WORKLOAD_NAME);
+    String workloadName = QueryOptionsUtils.getWorkloadName(reqMetadata);
     //TODO: Verify if this matches with what OOM protection expects. This method will not block for the query to
     // finish, so it may be breaking some of the OOM protection assumptions.
     Tracing.ThreadAccountantOps.setupRunner(QueryThreadContext.getCid(), ThreadExecutionContext.TaskType.MSE,

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/executor/OpChainSchedulerServiceTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/executor/OpChainSchedulerServiceTest.java
@@ -19,7 +19,7 @@
 package org.apache.pinot.query.runtime.executor;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
+import java.util.Map;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -78,10 +78,10 @@ public class OpChainSchedulerServiceTest {
     MailboxService mailboxService = mock(MailboxService.class);
     when(mailboxService.getHostname()).thenReturn("localhost");
     when(mailboxService.getPort()).thenReturn(1234);
-    WorkerMetadata workerMetadata = new WorkerMetadata(0, ImmutableMap.of(), ImmutableMap.of());
+    WorkerMetadata workerMetadata = new WorkerMetadata(0, Map.of(), Map.of());
     OpChainExecutionContext context =
-        new OpChainExecutionContext(mailboxService, 123L, Long.MAX_VALUE, ImmutableMap.of(),
-            new StageMetadata(0, ImmutableList.of(workerMetadata), ImmutableMap.of()), workerMetadata, null, null,
+        new OpChainExecutionContext(mailboxService, 123L, Long.MAX_VALUE, Long.MAX_VALUE, Map.of(),
+            new StageMetadata(0, ImmutableList.of(workerMetadata), Map.of()), workerMetadata, null, null,
             true);
     return new OpChain(context, operator);
   }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxSendOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxSendOperatorTest.java
@@ -196,8 +196,8 @@ public class MailboxSendOperatorTest {
     WorkerMetadata workerMetadata = new WorkerMetadata(0, Map.of(), Map.of());
     StageMetadata stageMetadata = new StageMetadata(SENDER_STAGE_ID, List.of(workerMetadata), Map.of());
     OpChainExecutionContext context =
-        new OpChainExecutionContext(_mailboxService, 123L, Long.MAX_VALUE, Map.of(), stageMetadata, workerMetadata,
-            null, null, true);
+        new OpChainExecutionContext(_mailboxService, 123L, Long.MAX_VALUE, Long.MAX_VALUE, Map.of(), stageMetadata,
+            workerMetadata, null, null, true);
     return new MailboxSendOperator(context, _input, statMap -> _exchange);
   }
 

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/OperatorTestUtil.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/OperatorTestUtil.java
@@ -18,8 +18,6 @@
  */
 package org.apache.pinot.query.runtime.operator;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -48,9 +46,10 @@ import static org.mockito.Mockito.when;
 
 public class OperatorTestUtil {
   // simple key-value collision schema/data test set: "Aa" and "BB" have same hash code in java.
-  private static final List<List<Object[]>> SIMPLE_KV_DATA_ROWS =
-      ImmutableList.of(ImmutableList.of(new Object[]{1, "Aa"}, new Object[]{2, "BB"}, new Object[]{3, "BB"}),
-          ImmutableList.of(new Object[]{1, "AA"}, new Object[]{2, "Aa"}));
+  private static final List<List<Object[]>> SIMPLE_KV_DATA_ROWS = List.of(
+      List.of(new Object[]{1, "Aa"}, new Object[]{2, "BB"}, new Object[]{3, "BB"}),
+      List.of(new Object[]{1, "AA"}, new Object[]{2, "Aa"})
+  );
   private static final MockDataBlockOperatorFactory MOCK_OPERATOR_FACTORY;
 
   public static final DataSchema SIMPLE_KV_DATA_SCHEMA = new DataSchema(new String[]{"foo", "bar"},
@@ -61,14 +60,14 @@ public class OperatorTestUtil {
 
   public static MultiStageQueryStats getDummyStats(int stageId) {
     MultiStageQueryStats stats = MultiStageQueryStats.emptyStats(stageId);
-    stats.getCurrentStats()
-        .addLastOperator(MultiStageOperator.Type.LEAF, new StatMap<>(LeafOperator.StatKey.class));
+    stats.getCurrentStats().addLastOperator(MultiStageOperator.Type.LEAF, new StatMap<>(LeafOperator.StatKey.class));
     return stats;
   }
 
   static {
     MOCK_OPERATOR_FACTORY = new MockDataBlockOperatorFactory().registerOperator(OP_1, SIMPLE_KV_DATA_SCHEMA)
-        .registerOperator(OP_2, SIMPLE_KV_DATA_SCHEMA).addRows(OP_1, SIMPLE_KV_DATA_ROWS.get(0))
+        .registerOperator(OP_2, SIMPLE_KV_DATA_SCHEMA)
+        .addRows(OP_1, SIMPLE_KV_DATA_ROWS.get(0))
         .addRows(OP_2, SIMPLE_KV_DATA_ROWS.get(1));
   }
 
@@ -109,12 +108,12 @@ public class OperatorTestUtil {
 
   public static OpChainExecutionContext getOpChainContext(MailboxService mailboxService, long deadlineMs,
       StageMetadata stageMetadata) {
-    return new OpChainExecutionContext(mailboxService, 0, deadlineMs, ImmutableMap.of(), stageMetadata,
+    return new OpChainExecutionContext(mailboxService, 0, deadlineMs, deadlineMs, Map.of(), stageMetadata,
         stageMetadata.getWorkerMetadataList().get(0), null, null, true);
   }
 
   public static OpChainExecutionContext getTracingContext() {
-    return getTracingContext(ImmutableMap.of(CommonConstants.Broker.Request.TRACE, "true"));
+    return getTracingContext(Map.of(CommonConstants.Broker.Request.TRACE, "true"));
   }
 
   public static OpChainExecutionContext getContext(Map<String, String> opChainMetadata) {
@@ -122,22 +121,20 @@ public class OperatorTestUtil {
   }
 
   public static OpChainExecutionContext getNoTracingContext() {
-    return getTracingContext(ImmutableMap.of());
+    return getTracingContext(Map.of());
   }
 
   private static OpChainExecutionContext getTracingContext(Map<String, String> opChainMetadata) {
     MailboxService mailboxService = mock(MailboxService.class);
     when(mailboxService.getHostname()).thenReturn("localhost");
     when(mailboxService.getPort()).thenReturn(1234);
-    WorkerMetadata workerMetadata = new WorkerMetadata(0, ImmutableMap.of(), ImmutableMap.of());
-    StageMetadata stageMetadata = new StageMetadata(0, ImmutableList.of(workerMetadata), ImmutableMap.of());
-    OpChainExecutionContext opChainExecutionContext = new OpChainExecutionContext(mailboxService, 123L, Long.MAX_VALUE,
-        opChainMetadata, stageMetadata, workerMetadata, null, null, true);
-
-    StagePlan stagePlan = new StagePlan(null, stageMetadata);
-
+    WorkerMetadata workerMetadata = new WorkerMetadata(0, Map.of(), Map.of());
+    StageMetadata stageMetadata = new StageMetadata(0, List.of(workerMetadata), Map.of());
+    OpChainExecutionContext opChainExecutionContext =
+        new OpChainExecutionContext(mailboxService, 123L, Long.MAX_VALUE, Long.MAX_VALUE, opChainMetadata,
+            stageMetadata, workerMetadata, null, null, true);
     opChainExecutionContext.setLeafStageContext(
-        new ServerPlanRequestContext(stagePlan, null, null, null));
+        new ServerPlanRequestContext(new StagePlan(null, stageMetadata), null, null, null));
     return opChainExecutionContext;
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/accounting/ThreadResourceUsageAccountant.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/accounting/ThreadResourceUsageAccountant.java
@@ -49,11 +49,10 @@ public interface ThreadResourceUsageAccountant {
   /**
    * Set up the thread execution context for an anchor a.k.a runner thread.
    * @param queryId query id string
-   * @param taskId a unique task id
    * @param taskType the type of the task - SSE or MSE
    * @param workloadName the name of the workload, can be null
    */
-  void setupRunner(String queryId, int taskId, ThreadExecutionContext.TaskType taskType, String workloadName);
+  void setupRunner(String queryId, ThreadExecutionContext.TaskType taskType, String workloadName);
 
   /**
    * Set up the thread execution context for a worker thread.

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/query/QueryThreadContext.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/query/QueryThreadContext.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.spi.query;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Supplier;
 import java.util.Map;
@@ -59,7 +60,7 @@ import org.slf4j.MDC;
 public class QueryThreadContext {
   private static final Logger LOGGER = LoggerFactory.getLogger(QueryThreadContext.class);
   private static final ThreadLocal<Instance> THREAD_LOCAL = new ThreadLocal<>();
-  public static volatile boolean _strictMode = false;
+  public static volatile boolean _strictMode;
   private static final FakeInstance FAKE_INSTANCE = new FakeInstance();
 
   static {
@@ -156,6 +157,7 @@ public class QueryThreadContext {
    * @return an {@link AutoCloseable} object that should be used within a try-with-resources block
    * @throws IllegalStateException if the {@link QueryThreadContext} is already initialized.
    */
+  @VisibleForTesting
   public static CloseableContext open() {
     return open("unknown");
   }
@@ -164,12 +166,6 @@ public class QueryThreadContext {
     CloseableContext open = open((Memento) null);
     get()._instanceId = instanceId;
     return open;
-  }
-
-  /// Just kept for backward compatibility.
-  @Deprecated
-  public static CloseableContext openFromRequestMetadata(Map<String, String> requestMetadata) {
-    return openFromRequestMetadata("unknown", requestMetadata);
   }
 
   public static CloseableContext openFromRequestMetadata(String instanceId, Map<String, String> requestMetadata) {
@@ -296,23 +292,6 @@ public class QueryThreadContext {
    */
   public static void setStartTimeMs(long startTimeMs) {
     get().setStartTimeMs(startTimeMs);
-  }
-
-  /**
-   * Use {@link #getActiveDeadlineMs()} instead.
-   */
-  @Deprecated
-  public static long getDeadlineMs() {
-    return get().getActiveDeadlineMs();
-  }
-
-  /**
-   * @deprecated Use {@link #setActiveDeadlineMs(long)} instead.
-   * @throws IllegalStateException if deadline is already set or if the {@link QueryThreadContext} is not initialized
-   */
-  @Deprecated
-  public static void setDeadlineMs(long deadlineMs) {
-    get().setActiveDeadlineMs(deadlineMs);
   }
 
   /**
@@ -516,18 +495,8 @@ public class QueryThreadContext {
       _startTimeMs = startTimeMs;
     }
 
-    @Deprecated
-    public long getDeadlineMs() {
-      return getActiveDeadlineMs();
-    }
-
     public long getActiveDeadlineMs() {
       return _activeDeadlineMs;
-    }
-
-    @Deprecated
-    public void setDeadlineMs(long deadlineMs) {
-      setActiveDeadlineMs(deadlineMs);
     }
 
     public void setActiveDeadlineMs(long activeDeadlineMs) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/trace/Tracing.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/trace/Tracing.java
@@ -217,7 +217,7 @@ public class Tracing {
     }
 
     @Override
-    public void setupRunner(String queryId, int taskId, ThreadExecutionContext.TaskType taskType, String workloadName) {
+    public void setupRunner(String queryId, ThreadExecutionContext.TaskType taskType, String workloadName) {
     }
 
     @Override
@@ -268,8 +268,7 @@ public class Tracing {
 
     public static void setupRunner(String queryId, ThreadExecutionContext.TaskType taskType, String workloadName) {
       // Set up the runner thread with the given query ID and workload name
-      Tracing.getThreadAccountant()
-          .setupRunner(queryId, CommonConstants.Accounting.ANCHOR_TASK_ID, taskType, workloadName);
+      Tracing.getThreadAccountant().setupRunner(queryId, taskType, workloadName);
     }
 
     /**

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/executor/ThrottleOnCriticalHeapUsageExecutorTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/executor/ThrottleOnCriticalHeapUsageExecutorTest.java
@@ -56,7 +56,7 @@ public class ThrottleOnCriticalHeapUsageExecutorTest {
       }
 
       @Override
-      public void setupRunner(String queryId, int taskId, ThreadExecutionContext.TaskType taskType,
+      public void setupRunner(String queryId, ThreadExecutionContext.TaskType taskType,
           String workloadName) {
       }
 


### PR DESCRIPTION
- Change `setupRunner()` to not take task id because it is always anchor thread
- Cleanup usage of deprecated `deadlineMs`
- Fix `workloadName` in `QueryServer`
- Fix `taskId` compare logic in `TestResourceAccountant`

# Binary Incompatible
Changed `Tracing.setupRunner()` signature, but it should be internal only API