### PR TITLE
Add interfaces to get partition columns and partition values from column value

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/partitioner/ColumnValuePartitioner.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/partitioner/ColumnValuePartitioner.java
@@ -36,4 +36,18 @@ public class ColumnValuePartitioner implements Partitioner {
   public String getPartition(GenericRow genericRow) {
     return String.valueOf(genericRow.getValue(_columnName));
   }
+
+  @Override
+  public String[] getPartitionColumns() {
+    return new String[]{_columnName};
+  }
+
+  @Override
+  public String getPartitionFromColumns(Object[] columnValues) {
+    if (columnValues.length != 1) {
+      throw new IllegalArgumentException(
+          "ColumnValuePartitioner expects exactly 1 column value, got " + columnValues.length);
+    }
+    return String.valueOf(columnValues[0]);
+  }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/partitioner/NoOpPartitioner.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/partitioner/NoOpPartitioner.java
@@ -29,4 +29,14 @@ public class NoOpPartitioner implements Partitioner {
   public String getPartition(GenericRow genericRow) {
     return "0";
   }
+
+  @Override
+  public String[] getPartitionColumns() {
+    return new String[0]; // No columns needed
+  }
+
+  @Override
+  public String getPartitionFromColumns(Object[] columnValues) {
+    return "0";
+  }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/partitioner/Partitioner.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/partitioner/Partitioner.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.segment.processing.partitioner;
 
+import javax.annotation.Nullable;
 import org.apache.pinot.spi.data.readers.GenericRow;
 
 
@@ -30,4 +31,24 @@ public interface Partitioner {
    * Computes a partition value for the given row
    */
   String getPartition(GenericRow genericRow);
+
+  /**
+   * Returns the column names used for partitioning,
+   * This enables efficient columnar processing by reading only the required columns.
+   * @return
+   *  1. array of column names, or
+   *  2. null if the partitioner doesn't support columnar processing, or
+   *  3. an empty array if no columns are needed to derive the partition.
+   */
+  @Nullable
+  String[] getPartitionColumns();
+
+  /**
+   * Computes a partition value from column values.
+   * Should only be called if getPartitionColumns() returns a non-null array.
+   *
+   * @param columnValues Array of column values in same order as columns returned by getPartitionColumns()
+   * @return The partition string
+   */
+  String getPartitionFromColumns(Object[] columnValues);
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/partitioner/RoundRobinPartitioner.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/partitioner/RoundRobinPartitioner.java
@@ -34,6 +34,20 @@ public class RoundRobinPartitioner implements Partitioner {
 
   @Override
   public String getPartition(GenericRow genericRow) {
+    return getPartition();
+  }
+
+  @Override
+  public String[] getPartitionColumns() {
+    return new String[0]; // No columns needed
+  }
+
+  @Override
+  public String getPartitionFromColumns(Object[] columnValues) {
+    return getPartition();
+  }
+
+  private String getPartition() {
     int currentPartition = _nextPartition;
     _nextPartition = (_nextPartition + 1) % _numPartitions;
     return String.valueOf(currentPartition);

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/partitioner/TableConfigPartitioner.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/partitioner/TableConfigPartitioner.java
@@ -37,11 +37,25 @@ public class TableConfigPartitioner implements Partitioner {
     _column = columnName;
     _partitionFunction = PartitionFunctionFactory
         .getPartitionFunction(columnPartitionConfig.getFunctionName(), columnPartitionConfig.getNumPartitions(),
-                columnPartitionConfig.getFunctionConfig());
+            columnPartitionConfig.getFunctionConfig());
   }
 
   @Override
   public String getPartition(GenericRow genericRow) {
     return String.valueOf(_partitionFunction.getPartition(FieldSpec.getStringValue(genericRow.getValue(_column))));
+  }
+
+  @Override
+  public String[] getPartitionColumns() {
+    return new String[]{_column};
+  }
+
+  @Override
+  public String getPartitionFromColumns(Object[] columnValues) {
+    if (columnValues.length != 1) {
+      throw new IllegalArgumentException(
+          "TableConfigPartitioner expects exactly 1 column value, got " + columnValues.length);
+    }
+    return String.valueOf(_partitionFunction.getPartition(FieldSpec.getStringValue(columnValues[0])));
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/partitioner/TransformFunctionPartitioner.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/partitioner/TransformFunctionPartitioner.java
@@ -38,4 +38,15 @@ public class TransformFunctionPartitioner implements Partitioner {
   public String getPartition(GenericRow genericRow) {
     return String.valueOf(_functionEvaluator.evaluate(genericRow));
   }
+
+  @Override
+  public String[] getPartitionColumns() {
+    return null;
+  }
+
+  @Override
+  public String getPartitionFromColumns(Object[] columnValues) {
+    // TODO - Implement
+    throw new UnsupportedOperationException("TransformFunctionPartitioner does not support getPartitionFromColumns");
+  }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/timehandler/EpochTimeHandler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/timehandler/EpochTimeHandler.java
@@ -70,4 +70,49 @@ public class EpochTimeHandler implements TimeHandler {
       return DEFAULT_PARTITION;
     }
   }
+
+  @Override
+  public String getTimeColumn() {
+    return _timeColumn;
+  }
+
+  @Override
+  @Nullable
+  public String handleTimeColumn(Object columnValue) {
+    long timeMs = _formatSpec.fromFormatToMillis(columnValue.toString());
+
+    // Apply time filter
+    if (_startTimeMs > 0) {
+      boolean outsideTimeWindow = (timeMs < _startTimeMs || timeMs >= _endTimeMs);
+      if (outsideTimeWindow != _negateWindowFilter) {
+        return null;
+      }
+    }
+
+    // Round time if needed
+    if (_roundBucketMs > 0) {
+      timeMs = (timeMs / _roundBucketMs) * _roundBucketMs;
+    }
+
+    // Compute partition
+    if (_partitionBucketMs > 0) {
+      return Long.toString(timeMs / _partitionBucketMs);
+    } else {
+      return DEFAULT_PARTITION;
+    }
+  }
+
+  @Override
+  @Nullable
+  public Object getModifiedTimeValue(Object columnValue) {
+    long timeMs = _formatSpec.fromFormatToMillis(columnValue.toString());
+
+    // Round time if needed
+    if (_roundBucketMs > 0) {
+      timeMs = (timeMs / _roundBucketMs) * _roundBucketMs;
+      return _dataType.convert(_formatSpec.fromMillisToFormat(timeMs));
+    } else {
+      return columnValue;
+    }
+  }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/timehandler/NoOpTimeHandler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/timehandler/NoOpTimeHandler.java
@@ -29,4 +29,19 @@ public class NoOpTimeHandler implements TimeHandler {
   public String handleTime(GenericRow row) {
     return DEFAULT_PARTITION;
   }
+
+  @Override
+  public String getTimeColumn() {
+    return null;
+  }
+
+  @Override
+  public String handleTimeColumn(Object columnValue) {
+    return DEFAULT_PARTITION;
+  }
+
+  @Override
+  public Object getModifiedTimeValue(Object columnValue) {
+    return columnValue;
+  }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/timehandler/TimeHandler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/timehandler/TimeHandler.java
@@ -42,4 +42,30 @@ public interface TimeHandler {
    */
   @Nullable
   String handleTime(GenericRow row);
+
+  /**
+   * Returns the time column name, or null if no time column is configured.
+   * This enables efficient columnar processing by reading only the time column.
+   */
+  @Nullable
+  String getTimeColumn();
+
+  /**
+   * Handles time value from a column and returns the time partition, or {@code null} if the value is filtered out.
+   *
+   * @param columnValue The time column value
+   * @return The time partition string, or null if the row is filtered based on time
+   */
+  @Nullable
+  String handleTimeColumn(Object columnValue);
+
+  /**
+   * Returns the modified time value (eg: rounding) from the original column value.
+   * It assumes that the column value has already passed the filtering criteria.
+   *
+   * @param columnValue The original time column value
+   * @return The modified time value
+   */
+  @Nullable
+  Object getModifiedTimeValue(Object columnValue);
 }


### PR DESCRIPTION
https://github.com/apache/pinot/pull/16727 added changes for column major segment build

The mapper phase in SegmentProcessorFramework still reads the input data as rows. To optimise that, we need new interfaces in Partitioner and TimeColumnHandler to return columns that are used for partitioning and accept column values rather than rows. This way, we can read specific columns from columnar input files. 

The actual changes to mapper will be in a seperate PR. This PR just adds the required interfaces.