### PR TITLE
Revert "Bump com.uber:h3 from 4.1.1 to 4.3.0"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -173,7 +173,7 @@
     <netty.version>4.1.122.Final</netty.version>
     <reactivestreams.version>1.0.4</reactivestreams.version>
     <jts.version>1.20.0</jts.version>
-    <h3.version>4.3.0</h3.version>
+    <h3.version>4.1.1</h3.version>
     <jmh.version>1.37</jmh.version>
     <audienceannotations.version>0.15.1</audienceannotations.version>
     <clp-ffi.version>0.4.7</clp-ffi.version>


### PR DESCRIPTION
Reverts apache/pinot#16669

This is needed because the newer H3 version requires atleast the GLIBC version 2.38. 

This leads to failure on some envs where libc version is older with exception
```
Caused by: java.lang.ExceptionInInitializerError: Exception java.lang.UnsatisfiedLinkError: /tmp/libh3-java11361924585609588992.so: /lib/x86_64-linux-gnu/libm.so.6: version `GLIBC_2.38' not found (required by /tmp/libh3-java11361924585609588992.so) [in thread "jersey-server-managed-async-executor-3"]
	at java.base/jdk.internal.loader.NativeLibraries.load(Native Method)
	at java.base/jdk.internal.loader.NativeLibraries$NativeLibraryImpl.open(NativeLibraries.java:331)
	at java.base/jdk.internal.loader.NativeLibraries.loadLibrary(NativeLibraries.java:197)
	at java.base/jdk.internal.loader.NativeLibraries.loadLibrary(NativeLibraries.java:139)
	at java.base/java.lang.ClassLoader.loadLibrary(ClassLoader.java:2418)
	at java.base/java.lang.Runtime.load0(Runtime.java:852)
	at java.base/java.lang.System.load(System.java:2025)
	at com.uber.h3core.H3CoreLoader.loadNatives(H3CoreLoader.java:141)
	at com.uber.h3core.H3CoreLoader.loadNatives(H3CoreLoader.java:93)
	at com.uber.h3core.H3Core.newInstance(H3Core.java:72)
	at org.apache.pinot.segment.local.utils.H3Utils.<clinit>(H3Utils.java:46)
	... 32 more
```



