### PR TITLE
Close receiving mailbox when an error block is received

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/InMemorySendingMailbox.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/InMemorySendingMailbox.java
@@ -95,6 +95,7 @@ public class InMemorySendingMailbox implements SendingMailbox {
         throw new QueryException(QueryErrorCode.EXECUTION_TIMEOUT,
             String.format("Timed out adding block into mailbox: %s with timeout: %dms", _id, timeoutMs));
       case EARLY_TERMINATED:
+      case FIRST_ERROR:
         _isEarlyTerminated = true;
         break;
       default:

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/ReceivingMailbox.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/ReceivingMailbox.java
@@ -140,7 +140,7 @@ public class ReceivingMailbox {
     _stats.merge(StatKey.IN_MEMORY_MESSAGES, 1);
     if (block instanceof ErrorMseBlock) {
       setErrorBlock((ErrorMseBlock) block, serializedStats);
-      return ReceivingMailboxStatus.EARLY_TERMINATED;
+      return ReceivingMailboxStatus.FIRST_ERROR;
     }
     return offerPrivate(block, serializedStats, timeoutMs);
   }
@@ -268,7 +268,12 @@ public class ReceivingMailbox {
   }
 
   public enum ReceivingMailboxStatus {
-    SUCCESS, FIRST_ERROR, ERROR, TIMEOUT, CANCELLED, EARLY_TERMINATED
+    SUCCESS,
+    /**
+     * Indicates that the block that is being offered is an error. No more blocks are expected after this status.
+     */
+    FIRST_ERROR,
+    ERROR, TIMEOUT, CANCELLED, EARLY_TERMINATED
   }
 
   public enum StatKey implements StatMap.Key {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/channel/MailboxContentObserver.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/channel/MailboxContentObserver.java
@@ -84,6 +84,9 @@ public class MailboxContentObserver implements StreamObserver<MailboxContent> {
           cancelStream();
           break;
         case FIRST_ERROR:
+          _responseObserver.onNext(MailboxStatus.newBuilder().setMailboxId(mailboxId)
+              .putMetadata(ChannelUtils.MAILBOX_METADATA_REQUEST_EARLY_TERMINATE, "true").build());
+          cancelStream();
           return;
         case ERROR:
           LOGGER.warn("Mailbox: {} already errored out (received error block before)", mailboxId);


### PR DESCRIPTION
We discovered another case where mailboxes may not be closed. Specifically, this issue prevented grpc methods from being finished early when errors were received.

This PR clearly defines the meaning of `ReceivingMailboxStatus.FIRST_ERROR` and modifies `MailboxContentObserver` to close the connection when status is received