### PR TITLE
[audit] Add audit logging configuration support with cluster config listener

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/audit/AuditConfig.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/audit/AuditConfig.java
@@ -38,7 +38,7 @@ public final class AuditConfig {
   @JsonProperty("capture.request.headers")
   private boolean _captureRequestHeaders = false;
 
-  @JsonProperty("max.payload.size")
+  @JsonProperty("payload.size.max.bytes")
   private int _maxPayloadSize = 10_240;
 
   @JsonProperty("excluded.endpoints")

--- a/pinot-common/src/main/java/org/apache/pinot/common/audit/AuditLogger.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/audit/AuditLogger.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
 public final class AuditLogger {
 
   private static final String PINOT_AUDIT_LOGGER_NAME = "org.apache.pinot.audit";
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
   // Default Pinot logger. For logging failures in audit logging itself
   private static final Logger LOG = LoggerFactory.getLogger(AuditLogger.class);
   private static final Logger AUDIT_LOGGER = LoggerFactory.getLogger(PINOT_AUDIT_LOGGER_NAME);

--- a/pinot-common/src/main/java/org/apache/pinot/common/audit/AuditRequestProcessor.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/audit/AuditRequestProcessor.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.common.audit;
 
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -82,7 +83,8 @@ public class AuditRequestProcessor {
       }
 
       // Log the audit event (service ID will be extracted from headers, not config)
-      return new AuditEvent().setEndpoint(endpoint)
+      return new AuditEvent().setTimestamp(Instant.now().toString())
+          .setEndpoint(endpoint)
           .setServiceId(extractServiceId(requestContext))
           .setMethod(requestContext.getMethod())
           .setOriginIpAddress(extractClientIpAddress(requestContext, remoteAddr))

--- a/pinot-common/src/test/java/org/apache/pinot/common/audit/AuditConfigManagerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/audit/AuditConfigManagerTest.java
@@ -1,0 +1,147 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.audit;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.helix.model.ClusterConfig;
+import org.testng.annotations.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+
+/**
+ * Unit tests for AuditConfigManager to verify correct config injection
+ * when onClusterConfigChange is called.
+ */
+public class AuditConfigManagerTest {
+
+  @Test
+  public void testOnClusterConfigChangeWithAllConfigs() {
+    // Given
+    ClusterConfig clusterConfig = createClusterConfig(
+        Map.of("pinot.audit.enabled", "true", "pinot.audit.capture.request.payload.enabled", "true",
+            "pinot.audit.capture.request.headers", "true", "pinot.audit.payload.size.max.bytes", "20480",
+            "pinot.audit.excluded.endpoints", "/health,/metrics"));
+
+    AuditConfigManager manager = new AuditConfigManager();
+
+    // When
+    manager.onClusterConfigChange(clusterConfig, null);
+
+    // Then
+    AuditConfig config = manager.getCurrentConfig();
+    assertThat(config.isEnabled()).isTrue();
+    assertThat(config.isCaptureRequestPayload()).isTrue();
+    assertThat(config.isCaptureRequestHeaders()).isTrue();
+    assertThat(config.getMaxPayloadSize()).isEqualTo(20480);
+    assertThat(config.getExcludedEndpoints()).isEqualTo("/health,/metrics");
+  }
+
+  @Test
+  public void testOnClusterConfigChangeWithPartialConfigs() {
+    // Given
+    ClusterConfig clusterConfig =
+        createClusterConfig(Map.of("pinot.audit.enabled", "true", "pinot.audit.payload.size.max.bytes", "5000"));
+
+    AuditConfigManager manager = new AuditConfigManager();
+
+    // When
+    manager.onClusterConfigChange(clusterConfig, null);
+
+    // Then
+    AuditConfig config = manager.getCurrentConfig();
+    assertThat(config.isEnabled()).isTrue();
+    assertThat(config.getMaxPayloadSize()).isEqualTo(5000);
+    // Verify defaults for unspecified configs
+    assertThat(config.isCaptureRequestPayload()).isFalse();
+    assertThat(config.isCaptureRequestHeaders()).isFalse();
+    assertThat(config.getExcludedEndpoints()).isEmpty();
+  }
+
+  @Test
+  public void testOnClusterConfigChangeWithNoAuditConfigs() {
+    // Given
+    ClusterConfig clusterConfig = createClusterConfig(Map.of());
+    AuditConfigManager manager = new AuditConfigManager();
+
+    // When
+    manager.onClusterConfigChange(clusterConfig, null);
+
+    // Then
+    AuditConfig config = manager.getCurrentConfig();
+    assertThat(config.isEnabled()).isFalse();
+    assertThat(config.isCaptureRequestPayload()).isFalse();
+    assertThat(config.isCaptureRequestHeaders()).isFalse();
+    assertThat(config.getMaxPayloadSize()).isEqualTo(10240);
+    assertThat(config.getExcludedEndpoints()).isEmpty();
+  }
+
+  @Test
+  public void testConfigUpdateOverwritesPrevious() {
+    // Given
+    AuditConfigManager manager = new AuditConfigManager();
+
+    // Set initial config
+    ClusterConfig initialConfig =
+        createClusterConfig(Map.of("pinot.audit.enabled", "true", "pinot.audit.payload.size.max.bytes", "15000"));
+    manager.onClusterConfigChange(initialConfig, null);
+    assertThat(manager.getCurrentConfig().isEnabled()).isTrue();
+    assertThat(manager.getCurrentConfig().getMaxPayloadSize()).isEqualTo(15000);
+
+    // When - Update with new config
+    ClusterConfig updatedConfig =
+        createClusterConfig(Map.of("pinot.audit.enabled", "false", "pinot.audit.payload.size.max.bytes", "25000"));
+    manager.onClusterConfigChange(updatedConfig, null);
+
+    // Then
+    assertThat(manager.getCurrentConfig().isEnabled()).isFalse();
+    assertThat(manager.getCurrentConfig().getMaxPayloadSize()).isEqualTo(25000);
+  }
+
+  @Test
+  public void testBuildFromClusterConfigDirectly() {
+    // Given
+    ClusterConfig clusterConfig = createClusterConfig(
+        Map.of("pinot.audit.enabled", "true", "pinot.audit.capture.request.payload.enabled", "false",
+            "pinot.audit.capture.request.headers", "true"));
+
+    // When
+    AuditConfig config = AuditConfigManager.buildFromClusterConfig(clusterConfig);
+
+    // Then
+    assertThat(config.isEnabled()).isTrue();
+    assertThat(config.isCaptureRequestPayload()).isFalse();
+    assertThat(config.isCaptureRequestHeaders()).isTrue();
+    // Verify defaults for unspecified fields
+    assertThat(config.getMaxPayloadSize()).isEqualTo(10240);
+    assertThat(config.getExcludedEndpoints()).isEmpty();
+  }
+
+  // Helper method to create ClusterConfig with given properties
+  private ClusterConfig createClusterConfig(Map<String, String> properties) {
+    ClusterConfig clusterConfig = new ClusterConfig("testCluster");
+    Map<String, String> allProperties = new HashMap<>(properties);
+    // Add some non-audit configs to verify filtering works
+    allProperties.put("some.other.config", "value");
+    allProperties.put("another.config", "123");
+    clusterConfig.getRecord().setSimpleFields(allProperties);
+    return clusterConfig;
+  }
+}


### PR DESCRIPTION
## Summary
- Implemented cluster config listener support for AuditConfigManager to enable dynamic audit configuration updates
- Added AuditConfigManager integration in BaseControllerStarter with proper HK2 dependency injection
- Created comprehensive unit tests for configuration injection and updates

## Changes
- Modified `AuditConfigManager` to implement `ClusterConfigChangeListener` interface for real-time config updates
- Updated `BaseControllerStarter` to initialize and register AuditConfigManager as a cluster config listener
- Added unit tests to verify proper config injection when cluster configs change

## Test plan
- Added `AuditConfigManagerTest` with tests covering:
  - Full config injection
  - Partial config with defaults
  - No config (all defaults)
  - Config updates overwriting previous values
  - Direct config building from ClusterConfig

## Related Issues
Part of audit logging feature implementation