### PR TITLE
[BugFix] fix pinot-driver brokercache permission

### DIFF
--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/utils/DriverUtils.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/utils/DriverUtils.java
@@ -58,6 +58,7 @@ public class DriverUtils {
   public static final String USER_PROPERTY = "user";
   public static final String PASSWORD_PROPERTY = "password";
   public static final String AUTH_HEADER = "Authorization";
+  public static final String AUTH_HEADER_CONFIG_KEY = "headers.Authorization";
 
   private DriverUtils() {
   }
@@ -80,6 +81,7 @@ public class DriverUtils {
       }
       String authToken = BasicAuthUtils.toBasicAuthToken(username, password);
       headers.put(AUTH_HEADER, authToken);
+      info.setProperty(AUTH_HEADER_CONFIG_KEY, authToken);
     }
     for (Object key : info.keySet()) {
       if (key.toString().equalsIgnoreCase(AUTH_HEADER)) {


### PR DESCRIPTION
When we use Properties as parameters to get a Pinot connection, everything works fine.
However, when we try to connect using user and password directly, the BrokerCache throws an exception.
After troubleshooting, I found that the authentication information is not being pushed down to the BrokerCache.
So I added the auth token to the connection info so that it can be propagated to the BrokerCache.
```
-- ok
Connection connection = DriverManager.getConnection(DB_URL, connectionProperties);
-- error
Connection conn = DriverManager.getConnection(DB_URL, "test", "test");
```

<img width="589" height="73" alt="image" src="https://github.com/user-attachments/assets/966a81aa-bd6c-432c-9a02-fc454c0c8ae1" />
<img width="871" height="243" alt="image" src="https://github.com/user-attachments/assets/22e3099f-54aa-4a2d-a30b-c3bb1ecdc766" />
