### PR TITLE
[Bug fix] Change consuming segment offset and age from int to long

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceSummaryResult.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceSummaryResult.java
@@ -344,8 +344,8 @@ public class RebalanceSummaryResult {
   public static class ConsumingSegmentToBeMovedSummary {
     private final int _numConsumingSegmentsToBeMoved;
     private final int _numServersGettingConsumingSegmentsAdded;
-    private final Map<String, Integer> _consumingSegmentsToBeMovedWithMostOffsetsToCatchUp;
-    private final Map<String, Integer> _consumingSegmentsToBeMovedWithOldestAgeInMinutes;
+    private final Map<String, Long> _consumingSegmentsToBeMovedWithMostOffsetsToCatchUp;
+    private final Map<String, Long> _consumingSegmentsToBeMovedWithOldestAgeInMinutes;
     private final Map<String, ConsumingSegmentSummaryPerServer> _serverConsumingSegmentSummary;
 
     /**
@@ -381,9 +381,9 @@ public class RebalanceSummaryResult {
         @JsonProperty("numConsumingSegmentsToBeMoved") int numConsumingSegmentsToBeMoved,
         @JsonProperty("numServersGettingConsumingSegmentsAdded") int numServersGettingConsumingSegmentsAdded,
         @JsonProperty("consumingSegmentsToBeMovedWithMostOffsetsToCatchUp") @Nullable
-        Map<String, Integer> consumingSegmentsToBeMovedWithMostOffsetsToCatchUp,
+        Map<String, Long> consumingSegmentsToBeMovedWithMostOffsetsToCatchUp,
         @JsonProperty("consumingSegmentsToBeMovedWithOldestAgeInMinutes") @Nullable
-        Map<String, Integer> consumingSegmentsToBeMovedWithOldestAgeInMinutes,
+        Map<String, Long> consumingSegmentsToBeMovedWithOldestAgeInMinutes,
         @JsonProperty("serverConsumingSegmentSummary") @Nullable
         Map<String, ConsumingSegmentSummaryPerServer> serverConsumingSegmentSummary) {
       _numConsumingSegmentsToBeMoved = numConsumingSegmentsToBeMoved;
@@ -404,12 +404,12 @@ public class RebalanceSummaryResult {
     }
 
     @JsonProperty
-    public Map<String, Integer> getConsumingSegmentsToBeMovedWithMostOffsetsToCatchUp() {
+    public Map<String, Long> getConsumingSegmentsToBeMovedWithMostOffsetsToCatchUp() {
       return _consumingSegmentsToBeMovedWithMostOffsetsToCatchUp;
     }
 
     @JsonProperty
-    public Map<String, Integer> getConsumingSegmentsToBeMovedWithOldestAgeInMinutes() {
+    public Map<String, Long> getConsumingSegmentsToBeMovedWithOldestAgeInMinutes() {
       return _consumingSegmentsToBeMovedWithOldestAgeInMinutes;
     }
 
@@ -420,7 +420,7 @@ public class RebalanceSummaryResult {
 
     public static class ConsumingSegmentSummaryPerServer {
       protected int _numConsumingSegmentsToBeAdded;
-      protected int _totalOffsetsToCatchUpAcrossAllConsumingSegments;
+      protected long _totalOffsetsToCatchUpAcrossAllConsumingSegments;
 
       /**
        * Constructor for ConsumingSegmentSummaryPerServer
@@ -437,7 +437,7 @@ public class RebalanceSummaryResult {
       public ConsumingSegmentSummaryPerServer(
           @JsonProperty("numConsumingSegmentsToBeAdded") int numConsumingSegmentsToBeAdded,
           @JsonProperty("totalOffsetsToCatchUpAcrossAllConsumingSegments")
-          int totalOffsetsToCatchUpAcrossAllConsumingSegments) {
+          long totalOffsetsToCatchUpAcrossAllConsumingSegments) {
         _numConsumingSegmentsToBeAdded = numConsumingSegmentsToBeAdded;
         _totalOffsetsToCatchUpAcrossAllConsumingSegments = totalOffsetsToCatchUpAcrossAllConsumingSegments;
       }
@@ -448,7 +448,7 @@ public class RebalanceSummaryResult {
       }
 
       @JsonProperty
-      public int getTotalOffsetsToCatchUpAcrossAllConsumingSegments() {
+      public long getTotalOffsetsToCatchUpAcrossAllConsumingSegments() {
         return _totalOffsetsToCatchUpAcrossAllConsumingSegments;
       }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/tenant/TenantRebalanceResult.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/tenant/TenantRebalanceResult.java
@@ -504,8 +504,8 @@ public class TenantRebalanceResult {
     int totalNumConsumingSegmentsToBeMoved = 0;
 
     // Create maps to store all segments by offset and age
-    Map<String, Integer> consumingSegmentsWithMostOffsetsPerTable = new HashMap<>();
-    Map<String, Integer> consumingSegmentsWithOldestAgePerTable = new HashMap<>();
+    Map<String, Long> consumingSegmentsWithMostOffsetsPerTable = new HashMap<>();
+    Map<String, Long> consumingSegmentsWithOldestAgePerTable = new HashMap<>();
 
     // Aggregate ConsumingSegmentSummaryPerServer by server name across all tables
     Map<String, AggregatedConsumingSegmentSummaryPerServer> serverAggregates = new HashMap<>();
@@ -516,7 +516,7 @@ public class TenantRebalanceResult {
       // Add one segment with offsets for each table
       if (summary.getConsumingSegmentsToBeMovedWithMostOffsetsToCatchUp() != null
           && !summary.getConsumingSegmentsToBeMovedWithMostOffsetsToCatchUp().isEmpty()) {
-        Map.Entry<String, Integer> consumingSegmentWithMostOffsetsToCatchUp =
+        Map.Entry<String, Long> consumingSegmentWithMostOffsetsToCatchUp =
             summary.getConsumingSegmentsToBeMovedWithMostOffsetsToCatchUp().entrySet().iterator().next();
         consumingSegmentsWithMostOffsetsPerTable.put(consumingSegmentWithMostOffsetsToCatchUp.getKey(),
             consumingSegmentWithMostOffsetsToCatchUp.getValue());
@@ -525,7 +525,7 @@ public class TenantRebalanceResult {
       // Add all segments with ages
       if (summary.getConsumingSegmentsToBeMovedWithOldestAgeInMinutes() != null
           && !summary.getConsumingSegmentsToBeMovedWithOldestAgeInMinutes().isEmpty()) {
-        Map.Entry<String, Integer> consumingSegmentWithOldestAge =
+        Map.Entry<String, Long> consumingSegmentWithOldestAge =
             summary.getConsumingSegmentsToBeMovedWithOldestAgeInMinutes().entrySet().iterator().next();
         consumingSegmentsWithOldestAgePerTable.put(consumingSegmentWithOldestAge.getKey(),
             consumingSegmentWithOldestAge.getValue());
@@ -548,14 +548,14 @@ public class TenantRebalanceResult {
     }
 
     // Sort consuming segments (top one from each table) by offsets and age
-    Map<String, Integer> sortedConsumingSegmentsWithMostOffsetsPerTable = new LinkedHashMap<>();
+    Map<String, Long> sortedConsumingSegmentsWithMostOffsetsPerTable = new LinkedHashMap<>();
     consumingSegmentsWithMostOffsetsPerTable.entrySet().stream()
-        .sorted(Map.Entry.<String, Integer>comparingByValue().reversed())
+        .sorted(Map.Entry.<String, Long>comparingByValue().reversed())
         .forEach(entry -> sortedConsumingSegmentsWithMostOffsetsPerTable.put(entry.getKey(), entry.getValue()));
 
-    Map<String, Integer> sortedConsumingSegmentsWithOldestAgePerTable = new LinkedHashMap<>();
+    Map<String, Long> sortedConsumingSegmentsWithOldestAgePerTable = new LinkedHashMap<>();
     consumingSegmentsWithOldestAgePerTable.entrySet().stream()
-        .sorted(Map.Entry.<String, Integer>comparingByValue().reversed())
+        .sorted(Map.Entry.<String, Long>comparingByValue().reversed())
         .forEach(entry -> sortedConsumingSegmentsWithOldestAgePerTable.put(entry.getKey(), entry.getValue()));
 
     // Convert aggregated server data to final ConsumingSegmentSummaryPerServer map

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerClusterStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerClusterStatelessTest.java
@@ -2223,7 +2223,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(consumingSegmentToBeMovedSummary.getNumConsumingSegmentsToBeMoved(),
         FakeStreamConfigUtils.DEFAULT_NUM_PARTITIONS * numReplica);
     assertEquals(consumingSegmentToBeMovedSummary.getNumServersGettingConsumingSegmentsAdded(), numServers);
-    Iterator<Integer> offsetToCatchUpIterator =
+    Iterator<Long> offsetToCatchUpIterator =
         consumingSegmentToBeMovedSummary.getConsumingSegmentsToBeMovedWithMostOffsetsToCatchUp().values().iterator();
     assertEquals(offsetToCatchUpIterator.next(), mockOffsetBig);
     if (FakeStreamConfigUtils.DEFAULT_NUM_PARTITIONS > 1) {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/KafkaConsumingSegmentToBeMovedSummaryIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/KafkaConsumingSegmentToBeMovedSummaryIntegrationTest.java
@@ -140,7 +140,7 @@ public class KafkaConsumingSegmentToBeMovedSummaryIntegrationTest extends BaseRe
         .getServerConsumingSegmentSummary()
         .values()
         .stream()
-        .reduce(0, (a, b) -> a + b.getTotalOffsetsToCatchUpAcrossAllConsumingSegments(), Integer::sum), 57801);
+        .reduce(0L, (a, b) -> a + b.getTotalOffsetsToCatchUpAcrossAllConsumingSegments(), Long::sum), 57801);
 
     // set includeConsuming to false
     response = sendPostRequest(


### PR DESCRIPTION
For cases we've seen, the offset could and should be `long` type since Kafka has this number with `long` type.

Before change, this could happen:
```
Caught exception while trying to fetch consuming segment info
java.lang.NumberFormatException: For input string: "5669486330"
        at java.base/java.lang.NumberFormatException.forInputString(NumberFormatException.java:67) ~[?:?]
        at java.base/java.lang.Integer.parseInt(Integer.java:662) ~[?:?]
        at java.base/java.lang.Integer.parseInt(Integer.java:778) ~[?:?]
        at org.apache.pinot.controller.helix.core.rebalance.TableRebalancer.getConsumingSegmentsOffsetsToCatchUp(TableRebalancer.java:1019)
```
