### PR TITLE
[audit] Extend audit logging support to broker REST APIs

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
@@ -35,6 +35,7 @@ import org.apache.helix.HelixManager;
 import org.apache.pinot.broker.queryquota.QueryQuotaManager;
 import org.apache.pinot.broker.requesthandler.BrokerRequestHandler;
 import org.apache.pinot.broker.routing.BrokerRoutingManager;
+import org.apache.pinot.common.audit.AuditLogFilter;
 import org.apache.pinot.common.cursors.AbstractResponseStore;
 import org.apache.pinot.common.http.PoolingHttpClientConnectionManagerHelper;
 import org.apache.pinot.common.metrics.BrokerMetrics;
@@ -131,6 +132,7 @@ public class BrokerAdminApiApplication extends ResourceConfig {
     register(SwaggerApiListingResource.class);
     register(SwaggerSerializers.class);
     register(AuthenticationFilter.class);
+    register(AuditLogFilter.class);
   }
 
   public void start(List<ListenerConfig> listenerConfigs) {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
@@ -131,12 +131,12 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
   private volatile boolean _isStarting = false;
   private volatile boolean _isShuttingDown = false;
 
-  // Class dedicated towards handling cluster config change
+  // Dedicated handler for listening to cluster config changes
   protected final DefaultClusterConfigChangeHandler _defaultClusterConfigChangeHandler =
       new DefaultClusterConfigChangeHandler();
 
-  // Deprecated in favor of using a dedicated _defaultClusterConfigChangeHandler to manage config related changes
-  @Deprecated
+  // TODO To be removed in favor of _defaultClusterConfigChangeHandler to manage config related changes.
+  //      Please use this only if you are reliant specifically on the ClusterChangeMediator infra.
   protected final List<ClusterChangeHandler> _clusterConfigChangeHandlers = new ArrayList<>();
   protected final List<ClusterChangeHandler> _idealStateChangeHandlers = new ArrayList<>();
   protected final List<ClusterChangeHandler> _externalViewChangeHandlers = new ArrayList<>();

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
@@ -56,6 +56,8 @@ import org.apache.pinot.broker.requesthandler.SingleConnectionBrokerRequestHandl
 import org.apache.pinot.broker.requesthandler.TimeSeriesRequestHandler;
 import org.apache.pinot.broker.routing.BrokerRoutingManager;
 import org.apache.pinot.common.Utils;
+import org.apache.pinot.common.audit.AuditServiceBinder;
+import org.apache.pinot.common.config.DefaultClusterConfigChangeHandler;
 import org.apache.pinot.common.config.NettyConfig;
 import org.apache.pinot.common.config.TlsConfig;
 import org.apache.pinot.common.config.provider.TableCache;
@@ -129,6 +131,12 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
   private volatile boolean _isStarting = false;
   private volatile boolean _isShuttingDown = false;
 
+  // Class dedicated towards handling cluster config change
+  protected final DefaultClusterConfigChangeHandler _defaultClusterConfigChangeHandler =
+      new DefaultClusterConfigChangeHandler();
+
+  // Deprecated in favor of using a dedicated _defaultClusterConfigChangeHandler to manage config related changes
+  @Deprecated
   protected final List<ClusterChangeHandler> _clusterConfigChangeHandlers = new ArrayList<>();
   protected final List<ClusterChangeHandler> _idealStateChangeHandlers = new ArrayList<>();
   protected final List<ClusterChangeHandler> _externalViewChangeHandlers = new ArrayList<>();
@@ -440,6 +448,10 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
     } else {
       _sqlQueryExecutor = new SqlQueryExecutor(_spectatorHelixManager);
     }
+
+    LOGGER.info("Wiring up cluster config change handler with helix");
+    _spectatorHelixManager.addClusterfigChangeListener(_defaultClusterConfigChangeHandler);
+
     LOGGER.info("Starting broker admin application on: {}", ListenerConfigUtil.toString(_listenerConfigs));
     _brokerAdminApplication = createBrokerAdminApp();
     _brokerAdminApplication.start(_listenerConfigs);
@@ -763,6 +775,7 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
         new BrokerAdminApiApplication(_routingManager, _brokerRequestHandler, _brokerMetrics, _brokerConf,
             _sqlQueryExecutor, _serverRoutingStatsManager, _accessControlFactory, _spectatorHelixManager,
             _queryQuotaManager, _responseStore);
+    brokerAdminApiApplication.register(new AuditServiceBinder(_defaultClusterConfigChangeHandler, getServiceRole()));
     registerExtraComponents(brokerAdminApiApplication);
     return brokerAdminApiApplication;
   }


### PR DESCRIPTION
This PR extends the existing audit logging infrastructure from the controller to support broker REST APIs. The implementation follows the same pattern used in the controller, enabling audit logging for broker query and admin endpoints.

## Configuration

To enable audit logging for broker, add these properties to cluster configuration:

```properties
# Enable audit logging
pinot.audit.broker.enabled=true

# Capture request payloads
pinot.audit.broker.capture.request.payload.enabled=true

# Capture specific headers
pinot.audit.broker.capture.request.headers=x-forwarded-for,x-real-ip

# Include health and metrics endpoints
pinot.audit.broker.url.filter.include.patterns=/tables/**

# Exclude health and metrics endpoints
pinot.audit.broker.url.filter.exclude.patterns=/health,/metrics,/swagger.*,/api-docs.*

# Fallback to JWT claim if header not found
pinot.audit.broker.userid.jwt.claim=email
```

## Testing
- Manually tested wiring with quickstart
