### PR TITLE
Improve segment build auto retry logics

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -24,6 +24,7 @@ import com.google.common.util.concurrent.Uninterruptibles;
 import java.io.File;
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.nio.BufferOverflowException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -1161,8 +1162,8 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
       } catch (Exception e) {
         String errorMessage = "Could not build segment";
         FileUtils.deleteQuietly(tempSegmentFolder);
-        if (e instanceof IllegalStateException) {
-          // Precondition checks fail, the segment build would fail consistently
+        if (e instanceof IllegalStateException || e instanceof BufferOverflowException) {
+          // Index or forward index too large issue, the segment build would fail consistently
           _segmentBuildFailedWithDeterministicError = true;
         }
         reportSegmentBuildFailure(errorMessage, e);


### PR DESCRIPTION
`ingestion`
Followup on https://github.com/apache/pinot/pull/15234
There could be some other similar "overflow" issues with different types of exceptions, add them to auto retry
(Sample error traceback)
```
java.nio.BufferOverflowException: null at java.base/java.nio.ByteBuffer.put(ByteBuffer.java:1210) at
org.apache.pinot.segment.local.io.util.VarLengthValueWriter.add(VarLengthValueWriter.java:119) at
org.apache.pinot.segment.local.segment.creator.impl.inv.json.OffHeapJsonIndexCreator.seal(OffHeapJsonIndexCreator.java:149) at
org.apache.pinot.segment.local.segment.creator.impl.SegmentColumnarIndexCreator.seal(SegmentColumnarIndexCreator.java:470) at
org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl.handlePostCreation(SegmentIndexCreationDriverImpl.java:372) at org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl.buildByColumn(SegmentIndexCreationDriverImpl.java:344) at org.apache.pinot.segment.local.realtime.converter.RealtimeSegmentConverter.build(RealtimeSegmentConverter.java:115) at org.apache.pinot.core.data.manager.realtime.RealtimeSegmentDataManager.buildSegmentInternal(RealtimeSegmentDataManager.java:1086) at org.apache.pinot.core.data.manager.realtime.RealtimeSegmentDataManager.buildSegmentForCommit(RealtimeSegmentDataManager.java:947) at org.apache.pinot.core.data.manager.realtime.RealtimeSegmentDataManager$PartitionConsumer.run(RealtimeSegmentDataManager.java:850) at java.base/java.lang.Thread.run(Thread.java:1583)
```
