### PR TITLE
Disable StaleInstancesCleanupTask by default

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -304,6 +304,11 @@ public class ControllerConf extends PinotConfiguration {
     public static final int DEFAULT_TASK_METRICS_EMITTER_FREQUENCY_IN_SECONDS = 5 * 60; // 5 minutes
     public static final int DEFAULT_STATUS_CONTROLLER_WAIT_FOR_PUSH_TIME_IN_SECONDS = 10 * 60; // 10 minutes
     public static final int DEFAULT_TASK_MANAGER_FREQUENCY_IN_SECONDS = -1; // Disabled
+    // NOTE:
+    //   StaleInstancesCleanupTask is disabled by default because there is a race condition between this task removing
+    //   instance and instance of the same name joining the cluster, which could end up leaving a live instance without
+    //   InstanceConfig, and breaks Helix controller.
+    public static final int DEFAULT_STALE_INSTANCES_CLEANUP_TASK_FREQUENCY_IN_SECONDS = -1; // Disabled
     @Deprecated
     public static final int DEFAULT_MINION_INSTANCES_CLEANUP_TASK_FREQUENCY_IN_SECONDS = 60 * 60; // 1 Hour.
     @Deprecated
@@ -982,7 +987,7 @@ public class ControllerConf extends PinotConfiguration {
             ControllerPeriodicTasksConf.MINION_INSTANCES_CLEANUP_TASK_FREQUENCY_PERIOD, period))
         .map(period -> (int) convertPeriodToSeconds(period)).orElseGet(
             () -> getProperty(ControllerPeriodicTasksConf.DEPRECATED_MINION_INSTANCES_CLEANUP_TASK_FREQUENCY_IN_SECONDS,
-                ControllerPeriodicTasksConf.DEFAULT_MINION_INSTANCES_CLEANUP_TASK_FREQUENCY_IN_SECONDS));
+                ControllerPeriodicTasksConf.DEFAULT_STALE_INSTANCES_CLEANUP_TASK_FREQUENCY_IN_SECONDS));
   }
 
   @Deprecated

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/cleanup/StaleInstancesCleanupTask.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/cleanup/StaleInstancesCleanupTask.java
@@ -43,6 +43,11 @@ import org.slf4j.LoggerFactory;
  * Automatically removes stale instances from the cluster to not spam Helix.
  * Stale instance is the instance not in use (not hosting any data or query) and has been in the offline status for more
  * than the stale instance retention time.
+ *
+ * TODO:
+ *   There is a race condition between this task removing instance and instance of the same name joining the cluster,
+ *   which could end up leaving a live instance without InstanceConfig, and breaks Helix controller.
+ *   To fix it, we need to do a version check when removing InstanceConfig, which requires Helix 1.4.0+.
  */
 public class StaleInstancesCleanupTask extends BasePeriodicTask {
   private static final Logger LOGGER = LoggerFactory.getLogger(StaleInstancesCleanupTask.class);


### PR DESCRIPTION
There is a race condition between `StaleInstancesCleanupTask` removing instance and instance of the same name joining the cluster, which could end up leaving a live instance without `InstanceConfig`, and breaks Helix controller.
In order to fix it, we need to do a version check when removing InstanceConfig, which requires Helix 1.4.0+.
For now, disable the task by default.