### PR TITLE
fetch append uuid to segment from config

### DIFF
--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segmentgenerationandpush/SegmentGenerationAndPushTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segmentgenerationandpush/SegmentGenerationAndPushTaskGenerator.java
@@ -290,7 +290,7 @@ public class SegmentGenerationAndPushTaskGenerator extends BaseTaskGenerator {
     // segments with same names, and override existing segments again... It becomes an endless loop
     // We add uuid to segment name to avoid segment collision across multiple rounds of task generation to solve the
     // problem.
-    singleFileGenerationTaskConfig.put(BatchConfigProperties.APPEND_UUID_TO_SEGMENT_NAME, 
+    singleFileGenerationTaskConfig.put(BatchConfigProperties.APPEND_UUID_TO_SEGMENT_NAME,
         batchConfigMap.getOrDefault(BatchConfigProperties.APPEND_UUID_TO_SEGMENT_NAME, Boolean.toString(false)));
     if ((outputDirURI == null) || (pushMode == null)) {
       singleFileGenerationTaskConfig.put(BatchConfigProperties.PUSH_MODE, DEFAULT_SEGMENT_PUSH_TYPE.toString());

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segmentgenerationandpush/SegmentGenerationAndPushTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segmentgenerationandpush/SegmentGenerationAndPushTaskGenerator.java
@@ -290,7 +290,8 @@ public class SegmentGenerationAndPushTaskGenerator extends BaseTaskGenerator {
     // segments with same names, and override existing segments again... It becomes an endless loop
     // We add uuid to segment name to avoid segment collision across multiple rounds of task generation to solve the
     // problem.
-    singleFileGenerationTaskConfig.put(BatchConfigProperties.APPEND_UUID_TO_SEGMENT_NAME, Boolean.toString(true));
+    singleFileGenerationTaskConfig.put(BatchConfigProperties.APPEND_UUID_TO_SEGMENT_NAME, 
+        batchConfigMap.getOrDefault(BatchConfigProperties.APPEND_UUID_TO_SEGMENT_NAME, Boolean.toString(false)));
     if ((outputDirURI == null) || (pushMode == null)) {
       singleFileGenerationTaskConfig.put(BatchConfigProperties.PUSH_MODE, DEFAULT_SEGMENT_PUSH_TYPE.toString());
     } else {

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/segmentgenerationandpush/SegmentGenerationAndPushTaskExecutorTest.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/segmentgenerationandpush/SegmentGenerationAndPushTaskExecutorTest.java
@@ -74,7 +74,7 @@ public class SegmentGenerationAndPushTaskExecutorTest {
       put(BatchConfigProperties.SEGMENT_NAME_GENERATOR_TYPE, "inputtext");
       put(BatchConfigProperties.SEGMENT_NAME_GENERATOR_PROP_PREFIX + ".prop.seg.1", "valseg1");
       put(BatchConfigProperties.SEGMENT_NAME_GENERATOR_PROP_PREFIX + ".propseg2", "valseg2");
-      put(BatchConfigProperties.APPEND_UUID_TO_SEGMENT_NAME, "true");
+      put(BatchConfigProperties.APPEND_UUID_TO_SEGMENT_NAME, "false");
     }};
     SegmentGenerationTaskSpec spec = executor.generateTaskSpec(configMap, Paths.get(resourcesLoc.toURI()).toFile());
     assertEquals(spec.getSequenceId(), 42);


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Configures APPEND\_UUID\_TO\_SEGMENT\_NAME from batch config with default false, and updates test to reflect false default\.

```mermaid
flowchart TD
  N0["Read APPEND#95;UUID#95;TO#95;SEGMENT#95;NAME from batchConfigMap #40;default false#41; #40;F1#41;"]:::stModified
  N1["Put APPEND#95;UUID#95;TO#95;SEGMENT#95;NAME into singleFileGenerationTaskConfig #40;F1#41;"]:::stModified
  N2["Set APPEND#95;UUID#95;TO#95;SEGMENT#95;NAME to false in test configMap #40;F2#41;"]:::stModified
  N3["Call generateTaskSpec #40;F2#41;"]:::stModified
  N0 -->|"data flow"| N1
  N2 -->|"test setup before call"| N3
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-plugins/pinot\-minion\-tasks/pinot\-minion\-builtin\-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segmentgenerationandpush/SegmentGenerationAndPushTaskGenerator\.java — [before](https://github.com/apache/pinot/blob/7f123000ca36a95fdd5a2203d3f45473a19cf9f3/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segmentgenerationandpush/SegmentGenerationAndPushTaskGenerator.java) · [after](https://github.com/apache/pinot/blob/dfcd90a3edfb20efd1d25360b0bf590e8e01de1a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segmentgenerationandpush/SegmentGenerationAndPushTaskGenerator.java)
- F2: pinot\-plugins/pinot\-minion\-tasks/pinot\-minion\-builtin\-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/segmentgenerationandpush/SegmentGenerationAndPushTaskExecutorTest\.java — [before](https://github.com/apache/pinot/blob/7f123000ca36a95fdd5a2203d3f45473a19cf9f3/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/segmentgenerationandpush/SegmentGenerationAndPushTaskExecutorTest.java) · [after](https://github.com/apache/pinot/blob/dfcd90a3edfb20efd1d25360b0bf590e8e01de1a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/segmentgenerationandpush/SegmentGenerationAndPushTaskExecutorTest.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjdmMTIzMDAwY2EzNmE5NWZkZDVhMjIwM2QzZjQ1NDczYTE5Y2Y5ZjMiLCJjb250ZXh0X2hhc2giOiJkYmYwNWE4OGE0MjIwMTc5ZDliZGQ5NjQyMDJlODBkZmViZjBjZmU3MjQyZTQxYmRhZTUyMmM4MjJmNjc1YzFhIiwiZ2VuZXJhdGVkX2F0IjoxNzg5ODc1MDc4LCJoZWFkX3NoYSI6ImRmY2Q5MGEzZWRmYjIwZWZkMWQyNTM2MGIwYmY1OTBlOGUwMWRlMWEiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiI3ZjEyMzAwMGNhMzZhOTVmZGQ1YTIyMDNkM2Y0NTQ3M2ExOWNmOWYzIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature e03b118eaf442f4cf3e5ce58b59dd7bc4308d8f7a5d5ac588275223ecb6b9eb0 -->
<!-- pinot-pr-flow:end -->

Instructions:
1. The PR has to be tagged with at least one of the following labels (*):
   1. `feature`
   2. `bugfix`
   3. `performance`
   4. `ui`
   5. `backward-incompat`
   6. `release-notes` (**)
2. Remove these instructions before publishing the PR.
 
(*) Other labels to consider:
- `testing`
- `dependencies`
- `docker`
- `kubernetes`
- `observability`
- `security`
- `code-style`
- `extension-point`
- `refactor`
- `cleanup`

(**) Use `release-notes` label for scenarios like:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
