### PR TITLE
updated putNodeData and zookeeperPutData to pass data in the payload/…

### DIFF
--- a/pinot-controller/src/main/resources/app/requests/index.ts
+++ b/pinot-controller/src/main/resources/app/requests/index.ts
@@ -260,8 +260,8 @@ export const zookeeperGetStat = (params: string): Promise<AxiosResponse<ZKConfig
 export const zookeeperGetListWithStat = (params: string): Promise<AxiosResponse<ZKConfig>> =>
   baseApi.get(`/zk/lsl?path=${params}`);
 
-export const zookeeperPutData = (params: string): Promise<AxiosResponse<OperationResponse>> =>
-  baseApi.put(`/zk/put?${params}`, null, { headers });
+export const zookeeperPutData = (params: string, data?: any): Promise<AxiosResponse<OperationResponse>> =>
+  baseApi.put(`/zk/put?${params}`, data, { headers });
 
 export const zookeeperDeleteNode = (params: string): Promise<AxiosResponse<OperationResponse>> =>
   baseApi.delete(`/zk/delete?path=${params}`);

--- a/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
+++ b/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
@@ -792,9 +792,10 @@ const getNodeData = (path) => {
   });
 };
 
-const putNodeData = (data) => {
-  const serializedData = Utils.serialize(data);
-  return zookeeperPutData(serializedData).then((obj)=>{
+const putNodeData = (nodeParams) => {
+  const { data, ...queryParams } = nodeParams;
+  const serializedParams = Utils.serialize(queryParams);
+  return zookeeperPutData(serializedParams, data).then((obj)=>{
     return obj;
   });
 };


### PR DESCRIPTION
…body instead of a query param

This screenshot shows that zk node data is now being passed via the request payload:

<img width="1907" height="828" alt="Screenshot 2025-09-12 at 6 05 21 PM" src="https://github.com/user-attachments/assets/4b2b0e20-0ac0-40dd-92e0-4a12ea8bdc2d" />

This fixes issue [#15311](https://github.com/apache/pinot/issues/15311)
