### PR TITLE
Fix common typos in comments, method names, and variable names

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
@@ -595,7 +595,7 @@ public class StringFunctions {
    * @see StringUtils#repeat(String, String, int)
    * @param input
    * @param times
-   * @return concatenate the string to itself specified number of times with specified seperator
+   * @return concatenate the string to itself specified number of times with specified separator
    */
   @ScalarFunction
   public static String repeat(String input, String sep, int times) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/realtime/provisioning/MemoryEstimator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/realtime/provisioning/MemoryEstimator.java
@@ -148,7 +148,7 @@ public class MemoryEstimator {
     File statsFile = new File(_workingDir, STATS_FILE_NAME);
     RealtimeSegmentStatsHistory sampleStatsHistory;
     try {
-      sampleStatsHistory = RealtimeSegmentStatsHistory.deserialzeFrom(statsFile);
+      sampleStatsHistory = RealtimeSegmentStatsHistory.deserializeFrom(statsFile);
     } catch (IOException | ClassNotFoundException e) {
       throw new RuntimeException(
           "Exception when deserializing stats history from stats file " + statsFile.getAbsolutePath(), e);
@@ -314,7 +314,7 @@ public class MemoryEstimator {
     FileUtils.copyFile(statsFile, statsFileCopy);
     RealtimeSegmentStatsHistory statsHistory;
     try {
-      statsHistory = RealtimeSegmentStatsHistory.deserialzeFrom(statsFileCopy);
+      statsHistory = RealtimeSegmentStatsHistory.deserializeFrom(statsFileCopy);
     } catch (IOException | ClassNotFoundException e) {
       throw new RuntimeException(
           "Exception when deserializing stats history from stats file " + statsFileCopy.getAbsolutePath(), e);

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -162,7 +162,7 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
     _ingestionDelayTracker = new IngestionDelayTracker(_serverMetrics, _tableNameWithType, this);
     File statsFile = new File(_tableDataDir, STATS_FILE_NAME);
     try {
-      _statsHistory = RealtimeSegmentStatsHistory.deserialzeFrom(statsFile);
+      _statsHistory = RealtimeSegmentStatsHistory.deserializeFrom(statsFile);
     } catch (IOException | ClassNotFoundException e) {
       _logger.error("Caught exception while reading stats history from: {}", statsFile.getAbsolutePath(), e);
       File savedFile = new File(_tableDataDir, STATS_FILE_NAME + "." + UUID.randomUUID());
@@ -175,7 +175,7 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
       _logger.warn("Saved unreadable {} into {}. Creating a fresh instance", statsFile.getAbsolutePath(),
           savedFile.getAbsolutePath());
       try {
-        _statsHistory = RealtimeSegmentStatsHistory.deserialzeFrom(statsFile);
+        _statsHistory = RealtimeSegmentStatsHistory.deserializeFrom(statsFile);
       } catch (Exception e2) {
         Utils.rethrowException(e2);
       }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/ScalarTransformFunctionWrapperTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/ScalarTransformFunctionWrapperTest.java
@@ -337,21 +337,21 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
     }
     testTransformFunction(transformFunction, expectedValues);
 
-    String seperator = "::";
+    String separator = "::";
     expression = RequestContextUtils.getExpression(
-        String.format("repeat(%s, '%s', %d)", STRING_ALPHANUM_SV_COLUMN, seperator, timesToRepeat));
+        String.format("repeat(%s, '%s', %d)", STRING_ALPHANUM_SV_COLUMN, separator, timesToRepeat));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     assertEquals(transformFunction.getName(), "repeat");
     expectedValues = new String[NUM_ROWS];
     for (int i = 0; i < NUM_ROWS; i++) {
-      expectedValues[i] = StringUtils.repeat(_stringAlphaNumericSVValues[i], seperator, timesToRepeat);
+      expectedValues[i] = StringUtils.repeat(_stringAlphaNumericSVValues[i], separator, timesToRepeat);
     }
     testTransformFunction(transformFunction, expectedValues);
 
     timesToRepeat = -1;
     expression = RequestContextUtils.getExpression(
-        String.format("repeat(%s, '%s', %d)", STRING_ALPHANUM_SV_COLUMN, seperator, timesToRepeat));
+        String.format("repeat(%s, '%s', %d)", STRING_ALPHANUM_SV_COLUMN, separator, timesToRepeat));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
     assertEquals(transformFunction.getName(), "repeat");

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/RealtimeSegmentStatsHistory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/RealtimeSegmentStatsHistory.java
@@ -57,7 +57,7 @@ public class RealtimeSegmentStatsHistory implements Serializable {
   // XXX MAX_NUM_ENTRIES should be a final variable, but we need to modify it for testing.
   private static int _maxNumEntries = 16;  // Max number of past segments for which stats are kept
 
-  // Fields to be serialzied.
+  // Fields to be serialized.
   private int _cursor = 0;
   private SegmentStats[] _entries;
   private boolean _isFull = false;
@@ -374,7 +374,7 @@ public class RealtimeSegmentStatsHistory implements Serializable {
     }
   }
 
-  public static synchronized RealtimeSegmentStatsHistory deserialzeFrom(File inFile)
+  public static synchronized RealtimeSegmentStatsHistory deserializeFrom(File inFile)
       throws IOException, ClassNotFoundException {
     if (inFile.exists()) {
       try (FileInputStream is = new FileInputStream(inFile); ObjectInputStream obis = new CustomObjectInputStream(is)) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/writer/StatelessRealtimeSegmentWriter.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/writer/StatelessRealtimeSegmentWriter.java
@@ -177,7 +177,7 @@ public class StatelessRealtimeSegmentWriter implements Closeable {
     // Load stats history, here we are using the same stats while as the RealtimeSegmentDataManager so that we are
     // much more efficient in allocating buffers. It also works with empty file
     File statsHistoryFile = new File(tableDataDir, SEGMENT_STATS_FILE_NAME);
-    RealtimeSegmentStatsHistory statsHistory = RealtimeSegmentStatsHistory.deserialzeFrom(statsHistoryFile);
+    RealtimeSegmentStatsHistory statsHistory = RealtimeSegmentStatsHistory.deserializeFrom(statsHistoryFile);
 
     // Initialize mutable segment with configurations
     RealtimeSegmentConfig.Builder realtimeSegmentConfigBuilder = new RealtimeSegmentConfig.Builder(indexLoadingConfig)

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/nativefst/automaton/RegExp.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/nativefst/automaton/RegExp.java
@@ -82,7 +82,7 @@ public class RegExp {
    * Constructs new <code>RegExp</code> from a string.
    * Same as <code>RegExp(s, ALL)</code>.
    * @param inputString regexp string
-   * @exception IllegalArgumentException if an error occured while parsing the regular expression
+   * @exception IllegalArgumentException if an error occurred while parsing the regular expression
    */
   public RegExp(String inputString)
       throws IllegalArgumentException {
@@ -93,7 +93,7 @@ public class RegExp {
    * Constructs new <code>RegExp</code> from a string.
    * @param inputString regexp string
    * @param syntaxFlags boolean 'or' of optional syntax constructs to be enabled
-   * @exception IllegalArgumentException if an error occured while parsing the regular expression
+   * @exception IllegalArgumentException if an error occurred while parsing the regular expression
    */
   public RegExp(String inputString, int syntaxFlags)
       throws IllegalArgumentException {

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/converter/RealtimeSegmentConverterTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/converter/RealtimeSegmentConverterTest.java
@@ -167,7 +167,7 @@ public class RealtimeSegmentConverterTest implements PinotBuffersAfterMethodChec
             .setIndex(Sets.newHashSet(STRING_COLUMN1), StandardIndexes.inverted(), IndexConfig.ENABLED)
             .setSegmentZKMetadata(getSegmentZKMetadata(segmentName)).setOffHeap(true)
             .setMemoryManager(new DirectMemoryManager(segmentName))
-            .setStatsHistory(RealtimeSegmentStatsHistory.deserialzeFrom(new File(tmpDir, "stats")))
+            .setStatsHistory(RealtimeSegmentStatsHistory.deserializeFrom(new File(tmpDir, "stats")))
             .setConsumerDir(new File(tmpDir, "consumerDir").getAbsolutePath());
 
     // create mutable segment impl
@@ -239,7 +239,7 @@ public class RealtimeSegmentConverterTest implements PinotBuffersAfterMethodChec
             .setIndex(Sets.newHashSet(STRING_COLUMN1, LONG_COLUMN1), StandardIndexes.inverted(), IndexConfig.ENABLED)
             .setSegmentZKMetadata(getSegmentZKMetadata(segmentName)).setOffHeap(true)
             .setMemoryManager(new DirectMemoryManager(segmentName))
-            .setStatsHistory(RealtimeSegmentStatsHistory.deserialzeFrom(new File(tmpDir, "stats")))
+            .setStatsHistory(RealtimeSegmentStatsHistory.deserializeFrom(new File(tmpDir, "stats")))
             .setConsumerDir(new File(tmpDir, "consumerDir").getAbsolutePath());
 
     // create mutable segment impl
@@ -319,7 +319,7 @@ public class RealtimeSegmentConverterTest implements PinotBuffersAfterMethodChec
             .setIndex(Sets.newHashSet(STRING_COLUMN1), StandardIndexes.inverted(), IndexConfig.ENABLED)
             .setSegmentZKMetadata(getSegmentZKMetadata(segmentName)).setOffHeap(true)
             .setMemoryManager(new DirectMemoryManager(segmentName))
-            .setStatsHistory(RealtimeSegmentStatsHistory.deserialzeFrom(new File(tmpDir, "stats")))
+            .setStatsHistory(RealtimeSegmentStatsHistory.deserializeFrom(new File(tmpDir, "stats")))
             .setConsumerDir(new File(tmpDir, "consumerDir").getAbsolutePath());
 
     // create mutable segment impl
@@ -391,7 +391,7 @@ public class RealtimeSegmentConverterTest implements PinotBuffersAfterMethodChec
             .setIndex(Sets.newHashSet(STRING_COLUMN1, LONG_COLUMN1), StandardIndexes.inverted(), IndexConfig.ENABLED)
             .setSegmentZKMetadata(getSegmentZKMetadata(segmentName)).setOffHeap(true)
             .setMemoryManager(new DirectMemoryManager(segmentName))
-            .setStatsHistory(RealtimeSegmentStatsHistory.deserialzeFrom(new File(tmpDir, "stats")))
+            .setStatsHistory(RealtimeSegmentStatsHistory.deserializeFrom(new File(tmpDir, "stats")))
             .setConsumerDir(new File(tmpDir, "consumerDir").getAbsolutePath());
 
     // create mutable segment impl
@@ -505,7 +505,7 @@ public class RealtimeSegmentConverterTest implements PinotBuffersAfterMethodChec
                 DictionaryIndexConfig.DEFAULT)
             .setSegmentZKMetadata(getSegmentZKMetadata(segmentName)).setOffHeap(true)
             .setMemoryManager(new DirectMemoryManager(segmentName))
-            .setStatsHistory(RealtimeSegmentStatsHistory.deserialzeFrom(new File(tmpDir, "stats")))
+            .setStatsHistory(RealtimeSegmentStatsHistory.deserializeFrom(new File(tmpDir, "stats")))
             .setConsumerDir(new File(tmpDir, "consumerDir").getAbsolutePath());
 
     // create mutable segment impl
@@ -621,7 +621,7 @@ public class RealtimeSegmentConverterTest implements PinotBuffersAfterMethodChec
             .setIndex(Sets.newHashSet(STRING_COLUMN1), StandardIndexes.dictionary(), dictionaryIndexConfig)
             .setSegmentZKMetadata(getSegmentZKMetadata(segmentName))
             .setOffHeap(true).setMemoryManager(new DirectMemoryManager(segmentName))
-            .setStatsHistory(RealtimeSegmentStatsHistory.deserialzeFrom(new File(tmpDir, "stats")))
+            .setStatsHistory(RealtimeSegmentStatsHistory.deserializeFrom(new File(tmpDir, "stats")))
             .setConsumerDir(new File(tmpDir, "consumerDir").getAbsolutePath());
 
     // create mutable segment impl

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/impl/RealtimeSegmentStatsHistoryTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/impl/RealtimeSegmentStatsHistoryTest.java
@@ -57,7 +57,7 @@ public class RealtimeSegmentStatsHistoryTest {
     String columName = "col1";
 
     {
-      RealtimeSegmentStatsHistory history = RealtimeSegmentStatsHistory.deserialzeFrom(serializedFile);
+      RealtimeSegmentStatsHistory history = RealtimeSegmentStatsHistory.deserializeFrom(serializedFile);
       RealtimeSegmentStatsHistory.SegmentStats segmentStats = new RealtimeSegmentStatsHistory.SegmentStats();
       segmentStats.setMemUsedBytes(100);
       segmentStats.setNumSeconds(101);
@@ -72,7 +72,7 @@ public class RealtimeSegmentStatsHistoryTest {
       history.addSegmentStats(segmentStats);
     }
     {
-      RealtimeSegmentStatsHistory history = RealtimeSegmentStatsHistory.deserialzeFrom(serializedFile);
+      RealtimeSegmentStatsHistory history = RealtimeSegmentStatsHistory.deserializeFrom(serializedFile);
       Assert.assertTrue(history.getEstimatedAvgColSize(columName) > 0);
       Assert.assertTrue(history.getEstimatedCardinality(columName) > 0);
       Assert.assertEquals(history.getEstimatedRowsToIndex(), 103);
@@ -90,7 +90,7 @@ public class RealtimeSegmentStatsHistoryTest {
     int maxNumEntries = RealtimeSegmentStatsHistory.getMaxNumEntries();
     int segmentId = 0;
     {
-      RealtimeSegmentStatsHistory history = RealtimeSegmentStatsHistory.deserialzeFrom(serializedFile);
+      RealtimeSegmentStatsHistory history = RealtimeSegmentStatsHistory.deserializeFrom(serializedFile);
       // We should have got an empty one here.
 
       history.getEstimatedAvgColSize("1");
@@ -113,7 +113,7 @@ public class RealtimeSegmentStatsHistoryTest {
       maxNumEntries += 2;
       RealtimeSegmentStatsHistory.setMaxNumEntries(maxNumEntries);
       // Deserialize
-      RealtimeSegmentStatsHistory history = RealtimeSegmentStatsHistory.deserialzeFrom(serializedFile);
+      RealtimeSegmentStatsHistory history = RealtimeSegmentStatsHistory.deserializeFrom(serializedFile);
       Assert.assertEquals(history.isFull(), false);
       Assert.assertEquals(history.getArraySize(), maxNumEntries);
       Assert.assertEquals(history.getCursor(), prevMax - 1);
@@ -157,7 +157,7 @@ public class RealtimeSegmentStatsHistoryTest {
       maxNumEntries -= 2;
       RealtimeSegmentStatsHistory.setMaxNumEntries(maxNumEntries);
 
-      RealtimeSegmentStatsHistory history = RealtimeSegmentStatsHistory.deserialzeFrom(serializedFile);
+      RealtimeSegmentStatsHistory history = RealtimeSegmentStatsHistory.deserializeFrom(serializedFile);
       Assert.assertEquals(history.isFull(), true);
       Assert.assertEquals(history.getArraySize(), maxNumEntries);
       Assert.assertEquals(history.getCursor(), 0);
@@ -174,7 +174,7 @@ public class RealtimeSegmentStatsHistoryTest {
       maxNumEntries += 2;
       RealtimeSegmentStatsHistory.setMaxNumEntries(maxNumEntries);
 
-      RealtimeSegmentStatsHistory history = RealtimeSegmentStatsHistory.deserialzeFrom(serializedFile);
+      RealtimeSegmentStatsHistory history = RealtimeSegmentStatsHistory.deserializeFrom(serializedFile);
       Assert.assertEquals(history.isFull(), false);
       Assert.assertEquals(history.getArraySize(), maxNumEntries);
       Assert.assertEquals(history.getCursor(), prevMax);
@@ -185,7 +185,7 @@ public class RealtimeSegmentStatsHistoryTest {
     boolean savedIsFull;
     int savedCursor;
     {
-      RealtimeSegmentStatsHistory history = RealtimeSegmentStatsHistory.deserialzeFrom(serializedFile);
+      RealtimeSegmentStatsHistory history = RealtimeSegmentStatsHistory.deserializeFrom(serializedFile);
       Assert.assertEquals(history.getEstimatedAvgColSize("new"), RealtimeSegmentStatsHistory.getDefaultEstAvgColSize());
       Assert
           .assertEquals(history.getEstimatedCardinality("new"), RealtimeSegmentStatsHistory.getDefaultEstCardinality());
@@ -193,7 +193,7 @@ public class RealtimeSegmentStatsHistoryTest {
       savedCursor = history.getCursor();
     }
     {
-      RealtimeSegmentStatsHistory history = RealtimeSegmentStatsHistory.deserialzeFrom(serializedFile);
+      RealtimeSegmentStatsHistory history = RealtimeSegmentStatsHistory.deserializeFrom(serializedFile);
       Assert.assertEquals(history.isFull(), savedIsFull);
       Assert.assertEquals(history.getCursor(), savedCursor);
     }
@@ -210,7 +210,7 @@ public class RealtimeSegmentStatsHistoryTest {
     File serializedFile = new File(tmpDir, STATS_FILE_NAME);
     FileUtils.deleteQuietly(serializedFile);
     serializedFile.deleteOnExit();
-    RealtimeSegmentStatsHistory statsHistory = RealtimeSegmentStatsHistory.deserialzeFrom(serializedFile);
+    RealtimeSegmentStatsHistory statsHistory = RealtimeSegmentStatsHistory.deserializeFrom(serializedFile);
 
     for (int i = 0; i < numThreads; i++) {
       threads[i] = new Thread(new StatsUpdater(statsHistory, numIterations, avgSleepTimeMs));
@@ -235,7 +235,7 @@ public class RealtimeSegmentStatsHistoryTest {
     File v1StatsFile = new File(
         TestUtils.getFileFromResourceUrl(RealtimeSegmentStatsHistoryTest.class.getClassLoader().getResource("data")),
         fileName);
-    RealtimeSegmentStatsHistory statsHistory = RealtimeSegmentStatsHistory.deserialzeFrom(v1StatsFile);
+    RealtimeSegmentStatsHistory statsHistory = RealtimeSegmentStatsHistory.deserializeFrom(v1StatsFile);
     RealtimeSegmentStatsHistory.SegmentStats segmentStats = statsHistory.getSegmentStatsAt(0);
     RealtimeSegmentStatsHistory.ColumnStats columnStats;
 
@@ -261,7 +261,7 @@ public class RealtimeSegmentStatsHistoryTest {
     FileUtils.deleteQuietly(serializedFile);
     long[] memoryValues = {100, 100, 200, 400, 450, 600};
 
-    RealtimeSegmentStatsHistory history = RealtimeSegmentStatsHistory.deserialzeFrom(serializedFile);
+    RealtimeSegmentStatsHistory history = RealtimeSegmentStatsHistory.deserializeFrom(serializedFile);
     Assert.assertEquals(history.getLatestSegmentMemoryConsumed(), -1);
     RealtimeSegmentStatsHistory.SegmentStats segmentStats = null;
 


### PR DESCRIPTION
## Description
Fixed 4 common typos found throughout the codebase:

1. `serialzied` → `serialized` (comment)
2. `deserialzeFrom` → `deserializeFrom` (method name)
3. `seperator` → `separator` (variable name)  
4. `occured` → `occurred` (comment)
