### PR TITLE
[minion] configure numConcurrentTasksPerInstance for minion tenant

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
@@ -252,9 +252,9 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
                 + "controlled by the cluster config %s which is set based on controller's performance.", taskType,
             tableName, pinotTaskConfigs.size(), maxNumberOfSubTasks, MinionConstants.MAX_ALLOWED_SUB_TASKS_KEY);
         message += "Optimise the task config or reduce tableMaxNumTasks to avoid the error";
-          // We throw an exception to notify the user
-          // This is to ensure that the user is aware of the task generation limit
-          throw new RuntimeException(message);
+        // We throw an exception to notify the user
+        // This is to ensure that the user is aware of the task generation limit
+        throw new RuntimeException(message);
       }
       pinotTaskConfigs.forEach(pinotTaskConfig -> pinotTaskConfig.getConfigs()
           .computeIfAbsent(MinionConstants.TRIGGERED_BY, k -> CommonConstants.TaskTriggers.ADHOC_TRIGGER.name()));
@@ -262,8 +262,9 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
       _controllerMetrics.addMeteredTableValue(taskType, ControllerMeter.NUMBER_ADHOC_TASKS_SUBMITTED, 1);
       responseMap.put(tableNameWithType,
           _helixTaskResourceManager.submitTask(parentTaskName, pinotTaskConfigs, minionInstanceTag,
-              taskGenerator.getTaskTimeoutMs(), taskGenerator.getNumConcurrentTasksPerInstance(minionInstanceTag),
-              taskGenerator.getMaxAttemptsPerTask()));
+              taskGenerator.getTaskTimeoutMs(minionInstanceTag),
+              taskGenerator.getNumConcurrentTasksPerInstance(minionInstanceTag),
+              taskGenerator.getMaxAttemptsPerTask(minionInstanceTag)));
     }
     if (responseMap.isEmpty()) {
       LOGGER.warn("No task submitted for tableName: {}", tableName);
@@ -727,7 +728,7 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
    */
   protected TaskSchedulingInfo scheduleTask(PinotTaskGenerator taskGenerator, List<TableConfig> enabledTableConfigs,
       boolean isLeader, @Nullable String minionInstanceTagForTask, String triggeredBy) {
-      TaskSchedulingInfo response = new TaskSchedulingInfo();
+    TaskSchedulingInfo response = new TaskSchedulingInfo();
     String taskType = taskGenerator.getTaskType();
     List<String> enabledTables =
         enabledTableConfigs.stream().map(TableConfig::getTableName).collect(Collectors.toList());
@@ -837,8 +838,9 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
           pinotTaskConfigs.forEach(pinotTaskConfig ->
               pinotTaskConfig.getConfigs().computeIfAbsent(MinionConstants.TRIGGERED_BY, k -> triggeredBy));
           String submittedTaskName = _helixTaskResourceManager.submitTask(pinotTaskConfigs, minionInstanceTag,
-              taskGenerator.getTaskTimeoutMs(), taskGenerator.getNumConcurrentTasksPerInstance(minionInstanceTag),
-              taskGenerator.getMaxAttemptsPerTask());
+              taskGenerator.getTaskTimeoutMs(minionInstanceTag),
+              taskGenerator.getNumConcurrentTasksPerInstance(minionInstanceTag),
+              taskGenerator.getMaxAttemptsPerTask(minionInstanceTag));
           submittedTaskNames.add(submittedTaskName);
           _controllerMetrics.addMeteredTableValue(taskType, ControllerMeter.NUMBER_TASKS_SUBMITTED, numTasks);
         }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
@@ -262,7 +262,7 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
       _controllerMetrics.addMeteredTableValue(taskType, ControllerMeter.NUMBER_ADHOC_TASKS_SUBMITTED, 1);
       responseMap.put(tableNameWithType,
           _helixTaskResourceManager.submitTask(parentTaskName, pinotTaskConfigs, minionInstanceTag,
-              taskGenerator.getTaskTimeoutMs(), taskGenerator.getNumConcurrentTasksPerInstance(),
+              taskGenerator.getTaskTimeoutMs(), taskGenerator.getNumConcurrentTasksPerInstance(minionInstanceTag),
               taskGenerator.getMaxAttemptsPerTask()));
     }
     if (responseMap.isEmpty()) {
@@ -837,7 +837,7 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
           pinotTaskConfigs.forEach(pinotTaskConfig ->
               pinotTaskConfig.getConfigs().computeIfAbsent(MinionConstants.TRIGGERED_BY, k -> triggeredBy));
           String submittedTaskName = _helixTaskResourceManager.submitTask(pinotTaskConfigs, minionInstanceTag,
-              taskGenerator.getTaskTimeoutMs(), taskGenerator.getNumConcurrentTasksPerInstance(),
+              taskGenerator.getTaskTimeoutMs(), taskGenerator.getNumConcurrentTasksPerInstance(minionInstanceTag),
               taskGenerator.getMaxAttemptsPerTask());
           submittedTaskNames.add(submittedTaskName);
           _controllerMetrics.addMeteredTableValue(taskType, ControllerMeter.NUMBER_TASKS_SUBMITTED, numTasks);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/generator/BaseTaskGenerator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/generator/BaseTaskGenerator.java
@@ -53,51 +53,16 @@ public abstract class BaseTaskGenerator implements PinotTaskGenerator {
   }
 
   @Override
-  public long getTaskTimeoutMs() {
-    String taskType = getTaskType();
-    String configKey = taskType + MinionConstants.TIMEOUT_MS_KEY_SUFFIX;
-    String configValue = _clusterInfoAccessor.getClusterConfig(configKey);
-    if (configValue != null) {
-      try {
-        return Long.parseLong(configValue);
-      } catch (Exception e) {
-        LOGGER.error("Invalid cluster config {}: '{}'", configKey, configValue, e);
-      }
-    }
-    return JobConfig.DEFAULT_TIMEOUT_PER_TASK;
+  public long getTaskTimeoutMs(String minionTag) {
+    return TaskGeneratorUtils.getClusterMinionConfigValue(getTaskType(), MinionConstants.TIMEOUT_MS_KEY_SUFFIX,
+        minionTag, JobConfig.DEFAULT_TIMEOUT_PER_TASK, Long.class, _clusterInfoAccessor);
   }
 
   @Override
   public int getNumConcurrentTasksPerInstance(String minionTag) {
-    String taskType = getTaskType();
-
-    // Priority 1: Check minion tenant specific cluster config
-    if (minionTag != null) {
-      String tenantSpecificConfigKey = taskType + "." + minionTag
-          + MinionConstants.NUM_CONCURRENT_TASKS_PER_INSTANCE_KEY_SUFFIX;
-      String configValue = _clusterInfoAccessor.getClusterConfig(tenantSpecificConfigKey);
-      if (configValue != null) {
-        try {
-          return Integer.parseInt(configValue);
-        } catch (Exception e) {
-          LOGGER.error("Invalid config {}: '{}'", tenantSpecificConfigKey, configValue, e);
-        }
-      }
-    }
-
-    // Priority 2: Check task type specific cluster config
-    String taskTypeConfigKey = taskType + MinionConstants.NUM_CONCURRENT_TASKS_PER_INSTANCE_KEY_SUFFIX;
-    String configValue = _clusterInfoAccessor.getClusterConfig(taskTypeConfigKey);
-    if (configValue != null) {
-      try {
-        return Integer.parseInt(configValue);
-      } catch (Exception e) {
-        LOGGER.error("Invalid config {}: '{}'", taskTypeConfigKey, configValue, e);
-      }
-    }
-
-    // Priority 3: Default value
-    return JobConfig.DEFAULT_NUM_CONCURRENT_TASKS_PER_INSTANCE;
+    return TaskGeneratorUtils.getClusterMinionConfigValue(getTaskType(),
+        MinionConstants.NUM_CONCURRENT_TASKS_PER_INSTANCE_KEY_SUFFIX,
+        minionTag, JobConfig.DEFAULT_NUM_CONCURRENT_TASKS_PER_INSTANCE, Integer.class, _clusterInfoAccessor);
   }
 
   @Override
@@ -180,18 +145,10 @@ public abstract class BaseTaskGenerator implements PinotTaskGenerator {
   }
 
   @Override
-  public int getMaxAttemptsPerTask() {
-    String taskType = getTaskType();
-    String configKey = taskType + MinionConstants.MAX_ATTEMPTS_PER_TASK_KEY_SUFFIX;
-    String configValue = _clusterInfoAccessor.getClusterConfig(configKey);
-    if (configValue != null) {
-      try {
-        return Integer.parseInt(configValue);
-      } catch (Exception e) {
-        LOGGER.error("Invalid config {}: '{}'", configKey, configValue, e);
-      }
-    }
-    return MinionConstants.DEFAULT_MAX_ATTEMPTS_PER_TASK;
+  public int getMaxAttemptsPerTask(String minionTag) {
+    return TaskGeneratorUtils.getClusterMinionConfigValue(getTaskType(),
+        MinionConstants.MAX_ATTEMPTS_PER_TASK_KEY_SUFFIX, minionTag, MinionConstants.DEFAULT_MAX_ATTEMPTS_PER_TASK,
+        Integer.class, _clusterInfoAccessor);
   }
 
   /**
@@ -257,7 +214,7 @@ public abstract class BaseTaskGenerator implements PinotTaskGenerator {
     Map<String, String> baseConfigs = new HashMap<>();
     baseConfigs.put(MinionConstants.TABLE_NAME_KEY, tableConfig.getTableName());
     baseConfigs.put(MinionConstants.SEGMENT_NAME_KEY, StringUtils.join(segmentNames,
-          MinionConstants.SEGMENT_NAME_SEPARATOR));
+        MinionConstants.SEGMENT_NAME_SEPARATOR));
     return baseConfigs;
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/generator/PinotTaskGenerator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/generator/PinotTaskGenerator.java
@@ -58,12 +58,13 @@ public interface PinotTaskGenerator {
   /**
    * Generates a list of task based on the given table configs, it also gets list of existing task configs
    */
-  void generateTasks(List<TableConfig> tableConfigs, List<PinotTaskConfig> pinotTaskConfigs) throws Exception;
+  void generateTasks(List<TableConfig> tableConfigs, List<PinotTaskConfig> pinotTaskConfigs)
+      throws Exception;
 
   /**
    * Returns the timeout in milliseconds for each task, 3600000 (1 hour) by default.
    */
-  default long getTaskTimeoutMs() {
+  default long getTaskTimeoutMs(String minionTag) {
     return JobConfig.DEFAULT_TIMEOUT_PER_TASK;
   }
 
@@ -98,7 +99,7 @@ public interface PinotTaskGenerator {
   /**
    * Returns the maximum number of attempts per task, 1 by default.
    */
-  default int getMaxAttemptsPerTask() {
+  default int getMaxAttemptsPerTask(String minionTag) {
     return MinionConstants.DEFAULT_MAX_ATTEMPTS_PER_TASK;
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/generator/PinotTaskGenerator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/generator/PinotTaskGenerator.java
@@ -69,8 +69,15 @@ public interface PinotTaskGenerator {
 
   /**
    * Returns the maximum number of concurrent tasks allowed per instance, 1 by default.
+   * Priority order (highest to lowest):
+   * 1. Minion tenant specific cluster config: taskType.minionTag.numConcurrentTasksPerInstance
+   * 2. Task type cluster config: taskType.numConcurrentTasksPerInstance
+   * 3. Default value
+   *
+   * @param minionTag Minion instance tag/tenant (can be null)
+   * @return Number of concurrent tasks per instance
    */
-  default int getNumConcurrentTasksPerInstance() {
+  default int getNumConcurrentTasksPerInstance(String minionTag) {
     return JobConfig.DEFAULT_NUM_CONCURRENT_TASKS_PER_INSTANCE;
   }
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManagerStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManagerStatelessTest.java
@@ -616,7 +616,7 @@ public class PinotTaskManagerStatelessTest extends ControllerTest {
       }
 
       @Override
-      public int getNumConcurrentTasksPerInstance() {
+      public int getNumConcurrentTasksPerInstance(String minionTag) {
         return 5;
       }
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManagerStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManagerStatelessTest.java
@@ -611,7 +611,7 @@ public class PinotTaskManagerStatelessTest extends ControllerTest {
       }
 
       @Override
-      public long getTaskTimeoutMs() {
+      public long getTaskTimeoutMs(String minionTag) {
         return 10000; // 10 seconds
       }
 
@@ -621,7 +621,7 @@ public class PinotTaskManagerStatelessTest extends ControllerTest {
       }
 
       @Override
-      public int getMaxAttemptsPerTask() {
+      public int getMaxAttemptsPerTask(String minionTag) {
         return 5;
       }
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SimpleMinionClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SimpleMinionClusterIntegrationTest.java
@@ -45,6 +45,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.testng.Assert.*;
 
 
@@ -110,14 +111,14 @@ public class SimpleMinionClusterIntegrationTest extends ClusterTest {
   public void testTaskTimeout() {
     PinotTaskGenerator taskGenerator = _taskManager.getTaskGeneratorRegistry().getTaskGenerator(TASK_TYPE);
     assertNotNull(taskGenerator);
-    assertEquals(taskGenerator.getTaskTimeoutMs(), 600_000L);
+    assertEquals(taskGenerator.getTaskTimeoutMs(any(String.class)), 600_000L);
   }
 
   @Test
   public void testTaskMaxAttempts() {
     PinotTaskGenerator taskGenerator = _taskManager.getTaskGeneratorRegistry().getTaskGenerator(TASK_TYPE);
     assertNotNull(taskGenerator);
-    assertEquals(taskGenerator.getMaxAttemptsPerTask(), 2);
+    assertEquals(taskGenerator.getMaxAttemptsPerTask(any(String.class)), 2);
   }
 
   private void verifyTaskCount(String task, int errors, int waiting, int running, int total) {


### PR DESCRIPTION
`Configuration` `release-notes`
 
## Change
Configuration to define numConcurrentTasksPerInstance at minion tenant level.

## Description
Relates to tuning performance of minion task execution in issue: https://github.com/apache/pinot/issues/16461

Pinot controller uses cluster config `numConcurrentTasksPerInstance` to control max number of tasks that can run on a minion instance.
This is not extensible for minion tenants as the configuration is per taskType and not for (taskType, minion_tag).

This change allows one to define configuration as `taskType.minionTag.numConcurrentTasksPerInstance` along with `taskType.numConcurrentTasksPerInstance`.

## Changes
- Added a generic method in https://github.com/apache/pinot/pull/16777/files#diff-4f5cd74811801a0996235647327edbbde79bf234b953e3fc6e245003211bd7df to read config from cluster config in ZK based on priority order.
- The priority order to pick up the config is: `<taskType>.<minionTag>.<configKey> > <taskType>.<configKey> > <DefaultConfigValue>`

## Test plan
- Unit tests
- local cluster test validations
  