### PR TITLE
Only use transform function nullBitmap when null handling is enabled

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CoalesceTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CoalesceTransformFunction.java
@@ -31,21 +31,20 @@ import org.apache.pinot.spi.utils.CommonConstants.NullValuePlaceHolder;
 import org.roaringbitmap.RoaringBitmap;
 
 
-/**
- * The <code>CoalesceTransformFunction</code> implements the Coalesce operator.
- *
- * The result is first non-null value in the argument list.
- * If all arguments are null, return null.
- *
- * Note: arguments have to be compatible type.
- * Number of arguments has to be greater than 0.
- *
- * Expected result:
- * Coalesce(nullColumn, columnA): columnA
- * Coalesce(columnA, nullColumn): columnA
- * Coalesce(nullColumnA, nullColumnB): null
- *
- */
+///
+/// <code>CoalesceTransformFunction</code> implements the SQL COALESCE operator.
+///
+/// The result is the first non-null value in the argument list.
+/// If all arguments are null, return null.
+///
+/// The arguments have to be of compatible types, and the number of arguments has to be greater than 0.
+///
+/// Expected result:
+/// - Coalesce(NULL, valueA): valueA
+/// - Coalesce(valueA, NULL): valueA
+/// - Coalesce(NULL, NULL): NULL
+/// - Coalesce(valueB, valueA): valueB
+///
 public class CoalesceTransformFunction extends BaseTransformFunction {
   private TransformFunction[] _transformFunctions;
   private DataType _dataType;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IsDistinctFromTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IsDistinctFromTransformFunction.java
@@ -18,23 +18,24 @@
  */
 package org.apache.pinot.core.operator.transform.function;
 
-/**
- * The <code>IsDistinctFromTransformFunction</code> extends <code>DistinctFromTransformFunction</code> to implement the
- * IS_DISTINCT_FROM operator.
- *
- * The results are in boolean format and stored as an integer array with 1 represents true and 0 represents false.
- * Expected result:
- * NUll IS_DISTINCT_FROM Value: 1
- * NUll IS_DISTINCT_FROM Null: 0
- * ValueA IS_DISTINCT_FROM ValueB: NotEQUALS(ValueA, ValueB)
- *
- * Note this operator only takes column names for now.
- * SQL Syntax:
- *    columnA IS DISTINCT FROM columnB
- *
- * Sample Usage:
- *    IS_DISTINCT_FROM(columnA, columnB)
- */
+///
+/// <code>IsDistinctFromTransformFunction</code> extends <code>DistinctFromTransformFunction</code> to implement the
+/// IS_DISTINCT_FROM operator.
+///
+/// The results are in boolean format and stored as an integer array where 1 represents true and 0 represents false.
+///
+/// Expected result:
+/// - NULL IS_DISTINCT_FROM Value: 1
+/// - NULL IS_DISTINCT_FROM NULL: 0
+/// - ValueA IS_DISTINCT_FROM ValueB: NOT_EQUALS(ValueA, ValueB)
+///
+/// Note that this operator only takes column names for now.
+/// SQL Syntax:
+///    columnA IS DISTINCT FROM columnB
+///
+/// Sample Usage:
+///    IS_DISTINCT_FROM(columnA, columnB)
+///
 public class IsDistinctFromTransformFunction extends DistinctFromTransformFunction {
   public IsDistinctFromTransformFunction() {
     super(true);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IsNotDistinctFromTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IsNotDistinctFromTransformFunction.java
@@ -18,23 +18,24 @@
  */
 package org.apache.pinot.core.operator.transform.function;
 
-/**
- * The <code>IsNotDistinctFromTransformFunction</code> extends <code>DistinctFromTransformFunction</code> to
- * implement the IS_NOT_DISTINCT_FROM operator.
- *
- * The results are in boolean format and stored as an integer array with 1 represents true and 0 represents false.
- * Expected result:
- * NUll IS_NOT_DISTINCT_FROM Value: 0
- * NUll IS_NOT_DISTINCT_FROM Null: 1
- * ValueA IS_NOT_DISTINCT_FROM ValueB: EQUALS(ValueA, ValueB)
- *
- * Note this operator only takes column names for now.
- * SQL Syntax:
- *    columnA IS_NOT_DISTINCT_FROM columnB
- *
- * Sample Usage:
- *    IS_NOT_DISTINCT_FROM(columnA, columnB)
- */
+///
+/// <code>IsNotDistinctFromTransformFunction</code> extends <code>DistinctFromTransformFunction</code> to implement the
+/// IS_NOT_DISTINCT_FROM operator.
+///
+/// The results are in boolean format and stored as an integer array where 1 represents true and 0 represents false.
+///
+/// Expected result:
+/// - NULL IS_NOT_DISTINCT_FROM Value: 0
+/// - NULL IS_NOT_DISTINCT_FROM NULL: 0
+/// - ValueA IS_NOT_DISTINCT_FROM ValueB: EQUALS(ValueA, ValueB)
+///
+/// Note that this operator only takes column names for now.
+/// SQL Syntax:
+///    columnA IS_NOT_DISTINCT_FROM columnB
+///
+/// Sample Usage:
+///    IS_NOT_DISTINCT_FROM(columnA, columnB)
+///
 public class IsNotDistinctFromTransformFunction extends DistinctFromTransformFunction {
   public IsNotDistinctFromTransformFunction() {
     super(false);


### PR DESCRIPTION
- Transform functions should only use the null bitmap when null handling is enabled, as we want to avoid paying the overhead cost of computing the null bitmap (and any other additional computation) when null handling is disabled (default behavior).
- The only exception to this is `COALESCE` since that transform function semantically requires knowledge of the true `null` values.