### PR TITLE
Implement allowPartitionRemapping feature for segment partition metadata management

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/manager/BaseBrokerRoutingManager.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/manager/BaseBrokerRoutingManager.java
@@ -813,7 +813,7 @@ public abstract class BaseBrokerRoutingManager implements RoutingManager, Cluste
                 tableNameWithType, partitionConfig.getKey());
             partitionMetadataManager = new SegmentPartitionMetadataManager(tableNameWithType, partitionConfig.getKey(),
                 partitionConfig.getValue().getFunctionName(), partitionConfig.getValue().getNumPartitions(),
-                _newSegmentExpirationMs);
+                _newSegmentExpirationMs, partitionConfig.getValue().isAllowPartitionRemapping());
           } else {
             LOGGER.warn(
                 "Cannot enable SegmentPartitionMetadataManager for table: {} with multiple partition columns: {}",

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpartition/SegmentPartitionMetadataManager.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpartition/SegmentPartitionMetadataManager.java
@@ -40,6 +40,7 @@ import org.apache.pinot.core.routing.TablePartitionReplicatedServersInfo;
 import org.apache.pinot.core.routing.TablePartitionReplicatedServersInfo.PartitionInfo;
 import org.apache.pinot.segment.spi.partition.PartitionFunction;
 import org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.SegmentStateModel;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -64,6 +65,7 @@ public class SegmentPartitionMetadataManager implements SegmentZkMetadataFetchLi
   private final String _partitionFunctionName;
   private final int _numPartitions;
   private final long _newSegmentExpirationMs;
+  private final boolean _allowPartitionRemapping;
 
   // cache-able content, only follow changes if onlineSegments list (of ideal-state) is changed.
   private final Map<String, SegmentInfo> _segmentInfoMap = new HashMap<>();
@@ -73,12 +75,13 @@ public class SegmentPartitionMetadataManager implements SegmentZkMetadataFetchLi
   private transient TablePartitionReplicatedServersInfo _tablePartitionReplicatedServersInfo;
 
   public SegmentPartitionMetadataManager(String tableNameWithType, String partitionColumn, String partitionFunctionName,
-      int numPartitions, long newSegmentExpirationMs) {
+      int numPartitions, long newSegmentExpirationMs, boolean allowPartitionRemapping) {
     _tableNameWithType = tableNameWithType;
     _partitionColumn = partitionColumn;
     _partitionFunctionName = partitionFunctionName;
     _numPartitions = numPartitions;
     _newSegmentExpirationMs = newSegmentExpirationMs;
+    _allowPartitionRemapping = allowPartitionRemapping;
   }
 
   @Override
@@ -98,8 +101,11 @@ public class SegmentPartitionMetadataManager implements SegmentZkMetadataFetchLi
   private int getPartitionId(String segment, @Nullable ZNRecord znRecord) {
     SegmentPartitionInfo segmentPartitionInfo =
         SegmentPartitionUtils.extractPartitionInfo(_tableNameWithType, _partitionColumn, segment, znRecord);
-    if (segmentPartitionInfo == null || segmentPartitionInfo == SegmentPartitionUtils.INVALID_PARTITION_INFO) {
+    if (segmentPartitionInfo == null) {
       return INVALID_PARTITION_ID;
+    }
+    if (segmentPartitionInfo == SegmentPartitionUtils.INVALID_PARTITION_INFO) {
+      return getPartitionIdFromSegmentName(segment);
     }
     if (!_partitionColumn.equals(segmentPartitionInfo.getPartitionColumn())) {
       return INVALID_PARTITION_ID;
@@ -108,14 +114,43 @@ public class SegmentPartitionMetadataManager implements SegmentZkMetadataFetchLi
     if (!_partitionFunctionName.equalsIgnoreCase(partitionFunction.getName())) {
       return INVALID_PARTITION_ID;
     }
-    if (_numPartitions != partitionFunction.getNumPartitions()) {
+    int numSegmentPartitions = partitionFunction.getNumPartitions();
+    if (_allowPartitionRemapping) {
+      // Ensure segment partitions can be evenly distributed across table partitions.
+      // For example, 8 Kafka partitions can be remapped to 4 Pinot partitions (8 % 4 = 0),
+      // but 8 partitions cannot be remapped to 3 partitions (8 % 3 != 0).
+      if (numSegmentPartitions % _numPartitions != 0) {
+        return INVALID_PARTITION_ID;
+      }
+    } else if (numSegmentPartitions != _numPartitions) {
       return INVALID_PARTITION_ID;
     }
     Set<Integer> partitions = segmentPartitionInfo.getPartitions();
     if (partitions.size() != 1) {
       return INVALID_PARTITION_ID;
     }
-    return partitions.iterator().next();
+    return getValidMetadataPartitionId(partitions.iterator().next(), numSegmentPartitions);
+  }
+
+  private int getValidMetadataPartitionId(int partitionId, int numSegmentPartitions) {
+    if (partitionId < 0 || partitionId >= numSegmentPartitions) {
+      return INVALID_PARTITION_ID;
+    }
+    return _allowPartitionRemapping ? partitionId % _numPartitions : partitionId;
+  }
+
+  private int getPartitionIdFromSegmentName(String segment) {
+    if (!TableNameBuilder.isRealtimeTableResource(_tableNameWithType)) {
+      return INVALID_PARTITION_ID;
+    }
+    Integer partitionId = SegmentUtils.getPartitionIdFromSegmentName(segment);
+    if (partitionId == null || partitionId < 0) {
+      return INVALID_PARTITION_ID;
+    }
+    if (_allowPartitionRemapping) {
+      return partitionId % _numPartitions;
+    }
+    return partitionId < _numPartitions ? partitionId : INVALID_PARTITION_ID;
   }
 
   private static long getCreationTimeMs(@Nullable ZNRecord znRecord) {

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentpartition/SegmentPartitionMetadataManagerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentpartition/SegmentPartitionMetadataManagerTest.java
@@ -42,12 +42,14 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import static org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.SegmentStateModel.CONSUMING;
 import static org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.SegmentStateModel.ONLINE;
 import static org.testng.Assert.*;
 
 
 public class SegmentPartitionMetadataManagerTest extends ControllerTest {
   private static final String OFFLINE_TABLE_NAME = "testTable_OFFLINE";
+  private static final String REALTIME_TABLE_NAME = "testTable_REALTIME";
   private static final String PARTITION_COLUMN = "memberId";
   private static final String PARTITION_COLUMN_FUNC = "Murmur";
   private static final int NUM_PARTITIONS = 2;
@@ -85,7 +87,7 @@ public class SegmentPartitionMetadataManagerTest extends ControllerTest {
 
     SegmentPartitionMetadataManager partitionMetadataManager =
         new SegmentPartitionMetadataManager(OFFLINE_TABLE_NAME, PARTITION_COLUMN, PARTITION_COLUMN_FUNC, NUM_PARTITIONS,
-            TimeUnit.MINUTES.toMillis(5));
+            TimeUnit.MINUTES.toMillis(5), false);
     SegmentZkMetadataFetcher segmentZkMetadataFetcher =
         new SegmentZkMetadataFetcher(OFFLINE_TABLE_NAME, _propertyStore);
     segmentZkMetadataFetcher.register(partitionMetadataManager);
@@ -285,6 +287,231 @@ public class SegmentPartitionMetadataManagerTest extends ControllerTest {
     assertEquals(tablePartitionReplicatedServersInfo.getSegmentsWithInvalidPartition().get(0), segmentInvalid);
   }
 
+  @Test
+  public void testPartitionIdRemappingLogic() {
+    ExternalView externalView = new ExternalView(OFFLINE_TABLE_NAME);
+    Map<String, Map<String, String>> segmentAssignment = externalView.getRecord().getMapFields();
+    Set<String> onlineSegments = new HashSet<>();
+    IdealState idealState = new IdealState(OFFLINE_TABLE_NAME);
+
+    // Create partition metadata manager with remapping enabled (4 table partitions from 8 segment partitions)
+    SegmentPartitionMetadataManager partitionMetadataManager =
+        new SegmentPartitionMetadataManager(OFFLINE_TABLE_NAME, PARTITION_COLUMN, PARTITION_COLUMN_FUNC, 4,
+            TimeUnit.MINUTES.toMillis(5), true);
+    SegmentZkMetadataFetcher segmentZkMetadataFetcher =
+        new SegmentZkMetadataFetcher(OFFLINE_TABLE_NAME, _propertyStore);
+    segmentZkMetadataFetcher.register(partitionMetadataManager);
+
+    // Initial state should be empty
+    segmentZkMetadataFetcher.init(idealState, externalView, onlineSegments);
+    TablePartitionReplicatedServersInfo tablePartitionReplicatedServersInfo = partitionMetadataManager
+        .getTablePartitionReplicatedServersInfo();
+    assertEquals(tablePartitionReplicatedServersInfo.getPartitionInfoMap(),
+        new TablePartitionReplicatedServersInfo.PartitionInfo[4]);
+
+    // Add segments with partition IDs 0, 4 (should both map to partition 0 via modulo)
+    String segment0 = "segment_partition_0";
+    String segment4 = "segment_partition_4";
+    onlineSegments.add(segment0);
+    onlineSegments.add(segment4);
+    segmentAssignment.put(segment0, Collections.singletonMap(SERVER_0, ONLINE));
+    segmentAssignment.put(segment4, Collections.singletonMap(SERVER_1, ONLINE));
+
+    // Set metadata for segments with 8 total partitions (will be remapped to 4)
+    setSegmentZKMetadata(segment0, PARTITION_COLUMN_FUNC, 8, 0, 0L);
+    setSegmentZKMetadata(segment4, PARTITION_COLUMN_FUNC, 8, 4, 0L);
+
+    segmentZkMetadataFetcher.onAssignmentChange(idealState, externalView, onlineSegments);
+    tablePartitionReplicatedServersInfo = partitionMetadataManager.getTablePartitionReplicatedServersInfo();
+    TablePartitionReplicatedServersInfo.PartitionInfo[] partitionInfoMap = tablePartitionReplicatedServersInfo
+        .getPartitionInfoMap();
+
+    // Both segments should be in partition 0 (0 % 4 = 0, 4 % 4 = 0)
+    assertNull(partitionInfoMap[1]);
+    assertNull(partitionInfoMap[2]);
+    assertNull(partitionInfoMap[3]);
+    // No single server has all segments in partition 0, so fullyReplicatedServers should be empty
+    assertTrue(partitionInfoMap[0]._fullyReplicatedServers.isEmpty());
+    assertEqualsNoOrder(partitionInfoMap[0]._segments.toArray(), new String[]{segment0, segment4});
+
+    // Add segments with partition IDs 1, 5 (should both map to partition 1)
+    String segment1 = "segment_partition_1";
+    String segment5 = "segment_partition_5";
+    onlineSegments.add(segment1);
+    onlineSegments.add(segment5);
+    segmentAssignment.put(segment1, Collections.singletonMap(SERVER_0, ONLINE));
+    segmentAssignment.put(segment5, Collections.singletonMap(SERVER_0, ONLINE));
+
+    setSegmentZKMetadata(segment1, PARTITION_COLUMN_FUNC, 8, 1, 0L);
+    setSegmentZKMetadata(segment5, PARTITION_COLUMN_FUNC, 8, 5, 0L);
+
+    segmentZkMetadataFetcher.onAssignmentChange(idealState, externalView, onlineSegments);
+    tablePartitionReplicatedServersInfo = partitionMetadataManager.getTablePartitionReplicatedServersInfo();
+    partitionInfoMap = tablePartitionReplicatedServersInfo.getPartitionInfoMap();
+
+    // Partition 1 should have both segments on SERVER_0, making it fully replicated
+    assertEquals(partitionInfoMap[1]._fullyReplicatedServers, Collections.singleton(SERVER_0));
+    assertEqualsNoOrder(partitionInfoMap[1]._segments.toArray(), new String[]{segment1, segment5});
+
+    // Add segments with partition IDs 2, 6 (should both map to partition 2)
+    String segment2 = "segment_partition_2";
+    String segment6 = "segment_partition_6";
+    onlineSegments.add(segment2);
+    onlineSegments.add(segment6);
+    segmentAssignment.put(segment2, Map.of(SERVER_0, ONLINE, SERVER_1, ONLINE));
+    segmentAssignment.put(segment6, Map.of(SERVER_0, ONLINE, SERVER_1, ONLINE));
+
+    setSegmentZKMetadata(segment2, PARTITION_COLUMN_FUNC, 8, 2, 0L);
+    setSegmentZKMetadata(segment6, PARTITION_COLUMN_FUNC, 8, 6, 0L);
+
+    segmentZkMetadataFetcher.onAssignmentChange(idealState, externalView, onlineSegments);
+    tablePartitionReplicatedServersInfo = partitionMetadataManager.getTablePartitionReplicatedServersInfo();
+    partitionInfoMap = tablePartitionReplicatedServersInfo.getPartitionInfoMap();
+
+    // Partition 2 should have both segments on both servers, making both servers fully replicated
+    assertEquals(partitionInfoMap[2]._fullyReplicatedServers, ImmutableSet.of(SERVER_0, SERVER_1));
+    assertEqualsNoOrder(partitionInfoMap[2]._segments.toArray(), new String[]{segment2, segment6});
+
+    assertTrue(tablePartitionReplicatedServersInfo.getSegmentsWithInvalidPartition().isEmpty());
+  }
+
+  @Test
+  public void testPartitionIdRemappingInvalidCases() {
+    ExternalView externalView = new ExternalView(OFFLINE_TABLE_NAME);
+    Map<String, Map<String, String>> segmentAssignment = externalView.getRecord().getMapFields();
+    Set<String> onlineSegments = new HashSet<>();
+    IdealState idealState = new IdealState(OFFLINE_TABLE_NAME);
+
+    // Create partition metadata manager with remapping enabled but invalid divisibility (3 table partitions from 8
+    // segment partitions)
+    SegmentPartitionMetadataManager partitionMetadataManager =
+        new SegmentPartitionMetadataManager(OFFLINE_TABLE_NAME, PARTITION_COLUMN, PARTITION_COLUMN_FUNC, 3,
+            TimeUnit.MINUTES.toMillis(5), true);
+    SegmentZkMetadataFetcher segmentZkMetadataFetcher =
+        new SegmentZkMetadataFetcher(OFFLINE_TABLE_NAME, _propertyStore);
+    segmentZkMetadataFetcher.register(partitionMetadataManager);
+
+    segmentZkMetadataFetcher.init(idealState, externalView, onlineSegments);
+
+    // Add segment with partition ID from 8-partition scheme (should be invalid because 8 % 3 != 0)
+    String invalidSegment = "invalid_segment";
+    onlineSegments.add(invalidSegment);
+    segmentAssignment.put(invalidSegment, Collections.singletonMap(SERVER_0, ONLINE));
+    setSegmentZKMetadata(invalidSegment, PARTITION_COLUMN_FUNC, 8, 0, 0L);
+
+    segmentZkMetadataFetcher.onAssignmentChange(idealState, externalView, onlineSegments);
+    TablePartitionReplicatedServersInfo tablePartitionReplicatedServersInfo = partitionMetadataManager
+        .getTablePartitionReplicatedServersInfo();
+
+    // Segment should be marked as invalid due to non-divisible partition count
+    assertEquals(tablePartitionReplicatedServersInfo.getSegmentsWithInvalidPartition(),
+        Collections.singletonList(invalidSegment));
+    assertEquals(tablePartitionReplicatedServersInfo.getPartitionInfoMap(),
+        new TablePartitionReplicatedServersInfo.PartitionInfo[3]);
+  }
+
+  @Test
+  public void testPartitionIdRemappingForConsumingSegments() {
+    ExternalView externalView = new ExternalView(REALTIME_TABLE_NAME);
+    Map<String, Map<String, String>> segmentAssignment = externalView.getRecord().getMapFields();
+    Set<String> onlineSegments = new HashSet<>();
+    IdealState idealState = new IdealState(REALTIME_TABLE_NAME);
+
+    SegmentPartitionMetadataManager partitionMetadataManager =
+        new SegmentPartitionMetadataManager(REALTIME_TABLE_NAME, PARTITION_COLUMN, PARTITION_COLUMN_FUNC, 4,
+            TimeUnit.MINUTES.toMillis(5), true);
+    SegmentZkMetadataFetcher segmentZkMetadataFetcher =
+        new SegmentZkMetadataFetcher(REALTIME_TABLE_NAME, _propertyStore);
+    segmentZkMetadataFetcher.register(partitionMetadataManager);
+    segmentZkMetadataFetcher.init(idealState, externalView, onlineSegments);
+
+    String llcSegmentP1 = "testTable__1__100__20240520T1234Z";
+    String llcSegmentP5 = "testTable__5__101__20240520T1235Z";
+    onlineSegments.add(llcSegmentP1);
+    onlineSegments.add(llcSegmentP5);
+    segmentAssignment.put(llcSegmentP1, Collections.singletonMap(SERVER_0, CONSUMING));
+    segmentAssignment.put(llcSegmentP5, Collections.singletonMap(SERVER_0, CONSUMING));
+    setSegmentZKMetadataWithoutPartitionMetadata(REALTIME_TABLE_NAME, llcSegmentP1);
+    setSegmentZKMetadataWithoutPartitionMetadata(REALTIME_TABLE_NAME, llcSegmentP5);
+
+    segmentZkMetadataFetcher.onAssignmentChange(idealState, externalView, onlineSegments);
+    TablePartitionReplicatedServersInfo tablePartitionReplicatedServersInfo =
+        partitionMetadataManager.getTablePartitionReplicatedServersInfo();
+    TablePartitionReplicatedServersInfo.PartitionInfo[] partitionInfoMap =
+        tablePartitionReplicatedServersInfo.getPartitionInfoMap();
+
+    assertNull(partitionInfoMap[0]);
+    assertEquals(partitionInfoMap[1]._fullyReplicatedServers, Collections.singleton(SERVER_0));
+    assertEqualsNoOrder(partitionInfoMap[1]._segments.toArray(), new String[]{llcSegmentP1, llcSegmentP5});
+    assertNull(partitionInfoMap[2]);
+    assertNull(partitionInfoMap[3]);
+    assertTrue(tablePartitionReplicatedServersInfo.getSegmentsWithInvalidPartition().isEmpty());
+  }
+
+  @Test
+  public void testPartitionIdRemappingDisabled() {
+    ExternalView externalView = new ExternalView(OFFLINE_TABLE_NAME);
+    Map<String, Map<String, String>> segmentAssignment = externalView.getRecord().getMapFields();
+    Set<String> onlineSegments = new HashSet<>();
+    IdealState idealState = new IdealState(OFFLINE_TABLE_NAME);
+
+    // Create partition metadata manager with remapping disabled (4 table partitions, remapping = false)
+    SegmentPartitionMetadataManager partitionMetadataManager =
+        new SegmentPartitionMetadataManager(OFFLINE_TABLE_NAME, PARTITION_COLUMN, PARTITION_COLUMN_FUNC, 4,
+            TimeUnit.MINUTES.toMillis(5), false);
+    SegmentZkMetadataFetcher segmentZkMetadataFetcher =
+        new SegmentZkMetadataFetcher(OFFLINE_TABLE_NAME, _propertyStore);
+    segmentZkMetadataFetcher.register(partitionMetadataManager);
+
+    segmentZkMetadataFetcher.init(idealState, externalView, onlineSegments);
+
+    // Add segment with matching partition count (4 partitions) - should be valid
+    String validSegment = "valid_segment";
+    onlineSegments.add(validSegment);
+    segmentAssignment.put(validSegment, Collections.singletonMap(SERVER_0, ONLINE));
+    setSegmentZKMetadata(validSegment, PARTITION_COLUMN_FUNC, 4, 0, 0L);
+
+    segmentZkMetadataFetcher.onAssignmentChange(idealState, externalView, onlineSegments);
+    TablePartitionReplicatedServersInfo tablePartitionReplicatedServersInfo = partitionMetadataManager
+        .getTablePartitionReplicatedServersInfo();
+    TablePartitionReplicatedServersInfo.PartitionInfo[] partitionInfoMap = tablePartitionReplicatedServersInfo
+        .getPartitionInfoMap();
+
+    // Valid segment should be placed in partition 0
+    assertEquals(partitionInfoMap[0]._fullyReplicatedServers, Collections.singleton(SERVER_0));
+    assertEquals(partitionInfoMap[0]._segments, Collections.singleton(validSegment));
+    assertTrue(tablePartitionReplicatedServersInfo.getSegmentsWithInvalidPartition().isEmpty());
+
+    // Add segment with different partition count (8 partitions) - should be invalid when remapping is disabled
+    String invalidSegment = "invalid_segment_8_partitions";
+    onlineSegments.add(invalidSegment);
+    segmentAssignment.put(invalidSegment, Collections.singletonMap(SERVER_1, ONLINE));
+    setSegmentZKMetadata(invalidSegment, PARTITION_COLUMN_FUNC, 8, 0, 0L);
+
+    segmentZkMetadataFetcher.onAssignmentChange(idealState, externalView, onlineSegments);
+    tablePartitionReplicatedServersInfo = partitionMetadataManager.getTablePartitionReplicatedServersInfo();
+    partitionInfoMap = tablePartitionReplicatedServersInfo.getPartitionInfoMap();
+
+    // Invalid segment should be marked as invalid, valid segment should remain in partition 0
+    assertEquals(partitionInfoMap[0]._fullyReplicatedServers, Collections.singleton(SERVER_0));
+    assertEquals(partitionInfoMap[0]._segments, Collections.singleton(validSegment));
+    assertEquals(tablePartitionReplicatedServersInfo.getSegmentsWithInvalidPartition(),
+        Collections.singletonList(invalidSegment));
+
+    // Add another segment with different partition count (2 partitions) - should also be invalid
+    String invalidSegment2 = "invalid_segment_2_partitions";
+    onlineSegments.add(invalidSegment2);
+    segmentAssignment.put(invalidSegment2, Collections.singletonMap(SERVER_0, ONLINE));
+    setSegmentZKMetadata(invalidSegment2, PARTITION_COLUMN_FUNC, 2, 0, 0L);
+
+    segmentZkMetadataFetcher.onAssignmentChange(idealState, externalView, onlineSegments);
+    tablePartitionReplicatedServersInfo = partitionMetadataManager.getTablePartitionReplicatedServersInfo();
+
+    // Both invalid segments should be marked as invalid
+    assertEqualsNoOrder(tablePartitionReplicatedServersInfo.getSegmentsWithInvalidPartition().toArray(),
+        new String[]{invalidSegment, invalidSegment2});
+  }
+
   private void setSegmentZKMetadata(String segment, String partitionFunction, int numPartitions, int partitionId,
       long creationTimeMs) {
     SegmentZKMetadata segmentZKMetadata = new SegmentZKMetadata(segment);
@@ -292,5 +519,11 @@ public class SegmentPartitionMetadataManagerTest extends ControllerTest {
         new ColumnPartitionMetadata(partitionFunction, numPartitions, Collections.singleton(partitionId), null))));
     segmentZKMetadata.setCreationTime(creationTimeMs);
     ZKMetadataProvider.setSegmentZKMetadata(_propertyStore, OFFLINE_TABLE_NAME, segmentZKMetadata);
+  }
+
+  private void setSegmentZKMetadataWithoutPartitionMetadata(String tableNameWithType, String segment) {
+    SegmentZKMetadata segmentZKMetadata = new SegmentZKMetadata(segment);
+    segmentZKMetadata.setCreationTime(0L);
+    ZKMetadataProvider.setSegmentZKMetadata(_propertyStore, tableNameWithType, segmentZKMetadata);
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ColumnPartitionConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ColumnPartitionConfig.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.spi.config.table;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import java.util.Map;
@@ -30,20 +31,27 @@ public class ColumnPartitionConfig extends BaseJsonConfig {
   private final String _functionName;
   private final int _numPartitions;
   private final Map<String, String> _functionConfig;
+  private final boolean _allowPartitionRemapping;
 
   public ColumnPartitionConfig(String functionName, int numPartitions) {
-    this(functionName, numPartitions, null);
+    this(functionName, numPartitions, null, null);
+  }
+
+  public ColumnPartitionConfig(String functionName, int numPartitions, @Nullable Map<String, String> functionConfig) {
+    this(functionName, numPartitions, functionConfig, null);
   }
 
   @JsonCreator
   public ColumnPartitionConfig(@JsonProperty(value = "functionName", required = true) String functionName,
       @JsonProperty(value = "numPartitions", required = true) int numPartitions,
-      @JsonProperty(value = "functionConfig") @Nullable Map<String, String> functionConfig) {
+      @JsonProperty(value = "functionConfig") @Nullable Map<String, String> functionConfig,
+      @JsonProperty(value = "allowPartitionRemapping") @Nullable Boolean allowPartitionRemapping) {
     Preconditions.checkArgument(functionName != null, "'functionName' must be configured");
     Preconditions.checkArgument(numPartitions > 0, "'numPartitions' must be positive");
     _functionName = functionName;
     _numPartitions = numPartitions;
     _functionConfig = functionConfig;
+    _allowPartitionRemapping = (allowPartitionRemapping != null) ? allowPartitionRemapping : false;
   }
 
   /**
@@ -72,5 +80,14 @@ public class ColumnPartitionConfig extends BaseJsonConfig {
    */
   public int getNumPartitions() {
     return _numPartitions;
+  }
+
+  /// Returns whether segment partition ids may be remapped to this column's configured partition count.
+  ///
+  /// This is useful when the upstream stream partition count expands but Pinot should keep routing by the existing
+  /// logical partition count.
+  @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+  public boolean isAllowPartitionRemapping() {
+    return _allowPartitionRemapping;
   }
 }


### PR DESCRIPTION
## Summary

## Background
The use case is I have a fairly large table, due to some real world event, I need to scale the ingestion, so in general the way is to double the Kafka partitions, however after the event, I want to shrink the kafka thing back.

So one of the best practice is to double the kafka partition count but keep pinot side partitioning. So old partition 0 will be halved.

This can avoid heavy data rebalance and re-ingestion. ( For a table with 100+TB it's almost impossible to re-ingestion)

Since this PR: https://github.com/apache/pinot/pull/11476 ensures all the consuming/realtime segments partition mapping follows the kafka partition way. The the key thing here is to ensure the SegmentPartitionManager able to produce the desired partitionId.

This PR implements the allowPartitionRemapping feature for segment partition metadata management in Apache Pinot. This feature enables remapping of higher Kafka partition IDs to lower Pinot partition numbers using modulo operation, which is useful when scaling Kafka partitions while maintaining fewer logical partitions in Pinot.

## Feature Implementation

### Core Changes:

1. **ColumnPartitionConfig.java** - Added allowPartitionRemapping field and getter method
   - New boolean field _allowPartitionRemapping to control remapping behavior
   - JSON property allowPartitionRemapping for table configuration

2. **SegmentPartitionMetadataManager.java** - Implemented partition remapping logic
   - Added _allowPartitionRemapping field to constructor
   - Implemented modulo-based remapping: partition_id % numPartitions when enabled
   - Enforces strict partition count matching when disabled

3. **BrokerRoutingManager.java** - Integrated allowPartitionRemapping flag
   - Extracts allowPartitionRemapping from table configuration
   - Passes flag to SegmentPartitionMetadataManager constructor

### Remapping Logic:

- **When allowPartitionRemapping=true**: Supports modulo-based remapping (e.g., 8 Kafka partitions to 4 Pinot partitions)
  - Partition 0,4 maps to Pinot partition 0
  - Partition 1,5 maps to Pinot partition 1  
  - Partition 2,6 maps to Pinot partition 2
  - Partition 3,7 maps to Pinot partition 3

- **When allowPartitionRemapping=false**: Enforces exact partition count matching
  - Only segments with matching partition counts are accepted
  - Segments with different partition counts are marked invalid

## Test Coverage

Added comprehensive test suite with 3 new test methods:

1. **testPartitionIdRemappingLogic()** - Validates core remapping functionality
2. **testPartitionIdRemappingInvalidCases()** - Tests invalid remapping scenarios  
3. **testPartitionIdRemappingDisabled()** - Tests strict matching when feature is disabled

## Use Case

This feature addresses the common scenario where users need to:
- Scale Kafka partitions (e.g., from 4 to 8 partitions)
- Maintain existing Pinot partition structure (4 partitions)
- Remap higher partition IDs using modulo operation for consistent data distribution
