### PR TITLE
Enhanced the close() method with defensive null checks to prevent NullPointerException during resource cleanup

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/readerwriter/impl/FixedByteSingleValueMultiColumnReaderWriter.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/readerwriter/impl/FixedByteSingleValueMultiColumnReaderWriter.java
@@ -150,11 +150,19 @@ public class FixedByteSingleValueMultiColumnReaderWriter implements Closeable {
   @Override
   public void close()
       throws IOException {
-    for (FixedByteSingleValueMultiColWriter writer : _writers) {
-      writer.close();
+    if (_writers != null) {
+      for (FixedByteSingleValueMultiColWriter writer : _writers) {
+        if (writer != null) {
+          writer.close();
+        }
+      }
     }
-    for (FixedByteSingleValueMultiColReader reader : _readers) {
-      reader.close();
+    if (_readers != null) {
+      for (FixedByteSingleValueMultiColReader reader : _readers) {
+        if (reader != null) {
+          reader.close();
+        }
+      }
     }
   }
 


### PR DESCRIPTION
### File Modified: `FixedByteSingleValueMultiColumnReaderWriter.java`

__Location__: `pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/readerwriter/impl/FixedByteSingleValueMultiColumnReaderWriter.java`

__Improvement__: Enhanced the `close()` method with defensive null checks to prevent NullPointerException during resource cleanup.

__Before__:

```java
@Override
public void close() throws IOException {
  for (FixedByteSingleValueMultiColWriter writer : _writers) {
    writer.close();
  }
  for (FixedByteSingleValueMultiColReader reader : _readers) {
    reader.close();
  }
}
```

__After__:

```java
@Override
public void close() throws IOException {
  if (_writers != null) {
    for (FixedByteSingleValueMultiColWriter writer : _writers) {
      if (writer != null) {
        writer.close();
      }
    }
  }
  if (_readers != null) {
    for (FixedByteSingleValueMultiColReader reader : _readers) {
      if (reader != null) {
        reader.close();
      }
    }
  }
}
```

## Impact

✅ __Prevents NullPointerException__ during resource cleanup\
✅ __Improves robustness__ of the close() method\
✅ __Follows defensive programming best practices__\
✅ __No functional changes__ to normal operation\
✅ __Low risk__ - purely defensive improvement
