### PR TITLE
Identify and compute common expressions to be reused in the Filter & Projection

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotProjectFilterTransposeRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotProjectFilterTransposeRule.java
@@ -46,7 +46,6 @@ import org.apache.calcite.tools.RelBuilder;
  */
 public class PinotProjectFilterTransposeRule extends RelOptRule {
   private static final String COMMON_EXPR_PREFIX = "commonExpr";
-  
   public static final PinotProjectFilterTransposeRule INSTANCE =
       new PinotProjectFilterTransposeRule("PinotProjectFilterTranspose");
 
@@ -205,8 +204,6 @@ public class PinotProjectFilterTransposeRule extends RelOptRule {
   }
 
   private boolean areEqual(RexNode node1, RexNode node2) {
-    return RexUtil.eq(node1, node2);
-  }
+  return RexUtil.eq(node1, node2);
 }
-
-
+}

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotProjectFilterTransposeRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotProjectFilterTransposeRule.java
@@ -45,6 +45,8 @@ import org.apache.calcite.tools.RelBuilder;
  * Computes shared expressions once instead of duplicating computation.
  */
 public class PinotProjectFilterTransposeRule extends RelOptRule {
+  private static final String COMMON_EXPR_PREFIX = "commonExpr";
+  
   public static final PinotProjectFilterTransposeRule INSTANCE =
       new PinotProjectFilterTransposeRule("PinotProjectFilterTranspose");
 
@@ -96,7 +98,7 @@ public class PinotProjectFilterTransposeRule extends RelOptRule {
     for (RexNode commonExpr : commonExprList) {
       int index = intermediateProjects.size();
       intermediateProjects.add(commonExpr);
-      intermediateNames.add("commonExpr" + (index - neededColumns.size()));
+      intermediateNames.add(COMMON_EXPR_PREFIX + (index - neededColumns.size()));
       commonExprToIndex.put(commonExpr, index);
     }
 

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotProjectFilterTransposeRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotProjectFilterTransposeRule.java
@@ -1,0 +1,210 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.calcite.rel.rules;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.logical.LogicalFilter;
+import org.apache.calcite.rel.logical.LogicalProject;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexInputRef;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexShuttle;
+import org.apache.calcite.rex.RexUtil;
+import org.apache.calcite.tools.RelBuilder;
+
+
+/**
+ * Optimizes queries with common expressions between project and filter operations.
+ * Computes shared expressions once instead of duplicating computation.
+ */
+public class PinotProjectFilterTransposeRule extends RelOptRule {
+  public static final PinotProjectFilterTransposeRule INSTANCE =
+      new PinotProjectFilterTransposeRule("PinotProjectFilterTranspose");
+
+  public static PinotProjectFilterTransposeRule instanceWithDescription(String description) {
+    return new PinotProjectFilterTransposeRule(description);
+  }
+
+  private PinotProjectFilterTransposeRule(String description) {
+    super(operand(LogicalProject.class, operand(LogicalFilter.class, any())), description);
+  }
+
+  @Override
+  public void onMatch(RelOptRuleCall call) {
+    LogicalProject project = call.rel(0);
+    LogicalFilter filter = call.rel(1);
+    RelBuilder relBuilder = call.builder();
+    RexBuilder rexBuilder = relBuilder.getRexBuilder();
+
+    // Find common expressions between project and filter
+    Set<RexNode> commonExprs = findCommonExpressions(project.getProjects(), filter.getCondition());
+    if (commonExprs.isEmpty()) {
+      return;
+    }
+
+    List<RexNode> commonExprList = new ArrayList<>(commonExprs);
+
+    // Collect columns needed by final project (excluding common expressions)
+    Set<Integer> neededColumns = new HashSet<>();
+    for (RexNode projectExpr : project.getProjects()) {
+      if (!commonExprs.contains(projectExpr)) {
+        collectInputRefs(projectExpr, neededColumns);
+      }
+    }
+
+    // Build intermediate projection: needed columns + common expressions
+    List<RexNode> intermediateProjects = new ArrayList<>();
+    List<String> intermediateNames = new ArrayList<>();
+    Map<Integer, Integer> oldToNewColumnMapping = new HashMap<>();
+
+    RelNode tableInput = filter.getInput();
+    for (int oldIndex : neededColumns) {
+      int newIndex = intermediateProjects.size();
+      intermediateProjects.add(rexBuilder.makeInputRef(tableInput, oldIndex));
+      intermediateNames.add(tableInput.getRowType().getFieldNames().get(oldIndex));
+      oldToNewColumnMapping.put(oldIndex, newIndex);
+    }
+
+    Map<RexNode, Integer> commonExprToIndex = new HashMap<>();
+    for (RexNode commonExpr : commonExprList) {
+      int index = intermediateProjects.size();
+      intermediateProjects.add(commonExpr);
+      intermediateNames.add("commonExpr" + (index - neededColumns.size()));
+      commonExprToIndex.put(commonExpr, index);
+    }
+
+    relBuilder.push(filter.getInput());
+    relBuilder.project(intermediateProjects, intermediateNames);
+    RelNode newInput = relBuilder.build();
+
+    // Prepare replacement references for common expressions
+    List<RexNode> commonExprReplacements = new ArrayList<>();
+    for (RexNode commonExpr : commonExprList) {
+      int index = commonExprToIndex.get(commonExpr);
+      RexNode replacement = rexBuilder.makeInputRef(newInput, index);
+      commonExprReplacements.add(replacement);
+    }
+
+    // Replace common expressions in filter and project
+    RexNode newCondition =
+        replaceExpressions(filter.getCondition(), commonExprList, commonExprReplacements, oldToNewColumnMapping);
+
+    List<RexNode> newProjects = project.getProjects().stream()
+        .map(expr -> replaceExpressions(expr, commonExprList, commonExprReplacements, oldToNewColumnMapping))
+        .collect(Collectors.toList());
+
+    // Build optimized plan
+    LogicalFilter newFilter = filter.copy(filter.getTraitSet(), newInput, newCondition);
+    LogicalProject newProject = project.copy(project.getTraitSet(), newFilter, newProjects, project.getRowType());
+    call.transformTo(newProject);
+  }
+
+  private Set<RexNode> findCommonExpressions(List<RexNode> projectExprs, RexNode filterCondition) {
+    Set<RexNode> common = new HashSet<>();
+    Set<RexNode> filterExprs = new HashSet<>();
+    collectAllExpressions(filterCondition, filterExprs);
+
+    for (RexNode pExpr : projectExprs) {
+      for (RexNode fExpr : filterExprs) {
+        if (pExpr instanceof RexCall && areEqual(pExpr, fExpr)) {
+          common.add(pExpr);
+        }
+      }
+    }
+    return common;
+  }
+
+  private void collectAllExpressions(RexNode node, Set<RexNode> expressions) {
+    if (node instanceof RexCall) {
+      RexCall call = (RexCall) node;
+      expressions.add(call);
+      for (RexNode operand : call.getOperands()) {
+        collectAllExpressions(operand, expressions);
+      }
+    } else {
+      expressions.add(node);
+    }
+  }
+
+  private void collectInputRefs(RexNode expr, Set<Integer> columnRefs) {
+    expr.accept(new RexShuttle() {
+      @Override
+      public RexNode visitInputRef(RexInputRef inputRef) {
+        columnRefs.add(inputRef.getIndex());
+        return inputRef;
+      }
+    });
+  }
+
+  private RexNode replaceExpressions(RexNode expr, List<RexNode> oldExprs, List<RexNode> newExprs,
+      Map<Integer, Integer> columnMapping) {
+    return expr.accept(new RexShuttle() {
+      @Override
+      public RexNode visitCall(RexCall call) {
+        for (int i = 0; i < oldExprs.size(); i++) {
+          if (areEqual(oldExprs.get(i), call)) {
+            return newExprs.get(i);
+          }
+        }
+        return (RexCall) super.visitCall(call);
+      }
+
+      @Override
+      public RexNode visitInputRef(RexInputRef inputRef) {
+        for (int i = 0; i < oldExprs.size(); i++) {
+          if (RexUtil.eq(oldExprs.get(i), inputRef)) {
+            return newExprs.get(i);
+          }
+        }
+        Integer newIndex = columnMapping.get(inputRef.getIndex());
+        if (newIndex != null) {
+          return new RexInputRef(newIndex, inputRef.getType());
+        }
+        return inputRef;
+      }
+
+      @Override
+      public RexNode visitLiteral(RexLiteral literal) {
+        for (int i = 0; i < oldExprs.size(); i++) {
+          if (RexUtil.eq(oldExprs.get(i), literal)) {
+            return newExprs.get(i);
+          }
+        }
+        return literal;
+      }
+    });
+  }
+
+  private boolean areEqual(RexNode node1, RexNode node2) {
+    return RexUtil.eq(node1, node2);
+  }
+}
+
+

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotQueryRuleSets.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotQueryRuleSets.java
@@ -216,6 +216,8 @@ public class PinotQueryRuleSets {
 
   // Pinot specific rules that should be run AFTER all other rules
   public static final List<RelOptRule> PINOT_POST_RULES = List.of(
+      // Common Expression evaluation for project and filter expressions
+      PinotProjectFilterTransposeRule.instanceWithDescription(PlannerRuleNames.PINOT_PROJECT_FILTER_TRANSPOSE),
       // TODO: Merge the following 2 rules into a single rule
       // add an extra exchange for sort
       PinotSortExchangeNodeInsertRule.INSTANCE,

--- a/pinot-query-planner/src/test/java/org/apache/pinot/calcite/rel/rules/PinotProjectFilterTransposeRuleTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/calcite/rel/rules/PinotProjectFilterTransposeRuleTest.java
@@ -1,0 +1,120 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.calcite.rel.rules;
+
+import org.apache.pinot.query.QueryEnvironmentTestBase;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+
+/**
+ * Tests for {@link PinotProjectFilterTransposeRule}.
+ */
+public class PinotProjectFilterTransposeRuleTest extends QueryEnvironmentTestBase {
+
+  private String explainQueryWithRule(String query) {
+    return _queryEnvironment.explainQuery(query, RANDOM_REQUEST_ID_GEN.nextLong());
+  }
+
+  @Test
+  public void testBasicCommonExpressionOptimization() {
+    String query = "EXPLAIN PLAN FOR SELECT col3+col3 FROM a WHERE col3+col3 > 59";
+    String explainPlan = explainQueryWithRule(query);
+
+    assertTrue(explainPlan.contains("commonExpr"), "Should create commonExpr optimization");
+    assertTrue(explainPlan.contains("LogicalProject(EXPR$0=[$0])"), "Should use pre-computed value");
+    assertTrue(explainPlan.contains("LogicalFilter(condition=[>($0, 59)])"), "Filter should use pre-computed value");
+    assertTrue(explainPlan.contains("commonExpr0=[+($2, $2)]"), "Should compute expression once");
+  }
+
+  @Test
+  public void testMultipleCommonExpressions() {
+    String query =
+        "EXPLAIN PLAN FOR SELECT col3+col6, col3*col6, col3+col6+col3 FROM a WHERE col3+col6 > 10 AND col3*col6 < 100"
+            + " OR col3+col6+col3>20";
+    String explainPlan = explainQueryWithRule(query);
+
+    assertTrue(explainPlan.contains("commonExpr"), "Should create commonExpr optimization");
+    assertTrue(explainPlan.contains("commonExpr0") && explainPlan.contains("commonExpr1") && explainPlan.contains(
+        "commonExpr2"), "Should optimize both expressions");
+  }
+
+  @Test
+  public void testOrConditionsWithCommonExpressions() {
+    String query = "EXPLAIN PLAN FOR SELECT col3+col6 FROM a WHERE col3+col6 > 100 OR col3+col6 < 10";
+    String explainPlan = explainQueryWithRule(query);
+
+    assertTrue(explainPlan.contains("commonExpr"), "Should optimize common expressions in OR conditions");
+  }
+
+  @Test
+  public void testNoOptimizationWhenNoCommonExpression() {
+    String query = "EXPLAIN PLAN FOR SELECT col3 FROM a WHERE col6 > 50";
+    String explainPlan = explainQueryWithRule(query);
+
+    assertFalse(explainPlan.contains("commonExpr"), "Should not create commonExpr when no common expressions exist");
+  }
+
+  @Test
+  public void testCorrectPlanStructure() {
+    String query = "EXPLAIN PLAN FOR SELECT col3+col3 FROM a WHERE col3+col3 > 59";
+    String explainPlan = explainQueryWithRule(query);
+
+    assertTrue(explainPlan.contains("commonExpr"), "Should create commonExpr optimization");
+    assertTrue(explainPlan.contains("LogicalProject(EXPR$0=[$0])"), "Should have top project");
+    assertTrue(explainPlan.contains("LogicalFilter(condition=[>($0, 59)])"), "Should have filter");
+    assertTrue(explainPlan.contains("commonExpr0=[+($2, $2)]"), "Should have intermediate project");
+    assertTrue(explainPlan.contains("PinotLogicalTableScan"), "Should have table scan");
+
+    String[] lines = explainPlan.split("\n");
+    boolean foundTopProject = false, foundFilter = false, foundBottomProject = false;
+
+    for (String line : lines) {
+      if (line.contains("LogicalProject(EXPR$0=[$0])")) {
+        foundTopProject = true;
+      } else if (line.contains("LogicalFilter(condition=[>($0, 59)])")) {
+        assertTrue(foundTopProject, "Filter should come after top project");
+        foundFilter = true;
+      } else if (line.contains("commonExpr0=[+($2, $2)]")) {
+        assertTrue(foundFilter, "Bottom project should come after filter");
+        foundBottomProject = true;
+      }
+    }
+
+    assertTrue(foundTopProject && foundFilter && foundBottomProject, "Should have correct plan structure");
+  }
+
+  @Test
+  public void testJoinWithCommonExpressions() {
+    String query = "EXPLAIN PLAN FOR SELECT a.col3+a.col6 FROM a JOIN b ON a.col1 = b.col1 WHERE a.col3+a.col6 > 100";
+    String explainPlan = explainQueryWithRule(query);
+
+    assertTrue(explainPlan.contains("commonExpr"), "Should optimize common expressions in JOIN");
+  }
+
+  @Test
+  public void testAggregateWithCommonExpressions() {
+    String query = "EXPLAIN PLAN FOR SELECT SUM(col3+col6) FROM a WHERE col3+col6 > 50 GROUP BY col1";
+    String explainPlan = explainQueryWithRule(query);
+
+    assertTrue(explainPlan.contains("commonExpr"), "Should optimize common expressions with aggregates");
+  }
+}

--- a/pinot-query-planner/src/test/java/org/apache/pinot/calcite/rel/rules/PinotProjectFilterTransposeRuleTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/calcite/rel/rules/PinotProjectFilterTransposeRuleTest.java
@@ -85,7 +85,9 @@ public class PinotProjectFilterTransposeRuleTest extends QueryEnvironmentTestBas
     assertTrue(explainPlan.contains("PinotLogicalTableScan"), "Should have table scan");
 
     String[] lines = explainPlan.split("\n");
-    boolean foundTopProject = false, foundFilter = false, foundBottomProject = false;
+    boolean foundTopProject = false;
+    boolean foundFilter = false;
+    boolean foundBottomProject = false;
 
     for (String line : lines) {
       if (line.contains("LogicalProject(EXPR$0=[$0])")) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -876,6 +876,7 @@ public class CommonConstants {
       public static final String PRUNE_EMPTY_JOIN_LEFT = "PruneEmptyJoinLeft";
       public static final String PRUNE_EMPTY_JOIN_RIGHT = "PruneEmptyJoinRight";
       public static final String JOIN_TO_ENRICHED_JOIN = "JoinToEnrichedJoin";
+      public static final String PINOT_PROJECT_FILTER_TRANSPOSE = "PinotProjectFilterTranspose";
     }
 
     /**


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Rule transposes common expressions between project and filter into an intermediate projection to avoid duplicate computation\.

```mermaid
flowchart TD
  N0["onMatch#40;LogicalProject project#44; LogicalFilter filter#41; #40;F1#41;"]:::stAdded
  N1["findCommonExpressions#40;project#46;getProjects#40;#41;#44; filter#46;getCondition#40;#41;#41; #40;F1#41;"]:::stAdded
  N2["if commonExprs#46;isEmpty#40;#41; return #40;F1#41;"]:::stAdded
  N3["collect needed columns from project expressions #40;F1#41;"]:::stAdded
  N4["build intermediate projection #40;needed columns #43; common exprs#41; #40;F1#41;"]:::stAdded
  N5["build replacement input refs for common exprs #40;F1#41;"]:::stAdded
  N6["replace common exprs in filter and project #40;F1#41;"]:::stAdded
  N7["create new LogicalFilter and LogicalProject #40;F1#41;"]:::stAdded
  N8["call#46;transformTo#40;newProject#41; #40;F1#41;"]:::stAdded
  N0 -->|"calls"| N1
  N1 -->|"value"| N2
  N2 -->|"branch #40;not empty#41;"| N3
  N3 -->|"value"| N4
  N4 -->|"value"| N5
  N5 -->|"value"| N6
  N6 -->|"value"| N7
  N7 -->|"calls"| N8
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-query\-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotProjectFilterTransposeRule\.java — [after](https://github.com/apache/pinot/blob/02ace2df7c7cf1706df7fccc057a0738e60e5b61/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotProjectFilterTransposeRule.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjE3ZGZhZmVkMGQ0ZDE2OTc3MzMyMWI2NGM4MWFjMTcyZGM0NTljZDIiLCJjb250ZXh0X2hhc2giOiI1Yzc1MzUyYzQxMDAzODMxNjk5NWQ4OTA1ZWE2OTZmM2IyNjllNDUzZTI2N2ExMzNhMmY0YTRjNGM1MjljZTBjIiwiZ2VuZXJhdGVkX2F0IjoxNzg5MTgwNjAxLCJoZWFkX3NoYSI6IjAyYWNlMmRmN2M3Y2YxNzA2ZGY3ZmNjYzA1N2EwNzM4ZTYwZTViNjEiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJlMjU4YzdkMGQ2MjJjOWZmN2VkNTA1NzYyZjI5OTJlZTE4YTJjNGU2IiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 7bae39c76b50350e0b0a1a9eb524e6b160cde820205c265df01193d1ce2ff27c -->
<!-- pinot-pr-flow:end -->

New Optimization rule PinotProjectFilterTransposeRule that eliminates duplicate expression evaluation when the same expression appears in both project and filter operations. This optimization improves query performance by computing shared expressions only once instead of redundantly evaluating them multiple times. For example:

```
select DateTimeConvert("zz_received_timestamp", '1:MILLISECONDS:EPOCH', '1:MILLISECONDS:EPOCH', '1:MINUTES')
from table
where DateTimeConvert("zz_received_timestamp", '1:MILLISECONDS:EPOCH', '1:MILLISECONDS:EPOCH', '1:MINUTES') >= 1752783630000
```

A query like above is computed twice once when filtering and second during projection

Current Implementation:
```
LogicalProject(alignedTimestamp=[DATETIMECONVERT($67, _UTF-8'1:MILLISECONDS:EPOCH', _UTF-8'1:MILLISECONDS:EPOCH', _UTF-8'1:MINUTES')], zz_groupby_1=[$28])
  LogicalFilter(condition=[AND(>=(DATETIMECONVERT($67, _UTF-8'1:MILLISECONDS:EPOCH', _UTF-8'1:MILLISECONDS:EPOCH', _UTF-8'1:MINUTES'), 1752783630000), <=(DATETIMECONVERT($67, _UTF-8'1:MILLISECONDS:EPOCH', _UTF-8'1:MILLISECONDS:EPOCH', _UTF-8'1:MINUTES'), 1752784219000), =($50, _UTF-8'Fortnite.Fortnite'), <>($28, _UTF-8'Mac'))])
    PinotLogicalTableScan(table=[[default, table]])

```

**Query 1:** EXPLAIN PLAN FOR select runs+runs from baseballStats where runs+runs>59;
**Before Fix:**

```
EXPLAIN PLAN FOR select runs+runs from baseballStats where runs+runs>59; 
 LogicalProject(EXPR$0=[+($20, $20)])
   LogicalFilter(condition=[>(+($20, $20), 59)])
     PinotLogicalTableScan(table=[[default, baseballStats]])
```



**After Fix:**
```
EXPLAIN PLAN FOR select runs+runs from baseballStats where runs+runs>59; 

Execution Plan
LogicalProject(EXPR$0=[$0])
   LogicalFilter(condition=[>($0, 59)])
     LogicalProject(commonExpr0=[+($20, $20)])
       PinotLogicalTableScan(table=[[default, baseballStats]])
```



**Query 2:**
**Before Fix:**

```
EXPLAIN PLAN FOR select runs+runs, doules from baseballStats where runs+runs>59; 
LogicalProject(EXPR$0=[+($20, $20)], doules=[$8])
   LogicalFilter(condition=[>(+($20, $20), 59)])
     PinotLogicalTableScan(table=[[default, baseballStats]])
```



**After Fix:**


```
EXPLAIN PLAN FOR select runs+runs, doules from baseballStats where runs+runs>59;
 
LogicalProject(EXPR$0=[$1], doules=[$0])
   LogicalFilter(condition=[>($1, 59)])
     LogicalProject(doules=[$8], commonExpr0=[+($20, $20)])
       PinotLogicalTableScan(table=[[default, baseballStats]])

```

**Query 3:**

**Before Fix:**

```
EXPLAIN PLAN FOR select runs+runs, runs+runs+runs from baseballStats where runs+runs>59 AND runs+runs +runs>170; 

LogicalProject(EXPR$0=[+($20, $20)], EXPR$1=[+(+($20, $20), $20)])
   LogicalFilter(condition=[AND(>(+($20, $20), 59), >(+(+($20, $20), $20), 170))])
     PinotLogicalTableScan(table=[[default, baseballStats]])
```


**After Fix:**

```
EXPLAIN PLAN FOR select runs+runs, runs+runs+runs from baseballStats where runs+runs>59 AND runs+runs +runs>170;

LogicalProject(EXPR$0=[$0], EXPR$1=[$1])
  LogicalFilter(condition=[AND(>($0, 59), >($1, 170))])
     LogicalProject(commonExpr0=[+($20, $20)], commonExpr1=[+(+($20, $20), $20)])
       PinotLogicalTableScan(table=[[default, baseballStats]])
```







