### PR TITLE
feat(common): Enhance ListAgg to support aggregation on multi-value columns

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactory.java
@@ -268,16 +268,19 @@ public class AggregationFunctionFactory {
           }
           case LISTAGG: {
             Preconditions.checkArgument(numArguments == 2 || numArguments == 3,
-                "LISTAGG expects 2 arguments, got: %s. The function can be used as "
-                    + "listAgg([distinct] expression, 'separator')", numArguments);
+                "LISTAGG expects 2 or 3 arguments, got: %s. The function can be used as "
+                    + "listAgg(expression, 'separator'[, true|false])", numArguments);
             ExpressionContext separatorExpression = arguments.get(1);
             Preconditions.checkArgument(separatorExpression.getType() == ExpressionContext.Type.LITERAL,
                 "LISTAGG expects the 2nd argument to be literal, got: %s. The function can be used as "
-                    + "listAgg([distinct] expression, 'separator')", separatorExpression.getType());
+                    + "listAgg(expression, 'separator'[, true|false])", separatorExpression.getType());
             String separator = separatorExpression.getLiteral().getStringValue();
             boolean isDistinct = false;
             if (numArguments == 3) {
               ExpressionContext isDistinctListAggExp = arguments.get(2);
+              Preconditions.checkArgument(isDistinctListAggExp.getType() == ExpressionContext.Type.LITERAL,
+                  "LISTAGG expects the 3rd argument to be a boolean literal (true/false), got: %s. The function can "
+                      + "be used as listAgg(expression, 'separator'[, true|false])", isDistinctListAggExp.getType());
               isDistinct = isDistinctListAggExp.getLiteral().getBooleanValue();
             }
             if (isDistinct) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/ListAggFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/ListAggFunctionTest.java
@@ -1,0 +1,153 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.aggregation.function;
+
+import java.util.Map;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.core.common.SyntheticBlockValSets;
+import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
+import org.apache.pinot.core.query.aggregation.function.array.ListAggDistinctFunction;
+import org.apache.pinot.core.query.aggregation.function.array.ListAggFunction;
+import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
+import org.apache.pinot.core.query.aggregation.groupby.ObjectGroupByResultHolder;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+
+public class ListAggFunctionTest extends AbstractAggregationFunctionTest {
+
+  private static class TestStringSVBlock extends SyntheticBlockValSets.Base {
+    private final String[] _values;
+
+    TestStringSVBlock(String[] values) {
+      _values = values;
+    }
+
+    @Override
+    public boolean isSingleValue() {
+      return true;
+    }
+
+    @Override
+    public String[] getStringValuesSV() {
+      return _values;
+    }
+
+    @Override
+    public FieldSpec.DataType getValueType() {
+      return FieldSpec.DataType.STRING;
+    }
+  }
+
+  private static class TestStringMVBlock extends SyntheticBlockValSets.Base {
+    private final String[][] _values;
+
+    TestStringMVBlock(String[][] values) {
+      _values = values;
+    }
+
+    @Override
+    public boolean isSingleValue() {
+      return false;
+    }
+
+    @Override
+    public String[][] getStringValuesMV() {
+      return _values;
+    }
+
+    @Override
+    public FieldSpec.DataType getValueType() {
+      return FieldSpec.DataType.STRING;
+    }
+  }
+
+  @Test
+  public void testListAggAggregate() {
+    ListAggFunction fn = new ListAggFunction(ExpressionContext.forIdentifier("myField"), ",", false);
+    AggregationResultHolder holder = fn.createAggregationResultHolder();
+    fn.aggregate(2, holder,
+        Map.of(ExpressionContext.forIdentifier("myField"), new TestStringMVBlock(new String[][]{{"A", "B"}, {"C"}})));
+    fn.aggregate(2, holder,
+        Map.of(ExpressionContext.forIdentifier("myField"), new TestStringMVBlock(new String[][]{{"B"}, {"D"}})));
+    String result = fn.extractFinalResult(holder.getResult());
+    assertEquals(result, "A,B,C,B,D");
+  }
+
+  @Test
+  public void testListAggAggregateSV() {
+    ListAggFunction fn = new ListAggFunction(ExpressionContext.forIdentifier("svField"), "|", false);
+    AggregationResultHolder holder = fn.createAggregationResultHolder();
+    fn.aggregate(3, holder,
+        Map.of(ExpressionContext.forIdentifier("svField"), new TestStringSVBlock(new String[]{"A", "B", "C"})));
+    fn.aggregate(2, holder,
+        Map.of(ExpressionContext.forIdentifier("svField"), new TestStringSVBlock(new String[]{"B", "D"})));
+    String result = fn.extractFinalResult(holder.getResult());
+    assertEquals(result, "A|B|C|B|D");
+  }
+
+  @Test
+  public void testListAggDistinctAggregate() {
+    ListAggDistinctFunction fn =
+        new ListAggDistinctFunction(ExpressionContext.forIdentifier("myField"), ",", false);
+    AggregationResultHolder holder = fn.createAggregationResultHolder();
+    fn.aggregate(2, holder,
+        Map.of(ExpressionContext.forIdentifier("myField"), new TestStringMVBlock(new String[][]{{"A", "B"}, {"C"}})));
+    fn.aggregate(2, holder,
+        Map.of(ExpressionContext.forIdentifier("myField"), new TestStringMVBlock(new String[][]{{"B"}, {"A"}})));
+    String result = fn.extractFinalResult(holder.getResult());
+    assertEquals(result, "A,B,C");
+  }
+
+  @Test
+  public void testListAggDistinctAggregateSV() {
+    ListAggDistinctFunction fn =
+        new ListAggDistinctFunction(ExpressionContext.forIdentifier("svField"), ",", false);
+    AggregationResultHolder holder = fn.createAggregationResultHolder();
+    fn.aggregate(3, holder,
+        Map.of(ExpressionContext.forIdentifier("svField"), new TestStringSVBlock(new String[]{"A", "B", "C"})));
+    fn.aggregate(3, holder,
+        Map.of(ExpressionContext.forIdentifier("svField"), new TestStringSVBlock(new String[]{"B", "A", "D"})));
+    String result = fn.extractFinalResult(holder.getResult());
+    assertEquals(result, "A,B,C,D");
+  }
+
+  @Test
+  public void testGroupByPaths() {
+    ListAggFunction fn = new ListAggFunction(ExpressionContext.forIdentifier("myField"), ";", false);
+    GroupByResultHolder gb = new ObjectGroupByResultHolder(4, 4);
+    fn.aggregateGroupBySV(2, new int[]{0, 1}, gb,
+        Map.of(ExpressionContext.forIdentifier("myField"), new TestStringMVBlock(new String[][]{{"X"}, {"Y", "Z"}})));
+    assertEquals(fn.extractFinalResult(gb.getResult(0)), "X");
+    assertEquals(fn.extractFinalResult(gb.getResult(1)), "Y;Z");
+  }
+
+  @Test
+  public void testGroupByMVKeysOnMVColumn() {
+    ListAggFunction fn = new ListAggFunction(ExpressionContext.forIdentifier("mvField"), ":", false);
+    GroupByResultHolder gb = new ObjectGroupByResultHolder(4, 4);
+    int[][] groupKeysArray = new int[][]{{0, 1}, {1}};
+    fn.aggregateGroupByMV(2, groupKeysArray, gb,
+        Map.of(ExpressionContext.forIdentifier("mvField"), new TestStringMVBlock(new String[][]{{"A"}, {"B", "C"}})));
+    assertEquals(fn.extractFinalResult(gb.getResult(0)), "A");
+    assertEquals(fn.extractFinalResult(gb.getResult(1)), "A:B:C");
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/queries/ListAggQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/ListAggQueriesTest.java
@@ -1,0 +1,193 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.queries;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.common.response.broker.ResultTable;
+import org.apache.pinot.core.operator.blocks.results.AggregationResultsBlock;
+import org.apache.pinot.core.operator.query.AggregationOperator;
+import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
+import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
+import org.apache.pinot.segment.spi.ImmutableSegment;
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.utils.ReadMode;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+
+public class ListAggQueriesTest extends BaseQueriesTest {
+  private static final File INDEX_DIR = new File(FileUtils.getTempDirectory(), "ListAggQueriesTest");
+  private static final String RAW_TABLE_NAME = "testTableListAgg";
+  private static final String SEGMENT_NAME = "testSegment";
+
+  private static final int NUM_RECORDS = 200;
+
+  private static final String STR_MV = "strMV";
+  private static final String STR_SV = "strSV";
+  private static final String GROUP_BY_COLUMN = "groupKey";
+
+  private static final Schema SCHEMA = new Schema.SchemaBuilder().addMultiValueDimension(STR_MV, DataType.STRING)
+      .addSingleValueDimension(STR_SV, DataType.STRING)
+      .addSingleValueDimension(GROUP_BY_COLUMN, DataType.STRING).build();
+
+  private IndexSegment _indexSegment;
+  private List<IndexSegment> _indexSegments;
+
+  @Override
+  protected String getFilter() {
+    return "";
+  }
+
+  @Override
+  protected IndexSegment getIndexSegment() {
+    return _indexSegment;
+  }
+
+  @Override
+  protected List<IndexSegment> getIndexSegments() {
+    return _indexSegments;
+  }
+
+  @BeforeClass
+  public void setUp()
+      throws Exception {
+    FileUtils.deleteDirectory(INDEX_DIR);
+
+    List<GenericRow> records = new ArrayList<>(NUM_RECORDS);
+    for (int i = 0; i < NUM_RECORDS; i++) {
+      GenericRow record = new GenericRow();
+      record.putValue(STR_MV, new String[]{"A", (i % 2 == 0) ? "B" : "C"});
+      record.putValue(STR_SV, (i % 2 == 0) ? "X" : "Y");
+      record.putValue(GROUP_BY_COLUMN, String.valueOf(i % 10));
+      records.add(record);
+    }
+
+    SegmentGeneratorConfig conf = new SegmentGeneratorConfig(
+        new TableConfigBuilder(org.apache.pinot.spi.config.table.TableType.OFFLINE).setTableName(RAW_TABLE_NAME)
+            .build(), SCHEMA);
+    conf.setTableName(RAW_TABLE_NAME);
+    conf.setSegmentName(SEGMENT_NAME);
+    conf.setOutDir(INDEX_DIR.getPath());
+    SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+    driver.init(conf, new GenericRowRecordReader(records));
+    driver.build();
+
+    ImmutableSegment immutableSegment = ImmutableSegmentLoader.load(new File(INDEX_DIR, SEGMENT_NAME), ReadMode.mmap);
+    _indexSegment = immutableSegment;
+    _indexSegments = Arrays.asList(immutableSegment, immutableSegment);
+  }
+
+  @Test
+  public void testListAggNonDistinct() {
+    String q = "SELECT listAgg(strMV, ',') FROM testTableListAgg";
+    AggregationOperator op = getOperator(q);
+    AggregationResultsBlock block = op.nextBlock();
+    List<Object> res = block.getResults();
+    assertNotNull(res);
+    // Each row contributes 2 elements; inner-segment result is the intermediate collection
+    Object partial = res.get(0);
+    assertEquals(((java.util.Collection<?>) partial).size(), 2 * NUM_RECORDS);
+
+    ResultTable table = getBrokerResponse(q).getResultTable();
+    assertEquals(table.getRows().get(0).length, 1);
+    // Each row has 2 MV values; with 2 segments and 2 servers, expect 8 * NUM_RECORDS
+    assertEquals(((String) table.getRows().get(0)[0]).split(",").length, 8 * NUM_RECORDS);
+  }
+
+  @Test
+  public void testListAggDistinct() {
+    String q = "SELECT listAgg(strMV, ',', true) FROM testTableListAgg";
+    AggregationOperator op = getOperator(q);
+    AggregationResultsBlock block = op.nextBlock();
+    List<Object> res = block.getResults();
+    assertNotNull(res);
+    // Distinct values are {A,B,C}; inner-segment result is the intermediate set
+    Object partial = res.get(0);
+    assertEquals(((java.util.Collection<?>) partial).size(), 3);
+
+    // Inter-segment (broker) result is the final string
+    ResultTable table = getBrokerResponse(q).getResultTable();
+    assertEquals(((String) table.getRows().get(0)[0]).split(",").length, 3);
+  }
+
+  @Test
+  public void testListAggExplicitFalseOnMV() {
+    String q = "SELECT listAgg(strMV, ',', false) FROM testTableListAgg";
+    AggregationOperator op = getOperator(q);
+    AggregationResultsBlock block = op.nextBlock();
+    List<Object> res = block.getResults();
+    assertNotNull(res);
+    Object partial = res.get(0);
+    assertEquals(((java.util.Collection<?>) partial).size(), 2 * NUM_RECORDS);
+
+    ResultTable table = getBrokerResponse(q).getResultTable();
+    assertEquals(((String) table.getRows().get(0)[0]).split(",").length, 8 * NUM_RECORDS);
+  }
+
+  @Test
+  public void testListAggSVNonDistinct() {
+    String q = "SELECT listAgg(strSV, '|') FROM testTableListAgg";
+    AggregationOperator op = getOperator(q);
+    AggregationResultsBlock block = op.nextBlock();
+    List<Object> res = block.getResults();
+    assertNotNull(res);
+    Object partial = res.get(0);
+    assertEquals(((java.util.Collection<?>) partial).size(), NUM_RECORDS);
+
+    ResultTable table = getBrokerResponse(q).getResultTable();
+    assertEquals(((String) table.getRows().get(0)[0]).split("\\|").length, 4 * NUM_RECORDS);
+  }
+
+  @Test
+  public void testListAggSVDistinct() {
+    String q = "SELECT listAgg(strSV, ',', true) FROM testTableListAgg";
+    AggregationOperator op = getOperator(q);
+    AggregationResultsBlock block = op.nextBlock();
+    List<Object> res = block.getResults();
+    assertNotNull(res);
+    Object partial = res.get(0);
+    // Distinct values are {X,Y}
+    assertEquals(((java.util.Collection<?>) partial).size(), 2);
+
+    ResultTable table = getBrokerResponse(q).getResultTable();
+    assertEquals(((String) table.getRows().get(0)[0]).split(",").length, 2);
+  }
+
+  @AfterClass
+  public void tearDown()
+      throws IOException {
+    _indexSegment.destroy();
+    FileUtils.deleteDirectory(INDEX_DIR);
+  }
+}


### PR DESCRIPTION
### Summary
- Enhance ListAgg to support aggregation on multi-value columns.
- ListAgg concatenates MV string values using a separator; optional distinct deduplicates while preserving order.

SQL Syntax
```
listAgg(expression, 'separator'[, isDistinct])
```
This pull request enhances the `LISTAGG` aggregation function in Pinot to support multi-value (MV) columns and improves its handling for both single-value (SV) and MV inputs. It also updates the function's argument validation and adds comprehensive unit and integration tests to ensure correctness across different scenarios.

### Enhancements to LISTAGG Functionality

* Added support for aggregating multi-value (MV) columns in the `ListAggFunction`, including correct handling in group-by operations for both SV and MV inputs. (`pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ListAggFunction.java`) [[1]](diffhunk://#diff-3d8f2abd86702b30338ff2da8dc6318f47b21bebdb58c59fe36d173a1fdebd11R68-R82) [[2]](diffhunk://#diff-3d8f2abd86702b30338ff2da8dc6318f47b21bebdb58c59fe36d173a1fdebd11R108-R133) [[3]](diffhunk://#diff-3d8f2abd86702b30338ff2da8dc6318f47b21bebdb58c59fe36d173a1fdebd11R143-R156)
* Updated argument validation and error messages for the `LISTAGG` function to clarify the expected number and type of arguments, reflecting the new MV support. (`pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactory.java`)
* Introduced a new aggregation function type, `LISTAGGMV`, to distinguish multi-value aggregation in the enum registry. (`pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/AggregationFunctionType.java`)

### Testing Improvements

* Added a dedicated unit test suite for `ListAggFunction` and `ListAggDistinctFunction`, covering SV and MV inputs, distinct aggregation, and group-by scenarios. (`pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/ListAggFunctionTest.java`)
* Added integration tests for `LISTAGG` queries on both SV and MV columns, including distinct and non-distinct cases, validating results at both segment and broker levels. (`pinot-core/src/test/java/org/apache/pinot/queries/ListAggQueriesTest.java`)