### PR TITLE
Disallow allowableValues and example together in @ApiParam due to swagger UI bug

### DIFF
--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -282,6 +282,20 @@
     <property name="file" value="${config_loc}/suppressions.xml"/>
   </module>
 
+  <!--
+  Prevent using both allowableValues and example in @ApiParam due to Swagger bug leading to UI inconsistencies
+  https://github.com/swagger-api/swagger-ui/issues/6560
+  https://github.com/swagger-api/swagger-ui/issues/5776
+   -->
+  <module name="RegexpMultiline">
+    <property name="format" value="@ApiParam\s*\([^@]*?allowableValues[^@]*?example[^@]*?\)"/>
+    <property name="message" value="Do not use both 'allowableValues' and 'example' together in @ApiParam annotations - this causes Swagger UI inconsistencies"/>
+  </module>
+  <module name="RegexpMultiline">
+    <property name="format" value="@ApiParam\s*\([^@]*?example[^@]*?allowableValues[^@]*?\)"/>
+    <property name="message" value="Do not use both 'allowableValues' and 'example' together in @ApiParam annotations - this causes Swagger UI inconsistencies"/>
+  </module>
+
   <module name="NewlineAtEndOfFile">
     <property name="lineSeparator" value="lf" />
   </module>

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableInstances.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableInstances.java
@@ -100,7 +100,7 @@ public class PinotTableInstances {
   })
   public String getTableInstances(
       @ApiParam(value = "Table name without type", required = true) @PathParam("tableName") String tableName,
-      @ApiParam(value = "Instance type", example = "broker", allowableValues = "BROKER, SERVER") @DefaultValue("")
+      @ApiParam(value = "Instance type", allowableValues = "BROKER, SERVER") @DefaultValue("")
       @QueryParam("type") String type, @Context HttpHeaders headers) {
     tableName = DatabaseUtils.translateTableName(tableName, headers);
     ObjectNode ret = JsonUtils.newObjectNode();


### PR DESCRIPTION
Bugfix

Remove the only usage of "allowableValues" and "example" parameters together in the @ApiParam swagger annotation and added linting to prevent future usages while https://github.com/swagger-api/swagger-ui/issues/6560 and https://github.com/swagger-api/swagger-ui/issues/5776 are left outstanding.

## Before

Inconsistent value being shown in selected dropdown (no type filter) vs request being made (using example value of broker even though not specific)

<img width="1135" height="550" alt="Screenshot 2025-10-02 at 5 26 54 PM" src="https://github.com/user-attachments/assets/a3682146-03f2-46bf-a954-fb42f729ce71" />

## After

No inconsistency anymore

<img width="1416" height="666" alt="Screenshot 2025-10-02 at 5 30 59 PM" src="https://github.com/user-attachments/assets/b89ad333-9dc1-40cd-a8a6-66bf5afe556a" />
