### PR TITLE
Controller UI: Fix subtask filter crash; add Minion Task page status filters

### DIFF
--- a/pinot-controller/src/main/resources/app/components/TaskStatusFilter.tsx
+++ b/pinot-controller/src/main/resources/app/components/TaskStatusFilter.tsx
@@ -100,7 +100,23 @@ const useStyles = makeStyles((theme) => ({
   },
 }));
 
-export type TaskStatus = 'COMPLETED' | 'RUNNING' | 'WAITING' | 'ERROR' | 'UNKNOWN' | 'DROPPED' | 'TIMED_OUT' | 'ABORTED';
+export type TaskStatus =
+  | 'COMPLETED'
+  | 'RUNNING'
+  | 'WAITING'
+  | 'ERROR'
+  | 'UNKNOWN'
+  | 'DROPPED'
+  | 'TIMED_OUT'
+  | 'ABORTED'
+  // Additional task-level statuses for Minion task page
+  | 'NOT_STARTED'
+  | 'IN_PROGRESS'
+  | 'STOPPED'
+  | 'STOPPING'
+  | 'FAILED'
+  | 'TIMING_OUT'
+  | 'FAILING';
 
 type TaskStatusFilterOption = {
   label: string;
@@ -125,6 +141,8 @@ export const getTaskStatusChipClass = (status: string, classes?: any) => {
       return classes.waiting;
     case 'ERROR':
       return classes.error;
+    case 'FAILED':
+      return classes.error;
     case 'UNKNOWN':
       return classes.unknown;
     case 'DROPPED':
@@ -132,8 +150,20 @@ export const getTaskStatusChipClass = (status: string, classes?: any) => {
     case 'TIMED_OUT':
     case 'TIMEDOUT':
       return classes.timedout;
+    case 'TIMING_OUT':
+      return classes.timedout;
     case 'ABORTED':
       return classes.aborted;
+    case 'NOT_STARTED':
+      return classes.unknown;
+    case 'IN_PROGRESS':
+      return classes.running;
+    case 'STOPPING':
+      return classes.waiting;
+    case 'STOPPED':
+      return classes.aborted;
+    case 'FAILING':
+      return classes.error;
     default:
       return '';
   }

--- a/pinot-controller/src/main/resources/app/components/useTaskListing.tsx
+++ b/pinot-controller/src/main/resources/app/components/useTaskListing.tsx
@@ -49,25 +49,30 @@ export default function useTaskListing(props) {
     }
 
     const filtered = tasks.records.filter(([_, status]) => {
-      const taskStatus = typeof status === 'object' && status !== null && 'value' in status
-        ? status.value as string
-        : status as string;
-      return taskStatus.toUpperCase() === statusFilter;
+      const rawStatus = (typeof status === 'object' && status !== null && 'value' in status)
+        ? (status as { value?: unknown }).value
+        : status;
+      const statusString = typeof rawStatus === 'string' ? rawStatus : '';
+      const normalized = statusString.toUpperCase() === 'TIMEDOUT' ? 'TIMED_OUT' : statusString.toUpperCase();
+      return normalized === statusFilter;
     });
 
     return { ...tasks, records: filtered };
   }, [tasks, statusFilter]);
 
+  // Minion task page statuses
   const statusFilterOptions = [
     { label: 'All', value: 'ALL' as const },
+    { label: 'Not Started', value: 'NOT_STARTED' as const },
+    { label: 'In Progress', value: 'IN_PROGRESS' as const },
+    { label: 'Stopped', value: 'STOPPED' as const },
+    { label: 'Stopping', value: 'STOPPING' as const },
+    { label: 'Failed', value: 'FAILED' as const },
     { label: 'Completed', value: 'COMPLETED' as const },
-    { label: 'Running', value: 'RUNNING' as const },
-    { label: 'Waiting', value: 'WAITING' as const },
-    { label: 'Error', value: 'ERROR' as const },
-    { label: 'Unknown', value: 'UNKNOWN' as const },
-    { label: 'Dropped', value: 'DROPPED' as const },
-    { label: 'Timed Out', value: 'TIMED_OUT' as const },
     { label: 'Aborted', value: 'ABORTED' as const },
+    { label: 'Timed Out', value: 'TIMED_OUT' as const },
+    { label: 'Timing Out', value: 'TIMING_OUT' as const },
+    { label: 'Failing', value: 'FAILING' as const },
   ];
 
   const statusFilterElement = (

--- a/pinot-controller/src/main/resources/app/components/useTaskListing.tsx
+++ b/pinot-controller/src/main/resources/app/components/useTaskListing.tsx
@@ -53,7 +53,8 @@ export default function useTaskListing(props) {
         ? (status as { value?: unknown }).value
         : status;
       const statusString = typeof rawStatus === 'string' ? rawStatus : '';
-      const normalized = statusString.toUpperCase() === 'TIMEDOUT' ? 'TIMED_OUT' : statusString.toUpperCase();
+      const upperStatus = statusString.toUpperCase();
+      const normalized = upperStatus === 'TIMEDOUT' ? 'TIMED_OUT' : upperStatus;
       return normalized === statusFilter;
     });
 

--- a/pinot-controller/src/main/resources/app/pages/TaskDetail.tsx
+++ b/pinot-controller/src/main/resources/app/pages/TaskDetail.tsx
@@ -119,7 +119,8 @@ const TaskDetail = (props) => {
         ? (status as { value?: unknown }).value
         : status;
       const statusString = typeof rawStatus === 'string' ? rawStatus : '';
-      const normalized = statusString.toUpperCase() === 'TIMEDOUT' ? 'TIMED_OUT' : statusString.toUpperCase();
+      const statusUpper = statusString.toUpperCase();
+      const normalized = statusUpper === 'TIMEDOUT' ? 'TIMED_OUT' : statusUpper;
       return normalized === subtaskStatusFilter;
     });
 

--- a/pinot-controller/src/main/resources/app/pages/TaskDetail.tsx
+++ b/pinot-controller/src/main/resources/app/pages/TaskDetail.tsx
@@ -115,10 +115,12 @@ const TaskDetail = (props) => {
     }
 
     const filtered = subtaskTableData.records.filter(([_, status]) => {
-      const subtaskStatus = typeof status === 'object' && status !== null && 'value' in status
-        ? status.value as string
-        : status as string;
-      return subtaskStatus.toUpperCase() === subtaskStatusFilter;
+      const rawStatus = (typeof status === 'object' && status !== null && 'value' in status)
+        ? (status as { value?: unknown }).value
+        : status;
+      const statusString = typeof rawStatus === 'string' ? rawStatus : '';
+      const normalized = statusString.toUpperCase() === 'TIMEDOUT' ? 'TIMED_OUT' : statusString.toUpperCase();
+      return normalized === subtaskStatusFilter;
     });
 
     return { ...subtaskTableData, records: filtered };


### PR DESCRIPTION
Fixes a white page crash when selecting a subtask status filter on the Minion Task page, and updates the Minion Task page filter options.

Changes
- Normalize 'TIMEDOUT' → 'TIMED_OUT' and safely handle non-string status values in filtering logic
- Add Minion Task page filter options: NOT_STARTED, IN_PROGRESS, STOPPED, STOPPING, FAILED, COMPLETED, ABORTED, TIMED_OUT, TIMING_OUT, FAILING
- Extend TaskStatus type and chip styling to cover new statuses

Validation
- Lint clean (eslint)
- UI builds successfully (webpack)
- Manually validated filters do not crash and options render correctly

No backend API changes. No DB schema changes.