### PR TITLE
Change segments/{tableName}/metadata API to sent 1 request per server rather than 1 request per segment

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
@@ -1162,8 +1162,8 @@ public class PinotSegmentRestletResource {
       throws InvalidConfigException, IOException {
     TableMetadataReader tableMetadataReader =
         new TableMetadataReader(_executor, _connectionManager, _pinotHelixResourceManager);
-    return tableMetadataReader
-        .getSegmentsMetadata(tableNameWithType, columns, _controllerConf.getServerAdminRequestTimeoutSeconds() * 1000);
+    return tableMetadataReader.getAllSegmentsMetadata(tableNameWithType, columns,
+        _controllerConf.getServerAdminRequestTimeoutSeconds() * 1000);
   }
 
   @POST


### PR DESCRIPTION
Today the `segments/{tableName}/metadata` API sends out one request per segment. For large tables this can be problematic because the MultiHttpRequest's multi-get function creates a separate thread for each request. For tables with a very large number of segments we have seen issues where a huge number of threads are spawned at once and even results in issues like OOMs

This PR addresses the above by modifying the call to get all segments to send one request per server
- Adds a server level API to return a list of `SegmentMetadata` objects, one for each segment. This naturally filters out OFFLINE segments as a segment data manager won't exist for OFFLINE segments (so no filtering needed on the caller side)
- Changes the controller API for `segments/{tableName}/metadata` to use the above server API instead (added all the helper classes for this)

Verifications done using `HybridQuickStart` with 4 servers:

With these changes, we see only 4 URLs when sending out the request (logs added locally for testing):
```
2025/08/21 16:07:03.116 ERROR [MultiHttpRequest] [grizzly-http-server-27] ************ NUMBER OF urlsAndRequestBodies: 4
2025/08/21 16:07:03.116 ERROR [MultiHttpRequest] [async-task-thread-60] *********** submitting request, url: http://192.168.86.234:7501/tables/airlineStats_OFFLINE/segments/metadata?columns=, body: 
2025/08/21 16:07:03.116 ERROR [MultiHttpRequest] [async-task-thread-26] *********** submitting request, url: http://192.168.86.234:7500/tables/airlineStats_OFFLINE/segments/metadata?columns=, body: 
2025/08/21 16:07:03.117 ERROR [MultiHttpRequest] [async-task-thread-28] *********** submitting request, url: http://192.168.86.234:7502/tables/airlineStats_OFFLINE/segments/metadata?columns=, body: 
2025/08/21 16:07:03.117 ERROR [MultiHttpRequest] [async-task-thread-58] *********** submitting request, url: http://192.168.86.234:7503/tables/airlineStats_OFFLINE/segments/metadata?columns=, body: 
```

Verified that we get back data for all segments (we expect a total of 62 segments as RF = 2, and there are 31 unique segments):
```
2025/08/21 16:07:03.128 ERROR [ServerSegmentMetadataReader] [grizzly-http-server-27] ***** SIZE of serviceResponse: 4 ********
2025/08/21 16:07:03.128 ERROR [ServerSegmentMetadataReader] [grizzly-http-server-27] ***** for server: http://192.168.86.234:7503/tables/airlineStats_OFFLINE/segments/metadata?columns=__1, number of segment metadata returned: 16 ********
2025/08/21 16:07:03.129 ERROR [ServerSegmentMetadataReader] [grizzly-http-server-27] ***** for server: http://192.168.86.234:7500/tables/airlineStats_OFFLINE/segments/metadata?columns=__1, number of segment metadata returned: 16 ********
2025/08/21 16:07:03.129 ERROR [ServerSegmentMetadataReader] [grizzly-http-server-27] ***** for server: http://192.168.86.234:7502/tables/airlineStats_OFFLINE/segments/metadata?columns=__1, number of segment metadata returned: 15 ********
2025/08/21 16:07:03.130 ERROR [ServerSegmentMetadataReader] [grizzly-http-server-27] ***** for server: http://192.168.86.234:7501/tables/airlineStats_OFFLINE/segments/metadata?columns=__1, number of segment metadata returned: 15 ********
...
...
2025/08/21 16:07:03.130 ERROR [ServerSegmentMetadataReader] [grizzly-http-server-27] ***** SIZE of segmentsMetadata: 62 ********
```

The older way sends out 62 separate requests (capturing only a subset for brevity):
```
2025/08/21 16:06:27.204 ERROR [MultiHttpRequest] [grizzly-http-server-26] ************ NUMBER OF urlsAndRequestBodies: 62
...
...
2025/08/21 16:06:27.219 ERROR [ServerSegmentMetadataReader] [grizzly-http-server-26] ***** for server: http://192.168.86.234:7501/tables/airlineStats_OFFLINE/segments/airlineStats_OFFLINE_16086_16086_0/metadata?columns=__1, number of segment metadata returned: 1 ********
2025/08/21 16:06:27.219 ERROR [ServerSegmentMetadataReader] [grizzly-http-server-26] ***** for server: http://192.168.86.234:7502/tables/airlineStats_OFFLINE/segments/airlineStats_OFFLINE_16076_16076_0/metadata?columns=__1, number of segment metadata returned: 1 ********
2025/08/21 16:06:27.219 ERROR [ServerSegmentMetadataReader] [grizzly-http-server-26] ***** for server: http://192.168.86.234:7503/tables/airlineStats_OFFLINE/segments/airlineStats_OFFLINE_16071_16071_0/metadata?columns=__1, number of segment metadata returned: 1 ********
2025/08/21 16:06:27.219 ERROR [ServerSegmentMetadataReader] [grizzly-http-server-26] ***** for server: http://192.168.86.234:7502/tables/airlineStats_OFFLINE/segments/airlineStats_OFFLINE_16100_16100_0/metadata?columns=__1, number of segment metadata returned: 1 ********
...
...
2025/08/21 16:06:27.219 ERROR [ServerSegmentMetadataReader] [grizzly-http-server-26] ***** SIZE of segmentsMetadata: 62 ********
```