### PR TITLE
The Pinot UI should distinguish between a server being up and being healthy #16775

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotInstanceRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotInstanceRestletResource.java
@@ -159,6 +159,10 @@ public class PinotInstanceRestletResource {
     if ("true".equalsIgnoreCase(queriesDisabled)) {
       response.put(CommonConstants.Helix.QUERIES_DISABLED, "true");
     }
+    // Add shutdown in progress status
+    boolean shutdownInProgress = instanceConfig.getRecord().getBooleanField(
+        CommonConstants.Helix.IS_SHUTDOWN_IN_PROGRESS, false);
+    response.put(CommonConstants.Helix.IS_SHUTDOWN_IN_PROGRESS, shutdownInProgress);
     response.put("systemResourceInfo", JsonUtils.objectToJsonNode(getSystemResourceInfo(instanceConfig)));
     return response.toString();
   }

--- a/pinot-controller/src/main/resources/app/interfaces/types.d.ts
+++ b/pinot-controller/src/main/resources/app/interfaces/types.d.ts
@@ -72,6 +72,7 @@ declare module 'Models' {
     queryServicePort: number;
     queryMailboxPort: number;
     queriesDisabled: boolean;
+    shutdownInProgress?: boolean;
     tags: Array<string>;
     pools?: string;
   };


### PR DESCRIPTION


The frontend logic in `PinotMethodUtils.ts` has been enhanced with:

1. __Health check functionality__ (lines 147-158): `checkInstanceHealth` function that pings the `/health` endpoint

2. __Enhanced status determination__ (lines 165-201): The `getInstanceData` function now includes logic to determine status based on:

   - `shutdownInProgress` flag
   - `enabled` state
   - `queriesDisabled` state
   - Health endpoint response
   - Live instance status

The status priority is correctly implemented:

- Dead (not alive)
- Shutting Down (alive + shutdownInProgress)
- Disabled (alive + not enabled)
- Queries Disabled (alive + queriesDisabled)
- Unhealthy (alive but health check fails)
- Healthy (alive + health check passes)
