### PR TITLE
Remove duplicate function name from annotation for ArraysOverlap

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/array/ArraysOverlapScalarFunction.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/array/ArraysOverlapScalarFunction.java
@@ -38,7 +38,7 @@ import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.spi.annotations.ScalarFunction;
 
 
-@ScalarFunction(names = {"ARRAYS_OVERLAP", "ARRAYSOVERLAP"})
+@ScalarFunction(names = {"ARRAYS_OVERLAP"})
 public class ArraysOverlapScalarFunction implements PinotScalarFunction {
 
   private static final Map<DataSchema.ColumnDataType, FunctionInfo>


### PR DESCRIPTION
- This log line gets printed at startup https://github.com/apache/pinot/blob/687770ee3e1b1042e954bc8f7b3e9b53997ab64c/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionRegistry.java#L142
because canonicalization makes `ARRAYS_OVERLAP` and `ARRAYSOVERLAP` equivalent.
- `WARN [FunctionRegistry] [main] Duplicate names: [ARRAYS_OVERLAP, ARRAYSOVERLAP] in class: class org.apache.pinot.common.function.scalar.array.ArraysOverlapScalarFunction`