### PR TITLE
Handle NullPointerException in tenant rebalance while rebalancing table with failed dry-run

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/tenant/TenantRebalancer.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/tenant/TenantRebalancer.java
@@ -359,7 +359,7 @@ public class TenantRebalancer {
       TenantTableRebalanceJobContext jobContext;
       if (dryRunResult.getStatus() == RebalanceResult.Status.FAILED) {
         jobContext = new TenantTableRebalanceJobContext(table, dryRunResult.getJobId(), false);
-        LOGGER.warn("User proceeded with rebalancing table: {} despite its failed dry-run", table);
+        LOGGER.warn("Proceeding with table rebalance: {} despite its failed dry-run", table);
       } else {
         Preconditions.checkState(dryRunResult.getRebalanceSummaryResult() != null,
             "Non-failed dry-run result missing summary");


### PR DESCRIPTION
## Description
For table with a `FAILED` dry-run result, it would not contain rebalance summary. `createTableQueue` assume that each dry-run result contains one, which is not the case of the above scenario. This leads to exception when user try to rebalance tables that failed their dry-run.

This PR fixes the above issue.