### PR TITLE
Add easier to read stats

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/InStageStatsTreeBuilder.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/InStageStatsTreeBuilder.java
@@ -97,7 +97,7 @@ public class InStageStatsTreeBuilder implements PlanNodeVisitor<ObjectNode, InSt
 
     selfNode.put("clockTimeMs", cpuTimeMs / context._parallelism);
 
-    long childrenStat = getChildrenStat(type, children, "executionTimeMs", false);
+    long childrenStat = getChildrenStat(type, children, "executionTimeMs");
     long selfExecutionTimeMs = cpuTimeMs - childrenStat;
     if (selfExecutionTimeMs != 0) {
       selfNode.put("selfExecutionTimeMs", selfExecutionTimeMs);
@@ -110,7 +110,7 @@ public class InStageStatsTreeBuilder implements PlanNodeVisitor<ObjectNode, InSt
     JsonNode allocatedBytes = selfNode.get("allocatedMemoryBytes");
     long totalAllocatedBytes = allocatedBytes == null ? 0 : allocatedBytes.asLong(0);
 
-    long selfAllocatedBytes = totalAllocatedBytes - getChildrenStat(type, children, "allocatedMemoryBytes", false);
+    long selfAllocatedBytes = totalAllocatedBytes - getChildrenStat(type, children, "allocatedMemoryBytes");
     if (selfAllocatedBytes != 0) {
       selfNode.put("selfAllocatedMB", selfAllocatedBytes / (1024 * 1024));
     }
@@ -120,17 +120,13 @@ public class InStageStatsTreeBuilder implements PlanNodeVisitor<ObjectNode, InSt
     JsonNode gcTimeMs = selfNode.get("gcTimeMs");
     long totalGcTimeMs = gcTimeMs == null ? 0 : gcTimeMs.asLong(0);
 
-    long selfGcTimeMs = totalGcTimeMs - getChildrenStat(type, children, "gcTimeMs", false);
+    long selfGcTimeMs = totalGcTimeMs - getChildrenStat(type, children, "gcTimeMs");
     if (selfGcTimeMs != 0) {
       selfNode.put("selfGcTimeMs", selfGcTimeMs);
     }
   }
 
-  private long getChildrenStat(
-      MultiStageOperator.Type type, JsonNode[] children, String key, boolean crossStageBoundary) {
-    if (type == MultiStageOperator.Type.MAILBOX_RECEIVE && !crossStageBoundary) {
-      return 0;
-    }
+  private long getChildrenStat(MultiStageOperator.Type type, JsonNode[] children, String key) {
     if (children == null) {
       return 0;
     }


### PR DESCRIPTION
This small PR adds some derived stats. This means these are not new stats collected by each operator, but instead stats that are calculated at the broker level using the other stats. The new stats are:
- `selfExecutionTimeMs`: Like `executionTimeMs`, but doesn't count time spent on children in the same stage
- `selfClockTimeMs`: Like `clockTimeMs`, but doesn't count time spent on children in the same stage
- `selfAllocatedMB`: Like `allocatedMemoryBytes`, but presents data in MB and doesn't count memory allocated by children in the same stage
- ~`individualAllocatedMB`: Like `selfAllocatedMB`, but divided by parallelism~
- `selfGcTimeMs`: Like `gcTimeMs`, but doesn't count gc time spent on children in the same stage.
- ~`individualGcTime`: Like `selfGcTimeMs`, but divided by parallelism~

Edit: Individual stats have been removed because we don't find a good name and they may not be that useful. We can always add them on a future PR

Example: 
<img width="827" height="695" alt="Screenshot 2025-09-11 at 11 26 36" src="https://github.com/user-attachments/assets/5986a004-0e2e-4853-945f-5f7d1be49f53" />
