### PR TITLE
Fix: Handle kafka topic not found exception in fetchPartitionCount fu…

### DIFF
--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamMetadataProvider.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamMetadataProvider.java
@@ -92,9 +92,11 @@ public interface StreamMetadataProvider extends Closeable {
     try {
       partitionCount = fetchPartitionCount(timeoutMillis);
     } catch (Exception e) {
-      LOGGER.warn("Failed to fetch partition count for stream config: {}. Skipping stream and using"
-      + "existing partitions only. Error: {}", streamConfig.getTopicName(), e.getMessage(), e);
+      LOGGER.warn("Failed to fetch partition count for stream config: {}. Skipping stream and using existing partitions only. Error: {}", streamConfig.getTopicName(), e.getMessage(), e);
       // Return only the existing partition groups if we can't fetch partition count
+      // Add a PartitionGroupMetadata into the list, foreach partition already present in current.
+      // Setting endOffset (exclusive) as the startOffset for new partition group.
+      // If partition group is still in progress, this value will be null
       List<PartitionGroupMetadata> existingPartitionGroupMetadataList =
       new ArrayList<>(partitionGroupConsumptionStatuses.size());
       for (PartitionGroupConsumptionStatus currentPartitionGroupConsumptionStatus : partitionGroupConsumptionStatuses) {

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/stream/StreamMetadataProviderTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/stream/StreamMetadataProviderTest.java
@@ -1,0 +1,200 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.stream;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeoutException;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+
+/**
+ * Unit tests for StreamMetadataProvider interface, specifically testing exception handling
+ * in the computePartitionGroupMetadata method.
+ */
+public class StreamMetadataProviderTest {
+
+  private static final String CLIENT_ID = "test-client";
+  private static final int TIMEOUT_MILLIS = 5000;
+  private static final String TOPIC_NAME = "test-topic";
+
+  @Mock
+  private StreamConfig _streamConfig;
+
+  @BeforeMethod
+  public void setUp() {
+    MockitoAnnotations.openMocks(this);
+
+    // Set up stream config mock
+    when(_streamConfig.getTopicName()).thenReturn(TOPIC_NAME);
+  }
+
+  @Test
+  public void testComputePartitionGroupMetadataWithFetchPartitionCountException() throws Exception {
+    // Create existing partition group consumption statuses
+    List<PartitionGroupConsumptionStatus> existingStatuses = createExistingPartitionStatuses();
+
+    // Create a StreamMetadataProvider that throws exception on fetchPartitionCount
+    StreamMetadataProvider provider = new TestStreamMetadataProviderWithException();
+
+    // Call computePartitionGroupMetadata
+    List<PartitionGroupMetadata> result = provider.computePartitionGroupMetadata(
+        CLIENT_ID, _streamConfig, existingStatuses, TIMEOUT_MILLIS);
+
+    // Verify that the method returns existing partitions only
+    Assert.assertEquals(result.size(), existingStatuses.size());
+
+    // Verify that the returned metadata matches the existing statuses
+    for (int i = 0; i < result.size(); i++) {
+      PartitionGroupMetadata metadata = result.get(i);
+      PartitionGroupConsumptionStatus status = existingStatuses.get(i);
+
+      Assert.assertEquals(metadata.getPartitionGroupId(), status.getStreamPartitionGroupId());
+      Assert.assertEquals(metadata.getStartOffset(), status.getEndOffset());
+    }
+  }
+
+  @Test
+  public void testComputePartitionGroupMetadataWithEmptyExistingStatuses() throws Exception {
+    // Test with empty existing partition statuses
+    List<PartitionGroupConsumptionStatus> emptyStatuses = new ArrayList<>();
+
+    StreamMetadataProvider provider = new TestStreamMetadataProviderWithException();
+
+    List<PartitionGroupMetadata> result = provider.computePartitionGroupMetadata(
+        CLIENT_ID, _streamConfig, emptyStatuses, TIMEOUT_MILLIS);
+
+    // Should return empty list when no existing partitions and fetchPartitionCount fails
+    Assert.assertEquals(result.size(), 0);
+  }
+
+  @Test
+  public void testComputePartitionGroupMetadataWithDifferentExceptionTypes() throws Exception {
+    List<PartitionGroupConsumptionStatus> existingStatuses = createExistingPartitionStatuses();
+
+    // Test with RuntimeException
+    StreamMetadataProvider providerWithRuntimeException = new StreamMetadataProvider() {
+      @Override
+      public int fetchPartitionCount(long timeoutMillis) {
+        throw new RuntimeException("Connection failed");
+      }
+
+      @Override
+      public StreamPartitionMsgOffset fetchStreamPartitionOffset(OffsetCriteria offsetCriteria, long timeoutMillis)
+          throws TimeoutException {
+        return mock(StreamPartitionMsgOffset.class);
+      }
+
+      @Override
+      public boolean supportsOffsetLag() {
+        return true;
+      }
+
+      @Override
+      public void close() throws IOException {
+      }
+    };
+
+    List<PartitionGroupMetadata> result = providerWithRuntimeException.computePartitionGroupMetadata(
+        CLIENT_ID, _streamConfig, existingStatuses, TIMEOUT_MILLIS);
+
+    Assert.assertEquals(result.size(), existingStatuses.size());
+
+    // Test with TimeoutException
+    StreamMetadataProvider providerWithTimeoutException = new StreamMetadataProvider() {
+      @Override
+      public int fetchPartitionCount(long timeoutMillis) {
+        throw new RuntimeException(new TimeoutException("Timeout occurred"));
+      }
+
+      @Override
+      public StreamPartitionMsgOffset fetchStreamPartitionOffset(OffsetCriteria offsetCriteria, long timeoutMillis)
+          throws TimeoutException {
+        return mock(StreamPartitionMsgOffset.class);
+      }
+
+      @Override
+      public boolean supportsOffsetLag() {
+        return true;
+      }
+
+      @Override
+      public void close() throws IOException {
+      }
+    };
+
+    result = providerWithTimeoutException.computePartitionGroupMetadata(
+        CLIENT_ID, _streamConfig, existingStatuses, TIMEOUT_MILLIS);
+
+    Assert.assertEquals(result.size(), existingStatuses.size());
+  }
+
+  /**
+   * Creates a list of existing partition group consumption statuses for testing
+   */
+  private List<PartitionGroupConsumptionStatus> createExistingPartitionStatuses() {
+    List<PartitionGroupConsumptionStatus> statuses = new ArrayList<>();
+
+    // Create mock offset
+    StreamPartitionMsgOffset mockOffset1 = mock(StreamPartitionMsgOffset.class);
+    StreamPartitionMsgOffset mockOffset2 = mock(StreamPartitionMsgOffset.class);
+
+    statuses.add(new PartitionGroupConsumptionStatus(0, 1, mockOffset1, mockOffset1, "CONSUMING"));
+    statuses.add(new PartitionGroupConsumptionStatus(1, 2, mockOffset2, mockOffset2, "CONSUMING"));
+
+    return statuses;
+  }
+
+  /**
+   * Test implementation of StreamMetadataProvider that throws an exception
+   * when fetchPartitionCount is called
+   */
+  private static class TestStreamMetadataProviderWithException implements StreamMetadataProvider {
+
+    @Override
+    public int fetchPartitionCount(long timeoutMillis) {
+      throw new RuntimeException("Simulated partition count fetch failure");
+    }
+
+    @Override
+    public StreamPartitionMsgOffset fetchStreamPartitionOffset(OffsetCriteria offsetCriteria, long timeoutMillis)
+        throws TimeoutException {
+      // This should not be called in the exception scenario
+      return mock(StreamPartitionMsgOffset.class);
+    }
+
+    @Override
+    public boolean supportsOffsetLag() {
+      return true;
+    }
+
+    @Override
+    public void close() throws IOException {
+      // No-op for test
+    }
+  }
+}


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

When fetchPartitionCount throws an exception, the method logs a warning and returns existing partition groups, allowing other topics to continue ingesting\.

```mermaid
flowchart TD
  N0["fetchPartitionCount#40;timeoutMillis#41; #40;F1#41;"]:::stModified
  N1["Exception thrown by fetchPartitionCount #40;F1#41;"]:::stModified
  N2["Log warning with topic and error #40;F1#41;"]:::stModified
  N3["Build existing partition group list from statuses #40;F1#41;"]:::stModified
  N4["Return existing partition groups #40;F1#41;"]:::stModified
  N5["Continue normal processing #40;new partition groups#41; #40;F1#41;"]:::stModified
  N0 -->|"throws"| N1
  N0 -->|"success"| N5
  N1 -->|"caught"| N2
  N2 -->|"then"| N3
  N3 -->|"then"| N4
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-spi/src/main/java/org/apache/pinot/spi/stream/StreamMetadataProvider\.java — [before](https://github.com/apache/pinot/blob/51632a51ff515b4cd84b226fca49a7b81b3884db/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamMetadataProvider.java) · [after](https://github.com/apache/pinot/blob/9999d5eab8dabe68d00126ec61aa893bf590cb24/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamMetadataProvider.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjUxNjMyYTUxZmY1MTViNGNkODRiMjI2ZmNhNDlhN2I4MWIzODg0ZGIiLCJjb250ZXh0X2hhc2giOiJhMzhlMDhhOGM5ZDEyNjA4NDI2ZDUzNWMyMzY5ZTI1YzMzNmRiNjIxZDQzNTNkNTUwNTNkMjY4MGExYjU3N2U4IiwiZ2VuZXJhdGVkX2F0IjoxNzg5NjA3MTE0LCJoZWFkX3NoYSI6Ijk5OTlkNWVhYjhkYWJlNjhkMDAxMjZlYzYxYWE4OTNiZjU5MGNiMjQiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiI1MTYzMmE1MWZmNTE1YjRjZDg0YjIyNmZjYTQ5YTdiODFiMzg4NGRiIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 82dc1e4bbb692bb944712527b7a13bc452ad066a72db674fa68b00b1fdee1393 -->
<!-- pinot-pr-flow:end -->

Summary

Resolves Issue  [17045](https://github.com/apache/pinot/issues/17045)

This PR fixes an issue where an exception in fetchPartitionCount, often caused by a deleted topic, would halt ingestion for an entire multi-topic table. By catching this exception, the failure is now isolated. Partitions for the deleted topic will get stuck in a "consuming" state, but ingestion from all other valid topics will continue unaffected.  


Testing

Tested on a pinot table. Validated single incorrect topic doesn't stop table ingestion completely. This table contains 2 topics - adaptive-authn-gateway & adaptive-authn-gatewy. adaptive-authn-gatewy is a invalid kafka topic.

<img width="1896" height="847" alt="Screenshot 2025-10-27 at 10 03 23 AM" src="https://github.com/user-attachments/assets/86a113b4-1018-4391-8d53-cf9ffd740ca2" />
<img width="1637" height="879" alt="Screenshot 2025-10-27 at 10 03 37 AM" src="https://github.com/user-attachments/assets/e48b80af-32cf-4ddf-8d22-bf6da26aada0" />

Validated logs are still getting ingested for adaptive-authn-gateway. 
<img width="941" height="705" alt="Screenshot 2025-10-28 at 4 23 06 PM" src="https://github.com/user-attachments/assets/460b2fa0-2d35-451e-b556-afcc425507c8" />

Warning message is logged for topic - adaptive-authn-gatewy
<img width="747" height="388" alt="Screenshot 2025-10-28 at 4 28 00 PM" src="https://github.com/user-attachments/assets/17c3089c-6d89-45e6-bb88-89d9116a90a0" />
