### PR TITLE
Perform table exists check early on for table creation

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -209,7 +209,7 @@ public class PinotTableRestletResource {
   public ConfigSuccessResponse addTable(String tableConfigStr,
       @ApiParam(value = "comma separated list of validation type(s) to skip. supported types: (ALL|TASK|UPSERT)")
       @QueryParam("validationTypesToSkip") @Nullable String typesToSkip,
-      @ApiParam(defaultValue = "false") @QueryParam("ignoreActiveTasks") boolean ignoreActiveTasks,
+      @DefaultValue("false") @QueryParam("ignoreActiveTasks") boolean ignoreActiveTasks,
       @Context HttpHeaders httpHeaders, @Context Request request)
       throws IOException {
     // TODO introduce a table config ctor with json string.
@@ -228,6 +228,13 @@ public class PinotTableRestletResource {
       ResourceUtils.checkPermissionAndAccess(tableNameWithType, request, httpHeaders,
           AccessType.CREATE, Actions.Table.CREATE_TABLE, _accessControlFactory, LOGGER);
 
+      // fail if table entry is present in IS. This saves all the validation checks if table already exists
+      if (_pinotHelixResourceManager.hasTable(tableNameWithType)) {
+        throw new TableAlreadyExistsException("Table config for " + tableNameWithType
+            + " already exists. If this is unexpected, try deleting the table to remove all metadata associated"
+            + " with it.");
+      }
+
       schema = _pinotHelixResourceManager.getTableSchema(tableNameWithType);
       Preconditions.checkState(schema != null, "Failed to find schema for table: %s", tableNameWithType);
 
@@ -236,6 +243,8 @@ public class PinotTableRestletResource {
       // TableConfigUtils.validate(...) is used across table create/update.
       TableConfigUtils.validate(tableConfig, schema, typesToSkip);
       TableConfigUtils.validateTableName(tableConfig);
+    } catch (TableAlreadyExistsException e) {
+      throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.CONFLICT, e);
     } catch (Exception e) {
       throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.BAD_REQUEST, e);
     }
@@ -434,7 +443,7 @@ public class PinotTableRestletResource {
       @ApiParam(value = "Retention period for the table segments (e.g. 12h, 3d); If not set, the retention period "
           + "will default to the first config that's not null: the cluster setting, then '7d'. Using 0d or -1d will "
           + "instantly delete segments without retention") @QueryParam("retention") String retentionPeriod,
-      @ApiParam(defaultValue = "false") @QueryParam("ignoreActiveTasks") boolean ignoreActiveTasks,
+      @DefaultValue("false") @QueryParam("ignoreActiveTasks") boolean ignoreActiveTasks,
       @Context HttpHeaders headers) {
     TableType tableType = Constants.validateTableType(tableTypeStr);
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -232,7 +232,7 @@ public class PinotTableRestletResource {
       if (_pinotHelixResourceManager.hasTable(tableNameWithType)) {
         throw new TableAlreadyExistsException("Table config for " + tableNameWithType
             + " already exists. If this is unexpected, try deleting the table to remove all metadata associated"
-            + " with it.");
+            + " with it before attempting to recreate.");
       }
 
       schema = _pinotHelixResourceManager.getTableSchema(tableNameWithType);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableConfigsRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableConfigsRestletResource.java
@@ -217,7 +217,7 @@ public class TableConfigsRestletResource {
           String.format("TableConfigs: %s already exists. Use PUT to update existing config", rawTableName),
           Response.Status.BAD_REQUEST);
     }
-    
+
     validateConfig(tableConfigs, databaseName, typesToSkip);
     tableConfigs.setTableName(rawTableName);
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableConfigsRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableConfigsRestletResource.java
@@ -197,7 +197,7 @@ public class TableConfigsRestletResource {
       String tableConfigsStr,
       @ApiParam(value = "comma separated list of validation type(s) to skip. supported types: (ALL|TASK|UPSERT)")
       @QueryParam("validationTypesToSkip") @Nullable String typesToSkip,
-      @ApiParam(defaultValue = "false") @QueryParam("ignoreActiveTasks") boolean ignoreActiveTasks,
+      @DefaultValue("false") @QueryParam("ignoreActiveTasks") boolean ignoreActiveTasks,
       @Context HttpHeaders httpHeaders, @Context Request request)
       throws Exception {
     Pair<TableConfigs, Map<String, Object>> tableConfigsAndUnrecognizedProps;
@@ -210,16 +210,16 @@ public class TableConfigsRestletResource {
     }
     TableConfigs tableConfigs = tableConfigsAndUnrecognizedProps.getLeft();
     String databaseName = DatabaseUtils.extractDatabaseFromHttpHeaders(httpHeaders);
-    validateConfig(tableConfigs, databaseName, typesToSkip);
     String rawTableName = DatabaseUtils.translateTableName(tableConfigs.getTableName(), databaseName);
-    tableConfigs.setTableName(rawTableName);
-
     if (_pinotHelixResourceManager.hasOfflineTable(rawTableName) || _pinotHelixResourceManager.hasRealtimeTable(
         rawTableName) || _pinotHelixResourceManager.getSchema(rawTableName) != null) {
       throw new ControllerApplicationException(LOGGER,
           String.format("TableConfigs: %s already exists. Use PUT to update existing config", rawTableName),
           Response.Status.BAD_REQUEST);
     }
+    
+    validateConfig(tableConfigs, databaseName, typesToSkip);
+    tableConfigs.setTableName(rawTableName);
 
     TableConfig offlineTableConfig = tableConfigs.getOffline();
     TableConfig realtimeTableConfig = tableConfigs.getRealtime();
@@ -298,7 +298,7 @@ public class TableConfigsRestletResource {
   public SuccessResponse deleteConfig(
       @ApiParam(value = "TableConfigs name i.e. raw table name", required = true) @PathParam("tableName")
       String tableName,
-      @ApiParam(defaultValue = "false") @QueryParam("ignoreActiveTasks") boolean ignoreActiveTasks,
+      @DefaultValue("false") @QueryParam("ignoreActiveTasks") boolean ignoreActiveTasks,
       @Context HttpHeaders headers) {
     try {
       if (TableNameBuilder.isOfflineTableResource(tableName) || TableNameBuilder.isRealtimeTableResource(tableName)) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -1760,7 +1760,7 @@ public class PinotHelixResourceManager {
     if (getTableConfig(tableNameWithType) != null) {
       throw new TableAlreadyExistsException("Table config for " + tableNameWithType
           + " already exists. If this is unexpected, try deleting the table to remove all metadata associated"
-          + " with it.");
+          + " with it before attempting to recreate.");
     }
 
     String rawTableName = TableNameBuilder.extractRawTableName(tableNameWithType);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotTableRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotTableRestletResourceTest.java
@@ -205,6 +205,7 @@ public class PinotTableRestletResourceTest extends ControllerTest {
     }
 
     // Create an OFFLINE table with invalid replication config
+    offlineTableConfig = _offlineBuilder.setTableName("invalid_replication_config").build();
     offlineTableConfig.getValidationConfig().setReplication("abc");
     try {
       sendPostRequest(_createTableUrl, offlineTableConfig.toJsonString());
@@ -901,6 +902,7 @@ public class PinotTableRestletResourceTest extends ControllerTest {
 
     try {
       sendPostRequest(_createTableUrl, realtimeTableConfig.toJsonString());
+      fail("Should fail due to invalid replication factor");
     } catch (Exception e) {
       assertTrue(e.getMessage().contains("Failed to calculate instance partitions for table: " + tableNameWithType));
     }
@@ -928,7 +930,8 @@ public class PinotTableRestletResourceTest extends ControllerTest {
         getInstanceAssignmentConfig("DefaultTenant_REALTIME", 1, 8));
 
     try {
-      sendPostRequest(_createTableUrl, realtimeTableConfig.toJsonString());
+      sendPutRequest(_createTableUrl + "/" + realtimeTableConfig.getTableName(), realtimeTableConfig.toJsonString());
+      fail("Table update should fail due to invalid RG config");
     } catch (Exception e) {
       assertTrue(e.getMessage().contains("Failed to calculate instance partitions for table: " + tableNameWithType));
     }
@@ -1000,7 +1003,8 @@ public class PinotTableRestletResourceTest extends ControllerTest {
         .build();
 
     try {
-      sendPostRequest(_createTableUrl, tableConfig.toJsonString());
+      sendPutRequest(_createTableUrl + "/" + tableConfig.getTableName(), tableConfig.toJsonString());
+      fail("Table update should fail due to invalid replication factor");
     } catch (Exception e) {
       assertTrue(e.getMessage().contains("Failed to calculate instance partitions for table: " + tableNameWithType));
     }
@@ -1036,6 +1040,7 @@ public class PinotTableRestletResourceTest extends ControllerTest {
 
     try {
       sendPostRequest(_createTableUrl, tableConfig.toJsonString());
+      fail("Table create should fail due to invalid replication factor");
     } catch (Exception e) {
       assertTrue(e.getMessage().contains("Failed to calculate instance partitions for table: " + tableNameWithType));
     }


### PR DESCRIPTION
## Description

This PR tweaks the table creation endpoints flow to check if table already exist before doing all the validations on the table configs. This refactor is done to avoid taking user through series of table config fixes only to later realise the table already exists.