### PR TITLE
Keep value of necessary columns only in ComplexTypeTranformer

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformer.java
@@ -396,6 +396,7 @@ public class ComplexTypeTransformer implements RecordTransformer {
     }
   }
 
+  @Nullable
   private String renamePrefix(String field) {
     for (Map.Entry<String, String> entry : _prefixesToRename.entrySet()) {
       String prefix = entry.getKey();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformer.java
@@ -184,7 +184,7 @@ public class ComplexTypeTransformer implements RecordTransformer {
   }
 
   @Override
-  public void withInputColumnsOfDownStreamTransformers(Collection<String> columns) {
+  public void withInputColumnsForDownstreamTransformers(Set<String> columns) {
     _fieldsNeededForDownstreamTransformers = new HashSet<>(columns);
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformer.java
@@ -138,7 +138,6 @@ public class ComplexTypeTransformer implements RecordTransformer {
       CollectionNotUnnestedToJson collectionNotUnnestedToJson, Map<String, String> prefixesToRename,
       boolean continueOnError) {
     _fieldsToUnnest = fieldsToUnnest;
-    Collections.sort(_fieldsToUnnest);
     _fieldsToUnnestAndKeepOriginalValue = new ArrayList<>(_fieldsToUnnest);
     _delimiter = delimiter;
     _collectionNotUnnestedToJson = collectionNotUnnestedToJson;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/TransformPipeline.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/TransformPipeline.java
@@ -43,6 +43,7 @@ public class TransformPipeline {
   private final List<RecordTransformer> _transformers;
   @Nullable
   private final FilterTransformer _filterTransformer;
+  private final Set<String> _inputColumns;
 
   private long _numRowsProcessed;
   private long _numRowsFiltered;
@@ -59,9 +60,10 @@ public class TransformPipeline {
       if (recordTransformer instanceof FilterTransformer) {
         filterTransformer = (FilterTransformer) recordTransformer;
       }
-      recordTransformer.withInputColumnsOfDownStreamTransformers(cumulativeInputColumns);
+      recordTransformer.withInputColumnsForDownstreamTransformers(cumulativeInputColumns);
       cumulativeInputColumns.addAll(recordTransformer.getInputColumns());
     }
+    _inputColumns = cumulativeInputColumns;
     _filterTransformer = filterTransformer;
   }
 
@@ -74,11 +76,7 @@ public class TransformPipeline {
   }
 
   public Set<String> getInputColumns() {
-    Set<String> inputColumns = new HashSet<>();
-    for (RecordTransformer transformer : _transformers) {
-      inputColumns.addAll(transformer.getInputColumns());
-    }
-    return inputColumns;
+    return _inputColumns;
   }
 
   public Result processRow(GenericRow decodedRow) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/TransformPipeline.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/TransformPipeline.java
@@ -53,11 +53,14 @@ public class TransformPipeline {
     _tableNameWithType = tableNameWithType;
     _transformers = transformers;
     FilterTransformer filterTransformer = null;
-    for (RecordTransformer recordTransformer : transformers) {
+    Set<String> cumulativeInputColumns = new HashSet<>();
+    for (int i = transformers.size() - 1; i >= 0; i--) {
+      RecordTransformer recordTransformer = transformers.get(i);
       if (recordTransformer instanceof FilterTransformer) {
         filterTransformer = (FilterTransformer) recordTransformer;
-        break;
       }
+      recordTransformer.withInputColumnsOfDownStreamTransformers(cumulativeInputColumns);
+      cumulativeInputColumns.addAll(recordTransformer.getInputColumns());
     }
     _filterTransformer = filterTransformer;
   }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/TransformPipelineTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/TransformPipelineTest.java
@@ -28,6 +28,7 @@ import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 
 
 public class TransformPipelineTest {
@@ -357,6 +358,30 @@ public class TransformPipelineTest {
             + "    {\n"
             + "      \"name\": \"commits.url\",\n"
             + "      \"dataType\": \"STRING\"\n"
+            + "    },\n"
+            + "    {\n"
+            + "      \"name\": \"a.id\",\n"
+            + "      \"dataType\": \"INT\"\n"
+            + "    },\n"
+            + "    {\n"
+            + "      \"name\": \"a.login\",\n"
+            + "      \"dataType\": \"STRING\"\n"
+            + "    },\n"
+            + "    {\n"
+            + "      \"name\": \"a.display_login\",\n"
+            + "      \"dataType\": \"STRING\"\n"
+            + "    },\n"
+            + "    {\n"
+            + "      \"name\": \"a.gravatar_id\",\n"
+            + "      \"dataType\": \"STRING\"\n"
+            + "    },\n"
+            + "    {\n"
+            + "      \"name\": \"a.url\",\n"
+            + "      \"dataType\": \"STRING\"\n"
+            + "    },\n"
+            + "    {\n"
+            + "      \"name\": \"a.avatar_url\",\n"
+            + "      \"dataType\": \"STRING\"\n"
             + "    }\n"
             + "  ],\n"
             + "  \"dateTimeFieldSpecs\": [\n"
@@ -441,8 +466,9 @@ public class TransformPipelineTest {
     assertEquals(transformedRow.getValue("a.url"), "https://api.github.com/users/LimeVista");
     assertEquals(transformedRow.getValue("a.avatar_url"), "https://avatars.githubusercontent.com/u/18542751?");
 
-    assertEquals(transformedRow.getValue("r.id"), 115911530);
-    assertEquals(transformedRow.getValue("r.name"), "LimeVista/Tapes");
-    assertEquals(transformedRow.getValue("r.url"), "https://api.github.com/repos/LimeVista/Tapes");
+    // field names should be in the schema
+    assertNull(transformedRow.getValue("r.id"));
+    assertNull(transformedRow.getValue("r.name"));
+    assertNull(transformedRow.getValue("r.url"));
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/TransformPipelineTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/TransformPipelineTest.java
@@ -28,7 +28,6 @@ import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertNull;
 
 
 public class TransformPipelineTest {
@@ -358,30 +357,6 @@ public class TransformPipelineTest {
             + "    {\n"
             + "      \"name\": \"commits.url\",\n"
             + "      \"dataType\": \"STRING\"\n"
-            + "    },\n"
-            + "    {\n"
-            + "      \"name\": \"a.id\",\n"
-            + "      \"dataType\": \"INT\"\n"
-            + "    },\n"
-            + "    {\n"
-            + "      \"name\": \"a.login\",\n"
-            + "      \"dataType\": \"STRING\"\n"
-            + "    },\n"
-            + "    {\n"
-            + "      \"name\": \"a.display_login\",\n"
-            + "      \"dataType\": \"STRING\"\n"
-            + "    },\n"
-            + "    {\n"
-            + "      \"name\": \"a.gravatar_id\",\n"
-            + "      \"dataType\": \"STRING\"\n"
-            + "    },\n"
-            + "    {\n"
-            + "      \"name\": \"a.url\",\n"
-            + "      \"dataType\": \"STRING\"\n"
-            + "    },\n"
-            + "    {\n"
-            + "      \"name\": \"a.avatar_url\",\n"
-            + "      \"dataType\": \"STRING\"\n"
             + "    }\n"
             + "  ],\n"
             + "  \"dateTimeFieldSpecs\": [\n"
@@ -466,9 +441,8 @@ public class TransformPipelineTest {
     assertEquals(transformedRow.getValue("a.url"), "https://api.github.com/users/LimeVista");
     assertEquals(transformedRow.getValue("a.avatar_url"), "https://avatars.githubusercontent.com/u/18542751?");
 
-    // field names should be in the schema
-    assertNull(transformedRow.getValue("r.id"));
-    assertNull(transformedRow.getValue("r.name"));
-    assertNull(transformedRow.getValue("r.url"));
+    assertEquals(transformedRow.getValue("r.id"), 115911530);
+    assertEquals(transformedRow.getValue("r.name"), "LimeVista/Tapes");
+    assertEquals(transformedRow.getValue("r.url"), "https://api.github.com/repos/LimeVista/Tapes");
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/GenericRow.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/GenericRow.java
@@ -164,7 +164,7 @@ public class GenericRow implements Serializable {
   /**
    * @return a deep copy of the generic row for the given fields
    */
-  public GenericRow copy(List<String> fieldsToCopy) {
+  public GenericRow copy(Collection<String> fieldsToCopy) {
     GenericRow copy = new GenericRow();
     for (String field : fieldsToCopy) {
       copy.putValue(field, copy(getValue(field)));

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/GenericRow.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/GenericRow.java
@@ -164,7 +164,7 @@ public class GenericRow implements Serializable {
   /**
    * @return a deep copy of the generic row for the given fields
    */
-  public GenericRow copy(Collection<String> fieldsToCopy) {
+  public GenericRow copy(List<String> fieldsToCopy) {
     GenericRow copy = new GenericRow();
     for (String field : fieldsToCopy) {
       copy.putValue(field, copy(getValue(field)));

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/recordtransformer/RecordTransformer.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/recordtransformer/RecordTransformer.java
@@ -40,8 +40,8 @@ public interface RecordTransformer extends Serializable {
     return List.of();
   }
 
-  /// Provides hint to the transformer with all the columns that are required as input across all the downstream
-  /// transformers in the TransformPipeline.
+  /// Provides hint to the transformer that which columns are required as input across all the downstream transformers
+  /// in the TransformPipeline.
   default void withInputColumnsOfDownStreamTransformers(Collection<String> inputColumnsOfDownstream) {
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/recordtransformer/RecordTransformer.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/recordtransformer/RecordTransformer.java
@@ -41,9 +41,14 @@ public interface RecordTransformer extends Serializable {
     return List.of();
   }
 
-  /// Provides hint to the transformer that which columns are required as input across all the downstream transformers
-  /// in the TransformPipeline.
-  default void withInputColumnsForDownstreamTransformers(Set<String> inputColumnsOfDownstream) {
+  /**
+   * Provides a hint to the transformer about which columns are required as input across all downstream transformers
+   * in the TransformPipeline. This can be used for optimization or to ensure necessary fields are available.
+   *
+   * @param inputColumns Set of column names that are required by all downstream transformers as their input columns.
+   *                     This set is mutable, implementations should make a copy if they need to preserve the set.
+   */
+  default void withInputColumnsForDownstreamTransformers(Set<String> inputColumns) {
   }
 
   /// Transforms and returns records based on some custom rules. Implement this method when the transformer can produce

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/recordtransformer/RecordTransformer.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/recordtransformer/RecordTransformer.java
@@ -40,6 +40,11 @@ public interface RecordTransformer extends Serializable {
     return List.of();
   }
 
+  /// Provides hint to the transformer with all the columns that are required as input across all the downstream
+  /// transformers in the TransformPipeline.
+  default void withInputColumnsOfDownStreamTransformers(Collection<String> inputColumnsOfDownstream) {
+  }
+
   /// Transforms and returns records based on some custom rules. Implement this method when the transformer can produce
   /// more records (e.g. unnesting) or fewer records (e.g. filtering).
   default List<GenericRow> transform(List<GenericRow> records) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/recordtransformer/RecordTransformer.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/recordtransformer/RecordTransformer.java
@@ -21,6 +21,7 @@ package org.apache.pinot.spi.recordtransformer;
 import java.io.Serializable;
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 import org.apache.pinot.spi.data.readers.GenericRow;
 
 
@@ -42,7 +43,7 @@ public interface RecordTransformer extends Serializable {
 
   /// Provides hint to the transformer that which columns are required as input across all the downstream transformers
   /// in the TransformPipeline.
-  default void withInputColumnsOfDownStreamTransformers(Collection<String> inputColumnsOfDownstream) {
+  default void withInputColumnsForDownstreamTransformers(Set<String> inputColumnsOfDownstream) {
   }
 
   /// Transforms and returns records based on some custom rules. Implement this method when the transformer can produce


### PR DESCRIPTION
## Description
Current `ComplexTypeTranformer` keeps original values of all unnest fields (see https://github.com/apache/pinot/pull/13490), and also some fields that are flattened but never used down the line nor in the schema.

It introduced issue: https://github.com/apache/pinot/issues/15665, where resources were eaten up by keeping these original values.

This PR adds a method 
```
  default void withInputColumnsOfDownStreamTransformers(Collection<String> inputColumnsOfDownstream) {
  }
```
in `org.apache.pinot.spi.recordtransformer.RecordTransformer`
It provides hint to the transformer that which columns are required as input across all the downstream transformers in the `TransformPipeline`.

In `ComplexTypeTranformer`, if a field is not needed as input in any downstream transformer, we don't keep it in the `GenericRow`. Doing so reduces the resource taken to store unnecessary fields.