### PR TITLE
Rewrite isDirectExchangeCompatible to support joins without partition functions

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/MailboxAssignmentVisitor.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/MailboxAssignmentVisitor.java
@@ -165,8 +165,13 @@ public class MailboxAssignmentVisitor extends DefaultPostOrderTraversalVisitor<V
       DispatchablePlanMetadata receiver) {
     int numSenders = sender.getWorkerIdToServerInstanceMap().size();
     int numReceivers = receiver.getWorkerIdToServerInstanceMap().size();
-    return numSenders * sender.getPartitionParallelism() == numReceivers && sender.getPartitionFunction() != null
-        && sender.getPartitionFunction().equalsIgnoreCase(receiver.getPartitionFunction());
+    if (numSenders * sender.getPartitionParallelism() != numReceivers) {
+      return false;
+    }
+    if (sender.getPartitionFunction() == null) {
+      return receiver.getPartitionFunction() == null;
+    }
+    return sender.getPartitionFunction().equalsIgnoreCase(receiver.getPartitionFunction());
   }
 
   private void connectWorkers(int stageId, Map<Integer, QueryServerInstance> serverMap,


### PR DESCRIPTION
In https://github.com/apache/pinot/pull/14912, we modified `is_colocated_by_join_keys` hint. If included, we should blindly apply joins in colocated fashion (even if we cannot verify it is correct to do so!), but simple queries like:

```sql
select /*+ joinOptions(is_colocated_by_join_keys='true') */ *
from userAttributes u 
join userGroups g
on u.userUUID = g.userUUID
```

Shows that mailboxes were sending raw messages. Funny enough, using `explain implementation plan for` in this case incorrectly indicates that the mailbox was partitioned.

The reason for this is that MailboxAssignmentVisitor was ignoring the pre-partitioned flag because `isDirectExchangeCompatible` returned false. This PR solves that.

In a future PR, I want to add new tests that verify this hint works as expected, given we have errors like this in the past and the semantics of the hint have changed several times in the last 3 years. Right now I just only tested this feature manually with the query above and with 

```sql
select /*+ joinOptions(is_colocated_by_join_keys='true') */ *
from userAttributes u 
join userGroups g
on u.userUUID = g.groupUUID
```

which is actually not collocated (see the ON condition), but the hint here forces colocation.

I've also opened a request on gitbook to document the hint. See https://app.gitbook.com/o/-LtRX9NwSr7Ga7zA4piL/s/-LtH6nl58DdnZnelPdTc-887967055/~/changes/2218/users/user-guide-query/multi-stage-query/join-strategies/colocated-join-strategy#advanced-configuration