### PR TITLE
Fix collision in trace

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/util/trace/BuiltInTracer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/trace/BuiltInTracer.java
@@ -62,8 +62,8 @@ public class BuiltInTracer implements Tracer {
   }
 
   @Override
-  public void register(long requestId) {
-    TraceContext.register(requestId);
+  public void register() {
+    TraceContext.register();
   }
 
   @Override

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/trace/Tracer.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/trace/Tracer.java
@@ -26,12 +26,9 @@ package org.apache.pinot.spi.trace;
 public interface Tracer {
 
   /**
-   * Registers the requestId on the current thread. This means the request will be traced.
-   * TODO: Consider using string id or random id. Currently different broker might send query with the same request id.
-   *
-   * @param requestId the requestId
+   * Registers the current thread for tracing.
    */
-  void register(long requestId);
+  void register();
 
   /**
    * Detach a trace from the current thread.

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/trace/Tracing.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/trace/Tracing.java
@@ -88,7 +88,7 @@ public class Tracing {
     static final FallbackTracer INSTANCE = new FallbackTracer();
 
     @Override
-    public void register(long requestId) {
+    public void register() {
     }
 
     @Override


### PR DESCRIPTION
Do not use request id as trace id because request id is not guaranteed to be unique across all server requests. E.g. for multi-stage query, one query can be split into multiple server requests, all with same request id and stage id.

Instead of using request id as trace id, trace id can be maintained within `TraceContext` completely, where we can simply generate a new id for each trace instance.

## Incompatible
`Tracer.register(long requestId);` is changed to `Tracer.register();`