### PR TITLE
Shade grpc library for pinot-spark-3-connector

### DIFF
--- a/pinot-connectors/pinot-spark-3-connector/pom.xml
+++ b/pinot-connectors/pinot-spark-3-connector/pom.xml
@@ -56,6 +56,7 @@
                       <includes>
                         <include>com.google.protobuf.**</include>
                         <include>com.google.common.**</include>
+                        <include>io.grpc.**</include>
                       </includes>
                     </relocation>
                   </relocations>


### PR DESCRIPTION
Shade `io.grpc` library for pinot-spark-3-connector。

When use `pinot-spark-3-connector` in AWS glue or other env with pre-installed grpc library, there could be issue of grpc lib version discrepancy issue, so shaded the grpc library to make the package self contained.