### PR TITLE
Annotate RebalanceConfig with ignoreUnknown = true

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceConfig.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceConfig.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.controller.helix.core.rebalance;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import io.swagger.annotations.ApiModel;
@@ -27,6 +28,7 @@ import org.apache.pinot.controller.api.resources.ForceCommitBatchConfig;
 import org.apache.pinot.spi.utils.Enablement;
 
 
+@JsonIgnoreProperties(ignoreUnknown = true)
 @ApiModel
 public class RebalanceConfig {
   public static final int DISABLE_BATCH_SIZE_PER_SERVER = -1;


### PR DESCRIPTION
Annotate RebalanceConfig with ignoreUnknown = true

Needed so that RebalanceChecker can work correctly as the property `summary` was removed, but if a rebalance was run when this property was around, then RebalanceChecker is going to have trouble parsing the jobs saved in ZK.

Tested this by using the object mapper to parse a string with and without this set, and saw that with this fix parsing goes through, but without it, parsing fails.