### PR TITLE
[routing] Handle New Segments in MultiStageReplicaGroupSelector

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/MultiStageReplicaGroupSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/MultiStageReplicaGroupSelector.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
@@ -38,6 +39,7 @@ import org.apache.pinot.broker.routing.adaptiveserverselector.ServerSelectionCon
 import org.apache.pinot.common.assignment.InstancePartitions;
 import org.apache.pinot.common.assignment.InstancePartitionsUtils;
 import org.apache.pinot.common.metrics.BrokerMetrics;
+import org.apache.pinot.common.utils.LLCSegmentName;
 import org.apache.pinot.core.transport.ServerInstance;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.assignment.InstancePartitionsType;
@@ -130,10 +132,11 @@ public class MultiStageReplicaGroupSelector extends BaseInstanceSelector {
     Map<String, Set<String>> instanceToSegmentsMap = new HashMap<>();
 
     // instanceToSegmentsMap stores the mapping from instance to the active segments it can serve.
+    // We have to handle new segments explicitly.
     for (String segment : segments) {
       List<SegmentInstanceCandidate> candidates = segmentStates.getCandidates(segment);
-      Preconditions.checkState(candidates != null && !candidates.isEmpty(),
-        "Failed to find servers for segment: %s", segment);
+      Preconditions.checkState(CollectionUtils.isNotEmpty(candidates) || isNewLLCSegment(segment),
+          "Failed to find servers for segment: %s", segment);
       for (SegmentInstanceCandidate candidate : candidates) {
         instanceToSegmentsMap
           .computeIfAbsent(candidate.getInstance(), k -> new HashSet<>())
@@ -164,6 +167,15 @@ public class MultiStageReplicaGroupSelector extends BaseInstanceSelector {
     }
 
     return computeOptionalSegments(segmentToSelectedInstanceMap, segmentStates);
+  }
+
+  private boolean isNewLLCSegment(String segmentName) {
+    LLCSegmentName llcSegmentName = LLCSegmentName.of(segmentName);
+    if (llcSegmentName == null) {
+      return false;
+    }
+    return InstanceSelector.isNewSegment(llcSegmentName.getCreationTimeMs(), System.currentTimeMillis(),
+        _newSegmentExpirationTimeInSeconds * 1000);
   }
 
   /**


### PR DESCRIPTION
### Summary

We are seeing this issue manifest in our production. The existing logic in the multiStageReplicaGroup instance selector doesn't handle new segments gracefully. If there's a new segment, that would be immediately returned by the Segment Selector, which is then passed onto the instance selector. Within `MultiStageReplicaGroupSelector`, we were throwing an exception if the candidates were empty, and not honoring the segment expiration threshold.

This PR fixes that by allowing the precondition to pass if the segment is new.

### Test Plan

Will figure it out soon. Hoping some existing UTs can be extended to cover this.