### PR TITLE
Handle null values gracefully in SSE's post aggregation functions

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/postaggregation/PostAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/postaggregation/PostAggregationFunction.java
@@ -89,15 +89,7 @@ public class PostAggregationFunction {
     if (_functionInvoker.getMethod().isVarArgs()) {
       result = _functionInvoker.invoke(new Object[]{arguments});
     } else {
-      int numArguments = arguments.length;
-      PinotDataType[] parameterTypes = _functionInvoker.getParameterTypes();
-      for (int i = 0; i < numArguments; i++) {
-        PinotDataType parameterType = parameterTypes[i];
-        PinotDataType argumentType = _argumentTypes[i];
-        if (parameterType != argumentType) {
-          arguments[i] = parameterType.convert(arguments[i], argumentType);
-        }
-      }
+      _functionInvoker.convertTypes(arguments);
       result = _functionInvoker.invoke(arguments);
     }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/postaggregation/PostAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/postaggregation/PostAggregationFunctionTest.java
@@ -128,5 +128,10 @@ public class PostAggregationFunctionTest {
     assertEquals(function.getResultType(), ColumnDataType.OBJECT);
     assertNull(function.invoke(new Object[]{null, null, null, null, null, null, null, null, null, null}));
     assertEquals(function.invoke(new Object[]{null, null, null, null, null, null, null, null, null, 10}), 10);
+
+    // Test null handling
+    function = new PostAggregationFunction("plus", new ColumnDataType[]{ColumnDataType.INT, ColumnDataType.INT});
+    // The function returns null if any argument is null
+    assertNull(function.invoke(new Object[]{null, 1}));
   }
 }


### PR DESCRIPTION
- A query like:
```
select AirlineID,
  datetimeconvert(
    min(
      CASE
        WHEN Year = 2014 THEN NULL
        ELSE ts
      END
    ),
    '1:MILLISECONDS:EPOCH',
    '1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSS tz(Asia/Seoul)',
    '1:MILLISECONDS'
  ) as "taskStartTs"
from airlinestats
group by AirlineID
limit 1000
```
results in the following error currently:
```
java.lang.NullPointerException: Cannot invoke "Object.toString()" because "value" is null
	at org.apache.pinot.common.utils.PinotDataType$8.toString(PinotDataType.java:469)
	at org.apache.pinot.common.utils.PinotDataType$11.convert(PinotDataType.java:653)
	at org.apache.pinot.common.utils.PinotDataType$11.convert(PinotDataType.java:603)
	at org.apache.pinot.core.query.postaggregation.PostAggregationFunction.invoke(PostAggregationFunction.java:98)
	at org.apache.pinot.core.query.reduce.PostAggregationHandler$PostAggregationValueExtractor.extract(PostAggregationHandler.java:183)
	at org.apache.pinot.core.query.reduce.PostAggregationHandler.getResult(PostAggregationHandler.java:99)
	at org.apache.pinot.core.query.reduce.GroupByDataTableReducer.calculateFinalResultRows(GroupByDataTableReducer.java:460)
	at org.apache.pinot.core.query.reduce.GroupByDataTableReducer.reduceResult(GroupByDataTableReducer.java:213)
```

```
2025/08/29 13:41:49.338 ERROR [WebApplicationExceptionMapper] [grizzly-http-server-14] Server error: 
java.io.IOException: HTTP error code: 500. Root Cause: Cannot invoke "Object.toString()" because "value" is null
	at org.apache.pinot.controller.api.resources.PinotQueryResource.sendRequestRaw(PinotQueryResource.java:506)
	at org.apache.pinot.controller.api.resources.PinotQueryResource.lambda$sendRequestRaw$2(PinotQueryResource.java:524)
	at org.glassfish.jersey.message.internal.StreamingOutputProvider.writeTo(StreamingOutputProvider.java:55)
```
- The reason is that the single-stage engine's `PostAggregationFunction` doesn't handle null values appropriately during type conversion. This logic already exists in `FunctionInvoker` which can be used directly.