### PR TITLE
Broker: fail fast when broker marked down; keep IdealState/ExternalView checks out of critical path

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.broker.broker.helix;
 
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.util.ArrayList;
@@ -572,7 +571,7 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
       if (StringUtils.isNotEmpty(instanceTagsConfig)) {
         for (String instanceTag : StringUtils.split(instanceTagsConfig, ',')) {
           Preconditions.checkArgument(TagNameUtils.isBrokerTag(instanceTag), "Illegal broker instance tag: %s",
-                  instanceTag);
+              instanceTag);
           instanceConfig.addTag(instanceTag);
         }
         shouldUpdateBrokerResource = true;
@@ -622,11 +621,12 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
 
     LOGGER.info("Registering service status handler");
     ServiceStatus.setServiceStatusCallback(_instanceId, new ServiceStatus.MultipleCallbackServiceStatusCallback(
-        ImmutableList.of(new ServiceStatus.IdealStateAndCurrentStateMatchServiceStatusCallback(_participantHelixManager,
+        List.of(
+            new ServiceStatus.LifecycleServiceStatusCallback(this::isStarting, this::isShuttingDown),
+            new ServiceStatus.IdealStateAndCurrentStateMatchServiceStatusCallback(_participantHelixManager,
                 _clusterName, _instanceId, resourcesToMonitor, minResourcePercentForStartup),
             new ServiceStatus.IdealStateAndExternalViewMatchServiceStatusCallback(_participantHelixManager,
-                _clusterName, _instanceId, resourcesToMonitor, minResourcePercentForStartup),
-            new ServiceStatus.LifecycleServiceStatusCallback(this::isStarting, this::isShuttingDown))));
+                _clusterName, _instanceId, resourcesToMonitor, minResourcePercentForStartup))));
   }
 
   private String getDefaultBrokerId() {


### PR DESCRIPTION
Context
- Brokers used to wait on IdealState/ExternalView convergence before reporting GOOD.
- When a broker is marked down in ZooKeeper/Helix, we want service status to reflect lifecycle immediately without blocking on heavy IS/EV scans.

Change
- In BaseBrokerStarter.registerServiceStatusHandler, register LifecycleServiceStatusCallback before Helix-based matchers so lifecycle transitions (STARTING/SHUTTING_DOWN) are reported promptly.
- Leave IdealState/CurrentState and IdealState/ExternalView matchers intact for readiness, but they no longer delay lifecycle-driven fail-fast.

Impact
- Faster and more accurate status when a broker is disabled or marked down.
- No additional work on IdealState/ExternalView during shutdown/startup.

Testing
- Compiled pinot-broker with dependencies.
- Manually verified callback order in status description during startup/shutdown.
