### PR TITLE
Configure switch for DICTIONARY scan vs RAW scan in REGEX LIKE evaluation

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -211,6 +211,13 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
             .putIfAbsent(Broker.Request.QueryOptionKey.ENABLE_NULL_HANDLING, _enableNullHandling);
       }
 
+      // Only set the threshold if not already specified in query options
+      if (!sqlNodeAndOptions.getOptions().containsKey(Broker.Request.QueryOptionKey.REGEXP_LIKE_ADAPTIVE_THRESHOLD)) {
+        sqlNodeAndOptions.getOptions().put(Broker.Request.QueryOptionKey.REGEXP_LIKE_ADAPTIVE_THRESHOLD, String.valueOf(
+            _config.getProperty(Broker.CONFIG_OF_REGEXP_LIKE_ADAPTIVE_THRESHOLD,
+                Broker.DEFAULT_REGEXP_LIKE_ADAPTIVE_THRESHOLD)));
+      }
+
       BrokerResponse brokerResponse =
           handleRequest(requestId, query, sqlNodeAndOptions, request, requesterIdentity, requestContext, httpHeaders,
               accessControl);

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
@@ -1212,6 +1212,11 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
             .putIfAbsent(Broker.Request.QueryOptionKey.ENABLE_NULL_HANDLING, _enableNullHandling);
       }
 
+        sqlNodeAndOptions.getOptions().putIfAbsent(QueryOptionKey.REGEXP_LIKE_ADAPTIVE_THRESHOLD, String.valueOf(
+            _config.getProperty(Broker.CONFIG_OF_REGEXP_LIKE_ADAPTIVE_THRESHOLD,
+                Broker.DEFAULT_REGEXP_LIKE_ADAPTIVE_THRESHOLD)));
+      }
+
       BrokerResponse response =
           doHandleRequest(requestId, subquery, sqlNodeAndOptions, jsonRequest, requesterIdentity, requestContext,
               httpHeaders, accessControl);

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
@@ -585,4 +585,31 @@ public class QueryOptionsUtils {
     }
     return Boolean.parseBoolean(value);
   }
+
+  /**
+   * Get the REGEXP_LIKE adaptive threshold from query options.
+   * This threshold controls when to switch between dictionary-based and scan-based evaluation.
+   * When (dictionary_size / num_docs) < threshold, use dictionary-based evaluation.
+   * When (dictionary_size / num_docs) >= threshold, use scan-based evaluation.
+   *
+   * @param queryOptions Query options map
+   * @param defaultThreshold Default threshold to use if not specified in query options
+   * @return The adaptive threshold value (between 0.0 and 1.0)
+   */
+  public static double getRegexpLikeAdaptiveThreshold(Map<String, String> queryOptions, double defaultThreshold) {
+    String thresholdStr = queryOptions.get(QueryOptionKey.REGEXP_LIKE_ADAPTIVE_THRESHOLD);
+    if (thresholdStr != null) {
+      try {
+        double threshold = Double.parseDouble(thresholdStr);
+        if (threshold >= 0.0 && threshold <= 1.0) {
+          return threshold;
+        } else {
+          throw new IllegalArgumentException("REGEXP_LIKE adaptive threshold must be between 0.0 and 1.0, got: " + threshold);
+        }
+      } catch (NumberFormatException e) {
+        throw new IllegalArgumentException("Invalid REGEXP_LIKE adaptive threshold value: " + thresholdStr, e);
+      }
+    }
+    return defaultThreshold;
+  }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/ExpressionFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/ExpressionFilterOperator.java
@@ -75,7 +75,7 @@ public class ExpressionFilterOperator extends BaseFilterOperator {
     } else {
       _predicateEvaluator =
           PredicateEvaluatorProvider.getPredicateEvaluator(predicate, _transformFunction.getDictionary(),
-              _transformFunction.getResultMetadata().getDataType());
+              _transformFunction.getResultMetadata().getDataType(), numDocs);
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/PredicateEvaluatorProvider.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/PredicateEvaluatorProvider.java
@@ -38,12 +38,12 @@ public class PredicateEvaluatorProvider {
   }
 
   public static PredicateEvaluator getPredicateEvaluator(Predicate predicate, @Nullable Dictionary dictionary,
-      DataType dataType) {
-    return getPredicateEvaluator(predicate, dictionary, dataType, null);
+      DataType dataType, int numDocs) {
+    return getPredicateEvaluator(predicate, dictionary, dataType, null, numDocs);
   }
 
   public static PredicateEvaluator getPredicateEvaluator(Predicate predicate, @Nullable Dictionary dictionary,
-      DataType dataType, @Nullable QueryContext queryContext) {
+      DataType dataType, @Nullable QueryContext queryContext, int numDocs) {
     try {
       if (dictionary != null) {
         // dictionary based predicate evaluators
@@ -65,7 +65,7 @@ public class PredicateEvaluatorProvider {
                 .newDictionaryBasedEvaluator((RangePredicate) predicate, dictionary, dataType);
           case REGEXP_LIKE:
             return RegexpLikePredicateEvaluatorFactory
-                .newDictionaryBasedEvaluator((RegexpLikePredicate) predicate, dictionary, dataType);
+                .newDictionaryBasedEvaluator((RegexpLikePredicate) predicate, dictionary, dataType, numDocs, queryContext);
           default:
             throw new UnsupportedOperationException("Unsupported predicate type: " + predicate.getType());
         }
@@ -96,8 +96,8 @@ public class PredicateEvaluatorProvider {
   }
 
   public static PredicateEvaluator getPredicateEvaluator(Predicate predicate, DataSource dataSource,
-      QueryContext queryContext) {
+      QueryContext queryContext, int numDocs) {
     return getPredicateEvaluator(predicate, dataSource.getDictionary(),
-        dataSource.getDataSourceMetadata().getDataType(), queryContext);
+        dataSource.getDataSourceMetadata().getDataType(), queryContext, numDocs);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/RegexpLikePredicateEvaluatorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/RegexpLikePredicateEvaluatorFactory.java
@@ -39,6 +39,9 @@ public class RegexpLikePredicateEvaluatorFactory {
   private RegexpLikePredicateEvaluatorFactory() {
   }
 
+  /// Default threshold when the cardinality of the dictionary is less than this threshold, scan the dictionary to get the matching ids.
+  public static final int DEFAULT_DICTIONARY_CARDINALITY_THRESHOLD_FOR_SCAN = 10000;
+
   /**
    * Create a new instance of dictionary based REGEXP_LIKE predicate evaluator with configurable threshold.
    *
@@ -60,7 +63,8 @@ public class RegexpLikePredicateEvaluatorFactory {
       threshold = QueryOptionsUtils.getRegexpLikeAdaptiveThreshold(queryContext.getQueryOptions(),
           Broker.DEFAULT_REGEXP_LIKE_ADAPTIVE_THRESHOLD);
     }
-    if ((double) dictionary.length() / numDocs < threshold) {
+    if (dictionary.length() < DEFAULT_DICTIONARY_CARDINALITY_THRESHOLD_FOR_SCAN
+        || (double) dictionary.length() / numDocs < threshold) {
       return new DictIdBasedRegexpLikePredicateEvaluator(regexpLikePredicate, dictionary);
     } else {
       return new ScanBasedRegexpLikePredicateEvaluator(regexpLikePredicate, dictionary);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/BinaryOperatorTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/BinaryOperatorTransformFunction.java
@@ -143,7 +143,7 @@ public abstract class BinaryOperatorTransformFunction extends BaseTransformFunct
     if (predicate == null) {
       return null;
     }
-    return PredicateEvaluatorProvider.getPredicateEvaluator(predicate, leftDictionary, leftDataType);
+    return PredicateEvaluatorProvider.getPredicateEvaluator(predicate, leftDictionary, leftDataType, 0);
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/FilterPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/FilterPlanNode.java
@@ -311,7 +311,8 @@ public class FilterPlanNode implements PlanNode {
                 } else {
                   predicateEvaluator =
                       PredicateEvaluatorProvider.getPredicateEvaluator(predicate, dataSource.getDictionary(),
-                          dataSource.getDataSourceMetadata().getDataType());
+                          dataSource.getDataSourceMetadata().getDataType(),
+                          dataSource.getDataSourceMetadata().getNumDocs());
                 }
               } else {
                 if (dataSource.getFSTIndex() != null) {
@@ -320,7 +321,8 @@ public class FilterPlanNode implements PlanNode {
                 } else {
                   predicateEvaluator =
                       PredicateEvaluatorProvider.getPredicateEvaluator(predicate, dataSource.getDictionary(),
-                          dataSource.getDataSourceMetadata().getDataType());
+                          dataSource.getDataSourceMetadata().getDataType(),
+                          dataSource.getDataSourceMetadata().getNumDocs());
                 }
               }
               _predicateEvaluators.add(Pair.of(predicate, predicateEvaluator));
@@ -361,7 +363,7 @@ public class FilterPlanNode implements PlanNode {
             }
             default:
               predicateEvaluator =
-                  PredicateEvaluatorProvider.getPredicateEvaluator(predicate, dataSource, _queryContext);
+                  PredicateEvaluatorProvider.getPredicateEvaluator(predicate, dataSource, _queryContext, 0);
               _predicateEvaluators.add(Pair.of(predicate, predicateEvaluator));
               return FilterOperatorUtils.getLeafFilterOperator(_queryContext, predicateEvaluator, dataSource, numDocs);
           }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountThetaSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountThetaSketchAggregationFunction.java
@@ -1546,7 +1546,7 @@ public class DistinctCountThetaSketchAggregationFunction
       DataType valueType = valueTypes[_expressionIndex];
       Object valueArray = valueArrays[_expressionIndex];
       if (_predicateEvaluator == null) {
-        _predicateEvaluator = PredicateEvaluatorProvider.getPredicateEvaluator(_predicate, null, valueType);
+        _predicateEvaluator = PredicateEvaluatorProvider.getPredicateEvaluator(_predicate, null, valueType, 0);
       }
       if (singleValue) {
         switch (valueType) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/filter/PredicateRowMatcher.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/filter/PredicateRowMatcher.java
@@ -44,7 +44,7 @@ public class PredicateRowMatcher implements RowMatcher {
     if (_predicateType == Predicate.Type.IS_NULL || _predicateType == Predicate.Type.IS_NOT_NULL) {
       _predicateEvaluator = null;
     } else {
-      _predicateEvaluator = PredicateEvaluatorProvider.getPredicateEvaluator(predicate, null, _valueType);
+      _predicateEvaluator = PredicateEvaluatorProvider.getPredicateEvaluator(predicate, null, _valueType, 0);
     }
     _nullHandlingEnabled = nullHandlingEnabled;
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -433,6 +433,10 @@ public class CommonConstants {
 
     public static final String DISABLE_GROOVY = "pinot.broker.disable.query.groovy";
     public static final boolean DEFAULT_DISABLE_GROOVY = true;
+
+    // REGEXP_LIKE adaptive threshold configuration
+    public static final String CONFIG_OF_REGEXP_LIKE_ADAPTIVE_THRESHOLD = "pinot.broker.regexp.like.adaptive.threshold";
+    public static final double DEFAULT_REGEXP_LIKE_ADAPTIVE_THRESHOLD = 0.1; // 10% threshold
     // Rewrite potential expensive functions to their approximation counterparts
     // - DISTINCT_COUNT -> DISTINCT_COUNT_SMART_HLL
     // - PERCENTILE -> PERCENTILE_SMART_TDIGEST
@@ -707,6 +711,11 @@ public class CommonConstants {
 
         public static final String IN_PREDICATE_PRE_SORTED = "inPredicatePreSorted";
         public static final String IN_PREDICATE_LOOKUP_ALGORITHM = "inPredicateLookupAlgorithm";
+
+        // REGEXP_LIKE adaptive threshold - controls when to switch between dictionary-based and scan-based evaluation
+        // When (dictionary_size / num_docs) < threshold, use dictionary-based evaluation (faster for small dictionaries)
+        // When (dictionary_size / num_docs) >= threshold, use scan-based evaluation (faster for large dictionaries)
+        public static final String REGEXP_LIKE_ADAPTIVE_THRESHOLD = "regexpLikeAdaptiveThreshold";
 
         public static final String DROP_RESULTS = "dropResults";
 


### PR DESCRIPTION
**Context:** Currently REGEXP_LIKE without FST/IFST index cases where the number of docs scanned exceed far beyond 10K, and the cardinality percent still remains low even if the cardinality of the dictionary exceeds 10k. So having a % configurable parameter for the user to switch between RAW scan and DICTIONARY based scan is necessary. This PR introduces this switch in 2 ways:

The existing check for dictionary length works as is, if the dictionary length< 10000 it uses dictionary scan. For other cases, the switch was made based on % of docs in a segment both committed and consuming.

Broker Configs:
-  Check the threshold limit on the dict usage from `regexpDictCardinalityThreshold`. By default this is set to 10%.

**Example:** select count(*) from mytable where REGEXP_LIKE(NewAddedSVJSONDimension, '.*')   OPTION(regexpDictCardinalityThreshold=50000)

`pinot.broker.regexp.dict.cardinality.threshold` - If one wants to set a threshold globally on broker level. 

**Order of Priority:**
Query options > Broker Configs