### PR TITLE
make server segment predownload configurable

### DIFF
--- a/pinot-server/src/main/java/org/apache/pinot/server/predownload/PredownloadScheduler.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/predownload/PredownloadScheduler.java
@@ -89,12 +89,24 @@ public class PredownloadScheduler {
     _pinotConfig = new PinotConfiguration(properties);
     _instanceDataManagerConfig =
         new HelixInstanceDataManagerConfig(new ServerConf(_pinotConfig).getInstanceDataManagerConfig());
-    // Get the number of available processors (vCPUs)
-    int numProcessors = Runtime.getRuntime().availableProcessors();
+
+    // Configure predownload parallelism
+    int predownloadParallelism = _pinotConfig.getProperty(CommonConstants.Server.CONFIG_OF_PREDOWNLOAD_PARALLELISM,
+        CommonConstants.Server.DEFAULT_PREDOWNLOAD_PARALLELISM);
+
+    if (predownloadParallelism <= 0) {
+      // Use default logic: numProcessors * 3
+      int numProcessors = Runtime.getRuntime().availableProcessors();
+      predownloadParallelism = numProcessors * 3;
+      LOGGER.info("Using default predownload parallelism: {} (numProcessors: {} * 3)", predownloadParallelism,
+          numProcessors);
+    } else {
+      LOGGER.info("Using configured predownload parallelism: {}", predownloadParallelism);
+    }
+
     _failedSegments = ConcurrentHashMap.newKeySet();
-    // TODO: tune the value
-    _executor = Executors.newFixedThreadPool(numProcessors * 3);
-    LOGGER.info("Created thread pool with num of threads: {}", numProcessors * 3);
+    _executor = Executors.newFixedThreadPool(predownloadParallelism);
+    LOGGER.info("Created thread pool with num of threads: {}", predownloadParallelism);
     _numOfSkippedSegments = 0;
     _numOfDownloadSegments = 0;
   }

--- a/pinot-server/src/main/java/org/apache/pinot/server/predownload/PredownloadStatusRecorder.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/predownload/PredownloadStatusRecorder.java
@@ -63,7 +63,7 @@ class ExitHelper {
   }
 }
 
-// Record the status of the pre-download to be consumed by odin-pinot-worker.
+// Record the status of the pre-download to be consumed by start up orchestration worker/service.
 public class PredownloadStatusRecorder {
   private static final Logger LOGGER = LoggerFactory.getLogger(PredownloadStatusRecorder.class);
   private static final long STATUS_RECORD_EXPIRATION_SEC = 3600 * 6; // 6 hours

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -1458,6 +1458,10 @@ public class CommonConstants {
     public static final boolean DEFAULT_ENABLE_THREAD_CPU_TIME_MEASUREMENT = false;
     public static final boolean DEFAULT_THREAD_ALLOCATED_BYTES_MEASUREMENT = false;
 
+    // Predownload related configs
+    public static final String CONFIG_OF_PREDOWNLOAD_PARALLELISM = "pinot.server.predownload.parallelism";
+    public static final int DEFAULT_PREDOWNLOAD_PARALLELISM = -1; // Use numProcessors * 3 as default
+
     public static final String CONFIG_OF_CURRENT_DATA_TABLE_VERSION = "pinot.server.instance.currentDataTableVersion";
 
     // Environment Provider Configs


### PR DESCRIPTION
`Configuration` `release-notes`

Relates to #14686

### Problem
In infrastructures where the underlying host can be shared by multiple technologies. Deepstore downloads in predownload step with high parallelism can lead to IO bandwidth exhaustion for colocated technology containers. Alternatively, hosts with higher bandwidth can allow a higher parallelism compared to the hard-coded value (numProcessors * 3).

This PR adds the capability to set parallelism using a server-level config.

### Changes:
- Define parallelism when pre-downloading segments from deepstore as `pinot.server.predownload.parallelism = 10`
- If any invalid config (<=0) is defined or missing then fallback to existing logic of using `parallellism = numProcessors * 3`
