### PR TITLE
Fix bug with COUNT(col) using star-tree index with null handling enabled

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/StarTreeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/StarTreeClusterIntegrationTest.java
@@ -202,6 +202,9 @@ public class StarTreeClusterIntegrationTest extends BaseClusterIntegrationTest {
         + "WHERE CRSDepTime BETWEEN 1137 AND 1849 AND DivArrDelay > 218 AND CRSDepTime NOT IN (35, 1633, 1457, 140) "
         + "AND LongestAddGTime NOT IN (17, 105, 20, 22) GROUP BY DepTimeBlk ORDER BY DepTimeBlk";
     testStarQuery(starQuery, !useMultiStageQueryEngine);
+
+    starQuery = "SET enableNullHandling=true; SELECT COUNT(DivArrDelay) FROM mytable WHERE DivArrDelay > 218";
+    testStarQuery(starQuery, false);
   }
 
   @Test(dataProvider = "useBothQueryEngines")


### PR DESCRIPTION
- Fixes https://github.com/apache/pinot/issues/17105.
- The issue is that the star-tree index is selected [here](https://github.com/apache/pinot/blob/563d8c621a86960ff427aa5c466346e77dc144f6/pinot-core/src/main/java/org/apache/pinot/core/startree/StarTreeUtils.java#L385-L435) (regardless of whether the column has null values or not), but then the aggregation function itself uses the non star-tree index count path [here](https://github.com/apache/pinot/blob/563d8c621a86960ff427aa5c466346e77dc144f6/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/CountAggregationFunction.java#L84-L107).
- The fix here is two-fold: the most important one is to make sure the aggregation function always uses the star-tree index count path when the block val set map contains `STAR_TREE_COUNT_STAR_EXPRESSION`. The other fix is to make sure that the star-tree index isn't used when the aggregation function is `COUNT(col)` and the column actually contains null values. This check was being skipped earlier because [this code path](https://github.com/apache/pinot/blob/563d8c621a86960ff427aa5c466346e77dc144f6/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/startree/AggregationFunctionColumnPair.java#L114-L116) always returns `COUNT(*)` regardless of the actual input expression.