### PR TITLE
Cleanup deprecated preferred replicas for routing query option

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerMetrics.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerMetrics.java
@@ -92,9 +92,7 @@ public class BrokerMetrics extends AbstractMetrics<BrokerQueryPhase, BrokerMeter
     if (queryOption == null) {
       return PREFERRED_POOL_UNSET_TAG;
     }
-    // backward compatibility to check ORDERED_PREFERRED_REPLICAS here
-    return (queryOption.containsKey(CommonConstants.Broker.Request.QueryOptionKey.ORDERED_PREFERRED_POOLS)
-            || queryOption.containsKey(CommonConstants.Broker.Request.QueryOptionKey.ORDERED_PREFERRED_REPLICAS))
+    return queryOption.containsKey(CommonConstants.Broker.Request.QueryOptionKey.ORDERED_PREFERRED_POOLS)
         ? PREFERRED_POOL_SET_TAG : PREFERRED_POOL_UNSET_TAG;
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
@@ -235,10 +235,6 @@ public class QueryOptionsUtils {
   public static List<Integer> getOrderedPreferredPools(Map<String, String> queryOptions) {
     String orderedPreferredPools = queryOptions.get(QueryOptionKey.ORDERED_PREFERRED_POOLS);
     if (StringUtils.isEmpty(orderedPreferredPools)) {
-      // backward compatibility
-      orderedPreferredPools = queryOptions.get(QueryOptionKey.ORDERED_PREFERRED_REPLICAS);
-    }
-    if (StringUtils.isEmpty(orderedPreferredPools)) {
       return Collections.emptyList();
     }
     // cannot use comma as the delimiter of pool list

--- a/pinot-common/src/test/java/org/apache/pinot/common/metrics/BrokerMetricsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/metrics/BrokerMetricsTest.java
@@ -52,11 +52,5 @@ public class BrokerMetricsTest {
     queryOptionWithPreferredPool.put("orderedPreferredPools", "0");
     assertEquals(BrokerMetrics.getTagForPreferredPool(queryOptionWithPreferredPool), "preferredPoolOptSet",
         "Should return preferredPoolOptSet when queryOption contains ORDERED_PREFERRED_POOLS");
-
-    // Test case 5: queryOption contains ORDERED_PREFERRED_REPLICAS
-    Map<String, String> queryOptionWithPreferredGroup = new HashMap<>();
-    queryOptionWithPreferredGroup.put("orderedPreferredReplicas", "0");
-    assertEquals(BrokerMetrics.getTagForPreferredPool(queryOptionWithPreferredGroup), "preferredPoolOptSet",
-        "Should return preferredPoolOptSet when queryOption contains ORDERED_PREFERRED_POOLS");
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -662,9 +662,6 @@ public class CommonConstants {
         public static final String CHUNK_SIZE_EXTRACT_FINAL_RESULT = "chunkSizeExtractFinalResult";
 
         public static final String NUM_REPLICA_GROUPS_TO_QUERY = "numReplicaGroupsToQuery";
-
-        @Deprecated
-        public static final String ORDERED_PREFERRED_REPLICAS = "orderedPreferredReplicas";
         public static final String ORDERED_PREFERRED_POOLS = "orderedPreferredPools";
         public static final String USE_FIXED_REPLICA = "useFixedReplica";
         public static final String EXPLAIN_PLAN_VERBOSE = "explainPlanVerbose";


### PR DESCRIPTION
- See history in https://github.com/apache/pinot/pull/15203#discussion_r2140629165 and https://github.com/apache/pinot/pull/16104.
- This needs to be cleaned up to avoid any confusion in the future if / when we introduce an actual replica group based routing strategy (i.e., using user specified replica groups to route queries to instead of computing RG definitions on the fly based on the ideal state like `ReplicaGroupInstanceSelector` currently does).