### PR TITLE
Handle timestamp string to long casts in scalar cast function

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/DataTypeConversionFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/DataTypeConversionFunctions.java
@@ -25,6 +25,7 @@ import org.apache.pinot.common.utils.PinotDataType;
 import org.apache.pinot.spi.annotations.ScalarFunction;
 import org.apache.pinot.spi.utils.BigDecimalUtils;
 import org.apache.pinot.spi.utils.BytesUtils;
+import org.apache.pinot.spi.utils.TimestampUtils;
 
 import static org.apache.pinot.common.utils.PinotDataType.*;
 
@@ -67,6 +68,14 @@ public class DataTypeConversionFunctions {
           throw new IllegalArgumentException("Unknown data type: " + targetTypeLiteral);
         }
         break;
+    }
+    if (sourceType == STRING && targetDataType == LONG) {
+      // Check if the STRING is a TIMESTAMP
+      try {
+        return TimestampUtils.toTimestamp(value.toString().trim()).getTime();
+      } catch (Exception e) {
+        // If it is not a TIMESTAMP, we will try to parse it as a LONG, so do nothing here.
+      }
     }
     if (sourceType == STRING && (targetDataType == INTEGER || targetDataType == LONG)) {
       if (String.valueOf(value).contains(".")) {

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryEnvironmentTestBase.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryEnvironmentTestBase.java
@@ -286,6 +286,7 @@ public class QueryEnvironmentTestBase {
         // Verify type coercion in standard functions
         new Object[]{"SELECT DATEADD('DAY', 1, col7) FROM a"},
         new Object[]{"SELECT TIMESTAMPADD(DAY, 10, NOW() - 100) FROM a"},
+        new Object[]{"SELECT ts FROM a WHERE ts <= '2025-08-14 00:00:00.000000'"}
     };
   }
 


### PR DESCRIPTION
- https://github.com/apache/pinot/pull/16421 was a bug fix but unintentionally broke some multi-stage engine queries (that themselves were unintentionally supported).
- Consider a query like `SELECT * FROM mytable WHERE tsCol >= '2025-08-07 00:00:00.000000'` but `tsCol` is actually a `LONG` type in the schema and not a `TIMESTAMP` type. This query actually doesn't work with the single-stage engine but worked with the MSE before the above patch. The reason is that before the above bugfix, the cast was evaluated through the [transform function variant](https://github.com/apache/pinot/blob/d9e731782afc62149b487c27e80de4d809673853/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CastTransformFunction.java#L180) of `CAST`, which handled timestamp strings to longs appropriately (see [here](https://github.com/apache/pinot/blob/d9e731782afc62149b487c27e80de4d809673853/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LiteralTransformFunction.java#L72), [here](https://github.com/apache/pinot/blob/d9e731782afc62149b487c27e80de4d809673853/pinot-common/src/main/java/org/apache/pinot/common/request/context/LiteralContext.java#L226-L235)).
- The [scalar function variant](https://github.com/apache/pinot/blob/d9e731782afc62149b487c27e80de4d809673853/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/DataTypeConversionFunctions.java#L71-L77) of `CAST` though doesn't support this pattern and the above bugfix to evaluate `CAST` at compile time rather than query execution time unintentionally broke some queries.
- This patch fixes the scalar function variant of `CAST` to also support the timestamp string to long conversion.