### PR TITLE
Fix LagValueWindowFunction type used for the default value

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/value/LagValueWindowFunction.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/value/LagValueWindowFunction.java
@@ -42,6 +42,7 @@ public class LagValueWindowFunction extends ValueWindowFunction {
     Object defaultValue = null;
     List<RexExpression> operands = aggCall.getFunctionOperands();
     int numOperands = operands.size();
+    Preconditions.checkArgument(numOperands > 0, "LAG function requires at least one operand");
     if (numOperands > 1) {
       RexExpression secondOperand = operands.get(1);
       Preconditions.checkArgument(secondOperand instanceof RexExpression.Literal,
@@ -59,7 +60,7 @@ public class LagValueWindowFunction extends ValueWindowFunction {
       defaultValue = defaultValueLiteral.getValue();
       if (defaultValue != null) {
         DataSchema.ColumnDataType srcDataType = defaultValueLiteral.getDataType();
-        DataSchema.ColumnDataType destDataType = inputSchema.getColumnDataType(0);
+        DataSchema.ColumnDataType destDataType = getDataType();
         if (srcDataType != destDataType) {
           // Convert the default value to the same data type as the input column
           // (e.g. convert INT to LONG, FLOAT to DOUBLE, etc.

--- a/pinot-query-runtime/src/test/resources/queries/WindowFunctions.json
+++ b/pinot-query-runtime/src/test/resources/queries/WindowFunctions.json
@@ -2416,6 +2416,18 @@
     },
     "queries": [
       {
+        "description": "LAG function with PARTITION BY",
+        "sql": "SELECT int_col, LAG(string_col, 1, 'defVal') OVER(PARTITION BY int_col ORDER BY double_col) as lag_col FROM {tbl} where int_col = 42 ORDER by int_col, double_col",
+        "outputs": [
+          [42, "defVal"],
+          [42, "a"],
+          [42, "d"],
+          [42, "e"],
+          [42, "e"],
+          [42, "a"]
+        ]
+      },
+      {
         "description": "Single OVER(PARTITION BY) sum",
         "sql": "SELECT SUM(int_col) OVER(PARTITION BY string_col) FROM {tbl}",
         "outputs": [


### PR DESCRIPTION
Recently, the following bug was reported on Apache Pinot slack ([link](https://apache-pinot.slack.com/archives/CDRCA57FC/p1758127794636609)):

Using ColocatedQuickStart, the following query:
```sql
select 
userUUID,
LAG(totalTrips, 1, 3) OVER (PARTITION BY userUUID ORDER BY deviceOS) AS prev_is_active
from userAttributes 
order by deviceOS
limit 10
```

Fails with:

```
Received 1 error from stage 2 on Server_192.168.1.93_7050: class java.lang.String cannot be cast to class java.lang.Number (java.lang.String and java.lang.Number are in module java.base of loader 'bootstrap')
```

If we weren't providing a default value for the LAG function (its 3rd argument). The reason is very simple, when we try to assign a type to that default value, we used the type of the _first input_ (in this case `userUUID`, whose type is String). The fix is to use the type of the expression itself or even easier, the type of the function itself, which is what I'm doing on this PR.

I've also added a test, which fails in master but works here.