### PR TITLE
Add support for minimum should match in lucene text search

### DIFF
--- a/pinot-core/src/test/java/org/apache/pinot/queries/TextSearchQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/TextSearchQueriesTest.java
@@ -2353,13 +2353,13 @@ public class TextSearchQueriesTest extends BaseQueriesTest {
 
     String queryMin2Of3 =
         "SELECT INT_COL, SKILLS_TEXT_COL FROM " + TABLE_NAME + " WHERE TEXT_MATCH(" + SKILLS_TEXT_COL_NAME
-            + ", 'AWS hadoop big', 'parser=MINIMUM_SHOULD_MATCH,minimumShouldMatch=2') LIMIT 50000";
+            + ", 'AWS hadoop big', 'parser=MATCH,minimumShouldMatch=2') LIMIT 50000";
     testTextSearchSelectQueryHelper(queryMin2Of3, expectedMin2Of3.size(), false, expectedMin2Of3);
 
     // Test 2: Percentage minimum_should_match - require at least 60% (2 out of 3 terms)
     String queryMin80Percent =
         "SELECT INT_COL, SKILLS_TEXT_COL FROM " + TABLE_NAME + " WHERE TEXT_MATCH(" + SKILLS_TEXT_COL_NAME
-            + ", 'AWS hadoop big', 'parser=MINIMUM_SHOULD_MATCH,minimumShouldMatch=80%') LIMIT 50000";
+            + ", 'AWS hadoop big', 'parser=MATCH,minimumShouldMatch=80%') LIMIT 50000";
     testTextSearchSelectQueryHelper(queryMin80Percent, expectedMin2Of3.size(), false, expectedMin2Of3);
 
     // Test 3: Require at least 1 out of 2 terms (minimumShouldMatch=1) - Stanford Tensor
@@ -2378,7 +2378,7 @@ public class TextSearchQueriesTest extends BaseQueriesTest {
 
     String queryMin1Of2 =
         "SELECT INT_COL, SKILLS_TEXT_COL FROM " + TABLE_NAME + " WHERE TEXT_MATCH(" + SKILLS_TEXT_COL_NAME
-            + ", 'Stanford Tensor', 'parser=MINIMUM_SHOULD_MATCH,minimumShouldMatch=1') LIMIT 50000";
+            + ", 'Stanford Tensor', 'parser=MATCH,minimumShouldMatch=1') LIMIT 50000";
     testTextSearchSelectQueryHelper(queryMin1Of2, expectedMin1Of2.size(), false, expectedMin1Of2);
 
     // Test 4: Require at least 3 out of 4 terms (minimumShouldMatch=3) - Apache Kafka publish subscribe
@@ -2390,7 +2390,7 @@ public class TextSearchQueriesTest extends BaseQueriesTest {
 
     String queryMin3Of4 =
         "SELECT INT_COL, SKILLS_TEXT_COL FROM " + TABLE_NAME + " WHERE TEXT_MATCH(" + SKILLS_TEXT_COL_NAME
-            + ", 'Apache Kafka publish subscribe', 'parser=MINIMUM_SHOULD_MATCH,minimumShouldMatch=3') LIMIT 50000";
+            + ", 'Apache Kafka publish subscribe', 'parser=MATCH,minimumShouldMatch=3') LIMIT 50000";
     testTextSearchSelectQueryHelper(queryMin3Of4, expectedMin3Of4.size(), false, expectedMin3Of4);
 
     // Test 5: Require all 3 terms (minimumShouldMatch=3) - AWS hadoop spark
@@ -2402,7 +2402,7 @@ public class TextSearchQueriesTest extends BaseQueriesTest {
 
     String queryMin3Of3 =
         "SELECT INT_COL, SKILLS_TEXT_COL FROM " + TABLE_NAME + " WHERE TEXT_MATCH(" + SKILLS_TEXT_COL_NAME
-            + ", 'AWS hadoop spark', 'parser=MINIMUM_SHOULD_MATCH,minimumShouldMatch=3') LIMIT 50000";
+            + ", 'AWS hadoop spark', 'parser=MATCH,minimumShouldMatch=3') LIMIT 50000";
     testTextSearchSelectQueryHelper(queryMin3Of3, expectedMin3Of3.size(), false, expectedMin3Of3);
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/TextSearchQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/TextSearchQueriesTest.java
@@ -2341,63 +2341,68 @@ public class TextSearchQueriesTest extends BaseQueriesTest {
         "Expected error related to leading wildcard or text search failure, got: " + errorMsg);
   }
 
-  // ===== TEST CASES FOR MINIMUM_SHOULD_MATCH PARSER =====
   @Test
   public void testTextSearchWithMinimumShouldMatchParser()
       throws Exception {
-    // Test 1: Positive integer minimum_should_match - require at least 2 out of 3 terms
+    // Test 1: Require at least 2 out of 3 terms (minimumShouldMatch=2) - AWS hadoop big
     List<Object[]> expectedMin2Of3 = new ArrayList<>();
     expectedMin2Of3.add(new Object[]{
-        1010, "Distributed systems, Java, realtime streaming systems, Machine learning, spark, Kubernetes, distributed "
-        + "storage, concurrency, multi-threading"
-    });
-    expectedMin2Of3.add(new Object[]{
-        1018,
-        "Realtime stream processing, publish subscribe, columnar processing for data warehouses, concurrency, Java, "
-            + "multi-threading, C++,"
-    });
-    expectedMin2Of3.add(new Object[]{
-        1019,
-        "C++, Java, Python, realtime streaming systems, Machine learning, spark, Kubernetes, transaction processing, "
-            + "distributed storage, concurrency, multi-threading, apache airflow"
+        1008, "Amazon EC2, AWS, hadoop, big data, spark, building high performance scalable systems, building and "
+        + "deploying large scale production systems, concurrency, multi-threading, Java, C++, CPU processing"
     });
 
     String queryMin2Of3 =
         "SELECT INT_COL, SKILLS_TEXT_COL FROM " + TABLE_NAME + " WHERE TEXT_MATCH(" + SKILLS_TEXT_COL_NAME
-            + ", 'Java realtime streaming', 'parser=MINIMUM_SHOULD_MATCH,minimumShouldMatch=2') LIMIT 50000";
+            + ", 'AWS hadoop big', 'parser=MINIMUM_SHOULD_MATCH,minimumShouldMatch=2') LIMIT 50000";
     testTextSearchSelectQueryHelper(queryMin2Of3, expectedMin2Of3.size(), false, expectedMin2Of3);
 
-    // Test 2: Percentage minimum_should_match - require at least 80% (2 out of 3 terms)
+    // Test 2: Percentage minimum_should_match - require at least 60% (2 out of 3 terms)
     String queryMin80Percent =
         "SELECT INT_COL, SKILLS_TEXT_COL FROM " + TABLE_NAME + " WHERE TEXT_MATCH(" + SKILLS_TEXT_COL_NAME
-            + ", 'Java realtime streaming', 'parser=MINIMUM_SHOULD_MATCH,minimumShouldMatch=80%') LIMIT 50000";
+            + ", 'AWS hadoop big', 'parser=MINIMUM_SHOULD_MATCH,minimumShouldMatch=80%') LIMIT 50000";
     testTextSearchSelectQueryHelper(queryMin80Percent, expectedMin2Of3.size(), false, expectedMin2Of3);
 
-    // Test 3: Single term query (minimum_should_match should be ignored)
-    List<Object[]> expectedSingleTerm = new ArrayList<>();
-    expectedSingleTerm.add(new Object[]{
-        1005,
-        "Distributed systems, Java, C++, Go, distributed query engines for analytics and data warehouses, Machine "
-            + "learning, spark, Kubernetes, transaction processing"
+    // Test 3: Require at least 1 out of 2 terms (minimumShouldMatch=1) - Stanford Tensor
+    List<Object[]> expectedMin1Of2 = new ArrayList<>();
+    expectedMin1Of2.add(new Object[]{
+        1004, "Machine learning, Tensor flow, Java, Stanford university,"
     });
-    expectedSingleTerm.add(new Object[]{
-        1010, "Distributed systems, Java, realtime streaming systems, Machine learning, spark, Kubernetes, distributed "
-        + "storage, concurrency, multi-threading"
+    expectedMin1Of2.add(new Object[]{
+        1007, "C++, Python, Tensor flow, database kernel, storage, indexing and transaction processing, building "
+        + "large scale systems, Machine learning"
     });
-    expectedSingleTerm.add(new Object[]{
-        1017,
-        "Distributed systems, Apache Kafka, publish-subscribe, building and deploying large scale production systems,"
-            + " concurrency, multi-threading, C++, CPU processing, Java"
-    });
-    expectedSingleTerm.add(new Object[]{
-        1019,
-        "C++, Java, Python, realtime streaming systems, Machine learning, spark, Kubernetes, transaction processing, "
-            + "distributed storage, concurrency, multi-threading, apache airflow"
+    expectedMin1Of2.add(new Object[]{
+        1016, "CUDA, GPU processing, Tensor flow, Pandas, Python, Jupyter notebook, spark, Machine learning, building"
+        + " high performance scalable systems"
     });
 
-    String querySingleTerm =
+    String queryMin1Of2 =
         "SELECT INT_COL, SKILLS_TEXT_COL FROM " + TABLE_NAME + " WHERE TEXT_MATCH(" + SKILLS_TEXT_COL_NAME
-            + ", 'Java', 'parser=MINIMUM_SHOULD_MATCH,minimumShouldMatch=2') LIMIT 50000";
-    testTextSearchSelectQueryHelper(querySingleTerm, expectedSingleTerm.size(), false, expectedSingleTerm);
+            + ", 'Stanford Tensor', 'parser=MINIMUM_SHOULD_MATCH,minimumShouldMatch=1') LIMIT 50000";
+    testTextSearchSelectQueryHelper(queryMin1Of2, expectedMin1Of2.size(), false, expectedMin1Of2);
+
+    // Test 4: Require at least 3 out of 4 terms (minimumShouldMatch=3) - Apache Kafka publish subscribe
+    List<Object[]> expectedMin3Of4 = new ArrayList<>();
+    expectedMin3Of4.add(new Object[]{
+        1017, "Distributed systems, Apache Kafka, publish-subscribe, building and deploying large scale production "
+        + "systems, concurrency, multi-threading, C++, CPU processing, Java"
+    });
+
+    String queryMin3Of4 =
+        "SELECT INT_COL, SKILLS_TEXT_COL FROM " + TABLE_NAME + " WHERE TEXT_MATCH(" + SKILLS_TEXT_COL_NAME
+            + ", 'Apache Kafka publish subscribe', 'parser=MINIMUM_SHOULD_MATCH,minimumShouldMatch=3') LIMIT 50000";
+    testTextSearchSelectQueryHelper(queryMin3Of4, expectedMin3Of4.size(), false, expectedMin3Of4);
+
+    // Test 5: Require all 3 terms (minimumShouldMatch=3) - AWS hadoop spark
+    List<Object[]> expectedMin3Of3 = new ArrayList<>();
+    expectedMin3Of3.add(new Object[]{
+        1008, "Amazon EC2, AWS, hadoop, big data, spark, building high performance scalable systems, building and "
+        + "deploying large scale production systems, concurrency, multi-threading, Java, C++, CPU processing"
+    });
+
+    String queryMin3Of3 =
+        "SELECT INT_COL, SKILLS_TEXT_COL FROM " + TABLE_NAME + " WHERE TEXT_MATCH(" + SKILLS_TEXT_COL_NAME
+            + ", 'AWS hadoop spark', 'parser=MINIMUM_SHOULD_MATCH,minimumShouldMatch=3') LIMIT 50000";
+    testTextSearchSelectQueryHelper(queryMin3Of3, expectedMin3Of3.size(), false, expectedMin3Of3);
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/text/lucene/parsers/MatchQueryParser.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/text/lucene/parsers/MatchQueryParser.java
@@ -214,7 +214,7 @@ public class MatchQueryParser extends QueryParserBase {
       return builder.build();
     }
 
-    //All the other queries are returned as is
+    // All the other queries are returned as is
     return parsedQuery;
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/text/lucene/parsers/MatchQueryParser.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/text/lucene/parsers/MatchQueryParser.java
@@ -68,7 +68,7 @@ import org.apache.lucene.search.TermQuery;
  * <p>This parser extends Lucene's QueryParserBase and implements the required abstract methods.
  * It uses the provided Analyzer for tokenization and creates appropriate Lucene Boolean queries.</p>
  */
-public class MinimumShouldMatchQueryParser extends QueryParserBase {
+public class MatchQueryParser extends QueryParserBase {
   /** The field name to search in */
   private final String _field;
 
@@ -91,7 +91,7 @@ public class MinimumShouldMatchQueryParser extends QueryParserBase {
    * @param analyzer the analyzer to use for tokenizing queries (must not be null)
    * @throws IllegalArgumentException if field or analyzer is null
    */
-  public MinimumShouldMatchQueryParser(String field, Analyzer analyzer) {
+  public MatchQueryParser(String field, Analyzer analyzer) {
     super();
     _field = field;
     _analyzer = analyzer;
@@ -214,9 +214,8 @@ public class MinimumShouldMatchQueryParser extends QueryParserBase {
       return builder.build();
     }
 
-    // For other query types, throw exception
-    throw new ParseException("MinimumShouldMatchQueryParser only supports Boolean queries and single term queries. "
-        + "Received: " + parsedQuery.getClass().getSimpleName());
+    //All the other queries are returned as is
+    return parsedQuery;
   }
 
   /**

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/text/lucene/parsers/MinimumShouldMatchQueryParser.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/text/lucene/parsers/MinimumShouldMatchQueryParser.java
@@ -1,0 +1,313 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.text.lucene.parsers;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.lucene.analysis.Analyzer;
+import org.apache.lucene.analysis.TokenStream;
+import org.apache.lucene.analysis.tokenattributes.CharTermAttribute;
+import org.apache.lucene.index.Term;
+import org.apache.lucene.queryparser.charstream.CharStream;
+import org.apache.lucene.queryparser.classic.ParseException;
+import org.apache.lucene.queryparser.classic.QueryParserBase;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
+
+
+/**
+ * A custom query parser that implements OpenSearch's minimum_should_match behavior.
+ * This parser creates Boolean queries with should clauses and enforces a minimum
+ * number of matches, similar to OpenSearch's minimum_should_match parameter.
+ *
+ * <p>This parser supports the following minimum_should_match formats:</p>
+ * <ul>
+ *   <li><strong>Positive integer:</strong> "3" - at least 3 should clauses must match</li>
+ *   <li><strong>Negative integer:</strong> "-2" - at most 2 should clauses can be missing</li>
+ *   <li><strong>Positive percentage:</strong> "80%" - at least 80% of should clauses must match</li>
+ *   <li><strong>Negative percentage:</strong> "-20%" - at most 20% of should clauses can be missing</li>
+ * </ul>
+ *
+ * <p><strong>Example usage:</strong></p>
+ * <ul>
+ *   <li>Input: 'java OR python OR scala' with minimumShouldMatch=2
+ *       <br>Output: BooleanQuery with 3 should clauses, requiring at least 2 matches</li>
+ *   <li>Input: 'machine learning OR deep learning OR neural networks' with minimumShouldMatch="80%"
+ *       <br>Output: BooleanQuery with 3 should clauses, requiring at least 2 matches (80% of 3 = 2.4, rounded down
+ *       to 2)</li>
+ *   <li>Input: 'error OR warning OR critical' with minimumShouldMatch="-1"
+ *       <br>Output: BooleanQuery with 3 should clauses, allowing at most 1 to be missing (requiring at least 2
+ *       matches)</li>
+ * </ul>
+ *
+ * <p><strong>Behavior:</strong></p>
+ * <ul>
+ *   <li>Single term queries: Returns TermQuery (minimum_should_match is ignored)</li>
+ *   <li>Multiple term queries: Returns BooleanQuery with should clauses and minimum match requirement</li>
+ *   <li>Null/empty queries: Throws ParseException</li>
+ *   <li>Whitespace-only queries: Throws ParseException</li>
+ * </ul>
+ *
+ * <p>This parser extends Lucene's QueryParserBase and implements the required abstract methods.
+ * It uses the provided Analyzer for tokenization and creates appropriate Lucene Boolean queries.</p>
+ */
+public class MinimumShouldMatchQueryParser extends QueryParserBase {
+  /** The field name to search in */
+  private final String _field;
+
+  /** The analyzer used for tokenizing the query */
+  private final Analyzer _analyzer;
+
+  /** The minimum should match specification (stored as string for dynamic calculation) */
+  private String _minimumShouldMatch = "1";
+
+  /** The default operator for combining terms */
+  private BooleanClause.Occur _defaultOperator = BooleanClause.Occur.SHOULD;
+
+  /** Pattern for parsing percentage values */
+  private static final Pattern PERCENTAGE_PATTERN = Pattern.compile("^(-?\\d+)%$");
+
+  /**
+   * Constructs a new MinimumShouldMatchQueryParser with the specified field and analyzer.
+   *
+   * @param field the field name to search in (must not be null)
+   * @param analyzer the analyzer to use for tokenizing queries (must not be null)
+   * @throws IllegalArgumentException if field or analyzer is null
+   */
+  public MinimumShouldMatchQueryParser(String field, Analyzer analyzer) {
+    super();
+    _field = field;
+    _analyzer = analyzer;
+  }
+
+  /**
+   * Sets the minimum number of should clauses that must match.
+   *
+   * <p>This method supports the same formats as OpenSearch's minimum_should_match:</p>
+   * <ul>
+   *   <li><strong>Positive integer:</strong> "3" - at least 3 should clauses must match</li>
+   *   <li><strong>Negative integer:</strong> "-2" - at most 2 should clauses can be missing</li>
+   *   <li><strong>Positive percentage:</strong> "80%" - at least 80% of should clauses must match</li>
+   *   <li><strong>Negative percentage:</strong> "-20%" - at most 20% of should clauses can be missing</li>
+   * </ul>
+   *
+   * <p>Examples:</p>
+   * <ul>
+   *   <li>setMinimumShouldMatch("3") - requires at least 3 matches</li>
+   *   <li>setMinimumShouldMatch("-1") - allows at most 1 to be missing</li>
+   *   <li>setMinimumShouldMatch("80%") - requires at least 80% matches</li>
+   *   <li>setMinimumShouldMatch("-20%") - allows at most 20% to be missing</li>
+   * </ul>
+   *
+   * @param minimumShouldMatch the minimum should match specification (integer or percentage)
+   * @throws IllegalArgumentException if the format is invalid or value is out of range
+   */
+  public void setMinimumShouldMatch(String minimumShouldMatch) {
+    if (minimumShouldMatch == null || minimumShouldMatch.trim().isEmpty()) {
+      _minimumShouldMatch = "1";
+      return;
+    }
+
+    String value = minimumShouldMatch.trim();
+
+    // Validate the format but store as string for dynamic calculation
+    Matcher matcher = PERCENTAGE_PATTERN.matcher(value);
+    if (matcher.matches()) {
+      int percentage = Integer.parseInt(matcher.group(1));
+      if (percentage < -100 || percentage > 100) {
+        throw new IllegalArgumentException("Percentage must be between -100 and 100: " + percentage);
+      }
+      _minimumShouldMatch = value;
+    } else {
+      // Try to parse as integer to validate
+      try {
+        Integer.parseInt(value);
+        _minimumShouldMatch = value;
+      } catch (NumberFormatException e) {
+        throw new IllegalArgumentException("Invalid minimum_should_match format: " + value
+            + ". Expected integer or percentage (e.g., '3', '-2', '80%', '-20%')");
+      }
+    }
+  }
+
+  /**
+   * Sets the default operator for combining terms.
+   *
+   * @param defaultOperator the default operator (MUST for AND, SHOULD for OR)
+   */
+  public void setDefaultOperator(BooleanClause.Occur defaultOperator) {
+    _defaultOperator = defaultOperator;
+  }
+
+  /**
+   * Parses the given query string and returns an appropriate Lucene Query.
+   *
+   * <p>This method performs the following steps:</p>
+   * <ol>
+   *   <li>Validates the input query (null, empty, whitespace-only)</li>
+   *   <li>Tokenizes the query using the configured analyzer</li>
+   *   <li>Creates appropriate Lucene queries based on the number of tokens and minimum_should_match setting</li>
+   * </ol>
+   *
+   * <p><strong>Query Types Returned:</strong></p>
+   * <ul>
+   *   <li><strong>Single term:</strong> TermQuery (minimum_should_match is ignored)</li>
+   *   <li><strong>Multiple terms:</strong> BooleanQuery with should clauses and minimum match requirement</li>
+   * </ul>
+   *
+   * @param query the query string to parse (must not be null or empty)
+   * @return a Lucene Query object representing the parsed query
+   * @throws ParseException if the query is null, empty, or contains no valid tokens after tokenization
+   * @throws RuntimeException if tokenization fails due to an IOException
+   */
+  @Override
+  public Query parse(String query)
+      throws ParseException {
+    if (query == null) {
+      throw new ParseException("Query cannot be null");
+    }
+
+    if (query.trim().isEmpty()) {
+      throw new ParseException("Query cannot be empty");
+    }
+
+    // Tokenize the query
+    List<String> tokens = new ArrayList<>();
+    try (TokenStream stream = _analyzer.tokenStream(_field, query)) {
+      stream.reset();
+      CharTermAttribute charTermAttribute = stream.addAttribute(CharTermAttribute.class);
+
+      while (stream.incrementToken()) {
+        String token = charTermAttribute.toString();
+        if (!token.trim().isEmpty()) {
+          tokens.add(token);
+        }
+      }
+      stream.end();
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to tokenize query: " + query, e);
+    }
+
+    // Check if we have any valid tokens after tokenization
+    if (tokens.isEmpty()) {
+      throw new ParseException("Query tokenization resulted in no valid tokens");
+    }
+
+    // Handle single token case
+    if (tokens.size() == 1) {
+      return new TermQuery(new Term(_field, tokens.get(0)));
+    }
+
+    // Handle multiple tokens case - create BooleanQuery with should clauses
+    BooleanQuery.Builder booleanQueryBuilder = new BooleanQuery.Builder();
+
+    for (String token : tokens) {
+      booleanQueryBuilder.add(new TermQuery(new Term(_field, token)), _defaultOperator);
+    }
+
+    // Calculate the actual minimum should match value
+    int actualMinimumShouldMatch = calculateMinimumShouldMatch(tokens.size());
+
+    // Set the minimum should match on the BooleanQuery
+    booleanQueryBuilder.setMinimumNumberShouldMatch(actualMinimumShouldMatch);
+
+    return booleanQueryBuilder.build();
+  }
+
+    /**
+   * Calculates the actual minimum should match value based on the number of tokens.
+   *
+   * <p>This method handles the different formats of minimum_should_match:</p>
+   * <ul>
+   *   <li>Positive integer: returns the value directly</li>
+   *   <li>Negative integer: returns (total tokens + negative value)</li>
+   *   <li>Positive percentage: returns (total tokens * percentage / 100), rounded down</li>
+   *   <li>Negative percentage: returns (total tokens * (100 + percentage) / 100), rounded down</li>
+   * </ul>
+   *
+   * @param totalTokens the total number of tokens in the query
+   * @return the calculated minimum should match value
+   */
+  private int calculateMinimumShouldMatch(int totalTokens) {
+    String value = _minimumShouldMatch.trim();
+    
+    // Check if it's a percentage
+    Matcher matcher = PERCENTAGE_PATTERN.matcher(value);
+    if (matcher.matches()) {
+      int percentage = Integer.parseInt(matcher.group(1));
+      if (percentage > 0) {
+        // Positive percentage: (total * percentage / 100)
+        int minimumMatches = (totalTokens * percentage) / 100;
+        return Math.max(1, minimumMatches);
+      } else {
+        // Negative percentage: (total * (100 + percentage) / 100)
+        int minimumMatches = (totalTokens * (100 + percentage)) / 100;
+        return Math.max(1, minimumMatches);
+      }
+    } else {
+      // Integer calculation
+      int intValue = Integer.parseInt(value);
+      if (intValue > 0) {
+        // Positive integer: return the value directly, but cap at total tokens
+        return Math.min(intValue, totalTokens);
+      } else {
+        // Negative integer: calculate as (total + negative value)
+        int minimumMatches = totalTokens + intValue;
+        return Math.max(1, minimumMatches);
+      }
+    }
+  }
+
+  /**
+   * Reinitializes the parser with a new CharStream.
+   *
+   * <p>This method is required by QueryParserBase but is not used in this implementation
+   * since we override the parse(String) method directly. The method is left as a no-op.</p>
+   *
+   * @param input the CharStream to reinitialize with (ignored in this implementation)
+   */
+  @Override
+  public void ReInit(CharStream input) {
+    // This method is required by QueryParserBase but not used in our implementation
+    // since we override parse(String) directly
+  }
+
+  /**
+   * Creates a top-level query for the specified field.
+   *
+   * <p>This method is required by QueryParserBase but is not supported in this implementation.
+   * Use the parse(String) method instead for query parsing.</p>
+   *
+   * @param field the field name (ignored in this implementation)
+   * @return never returns (always throws UnsupportedOperationException)
+   * @throws ParseException never thrown (method always throws UnsupportedOperationException)
+   * @throws UnsupportedOperationException always thrown, indicating this method is not supported
+   */
+  @Override
+  public Query TopLevelQuery(String field)
+      throws ParseException {
+    throw new UnsupportedOperationException(
+        "TopLevelQuery is not supported in MinimumShouldMatchQueryParser. Use parse(String) method instead.");
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/LuceneTextIndexUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/LuceneTextIndexUtils.java
@@ -49,6 +49,7 @@ public class LuceneTextIndexUtils {
   public static final String PARSER_STANDARD = "STANDARD";
   public static final String PARSER_COMPLEX = "COMPLEX";
   public static final String PARSER_MATCHPHRASE = "MATCHPHRASE";
+  public static final String PARSER_MINIMUM_SHOULD_MATCH = "MINIMUM_SHOULD_MATCH";
 
   // Default operator constants
   public static final String DEFAULT_OPERATOR_AND = "AND";
@@ -80,6 +81,7 @@ public class LuceneTextIndexUtils {
     public static final String SLOP = "slop";
     public static final String IN_ORDER = "inOrder";
     public static final String ENABLE_PREFIX_MATCH = "enablePrefixMatch";
+    public static final String MINIMUM_SHOULD_MATCH = "minimumShouldMatch";
   }
 
   // Parser class names
@@ -90,6 +92,8 @@ public class LuceneTextIndexUtils {
   public static final String CLASSIC_QUERY_PARSER = "org.apache.lucene.queryparser.classic.QueryParser";
   public static final String MATCHPHRASE_QUERY_PARSER_CLASS =
       "org.apache.pinot.segment.local.segment.index.text.lucene.parsers.PrefixPhraseQueryParser";
+  public static final String MINIMUM_SHOULD_MATCH_QUERY_PARSER_CLASS =
+      "org.apache.pinot.segment.local.segment.index.text.lucene.parsers.MinimumShouldMatchQueryParser";
 
   private LuceneTextIndexUtils() {
   }
@@ -155,6 +159,9 @@ public class LuceneTextIndexUtils {
         break;
       case PARSER_MATCHPHRASE:
         parserClassName = MATCHPHRASE_QUERY_PARSER_CLASS;
+        break;
+      case PARSER_MINIMUM_SHOULD_MATCH:
+        parserClassName = MINIMUM_SHOULD_MATCH_QUERY_PARSER_CLASS;
         break;
       default:
         parserClassName = CLASSIC_QUERY_PARSER;
@@ -352,6 +359,10 @@ public class LuceneTextIndexUtils {
 
     public boolean isEnablePrefixMatch() {
       return Boolean.parseBoolean(_options.getOrDefault(OptionKey.ENABLE_PREFIX_MATCH, "false"));
+    }
+
+    public String getMinimumShouldMatch() {
+      return _options.getOrDefault(OptionKey.MINIMUM_SHOULD_MATCH, null);
     }
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/LuceneTextIndexUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/LuceneTextIndexUtils.java
@@ -49,7 +49,7 @@ public class LuceneTextIndexUtils {
   public static final String PARSER_STANDARD = "STANDARD";
   public static final String PARSER_COMPLEX = "COMPLEX";
   public static final String PARSER_MATCHPHRASE = "MATCHPHRASE";
-  public static final String PARSER_MINIMUM_SHOULD_MATCH = "MINIMUM_SHOULD_MATCH";
+  public static final String PARSER_MATCH = "MATCH";
 
   // Default operator constants
   public static final String DEFAULT_OPERATOR_AND = "AND";
@@ -92,8 +92,8 @@ public class LuceneTextIndexUtils {
   public static final String CLASSIC_QUERY_PARSER = "org.apache.lucene.queryparser.classic.QueryParser";
   public static final String MATCHPHRASE_QUERY_PARSER_CLASS =
       "org.apache.pinot.segment.local.segment.index.text.lucene.parsers.PrefixPhraseQueryParser";
-  public static final String MINIMUM_SHOULD_MATCH_QUERY_PARSER_CLASS =
-      "org.apache.pinot.segment.local.segment.index.text.lucene.parsers.MinimumShouldMatchQueryParser";
+  public static final String MATCH_QUERY_PARSER_CLASS =
+      "org.apache.pinot.segment.local.segment.index.text.lucene.parsers.MatchQueryParser";
 
   private LuceneTextIndexUtils() {
   }
@@ -160,8 +160,8 @@ public class LuceneTextIndexUtils {
       case PARSER_MATCHPHRASE:
         parserClassName = MATCHPHRASE_QUERY_PARSER_CLASS;
         break;
-      case PARSER_MINIMUM_SHOULD_MATCH:
-        parserClassName = MINIMUM_SHOULD_MATCH_QUERY_PARSER_CLASS;
+      case PARSER_MATCH:
+        parserClassName = MATCH_QUERY_PARSER_CLASS;
         break;
       default:
         parserClassName = CLASSIC_QUERY_PARSER;

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/text/lucene/parsers/MinimumShouldMatchQueryParserTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/text/lucene/parsers/MinimumShouldMatchQueryParserTest.java
@@ -215,9 +215,6 @@ public class MinimumShouldMatchQueryParserTest {
     } catch (ParseException e) {
       // Expected
     }
-
-
-
     // Case 9: Non-Boolean query (phrase query)
     parseQueryWithMinimumShouldMatch("\"java programming\"", null);
     parseQueryWithMinimumShouldMatch("java*", null);

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/text/lucene/parsers/MinimumShouldMatchQueryParserTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/text/lucene/parsers/MinimumShouldMatchQueryParserTest.java
@@ -1,0 +1,238 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.text.lucene.parsers;
+
+import org.apache.lucene.analysis.standard.StandardAnalyzer;
+import org.apache.lucene.queryparser.classic.ParseException;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.Query;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class MinimumShouldMatchQueryParserTest {
+
+  private static final String FIELD_NAME = "content";
+
+  /**
+   * Helper method to parse query with minimum_should_match option and return the result.
+   *
+   * @param query the query string to parse
+   * @param minimumShouldMatch the minimum_should_match value (can be null)
+   * @return the parsed Query
+   * @throws ParseException if parsing fails
+   */
+  private Query parseQueryWithMinimumShouldMatch(String query, String minimumShouldMatch)
+      throws ParseException {
+    MinimumShouldMatchQueryParser parser = new MinimumShouldMatchQueryParser(FIELD_NAME, new StandardAnalyzer());
+    if (minimumShouldMatch != null) {
+      parser.setMinimumShouldMatch(minimumShouldMatch);
+    }
+    return parser.parse(query);
+  }
+
+  @Test
+  public void testPositiveCases()
+      throws ParseException {
+    // Case 1: setMinimumShouldMatch("3") - requires at least 3 matches
+    Query result1 = parseQueryWithMinimumShouldMatch("java OR python OR scala OR kotlin OR rust", "3");
+    Assert.assertTrue(result1 instanceof BooleanQuery);
+    BooleanQuery booleanQuery1 = (BooleanQuery) result1;
+    Assert.assertEquals(booleanQuery1.clauses().size(), 5);
+    Assert.assertEquals(booleanQuery1.getMinimumNumberShouldMatch(), 3);
+
+    // Case 2: setMinimumShouldMatch("-1") - allows at most 1 to be missing
+    Query result2 = parseQueryWithMinimumShouldMatch("java OR python OR scala OR kotlin", "-1");
+    Assert.assertTrue(result2 instanceof BooleanQuery);
+    BooleanQuery booleanQuery2 = (BooleanQuery) result2;
+    Assert.assertEquals(booleanQuery2.clauses().size(), 4);
+    // -1 means at most 1 can be missing, so 3 must match (4 - 1 = 3)
+    Assert.assertEquals(booleanQuery2.getMinimumNumberShouldMatch(), 3);
+
+    // Case 3: setMinimumShouldMatch("80%") - requires at least 80% matches
+    Query result3 = parseQueryWithMinimumShouldMatch("java OR python OR scala OR kotlin OR rust", "80%");
+    Assert.assertTrue(result3 instanceof BooleanQuery);
+    BooleanQuery booleanQuery3 = (BooleanQuery) result3;
+    Assert.assertEquals(booleanQuery3.clauses().size(), 5);
+    // 80% of 5 = 4 matches required
+    Assert.assertEquals(booleanQuery3.getMinimumNumberShouldMatch(), 4);
+
+    // Case 4: setMinimumShouldMatch("-20%") - allows at most 20% to be missing
+    Query result4 = parseQueryWithMinimumShouldMatch("java OR python OR scala OR kotlin OR rust", "-20%");
+    Assert.assertTrue(result4 instanceof BooleanQuery);
+    BooleanQuery booleanQuery4 = (BooleanQuery) result4;
+    Assert.assertEquals(booleanQuery4.clauses().size(), 5);
+    // -20% means at most 20% can be missing, so 80% must match
+    // 80% of 5 = 4 matches required
+    Assert.assertEquals(booleanQuery4.getMinimumNumberShouldMatch(), 4);
+  }
+
+  @Test
+  public void testNegativeCases() {
+    // Case 1: Invalid percentage value (> 100%)
+    try {
+      parseQueryWithMinimumShouldMatch("java OR python", "101%");
+      Assert.fail("Should throw IllegalArgumentException for invalid percentage");
+    } catch (IllegalArgumentException e) {
+      // Expected
+    } catch (ParseException e) {
+      Assert.fail("Should throw IllegalArgumentException, not ParseException");
+    }
+
+    // Case 2: Invalid negative percentage value (< -100%)
+    try {
+      parseQueryWithMinimumShouldMatch("java OR python", "-101%");
+      Assert.fail("Should throw IllegalArgumentException for invalid negative percentage");
+    } catch (IllegalArgumentException e) {
+      // Expected
+    } catch (ParseException e) {
+      Assert.fail("Should throw IllegalArgumentException, not ParseException");
+    }
+
+    // Case 3: Invalid format (not integer or percentage)
+    try {
+      parseQueryWithMinimumShouldMatch("java OR python", "abc");
+      Assert.fail("Should throw IllegalArgumentException for invalid format");
+    } catch (IllegalArgumentException e) {
+      // Expected
+    } catch (ParseException e) {
+      Assert.fail("Should throw IllegalArgumentException, not ParseException");
+    }
+
+    // Case 4: Invalid decimal percentage
+    try {
+      parseQueryWithMinimumShouldMatch("java OR python", "50.5%");
+      Assert.fail("Should throw IllegalArgumentException for invalid decimal percentage");
+    } catch (IllegalArgumentException e) {
+      // Expected
+    } catch (ParseException e) {
+      Assert.fail("Should throw IllegalArgumentException, not ParseException");
+    }
+
+    // Case 5: Null query
+    try {
+      parseQueryWithMinimumShouldMatch(null, null);
+      Assert.fail("Should throw ParseException for null query");
+    } catch (ParseException e) {
+      // Expected
+    }
+
+    // Case 6: Empty query
+    try {
+      parseQueryWithMinimumShouldMatch("", null);
+      Assert.fail("Should throw ParseException for empty query");
+    } catch (ParseException e) {
+      // Expected
+    }
+
+    // Case 7: Whitespace-only query
+    try {
+      parseQueryWithMinimumShouldMatch("   ", null);
+      Assert.fail("Should throw ParseException for whitespace-only query");
+    } catch (ParseException e) {
+      // Expected
+    }
+
+    // Case 8: Single term query should work with explicit minimum_should_match
+    try {
+      Query result8 = parseQueryWithMinimumShouldMatch("java", "1");
+      Assert.assertTrue(result8 instanceof BooleanQuery);
+      BooleanQuery booleanQuery8 = (BooleanQuery) result8;
+      Assert.assertEquals(booleanQuery8.clauses().size(), 1);
+      Assert.assertEquals(booleanQuery8.getMinimumNumberShouldMatch(), 1);
+    } catch (ParseException e) {
+      Assert.fail("Single term query should work with minimum_should_match: " + e.getMessage());
+    }
+
+    // Case 8b: Single term query should work without minimum_should_match (defaults to 1)
+    try {
+      Query result8b = parseQueryWithMinimumShouldMatch("java", null);
+      Assert.assertTrue(result8b instanceof BooleanQuery);
+      BooleanQuery booleanQuery8b = (BooleanQuery) result8b;
+      Assert.assertEquals(booleanQuery8b.clauses().size(), 1);
+      Assert.assertEquals(booleanQuery8b.getMinimumNumberShouldMatch(), 1);
+    } catch (ParseException e) {
+      Assert.fail("Single term query should work without minimum_should_match: " + e.getMessage());
+    }
+
+    // Case 9: Non-Boolean query (phrase query)
+    try {
+      parseQueryWithMinimumShouldMatch("\"java programming\"", null);
+      Assert.fail("Should throw ParseException for non-Boolean query (phrase)");
+    } catch (ParseException e) {
+      // Expected - should contain the error message about Boolean queries
+      Assert.assertTrue(e.getMessage().contains("Boolean queries"),
+          "Error message should mention Boolean queries, got: " + e.getMessage());
+    }
+
+    // Case 10: Non-Boolean query (wildcard query)
+    try {
+      parseQueryWithMinimumShouldMatch("java*", null);
+      Assert.fail("Should throw ParseException for non-Boolean query (wildcard)");
+    } catch (ParseException e) {
+      // Expected - should contain the error message about Boolean queries
+      Assert.assertTrue(e.getMessage().contains("Boolean queries"),
+          "Error message should mention Boolean queries, got: " + e.getMessage());
+    }
+  }
+
+  @Test
+  public void testEdgeCases()
+      throws ParseException {
+    // Case 1: minimum_should_match value greater than number of should clauses (boundary)
+    Query result1 = parseQueryWithMinimumShouldMatch("java OR python", "5");
+    Assert.assertTrue(result1 instanceof BooleanQuery);
+    BooleanQuery booleanQuery1 = (BooleanQuery) result1;
+    Assert.assertEquals(booleanQuery1.clauses().size(), 2);
+    // Should cap at the number of available clauses (2)
+    Assert.assertEquals(booleanQuery1.getMinimumNumberShouldMatch(), 2);
+
+    // Case 2: negative minimum_should_match that would result in negative value (boundary)
+    Query result2 = parseQueryWithMinimumShouldMatch("java OR python", "-5");
+    Assert.assertTrue(result2 instanceof BooleanQuery);
+    BooleanQuery booleanQuery2 = (BooleanQuery) result2;
+    Assert.assertEquals(booleanQuery2.clauses().size(), 2);
+    // Should not go below 0 (2 - 5 = -3, but capped at 0)
+    Assert.assertEquals(booleanQuery2.getMinimumNumberShouldMatch(), 0);
+
+    // Case 3: negative percentage that would result in zero (boundary)
+    Query result3 = parseQueryWithMinimumShouldMatch("java OR python", "-80%");
+    Assert.assertTrue(result3 instanceof BooleanQuery);
+    BooleanQuery booleanQuery3 = (BooleanQuery) result3;
+    Assert.assertEquals(booleanQuery3.clauses().size(), 2);
+    // -80% means 20% must match, but 20% of 2 = 0.4, rounded down to 0
+    Assert.assertEquals(booleanQuery3.getMinimumNumberShouldMatch(), 0);
+
+    // Case 4: minimum_should_match value equal to number of should clauses (boundary)
+    Query result4 = parseQueryWithMinimumShouldMatch("java OR python OR scala", "3");
+    Assert.assertTrue(result4 instanceof BooleanQuery);
+    BooleanQuery booleanQuery4 = (BooleanQuery) result4;
+    Assert.assertEquals(booleanQuery4.clauses().size(), 3);
+    // Should require all 3 clauses to match
+    Assert.assertEquals(booleanQuery4.getMinimumNumberShouldMatch(), 3);
+
+    // Case 5: percentage that results in decimal value (boundary rounding)
+    Query result5 = parseQueryWithMinimumShouldMatch("java OR python OR scala OR kotlin", "75%");
+    Assert.assertTrue(result5 instanceof BooleanQuery);
+    BooleanQuery booleanQuery5 = (BooleanQuery) result5;
+    Assert.assertEquals(booleanQuery5.clauses().size(), 4);
+    // 75% of 4 = 3.0, should round down to 3
+    Assert.assertEquals(booleanQuery5.getMinimumNumberShouldMatch(), 3);
+  }
+}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/text/lucene/parsers/MinimumShouldMatchQueryParserTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/text/lucene/parsers/MinimumShouldMatchQueryParserTest.java
@@ -40,7 +40,7 @@ public class MinimumShouldMatchQueryParserTest {
    */
   private Query parseQueryWithMinimumShouldMatch(String query, String minimumShouldMatch)
       throws ParseException {
-    MinimumShouldMatchQueryParser parser = new MinimumShouldMatchQueryParser(FIELD_NAME, new StandardAnalyzer());
+    MatchQueryParser parser = new MatchQueryParser(FIELD_NAME, new StandardAnalyzer());
     if (minimumShouldMatch != null) {
       parser.setMinimumShouldMatch(minimumShouldMatch);
     }
@@ -150,7 +150,8 @@ public class MinimumShouldMatchQueryParserTest {
   }
 
   @Test
-  public void testNegativeCases() {
+  public void testNegativeCases()
+      throws ParseException {
     // Case 1: Invalid percentage value (> 100%)
     try {
       parseQueryWithMinimumShouldMatch("java OR python", "101%");
@@ -218,24 +219,8 @@ public class MinimumShouldMatchQueryParserTest {
 
 
     // Case 9: Non-Boolean query (phrase query)
-    try {
-      parseQueryWithMinimumShouldMatch("\"java programming\"", null);
-      Assert.fail("Should throw ParseException for non-Boolean query (phrase)");
-    } catch (ParseException e) {
-      // Expected - should contain the error message about Boolean queries
-      Assert.assertTrue(e.getMessage().contains("Boolean queries"),
-          "Error message should mention Boolean queries, got: " + e.getMessage());
-    }
-
-    // Case 10: Non-Boolean query (wildcard query)
-    try {
-      parseQueryWithMinimumShouldMatch("java*", null);
-      Assert.fail("Should throw ParseException for non-Boolean query (wildcard)");
-    } catch (ParseException e) {
-      // Expected - should contain the error message about Boolean queries
-      Assert.assertTrue(e.getMessage().contains("Boolean queries"),
-          "Error message should mention Boolean queries, got: " + e.getMessage());
-    }
+    parseQueryWithMinimumShouldMatch("\"java programming\"", null);
+    parseQueryWithMinimumShouldMatch("java*", null);
   }
 
 

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/text/lucene/parsers/MinimumShouldMatchQueryParserTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/text/lucene/parsers/MinimumShouldMatchQueryParserTest.java
@@ -220,8 +220,6 @@ public class MinimumShouldMatchQueryParserTest {
     parseQueryWithMinimumShouldMatch("java*", null);
   }
 
-
-
   @Test
   public void testEdgeCases()
       throws ParseException {


### PR DESCRIPTION
This PR adds a new text search parser that provides [OpenSearch-compatible](https://docs.opensearch.org/latest/query-dsl/minimum-should-match/)  minimum_should_match functionality, allowing users to specify the minimum number of terms that must match in Boolean queries. The parser supports both simple and deeply nested queries with percentage-based and integer-based specifications, enabling more control over text search matching behavior.

Sample Query
````
-- Require 2 out of 4 terms to match
SELECT * FROM table WHERE TEXT_MATCH(field, 'one OR two OR three OR four', 
  'parser=MATCH', 'minimumShouldMatch=2')

-- Require 75% of terms to match (3 out of 4)
SELECT * FROM table WHERE TEXT_MATCH(field, 'one OR two OR three OR four', 
  'parser=MATCH', 'minimumShouldMatch=75%')
````

How minimumShouldMatch Works 
- Positive Integer (e.g., "3"): At least N should clauses must match
- Negative Integer (e.g., "-2"): At most N should clauses can be missing
- Positive Percentage (e.g., "80%"): At least X% of should clauses must match
- Negative Percentage (e.g., "-20%"): At most X% of should clauses can be missing

Test Coverage
- Added Unit Test.
- Added Integration test.

Backward Compatibility: N/A
