### PR TITLE
[bugfix] Fix flaky SSBQueryIntegrationTest by waiting for bootstrap

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SSBQueryIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SSBQueryIntegrationTest.java
@@ -93,6 +93,7 @@ public class SSBQueryIntegrationTest extends BaseClusterIntegrationTest {
       uploadSegments(tableName, _tarDir);
       // H2
       ClusterIntegrationTestUtils.setUpH2TableWithAvro(Collections.singletonList(dataFile), tableName, _h2Connection);
+      waitForNonZeroDocsLoaded(60_000L, true, tableName);
     }
   }
 


### PR DESCRIPTION
## Summary

The SSB integration test sometimes raced ahead before ingestion completed, causing the following transient failures:
```
Error:  Failures: 
Error:    SSBQueryIntegrationTest.testSSBQueries:102->testQueriesValidateAgainstH2:108 » PinotClient Query had processing exceptions: 
[{"errorCode":235,"message":"Found 1 unavailable segments for table dates: [dates_0 %]"}]
```
happening in many recent PRs. https://github.com/apache/pinot/pull/17192 is one example.

This PR fixes it by waiting for a non-zero count for each table being initialized, before the integration tests are run.

## Testing

Verified by running the integration test multiple times to assert transient failures are gone.

### Before:
```
shauryachats-pinot3% run_tests_n_times() { for i in $(seq 1 $1); do echo -n "Run #$i: "; mvn test -Dtest=SSBQueryIntegrationTest -pl pinot-integration-tests >/dev/null 2>&1 && echo "PASSED" || echo "FAILED"; done; }

shauryachats-pinot3% run_tests_n_times 10                                                                                                                                                                              
Run #1: PASSED
Run #2: PASSED
Run #3: PASSED
Run #4: FAILED
Run #5: FAILED
Run #6: PASSED
Run #7: PASSED
Run #8: FAILED
Run #9: PASSED
Run #10: FAILED
```

### After:
```
shauryachats-pinot3% run_tests_n_times 10                                                                                                                                                                              
Run #1: PASSED
Run #2: PASSED
Run #3: PASSED
Run #4: PASSED
Run #5: PASSED
Run #6: PASSED
Run #7: PASSED
Run #8: PASSED
Run #9: PASSED
Run #10: PASSED
```