### PR TITLE
Change BrokerRoutingManager synchronization mechanism to allow more parallelism

### DIFF
--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/BuildRoutingDelayTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/BuildRoutingDelayTest.java
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.routing;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class BuildRoutingDelayTest {
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void testBuildRoutingSkipsWhenRequestIsOlderThanLastStart()
+      throws Exception {
+    // Construct with nulls as the build should return early before using these fields
+    BrokerRoutingManager manager = new BrokerRoutingManager(null, null, new PinotConfiguration());
+
+    String tableNameWithType = "testTable_OFFLINE";
+
+    // Set a future last build start time to force skipping the current build call
+    long futureStart = System.currentTimeMillis() + 10_000L;
+
+    Field startTimesField = BrokerRoutingManager.class.getDeclaredField("_routingTableBuildStartTimeMs");
+    startTimesField.setAccessible(true);
+    Map<String, Long> startTimes = (Map<String, Long>) startTimesField.get(manager);
+    if (startTimes == null) {
+      startTimes = new ConcurrentHashMap<>();
+      startTimesField.set(manager, startTimes);
+    }
+    startTimes.put(tableNameWithType, futureStart);
+
+    // Should return without throwing and without attempting to build routing
+    manager.buildRouting(tableNameWithType);
+
+    // Ensure routing was not created and the last start time was not overwritten
+    Assert.assertFalse(manager.routingExists(tableNameWithType));
+    Assert.assertEquals(startTimes.get(tableNameWithType).longValue(), futureStart);
+  }
+}


### PR DESCRIPTION
This PR builds on top of https://github.com/apache/pinot/pull/16585 which didn't handle the dependencies for time boundary among related tables.

Changes introduced in this PR:

- _globalLock - ReadWriteLock for updates to global data structures used in the class such as `_excludedServers`, `_routableServers` and `_enabledServerInstanceMap`. These cannot be broken down to a per table / per table-group scope
- _routingTableBuildLocks - Map of locks keyed on the raw table name (to capture dependencies between OFFLINE and REALTIME tables that are dependent on each other for time boundary calculations) to Object locks. This is mostly to protect access to `_routingEntryMap` and allow more parallelism to build the map when routing entries are built for different tables.
- _routingTableBuildStartTimeMs - Map of tableNameWithType to the last `buildRouting` call to skip building if it took too long to wait for the lock

The above should improve parallelism among some of the operations that are safe to perform in parallel (e.g. those that don't modify the global data structures of the class). The table level locks help improve parallelism when performing `_routingEntryMap` operations at the table level.

Building the routing table for logical tables relies on `buildRouting` for each table configured in the table list. Only if the `buildRouting` call doesn't set the TimeBoundaryManager, does the logical table code try to create one for the OFFLINE tables. Thus it should be sufficient to group the table level locks on the raw table name

cc @Jackie-Jiang @xiangfu0 @abhishekbafna 