### PR TITLE
Removes recentlyOffloadedConsumingSegments cache

### DIFF
--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/SegmentOnlineOfflineStateModelFactory.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/SegmentOnlineOfflineStateModelFactory.java
@@ -18,10 +18,6 @@
  */
 package org.apache.pinot.server.starter.helix;
 
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
-import java.util.concurrent.TimeUnit;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.helix.NotificationContext;
 import org.apache.helix.model.Message;
 import org.apache.helix.participant.statemachine.StateModel;
@@ -30,7 +26,6 @@ import org.apache.helix.participant.statemachine.StateModelInfo;
 import org.apache.helix.participant.statemachine.Transition;
 import org.apache.pinot.core.data.manager.InstanceDataManager;
 import org.apache.pinot.segment.local.data.manager.TableDataManager;
-import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 


### PR DESCRIPTION
Post this PR: https://github.com/apache/pinot/pull/16657 and this PR: https://github.com/apache/pinot/pull/15190
`recentlyOffloadedConsumingSegments` cache is not required.

This cache was added with reason: 
```
  // NOTE: Helix might process CONSUMING -> DROPPED transition as 2 separate transitions: CONSUMING -> OFFLINE followed
  // by OFFLINE -> DROPPED. Use this cache to track the segments that just went through CONSUMING -> OFFLINE transition
  // to detect CONSUMING -> DROPPED transition.
  // TODO: Check how Helix handle CONSUMING -> DROPPED transition and remove this cache if it's not needed.
```

This cache was used to detect when `CONSUMING -> OFFLINE` was followed by `OFFLINE -> DROPPED`. And when it's detected, the ingestion metrics are removed. However after this PR: https://github.com/apache/pinot/pull/16657, the ingestion metrics are removed in `CONSUMING -> OFFLINE` transition itself. (`onConsumingToDropped(tableNameWithType, segmentName)` is similar to `onConsumingToOffline(realtimeTableName, segmentName)`). So we don't need to again remove these metrics in `OFFLINE -> DROPPED`.

Also now we have direct transition from CONSUMING -> DROPPED after this PR: https://github.com/apache/pinot/pull/15190
