### PR TITLE
Make ingestion delay metric more resilient to transient errors

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -335,6 +335,19 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
     _ingestionDelayTracker.stopTrackingPartitionIngestionDelay(new LLCSegmentName(segmentName).getPartitionGroupId());
   }
 
+  /**
+   * Method to handle CONSUMING -> OFFLINE segment state transitions:
+   * We stop tracking partitions whose segments are going OFFLINE. The reason is that offline segments are not queried.
+   * So ingestion delay for the offline replicas are not relevant. If there are more replicas with offline state,
+   * replica up metric will determine the severity of the issue.
+   *
+   * @param segmentName name of segment for which the state change is being handled
+   */
+  @Override
+  public void onConsumingToOffline(String segmentName) {
+    _ingestionDelayTracker.stopTrackingPartitionIngestionDelay(segmentName);
+  }
+
   @Override
   public List<SegmentContext> getSegmentContexts(List<IndexSegment> selectedSegments,
       Map<String, String> queryOptions) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManager.java
@@ -337,6 +337,13 @@ public interface TableDataManager {
   }
 
   /**
+   * Interface to handle segment state transitions from CONSUMING to DROPPED
+   *
+   * @param segmentNameStr name of segment for which the state change is being handled
+   */
+  default void onConsumingToOffline(String segmentNameStr) {
+  }
+  /**
    * Return list of segment names that are stale along with reason.
    *
    * @return List of {@link StaleSegment} with segment names and reason why it is stale

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/SegmentOnlineOfflineStateModelFactory.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/SegmentOnlineOfflineStateModelFactory.java
@@ -115,6 +115,7 @@ public class SegmentOnlineOfflineStateModelFactory extends StateModelFactory<Sta
         String segmentName = message.getPartitionName();
         _instanceDataManager.offloadSegment(realtimeTableName, segmentName);
         _recentlyOffloadedConsumingSegments.put(Pair.of(realtimeTableName, segmentName), true);
+        onConsumingToOffline(realtimeTableName, segmentName);
       } catch (Exception e) {
         _logger.error(
             "Caught exception while processing SegmentOnlineOfflineStateModel.onBecomeOfflineFromConsuming() for "
@@ -156,6 +157,17 @@ public class SegmentOnlineOfflineStateModelFactory extends StateModelFactory<Sta
         return;
       }
       tableDataManager.onConsumingToDropped(segmentName);
+    }
+
+    private void onConsumingToOffline(String realtimeTableName, String segmentName) {
+      TableDataManager tableDataManager = _instanceDataManager.getTableDataManager(realtimeTableName);
+      if (tableDataManager == null) {
+        _logger.warn(
+            "Failed to find data manager for table: {}, skip invoking consuming to offline callback for segment: {}",
+            realtimeTableName, segmentName);
+        return;
+      }
+      tableDataManager.onConsumingToOffline(segmentName);
     }
 
     @Transition(from = "OFFLINE", to = "ONLINE")


### PR DESCRIPTION
Tracking ingestion delay metrics should stop for partitions whose segments are going to OFFLINE state. The reason is that offline segments are not queried. So ingestion delay for the offline replicas are not relevant. If there are more replicas with offline state, replica up metric will determine the severity of the issue. This PR stops tracking ingestion delay on CONSUMING to OFFLINE transition.
 
