### PR TITLE
Add table level distributed locking for ensuring minion task generation is atomic

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider.java
@@ -308,6 +308,10 @@ public class ZKMetadataProvider {
     return StringUtil.join("/", PROPERTYSTORE_MINION_TASK_METADATA_PREFIX, tableNameWithType);
   }
 
+  public static String constructPropertyStorePathForMinionTaskGenerationLock(String tableNameWithType) {
+    return StringUtil.join("/", PROPERTYSTORE_MINION_TASK_METADATA_PREFIX, tableNameWithType + "-Lock");
+  }
+
   public static String getPropertyStoreWorkloadConfigsPrefix() {
     return PROPERTYSTORE_QUERY_WORKLOAD_CONFIGS_PREFIX;
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -186,6 +186,10 @@ public class ControllerConf extends PinotConfiguration {
     // end of the task.
     public static final String PINOT_TASK_EXPIRE_TIME_MS = "controller.task.expire.time.ms";
 
+    // Distributed lock enablement for PinotTaskManager
+    public static final String ENABLE_DISTRIBUTED_LOCKING = "controller.task.enableDistributedLocking";
+    public static final boolean DEFAULT_ENABLE_DISTRIBUTED_LOCKING = false;
+
     @Deprecated
     // RealtimeSegmentRelocator has been rebranded as SegmentRelocator
     public static final String DEPRECATED_REALTIME_SEGMENT_RELOCATOR_FREQUENCY =
@@ -1243,6 +1247,11 @@ public class ControllerConf extends PinotConfiguration {
 
   public boolean isPinotTaskManagerSchedulerEnabled() {
     return getProperty(ControllerPeriodicTasksConf.PINOT_TASK_MANAGER_SCHEDULER_ENABLED, false);
+  }
+
+  public boolean isPinotTaskManagerDistributedLockingEnabled() {
+    return getProperty(ControllerPeriodicTasksConf.ENABLE_DISTRIBUTED_LOCKING,
+        ControllerPeriodicTasksConf.DEFAULT_ENABLE_DISTRIBUTED_LOCKING);
   }
 
   public long getPinotTaskExpireTimeInMs() {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTaskRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTaskRestletResource.java
@@ -785,4 +785,24 @@ public class PinotTaskRestletResource {
     _pinotHelixTaskResourceManager.deleteTask(taskName, forceDelete);
     return new SuccessResponse("Successfully deleted task: " + taskName);
   }
+
+  @DELETE
+  @Path("/tasks/lock/forceRelease")
+  @Authorize(targetType = TargetType.TABLE, action = Actions.Table.FORCE_RELEASE_TASK_GENERATION_LOCK,
+      paramName = "tableNameWithType")
+  @Produces(MediaType.APPLICATION_JSON)
+  @Authenticate(AccessType.DELETE)
+  @ApiOperation("Force releases the task generation lock for a given table. Call this API with caution")
+  public SuccessResponse forceReleaseTaskGenerationLock(
+      @ApiParam(value = "Table name (with type suffix).", required = true)
+      @QueryParam("tableNameWithType") String tableNameWithType) {
+    boolean lockReleased = _pinotTaskManager.forceReleaseLock(tableNameWithType);
+    if (lockReleased) {
+      return new SuccessResponse("Successfully released task generation lock on table " + tableNameWithType
+          + " for all task types");
+    } else {
+      throw new ControllerApplicationException(LOGGER, "Failed to release task generation lock on table: "
+          + tableNameWithType + ", try again later", Response.Status.INTERNAL_SERVER_ERROR);
+    }
+  }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/DistributedTaskLockManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/DistributedTaskLockManager.java
@@ -1,0 +1,563 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core.minion;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.annotation.Nullable;
+import org.apache.helix.AccessOption;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.pinot.common.metadata.ZKMetadataProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Manages distributed locks for minion task generation using ZooKeeper ephemeral sequential nodes.
+ * Uses ephemeral nodes that automatically disappear when the controller session ends.
+ * This approach provides automatic cleanup and is suitable for long-running task generation.
+ * Locks are held until explicitly released or the controller session terminates.
+ * Locks are at the table level, to ensure that only one type of task can be generated per table at any given time.
+ */
+public class DistributedTaskLockManager {
+  private static final Logger LOGGER = LoggerFactory.getLogger(DistributedTaskLockManager.class);
+
+  // Lock and state paths are constructed using ZKMetadataProvider
+  private static final String LOCK_SUFFIX = "-Lock";
+  private static final String STATE_SUFFIX = "-State";
+  private static final String LOCK_OWNER_KEY = "lockOwner";
+  private static final String LOCK_PATH_KEY = "lockPath";
+  private static final String LOCK_UUID_KEY = "lockUuid";
+  private static final String LOCK_TIMESTAMP_MILLIS_KEY = "lockTimestampMillis";
+  private static final String TASK_GENERATION_STATUS_KEY = "status";
+  private static final String TASK_GENERATION_START_TIME_MILLIS_KEY = "startTimeMillis";
+  private static final String TASK_GENERATION_COMPLETION_TIME_MILLIS_KEY = "completionTimeMillis";
+  private static final long STALE_THRESHOLD_MILLIS = 24 * 60 * 60 * 1000L; // 24 hours;
+
+  // Task generation states
+  private enum Status {
+    // IN_PROGRESS if the task generation is currently in progress;
+    // COMPLETED if the task generation completed successfully;
+    // FAILED if the task generation failed.
+    IN_PROGRESS, COMPLETED, FAILED
+  }
+
+  // Define a custom comparator to compare strings of format '<controllerName>-lock-<sequenceNumber>' and sort them by
+  // the sequence number at the end
+  private static final Comparator<String> TASK_LOCK_SEQUENCE_ID_COMPARATOR = (s1, s2) -> {
+    // Regex to find the trailing sequence of digits
+    Pattern p = Pattern.compile("\\d+$");
+
+    // Extract the number from the first string
+    Matcher m1 = p.matcher(s1);
+    long num1 = m1.find() ? Long.parseLong(m1.group()) : 0;
+
+    // Extract the number from the second string
+    Matcher m2 = p.matcher(s2);
+    long num2 = m2.find() ? Long.parseLong(m2.group()) : 0;
+
+    return Long.compare(num1, num2);
+  };
+
+  private final ZkHelixPropertyStore<ZNRecord> _propertyStore;
+  private final String _controllerInstanceId;
+
+  public DistributedTaskLockManager(ZkHelixPropertyStore<ZNRecord> propertyStore, String controllerInstanceId) {
+    _propertyStore = propertyStore;
+    _controllerInstanceId = controllerInstanceId;
+
+    // Ensure base paths exist
+    ensureBasePaths();
+  }
+
+  /**
+   * Attempts to acquire a distributed lock for task generation using session-based locking.
+   * The lock is held until explicitly released or the controller session ends.
+   * The lock is created at the table level
+   *
+   * @param tableName the table name (can be null for all-table operations)
+   * @return TaskLock object if successful, null if lock could not be acquired
+   */
+  @Nullable
+  public TaskLock acquireLock(@Nullable String tableName) {
+    String tableNameForPath = (tableName != null) ? tableName : "ALL_TABLES";
+    String lockBasePath = getLockBasePath(tableNameForPath);
+    String statePath = lockBasePath.replace(LOCK_SUFFIX, STATE_SUFFIX);
+
+    LOGGER.info("Attempting to acquire task generation lock: {} by controller: {}", tableNameForPath,
+        _controllerInstanceId);
+
+    try {
+      // Check if task generation is already in progress
+      if (isTaskGenerationInProgress(tableNameForPath, lockBasePath, statePath)) {
+        LOGGER.info("Task generation already in progress for: {} by this or another controller", tableNameForPath);
+        return null;
+      }
+
+      // Try to acquire the lock using ephemeral sequential node
+      TaskLock lock = tryAcquireSessionBasedLock(lockBasePath, statePath, tableNameForPath);
+      if (lock != null) {
+        LOGGER.info("Successfully acquired task generation lock: {} by controller: {}", tableNameForPath,
+            _controllerInstanceId);
+        return lock;
+      } else {
+        LOGGER.warn("Could not acquire lock: {} - another controller holds it", tableNameForPath);
+        return null;
+      }
+    } catch (Exception e) {
+      LOGGER.error("Error while trying to acquire lock: {}", tableNameForPath, e);
+      return null;
+    }
+  }
+
+  private String getLockBasePath(String tableNameForPath) {
+    return ZKMetadataProvider.constructPropertyStorePathForMinionTaskGenerationLock(tableNameForPath);
+  }
+
+  private String getBasePath() {
+    return ZKMetadataProvider.getPropertyStorePathForMinionTaskMetadataPrefix();
+  }
+
+  /**
+   * Releases a lock assuming successful completion.
+   */
+  public boolean releaseLock(TaskLock lock) {
+    return releaseLock(lock, true);
+  }
+
+  /**
+   * Releases a previously acquired session-based lock and marks task generation as completed.
+   *
+   * @param lock the lock to release
+   * @param success whether task generation completed successfully
+   * @return true if successfully released, false otherwise
+   */
+  public boolean releaseLock(TaskLock lock, boolean success) {
+    if (lock == null) {
+      return true;
+    }
+
+    String lockKey = lock.getLockKey();
+
+    try {
+      // Mark task generation as completed/failed
+      markTaskGenerationCompleted(lock.getStatePath(), lockKey, success);
+
+      // Remove the ephemeral lock node
+      if (lock.getLockNodePath() != null) {
+        try {
+          boolean status = _propertyStore.remove(lock.getLockNodePath(), AccessOption.EPHEMERAL);
+          LOGGER.info("Removed ephemeral lock node: {}, removal success: {}", lock.getLockNodePath(), status);
+        } catch (Exception e) {
+          // Lock node might have already been removed due to session timeout - this is OK
+          LOGGER.warn("Ephemeral lock node already removed or session expired: {}", lock.getLockNodePath(), e);
+        }
+      }
+
+      LOGGER.info("Successfully released task generation lock: {} by controller: {} (success: {})", lockKey,
+          _controllerInstanceId, success);
+      return true;
+    } catch (Exception e) {
+      LOGGER.error("Error while releasing lock: {}", lockKey, e);
+      return false;
+    }
+  }
+
+  /**
+   * Force release the lock without checking if any tasks are in progress
+   */
+  public boolean forceReleaseLock(String tableNameWithType) {
+    LOGGER.info("Trying to force release the lock for table: {}", tableNameWithType);
+    String lockBasePath = getLockBasePath(tableNameWithType);
+
+    boolean released = true;
+    if (_propertyStore.exists(lockBasePath, AccessOption.PERSISTENT)) {
+      List<String> lockNodes = _propertyStore.getChildNames(lockBasePath, AccessOption.PERSISTENT);
+      if (lockNodes != null && !lockNodes.isEmpty()) {
+        // There are active ephemeral lock nodes, check if any are still valid and delete them
+        for (String nodeName : lockNodes) {
+          String nodePath = lockBasePath + "/" + nodeName;
+          if (_propertyStore.exists(nodePath, AccessOption.EPHEMERAL)) {
+            LOGGER.info("Lock for table: {} found at path: {}, trying to remove", tableNameWithType, nodePath);
+            boolean result = _propertyStore.remove(nodePath, AccessOption.EPHEMERAL);
+            if (!result) {
+              LOGGER.warn("Could not force release lock: {}", nodePath);
+              released = false;
+            }
+          }
+        }
+      } else {
+        LOGGER.info("No locks to force release, no child lock ZNodes found for table: {} under base: {}",
+            tableNameWithType, lockBasePath);
+      }
+    } else {
+      LOGGER.info("No locks to force release, no base lock ZNode: {} found for table: {}", lockBasePath,
+          tableNameWithType);
+    }
+    return released;
+  }
+
+  /**
+   * Checks if task generation is currently in progress for the given task type and table.
+   *
+   * @param tableName the table name
+   * @return true if task generation is in progress, false otherwise
+   */
+  @VisibleForTesting
+  boolean isTaskGenerationInProgress(@Nullable String tableName) {
+    String tableNameForPath = (tableName != null) ? tableName : "ALL_TABLES";
+    String lockBasePath = getLockBasePath(tableNameForPath);
+    String statePath = lockBasePath.replace(LOCK_SUFFIX, STATE_SUFFIX);
+    return isTaskGenerationInProgress(tableNameForPath, lockBasePath, statePath);
+  }
+
+  /**
+   * Internal method to check if task generation is in progress for a lock key.
+   */
+  private boolean isTaskGenerationInProgress(String lockKey, String lockBasePath, String statePath) {
+    try {
+      // Check if there are any active ephemeral lock nodes
+      if (_propertyStore.exists(lockBasePath, AccessOption.PERSISTENT)) {
+        List<String> lockNodes = _propertyStore.getChildNames(lockBasePath, AccessOption.PERSISTENT);
+        if (lockNodes != null && !lockNodes.isEmpty()) {
+          // There are active ephemeral lock nodes, check if any are still valid
+          boolean anyEphemeralLockExists = false;
+          for (String nodeName : lockNodes) {
+            String nodePath = lockBasePath + "/" + nodeName;
+            if (_propertyStore.exists(nodePath, AccessOption.EPHEMERAL)) {
+              anyEphemeralLockExists = true;
+              // Ephemeral node exists, meaning session is still alive and task could be in progress (we update the
+              // state to COMPLETED / FAILED before removing the lock, so better to double-check the task generation
+              // state if the lock exists)
+              ZNRecord stateRecord = _propertyStore.get(statePath, null, AccessOption.PERSISTENT);
+              if (stateRecord != null) {
+                String status = stateRecord.getSimpleField(TASK_GENERATION_STATUS_KEY);
+                String lockPath = stateRecord.getSimpleField(LOCK_PATH_KEY);
+                if (lockPath != null && lockPath.equals(nodePath)) {
+                  return Status.IN_PROGRESS.name().equals(status);
+                }
+              }
+            }
+          }
+
+          // If we cannot find a matching statePath, but found valid locks, return true just in case the state path
+          // wasn't created yet
+          return anyEphemeralLockExists;
+        }
+      }
+
+      return false;
+    } catch (Exception e) {
+      LOGGER.error("Error checking task generation status for: {}", lockKey, e);
+      return false;
+    }
+  }
+
+  /**
+   * Cleans up stale task generation state records.
+   * Since we use session-based locking, expired locks clean themselves up automatically.
+   * This method only cleans up stale state records.
+   */
+  public void cleanupStaleStates() {
+    try {
+      LOGGER.info("Start cleaning up stale states");
+      // Get the base path for minion task metadata
+      String basePath = getBasePath();
+      if (!_propertyStore.exists(basePath, AccessOption.PERSISTENT)) {
+        return;
+      }
+
+      // Traverse table directories under the base path
+      List<String> tableNameEntries = _propertyStore.getChildNames(basePath, AccessOption.PERSISTENT);
+      if (tableNameEntries == null) {
+        return;
+      }
+
+      long currentTimeMs = System.currentTimeMillis();
+
+      for (String tableNameEntry : tableNameEntries) {
+        try {
+          if (tableNameEntry.endsWith(STATE_SUFFIX)) {
+            String statePath = basePath + "/" + tableNameEntry;
+            ZNRecord stateRecord = _propertyStore.get(statePath, null, AccessOption.PERSISTENT);
+
+            if (stateRecord != null) {
+              String status = stateRecord.getSimpleField(TASK_GENERATION_STATUS_KEY);
+              String startTimeMsStr = stateRecord.getSimpleField(TASK_GENERATION_START_TIME_MILLIS_KEY);
+
+              if (startTimeMsStr != null) {
+                long startTimeMs = Long.parseLong(startTimeMsStr);
+                boolean isStale = (currentTimeMs - startTimeMs) > STALE_THRESHOLD_MILLIS;
+
+                int lastIndexOfTableName = tableNameEntry.lastIndexOf(STATE_SUFFIX);
+
+                // Clean up completed/failed states older than threshold, or in-progress states without active locks
+                if ((Status.COMPLETED.name().equals(status) || Status.FAILED.name().equals(status)) && isStale) {
+                  _propertyStore.remove(statePath, AccessOption.PERSISTENT);
+                  LOGGER.info("Cleaned up stale table state: {} (status: {}, age: {}ms)",
+                      tableNameEntry, status, currentTimeMs - startTimeMs);
+                } else if (Status.IN_PROGRESS.name().equals(status)
+                    && !hasActiveLocks(tableNameEntry.substring(0, lastIndexOfTableName))) {
+                  // In-progress state without active locks - likely a dead session
+                  _propertyStore.remove(statePath, AccessOption.PERSISTENT);
+                  LOGGER.info("Cleaned up orphaned in-progress task state: {}, for table: {}", tableNameEntry,
+                      tableNameEntry.substring(0, lastIndexOfTableName));
+                }
+              }
+            }
+          }
+        } catch (Exception e) {
+          LOGGER.warn("Error cleaning up state for table: {}", tableNameEntry, e);
+        }
+      }
+    } catch (Exception e) {
+      LOGGER.error("Error during state cleanup", e);
+    }
+  }
+
+  /**
+   * Attempts to acquire a lock using ephemeral sequential nodes.
+   * Uses the ZooKeeper recipe for distributed locking with automatic cleanup.
+   */
+  @VisibleForTesting
+  TaskLock tryAcquireSessionBasedLock(String lockBasePath, String statePath, String lockKey) {
+    try {
+      long currentTimeMs = System.currentTimeMillis();
+
+      // Ensure the base lock directory exists
+      if (!_propertyStore.exists(lockBasePath, AccessOption.PERSISTENT)) {
+        ZNRecord baseRecord = new ZNRecord(lockKey);
+        _propertyStore.create(lockBasePath, baseRecord, AccessOption.PERSISTENT);
+      }
+
+      // Create ephemeral sequential node for this controller, add an UUID to ensure that the path is unique in case
+      // multiple controller threads run at the same time
+      UUID uuid = UUID.randomUUID();
+      String lockNodePrefix = lockBasePath + "/" + _controllerInstanceId + "-" + uuid + "-lock-";
+      ZNRecord lockRecord = new ZNRecord(_controllerInstanceId);
+      lockRecord.setSimpleField(LOCK_OWNER_KEY, _controllerInstanceId);
+      lockRecord.setSimpleField(LOCK_TIMESTAMP_MILLIS_KEY, String.valueOf(currentTimeMs));
+      lockRecord.setSimpleField(LOCK_UUID_KEY, uuid.toString());
+
+      // ZK will assign the sequence when creating EPHEMERAL_SEQUENTIAL ZNodes
+      boolean created = _propertyStore.create(lockNodePrefix, lockRecord, AccessOption.EPHEMERAL_SEQUENTIAL);
+
+      if (created) {
+        // Find our actual node path by listing children and finding the one we just created, the UUID makes the path
+        // unique, even if we have multiple requests from the same controller
+        List<String> children = _propertyStore.getChildNames(lockBasePath, AccessOption.PERSISTENT);
+        List<String> allLockNodePathsForController = new ArrayList<>();
+        String lockNodePath = null;
+        if (children != null) {
+          // Find any node that starts with our controller ID and contains "-lock-"
+          for (String child : children) {
+            if (child.startsWith(_controllerInstanceId) && child.contains("-lock-")) {
+              if (child.startsWith(_controllerInstanceId + "-" + uuid)) {
+                // If the node also contains the UUID, it's the lock we created
+                lockNodePath = lockBasePath + "/" + child;
+              }
+              allLockNodePathsForController.add(lockBasePath + "/" + child);
+            }
+          }
+        }
+
+        LOGGER.info("Found {} lockNodePaths for controller instance: {}, list: {}, first lockNodePath cached: {}",
+            allLockNodePathsForController.size(), _controllerInstanceId, allLockNodePathsForController, lockNodePath);
+
+        if (lockNodePath != null && allLockNodePathsForController.size() == 1) {
+          // Check if we got the lowest sequence number (i.e., we're first in line)
+          List<String> allChildren = _propertyStore.getChildNames(lockBasePath, AccessOption.PERSISTENT);
+          if (allChildren != null && !allChildren.isEmpty()) {
+            allChildren.sort(TASK_LOCK_SEQUENCE_ID_COMPARATOR); // Sort by sequence number
+            String ourNode = lockNodePath.substring(lockNodePath.lastIndexOf('/') + 1);
+            if (ourNode.equals(allChildren.get(0))) {
+              // We have the lock! Mark task generation as in progress
+              markTaskGenerationInProgress(statePath, lockNodePath, lockKey);
+              LOGGER.info("Acquired lock with ephemeral node: {}", lockNodePath);
+              return new TaskLock(lockKey, _controllerInstanceId, currentTimeMs, lockNodePath, statePath);
+            } else {
+              // Someone else has the lock, clean up our node
+              boolean status = _propertyStore.remove(lockNodePath, AccessOption.EPHEMERAL);
+              LOGGER.info("Did not get lock, removing ephemeral node: {}, return status: {}", lockNodePath, status);
+              return null;
+            }
+          } else {
+            // No children found, something went wrong, clean up
+            boolean status = _propertyStore.remove(lockNodePath, AccessOption.EPHEMERAL);
+            LOGGER.warn("No children found under {}. Remove lockNodePath status: {} for node: {}. Something must have "
+                    + "gone wrong", lockBasePath, status, lockNodePath);
+            return null;
+          }
+        } else {
+          // Could not find our node path, or found too many paths for the same controller, cleanup failed creation
+          LOGGER.warn("Either lockNodePath: {} wasn't found, or too many locks ({}) found for the same controller: {},"
+                  + "list of locks: {}", lockNodePath, allLockNodePathsForController.size(), _controllerInstanceId,
+              allLockNodePathsForController);
+
+          if (lockNodePath != null) {
+            boolean status = _propertyStore.remove(lockNodePath, AccessOption.EPHEMERAL);
+            LOGGER.warn("Remove lockNodePath status: {} for path: {}", status, lockNodePath);
+          }
+          return null;
+        }
+      }
+      return null;
+    } catch (Exception e) {
+      LOGGER.error("Error creating ephemeral lock under path: {}, lockKey: {}", lockBasePath, lockKey, e);
+      return null;
+    }
+  }
+
+  /**
+   * Marks task generation as in progress.
+   */
+  private void markTaskGenerationInProgress(String statePath, String lockNodePath, String lockKey) {
+    try {
+      ZNRecord stateRecord = new ZNRecord(lockKey);
+      stateRecord.setSimpleField(TASK_GENERATION_STATUS_KEY, Status.IN_PROGRESS.name());
+      stateRecord.setSimpleField(TASK_GENERATION_START_TIME_MILLIS_KEY, String.valueOf(System.currentTimeMillis()));
+      stateRecord.setSimpleField(LOCK_OWNER_KEY, _controllerInstanceId);
+      stateRecord.setSimpleField(LOCK_PATH_KEY, lockNodePath);
+
+      _propertyStore.set(statePath, stateRecord, AccessOption.PERSISTENT);
+    } catch (Exception e) {
+      LOGGER.warn("Error marking task generation in progress for path: {}, lockKey: {}", statePath, lockKey, e);
+    }
+  }
+
+  /**
+   * Marks task generation as completed or failed.
+   */
+  private void markTaskGenerationCompleted(String statePath, String lockKey, boolean success) {
+    try {
+      ZNRecord stateRecord = _propertyStore.get(statePath, null, AccessOption.PERSISTENT);
+
+      if (stateRecord == null) {
+        LOGGER.info("Could not find ZNode record for state path: {}, creating a new one", statePath);
+        stateRecord = new ZNRecord(lockKey);
+      }
+
+      stateRecord.setSimpleField(TASK_GENERATION_STATUS_KEY, success ? Status.COMPLETED.name() : Status.FAILED.name());
+      stateRecord.setSimpleField(TASK_GENERATION_COMPLETION_TIME_MILLIS_KEY,
+          String.valueOf(System.currentTimeMillis()));
+
+      _propertyStore.set(statePath, stateRecord, AccessOption.PERSISTENT);
+    } catch (Exception e) {
+      LOGGER.warn("Error marking task generation completed for path: {}, lockKey: {}", statePath, lockKey, e);
+    }
+  }
+
+  /**
+   * Checks if there are active ephemeral locks for the given key.
+   */
+  private boolean hasActiveLocks(String tableName) {
+    try {
+      String lockBasePath = getLockBasePath(tableName);
+      if (!_propertyStore.exists(lockBasePath, AccessOption.PERSISTENT)) {
+        return false;
+      }
+
+      List<String> children = _propertyStore.getChildNames(lockBasePath, AccessOption.PERSISTENT);
+      if (children != null && !children.isEmpty()) {
+        // Check if any ephemeral nodes still exist (session still alive)
+        for (String childName : children) {
+          String childPath = lockBasePath + "/" + childName;
+          if (_propertyStore.exists(childPath, AccessOption.EPHEMERAL)) {
+            return true;
+          }
+        }
+      }
+      return false;
+    } catch (Exception e) {
+      LOGGER.warn("Error checking active locks for table: {}", tableName, e);
+      return false;
+    }
+  }
+
+  private void ensureBasePaths() {
+    try {
+      // Ensure minion task metadata base path exists
+      String basePath = getBasePath();
+      if (!_propertyStore.exists(basePath, AccessOption.PERSISTENT)) {
+        ZNRecord baseRecord = new ZNRecord("MINION_TASK_METADATA");
+        _propertyStore.create(basePath, baseRecord, AccessOption.PERSISTENT);
+        LOGGER.info("Created base path for minion task metadata: {}", basePath);
+      }
+    } catch (Exception e) {
+      LOGGER.warn("Error ensuring base paths exist", e);
+    }
+  }
+
+  /**
+   * Represents a session-based distributed lock for task generation.
+   * The lock is automatically released when the controller session ends.
+   * The state node is periodically cleaned up
+   */
+  public static class TaskLock {
+    private final String _lockKey;
+    private final String _owner;
+    private final long _timestamp;
+    private final String _lockNodePath; // Path to the ephemeral lock node
+    private final String _statePath; // Path to the state record
+
+    public TaskLock(String lockKey, String owner, long timestamp, String lockNodePath, String statePath) {
+      _lockKey = lockKey;
+      _owner = owner;
+      _timestamp = timestamp;
+      _lockNodePath = lockNodePath;
+      _statePath = statePath;
+    }
+
+    public String getLockKey() {
+      return _lockKey;
+    }
+
+    public String getOwner() {
+      return _owner;
+    }
+
+    public long getTimestamp() {
+      return _timestamp;
+    }
+
+    public String getLockNodePath() {
+      return _lockNodePath;
+    }
+
+    public String getStatePath() {
+      return _statePath;
+    }
+
+    public long getAge() {
+      return System.currentTimeMillis() - _timestamp;
+    }
+
+    @Override
+    public String toString() {
+      return String.format("TaskLock{key='%s', owner='%s', timestamp=%d, age=%dms, nodePath='%s'}",
+          _lockKey, _owner, _timestamp, getAge(), _lockNodePath);
+    }
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
@@ -34,6 +34,9 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.commons.collections4.CollectionUtils;
@@ -122,6 +125,9 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
 
   private final TaskManagerStatusCache<TaskGeneratorMostRecentRunInfo> _taskManagerStatusCache;
 
+  protected final DistributedTaskLockManager _distributedTaskLockManager;
+  private ScheduledExecutorService _distributedTaskExecutorService = null;
+
   public PinotTaskManager(PinotHelixTaskResourceManager helixTaskResourceManager,
       PinotHelixResourceManager helixResourceManager, LeadControllerManager leadControllerManager,
       ControllerConf controllerConf, ControllerMetrics controllerMetrics,
@@ -149,6 +155,18 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
     } else {
       _scheduler = null;
     }
+
+    // For distributed locking
+    boolean enableDistributedLocking = controllerConf.isPinotTaskManagerDistributedLockingEnabled();
+    if (enableDistributedLocking) {
+      LOGGER.info("Distributed locking is enabled for PinotTaskManager");
+      // Initialize distributed task lock manager if distributed locking is enabled
+      _distributedTaskLockManager = new DistributedTaskLockManager(helixResourceManager.getPropertyStore(),
+          helixResourceManager.getHelixZkManager().getInstanceName());
+    } else {
+      LOGGER.info("Distributed locking is disabled for PinotTaskManager");
+      _distributedTaskLockManager = null;
+    }
   }
 
   public void init() {
@@ -169,6 +187,11 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
       } catch (SchedulerException e) {
         throw new RuntimeException("Caught exception while setting up the scheduler", e);
       }
+    }
+
+    if (_distributedTaskLockManager != null) {
+      // Start the distributed lock cleanup task if enabled
+      startLockCleanupTask();
     }
   }
 
@@ -210,6 +233,7 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
     if (tableNameWithTypes.isEmpty()) {
       throw new TableNotFoundException("'tableName' " + tableName + " is not found");
     }
+    LOGGER.info("Generating tasks for {} tables, list: {}", tableNameWithTypes.size(), tableNameWithTypes);
 
     PinotTaskGenerator taskGenerator = _taskGeneratorRegistry.getTaskGenerator(taskType);
     // Generate each type of tasks
@@ -239,37 +263,76 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
       // Example usage in BaseTaskGenerator.getNumSubTasks()
       taskConfigs.put(MinionConstants.TRIGGERED_BY, CommonConstants.TaskTriggers.ADHOC_TRIGGER.name());
 
-      List<PinotTaskConfig> pinotTaskConfigs = taskGenerator.generateTasks(tableConfig, taskConfigs);
-      if (pinotTaskConfigs.isEmpty()) {
-        LOGGER.warn("No ad-hoc task generated for task type: {}", taskType);
-        continue;
+      // Acquire distributed lock before proceeding with ad-hoc task generation
+      // Need locking to protect against:
+      // 1. Race conditions with periodic task generation
+      // 2. Multiple simultaneous ad-hoc requests
+      // 3. Leadership changes during task generation
+      DistributedTaskLockManager.TaskLock lock = null;
+      boolean taskCreationSuccess = true;
+      if (_distributedTaskLockManager != null) {
+        lock = _distributedTaskLockManager.acquireLock(tableNameWithType);
+        if (lock == null) {
+          String message = String.format("Could not acquire table level distributed lock for ad-hoc task type: %s, "
+                  + "table: %s. Another controller is likely generating tasks for this type. Please try again later.",
+              taskType, tableNameWithType);
+          LOGGER.warn(message);
+          throw new RuntimeException(message);
+        }
+        LOGGER.info("Acquired table level distributed lock for ad-hoc task type: {} on table: {}", taskType,
+            tableNameWithType);
       }
-      int maxNumberOfSubTasks = taskGenerator.getMaxAllowedSubTasksPerTask();
-      if (pinotTaskConfigs.size() > maxNumberOfSubTasks) {
-        String message = String.format(
-            "Number of tasks generated for task type: %s for table: %s is %d, which is greater than the "
-                + "maximum number of tasks to schedule: %d. This is "
-                + "controlled by the cluster config %s which is set based on controller's performance.", taskType,
-            tableName, pinotTaskConfigs.size(), maxNumberOfSubTasks, MinionConstants.MAX_ALLOWED_SUB_TASKS_KEY);
-        message += "Optimise the task config or reduce tableMaxNumTasks to avoid the error";
-        // We throw an exception to notify the user
-        // This is to ensure that the user is aware of the task generation limit
-        throw new RuntimeException(message);
+
+      try {
+        List<PinotTaskConfig> pinotTaskConfigs = taskGenerator.generateTasks(tableConfig, taskConfigs);
+        if (pinotTaskConfigs.isEmpty()) {
+          LOGGER.warn("No ad-hoc task generated for task type: {}, for table: {}", taskType, tableNameWithType);
+          continue;
+        }
+        int maxNumberOfSubTasks = taskGenerator.getMaxAllowedSubTasksPerTask();
+        if (pinotTaskConfigs.size() > maxNumberOfSubTasks) {
+          String message = String.format(
+              "Number of tasks generated for task type: %s for table: %s is %d, which is greater than the "
+                  + "maximum number of tasks to schedule: %d. This is controlled by the cluster config %s which is set "
+                  + "based on controller's performance.", taskType, tableNameWithType, pinotTaskConfigs.size(),
+              maxNumberOfSubTasks, MinionConstants.MAX_ALLOWED_SUB_TASKS_KEY);
+          message += "Optimise the task config or reduce tableMaxNumTasks to avoid the error";
+          // We throw an exception to notify the user
+          // This is to ensure that the user is aware of the task generation limit
+          taskCreationSuccess = false;
+          throw new RuntimeException(message);
+        }
+        pinotTaskConfigs.forEach(pinotTaskConfig -> pinotTaskConfig.getConfigs()
+            .computeIfAbsent(MinionConstants.TRIGGERED_BY, k -> CommonConstants.TaskTriggers.ADHOC_TRIGGER.name()));
+        LOGGER.info("Submitting ad-hoc task for task type: {} with task configs: {}", taskType, pinotTaskConfigs);
+        _controllerMetrics.addMeteredTableValue(taskType, ControllerMeter.NUMBER_ADHOC_TASKS_SUBMITTED, 1);
+        responseMap.put(tableNameWithType,
+            _helixTaskResourceManager.submitTask(parentTaskName, pinotTaskConfigs, minionInstanceTag,
+                taskGenerator.getTaskTimeoutMs(minionInstanceTag),
+                taskGenerator.getNumConcurrentTasksPerInstance(minionInstanceTag),
+                taskGenerator.getMaxAttemptsPerTask(minionInstanceTag)));
+      } finally {
+        if (!responseMap.containsKey(tableNameWithType)) {
+          LOGGER.warn("No task submitted for tableNameWithType: {}", tableNameWithType);
+          taskCreationSuccess = false;
+        }
+        if (lock != null) {
+          _distributedTaskLockManager.releaseLock(lock, taskCreationSuccess);
+        }
       }
-      pinotTaskConfigs.forEach(pinotTaskConfig -> pinotTaskConfig.getConfigs()
-          .computeIfAbsent(MinionConstants.TRIGGERED_BY, k -> CommonConstants.TaskTriggers.ADHOC_TRIGGER.name()));
-      LOGGER.info("Submitting ad-hoc task for task type: {} with task configs: {}", taskType, pinotTaskConfigs);
-      _controllerMetrics.addMeteredTableValue(taskType, ControllerMeter.NUMBER_ADHOC_TASKS_SUBMITTED, 1);
-      responseMap.put(tableNameWithType,
-          _helixTaskResourceManager.submitTask(parentTaskName, pinotTaskConfigs, minionInstanceTag,
-              taskGenerator.getTaskTimeoutMs(minionInstanceTag),
-              taskGenerator.getNumConcurrentTasksPerInstance(minionInstanceTag),
-              taskGenerator.getMaxAttemptsPerTask(minionInstanceTag)));
     }
     if (responseMap.isEmpty()) {
       LOGGER.warn("No task submitted for tableName: {}", tableName);
     }
     return responseMap;
+  }
+
+  public boolean forceReleaseLock(String tableNameWithType) {
+    if (_distributedTaskLockManager == null) {
+      LOGGER.info("Distributed task lock manager is disabled, no locks to release");
+      return true;
+    }
+    return _distributedTaskLockManager.forceReleaseLock(tableNameWithType);
   }
 
   private class ZkTableConfigChangeListener implements IZkChildListener {
@@ -690,8 +753,46 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
       if (taskGenerator != null) {
         _helixTaskResourceManager.ensureTaskQueueExists(taskType);
         addTaskTypeMetricsUpdaterIfNeeded(taskType);
-        tasksScheduled.put(taskType, scheduleTask(taskGenerator, enabledTableConfigs, context.isLeader(),
-            context.getMinionInstanceTag(), context.getTriggeredBy()));
+
+        // Take the lock for all tables for which to schedule the tasks and pass the list of tables for which getting
+        // the lock was successful
+        // Need locking to protect against:
+        // 1. Race conditions with periodic task generation
+        // 2. Multiple simultaneous ad-hoc requests
+        // 3. Leadership changes during task generation
+        List<String> enabledTables =
+            enabledTableConfigs.stream().map(TableConfig::getTableName).collect(Collectors.toList());
+        Map<String, DistributedTaskLockManager.TaskLock> acquiredTaskLocks = new HashMap<>();
+        Map<String, Boolean> taskGenerationSuccesses = new HashMap<>();
+        for (String tableName : enabledTables) {
+          DistributedTaskLockManager.TaskLock lock;
+          if (_distributedTaskLockManager != null) {
+            lock = _distributedTaskLockManager.acquireLock(tableName);
+            if (lock == null) {
+              LOGGER.warn("Could not acquire table level distributed lock for scheduled task type: {} on table: {}, "
+                      + "skipping lock acquisition", taskType, tableName);
+              taskGenerationSuccesses.put(tableName, false);
+              continue;
+            }
+            acquiredTaskLocks.put(tableName, lock);
+            taskGenerationSuccesses.put(tableName, true);
+            LOGGER.info("Acquired table level distributed lock for scheduled task type: {} on table: {}", taskType,
+                tableName);
+          }
+        }
+
+        try {
+          tasksScheduled.put(taskType, scheduleTask(taskGenerator, enabledTableConfigs, context.isLeader(),
+              context.getMinionInstanceTag(), context.getTriggeredBy(), acquiredTaskLocks, taskGenerationSuccesses));
+        } finally {
+          // Release all the distributed table locks
+          if (_distributedTaskLockManager != null) {
+            for (Map.Entry<String, DistributedTaskLockManager.TaskLock> taskLockEntry : acquiredTaskLocks.entrySet()) {
+              _distributedTaskLockManager.releaseLock(taskLockEntry.getValue(),
+                  taskGenerationSuccesses.getOrDefault(taskLockEntry.getKey(), true));
+            }
+          }
+        }
       } else {
         List<String> enabledTables =
             enabledTableConfigs.stream().map(TableConfig::getTableName).collect(Collectors.toList());
@@ -727,7 +828,9 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
    *  - list of task scheduling errors if any
    */
   protected TaskSchedulingInfo scheduleTask(PinotTaskGenerator taskGenerator, List<TableConfig> enabledTableConfigs,
-      boolean isLeader, @Nullable String minionInstanceTagForTask, String triggeredBy) {
+      boolean isLeader, @Nullable String minionInstanceTagForTask, String triggeredBy,
+      Map<String, DistributedTaskLockManager.TaskLock> acquiredTaskLocks,
+      Map<String, Boolean> taskGenerationSuccesses) {
     TaskSchedulingInfo response = new TaskSchedulingInfo();
     String taskType = taskGenerator.getTaskType();
     List<String> enabledTables =
@@ -748,7 +851,8 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
               + "table: %s. Disk utilization for one or more servers hosting this table has exceeded the threshold. "
               + "Tasks won't be generated until the issue is mitigated.", tableName);
           LOGGER.warn(message);
-          response.addSchedulingError(message);
+          response.addGenerationError(message);
+          taskGenerationSuccesses.put(tableName, false);
           _controllerMetrics.setOrUpdateTableGauge(tableName, ControllerGauge.RESOURCE_UTILIZATION_LIMIT_EXCEEDED, 1L);
           continue;
         }
@@ -766,39 +870,49 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
           tableTaskConfig.getConfigsForTaskType(taskType).put(MinionConstants.TRIGGERED_BY, triggeredBy);
         }
 
-        taskGenerator.generateTasks(List.of(tableConfig), presentTaskConfig);
-        int maxNumberOfSubTasks = taskGenerator.getMaxAllowedSubTasksPerTask();
-        if (presentTaskConfig.size() > maxNumberOfSubTasks) {
-          String message = String.format(
-              "Number of tasks generated for task type: %s for table: %s is %d, which is greater than the "
-                  + "maximum number of tasks to schedule: %d. This is "
-                  + "controlled by the cluster config %s which is set based on controller's performance.", taskType,
-              tableName, presentTaskConfig.size(), maxNumberOfSubTasks, MinionConstants.MAX_ALLOWED_SUB_TASKS_KEY);
-          if (TaskSchedulingContext.isUserTriggeredTask(triggeredBy)) {
-            message += "Optimise the task config or reduce tableMaxNumTasks to avoid the error";
-            presentTaskConfig.clear();
-            // If the task is user-triggered, we throw an exception to notify the user
-            // This is to ensure that the user is aware of the task generation limit
-            throw new RuntimeException(message);
+        if (_distributedTaskLockManager == null || acquiredTaskLocks.containsKey(tableName)) {
+          taskGenerator.generateTasks(List.of(tableConfig), presentTaskConfig);
+          int maxNumberOfSubTasks = taskGenerator.getMaxAllowedSubTasksPerTask();
+          if (presentTaskConfig.size() > maxNumberOfSubTasks) {
+            String message = String.format(
+                "Number of tasks generated for task type: %s for table: %s is %d, which is greater than the "
+                    + "maximum number of tasks to schedule: %d. This is "
+                    + "controlled by the cluster config %s which is set based on controller's performance.", taskType,
+                tableName, presentTaskConfig.size(), maxNumberOfSubTasks, MinionConstants.MAX_ALLOWED_SUB_TASKS_KEY);
+            if (TaskSchedulingContext.isUserTriggeredTask(triggeredBy)) {
+              message += "Optimise the task config or reduce tableMaxNumTasks to avoid the error";
+              presentTaskConfig.clear();
+              taskGenerationSuccesses.put(tableName, false);
+              // If the task is user-triggered, we throw an exception to notify the user
+              // This is to ensure that the user is aware of the task generation limit
+              throw new RuntimeException(message);
+            }
+            // For scheduled tasks, we log a warning and limit the number of tasks
+            LOGGER.warn(message + "Only the first {} tasks will be scheduled", maxNumberOfSubTasks);
+            presentTaskConfig = new ArrayList<>(presentTaskConfig.subList(0, maxNumberOfSubTasks));
+            // Provide user visibility to the maximum number of subtasks that were used for the task
+            presentTaskConfig.forEach(pinotTaskConfig -> pinotTaskConfig.getConfigs()
+                .put(MinionConstants.TABLE_MAX_NUM_TASKS_KEY, String.valueOf(maxNumberOfSubTasks)));
           }
-          // For scheduled tasks, we log a warning and limit the number of tasks
-          LOGGER.warn(message + "Only the first {} tasks will be scheduled", maxNumberOfSubTasks);
-          presentTaskConfig = new ArrayList<>(presentTaskConfig.subList(0, maxNumberOfSubTasks));
-          // Provide user visibility to the maximum number of subtasks that were used for the task
-          presentTaskConfig.forEach(pinotTaskConfig -> pinotTaskConfig.getConfigs()
-              .put(MinionConstants.TABLE_MAX_NUM_TASKS_KEY, String.valueOf(maxNumberOfSubTasks)));
+          minionInstanceTagToTaskConfigs.put(minionInstanceTag, presentTaskConfig);
+          long successRunTimestamp = System.currentTimeMillis();
+          _taskManagerStatusCache.saveTaskGeneratorInfo(tableName, taskType,
+              taskGeneratorMostRecentRunInfo -> taskGeneratorMostRecentRunInfo.addSuccessRunTs(successRunTimestamp));
+          // before the first task schedule, the follow two gauge metrics will be empty
+          // TODO: find a better way to report task generation information
+          _controllerMetrics.setOrUpdateTableGauge(tableName, taskType,
+              ControllerGauge.TIME_MS_SINCE_LAST_SUCCESSFUL_MINION_TASK_GENERATION,
+              () -> System.currentTimeMillis() - successRunTimestamp);
+          _controllerMetrics.setOrUpdateTableGauge(tableName, taskType,
+              ControllerGauge.LAST_MINION_TASK_GENERATION_ENCOUNTERS_ERROR, 0L);
+        } else {
+          String message = String.format("Could not acquire table level distributed lock for scheduled task type: "
+              + "%s, table: %s. Another controller is likely generating tasks for this type. Please try again later.",
+              taskType, tableName);
+          LOGGER.warn(message);
+          response.addGenerationError(message);
+          taskGenerationSuccesses.put(tableName, false);
         }
-        minionInstanceTagToTaskConfigs.put(minionInstanceTag, presentTaskConfig);
-        long successRunTimestamp = System.currentTimeMillis();
-        _taskManagerStatusCache.saveTaskGeneratorInfo(tableName, taskType,
-            taskGeneratorMostRecentRunInfo -> taskGeneratorMostRecentRunInfo.addSuccessRunTs(successRunTimestamp));
-        // before the first task schedule, the follow two gauge metrics will be empty
-        // TODO: find a better way to report task generation information
-        _controllerMetrics.setOrUpdateTableGauge(tableName, taskType,
-            ControllerGauge.TIME_MS_SINCE_LAST_SUCCESSFUL_MINION_TASK_GENERATION,
-            () -> System.currentTimeMillis() - successRunTimestamp);
-        _controllerMetrics.setOrUpdateTableGauge(tableName, taskType,
-            ControllerGauge.LAST_MINION_TASK_GENERATION_ENCOUNTERS_ERROR, 0L);
       } catch (Exception e) {
         StringWriter errors = new StringWriter();
         try (PrintWriter pw = new PrintWriter(errors)) {
@@ -814,6 +928,7 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
         // TODO: find a better way to report task generation information
         _controllerMetrics.setOrUpdateTableGauge(tableName, taskType,
             ControllerGauge.LAST_MINION_TASK_GENERATION_ENCOUNTERS_ERROR, 1L);
+        taskGenerationSuccesses.put(tableName, false);
         LOGGER.error("Failed to generate tasks for task type {} for table {}", taskType, tableName, e);
       }
     }
@@ -883,6 +998,12 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
     for (String taskType : _taskGeneratorRegistry.getAllTaskTypes()) {
       _taskGeneratorRegistry.getTaskGenerator(taskType).nonLeaderCleanUp();
     }
+
+    if (_distributedTaskExecutorService != null) {
+      LOGGER.info("Shutting down lock cleanup executor service");
+      _distributedTaskExecutorService.shutdown();
+      _distributedTaskExecutorService = null;
+    }
   }
 
   @Override
@@ -936,5 +1057,31 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
       return false;
     }
     return true;
+  }
+
+  /**
+   * Starts a background thread to periodically clean up stale task generation states.
+   * Note: Session-based locks clean themselves up automatically, but we still need to clean up state records.
+   */
+  public void startLockCleanupTask() {
+    if (_distributedTaskExecutorService != null) {
+      LOGGER.warn("Lock cleanup task already started");
+    }
+
+    LOGGER.info("Starting lock clean up task");
+    _distributedTaskExecutorService = Executors.newSingleThreadScheduledExecutor();
+    _distributedTaskExecutorService.scheduleWithFixedDelay(() -> {
+      try {
+        LOGGER.info("Starting the lock clean up task");
+        _distributedTaskLockManager.cleanupStaleStates();
+      } catch (Throwable e) {
+        // catch all errors to prevent subsequent executions from being silently suppressed
+        // <pre>
+        // See <a href="https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ScheduledExecutorService
+        // .html#scheduleWithFixedDelay-java.lang.Runnable-long-long-java.util.concurrent.TimeUnit-">Ref</a>
+        // </pre>
+        LOGGER.warn("Caught exception while running lock clean up task", e);
+      }
+    }, getInitialDelayInSeconds(), 300, TimeUnit.SECONDS);
   }
 }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/DistributedTaskLockManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/DistributedTaskLockManagerTest.java
@@ -1,0 +1,233 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core.minion;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.UUID;
+import org.apache.helix.AccessOption;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.mockito.MockedStatic;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.*;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+
+public class DistributedTaskLockManagerTest {
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testEphemeralLockAcquisitionAndRelease() {
+    // Mock the property store and data accessor
+    ZkHelixPropertyStore<ZNRecord> mockPropertyStore = mock(ZkHelixPropertyStore.class);
+
+    // Define the specific UUID to use for the lock
+    UUID expectedUuid = UUID.fromString("123e4567-e89b-42d3-a456-426614174000");
+
+    // Configure mocks for ephemeral sequential node creation
+    when(mockPropertyStore.exists(anyString(), eq(AccessOption.PERSISTENT))).thenReturn(true);
+    when(mockPropertyStore.create(anyString(), any(ZNRecord.class), eq(AccessOption.EPHEMERAL_SEQUENTIAL)))
+        .thenReturn(true);
+    // Use the expectedUuid in the lock name to be returned
+    // Return just one controller, with the first sequence number
+    when(mockPropertyStore.getChildNames(anyString(), eq(AccessOption.PERSISTENT)))
+        .thenReturn(Arrays.asList("controller1-" + expectedUuid + "-lock-0000000001"));
+    when(mockPropertyStore.remove(anyString(), eq(AccessOption.EPHEMERAL))).thenReturn(true);
+    when(mockPropertyStore.set(anyString(), any(ZNRecord.class), eq(AccessOption.PERSISTENT))).thenReturn(true);
+
+    DistributedTaskLockManager lockManager = new DistributedTaskLockManager(mockPropertyStore, "controller1");
+
+    try (MockedStatic<UUID> mockedUuid = mockStatic(UUID.class)) {
+      // Configure the mock to return the specific UUID when randomUUID() is called
+      mockedUuid.when(UUID::randomUUID).thenReturn(expectedUuid);
+
+      // Test lock acquisition
+      DistributedTaskLockManager.TaskLock lock = lockManager.acquireLock("testTable");
+      Assert.assertNotNull(lock, "Should successfully acquire lock");
+      assertEquals(lock.getOwner(), "controller1");
+      assertTrue(lock.getAge() >= 0, "Lock should have valid age");
+
+      // Test lock release
+      boolean released = lockManager.releaseLock(lock, true);
+      Assert.assertTrue(released, "Should successfully release lock");
+    }
+
+    // Verify ephemeral node interactions
+    verify(mockPropertyStore, times(1)).create(anyString(), any(ZNRecord.class),
+        eq(AccessOption.EPHEMERAL_SEQUENTIAL));
+    verify(mockPropertyStore, times(1)).remove(anyString(), eq(AccessOption.EPHEMERAL));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testConcurrentEphemeralLockAcquisition() {
+    // Mock the property store and data accessor
+    ZkHelixPropertyStore<ZNRecord> mockPropertyStore = mock(ZkHelixPropertyStore.class);
+
+    // Define the specific UUID to use for the lock
+    UUID expectedUuid1 = UUID.fromString("123e4567-e89b-42d3-a456-426614174000");
+    UUID expectedUuid2 = UUID.fromString("543e4239-e89b-53d4-b474-24423374adf6");
+
+    // Configure mocks to simulate another controller already has the lock
+    when(mockPropertyStore.exists(anyString(), eq(AccessOption.PERSISTENT))).thenReturn(true);
+    when(mockPropertyStore.create(anyString(), any(ZNRecord.class), eq(AccessOption.EPHEMERAL_SEQUENTIAL)))
+        .thenReturn(true);
+    // Use the expectedUuid in the lock name to be returned
+    // Have controller2 have the lower sequence number
+    when(mockPropertyStore.getChildNames(anyString(), eq(AccessOption.PERSISTENT)))
+        .thenReturn(Arrays.asList("controller2-" + expectedUuid2 + "-lock-0000000001",
+            "controller1-" + expectedUuid1 + "-lock-0000000002"));
+    when(mockPropertyStore.remove(anyString(), eq(AccessOption.EPHEMERAL))).thenReturn(true);
+
+    DistributedTaskLockManager lockManager = new DistributedTaskLockManager(mockPropertyStore, "controller1");
+
+    try (MockedStatic<UUID> mockedUuid = mockStatic(UUID.class)) {
+      // Configure the mock to return the specific UUID when randomUUID() is called
+      mockedUuid.when(UUID::randomUUID).thenReturn(expectedUuid1);
+
+      // Test lock acquisition should fail because controller2 has lower sequence number
+      DistributedTaskLockManager.TaskLock lock = lockManager.acquireLock("testTable");
+      Assert.assertNull(lock, "Should fail to acquire lock when another controller has lower sequence number");
+    }
+
+    // Verify that we cleaned up our node after failing to get the lock
+    verify(mockPropertyStore, times(1)).create(anyString(), any(ZNRecord.class),
+        eq(AccessOption.EPHEMERAL_SEQUENTIAL));
+    verify(mockPropertyStore, times(1)).remove(anyString(), eq(AccessOption.EPHEMERAL));
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testEphemeralNodeAutomaticCleanup() {
+    // Mock the property store and data accessor
+    ZkHelixPropertyStore<ZNRecord> mockPropertyStore = mock(ZkHelixPropertyStore.class);
+
+    // Define the specific UUID to use for the lock
+    UUID expectedUuid = UUID.fromString("123e4567-e89b-42d3-a456-426614174000");
+
+    // Simulate a scenario where ephemeral nodes from dead sessions are automatically cleaned up
+    when(mockPropertyStore.exists(anyString(), eq(AccessOption.PERSISTENT))).thenReturn(true);
+    // First return: No existing locks - dead sessions cleaned up automatically
+    // Then return: lock which we created with provided UUID
+    when(mockPropertyStore.getChildNames(anyString(), eq(AccessOption.PERSISTENT)))
+        .thenReturn(Collections.emptyList())
+        .thenReturn(Arrays.asList("controller1-" + expectedUuid + "-lock-0000000001"));
+    when(mockPropertyStore.create(anyString(), any(ZNRecord.class), eq(AccessOption.EPHEMERAL_SEQUENTIAL)))
+        .thenReturn(true);
+
+    when(mockPropertyStore.set(anyString(), any(ZNRecord.class), eq(AccessOption.PERSISTENT))).thenReturn(true);
+
+    DistributedTaskLockManager lockManager = new DistributedTaskLockManager(mockPropertyStore, "controller1");
+
+    try (MockedStatic<UUID> mockedUuid = mockStatic(UUID.class)) {
+      // Configure the mock to return the specific UUID when randomUUID() is called
+      mockedUuid.when(UUID::randomUUID).thenReturn(expectedUuid);
+
+      // Test that we can acquire lock when no other ephemeral nodes exist (automatic cleanup)
+      DistributedTaskLockManager.TaskLock lock = lockManager.acquireLock("testTable");
+      Assert.assertNotNull(lock, "Should successfully acquire lock when dead sessions are automatically cleaned up");
+      assertEquals(lock.getOwner(), "controller1");
+    }
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testTaskGenerationInProgressDetection() {
+    // Mock the property store and data accessor
+    ZkHelixPropertyStore<ZNRecord> mockPropertyStore = mock(ZkHelixPropertyStore.class);
+
+    // Define the specific UUID to use for the lock
+    UUID expectedUuid = UUID.fromString("123e4567-e89b-42d3-a456-426614174000");
+
+    // Simulate active ephemeral nodes indicating task generation in progress
+    when(mockPropertyStore.exists(anyString(), eq(AccessOption.PERSISTENT))).thenReturn(true);
+    // Use the expectedUuid in the lock name to be returned
+    when(mockPropertyStore.getChildNames(anyString(), eq(AccessOption.PERSISTENT)))
+        .thenReturn(Arrays.asList("controller2-" + expectedUuid + "-lock-0000000001"));
+    when(mockPropertyStore.exists(contains("controller2-" + expectedUuid + "-lock-0000000001"),
+        eq(AccessOption.EPHEMERAL))).thenReturn(true);
+
+    DistributedTaskLockManager lockManager = new DistributedTaskLockManager(mockPropertyStore, "controller1");
+
+    // Test that we can detect task generation in progress
+    boolean inProgress = lockManager.isTaskGenerationInProgress("testTable");
+    Assert.assertTrue(inProgress, "Should detect task generation in progress when ephemeral nodes exist");
+
+    // Also create a state node that matches the lock
+    ZNRecord staleState = new ZNRecord("testTable");
+    staleState.setSimpleField("status", "IN_PROGRESS");
+    staleState.setSimpleField("startTimeMillis", String.valueOf(System.currentTimeMillis())); // 24 hours ago
+    staleState.setSimpleField("lockPath", "/MINION_TASK_METADATA/testTable-Lock/controller2-" + expectedUuid
+        + "-lock-0000000001");
+    when(mockPropertyStore.get(anyString(), any(), eq(AccessOption.PERSISTENT))).thenReturn(staleState);
+
+    // Test that we can detect task generation in progress
+    inProgress = lockManager.isTaskGenerationInProgress("testTable");
+    Assert.assertTrue(inProgress, "Should detect task generation in progress when ephemeral nodes exist");
+
+    // Should detect task generation is completed if state ZNode indicates completed / failed
+    staleState.setSimpleField("status", "COMPLETED");
+    when(mockPropertyStore.get(anyString(), any(), eq(AccessOption.PERSISTENT))).thenReturn(staleState);
+    inProgress = lockManager.isTaskGenerationInProgress("testTable");
+    Assert.assertFalse(inProgress, "Should detect task generation is not in progress when ephemeral nodes "
+        + "exist but state node indicates completed and matches ephemeral node");
+
+    staleState.setSimpleField("status", "FAILED");
+    when(mockPropertyStore.get(anyString(), any(), eq(AccessOption.PERSISTENT))).thenReturn(staleState);
+    inProgress = lockManager.isTaskGenerationInProgress("testTable");
+    Assert.assertFalse(inProgress, "Should detect task generation is not in progress when ephemeral nodes "
+        + "exist but state node indicates completed and matches ephemeral node");
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testLockManagerStateCleanup() {
+    // Mock the property store and data accessor
+    ZkHelixPropertyStore<ZNRecord> mockPropertyStore = mock(ZkHelixPropertyStore.class);
+
+    // Define the specific UUID to use for the lock
+    UUID expectedUuid = UUID.fromString("123e4567-e89b-42d3-a456-426614174000");
+
+    // Configure mocks for state cleanup
+    when(mockPropertyStore.exists(anyString(), eq(AccessOption.PERSISTENT))).thenReturn(true);
+    when(mockPropertyStore.getChildNames(anyString(), eq(AccessOption.PERSISTENT)))
+        .thenReturn(Arrays.asList("testTable-State"));
+
+    // Create a stale state record
+    ZNRecord staleState = new ZNRecord("testTable");
+    staleState.setSimpleField("status", "COMPLETED");
+    staleState.setSimpleField("startTimeMillis", String.valueOf(System.currentTimeMillis() - 86400000)); // 24 hours ago
+    staleState.setSimpleField("lockPath", "/MINION_TASK_METADATA/testTable-Lock/controller2-" + expectedUuid
+        + "-lock-0000000001");
+    when(mockPropertyStore.get(anyString(), any(), eq(AccessOption.PERSISTENT))).thenReturn(staleState);
+    when(mockPropertyStore.remove(anyString(), eq(AccessOption.PERSISTENT))).thenReturn(true);
+
+    DistributedTaskLockManager lockManager = new DistributedTaskLockManager(mockPropertyStore, "controller1");
+
+    // Test state cleanup
+    lockManager.cleanupStaleStates();
+
+    // Verify that stale state was removed
+    verify(mockPropertyStore, times(1)).remove(anyString(), eq(AccessOption.PERSISTENT));
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/auth/Actions.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/auth/Actions.java
@@ -166,5 +166,6 @@ public class Actions {
     public static final String UPLOAD_SEGMENT = "UploadSegment";
     public static final String VALIDATE_SCHEMA = "ValidateSchema";
     public static final String VALIDATE_TABLE_CONFIGS = "ValidateTableConfigs";
+    public static final String FORCE_RELEASE_TASK_GENERATION_LOCK = "ForceReleaseTaskGenerationLock";
   }
 }


### PR DESCRIPTION
Scheduled minion tasks are generated by the lead controller and the methods to generate the tasks are synchronized, ensuring that multiple tasks for the same table aren't generated. Pinot allows ad-hoc task creation as well, but this is performed on the controller that gets the request. This can result in scenarios where a task generation happens in parallel on multiple controllers.

This PR addresses this by implementing a distributed locking mechanism to guard minion task creation across controllers vis the use of EPHEMERAL_SEQUENTIAL nodes. This PR also adds an API to forceRelease the lock for scenarios where the lock may be left behind incorrectly.

Testing done using the HybridQuickStart to ensure that the features added work, and some unit tests have been added.

Some other options considered:
- Using a PERSISTENT lock with a timeout: https://github.com/apache/pinot/pull/16631 - task generation can take a long time, so choosing a timeout for clean-up is tricky
- Forward all task generation requests to the lead controller of that table - this can provide automatic synchronization but has the disadvantage of how to handle lead controller changes for a given table. In such cases, it is still possible for the task generation to run on two different controllers. So some kind of distributed locking is still necessary

cc @krishan1390 @shounakmk219 @swaminathanmanish @npawar 