### PR TITLE
fix(ui): table type input was always disabled

### DIFF
--- a/pinot-controller/src/main/resources/app/components/Homepage/Operations/AddOfflineTableOp.tsx
+++ b/pinot-controller/src/main/resources/app/components/Homepage/Operations/AddOfflineTableOp.tsx
@@ -321,7 +321,6 @@ const checkFields = (tableObj,fields) => {
                 tableObj={tableObj}
                 setTableObj={setTableObj}
                 dateTimeFieldSpecs={schemaObj.dateTimeFieldSpecs}
-                disable={tableType !== ""}
               />
             </SimpleAccordion>
           </Grid>

--- a/pinot-controller/src/main/resources/app/components/Homepage/Operations/AddRealtimeTableOp.tsx
+++ b/pinot-controller/src/main/resources/app/components/Homepage/Operations/AddRealtimeTableOp.tsx
@@ -334,7 +334,6 @@ const checkFields = (tableObj,fields) => {
                 tableObj={tableObj}
                 setTableObj={setTableObj}
                 dateTimeFieldSpecs={schemaObj.dateTimeFieldSpecs}
-                disable={tableType !== ""}
               />
             </SimpleAccordion>
           </Grid>

--- a/pinot-controller/src/main/resources/app/components/Homepage/Operations/AddTableComponent.tsx
+++ b/pinot-controller/src/main/resources/app/components/Homepage/Operations/AddTableComponent.tsx
@@ -46,14 +46,12 @@ type Props = {
   tableObj: any,
   setTableObj: Function,
   dateTimeFieldSpecs: Array<any>
-  disable:boolean
 };
 
 export default function AddTableComponent({
   tableObj,
   setTableObj,
   dateTimeFieldSpecs,
-  disable
 }: Props) {
   const classes = useStyles();
 
@@ -132,7 +130,6 @@ export default function AddTableComponent({
             id="tableType"
             value={tableDataObj.tableType}
             onChange={(e)=> changeHandler('tableType', e.target.value)}
-            disabled={disable}
           >
             <MenuItem value="OFFLINE">OFFLINE</MenuItem>
             <MenuItem value="REALTIME">REALTIME</MenuItem>


### PR DESCRIPTION
Enable table type input which was always disabled before. 

Before
<img width="211" height="84" alt="image" src="https://github.com/user-attachments/assets/3bb4da2b-58fe-4f12-b634-9e78bf22f897" />


After
<img width="799" height="286" alt="image" src="https://github.com/user-attachments/assets/10c8ddd6-f4a2-4e7d-96ec-9265b04863c3" />

