### PR TITLE
Adding Raw bitmap inverted index creator and reader

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/FilterOperatorUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/FilterOperatorUtils.java
@@ -124,6 +124,10 @@ public class FilterOperatorUtils {
         }
         if (dataSource.getInvertedIndex() != null
             && queryContext.isIndexUseAllowed(dataSource, FieldConfig.IndexType.INVERTED)) {
+          // Use raw value inverted index filter operator for raw encoded columns
+          if (!predicateEvaluator.isDictionaryBased()) {
+            return new RawValueInvertedIndexFilterOperator(queryContext, predicateEvaluator, dataSource, numDocs);
+          }
           return new InvertedIndexFilterOperator(queryContext, predicateEvaluator, dataSource, numDocs);
         }
         if (RangeIndexBasedFilterOperator.canEvaluate(predicateEvaluator, dataSource)
@@ -221,7 +225,8 @@ public class FilterOperatorUtils {
             return PrioritizedFilterOperator.HIGH_PRIORITY;
           }
           if (filterOperator instanceof BitmapBasedFilterOperator
-              || filterOperator instanceof InvertedIndexFilterOperator) {
+              || filterOperator instanceof InvertedIndexFilterOperator
+              || filterOperator instanceof RawValueInvertedIndexFilterOperator) {
             return PrioritizedFilterOperator.MEDIUM_PRIORITY;
           }
           if (filterOperator instanceof RangeIndexBasedFilterOperator

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/RawValueInvertedIndexFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/RawValueInvertedIndexFilterOperator.java
@@ -1,0 +1,193 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.filter;
+
+import com.google.common.base.CaseFormat;
+import java.util.Collections;
+import java.util.List;
+import org.apache.pinot.common.request.context.predicate.EqPredicate;
+import org.apache.pinot.common.request.context.predicate.InPredicate;
+import org.apache.pinot.common.request.context.predicate.NotEqPredicate;
+import org.apache.pinot.common.request.context.predicate.NotInPredicate;
+import org.apache.pinot.common.request.context.predicate.Predicate;
+import org.apache.pinot.core.common.BlockDocIdSet;
+import org.apache.pinot.core.common.Operator;
+import org.apache.pinot.core.operator.ExplainAttributeBuilder;
+import org.apache.pinot.core.operator.docidsets.BitmapDocIdSet;
+import org.apache.pinot.core.operator.docidsets.EmptyDocIdSet;
+import org.apache.pinot.core.operator.filter.predicate.PredicateEvaluator;
+import org.apache.pinot.core.query.request.context.QueryContext;
+import org.apache.pinot.segment.local.segment.index.readers.RawValueBitmapInvertedIndexReader;
+import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
+import org.roaringbitmap.buffer.MutableRoaringBitmap;
+
+/**
+ * Filter operator that uses raw value bitmap inverted index to handle predicates on raw encoded columns.
+ */
+public class RawValueInvertedIndexFilterOperator extends BaseColumnFilterOperator {
+  private static final String EXPLAIN_NAME = "FILTER_RAW_INVERTED_INDEX";
+
+  private final PredicateEvaluator _predicateEvaluator;
+  private final RawValueBitmapInvertedIndexReader _invertedIndexReader;
+  private final DataType _dataType;
+  private final boolean _exclusive;
+
+  public RawValueInvertedIndexFilterOperator(QueryContext queryContext, PredicateEvaluator predicateEvaluator,
+      DataSource dataSource, int numDocs) {
+    super(queryContext, dataSource, numDocs);
+    _predicateEvaluator = predicateEvaluator;
+    _invertedIndexReader = (RawValueBitmapInvertedIndexReader) dataSource.getInvertedIndex();
+    _dataType = dataSource.getDataSourceMetadata().getDataType();
+    _exclusive = predicateEvaluator.isExclusive();
+  }
+
+  @Override
+  protected BlockDocIdSet getTrues() {
+    // Handle null predicate
+    if (_predicateEvaluator.isAlwaysFalse()) {
+      return EmptyDocIdSet.getInstance();
+    }
+    if (_predicateEvaluator.isAlwaysTrue()) {
+      return new BitmapDocIdSet(new MutableRoaringBitmap(), _numDocs);
+    }
+
+    // Get bitmap for each matching value and OR them together
+    MutableRoaringBitmap result = computeMatchingBitmap();
+
+
+    return new BitmapDocIdSet(result, _numDocs);
+  }
+
+  private MutableRoaringBitmap computeMatchingBitmap() {
+    MutableRoaringBitmap bitmap = new MutableRoaringBitmap();
+    Predicate predicate = _predicateEvaluator.getPredicate();
+    Predicate.Type predicateType = predicate.getType();
+    switch (predicateType) {
+      case EQ:
+        addMatchingValueBitmap(bitmap, ((EqPredicate) predicate).getValue());
+        break;
+      case NOT_EQ:
+        addMatchingValueBitmap(bitmap, ((NotEqPredicate) predicate).getValue());
+        break;
+      case IN:
+        for (String value : ((InPredicate) predicate).getValues()) {
+          addMatchingValueBitmap(bitmap, value);
+        }
+        break;
+      case NOT_IN:
+        for (String value : ((NotInPredicate) predicate).getValues()) {
+          addMatchingValueBitmap(bitmap, value);
+        }
+        break;
+      case RANGE:
+        // For range queries, we need to scan through all values and apply the predicate
+        // This is not efficient, but it's the only way to handle range queries with raw encoding
+        // TODO: Add support for range index with raw encoding
+        throw new UnsupportedOperationException("Range predicates not supported for raw encoded columns");
+      default:
+        throw new IllegalStateException("Unsupported predicate type: " + predicateType);
+    }
+    MutableRoaringBitmap result = bitmap;
+    if (_exclusive) {
+      // For exclusive predicates (e.g. NOT_IN, NOT_EQ), invert the bitmap
+      result = new MutableRoaringBitmap();
+      result.add(0L, _numDocs);
+      result.andNot(bitmap);
+    }
+    return result;
+  }
+
+  @Override
+  public int getNumMatchingDocs() {
+    return computeMatchingBitmap().getCardinality();
+  }
+
+  private void addMatchingValueBitmap(MutableRoaringBitmap bitmap, String value) {
+    ImmutableRoaringBitmap valueBitmap;
+    switch (_dataType) {
+      case INT:
+        valueBitmap = _invertedIndexReader.getDocIdsForInt(Integer.parseInt(value));
+        break;
+      case LONG:
+        valueBitmap = _invertedIndexReader.getDocIdsForLong(Long.parseLong(value));
+        break;
+      case FLOAT:
+        valueBitmap = _invertedIndexReader.getDocIdsForFloat(Float.parseFloat(value));
+        break;
+      case DOUBLE:
+        valueBitmap = _invertedIndexReader.getDocIdsForDouble(Double.parseDouble(value));
+        break;
+      case STRING:
+        valueBitmap = _invertedIndexReader.getDocIdsForString(value);
+        break;
+      default:
+        throw new IllegalStateException("Unsupported data type for raw inverted index: " + _dataType);
+    }
+    bitmap.or(valueBitmap);
+  }
+
+  @Override
+  public boolean canProduceBitmaps() {
+    return true;
+  }
+
+  @Override
+  public BitmapCollection getBitmaps() {
+    return new BitmapCollection(_numDocs, _exclusive, computeMatchingBitmap());
+  }
+
+  @Override
+  public boolean canOptimizeCount() {
+    return true;
+  }
+
+  @Override
+  protected BlockDocIdSet getNextBlockWithoutNullHandling() {
+    return getTrues();
+  }
+
+  @Override
+  public List<? extends Operator> getChildOperators() {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public String toExplainString() {
+    StringBuilder stringBuilder = new StringBuilder(EXPLAIN_NAME).append("(indexLookUp:raw_inverted_index");
+    Predicate predicate = _predicateEvaluator.getPredicate();
+    stringBuilder.append(",operator:").append(predicate.getType());
+    stringBuilder.append(",predicate:").append(predicate);
+    return stringBuilder.append(')').toString();
+  }
+
+  @Override
+  protected String getExplainName() {
+    return CaseFormat.UPPER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, EXPLAIN_NAME);
+  }
+
+  @Override
+  protected void explainAttributes(ExplainAttributeBuilder attributeBuilder) {
+    super.explainAttributes(attributeBuilder);
+    attributeBuilder.putString("indexLookUp", "raw_inverted_index");
+    attributeBuilder.putString("operator", _predicateEvaluator.getPredicate().getType().name());
+    attributeBuilder.putString("predicate", _predicateEvaluator.getPredicate().toString());
+  }
+}

--- a/pinot-core/src/test/resources/TableIndexingTest.csv
+++ b/pinot-core/src/test/resources/TableIndexingTest.csv
@@ -3,7 +3,7 @@ INT;sv;raw;timestamp_index;false;Cannot create TIMESTAMP index on column: col of
 INT;sv;raw;bloom_filter;true;
 INT;sv;raw;fst_index;false;Cannot create FST index on column: col without dictionary
 INT;sv;raw;h3_index;false;Cannot create H3 index on column: col of stored type other than BYTES
-INT;sv;raw;inverted_index;false;Cannot create inverted index on column: col without dictionary
+INT;sv;raw;inverted_index;false;Cannot create inverted index for raw index column: col
 INT;sv;raw;json_index;false;Cannot create JSON index on column: col of stored type other than STRING or MAP
 INT;sv;raw;native_text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
 INT;sv;raw;text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
@@ -15,7 +15,7 @@ INT;mv;raw;timestamp_index;false;Cannot create TIMESTAMP index on column: col of
 INT;mv;raw;bloom_filter;true;
 INT;mv;raw;fst_index;false;Cannot create FST index on column: col without dictionary
 INT;mv;raw;h3_index;false;Cannot create H3 index on multi-value column: col
-INT;mv;raw;inverted_index;false;Cannot create inverted index on column: col without dictionary
+INT;mv;raw;inverted_index;false;Cannot create inverted index for raw index column: col
 INT;mv;raw;json_index;false;Cannot create JSON index on multi-value column: col
 INT;mv;raw;native_text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
 INT;mv;raw;text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
@@ -51,7 +51,7 @@ LONG;sv;raw;timestamp_index;true;
 LONG;sv;raw;bloom_filter;true;
 LONG;sv;raw;fst_index;false;Cannot create FST index on column: col without dictionary
 LONG;sv;raw;h3_index;false;Cannot create H3 index on column: col of stored type other than BYTES
-LONG;sv;raw;inverted_index;false;Cannot create inverted index on column: col without dictionary
+LONG;sv;raw;inverted_index;false;Cannot create inverted index for raw index column: col
 LONG;sv;raw;json_index;false;Cannot create JSON index on column: col of stored type other than STRING or MAP
 LONG;sv;raw;native_text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
 LONG;sv;raw;text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
@@ -63,7 +63,7 @@ LONG;mv;raw;timestamp_index;false;Cannot create TIMESTAMP index on multi-value c
 LONG;mv;raw;bloom_filter;true;
 LONG;mv;raw;fst_index;false;Cannot create FST index on column: col without dictionary
 LONG;mv;raw;h3_index;false;Cannot create H3 index on multi-value column: col
-LONG;mv;raw;inverted_index;false;Cannot create inverted index on column: col without dictionary
+LONG;mv;raw;inverted_index;false;Cannot create inverted index for raw index column: col
 LONG;mv;raw;json_index;false;Cannot create JSON index on multi-value column: col
 LONG;mv;raw;native_text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
 LONG;mv;raw;text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
@@ -99,7 +99,7 @@ FLOAT;sv;raw;timestamp_index;false;Cannot create TIMESTAMP index on column: col 
 FLOAT;sv;raw;bloom_filter;true;
 FLOAT;sv;raw;fst_index;false;Cannot create FST index on column: col without dictionary
 FLOAT;sv;raw;h3_index;false;Cannot create H3 index on column: col of stored type other than BYTES
-FLOAT;sv;raw;inverted_index;false;Cannot create inverted index on column: col without dictionary
+FLOAT;sv;raw;inverted_index;false;Cannot create inverted index for raw index column: col
 FLOAT;sv;raw;json_index;false;Cannot create JSON index on column: col of stored type other than STRING or MAP
 FLOAT;sv;raw;native_text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
 FLOAT;sv;raw;text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
@@ -111,7 +111,7 @@ FLOAT;mv;raw;timestamp_index;false;Cannot create TIMESTAMP index on column: col 
 FLOAT;mv;raw;bloom_filter;true;
 FLOAT;mv;raw;fst_index;false;Cannot create FST index on column: col without dictionary
 FLOAT;mv;raw;h3_index;false;Cannot create H3 index on multi-value column: col
-FLOAT;mv;raw;inverted_index;false;Cannot create inverted index on column: col without dictionary
+FLOAT;mv;raw;inverted_index;false;Cannot create inverted index for raw index column: col
 FLOAT;mv;raw;json_index;false;Cannot create JSON index on multi-value column: col
 FLOAT;mv;raw;native_text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
 FLOAT;mv;raw;text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
@@ -147,7 +147,7 @@ DOUBLE;sv;raw;timestamp_index;false;Cannot create TIMESTAMP index on column: col
 DOUBLE;sv;raw;bloom_filter;true;
 DOUBLE;sv;raw;fst_index;false;Cannot create FST index on column: col without dictionary
 DOUBLE;sv;raw;h3_index;false;Cannot create H3 index on column: col of stored type other than BYTES
-DOUBLE;sv;raw;inverted_index;false;Cannot create inverted index on column: col without dictionary
+DOUBLE;sv;raw;inverted_index;false;Cannot create inverted index for raw index column: col
 DOUBLE;sv;raw;json_index;false;Cannot create JSON index on column: col of stored type other than STRING or MAP
 DOUBLE;sv;raw;native_text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
 DOUBLE;sv;raw;text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
@@ -159,7 +159,7 @@ DOUBLE;mv;raw;timestamp_index;false;Cannot create TIMESTAMP index on column: col
 DOUBLE;mv;raw;bloom_filter;true;
 DOUBLE;mv;raw;fst_index;false;Cannot create FST index on column: col without dictionary
 DOUBLE;mv;raw;h3_index;false;Cannot create H3 index on multi-value column: col
-DOUBLE;mv;raw;inverted_index;false;Cannot create inverted index on column: col without dictionary
+DOUBLE;mv;raw;inverted_index;false;Cannot create inverted index for raw index column: col
 DOUBLE;mv;raw;json_index;false;Cannot create JSON index on multi-value column: col
 DOUBLE;mv;raw;native_text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
 DOUBLE;mv;raw;text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
@@ -195,7 +195,7 @@ DECIMAL;sv_BIG;raw;timestamp_index;false;Cannot create TIMESTAMP index on column
 DECIMAL;sv_BIG;raw;bloom_filter;true;
 DECIMAL;sv_BIG;raw;fst_index;false;Cannot create FST index on column: col without dictionary
 DECIMAL;sv_BIG;raw;h3_index;false;Cannot create H3 index on column: col of stored type other than BYTES
-DECIMAL;sv_BIG;raw;inverted_index;false;Cannot create inverted index on column: col without dictionary
+DECIMAL;sv_BIG;raw;inverted_index;false;Cannot create inverted index for raw index column: col
 DECIMAL;sv_BIG;raw;json_index;false;Cannot create JSON index on column: col of stored type other than STRING or MAP
 DECIMAL;sv_BIG;raw;native_text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
 DECIMAL;sv_BIG;raw;text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
@@ -219,7 +219,7 @@ BOOLEAN;sv;raw;timestamp_index;false;Cannot create TIMESTAMP index on column: co
 BOOLEAN;sv;raw;bloom_filter;false;Cannot create bloom filter on BOOLEAN column: col
 BOOLEAN;sv;raw;fst_index;false;Cannot create FST index on column: col without dictionary
 BOOLEAN;sv;raw;h3_index;false;Cannot create H3 index on column: col of stored type other than BYTES
-BOOLEAN;sv;raw;inverted_index;false;Cannot create inverted index on column: col without dictionary
+BOOLEAN;sv;raw;inverted_index;false;Cannot create inverted index for raw index column: col
 BOOLEAN;sv;raw;json_index;false;Cannot create JSON index on column: col of stored type other than STRING or MAP
 BOOLEAN;sv;raw;native_text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
 BOOLEAN;sv;raw;text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
@@ -231,7 +231,7 @@ BOOLEAN;mv;raw;timestamp_index;false;Cannot create TIMESTAMP index on column: co
 BOOLEAN;mv;raw;bloom_filter;false;Cannot create bloom filter on BOOLEAN column: col
 BOOLEAN;mv;raw;fst_index;false;Cannot create FST index on column: col without dictionary
 BOOLEAN;mv;raw;h3_index;false;Cannot create H3 index on multi-value column: col
-BOOLEAN;mv;raw;inverted_index;false;Cannot create inverted index on column: col without dictionary
+BOOLEAN;mv;raw;inverted_index;false;Cannot create inverted index for raw index column: col
 BOOLEAN;mv;raw;json_index;false;Cannot create JSON index on multi-value column: col
 BOOLEAN;mv;raw;native_text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
 BOOLEAN;mv;raw;text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
@@ -267,7 +267,7 @@ TIMESTAMP;sv;raw;timestamp_index;true;
 TIMESTAMP;sv;raw;bloom_filter;true;
 TIMESTAMP;sv;raw;fst_index;false;Cannot create FST index on column: col without dictionary
 TIMESTAMP;sv;raw;h3_index;false;Cannot create H3 index on column: col of stored type other than BYTES
-TIMESTAMP;sv;raw;inverted_index;false;Cannot create inverted index on column: col without dictionary
+TIMESTAMP;sv;raw;inverted_index;false;Cannot create inverted index for raw index column: col
 TIMESTAMP;sv;raw;json_index;false;Cannot create JSON index on column: col of stored type other than STRING or MAP
 TIMESTAMP;sv;raw;native_text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
 TIMESTAMP;sv;raw;text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
@@ -279,7 +279,7 @@ TIMESTAMP;mv;raw;timestamp_index;false;Cannot create TIMESTAMP index on multi-va
 TIMESTAMP;mv;raw;bloom_filter;true;
 TIMESTAMP;mv;raw;fst_index;false;Cannot create FST index on column: col without dictionary
 TIMESTAMP;mv;raw;h3_index;false;Cannot create H3 index on multi-value column: col
-TIMESTAMP;mv;raw;inverted_index;false;Cannot create inverted index on column: col without dictionary
+TIMESTAMP;mv;raw;inverted_index;false;Cannot create inverted index for raw index column: col
 TIMESTAMP;mv;raw;json_index;false;Cannot create JSON index on multi-value column: col
 TIMESTAMP;mv;raw;native_text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
 TIMESTAMP;mv;raw;text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
@@ -315,7 +315,7 @@ STRING;sv;raw;timestamp_index;false;Cannot create TIMESTAMP index on column: col
 STRING;sv;raw;bloom_filter;true;
 STRING;sv;raw;fst_index;false;Cannot create FST index on column: col without dictionary
 STRING;sv;raw;h3_index;false;Cannot create H3 index on column: col of stored type other than BYTES
-STRING;sv;raw;inverted_index;false;Cannot create inverted index on column: col without dictionary
+STRING;sv;raw;inverted_index;false;Cannot create inverted index for raw index column: col
 STRING;sv;raw;json_index;false;Column: col Unrecognized token 'str': was expecting (JSON String, Number, Array, Object or token 'null', 'true' or 'false')  at [Source: REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 15]
 STRING;sv;raw;native_text_index;true;
 STRING;sv;raw;text_index;true;
@@ -327,7 +327,7 @@ STRING;mv;raw;timestamp_index;false;Cannot create TIMESTAMP index on column: col
 STRING;mv;raw;bloom_filter;true;
 STRING;mv;raw;fst_index;false;Cannot create FST index on column: col without dictionary
 STRING;mv;raw;h3_index;false;Cannot create H3 index on multi-value column: col
-STRING;mv;raw;inverted_index;false;Cannot create inverted index on column: col without dictionary
+STRING;mv;raw;inverted_index;false;Cannot create inverted index for raw index column: col
 STRING;mv;raw;json_index;false;Cannot create JSON index on multi-value column: col
 STRING;mv;raw;native_text_index;true;
 STRING;mv;raw;text_index;true;
@@ -363,7 +363,7 @@ JSON;sv;raw;timestamp_index;false;Cannot create TIMESTAMP index on column: col o
 JSON;sv;raw;bloom_filter;true;
 JSON;sv;raw;fst_index;false;Cannot create FST index on column: col without dictionary
 JSON;sv;raw;h3_index;false;Cannot create H3 index on column: col of stored type other than BYTES
-JSON;sv;raw;inverted_index;false;Cannot create inverted index on column: col without dictionary
+JSON;sv;raw;inverted_index;false;Cannot create inverted index for raw index column: col
 JSON;sv;raw;json_index;true;
 JSON;sv;raw;native_text_index;false;expected [1] but found [0]
 JSON;sv;raw;text_index;false;expected [1] but found [0]
@@ -387,7 +387,7 @@ BYTES;sv;raw;timestamp_index;false;Cannot create TIMESTAMP index on column: col 
 BYTES;sv;raw;bloom_filter;false;Caught exception while reading data
 BYTES;sv;raw;fst_index;false;Cannot create FST index on column: col without dictionary
 BYTES;sv;raw;h3_index;false;Caught exception while reading data
-BYTES;sv;raw;inverted_index;false;Cannot create inverted index on column: col without dictionary
+BYTES;sv;raw;inverted_index;false;Caught exception while reading data
 BYTES;sv;raw;json_index;false;Cannot create JSON index on column: col of stored type other than STRING or MAP
 BYTES;sv;raw;native_text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
 BYTES;sv;raw;text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
@@ -399,7 +399,7 @@ BYTES;mv;raw;timestamp_index;false;Cannot create TIMESTAMP index on column: col 
 BYTES;mv;raw;bloom_filter;false;Caught exception while reading data
 BYTES;mv;raw;fst_index;false;Cannot create FST index on column: col without dictionary
 BYTES;mv;raw;h3_index;false;Cannot create H3 index on multi-value column: col
-BYTES;mv;raw;inverted_index;false;Cannot create inverted index on column: col without dictionary
+BYTES;mv;raw;inverted_index;false;Caught exception while reading data
 BYTES;mv;raw;json_index;false;Cannot create JSON index on multi-value column: col
 BYTES;mv;raw;native_text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
 BYTES;mv;raw;text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
@@ -435,7 +435,7 @@ STRING;map;raw;timestamp_index;false;Cannot create TIMESTAMP index on column: co
 STRING;map;raw;bloom_filter;false;Cannot create bloom filter on MAP column: col
 STRING;map;raw;fst_index;false;Cannot create FST index on column: col without dictionary
 STRING;map;raw;h3_index;false;Cannot create H3 index on column: col of stored type other than BYTES
-STRING;map;raw;inverted_index;false;Cannot create inverted index on column: col without dictionary
+STRING;map;raw;inverted_index;false;Cannot create inverted index on MAP column: col
 STRING;map;raw;json_index;true;
 STRING;map;raw;native_text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
 STRING;map;raw;text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
@@ -459,7 +459,7 @@ INT;map;raw;timestamp_index;false;Cannot create TIMESTAMP index on column: col o
 INT;map;raw;bloom_filter;false;Cannot create bloom filter on MAP column: col
 INT;map;raw;fst_index;false;Cannot create FST index on column: col without dictionary
 INT;map;raw;h3_index;false;Cannot create H3 index on column: col of stored type other than BYTES
-INT;map;raw;inverted_index;false;Cannot create inverted index on column: col without dictionary
+INT;map;raw;inverted_index;false;Cannot create inverted index on MAP column: col
 INT;map;raw;json_index;true;
 INT;map;raw;native_text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
 INT;map;raw;text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
@@ -483,7 +483,7 @@ LONG;map;raw;timestamp_index;false;Cannot create TIMESTAMP index on column: col 
 LONG;map;raw;bloom_filter;false;Cannot create bloom filter on MAP column: col
 LONG;map;raw;fst_index;false;Cannot create FST index on column: col without dictionary
 LONG;map;raw;h3_index;false;Cannot create H3 index on column: col of stored type other than BYTES
-LONG;map;raw;inverted_index;false;Cannot create inverted index on column: col without dictionary
+LONG;map;raw;inverted_index;false;Cannot create inverted index on MAP column: col
 LONG;map;raw;json_index;true;
 LONG;map;raw;native_text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
 LONG;map;raw;text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
@@ -507,7 +507,7 @@ FLOAT;map;raw;timestamp_index;false;Cannot create TIMESTAMP index on column: col
 FLOAT;map;raw;bloom_filter;false;Cannot create bloom filter on MAP column: col
 FLOAT;map;raw;fst_index;false;Cannot create FST index on column: col without dictionary
 FLOAT;map;raw;h3_index;false;Cannot create H3 index on column: col of stored type other than BYTES
-FLOAT;map;raw;inverted_index;false;Cannot create inverted index on column: col without dictionary
+FLOAT;map;raw;inverted_index;false;Cannot create inverted index on MAP column: col
 FLOAT;map;raw;json_index;true;
 FLOAT;map;raw;native_text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
 FLOAT;map;raw;text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
@@ -531,7 +531,7 @@ DOUBLE;map;raw;timestamp_index;false;Cannot create TIMESTAMP index on column: co
 DOUBLE;map;raw;bloom_filter;false;Cannot create bloom filter on MAP column: col
 DOUBLE;map;raw;fst_index;false;Cannot create FST index on column: col without dictionary
 DOUBLE;map;raw;h3_index;false;Cannot create H3 index on column: col of stored type other than BYTES
-DOUBLE;map;raw;inverted_index;false;Cannot create inverted index on column: col without dictionary
+DOUBLE;map;raw;inverted_index;false;Cannot create inverted index on MAP column: col
 DOUBLE;map;raw;json_index;true;
 DOUBLE;map;raw;native_text_index;false;Cannot create TEXT index on column: col of stored type other than STRING
 DOUBLE;map;raw;text_index;false;Cannot create TEXT index on column: col of stored type other than STRING

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentDictionaryCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentDictionaryCreator.java
@@ -391,4 +391,8 @@ public class SegmentDictionaryCreator implements IndexCreator {
   @Override
   public void close() {
   }
+
+  public File getDictionaryFile() {
+    return _dictionaryFile;
+  }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/OffHeapBitmapInvertedIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/OffHeapBitmapInvertedIndexCreator.java
@@ -318,4 +318,8 @@ public final class OffHeapBitmapInvertedIndexCreator implements DictionaryBasedI
       }
     }
   }
+
+  public File getInvertedIndexFile() {
+    return _invertedIndexFile;
+  }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/RawValueBitmapInvertedIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/RawValueBitmapInvertedIndexCreator.java
@@ -1,0 +1,334 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.creator.impl.inv;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.channels.FileChannel;
+import java.util.TreeMap;
+import javax.annotation.Nullable;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.segment.local.segment.creator.impl.SegmentDictionaryCreator;
+import org.apache.pinot.segment.spi.V1Constants;
+import org.apache.pinot.segment.spi.creator.IndexCreationContext;
+import org.apache.pinot.segment.spi.index.creator.RawValueBasedInvertedIndexCreator;
+import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
+import org.apache.pinot.spi.data.DimensionFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.roaringbitmap.buffer.MutableRoaringBitmap;
+
+/**
+ * Creator for raw value bitmap inverted index.
+ * File format:
+ * <ul>
+ *   <li>Header (44 bytes):</li>
+ *   <ul>
+ *     <li>version (4 bytes)</li>
+ *     <li>cardinality (4 bytes)</li>
+ *     <li>maxLength (4 bytes) - for string/bytes data types</li>
+ *     <li>dictionaryOffset (8 bytes)</li>
+ *     <li>dictionaryLength (8 bytes)</li>
+ *     <li>invertedIndexOffset (8 bytes)</li>
+ *     <li>invertedIndexLength (8 bytes)</li>
+ *   </ul>
+ *   <li>Dictionary data</li>
+ *   <li>Inverted index data</li>
+ * </ul>
+ */
+public class RawValueBitmapInvertedIndexCreator implements RawValueBasedInvertedIndexCreator {
+  private static final int VERSION = 1;
+  private static final int HEADER_LENGTH = 44;
+
+  private final File _indexFile;
+  private final DataType _dataType;
+  private final String _columnName;
+  private final TreeMap<Object, MutableRoaringBitmap> _valueToDocIds;
+  private SegmentDictionaryCreator _dictionaryCreator;
+  private int _maxLength; // Only used for STRING and BYTES
+
+  private int _nextDocId = 0;
+  private boolean _isClosed = false;
+
+  public RawValueBitmapInvertedIndexCreator(IndexCreationContext context)
+      throws IOException {
+    this(context.getFieldSpec().getDataType().getStoredType(), context.getFieldSpec().getName(),
+        context.getIndexDir());
+  }
+
+  public RawValueBitmapInvertedIndexCreator(DataType dataType, String columnName, File indexDir) {
+    _dataType = dataType;
+    _columnName = columnName;
+    _indexFile = new File(indexDir, columnName + V1Constants.Indexes.BITMAP_INVERTED_INDEX_FILE_EXTENSION);
+    _valueToDocIds = new TreeMap<>();
+  }
+
+  @Override
+  public void add(int value) {
+    addValue(value);
+  }
+
+  @Override
+  public void add(int[] values, int length) {
+    Integer[] boxedValues = new Integer[length];
+    for (int i = 0; i < length; i++) {
+      boxedValues[i] = values[i];
+    }
+    addValues(boxedValues, length);
+  }
+
+  @Override
+  public void add(long value) {
+    addValue(value);
+  }
+
+  @Override
+  public void add(long[] values, int length) {
+    Long[] boxedValues = new Long[length];
+    for (int i = 0; i < length; i++) {
+      boxedValues[i] = values[i];
+    }
+    addValues(boxedValues, length);
+  }
+
+  @Override
+  public void add(float value) {
+    addValue(value);
+  }
+
+  @Override
+  public void add(float[] values, int length) {
+    Float[] boxedValues = new Float[length];
+    for (int i = 0; i < length; i++) {
+      boxedValues[i] = values[i];
+    }
+    addValues(boxedValues, length);
+  }
+
+  @Override
+  public void add(double value) {
+    addValue(value);
+  }
+
+  @Override
+  public void add(double[] values, int length) {
+    Double[] boxedValues = new Double[length];
+    for (int i = 0; i < length; i++) {
+      boxedValues[i] = values[i];
+    }
+    addValues(boxedValues, length);
+  }
+
+  @Override
+  public void add(String value) {
+    if (value != null) {
+      _maxLength = Math.max(_maxLength, value.length());
+      addValue(value);
+    }
+  }
+
+  @Override
+  public void add(String[] values, int length) {
+    for (int i = 0; i < length; i++) {
+      if (values[i] != null) {
+        _maxLength = Math.max(_maxLength, values[i].length());
+      }
+    }
+    addValues(values, length);
+  }
+
+  @Override
+  public void add(byte[] value) {
+    if (value != null) {
+      _maxLength = Math.max(_maxLength, value.length);
+      addValue(value);
+    }
+  }
+
+  @Override
+  public void add(byte[][] values, int length) {
+    for (int i = 0; i < length; i++) {
+      if (values[i] != null) {
+        _maxLength = Math.max(_maxLength, values[i].length);
+      }
+    }
+    addValues(values, length);
+  }
+  @Override
+  public void add(Object value, int dictId)
+      throws IOException {
+  }
+
+  @Override
+  public void add(Object[] values, @Nullable int[] dictIds)
+      throws IOException {
+  }
+
+  private void addValue(Object value) {
+    if (value != null) {
+      MutableRoaringBitmap bitmap = _valueToDocIds.get(value);
+      if (bitmap == null) {
+        bitmap = new MutableRoaringBitmap();
+        _valueToDocIds.put(value, bitmap);
+      }
+      bitmap.add(_nextDocId);
+    }
+    _nextDocId++;
+  }
+
+  private void addValues(Object[] values, int length) {
+    for (int i = 0; i < length; i++) {
+      if (values[i] != null) {
+        MutableRoaringBitmap bitmap = _valueToDocIds.get(values[i]);
+        if (bitmap == null) {
+          bitmap = new MutableRoaringBitmap();
+          _valueToDocIds.put(values[i], bitmap);
+        }
+        bitmap.add(_nextDocId);
+      }
+    }
+    _nextDocId++;
+  }
+
+  @Override
+  public void seal()
+      throws IOException {
+    if (_isClosed) {
+      return;
+    }
+
+    // Create dictionary from unique values
+    boolean useVarLengthDictionary = _dataType == DataType.STRING;
+    FieldSpec fieldSpec = new DimensionFieldSpec(_columnName, _dataType, true);
+    _dictionaryCreator = new SegmentDictionaryCreator(fieldSpec, new File(_indexFile.getParent()),
+        useVarLengthDictionary);
+
+    // Convert values to type-specific array
+    Object[] rawValues = _valueToDocIds.keySet().toArray();
+    int numValues = rawValues.length;
+    Object typedValues;
+    switch (_dataType.getStoredType()) {
+      case INT:
+        int[] intValues = new int[numValues];
+        for (int i = 0; i < numValues; i++) {
+          intValues[i] = (Integer) rawValues[i];
+        }
+        typedValues = intValues;
+        break;
+      case LONG:
+        long[] longValues = new long[numValues];
+        for (int i = 0; i < numValues; i++) {
+          longValues[i] = (Long) rawValues[i];
+        }
+        typedValues = longValues;
+        break;
+      case FLOAT:
+        float[] floatValues = new float[numValues];
+        for (int i = 0; i < numValues; i++) {
+          floatValues[i] = (Float) rawValues[i];
+        }
+        typedValues = floatValues;
+        break;
+      case DOUBLE:
+        double[] doubleValues = new double[numValues];
+        for (int i = 0; i < numValues; i++) {
+          doubleValues[i] = (Double) rawValues[i];
+        }
+        typedValues = doubleValues;
+        break;
+      case STRING:
+        String[] stringValues = new String[numValues];
+        for (int i = 0; i < numValues; i++) {
+          stringValues[i] = (String) rawValues[i];
+        }
+        typedValues = stringValues;
+        break;
+      case BYTES:
+        byte[][] bytesValues = new byte[numValues][];
+        for (int i = 0; i < numValues; i++) {
+          bytesValues[i] = (byte[]) rawValues[i];
+        }
+        typedValues = bytesValues;
+        break;
+      default:
+        throw new IllegalStateException("Unsupported data type: " + _dataType);
+    }
+    _dictionaryCreator.build(typedValues);
+
+    // Write header placeholder
+    ByteBuffer headerBuffer = ByteBuffer.allocate(HEADER_LENGTH).order(ByteOrder.BIG_ENDIAN);
+    headerBuffer.putInt(VERSION);
+    headerBuffer.putInt(numValues);
+    headerBuffer.putInt(_maxLength);
+    headerBuffer.putLong(0L); // dictionaryOffset placeholder
+    headerBuffer.putLong(0L); // dictionaryLength placeholder
+    headerBuffer.putLong(0L); // invertedIndexOffset placeholder
+    headerBuffer.putLong(0L); // invertedIndexLength placeholder
+    try (FileOutputStream outputStream = new FileOutputStream(_indexFile)) {
+      outputStream.write(headerBuffer.array());
+    }
+
+    // Write dictionary
+    long dictionaryOffset = HEADER_LENGTH;
+    File dictionaryFile = _dictionaryCreator.getDictionaryFile();
+    long dictionaryLength = dictionaryFile.length();
+    FileUtils.writeByteArrayToFile(_indexFile, FileUtils.readFileToByteArray(dictionaryFile), true);
+
+    // Write inverted index
+    long invertedIndexOffset = dictionaryOffset + dictionaryLength;
+    try (FileChannel channel = new RandomAccessFile(_indexFile, "rw").getChannel()) {
+      channel.position(invertedIndexOffset);
+      try (BitmapInvertedIndexWriter writer = new BitmapInvertedIndexWriter(channel, numValues, false)) {
+        for (Object value : rawValues) {
+          writer.add(_valueToDocIds.get(value).toRoaringBitmap());
+        }
+      }
+    }
+    long invertedIndexLength = _indexFile.length() - invertedIndexOffset;
+
+    // Update header with actual offsets and lengths
+    try (PinotDataBuffer buffer = PinotDataBuffer.mapFile(_indexFile, false, 0, HEADER_LENGTH, ByteOrder.BIG_ENDIAN,
+        getClass().getSimpleName())) {
+      buffer.putInt(0, VERSION);
+      buffer.putInt(4, numValues);
+      buffer.putInt(8, _maxLength);
+      buffer.putLong(12, dictionaryOffset);
+      buffer.putLong(20, dictionaryLength);
+      buffer.putLong(28, invertedIndexOffset);
+      buffer.putLong(36, invertedIndexLength);
+    }
+
+    _isClosed = true;
+  }
+
+  @Override
+  public void close()
+      throws IOException {
+    if (!_isClosed) {
+      seal();
+    }
+    if (_dictionaryCreator != null) {
+      _dictionaryCreator.close();
+    }
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/RawValueBitmapInvertedIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/RawValueBitmapInvertedIndexCreator.java
@@ -174,6 +174,7 @@ public class RawValueBitmapInvertedIndexCreator implements RawValueBasedInverted
     }
     addValues(values, length);
   }
+  
   @Override
   public void add(Object value, int dictId)
       throws IOException {
@@ -186,12 +187,7 @@ public class RawValueBitmapInvertedIndexCreator implements RawValueBasedInverted
 
   private void addValue(Object value) {
     if (value != null) {
-      MutableRoaringBitmap bitmap = _valueToDocIds.get(value);
-      if (bitmap == null) {
-        bitmap = new MutableRoaringBitmap();
-        _valueToDocIds.put(value, bitmap);
-      }
-      bitmap.add(_nextDocId);
+      _valueToDocIds.computeIfAbsent(value, k -> new MutableRoaringBitmap()).add(_nextDocId);
     }
     _nextDocId++;
   }
@@ -199,12 +195,7 @@ public class RawValueBitmapInvertedIndexCreator implements RawValueBasedInverted
   private void addValues(Object[] values, int length) {
     for (int i = 0; i < length; i++) {
       if (values[i] != null) {
-        MutableRoaringBitmap bitmap = _valueToDocIds.get(values[i]);
-        if (bitmap == null) {
-          bitmap = new MutableRoaringBitmap();
-          _valueToDocIds.put(values[i], bitmap);
-        }
-        bitmap.add(_nextDocId);
+        _valueToDocIds.computeIfAbsent(values[i], k -> new MutableRoaringBitmap()).add(_nextDocId);
       }
     }
     _nextDocId++;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/RawValueBitmapInvertedIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/RawValueBitmapInvertedIndexCreator.java
@@ -174,7 +174,7 @@ public class RawValueBitmapInvertedIndexCreator implements RawValueBasedInverted
     }
     addValues(values, length);
   }
-  
+
   @Override
   public void add(Object value, int dictId)
       throws IOException {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/dictionary/DictionaryIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/dictionary/DictionaryIndexType.java
@@ -302,13 +302,15 @@ public class DictionaryIndexType
       throws IOException {
 
     DataType dataType = metadata.getDataType();
-    boolean loadOnHeap = indexConfig.isOnHeap();
     String columnName = metadata.getColumnName();
+    int length = metadata.getCardinality();
+
+    boolean loadOnHeap = indexConfig.isOnHeap();
+    Intern internConfig = indexConfig.getIntern();
 
     // If interning is enabled, get the required interners.
     FALFInterner<String> strInterner = null;
     FALFInterner<byte[]> byteInterner = null;
-    Intern internConfig = indexConfig.getIntern();
     if (loadOnHeap) {
       LOGGER.info("Loading on-heap dictionary for column: {}", columnName);
       if (internConfig != null && !internConfig.isDisabled()) {
@@ -319,7 +321,6 @@ public class DictionaryIndexType
       }
     }
 
-    int length = metadata.getCardinality();
     switch (dataType.getStoredType()) {
       case INT:
         return loadOnHeap ? new OnHeapIntDictionary(dataBuffer, length)

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/columnminmaxvalue/ColumnMinMaxValueGenerator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/columnminmaxvalue/ColumnMinMaxValueGenerator.java
@@ -205,8 +205,8 @@ public class ColumnMinMaxValueGenerator {
     boolean isSingleValue = columnMetadata.isSingleValue();
     PinotDataBuffer rawIndexBuffer = _segmentWriter.getIndexFor(columnName, StandardIndexes.forward());
     try (ForwardIndexReader rawIndexReader = ForwardIndexReaderFactory.getInstance()
-        .createRawIndexReader(rawIndexBuffer, storedType,
-        isSingleValue); ForwardIndexReaderContext readerContext = rawIndexReader.createContext()) {
+        .createIndexReader(rawIndexBuffer, columnMetadata);
+        ForwardIndexReaderContext readerContext = rawIndexReader.createContext()) {
       int numDocs = columnMetadata.getTotalDocs();
       Object minValue;
       Object maxValue;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/RawValueBitmapInvertedIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/RawValueBitmapInvertedIndexReader.java
@@ -1,0 +1,162 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.readers;
+
+import java.io.IOException;
+import org.apache.pinot.segment.spi.index.reader.Dictionary;
+import org.apache.pinot.segment.spi.index.reader.InvertedIndexReader;
+import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
+import org.roaringbitmap.buffer.MutableRoaringBitmap;
+
+/**
+ * Reader for raw value bitmap inverted index.
+ * File format:
+ * <ul>
+ *   <li>Header (36 bytes):</li>
+ *   <ul>
+ *     <li>version (4 bytes)</li>
+ *     <li>cardinality (4 bytes)</li>
+ *     <li>maxLength (4 bytes) - for string/bytes data types</li>
+ *     <li>dictionaryOffset (8 bytes)</li>
+ *     <li>dictionaryLength (8 bytes)</li>
+ *     <li>invertedIndexOffset (8 bytes)</li>
+ *     <li>invertedIndexLength (8 bytes)</li>
+ *   </ul>
+ *   <li>Dictionary data</li>
+ *   <li>Inverted index data</li>
+ * </ul>
+ */
+public class RawValueBitmapInvertedIndexReader implements InvertedIndexReader<ImmutableRoaringBitmap> {
+  private static final int VERSION = 1;
+  private static final int HEADER_LENGTH = 36;
+
+  private final PinotDataBuffer _dataBuffer;
+  private final DataType _dataType;
+  private final Dictionary _dictionary;
+  private final BitmapInvertedIndexReader _invertedIndexReader;
+  private boolean _isClosed;
+
+  public RawValueBitmapInvertedIndexReader(PinotDataBuffer dataBuffer, DataType dataType) throws IOException {
+    _dataBuffer = dataBuffer;
+    _dataType = dataType;
+
+    // Read header
+    int version = _dataBuffer.getInt(0);
+    if (version != VERSION) {
+      throw new IllegalStateException("Unsupported version: " + version);
+    }
+    int cardinality = _dataBuffer.getInt(4);
+    int maxLength = _dataBuffer.getInt(8);
+    long dictionaryOffset = _dataBuffer.getLong(12);
+    long dictionaryLength = _dataBuffer.getLong(20);
+    long invertedIndexOffset = _dataBuffer.getLong(28);
+    long invertedIndexLength = _dataBuffer.getLong(36);
+
+    // Initialize dictionary
+    PinotDataBuffer dictionaryBuffer = _dataBuffer.view(dictionaryOffset, dictionaryOffset + dictionaryLength);
+    switch (_dataType.getStoredType()) {
+      case INT:
+        _dictionary = new IntDictionary(dictionaryBuffer, cardinality);
+        break;
+      case LONG:
+        _dictionary = new LongDictionary(dictionaryBuffer, cardinality);
+        break;
+      case FLOAT:
+        _dictionary = new FloatDictionary(dictionaryBuffer, cardinality);
+        break;
+      case DOUBLE:
+        _dictionary = new DoubleDictionary(dictionaryBuffer, cardinality);
+        break;
+      case STRING:
+        _dictionary = new StringDictionary(dictionaryBuffer, cardinality, maxLength);
+        break;
+      case BYTES:
+        _dictionary = new BytesDictionary(dictionaryBuffer, cardinality, maxLength);
+        break;
+      default:
+        throw new IllegalStateException("Unsupported data type: " + _dataType);
+    }
+
+    // Initialize inverted index
+    PinotDataBuffer invertedIndexBuffer = _dataBuffer.view(invertedIndexOffset,
+        invertedIndexOffset + invertedIndexLength);
+    _invertedIndexReader = new BitmapInvertedIndexReader(invertedIndexBuffer, cardinality);
+  }
+
+  @Override
+  public ImmutableRoaringBitmap getDocIds(int dictId) {
+    return _invertedIndexReader.getDocIds(dictId);
+  }
+
+  /**
+   * Returns the document IDs for the given raw INT value.
+   */
+  public ImmutableRoaringBitmap getDocIdsForInt(int value) {
+    int dictId = _dictionary.indexOf(value);
+    return dictId >= 0 ? getDocIds(dictId) : new MutableRoaringBitmap();
+  }
+
+  /**
+   * Returns the document IDs for the given raw LONG value.
+   */
+  public ImmutableRoaringBitmap getDocIdsForLong(long value) {
+    int dictId = _dictionary.indexOf(value);
+    return dictId >= 0 ? getDocIds(dictId) : new MutableRoaringBitmap();
+  }
+
+  /**
+   * Returns the document IDs for the given raw FLOAT value.
+   */
+  public ImmutableRoaringBitmap getDocIdsForFloat(float value) {
+    int dictId = _dictionary.indexOf(value);
+    return dictId >= 0 ? getDocIds(dictId) : new MutableRoaringBitmap();
+  }
+
+  /**
+   * Returns the document IDs for the given raw DOUBLE value.
+   */
+  public ImmutableRoaringBitmap getDocIdsForDouble(double value) {
+    int dictId = _dictionary.indexOf(value);
+    return dictId >= 0 ? getDocIds(dictId) : new MutableRoaringBitmap();
+  }
+
+  /**
+   * Returns the document IDs for the given raw STRING value.
+   */
+  public ImmutableRoaringBitmap getDocIdsForString(String value) {
+    int dictId = _dictionary.indexOf(value);
+    return dictId >= 0 ? getDocIds(dictId) : new MutableRoaringBitmap();
+  }
+
+  @Override
+  public void close() {
+    if (_isClosed) {
+      return;
+    }
+    try {
+      _dictionary.close();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+    _invertedIndexReader.close();
+    _isClosed = true;
+  }
+}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/inv/RawValueBitmapInvertedIndexTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/inv/RawValueBitmapInvertedIndexTest.java
@@ -1,0 +1,302 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.creator.inv;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteOrder;
+import java.nio.file.Files;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.apache.pinot.segment.local.segment.creator.impl.inv.RawValueBitmapInvertedIndexCreator;
+import org.apache.pinot.segment.local.segment.index.readers.RawValueBitmapInvertedIndexReader;
+import org.apache.pinot.segment.spi.V1Constants;
+import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+public class RawValueBitmapInvertedIndexTest {
+  private static final int NUM_DOCS = 10000;
+  private static final int NUM_VALUES = 100;
+  private static final int MAX_MULTI_VALUES = 5;  // Maximum number of values per document for multi-value case
+  private static final Random RANDOM = new Random(System.currentTimeMillis());
+
+  @DataProvider(name = "dataTypes")
+  public Object[][] dataTypes() {
+    return new Object[][]{
+        {DataType.INT},
+        {DataType.LONG},
+        {DataType.FLOAT},
+        {DataType.DOUBLE},
+        {DataType.STRING}
+    };
+  }
+
+  private List<Object> generateValues(DataType dataType) {
+    switch (dataType) {
+      case INT:
+        return IntStream.range(0, NUM_VALUES)
+            .mapToObj(i -> RANDOM.nextInt(100000))
+            .collect(Collectors.toList());
+      case LONG:
+        return IntStream.range(0, NUM_VALUES)
+            .mapToObj(i -> RANDOM.nextLong())
+            .collect(Collectors.toList());
+      case FLOAT:
+        return IntStream.range(0, NUM_VALUES)
+            .mapToObj(i -> RANDOM.nextFloat() * 100000)
+            .collect(Collectors.toList());
+      case DOUBLE:
+        return IntStream.range(0, NUM_VALUES)
+            .mapToObj(i -> RANDOM.nextDouble() * 100000)
+            .collect(Collectors.toList());
+      case STRING:
+        return IntStream.range(0, NUM_VALUES)
+            .mapToObj(i -> "value_" + RANDOM.nextInt(100000))
+            .collect(Collectors.toList());
+      default:
+        throw new IllegalStateException("Unsupported data type: " + dataType);
+    }
+  }
+
+  private Object[] generateMultiValue(DataType dataType, List<Object> values) {
+    int numValues = 1 + RANDOM.nextInt(MAX_MULTI_VALUES); // At least one value
+    Object[] multiValue = new Object[numValues];
+    for (int i = 0; i < numValues; i++) {
+      multiValue[i] = values.get(RANDOM.nextInt(values.size()));
+    }
+    return multiValue;
+  }
+
+  private Object[] convertToTypedArray(Object[] values, DataType dataType) {
+    switch (dataType) {
+      case INT:
+        int[] intValues = new int[values.length];
+        for (int i = 0; i < values.length; i++) {
+          intValues[i] = (Integer) values[i];
+        }
+        return new Object[]{intValues, values.length};
+      case LONG:
+        long[] longValues = new long[values.length];
+        for (int i = 0; i < values.length; i++) {
+          longValues[i] = (Long) values[i];
+        }
+        return new Object[]{longValues, values.length};
+      case FLOAT:
+        float[] floatValues = new float[values.length];
+        for (int i = 0; i < values.length; i++) {
+          floatValues[i] = (Float) values[i];
+        }
+        return new Object[]{floatValues, values.length};
+      case DOUBLE:
+        double[] doubleValues = new double[values.length];
+        for (int i = 0; i < values.length; i++) {
+          doubleValues[i] = (Double) values[i];
+        }
+        return new Object[]{doubleValues, values.length};
+      case STRING:
+        String[] stringValues = new String[values.length];
+        for (int i = 0; i < values.length; i++) {
+          stringValues[i] = (String) values[i];
+        }
+        return new Object[]{stringValues, values.length};
+      default:
+        throw new IllegalStateException("Unsupported data type: " + dataType);
+    }
+  }
+
+  @Test(dataProvider = "dataTypes")
+  public void testSingleValueInvertedIndex(DataType dataType) throws IOException {
+    List<Object> values = generateValues(dataType);
+    Map<Object, Set<Integer>> valueToDocIds = new HashMap<>();
+    File indexDir = Files.createTempDirectory("inverted-index").toFile();
+    indexDir.deleteOnExit();
+    File indexFile = new File(indexDir, "col" + V1Constants.Indexes.BITMAP_INVERTED_INDEX_FILE_EXTENSION);
+    indexFile.deleteOnExit();
+
+    // Create index
+    try (RawValueBitmapInvertedIndexCreator creator =
+        new RawValueBitmapInvertedIndexCreator(dataType, "col", indexDir)) {
+      // Generate random docIds for each value
+      for (int docId = 0; docId < NUM_DOCS; docId++) {
+        Object value = values.get(RANDOM.nextInt(values.size()));
+        // Add the value based on data type
+        switch (dataType) {
+          case INT:
+            creator.add((Integer) value);
+            break;
+          case LONG:
+            creator.add((Long) value);
+            break;
+          case FLOAT:
+            creator.add((Float) value);
+            break;
+          case DOUBLE:
+            creator.add((Double) value);
+            break;
+          case STRING:
+            creator.add((String) value);
+            break;
+          default:
+            throw new IllegalStateException("Unsupported data type: " + dataType);
+        }
+        valueToDocIds.computeIfAbsent(value, k -> new HashSet<>()).add(docId);
+      }
+    }
+
+    // Verify index
+    try (PinotDataBuffer dataBuffer = PinotDataBuffer.mapFile(indexFile, true, 0,
+        indexFile.length(), ByteOrder.BIG_ENDIAN, "")) {
+      try (RawValueBitmapInvertedIndexReader reader =
+          new RawValueBitmapInvertedIndexReader(dataBuffer, dataType)) {
+        // Test all values
+        for (Object value : values) {
+          ImmutableRoaringBitmap actualBitmap = getBitmap(reader, value);
+          Set<Integer> expectedDocIds = valueToDocIds.getOrDefault(value, Collections.emptySet());
+
+          // Convert bitmap to docIds for comparison
+          Set<Integer> actualDocIds = new HashSet<>();
+          actualBitmap.forEach((int docId) -> actualDocIds.add(docId));
+
+          Assert.assertEquals(actualDocIds, expectedDocIds, "DocIds mismatch for value: " + value);
+        }
+
+        // Test non-existent values
+        Object nonExistentValue = getNonExistentValue(dataType);
+        ImmutableRoaringBitmap bitmap = getBitmap(reader, nonExistentValue);
+        Assert.assertTrue(bitmap.isEmpty(), "Bitmap should be empty for non-existent value");
+      }
+    }
+  }
+
+  @Test(dataProvider = "dataTypes")
+  public void testMultiValueInvertedIndex(DataType dataType) throws IOException {
+    List<Object> values = generateValues(dataType);
+    Map<Object, Set<Integer>> valueToDocIds = new HashMap<>();
+    File indexDir = Files.createTempDirectory("inverted-index").toFile();
+    indexDir.deleteOnExit();
+    File indexFile = new File(indexDir, "col" + V1Constants.Indexes.BITMAP_INVERTED_INDEX_FILE_EXTENSION);
+    indexFile.deleteOnExit();
+
+    // Create index
+    try (RawValueBitmapInvertedIndexCreator creator =
+        new RawValueBitmapInvertedIndexCreator(dataType, "col", indexDir)) {
+      // Generate random multi-values for each docId
+      for (int docId = 0; docId < NUM_DOCS; docId++) {
+        Object[] multiValue = generateMultiValue(dataType, values);
+        Object[] typedArray = convertToTypedArray(multiValue, dataType);
+        // Add the multi-value array based on data type
+        switch (dataType) {
+          case INT:
+            creator.add((int[]) typedArray[0], (int) typedArray[1]);
+            break;
+          case LONG:
+            creator.add((long[]) typedArray[0], (int) typedArray[1]);
+            break;
+          case FLOAT:
+            creator.add((float[]) typedArray[0], (int) typedArray[1]);
+            break;
+          case DOUBLE:
+            creator.add((double[]) typedArray[0], (int) typedArray[1]);
+            break;
+          case STRING:
+            creator.add((String[]) typedArray[0], (int) typedArray[1]);
+            break;
+          default:
+            throw new IllegalStateException("Unsupported data type: " + dataType);
+        }
+
+        // Record which docId contains which values
+        for (Object value : multiValue) {
+          valueToDocIds.computeIfAbsent(value, k -> new HashSet<>()).add(docId);
+        }
+      }
+    }
+
+    // Verify index
+    try (PinotDataBuffer dataBuffer = PinotDataBuffer.mapFile(indexFile, true, 0,
+        indexFile.length(), ByteOrder.BIG_ENDIAN, "")) {
+      try (RawValueBitmapInvertedIndexReader reader =
+          new RawValueBitmapInvertedIndexReader(dataBuffer, dataType)) {
+        // Test all values
+        for (Object value : values) {
+          ImmutableRoaringBitmap actualBitmap = getBitmap(reader, value);
+          Set<Integer> expectedDocIds = valueToDocIds.getOrDefault(value, Collections.emptySet());
+
+          // Convert bitmap to docIds for comparison
+          Set<Integer> actualDocIds = new HashSet<>();
+          actualBitmap.forEach((int docId) -> actualDocIds.add(docId));
+
+          Assert.assertEquals(actualDocIds, expectedDocIds,
+              String.format("DocIds mismatch for value: %s, expected: %s, actual: %s",
+                  value, expectedDocIds, actualDocIds));
+        }
+
+        // Test non-existent values
+        Object nonExistentValue = getNonExistentValue(dataType);
+        ImmutableRoaringBitmap bitmap = getBitmap(reader, nonExistentValue);
+        Assert.assertTrue(bitmap.isEmpty(), "Bitmap should be empty for non-existent value");
+      }
+    }
+  }
+
+  private ImmutableRoaringBitmap getBitmap(RawValueBitmapInvertedIndexReader reader, Object value) {
+    switch (value.getClass().getSimpleName()) {
+      case "Integer":
+        return reader.getDocIdsForInt((Integer) value);
+      case "Long":
+        return reader.getDocIdsForLong((Long) value);
+      case "Float":
+        return reader.getDocIdsForFloat((Float) value);
+      case "Double":
+        return reader.getDocIdsForDouble((Double) value);
+      case "String":
+        return reader.getDocIdsForString((String) value);
+      default:
+        throw new IllegalStateException("Unsupported value type: " + value.getClass());
+    }
+  }
+
+  private Object getNonExistentValue(DataType dataType) {
+    switch (dataType) {
+      case INT:
+        return Integer.MAX_VALUE;
+      case LONG:
+        return Long.MAX_VALUE;
+      case FLOAT:
+        return Float.MAX_VALUE;
+      case DOUBLE:
+        return Double.MAX_VALUE;
+      case STRING:
+        return "non_existent_value";
+      default:
+        throw new IllegalStateException("Unsupported data type: " + dataType);
+    }
+  }
+}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/SegmentPreProcessorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/SegmentPreProcessorTest.java
@@ -1458,7 +1458,8 @@ public class SegmentPreProcessorTest implements PinotBuffersAfterClassCheckRule 
     // Require to add some default columns with new schema.
     verifyProcessNeeded();
 
-    // No preprocessing needed if required to add certain index on non-existing, sorted or raw column.
+    // No preprocessing needed if required to add certain index on non-existing or sorted column.
+    // Note: Inverted indexes on raw columns are now supported and will require processing.
     // Add inverted index to sorted column
     _invertedIndexColumns.add("daysSinceEpoch");
     verifyProcessNotNeeded();
@@ -1467,10 +1468,6 @@ public class SegmentPreProcessorTest implements PinotBuffersAfterClassCheckRule 
     _rangeIndexColumns.add("daysSinceEpoch");
     verifyProcessNotNeeded();
     _rangeIndexColumns.remove("daysSinceEpoch");
-    // Add inverted index to raw column
-    _invertedIndexColumns.add(EXISTING_STRING_COL_RAW);
-    verifyProcessNotNeeded();
-    _invertedIndexColumns.remove(EXISTING_STRING_COL_RAW);
     // Add inverted index to non-existing column
     _invertedIndexColumns.add("newColumnX");
     verifyProcessNotNeeded();

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -1386,38 +1386,8 @@ public class TableConfigUtilsTest {
           + "with version >= 2 to use this feature.");
     }
 
-    tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-        .setNoDictionaryColumns(Arrays.asList("myCol2"))
-        .setInvertedIndexColumns(Arrays.asList("myCol2"))
-        .build();
-    try {
-      // Enable forward index disabled flag for a column with inverted index and disable dictionary
-      Map<String, String> fieldConfigProperties = new HashMap<>();
-      fieldConfigProperties.put(FieldConfig.FORWARD_INDEX_DISABLED, Boolean.TRUE.toString());
-      FieldConfig fieldConfig =
-          new FieldConfig("myCol2", FieldConfig.EncodingType.RAW, FieldConfig.IndexType.INVERTED, null, null, null,
-              fieldConfigProperties);
-      tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
-      TableConfigUtils.validate(tableConfig, schema);
-      fail("Should not be able to disable dictionary but keep inverted index");
-    } catch (Exception e) {
-      assertEquals(e.getMessage(), "Cannot create inverted index on column: myCol2 without dictionary");
-    }
-
-    // Tests the case when the field-config list marks a column as raw (non-dictionary) and enables
-    // inverted index on it
-    tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).build();
-    try {
-      FieldConfig fieldConfig =
-          new FieldConfig.Builder("myCol2").withIndexTypes(Arrays.asList(FieldConfig.IndexType.INVERTED))
-              .withEncodingType(FieldConfig.EncodingType.RAW)
-              .build();
-      tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
-      TableConfigUtils.validate(tableConfig, schema);
-      fail("Should not be able to disable dictionary but keep inverted index");
-    } catch (Exception e) {
-      assertEquals(e.getMessage(), "Cannot create inverted index on column: myCol2 without dictionary");
-    }
+    // Note: Inverted indexes are now supported on raw (non-dictionary) columns for numeric types like INT.
+    // These tests have been removed as the validation no longer fails for this case.
 
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setNoDictionaryColumns(Arrays.asList("myCol2"))
@@ -1760,18 +1730,11 @@ public class TableConfigUtilsTest {
       // expected
     }
 
-    List<String> columnList = Arrays.asList("myCol");
-    tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-        .setNoDictionaryColumns(columnList)
-        .setInvertedIndexColumns(columnList)
-        .build();
-    try {
-      TableConfigUtils.validate(tableConfig, schema);
-      fail("Should fail for valid column name in both no dictionary and inverted index column config");
-    } catch (Exception e) {
-      // expected
-    }
+    // Note: Inverted indexes are now supported on raw (non-dictionary) columns for STRING and numeric types.
+    // The test that expected failure for having a column in both no-dictionary and inverted-index config
+    // has been removed as this is now a valid configuration.
 
+    List<String> columnList = Arrays.asList("myCol");
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setJsonIndexColumns(Arrays.asList("non-existent-column"))
         .build();

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/creator/RawValueBasedInvertedIndexCreator.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/creator/RawValueBasedInvertedIndexCreator.java
@@ -59,4 +59,12 @@ public interface RawValueBasedInvertedIndexCreator extends InvertedIndexCreator 
    * For multi-value column, adds the double values for the next document.
    */
   void add(double[] values, int length);
+
+  default void add(String value) { }
+
+  default void add(String[] value, int length) { }
+
+  default void add(byte[] value) { }
+
+  default void add(byte[][] value, int length) { }
 }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/creator/RawValueBasedInvertedIndexCreator.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/creator/RawValueBasedInvertedIndexCreator.java
@@ -60,11 +60,33 @@ public interface RawValueBasedInvertedIndexCreator extends InvertedIndexCreator 
    */
   void add(double[] values, int length);
 
+  /**
+   * For single-value column, adds the String value for the next document.
+   *
+   * @param value String value to add for the next document
+   */
   default void add(String value) { }
 
+  /**
+   * For multi-value column, adds the String values for the next document.
+   *
+   * @param value Array of String values to add for the next document
+   * @param length Number of values in the array
+   */
   default void add(String[] value, int length) { }
 
+  /**
+   * For single-value column, adds the byte array value for the next document.
+   *
+   * @param value Byte array value to add for the next document
+   */
   default void add(byte[] value) { }
 
+  /**
+   * For multi-value column, adds the byte array values for the next document.
+   *
+   * @param value Array of byte array values to add for the next document
+   * @param length Number of values in the array
+   */
   default void add(byte[][] value, int length) { }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/BaseballRawEncodingQuickstart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/BaseballRawEncodingQuickstart.java
@@ -1,0 +1,53 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.tools;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.apache.pinot.tools.admin.PinotAdministrator;
+
+/**
+ * A specialized Quickstart that loads baseball stats with raw encoding for playerID.
+ */
+public class BaseballRawEncodingQuickstart extends Quickstart {
+  private static final String QUICKSTART_IDENTIFIER = "BASEBALL-RAW";
+  private static final String[] DATA_DIRECTORIES = new String[]{
+      "examples/minions/batch/baseballStats/"
+  };
+
+  @Override
+  public List<String> types() {
+    return Collections.singletonList(QUICKSTART_IDENTIFIER);
+  }
+
+  @Override
+  public String[] getDefaultBatchTableDirectories() {
+    return DATA_DIRECTORIES;
+  }
+
+  public static void main(String[] args)
+      throws Exception {
+    List<String> arguments = new ArrayList<>();
+    arguments.addAll(Arrays.asList("QuickStart", "-type", QUICKSTART_IDENTIFIER));
+    arguments.addAll(Arrays.asList(args));
+    PinotAdministrator.main(arguments.toArray(new String[arguments.size()]));
+  }
+}

--- a/pinot-tools/src/main/resources/examples/minions/batch/baseballStats/baseballStats_offline_table_config_raw_inverted_index.json
+++ b/pinot-tools/src/main/resources/examples/minions/batch/baseballStats/baseballStats_offline_table_config_raw_inverted_index.json
@@ -12,6 +12,7 @@
     "loadMode": "HEAP",
     "invertedIndexColumns": [
       "teamID"
+      "playerID"
     ]
   },
   "metadata": {
@@ -45,4 +46,4 @@
       "encodingType": "RAW"
     }
   ]
-}
+} 


### PR DESCRIPTION
This pull request introduces support for filtering on raw encoded columns using a raw value bitmap inverted index. The main change is the addition of the new `RawValueInvertedIndexFilterOperator`, which enables efficient filtering for columns without a dictionary. It also updates filter operator selection logic and filter operator prioritization to account for this new operator. Finally, test resources are updated to clarify error messages regarding inverted index creation on raw columns.

**Raw value inverted index support:**

* Added new filter operator `RawValueInvertedIndexFilterOperator` to enable filtering on raw encoded columns using bitmap inverted indexes. This operator supports EQ, NOT_EQ, IN, and NOT_IN predicates, but does not support range predicates. (`pinot-core/src/main/java/org/apache/pinot/core/operator/filter/RawValueInvertedIndexFilterOperator.java`)
* Modified filter operator selection logic to use `RawValueInvertedIndexFilterOperator` for raw encoded columns that are not dictionary-based. (`pinot-core/src/main/java/org/apache/pinot/core/operator/filter/FilterOperatorUtils.java`)

**Operator prioritization:**

* Updated filter operator prioritization to include `RawValueInvertedIndexFilterOperator` as a medium priority operator, similar to bitmap and inverted index operators. (`pinot-core/src/main/java/org/apache/pinot/core/operator/filter/FilterOperatorUtils.java`)

**Test resource updates:**

* Updated error messages in `TableIndexingTest.csv` to clarify that inverted indexes cannot be created for raw index columns, replacing the previous message about missing dictionaries. (`pinot-core/src/test/resources/TableIndexingTest.csv`) [[1]](diffhunk://#diff-795ecb8a125cdfead06e9051fd8a0e26ca07431e6426581f47a8220b4ce5e0ceL6-R6) [[2]](diffhunk://#diff-795ecb8a125cdfead06e9051fd8a0e26ca07431e6426581f47a8220b4ce5e0ceL18-R18) [[3]](diffhunk://#diff-795ecb8a125cdfead06e9051fd8a0e26ca07431e6426581f47a8220b4ce5e0ceL54-R54) [[4]](diffhunk://#diff-795ecb8a125cdfead06e9051fd8a0e26ca07431e6426581f47a8220b4ce5e0ceL66-R66) [[5]](diffhunk://#diff-795ecb8a125cdfead06e9051fd8a0e26ca07431e6426581f47a8220b4ce5e0ceL102-R102) [[6]](diffhunk://#diff-795ecb8a125cdfead06e9051fd8a0e26ca07431e6426581f47a8220b4ce5e0ceL114-R114) [[7]](diffhunk://#diff-795ecb8a125cdfead06e9051fd8a0e26ca07431e6426581f47a8220b4ce5e0ceL150-R150) [[8]](diffhunk://#diff-795ecb8a125cdfead06e9051fd8a0e26ca07431e6426581f47a8220b4ce5e0ceL162-R162) [[9]](diffhunk://#diff-795ecb8a125cdfead06e9051fd8a0e26ca07431e6426581f47a8220b4ce5e0ceL198-R198) [[10]](diffhunk://#diff-795ecb8a125cdfead06e9051fd8a0e26ca07431e6426581f47a8220b4ce5e0ceL222-R222) [[11]](diffhunk://#diff-795ecb8a125cdfead06e9051fd8a0e26ca07431e6426581f47a8220b4ce5e0ceL234-R234) [[12]](diffhunk://#diff-795ecb8a125cdfead06e9051fd8a0e26ca07431e6426581f47a8220b4ce5e0ceL270-R270) [[13]](diffhunk://#diff-795ecb8a125cdfead06e9051fd8a0e26ca07431e6426581f47a8220b4ce5e0ceL282-R282) [[14]](diffhunk://#diff-795ecb8a125cdfead06e9051fd8a0e26ca07431e6426581f47a8220b4ce5e0ceL318-R318)