### PR TITLE
Fix typos in Java codebase

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/FunnelCountAggregationFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/FunnelCountAggregationFunctionFactory.java
@@ -49,7 +49,7 @@ import org.roaringbitmap.RoaringBitmap;
  *  <li>'bitmap' (default): See DISTINCTCOUNTBITMAP at {@link DistinctCountBitmapAggregationFunction}
  *  <li>'theta_sketch': See DISTINCTCOUNTTHETASKETCH at {@link DistinctCountThetaSketchAggregationFunction}
  *  <li>'partitioned': See SEGMENTPARTITIONEDDISTINCTCOUNT {@link SegmentPartitionedDistinctCountAggregationFunction}
- *  <li>'sorted': sorted counts per segment then sums up. Only availabe in combination with 'partitioned'.
+ *  <li>'sorted': sorted counts per segment then sums up. Only available in combination with 'partitioned'.
  *  <li>'nominalEntries=4096': theta sketch configuration, default is 4096.
  *  </ul><p>
  */

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/GapfillUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/GapfillUtils.java
@@ -33,7 +33,7 @@ import org.apache.pinot.core.query.request.context.QueryContext;
 
 
 /**
- * Util class to encapsulate all utilites required for gapfill.
+ * Util class to encapsulate all utilities required for gapfill.
  */
 public class GapfillUtils {
   private static final String GAP_FILL = "gapfill";

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/realtime/ingestion/BaseKinesisIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/realtime/ingestion/BaseKinesisIntegrationTest.java
@@ -176,7 +176,7 @@ abstract class BaseKinesisIntegrationTest extends BaseClusterIntegrationTest {
   @Override
   public TableConfig createRealtimeTableConfig(File sampleAvroFile) {
     // Calls the super class to create the table config.
-    // Properties like stream configs are overriden in the getStreamConfigs() method.
+    // Properties like stream configs are overridden in the getStreamConfigs() method.
     return super.createRealtimeTableConfig(sampleAvroFile);
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/VarByteChunkForwardIndexReaderV4.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/VarByteChunkForwardIndexReaderV4.java
@@ -73,7 +73,7 @@ public class VarByteChunkForwardIndexReaderV4
     _chunkCompressionType = ChunkCompressionType.valueOf(dataBuffer.getInt(8));
     _chunkDecompressor = ChunkCompressorFactory.getDecompressor(_chunkCompressionType);
     int chunksOffset = dataBuffer.getInt(12);
-    // the file has a BE header for compatability reasons (version selection) but the content is LE
+    // the file has a BE header for compatibility reasons (version selection) but the content is LE
     _metadata = dataBuffer.view(16, chunksOffset, ByteOrder.LITTLE_ENDIAN);
     _chunksStartOffset = chunksOffset;
     _chunks = dataBuffer.view(chunksOffset, dataBuffer.size(), ByteOrder.LITTLE_ENDIAN);

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/env/PinotConfigurationTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/env/PinotConfigurationTest.java
@@ -107,16 +107,16 @@ public class PinotConfigurationTest {
   @Test
   public void assertPropertyOverride() {
     PinotConfiguration pinotConfiguration = new PinotConfiguration();
-    pinotConfiguration.setProperty("property.override", "overriden-value");
+    pinotConfiguration.setProperty("property.override", "overridden-value");
 
     pinotConfiguration.containsKey("property.override");
-    Assert.assertEquals(pinotConfiguration.getProperty("property.override"), "overriden-value");
+    Assert.assertEquals(pinotConfiguration.getProperty("property.override"), "overridden-value");
 
     pinotConfiguration = new PinotConfiguration(pinotConfiguration.toMap()).clone().subset("property");
 
-    pinotConfiguration.addProperty("override", "overriden-value-2");
+    pinotConfiguration.addProperty("override", "overridden-value-2");
 
-    Assert.assertEquals(pinotConfiguration.getProperty("override"), "overriden-value,overriden-value-2");
+    Assert.assertEquals(pinotConfiguration.getProperty("override"), "overridden-value,overridden-value-2");
 
     Object object = new Object();
     pinotConfiguration.setProperty("raw-property", object);

--- a/pinot-timeseries/pinot-timeseries-spi/src/main/java/org/apache/pinot/tsdb/spi/TimeSeriesLogicalPlanner.java
+++ b/pinot-timeseries/pinot-timeseries-spi/src/main/java/org/apache/pinot/tsdb/spi/TimeSeriesLogicalPlanner.java
@@ -40,7 +40,7 @@ public interface TimeSeriesLogicalPlanner {
   /**
    * Returns the name of the table from the logical plan result by traversing the plan tree and extracting the
    * table name from the first encountered {@link LeafTimeSeriesPlanNode}
-   * This method is recommended to be overriden by implementations for more efficient table name extraction.
+   * This method is recommended to be overridden by implementations for more efficient table name extraction.
    */
   default String getTableName(TimeSeriesLogicalPlanResult result) {
     BaseTimeSeriesPlanNode node = result.getPlanNode();


### PR DESCRIPTION
## Fixed Typos:

1. __compatability → compatibility__ (1 occurrence)

   - File: `pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/VarByteChunkForwardIndexReaderV4.java`
   - Fixed in comment about dictionary compatibility

2. __overriden → overridden__ (3 occurrences)

   - File: `pinot-spi/src/test/java/org/apache/pinot/spi/env/PinotConfigurationTest.java`
   - File: `pinot-timeseries/pinot-timeseries-spi/src/main/java/org/apache/pinot/tsdb/spi/TimeSeriesLogicalPlanner.java`
   - File: `pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/realtime/ingestion/BaseKinesisIntegrationTest.java`
   - Fixed in comments and documentation about method overriding

3. __availabe → available__ (1 occurrence)

   - File: `pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/FunnelCountAggregationFunctionFactory.java`
   - Fixed in JavaDoc comment about sorted strategy availability

4. __utilites → utilities__ (1 occurrence)

   - File: `pinot-core/src/main/java/org/apache/pinot/core/util/GapfillUtils.java`
   - Fixed in class-level JavaDoc comment
