### PR TITLE
Change Netty defaults and add new metrics exporting the total max and used memory by Netty and gRPC

### DIFF
--- a/.github/workflows/pinot_tests.yml
+++ b/.github/workflows/pinot_tests.yml
@@ -185,6 +185,9 @@ jobs:
             --add-opens=java.base/java.lang=ALL-UNNAMED
             --add-opens=java.base/java.util=ALL-UNNAMED
             --add-opens=java.base/java.lang.reflect=ALL-UNNAMED
+            --add-opens=java.base/jdk.internal.misc=ALL-UNNAMED
+            -Dio.netty.tryReflectionSetAccessible=true
+            -Dio.grpc.netty.shaded.io.netty.tryReflectionSetAccessible=true
         run: .github/workflows/scripts/pr-tests/.pinot_tests_build.sh
       - name: Unit Test
         env:
@@ -206,6 +209,9 @@ jobs:
             --add-opens=java.base/java.lang=ALL-UNNAMED
             --add-opens=java.base/java.util=ALL-UNNAMED
             --add-opens=java.base/java.lang.reflect=ALL-UNNAMED
+            --add-opens=java.base/jdk.internal.misc=ALL-UNNAMED
+            -Dio.netty.tryReflectionSetAccessible=true
+            -Dio.grpc.netty.shaded.io.netty.tryReflectionSetAccessible=true
         run: .github/workflows/scripts/pr-tests/.pinot_tests_unit.sh
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v5

--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -1,0 +1,8 @@
+--add-opens=java.base/java.nio=ALL-UNNAMED
+--add-opens=java.base/sun.nio.ch=ALL-UNNAMED
+--add-opens=java.base/java.lang=ALL-UNNAMED
+--add-opens=java.base/java.util=ALL-UNNAMED
+--add-opens=java.base/java.lang.reflect=ALL-UNNAMED
+--add-opens=java.base/jdk.internal.misc=ALL-UNNAMED
+-Dio.netty.tryReflectionSetAccessible=true
+-Dio.grpc.netty.shaded.io.netty.tryReflectionSetAccessible=true

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerGauge.java
@@ -97,7 +97,16 @@ public enum BrokerGauge implements AbstractMetrics.Gauge {
   MAILBOX_SERVER_CACHE_SIZE_SMALL("bytes", true),
   MAILBOX_SERVER_CACHE_SIZE_NORMAL("bytes", true),
   MAILBOX_SERVER_THREADLOCALCACHE("bytes", true),
-  MAILBOX_SERVER_CHUNK_SIZE("bytes", true);
+  MAILBOX_SERVER_CHUNK_SIZE("bytes", true),
+
+  /// Exports the max amount of direct memory that can be allocated by the shaded Netty code used by gRPC
+  /// It is basically an adaptor for io.grpc.netty.shaded.io.netty.util.internal.PlatformDependent.maxDirectMemory()
+  ///
+  /// This value can be changed by setting the JVM option -Dio.grpc.netty.shaded.io.netty.maxDirectMemory
+  GRPC_TOTAL_MAX_DIRECT_MEMORY("bytes", true),
+  /// Exports the total amount of direct memory allocated by the shaded Netty code used by gRPC
+  /// It is basically an adaptor for io.grpc.netty.shaded.io.netty.util.internal.PlatformDependent.usedDirectMemory()
+  GRPC_TOTAL_USED_DIRECT_MEMORY("bytes", true);
 
   private final String _brokerGaugeName;
   private final String _unit;

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
@@ -123,6 +123,23 @@ public enum ServerGauge implements AbstractMetrics.Gauge {
   MAILBOX_SERVER_THREADLOCALCACHE("bytes", true),
   MAILBOX_SERVER_CHUNK_SIZE("bytes", true),
 
+  /// Exports the max amount of direct memory that can be allocated by Netty
+  /// It is basically an adaptor for io.netty.util.internal.PlatformDependent.maxDirectMemory()
+  ///
+  /// This value can be changed by setting the JVM option -Dio.netty.maxDirectMemory
+  NETTY_TOTAL_MAX_DIRECT_MEMORY("bytes", true),
+  /// Exports the total amount of direct memory allocated by Netty
+  /// It is basically an adaptor for io.netty.util.internal.PlatformDependent.usedDirectMemory()
+  NETTY_TOTAL_USED_DIRECT_MEMORY("bytes", true),
+  /// Exports the max amount of direct memory that can be allocated by the shaded Netty code used by gRPC
+  /// It is basically an adaptor for io.grpc.netty.shaded.io.netty.util.internal.PlatformDependent.maxDirectMemory()
+  ///
+  /// This value can be changed by setting the JVM option -Dio.grpc.netty.shaded.io.netty.maxDirectMemory
+  GRPC_TOTAL_MAX_DIRECT_MEMORY("bytes", true),
+  /// Exports the total amount of direct memory allocated by the shaded Netty code used by gRPC
+  /// It is basically an adaptor for io.grpc.netty.shaded.io.netty.util.internal.PlatformDependent.usedDirectMemory()
+  GRPC_TOTAL_USED_DIRECT_MEMORY("bytes", true),
+
   // how many message are there in the server's message queue in helix
   HELIX_MESSAGES_COUNT("count", true),
   STARTUP_STATUS_CHECK_IN_PROGRESS("state", true,

--- a/pinot-connectors/pinot-spark-3-connector/pom.xml
+++ b/pinot-connectors/pinot-spark-3-connector/pom.xml
@@ -155,6 +155,9 @@
             --add-opens=java.base/java.lang=ALL-UNNAMED
             --add-opens=java.base/java.util=ALL-UNNAMED
             --add-opens=java.base/java.lang.reflect=ALL-UNNAMED
+            --add-opens=java.base/jdk.internal.misc=ALL-UNNAMED
+            -Dio.netty.tryReflectionSetAccessible=true
+            -Dio.grpc.netty.shaded.io.netty.tryReflectionSetAccessible=true
           </argLine>
         </configuration>
       </plugin>

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/QueryServer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/QueryServer.java
@@ -36,6 +36,7 @@ import io.netty.channel.nio.NioEventLoopGroup;
 import io.netty.channel.socket.ServerSocketChannel;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
+import io.netty.util.internal.PlatformDependent;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import org.apache.pinot.common.config.NettyConfig;
@@ -130,6 +131,9 @@ public class QueryServer {
       metrics.setOrUpdateGlobalGauge(ServerGauge.NETTY_POOLED_CACHE_SIZE_NORMAL, metric::normalCacheSize);
       metrics.setOrUpdateGlobalGauge(ServerGauge.NETTY_POOLED_THREADLOCALCACHE, metric::numThreadLocalCaches);
       metrics.setOrUpdateGlobalGauge(ServerGauge.NETTY_POOLED_CHUNK_SIZE, metric::chunkSize);
+      metrics.setOrUpdateGlobalGauge(ServerGauge.NETTY_TOTAL_MAX_DIRECT_MEMORY, PlatformDependent::maxDirectMemory);
+      metrics.setOrUpdateGlobalGauge(ServerGauge.NETTY_TOTAL_USED_DIRECT_MEMORY, PlatformDependent::usedDirectMemory);
+
       _channel = (ServerSocketChannel) serverBootstrap.group(_bossGroup, _workerGroup).channel(_channelClass)
           .option(ChannelOption.SO_BACKLOG, 128)
           .childOption(ChannelOption.SO_KEEPALIVE, true)

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/channel/GrpcMailboxServer.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/channel/GrpcMailboxServer.java
@@ -24,6 +24,7 @@ import io.grpc.netty.shaded.io.grpc.netty.NettyServerBuilder;
 import io.grpc.netty.shaded.io.netty.buffer.PooledByteBufAllocator;
 import io.grpc.netty.shaded.io.netty.buffer.PooledByteBufAllocatorMetric;
 import io.grpc.netty.shaded.io.netty.channel.ChannelOption;
+import io.grpc.netty.shaded.io.netty.util.internal.PlatformDependent;
 import io.grpc.stub.StreamObserver;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
@@ -79,6 +80,17 @@ public class GrpcMailboxServer extends PinotMailboxGrpc.PinotMailboxImplBase {
       brokerMetrics.setOrUpdateGlobalGauge(BrokerGauge.MAILBOX_SERVER_CACHE_SIZE_NORMAL, metric::normalCacheSize);
       brokerMetrics.setOrUpdateGlobalGauge(BrokerGauge.MAILBOX_SERVER_THREADLOCALCACHE, metric::numThreadLocalCaches);
       brokerMetrics.setOrUpdateGlobalGauge(BrokerGauge.MAILBOX_SERVER_CHUNK_SIZE, metric::chunkSize);
+
+      // Notice here we are using io.grpc.netty.shaded.io.netty.util.internal.PlatformDependent instead of
+      // io.netty.util.internal.PlatformDependent because gRPC shades Netty to avoid version conflicts.
+      // This also means it uses a different pool of direct memory and a different setting of max direct memory.
+      //
+      // Also notice these two metrics are also set by GrpcQueryService. Both are set to the same value, so it
+      // doesn't matter which one _wins_ in the metrics system.
+      brokerMetrics.setOrUpdateGlobalGauge(BrokerGauge.GRPC_TOTAL_MAX_DIRECT_MEMORY,
+          PlatformDependent::maxDirectMemory);
+      brokerMetrics.setOrUpdateGlobalGauge(BrokerGauge.GRPC_TOTAL_USED_DIRECT_MEMORY,
+          PlatformDependent::usedDirectMemory);
     } else {
       Preconditions.checkState(instanceType == InstanceType.SERVER, "Unexpected instance type: %s", instanceType);
       ServerMetrics serverMetrics = ServerMetrics.get();
@@ -90,6 +102,17 @@ public class GrpcMailboxServer extends PinotMailboxGrpc.PinotMailboxImplBase {
       serverMetrics.setOrUpdateGlobalGauge(ServerGauge.MAILBOX_SERVER_CACHE_SIZE_NORMAL, metric::normalCacheSize);
       serverMetrics.setOrUpdateGlobalGauge(ServerGauge.MAILBOX_SERVER_THREADLOCALCACHE, metric::numThreadLocalCaches);
       serverMetrics.setOrUpdateGlobalGauge(ServerGauge.MAILBOX_SERVER_CHUNK_SIZE, metric::chunkSize);
+
+      // Notice here we are using io.grpc.netty.shaded.io.netty.util.internal.PlatformDependent instead of
+      // io.netty.util.internal.PlatformDependent because gRPC shades Netty to avoid version conflicts.
+      // This also means it uses a different pool of direct memory and a different setting of max direct memory.
+      //
+      // Also notice these two metrics are also set by GrpcQueryService. Both are set to the same value, so it
+      // doesn't matter which one _wins_ in the metrics system.
+      serverMetrics.setOrUpdateGlobalGauge(ServerGauge.GRPC_TOTAL_MAX_DIRECT_MEMORY,
+          PlatformDependent::maxDirectMemory);
+      serverMetrics.setOrUpdateGlobalGauge(ServerGauge.GRPC_TOTAL_USED_DIRECT_MEMORY,
+          PlatformDependent::usedDirectMemory);
     }
 
     NettyServerBuilder builder = NettyServerBuilder

--- a/pinot-tools/src/main/resources/appAssemblerScriptTemplate
+++ b/pinot-tools/src/main/resources/appAssemblerScriptTemplate
@@ -206,6 +206,9 @@ if [ "$(jdk_version)" -gt 11 ]; then
   --add-opens=java.base/java.lang=ALL-UNNAMED \
   --add-opens=java.base/java.util=ALL-UNNAMED \
   --add-opens=java.base/java.lang.reflect=ALL-UNNAMED \
+  --add-opens=java.base/jdk.internal.misc=ALL-UNNAMED \
+  -Dio.netty.tryReflectionSetAccessible=true \
+  -Dio.grpc.netty.shaded.io.netty.tryReflectionSetAccessible=true \
   $JAVA_OPTS"
 fi
 

--- a/pom.xml
+++ b/pom.xml
@@ -2288,6 +2288,9 @@
               --add-opens=java.base/java.util=ALL-UNNAMED
               --add-exports=java.base/jdk.internal.util.random=ALL-UNNAMED
               --add-opens=java.base/java.lang.reflect=ALL-UNNAMED
+              --add-opens=java.base/jdk.internal.misc=ALL-UNNAMED
+              -Dio.netty.tryReflectionSetAccessible=true
+              -Dio.grpc.netty.shaded.io.netty.tryReflectionSetAccessible=true
               -Dnet.bytebuddy.experimental=true
               -javaagent:${settings.localRepository}/org/mockito/mockito-core/${mockito-core.version}/mockito-core-${mockito-core.version}.jar
               -Xshare:off


### PR DESCRIPTION
This PR adds 6 new metrics to measure direct memory used by gRPC and Netty:

- On Broker:
  - grpcTotalUsedDirectMemory: Total used direct memory used by the version of Netty shaded by gRPC. It is -1 if grpc-netty is not configured to measure bytes.
  - grpcTotalMaxDirectMemory: Total max direct memory used by the version of Netty shaded by gRPC.
- On Server:
  - grpcTotalUsedDirectMemory: Same as on broker
  - grpcTotalMaxDirectMemory: Same as on broker
  - nettyTotalUsedDirectMemory: Total used direct memory used by the vanilla version Netty. It is -1 if Netty is not configured to measure bytes.
  - nettyTotalMaxDirectMemory: Total max direct memory used by the vanilla version Netty.

The metrics prefixed as _netty_ are used by the normal SSE query server, while the ones prefixed as _grpc_ are used by MSE (for both plan protocol and mailbox protocol), the gRPC query server and the gRPC query broker.

The following JAVA_OPTS are needed to use Netty correctly:
- --add-opens=java.base/jdk.internal.misc=ALL-UNNAMED
- -Dio.netty.tryReflectionSetAccessible=true
- -Dio.grpc.netty.shaded.io.netty.tryReflectionSetAccessible=true
  
Without these options, Netty won't be able to manage ByteBuffers optimally and it won't count (or limit) the amount of direct memory being used.

This PR adds these three options to the bash scripts, as well as to `.mvn/jvm.config`, a new file Maven reads to set its default JVM options.