### PR TITLE
Change the globalLock of BrokerRoutingManager to be fair to prevent writer starvation

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/BrokerRoutingManager.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/BrokerRoutingManager.java
@@ -133,7 +133,7 @@ public class BrokerRoutingManager implements RoutingManager, ClusterChangeHandle
   // Global read-write lock for protecting the global data structures such as _enabledServerInstanceMap,
   // _excludedServers, and _routableServers. Write lock must be held if any of these are modified, read lock must be
   // held otherwise
-  private final ReadWriteLock _globalLock = new ReentrantReadWriteLock();
+  private final ReadWriteLock _globalLock = new ReentrantReadWriteLock(true);
 
   // Per-table locks to allow concurrent routing builds across different tables while serializing per-table operations
   // This must be keyed on the raw table name due to dependencies for TimeBoundaryManager creation between REALTIME


### PR DESCRIPTION
Changing the `_globalLock` of `BrokerRoutingManager` to enable fairness to avoid writer starvation in case of high number of readers.