### PR TITLE
Optimize RetentionManager performance by replacing List with Set for segment lookups

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/retention/RetentionManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/retention/RetentionManager.java
@@ -338,18 +338,18 @@ public class RetentionManager extends ControllerPeriodicTask<Void> {
       return segmentsToDelete;
     }
 
-    List<String> segmentsPresentInZK;
+    Set<String> segmentsPresentInZK;
     if (isHybridTable) {
-      segmentsPresentInZK = new ArrayList<>();
+      segmentsPresentInZK = new HashSet<>();
       // This must be the OFFLINE table
       segmentsPresentInZK.addAll(
-          segmentZKMetadataList.stream().map(SegmentZKMetadata::getSegmentName).collect(Collectors.toList()));
+          segmentZKMetadataList.stream().map(SegmentZKMetadata::getSegmentName).collect(Collectors.toSet()));
       // Add segments from the REALTIME table as well
       segmentsPresentInZK.addAll(
           _pinotHelixResourceManager.getSegmentsFor(TableNameBuilder.REALTIME.tableNameWithType(rawTableName), false));
     } else {
       segmentsPresentInZK =
-          segmentZKMetadataList.stream().map(SegmentZKMetadata::getSegmentName).collect(Collectors.toList());
+          segmentZKMetadataList.stream().map(SegmentZKMetadata::getSegmentName).collect(Collectors.toSet());
     }
 
     try {
@@ -384,13 +384,13 @@ public class RetentionManager extends ControllerPeriodicTask<Void> {
    *
    * @param tableNameWithType   Name of the offline table
    * @param retentionStrategy  Strategy to determine if a segment should be purged
-   * @param segmentsToExclude  List of segment names that should be excluded from deletion
+   * @param segmentsToExclude  Set of segment names that should be excluded from deletion
    * @return List of segment names that should be deleted from deepstore
    * @throws IOException If there's an error accessing the filesystem
    */
-  private List<String> findUntrackedSegmentsToDeleteFromDeepstore(String tableNameWithType,
-      RetentionStrategy retentionStrategy, List<String> segmentsToExclude,
-      RetentionStrategy untrackedSegmentsRetentionStrategy)
+  @VisibleForTesting
+  List<String> findUntrackedSegmentsToDeleteFromDeepstore(String tableNameWithType, RetentionStrategy retentionStrategy,
+      Set<String> segmentsToExclude, RetentionStrategy untrackedSegmentsRetentionStrategy)
       throws IOException {
 
     List<String> segmentsToDelete = new ArrayList<>();

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/retention/RetentionManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/retention/RetentionManagerTest.java
@@ -20,6 +20,7 @@ package org.apache.pinot.controller.helix.core.retention;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.attribute.FileTime;
@@ -27,8 +28,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.FileUtils;
 import org.apache.helix.AccessOption;
@@ -56,6 +59,9 @@ import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.apache.pinot.spi.data.DateTimeFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.filesystem.FileMetadata;
+import org.apache.pinot.spi.filesystem.LocalPinotFS;
+import org.apache.pinot.spi.filesystem.PinotFSFactory;
 import org.apache.pinot.spi.metrics.PinotMetricUtils;
 import org.apache.pinot.spi.stream.LongMsgOffset;
 import org.apache.pinot.spi.utils.CommonConstants;
@@ -79,6 +85,7 @@ public class RetentionManagerTest {
   private static final String TEST_TABLE_NAME = "testTable";
   private static final String OFFLINE_TABLE_NAME = TableNameBuilder.OFFLINE.tableNameWithType(TEST_TABLE_NAME);
   private static final String REALTIME_TABLE_NAME = TableNameBuilder.REALTIME.tableNameWithType(TEST_TABLE_NAME);
+  private static final int LARGE_SEGMENT_COUNT = 400_000;
 
   // Variables for real file test
   private Path _tempDir;
@@ -382,7 +389,7 @@ public class RetentionManagerTest {
     when(leadControllerManager.isLeaderForTable(anyString())).thenReturn(true);
     PinotHelixResourceManager pinotHelixResourceManager = mock(PinotHelixResourceManager.class);
 
-      setupPinotHelixResourceManager(tableConfig, removedSegments, pinotHelixResourceManager, leadControllerManager);
+    setupPinotHelixResourceManager(tableConfig, removedSegments, pinotHelixResourceManager, leadControllerManager);
 
     when(pinotHelixResourceManager.getTableConfig(OFFLINE_TABLE_NAME)).thenReturn(tableConfig);
     when(pinotHelixResourceManager.getSegmentsZKMetadata(OFFLINE_TABLE_NAME)).thenReturn(segmentsZKMetadata);
@@ -651,6 +658,48 @@ public class RetentionManagerTest {
     verify(pinotHelixResourceManager, times(1)).deleteSegments(anyString(), anyList());
   }
 
+  @Test
+  public void testPerformanceWithLargeNumberOfSegments()
+      throws Exception {
+    // Test that the optimized Set-based lookup can handle 400,000 segments within 30 seconds
+    final long maxTestExecutionTimeMs = 30_000; // 30 seconds
+
+    long startTime = System.currentTimeMillis();
+
+    PinotFSFactory.register("fake", RetentionManagerTest.FakePinotFs.class.getName(), null);
+
+    Set<String> segmentsToExclude = new HashSet<>();
+
+    for (int i = 0; i < LARGE_SEGMENT_COUNT; i++) {
+      String segmentName = "segment" + i;
+      segmentsToExclude.add(segmentName);
+    }
+
+    LeadControllerManager leadControllerManager = mock(LeadControllerManager.class);
+    when(leadControllerManager.isLeaderForTable(anyString())).thenReturn(true);
+
+    PinotHelixResourceManager pinotHelixResourceManager = mock(PinotHelixResourceManager.class);
+    when(pinotHelixResourceManager.getDataDir()).thenReturn("fake://bucket/sc/managed/pinot/");
+
+    ControllerConf conf = new ControllerConf();
+    ControllerMetrics controllerMetrics = new ControllerMetrics(PinotMetricUtils.getPinotMetricsRegistry());
+    conf.setRetentionControllerFrequencyInSeconds(0);
+    conf.setDeletedSegmentsRetentionInDays(0);
+    conf.setUntrackedSegmentDeletionEnabled(true);
+    PinotHelixResourceManager mockResourceManager = mock(PinotHelixResourceManager.class);
+    BrokerServiceHelper brokerServiceHelper =
+        new BrokerServiceHelper(mockResourceManager, conf, null, null);
+    RetentionManager retentionManager =
+        new RetentionManager(pinotHelixResourceManager, leadControllerManager, conf, controllerMetrics,
+            brokerServiceHelper);
+
+    retentionManager.findUntrackedSegmentsToDeleteFromDeepstore("table1_REALTIME", null, segmentsToExclude, null);
+
+    long executionTime = System.currentTimeMillis() - startTime;
+    assertTrue(executionTime < maxTestExecutionTimeMs,
+        "Test should complete within 30 seconds but took " + executionTime + "ms");
+  }
+
   private PinotHelixResourceManager setupSegmentMetadata(TableConfig tableConfig, final long now, final int nSegments,
       List<String> segmentsToBeDeleted) {
     final int replicaCount = tableConfig.getReplication();
@@ -799,6 +848,31 @@ public class RetentionManagerTest {
       Files.setLastModifiedTime(file.toPath(), fileTime);
     } catch (IOException e) {
       throw new RuntimeException(e);
+    }
+  }
+
+  public static class FakePinotFs extends LocalPinotFS {
+
+    @Override
+    public List<FileMetadata> listFilesWithMetadata(URI fileUri, boolean recursive)
+        throws IOException {
+
+      URI tableUri1 = null;
+      List<FileMetadata> fileMetadataList = new ArrayList<>();
+      try {
+        tableUri1 = new URI("fake://bucket/sc/managed/pinot/table1/");
+
+        for (int i = 0; i < LARGE_SEGMENT_COUNT; i++) {
+          String segmentName = "segment" + i;
+          URI segmentURIForTable =
+              new URI(tableUri1.getPath() + segmentName);
+          fileMetadataList.add(
+              new FileMetadata.Builder().setFilePath(segmentURIForTable.getPath()).setIsDirectory(false).build());
+        }
+        return fileMetadataList;
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
     }
   }
 }


### PR DESCRIPTION
## Problem

  RetentionManager was experiencing high runtime when processing large numbers of segments due to O(n) List.contains() operations during segment exclusion checks.


```
03:18:05.742 INFO [RetentionManager] [pool-16-thread-12] Found: 394300 segments in deepstore for table: <tableName>. Time taken to list segments: 37021 ms
03:49:30.354 INFO [RetentionManager] [pool-16-thread-12] Took: 1921633 ms to identify 56 segments for deletion from deep store for table: <tableName> as they have no corresponding entry in the property store.
```

## Solution

  Replaced List<String> with Set<String> for segment collections, converting O(n) lookups to O(1) HashSet operations. This eliminates the performance bottleneck in findUntrackedSegmentsToDeleteFromDeepstore().

## Impact

  Dramatically improves performance for large-scale deployments. Added performance test validates handling 400,000 segments within 30 seconds, preventing future regressions.
  
### Sample runs using List and Set
  
<img width="720" height="176" alt="image" src="https://github.com/user-attachments/assets/736766b1-f119-4145-b11f-49020b143fe6" />
<img width="720" height="137" alt="image" src="https://github.com/user-attachments/assets/969cb81a-7317-4387-a847-ddf25aa46d75" />


