### PR TITLE
Disable OOM protection when IHOP JVM params not active (server/broker)

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
@@ -365,6 +365,14 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
     ThreadResourceUsageProvider.setThreadMemoryMeasurementEnabled(
         _brokerConf.getProperty(CommonConstants.Broker.CONFIG_OF_ENABLE_THREAD_ALLOCATED_BYTES_MEASUREMENT,
             CommonConstants.Broker.DEFAULT_THREAD_ALLOCATED_BYTES_MEASUREMENT));
+    // If JVM does not enable thread allocated bytes measurement, disable OOM protection to avoid false actions.
+    if (!ThreadResourceUsageProvider.isThreadMemoryMeasurementEnabled()) {
+      LOGGER.warn("Thread allocated bytes measurement is not enabled by JVM. Disabling OOM protection.");
+      _brokerConf.setProperty(
+          CommonConstants.PINOT_QUERY_SCHEDULER_PREFIX + "."
+              + CommonConstants.Accounting.CONFIG_OF_OOM_PROTECTION_KILLING_QUERY,
+          false);
+    }
     // initialize the thread accountant for query killing
     PinotConfiguration threadAccountantConfigs = _brokerConf.subset(CommonConstants.PINOT_QUERY_SCHEDULER_PREFIX);
     // This allows for custom implementations of WorkloadBudgetManager.

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
@@ -686,6 +686,14 @@ public abstract class BaseServerStarter implements ServiceStartable {
     ThreadResourceUsageProvider.setThreadMemoryMeasurementEnabled(
         _serverConf.getProperty(Server.CONFIG_OF_ENABLE_THREAD_ALLOCATED_BYTES_MEASUREMENT,
             Server.DEFAULT_THREAD_ALLOCATED_BYTES_MEASUREMENT));
+    // If JVM does not enable thread allocated bytes measurement, disable OOM protection to avoid false actions.
+    if (!ThreadResourceUsageProvider.isThreadMemoryMeasurementEnabled()) {
+      LOGGER.warn("Thread allocated bytes measurement is not enabled by JVM. Disabling OOM protection.");
+      _serverConf.setProperty(
+          CommonConstants.PINOT_QUERY_SCHEDULER_PREFIX + "."
+              + CommonConstants.Accounting.CONFIG_OF_OOM_PROTECTION_KILLING_QUERY,
+          false);
+    }
     // Initialize the thread accountant for query killing
     PinotConfiguration threadAccountantConfigs = _serverConf.subset(CommonConstants.PINOT_QUERY_SCHEDULER_PREFIX);
     // This allows for custom implementations of WorkloadBudgetManager.


### PR DESCRIPTION
This change adds a JVM capability guard for OOM protection on both Server and Broker.

- During startup, after enabling thread memory allocation tracking, we verify whether the JVM actually has thread-allocated-bytes measurement enabled via `ThreadResourceUsageProvider.isThreadMemoryMeasurementEnabled()`.
- If not enabled (IHOP JVM parameters not active), we proactively set `pinot.query.scheduler.accounting.oom.enable.killing.query=false` in the effective config, disabling OOM query killing to avoid false positives.

Files changed:
- server: `pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java`
- broker: `pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java`

Motivation:
- OOM protection relies on accurate per-thread allocated-bytes telemetry. When the JVM isn’t configured to expose it, keeping OOM protection enabled can lead to incorrect throttling or query killing decisions.

Notes:
- No behavioral change when IHOP JVM params are present and the capability is enabled.
- Only deprecation warnings observed in lints; no new errors introduced.
