### PR TITLE
Enhance audit logging: Support comma-separated header filtering with comprehensive tests

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/audit/AuditConfig.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/audit/AuditConfig.java
@@ -36,7 +36,7 @@ public final class AuditConfig {
   private boolean _captureRequestPayload = false;
 
   @JsonProperty("capture.request.headers")
-  private boolean _captureRequestHeaders = false;
+  private String _captureRequestHeaders = "";
 
   @JsonProperty("payload.size.max.bytes")
   private int _maxPayloadSize = 10_240;
@@ -60,11 +60,11 @@ public final class AuditConfig {
     _captureRequestPayload = captureRequestPayload;
   }
 
-  public boolean isCaptureRequestHeaders() {
+  public String getCaptureRequestHeaders() {
     return _captureRequestHeaders;
   }
 
-  public void setCaptureRequestHeaders(boolean captureRequestHeaders) {
+  public void setCaptureRequestHeaders(String captureRequestHeaders) {
     _captureRequestHeaders = captureRequestHeaders;
   }
 
@@ -87,7 +87,7 @@ public final class AuditConfig {
   @Override
   public String toString() {
     return "AuditConfig{" + "enabled=" + _enabled + ", captureRequestPayload=" + _captureRequestPayload
-        + ", captureRequestHeaders=" + _captureRequestHeaders + ", maxPayloadSize=" + _maxPayloadSize
+        + ", captureRequestHeaders='" + _captureRequestHeaders + "', maxPayloadSize=" + _maxPayloadSize
         + ", excludedEndpoints='" + _excludedEndpoints + "'}";
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/audit/AuditRequestProcessor.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/audit/AuditRequestProcessor.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.common.audit;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.time.Instant;
 import java.util.Collections;
 import java.util.HashMap;
@@ -210,7 +211,8 @@ public class AuditRequestProcessor {
    * @param headerList comma-separated list of header names
    * @return Set of lowercase header names, empty if headerList is blank
    */
-  private static Set<String> parseAllowedHeaders(String headerList) {
+  @VisibleForTesting
+  static Set<String> parseAllowedHeaders(String headerList) {
     if (StringUtils.isBlank(headerList)) {
       return Collections.emptySet();
     }

--- a/pinot-common/src/test/java/org/apache/pinot/common/audit/AuditConfigManagerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/audit/AuditConfigManagerTest.java
@@ -38,7 +38,7 @@ public class AuditConfigManagerTest {
     Map<String, String> properties = new HashMap<>();
     properties.put("pinot.audit.enabled", "true");
     properties.put("pinot.audit.capture.request.payload.enabled", "true");
-    properties.put("pinot.audit.capture.request.headers", "true");
+    properties.put("pinot.audit.capture.request.headers", "Content-Type,X-Request-Id,Authorization");
     properties.put("pinot.audit.payload.size.max.bytes", "20480");
     properties.put("pinot.audit.excluded.endpoints", "/health,/metrics");
     properties.put("some.other.config", "value");
@@ -53,7 +53,7 @@ public class AuditConfigManagerTest {
     AuditConfig config = manager.getCurrentConfig();
     assertThat(config.isEnabled()).isTrue();
     assertThat(config.isCaptureRequestPayload()).isTrue();
-    assertThat(config.isCaptureRequestHeaders()).isTrue();
+    assertThat(config.getCaptureRequestHeaders()).isEqualTo("Content-Type,X-Request-Id,Authorization");
     assertThat(config.getMaxPayloadSize()).isEqualTo(20480);
     assertThat(config.getExcludedEndpoints()).isEqualTo("/health,/metrics");
   }
@@ -78,7 +78,7 @@ public class AuditConfigManagerTest {
     assertThat(config.getMaxPayloadSize()).isEqualTo(5000);
     // Verify defaults for unspecified configs
     assertThat(config.isCaptureRequestPayload()).isFalse();
-    assertThat(config.isCaptureRequestHeaders()).isFalse();
+    assertThat(config.getCaptureRequestHeaders()).isEmpty();
     assertThat(config.getExcludedEndpoints()).isEmpty();
   }
 
@@ -97,7 +97,7 @@ public class AuditConfigManagerTest {
     AuditConfig config = manager.getCurrentConfig();
     assertThat(config.isEnabled()).isFalse();
     assertThat(config.isCaptureRequestPayload()).isFalse();
-    assertThat(config.isCaptureRequestHeaders()).isFalse();
+    assertThat(config.getCaptureRequestHeaders()).isEmpty();
     assertThat(config.getMaxPayloadSize()).isEqualTo(10240);
     assertThat(config.getExcludedEndpoints()).isEmpty();
   }
@@ -132,7 +132,7 @@ public class AuditConfigManagerTest {
     Map<String, String> properties = new HashMap<>();
     properties.put("pinot.audit.enabled", "true");
     properties.put("pinot.audit.capture.request.payload.enabled", "false");
-    properties.put("pinot.audit.capture.request.headers", "true");
+    properties.put("pinot.audit.capture.request.headers", "X-User-Id,X-Session-Token");
     properties.put("some.other.config", "value");
     properties.put("another.config", "123");
 
@@ -142,7 +142,7 @@ public class AuditConfigManagerTest {
     // Then
     assertThat(config.isEnabled()).isTrue();
     assertThat(config.isCaptureRequestPayload()).isFalse();
-    assertThat(config.isCaptureRequestHeaders()).isTrue();
+    assertThat(config.getCaptureRequestHeaders()).isEqualTo("X-User-Id,X-Session-Token");
     // Verify defaults for unspecified fields
     assertThat(config.getMaxPayloadSize()).isEqualTo(10240);
     assertThat(config.getExcludedEndpoints()).isEmpty();
@@ -211,7 +211,7 @@ public class AuditConfigManagerTest {
     Map<String, String> customProperties = new HashMap<>();
     customProperties.put("pinot.audit.enabled", "true");
     customProperties.put("pinot.audit.capture.request.payload.enabled", "true");
-    customProperties.put("pinot.audit.capture.request.headers", "true");
+    customProperties.put("pinot.audit.capture.request.headers", "X-Trace-Id,X-Correlation-Id");
     customProperties.put("pinot.audit.payload.size.max.bytes", "50000");
     customProperties.put("pinot.audit.excluded.endpoints", "/test,/debug");
     manager.onChange(customProperties.keySet(), customProperties);
@@ -220,7 +220,7 @@ public class AuditConfigManagerTest {
     AuditConfig customConfig = manager.getCurrentConfig();
     assertThat(customConfig.isEnabled()).isTrue();
     assertThat(customConfig.isCaptureRequestPayload()).isTrue();
-    assertThat(customConfig.isCaptureRequestHeaders()).isTrue();
+    assertThat(customConfig.getCaptureRequestHeaders()).isEqualTo("X-Trace-Id,X-Correlation-Id");
     assertThat(customConfig.getMaxPayloadSize()).isEqualTo(50000);
     assertThat(customConfig.getExcludedEndpoints()).isEqualTo("/test,/debug");
 
@@ -233,7 +233,7 @@ public class AuditConfigManagerTest {
     AuditConfig defaultConfig = manager.getCurrentConfig();
     assertThat(defaultConfig.isEnabled()).isFalse();
     assertThat(defaultConfig.isCaptureRequestPayload()).isFalse();
-    assertThat(defaultConfig.isCaptureRequestHeaders()).isFalse();
+    assertThat(defaultConfig.getCaptureRequestHeaders()).isEmpty();
     assertThat(defaultConfig.getMaxPayloadSize()).isEqualTo(10240);
     assertThat(defaultConfig.getExcludedEndpoints()).isEmpty();
   }

--- a/pinot-common/src/test/java/org/apache/pinot/common/audit/AuditConfigManagerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/audit/AuditConfigManagerTest.java
@@ -237,4 +237,29 @@ public class AuditConfigManagerTest {
     assertThat(defaultConfig.getMaxPayloadSize()).isEqualTo(10240);
     assertThat(defaultConfig.getExcludedEndpoints()).isEmpty();
   }
+
+  @Test
+  public void testConfigurationStringFormats() {
+    Map<String, String> properties = new HashMap<>();
+
+    // Test various string formats
+    properties.put("pinot.audit.capture.request.headers", "Header1,Header2,Header3");
+    AuditConfig config1 = AuditConfigManager.buildFromClusterConfig(properties);
+    assertThat(config1.getCaptureRequestHeaders()).isEqualTo("Header1,Header2,Header3");
+
+    // Test empty string
+    properties.put("pinot.audit.capture.request.headers", "");
+    AuditConfig config2 = AuditConfigManager.buildFromClusterConfig(properties);
+    assertThat(config2.getCaptureRequestHeaders()).isEmpty();
+
+    // Test single header
+    properties.put("pinot.audit.capture.request.headers", "Content-Type");
+    AuditConfig config3 = AuditConfigManager.buildFromClusterConfig(properties);
+    assertThat(config3.getCaptureRequestHeaders()).isEqualTo("Content-Type");
+
+    // Test headers with mixed case and special characters
+    properties.put("pinot.audit.capture.request.headers", "Content-Type,X-Request-ID,User-Agent,X-Custom-123");
+    AuditConfig config4 = AuditConfigManager.buildFromClusterConfig(properties);
+    assertThat(config4.getCaptureRequestHeaders()).isEqualTo("Content-Type,X-Request-ID,User-Agent,X-Custom-123");
+  }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/common/audit/AuditRequestProcessorTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/audit/AuditRequestProcessorTest.java
@@ -21,6 +21,7 @@ package org.apache.pinot.common.audit;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.MultivaluedHashMap;
 import javax.ws.rs.core.MultivaluedMap;
@@ -240,5 +241,126 @@ public class AuditRequestProcessorTest {
 
     // The main processRequest catches all exceptions and returns null, so test for that
     assertThat(result).isNull();
+  }
+
+  @Test
+  public void testParseAllowedHeadersEdgeCases() {
+    // Empty/null/whitespace
+    assertThat(AuditRequestProcessor.parseAllowedHeaders("")).isEmpty();
+    assertThat(AuditRequestProcessor.parseAllowedHeaders("   ")).isEmpty();
+    assertThat(AuditRequestProcessor.parseAllowedHeaders(null)).isEmpty();
+
+    // Single header
+    Set<String> singleHeader = AuditRequestProcessor.parseAllowedHeaders("Content-Type");
+    assertThat(singleHeader).containsExactly("content-type");
+
+    // Malformed comma separation
+    Set<String> malformed1 = AuditRequestProcessor.parseAllowedHeaders("Header1,,Header2");
+    assertThat(malformed1).containsExactlyInAnyOrder("header1", "header2");
+
+    Set<String> malformed2 = AuditRequestProcessor.parseAllowedHeaders(",Header1,Header2,");
+    assertThat(malformed2).containsExactlyInAnyOrder("header1", "header2");
+
+    // Whitespace handling
+    Set<String> withWhitespace = AuditRequestProcessor.parseAllowedHeaders(" Content-Type , X-Custom ");
+    assertThat(withWhitespace).containsExactly("content-type", "x-custom");
+  }
+
+  @Test
+  public void testHeaderFilteringCaseInsensitive() {
+    _defaultConfig.setCaptureRequestHeaders("content-type,authorization,x-custom-header");
+
+    MultivaluedMap<String, String> headers = createHeaders(
+        "Content-Type", "application/json",      // Different case
+        "AUTHORIZATION", "Bearer token",         // All caps
+        "x-custom-header", "value",              // All lower
+        "X-Ignored-Header", "ignored"            // Not in config
+    );
+
+    when(_requestContext.getUriInfo()).thenReturn(_uriInfo);
+    when(_uriInfo.getQueryParameters()).thenReturn(new MultivaluedHashMap<>());
+    when(_uriInfo.getPath()).thenReturn("/test");
+    when(_requestContext.getMethod()).thenReturn("GET");
+    when(_requestContext.getHeaders()).thenReturn(headers);
+
+    AuditEvent result = _processor.processRequest(_requestContext, "10.0.0.1");
+
+    assertThat(result).isNotNull();
+    AuditEvent.AuditRequestPayload payload = result.getRequest();
+    assertThat(payload).isNotNull();
+    Map<String, Object> capturedHeaders = payload.getHeaders();
+
+    // Should capture first 3, ignore the 4th
+    assertThat(capturedHeaders).hasSize(3);
+    assertThat(capturedHeaders).containsKeys("Content-Type", "AUTHORIZATION", "x-custom-header");
+    assertThat(capturedHeaders).doesNotContainKey("X-Ignored-Header");
+  }
+
+  @Test
+  public void testHeaderValueHandling() {
+    _defaultConfig.setCaptureRequestHeaders("single-value,multi-value,empty-value");
+
+    MultivaluedMap<String, String> headers = new MultivaluedHashMap<>();
+    headers.add("single-value", "value1");
+    headers.addAll("multi-value", Arrays.asList("val1", "val2", "val3"));
+    headers.add("empty-value", "");
+
+    when(_requestContext.getUriInfo()).thenReturn(_uriInfo);
+    when(_uriInfo.getQueryParameters()).thenReturn(new MultivaluedHashMap<>());
+    when(_uriInfo.getPath()).thenReturn("/test");
+    when(_requestContext.getMethod()).thenReturn("GET");
+    when(_requestContext.getHeaders()).thenReturn(headers);
+
+    AuditEvent result = _processor.processRequest(_requestContext, "10.0.0.1");
+
+    assertThat(result).isNotNull();
+    AuditEvent.AuditRequestPayload payload = result.getRequest();
+    assertThat(payload).isNotNull();
+    Map<String, Object> capturedHeaders = payload.getHeaders();
+
+    // Single value stored as String
+    assertThat(capturedHeaders.get("single-value")).isEqualTo("value1");
+
+    // Multiple values stored as List
+    @SuppressWarnings("unchecked")
+    List<String> multiValues = (List<String>) capturedHeaders.get("multi-value");
+    assertThat(multiValues).containsExactly("val1", "val2", "val3");
+
+    // Empty value still captured
+    assertThat(capturedHeaders.get("empty-value")).isEqualTo("");
+  }
+
+  @Test
+  public void testCompleteHeaderCaptureFlow() {
+    // Configure specific headers
+    _defaultConfig.setCaptureRequestHeaders("Content-Type,X-Request-ID,User-Agent");
+
+    // Create request with mixed case headers + extras
+    MultivaluedMap<String, String> headers = createHeaders(
+        "content-type", "application/json",
+        "X-REQUEST-ID", "req-123",
+        "user-agent", "test-client",
+        "Cookie", "session=abc",           // Should be ignored
+        "Accept", "application/json"       // Should be ignored
+    );
+
+    when(_requestContext.getUriInfo()).thenReturn(_uriInfo);
+    when(_uriInfo.getQueryParameters()).thenReturn(new MultivaluedHashMap<>());
+    when(_uriInfo.getPath()).thenReturn("/test");
+    when(_requestContext.getMethod()).thenReturn("GET");
+    when(_requestContext.getHeaders()).thenReturn(headers);
+
+    AuditEvent result = _processor.processRequest(_requestContext, "10.0.0.1");
+
+    assertThat(result).isNotNull();
+    AuditEvent.AuditRequestPayload payload = result.getRequest();
+    assertThat(payload).isNotNull();
+    Map<String, Object> capturedHeaders = payload.getHeaders();
+
+    assertThat(capturedHeaders).hasSize(3);
+    assertThat(capturedHeaders).containsOnlyKeys("content-type", "X-REQUEST-ID", "user-agent");
+    assertThat(capturedHeaders).containsEntry("content-type", "application/json");
+    assertThat(capturedHeaders).containsEntry("X-REQUEST-ID", "req-123");
+    assertThat(capturedHeaders).containsEntry("user-agent", "test-client");
   }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/common/audit/AuditRequestProcessorTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/audit/AuditRequestProcessorTest.java
@@ -68,7 +68,7 @@ public class AuditRequestProcessorTest {
     _defaultConfig = new AuditConfig();
     _defaultConfig.setEnabled(true);
     _defaultConfig.setCaptureRequestPayload(false);
-    _defaultConfig.setCaptureRequestHeaders(false);
+    _defaultConfig.setCaptureRequestHeaders("");
     _defaultConfig.setMaxPayloadSize(10240);
     _defaultConfig.setExcludedEndpoints("");
 
@@ -139,7 +139,7 @@ public class AuditRequestProcessorTest {
 
   @Test
   public void testCaptureHeadersWhenEnabled() {
-    _defaultConfig.setCaptureRequestHeaders(true);
+    _defaultConfig.setCaptureRequestHeaders("Content-Type,X-Custom-Header,Authorization,X-Password");
     MultivaluedMap<String, String> headers =
         createHeaders("Content-Type", "application/json", "X-Custom-Header", "custom-value", "Authorization",
             "Bearer token123",  // Should be filtered out
@@ -167,7 +167,7 @@ public class AuditRequestProcessorTest {
 
   @Test
   public void testSkipHeadersWhenDisabled() {
-    _defaultConfig.setCaptureRequestHeaders(false);
+    _defaultConfig.setCaptureRequestHeaders("");
     MultivaluedMap<String, String> headers = createHeaders("Content-Type", "application/json");
 
     when(_requestContext.getUriInfo()).thenReturn(_uriInfo);
@@ -187,7 +187,8 @@ public class AuditRequestProcessorTest {
 
   @Test
   public void testFilterSensitiveHeaders() {
-    _defaultConfig.setCaptureRequestHeaders(true);
+    _defaultConfig.setCaptureRequestHeaders(
+        "authorization,x-auth-token,password-header,api-secret,x-api-key,content-type");
     MultivaluedMap<String, String> headers =
         createHeaders("authorization", "Bearer token123", "x-auth-token", "token456", "password-header", "pass123",
             "api-secret", "secret789", "x-api-key", "key123",


### PR DESCRIPTION
## Summary
- Transform captureRequestHeaders configuration from boolean to comma-separated list of specific headers to capture
- Implement case-insensitive header matching per HTTP RFC 7230
- Add comprehensive test coverage for edge cases and various string formats
- Refactor header filtering logic to reuse existing toMap function with allow list parameter

## Changes
- **AuditConfig**: Change `_captureRequestHeaders` from `boolean` to `String`
- **AuditRequestProcessor**: Add `parseAllowedHeaders()` utility and enhance `toMap()` with filtering
- **Tests**: Add comprehensive test coverage for configuration parsing, case sensitivity, value handling, and end-to-end flow

## Test Coverage
- Configuration parsing edge cases (empty, whitespace, malformed comma separation)
- Case-insensitive HTTP header matching
- Single vs multiple header values handling
- Complete request processing integration tests

## Breaking Changes
None - this is an unlaunched feature in active development.