### PR TITLE
[Query Engine] ANY VALUE Support

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactory.java
@@ -229,6 +229,8 @@ public class AggregationFunctionFactory {
             return new AvgAggregationFunction(arguments, nullHandlingEnabled);
           case MODE:
             return new ModeAggregationFunction(arguments, nullHandlingEnabled);
+          case ANYVALUE:
+            return new AnyValueAggregationFunction(arguments, nullHandlingEnabled);
           case FIRSTWITHTIME: {
             Preconditions.checkArgument(numArguments == 3,
                 "FIRST_WITH_TIME expects 3 arguments, got: %s. The function can be used as "

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AnyValueAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AnyValueAggregationFunction.java
@@ -1,0 +1,398 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.aggregation.function;
+
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.pinot.common.CustomObject;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.common.ObjectSerDeUtils;
+import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
+import org.apache.pinot.core.query.aggregation.ObjectAggregationResultHolder;
+import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
+import org.apache.pinot.core.query.aggregation.groupby.ObjectGroupByResultHolder;
+import org.apache.pinot.segment.spi.AggregationFunctionType;
+
+
+/**
+ * AnyValue aggregation function returns any arbitrary value from the column for each group.
+ * This is useful for GROUP BY queries where you want to include a column in SELECT that has
+ * a 1:1 mapping with the GROUP BY columns, avoiding the need to add it to GROUP BY clause.
+ *
+ * Example: SELECT CustomerID, ANY_VALUE(CustomerName), SUM(OrderValue) FROM Orders GROUP BY CustomerID
+ */
+@SuppressWarnings({"rawtypes", "unchecked"})
+public class AnyValueAggregationFunction extends NullableSingleInputAggregationFunction<Object, Comparable> {
+
+  public AnyValueAggregationFunction(List<ExpressionContext> arguments, boolean nullHandlingEnabled) {
+    super(verifySingleArgument(arguments, "ANY_VALUE"), nullHandlingEnabled);
+  }
+
+  @Override
+  public AggregationFunctionType getType() {
+    return AggregationFunctionType.ANYVALUE;
+  }
+
+  @Override
+  public AggregationResultHolder createAggregationResultHolder() {
+    return new ObjectAggregationResultHolder();
+  }
+
+  @Override
+  public GroupByResultHolder createGroupByResultHolder(int initialCapacity, int maxCapacity) {
+    return new ObjectGroupByResultHolder(initialCapacity, maxCapacity);
+  }
+
+  @Override
+  public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
+    BlockValSet blockValSet = blockValSetMap.get(_expression);
+
+    // If we already have a value, we don't need to process more (any value is fine)
+    if (aggregationResultHolder.getResult() != null) {
+      return;
+    }
+
+    switch (blockValSet.getValueType().getStoredType()) {
+      case INT: {
+        int[] values = blockValSet.getIntValuesSV();
+        Integer anyValue = foldNotNull(length, blockValSet, null, (acum, from, to) -> {
+          // Return the first non-null value we encounter
+          return acum != null ? acum : values[from];
+        });
+        if (anyValue != null) {
+          aggregationResultHolder.setValue(anyValue);
+        }
+        break;
+      }
+      case LONG: {
+        long[] values = blockValSet.getLongValuesSV();
+        Long anyValue = foldNotNull(length, blockValSet, null, (acum, from, to) -> {
+          return acum != null ? acum : values[from];
+        });
+        if (anyValue != null) {
+          aggregationResultHolder.setValue(anyValue);
+        }
+        break;
+      }
+      case FLOAT: {
+        float[] values = blockValSet.getFloatValuesSV();
+        Float anyValue = foldNotNull(length, blockValSet, null, (acum, from, to) -> {
+          return acum != null ? acum : values[from];
+        });
+        if (anyValue != null) {
+          aggregationResultHolder.setValue(anyValue);
+        }
+        break;
+      }
+      case DOUBLE: {
+        double[] values = blockValSet.getDoubleValuesSV();
+        Double anyValue = foldNotNull(length, blockValSet, null, (acum, from, to) -> {
+          return acum != null ? acum : values[from];
+        });
+        if (anyValue != null) {
+          aggregationResultHolder.setValue(anyValue);
+        }
+        break;
+      }
+      case BIG_DECIMAL: {
+        BigDecimal[] values = blockValSet.getBigDecimalValuesSV();
+        BigDecimal anyValue = foldNotNull(length, blockValSet, null, (acum, from, to) -> {
+          return acum != null ? acum : values[from];
+        });
+        if (anyValue != null) {
+          aggregationResultHolder.setValue(anyValue);
+        }
+        break;
+      }
+      case STRING: {
+        String[] values = blockValSet.getStringValuesSV();
+        String anyValue = foldNotNull(length, blockValSet, null, (acum, from, to) -> {
+          return acum != null ? acum : values[from];
+        });
+        if (anyValue != null) {
+          aggregationResultHolder.setValue(anyValue);
+        }
+        break;
+      }
+      case BYTES: {
+        byte[][] values = blockValSet.getBytesValuesSV();
+        byte[] anyValue = foldNotNull(length, blockValSet, null, (acum, from, to) -> {
+          return acum != null ? acum : values[from];
+        });
+        if (anyValue != null) {
+          aggregationResultHolder.setValue(anyValue);
+        }
+        break;
+      }
+      default:
+        throw new IllegalStateException("Cannot compute ANY_VALUE for type: " + blockValSet.getValueType());
+    }
+  }
+
+  @Override
+  public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
+    BlockValSet blockValSet = blockValSetMap.get(_expression);
+
+    switch (blockValSet.getValueType().getStoredType()) {
+      case INT: {
+        int[] values = blockValSet.getIntValuesSV();
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            int groupKey = groupKeyArray[i];
+            if (groupByResultHolder.getResult(groupKey) == null) {
+              groupByResultHolder.setValueForKey(groupKey, values[i]);
+            }
+          }
+        });
+        break;
+      }
+      case LONG: {
+        long[] values = blockValSet.getLongValuesSV();
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            int groupKey = groupKeyArray[i];
+            if (groupByResultHolder.getResult(groupKey) == null) {
+              groupByResultHolder.setValueForKey(groupKey, values[i]);
+            }
+          }
+        });
+        break;
+      }
+      case FLOAT: {
+        float[] values = blockValSet.getFloatValuesSV();
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            int groupKey = groupKeyArray[i];
+            if (groupByResultHolder.getResult(groupKey) == null) {
+              groupByResultHolder.setValueForKey(groupKey, values[i]);
+            }
+          }
+        });
+        break;
+      }
+      case DOUBLE: {
+        double[] values = blockValSet.getDoubleValuesSV();
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            int groupKey = groupKeyArray[i];
+            if (groupByResultHolder.getResult(groupKey) == null) {
+              groupByResultHolder.setValueForKey(groupKey, values[i]);
+            }
+          }
+        });
+        break;
+      }
+      case BIG_DECIMAL: {
+        BigDecimal[] values = blockValSet.getBigDecimalValuesSV();
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            int groupKey = groupKeyArray[i];
+            if (groupByResultHolder.getResult(groupKey) == null) {
+              groupByResultHolder.setValueForKey(groupKey, values[i]);
+            }
+          }
+        });
+        break;
+      }
+      case STRING: {
+        String[] values = blockValSet.getStringValuesSV();
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            int groupKey = groupKeyArray[i];
+            if (groupByResultHolder.getResult(groupKey) == null) {
+              groupByResultHolder.setValueForKey(groupKey, values[i]);
+            }
+          }
+        });
+        break;
+      }
+      case BYTES: {
+        byte[][] values = blockValSet.getBytesValuesSV();
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            int groupKey = groupKeyArray[i];
+            if (groupByResultHolder.getResult(groupKey) == null) {
+              groupByResultHolder.setValueForKey(groupKey, values[i]);
+            }
+          }
+        });
+        break;
+      }
+      default:
+        throw new IllegalStateException("Cannot compute ANY_VALUE for type: " + blockValSet.getValueType());
+    }
+  }
+
+  @Override
+  public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
+    BlockValSet blockValSet = blockValSetMap.get(_expression);
+
+    switch (blockValSet.getValueType().getStoredType()) {
+      case INT: {
+        int[] values = blockValSet.getIntValuesSV();
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            for (int groupKey : groupKeysArray[i]) {
+              if (groupByResultHolder.getResult(groupKey) == null) {
+                groupByResultHolder.setValueForKey(groupKey, values[i]);
+              }
+            }
+          }
+        });
+        break;
+      }
+      case LONG: {
+        long[] values = blockValSet.getLongValuesSV();
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            for (int groupKey : groupKeysArray[i]) {
+              if (groupByResultHolder.getResult(groupKey) == null) {
+                groupByResultHolder.setValueForKey(groupKey, values[i]);
+              }
+            }
+          }
+        });
+        break;
+      }
+      case FLOAT: {
+        float[] values = blockValSet.getFloatValuesSV();
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            for (int groupKey : groupKeysArray[i]) {
+              if (groupByResultHolder.getResult(groupKey) == null) {
+                groupByResultHolder.setValueForKey(groupKey, values[i]);
+              }
+            }
+          }
+        });
+        break;
+      }
+      case DOUBLE: {
+        double[] values = blockValSet.getDoubleValuesSV();
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            for (int groupKey : groupKeysArray[i]) {
+              if (groupByResultHolder.getResult(groupKey) == null) {
+                groupByResultHolder.setValueForKey(groupKey, values[i]);
+              }
+            }
+          }
+        });
+        break;
+      }
+      case BIG_DECIMAL: {
+        BigDecimal[] values = blockValSet.getBigDecimalValuesSV();
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            for (int groupKey : groupKeysArray[i]) {
+              if (groupByResultHolder.getResult(groupKey) == null) {
+                groupByResultHolder.setValueForKey(groupKey, values[i]);
+              }
+            }
+          }
+        });
+        break;
+      }
+      case STRING: {
+        String[] values = blockValSet.getStringValuesSV();
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            for (int groupKey : groupKeysArray[i]) {
+              if (groupByResultHolder.getResult(groupKey) == null) {
+                groupByResultHolder.setValueForKey(groupKey, values[i]);
+              }
+            }
+          }
+        });
+        break;
+      }
+      case BYTES: {
+        byte[][] values = blockValSet.getBytesValuesSV();
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            for (int groupKey : groupKeysArray[i]) {
+              if (groupByResultHolder.getResult(groupKey) == null) {
+                groupByResultHolder.setValueForKey(groupKey, values[i]);
+              }
+            }
+          }
+        });
+        break;
+      }
+      default:
+        throw new IllegalStateException("Cannot compute ANY_VALUE for type: " + blockValSet.getValueType());
+    }
+  }
+
+  @Override
+  public Object extractAggregationResult(AggregationResultHolder aggregationResultHolder) {
+    return aggregationResultHolder.getResult();
+  }
+
+  @Override
+  public Object extractGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey) {
+    return groupByResultHolder.getResult(groupKey);
+  }
+
+  @Override
+  public Object merge(Object intermediateResult1, Object intermediateResult2) {
+    // For ANY_VALUE, we can return either value. Prefer the first non-null value.
+    if (intermediateResult1 != null) {
+      return intermediateResult1;
+    }
+    return intermediateResult2;
+  }
+
+  @Override
+  public ColumnDataType getIntermediateResultColumnType() {
+    return ColumnDataType.OBJECT;
+  }
+
+  @Override
+  public ColumnDataType getFinalResultColumnType() {
+    return ColumnDataType.OBJECT;
+  }
+
+  @Override
+  public Comparable extractFinalResult(Object intermediateResult) {
+    return (Comparable) intermediateResult;
+  }
+
+  @Override
+  public SerializedIntermediateResult serializeIntermediateResult(Object intermediateResult) {
+    // For ANY_VALUE, we serialize the intermediate result using the generic ObjectSerDeUtils
+    // Get the object type and serialize with the appropriate type
+    int type = ObjectSerDeUtils.ObjectType.getObjectType(intermediateResult).getValue();
+    byte[] bytes = ObjectSerDeUtils.serialize(intermediateResult, type);
+    return new SerializedIntermediateResult(type, bytes);
+  }
+
+  @Override
+  public Object deserializeIntermediateResult(CustomObject customObject) {
+    // Deserialize the intermediate result using the generic ObjectSerDeUtils
+    return ObjectSerDeUtils.deserialize(customObject);
+  }
+}

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/AnyValueFunctionIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/AnyValueFunctionIntegrationTest.java
@@ -1,0 +1,166 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.integration.tests;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+
+/**
+ * Integration test for ANY_VALUE aggregation function.
+ * Tests the function using the existing airline data from BaseClusterIntegrationTestSet.
+ * Uses the standard "mytable" with airline data that's already loaded.
+ */
+public class AnyValueFunctionIntegrationTest extends BaseClusterIntegrationTestSet {
+  
+  // This test extends BaseClusterIntegrationTestSet which already has airline test data loaded
+  // We'll use the existing "mytable" with airline data to test ANY_VALUE functionality
+
+  @Test
+  public void testAnyValueBasicFunctionality() throws Exception {
+    // Test basic ANY_VALUE functionality using existing airline data
+    String query = "SELECT Carrier, ANY_VALUE(Origin), COUNT(*) FROM mytable GROUP BY Carrier ORDER BY Carrier LIMIT 5";
+
+    JsonNode response = postQuery(query);
+    JsonNode rows = response.get("resultTable").get("rows");
+
+    assertTrue(rows.size() > 0, "Should have results");
+    
+    // Verify that ANY_VALUE returns valid values
+    for (int i = 0; i < rows.size(); i++) {
+      JsonNode row = rows.get(i);
+      assertNotNull(row.get(0).asText(), "Carrier should not be null");
+      assertNotNull(row.get(1).asText(), "ANY_VALUE(Origin) should not be null");
+      assertTrue(row.get(2).asInt() > 0, "COUNT should be greater than 0");
+    }
+  }
+
+  @Test
+  public void testAnyValueWithoutGroupBy() throws Exception {
+    // Test ANY_VALUE without GROUP BY - should return any single value
+    String query = "SELECT ANY_VALUE(Carrier), ANY_VALUE(Origin), COUNT(*) FROM mytable";
+
+    JsonNode response = postQuery(query);
+    JsonNode rows = response.get("resultTable").get("rows");
+
+    assertEquals(rows.size(), 1, "Should have 1 row without GROUP BY");
+
+    JsonNode row = rows.get(0);
+    assertNotNull(row.get(0).asText(), "Should have a carrier");
+    assertNotNull(row.get(1).asText(), "Should have an origin");
+    assertTrue(row.get(2).asInt() > 0, "Should have records");
+  }
+
+  @Test
+  public void testAnyValueWithMultipleGroupByColumns() throws Exception {
+    // Test ANY_VALUE with multiple GROUP BY columns
+    String query = "SELECT Carrier, Origin, ANY_VALUE(Dest), COUNT(*) FROM mytable GROUP BY Carrier, Origin ORDER BY Carrier, Origin LIMIT 10";
+
+    JsonNode response = postQuery(query);
+    JsonNode rows = response.get("resultTable").get("rows");
+
+    assertTrue(rows.size() > 0, "Should have results");
+    
+    // Verify that ANY_VALUE returns valid values for each group
+    for (int i = 0; i < rows.size(); i++) {
+      JsonNode row = rows.get(i);
+      assertNotNull(row.get(0).asText(), "Carrier should not be null");
+      assertNotNull(row.get(1).asText(), "Origin should not be null");
+      assertNotNull(row.get(2).asText(), "ANY_VALUE(Dest) should not be null");
+      assertTrue(row.get(3).asInt() > 0, "COUNT should be greater than 0");
+    }
+  }
+
+  @Test
+  public void testAnyValuePerformanceComparison() throws Exception {
+    // Test that ANY_VALUE can be used as an alternative to GROUP BY for 1:1 mappings
+    // Compare ANY_VALUE approach vs traditional GROUP BY approach
+    
+    String anyValueQuery = "SELECT Carrier, ANY_VALUE(AirlineID), COUNT(*) FROM mytable GROUP BY Carrier ORDER BY Carrier LIMIT 5";
+    String groupByQuery = "SELECT Carrier, AirlineID, COUNT(*) FROM mytable GROUP BY Carrier, AirlineID ORDER BY Carrier LIMIT 5";
+
+    JsonNode anyValueResponse = postQuery(anyValueQuery);
+    JsonNode groupByResponse = postQuery(groupByQuery);
+
+    JsonNode anyValueRows = anyValueResponse.get("resultTable").get("rows");
+    JsonNode groupByRows = groupByResponse.get("resultTable").get("rows");
+
+    assertTrue(anyValueRows.size() > 0, "ANY_VALUE query should return results");
+    assertTrue(groupByRows.size() > 0, "GROUP BY query should return results");
+    
+    // ANY_VALUE should return fewer or equal rows (since it doesn't expand groups)
+    assertTrue(anyValueRows.size() <= groupByRows.size(), 
+              "ANY_VALUE should return fewer or equal rows than full GROUP BY");
+  }
+
+  @Test
+  public void testAnyValueWithDifferentDataTypes() throws Exception {
+    // Test ANY_VALUE with different data types using existing airline data
+    String query = "SELECT " +
+                   "ANY_VALUE(Carrier) as StringValue, " +
+                   "ANY_VALUE(AirlineID) as IntValue, " +
+                   "ANY_VALUE(FlightNum) as IntValue2, " +
+                   "ANY_VALUE(ArrDelay) as DoubleValue " +
+                   "FROM mytable";
+
+    JsonNode response = postQuery(query);
+    JsonNode rows = response.get("resultTable").get("rows");
+
+    assertEquals(rows.size(), 1, "Should have 1 row without GROUP BY");
+
+    JsonNode row = rows.get(0);
+    assertNotNull(row.get(0).asText(), "String value should not be null");
+    assertTrue(row.get(1).asInt() >= 0, "Int value should be valid");
+    assertTrue(row.get(2).asInt() >= 0, "Int value2 should be valid");
+    // ArrDelay can be negative, so just check it's a valid number
+    assertNotNull(row.get(3), "Double value should not be null");
+  }
+
+  @Test
+  public void testAnyValueWithComplexGroupBy() throws Exception {
+    // Test ANY_VALUE in more complex scenarios
+    String query = "SELECT " +
+                   "Origin, " +
+                   "ANY_VALUE(Carrier) as SampleCarrier, " +
+                   "ANY_VALUE(Dest) as SampleDest, " +
+                   "COUNT(*) as FlightCount, " +
+                   "AVG(ArrDelay) as AvgDelay " +
+                   "FROM mytable " +
+                   "GROUP BY Origin " +
+                   "ORDER BY FlightCount DESC " +
+                   "LIMIT 5";
+
+    JsonNode response = postQuery(query);
+    JsonNode rows = response.get("resultTable").get("rows");
+
+    assertTrue(rows.size() > 0, "Should have results");
+    
+    for (int i = 0; i < rows.size(); i++) {
+      JsonNode row = rows.get(i);
+      assertNotNull(row.get(0).asText(), "Origin should not be null");
+      assertNotNull(row.get(1).asText(), "ANY_VALUE(Carrier) should not be null");
+      assertNotNull(row.get(2).asText(), "ANY_VALUE(Dest) should not be null");
+      assertTrue(row.get(3).asInt() > 0, "FlightCount should be positive");
+      // AvgDelay can be negative, so just verify it's a number
+      assertNotNull(row.get(4), "AvgDelay should not be null");
+    }
+  }
+}

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/AggregationFunctionType.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/AggregationFunctionType.java
@@ -60,6 +60,7 @@ public enum AggregationFunctionType {
   SUMPRECISION("sumPrecision", ReturnTypes.explicit(SqlTypeName.DECIMAL), OperandTypes.ANY, SqlTypeName.OTHER),
   AVG("avg", SqlTypeName.OTHER, SqlTypeName.DOUBLE),
   MODE("mode", SqlTypeName.OTHER, SqlTypeName.DOUBLE),
+  ANYVALUE("anyValue", ReturnTypes.ARG0, OperandTypes.ANY, SqlTypeName.OTHER),
   FIRSTWITHTIME("firstWithTime", ReturnTypes.ARG0,
       OperandTypes.family(SqlTypeFamily.ANY, SqlTypeFamily.ANY, SqlTypeFamily.CHARACTER), SqlTypeName.OTHER),
   LASTWITHTIME("lastWithTime", ReturnTypes.ARG0,


### PR DESCRIPTION
# ANY_VALUE Aggregation Function

## Overview

The `ANY_VALUE` aggregation function returns any arbitrary value from the specified column for each group in a `GROUP BY` query. This function is particularly useful for optimizing queries where you need to include a column in the `SELECT` clause that has a 1:1 mapping with the `GROUP BY` columns, without forcing that column into the `GROUP BY` clause.

## Syntax

```sql
ANY_VALUE(column_name)
```

## Use Cases

### Primary Use Case: Avoiding Unnecessary GROUP BY Columns

Standard SQL requires that all non-aggregation expressions in the `SELECT` clause must also be part of the `GROUP BY` clause. However, there are scenarios where:

1. **Functional Dependency**: A column has a 1:1 mapping with the grouped columns
2. **Performance Optimization**: Adding the column to `GROUP BY` would increase computation without changing the logical result
3. **Query Simplification**: You want to display related data without affecting grouping behavior

### Example Scenario

Consider an `ORDERS` table with `CustomerID`, `CustomerName`, and `OrderValue`:

**Without ANY_VALUE (Standard SQL):**
```sql
-- Option 1: Add CustomerName to GROUP BY (more computation)
SELECT CustomerID, CustomerName, SUM(OrderValue)
FROM Orders 
GROUP BY CustomerID, CustomerName;

-- Option 2: Remove CustomerName from SELECT (lose information)
SELECT CustomerID, SUM(OrderValue)
FROM Orders 
GROUP BY CustomerID;
```

**With ANY_VALUE (Optimized):**
```sql
-- Get CustomerName without adding to GROUP BY
SELECT CustomerID, ANY_VALUE(CustomerName), SUM(OrderValue)
FROM Orders 
GROUP BY CustomerID;
```

## Behavior

- **Returns**: Any arbitrary value from the column for each group
- **Null Handling**: Supports both null-handling enabled and disabled modes
- **Data Types**: Works with all Pinot data types (INT, LONG, FLOAT, DOUBLE, STRING, BYTES, BIG_DECIMAL)
- **Performance**: More efficient than adding the column to `GROUP BY` when there's a 1:1 mapping


