### PR TITLE
Add support to configure the maximum minion tasks that can be run per instance

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/HelixHelper.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/HelixHelper.java
@@ -663,4 +663,13 @@ public class HelixHelper {
     }
     return false;
   }
+
+  public static boolean updateMaxConcurrentTasksPerInstance(InstanceConfig instanceConfig, int maxConcurrentTasks) {
+    int currentMaxConcurrentTasks = instanceConfig.getMaxConcurrentTask();
+    if (currentMaxConcurrentTasks != maxConcurrentTasks) {
+      instanceConfig.setMaxConcurrentTask(maxConcurrentTasks);
+      return true;
+    }
+    return false;
+  }
 }

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/BaseMinionStarter.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/BaseMinionStarter.java
@@ -367,6 +367,8 @@ public abstract class BaseMinionStarter implements ServiceStartable {
         () -> Collections.singletonList(CommonConstants.Helix.UNTAGGED_MINION_INSTANCE));
     updated |= HelixHelper.removeDisabledPartitions(instanceConfig);
     updated |= HelixHelper.updatePinotVersion(instanceConfig);
+    updated |= HelixHelper.updateMaxConcurrentTasksPerInstance(instanceConfig,
+        _config.getMaxConcurrentTasksPerInstance());
     if (updated) {
       HelixHelper.updateInstanceConfig(_helixManager, instanceConfig);
     }

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/MinionConf.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/MinionConf.java
@@ -92,4 +92,9 @@ public class MinionConf extends PinotConfiguration {
         .orElseGet(() -> getProperty(CommonConstants.Minion.DEPRECATED_CONFIG_OF_METRICS_PREFIX_KEY,
             CommonConstants.Minion.CONFIG_OF_METRICS_PREFIX));
   }
+
+  public int getMaxConcurrentTasksPerInstance() {
+    return getProperty(CommonConstants.Minion.CONFIG_OF_MAX_CONCURRENT_TASKS_PER_INSTANCE,
+        CommonConstants.Minion.DEFAULT_MAX_CONCURRENT_TASKS_PER_INSTANCE);
+  }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -1494,6 +1494,8 @@ public class CommonConstants {
     // Config keys
     public static final String CONFIG_OF_SWAGGER_USE_HTTPS = "pinot.minion.swagger.use.https";
     public static final String CONFIG_OF_METRICS_PREFIX_KEY = "pinot.minion.metrics.prefix";
+    public static final String CONFIG_OF_MAX_CONCURRENT_TASKS_PER_INSTANCE =
+        "pinot.minion.max.concurrent.tasks.per.instance";
     @Deprecated
     public static final String DEPRECATED_CONFIG_OF_METRICS_PREFIX_KEY = "metricsPrefix";
     public static final String METRICS_REGISTRY_REGISTRATION_LISTENERS_KEY = "metricsRegistryRegistrationListeners";
@@ -1504,6 +1506,8 @@ public class CommonConstants {
     public static final String DEFAULT_INSTANCE_BASE_DIR =
         System.getProperty("java.io.tmpdir") + File.separator + "PinotMinion";
     public static final String DEFAULT_INSTANCE_DATA_DIR = DEFAULT_INSTANCE_BASE_DIR + File.separator + "data";
+    // Use Helix side default if configured to be -1
+    public static final int DEFAULT_MAX_CONCURRENT_TASKS_PER_INSTANCE = -1;
 
     // Add pinot.minion prefix on those configs to be consistent with configs of controller and server.
     public static final String PREFIX_OF_CONFIG_OF_PINOT_FS_FACTORY = "pinot.minion.storage.factory";


### PR DESCRIPTION
Today we only limit the total tasks allowed to run on a minion instance based on the task type. This does not protect against scenarios where too many tasks across different tasks types get scheduled on a single minion. Scheduling too many tasks can lead to resource utilization issues like OOMs or high disk usage.

This PR adds support to set an upper limit cap on the max concurrent tasks that can be run on on a given minion instance. This utilizes the Helix side Instance level config defined here: https://helix.apache.org/1.3.2-docs/tutorial_task_throttling.html

The default is configured to be `-1` which falls back to Helix's default (which I believe is 40). Follow the code here: https://github.com/apache/helix/blob/02a170c7106081108f0563fc09640f7a67a603a9/helix-core/src/main/java/org/apache/helix/task/AbstractTaskDispatcher.java#L650

Testing done:
Did exhaustive testing using the HybridQuickStart. Some scenarios tested:

- Set an instance level cap of 3, and a higher cap of 5 for the per task type level - saw that only 3 tasks were scheduled at a time
- Set an instance level cap of 3, and a cap of 2 for the per task type level - if a single task type ran, only 2 were scheduled at a time, but if two different tasks types were run, then a maximum of 3 task were scheduled on the minion
- Setting the default of -1 keeps the behavior the same as today, and the default Helix side limit is used
- Tested config update via setting the config in the Pinot cluster configs, and that overrides the default

cc @krishan1390 @swaminathanmanish @Jackie-Jiang 