### PR TITLE
Include record when filter transform throws exception

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/FilterTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/FilterTransformer.java
@@ -85,6 +85,7 @@ public class FilterTransformer implements RecordTransformer {
           LOGGER.debug("Caught exception while executing filter function: {} for record: {}", _filterFunction,
               record.toString(), e);
           record.markIncomplete();
+          filteredRecords.add(record);
         }
       }
     }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/RecordTransformerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/RecordTransformerTest.java
@@ -164,6 +164,20 @@ public class RecordTransformerTest {
       // expected
     }
 
+    // invalid function at runtime
+    ingestionConfig.setFilterConfig(new FilterConfig("svInt = 'abc'"));
+    transformer = new FilterTransformer(tableConfig);
+    try {
+      transformer.transform(List.of(genericRow));
+      fail("Should have failed executing function");
+    } catch (Exception e) {
+      // expected
+    }
+    ingestionConfig.setContinueOnError(true);
+    transformer = new FilterTransformer(tableConfig);
+    assertFalse(transformer.transform(List.of(genericRow)).isEmpty());
+    assertEquals(transformer.getNumRecordsFiltered(), 0);
+
     // multi value column
     ingestionConfig.setFilterConfig(new FilterConfig("Groovy({svFloat.max() < 500}, svFloat)"));
     transformer = new FilterTransformer(tableConfig);


### PR DESCRIPTION
This bug (behavior change) was introduced in #16254

When filter transform throws exception at runtime and continue on error is set, we should include the record