### PR TITLE
Add support for MAP data type in batch File ingestion Tasks

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/genericrow/GenericRowSerializer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/genericrow/GenericRowSerializer.java
@@ -30,6 +30,7 @@ import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.utils.BigDecimalUtils;
+import org.apache.pinot.spi.utils.MapUtils;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -110,6 +111,12 @@ public class GenericRowSerializer {
             break;
           case BYTES:
             numBytes += Integer.BYTES + ((byte[]) value).length;
+            break;
+          case MAP:
+            Map<String, Object> map = (Map<String, Object>) value;
+            byte[] mapBytes = MapUtils.serializeMap(map);
+            numBytes += Integer.BYTES + mapBytes.length;
+            _objectBytes[i] = mapBytes;
             break;
           default:
             throw new IllegalStateException("Unsupported SV stored type: " + _storedTypes[i]);
@@ -193,6 +200,11 @@ public class GenericRowSerializer {
             byte[] bytes = (byte[]) value;
             byteBuffer.putInt(bytes.length);
             byteBuffer.put(bytes);
+            break;
+          case MAP:
+            byte[] mapBytes = (byte[]) _objectBytes[i];
+            byteBuffer.putInt(mapBytes.length);
+            byteBuffer.put(mapBytes);
             break;
           default:
             throw new IllegalStateException("Unsupported SV stored type: " + _storedTypes[i]);

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/processing/genericrow/GenericRowSerDeTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/processing/genericrow/GenericRowSerDeTest.java
@@ -21,10 +21,12 @@ package org.apache.pinot.core.segment.processing.genericrow;
 import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
+import org.apache.pinot.spi.data.ComplexFieldSpec;
 import org.apache.pinot.spi.data.DimensionFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
@@ -49,6 +51,7 @@ public class GenericRowSerDeTest {
         new DimensionFieldSpec("stringSV", DataType.STRING, true),
         new DimensionFieldSpec("bytesSV", DataType.BYTES, true),
         new MetricFieldSpec("bigDecimalSV", DataType.BIG_DECIMAL), new DimensionFieldSpec("nullSV", DataType.INT, true),
+        new ComplexFieldSpec("mapSV", DataType.MAP, true, new HashMap<>()),
         new DimensionFieldSpec("intMV", DataType.INT, false), new DimensionFieldSpec("longMV", DataType.LONG, false),
         new DimensionFieldSpec("floatMV", DataType.FLOAT, false),
         new DimensionFieldSpec("doubleMV", DataType.DOUBLE, false),
@@ -64,6 +67,13 @@ public class GenericRowSerDeTest {
     _row.putValue("bytesSV", new byte[]{1, 2, 3});
     _row.putValue("bigDecimalSV", new BigDecimal("122333"));
     _row.putDefaultNullValue("nullSV", Integer.MAX_VALUE);
+
+    // Add MAP data
+    Map<String, Object> mapData = new HashMap<>();
+    mapData.put("key1", "value1");
+    mapData.put("key2", 42);
+    mapData.put("key3", 3.14);
+    _row.putValue("mapSV", mapData);
     _row.putValue("intMV", new Object[]{123, 456});
     _row.putValue("longMV", new Object[]{123L, 456L});
     _row.putValue("floatMV", new Object[]{123.0f, 456.0f});
@@ -135,5 +145,88 @@ public class GenericRowSerDeTest {
     for (int i = 0; i < numFields; i++) {
       assertEquals(deserializer.compare(0L, numBytes, i), 0);
     }
+  }
+
+  @Test
+  public void testMapSerDe() {
+    List<FieldSpec> mapFieldSpecs = Arrays.asList(new ComplexFieldSpec("mapSV", DataType.MAP, true, new HashMap<>()));
+
+    GenericRow mapRow = new GenericRow();
+    Map<String, Object> testMap = new HashMap<>();
+    testMap.put("stringKey", "stringValue");
+    testMap.put("intKey", 123);
+    testMap.put("doubleKey", 45.67);
+    mapRow.putValue("mapSV", testMap);
+
+    GenericRowSerializer serializer = new GenericRowSerializer(mapFieldSpecs, false);
+    byte[] bytes = serializer.serialize(mapRow);
+    PinotDataBuffer dataBuffer = PinotDataBuffer.allocateDirect(bytes.length, PinotDataBuffer.NATIVE_ORDER, null);
+    dataBuffer.readFrom(0L, bytes);
+    GenericRowDeserializer deserializer = new GenericRowDeserializer(dataBuffer, mapFieldSpecs, false);
+    GenericRow buffer = new GenericRow();
+    deserializer.deserialize(0L, buffer);
+
+    @SuppressWarnings("unchecked")
+    Map<String, Object> deserializedMap = (Map<String, Object>) buffer.getValue("mapSV");
+    assertEquals(deserializedMap, testMap);
+  }
+
+  @Test
+  public void testMapCompare() {
+    // Test MAP comparison for both different and equal maps
+    List<FieldSpec> mapFieldSpecs = Arrays.asList(new ComplexFieldSpec("mapSV", DataType.MAP, true, new HashMap<>()));
+
+    GenericRow mapRow1 = new GenericRow();
+    Map<String, Object> testMap1 = new HashMap<>();
+    testMap1.put("key1", "value1");
+    testMap1.put("key2", 123);
+    mapRow1.putValue("mapSV", testMap1);
+
+    GenericRow mapRow2 = new GenericRow();
+    Map<String, Object> testMap2 = new HashMap<>();
+    testMap2.put("key1", "value2");
+    testMap2.put("key2", 123);
+    mapRow2.putValue("mapSV", testMap2);
+
+    GenericRowSerializer serializer = new GenericRowSerializer(mapFieldSpecs, false);
+    byte[] bytes1 = serializer.serialize(mapRow1);
+    byte[] bytes2 = serializer.serialize(mapRow2);
+
+    long numBytes = Math.max(bytes1.length, bytes2.length);
+    PinotDataBuffer dataBuffer = PinotDataBuffer.allocateDirect(numBytes * 2, PinotDataBuffer.NATIVE_ORDER, null);
+    dataBuffer.readFrom(0L, bytes1);
+    dataBuffer.readFrom(numBytes, bytes2);
+
+    GenericRowDeserializer deserializer = new GenericRowDeserializer(dataBuffer, mapFieldSpecs, true);
+
+    // This should return non-zero as values are different
+    int result = deserializer.compare(0L, numBytes, 1);
+    assertTrue(result != 0, "MAP comparison should return non-zero for different maps");
+
+    // Test 2: Equal maps should return 0
+    GenericRow mapRow3 = new GenericRow();
+    Map<String, Object> testMap3 = new HashMap<>();
+    testMap3.put("key1", "value1");
+    testMap3.put("key2", 123);
+    mapRow3.putValue("mapSV", testMap3);
+
+    GenericRow mapRow4 = new GenericRow();
+    Map<String, Object> testMap4 = new HashMap<>();
+    testMap4.put("key1", "value1"); // Same value
+    testMap4.put("key2", 123);      // Same value
+    mapRow4.putValue("mapSV", testMap4);
+
+    byte[] bytes3 = serializer.serialize(mapRow3);
+    byte[] bytes4 = serializer.serialize(mapRow4);
+
+    long numBytes2 = Math.max(bytes3.length, bytes4.length);
+    PinotDataBuffer dataBuffer2 = PinotDataBuffer.allocateDirect(numBytes2 * 2, PinotDataBuffer.NATIVE_ORDER, null);
+    dataBuffer2.readFrom(0L, bytes3);
+    dataBuffer2.readFrom(numBytes2, bytes4);
+
+    GenericRowDeserializer deserializer2 = new GenericRowDeserializer(dataBuffer2, mapFieldSpecs, true);
+
+    int result2 = deserializer2.compare(0L, numBytes2, 1);
+    assertEquals(result2, 0, "MAP comparison should return 0 for equal maps");
   }
 }


### PR DESCRIPTION
PR contains changes to add support for MAP data type in GenericRowSerializer and GenericRowDeserializer for File Ingestion Tasks for MAP data type.
