### PR TITLE
Support to create combined Lucene Text Index Files and merge into columns.psf

### DIFF
--- a/pinot-core/src/test/java/org/apache/pinot/queries/TextSearchQueriesWithCombinedFilesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/TextSearchQueriesWithCombinedFilesTest.java
@@ -1,0 +1,58 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.queries;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.spi.config.table.FieldConfig;
+
+/**
+ * Test class that runs all the same tests as TextSearchQueriesTest but with useCombineFiles=true.
+ * This ensures that all text search functionality works correctly with the combined files configuration.
+ */
+public class TextSearchQueriesWithCombinedFilesTest extends TextSearchQueriesTest {
+
+  @Override
+  protected List<FieldConfig> createFieldConfigs() {
+    List<FieldConfig> fieldConfigs = super.createFieldConfigs();
+
+    // Override all text index configurations to use useCombineFiles=true
+    for (int i = 0; i < fieldConfigs.size(); i++) {
+      FieldConfig fieldConfig = fieldConfigs.get(i);
+      if (fieldConfig.getIndexTypes().contains(FieldConfig.IndexType.TEXT)) {
+        Map<String, String> properties = new HashMap<>();
+        if (fieldConfig.getProperties() != null) {
+          properties.putAll(fieldConfig.getProperties());
+        }
+        properties.put("useCombineFiles", "true");
+
+        fieldConfigs.set(i, new FieldConfig(
+            fieldConfig.getName(),
+            fieldConfig.getEncodingType(),
+            fieldConfig.getIndexTypes(),
+            fieldConfig.getCompressionCodec(),
+            properties
+        ));
+      }
+    }
+
+    return fieldConfigs;
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/text/LuceneCombinedTextIndexConstants.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/text/LuceneCombinedTextIndexConstants.java
@@ -1,0 +1,105 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.creator.impl.text;
+
+/**
+ * Constants for Lucene text index V2 format.
+ * This class defines the format structure and constants used by both the writer and reader.
+ */
+public final class LuceneCombinedTextIndexConstants {
+  private LuceneCombinedTextIndexConstants() {
+    // Utility class
+  }
+
+  /** Magic number for V2 format */
+  public static final String MAGIC_NUMBER = "LUCENE_V2";
+
+  /** Version number for V2 format */
+  public static final int VERSION = 2;
+
+  /** Magic number length in bytes */
+  public static final int MAGIC_NUMBER_LENGTH = MAGIC_NUMBER.length();
+
+  /** Version field size in bytes */
+  public static final int VERSION_SIZE = Integer.BYTES;
+
+  /** Total buffer size field size in bytes */
+  public static final int TOTAL_SIZE_FIELD_SIZE = Long.BYTES;
+
+  /** File count field size in bytes */
+  public static final int FILE_COUNT_FIELD_SIZE = Integer.BYTES;
+
+  /** Reserved field size in bytes */
+  public static final int RESERVED_FIELD_SIZE = Integer.BYTES;
+
+  /** File name length field size in bytes */
+  public static final int FILE_NAME_LENGTH_FIELD_SIZE = Short.BYTES;
+
+  /** File offset field size in bytes */
+  public static final int FILE_OFFSET_FIELD_SIZE = Long.BYTES;
+
+  /** File size field size in bytes */
+  public static final int FILE_SIZE_FIELD_SIZE = Long.BYTES;
+
+  /**
+   * Calculates the header size in bytes.
+   * Header structure: Magic number + Version + Total buffer size + File count + Reserved
+   */
+  public static int getHeaderSize() {
+    return MAGIC_NUMBER_LENGTH + VERSION_SIZE + TOTAL_SIZE_FIELD_SIZE + FILE_COUNT_FIELD_SIZE + RESERVED_FIELD_SIZE;
+  }
+
+  /**
+   * Calculates the file metadata entry size (excluding variable length filename).
+   * Entry structure: File name length + File offset + File size
+   */
+  public static int getFileMetadataEntrySize() {
+    return FILE_NAME_LENGTH_FIELD_SIZE + FILE_OFFSET_FIELD_SIZE + FILE_SIZE_FIELD_SIZE;
+  }
+
+  /**
+   * Calculates the total file metadata entry size including the filename.
+   * Entry structure: File name length + File name (variable length) + File offset + File size
+   */
+  public static int getFileMetadataEntrySizeWithFilename(String filename) {
+    return getFileMetadataEntrySize() + filename.length();
+  }
+
+  /** Header field offsets */
+  public static final class HeaderOffsets {
+    private HeaderOffsets() {
+      // Utility class
+    }
+
+    /** Magic number starts at offset 0 */
+    public static final int MAGIC_NUMBER_OFFSET = 0;
+
+    /** Version starts after magic number */
+    public static final int VERSION_OFFSET = MAGIC_NUMBER_OFFSET + MAGIC_NUMBER_LENGTH;
+
+    /** Total buffer size starts after version */
+    public static final int TOTAL_SIZE_OFFSET = VERSION_OFFSET + VERSION_SIZE;
+
+    /** File count starts after total buffer size */
+    public static final int FILE_COUNT_OFFSET = TOTAL_SIZE_OFFSET + TOTAL_SIZE_FIELD_SIZE;
+
+    /** Reserved field starts after file count */
+    public static final int RESERVED_OFFSET = FILE_COUNT_OFFSET + FILE_COUNT_FIELD_SIZE;
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/text/LuceneTextIndexCombined.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/text/LuceneTextIndexCombined.java
@@ -1,0 +1,260 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.creator.impl.text;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.FileChannel;
+import java.nio.file.StandardOpenOption;
+import java.util.Map;
+import java.util.TreeMap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Utility class to combine all Lucene text index files into a single buffer in V2 format.
+ * This class handles the serialization of Lucene index directory into a compact buffer format
+ * that can be efficiently stored and loaded.
+ *
+ * <p>The V2 format structure:</p>
+ * <pre>
+ * [Header Section]
+ * - Magic number: "LUCENE_V2" (9 bytes)
+ * - Version: 2 (4 bytes)
+ * - Total buffer size: 8 bytes
+ * - File count: 4 bytes
+ * - Reserved: 4 bytes (for future use)
+ *
+ * [File Metadata Section]
+ * - File name length: 2 bytes
+ * - File name: variable length
+ * - File offset: 8 bytes
+ * - File size: 8 bytes
+ *
+ * [File Data Section]
+ * - Raw file data concatenated in order
+ * </pre>
+ */
+public class LuceneTextIndexCombined {
+  private static final Logger LOGGER = LoggerFactory.getLogger(LuceneTextIndexCombined.class);
+
+  /**
+   * Private constructor to prevent instantiation of utility class.
+   */
+  private LuceneTextIndexCombined() {
+  }
+
+  /**
+   * Combines all files from a Lucene text index directory into a single file.
+   *
+   * @param luceneIndexDir the Lucene index directory to combine
+   * @param outputFilePath the output file path to write the combined data
+   * @throws IOException if any file operations fail
+   */
+  public static void combineLuceneIndexFiles(File luceneIndexDir, String outputFilePath)
+      throws IOException {
+    if (!luceneIndexDir.exists() || !luceneIndexDir.isDirectory()) {
+      throw new IllegalArgumentException(
+          "Lucene index directory does not exist or is not a directory: " + luceneIndexDir);
+    }
+
+    LOGGER.info("Combining Lucene text index files from directory: {}", luceneIndexDir.getAbsolutePath());
+
+    // Step 1: Collect all files and calculate total size
+    Map<String, FileInfo> fileInfoMap = collectFiles(luceneIndexDir);
+    int fileCount = fileInfoMap.size();
+
+    if (fileCount == 0) {
+      throw new IOException("No files found in Lucene index directory: " + luceneIndexDir);
+    }
+
+    // Step 2: Calculate total buffer size
+    long totalSize = calculateTotalBufferSize(fileInfoMap);
+
+    if (totalSize > Integer.MAX_VALUE) {
+      throw new IOException("Combined index size too large: " + totalSize + " bytes");
+    }
+
+    // Step 3: Create output file and write data using FileChannel
+    File outputFile = new File(outputFilePath);
+    try (FileChannel outputChannel = FileChannel.open(outputFile.toPath(), StandardOpenOption.CREATE,
+        StandardOpenOption.WRITE)) {
+
+      // Write header
+      writeHeader(outputChannel, fileCount, (int) totalSize);
+
+      // Write file metadata
+      long dataOffset = LuceneCombinedTextIndexConstants.getHeaderSize() + calculateMetadataSize(fileInfoMap);
+      writeFileMetadata(outputChannel, fileInfoMap, dataOffset);
+
+      // Write file data
+      writeFileData(outputChannel, fileInfoMap);
+    }
+
+    LOGGER.info("Successfully combined {} files into file: {} (size: {} bytes)", fileCount, outputFilePath, totalSize);
+  }
+
+  /**
+   * Collects all files from the Lucene index directory and their metadata.
+   */
+  private static Map<String, FileInfo> collectFiles(File luceneIndexDir)
+      throws IOException {
+    Map<String, FileInfo> fileInfoMap = new TreeMap<>(); // Use TreeMap for consistent ordering
+
+    File[] files = luceneIndexDir.listFiles();
+    if (files != null) {
+      for (File file : files) {
+        if (file.isFile()) {
+          String fileName = file.getName();
+          long fileSize = file.length();
+
+          fileInfoMap.put(fileName, new FileInfo(file, fileName, fileSize));
+        }
+      }
+    }
+
+    return fileInfoMap;
+  }
+
+  /**
+   * Calculates the total buffer size needed.
+   */
+  private static long calculateTotalBufferSize(Map<String, FileInfo> fileInfoMap) {
+    long totalSize = LuceneCombinedTextIndexConstants.getHeaderSize();
+    totalSize += calculateMetadataSize(fileInfoMap);
+
+    for (FileInfo fileInfo : fileInfoMap.values()) {
+      totalSize += fileInfo._size;
+    }
+
+    return totalSize;
+  }
+
+  /**
+   * Calculates the size needed for file metadata section.
+   */
+  private static long calculateMetadataSize(Map<String, FileInfo> fileInfoMap) {
+    long metadataSize = 0;
+    for (FileInfo fileInfo : fileInfoMap.values()) {
+      metadataSize += LuceneCombinedTextIndexConstants.getFileMetadataEntrySizeWithFilename(fileInfo._name);
+    }
+    return metadataSize;
+  }
+
+  /**
+   * Writes the header section to the file.
+   */
+  private static void writeHeader(FileChannel outputChannel, int fileCount, int totalSize)
+      throws IOException {
+    // Magic number
+    outputChannel.write(ByteBuffer.wrap(LuceneCombinedTextIndexConstants.MAGIC_NUMBER.getBytes()));
+
+    // Version
+    ByteBuffer versionBuffer = ByteBuffer.allocate(Integer.BYTES).order(ByteOrder.LITTLE_ENDIAN);
+    versionBuffer.putInt(LuceneCombinedTextIndexConstants.VERSION);
+    versionBuffer.flip();
+    outputChannel.write(versionBuffer);
+
+    // Total buffer size
+    ByteBuffer totalSizeBuffer = ByteBuffer.allocate(Long.BYTES).order(ByteOrder.LITTLE_ENDIAN);
+    totalSizeBuffer.putLong(totalSize);
+    totalSizeBuffer.flip();
+    outputChannel.write(totalSizeBuffer);
+
+    // File count
+    ByteBuffer fileCountBuffer = ByteBuffer.allocate(Integer.BYTES).order(ByteOrder.LITTLE_ENDIAN);
+    fileCountBuffer.putInt(fileCount);
+    fileCountBuffer.flip();
+    outputChannel.write(fileCountBuffer);
+
+    // Reserved
+    ByteBuffer reservedBuffer = ByteBuffer.allocate(Integer.BYTES).order(ByteOrder.LITTLE_ENDIAN);
+    reservedBuffer.putInt(0);
+    reservedBuffer.flip();
+    outputChannel.write(reservedBuffer);
+  }
+
+  /**
+   * Writes the file metadata section to the file.
+   */
+  private static void writeFileMetadata(FileChannel outputChannel, Map<String, FileInfo> fileInfoMap, long dataOffset)
+      throws IOException {
+    for (FileInfo fileInfo : fileInfoMap.values()) {
+      // File name length
+      ByteBuffer nameLengthBuffer = ByteBuffer.allocate(Short.BYTES).order(ByteOrder.LITTLE_ENDIAN);
+      nameLengthBuffer.putShort((short) fileInfo._name.length());
+      nameLengthBuffer.flip();
+      outputChannel.write(nameLengthBuffer);
+
+      // File name (variable length)
+      outputChannel.write(ByteBuffer.wrap(fileInfo._name.getBytes()));
+
+      // File offset
+      ByteBuffer fileOffsetBuffer = ByteBuffer.allocate(Long.BYTES).order(ByteOrder.LITTLE_ENDIAN);
+      fileOffsetBuffer.putLong(dataOffset);
+      fileOffsetBuffer.flip();
+      outputChannel.write(fileOffsetBuffer);
+
+      // File size
+      ByteBuffer fileSizeBuffer = ByteBuffer.allocate(Long.BYTES).order(ByteOrder.LITTLE_ENDIAN);
+      fileSizeBuffer.putLong(fileInfo._size);
+      fileSizeBuffer.flip();
+      outputChannel.write(fileSizeBuffer);
+
+      dataOffset += fileInfo._size;
+    }
+  }
+
+  /**
+   * Writes the file data section to the file.
+   */
+  private static void writeFileData(FileChannel outputChannel, Map<String, FileInfo> fileInfoMap)
+      throws IOException {
+    for (FileInfo fileInfo : fileInfoMap.values()) {
+      try (FileChannel sourceChannel = FileChannel.open(fileInfo._file.toPath(), StandardOpenOption.READ)) {
+        long transferred = 0;
+        long fileSize = fileInfo._size;
+        while (transferred < fileSize) {
+          transferred += sourceChannel.transferTo(transferred, fileSize - transferred, outputChannel);
+        }
+        LOGGER.debug("Wrote file {} ({} bytes) to file", fileInfo._name, fileSize);
+      } catch (IOException e) {
+        throw new IOException("Failed to read file: " + fileInfo._file.getAbsolutePath(), e);
+      }
+    }
+  }
+
+  /**
+   * Internal class to hold file information.
+   */
+  private static class FileInfo {
+    final File _file;
+    final String _name;
+    final long _size;
+
+    FileInfo(File file, String name, long size) {
+      _file = file;
+      _name = name;
+      _size = size;
+    }
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/text/LuceneTextIndexBufferReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/text/LuceneTextIndexBufferReader.java
@@ -1,0 +1,245 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.readers.text;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import org.apache.lucene.store.Directory;
+import org.apache.pinot.segment.local.segment.creator.impl.text.LuceneCombinedTextIndexConstants;
+import org.apache.pinot.segment.local.segment.index.readers.text.LuceneTextIndexHeader.FileInfo;
+import org.apache.pinot.segment.local.segment.index.readers.text.LuceneTextIndexHeader.TextIndexMetadata;
+import org.apache.pinot.segment.spi.V1Constants;
+import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+/**
+ * Utility class for reading Lucene text index from a combined buffer.
+ * This class provides methods to extract files and create Lucene Directory
+ * from a PinotDataBuffer containing the combined text index data.
+ */
+public class LuceneTextIndexBufferReader {
+  private static final Logger LOGGER = LoggerFactory.getLogger(LuceneTextIndexBufferReader.class);
+
+  private LuceneTextIndexBufferReader() {
+  }
+
+  /**
+   * Creates a Lucene Directory from a PinotDataBuffer containing combined text index
+   *
+   * @param indexBuffer the buffer containing combined text index data
+   * @param column the column name
+   * @return Lucene Directory that reads from the buffer
+   * @throws IOException if buffer parsing fails
+   */
+  public static Directory createLuceneDirectory(PinotDataBuffer indexBuffer, String column)
+      throws IOException {
+    // Parse buffer header and metadata
+    LuceneTextIndexHeader.TextIndexMetadata metadata = parseBufferMetadata(indexBuffer);
+
+    // Create file map from metadata
+    Map<String, LuceneTextIndexHeader.FileInfo> fileMap = buildFileMap(indexBuffer, metadata);
+
+    // Return custom Directory implementation
+    return new PinotBufferLuceneDirectory(indexBuffer, fileMap, column);
+  }
+
+  /**
+   * Extracts docId mapping buffer from combined index buffer
+   *
+   * @param indexBuffer the buffer containing combined text index data
+   * @param column the column name
+   * @return PinotDataBuffer for docId mapping, or null if not found
+   * @throws IOException if extraction fails
+   */
+  public static PinotDataBuffer extractDocIdMappingBuffer(PinotDataBuffer indexBuffer, String column)
+      throws IOException {
+    String mappingFileName = column + V1Constants.Indexes.LUCENE_TEXT_INDEX_DOCID_MAPPING_FILE_EXTENSION;
+    LuceneTextIndexHeader.FileInfo fileInfo = getFileInfo(indexBuffer, mappingFileName);
+
+    if (fileInfo != null) {
+      return indexBuffer.view(fileInfo.getOffset(), fileInfo.getOffset() + fileInfo.getSize());
+    }
+    return null;
+  }
+
+  /**
+   * Extracts properties from combined index buffer
+   *
+   * @param indexBuffer the buffer containing combined text index data
+   * @param column the column name
+   * @return Properties object, or empty Properties if not found
+   * @throws IOException if extraction fails
+   */
+  public static Properties extractProperties(PinotDataBuffer indexBuffer, String column)
+      throws IOException {
+    String propertiesFileName = V1Constants.Indexes.LUCENE_TEXT_INDEX_PROPERTIES_FILE;
+    LuceneTextIndexHeader.FileInfo fileInfo = getFileInfo(indexBuffer, propertiesFileName);
+
+    if (fileInfo != null) {
+      PinotDataBuffer propertiesBuffer =
+          indexBuffer.view(fileInfo.getOffset(), fileInfo.getOffset() + fileInfo.getSize());
+      return parsePropertiesFromBuffer(propertiesBuffer);
+    }
+    return new Properties();
+  }
+
+  /**
+   * Checks if buffer contains a specific file
+   *
+   * @param indexBuffer the buffer containing combined text index data
+   * @param fileName the file name to check
+   * @return true if file exists in buffer
+   * @throws IOException if buffer parsing fails
+   */
+  public static boolean hasFile(PinotDataBuffer indexBuffer, String fileName)
+      throws IOException {
+    return getFileInfo(indexBuffer, fileName) != null;
+  }
+
+  /**
+   * Gets list of all files in the buffer
+   *
+   * @param indexBuffer the buffer containing combined text index data
+   * @return list of file names
+   * @throws IOException if buffer parsing fails
+   */
+  public static List<String> listFiles(PinotDataBuffer indexBuffer)
+      throws IOException {
+    TextIndexMetadata metadata = parseBufferMetadata(indexBuffer);
+    return metadata.getFileNames();
+  }
+
+  /**
+   * Gets file info for a specific file
+   *
+   * @param indexBuffer the buffer containing combined text index data
+   * @param fileName the file name
+   * @return FileInfo object, or null if not found
+   * @throws IOException if buffer parsing fails
+   */
+  public static FileInfo getFileInfo(PinotDataBuffer indexBuffer, String fileName)
+      throws IOException {
+    TextIndexMetadata metadata = parseBufferMetadata(indexBuffer);
+    return metadata.getFileInfoMap().get(fileName);
+  }
+
+  /**
+   * Parses buffer metadata from the combined index buffer
+   */
+  private static TextIndexMetadata parseBufferMetadata(PinotDataBuffer indexBuffer)
+      throws IOException {
+    // Read and validate header
+    byte[] magicBytes = new byte[LuceneCombinedTextIndexConstants.MAGIC_NUMBER_LENGTH];
+    indexBuffer.copyTo(LuceneCombinedTextIndexConstants.HeaderOffsets.MAGIC_NUMBER_OFFSET, magicBytes, 0,
+        LuceneCombinedTextIndexConstants.MAGIC_NUMBER_LENGTH);
+    String magic = new String(magicBytes);
+
+    if (!LuceneCombinedTextIndexConstants.MAGIC_NUMBER.equals(magic)) {
+      throw new IOException("Invalid magic number: " + magic);
+    }
+
+    byte[] versionBytes = new byte[LuceneCombinedTextIndexConstants.VERSION_SIZE];
+    indexBuffer.copyTo(LuceneCombinedTextIndexConstants.HeaderOffsets.VERSION_OFFSET, versionBytes, 0,
+        LuceneCombinedTextIndexConstants.VERSION_SIZE);
+    int version = java.nio.ByteBuffer.wrap(versionBytes).order(java.nio.ByteOrder.LITTLE_ENDIAN).getInt();
+
+    LOGGER.debug("Reading buffer version: {}, expected version: {}", version, LuceneCombinedTextIndexConstants.VERSION);
+    if (version != LuceneCombinedTextIndexConstants.VERSION) {
+      throw new IOException(
+          "Unsupported version: " + version + ", expected: " + LuceneCombinedTextIndexConstants.VERSION);
+    }
+
+    byte[] totalSizeBytes = new byte[LuceneCombinedTextIndexConstants.TOTAL_SIZE_FIELD_SIZE];
+    indexBuffer.copyTo(LuceneCombinedTextIndexConstants.HeaderOffsets.TOTAL_SIZE_OFFSET, totalSizeBytes, 0,
+        LuceneCombinedTextIndexConstants.TOTAL_SIZE_FIELD_SIZE);
+    long totalSize = java.nio.ByteBuffer.wrap(totalSizeBytes).order(java.nio.ByteOrder.LITTLE_ENDIAN).getLong();
+
+    byte[] fileCountBytes = new byte[LuceneCombinedTextIndexConstants.FILE_COUNT_FIELD_SIZE];
+    indexBuffer.copyTo(LuceneCombinedTextIndexConstants.HeaderOffsets.FILE_COUNT_OFFSET, fileCountBytes, 0,
+        LuceneCombinedTextIndexConstants.FILE_COUNT_FIELD_SIZE);
+    int fileCount = java.nio.ByteBuffer.wrap(fileCountBytes).order(java.nio.ByteOrder.LITTLE_ENDIAN).getInt();
+    // Skip reserved bytes at position RESERVED_OFFSET
+
+    LOGGER.debug("Parsing buffer metadata: {} files, total size: {} bytes", fileCount, totalSize);
+
+    // Read file metadata
+    List<String> fileNames = new ArrayList<>();
+    Map<String, LuceneTextIndexHeader.FileInfo> fileInfoMap = new HashMap<>();
+    long metadataOffset = LuceneCombinedTextIndexConstants.getHeaderSize();
+
+    for (int i = 0; i < fileCount; i++) {
+      byte[] nameLengthBytes = new byte[LuceneCombinedTextIndexConstants.FILE_NAME_LENGTH_FIELD_SIZE];
+      indexBuffer.copyTo(metadataOffset, nameLengthBytes, 0,
+          LuceneCombinedTextIndexConstants.FILE_NAME_LENGTH_FIELD_SIZE);
+      short nameLength = java.nio.ByteBuffer.wrap(nameLengthBytes).order(java.nio.ByteOrder.LITTLE_ENDIAN).getShort();
+      metadataOffset += LuceneCombinedTextIndexConstants.FILE_NAME_LENGTH_FIELD_SIZE;
+
+      byte[] nameBytes = new byte[nameLength];
+      indexBuffer.copyTo(metadataOffset, nameBytes, 0, nameLength);
+      String fileName = new String(nameBytes);
+      metadataOffset += nameLength;
+
+      // Read file offset
+      byte[] fileOffsetBytes = new byte[LuceneCombinedTextIndexConstants.FILE_OFFSET_FIELD_SIZE];
+      indexBuffer.copyTo(metadataOffset, fileOffsetBytes, 0, LuceneCombinedTextIndexConstants.FILE_OFFSET_FIELD_SIZE);
+      long fileOffset = java.nio.ByteBuffer.wrap(fileOffsetBytes).order(java.nio.ByteOrder.LITTLE_ENDIAN).getLong();
+      metadataOffset += LuceneCombinedTextIndexConstants.FILE_OFFSET_FIELD_SIZE;
+
+      // Read file size
+      byte[] fileSizeBytes = new byte[LuceneCombinedTextIndexConstants.FILE_SIZE_FIELD_SIZE];
+      indexBuffer.copyTo(metadataOffset, fileSizeBytes, 0, LuceneCombinedTextIndexConstants.FILE_SIZE_FIELD_SIZE);
+      long fileSize = java.nio.ByteBuffer.wrap(fileSizeBytes).order(java.nio.ByteOrder.LITTLE_ENDIAN).getLong();
+      metadataOffset += LuceneCombinedTextIndexConstants.FILE_SIZE_FIELD_SIZE;
+
+      fileNames.add(fileName);
+      fileInfoMap.put(fileName, new LuceneTextIndexHeader.FileInfo(fileName, fileOffset, fileSize));
+    }
+
+    return new LuceneTextIndexHeader.TextIndexMetadata(magic, version, totalSize, fileCount, fileNames, fileInfoMap);
+  }
+
+  /**
+   * Builds file map from buffer metadata
+   */
+  private static Map<String, LuceneTextIndexHeader.FileInfo> buildFileMap(PinotDataBuffer indexBuffer,
+      LuceneTextIndexHeader.TextIndexMetadata metadata) {
+    return metadata.getFileInfoMap();
+  }
+
+  /**
+   * Parses properties from buffer
+   */
+  private static Properties parsePropertiesFromBuffer(PinotDataBuffer propertiesBuffer)
+      throws IOException {
+    Properties properties = new Properties();
+    try {
+      // Convert buffer to byte array for Properties.load()
+      byte[] propertiesData = new byte[(int) propertiesBuffer.size()];
+      propertiesBuffer.copyTo(0, propertiesData, 0, (int) propertiesBuffer.size());
+      properties.load(new java.io.ByteArrayInputStream(propertiesData));
+    } catch (Exception e) {
+      throw new IOException("Failed to parse properties", e);
+    }
+    return properties;
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/text/LuceneTextIndexHeader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/text/LuceneTextIndexHeader.java
@@ -1,0 +1,103 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.readers.text;
+
+import java.util.List;
+import java.util.Map;
+
+
+/**
+ * Metadata classes for Lucene text index buffer.
+ * Contains BufferMetadata and FileInfo classes with proper getter APIs.
+ */
+public class LuceneTextIndexHeader {
+
+  /**
+   * Metadata class for buffer information
+   */
+  public static class TextIndexMetadata {
+    private final String _magicNumber;
+    private final int _version;
+    private final long _totalSize;
+    private final int _fileCount;
+    private final List<String> _fileNames;
+    private final Map<String, FileInfo> _fileInfoMap;
+
+    public TextIndexMetadata(String magicNumber, int version, long totalSize, int fileCount, List<String> fileNames,
+        Map<String, FileInfo> fileInfoMap) {
+      _magicNumber = magicNumber;
+      _version = version;
+      _totalSize = totalSize;
+      _fileCount = fileCount;
+      _fileNames = fileNames;
+      _fileInfoMap = fileInfoMap;
+    }
+
+    public String getMagicNumber() {
+      return _magicNumber;
+    }
+
+    public int getVersion() {
+      return _version;
+    }
+
+    public long getTotalSize() {
+      return _totalSize;
+    }
+
+    public int getFileCount() {
+      return _fileCount;
+    }
+
+    public List<String> getFileNames() {
+      return _fileNames;
+    }
+
+    public Map<String, FileInfo> getFileInfoMap() {
+      return _fileInfoMap;
+    }
+  }
+
+  /**
+   * File information class
+   */
+  public static class FileInfo {
+    private final String _name;
+    private final long _offset;
+    private final long _size;
+
+    public FileInfo(String name, long offset, long size) {
+      _name = name;
+      _offset = offset;
+      _size = size;
+    }
+
+    public String getName() {
+      return _name;
+    }
+
+    public long getOffset() {
+      return _offset;
+    }
+
+    public long getSize() {
+      return _size;
+    }
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/text/LuceneTextIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/text/LuceneTextIndexReader.java
@@ -22,7 +22,10 @@ import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.nio.ByteOrder;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import javax.annotation.Nullable;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.document.Document;
@@ -52,6 +55,7 @@ import org.apache.pinot.segment.spi.index.reader.TextIndexReader;
 import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
 import org.apache.pinot.segment.spi.store.SegmentDirectoryPaths;
 import org.apache.pinot.spi.config.table.FSTType;
+import org.apache.pinot.spi.config.table.FieldConfig;
 import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
 import org.roaringbitmap.buffer.MutableRoaringBitmap;
 import org.slf4j.LoggerFactory;
@@ -65,14 +69,14 @@ import org.slf4j.LoggerFactory;
 public class LuceneTextIndexReader implements TextIndexReader {
   private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(LuceneTextIndexReader.class);
 
-  private final IndexReader _indexReader;
-  private final Directory _indexDirectory;
-  private final IndexSearcher _indexSearcher;
+  private IndexReader _indexReader;
+  private Directory _indexDirectory;
+  private IndexSearcher _indexSearcher;
   private final String _column;
-  private final DocIdTranslator _docIdTranslator;
-  private final Analyzer _analyzer;
+  private DocIdTranslator _docIdTranslator;
+  private Analyzer _analyzer;
   private boolean _useANDForMultiTermQueries = false;
-  private final String _queryParserClass;
+  private String _queryParserClass;
   private Constructor<QueryParserBase> _queryParserClassConstructor;
   private boolean _enablePrefixSuffixMatchingInPhraseQueries = false;
 
@@ -80,33 +84,20 @@ public class LuceneTextIndexReader implements TextIndexReader {
     _column = column;
     try {
       File indexFile = getTextIndexFile(indexDir);
-      _indexDirectory = FSDirectory.open(indexFile.toPath());
-      _indexReader = DirectoryReader.open(_indexDirectory);
-      _indexSearcher = new IndexSearcher(_indexReader);
-      if (!config.isEnableQueryCache()) {
-        // Disable Lucene query result cache. While it helps a lot with performance for
-        // repeated queries, on the downside it can cause heap issues.
-        _indexSearcher.setQueryCache(null);
-      }
-      if (config.isUseANDForMultiTermQueries()) {
-        _useANDForMultiTermQueries = true;
-      }
-      if (config.isEnablePrefixSuffixMatchingInPhraseQueries()) {
-        _enablePrefixSuffixMatchingInPhraseQueries = true;
-      }
-      // TODO: consider using a threshold of num docs per segment to decide between building
-      // mapping file upfront on segment load v/s on-the-fly during query processing
-      // If the properties file exists, use the analyzer properties and query parser class from the properties file
+      Directory indexDirectory = FSDirectory.open(indexFile.toPath());
+
+      // Load properties from file if exists
       File propertiesFile = new File(indexFile, V1Constants.Indexes.LUCENE_TEXT_INDEX_PROPERTIES_FILE);
       if (propertiesFile.exists()) {
         config = TextIndexUtils.getUpdatedConfigFromPropertiesFile(propertiesFile, config);
       }
 
-      _docIdTranslator = prepareDocIdTranslator(indexDir, _column, numDocs, _indexSearcher, config, indexFile);
-      _analyzer = TextIndexUtils.getAnalyzer(config);
-      _queryParserClass = config.getLuceneQueryParserClass();
-      _queryParserClassConstructor =
-          TextIndexUtils.getQueryParserWithStringAndAnalyzerTypeConstructor(_queryParserClass);
+      // Prepare docId mapping buffer
+      PinotDataBuffer docIdMappingBuffer = prepareDocIdMappingBuffer(indexDir, column, numDocs, config, indexFile);
+
+      // Initialize from components
+      initializeFromComponents(indexDirectory, docIdMappingBuffer, config, numDocs);
+
       LOGGER.info("Successfully read lucene index for {} from {}", _column, indexDir);
     } catch (Exception e) {
       LOGGER.error("Failed to instantiate Lucene text index reader for column {}, exception {}", column,
@@ -129,6 +120,41 @@ public class LuceneTextIndexReader implements TextIndexReader {
       @Nullable Map<String, String> textIndexProperties) {
     this(column, indexDir, numDocs,
         new TextIndexConfigBuilder(FSTType.LUCENE).withProperties(textIndexProperties).build());
+  }
+
+  /**
+   * Buffer-based constructor for reading Lucene text index from a combined buffer.
+   * This constructor creates a Lucene Directory from a PinotDataBuffer containing
+   * all the text index files in a combined format.
+   *
+   * @param column the column name
+   * @param indexBuffer the buffer containing combined text index data
+   * @param numDocs number of documents in the segment
+   * @param config text index configuration
+   */
+  public LuceneTextIndexReader(String column, PinotDataBuffer indexBuffer, int numDocs, TextIndexConfig config) {
+    _column = column;
+    try {
+      // Create Lucene Directory from buffer
+      Directory indexDirectory = LuceneTextIndexBufferReader.createLuceneDirectory(indexBuffer, column);
+
+      // Extract properties from buffer
+      Properties properties = LuceneTextIndexBufferReader.extractProperties(indexBuffer, column);
+      if (!properties.isEmpty()) {
+        config = updateConfigFromProperties(properties, config);
+      }
+
+      // Extract docId mapping buffer from combined index buffer
+      PinotDataBuffer docIdMappingBuffer = LuceneTextIndexBufferReader.extractDocIdMappingBuffer(indexBuffer, column);
+
+      // Initialize from components
+      initializeFromComponents(indexDirectory, docIdMappingBuffer, config, numDocs);
+
+      LOGGER.info("Successfully read lucene index for {} from buffer", _column);
+    } catch (Exception e) {
+      LOGGER.error("Failed to instantiate Lucene text index reader for column {} from buffer", column, e);
+      throw new RuntimeException(e);
+    }
   }
 
   /**
@@ -237,12 +263,15 @@ public class LuceneTextIndexReader implements TextIndexReader {
     _analyzer.close();
   }
 
-  DocIdTranslator prepareDocIdTranslator(File segmentIndexDir, String column, int numDocs,
-      IndexSearcher indexSearcher, TextIndexConfig config, File indexDir)
+  /**
+   * Prepares docId mapping buffer from file or creates a new one
+   */
+  private PinotDataBuffer prepareDocIdMappingBuffer(File segmentIndexDir, String column, int numDocs,
+      TextIndexConfig config, File indexDir)
       throws IOException {
     if (config.getDocIdTranslatorMode() == DocIdTranslatorMode.Skip) {
       LOGGER.debug("Using no-op doc id translator");
-      return NoOpDocIdTranslator.INSTANCE;
+      return null;
     }
 
     int length = Integer.BYTES * numDocs;
@@ -261,82 +290,158 @@ public class LuceneTextIndexReader implements TextIndexReader {
         // TODO: see if we can prefetch the pages
         buffer =
             PinotDataBuffer.mapFile(docIdMappingFile, /* readOnly */ true, 0, length, ByteOrder.LITTLE_ENDIAN, desc);
-
-        return new DefaultDocIdTranslator(buffer);
-      } else {
-        buffer =
-            PinotDataBuffer.mapFile(docIdMappingFile, /* readOnly */ false, 0, length, ByteOrder.LITTLE_ENDIAN, desc);
-
-        if (config.getDocIdTranslatorMode() == DocIdTranslatorMode.TryOptimize) {
-          LOGGER.debug("Creating lucene to pinot doc id mapping.");
-          boolean allIdsAreEqual = true;
-
-          class DocIdVisitor extends DocumentStoredFieldVisitor {
-            int _pinotDocId;
-
-            @Override
-            public Status needsField(FieldInfo fieldInfo) {
-              // assume doc id is the only stored document
-              assert LuceneTextIndexCreator.LUCENE_INDEX_DOC_ID_COLUMN_NAME.equals(fieldInfo.name);
-              return Status.YES;
-            }
-
-            @Override
-            public void intField(FieldInfo fieldInfo, int value) {
-              _pinotDocId = value;
-            }
-          }
-
-          DocIdVisitor visitor = new DocIdVisitor();
-          StoredFields storedFields = indexSearcher.storedFields();
-
-          for (int i = 0; i < numDocs; i++) {
-            storedFields.document(i, visitor);
-            int pinotDocId = visitor._pinotDocId;
-            allIdsAreEqual &= (i == pinotDocId);
-            buffer.putInt(i * Integer.BYTES, pinotDocId);
-          }
-
-          if (allIdsAreEqual) {
-            LOGGER.debug("Lucene doc ids are equal to Pinot's. Deleting mapping and updating index settings.");
-            // TODO: it'd be better to unmap without flushing the buffer. Only some buffer types support it, though.
-            buffer.close();
-            buffer = null;
-            // get rid of mapping and use lucene ids
-            docIdMappingFile.delete();
-
-            // mapping is unnecessary so store flag in config file to skip checking on next load
-            TextIndexConfig newConfig =
-                new TextIndexConfigBuilder(config).withDocIdTranslatorMode(DocIdTranslatorMode.Skip.name()).build();
-            TextIndexUtils.writeConfigToPropertiesFile(indexDir, newConfig);
-
-            return NoOpDocIdTranslator.INSTANCE;
-          } else {
-            LOGGER.debug("Lucene doc ids are not equal to Pinot's. Keeping the mapping.");
-            // mapping is required so switch to default mode
-            TextIndexConfig newConfig =
-                new TextIndexConfigBuilder(config).withDocIdTranslatorMode(DocIdTranslatorMode.Default.name()).build();
-            TextIndexUtils.writeConfigToPropertiesFile(indexDir, newConfig);
-
-            return new DefaultDocIdTranslator(buffer);
-          }
-        } else {
-          for (int i = 0; i < numDocs; i++) {
-            Document document = indexSearcher.doc(i);
-            IndexableField field = document.getField(LuceneTextIndexCreator.LUCENE_INDEX_DOC_ID_COLUMN_NAME);
-            int pinotDocId = Integer.parseInt(field.stringValue());
-            buffer.putInt(i * Integer.BYTES, pinotDocId);
-          }
-          return new DefaultDocIdTranslator(buffer);
-        }
+        return buffer;
       }
     } catch (Exception e) {
       if (buffer != null) {
         buffer.close();
       }
-
       throw new RuntimeException(
-          "Caught exception while building doc id mapping for text index column: " + column, e);
+          "Caught exception while preparing doc id mapping buffer for text index column: " + column, e);
+    }
+    return null;
+  }
+
+  /**
+   * Initializes the reader from components (directory, docId mapping buffer, and config)
+   */
+  private void initializeFromComponents(Directory indexDirectory, PinotDataBuffer docIdMappingBuffer,
+      TextIndexConfig config, int numDocs)
+      throws IOException, ReflectiveOperationException {
+    _indexDirectory = indexDirectory;
+    _indexReader = DirectoryReader.open(_indexDirectory);
+    _indexSearcher = new IndexSearcher(_indexReader);
+
+    if (!config.isEnableQueryCache()) {
+      // Disable Lucene query result cache. While it helps a lot with performance for
+      // repeated queries, on the downside it can cause heap issues.
+      _indexSearcher.setQueryCache(null);
+    }
+
+    if (config.isUseANDForMultiTermQueries()) {
+      _useANDForMultiTermQueries = true;
+    }
+
+    if (config.isEnablePrefixSuffixMatchingInPhraseQueries()) {
+      _enablePrefixSuffixMatchingInPhraseQueries = true;
+    }
+
+    // Initialize docId translator
+    _docIdTranslator = createDocIdTranslator(docIdMappingBuffer, config, numDocs);
+
+    // Initialize analyzer and query parser
+    _analyzer = TextIndexUtils.getAnalyzer(config);
+    _queryParserClass = config.getLuceneQueryParserClass();
+    _queryParserClassConstructor = TextIndexUtils.getQueryParserWithStringAndAnalyzerTypeConstructor(_queryParserClass);
+  }
+
+  /**
+   * Updates TextIndexConfig from Properties object
+   */
+  private TextIndexConfig updateConfigFromProperties(Properties properties, TextIndexConfig config) {
+    TextIndexConfigBuilder builder = new TextIndexConfigBuilder(config);
+
+    String analyzerClass = properties.getProperty(FieldConfig.TEXT_INDEX_LUCENE_ANALYZER_CLASS);
+    if (analyzerClass != null) {
+      builder.withLuceneAnalyzerClass(analyzerClass);
+    }
+
+    String analyzerArgs = properties.getProperty(FieldConfig.TEXT_INDEX_LUCENE_ANALYZER_CLASS_ARGS);
+    if (analyzerArgs != null) {
+      List<String> args = Arrays.asList(analyzerArgs.split(","));
+      builder.withLuceneAnalyzerClassArgs(args);
+    }
+
+    String analyzerArgTypes = properties.getProperty(FieldConfig.TEXT_INDEX_LUCENE_ANALYZER_CLASS_ARG_TYPES);
+    if (analyzerArgTypes != null) {
+      List<String> argTypes = Arrays.asList(analyzerArgTypes.split(","));
+      builder.withLuceneAnalyzerClassArgTypes(argTypes);
+    }
+
+    String queryParserClass = properties.getProperty(FieldConfig.TEXT_INDEX_LUCENE_QUERY_PARSER_CLASS);
+    if (queryParserClass != null) {
+      builder.withLuceneQueryParserClass(queryParserClass);
+    }
+
+    String docIdTranslatorMode = properties.getProperty(FieldConfig.TEXT_INDEX_LUCENE_DOC_ID_TRANSLATOR_MODE);
+    if (docIdTranslatorMode != null) {
+      builder.withDocIdTranslatorMode(docIdTranslatorMode);
+    }
+
+    return builder.build();
+  }
+
+  /**
+   * Creates docId translator from buffer
+   */
+  private DocIdTranslator createDocIdTranslator(PinotDataBuffer docIdMappingBuffer, TextIndexConfig config, int numDocs)
+      throws IOException {
+    if (config.getDocIdTranslatorMode() == DocIdTranslatorMode.Skip) {
+      LOGGER.debug("Using no-op doc id translator");
+      return NoOpDocIdTranslator.INSTANCE;
+    }
+
+    if (docIdMappingBuffer != null) {
+      return new DefaultDocIdTranslator(docIdMappingBuffer);
+    }
+
+    // Create a new buffer and populate it
+    int length = Integer.BYTES * numDocs;
+    String desc = "Text index docId mapping buffer: " + _column;
+    PinotDataBuffer buffer = PinotDataBuffer.allocateDirect(length, ByteOrder.LITTLE_ENDIAN, desc);
+
+    try {
+      if (config.getDocIdTranslatorMode() == DocIdTranslatorMode.TryOptimize) {
+        LOGGER.debug("Creating lucene to pinot doc id mapping.");
+        boolean allIdsAreEqual = true;
+
+        class DocIdVisitor extends DocumentStoredFieldVisitor {
+          int _pinotDocId;
+
+          @Override
+          public Status needsField(FieldInfo fieldInfo) {
+            // assume doc id is the only stored document
+            assert LuceneTextIndexCreator.LUCENE_INDEX_DOC_ID_COLUMN_NAME.equals(fieldInfo.name);
+            return Status.YES;
+          }
+
+          @Override
+          public void intField(FieldInfo fieldInfo, int value) {
+            _pinotDocId = value;
+          }
+        }
+
+        DocIdVisitor visitor = new DocIdVisitor();
+        StoredFields storedFields = _indexSearcher.storedFields();
+
+        for (int i = 0; i < numDocs; i++) {
+          storedFields.document(i, visitor);
+          int pinotDocId = visitor._pinotDocId;
+          allIdsAreEqual &= (i == pinotDocId);
+          buffer.putInt(i * Integer.BYTES, pinotDocId);
+        }
+
+        if (allIdsAreEqual) {
+          LOGGER.debug("Lucene doc ids are equal to Pinot's. Using no-op translator.");
+          buffer.close();
+          return NoOpDocIdTranslator.INSTANCE;
+        } else {
+          LOGGER.debug("Lucene doc ids are not equal to Pinot's. Using default translator.");
+          return new DefaultDocIdTranslator(buffer);
+        }
+      } else {
+        for (int i = 0; i < numDocs; i++) {
+          Document document = _indexSearcher.doc(i);
+          IndexableField field = document.getField(LuceneTextIndexCreator.LUCENE_INDEX_DOC_ID_COLUMN_NAME);
+          int pinotDocId = Integer.parseInt(field.stringValue());
+          buffer.putInt(i * Integer.BYTES, pinotDocId);
+        }
+        return new DefaultDocIdTranslator(buffer);
+      }
+    } catch (Exception e) {
+      buffer.close();
+      throw new RuntimeException("Caught exception while creating doc id translator for text index column: " + _column,
+          e);
     }
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/text/PinotBufferIndexInput.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/text/PinotBufferIndexInput.java
@@ -1,0 +1,88 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.readers.text;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import org.apache.lucene.store.BufferedIndexInput;
+import org.apache.lucene.store.IndexInput;
+import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
+
+
+/**
+ * Custom Lucene BufferedIndexInput implementation that reads from a PinotDataBuffer.
+ * This allows Lucene to read file data directly from memory buffers with buffering for better performance.
+ */
+public class PinotBufferIndexInput extends BufferedIndexInput {
+  private final PinotDataBuffer _buffer;
+  private final long _length;
+
+  public PinotBufferIndexInput(String name, PinotDataBuffer buffer, long startOffset, long length) {
+    super(name);
+    _buffer = buffer.view(startOffset, startOffset + length);
+    _length = length;
+  }
+
+  @Override
+  public void close()
+      throws IOException {
+    // No-op - buffer is managed externally
+  }
+
+  @Override
+  protected void readInternal(ByteBuffer b)
+      throws IOException {
+    long currentPosition = getFilePointer();
+    if (currentPosition + b.remaining() > _length) {
+      throw new IOException("Read past end of file");
+    }
+
+    // Copy data from PinotDataBuffer to ByteBuffer
+    byte[] tempBuffer = new byte[b.remaining()];
+    _buffer.copyTo(currentPosition, tempBuffer, 0, tempBuffer.length);
+    b.put(tempBuffer);
+  }
+
+  @Override
+  public long length() {
+    return _length;
+  }
+
+  @Override
+  protected void seekInternal(long pos) throws IOException {
+    if (pos < 0 || pos > _length) {
+      throw new IOException("Seek position out of bounds: " + pos + ", length: " + _length);
+    }
+    // BufferedIndexInput handles the actual seeking, we just validate bounds
+  }
+
+  @Override
+  public IndexInput slice(String sliceDescription, long offset, long length) throws IOException {
+    if (offset < 0 || length < 0 || offset + length > _length) {
+      throw new IOException("Slice out of bounds: offset=" + offset + ", length=" + length + ", fileLength=" + _length);
+    }
+    PinotDataBuffer sliceBuffer = _buffer.view(offset, offset + length);
+    return new PinotBufferIndexInput(getFullSliceDescription(sliceDescription), sliceBuffer, 0, length);
+  }
+
+  @Override
+  public String toString() {
+    return "PinotBufferIndexInput(name=" + super.toString() + ", length=" + _length + ")";
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/text/PinotBufferLuceneDirectory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/text/PinotBufferLuceneDirectory.java
@@ -1,0 +1,139 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.readers.text;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import org.apache.lucene.store.Directory;
+import org.apache.lucene.store.IOContext;
+import org.apache.lucene.store.IndexInput;
+import org.apache.lucene.store.IndexOutput;
+import org.apache.lucene.store.Lock;
+import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Custom Lucene Directory implementation that reads from a PinotDataBuffer.
+ * This allows Lucene to work with combined text index buffers without creating
+ * temporary files or directories.
+ */
+public class PinotBufferLuceneDirectory extends Directory {
+  private static final Logger LOGGER = LoggerFactory.getLogger(PinotBufferLuceneDirectory.class);
+
+  private final PinotDataBuffer _indexBuffer;
+  private final java.util.Map<String, LuceneTextIndexHeader.FileInfo> _fileMap;
+  private final String _column;
+  private final Set<String> _fileNames;
+
+  public PinotBufferLuceneDirectory(PinotDataBuffer indexBuffer, Map<String, LuceneTextIndexHeader.FileInfo> fileMap,
+      String column) {
+    _indexBuffer = indexBuffer;
+    _fileMap = fileMap;
+    _column = column;
+    _fileNames = fileMap.keySet();
+  }
+
+  @Override
+  public String[] listAll() {
+    return _fileNames.toArray(new String[0]);
+  }
+
+  @Override
+  public void deleteFile(String name)
+      throws IOException {
+    throw new UnsupportedOperationException("Delete not supported in read-only buffer directory");
+  }
+
+  @Override
+  public long fileLength(String name)
+      throws IOException {
+    LuceneTextIndexHeader.FileInfo fileInfo = _fileMap.get(name);
+    if (fileInfo == null) {
+      throw new IOException("File not found: " + name);
+    }
+    return fileInfo.getSize();
+  }
+
+  @Override
+  public IndexOutput createOutput(String name, IOContext context)
+      throws IOException {
+    throw new UnsupportedOperationException("Write not supported in read-only buffer directory");
+  }
+
+  @Override
+  public IndexOutput createTempOutput(String prefix, String suffix, IOContext context)
+      throws IOException {
+    throw new UnsupportedOperationException("Write not supported in read-only buffer directory");
+  }
+
+  @Override
+  public void sync(Collection<String> names)
+      throws IOException {
+    // No-op for read-only directory
+  }
+
+  @Override
+  public void syncMetaData()
+      throws IOException {
+    // No-op for read-only directory
+  }
+
+  @Override
+  public void rename(String source, String dest)
+      throws IOException {
+    throw new UnsupportedOperationException("Write not supported in read-only buffer directory");
+  }
+
+  @Override
+  public IndexInput openInput(String name, IOContext context)
+      throws IOException {
+    LuceneTextIndexHeader.FileInfo fileInfo = _fileMap.get(name);
+    if (fileInfo == null) {
+      throw new IOException("File not found: " + name);
+    }
+    return new PinotBufferIndexInput(name, _indexBuffer, fileInfo.getOffset(), fileInfo.getSize());
+  }
+
+  @Override
+  public Lock obtainLock(String name)
+      throws IOException {
+    throw new UnsupportedOperationException("Locking not supported in read-only buffer directory");
+  }
+
+  @Override
+  public void close()
+      throws IOException {
+    // No-op - buffer is managed externally
+  }
+
+  @Override
+  public String toString() {
+    return "PinotBufferLuceneDirectory(column=" + _column + ", files=" + _fileNames.size() + ")";
+  }
+
+  @Override
+  public Set<String> getPendingDeletions()
+      throws IOException {
+    throw new UnsupportedOperationException("Pending deletions not supported in read-only buffer directory");
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/text/TextIndexConfigBuilder.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/text/TextIndexConfigBuilder.java
@@ -106,7 +106,22 @@ public class TextIndexConfigBuilder extends TextIndexConfig.AbstractBuilder {
           _fstType = FSTType.LUCENE;
         }
       }
+
+      if (textIndexProperties.get("useCombineFiles") != null) {
+        withUseCombineFiles(Boolean.parseBoolean(textIndexProperties.get("useCombineFiles")));
+      }
     }
+    return this;
+  }
+
+  /**
+   * Sets whether to combine text index files into a single file and cleanup the directory structure.
+   *
+   * @param useCombineFiles true if files should be combined and directory cleaned up, false to keep directory structure
+   * @return this builder
+   */
+  public TextIndexConfigBuilder setUseCombineFiles(boolean useCombineFiles) {
+    withUseCombineFiles(useCombineFiles);
     return this;
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/text/TextIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/text/TextIndexType.java
@@ -50,6 +50,7 @@ import org.apache.pinot.segment.spi.index.creator.TextIndexCreator;
 import org.apache.pinot.segment.spi.index.mutable.MutableIndex;
 import org.apache.pinot.segment.spi.index.mutable.provider.MutableIndexContext;
 import org.apache.pinot.segment.spi.index.reader.TextIndexReader;
+import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
 import org.apache.pinot.segment.spi.store.SegmentDirectory;
 import org.apache.pinot.spi.config.table.FSTType;
 import org.apache.pinot.spi.config.table.FieldConfig;
@@ -66,12 +67,7 @@ public class TextIndexType extends AbstractIndexType<TextIndexConfig, TextIndexR
   public static final String INDEX_DISPLAY_NAME = "text";
   // TODO: Should V1Constants.Indexes.LUCENE_TEXT_INDEX_DOCID_MAPPING_FILE_EXTENSION be added here?
   private static final List<String> EXTENSIONS = Lists.newArrayList(
-      V1Constants.Indexes.LUCENE_TEXT_INDEX_FILE_EXTENSION,
-      V1Constants.Indexes.NATIVE_TEXT_INDEX_FILE_EXTENSION,
-      V1Constants.Indexes.LUCENE_V9_TEXT_INDEX_FILE_EXTENSION,
-      V1Constants.Indexes.LUCENE_V99_TEXT_INDEX_FILE_EXTENSION,
-      V1Constants.Indexes.LUCENE_V912_TEXT_INDEX_FILE_EXTENSION
-  );
+      V1Constants.Indexes.LUCENE_COMBINE_TEXT_INDEX_FILE_EXTENSION);
 
   protected TextIndexType() {
     super(StandardIndexes.TEXT_ID);
@@ -119,7 +115,7 @@ public class TextIndexType extends AbstractIndexType<TextIndexConfig, TextIndexR
       return new NativeTextIndexCreator(context.getFieldSpec().getName(), context.getTableNameWithType(),
           context.isContinueOnError(), context.getIndexDir());
     } else {
-      return new LuceneTextIndexCreator(context, indexConfig);
+      return new LuceneTextIndexCreator(context, indexConfig.isUseCombineFiles(), indexConfig);
     }
   }
 
@@ -149,18 +145,23 @@ public class TextIndexType extends AbstractIndexType<TextIndexConfig, TextIndexR
     @Override
     public TextIndexReader createIndexReader(SegmentDirectory.Reader segmentReader, FieldIndexConfigs fieldIndexConfigs,
         ColumnMetadata metadata)
-        throws IndexReaderConstraintException {
+        throws IndexReaderConstraintException, IOException {
       if (metadata.getDataType() != FieldSpec.DataType.STRING) {
         throw new IndexReaderConstraintException(metadata.getColumnName(), StandardIndexes.text(),
             "Text index is currently only supported on STRING type columns");
       }
       File segmentDir = segmentReader.toSegmentDirectory().getPath().toFile();
+      TextIndexConfig indexConfig = fieldIndexConfigs.getConfig(StandardIndexes.text());
+      if (indexConfig.isUseCombineFiles()) {
+        PinotDataBuffer textIndexBuffer = segmentReader.getIndexFor(metadata.getColumnName(), StandardIndexes.text());
+        return new LuceneTextIndexReader(metadata.getColumnName(), textIndexBuffer, metadata.getTotalDocs(),
+            indexConfig);
+      }
       FSTType textIndexFSTType = TextIndexUtils.getFSTTypeOfIndex(segmentDir, metadata.getColumnName());
       if (textIndexFSTType == FSTType.NATIVE) {
         // TODO: Support loading native text index from a PinotDataBuffer
         return new NativeTextIndexReader(metadata.getColumnName(), segmentDir);
       }
-      TextIndexConfig indexConfig = fieldIndexConfigs.getConfig(StandardIndexes.text());
       return new LuceneTextIndexReader(metadata.getColumnName(), segmentDir, metadata.getTotalDocs(), indexConfig);
     }
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/SingleFileIndexDirectory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/SingleFileIndexDirectory.java
@@ -140,8 +140,8 @@ class SingleFileIndexDirectory extends ColumnIndexDirectory {
 
   @Override
   public boolean hasIndexFor(String column, IndexType<?, ?, ?> type) {
-    if (type == StandardIndexes.text()) {
-      return TextIndexUtils.hasTextIndex(_segmentDirectory, column);
+    if (type == StandardIndexes.text() && TextIndexUtils.hasTextIndex(_segmentDirectory, column)) {
+      return true;
     }
     if (type == StandardIndexes.vector()) {
       return VectorIndexUtils.hasVectorIndex(_segmentDirectory, column);
@@ -387,7 +387,6 @@ class SingleFileIndexDirectory extends ColumnIndexDirectory {
           columns.add(column);
         }
       }
-      return columns;
     }
     if (type == StandardIndexes.vector()) {
       for (String column : _segmentMetadata.getAllColumns()) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/TextIndexUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/TextIndexUtils.java
@@ -109,7 +109,7 @@ public class TextIndexUtils {
     FileUtils.deleteQuietly(nativeIndexFile);
   }
 
-  static boolean hasTextIndex(File segDir, String column) {
+  public static boolean hasTextIndex(File segDir, String column) {
     //@formatter:off
     return new File(segDir, column + Indexes.LUCENE_TEXT_INDEX_FILE_EXTENSION).exists()
         || new File(segDir, column + Indexes.LUCENE_V9_TEXT_INDEX_FILE_EXTENSION).exists()

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/impl/text/LuceneTextIndexBufferIntegrationTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/impl/text/LuceneTextIndexBufferIntegrationTest.java
@@ -1,0 +1,210 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.creator.impl.text;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.segment.local.segment.index.readers.text.LuceneTextIndexReader;
+import org.apache.pinot.segment.local.segment.index.text.TextIndexConfigBuilder;
+import org.apache.pinot.segment.spi.V1Constants;
+import org.apache.pinot.segment.spi.index.TextIndexConfig;
+import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
+import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+/**
+ * Integration test for the complete Lucene text index buffer flow:
+ * 1. Create Lucene text index files in a directory
+ * 2. Combine files using LuceneTextIndexCombined
+ * 3. Read combined file via PinotDataBuffer
+ * 4. Verify document search using LuceneTextIndexReader
+ */
+public class LuceneTextIndexBufferIntegrationTest {
+  private static final String COLUMN_NAME = "textColumn";
+  private static final int NUM_DOCS = 4;
+
+  private File _tempDir;
+  private File _indexDir;
+  private File _combinedFile;
+  private List<String> _documents;
+
+  @BeforeMethod
+  public void setUp() throws IOException {
+    // Create temporary directory structure
+    _tempDir = new File(System.getProperty("java.io.tmpdir"),
+        "lucene_buffer_test_" + System.currentTimeMillis());
+    _tempDir.mkdirs();
+
+    _indexDir = new File(_tempDir, COLUMN_NAME + V1Constants.Indexes.LUCENE_V912_TEXT_INDEX_FILE_EXTENSION);
+    _combinedFile = new File(_tempDir, COLUMN_NAME + V1Constants.Indexes.LUCENE_COMBINE_TEXT_INDEX_FILE_EXTENSION);
+
+    // Prepare test documents
+    _documents = new ArrayList<>();
+    _documents.add("Apache Pinot is a distributed OLAP datastore");
+    _documents.add("Real-time analytics with low latency queries");
+    _documents.add("Scalable analytics platform for big data");
+    _documents.add("Fast aggregations and filtering capabilities");
+  }
+
+  @AfterMethod
+  public void tearDown() throws IOException {
+    if (_tempDir != null && _tempDir.exists()) {
+      FileUtils.deleteDirectory(_tempDir);
+    }
+  }
+
+  @Test
+  public void testCompleteBufferFlow() throws Exception {
+    // Step 1: Create Lucene text index files
+    createLuceneIndexFiles();
+
+    // Step 2: Combine files into buffer format
+    combineLuceneFiles();
+
+    // Step 3: Read via PinotDataBuffer and verify search functionality
+    verifyBufferBasedSearch();
+  }
+
+  /**
+   * Step 1: Create Lucene text index files in directory structure
+   */
+  private void createLuceneIndexFiles() throws Exception {
+    System.out.println("Creating Lucene index files in: " + _indexDir.getAbsolutePath());
+
+    // Create the index directory
+    _indexDir.mkdirs();
+
+    // Create text index config
+    TextIndexConfig textIndexConfig = new TextIndexConfigBuilder()
+        .withLuceneAnalyzerClass("org.apache.lucene.analysis.standard.StandardAnalyzer")
+        .build();
+
+    // Create the Lucene text index creator
+    try (LuceneTextIndexCreator creator = new LuceneTextIndexCreator(COLUMN_NAME, _tempDir, true, false, null, null,
+        true, textIndexConfig)) {
+
+      // Add documents to the index
+      for (int docId = 0; docId < _documents.size(); docId++) {
+        creator.add(_documents.get(docId), docId);
+        System.out.println("Added doc " + docId + ": " + _documents.get(docId));
+      }
+
+      // Seal the index (this will also combine files and delete the original directory)
+      creator.seal();
+    }
+
+    // Note: After sealing, the original Lucene directory is deleted and files are combined
+    System.out.println("Index files created and combined into single buffer file");
+  }
+
+  /**
+   * Step 2: Verify combined file was created during seal()
+   */
+  private void combineLuceneFiles() throws Exception {
+    System.out.println("Verifying combined file: " + _combinedFile.getAbsolutePath());
+
+    // Verify that combined file was created during seal()
+    assertTrue(_combinedFile.exists(), "Combined file should exist");
+    assertTrue(_combinedFile.length() > 0, "Combined file should not be empty");
+
+    System.out.println("Combined file verified: " + _combinedFile.length() + " bytes");
+  }
+
+  /**
+   * Step 3: Read via PinotDataBuffer and verify search functionality
+   */
+  private void verifyBufferBasedSearch() throws Exception {
+    System.out.println("Verifying buffer-based search functionality");
+
+    // Load the combined file as PinotDataBuffer
+    PinotDataBuffer indexBuffer = PinotDataBuffer.mapFile(_combinedFile, true, 0, _combinedFile.length(),
+        java.nio.ByteOrder.LITTLE_ENDIAN, "LuceneTextIndexBufferTest");
+
+    try {
+      // Create text index config
+      TextIndexConfig textIndexConfig = new TextIndexConfigBuilder()
+          .withLuceneAnalyzerClass("org.apache.lucene.analysis.standard.StandardAnalyzer")
+          .build();
+
+      // Create LuceneTextIndexReader using the buffer-based constructor
+      try (LuceneTextIndexReader reader = new LuceneTextIndexReader(COLUMN_NAME, indexBuffer, NUM_DOCS,
+          textIndexConfig)) {
+
+        // Test various search queries
+        testSearchQuery(reader, "Apache", "Should find documents containing 'Apache'");
+        testSearchQuery(reader, "analytics", "Should find documents containing 'analytics'");
+        testSearchQuery(reader, "distributed", "Should find documents containing 'distributed'");
+        testSearchQuery(reader, "nonexistent", "Should return empty results for non-existent terms");
+
+        // Test phrase queries
+        testSearchQuery(reader, "\"real-time analytics\"", "Should find exact phrase");
+        testSearchQuery(reader, "\"Apache Pinot\"", "Should find exact phrase");
+
+        System.out.println("All search tests passed successfully!");
+      }
+    } finally {
+      indexBuffer.close();
+    }
+  }
+
+  /**
+   * Helper method to test a search query and verify results
+   */
+  private void testSearchQuery(LuceneTextIndexReader reader, String query, String description) {
+    try {
+      System.out.println("Testing query: '" + query + "' - " + description);
+
+      ImmutableRoaringBitmap results = reader.getDocIds(query);
+      assertNotNull(results, "Search results should not be null");
+
+      int resultCount = results.getCardinality();
+      System.out.println("  Found " + resultCount + " matching documents");
+
+      if (resultCount > 0) {
+        System.out.print("  Document IDs: ");
+        results.forEach((int docId) -> System.out.print(docId + " "));
+        System.out.println();
+
+        // Print the actual document content for verification
+        results.forEach((int docId) -> {
+          if (docId < _documents.size()) {
+            System.out.println("    Doc " + docId + ": " + _documents.get(docId));
+          }
+        });
+      }
+
+      // Verify that results are within valid range
+      results.forEach((int docId) -> {
+        assertTrue(docId >= 0 && docId < NUM_DOCS,
+            "Document ID " + docId + " should be within valid range [0, " + NUM_DOCS + ")");
+      });
+    } catch (Exception e) {
+      fail("Search query '" + query + "' failed: " + e.getMessage(), e);
+    }
+  }
+}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/text/LuceneTextIndexConfigReloadTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/text/LuceneTextIndexConfigReloadTest.java
@@ -1,0 +1,289 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.text;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
+import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
+import org.apache.pinot.segment.local.segment.index.loader.invertedindex.TextIndexHandler;
+import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
+import org.apache.pinot.segment.spi.ImmutableSegment;
+import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
+import org.apache.pinot.segment.spi.creator.SegmentVersion;
+import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.segment.spi.index.FieldIndexConfigs;
+import org.apache.pinot.segment.spi.index.reader.TextIndexReader;
+import org.apache.pinot.segment.spi.loader.SegmentDirectoryLoaderContext;
+import org.apache.pinot.segment.spi.loader.SegmentDirectoryLoaderRegistry;
+import org.apache.pinot.segment.spi.store.SegmentDirectory;
+import org.apache.pinot.spi.config.table.FieldConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.data.readers.RecordReader;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.utils.ReadMode;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.roaringbitmap.buffer.MutableRoaringBitmap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+/**
+ * Tests for Lucene text index backward compatibility and upgrade scenarios.
+ * This test verifies that old format text indexes can be loaded and upgraded
+ * to the new format without losing functionality.
+ */
+public class LuceneTextIndexConfigReloadTest {
+  private static final Logger LOGGER = LoggerFactory.getLogger(LuceneTextIndexConfigReloadTest.class);
+
+  private static final String TEST_COLUMN = "testColumn";
+  private static final String[] TEST_DOCUMENTS = {
+      "java programming language", "python programming language", "scala programming language",
+      "kotlin programming " + "language", "rust programming language"
+  };
+
+  private File _tempDir;
+
+  @BeforeMethod
+  public void setUp()
+      throws IOException {
+    _tempDir = Files.createTempDirectory("lucene_text_index_test").toFile();
+  }
+
+  @AfterMethod
+  public void tearDown()
+      throws IOException {
+    if (_tempDir != null && _tempDir.exists()) {
+      FileUtils.deleteDirectory(_tempDir);
+    }
+  }
+
+  /**
+   * Creates test data for the segment
+   */
+  private List<GenericRow> createTestData() {
+    List<GenericRow> rows = new ArrayList<>();
+    for (int i = 0; i < TEST_DOCUMENTS.length; i++) {
+      GenericRow row = new GenericRow();
+      row.putValue(TEST_COLUMN, TEST_DOCUMENTS[i]);
+      row.putValue("id", i);
+      rows.add(row);
+    }
+    return rows;
+  }
+
+  /**
+   * Creates a table config with text index configuration
+   */
+  private TableConfig createTableConfigWithTextIndex(boolean useNewFormat) {
+    // Create field config for text index with custom properties
+    // For new format (combined files), set useCombineFiles=true
+    // For old format (directory structure), set useCombineFiles=false
+    Map<String, String> properties = Map.of("useCombineFiles", String.valueOf(useNewFormat));
+    FieldConfig fieldConfig =
+        new FieldConfig(TEST_COLUMN, FieldConfig.EncodingType.DICTIONARY, Arrays.asList(FieldConfig.IndexType.TEXT),
+            null, properties);
+
+    // Create table config
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable")
+        .setFieldConfigList(Arrays.asList(fieldConfig)).build();
+
+    return tableConfig;
+  }
+
+  /**
+   * Creates a schema for the test
+   */
+  private Schema createSchema() {
+    return new Schema.SchemaBuilder().setSchemaName("testSchema")
+        .addSingleValueDimension(TEST_COLUMN, FieldSpec.DataType.STRING)
+        .addSingleValueDimension("id", FieldSpec.DataType.INT).build();
+  }
+
+  @Test
+  public void testFormatUpgradeProcess()
+      throws Exception {
+    //Create segment with useCombineFiles = false and test queries
+    TableConfig oldConfig = createTableConfigWithTextIndex(false);
+    Schema schema = createSchema();
+    File segmentFile = createSegment(oldConfig, schema);
+
+    // Test queries with old config
+    testSegmentWithConfig(segmentFile, oldConfig, schema, "old config");
+
+    // Same config - should return false
+    boolean needsUpdate = checkNeedUpdateIndices(segmentFile, oldConfig, schema);
+    Assert.assertFalse(needsUpdate, "needUpdateIndices should return false when config is not changed");
+
+    //Update table config with useCombineFiles = true and create new segment
+    TableConfig newConfig = createTableConfigWithTextIndex(true);
+
+    // Different config - should return true
+    needsUpdate = checkNeedUpdateIndices(segmentFile, newConfig, schema);
+    Assert.assertTrue(needsUpdate, "needUpdateIndices should return true when useCombineFiles config is changed");
+
+    File newSegmentFile = createSegment(newConfig, schema);
+
+    // Test queries with new config
+    testSegmentWithConfig(newSegmentFile, newConfig, schema, "new config");
+    // Same config - should return false
+    needsUpdate = checkNeedUpdateIndices(newSegmentFile, newConfig, schema);
+    Assert.assertFalse(needsUpdate, "needUpdateIndices should return false when config is not changed");
+  }
+
+  /**
+   * Helper method to create a segment with given table config and schema
+   */
+  private File createSegment(TableConfig tableConfig, Schema schema)
+      throws Exception {
+    File outputDir = new File(_tempDir, "test_segment");
+    if (outputDir.exists()) {
+      FileUtils.deleteDirectory(outputDir);
+    }
+    outputDir.mkdirs();
+
+    List<GenericRow> testData = createTestData();
+
+    SegmentGeneratorConfig config = new SegmentGeneratorConfig(tableConfig, schema);
+    config.setOutDir(outputDir.getAbsolutePath());
+    config.setTableName("testTable");
+    config.setSegmentName("testSegment");
+    config.setSegmentVersion(SegmentVersion.v3);
+
+    SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+    try (RecordReader recordReader = new GenericRowRecordReader(testData)) {
+      driver.init(config, recordReader);
+      driver.build();
+    }
+
+    String segmentName = driver.getSegmentName();
+    File segmentFile = new File(outputDir, segmentName);
+    Assert.assertTrue(segmentFile.exists(), "Segment should be created");
+    return segmentFile;
+  }
+
+  /**
+   * Helper method to test a segment with given config
+   */
+  private void testSegmentWithConfig(File segmentFile, TableConfig tableConfig, Schema schema, String configName)
+      throws Exception {
+    IndexLoadingConfig indexLoadingConfig = new IndexLoadingConfig(tableConfig, schema);
+    ImmutableSegment segment = ImmutableSegmentLoader.load(segmentFile, indexLoadingConfig);
+
+    try {
+      testTextSearchQueries(segment);
+      LOGGER.info("Text search queries work correctly with {}", configName);
+    } finally {
+      segment.destroy();
+    }
+  }
+
+  /**
+   * Helper method to check if needUpdateIndices returns true for configuration changes
+   */
+  private boolean checkNeedUpdateIndices(File segmentFile, TableConfig tableConfig, Schema schema)
+      throws Exception {
+    Map<String, Object> props = new HashMap<>();
+    props.put(IndexLoadingConfig.READ_MODE_KEY, ReadMode.mmap);
+    PinotConfiguration segmentDirectoryConfigs = new PinotConfiguration(props);
+
+    SegmentDirectoryLoaderContext segmentLoaderContext =
+        new SegmentDirectoryLoaderContext.Builder().setTableConfig(tableConfig).setSchema(schema)
+            .setSegmentName(segmentFile.getName()).setSegmentDirectoryConfigs(segmentDirectoryConfigs).build();
+    SegmentDirectory segmentDirectory = SegmentDirectoryLoaderRegistry.getDefaultSegmentDirectoryLoader()
+        .load(segmentFile.toURI(), segmentLoaderContext);
+
+    // Create TextIndexHandler with the config
+    Map<String, FieldIndexConfigs> fieldIndexConfigs =
+        new IndexLoadingConfig(tableConfig, schema).getFieldIndexConfigByColName();
+    TextIndexHandler textIndexHandler = new TextIndexHandler(segmentDirectory, fieldIndexConfigs, tableConfig, schema);
+
+    // Check if needUpdateIndices detects the configuration change
+    SegmentDirectory.Reader reader = segmentDirectory.createReader();
+    boolean needsUpdate = textIndexHandler.needUpdateIndices(reader);
+    reader.close();
+    segmentDirectory.close();
+
+    LOGGER.info("needUpdateIndices returned: {} for config with useCombineFiles: {}", needsUpdate,
+        tableConfig.getFieldConfigList().get(0).getProperties().get("useCombineFiles"));
+
+    return needsUpdate;
+  }
+
+  /**
+   * Helper method to test text search queries on a segment
+   */
+  private void testTextSearchQueries(ImmutableSegment segment)
+      throws Exception {
+    // Get the text index reader
+    DataSource dataSource = segment.getDataSource(TEST_COLUMN);
+    TextIndexReader textIndexReader = dataSource.getTextIndex();
+    Assert.assertNotNull(textIndexReader, "Text index reader should be available");
+
+    // Test various search queries
+    testSearchQuery(textIndexReader, "java", "Should find documents containing 'java'");
+    testSearchQuery(textIndexReader, "python", "Should find documents containing 'python'");
+    testSearchQuery(textIndexReader, "programming", "Should find documents containing 'programming'");
+    testSearchQuery(textIndexReader, "language", "Should find documents containing 'language'");
+    testSearchQuery(textIndexReader, "nonexistent", "Should return empty results for non-existent terms");
+
+    // Test phrase queries
+    testSearchQuery(textIndexReader, "\"java programming\"", "Should find exact phrase");
+    testSearchQuery(textIndexReader, "\"python programming\"", "Should find exact phrase");
+  }
+
+  /**
+   * Helper method to test a single search query
+   */
+  private void testSearchQuery(TextIndexReader textIndexReader, String query, String description) {
+    try {
+      LOGGER.debug("Testing query: '{}' - {}", query, description);
+
+      MutableRoaringBitmap results = textIndexReader.getDocIds(query);
+      Assert.assertNotNull(results, "Search results should not be null");
+
+      int resultCount = results.getCardinality();
+      LOGGER.debug("Found {} matching documents for query: '{}'", resultCount, query);
+
+      // Verify that results are within valid range
+      results.forEach((int docId) -> {
+        Assert.assertTrue(docId >= 0 && docId < TEST_DOCUMENTS.length,
+            "Document ID " + docId + " should be within valid range [0, " + TEST_DOCUMENTS.length + ")");
+      });
+    } catch (Exception e) {
+      Assert.fail("Search query '" + query + "' failed: " + e.getMessage(), e);
+    }
+  }
+}

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/V1Constants.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/V1Constants.java
@@ -52,6 +52,7 @@ public class V1Constants {
     public static final String NULLVALUE_VECTOR_FILE_EXTENSION = ".bitmap.nullvalue";
     public static final String LUCENE_FST_INDEX_FILE_EXTENSION = ".lucene.fst";
     public static final String LUCENE_TEXT_INDEX_DOCID_MAPPING_FILE_EXTENSION = ".lucene.mapping";
+    public static final String LUCENE_COMBINE_TEXT_INDEX_FILE_EXTENSION = ".text.index";
     public static final String LUCENE_TEXT_INDEX_FILE_EXTENSION = ".lucene.index";
     public static final String LUCENE_V9_FST_INDEX_FILE_EXTENSION = ".lucene.v9.fst";
     public static final String LUCENE_V9_TEXT_INDEX_FILE_EXTENSION = ".lucene.v9.index";


### PR DESCRIPTION
This PR introduces a new configuration option to merge Lucene text index files into consolidated column file. This enhancement reduces the number of files generated during text index creation and enables the LuceneTextIndexReader to operate directly on PinotBuffer.

**Key Changes**
-  New Configuration Flag: Added useCombineFiles option in field configuration
-  File Consolidation: Lucene text index files are now merged into single column files when enabled
-  Buffer Integration: LuceneTextIndexReader now works seamlessly with PinotBuffer

**Configuration**
To enable file combination, add the following to your field configuration:
{
  "name": "your_text_column",
  "encodingType": "DICTIONARY",
  "indexTypes": ["TEXT"],
  "properties": {
    "useCombineFiles": "true"
  }
}

**Testing**

-  LuceneTextIndexCombinedTest - Tests file combination functionality
-  LuceneTextIndexBufferReaderTest - Tests buffer-based reading
-  TextSearchQueriesWithCombinedFilesTest - Integration tests with combined files

**Backward Compatibility:** 
- Changes are backward compatible. 
