### PR TITLE
Fix server metric initialization

### DIFF
--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/ServerInstance.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/ServerInstance.java
@@ -29,10 +29,8 @@ import org.apache.pinot.common.config.GrpcConfig;
 import org.apache.pinot.common.config.NettyConfig;
 import org.apache.pinot.common.config.TlsConfig;
 import org.apache.pinot.common.function.FunctionRegistry;
-import org.apache.pinot.common.metrics.ServerGauge;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.utils.tls.TlsUtils;
-import org.apache.pinot.common.version.PinotVersion;
 import org.apache.pinot.core.data.manager.InstanceDataManager;
 import org.apache.pinot.core.operator.transform.function.TransformFunction;
 import org.apache.pinot.core.operator.transform.function.TransformFunctionFactory;
@@ -53,8 +51,6 @@ import org.apache.pinot.server.starter.helix.SendStatsPredicate;
 import org.apache.pinot.server.worker.WorkerQueryServer;
 import org.apache.pinot.spi.accounting.ThreadResourceUsageAccountant;
 import org.apache.pinot.spi.env.PinotConfiguration;
-import org.apache.pinot.spi.metrics.PinotMetricUtils;
-import org.apache.pinot.spi.metrics.PinotMetricsRegistry;
 import org.apache.pinot.spi.plugin.PluginManager;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.slf4j.Logger;
@@ -68,7 +64,7 @@ import org.slf4j.LoggerFactory;
 public class ServerInstance {
   private static final Logger LOGGER = LoggerFactory.getLogger(ServerInstance.class);
 
-  private final ServerMetrics _serverMetrics;
+  private final HelixManager _helixManager;
   private final InstanceDataManager _instanceDataManager;
   private final QueryExecutor _queryExecutor;
   private final LongAccumulator _latestQueryTime;
@@ -76,11 +72,9 @@ public class ServerInstance {
   private final QueryServer _nettyQueryServer;
   private final QueryServer _nettyTlsQueryServer;
   private final GrpcQueryServer _grpcQueryServer;
-  private final AccessControl _accessControl;
-  private final HelixManager _helixManager;
-
   private final WorkerQueryServer _workerQueryServer;
-  private ChannelHandler _instanceRequestHandler;
+  private final ChannelHandler _instanceRequestHandler;
+  private final ServerMetrics _serverMetrics = ServerMetrics.get();
 
   private boolean _dataManagerStarted = false;
   private boolean _queryServerStarted = false;
@@ -92,14 +86,6 @@ public class ServerInstance {
     LOGGER.info("Initializing server instance");
     _helixManager = helixManager;
 
-    LOGGER.info("Initializing server metrics");
-    PinotMetricsRegistry metricsRegistry = PinotMetricUtils.getPinotMetricsRegistry(serverConf.getMetricsConfig());
-    _serverMetrics =
-        new ServerMetrics(serverConf.getMetricsPrefix(), metricsRegistry, serverConf.emitTableLevelMetrics(),
-            serverConf.getAllowedTablesForEmittingMetrics());
-    _serverMetrics.initializeGlobalMeters();
-    _serverMetrics.setValueOfGlobalGauge(ServerGauge.VERSION, PinotVersion.VERSION_METRIC_NAME, 1);
-    ServerMetrics.register(_serverMetrics);
     if (segmentOperationsThrottler != null) {
       // Initialize the metrics for the throttler so it picks up the newly registered ServerMetrics object
       segmentOperationsThrottler.initializeMetrics();
@@ -133,7 +119,7 @@ public class ServerInstance {
         NettyConfig.extractNettyConfig(serverConf.getPinotConfig(), CommonConstants.Server.SERVER_NETTY_PREFIX);
     accessControlFactory.init(
         serverConf.getPinotConfig().subset(CommonConstants.Server.PREFIX_OF_CONFIG_OF_ACCESS_CONTROL), helixManager);
-    _accessControl = accessControlFactory.create();
+    AccessControl accessControl = accessControlFactory.create();
 
     if (serverConf.isMultiStageServerEnabled()) {
       LOGGER.info("Initializing Multi-stage query engine");
@@ -143,24 +129,24 @@ public class ServerInstance {
       _workerQueryServer = null;
     }
 
+    ChannelHandler instanceRequestHandler = null;
     if (serverConf.isNettyServerEnabled()) {
       int nettyPort = serverConf.getNettyPort();
       LOGGER.info("Initializing Netty query server on port: {}", nettyPort);
-      _instanceRequestHandler =
+      instanceRequestHandler =
           ChannelHandlerFactory.getInstanceRequestHandler(helixManager.getInstanceName(), serverConf.getPinotConfig(),
               _queryScheduler, _serverMetrics, new AllowAllAccessFactory().create());
-      _nettyQueryServer = new QueryServer(nettyPort, nettyConfig, _instanceRequestHandler);
+      _nettyQueryServer = new QueryServer(nettyPort, nettyConfig, instanceRequestHandler);
     } else {
       _nettyQueryServer = null;
     }
-
     if (serverConf.isNettyTlsServerEnabled()) {
       int nettySecPort = serverConf.getNettyTlsPort();
       LOGGER.info("Initializing TLS-secured Netty query server on port: {}", nettySecPort);
-      _instanceRequestHandler =
+      instanceRequestHandler =
           ChannelHandlerFactory.getInstanceRequestHandler(helixManager.getInstanceName(), serverConf.getPinotConfig(),
-              _queryScheduler, _serverMetrics, _accessControl);
-      _nettyTlsQueryServer = new QueryServer(nettySecPort, nettyConfig, tlsConfig, _instanceRequestHandler);
+              _queryScheduler, _serverMetrics, accessControl);
+      _nettyTlsQueryServer = new QueryServer(nettySecPort, nettyConfig, tlsConfig, instanceRequestHandler);
     } else {
       _nettyTlsQueryServer = null;
     }
@@ -173,10 +159,11 @@ public class ServerInstance {
           : null;
       _grpcQueryServer = new GrpcQueryServer(instanceName, grpcPort,
           GrpcConfig.buildGrpcQueryConfig(serverConf.getPinotConfig()),
-          actualTslConfig, _queryExecutor, _serverMetrics, _accessControl);
+          actualTslConfig, _queryExecutor, _serverMetrics, accessControl);
     } else {
       _grpcQueryServer = null;
     }
+    _instanceRequestHandler = instanceRequestHandler;
 
     LOGGER.info("Initializing transform functions");
     Set<Class<TransformFunction>> transformFunctionClasses = new HashSet<>();

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
@@ -112,6 +112,8 @@ import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.environmentprovider.PinotEnvironmentProvider;
 import org.apache.pinot.spi.environmentprovider.PinotEnvironmentProviderFactory;
 import org.apache.pinot.spi.filesystem.PinotFSFactory;
+import org.apache.pinot.spi.metrics.PinotMetricUtils;
+import org.apache.pinot.spi.metrics.PinotMetricsRegistry;
 import org.apache.pinot.spi.plugin.PluginManager;
 import org.apache.pinot.spi.services.ServiceRole;
 import org.apache.pinot.spi.services.ServiceStartable;
@@ -163,6 +165,7 @@ public abstract class BaseServerStarter implements ServiceStartable {
   protected HelixConfigScope _instanceConfigScope;
   protected HelixManager _helixManager;
   protected HelixAdmin _helixAdmin;
+  protected ServerMetrics _serverMetrics;
   protected ServerInstance _serverInstance;
   protected AccessControlFactory _accessControlFactory;
   protected AdminApiApplication _adminApiApplication;
@@ -173,7 +176,7 @@ public abstract class BaseServerStarter implements ServiceStartable {
   protected SegmentOperationsThrottler _segmentOperationsThrottler;
   protected DefaultClusterConfigChangeHandler _clusterConfigChangeHandler;
   protected volatile boolean _isServerReadyToServeQueries = false;
-  private ScheduledExecutorService _helixMessageCountScheduler;
+  protected ScheduledExecutorService _helixMessageCountScheduler;
   protected ThreadResourceUsageAccountant _resourceUsageAccountant;
 
   @Override
@@ -608,6 +611,16 @@ public abstract class BaseServerStarter implements ServiceStartable {
     LOGGER.info("Server configs: {}", new PinotAppConfigs(getConfig()).toJSONString());
     long startTimeMs = System.currentTimeMillis();
 
+    LOGGER.info("Initializing server metrics");
+    ServerConf serverConf = new ServerConf(_serverConf);
+    PinotMetricsRegistry metricsRegistry = PinotMetricUtils.getPinotMetricsRegistry(serverConf.getMetricsConfig());
+    _serverMetrics =
+        new ServerMetrics(serverConf.getMetricsPrefix(), metricsRegistry, serverConf.emitTableLevelMetrics(),
+            serverConf.getAllowedTablesForEmittingMetrics());
+    _serverMetrics.initializeGlobalMeters();
+    _serverMetrics.setValueOfGlobalGauge(ServerGauge.VERSION, PinotVersion.VERSION_METRIC_NAME, 1);
+    ServerMetrics.register(_serverMetrics);
+
     // install default SSL context if necessary (even if not force-enabled everywhere)
     TlsConfig tlsDefaults = TlsUtils.extractTlsConfig(_serverConf, Server.SERVER_TLS_PREFIX);
     if (StringUtils.isNotBlank(tlsDefaults.getKeyStorePath()) || StringUtils.isNotBlank(
@@ -683,18 +696,16 @@ public abstract class BaseServerStarter implements ServiceStartable {
     Preconditions.checkNotNull(_resourceUsageAccountant);
 
     SendStatsPredicate sendStatsPredicate = SendStatsPredicate.create(_serverConf, _helixManager);
-    ServerConf serverConf = new ServerConf(_serverConf);
     _serverInstance = new ServerInstance(serverConf, _helixManager, _accessControlFactory, _segmentOperationsThrottler,
         sendStatsPredicate, _resourceUsageAccountant);
-    ServerMetrics serverMetrics = _serverInstance.getServerMetrics();
 
     InstanceDataManager instanceDataManager = _serverInstance.getInstanceDataManager();
     instanceDataManager.setSupplierOfIsServerReadyToServeQueries(() -> _isServerReadyToServeQueries);
 
     // Enable Server level realtime ingestion rate limier
-    RealtimeConsumptionRateManager.getInstance().createServerRateLimiter(_serverConf, serverMetrics);
+    RealtimeConsumptionRateManager.getInstance().createServerRateLimiter(_serverConf, _serverMetrics);
     PinotClusterConfigChangeListener serverRateLimitConfigChangeListener =
-        new ServerRateLimitConfigChangeListener(serverMetrics);
+        new ServerRateLimitConfigChangeListener(_serverMetrics);
     _clusterConfigChangeHandler.registerClusterConfigChangeListener(serverRateLimitConfigChangeListener);
 
     initSegmentFetcher(_serverConf);
@@ -747,13 +758,13 @@ public abstract class BaseServerStarter implements ServiceStartable {
 
     // Register message handler factory
     SegmentMessageHandlerFactory messageHandlerFactory =
-        new SegmentMessageHandlerFactory(instanceDataManager, serverMetrics);
+        new SegmentMessageHandlerFactory(instanceDataManager, _serverMetrics);
     _helixManager.getMessagingService()
         .registerMessageHandlerFactory(Message.MessageType.USER_DEFINE_MSG.toString(), messageHandlerFactory);
 
-    serverMetrics.addCallbackGauge(Helix.INSTANCE_CONNECTED_METRIC_NAME, () -> _helixManager.isConnected() ? 1L : 0L);
+    _serverMetrics.addCallbackGauge(Helix.INSTANCE_CONNECTED_METRIC_NAME, () -> _helixManager.isConnected() ? 1L : 0L);
     _helixManager.addPreConnectCallback(
-        () -> serverMetrics.addMeteredGlobalValue(ServerMeter.HELIX_ZOOKEEPER_RECONNECTS, 1L));
+        () -> _serverMetrics.addMeteredGlobalValue(ServerMeter.HELIX_ZOOKEEPER_RECONNECTS, 1L));
 
     // Register the service status handler
     registerServiceStatusHandler();
@@ -763,7 +774,7 @@ public abstract class BaseServerStarter implements ServiceStartable {
       long endTimeMs =
           startTimeMs + _serverConf.getProperty(Server.CONFIG_OF_STARTUP_TIMEOUT_MS, Server.DEFAULT_STARTUP_TIMEOUT_MS);
       try {
-        serverMetrics.setValueOfGlobalGauge(ServerGauge.STARTUP_STATUS_CHECK_IN_PROGRESS, 1);
+        _serverMetrics.setValueOfGlobalGauge(ServerGauge.STARTUP_STATUS_CHECK_IN_PROGRESS, 1);
         startupServiceStatusCheck(endTimeMs);
       } catch (Exception e) {
         LOGGER.error("Caught exception while checking service status. Stopping server.", e);
@@ -772,7 +783,7 @@ public abstract class BaseServerStarter implements ServiceStartable {
         _helixManager.disconnect();
         throw e;
       } finally {
-        serverMetrics.setValueOfGlobalGauge(ServerGauge.STARTUP_STATUS_CHECK_IN_PROGRESS, 0);
+        _serverMetrics.setValueOfGlobalGauge(ServerGauge.STARTUP_STATUS_CHECK_IN_PROGRESS, 0);
       }
     }
 
@@ -803,23 +814,23 @@ public abstract class BaseServerStarter implements ServiceStartable {
     LOGGER.info("Pinot server ready");
 
     // Create metrics for mmap stuff
-    serverMetrics.addCallbackGauge("memory.directBufferCount", PinotDataBuffer::getDirectBufferCount);
-    serverMetrics.addCallbackGauge("memory.directBufferUsage", PinotDataBuffer::getDirectBufferUsage);
-    serverMetrics.addCallbackGauge("memory.mmapBufferCount", PinotDataBuffer::getMmapBufferCount);
-    serverMetrics.addCallbackGauge("memory.mmapBufferUsage", PinotDataBuffer::getMmapBufferUsage);
-    serverMetrics.addCallbackGauge("memory.allocationFailureCount", PinotDataBuffer::getAllocationFailureCount);
+    _serverMetrics.addCallbackGauge("memory.directBufferCount", PinotDataBuffer::getDirectBufferCount);
+    _serverMetrics.addCallbackGauge("memory.directBufferUsage", PinotDataBuffer::getDirectBufferUsage);
+    _serverMetrics.addCallbackGauge("memory.mmapBufferCount", PinotDataBuffer::getMmapBufferCount);
+    _serverMetrics.addCallbackGauge("memory.mmapBufferUsage", PinotDataBuffer::getMmapBufferUsage);
+    _serverMetrics.addCallbackGauge("memory.allocationFailureCount", PinotDataBuffer::getAllocationFailureCount);
 
     // Add ZK buffer size metric
-    serverMetrics.setOrUpdateGlobalGauge(ServerGauge.ZK_JUTE_MAX_BUFFER,
+    _serverMetrics.setOrUpdateGlobalGauge(ServerGauge.ZK_JUTE_MAX_BUFFER,
         () -> Integer.getInteger(ZkSystemPropertyKeys.JUTE_MAXBUFFER, 0xfffff));
 
     // Track metric for queries disabled
     _serverQueriesDisabledTracker =
-        new ServerQueriesDisabledTracker(_helixClusterName, _instanceId, _helixManager, serverMetrics);
+        new ServerQueriesDisabledTracker(_helixClusterName, _instanceId, _helixManager, _serverMetrics);
     _serverQueriesDisabledTracker.start();
 
     // Add metrics for consumer directory usage
-    serverMetrics.setOrUpdateGlobalGauge(ServerGauge.REALTIME_CONSUMER_DIR_USAGE, () -> {
+    _serverMetrics.setOrUpdateGlobalGauge(ServerGauge.REALTIME_CONSUMER_DIR_USAGE, () -> {
       List<File> instanceConsumerDirs = instanceDataManager.getConsumerDirPaths();
       long totalSize = 0;
       try {
@@ -837,11 +848,9 @@ public abstract class BaseServerStarter implements ServiceStartable {
 
     long startupDurationMs = System.currentTimeMillis() - startTimeMs;
     if (ServiceStatus.getServiceStatus(_instanceId).equals(Status.GOOD)) {
-      serverMetrics.addTimedValue(
-          ServerTimer.STARTUP_SUCCESS_DURATION_MS, startupDurationMs, TimeUnit.MILLISECONDS);
+      _serverMetrics.addTimedValue(ServerTimer.STARTUP_SUCCESS_DURATION_MS, startupDurationMs, TimeUnit.MILLISECONDS);
     } else {
-      serverMetrics.addTimedValue(
-          ServerTimer.STARTUP_FAILURE_DURATION_MS, startupDurationMs, TimeUnit.MILLISECONDS);
+      _serverMetrics.addTimedValue(ServerTimer.STARTUP_FAILURE_DURATION_MS, startupDurationMs, TimeUnit.MILLISECONDS);
     }
   }
 


### PR DESCRIPTION
Fix #16849

Initialize server metrics as the first step when starting a server to ensure it is accessible in all components