### PR TITLE
[bugfix] Fixing the TableType value passed for unavailable segments in physical optimizer

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/opt/rules/LeafStageWorkerAssignmentRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/opt/rules/LeafStageWorkerAssignmentRule.java
@@ -174,7 +174,7 @@ public class LeafStageWorkerAssignmentRule extends PRelOptRule {
       }
       if (!routingTable.getUnavailableSegments().isEmpty()) {
         // Set unavailable segments in context, keyed by PRelNode ID.
-        segmentUnavailableMap.put(TableNameBuilder.forType(TableType.valueOf(tableName)).tableNameWithType(tableName),
+        segmentUnavailableMap.put(TableNameBuilder.forType(TableType.valueOf(tableType)).tableNameWithType(tableName),
             new HashSet<>(routingTable.getUnavailableSegments()));
       }
     }


### PR DESCRIPTION
## Summary
An issue was discovered while querying a table with unavailable segments with the physical optimizer enabled.
```
Error Code: 150 (SQLParsingError)

SQLParsingError: Error composing query plan: No enum constant org.apache.pinot.spi.config.table.TableType.my_table_name.
```
This was due to the `tableName` incorrectly passed instead of `tableType` for `TableType.valueOf()`. 