### PR TITLE
[Query Resource Isolation] Reduce logging in QueryAggregator

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/accounting/QueryAggregator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/accounting/QueryAggregator.java
@@ -454,7 +454,7 @@ public class QueryAggregator implements ResourceAggregator {
   }
 
   protected void logQueryResourceUsage(Map<String, ? extends QueryResourceTracker> aggregatedUsagePerActiveQuery) {
-    LOGGER.warn("Query aggregation results {} for the previous kill.", aggregatedUsagePerActiveQuery);
+    LOGGER.debug("Query aggregation results {} for the previous kill.", aggregatedUsagePerActiveQuery);
   }
 
   protected void logTerminatedQuery(QueryResourceTracker queryResourceTracker, long totalHeapMemoryUsage) {


### PR DESCRIPTION
## Summary 
Reduce logging in QueryAggregator by changing the log level from warn -> info to match the same in `PerCPUMemAccountant`

## Testing Done
Just log level change