### PR TITLE
[audit] Make audit config prefix component-specific (controller, broker, server)

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/audit/AuditConfigManager.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/audit/AuditConfigManager.java
@@ -21,10 +21,12 @@ package org.apache.pinot.common.audit;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.Map;
 import java.util.Set;
+import javax.inject.Inject;
 import javax.inject.Singleton;
 import org.apache.commons.configuration2.MapConfiguration;
 import org.apache.pinot.spi.config.provider.PinotClusterConfigChangeListener;
 import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.services.ServiceRole;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,12 +40,15 @@ import org.slf4j.LoggerFactory;
 public final class AuditConfigManager implements PinotClusterConfigChangeListener {
   private static final Logger LOG = LoggerFactory.getLogger(AuditConfigManager.class);
   private static final String AUDIT_CONFIG_PREFIX = "pinot.audit";
+  private static final Map<ServiceRole, String> SERVICE_ROLE_CONFIG_PREFIX_MAP =
+      Map.of(ServiceRole.CONTROLLER, "controller");
 
+  private final String _configPrefix;
   private AuditConfig _currentConfig = new AuditConfig();
 
-  @VisibleForTesting
-  static AuditConfig buildFromClusterConfig(Map<String, String> clusterConfigs) {
-    return mapPrefixedConfigToObject(clusterConfigs, AUDIT_CONFIG_PREFIX, AuditConfig.class);
+  @Inject
+  public AuditConfigManager(ServiceRole serviceRole) {
+    _configPrefix = constructAuditConfigPrefix(serviceRole);
   }
 
   /**
@@ -51,11 +56,16 @@ public final class AuditConfigManager implements PinotClusterConfigChangeListene
    * Uses PinotConfiguration.subset() to extract properties with the given prefix and
    * Jackson's convertValue() for automatic object mapping.
    */
-  private static <T> T mapPrefixedConfigToObject(Map<String, String> clusterConfigs, String prefix,
-      Class<T> configClass) {
+  @VisibleForTesting
+  static AuditConfig buildFromClusterConfig(Map<String, String> clusterConfigs, String auditConfigPrefix) {
     final MapConfiguration mapConfig = new MapConfiguration(clusterConfigs);
-    final PinotConfiguration subsetConfig = new PinotConfiguration(mapConfig).subset(prefix);
-    return AuditLogger.OBJECT_MAPPER.convertValue(subsetConfig.toMap(), configClass);
+    final PinotConfiguration subsetConfig = new PinotConfiguration(mapConfig).subset(auditConfigPrefix);
+    return AuditLogger.OBJECT_MAPPER.convertValue(subsetConfig.toMap(), AuditConfig.class);
+  }
+
+  private static String constructAuditConfigPrefix(ServiceRole serviceRole) {
+    // TODO Implement broker handling of audit config. Currently hardcoded to controller always
+    return AUDIT_CONFIG_PREFIX + "." + SERVICE_ROLE_CONFIG_PREFIX_MAP.get(ServiceRole.CONTROLLER);
   }
 
   public AuditConfig getCurrentConfig() {
@@ -68,8 +78,7 @@ public final class AuditConfigManager implements PinotClusterConfigChangeListene
 
   @Override
   public void onChange(Set<String> changedConfigs, Map<String, String> clusterConfigs) {
-    boolean hasAuditConfigChanges =
-        changedConfigs.stream().anyMatch(configKey -> configKey.startsWith(AUDIT_CONFIG_PREFIX));
+    boolean hasAuditConfigChanges = changedConfigs.stream().anyMatch(key -> key.startsWith(_configPrefix));
 
     if (!hasAuditConfigChanges) {
       LOG.info("No audit-related configs changed, skipping configuration rebuild");
@@ -77,7 +86,7 @@ public final class AuditConfigManager implements PinotClusterConfigChangeListene
     }
 
     try {
-      _currentConfig = buildFromClusterConfig(clusterConfigs);
+      _currentConfig = buildFromClusterConfig(clusterConfigs, _configPrefix);
       LOG.info("Successfully updated audit configuration");
     } catch (Exception e) {
       LOG.error("Failed to update audit configuration from cluster configs", e);

--- a/pinot-common/src/main/java/org/apache/pinot/common/audit/AuditConfigManager.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/audit/AuditConfigManager.java
@@ -20,6 +20,7 @@ package org.apache.pinot.common.audit;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import javax.inject.Inject;
 import javax.inject.Singleton;
@@ -41,7 +42,7 @@ public final class AuditConfigManager implements PinotClusterConfigChangeListene
   private static final Logger LOG = LoggerFactory.getLogger(AuditConfigManager.class);
   private static final String AUDIT_CONFIG_PREFIX = "pinot.audit";
   private static final Map<ServiceRole, String> SERVICE_ROLE_CONFIG_PREFIX_MAP =
-      Map.of(ServiceRole.CONTROLLER, "controller");
+      Map.of(ServiceRole.CONTROLLER, "controller", ServiceRole.SERVER, "server", ServiceRole.BROKER, "broker");
 
   private final String _configPrefix;
   private AuditConfig _currentConfig = new AuditConfig();
@@ -64,8 +65,9 @@ public final class AuditConfigManager implements PinotClusterConfigChangeListene
   }
 
   private static String constructAuditConfigPrefix(ServiceRole serviceRole) {
-    // TODO Implement broker handling of audit config. Currently hardcoded to controller always
-    return AUDIT_CONFIG_PREFIX + "." + SERVICE_ROLE_CONFIG_PREFIX_MAP.get(ServiceRole.CONTROLLER);
+    String componentPrefix = SERVICE_ROLE_CONFIG_PREFIX_MAP.get(serviceRole);
+    Objects.requireNonNull(componentPrefix, "Unsupported service role: " + serviceRole);
+    return AUDIT_CONFIG_PREFIX + "." + componentPrefix;
   }
 
   public AuditConfig getCurrentConfig() {

--- a/pinot-common/src/test/java/org/apache/pinot/common/audit/AuditConfigManagerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/audit/AuditConfigManagerTest.java
@@ -21,6 +21,7 @@ package org.apache.pinot.common.audit;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
+import org.apache.pinot.spi.services.ServiceRole;
 import org.testng.annotations.Test;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -36,15 +37,15 @@ public class AuditConfigManagerTest {
   public void testOnClusterConfigChangeWithAllConfigs() {
     // Given
     Map<String, String> properties = new HashMap<>();
-    properties.put("pinot.audit.enabled", "true");
-    properties.put("pinot.audit.capture.request.payload.enabled", "true");
-    properties.put("pinot.audit.capture.request.headers", "Content-Type,X-Request-Id,Authorization");
-    properties.put("pinot.audit.request.payload.size.max.bytes", "20480");
-    properties.put("pinot.audit.url.filter.exclude.patterns", "/health,/metrics");
+    properties.put("pinot.audit.controller.enabled", "true");
+    properties.put("pinot.audit.controller.capture.request.payload.enabled", "true");
+    properties.put("pinot.audit.controller.capture.request.headers", "Content-Type,X-Request-Id,Authorization");
+    properties.put("pinot.audit.controller.request.payload.size.max.bytes", "20480");
+    properties.put("pinot.audit.controller.url.filter.exclude.patterns", "/health,/metrics");
     properties.put("some.other.config", "value");
     properties.put("another.config", "123");
 
-    AuditConfigManager manager = new AuditConfigManager();
+    AuditConfigManager manager = new AuditConfigManager(ServiceRole.CONTROLLER);
 
     // When
     manager.onChange(properties.keySet(), properties);
@@ -62,12 +63,12 @@ public class AuditConfigManagerTest {
   public void testOnClusterConfigChangeWithPartialConfigs() {
     // Given
     Map<String, String> properties = new HashMap<>();
-    properties.put("pinot.audit.enabled", "true");
-    properties.put("pinot.audit.request.payload.size.max.bytes", "5000");
+    properties.put("pinot.audit.controller.enabled", "true");
+    properties.put("pinot.audit.controller.request.payload.size.max.bytes", "5000");
     properties.put("some.other.config", "value");
     properties.put("another.config", "123");
 
-    AuditConfigManager manager = new AuditConfigManager();
+    AuditConfigManager manager = new AuditConfigManager(ServiceRole.CONTROLLER);
 
     // When
     manager.onChange(properties.keySet(), properties);
@@ -88,7 +89,7 @@ public class AuditConfigManagerTest {
     Map<String, String> properties = new HashMap<>();
     properties.put("some.other.config", "value");
     properties.put("another.config", "123");
-    AuditConfigManager manager = new AuditConfigManager();
+    AuditConfigManager manager = new AuditConfigManager(ServiceRole.CONTROLLER);
 
     // When
     manager.onChange(properties.keySet(), properties);
@@ -105,20 +106,20 @@ public class AuditConfigManagerTest {
   @Test
   public void testConfigUpdateOverwritesPrevious() {
     // Given
-    AuditConfigManager manager = new AuditConfigManager();
+    AuditConfigManager manager = new AuditConfigManager(ServiceRole.CONTROLLER);
 
     // Set initial config
     Map<String, String> initialProperties = new HashMap<>();
-    initialProperties.put("pinot.audit.enabled", "true");
-    initialProperties.put("pinot.audit.request.payload.size.max.bytes", "15000");
+    initialProperties.put("pinot.audit.controller.enabled", "true");
+    initialProperties.put("pinot.audit.controller.request.payload.size.max.bytes", "15000");
     manager.onChange(initialProperties.keySet(), initialProperties);
     assertThat(manager.getCurrentConfig().isEnabled()).isTrue();
     assertThat(manager.getCurrentConfig().getMaxPayloadSize()).isEqualTo(15000);
 
     // When - Update with new config
     Map<String, String> updatedProperties = new HashMap<>();
-    updatedProperties.put("pinot.audit.enabled", "false");
-    updatedProperties.put("pinot.audit.request.payload.size.max.bytes", "25000");
+    updatedProperties.put("pinot.audit.controller.enabled", "false");
+    updatedProperties.put("pinot.audit.controller.request.payload.size.max.bytes", "25000");
     manager.onChange(updatedProperties.keySet(), updatedProperties);
 
     // Then
@@ -130,14 +131,14 @@ public class AuditConfigManagerTest {
   public void testBuildFromClusterConfigDirectly() {
     // Given
     Map<String, String> properties = new HashMap<>();
-    properties.put("pinot.audit.enabled", "true");
-    properties.put("pinot.audit.capture.request.payload.enabled", "false");
-    properties.put("pinot.audit.capture.request.headers", "X-User-Id,X-Session-Token");
+    properties.put("pinot.audit.controller.enabled", "true");
+    properties.put("pinot.audit.controller.capture.request.payload.enabled", "false");
+    properties.put("pinot.audit.controller.capture.request.headers", "X-User-Id,X-Session-Token");
     properties.put("some.other.config", "value");
     properties.put("another.config", "123");
 
     // When
-    AuditConfig config = AuditConfigManager.buildFromClusterConfig(properties);
+    AuditConfig config = AuditConfigManager.buildFromClusterConfig(properties, "pinot.audit.controller");
 
     // Then
     assertThat(config.isEnabled()).isTrue();
@@ -151,10 +152,10 @@ public class AuditConfigManagerTest {
   @Test
   public void testOnChangeSkipsRebuildWhenNoAuditConfigsChanged() {
     // Given - AuditConfigManager with initial config
-    AuditConfigManager manager = new AuditConfigManager();
+    AuditConfigManager manager = new AuditConfigManager(ServiceRole.CONTROLLER);
     Map<String, String> initialProperties = new HashMap<>();
-    initialProperties.put("pinot.audit.enabled", "true");
-    initialProperties.put("pinot.audit.request.payload.size.max.bytes", "15000");
+    initialProperties.put("pinot.audit.controller.enabled", "true");
+    initialProperties.put("pinot.audit.controller.request.payload.size.max.bytes", "15000");
     manager.onChange(initialProperties.keySet(), initialProperties);
 
     // Capture initial config instance - this should NOT change after non-audit config changes
@@ -179,10 +180,10 @@ public class AuditConfigManagerTest {
   @Test
   public void testOnChangeRebuildsWhenAuditConfigsChanged() {
     // Given - AuditConfigManager with initial config
-    AuditConfigManager manager = new AuditConfigManager();
+    AuditConfigManager manager = new AuditConfigManager(ServiceRole.CONTROLLER);
     Map<String, String> initialProperties = new HashMap<>();
-    initialProperties.put("pinot.audit.enabled", "false");
-    initialProperties.put("pinot.audit.request.payload.size.max.bytes", "10000");
+    initialProperties.put("pinot.audit.controller.enabled", "false");
+    initialProperties.put("pinot.audit.controller.request.payload.size.max.bytes", "10000");
     manager.onChange(initialProperties.keySet(), initialProperties);
 
     assertThat(manager.getCurrentConfig().isEnabled()).isFalse();
@@ -190,11 +191,12 @@ public class AuditConfigManagerTest {
 
     // When - Update with audit configs changed
     Map<String, String> updatedProperties = new HashMap<>();
-    updatedProperties.put("pinot.audit.enabled", "true");
-    updatedProperties.put("pinot.audit.request.payload.size.max.bytes", "20000");
+    updatedProperties.put("pinot.audit.controller.enabled", "true");
+    updatedProperties.put("pinot.audit.controller.request.payload.size.max.bytes", "20000");
     updatedProperties.put("some.other.config", "value");
 
-    manager.onChange(Set.of("pinot.audit.enabled", "pinot.audit.request.payload.size.max.bytes"), updatedProperties);
+    manager.onChange(Set.of("pinot.audit.controller.enabled", "pinot.audit.controller.request.payload.size.max.bytes"),
+        updatedProperties);
 
     // Then - Config should be rebuilt with new audit config values
     AuditConfig updatedConfig = manager.getCurrentConfig();
@@ -205,15 +207,15 @@ public class AuditConfigManagerTest {
   @Test
   public void testZookeeperConfigDeletionRevertsToDefaults() {
     // Given
-    AuditConfigManager manager = new AuditConfigManager();
+    AuditConfigManager manager = new AuditConfigManager(ServiceRole.CONTROLLER);
 
     // Set initial custom configs
     Map<String, String> customProperties = new HashMap<>();
-    customProperties.put("pinot.audit.enabled", "true");
-    customProperties.put("pinot.audit.capture.request.payload.enabled", "true");
-    customProperties.put("pinot.audit.capture.request.headers", "X-Trace-Id,X-Correlation-Id");
-    customProperties.put("pinot.audit.request.payload.size.max.bytes", "50000");
-    customProperties.put("pinot.audit.url.filter.exclude.patterns", "/test,/debug");
+    customProperties.put("pinot.audit.controller.enabled", "true");
+    customProperties.put("pinot.audit.controller.capture.request.payload.enabled", "true");
+    customProperties.put("pinot.audit.controller.capture.request.headers", "X-Trace-Id,X-Correlation-Id");
+    customProperties.put("pinot.audit.controller.request.payload.size.max.bytes", "50000");
+    customProperties.put("pinot.audit.controller.url.filter.exclude.patterns", "/test,/debug");
     manager.onChange(customProperties.keySet(), customProperties);
 
     // Verify custom configs are applied
@@ -243,23 +245,24 @@ public class AuditConfigManagerTest {
     Map<String, String> properties = new HashMap<>();
 
     // Test various string formats
-    properties.put("pinot.audit.capture.request.headers", "Header1,Header2,Header3");
-    AuditConfig config1 = AuditConfigManager.buildFromClusterConfig(properties);
+    properties.put("pinot.audit.controller.capture.request.headers", "Header1,Header2,Header3");
+    AuditConfig config1 = AuditConfigManager.buildFromClusterConfig(properties, "pinot.audit.controller");
     assertThat(config1.getCaptureRequestHeaders()).isEqualTo("Header1,Header2,Header3");
 
     // Test empty string
-    properties.put("pinot.audit.capture.request.headers", "");
-    AuditConfig config2 = AuditConfigManager.buildFromClusterConfig(properties);
+    properties.put("pinot.audit.controller.capture.request.headers", "");
+    AuditConfig config2 = AuditConfigManager.buildFromClusterConfig(properties, "pinot.audit.controller");
     assertThat(config2.getCaptureRequestHeaders()).isEmpty();
 
     // Test single header
-    properties.put("pinot.audit.capture.request.headers", "Content-Type");
-    AuditConfig config3 = AuditConfigManager.buildFromClusterConfig(properties);
+    properties.put("pinot.audit.controller.capture.request.headers", "Content-Type");
+    AuditConfig config3 = AuditConfigManager.buildFromClusterConfig(properties, "pinot.audit.controller");
     assertThat(config3.getCaptureRequestHeaders()).isEqualTo("Content-Type");
 
     // Test headers with mixed case and special characters
-    properties.put("pinot.audit.capture.request.headers", "Content-Type,X-Request-ID,User-Agent,X-Custom-123");
-    AuditConfig config4 = AuditConfigManager.buildFromClusterConfig(properties);
+    properties.put("pinot.audit.controller.capture.request.headers",
+        "Content-Type,X-Request-ID,User-Agent,X-Custom-123");
+    AuditConfig config4 = AuditConfigManager.buildFromClusterConfig(properties, "pinot.audit.controller");
     assertThat(config4.getCaptureRequestHeaders()).isEqualTo("Content-Type,X-Request-ID,User-Agent,X-Custom-123");
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
@@ -652,7 +652,7 @@ public abstract class BaseControllerStarter implements ServiceStartable {
     });
 
     // Register audit services binder
-    _adminApp.registerBinder(new AuditServiceBinder(_clusterConfigChangeHandler));
+    _adminApp.registerBinder(new AuditServiceBinder(_clusterConfigChangeHandler, getServiceRole()));
 
     LOGGER.info("Starting controller admin application on: {}", ListenerConfigUtil.toString(_listenerConfigs));
     _adminApp.start(_listenerConfigs, _controllerMetrics);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/audit/AuditServiceBinder.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/audit/AuditServiceBinder.java
@@ -23,6 +23,7 @@ import org.apache.pinot.common.audit.AuditIdentityResolver;
 import org.apache.pinot.common.audit.AuditRequestProcessor;
 import org.apache.pinot.common.audit.AuditUrlPathFilter;
 import org.apache.pinot.common.config.DefaultClusterConfigChangeHandler;
+import org.apache.pinot.spi.services.ServiceRole;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
 
 
@@ -32,15 +33,17 @@ import org.glassfish.hk2.utilities.binding.AbstractBinder;
  */
 public class AuditServiceBinder extends AbstractBinder {
   private final DefaultClusterConfigChangeHandler _clusterConfigChangeHandler;
+  private final ServiceRole _serviceRole;
 
-  public AuditServiceBinder(DefaultClusterConfigChangeHandler clusterConfigChangeHandler) {
+  public AuditServiceBinder(DefaultClusterConfigChangeHandler clusterConfigChangeHandler, ServiceRole serviceRole) {
     _clusterConfigChangeHandler = clusterConfigChangeHandler;
+    _serviceRole = serviceRole;
   }
 
   @Override
   protected void configure() {
     // Create and initialize AuditConfigManager
-    AuditConfigManager auditConfigManager = new AuditConfigManager();
+    AuditConfigManager auditConfigManager = new AuditConfigManager(_serviceRole);
 
     // Register with cluster config change handler
     _clusterConfigChangeHandler.registerClusterConfigChangeListener(auditConfigManager);


### PR DESCRIPTION
This PR updates the audit configuration system to use component-specific configuration prefixes, enabling different audit configurations for controller, broker, and server components.

## Changes
### 1. **Dynamic Prefix Construction in AuditConfigManager**
- Added `ServiceRole` parameter to constructor to identify the component type
- Changed config prefix from static `"pinot.audit"` to dynamic `"pinot.audit.controller"` (with TODO for other components)
- Made the prefix an instance variable (`_configPrefix`) constructed based on service role
- Added mapping for service roles to their config prefix suffixes

### 2. **Updated AuditServiceBinder**  
- Added `ServiceRole` parameter to constructor
- Passes service role to `AuditConfigManager` during initialization
- Controller passes its service role when creating the binder

### 3. **Configuration Properties**
All audit configuration properties now use the component-specific prefix:
- `pinot.audit.controller.enabled`
- `pinot.audit.controller.capture.request.payload.enabled`
- `pinot.audit.controller.capture.request.headers`
- `pinot.audit.controller.request.payload.size.max.bytes`
- `pinot.audit.controller.url.filter.exclude.patterns`
- `pinot.audit.controller.userid.header`
- `pinot.audit.controller.userid.jwt.claim`

### 4. **Test Updates**
- Updated all tests to use the new `pinot.audit.controller` prefix
- Tests now instantiate `AuditConfigManager` with `ServiceRole.CONTROLLER`
- Fixed static method calls to pass the audit config prefix as a parameter

## Benefits
- **Component Isolation**: Each Pinot component can have its own audit configuration
- **Extensibility**: Easy to add broker/server/minion-specific audit configs in the future
- **Backward Compatibility**: Controller maintains the same configuration structure, just with updated prefix
- **Clear Architecture**: Service role determines configuration namespace

## Testing
- All existing tests pass with updated configuration prefix
- Tested configuration updates via cluster config changes
- Verified proper prefix construction based on service role

## Future Work
- TODO comment added for implementing broker/server-specific configurations
- Currently all components fall back to controller prefix until their specific implementations are added