### PR TITLE
Helix initial tags: add *.initial.tags for broker/server/minion; apply only on first join

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/HelixHelper.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/HelixHelper.java
@@ -565,6 +565,30 @@ public class HelixHelper {
   }
 
   /**
+   * Returns whether a given instance exists in Helix using a HelixManager.
+   */
+  public static boolean instanceExists(HelixManager helixManager, String instanceId) {
+    try {
+      return getInstanceConfig(helixManager, instanceId) != null;
+    } catch (Exception e) {
+      LOGGER.warn("Failed to check instance existence for {} via HelixManager", instanceId, e);
+      return false;
+    }
+  }
+
+  /**
+   * Returns whether a given instance exists in Helix using a HelixAdmin and explicit cluster name.
+   */
+  public static boolean instanceExists(HelixAdmin helixAdmin, String clusterName, String instanceId) {
+    try {
+      return helixAdmin.getInstanceConfig(clusterName, instanceId) != null;
+    } catch (Exception e) {
+      LOGGER.warn("Failed to check instance existence for {} in cluster {}", instanceId, clusterName, e);
+      return false;
+    }
+  }
+
+  /**
    * Updates instance config to the Helix property store.
    */
   public static void updateInstanceConfig(HelixManager helixManager, InstanceConfig instanceConfig) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -365,6 +365,8 @@ public class CommonConstants {
     public static final long DEFAULT_EXTRA_PASSIVE_TIMEOUT_MS = 100L;
     public static final String CONFIG_OF_BROKER_ID = "pinot.broker.instance.id";
     public static final String CONFIG_OF_BROKER_INSTANCE_TAGS = "pinot.broker.instance.tags";
+    // New key used only for first-time join initialization of tags
+    public static final String CONFIG_OF_BROKER_INSTANCE_INITIAL_TAGS = "pinot.broker.instance.initial.tags";
     public static final String CONFIG_OF_BROKER_HOSTNAME = "pinot.broker.hostname";
     public static final String CONFIG_OF_SWAGGER_USE_HTTPS = "pinot.broker.swagger.use.https";
     // Comma separated list of packages that contains javax service resources.
@@ -1040,6 +1042,8 @@ public class CommonConstants {
     public static final String INSTANCE_DATA_MANAGER_CONFIG_PREFIX = "pinot.server.instance";
     public static final String QUERY_EXECUTOR_CONFIG_PREFIX = "pinot.server.query.executor";
     public static final String METRICS_CONFIG_PREFIX = "pinot.server.metrics";
+    // Config to initialize server instance tags for first-time joiners (comma-separated)
+    public static final String CONFIG_OF_SERVER_INSTANCE_INITIAL_TAGS = "pinot.server.instance.initial.tags";
 
     public static final String CONFIG_OF_INSTANCE_DATA_MANAGER_CLASS = "pinot.server.instance.data.manager.class";
     public static final String DEFAULT_INSTANCE_DATA_MANAGER_CLASS =
@@ -1520,6 +1524,8 @@ public class CommonConstants {
     @Deprecated
     public static final String DEPRECATED_CONFIG_OF_METRICS_PREFIX_KEY = "metricsPrefix";
     public static final String METRICS_REGISTRY_REGISTRATION_LISTENERS_KEY = "metricsRegistryRegistrationListeners";
+    // Config to initialize minion instance tags for first-time joiners (comma-separated)
+    public static final String CONFIG_OF_MINION_INSTANCE_INITIAL_TAGS = "pinot.minion.instance.initial.tags";
     public static final String METRICS_CONFIG_PREFIX = "pinot.minion.metrics";
 
     // Default settings


### PR DESCRIPTION
Summary
- Add new config keys: `pinot.broker.instance.initial.tags`, `pinot.server.instance.initial.tags`, `pinot.minion.instance.initial.tags`.
- Apply only when an instance first joins Helix (skip if instance already exists).
- Trim whitespace and skip blank tags.
- Extract shared existence check to `HelixHelper.instanceExists(...)`.
- Update server integration test to validate initial tags behavior.

Details
- Server: `BaseServerStarter` reads `pinot.server.instance.initial.tags` when tag list empty; validates with `TagNameUtils.isServerTag`; falls back to tenant isolation tags or `server_untagged`.
- Minion: `BaseMinionStarter` reads `pinot.minion.instance.initial.tags` when tag list empty; falls back to `minion_untagged`.
- Broker: prefers `pinot.broker.instance.initial.tags`, falls back to legacy `pinot.broker.instance.tags` for compatibility; validates with `TagNameUtils.isBrokerTag`.
- Shared helper: `HelixHelper.instanceExists(HelixManager, String)` and `instanceExists(HelixAdmin, String, String)`.

Testing
- Added/updated `ServerStarterIntegrationTest#testInitialServerTagsFromConfig`.
- Local module builds and targeted test run succeeded (skipped unrelated checks).