### PR TITLE
Add support to process segment refresh messages asynchronously if enabled

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/InstanceDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/InstanceDataManager.java
@@ -170,6 +170,11 @@ public interface InstanceDataManager {
   int getMaxParallelRefreshThreads();
 
   /**
+   * Returns true if background processing for SEGMENT_REFRESH is enabled, false otherwise
+   */
+  boolean isEnableSegmentRefreshAsynchronousHandling();
+
+  /**
    * Returns the Helix property store.
    */
   ZkHelixPropertyStore<ZNRecord> getPropertyStore();

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/provider/DefaultTableDataManagerProvider.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/provider/DefaultTableDataManagerProvider.java
@@ -67,7 +67,7 @@ public class DefaultTableDataManagerProvider implements TableDataManagerProvider
   @Override
   public TableDataManager getTableDataManager(TableConfig tableConfig, Schema schema,
       SegmentReloadSemaphore segmentReloadSemaphore, ExecutorService segmentReloadExecutor,
-      @Nullable ExecutorService segmentPreloadExecutor,
+      @Nullable ExecutorService segmentPreloadExecutor, @Nullable ExecutorService segmentRefreshExecutor,
       @Nullable Cache<Pair<String, String>, SegmentErrorInfo> errorCache,
       Supplier<Boolean> isServerReadyToServeQueries) {
     TableDataManager tableDataManager;
@@ -93,7 +93,8 @@ public class DefaultTableDataManagerProvider implements TableDataManagerProvider
         throw new IllegalStateException();
     }
     tableDataManager.init(_instanceDataManagerConfig, _helixManager, _segmentLocks, tableConfig, schema,
-        segmentReloadSemaphore, segmentReloadExecutor, segmentPreloadExecutor, errorCache, _segmentOperationsThrottler);
+        segmentReloadSemaphore, segmentReloadExecutor, segmentPreloadExecutor, segmentRefreshExecutor, errorCache,
+        _segmentOperationsThrottler);
     return tableDataManager;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/provider/TableDataManagerProvider.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/provider/TableDataManagerProvider.java
@@ -47,14 +47,14 @@ public interface TableDataManagerProvider {
       @Nullable SegmentOperationsThrottler segmentOperationsThrottler);
 
   TableDataManager getTableDataManager(TableConfig tableConfig, Schema schema,
-      SegmentReloadSemaphore segmentRefreshSemaphore, ExecutorService segmentRefreshExecutor,
-      @Nullable ExecutorService segmentPreloadExecutor,
+      SegmentReloadSemaphore segmentRefreshSemaphore, ExecutorService segmentReloadExecutor,
+      @Nullable ExecutorService segmentPreloadExecutor, @Nullable ExecutorService segmentRefreshExecutor,
       @Nullable Cache<Pair<String, String>, SegmentErrorInfo> errorCache,
       Supplier<Boolean> isServerReadyToServeQueries);
 
   @VisibleForTesting
   default TableDataManager getTableDataManager(TableConfig tableConfig, Schema schema) {
     return getTableDataManager(tableConfig, schema, new SegmentReloadSemaphore(1), Executors.newSingleThreadExecutor(),
-        null, null, () -> true);
+        null, null, null, () -> true);
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerAcquireSegmentTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerAcquireSegmentTest.java
@@ -134,7 +134,8 @@ public class BaseTableDataManagerAcquireSegmentTest {
             new SegmentMultiColTextIndexPreprocessThrottler(4, 8, true));
     TableDataManager tableDataManager = new OfflineTableDataManager();
     tableDataManager.init(instanceDataManagerConfig, mock(HelixManager.class), new SegmentLocks(), tableConfig, schema,
-        new SegmentReloadSemaphore(1), Executors.newSingleThreadExecutor(), null, null, segmentOperationsThrottler);
+        new SegmentReloadSemaphore(1), Executors.newSingleThreadExecutor(), null, null, null,
+        segmentOperationsThrottler);
     tableDataManager.start();
     Field segsMapField = BaseTableDataManager.class.getDeclaredField("_segmentDataManagerMap");
     segsMapField.setAccessible(true);

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerTest.java
@@ -667,7 +667,7 @@ public class BaseTableDataManagerTest {
   private static OfflineTableDataManager createTableManager(InstanceDataManagerConfig instanceDataManagerConfig) {
     OfflineTableDataManager tableDataManager = new OfflineTableDataManager();
     tableDataManager.init(instanceDataManagerConfig, mock(HelixManager.class), new SegmentLocks(), DEFAULT_TABLE_CONFIG,
-        SCHEMA, new SegmentReloadSemaphore(1), Executors.newSingleThreadExecutor(), null, null,
+        SCHEMA, new SegmentReloadSemaphore(1), Executors.newSingleThreadExecutor(), null, null, null,
         SEGMENT_OPERATIONS_THROTTLER);
     return tableDataManager;
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/offline/DimensionTableDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/offline/DimensionTableDataManagerTest.java
@@ -177,7 +177,8 @@ public class DimensionTableDataManagerTest {
     DimensionTableDataManager tableDataManager =
         DimensionTableDataManager.createInstanceByTableName(OFFLINE_TABLE_NAME);
     tableDataManager.init(instanceDataManagerConfig, helixManager, new SegmentLocks(), tableConfig, schema,
-        new SegmentReloadSemaphore(1), Executors.newSingleThreadExecutor(), null, null, SEGMENT_OPERATIONS_THROTTLER);
+        new SegmentReloadSemaphore(1), Executors.newSingleThreadExecutor(), null, null, null,
+        SEGMENT_OPERATIONS_THROTTLER);
     tableDataManager.start();
     return tableDataManager;
   }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/realtime/utils/FailureInjectingTableDataManagerProvider.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/realtime/utils/FailureInjectingTableDataManagerProvider.java
@@ -65,7 +65,7 @@ public class FailureInjectingTableDataManagerProvider implements TableDataManage
   @Override
   public TableDataManager getTableDataManager(TableConfig tableConfig, Schema schema,
       SegmentReloadSemaphore segmentReloadSemaphore, ExecutorService segmentReloadExecutor,
-      @Nullable ExecutorService segmentPreloadExecutor,
+      @Nullable ExecutorService segmentPreloadExecutor, @Nullable ExecutorService segmentRefreshExecutor,
       @Nullable Cache<Pair<String, String>, SegmentErrorInfo> errorCache,
       Supplier<Boolean> isServerReadyToServeQueries) {
     TableDataManager tableDataManager;
@@ -92,7 +92,8 @@ public class FailureInjectingTableDataManagerProvider implements TableDataManage
         throw new IllegalStateException();
     }
     tableDataManager.init(_instanceDataManagerConfig, _helixManager, _segmentLocks, tableConfig, schema,
-        segmentReloadSemaphore, segmentReloadExecutor, segmentPreloadExecutor, errorCache, null);
+        segmentReloadSemaphore, segmentReloadExecutor, segmentPreloadExecutor, segmentRefreshExecutor, errorCache,
+        null);
     return tableDataManager;
   }
 }

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkDimensionTableOverhead.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkDimensionTableOverhead.java
@@ -187,7 +187,8 @@ public class BenchmarkDimensionTableOverhead extends BaseQueriesTest {
     String tableName = TABLE_NAME + "_" + _iteration;
     _tableDataManager = DimensionTableDataManager.createInstanceByTableName(tableName);
     _tableDataManager.init(instanceDataManagerConfig, helixManager, new SegmentLocks(), tableConfig, SCHEMA,
-        new SegmentReloadSemaphore(1), Executors.newSingleThreadExecutor(), null, null, SEGMENT_OPERATIONS_THROTTLER);
+        new SegmentReloadSemaphore(1), Executors.newSingleThreadExecutor(), null, null, null,
+        SEGMENT_OPERATIONS_THROTTLER);
     _tableDataManager.start();
 
     for (int i = 0; i < _indexSegments.size(); i++) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManager.java
@@ -55,6 +55,7 @@ public interface TableDataManager {
   void init(InstanceDataManagerConfig instanceDataManagerConfig, HelixManager helixManager, SegmentLocks segmentLocks,
       TableConfig tableConfig, Schema schema, SegmentReloadSemaphore segmentReloadSemaphore,
       ExecutorService segmentReloadExecutor, @Nullable ExecutorService segmentPreloadExecutor,
+      @Nullable ExecutorService segmentRefreshExecutor,
       @Nullable Cache<Pair<String, String>, SegmentErrorInfo> errorCache,
       @Nullable SegmentOperationsThrottler segmentOperationsThrottler);
 
@@ -160,6 +161,13 @@ public interface TableDataManager {
    * This method is triggered by state transition to CONSUMING state.
    */
   void addConsumingSegment(String segmentName)
+      throws Exception;
+
+  /**
+   * Enqueues a segment to be replaced by a background thread and is to be called instead of replaceSegment() if
+   * background processing is enabled for refresh messages.
+   */
+  void enqueueSegmentToReplace(String segmentName)
       throws Exception;
 
   /**

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SegmentReloadSemaphore.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SegmentReloadSemaphore.java
@@ -35,9 +35,9 @@ public class SegmentReloadSemaphore {
   public void acquire(String segmentName, Logger logger)
       throws InterruptedException {
     long startTimeMs = System.currentTimeMillis();
-    logger.info("Waiting for lock to reload: {}, queue-length: {}", segmentName, _semaphore.getQueueLength());
+    logger.info("Waiting for lock to reload/refresh: {}, queue-length: {}", segmentName, _semaphore.getQueueLength());
     _semaphore.acquire();
-    logger.info("Acquired lock to reload segment: {} (lock-time={}ms, queue-length={})", segmentName,
+    logger.info("Acquired lock to reload/refresh segment: {} (lock-time={}ms, queue-length={})", segmentName,
         System.currentTimeMillis() - startTimeMs, _semaphore.getQueueLength());
   }
 

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
@@ -100,6 +100,11 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
   //
   public static final String MAX_PARALLEL_REFRESH_THREADS = "max.parallel.refresh.threads";
 
+  // Whether to process SEGMENT_REFRESH in a synchronous or asynchronous manner when the messaged is received.
+  // Defaults to false, meaning SEGMENT_REFRESH will be processed in a synchronous manner.
+  public static final String ENABLE_SEGMENT_REFRESH_ASYNCHRONOUS_HANDLING = "segment.refresh.asynchronous.handling";
+  private static final boolean DEFAULT_ENABLE_SEGMENT_REFRESH_ASYNCHRONOUS_HANDLING = false;
+
   // To preload segments of table using upsert in parallel for fast upsert metadata recovery.
   private static final String MAX_SEGMENT_PRELOAD_THREADS = "max.segment.preload.threads";
 
@@ -250,6 +255,12 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
   @Override
   public int getMaxParallelRefreshThreads() {
     return _serverConfig.getProperty(MAX_PARALLEL_REFRESH_THREADS, 1);
+  }
+
+  @Override
+  public boolean isEnableSegmentRefreshAsynchronousHandling() {
+    return _serverConfig.getProperty(ENABLE_SEGMENT_REFRESH_ASYNCHRONOUS_HANDLING,
+        DEFAULT_ENABLE_SEGMENT_REFRESH_ASYNCHRONOUS_HANDLING);
   }
 
   @Override

--- a/pinot-server/src/test/java/org/apache/pinot/server/api/BaseResourceTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/api/BaseResourceTest.java
@@ -226,7 +226,7 @@ public abstract class BaseResourceTest {
     //       more checks
     TableDataManager tableDataManager = new OfflineTableDataManager();
     tableDataManager.init(instanceDataManagerConfig, helixManager, new SegmentLocks(), tableConfig, schema,
-        new SegmentReloadSemaphore(1), Executors.newSingleThreadExecutor(), null, null, null);
+        new SegmentReloadSemaphore(1), Executors.newSingleThreadExecutor(), null, null, null, null);
     tableDataManager.start();
     _tableDataManagerMap.put(tableNameWithType, tableDataManager);
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/instance/InstanceDataManagerConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/instance/InstanceDataManagerConfig.java
@@ -55,6 +55,8 @@ public interface InstanceDataManagerConfig {
 
   int getMaxParallelRefreshThreads();
 
+  boolean isEnableSegmentRefreshAsynchronousHandling();
+
   int getMaxSegmentPreloadThreads();
 
   int getMaxParallelSegmentBuilds();


### PR DESCRIPTION
This PR adds support for processing SEGMENT_REFRESH messages asynchronously rather than holding up the Helix message thread while doing the processing. The main objective is to free up the Helix threads faster for handling SEGMENT_REFRESH messages. We have seen issues where processing a large number of refresh messages can take time and back-up and delay processing of other Helix messages if the Helix messages queue is very full.

A config is required to enable this feature: `segment.refresh.asynchronous.handling`, and is disabled by default

Testing done:
- Added a refreshSegment API locally and ran QuickStart to verify that the refresh messages are added to the ExecutorService when this is enabled

cc @Jackie-Jiang @krishan1390 