### PR TITLE
Handle NaN and +/- Infinity in ROUND_DECIMAL

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/ArithmeticFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/ArithmeticFunctions.java
@@ -169,6 +169,10 @@ public class ArithmeticFunctions {
   // when multiplying by Math.pow(10, scale) for rounding
   @ScalarFunction
   public static double roundDecimal(double a, int scale) {
+    if (Double.isNaN(a) || Double.isInfinite(a)) {
+      // Follow standard PostgreSQL behavior where NaN and +/- Inf are returned as is
+      return a;
+    }
     return BigDecimal.valueOf(a).setScale(scale, RoundingMode.HALF_UP).doubleValue();
   }
 
@@ -176,6 +180,12 @@ public class ArithmeticFunctions {
   // but it is not possible because of existing DateTimeFunction with same name.
   @ScalarFunction
   public static double roundDecimal(double a) {
+    if (Double.isNaN(a) || Double.isInfinite(a)) {
+      // Math.round has special handling for NaN and +/- Inf:
+      // NaN -> 0, -Inf -> Long.MIN_VALUE, +Inf -> Long.MAX_VALUE
+      // Follow standard PostgreSQL behavior where NaN and +/- Inf are returned as is
+      return a;
+    }
     return Math.round(a);
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/function/ArithmeticFunctionsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/function/ArithmeticFunctionsTest.java
@@ -327,6 +327,30 @@ public class ArithmeticFunctionsTest {
       inputs.add(new Object[]{"roundDecimal(a, 2)", Lists.newArrayList("a"), row, 9.46});
       inputs.add(new Object[]{"roundDecimal(a, 3)", Lists.newArrayList("a"), row, 9.46});
     }
+    {
+      GenericRow row = new GenericRow();
+      row.putValue("a", Double.NEGATIVE_INFINITY);
+      inputs.add(new Object[]{"roundDecimal(a)", Lists.newArrayList("a"), row, Double.NEGATIVE_INFINITY});
+      inputs.add(new Object[]{"roundDecimal(a, 1)", Lists.newArrayList("a"), row, Double.NEGATIVE_INFINITY});
+      inputs.add(new Object[]{"roundDecimal(a, 2)", Lists.newArrayList("a"), row, Double.NEGATIVE_INFINITY});
+      inputs.add(new Object[]{"roundDecimal(a, 3)", Lists.newArrayList("a"), row, Double.NEGATIVE_INFINITY});
+    }
+    {
+      GenericRow row = new GenericRow();
+      row.putValue("a", Double.POSITIVE_INFINITY);
+      inputs.add(new Object[]{"roundDecimal(a)", Lists.newArrayList("a"), row, Double.POSITIVE_INFINITY});
+      inputs.add(new Object[]{"roundDecimal(a, 1)", Lists.newArrayList("a"), row, Double.POSITIVE_INFINITY});
+      inputs.add(new Object[]{"roundDecimal(a, 2)", Lists.newArrayList("a"), row, Double.POSITIVE_INFINITY});
+      inputs.add(new Object[]{"roundDecimal(a, 3)", Lists.newArrayList("a"), row, Double.POSITIVE_INFINITY});
+    }
+    {
+      GenericRow row = new GenericRow();
+      row.putValue("a", Double.NaN);
+      inputs.add(new Object[]{"roundDecimal(a)", Lists.newArrayList("a"), row, Double.NaN});
+      inputs.add(new Object[]{"roundDecimal(a, 1)", Lists.newArrayList("a"), row, Double.NaN});
+      inputs.add(new Object[]{"roundDecimal(a, 2)", Lists.newArrayList("a"), row, Double.NaN});
+      inputs.add(new Object[]{"roundDecimal(a, 3)", Lists.newArrayList("a"), row, Double.NaN});
+    }
     // test truncate
     {
       GenericRow row = new GenericRow();

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/RoundDecimalTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/RoundDecimalTransformFunctionTest.java
@@ -98,4 +98,24 @@ public class RoundDecimalTransformFunctionTest extends BaseTransformFunctionTest
     }
     testTransformFunctionWithNull(transformFunction, expectedValues, roaringBitmap);
   }
+
+  @Test
+  public void testRoundDecimalNaNAndInfinity() {
+    ExpressionContext expression =
+        RequestContextUtils.getExpression(String.format("round_decimal(%s / 0)", INT_SV_COLUMN));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    Assert.assertTrue(transformFunction instanceof RoundDecimalTransformFunction);
+    Assert.assertEquals(transformFunction.getName(), TransformFunctionType.ROUND_DECIMAL.getName());
+    double[] expectedValues = new double[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      if (_intSVValues[i] < 0) {
+        expectedValues[i] = Double.NEGATIVE_INFINITY;
+      } else if (_intSVValues[i] == 0) {
+        expectedValues[i] = Double.NaN;
+      } else {
+        expectedValues[i] = Double.POSITIVE_INFINITY;
+      }
+    }
+    testTransformFunction(transformFunction, expectedValues);
+  }
 }


### PR DESCRIPTION
- Currently, `NaN` and `+/- Infinity` handling is inconsistent for  `ROUND_DECIMAL`.
- The scalar function version with a single argument currently returns 0 for `NaN`, `Long.MIN_VALUE` for `-Infinity` and `Long.MAX_VALUE` for `+Infinity` based on Java's `Math.round(double)` behavior. 
- The scalar function version with two arguments fails for `NaN` and `+/- Infinity` because they can't be converted to `BigDecimal`.
- This patch fixes `ROUND_DECIMAL` scalar and transform function implementations (both 1 and 2 argument versions) to handle `NaN` and `+/- Infinity` in a standard way following PostgreSQL behavior - the values are simply returned as is.