### PR TITLE
Parse booleans for optimizeMaxInitialResultHolder once

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/InstancePlanMakerImplV2.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/InstancePlanMakerImplV2.java
@@ -285,6 +285,10 @@ public class InstancePlanMakerImplV2 implements PlanMaker {
       } else {
         queryContext.setGroupTrimThreshold(_groupByTrimThreshold);
       }
+      // Set optimizeMaxInitialResultHolderCapacity
+      boolean optimizeMaxInitialResultHolderCapacity =
+          QueryOptionsUtils.optimizeMaxInitialResultHolderCapacityEnabled(queryOptions);
+      queryContext.setOptimizeMaxInitialResultHolderCapacity(optimizeMaxInitialResultHolderCapacity);
       // Set numThreadsExtractFinalResult
       Integer numThreadsExtractFinalResult = QueryOptionsUtils.getNumThreadsExtractFinalResult(queryOptions);
       if (numThreadsExtractFinalResult != null) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/DefaultGroupByExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/DefaultGroupByExecutor.java
@@ -28,7 +28,6 @@ import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.FilterContext;
 import org.apache.pinot.common.request.context.predicate.InPredicate;
 import org.apache.pinot.common.request.context.predicate.Predicate;
-import org.apache.pinot.common.utils.config.QueryOptionsUtils;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.data.table.IntermediateRecord;
 import org.apache.pinot.core.data.table.TableResizer;
@@ -96,8 +95,7 @@ public class DefaultGroupByExecutor implements GroupByExecutor {
     int numGroupsLimit = queryContext.getNumGroupsLimit();
     int maxInitialResultHolderCapacity = queryContext.getMaxInitialResultHolderCapacity();
     Map<ExpressionContext, Integer> groupByExpressionSizesFromPredicates = null;
-    if (queryContext.getQueryOptions() != null
-        && QueryOptionsUtils.optimizeMaxInitialResultHolderCapacityEnabled(queryContext.getQueryOptions())) {
+    if (queryContext.isOptimizeMaxInitialResultHolderCapacity()) {
       groupByExpressionSizesFromPredicates = getGroupByExpressionSizesFromPredicates(queryContext);
     }
     if (groupKeyGenerator != null) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/QueryContext.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/QueryContext.java
@@ -128,6 +128,7 @@ public class QueryContext {
   private int _minServerGroupTrimSize = Server.DEFAULT_QUERY_EXECUTOR_MIN_SERVER_GROUP_TRIM_SIZE;
   // Trim threshold to use for server combine for SQL GROUP BY
   private int _groupTrimThreshold = Server.DEFAULT_QUERY_EXECUTOR_GROUPBY_TRIM_THRESHOLD;
+  private boolean _optimizeMaxInitialResultHolderCapacity;
   // Number of threads to use for final reduce
   private int _numThreadsExtractFinalResult = InstancePlanMakerImplV2.DEFAULT_NUM_THREADS_EXTRACT_FINAL_RESULT;
   // Parallel chunk size for final reduce
@@ -455,6 +456,15 @@ public class QueryContext {
   public void setGroupTrimThreshold(int groupTrimThreshold) {
     _groupTrimThreshold = groupTrimThreshold;
   }
+
+  public boolean isOptimizeMaxInitialResultHolderCapacity() {
+    return _optimizeMaxInitialResultHolderCapacity;
+  }
+
+  public void setOptimizeMaxInitialResultHolderCapacity(boolean optimizeMaxInitialResultHolderCapacity) {
+    _optimizeMaxInitialResultHolderCapacity = optimizeMaxInitialResultHolderCapacity;
+  }
+
 
   public int getNumThreadsExtractFinalResult() {
     return _numThreadsExtractFinalResult;

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/groupby/DictionaryBasedGroupKeyGeneratorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/groupby/DictionaryBasedGroupKeyGeneratorTest.java
@@ -430,8 +430,8 @@ public class DictionaryBasedGroupKeyGeneratorTest {
 
   @Test(dataProvider = "groupByResultHolderCapacityDataProvider")
   public void testGetGroupByResultHolderCapacity(String query, Integer expectedCapacity) {
-    query = query + "SET optimizeMaxInitialResultHolderCapacity=true";
     QueryContext queryContext = QueryContextConverterUtils.getQueryContext(query);
+    queryContext.setOptimizeMaxInitialResultHolderCapacity(true);
     List<ExpressionContext> expressionContextList = queryContext.getGroupByExpressions();
     ExpressionContext[] expressions =
         expressionContextList.toArray(new ExpressionContext[expressionContextList.size()]);


### PR DESCRIPTION
Parsing booleans in `DefaultGroupByExecutor` shows up as a hotspot for one usecase using this feature...

<img width="931" height="724" alt="Screenshot 2025-08-08 at 11 32 15 AM" src="https://github.com/user-attachments/assets/f9f561d0-9ff9-40cf-acb4-61cc4ddd0266" />

Move the parsing to happen only once per query instead of once per block