### PR TITLE
Making LIKE predicate case in-sensitive.

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/regexp/RegexpLikeConstFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/regexp/RegexpLikeConstFunctions.java
@@ -54,7 +54,7 @@ public class RegexpLikeConstFunctions {
   public boolean like(String inputStr, String likePatternStr) {
     if (_matcher == null) {
       String regexPatternStr = RegexpPatternConverterUtils.likeToRegexpLike(likePatternStr);
-      _matcher = PatternFactory.compile(regexPatternStr).matcher("");
+      _matcher = PatternFactory.compile(regexPatternStr, true).matcher("");
     }
 
     return _matcher.reset(inputStr).find();

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/regexp/RegexpLikeVarFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/regexp/RegexpLikeVarFunctions.java
@@ -45,6 +45,6 @@ public class RegexpLikeVarFunctions {
   @ScalarFunction
   public static boolean likeVar(String inputStr, String likePatternStr) {
     String regexPatternStr = RegexpPatternConverterUtils.likeToRegexpLike(likePatternStr);
-    return regexpLikeVar(inputStr, regexPatternStr);
+    return PatternFactory.compile(regexPatternStr, true).matcher(inputStr).find(); // Case insensitive by default
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/request/context/RequestContextUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/request/context/RequestContextUtils.java
@@ -242,7 +242,7 @@ public class RequestContextUtils {
 
       case LIKE:
         return FilterContext.forPredicate(new RegexpLikePredicate(getExpression(operands.get(0)),
-            RegexpPatternConverterUtils.likeToRegexpLike(getStringValue(operands.get(1)))));
+            RegexpPatternConverterUtils.likeToRegexpLike(getStringValue(operands.get(1))), "i"));
       case TEXT_CONTAINS:
         return FilterContext.forPredicate(
             new TextContainsPredicate(getExpression(operands.get(0)), getStringValue(operands.get(1))));
@@ -418,7 +418,7 @@ public class RequestContextUtils {
         }
       case LIKE:
         return FilterContext.forPredicate(new RegexpLikePredicate(operands.get(0),
-            RegexpPatternConverterUtils.likeToRegexpLike(getStringValue(operands.get(1)))));
+            RegexpPatternConverterUtils.likeToRegexpLike(getStringValue(operands.get(1))), "i"));
       case TEXT_CONTAINS:
         return FilterContext.forPredicate(new TextContainsPredicate(operands.get(0), getStringValue(operands.get(1))));
       case TEXT_MATCH:


### PR DESCRIPTION
The [PR](https://github.com/apache/pinot/commit/d9e06d0697f1315f8223af05e9ed3b430b329d2b) modified the LIKE behavior to be case sensitive whereas previously it was case insensitive. 
the change reverts the LIKE to be case insensitive again. 