### PR TITLE
Generate surefire report and upload artifacts in Pinot test Github Action

### DIFF
--- a/.github/workflows/pinot_tests.yml
+++ b/.github/workflows/pinot_tests.yml
@@ -234,10 +234,10 @@ jobs:
           fail_ci_if_error: false
           verbose: true
       - name: Generate Surefire Report
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && github.ref == 'refs/heads/master' }}
         run: mvn surefire-report:report-only -P github-actions,codecoverage,no-integration-tests || echo "Surefire report generation failed, but continuing..."
       - name: Upload Surefire Reports
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && github.ref == 'refs/heads/master' }}
         uses: actions/upload-artifact@v4
         with:
           name: surefire-reports-unit-test-${{ matrix.testset }}-${{matrix.distribution}}-${{matrix.java}}
@@ -365,10 +365,10 @@ jobs:
           fail_ci_if_error: false
           verbose: true
       - name: Generate Surefire Report
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && github.ref == 'refs/heads/master' }}
         run: mvn surefire-report:report-only -P github-actions,codecoverage || echo "Surefire report generation failed, but continuing..."
       - name: Upload Surefire Reports
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && github.ref == 'refs/heads/master' }}
         uses: actions/upload-artifact@v4
         with:
           name: surefire-reports-integration-test-${{ matrix.testset }}-${{matrix.distribution}}-${{matrix.java}}


### PR DESCRIPTION
## Description
This PR enables the Pinot Test workflow in Github Action to generate surefire reports and upload the artifacts to this repo for better analysis of the increasing pinot test suites. This only targets the new push on the `master` branch.

Refer to https://github.com/apache/pinot/actions/runs/18790565942 for the example artifacts output. For the current test suites, it's around ~25MB per run.