### PR TITLE
Add a rebalance option to disable the summary

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -704,6 +704,8 @@ public class PinotTableRestletResource {
       boolean dryRun,
       @ApiParam(value = "Whether to enable pre-checks for table, must be in dry-run mode to enable")
       @DefaultValue("false") @QueryParam("preChecks") boolean preChecks,
+      @ApiParam(value = "Whether to disable summary calculation")
+      @DefaultValue("false") @QueryParam("preChecks") boolean disableSummary,
       @ApiParam(value = "Whether to reassign instances before reassigning segments") @DefaultValue("true")
       @QueryParam("reassignInstances") boolean reassignInstances,
       @ApiParam(value = "Whether to reassign CONSUMING segments for real-time table") @DefaultValue("true")
@@ -781,6 +783,7 @@ public class PinotTableRestletResource {
     RebalanceConfig rebalanceConfig = new RebalanceConfig();
     rebalanceConfig.setDryRun(dryRun);
     rebalanceConfig.setPreChecks(preChecks);
+    rebalanceConfig.setDisableSummary(disableSummary);
     rebalanceConfig.setReassignInstances(reassignInstances);
     rebalanceConfig.setIncludeConsuming(includeConsuming);
     rebalanceConfig.setMinimizeDataMovement(minimizeDataMovement);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -705,7 +705,7 @@ public class PinotTableRestletResource {
       @ApiParam(value = "Whether to enable pre-checks for table, must be in dry-run mode to enable")
       @DefaultValue("false") @QueryParam("preChecks") boolean preChecks,
       @ApiParam(value = "Whether to disable summary calculation")
-      @DefaultValue("false") @QueryParam("preChecks") boolean disableSummary,
+      @DefaultValue("false") @QueryParam("disableSummary") boolean disableSummary,
       @ApiParam(value = "Whether to reassign instances before reassigning segments") @DefaultValue("true")
       @QueryParam("reassignInstances") boolean reassignInstances,
       @ApiParam(value = "Whether to reassign CONSUMING segments for real-time table") @DefaultValue("true")

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/DefaultRebalancePreChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/DefaultRebalancePreChecker.java
@@ -412,16 +412,21 @@ public class DefaultRebalancePreChecker implements RebalancePreChecker {
     }
 
     // --- Batch size per server recommendation check using summary ---
-    int maxSegmentsToAddOnServer = rebalanceSummaryResult.getSegmentInfo().getMaxSegmentsAddedToASingleServer();
-    int batchSizePerServer = rebalanceConfig.getBatchSizePerServer();
-    if (maxSegmentsToAddOnServer > SEGMENT_ADD_THRESHOLD) {
-      if (batchSizePerServer == RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER
-          || batchSizePerServer > RECOMMENDED_BATCH_SIZE) {
-        pass = false;
-        warnings.add("Number of segments to add to a single server (" + maxSegmentsToAddOnServer + ") is high (>"
-            + SEGMENT_ADD_THRESHOLD + "). It is recommended to set batchSizePerServer to " + RECOMMENDED_BATCH_SIZE
-            + " or lower to avoid excessive load on servers.");
+    if (rebalanceSummaryResult != null) {
+      int maxSegmentsToAddOnServer = rebalanceSummaryResult.getSegmentInfo().getMaxSegmentsAddedToASingleServer();
+      int batchSizePerServer = rebalanceConfig.getBatchSizePerServer();
+      if (maxSegmentsToAddOnServer > SEGMENT_ADD_THRESHOLD) {
+        if (batchSizePerServer == RebalanceConfig.DISABLE_BATCH_SIZE_PER_SERVER
+            || batchSizePerServer > RECOMMENDED_BATCH_SIZE) {
+          pass = false;
+          warnings.add("Number of segments to add to a single server (" + maxSegmentsToAddOnServer + ") is high (>"
+              + SEGMENT_ADD_THRESHOLD + "). It is recommended to set batchSizePerServer to " + RECOMMENDED_BATCH_SIZE
+              + " or lower to avoid excessive load on servers.");
+        }
       }
+    } else {
+      pass = false;
+      warnings.add("Could not assess batchSizePerServer recommendation as rebalance summary is null");
     }
 
     return pass ? RebalancePreCheckerResult.pass("All rebalance parameters look good")

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/DefaultRebalancePreChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/DefaultRebalancePreChecker.java
@@ -425,8 +425,10 @@ public class DefaultRebalancePreChecker implements RebalancePreChecker {
         }
       }
     } else {
+      // Rebalance summary should not be null when pre-checks are enabled unless an exception was thrown while
+      // calculating it
       pass = false;
-      warnings.add("Could not assess batchSizePerServer recommendation as rebalance summary is null");
+      warnings.add("Could not assess batchSizePerServer recommendation as rebalance summary could not be calculated");
     }
 
     return pass ? RebalancePreCheckerResult.pass("All rebalance parameters look good")

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceConfig.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceConfig.java
@@ -39,10 +39,15 @@ public class RebalanceConfig {
   private boolean _dryRun = false;
 
   // Whether to perform pre-checks for rebalance. This only returns the status of each pre-check and does not fail
-  // rebalance
+  // rebalance. Summary is required to calculate pre-checks, so if 'disableSummary=true', it will be reset to false
   @JsonProperty("preChecks")
   @ApiModelProperty(example = "false")
   private boolean _preChecks = false;
+
+  // Whether to disable the summary or not. If set to true the summary will not be calculated
+  @JsonProperty("disableSummary")
+  @ApiModelProperty(example = "false")
+  private boolean _disableSummary = false;
 
   // Whether to reassign instances before reassigning segments
   @JsonProperty("reassignInstances")
@@ -184,6 +189,14 @@ public class RebalanceConfig {
 
   public void setPreChecks(boolean preChecks) {
     _preChecks = preChecks;
+  }
+
+  public boolean isDisableSummary() {
+    return _disableSummary;
+  }
+
+  public void setDisableSummary(boolean disableSummary) {
+    _disableSummary = disableSummary;
   }
 
   public boolean isReassignInstances() {
@@ -366,9 +379,9 @@ public class RebalanceConfig {
 
   @Override
   public String toString() {
-    return "RebalanceConfig{" + "_dryRun=" + _dryRun + ", preChecks=" + _preChecks + ", _reassignInstances="
-        + _reassignInstances + ", _includeConsuming=" + _includeConsuming + ", _minimizeDataMovement="
-        + _minimizeDataMovement + ", _bootstrap=" + _bootstrap + ", _downtime=" + _downtime
+    return "RebalanceConfig{" + "_dryRun=" + _dryRun + ", preChecks=" + _preChecks + ", _disableSummary="
+        + _disableSummary + ", _reassignInstances=" + _reassignInstances + ", _includeConsuming=" + _includeConsuming
+        + ", _minimizeDataMovement=" + _minimizeDataMovement + ", _bootstrap=" + _bootstrap + ", _downtime=" + _downtime
         + ", _allowPeerDownloadDataLoss=" + _allowPeerDownloadDataLoss + ", _minAvailableReplicas="
         + _minAvailableReplicas + ", _bestEfforts=" + _bestEfforts + ", batchSizePerServer="
         + _batchSizePerServer + ", _externalViewCheckIntervalInMs=" + _externalViewCheckIntervalInMs
@@ -382,8 +395,9 @@ public class RebalanceConfig {
   }
 
   public String toQueryString() {
-    return "dryRun=" + _dryRun + "&preChecks=" + _preChecks + "&reassignInstances=" + _reassignInstances
-        + "&includeConsuming=" + _includeConsuming + "&bootstrap=" + _bootstrap + "&downtime=" + _downtime
+    return "dryRun=" + _dryRun + "&preChecks=" + _preChecks + "&disableSummary=" + _disableSummary
+        + "&reassignInstances=" + _reassignInstances + "&includeConsuming=" + _includeConsuming
+        + "&bootstrap=" + _bootstrap + "&downtime=" + _downtime
         + "&allowPeerDownloadDataLoss=" + _allowPeerDownloadDataLoss + "&minAvailableReplicas=" + _minAvailableReplicas
         + "&bestEfforts=" + _bestEfforts + "&minimizeDataMovement=" + _minimizeDataMovement.name()
         + "&batchSizePerServer=" + _batchSizePerServer
@@ -402,6 +416,7 @@ public class RebalanceConfig {
     RebalanceConfig rc = new RebalanceConfig();
     rc._dryRun = cfg._dryRun;
     rc._preChecks = cfg._preChecks;
+    rc._disableSummary = cfg._disableSummary;
     rc._reassignInstances = cfg._reassignInstances;
     rc._includeConsuming = cfg._includeConsuming;
     rc._bootstrap = cfg._bootstrap;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
@@ -368,7 +368,8 @@ public class TableRebalancer {
         summaryResult = calculateRebalanceSummary(currentAssignment, targetAssignment, tableNameWithType,
             tableSubTypeSizeDetails, tableConfig, tableRebalanceLogger);
       } catch (Exception e) {
-        tableRebalanceLogger.warn("Caught exception while trying to run the rebalance summary, skipping", e);
+        tableRebalanceLogger.warn("Caught exception while trying to calculate the rebalance summary, skipping summary "
+            + "calculation", e);
       }
     }
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerClusterStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerClusterStatelessTest.java
@@ -657,6 +657,31 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
       assertNull(rebalanceResult.getRebalanceSummaryResult());
       assertNull(rebalanceResult.getPreChecksResult());
 
+      // Try pre-checks mode with disableSummary set - this should work and summary should still be returned
+      rebalanceConfig = new RebalanceConfig();
+      rebalanceConfig.setPreChecks(true);
+      rebalanceConfig.setDryRun(true);
+      rebalanceConfig.setDisableSummary(true);
+      rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
+      assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.NO_OP);
+      assertNotNull(rebalanceResult.getRebalanceSummaryResult());
+      assertNotNull(rebalanceResult.getPreChecksResult());
+
+      // Try dry-run mode with disableSummary set - this should work and summary should not be returned
+      rebalanceConfig = new RebalanceConfig();
+      rebalanceConfig.setDryRun(true);
+      rebalanceConfig.setDisableSummary(true);
+      rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
+      assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.NO_OP);
+      assertNull(rebalanceResult.getRebalanceSummaryResult());
+
+      // Try rebalance with disableSummary set - this should work and summary should not be returned
+      rebalanceConfig = new RebalanceConfig();
+      rebalanceConfig.setDisableSummary(true);
+      rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
+      assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.NO_OP);
+      assertNull(rebalanceResult.getRebalanceSummaryResult());
+
       _helixResourceManager.deleteOfflineTable(RAW_TABLE_NAME);
 
       for (int i = 0; i < numServers; i++) {


### PR DESCRIPTION
This PR adds an option to disable the rebalance summary. This can be useful in scenarios where we want to skip the overhead of calculating the summary, especially from calls within the code. It also makes the summary and pre-checks code more robust to failures by catching all exceptions and logging a warning to avoid failing the rebalance operation itself.