### PR TITLE
[Commit time compaction] Do not remove soft-delete record for commit time compaction

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/converter/RealtimeSegmentConverter.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/converter/RealtimeSegmentConverter.java
@@ -128,7 +128,7 @@ public class RealtimeSegmentConverter {
       }
       // Use CompactedPinotSegmentRecordReader to remove obsolete/invalidated records
       try (CompactedPinotSegmentRecordReader recordReader = new CompactedPinotSegmentRecordReader(
-          validDocIdsSnapshot, _realtimeSegmentImpl.getDeleteRecordColumn())) {
+          validDocIdsSnapshot)) {
         recordReader.init(_realtimeSegmentImpl, sortedDocIds);
         buildSegmentWithReader(driver, genConfig, recordReader, sortedDocIds, useCompactedReader, validDocIdsSnapshot);
         publishCompactionMetrics(serverMetrics, preCommitRowCount, driver, compactionStartTime);


### PR DESCRIPTION
In #16344, we added commit-time compaction to remove invalid and soft-deleted records from consuming segments before committing. While removing invalid records is safe, compacting soft-deleted records can cause inconsistencies where deleted rows reappear as valid.

Example: Suppose segment S2 contains a delete record R2 (deleteColumn=true) for a primary key that already exists as R1 in segment S0. During commit, R2 is removed from S2. After a server restart, Pinot reads R1 from S0 and treats it as valid, since R2 no longer exists to mark it as deleted.

To prevent this, this change removes the deleteRecordColumn parameter from the CompactedPinotSegmentRecordReader constructor, ensuring soft-deleted records are not compacted.

### Test
Added integration test testCommitTimeCompactionPreservesDeletedRecords().