### PR TITLE
fix wrong timeunit in ExecutorServiceUtils close

### DIFF
--- a/pinot-spi/src/main/java/org/apache/pinot/spi/executor/ExecutorServiceUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/executor/ExecutorServiceUtils.java
@@ -124,7 +124,7 @@ public class ExecutorServiceUtils {
   public static void close(ExecutorService executorService, long terminationMillis) {
     executorService.shutdown();
     try {
-      if (!executorService.awaitTermination(terminationMillis, TimeUnit.SECONDS)) {
+      if (!executorService.awaitTermination(terminationMillis, TimeUnit.MILLISECONDS)) {
         List<Runnable> runnables = executorService.shutdownNow();
         LOGGER.warn("Around {} didn't finish in time after a shutdown", runnables.size());
       }


### PR DESCRIPTION
closes https://github.com/apache/pinot/issues/16841

this is a `bugfix`. The v2 engine is effectively taking ~9 hours to shutdown instead of 30s. 