### PR TITLE
Change default kafka consumer to use Kafka 3 from Kafka 2

### DIFF
--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfig.java
@@ -44,7 +44,7 @@ public class StreamConfig {
   public static final int DEFAULT_FLUSH_AUTOTUNE_INITIAL_ROWS = 100_000;
 
   public static final String DEFAULT_CONSUMER_FACTORY_CLASS_NAME_STRING =
-      "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory";
+      "org.apache.pinot.plugin.stream.kafka30.KafkaConsumerFactory";
 
   public static final long DEFAULT_STREAM_CONNECTION_TIMEOUT_MILLIS = 30_000;
   public static final int DEFAULT_STREAM_FETCH_TIMEOUT_MILLIS = 5_000;

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/config/ConfigUtilsTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/config/ConfigUtilsTest.java
@@ -79,7 +79,7 @@ public class ConfigUtilsTest {
     String streamType = "fakeStream";
     String topic = "fakeTopic";
     String tableName = "fakeTable_REALTIME";
-    String defaultConsumerFactoryClass = "org.apache.pinot.plugin.stream.kafka20.StreamConsumerFactory";
+    String defaultConsumerFactoryClass = "org.apache.pinot.plugin.stream.kafka30.StreamConsumerFactory";
     String defaultDecoderClass = "org.apache.pinot.plugin.inputformat.avro.KafkaAvroMessageDecoder";
 
     String consumerFactoryClass = "${CONSUMER_FACTORY_CLASS:" + defaultConsumerFactoryClass + "}";


### PR DESCRIPTION
Since kafka 2 is not actively maintained and majority people are moving to Kafka 3.
If user still want to use kafka 2, simply add below config into your table stream config:
```
"stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory"
```