### PR TITLE
AvgPrecision aggregation function

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/common/ObjectSerDeUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/ObjectSerDeUtils.java
@@ -82,6 +82,7 @@ import org.apache.pinot.core.query.aggregation.utils.exprminmax.ExprMinMaxObject
 import org.apache.pinot.core.query.utils.idset.IdSet;
 import org.apache.pinot.core.query.utils.idset.IdSets;
 import org.apache.pinot.segment.local.customobject.AvgPair;
+import org.apache.pinot.segment.local.customobject.AvgPrecisionPair;
 import org.apache.pinot.segment.local.customobject.CovarianceTuple;
 import org.apache.pinot.segment.local.customobject.CpcSketchAccumulator;
 import org.apache.pinot.segment.local.customobject.DoubleLongPair;
@@ -165,7 +166,8 @@ public class ObjectSerDeUtils {
     TupleIntSketchAccumulator(48),
     CpcSketchAccumulator(49),
     OrderedStringSet(50),
-    FunnelStepEventAccumulator(51);
+    FunnelStepEventAccumulator(51),
+    AvgPrecisionPair(52);
 
     private final int _value;
 
@@ -211,6 +213,8 @@ public class ObjectSerDeUtils {
         return ObjectType.StringArrayList;
       } else if (value instanceof AvgPair) {
         return ObjectType.AvgPair;
+      } else if (value instanceof AvgPrecisionPair) {
+        return ObjectType.AvgPrecisionPair;
       } else if (value instanceof MinMaxRangePair) {
         return ObjectType.MinMaxRangePair;
       } else if (value instanceof HyperLogLog) {
@@ -577,6 +581,24 @@ public class ObjectSerDeUtils {
     @Override
     public AvgPair deserialize(ByteBuffer byteBuffer) {
       return AvgPair.fromByteBuffer(byteBuffer);
+    }
+  };
+
+  public static final ObjectSerDe<AvgPrecisionPair> AVG_PRECISION_PAIR_SER_DE = new ObjectSerDe<AvgPrecisionPair>() {
+
+    @Override
+    public byte[] serialize(AvgPrecisionPair avgPrecisionPair) {
+      return avgPrecisionPair.toBytes();
+    }
+
+    @Override
+    public AvgPrecisionPair deserialize(byte[] bytes) {
+      return AvgPrecisionPair.fromBytes(bytes);
+    }
+
+    @Override
+    public AvgPrecisionPair deserialize(ByteBuffer byteBuffer) {
+      return AvgPrecisionPair.fromByteBuffer(byteBuffer);
     }
   };
 
@@ -1803,6 +1825,7 @@ public class ObjectSerDeUtils {
       DATA_SKETCH_CPC_ACCUMULATOR_SER_DE,
       ORDERED_STRING_SET_SER_DE,
       FUNNEL_STEP_EVENT_ACCUMULATOR_SER_DE,
+      AVG_PRECISION_PAIR_SER_DE,
   };
   //@formatter:on
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactory.java
@@ -235,6 +235,8 @@ public class AggregationFunctionFactory {
             return new SumPrecisionAggregationFunction(arguments, nullHandlingEnabled);
           case AVG:
             return new AvgAggregationFunction(arguments, nullHandlingEnabled);
+          case AVGPRECISION:
+            return new AvgPrecisionAggregationFunction(arguments, nullHandlingEnabled);
           case MODE:
             return new ModeAggregationFunction(arguments, nullHandlingEnabled);
           case FIRSTWITHTIME: {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AvgPrecisionAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AvgPrecisionAggregationFunction.java
@@ -1,0 +1,416 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.aggregation.function;
+
+import com.google.common.base.Preconditions;
+import java.math.BigDecimal;
+import java.math.MathContext;
+import java.math.RoundingMode;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.common.CustomObject;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.common.ObjectSerDeUtils;
+import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
+import org.apache.pinot.core.query.aggregation.ObjectAggregationResultHolder;
+import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
+import org.apache.pinot.core.query.aggregation.groupby.ObjectGroupByResultHolder;
+import org.apache.pinot.segment.local.customobject.AvgPrecisionPair;
+import org.apache.pinot.segment.spi.AggregationFunctionType;
+
+
+/**
+ * This function is used for BigDecimal average calculations.
+ * It supports the average aggregation using precision and scale.
+ * <p>The function can be used as AVGPRECISION(expression, precision, scale, roundingMode)
+ * <p>Following arguments are supported:
+ * <ul>
+ *   <li>Expression: expression that contains the values to be averaged, can be serialized BigDecimal objects</li>
+ *   <li>Precision (optional): precision to be set to the final result</li>
+ *   <li>Scale (optional): scale to be set to the final result</li>
+ *   <li>RoundingMode (optional): rounding mode to be used (default: HALF_EVEN)</li>
+ * </ul>
+ */
+public class AvgPrecisionAggregationFunction
+    extends NullableSingleInputAggregationFunction<AvgPrecisionPair, BigDecimal> {
+  private final Integer _precision;
+  private final Integer _scale;
+  private final RoundingMode _roundingMode;
+
+  public AvgPrecisionAggregationFunction(List<ExpressionContext> arguments, boolean nullHandlingEnabled) {
+    super(arguments.get(0), nullHandlingEnabled);
+
+    int numArguments = arguments.size();
+    Preconditions.checkArgument(numArguments <= 4, "AvgPrecision expects at most 4 arguments, got: %s", numArguments);
+
+    if (numArguments > 1) {
+      _precision = arguments.get(1).getLiteral().getIntValue();
+      if (numArguments > 2) {
+        _scale = arguments.get(2).getLiteral().getIntValue();
+        if (numArguments > 3) {
+          String roundingModeStr = arguments.get(3).getLiteral().getStringValue();
+          _roundingMode = RoundingMode.valueOf(roundingModeStr.toUpperCase());
+        } else {
+          _roundingMode = RoundingMode.HALF_EVEN;
+        }
+      } else {
+        _scale = null;
+        _roundingMode = RoundingMode.HALF_EVEN;
+      }
+    } else {
+      _precision = null;
+      _scale = null;
+      _roundingMode = RoundingMode.HALF_EVEN;
+    }
+  }
+
+  @Override
+  public AggregationFunctionType getType() {
+    return AggregationFunctionType.AVGPRECISION;
+  }
+
+  @Override
+  public AggregationResultHolder createAggregationResultHolder() {
+    return new ObjectAggregationResultHolder();
+  }
+
+  @Override
+  public GroupByResultHolder createGroupByResultHolder(int initialCapacity, int maxCapacity) {
+    return new ObjectGroupByResultHolder(initialCapacity, maxCapacity);
+  }
+
+  @Override
+  public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
+    BlockValSet blockValSet = blockValSetMap.get(_expression);
+
+    AvgPrecisionPair avgPair;
+    switch (blockValSet.getValueType().getStoredType()) {
+      case INT:
+        int[] intValues = blockValSet.getIntValuesSV();
+
+        avgPair = foldNotNull(length, blockValSet, null, (acum, from, to) -> {
+          AvgPrecisionPair innerPair = acum == null ? new AvgPrecisionPair() : acum;
+          for (int i = from; i < to; i++) {
+            innerPair.apply(BigDecimal.valueOf(intValues[i]));
+          }
+          return innerPair;
+        });
+
+        break;
+      case LONG:
+        long[] longValues = blockValSet.getLongValuesSV();
+
+        avgPair = foldNotNull(length, blockValSet, null, (acum, from, to) -> {
+          AvgPrecisionPair innerPair = acum == null ? new AvgPrecisionPair() : acum;
+          for (int i = from; i < to; i++) {
+            innerPair.apply(BigDecimal.valueOf(longValues[i]));
+          }
+          return innerPair;
+        });
+
+        break;
+      case FLOAT:
+      case DOUBLE:
+      case STRING:
+        String[] stringValues = blockValSet.getStringValuesSV();
+
+        avgPair = foldNotNull(length, blockValSet, null, (acum, from, to) -> {
+          AvgPrecisionPair innerPair = acum == null ? new AvgPrecisionPair() : acum;
+          for (int i = from; i < to; i++) {
+            innerPair.apply(new BigDecimal(stringValues[i]));
+          }
+          return innerPair;
+        });
+
+        break;
+      case BIG_DECIMAL:
+        BigDecimal[] bigDecimalValues = blockValSet.getBigDecimalValuesSV();
+
+        avgPair = foldNotNull(length, blockValSet, null, (acum, from, to) -> {
+          AvgPrecisionPair innerPair = acum == null ? new AvgPrecisionPair() : acum;
+          for (int i = from; i < to; i++) {
+            innerPair.apply(bigDecimalValues[i]);
+          }
+          return innerPair;
+        });
+
+        break;
+      case BYTES:
+        // Serialized AvgPrecisionPair
+        byte[][] bytesValues = blockValSet.getBytesValuesSV();
+        avgPair = new AvgPrecisionPair();
+        for (int i = 0; i < length; i++) {
+          AvgPrecisionPair value = ObjectSerDeUtils.AVG_PRECISION_PAIR_SER_DE.deserialize(bytesValues[i]);
+          avgPair.apply(value);
+        }
+        break;
+      default:
+        throw new IllegalStateException("Unsupported value type: " + blockValSet.getValueType());
+    }
+    updateAggregationResult(aggregationResultHolder, avgPair);
+  }
+
+  protected void updateAggregationResult(AggregationResultHolder aggregationResultHolder, AvgPrecisionPair avgPair) {
+    if (_nullHandlingEnabled) {
+      if (avgPair != null && avgPair.getCount() > 0) {
+        AvgPrecisionPair otherPair = aggregationResultHolder.getResult();
+        if (otherPair == null) {
+          aggregationResultHolder.setValue(avgPair);
+        } else {
+          otherPair.apply(avgPair);
+        }
+      }
+    } else {
+      if (avgPair == null) {
+        avgPair = new AvgPrecisionPair();
+      }
+      AvgPrecisionPair otherPair = aggregationResultHolder.getResult();
+      if (otherPair == null) {
+        aggregationResultHolder.setValue(avgPair);
+      } else {
+        otherPair.apply(avgPair);
+      }
+    }
+  }
+
+  @Override
+  public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
+    BlockValSet blockValSet = blockValSetMap.get(_expression);
+
+    switch (blockValSet.getValueType().getStoredType()) {
+      case INT:
+        int[] intValues = blockValSet.getIntValuesSV();
+
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            updateGroupByResult(groupKeyArray[i], groupByResultHolder, BigDecimal.valueOf(intValues[i]));
+          }
+        });
+
+        break;
+      case LONG:
+        long[] longValues = blockValSet.getLongValuesSV();
+
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            updateGroupByResult(groupKeyArray[i], groupByResultHolder, BigDecimal.valueOf(longValues[i]));
+          }
+        });
+
+        break;
+      case FLOAT:
+      case DOUBLE:
+      case STRING:
+        String[] stringValues = blockValSet.getStringValuesSV();
+
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            updateGroupByResult(groupKeyArray[i], groupByResultHolder, new BigDecimal(stringValues[i]));
+          }
+        });
+
+        break;
+      case BIG_DECIMAL:
+        BigDecimal[] bigDecimalValues = blockValSet.getBigDecimalValuesSV();
+
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            updateGroupByResult(groupKeyArray[i], groupByResultHolder, bigDecimalValues[i]);
+          }
+        });
+
+        break;
+      case BYTES:
+        // Serialized AvgPrecisionPair
+        byte[][] bytesValues = blockValSet.getBytesValuesSV();
+        for (int i = 0; i < length; i++) {
+          AvgPrecisionPair avgPair = ObjectSerDeUtils.AVG_PRECISION_PAIR_SER_DE.deserialize(bytesValues[i]);
+          updateGroupByResult(groupKeyArray[i], groupByResultHolder, avgPair);
+        }
+        break;
+      default:
+        throw new IllegalStateException("Unsupported value type: " + blockValSet.getValueType());
+    }
+  }
+
+  private void updateGroupByResult(int groupKey, GroupByResultHolder groupByResultHolder, BigDecimal value) {
+    AvgPrecisionPair avgPair = groupByResultHolder.getResult(groupKey);
+    if (avgPair == null) {
+      avgPair = new AvgPrecisionPair();
+      groupByResultHolder.setValueForKey(groupKey, avgPair);
+    }
+    avgPair.apply(value);
+  }
+
+  private void updateGroupByResult(int groupKey, GroupByResultHolder groupByResultHolder, AvgPrecisionPair value) {
+    AvgPrecisionPair avgPair = groupByResultHolder.getResult(groupKey);
+    if (avgPair == null) {
+      groupByResultHolder.setValueForKey(groupKey, value);
+    } else {
+      avgPair.apply(value);
+    }
+  }
+
+  @Override
+  public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
+      Map<ExpressionContext, BlockValSet> blockValSetMap) {
+    BlockValSet blockValSet = blockValSetMap.get(_expression);
+
+    switch (blockValSet.getValueType().getStoredType()) {
+      case INT:
+        int[] intValues = blockValSet.getIntValuesSV();
+
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            for (int groupKey : groupKeysArray[i]) {
+              updateGroupByResult(groupKey, groupByResultHolder, BigDecimal.valueOf(intValues[i]));
+            }
+          }
+        });
+
+        break;
+      case LONG:
+        long[] longValues = blockValSet.getLongValuesSV();
+
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            for (int groupKey : groupKeysArray[i]) {
+              updateGroupByResult(groupKey, groupByResultHolder, BigDecimal.valueOf(longValues[i]));
+            }
+          }
+        });
+
+        break;
+      case FLOAT:
+      case DOUBLE:
+      case STRING:
+        String[] stringValues = blockValSet.getStringValuesSV();
+
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            for (int groupKey : groupKeysArray[i]) {
+              updateGroupByResult(groupKey, groupByResultHolder, new BigDecimal(stringValues[i]));
+            }
+          }
+        });
+
+        break;
+      case BIG_DECIMAL:
+        BigDecimal[] bigDecimalValues = blockValSet.getBigDecimalValuesSV();
+
+        forEachNotNull(length, blockValSet, (from, to) -> {
+          for (int i = from; i < to; i++) {
+            for (int groupKey : groupKeysArray[i]) {
+              updateGroupByResult(groupKey, groupByResultHolder, bigDecimalValues[i]);
+            }
+          }
+        });
+
+        break;
+      case BYTES:
+        // Serialized AvgPrecisionPair
+        byte[][] bytesValues = blockValSet.getBytesValuesSV();
+        for (int i = 0; i < length; i++) {
+          AvgPrecisionPair avgPair = ObjectSerDeUtils.AVG_PRECISION_PAIR_SER_DE.deserialize(bytesValues[i]);
+          for (int groupKey : groupKeysArray[i]) {
+            updateGroupByResult(groupKey, groupByResultHolder, avgPair);
+          }
+        }
+        break;
+      default:
+        throw new IllegalStateException("Unsupported value type: " + blockValSet.getValueType());
+    }
+  }
+
+  @Override
+  public AvgPrecisionPair extractAggregationResult(AggregationResultHolder aggregationResultHolder) {
+    AvgPrecisionPair result = aggregationResultHolder.getResult();
+    if (result == null) {
+      return _nullHandlingEnabled ? null : new AvgPrecisionPair();
+    }
+    return result;
+  }
+
+  @Override
+  public AvgPrecisionPair extractGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey) {
+    AvgPrecisionPair result = groupByResultHolder.getResult(groupKey);
+    if (result == null) {
+      return _nullHandlingEnabled ? null : new AvgPrecisionPair();
+    }
+    return result;
+  }
+
+  @Override
+  public AvgPrecisionPair merge(AvgPrecisionPair intermediateResult1, AvgPrecisionPair intermediateResult2) {
+    if (_nullHandlingEnabled) {
+      if (intermediateResult1 == null) {
+        return intermediateResult2;
+      }
+      if (intermediateResult2 == null) {
+        return intermediateResult1;
+      }
+    }
+    intermediateResult1.apply(intermediateResult2);
+    return intermediateResult1;
+  }
+
+  @Override
+  public ColumnDataType getIntermediateResultColumnType() {
+    return ColumnDataType.OBJECT;
+  }
+
+  @Override
+  public SerializedIntermediateResult serializeIntermediateResult(AvgPrecisionPair avgPrecisionPair) {
+    return new SerializedIntermediateResult(ObjectSerDeUtils.ObjectType.AvgPrecisionPair.getValue(),
+        ObjectSerDeUtils.AVG_PRECISION_PAIR_SER_DE.serialize(avgPrecisionPair));
+  }
+
+  @Override
+  public AvgPrecisionPair deserializeIntermediateResult(CustomObject customObject) {
+    return ObjectSerDeUtils.AVG_PRECISION_PAIR_SER_DE.deserialize(customObject.getBuffer());
+  }
+
+  @Override
+  public ColumnDataType getFinalResultColumnType() {
+    return ColumnDataType.STRING;
+  }
+
+  @Override
+  public BigDecimal extractFinalResult(AvgPrecisionPair intermediateResult) {
+    if (intermediateResult == null || intermediateResult.getCount() == 0) {
+      return null;
+    }
+
+    BigDecimal sum = intermediateResult.getSum();
+    long count = intermediateResult.getCount();
+
+    MathContext mathContext = _precision != null
+        ? new MathContext(_precision, _roundingMode)
+        : MathContext.DECIMAL128;
+
+    BigDecimal average = sum.divide(BigDecimal.valueOf(count), mathContext);
+    return _scale != null
+        ? average.setScale(_scale, _roundingMode)
+        : average;
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/common/ObjectSerDeUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/common/ObjectSerDeUtilsTest.java
@@ -33,6 +33,7 @@ import it.unimi.dsi.fastutil.longs.Long2LongOpenHashMap;
 import it.unimi.dsi.fastutil.longs.LongArrayList;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import it.unimi.dsi.fastutil.objects.ObjectLinkedOpenHashSet;
+import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -52,6 +53,7 @@ import org.apache.pinot.core.query.aggregation.function.PercentileEstAggregation
 import org.apache.pinot.core.query.aggregation.function.PercentileTDigestAggregationFunction;
 import org.apache.pinot.core.query.aggregation.function.funnel.FunnelStepEvent;
 import org.apache.pinot.segment.local.customobject.AvgPair;
+import org.apache.pinot.segment.local.customobject.AvgPrecisionPair;
 import org.apache.pinot.segment.local.customobject.CpcSketchAccumulator;
 import org.apache.pinot.segment.local.customobject.DoubleLongPair;
 import org.apache.pinot.segment.local.customobject.FloatLongPair;
@@ -137,6 +139,19 @@ public class ObjectSerDeUtilsTest {
 
       byte[] bytes = ObjectSerDeUtils.serialize(expected);
       AvgPair actual = ObjectSerDeUtils.deserialize(bytes, ObjectSerDeUtils.ObjectType.AvgPair);
+
+      assertEquals(actual.getSum(), expected.getSum(), ERROR_MESSAGE);
+      assertEquals(actual.getCount(), expected.getCount(), ERROR_MESSAGE);
+    }
+  }
+
+  @Test
+  public void testAvgPrecisionPair() {
+    for (int i = 0; i < NUM_ITERATIONS; i++) {
+      AvgPrecisionPair expected = new AvgPrecisionPair(new BigDecimal(RANDOM.nextDouble()), RANDOM.nextLong());
+
+      byte[] bytes = ObjectSerDeUtils.serialize(expected);
+      AvgPrecisionPair actual = ObjectSerDeUtils.deserialize(bytes, ObjectSerDeUtils.ObjectType.AvgPrecisionPair);
 
       assertEquals(actual.getSum(), expected.getSum(), ERROR_MESSAGE);
       assertEquals(actual.getCount(), expected.getCount(), ERROR_MESSAGE);

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactoryTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactoryTest.java
@@ -88,6 +88,12 @@ public class AggregationFunctionFactoryTest {
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.AVG);
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
+    function = getFunction("AvGPreCIsiON");
+    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    assertTrue(aggregationFunction instanceof AvgPrecisionAggregationFunction);
+    assertEquals(aggregationFunction.getType(), AggregationFunctionType.AVGPRECISION);
+    assertEquals(aggregationFunction.getResultColumnName(), function.toString());
+
     function = getFunction("MoDe");
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
     assertTrue(aggregationFunction instanceof ModeAggregationFunction);

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/AvgPrecisionAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/AvgPrecisionAggregationFunctionTest.java
@@ -1,0 +1,440 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.aggregation.function;
+
+import java.math.BigDecimal;
+import org.apache.pinot.queries.FluentQueryTest;
+import org.apache.pinot.segment.local.customobject.AvgPrecisionPair;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.apache.pinot.common.function.scalar.DataTypeConversionFunctions.bytesToHex;
+
+
+public class AvgPrecisionAggregationFunctionTest extends AbstractAggregationFunctionTest {
+
+  @DataProvider(name = "scenarios")
+  Object[] scenarios() {
+    return new Object[] {
+        new DataTypeScenario(FieldSpec.DataType.INT),
+        new DataTypeScenario(FieldSpec.DataType.LONG),
+        new DataTypeScenario(FieldSpec.DataType.FLOAT),
+        new DataTypeScenario(FieldSpec.DataType.DOUBLE),
+        new DataTypeScenario(FieldSpec.DataType.BIG_DECIMAL)
+    };
+  }
+
+  @Test(dataProvider = "scenarios")
+  void aggregationAllNullsWithNullHandlingDisabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(false, FieldSpec.FieldType.METRIC)
+        .onFirstInstance("myField",
+            "null",
+            "null"
+        ).andOnSecondInstance("myField",
+            "null"
+        ).whenQuery("select avgprecision(myField) from testTable")
+        .thenResultIs("STRING",
+            String.valueOf(FieldSpec.getDefaultNullValue(FieldSpec.FieldType.METRIC, scenario.getDataType(), null)));
+  }
+
+  @Test(dataProvider = "scenarios")
+  void aggregationAllNullsWithNullHandlingEnabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(true, FieldSpec.FieldType.METRIC)
+        .onFirstInstance("myField",
+            "null",
+            "null"
+        ).andOnSecondInstance("myField",
+            "null"
+        ).whenQuery("select avgprecision(myField) from testTable")
+        .thenResultIs("STRING", "null");
+  }
+
+  @Test(dataProvider = "scenarios")
+  void aggregationGroupBySVAllNullsWithNullHandlingDisabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(false, FieldSpec.FieldType.METRIC)
+        .onFirstInstance("myField",
+            "null",
+            "null"
+        ).andOnSecondInstance("myField",
+            "null"
+        ).whenQuery("select 'literal', avgprecision(myField) from testTable group by 'literal'")
+        .thenResultIs("STRING | STRING", "literal | "
+            + FieldSpec.getDefaultNullValue(FieldSpec.FieldType.METRIC, scenario.getDataType(), null));
+  }
+
+  @Test(dataProvider = "scenarios")
+  void aggregationGroupBySVAllNullsWithNullHandlingEnabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(true, FieldSpec.FieldType.METRIC)
+        .onFirstInstance("myField",
+            "null",
+            "null"
+        ).andOnSecondInstance("myField",
+            "null"
+        ).whenQuery("select 'literal', avgprecision(myField) from testTable group by 'literal'")
+        .thenResultIs("STRING | STRING", "literal | null");
+  }
+
+  @Test(dataProvider = "scenarios")
+  void aggregationWithNullHandlingDisabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(false, FieldSpec.FieldType.METRIC)
+        .onFirstInstance("myField",
+            "3",
+            "null",
+            "5"
+        ).andOnSecondInstance("myField",
+            "null",
+            "null"
+        ).whenQuery("select avgprecision(myField) from testTable")
+        .thenResultIs("STRING", "1.6");
+  }
+
+  @Test(dataProvider = "scenarios")
+  void aggregationWithNullHandlingEnabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(true, FieldSpec.FieldType.METRIC)
+        .onFirstInstance("myField",
+            "null",
+            "5",
+            "null"
+        ).andOnSecondInstance("myField",
+            "2",
+            "null",
+            "3"
+        ).whenQuery("select avgprecision(myField) from testTable")
+        .thenResultIs("STRING", "3.333333333333333333333333333333333");
+  }
+
+  @Test(dataProvider = "scenarios")
+  void aggregationGroupBySVWithNullHandlingDisabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(false, FieldSpec.FieldType.METRIC)
+        .onFirstInstance("myField",
+            "5",
+            "null",
+            "3"
+        ).andOnSecondInstance("myField",
+            "null",
+            "2",
+            "null"
+        ).whenQuery("select 'literal', avgprecision(myField) from testTable group by 'literal'")
+        .thenResultIs("STRING | STRING", "literal | " + "1.666666666666666666666666666666667");
+  }
+
+  @Test(dataProvider = "scenarios")
+  void aggregationGroupBySVWithNullHandlingEnabled(DataTypeScenario scenario) {
+    scenario.getDeclaringTable(true, FieldSpec.FieldType.METRIC)
+        .onFirstInstance("myField",
+            "5",
+            "null",
+            "3"
+        ).andOnSecondInstance("myField",
+            "null",
+            "null",
+            "null"
+        ).whenQuery("select 'literal', avgprecision(myField) from testTable group by 'literal'")
+        .thenResultIs("STRING | STRING", "literal | " + getStringValueOfAvg(8, 2, scenario.getDataType()));
+  }
+
+  @Test(dataProvider = "scenarios")
+  void aggregationGroupByMV(DataTypeScenario scenario) {
+    FluentQueryTest.withBaseDir(_baseDir)
+        .givenTable(
+            new Schema.SchemaBuilder()
+                .setSchemaName("testTable")
+                .setEnableColumnBasedNullHandling(true)
+                .addMultiValueDimension("tags", FieldSpec.DataType.STRING)
+                .addMetricField("value", scenario.getDataType())
+                .build(), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(
+            new Object[]{"tag1;tag2", 1},
+            new Object[]{"tag2;tag3", null}
+        )
+        .andOnSecondInstance(
+            new Object[]{"tag1;tag2", 2},
+            new Object[]{"tag2;tag3", null}
+        )
+        .whenQuery("select tags, avgprecision(value) from testTable group by tags order by tags")
+        .thenResultIs(
+            "STRING | STRING",
+            "tag1    | " + "1.5",
+            "tag2    | " + "0.75",
+            "tag3    | " + getStringValueOfAvg(0, 2, scenario.getDataType())
+        )
+        .whenQueryWithNullHandlingEnabled("select tags, avgprecision(value) from testTable group by tags order by tags")
+        .thenResultIs(
+            "STRING | STRING",
+            "tag1    | " + "1.5",
+            "tag2    | " + "1.5",
+            "tag3    | null"
+        );
+  }
+
+  @Test
+  void testAvgPrecisionWithPrecisionParameter() {
+    FluentQueryTest.withBaseDir(_baseDir)
+        .givenTable(
+            new Schema.SchemaBuilder()
+                .setSchemaName("testTable")
+                .setEnableColumnBasedNullHandling(true)
+                .addSingleValueDimension("value", FieldSpec.DataType.DOUBLE, 0.0)
+                .build(), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(
+            new Object[]{10.123456789},
+            new Object[]{20.987654321}
+        )
+        .andOnSecondInstance(
+            new Object[]{30.555555555}
+        )
+        .whenQuery("select avgprecision(value, 10) from testTable")
+        .thenResultIs("STRING", "20.55555556");
+  }
+
+  @Test
+  void testAvgPrecisionWithPrecisionAndScale() {
+    FluentQueryTest.withBaseDir(_baseDir)
+        .givenTable(
+            new Schema.SchemaBuilder()
+                .setSchemaName("testTable")
+                .setEnableColumnBasedNullHandling(true)
+                .addSingleValueDimension("value", FieldSpec.DataType.DOUBLE, 0.0)
+                .build(), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(
+            new Object[]{100.123},
+            new Object[]{200.456}
+        )
+        .andOnSecondInstance(
+            new Object[]{300.789}
+        )
+        .whenQuery("select avgprecision(value, 10, 2) from testTable")
+        .thenResultIs("STRING", "200.46");
+  }
+
+  @Test
+  void testAvgPrecisionWithBigDecimalValues() {
+    FluentQueryTest.withBaseDir(_baseDir)
+        .givenTable(
+            new Schema.SchemaBuilder()
+                .setSchemaName("testTable")
+                .setEnableColumnBasedNullHandling(true)
+                .addSingleValueDimension("value", FieldSpec.DataType.BIG_DECIMAL, "0")
+                .build(), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(
+            new Object[]{"123456789012345678901234567890.123456789"},
+            new Object[]{"987654321098765432109876543210.987654321"}
+        )
+        .andOnSecondInstance(
+            new Object[]{"555555555555555555555555555555.555555555"}
+        )
+        .whenQuery("select avgprecision(value) from testTable")
+        .thenResultIs("STRING", "555555555222222222188888888885.5556");
+  }
+
+  @Test
+  void testAvgPrecisionWithDifferentRoundingModes() {
+    FluentQueryTest.withBaseDir(_baseDir)
+        .givenTable(
+            new Schema.SchemaBuilder()
+                .setSchemaName("testTable")
+                .setEnableColumnBasedNullHandling(true)
+                .addSingleValueDimension("value", FieldSpec.DataType.DOUBLE, 0.0)
+                .build(), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(
+            new Object[]{10.125},
+            new Object[]{20.125}
+        )
+        .andOnSecondInstance(
+            new Object[]{30.125}
+        )
+        .whenQuery("select avgprecision(value, 10, 2, 'UP') from testTable")
+        .thenResultIs("STRING", "20.13")
+        .whenQuery("select avgprecision(value, 10, 2, 'DOWN') from testTable")
+        .thenResultIs("STRING", "20.12")
+        .whenQuery("select avgprecision(value, 10, 2, 'CEILING') from testTable")
+        .thenResultIs("STRING", "20.13")
+        .whenQuery("select avgprecision(value, 10, 2, 'FLOOR') from testTable")
+        .thenResultIs("STRING", "20.12")
+        .whenQuery("select avgprecision(value, 10, 2, 'HALF_UP') from testTable")
+        .thenResultIs("STRING", "20.13")
+        .whenQuery("select avgprecision(value, 10, 2, 'HALF_DOWN') from testTable")
+        .thenResultIs("STRING", "20.12")
+        .whenQuery("select avgprecision(value, 10, 2, 'HALF_EVEN') from testTable")
+        .thenResultIs("STRING", "20.12");
+  }
+
+  @Test
+  void testAvgPrecisionWithZeroValues() {
+    FluentQueryTest.withBaseDir(_baseDir)
+        .givenTable(
+            new Schema.SchemaBuilder()
+                .setSchemaName("testTable")
+                .setEnableColumnBasedNullHandling(true)
+                .addSingleValueDimension("value", FieldSpec.DataType.DOUBLE, 0.0)
+                .build(), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(
+            new Object[]{0.0},
+            new Object[]{0.0}
+        )
+        .andOnSecondInstance(
+            new Object[]{0.0}
+        )
+        .whenQuery("select avgprecision(value) from testTable")
+        .thenResultIs("STRING", "0.0");
+  }
+
+  @Test
+  void testAvgPrecisionWithNegativeValues() {
+    FluentQueryTest.withBaseDir(_baseDir)
+        .givenTable(
+            new Schema.SchemaBuilder()
+                .setSchemaName("testTable")
+                .setEnableColumnBasedNullHandling(true)
+                .addSingleValueDimension("value", FieldSpec.DataType.DOUBLE, 0.0)
+                .build(), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(
+            new Object[]{-10.5},
+            new Object[]{20.5}
+        )
+        .andOnSecondInstance(
+            new Object[]{-5.0}
+        )
+        .whenQuery("select avgprecision(value, 10, 2) from testTable")
+        .thenResultIs("STRING", "1.67");
+  }
+
+  @Test
+  void testAvgPrecisionWithMixedPositiveNegativeAndNull() {
+    FluentQueryTest.withBaseDir(_baseDir)
+        .givenTable(
+            new Schema.SchemaBuilder()
+                .setSchemaName("testTable")
+                .setEnableColumnBasedNullHandling(true)
+                .addSingleValueDimension("value", FieldSpec.DataType.DOUBLE, 0.0)
+                .build(), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(
+            new Object[]{-100.5},
+            new Object[]{null}
+        )
+        .andOnSecondInstance(
+            new Object[]{200.5},
+            new Object[]{null}
+        )
+        .whenQueryWithNullHandlingEnabled("select avgprecision(value, 10, 2) from testTable")
+        .thenResultIs("STRING", "50.00");
+  }
+
+  @Test
+  void testAvgPrecisionWithSingleValue() {
+    FluentQueryTest.withBaseDir(_baseDir)
+        .givenTable(
+            new Schema.SchemaBuilder()
+                .setSchemaName("testTable")
+                .setEnableColumnBasedNullHandling(true)
+                .addSingleValueDimension("value", FieldSpec.DataType.DOUBLE, 0.0)
+                .build(), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(
+            new Object[]{42.123456789}
+        )
+        .whenQuery("select avgprecision(value, 10, 4) from testTable")
+        .thenResultIs("STRING", "42.1235");
+  }
+
+  @Test
+  void testAvgPrecisionWithVeryLargePrecision() {
+    FluentQueryTest.withBaseDir(_baseDir)
+        .givenTable(
+            new Schema.SchemaBuilder()
+                .setSchemaName("testTable")
+                .setEnableColumnBasedNullHandling(true)
+                .addSingleValueDimension("value", FieldSpec.DataType.DOUBLE, 0.0)
+                .build(), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(
+            new Object[]{1.0},
+            new Object[]{2.0}
+        )
+        .andOnSecondInstance(
+            new Object[]{3.0}
+        )
+        .whenQuery("select avgprecision(value, 100, 50) from testTable")
+        .thenResultIs("STRING", "2.00000000000000000000000000000000000000000000000000");
+  }
+
+  @Test
+  void testAvgPrecisionWithBytesInput() {
+    // Serialize BigDecimal values to bytes and convert to hex strings for FluentQueryTest
+    byte[] bytes1 = new AvgPrecisionPair(new BigDecimal("100.5"), 1).toBytes();
+    byte[] bytes2 = new AvgPrecisionPair(new BigDecimal("200.5"), 1).toBytes();
+    byte[] bytes3 = new AvgPrecisionPair(new BigDecimal("300.5"), 1).toBytes();
+
+    // Convert byte arrays to hex strings (FluentQueryTest expects hex-encoded strings for BYTES type)
+    String hex1 = bytesToHex(bytes1);
+    String hex2 = bytesToHex(bytes2);
+    String hex3 = bytesToHex(bytes3);
+
+    FluentQueryTest.withBaseDir(_baseDir)
+        .givenTable(
+            new Schema.SchemaBuilder()
+                .setSchemaName("testTable")
+                .setEnableColumnBasedNullHandling(true)
+                .addSingleValueDimension("value", FieldSpec.DataType.BYTES, new byte[0])
+                .build(), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(
+            new Object[]{hex1},
+            new Object[]{hex2}
+        )
+        .andOnSecondInstance(
+            new Object[]{hex3}
+        )
+        .whenQuery("select avgprecision(value, 10, 2) from testTable")
+        .thenResultIs("STRING", "200.50");
+  }
+
+  @Test
+  void testAvgPrecisionWithStringInput() {
+    FluentQueryTest.withBaseDir(_baseDir)
+        .givenTable(
+            new Schema.SchemaBuilder()
+                .setSchemaName("testTable")
+                .setEnableColumnBasedNullHandling(true)
+                .addSingleValueDimension("value", FieldSpec.DataType.STRING, "0")
+                .build(), SINGLE_FIELD_TABLE_CONFIG)
+        .onFirstInstance(
+            new Object[]{"123.456"},
+            new Object[]{"789.012"}
+        )
+        .andOnSecondInstance(
+            new Object[]{"345.678"}
+        )
+        .whenQuery("select avgprecision(value, 10, 3) from testTable")
+        .thenResultIs("STRING", "419.382");
+  }
+
+  private String getStringValueOfAvg(int sum, int count, FieldSpec.DataType dataType) {
+    if (dataType == FieldSpec.DataType.FLOAT || dataType == FieldSpec.DataType.DOUBLE) {
+      return String.valueOf((double) sum / count);
+    } else {
+      // For integer types, return the exact division result
+      if (sum % count == 0) {
+        return String.valueOf(sum / count);
+      } else {
+        // Return decimal representation
+        return String.valueOf((double) sum / count);
+      }
+    }
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/customobject/AvgPrecisionPair.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/customobject/AvgPrecisionPair.java
@@ -1,0 +1,109 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.customobject;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.nio.ByteBuffer;
+import org.apache.pinot.spi.utils.BigDecimalUtils;
+
+
+/**
+ * AvgPrecisionPair stores the sum as BigDecimal and count for high-precision average calculations.
+ * This is used by the AVGPRECISION aggregation function to maintain precision when computing averages.
+ */
+public class AvgPrecisionPair implements Comparable<AvgPrecisionPair> {
+  private BigDecimal _sum;
+  private long _count;
+
+  public AvgPrecisionPair() {
+    this(BigDecimal.ZERO, 0L);
+  }
+
+  public AvgPrecisionPair(BigDecimal sum, long count) {
+    _sum = sum;
+    _count = count;
+  }
+
+  public void apply(BigDecimal sum, long count) {
+    _sum = _sum.add(sum);
+    _count += count;
+  }
+
+  public void apply(AvgPrecisionPair avgPrecisionPair) {
+    _sum = _sum.add(avgPrecisionPair._sum);
+    _count += avgPrecisionPair._count;
+  }
+
+  public void apply(BigDecimal value) {
+    _sum = _sum.add(value);
+    _count++;
+  }
+
+  public BigDecimal getSum() {
+    return _sum;
+  }
+
+  public long getCount() {
+    return _count;
+  }
+
+  public byte[] toBytes() {
+    byte[] sumBytes = BigDecimalUtils.serialize(_sum);
+    ByteBuffer byteBuffer = ByteBuffer.allocate(Integer.BYTES + sumBytes.length + Long.BYTES);
+    byteBuffer.putInt(sumBytes.length);
+    byteBuffer.put(sumBytes);
+    byteBuffer.putLong(_count);
+    return byteBuffer.array();
+  }
+
+  public static AvgPrecisionPair fromBytes(byte[] bytes) {
+    return fromByteBuffer(ByteBuffer.wrap(bytes));
+  }
+
+  public static AvgPrecisionPair fromByteBuffer(ByteBuffer byteBuffer) {
+    int sumBytesLength = byteBuffer.getInt();
+    byte[] sumBytes = new byte[sumBytesLength];
+    byteBuffer.get(sumBytes);
+    BigDecimal sum = BigDecimalUtils.deserialize(sumBytes);
+    long count = byteBuffer.getLong();
+    return new AvgPrecisionPair(sum, count);
+  }
+
+  @Override
+  public int compareTo(AvgPrecisionPair avgPrecisionPair) {
+    if (_count == 0) {
+      if (avgPrecisionPair._count == 0) {
+        return 0;
+      } else {
+        return -1;
+      }
+    } else {
+      if (avgPrecisionPair._count == 0) {
+        return 1;
+      } else {
+        BigDecimal avg1 = _sum.divide(BigDecimal.valueOf(_count),
+                RoundingMode.HALF_EVEN);
+        BigDecimal avg2 = avgPrecisionPair._sum.divide(
+                BigDecimal.valueOf(avgPrecisionPair._count), RoundingMode.HALF_EVEN);
+        return avg1.compareTo(avg2);
+      }
+    }
+  }
+}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/customobject/AvgPrecisionPairTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/customobject/AvgPrecisionPairTest.java
@@ -1,0 +1,206 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.customobject;
+
+import java.math.BigDecimal;
+import java.nio.ByteBuffer;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+
+public class AvgPrecisionPairTest {
+
+  @Test
+  public void testConstructorAndGetters() {
+    BigDecimal sum = new BigDecimal("123.456");
+    long count = 10L;
+
+    AvgPrecisionPair pair = new AvgPrecisionPair(sum, count);
+
+    assertEquals(pair.getSum(), sum);
+    assertEquals(pair.getCount(), count);
+  }
+
+  @Test
+  public void testApply() {
+    AvgPrecisionPair pair = new AvgPrecisionPair(new BigDecimal("100"), 5L);
+
+    pair.apply(new BigDecimal("50"), 3L);
+
+    assertEquals(pair.getSum(), new BigDecimal("150"));
+    assertEquals(pair.getCount(), 8L);
+  }
+
+  @Test
+  public void testApplyWithNegativeValues() {
+    AvgPrecisionPair pair = new AvgPrecisionPair(new BigDecimal("100"), 5L);
+
+    pair.apply(new BigDecimal("-30"), 2L);
+
+    assertEquals(pair.getSum(), new BigDecimal("70"));
+    assertEquals(pair.getCount(), 7L);
+  }
+
+  @Test
+  public void testApplyWithZeroCount() {
+    AvgPrecisionPair pair = new AvgPrecisionPair(new BigDecimal("100"), 5L);
+
+    pair.apply(new BigDecimal("50"), 0L);
+
+    assertEquals(pair.getSum(), new BigDecimal("150"));
+    assertEquals(pair.getCount(), 5L);
+  }
+
+  @Test
+  public void testApplyWithLargeNumbers() {
+    BigDecimal largeSum = new BigDecimal("999999999999999999999999999999.999999999");
+    AvgPrecisionPair pair = new AvgPrecisionPair(largeSum, 1000000L);
+
+    BigDecimal additionalSum = new BigDecimal("111111111111111111111111111111.111111111");
+    pair.apply(additionalSum, 500000L);
+
+    assertEquals(pair.getSum(), largeSum.add(additionalSum));
+    assertEquals(pair.getCount(), 1500000L);
+  }
+
+  @Test
+  public void testSerializationDeserialization() {
+    BigDecimal sum = new BigDecimal("12345.6789");
+    long count = 42L;
+    AvgPrecisionPair original = new AvgPrecisionPair(sum, count);
+
+    byte[] bytes = original.toBytes();
+    AvgPrecisionPair deserialized = AvgPrecisionPair.fromBytes(bytes);
+
+    assertEquals(deserialized.getSum(), sum);
+    assertEquals(deserialized.getCount(), count);
+  }
+
+  @Test
+  public void testSerializationDeserializationWithByteBuffer() {
+    BigDecimal sum = new BigDecimal("98765.4321");
+    long count = 100L;
+    AvgPrecisionPair original = new AvgPrecisionPair(sum, count);
+
+    byte[] bytes = original.toBytes();
+    ByteBuffer byteBuffer = ByteBuffer.wrap(bytes);
+    AvgPrecisionPair deserialized = AvgPrecisionPair.fromByteBuffer(byteBuffer);
+
+    assertEquals(deserialized.getSum(), sum);
+    assertEquals(deserialized.getCount(), count);
+  }
+
+  @Test
+  public void testSerializationWithZeroValues() {
+    AvgPrecisionPair original = new AvgPrecisionPair(BigDecimal.ZERO, 0L);
+
+    byte[] bytes = original.toBytes();
+    AvgPrecisionPair deserialized = AvgPrecisionPair.fromBytes(bytes);
+
+    assertEquals(deserialized.getSum(), BigDecimal.ZERO);
+    assertEquals(deserialized.getCount(), 0L);
+  }
+
+  @Test
+  public void testSerializationWithNegativeSum() {
+    BigDecimal negativeSum = new BigDecimal("-12345.6789");
+    long count = 10L;
+    AvgPrecisionPair original = new AvgPrecisionPair(negativeSum, count);
+
+    byte[] bytes = original.toBytes();
+    AvgPrecisionPair deserialized = AvgPrecisionPair.fromBytes(bytes);
+
+    assertEquals(deserialized.getSum(), negativeSum);
+    assertEquals(deserialized.getCount(), count);
+  }
+
+  @Test
+  public void testCompareTo() {
+    AvgPrecisionPair pair1 = new AvgPrecisionPair(new BigDecimal("100"), 10L);
+    AvgPrecisionPair pair2 = new AvgPrecisionPair(new BigDecimal("200"), 10L);
+    AvgPrecisionPair pair3 = new AvgPrecisionPair(new BigDecimal("100"), 10L);
+
+    assertTrue(pair1.compareTo(pair2) < 0);
+    assertTrue(pair2.compareTo(pair1) > 0);
+    assertEquals(pair1.compareTo(pair3), 0);
+  }
+
+  @Test
+  public void testCompareToWithDifferentCounts() {
+    // Average of pair1: 100/10 = 10
+    AvgPrecisionPair pair1 = new AvgPrecisionPair(new BigDecimal("100"), 10L);
+    // Average of pair2: 200/10 = 20
+    AvgPrecisionPair pair2 = new AvgPrecisionPair(new BigDecimal("200"), 10L);
+    // Average of pair3: 150/10 = 15
+    AvgPrecisionPair pair3 = new AvgPrecisionPair(new BigDecimal("150"), 10L);
+
+    assertTrue(pair1.compareTo(pair2) < 0);
+    assertTrue(pair2.compareTo(pair3) > 0);
+    assertTrue(pair1.compareTo(pair3) < 0);
+  }
+
+  @Test
+  public void testCompareToWithZeroCount() {
+    AvgPrecisionPair pair1 = new AvgPrecisionPair(new BigDecimal("100"), 0L);
+    AvgPrecisionPair pair2 = new AvgPrecisionPair(new BigDecimal("200"), 0L);
+
+    // Both have zero count, averages are undefined, so they are equal
+    assertEquals(pair1.compareTo(pair2), 0);
+  }
+
+  @Test
+  public void testRoundTripSerializationWithVeryLargeNumbers() {
+    BigDecimal veryLargeSum = new BigDecimal("123456789012345678901234567890.123456789012345678901234567890");
+    long veryLargeCount = Long.MAX_VALUE;
+    AvgPrecisionPair original = new AvgPrecisionPair(veryLargeSum, veryLargeCount);
+
+    byte[] bytes = original.toBytes();
+    AvgPrecisionPair deserialized = AvgPrecisionPair.fromBytes(bytes);
+
+    assertEquals(deserialized.getSum(), veryLargeSum);
+    assertEquals(deserialized.getCount(), veryLargeCount);
+  }
+
+  @Test
+  public void testMultipleApplyCalls() {
+    AvgPrecisionPair pair = new AvgPrecisionPair(BigDecimal.ZERO, 0L);
+
+    pair.apply(new BigDecimal("10"), 1L);
+    pair.apply(new BigDecimal("20"), 2L);
+    pair.apply(new BigDecimal("30"), 3L);
+
+    assertEquals(pair.getSum(), new BigDecimal("60"));
+    assertEquals(pair.getCount(), 6L);
+  }
+
+  @Test
+  public void testPrecisionPreservation() {
+    // Test that BigDecimal precision is preserved through serialization
+    BigDecimal preciseSum = new BigDecimal("0.123456789012345678901234567890");
+    AvgPrecisionPair original = new AvgPrecisionPair(preciseSum, 1L);
+
+    byte[] bytes = original.toBytes();
+    AvgPrecisionPair deserialized = AvgPrecisionPair.fromBytes(bytes);
+
+    assertEquals(deserialized.getSum(), preciseSum);
+    assertEquals(deserialized.getSum().scale(), preciseSum.scale());
+  }
+}

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/AggregationFunctionType.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/AggregationFunctionType.java
@@ -63,6 +63,7 @@ public enum AggregationFunctionType {
   SUMLONG("sumLong", ReturnTypes.AGG_SUM, OperandTypes.or(OperandTypes.INTEGER, OperandTypes.ARRAY_OF_INTEGER)),
   SUMPRECISION("sumPrecision", ReturnTypes.explicit(SqlTypeName.DECIMAL), OperandTypes.ANY, SqlTypeName.OTHER),
   AVG("avg", SqlTypeName.OTHER, SqlTypeName.DOUBLE),
+  AVGPRECISION("avgPrecision", ReturnTypes.explicit(SqlTypeName.DECIMAL), OperandTypes.ANY, SqlTypeName.OTHER),
   MODE("mode", SqlTypeName.OTHER, SqlTypeName.DOUBLE),
   FIRSTWITHTIME("firstWithTime", ReturnTypes.ARG0,
       OperandTypes.family(SqlTypeFamily.ANY, SqlTypeFamily.ANY, SqlTypeFamily.CHARACTER), SqlTypeName.OTHER),


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

AvgPrecision aggregation function creation and accumulation flow

```mermaid
flowchart TD
  N0["AggregationFunctionFactory #40;F2#41;"]:::stModified
  N1["AvgPrecisionAggregationFunction#46;aggregate #40;F3#41;"]:::stModified
  N2["AvgPrecisionPair #40;F4#41;"]:::stAdded
  N3["ObjectSerDeUtils #40;F1#41;"]:::stModified
  N0 -->|"returns"| N1
  N1 -->|"updates"| N2
  N1 -->|"uses #40;BYTES case#41;"| N3
  N3 -->|"deserializes to"| N2
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-core/src/main/java/org/apache/pinot/core/common/ObjectSerDeUtils\.java — [before](https://github.com/apache/pinot/blob/d78b39b6ca850d9aa2d50f4c47a9a92a1c8a4745/pinot-core/src/main/java/org/apache/pinot/core/common/ObjectSerDeUtils.java) · [after](https://github.com/apache/pinot/blob/31f01c075a1c2d9c6e6e1059d14f736c95555ab8/pinot-core/src/main/java/org/apache/pinot/core/common/ObjectSerDeUtils.java)
- F2: pinot\-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactory\.java — [before](https://github.com/apache/pinot/blob/d78b39b6ca850d9aa2d50f4c47a9a92a1c8a4745/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactory.java) · [after](https://github.com/apache/pinot/blob/31f01c075a1c2d9c6e6e1059d14f736c95555ab8/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactory.java)
- F3: pinot\-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AvgPrecisionAggregationFunction\.java — [after](https://github.com/apache/pinot/blob/31f01c075a1c2d9c6e6e1059d14f736c95555ab8/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AvgPrecisionAggregationFunction.java)
- F4: pinot\-segment\-local/src/main/java/org/apache/pinot/segment/local/customobject/AvgPrecisionPair\.java — [after](https://github.com/apache/pinot/blob/31f01c075a1c2d9c6e6e1059d14f736c95555ab8/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/customobject/AvgPrecisionPair.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImQ3OGIzOWI2Y2E4NTBkOWFhMmQ1MGY0YzQ3YTlhOTJhMWM4YTQ3NDUiLCJjb250ZXh0X2hhc2giOiIzZGY5ZDcxNDhkNjkyMmJhNDE0NjVhYTJjMmJiMTIzNTM1ZWYzYTYyY2ZmMTQ2Mzk5ZTAyZGQ1OTFjOGFjMTdmIiwiZ2VuZXJhdGVkX2F0IjoxNzkwMDk5NTY2LCJoZWFkX3NoYSI6IjMxZjAxYzA3NWExYzJkOWM2ZTZlMTA1OWQxNGY3MzZjOTU1NTVhYjgiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiI1N2Y5NGYzYTdlY2ZlZjgyODIyNGIxOGZiMGU0NDcyNzJkN2FkOTIyIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 1531379102faed78ddfb54d0742e2a421f609de637bcf344124c7bbc070d6b9c -->
<!-- pinot-pr-flow:end -->

This pr adds the support to perform average with fixed precision.

`SELECT AVGPRECISION(colA, precision, scale, roundingmode) FROM table`

`SELECT AVGPRECISION(colA, precision, scale) FROM table`

`SELECT AVGPRECISION(colA, precision) FROM table`

`SELECT AVGPRECISION(colA) FROM table`

**RoundingModes:** https://docs.oracle.com/javase/8/docs/api/java/math/RoundingMode.html
- UP
- DOWN
- CEILING
- FLOOR
- HALF_UP
- HALF_DOWN
- HALF_EVEN (DEFAULT)
- UNNECESSARY

**Additional context:** https://github.com/apache/pinot/issues/17095