### PR TITLE
Fix multiple aggregation functions(StUnion/SumArrayLong/SumArrayDouble/DistinctCountULL) intermediate results serde issue

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/SumArrayDoubleAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/SumArrayDoubleAggregationFunction.java
@@ -138,7 +138,10 @@ public class SumArrayDoubleAggregationFunction
 
   @Override
   public DataSchema.ColumnDataType getIntermediateResultColumnType() {
-    return DataSchema.ColumnDataType.DOUBLE_ARRAY;
+    // AggregationResultsBlock#setIntermediateResult and AggregationFunctionUtils#getIntermediateResult only serialize
+    // intermediate results whose stored type is INT/LONG/DOUBLE/STRING/OBJECT, so we need the OBJECT/custom ser-de path
+    // for DoubleArrayList payloads.
+    return DataSchema.ColumnDataType.OBJECT;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/SumArrayLongAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/SumArrayLongAggregationFunction.java
@@ -148,7 +148,10 @@ public class SumArrayLongAggregationFunction extends BaseSingleInputAggregationF
 
   @Override
   public DataSchema.ColumnDataType getIntermediateResultColumnType() {
-    return DataSchema.ColumnDataType.LONG_ARRAY;
+    // AggregationResultsBlock#setIntermediateResult and AggregationFunctionUtils#getIntermediateResult only support
+    // INT/LONG/DOUBLE/STRING/OBJECT stored types, so LongArrayList must use OBJECT to piggyback on the custom ser-de
+    // implemented in ObjectSerDeUtils.
+    return DataSchema.ColumnDataType.OBJECT;
   }
 
   @Override

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/StUnionAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/StUnionAggregationFunctionTest.java
@@ -1,0 +1,106 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.aggregation.function;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.common.SyntheticBlockValSets;
+import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
+import org.apache.pinot.segment.local.utils.GeometrySerializer;
+import org.apache.pinot.segment.local.utils.GeometryUtils;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.locationtech.jts.geom.Geometry;
+import org.locationtech.jts.geom.util.GeometryCombiner;
+import org.locationtech.jts.operation.union.UnaryUnionOp;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+
+public class StUnionAggregationFunctionTest {
+  @Test
+  public void testMergeHandlesGeometryCollectionInputs()
+      throws Exception {
+    ExpressionContext expression = ExpressionContext.forIdentifier("geometryColumn");
+    StUnionAggregationFunction aggregationFunction = new StUnionAggregationFunction(List.of(expression));
+    Geometry polygon = GeometryUtils.GEOMETRY_WKT_READER.read("POLYGON((0 0, 0 5, 5 5, 5 0, 0 0))");
+    Geometry line = GeometryUtils.GEOMETRY_WKT_READER.read("LINESTRING(20 20, 25 25)");
+    Geometry geometryCollection =
+        GeometryUtils.GEOMETRY_WKT_READER.read("GEOMETRYCOLLECTION (POINT (30 30), LINESTRING (35 35, 40 40))");
+
+    Geometry intermediate = aggregationFunction.merge(polygon, line);
+    Geometry result = aggregationFunction.merge(intermediate, geometryCollection);
+
+    Geometry expected = UnaryUnionOp.union(GeometryCombiner.combine(polygon, line, geometryCollection));
+    assertEquals(result, expected);
+  }
+
+  @Test
+  public void testAggregateHandlesMixedDimensionSequence()
+      throws Exception {
+    ExpressionContext expression = ExpressionContext.forIdentifier("geometryColumn");
+    StUnionAggregationFunction aggregationFunction = new StUnionAggregationFunction(List.of(expression));
+
+    Geometry polygon = GeometryUtils.GEOMETRY_WKT_READER.read("POLYGON((0 0, 0 5, 5 5, 5 0, 0 0))");
+    Geometry line = GeometryUtils.GEOMETRY_WKT_READER.read("LINESTRING(10 10, 15 15)");
+    Geometry geometryCollection =
+        GeometryUtils.GEOMETRY_WKT_READER.read("GEOMETRYCOLLECTION (POINT (20 20), LINESTRING (25 25, 30 30))");
+
+    byte[][] values = new byte[][]{
+        GeometrySerializer.serialize(polygon),
+        GeometrySerializer.serialize(line),
+        GeometrySerializer.serialize(geometryCollection)
+    };
+
+    AggregationResultHolder aggregationResultHolder = aggregationFunction.createAggregationResultHolder();
+    Map<ExpressionContext, BlockValSet> blockValSetMap =
+        Collections.singletonMap(expression, new BytesBlockValSet(values));
+
+    aggregationFunction.aggregate(values.length, aggregationResultHolder, blockValSetMap);
+
+    Geometry expected = UnaryUnionOp.union(GeometryCombiner.combine(polygon, line, geometryCollection));
+    assertEquals(aggregationResultHolder.getResult(), expected);
+  }
+
+  private static class BytesBlockValSet extends SyntheticBlockValSets.Base {
+    private final byte[][] _values;
+
+    private BytesBlockValSet(byte[][] values) {
+      _values = values;
+    }
+
+    @Override
+    public FieldSpec.DataType getValueType() {
+      return FieldSpec.DataType.BYTES;
+    }
+
+    @Override
+    public boolean isSingleValue() {
+      return true;
+    }
+
+    @Override
+    public byte[][] getBytesValuesSV() {
+      return _values;
+    }
+  }
+}

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/CLPEncodingRealtimeIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/CLPEncodingRealtimeIntegrationTest.java
@@ -22,7 +22,6 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Random;
 import javax.annotation.Nullable;
 import org.apache.pinot.spi.config.table.FieldConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -38,7 +37,6 @@ import org.testng.annotations.Test;
 public class CLPEncodingRealtimeIntegrationTest extends BaseClusterIntegrationTestSet {
   private List<File> _avroFiles;
   private FieldConfig.CompressionCodec _selectedCompressionCodec;
-  private final Random _random = new Random();
 
   @BeforeClass
   public void setUp()
@@ -48,7 +46,7 @@ public class CLPEncodingRealtimeIntegrationTest extends BaseClusterIntegrationTe
 
     // Randomly select CLP or CLPV2 compression codec
     _selectedCompressionCodec =
-        _random.nextBoolean() ? FieldConfig.CompressionCodec.CLP : FieldConfig.CompressionCodec.CLPV2;
+        RANDOM.nextBoolean() ? FieldConfig.CompressionCodec.CLP : FieldConfig.CompressionCodec.CLPV2;
 
     // Start the Pinot cluster
     startZk();

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineTimestampIndexIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineTimestampIndexIntegrationTest.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.integration.tests.custom;
+package org.apache.pinot.integration.tests;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import java.io.File;
@@ -24,9 +24,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
-import org.apache.pinot.integration.tests.BaseClusterIntegrationTest;
-import org.apache.pinot.integration.tests.ClusterIntegrationTestUtils;
-import org.apache.pinot.integration.tests.ExplainIntegrationTestTrait;
 import org.apache.pinot.spi.config.table.FieldConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TimestampConfig;

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/GeoSpatialTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/GeoSpatialTest.java
@@ -24,7 +24,6 @@ import java.nio.ByteBuffer;
 import java.util.List;
 import org.apache.avro.file.DataFileWriter;
 import org.apache.avro.generic.GenericData;
-import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.pinot.core.geospatial.transform.function.ScalarFunctions;
 import org.apache.pinot.segment.local.utils.GeometrySerializer;
 import org.apache.pinot.segment.local.utils.GeometryUtils;
@@ -161,10 +160,10 @@ public class GeoSpatialTest extends CustomDataQueryClusterIntegrationTest {
             org.apache.avro.Schema.create(org.apache.avro.Schema.Type.DOUBLE), null, null)
     ));
 
-    File avroFile = new File(_tempDir, "data.avro");
-    try (DataFileWriter<GenericData.Record> fileWriter = new DataFileWriter<>(new GenericDatumWriter<>(avroSchema))) {
-      fileWriter.create(avroSchema, avroFile);
+    try (AvroFilesAndWriters avroFilesAndWriters = createAvroFilesAndWriters(avroSchema)) {
+      List<DataFileWriter<GenericData.Record>> writers = avroFilesAndWriters.getWriters();
       for (int i = 0; i < NUM_TOTAL_DOCS; i++) {
+        int fileIdx = Math.min(i / (NUM_TOTAL_DOCS / getNumAvroFiles()), getNumAvroFiles() - 1);
         GenericData.Record record = new GenericData.Record(avroSchema);
         record.put(DIM_NAME, "dim" + i);
         Point point =
@@ -181,11 +180,10 @@ public class GeoSpatialTest extends CustomDataQueryClusterIntegrationTest {
         record.put(AREA_GEOM_SIZE_NAME, AREA_GEOM_SIZE_DATA[i % AREA_GEOM_SIZE_DATA.length]);
         record.put(AREA_GEOG_NAME, AREA_GEOG_DATA[i % AREA_GEOG_DATA.length]);
         record.put(AREA_GEOG_SIZE_NAME, AREA_GEOG_SIZE_DATA[i % AREA_GEOG_SIZE_DATA.length]);
-        fileWriter.append(record);
+        writers.get(fileIdx).append(record);
       }
+      return avroFilesAndWriters.getAvroFiles();
     }
-
-    return List.of(avroFile);
   }
 
   @Test(dataProvider = "useBothQueryEngines")

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/ULLTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/ULLTest.java
@@ -24,10 +24,8 @@ import java.io.File;
 import java.nio.ByteBuffer;
 import java.util.Base64;
 import java.util.List;
-import java.util.Random;
 import org.apache.avro.file.DataFileWriter;
 import org.apache.avro.generic.GenericData;
-import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.segment.local.utils.UltraLogLogUtils;
 import org.apache.pinot.spi.data.FieldSpec;
@@ -55,7 +53,7 @@ public class ULLTest extends CustomDataQueryClusterIntegrationTest {
       throws Exception {
     setUseMultiStageQueryEngine(useMultiStageQueryEngine);
     String query = String.format("SELECT DISTINCT_COUNT_ULL(%s), DISTINCT_COUNT_RAW_ULL(%s) FROM %s",
-       COLUMN, COLUMN, getTableName());
+        COLUMN, COLUMN, getTableName());
     JsonNode jsonNode = postQuery(query);
     long distinctCount = jsonNode.get("resultTable").get("rows").get(0).get(0).asLong();
     byte[] rawSketchBytes = Base64.getDecoder().decode(jsonNode.get("resultTable").get("rows").get(0).get(1).asText());
@@ -69,13 +67,18 @@ public class ULLTest extends CustomDataQueryClusterIntegrationTest {
   public void testUnionWithSketchQueries(boolean useMultiStageQueryEngine)
       throws Exception {
     setUseMultiStageQueryEngine(useMultiStageQueryEngine);
-
     String query = String.format(
-        "SELECT " + "DISTINCT_COUNT_ULL(%s), " + "DISTINCT_COUNT_RAW_ULL(%s) " + "FROM " + "("
-            + "SELECT %s FROM %s WHERE %s = 4 " + "UNION ALL " + "SELECT %s FROM %s WHERE %s = 5 " + "UNION ALL "
-            + "SELECT %s FROM %s WHERE %s = 6 " + "UNION ALL " + "SELECT %s FROM %s WHERE %s = 7 " + ")",
-        COLUMN, COLUMN, COLUMN, getTableName(), ID, COLUMN,
-        getTableName(), ID, COLUMN, getTableName(), ID, COLUMN, getTableName(), ID);
+        "SELECT " + "DISTINCT_COUNT_ULL(%s), " + "DISTINCT_COUNT_RAW_ULL(%s) "
+            + "FROM " + "("
+            + "SELECT %s FROM %s WHERE %s = 4 " + "UNION ALL "
+            + "SELECT %s FROM %s WHERE %s = 5 " + "UNION ALL "
+            + "SELECT %s FROM %s WHERE %s = 6 " + "UNION ALL "
+            + "SELECT %s FROM %s WHERE %s = 7 " + ")",
+        COLUMN, COLUMN,
+        COLUMN, getTableName(), ID,
+        COLUMN, getTableName(), ID,
+        COLUMN, getTableName(), ID,
+        COLUMN, getTableName(), ID);
     JsonNode jsonNode = postQuery(query);
     long distinctCount = jsonNode.get("resultTable").get("rows").get(0).get(0).asLong();
     byte[] rawSketchBytes = Base64.getDecoder().decode(jsonNode.get("resultTable").get("rows").get(0).get(1).asText());
@@ -132,21 +135,18 @@ public class ULLTest extends CustomDataQueryClusterIntegrationTest {
             null), new org.apache.avro.Schema.Field(COLUMN,
             org.apache.avro.Schema.create(org.apache.avro.Schema.Type.BYTES), null, null)));
 
-    // create avro file
-    File avroFile = new File(_tempDir, "data.avro");
-    try (DataFileWriter<GenericData.Record> fileWriter = new DataFileWriter<>(new GenericDatumWriter<>(avroSchema))) {
-      Random random = new Random();
-      fileWriter.create(avroSchema, avroFile);
+    try (AvroFilesAndWriters avroFilesAndWriters = createAvroFilesAndWriters(avroSchema)) {
+      List<DataFileWriter<GenericData.Record>> writers = avroFilesAndWriters.getWriters();
       for (int i = 0; i < getCountStarResult(); i++) {
         // create avro record
         GenericData.Record record = new GenericData.Record(avroSchema);
-        record.put(ID, random.nextInt(10));
+        record.put(ID, RANDOM.nextInt(10));
         record.put(COLUMN, ByteBuffer.wrap(getRandomRawValue()));
         // add avro record to file
-        fileWriter.append(record);
+        writers.get(i % getNumAvroFiles()).append(record);
       }
+      return avroFilesAndWriters.getAvroFiles();
     }
-    return List.of(avroFile);
   }
 
   private byte[] getRandomRawValue() {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/UnnestIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/UnnestIntegrationTest.java
@@ -19,13 +19,10 @@
 package org.apache.pinot.integration.tests.custom;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
 import java.io.File;
 import java.util.List;
 import org.apache.avro.file.DataFileWriter;
 import org.apache.avro.generic.GenericData;
-import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
@@ -366,32 +363,25 @@ public class UnnestIntegrationTest extends CustomDataQueryClusterIntegrationTest
             null, null)
     ));
 
-    // create avro file
-    File avroFile = new File(_tempDir, "data.avro");
-    Cache<Integer, GenericData.Record> recordCache = CacheBuilder.newBuilder().build();
-    try (DataFileWriter<GenericData.Record> fileWriter = new DataFileWriter<>(new GenericDatumWriter<>(avroSchema))) {
-      fileWriter.create(avroSchema, avroFile);
+    try (AvroFilesAndWriters avroFilesAndWriters = createAvroFilesAndWriters(avroSchema)) {
+      List<DataFileWriter<GenericData.Record>> writers = avroFilesAndWriters.getWriters();
       for (int i = 0; i < getCountStarResult(); i++) {
+        // create avro record
+        GenericData.Record record = new GenericData.Record(avroSchema);
+        record.put(INT_COLUMN, i);
+        record.put(LONG_COLUMN, i);
+        record.put(FLOAT_COLUMN, i + RANDOM.nextFloat());
+        record.put(DOUBLE_COLUMN, i + RANDOM.nextDouble());
+        record.put(STRING_COLUMN, RandomStringUtils.insecure().next(i));
+        record.put(TIMESTAMP_COLUMN, i);
+        record.put(GROUP_BY_COLUMN, String.valueOf(i % 10));
+        record.put(LONG_ARRAY_COLUMN, List.of(0, 1, 2, 3));
+        record.put(DOUBLE_ARRAY_COLUMN, List.of(0.0, 0.1, 0.2, 0.3));
+        record.put(STRING_ARRAY_COLUMN, List.of("a", "b", "c"));
         // add avro record to file
-        int finalI = i;
-        fileWriter.append(recordCache.get(i, () -> {
-              // create avro record
-              GenericData.Record record = new GenericData.Record(avroSchema);
-              record.put(INT_COLUMN, finalI);
-              record.put(LONG_COLUMN, finalI);
-              record.put(FLOAT_COLUMN, finalI + RANDOM.nextFloat());
-              record.put(DOUBLE_COLUMN, finalI + RANDOM.nextDouble());
-              record.put(STRING_COLUMN, RandomStringUtils.insecure().next(finalI));
-              record.put(TIMESTAMP_COLUMN, finalI);
-              record.put(GROUP_BY_COLUMN, String.valueOf(finalI % 10));
-              record.put(LONG_ARRAY_COLUMN, List.of(0, 1, 2, 3));
-              record.put(DOUBLE_ARRAY_COLUMN, List.of(0.0, 0.1, 0.2, 0.3));
-              record.put(STRING_ARRAY_COLUMN, List.of("a", "b", "c"));
-              return record;
-            }
-        ));
+        writers.get(i % getNumAvroFiles()).append(record);
       }
+      return avroFilesAndWriters.getAvroFiles();
     }
-    return List.of(avroFile);
   }
 }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/WindowFunnelTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/WindowFunnelTest.java
@@ -22,7 +22,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import java.io.File;
 import java.util.List;
-import java.util.Random;
 import org.apache.pinot.integration.tests.window.utils.WindowFunnelUtils;
 import org.apache.pinot.spi.data.Schema;
 import org.testng.annotations.Test;
@@ -472,7 +471,7 @@ public class WindowFunnelTest extends CustomDataQueryClusterIntegrationTest {
   public void testFunnelMatchStepWithMultiThreadsReduce(boolean useMultiStageQueryEngine)
       throws Exception {
     setUseMultiStageQueryEngine(useMultiStageQueryEngine);
-    int numThreadsExtractFinalResult = 2 + new Random().nextInt(10);
+    int numThreadsExtractFinalResult = 2 + RANDOM.nextInt(10);
     LOGGER.info("Running testFunnelMatchStepWithMultiThreadsReduce with numThreadsExtractFinalResult: {}",
         numThreadsExtractFinalResult);
     String query =

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/tpch/generator/TPCHQueryGeneratorV2.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/tpch/generator/TPCHQueryGeneratorV2.java
@@ -30,6 +30,7 @@ import org.codehaus.jettison.json.JSONException;
 
 
 public class TPCHQueryGeneratorV2 {
+  private static final Random RANDOM = new Random();
   private static final Map<String, Table> TABLES_MAP = new HashMap<>();
   private static final List<String> TABLE_NAMES =
       List.of("nation", "region", "supplier", "customer", "part", "partsupp", "orders", "lineitem");
@@ -48,8 +49,7 @@ public class TPCHQueryGeneratorV2 {
   }
 
   private static Table getRandomTable() {
-    Random random = new Random();
-    int index = random.nextInt(TABLES_MAP.size());
+    int index = RANDOM.nextInt(TABLES_MAP.size());
     return TABLES_MAP.get(TABLE_NAMES.get(index));
   }
 
@@ -138,12 +138,11 @@ public class TPCHQueryGeneratorV2 {
   }
 
   private List<String> getRandomProjections(Table t1) {
-    Random random = new Random();
-    int numColumns = random.nextInt(t1.getColumns().size()) + 1;
+    int numColumns = RANDOM.nextInt(t1.getColumns().size()) + 1;
     List<String> selectedColumns = new ArrayList<>();
 
     while (selectedColumns.size() < numColumns) {
-      String columnName = t1.getColumns().get(random.nextInt(t1.getColumns().size())).getColumnName();
+      String columnName = t1.getColumns().get(RANDOM.nextInt(t1.getColumns().size())).getColumnName();
       if (!selectedColumns.contains(columnName)) {
         selectedColumns.add(columnName);
       }
@@ -155,12 +154,11 @@ public class TPCHQueryGeneratorV2 {
   private String generateInnerQueryForPredicate(Table t1, Column c) {
     QuerySkeleton innerQuery = new QuerySkeleton();
 
-    Random random = new Random();
     List<String> predicates = new ArrayList<>();
     innerQuery.addTable(t1.getTableName());
     // Limit to maximum of 1 join
-    if (random.nextBoolean()) {
-      RelatedTable relatedTable = t1.getRelatedTables().get(random.nextInt(t1.getRelatedTables().size()));
+    if (RANDOM.nextBoolean()) {
+      RelatedTable relatedTable = t1.getRelatedTables().get(RANDOM.nextInt(t1.getRelatedTables().size()));
       if (relatedTable != null) {
         innerQuery.addTable(relatedTable.getForeignTableName());
         predicates.add(relatedTable.getLocalTableKey() + "=" + relatedTable.getForeignTableKey());
@@ -169,7 +167,7 @@ public class TPCHQueryGeneratorV2 {
         predicates.addAll(inp);
       }
     }
-    String aggregation = c.getColumnType()._aggregations.get(random.nextInt(c.getColumnType()._aggregations.size()));
+    String aggregation = c.getColumnType()._aggregations.get(RANDOM.nextInt(c.getColumnType()._aggregations.size()));
     innerQuery.addProjection(aggregation + "(" + c.getColumnName() + ")");
 
     List<String> inp = getRandomPredicates(t1, false);
@@ -181,8 +179,7 @@ public class TPCHQueryGeneratorV2 {
   }
 
   private String getRandomValueForPredicate(Table t1, Column c, boolean useNextedQueries) {
-    Random random = new Random();
-    if (random.nextBoolean() && useNextedQueries && c.getColumnType()._aggregations.size() > 0) {
+    if (RANDOM.nextBoolean() && useNextedQueries && c.getColumnType()._aggregations.size() > 0) {
       // Use nested query for predicate
       String nestedQueries = generateInnerQueryForPredicate(t1, c);
       return "(" + nestedQueries + ")";
@@ -196,15 +193,14 @@ public class TPCHQueryGeneratorV2 {
   }
 
   private List<String> getRandomPredicates(Table t1, boolean useNestedQueries) {
-    Random random = new Random();
-    int predicateCount = random.nextInt(5) + 1;
+    int predicateCount = RANDOM.nextInt(5) + 1;
     List<String> predicates = new ArrayList<>();
     List<String> results = new ArrayList<>();
     while (predicates.size() < predicateCount) {
-      Column column = t1.getColumns().get(random.nextInt(t1.getColumns().size()));
+      Column column = t1.getColumns().get(RANDOM.nextInt(t1.getColumns().size()));
       predicates.add(column.getColumnName());
       ColumnType columnType = column.getColumnType();
-      String operator = columnType._operators.get(random.nextInt(columnType._operators.size()));
+      String operator = columnType._operators.get(RANDOM.nextInt(columnType._operators.size()));
       String value = getRandomValueForPredicate(t1, column, useNestedQueries);
       String predicateBuilder = column.getColumnName() + " " + operator + " " + value + " ";
       results.add(predicateBuilder);
@@ -218,17 +214,16 @@ public class TPCHQueryGeneratorV2 {
   }
 
   private List<String> getRandomOrderBys(Table t1) {
-    Random random = new Random();
-    int orderByCount = random.nextInt(2) + 1;
+    int orderByCount = RANDOM.nextInt(2) + 1;
     List<String> orderBys = new ArrayList<>();
     List<String> results = new ArrayList<>();
     while (orderBys.size() < orderByCount) {
-      Column column = t1.getColumns().get(random.nextInt(t1.getColumns().size()));
+      Column column = t1.getColumns().get(RANDOM.nextInt(t1.getColumns().size()));
       orderBys.add(column.getColumnName());
       String name = column.getColumnName();
       StringBuilder orderByBuilder = new StringBuilder();
       orderByBuilder.append(name).append(" ");
-      if (random.nextBoolean()) {
+      if (RANDOM.nextBoolean()) {
         orderByBuilder.append(" DESC ");
       }
       results.add(orderByBuilder.toString());
@@ -261,15 +256,14 @@ public class TPCHQueryGeneratorV2 {
     if (groupByCols.size() == 0) {
       return result;
     }
-    Random random = new Random();
     List<String> orderBys = new ArrayList<>();
-    int orderByCount = random.nextInt(groupByCols.size()) + 1;
+    int orderByCount = RANDOM.nextInt(groupByCols.size()) + 1;
     while (orderBys.size() < orderByCount) {
-      String column = groupByCols.get(random.nextInt(groupByCols.size()));
+      String column = groupByCols.get(RANDOM.nextInt(groupByCols.size()));
 
       if (groupByCols.contains(column)) {
         orderBys.add(column);
-        if (random.nextBoolean()) {
+        if (RANDOM.nextBoolean()) {
           result.add(column + " DESC");
         } else {
           result.add(column);
@@ -291,14 +285,13 @@ public class TPCHQueryGeneratorV2 {
       }
     }
 
-    Random random = new Random();
-    RelatedTable rt = t1.getRelatedTables().get(random.nextInt(t1.getRelatedTables().size()));
+    RelatedTable rt = t1.getRelatedTables().get(RANDOM.nextInt(t1.getRelatedTables().size()));
     Table t2 = TABLES_MAP.get(rt.getForeignTableName());
     getRandomProjections(t1).forEach(querySkeleton::addProjection);
     getRandomProjections(t2).forEach(querySkeleton::addProjection);
 
     String t2NameWithJoin =
-        t1.getTableName() + " " + JOIN_TYPES[random.nextInt(JOIN_TYPES.length)] + " " + t2.getTableName() + " ON "
+        t1.getTableName() + " " + JOIN_TYPES[RANDOM.nextInt(JOIN_TYPES.length)] + " " + t2.getTableName() + " ON "
             + rt.getLocalTableKey() + " = " + rt.getForeignTableKey() + " ";
     querySkeleton.addTable(t2NameWithJoin);
 
@@ -318,20 +311,19 @@ public class TPCHQueryGeneratorV2 {
   }
 
   private Pair<List<String>, List<String>> getGroupByAndAggregates(Table t1) {
-    Random random = new Random();
-    int numColumns = random.nextInt(t1.getColumns().size()) + 1;
+    int numColumns = RANDOM.nextInt(t1.getColumns().size()) + 1;
     List<String> selectedColumns = new ArrayList<>();
     List<String> groupByColumns = new ArrayList<>();
     List<String> resultProjections = new ArrayList<>();
 
     while (selectedColumns.size() < numColumns) {
-      Column column = t1.getColumns().get(random.nextInt(t1.getColumns().size()));
+      Column column = t1.getColumns().get(RANDOM.nextInt(t1.getColumns().size()));
       String columnName = column.getColumnName();
       if (!selectedColumns.contains(columnName)) {
-        if (random.nextBoolean() && column.getColumnType()._aggregations.size() > 0) {
+        if (RANDOM.nextBoolean() && column.getColumnType()._aggregations.size() > 0) {
           // Use as aggregation
           String aggregation =
-              column.getColumnType()._aggregations.get(random.nextInt(column.getColumnType()._aggregations.size()));
+              column.getColumnType()._aggregations.get(RANDOM.nextInt(column.getColumnType()._aggregations.size()));
           resultProjections.add(aggregation + "(" + columnName + ")");
         } else {
           // Use as group by
@@ -377,8 +369,7 @@ public class TPCHQueryGeneratorV2 {
       }
     }
 
-    Random random = new Random();
-    RelatedTable rt = t1.getRelatedTables().get(random.nextInt(t1.getRelatedTables().size()));
+    RelatedTable rt = t1.getRelatedTables().get(RANDOM.nextInt(t1.getRelatedTables().size()));
     Table t2 = TABLES_MAP.get(rt.getForeignTableName());
     Pair<List<String>, List<String>> groupByColumns = getGroupByAndAggregates(t1);
     groupByColumns.getLeft().forEach(querySkeleton::addProjection);
@@ -387,7 +378,7 @@ public class TPCHQueryGeneratorV2 {
     groupByColumnsT2.getLeft().forEach(querySkeleton::addProjection);
 
     String tName =
-        t1.getTableName() + "  " + JOIN_TYPES[random.nextInt(JOIN_TYPES.length)] + " " + t2.getTableName() + " ON "
+        t1.getTableName() + "  " + JOIN_TYPES[RANDOM.nextInt(JOIN_TYPES.length)] + " " + t2.getTableName() + " ON "
             + " " + rt.getLocalTableKey() + " = " + " " + rt.getForeignTableKey() + " ";
 
     querySkeleton.addTable(tName);
@@ -415,7 +406,6 @@ public class TPCHQueryGeneratorV2 {
     List<Table> tables = new ArrayList<>();
     Set<String> tableNames = new HashSet<>();
 
-    Random random = new Random();
 
     // Start off with a random table with related tables
     while (true) {
@@ -428,10 +418,10 @@ public class TPCHQueryGeneratorV2 {
     }
 
     // Add more tables
-    while (random.nextInt() % 8 != 0) {
-      int tableToAddIdx = random.nextInt(tables.size());
+    while (RANDOM.nextInt() % 8 != 0) {
+      int tableToAddIdx = RANDOM.nextInt(tables.size());
       RelatedTable relatedTable = tables.get(tableToAddIdx).getRelatedTables()
-          .get(random.nextInt(tables.get(tableToAddIdx).getRelatedTables().size()));
+          .get(RANDOM.nextInt(tables.get(tableToAddIdx).getRelatedTables().size()));
       if (!tableNames.contains(relatedTable.getForeignTableName())) {
         tableNames.add(relatedTable.getForeignTableName());
         tables.add(TPCHQueryGeneratorV2.TABLES_MAP.get(relatedTable.getForeignTableName()));
@@ -475,7 +465,6 @@ public class TPCHQueryGeneratorV2 {
     List<Table> tables = new ArrayList<>();
     Set<String> tableNames = new HashSet<>();
 
-    Random random = new Random();
 
     // Start off with a random table with related tables
     while (true) {
@@ -488,10 +477,10 @@ public class TPCHQueryGeneratorV2 {
     }
 
     // Add more tables
-    while (random.nextInt() % 8 != 0) {
-      int tableToAddIdx = random.nextInt(tables.size());
+    while (RANDOM.nextInt() % 8 != 0) {
+      int tableToAddIdx = RANDOM.nextInt(tables.size());
       RelatedTable relatedTable = tables.get(tableToAddIdx).getRelatedTables()
-          .get(random.nextInt(tables.get(tableToAddIdx).getRelatedTables().size()));
+          .get(RANDOM.nextInt(tables.get(tableToAddIdx).getRelatedTables().size()));
       if (!tableNames.contains(relatedTable.getForeignTableName())) {
         tableNames.add(relatedTable.getForeignTableName());
         tables.add(TPCHQueryGeneratorV2.TABLES_MAP.get(relatedTable.getForeignTableName()));
@@ -529,9 +518,8 @@ public class TPCHQueryGeneratorV2 {
   }
 
   public String generateRandomQuery() {
-    Random random = new Random();
-    int queryType = random.nextInt(6);
-    boolean includePredicates = random.nextBoolean();
+    int queryType = RANDOM.nextInt(6);
+    boolean includePredicates = RANDOM.nextBoolean();
     boolean includeOrderBy = true;
     switch (queryType) {
       case 0:


### PR DESCRIPTION
1. Increase all CustomDataQueryClusterIntegrationTest test suite to use 2 servers and 2 segments to ensure the query behaviors like intermediate results serde/ merge/exchange etc are expected.
2. Change SumArrayLong and SumArrayDouble Agg function intermediate result type to `OBJECT` so the DataTable serde will work automatically for them.
3. Fix StUnion object merge issue
4. Fix ULL merge issue when aggregation on bytes column which may use different p, then return ULL object with default p will cause merge failure.