### PR TITLE
Fix query cancellation on op-chain not scheduled

### DIFF
--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/executor/OpChainSchedulerServiceTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/executor/OpChainSchedulerServiceTest.java
@@ -34,10 +34,10 @@ import org.apache.pinot.query.runtime.operator.MultiStageOperator;
 import org.apache.pinot.query.runtime.operator.OpChain;
 import org.apache.pinot.query.runtime.plan.MultiStageQueryStats;
 import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
+import org.apache.pinot.spi.exception.QueryCancelledException;
 import org.apache.pinot.spi.executor.ExecutorServiceUtils;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
-import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
@@ -46,6 +46,8 @@ import org.testng.annotations.Test;
 import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 
 public class OpChainSchedulerServiceTest {
@@ -81,8 +83,7 @@ public class OpChainSchedulerServiceTest {
     WorkerMetadata workerMetadata = new WorkerMetadata(0, Map.of(), Map.of());
     OpChainExecutionContext context =
         new OpChainExecutionContext(mailboxService, 123L, Long.MAX_VALUE, Long.MAX_VALUE, Map.of(),
-            new StageMetadata(0, ImmutableList.of(workerMetadata), Map.of()), workerMetadata, null, null,
-            true);
+            new StageMetadata(0, ImmutableList.of(workerMetadata), Map.of()), workerMetadata, null, null, true);
     return new OpChain(context, operator);
   }
 
@@ -100,7 +101,7 @@ public class OpChainSchedulerServiceTest {
 
     schedulerService.register(opChain);
 
-    Assert.assertTrue(latch.await(10, TimeUnit.SECONDS), "expected await to be called in less than 10 seconds");
+    assertTrue(latch.await(10, TimeUnit.SECONDS), "expected await to be called in less than 10 seconds");
   }
 
   @Test
@@ -117,7 +118,7 @@ public class OpChainSchedulerServiceTest {
 
     schedulerService.register(opChain);
 
-    Assert.assertTrue(latch.await(10, TimeUnit.SECONDS), "expected await to be called in less than 10 seconds");
+    assertTrue(latch.await(10, TimeUnit.SECONDS), "expected await to be called in less than 10 seconds");
   }
 
   @Test
@@ -135,7 +136,7 @@ public class OpChainSchedulerServiceTest {
 
     schedulerService.register(opChain);
 
-    Assert.assertTrue(latch.await(10, TimeUnit.SECONDS), "expected await to be called in less than 10 seconds");
+    assertTrue(latch.await(10, TimeUnit.SECONDS), "expected await to be called in less than 10 seconds");
   }
 
   @Test
@@ -153,7 +154,7 @@ public class OpChainSchedulerServiceTest {
 
     schedulerService.register(opChain);
 
-    Assert.assertTrue(latch.await(10, TimeUnit.SECONDS), "expected await to be called in less than 10 seconds");
+    assertTrue(latch.await(10, TimeUnit.SECONDS), "expected await to be called in less than 10 seconds");
   }
 
   @Test
@@ -179,12 +180,12 @@ public class OpChainSchedulerServiceTest {
 
     schedulerService.register(opChain);
 
-    Assert.assertTrue(opChainStarted.await(10, TimeUnit.SECONDS), "op chain doesn't seem to be started");
+    assertTrue(opChainStarted.await(10, TimeUnit.SECONDS), "op chain doesn't seem to be started");
 
     // now cancel the request.
-    schedulerService.cancel(123);
+    schedulerService.cancel(123L);
 
-    Assert.assertTrue(cancelLatch.await(10, TimeUnit.SECONDS), "expected OpChain to be cancelled");
+    assertTrue(cancelLatch.await(10, TimeUnit.SECONDS), "expected OpChain to be cancelled");
     Mockito.verify(_operatorA, Mockito.times(1)).cancel(Mockito.any());
   }
 
@@ -203,7 +204,82 @@ public class OpChainSchedulerServiceTest {
 
     schedulerService.register(opChain);
 
-    Assert.assertTrue(cancelLatch.await(10, TimeUnit.SECONDS), "expected OpChain to be cancelled");
+    assertTrue(cancelLatch.await(10, TimeUnit.SECONDS), "expected OpChain to be cancelled");
     Mockito.verify(_operatorA, Mockito.times(1)).cancel(Mockito.any());
+  }
+
+  @Test
+  public void shouldThrowQueryCancelledExceptionWhenRegisteringOpChainAfterQueryCancellation() {
+    OpChain opChain = getChain(_operatorA);
+    OpChainSchedulerService schedulerService = new OpChainSchedulerService(_executor);
+
+    // First cancel the query with the same requestId (123L as defined in getChain method)
+    schedulerService.cancel(123L);
+
+    // Now try to register an OpChain for the same query - should throw QueryCancelledException
+    try {
+      schedulerService.register(opChain);
+      fail("Expected QueryCancelledException to be thrown when registering OpChain after query cancellation");
+    } catch (QueryCancelledException e) {
+      assertTrue(e.getMessage().contains("Query has been cancelled before op-chain"));
+      assertTrue(e.getMessage().contains("being scheduled"));
+    }
+  }
+
+  @Test
+  public void shouldHandleConcurrentCancellationAndRegistration()
+      throws InterruptedException {
+    OpChain opChain = getChain(_operatorA);
+    OpChainSchedulerService schedulerService = new OpChainSchedulerService(_executor);
+
+    // Setup mock to slow down the execution so we can test concurrent cancellation
+    CountDownLatch registrationStarted = new CountDownLatch(1);
+    CountDownLatch cancellationCanProceed = new CountDownLatch(1);
+    Mockito.when(_operatorA.nextBlock()).thenAnswer(inv -> {
+      registrationStarted.countDown();
+      cancellationCanProceed.await();
+      return SuccessMseBlock.INSTANCE;
+    });
+    Mockito.doAnswer(inv -> MultiStageQueryStats.emptyStats(1)).when(_operatorA).calculateStats();
+
+    // Start registration in a separate thread
+    CountDownLatch registrationCompleted = new CountDownLatch(1);
+    boolean[] registrationSucceeded = {false};
+    Thread registrationThread = new Thread(() -> {
+      try {
+        schedulerService.register(opChain);
+        registrationSucceeded[0] = true;
+      } catch (QueryCancelledException e) {
+        // Expected if cancellation happens before registration
+        registrationSucceeded[0] = false;
+      } finally {
+        registrationCompleted.countDown();
+      }
+    });
+
+    registrationThread.start();
+
+    // Wait for registration to start
+    assertTrue(registrationStarted.await(10, TimeUnit.SECONDS), "Registration should have started");
+
+    // Now cancel the query while it's running
+    schedulerService.cancel(123L);
+
+    // Allow the opchain execution to complete
+    cancellationCanProceed.countDown();
+
+    // Wait for registration thread to complete
+    assertTrue(registrationCompleted.await(10, TimeUnit.SECONDS), "Registration thread should complete");
+
+    // The registration should have succeeded since it started before cancellation
+    assertTrue(registrationSucceeded[0], "Registration should have succeeded");
+
+    // Now try to register another OpChain with the same requestId - should fail
+    try {
+      schedulerService.register(getChain(_operatorA));
+      fail("Expected QueryCancelledException for subsequent registration after cancellation");
+    } catch (QueryCancelledException e) {
+      assertTrue(e.getMessage().contains("Query has been cancelled before op-chain"));
+    }
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -1953,7 +1953,17 @@ public class CommonConstants {
     /// Max time to keep the op stats in the cache.
     public static final String KEY_OF_OP_STATS_CACHE_EXPIRE_MS = "pinot.server.query.op.stats.cache.ms";
     public static final int DEFAULT_OF_OP_STATS_CACHE_EXPIRE_MS = 60 * 1000;
+
+    /// Max number of cancelled queries to keep in the cache.
+    public static final String KEY_OF_CANCELLED_QUERY_CACHE_SIZE = "pinot.server.query.cancelled.cache.size";
+    public static final int DEFAULT_OF_CANCELLED_QUERY_CACHE_SIZE = 1000;
+
+    /// Max time to keep the cancelled queries in the cache.
+    public static final String KEY_OF_CANCELLED_QUERY_CACHE_EXPIRE_MS = "pinot.server.query.cancelled.cache.ms";
+    public static final int DEFAULT_OF_CANCELLED_QUERY_CACHE_EXPIRE_MS = 60 * 1000;
+
     /// Timeout of the cancel request, in milliseconds.
+    /// TODO: This is used by the broker. Consider renaming it.
     public static final String KEY_OF_CANCEL_TIMEOUT_MS = "pinot.server.query.cancel.timeout.ms";
     public static final long DEFAULT_OF_CANCEL_TIMEOUT_MS = 1000;
   }


### PR DESCRIPTION
## Fix query cancellation race condition for unscheduled op-chains

### Problem

Previously, there was a race condition in the multi-stage query engine where query cancellation could fail to prevent new OpChains from being scheduled after the cancellation request was issued. This occurred because:

1. **Race condition**: The `cancel()` method only cancelled already-submitted OpChains in `_submittedOpChainMap`, but new OpChains could still be registered and scheduled after cancellation
2. **Missing synchronization**: There was no coordination between the cancellation process and OpChain registration
3. **Incomplete cancellation**: OpChains that hadn't been scheduled yet would continue to execute even after the query was cancelled

This could lead to:
- Resource waste from executing cancelled queries
- Delayed query termination
- Inconsistent cancellation behavior across different timing scenarios

### Solution

This PR introduces a comprehensive fix with proper synchronization and state tracking:

#### 1. **Cancelled Query Cache**
- Added `_cancelledQueryCache` to track queries that have been cancelled
- Prevents scheduling of new OpChains for cancelled queries
- Configurable cache size and expiration via new constants:
  - `KEY_OF_CANCELLED_QUERY_CACHE_SIZE` (default: 1000)
  - `KEY_OF_CANCELLED_QUERY_CACHE_EXPIRE_MS` (default: 60s)

#### 2. **Read/Write Lock Synchronization**
- Introduced `_queryLocks` array with 1024 ReadWriteLocks for fine-grained synchronization
- **Registration**: Acquires read lock to check cancellation status before scheduling
- **Cancellation**: Acquires write lock to mark query as cancelled
- Prevents race conditions between concurrent registration and cancellation operations

#### 3. **Enhanced Registration Logic**
- `register()` method now checks `_cancelledQueryCache` before scheduling OpChains
- Throws `QueryCancelledException` with descriptive message if query was already cancelled
- Maintains backward compatibility for non-cancelled queries

#### 4. **Improved Error Handling**
- Updated `PipelineBreakerExecutor` to handle `QueryCancelledException` with debug-level logging instead of error-level
- Distinguishes between cancellation (expected) and actual errors

### Key Changes

**OpChainSchedulerService.java:**
- Added cancelled query cache and read/write locks infrastructure
- Enhanced `register()` method with cancellation check and proper synchronization
- Updated `cancel()` method to mark queries as cancelled in the cache
- Added `getQueryLock()` helper for consistent lock access

**PipelineBreakerExecutor.java:**
- Improved exception handling for `QueryCancelledException`
- Reduced log noise for expected cancellation scenarios

**CommonConstants.java:**
- Added configuration constants for cancelled query cache tuning

### Testing

Added comprehensive test coverage in `OpChainSchedulerServiceTest`:

1. **`shouldThrowQueryCancelledExceptionWhenRegisteringOpChainAfterQueryCancellation()`**
   - Verifies that OpChain registration fails with proper exception after query cancellation

2. **`shouldHandleConcurrentCancellationAndRegistration()`**
   - Tests race condition handling between concurrent cancellation and registration
   - Ensures proper synchronization with read/write locks

3. **Updated existing tests** to use static imports and improved assertions

### Configuration

Added new configuration options:
- `pinot.server.query.cancelled.cache.size` (default: 1000) - Maximum number of cancelled queries to cache
- `pinot.server.query.cancelled.cache.ms` (default: 60000) - Cache expiration time in milliseconds

### Backward Compatibility

- All existing functionality remains unchanged
- New configuration parameters have sensible defaults
- No breaking changes to public APIs
- Graceful degradation if caches are disabled

### Performance Impact

- Minimal overhead: O(1) cache lookups and lightweight read/write locks
- Lock contention minimized through 1024-bucket lock striping
- Cache expiration prevents memory leaks from long-running systems

This fix ensures reliable query cancellation behavior in all timing scenarios while maintaining high performance and backward compatibility.
