### PR TITLE
Fix  in RealtimeTableDataManager.java using BooleanSupplier

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/InstanceDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/InstanceDataManager.java
@@ -21,7 +21,7 @@ package org.apache.pinot.core.data.manager;
 import java.io.File;
 import java.util.List;
 import java.util.Set;
-import java.util.function.Supplier;
+import java.util.function.BooleanSupplier;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.helix.HelixManager;
@@ -195,7 +195,7 @@ public interface InstanceDataManager {
    *
    * @param isServerReadyToServeQueries supplier to retrieve state of server.
    */
-  void setSupplierOfIsServerReadyToServeQueries(Supplier<Boolean> isServerReadyToServeQueries);
+  void setSupplierOfIsServerReadyToServeQueries(BooleanSupplier isServerReadyToServeQueries);
 
   /**
    * Returns consumer directory paths on the instance

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/provider/DefaultTableDataManagerProvider.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/provider/DefaultTableDataManagerProvider.java
@@ -22,7 +22,7 @@ import com.google.common.cache.Cache;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Semaphore;
-import java.util.function.Supplier;
+import java.util.function.BooleanSupplier;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
@@ -69,7 +69,7 @@ public class DefaultTableDataManagerProvider implements TableDataManagerProvider
       SegmentReloadSemaphore segmentReloadSemaphore, ExecutorService segmentReloadRefreshExecutor,
       @Nullable ExecutorService segmentPreloadExecutor,
       @Nullable Cache<Pair<String, String>, SegmentErrorInfo> errorCache,
-      Supplier<Boolean> isServerReadyToServeQueries, boolean enableAsyncSegmentRefresh) {
+      BooleanSupplier isServerReadyToServeQueries, boolean enableAsyncSegmentRefresh) {
     TableDataManager tableDataManager;
     switch (tableConfig.getTableType()) {
       case OFFLINE:

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/provider/TableDataManagerProvider.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/provider/TableDataManagerProvider.java
@@ -22,7 +22,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.cache.Cache;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.function.Supplier;
+import java.util.function.BooleanSupplier;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.helix.HelixManager;
@@ -50,7 +50,7 @@ public interface TableDataManagerProvider {
       SegmentReloadSemaphore segmentRefreshSemaphore, ExecutorService segmentReloadRefreshExecutor,
       @Nullable ExecutorService segmentPreloadExecutor,
       @Nullable Cache<Pair<String, String>, SegmentErrorInfo> errorCache,
-      Supplier<Boolean> isServerReadyToServeQueries, boolean enableAsyncSegmentRefresh);
+      BooleanSupplier isServerReadyToServeQueries, boolean enableAsyncSegmentRefresh);
 
   @VisibleForTesting
   default TableDataManager getTableDataManager(TableConfig tableConfig, Schema schema) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -36,7 +36,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.locks.Lock;
 import java.util.function.BooleanSupplier;
-import java.util.function.Supplier;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.commons.collections4.CollectionUtils;
@@ -135,8 +134,7 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
   @Deprecated
   private static final String SEGMENT_DOWNLOAD_TIMEOUT_MINUTES = "segmentDownloadTimeoutMinutes";
 
-  // TODO: Change it to BooleanSupplier
-  private final Supplier<Boolean> _isServerReadyToServeQueries;
+  private final BooleanSupplier _isServerReadyToServeQueries;
 
   // Object to track ingestion delay for all partitions
   private IngestionDelayTracker _ingestionDelayTracker;
@@ -150,7 +148,7 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
     this(segmentBuildSemaphore, () -> true);
   }
 
-  public RealtimeTableDataManager(Semaphore segmentBuildSemaphore, Supplier<Boolean> isServerReadyToServeQueries) {
+  public RealtimeTableDataManager(Semaphore segmentBuildSemaphore, BooleanSupplier isServerReadyToServeQueries) {
     _segmentBuildSemaphore = segmentBuildSemaphore;
     _isServerReadyToServeQueries = isServerReadyToServeQueries;
   }
@@ -918,7 +916,7 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
     _enforceConsumptionInOrder = enforceConsumptionInOrder;
   }
 
-  public Supplier<Boolean> getIsServerReadyToServeQueries() {
+  public BooleanSupplier getIsServerReadyToServeQueries() {
     return _isServerReadyToServeQueries;
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTrackerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTrackerTest.java
@@ -32,7 +32,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Supplier;
+import java.util.function.BooleanSupplier;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pinot.common.metrics.ServerGauge;
 import org.apache.pinot.common.metrics.ServerMetrics;
@@ -96,7 +96,7 @@ public class IngestionDelayTrackerTest {
 
     public MockIngestionDelayTracker(ServerMetrics serverMetrics, String tableNameWithType,
         RealtimeTableDataManager realtimeTableDataManager, int timerThreadTickIntervalMs, int metricTrackingIntervalMs,
-        Supplier<Boolean> isServerReadyToServeQueries) {
+        BooleanSupplier isServerReadyToServeQueries) {
       super(serverMetrics, tableNameWithType, realtimeTableDataManager, timerThreadTickIntervalMs,
           metricTrackingIntervalMs, isServerReadyToServeQueries);
     }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/realtime/utils/FailureInjectingRealtimeTableDataManager.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/realtime/utils/FailureInjectingRealtimeTableDataManager.java
@@ -21,7 +21,6 @@ package org.apache.pinot.integration.tests.realtime.utils;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BooleanSupplier;
-import java.util.function.Supplier;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.utils.LLCSegmentName;
@@ -46,7 +45,7 @@ public class FailureInjectingRealtimeTableDataManager extends RealtimeTableDataM
   }
 
   public FailureInjectingRealtimeTableDataManager(Semaphore segmentBuildSemaphore,
-      Supplier<Boolean> isServerReadyToServeQueries,
+      BooleanSupplier isServerReadyToServeQueries,
       @Nullable FailureInjectingTableConfig failureInjectingTableConfig) {
     super(segmentBuildSemaphore, isServerReadyToServeQueries);
     _failureInjectingTableConfig = failureInjectingTableConfig;

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/realtime/utils/FailureInjectingTableDataManagerProvider.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/realtime/utils/FailureInjectingTableDataManagerProvider.java
@@ -24,7 +24,7 @@ import com.google.common.cache.Cache;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Semaphore;
-import java.util.function.Supplier;
+import java.util.function.BooleanSupplier;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
@@ -76,7 +76,7 @@ public class FailureInjectingTableDataManagerProvider implements TableDataManage
       SegmentReloadSemaphore segmentReloadSemaphore, ExecutorService segmentReloadRefreshExecutor,
       @Nullable ExecutorService segmentPreloadExecutor,
       @Nullable Cache<Pair<String, String>, SegmentErrorInfo> errorCache,
-      Supplier<Boolean> isServerReadyToServeQueries, boolean enableAsyncSegmentRefresh) {
+      BooleanSupplier isServerReadyToServeQueries, boolean enableAsyncSegmentRefresh) {
     TableDataManager tableDataManager;
     switch (tableConfig.getTableType()) {
       case OFFLINE:

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
@@ -36,7 +36,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
-import java.util.function.Supplier;
+import java.util.function.BooleanSupplier;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.commons.io.FileUtils;
@@ -99,7 +99,7 @@ public class HelixInstanceDataManager implements InstanceDataManager {
   private HelixManager _helixManager;
   private ZkHelixPropertyStore<ZNRecord> _propertyStore;
   private SegmentUploader _segmentUploader;
-  private Supplier<Boolean> _isServerReadyToServeQueries = () -> false;
+  private BooleanSupplier _isServerReadyToServeQueries = () -> false;
 
   // Fixed size LRU cache for storing last N errors on the instance.
   // Key is TableNameWithType-SegmentName pair.
@@ -117,7 +117,7 @@ public class HelixInstanceDataManager implements InstanceDataManager {
   private ExecutorService _segmentPreloadExecutor;
 
   @Override
-  public void setSupplierOfIsServerReadyToServeQueries(Supplier<Boolean> isServingQueries) {
+  public void setSupplierOfIsServerReadyToServeQueries(BooleanSupplier isServingQueries) {
     _isServerReadyToServeQueries = isServingQueries;
   }
 


### PR DESCRIPTION
### Benefits of using BooleanSupplier

The `RealtimeTableDataManager` class uses Java's `BooleanSupplier` functional interface extensively for lazy evaluation of boolean conditions. This approach provides several advantages:

1. __Lazy Evaluation__: The boolean condition is only evaluated when needed, which is more efficient when the evaluation is expensive or rarely needed.

2. __Stateful Evaluation__: As seen in the implementation of `_isTableReadyToConsumeData`, a `BooleanSupplier` can maintain internal state between invocations:

   ```java
   _isTableReadyToConsumeData = new BooleanSupplier() {
     volatile boolean _allSegmentsLoaded;
     long _lastCheckTimeMs;
     
     @Override
     public boolean getAsBoolean() {
       // Logic with internal state management
     }
   };
   ```

3. __Thread Safety__: The implementation includes proper synchronization with `synchronized` blocks and `volatile` variables to ensure thread safety.

4. __Simplified Conditional Logic__: For simpler cases, lambda expressions provide concise implementations:

   ```java
   _isTableReadyToConsumeData = () -> true;
   ```

5. __Consistent API__: Using a standard functional interface from `java.util.function` package provides a clear contract with the `getAsBoolean()` method.

### Implementation in RealtimeTableDataManager

The class uses `BooleanSupplier` in several key places:

1. As a constructor parameter and instance variable to determine if the server is ready to serve queries:

   ```java
   private final BooleanSupplier _isServerReadyToServeQueries;
   ```

2. For determining if a table is ready to consume data:

   ```java
   private BooleanSupplier _isTableReadyToConsumeData;
   ```

3. As a parameter to the `createRealtimeSegmentDataManager` method:

   ```java
   protected RealtimeSegmentDataManager createRealtimeSegmentDataManager(
       // other parameters
       BooleanSupplier isTableReadyToConsumeData)
   ```
