### PR TITLE
v1 queries populate tablesQueried for empty responses

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
@@ -1096,6 +1096,7 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
       LOGGER.warn("Caught exception while building empty response for request {}: {}, {}",
           requestContext.getRequestId(), query, e.getMessage());
     }
+    brokerResponse.setTablesQueried(Set.of(TableNameBuilder.extractRawTableName(tableName)));
     brokerResponse.setTimeUsedMs(System.currentTimeMillis() - requestContext.getRequestArrivalTimeMillis());
     _queryLogger.log(new QueryLogger.QueryLogParams(requestContext, tableName, brokerResponse,
         QueryLogger.QueryLogParams.QueryEngine.SINGLE_STAGE, requesterIdentity, null));


### PR DESCRIPTION
This is a `bugfix` to address the 3rd issue in https://github.com/apache/pinot/issues/17115 for v1 queries. For empty responses, we now set `tablesQueried` even if we are returning an empty broker response. I added a unit test for this.