### PR TITLE
Correct typos in code comments across multiple Java files

### DIFF
--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/IdealStateGroupCommitTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/IdealStateGroupCommitTest.java
@@ -117,7 +117,7 @@ public class IdealStateGroupCommitTest {
       long idealStateUpdateSuccessCount =
           controllerMetrics.getMeteredTableValue(tableName, ControllerMeter.IDEAL_STATE_UPDATE_SUCCESS).count();
       Assert.assertTrue(idealStateUpdateSuccessCount <= NUM_UPDATES);
-      LOGGER.info("{} IdealState update are successfully commited with {} times zk updates.", NUM_UPDATES,
+      LOGGER.info("{} IdealState update are successfully committed with {} times zk updates.", NUM_UPDATES,
           idealStateUpdateSuccessCount);
     }
   }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/util/ListenerConfigUtilTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/util/ListenerConfigUtilTest.java
@@ -101,7 +101,7 @@ public class ListenerConfigUtilTest {
   }
 
   /**
-   * Asserts that controller.port can be opt-out and both http and https can be configured with seperate ports.
+   * Asserts that controller.port can be opt-out and both http and https can be configured with separate ports.
    */
   @Test
   public void testHttpAndHttpsConfigs() {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ItemTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ItemTransformFunction.java
@@ -70,8 +70,8 @@ public class ItemTransformFunction extends BaseTransformFunction {
         + "must be a string literal");
     _keyPath = new String[]{_column, _key};
 
-    // The metadata about the values that this operation will resolve to is determined by the type of teh data
-    // under they key, not by the Map column.  So we need to look up the Key's Metadata.
+    // The metadata about the values that this operation will resolve to is determined by the type of the data
+    // under the key, not by the Map column.  So we need to look up the Key's Metadata.
     DataSource dataSource = columnContextMap.get(_column).getDataSource();
 
     if (dataSource instanceof MapDataSource) {

--- a/pinot-core/src/test/java/org/apache/pinot/queries/ExplainPlanQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/ExplainPlanQueriesTest.java
@@ -1786,7 +1786,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     result1.add(new Object[]{"AGGREGATE_NO_SCAN", 3, 2});
     check(query1, new ResultTable(DATA_SCHEMA, result1));
 
-    // No scan required as metadata is sufficient to answer teh query for all segments
+    // No scan required as metadata is sufficient to answer the query for all segments
     String query2 = "EXPLAIN PLAN FOR SELECT min(invertedIndexCol1) FROM testTable";
     List<Object[]> result2 = new ArrayList<>();
     result2.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
@@ -1898,7 +1898,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     result1.add(new Object[]{"AGGREGATE_NO_SCAN", 3, 2});
     check(query1, new ResultTable(DATA_SCHEMA, result1));
 
-    // No scan required as metadata is sufficient to answer teh query for all segments
+    // No scan required as metadata is sufficient to answer the query for all segments
     String query2 = "SET explainPlanVerbose=true; EXPLAIN PLAN FOR SELECT min(invertedIndexCol1) FROM testTable";
     List<Object[]> result2 = new ArrayList<>();
     result2.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});

--- a/pinot-plugins/pinot-file-system/pinot-adls/src/main/java/org/apache/pinot/plugin/filesystem/ADLSGen2PinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-adls/src/main/java/org/apache/pinot/plugin/filesystem/ADLSGen2PinotFS.java
@@ -396,7 +396,7 @@ public class ADLSGen2PinotFS extends BasePinotFS {
   /**
    * Checks if the file exists at a given location
    *
-   * @param fileUri location to check the existance of the file.
+   * @param fileUri location to check the existence of the file.
    * @return true if exists else false.
    */
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/readerwriter/impl/FixedByteSingleValueMultiColumnReaderWriter.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/readerwriter/impl/FixedByteSingleValueMultiColumnReaderWriter.java
@@ -186,7 +186,7 @@ public class FixedByteSingleValueMultiColumnReaderWriter implements Closeable {
 
     FixedByteSingleValueMultiColReader reader =
         new FixedByteSingleValueMultiColReader(buffer, _numRowsPerChunk, _columnSizesInBytes);
-    // ArrayList is non-threadsafe. So add to a new copy and then change teh reference (_readers is volatile).
+    // ArrayList is non-threadsafe. So add to a new copy and then change the reference (_readers is volatile).
     List<FixedByteSingleValueMultiColReader> readers = new ArrayList<>(_readers);
     readers.add(reader);
     _readers = readers;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/nativefst/automaton/RegExp.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/nativefst/automaton/RegExp.java
@@ -82,7 +82,7 @@ public class RegExp {
    * Constructs new <code>RegExp</code> from a string.
    * Same as <code>RegExp(s, ALL)</code>.
    * @param inputString regexp string
-   * @exception IllegalArgumentException if an error occured while parsing the regular expression
+   * @exception IllegalArgumentException if an error occurred while parsing the regular expression
    */
   public RegExp(String inputString)
       throws IllegalArgumentException {
@@ -93,7 +93,7 @@ public class RegExp {
    * Constructs new <code>RegExp</code> from a string.
    * @param inputString regexp string
    * @param syntaxFlags boolean 'or' of optional syntax constructs to be enabled
-   * @exception IllegalArgumentException if an error occured while parsing the regular expression
+   * @exception IllegalArgumentException if an error occurred while parsing the regular expression
    */
   public RegExp(String inputString, int syntaxFlags)
       throws IllegalArgumentException {


### PR DESCRIPTION
__Fixed Files:__

1. __pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/readerwriter/impl/FixedByteSingleValueMultiColumnReaderWriter.java__

   - Line 185: Fixed "teh" → "the" in comment about ArrayList reference

2. __pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ItemTransformFunction.java__

   - Line 68: Fixed "teh" → "the" in comment about data type
   - Line 68: Fixed "they key" → "the key" in the same comment

3. __pinot-core/src/test/java/org/apache/pinot/queries/ExplainPlanQueriesTest.java__

   - Line 1003: Fixed "teh" → "the" in comment about metadata
   - Line 1038: Fixed "teh" → "the" in comment about metadata (verbose version)
