### PR TITLE
Add TASK_ERROR to subtask status filter

### DIFF
--- a/pinot-controller/src/main/resources/app/components/TaskStatusFilter.tsx
+++ b/pinot-controller/src/main/resources/app/components/TaskStatusFilter.tsx
@@ -105,6 +105,7 @@ export type TaskStatus =
   | 'RUNNING'
   | 'WAITING'
   | 'ERROR'
+  | 'TASK_ERROR'
   | 'UNKNOWN'
   | 'DROPPED'
   | 'TIMED_OUT'
@@ -140,6 +141,8 @@ export const getTaskStatusChipClass = (status: string, classes?: any) => {
     case 'WAITING':
       return classes.waiting;
     case 'ERROR':
+      return classes.error;
+    case 'TASK_ERROR':
       return classes.error;
     case 'FAILED':
       return classes.error;

--- a/pinot-controller/src/main/resources/app/pages/TaskDetail.tsx
+++ b/pinot-controller/src/main/resources/app/pages/TaskDetail.tsx
@@ -133,6 +133,7 @@ const TaskDetail = (props) => {
     { label: 'Running', value: 'RUNNING' as const },
     { label: 'Waiting', value: 'WAITING' as const },
     { label: 'Error', value: 'ERROR' as const },
+    { label: 'Task Error', value: 'TASK_ERROR' as const },
     { label: 'Unknown', value: 'UNKNOWN' as const },
     { label: 'Dropped', value: 'DROPPED' as const },
     { label: 'Timed Out', value: 'TIMED_OUT' as const },


### PR DESCRIPTION
Adds TASK_ERROR to the subtask status filter in the Controller UI.\n\n- Extends TaskStatus type and chip rendering in app/components/TaskStatusFilter.tsx\n- Adds 'Task Error' option to the subtask filter options in app/pages/TaskDetail.tsx