### PR TITLE
Adding a new property minNumSegmentsPerTask for UpsertCompactMerge task

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
@@ -316,6 +316,18 @@ public class MinionConstants {
      */
     public static final long DEFAULT_MAX_NUM_SEGMENTS_PER_TASK = 10;
 
+    /**
+     * minimum number of segments to process in a single task
+     */
+    public static final String MIN_NUM_SEGMENTS_PER_TASK_KEY = "minNumSegmentsPerTask";
+
+    /**
+     * default minimum number of segments to process in a single task.
+     * Keeping this default to 2 means that we won't run this task if there is only one segment which can be merged.
+     * If this is set to 1, this task can act as UpsertCompact task as well.
+     */
+    public static final long DEFAULT_MIN_NUM_SEGMENTS_PER_TASK = 2;
+
     public static final String MERGED_SEGMENTS_ZK_SUFFIX = ".mergedSegments";
 
     public static final String MAX_ZK_CREATION_TIME_MILLIS_KEY = "maxZKCreationTimeMillis";


### PR DESCRIPTION
This PR introduces a new configurable property `minNumSegmentsPerTask` for the UpsertCompactMerge task, providing users with fine-grained control over segment merging behavior.

## What Changed

- **Added new configuration property**: `minNumSegmentsPerTask` with a default value of 2
- **Enhanced task filtering logic**: Tasks now only execute when the minimum segment threshold is met
- **Maintained backward compatibility**: Default behavior remains unchanged (minimum 2 segments)

## Key Benefits

### 1. **Flexible Task Behavior**
- **Single-segment processing**: Set `minNumSegmentsPerTask=1` to enable UpsertCompactMerge to function as a replacement for UpsertCompaction task
- **Resource optimization**: Set higher values (e.g., 5+) to prevent task execution unless sufficient segments are available for merging

## Configuration

```yaml
# Example table configuration
{
  "tableName": "myTable",
  "taskTypeConfigsMap": {
    "UpsertCompactMergeTask": {
       ...,
      "minNumSegmentsPerTask": "3"  // Only merge when 3+ segments available
    }
  }
}
```