### PR TITLE
Fix non-daemon threads blocking JVM shutdown in RenewableTlsUtils

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/NamedThreadFactory.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/NamedThreadFactory.java
@@ -53,6 +53,7 @@ public class NamedThreadFactory implements ThreadFactory {
   private final ThreadGroup _group;
   private final AtomicInteger _threadNumber = new AtomicInteger(1);
   private final String _threadNamePrefix;
+  private final boolean _daemon;
 
   /**
    * Creates a new {@link NamedThreadFactory} instance
@@ -60,10 +61,21 @@ public class NamedThreadFactory implements ThreadFactory {
    * @param threadNamePrefix the name prefix assigned to each thread created.
    */
   public NamedThreadFactory(String threadNamePrefix) {
+    this(threadNamePrefix, false);
+  }
+
+  /**
+   * Creates a new {@link NamedThreadFactory} instance
+   *
+   * @param threadNamePrefix the name prefix assigned to each thread created.
+   * @param daemon if true, creates daemon threads
+   */
+  public NamedThreadFactory(String threadNamePrefix, boolean daemon) {
     final SecurityManager s = System.getSecurityManager();
     _group = (s != null) ? s.getThreadGroup() : Thread.currentThread().getThreadGroup();
     _threadNamePrefix =
-        String.format(NAME_PATTERN, checkPrefix(threadNamePrefix), THREAD_POOL_NUMBER.getAndIncrement());
+            String.format(NAME_PATTERN, checkPrefix(threadNamePrefix), THREAD_POOL_NUMBER.getAndIncrement());
+    _daemon = daemon;
   }
 
   private static String checkPrefix(String prefix) {
@@ -78,7 +90,7 @@ public class NamedThreadFactory implements ThreadFactory {
   public Thread newThread(Runnable r) {
     final Thread t =
         new Thread(_group, r, String.format("%s-%d", _threadNamePrefix, _threadNumber.getAndIncrement()), 0);
-    t.setDaemon(false);
+    t.setDaemon(_daemon);
     t.setPriority(Thread.NORM_PRIORITY);
     return t;
   }

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/tls/RenewableTlsUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/tls/RenewableTlsUtilsTest.java
@@ -54,6 +54,7 @@ import nl.altindag.ssl.trustmanager.HotSwappableX509ExtendedTrustManager;
 import nl.altindag.ssl.trustmanager.UnsafeX509ExtendedTrustManager;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.config.TlsConfig;
+import org.apache.pinot.common.utils.NamedThreadFactory;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -84,6 +85,7 @@ public class RenewableTlsUtilsTest {
 
   private static final String TLS_KEYSTORE_FILE_PATH = DEFAULT_TEST_TLS_DIR + "/" + TLS_KEYSTORE_FILE;
   private static final String TLS_TRUSTSTORE_FILE_PATH = DEFAULT_TEST_TLS_DIR + "/" + TLS_TRUSTSTORE_FILE;
+  private static final String SSL_RELOAD_THREAD_PREFIX = "ssl-reload-test";
 
   @BeforeMethod
   public void setUp()
@@ -183,7 +185,8 @@ public class RenewableTlsUtilsTest {
 
     // Start a new thread to reload the ssl factory when the tls files change
     // Avoid early finalization by not using Executors.newSingleThreadExecutor (java <= 20, JDK-8145304)
-    ExecutorService executorService = Executors.newFixedThreadPool(1);
+    ExecutorService executorService = Executors.newFixedThreadPool(1,
+            new NamedThreadFactory(SSL_RELOAD_THREAD_PREFIX, true));
     executorService.execute(
         () -> {
           try {


### PR DESCRIPTION
### Description

Fixes #16979  

### Problem
The `RenewableTlsUtils` prevents JVM shutdown in on-demand processes (e.g., Pinot Admin commands). Background threads monitoring SSL certificates used non-daemon threads, keeping the JVM alive indefinitely after process completion, requiring manual termination.

### Fix

- Modified `NamedThreadFactory` usage in `RenewableTlsUtils` to create daemon threads by passing true as the second constructor argument
- Updated `reloadSslFactoryWhenFileStoreChanges` and `reloadSslFactory` methods to use `NamedThreadFactory` with daemon flag enabled.