### PR TITLE
[Query] Server level runtime query throttling (pause/limit) 

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/accounting/QueryResourceAggregator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/accounting/QueryResourceAggregator.java
@@ -36,6 +36,7 @@ import org.apache.pinot.common.metrics.BrokerMetrics;
 import org.apache.pinot.common.metrics.ServerGauge;
 import org.apache.pinot.common.metrics.ServerMeter;
 import org.apache.pinot.common.metrics.ServerMetrics;
+import org.apache.pinot.core.query.scheduler.ThrottlingRuntime;
 import org.apache.pinot.spi.accounting.QueryResourceTracker;
 import org.apache.pinot.spi.config.instance.InstanceType;
 import org.apache.pinot.spi.exception.QueryErrorCode;
@@ -305,9 +306,19 @@ public class QueryResourceAggregator implements ResourceAggregator {
           break;
         case HeapMemoryAlarmingVerbose:
           LOGGER.debug("Heap used bytes: {} exceeds alarming level: {}", _usedBytes, config.getAlarmingLevel());
+          try {
+            ThrottlingRuntime.onLevelChange("HeapMemoryAlarmingVerbose");
+          } catch (Throwable t) {
+            // best-effort
+          }
           break;
         case Normal:
           LOGGER.info("Heap used bytes: {} drops to safe zone, entering to normal mode", _usedBytes);
+          try {
+            ThrottlingRuntime.onLevelChange("Normal");
+          } catch (Throwable t) {
+            // best-effort
+          }
           break;
         default:
           throw new IllegalStateException("Unsupported triggering level: " + _triggeringLevel);

--- a/pinot-core/src/main/java/org/apache/pinot/core/accounting/ResourceUsageAccountantFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/accounting/ResourceUsageAccountantFactory.java
@@ -26,6 +26,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicReference;
+import org.apache.pinot.core.query.scheduler.ThrottlingRuntime;
 import org.apache.pinot.spi.accounting.QueryResourceTracker;
 import org.apache.pinot.spi.accounting.ThreadAccountant;
 import org.apache.pinot.spi.accounting.ThreadAccountantFactory;
@@ -310,6 +311,13 @@ public class ResourceUsageAccountantFactory implements ThreadAccountantFactory {
             new QueryMonitorConfig(oldConfig, change.getChangedConfigs(), change.getClusterConfigs());
         _queryMonitorConfig.set(newConfig);
         logQueryMonitorConfig(newConfig);
+
+        // Apply throttling-related settings, if present
+        try {
+          ThrottlingRuntime.applyClusterConfig(change.getClusterConfigs());
+        } catch (Exception e) {
+          LOGGER.warn("Failed to apply throttling runtime config updates", e);
+        }
       }
 
       private void logQueryMonitorConfig(QueryMonitorConfig queryMonitorConfig) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/PriorityScheduler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/PriorityScheduler.java
@@ -115,8 +115,11 @@ public abstract class PriorityScheduler extends QueryScheduler {
             break;
           }
           try {
+            // Global runtime throttling gate: optional pause/limit of inflight queries
+            ThrottlingRuntime.acquireSchedulerPermit();
             SchedulerQueryContext request = _queryQueue.take();
             if (request == null) {
+              ThrottlingRuntime.releaseSchedulerPermit();
               continue;
             }
             ServerQueryRequest queryRequest = request.getQueryRequest();
@@ -129,6 +132,7 @@ public abstract class PriorityScheduler extends QueryScheduler {
                 executorService.releaseWorkers();
                 schedulerGroup.endQuery();
                 _runningQueriesSemaphore.release();
+                ThrottlingRuntime.releaseSchedulerPermit();
                 checkStopResourceManager();
                 if (!_isRunning && _runningQueriesSemaphore.availablePermits() == _numRunners) {
                   _resourceManager.stop();

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/QueryScheduler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/QueryScheduler.java
@@ -92,6 +92,13 @@ public abstract class QueryScheduler {
   /// Start query scheduler thread
   public void start() {
     _isRunning = true;
+    // Initialize global throttling default concurrency from the number of query runner threads
+    try {
+      ThrottlingRuntime.setDefaultConcurrency(_resourceManager.getNumQueryRunnerThreads());
+    } catch (Throwable t) {
+      // Be defensive: throttling is best-effort and should not block startup
+      LOGGER.debug("Failed to initialize ThrottlingRuntime default concurrency.", t);
+    }
   }
 
   /// stop the scheduler and shutdown services

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/ThrottlingRuntime.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/ThrottlingRuntime.java
@@ -1,0 +1,196 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.scheduler;
+
+import java.util.Map;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Global runtime throttling controller for query runner concurrency.
+ *
+ * This class exposes a dynamic permit gate that schedulers can consult to
+ * limit the number of in-flight queries. The gate can be adjusted at runtime
+ * via cluster configs or by accounting triggers (alarm/critical/panic).
+ *
+ * Keys (under pinot.query.scheduler.* cluster config):
+ * - throttling.pause_on_alarm: boolean (default false)
+ * - throttling.alarm_max_concurrent: int (default 1)
+ * - throttling.normal_max_concurrent: int (default = defaultConcurrency)
+ */
+public final class ThrottlingRuntime {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ThrottlingRuntime.class);
+
+  private static final AtomicInteger DEFAULT_CONCURRENCY = new AtomicInteger(0);
+  private static final AtomicInteger NORMAL_MAX_CONCURRENT = new AtomicInteger(0);
+  private static final AtomicInteger ALARM_MAX_CONCURRENT = new AtomicInteger(1);
+  private static final AtomicBoolean PAUSE_ON_ALARM = new AtomicBoolean(false);
+
+  private static final ConcurrencyController CONTROLLER = new ConcurrencyController();
+
+  private ThrottlingRuntime() {
+  }
+
+  public static void setDefaultConcurrency(int defaultConcurrency) {
+    if (defaultConcurrency <= 0) {
+      return;
+    }
+    if (DEFAULT_CONCURRENCY.get() == 0) {
+      DEFAULT_CONCURRENCY.set(defaultConcurrency);
+      if (NORMAL_MAX_CONCURRENT.get() == 0) {
+        NORMAL_MAX_CONCURRENT.set(defaultConcurrency);
+      }
+      CONTROLLER.updateLimit(NORMAL_MAX_CONCURRENT.get());
+      LOGGER.info("Initialized default scheduler concurrency: {}", defaultConcurrency);
+    }
+  }
+
+  public static void applyClusterConfig(Map<String, String> schedulerScopedConfigs) {
+    // Expect keys without the common prefix (already stripped by caller)
+    // throttling.pause_on_alarm
+    if (schedulerScopedConfigs.containsKey("throttling.pause_on_alarm")) {
+      boolean pause = Boolean.parseBoolean(schedulerScopedConfigs.get("throttling.pause_on_alarm"));
+      PAUSE_ON_ALARM.set(pause);
+      LOGGER.info("Updated throttling.pause_on_alarm -> {}", pause);
+    }
+    // throttling.alarm_max_concurrent
+    if (schedulerScopedConfigs.containsKey("throttling.alarm_max_concurrent")) {
+      try {
+        int v = Integer.parseInt(schedulerScopedConfigs.get("throttling.alarm_max_concurrent"));
+        if (v > 0) {
+          ALARM_MAX_CONCURRENT.set(v);
+          LOGGER.info("Updated throttling.alarm_max_concurrent -> {}", v);
+        }
+      } catch (Exception e) {
+        LOGGER.warn("Invalid throttling.alarm_max_concurrent: {}",
+            schedulerScopedConfigs.get("throttling.alarm_max_concurrent"), e);
+      }
+    }
+    // throttling.normal_max_concurrent
+    if (schedulerScopedConfigs.containsKey("throttling.normal_max_concurrent")) {
+      try {
+        int v = Integer.parseInt(schedulerScopedConfigs.get("throttling.normal_max_concurrent"));
+        if (v > 0) {
+          NORMAL_MAX_CONCURRENT.set(v);
+          LOGGER.info("Updated throttling.normal_max_concurrent -> {}", v);
+        }
+      } catch (Exception e) {
+        LOGGER.warn("Invalid throttling.normal_max_concurrent: {}",
+            schedulerScopedConfigs.get("throttling.normal_max_concurrent"), e);
+      }
+    }
+  }
+
+  public static void onLevelChange(String levelName) {
+    // Normalize
+    String level = levelName == null ? "" : levelName.toUpperCase();
+    switch (level) {
+      case "HEAPMEMORYALARMINGVERBOSE":
+        if (PAUSE_ON_ALARM.get()) {
+          CONTROLLER.updateLimit(Math.max(1, ALARM_MAX_CONCURRENT.get()));
+          LOGGER.debug("Alarm level detected, pausing concurrency to {}", ALARM_MAX_CONCURRENT.get());
+        }
+        break;
+      case "NORMAL":
+        // restore
+        CONTROLLER.updateLimit(Math.max(1, NORMAL_MAX_CONCURRENT.get() > 0 ? NORMAL_MAX_CONCURRENT.get()
+            : DEFAULT_CONCURRENCY.get()));
+        LOGGER.debug("Restored concurrency to normal: {}", NORMAL_MAX_CONCURRENT.get());
+        break;
+      case "HEAPMEMORYCRITICAL":
+      case "HEAPMEMORYPANIC":
+      case "CPUTIMEBASEDKILLING":
+      default:
+        // Leave concurrency as-is; killing strategies already act elsewhere
+        break;
+    }
+  }
+
+  public static void acquireSchedulerPermit() {
+    CONTROLLER.acquire();
+  }
+
+  public static void releaseSchedulerPermit() {
+    CONTROLLER.release();
+  }
+
+  public static boolean isPauseOnAlarm() {
+    return PAUSE_ON_ALARM.get();
+  }
+
+  public static int getAlarmMaxConcurrent() {
+    return ALARM_MAX_CONCURRENT.get();
+  }
+
+  public static int getNormalMaxConcurrent() {
+    return NORMAL_MAX_CONCURRENT.get();
+  }
+
+  public static int getDefaultConcurrency() {
+    return DEFAULT_CONCURRENCY.get();
+  }
+
+  public static int getCurrentLimit() {
+    return CONTROLLER.currentLimit();
+  }
+
+  public static void setCurrentLimit(int newLimit) {
+    CONTROLLER.updateLimit(newLimit);
+  }
+
+  private static final class ConcurrencyController {
+    private final Semaphore _semaphore = new Semaphore(0);
+    private final AtomicInteger _limit = new AtomicInteger(0);
+
+    void updateLimit(int newLimit) {
+      if (newLimit <= 0) {
+        return;
+      }
+      int old = _limit.getAndSet(newLimit);
+      int delta = newLimit - old;
+      if (old == 0) {
+        // first init
+        _semaphore.release(newLimit);
+        return;
+      }
+      if (delta > 0) {
+        _semaphore.release(delta);
+      } else if (delta < 0) {
+        // Reduce available permits by acquiring the extra permits. This will block until enough are released.
+        _semaphore.acquireUninterruptibly(-delta);
+      }
+    }
+
+    void acquire() {
+      _semaphore.acquireUninterruptibly(1);
+    }
+
+    void release() {
+      _semaphore.release(1);
+    }
+
+    int currentLimit() {
+      return _limit.get();
+    }
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/fcfs/FCFSQueryScheduler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/fcfs/FCFSQueryScheduler.java
@@ -20,11 +20,13 @@ package org.apache.pinot.core.query.scheduler.fcfs;
 
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.ListenableFutureTask;
+import com.google.common.util.concurrent.MoreExecutors;
 import java.util.concurrent.atomic.LongAccumulator;
 import org.apache.pinot.common.metrics.ServerQueryPhase;
 import org.apache.pinot.core.query.executor.QueryExecutor;
 import org.apache.pinot.core.query.request.ServerQueryRequest;
 import org.apache.pinot.core.query.scheduler.QueryScheduler;
+import org.apache.pinot.core.query.scheduler.ThrottlingRuntime;
 import org.apache.pinot.core.query.scheduler.resources.QueryExecutorService;
 import org.apache.pinot.core.query.scheduler.resources.UnboundedResourceManager;
 import org.apache.pinot.spi.accounting.ThreadAccountant;
@@ -47,9 +49,15 @@ public class FCFSQueryScheduler extends QueryScheduler {
       return shuttingDown(queryRequest);
     }
     queryRequest.getTimerContext().startNewPhaseTimer(ServerQueryPhase.SCHEDULER_WAIT);
+    // Global runtime throttling gate
+    ThrottlingRuntime.acquireSchedulerPermit();
     QueryExecutorService executorService = _resourceManager.getExecutorService(queryRequest, null);
     ListenableFutureTask<byte[]> queryTask = createQueryFutureTask(queryRequest, executorService);
     _resourceManager.getQueryRunners().submit(queryTask);
+    queryTask.addListener(() -> {
+      // nothing else to release here (no scheduler group in FCFS), but ensure we free the global permit
+      ThrottlingRuntime.releaseSchedulerPermit();
+    }, MoreExecutors.directExecutor());
     return queryTask;
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/scheduler/ThrottlingRuntimeTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/scheduler/ThrottlingRuntimeTest.java
@@ -1,0 +1,88 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.scheduler;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+
+public class ThrottlingRuntimeTest {
+
+  @Test
+  public void testInitializationAndUpdate() {
+    ThrottlingRuntime.setDefaultConcurrency(4);
+    assertTrue(ThrottlingRuntime.getDefaultConcurrency() >= 4);
+    assertTrue(ThrottlingRuntime.getCurrentLimit() >= 1);
+
+    Map<String, String> cfg = new HashMap<>();
+    cfg.put("throttling.pause_on_alarm", "true");
+    cfg.put("throttling.alarm_max_concurrent", "1");
+    cfg.put("throttling.normal_max_concurrent", "3");
+    ThrottlingRuntime.applyClusterConfig(cfg);
+    assertTrue(ThrottlingRuntime.isPauseOnAlarm());
+    assertEquals(ThrottlingRuntime.getAlarmMaxConcurrent(), 1);
+    assertEquals(ThrottlingRuntime.getNormalMaxConcurrent(), 3);
+
+    ThrottlingRuntime.onLevelChange("HeapMemoryAlarmingVerbose");
+    // best effort: gate should be at most 1 in alarm
+    assertTrue(ThrottlingRuntime.getCurrentLimit() >= 1);
+
+    ThrottlingRuntime.onLevelChange("Normal");
+    assertEquals(ThrottlingRuntime.getCurrentLimit(), 3);
+  }
+
+  @Test
+  public void testPermitGate()
+      throws Exception {
+    ThrottlingRuntime.setDefaultConcurrency(2);
+    ThrottlingRuntime.setCurrentLimit(2);
+    CountDownLatch started = new CountDownLatch(2);
+    CountDownLatch done = new CountDownLatch(2);
+
+    Runnable r = () -> {
+      ThrottlingRuntime.acquireSchedulerPermit();
+      try {
+        started.countDown();
+        try {
+          Thread.sleep(100);
+        } catch (InterruptedException ignored) {
+        }
+      } finally {
+        ThrottlingRuntime.releaseSchedulerPermit();
+        done.countDown();
+      }
+    };
+
+    new Thread(r).start();
+    new Thread(r).start();
+
+    assertTrue(started.await(2, TimeUnit.SECONDS));
+
+    // Reduce current limit; should not block until releases
+    ThrottlingRuntime.setCurrentLimit(1);
+    assertEquals(ThrottlingRuntime.getCurrentLimit(), 1);
+    assertTrue(done.await(2, TimeUnit.SECONDS));
+  }
+}

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/ThrottlingResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/ThrottlingResource.java
@@ -1,0 +1,76 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.server.api.resources;
+
+import io.swagger.annotations.Api;
+import io.swagger.annotations.ApiOperation;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
+import java.util.HashMap;
+import java.util.Map;
+import javax.inject.Singleton;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import org.apache.pinot.core.query.scheduler.ThrottlingRuntime;
+
+
+@Singleton
+@Path("/throttling")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+@Api(tags = "throttling")
+public class ThrottlingResource {
+
+  @GET
+  @Path("/state")
+  @ApiOperation(value = "Get current throttling state", notes = "Returns current concurrency limit and config flags")
+  @ApiResponses({@ApiResponse(code = 200, message = "Success"), @ApiResponse(code = 500, message = "Error")})
+  public Response getState() {
+    Map<String, Object> state = new HashMap<>();
+    state.put("pauseOnAlarm", ThrottlingRuntime.isPauseOnAlarm());
+    state.put("alarmMaxConcurrent", ThrottlingRuntime.getAlarmMaxConcurrent());
+    state.put("normalMaxConcurrent", ThrottlingRuntime.getNormalMaxConcurrent());
+    state.put("defaultConcurrency", ThrottlingRuntime.getDefaultConcurrency());
+    state.put("currentConcurrencyLimit", ThrottlingRuntime.getCurrentLimit());
+    return Response.ok(state).build();
+  }
+
+  public static class ConcurrencyUpdate {
+    public int _limit;
+  }
+
+  @POST
+  @Path("/setLimit")
+  @ApiOperation(value = "Set current concurrency limit", notes = "Sets the current scheduler concurrency limit")
+  @ApiResponses({@ApiResponse(code = 200, message = "Success"), @ApiResponse(code = 400, message = "Bad request")})
+  public Response setLimit(ConcurrencyUpdate update) {
+    if (update == null || update._limit <= 0) {
+      return Response.status(Response.Status.BAD_REQUEST).entity("limit must be > 0").build();
+    }
+    ThrottlingRuntime.setCurrentLimit(update._limit);
+    Map<String, Object> result = new HashMap<>();
+    result.put("currentConcurrencyLimit", ThrottlingRuntime.getCurrentLimit());
+    return Response.ok(result).build();
+  }
+}

--- a/pinot-server/src/test/java/org/apache/pinot/server/api/ThrottlingResourceTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/api/ThrottlingResourceTest.java
@@ -1,0 +1,51 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.server.api;
+
+import javax.ws.rs.client.Entity;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+
+public class ThrottlingResourceTest extends BaseResourceTest {
+
+  @Test
+  public void testStateAndSetLimit() {
+    Response r = _webTarget.path("/throttling/state").request().get(Response.class);
+    assertEquals(r.getStatus(), 200);
+    String json = r.readEntity(String.class);
+    assertTrue(json.contains("currentConcurrencyLimit"));
+
+    String body = "{\"_limit\":2}";
+    Response r2 =
+        _webTarget.path("/throttling/setLimit").request().post(Entity.entity(body, MediaType.APPLICATION_JSON));
+    assertEquals(r2.getStatus(), 200);
+    String json2 = r2.readEntity(String.class);
+    assertTrue(json2.contains("currentConcurrencyLimit"));
+
+    String bad = "{\"_limit\":0}";
+    Response r3 =
+        _webTarget.path("/throttling/setLimit").request().post(Entity.entity(bad, MediaType.APPLICATION_JSON));
+    assertEquals(r3.getStatus(), 400);
+  }
+}


### PR DESCRIPTION
**Why**
- Keep servers stable under load (reduce OOM and spike-driven failures)
- Improve user experience by preventing single-query hogging and lowering error rates

**What**
- Global concurrency gate for in-flight queries integrated into FCFS and Priority schedulers
  - Allows pausing/serializing queries (FIFO) or limiting concurrency at runtime
- Level-aware behavior driven by existing accounting thresholds:
  - Alarm: optionally reduce concurrency (e.g., 1 to serialize)
  - Critical: keep existing “kill the most expensive query”
  - Panic: keep existing “kill all in-flight queries”
- Dynamic config updates (live, no restart) for throttling settings under pinot.query.scheduler.*
- Server admin API to inspect and adjust the current concurrency limit on the fly

**Config (live reloaded)**
- `pinot.query.scheduler.throttling.pause_on_alarm`: boolean, default false
- `pinot.query.scheduler.throttling.alarm_max_concurrent`: int, cap during Alarm (e.g., 1)
- `pinot.query.scheduler.throttling.normal_max_concurrent`: int, cap during Normal (defaults to query runner threads)
This complements existing heap-usage queue throttling (unchanged).

**Admin API (server)**
- `GET /throttling/state` → current flags and concurrency limit
- `POST /throttling/setLimit` with body:
```
{ "_limit": 2 }
```

**Design notes**
- New `ThrottlingRuntime` provides a permit gate shared by schedulers
- `QueryResourceAggregator` informs the gate on Alarm/Normal transitions
- `ResourceUsageAccountantFactory` applies `pinot.query.scheduler.*` changes at runtime
- Default behavior unchanged unless config or admin API is used

**Backward compatibility and rollout**
- Opt-in; defaults preserve existing behavior
- Safe to enable gradually via config or admin API
