### PR TITLE
Add support to add a resource level Helix constraint on state transition messages

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
@@ -168,6 +168,7 @@ public abstract class BaseControllerStarter implements ServiceStartable {
   private static final Long DATA_DIRECTORY_EXCEPTION_VALUE = 1100000L;
   private static final String METADATA_EVENT_NOTIFIER_PREFIX = "metadata.event.notifier";
   private static final String MAX_STATE_TRANSITIONS_PER_INSTANCE = "MaxStateTransitionsPerInstance";
+  private static final String MAX_STATE_TRANSITIONS_PER_RESOURCE = "MaxStateTransitionsPerResource";
 
   protected ControllerConf _config;
   protected List<ListenerConfig> _listenerConfigs;
@@ -338,6 +339,8 @@ public abstract class BaseControllerStarter implements ServiceStartable {
   }
 
   private void setupHelixClusterConstraints() {
+    // Set up the INSTANCE level state transition constraint. This provides an upper-bound on the total state transition
+    // messages that can be in the Helix messages queue for a given instance
     String maxStateTransitions = _config.getProperty(Helix.CONFIG_OF_HELIX_INSTANCE_MAX_STATE_TRANSITIONS,
         Helix.DEFAULT_HELIX_INSTANCE_MAX_STATE_TRANSITIONS);
     Map<ClusterConstraints.ConstraintAttribute, String> constraintAttributes = new HashMap<>();
@@ -349,6 +352,21 @@ public abstract class BaseControllerStarter implements ServiceStartable {
     _helixControllerManager.getClusterManagmentTool()
         .setConstraint(_helixClusterName, ClusterConstraints.ConstraintType.MESSAGE_CONSTRAINT,
             MAX_STATE_TRANSITIONS_PER_INSTANCE, constraintItem);
+
+    // Set up the RESOURCE level state transition constraint, this applies per-resource per-instance
+    String maxStateTransitionsPerResource = _config.getProperty(Helix.CONFIG_OF_MAX_STATE_TRANSITIONS_PER_RESOURCE,
+        Helix.DEFAULT_HELIX_INSTANCE_MAX_STATE_TRANSITIONS_PER_RESOURCE);
+    Map<ClusterConstraints.ConstraintAttribute, String> constraintAttributesResource = new HashMap<>();
+    constraintAttributesResource.put(ClusterConstraints.ConstraintAttribute.RESOURCE, ".*");
+    constraintAttributesResource.put(ClusterConstraints.ConstraintAttribute.INSTANCE, ".*");
+    constraintAttributesResource.put(ClusterConstraints.ConstraintAttribute.MESSAGE_TYPE,
+        Message.MessageType.STATE_TRANSITION.name());
+    ConstraintItem constraintItemResource = new ConstraintItem(constraintAttributesResource,
+        maxStateTransitionsPerResource);
+
+    _helixControllerManager.getClusterManagmentTool()
+        .setConstraint(_helixClusterName, ClusterConstraints.ConstraintType.MESSAGE_CONSTRAINT,
+            MAX_STATE_TRANSITIONS_PER_RESOURCE, constraintItemResource);
   }
 
   protected void addUtilizationChecker(UtilizationChecker utilizationChecker) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -235,10 +235,16 @@ public class CommonConstants {
     public static final String CONFIG_OF_BROKER_FLAPPING_TIME_WINDOW_MS = "pinot.broker.flapping.timeWindowMs";
     public static final String CONFIG_OF_SERVER_FLAPPING_TIME_WINDOW_MS = "pinot.server.flapping.timeWindowMs";
     public static final String CONFIG_OF_MINION_FLAPPING_TIME_WINDOW_MS = "pinot.minion.flapping.timeWindowMs";
+    public static final String DEFAULT_FLAPPING_TIME_WINDOW_MS = "1";
+    // Max state transitions per-instance across all resources
     public static final String CONFIG_OF_HELIX_INSTANCE_MAX_STATE_TRANSITIONS =
         "pinot.helix.instance.state.maxStateTransitions";
     public static final String DEFAULT_HELIX_INSTANCE_MAX_STATE_TRANSITIONS = "100000";
-    public static final String DEFAULT_FLAPPING_TIME_WINDOW_MS = "1";
+    // Max state transitions per-resource per-instance. Used to provide more fairness in case a large number of state
+    // transitions come in for a single resource
+    public static final String CONFIG_OF_MAX_STATE_TRANSITIONS_PER_RESOURCE =
+        "pinot.helix.instance.state.maxStateTransitionsPerResource";
+    public static final String DEFAULT_HELIX_INSTANCE_MAX_STATE_TRANSITIONS_PER_RESOURCE = "100000";
     public static final String PINOT_SERVICE_ROLE = "pinot.service.role";
     public static final String CONFIG_OF_CLUSTER_NAME = "pinot.cluster.name";
     public static final String CONFIG_OF_ZOOKEEPER_SERVER = "pinot.zk.server";


### PR DESCRIPTION
This PR adds the capability to have a Helix constraint on the number of state transitions per-resource per-instance. This is to prevent starvation of handling state transitions for certain resources when a flood of state transitions come in for other resources (e.g. say a large number of OFFLINE segments are added to the IdealState, we can run into issues where the REALTIME segment commits may take a long time to process because the Helix messages queue is too full.

This PR sets the default value to a very high value to ensure existing systems don't see behavior change.

Testing:
Tested this locally using the HybridQuickStart. Added some artificial delay to the state transition callbacks to see the behavior assuming these take time to process. Scenarios tried:
- Setting a resource limit of "2" per-instance and validated that for each table only 2 messages were in the Helix messages queue. There were 2 tables, so at most had 4 state transition messages at any time for each server
- Setting a resource limit of "2" per-instance and an overall instance limit of "3". Validated that the Helix messages queue didn't have more than 3 messages, even though 2 tables had state transitions that needed to be processed

cc @Jackie-Jiang @krishan1390 