### PR TITLE
Add consuming segment check for retention check

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/retention/strategy/TimeRetentionStrategy.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/retention/strategy/TimeRetentionStrategy.java
@@ -39,6 +39,13 @@ public class TimeRetentionStrategy implements RetentionStrategy {
 
   @Override
   public boolean isPurgeable(String tableNameWithType, SegmentZKMetadata segmentZKMetadata) {
+
+    // For realtime tables, only completed segments(DONE or UPLOADED) are eligible for purging.
+    //For offline tables, status defaults to UPLOADED which is completed, so they proceed to normal retention
+    if (!segmentZKMetadata.getStatus().isCompleted()) {
+      return false; // Incomplete segments don't have final end time and should not be purged
+    }
+
     return isPurgeable(tableNameWithType, segmentZKMetadata.getSegmentName(), segmentZKMetadata.getEndTimeMs());
   }
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/retention/RetentionManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/retention/RetentionManagerTest.java
@@ -833,6 +833,7 @@ public class RetentionManagerTest {
     when(segmentZKMetadata.getCreationTime()).thenReturn(creationTime);
     when(segmentZKMetadata.getStartTimeMs()).thenReturn(timeUnit.toMillis(startTime));
     when(segmentZKMetadata.getEndTimeMs()).thenReturn(timeUnit.toMillis(endTime));
+    when(segmentZKMetadata.getStatus()).thenReturn(CommonConstants.Segment.Realtime.Status.DONE);
     return segmentZKMetadata;
   }
 


### PR DESCRIPTION
as reported in #17116 , Fixes noisy logs by skipping retention check for consuming segments (IN_PROGRESS status).
Consuming segments have expected end time of -1 and should not trigger invalid time warnings