### PR TITLE
Enhance ValueAggregator

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/AvgValueAggregator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/AvgValueAggregator.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.segment.local.aggregator;
 
+import javax.annotation.Nullable;
 import org.apache.pinot.segment.local.customobject.AvgPair;
 import org.apache.pinot.segment.local.utils.CustomSerDeUtils;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
@@ -38,7 +39,10 @@ public class AvgValueAggregator implements ValueAggregator<Object, AvgPair> {
   }
 
   @Override
-  public AvgPair getInitialAggregatedValue(Object rawValue) {
+  public AvgPair getInitialAggregatedValue(@Nullable Object rawValue) {
+    if (rawValue == null) {
+      return new AvgPair();
+    }
     if (rawValue instanceof byte[]) {
       return deserializeAggregatedValue((byte[]) rawValue);
     } else {
@@ -65,6 +69,11 @@ public class AvgValueAggregator implements ValueAggregator<Object, AvgPair> {
   @Override
   public AvgPair cloneAggregatedValue(AvgPair value) {
     return new AvgPair(value.getSum(), value.getCount());
+  }
+
+  @Override
+  public boolean isAggregatedValueFixedSize() {
+    return true;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/CountValueAggregator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/CountValueAggregator.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.segment.local.aggregator;
 
+import javax.annotation.Nullable;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 
@@ -36,8 +37,8 @@ public class CountValueAggregator implements ValueAggregator<Object, Long> {
   }
 
   @Override
-  public Long getInitialAggregatedValue(Object rawValue) {
-    return 1L;
+  public Long getInitialAggregatedValue(@Nullable Object rawValue) {
+    return rawValue != null ? 1L : 0L;
   }
 
   @Override
@@ -53,6 +54,11 @@ public class CountValueAggregator implements ValueAggregator<Object, Long> {
   @Override
   public Long cloneAggregatedValue(Long value) {
     return value;
+  }
+
+  @Override
+  public boolean isAggregatedValueFixedSize() {
+    return true;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/DistinctCountBitmapValueAggregator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/DistinctCountBitmapValueAggregator.java
@@ -41,6 +41,8 @@ public class DistinctCountBitmapValueAggregator implements ValueAggregator<Objec
 
   @Override
   public RoaringBitmap getInitialAggregatedValue(Object rawValue) {
+    // NOTE: rawValue cannot be null because this aggregator can only be used for star-tree index.
+    assert rawValue != null;
     RoaringBitmap initialValue;
     if (rawValue instanceof byte[]) {
       byte[] bytes = (byte[]) rawValue;
@@ -75,6 +77,11 @@ public class DistinctCountBitmapValueAggregator implements ValueAggregator<Objec
   @Override
   public RoaringBitmap cloneAggregatedValue(RoaringBitmap value) {
     return value.clone();
+  }
+
+  @Override
+  public boolean isAggregatedValueFixedSize() {
+    return false;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/DistinctCountHLLPlusValueAggregator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/DistinctCountHLLPlusValueAggregator.java
@@ -22,6 +22,7 @@ import com.clearspring.analytics.stream.cardinality.CardinalityMergeException;
 import com.clearspring.analytics.stream.cardinality.HyperLogLogPlus;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.List;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.segment.local.utils.CustomSerDeUtils;
 import org.apache.pinot.segment.local.utils.HyperLogLogPlusUtils;
@@ -64,7 +65,10 @@ public class DistinctCountHLLPlusValueAggregator implements ValueAggregator<Obje
   }
 
   @Override
-  public HyperLogLogPlus getInitialAggregatedValue(Object rawValue) {
+  public HyperLogLogPlus getInitialAggregatedValue(@Nullable Object rawValue) {
+    if (rawValue == null) {
+      return new HyperLogLogPlus(_p, _sp);
+    }
     HyperLogLogPlus initialValue;
     if (rawValue instanceof byte[]) {
       byte[] bytes = (byte[]) rawValue;
@@ -105,6 +109,11 @@ public class DistinctCountHLLPlusValueAggregator implements ValueAggregator<Obje
   @Override
   public HyperLogLogPlus cloneAggregatedValue(HyperLogLogPlus value) {
     return deserializeAggregatedValue(serializeAggregatedValue(value));
+  }
+
+  @Override
+  public boolean isAggregatedValueFixedSize() {
+    return true;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/DistinctCountHLLValueAggregator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/DistinctCountHLLValueAggregator.java
@@ -22,6 +22,7 @@ import com.clearspring.analytics.stream.cardinality.CardinalityMergeException;
 import com.clearspring.analytics.stream.cardinality.HyperLogLog;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.List;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.segment.local.utils.CustomSerDeUtils;
 import org.apache.pinot.segment.local.utils.HyperLogLogUtils;
@@ -58,7 +59,10 @@ public class DistinctCountHLLValueAggregator implements ValueAggregator<Object, 
   }
 
   @Override
-  public HyperLogLog getInitialAggregatedValue(Object rawValue) {
+  public HyperLogLog getInitialAggregatedValue(@Nullable Object rawValue) {
+    if (rawValue == null) {
+      return new HyperLogLog(_log2m);
+    }
     HyperLogLog initialValue;
     if (rawValue instanceof byte[]) {
       byte[] bytes = (byte[]) rawValue;
@@ -99,6 +103,11 @@ public class DistinctCountHLLValueAggregator implements ValueAggregator<Object, 
   @Override
   public HyperLogLog cloneAggregatedValue(HyperLogLog value) {
     return deserializeAggregatedValue(serializeAggregatedValue(value));
+  }
+
+  @Override
+  public boolean isAggregatedValueFixedSize() {
+    return true;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/DistinctCountThetaSketchValueAggregator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/DistinctCountThetaSketchValueAggregator.java
@@ -116,6 +116,8 @@ public class DistinctCountThetaSketchValueAggregator implements ValueAggregator<
 
   @Override
   public Object getInitialAggregatedValue(Object rawValue) {
+    // NOTE: rawValue cannot be null because this aggregator can only be used for star-tree index.
+    assert rawValue != null;
     Union thetaUnion = _setOperationBuilder.buildUnion();
     if (rawValue instanceof byte[]) { // Serialized Sketch
       byte[] bytes = (byte[]) rawValue;
@@ -173,6 +175,11 @@ public class DistinctCountThetaSketchValueAggregator implements ValueAggregator<
   @Override
   public Object cloneAggregatedValue(Object value) {
     return deserializeAggregatedValue(serializeAggregatedValue(value));
+  }
+
+  @Override
+  public boolean isAggregatedValueFixedSize() {
+    return false;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/DistinctCountULLValueAggregator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/DistinctCountULLValueAggregator.java
@@ -21,6 +21,7 @@ package org.apache.pinot.segment.local.aggregator;
 import com.dynatrace.hash4j.distinctcount.UltraLogLog;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.List;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.segment.local.utils.CustomSerDeUtils;
 import org.apache.pinot.segment.local.utils.UltraLogLogUtils;
@@ -54,7 +55,10 @@ public class DistinctCountULLValueAggregator implements ValueAggregator<Object, 
   }
 
   @Override
-  public UltraLogLog getInitialAggregatedValue(Object rawValue) {
+  public UltraLogLog getInitialAggregatedValue(@Nullable Object rawValue) {
+    if (rawValue == null) {
+      return UltraLogLog.create(_p);
+    }
     UltraLogLog initialValue;
     if (rawValue instanceof byte[]) {
       byte[] bytes = (byte[]) rawValue;
@@ -81,6 +85,11 @@ public class DistinctCountULLValueAggregator implements ValueAggregator<Object, 
   @Override
   public UltraLogLog cloneAggregatedValue(UltraLogLog value) {
     return deserializeAggregatedValue(serializeAggregatedValue(value));
+  }
+
+  @Override
+  public boolean isAggregatedValueFixedSize() {
+    return true;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/IntegerTupleSketchValueAggregator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/IntegerTupleSketchValueAggregator.java
@@ -20,6 +20,7 @@ package org.apache.pinot.segment.local.aggregator;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.util.List;
+import javax.annotation.Nullable;
 import org.apache.datasketches.tuple.Sketch;
 import org.apache.datasketches.tuple.Union;
 import org.apache.datasketches.tuple.aninteger.IntegerSummary;
@@ -60,9 +61,12 @@ public class IntegerTupleSketchValueAggregator implements ValueAggregator<byte[]
   }
 
   @Override
-  public Object getInitialAggregatedValue(byte[] rawValue) {
-    Sketch<IntegerSummary> initialValue = deserializeAggregatedValue(rawValue);
+  public Object getInitialAggregatedValue(@Nullable byte[] rawValue) {
     Union tupleUnion = new Union<>(_nominalEntries, new IntegerSummarySetOperations(_mode, _mode));
+    if (rawValue == null) {
+      return tupleUnion;
+    }
+    Sketch<IntegerSummary> initialValue = deserializeAggregatedValue(rawValue);
     tupleUnion.union(initialValue);
     return tupleUnion;
   }
@@ -112,6 +116,11 @@ public class IntegerTupleSketchValueAggregator implements ValueAggregator<byte[]
   @Override
   public Object cloneAggregatedValue(Object value) {
     return deserializeAggregatedValue(serializeAggregatedValue(value));
+  }
+
+  @Override
+  public boolean isAggregatedValueFixedSize() {
+    return true;
   }
 
   /**

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/MaxValueAggregator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/MaxValueAggregator.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.segment.local.aggregator;
 
+import javax.annotation.Nullable;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 
@@ -36,7 +37,10 @@ public class MaxValueAggregator implements ValueAggregator<Object, Double> {
   }
 
   @Override
-  public Double getInitialAggregatedValue(Object rawValue) {
+  public Double getInitialAggregatedValue(@Nullable Object rawValue) {
+    if (rawValue == null) {
+      return Double.NEGATIVE_INFINITY;
+    }
     return ValueAggregatorUtils.toDouble(rawValue);
   }
 
@@ -53,6 +57,11 @@ public class MaxValueAggregator implements ValueAggregator<Object, Double> {
   @Override
   public Double cloneAggregatedValue(Double value) {
     return value;
+  }
+
+  @Override
+  public boolean isAggregatedValueFixedSize() {
+    return true;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/MinMaxRangeValueAggregator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/MinMaxRangeValueAggregator.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.segment.local.aggregator;
 
+import javax.annotation.Nullable;
 import org.apache.pinot.segment.local.customobject.MinMaxRangePair;
 import org.apache.pinot.segment.local.utils.CustomSerDeUtils;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
@@ -38,7 +39,10 @@ public class MinMaxRangeValueAggregator implements ValueAggregator<Object, MinMa
   }
 
   @Override
-  public MinMaxRangePair getInitialAggregatedValue(Object rawValue) {
+  public MinMaxRangePair getInitialAggregatedValue(@Nullable Object rawValue) {
+    if (rawValue == null) {
+      return new MinMaxRangePair();
+    }
     if (rawValue instanceof byte[]) {
       return deserializeAggregatedValue((byte[]) rawValue);
     } else {
@@ -66,6 +70,11 @@ public class MinMaxRangeValueAggregator implements ValueAggregator<Object, MinMa
   @Override
   public MinMaxRangePair cloneAggregatedValue(MinMaxRangePair value) {
     return new MinMaxRangePair(value.getMin(), value.getMax());
+  }
+
+  @Override
+  public boolean isAggregatedValueFixedSize() {
+    return true;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/MinValueAggregator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/MinValueAggregator.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.segment.local.aggregator;
 
+import javax.annotation.Nullable;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 
@@ -36,7 +37,10 @@ public class MinValueAggregator implements ValueAggregator<Object, Double> {
   }
 
   @Override
-  public Double getInitialAggregatedValue(Object rawValue) {
+  public Double getInitialAggregatedValue(@Nullable Object rawValue) {
+    if (rawValue == null) {
+      return Double.POSITIVE_INFINITY;
+    }
     return ValueAggregatorUtils.toDouble(rawValue);
   }
 
@@ -53,6 +57,11 @@ public class MinValueAggregator implements ValueAggregator<Object, Double> {
   @Override
   public Double cloneAggregatedValue(Double value) {
     return value;
+  }
+
+  @Override
+  public boolean isAggregatedValueFixedSize() {
+    return true;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/PercentileEstValueAggregator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/PercentileEstValueAggregator.java
@@ -44,6 +44,8 @@ public class PercentileEstValueAggregator implements ValueAggregator<Object, Qua
 
   @Override
   public QuantileDigest getInitialAggregatedValue(Object rawValue) {
+    // NOTE: rawValue cannot be null because this aggregator can only be used for star-tree index.
+    assert rawValue != null;
     QuantileDigest initialValue;
     if (rawValue instanceof byte[]) {
       byte[] bytes = (byte[]) rawValue;
@@ -90,6 +92,11 @@ public class PercentileEstValueAggregator implements ValueAggregator<Object, Qua
   @Override
   public QuantileDigest cloneAggregatedValue(QuantileDigest value) {
     return deserializeAggregatedValue(serializeAggregatedValue(value));
+  }
+
+  @Override
+  public boolean isAggregatedValueFixedSize() {
+    return false;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/PercentileTDigestValueAggregator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/PercentileTDigestValueAggregator.java
@@ -54,6 +54,8 @@ public class PercentileTDigestValueAggregator implements ValueAggregator<Object,
 
   @Override
   public TDigest getInitialAggregatedValue(Object rawValue) {
+    // NOTE: rawValue cannot be null because this aggregator can only be used for star-tree index.
+    assert rawValue != null;
     TDigest initialValue;
     if (rawValue instanceof byte[]) {
       byte[] bytes = (byte[]) rawValue;
@@ -88,6 +90,11 @@ public class PercentileTDigestValueAggregator implements ValueAggregator<Object,
   @Override
   public TDigest cloneAggregatedValue(TDigest value) {
     return deserializeAggregatedValue(serializeAggregatedValue(value));
+  }
+
+  @Override
+  public boolean isAggregatedValueFixedSize() {
+    return false;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/SumPrecisionValueAggregator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/SumPrecisionValueAggregator.java
@@ -21,6 +21,7 @@ package org.apache.pinot.segment.local.aggregator;
 import com.google.common.base.Preconditions;
 import java.math.BigDecimal;
 import java.util.List;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
@@ -58,7 +59,10 @@ public class SumPrecisionValueAggregator implements ValueAggregator<Object, BigD
   }
 
   @Override
-  public BigDecimal getInitialAggregatedValue(Object rawValue) {
+  public BigDecimal getInitialAggregatedValue(@Nullable Object rawValue) {
+    if (rawValue == null) {
+      return BigDecimal.ZERO;
+    }
     BigDecimal initialValue = toBigDecimal(rawValue);
     if (_fixedSize < 0) {
       _maxByteSize = Math.max(_maxByteSize, BigDecimalUtils.byteSize(initialValue));
@@ -98,6 +102,11 @@ public class SumPrecisionValueAggregator implements ValueAggregator<Object, BigD
   public BigDecimal cloneAggregatedValue(BigDecimal value) {
     // NOTE: No need to clone because BigDecimal is immutable
     return value;
+  }
+
+  @Override
+  public boolean isAggregatedValueFixedSize() {
+    return _fixedSize > 0;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/SumValueAggregator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/SumValueAggregator.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.segment.local.aggregator;
 
+import javax.annotation.Nullable;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 
@@ -36,7 +37,10 @@ public class SumValueAggregator implements ValueAggregator<Object, Double> {
   }
 
   @Override
-  public Double getInitialAggregatedValue(Object rawValue) {
+  public Double getInitialAggregatedValue(@Nullable Object rawValue) {
+    if (rawValue == null) {
+      return 0.0;
+    }
     return ValueAggregatorUtils.toDouble(rawValue);
   }
 
@@ -53,6 +57,11 @@ public class SumValueAggregator implements ValueAggregator<Object, Double> {
   @Override
   public Double cloneAggregatedValue(Double value) {
     return value;
+  }
+
+  @Override
+  public boolean isAggregatedValueFixedSize() {
+    return true;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/ValueAggregator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/ValueAggregator.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.segment.local.aggregator;
 
+import javax.annotation.Nullable;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 
@@ -42,8 +43,10 @@ public interface ValueAggregator<R, A> {
 
   /**
    * Returns the initial aggregated value.
+   * <p>NOTE: rawValue can be null when the aggregator is used for ingestion aggregation, and the column is not
+   * specified in the schema.
    */
-  A getInitialAggregatedValue(R rawValue);
+  A getInitialAggregatedValue(@Nullable R rawValue);
 
   /**
    * Applies a raw value to the current aggregated value.
@@ -61,6 +64,12 @@ public interface ValueAggregator<R, A> {
    * Clones an aggregated value.
    */
   A cloneAggregatedValue(A value);
+
+  /**
+   * Returns whether the aggregated value is of fixed size. Value aggregator can be used for ingestion aggregation only
+   * when the aggregated value is of fixed size.
+   */
+  boolean isAggregatedValueFixedSize();
 
   /**
    * Returns the maximum size in bytes of the aggregated values seen so far.

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/ValueAggregatorFactory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/ValueAggregatorFactory.java
@@ -61,18 +61,15 @@ public class ValueAggregatorFactory {
       case DISTINCTCOUNTHLL:
       case DISTINCTCOUNTRAWHLL:
         return new DistinctCountHLLValueAggregator(arguments);
-      case PERCENTILEEST:
-      case PERCENTILERAWEST:
-        return new PercentileEstValueAggregator();
-      case PERCENTILETDIGEST:
-      case PERCENTILERAWTDIGEST:
-        return new PercentileTDigestValueAggregator(arguments);
-      case DISTINCTCOUNTTHETASKETCH:
-      case DISTINCTCOUNTRAWTHETASKETCH:
-        return new DistinctCountThetaSketchValueAggregator(arguments);
       case DISTINCTCOUNTHLLPLUS:
       case DISTINCTCOUNTRAWHLLPLUS:
         return new DistinctCountHLLPlusValueAggregator(arguments);
+      case DISTINCTCOUNTULL:
+      case DISTINCTCOUNTRAWULL:
+        return new DistinctCountULLValueAggregator(arguments);
+      case DISTINCTCOUNTTHETASKETCH:
+      case DISTINCTCOUNTRAWTHETASKETCH:
+        return new DistinctCountThetaSketchValueAggregator(arguments);
       case DISTINCTCOUNTTUPLESKETCH:
       case DISTINCTCOUNTRAWINTEGERSUMTUPLESKETCH:
       case AVGVALUEINTEGERSUMTUPLESKETCH:
@@ -81,9 +78,12 @@ public class ValueAggregatorFactory {
       case DISTINCTCOUNTCPCSKETCH:
       case DISTINCTCOUNTRAWCPCSKETCH:
         return new DistinctCountCPCSketchValueAggregator(arguments);
-      case DISTINCTCOUNTULL:
-      case DISTINCTCOUNTRAWULL:
-        return new DistinctCountULLValueAggregator(arguments);
+      case PERCENTILEEST:
+      case PERCENTILERAWEST:
+        return new PercentileEstValueAggregator();
+      case PERCENTILETDIGEST:
+      case PERCENTILERAWTDIGEST:
+        return new PercentileTDigestValueAggregator(arguments);
       default:
         throw new IllegalStateException("Unsupported aggregation type: " + aggregationType);
     }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/aggregator/DistinctCountCPCSketchValueAggregatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/aggregator/DistinctCountCPCSketchValueAggregatorTest.java
@@ -60,6 +60,12 @@ public class DistinctCountCPCSketchValueAggregatorTest {
   }
 
   @Test
+  public void nullInitialShouldReturnEmptySketch() {
+    DistinctCountCPCSketchValueAggregator agg = new DistinctCountCPCSketchValueAggregator(Collections.emptyList());
+    assertEquals(toSketch(agg.getInitialAggregatedValue(null)).getEstimate(), 0.0);
+  }
+
+  @Test
   public void applyAggregatedValueShouldUnion() {
     CpcSketch input1 = new CpcSketch();
     IntStream.range(0, 1000).forEach(input1::update);

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/aggregator/DistinctCountULLValueAggregatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/aggregator/DistinctCountULLValueAggregatorTest.java
@@ -81,6 +81,12 @@ public class DistinctCountULLValueAggregatorTest {
   }
 
   @Test
+  public void nullInitialShouldReturnEmptyULL() {
+    DistinctCountULLValueAggregator agg = new DistinctCountULLValueAggregator(Collections.emptyList());
+    assertEquals(agg.getInitialAggregatedValue(null).getDistinctCountEstimate(), 0.0);
+  }
+
+  @Test
   public void applyAggregatedValueShouldUnion() {
     UltraLogLog input1 = UltraLogLog.create(12);
     IntStream.range(0, 1000).mapToObj(UltraLogLogUtils::hashObject).forEach(h -> h.ifPresent(input1::add));

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/aggregator/IntegerTupleSketchValueAggregatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/aggregator/IntegerTupleSketchValueAggregatorTest.java
@@ -44,6 +44,13 @@ public class IntegerTupleSketchValueAggregatorTest {
   }
 
   @Test
+  public void nullInitialShouldReturnEmptySketch() {
+    IntegerTupleSketchValueAggregator agg =
+        new IntegerTupleSketchValueAggregator(Collections.emptyList(), IntegerSummary.Mode.Sum);
+    assertEquals(toSketch(agg.getInitialAggregatedValue(null)).getEstimate(), 0.0);
+  }
+
+  @Test
   public void applyAggregatedValueShouldUnion() {
     IntegerSketch s1 = new IntegerSketch(16, IntegerSummary.Mode.Sum);
     IntegerSketch s2 = new IntegerSketch(16, IntegerSummary.Mode.Sum);

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/aggregator/ValueAggregatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/aggregator/ValueAggregatorTest.java
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.aggregator;
+
+import java.util.List;
+import org.apache.pinot.common.request.Literal;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.segment.spi.AggregationFunctionType;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+
+public class ValueAggregatorTest {
+
+  @Test(dataProvider = "fixedSizeAggregatedValue")
+  public void testFixedSizeAggregatedValue(AggregationFunctionType functionType, List<ExpressionContext> arguments,
+      boolean expected) {
+    assertEquals(ValueAggregatorFactory.getValueAggregator(functionType, arguments).isAggregatedValueFixedSize(),
+        expected);
+  }
+
+  @DataProvider
+  public static Object[][] fixedSizeAggregatedValue() {
+    return new Object[][]{
+        {AggregationFunctionType.COUNT, List.of(), true},
+        {AggregationFunctionType.MIN, List.of(), true},
+        {AggregationFunctionType.MAX, List.of(), true},
+        {AggregationFunctionType.SUM, List.of(), true},
+        {AggregationFunctionType.SUMPRECISION, List.of(), false},
+        {AggregationFunctionType.SUMPRECISION, List.of(ExpressionContext.forLiteral(Literal.intValue(20))), true},
+        {AggregationFunctionType.AVG, List.of(), true},
+        {AggregationFunctionType.MINMAXRANGE, List.of(), true},
+        {AggregationFunctionType.DISTINCTCOUNTBITMAP, List.of(), false},
+        {AggregationFunctionType.DISTINCTCOUNTHLL, List.of(), true},
+        {AggregationFunctionType.DISTINCTCOUNTHLLPLUS, List.of(), true},
+        {AggregationFunctionType.DISTINCTCOUNTULL, List.of(), true},
+        {AggregationFunctionType.DISTINCTCOUNTTHETASKETCH, List.of(), false},
+        {AggregationFunctionType.DISTINCTCOUNTTUPLESKETCH, List.of(), true},
+        {AggregationFunctionType.DISTINCTCOUNTCPCSKETCH, List.of(), true},
+        {AggregationFunctionType.PERCENTILEEST, List.of(), false},
+        {AggregationFunctionType.PERCENTILETDIGEST, List.of(), false}
+    };
+  }
+}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplIngestionAggregationTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplIngestionAggregationTest.java
@@ -18,31 +18,29 @@
  */
 package org.apache.pinot.segment.local.indexsegment.mutable;
 
-import com.clearspring.analytics.stream.cardinality.CardinalityMergeException;
 import com.clearspring.analytics.stream.cardinality.HyperLogLog;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
-import org.apache.pinot.common.request.Literal;
-import org.apache.pinot.common.request.context.ExpressionContext;
-import org.apache.pinot.segment.local.aggregator.DistinctCountHLLValueAggregator;
+import org.apache.pinot.segment.local.utils.CustomSerDeUtils;
 import org.apache.pinot.spi.config.table.ingestion.AggregationConfig;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.stream.StreamMessageMetadata;
 import org.apache.pinot.spi.utils.BigDecimalUtils;
-import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
 
 
 public class MutableSegmentImplIngestionAggregationTest {
@@ -61,18 +59,17 @@ public class MutableSegmentImplIngestionAggregationTest {
 
   private static Schema.SchemaBuilder getSchemaBuilder() {
     return new Schema.SchemaBuilder().setSchemaName("testSchema")
-        .addSingleValueDimension(DIMENSION_1, FieldSpec.DataType.INT)
-        .addSingleValueDimension(DIMENSION_2, FieldSpec.DataType.STRING)
-        .addDateTime(TIME_COLUMN1, FieldSpec.DataType.INT, "1:DAYS:EPOCH", "1:DAYS")
-        .addDateTime(TIME_COLUMN2, FieldSpec.DataType.INT, "1:HOURS:EPOCH", "1:HOURS");
+        .addSingleValueDimension(DIMENSION_1, DataType.INT)
+        .addSingleValueDimension(DIMENSION_2, DataType.STRING)
+        .addDateTime(TIME_COLUMN1, DataType.INT, "1:DAYS:EPOCH", "1:DAYS")
+        .addDateTime(TIME_COLUMN2, DataType.INT, "1:HOURS:EPOCH", "1:HOURS");
   }
 
-  private static final Set<String> VAR_LENGTH_SET = Collections.singleton(DIMENSION_2);
-  private static final Set<String> INVERTED_INDEX_SET =
-      new HashSet<>(Arrays.asList(DIMENSION_1, DIMENSION_2, TIME_COLUMN1, TIME_COLUMN2));
+  private static final Set<String> VAR_LENGTH_SET = Set.of(DIMENSION_2);
+  private static final Set<String> INVERTED_INDEX_SET = Set.of(DIMENSION_1, DIMENSION_2, TIME_COLUMN1, TIME_COLUMN2);
 
   private static final List<String> STRING_VALUES =
-      Collections.unmodifiableList(Arrays.asList("aa", "bbb", "cc", "ddd", "ee", "fff", "gg", "hhh", "ii", "jjj"));
+      List.of("aa", "bbb", "cc", "ddd", "ee", "fff", "gg", "hhh", "ii", "jjj");
 
   @Test
   public void testSameSrcDifferentAggregations()
@@ -80,12 +77,10 @@ public class MutableSegmentImplIngestionAggregationTest {
     String m1 = "metric_MAX";
     String m2 = "metric_MIN";
 
-    Schema schema =
-        getSchemaBuilder().addMetric(m2, FieldSpec.DataType.DOUBLE).addMetric(m1, FieldSpec.DataType.DOUBLE).build();
+    Schema schema = getSchemaBuilder().addMetric(m2, DataType.DOUBLE).addMetric(m1, DataType.DOUBLE).build();
     MutableSegmentImpl mutableSegmentImpl =
-        MutableSegmentImplTestUtils.createMutableSegmentImpl(schema, new HashSet<>(Arrays.asList(m2, m1)),
-            VAR_LENGTH_SET, INVERTED_INDEX_SET,
-            Arrays.asList(new AggregationConfig(m1, "MAX(metric)"), new AggregationConfig(m2, "MIN(metric)")));
+        MutableSegmentImplTestUtils.createMutableSegmentImpl(schema, Set.of(m1, m2), VAR_LENGTH_SET, INVERTED_INDEX_SET,
+            List.of(new AggregationConfig(m1, "MAX(metric)"), new AggregationConfig(m2, "MIN(metric)")));
 
     Map<String, Double> expectedMin = new HashMap<>();
     Map<String, Double> expectedMax = new HashMap<>();
@@ -98,12 +93,13 @@ public class MutableSegmentImplIngestionAggregationTest {
               (Integer) metrics.get(0).getValue()));
     }
 
+    int numDocsIndexed = mutableSegmentImpl.getNumDocsIndexed();
     GenericRow reuse = new GenericRow();
-    for (int docId = 0; docId < expectedMax.size(); docId++) {
+    for (int docId = 0; docId < numDocsIndexed; docId++) {
       GenericRow row = mutableSegmentImpl.getRecord(docId, reuse);
       String key = buildKey(row);
-      Assert.assertEquals(row.getValue(m2), expectedMin.get(key), key);
-      Assert.assertEquals(row.getValue(m1), expectedMax.get(key), key);
+      assertEquals(row.getValue(m2), expectedMin.get(key), key);
+      assertEquals(row.getValue(m1), expectedMax.get(key), key);
     }
 
     mutableSegmentImpl.destroy();
@@ -115,12 +111,10 @@ public class MutableSegmentImplIngestionAggregationTest {
     String m1 = "sum1";
     String m2 = "sum2";
 
-    Schema schema =
-        getSchemaBuilder().addMetric(m1, FieldSpec.DataType.INT).addMetric(m2, FieldSpec.DataType.LONG).build();
+    Schema schema = getSchemaBuilder().addMetric(m1, DataType.INT).addMetric(m2, DataType.LONG).build();
     MutableSegmentImpl mutableSegmentImpl =
-        MutableSegmentImplTestUtils.createMutableSegmentImpl(schema, new HashSet<>(Arrays.asList(m2, m1)),
-            VAR_LENGTH_SET, INVERTED_INDEX_SET,
-            Arrays.asList(new AggregationConfig(m1, "SUM(metric)"), new AggregationConfig(m2, "SUM(metric_2)")));
+        MutableSegmentImplTestUtils.createMutableSegmentImpl(schema, Set.of(m1, m2), VAR_LENGTH_SET, INVERTED_INDEX_SET,
+            List.of(new AggregationConfig(m1, "SUM(metric)"), new AggregationConfig(m2, "SUM(metric_2)")));
 
     Map<String, Integer> expectedSum1 = new HashMap<>();
     Map<String, Long> expectedSum2 = new HashMap<>();
@@ -131,38 +125,44 @@ public class MutableSegmentImplIngestionAggregationTest {
           expectedSum2.getOrDefault(metrics.get(1).getKey(), 0L) + ((Integer) metrics.get(1).getValue()).longValue());
     }
 
+    int numDocsIndexed = mutableSegmentImpl.getNumDocsIndexed();
     GenericRow reuse = new GenericRow();
-    for (int docId = 0; docId < expectedSum1.size(); docId++) {
+    for (int docId = 0; docId < numDocsIndexed; docId++) {
       GenericRow row = mutableSegmentImpl.getRecord(docId, reuse);
       String key = buildKey(row);
-      Assert.assertEquals(row.getValue(m1), expectedSum1.get(key), key);
-      Assert.assertEquals(row.getValue(m2), expectedSum2.get(key), key);
+      assertEquals(row.getValue(m1), expectedSum1.get(key), key);
+      assertEquals(row.getValue(m2), expectedSum2.get(key), key);
     }
 
     mutableSegmentImpl.destroy();
   }
 
   @Test
-  public void testValuesAreNullThrowsException()
+  public void testNullValues()
       throws Exception {
     String m1 = "sum1";
 
-    Schema schema = getSchemaBuilder().addMetric(m1, FieldSpec.DataType.INT).build();
+    Schema schema = getSchemaBuilder().addMetric(m1, DataType.INT).build();
     MutableSegmentImpl mutableSegmentImpl =
-        MutableSegmentImplTestUtils.createMutableSegmentImpl(schema, Collections.singleton(m1), VAR_LENGTH_SET,
-            INVERTED_INDEX_SET, Collections.singletonList(new AggregationConfig(m1, "SUM(metric)")));
+        MutableSegmentImplTestUtils.createMutableSegmentImpl(schema, Set.of(m1), VAR_LENGTH_SET, INVERTED_INDEX_SET,
+            List.of(new AggregationConfig(m1, "SUM(metric)")));
 
     long seed = 2;
     Random random = new Random(seed);
 
-    // Generate random int to prevent overflow
-    GenericRow row = getRow(random, 1);
-    row.putValue(METRIC, null);
-    try {
+    for (int i = 0; i < NUM_ROWS; i++) {
+      GenericRow row = getRow(random, 1);
       mutableSegmentImpl.index(row, METADATA);
-      Assert.fail();
-    } catch (NullPointerException e) {
-      // expected
+    }
+
+    int numDocsIndexed = mutableSegmentImpl.getNumDocsIndexed();
+    assertTrue(numDocsIndexed < NUM_ROWS);
+
+    GenericRow reuse = new GenericRow();
+    for (int i = 0; i < numDocsIndexed; i++) {
+      GenericRow row = mutableSegmentImpl.getRecord(i, reuse);
+      String key = buildKey(row);
+      assertEquals(row.getValue(m1), 0, key);
     }
 
     mutableSegmentImpl.destroy();
@@ -173,58 +173,25 @@ public class MutableSegmentImplIngestionAggregationTest {
       throws Exception {
     String m1 = "hll1";
 
-    Schema schema = getSchemaBuilder().addMetric(m1, FieldSpec.DataType.BYTES).build();
+    Schema schema = getSchemaBuilder().addMetric(m1, DataType.BYTES).build();
     MutableSegmentImpl mutableSegmentImpl =
-        MutableSegmentImplTestUtils.createMutableSegmentImpl(schema, Collections.singleton(m1), VAR_LENGTH_SET,
-            INVERTED_INDEX_SET, Collections.singletonList(new AggregationConfig(m1, "distinctCountHLL(metric, 12)")));
+        MutableSegmentImplTestUtils.createMutableSegmentImpl(schema, Set.of(m1), VAR_LENGTH_SET, INVERTED_INDEX_SET,
+            List.of(new AggregationConfig(m1, "distinctCountHLL(metric, 12)")));
 
-    Map<String, HLLTestData> expected = new HashMap<>();
-    List<Metric> metrics = addRowsDistinctCountHLL(998, mutableSegmentImpl);
-    for (Metric metric : metrics) {
-      expected.put(metric.getKey(), (HLLTestData) metric.getValue());
-    }
+    Map<String, HyperLogLog> expectedValues = addRowsDistinctCountHLL(998, mutableSegmentImpl);
 
-    List<ExpressionContext> arguments = List.of(ExpressionContext.forLiteral(Literal.stringValue("12")));
-    DistinctCountHLLValueAggregator valueAggregator = new DistinctCountHLLValueAggregator(arguments);
+    int numDocsIndexed = mutableSegmentImpl.getNumDocsIndexed();
+    assertTrue(numDocsIndexed < NUM_ROWS);
+    assertEquals(numDocsIndexed, expectedValues.size());
 
-    Set<Integer> integers = new HashSet<>();
-
-    // Assert that the distinct count is within an error margin. We assert on the cardinality of the HLL in the docID
-    // and the HLL we made, but also on the cardinality of the HLL in the docID and the actual cardinality from the set
-    // of integers.
     GenericRow reuse = new GenericRow();
-    for (int docId = 0; docId < expected.size(); docId++) {
+    for (int docId = 0; docId < numDocsIndexed; docId++) {
       GenericRow row = mutableSegmentImpl.getRecord(docId, reuse);
-      String key = buildKey(row);
-
-      integers.addAll(expected.get(key)._integers);
-
-      HyperLogLog expectedHLL = expected.get(key)._hll;
-      HyperLogLog actualHLL = valueAggregator.deserializeAggregatedValue((byte[]) row.getValue(m1));
-
-      Assert.assertEquals(actualHLL.cardinality(), expectedHLL.cardinality(), (int) (expectedHLL.cardinality() * 0.04),
-          "The HLL cardinality from the index is within a tolerable error margin (4%) of the cardinality of the "
-              + "expected HLL.");
-      Assert.assertEquals(actualHLL.cardinality(), expected.get(key)._integers.size(),
-          expected.get(key)._integers.size() * 0.04,
-          "The HLL cardinality from the index is within a tolerable error margin (4%) of the actual cardinality of "
-              + "the integers.");
+      HyperLogLog actualHLL = CustomSerDeUtils.HYPER_LOG_LOG_SER_DE.deserialize((byte[]) row.getValue(m1));
+      HyperLogLog expectedHLL = expectedValues.get(buildKey(row));
+      assertEquals(actualHLL.cardinality(), expectedHLL.cardinality());
     }
 
-    // Assert that the aggregated HyperLogLog is also within the error margin
-    HyperLogLog togetherHLL = new HyperLogLog(12);
-    expected.forEach((key, value) -> {
-      try {
-        togetherHLL.addAll(value._hll);
-      } catch (CardinalityMergeException e) {
-        e.printStackTrace();
-        throw new RuntimeException(e);
-      }
-    });
-
-    Assert.assertEquals(togetherHLL.cardinality(), integers.size(), (int) (integers.size() * 0.04),
-        "The aggregated HLL cardinality is within a tolerable error margin (4%) of the actual cardinality of the "
-            + "integers.");
     mutableSegmentImpl.destroy();
   }
 
@@ -234,24 +201,23 @@ public class MutableSegmentImplIngestionAggregationTest {
     String m1 = "count1";
     String m2 = "count2";
 
-    Schema schema =
-        getSchemaBuilder().addMetric(m1, FieldSpec.DataType.LONG).addMetric(m2, FieldSpec.DataType.LONG).build();
+    Schema schema = getSchemaBuilder().addMetric(m1, DataType.LONG).addMetric(m2, DataType.LONG).build();
     MutableSegmentImpl mutableSegmentImpl =
-        MutableSegmentImplTestUtils.createMutableSegmentImpl(schema, new HashSet<>(Arrays.asList(m1, m2)),
-            VAR_LENGTH_SET, INVERTED_INDEX_SET,
-            Arrays.asList(new AggregationConfig(m1, "COUNT(metric)"), new AggregationConfig(m2, "COUNT(*)")));
+        MutableSegmentImplTestUtils.createMutableSegmentImpl(schema, Set.of(m1, m2), VAR_LENGTH_SET, INVERTED_INDEX_SET,
+            List.of(new AggregationConfig(m1, "COUNT(metric)"), new AggregationConfig(m2, "COUNT(*)")));
 
     Map<String, Long> expectedCount = new HashMap<>();
     for (List<Metric> metrics : addRows(3, mutableSegmentImpl)) {
       expectedCount.put(metrics.get(0).getKey(), expectedCount.getOrDefault(metrics.get(0).getKey(), 0L) + 1L);
     }
 
+    int numDocsIndexed = mutableSegmentImpl.getNumDocsIndexed();
     GenericRow reuse = new GenericRow();
-    for (int docId = 0; docId < expectedCount.size(); docId++) {
+    for (int docId = 0; docId < numDocsIndexed; docId++) {
       GenericRow row = mutableSegmentImpl.getRecord(docId, reuse);
       String key = buildKey(row);
-      Assert.assertEquals(row.getValue(m1), expectedCount.get(key), key);
-      Assert.assertEquals(row.getValue(m2), expectedCount.get(key), key);
+      assertEquals(row.getValue(m1), expectedCount.get(key), key);
+      assertEquals(row.getValue(m2), expectedCount.get(key), key);
     }
 
     mutableSegmentImpl.destroy();
@@ -262,7 +228,7 @@ public class MutableSegmentImplIngestionAggregationTest {
         TIME_COLUMN1) + KEY_SEPARATOR + row.getValue(TIME_COLUMN2);
   }
 
-  private GenericRow getRow(Random random, Integer multiplicationFactor) {
+  private GenericRow getRow(Random random, int multiplicationFactor) {
     GenericRow row = new GenericRow();
 
     row.putValue(DIMENSION_1, random.nextInt(2 * multiplicationFactor));
@@ -273,126 +239,66 @@ public class MutableSegmentImplIngestionAggregationTest {
     return row;
   }
 
-  private class HLLTestData {
-    private HyperLogLog _hll;
-    private Set<Integer> _integers;
-
-    public HLLTestData(HyperLogLog hll, Set<Integer> integers) {
-      _hll = hll;
-      _integers = integers;
-    }
-
-    public HyperLogLog getHll() {
-      return _hll;
-    }
-
-    public Set<Integer> getIntegers() {
-      return _integers;
-    }
-  }
-
-  private class Metric {
-    private final String _key;
-    private final Object _value;
+  private static class Metric {
+    final String _key;
+    final Object _value;
 
     Metric(String key, Object value) {
       _key = key;
       _value = value;
     }
 
-    public String getKey() {
+    String getKey() {
       return _key;
     }
 
-    public Object getValue() {
+    Object getValue() {
       return _value;
     }
   }
 
-  private List<Metric> addRowsDistinctCountHLL(long seed, MutableSegmentImpl mutableSegmentImpl)
+  private Map<String, HyperLogLog> addRowsDistinctCountHLL(long seed, MutableSegmentImpl mutableSegmentImpl)
       throws Exception {
-    List<Metric> metrics = new ArrayList<>();
+    Map<String, HyperLogLog> valueMap = new HashMap<>();
 
     Random random = new Random(seed);
-
-    HashMap<String, HyperLogLog> hllMap = new HashMap<>();
-    HashMap<String, Set<Integer>> distinctMap = new HashMap<>();
-
-    Integer rows = 500000;
-
-    for (int i = 0; i < (rows); i++) {
+    for (int i = 0; i < NUM_ROWS; i++) {
       GenericRow row = getRow(random, 1);
       String key = buildKey(row);
 
       int metricValue = random.nextInt(5000000);
       row.putValue(METRIC, metricValue);
-
-      if (hllMap.containsKey(key)) {
-        hllMap.get(key).offer(row.getValue(METRIC));
-        distinctMap.get(key).add(metricValue);
-      } else {
-        HyperLogLog hll = new HyperLogLog(12);
-        hll.offer(row.getValue(METRIC));
-        hllMap.put(key, hll);
-        distinctMap.put(key, new HashSet<>(metricValue));
-      }
-
       mutableSegmentImpl.index(row, METADATA);
+
+      valueMap.computeIfAbsent(key, k -> new HyperLogLog(12)).offer(metricValue);
     }
 
-    distinctMap.forEach(
-        (key, value) -> metrics.add(new Metric(key, new HLLTestData(hllMap.get(key), distinctMap.get(key)))));
-
-    int numDocsIndexed = mutableSegmentImpl.getNumDocsIndexed();
-    Assert.assertEquals(numDocsIndexed, hllMap.keySet().size());
-
-    // Assert that aggregation happened.
-    Assert.assertTrue(numDocsIndexed < NUM_ROWS);
-
-    return metrics;
+    return valueMap;
   }
 
-  private List<Metric> addRowsSumPrecision(long seed, MutableSegmentImpl mutableSegmentImpl)
+  private Map<String, BigDecimal> addRowsSumPrecision(long seed, MutableSegmentImpl mutableSegmentImpl)
       throws Exception {
-    List<Metric> metrics = new ArrayList<>();
+    Map<String, BigDecimal> valueMap = new HashMap<>();
 
     Random random = new Random(seed);
-
-    HashMap<String, BigDecimal> bdMap = new HashMap<>();
-    HashMap<String, ArrayList<BigDecimal>> bdIndividualMap = new HashMap<>();
-
-    int numRows = 50000;
-    for (int i = 0; i < numRows; i++) {
+    for (int i = 0; i < NUM_ROWS; i++) {
       GenericRow row = getRow(random, 1);
       String key = buildKey(row);
 
       BigDecimal metricValue = generateRandomBigDecimal(random, 5, 6);
-      row.putValue(METRIC, metricValue.toString());
-
-      if (bdMap.containsKey(key)) {
-        bdMap.put(key, bdMap.get(key).add(metricValue));
-        bdIndividualMap.get(key).add(metricValue);
-      } else {
-        bdMap.put(key, metricValue);
-        ArrayList<BigDecimal> bdList = new ArrayList<>();
-        bdList.add(metricValue);
-        bdIndividualMap.put(key, bdList);
-      }
-
+      row.putValue(METRIC, metricValue);
       mutableSegmentImpl.index(row, METADATA);
+
+      valueMap.compute(key, (k, v) -> {
+        if (v == null) {
+          return metricValue;
+        } else {
+          return v.add(metricValue);
+        }
+      });
     }
 
-    for (String key : bdMap.keySet()) {
-      metrics.add(new Metric(key, bdMap.get(key)));
-    }
-
-    int numDocsIndexed = mutableSegmentImpl.getNumDocsIndexed();
-    Assert.assertEquals(numDocsIndexed, bdMap.keySet().size());
-
-    // Assert that aggregation happened.
-    Assert.assertTrue(numDocsIndexed < NUM_ROWS);
-
-    return metrics;
+    return valueMap;
   }
 
   private List<List<Metric>> addRows(long seed, MutableSegmentImpl mutableSegmentImpl)
@@ -403,7 +309,6 @@ public class MutableSegmentImplIngestionAggregationTest {
     Random random = new Random(seed);
 
     for (int i = 0; i < NUM_ROWS; i++) {
-      // Generate random int to prevent overflow
       GenericRow row = getRow(random, 1);
       Integer metricValue = random.nextInt(10000);
       Integer metric2Value = random.nextInt();
@@ -413,15 +318,15 @@ public class MutableSegmentImplIngestionAggregationTest {
       mutableSegmentImpl.index(row, METADATA);
 
       String key = buildKey(row);
-      metrics.add(Arrays.asList(new Metric(key, metricValue), new Metric(key, metric2Value)));
+      metrics.add(List.of(new Metric(key, metricValue), new Metric(key, metric2Value)));
       keys.add(key);
     }
 
     int numDocsIndexed = mutableSegmentImpl.getNumDocsIndexed();
-    Assert.assertEquals(numDocsIndexed, keys.size());
+    assertEquals(numDocsIndexed, keys.size());
 
     // Assert that aggregation happened.
-    Assert.assertTrue(numDocsIndexed < NUM_ROWS);
+    assertTrue(numDocsIndexed < NUM_ROWS);
 
     return metrics;
   }
@@ -430,70 +335,61 @@ public class MutableSegmentImplIngestionAggregationTest {
   public void testSumPrecision()
       throws Exception {
     String m1 = "sumPrecision1";
-    Schema schema = getSchemaBuilder().addMetric(m1, FieldSpec.DataType.BIG_DECIMAL).build();
+    Schema schema = getSchemaBuilder().addMetric(m1, DataType.BIG_DECIMAL).build();
 
     MutableSegmentImpl mutableSegmentImpl =
-        MutableSegmentImplTestUtils.createMutableSegmentImpl(schema, Collections.singleton(m1), VAR_LENGTH_SET,
-            INVERTED_INDEX_SET,
+        MutableSegmentImplTestUtils.createMutableSegmentImpl(schema, Set.of(m1), VAR_LENGTH_SET, INVERTED_INDEX_SET,
             // Setting precision to 38 in the arguments for SUM_PRECISION
-            Collections.singletonList(new AggregationConfig(m1, "SUM_PRECISION(metric, 38)")));
+            List.of(new AggregationConfig(m1, "SUM_PRECISION(metric, 38)")));
 
-    Map<String, BigDecimal> expected = new HashMap<>();
-    List<Metric> metrics = addRowsSumPrecision(998, mutableSegmentImpl);
-    for (Metric metric : metrics) {
-      expected.put(metric.getKey(), (BigDecimal) metric.getValue());
-    }
+    Map<String, BigDecimal> expectedValues = addRowsSumPrecision(998, mutableSegmentImpl);
 
-    // Assert that the aggregated values are correct
+    int numDocsIndexed = mutableSegmentImpl.getNumDocsIndexed();
+    assertTrue(numDocsIndexed < NUM_ROWS);
+    assertEquals(numDocsIndexed, expectedValues.size());
+
     GenericRow reuse = new GenericRow();
-    for (int docId = 0; docId < expected.size(); docId++) {
+    for (int docId = 0; docId < numDocsIndexed; docId++) {
       GenericRow row = mutableSegmentImpl.getRecord(docId, reuse);
-      String key = buildKey(row);
-
-      BigDecimal expectedBigDecimal = expected.get(key);
       BigDecimal actualBigDecimal = (BigDecimal) row.getValue(m1);
-
-      Assert.assertEquals(actualBigDecimal, expectedBigDecimal, "The aggregated SUM does not match the expected SUM");
+      BigDecimal expectedBigDecimal = expectedValues.get(buildKey(row));
+      assertEquals(actualBigDecimal, expectedBigDecimal);
     }
+
     mutableSegmentImpl.destroy();
   }
 
   @Test
   public void testBigDecimalTooBig() {
     String m1 = "sumPrecision1";
-    Schema schema = getSchemaBuilder().addMetric(m1, FieldSpec.DataType.BIG_DECIMAL).build();
+    Schema schema = getSchemaBuilder().addMetric(m1, DataType.BIG_DECIMAL).build();
 
     int seed = 1;
     Random random = new Random(seed);
 
     MutableSegmentImpl mutableSegmentImpl =
-        MutableSegmentImplTestUtils.createMutableSegmentImpl(schema, Collections.singleton(m1), VAR_LENGTH_SET,
-            INVERTED_INDEX_SET, Collections.singletonList(new AggregationConfig(m1, "SUM_PRECISION(metric, 3)")));
+        MutableSegmentImplTestUtils.createMutableSegmentImpl(schema, Set.of(m1), VAR_LENGTH_SET, INVERTED_INDEX_SET,
+            List.of(new AggregationConfig(m1, "SUM_PRECISION(metric, 3)")));
 
     // Make a big decimal larger than 3 precision and try to index it
     BigDecimal large = BigDecimalUtils.generateMaximumNumberWithPrecision(5);
     GenericRow row = getRow(random, 1);
 
     row.putValue("metric", large);
-    Assert.assertThrows(IllegalArgumentException.class, () -> {
+    assertThrows(IllegalArgumentException.class, () -> {
       mutableSegmentImpl.index(row, METADATA);
     });
 
     mutableSegmentImpl.destroy();
   }
 
-  private BigDecimal generateRandomBigDecimal(Random random, int maxPrecision, int scale) {
+  private static BigDecimal generateRandomBigDecimal(Random random, int maxPrecision, int scale) {
     int precision = 1 + random.nextInt(maxPrecision);
-
-    String s = "";
+    StringBuilder stringBuilder = new StringBuilder();
     for (int i = 0; i < precision; i++) {
-      s = s + (1 + random.nextInt(9));
+      stringBuilder.append(1 + random.nextInt(9));
     }
-
-    if ((1 + random.nextInt(2)) == 1) {
-      return (new BigDecimal(s).setScale(scale)).negate();
-    } else {
-      return new BigDecimal(s).setScale(scale);
-    }
+    BigDecimal bigDecimal = new BigDecimal(stringBuilder.toString()).setScale(scale, RoundingMode.UNNECESSARY);
+    return random.nextBoolean() ? bigDecimal : bigDecimal.negate();
   }
 }


### PR DESCRIPTION
- Handle `null` raw value in `ValueAggregator`. Ingestion aggregation might introduce `null` raw value when the column is not specified in the schema. (See more details in #16317)
- Introduce a systematic way to determine whether the aggregated value is of fixed size. Ingestion aggregation can be enabled only when the aggregated value is of fixed size.
- This also fix the bug where several supported aggregations are not allowed in ingestion aggregation: `AVG`, `MIN_MAX_RANGE`, `DISTINCT_COUNT_ULL`, `DISTINCT_COUNT_TUPLE_SKETCH`, `DISTINCT_COUNT_CPC_SKETCH`