### PR TITLE
Fix auto reset and optimize multi-topic ingestion

### DIFF
--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/PauseState.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/PauseState.java
@@ -29,7 +29,7 @@ public class PauseState extends BaseJsonConfig {
   private String _comment;
   private String _timestamp;
   // List of inactive topic indices. Index is the index of the topic in the streamConfigMaps.
-  private List<Integer> _indexOfInactiveTopics;
+  private List<Integer> _indexOfInactiveTopics = new ArrayList<>();
 
   public PauseState() {
   }
@@ -80,7 +80,10 @@ public class PauseState extends BaseJsonConfig {
   }
 
   public void setIndexOfInactiveTopics(List<Integer> indexOfInactiveTopics) {
-    _indexOfInactiveTopics = indexOfInactiveTopics == null ? new ArrayList<>() : indexOfInactiveTopics;
+    _indexOfInactiveTopics.clear();
+    if (indexOfInactiveTopics != null) {
+      _indexOfInactiveTopics.addAll(indexOfInactiveTopics);
+    }
   }
 
   public enum ReasonCode {


### PR DESCRIPTION
`bugfix` `feature`
Issue: https://github.com/apache/pinot/issues/16831

Fix the NPE issue caused by using the empty constructor with some fixes and improvements:

- Remove most usages of `streamConfigs.get(0)` and pass in the actual `streamConfig` that should be in use. Now the only remaining part of `get(0)` use are
    - Fetching table name -- ok to keep
    - Fetching segment offset criteria -- should fix, so that we can pause by topic and resume topic consumption with different criteria
    - Creating streamMetadataFactory -- should fix, so that we can do multi-topic consumption from different stream types
- Bug fix on pause/resume on topics
- Make offset auto reset compatible with multi-topic ingestion
