### PR TITLE
Fix key map cleanup in group key generator

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/DictionaryBasedGroupKeyGenerator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/DictionaryBasedGroupKeyGenerator.java
@@ -148,6 +148,9 @@ public class DictionaryBasedGroupKeyGenerator implements GroupKeyGenerator {
         cardinalityProduct = Math.min(optimizedCardinality.getRight(), cardinalityProduct);
       }
     }
+    // NOTE: We need to clean up the thread-local map before using it in case RawKeyHolder.close() is not called
+    //       for the previous segment
+    // TODO: Ensure RawKeyHolder.close()
     if (longOverflow) {
       // ArrayMapBasedHolder
       _globalGroupIdUpperBound = numGroupsLimit;


### PR DESCRIPTION
The bug was introduced in #16454 

There is no guarantee `close()` is always invoked when a query is interrupted, which could leave the thread-local map in a unclean state, then cause next query to fail. We should check again when initializing the group key generator