### PR TITLE
Add FlameGraph visualization for query stage stats

### DIFF
--- a/pinot-controller/src/main/resources/app/components/Query/FlamegraphQueryStageStats.tsx
+++ b/pinot-controller/src/main/resources/app/components/Query/FlamegraphQueryStageStats.tsx
@@ -1,0 +1,156 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+import React, {useMemo, useState} from "react";
+import { Typography, useTheme } from "@material-ui/core";
+import "react-flow-renderer/dist/style.css";
+import isEmpty from "lodash/isEmpty";
+import { FlameGraph } from 'react-flame-graph';
+
+
+/**
+ * Main component to visualize query stage stats as a flowchart.
+ */
+export const FlameGraphQueryStageStats = ({ stageStats, mode }) => {
+  // highlighted stage is the stage currently highlighted by the user
+  const [highlightedStage, setHighlightedStage] = useState<number | null>(null);
+  const { data } = useMemo(() => generateFlameGraphData(stageStats, highlightedStage, mode), [stageStats, highlightedStage, mode]);
+
+  if(isEmpty(stageStats)) {
+    return (
+      <Typography style={{height: "100px", textAlign: "center"}} variant="body1">
+        No stats available
+      </Typography>
+    );
+  }
+
+  return (
+    <div style={{ height: 1000}}>
+      <FlameGraph
+        data={data}
+        height={1000}
+        width={800}
+        onMouseOver = {(event, itemData) => {
+          if (itemData?.relatedStage) {
+            setHighlightedStage(itemData.relatedStage);
+          }
+        }}
+        onMouseOut = {(event, itemData) => {
+          setHighlightedStage(null);
+        }}
+      />
+    </div>
+  );
+};
+
+// ------------------------------------------------------------
+// Helper functions and constants
+
+export enum FlamegraphMode
+{
+  /**
+   * Uses clockTimeMs to size the nodes.
+   */
+  CLOCK_TIME,
+  /**
+   * Uses allocatedBytes to size the nodes.
+   */
+  ALLOCATION,
+}
+
+/**
+ * Recursively generates data for the flame graph from the stats.
+ *
+ * Although the actual value used for sizing the nodes depends on the selected mode, the structure remains the same.
+ *
+ * The returned flame graph structure has two different nodes: Stage nodes and Operation nodes. Stage nodes are always
+ * the children of the root node. Each stage node contains a single children node that corresponds to the MAILBOX_SEND
+ * operation whose "stage" field matches the stage id. The rest of the operations are children of this MAILBOX_SEND
+ * node. In other words, for each MAILBOX_SEND operation, we create a new stage node that is a children of the root
+ * node.
+ * Then the MAILBOX_SEND node contains the rest of the operations as children, pruning after the MAILBOX_RECEIVE nodes.
+ */
+const generateFlameGraphData = (stats, highlightedStage : Number = null, mode : FlamegraphMode = FlamegraphMode.CLOCK_TIME) => {
+  let getNodeValue;
+  switch (mode) {
+    case FlamegraphMode.ALLOCATION:
+      getNodeValue = (node) => node["allocatedMemoryBytes"] || 0;
+      break;
+    case FlamegraphMode.CLOCK_TIME:
+    default:
+      getNodeValue = (node) => node["clockTimeMs"] || 1;
+      break;
+  }
+
+  const stages = [];
+
+  const processNode = (node, currentStage) => {
+    const { children, ...data } = node;
+
+    const baseNode = {
+      tooltip: JSON.stringify(data),
+      value: getNodeValue(data),
+      backgroundColor: highlightedStage === currentStage ? 'lightblue' : null,
+    }
+    // If it's a MAILBOX_RECEIVE node, prune the tree here
+    if (data.type === "MAILBOX_RECEIVE") {
+      const sendOperator = children[0];
+      visitStage(sendOperator, currentStage);
+      return {
+        name: `MAILBOX_RECEIVE from stage ${sendOperator.stage || 'unknown'}`,
+        relatedStage: sendOperator.stage || null,
+        ...baseNode,
+      };
+    }
+
+    // For other nodes, continue processing children
+    return {
+      name: data.type || "Unknown Type",
+      ...baseNode,
+      children: children
+        ? children.map(node => processNode(node, currentStage))
+          .filter(child => child !== null) : [],
+    };
+  }
+
+  const visitStage = (node, parentStage = null) => {
+    const { children, ...data } = node;
+    const stage = data.stage || 0;
+    const value = getNodeValue(node);
+    stages.push({
+      name: "Stage " + stage,
+      value: value,
+      tooltip: JSON.stringify(data),
+      backgroundColor: stage === highlightedStage ? 'lightblue' : null,
+      relatedStage: parentStage,
+      children: children
+        ? children.map(node => processNode(node, stage)).filter(child => child !== null)
+        : [],
+    });
+  }
+  stats.children.forEach((node) => visitStage(node));
+  stages.sort((a, b) => b.value - a.value);
+
+  return {
+    data: {
+      name: 'All stages',
+      value: stages.reduce((sum, child) => sum + child.value, 1),
+      children: stages,
+    }
+  };
+}

--- a/pinot-controller/src/main/resources/app/pages/Query.tsx
+++ b/pinot-controller/src/main/resources/app/pages/Query.tsx
@@ -18,13 +18,13 @@
  * under the License.
  */
 
-import React, { useEffect, useState } from 'react';
-import { makeStyles } from '@material-ui/core/styles';
-import { Grid, Checkbox, Button, FormControl, Input, InputLabel, Box, Typography, ButtonGroup } from '@material-ui/core';
+import React, {useEffect, useState} from 'react';
+import {makeStyles} from '@material-ui/core/styles';
+import {Box, Button, ButtonGroup, Checkbox, FormControl, Grid, Input, InputLabel, Typography} from '@material-ui/core';
 import Alert from '@material-ui/lab/Alert';
 import FileCopyIcon from '@material-ui/icons/FileCopy';
-import { SqlException, TableData } from 'Models';
-import { UnControlled as CodeMirror } from 'react-codemirror2';
+import {SqlException, TableData} from 'Models';
+import {UnControlled as CodeMirror} from 'react-codemirror2';
 import 'codemirror/lib/codemirror.css';
 import 'codemirror/theme/material.css';
 import 'codemirror/mode/javascript/javascript';
@@ -33,9 +33,8 @@ import 'codemirror/addon/hint/show-hint';
 import 'codemirror/addon/hint/sql-hint';
 import 'codemirror/addon/hint/show-hint.css';
 import NativeCodeMirror from 'codemirror';
-import { forEach, uniqBy, range as _range } from 'lodash';
+import {forEach, range as _range, uniqBy} from 'lodash';
 import FormControlLabel from '@material-ui/core/FormControlLabel';
-import Switch from '@material-ui/core/Switch';
 import exportFromJSON from 'export-from-json';
 import Utils from '../utils/Utils';
 import AppLoader from '../components/AppLoader';
@@ -46,9 +45,10 @@ import SimpleAccordion from '../components/SimpleAccordion';
 import PinotMethodUtils from '../utils/PinotMethodUtils';
 import '../styles/styles.css';
 import {Resizable} from "re-resizable";
-import { useHistory, useLocation } from 'react-router';
+import {useHistory, useLocation} from 'react-router';
 import sqlFormatter from '@sqltools/formatter';
-import { VisualizeQueryStageStats } from '../components/Query/VisualizeQueryStageStats';
+import {FlamegraphMode, FlameGraphQueryStageStats} from '../components/Query/FlamegraphQueryStageStats';
+import {VisualizeQueryStageStats} from '../components/Query/VisualizeQueryStageStats';
 
 enum ResultViewType {
   TABULAR = 'tabular',
@@ -713,14 +713,7 @@ const QueryPage = () => {
                             />
                           </SimpleAccordion>
                       )}
-                      {showErrorType === ErrorViewType.VISUAL && (
-                          <SimpleAccordion
-                              headerTitle="Query Stats Visualized"
-                              showSearchBox={false}
-                          >
-                            <VisualizeQueryStageStats stageStats={stageStats} />
-                          </SimpleAccordion>
-                      )}
+                      {showErrorType === ErrorViewType.VISUAL && <MseVisualizer stageStats={stageStats}/>}
                     </>
                   )
                 }
@@ -802,14 +795,7 @@ const QueryPage = () => {
                           />
                         </SimpleAccordion>
                       )}
-                      {resultViewType === ResultViewType.VISUAL && (
-                        <SimpleAccordion
-                          headerTitle="Query Stats Visualized"
-                          showSearchBox={false}
-                        >
-                          <VisualizeQueryStageStats stageStats={stageStats} />
-                        </SimpleAccordion>
-                      )}
+                      {resultViewType === ResultViewType.VISUAL && <MseVisualizer stageStats={stageStats} />}
                     </>
                   ) : null}
                 </Grid>
@@ -821,5 +807,35 @@ const QueryPage = () => {
     </>
   );
 };
+
+const MseVisualizer = ({ stageStats }) => {
+  const [flameGraphMode, setFlameGraphMode] = useState(FlamegraphMode.CLOCK_TIME);
+  return <Grid container direction="row" alignItems="stretch" spacing={2}>
+    <Grid item xs>
+      <SimpleAccordion
+        headerTitle="Query Stats Visualized"
+        showSearchBox={false}
+        key={1}
+      >
+        <VisualizeQueryStageStats stageStats={stageStats} />
+      </SimpleAccordion>
+    </Grid>
+    <Grid item xs>
+      <SimpleAccordion
+        headerTitle="Querœy Stats Visualized"
+        showSearchBox={false}
+        key={2}
+        additionalControls={
+          <ButtonGroup color='primary' size='small'>
+            <Button onClick={() => setFlameGraphMode(FlamegraphMode.CLOCK_TIME)} variant={flameGraphMode === FlamegraphMode.CLOCK_TIME ? "contained" : "outlined"}>Clock</Button>
+            <Button onClick={() => setFlameGraphMode(FlamegraphMode.ALLOCATION)} variant={flameGraphMode === FlamegraphMode.ALLOCATION ? "contained" : "outlined"}>Alloc</Button>
+          </ButtonGroup>
+        }
+      >
+        <FlameGraphQueryStageStats stageStats={stageStats} mode={flameGraphMode}/>
+      </SimpleAccordion>
+    </Grid>
+  </Grid>
+}
 
 export default QueryPage;

--- a/pinot-controller/src/main/resources/package-lock.json
+++ b/pinot-controller/src/main/resources/package-lock.json
@@ -41,6 +41,7 @@
         "react-codemirror2": "7.2.1",
         "react-diff-viewer": "3.1.1",
         "react-dom": "16.13.1",
+        "react-flame-graph": "^1.4.0",
         "react-flow-renderer": "^10.3.17",
         "react-hook-form": "6.15.8",
         "react-router-dom": "5.3.3",
@@ -6476,16 +6477,6 @@
         "eslint": "^8.56.0"
       }
     },
-    "node_modules/eslint-config-airbnb-typescript/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "ms": "^2.1.1"
-      }
-    },
     "node_modules/eslint-config-airbnb-typescript/node_modules/eslint-config-airbnb-base": {
       "version": "15.0.0",
       "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-15.0.0.tgz",
@@ -6503,53 +6494,6 @@
       "peerDependencies": {
         "eslint": "^7.32.0 || ^8.2.0",
         "eslint-plugin-import": "^2.25.2"
-      }
-    },
-    "node_modules/eslint-config-airbnb-typescript/node_modules/eslint-plugin-import": {
-      "version": "2.32.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
-      "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "@rtsao/scc": "^1.1.0",
-        "array-includes": "^3.1.9",
-        "array.prototype.findlastindex": "^1.2.6",
-        "array.prototype.flat": "^1.3.3",
-        "array.prototype.flatmap": "^1.3.3",
-        "debug": "^3.2.7",
-        "doctrine": "^2.1.0",
-        "eslint-import-resolver-node": "^0.3.9",
-        "eslint-module-utils": "^2.12.1",
-        "hasown": "^2.0.2",
-        "is-core-module": "^2.16.1",
-        "is-glob": "^4.0.3",
-        "minimatch": "^3.1.2",
-        "object.fromentries": "^2.0.8",
-        "object.groupby": "^1.0.3",
-        "object.values": "^1.2.1",
-        "semver": "^6.3.1",
-        "string.prototype.trimend": "^1.0.9",
-        "tsconfig-paths": "^3.15.0"
-      },
-      "engines": {
-        "node": ">=4"
-      },
-      "peerDependencies": {
-        "eslint": "^2 || ^3 || ^4 || ^5 || ^6 || ^7.2.0 || ^8 || ^9"
-      }
-    },
-    "node_modules/eslint-config-airbnb-typescript/node_modules/minimatch": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/eslint-config-airbnb/node_modules/eslint-config-airbnb-base": {
@@ -8472,6 +8416,17 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true
+    },
+    "node_modules/flow-bin": {
+      "version": "0.118.0",
+      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.118.0.tgz",
+      "integrity": "sha512-jlbUu0XkbpXeXhan5xyTqVK1jmEKNxE8hpzznI3TThHTr76GiFwK0iRzhDo4KNy+S9h/KxHaqVhTP86vA6wHCg==",
+      "bin": {
+        "flow": "cli.js"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/flush-write-stream": {
       "version": "1.1.1",
@@ -13870,6 +13825,28 @@
         "react": "^16.13.1"
       }
     },
+    "node_modules/react-flame-graph": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/react-flame-graph/-/react-flame-graph-1.4.0.tgz",
+      "integrity": "sha512-DaCK9ZX+xK0mNca72kUE5cu6T8hGe/KLsefQWf+eT9sVt+0WP1dVxZCGD8Svfn2KrZB9Mv011Intg/yG2YWSxA==",
+      "dependencies": {
+        "flow-bin": "^0.118.0",
+        "memoize-one": "^3.1.1",
+        "react-window": "^1"
+      },
+      "engines": {
+        "node": ">8.0.0"
+      },
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/react-flame-graph/node_modules/memoize-one": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-3.1.1.tgz",
+      "integrity": "sha512-YqVh744GsMlZu6xkhGslPSqSurOv6P+kLN2J3ysBZfagLcL5FdRK/0UpgLoL8hwjjEvvAVkjJZyFP+1T6p1vgA=="
+    },
     "node_modules/react-flow-renderer": {
       "version": "10.3.17",
       "resolved": "https://registry.npmjs.org/react-flow-renderer/-/react-flow-renderer-10.3.17.tgz",
@@ -13969,6 +13946,22 @@
       "peerDependencies": {
         "react": ">=16.6.0",
         "react-dom": ">=16.6.0"
+      }
+    },
+    "node_modules/react-window": {
+      "version": "1.8.11",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.11.tgz",
+      "integrity": "sha512-+SRbUVT2scadgFSWx+R1P754xHPEqvcfSfVX10QYg6POOz+WNgkN48pS+BtZNIMGiL1HYrSEiCkwsMS15QogEQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.0.0",
+        "memoize-one": ">=3.1.1 <6"
+      },
+      "engines": {
+        "node": ">8.0.0"
+      },
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/read-pkg": {
@@ -18466,8 +18459,7 @@
           "version": "7.21.0-placeholder-for-preset-env.2",
           "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
           "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         }
       }
     },
@@ -19030,8 +19022,7 @@
     "@material-ui/types": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/@material-ui/types/-/types-5.1.0.tgz",
-      "integrity": "sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A==",
-      "requires": {}
+      "integrity": "sha512-7cqRjrY50b8QzRSYyhSpx4WRw2YuO0KKIGQEVk5J8uoz2BanawykgZGoWEqKm7pVIbzFDN0SpPcVV4IhOFkl8A=="
     },
     "@material-ui/utils": {
       "version": "4.11.3",
@@ -19624,8 +19615,7 @@
     "@types/react-transition-group": {
       "version": "4.4.12",
       "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.12.tgz",
-      "integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w==",
-      "requires": {}
+      "integrity": "sha512-8TV6R3h2j7a91c+1DXdJi3Syo69zzIZbz7Lg5tORM5LEJG7X/E6a1V3drRyBRZq7/utz7A+c4OgYLiLcYGHG6w=="
     },
     "@types/resize-observer-browser": {
       "version": "0.1.11",
@@ -19814,8 +19804,7 @@
       "version": "8.39.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.39.0.tgz",
       "integrity": "sha512-Fd3/QjmFV2sKmvv3Mrj8r6N8CryYiCS8Wdb/6/rgOXAWGcFuc+VkQuG28uk/4kVNVZBQuuDHEDUpo/pQ32zsIQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@typescript-eslint/type-utils": {
       "version": "8.39.0",
@@ -20066,22 +20055,19 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-2.1.1.tgz",
       "integrity": "sha512-wy0mglZpDSiSS0XHrVR+BAdId2+yxPSoJW8fsna3ZpYSlufjvxnP4YbKTCBZnNIcGN4r6ZPXV55X4mYExOfLmw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@webpack-cli/info": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-2.0.2.tgz",
       "integrity": "sha512-zLHQdI/Qs1UyT5UBdWNqsARasIA+AaF8t+4u2aS2nEpBQh2mWIVb8qAklq0eUENnC5mOItrIB4LiS9xMtph18A==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@webpack-cli/serve": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-2.0.5.tgz",
       "integrity": "sha512-lqaoKnRYBdo1UgDX8uF24AfGMifWK19TxPmM5FHc2vAGxrJ/qtyUyFBWoY1tISZdelsQ5fBcOusifo5o5wSJxQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@xtuc/ieee754": {
       "version": "1.2.0",
@@ -20123,8 +20109,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ajv": {
       "version": "6.12.6",
@@ -20142,8 +20127,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
       "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ajv-formats": {
       "version": "2.1.1",
@@ -20178,8 +20162,7 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ansi-colors": {
       "version": "3.2.4",
@@ -22276,16 +22259,6 @@
         "eslint-config-airbnb-base": "^15.0.0"
       },
       "dependencies": {
-        "debug": {
-          "version": "3.2.7",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-          "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        },
         "eslint-config-airbnb-base": {
           "version": "15.0.0",
           "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-15.0.0.tgz",
@@ -22296,44 +22269,6 @@
             "object.assign": "^4.1.2",
             "object.entries": "^1.1.5",
             "semver": "^6.3.0"
-          }
-        },
-        "eslint-plugin-import": {
-          "version": "2.32.0",
-          "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.32.0.tgz",
-          "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "@rtsao/scc": "^1.1.0",
-            "array-includes": "^3.1.9",
-            "array.prototype.findlastindex": "^1.2.6",
-            "array.prototype.flat": "^1.3.3",
-            "array.prototype.flatmap": "^1.3.3",
-            "debug": "^3.2.7",
-            "doctrine": "^2.1.0",
-            "eslint-import-resolver-node": "^0.3.9",
-            "eslint-module-utils": "^2.12.1",
-            "hasown": "^2.0.2",
-            "is-core-module": "^2.16.1",
-            "is-glob": "^4.0.3",
-            "minimatch": "^3.1.2",
-            "object.fromentries": "^2.0.8",
-            "object.groupby": "^1.0.3",
-            "object.values": "^1.2.1",
-            "semver": "^6.3.1",
-            "string.prototype.trimend": "^1.0.9",
-            "tsconfig-paths": "^3.15.0"
-          }
-        },
-        "minimatch": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-          "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "brace-expansion": "^1.1.7"
           }
         }
       }
@@ -22692,8 +22627,7 @@
           "version": "4.6.2",
           "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz",
           "integrity": "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "eslint-plugin-testing-library": {
           "version": "5.11.1",
@@ -23082,8 +23016,7 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-2.5.1.tgz",
       "integrity": "sha512-Y2c4b55R+6ZzwtTppKwSmK/Kar8AdLiC2f9NADCuxbcTgPPg41Gyqa6b9GppgXSvCtkRw43ZE86CT5sejKC6/g==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-scope": {
       "version": "5.1.1",
@@ -23487,6 +23420,11 @@
       "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.3.3.tgz",
       "integrity": "sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==",
       "dev": true
+    },
+    "flow-bin": {
+      "version": "0.118.0",
+      "resolved": "https://registry.npmjs.org/flow-bin/-/flow-bin-0.118.0.tgz",
+      "integrity": "sha512-jlbUu0XkbpXeXhan5xyTqVK1jmEKNxE8hpzznI3TThHTr76GiFwK0iRzhDo4KNy+S9h/KxHaqVhTP86vA6wHCg=="
     },
     "flush-write-stream": {
       "version": "1.1.1",
@@ -25171,8 +25109,7 @@
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/@jsonjoy.com/base64/-/base64-1.1.2.tgz",
           "integrity": "sha512-q6XAnWQDIMA3+FTiOYajoYqySkO+JSat0ytXGSuRdq9uXE7o92gzuQwQM14xaCRlBLGq3v5miDGC4vkVTn54xA==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "@jsonjoy.com/json-pack": {
           "version": "1.2.0",
@@ -25190,22 +25127,19 @@
           "version": "1.6.0",
           "resolved": "https://registry.npmjs.org/@jsonjoy.com/util/-/util-1.6.0.tgz",
           "integrity": "sha512-sw/RMbehRhN68WRtcKCpQOPfnH6lLP4GJfqzi3iYej8tnzpZUDr6UkZYJjcjjC0FWEJOJbyM3PTIwxucUmDG2A==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "thingies": {
           "version": "1.21.0",
           "resolved": "https://registry.npmjs.org/thingies/-/thingies-1.21.0.tgz",
           "integrity": "sha512-hsqsJsFMsV+aD4s3CWKk85ep/3I9XzYV/IXaSouJMYIoDlgyi11cBhsqYe9/geRfB0YIikBQg6raRaM+nIMP9g==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "tree-dump": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/tree-dump/-/tree-dump-1.0.3.tgz",
           "integrity": "sha512-il+Cv80yVHFBwokQSfd4bldvr1Md951DpgAGfmhydt04L+YzHgubm2tQ7zueWDcGENKHq0ZvGFR/hjvNXilHEg==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         }
       }
     },
@@ -26533,8 +26467,7 @@
           "version": "1.4.3",
           "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
           "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "type-fest": {
           "version": "0.20.2",
@@ -27112,8 +27045,7 @@
           "version": "1.4.3",
           "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-1.4.3.tgz",
           "integrity": "sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "type-fest": {
           "version": "0.20.2",
@@ -27317,8 +27249,7 @@
     "re-resizable": {
       "version": "6.9.9",
       "resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-6.9.9.tgz",
-      "integrity": "sha512-l+MBlKZffv/SicxDySKEEh42hR6m5bAHfNu3Tvxks2c4Ah+ldnWjfnVRwxo/nxF27SsUsxDS0raAzFuJNKABXA==",
-      "requires": {}
+      "integrity": "sha512-l+MBlKZffv/SicxDySKEEh42hR6m5bAHfNu3Tvxks2c4Ah+ldnWjfnVRwxo/nxF27SsUsxDS0raAzFuJNKABXA=="
     },
     "react": {
       "version": "16.13.1",
@@ -27333,8 +27264,7 @@
     "react-codemirror2": {
       "version": "7.2.1",
       "resolved": "https://registry.npmjs.org/react-codemirror2/-/react-codemirror2-7.2.1.tgz",
-      "integrity": "sha512-t7YFmz1AXdlImgHXA9Ja0T6AWuopilub24jRaQdPVbzUJVNKIYuy3uCFZYa7CE5S3UW6SrSa5nAqVQvtzRF9gw==",
-      "requires": {}
+      "integrity": "sha512-t7YFmz1AXdlImgHXA9Ja0T6AWuopilub24jRaQdPVbzUJVNKIYuy3uCFZYa7CE5S3UW6SrSa5nAqVQvtzRF9gw=="
     },
     "react-diff-viewer": {
       "version": "3.1.1",
@@ -27360,6 +27290,23 @@
         "scheduler": "^0.19.1"
       }
     },
+    "react-flame-graph": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/react-flame-graph/-/react-flame-graph-1.4.0.tgz",
+      "integrity": "sha512-DaCK9ZX+xK0mNca72kUE5cu6T8hGe/KLsefQWf+eT9sVt+0WP1dVxZCGD8Svfn2KrZB9Mv011Intg/yG2YWSxA==",
+      "requires": {
+        "flow-bin": "^0.118.0",
+        "memoize-one": "^3.1.1",
+        "react-window": "^1"
+      },
+      "dependencies": {
+        "memoize-one": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/memoize-one/-/memoize-one-3.1.1.tgz",
+          "integrity": "sha512-YqVh744GsMlZu6xkhGslPSqSurOv6P+kLN2J3ysBZfagLcL5FdRK/0UpgLoL8hwjjEvvAVkjJZyFP+1T6p1vgA=="
+        }
+      }
+    },
     "react-flow-renderer": {
       "version": "10.3.17",
       "resolved": "https://registry.npmjs.org/react-flow-renderer/-/react-flow-renderer-10.3.17.tgz",
@@ -27378,8 +27325,7 @@
     "react-hook-form": {
       "version": "6.15.8",
       "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-6.15.8.tgz",
-      "integrity": "sha512-prq82ofMbnRyj5wqDe8hsTRcdR25jQ+B8KtCS7BLCzjFHAwNuCjRwzPuP4eYLsEBjEIeYd6try+pdLdw0kPkpg==",
-      "requires": {}
+      "integrity": "sha512-prq82ofMbnRyj5wqDe8hsTRcdR25jQ+B8KtCS7BLCzjFHAwNuCjRwzPuP4eYLsEBjEIeYd6try+pdLdw0kPkpg=="
     },
     "react-is": {
       "version": "16.13.1",
@@ -27435,6 +27381,15 @@
         "dom-helpers": "^5.0.1",
         "loose-envify": "^1.4.0",
         "prop-types": "^15.6.2"
+      }
+    },
+    "react-window": {
+      "version": "1.8.11",
+      "resolved": "https://registry.npmjs.org/react-window/-/react-window-1.8.11.tgz",
+      "integrity": "sha512-+SRbUVT2scadgFSWx+R1P754xHPEqvcfSfVX10QYg6POOz+WNgkN48pS+BtZNIMGiL1HYrSEiCkwsMS15QogEQ==",
+      "requires": {
+        "@babel/runtime": "^7.0.0",
+        "memoize-one": ">=3.1.1 <6"
       }
     },
     "read-pkg": {
@@ -28782,8 +28737,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/ts-api-utils/-/ts-api-utils-2.1.0.tgz",
       "integrity": "sha512-CUgTZL1irw8u29bzrOD/nH85jqyc74D6SshFgujOIA7osm2Rz7dYH77agkx7H4FBNxDq7Cjf+IjaX/8zwFW+ZQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ts-loader": {
       "version": "9.5.2",
@@ -29330,8 +29284,7 @@
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/acorn-import-phases/-/acorn-import-phases-1.0.4.tgz",
           "integrity": "sha512-wKmbr/DDiIXzEOiWrTTUcDm24kQ2vGfZQvM2fwg2vXqR5uW6aapr7ObPtj1th32b9u90/Pf4AItvdTh42fBmVQ==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "ajv": {
           "version": "8.17.1",
@@ -29817,8 +29770,7 @@
       "version": "8.18.3",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.3.tgz",
       "integrity": "sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "wsl-utils": {
       "version": "0.1.0",
@@ -29914,8 +29866,7 @@
     "zustand": {
       "version": "3.7.2",
       "resolved": "https://registry.npmjs.org/zustand/-/zustand-3.7.2.tgz",
-      "integrity": "sha512-PIJDIZKtokhof+9+60cpockVOq05sJzHCriyvaLBmEJixseQ1a5Kdov6fWZfWOu5SK9c+FhH1jU0tntLxRJYMA==",
-      "requires": {}
+      "integrity": "sha512-PIJDIZKtokhof+9+60cpockVOq05sJzHCriyvaLBmEJixseQ1a5Kdov6fWZfWOu5SK9c+FhH1jU0tntLxRJYMA=="
     }
   }
 }

--- a/pinot-controller/src/main/resources/package.json
+++ b/pinot-controller/src/main/resources/package.json
@@ -96,6 +96,7 @@
     "react-codemirror2": "7.2.1",
     "react-diff-viewer": "3.1.1",
     "react-dom": "16.13.1",
+    "react-flame-graph": "^1.4.0",
     "react-flow-renderer": "^10.3.17",
     "react-hook-form": "6.15.8",
     "react-router-dom": "5.3.3",


### PR DESCRIPTION
This PR improves the visualization tab for MSE queries, splitting the panel vertically. The left side is the same graph we had before, while the right side shows a new flamegraph. There are multiple resources online explaining flamegraph (ie, https://signoz.io/blog/flamegraphs/), but the idea is that they create a structure where the vertical axis represents different phases of a call (in our case, operators) while the horizontal axis represents proportional value.

Current state:
- Two modes: Clock time and allocation
- The flamegraph is divided by stages. This is the best way I found to represent the stats in a flamegraph format, given that the stage boundary breaks some invariants (ie, upstream stage 2 may allocate more than downstream stage 1).
- The tooltip of each entry in the flamegraph is just the JSON stats of the operator.
- When the mouse hovers MAILBOX_SEND nodes, the receiving stage is highlighted.
- When the mouse hovers `Stage X` nodes, the sending stage is highlighted.  


https://github.com/user-attachments/assets/08ffd6f6-b5a0-4ab0-ad6a-1a50d1f1799a


Things we should improve:
- Add proper tooltips
- Interconnect the flamegraph and the graph. For example, when zooming in on an operator/stage in the flamegraph, the graph could be refocused on that specific operator/stage. Or when the mouse hovers over a node in the graph, that same stage/operator could be highlighted.
- Add search functionality. 
- Add other diagrams for other non-incremental important stats like emitted rows
- Add GC time as a mode in case it the stat is included (which depends on how the cluster/query is configured)