### PR TITLE
Use different ingestion delay metrics for backfill topics

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
@@ -98,6 +98,7 @@ public enum ServerGauge implements AbstractMetrics.Gauge {
   REALTIME_INGESTION_CONSUMING_OFFSET("consumingOffset", false, "The offset of the last consumed message."),
   REALTIME_INGESTION_DELAY_MS("milliseconds", false,
       "The difference of the current timestamp and the timestamp present in the last consumed message record."),
+  BACKFILL_REALTIME_INGESTION_DELAY_MS("milliseconds", false),
   REALTIME_CONSUMER_DIR_USAGE("bytes", true),
   SEGMENT_DOWNLOAD_SPEED("bytes", true),
   PREDOWNLOAD_SPEED("bytes", true),


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Add backfill\-specific ingestion delay metric and use it conditionally based on stream config\.

```mermaid
flowchart TD
  N0["Add BACKFILL gauge enum #40;F1#41;"]:::stAdded
  N1["Fetch stream configs list #40;F2#41;"]:::stAdded
  N2["Get stream config index for partition #40;F2#41;"]:::stAdded
  N3["Select stream config by index #40;F2#41;"]:::stAdded
  N4["Check if backfill topic #40;F2#41;"]:::stAdded
  N5["Set ingestion delay gauge #40;backfill#47;realtime#41; #40;F2#41;"]:::stAdded
  N6["Remove backfill gauge on partition removal #40;F2#41;"]:::stAdded
  N1 -->|"uses"| N3
  N2 -->|"uses"| N3
  N3 -->|"uses"| N4
  N4 -->|"branch"| N5
  N0 -->|"uses"| N5
  N0 -->|"uses"| N6
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge\.java — [before](https://github.com/apache/pinot/blob/9d32f376d839330fbec98d48738ee0d82de122e7/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java) · [after](https://github.com/apache/pinot/blob/61d00ff4f25a835894f000aaf4447b174f140b53/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java)
- F2: pinot\-core/src/main/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTracker\.java — [before](https://github.com/apache/pinot/blob/9d32f376d839330fbec98d48738ee0d82de122e7/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTracker.java) · [after](https://github.com/apache/pinot/blob/61d00ff4f25a835894f000aaf4447b174f140b53/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTracker.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjlkMzJmMzc2ZDgzOTMzMGZiZWM5OGQ0ODczOGVlMGQ4MmRlMTIyZTciLCJjb250ZXh0X2hhc2giOiI2NGFmNWEzNzU1MjAxNjA0ODYzMjM1YmZjM2EzMWU0YzdjNTBmY2M2YzUzMmZjMmVhNDVlNmM1YmRjMmY1MTVlIiwiZ2VuZXJhdGVkX2F0IjoxNzkwMDYyNTI4LCJoZWFkX3NoYSI6IjYxZDAwZmY0ZjI1YTgzNTg5NGYwMDBhYWY0NDQ3YjE3NGYxNDBiNTMiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiI5ZDMyZjM3NmQ4MzkzMzBmYmVjOThkNDg3MzhlZTBkODJkZTEyMmU3IiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 4b2830a29cf5afb516eab26163a3e8aca6bfefb74dbc9f07cebf89c44f29035a -->
<!-- pinot-pr-flow:end -->

`observability`

The backfill topics may inherit the source topic's timestamp (e.g. Kafka metadata). In such use case, we want to track how users can consume the latest data. The backfill should have a different metrics to track latency.
