### PR TITLE
add gauges + rejections counter for mse thread usage and limit when the limiting feature is used

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
@@ -153,7 +153,11 @@ public enum ServerGauge implements AbstractMetrics.Gauge {
 
   // ThrottleOnCriticalHeapUsageExecutor metrics
   THROTTLE_EXECUTOR_QUEUE_SIZE("count", true,
-      "Current number of tasks in the throttle executor queue");
+      "Current number of tasks in the throttle executor queue"),
+
+  // Multi-stage executor thread usage metrics
+  MSE_THREAD_USAGE_MAX("threads", true, "Maximum allowed threads for multi-stage executor"),
+  MSE_THREAD_USAGE_CURRENT("threads", true, "Current number of threads in use by multi-stage executor");
 
   private final String _gaugeName;
   private final String _unit;

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
@@ -156,8 +156,8 @@ public enum ServerGauge implements AbstractMetrics.Gauge {
       "Current number of tasks in the throttle executor queue"),
 
   // Multi-stage executor thread usage metrics
-  MSE_THREAD_USAGE_MAX("threads", true, "Maximum allowed threads for multi-stage executor"),
-  MSE_THREAD_USAGE_CURRENT("threads", true, "Current number of threads in use by multi-stage executor");
+  MSE_EXECUTION_THREADS_MAX("threads", true, "Maximum allowed threads for multi-stage executor"),
+  MSE_EXECUTION_THREADS_CURRENT("threads", true, "Current number of threads in use by multi-stage executor");
 
   private final String _gaugeName;
   private final String _unit;

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
@@ -203,6 +203,10 @@ public enum ServerMeter implements AbstractMetrics.Meter {
   /// Number of tasks completed by the MSE query submission executor
   MULTI_STAGE_SUBMISSION_COMPLETED_TASKS("tasks", true),
 
+  // Multi-stage executor thread limit metrics
+  MSE_THREAD_LIMIT_TASK_REJECTIONS("tasks", true,
+      "Number of tasks rejected by multi-stage executor due to thread limit being exceeded"),
+
   // predownload metrics
   PREDOWNLOAD_SEGMENT_DOWNLOAD_COUNT("predownloadSegmentCount", true),
   PREDOWNLOAD_SEGMENT_DOWNLOAD_FAILURE_COUNT("predownloadSegmentFailureCount", true),

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
@@ -204,7 +204,7 @@ public enum ServerMeter implements AbstractMetrics.Meter {
   MULTI_STAGE_SUBMISSION_COMPLETED_TASKS("tasks", true),
 
   // Multi-stage executor thread limit metrics
-  MSE_THREAD_LIMIT_TASK_REJECTIONS("tasks", true,
+  MSE_EXECUTION_THREADS_TASK_REJECTIONS("tasks", true,
       "Number of tasks rejected by multi-stage executor due to thread limit being exceeded"),
 
   // predownload metrics

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
@@ -217,7 +217,8 @@ public class QueryRunner {
       LOGGER.info("Setting multi-stage executor hardLimit: {} exceedStrategy: {}", hardLimit, exceedStrategy);
       _executorService = new HardLimitExecutor(hardLimit, _executorService, exceedStrategy,
           max -> serverMetrics.setValueOfGlobalGauge(ServerGauge.MSE_THREAD_USAGE_MAX, max.longValue()),
-          current -> serverMetrics.setValueOfGlobalGauge(ServerGauge.MSE_THREAD_USAGE_CURRENT, current.longValue()));
+          current -> serverMetrics.setValueOfGlobalGauge(ServerGauge.MSE_THREAD_USAGE_CURRENT, current.longValue()),
+          () -> serverMetrics.addMeteredGlobalValue(ServerMeter.MSE_THREAD_LIMIT_TASK_REJECTIONS, 1L));
     }
 
     _executorService = ThrottleOnCriticalHeapUsageExecutor.maybeWrap(

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
@@ -31,7 +31,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.function.BiConsumer;
 import java.util.function.BooleanSupplier;
 import java.util.function.Consumer;
-import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
@@ -217,14 +216,14 @@ public class QueryRunner {
       }
       LOGGER.info("Setting multi-stage executor hardLimit: {} exceedStrategy: {}", hardLimit, exceedStrategy);
       HardLimitExecutor hardLimitExecutor = new HardLimitExecutor(hardLimit, _executorService, exceedStrategy,
-          () -> serverMetrics.addMeteredGlobalValue(ServerMeter.MSE_THREAD_LIMIT_TASK_REJECTIONS, 1L));
+          () -> serverMetrics.addMeteredGlobalValue(ServerMeter.MSE_EXECUTION_THREADS_TASK_REJECTIONS, 1L));
 
       // Set max thread limit gauge (constant value)
-      serverMetrics.setValueOfGlobalGauge(ServerGauge.MSE_THREAD_USAGE_MAX, (long) hardLimit);
+      serverMetrics.setValueOfGlobalGauge(ServerGauge.MSE_EXECUTION_THREADS_MAX, (long) hardLimit);
 
       // Register callback gauge for current thread usage
-      serverMetrics.setOrUpdateGauge(ServerGauge.MSE_THREAD_USAGE_CURRENT.getGaugeName(),
-          (Supplier<Long>) () -> (long) hardLimitExecutor.getCurrentThreadUsage());
+      serverMetrics.setOrUpdateGlobalGauge(ServerGauge.MSE_EXECUTION_THREADS_CURRENT,
+          hardLimitExecutor::getCurrentThreadUsage);
 
       _executorService = hardLimitExecutor;
     }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
@@ -38,6 +38,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pinot.common.config.TlsConfig;
 import org.apache.pinot.common.datatable.StatMap;
+import org.apache.pinot.common.metrics.ServerGauge;
 import org.apache.pinot.common.metrics.ServerMeter;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.proto.Worker;
@@ -214,7 +215,9 @@ public class QueryRunner {
         exceedStrategy = QueryThreadExceedStrategy.valueOf(Server.DEFAULT_MSE_MAX_EXECUTION_THREADS_EXCEED_STRATEGY);
       }
       LOGGER.info("Setting multi-stage executor hardLimit: {} exceedStrategy: {}", hardLimit, exceedStrategy);
-      _executorService = new HardLimitExecutor(hardLimit, _executorService, exceedStrategy);
+      _executorService = new HardLimitExecutor(hardLimit, _executorService, exceedStrategy,
+          max -> serverMetrics.setValueOfGlobalGauge(ServerGauge.MSE_THREAD_USAGE_MAX, max.longValue()),
+          current -> serverMetrics.setValueOfGlobalGauge(ServerGauge.MSE_THREAD_USAGE_CURRENT, current.longValue()));
     }
 
     _executorService = ThrottleOnCriticalHeapUsageExecutor.maybeWrap(

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
@@ -217,8 +217,10 @@ public class QueryRunner {
       }
       LOGGER.info("Setting multi-stage executor hardLimit: {} exceedStrategy: {}", hardLimit, exceedStrategy);
       HardLimitExecutor hardLimitExecutor = new HardLimitExecutor(hardLimit, _executorService, exceedStrategy,
-          max -> serverMetrics.setValueOfGlobalGauge(ServerGauge.MSE_THREAD_USAGE_MAX, max.longValue()),
           () -> serverMetrics.addMeteredGlobalValue(ServerMeter.MSE_THREAD_LIMIT_TASK_REJECTIONS, 1L));
+
+      // Set max thread limit gauge (constant value)
+      serverMetrics.setValueOfGlobalGauge(ServerGauge.MSE_THREAD_USAGE_MAX, (long) hardLimit);
 
       // Register callback gauge for current thread usage
       serverMetrics.setOrUpdateGauge(ServerGauge.MSE_THREAD_USAGE_CURRENT.getGaugeName(),

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/executor/HardLimitExecutor.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/executor/HardLimitExecutor.java
@@ -55,6 +55,14 @@ public class HardLimitExecutor extends DecoratorExecutorService {
     _currentUsageGaugeUpdater.accept(0);
   }
 
+  public HardLimitExecutor(int max, ExecutorService executorService, QueryThreadExceedStrategy exceedStrategy) {
+    this(max, executorService, exceedStrategy, max1 -> { }, current -> { }, () -> { });
+  }
+
+  public HardLimitExecutor(int max, ExecutorService executorService) {
+    this(max, executorService, QueryThreadExceedStrategy.ERROR);
+  }
+
   /**
    * Returns the hard limit of the number of threads that can be used by the multi-stage executor.
    * @param serverConf Pinot configuration

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/executor/HardLimitExecutor.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/executor/HardLimitExecutor.java
@@ -21,7 +21,6 @@ package org.apache.pinot.spi.executor;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.function.Consumer;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.query.QueryThreadExceedStrategy;
 import org.apache.pinot.spi.utils.CommonConstants;
@@ -42,17 +41,16 @@ public class HardLimitExecutor extends DecoratorExecutorService {
   private final Runnable _taskRejectionCounter;
 
   public HardLimitExecutor(int max, ExecutorService executorService, QueryThreadExceedStrategy exceedStrategy,
-      Consumer<Integer> maxUsageGaugeUpdater, Runnable taskRejectionCounter) {
+      Runnable taskRejectionCounter) {
     super(executorService);
     _running = new AtomicInteger(0);
     _max = max;
     _exceedStrategy = exceedStrategy;
     _taskRejectionCounter = taskRejectionCounter;
-    maxUsageGaugeUpdater.accept(max);
   }
 
   public HardLimitExecutor(int max, ExecutorService executorService, QueryThreadExceedStrategy exceedStrategy) {
-    this(max, executorService, exceedStrategy, max1 -> { }, () -> { });
+    this(max, executorService, exceedStrategy, () -> { });
   }
 
   public HardLimitExecutor(int max, ExecutorService executorService) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/executor/HardLimitExecutor.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/executor/HardLimitExecutor.java
@@ -55,14 +55,6 @@ public class HardLimitExecutor extends DecoratorExecutorService {
     _currentUsageGaugeUpdater.accept(0);
   }
 
-  public HardLimitExecutor(int max, ExecutorService executorService, QueryThreadExceedStrategy exceedStrategy) {
-    this(max, executorService, exceedStrategy, max1 -> { }, current -> { }, () -> { });
-  }
-
-  public HardLimitExecutor(int max, ExecutorService executorService) {
-    this(max, executorService, QueryThreadExceedStrategy.ERROR);
-  }
-
   /**
    * Returns the hard limit of the number of threads that can be used by the multi-stage executor.
    * @param serverConf Pinot configuration

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/executor/HardLimitExecutorTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/executor/HardLimitExecutorTest.java
@@ -142,7 +142,7 @@ public class HardLimitExecutorTest {
   }
 
   @Test
-  public void testGaugeTracking()
+  public void testMetricsTracking()
       throws Exception {
     AtomicInteger maxGauge = new AtomicInteger(-1);
     AtomicInteger currentGauge = new AtomicInteger(-1);

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/executor/HardLimitExecutorTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/executor/HardLimitExecutorTest.java
@@ -40,7 +40,7 @@ public class HardLimitExecutorTest {
       throws Exception {
     AtomicInteger rejectionCount = new AtomicInteger(0);
     HardLimitExecutor ex = new HardLimitExecutor(1, Executors.newCachedThreadPool(),
-        QueryThreadExceedStrategy.ERROR, max -> { }, rejectionCount::incrementAndGet);
+        QueryThreadExceedStrategy.ERROR, rejectionCount::incrementAndGet);
     CyclicBarrier barrier = new CyclicBarrier(2);
 
     try {
@@ -78,7 +78,7 @@ public class HardLimitExecutorTest {
       throws Exception {
     AtomicInteger rejectionCount = new AtomicInteger(0);
     HardLimitExecutor ex = new HardLimitExecutor(1, Executors.newCachedThreadPool(), QueryThreadExceedStrategy.LOG,
-        max -> { }, rejectionCount::incrementAndGet);
+        rejectionCount::incrementAndGet);
     CyclicBarrier barrier = new CyclicBarrier(2);
 
     try {
@@ -144,18 +144,15 @@ public class HardLimitExecutorTest {
   @Test
   public void testMetricsTracking()
       throws Exception {
-    AtomicInteger maxGauge = new AtomicInteger(-1);
     AtomicInteger rejectionCount = new AtomicInteger(0);
 
     HardLimitExecutor ex = new HardLimitExecutor(2, Executors.newCachedThreadPool(),
         QueryThreadExceedStrategy.ERROR,
-        max -> maxGauge.set(max),
         rejectionCount::incrementAndGet);
 
     CyclicBarrier barrier = new CyclicBarrier(3);
 
     try {
-      assertEquals(maxGauge.get(), 2);
       assertEquals(ex.getCurrentThreadUsage(), 0);
       assertEquals(rejectionCount.get(), 0);
 
@@ -180,7 +177,6 @@ public class HardLimitExecutorTest {
       barrier.await();
 
       assertEquals(ex.getCurrentThreadUsage(), 2);
-      assertEquals(maxGauge.get(), 2);
       assertEquals(rejectionCount.get(), 0);
 
       // Try to submit a third task, should be rejected

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/executor/HardLimitExecutorTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/executor/HardLimitExecutorTest.java
@@ -40,7 +40,7 @@ public class HardLimitExecutorTest {
       throws Exception {
     AtomicInteger rejectionCount = new AtomicInteger(0);
     HardLimitExecutor ex = new HardLimitExecutor(1, Executors.newCachedThreadPool(),
-        QueryThreadExceedStrategy.ERROR, max -> { }, current -> { }, rejectionCount::incrementAndGet);
+        QueryThreadExceedStrategy.ERROR, max -> { }, rejectionCount::incrementAndGet);
     CyclicBarrier barrier = new CyclicBarrier(2);
 
     try {
@@ -78,7 +78,7 @@ public class HardLimitExecutorTest {
       throws Exception {
     AtomicInteger rejectionCount = new AtomicInteger(0);
     HardLimitExecutor ex = new HardLimitExecutor(1, Executors.newCachedThreadPool(), QueryThreadExceedStrategy.LOG,
-        max -> { }, current -> { }, rejectionCount::incrementAndGet);
+        max -> { }, rejectionCount::incrementAndGet);
     CyclicBarrier barrier = new CyclicBarrier(2);
 
     try {
@@ -145,20 +145,18 @@ public class HardLimitExecutorTest {
   public void testMetricsTracking()
       throws Exception {
     AtomicInteger maxGauge = new AtomicInteger(-1);
-    AtomicInteger currentGauge = new AtomicInteger(-1);
     AtomicInteger rejectionCount = new AtomicInteger(0);
 
     HardLimitExecutor ex = new HardLimitExecutor(2, Executors.newCachedThreadPool(),
         QueryThreadExceedStrategy.ERROR,
         max -> maxGauge.set(max),
-        current -> currentGauge.set(current),
         rejectionCount::incrementAndGet);
 
     CyclicBarrier barrier = new CyclicBarrier(3);
 
     try {
       assertEquals(maxGauge.get(), 2);
-      assertEquals(currentGauge.get(), 0);
+      assertEquals(ex.getCurrentThreadUsage(), 0);
       assertEquals(rejectionCount.get(), 0);
 
       ex.execute(() -> {
@@ -181,7 +179,7 @@ public class HardLimitExecutorTest {
 
       barrier.await();
 
-      assertEquals(currentGauge.get(), 2);
+      assertEquals(ex.getCurrentThreadUsage(), 2);
       assertEquals(maxGauge.get(), 2);
       assertEquals(rejectionCount.get(), 0);
 


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Adds MSE thread limit gauges and rejection counter; init creates executor, sets max gauge, registers usage gauge, and increments counter on limit exceed\.

```mermaid
flowchart TD
  N0["QueryRunner#46;init #40;F3#41;"]:::stAdded
  N1["HardLimitExecutor constructor #40;F4#41;"]:::stAdded
  N2["Set max gauge #40;MSE#95;EXECUTION#95;THREADS#95;MAX#41; #40;F3#41;"]:::stAdded
  N3["Register current gauge #40;MSE#95;EXECUTION#95;THREADS#95;CURRENT#41; #40;F3#41;"]:::stAdded
  N4["getCurrentThreadUsage method #40;F4#41;"]:::stAdded
  N5["checkTaskAllowed exceed branch #40;ERROR#41; #40;F4#41;"]:::stAdded
  N6["Increment rejection meter #40;MSE#95;EXECUTION#95;THREADS#95;TASK#95;REJECTIONS#41; #40;F3#41;"]:::stAdded
  N0 -->|"constructor call with rejection lambda"| N1
  N0 -->|"set max gauge value"| N2
  N0 -->|"register current gauge callback"| N3
  N3 -->|"gauge callback invokes getCurrentThreadUsage"| N4
  N5 -->|"call taskRejectionCounter #45;#62; increment meter"| N6
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F3: pinot\-query\-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner\.java — [before](https://github.com/apache/pinot/blob/c6d4f1c5aab5bf64c4b351f479d9ae95e3483f81/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java) · [after](https://github.com/apache/pinot/blob/effa3fcd9ddfca9c9e656a371f7ce005c3a6398a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java)
- F4: pinot\-spi/src/main/java/org/apache/pinot/spi/executor/HardLimitExecutor\.java — [before](https://github.com/apache/pinot/blob/c6d4f1c5aab5bf64c4b351f479d9ae95e3483f81/pinot-spi/src/main/java/org/apache/pinot/spi/executor/HardLimitExecutor.java) · [after](https://github.com/apache/pinot/blob/effa3fcd9ddfca9c9e656a371f7ce005c3a6398a/pinot-spi/src/main/java/org/apache/pinot/spi/executor/HardLimitExecutor.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImM2ZDRmMWM1YWFiNWJmNjRjNGIzNTFmNDc5ZDlhZTk1ZTM0ODNmODEiLCJjb250ZXh0X2hhc2giOiI3ZTQ1OGIxY2Y1MjA4MTFmOGIzZGRmNjFiNDM1MTZmYTRmMmFkZTVmNTgzYTcwM2NmNGQzMzMzM2Y0OGRmZTU2IiwiZ2VuZXJhdGVkX2F0IjoxNzg5NjQxMTUwLCJoZWFkX3NoYSI6ImVmZmEzZmNkOWRkZmNhOWM5ZTY1NmEzNzFmN2NlMDA1YzNhNjM5OGEiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJjNmQ0ZjFjNWFhYjViZjY0YzRiMzUxZjQ3OWQ5YWU5NWUzNDgzZjgxIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 7edf4556c10e947ded4f29cd827c7b2cd0726ce4ef5b718ac2d38655ec2bc92f -->
<!-- pinot-pr-flow:end -->

Currently, when you use the multi stage engine thread limiting feature, (via configs such as below)
```
pinot.server.query.executor.mse.max.execution.threads=1000
pinot.server.query.executor.mse.max.execution.threads.exceed.strategy=ERROR
```
you have no insights, through metrics, what's the current usage or how close you are to the limits. So without this, we are also unable to catch issues inadvance of when users might see them

This PR adds two gauges:
  MSE_EXECUTION_THREADS_MAX("threads", true, "Maximum allowed threads for multi-stage executor"),
  MSE_EXECUTION_THREADS_CURRENT("threads", true, "Current number of threads in use by multi-stage executor");

And a metric for task rejections
MSE_EXECUTION_THREADS_TASK_REJECTIONS("tasks", true,
      "Number of tasks rejected by multi-stage executor due to thread limit being exceeded"),

Also updates the test using similiar code to existing tests
