### PR TITLE
Remove deprecated DEFAULT_SEGMENT_PUSH_TYPE constant

### DIFF
--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/TableConfigBuilder.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/TableConfigBuilder.java
@@ -55,8 +55,6 @@ import org.apache.pinot.spi.config.table.sampler.TableSamplerConfig;
 
 
 public class TableConfigBuilder {
-  private static final String DEFAULT_SEGMENT_PUSH_TYPE = "APPEND";
-  private static final String REFRESH_SEGMENT_PUSH_TYPE = "REFRESH";
   private static final String DEFAULT_DELETED_SEGMENTS_RETENTION_PERIOD = "7d";
   private static final String DEFAULT_NUM_REPLICAS = "1";
   private static final String MMAP_LOAD_MODE = "MMAP";
@@ -79,9 +77,8 @@ public class TableConfigBuilder {
   @Deprecated
   private String _segmentPushFrequency;
 
-  // TODO: Remove 'DEFAULT_SEGMENT_PUSH_TYPE' in the future major release.
   @Deprecated
-  private String _segmentPushType = DEFAULT_SEGMENT_PUSH_TYPE;
+  private String _segmentPushType = "APPEND";
   private String _peerSegmentDownloadScheme;
   @Deprecated
   private ReplicaGroupStrategyConfig _replicaGroupStrategyConfig;
@@ -221,10 +218,10 @@ public class TableConfigBuilder {
    * @deprecated Use {@code segmentIngestionType} from {@link IngestionConfig#getBatchIngestionConfig()}
    */
   public TableConfigBuilder setSegmentPushType(String segmentPushType) {
-    if (REFRESH_SEGMENT_PUSH_TYPE.equalsIgnoreCase(segmentPushType)) {
-      _segmentPushType = REFRESH_SEGMENT_PUSH_TYPE;
+    if ("REFRESH".equalsIgnoreCase(segmentPushType)) {
+      _segmentPushType = "REFRESH";
     } else {
-      _segmentPushType = DEFAULT_SEGMENT_PUSH_TYPE;
+      _segmentPushType = "APPEND";
     }
     return this;
   }


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Shows inlining of segment push type literals in field initializer and setter method, preserving original behavior\.

```mermaid
flowchart TD
  N0["#95;segmentPushType field initialized to #38;quot#59;APPEND#38;quot#59; #40;F1#41;"]:::stModified
  N1["setSegmentPushType method receives segmentPushType argument #40;F1#41;"]:::stModified
  N2["Condition checks if argument equalsIgnoreCase #38;quot#59;REFRESH#38;quot#59; #40;F1#41;"]:::stModified
  N3["True branch sets #95;segmentPushType to #38;quot#59;REFRESH#38;quot#59; #40;F1#41;"]:::stModified
  N4["False branch sets #95;segmentPushType to #38;quot#59;APPEND#38;quot#59; #40;F1#41;"]:::stModified
  N1 -->|"calls"| N2
  N2 -->|"if true"| N3
  N2 -->|"else"| N4
  N0 -->|"same literal"| N4
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-spi/src/main/java/org/apache/pinot/spi/utils/builder/TableConfigBuilder\.java — [before](https://github.com/apache/pinot/blob/7fe517afce7bd1d892516f7cddcd7baff41278aa/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/TableConfigBuilder.java) · [after](https://github.com/apache/pinot/blob/5dd4750887649229fc840a20a605ddfc48240cfb/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/TableConfigBuilder.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjdmZTUxN2FmY2U3YmQxZDg5MjUxNmY3Y2RkY2Q3YmFmZjQxMjc4YWEiLCJjb250ZXh0X2hhc2giOiI3ZGIzODBlYTNmN2Y1MjY1MWRmNDViMzNhMGE0MmI1NWYxYzVmNTcxMDQxNTlmZWM0OTYyOWUyNWY4MjMwNjU1IiwiZ2VuZXJhdGVkX2F0IjoxNzg5NjA3MDcyLCJoZWFkX3NoYSI6IjVkZDQ3NTA4ODc2NDkyMjlmYzg0MGEyMGE2MDVkZGZjNDgyNDBjZmIiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiI5MTQxNjA3OTg0OTU5OTY2OGRlOTFjMjAwZWIxNmFlYmMxMjg4ZjQ2IiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature e805954d13348bd008f32e4d26608ee23f353816c396bd89f68316e0fab8ab42 -->
<!-- pinot-pr-flow:end -->

## Description

Removes the **private** string constants `DEFAULT_SEGMENT_PUSH_TYPE` and `REFRESH_SEGMENT_PUSH_TYPE` from `TableConfigBuilder`, which were only used internally within the class itself.

The literal values (`"APPEND"` / `"REFRESH"`) are inlined directly into the deprecated `_segmentPushType` field initializer and the `setSegmentPushType()` method body.

### What is NOT changed

All public `@Deprecated` methods (`setSegmentPushType`, `setSegmentPushFrequency` and their counterparts in `SegmentsValidationAndRetentionConfig`) are intentionally preserved.  Removing public API in a minor version would be a binary-incompatible change caught by the CI binary compatibility check.  Method removal is deferred to the next major release.

## Related Issue

Addresses the TODO comment added in the original deprecation: `// TODO: Remove 'DEFAULT_SEGMENT_PUSH_TYPE' in the future major release.`

## Upgrade Notes

None. This is a private-only change with no impact on callers.

## Testing Done

- [x] No test changes required — the public API surface is identical
- [x] Binary compatibility check passes (only private constants removed)

cc @Jackie-Jiang @xiangfu0