### PR TITLE
Set skipCrcCheckOnLoad in table config

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -442,9 +442,9 @@ public abstract class BaseTableDataManager implements TableDataManager {
       _logger.info("Segment: {} has CRC: {} same as before, not replacing it", segmentName, localMetadata.getCrc());
       return;
     }
-    if (!_instanceDataManagerConfig.shouldCheckCRCOnSegmentLoad() || _skipCrcCheckForThisTable) {
+    if (!_instanceDataManagerConfig.shouldCheckCRCOnSegmentLoad()) {
       _logger.info("Skipping replacing segment: {} even though its CRC has changed from: {} to: {} because "
-          + "instance.check.crc.on.segment.load is set to false or skipCrcCheckOnLoad is enabled", segmentName,
+          + "instance.check.crc.on.segment.load is set to false", segmentName,
           localMetadata.getCrc(), zkMetadata.getCrc());
       return;
     }

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerTest.java
@@ -832,10 +832,15 @@ public class BaseTableDataManagerTest {
   }
 
   private static OfflineTableDataManager createTableManager(InstanceDataManagerConfig instanceDataManagerConfig) {
+    return createTableManager(instanceDataManagerConfig, DEFAULT_TABLE_CONFIG);
+  }
+
+  private static OfflineTableDataManager createTableManager(InstanceDataManagerConfig instanceDataManagerConfig,
+      TableConfig tableConfig) {
     OfflineTableDataManager tableDataManager = new OfflineTableDataManager();
-    tableDataManager.init(instanceDataManagerConfig, mock(HelixManager.class), new SegmentLocks(), DEFAULT_TABLE_CONFIG,
-        SCHEMA, new SegmentReloadSemaphore(1), Executors.newSingleThreadExecutor(), null, null,
-        SEGMENT_OPERATIONS_THROTTLER, false, mock(ServerReloadJobStatusCache.class));
+    tableDataManager.init(instanceDataManagerConfig, mock(HelixManager.class), new SegmentLocks(), tableConfig, SCHEMA,
+        new SegmentReloadSemaphore(1), Executors.newSingleThreadExecutor(), null, null, SEGMENT_OPERATIONS_THROTTLER,
+        false, mock(ServerReloadJobStatusCache.class));
     return tableDataManager;
   }
 
@@ -923,6 +928,56 @@ public class BaseTableDataManagerTest {
     when(immutableSegment.getSegmentMetadata()).thenReturn(segmentMetadata);
     when(segmentMetadata.getCrc()).thenReturn(Long.toString(crc));
     return segmentDataManager;
+  }
+
+  @Test
+  public void testSkipCrcCheckOnLoadDefaultFalseReplaces()
+      throws Exception {
+    SegmentZKMetadata zkMetadata = createRawSegment(SegmentVersion.v3, 5);
+    ImmutableSegmentDataManager segmentDataManager = createImmutableSegmentDataManager(SEGMENT_NAME, 0);
+    BaseTableDataManager tableDataManager = createTableManager();
+    File dataDir = tableDataManager.getSegmentDataDir(SEGMENT_NAME);
+    assertFalse(dataDir.exists());
+    tableDataManager.replaceSegmentIfCrcMismatch(segmentDataManager, zkMetadata, new IndexLoadingConfig());
+    assertTrue(dataDir.exists());
+    assertEquals(new SegmentMetadataImpl(dataDir).getTotalDocs(), 5);
+  }
+
+  @Test
+  public void testSkipCrcCheckOnLoadTrueSkipsReplace()
+      throws Exception {
+    // Prepare ZK metadata with tar ready; local immutable segment reports different CRC
+    SegmentZKMetadata zkMetadata = createRawSegment(SegmentVersion.v3, 5);
+    ImmutableSegmentDataManager segmentDataManager = createImmutableSegmentDataManager(SEGMENT_NAME, 0);
+    TableConfig tableConfig =
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).setSkipCrcCheckOnLoad(true).build();
+    BaseTableDataManager tableDataManager =
+        createTableManager(createDefaultInstanceDataManagerConfig(), tableConfig);
+    File dataDir = tableDataManager.getSegmentDataDir(SEGMENT_NAME);
+    assertFalse(dataDir.exists());
+    tableDataManager.replaceSegmentIfCrcMismatch(segmentDataManager, zkMetadata, new IndexLoadingConfig());
+    assertFalse(dataDir.exists(), "Local segment dir should not be replaced");
+  }
+
+  @Test
+  public void testTryLoadExistingSegmentSkipTrueUsesLocal()
+      throws Exception {
+    // Create a local segment directory
+    File localIndexDir = createSegment(SegmentVersion.v3, 5);
+    long localCrc = getCRC(localIndexDir);
+    // Create ZK metadata with a different CRC but keep local dir
+    SegmentZKMetadata zkMetadata =
+        makeRawSegment(localIndexDir, new File(TEMP_DIR, "tmp-" + SEGMENT_NAME + ".tar.gz"), false);
+    zkMetadata.setCrc(localCrc + 1); // ensure mismatch
+
+    TableConfig tableConfig =
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).setSkipCrcCheckOnLoad(true).build();
+    BaseTableDataManager tableDataManager =
+        createTableManager(createDefaultInstanceDataManagerConfig(), tableConfig);
+    IndexLoadingConfig indexLoadingConfig = new IndexLoadingConfig(tableConfig, SCHEMA);
+    boolean reused = tableDataManager.tryLoadExistingSegment(zkMetadata, indexLoadingConfig);
+    assertTrue(reused, "Should reuse local segment when skipCrcCheckOnLoad is true");
+    assertTrue(localIndexDir.exists(), "Local segment dir should remain");
   }
 
   private static boolean hasInvertedIndex(File indexDir, String columnName)

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/SegmentsValidationAndRetentionConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/SegmentsValidationAndRetentionConfig.java
@@ -56,6 +56,8 @@ public class SegmentsValidationAndRetentionConfig extends BaseJsonConfig {
   private String _untrackedSegmentsDeletionBatchSize;
   private String _untrackedSegmentsRetentionTimeUnit;
   private String _untrackedSegmentsRetentionTimeValue;
+  // Skip CRC check for segment load at table level; defaults to false
+  private boolean _skipCrcCheckOnLoad;
 
   /**
    * @deprecated Use {@link InstanceAssignmentConfig} instead
@@ -258,6 +260,14 @@ public class SegmentsValidationAndRetentionConfig extends BaseJsonConfig {
 
   public String getUntrackedSegmentsRetentionTimeValue() {
     return _untrackedSegmentsRetentionTimeValue;
+  }
+
+  public boolean isSkipCrcCheckOnLoad() {
+    return _skipCrcCheckOnLoad;
+  }
+
+  public void setSkipCrcCheckOnLoad(boolean skipCrcCheckOnLoad) {
+    _skipCrcCheckOnLoad = skipCrcCheckOnLoad;
   }
 
   public void setUntrackedSegmentsRetentionTimeValue(String untrackedSegmentsRetentionTimeValue) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/TableConfigBuilder.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/TableConfigBuilder.java
@@ -119,6 +119,7 @@ public class TableConfigBuilder {
   private boolean _optimizeDictionaryType;
   private double _noDictionarySizeRatioThreshold;
   private double _noDictionaryCardinalityRatioThreshold;
+  private Boolean _skipCrcCheckOnLoad = false;
 
   private TableCustomConfig _customConfig;
   private QuotaConfig _quotaConfig;
@@ -387,6 +388,11 @@ public class TableConfigBuilder {
     return this;
   }
 
+  public TableConfigBuilder setSkipCrcCheckOnLoad(boolean skipCrcCheckOnLoad) {
+    _skipCrcCheckOnLoad = skipCrcCheckOnLoad;
+    return this;
+  }
+
   public TableConfigBuilder setCustomConfig(TableCustomConfig customConfig) {
     _customConfig = customConfig;
     return this;
@@ -495,6 +501,7 @@ public class TableConfigBuilder {
     validationConfig.setReplication(_numReplicas);
     validationConfig.setPeerSegmentDownloadScheme(_peerSegmentDownloadScheme);
     validationConfig.setCrypterClassName(_crypterClassName);
+    validationConfig.setSkipCrcCheckOnLoad(_skipCrcCheckOnLoad);
 
     // Tenant config
     TenantConfig tenantConfig = new TenantConfig(_brokerTenant, _serverTenant, _tagOverrideConfig);


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Table\-level skipCrcCheckOnLoad enables serving local segment on download failure during replacement\.

```mermaid
flowchart TD
  N0["Set table#45;level skipCrcCheck flag #40;F1#41;"]:::stModified
  N1["Compute tolerateCrcMismatch #61; #33;instanceCheckCrc #124;#124; tableSkip #40;F1#41;"]:::stModified
  N2["Log #39;Replacing segment due to CRC change#39; #40;F1#41;"]:::stModified
  N3["Attempt downloadAndLoadSegment #40;F1#41;"]:::stModified
  N4["On success#58; log replacement and update segment #40;F1#41;"]:::stModified
  N5["On failure and tolerant#58; log warning#44; update metrics#44; add error#44; keep local #40;F1#41;"]:::stModified
  N6["On failure and not tolerant#58; rethrow exception #40;F1#41;"]:::stModified
  N0 --> N1
  N1 --> N2
  N2 --> N3
  N3 --> N4
  N3 --> N5
  N3 --> N6
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager\.java — [before](https://github.com/apache/pinot/blob/8de6fa9b9a24c4949307ba78d7f3894eaf59fe04/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java) · [after](https://github.com/apache/pinot/blob/aeec6d0d35ec17cbdc498a9cc75fa19695eaea8c/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjhkZTZmYTliOWEyNGM0OTQ5MzA3YmE3OGQ3ZjM4OTRlYWY1OWZlMDQiLCJjb250ZXh0X2hhc2giOiI1YjMwZjA5Y2E5Mjc5NTg0YjJkNTczNTQ4NjE4N2M3ZGJkYzI5N2Y3N2M1Nzg1ZTI4ODBkYmZlMWVlY2UzNTFiIiwiZ2VuZXJhdGVkX2F0IjoxNzg5NjQxMjYzLCJoZWFkX3NoYSI6ImFlZWM2ZDBkMzVlYzE3Y2JkYzQ5OGE5Y2M3NWZhMTk2OTVlYWVhOGMiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiI1ZWIyZGQ3ZTM3ZjUwOTJmZWMxY2MzNDcwOWI3YmU5OTU1YTJmZjI3IiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature d9388203f9ca6b5f7942b56ff1c36011cdf12f3f5d2ec64f421df233a0232d2b -->
<!-- pinot-pr-flow:end -->

Fix for #17233 

This PR adds skipCrcCheckOnLoad as table config as an alternate to server level config to allow for fine grained control on disabling CRC check for tables. 

New config added: `skipCrcCheckOnLoad` under segmentsConfig in table config

## Test Plan 
Tested with Pinot batch quickstart: 
1. With skipCrcCheckOnLoad config enabled in airlineStats table:
```
Handling message: ZnRecord=cb7bee95-dde7-41c9-a0ad-53e4a26e6381, {CREATE_TIMESTAMP=1763551164828, EXECUTE_START_TIMESTAMP=1763551164866, MSG_ID=cb7bee95-dde7-41c9-a0ad-53e4a26e6381, MSG_STATE=new, MSG_SUBTYPE=REFRESH_SEGMENT, MSG_TYPE=USER_DEFINE_MSG, PARTITION_NAME=airlineStats_OFFLINE_16074_16074_0, RESOURCE_NAME=airlineStats_OFFLINE, RETRY_COUNT=0, SRC_CLUSTER=QuickStartCluster, SRC_INSTANCE_TYPE=PARTICIPANT, SRC_NAME=Controller_127.0.0.1_9002, TGT_NAME=Server_127.0.0.1_7050, TGT_SESSION_ID=1005c2cb4d30018, TIMEOUT=-1, segmentName=airlineStats_OFFLINE_16074_16074_0, tableName=airlineStats_OFFLINE}{}{}, Stat=Stat {_version=0, _creationTime=1763551164837, _modifiedTime=1763551164837, _ephemeralOwner=0}
Replacing segment: airlineStats_OFFLINE_16074_16074_0 in table: airlineStats_OFFLINE
Replacing segment: airlineStats_OFFLINE_16074_16074_0
END: GenericClusterController.onMessage() for cluster QuickStartCluster
144 END:INVOKE CallbackHandler 26, /QuickStartCluster/INSTANCES/Broker_127.0.0.1_8000/MESSAGES listener: org.apache.helix.controller.GenericHelixController@10bdfbcc type: CALLBACK Took: 1ms
The latency of message e3a32ea1-8025-40c7-ac3f-7bfb9f2bf8a7 is 38 ms
END: InstanceMessagesCache.refresh(), 2 of Messages read from ZooKeeper. took 1 ms.
Start to refresh stale message cache
END: InstanceMessagesCache.refresh(), 2 of Messages read from ZooKeeper. took 1 ms.
Start to refresh stale message cache
Waiting for lock to reload/refresh: airlineStats_OFFLINE_16074_16074_0, queue-length: 0
Acquired lock to reload/refresh segment: airlineStats_OFFLINE_16074_16074_0 (lock-time=0ms, queue-length=0)
Skipping replacing segment: airlineStats_OFFLINE_16074_16074_0 even though its CRC has changed from: 2686808396 to: 2686808519 because skipCrcCheckOnLoad is enabled
Message cb7bee95-dde7-41c9-a0ad-53e4a26e6381 completed.
Scheduling message e3a32ea1-8025-40c7-ac3f-7bfb9f2bf8a7: brokerResource:airlineStats_OFFLINE, null->null
Submit task: e3a32ea1-8025-40c7-ac3f-7bfb9f2bf8a7 to pool: java.util.concurrent.ThreadPoolExecutor@6350aec6[Running, pool size = 0, active threads = 0, queued tasks = 0, completed tasks = 0]
Message: e3a32ea1-8025-40c7-ac3f-7bfb9f2bf8a7 handling task scheduled
377 END:INVOKE CallbackHandler 28, /QuickStartCluster/INSTANCES/Broker_127.0.0.1_8000/MESSAGES listener: org.apache.helix.messaging.handling.HelixTaskExecutor@702c26cd type: CALLBACK Took: 7ms
handling task: e3a32ea1-8025-40c7-ac3f-7bfb9f2bf8a7 begin, at: 1763551164872
Refreshing segment: airlineStats_OFFLINE_16074_16074_0 for table: airlineStats_OFFLINE
Refreshed segment: airlineStats_OFFLINE_16074_16074_0 for table: airlineStats_OFFLINE
Message e3a32ea1-8025-40c7-ac3f-7bfb9f2bf8a7 completed.
Handled request from 127.0.0.1 POST http://localhost:9002/v2/segments?tableName=airlineStats&tableType=OFFLINE, content-type multipart/form-data; charset=ISO-8859-1; boundary=httpclient_boundary_8c757373-6c11-4c17-a0c3-2d3fad879992 status code 200 OK
Delete message cb7bee95-dde7-41c9-a0ad-53e4a26e6381 from zk!
message finished: cb7bee95-dde7-41c9-a0ad-53e4a26e6381, took 11
Message: cb7bee95-dde7-41c9-a0ad-53e4a26e6381 (parent: null) handling task for airlineStats_OFFLINE:airlineStats_OFFLINE_16074_16074_0 completed at: 1763551164877, results: true. FrameworkTime: 11 ms; HandlerTime: 1 ms.
Delete message e3a32ea1-8025-40c7-ac3f-7bfb9f2bf8a7 from zk!
message finished: e3a32ea1-8025-40c7-ac3f-7bfb9f2bf8a7, took 10
```

2. With skipCrcCheckOnLoad disabled on billing table by default:
```
Handling message: ZnRecord=c5bb3f12-3937-4761-99ed-b7833f02789b, {CREATE_TIMESTAMP=1763552941563, EXECUTE_START_TIMESTAMP=1763552941592, MSG_ID=c5bb3f12-3937-4761-99ed-b7833f02789b, MSG_STATE=new, MSG_SUBTYPE=REFRESH_SEGMENT, MSG_TYPE=USER_DEFINE_MSG, PARTITION_NAME=billing_OFFLINE_0, RESOURCE_NAME=billing_OFFLINE, RETRY_COUNT=0, SRC_CLUSTER=QuickStartCluster, SRC_INSTANCE_TYPE=PARTICIPANT, SRC_NAME=Controller_127.0.0.1_9002, TGT_NAME=Server_127.0.0.1_7050, TGT_SESSION_ID=1005c43051f0018, TIMEOUT=-1, segmentName=billing_OFFLINE_0, tableName=billing_OFFLINE}{}{}, Stat=Stat {_version=0, _creationTime=1763552941572, _modifiedTime=1763552941572, _ephemeralOwner=0}
CallbackHandler26, Subscribing to path: /QuickStartCluster/INSTANCES/Broker_127.0.0.1_8000/MESSAGES took: 0
START: GenericClusterController.onMessage() for cluster QuickStartCluster
Replacing segment: billing_OFFLINE_0 in table: billing_OFFLINE
Replacing segment: billing_OFFLINE_0
CallbackHandler28, Subscribing to path: /QuickStartCluster/INSTANCES/Broker_127.0.0.1_8000/MESSAGES took: 0
END: GenericClusterController.onMessage() for cluster QuickStartCluster
144 END:INVOKE CallbackHandler 26, /QuickStartCluster/INSTANCES/Broker_127.0.0.1_8000/MESSAGES listener: org.apache.helix.controller.GenericHelixController@382d549a type: CALLBACK Took: 0ms
START: InstanceMessagesCache.refresh()
The latency of message dd9dfcb1-3f9c-4c3e-b009-9ba5f24ef8bb is 30 ms
END: InstanceMessagesCache.refresh(), 2 of Messages read from ZooKeeper. took 1 ms.
Start to refresh stale message cache
Waiting for lock to reload/refresh: billing_OFFLINE_0, queue-length: 0
Acquired lock to reload/refresh segment: billing_OFFLINE_0 (lock-time=0ms, queue-length=0)
Replacing segment: billing_OFFLINE_0 because its CRC has changed from: 2262953635 to: 2262953636
Downloading and loading segment: billing_OFFLINE_0
Downloading segment: billing_OFFLINE_0 from: http://127.0.0.1:9002/segments/billing/billing_OFFLINE_0
Acquiring instance level segment download semaphore for segment: billing_OFFLINE_0, queue-length: 0
Acquired instance level segment download semaphore for segment: billing_OFFLINE_0 (lock-time=0ms, queue-length=0).
```

Also tested with realtime tables with lucene index and upsert compaction on our test clusters. 

