### PR TITLE
add ability to cleanup dedup metadata in realtime

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
@@ -59,6 +59,7 @@ public enum ServerMeter implements AbstractMetrics.Meter {
   REALTIME_PARTITION_MISMATCH("mismatch", false),
   REALTIME_DEDUP_DROPPED("rows", false),
   DEDUP_PRELOAD_FAILURE("count", false),
+  DEDUP_REMOVE_EXPIRED_PRIMARY_KEYS_COUNT("keys", false),
   UPSERT_KEYS_IN_WRONG_SEGMENT("rows", false),
   PARTIAL_UPSERT_OUT_OF_ORDER("rows", false),
   PARTIAL_UPSERT_KEYS_NOT_REPLACED("rows", false),

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/dedup/DedupContext.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/dedup/DedupContext.java
@@ -39,6 +39,7 @@ public class DedupContext {
   private final double _metadataTTL;
   @Nullable
   private final String _dedupTimeColumn;
+  private final double _realtimeTTLCleanupIntervalSeconds;
   private final boolean _enablePreload;
   private final boolean _ignoreNonDefaultTiers;
   @Nullable
@@ -54,15 +55,17 @@ public class DedupContext {
   private final File _tableIndexDir;
 
   private DedupContext(TableConfig tableConfig, Schema schema, List<String> primaryKeyColumns,
-      HashFunction hashFunction, double metadataTTL, @Nullable String dedupTimeColumn, boolean enablePreload,
-      boolean ignoreNonDefaultTiers, @Nullable Map<String, String> metadataManagerConfigs,
-      boolean allowDedupConsumptionDuringCommit, @Nullable TableDataManager tableDataManager, File tableIndexDir) {
+      HashFunction hashFunction, double metadataTTL, @Nullable String dedupTimeColumn,
+      double realtimeTTLCleanupIntervalSeconds, boolean enablePreload, boolean ignoreNonDefaultTiers,
+      @Nullable Map<String, String> metadataManagerConfigs, boolean allowDedupConsumptionDuringCommit,
+      @Nullable TableDataManager tableDataManager, File tableIndexDir) {
     _tableConfig = tableConfig;
     _schema = schema;
     _primaryKeyColumns = primaryKeyColumns;
     _hashFunction = hashFunction;
     _metadataTTL = metadataTTL;
     _dedupTimeColumn = dedupTimeColumn;
+    _realtimeTTLCleanupIntervalSeconds = realtimeTTLCleanupIntervalSeconds;
     _enablePreload = enablePreload;
     _ignoreNonDefaultTiers = ignoreNonDefaultTiers;
     _metadataManagerConfigs = metadataManagerConfigs;
@@ -94,6 +97,10 @@ public class DedupContext {
   @Nullable
   public String getDedupTimeColumn() {
     return _dedupTimeColumn;
+  }
+
+  public double getRealtimeTTLCleanupIntervalSeconds() {
+    return _realtimeTTLCleanupIntervalSeconds;
   }
 
   public boolean isPreloadEnabled() {
@@ -130,6 +137,7 @@ public class DedupContext {
         .append("hashFunction", _hashFunction)
         .append("metadataTTL", _metadataTTL)
         .append("dedupTimeColumn", _dedupTimeColumn)
+        .append("realtimeTTLCleanupIntervalSeconds", _realtimeTTLCleanupIntervalSeconds)
         .append("enablePreload", _enablePreload)
         .append("ignoreNonDefaultTiers", _ignoreNonDefaultTiers)
         .append("metadataManagerConfigs", _metadataManagerConfigs)
@@ -145,6 +153,7 @@ public class DedupContext {
     private HashFunction _hashFunction = HashFunction.NONE;
     private double _metadataTTL;
     private String _dedupTimeColumn;
+    private double _realtimeTTLCleanupIntervalSeconds;
     private boolean _enablePreload;
     private boolean _ignoreNonDefaultTiers;
     private Map<String, String> _metadataManagerConfigs;
@@ -180,6 +189,11 @@ public class DedupContext {
 
     public Builder setDedupTimeColumn(String dedupTimeColumn) {
       _dedupTimeColumn = dedupTimeColumn;
+      return this;
+    }
+
+    public Builder setRealtimeTTLCleanupIntervalSeconds(double realtimeTTLCleanupIntervalSeconds) {
+      _realtimeTTLCleanupIntervalSeconds = realtimeTTLCleanupIntervalSeconds;
       return this;
     }
 
@@ -224,8 +238,8 @@ public class DedupContext {
         _tableIndexDir = _tableDataManager.getTableDataDir();
       }
       return new DedupContext(_tableConfig, _schema, _primaryKeyColumns, _hashFunction, _metadataTTL, _dedupTimeColumn,
-          _enablePreload, _ignoreNonDefaultTiers, _metadataManagerConfigs, _allowDedupConsumptionDuringCommit,
-          _tableDataManager, _tableIndexDir);
+          _realtimeTTLCleanupIntervalSeconds, _enablePreload, _ignoreNonDefaultTiers, _metadataManagerConfigs,
+          _allowDedupConsumptionDuringCommit, _tableDataManager, _tableIndexDir);
     }
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/dedup/PartitionDedupMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/dedup/PartitionDedupMetadataManager.java
@@ -90,6 +90,14 @@ public interface PartitionDedupMetadataManager extends Closeable {
   }
 
   /**
+   * Starts the metadata manager. This should be called after the manager is constructed and before it is used.
+   * Default implementation is a no-op for backward compatibility.
+   */
+  default void start() {
+    // No-op by default
+  }
+
+  /**
    * Stops the metadata manager. After invoking this method, no access to the metadata will be accepted.
    */
   void stop();

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/DedupConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/DedupConfig.java
@@ -45,6 +45,12 @@ public class DedupConfig extends BaseJsonConfig {
   @Nullable
   private String _dedupTimeColumn;
 
+  @JsonPropertyDescription("Interval in seconds for realtime TTL cleanup of dedup metadata. When set to 0 (default), "
+      + "realtime cleanup is disabled and metadata is only cleaned up during segment commit. When set to a value > 0, "
+      + "a background thread will periodically remove expired primary keys at the specified interval to reduce memory "
+      + "usage. This does not impact ingestion performance as cleanup happens asynchronously.")
+  private double _realtimeTTLCleanupIntervalSeconds = 0;
+
   @JsonPropertyDescription("Whether to preload segments for fast dedup metadata recovery. Available values are "
       + "ENABLE, DISABLE and DEFAULT (use instance level default behavior).")
   private Enablement _preload = Enablement.DEFAULT;
@@ -125,6 +131,14 @@ public class DedupConfig extends BaseJsonConfig {
 
   public void setDedupTimeColumn(@Nullable String dedupTimeColumn) {
     _dedupTimeColumn = dedupTimeColumn;
+  }
+
+  public double getRealtimeTTLCleanupIntervalSeconds() {
+    return _realtimeTTLCleanupIntervalSeconds;
+  }
+
+  public void setRealtimeTTLCleanupIntervalSeconds(double realtimeTTLCleanupIntervalSeconds) {
+    _realtimeTTLCleanupIntervalSeconds = realtimeTTLCleanupIntervalSeconds;
   }
 
   public Enablement getPreload() {


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Realtime TTL cleanup flow: table init \-&gt; partition manager start \-&gt; scheduler setup \-&gt; periodic key removal and metric update

```mermaid
flowchart TD
  N0["Table init#58; set cleanup interval in DedupContext #40;F3#44; F5#41;"]:::stAdded
  N1["Create partition manager and call start#40;#41; #40;F3#44; F6#41;"]:::stAdded
  N2["BasePartitionDedupMetadataManager#46;start#40;#41; #45;#62; startRealtimeTTLCleanup#40;#41; #40;F2#41;"]:::stAdded
  N3["startRealtimeTTLCleanup#40;#41;#58; setup scheduler #40;F2#41;"]:::stAdded
  N4["Scheduler task#58; call removeExpiredPrimaryKeys#40;#41; #40;F2#41;"]:::stAdded
  N5["ConcurrentMapPartitionDedupMetadataManager#58; remove expired keys and update meter #40;F4#41;"]:::stAdded
  N0 --> N1
  N1 --> N2
  N2 --> N3
  N3 --> N4
  N4 --> N5
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F2: pinot\-segment\-local/src/main/java/org/apache/pinot/segment/local/dedup/BasePartitionDedupMetadataManager\.java — [before](https://github.com/apache/pinot/blob/687770ee3e1b1042e954bc8f7b3e9b53997ab64c/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/dedup/BasePartitionDedupMetadataManager.java) · [after](https://github.com/apache/pinot/blob/e2d198aec5494043928b21125ab3a0ac4023b8cf/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/dedup/BasePartitionDedupMetadataManager.java)
- F3: pinot\-segment\-local/src/main/java/org/apache/pinot/segment/local/dedup/BaseTableDedupMetadataManager\.java — [before](https://github.com/apache/pinot/blob/687770ee3e1b1042e954bc8f7b3e9b53997ab64c/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/dedup/BaseTableDedupMetadataManager.java) · [after](https://github.com/apache/pinot/blob/e2d198aec5494043928b21125ab3a0ac4023b8cf/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/dedup/BaseTableDedupMetadataManager.java)
- F4: pinot\-segment\-local/src/main/java/org/apache/pinot/segment/local/dedup/ConcurrentMapPartitionDedupMetadataManager\.java — [before](https://github.com/apache/pinot/blob/687770ee3e1b1042e954bc8f7b3e9b53997ab64c/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/dedup/ConcurrentMapPartitionDedupMetadataManager.java) · [after](https://github.com/apache/pinot/blob/e2d198aec5494043928b21125ab3a0ac4023b8cf/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/dedup/ConcurrentMapPartitionDedupMetadataManager.java)
- F5: pinot\-segment\-local/src/main/java/org/apache/pinot/segment/local/dedup/DedupContext\.java — [before](https://github.com/apache/pinot/blob/687770ee3e1b1042e954bc8f7b3e9b53997ab64c/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/dedup/DedupContext.java) · [after](https://github.com/apache/pinot/blob/e2d198aec5494043928b21125ab3a0ac4023b8cf/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/dedup/DedupContext.java)
- F6: pinot\-segment\-local/src/main/java/org/apache/pinot/segment/local/dedup/PartitionDedupMetadataManager\.java — [before](https://github.com/apache/pinot/blob/687770ee3e1b1042e954bc8f7b3e9b53997ab64c/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/dedup/PartitionDedupMetadataManager.java) · [after](https://github.com/apache/pinot/blob/e2d198aec5494043928b21125ab3a0ac4023b8cf/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/dedup/PartitionDedupMetadataManager.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjY4Nzc3MGVlM2UxYjEwNDJlOTU0YmM4ZjdiM2U5YjUzOTk3YWI2NGMiLCJjb250ZXh0X2hhc2giOiJhYTRjMzA4YzRhOGI5OTJkYTNmYzQyZDMwYWQzZmYzODQ1MTMxZjc0ZjU2M2ZkNDM5YTE5OTBiZGI1YTYwNjhjIiwiZ2VuZXJhdGVkX2F0IjoxNzg5ODc1MTYxLCJoZWFkX3NoYSI6ImUyZDE5OGFlYzU0OTQwNDM5MjhiMjExMjVhYjNhMGFjNDAyM2I4Y2YiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiI2ODc3NzBlZTNlMWIxMDQyZTk1NGJjOGY3YjNlOWI1Mzk5N2FiNjRjIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature aec711ce26a0328a1e11dd157da53715d922e929308bb6c3bea05eec8d02bab5 -->
<!-- pinot-pr-flow:end -->

This is a new table config deduplication feature to allow near realtime cleanup of metadata keys. When `realtimeTTLCleanupIntervalSeconds` > 0, we start a background thread per partition to call `removeExpiredPrimaryKeys` on every key that is outside of the `metadataTTL`.

The use case for this feature is when `metadataTTL` << segment flush threshold. With high throughput topics, we may want just a few minutes of deduplication to handle transient, upstream duplicates, but we do not want the memory overhead of hours of keys. It is safe to repeatedly call `removeExpiredPrimaryKeys` because deduplication in the ingestion path already respects the TTL even if the key is already in the dictionary.

The goal is for this feature to be backwards compatible. It adds a new interface method for starting the manager after initialization. The only possible and unlikely edge case is if someone overrides `BasePartitionDedupMetadataManager.stop` and uses this feature and does not correctly stop the async cleanup. But even then, it should be safe to keep running.

We tested this over 12 hours publishing ~250 random events per second with a 10 minute metadataTTL and cleanup every 1 minute. We then republished those same events 3-5 minutes later. We then ran `count(*)` repeatedly to show it was < .01% behind the number of unique events published

Monitoring shows a few things:
- the primary key count is capped
- we see rows dropped increase after a few minutes from republishing starting
- we see expired key removal starting after ~10-11 minutes when keys first hit the TTL

<img width="2072" height="309" alt="image" src="https://github.com/user-attachments/assets/a80e33e4-a31c-482b-a284-0ff8fa68e6cf" />
