### PR TITLE
Enable table based filtering for minion subtask details

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTaskRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTaskRestletResource.java
@@ -384,8 +384,14 @@ public class PinotTaskRestletResource {
       @ApiParam(value = "verbosity (Prints information for the given task name."
           + "By default, only prints subtask details for running and error tasks. "
           + "Value of > 0 prints subtask details for all tasks)")
-      @DefaultValue("0") @QueryParam("verbosity") int verbosity) {
-    return _pinotHelixTaskResourceManager.getTaskDebugInfo(taskName, verbosity);
+      @DefaultValue("0") @QueryParam("verbosity") int verbosity,
+      @ApiParam(value = "Table name with type (e.g., 'myTable_OFFLINE') to filter subtasks by table. "
+          + "Only subtasks for this table will be returned.")
+      @QueryParam("tableName") @Nullable String tableNameWithType, @Context HttpHeaders httpHeaders) {
+    if (tableNameWithType != null) {
+      tableNameWithType = DatabaseUtils.translateTableName(tableNameWithType, httpHeaders);
+    }
+    return _pinotHelixTaskResourceManager.getTaskDebugInfo(taskName, tableNameWithType, verbosity);
   }
 
   @GET

--- a/pinot-controller/src/main/resources/app/pages/SubTaskDetail.tsx
+++ b/pinot-controller/src/main/resources/app/pages/SubTaskDetail.tsx
@@ -80,12 +80,12 @@ const useStyles = makeStyles(() => ({
 const TaskDetail = (props) => {
   const classes = useStyles();
   const { currentTimezone } = useTimezone();
-  const { subTaskID, taskID } = props.match.params;
+  const { subTaskID, taskID, queueTableName } = props.match.params;
   const [taskDebugData, setTaskDebugData] = useState({});
   const [taskProgressData, setTaskProgressData] = useState<TaskProgressStatus[] | string>("");
 
   const fetchTaskDebugData = async () => {
-    const debugRes = await PinotMethodUtils.getTaskDebugData(taskID);
+    const debugRes = await PinotMethodUtils.getTaskDebugData(taskID, queueTableName);
     const subTaskData = find(debugRes.data.subtaskInfos, (subTask) => get(subTask, 'taskId', '') === subTaskID);
     setTaskDebugData(subTaskData);
   };

--- a/pinot-controller/src/main/resources/app/pages/TaskDetail.tsx
+++ b/pinot-controller/src/main/resources/app/pages/TaskDetail.tsx
@@ -83,7 +83,7 @@ const TaskDetail = (props) => {
   const fetchData = useCallback(async () => {
     setFetching(true);
     const [debugRes, runtimeConfig] = await Promise.all([
-      PinotMethodUtils.getTaskDebugData(taskID),
+      PinotMethodUtils.getTaskDebugData(taskID, queueTableName),
       PinotMethodUtils.getTaskRuntimeConfigData(taskID)
     ]);
     const subtaskTableRecords = [];

--- a/pinot-controller/src/main/resources/app/requests/index.ts
+++ b/pinot-controller/src/main/resources/app/requests/index.ts
@@ -209,8 +209,8 @@ export const getTasks = (tableName: string, taskType: string): Promise<AxiosResp
 export const getTaskRuntimeConfig = (taskName: string): Promise<AxiosResponse<TaskRuntimeConfig>> =>
   baseApi.get(`/tasks/task/${taskName}/runtime/config`, { headers: { ...headers, Accept: 'application/json' }});
 
-export const getTaskDebug = (taskName: string): Promise<AxiosResponse<OperationResponse>> =>
-  baseApi.get(`/tasks/task/${taskName}/debug?verbosity=1`, { headers: { ...headers, Accept: 'application/json' } });
+export const getTaskDebug = (taskName: string, tableName: string): Promise<AxiosResponse<OperationResponse>> =>
+  baseApi.get(`/tasks/task/${taskName}/debug?verbosity=1&tableName=${tableName}`, { headers: { ...headers, Accept: 'application/json' } });
 
 export const getTaskProgress = (taskName: string, subTaskName: string): Promise<AxiosResponse<TaskProgressResponse>> =>
   baseApi.get(`/tasks/subtask/${taskName}/progress`, { headers: { ...headers, Accept: 'application/json' }, params: {subtaskNames: subTaskName} });

--- a/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
+++ b/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
@@ -943,7 +943,7 @@ const getTasksList = async (tableName, taskType) => {
     getTasks(tableName, taskType).then(async (response)=>{
       const promiseArr = [];
       const fetchInfo = async (taskID, status) => {
-        const debugData = await getTaskDebugData(taskID);
+        const debugData = await getTaskDebugData(taskID, tableName);
         const subtaskCount = get(debugData, 'data.subtaskCount', {});
         const total = get(subtaskCount, 'total', 0);
         const completed = get(subtaskCount, 'completed', 0);
@@ -980,8 +980,8 @@ const getTaskRuntimeConfigData = async (taskName: string) => {
   return response.data;
 }
 
-const getTaskDebugData = async (taskName) => {
-  const debugRes = await getTaskDebug(taskName);
+const getTaskDebugData = async (taskName, tableName) => {
+  const debugRes = await getTaskDebug(taskName, tableName);
   return debugRes;
 };
 


### PR DESCRIPTION
## Description

When minion tasks are scheduled with the /schedule endpoint without specifying a particular table it schedules the tasks for all tables where the task is configured. This leads to controller submitting a single job containing task configs from multiple tables. When user opens the minion UI it gets confusing as subtasks from different tables appears on the UI making it hard to follow the actual progress for the particular table

### Current behaviour

The test1 table view shows 30 subtasks (only 15 subtasks belong to the table)
<img width="1726" height="891" alt="image" src="https://github.com/user-attachments/assets/81585b60-31b1-4042-aaf9-fd4cedf12648" />

One of the subtask from another table (test2)

<img width="3452" height="1628" alt="image" src="https://github.com/user-attachments/assets/035affed-d4ba-4fe9-b7b4-284c3e5f2358" />


### After the changes

Post the table based filtering each table view will only list the subtasks that belong to the table (check the subtask count showing 15 now) 

<img width="1726" height="891" alt="image" src="https://github.com/user-attachments/assets/c813a9b5-a090-4752-89e4-f7bae371d0bc" />

### Important changes

- New query param `tableName` added to `/tasks/task/{taskName}/debug` endpoint to filter based in table name. Subtasks from all tables would be returned if table name is not passed (current behaviour)
- Updated minion task manager UI page to pass the tableName filter param to show the correct view
