### PR TITLE
[bugfix] Returning error block for OpChain initialization errors

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
@@ -288,16 +288,16 @@ public class QueryRunner {
     OpChainExecutionContext executionContext =
         OpChainExecutionContext.fromQueryContext(_mailboxService, opChainMetadata, stageMetadata, workerMetadata,
             pipelineBreakerResult, _sendStats.getAsBoolean());
-    OpChain opChain;
-    if (workerMetadata.isLeafStageWorker()) {
-      Map<String, String> rlsFilters = RlsUtils.extractRlsFilters(requestMetadata);
-      opChain =
-          ServerPlanRequestUtils.compileLeafStage(executionContext, stagePlan, _leafQueryExecutor, _executorService,
-              rlsFilters);
-    } else {
-      opChain = PlanNodeToOpChain.convert(stagePlan.getRootNode(), executionContext);
-    }
     try {
+      OpChain opChain;
+      if (workerMetadata.isLeafStageWorker()) {
+        Map<String, String> rlsFilters = RlsUtils.extractRlsFilters(requestMetadata);
+        opChain =
+            ServerPlanRequestUtils.compileLeafStage(executionContext, stagePlan, _leafQueryExecutor, _executorService,
+                rlsFilters);
+      } else {
+        opChain = PlanNodeToOpChain.convert(stagePlan.getRootNode(), executionContext);
+      }
       // This can fail if the executor rejects the task.
       _opChainScheduler.register(opChain);
     } catch (RuntimeException e) {


### PR DESCRIPTION
## Summary

There is a `Preconditions.checkNotNull` check for logical table context within [ServerPlanRequestUtils](https://github.com/apache/pinot/blob/master/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestUtils.java#L429) which throws a NPE when the server cannot correctly access the logical table context from Helix.

When this happens, the `QueryRunner::processQueryBlocking` silently fails with a warn log whereas the broker is stuck waiting for data from the particular server, and times out instead of returning the error message. This change fixes that by including the `OpChain` initialization and compilation inside the `try...catch`.

## Testing

Successfully tested by simulating a scenario where logical table context was inaccessible for a particular server.

Error before fix:
```
{"exceptions":[{"errorCode":250,"message":"Received 1 error from stage 0 on Broker_localhost_41000: Timed out on stage 0 waiting for data from child stage 1"}]}
```

Error after fix:
```
{"exceptions":[{"errorCode":1000,"message":"Received 1 error from stage 5 on Server_localhost_32001: LogicalTableContext not found for logical table name: logical_table_2, query context id: 639209137000000000"}]}
```