### PR TITLE
[multistage] Push Collation from Exchange to Lite Mode Sort

### DIFF
--- a/pinot-query-planner/src/test/resources/queries/PhysicalOptimizerPlans.json
+++ b/pinot-query-planner/src/test/resources/queries/PhysicalOptimizerPlans.json
@@ -805,6 +805,21 @@
           "\n                PhysicalTableScan(table=[[default, a]])",
           "\n"
         ]
+      },
+      {
+        "description": "Tests collation push down for Lite Mode. Collation from the exchange above should get pushed down to the sort below.",
+        "sql": "SET usePhysicalOptimizer=true; SET useLiteMode=true; EXPLAIN PLAN FOR WITH tmp AS (SELECT col1, ROW_NUMBER() OVER (ORDER BY ts DESC) as row_num FROM a) SELECT COUNT(*) FROM tmp WHERE row_num <= 100",
+        "output": [
+          "Execution Plan",
+          "\nPhysicalAggregate(group=[{}], agg#0=[COUNT()], aggType=[DIRECT])",
+          "\n  PhysicalFilter(condition=[<=($1, 100)])",
+          "\n    PhysicalWindow(window#0=[window(order by [0 DESC] rows between UNBOUNDED PRECEDING and CURRENT ROW aggs [ROW_NUMBER()])])",
+          "\n      PhysicalExchange(exchangeStrategy=[SINGLETON_EXCHANGE], collation=[[0 DESC]])",
+          "\n        PhysicalSort(sort0=[$0], dir0=[DESC], fetch=[100000])",
+          "\n          PhysicalProject(ts=[$7])",
+          "\n            PhysicalTableScan(table=[[default, a]])",
+          "\n"
+        ]
       }
     ]
   },


### PR DESCRIPTION
### Summary

Minor improvement to pushdown collation from the enclosing Exchange to the Lite Mode generated Sort.

This is good for queries like the following. Without this patch the generated Sort only has a fetch and no collation.

```
SET useMultistageEngine = true;
SET usePhysicalOptimizer = true;
SET useLiteMode = true;

EXPLAIN PLAN FOR WITH ordered_events AS (
  SELECT 
    cityName,
    tripAmount,
    ROW_NUMBER() OVER (
      ORDER BY ts DESC
    ) as row_num
  FROM userFactEvents
),
filtered_events AS (
  SELECT 
    *
  FROM ordered_events
  WHERE row_num < 1000
)
SELECT 
  cityName,
  SUM(tripAmount) as cityTotal
FROM filtered_events
GROUP BY cityName
```

The plan now for this query is:

```
Execution Plan
PhysicalAggregate(group=[{0}], agg#0=[$SUM0($1)], aggType=[DIRECT])
  PhysicalFilter(condition=[<($3, 1000)])
    PhysicalWindow(window#0=[window(order by [2 DESC] rows between UNBOUNDED PRECEDING and CURRENT ROW aggs [ROW_NUMBER()])])
      PhysicalExchange(exchangeStrategy=[SINGLETON_EXCHANGE], collation=[[2 DESC]])
        PhysicalSort(fetch=[100000])
          PhysicalProject(cityName=[$3], tripAmount=[$7], ts=[$9])
            PhysicalTableScan(table=[[default, userFactEvents]])
```

### Test Plan

Added a UT and also verified on Quickstart.