### PR TITLE
Add a framework to validate each of the Ingestion Transformation functions

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunction.java
@@ -27,7 +27,6 @@ import org.apache.pinot.core.operator.blocks.ValueBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.spi.data.FieldSpec;
-import org.apache.pinot.spi.data.Schema;
 import org.roaringbitmap.RoaringBitmap;
 
 
@@ -177,8 +176,7 @@ public interface TransformFunction {
   /**
    * Validates transform function configuration during table creation.
    */
-  default void validateIngestionConfig(String transformFunctionExpression, 
-      org.apache.pinot.spi.data.Schema schema) {
+  default void validateIngestionConfig(String transformFunctionExpression, org.apache.pinot.spi.data.Schema schema) {
     // Default: no validation
   }
 
@@ -192,15 +190,15 @@ public interface TransformFunction {
   /**
    * Infers output data type based on input arguments.
    */
-  default org.apache.pinot.spi.data.FieldSpec.DataType inferOutputDataType(
-      List<String> inputArguments, org.apache.pinot.spi.data.Schema schema) {
-    return org.apache.pinot.spi.data.FieldSpec.DataType.STRING;
+  default org.apache.pinot.spi.data.FieldSpec.DataType inferOutputDataType(List<String> inputArguments,
+      org.apache.pinot.spi.data.Schema schema) {
+    return FieldSpec.DataType.STRING;
   }
 
   /**
    * Returns expected input data types for validation.
    */
-  default org.apache.pinot.spi.data.FieldSpec.DataType[] getExpectedInputDataTypes() {
+  default FieldSpec.DataType[] getExpectedInputDataTypes() {
     return new org.apache.pinot.spi.data.FieldSpec.DataType[0];
   }
 
@@ -221,7 +219,7 @@ public interface TransformFunction {
   /**
    * Validates input data type compatibility.
    */
-  default boolean isInputDataTypeSupported(org.apache.pinot.spi.data.FieldSpec.DataType inputType, 
+  default boolean isInputDataTypeSupported(FieldSpec.DataType inputType,
       int argumentIndex) {
     return true;
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunction.java
@@ -26,6 +26,8 @@ import org.apache.pinot.core.operator.ColumnContext;
 import org.apache.pinot.core.operator.blocks.ValueBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
 import org.roaringbitmap.RoaringBitmap;
 
 
@@ -171,4 +173,56 @@ public interface TransformFunction {
    */
   @Nullable
   RoaringBitmap getNullBitmap(ValueBlock block);
+
+  /**
+   * Validates transform function configuration during table creation.
+   */
+  default void validateIngestionConfig(String transformFunctionExpression, 
+      org.apache.pinot.spi.data.Schema schema) {
+    // Default: no validation
+  }
+
+  /**
+   * Returns whether this function supports ingestion-time transformation.
+   */
+  default boolean supportsIngestionTransform() {
+    return true;
+  }
+
+  /**
+   * Infers output data type based on input arguments.
+   */
+  default org.apache.pinot.spi.data.FieldSpec.DataType inferOutputDataType(
+      List<String> inputArguments, org.apache.pinot.spi.data.Schema schema) {
+    return org.apache.pinot.spi.data.FieldSpec.DataType.STRING;
+  }
+
+  /**
+   * Returns expected input data types for validation.
+   */
+  default org.apache.pinot.spi.data.FieldSpec.DataType[] getExpectedInputDataTypes() {
+    return new org.apache.pinot.spi.data.FieldSpec.DataType[0];
+  }
+
+  /**
+   * Returns minimum number of arguments required.
+   */
+  default int getMinArgumentCount() {
+    return 0;
+  }
+
+  /**
+   * Returns maximum number of arguments allowed (-1 for unlimited).
+   */
+  default int getMaxArgumentCount() {
+    return -1;
+  }
+
+  /**
+   * Validates input data type compatibility.
+   */
+  default boolean isInputDataTypeSupported(org.apache.pinot.spi.data.FieldSpec.DataType inputType, 
+      int argumentIndex) {
+    return true;
+  }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/IngestionConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/IngestionConfig.java
@@ -76,6 +76,9 @@ public class IngestionConfig extends BaseJsonConfig {
   @JsonPropertyDescription("Configs related to check time value for segment")
   private boolean _segmentTimeValueCheck = true;
 
+  @JsonPropertyDescription("Default validation mode for transform functions: STRICT, LENIENT, or LEGACY")
+  private TransformConfig.ValidationMode _defaultTransformValidationMode;
+
   @Deprecated
   public IngestionConfig(@Nullable BatchIngestionConfig batchIngestionConfig,
       @Nullable StreamIngestionConfig streamIngestionConfig, @Nullable FilterConfig filterConfig,
@@ -199,5 +202,14 @@ public class IngestionConfig extends BaseJsonConfig {
 
   public void setSegmentTimeValueCheck(boolean segmentTimeValueCheck) {
     _segmentTimeValueCheck = segmentTimeValueCheck;
+  }
+
+  @Nullable
+  public TransformConfig.ValidationMode getDefaultTransformValidationMode() {
+    return _defaultTransformValidationMode;
+  }
+
+  public void setDefaultTransformValidationMode(@Nullable TransformConfig.ValidationMode defaultTransformValidationMode) {
+    _defaultTransformValidationMode = defaultTransformValidationMode;
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/IngestionConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/IngestionConfig.java
@@ -209,7 +209,8 @@ public class IngestionConfig extends BaseJsonConfig {
     return _defaultTransformValidationMode;
   }
 
-  public void setDefaultTransformValidationMode(@Nullable TransformConfig.ValidationMode defaultTransformValidationMode) {
+  public void setDefaultTransformValidationMode(
+      @Nullable TransformConfig.ValidationMode defaultTransformValidationMode) {
     _defaultTransformValidationMode = defaultTransformValidationMode;
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/TransformConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/TransformConfig.java
@@ -29,17 +29,33 @@ import org.apache.pinot.spi.config.BaseJsonConfig;
  */
 public class TransformConfig extends BaseJsonConfig {
 
+  public enum ValidationMode {
+    STRICT,   // No automatic type conversions allowed
+    LENIENT,  // Allow safe type conversions (recommended)
+    LEGACY    // Allow all existing conversions including STRING->numeric (default)
+  }
+
   @JsonPropertyDescription("Column name")
   private final String _columnName;
 
   @JsonPropertyDescription("Transformation function string")
   private final String _transformFunction;
 
+  @JsonPropertyDescription("Validation mode for type checking: STRICT, LENIENT, or LEGACY")
+  private final ValidationMode _validationMode;
+
   @JsonCreator
   public TransformConfig(@JsonProperty("columnName") String columnName,
-      @JsonProperty("transformFunction") String transformFunction) {
+      @JsonProperty("transformFunction") String transformFunction,
+      @JsonProperty("validationMode") ValidationMode validationMode) {
     _columnName = columnName;
     _transformFunction = transformFunction;
+    _validationMode = validationMode != null ? validationMode : ValidationMode.LEGACY;
+  }
+
+  // Backward compatibility constructor
+  public TransformConfig(String columnName, String transformFunction) {
+    this(columnName, transformFunction, ValidationMode.LEGACY);
   }
 
   public String getColumnName() {
@@ -48,5 +64,9 @@ public class TransformConfig extends BaseJsonConfig {
 
   public String getTransformFunction() {
     return _transformFunction;
+  }
+
+  public ValidationMode getValidationMode() {
+    return _validationMode;
   }
 }


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Shows how validation mode is set and retrieved in config objects, and the validation methods added to TransformFunction\.

```mermaid
flowchart TD
  N0["TransformConfig#46;constructor #40;F3#41;"]:::stModified
  N1["TransformConfig#46;getValidationMode #40;F3#41;"]:::stModified
  N2["IngestionConfig#46;setDefaultTransformValidationMode #40;F2#41;"]:::stModified
  N3["IngestionConfig#46;getDefaultTransformValidationMode #40;F2#41;"]:::stModified
  N4["TransformFunction#46;validateIngestionConfig #40;F1#41;"]:::stModified
  N5["TransformFunction#46;supportsIngestionTransform #40;F1#41;"]:::stModified
  N6["TransformFunction#46;inferOutputDataType #40;F1#41;"]:::stModified
  N0 -->|"value transfer via #95;validationMode"| N1
  N2 -->|"value transfer via #95;defaultTransformValidationMode"| N3
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunction\.java — [before](https://github.com/apache/pinot/blob/1b6866d5aea791c5b8f93f5b397e284047797a61/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunction.java) · [after](https://github.com/apache/pinot/blob/3b4410f0b8c1eebde7c502fb6f1550e8f51c4053/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunction.java)
- F2: pinot\-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/IngestionConfig\.java — [before](https://github.com/apache/pinot/blob/1b6866d5aea791c5b8f93f5b397e284047797a61/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/IngestionConfig.java) · [after](https://github.com/apache/pinot/blob/3b4410f0b8c1eebde7c502fb6f1550e8f51c4053/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/IngestionConfig.java)
- F3: pinot\-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/TransformConfig\.java — [before](https://github.com/apache/pinot/blob/1b6866d5aea791c5b8f93f5b397e284047797a61/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/TransformConfig.java) · [after](https://github.com/apache/pinot/blob/3b4410f0b8c1eebde7c502fb6f1550e8f51c4053/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/TransformConfig.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjFiNjg2NmQ1YWVhNzkxYzViOGY5M2Y1YjM5N2UyODQwNDc3OTdhNjEiLCJjb250ZXh0X2hhc2giOiJjNTg0MmZmOTVhOGNlMTZkN2QzM2I2YmE5ZGVkNWU5YmY1NWVlY2RjZDFkOTc3ODViN2IxY2I2YmUxM2MxMDQzIiwiZ2VuZXJhdGVkX2F0IjoxNzg5NjQwOTg0LCJoZWFkX3NoYSI6IjNiNDQxMGYwYjhjMWVlYmRlN2M1MDJmYjZmMTU1MGU4ZjUxYzQwNTMiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiI3NmMyZWMyNWM1ZGFmYWZmODZiOTg0YWJjNjlmNDFmM2RkYTk0YTE3IiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature a002f592400a151a9174bdd1adc045c419e43f278fd1c668f5ad580bab5f655a -->
<!-- pinot-pr-flow:end -->

This PR adds a validation framework for Pinot transform functions used in ingestion configs. It provides validation hooks for datatype checks in the TransformFunction interface that individual functions can implement to validate their configurations during table creation.

We can include validationMode in the transform function specification:

1. **LEGACY** Mode (Default)
Purpose: Backward compatibility - allows all existing type conversions
Behavior: No validation, accepts everything (current Pinot behavior)
Use Case: Existing tables that shouldn't break
2. **LENIENT** Mode (Recommended)
Purpose: Safe type conversions allowed
Behavior: Allows safe conversions like INT→LONG, FLOAT→DOUBLE, but blocks unsafe ones like STRING→INT
Use Case: New tables that want some safety but flexibility
3. **STRICT** Mode
Purpose: Maximum type safety
Behavior: No automatic type conversions, exact type matching required
Use Case: Critical tables where type safety is paramount

```
{
  "columnName": "processed_age",
  "transformFunction": "CAST(age_string AS INT)",
  "validationMode": "STRICT"
}
```