### PR TITLE
Add ScalarFunction for JSON_EXTRACT_SCALAR

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/JsonFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/JsonFunctions.java
@@ -382,7 +382,8 @@ public class JsonFunctions {
     }
   }
 
-  private static String jsonPathStringOrThrowIfNoDefault(@Nullable Object object, String jsonPath, Object defaultValue) {
+  private static String jsonPathStringOrThrowIfNoDefault(@Nullable Object object, String jsonPath,
+      Object defaultValue) {
     Object res = null;
     try {
       res = jsonPath(object, jsonPath);
@@ -430,7 +431,8 @@ public class JsonFunctions {
     return objToInt(res, objToInt(defaultValue, 0));
   }
 
-  private static double jsonPathDoubleOrThrowIfNoDefault(@Nullable Object object, String jsonPath, Object defaultValue) {
+  private static double jsonPathDoubleOrThrowIfNoDefault(@Nullable Object object, String jsonPath,
+      Object defaultValue) {
     Object res = null;
     try {
       res = jsonPath(object, jsonPath);
@@ -446,7 +448,8 @@ public class JsonFunctions {
     return objToDouble(res, objToDouble(defaultValue, Double.NaN));
   }
 
-  private static boolean jsonPathBooleanOrThrowIfNoDefault(@Nullable Object object, String jsonPath, Object defaultValue) {
+  private static boolean jsonPathBooleanOrThrowIfNoDefault(@Nullable Object object, String jsonPath,
+      Object defaultValue) {
     Object res = null;
     try {
       res = jsonPath(object, jsonPath);

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/JsonFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/JsonFunctions.java
@@ -348,11 +348,19 @@ public class JsonFunctions {
 
   @ScalarFunction
   public static Object jsonExtractScalar(Object jsonInput, String jsonPath, String dataType) {
-    return jsonExtractScalar(jsonInput, jsonPath, dataType, null);
+    return doJsonExtractScalar(jsonInput, jsonPath, dataType, null);
   }
 
   @ScalarFunction
   public static Object jsonExtractScalar(Object jsonInput, String jsonPath, String dataType, Object defaultValue) {
+    /*
+     * If a default value is explicitly provided as null, it is converted to an empty string literal ("").
+     * This behavior exactly matches the semantics of JsonExtractTransformationFunction.
+     */
+    return doJsonExtractScalar(jsonInput, jsonPath, dataType, defaultValue == null ? "" : defaultValue);
+  }
+
+  private static Object doJsonExtractScalar(Object jsonInput, String jsonPath, String dataType, Object defaultValue) {
     switch (dataType.toUpperCase()) {
       case "STRING":
         return jsonPathStringOrThrowIfNoDefault(jsonInput, jsonPath, defaultValue);
@@ -396,7 +404,7 @@ public class JsonFunctions {
                 "Cannot resolve JSON path on some records. Consider setting a default value.");
       }
     }
-    return objToString(res, objToString(defaultValue, null));
+    return objToString(res, (String) defaultValue);
   }
 
   private static long jsonPathLongOrThrowIfNoDefault(@Nullable Object object, String jsonPath, Object defaultValue) {
@@ -412,7 +420,7 @@ public class JsonFunctions {
                 "Cannot resolve JSON path on some records. Consider setting a default value.");
       }
     }
-    return objToLong(res, objToLong(defaultValue, 0L));
+    return objToLong(res, defaultValue);
   }
 
   private static int jsonPathIntOrThrowIfNoDefault(@Nullable Object object, String jsonPath, Object defaultValue) {
@@ -428,7 +436,7 @@ public class JsonFunctions {
                 "Cannot resolve JSON path on some records. Consider setting a default value.");
       }
     }
-    return objToInt(res, objToInt(defaultValue, 0));
+    return objToInt(res, defaultValue);
   }
 
   private static double jsonPathDoubleOrThrowIfNoDefault(@Nullable Object object, String jsonPath,
@@ -445,7 +453,7 @@ public class JsonFunctions {
                 "Cannot resolve JSON path on some records. Consider setting a default value.");
       }
     }
-    return objToDouble(res, objToDouble(defaultValue, Double.NaN));
+    return objToDouble(res, defaultValue);
   }
 
   private static boolean jsonPathBooleanOrThrowIfNoDefault(@Nullable Object object, String jsonPath,
@@ -462,7 +470,7 @@ public class JsonFunctions {
                 "Cannot resolve JSON path on some records. Consider setting a default value.");
       }
     }
-    return objToBoolean(res, objToBoolean(defaultValue, Boolean.FALSE));
+    return objToBoolean(res, defaultValue);
   }
 
   private static String[] jsonPathStringArray(Object jsonInput, String jsonPath, Object defaultValue) {
@@ -512,7 +520,7 @@ public class JsonFunctions {
                           + "Consider setting a default value as the fourth argument of json_extract_scalar.");
         }
       }
-      result[i] = objToInt(o, objToInt(defaultValue, 0));
+      result[i] = objToInt(o, defaultValue);
     }
     return result;
   }
@@ -538,7 +546,7 @@ public class JsonFunctions {
                           + "Consider setting a default value as the fourth argument of json_extract_scalar.");
         }
       }
-      result[i] = objToDouble(o, objToDouble(defaultValue, Double.NaN));
+      result[i] = objToDouble(o, defaultValue);
     }
     return result;
   }
@@ -564,7 +572,7 @@ public class JsonFunctions {
                           + "Consider setting a default value as the fourth argument of json_extract_scalar.");
         }
       }
-      result[i] = objToLong(o, objToLong(defaultValue, 0L));
+      result[i] = objToLong(o, defaultValue);
     }
     return result;
   }
@@ -584,8 +592,8 @@ public class JsonFunctions {
     return res;
   }
 
-  private static int objToInt(Object obj, int defaultValue) {
-    int res = defaultValue;
+  private static Integer objToInt(Object obj, Object defaultValue) {
+    Integer res = null;
     if (obj != null) {
       if (obj instanceof Number) {
         res = ((Number) obj).intValue();
@@ -596,11 +604,14 @@ public class JsonFunctions {
         }
       }
     }
+    if (res == null) {
+      return Integer.parseInt(defaultValue.toString());
+    }
     return res;
   }
 
-  private static double objToDouble(Object obj, double defaultValue) {
-    double res = defaultValue;
+  private static Double objToDouble(Object obj, Object defaultValue) {
+    Double res = null;
     if (obj != null) {
       if (obj instanceof Number) {
         res = ((Number) obj).doubleValue();
@@ -611,11 +622,14 @@ public class JsonFunctions {
         }
       }
     }
+    if (res == null) {
+      return Double.parseDouble(defaultValue.toString());
+    }
     return res;
   }
 
-  private static long objToLong(Object obj, long defaultValue) {
-    long res = defaultValue;
+  private static Long objToLong(Object obj, Object defaultValue) {
+    Long res = null;
     if (obj != null) {
       if (obj instanceof Number) {
         res = ((Number) obj).longValue();
@@ -626,11 +640,14 @@ public class JsonFunctions {
         }
       }
     }
+    if (res == null) {
+      return Long.parseLong(defaultValue.toString());
+    }
     return res;
   }
 
-  private static boolean objToBoolean(Object obj, boolean defaultValue) {
-    boolean res = defaultValue;
+  private static Boolean objToBoolean(Object obj, Object defaultValue) {
+    Boolean res = null;
     if (obj != null) {
       if (obj instanceof Boolean) {
         return (Boolean) obj;
@@ -640,6 +657,9 @@ public class JsonFunctions {
         } catch (Exception ignored) {
         }
       }
+    }
+    if (res == null) {
+      return Boolean.parseBoolean(defaultValue.toString());
     }
     return res;
   }

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/JsonFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/JsonFunctions.java
@@ -35,8 +35,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.function.IntFunction;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.function.JsonPathCache;
@@ -368,7 +366,7 @@ public class JsonFunctions {
         case "DOUBLE":
           return jsonPathDouble(jsonInput, jsonPath, objToDouble(defaultValue, 0D));
         case "BOOLEAN":
-          return jsonPathBoolean(jsonInput, jsonPath, Objects.isNull(defaultValue) ? Boolean.FALSE : (Boolean) defaultValue);
+          return jsonPathBoolean(jsonInput, jsonPath, objToBoolean(defaultValue, false));
         case "STRING_ARRAY":
           return jsonPathStringArray(jsonInput, jsonPath, defaultValue);
         case "INT_ARRAY":
@@ -509,7 +507,7 @@ public class JsonFunctions {
     if (obj != null) {
       if (obj instanceof Boolean) {
         return (Boolean) obj;
-      }else {
+      } else {
         try {
           res = Boolean.parseBoolean(obj.toString());
         } catch (Exception ignored) {

--- a/pinot-common/src/test/java/org/apache/pinot/common/function/JsonFunctionsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/function/JsonFunctionsTest.java
@@ -721,8 +721,11 @@ public class JsonFunctionsTest {
     assertEquals(JsonFunctions.jsonExtractScalar(json, "$.bool-key", "BOOLEAN", false), true);
     assertEquals(JsonFunctions.jsonExtractScalar(json, "$.nonexistent", "STRING", "missing"), "missing");
 
-    assertThrows(() -> JsonFunctions.jsonExtractScalar(json, "$.nonexistent", "STRING", null));
+    assertEquals(JsonFunctions.jsonExtractScalar(json, "$.nonexistent", "STRING", null), "");
+    assertThrows(() -> JsonFunctions.jsonExtractScalar(json, "$.nonexistent", "STRING"));
     assertThrows(() -> JsonFunctions.jsonExtractScalar(json, "$.nonexistent", "INT"));
+    assertThrows(() -> JsonFunctions.jsonExtractScalar(json, "$.nonexistent", "INT", ""));
+    assertEquals(JsonFunctions.jsonExtractScalar(json, "$.nonexistent", "INT", 0), 0);
 
     String nestedJson = String.format(
             "{\"intVal\":%s, \"longVal\":%s, \"floatVal\":%s, \"doubleVal\":%s, \"bigDecimalVal\":%s, "

--- a/pinot-common/src/test/java/org/apache/pinot/common/function/JsonFunctionsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/function/JsonFunctionsTest.java
@@ -709,4 +709,17 @@ public class JsonFunctionsTest {
     Assert.assertTrue(jsonPathResult.contains("$['field_with_underscores']"));
     Assert.assertTrue(jsonPathResult.contains("$['field with spaces']"));
   }
+
+  @Test
+  public void testJsonExtractScalar() {
+    String json = "{\"int-key\":123,\"string-key\":\"value\",\"bool-key\":true,\"double-key\":12.3}";
+    assertEquals(JsonFunctions.jsonExtractScalar(json, "$.string-key", "STRING", "unknown"), "value");
+    assertEquals(JsonFunctions.jsonExtractScalar(json, "$.int-key", "INT", -1), 123);
+    assertEquals(JsonFunctions.jsonExtractScalar(json, "$.double-key", "DOUBLE", -1.0), 12.3);
+    assertEquals(JsonFunctions.jsonExtractScalar(json, "$.bool-key", "BOOLEAN", false), true);
+    assertEquals(JsonFunctions.jsonExtractScalar(json, "$.nonexistent", "STRING", "missing"), "missing");
+    assertNull(JsonFunctions.jsonExtractScalar(json, "$.nonexistent", "STRING"));
+    assertEquals(JsonFunctions.jsonExtractScalar(json, "$.nonexistent", "INT"), Integer.MIN_VALUE);
+    assertNull(JsonFunctions.jsonExtractScalar(json, "$.nonexistent", "STRING"));
+  }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/common/function/JsonFunctionsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/function/JsonFunctionsTest.java
@@ -37,6 +37,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
+import static org.testng.internal.junit.ArrayAsserts.assertArrayEquals;
 
 
 public class JsonFunctionsTest {
@@ -719,7 +720,23 @@ public class JsonFunctionsTest {
     assertEquals(JsonFunctions.jsonExtractScalar(json, "$.bool-key", "BOOLEAN", false), true);
     assertEquals(JsonFunctions.jsonExtractScalar(json, "$.nonexistent", "STRING", "missing"), "missing");
     assertNull(JsonFunctions.jsonExtractScalar(json, "$.nonexistent", "STRING"));
-    assertEquals(JsonFunctions.jsonExtractScalar(json, "$.nonexistent", "INT"), Integer.MIN_VALUE);
+    assertEquals(JsonFunctions.jsonExtractScalar(json, "$.nonexistent", "INT"), 0);
     assertNull(JsonFunctions.jsonExtractScalar(json, "$.nonexistent", "STRING"));
+
+
+    json = String.format(
+            "{\"intVal\":%s, \"longVal\":%s, \"floatVal\":%s, \"doubleVal\":%s, \"bigDecimalVal\":%s, "
+                    + "\"stringVal\":\"%s\", \"arrayField\": [{\"arrIntField\": 1, \"arrStringField\": \"abc\"}, "
+                    + "{\"arrIntField\": 2, \"arrStringField\": \"xyz\"},"
+                    + "{\"arrIntField\": 5, \"arrStringField\": \"wxy\"},"
+                    + "{\"arrIntField\": 0}], "
+                    + "\"intVals\":[0,1], \"longVals\":[0,1], \"floatVals\":[0.0,1.0], \"doubleVals\":[0.0,1.0], "
+                    + "\"bigDecimalVals\":[0.0,1.0], \"stringVals\":[\"0\",\"1\"]}",
+            42, 9999999999L, 3.14f, 6.28d, 123.456, "hello");
+
+    Object result = JsonFunctions.jsonExtractScalar(json, "$.arrayField[*].arrIntField", "INT_ARRAY", -1);
+    int[] arrIntField = (int[]) result;
+
+    assertArrayEquals(new int[]{1, 2, 5, 0}, arrIntField);
   }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/common/function/JsonFunctionsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/function/JsonFunctionsTest.java
@@ -735,8 +735,9 @@ public class JsonFunctionsTest {
             42, 9999999999L, 3.14f, 6.28d, 123.456, "hello");
 
     Object result = JsonFunctions.jsonExtractScalar(json, "$.arrayField[*].arrIntField", "INT_ARRAY", -1);
-    int[] arrIntField = (int[]) result;
+    assertArrayEquals(new int[]{1, 2, 5, 0}, (int[]) result);
 
-    assertArrayEquals(new int[]{1, 2, 5, 0}, arrIntField);
+    result = JsonFunctions.jsonExtractScalar(json, "$.arrayWrongField[*].arrIntField", "INT_ARRAY", -1);
+    assertArrayEquals(new int[0], (int[]) result);
   }
 }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/QueryRunnerTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/QueryRunnerTest.java
@@ -337,11 +337,6 @@ public class QueryRunnerTest extends QueryRunnerTestBase {
     //    - checked "Illegal Json Path" as col1 is not actually a json string, but the call is correctly triggered.
     testCases.add(
         new Object[]{"SELECT CAST(jsonExtractScalar(col1, 'path', 'INT') AS INT) FROM a", "Cannot resolve JSON path"});
-    //    - checked function cannot be found b/c there's no intermediate stage impl for json_extract_scalar
-    testCases.add(new Object[]{
-        "SELECT CAST(json_extract_scalar(a.col1, b.col2, 'INT') AS INT) FROM a JOIN b ON a.col1 = b.col1",
-        "Unsupported function: JSONEXTRACTSCALAR"
-    });
 
     // Positive int keys (only included ones that will be parsed for this query)
     for (String key : new String[]{


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Adds jsonExtractScalar function that dispatches by data type to extract JSON scalars or arrays, using helper converters and throwing on missing values without default\.

```mermaid
flowchart TD
  N0["jsonExtractScalar #40;F1#41;"]:::stAdded
  N1["doJsonExtractScalar #40;F1#41;"]:::stAdded
  N2["jsonPathStringOrThrowIfNoDefault #40;scalar handler#41; #40;F1#41;"]:::stAdded
  N3["objToString #40;value conversion#41; #40;F1#41;"]:::stAdded
  N4["jsonPathStringArray #40;array handler#41; #40;F1#41;"]:::stAdded
  N5["objToString #40;array element conversion#41; #40;F1#41;"]:::stAdded
  N0 -->|"calls"| N1
  N1 -->|"dispatch STRING case"| N2
  N2 -->|"convert result"| N3
  N1 -->|"dispatch STRING#95;ARRAY case"| N4
  N4 -->|"convert each element"| N5
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-common/src/main/java/org/apache/pinot/common/function/scalar/JsonFunctions\.java — [before](https://github.com/apache/pinot/blob/b2760be562eac82ec7e5ca2eff06e357ad2a0ffe/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/JsonFunctions.java) · [after](https://github.com/apache/pinot/blob/13350ed1b147aa9c6df020fee9e0061162f1239b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/JsonFunctions.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImIyNzYwYmU1NjJlYWM4MmVjN2U1Y2EyZWZmMDZlMzU3YWQyYTBmZmUiLCJjb250ZXh0X2hhc2giOiI4ZTE0ZTkzMGU0Y2JiYzMyNzFhZTczNTU0NDdiMDdjZDcyZTc1MTFlOGMzYTlkOGRmZWQ4MDdmMGM4M2U1NDBhIiwiZ2VuZXJhdGVkX2F0IjoxNzg5MTgwNDU0LCJoZWFkX3NoYSI6IjEzMzUwZWQxYjE0N2FhOWM2ZGYwMjBmZWU5ZTAwNjExNjJmMTIzOWIiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJiMjc2MGJlNTYyZWFjODJlYzdlNWNhMmVmZjA2ZTM1N2FkMmEwZmZlIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 86256af9afac70fdd3aaa90251c1b7cd218ea0b8f90b533a2c4987a628a9bb49 -->
<!-- pinot-pr-flow:end -->

Summary
This PR adds a new scalar function jsonExtractScalar to enable flexible extraction of scalar values from JSON fields in Pinot queries.

Key Changes
- Introduced jsonExtractScalar scalar function. Supported scalar data types: STRING, INT, LONG, DOUBLE, BOOLEAN, and newly added TIMESTAMP

Testing
- Added test cases in JsonFunctionsTest
