### PR TITLE
[Auto reset 3/3]Add backfill manager and handler interfaces

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerMeter.java
@@ -75,7 +75,9 @@ public enum ControllerMeter implements AbstractMetrics.Meter {
   // Total Bytes written to deep store
   DEEP_STORE_WRITE_BYTES_COMPLETED("deepStoreWriteBytesCompleted", true),
   // Tracks failures encountered while fetching partition group metadata
-  PARTITION_GROUP_METADATA_FETCH_ERROR("failures", true);
+  PARTITION_GROUP_METADATA_FETCH_ERROR("failures", true),
+  OFFSET_AUTO_RESET_SKIPPED_OFFSETS("autoResetSkippedOffsets", false),
+  OFFSET_AUTO_RESET_BACKFILL_OFFSETS("autoResetBackfillOffsets", false);
 
   private final String _brokerMeterName;
   private final String _unit;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
@@ -120,6 +120,7 @@ import org.apache.pinot.controller.util.TableSizeReader;
 import org.apache.pinot.controller.validation.BrokerResourceValidationManager;
 import org.apache.pinot.controller.validation.DiskUtilizationChecker;
 import org.apache.pinot.controller.validation.OfflineSegmentIntervalChecker;
+import org.apache.pinot.controller.validation.RealtimeOffsetAutoResetManager;
 import org.apache.pinot.controller.validation.RealtimeSegmentValidationManager;
 import org.apache.pinot.controller.validation.ResourceUtilizationChecker;
 import org.apache.pinot.controller.validation.ResourceUtilizationManager;
@@ -191,6 +192,7 @@ public abstract class BaseControllerStarter implements ServiceStartable {
   protected SqlQueryExecutor _sqlQueryExecutor;
   // Can only be constructed after resource manager getting started
   protected OfflineSegmentIntervalChecker _offlineSegmentIntervalChecker;
+  protected RealtimeOffsetAutoResetManager _realtimeOffsetAutoResetManager;
   protected RealtimeSegmentValidationManager _realtimeSegmentValidationManager;
   protected BrokerResourceValidationManager _brokerResourceValidationManager;
   protected SegmentRelocator _segmentRelocator;
@@ -382,6 +384,10 @@ public abstract class BaseControllerStarter implements ServiceStartable {
 
   public OfflineSegmentIntervalChecker getOfflineSegmentIntervalChecker() {
     return _offlineSegmentIntervalChecker;
+  }
+
+  public RealtimeOffsetAutoResetManager getRealtimeOffsetAutoResetManager() {
+    return _realtimeOffsetAutoResetManager;
   }
 
   public RealtimeSegmentValidationManager getRealtimeSegmentValidationManager() {
@@ -884,6 +890,7 @@ public abstract class BaseControllerStarter implements ServiceStartable {
     _taskManager = createTaskManager();
     _taskManager.init();
     periodicTasks.add(_taskManager);
+    initRealtimeOffsetAutoResetManager(periodicTasks);
     BrokerServiceHelper brokerServiceHelper =
         new BrokerServiceHelper(_helixResourceManager, _config, _executorService, _connectionManager);
     _retentionManager = new RetentionManager(_helixResourceManager, _leadControllerManager, _config, _controllerMetrics,
@@ -935,6 +942,17 @@ public abstract class BaseControllerStarter implements ServiceStartable {
     periodicTasks.add(tenantRebalanceChecker);
 
     return periodicTasks;
+  }
+
+  private void initRealtimeOffsetAutoResetManager(List<PeriodicTask> periodicTasks) {
+    if (!_config.isRealtimeOffsetAutoResetBackfillEnabled()) {
+      LOGGER.info("Realtime offset auto reset is disabled, skipping initialization");
+      return;
+    }
+    _realtimeOffsetAutoResetManager =
+        new RealtimeOffsetAutoResetManager(_config, _helixResourceManager, _leadControllerManager,
+            _pinotLLCRealtimeSegmentManager, _controllerMetrics);
+    periodicTasks.add(_realtimeOffsetAutoResetManager);
   }
 
   /**

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -117,6 +117,12 @@ public class ControllerConf extends PinotConfiguration {
         "controller.realtime.segment.validation.frequencyPeriod";
     public static final String REALTIME_SEGMENT_VALIDATION_INITIAL_DELAY_IN_SECONDS =
         "controller.realtime.segment.validation.initialDelayInSeconds";
+    public static final String REALTIME_OFFSET_AUTO_RESET_BACKFILL_ENABLED =
+        "controller.realtime.offsetAutoReset.backfill.enabled";
+    public static final String REALTIME_OFFSET_AUTO_RESET_BACKFILL_FREQUENCY_PERIOD =
+        "controller.realtime.offsetAutoReset.backfill.frequencyPeriod";
+    public static final String REALTIME_OFFSET_AUTO_RESET_BACKFILL_INITIAL_DELAY_IN_SECONDS =
+        "controller.realtime.offsetAutoReset.backfill.initialDelayInSeconds";
     // Deprecated as of 0.8.0
     @Deprecated
     public static final String DEPRECATED_BROKER_RESOURCE_VALIDATION_FREQUENCY_IN_SECONDS =
@@ -279,6 +285,7 @@ public class ControllerConf extends PinotConfiguration {
     public static final int DEFAULT_RETENTION_MANAGER_FREQUENCY_IN_SECONDS = 6 * 60 * 60; // 6 Hours.
     public static final int DEFAULT_OFFLINE_SEGMENT_INTERVAL_CHECKER_FREQUENCY_IN_SECONDS = 24 * 60 * 60; // 24 Hours.
     public static final int DEFAULT_REALTIME_SEGMENT_VALIDATION_FREQUENCY_IN_SECONDS = 60 * 60; // 1 Hour.
+    public static final int DEFAULT_REALTIME_OFFSET_AUTO_RESET_BACKFILL_FREQUENCY_IN_SECONDS = 60 * 60; // 1 Hour.
     public static final int DEFAULT_BROKER_RESOURCE_VALIDATION_FREQUENCY_IN_SECONDS = 60 * 60; // 1 Hour.
     public static final int DEFAULT_STATUS_CHECKER_FREQUENCY_IN_SECONDS = 5 * 60; // 5 minutes
     public static final int DEFAULT_REBALANCE_CHECKER_FREQUENCY_IN_SECONDS = 5 * 60; // 5 minutes
@@ -680,6 +687,20 @@ public class ControllerConf extends PinotConfiguration {
   public void setRealtimeSegmentValidationFrequencyInSeconds(int validationFrequencyInSeconds) {
     setProperty(ControllerPeriodicTasksConf.DEPRECATED_REALTIME_SEGMENT_VALIDATION_FREQUENCY_IN_SECONDS,
         Integer.toString(validationFrequencyInSeconds));
+  }
+
+  public boolean isRealtimeOffsetAutoResetBackfillEnabled() {
+    return getProperty(ControllerPeriodicTasksConf.REALTIME_OFFSET_AUTO_RESET_BACKFILL_ENABLED, false);
+  }
+
+  public int getRealtimeOffsetAutoResetBackfillFrequencyInSeconds() {
+    return getProperty(ControllerPeriodicTasksConf.REALTIME_OFFSET_AUTO_RESET_BACKFILL_FREQUENCY_PERIOD,
+        ControllerPeriodicTasksConf.DEFAULT_REALTIME_OFFSET_AUTO_RESET_BACKFILL_FREQUENCY_IN_SECONDS);
+  }
+
+  public void setRealtimeOffsetAutoResetBackfillFrequencyInSeconds(int offsetAutoResetBackfillFrequencyInSeconds) {
+    setProperty(ControllerPeriodicTasksConf.REALTIME_OFFSET_AUTO_RESET_BACKFILL_FREQUENCY_PERIOD,
+        Integer.toString(offsetAutoResetBackfillFrequencyInSeconds));
   }
 
   /**
@@ -1171,6 +1192,11 @@ public class ControllerConf extends PinotConfiguration {
 
   public long getRealtimeSegmentValidationManagerInitialDelaySeconds() {
     return getProperty(ControllerPeriodicTasksConf.REALTIME_SEGMENT_VALIDATION_INITIAL_DELAY_IN_SECONDS,
+        getPeriodicTaskInitialDelayInSeconds());
+  }
+
+  public long getRealtimeOffsetAutoResetBackfillInitialDelaySeconds() {
+    return getProperty(ControllerPeriodicTasksConf.REALTIME_OFFSET_AUTO_RESET_BACKFILL_INITIAL_DELAY_IN_SECONDS,
         getPeriodicTaskInitialDelayInSeconds());
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/Constants.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/Constants.java
@@ -54,8 +54,13 @@ public class Constants {
   public static final String PERIODIC_TASK_TAG = "PeriodicTask";
   public static final String UPSERT_RESOURCE_TAG = "Upsert";
   public static final String QUERY_WORKLOAD_TAG = "QueryWorkload";
+  public static final String RESET_OFFSET_FROM = "ResetOffsetFrom";
+  public static final String RESET_OFFSET_TO = "ResetOffsetTo";
+  public static final String RESET_OFFSET_TOPIC_NAME = "ResetOffsetTopicName";
+  public static final String RESET_OFFSET_TOPIC_PARTITION = "ResetOffsetTopicPartition";
 
   public static final String REALTIME_SEGMENT_VALIDATION_MANAGER = "RealtimeSegmentValidationManager";
+  public static final String REALTIME_OFFSET_AUTO_RESET_MANAGER = "RealtimeOffsetAutoResetManager";
 
   public static TableType validateTableType(String tableTypeStr) {
     if (StringUtils.isBlank(tableTypeStr)) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/periodictask/RealtimeOffsetAutoResetHandler.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/periodictask/RealtimeOffsetAutoResetHandler.java
@@ -1,0 +1,58 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core.periodictask;
+
+import java.util.Collection;
+import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
+import org.apache.pinot.controller.helix.core.realtime.PinotLLCRealtimeSegmentManager;
+import org.apache.pinot.spi.stream.StreamConfig;
+
+
+public interface RealtimeOffsetAutoResetHandler {
+
+  /**
+   * Initialize the handler with the PinotLLCRealtimeSegmentManager and PinotHelixResourceManager.
+   * This is called once in constructor.
+   */
+  public abstract void init(
+      PinotLLCRealtimeSegmentManager llcRealtimeSegmentManager, PinotHelixResourceManager pinotHelixResourceManager);
+
+  /**
+   * Trigger the job to backfill the skipped interval due to offset auto reset.
+   * It is expected to backfill the [fromOffset, toOffset) interval.
+   * @return if successfully started the backfill job
+   */
+  public abstract boolean triggerBackfillJob(
+      String tableNameWithType, StreamConfig streamConfig, String topicName, int partitionId, long fromOffset,
+      long toOffset);
+
+  /**
+   * Ensure all topics under the table are being backfilled. It is the caller's responsibility to figure out what
+   * topic set it should check.
+   */
+  public abstract void ensureBackfillJobsRunning(String tableNameWithType, Collection<String> topicNames);
+
+  /**
+   * Return the Collection of completed and cleaned up topicNames from the input.
+   */
+  public abstract Collection<String> cleanupCompletedBackfillJobs(
+      String tableNameWithType, Collection<String> topicNames);
+
+  public abstract void close();
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/periodictask/RealtimeOffsetAutoResetKafkaHandler.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/periodictask/RealtimeOffsetAutoResetKafkaHandler.java
@@ -1,0 +1,184 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core.periodictask;
+
+import com.google.common.base.Preconditions;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
+import org.apache.pinot.controller.helix.core.realtime.PinotLLCRealtimeSegmentManager;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.stream.OffsetCriteria;
+import org.apache.pinot.spi.stream.StreamConfig;
+import org.apache.pinot.spi.stream.StreamConfigProperties;
+import org.apache.pinot.spi.utils.IngestionConfigUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Base class for handling offset auto reset with multi-topic ingestion.
+ * The handler would request Kafka Ecosystem APIs to replicate the skipped offsets and
+ * add the new topic to the table config for backfilling.
+ * After the backfill job is complete, it would remove the topic from the table config.
+ */
+public abstract class RealtimeOffsetAutoResetKafkaHandler implements RealtimeOffsetAutoResetHandler {
+
+  protected PinotLLCRealtimeSegmentManager _llcRealtimeSegmentManager;
+  protected PinotHelixResourceManager _pinotHelixResourceManager;
+  private Map<String, Integer> _topicNameToIndexMap;
+  private static final Logger LOGGER = LoggerFactory.getLogger(RealtimeOffsetAutoResetKafkaHandler.class);
+  private static final String STREAM_TYPE = "kafka";
+
+  public RealtimeOffsetAutoResetKafkaHandler(PinotLLCRealtimeSegmentManager llcRealtimeSegmentManager,
+      PinotHelixResourceManager pinotHelixResourceManager) {
+    init(llcRealtimeSegmentManager, pinotHelixResourceManager);
+  }
+
+  @Override
+  public void init(PinotLLCRealtimeSegmentManager llcRealtimeSegmentManager,
+      PinotHelixResourceManager pinotHelixResourceManager) {
+    _llcRealtimeSegmentManager = llcRealtimeSegmentManager;
+    _pinotHelixResourceManager = pinotHelixResourceManager;
+    _topicNameToIndexMap = new HashMap<>();
+  }
+
+  /**
+   * Trigger the job to backfill the skipped interval due to offset auto reset.
+   * It is expected to backfill the [fromOffset, toOffset) interval.
+   * @return true if successfully started the backfill job and its ingestion
+   */
+  @Override
+  public boolean triggerBackfillJob(
+      String tableNameWithType, StreamConfig streamConfig, String topicName, int partitionId, long fromOffset,
+      long toOffset) {
+    // Trigger the data replication and get the new topic's stream config.
+    Map<String, String> newTopicStreamConfig = triggerDataReplicationAndGetTopicInfo(
+        tableNameWithType, streamConfig, topicName, partitionId, fromOffset, toOffset);
+    if (newTopicStreamConfig == null) {
+      return false;
+    }
+    try {
+      // Add the new topic to the table config.
+      TableConfig currentTableConfig = _pinotHelixResourceManager.getTableConfig(tableNameWithType);
+      if (getOrAddBackfillTopic(newTopicStreamConfig, currentTableConfig)) {
+        _pinotHelixResourceManager.setExistingTableConfig(currentTableConfig);
+      }
+    } catch (IOException e) {
+      LOGGER.error("Cannot add backfill topic to the table config", e);
+      return false;
+    }
+    return true;
+  }
+
+  /**
+   * Override this method to trigger Kafka Ecosystem APIs and replicate skipped offsets to the new topic.
+   * Then refer to the lagged topic's StreamConfig and return the new topic's stream config map.
+   */
+  protected abstract Map<String, String> triggerDataReplicationAndGetTopicInfo(
+      String tableNameWithType, StreamConfig streamConfig, String topicName, int partitionId, long fromOffset,
+      long toOffset);
+
+  public abstract void ensureBackfillJobsRunning(String tableNameWithType, List<String> topicNames);
+
+  /**
+   * Cleanup completed backfill jobs by checking if the topic is complete.
+   * If it is complete, pause the topic consumption.
+   *
+   * @param tableNameWithType The name of the table with type
+   * @param topicNames The collection of topic names to check for completion
+   * @return Collection of cleaned up topic names
+   */
+  public Collection<String> cleanupCompletedBackfillJobs(String tableNameWithType, Collection<String> topicNames) {
+    Collection<String> cleanedUpTopics = new ArrayList<>();
+    for (String topicName : topicNames) {
+      if (isTopicBackfillJobComplete(tableNameWithType, topicName)) {
+        cleanedUpTopics.add(topicName);
+      }
+    }
+    if (cleanedUpTopics.isEmpty()) {
+      return cleanedUpTopics;
+    }
+    TableConfig currentTableConfig = _pinotHelixResourceManager.getTableConfig(tableNameWithType);
+    updateTopicIndexMap(IngestionConfigUtils.getStreamConfigMaps(currentTableConfig));
+    _llcRealtimeSegmentManager.pauseTopicsConsumption(currentTableConfig.getTableName(),
+        cleanedUpTopics.stream().map(_topicNameToIndexMap::get).collect(Collectors.toList()));
+    try {
+      _pinotHelixResourceManager.setExistingTableConfig(currentTableConfig);
+    } catch (IOException e) {
+      LOGGER.error("Cannot remove backfill topics {} from the table config", topicNames, e);
+      cleanedUpTopics.clear();
+    }
+    return cleanedUpTopics;
+  }
+
+  public abstract boolean isTopicBackfillJobComplete(String tableNameWithType, String topicName);
+
+  /**
+   * "Add the new topic to the table config" OR "resume the topic consumption if already added" for backfilling.
+   * @param streamConfig the new topic's stream config map
+   * @param tableConfig the table config to update
+   * @return true if the topic is newly added, false if the topic is already added and resumed
+   */
+  private boolean getOrAddBackfillTopic(Map<String, String> streamConfig, TableConfig tableConfig) {
+    List<Map<String, String>> streamConfigs = IngestionConfigUtils.getStreamConfigMaps(tableConfig);
+    String topicNameKey = StreamConfigProperties.constructStreamProperty(
+        STREAM_TYPE, StreamConfigProperties.STREAM_TOPIC_NAME);
+    String topicName = streamConfig.get(topicNameKey);
+    Preconditions.checkNotNull(topicName);
+    updateTopicIndexMap(streamConfigs);
+    if (_topicNameToIndexMap.containsKey(topicName)) {
+      if (_llcRealtimeSegmentManager.isTopicConsumptionPaused(
+          tableConfig.getTableName(), _topicNameToIndexMap.get(topicName))) {
+        LOGGER.info("Resuming topic {} consumption for table {}", topicName, tableConfig.getTableName());
+        _llcRealtimeSegmentManager.resumeTopicsConsumption(
+            tableConfig.getTableName(), Arrays.asList(_topicNameToIndexMap.get(topicName)));
+      }
+      return false;
+    }
+    streamConfig.put(StreamConfigProperties.BACKFILL_TOPIC, String.valueOf(true));
+    streamConfig.put(
+        StreamConfigProperties.constructStreamProperty(
+            STREAM_TYPE, StreamConfigProperties.STREAM_CONSUMER_OFFSET_CRITERIA),
+        OffsetCriteria.SMALLEST_OFFSET_CRITERIA.getOffsetString());
+    IngestionConfigUtils.getStreamConfigMaps(tableConfig).add(streamConfig);
+    return true;
+  }
+
+  private void updateTopicIndexMap(List<Map<String, String>> streamConfigs) {
+    if (streamConfigs.size() == _topicNameToIndexMap.size()) {
+      return;
+    }
+    _topicNameToIndexMap.clear();
+    for (int i = 0; i < streamConfigs.size(); i++) {
+      String topicName = streamConfigs.get(i).get(
+          StreamConfigProperties.constructStreamProperty(
+              STREAM_TYPE, StreamConfigProperties.STREAM_TOPIC_NAME));
+      if (topicName != null) {
+        _topicNameToIndexMap.put(topicName, i);
+      }
+    }
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/periodictask/RealtimeOffsetAutoResetKafkaHandler.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/periodictask/RealtimeOffsetAutoResetKafkaHandler.java
@@ -30,7 +30,6 @@ import java.util.stream.Collectors;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.helix.core.realtime.PinotLLCRealtimeSegmentManager;
 import org.apache.pinot.spi.config.table.TableConfig;
-import org.apache.pinot.spi.stream.OffsetCriteria;
 import org.apache.pinot.spi.stream.StreamConfig;
 import org.apache.pinot.spi.stream.StreamConfigProperties;
 import org.apache.pinot.spi.utils.IngestionConfigUtils;
@@ -159,10 +158,6 @@ public abstract class RealtimeOffsetAutoResetKafkaHandler implements RealtimeOff
       return false;
     }
     streamConfig.put(StreamConfigProperties.BACKFILL_TOPIC, String.valueOf(true));
-    streamConfig.put(
-        StreamConfigProperties.constructStreamProperty(
-            STREAM_TYPE, StreamConfigProperties.STREAM_CONSUMER_OFFSET_CRITERIA),
-        OffsetCriteria.SMALLEST_OFFSET_CRITERIA.getOffsetString());
     IngestionConfigUtils.getStreamConfigMaps(tableConfig).add(streamConfig);
     return true;
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/periodictask/RealtimeOffsetAutoResetKafkaHandler.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/periodictask/RealtimeOffsetAutoResetKafkaHandler.java
@@ -124,12 +124,6 @@ public abstract class RealtimeOffsetAutoResetKafkaHandler implements RealtimeOff
     updateTopicIndexMap(IngestionConfigUtils.getStreamConfigMaps(currentTableConfig));
     _llcRealtimeSegmentManager.pauseTopicsConsumption(currentTableConfig.getTableName(),
         cleanedUpTopics.stream().map(_topicNameToIndexMap::get).collect(Collectors.toList()));
-    try {
-      _pinotHelixResourceManager.setExistingTableConfig(currentTableConfig);
-    } catch (IOException e) {
-      LOGGER.error("Cannot remove backfill topics {} from the table config", topicNames, e);
-      cleanedUpTopics.clear();
-    }
     return cleanedUpTopics;
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -1017,7 +1017,7 @@ public class PinotLLCRealtimeSegmentManager {
       return nextOffset;
     }
     try {
-      if (timeThreshold > 0 && offsetAtSLA != null && offsetAtSLA.compareTo(nextOffsetWithType) < 0) {
+      if (timeThreshold > 0 && offsetAtSLA != null && offsetAtSLA.compareTo(nextOffsetWithType) > 0) {
         LOGGER.info("Auto reset offset from {} to {} on partition {} because time threshold reached", nextOffset,
             latestOffset, partitionId);
         return latestOffset.toString();

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -935,6 +935,8 @@ public class PinotLLCRealtimeSegmentManager {
     String nextOffset = committingSegmentDescriptor.getNextOffset();
     String startOffset = computeStartOffset(nextOffset, streamConfig, newLLCSegmentName.getPartitionGroupId());
     if (!startOffset.equals(nextOffset)) {
+      _controllerMetrics.addMeteredTableValue(realtimeTableName, ControllerMeter.OFFSET_AUTO_RESET_SKIPPED_OFFSETS,
+          Long.parseLong(startOffset) - Long.parseLong(nextOffset));
       Map<String, String> taskProperties = new HashMap<>();
       taskProperties.put(Constants.RESET_OFFSET_FROM, nextOffset);
       taskProperties.put(Constants.RESET_OFFSET_TO, startOffset);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeOffsetAutoResetManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeOffsetAutoResetManager.java
@@ -1,0 +1,249 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.validation;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.pinot.common.metrics.ControllerMetrics;
+import org.apache.pinot.controller.ControllerConf;
+import org.apache.pinot.controller.LeadControllerManager;
+import org.apache.pinot.controller.api.resources.Constants;
+import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
+import org.apache.pinot.controller.helix.core.periodictask.ControllerPeriodicTask;
+import org.apache.pinot.controller.helix.core.periodictask.RealtimeOffsetAutoResetHandler;
+import org.apache.pinot.controller.helix.core.realtime.PinotLLCRealtimeSegmentManager;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.stream.StreamConfig;
+import org.apache.pinot.spi.utils.IngestionConfigUtils;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class RealtimeOffsetAutoResetManager extends ControllerPeriodicTask<RealtimeOffsetAutoResetManager.Context> {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(RealtimeOffsetAutoResetManager.class);
+  private final PinotLLCRealtimeSegmentManager _llcRealtimeSegmentManager;
+  private final PinotHelixResourceManager _pinotHelixResourceManager;
+  private final Map<String, RealtimeOffsetAutoResetHandler> _tableToHandler;
+  private final Map<String, Set<String>> _tableTopicsUnderBackfill;
+  private final Map<String, Set<String>> _tableBackfillTopics;
+
+  public RealtimeOffsetAutoResetManager(ControllerConf config, PinotHelixResourceManager pinotHelixResourceManager,
+      LeadControllerManager leadControllerManager, PinotLLCRealtimeSegmentManager llcRealtimeSegmentManager,
+      ControllerMetrics controllerMetrics) {
+    super("RealtimeOffsetAutoResetManager", config.getRealtimeOffsetAutoResetBackfillFrequencyInSeconds(),
+        config.getRealtimeOffsetAutoResetBackfillInitialDelaySeconds(), pinotHelixResourceManager,
+        leadControllerManager, controllerMetrics);
+    _llcRealtimeSegmentManager = llcRealtimeSegmentManager;
+    _pinotHelixResourceManager = pinotHelixResourceManager;
+    _tableToHandler = new ConcurrentHashMap<>();
+    _tableTopicsUnderBackfill = new ConcurrentHashMap<>();
+    _tableBackfillTopics = new ConcurrentHashMap<>();
+  }
+
+  @Override
+  protected RealtimeOffsetAutoResetManager.Context preprocess(Properties periodicTaskProperties) {
+    RealtimeOffsetAutoResetManager.Context context = new RealtimeOffsetAutoResetManager.Context();
+    // Fill offset backfill job required info
+    // Examples of properties:
+    //   resetOffsetTopicName=topicName
+    //   resetOffsetTopicPartition=0
+    //   resetOffsetFrom=0
+    //   resetOffsetTo=1000
+    if (periodicTaskProperties.keySet().containsAll(context._backfillJobPropertyKeys)) {
+      context._shouldTriggerBackfillJobs = true;
+      for (String key : context._backfillJobPropertyKeys) {
+        context._backfillJobProperties.put(key, periodicTaskProperties.getProperty(key));
+      }
+    }
+    return context;
+  }
+
+  @VisibleForTesting
+  protected RealtimeOffsetAutoResetHandler getTableHandler(String tableNameWithType) {
+    return _tableToHandler.get(tableNameWithType);
+  }
+
+  @Override
+  protected void processTable(String tableNameWithType, RealtimeOffsetAutoResetManager.Context context) {
+    if (!TableNameBuilder.isRealtimeTableResource(tableNameWithType)) {
+      return;
+    }
+    LOGGER.info("Processing offset auto reset backfill for table {}, with context {}", tableNameWithType, context);
+
+    TableConfig tableConfig = _pinotHelixResourceManager.getTableConfig(tableNameWithType);
+    if (tableConfig == null) {
+      LOGGER.error("Failed to find table config for table: {}, skipping auto reset periodic job", tableNameWithType);
+      return;
+    }
+    RealtimeOffsetAutoResetHandler handler = getOrConstructHandler(tableConfig);
+    if (handler == null) {
+      return;
+    }
+
+    if (context._shouldTriggerBackfillJobs) {
+      _tableTopicsUnderBackfill.putIfAbsent(tableNameWithType, ConcurrentHashMap.newKeySet());
+      String topicName = context._backfillJobProperties.get(Constants.RESET_OFFSET_TOPIC_NAME);
+      _tableTopicsUnderBackfill.get(tableNameWithType).add(topicName);
+
+      StreamConfig topicStreamConfig = IngestionConfigUtils.getStreamConfigs(tableConfig).stream()
+          .filter(config -> topicName.equals(config.getTopicName()))
+          .findFirst().orElseThrow(() -> new RuntimeException("No matching topic found"));
+      LOGGER.info("Trigger backfill jobs with StreamConfig {}, topicName {}, properties {}",
+          topicStreamConfig, topicName, context._backfillJobProperties);
+      try {
+        // TODO: use the returned boolean value to ensure at least once delivery of the backfill job
+        _tableToHandler.get(tableNameWithType).triggerBackfillJob(tableNameWithType,
+            topicStreamConfig,
+            topicName,
+            Integer.parseInt(context._backfillJobProperties.get(Constants.RESET_OFFSET_TOPIC_PARTITION)),
+            Long.parseLong(context._backfillJobProperties.get(Constants.RESET_OFFSET_FROM)),
+            Long.parseLong(context._backfillJobProperties.get(Constants.RESET_OFFSET_TO)));
+      } catch (NumberFormatException e) {
+        LOGGER.error("Invalid backfill job properties for table: {}, properties: {}, error: {}",
+            tableNameWithType, context._backfillJobProperties, e.getMessage(), e);
+      }
+    }
+
+    ensureBackfillJobsRunning(tableNameWithType);
+    ensureCompletedBackfillJobsCleanedUp(tableConfig);
+  }
+
+  /**
+   * Get the list of tables & topics being backfilled and ensure the backfill jobs are running.
+   */
+  private void ensureBackfillJobsRunning(String tableNameWithType) {
+    // Recover state from ephemeral multi-topics ingestion
+    // TODO: refactor or add other recover methods when other backfill approaches are ready
+    TableConfig tableConfig = _pinotHelixResourceManager.getTableConfig(tableNameWithType);
+    List<StreamConfig> streamConfigs = IngestionConfigUtils.getStreamConfigs(tableConfig);
+    for (int i = 0; i < streamConfigs.size(); i++) {
+      if (streamConfigs.get(i).isBackfillTopic() && !_llcRealtimeSegmentManager.isTopicConsumptionPaused(
+          tableConfig.getTableName(), i)) {
+        _tableBackfillTopics.putIfAbsent(tableNameWithType, ConcurrentHashMap.newKeySet());
+        _tableBackfillTopics.get(tableNameWithType).add(streamConfigs.get(i).getTopicName());
+      }
+    }
+    if (!_tableTopicsUnderBackfill.containsKey(tableNameWithType)
+        || _tableTopicsUnderBackfill.get(tableNameWithType).isEmpty()) {
+      return;
+    }
+    RealtimeOffsetAutoResetHandler handler = getOrConstructHandler(tableConfig);
+    if (handler == null) {
+      return;
+    }
+    handler.ensureBackfillJobsRunning(tableNameWithType, _tableTopicsUnderBackfill.get(tableNameWithType));
+  }
+
+  private void ensureCompletedBackfillJobsCleanedUp(TableConfig tableConfig) {
+    String tableNameWithType = tableConfig.getTableName();
+    if (!_tableBackfillTopics.containsKey(tableNameWithType)) {
+      return;
+    }
+    LOGGER.info("Trying to clean up backfill jobs on {}", tableNameWithType);
+    RealtimeOffsetAutoResetHandler handler = getOrConstructHandler(tableConfig);
+    Collection<String> cleanedUpTopics = handler.cleanupCompletedBackfillJobs(
+        tableNameWithType, _tableBackfillTopics.get(tableNameWithType));
+    if (cleanedUpTopics.containsAll(_tableBackfillTopics.get(tableNameWithType))) {
+      _tableTopicsUnderBackfill.remove(tableNameWithType);
+      _tableBackfillTopics.remove(tableNameWithType);
+      if (_tableToHandler.get(tableNameWithType) != null) {
+        _tableToHandler.get(tableNameWithType).close();
+        _tableToHandler.remove(tableNameWithType);
+      }
+    } else {
+      _tableBackfillTopics.get(tableNameWithType).removeAll(cleanedUpTopics);
+    }
+    if (cleanedUpTopics.size() > 0) {
+      LOGGER.info("Cleaned up complete backfill topics {} for table {}", cleanedUpTopics, tableNameWithType);
+    }
+  }
+
+  @Override
+  protected void nonLeaderCleanup(List<String> tableNamesWithType) {
+    for (String tableNameWithType : tableNamesWithType) {
+      _tableTopicsUnderBackfill.remove(tableNameWithType);
+      _tableToHandler.remove(tableNameWithType);
+    }
+  }
+
+  private RealtimeOffsetAutoResetHandler getOrConstructHandler(TableConfig tableConfig) {
+    RealtimeOffsetAutoResetHandler handler = _tableToHandler.get(tableConfig.getTableName());
+    if (handler != null) {
+      return handler;
+    }
+    if (tableConfig.getIngestionConfig() == null
+        || tableConfig.getIngestionConfig().getStreamIngestionConfig() == null) {
+      LOGGER.debug("Table {} config is in the legacy mode, cannot do auto reset", tableConfig.getTableName());
+      return null;
+    }
+    String className = tableConfig.getIngestionConfig().getStreamIngestionConfig()
+        .getRealtimeOffsetAutoResetHandlerClass();
+    if (className == null) {
+      LOGGER.debug("RealtimeOffsetAutoResetHandlerClass is not specified for table {}", tableConfig.getTableName());
+      return null;
+    }
+    try {
+      Class<?> clazz = Class.forName(className);
+      if (!RealtimeOffsetAutoResetHandler.class.isAssignableFrom(clazz)) {
+        String exceptionMessage = "Custom analyzer must be a child of "
+            + RealtimeOffsetAutoResetHandler.class.getCanonicalName();
+        throw new ReflectiveOperationException(exceptionMessage);
+      }
+      handler = (RealtimeOffsetAutoResetHandler) clazz.getConstructor(
+          PinotLLCRealtimeSegmentManager.class, PinotHelixResourceManager.class).newInstance(
+          _llcRealtimeSegmentManager, _pinotHelixResourceManager);
+      _tableToHandler.put(tableConfig.getTableName(), handler);
+      return handler;
+    } catch (Exception e) {
+      LOGGER.error("Cannot create RealtimeOffsetAutoResetHandler", e);
+      return null;
+    }
+  }
+
+  public class Context {
+    public final List<String> _backfillJobPropertyKeys = List.of(
+        Constants.RESET_OFFSET_TOPIC_NAME, Constants.RESET_OFFSET_TOPIC_PARTITION,
+        Constants.RESET_OFFSET_FROM, Constants.RESET_OFFSET_TO);
+    private boolean _shouldTriggerBackfillJobs;
+    private Map<String, String> _backfillJobProperties = new HashMap<>();
+
+    @VisibleForTesting
+    protected boolean isShouldTriggerBackfillJobs() {
+      return _shouldTriggerBackfillJobs;
+    }
+
+    @VisibleForTesting
+    protected Map<String, String> getBackfillJobProperties() {
+      return _backfillJobProperties;
+    }
+
+    @Override
+    public String toString() {
+      return _backfillJobProperties.toString();
+    }
+  }
+}

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
@@ -440,7 +440,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
     when(mockMetadataProvider.fetchStreamPartitionOffset(eq(OffsetCriteria.LARGEST_OFFSET_CRITERIA),
         anyLong())).thenReturn(new LongMsgOffset(LATEST_OFFSET));
     when(mockMetadataProvider.getOffsetAtTimestamp(eq(0), anyLong(), anyLong())).thenReturn(
-        new LongMsgOffset(PARTITION_OFFSET.getOffset() + 1L));
+        new LongMsgOffset(PARTITION_OFFSET.getOffset() + NUM_DOCS + 1L));
 
     try (MockedStatic<StreamConsumerFactoryProvider> mockedStaticProvider = mockStatic(
         StreamConsumerFactoryProvider.class)) {

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/validation/RealtimeOffsetAutoResetManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/validation/RealtimeOffsetAutoResetManagerTest.java
@@ -1,0 +1,342 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.validation;
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import org.apache.pinot.common.metrics.ControllerMetrics;
+import org.apache.pinot.controller.ControllerConf;
+import org.apache.pinot.controller.LeadControllerManager;
+import org.apache.pinot.controller.api.resources.Constants;
+import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
+import org.apache.pinot.controller.helix.core.periodictask.RealtimeOffsetAutoResetHandler;
+import org.apache.pinot.controller.helix.core.realtime.PinotLLCRealtimeSegmentManager;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
+import org.apache.pinot.spi.config.table.ingestion.StreamIngestionConfig;
+import org.apache.pinot.spi.stream.StreamConfig;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+public class RealtimeOffsetAutoResetManagerTest {
+  private static final String REALTIME_TABLE_NAME = "testTable_REALTIME";
+  private static final String OFFLINE_TABLE_NAME = "testTable_OFFLINE";
+  private static final String TOPIC_NAME = "testTopic";
+  private static final String TEST_HANDLER_CLASS_NAME =
+      "org.apache.pinot.controller.validation.RealtimeOffsetAutoResetManagerTest$TestRealtimeOffsetAutoResetHandler";
+
+  @Mock
+  private PinotLLCRealtimeSegmentManager _llcRealtimeSegmentManager;
+
+  @Mock
+  private PinotHelixResourceManager _pinotHelixResourceManager;
+
+  @Mock
+  private LeadControllerManager _leadControllerManager;
+
+  @Mock
+  private ControllerMetrics _controllerMetrics;
+
+  @Mock
+  private RealtimeOffsetAutoResetHandler _mockHandler;
+
+  private AutoCloseable _mocks;
+  private RealtimeOffsetAutoResetManager _realtimeOffsetAutoResetManager;
+  private ControllerConf _controllerConf;
+  Properties _properties;
+
+  @BeforeMethod
+  public void setup() {
+    _mocks = MockitoAnnotations.openMocks(this);
+    _controllerConf = new ControllerConf();
+    _controllerConf.setRealtimeOffsetAutoResetBackfillFrequencyInSeconds(60);
+    _properties = new Properties();
+    _properties.setProperty(Constants.RESET_OFFSET_TOPIC_NAME, TOPIC_NAME);
+    _properties.setProperty(Constants.RESET_OFFSET_TOPIC_PARTITION, "0");
+    _properties.setProperty(Constants.RESET_OFFSET_FROM, "100");
+    _properties.setProperty(Constants.RESET_OFFSET_TO, "200");
+
+    _realtimeOffsetAutoResetManager = new RealtimeOffsetAutoResetManager(_controllerConf,
+        _pinotHelixResourceManager, _leadControllerManager, _llcRealtimeSegmentManager, _controllerMetrics);
+  }
+
+  @AfterMethod
+  public void tearDown()
+      throws Exception {
+    _mocks.close();
+  }
+
+  @Test
+  public void testPreprocessWithBackfillJobProperties() {
+
+    RealtimeOffsetAutoResetManager.Context context = _realtimeOffsetAutoResetManager.preprocess(_properties);
+
+    Assert.assertNotNull(context);
+    // The static fields should be set
+    Assert.assertTrue(context.isShouldTriggerBackfillJobs());
+    Assert.assertEquals(
+        context.getBackfillJobProperties().get(Constants.RESET_OFFSET_TOPIC_NAME),
+        TOPIC_NAME);
+    Assert.assertEquals(
+        context.getBackfillJobProperties().get(Constants.RESET_OFFSET_TOPIC_PARTITION), "0");
+    Assert.assertEquals(context.getBackfillJobProperties().get(Constants.RESET_OFFSET_FROM),
+        "100");
+    Assert.assertEquals(context.getBackfillJobProperties().get(Constants.RESET_OFFSET_TO),
+        "200");
+  }
+
+  @Test
+  public void testPreprocessWithoutBackfillJobProperties() {
+    Properties otherProperties = new Properties();
+    otherProperties.setProperty("otherProperty", "value");
+
+    RealtimeOffsetAutoResetManager.Context context = _realtimeOffsetAutoResetManager.preprocess(otherProperties);
+
+    Assert.assertNotNull(context);
+    // The static fields should not be set
+    Assert.assertFalse(context.isShouldTriggerBackfillJobs());
+    Assert.assertTrue(context.getBackfillJobProperties().isEmpty());
+  }
+
+  @Test
+  public void testProcessTableWithOfflineTable() {
+    RealtimeOffsetAutoResetManager.Context context = _realtimeOffsetAutoResetManager.preprocess(new Properties());
+
+    _realtimeOffsetAutoResetManager.processTable(OFFLINE_TABLE_NAME, context);
+
+    // Should return early for offline tables, no interactions with handlers
+    verify(_pinotHelixResourceManager, never()).getTableConfig(anyString());
+  }
+
+  @Test
+  public void testProcessTableWithRealtimeTableNoTableConfig() {
+    RealtimeOffsetAutoResetManager.Context context = _realtimeOffsetAutoResetManager.preprocess(new Properties());
+    when(_pinotHelixResourceManager.getTableConfig(REALTIME_TABLE_NAME)).thenReturn(null);
+
+    _realtimeOffsetAutoResetManager.processTable(REALTIME_TABLE_NAME, context);
+
+    verify(_pinotHelixResourceManager).getTableConfig(REALTIME_TABLE_NAME);
+    // Should return early when table config is null
+  }
+
+  @Test
+  public void testProcessTableWithRealtimeTableNoHandlerClass() {
+    RealtimeOffsetAutoResetManager.Context context = _realtimeOffsetAutoResetManager.preprocess(new Properties());
+    TableConfig tableConfig = createTableConfigWithoutHandlerClass();
+    when(_pinotHelixResourceManager.getTableConfig(REALTIME_TABLE_NAME)).thenReturn(tableConfig);
+
+    _realtimeOffsetAutoResetManager.processTable(REALTIME_TABLE_NAME, context);
+
+    verify(_pinotHelixResourceManager).getTableConfig(REALTIME_TABLE_NAME);
+    // Should return early when handler class is not specified
+  }
+
+  @Test
+  public void testProcessTableWithRealtimeTableInvalidHandlerClass() {
+    RealtimeOffsetAutoResetManager.Context context = _realtimeOffsetAutoResetManager.preprocess(new Properties());
+    TableConfig tableConfig = createTableConfigWithInvalidHandlerClass();
+    when(_pinotHelixResourceManager.getTableConfig(REALTIME_TABLE_NAME)).thenReturn(tableConfig);
+
+    _realtimeOffsetAutoResetManager.processTable(REALTIME_TABLE_NAME, context);
+
+    verify(_pinotHelixResourceManager).getTableConfig(REALTIME_TABLE_NAME);
+    RealtimeOffsetAutoResetHandler handler = _realtimeOffsetAutoResetManager.getTableHandler(REALTIME_TABLE_NAME);
+    Assert.assertNull(handler);
+  }
+
+  @Test
+  public void testProcessTableWithRealtimeTableValidHandler() {
+    RealtimeOffsetAutoResetManager.Context context = _realtimeOffsetAutoResetManager.preprocess(_properties);
+
+    _realtimeOffsetAutoResetManager.processTable(OFFLINE_TABLE_NAME, context);
+
+    TableConfig tableConfig = createTableConfigWithValidHandlerClass();
+    when(_pinotHelixResourceManager.getTableConfig(REALTIME_TABLE_NAME)).thenReturn(tableConfig);
+
+    _realtimeOffsetAutoResetManager.processTable(REALTIME_TABLE_NAME, context);
+    RealtimeOffsetAutoResetHandler handler = _realtimeOffsetAutoResetManager.getTableHandler(REALTIME_TABLE_NAME);
+    Assert.assertNotNull(handler);
+    Assert.assertTrue(((TestRealtimeOffsetAutoResetHandler) handler)._triggedBackfillJob);
+  }
+
+  @Test
+  public void testProcessTableWithRealtimeTableNoBackfillJobTrigger() {
+    RealtimeOffsetAutoResetManager.Context context = _realtimeOffsetAutoResetManager.preprocess(new Properties());
+
+    TableConfig tableConfig = createTableConfigWithValidHandlerClass();
+    when(_pinotHelixResourceManager.getTableConfig(REALTIME_TABLE_NAME)).thenReturn(tableConfig);
+
+    _realtimeOffsetAutoResetManager.processTable(REALTIME_TABLE_NAME, context);
+
+    RealtimeOffsetAutoResetHandler handler = _realtimeOffsetAutoResetManager.getTableHandler(REALTIME_TABLE_NAME);
+    Assert.assertNotNull(handler);
+    Assert.assertFalse(((TestRealtimeOffsetAutoResetHandler) handler)._triggedBackfillJob);
+  }
+
+  @Test
+  public void testNonLeaderCleanup() {
+    List<String> tableNames = Arrays.asList(REALTIME_TABLE_NAME, OFFLINE_TABLE_NAME);
+
+    _realtimeOffsetAutoResetManager.nonLeaderCleanup(tableNames);
+
+    // The cleanup should remove the tables from internal maps
+    // This is tested indirectly by verifying the method completes without exception
+  }
+
+  @Test
+  public void testEnsureCompletedBackfillJobsCleanedUp() {
+    TableConfig tableConfig = createTableConfigWithValidHandlerClass();
+    RealtimeOffsetAutoResetManager.Context context = _realtimeOffsetAutoResetManager.preprocess(new Properties());
+    when(_pinotHelixResourceManager.getTableConfig(REALTIME_TABLE_NAME)).thenReturn(tableConfig);
+
+    _realtimeOffsetAutoResetManager.processTable(REALTIME_TABLE_NAME, context);
+
+    // The test handler should be created and cleanupCompletedBackfillJobs should be called
+    // We can verify this by checking that the process completes without exception
+  }
+
+  @Test
+  public void testGetOrConstructHandlerWithExistingHandler() {
+    TableConfig tableConfig = createTableConfigWithValidHandlerClass();
+    RealtimeOffsetAutoResetManager.Context context = _realtimeOffsetAutoResetManager.preprocess(new Properties());
+    when(_pinotHelixResourceManager.getTableConfig(REALTIME_TABLE_NAME)).thenReturn(tableConfig);
+
+    // First call to create handler
+    _realtimeOffsetAutoResetManager.processTable(REALTIME_TABLE_NAME, context);
+
+    // Second call should reuse existing handler
+    _realtimeOffsetAutoResetManager.processTable(REALTIME_TABLE_NAME, context);
+
+    // Handler should be created only once and reused
+    // We can verify this by checking that the process completes without exception
+  }
+
+  private TableConfig createTableConfigWithoutHandlerClass() {
+    TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(REALTIME_TABLE_NAME).build();
+    IngestionConfig ingestionConfig = new IngestionConfig();
+    Map<String, String> streamConfigMap = new HashMap<>();
+    streamConfigMap.put("streamType", "kafka");
+    streamConfigMap.put("stream.kafka.topic.name", TOPIC_NAME);
+    streamConfigMap.put("stream.kafka.consumer.type", "simple");
+    streamConfigMap.put("realtime.segment.offsetAutoReset.timeSecThreshold", "1800");
+    streamConfigMap.put("stream.kafka.decoder.class.name", "testDecoder");
+    StreamIngestionConfig streamIngestionConfig = new StreamIngestionConfig(Collections.singletonList(streamConfigMap));
+    streamIngestionConfig.setRealtimeOffsetAutoResetHandlerClass(null);
+    ingestionConfig.setStreamIngestionConfig(streamIngestionConfig);
+    tableConfig.setIngestionConfig(ingestionConfig);
+    return tableConfig;
+  }
+
+  private TableConfig createTableConfigWithInvalidHandlerClass() {
+    TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(REALTIME_TABLE_NAME).build();
+    IngestionConfig ingestionConfig = new IngestionConfig();
+
+    Map<String, String> streamConfigMap = new HashMap<>();
+    streamConfigMap.put("streamType", "kafka");
+    streamConfigMap.put("stream.kafka.topic.name", TOPIC_NAME);
+    streamConfigMap.put("stream.kafka.consumer.type", "simple");
+    streamConfigMap.put("realtime.segment.offsetAutoReset.timeSecThreshold", "1800");
+    streamConfigMap.put("stream.kafka.decoder.class.name", "testDecoder");
+    StreamIngestionConfig streamIngestionConfig = new StreamIngestionConfig(Collections.singletonList(streamConfigMap));
+    streamIngestionConfig.setRealtimeOffsetAutoResetHandlerClass("InvalidClass");
+    ingestionConfig.setStreamIngestionConfig(streamIngestionConfig);
+    tableConfig.setIngestionConfig(ingestionConfig);
+    return tableConfig;
+  }
+
+  private TableConfig createTableConfigWithValidHandlerClass() {
+    TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(REALTIME_TABLE_NAME).build();
+    IngestionConfig ingestionConfig = new IngestionConfig();
+
+    // Add stream configs
+    Map<String, String> streamConfigMap = new HashMap<>();
+    streamConfigMap.put("streamType", "kafka");
+    streamConfigMap.put("stream.kafka.topic.name", TOPIC_NAME);
+    streamConfigMap.put("stream.kafka.consumer.type", "simple");
+    streamConfigMap.put("realtime.segment.offsetAutoReset.timeSecThreshold", "1800");
+    streamConfigMap.put("stream.kafka.decoder.class.name", "testDecoder");
+
+    StreamIngestionConfig streamIngestionConfig = new StreamIngestionConfig(Collections.singletonList(streamConfigMap));
+    streamIngestionConfig.setRealtimeOffsetAutoResetHandlerClass(TEST_HANDLER_CLASS_NAME);
+    ingestionConfig.setStreamIngestionConfig(streamIngestionConfig);
+    tableConfig.setIngestionConfig(ingestionConfig);
+    return tableConfig;
+  }
+
+  /**
+   * Test implementation of RealtimeOffsetAutoResetHandler for testing purposes
+   */
+  public static class TestRealtimeOffsetAutoResetHandler implements RealtimeOffsetAutoResetHandler {
+
+    public PinotLLCRealtimeSegmentManager _llcRealtimeSegmentManager;
+    public PinotHelixResourceManager _pinotHelixResourceManager;
+    public boolean _triggedBackfillJob = false;
+
+    public TestRealtimeOffsetAutoResetHandler(PinotLLCRealtimeSegmentManager llcRealtimeSegmentManager,
+        PinotHelixResourceManager pinotHelixResourceManager) {
+      init(llcRealtimeSegmentManager, pinotHelixResourceManager);
+    }
+
+    @Override
+    public void init(PinotLLCRealtimeSegmentManager llcRealtimeSegmentManager,
+        PinotHelixResourceManager pinotHelixResourceManager) {
+      _llcRealtimeSegmentManager = llcRealtimeSegmentManager;
+      _pinotHelixResourceManager = pinotHelixResourceManager;
+    }
+
+    @Override
+    public boolean triggerBackfillJob(String tableNameWithType, StreamConfig streamConfig, String topicName,
+        int partitionId, long fromOffset, long toOffset) {
+      _triggedBackfillJob = true;
+      return true;
+    }
+
+    @Override
+    public void ensureBackfillJobsRunning(String tableNameWithType, Collection<String> topicNames) {
+      // Test implementation - do nothing
+    }
+
+    @Override
+    public Collection<String> cleanupCompletedBackfillJobs(String tableNameWithType, Collection<String> topicNames) {
+      // Test implementation - return empty collection
+      return Collections.emptyList();
+    }
+
+    @Override
+    public void close() {
+    }
+  }
+}

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaStreamMetadataProvider.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaStreamMetadataProvider.java
@@ -35,6 +35,7 @@ import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.ListTopicsResult;
 import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
 import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.pinot.plugin.stream.kafka.KafkaConsumerPartitionLag;
 import org.apache.pinot.spi.stream.ConsumerPartitionState;
@@ -191,6 +192,38 @@ public class KafkaStreamMetadataProvider extends KafkaPartitionLevelConnectionHa
   public StreamPartitionMsgOffset getOffsetAtTimestamp(int partitionId, long timestampMillis, long timeoutMillis) {
     return new LongMsgOffset(_consumer.offsetsForTimes(Map.of(_topicPartition, timestampMillis),
             Duration.ofMillis(timeoutMillis)).get(_topicPartition).offset());
+  }
+
+  @Override
+  public Map<String, StreamPartitionMsgOffset> getStreamStartOffsets() {
+    List<PartitionInfo> partitionInfos = _consumer.partitionsFor(_topic);
+    Map<TopicPartition, Long> startOffsets = _consumer.beginningOffsets(
+        partitionInfos.stream()
+            .filter(info -> info != null)
+            .map(info -> new TopicPartition(_topic, info.partition()))
+            .collect(Collectors.toList()));
+    return startOffsets.entrySet().stream().collect(
+        Collectors.toMap(
+            entry -> String.valueOf(entry.getKey().partition()),
+            entry -> new LongMsgOffset(entry.getValue()),
+            (existingValue, newValue) -> newValue
+        ));
+  }
+
+  @Override
+  public Map<String, StreamPartitionMsgOffset> getStreamEndOffsets() {
+    List<PartitionInfo> partitionInfos = _consumer.partitionsFor(_topic);
+    Map<TopicPartition, Long> startOffsets = _consumer.endOffsets(
+        partitionInfos.stream()
+            .filter(info -> info != null)
+            .map(info -> new TopicPartition(_topic, info.partition()))
+            .collect(Collectors.toList()));
+    return startOffsets.entrySet().stream().collect(
+        Collectors.toMap(
+            entry -> String.valueOf(entry.getKey().partition()),
+            entry -> new LongMsgOffset(entry.getValue()),
+            (existingValue, newValue) -> newValue
+        ));
   }
 
   public static class KafkaTopicMetadata implements TopicMetadata {

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/main/java/org/apache/pinot/plugin/stream/kafka30/KafkaStreamMetadataProvider.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/main/java/org/apache/pinot/plugin/stream/kafka30/KafkaStreamMetadataProvider.java
@@ -35,6 +35,7 @@ import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.ListTopicsResult;
 import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
 import org.apache.kafka.common.PartitionInfo;
+import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.pinot.plugin.stream.kafka.KafkaConsumerPartitionLag;
 import org.apache.pinot.spi.stream.ConsumerPartitionState;
@@ -204,6 +205,38 @@ public class KafkaStreamMetadataProvider extends KafkaPartitionLevelConnectionHa
   public StreamPartitionMsgOffset getOffsetAtTimestamp(int partitionId, long timestampMillis, long timeoutMillis) {
       return new LongMsgOffset(_consumer.offsetsForTimes(Map.of(_topicPartition, timestampMillis),
               Duration.ofMillis(timeoutMillis)).get(_topicPartition).offset());
+  }
+
+  @Override
+  public Map<String, StreamPartitionMsgOffset> getStreamStartOffsets() {
+    List<PartitionInfo> partitionInfos = _consumer.partitionsFor(_topic);
+    Map<TopicPartition, Long> startOffsets = _consumer.beginningOffsets(
+        partitionInfos.stream()
+            .filter(info -> info != null)
+            .map(info -> new TopicPartition(_topic, info.partition()))
+            .collect(Collectors.toList()));
+    return startOffsets.entrySet().stream().collect(
+        Collectors.toMap(
+            entry -> String.valueOf(entry.getKey().partition()),
+            entry -> new LongMsgOffset(entry.getValue()),
+            (existingValue, newValue) -> newValue
+        ));
+  }
+
+  @Override
+  public Map<String, StreamPartitionMsgOffset> getStreamEndOffsets() {
+    List<PartitionInfo> partitionInfos = _consumer.partitionsFor(_topic);
+    Map<TopicPartition, Long> startOffsets = _consumer.endOffsets(
+        partitionInfos.stream()
+            .filter(info -> info != null)
+            .map(info -> new TopicPartition(_topic, info.partition()))
+            .collect(Collectors.toList()));
+    return startOffsets.entrySet().stream().collect(
+        Collectors.toMap(
+            entry -> String.valueOf(entry.getKey().partition()),
+            entry -> new LongMsgOffset(entry.getValue()),
+            (existingValue, newValue) -> newValue
+        ));
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -642,14 +642,17 @@ public final class TableConfigUtils {
       // 2. Ensure segment flush parameters consistent across all streamConfigs. We need this because Pinot is
       // predefining the values before fetching stream partition info from stream. At the construction time, we don't
       // know the value extracted from a streamConfig would be applied to which segment.
+      // 3. There should not be duplicate topic names across streamConfigs.
       // TODO: Remove these limitations
       StreamConfig firstStreamConfig = streamConfigs.get(0);
+      Set<String> topicNames = new HashSet<>();
       String streamType = firstStreamConfig.getType();
       int flushThresholdRows = firstStreamConfig.getFlushThresholdRows();
       long flushThresholdTimeMillis = firstStreamConfig.getFlushThresholdTimeMillis();
       double flushThresholdVarianceFraction = firstStreamConfig.getFlushThresholdVarianceFraction();
       long flushThresholdSegmentSizeBytes = firstStreamConfig.getFlushThresholdSegmentSizeBytes();
       int flushThresholdSegmentRows = firstStreamConfig.getFlushThresholdSegmentRows();
+      topicNames.add(firstStreamConfig.getTopicName());
       for (int i = 1; i < numStreamConfigs; i++) {
         StreamConfig streamConfig = streamConfigs.get(i);
         Preconditions.checkState(streamConfig.getType().equals(streamType),
@@ -660,6 +663,8 @@ public final class TableConfigUtils {
                 && streamConfig.getFlushThresholdSegmentSizeBytes() == flushThresholdSegmentSizeBytes
                 && streamConfig.getFlushThresholdSegmentRows() == flushThresholdSegmentRows,
             "Segment flush parameters must be consistent across all streamConfigs");
+        Preconditions.checkState(topicNames.add(streamConfig.getTopicName()),
+            "Duplicate topic names found in streamConfigs: %s", streamConfig.getTopicName());
       }
     }
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/StreamIngestionConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/StreamIngestionConfig.java
@@ -59,6 +59,9 @@ public class StreamIngestionConfig extends BaseJsonConfig {
       + " completed (immutable) replica on any server in pause-less ingestion")
   private DisasterRecoveryMode _disasterRecoveryMode = DisasterRecoveryMode.DEFAULT;
 
+  @JsonPropertyDescription("Class to handle realtime offset auto reset")
+  private String _realtimeOffsetAutoResetHandlerClass;
+
   @JsonCreator
   public StreamIngestionConfig(@JsonProperty("streamConfigMaps") List<Map<String, String>> streamConfigMaps) {
     _streamConfigMaps = streamConfigMaps;
@@ -123,5 +126,14 @@ public class StreamIngestionConfig extends BaseJsonConfig {
 
   public void setDisasterRecoveryMode(DisasterRecoveryMode disasterRecoveryMode) {
     _disasterRecoveryMode = disasterRecoveryMode;
+  }
+
+  @Nullable
+  public String getRealtimeOffsetAutoResetHandlerClass() {
+    return _realtimeOffsetAutoResetHandlerClass;
+  }
+
+  public void setRealtimeOffsetAutoResetHandlerClass(String realtimeOffsetAutoResetHandlerClass) {
+    _realtimeOffsetAutoResetHandlerClass = realtimeOffsetAutoResetHandlerClass;
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfig.java
@@ -78,6 +78,7 @@ public class StreamConfig {
   private final boolean _enableOffsetAutoReset;
   private final int _offsetAutoResetOffsetThreshold;
   private final long _offsetAutoResetTimeSecThreshold;
+  private final Boolean _backfillTopic;
 
   private final Map<String, String> _streamConfigMap = new HashMap<>();
 
@@ -206,7 +207,9 @@ public class StreamConfig {
     _enableOffsetAutoReset = Boolean.parseBoolean(streamConfigMap.get(StreamConfigProperties.ENABLE_OFFSET_AUTO_RESET));
     _offsetAutoResetOffsetThreshold = parseOffsetAutoResetOffsetThreshold(streamConfigMap);
     _offsetAutoResetTimeSecThreshold = parseOffsetAutoResetTimeSecThreshold(streamConfigMap);
-
+    _backfillTopic = streamConfigMap.containsKey(StreamConfigProperties.BACKFILL_TOPIC)
+        ? Boolean.valueOf(streamConfigMap.get(StreamConfigProperties.BACKFILL_TOPIC))
+        : null;
     _streamConfigMap.putAll(streamConfigMap);
   }
 
@@ -431,6 +434,10 @@ public class StreamConfig {
     return _offsetAutoResetTimeSecThreshold;
   }
 
+  public boolean isBackfillTopic() {
+    return Boolean.TRUE.equals(_backfillTopic);
+  }
+
   public String getTableNameWithType() {
     return _tableNameWithType;
   }
@@ -454,6 +461,7 @@ public class StreamConfig {
         + ", _enableOffsetAutoReset=" + _enableOffsetAutoReset
         + ", _offsetAutoResetOffsetThreshold" + _offsetAutoResetOffsetThreshold
         + ", _offSetAutoResetTimeSecThreshold" + _offsetAutoResetTimeSecThreshold
+        + ", _backfillTopic=" + _backfillTopic
         + ", _streamConfigMap=" + _streamConfigMap
         + ", _offsetCriteria=" + _offsetCriteria + ", _serverUploadToDeepStore=" + _serverUploadToDeepStore + '}';
   }
@@ -482,7 +490,8 @@ public class StreamConfig {
         that._offsetCriteria) && Objects.equals(_flushThresholdVarianceFraction, that._flushThresholdVarianceFraction)
         && _enableOffsetAutoReset == that._enableOffsetAutoReset
         && _offsetAutoResetOffsetThreshold == that._offsetAutoResetOffsetThreshold
-        && _offsetAutoResetTimeSecThreshold == that._offsetAutoResetTimeSecThreshold;
+        && _offsetAutoResetTimeSecThreshold == that._offsetAutoResetTimeSecThreshold
+        && Objects.equals(_backfillTopic, that._backfillTopic);
   }
 
   @Override
@@ -492,6 +501,6 @@ public class StreamConfig {
         _flushThresholdSegmentRows, _flushThresholdTimeMillis, _flushThresholdSegmentSizeBytes,
         _flushAutotuneInitialRows, _groupId, _topicConsumptionRateLimit, _streamConfigMap, _offsetCriteria,
         _serverUploadToDeepStore, _flushThresholdVarianceFraction, _offsetAutoResetOffsetThreshold,
-        _enableOffsetAutoReset, _offsetAutoResetTimeSecThreshold);
+        _enableOffsetAutoReset, _offsetAutoResetTimeSecThreshold, _backfillTopic);
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfigProperties.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfigProperties.java
@@ -163,6 +163,11 @@ public class StreamConfigProperties {
       "realtime.segment.offsetAutoReset.timeThresholdSeconds";
 
   /**
+   * Config used to indicate whether the topic is a temporary topic for offset auto reset backfilling
+   */
+  public static final String BACKFILL_TOPIC = "realtime.segment.isBackfillTopic";
+
+  /**
    * Helper method to create a stream specific property
    */
   public static String constructStreamProperty(String streamType, String property) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamMetadataProvider.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamMetadataProvider.java
@@ -133,6 +133,16 @@ public interface StreamMetadataProvider extends Closeable {
     return null;
   }
 
+  @Nullable
+  default Map<String, StreamPartitionMsgOffset> getStreamStartOffsets() {
+    return null;
+  }
+
+  @Nullable
+  default Map<String, StreamPartitionMsgOffset> getStreamEndOffsets() {
+    return null;
+  }
+
   /**
    * Fetches the list of available topics/streams
    *


### PR DESCRIPTION
`real-time` `ingestion` `feature`
Part 3 of https://github.com/apache/pinot/pull/15782
Issue https://github.com/apache/pinot/issues/14815
Design doc https://docs.google.com/document/d/1NKPeNh6V2ctaQ4T_X3OKJ6Gcy5TRanLiU1uIDT8_9UA/edit?usp=sharing

Once the offset auto reset (in [1/3](https://github.com/apache/pinot/pull/16492)) happens, users can choose to backfill the skipped in-between data. To enable that, configs to be added are:

- `controller.realtime.offsetAutoReset.backfill.enabled = true` in controller config.
- `realtimeOffsetAutoResetHandlerClass` in `streamIngestionConfig` to determine how to handle the backfill. This is a plugin with defined the interfaces.

The `RealtimeOffsetAutoResetManager` could:

- Construct the handler per user's config.
- Trigger the backfill once such helix message/event sent after reset happened.
- Periodically scan the table config and find the existing backfill topics.
- Afterwards, it can check the backfill status by the handler and trigger the clean up if needed.

Besides, the PR also introduces an alternative abstract implementation of backfill based on multi-topic ingestion:

- Ask Kafka Ecosystem to replicate the skipped offsets once reset happens.
- Add the replicated topic to the table. Or if already added, resume the consumption if needed.
- Pause the backfill topic's consumption if backfill completes.