### PR TITLE
Pass QueryContext to ProjectionOperator

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/ProjectionOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/ProjectionOperator.java
@@ -31,26 +31,29 @@ import org.apache.pinot.core.common.DataFetcher;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.operator.blocks.DocIdSetBlock;
 import org.apache.pinot.core.operator.blocks.ProjectionBlock;
+import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.spi.trace.Tracing;
 
 
 public class ProjectionOperator extends BaseProjectOperator<ProjectionBlock> implements AutoCloseable {
-  private static final String EXPLAIN_NAME = "PROJECT";
+  protected static final String EXPLAIN_NAME = "PROJECT";
 
-  private final Map<String, DataSource> _dataSourceMap;
-  private final BaseOperator<DocIdSetBlock> _docIdSetOperator;
-  private final DataBlockCache _dataBlockCache;
-  private final Map<String, ColumnContext> _columnContextMap;
+  protected final Map<String, DataSource> _dataSourceMap;
+  protected final BaseOperator<DocIdSetBlock> _docIdSetOperator;
+  protected final DataBlockCache _dataBlockCache;
+  protected final Map<String, ColumnContext> _columnContextMap;
+  protected final QueryContext _queryContext;
 
   public ProjectionOperator(Map<String, DataSource> dataSourceMap,
-      @Nullable BaseOperator<DocIdSetBlock> docIdSetOperator) {
+      @Nullable BaseOperator<DocIdSetBlock> docIdSetOperator, QueryContext queryContext) {
     _dataSourceMap = dataSourceMap;
     _docIdSetOperator = docIdSetOperator;
     _dataBlockCache = new DataBlockCache(new DataFetcher(dataSourceMap));
     _columnContextMap = new HashMap<>(HashUtil.getHashMapCapacity(dataSourceMap.size()));
     dataSourceMap.forEach(
         (column, dataSource) -> _columnContextMap.put(column, ColumnContext.fromDataSource(dataSource)));
+    _queryContext = queryContext;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/ProjectionOperatorUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/ProjectionOperatorUtils.java
@@ -21,6 +21,7 @@ package org.apache.pinot.core.operator;
 import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.pinot.core.operator.blocks.DocIdSetBlock;
+import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.segment.spi.datasource.DataSource;
 
 
@@ -35,8 +36,8 @@ public class ProjectionOperatorUtils {
   }
 
   public static ProjectionOperator getProjectionOperator(Map<String, DataSource> dataSourceMap,
-      @Nullable BaseOperator<DocIdSetBlock> docIdSetOperator) {
-    return _instance.getProjectionOperator(dataSourceMap, docIdSetOperator);
+      @Nullable BaseOperator<DocIdSetBlock> docIdSetOperator, QueryContext queryContext) {
+    return _instance.getProjectionOperator(dataSourceMap, docIdSetOperator, queryContext);
   }
 
   public interface Implementation {
@@ -44,14 +45,14 @@ public class ProjectionOperatorUtils {
      * Returns the projection operator
      */
     ProjectionOperator getProjectionOperator(Map<String, DataSource> dataSourceMap,
-        @Nullable BaseOperator<DocIdSetBlock> docIdSetOperator);
+        @Nullable BaseOperator<DocIdSetBlock> docIdSetOperator, QueryContext queryContext);
   }
 
   public static class DefaultImplementation implements Implementation {
     @Override
     public ProjectionOperator getProjectionOperator(Map<String, DataSource> dataSourceMap,
-        @Nullable BaseOperator<DocIdSetBlock> docIdSetOperator) {
-      return new ProjectionOperator(dataSourceMap, docIdSetOperator);
+        @Nullable BaseOperator<DocIdSetBlock> docIdSetOperator, QueryContext queryContext) {
+      return new ProjectionOperator(dataSourceMap, docIdSetOperator, queryContext);
     }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/ExpressionDocIdSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/ExpressionDocIdSet.java
@@ -24,6 +24,7 @@ import org.apache.pinot.core.common.BlockDocIdSet;
 import org.apache.pinot.core.operator.dociditerators.ExpressionScanDocIdIterator;
 import org.apache.pinot.core.operator.filter.predicate.PredicateEvaluator;
 import org.apache.pinot.core.operator.transform.function.TransformFunction;
+import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.segment.spi.datasource.DataSource;
 
 
@@ -31,10 +32,10 @@ public final class ExpressionDocIdSet implements BlockDocIdSet {
   private final ExpressionScanDocIdIterator _docIdIterator;
 
   public ExpressionDocIdSet(TransformFunction transformFunction, @Nullable PredicateEvaluator predicateEvaluator,
-      Map<String, DataSource> dataSourceMap, int numDocs, boolean nullHandlingEnabled,
-      ExpressionScanDocIdIterator.PredicateEvaluationResult predicateEvaluationResult) {
+      Map<String, DataSource> dataSourceMap, int numDocs,
+      ExpressionScanDocIdIterator.PredicateEvaluationResult predicateEvaluationResult, QueryContext queryContext) {
     _docIdIterator = new ExpressionScanDocIdIterator(transformFunction, predicateEvaluator, dataSourceMap, numDocs,
-        nullHandlingEnabled, predicateEvaluationResult);
+        predicateEvaluationResult, queryContext);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/ExpressionFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/ExpressionFilterOperator.java
@@ -87,14 +87,14 @@ public class ExpressionFilterOperator extends BaseFilterOperator {
       return new NotDocIdSet(getNulls(), _numDocs);
     } else {
       return new ExpressionDocIdSet(_transformFunction, _predicateEvaluator, _dataSourceMap, _numDocs,
-          _queryContext.isNullHandlingEnabled(), ExpressionScanDocIdIterator.PredicateEvaluationResult.TRUE);
+          ExpressionScanDocIdIterator.PredicateEvaluationResult.TRUE, _queryContext);
     }
   }
 
   @Override
   protected BlockDocIdSet getNulls() {
     return new ExpressionDocIdSet(_transformFunction, null, _dataSourceMap, _numDocs,
-        _queryContext.isNullHandlingEnabled(), ExpressionScanDocIdIterator.PredicateEvaluationResult.NULL);
+        ExpressionScanDocIdIterator.PredicateEvaluationResult.NULL, _queryContext);
   }
 
   @Override
@@ -105,7 +105,7 @@ public class ExpressionFilterOperator extends BaseFilterOperator {
       return getNulls();
     } else {
       return new ExpressionDocIdSet(_transformFunction, _predicateEvaluator, _dataSourceMap, _numDocs,
-          _queryContext.isNullHandlingEnabled(), ExpressionScanDocIdIterator.PredicateEvaluationResult.FALSE);
+          ExpressionScanDocIdIterator.PredicateEvaluationResult.FALSE, _queryContext);
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/SelectionOrderByOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/SelectionOrderByOperator.java
@@ -283,7 +283,8 @@ public class SelectionOrderByOperator extends BaseOperator<SelectionResultsBlock
     }
 
     try (ProjectionOperator projectionOperator =
-        ProjectionOperatorUtils.getProjectionOperator(dataSourceMap, new BitmapDocIdSetOperator(docIds, numRows))) {
+        ProjectionOperatorUtils.getProjectionOperator(dataSourceMap, new BitmapDocIdSetOperator(docIds, numRows),
+            _queryContext)) {
       TransformOperator transformOperator =
           new TransformOperator(_queryContext, projectionOperator, nonOrderByExpressions);
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/ProjectPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/ProjectPlanNode.java
@@ -84,7 +84,7 @@ public class ProjectPlanNode implements PlanNode {
 
     // TODO: figure out a way to close this operator, as it may hold reader context
     ProjectionOperator projectionOperator =
-        ProjectionOperatorUtils.getProjectionOperator(dataSourceMap, docIdSetOperator);
+        ProjectionOperatorUtils.getProjectionOperator(dataSourceMap, docIdSetOperator, _queryContext);
     return hasNonIdentifierExpression ? new TransformOperator(_queryContext, projectionOperator, _expressions)
         : projectionOperator;
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/startree/plan/StarTreeProjectPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/startree/plan/StarTreeProjectPlanNode.java
@@ -84,7 +84,7 @@ public class StarTreeProjectPlanNode implements PlanNode {
 
     // TODO: figure out a way to close this operator, as it may hold reader context
     ProjectionOperator projectionOperator =
-        ProjectionOperatorUtils.getProjectionOperator(dataSourceMap, docIdSetOperator);
+        ProjectionOperatorUtils.getProjectionOperator(dataSourceMap, docIdSetOperator, _queryContext);
     // NOTE: Here we do not put aggregation expressions into TransformOperator based on the following assumptions:
     //       - They are all columns (not functions or constants), where no transform is required
     //       - We never call TransformOperator.getResultColumnContext() on them


### PR DESCRIPTION
In certain ProjectionOperator plugins, we may need to use QueryContext to enable or disable specific behaviors based on per-query options. To support this, we pass the QueryContext into ProjectionOperator, allowing derived classes to access it as needed.