### PR TITLE
Convert group by with no order by case to safeTrim when beneficial

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/TableResizer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/TableResizer.java
@@ -326,13 +326,12 @@ public class TableResizer {
    * This method is to be called from individual segment if the intermediate results need to be trimmed.
    */
   public List<IntermediateRecord> sortInSegmentResults(GroupKeyGenerator groupKeyGenerator,
-      GroupByResultHolder[] groupByResultHolders, int size) {
+      GroupByResultHolder[] groupByResultHolders) {
     // getNumKeys() does not count nulls
-    assert groupKeyGenerator.getNumKeys() <= size;
     Iterator<GroupKeyGenerator.GroupKey> groupKeyIterator = groupKeyGenerator.getGroupKeys();
 
     // Initialize a heap with the first 'size' groups
-    List<IntermediateRecord> arr = new ArrayList<>(size);
+    List<IntermediateRecord> arr = new ArrayList<>(groupKeyGenerator.getNumKeys());
     while (groupKeyIterator.hasNext()) {
       arr.add(getIntermediateRecord(groupKeyIterator.next(), groupByResultHolders));
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/FilteredGroupByOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/FilteredGroupByOperator.java
@@ -222,7 +222,7 @@ public class FilteredGroupByOperator extends BaseOperator<GroupByResultsBlock> {
       TableResizer tableResizer = new TableResizer(_dataSchema, _queryContext);
       List<IntermediateRecord> intermediateRecords =
           tableResizer.sortInSegmentResults(groupKeyGenerator,
-              groupByResultHolders, trimSize);
+              groupByResultHolders);
       groupKeyGenerator.close();
       resultsBlock = new GroupByResultsBlock(_dataSchema, intermediateRecords, _queryContext);
     } else {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/GroupByOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/GroupByOperator.java
@@ -172,7 +172,7 @@ public class GroupByOperator extends BaseOperator<GroupByResultsBlock> {
       TableResizer tableResizer = new TableResizer(_dataSchema, _queryContext);
       List<IntermediateRecord> intermediateRecords =
           tableResizer.sortInSegmentResults(groupByExecutor.getGroupKeyGenerator(),
-              groupByExecutor.getGroupByResultHolders(), trimSize);
+              groupByExecutor.getGroupByResultHolders());
       // close groupKeyGenerator after getting intermediateRecords
       groupByExecutor.getGroupKeyGenerator().close();
       resultsBlock = new GroupByResultsBlock(_dataSchema, intermediateRecords, _queryContext);

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/combine/SortedGroupByCombineOperatorsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/combine/SortedGroupByCombineOperatorsTest.java
@@ -184,6 +184,27 @@ public class SortedGroupByCombineOperatorsTest {
     }
   }
 
+  @Test
+  public void testNoOrderByToSafeTrimPairWiseCombine() {
+    GroupByResultsBlock combineResult = getPairWiseCombineResult(
+        "SELECT intColumn, COUNT(*) FROM testTable GROUP BY intColumn LIMIT 100");
+    assertEquals(combineResult.getDataSchema(),
+        new DataSchema(new String[]{INT_COLUMN, "count(*)"},
+            new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.LONG}));
+    assertEquals(combineResult.getRows().size(), 100);
+    assertEquals(combineResult.getNumSegmentsProcessed(), NUM_SEGMENTS);
+    for (int i = 0; i < 50; i++) {
+      Object[] row = combineResult.getRows().get(i);
+      assertEquals(row[0], i);
+      assertEquals(row[1], 1L);
+    }
+    for (int i = 50; i < 100; i++) {
+      Object[] row = combineResult.getRows().get(i);
+      assertEquals(row[0], i);
+      assertEquals(row[1], 2L);
+    }
+  }
+
   // ----
   // Sequential combine
   @Test
@@ -271,6 +292,27 @@ public class SortedGroupByCombineOperatorsTest {
   public void testSafeTrimSequentialCombineServerReturnFinal() {
     GroupByResultsBlock combineResult = getSequentialCombineResultServerReturnFinal(
         "SELECT intColumn, COUNT(*) FROM testTable GROUP BY intColumn ORDER BY intColumn LIMIT 100");
+    assertEquals(combineResult.getDataSchema(),
+        new DataSchema(new String[]{INT_COLUMN, "count(*)"},
+            new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.LONG}));
+    assertEquals(combineResult.getRows().size(), 100);
+    assertEquals(combineResult.getNumSegmentsProcessed(), NUM_SEGMENTS);
+    for (int i = 0; i < 50; i++) {
+      Object[] row = combineResult.getRows().get(i);
+      assertEquals(row[0], i);
+      assertEquals(row[1], 1L);
+    }
+    for (int i = 50; i < 100; i++) {
+      Object[] row = combineResult.getRows().get(i);
+      assertEquals(row[0], i);
+      assertEquals(row[1], 2L);
+    }
+  }
+
+  @Test
+  public void testNoOrderByToSafeTrimSequentialCombine() {
+    GroupByResultsBlock combineResult = getSequentialCombineResult(
+        "SELECT intColumn, COUNT(*) FROM testTable GROUP BY intColumn LIMIT 100");
     assertEquals(combineResult.getDataSchema(),
         new DataSchema(new String[]{INT_COLUMN, "count(*)"},
             new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.LONG}));


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

PR adds order\-by for small\-limit group\-by queries to enable safeTrim, then operators call trimmer without explicit size and trimmer uses group key count\.

```mermaid
flowchart TD
  N0["QueryContext#46;build#40;#41;#58; set orderByExpressions when no order#45;by#44; limit#60;threshold#44; #40;F4#41;"]:::stAdded
  N1["QueryContext#46;#95;isUnsafeTrim #61; #33;isSameOrderAndGroupByColumns#40;#41; #124;#124; havingFilter#33;#61;n #40;F4#41;"]:::stModified
  N2["TableResizer#46;sortInSegmentResults signature change#44; heap size #61; groupKey count #40;F1#41;"]:::stModified
  N3["GroupByOperator#46;getNextBlock#40;#41;#58; call sortInSegmentResults without trimSize #40;F3#41;"]:::stModified
  N4["FilteredGroupByOperator#46;getNextBlock#40;#41;#58; call sortInSegmentResults without trimSi #40;F2#41;"]:::stModified
  N0 -->|"orderByExpressions affect isUnsafeTrim"| N1
  N3 -->|"calls sortInSegmentResults"| N2
  N4 -->|"calls sortInSegmentResults"| N2
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-core/src/main/java/org/apache/pinot/core/data/table/TableResizer\.java — [before](https://github.com/apache/pinot/blob/3349df12a82e489ba18dace7e20fd209417c9da4/pinot-core/src/main/java/org/apache/pinot/core/data/table/TableResizer.java) · [after](https://github.com/apache/pinot/blob/a05128cd0db1c144206af46ccd4ea5f5157739e9/pinot-core/src/main/java/org/apache/pinot/core/data/table/TableResizer.java)
- F2: pinot\-core/src/main/java/org/apache/pinot/core/operator/query/FilteredGroupByOperator\.java — [before](https://github.com/apache/pinot/blob/3349df12a82e489ba18dace7e20fd209417c9da4/pinot-core/src/main/java/org/apache/pinot/core/operator/query/FilteredGroupByOperator.java) · [after](https://github.com/apache/pinot/blob/a05128cd0db1c144206af46ccd4ea5f5157739e9/pinot-core/src/main/java/org/apache/pinot/core/operator/query/FilteredGroupByOperator.java)
- F3: pinot\-core/src/main/java/org/apache/pinot/core/operator/query/GroupByOperator\.java — [before](https://github.com/apache/pinot/blob/3349df12a82e489ba18dace7e20fd209417c9da4/pinot-core/src/main/java/org/apache/pinot/core/operator/query/GroupByOperator.java) · [after](https://github.com/apache/pinot/blob/a05128cd0db1c144206af46ccd4ea5f5157739e9/pinot-core/src/main/java/org/apache/pinot/core/operator/query/GroupByOperator.java)
- F4: pinot\-core/src/main/java/org/apache/pinot/core/query/request/context/QueryContext\.java — [before](https://github.com/apache/pinot/blob/3349df12a82e489ba18dace7e20fd209417c9da4/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/QueryContext.java) · [after](https://github.com/apache/pinot/blob/a05128cd0db1c144206af46ccd4ea5f5157739e9/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/QueryContext.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjMzNDlkZjEyYTgyZTQ4OWJhMThkYWNlN2UyMGZkMjA5NDE3YzlkYTQiLCJjb250ZXh0X2hhc2giOiJlYTY3NzY5Yjk5NzMxMmIxNTFhOWExNjE1MjcwMDhlOTFiZDc3ZWU1OGU5MzVhNmJmNDUwY2NkNDg1NjcxZjZmIiwiZ2VuZXJhdGVkX2F0IjoxNzg5MzQ4MDUyLCJoZWFkX3NoYSI6ImEwNTEyOGNkMGRiMWMxNDQyMDZhZjQ2Y2NkNGVhNWY1MTU3NzM5ZTkiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiIyODVhMThiODQ0MjdlN2U4ZTdlNjBlYTg5NzBlOWZjMmQ1ZDMyNWRhIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature e341364dcef5f33260796f01ca9048e44f1d3bfe0ff0f0ec8a727c4e4b5c2887 -->
<!-- pinot-pr-flow:end -->

Convert group by query with no order-by, small limit, and no having to safeTrim case by adding order-by  of group keys.

Ideally, users could adjust `sortAggregateLimitThrshold` knobs for more correct result, and set `sortAggregateSequentialSegmentsThreshold` to use single-threaded combine for minimum mem usage. (Smaller than concurrentHashMap and pair-wise combine)

IMO converting queries with HAVING might not be a good idea, since for these queries we may not want to  trim segments, and then we don't get the sorted segment results for free. 

TODO: convert partial order by key as well.