### PR TITLE
Configure switch for DICTIONARY scan vs RAW scan in REGEX LIKE evaluation using query Options

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -76,7 +76,6 @@ import org.slf4j.LoggerFactory;
 @ThreadSafe
 public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
   private static final Logger LOGGER = LoggerFactory.getLogger(BaseBrokerRequestHandler.class);
-
   protected final PinotConfiguration _config;
   protected final String _brokerId;
   protected final RoutingManager _routingManager;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/ExpressionFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/ExpressionFilterOperator.java
@@ -75,7 +75,7 @@ public class ExpressionFilterOperator extends BaseFilterOperator {
     } else {
       _predicateEvaluator =
           PredicateEvaluatorProvider.getPredicateEvaluator(predicate, _transformFunction.getDictionary(),
-              _transformFunction.getResultMetadata().getDataType());
+              _transformFunction.getResultMetadata().getDataType(), _queryContext);
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/PredicateEvaluatorProvider.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/PredicateEvaluatorProvider.java
@@ -65,7 +65,7 @@ public class PredicateEvaluatorProvider {
                 .newDictionaryBasedEvaluator((RangePredicate) predicate, dictionary, dataType);
           case REGEXP_LIKE:
             return RegexpLikePredicateEvaluatorFactory
-                .newDictionaryBasedEvaluator((RegexpLikePredicate) predicate, dictionary, dataType);
+                .newDictionaryBasedEvaluator((RegexpLikePredicate) predicate, dictionary, dataType, queryContext);
           default:
             throw new UnsupportedOperationException("Unsupported predicate type: " + predicate.getType());
         }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/RegexpLikePredicateEvaluatorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/RegexpLikePredicateEvaluatorFactory.java
@@ -29,6 +29,7 @@ import org.apache.pinot.common.utils.regex.Matcher;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.utils.CommonConstants.Broker.Request.QueryOptionKey;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,16 +42,6 @@ public class RegexpLikePredicateEvaluatorFactory {
 
   private RegexpLikePredicateEvaluatorFactory() {
   }
-
-  /// When the cardinality of the dictionary is less than this threshold, scan the dictionary
-  // to get the matching ids. Default value is 10K.
-  public static final int DEFAULT_DICTIONARY_CARDINALITY_THRESHOLD = 10000;
-
-  /// Query option key for configuring the dictionary cardinality threshold
-  public static final String REGEXP_DICTIONARY_CARDINALITY_THRESHOLD_OPTION = "regexpDictCardinalityThreshold";
-
-  /// Query option key to force use of dictionary scan
-  public static final String USE_DICT_FOR_REGEXP_LIKE_PREDICATE_OPTION = "useDictForRegexpLikePredicate";
 
   /**
    * Create a new instance of dictionary based REGEXP_LIKE predicate evaluator.
@@ -67,16 +58,18 @@ public class RegexpLikePredicateEvaluatorFactory {
 
     // 1. If useDictForRegexpLikePredicate is set to true, always use dictionary
     if (queryContext != null && queryContext.getQueryOptions() != null) {
-      String useDictOption = queryContext.getQueryOptions().get(USE_DICT_FOR_REGEXP_LIKE_PREDICATE_OPTION);
+      String useDictOption =
+          queryContext.getQueryOptions().get(QueryOptionKey.USE_DICT_FOR_REGEXP_LIKE_PREDICATE_OPTION);
       if ("true".equalsIgnoreCase(useDictOption)) {
         return new DictIdBasedRegexpLikePredicateEvaluator(regexpLikePredicate, dictionary);
       }
     }
 
     // 2. Otherwise, get the threshold number from regexpDictCardinalityThreshold (default 10K)
-    int cardinalityThreshold = DEFAULT_DICTIONARY_CARDINALITY_THRESHOLD;
+    int cardinalityThreshold = QueryOptionKey.DEFAULT_DICTIONARY_CARDINALITY_THRESHOLD;
     if (queryContext != null && queryContext.getQueryOptions() != null) {
-      String queryOptionValue = queryContext.getQueryOptions().get(REGEXP_DICTIONARY_CARDINALITY_THRESHOLD_OPTION);
+      String queryOptionValue =
+          queryContext.getQueryOptions().get(QueryOptionKey.REGEXP_DICTIONARY_CARDINALITY_THRESHOLD_OPTION);
       if (queryOptionValue != null) {
         try {
           int threshold = Integer.parseInt(queryOptionValue);
@@ -84,11 +77,11 @@ public class RegexpLikePredicateEvaluatorFactory {
             cardinalityThreshold = threshold;
           } else {
             LOGGER.warn("Invalid negative regexpDictCardinalityThreshold value: '{}', using default: {}",
-                queryOptionValue, DEFAULT_DICTIONARY_CARDINALITY_THRESHOLD);
+                queryOptionValue, QueryOptionKey.DEFAULT_DICTIONARY_CARDINALITY_THRESHOLD);
           }
         } catch (NumberFormatException e) {
           LOGGER.warn("Invalid regexpDictCardinalityThreshold value: '{}', using default: {}", queryOptionValue,
-              DEFAULT_DICTIONARY_CARDINALITY_THRESHOLD);
+              QueryOptionKey.DEFAULT_DICTIONARY_CARDINALITY_THRESHOLD);
         }
       }
     }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/QueryConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/QueryConfig.java
@@ -58,7 +58,7 @@ public class QueryConfig extends BaseJsonConfig {
 
   private final Boolean _useDictForRegexpLikePredicate;
 
-  private final int _regexpDictCardinalityThreshold;
+  private final Integer _regexpDictCardinalityThreshold;
 
   @JsonCreator
   public QueryConfig(@JsonProperty("timeoutMs") @Nullable Long timeoutMs,

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/QueryConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/QueryConfig.java
@@ -56,13 +56,19 @@ public class QueryConfig extends BaseJsonConfig {
   // Indicates the maximum length of the serialized response per server for a query.
   private final Long _maxServerResponseSizeBytes;
 
+  private final Boolean _useDictForRegexpLikePredicate;
+
+  private final int _regexpDictCardinalityThreshold;
+
   @JsonCreator
   public QueryConfig(@JsonProperty("timeoutMs") @Nullable Long timeoutMs,
       @JsonProperty("disableGroovy") @Nullable Boolean disableGroovy,
       @JsonProperty("useApproximateFunction") @Nullable Boolean useApproximateFunction,
       @JsonProperty("expressionOverrideMap") @Nullable Map<String, String> expressionOverrideMap,
       @JsonProperty("maxQueryResponseSizeBytes") @Nullable Long maxQueryResponseSizeBytes,
-      @JsonProperty("maxServerResponseSizeBytes") @Nullable Long maxServerResponseSizeBytes) {
+      @JsonProperty("maxServerResponseSizeBytes") @Nullable Long maxServerResponseSizeBytes,
+      @JsonProperty("useDictForRegexpLikePredicate") Boolean useDictForRegexpLikePredicate,
+      @JsonProperty("regexpDictCardinalityThreshold") int regexpDictCardinalityThreshold) {
     Preconditions.checkArgument(timeoutMs == null || timeoutMs > 0, "Invalid 'timeoutMs': %s", timeoutMs);
     Preconditions.checkArgument(maxQueryResponseSizeBytes == null || maxQueryResponseSizeBytes > 0,
         "Invalid 'maxQueryResponseSizeBytes': %s", maxQueryResponseSizeBytes);
@@ -75,6 +81,8 @@ public class QueryConfig extends BaseJsonConfig {
     _expressionOverrideMap = expressionOverrideMap;
     _maxQueryResponseSizeBytes = maxQueryResponseSizeBytes;
     _maxServerResponseSizeBytes = maxServerResponseSizeBytes;
+    _useDictForRegexpLikePredicate = useDictForRegexpLikePredicate;
+    _regexpDictCardinalityThreshold = regexpDictCardinalityThreshold;
   }
 
   @Nullable
@@ -111,5 +119,17 @@ public class QueryConfig extends BaseJsonConfig {
   @JsonProperty("maxServerResponseSizeBytes")
   public Long getMaxServerResponseSizeBytes() {
     return _maxServerResponseSizeBytes;
+  }
+
+  @Nullable
+  @JsonProperty("regexpDictCardinalityThreshold")
+  public int getRegexpDictCardinalityThreshold() {
+    return _regexpDictCardinalityThreshold;
+  }
+
+  @Nullable
+  @JsonProperty("useDictForRegexpLikePredicate")
+  public Boolean getUseDictForRegexpLikePredicate() {
+    return _useDictForRegexpLikePredicate;
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/QueryConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/QueryConfig.java
@@ -56,19 +56,13 @@ public class QueryConfig extends BaseJsonConfig {
   // Indicates the maximum length of the serialized response per server for a query.
   private final Long _maxServerResponseSizeBytes;
 
-  private final Boolean _useDictForRegexpLikePredicate;
-
-  private final Integer _regexpDictCardinalityThreshold;
-
   @JsonCreator
   public QueryConfig(@JsonProperty("timeoutMs") @Nullable Long timeoutMs,
       @JsonProperty("disableGroovy") @Nullable Boolean disableGroovy,
       @JsonProperty("useApproximateFunction") @Nullable Boolean useApproximateFunction,
       @JsonProperty("expressionOverrideMap") @Nullable Map<String, String> expressionOverrideMap,
       @JsonProperty("maxQueryResponseSizeBytes") @Nullable Long maxQueryResponseSizeBytes,
-      @JsonProperty("maxServerResponseSizeBytes") @Nullable Long maxServerResponseSizeBytes,
-      @JsonProperty("useDictForRegexpLikePredicate") Boolean useDictForRegexpLikePredicate,
-      @JsonProperty("regexpDictCardinalityThreshold") int regexpDictCardinalityThreshold) {
+      @JsonProperty("maxServerResponseSizeBytes") @Nullable Long maxServerResponseSizeBytes) {
     Preconditions.checkArgument(timeoutMs == null || timeoutMs > 0, "Invalid 'timeoutMs': %s", timeoutMs);
     Preconditions.checkArgument(maxQueryResponseSizeBytes == null || maxQueryResponseSizeBytes > 0,
         "Invalid 'maxQueryResponseSizeBytes': %s", maxQueryResponseSizeBytes);
@@ -81,8 +75,6 @@ public class QueryConfig extends BaseJsonConfig {
     _expressionOverrideMap = expressionOverrideMap;
     _maxQueryResponseSizeBytes = maxQueryResponseSizeBytes;
     _maxServerResponseSizeBytes = maxServerResponseSizeBytes;
-    _useDictForRegexpLikePredicate = useDictForRegexpLikePredicate;
-    _regexpDictCardinalityThreshold = regexpDictCardinalityThreshold;
   }
 
   @Nullable
@@ -119,17 +111,5 @@ public class QueryConfig extends BaseJsonConfig {
   @JsonProperty("maxServerResponseSizeBytes")
   public Long getMaxServerResponseSizeBytes() {
     return _maxServerResponseSizeBytes;
-  }
-
-  @Nullable
-  @JsonProperty("regexpDictCardinalityThreshold")
-  public int getRegexpDictCardinalityThreshold() {
-    return _regexpDictCardinalityThreshold;
-  }
-
-  @Nullable
-  @JsonProperty("useDictForRegexpLikePredicate")
-  public Boolean getUseDictForRegexpLikePredicate() {
-    return _useDictForRegexpLikePredicate;
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -556,6 +556,12 @@ public class CommonConstants {
         "pinot.broker.enable.single.pool.segments.metric";
     public static final boolean DEFAULT_ENABLE_SINGLE_POOL_SEGMENTS_METRIC = false;
 
+    // REGEXP_LIKE broker configuration constants
+    public static final String REGEXP_DICT_CARDINALITY_THRESHOLD_KEY =
+        "pinot.broker.regexp.dict.cardinality.threshold";
+    public static final String USE_DICT_FOR_REGEXP_LIKE_PREDICATE_KEY =
+        "pinot.broker.use.dict.regexp.predicate";
+
     // When the server instance's pool field is null or the pool contains multi distinguished group value, the broker
     // would set the pool to -1 in the routing table for that server.
     public static final int FALLBACK_POOL_ID = -1;
@@ -788,6 +794,16 @@ public class CommonConstants {
         // Option denoting the workloadName to which the query belongs. This is used to enforce resource budgets for
         // each workload if "Query Workload Isolation" feature enabled.
         public static final String WORKLOAD_NAME = "workloadName";
+
+        /// When the cardinality of the dictionary is less than this threshold, scan the dictionary
+        // to get the matching ids. Default value is 10K.
+        public static final int DEFAULT_DICTIONARY_CARDINALITY_THRESHOLD = 10000;
+
+        /// Query option key for configuring the dictionary cardinality threshold
+        public static final String REGEXP_DICTIONARY_CARDINALITY_THRESHOLD_OPTION = "regexpDictCardinalityThreshold";
+
+        /// Query option key to force use of dictionary scan
+        public static final String USE_DICT_FOR_REGEXP_LIKE_PREDICATE_OPTION = "useDictForRegexpLikePredicate";
       }
 
       public static class QueryOptionValue {


### PR DESCRIPTION
**Context:** Currently REGEXP_LIKE without FST/IFST index cases where the number of docs scanned exceed  far beyond 10K, and the cardinality percent still remains low even if the cardinality of the dictionary exceeds 10k. So having a configurable parameter for the user to switch between RAW scan and DICTIONARY based scan is necessary. This PR introduces this switch in 2 ways:
- Always use Dictionary scan using query option - `useDictForRegexpLikePredicate`

**Example:** select count(*) from mytable where REGEXP_LIKE(NewAddedSVJSONDimension, '.*')  OPTION(useDictForRegexpLikePredicate=true)

-  If the `useDictForRegexpLikePredicate` is not set to true, then check the threshold limit on the dict usage from `regexpDictCardinalityThreshold`. By default this is set to 10K.

**Example:** select count(*) from mytable where REGEXP_LIKE(NewAddedSVJSONDimension, '.*')   OPTION(regexpDictCardinalityThreshold=50000)

Broker Configs:

`pinot.broker.use.dict.regexp.predicate` - If one wants to always use Dictionary scan for REGEXP_LIKE queries. 
`pinot.broker.regexp.dict.cardinality.threshold` - If one wants to set a threshold when pinot.broker.use.dict.regexp.predicate is not set to true. 

**Order of Priority:**
Query options > Broker Configs

**Note:** Implementing the configs at table level is complex for MultiStage Engine queries, although it's pretty straight forward for SSE. So, keeping that in mind didn't update the query config settings in the table config for now.