### PR TITLE
Removes ingestion metrics for consuming -> offline transition

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -335,6 +335,19 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
     _ingestionDelayTracker.stopTrackingPartitionIngestionDelay(new LLCSegmentName(segmentName).getPartitionGroupId());
   }
 
+  /**
+   * Method to handle CONSUMING -> OFFLINE segment state transitions:
+   * We must mark partitions for verification if consuming segment is marked as offline.
+   * This is because before consumer thread dies upon encountering an exception, controller marks it as offline and
+   * there might be no consumer present on the server.
+   *
+   * @param segmentName name of segment which is transitioning state.
+   */
+  @Override
+  public void onConsumingToOffline(String segmentName) {
+    _ingestionDelayTracker.stopTrackingPartitionIngestionDelay(new LLCSegmentName(segmentName).getPartitionGroupId());
+  }
+
   @Override
   public List<SegmentContext> getSegmentContexts(List<IndexSegment> selectedSegments,
       Map<String, String> queryOptions) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -337,10 +337,11 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
 
   /**
    * Method to handle CONSUMING -> OFFLINE segment state transitions:
-   * We must stop tracking partitions for ingestion-delay if consuming segment is marked as offline as there won't be
-   * any consumer present on the server for the partition segment is consuming from.
+   * We stop tracking partitions whose segments are going OFFLINE. The reason is that offline segments are not queried.
+   * So ingestion delay for the offline replicas are not relevant. If there are more replicas with offline state,
+   * replica up metric will determine the severity of the issue.
    *
-   * @param segmentName name of segment which is transitioning state.
+   * @param segmentName name of segment for which the state change is being handled
    */
   @Override
   public void onConsumingToOffline(String segmentName) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -345,7 +345,7 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
    */
   @Override
   public void onConsumingToOffline(String segmentName) {
-    _ingestionDelayTracker.stopTrackingPartitionIngestionDelay(new LLCSegmentName(segmentName).getPartitionGroupId());
+    _ingestionDelayTracker.stopTrackingPartitionIngestionDelay(segmentName);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -337,9 +337,8 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
 
   /**
    * Method to handle CONSUMING -> OFFLINE segment state transitions:
-   * We must mark partitions for verification if consuming segment is marked as offline.
-   * This is because before consumer thread dies upon encountering an exception, controller marks it as offline and
-   * there might be no consumer present on the server.
+   * We must stop tracking partitions for ingestion-delay if consuming segment is marked as offline as there won't be
+   * any consumer present on the server for the partition segment is consuming from.
    *
    * @param segmentName name of segment which is transitioning state.
    */

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManager.java
@@ -337,6 +337,14 @@ public interface TableDataManager {
   }
 
   /**
+   * Interface to handle segment state transitions from CONSUMING to OFFLINE
+   *
+   * @param segmentNameStr name of segment for which the state change is being handled
+   */
+  default void onConsumingToOffline(String segmentNameStr) {
+  }
+
+  /**
    * Return list of segment names that are stale along with reason.
    *
    * @return List of {@link StaleSegment} with segment names and reason why it is stale

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/SegmentOnlineOfflineStateModelFactory.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/SegmentOnlineOfflineStateModelFactory.java
@@ -115,6 +115,7 @@ public class SegmentOnlineOfflineStateModelFactory extends StateModelFactory<Sta
         String segmentName = message.getPartitionName();
         _instanceDataManager.offloadSegment(realtimeTableName, segmentName);
         _recentlyOffloadedConsumingSegments.put(Pair.of(realtimeTableName, segmentName), true);
+        onConsumingToOffline(realtimeTableName, segmentName);
       } catch (Exception e) {
         _logger.error(
             "Caught exception while processing SegmentOnlineOfflineStateModel.onBecomeOfflineFromConsuming() for "
@@ -122,6 +123,17 @@ public class SegmentOnlineOfflineStateModelFactory extends StateModelFactory<Sta
             message.getResourceName(), message.getPartitionName(), e);
         throw e;
       }
+    }
+
+    private void onConsumingToOffline(String realtimeTableName, String segmentName) {
+      TableDataManager tableDataManager = _instanceDataManager.getTableDataManager(realtimeTableName);
+      if (tableDataManager == null) {
+        _logger.warn(
+            "Failed to find data manager for table: {}, skip invoking consuming to offline callback for segment: {}",
+            realtimeTableName, segmentName);
+        return;
+      }
+      tableDataManager.onConsumingToOffline(segmentName);
     }
 
     @Transition(from = "CONSUMING", to = "DROPPED")


### PR DESCRIPTION
**Problem:**
Consider a case where consumer encounters an exception and controller marks the consuming segment as offline. Now when RVM restarts the consumption, there might be a segment movement, i.e, the server hosting the partition before will no longer host the same partition of the stream and hence consuming segment is going to be assigned to a new server. 
For such cases ingestion metrics are not removed.

**Solution**
Make `consuming -> offline` transition equivalent of `consuming -> dropped` in terms of handling ingestion metrics.