### PR TITLE
EmptyResponseUtils converts before setting final rows

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/EmptyResponseUtils.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/EmptyResponseUtils.java
@@ -85,8 +85,9 @@ public class EmptyResponseUtils {
       AggregationFunction aggregationFunction = pair.getLeft();
       columnNames[i] = AggregationFunctionUtils.getResultColumnName(aggregationFunction, pair.getRight());
       columnDataTypes[i] = aggregationFunction.getFinalResultColumnType();
-      row[i] = aggregationFunction.extractFinalResult(
+      Object finalResult = aggregationFunction.extractFinalResult(
           aggregationFunction.extractAggregationResult(aggregationFunction.createAggregationResultHolder()));
+      row[i] = finalResult != null ? columnDataTypes[i].convert(finalResult) : null;
     }
     return new ResultTable(new DataSchema(columnNames, columnDataTypes), List.<Object[]>of(row));
   }

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/EmptyResponseUtilsTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/EmptyResponseUtilsTest.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.broker.requesthandler;
 
 import java.util.List;
+import org.apache.pinot.common.response.broker.BrokerResponseNative;
 import org.apache.pinot.common.response.broker.ResultTable;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
@@ -27,6 +28,7 @@ import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUt
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
 
@@ -81,5 +83,73 @@ public class EmptyResponseUtilsTest {
         ColumnDataType.STRING, ColumnDataType.STRING, ColumnDataType.LONG, ColumnDataType.DOUBLE, ColumnDataType.DOUBLE
     });
     assertTrue(resultTable.getRows().isEmpty());
+  }
+
+  @Test
+  public void testBuildEmptyResultTableWithDistinctCountRawHLL() {
+    // Test DISTINCTCOUNTRAWHLL aggregation with empty results
+    // This should not throw a Jackson serialization error
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContext(
+        "SELECT DISTINCTCOUNTRAWHLL(a) FROM testTable WHERE foo = 'bar'");
+    ResultTable resultTable = EmptyResponseUtils.buildEmptyResultTable(queryContext);
+    DataSchema dataSchema = resultTable.getDataSchema();
+
+    // Verify schema is correct
+    assertEquals(dataSchema.getColumnNames(), new String[]{"distinctcountrawhll(a)"});
+    assertEquals(dataSchema.getColumnDataTypes(), new ColumnDataType[]{ColumnDataType.STRING});
+
+    // Verify we have one row with a result
+    List<Object[]> rows = resultTable.getRows();
+    assertEquals(rows.size(), 1);
+    Object[] row = rows.get(0);
+    assertNotNull(row[0], "Result should not be null");
+
+    // The critical test: verify the result is a String (or can be serialized)
+    // This will fail before the fix because row[0] is a SerializedHLL object
+    assertTrue(row[0] instanceof String,
+        "Result should be a String, but got: " + row[0].getClass().getName());
+
+    // Verify it can be serialized to JSON (this is where the original bug manifests)
+    BrokerResponseNative response = new BrokerResponseNative();
+    response.setResultTable(resultTable);
+    try {
+      String jsonString = response.toJsonString();
+      assertNotNull(jsonString, "Should be able to serialize to JSON");
+    } catch (Exception e) {
+      throw new AssertionError("Failed to serialize BrokerResponseNative to JSON: " + e.getMessage(), e);
+    }
+  }
+
+  @Test
+  public void testBuildEmptyResultTableWithDistinctCountRawHLLPlus() {
+    // Test DISTINCTCOUNTRAWHLLPLUS aggregation with empty results
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContext(
+        "SELECT DISTINCTCOUNTRAWHLLPLUS(a) FROM testTable WHERE foo = 'bar'");
+    ResultTable resultTable = EmptyResponseUtils.buildEmptyResultTable(queryContext);
+    DataSchema dataSchema = resultTable.getDataSchema();
+
+    // Verify schema is correct
+    assertEquals(dataSchema.getColumnNames(), new String[]{"distinctcountrawhllplus(a)"});
+    assertEquals(dataSchema.getColumnDataTypes(), new ColumnDataType[]{ColumnDataType.STRING});
+
+    // Verify we have one row with a result
+    List<Object[]> rows = resultTable.getRows();
+    assertEquals(rows.size(), 1);
+    Object[] row = rows.get(0);
+    assertNotNull(row[0], "Result should not be null");
+
+    // Verify the result is a String
+    assertTrue(row[0] instanceof String,
+        "Result should be a String, but got: " + row[0].getClass().getName());
+
+    // Verify it can be serialized to JSON
+    BrokerResponseNative response = new BrokerResponseNative();
+    response.setResultTable(resultTable);
+    try {
+      String jsonString = response.toJsonString();
+      assertNotNull(jsonString, "Should be able to serialize to JSON");
+    } catch (Exception e) {
+      throw new AssertionError("Failed to serialize BrokerResponseNative to JSON: " + e.getMessage(), e);
+    }
   }
 }


### PR DESCRIPTION
This is a `bugfix` to address https://github.com/apache/pinot/issues/17115. We need to convert the empty, final result before returning it.

I've added several unit tests for the cases we saw.