### PR TITLE
Report table's server instances based on ideal state instead of tags

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PartialUpsertTableRebalanceIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PartialUpsertTableRebalanceIntegrationTest.java
@@ -131,16 +131,12 @@ public class PartialUpsertTableRebalanceIntegrationTest extends BaseClusterInteg
     BaseServerStarter serverStarter2 = startOneServer(NUM_SERVERS + 1);
     rebalanceResult = _tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
 
-    // Check the number of servers after rebalancing
-    finalServers = _resourceManager.getServerInstancesForTable(getTableName(), TableType.REALTIME).size();
-
-    // Check that a server has been added
-    assertEquals(finalServers, NUM_SERVERS + 2, "Rebalancing didn't correctly add the new server");
-
     waitForRebalanceToComplete(rebalanceResult, 600_000L);
     waitForAllDocsLoaded(600_000L);
 
     // number of instances assigned can't be more than number of partitions for rf = 1
+    finalServers = _resourceManager.getServerInstancesForTable(getTableName(), TableType.REALTIME).size();
+    assertEquals(finalServers, getNumKafkaPartitions(), "Rebalancing didn't correctly add the new server");
     verifySegmentAssignment(rebalanceResult.getSegmentAssignment(), 5, getNumKafkaPartitions());
 
     _resourceManager.updateInstanceTags(serverStarter1.getInstanceId(), "", false);
@@ -199,16 +195,12 @@ public class PartialUpsertTableRebalanceIntegrationTest extends BaseClusterInteg
     BaseServerStarter serverStarter2 = startOneServer(NUM_SERVERS + 1);
     rebalanceResult = _tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
 
-    // Check the number of servers after rebalancing
-    finalServers = _resourceManager.getServerInstancesForTable(getTableName(), TableType.REALTIME).size();
-
-    // Check that a server has been added
-    assertEquals(finalServers, NUM_SERVERS + 2, "Rebalancing didn't correctly add the new server");
-
     waitForRebalanceToComplete(rebalanceResult, 600_000L);
     waitForAllDocsLoaded(600_000L);
 
     // number of instances assigned can't be more than number of partitions for rf = 1
+    finalServers = _resourceManager.getServerInstancesForTable(getTableName(), TableType.REALTIME).size();
+    assertEquals(finalServers, getNumKafkaPartitions(), "Rebalancing didn't correctly add the new server");
     verifySegmentAssignment(rebalanceResult.getSegmentAssignment(), 5, getNumKafkaPartitions());
 
     _resourceManager.updateInstanceTags(serverStarter1.getInstanceId(), "", false);


### PR DESCRIPTION
Currently `PinotHelixResourceManager#getServerInstancesForTable` find instances based on the tenant and tag overrides in table config.
This cause problems when:
1. Table config has changed without a rebalance - instances returned by this method are the target servers that don't have any segment yet, also the instances that still host the segments won't be reported.
2. Doesn't reflect tags set in instance assignment config, as well as tier configs - when instance assignment config or tier config is set for the table, the actual instances that are/will be assigned to the table will not be reported.

This PR change the method to scan for the current ideal state of the table, and collect all instances that host a segment of the table.