### PR TITLE
Add Package Versions section to cluster manager UI

### DIFF
--- a/pinot-controller/src/main/resources/app/components/Homepage/PackageVersions.tsx
+++ b/pinot-controller/src/main/resources/app/components/Homepage/PackageVersions.tsx
@@ -1,0 +1,54 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { useEffect, useState } from 'react';
+import { TableData } from 'Models';
+import AppLoader from '../AppLoader';
+import CustomizedTables from '../Table';
+import PinotMethodUtils from '../../utils/PinotMethodUtils';
+
+const PackageVersions = () => {
+
+  const [fetching, setFetching] = useState(true);
+  const [tableData, setTableData] = useState<TableData>({
+    columns: [],
+    records: []
+  });
+
+  const fetchData = async () => {
+    const result = await PinotMethodUtils.getPackageVersionsData();
+    setTableData(result);
+    setFetching(false);
+  };
+  useEffect(() => {
+    fetchData();
+  }, []);
+
+  return (
+    fetching ? <AppLoader /> :
+    <CustomizedTables
+      title="Package Versions"
+      data={tableData}
+      showSearchBox={true}
+      inAccordionFormat={true}
+    />
+  );
+};
+
+export default PackageVersions;

--- a/pinot-controller/src/main/resources/app/components/Table.tsx
+++ b/pinot-controller/src/main/resources/app/components/Table.tsx
@@ -597,7 +597,7 @@ export default function CustomizedTables({
         </TableContainer>
         {finalData.length > 10 ? (
           <TablePagination
-            rowsPerPageOptions={[5, 10, 25]}
+            rowsPerPageOptions={[5, 10, 25, 50, 100]}
             component="div"
             count={finalData.length}
             rowsPerPage={rowsPerPage}

--- a/pinot-controller/src/main/resources/app/pages/HomePage.tsx
+++ b/pinot-controller/src/main/resources/app/pages/HomePage.tsx
@@ -25,6 +25,7 @@ import PinotMethodUtils from '../utils/PinotMethodUtils';
 import TenantsListing from '../components/Homepage/TenantsListing';
 import Instances from '../components/Homepage/InstancesTables';
 import ClusterConfig from '../components/Homepage/ClusterConfig';
+import PackageVersions from '../components/Homepage/PackageVersions';
 import useTaskTypesTable from '../components/Homepage/useTaskTypesTable';
 import Skeleton from '@material-ui/lab/Skeleton';
 import { getTenants } from '../requests';
@@ -215,6 +216,7 @@ const HomePage = () => {
       />
       {taskTypesTable}
       <ClusterConfig />
+      <PackageVersions />
     </Grid>
   );
 };

--- a/pinot-controller/src/main/resources/app/requests/index.ts
+++ b/pinot-controller/src/main/resources/app/requests/index.ts
@@ -244,6 +244,9 @@ export const getTimeSeriesLanguages = (): Promise<AxiosResponse<string[]>> =>
 export const getClusterInfo = (): Promise<AxiosResponse<ClusterName>> =>
   baseApi.get('/cluster/info');
 
+export const getVersions = (): Promise<AxiosResponse<any>> =>
+  baseApi.get('/version');
+
 export const zookeeperGetList = (params: string): Promise<AxiosResponse<ZKGetList>> =>
   baseApi.get(`/zk/ls?path=${params}`);
 

--- a/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
+++ b/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
@@ -113,7 +113,8 @@ import {
   getServerToSegmentsCount,
   pauseConsumption,
   resumeConsumption,
-  getPauseStatus
+  getPauseStatus,
+  getVersions
 } from '../requests';
 import { baseApi } from './axios-config';
 import Utils from './Utils';
@@ -1351,6 +1352,24 @@ const getAuthUserEmailFromAccessToken = (
   return email;
 };
 
+// This method is used to display package versions in tabular format on cluster manager home page
+// API: /version
+// Expected Output: {columns: [], records: []}
+const getPackageVersionsData = () => {
+  return getVersions().then(({ data }) => {
+    const versionData = getAsObject(data);
+    const records = Object.entries(versionData).map(([packageName, version]) => [
+      packageName,
+      String(version)
+    ]);
+    
+    return {
+      columns: ['Package', 'Version'],
+      records: records
+    };
+  });
+};
+
 export default {
   getTenantsData,
   getAllInstances,
@@ -1448,5 +1467,6 @@ export default {
   resumeConsumptionOp,
   getPauseStatusData,
   fetchServerToSegmentsCountData,
-  getConsumingSegmentsInfoData
+  getConsumingSegmentsInfoData,
+  getPackageVersionsData
 };


### PR DESCRIPTION
This PR adds a new Package Versions section to the cluster manager homepage that displays version information for all Pinot components.

Features:
- New PackageVersions component below cluster configuration section
- Fetches data from /version API endpoint  
- Searchable table with Package Name and Version columns
- Added pagination options: 50 and 100 rows per page for all tables
- UI built and tested successfully

The section provides administrators with immediate visibility into component versions across their Pinot cluster.