### PR TITLE
funnel: fix deserialize offset for extra fields; add round-trip unit test

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/FunnelStepEventWithExtraFields.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/FunnelStepEventWithExtraFields.java
@@ -40,7 +40,8 @@ public class FunnelStepEventWithExtraFields implements Comparable<FunnelStepEven
   public FunnelStepEventWithExtraFields(byte[] bytes) {
     _funnelStepEvent = new FunnelStepEvent(Arrays.copyOf(bytes, FunnelStepEvent.SIZE_IN_BYTES));
     try {
-      _extraFields = OBJECT_MAPPER.readValue(bytes, 2, bytes.length, new TypeReference<List<Object>>() {
+      int offset = FunnelStepEvent.SIZE_IN_BYTES;
+      _extraFields = OBJECT_MAPPER.readValue(bytes, offset, bytes.length - offset, new TypeReference<List<Object>>() {
       });
     } catch (IOException e) {
       throw new RuntimeException("Caught exception while converting byte[] to FunnelStepEventWithExtraFields", e);

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/funnel/FunnelStepEventWithExtraFieldsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/funnel/FunnelStepEventWithExtraFieldsTest.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.aggregation.function.funnel;
+
+import java.util.Arrays;
+import java.util.List;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class FunnelStepEventWithExtraFieldsTest {
+
+  @Test
+  public void testSerializeDeserializeRoundTrip() {
+    long timestamp = 123456789L;
+    int step = 2;
+    FunnelStepEvent event = new FunnelStepEvent(timestamp, step);
+    List<Object> extra = Arrays.asList("foo", "bar", 42, "baz");
+
+    FunnelStepEventWithExtraFields original = new FunnelStepEventWithExtraFields(event, extra);
+    byte[] bytes = original.getBytes();
+
+    FunnelStepEventWithExtraFields restored = new FunnelStepEventWithExtraFields(bytes);
+
+    Assert.assertEquals(restored.getFunnelStepEvent().getTimestamp(), timestamp);
+    Assert.assertEquals(restored.getFunnelStepEvent().getStep(), step);
+    Assert.assertEquals(restored.getExtraFields(), extra);
+  }
+}


### PR DESCRIPTION
Fixes IllegalArgumentException when Jackson is given invalid offset/len. 
The JSON portion begins after FunnelStepEvent (SIZE_IN_BYTES).