### PR TITLE
Add more template to capture the kafka client-id with double-quoted and use | for prefixes

### DIFF
--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/pinot.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/pinot.yml
@@ -608,6 +608,15 @@ rules:
     topic_name: "$4"
     partition: "$5"
     scope: "consumer"
+- pattern: "kafka\\.consumer<type=consumer-fetch-manager-metrics, client-id=\\\"?(([^.]+)\\.)?(?:[^,]*?\\|\\|\\|)?([^,]+)_REALTIME-([^,]+)-(\\d+)\\\"?><>(fetch-rate|fetch-latency-avg|fetch-throttle-time-avg|bytes-consumed-rate|records-consumed-rate|fetch-size-avg|fetch-size-max|records-per-request-avg)"
+  name: "kafka_consumer_$6"
+  cache: true
+  labels:
+    database: "$2"
+    table: "$3"
+    topic_name: "$4"
+    partition: "$5"
+    scope: "consumer"
 # Topic-level metrics (includes topic information from MBean)
 - pattern: "kafka\\.consumer<type=consumer-fetch-manager-metrics, client-id=(([^.]+)\\.)?([^,]+)_REALTIME-([^,]+)-(\\d+), topic=([^\"]+)><>(bytes-consumed-rate|records-consumed-rate|fetch-size-avg|fetch-size-max|records-per-request-avg)"
   name: "kafka_consumer_$7"
@@ -618,8 +627,26 @@ rules:
     topic_name: "$4"
     partition: "$5"
     scope: "topic"
+- pattern: "kafka\\.consumer<type=consumer-fetch-manager-metrics, client-id=\\\"?(([^.]+)\\.)?(?:[^,]*?\\|\\|\\|)?([^,]+)_REALTIME-([^,]+)-(\\d+)\\\"?, topic=([^\"]+)><>(bytes-consumed-rate|records-consumed-rate|fetch-size-avg|fetch-size-max|records-per-request-avg)"
+  name: "kafka_consumer_$7"
+  cache: true
+  labels:
+    database: "$2"
+    table: "$3"
+    topic_name: "$4"
+    partition: "$5"
+    scope: "topic"
 # Partition-level metrics (most granular, includes both topic and partition from MBean)
 - pattern: "kafka\\.consumer<type=consumer-fetch-manager-metrics, client-id=(([^.]+)\\.)?([^,]+)_REALTIME-([^,]+)-(\\d+), topic=([^,\"]+), partition=([^\"]+)><>(records-lag-avg|records-lag-max|records-lead-avg|records-lead-min)"
+  name: "kafka_consumer_$8"
+  cache: true
+  labels:
+    database: "$2"
+    table: "$3"
+    topic_name: "$4"
+    partition: "$5"
+    scope: "partition"
+- pattern: "kafka\\.consumer<type=consumer-fetch-manager-metrics, client-id=\\\"?(([^.]+)\\.)?(?:[^,]*?\\|\\|\\|)?([^,]+)_REALTIME-([^,]+)-(\\d+)\\\"?, topic=([^,\"]+), partition=([^\"]+)><>(records-lag-avg|records-lag-max|records-lead-avg|records-lead-min)"
   name: "kafka_consumer_$8"
   cache: true
   labels:

--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/server.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/server.yml
@@ -96,6 +96,15 @@ rules:
     topic_name: "$4"
     partition: "$5"
     scope: "consumer"
+- pattern: "kafka\\.consumer<type=consumer-fetch-manager-metrics, client-id=\\\"?(([^.]+)\\.)?(?:[^,]*?\\|\\|\\|)?([^,]+)_REALTIME-([^,]+)-(\\d+)\\\"?><>(fetch-rate|fetch-latency-avg|fetch-throttle-time-avg|bytes-consumed-rate|records-consumed-rate|fetch-size-avg|fetch-size-max|records-per-request-avg)"
+  name: "kafka_consumer_$6"
+  cache: true
+  labels:
+    database: "$2"
+    table: "$3"
+    topic_name: "$4"
+    partition: "$5"
+    scope: "consumer"
 # Topic-level metrics (includes topic information from MBean)
 - pattern: "kafka\\.consumer<type=consumer-fetch-manager-metrics, client-id=(([^.]+)\\.)?([^,]+)_REALTIME-([^,]+)-(\\d+), topic=([^\"]+)><>(bytes-consumed-rate|records-consumed-rate|fetch-size-avg|fetch-size-max|records-per-request-avg)"
   name: "kafka_consumer_$7"
@@ -106,8 +115,26 @@ rules:
     topic_name: "$4"
     partition: "$5"
     scope: "topic"
+- pattern: "kafka\\.consumer<type=consumer-fetch-manager-metrics, client-id=\\\"?(([^.]+)\\.)?(?:[^,]*?\\|\\|\\|)?([^,]+)_REALTIME-([^,]+)-(\\d+)\\\"?, topic=([^\"]+)><>(bytes-consumed-rate|records-consumed-rate|fetch-size-avg|fetch-size-max|records-per-request-avg)"
+  name: "kafka_consumer_$7"
+  cache: true
+  labels:
+    database: "$2"
+    table: "$3"
+    topic_name: "$4"
+    partition: "$5"
+    scope: "topic"
 # Partition-level metrics (most granular, includes both topic and partition from MBean)
 - pattern: "kafka\\.consumer<type=consumer-fetch-manager-metrics, client-id=(([^.]+)\\.)?([^,]+)_REALTIME-([^,]+)-(\\d+), topic=([^,\"]+), partition=([^\"]+)><>(records-lag-avg|records-lag-max|records-lead-avg|records-lead-min)"
+  name: "kafka_consumer_$8"
+  cache: true
+  labels:
+    database: "$2"
+    table: "$3"
+    topic_name: "$4"
+    partition: "$5"
+    scope: "partition"
+- pattern: "kafka\\.consumer<type=consumer-fetch-manager-metrics, client-id=\\\"?(([^.]+)\\.)?(?:[^,]*?\\|\\|\\|)?([^,]+)_REALTIME-([^,]+)-(\\d+)\\\"?, topic=([^,\"]+), partition=([^\"]+)><>(records-lag-avg|records-lag-max|records-lead-avg|records-lead-min)"
   name: "kafka_consumer_$8"
   cache: true
   labels:


### PR DESCRIPTION
Examples of client-id could be using confluent Kafka consumer:
`kafka.consumer:client-id="dfd|0021Q00008dPMDJKS5|||my_tbl_REALTIME-my_topic-123",type=consumer-fetch-manager-metrics`.
In this case, the client-id has the prefix `cwc|0014U00002jPVVSQA4|||` then table name is `my_tbl`, topic is `my_topic`, partition is `123`)