### PR TITLE
Fix multi-stage stats aggregation to avoid ConcurrentModificationException in leaf stages

### DIFF
--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandlerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandlerTest.java
@@ -1,0 +1,98 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.requesthandler;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.common.datatable.StatMap;
+import org.apache.pinot.common.response.broker.BrokerResponseNativeV2;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.query.planner.PlanFragment;
+import org.apache.pinot.query.planner.physical.DispatchablePlanFragment;
+import org.apache.pinot.query.planner.physical.DispatchableSubPlan;
+import org.apache.pinot.query.planner.plannode.PlanNode;
+import org.apache.pinot.query.planner.plannode.ValueNode;
+import org.apache.pinot.query.runtime.operator.LeafOperator;
+import org.apache.pinot.query.runtime.operator.MultiStageOperator;
+import org.apache.pinot.query.runtime.plan.MultiStageQueryStats;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+
+public class MultiStageBrokerRequestHandlerTest {
+
+  @Test
+  public void testFillOldBrokerResponseStatsWithMixedStageStats()
+      throws Exception {
+    MultiStageBrokerRequestHandler handler = Mockito.mock(MultiStageBrokerRequestHandler.class);
+    Method method = MultiStageBrokerRequestHandler.class.getDeclaredMethod("fillOldBrokerResponseStats",
+        BrokerResponseNativeV2.class, List.class, DispatchableSubPlan.class);
+    method.setAccessible(true);
+
+    BrokerResponseNativeV2 brokerResponse = new BrokerResponseNativeV2();
+    List<MultiStageQueryStats.StageStats.Closed> stageStats = new ArrayList<>();
+    stageStats.add(new MultiStageQueryStats.StageStats.Closed(Collections.emptyList(), Collections.emptyList()));
+    stageStats.add(createLeafStageStats(42L, 17L));
+
+    Map<Integer, DispatchablePlanFragment> stageMap = new HashMap<>();
+    stageMap.put(0, createFragment(0, "testTable_OFFLINE"));
+    stageMap.put(1, createFragment(1, null));
+    DispatchableSubPlan subPlan = Mockito.mock(DispatchableSubPlan.class);
+    when(subPlan.getQueryStageMap()).thenReturn(stageMap);
+
+    method.invoke(handler, brokerResponse, stageStats, subPlan);
+
+    ObjectNode json = brokerResponse.getStageStats();
+    assertNotNull(json);
+    assertEquals(json.get("type").asText(), "EMPTY_MAILBOX_SEND");
+    assertEquals(json.get("stage").asInt(), 0);
+    assertEquals(json.get("table").asText(), "testTable_OFFLINE");
+
+    assertEquals(brokerResponse.getNumDocsScanned(), 42L);
+    assertEquals(brokerResponse.getMaxRowsInOperator(), 17L);
+  }
+
+  private static MultiStageQueryStats.StageStats.Closed createLeafStageStats(long numDocsScanned, long emittedRows) {
+    StatMap<LeafOperator.StatKey> statMap = new StatMap<>(LeafOperator.StatKey.class);
+    statMap.merge(LeafOperator.StatKey.NUM_DOCS_SCANNED, numDocsScanned);
+    statMap.merge(LeafOperator.StatKey.EMITTED_ROWS, emittedRows);
+    return new MultiStageQueryStats.StageStats.Closed(
+        Collections.singletonList(MultiStageOperator.Type.LEAF), Collections.singletonList(statMap));
+  }
+
+  private static DispatchablePlanFragment createFragment(int stageId, String tableName) {
+    DataSchema emptySchema = new DataSchema(new String[0], new DataSchema.ColumnDataType[0]);
+    PlanNode root = new ValueNode(stageId, emptySchema, null, Collections.emptyList(), Collections.emptyList());
+    PlanFragment fragment = new PlanFragment(stageId, root, Collections.emptyList());
+    DispatchablePlanFragment dispatchable = new DispatchablePlanFragment(fragment);
+    if (tableName != null) {
+      dispatchable.setTableName(tableName);
+    }
+    return dispatchable;
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/InstanceResponseBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/InstanceResponseBlock.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.datatable.DataTable;
 import org.apache.pinot.common.utils.DataSchema;
@@ -49,7 +50,8 @@ public class InstanceResponseBlock implements Block {
         _exceptions.put(errMsg.getErrCode().getId(), errMsg.getUsrMsg());
       }
     }
-    _metadata = resultsBlock.getResultsMetadata();
+    // Copy the metadata to a concurrent hash map to avoid concurrent modification exceptions when merging stats
+    _metadata = new ConcurrentHashMap<>(resultsBlock.getResultsMetadata());
   }
 
   /**
@@ -58,13 +60,13 @@ public class InstanceResponseBlock implements Block {
   public InstanceResponseBlock() {
     _resultsBlock = null;
     _exceptions = new HashMap<>();
-    _metadata = new HashMap<>();
+    _metadata = new ConcurrentHashMap<>();
   }
 
   private InstanceResponseBlock(Map<Integer, String> exceptions, Map<String, String> metadata) {
     _resultsBlock = null;
     _exceptions = exceptions;
-    _metadata = metadata;
+    _metadata = new ConcurrentHashMap<>(metadata);
   }
 
   public InstanceResponseBlock toMetadataOnlyResponseBlock() {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/QueryScheduler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/QueryScheduler.java
@@ -150,9 +150,11 @@ public abstract class QueryScheduler {
       String queryId = executionContext.getCid();
       String workloadName = executionContext.getWorkloadName();
       Map<String, String> responseMetadata = instanceResponse.getResponseMetadata();
-      responseMetadata.put(MetadataKey.REQUEST_ID.getName(), Long.toString(requestId));
-      responseMetadata.put(MetadataKey.QUERY_ID.getName(), queryId);
-      responseMetadata.put(MetadataKey.WORKLOAD_NAME.getName(), workloadName);
+      synchronized (responseMetadata) {
+        responseMetadata.put(MetadataKey.REQUEST_ID.getName(), Long.toString(requestId));
+        responseMetadata.put(MetadataKey.QUERY_ID.getName(), queryId);
+        responseMetadata.put(MetadataKey.WORKLOAD_NAME.getName(), workloadName);
+      }
       byte[] responseBytes = serializeResponse(queryRequest, instanceResponse);
 
       // Log the statistics

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/MultiStageStatsTreeBuilder.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/MultiStageStatsTreeBuilder.java
@@ -47,7 +47,7 @@ public class MultiStageStatsTreeBuilder {
     PlanNode planNode = _planNodes.get(stage);
 
     MultiStageQueryStats.StageStats stageStats = stage < _queryStats.size() ? _queryStats.get(stage) : null;
-    if (stageStats == null) {
+    if (stageStats == null || stageStats.isEmpty()) {
       // We don't have stats for this stage. This can happen when the stage is not executed. For example, when there
       // are no segments for a table.
       ObjectNode jsonNodes = JsonUtils.newObjectNode();

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/MultiStageStatsTreeBuilderTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/MultiStageStatsTreeBuilderTest.java
@@ -1,0 +1,88 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.query.planner.PlanFragment;
+import org.apache.pinot.query.planner.physical.DispatchablePlanFragment;
+import org.apache.pinot.query.planner.plannode.PlanNode;
+import org.apache.pinot.query.planner.plannode.ValueNode;
+import org.apache.pinot.query.runtime.plan.MultiStageQueryStats;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class MultiStageStatsTreeBuilderTest {
+  private static PlanNode createMinimalPlanNode(int stageId) {
+    // Minimal ValueNode with empty schema and no literals
+    DataSchema emptySchema = new DataSchema(new String[0], new DataSchema.ColumnDataType[0]);
+    return new ValueNode(stageId, emptySchema, null, Collections.emptyList(), Collections.emptyList());
+  }
+
+  private static DispatchablePlanFragment createDispatchableFragmentForStage(int stageId) {
+    PlanNode root = createMinimalPlanNode(stageId);
+    PlanFragment fragment = new PlanFragment(stageId, root, Collections.emptyList());
+    DispatchablePlanFragment dispatchable = new DispatchablePlanFragment(fragment);
+    // Set optional table name for better coverage
+    dispatchable.setTableName("testTable_OFFLINE");
+    return dispatchable;
+  }
+
+  @Test
+  public void jsonStatsByStageReturnsPlaceholderWhenStageStatsIsNull() {
+    Map<Integer, DispatchablePlanFragment> fragments = new HashMap<>();
+    fragments.put(0, createDispatchableFragmentForStage(0));
+
+    List<MultiStageQueryStats.StageStats> stats = new ArrayList<>();
+    // Intentionally leave index 0 as null by having an empty list
+
+    MultiStageStatsTreeBuilder builder = new MultiStageStatsTreeBuilder(fragments, stats);
+    ObjectNode node = builder.jsonStatsByStage(0);
+
+    Assert.assertEquals("EMPTY_MAILBOX_SEND", node.get("type").asText());
+    Assert.assertEquals(0, node.get("stage").asInt());
+    Assert.assertTrue(node.get("description").asText().contains("No stats available"));
+  }
+
+  @Test
+  public void jsonStatsByStageReturnsPlaceholderWhenStageStatsIsEmpty() {
+    Map<Integer, DispatchablePlanFragment> fragments = new HashMap<>();
+    fragments.put(0, createDispatchableFragmentForStage(0));
+
+    // Create an explicit empty Closed stats for stage 0
+    MultiStageQueryStats.StageStats.Closed emptyClosed =
+        new MultiStageQueryStats.StageStats.Closed(Collections.emptyList(), Collections.emptyList());
+    List<MultiStageQueryStats.StageStats> stats = new ArrayList<>();
+    stats.add(emptyClosed);
+
+    MultiStageStatsTreeBuilder builder = new MultiStageStatsTreeBuilder(fragments, stats);
+    JsonNode node = builder.jsonStatsByStage(0);
+
+    Assert.assertEquals("EMPTY_MAILBOX_SEND", node.get("type").asText());
+    Assert.assertEquals(0, node.get("stage").asInt());
+    Assert.assertTrue(node.get("description").asText().contains("No stats available"));
+  }
+}


### PR DESCRIPTION
- Snapshot `LeafOperator` execution metadata before merging so we stop hitting `INTERNAL=Caught exception while executing leaf stage: java.util.ConcurrentModificationException`, and emit a clear error log when a leaf stage fails.

- Treat null/empty `StageStats` as “no stats” in `MultiStageStatsTreeBuilder`, ensuring the broker’s stage-stats tree shows `EMPTY_MAILBOX_SEND` placeholders instead of recursing into missing stages.

- Add broker/runtime regression tests covering mixed empty/populated stage stats and the concurrent metadata merge path (`MultiStageBrokerRequestHandlerTest`, `MultiStageStatsTreeBuilderTest`, and `LeafOperatorTest`).