### PR TITLE
Cleap up deprecated configs for MinionInstancesCleanupTask

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -149,23 +149,6 @@ public class ControllerConf extends PinotConfiguration {
     public static final String TASK_MANAGER_SKIP_LATE_CRON_SCHEDULE = "controller.task.skipLateCronSchedule";
     public static final String TASK_MANAGER_MAX_CRON_SCHEDULE_DELAY_IN_SECONDS =
         "controller.task.maxCronScheduleDelayInSeconds";
-    // Deprecated as of 0.8.0
-    @Deprecated
-    public static final String DEPRECATED_MINION_INSTANCES_CLEANUP_TASK_FREQUENCY_IN_SECONDS =
-        "controller.minion.instances.cleanup.task.frequencyInSeconds";
-    @Deprecated
-    public static final String MINION_INSTANCES_CLEANUP_TASK_FREQUENCY_PERIOD =
-        "controller.minion.instances.cleanup.task.frequencyPeriod";
-    @Deprecated
-    public static final String MINION_INSTANCES_CLEANUP_TASK_INITIAL_DELAY_SECONDS =
-        "controller.minion.instances.cleanup.task.initialDelaySeconds";
-    // Deprecated as of 0.8.0
-    @Deprecated
-    public static final String DEPRECATED_MINION_INSTANCES_CLEANUP_TASK_MIN_OFFLINE_TIME_BEFORE_DELETION_SECONDS =
-        "controller.minion.instances.cleanup.task.minOfflineTimeBeforeDeletionSeconds";
-    @Deprecated
-    public static final String MINION_INSTANCES_CLEANUP_TASK_MIN_OFFLINE_TIME_BEFORE_DELETION_PERIOD =
-        "controller.minion.instances.cleanup.task.minOfflineTimeBeforeDeletionPeriod";
 
     public static final String STALE_INSTANCES_CLEANUP_TASK_FREQUENCY_PERIOD =
         "controller.stale.instances.cleanup.task.frequencyPeriod";
@@ -243,7 +226,6 @@ public class ControllerConf extends PinotConfiguration {
     public static final String OFFLINE_SEGMENT_VALIDATION_FREQUENCY_PERIOD =
         "controller.offline.segment.validation.frequencyPeriod";
 
-
     @Deprecated
     // RealtimeSegmentRelocator has been rebranded as SegmentRelocator
     public static final String DEPRECATED_REALTIME_SEGMENT_RELOCATION_INITIAL_DELAY_IN_SECONDS =
@@ -309,11 +291,8 @@ public class ControllerConf extends PinotConfiguration {
     //   instance and instance of the same name joining the cluster, which could end up leaving a live instance without
     //   InstanceConfig, and breaks Helix controller.
     public static final int DEFAULT_STALE_INSTANCES_CLEANUP_TASK_FREQUENCY_IN_SECONDS = -1; // Disabled
-    @Deprecated
-    public static final int DEFAULT_MINION_INSTANCES_CLEANUP_TASK_FREQUENCY_IN_SECONDS = 60 * 60; // 1 Hour.
-    @Deprecated
-    public static final int DEFAULT_MINION_INSTANCES_CLEANUP_TASK_MIN_OFFLINE_TIME_BEFORE_DELETION_IN_SECONDS =
-        60 * 60; // 1 Hour.
+    // TODO: Consider making it longer (e.g. 24 hours) to avoid deleting instances that are temporarily down
+    public static final int DEFAULT_STALE_INSTANCES_CLEANUP_TASK_INSTANCES_RETENTION_IN_SECONDS = 60 * 60; // 1 Hour.
 
     public static final int DEFAULT_SEGMENT_LEVEL_VALIDATION_INTERVAL_IN_SECONDS = 24 * 60 * 60;
     public static final int DEFAULT_SEGMENT_RELOCATOR_FREQUENCY_IN_SECONDS = 60 * 60;
@@ -980,61 +959,12 @@ public class ControllerConf extends PinotConfiguration {
         Integer.toString(frequencyInSeconds));
   }
 
-  @Deprecated
-  public int getMinionInstancesCleanupTaskFrequencyInSeconds() {
-    return Optional.ofNullable(getProperty(ControllerPeriodicTasksConf.MINION_INSTANCES_CLEANUP_TASK_FREQUENCY_PERIOD))
-        .filter(period -> isValidPeriodWithLogging(
-            ControllerPeriodicTasksConf.MINION_INSTANCES_CLEANUP_TASK_FREQUENCY_PERIOD, period))
-        .map(period -> (int) convertPeriodToSeconds(period)).orElseGet(
-            () -> getProperty(ControllerPeriodicTasksConf.DEPRECATED_MINION_INSTANCES_CLEANUP_TASK_FREQUENCY_IN_SECONDS,
-                ControllerPeriodicTasksConf.DEFAULT_STALE_INSTANCES_CLEANUP_TASK_FREQUENCY_IN_SECONDS));
-  }
-
-  @Deprecated
-  public void setMinionInstancesCleanupTaskFrequencyInSeconds(int frequencyInSeconds) {
-    setProperty(ControllerPeriodicTasksConf.DEPRECATED_MINION_INSTANCES_CLEANUP_TASK_FREQUENCY_IN_SECONDS,
-        Integer.toString(frequencyInSeconds));
-  }
-
-  @Deprecated
-  public long getMinionInstancesCleanupTaskInitialDelaySeconds() {
-    return getProperty(ControllerPeriodicTasksConf.MINION_INSTANCES_CLEANUP_TASK_INITIAL_DELAY_SECONDS,
-        ControllerPeriodicTasksConf.getRandomInitialDelayInSeconds());
-  }
-
-  @Deprecated
-  public void setMinionInstancesCleanupTaskInitialDelaySeconds(int initialDelaySeconds) {
-    setProperty(ControllerPeriodicTasksConf.MINION_INSTANCES_CLEANUP_TASK_INITIAL_DELAY_SECONDS,
-        Integer.toString(initialDelaySeconds));
-  }
-
-  @Deprecated
-  public int getMinionInstancesCleanupTaskMinOfflineTimeBeforeDeletionInSeconds() {
-    return Optional.ofNullable(
-        getProperty(ControllerPeriodicTasksConf.MINION_INSTANCES_CLEANUP_TASK_MIN_OFFLINE_TIME_BEFORE_DELETION_PERIOD))
-        .filter(period -> isValidPeriodWithLogging(
-            ControllerPeriodicTasksConf.MINION_INSTANCES_CLEANUP_TASK_MIN_OFFLINE_TIME_BEFORE_DELETION_PERIOD, period))
-        .map(period -> (int) convertPeriodToSeconds(period)).orElseGet(() -> getProperty(
-            ControllerPeriodicTasksConf.
-                DEPRECATED_MINION_INSTANCES_CLEANUP_TASK_MIN_OFFLINE_TIME_BEFORE_DELETION_SECONDS,
-            ControllerPeriodicTasksConf.
-                DEFAULT_MINION_INSTANCES_CLEANUP_TASK_MIN_OFFLINE_TIME_BEFORE_DELETION_IN_SECONDS));
-  }
-
-  @Deprecated
-  public void setMinionInstancesCleanupTaskMinOfflineTimeBeforeDeletionInSeconds(int maxOfflineTimeRangeInSeconds) {
-    setProperty(
-        ControllerPeriodicTasksConf.DEPRECATED_MINION_INSTANCES_CLEANUP_TASK_MIN_OFFLINE_TIME_BEFORE_DELETION_SECONDS,
-        Integer.toString(maxOfflineTimeRangeInSeconds));
-  }
-
   public int getStaleInstancesCleanupTaskFrequencyInSeconds() {
     return Optional.ofNullable(getProperty(ControllerPeriodicTasksConf.STALE_INSTANCES_CLEANUP_TASK_FREQUENCY_PERIOD))
         .filter(period -> isValidPeriodWithLogging(
             ControllerPeriodicTasksConf.STALE_INSTANCES_CLEANUP_TASK_FREQUENCY_PERIOD, period))
         .map(period -> (int) convertPeriodToSeconds(period))
-        // Backward compatible for existing users who configured MinionInstancesCleanupTask
-        .orElse(getMinionInstancesCleanupTaskFrequencyInSeconds());
+        .orElse(ControllerPeriodicTasksConf.DEFAULT_STALE_INSTANCES_CLEANUP_TASK_FREQUENCY_IN_SECONDS);
   }
 
   public void setStaleInstanceCleanupTaskFrequencyInSeconds(String frequencyPeriod) {
@@ -1043,8 +973,7 @@ public class ControllerConf extends PinotConfiguration {
 
   public long getStaleInstanceCleanupTaskInitialDelaySeconds() {
     return getProperty(ControllerPeriodicTasksConf.STALE_INSTANCES_CLEANUP_TASK_INITIAL_DELAY_SECONDS,
-        // Backward compatible for existing users who configured MinionInstancesCleanupTask
-        getMinionInstancesCleanupTaskInitialDelaySeconds());
+        ControllerPeriodicTasksConf.getRandomInitialDelayInSeconds());
   }
 
   public void setStaleInstanceCleanupTaskInitialDelaySeconds(long initialDelaySeconds) {
@@ -1057,8 +986,7 @@ public class ControllerConf extends PinotConfiguration {
         .filter(period -> isValidPeriodWithLogging(
             ControllerPeriodicTasksConf.STALE_INSTANCES_CLEANUP_TASK_INSTANCES_RETENTION_PERIOD, period))
         .map(period -> (int) convertPeriodToSeconds(period))
-        // Backward compatible for existing users who configured MinionInstancesCleanupTask
-        .orElse(getMinionInstancesCleanupTaskMinOfflineTimeBeforeDeletionInSeconds());
+        .orElse(ControllerPeriodicTasksConf.DEFAULT_STALE_INSTANCES_CLEANUP_TASK_INSTANCES_RETENTION_IN_SECONDS);
   }
 
   public void setStaleInstancesCleanupTaskInstancesRetentionPeriod(String retentionPeriod) {
@@ -1177,15 +1105,14 @@ public class ControllerConf extends PinotConfiguration {
     return getProperty(ENABLE_HYBRID_TABLE_RETENTION_STRATEGY, DEFAULT_ENABLE_HYBRID_TABLE_RETENTION_STRATEGY);
   }
 
-   public int getSegmentLevelValidationIntervalInSeconds() {
-      return Optional.ofNullable(getProperty(ControllerPeriodicTasksConf.SEGMENT_LEVEL_VALIDATION_INTERVAL_PERIOD))
-          .filter(period -> isValidPeriodWithLogging(
-              ControllerPeriodicTasksConf.SEGMENT_LEVEL_VALIDATION_INTERVAL_PERIOD, period))
-          .map(period -> (int) convertPeriodToSeconds(period)).orElseGet(
-              () -> getProperty(ControllerPeriodicTasksConf.DEPRECATED_SEGMENT_LEVEL_VALIDATION_INTERVAL_IN_SECONDS,
-                  ControllerPeriodicTasksConf.DEFAULT_SEGMENT_LEVEL_VALIDATION_INTERVAL_IN_SECONDS));
+  public int getSegmentLevelValidationIntervalInSeconds() {
+    return Optional.ofNullable(getProperty(ControllerPeriodicTasksConf.SEGMENT_LEVEL_VALIDATION_INTERVAL_PERIOD))
+        .filter(period -> isValidPeriodWithLogging(
+            ControllerPeriodicTasksConf.SEGMENT_LEVEL_VALIDATION_INTERVAL_PERIOD, period))
+        .map(period -> (int) convertPeriodToSeconds(period)).orElseGet(
+            () -> getProperty(ControllerPeriodicTasksConf.DEPRECATED_SEGMENT_LEVEL_VALIDATION_INTERVAL_IN_SECONDS,
+                ControllerPeriodicTasksConf.DEFAULT_SEGMENT_LEVEL_VALIDATION_INTERVAL_IN_SECONDS));
   }
-
 
   public boolean isAutoResetErrorSegmentsOnValidationEnabled() {
     return getProperty(ControllerPeriodicTasksConf.AUTO_RESET_ERROR_SEGMENTS_VALIDATION, true);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/ControllerConfTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/ControllerConfTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.controller;
 
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -36,27 +35,33 @@ import static org.apache.pinot.controller.ControllerConf.ControllerPeriodicTasks
 
 public class ControllerConfTest {
 
-  private static final List<String> DEPRECATED_CONFIGS = Arrays
-      .asList(DEPRECATED_RETENTION_MANAGER_FREQUENCY_IN_SECONDS,
-          DEPRECATED_OFFLINE_SEGMENT_INTERVAL_CHECKER_FREQUENCY_IN_SECONDS,
-          DEPRECATED_OFFLINE_SEGMENT_INTERVAL_CHECKER_FREQUENCY_IN_SECONDS,
-          DEPRECATED_REALTIME_SEGMENT_VALIDATION_FREQUENCY_IN_SECONDS,
-          DEPRECATED_BROKER_RESOURCE_VALIDATION_FREQUENCY_IN_SECONDS, DEPRECATED_STATUS_CHECKER_FREQUENCY_IN_SECONDS,
-          DEPRECATED_TASK_MANAGER_FREQUENCY_IN_SECONDS, DEPRECATED_MINION_INSTANCES_CLEANUP_TASK_FREQUENCY_IN_SECONDS,
-          DEPRECATED_MINION_INSTANCES_CLEANUP_TASK_MIN_OFFLINE_TIME_BEFORE_DELETION_SECONDS,
-          DEPRECATED_TASK_METRICS_EMITTER_FREQUENCY_IN_SECONDS, DEPRECATED_SEGMENT_RELOCATOR_FREQUENCY_IN_SECONDS,
-          DEPRECATED_SEGMENT_LEVEL_VALIDATION_INTERVAL_IN_SECONDS,
-          DEPRECATED_REALTIME_SEGMENT_RELOCATION_INITIAL_DELAY_IN_SECONDS,
-          DEPRECATED_STATUS_CHECKER_WAIT_FOR_PUSH_TIME_IN_SECONDS);
+  private static final List<String> DEPRECATED_CONFIGS = List.of(
+      DEPRECATED_RETENTION_MANAGER_FREQUENCY_IN_SECONDS,
+      DEPRECATED_OFFLINE_SEGMENT_INTERVAL_CHECKER_FREQUENCY_IN_SECONDS,
+      DEPRECATED_REALTIME_SEGMENT_VALIDATION_FREQUENCY_IN_SECONDS,
+      DEPRECATED_BROKER_RESOURCE_VALIDATION_FREQUENCY_IN_SECONDS,
+      DEPRECATED_STATUS_CHECKER_FREQUENCY_IN_SECONDS,
+      DEPRECATED_TASK_MANAGER_FREQUENCY_IN_SECONDS,
+      DEPRECATED_TASK_METRICS_EMITTER_FREQUENCY_IN_SECONDS,
+      DEPRECATED_SEGMENT_RELOCATOR_FREQUENCY_IN_SECONDS,
+      DEPRECATED_SEGMENT_LEVEL_VALIDATION_INTERVAL_IN_SECONDS,
+      DEPRECATED_REALTIME_SEGMENT_RELOCATION_INITIAL_DELAY_IN_SECONDS,
+      DEPRECATED_STATUS_CHECKER_WAIT_FOR_PUSH_TIME_IN_SECONDS
+  );
 
-  private static final List<String> NEW_CONFIGS = Arrays
-      .asList(RETENTION_MANAGER_FREQUENCY_PERIOD, OFFLINE_SEGMENT_INTERVAL_CHECKER_FREQUENCY_PERIOD,
-          REALTIME_SEGMENT_VALIDATION_FREQUENCY_PERIOD, BROKER_RESOURCE_VALIDATION_FREQUENCY_PERIOD,
-          STATUS_CHECKER_FREQUENCY_PERIOD, TASK_MANAGER_FREQUENCY_PERIOD,
-          MINION_INSTANCES_CLEANUP_TASK_FREQUENCY_PERIOD,
-          MINION_INSTANCES_CLEANUP_TASK_MIN_OFFLINE_TIME_BEFORE_DELETION_PERIOD, TASK_METRICS_EMITTER_FREQUENCY_PERIOD,
-          SEGMENT_RELOCATOR_FREQUENCY_PERIOD, SEGMENT_LEVEL_VALIDATION_INTERVAL_PERIOD,
-          STATUS_CHECKER_WAIT_FOR_PUSH_TIME_PERIOD);
+  private static final List<String> NEW_CONFIGS = List.of(
+      RETENTION_MANAGER_FREQUENCY_PERIOD,
+      OFFLINE_SEGMENT_INTERVAL_CHECKER_FREQUENCY_PERIOD,
+      REALTIME_SEGMENT_VALIDATION_FREQUENCY_PERIOD,
+      BROKER_RESOURCE_VALIDATION_FREQUENCY_PERIOD,
+      STATUS_CHECKER_FREQUENCY_PERIOD,
+      TASK_MANAGER_FREQUENCY_PERIOD,
+      TASK_METRICS_EMITTER_FREQUENCY_PERIOD,
+      SEGMENT_RELOCATOR_FREQUENCY_PERIOD,
+      SEGMENT_LEVEL_VALIDATION_INTERVAL_PERIOD,
+      SEGMENT_RELOCATOR_INITIAL_DELAY_IN_SECONDS,
+      STATUS_CHECKER_WAIT_FOR_PUSH_TIME_PERIOD
+  );
 
   private static final Random RAND = new Random();
 
@@ -239,9 +244,6 @@ public class ControllerConfTest {
     int segmentLevelValidationIntervalInSeconds = conf.getSegmentLevelValidationIntervalInSeconds();
     int segmentRelocatorFrequencyInSeconds = conf.getSegmentRelocatorFrequencyInSeconds();
     int taskMetricsEmitterFrequencyInSeconds = conf.getTaskMetricsEmitterFrequencyInSeconds();
-    int minionInstancesCleanupTaskMinOfflineTimeBeforeDeletionInSeconds =
-        conf.getMinionInstancesCleanupTaskMinOfflineTimeBeforeDeletionInSeconds();
-    long minionInstancesCleanupTaskFrequencyInSeconds = conf.getMinionInstancesCleanupTaskFrequencyInSeconds();
     int taskManagerFrequencyInSeconds = conf.getTaskManagerFrequencyInSeconds();
     int statusCheckerFrequencyInSeconds = conf.getStatusCheckerFrequencyInSeconds();
     int brokerResourceValidationFrequencyInSeconds = conf.getBrokerResourceValidationFrequencyInSeconds();
@@ -253,9 +255,6 @@ public class ControllerConfTest {
     Assert.assertEquals(segmentLevelValidationIntervalInSeconds, expectedDuration, confAsString);
     Assert.assertEquals(segmentRelocatorFrequencyInSeconds, expectedDuration, confAsString);
     Assert.assertEquals(taskMetricsEmitterFrequencyInSeconds, expectedDuration, confAsString);
-    Assert
-        .assertEquals(minionInstancesCleanupTaskMinOfflineTimeBeforeDeletionInSeconds, expectedDuration, confAsString);
-    Assert.assertEquals(minionInstancesCleanupTaskFrequencyInSeconds, expectedDuration, confAsString);
     Assert.assertEquals(taskManagerFrequencyInSeconds, expectedDuration, confAsString);
     Assert.assertEquals(statusCheckerFrequencyInSeconds, expectedDuration, confAsString);
     Assert.assertEquals(brokerResourceValidationFrequencyInSeconds, expectedDuration, confAsString);


### PR DESCRIPTION
Cleanup configs for the deprecated `MinionInstancesCleanupTask`.
It has been deprecated since #10027 (1.0.0)