### PR TITLE
Resets in-progress pauseless table segments

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -2734,7 +2734,6 @@ public class PinotLLCRealtimeSegmentManager {
           LOGGER.error("Failed to call reingestSegment for segment: {} on server: {}", segmentName, aliveServer, e);
         }
       } else {
-        // Trigger reset for segment not in IN_PROGRESS state to download the segment from deep store or peer server
         _helixResourceManager.resetSegment(realtimeTableName, segmentName, null);
       }
     }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
@@ -1977,7 +1977,7 @@ public class TableRebalancer {
       //       best to return that there is a risk of data loss for pauseless enabled tables for segments in COMMITTING
       //       state
       if (_isPauselessEnabled && segmentZKMetadata.getStatus() == CommonConstants.Segment.Realtime.Status.COMMITTING
-          && !_pinotLLCRealtimeSegmentManager.allowRepairOfErrorSegments(false, _tableConfig)) {
+          && !_pinotLLCRealtimeSegmentManager.allowRepairOfCommittingSegments(false, _tableConfig)) {
         return Pair.of(true, generateDataLossRiskMessage(segmentName, false));
       }
       return NO_DATA_LOSS_RISK_RESULT;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeSegmentValidationManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeSegmentValidationManager.java
@@ -134,7 +134,7 @@ public class RealtimeSegmentValidationManager extends ControllerPeriodicTask<Rea
     if (isPauselessConsumptionEnabled) {
       // For pauseless tables without dedup or partial upsert, repair segments in error state
       _llcRealtimeSegmentManager.repairSegmentsInErrorStateForPauselessConsumption(tableConfig,
-          context._repairErrorSegmentsForPartialUpsertOrDedup);
+          context._repairErrorSegmentsForPartialUpsertOrDedup, _segmentAutoResetOnErrorAtValidation);
     } else if (_segmentAutoResetOnErrorAtValidation) {
       // Reset for pauseless tables is already handled in repairSegmentsInErrorStateForPauselessConsumption method with
       // additional checks for pauseless consumption

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PauselessDedupRealtimeIngestionConsumingTransitionFailureTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PauselessDedupRealtimeIngestionConsumingTransitionFailureTest.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.integration.tests;
+
+import org.apache.pinot.integration.tests.realtime.utils.FailureInjectingTableConfig;
+import org.apache.pinot.integration.tests.realtime.utils.FailureInjectingTableDataManagerProvider;
+import org.apache.pinot.server.starter.helix.HelixInstanceDataManagerConfig;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.utils.CommonConstants;
+
+
+public class PauselessDedupRealtimeIngestionConsumingTransitionFailureTest
+    extends PauselessDedupRealtimeIngestionSegmentCommitFailureTest {
+  @Override
+  protected void overrideServerConf(PinotConfiguration serverConf) {
+    serverConf.setProperty("pinot.server.instance.segment.store.uri", "file:" + _controllerConfig.getDataDir());
+    serverConf.setProperty("pinot.server.instance." + HelixInstanceDataManagerConfig.UPLOAD_SEGMENT_TO_DEEP_STORE,
+        "true");
+    serverConf.setProperty("pinot.server.instance." + CommonConstants.Server.TABLE_DATA_MANAGER_PROVIDER_CLASS,
+        "org.apache.pinot.integration.tests.realtime.utils.FailureInjectingTableDataManagerProvider");
+    serverConf.setProperty("pinot.server.instance." + FailureInjectingTableDataManagerProvider.FAILURE_CONFIG_KEY + "."
+        + getPauselessTableName(), new FailureInjectingTableConfig(false, true, getExpectedMaxFailures()).toJson());
+  }
+
+  @Override
+  protected int getExpectedMaxFailures() {
+    return 2;
+  }
+}

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PauselessRealtimeIngestionConsumingTransitionFailureTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PauselessRealtimeIngestionConsumingTransitionFailureTest.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.integration.tests;
+
+import org.apache.pinot.integration.tests.realtime.utils.FailureInjectingTableConfig;
+import org.apache.pinot.integration.tests.realtime.utils.FailureInjectingTableDataManagerProvider;
+import org.apache.pinot.server.starter.helix.HelixInstanceDataManagerConfig;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.utils.CommonConstants;
+
+
+public class PauselessRealtimeIngestionConsumingTransitionFailureTest
+    extends PauselessRealtimeIngestionSegmentCommitFailureTest {
+  @Override
+  protected void overrideServerConf(PinotConfiguration serverConf) {
+    serverConf.setProperty("pinot.server.instance.segment.store.uri", "file:" + _controllerConfig.getDataDir());
+    serverConf.setProperty("pinot.server.instance." + HelixInstanceDataManagerConfig.UPLOAD_SEGMENT_TO_DEEP_STORE,
+        "true");
+    serverConf.setProperty("pinot.server.instance." + CommonConstants.Server.TABLE_DATA_MANAGER_PROVIDER_CLASS,
+        "org.apache.pinot.integration.tests.realtime.utils.FailureInjectingTableDataManagerProvider");
+    serverConf.setProperty("pinot.server.instance." + FailureInjectingTableDataManagerProvider.FAILURE_CONFIG_KEY + "."
+        + getPauselessTableName(), new FailureInjectingTableConfig(false, true, getExpectedMaxFailures()).toJson());
+  }
+
+  @Override
+  protected int getExpectedMaxFailures() {
+    return 2;
+  }
+}

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PauselessRealtimeIngestionSegmentCommitFailureTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PauselessRealtimeIngestionSegmentCommitFailureTest.java
@@ -199,7 +199,7 @@ public class PauselessRealtimeIngestionSegmentCommitFailureTest extends BaseClus
   }
 
   /**
-   * Returns the list of segment names in ERROR state from the ExternalView of the given table.
+   * Returns the list of segment names in the given state from the ExternalView of the given table.
    */
   private List<String> getSegmentsInEV(String realtimeTableName, String status) {
     ExternalView externalView = _helixResourceManager.getHelixAdmin()

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/realtime/utils/FailureInjectingRealtimeSegmentDataManager.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/realtime/utils/FailureInjectingRealtimeSegmentDataManager.java
@@ -50,13 +50,15 @@ public class FailureInjectingRealtimeSegmentDataManager extends RealtimeSegmentD
       RealtimeTableDataManager realtimeTableDataManager, String resourceDataDir, IndexLoadingConfig indexLoadingConfig,
       Schema schema, LLCSegmentName llcSegmentName, ConsumerCoordinator consumerCoordinator,
       ServerMetrics serverMetrics, boolean failCommit, PartitionDedupMetadataManager partitionDedupMetadataManager,
-      BooleanSupplier isTableReadyToConsumeData)
+      BooleanSupplier isTableReadyToConsumeData, boolean failConsumingTransition)
       throws AttemptsExceededException, RetriableOperationException {
     // Pass through to the real parent constructor
     super(segmentZKMetadata, tableConfig, realtimeTableDataManager, resourceDataDir, indexLoadingConfig, schema,
         llcSegmentName, consumerCoordinator, serverMetrics, null /* no PartitionUpsertMetadataManager */,
         partitionDedupMetadataManager, isTableReadyToConsumeData);
-
+    if (failConsumingTransition) {
+      throw new RuntimeException("Forced to fail the consuming transition");
+    }
     _failCommit = failCommit;
   }
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/realtime/utils/FailureInjectingTableConfig.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/realtime/utils/FailureInjectingTableConfig.java
@@ -1,0 +1,69 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.integration.tests.realtime.utils;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+
+public class FailureInjectingTableConfig {
+  private final boolean _failCommit;
+  private final boolean _failConsumingSegment;
+  private final int _maxFailures;
+
+  @JsonCreator
+  public FailureInjectingTableConfig(@JsonProperty("failCommit") boolean failCommit,
+      @JsonProperty("failConsumingSegment") boolean failConsumingSegment,
+      @JsonProperty("maxFailures") int maxFailures) {
+    _failCommit = failCommit;
+    _failConsumingSegment = failConsumingSegment;
+    _maxFailures = maxFailures;
+  }
+
+  public boolean isFailConsumingSegment() {
+    return _failConsumingSegment;
+  }
+
+  public boolean isFailCommit() {
+    return _failCommit;
+  }
+
+  public int getMaxFailures() {
+    return _maxFailures;
+  }
+
+  public String toJson() {
+    try {
+      return new ObjectMapper().writeValueAsString(this);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public String toString() {
+    return "FailureInjectingTableConfig{"
+        + "_failCommit=" + _failCommit
+        + ", _failConsumingSegment=" + _failConsumingSegment
+        + ", _maxFailures=" + _maxFailures
+        + '}';
+  }
+}


### PR DESCRIPTION
**Problem**
Most of the errors in `OFFLINE -> CONSUMING` transition leads to server notifying controller to mark segment as offline. 
All such cases are fixed by default by RVM.
However saw a new error first time where `OFFLINE -> CONSUMING` errored out very early and hence Helix thread marked the segment as `ERROR` in EV. For pauseless tables, such segments are not repaired by default and existing code only cares about `COMMITTING` segments.

**PR**
Allow reset of segments in `ERROR` state having segment ZK status as `IN_PROGRESS`. 