### PR TITLE
[BugFix] Fix authorization issue caused by duplicate auth header

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/ZkBasicAuthAccessControlFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/ZkBasicAuthAccessControlFactory.java
@@ -130,8 +130,10 @@ public class ZkBasicAuthAccessControlFactory extends AccessControlFactory {
           .collect(Collectors.toMap(BasicAuthPrincipal::getName, p -> p));
 
       Map<String, String> name2password = tokens.stream().collect(
-          Collectors.toMap(org.apache.pinot.common.auth.BasicAuthUtils::extractUsername,
-              org.apache.pinot.common.auth.BasicAuthUtils::extractPassword));
+          Collectors.toMap(
+              org.apache.pinot.common.auth.BasicAuthUtils::extractUsername,
+              org.apache.pinot.common.auth.BasicAuthUtils::extractPassword,
+              (v1, v2) -> v2));
       Map<String, ZkBasicAuthPrincipal> password2principal =
           name2password.keySet().stream().collect(Collectors.toMap(name2password::get, _name2principal::get));
 

--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/admin/PinotAdminTransport.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/admin/PinotAdminTransport.java
@@ -280,13 +280,13 @@ public class PinotAdminTransport implements AutoCloseable {
 
     // Add default headers
     for (Map.Entry<String, String> header : _defaultHeaders.entrySet()) {
-      requestBuilder.addHeader(header.getKey(), header.getValue());
+      requestBuilder.setHeader(header.getKey(), header.getValue());
     }
 
     // Add request-specific headers
     if (headers != null) {
       for (Map.Entry<String, String> header : headers.entrySet()) {
-        requestBuilder.addHeader(header.getKey(), header.getValue());
+        requestBuilder.setHeader(header.getKey(), header.getValue());
       }
     }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/ZkBasicAuthAccessControlFactory.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/ZkBasicAuthAccessControlFactory.java
@@ -103,8 +103,10 @@ public class ZkBasicAuthAccessControlFactory implements AccessControlFactory {
         return Optional.empty();
       }
       Map<String, String> name2password = authHeaders.stream().collect(
-          Collectors.toMap(org.apache.pinot.common.auth.BasicAuthUtils::extractUsername,
-              org.apache.pinot.common.auth.BasicAuthUtils::extractPassword));
+          Collectors.toMap(
+              org.apache.pinot.common.auth.BasicAuthUtils::extractUsername,
+              org.apache.pinot.common.auth.BasicAuthUtils::extractPassword,
+              (v1, v2) -> v2));
       Map<String, ZkBasicAuthPrincipal> password2principal =
           name2password.keySet().stream().collect(Collectors.toMap(name2password::get, _name2principal::get));
 

--- a/pinot-core/src/main/java/org/apache/pinot/server/access/ZkBasicAuthAccessFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/server/access/ZkBasicAuthAccessFactory.java
@@ -95,8 +95,10 @@ public class ZkBasicAuthAccessFactory implements AccessControlFactory {
           .collect(Collectors.toMap(ZkBasicAuthPrincipal::getName, p -> p));
 
       Map<String, String> name2password = tokens.stream().collect(
-          Collectors.toMap(org.apache.pinot.common.auth.BasicAuthUtils::extractUsername,
-              org.apache.pinot.common.auth.BasicAuthUtils::extractPassword));
+          Collectors.toMap(
+              org.apache.pinot.common.auth.BasicAuthUtils::extractUsername,
+              org.apache.pinot.common.auth.BasicAuthUtils::extractPassword,
+              (v1, v2) -> v2));
       Map<String, ZkBasicAuthPrincipal> password2principal =
           name2password.keySet().stream().collect(Collectors.toMap(name2password::get, _name2principal::get));
       return password2principal.entrySet().stream().filter(


### PR DESCRIPTION
This PR aim to fix duplcated auth header issue.
1. PinotAdminClient will send double auth header. So change `addHeader` to `setHeader` to make sure keep latest(or unique) auth header
2. Update the getPrincipal extraction logic to prevent access-denied errors caused by duplicate authentication headers in the HTTP request.