### PR TITLE
Emit SegmentRelocation failure metric and shouldRelocateCompletedSegments logic

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/assignment/InstanceAssignmentConfigUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/assignment/InstanceAssignmentConfigUtils.java
@@ -30,6 +30,7 @@ import org.apache.pinot.spi.config.table.assignment.InstancePartitionsType;
 import org.apache.pinot.spi.config.table.assignment.InstanceReplicaGroupPartitionConfig;
 import org.apache.pinot.spi.config.table.assignment.InstanceTagPoolConfig;
 import org.apache.pinot.spi.utils.CommonConstants.Segment.AssignmentStrategy;
+import java.util.Objects;
 
 
 public class InstanceAssignmentConfigUtils {
@@ -39,14 +40,24 @@ public class InstanceAssignmentConfigUtils {
   /**
    * Returns whether the COMPLETED segments should be relocated (offloaded from CONSUMING instances to COMPLETED
    * instances) for a LLC real-time table based on the given table config.
-   * <p>COMPLETED segments should be relocated iff the COMPLETED instance assignment is configured or (for
+   * <p>COMPLETED segments should be relocated if the COMPLETED instance assignment is configured or (for
    * backward-compatibility) COMPLETED server tag is overridden to be different from the CONSUMING server tag.
    */
   public static boolean shouldRelocateCompletedSegments(TableConfig tableConfig) {
     Map<String, InstanceAssignmentConfig> instanceAssignmentConfigMap = tableConfig.getInstanceAssignmentConfigMap();
-    return (instanceAssignmentConfigMap != null
-        && instanceAssignmentConfigMap.get(InstancePartitionsType.COMPLETED.toString()) != null)
+    return isDifferentInstanceAssignmentGroup(instanceAssignmentConfigMap)
         || TagNameUtils.isRelocateCompletedSegments(tableConfig.getTenantConfig());
+  }
+
+  /**
+   * Helper function to check if instanceAssignmentConfig is different for CONSUMING and COMPLETED type
+   */
+  public static boolean isDifferentInstanceAssignmentGroup(Map<String, InstanceAssignmentConfig> instanceAssignmentConfigMap) {
+    return (instanceAssignmentConfigMap != null
+        && instanceAssignmentConfigMap.get(InstancePartitionsType.COMPLETED.toString()) != null
+        && instanceAssignmentConfigMap.get(InstancePartitionsType.CONSUMING.toString()) != null) &&
+        !(Objects.equals(instanceAssignmentConfigMap.get(InstancePartitionsType.CONSUMING.toString()),
+            instanceAssignmentConfigMap.get(InstancePartitionsType.COMPLETED.toString())));
   }
 
   /**

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
@@ -221,8 +221,9 @@ public enum ControllerGauge implements AbstractMetrics.Gauge {
   // The progress of a certain table rebalance job of a table
   TABLE_REBALANCE_JOB_PROGRESS_PERCENT("percent", false),
   // HTTP thread utilization
-  HTTP_THREAD_UTILIZATION("httpThreadUtilization", true);
-
+  HTTP_THREAD_UTILIZATION("httpThreadUtilization", true),
+  // Track failure encountered during segments relocation
+  SEGMENT_RELOCATION_FAILURE("segmentRelocationFailure", false);
 
   private final String _gaugeName;
   private final String _unit;

--- a/pinot-common/src/test/java/org/apache/pinot/common/assignment/InstanceAssignmentConfigUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/assignment/InstanceAssignmentConfigUtilsTest.java
@@ -43,13 +43,27 @@ import org.testng.annotations.Test;
 public class InstanceAssignmentConfigUtilsTest {
 
   @Test
-  public void testShouldRelocateCompletedSegmentsWhenInstancePartitionIsCompleted() {
+  public void testShouldRelocateCompletedSegmentsWhenInstancePartitionIsCompletedAndInstanceAssignmentIsDifferent() {
     Map<String, InstanceAssignmentConfig> instanceAssignmentConfigMap = new HashMap<>();
     instanceAssignmentConfigMap.put(InstancePartitionsType.COMPLETED.toString(),
         getInstanceAssignmentConfig(InstanceAssignmentConfig.PartitionSelector.FD_AWARE_INSTANCE_PARTITION_SELECTOR));
+    instanceAssignmentConfigMap.put(InstancePartitionsType.CONSUMING.toString(),
+        getInstanceAssignmentConfig(InstanceAssignmentConfig.PartitionSelector.IMPLICIT_REALTIME_TABLE_PARTITION_SELECTOR));
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable")
         .setInstanceAssignmentConfigMap(instanceAssignmentConfigMap).build();
     Assert.assertTrue(InstanceAssignmentConfigUtils.shouldRelocateCompletedSegments(tableConfig));
+  }
+
+  @Test
+  public void testShouldNotRelocateCompletedSegmentsWhenInstancePartitionIsCompletedAndInstanceAssignmentIsSame() {
+    Map<String, InstanceAssignmentConfig> instanceAssignmentConfigMap = new HashMap<>();
+    instanceAssignmentConfigMap.put(InstancePartitionsType.COMPLETED.toString(),
+        getInstanceAssignmentConfig(InstanceAssignmentConfig.PartitionSelector.FD_AWARE_INSTANCE_PARTITION_SELECTOR));
+    instanceAssignmentConfigMap.put(InstancePartitionsType.CONSUMING.toString(),
+        getInstanceAssignmentConfig(InstanceAssignmentConfig.PartitionSelector.FD_AWARE_INSTANCE_PARTITION_SELECTOR));
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable")
+        .setInstanceAssignmentConfigMap(instanceAssignmentConfigMap).build();
+    Assert.assertFalse(InstanceAssignmentConfigUtils.shouldRelocateCompletedSegments(tableConfig));
   }
 
   @Test

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/relocation/SegmentRelocator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/relocation/SegmentRelocator.java
@@ -36,6 +36,8 @@ import org.apache.hc.client5.http.io.HttpClientConnectionManager;
 import org.apache.helix.ClusterMessagingService;
 import org.apache.pinot.common.assignment.InstanceAssignmentConfigUtils;
 import org.apache.pinot.common.messages.SegmentReloadMessage;
+import org.apache.pinot.common.metrics.ControllerGauge;
+import org.apache.pinot.common.metrics.ControllerMeter;
 import org.apache.pinot.common.metrics.ControllerMetrics;
 import org.apache.pinot.common.utils.config.TierConfigUtils;
 import org.apache.pinot.controller.ControllerConf;
@@ -248,6 +250,7 @@ public class SegmentRelocator extends ControllerPeriodicTask<Void> {
           break;
         default:
           LOGGER.error("Relocation failed for table: {}", tableNameWithType);
+          _controllerMetrics.setValueOfTableGauge(tableNameWithType, ControllerGauge.SEGMENT_RELOCATION_FAILURE, 1);
           break;
       }
     } catch (Throwable t) {


### PR DESCRIPTION
### Summary
1. Emit SegmentRelocation failure metric for error tracking and troubleshooting 
2. Optimize shouldRelocateCompletedSegments logic so that only relocate segments when CONSUMING and COMPLETED instance assignment is different

### Testing Done
Add unit tests under InstanceAssignmentConfigUtilsTest.java


