### PR TITLE
Make DefaultClusterConfigChangeHandler thread safe

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/config/DefaultClusterConfigChangeHandler.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/config/DefaultClusterConfigChangeHandler.java
@@ -18,11 +18,14 @@
  */
 package org.apache.pinot.common.config;
 
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CopyOnWriteArrayList;
 import org.apache.helix.NotificationContext;
 import org.apache.helix.api.listeners.BatchMode;
 import org.apache.helix.api.listeners.ClusterConfigChangeListener;
@@ -37,12 +40,12 @@ import org.slf4j.LoggerFactory;
 public class DefaultClusterConfigChangeHandler implements ClusterConfigChangeListener, PinotClusterConfigProvider {
   private static final Logger LOGGER = LoggerFactory.getLogger(DefaultClusterConfigChangeHandler.class);
 
-  private volatile Map<String, String> _properties;
-  private final List<PinotClusterConfigChangeListener> _clusterConfigChangeListeners;
+  private volatile ImmutableMap<String, String> _properties;
+  private final CopyOnWriteArrayList<PinotClusterConfigChangeListener> _clusterConfigChangeListeners;
 
   public DefaultClusterConfigChangeHandler() {
-    _properties = new HashMap<>();
-    _clusterConfigChangeListeners = new ArrayList<>();
+    _properties = ImmutableMap.of();
+    _clusterConfigChangeListeners = new CopyOnWriteArrayList<>();
   }
 
   @Override
@@ -53,13 +56,15 @@ public class DefaultClusterConfigChangeHandler implements ClusterConfigChangeLis
   }
 
   private synchronized void process(Map<String, String> properties) {
-    Set<String> changedProperties = getChangedProperties(_properties, properties);
-    _properties = properties;
-    _clusterConfigChangeListeners.forEach(l -> l.onChange(changedProperties, _properties));
+    Set<String> changedProperties = ImmutableSet.copyOf(getChangedProperties(_properties, properties));
+    _properties = ImmutableMap.copyOf(properties);
+    for (PinotClusterConfigChangeListener listener : _clusterConfigChangeListeners) {
+      listener.onChange(changedProperties, _properties);
+    }
   }
 
   @Override
-  public Map<String, String> getClusterConfigs() {
+  public ImmutableMap<String, String> getClusterConfigs() {
     return _properties;
   }
 


### PR DESCRIPTION
This PR changes the structures being used in DefaultClusterConfigChangeHandler to be:
- Safe to add new listeners concurrently
- Improve defensive programming in case a listener tries to keep a reference or modify the received structures.