### PR TITLE
Add JDK 25 support: CI matrix + SecurityManager/AccessController removal

### DIFF
--- a/.github/workflows/pinot_integration_tests.yml
+++ b/.github/workflows/pinot_integration_tests.yml
@@ -56,8 +56,10 @@ jobs:
       fail-fast: false
       matrix:
         testset: [ 1, 2 ]
-        java: [ 21 ]
+        java: [ 21, 25 ]
         distribution: [ "temurin" ]
+    # JDK 25 is experimental due to datasketches-memory 3.0.2 incompatibility
+    continue-on-error: ${{ matrix.java == 25 }}
     name: Pinot Integration Test Set ${{ matrix.testset }} (${{matrix.distribution}}-${{matrix.java}})
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/pinot_quickstart_tests.yml
+++ b/.github/workflows/pinot_quickstart_tests.yml
@@ -55,8 +55,10 @@ jobs:
       # Changed to false in order to improve coverage using unsafe buffers
       fail-fast: false
       matrix:
-        java: [ 21 ]
+        java: [ 21, 25 ]
         distribution: [ "temurin" ]
+    # JDK 25 is experimental due to datasketches-memory 3.0.2 incompatibility
+    continue-on-error: ${{ matrix.java == 25 }}
     name: Pinot Quickstart on JDK ${{ matrix.java }}-${{ matrix.distribution }}
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/pinot_unit_tests.yml
+++ b/.github/workflows/pinot_unit_tests.yml
@@ -91,8 +91,11 @@ jobs:
       fail-fast: false
       matrix:
         testset: [ 1, 2 ]
-        java: [ 21 ]
+        java: [ 21, 25 ]
         distribution: [ "temurin" ]
+    # JDK 25 is experimental due to datasketches-memory 3.0.2 incompatibility
+    # (hardcoded JDK allowlist, see https://github.com/apache/datasketches-memory/issues/270)
+    continue-on-error: ${{ matrix.java == 25 }}
     name: Pinot Unit Test Set ${{ matrix.testset }} (${{matrix.distribution}}-${{matrix.java}})
     steps:
       - uses: actions/checkout@v7

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/NamedThreadFactory.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/NamedThreadFactory.java
@@ -71,8 +71,7 @@ public class NamedThreadFactory implements ThreadFactory {
    * @param daemon if true, creates daemon threads
    */
   public NamedThreadFactory(String threadNamePrefix, boolean daemon) {
-    final SecurityManager s = System.getSecurityManager();
-    _group = (s != null) ? s.getThreadGroup() : Thread.currentThread().getThreadGroup();
+    _group = Thread.currentThread().getThreadGroup();
     _threadNamePrefix =
             String.format(NAME_PATTERN, checkPrefix(threadNamePrefix), THREAD_POOL_NUMBER.getAndIncrement());
     _daemon = daemon;

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkTextMatchQueriesSSQE.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkTextMatchQueriesSSQE.java
@@ -186,9 +186,7 @@ public class BenchmarkTextMatchQueriesSSQE extends BaseQueriesTest {
       private final String _namePrefix;
 
       {
-        @SuppressWarnings("removal")
-        SecurityManager s = System.getSecurityManager();
-        _group = (s != null) ? s.getThreadGroup() : Thread.currentThread().getThreadGroup();
+        _group = Thread.currentThread().getThreadGroup();
         _namePrefix = "thread-";
       }
 

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/memory/CleanerUtil.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/memory/CleanerUtil.java
@@ -24,8 +24,6 @@ import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
-import java.security.AccessController;
-import java.security.PrivilegedAction;
 import java.util.Objects;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -73,7 +71,7 @@ public final class CleanerUtil {
   }
 
   static {
-    final Object hack = AccessController.doPrivileged((PrivilegedAction<Object>) CleanerUtil::unmapHackImpl);
+    final Object hack = unmapHackImpl();
     if (hack instanceof BufferCleaner) {
       CLEANER = (BufferCleaner) hack;
       UNMAP_SUPPORTED = true;
@@ -161,14 +159,12 @@ public final class CleanerUtil {
       if (!unmappableBufferClass.isInstance(buffer)) {
         throw new IllegalArgumentException("buffer is not an instance of " + unmappableBufferClass.getName());
       }
-      final Throwable error = AccessController.doPrivileged((PrivilegedAction<Throwable>) () -> {
-        try {
-          unmapper.invokeExact(buffer);
-          return null;
-        } catch (Throwable t) {
-          return t;
-        }
-      });
+      Throwable error = null;
+      try {
+        unmapper.invokeExact(buffer);
+      } catch (Throwable t) {
+        error = t;
+      }
       if (error != null) {
         throw new IOException("Unable to unmap the mapped buffer", error);
       }

--- a/pinot-server/src/test/java/org/apache/pinot/server/predownload/PredownloadPredownloadStatusRecorderTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/predownload/PredownloadPredownloadStatusRecorderTest.java
@@ -67,18 +67,12 @@ public class PredownloadPredownloadStatusRecorderTest {
     testFolder.mkdir();
     PredownloadStatusRecorder.setStatusRecordFolder(testFolder.getAbsolutePath());
 
-    SecurityManager originalSecurityManager = System.getSecurityManager();
-    try {
-      ExitHelper.setExitAction(status -> {
-        throw new ExitException(status);
-      });
-      trySucceed(testFolder);
-      tryRetriableFailure(testFolder);
-      tryNonRetriableFailure(testFolder);
-    } finally {
-      // Restore the original SecurityManager
-      System.setSecurityManager(originalSecurityManager);
-    }
+    ExitHelper.setExitAction(status -> {
+      throw new ExitException(status);
+    });
+    trySucceed(testFolder);
+    tryRetriableFailure(testFolder);
+    tryNonRetriableFailure(testFolder);
   }
 
   private void trySucceed(File testFolder) {


### PR DESCRIPTION
## Summary
- Add JDK 25 to GitHub Actions PR test matrix (unit, integration, quickstart)
- Remove `SecurityManager` and `AccessController` usage removed in JDK 25
- Mark JDK 25 jobs as experimental (`continue-on-error`) due to upstream dependency issue

## Changes

### CI Matrix (`pinot_tests.yml`)
- Add JDK 25 (Temurin) to unit test, integration test, and quickstart matrices
- JDK 25 jobs use `continue-on-error: true` — failures won't block CI

### Code Fixes for JDK 25 Compatibility
- **`CleanerUtil.java`**: Remove `AccessController.doPrivileged()` — Security Manager removed in JDK 25 (JEP 486)
- **`NamedThreadFactory.java`**: Replace `System.getSecurityManager().getThreadGroup()` with `Thread.currentThread().getThreadGroup()`
- **`BenchmarkTextMatchQueriesSSQE.java`**: Same SecurityManager fix
- **`PredownloadPredownloadStatusRecorderTest.java`**: Remove `System.setSecurityManager()` save/restore

## Known Limitation: DataSketches
`datasketches-memory 3.0.2` (transitive dep of `datasketches-java 6.2.0`) has a hardcoded JDK allowlist (`8, 11, 17, 21`) that rejects JDK 25 with `ExceptionInInitializerError`. This causes ~15 sketch-related test failures on JDK 25. No released `datasketches-memory` version supports JDK 25:
- 3.0.3 fix merged upstream but not released ([datasketches-memory#270](https://github.com/apache/datasketches-memory/issues/270))
- 4.1.0 only allows JDK 17
- 5.0.0/6.0.0 use `--enable-preview` (incompatible with `--release 11`)

Once `datasketches-memory 3.0.3` is released, the `continue-on-error` can be removed.

## Test Results (Run 1 — before datasketches workaround)
| Job | JDK 11 | JDK 21 | JDK 25 |
|---|---|---|---|
| Quickstart | ✅ | ✅ | ✅ |
| Unit Test Set 1 | ✅ | ✅ | ❌ 3 sketch tests |
| Unit Test Set 2 | ✅ | ✅ | ❌ 10 sketch tests |
| Integration Test Set 1 | ✅ | ✅ | ❌ 4 sketch + 1 flake |
| Integration Test Set 2 | ✅ | ✅ | ✅ |
| Linter | ✅ | — | — |
| Compat Regression | ✅ | — | — |

All non-sketch Pinot code works on JDK 25.