### PR TITLE
[logical] Add Logical Tables section to Query sidebar in Controller UI

### DIFF
--- a/pinot-controller/src/main/resources/app/components/Query/QuerySideBar.tsx
+++ b/pinot-controller/src/main/resources/app/components/Query/QuerySideBar.tsx
@@ -77,6 +77,7 @@ const useStyles = makeStyles((theme: Theme) =>
 
 type Props = {
   tableList: TableData;
+  logicalTableList?: TableData;
   fetchSQLData: Function;
   tableSchema: TableData;
   selectedTable: string;
@@ -84,7 +85,7 @@ type Props = {
   queryType?: 'sql' | 'timeseries';
 };
 
-const Sidebar = ({ tableList, fetchSQLData, tableSchema, selectedTable, queryLoader }: Props) => {
+const Sidebar = ({ tableList, logicalTableList, fetchSQLData, tableSchema, selectedTable, queryLoader }: Props) => {
   const classes = useStyles();
   const history = useHistory();
   const location = useLocation();
@@ -143,6 +144,17 @@ const Sidebar = ({ tableList, fetchSQLData, tableSchema, selectedTable, queryLoa
               showSearchBox={true}
               inAccordionFormat
             />
+
+            {logicalTableList && logicalTableList.records.length > 0 && isSqlQuery ? (
+              <CustomizedTables
+                title="Logical Tables"
+                data={logicalTableList}
+                cellClickCallback={fetchSQLData}
+                isCellClickable={isSqlQuery}
+                showSearchBox={true}
+                inAccordionFormat
+              />
+            ) : null}
 
             {!queryLoader && tableSchema.records.length && isSqlQuery ? (
               <CustomizedTables

--- a/pinot-controller/src/main/resources/app/pages/Query.tsx
+++ b/pinot-controller/src/main/resources/app/pages/Query.tsx
@@ -228,6 +228,10 @@ const QueryPage = () => {
     columns: [],
     records: [],
   });
+  const [logicalTableList, setLogicalTableList] = useState<TableData>({
+    columns: [],
+    records: [],
+  });
   const [showErrorType, setShowErrorType] = useState<ErrorViewType>(ErrorViewType.EXCEPTION);
 
   const [tableSchema, setTableSchema] = useState<TableData>({
@@ -451,6 +455,8 @@ const QueryPage = () => {
   const fetchData = async () => {
     const result = await PinotMethodUtils.getQueryTablesList({bothType: false});
     setTableList(result);
+    const logicalTablesResult = await PinotMethodUtils.getQueryLogicalTablesList();
+    setLogicalTableList(logicalTablesResult);
     setFetching(false);
   };
 
@@ -526,6 +532,7 @@ const QueryPage = () => {
       <Grid item>
         <QuerySideBar
           tableList={tableList}
+          logicalTableList={logicalTableList}
           fetchSQLData={fetchSQLData}
           tableSchema={tableSchema}
           selectedTable={selectedTable}

--- a/pinot-controller/src/main/resources/app/requests/index.ts
+++ b/pinot-controller/src/main/resources/app/requests/index.ts
@@ -230,6 +230,9 @@ export const getClusterConfig = (): Promise<AxiosResponse<ClusterConfig>> =>
 export const getQueryTables = (type?: string): Promise<AxiosResponse<QueryTables>> =>
   baseApi.get(`/tables${type ? `?type=${type}`: ''}`);
 
+export const getLogicalTables = (): Promise<AxiosResponse<string[]>> =>
+  baseApi.get(`/logicalTables`);
+
 export const getTableSchema = (name: string): Promise<AxiosResponse<TableSchema>> =>
   baseApi.get(`/tables/${name}/schema`);
 

--- a/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
+++ b/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
@@ -114,7 +114,8 @@ import {
   pauseConsumption,
   resumeConsumption,
   getPauseStatus,
-  getVersions
+  getVersions,
+  getLogicalTables
 } from '../requests';
 import { baseApi } from './axios-config';
 import Utils from './Utils';
@@ -272,6 +273,22 @@ const getQueryTablesList = ({bothType = false}) => {
       result.data.tables.map((table)=>{
         responseObj.records.push([table]);
       });
+    });
+    return responseObj;
+  });
+};
+
+// This method is used to display logical table listing on query page
+// API: /logicalTables
+// Expected Output: {columns: [], records: []}
+const getQueryLogicalTablesList = () => {
+  return getLogicalTables().then(({ data }) => {
+    const responseObj = {
+      columns: ['Logical Tables'],
+      records: []
+    };
+    data.map((logicalTable) => {
+      responseObj.records.push([logicalTable]);
     });
     return responseObj;
   });
@@ -1377,6 +1394,7 @@ export default {
   getClusterConfigData,
   getClusterConfigJSON,
   getQueryTablesList,
+  getQueryLogicalTablesList,
   getTableSchemaData,
   getQueryResults,
   getTenantTableData,


### PR DESCRIPTION
## Summary

This PR introduces a new “Logical Tables” panel in the Query sidebar for SQL queries. It fetches data from the `GET /logicalTables` API via `getQueryLogicalTablesList` and displays it using `CustomizedTables`.
The section is only displayed if there is atleast one logical table in the cluster.

## Testing 

### Logical Table section

https://github.com/user-attachments/assets/0407294c-c805-4c34-8aea-d4d5de5dacb7

### Query Section UI when there is no logical table

<img width="1800" height="1169" alt="Screenshot 2025-11-12 at 12 09 48 PM" src="https://github.com/user-attachments/assets/5846385d-661a-4d97-b358-eb7a759a6c40" />
