### PR TITLE
Fix logger for pauseless

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/BlockingSegmentCompletionFSM.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/BlockingSegmentCompletionFSM.java
@@ -57,7 +57,6 @@ import org.slf4j.LoggerFactory;
  * See https://github.com/linkedin/pinot/wiki/Low-level-kafka-consumers
  */
 public class BlockingSegmentCompletionFSM implements SegmentCompletionFSM {
-  public static final Logger LOGGER = LoggerFactory.getLogger(BlockingSegmentCompletionFSM.class);
 
   public enum BlockingSegmentCompletionFSMState {
     PARTIAL_CONSUMING,  // Indicates that at least one replica has reported that it has stopped consuming.
@@ -130,7 +129,7 @@ public class BlockingSegmentCompletionFSM implements SegmentCompletionFSM {
     if (savedCommitTime != null && savedCommitTime > initialCommitTimeMs) {
       initialCommitTimeMs = savedCommitTime;
     }
-    _logger = LoggerFactory.getLogger("SegmentCompletionFSM_" + segmentName.getSegmentName());
+    _logger = LoggerFactory.getLogger(this.getClass().getSimpleName() + "_" + segmentName.getSegmentName());
     int maxCommitTimeForAllSegmentsSeconds = SegmentCompletionManager.getMaxCommitTimeForAllSegmentsSeconds();
     if (initialCommitTimeMs > maxCommitTimeForAllSegmentsSeconds * 1000L) {
       // The table has a really high value configured for max commit time. Set it to a higher value than default
@@ -771,7 +770,7 @@ public class BlockingSegmentCompletionFSM implements SegmentCompletionFSM {
       // The winner is coming back to report its offset. Take a decision based on the offset reported, and whether we
       // already notified them
       // Winner is supposedly already in the commit call. Something wrong.
-      LOGGER.warn(
+      _logger.warn(
           "{}:Aborting FSM because winner is reporting a segment while it is also committing instance={} offset={} "
               + "now={}", _state, instanceId, offset, now);
       // Ask them to hold, just in case the committer fails for some reason..

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PauselessSegmentCompletionFSM.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PauselessSegmentCompletionFSM.java
@@ -46,7 +46,7 @@ public class PauselessSegmentCompletionFSM extends BlockingSegmentCompletionFSM 
     try {
       CommittingSegmentDescriptor committingSegmentDescriptor =
           CommittingSegmentDescriptor.fromSegmentCompletionReqParams(reqParams);
-      LOGGER.info(
+      _logger.info(
           "Starting to commit changes to ZK and ideal state for the segment:{} during pauseles ingestion as the "
               + "leader has been selected", _segmentName);
       _segmentManager.commitSegmentMetadataToCommitting(

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PauselessSegmentCompletionFSM.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PauselessSegmentCompletionFSM.java
@@ -47,7 +47,7 @@ public class PauselessSegmentCompletionFSM extends BlockingSegmentCompletionFSM 
       CommittingSegmentDescriptor committingSegmentDescriptor =
           CommittingSegmentDescriptor.fromSegmentCompletionReqParams(reqParams);
       _logger.info(
-          "Starting to commit changes to ZK and ideal state for the segment:{} during pauseles ingestion as the "
+          "Starting to commit changes to ZK and ideal state for the segment:{} during pauseless ingestion as the "
               + "leader has been selected", _segmentName);
       _segmentManager.commitSegmentMetadataToCommitting(
           TableNameBuilder.REALTIME.tableNameWithType(_segmentName.getTableName()), committingSegmentDescriptor);


### PR DESCRIPTION
## Objective

Easily identify whether BlockingSegmentCompletionFSM or PauselessSegmentCompletionFSM is being used during the segment commit protocol at the controller.

## Changes
 - Use the class name in the logger. 
 - Correct usage of _logger instead of LOGGER to get the segment being committed.
 
Fix a small typo