### PR TITLE
Enhance LeafOperator

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/datatable/StatMap.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/datatable/StatMap.java
@@ -58,6 +58,7 @@ public class StatMap<K extends Enum<K> & StatMap.Key> {
   public StatMap(Class<K> keyClass) {
     _keyClass = keyClass;
     // TODO: Study whether this is fine or we should impose a single thread policy in StatMaps
+    // TODO: We might need to synchronize the methods because some methods access the map multiple times
     _map = Collections.synchronizedMap(new EnumMap<>(keyClass));
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
@@ -88,7 +88,6 @@ import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.CommonConstants.Broker.Request.QueryOptionKey;
 import org.apache.pinot.spi.utils.CommonConstants.MultiStageQueryRunner.JoinOverFlowMode;
 import org.apache.pinot.spi.utils.CommonConstants.MultiStageQueryRunner.WindowOverFlowMode;
-import org.apache.pinot.spi.utils.CommonConstants.Query.Request.MetadataKeys;
 import org.apache.pinot.spi.utils.CommonConstants.Server;
 import org.apache.pinot.sql.parsers.rewriter.RlsUtils;
 import org.apache.pinot.tsdb.planner.TimeSeriesPlanConstants.WorkerRequestMetadataKeys;
@@ -532,9 +531,6 @@ public class QueryRunner {
       LOGGER.debug("Explain query on intermediate stages is a NOOP");
       return stagePlan;
     }
-    long requestId = Long.parseLong(requestMetadata.get(MetadataKeys.REQUEST_ID));
-    long timeoutMs = Long.parseLong(requestMetadata.get(QueryOptionKey.TIMEOUT_MS));
-    long deadlineMs = System.currentTimeMillis() + timeoutMs;
 
     StageMetadata stageMetadata = stagePlan.getStageMetadata();
     Map<String, String> opChainMetadata = consolidateMetadata(stageMetadata.getCustomProperties(), requestMetadata);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/server/QueryServer.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/server/QueryServer.java
@@ -33,7 +33,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import java.util.function.BiFunction;
 import javax.annotation.Nullable;
 import org.apache.commons.io.output.UnsynchronizedByteArrayOutputStream;
 import org.apache.pinot.common.config.TlsConfig;
@@ -357,10 +356,6 @@ public class QueryServer extends PinotQueryWorkerGrpc.PinotQueryWorkerImplBase {
     try (QueryThreadContext.CloseableContext qTlClosable
         = QueryThreadContext.openFromRequestMetadata(_instanceId, reqMetadata);
         QueryThreadContext.CloseableContext mseTlCloseable = MseWorkerThreadContext.open()) {
-      // Explain the stage for each worker
-      BiFunction<StagePlan, WorkerMetadata, StagePlan> explainFun = (stagePlan, workerMetadata) ->
-          _queryRunner.explainQuery(workerMetadata, stagePlan, reqMetadata);
-
       List<Worker.StagePlan> protoStagePlans = request.getStagePlanList();
 
       for (Worker.StagePlan protoStagePlan : protoStagePlans) {

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/OperatorTestUtil.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/OperatorTestUtil.java
@@ -18,8 +18,6 @@
  */
 package org.apache.pinot.query.runtime.operator;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
@@ -28,6 +26,7 @@ import org.apache.pinot.common.datatable.StatMap;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.query.mailbox.MailboxService;
 import org.apache.pinot.query.mailbox.ReceivingMailbox;
+import org.apache.pinot.query.planner.physical.DispatchablePlanFragment;
 import org.apache.pinot.query.routing.StageMetadata;
 import org.apache.pinot.query.routing.StagePlan;
 import org.apache.pinot.query.routing.WorkerMetadata;
@@ -48,9 +47,10 @@ import static org.mockito.Mockito.when;
 
 public class OperatorTestUtil {
   // simple key-value collision schema/data test set: "Aa" and "BB" have same hash code in java.
-  private static final List<List<Object[]>> SIMPLE_KV_DATA_ROWS =
-      ImmutableList.of(ImmutableList.of(new Object[]{1, "Aa"}, new Object[]{2, "BB"}, new Object[]{3, "BB"}),
-          ImmutableList.of(new Object[]{1, "AA"}, new Object[]{2, "Aa"}));
+  private static final List<List<Object[]>> SIMPLE_KV_DATA_ROWS = List.of(
+      List.of(new Object[]{1, "Aa"}, new Object[]{2, "BB"}, new Object[]{3, "BB"}),
+      List.of(new Object[]{1, "AA"}, new Object[]{2, "Aa"})
+  );
   private static final MockDataBlockOperatorFactory MOCK_OPERATOR_FACTORY;
 
   public static final DataSchema SIMPLE_KV_DATA_SCHEMA = new DataSchema(new String[]{"foo", "bar"},
@@ -61,14 +61,14 @@ public class OperatorTestUtil {
 
   public static MultiStageQueryStats getDummyStats(int stageId) {
     MultiStageQueryStats stats = MultiStageQueryStats.emptyStats(stageId);
-    stats.getCurrentStats()
-        .addLastOperator(MultiStageOperator.Type.LEAF, new StatMap<>(LeafOperator.StatKey.class));
+    stats.getCurrentStats().addLastOperator(MultiStageOperator.Type.LEAF, new StatMap<>(LeafOperator.StatKey.class));
     return stats;
   }
 
   static {
     MOCK_OPERATOR_FACTORY = new MockDataBlockOperatorFactory().registerOperator(OP_1, SIMPLE_KV_DATA_SCHEMA)
-        .registerOperator(OP_2, SIMPLE_KV_DATA_SCHEMA).addRows(OP_1, SIMPLE_KV_DATA_ROWS.get(0))
+        .registerOperator(OP_2, SIMPLE_KV_DATA_SCHEMA)
+        .addRows(OP_1, SIMPLE_KV_DATA_ROWS.get(0))
         .addRows(OP_2, SIMPLE_KV_DATA_ROWS.get(1));
   }
 
@@ -109,12 +109,12 @@ public class OperatorTestUtil {
 
   public static OpChainExecutionContext getOpChainContext(MailboxService mailboxService, long deadlineMs,
       StageMetadata stageMetadata) {
-    return new OpChainExecutionContext(mailboxService, 0, deadlineMs, ImmutableMap.of(), stageMetadata,
+    return new OpChainExecutionContext(mailboxService, 0, deadlineMs, Map.of(), stageMetadata,
         stageMetadata.getWorkerMetadataList().get(0), null, null, true);
   }
 
   public static OpChainExecutionContext getTracingContext() {
-    return getTracingContext(ImmutableMap.of(CommonConstants.Broker.Request.TRACE, "true"));
+    return getTracingContext(Map.of(CommonConstants.Broker.Request.TRACE, "true"));
   }
 
   public static OpChainExecutionContext getContext(Map<String, String> opChainMetadata) {
@@ -122,22 +122,23 @@ public class OperatorTestUtil {
   }
 
   public static OpChainExecutionContext getNoTracingContext() {
-    return getTracingContext(ImmutableMap.of());
+    return getTracingContext(Map.of());
   }
 
   private static OpChainExecutionContext getTracingContext(Map<String, String> opChainMetadata) {
     MailboxService mailboxService = mock(MailboxService.class);
     when(mailboxService.getHostname()).thenReturn("localhost");
     when(mailboxService.getPort()).thenReturn(1234);
-    WorkerMetadata workerMetadata = new WorkerMetadata(0, ImmutableMap.of(), ImmutableMap.of());
-    StageMetadata stageMetadata = new StageMetadata(0, ImmutableList.of(workerMetadata), ImmutableMap.of());
-    OpChainExecutionContext opChainExecutionContext = new OpChainExecutionContext(mailboxService, 123L, Long.MAX_VALUE,
-        opChainMetadata, stageMetadata, workerMetadata, null, null, true);
+    WorkerMetadata workerMetadata = new WorkerMetadata(0, Map.of(), Map.of());
+    StageMetadata stageMetadata =
+        new StageMetadata(0, List.of(workerMetadata), Map.of(DispatchablePlanFragment.TABLE_NAME_KEY, "testTable"));
+    OpChainExecutionContext opChainExecutionContext =
+        new OpChainExecutionContext(mailboxService, 123L, Long.MAX_VALUE, opChainMetadata, stageMetadata,
+            workerMetadata, null, null, true);
 
     StagePlan stagePlan = new StagePlan(null, stageMetadata);
 
-    opChainExecutionContext.setLeafStageContext(
-        new ServerPlanRequestContext(stagePlan, null, null, null));
+    opChainExecutionContext.setLeafStageContext(new ServerPlanRequestContext(stagePlan, null, null, null));
     return opChainExecutionContext;
   }
 


### PR DESCRIPTION
# Enhance LeafOperator: robustness, cancellation, modernization

## Summary
- Avoids blocking on adding the last results block when query is cancelled- Improves error handling and resource cleanup in `LeafOperator`
- Adds cooperative cancellation to stop execution promptly and safely
- Replaces Guava collections with Java standard library equivalents
- Modernizes code style; removes unused variables and dead code

## Details
- **Thread-safety**: guards shared state and cancellation flags; ensures `close()` pathways run exactly once
- **Resource management**: uses try-with-resources where applicable; guarantees cleanup on success/failure
- **Error handling**: preserves root causes with context; avoids swallowing exceptions

## Tests
- Updates `LeafOperatorTest` assertions and adds a new cancellation test
- Updates `OperatorTestUtil` to use JDK collections and include table name metadata

## Backward compatibility
- No public API changes; observable behavior unchanged except faster cancellation and clearer error messages

## Risk and performance
- Risk: medium (concurrency and cleanup paths). Covered by unit tests; no regressions observed locally.

## Misc cleanup
- Removes unused variables in `QueryServer` and `QueryRunner`
- Notes synchronization needs in `StatMap`

