### PR TITLE
Add timeout overflow break handling at leaf stage

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -977,6 +977,10 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
             (int) numSegmentsPrunedByBroker);
         brokerResponse.addBrokerStats(brokerPruningStats);
       }
+
+      if (isLeafStageMissingStats(queryStageMap, queryStats)) {
+        brokerResponse.mergeTimeoutOverflowReached(true);
+      }
     } catch (Exception e) {
       LOGGER.warn("Error encountered while collecting multi-stage stats", e);
       brokerResponse.setStageStats(JsonNodeFactory.instance.objectNode()
@@ -996,6 +1000,31 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
       }
       brokerResponse.setStreamStatsCoverage(coverageArray);
     }
+  }
+
+  private boolean isLeafStageMissingStats(Map<Integer, DispatchablePlanFragment> queryStageMap,
+      List<MultiStageQueryStats.StageStats.Closed> queryStats) {
+    for (Map.Entry<Integer, DispatchablePlanFragment> entry : queryStageMap.entrySet()) {
+      int stageId = entry.getKey();
+      DispatchablePlanFragment fragment = entry.getValue();
+      if (!isLeafStage(fragment)) {
+        continue;
+      }
+      MultiStageQueryStats.StageStats.Closed stageStats =
+          stageId < queryStats.size() ? queryStats.get(stageId) : null;
+      if (stageStats == null) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private boolean isLeafStage(DispatchablePlanFragment fragment) {
+    Map<String, String> customProperties = fragment.getCustomProperties();
+    if (customProperties.containsKey(DispatchablePlanFragment.TABLE_NAME_KEY)) {
+      return true;
+    }
+    return !fragment.getWorkerIdToSegmentsMap().isEmpty();
   }
 
   private BrokerResponse constructMultistageExplainPlan(String sql, String plan, Map<String, String> extraFields) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNativeV2.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNativeV2.java
@@ -80,6 +80,7 @@ public class BrokerResponseNativeV2 implements BrokerResponse {
   private String _requestId;
   private String _clientRequestId;
   private String _brokerId;
+  private boolean _timeoutOverflowReached;
   private int _numServersQueried;
   private int _numServersResponded;
   private long _brokerReduceTimeMs;
@@ -118,7 +119,7 @@ public class BrokerResponseNativeV2 implements BrokerResponse {
   @Override
   public boolean isPartialResult() {
     return getExceptionsSize() > 0 || isNumGroupsLimitReached() || !getEarlyTerminationReasons().isEmpty()
-        || isMaxRowsInJoinReached() || isMseLiteLeafStageLimitReached();
+        || isMaxRowsInJoinReached() || isMseLiteLeafStageLimitReached() || isTimeoutOverflowReached();
   }
 
   @Override
@@ -201,6 +202,18 @@ public class BrokerResponseNativeV2 implements BrokerResponse {
   @JsonInclude(JsonInclude.Include.NON_EMPTY)
   public List<String> getEarlyTerminationReasons() {
     return List.copyOf(_brokerStats.getStringSet(StatKey.EARLY_TERMINATION_REASONS));
+  }
+
+  @JsonProperty("timeoutOverflowReached")
+  public boolean isTimeoutOverflowReached() {
+    return _timeoutOverflowReached;
+  }
+
+  public void mergeTimeoutOverflowReached(boolean timeoutOverflowReached) {
+    if (timeoutOverflowReached) {
+      _timeoutOverflowReached = true;
+    }
+    _brokerStats.merge(StatKey.TIMEOUT_OVERFLOW_REACHED, timeoutOverflowReached);
   }
 
   @Override
@@ -501,6 +514,9 @@ public class BrokerResponseNativeV2 implements BrokerResponse {
 
   public void addBrokerStats(StatMap<StatKey> brokerStats) {
     _brokerStats.merge(brokerStats);
+    if (brokerStats.getBoolean(StatKey.TIMEOUT_OVERFLOW_REACHED)) {
+      _timeoutOverflowReached = true;
+    }
   }
 
   // NOTE: The following keys should match the keys in the leaf-stage operator.
@@ -536,7 +552,8 @@ public class BrokerResponseNativeV2 implements BrokerResponse {
       }
     },
     EARLY_TERMINATION_REASONS(StatMap.Type.STRING_SET),
-    LITE_MODE_LEAF_STAGE_LIMIT_REACHED(StatMap.Type.BOOLEAN);
+    LITE_MODE_LEAF_STAGE_LIMIT_REACHED(StatMap.Type.BOOLEAN),
+    TIMEOUT_OVERFLOW_REACHED(StatMap.Type.BOOLEAN);
 
     private final StatMap.Type _type;
 

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
@@ -33,6 +33,7 @@ import org.apache.pinot.spi.config.table.FieldConfig;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.CommonConstants.Broker.Request.QueryOptionKey;
 import org.apache.pinot.spi.utils.CommonConstants.MultiStageQueryRunner.JoinOverFlowMode;
+import org.apache.pinot.spi.utils.CommonConstants.MultiStageQueryRunner.TimeoutOverflowMode;
 import org.apache.pinot.spi.utils.CommonConstants.MultiStageQueryRunner.WindowOverFlowMode;
 
 
@@ -503,6 +504,24 @@ public class QueryOptionsUtils {
   public static WindowOverFlowMode getWindowOverflowMode(Map<String, String> queryOptions) {
     String windowOverflowModeStr = queryOptions.get(QueryOptionKey.WINDOW_OVERFLOW_MODE);
     return windowOverflowModeStr != null ? WindowOverFlowMode.valueOf(windowOverflowModeStr) : null;
+  }
+
+  @Nullable
+  public static TimeoutOverflowMode getTimeoutOverflowMode(Map<String, String> queryOptions) {
+    String timeoutOverflowModeStr = queryOptions.get(QueryOptionKey.TIMEOUT_OVERFLOW_MODE);
+    return timeoutOverflowModeStr != null ? TimeoutOverflowMode.valueOf(timeoutOverflowModeStr) : null;
+  }
+
+  @Nullable
+  public static Long getLeafTimeoutMs(Map<String, String> queryOptions) {
+    String leafTimeoutMs = queryOptions.get(QueryOptionKey.LEAF_TIMEOUT_MS);
+    return checkedParseLongPositive(QueryOptionKey.LEAF_TIMEOUT_MS, leafTimeoutMs);
+  }
+
+  @Nullable
+  public static Long getLeafExtraPassiveTimeoutMs(Map<String, String> queryOptions) {
+    String leafExtraPassiveTimeoutMs = queryOptions.get(QueryOptionKey.LEAF_EXTRA_PASSIVE_TIMEOUT_MS);
+    return checkedParseLong(QueryOptionKey.LEAF_EXTRA_PASSIVE_TIMEOUT_MS, leafExtraPassiveTimeoutMs, 0);
   }
 
   public static boolean isSkipUnavailableServers(Map<String, String> queryOptions) {

--- a/pinot-common/src/test/java/org/apache/pinot/common/response/broker/BrokerResponseNativeV2Test.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/response/broker/BrokerResponseNativeV2Test.java
@@ -18,10 +18,13 @@
  */
 package org.apache.pinot.common.response.broker;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import org.apache.pinot.common.datatable.StatMap;
+import org.apache.pinot.spi.utils.JsonUtils;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
@@ -45,6 +48,23 @@ public class BrokerResponseNativeV2Test {
     assertEquals(brokerResponse.getEarlyTerminationReasons(),
         List.of("DISTINCT_MAX_ROWS", "DISTINCT_MAX_ROWS_WITHOUT_CHANGE", "DISTINCT_MAX_EXECUTION_TIME"));
     assertTrue(brokerResponse.isPartialResult());
+  }
+
+  @Test
+  public void testTimeoutOverflowFlagSerialized()
+      throws IOException {
+    BrokerResponseNativeV2 response = new BrokerResponseNativeV2();
+    assertFalse(response.isTimeoutOverflowReached());
+    assertFalse(response.isPartialResult());
+
+    response.mergeTimeoutOverflowReached(true);
+
+    assertTrue(response.isTimeoutOverflowReached());
+    assertTrue(response.isPartialResult());
+
+    JsonNode json = JsonUtils.objectToJsonNode(response);
+    assertTrue(json.get("timeoutOverflowReached").asBoolean());
+    assertTrue(json.get("partialResult").asBoolean());
   }
 
   private static Set<String> stringSet(String... values) {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
@@ -77,6 +77,7 @@ import org.apache.pinot.spi.utils.CommonConstants.Broker.Request.QueryOptionKey;
 import org.apache.pinot.spi.utils.CommonConstants.Helix;
 import org.apache.pinot.spi.utils.CommonConstants.MultiStageQueryRunner;
 import org.apache.pinot.spi.utils.CommonConstants.MultiStageQueryRunner.JoinOverFlowMode;
+import org.apache.pinot.spi.utils.CommonConstants.MultiStageQueryRunner.TimeoutOverflowMode;
 import org.apache.pinot.spi.utils.CommonConstants.MultiStageQueryRunner.WindowOverFlowMode;
 import org.apache.pinot.spi.utils.CommonConstants.Query.Request;
 import org.apache.pinot.spi.utils.CommonConstants.Query.Response;
@@ -96,6 +97,7 @@ import org.slf4j.LoggerFactory;
 /// [QueryRunner] accepts a [StagePlan] and runs it.
 public class QueryRunner {
   private static final Logger LOGGER = LoggerFactory.getLogger(QueryRunner.class);
+  private static final double DEFAULT_LEAF_TIMEOUT_RATIO = 0.8;
 
   private ExecutorService _executorService;
   private OpChainSchedulerService _opChainScheduler;
@@ -127,6 +129,8 @@ public class QueryRunner {
   private Integer _maxRowsInWindow;
   @Nullable
   private WindowOverFlowMode _windowOverflowMode;
+  @Nullable
+  private TimeoutOverflowMode _timeoutOverflowMode;
   @Nullable
   private PhysicalTimeSeriesServerPlanVisitor _timeSeriesPhysicalPlanVisitor;
   /// Cluster-level decision on whether to send stats over the mailbox path, driven by the `SendStatsPredicate`
@@ -187,6 +191,10 @@ public class QueryRunner {
 
     String windowOverflowModeStr = serverConf.getProperty(MultiStageQueryRunner.KEY_OF_WINDOW_OVERFLOW_MODE);
     _windowOverflowMode = windowOverflowModeStr != null ? WindowOverFlowMode.valueOf(windowOverflowModeStr) : null;
+
+    String timeoutOverflowModeStr = serverConf.getProperty(MultiStageQueryRunner.KEY_OF_TIMEOUT_OVERFLOW_MODE);
+    _timeoutOverflowMode =
+        timeoutOverflowModeStr != null ? TimeoutOverflowMode.valueOf(timeoutOverflowModeStr) : null;
 
     ExecutorService baseExecutorService =
         ExecutorServiceUtils.create(serverConf, Server.MULTISTAGE_EXECUTOR_CONFIG_PREFIX, "query-runner-on-" + port,
@@ -296,6 +304,7 @@ public class QueryRunner {
       Map<String, String> requestMetadata) {
     StageMetadata stageMetadata = stagePlan.getStageMetadata();
     Map<String, String> opChainMetadata = consolidateMetadata(stageMetadata.getCustomProperties(), requestMetadata);
+    applyLeafDeadlineOverrides(workerMetadata, opChainMetadata);
 
     // The cluster-level _sendStats decision can be overridden per-request by the SubmitWithStream RPC handler via
     // MultiStageQueryRunner.KEY_OF_STATS_REPORTING_MODE; in stream mode stats travel out-of-band
@@ -546,6 +555,14 @@ public class QueryRunner {
       opChainMetadata.put(QueryOptionKey.WINDOW_OVERFLOW_MODE, windowOverflowMode.name());
     }
 
+    TimeoutOverflowMode timeoutOverflowMode = QueryOptionsUtils.getTimeoutOverflowMode(opChainMetadata);
+    if (timeoutOverflowMode == null) {
+      timeoutOverflowMode = _timeoutOverflowMode;
+    }
+    if (timeoutOverflowMode != null) {
+      opChainMetadata.put(QueryOptionKey.TIMEOUT_OVERFLOW_MODE, timeoutOverflowMode.name());
+    }
+
     return opChainMetadata;
   }
 
@@ -590,6 +607,53 @@ public class QueryRunner {
     _opChainScheduler.unregisterCompletionListener(requestId);
   }
 
+  private void applyLeafDeadlineOverrides(WorkerMetadata workerMetadata, Map<String, String> opChainMetadata) {
+    if (!workerMetadata.isLeafStageWorker()) {
+      return;
+    }
+    Long leafTimeoutMs = QueryOptionsUtils.getLeafTimeoutMs(opChainMetadata);
+    Long leafExtraPassiveTimeoutMs = QueryOptionsUtils.getLeafExtraPassiveTimeoutMs(opChainMetadata);
+    TimeoutOverflowMode timeoutOverflowMode = _timeoutOverflowMode;
+    String timeoutOverflowModeStr = opChainMetadata.get(QueryOptionKey.TIMEOUT_OVERFLOW_MODE);
+    if (timeoutOverflowModeStr != null) {
+      try {
+        timeoutOverflowMode = TimeoutOverflowMode.valueOf(timeoutOverflowModeStr);
+      } catch (IllegalArgumentException e) {
+        LOGGER.warn("Invalid timeout overflow mode: {}", timeoutOverflowModeStr, e);
+      }
+    }
+    QueryThreadContext threadContext = QueryThreadContext.getIfAvailable();
+    if (threadContext == null) {
+      return;
+    }
+    QueryExecutionContext executionContext = threadContext.getExecutionContext();
+    long startTimeMs = executionContext.getStartTimeMs();
+    if (leafTimeoutMs == null && timeoutOverflowMode == TimeoutOverflowMode.BREAK) {
+      long globalActiveWindowMs = Math.max(1L, executionContext.getActiveDeadlineMs() - startTimeMs);
+      leafTimeoutMs = Math.max(1L, (long) Math.floor(globalActiveWindowMs * DEFAULT_LEAF_TIMEOUT_RATIO));
+    }
+    if (leafExtraPassiveTimeoutMs == null && timeoutOverflowMode == TimeoutOverflowMode.BREAK) {
+      long globalPassiveWindowMs =
+          Math.max(0L, executionContext.getPassiveDeadlineMs() - executionContext.getActiveDeadlineMs());
+      leafExtraPassiveTimeoutMs =
+          Math.max(0L, (long) Math.floor(globalPassiveWindowMs * DEFAULT_LEAF_TIMEOUT_RATIO));
+    }
+    if (leafTimeoutMs == null && leafExtraPassiveTimeoutMs == null) {
+      return;
+    }
+    long activeDeadlineMs = executionContext.getActiveDeadlineMs();
+    long passiveDeadlineMs = executionContext.getPassiveDeadlineMs();
+    if (leafTimeoutMs != null) {
+      activeDeadlineMs = Math.min(activeDeadlineMs, startTimeMs + leafTimeoutMs);
+    }
+    if (leafExtraPassiveTimeoutMs != null) {
+      passiveDeadlineMs = Math.min(passiveDeadlineMs, activeDeadlineMs + leafExtraPassiveTimeoutMs);
+    }
+    passiveDeadlineMs = Math.max(passiveDeadlineMs, activeDeadlineMs);
+    opChainMetadata.put(LeafOperator.LEAF_ACTIVE_DEADLINE_METADATA_KEY, Long.toString(activeDeadlineMs));
+    opChainMetadata.put(LeafOperator.LEAF_PASSIVE_DEADLINE_METADATA_KEY, Long.toString(passiveDeadlineMs));
+  }
+
   public StagePlan explainQuery(WorkerMetadata workerMetadata, StagePlan stagePlan,
       Map<String, String> requestMetadata) {
     if (!workerMetadata.isLeafStageWorker()) {
@@ -599,6 +663,7 @@ public class QueryRunner {
 
     StageMetadata stageMetadata = stagePlan.getStageMetadata();
     Map<String, String> opChainMetadata = consolidateMetadata(stageMetadata.getCustomProperties(), requestMetadata);
+    applyLeafDeadlineOverrides(workerMetadata, opChainMetadata);
 
     if (PipelineBreakerExecutor.hasPipelineBreakers(stagePlan)) {
       //TODO: See https://github.com/apache/pinot/pull/13733#discussion_r1752031714

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/BaseJoinOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/BaseJoinOperator.java
@@ -39,9 +39,11 @@ import org.apache.pinot.query.runtime.operator.operands.TransformOperand;
 import org.apache.pinot.query.runtime.operator.operands.TransformOperandFactory;
 import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
 import org.apache.pinot.spi.exception.QueryErrorCode;
+import org.apache.pinot.spi.exception.QueryException;
 import org.apache.pinot.spi.utils.BooleanUtils;
 import org.apache.pinot.spi.utils.CommonConstants.Broker.Request.QueryOptionKey;
 import org.apache.pinot.spi.utils.CommonConstants.MultiStageQueryRunner.JoinOverFlowMode;
+import org.apache.pinot.spi.utils.CommonConstants.MultiStageQueryRunner.TimeoutOverflowMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -79,10 +81,12 @@ public abstract class BaseJoinOperator extends MultiStageOperator {
   ///   THROW(default): Break right table build process, and throw exception, no JOIN with left table performed.
   ///   BREAK: Break right table build process, continue to perform JOIN operation, results might be partial.
   protected final JoinOverFlowMode _joinOverflowMode;
+  protected final TimeoutOverflowMode _timeoutOverflowMode;
 
   protected boolean _isRightTableBuilt;
   @Nullable
   protected MseBlock.Eos _eos;
+  private boolean _timeoutOverflowTriggered;
 
   public BaseJoinOperator(OpChainExecutionContext context, MultiStageOperator leftInput, DataSchema leftSchema,
       MultiStageOperator rightInput, JoinNode node) {
@@ -102,6 +106,8 @@ public abstract class BaseJoinOperator extends MultiStageOperator {
     PlanNode.NodeHint nodeHint = node.getNodeHint();
     _maxRowsInJoin = getMaxRowsInJoin(metadata, nodeHint);
     _joinOverflowMode = getJoinOverflowMode(metadata, nodeHint);
+    TimeoutOverflowMode timeoutOverflowMode = QueryOptionsUtils.getTimeoutOverflowMode(metadata);
+    _timeoutOverflowMode = timeoutOverflowMode != null ? timeoutOverflowMode : TimeoutOverflowMode.THROW;
   }
 
   /// Constructor that takes the schema for NonEquiEvaluator as an argument
@@ -123,6 +129,8 @@ public abstract class BaseJoinOperator extends MultiStageOperator {
     PlanNode.NodeHint nodeHint = node.getNodeHint();
     _maxRowsInJoin = getMaxRowsInJoin(metadata, nodeHint);
     _joinOverflowMode = getJoinOverflowMode(metadata, nodeHint);
+    TimeoutOverflowMode timeoutOverflowMode = QueryOptionsUtils.getTimeoutOverflowMode(metadata);
+    _timeoutOverflowMode = timeoutOverflowMode != null ? timeoutOverflowMode : TimeoutOverflowMode.THROW;
   }
 
   protected static int getMaxRowsInJoin(Map<String, String> opChainMetadata, @Nullable PlanNode.NodeHint nodeHint) {
@@ -152,6 +160,14 @@ public abstract class BaseJoinOperator extends MultiStageOperator {
     }
     JoinOverFlowMode joinOverflowMode = QueryOptionsUtils.getJoinOverflowMode(contextMetadata);
     return joinOverflowMode != null ? joinOverflowMode : DEFAULT_JOIN_OVERFLOW_MODE;
+  }
+
+  @Override
+  protected long getDeadlineMs() {
+    if (_timeoutOverflowTriggered && _timeoutOverflowMode == TimeoutOverflowMode.BREAK) {
+      return Long.MAX_VALUE;
+    }
+    return super.getDeadlineMs();
   }
 
   @Override
@@ -282,6 +298,14 @@ public abstract class BaseJoinOperator extends MultiStageOperator {
 
   protected abstract List<Object[]> buildNonMatchRightRows();
 
+  @Override
+  protected MseBlock handleException(Exception e) {
+    if (maybeHandleTimeoutOverflow(e)) {
+      return SuccessMseBlock.INSTANCE;
+    }
+    return super.handleException(e);
+  }
+
   // TODO: Optimize this to avoid unnecessary object copy.
   protected Object[] joinRow(@Nullable Object[] leftRow, @Nullable Object[] rightRow) {
     Object[] resultRow = new Object[_resultColumnSize];
@@ -326,6 +350,29 @@ public abstract class BaseJoinOperator extends MultiStageOperator {
       leftBlock = _leftInput.nextBlock();
     }
     _eos = (MseBlock.Eos) leftBlock;
+  }
+
+  private boolean maybeHandleTimeoutOverflow(Exception e) {
+    if (_timeoutOverflowMode != TimeoutOverflowMode.BREAK) {
+      return false;
+    }
+    if (e instanceof QueryException) {
+      QueryException queryException = (QueryException) e;
+      if (queryException.getErrorCode() == QueryErrorCode.EXECUTION_TIMEOUT) {
+        if (!_timeoutOverflowTriggered) {
+          logger().warn("Join operator {} returning partial results after timeout: {}", _operatorId,
+              queryException.getMessage());
+        }
+        _timeoutOverflowTriggered = true;
+        _statMap.merge(StatKey.TIMEOUT_OVERFLOW_REACHED, true);
+        _leftInput.earlyTerminate();
+        _rightInput.earlyTerminate();
+        _eos = SuccessMseBlock.INSTANCE;
+        onEosProduced();
+        return true;
+      }
+    }
+    return false;
   }
 
   @Override
@@ -398,7 +445,8 @@ public abstract class BaseJoinOperator extends MultiStageOperator {
     /// Allocated memory in bytes for this operator or its children in the same stage.
     ALLOCATED_MEMORY_BYTES(StatMap.Type.LONG),
     /// Time spent on GC while this operator or its children in the same stage were running.
-    GC_TIME_MS(StatMap.Type.LONG);
+    GC_TIME_MS(StatMap.Type.LONG),
+    TIMEOUT_OVERFLOW_REACHED(StatMap.Type.BOOLEAN);
 
     private final StatMap.Type _type;
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafOperator.java
@@ -69,6 +69,7 @@ import org.apache.pinot.spi.exception.QueryErrorCode;
 import org.apache.pinot.spi.exception.TerminationException;
 import org.apache.pinot.spi.query.QueryThreadContext;
 import org.apache.pinot.spi.utils.CommonConstants.Broker.Request.QueryOptionValue;
+import org.apache.pinot.spi.utils.CommonConstants.MultiStageQueryRunner.TimeoutOverflowMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -84,6 +85,8 @@ public class LeafOperator extends MultiStageOperator {
       ErrorMseBlock.fromError(QueryErrorCode.QUERY_CANCELLATION, "Cancelled while waiting for leaf results");
   private static final ErrorMseBlock TIMEOUT_BLOCK =
       ErrorMseBlock.fromError(QueryErrorCode.EXECUTION_TIMEOUT, "Timed out waiting for leaf results");
+  public static final String LEAF_ACTIVE_DEADLINE_METADATA_KEY = "leafActiveDeadlineMs";
+  public static final String LEAF_PASSIVE_DEADLINE_METADATA_KEY = "leafPassiveDeadlineMs";
 
   // Use a special results block to indicate that this is the last results block
   @VisibleForTesting
@@ -103,10 +106,14 @@ public class LeafOperator extends MultiStageOperator {
   // Use a limit-sized BlockingQueue to store the results blocks and apply back pressure to the single-stage threads
   @VisibleForTesting
   final BlockingQueue<BaseResultsBlock> _blockingQueue;
+  private final TimeoutOverflowMode _timeoutOverflowMode;
 
   @Nullable
   private volatile Future<?> _executionFuture;
   private volatile boolean _terminated;
+  private volatile boolean _timeoutOverflowTriggered;
+  private final long _customActiveDeadlineMs;
+  private final long _customPassiveDeadlineMs;
 
   public LeafOperator(OpChainExecutionContext context, List<ServerQueryRequest> requests, DataSchema dataSchema,
       QueryExecutor queryExecutor, ExecutorService executorService) {
@@ -134,6 +141,12 @@ public class LeafOperator extends MultiStageOperator {
     _blockingQueue = new ArrayBlockingQueue<>(maxStreamingPendingBlocks != null ? maxStreamingPendingBlocks
         : QueryOptionValue.DEFAULT_MAX_STREAMING_PENDING_BLOCKS);
     _pipelineBreakerStats = pipelineBreakerStats;
+    TimeoutOverflowMode timeoutOverflowMode =
+        QueryOptionsUtils.getTimeoutOverflowMode(context.getOpChainMetadata());
+    _timeoutOverflowMode = timeoutOverflowMode != null ? timeoutOverflowMode : TimeoutOverflowMode.THROW;
+    Map<String, String> metadata = context.getOpChainMetadata();
+    _customActiveDeadlineMs = parseDeadline(metadata.get(LEAF_ACTIVE_DEADLINE_METADATA_KEY));
+    _customPassiveDeadlineMs = parseDeadline(metadata.get(LEAF_PASSIVE_DEADLINE_METADATA_KEY));
   }
 
   public List<ServerQueryRequest> getRequests() {
@@ -197,15 +210,15 @@ public class LeafOperator extends MultiStageOperator {
     BaseResultsBlock resultsBlock;
     try {
       // Here we use passive deadline because we end up waiting for the SSE operators which can timeout by their own.
-      resultsBlock =
-          _blockingQueue.poll(_context.getPassiveDeadlineMs() - System.currentTimeMillis(), TimeUnit.MILLISECONDS);
+      long deadlineMs = getWaitDeadlineMs();
+      resultsBlock = _blockingQueue.poll(Math.max(0L, deadlineMs - System.currentTimeMillis()), TimeUnit.MILLISECONDS);
     } catch (InterruptedException e) {
       terminateAndClearResultsBlocks();
       return replaceWithTerminateExceptionIfAvailable(CANCELLED_BLOCK);
     }
     if (resultsBlock == null) {
       terminateAndClearResultsBlocks();
-      return replaceWithTerminateExceptionIfAvailable(TIMEOUT_BLOCK);
+      return handleTimeoutOverflow(TIMEOUT_BLOCK, "waiting for leaf results");
     }
     // Terminate when there is error block
     ErrorMseBlock errorBlock = getErrorBlock();
@@ -230,6 +243,42 @@ public class LeafOperator extends MultiStageOperator {
         terminateException.getMessage()) : errorBlock;
   }
 
+  private MseBlock handleTimeoutOverflow(ErrorMseBlock defaultBlock, String reason) {
+    if (recordTimeoutOverflow(reason)) {
+      return SuccessMseBlock.INSTANCE;
+    }
+    return replaceWithTerminateExceptionIfAvailable(defaultBlock);
+  }
+
+  private boolean recordTimeoutOverflow(String reason) {
+    if (_timeoutOverflowMode != TimeoutOverflowMode.BREAK) {
+      return false;
+    }
+    if (!_timeoutOverflowTriggered) {
+      LOGGER.warn("Leaf operator for table '{}' returning partial results after timeout: {}", _tableName, reason);
+    }
+    _timeoutOverflowTriggered = true;
+    _statMap.merge(StatKey.TIMEOUT_OVERFLOW_REACHED, true);
+    return true;
+  }
+
+  private long getActiveDeadlineMsOverride() {
+    return _customActiveDeadlineMs != Long.MAX_VALUE ? _customActiveDeadlineMs : _context.getActiveDeadlineMs();
+  }
+
+  private long getPassiveDeadlineMsOverride() {
+    return _customPassiveDeadlineMs != Long.MAX_VALUE ? _customPassiveDeadlineMs : _context.getPassiveDeadlineMs();
+  }
+
+  private static long parseDeadline(@Nullable String value) {
+    return value != null ? Long.parseLong(value) : Long.MAX_VALUE;
+  }
+
+  private long getWaitDeadlineMs() {
+    return _timeoutOverflowMode == TimeoutOverflowMode.BREAK ? getActiveDeadlineMsOverride()
+        : getPassiveDeadlineMsOverride();
+  }
+
   public ExplainedNode explain() {
     if (_executionFuture == null) {
       _executionFuture = startExecution();
@@ -243,8 +292,9 @@ public class LeafOperator extends MultiStageOperator {
       BaseResultsBlock resultsBlock;
       try {
         // Here we use passive deadline because we end up waiting for the SSE operators which can timeout by their own.
-        resultsBlock =
-            _blockingQueue.poll(_context.getPassiveDeadlineMs() - System.currentTimeMillis(), TimeUnit.MILLISECONDS);
+        long deadlineMs = getWaitDeadlineMs();
+        long waitMs = Math.max(0L, deadlineMs - System.currentTimeMillis());
+        resultsBlock = _blockingQueue.poll(waitMs, TimeUnit.MILLISECONDS);
       } catch (InterruptedException e) {
         terminateAndClearResultsBlocks();
         checkTerminateException();
@@ -519,8 +569,11 @@ public class LeafOperator extends MultiStageOperator {
         });
       }
       try {
-        if (!latch.await(_context.getPassiveDeadlineMs() - System.currentTimeMillis(), TimeUnit.MILLISECONDS)) {
-          setErrorBlock(TIMEOUT_BLOCK);
+        long deadlineMs = getWaitDeadlineMs();
+        if (!latch.await(Math.max(0L, deadlineMs - System.currentTimeMillis()), TimeUnit.MILLISECONDS)) {
+          if (!recordTimeoutOverflow("waiting for hybrid leaf responses")) {
+            setErrorBlock(TIMEOUT_BLOCK);
+          }
         }
       } catch (InterruptedException e) {
         setErrorBlock(CANCELLED_BLOCK);
@@ -545,7 +598,12 @@ public class LeafOperator extends MultiStageOperator {
     //       SERVER_SEGMENT_MISSING_ERROR are counted as query failure.
     Map<Integer, String> exceptions = instanceResponseBlock.getExceptions();
     if (!exceptions.isEmpty()) {
-      setErrorBlock(ErrorMseBlock.fromMap(QueryErrorCode.fromKeyMap(exceptions)));
+      Map<QueryErrorCode, String> errorMessages = QueryErrorCode.fromKeyMap(exceptions);
+      if (errorMessages.size() == 1 && errorMessages.containsKey(QueryErrorCode.EXECUTION_TIMEOUT)
+          && recordTimeoutOverflow("single-stage execution")) {
+        return;
+      }
+      setErrorBlock(ErrorMseBlock.fromMap(errorMessages));
       if (onException != null) {
         onException.run();
       }
@@ -559,7 +617,9 @@ public class LeafOperator extends MultiStageOperator {
         } catch (InterruptedException e) {
           setErrorBlock(CANCELLED_BLOCK);
         } catch (TimeoutException e) {
-          setErrorBlock(TIMEOUT_BLOCK);
+          if (!recordTimeoutOverflow("adding results block")) {
+            setErrorBlock(TIMEOUT_BLOCK);
+          }
         } catch (Exception e) {
           if (!(e instanceof EarlyTerminationException)) {
             LOGGER.warn("Failed to add results block", e);
@@ -575,8 +635,9 @@ public class LeafOperator extends MultiStageOperator {
     if (_terminated) {
       throw new EarlyTerminationException("Query has been terminated");
     }
-    if (!_blockingQueue.offer(resultsBlock, _context.getPassiveDeadlineMs() - System.currentTimeMillis(),
-        TimeUnit.MILLISECONDS)) {
+    long deadlineMs = getWaitDeadlineMs();
+    long waitMs = Math.max(0L, deadlineMs - System.currentTimeMillis());
+    if (!_blockingQueue.offer(resultsBlock, waitMs, TimeUnit.MILLISECONDS)) {
       throw new TimeoutException("Timed out waiting to add results block");
     }
   }
@@ -750,6 +811,7 @@ public class LeafOperator extends MultiStageOperator {
     NUM_GROUPS_LIMIT_REACHED(StatMap.Type.BOOLEAN),
     NUM_GROUPS_WARNING_LIMIT_REACHED(StatMap.Type.BOOLEAN),
     LITE_MODE_LEAF_STAGE_LIMIT_REACHED(StatMap.Type.BOOLEAN),
+    TIMEOUT_OVERFLOW_REACHED(StatMap.Type.BOOLEAN, BrokerResponseNativeV2.StatKey.TIMEOUT_OVERFLOW_REACHED),
     NUM_RESIZES(StatMap.Type.INT, null),
     RESIZE_TIME_MS(StatMap.Type.LONG, null),
     THREAD_CPU_TIME_NS(StatMap.Type.LONG, null),

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java
@@ -109,8 +109,13 @@ public abstract class MultiStageOperator implements Operator<MseBlock>, AutoClos
         checkTermination();
         nextBlock = getNextBlock();
       } catch (Exception e) {
-        logger().warn("Operator {}: Exception while processing next block", _operatorId, e);
-        nextBlock = ErrorMseBlock.fromException(e);
+        MseBlock handled = handleException(e);
+        if (handled != null) {
+          nextBlock = handled;
+        } else {
+          logger().warn("Operator {}: Exception while processing next block", _operatorId, e);
+          nextBlock = ErrorMseBlock.fromException(e);
+        }
       }
       int numRows = nextBlock instanceof MseBlock.Data ? ((MseBlock.Data) nextBlock).getNumRows() : 0;
       long memoryUsedBytes = resourceSnapshot.getAllocatedBytes();
@@ -127,6 +132,16 @@ public abstract class MultiStageOperator implements Operator<MseBlock>, AutoClos
   // Make it protected because we should always call nextBlock()
   protected abstract MseBlock getNextBlock()
       throws Exception;
+
+  /// Gives operator implementations a chance to translate an exception into a result block instead of bubbling the
+  /// error up to the caller.
+  ///
+  /// @return an [MseBlock] that should be returned to the caller, or `null` to keep the default behavior of returning
+  /// an [ErrorMseBlock].
+  @Nullable
+  protected MseBlock handleException(Exception e) {
+    return null;
+  }
 
   /// Signals the operator to terminate early.
   ///
@@ -265,6 +280,7 @@ public abstract class MultiStageOperator implements Operator<MseBlock>, AutoClos
         response.mergeMaxRowsInOperator(stats.getLong(HashJoinOperator.StatKey.EMITTED_ROWS));
         response.mergeMaxRowsInJoinReached(stats.getBoolean(HashJoinOperator.StatKey.MAX_ROWS_IN_JOIN_REACHED));
         response.mergeMaxRowsInJoin(stats.getLong(HashJoinOperator.StatKey.MAX_ROWS_IN_JOIN));
+        response.mergeTimeoutOverflowReached(stats.getBoolean(HashJoinOperator.StatKey.TIMEOUT_OVERFLOW_REACHED));
       }
 
       @Override

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/LeafOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/LeafOperatorTest.java
@@ -50,13 +50,18 @@ import org.apache.pinot.core.query.executor.QueryExecutor;
 import org.apache.pinot.core.query.request.ServerQueryRequest;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
+import org.apache.pinot.query.mailbox.MailboxService;
+import org.apache.pinot.query.planner.physical.DispatchablePlanFragment;
+import org.apache.pinot.query.routing.StageMetadata;
 import org.apache.pinot.query.routing.VirtualServerAddress;
+import org.apache.pinot.query.routing.WorkerMetadata;
 import org.apache.pinot.query.runtime.blocks.MseBlock;
 import org.apache.pinot.query.runtime.blocks.SuccessMseBlock;
 import org.apache.pinot.query.runtime.plan.MultiStageQueryStats;
 import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
 import org.apache.pinot.query.runtime.plan.pipeline.PipelineBreakerOperator;
 import org.apache.pinot.spi.exception.QueryErrorCode;
+import org.apache.pinot.spi.utils.CommonConstants.Broker.Request.QueryOptionKey;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -122,6 +127,39 @@ public class LeafOperatorTest {
       queryRequests.add(queryRequest);
     }
     return queryRequests;
+  }
+
+  private LeafOperator createLeafOperatorWithTimeoutMode(String timeoutOverflowMode, long timeoutMs,
+      QueryExecutor queryExecutor, DataSchema schema) {
+    Map<String, String> metadata = new HashMap<>();
+    metadata.put(QueryOptionKey.TIMEOUT_OVERFLOW_MODE, timeoutOverflowMode);
+    return new LeafOperator(createExecutionContext(metadata, timeoutMs), mockQueryRequests(1), schema, queryExecutor,
+        _executorService);
+  }
+
+  private OpChainExecutionContext createExecutionContext(Map<String, String> metadata, long timeoutMs) {
+    long deadline = System.currentTimeMillis() + timeoutMs;
+    MailboxService mailboxService = mock(MailboxService.class);
+    when(mailboxService.getHostname()).thenReturn("localhost");
+    when(mailboxService.getPort()).thenReturn(1234);
+    WorkerMetadata workerMetadata = new WorkerMetadata(0, Map.of(), Map.of());
+    StageMetadata stageMetadata =
+        new StageMetadata(0, List.of(workerMetadata), Map.of(DispatchablePlanFragment.TABLE_NAME_KEY, "testTable"));
+    return new OpChainExecutionContext(mailboxService, 0L, "cid", deadline, deadline, "brokerId", metadata,
+        stageMetadata, workerMetadata, null, true, true);
+  }
+
+  private QueryExecutor slowQueryExecutor(long sleepMs) {
+    QueryExecutor queryExecutor = mock(QueryExecutor.class);
+    when(queryExecutor.execute(any(), any(), any())).thenAnswer(invocation -> {
+      try {
+        Thread.sleep(sleepMs);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+      return new InstanceResponseBlock(new MetadataResultsBlock());
+    });
+    return queryExecutor;
   }
 
   @Test
@@ -258,6 +296,65 @@ public class LeafOperatorTest {
     assertEquals(rows2.get(0), new Object[]{"bar", 3});
     assertEquals(rows2.get(1), new Object[]{"foo", 4});
     assertTrue(resultBlock3.isEos(), "Expected EOS after reading 2 blocks");
+
+    operator.close();
+  }
+
+  @Test
+  public void shouldBreakOnTimeoutOverflowMode()
+      throws Exception {
+    DataSchema schema = new DataSchema(new String[]{"strCol"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING});
+    LeafOperator operator =
+        createLeafOperatorWithTimeoutMode("BREAK", 20, slowQueryExecutor(500), schema);
+    _operatorRef.set(operator);
+
+    MseBlock block = operator.nextBlock();
+    assertSame(block, SuccessMseBlock.INSTANCE);
+    MultiStageQueryStats stats = operator.calculateStats();
+    assertTrue(OperatorTestUtil.getStatMap(LeafOperator.StatKey.class, stats)
+        .getBoolean(LeafOperator.StatKey.TIMEOUT_OVERFLOW_REACHED));
+
+    operator.close();
+  }
+
+  @Test
+  public void shouldEmitPartialResultsWhenTimeoutErrorBlockReceived()
+      throws Exception {
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContext("SELECT strCol FROM tbl");
+    DataSchema schema = new DataSchema(new String[]{"strCol"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING});
+    List<BaseResultsBlock> dataBlocks = List.of(
+        new SelectionResultsBlock(schema, Arrays.asList(new Object[]{"foo"}, new Object[]{"bar"}), queryContext));
+    InstanceResponseBlock metadataBlock = new InstanceResponseBlock(new MetadataResultsBlock());
+    metadataBlock.addException(QueryErrorCode.EXECUTION_TIMEOUT, "Timing out on: LEAF");
+    QueryExecutor queryExecutor = mockQueryExecutor(dataBlocks, metadataBlock);
+    LeafOperator operator = createLeafOperatorWithTimeoutMode("BREAK", 1_000, queryExecutor, schema);
+    _operatorRef.set(operator);
+
+    MseBlock dataBlock = operator.nextBlock();
+    List<Object[]> rows = ((MseBlock.Data) dataBlock).asRowHeap().getRows();
+    assertEquals(rows.get(0), new Object[]{"foo"});
+    assertEquals(rows.get(1), new Object[]{"bar"});
+    assertSame(operator.nextBlock(), SuccessMseBlock.INSTANCE);
+    MultiStageQueryStats stats = operator.calculateStats();
+    assertTrue(OperatorTestUtil.getStatMap(LeafOperator.StatKey.class, stats)
+        .getBoolean(LeafOperator.StatKey.TIMEOUT_OVERFLOW_REACHED));
+
+    operator.close();
+  }
+
+  @Test
+  public void shouldThrowOnTimeoutOverflowMode()
+      throws Exception {
+    DataSchema schema = new DataSchema(new String[]{"strCol"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING});
+    LeafOperator operator =
+        createLeafOperatorWithTimeoutMode("THROW", 20, slowQueryExecutor(500), schema);
+    _operatorRef.set(operator);
+
+    MseBlock block = operator.nextBlock();
+    assertTrue(block.isError());
 
     operator.close();
   }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/TimeoutOverflowQueryRunnerTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/TimeoutOverflowQueryRunnerTest.java
@@ -1,0 +1,235 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.queries;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.pinot.common.response.broker.QueryProcessingException;
+import org.apache.pinot.common.response.broker.ResultTable;
+import org.apache.pinot.query.QueryEnvironmentTestBase;
+import org.apache.pinot.query.QueryServerEnclosure;
+import org.apache.pinot.query.mailbox.MailboxService;
+import org.apache.pinot.query.routing.QueryServerInstance;
+import org.apache.pinot.query.runtime.operator.LeafOperator;
+import org.apache.pinot.query.runtime.operator.MultiStageOperator;
+import org.apache.pinot.query.runtime.plan.MultiStageQueryStats;
+import org.apache.pinot.query.service.dispatch.QueryDispatcher;
+import org.apache.pinot.query.testutils.MockInstanceDataManagerFactory;
+import org.apache.pinot.query.testutils.QueryTestUtils;
+import org.apache.pinot.query.testutils.SlowMockInstanceDataManagerFactory;
+import org.apache.pinot.spi.config.instance.InstanceType;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.exception.QueryErrorCode;
+import org.apache.pinot.spi.utils.CommonConstants.MultiStageQueryRunner;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+/// Integration tests covering timeout overflow behavior end-to-end.
+public class TimeoutOverflowQueryRunnerTest extends QueryRunnerTestBase {
+  private static final String TABLE_NAME = "slowTable";
+  private static final String TABLE_NAME_WITH_TYPE = TABLE_NAME + "_OFFLINE";
+  private static final String FAST_TABLE_NAME = "fastTable";
+  private static final String FAST_TABLE_WITH_TYPE = FAST_TABLE_NAME + "_OFFLINE";
+  private static final long LEAF_TIMEOUT_MS = 1;
+  private static final long LEAF_EXTRA_PASSIVE_TIMEOUT_MS = 0;
+  private static final long QUERY_TIMEOUT_MS = 2000;
+  private static final long QUERY_EXTRA_PASSIVE_TIMEOUT_MS = 1000;
+
+  private QueryServerEnclosure _slowServer;
+  private QueryServerEnclosure _fastServer;
+
+  @BeforeClass
+  public void setUp()
+      throws Exception {
+    SlowMockInstanceDataManagerFactory slowFactory = new SlowMockInstanceDataManagerFactory("slowServer", 500);
+    Schema schema = new Schema.SchemaBuilder().addSingleValueDimension("col1", FieldSpec.DataType.STRING, "")
+        .addSingleValueDimension("col2", FieldSpec.DataType.STRING, "")
+        .addMetric("col3", FieldSpec.DataType.INT, 0)
+        .addDateTime("ts", FieldSpec.DataType.LONG, "1:MILLISECONDS:EPOCH", "1:HOURS")
+        .setSchemaName(TABLE_NAME)
+        .setEnableColumnBasedNullHandling(true)
+        .build();
+    slowFactory.registerTable(schema, TABLE_NAME_WITH_TYPE);
+    slowFactory.addSegment(TABLE_NAME_WITH_TYPE, QueryRunnerTest.buildRows(TABLE_NAME_WITH_TYPE));
+    slowFactory.addSegment(TABLE_NAME_WITH_TYPE, QueryRunnerTest.buildRows(TABLE_NAME_WITH_TYPE));
+
+    MockInstanceDataManagerFactory fastFactory = new MockInstanceDataManagerFactory("fastServer");
+    fastFactory.registerTable(
+        new Schema.SchemaBuilder().addSingleValueDimension("col1", FieldSpec.DataType.STRING, "")
+            .addSingleValueDimension("col2", FieldSpec.DataType.STRING, "")
+            .addMetric("col3", FieldSpec.DataType.INT, 0)
+            .addDateTime("ts", FieldSpec.DataType.LONG, "1:MILLISECONDS:EPOCH", "1:HOURS")
+            .setSchemaName(FAST_TABLE_NAME)
+            .setEnableColumnBasedNullHandling(true)
+            .build(),
+        FAST_TABLE_WITH_TYPE);
+    fastFactory.addSegment(FAST_TABLE_WITH_TYPE, QueryRunnerTest.buildRows(FAST_TABLE_WITH_TYPE));
+    fastFactory.addSegment(FAST_TABLE_WITH_TYPE, QueryRunnerTest.buildRows(FAST_TABLE_WITH_TYPE));
+
+    _reducerHostname = "localhost";
+    _reducerPort = QueryTestUtils.getAvailablePort();
+    Map<String, Object> reducerConfig = new HashMap<>();
+    reducerConfig.put(MultiStageQueryRunner.KEY_OF_QUERY_RUNNER_HOSTNAME, _reducerHostname);
+    reducerConfig.put(MultiStageQueryRunner.KEY_OF_QUERY_RUNNER_PORT, _reducerPort);
+    _mailboxService = new MailboxService(_reducerHostname, _reducerPort, InstanceType.BROKER,
+        new PinotConfiguration(reducerConfig));
+    _mailboxService.start();
+
+    _slowServer = new QueryServerEnclosure(slowFactory);
+    _slowServer.start();
+    _fastServer = new QueryServerEnclosure(fastFactory);
+    _fastServer.start();
+
+    QueryServerInstance slowInstance =
+        new QueryServerInstance("Server_localhost_" + _slowServer.getPort(), "localhost", _slowServer.getPort(),
+            _slowServer.getPort());
+    QueryServerInstance fastInstance =
+        new QueryServerInstance("Server_localhost_" + _fastServer.getPort(), "localhost", _fastServer.getPort(),
+            _fastServer.getPort());
+    _servers.put(slowInstance, _slowServer);
+    _servers.put(fastInstance, _fastServer);
+
+    Map<String, Schema> schemaMap = new HashMap<>();
+    schemaMap.putAll(slowFactory.getRegisteredSchemaMap());
+    schemaMap.putAll(fastFactory.getRegisteredSchemaMap());
+    _queryEnvironment = QueryEnvironmentTestBase.getQueryEnvironment(_reducerPort, _slowServer.getPort(),
+        _fastServer.getPort(), schemaMap, slowFactory.buildTableSegmentNameMap(),
+        fastFactory.buildTableSegmentNameMap(), null);
+  }
+
+  @AfterClass
+  public void tearDownClass() {
+    if (_mailboxService != null) {
+      _mailboxService.shutdown();
+    }
+    if (_slowServer != null) {
+      _slowServer.shutDown();
+    }
+    if (_fastServer != null) {
+      _fastServer.shutDown();
+    }
+  }
+
+  @Test
+  public void testTimeoutOverflowBreakReturnsPartialResults() {
+    String sql = queryPrefix("BREAK") + "SELECT col1 FROM " + TABLE_NAME + " LIMIT 5";
+    QueryDispatcher.QueryResult result = queryRunner(sql, false);
+    Assert.assertNull(result.getProcessingException(), "Expected partial success without exception");
+    ResultTable resultTable = result.getResultTable();
+    Assert.assertNotNull(resultTable, "Result table should be present even for partial results");
+    Assert.assertTrue(hasTimeoutOverflowStats(result), "Leaf stats should record timeout overflow");
+  }
+
+  @Test
+  public void testTimeoutOverflowThrowFailsQuery() {
+    String sql = queryPrefix("THROW") + "SELECT col1 FROM " + TABLE_NAME + " LIMIT 5";
+    QueryDispatcher.QueryResult result = queryRunner(sql, false);
+    QueryProcessingException processingException = result.getProcessingException();
+    Assert.assertNotNull(processingException, "Expected exception when overflow mode is THROW");
+    Assert.assertEquals(processingException.getErrorCode(), QueryErrorCode.EXECUTION_TIMEOUT.getId());
+  }
+
+  @Test
+  public void testTimeoutOverflowBreakOnJoin() {
+    String sql = queryPrefix("BREAK")
+        + "SELECT slow.col1, fast.col1 FROM " + TABLE_NAME + " slow JOIN "
+        + FAST_TABLE_NAME + " fast ON slow.col2 = fast.col2";
+    QueryDispatcher.QueryResult result = queryRunner(sql, false);
+    Assert.assertNull(result.getProcessingException(), "Join should return partial results without error");
+    Assert.assertNotNull(result.getResultTable());
+    Assert.assertTrue(hasTimeoutOverflowStats(result));
+  }
+
+  @Test
+  public void testTimeoutOverflowThrowOnJoin() {
+    String sql = queryPrefix("THROW")
+        + "SELECT slow.col1, fast.col1 FROM " + TABLE_NAME + " slow JOIN "
+        + FAST_TABLE_NAME + " fast ON slow.col2 = fast.col2";
+    QueryDispatcher.QueryResult result = queryRunner(sql, false);
+    Assert.assertNotNull(result.getProcessingException(), "Join should fail when overflow mode THROW is used");
+    Assert.assertEquals(result.getProcessingException().getErrorCode(), QueryErrorCode.EXECUTION_TIMEOUT.getId());
+  }
+
+  @Test
+  public void testTimeoutOverflowBreakOnAggregation() {
+    String sql = queryPrefix("BREAK")
+        + "SELECT col2, COUNT(*) FROM " + TABLE_NAME + " GROUP BY col2";
+    QueryDispatcher.QueryResult result = queryRunner(sql, false);
+    Assert.assertNull(result.getProcessingException(), "Aggregation should emit partial results on BREAK");
+    Assert.assertNotNull(result.getResultTable());
+    Assert.assertTrue(hasTimeoutOverflowStats(result));
+  }
+  @Test
+  public void testTimeoutOverflowBreakUsesDefaultLeafTimeout() {
+    long timeoutMs = 100;
+    long extraPassiveTimeoutMs = 50;
+    String sql = queryPrefixWithoutLeafOverrides("BREAK", timeoutMs, extraPassiveTimeoutMs)
+        + "SELECT col1 FROM " + TABLE_NAME + " LIMIT 5";
+    QueryDispatcher.QueryResult result = queryRunner(sql, false);
+    Assert.assertNull(result.getProcessingException(), "Expected partial results when relying on default leaf timeout");
+    ResultTable resultTable = result.getResultTable();
+    Assert.assertNotNull(resultTable);
+    Assert.assertTrue(hasTimeoutOverflowStats(result));
+  }
+
+  private String queryPrefix(String overflowMode) {
+    return buildQueryPrefix(overflowMode, QUERY_TIMEOUT_MS, QUERY_EXTRA_PASSIVE_TIMEOUT_MS, true);
+  }
+
+  private String queryPrefixWithoutLeafOverrides(String overflowMode, long timeoutMs, long extraPassiveTimeoutMs) {
+    return buildQueryPrefix(overflowMode, timeoutMs, extraPassiveTimeoutMs, false);
+  }
+
+  private String buildQueryPrefix(String overflowMode, long timeoutMs, long extraPassiveTimeoutMs,
+      boolean includeLeafOverrides) {
+    StringBuilder builder = new StringBuilder();
+    builder.append("SET useMultistageEngine='true';")
+        .append("SET timeoutOverflowMode='").append(overflowMode).append("';")
+        .append("SET timeoutMs='").append(timeoutMs).append("';")
+        .append("SET extraPassiveTimeoutMs='").append(extraPassiveTimeoutMs).append("';");
+    if (includeLeafOverrides) {
+      builder.append("SET leafTimeoutMs='").append(LEAF_TIMEOUT_MS).append("';")
+          .append("SET leafExtraPassiveTimeoutMs='").append(LEAF_EXTRA_PASSIVE_TIMEOUT_MS).append("';");
+    }
+    return builder.toString();
+  }
+
+  private boolean hasTimeoutOverflowStats(QueryDispatcher.QueryResult result) {
+    AtomicBoolean overflow = new AtomicBoolean(false);
+    for (MultiStageQueryStats.StageStats.Closed stageStats : result.getQueryStats()) {
+      stageStats.forEach((type, statMap) -> {
+        if (type == MultiStageOperator.Type.LEAF) {
+          @SuppressWarnings("unchecked")
+          org.apache.pinot.common.datatable.StatMap<LeafOperator.StatKey> stats =
+              (org.apache.pinot.common.datatable.StatMap<LeafOperator.StatKey>) statMap;
+          if (stats.getBoolean(LeafOperator.StatKey.TIMEOUT_OVERFLOW_REACHED)) {
+            overflow.set(true);
+          }
+        }
+      });
+    }
+    return overflow.get();
+  }
+}

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/testutils/SlowMockInstanceDataManagerFactory.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/testutils/SlowMockInstanceDataManagerFactory.java
@@ -1,0 +1,54 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.testutils;
+
+import java.util.List;
+import org.apache.pinot.segment.local.data.manager.SegmentDataManager;
+import org.apache.pinot.segment.local.data.manager.TableDataManager;
+import org.mockito.stubbing.Answer;
+
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+
+/// A [MockInstanceDataManagerFactory] variant that sleeps when segments are acquired.
+///
+/// This allows integration tests to deterministically trigger server-side timeouts.
+public class SlowMockInstanceDataManagerFactory extends MockInstanceDataManagerFactory {
+  private final long _sleepMs;
+
+  public SlowMockInstanceDataManagerFactory(String serverName, long sleepMs) {
+    super(serverName);
+    _sleepMs = sleepMs;
+  }
+
+  @Override
+  protected void customizeTableDataManager(TableDataManager tableDataManager, String tableNameWithType,
+      Answer<List<SegmentDataManager>> acquireSegmentsAnswer) {
+    when(tableDataManager.acquireSegments(anyList(), eq(null), anyList())).thenAnswer(invocation -> {
+      try {
+        Thread.sleep(_sleepMs);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+      return acquireSegmentsAnswer.answer(invocation);
+    });
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -711,6 +711,8 @@ public class CommonConstants {
         /// SQL sets this option.
         public static final String ENABLE_MATERIALIZED_VIEW_REWRITE = "enableMaterializedViewRewrite";
         public static final String EXTRA_PASSIVE_TIMEOUT_MS = "extraPassiveTimeoutMs";
+        public static final String LEAF_TIMEOUT_MS = "leafTimeoutMs";
+        public static final String LEAF_EXTRA_PASSIVE_TIMEOUT_MS = "leafExtraPassiveTimeoutMs";
         public static final String SKIP_UPSERT = "skipUpsert";
         public static final String SKIP_UPSERT_VIEW = "skipUpsertView";
         public static final String UPSERT_VIEW_FRESHNESS_MS = "upsertViewFreshnessMs";
@@ -894,6 +896,7 @@ public class CommonConstants {
         // Handle WINDOW Overflow
         public static final String MAX_ROWS_IN_WINDOW = "maxRowsInWindow";
         public static final String WINDOW_OVERFLOW_MODE = "windowOverflowMode";
+        public static final String TIMEOUT_OVERFLOW_MODE = "timeoutOverflowMode";
 
         // Indicates the maximum length of the serialized response per server for a query.
         public static final String MAX_SERVER_RESPONSE_SIZE_BYTES = "maxServerResponseSizeBytes";
@@ -2531,6 +2534,7 @@ public class CommonConstants {
     /// Configuration for join overflow.
     public static final String KEY_OF_MAX_ROWS_IN_JOIN = "pinot.query.join.max.rows";
     public static final String KEY_OF_JOIN_OVERFLOW_MODE = "pinot.query.join.overflow.mode";
+    public static final String KEY_OF_TIMEOUT_OVERFLOW_MODE = "pinot.query.timeout.overflow.mode";
 
     /// Specifies the send stats mode used in MSE.
     ///
@@ -2570,6 +2574,9 @@ public class CommonConstants {
     public static final String KEY_OF_LOG_STATS = "logStats";
 
     public enum JoinOverFlowMode {
+      THROW, BREAK
+    }
+    public enum TimeoutOverflowMode {
       THROW, BREAK
     }
 


### PR DESCRIPTION
## Summary
- introduce timeoutOverflowMode plumbing in server/broker metadata
- make LeafOperator break early only if mode=BREAK and expose a TIMEOUT_OVERFLOW_REACHED stat so intermediates keep running
- add SlowMockInstanceDataManagerFactory plus TimeoutOverflowQueryRunnerTest to cover simple select, join, and aggregation cases

query with partial results
<img width="1221" height="585" alt="image" src="https://github.com/user-attachments/assets/e1415be0-a4b8-4a03-b35b-bb4263e487f4" />
query with full results
<img width="1491" height="814" alt="image" src="https://github.com/user-attachments/assets/30238af7-dee7-4b26-bc1a-62c37efd068a" />
