### PR TITLE
Reenable the single commit for idealstate update to zk metadata.

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/IdealStateGroupCommit.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/IdealStateGroupCommit.java
@@ -114,7 +114,7 @@ public class IdealStateGroupCommit {
     Entry entry = new Entry(resourceName, updater);
 
     queue._pending.add(entry);
-    LOGGER.info("The queue size for resource {} is {}", resourceName, queue._pending.size());
+    LOGGER.debug("The queue size for resource {} is {}", resourceName, queue._pending.size());
     while (!entry._sent.get()) {
       if (queue._running.compareAndSet(null, Thread.currentThread())) {
         ArrayList<Entry> processed = new ArrayList<>();

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/IdealStateSingleCommit.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/IdealStateSingleCommit.java
@@ -18,8 +18,6 @@
  */
 package org.apache.pinot.common.utils.helix;
 
-import java.util.Iterator;
-import java.util.Map;
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
@@ -46,8 +44,10 @@ public class IdealStateSingleCommit {
   private static final Logger LOGGER = LoggerFactory.getLogger(IdealStateSingleCommit.class);
   private static final String ENABLE_COMPRESSIONS_KEY = "enableCompression";
   private static final int NUM_PARTITIONS_THRESHOLD_TO_ENABLE_COMPRESSION = 1000;
-  private static final int _minNumCharsInISToTurnOnCompression = -1;
   private static final ZNRecordSerializer ZN_RECORD_SERIALIZER = new ZNRecordSerializer();
+
+  private IdealStateSingleCommit() {
+  }
 
   public static IdealState updateIdealState(HelixManager helixManager, String resourceName,
       Function<IdealState, IdealState> updater, RetryPolicy policy, boolean noChangeOk) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/IdealStateSingleCommit.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/IdealStateSingleCommit.java
@@ -125,28 +125,7 @@ public class IdealStateSingleCommit {
         }
 
         private boolean shouldCompress(IdealState is) {
-          if (is.getNumPartitions() > NUM_PARTITIONS_THRESHOLD_TO_ENABLE_COMPRESSION) {
-            return true;
-          }
-
-          // Find the number of characters in one partition in idealstate, and extrapolate
-          // to estimate the number of characters.
-          // We could serialize the znode to determine the exact size, but that would mean serializing every
-          // idealstate znode twice. We avoid some extra GC by estimating the size instead. Such estimations
-          // should be good for most installations that have similar segment and instance names.
-          Iterator<String> it = is.getPartitionSet().iterator();
-          if (it.hasNext()) {
-            String partitionName = it.next();
-            int numChars = partitionName.length();
-            Map<String, String> stateMap = is.getInstanceStateMap(partitionName);
-            for (Map.Entry<String, String> entry : stateMap.entrySet()) {
-              numChars += entry.getKey().length();
-              numChars += entry.getValue().length();
-            }
-            numChars *= is.getNumPartitions();
-            return (_minNumCharsInISToTurnOnCompression > 0) && (numChars > _minNumCharsInISToTurnOnCompression);
-          }
-          return false;
+          return is.getNumPartitions() > NUM_PARTITIONS_THRESHOLD_TO_ENABLE_COMPRESSION;
         }
       });
       if (controllerMetrics != null) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/IdealStateSingleCommit.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/IdealStateSingleCommit.java
@@ -38,6 +38,7 @@ import org.apache.pinot.spi.utils.retry.RetryPolicy;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+
 /**
  * A utility class for committing ideal states in a single commit operation.
  */

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -92,6 +92,9 @@ public class ControllerConf extends PinotConfiguration {
   // Consider tierConfigs when assigning new offline segment
   public static final String CONTROLLER_ENABLE_TIERED_SEGMENT_ASSIGNMENT = "controller.segment.enableTieredAssignment";
 
+  // Used to determine whether to use group commit idealstate on segment completion
+  public static final String CONTROLLER_SEGMENT_COMPLETION_GROUP_COMMIT_ENABLED =
+      "controller.segment.completion.group.commit.enabled";
   public enum ControllerMode {
     DUAL, PINOT_ONLY, HELIX_ONLY
   }
@@ -1364,5 +1367,9 @@ public class ControllerConf extends PinotConfiguration {
         .map(String::trim)
         .filter(lang -> !lang.isEmpty())
         .collect(Collectors.toList());
+  }
+
+  public boolean getSegmentCompletionGroupCommitEnabled() {
+    return getProperty(CONTROLLER_SEGMENT_COMPLETION_GROUP_COMMIT_ENABLED, true);
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -1414,7 +1414,8 @@ public class PinotLLCRealtimeSegmentManager {
     }
     LOGGER.info("Updating the ideal state for table: {}, committing segment: {}, new consuming segment: {}",
         realtimeTableName, committingSegmentName, newSegmentName);
-    return IdealStateSingleCommit.updateIdealState(_helixManager, realtimeTableName, updater, DEFAULT_RETRY_POLICY, false);
+    return IdealStateSingleCommit.updateIdealState(_helixManager, realtimeTableName, updater, DEFAULT_RETRY_POLICY,
+        false);
   }
 
   public static boolean isTablePaused(IdealState idealState) {


### PR DESCRIPTION
Make group commit optional. In the production env running with the group commit, we found bugs related to group commit on tables with a large number of Kafka topics and partitions with high segment commit rates. In particular, segment commit will not be able to finish due to the 300 sec hard limit.

This PR makes group commit optional. The default value is enabled as of today.