### PR TITLE
(test) easy command - elderberry

### DIFF
--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/PinotAdministrator.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/PinotAdministrator.java
@@ -125,6 +125,8 @@ public class PinotAdministrator {
     SUBCOMMAND_MAP.put("DeleteCluster", new DeleteClusterCommand());
     SUBCOMMAND_MAP.put("ShowClusterInfo", new ShowClusterInfoCommand());
     SUBCOMMAND_MAP.put("AvroSchemaToPinotSchema", new AvroSchemaToPinotSchema());
+    SUBCOMMAND_MAP.put("ParquetSchemaToPinotSchema", new ParquetSchemaToPinotSchema());
+    SUBCOMMAND_MAP.put("InputSchemaToPinotSchema", new InputSchemaToPinotSchema());
     SUBCOMMAND_MAP.put("JsonToPinotSchema", new JsonToPinotSchema());
     SUBCOMMAND_MAP.put("RebalanceTable", new RebalanceTableCommand());
     SUBCOMMAND_MAP.put("ChangeNumReplicas", new ChangeNumReplicasCommand());

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/InputSchemaToPinotSchema.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/InputSchemaToPinotSchema.java
@@ -1,0 +1,230 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.tools.admin.command;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.apache.hadoop.fs.Path;
+import org.apache.pinot.plugin.inputformat.avro.AvroUtils;
+import org.apache.pinot.plugin.inputformat.parquet.ParquetUtils;
+import org.apache.pinot.segment.local.recordtransformer.ComplexTypeTransformer;
+import org.apache.pinot.spi.config.table.ingestion.ComplexTypeConfig;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.tools.Command;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import picocli.CommandLine;
+
+
+/**
+ * Unified command to convert Avro/Parquet schemas into a Pinot schema.
+ *
+ * Supported input types:
+ * - AVRO_SCHEMA (.avsc)
+ * - AVRO_DATA (.avro)
+ * - PARQUET (.parquet)
+ */
+@CommandLine.Command(name = "InputSchemaToPinotSchema", mixinStandardHelpOptions = true)
+public class InputSchemaToPinotSchema extends AbstractBaseAdminCommand implements Command {
+  private static final Logger LOGGER = LoggerFactory.getLogger(InputSchemaToPinotSchema.class);
+
+  public enum InputType {
+    AVRO_SCHEMA, AVRO_DATA, PARQUET
+  }
+
+  @CommandLine.Option(names = {"-inputFile"}, required = true, description = "Path to schema or data file (.avsc/.avro/.parquet)")
+  String _inputFile;
+
+  @CommandLine.Option(names = {"-inputType"}, description = "Explicit input type: AVRO_SCHEMA | AVRO_DATA | PARQUET. If omitted, inferred from file extension.")
+  String _inputType;
+
+  @CommandLine.Option(names = {"-outputDir"}, required = true, description = "Path to output directory")
+  String _outputDir;
+
+  @CommandLine.Option(names = {"-pinotSchemaName"}, required = true, description = "Pinot schema name")
+  String _pinotSchemaName;
+
+  @CommandLine.Option(names = {"-dimensions"}, description = "Comma separated dimension column names.")
+  String _dimensions;
+
+  @CommandLine.Option(names = {"-metrics"}, description = "Comma separated metric column names.")
+  String _metrics;
+
+  @CommandLine.Option(names = {"-timeColumnName"}, description = "Name of the time column.")
+  String _timeColumnName;
+
+  @CommandLine.Option(names = {"-timeUnit"}, description = "Unit of the time column (default DAYS).")
+  TimeUnit _timeUnit = TimeUnit.DAYS;
+
+  @CommandLine.Option(names = {"-fieldsToUnnest"}, description = "Comma separated fields to unnest")
+  String _fieldsToUnnest;
+
+  @CommandLine.Option(names = {"-delimiter"}, description = "The delimiter separating components in nested structure, default to dot")
+  String _delimiter;
+
+  @CommandLine.Option(names = {"-complexType"}, description = "allow complex-type handling, default to false")
+  boolean _complexType;
+
+  @CommandLine.Option(names = {"-collectionNotUnnestedToJson"}, description = "Mode for converting collections to JSON: NONE | NON_PRIMITIVE | ALL")
+  String _collectionNotUnnestedToJson;
+
+  @Override
+  public boolean execute() throws Exception {
+    if (_dimensions == null && _metrics == null && _timeColumnName == null) {
+      LOGGER.error("Error: specify at least one of -dimensions, -metrics, -timeColumnName");
+      return false;
+    }
+
+    File input = new File(_inputFile);
+    if (!input.isFile()) {
+      LOGGER.error("ERROR: Input file: {} does not exist or is not a file", _inputFile);
+      return false;
+    }
+
+    InputType inputType = determineInputType(input, _inputType);
+    LOGGER.info("Detected inputType={} for file={}", inputType, input.getAbsolutePath());
+
+    Schema schema;
+    switch (inputType) {
+      case AVRO_SCHEMA: {
+        if (!_complexType) {
+          schema = AvroUtils.getPinotSchemaFromAvroSchemaFile(input, buildFieldTypesMap(), _timeUnit, false,
+              Collections.emptyList(), getDelimiter(), getCollectionNotUnnestedToJson());
+        } else {
+          schema = AvroUtils.getPinotSchemaFromAvroSchemaFile(input, buildFieldTypesMap(), _timeUnit, true,
+              buildFieldsToUnnest(), getDelimiter(), getCollectionNotUnnestedToJson());
+        }
+        break;
+      }
+      case AVRO_DATA: {
+        schema = AvroUtils.getPinotSchemaFromAvroDataFile(input, buildFieldTypesMap(), _timeUnit);
+        break;
+      }
+      case PARQUET: {
+        Path parquetPath = new Path(input.getAbsolutePath());
+        boolean hasEmbeddedAvro = ParquetUtils.hasAvroSchemaInFileMetadata(parquetPath);
+        LOGGER.info("Reading Parquet schema (hasEmbeddedAvroSchemaMetadata={})", hasEmbeddedAvro);
+        org.apache.avro.Schema avroSchema = ParquetUtils.getParquetAvroSchema(parquetPath);
+        if (!_complexType) {
+          schema = AvroUtils.getPinotSchemaFromAvroSchema(avroSchema, buildFieldTypesMap(), _timeUnit);
+        } else {
+          schema = AvroUtils.getPinotSchemaFromAvroSchemaWithComplexTypeHandling(avroSchema, buildFieldTypesMap(),
+              _timeUnit, buildFieldsToUnnest(), getDelimiter(), getCollectionNotUnnestedToJson());
+        }
+        break;
+      }
+      default:
+        LOGGER.error("Unsupported inputType: {}", inputType);
+        return false;
+    }
+
+    schema.setSchemaName(_pinotSchemaName);
+
+    File outputDir = new File(_outputDir);
+    if (!outputDir.isDirectory()) {
+      LOGGER.error("ERROR: Output directory: {} does not exist or is not a directory", _outputDir);
+      return false;
+    }
+    File outputFile = new File(outputDir, _pinotSchemaName + ".json");
+    LOGGER.info("Store Pinot schema to file: {}", outputFile.getAbsolutePath());
+
+    try (FileWriter writer = new FileWriter(outputFile)) {
+      writer.write(schema.toPrettyJsonString());
+    }
+
+    return true;
+  }
+
+  private static InputType determineInputType(File input, String explicit) {
+    if (explicit != null && !explicit.isEmpty()) {
+      return InputType.valueOf(explicit.trim().toUpperCase(Locale.ROOT));
+    }
+    String name = input.getName().toLowerCase(Locale.ROOT);
+    if (name.endsWith(".avsc")) {
+      return InputType.AVRO_SCHEMA;
+    } else if (name.endsWith(".avro")) {
+      return InputType.AVRO_DATA;
+    } else if (name.endsWith(".parquet")) {
+      return InputType.PARQUET;
+    }
+    throw new IllegalArgumentException("Cannot infer input type from file extension: " + input.getName()
+        + ". Use -inputType to specify explicitly.");
+  }
+
+  @Override
+  public String description() {
+    return "Extract Pinot schema from Avro schema/data or Parquet file.";
+  }
+
+  @Override
+  public String toString() {
+    return "InputSchemaToPinotSchema -inputFile " + _inputFile + " -inputType " + _inputType + " -outputDir "
+        + _outputDir + " -pinotSchemaName " + _pinotSchemaName + " -dimensions " + _dimensions + " -metrics "
+        + _metrics + " -timeColumnName " + _timeColumnName + " -timeUnit " + _timeUnit + " _fieldsToUnnest "
+        + _fieldsToUnnest + " _delimiter " + _delimiter + " _complexType " + _complexType
+        + " _collectionNotUnnestedToJson " + _collectionNotUnnestedToJson;
+  }
+
+  private Map<String, FieldSpec.FieldType> buildFieldTypesMap() {
+    Map<String, FieldSpec.FieldType> fieldTypes = new HashMap<>();
+    if (_dimensions != null) {
+      for (String column : _dimensions.split("\\s*,\\s*")) {
+        fieldTypes.put(column, FieldSpec.FieldType.DIMENSION);
+      }
+    }
+    if (_metrics != null) {
+      for (String column : _metrics.split("\\s*,\\s*")) {
+        fieldTypes.put(column, FieldSpec.FieldType.METRIC);
+      }
+    }
+    if (_timeColumnName != null) {
+      fieldTypes.put(_timeColumnName, FieldSpec.FieldType.DATE_TIME);
+    }
+    return fieldTypes;
+  }
+
+  private List<String> buildFieldsToUnnest() {
+    if (_fieldsToUnnest != null) {
+      return Arrays.asList(_fieldsToUnnest.split("\\s*,\\s*"));
+    } else {
+      return Collections.emptyList();
+    }
+  }
+
+  private ComplexTypeConfig.CollectionNotUnnestedToJson getCollectionNotUnnestedToJson() {
+    if (_collectionNotUnnestedToJson == null) {
+      return ComplexTypeTransformer.DEFAULT_COLLECTION_TO_JSON_MODE;
+    }
+    return ComplexTypeConfig.CollectionNotUnnestedToJson.valueOf(_collectionNotUnnestedToJson);
+  }
+
+  private String getDelimiter() {
+    return _delimiter == null ? ComplexTypeTransformer.DEFAULT_DELIMITER : _delimiter;
+  }
+}
+
+

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/ParquetSchemaToPinotSchema.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/ParquetSchemaToPinotSchema.java
@@ -1,0 +1,187 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.tools.admin.command;
+
+import java.io.File;
+import java.io.FileWriter;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.apache.hadoop.fs.Path;
+import org.apache.pinot.plugin.inputformat.avro.AvroUtils;
+import org.apache.pinot.plugin.inputformat.parquet.ParquetUtils;
+import org.apache.pinot.segment.local.recordtransformer.ComplexTypeTransformer;
+import org.apache.pinot.spi.config.table.ingestion.ComplexTypeConfig;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.tools.Command;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import picocli.CommandLine;
+
+
+/**
+ * Command to convert a Parquet schema (inferred from a Parquet file) to a Pinot schema.
+ * If Parquet file contains embedded Avro schema metadata, it will be used; otherwise,
+ * Parquet schema will be converted to an Avro schema first.
+ * Similar to AvroSchemaToPinotSchema, this aims to automate most of the work while
+ * allowing manual touch-ups afterwards if needed.
+ */
+@CommandLine.Command(name = "ParquetSchemaToPinotSchema", mixinStandardHelpOptions = true)
+public class ParquetSchemaToPinotSchema extends AbstractBaseAdminCommand implements Command {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ParquetSchemaToPinotSchema.class);
+
+  @CommandLine.Option(names = {"-parquetFile"}, required = true, description = "Path to parquet file.")
+  String _parquetFile;
+
+  @CommandLine.Option(names = {"-outputDir"}, required = true, description = "Path to output directory")
+  String _outputDir;
+
+  @CommandLine.Option(names = {"-pinotSchemaName"}, required = true, description = "Pinot schema name")
+  String _pinotSchemaName;
+
+  @CommandLine.Option(names = {"-dimensions"}, description = "Comma separated dimension column names.")
+  String _dimensions;
+
+  @CommandLine.Option(names = {"-metrics"}, description = "Comma separated metric column names.")
+  String _metrics;
+
+  @CommandLine.Option(names = {"-timeColumnName"}, description = "Name of the time column.")
+  String _timeColumnName;
+
+  @CommandLine.Option(names = {"-timeUnit"}, description = "Unit of the time column (default DAYS).")
+  TimeUnit _timeUnit = TimeUnit.DAYS;
+
+  @CommandLine.Option(names = {"-fieldsToUnnest"}, description = "Comma separated fields to unnest")
+  String _fieldsToUnnest;
+
+  @CommandLine.Option(names = {"-delimiter"}, description = "The delimiter separating components in nested "
+      + "structure, default to dot")
+  String _delimiter;
+
+  @CommandLine.Option(names = {"-complexType"}, description = "allow complex-type handling, default to false")
+  boolean _complexType;
+
+  @CommandLine.Option(names = {"-collectionNotUnnestedToJson"}, description = "The mode of converting collection to "
+      + "JSON string, can be NONE/NON_PRIMITIVE/ALL")
+  String _collectionNotUnnestedToJson;
+
+  @Override
+  public boolean execute() throws Exception {
+    if (_dimensions == null && _metrics == null && _timeColumnName == null) {
+      LOGGER.error(
+          "Error: Missing required argument, please specify at least one of -dimensions, -metrics, -timeColumnName");
+      return false;
+    }
+
+    File parquet = new File(_parquetFile);
+    if (!parquet.isFile()) {
+      LOGGER.error("ERROR: Parquet file: {} does not exist or is not a file", _parquetFile);
+      return false;
+    }
+
+    Path parquetPath = new Path(parquet.getAbsolutePath());
+    // Log which path we take for schema extraction to validate assumptions.
+    boolean hasEmbeddedAvro = ParquetUtils.hasAvroSchemaInFileMetadata(parquetPath);
+    LOGGER.info("Converting Parquet file: {} (hasEmbeddedAvroSchemaMetadata={})", parquetPath, hasEmbeddedAvro);
+
+    org.apache.avro.Schema avroSchema = ParquetUtils.getParquetAvroSchema(parquetPath);
+
+    Schema schema;
+    if (!_complexType) {
+      schema = AvroUtils.getPinotSchemaFromAvroSchema(avroSchema, buildFieldTypesMap(), _timeUnit);
+    } else {
+      schema = AvroUtils.getPinotSchemaFromAvroSchemaWithComplexTypeHandling(avroSchema, buildFieldTypesMap(),
+          _timeUnit, buildFieldsToUnnest(), getDelimiter(), getCollectionNotUnnestedToJson());
+    }
+
+    schema.setSchemaName(_pinotSchemaName);
+
+    File outputDir = new File(_outputDir);
+    if (!outputDir.isDirectory()) {
+      LOGGER.error("ERROR: Output directory: {} does not exist or is not a directory", _outputDir);
+      return false;
+    }
+
+    File outputFile = new File(outputDir, _pinotSchemaName + ".json");
+    LOGGER.info("Store Pinot schema to file: {}", outputFile.getAbsolutePath());
+
+    try (FileWriter writer = new FileWriter(outputFile)) {
+      writer.write(schema.toPrettyJsonString());
+    }
+
+    return true;
+  }
+
+  @Override
+  public String description() {
+    return "Extracting Pinot schema file from a Parquet file (via Avro schema).";
+  }
+
+  @Override
+  public String toString() {
+    return "ParquetSchemaToPinotSchema -parquetFile " + _parquetFile + " -outputDir " + _outputDir
+        + " -pinotSchemaName " + _pinotSchemaName + " -dimensions " + _dimensions + " -metrics " + _metrics
+        + " -timeColumnName " + _timeColumnName + " -timeUnit " + _timeUnit + " _fieldsToUnnest " + _fieldsToUnnest
+        + " _delimiter " + _delimiter + " _complexType " + _complexType + " _collectionNotUnnestedToJson "
+        + _collectionNotUnnestedToJson;
+  }
+
+  private Map<String, FieldSpec.FieldType> buildFieldTypesMap() {
+    Map<String, FieldSpec.FieldType> fieldTypes = new HashMap<>();
+    if (_dimensions != null) {
+      for (String column : _dimensions.split("\\s*,\\s*")) {
+        fieldTypes.put(column, FieldSpec.FieldType.DIMENSION);
+      }
+    }
+    if (_metrics != null) {
+      for (String column : _metrics.split("\\s*,\\s*")) {
+        fieldTypes.put(column, FieldSpec.FieldType.METRIC);
+      }
+    }
+    if (_timeColumnName != null) {
+      fieldTypes.put(_timeColumnName, FieldSpec.FieldType.DATE_TIME);
+    }
+    return fieldTypes;
+  }
+
+  private List<String> buildFieldsToUnnest() {
+    if (_fieldsToUnnest != null) {
+      return Arrays.asList(_fieldsToUnnest.split("\\s*,\\s*"));
+    } else {
+      return Collections.emptyList();
+    }
+  }
+
+  private ComplexTypeConfig.CollectionNotUnnestedToJson getCollectionNotUnnestedToJson() {
+    if (_collectionNotUnnestedToJson == null) {
+      return ComplexTypeTransformer.DEFAULT_COLLECTION_TO_JSON_MODE;
+    }
+    return ComplexTypeConfig.CollectionNotUnnestedToJson.valueOf(_collectionNotUnnestedToJson);
+  }
+
+  private String getDelimiter() {
+    return _delimiter == null ? ComplexTypeTransformer.DEFAULT_DELIMITER : _delimiter;
+  }
+}
+
+


### PR DESCRIPTION

- I read existing schema conversion utilities and commands, and implemented a unified command to handle both Avro and Parquet schema inputs.

What I added next:
- New command: `InputSchemaToPinotSchema`
  - Location: `pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/InputSchemaToPinotSchema.java`
  - Detects type from file extension (.avsc → AVRO_SCHEMA, .avro → AVRO_DATA, .parquet → PARQUET) or via `-inputType`.
  - Converts using:
    - Avro schema file: `AvroUtils.getPinotSchemaFromAvroSchemaFile(...)`
    - Avro data file: `AvroUtils.getPinotSchemaFromAvroDataFile(...)`
    - Parquet file: `ParquetUtils.getParquetAvroSchema(...)` then `AvroUtils` to Pinot schema
  - Supports complex-type handling flags consistent with `AvroSchemaToPinotSchema`
  - Adds logs to validate assumptions:
    - detected input type
    - Parquet embedded Avro schema presence

- Registration:
  - Added to `PinotAdministrator`: `SUBCOMMAND_MAP.put("InputSchemaToPinotSchema", new InputSchemaToPinotSchema());`

- Kept a dedicated Parquet command:
  - New command: `ParquetSchemaToPinotSchema`
  - Location: `pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/ParquetSchemaToPinotSchema.java`
  - Registered in `PinotAdministrator`
  - This complements the existing `AvroSchemaToPinotSchema` and provides a simple entry for Parquet-only workflows.

How to use (examples):
- pinot-admin InputSchemaToPinotSchema -inputFile /path/to/schema.avsc -outputDir /tmp -pinotSchemaName MySchema -dimensions colA,colB
- pinot-admin InputSchemaToPinotSchema -inputFile /path/to/data.avro -outputDir /tmp -pinotSchemaName MySchema -metrics m1,m2
- pinot-admin InputSchemaToPinotSchema -inputFile /path/to/file.parquet -outputDir /tmp -pinotSchemaName MySchema -timeColumnName ts -timeUnit HOURS
- Optional: -inputType AVRO_SCHEMA|AVRO_DATA|PARQUET, -complexType, -fieldsToUnnest a.b,c.d, -delimiter ., -collectionNotUnnestedToJson NONE|NON_PRIMITIVE|ALL

- Logs added to validate key assumptions:
  - Input type detection and Parquet embedded-avro metadata detection.

- No linter errors introduced.