### PR TITLE
force commit API does not fail for non-existing segment names

### DIFF
--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
@@ -336,6 +336,24 @@ public class PinotLLCRealtimeSegmentManagerTest {
   }
 
   @Test
+  public void testForceCommitWithNonConsumingSegmentsIsIgnored() {
+    // Set up a new table with 1 replica, 2 instances, 1 partition
+    FakePinotLLCRealtimeSegmentManager segmentManager = new FakePinotLLCRealtimeSegmentManager();
+    segmentManager._numReplicas = 1;
+    segmentManager.makeTableConfig();
+    segmentManager._numInstances = 2;
+    segmentManager.makeConsumingInstancePartitions();
+    segmentManager._numPartitions = 1;
+    segmentManager.setUpNewTable();
+
+    // Provide a segment that is not in CONSUMING state (non-existent); should be ignored without exception
+    String nonConsumingSegment = "nonExistingSegment";
+    Set<String> committed = segmentManager.forceCommit(REALTIME_TABLE_NAME, null, nonConsumingSegment,
+        org.apache.pinot.controller.api.resources.ForceCommitBatchConfig.of(1, 1, 5));
+    assertTrue(committed.isEmpty(), "Expected no segments to be committed when only non-consuming segments provided");
+  }
+
+  @Test
   public void testCommitSegmentWithOffsetAutoResetOnOffset()
       throws Exception {
     // Set up a new table with 2 replicas, 5 instances, 4 partition


### PR DESCRIPTION
closes https://github.com/apache/pinot/issues/16435

This is a behavior change to warn about non-consuming segments rather than fail the API. In our case, we want to commit all segments more than X time old. We compute them ahead of time then force commit them in batches. Sometimes, by the time we get to a certain batch, the segment has already been committed by Pinot. This makes the API a bit more forgiving to just log these cases rather than fail.

I've added a unit test for this case.