### PR TITLE
Fix query generator REGEXP_LIKE case sensitivity mismatch between Pinot and H2

### DIFF
--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/QueryGenerator.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/QueryGenerator.java
@@ -1049,8 +1049,11 @@ public class QueryGenerator {
         int indexToReplaceWithRegex = 1 + _random.nextInt(value.length() - 2);
         String regex = value.substring(1, indexToReplaceWithRegex) + ".*" + value.substring(indexToReplaceWithRegex + 1,
             value.length() - 1);
-        String regexpPredicate = String.format(" REGEXP_LIKE(%s, '%s')", columnName, regex);
-        String h2RegexpPredicate = String.format(" REGEXP_LIKE(`%s`, '%s', 'i')", columnName, regex);
+        boolean caseSensitive = _random.nextBoolean();
+        String regexpPredicate =
+            String.format(" REGEXP_LIKE(%s, '%s', '%s')", columnName, regex, caseSensitive ? "c" : "i");
+        String h2RegexpPredicate =
+            String.format(" REGEXP_LIKE(`%s`, '%s', '%s')", columnName, regex, caseSensitive ? "c" : "i");
         return new StringQueryFragment(regexpPredicate, h2RegexpPredicate);
       } else {
         String equalsPredicate = String.format("%s = %s", columnName, value);


### PR DESCRIPTION
- Case sensitivity handling for `REGEXP_LIKE` was changed in https://github.com/apache/pinot/pull/16276. Earlier, `REGEXP_LIKE` was case insensitive by default and now it's case sensitive by default (similar to most other databases).
- Sample test failure due to the above change - https://github.com/apache/pinot/actions/runs/17491358467/job/49681766751?pr=16762.
- This patch enhances the query generator to randomly test both kinds of regex predicate matches (case sensitive and insensitive). Earlier, Pinot didn't support configuring this behavior for the `REGEXP_LIKE` predicate and hence the query generator had the hardcoded assumption that the predicate was case insensitive.