### PR TITLE
Fix flaky RenewableTlsUtilsTest reload wait

### DIFF
--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/tls/RenewableTlsUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/tls/RenewableTlsUtilsTest.java
@@ -82,6 +82,8 @@ public class RenewableTlsUtilsTest {
   private static final String DEFAULT_TEST_TLS_DIR
       = new File(FileUtils.getTempDirectoryPath(), "test-tls-dir" + System.currentTimeMillis()).getAbsolutePath();
   private static final String KEY_NAME_ALIAS = "mykey";
+  private static final long SSL_FACTORY_RELOAD_TIMEOUT_MS = 5000L;
+  private static final long SSL_FACTORY_RELOAD_POLL_INTERVAL_MS = 100L;
 
   private static final String TLS_KEYSTORE_FILE_PATH = DEFAULT_TEST_TLS_DIR + "/" + TLS_KEYSTORE_FILE;
   private static final String TLS_TRUSTSTORE_FILE_PATH = DEFAULT_TEST_TLS_DIR + "/" + TLS_TRUSTSTORE_FILE;
@@ -109,8 +111,6 @@ public class RenewableTlsUtilsTest {
         Path destinationPath = Paths.get(DEFAULT_TEST_TLS_DIR, entry.getValue());
         // Use Files.copy to copy the file to the destination folder
         Files.copy(resourceStream, destinationPath, StandardCopyOption.REPLACE_EXISTING);
-      } catch (IOException e) {
-        e.printStackTrace(); // Handle the exception as needed
       }
     }
   }
@@ -197,6 +197,7 @@ public class RenewableTlsUtilsTest {
           }
         });
     updateTlsFilesAndWaitForSslFactoryToBeRenewed();
+    waitForTlsMaterialChange(sslFactory, privateKey, certForPrivateKey, acceptedIssuerForCert);
     executorService.shutdown();
 
     // after tls file update, the returned values should be the same, since the wrapper is the same
@@ -346,24 +347,41 @@ public class RenewableTlsUtilsTest {
     return tlsConfig;
   }
 
+  private void waitForTlsMaterialChange(SSLFactory sslFactory, PrivateKey privateKey, Certificate certForPrivateKey,
+      X509Certificate acceptedIssuerForCert)
+      throws InterruptedException {
+    long deadline = System.currentTimeMillis() + SSL_FACTORY_RELOAD_TIMEOUT_MS;
+    while (System.currentTimeMillis() < deadline) {
+      X509ExtendedKeyManager keyManager = sslFactory.getKeyManager().orElseThrow();
+      X509ExtendedTrustManager trustManager = sslFactory.getTrustManager().orElseThrow();
+      boolean keyChanged = !privateKey.equals(keyManager.getPrivateKey(KEY_NAME_ALIAS));
+      boolean certChanged = !certForPrivateKey.equals(keyManager.getCertificateChain(KEY_NAME_ALIAS)[0]);
+      boolean issuerChanged = !acceptedIssuerForCert.equals(trustManager.getAcceptedIssuers()[0]);
+      if (keyChanged && certChanged && issuerChanged) {
+        return;
+      }
+      Thread.sleep(SSL_FACTORY_RELOAD_POLL_INTERVAL_MS);
+    }
+    fail("SSLFactory was not reloaded with updated TLS material within " + SSL_FACTORY_RELOAD_TIMEOUT_MS + "ms");
+  }
+
   private void updateTlsFilesAndWaitForSslFactoryToBeRenewed()
       throws IOException, URISyntaxException, InterruptedException {
-    WatchService watchService = FileSystems.getDefault().newWatchService();
-    Map<WatchKey, Set<Path>> watchKeyPathMap = new HashMap<>();
-    RenewableTlsUtils.registerFile(watchService, watchKeyPathMap, TLS_KEYSTORE_FILE_PATH);
-    RenewableTlsUtils.registerFile(watchService, watchKeyPathMap, TLS_TRUSTSTORE_FILE_PATH);
+    try (WatchService watchService = FileSystems.getDefault().newWatchService()) {
+      Map<WatchKey, Set<Path>> watchKeyPathMap = new HashMap<>();
+      RenewableTlsUtils.registerFile(watchService, watchKeyPathMap, TLS_KEYSTORE_FILE_PATH);
+      RenewableTlsUtils.registerFile(watchService, watchKeyPathMap, TLS_TRUSTSTORE_FILE_PATH);
 
-    // wait for the new thread to start
-    Thread.sleep(100);
+      // wait for the new thread to start
+      Thread.sleep(100);
 
-    // update tls files
-    copyResourceFilesToTempFolder(
-        Map.of(TLS_KEYSTORE_UPDATED_FILE, TLS_KEYSTORE_FILE, TLS_TRUSTSTORE_UPDATED_FILE,
-            TLS_TRUSTSTORE_FILE));
+      // update tls files
+      copyResourceFilesToTempFolder(
+          Map.of(TLS_KEYSTORE_UPDATED_FILE, TLS_KEYSTORE_FILE, TLS_TRUSTSTORE_UPDATED_FILE,
+              TLS_TRUSTSTORE_FILE));
 
-    // wait for the file change event to be detected
-    watchService.take();
-    // it will take some time for the thread to be notified and reload the ssl factory
-    Thread.sleep(500);
+      // wait for the file change event to be detected
+      watchService.take();
+    }
   }
 }


### PR DESCRIPTION
This pull request improves the reliability and accuracy of the TLS material reload tests in `RenewableTlsUtilsTest.java` by introducing a polling mechanism to verify that the SSL factory has been properly reloaded after TLS file changes, and by cleaning up exception handling in resource file copying.

Test reliability and TLS material verification:

* Added the `waitForTlsMaterialChange` helper method to poll for changes in the SSL factory's key, certificate, and issuer, ensuring the SSL factory reload is complete before proceeding. This replaces the previous fixed sleep approach and improves test robustness.
* Updated the `reloadSslFactoryWhenFileStoreChanges()` test to use the new `waitForTlsMaterialChange` method after updating TLS files, ensuring the test waits for actual material changes rather than relying on timing.
* Removed the fixed `Thread.sleep(500)` from `updateTlsFilesAndWaitForSslFactoryToBeRenewed()` and replaced it with the more reliable polling mechanism.

Code hygiene and resource management:

* Cleaned up exception handling in `copyResourceFilesToTempFolder` by removing unnecessary printing of stack traces for IO exceptions.
* Ensured proper resource management by using a try-with-resources block for `WatchService` in `updateTlsFilesAndWaitForSslFactoryToBeRenewed()`.

Configuration improvements:

* Introduced constants `SSL_FACTORY_RELOAD_TIMEOUT_MS` and `SSL_FACTORY_RELOAD_POLL_INTERVAL_MS` to configure the polling behavior for SSL factory reload verification.