### PR TITLE
Reduce memory footprint for MailboxContentObserver and ReceivingMailbox

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/datablock/DataBlockUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/datablock/DataBlockUtils.java
@@ -32,7 +32,6 @@ import java.util.EnumMap;
 import java.util.List;
 import java.util.function.LongConsumer;
 import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.utils.DataSchema;
@@ -229,12 +228,9 @@ public final class DataBlockUtils {
    */
   public static DataBlock deserialize(List<ByteBuffer> buffers)
       throws IOException {
-    List<DataBuffer> dataBuffers = buffers.stream()
-        .map(PinotByteBuffer::slice)
-        .collect(Collectors.toList());
-    try (CompoundDataBuffer compoundBuffer = new CompoundDataBuffer(dataBuffers, ByteOrder.BIG_ENDIAN, false)) {
-      return deserialize(compoundBuffer);
-    }
+    DataBuffer dataBuffer = buffers.size() == 1 ? PinotByteBuffer.wrap(buffers.get(0))
+        : CompoundDataBuffer.fromByteBuffers(buffers, ByteOrder.BIG_ENDIAN, false);
+    return deserialize(dataBuffer);
   }
 
   /**
@@ -243,9 +239,9 @@ public final class DataBlockUtils {
    */
   public static DataBlock deserialize(ByteBuffer[] buffers)
       throws IOException {
-    try (CompoundDataBuffer compoundBuffer = new CompoundDataBuffer(buffers, ByteOrder.BIG_ENDIAN, false)) {
-      return deserialize(compoundBuffer);
-    }
+    DataBuffer dataBuffer = buffers.length == 1 ? PinotByteBuffer.wrap(buffers[0])
+        : CompoundDataBuffer.fromByteBuffers(buffers, ByteOrder.BIG_ENDIAN, false);
+    return deserialize(dataBuffer);
   }
 
   /**

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/memory/CompoundDataBuffer.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/memory/CompoundDataBuffer.java
@@ -91,12 +91,29 @@ public class CompoundDataBuffer implements DataBuffer {
     this(buffers.toArray(new DataBuffer[0]), order, owner);
   }
 
+  public static CompoundDataBuffer fromByteBuffers(ByteBuffer[] buffers, ByteOrder order, boolean owner) {
+    return new CompoundDataBuffer(asDataBufferArray(buffers), order, owner);
+  }
+
+  public static CompoundDataBuffer fromByteBuffers(List<ByteBuffer> buffers, ByteOrder order, boolean owner) {
+    return new CompoundDataBuffer(asDataBufferArray(buffers), order, owner);
+  }
+
   private static DataBuffer[] asDataBufferArray(ByteBuffer[] buffers) {
     DataBuffer[] result = new DataBuffer[buffers.length];
     for (int i = 0; i < buffers.length; i++) {
       result[i] = PinotByteBuffer.wrap(buffers[i]);
     }
     return result;
+  }
+
+  private static DataBuffer[] asDataBufferArray(List<ByteBuffer> buffers) {
+    int numBuffers = buffers.size();
+    DataBuffer[] dataBuffers = new DataBuffer[numBuffers];
+    for (int i = 0; i < numBuffers; i++) {
+      dataBuffers[i] = PinotByteBuffer.wrap(buffers.get(i));
+    }
+    return dataBuffers;
   }
 
   private int getBufferIndex(long offset) {


### PR DESCRIPTION
- In `MailboxContentObserver`, clear the `_mailboxBuffers` when stream completes
- In `ReceivingMailbox`, specialize the handling for single `ByteBuffer` to avoid creating `CompoundDataBuffer`