### PR TITLE
Add system tables support with registry and broker wiring

### DIFF
--- a/pinot-broker/pom.xml
+++ b/pinot-broker/pom.xml
@@ -35,6 +35,10 @@
   <dependencies>
     <dependency>
       <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-java-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-query-runtime</artifactId>
     </dependency>
     <dependency>
@@ -88,6 +92,11 @@
     <dependency>
       <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-yammer</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-system-table</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/SystemTableDataTableResource.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/SystemTableDataTableResource.java
@@ -1,0 +1,84 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.api.resources;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import javax.inject.Inject;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.Context;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+import org.apache.pinot.broker.requesthandler.SystemTableBrokerRequestHandler;
+import org.apache.pinot.common.datatable.DataTable;
+import org.apache.pinot.common.datatable.DataTableImplV4;
+import org.apache.pinot.core.auth.ManualAuthorization;
+import org.apache.pinot.spi.exception.QueryErrorCode;
+import org.apache.pinot.spi.trace.RequestScope;
+import org.apache.pinot.spi.trace.Tracing;
+import org.apache.pinot.spi.utils.JsonUtils;
+
+import static org.apache.pinot.spi.utils.CommonConstants.Broker.Request.SQL;
+
+
+/**
+ * Internal endpoint used for broker-to-broker scatter-gather for system tables.
+ * <p>
+ * Returns a serialized {@link DataTable} payload (application/octet-stream) that represents the local broker's shard
+ * of a system table query.
+ */
+@Path("/")
+public class SystemTableDataTableResource {
+  @Inject
+  private SystemTableBrokerRequestHandler _systemTableBrokerRequestHandler;
+
+  @POST
+  @Produces(MediaType.APPLICATION_OCTET_STREAM)
+  @Path("query/systemTable/datatable")
+  @ManualAuthorization
+  public Response processSystemTableDataTable(String requestBody,
+      @Context org.glassfish.grizzly.http.server.Request requestContext, @Context HttpHeaders httpHeaders) {
+    DataTable dataTable;
+    try {
+      JsonNode requestJson = JsonUtils.stringToJsonNode(requestBody);
+      if (requestJson == null || !requestJson.isObject() || !requestJson.has(SQL)) {
+        dataTable = new DataTableImplV4();
+        dataTable.addException(QueryErrorCode.JSON_PARSING, "Payload is missing the query string field 'sql'");
+      } else {
+        try (RequestScope requestScope = Tracing.getTracer().createRequestScope()) {
+          requestScope.setRequestArrivalTimeMillis(System.currentTimeMillis());
+          dataTable = _systemTableBrokerRequestHandler.handleSystemTableDataTableRequest(requestJson,
+              PinotClientRequest.makeHttpIdentity(requestContext), requestScope, httpHeaders);
+        }
+      }
+    } catch (Exception e) {
+      dataTable = new DataTableImplV4();
+      dataTable.addException(QueryErrorCode.QUERY_EXECUTION, e.getMessage());
+    }
+
+    try {
+      return Response.ok(dataTable.toBytes(), MediaType.APPLICATION_OCTET_STREAM).build();
+    } catch (Exception e) {
+      // As a last resort, return an empty body; the caller will treat this as a failure.
+      return Response.ok(new byte[0], MediaType.APPLICATION_OCTET_STREAM).build();
+    }
+  }
+}

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
@@ -34,6 +34,7 @@ import org.apache.hc.core5.util.Timeout;
 import org.apache.helix.HelixManager;
 import org.apache.pinot.broker.queryquota.QueryQuotaManager;
 import org.apache.pinot.broker.requesthandler.BrokerRequestHandler;
+import org.apache.pinot.broker.requesthandler.SystemTableBrokerRequestHandler;
 import org.apache.pinot.broker.routing.manager.BrokerRoutingManager;
 import org.apache.pinot.common.audit.AuditLogFilter;
 import org.apache.pinot.common.cursors.AbstractResponseStore;
@@ -78,6 +79,7 @@ public class BrokerAdminApiApplication extends ResourceConfig {
   public BrokerAdminApiApplication(BrokerRoutingManager routingManager, BrokerRequestHandler brokerRequestHandler,
       BrokerMetrics brokerMetrics, PinotConfiguration brokerConf, SqlQueryExecutor sqlQueryExecutor,
       ServerRoutingStatsManager serverRoutingStatsManager, AccessControlFactory accessFactory,
+      SystemTableBrokerRequestHandler systemTableBrokerRequestHandler,
       HelixManager helixManager, QueryQuotaManager queryQuotaManager, ThreadAccountant threadAccountant,
       AbstractResponseStore responseStore) {
     _brokerResourcePackages = brokerConf.getProperty(CommonConstants.Broker.BROKER_RESOURCE_PACKAGES,
@@ -108,6 +110,7 @@ public class BrokerAdminApiApplication extends ResourceConfig {
         bind(sqlQueryExecutor).to(SqlQueryExecutor.class);
         bind(routingManager).to(BrokerRoutingManager.class);
         bind(brokerRequestHandler).to(BrokerRequestHandler.class);
+        bind(systemTableBrokerRequestHandler).to(SystemTableBrokerRequestHandler.class);
         bind(brokerMetrics).to(BrokerMetrics.class);
         String loggerRootDir = brokerConf.getProperty(CommonConstants.Broker.CONFIG_OF_LOGGER_ROOT_DIR);
         if (loggerRootDir != null) {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
@@ -55,6 +55,7 @@ import org.apache.pinot.broker.requesthandler.GrpcBrokerRequestHandler;
 import org.apache.pinot.broker.requesthandler.MultiStageBrokerRequestHandler;
 import org.apache.pinot.broker.requesthandler.MultiStageQueryThrottler;
 import org.apache.pinot.broker.requesthandler.SingleConnectionBrokerRequestHandler;
+import org.apache.pinot.broker.requesthandler.SystemTableBrokerRequestHandler;
 import org.apache.pinot.broker.requesthandler.TimeSeriesRequestHandler;
 import org.apache.pinot.broker.routing.manager.BrokerRoutingManager;
 import org.apache.pinot.broker.routing.tablesampler.TableSamplerFactory;
@@ -74,6 +75,7 @@ import org.apache.pinot.common.metrics.BrokerGauge;
 import org.apache.pinot.common.metrics.BrokerMeter;
 import org.apache.pinot.common.metrics.BrokerMetrics;
 import org.apache.pinot.common.metrics.BrokerTimer;
+import org.apache.pinot.common.systemtable.SystemTableRegistry;
 import org.apache.pinot.common.utils.PinotAppConfigs;
 import org.apache.pinot.common.utils.ServiceStartableUtils;
 import org.apache.pinot.common.utils.ServiceStatus;
@@ -157,10 +159,12 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
   protected ZkHelixPropertyStore<ZNRecord> _propertyStore;
   protected HelixDataAccessor _helixDataAccessor;
   protected TableCache _tableCache;
+  protected SystemTableRegistry _systemTableRegistry;
   protected PinotMetricsRegistry _metricsRegistry;
   protected BrokerMetrics _brokerMetrics;
   protected BrokerRoutingManager _routingManager;
   protected AccessControlFactory _accessControlFactory;
+  protected SystemTableBrokerRequestHandler _systemTableBrokerRequestHandler;
   protected BrokerRequestHandler _brokerRequestHandler;
   protected SqlQueryExecutor _sqlQueryExecutor;
   protected BrokerAdminApiApplication _brokerAdminApplication;
@@ -368,6 +372,7 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
     boolean caseInsensitive =
         _brokerConf.getProperty(Helix.ENABLE_CASE_INSENSITIVE_KEY, Helix.DEFAULT_ENABLE_CASE_INSENSITIVE);
     _tableCache = new ZkTableCache(_propertyStore, caseInsensitive);
+    _systemTableRegistry = new SystemTableRegistry(_tableCache, _helixAdmin, _clusterName, _brokerConf);
 
     LOGGER.info("Initializing Broker Event Listener Factory");
     BrokerQueryEventListenerFactory.init(_brokerConf.subset(Broker.EVENT_LISTENER_CONFIG_PREFIX));
@@ -490,9 +495,13 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
     _responseStore.init(responseStoreConfiguration.subset(_responseStore.getType()), _hostname, _port, brokerId,
         _brokerMetrics, expirationTime);
 
+    _systemTableBrokerRequestHandler =
+        new SystemTableBrokerRequestHandler(_brokerConf, brokerId, requestIdGenerator, _routingManager,
+            _accessControlFactory, _queryQuotaManager, _tableCache, _systemTableRegistry, _threadAccountant,
+            multiClusterRoutingContext, _spectatorHelixManager);
     _brokerRequestHandler =
-        new BrokerRequestHandlerDelegate(singleStageBrokerRequestHandler, multiStageBrokerRequestHandler,
-            timeSeriesRequestHandler, _responseStore);
+        new BrokerRequestHandlerDelegate(singleStageBrokerRequestHandler, _systemTableBrokerRequestHandler,
+            multiStageBrokerRequestHandler, timeSeriesRequestHandler, _responseStore);
     _brokerRequestHandler.start();
 
     String controllerUrl = _brokerConf.getProperty(Broker.CONTROLLER_URL);
@@ -807,6 +816,13 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
     } catch (IOException e) {
       LOGGER.error("Caught exception when shutting down PinotFsFactory", e);
     }
+    if (_systemTableRegistry != null) {
+      try {
+        _systemTableRegistry.close();
+      } catch (Exception e) {
+        LOGGER.warn("Failed to close system table registry cleanly", e);
+      }
+    }
 
     LOGGER.info("Disconnecting spectator Helix manager");
     _spectatorHelixManager.disconnect();
@@ -857,7 +873,8 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
   protected BrokerAdminApiApplication createBrokerAdminApp() {
     BrokerAdminApiApplication brokerAdminApiApplication =
         new BrokerAdminApiApplication(_routingManager, _brokerRequestHandler, _brokerMetrics, _brokerConf,
-            _sqlQueryExecutor, _serverRoutingStatsManager, _accessControlFactory, _spectatorHelixManager,
+            _sqlQueryExecutor, _serverRoutingStatsManager, _accessControlFactory, _systemTableBrokerRequestHandler,
+            _spectatorHelixManager,
             _queryQuotaManager, _threadAccountant, _responseStore);
     brokerAdminApiApplication.register(
         new AuditServiceBinder(_clusterConfigChangeHandler, getServiceRole(), _brokerMetrics));

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BrokerRequestHandlerDelegate.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BrokerRequestHandlerDelegate.java
@@ -43,20 +43,21 @@ import org.apache.pinot.tsdb.spi.series.TimeSeriesBlock;
 
 /**
  * {@code BrokerRequestHandlerDelegate} delegates the inbound broker request to one of the enabled
- * {@link BrokerRequestHandler} based on the requested handle type.
- *
- * {@see: @CommonConstant
+ * {@link BrokerRequestHandler} implementations based on the request type.
  */
 public class BrokerRequestHandlerDelegate implements BrokerRequestHandler {
   private final BaseSingleStageBrokerRequestHandler _singleStageBrokerRequestHandler;
+  private final SystemTableBrokerRequestHandler _systemTableBrokerRequestHandler;
   private final MultiStageBrokerRequestHandler _multiStageBrokerRequestHandler;
   private final TimeSeriesRequestHandler _timeSeriesRequestHandler;
   private final AbstractResponseStore _responseStore;
 
   public BrokerRequestHandlerDelegate(BaseSingleStageBrokerRequestHandler singleStageBrokerRequestHandler,
+      SystemTableBrokerRequestHandler systemTableBrokerRequestHandler,
       @Nullable MultiStageBrokerRequestHandler multiStageBrokerRequestHandler,
       @Nullable TimeSeriesRequestHandler timeSeriesRequestHandler, AbstractResponseStore responseStore) {
     _singleStageBrokerRequestHandler = singleStageBrokerRequestHandler;
+    _systemTableBrokerRequestHandler = systemTableBrokerRequestHandler;
     _multiStageBrokerRequestHandler = multiStageBrokerRequestHandler;
     _timeSeriesRequestHandler = timeSeriesRequestHandler;
     _responseStore = responseStore;
@@ -69,6 +70,7 @@ public class BrokerRequestHandlerDelegate implements BrokerRequestHandler {
 
   @Override
   public void start() {
+    _systemTableBrokerRequestHandler.start();
     _singleStageBrokerRequestHandler.start();
     if (_multiStageBrokerRequestHandler != null) {
       _multiStageBrokerRequestHandler.start();
@@ -80,6 +82,7 @@ public class BrokerRequestHandlerDelegate implements BrokerRequestHandler {
 
   @Override
   public void shutDown() {
+    _systemTableBrokerRequestHandler.shutDown();
     _singleStageBrokerRequestHandler.shutDown();
     if (_multiStageBrokerRequestHandler != null) {
       _multiStageBrokerRequestHandler.shutDown();
@@ -111,13 +114,18 @@ public class BrokerRequestHandlerDelegate implements BrokerRequestHandler {
       }
     }
 
-    BaseBrokerRequestHandler requestHandler = _singleStageBrokerRequestHandler;
-    if (QueryOptionsUtils.isUseMultistageEngine(sqlNodeAndOptions.getOptions())) {
+    // System table queries always use the single-stage engine, regardless of the useMultistageEngine option.
+    BaseBrokerRequestHandler requestHandler;
+    if (isSystemTableQuery(sqlNodeAndOptions)) {
+      requestHandler = _systemTableBrokerRequestHandler;
+    } else if (QueryOptionsUtils.isUseMultistageEngine(sqlNodeAndOptions.getOptions())) {
       if (_multiStageBrokerRequestHandler != null) {
         requestHandler = _multiStageBrokerRequestHandler;
       } else {
         return new BrokerResponseNative(QueryErrorCode.INTERNAL, "V2 Multi-Stage query engine not enabled.");
       }
+    } else {
+      requestHandler = _singleStageBrokerRequestHandler;
     }
 
     BrokerResponse response = requestHandler.handleRequest(request, sqlNodeAndOptions, requesterIdentity,
@@ -165,7 +173,7 @@ public class BrokerRequestHandlerDelegate implements BrokerRequestHandler {
       throws Exception {
     if (_multiStageBrokerRequestHandler != null && _multiStageBrokerRequestHandler.cancelQuery(
         queryId, timeoutMs, executor, connMgr, serverResponses)) {
-        return true;
+      return true;
     }
     return _singleStageBrokerRequestHandler.cancelQuery(queryId, timeoutMs, executor, connMgr, serverResponses);
   }
@@ -191,6 +199,11 @@ public class BrokerRequestHandlerDelegate implements BrokerRequestHandler {
       }
     }
     return _singleStageBrokerRequestHandler.getRequestIdByClientId(clientQueryId);
+  }
+
+  private static boolean isSystemTableQuery(@Nullable SqlNodeAndOptions sqlNodeAndOptions) {
+    return sqlNodeAndOptions != null
+        && SystemTableQueryDetector.containsSystemTableReference(sqlNodeAndOptions.getSqlNode());
   }
 
   private CursorResponse getCursorResponse(Integer numRows, BrokerResponse response)

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/SystemTableBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/SystemTableBrokerRequestHandler.java
@@ -1,0 +1,585 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.requesthandler;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.annotations.VisibleForTesting;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.OptionalLong;
+import java.util.Set;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import javax.annotation.Nullable;
+import javax.net.ssl.SSLContext;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MediaType;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.hc.client5.http.io.HttpClientConnectionManager;
+import org.apache.helix.HelixDataAccessor;
+import org.apache.helix.HelixManager;
+import org.apache.helix.model.InstanceConfig;
+import org.apache.pinot.broker.api.AccessControl;
+import org.apache.pinot.broker.broker.AccessControlFactory;
+import org.apache.pinot.broker.querylog.QueryLogger;
+import org.apache.pinot.broker.queryquota.QueryQuotaManager;
+import org.apache.pinot.client.ConnectionTimeouts;
+import org.apache.pinot.client.PinotClientException;
+import org.apache.pinot.client.SystemTableDataTableClient;
+import org.apache.pinot.common.config.provider.TableCache;
+import org.apache.pinot.common.datatable.DataTable;
+import org.apache.pinot.common.datatable.DataTableImplV4;
+import org.apache.pinot.common.metrics.BrokerMeter;
+import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.common.request.PinotQuery;
+import org.apache.pinot.common.request.QuerySource;
+import org.apache.pinot.common.response.BrokerResponse;
+import org.apache.pinot.common.response.broker.BrokerResponseNative;
+import org.apache.pinot.common.systemtable.SystemTableProvider;
+import org.apache.pinot.common.systemtable.SystemTableRegistry;
+import org.apache.pinot.common.utils.NamedThreadFactory;
+import org.apache.pinot.common.utils.config.InstanceUtils;
+import org.apache.pinot.common.utils.config.QueryOptionsUtils;
+import org.apache.pinot.common.utils.request.RequestUtils;
+import org.apache.pinot.core.instance.context.BrokerContext;
+import org.apache.pinot.core.operator.blocks.InstanceResponseBlock;
+import org.apache.pinot.core.plan.Plan;
+import org.apache.pinot.core.plan.maker.InstancePlanMakerImplV2;
+import org.apache.pinot.core.plan.maker.PlanMaker;
+import org.apache.pinot.core.query.reduce.BrokerReduceService;
+import org.apache.pinot.core.query.request.context.QueryContext;
+import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
+import org.apache.pinot.core.routing.MultiClusterRoutingContext;
+import org.apache.pinot.core.routing.RoutingManager;
+import org.apache.pinot.core.transport.ServerRoutingInstance;
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.SegmentContext;
+import org.apache.pinot.spi.accounting.ThreadAccountant;
+import org.apache.pinot.spi.auth.AuthorizationResult;
+import org.apache.pinot.spi.auth.broker.RequesterIdentity;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.exception.BadQueryRequestException;
+import org.apache.pinot.spi.exception.QueryErrorCode;
+import org.apache.pinot.spi.query.QueryExecutionContext;
+import org.apache.pinot.spi.query.QueryThreadContext;
+import org.apache.pinot.spi.trace.RequestContext;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.InstanceTypeUtils;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+import org.apache.pinot.sql.parsers.CalciteSqlParser;
+import org.apache.pinot.sql.parsers.SqlNodeAndOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Broker request handler for system tables (handled entirely on the broker).
+ * <p>
+ * System tables are virtual tables that expose cluster metadata (e.g., system.tables, system.instances).
+ * They are executed using the v1 query engine against in-memory segments generated on-demand by
+ * {@link SystemTableProvider} implementations.
+ */
+public class SystemTableBrokerRequestHandler extends BaseBrokerRequestHandler {
+  private static final Logger LOGGER = LoggerFactory.getLogger(SystemTableBrokerRequestHandler.class);
+  // Sentinel values used for broker-local execution of system table queries where no actual server routing is needed.
+  private static final String SYSTEM_TABLE_PSEUDO_HOST = "localhost";
+  private static final int SYSTEM_TABLE_PSEUDO_PORT = 0;
+  private static final String SYSTEM_TABLE_DATATABLE_API_PATH = "/query/systemTable/datatable";
+  // Hop-by-hop headers per RFC 7230 plus content-length/host which are request-specific.
+  private static final Set<String> HOP_BY_HOP_HEADERS_TO_SKIP = Set.of(
+      "connection",
+      "keep-alive",
+      "proxy-authenticate",
+      "proxy-authorization",
+      "te",
+      "trailer",
+      "transfer-encoding",
+      "upgrade",
+      "host",
+      "content-length");
+
+  private final SystemTableRegistry _systemTableRegistry;
+  private final BrokerReduceService _brokerReduceService;
+  private final PlanMaker _planMaker;
+  private final ExecutorService _executorService;
+  private final ExecutorService _scatterGatherExecutorService;
+  private final SystemTableDataTableClient _systemTableDataTableClient;
+  @Nullable
+  private final HelixManager _helixManager;
+
+  public SystemTableBrokerRequestHandler(PinotConfiguration config, String brokerId,
+      BrokerRequestIdGenerator requestIdGenerator, RoutingManager routingManager,
+      AccessControlFactory accessControlFactory, QueryQuotaManager queryQuotaManager, TableCache tableCache,
+      SystemTableRegistry systemTableRegistry, ThreadAccountant threadAccountant,
+      @Nullable MultiClusterRoutingContext multiClusterRoutingContext, @Nullable HelixManager helixManager) {
+    super(config, brokerId, requestIdGenerator, routingManager, accessControlFactory, queryQuotaManager, tableCache,
+        threadAccountant, multiClusterRoutingContext);
+    _systemTableRegistry = systemTableRegistry;
+    _brokerReduceService = new BrokerReduceService(_config);
+    _planMaker = new InstancePlanMakerImplV2();
+    _planMaker.init(_config);
+    _helixManager = helixManager;
+    int executorPoolSize = config.getProperty(CommonConstants.Broker.CONFIG_OF_SYSTEM_TABLE_EXECUTOR_POOL_SIZE,
+        CommonConstants.Broker.DEFAULT_SYSTEM_TABLE_EXECUTOR_POOL_SIZE);
+    executorPoolSize = Math.max(1, executorPoolSize);
+    _executorService = QueryThreadContext.contextAwareExecutorService(Executors.newFixedThreadPool(executorPoolSize,
+        new NamedThreadFactory("system-table-query-executor")));
+    _scatterGatherExecutorService =
+        QueryThreadContext.contextAwareExecutorService(Executors.newFixedThreadPool(executorPoolSize,
+            new NamedThreadFactory("system-table-scatter-gather-executor")));
+    SSLContext sslContext = BrokerContext.getInstance().getClientHttpsContext();
+    int timeoutMs;
+    if (_brokerTimeoutMs > Integer.MAX_VALUE) {
+      LOGGER.warn("Broker timeout {}ms exceeds Integer.MAX_VALUE; clamping to {} for system table client connections",
+          _brokerTimeoutMs, Integer.MAX_VALUE);
+      timeoutMs = Integer.MAX_VALUE;
+    } else if (_brokerTimeoutMs < 1) {
+      LOGGER.warn("Broker timeout {}ms is non-positive; using default 5000ms for system table client connections",
+          _brokerTimeoutMs);
+      timeoutMs = 5000;
+    } else {
+      timeoutMs = (int) _brokerTimeoutMs;
+    }
+    ConnectionTimeouts connectionTimeouts = ConnectionTimeouts.create(timeoutMs, timeoutMs, timeoutMs);
+    _systemTableDataTableClient =
+        new SystemTableDataTableClient(connectionTimeouts, sslContext);
+  }
+
+  @Override
+  public void start() {
+  }
+
+  @Override
+  public void shutDown() {
+    _executorService.shutdownNow();
+    _scatterGatherExecutorService.shutdownNow();
+    try {
+      _systemTableDataTableClient.close();
+    } catch (Exception e) {
+      LOGGER.debug("Failed to close system table data table client: {}", e.toString());
+    }
+    _brokerReduceService.shutDown();
+  }
+
+  public boolean canHandle(String tableName) {
+    return isSystemTable(tableName) && _systemTableRegistry.isRegistered(tableName);
+  }
+
+  @Override
+  protected BrokerResponse handleRequest(long requestId, String query, SqlNodeAndOptions sqlNodeAndOptions,
+      JsonNode request, @Nullable RequesterIdentity requesterIdentity, RequestContext requestContext,
+      @Nullable HttpHeaders httpHeaders, AccessControl accessControl)
+      throws Exception {
+    long startTimeMs = requestContext.getRequestArrivalTimeMillis();
+    long deadlineMs = startTimeMs + _brokerTimeoutMs;
+    QueryExecutionContext executionContext =
+        new QueryExecutionContext(QueryExecutionContext.QueryType.STE, requestId, Long.toString(requestId),
+            QueryOptionsUtils.getWorkloadName(sqlNodeAndOptions.getOptions()), startTimeMs, deadlineMs, deadlineMs,
+            _brokerId, _brokerId, org.apache.pinot.spi.utils.CommonConstants.Broker.DEFAULT_QUERY_HASH);
+    try (QueryThreadContext ignore = QueryThreadContext.open(executionContext, _threadAccountant)) {
+      PinotQuery pinotQuery;
+      try {
+        pinotQuery = CalciteSqlParser.compileToPinotQuery(sqlNodeAndOptions);
+      } catch (Exception e) {
+        requestContext.setErrorCode(QueryErrorCode.SQL_PARSING);
+        return new BrokerResponseNative(QueryErrorCode.SQL_PARSING, e.getMessage());
+      }
+
+      Set<String> tableNames = RequestUtils.getTableNames(pinotQuery);
+      if (tableNames == null || tableNames.isEmpty()) {
+        requestContext.setErrorCode(QueryErrorCode.QUERY_VALIDATION);
+        return new BrokerResponseNative(QueryErrorCode.QUERY_VALIDATION, "Failed to extract table name");
+      }
+      if (tableNames.size() != 1) {
+        requestContext.setErrorCode(QueryErrorCode.QUERY_VALIDATION);
+        return new BrokerResponseNative(QueryErrorCode.QUERY_VALIDATION, "System tables do not support joins");
+      }
+      String tableName = tableNames.iterator().next();
+      if (!isSystemTable(tableName)) {
+        requestContext.setErrorCode(QueryErrorCode.QUERY_VALIDATION);
+        return new BrokerResponseNative(QueryErrorCode.QUERY_VALIDATION, "Not a system table query");
+      }
+      AuthorizationResult authorizationResult =
+          hasTableAccess(requesterIdentity, Set.of(tableName), requestContext, httpHeaders);
+      if (!authorizationResult.hasAccess()) {
+        requestContext.setErrorCode(QueryErrorCode.ACCESS_DENIED);
+        return new BrokerResponseNative(QueryErrorCode.ACCESS_DENIED, authorizationResult.getFailureMessage());
+      }
+
+      boolean queryWasLogged = _queryLogger.logQueryReceived(requestId, query);
+      return handleSystemTableQuery(request, pinotQuery, tableName, requestContext, requesterIdentity, query,
+          httpHeaders, queryWasLogged);
+    }
+  }
+
+  @Override
+  protected boolean handleCancel(long queryId, int timeoutMs, Executor executor,
+      HttpClientConnectionManager connMgr, Map<String, Integer> serverResponses) {
+    return false;
+  }
+
+  @Override
+  public boolean cancelQueryByClientId(String clientQueryId, int timeoutMs, Executor executor,
+      HttpClientConnectionManager connMgr, Map<String, Integer> serverResponses)
+      throws Exception {
+    return false;
+  }
+
+  @Override
+  public Map<Long, String> getRunningQueries() {
+    return Collections.emptyMap();
+  }
+
+  @Override
+  public OptionalLong getRequestIdByClientId(String clientQueryId) {
+    return OptionalLong.empty();
+  }
+
+  private boolean isSystemTable(String tableName) {
+    return tableName != null && tableName.toLowerCase(Locale.ROOT).startsWith("system.");
+  }
+
+  /**
+   * Executes a system table query against the local broker and returns the raw {@link DataTable} results.
+   * <p>
+   * This method is used by the internal broker-to-broker scatter-gather endpoint and must never perform fanout.
+   * It is invoked when a broker receives a scatter-gather request from another broker for a system table query.
+   *
+   * @param request the JSON request containing the SQL query and options
+   * @param requesterIdentity the identity of the requester for authorization
+   * @param requestContext the request context for tracking
+   * @param httpHeaders the HTTP headers from the request
+   * @return a DataTable containing the query results from this broker's local shard
+   */
+  public DataTable handleSystemTableDataTableRequest(JsonNode request, @Nullable RequesterIdentity requesterIdentity,
+      RequestContext requestContext, @Nullable HttpHeaders httpHeaders) {
+    long startTimeMs = requestContext.getRequestArrivalTimeMillis();
+    if (startTimeMs <= 0) {
+      startTimeMs = System.currentTimeMillis();
+      requestContext.setRequestArrivalTimeMillis(startTimeMs);
+    }
+    long requestId = _requestIdGenerator.get();
+    long deadlineMs = startTimeMs + _brokerTimeoutMs;
+
+    JsonNode sql = request.get(CommonConstants.Broker.Request.SQL);
+    if (sql == null || !sql.isTextual()) {
+      return exceptionDataTable(QueryErrorCode.JSON_PARSING, "Failed to find 'sql' in the request: " + request);
+    }
+    String query = sql.textValue();
+    requestContext.setQuery(query);
+
+    SqlNodeAndOptions sqlNodeAndOptions;
+    try {
+      sqlNodeAndOptions = RequestUtils.parseQuery(query, request);
+    } catch (Exception e) {
+      requestContext.setErrorCode(QueryErrorCode.SQL_PARSING);
+      return exceptionDataTable(QueryErrorCode.SQL_PARSING, e.getMessage());
+    }
+
+    QueryExecutionContext executionContext =
+        new QueryExecutionContext(QueryExecutionContext.QueryType.STE, requestId, Long.toString(requestId),
+            QueryOptionsUtils.getWorkloadName(sqlNodeAndOptions.getOptions()), startTimeMs, deadlineMs, deadlineMs,
+            _brokerId, _brokerId, org.apache.pinot.spi.utils.CommonConstants.Broker.DEFAULT_QUERY_HASH);
+    try (QueryThreadContext ignore = QueryThreadContext.open(executionContext, _threadAccountant)) {
+      AccessControl accessControl = _accessControlFactory.create();
+      AuthorizationResult authorizationResult = accessControl.authorize(requesterIdentity);
+      if (!authorizationResult.hasAccess()) {
+        requestContext.setErrorCode(QueryErrorCode.ACCESS_DENIED);
+        return exceptionDataTable(QueryErrorCode.ACCESS_DENIED, authorizationResult.getFailureMessage());
+      }
+
+      PinotQuery pinotQuery;
+      try {
+        pinotQuery = CalciteSqlParser.compileToPinotQuery(sqlNodeAndOptions);
+      } catch (Exception e) {
+        requestContext.setErrorCode(QueryErrorCode.SQL_PARSING);
+        return exceptionDataTable(QueryErrorCode.SQL_PARSING, e.getMessage());
+      }
+
+      Set<String> tableNames = RequestUtils.getTableNames(pinotQuery);
+      if (tableNames == null || tableNames.isEmpty()) {
+        requestContext.setErrorCode(QueryErrorCode.QUERY_VALIDATION);
+        return exceptionDataTable(QueryErrorCode.QUERY_VALIDATION, "Failed to extract table name");
+      }
+      if (tableNames.size() != 1) {
+        requestContext.setErrorCode(QueryErrorCode.QUERY_VALIDATION);
+        return exceptionDataTable(QueryErrorCode.QUERY_VALIDATION, "System tables do not support joins");
+      }
+      String tableName = tableNames.iterator().next();
+      if (!isSystemTable(tableName)) {
+        requestContext.setErrorCode(QueryErrorCode.QUERY_VALIDATION);
+        return exceptionDataTable(QueryErrorCode.QUERY_VALIDATION, "Not a system table query");
+      }
+
+      AuthorizationResult tableAuthorizationResult =
+          hasTableAccess(requesterIdentity, Set.of(tableName), requestContext, httpHeaders);
+      if (!tableAuthorizationResult.hasAccess()) {
+        requestContext.setErrorCode(QueryErrorCode.ACCESS_DENIED);
+        return exceptionDataTable(QueryErrorCode.ACCESS_DENIED, tableAuthorizationResult.getFailureMessage());
+      }
+
+      SystemTableProvider provider = _systemTableRegistry.get(tableName);
+      if (provider == null) {
+        requestContext.setErrorCode(QueryErrorCode.TABLE_DOES_NOT_EXIST);
+        Collection<SystemTableProvider> availableProviders = _systemTableRegistry.getProviders();
+        String availableTables = availableProviders.isEmpty()
+            ? "No system tables are available"
+            : "Available system tables: "
+                + availableProviders.stream().map(SystemTableProvider::getTableName)
+                    .collect(java.util.stream.Collectors.joining(", "));
+        return exceptionDataTable(QueryErrorCode.TABLE_DOES_NOT_EXIST,
+            "System table does not exist: " + tableName + ". " + availableTables);
+      }
+
+      try {
+        return executeLocalSystemTableQuery(pinotQuery, provider);
+      } catch (BadQueryRequestException e) {
+        requestContext.setErrorCode(QueryErrorCode.QUERY_VALIDATION);
+        _brokerMetrics.addMeteredGlobalValue(BrokerMeter.QUERY_VALIDATION_EXCEPTIONS, 1);
+        return exceptionDataTable(QueryErrorCode.QUERY_VALIDATION, e.getMessage());
+      } catch (Exception e) {
+        LOGGER.warn("Caught exception while handling system table datatable query {}: {}", tableName, e.getMessage(),
+            e);
+        requestContext.setErrorCode(QueryErrorCode.QUERY_EXECUTION);
+        return exceptionDataTable(QueryErrorCode.QUERY_EXECUTION, e.getMessage());
+      }
+    }
+  }
+
+  private BrokerResponse handleSystemTableQuery(JsonNode request, PinotQuery pinotQuery, String tableName,
+      RequestContext requestContext, @Nullable RequesterIdentity requesterIdentity, String query,
+      @Nullable HttpHeaders httpHeaders, boolean queryWasLogged) {
+    if (pinotQuery.isExplain()) {
+      return BrokerResponseNative.BROKER_ONLY_EXPLAIN_PLAN_OUTPUT;
+    }
+    SystemTableProvider provider = _systemTableRegistry.get(tableName);
+    if (provider == null) {
+      requestContext.setErrorCode(QueryErrorCode.TABLE_DOES_NOT_EXIST);
+      Collection<SystemTableProvider> availableProviders = _systemTableRegistry.getProviders();
+      String availableTables = availableProviders.isEmpty()
+          ? "No system tables are available"
+          : "Available system tables: "
+              + availableProviders.stream().map(SystemTableProvider::getTableName)
+                  .collect(java.util.stream.Collectors.joining(", "));
+      return new BrokerResponseNative(QueryErrorCode.TABLE_DOES_NOT_EXIST,
+          "System table does not exist: " + tableName + ". " + availableTables);
+    }
+    try {
+      long deadlineMs = requestContext.getRequestArrivalTimeMillis() + _brokerTimeoutMs;
+      Map<ServerRoutingInstance, DataTable> dataTableMap;
+      if (provider.getExecutionMode() == SystemTableProvider.ExecutionMode.BROKER_SCATTER_GATHER) {
+        dataTableMap =
+            scatterGatherSystemTableDataTables(provider, pinotQuery, tableName, request, httpHeaders, deadlineMs);
+      } else {
+        dataTableMap = new HashMap<>(1);
+        // Use a synthetic routing instance for broker-local execution of system table queries.
+        dataTableMap.put(new ServerRoutingInstance(SYSTEM_TABLE_PSEUDO_HOST, SYSTEM_TABLE_PSEUDO_PORT,
+            TableType.OFFLINE), executeLocalSystemTableQuery(pinotQuery, provider));
+      }
+
+      BrokerResponseNative brokerResponse;
+      BrokerRequest brokerRequest = new BrokerRequest();
+      QuerySource querySource = new QuerySource();
+      querySource.setTableName(tableName);
+      brokerRequest.setQuerySource(querySource);
+      brokerRequest.setPinotQuery(pinotQuery);
+      brokerResponse = _brokerReduceService.reduceOnDataTable(brokerRequest, brokerRequest, dataTableMap,
+          _brokerTimeoutMs, _brokerMetrics);
+      brokerResponse.setTablesQueried(Set.of(TableNameBuilder.extractRawTableName(tableName)));
+      brokerResponse.setTimeUsedMs(System.currentTimeMillis() - requestContext.getRequestArrivalTimeMillis());
+      _queryLogger.logQueryCompleted(
+          new QueryLogger.QueryLogParams(requestContext, tableName, brokerResponse,
+              QueryLogger.QueryLogParams.QueryEngine.SINGLE_STAGE, requesterIdentity, null),
+          queryWasLogged);
+      return brokerResponse;
+    } catch (BadQueryRequestException e) {
+      requestContext.setErrorCode(QueryErrorCode.QUERY_VALIDATION);
+      _brokerMetrics.addMeteredGlobalValue(BrokerMeter.QUERY_VALIDATION_EXCEPTIONS, 1);
+      return new BrokerResponseNative(QueryErrorCode.QUERY_VALIDATION, e.getMessage());
+    } catch (Exception e) {
+      LOGGER.warn("Caught exception while handling system table query {}: {}", tableName, e.getMessage(), e);
+      requestContext.setErrorCode(QueryErrorCode.QUERY_EXECUTION);
+      return new BrokerResponseNative(QueryErrorCode.QUERY_EXECUTION, e.getMessage());
+    }
+  }
+
+  private DataTable executeLocalSystemTableQuery(PinotQuery pinotQuery, SystemTableProvider provider)
+      throws Exception {
+    IndexSegment dataSource = provider.getDataSource();
+    try {
+      QueryContext queryContext = QueryContextConverterUtils.getQueryContext(pinotQuery);
+      queryContext.setSchema(provider.getSchema());
+      queryContext.setEndTimeMs(System.currentTimeMillis() + _brokerTimeoutMs);
+
+      // Pass null for serverMetrics because system table queries run broker-local against an in-memory IndexSegment.
+      Plan plan = _planMaker.makeInstancePlan(List.of(new SegmentContext(dataSource)), queryContext, _executorService,
+          null);
+      InstanceResponseBlock instanceResponse = plan.execute();
+      return instanceResponse.toDataTable();
+    } finally {
+      dataSource.destroy();
+    }
+  }
+
+  private static final class BrokerTarget {
+    final ServerRoutingInstance _routingInstance;
+    final String _dataTableUrl;
+
+    BrokerTarget(ServerRoutingInstance routingInstance, String dataTableUrl) {
+      _routingInstance = routingInstance;
+      _dataTableUrl = dataTableUrl;
+    }
+  }
+
+  @VisibleForTesting
+  protected Map<ServerRoutingInstance, DataTable> scatterGatherSystemTableDataTables(SystemTableProvider provider,
+      PinotQuery pinotQuery, String tableName, JsonNode request, @Nullable HttpHeaders httpHeaders, long deadlineMs) {
+    if (_helixManager == null) {
+      throw new IllegalStateException(
+          "HelixManager is required for scatter-gather execution of system table: " + tableName);
+    }
+
+    HelixDataAccessor dataAccessor = _helixManager.getHelixDataAccessor();
+    List<String> liveInstances = dataAccessor.getChildNames(dataAccessor.keyBuilder().liveInstances());
+    if (liveInstances == null || liveInstances.isEmpty()) {
+      throw new IllegalStateException("No live instances found for scatter-gather execution of system table: "
+          + tableName);
+    }
+
+    String localInstanceId = _brokerId;
+    List<BrokerTarget> remoteTargets = new ArrayList<>();
+    @Nullable ServerRoutingInstance localRoutingInstance = null;
+    for (String instanceId : liveInstances) {
+      if (!InstanceTypeUtils.isBroker(instanceId)) {
+        continue;
+      }
+      InstanceConfig instanceConfig = dataAccessor.getProperty(dataAccessor.keyBuilder().instanceConfig(instanceId));
+      if (instanceConfig == null) {
+        LOGGER.warn("Instance config not found for broker instance: {}. This instance will be skipped in scatter-gather"
+            + " execution for system table: {}", instanceId, tableName);
+        continue;
+      }
+      URI baseUri = URI.create(InstanceUtils.getInstanceBaseUri(instanceConfig));
+      ServerRoutingInstance routingInstance = new ServerRoutingInstance(baseUri.getHost(), baseUri.getPort(),
+          TableType.OFFLINE);
+      if (instanceId.equals(localInstanceId)) {
+        localRoutingInstance = routingInstance;
+      } else {
+        remoteTargets.add(new BrokerTarget(routingInstance, baseUri.toString() + SYSTEM_TABLE_DATATABLE_API_PATH));
+      }
+    }
+
+    Map<ServerRoutingInstance, DataTable> dataTableMap = new HashMap<>(remoteTargets.size() + 1);
+    ServerRoutingInstance routingInstance;
+    if (localRoutingInstance != null) {
+      routingInstance = localRoutingInstance;
+    } else {
+      routingInstance = new ServerRoutingInstance(SYSTEM_TABLE_PSEUDO_HOST, SYSTEM_TABLE_PSEUDO_PORT,
+          TableType.OFFLINE);
+    }
+    try {
+      dataTableMap.put(routingInstance, executeLocalSystemTableQuery(pinotQuery, provider));
+    } catch (Exception e) {
+      LOGGER.error("Failed to execute system table query locally for query: {}", pinotQuery, e);
+      dataTableMap.put(routingInstance,
+          exceptionDataTable(QueryErrorCode.QUERY_EXECUTION, "Failed to execute system table query locally: "
+              + e.getMessage()));
+    }
+
+    if (remoteTargets.isEmpty()) {
+      return dataTableMap;
+    }
+
+    String requestBody = request.toString();
+    @Nullable Map<String, String> requestHeaders = toSingleValueRequestHeaders(httpHeaders);
+    if (requestHeaders == null) {
+      requestHeaders = new HashMap<>();
+    }
+    requestHeaders.putIfAbsent("Content-Type", MediaType.APPLICATION_JSON);
+    Map<String, String> requestHeadersFinal = requestHeaders;
+    List<Pair<BrokerTarget, Future<DataTable>>> futures = new ArrayList<>(remoteTargets.size());
+    for (BrokerTarget target : remoteTargets) {
+      Future<DataTable> future =
+          _scatterGatherExecutorService.submit(() -> fetchDataTableFromBroker(target._dataTableUrl, requestBody,
+              requestHeadersFinal));
+      futures.add(Pair.of(target, future));
+    }
+
+    long remainingMs = Math.max(1, deadlineMs - System.currentTimeMillis());
+    for (Pair<BrokerTarget, Future<DataTable>> pair : futures) {
+      BrokerTarget target = pair.getLeft();
+      try {
+        dataTableMap.put(target._routingInstance, pair.getRight().get(remainingMs, TimeUnit.MILLISECONDS));
+      } catch (TimeoutException e) {
+        pair.getRight().cancel(true);
+        dataTableMap.put(target._routingInstance, exceptionDataTable(QueryErrorCode.BROKER_TIMEOUT,
+            "Timed out waiting for system table response from " + target._dataTableUrl));
+      } catch (Exception e) {
+        dataTableMap.put(target._routingInstance, exceptionDataTable(QueryErrorCode.BROKER_REQUEST_SEND,
+            "Failed to gather system table response from " + target._dataTableUrl + ": " + e.getMessage()));
+      }
+    }
+    return dataTableMap;
+  }
+
+  private DataTable fetchDataTableFromBroker(String url, String requestBody, Map<String, String> requestHeaders) {
+    try {
+      return _systemTableDataTableClient.fetchDataTable(url, requestBody, requestHeaders);
+    } catch (PinotClientException e) {
+      return exceptionDataTable(QueryErrorCode.BROKER_REQUEST_SEND,
+          String.format("Scatter-gather system table request failed for %s: %s", url, e.getMessage()));
+    }
+  }
+
+  private static @Nullable Map<String, String> toSingleValueRequestHeaders(@Nullable HttpHeaders httpHeaders) {
+    if (httpHeaders == null) {
+      return null;
+    }
+    Map<String, String> requestHeaders = new HashMap<>();
+    for (Map.Entry<String, List<String>> entry : httpHeaders.getRequestHeaders().entrySet()) {
+      String headerName = entry.getKey();
+      // Do not forward hop-by-hop headers or content-specific headers that may be invalid for the new request body.
+      // See https://www.rfc-editor.org/rfc/rfc7230#section-6.1
+      String headerNameLower = headerName.toLowerCase(Locale.ROOT);
+      if (HOP_BY_HOP_HEADERS_TO_SKIP.contains(headerNameLower)) {
+        continue;
+      }
+      if (entry.getValue() != null && !entry.getValue().isEmpty()) {
+        requestHeaders.put(headerName, entry.getValue().get(0));
+      }
+    }
+    return requestHeaders;
+  }
+
+  private static DataTable exceptionDataTable(QueryErrorCode errorCode, String message) {
+    DataTable dataTable = new DataTableImplV4();
+    dataTable.addException(errorCode, message);
+    return dataTable;
+  }
+}

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/SystemTableBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/SystemTableBrokerRequestHandler.java
@@ -448,10 +448,10 @@ public class SystemTableBrokerRequestHandler extends BaseBrokerRequestHandler {
   }
 
   private static final class BrokerTarget {
-    final ServerRoutingInstance _routingInstance;
-    final String _dataTableUrl;
+    private final ServerRoutingInstance _routingInstance;
+    private final String _dataTableUrl;
 
-    BrokerTarget(ServerRoutingInstance routingInstance, String dataTableUrl) {
+    private BrokerTarget(ServerRoutingInstance routingInstance, String dataTableUrl) {
       _routingInstance = routingInstance;
       _dataTableUrl = dataTableUrl;
     }
@@ -531,10 +531,10 @@ public class SystemTableBrokerRequestHandler extends BaseBrokerRequestHandler {
       futures.add(Pair.of(target, future));
     }
 
-    long remainingMs = Math.max(1, deadlineMs - System.currentTimeMillis());
     for (Pair<BrokerTarget, Future<DataTable>> pair : futures) {
       BrokerTarget target = pair.getLeft();
       try {
+        long remainingMs = Math.max(1, deadlineMs - System.currentTimeMillis());
         dataTableMap.put(target._routingInstance, pair.getRight().get(remainingMs, TimeUnit.MILLISECONDS));
       } catch (TimeoutException e) {
         pair.getRight().cancel(true);

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/SystemTableQueryDetector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/SystemTableQueryDetector.java
@@ -1,0 +1,153 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.requesthandler;
+
+import javax.annotation.Nullable;
+import org.apache.calcite.sql.SqlBasicCall;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlJoin;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlOrderBy;
+import org.apache.calcite.sql.SqlSelect;
+import org.apache.calcite.sql.SqlWith;
+import org.apache.calcite.sql.SqlWithItem;
+
+/**
+ * Detects whether a parsed SQL query references a system table (e.g. "FROM system.tables").
+ * <p>
+ * This is intentionally implemented using Calcite AST traversal instead of raw string matching so it naturally ignores
+ * strings/comments and is resilient to formatting variations.
+ */
+final class SystemTableQueryDetector {
+  private static final String SYSTEM_DATABASE_NAME = "system";
+
+  private SystemTableQueryDetector() {
+  }
+
+  static boolean containsSystemTableReference(@Nullable SqlNode sqlNode) {
+    return containsSystemTableReferenceInternal(sqlNode);
+  }
+
+  private static boolean containsSystemTableReferenceInternal(@Nullable SqlNode sqlNode) {
+    if (sqlNode == null) {
+      return false;
+    }
+    if (sqlNode instanceof SqlSelect) {
+      return containsSystemTableReferenceInSelect((SqlSelect) sqlNode);
+    }
+    if (sqlNode instanceof SqlOrderBy) {
+      SqlOrderBy orderBy = (SqlOrderBy) sqlNode;
+      return containsSystemTableReferenceInternal(orderBy.query)
+          || containsSystemTableReferenceInternal(orderBy.orderList)
+          || containsSystemTableReferenceInternal(orderBy.offset)
+          || containsSystemTableReferenceInternal(orderBy.fetch);
+    }
+    if (sqlNode instanceof SqlWith) {
+      SqlWith with = (SqlWith) sqlNode;
+      return containsSystemTableReferenceInternal(with.withList) || containsSystemTableReferenceInternal(with.body);
+    }
+    if (sqlNode instanceof SqlWithItem) {
+      SqlWithItem withItem = (SqlWithItem) sqlNode;
+      return containsSystemTableReferenceInternal(withItem.query);
+    }
+    if (sqlNode instanceof SqlNodeList) {
+      SqlNodeList nodeList = (SqlNodeList) sqlNode;
+      for (SqlNode node : nodeList) {
+        if (containsSystemTableReferenceInternal(node)) {
+          return true;
+        }
+      }
+      return false;
+    }
+    if (sqlNode instanceof SqlJoin) {
+      return containsSystemTableReferenceInFrom(sqlNode);
+    }
+    if (sqlNode instanceof SqlCall) {
+      SqlCall call = (SqlCall) sqlNode;
+      for (SqlNode operand : call.getOperandList()) {
+        if (containsSystemTableReferenceInternal(operand)) {
+          return true;
+        }
+      }
+      return false;
+    }
+    return false;
+  }
+
+  private static boolean containsSystemTableReferenceInSelect(SqlSelect select) {
+    if (containsSystemTableReferenceInFrom(select.getFrom())) {
+      return true;
+    }
+    return containsSystemTableReferenceInternal(select.getWhere())
+        || containsSystemTableReferenceInternal(select.getHaving())
+        || containsSystemTableReferenceInternal(select.getGroup())
+        || containsSystemTableReferenceInternal(select.getOrderList())
+        || containsSystemTableReferenceInternal(select.getSelectList());
+  }
+
+  private static boolean containsSystemTableReferenceInFrom(@Nullable SqlNode from) {
+    if (from == null) {
+      return false;
+    }
+    if (from instanceof SqlIdentifier) {
+      return isSystemTableIdentifier((SqlIdentifier) from);
+    }
+    if (from instanceof SqlJoin) {
+      SqlJoin join = (SqlJoin) from;
+      return containsSystemTableReferenceInFrom(join.getLeft())
+          || containsSystemTableReferenceInFrom(join.getRight())
+          || containsSystemTableReferenceInternal(join.getCondition());
+    }
+    if (from instanceof SqlSelect || from instanceof SqlOrderBy || from instanceof SqlWith) {
+      return containsSystemTableReferenceInternal(from);
+    }
+    if (from instanceof SqlBasicCall) {
+      SqlBasicCall call = (SqlBasicCall) from;
+      SqlKind kind = call.getKind();
+      if ((kind == SqlKind.AS || kind == SqlKind.TABLESAMPLE) && !call.getOperandList().isEmpty()) {
+        return containsSystemTableReferenceInFrom(call.getOperandList().get(0));
+      }
+      // E.g. table functions; we only look for subqueries within operands.
+      for (SqlNode operand : call.getOperandList()) {
+        if (containsSystemTableReferenceInternal(operand)) {
+          return true;
+        }
+      }
+      return false;
+    }
+    if (from instanceof SqlCall) {
+      // E.g. other SqlCall implementations that can appear in FROM; only inspect subqueries within operands.
+      SqlCall call = (SqlCall) from;
+      for (SqlNode operand : call.getOperandList()) {
+        if (containsSystemTableReferenceInternal(operand)) {
+          return true;
+        }
+      }
+      return false;
+    }
+    return false;
+  }
+
+  private static boolean isSystemTableIdentifier(SqlIdentifier identifier) {
+    return identifier.names.size() >= 2 && SYSTEM_DATABASE_NAME.equalsIgnoreCase(identifier.names.get(0));
+  }
+}

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/SystemTableBrokerRequestHandlerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/SystemTableBrokerRequestHandlerTest.java
@@ -1,0 +1,363 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.requesthandler;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.IntFunction;
+import javax.annotation.Nullable;
+import javax.ws.rs.core.HttpHeaders;
+import org.apache.helix.HelixManager;
+import org.apache.pinot.broker.broker.AccessControlFactory;
+import org.apache.pinot.broker.broker.AllowAllAccessControlFactory;
+import org.apache.pinot.broker.queryquota.QueryQuotaManager;
+import org.apache.pinot.common.config.provider.TableCache;
+import org.apache.pinot.common.datatable.DataTable;
+import org.apache.pinot.common.metrics.BrokerMetrics;
+import org.apache.pinot.common.request.PinotQuery;
+import org.apache.pinot.common.response.BrokerResponse;
+import org.apache.pinot.common.response.broker.BrokerResponseNative;
+import org.apache.pinot.common.response.broker.ResultTable;
+import org.apache.pinot.common.systemtable.SystemTableProvider;
+import org.apache.pinot.common.systemtable.SystemTableRegistry;
+import org.apache.pinot.common.systemtable.datasource.InMemorySystemTableSegment;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.core.common.datatable.DataTableBuilder;
+import org.apache.pinot.core.common.datatable.DataTableBuilderFactory;
+import org.apache.pinot.core.routing.MultiClusterRoutingContext;
+import org.apache.pinot.core.routing.RoutingManager;
+import org.apache.pinot.core.transport.ServerRoutingInstance;
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.spi.accounting.ThreadAccountant;
+import org.apache.pinot.spi.accounting.ThreadAccountantUtils;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.eventlistener.query.BrokerQueryEventListenerFactory;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+
+public class SystemTableBrokerRequestHandlerTest {
+  private static final AccessControlFactory ACCESS_CONTROL_FACTORY = new AllowAllAccessControlFactory();
+
+  @BeforeClass
+  public void setUp() {
+    BrokerMetrics.register(Mockito.mock(BrokerMetrics.class));
+    BrokerQueryEventListenerFactory.init(new PinotConfiguration());
+  }
+
+  @Test
+  public void testSystemTablesQuery()
+      throws Exception {
+    TableCache tableCache = Mockito.mock(TableCache.class);
+    Mockito.when(tableCache.getColumnNameMap(anyString())).thenReturn(null);
+    Mockito.when(tableCache.getSchema(anyString())).thenReturn(null);
+
+    SystemTableRegistry registry = new SystemTableRegistry(tableCache, null, null, null);
+    registry.register(new FakeTablesProvider());
+
+    SystemTableBrokerRequestHandler handler =
+        new SystemTableBrokerRequestHandler(new PinotConfiguration(), "testBrokerId",
+            new BrokerRequestIdGenerator(), null, ACCESS_CONTROL_FACTORY, null, tableCache, registry,
+            ThreadAccountantUtils.getNoOpAccountant(), null, null);
+
+    BrokerResponse response = handler.handleRequest("SELECT tableName,status FROM system.tables ORDER BY tableName");
+    if (response.getExceptionsSize() > 0) {
+      Assert.fail("Unexpected exceptions: " + response.getExceptions());
+    }
+    ResultTable resultTable = response.getResultTable();
+    assertNotNull(resultTable, response.toString());
+    DataSchema dataSchema = resultTable.getDataSchema();
+    assertEquals(dataSchema.getColumnNames(), new String[]{"tableName", "status"});
+    assertEquals(dataSchema.getColumnDataTypes(), new DataSchema.ColumnDataType[]{
+        DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.STRING});
+    List<Object[]> rows = resultTable.getRows();
+    assertEquals(rows.size(), 2);
+    assertEquals(rows.get(0)[0], "tblA");
+    assertEquals(rows.get(0)[1], "ONLINE");
+    assertEquals(rows.get(1)[0], "tblB");
+    assertEquals(rows.get(1)[1], "OFFLINE");
+  }
+
+  @Test
+  public void testSystemTablesQueryOnAnotherSystemTable()
+      throws Exception {
+    TableCache tableCache = Mockito.mock(TableCache.class);
+    Mockito.when(tableCache.getColumnNameMap(anyString())).thenReturn(null);
+    Mockito.when(tableCache.getSchema(anyString())).thenReturn(null);
+
+    SystemTableRegistry registry = new SystemTableRegistry(tableCache, null, null, null);
+    registry.register(new NativeResponseProvider());
+
+    SystemTableBrokerRequestHandler handler =
+        new SystemTableBrokerRequestHandler(new PinotConfiguration(), "testBrokerId",
+            new BrokerRequestIdGenerator(), null, ACCESS_CONTROL_FACTORY, null, tableCache, registry,
+            ThreadAccountantUtils.getNoOpAccountant(), null, null);
+
+    BrokerResponse response = handler.handleRequest("SELECT tableName,latencyMs FROM system.native_latency");
+    if (response.getExceptionsSize() > 0) {
+      Assert.fail("Unexpected exceptions: " + response.getExceptions());
+    }
+    ResultTable resultTable = response.getResultTable();
+    assertNotNull(resultTable, response.toString());
+    assertEquals(resultTable.getRows().size(), 1);
+    assertEquals(resultTable.getRows().get(0)[0], "tblC");
+    assertEquals(resultTable.getRows().get(0)[1], 123L);
+    assertEquals(((BrokerResponseNative) response).getTablesQueried(), Set.of("system.native_latency"));
+    assertEquals(response.getNumDocsScanned(), 1);
+    assertEquals(response.getTotalDocs(), 1);
+  }
+
+  @Test
+  public void testSystemTablesOffsetLimit()
+      throws Exception {
+    TableCache tableCache = Mockito.mock(TableCache.class);
+    Mockito.when(tableCache.getColumnNameMap(anyString())).thenReturn(null);
+    Mockito.when(tableCache.getSchema(anyString())).thenReturn(null);
+
+    SystemTableRegistry registry = new SystemTableRegistry(tableCache, null, null, null);
+    registry.register(new FakeTablesProvider());
+
+    SystemTableBrokerRequestHandler handler =
+        new SystemTableBrokerRequestHandler(new PinotConfiguration(), "testBrokerId",
+            new BrokerRequestIdGenerator(), null, ACCESS_CONTROL_FACTORY, null, tableCache, registry,
+            ThreadAccountantUtils.getNoOpAccountant(), null, null);
+
+    BrokerResponse response = handler.handleRequest(
+        "SELECT tableName,status FROM system.tables ORDER BY tableName LIMIT 1 OFFSET 1");
+    if (response.getExceptionsSize() > 0) {
+      Assert.fail("Unexpected exceptions: " + response.getExceptions());
+    }
+    ResultTable resultTable = response.getResultTable();
+    assertNotNull(resultTable, response.toString());
+    assertEquals(resultTable.getRows().size(), 1);
+    assertEquals(resultTable.getRows().get(0)[0], "tblB");
+    assertEquals(resultTable.getRows().get(0)[1], "OFFLINE");
+    assertEquals(response.getTotalDocs(), 2);
+  }
+
+  @Test
+  public void testSystemTablesSupportGroupBy()
+      throws Exception {
+    TableCache tableCache = Mockito.mock(TableCache.class);
+    Mockito.when(tableCache.getColumnNameMap(anyString())).thenReturn(null);
+    Mockito.when(tableCache.getSchema(anyString())).thenReturn(null);
+
+    SystemTableRegistry registry = new SystemTableRegistry(tableCache, null, null, null);
+    registry.register(new FakeTablesProvider());
+
+    SystemTableBrokerRequestHandler handler =
+        new SystemTableBrokerRequestHandler(new PinotConfiguration(), "testBrokerId",
+            new BrokerRequestIdGenerator(), null, ACCESS_CONTROL_FACTORY, null, tableCache, registry,
+            ThreadAccountantUtils.getNoOpAccountant(), null, null);
+
+    BrokerResponse response = handler.handleRequest(
+        "SELECT status, COUNT(*) AS cnt FROM system.tables GROUP BY status ORDER BY status");
+    if (response.getExceptionsSize() > 0) {
+      Assert.fail("Unexpected exceptions: " + response.getExceptions());
+    }
+    ResultTable resultTable = response.getResultTable();
+    assertNotNull(resultTable, response.toString());
+    assertEquals(resultTable.getDataSchema().getColumnNames(), new String[]{"status", "cnt"});
+    assertEquals(resultTable.getDataSchema().getColumnDataTypes(), new DataSchema.ColumnDataType[]{
+        DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG});
+    List<Object[]> rows = resultTable.getRows();
+    assertEquals(rows.size(), 2);
+    assertEquals(rows.get(0)[0], "OFFLINE");
+    assertEquals(rows.get(0)[1], 1L);
+    assertEquals(rows.get(1)[0], "ONLINE");
+    assertEquals(rows.get(1)[1], 1L);
+  }
+
+  @Test
+  public void testScatterGatherSystemTableQuery()
+      throws Exception {
+    TableCache tableCache = Mockito.mock(TableCache.class);
+    Mockito.when(tableCache.getColumnNameMap(anyString())).thenReturn(null);
+    Mockito.when(tableCache.getSchema(anyString())).thenReturn(null);
+
+    SystemTableRegistry registry = new SystemTableRegistry(tableCache, null, null, null);
+    registry.register(new ScatterGatherTablesProvider());
+
+    SystemTableBrokerRequestHandler handler =
+        new ScatterGatherTestHandler(new PinotConfiguration(), "testBrokerId", new BrokerRequestIdGenerator(), null,
+            ACCESS_CONTROL_FACTORY, null, tableCache, registry, ThreadAccountantUtils.getNoOpAccountant(), null, null);
+
+    BrokerResponse response =
+        handler.handleRequest("SELECT tableName,status FROM system.sg_tables ORDER BY tableName");
+    if (response.getExceptionsSize() > 0) {
+      Assert.fail("Unexpected exceptions: " + response.getExceptions());
+    }
+    ResultTable resultTable = response.getResultTable();
+    assertNotNull(resultTable, response.toString());
+    List<Object[]> rows = resultTable.getRows();
+    assertEquals(rows.size(), 2);
+    assertEquals(rows.get(0)[0], "tblA");
+    assertEquals(rows.get(0)[1], "ONLINE");
+    assertEquals(rows.get(1)[0], "tblB");
+    assertEquals(rows.get(1)[1], "OFFLINE");
+  }
+
+  private static class FakeTablesProvider implements SystemTableProvider {
+    private final Schema _schema = new Schema.SchemaBuilder().setSchemaName("system.tables")
+        .addSingleValueDimension("tableName", FieldSpec.DataType.STRING)
+        .addSingleValueDimension("status", FieldSpec.DataType.STRING).build();
+
+    @Override
+    public String getTableName() {
+      return "system.tables";
+    }
+
+    @Override
+    public Schema getSchema() {
+      return _schema;
+    }
+
+    @Override
+    public TableConfig getTableConfig() {
+      return new TableConfigBuilder(TableType.OFFLINE).setTableName(getTableName()).build();
+    }
+
+    @Override
+    public IndexSegment getDataSource() {
+      Map<String, IntFunction<Object>> valueProviders = new HashMap<>();
+      valueProviders.put("tableName", docId -> docId == 0 ? "tblA" : "tblB");
+      valueProviders.put("status", docId -> docId == 0 ? "ONLINE" : "OFFLINE");
+      return new InMemorySystemTableSegment(getTableName(), _schema, 2, valueProviders);
+    }
+  }
+
+  private static class NativeResponseProvider implements SystemTableProvider {
+    private final Schema _schema = new Schema.SchemaBuilder().setSchemaName("system.native_latency")
+        .addSingleValueDimension("tableName", FieldSpec.DataType.STRING)
+        .addSingleValueDimension("latencyMs", FieldSpec.DataType.LONG).build();
+
+    @Override
+    public String getTableName() {
+      return "system.native_latency";
+    }
+
+    @Override
+    public Schema getSchema() {
+      return _schema;
+    }
+
+    @Override
+    public TableConfig getTableConfig() {
+      return new TableConfigBuilder(TableType.OFFLINE).setTableName(getTableName()).build();
+    }
+
+    @Override
+    public IndexSegment getDataSource() {
+      Map<String, IntFunction<Object>> valueProviders = new HashMap<>();
+      valueProviders.put("tableName", docId -> "tblC");
+      valueProviders.put("latencyMs", docId -> 123L);
+      return new InMemorySystemTableSegment(getTableName(), _schema, 1, valueProviders);
+    }
+  }
+
+  private static class ScatterGatherTablesProvider implements SystemTableProvider {
+    private final Schema _schema = new Schema.SchemaBuilder().setSchemaName("system.sg_tables")
+        .addSingleValueDimension("tableName", FieldSpec.DataType.STRING)
+        .addSingleValueDimension("status", FieldSpec.DataType.STRING).build();
+
+    @Override
+    public ExecutionMode getExecutionMode() {
+      return ExecutionMode.BROKER_SCATTER_GATHER;
+    }
+
+    @Override
+    public String getTableName() {
+      return "system.sg_tables";
+    }
+
+    @Override
+    public Schema getSchema() {
+      return _schema;
+    }
+
+    @Override
+    public TableConfig getTableConfig() {
+      return new TableConfigBuilder(TableType.OFFLINE).setTableName(getTableName()).build();
+    }
+
+    @Override
+    public IndexSegment getDataSource() {
+      return new InMemorySystemTableSegment(getTableName(), _schema, 0, Map.of());
+    }
+  }
+
+  private static class ScatterGatherTestHandler extends SystemTableBrokerRequestHandler {
+    ScatterGatherTestHandler(PinotConfiguration config, String brokerId, BrokerRequestIdGenerator requestIdGenerator,
+        RoutingManager routingManager, AccessControlFactory accessControlFactory, QueryQuotaManager queryQuotaManager,
+        TableCache tableCache, SystemTableRegistry systemTableRegistry, ThreadAccountant threadAccountant,
+        @Nullable MultiClusterRoutingContext multiClusterRoutingContext, @Nullable HelixManager helixManager) {
+      super(config, brokerId, requestIdGenerator, routingManager, accessControlFactory, queryQuotaManager, tableCache,
+          systemTableRegistry, threadAccountant, multiClusterRoutingContext, helixManager);
+    }
+
+    @Override
+    protected Map<ServerRoutingInstance, DataTable> scatterGatherSystemTableDataTables(SystemTableProvider provider,
+        PinotQuery pinotQuery, String tableName, JsonNode request, @Nullable HttpHeaders httpHeaders,
+        long deadlineMs) {
+      DataSchema dataSchema =
+          new DataSchema(new String[]{"tableName", "status"}, new DataSchema.ColumnDataType[]{
+              DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.STRING});
+      DataTableBuilder builder1 = DataTableBuilderFactory.getDataTableBuilder(dataSchema);
+      builder1.startRow();
+      builder1.setColumn(0, "tblA");
+      builder1.setColumn(1, "ONLINE");
+      try {
+        builder1.finishRow();
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+      DataTable dataTable1 = builder1.build();
+
+      DataTableBuilder builder2 = DataTableBuilderFactory.getDataTableBuilder(dataSchema);
+      builder2.startRow();
+      builder2.setColumn(0, "tblB");
+      builder2.setColumn(1, "OFFLINE");
+      try {
+        builder2.finishRow();
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+      DataTable dataTable2 = builder2.build();
+
+      Map<ServerRoutingInstance, DataTable> dataTableMap = new HashMap<>(2);
+      dataTableMap.put(new ServerRoutingInstance("brokerA", 8000, TableType.OFFLINE), dataTable1);
+      dataTableMap.put(new ServerRoutingInstance("brokerB", 8000, TableType.OFFLINE), dataTable2);
+      return dataTableMap;
+    }
+  }
+}

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/SystemTableQueryDetectorTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/SystemTableQueryDetectorTest.java
@@ -1,0 +1,66 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.requesthandler;
+
+import org.apache.pinot.sql.parsers.CalciteSqlParser;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class SystemTableQueryDetectorTest {
+
+  @Test
+  public void testDoesNotMatchInsideStringLiteral() {
+    assertFalse(containsSystemTableReference("SELECT 'from system.foo' FROM my_table"));
+    assertFalse(containsSystemTableReference("SELECT 'join system.foo' FROM my_table"));
+    assertFalse(containsSystemTableReference("SELECT 'from system.foo and join system.bar' FROM my_table"));
+  }
+
+  @Test
+  public void testDoesNotMatchInsideEscapedStringLiteral() {
+    assertFalse(containsSystemTableReference("SELECT 'from system.''foo''' FROM my_table"));
+  }
+
+  @Test
+  public void testDoesNotMatchInsideComments() {
+    assertFalse(containsSystemTableReference("SELECT 1 FROM my_table -- from system.foo"));
+    assertFalse(containsSystemTableReference("SELECT 1 FROM my_table /* join system.foo */"));
+    assertFalse(containsSystemTableReference("SELECT 1\nFROM my_table\n-- from system.foo\nWHERE col = 1"));
+  }
+
+  @Test
+  public void testMatchesRealSystemTableReferences() {
+    assertTrue(containsSystemTableReference("SELECT * FROM system.tables"));
+    assertTrue(containsSystemTableReference("select * from SYSTEM.tables"));
+    assertTrue(containsSystemTableReference("SELECT * FROM my_table JOIN system.tables"));
+  }
+
+  @Test
+  public void testMatchesNestedSystemTableReferences() {
+    assertTrue(containsSystemTableReference(
+        "SELECT * FROM my_table WHERE col IN (SELECT col FROM system.tables WHERE type = 'OFFLINE')"));
+    assertTrue(containsSystemTableReference("WITH t AS (SELECT * FROM system.tables) SELECT * FROM t"));
+  }
+
+  private static boolean containsSystemTableReference(String sql) {
+    return SystemTableQueryDetector.containsSystemTableReference(CalciteSqlParser.compileToSqlNodeAndOptions(sql)
+        .getSqlNode());
+  }
+}

--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/SystemTableDataTableClient.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/SystemTableDataTableClient.java
@@ -1,0 +1,118 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.client;
+
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
+import javax.net.ssl.SSLContext;
+import org.apache.pinot.client.utils.ConnectionUtils;
+import org.apache.pinot.common.datatable.DataTable;
+import org.apache.pinot.common.datatable.DataTableFactory;
+import org.asynchttpclient.AsyncHttpClient;
+import org.asynchttpclient.BoundRequestBuilder;
+import org.asynchttpclient.DefaultAsyncHttpClientConfig.Builder;
+import org.asynchttpclient.Dsl;
+
+
+/**
+ * Client for fetching system table {@link DataTable} payloads from broker endpoints.
+ */
+public final class SystemTableDataTableClient implements AutoCloseable {
+  private static final String CONTENT_TYPE_JSON = "application/json; charset=utf-8";
+  private static final SslContextProvider SSL_CONTEXT_PROVIDER = SslContextProviderFactory.create();
+
+  private final AsyncHttpClient _httpClient;
+  private final int _requestTimeoutMs;
+  private final Map<String, String> _defaultHeaders;
+
+  public SystemTableDataTableClient(ConnectionTimeouts connectionTimeouts, @Nullable SSLContext sslContext) {
+    this(Map.of(), connectionTimeouts, sslContext, TlsProtocols.defaultProtocols(false), null);
+  }
+
+  public SystemTableDataTableClient(Map<String, String> defaultHeaders, ConnectionTimeouts connectionTimeouts,
+      @Nullable SSLContext sslContext, TlsProtocols tlsProtocols, @Nullable String appId) {
+    _requestTimeoutMs = connectionTimeouts.getReadTimeoutMs();
+    _defaultHeaders = defaultHeaders != null ? new HashMap<>(defaultHeaders) : new HashMap<>();
+    Builder builder = Dsl.config();
+    SSL_CONTEXT_PROVIDER.configure(builder, sslContext, tlsProtocols);
+    builder.setRequestTimeout(Duration.ofMillis(_requestTimeoutMs))
+        .setReadTimeout(Duration.ofMillis(connectionTimeouts.getReadTimeoutMs()))
+        .setConnectTimeout(Duration.ofMillis(connectionTimeouts.getConnectTimeoutMs()))
+        .setHandshakeTimeout(connectionTimeouts.getHandshakeTimeoutMs())
+        .setUserAgent(ConnectionUtils.getUserAgentVersionFromClassPath("ua", appId));
+    _httpClient = Dsl.asyncHttpClient(builder.build());
+  }
+
+  public DataTable fetchDataTable(String url, String requestBody, @Nullable Map<String, String> headers)
+      throws PinotClientException {
+    try {
+      return fetchDataTableAsync(url, requestBody, headers).get(_requestTimeoutMs, TimeUnit.MILLISECONDS);
+    } catch (Exception e) {
+      throw new PinotClientException(e);
+    }
+  }
+
+  public CompletableFuture<DataTable> fetchDataTableAsync(String url, String requestBody,
+      @Nullable Map<String, String> headers) {
+    try {
+      BoundRequestBuilder requestBuilder = _httpClient.preparePost(url);
+      Map<String, String> mergedHeaders = new HashMap<>(_defaultHeaders);
+      if (headers != null && !headers.isEmpty()) {
+        mergedHeaders.putAll(headers);
+      }
+      mergedHeaders.putIfAbsent("Content-Type", CONTENT_TYPE_JSON);
+      mergedHeaders.forEach(requestBuilder::addHeader);
+      return requestBuilder.setBody(requestBody).execute().toCompletableFuture().thenApply(response -> {
+        int status = response.getStatusCode();
+        if (status != 200) {
+          throw new PinotClientException("HTTP status " + status + ": " + response.getResponseBody());
+        }
+        byte[] payload = response.getResponseBodyAsBytes();
+        if (payload == null || payload.length == 0) {
+          throw new PinotClientException("Empty response body");
+        }
+        try {
+          return DataTableFactory.getDataTable(payload);
+        } catch (Exception e) {
+          throw new CompletionException(e);
+        }
+      });
+    } catch (Exception e) {
+      return CompletableFuture.failedFuture(new PinotClientException(e));
+    }
+  }
+
+  @Override
+  public void close()
+      throws PinotClientException {
+    if (_httpClient.isClosed()) {
+      return;
+    }
+    try {
+      _httpClient.close();
+    } catch (Exception e) {
+      throw new PinotClientException("Error while closing connection!", e);
+    }
+  }
+}

--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/admin/PinotAdminClient.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/admin/PinotAdminClient.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.client.admin;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import java.io.IOException;
 import java.util.Map;
 import java.util.Properties;
@@ -195,6 +196,20 @@ public class PinotAdminClient implements AutoCloseable {
       _taskClient = new PinotTaskAdminClient(_transport, _controllerAddress, _headers);
     }
     return _taskClient;
+  }
+
+  /**
+   * Fetches the table size details.
+   *
+   * @param tableName Table name (raw or with type)
+   * @param verbose Whether to include per-segment details
+   * @param includeReplacedSegments Whether to include replaced segments
+   * @return Table size response as JsonNode
+   * @throws PinotAdminException If the request fails
+   */
+  public JsonNode getTableSize(String tableName, boolean verbose, boolean includeReplacedSegments)
+      throws PinotAdminException {
+    return getTableClient().getTableSize(tableName, verbose, includeReplacedSegments);
   }
 
   @Override

--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/admin/PinotAdminPathUtils.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/admin/PinotAdminPathUtils.java
@@ -1,0 +1,37 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.client.admin;
+
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+
+
+/**
+ * Utility for encoding admin client URL path segments. Stateless and thread-safe.
+ */
+final class PinotAdminPathUtils {
+  private PinotAdminPathUtils() {
+  }
+
+  static String encodePathSegment(String pathSegment) {
+    // URLEncoder applies application/x-www-form-urlencoded rules, where spaces become '+'. For URL path segments
+    // spaces must be percent-encoded, so replace '+' with "%20".
+    return URLEncoder.encode(pathSegment, StandardCharsets.UTF_8).replace("+", "%20");
+  }
+}

--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/admin/PinotAdminTransport.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/admin/PinotAdminTransport.java
@@ -49,8 +49,18 @@ import org.slf4j.LoggerFactory;
 public class PinotAdminTransport implements AutoCloseable {
   private static final Logger LOGGER = LoggerFactory.getLogger(PinotAdminTransport.class);
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-  public static final String ADMIN_TRANSPORT_REQUEST_TIMEOUT_MS = "pinot.admin.request.timeout.ms";
-  public static final String ADMIN_TRANSPORT_SCHEME = "pinot.admin.scheme";
+  public static final String PINOT_ADMIN_REQUEST_TIMEOUT_MS_PROPERTY_KEY = "pinot.admin.request.timeout.ms";
+  public static final String PINOT_ADMIN_SCHEME_PROPERTY_KEY = "pinot.admin.scheme";
+  /**
+   * @deprecated Use {@link #PINOT_ADMIN_REQUEST_TIMEOUT_MS_PROPERTY_KEY} instead.
+   */
+  @Deprecated
+  public static final String ADMIN_TRANSPORT_REQUEST_TIMEOUT_MS = PINOT_ADMIN_REQUEST_TIMEOUT_MS_PROPERTY_KEY;
+  /**
+   * @deprecated Use {@link #PINOT_ADMIN_SCHEME_PROPERTY_KEY} instead.
+   */
+  @Deprecated
+  public static final String ADMIN_TRANSPORT_SCHEME = PINOT_ADMIN_SCHEME_PROPERTY_KEY;
 
   /**
    * Gets the ObjectMapper instance for JSON serialization/deserialization.
@@ -70,10 +80,10 @@ public class PinotAdminTransport implements AutoCloseable {
     _defaultHeaders = authHeaders != null ? authHeaders : Map.of();
 
     // Extract timeout configuration
-    _requestTimeoutMs = Integer.parseInt(properties.getProperty(ADMIN_TRANSPORT_REQUEST_TIMEOUT_MS, "60000"));
+    _requestTimeoutMs = Integer.parseInt(properties.getProperty(PINOT_ADMIN_REQUEST_TIMEOUT_MS_PROPERTY_KEY, "60000"));
 
     // Extract scheme (http/https)
-    String scheme = properties.getProperty(ADMIN_TRANSPORT_SCHEME, CommonConstants.HTTP_PROTOCOL);
+    String scheme = properties.getProperty(PINOT_ADMIN_SCHEME_PROPERTY_KEY, CommonConstants.HTTP_PROTOCOL);
     _scheme = scheme;
 
     // Build HTTP client

--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/admin/PinotSegmentAdminClient.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/admin/PinotSegmentAdminClient.java
@@ -55,7 +55,9 @@ public class PinotSegmentAdminClient {
       throws PinotAdminException {
     Map<String, String> queryParams = Map.of("excludeReplacedSegments", String.valueOf(excludeReplacedSegments));
 
-    JsonNode response = _transport.executeGet(_controllerAddress, "/segments/" + tableName, queryParams, _headers);
+    JsonNode response =
+        _transport.executeGet(_controllerAddress,
+            "/segments/" + PinotAdminPathUtils.encodePathSegment(tableName), queryParams, _headers);
     return _transport.parseStringArray(response, "segments");
   }
 
@@ -81,7 +83,8 @@ public class PinotSegmentAdminClient {
   public String getServerToSegmentsMap(String tableName)
       throws PinotAdminException {
     JsonNode response =
-        _transport.executeGet(_controllerAddress, "/segments/" + tableName + "/servers", null, _headers);
+        _transport.executeGet(_controllerAddress,
+            "/segments/" + PinotAdminPathUtils.encodePathSegment(tableName) + "/servers", null, _headers);
     return response.toString();
   }
 
@@ -95,7 +98,8 @@ public class PinotSegmentAdminClient {
   public String listSegmentLineage(String tableName)
       throws PinotAdminException {
     JsonNode response =
-        _transport.executeGet(_controllerAddress, "/segments/" + tableName + "/lineage", null, _headers);
+        _transport.executeGet(_controllerAddress,
+            "/segments/" + PinotAdminPathUtils.encodePathSegment(tableName) + "/lineage", null, _headers);
     return response.toString();
   }
 
@@ -108,7 +112,9 @@ public class PinotSegmentAdminClient {
    */
   public Map<String, String> getSegmentToCrcMap(String tableName)
       throws PinotAdminException {
-    JsonNode response = _transport.executeGet(_controllerAddress, "/segments/" + tableName + "/crc", null, _headers);
+    JsonNode response =
+        _transport.executeGet(_controllerAddress,
+            "/segments/" + PinotAdminPathUtils.encodePathSegment(tableName) + "/crc", null, _headers);
     return PinotAdminTransport.getObjectMapper().convertValue(response.get("segmentCrcMap"),
         new TypeReference<Map<String, String>>() {
         });
@@ -132,7 +138,9 @@ public class PinotSegmentAdminClient {
     }
 
     JsonNode response =
-        _transport.executeGet(_controllerAddress, "/segments/" + tableName + "/" + segmentName + "/metadata",
+        _transport.executeGet(_controllerAddress,
+            "/segments/" + PinotAdminPathUtils.encodePathSegment(tableName) + "/"
+                + PinotAdminPathUtils.encodePathSegment(segmentName) + "/metadata",
             queryParams, _headers);
     return PinotAdminTransport.getObjectMapper().convertValue(response,
         new TypeReference<Map<String, Object>>() {
@@ -156,7 +164,9 @@ public class PinotSegmentAdminClient {
     }
 
     JsonNode response =
-        _transport.executePost(_controllerAddress, "/segments/" + tableNameWithType + "/" + segmentName + "/reset",
+        _transport.executePost(_controllerAddress,
+            "/segments/" + PinotAdminPathUtils.encodePathSegment(tableNameWithType) + "/"
+                + PinotAdminPathUtils.encodePathSegment(segmentName) + "/reset",
             null, queryParams, _headers);
     return response.toString();
   }
@@ -173,8 +183,10 @@ public class PinotSegmentAdminClient {
       throws PinotAdminException {
     Map<String, String> queryParams = Map.of("errorSegmentsOnly", String.valueOf(errorSegmentsOnly));
 
-    JsonNode response = _transport.executePost(_controllerAddress, "/segments/" + tableNameWithType + "/reset",
-        null, queryParams, _headers);
+    JsonNode response =
+        _transport.executePost(_controllerAddress,
+            "/segments/" + PinotAdminPathUtils.encodePathSegment(tableNameWithType) + "/reset",
+            null, queryParams, _headers);
     return response.toString();
   }
 
@@ -194,7 +206,9 @@ public class PinotSegmentAdminClient {
       queryParams.put("retention", retentionPeriod);
     }
 
-    JsonNode response = _transport.executeDelete(_controllerAddress, "/segments/" + tableName + "/" + segmentName,
+    JsonNode response = _transport.executeDelete(_controllerAddress,
+        "/segments/" + PinotAdminPathUtils.encodePathSegment(tableName) + "/"
+            + PinotAdminPathUtils.encodePathSegment(segmentName),
         queryParams, _headers);
     return response.toString();
   }
@@ -219,8 +233,8 @@ public class PinotSegmentAdminClient {
       queryParams.put("retention", retentionPeriod);
     }
 
-    JsonNode response = _transport.executeDelete(_controllerAddress, "/segments/" + tableName,
-        queryParams, _headers);
+    JsonNode response = _transport.executeDelete(_controllerAddress,
+        "/segments/" + PinotAdminPathUtils.encodePathSegment(tableName), queryParams, _headers);
     return response.toString();
   }
 
@@ -234,7 +248,8 @@ public class PinotSegmentAdminClient {
    */
   public String deleteSegments(String tableName, String segmentDeleteRequest)
       throws PinotAdminException {
-    JsonNode response = _transport.executePost(_controllerAddress, "/segments/" + tableName + "/delete",
+    JsonNode response = _transport.executePost(_controllerAddress,
+        "/segments/" + PinotAdminPathUtils.encodePathSegment(tableName) + "/delete",
         segmentDeleteRequest, null, _headers);
     return response.toString();
   }

--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/admin/PinotSegmentApiClient.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/admin/PinotSegmentApiClient.java
@@ -59,13 +59,15 @@ public class PinotSegmentApiClient implements Closeable {
     queryParams.put(QueryParameters.END_TIMESTAMP, String.valueOf(endTimestamp));
     queryParams.put(QueryParameters.EXCLUDE_OVERLAPPING, String.valueOf(excludeOverlapping));
     queryParams.put(QueryParameters.TYPE, tableType);
-    return _transport.executeGet(_controllerAddress, SEGMENT_PATH + "/" + rawTableName + SELECT_PATH,
-        queryParams, _headers);
+    return _transport.executeGet(_controllerAddress,
+        SEGMENT_PATH + "/" + PinotAdminPathUtils.encodePathSegment(rawTableName) + SELECT_PATH, queryParams, _headers);
   }
 
   public JsonNode getSegmentMetadata(String tableNameWithType, String segmentName) throws PinotAdminException {
     return _transport.executeGet(_controllerAddress,
-        SEGMENT_PATH + "/" + tableNameWithType + "/" + segmentName + METADATA_PATH, null, _headers);
+        SEGMENT_PATH + "/" + PinotAdminPathUtils.encodePathSegment(tableNameWithType) + "/"
+            + PinotAdminPathUtils.encodePathSegment(segmentName) + METADATA_PATH,
+        null, _headers);
   }
 
   @Override

--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/admin/PinotTableAdminClient.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/admin/PinotTableAdminClient.java
@@ -186,6 +186,23 @@ public class PinotTableAdminClient {
   }
 
   /**
+   * Fetches the table size details.
+   *
+   * @param tableName Table name (raw or with type)
+   * @param verbose Whether to include per-segment details
+   * @param includeReplacedSegments Whether to include replaced segments
+   * @return Table size response as JsonNode
+   * @throws PinotAdminException If the request fails
+   */
+  public JsonNode getTableSize(String tableName, boolean verbose, boolean includeReplacedSegments)
+      throws PinotAdminException {
+    Map<String, String> queryParams = new HashMap<>();
+    queryParams.put("verbose", String.valueOf(verbose));
+    queryParams.put("includeReplacedSegments", String.valueOf(includeReplacedSegments));
+    return _transport.executeGet(_controllerAddress, "/tables/" + tableName + "/size", queryParams, _headers);
+  }
+
+  /**
    * Gets the current state of a table.
    *
    * @param tableName Name of the table

--- a/pinot-common/src/main/java/org/apache/pinot/common/systemtable/SystemTable.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/systemtable/SystemTable.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.systemtable;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+
+/**
+ * Marker for system table providers that should be auto-registered.
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+public @interface SystemTable {
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/systemtable/SystemTableProvider.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/systemtable/SystemTableProvider.java
@@ -1,0 +1,107 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.systemtable;
+
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.data.Schema;
+
+
+/**
+ * SPI for system table providers. Implementations live with the broker path and describe virtual tables
+ * (name, schema, config) and provide an {@link IndexSegment} for query execution.
+ * <p>
+ * Security note: system tables are intentionally not protected by database-scoped access controls (e.g. database header
+ * validation is bypassed for {@code system.*} tables). Access is still governed by the configured broker
+ * {@link org.apache.pinot.spi.security.AccessControl} implementation, so providers must ensure they do not expose
+ * sensitive information to unauthorized users.
+ */
+public interface SystemTableProvider extends AutoCloseable {
+  /**
+   * How the broker should execute queries for this system table.
+   */
+  enum ExecutionMode {
+    /**
+     * Execute the query on the broker that received it.
+     */
+    BROKER_LOCAL,
+    /**
+     * Scatter-gather the query across all live brokers and merge results on the receiving broker.
+     * <p>
+     * Use this mode for system tables where each broker owns a shard of local-only data (e.g. query logs).
+     */
+    BROKER_SCATTER_GATHER
+  }
+
+  /**
+   * Returns the {@link ExecutionMode} for this system table.
+   * <p>
+   * The default is {@link ExecutionMode#BROKER_LOCAL} to preserve the current behavior.
+   */
+  default ExecutionMode getExecutionMode() {
+    return ExecutionMode.BROKER_LOCAL;
+  }
+
+  /**
+   * Initializes the provider with broker-supplied dependencies.
+   * <p>
+   * Called once by the {@link SystemTableRegistry} after construction and before any queries are served.
+   * Providers should extract whatever they need from the context and store it. The default implementation
+   * is a no-op so that simple providers (e.g. those that need no external dependencies) can skip it.
+   */
+  default void init(SystemTableProviderContext context) {
+  }
+
+  /**
+   * Logical name, e.g. "system.tables".
+   */
+  String getTableName();
+
+  /**
+   * Schema for the virtual table.
+   */
+  Schema getSchema();
+
+  /**
+   * Lightweight virtual table config.
+   */
+  TableConfig getTableConfig();
+
+  /**
+   * Returns an {@link IndexSegment} representing the system table contents.
+   * <p>
+   * The returned segment is used for query execution on the broker. Implementations may return a new segment for each
+   * call (recommended) or a cached segment. Callers should invoke {@link IndexSegment#destroy()} when done with the
+   * returned segment.
+   * <p>
+   * For {@link ExecutionMode#BROKER_SCATTER_GATHER} tables, the returned segment should represent only the local
+   * broker's shard of the data; the receiving broker will scatter-gather the query across all live brokers and merge
+   * the results.
+   */
+  IndexSegment getDataSource()
+      throws Exception;
+
+  /**
+   * Shutdown hook.
+   */
+  @Override
+  default void close()
+      throws Exception {
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/systemtable/SystemTableProviderContext.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/systemtable/SystemTableProviderContext.java
@@ -1,0 +1,71 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.systemtable;
+
+import javax.annotation.Nullable;
+import org.apache.helix.HelixAdmin;
+import org.apache.pinot.common.config.provider.TableCache;
+import org.apache.pinot.spi.env.PinotConfiguration;
+
+
+/**
+ * Context object passed to {@link SystemTableProvider#init(SystemTableProviderContext)} during registration.
+ * <p>
+ * Bundles all broker-provided dependencies so that providers can pick what they need without requiring specific
+ * constructor signatures. This makes the SPI forward-compatible: new dependencies can be added here without
+ * breaking existing providers.
+ */
+public final class SystemTableProviderContext {
+  @Nullable
+  private final TableCache _tableCache;
+  @Nullable
+  private final HelixAdmin _helixAdmin;
+  @Nullable
+  private final String _clusterName;
+  @Nullable
+  private final PinotConfiguration _config;
+
+  public SystemTableProviderContext(@Nullable TableCache tableCache, @Nullable HelixAdmin helixAdmin,
+      @Nullable String clusterName, @Nullable PinotConfiguration config) {
+    _tableCache = tableCache;
+    _helixAdmin = helixAdmin;
+    _clusterName = clusterName;
+    _config = config;
+  }
+
+  @Nullable
+  public TableCache getTableCache() {
+    return _tableCache;
+  }
+
+  @Nullable
+  public HelixAdmin getHelixAdmin() {
+    return _helixAdmin;
+  }
+
+  @Nullable
+  public String getClusterName() {
+    return _clusterName;
+  }
+
+  @Nullable
+  public PinotConfiguration getConfig() {
+    return _config;
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/systemtable/SystemTableRegistry.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/systemtable/SystemTableRegistry.java
@@ -1,0 +1,201 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.systemtable;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.IdentityHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.apache.helix.HelixAdmin;
+import org.apache.pinot.common.config.provider.TableCache;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.utils.PinotReflectionUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Registry to hold and lifecycle-manage system table data providers.
+ * <p>
+ * This class is thread-safe and manages the lifecycle of registered providers.
+ */
+public final class SystemTableRegistry implements AutoCloseable {
+  private static final Logger LOGGER = LoggerFactory.getLogger(SystemTableRegistry.class);
+  private static final String SYSTEM_TABLE_PREFIX = "system.";
+
+  // Providers are registered once at broker startup.
+  private final Map<String, SystemTableProvider> _providers = new HashMap<>();
+  private final SystemTableProviderContext _context;
+  private volatile boolean _closed = false;
+
+  /**
+   * Creates a new SystemTableRegistry and initializes it with annotated providers.
+   */
+  public SystemTableRegistry(TableCache tableCache, HelixAdmin helixAdmin, String clusterName,
+      @Nullable PinotConfiguration config) {
+    _context = new SystemTableProviderContext(tableCache, helixAdmin, clusterName, config);
+    registerAnnotatedProviders();
+  }
+
+  /**
+   * Registers a system table provider.
+   * <p>
+   * Note: This method does NOT call {@link SystemTableProvider#init(SystemTableProviderContext)} on the provider.
+   * It is intended for registering providers that have already been initialized (e.g. in tests).
+   *
+   * @throws IllegalArgumentException if the table name does not start with "system."
+   */
+  public void register(SystemTableProvider provider) {
+    String tableName = provider.getTableName();
+    if (!tableName.toLowerCase(Locale.ROOT).startsWith(SYSTEM_TABLE_PREFIX)) {
+      throw new IllegalArgumentException(
+          "System table name must start with '" + SYSTEM_TABLE_PREFIX + "', got: " + tableName);
+    }
+    synchronized (_providers) {
+      if (_closed) {
+        throw new IllegalStateException("Cannot register provider after registry is closed");
+      }
+      _providers.put(normalize(tableName), provider);
+    }
+  }
+
+  /**
+   * Retrieves a registered system table provider by table name.
+   *
+   * @return the provider, or null if not found or registry is closed
+   */
+  @Nullable
+  public SystemTableProvider get(String tableName) {
+    synchronized (_providers) {
+      if (_closed) {
+        return null;
+      }
+      return _providers.get(normalize(tableName));
+    }
+  }
+
+  /**
+   * Checks if a system table is registered.
+   */
+  public boolean isRegistered(String tableName) {
+    synchronized (_providers) {
+      if (_closed) {
+        return false;
+      }
+      return _providers.containsKey(normalize(tableName));
+    }
+  }
+
+  /**
+   * Returns all registered providers.
+   */
+  public Collection<SystemTableProvider> getProviders() {
+    synchronized (_providers) {
+      if (_closed) {
+        return Collections.emptyList();
+      }
+      return Collections.unmodifiableCollection(new java.util.ArrayList<>(_providers.values()));
+    }
+  }
+
+  /**
+   * Discover and register providers marked with {@link SystemTable} using the available dependencies.
+   * <p>
+   * Follows the ScalarFunction pattern: any class annotated with @SystemTable under a "*.systemtable.*" package
+   * will be discovered via reflection, instantiated with a no-arg constructor, initialized via
+   * {@link SystemTableProvider#init(SystemTableProviderContext)}, and registered.
+   */
+  private void registerAnnotatedProviders() {
+    Set<Class<?>> classes =
+        PinotReflectionUtils.getClassesThroughReflection(".*\\.systemtable\\..*", SystemTable.class);
+    for (Class<?> clazz : classes) {
+      if (!SystemTableProvider.class.isAssignableFrom(clazz)) {
+        continue;
+      }
+      SystemTableProvider provider = instantiateProvider(clazz.asSubclass(SystemTableProvider.class));
+      if (provider == null) {
+        continue;
+      }
+      if (isRegistered(provider.getTableName())) {
+        continue;
+      }
+      LOGGER.info("Registering system table provider: {}", provider.getTableName());
+      register(provider);
+    }
+  }
+
+  /**
+   * Closes the registry and all registered providers.
+   * After calling this method, the registry will not accept new registrations
+   * and will return null for all lookups.
+   */
+  @Override
+  public void close()
+      throws Exception {
+    Exception firstException = null;
+    // Snapshot providers to avoid concurrent modifications and to close each provider at most once.
+    Set<SystemTableProvider> providersToClose = Collections.newSetFromMap(new IdentityHashMap<>());
+    synchronized (_providers) {
+      _closed = true;
+      for (SystemTableProvider provider : _providers.values()) {
+        providersToClose.add(provider);
+      }
+    }
+    try {
+      for (SystemTableProvider provider : providersToClose) {
+        try {
+          provider.close();
+        } catch (Exception e) {
+          if (firstException == null) {
+            firstException = e;
+          } else {
+            firstException.addSuppressed(e);
+          }
+        }
+      }
+    } finally {
+      synchronized (_providers) {
+        _providers.clear();
+      }
+    }
+    if (firstException != null) {
+      throw firstException;
+    }
+  }
+
+  private String normalize(String tableName) {
+    return tableName.toLowerCase(Locale.ROOT);
+  }
+
+  @Nullable
+  private SystemTableProvider instantiateProvider(Class<? extends SystemTableProvider> clazz) {
+    try {
+      SystemTableProvider provider = clazz.getConstructor().newInstance();
+      provider.init(_context);
+      return provider;
+    } catch (Exception e) {
+      LOGGER.warn("Failed to instantiate system table provider {}: {}", clazz.getName(), e.toString());
+      return null;
+    }
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/systemtable/SystemTableRegistry.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/systemtable/SystemTableRegistry.java
@@ -71,11 +71,19 @@ public final class SystemTableRegistry implements AutoCloseable {
       throw new IllegalArgumentException(
           "System table name must start with '" + SYSTEM_TABLE_PREFIX + "', got: " + tableName);
     }
+    SystemTableProvider displaced;
     synchronized (_providers) {
       if (_closed) {
         throw new IllegalStateException("Cannot register provider after registry is closed");
       }
-      _providers.put(normalize(tableName), provider);
+      displaced = _providers.put(normalize(tableName), provider);
+    }
+    if (displaced != null && displaced != provider) {
+      try {
+        displaced.close();
+      } catch (Exception e) {
+        LOGGER.warn("Failed to close displaced provider for {}: {}", tableName, e.toString());
+      }
     }
   }
 
@@ -132,11 +140,21 @@ public final class SystemTableRegistry implements AutoCloseable {
       if (!SystemTableProvider.class.isAssignableFrom(clazz)) {
         continue;
       }
-      SystemTableProvider provider = instantiateProvider(clazz.asSubclass(SystemTableProvider.class));
-      if (provider == null) {
+      Class<? extends SystemTableProvider> providerClass = clazz.asSubclass(SystemTableProvider.class);
+      SystemTableProvider provider;
+      try {
+        provider = providerClass.getConstructor().newInstance();
+      } catch (Exception e) {
+        LOGGER.warn("Failed to instantiate system table provider {}: {}", providerClass.getName(), e.toString());
         continue;
       }
       if (isRegistered(provider.getTableName())) {
+        continue;
+      }
+      try {
+        provider.init(_context);
+      } catch (Exception e) {
+        LOGGER.warn("Failed to initialize system table provider {}: {}", providerClass.getName(), e.toString());
         continue;
       }
       LOGGER.info("Registering system table provider: {}", provider.getTableName());
@@ -185,17 +203,5 @@ public final class SystemTableRegistry implements AutoCloseable {
 
   private String normalize(String tableName) {
     return tableName.toLowerCase(Locale.ROOT);
-  }
-
-  @Nullable
-  private SystemTableProvider instantiateProvider(Class<? extends SystemTableProvider> clazz) {
-    try {
-      SystemTableProvider provider = clazz.getConstructor().newInstance();
-      provider.init(_context);
-      return provider;
-    } catch (Exception e) {
-      LOGGER.warn("Failed to instantiate system table provider {}: {}", clazz.getName(), e.toString());
-      return null;
-    }
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/systemtable/datasource/InMemorySystemTableSegment.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/systemtable/datasource/InMemorySystemTableSegment.java
@@ -1,0 +1,734 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.systemtable.datasource;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import java.io.File;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Function;
+import java.util.function.IntFunction;
+import javax.annotation.Nullable;
+import org.apache.pinot.segment.spi.ColumnMetadata;
+import org.apache.pinot.segment.spi.Constants;
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.SegmentMetadata;
+import org.apache.pinot.segment.spi.creator.SegmentVersion;
+import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.segment.spi.datasource.DataSourceMetadata;
+import org.apache.pinot.segment.spi.index.IndexReader;
+import org.apache.pinot.segment.spi.index.IndexType;
+import org.apache.pinot.segment.spi.index.StandardIndexes;
+import org.apache.pinot.segment.spi.index.column.ColumnIndexContainer;
+import org.apache.pinot.segment.spi.index.multicolumntext.MultiColumnTextMetadata;
+import org.apache.pinot.segment.spi.index.mutable.ThreadSafeMutableRoaringBitmap;
+import org.apache.pinot.segment.spi.index.reader.BloomFilterReader;
+import org.apache.pinot.segment.spi.index.reader.Dictionary;
+import org.apache.pinot.segment.spi.index.reader.ForwardIndexReader;
+import org.apache.pinot.segment.spi.index.reader.ForwardIndexReaderContext;
+import org.apache.pinot.segment.spi.index.reader.H3IndexReader;
+import org.apache.pinot.segment.spi.index.reader.InvertedIndexReader;
+import org.apache.pinot.segment.spi.index.reader.JsonIndexReader;
+import org.apache.pinot.segment.spi.index.reader.NullValueVectorReader;
+import org.apache.pinot.segment.spi.index.reader.RangeIndexReader;
+import org.apache.pinot.segment.spi.index.reader.TextIndexReader;
+import org.apache.pinot.segment.spi.index.reader.VectorIndexReader;
+import org.apache.pinot.segment.spi.index.startree.StarTreeV2;
+import org.apache.pinot.segment.spi.index.startree.StarTreeV2Metadata;
+import org.apache.pinot.segment.spi.partition.PartitionFunction;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.joda.time.Duration;
+import org.joda.time.Interval;
+
+
+/**
+ * In-memory {@link IndexSegment} implementation intended for system table queries.
+ * <p>
+ * This segment is backed by per-column value functions (docId -&gt; value) and exposes raw forward indexes (no
+ * dictionaries/inverted indexes) so that the standard v1 query engine can operate on it.
+ */
+public final class InMemorySystemTableSegment implements IndexSegment {
+  private final String _segmentName;
+  private final Schema _schema;
+  private final int _numDocs;
+  private final Map<String, IntFunction<Object>> _valueProvidersByColumn;
+  private final Map<String, DataSource> _dataSourcesByColumn;
+  private final SegmentMetadata _segmentMetadata;
+
+  public InMemorySystemTableSegment(String segmentName, Schema schema, int numDocs,
+      Map<String, IntFunction<Object>> valueProvidersByColumn) {
+    _segmentName = segmentName;
+    _schema = schema;
+    _numDocs = numDocs;
+    _valueProvidersByColumn = new HashMap<>(valueProvidersByColumn);
+    _dataSourcesByColumn = new HashMap<>(schema.getColumnNames().size());
+    for (String column : schema.getColumnNames()) {
+      FieldSpec fieldSpec = schema.getFieldSpecFor(column);
+      if (fieldSpec == null) {
+        continue;
+      }
+      IntFunction<Object> provider = _valueProvidersByColumn.get(column);
+      if (provider == null) {
+        provider = docId -> defaultValue(fieldSpec.getDataType());
+        _valueProvidersByColumn.put(column, provider);
+      }
+      _dataSourcesByColumn.put(column, new FunctionBasedDataSource(fieldSpec, numDocs, provider));
+    }
+    _segmentMetadata = new InMemorySegmentMetadata(segmentName, schema, numDocs);
+  }
+
+  @Override
+  public String getSegmentName() {
+    return _segmentName;
+  }
+
+  @Override
+  public SegmentMetadata getSegmentMetadata() {
+    return _segmentMetadata;
+  }
+
+  @Override
+  public Set<String> getColumnNames() {
+    return _schema.getColumnNames();
+  }
+
+  @Override
+  public Set<String> getPhysicalColumnNames() {
+    return _schema.getPhysicalColumnNames();
+  }
+
+  @Nullable
+  @Override
+  public DataSource getDataSourceNullable(String column) {
+    return _dataSourcesByColumn.get(column);
+  }
+
+  @Override
+  public DataSource getDataSource(String column, Schema schema) {
+    DataSource dataSource = getDataSourceNullable(column);
+    if (dataSource != null) {
+      return dataSource;
+    }
+    throw new IllegalStateException("Failed to find data source for column: " + column);
+  }
+
+  @Nullable
+  @Override
+  public List<StarTreeV2> getStarTrees() {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public TextIndexReader getMultiColumnTextIndex() {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public ThreadSafeMutableRoaringBitmap getValidDocIds() {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public ThreadSafeMutableRoaringBitmap getQueryableDocIds() {
+    return null;
+  }
+
+  @Override
+  public GenericRow getRecord(int docId, GenericRow reuse) {
+    GenericRow row = reuse != null ? reuse : new GenericRow();
+    row.getFieldToValueMap().clear();
+    for (String column : _schema.getColumnNames()) {
+      row.putValue(column, getValue(docId, column));
+    }
+    return row;
+  }
+
+  @Override
+  public Object getValue(int docId, String column) {
+    IntFunction<Object> provider = _valueProvidersByColumn.get(column);
+    if (provider == null) {
+      return null;
+    }
+    return provider.apply(docId);
+  }
+
+  @Override
+  public void offload() {
+  }
+
+  @Override
+  public void destroy() {
+  }
+
+  private static Object defaultValue(FieldSpec.DataType dataType) {
+    switch (dataType) {
+      case INT:
+        return 0;
+      case LONG:
+        return 0L;
+      case FLOAT:
+        return 0.0f;
+      case DOUBLE:
+        return 0.0d;
+      case BIG_DECIMAL:
+        return BigDecimal.ZERO;
+      case BOOLEAN:
+        return false;
+      case STRING:
+        return "";
+      case BYTES:
+        return new byte[0];
+      default:
+        return null;
+    }
+  }
+
+  private static final class InMemorySegmentMetadata implements SegmentMetadata {
+    private final String _segmentName;
+    private final Schema _schema;
+    private final int _totalDocs;
+    private final TreeMap<String, ColumnMetadata> _columnMetadataMap;
+
+    private InMemorySegmentMetadata(String segmentName, Schema schema, int totalDocs) {
+      _segmentName = segmentName;
+      _schema = schema;
+      _totalDocs = totalDocs;
+      _columnMetadataMap = new TreeMap<>();
+      for (String column : schema.getColumnNames()) {
+        FieldSpec fieldSpec = schema.getFieldSpecFor(column);
+        if (fieldSpec != null) {
+          _columnMetadataMap.put(column, new InMemoryColumnMetadata(fieldSpec, totalDocs));
+        }
+      }
+    }
+
+    @Deprecated
+    @Override
+    public String getTableName() {
+      return _schema.getSchemaName();
+    }
+
+    @Override
+    public String getName() {
+      return _segmentName;
+    }
+
+    @Override
+    public String getTimeColumn() {
+      return "";
+    }
+
+    @Override
+    public long getStartTime() {
+      return 0;
+    }
+
+    @Override
+    public long getEndTime() {
+      return 0;
+    }
+
+    @Override
+    public TimeUnit getTimeUnit() {
+      return TimeUnit.MILLISECONDS;
+    }
+
+    @Override
+    public Duration getTimeGranularity() {
+      return Duration.ZERO;
+    }
+
+    @Override
+    public Interval getTimeInterval() {
+      return new Interval(0L, 0L);
+    }
+
+    @Override
+    public String getCrc() {
+      return "";
+    }
+
+    @Override
+    public String getDataCrc() {
+      return "";
+    }
+
+    @Override
+    public SegmentVersion getVersion() {
+      return SegmentVersion.v3;
+    }
+
+    @Override
+    public Schema getSchema() {
+      return _schema;
+    }
+
+    @Override
+    public int getTotalDocs() {
+      return _totalDocs;
+    }
+
+    @Override
+    public File getIndexDir() {
+      return new File("");
+    }
+
+    @Nullable
+    @Override
+    public String getCreatorName() {
+      return "systemtable";
+    }
+
+    @Override
+    public long getIndexCreationTime() {
+      return 0;
+    }
+
+    @Override
+    public long getLastIndexedTimestamp() {
+      return 0;
+    }
+
+    @Override
+    public long getLatestIngestionTimestamp() {
+      return Long.MIN_VALUE;
+    }
+
+    @Override
+    public long getMinimumIngestionLagMs() {
+      return Long.MAX_VALUE;
+    }
+
+    @Nullable
+    @Override
+    public List<StarTreeV2Metadata> getStarTreeV2MetadataList() {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public MultiColumnTextMetadata getMultiColumnTextMetadata() {
+      return null;
+    }
+
+    @Override
+    public Map<String, String> getCustomMap() {
+      return Collections.emptyMap();
+    }
+
+    @Override
+    public String getStartOffset() {
+      return "";
+    }
+
+    @Override
+    public String getEndOffset() {
+      return "";
+    }
+
+    @Override
+    public TreeMap<String, ColumnMetadata> getColumnMetadataMap() {
+      return _columnMetadataMap;
+    }
+
+    @Override
+    public void removeColumn(String column) {
+      _columnMetadataMap.remove(column);
+    }
+
+    @Override
+    public JsonNode toJson(@Nullable Set<String> columnFilter) {
+      return JsonNodeFactory.instance.objectNode();
+    }
+  }
+
+  private static final class InMemoryColumnMetadata implements ColumnMetadata {
+    private final FieldSpec _fieldSpec;
+    private final int _totalDocs;
+
+    private InMemoryColumnMetadata(FieldSpec fieldSpec, int totalDocs) {
+      _fieldSpec = fieldSpec;
+      _totalDocs = totalDocs;
+    }
+
+    @Override
+    public FieldSpec getFieldSpec() {
+      return _fieldSpec;
+    }
+
+    @Override
+    public int getTotalDocs() {
+      return _totalDocs;
+    }
+
+    @Override
+    public int getCardinality() {
+      return Constants.UNKNOWN_CARDINALITY;
+    }
+
+    @Override
+    public boolean isSorted() {
+      return false;
+    }
+
+    @Override
+    public Comparable getMinValue() {
+      return defaultComparableValue(_fieldSpec.getDataType());
+    }
+
+    @Override
+    public Comparable getMaxValue() {
+      return defaultComparableValue(_fieldSpec.getDataType());
+    }
+
+    @Override
+    public boolean hasDictionary() {
+      return false;
+    }
+
+    @Override
+    public int getColumnMaxLength() {
+      return 0;
+    }
+
+    @Override
+    public int getBitsPerElement() {
+      return 0;
+    }
+
+    @Override
+    public int getMaxNumberOfMultiValues() {
+      return 0;
+    }
+
+    @Override
+    public int getTotalNumberOfEntries() {
+      return _totalDocs;
+    }
+
+    @Nullable
+    @Override
+    public PartitionFunction getPartitionFunction() {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public Set<Integer> getPartitions() {
+      return null;
+    }
+
+    @Override
+    public boolean isAutoGenerated() {
+      return false;
+    }
+
+    @Override
+    public Map<IndexType<?, ?, ?>, Long> getIndexSizeMap() {
+      return Collections.emptyMap();
+    }
+
+    private static Comparable defaultComparableValue(FieldSpec.DataType dataType) {
+      switch (dataType) {
+        case INT:
+          return 0;
+        case LONG:
+          return 0L;
+        case FLOAT:
+          return 0.0f;
+        case DOUBLE:
+          return 0.0d;
+        case BIG_DECIMAL:
+          return BigDecimal.ZERO;
+        case BOOLEAN:
+          return false;
+        case STRING:
+          return "";
+        default:
+          return 0;
+      }
+    }
+  }
+
+  private static final class FunctionBasedDataSource implements DataSource {
+    private final DataSourceMetadata _metadata;
+    private final ColumnIndexContainer _indexContainer;
+    private final ForwardIndexReader<?> _forwardIndex;
+
+    private FunctionBasedDataSource(FieldSpec fieldSpec, int numDocs, IntFunction<Object> valueProvider) {
+      _metadata = new FunctionBasedDataSourceMetadata(fieldSpec, numDocs);
+      _indexContainer = ColumnIndexContainer.Empty.INSTANCE;
+      _forwardIndex = new FunctionBasedForwardIndexReader(fieldSpec.getDataType(), valueProvider);
+    }
+
+    @Override
+    public DataSourceMetadata getDataSourceMetadata() {
+      return _metadata;
+    }
+
+    @Override
+    public ColumnIndexContainer getIndexContainer() {
+      return _indexContainer;
+    }
+
+    @Override
+    public <R extends IndexReader> R getIndex(IndexType<?, R, ?> type) {
+      if (type == null) {
+        return null;
+      }
+      if (StandardIndexes.FORWARD_ID.equals(type.getId())) {
+        return (R) _forwardIndex;
+      }
+      return null;
+    }
+
+    @Override
+    public ForwardIndexReader<?> getForwardIndex() {
+      return _forwardIndex;
+    }
+
+    @Nullable
+    @Override
+    public Dictionary getDictionary() {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public InvertedIndexReader<?> getInvertedIndex() {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public RangeIndexReader<?> getRangeIndex() {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public TextIndexReader getTextIndex() {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public TextIndexReader getFSTIndex() {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public TextIndexReader getIFSTIndex() {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public JsonIndexReader getJsonIndex() {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public H3IndexReader getH3Index() {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public BloomFilterReader getBloomFilter() {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public NullValueVectorReader getNullValueVector() {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public VectorIndexReader getVectorIndex() {
+      return null;
+    }
+  }
+
+  private static final class FunctionBasedDataSourceMetadata implements DataSourceMetadata {
+    private final FieldSpec _fieldSpec;
+    private final int _numDocs;
+
+    private FunctionBasedDataSourceMetadata(FieldSpec fieldSpec, int numDocs) {
+      _fieldSpec = fieldSpec;
+      _numDocs = numDocs;
+    }
+
+    @Override
+    public FieldSpec getFieldSpec() {
+      return _fieldSpec;
+    }
+
+    @Override
+    public boolean isSorted() {
+      return false;
+    }
+
+    @Override
+    public int getNumDocs() {
+      return _numDocs;
+    }
+
+    @Override
+    public int getNumValues() {
+      return _numDocs;
+    }
+
+    @Override
+    public int getMaxNumValuesPerMVEntry() {
+      return -1;
+    }
+
+    @Nullable
+    @Override
+    public Comparable getMinValue() {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public Comparable getMaxValue() {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public PartitionFunction getPartitionFunction() {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public Set<Integer> getPartitions() {
+      return null;
+    }
+
+    @Override
+    public int getCardinality() {
+      return -1;
+    }
+  }
+
+  private static final class FunctionBasedForwardIndexReader implements ForwardIndexReader<ForwardIndexReaderContext> {
+    private final FieldSpec.DataType _storedType;
+    private final IntFunction<Object> _valueProvider;
+
+    private FunctionBasedForwardIndexReader(FieldSpec.DataType storedType, IntFunction<Object> valueProvider) {
+      _storedType = storedType;
+      _valueProvider = valueProvider;
+    }
+
+    private static <T> T coerceNumber(Object value, Function<Number, T> numberConverter, Function<String, T> parser) {
+      return value instanceof Number ? numberConverter.apply((Number) value) : parser.apply(String.valueOf(value));
+    }
+
+    @Override
+    public boolean isDictionaryEncoded() {
+      return false;
+    }
+
+    @Override
+    public boolean isSingleValue() {
+      return true;
+    }
+
+    @Override
+    public FieldSpec.DataType getStoredType() {
+      return _storedType;
+    }
+
+    @Override
+    public int getInt(int docId, ForwardIndexReaderContext context) {
+      Object value = _valueProvider.apply(docId);
+      return coerceNumber(value, number -> number.intValue(), Integer::parseInt);
+    }
+
+    @Override
+    public long getLong(int docId, ForwardIndexReaderContext context) {
+      Object value = _valueProvider.apply(docId);
+      return coerceNumber(value, number -> number.longValue(), Long::parseLong);
+    }
+
+    @Override
+    public float getFloat(int docId, ForwardIndexReaderContext context) {
+      Object value = _valueProvider.apply(docId);
+      return coerceNumber(value, number -> number.floatValue(), Float::parseFloat);
+    }
+
+    @Override
+    public double getDouble(int docId, ForwardIndexReaderContext context) {
+      Object value = _valueProvider.apply(docId);
+      return coerceNumber(value, number -> number.doubleValue(), Double::parseDouble);
+    }
+
+    @Override
+    public BigDecimal getBigDecimal(int docId, ForwardIndexReaderContext context) {
+      Object value = _valueProvider.apply(docId);
+      if (value instanceof BigDecimal) {
+        return (BigDecimal) value;
+      }
+      if (value instanceof Number) {
+        return BigDecimal.valueOf(((Number) value).doubleValue());
+      }
+      return new BigDecimal(String.valueOf(value));
+    }
+
+    @Override
+    public String getString(int docId, ForwardIndexReaderContext context) {
+      Object value = _valueProvider.apply(docId);
+      return value != null ? value.toString() : null;
+    }
+
+    @Override
+    public byte[] getBytes(int docId, ForwardIndexReaderContext context) {
+      Object value = _valueProvider.apply(docId);
+      if (value instanceof byte[]) {
+        return (byte[]) value;
+      }
+      return value != null ? value.toString().getBytes(java.nio.charset.StandardCharsets.UTF_8) : null;
+    }
+
+    @Override
+    public void close()
+        throws IOException {
+    }
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/systemtable/datasource/InMemorySystemTableSegment.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/systemtable/datasource/InMemorySystemTableSegment.java
@@ -656,7 +656,11 @@ public final class InMemorySystemTableSegment implements IndexSegment {
       _valueProvider = valueProvider;
     }
 
-    private static <T> T coerceNumber(Object value, Function<Number, T> numberConverter, Function<String, T> parser) {
+    private static <T> T coerceNumber(Object value, T defaultValue, Function<Number, T> numberConverter,
+        Function<String, T> parser) {
+      if (value == null) {
+        return defaultValue;
+      }
       return value instanceof Number ? numberConverter.apply((Number) value) : parser.apply(String.valueOf(value));
     }
 
@@ -678,25 +682,25 @@ public final class InMemorySystemTableSegment implements IndexSegment {
     @Override
     public int getInt(int docId, ForwardIndexReaderContext context) {
       Object value = _valueProvider.apply(docId);
-      return coerceNumber(value, number -> number.intValue(), Integer::parseInt);
+      return coerceNumber(value, 0, Number::intValue, Integer::parseInt);
     }
 
     @Override
     public long getLong(int docId, ForwardIndexReaderContext context) {
       Object value = _valueProvider.apply(docId);
-      return coerceNumber(value, number -> number.longValue(), Long::parseLong);
+      return coerceNumber(value, 0L, Number::longValue, Long::parseLong);
     }
 
     @Override
     public float getFloat(int docId, ForwardIndexReaderContext context) {
       Object value = _valueProvider.apply(docId);
-      return coerceNumber(value, number -> number.floatValue(), Float::parseFloat);
+      return coerceNumber(value, 0.0f, Number::floatValue, Float::parseFloat);
     }
 
     @Override
     public double getDouble(int docId, ForwardIndexReaderContext context) {
       Object value = _valueProvider.apply(docId);
-      return coerceNumber(value, number -> number.doubleValue(), Double::parseDouble);
+      return coerceNumber(value, 0.0d, Number::doubleValue, Double::parseDouble);
     }
 
     @Override

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/DatabaseUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/DatabaseUtils.java
@@ -67,6 +67,21 @@ public class DatabaseUtils {
       case 2:
         Preconditions.checkArgument(!tableSplit[1].isEmpty(), "Invalid table name '%s'", tableName);
         String databasePrefix = tableSplit[0];
+        /*
+         * Allow system tables to bypass database prefix validation so they can be queried regardless of the database
+         * header. System tables are intended to be globally accessible and are not subject to database-level access
+         * controls.
+         *
+         * Security note: system tables are intentionally exempt from database-scoped access control, but access is
+         * still enforced by the configured broker {@link org.apache.pinot.spi.security.AccessControl} implementation.
+         * New system tables should avoid exposing sensitive information because they can be queried without a matching
+         * database context.
+         *
+         * See also: {@link org.apache.pinot.common.systemtable.SystemTableProvider}.
+         */
+        if ("system".equalsIgnoreCase(databasePrefix)) {
+          return tableName;
+        }
         if (!StringUtils.isEmpty(databaseName) && (ignoreCase || !databaseName.equals(databasePrefix))
             && (!ignoreCase || !databaseName.equalsIgnoreCase(databasePrefix))) {
           throw new DatabaseConflictException("Database name '" + databasePrefix

--- a/pinot-common/src/test/java/org/apache/pinot/common/systemtable/SystemTableRegistryTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/systemtable/SystemTableRegistryTest.java
@@ -1,0 +1,100 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.systemtable;
+
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertThrows;
+
+
+public class SystemTableRegistryTest {
+  @Test
+  public void testRegisterGetAndClose()
+      throws Exception {
+    SystemTableRegistry registry = new SystemTableRegistry(null, null, null, null);
+    AtomicInteger closeCount = new AtomicInteger();
+    SystemTableProvider provider = new TestProvider("SYSTEM.FOO", closeCount);
+    registry.register(provider);
+
+    assertNotNull(registry.get("system.foo"));
+    assertSame(registry.get("SYSTEM.FOO"), provider);
+    assertEquals(registry.getProviders().size(), 1);
+    assertEquals(closeCount.get(), 0);
+
+    registry.close();
+    assertEquals(closeCount.get(), 1);
+    assertFalse(registry.isRegistered("system.foo"));
+  }
+
+  @Test
+  public void testRegisterRejectsInvalidPrefix() {
+    SystemTableRegistry registry = new SystemTableRegistry(null, null, null, null);
+    TestProvider badProvider = new TestProvider("foo.bar", new AtomicInteger());
+    assertThrows(IllegalArgumentException.class, () -> registry.register(badProvider));
+  }
+
+  private static final class TestProvider implements SystemTableProvider {
+    private final String _tableName;
+    private final AtomicInteger _closeCount;
+    private final Schema _schema;
+
+    private TestProvider(String tableName, AtomicInteger closeCount) {
+      _tableName = tableName;
+      _closeCount = closeCount;
+      _schema = new Schema.SchemaBuilder().setSchemaName(tableName)
+          .addSingleValueDimension("tableName", FieldSpec.DataType.STRING).build();
+    }
+
+    @Override
+    public String getTableName() {
+      return _tableName;
+    }
+
+    @Override
+    public Schema getSchema() {
+      return _schema;
+    }
+
+    @Override
+    public TableConfig getTableConfig() {
+      return new TableConfigBuilder(TableType.OFFLINE).setTableName(_tableName).build();
+    }
+
+    @Override
+    public IndexSegment getDataSource() {
+      return org.mockito.Mockito.mock(IndexSegment.class);
+    }
+
+    @Override
+    public void close() {
+      _closeCount.incrementAndGet();
+    }
+  }
+}

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/DatabaseUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/DatabaseUtilsTest.java
@@ -60,6 +60,15 @@ public class DatabaseUtilsTest {
     error(DEFAULT_DATABASE_NAME + "." + FULLY_QUALIFIED_TABLE_NAME, DEFAULT_DATABASE_NAME);
   }
 
+  @Test
+  public void systemTableDatabaseBypassTest() {
+    assertEquals(DatabaseUtils.translateTableName("system.tables", DATABASE_NAME), "system.tables");
+    assertEquals(DatabaseUtils.translateTableName("system.tables", DEFAULT_DATABASE_NAME), "system.tables");
+    assertEquals(DatabaseUtils.translateTableName("system.tables", (String) null), "system.tables");
+    assertEquals(DatabaseUtils.translateTableName("system.tables", DATABASE_NAME, true), "system.tables");
+    assertEquals(DatabaseUtils.translateTableName("SYSTEM.tables", DATABASE_NAME, true), "SYSTEM.tables");
+  }
+
   private void check(String tableName, String databaseName, String fqn) {
     check(tableName, databaseName, fqn, false);
   }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SystemTableIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SystemTableIntegrationTest.java
@@ -1,0 +1,131 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.integration.tests;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.File;
+import java.net.URI;
+import java.util.Iterator;
+import java.util.List;
+import org.apache.pinot.client.admin.PinotAdminClient;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.apache.pinot.util.TestUtils;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+
+/**
+ * Integration test to ensure system tables can be queried through the broker.
+ */
+public class SystemTableIntegrationTest extends BaseClusterIntegrationTestSet {
+
+  @Override
+  protected void overrideBrokerConf(PinotConfiguration brokerConf) {
+    // Provide controller URL so system.tables provider can call size API.
+    brokerConf.setProperty(CommonConstants.Broker.CONTROLLER_URL, getControllerBaseApiUrl());
+  }
+
+  @BeforeClass
+  public void setUp()
+      throws Exception {
+    TestUtils.ensureDirectoriesExistAndEmpty(_tempDir, _segmentDir, _tarDir);
+
+    startZk();
+    startController();
+    startBroker();
+    startServer();
+
+    Schema schema = createSchema();
+    addSchema(schema);
+    TableConfig tableConfig = createOfflineTableConfig();
+    addTableConfig(tableConfig);
+
+    List<File> avroFiles = unpackAvroData(_tempDir);
+    ClusterIntegrationTestUtils.buildSegmentsFromAvro(avroFiles, tableConfig, schema, 0, _segmentDir, _tarDir);
+    uploadSegments(getTableName(), _tarDir);
+    waitForAllDocsLoaded(600_000L);
+  }
+
+  @AfterClass
+  public void tearDown()
+      throws Exception {
+    stopServer();
+    stopBroker();
+    stopController();
+    stopZk();
+  }
+
+  @Test
+  public void testSystemTablesSize()
+      throws Exception {
+    URI controllerBaseUri = URI.create(getControllerBaseApiUrl());
+    URI sizeUri = controllerBaseUri.resolve("/tables/mytable/size?verbose=true&includeReplacedSegments=false");
+    JsonNode controllerSize = JsonUtils.stringToJsonNode(sendGetRequest(sizeUri.toString()));
+    int controllerSegments = controllerSize.path("offlineSegments").path("segments").size();
+    long controllerReportedSize = controllerSize.path("reportedSizeInBytes").asLong();
+    long controllerEstimatedSize = controllerSize.path("estimatedSizeInBytes").asLong();
+    assertTrue(controllerSegments > 0, "controller size endpoint should report segments");
+    assertTrue(controllerReportedSize > 0, "controller size endpoint should report size");
+    assertTrue(controllerEstimatedSize > 0, "controller size endpoint should report estimated size");
+
+    long controllerTotalDocs = 0;
+    String controllerAddress = URI.create(getControllerBaseApiUrl()).getAuthority();
+    try (PinotAdminClient adminClient = new PinotAdminClient(controllerAddress)) {
+      JsonNode offlineSegments = controllerSize.path("offlineSegments").path("segments");
+      Iterator<String> segmentNames = offlineSegments.fieldNames();
+      while (segmentNames.hasNext()) {
+        String segmentName = segmentNames.next();
+        JsonNode segmentMetadata =
+            adminClient.getSegmentApiClient().getSegmentMetadata("mytable_OFFLINE", segmentName);
+        controllerTotalDocs += segmentMetadata.path(CommonConstants.Segment.TOTAL_DOCS).asLong();
+      }
+    }
+    assertTrue(controllerTotalDocs > 0, "controller segment metadata should report totalDocs");
+
+    JsonNode response = postQuery(
+        "SELECT tableName,type,segments,totalDocs,reportedSizeBytes,estimatedSizeBytes FROM system.tables "
+            + "WHERE tableName='mytable' AND type='OFFLINE'");
+    assertNotNull(response);
+    assertEquals(response.withArray("exceptions").size(), 0);
+    JsonNode rows = response.get("resultTable").get("rows");
+    assertEquals(rows.size(), 1, "Expected exactly one offline table row");
+    JsonNode row = rows.get(0);
+    assertEquals(row.get(0).asText(), "mytable");
+    assertEquals(row.get(1).asText(), "OFFLINE");
+    int segments = row.get(2).asInt();
+    long totalDocs = row.get(3).asLong();
+    long reportedSize = row.get(4).asLong();
+    long estimatedSize = row.get(5).asLong();
+    assertTrue(segments > 0, "segments should be > 0 but was " + segments);
+    assertTrue(totalDocs > 0, "totalDocs should be > 0 but was " + totalDocs);
+    assertTrue(reportedSize > 0, "reportedSizeBytes should be > 0 but was " + reportedSize);
+    assertTrue(estimatedSize > 0, "estimatedSizeBytes should be > 0 but was " + estimatedSize);
+    assertEquals(segments, controllerSegments, "segment count should match controller");
+    assertEquals(totalDocs, controllerTotalDocs, "totalDocs should match controller segment metadata");
+  }
+}

--- a/pinot-plugins/pinot-system-table/pom.xml
+++ b/pinot-plugins/pinot-system-table/pom.xml
@@ -1,0 +1,83 @@
+<?xml version="1.0"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>pinot-plugins</artifactId>
+    <groupId>org.apache.pinot</groupId>
+    <version>1.5.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>pinot-system-table</artifactId>
+  <name>Pinot System Table</name>
+  <url>https://pinot.apache.org/</url>
+  <properties>
+    <pinot.root>${basedir}/../..</pinot.root>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-common</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-java-client</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>org.apache.pinot</groupId>
+          <artifactId>pinot-common</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <profiles>
+    <profile>
+      <id>build-shaded-jar</id>
+      <activation>
+        <property>
+          <name>skipShade</name>
+          <value>!true</value>
+        </property>
+      </activation>
+      <properties>
+        <shade.phase.prop>package</shade.phase.prop>
+      </properties>
+    </profile>
+    <profile>
+      <id>pinot-fastdev</id>
+      <properties>
+        <shade.phase.prop>none</shade.phase.prop>
+      </properties>
+    </profile>
+  </profiles>
+</project>

--- a/pinot-plugins/pinot-system-table/src/main/java/org/apache/pinot/systemtable/provider/BrokerRuntimeSystemTableProvider.java
+++ b/pinot-plugins/pinot-system-table/src/main/java/org/apache/pinot/systemtable/provider/BrokerRuntimeSystemTableProvider.java
@@ -1,0 +1,218 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.systemtable.provider;
+
+import java.lang.management.ManagementFactory;
+import java.lang.management.MemoryMXBean;
+import java.lang.management.MemoryUsage;
+import java.lang.management.OperatingSystemMXBean;
+import java.lang.management.RuntimeMXBean;
+import java.lang.management.ThreadMXBean;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.IntFunction;
+import javax.annotation.Nullable;
+import org.apache.helix.HelixAdmin;
+import org.apache.helix.model.InstanceConfig;
+import org.apache.pinot.common.systemtable.SystemTable;
+import org.apache.pinot.common.systemtable.SystemTableProvider;
+import org.apache.pinot.common.systemtable.SystemTableProviderContext;
+import org.apache.pinot.common.systemtable.datasource.InMemorySystemTableSegment;
+import org.apache.pinot.common.utils.config.InstanceUtils;
+import org.apache.pinot.common.version.PinotVersion;
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * System table that exposes broker-local runtime/JVM information across all live brokers.
+ */
+@SystemTable
+public final class BrokerRuntimeSystemTableProvider implements SystemTableProvider {
+  private static final Logger LOGGER = LoggerFactory.getLogger(BrokerRuntimeSystemTableProvider.class);
+
+  public static final String TABLE_NAME = "system.broker_runtime";
+
+  private static final Schema SCHEMA = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
+      .addSingleValueDimension("brokerId", FieldSpec.DataType.STRING)
+      .addSingleValueDimension("host", FieldSpec.DataType.STRING)
+      .addSingleValueDimension("port", FieldSpec.DataType.INT)
+      .addMetric("startTimeMs", FieldSpec.DataType.LONG)
+      .addMetric("uptimeMs", FieldSpec.DataType.LONG)
+      .addMetric("jvmHeapUsedBytes", FieldSpec.DataType.LONG)
+      .addMetric("jvmHeapMaxBytes", FieldSpec.DataType.LONG)
+      .addMetric("jvmNonHeapUsedBytes", FieldSpec.DataType.LONG)
+      .addMetric("threadCount", FieldSpec.DataType.INT)
+      .addMetric("peakThreadCount", FieldSpec.DataType.INT)
+      .addMetric("availableProcessors", FieldSpec.DataType.INT)
+      .addMetric("systemLoadAverage", FieldSpec.DataType.DOUBLE)
+      .addMetric("timestampMs", FieldSpec.DataType.LONG)
+      .addSingleValueDimension("pinotVersion", FieldSpec.DataType.STRING)
+      .build();
+
+  @Nullable
+  private HelixAdmin _helixAdmin;
+  @Nullable
+  private String _clusterName;
+  @Nullable
+  private PinotConfiguration _brokerConfig;
+
+  public BrokerRuntimeSystemTableProvider() {
+  }
+
+  @Override
+  public void init(SystemTableProviderContext context) {
+    _helixAdmin = context.getHelixAdmin();
+    _clusterName = context.getClusterName();
+    _brokerConfig = context.getConfig();
+  }
+
+  @Override
+  public ExecutionMode getExecutionMode() {
+    return ExecutionMode.BROKER_SCATTER_GATHER;
+  }
+
+  @Override
+  public String getTableName() {
+    return TABLE_NAME;
+  }
+
+  @Override
+  public Schema getSchema() {
+    return SCHEMA;
+  }
+
+  @Override
+  public TableConfig getTableConfig() {
+    return new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).build();
+  }
+
+  @Override
+  public IndexSegment getDataSource() {
+    String brokerId = getBrokerId();
+    HostPort hostPort = getHostPort(brokerId);
+
+    long timestampMs = System.currentTimeMillis();
+    RuntimeMXBean runtimeMXBean = ManagementFactory.getRuntimeMXBean();
+    long startTimeMs = runtimeMXBean.getStartTime();
+    long uptimeMs = runtimeMXBean.getUptime();
+
+    MemoryMXBean memoryMXBean = ManagementFactory.getMemoryMXBean();
+    MemoryUsage heap = memoryMXBean.getHeapMemoryUsage();
+    long heapUsedBytes = heap.getUsed();
+    long heapMaxBytes = heap.getMax();
+    MemoryUsage nonHeap = memoryMXBean.getNonHeapMemoryUsage();
+    long nonHeapUsedBytes = nonHeap.getUsed();
+
+    ThreadMXBean threadMXBean = ManagementFactory.getThreadMXBean();
+    int threadCount = threadMXBean.getThreadCount();
+    int peakThreadCount = threadMXBean.getPeakThreadCount();
+
+    OperatingSystemMXBean osMxBean = ManagementFactory.getOperatingSystemMXBean();
+    int availableProcessors = osMxBean.getAvailableProcessors();
+    double systemLoadAverage = Math.max(osMxBean.getSystemLoadAverage(), 0.0);
+
+    Map<String, IntFunction<Object>> valueProviders = new HashMap<>();
+    valueProviders.put("brokerId", docId -> brokerId);
+    valueProviders.put("host", docId -> hostPort._host);
+    valueProviders.put("port", docId -> hostPort._port);
+    valueProviders.put("startTimeMs", docId -> startTimeMs);
+    valueProviders.put("uptimeMs", docId -> uptimeMs);
+    valueProviders.put("jvmHeapUsedBytes", docId -> heapUsedBytes);
+    valueProviders.put("jvmHeapMaxBytes", docId -> heapMaxBytes);
+    valueProviders.put("jvmNonHeapUsedBytes", docId -> nonHeapUsedBytes);
+    valueProviders.put("threadCount", docId -> threadCount);
+    valueProviders.put("peakThreadCount", docId -> peakThreadCount);
+    valueProviders.put("availableProcessors", docId -> availableProcessors);
+    valueProviders.put("systemLoadAverage", docId -> systemLoadAverage);
+    valueProviders.put("timestampMs", docId -> timestampMs);
+    valueProviders.put("pinotVersion", docId -> PinotVersion.VERSION);
+
+    return new InMemorySystemTableSegment(TABLE_NAME, SCHEMA, 1, valueProviders);
+  }
+
+  private String getBrokerId() {
+    if (_brokerConfig == null) {
+      return "";
+    }
+    return _brokerConfig.getProperty(CommonConstants.Broker.CONFIG_OF_BROKER_ID, "");
+  }
+
+  private HostPort getHostPort(String brokerId) {
+    if (_helixAdmin == null || _clusterName == null || brokerId.isEmpty()) {
+      return getHostPortFromConfigOrInstanceId(brokerId);
+    }
+    try {
+      InstanceConfig instanceConfig = _helixAdmin.getInstanceConfig(_clusterName, brokerId);
+      if (instanceConfig == null) {
+        return getHostPortFromConfigOrInstanceId(brokerId);
+      }
+      URI baseUri = URI.create(InstanceUtils.getInstanceBaseUri(instanceConfig));
+      return new HostPort(baseUri.getHost(), baseUri.getPort());
+    } catch (Exception e) {
+      LOGGER.debug("{}: error fetching broker instance config for {}", TABLE_NAME, brokerId, e);
+      return getHostPortFromConfigOrInstanceId(brokerId);
+    }
+  }
+
+  private HostPort getHostPortFromConfigOrInstanceId(String brokerId) {
+    if (_brokerConfig != null) {
+      String host = _brokerConfig.getProperty(CommonConstants.Broker.CONFIG_OF_BROKER_HOSTNAME, "");
+      int port = _brokerConfig.getProperty(CommonConstants.Helix.KEY_OF_BROKER_QUERY_PORT, -1);
+      if (!host.isEmpty() && port > 0) {
+        return new HostPort(host, port);
+      }
+    }
+
+    if (brokerId.startsWith(CommonConstants.Helix.PREFIX_OF_BROKER_INSTANCE)) {
+      String suffix = brokerId.substring(CommonConstants.Helix.BROKER_INSTANCE_PREFIX_LENGTH);
+      int lastUnderscore = suffix.lastIndexOf('_');
+      if (lastUnderscore > 0 && lastUnderscore + 1 < suffix.length()) {
+        String host = suffix.substring(0, lastUnderscore);
+        String portString = suffix.substring(lastUnderscore + 1);
+        try {
+          int port = Integer.parseInt(portString);
+          return new HostPort(host, port);
+        } catch (NumberFormatException ignored) {
+          // fall through
+        }
+      }
+    }
+    return new HostPort("", -1);
+  }
+
+  private static final class HostPort {
+    final String _host;
+    final int _port;
+
+    private HostPort(String host, int port) {
+      _host = host;
+      _port = port;
+    }
+  }
+}

--- a/pinot-plugins/pinot-system-table/src/main/java/org/apache/pinot/systemtable/provider/HelixControllerUtils.java
+++ b/pinot-plugins/pinot-system-table/src/main/java/org/apache/pinot/systemtable/provider/HelixControllerUtils.java
@@ -1,0 +1,77 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.systemtable.provider;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nullable;
+import org.apache.helix.HelixAdmin;
+import org.apache.helix.model.InstanceConfig;
+import org.apache.pinot.common.utils.config.InstanceUtils;
+import org.apache.pinot.spi.utils.InstanceTypeUtils;
+import org.slf4j.Logger;
+
+
+final class HelixControllerUtils {
+  private HelixControllerUtils() {
+  }
+
+  static List<String> discoverControllerBaseUrls(HelixAdmin helixAdmin, String clusterName, Logger logger) {
+    List<String> urls = new ArrayList<>();
+    List<String> instanceIds;
+    try {
+      instanceIds = helixAdmin.getInstancesInCluster(clusterName);
+    } catch (Exception e) {
+      logger.warn("Failed to list instances in cluster '{}' while discovering controllers", clusterName, e);
+      return List.of();
+    }
+    for (String instanceId : instanceIds) {
+      if (!InstanceTypeUtils.isController(instanceId)) {
+        continue;
+      }
+      String baseUrl = getInstanceBaseUrl(helixAdmin, clusterName, instanceId, logger);
+      if (baseUrl != null) {
+        urls.add(baseUrl);
+      }
+    }
+    return urls;
+  }
+
+  private static @Nullable String getInstanceBaseUrl(HelixAdmin helixAdmin, String clusterName, String instanceId,
+      Logger logger) {
+    InstanceConfig instanceConfig;
+    try {
+      instanceConfig = helixAdmin.getInstanceConfig(clusterName, instanceId);
+    } catch (Exception e) {
+      logger.warn("Failed to fetch Helix InstanceConfig for instance '{}' in cluster '{}'", instanceId, clusterName, e);
+      return null;
+    }
+    if (instanceConfig == null) {
+      logger.warn("Missing Helix InstanceConfig for instance '{}' in cluster '{}'", instanceId, clusterName);
+      return null;
+    }
+    String baseUrl = InstanceUtils.getInstanceBaseUri(instanceConfig);
+    if (baseUrl.isEmpty()) {
+      logger.warn("Failed to build instance base URL from Helix InstanceConfig for instance '{}' in cluster '{}'",
+          instanceId, clusterName);
+      return null;
+    }
+    return baseUrl;
+  }
+}

--- a/pinot-plugins/pinot-system-table/src/main/java/org/apache/pinot/systemtable/provider/InstancesSystemTableProvider.java
+++ b/pinot-plugins/pinot-system-table/src/main/java/org/apache/pinot/systemtable/provider/InstancesSystemTableProvider.java
@@ -1,0 +1,384 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.systemtable.provider;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import javax.annotation.Nullable;
+import org.apache.helix.HelixAdmin;
+import org.apache.pinot.client.admin.PinotAdminClient;
+import org.apache.pinot.client.admin.PinotAdminTransport;
+import org.apache.pinot.common.systemtable.SystemTable;
+import org.apache.pinot.common.systemtable.SystemTableProvider;
+import org.apache.pinot.common.systemtable.SystemTableProviderContext;
+import org.apache.pinot.common.systemtable.datasource.InMemorySystemTableSegment;
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.InstanceTypeUtils;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Basic system table exposing Pinot instance metadata.
+ */
+@SystemTable
+public final class InstancesSystemTableProvider implements SystemTableProvider {
+  private static final Logger LOGGER = LoggerFactory.getLogger(InstancesSystemTableProvider.class);
+  public static final String TABLE_NAME = "system.instances";
+
+  private static final String CONTROLLER_TIMEOUT_MS_PROPERTY = "pinot.systemtable.instances.controllerTimeoutMs";
+  private static final long DEFAULT_CONTROLLER_TIMEOUT_MS = Duration.ofSeconds(5).toMillis();
+
+  private static final Schema SCHEMA = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
+      .addSingleValueDimension("instanceId", FieldSpec.DataType.STRING)
+      .addSingleValueDimension("type", FieldSpec.DataType.STRING)
+      .addSingleValueDimension("host", FieldSpec.DataType.STRING)
+      .addSingleValueDimension("port", FieldSpec.DataType.INT)
+      .addSingleValueDimension("state", FieldSpec.DataType.STRING)
+      .addSingleValueDimension("tags", FieldSpec.DataType.STRING)
+      .build();
+
+  @Nullable
+  private HelixAdmin _helixAdmin;
+  @Nullable
+  private String _clusterName;
+  private List<String> _configuredControllerUrls = List.of();
+  private long _controllerTimeoutMs = DEFAULT_CONTROLLER_TIMEOUT_MS;
+  private final Map<String, PinotAdminClient> _adminClientCache = new ConcurrentHashMap<>();
+
+  public InstancesSystemTableProvider() {
+  }
+
+  @Override
+  public void init(SystemTableProviderContext context) {
+    _helixAdmin = context.getHelixAdmin();
+    _clusterName = context.getClusterName();
+    if (context.getConfig() != null) {
+      _controllerTimeoutMs =
+          context.getConfig().getProperty(CONTROLLER_TIMEOUT_MS_PROPERTY, DEFAULT_CONTROLLER_TIMEOUT_MS);
+    }
+  }
+
+  /**
+   * Package-private constructor for testing with overrides.
+   */
+  InstancesSystemTableProvider(@Nullable HelixAdmin helixAdmin, @Nullable String clusterName,
+      @Nullable List<String> controllerUrls) {
+    _helixAdmin = helixAdmin;
+    _clusterName = clusterName;
+    _configuredControllerUrls = controllerUrls != null ? new ArrayList<>(controllerUrls) : List.of();
+  }
+
+  @Override
+  public String getTableName() {
+    return TABLE_NAME;
+  }
+
+  @Override
+  public Schema getSchema() {
+    return SCHEMA;
+  }
+
+  @Override
+  public TableConfig getTableConfig() {
+    return new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).build();
+  }
+
+  @Override
+  public void close()
+      throws Exception {
+    for (Map.Entry<String, PinotAdminClient> entry : _adminClientCache.entrySet()) {
+      try {
+        entry.getValue().close();
+      } catch (Exception e) {
+        LOGGER.debug("Failed to close admin client for {}: {}", entry.getKey(), e.toString());
+      }
+    }
+    _adminClientCache.clear();
+  }
+
+  @Override
+  public IndexSegment getDataSource() {
+    List<String> controllerBaseUrls = getControllerBaseUrls();
+    if (controllerBaseUrls.isEmpty()) {
+      return new InMemorySystemTableSegment(TABLE_NAME, SCHEMA, 0, Collections.emptyMap());
+    }
+
+    List<String> instances = fetchInstances(controllerBaseUrls);
+    if (instances.isEmpty()) {
+      return new InMemorySystemTableSegment(TABLE_NAME, SCHEMA, 0, Collections.emptyMap());
+    }
+
+    Set<String> liveInstances = fetchLiveInstances(controllerBaseUrls);
+
+    List<InstanceRow> rows = new ArrayList<>(instances.size());
+    for (String instanceId : instances) {
+      rows.add(fetchInstanceRow(instanceId, liveInstances, controllerBaseUrls));
+    }
+
+    Map<String, java.util.function.IntFunction<Object>> valueProviders = new java.util.HashMap<>();
+    valueProviders.put("instanceId", docId -> rows.get(docId)._instanceId);
+    valueProviders.put("type", docId -> rows.get(docId)._type);
+    valueProviders.put("host", docId -> rows.get(docId)._host);
+    valueProviders.put("port", docId -> rows.get(docId)._port);
+    valueProviders.put("state", docId -> rows.get(docId)._state);
+    valueProviders.put("tags", docId -> rows.get(docId)._tags);
+
+    return new InMemorySystemTableSegment(TABLE_NAME, SCHEMA, rows.size(), valueProviders);
+  }
+
+  private List<String> fetchInstances(List<String> controllerBaseUrls) {
+    for (String baseUrl : controllerBaseUrls) {
+      try {
+        PinotAdminClient adminClient = getOrCreateAdminClient(baseUrl);
+        if (adminClient == null) {
+          continue;
+        }
+        return adminClient.getInstanceClient().listInstances();
+      } catch (Exception e) {
+        LOGGER.debug("{}: error fetching instances via {}", TABLE_NAME, baseUrl, e);
+      }
+    }
+    return List.of();
+  }
+
+  private Set<String> fetchLiveInstances(List<String> controllerBaseUrls) {
+    for (String baseUrl : controllerBaseUrls) {
+      try {
+        PinotAdminClient adminClient = getOrCreateAdminClient(baseUrl);
+        if (adminClient == null) {
+          continue;
+        }
+        return new java.util.HashSet<>(adminClient.getInstanceClient().listLiveInstances());
+      } catch (Exception e) {
+        LOGGER.debug("{}: error fetching live instances via {}", TABLE_NAME, baseUrl, e);
+      }
+    }
+    return Set.of();
+  }
+
+  private InstanceRow fetchInstanceRow(String instanceId, Set<String> liveInstances, List<String> controllerBaseUrls) {
+    JsonNode instanceInfo = fetchInstanceInfo(instanceId, controllerBaseUrls);
+    boolean enabled = instanceInfo != null && instanceInfo.has("enabled") ? instanceInfo.path("enabled").asBoolean()
+        : true;
+
+    String host = instanceInfo != null ? instanceInfo.path("hostName").asText("") : "";
+    int port = instanceInfo != null && instanceInfo.has("port") ? instanceInfo.path("port").asInt(-1) : -1;
+    String tags = instanceInfo != null ? joinTags(instanceInfo.path("tags")) : "";
+
+    if ((host.isEmpty() || port < 0)) {
+      HostPort parsed = parseHostPort(instanceId);
+      if (parsed != null) {
+        if (host.isEmpty()) {
+          host = parsed._host;
+        }
+        if (port < 0) {
+          port = parsed._port;
+        }
+      }
+    }
+
+    String state;
+    if (!enabled) {
+      state = "DISABLED";
+    } else if (liveInstances.contains(instanceId)) {
+      state = "ONLINE";
+    } else {
+      state = "OFFLINE";
+    }
+
+    return new InstanceRow(instanceId, InstanceTypeUtils.getInstanceType(instanceId).name(), host, port, state, tags);
+  }
+
+  private @Nullable JsonNode fetchInstanceInfo(String instanceId, List<String> controllerBaseUrls) {
+    for (String baseUrl : controllerBaseUrls) {
+      try {
+        PinotAdminClient adminClient = getOrCreateAdminClient(baseUrl);
+        if (adminClient == null) {
+          continue;
+        }
+        String response = adminClient.getInstanceClient().getInstance(instanceId);
+        return JsonUtils.stringToJsonNode(response);
+      } catch (Exception e) {
+        LOGGER.debug("{}: error fetching instance info for {} via {}", TABLE_NAME, instanceId, baseUrl, e);
+      }
+    }
+    return null;
+  }
+
+  private static String joinTags(JsonNode tagsNode) {
+    if (tagsNode == null || tagsNode.isMissingNode() || tagsNode.isNull()) {
+      return "";
+    }
+    if (!tagsNode.isArray()) {
+      return tagsNode.asText(tagsNode.toString());
+    }
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < tagsNode.size(); i++) {
+      if (i > 0) {
+        sb.append(',');
+      }
+      sb.append(tagsNode.get(i).asText());
+    }
+    return sb.toString();
+  }
+
+  private List<String> getControllerBaseUrls() {
+    Set<String> urls = new LinkedHashSet<>();
+    if (_helixAdmin != null) {
+      for (String controller : discoverControllersFromHelix()) {
+        String normalized = normalizeControllerUrl(controller);
+        if (normalized != null) {
+          urls.add(normalized);
+        }
+      }
+    }
+    for (String url : _configuredControllerUrls) {
+      String normalized = normalizeControllerUrl(url);
+      if (normalized != null) {
+        urls.add(normalized);
+      }
+    }
+    return new ArrayList<>(urls);
+  }
+
+  private List<String> discoverControllersFromHelix() {
+    if (_helixAdmin == null) {
+      return List.of();
+    }
+    if (_clusterName == null) {
+      LOGGER.warn("Cannot discover controllers without cluster name");
+      return List.of();
+    }
+    return HelixControllerUtils.discoverControllerBaseUrls(_helixAdmin, _clusterName, LOGGER);
+  }
+
+  private @Nullable PinotAdminClient getOrCreateAdminClient(String controllerBaseUrl) {
+    String normalized = normalizeControllerUrl(controllerBaseUrl);
+    if (normalized == null) {
+      return null;
+    }
+    return _adminClientCache.computeIfAbsent(normalized, controller -> {
+      try {
+        String controllerAddress = stripScheme(controller);
+        Properties properties = new Properties();
+        properties.setProperty(PinotAdminTransport.PINOT_ADMIN_REQUEST_TIMEOUT_MS_PROPERTY_KEY,
+            String.valueOf(_controllerTimeoutMs));
+        properties.setProperty(PinotAdminTransport.PINOT_ADMIN_SCHEME_PROPERTY_KEY,
+            controller.startsWith("https://") ? "https" : "http");
+        return new PinotAdminClient(controllerAddress, properties);
+      } catch (Exception e) {
+        LOGGER.warn("Failed to create admin client for {}: {}", controller, e.toString());
+        return null;
+      }
+    });
+  }
+
+  private static @Nullable String normalizeControllerUrl(@Nullable String controllerUrl) {
+    if (controllerUrl == null || controllerUrl.isEmpty()) {
+      return null;
+    }
+    String normalized = controllerUrl;
+    if (!normalized.startsWith("http://") && !normalized.startsWith("https://")) {
+      normalized = "http://" + normalized;
+    }
+    if (normalized.endsWith("/")) {
+      normalized = normalized.substring(0, normalized.length() - 1);
+    }
+    return normalized;
+  }
+
+  private static String stripScheme(String controllerUrl) {
+    if (controllerUrl.startsWith("http://")) {
+      return controllerUrl.substring("http://".length());
+    }
+    if (controllerUrl.startsWith("https://")) {
+      return controllerUrl.substring("https://".length());
+    }
+    return controllerUrl;
+  }
+
+  private static final class InstanceRow {
+    private final String _instanceId;
+    private final String _type;
+    private final String _host;
+    private final int _port;
+    private final String _state;
+    private final String _tags;
+
+    private InstanceRow(String instanceId, String type, String host, int port, String state, String tags) {
+      _instanceId = instanceId;
+      _type = type;
+      _host = host;
+      _port = port;
+      _state = state;
+      _tags = tags;
+    }
+  }
+
+  private static final class HostPort {
+    private final String _host;
+    private final int _port;
+
+    private HostPort(String host, int port) {
+      _host = host;
+      _port = port;
+    }
+  }
+
+  private static @Nullable HostPort parseHostPort(String instanceId) {
+    int lastUnderscore = instanceId.lastIndexOf('_');
+    if (lastUnderscore <= 0 || lastUnderscore >= instanceId.length() - 1) {
+      return null;
+    }
+    String portString = instanceId.substring(lastUnderscore + 1);
+    int port;
+    try {
+      port = Integer.parseInt(portString);
+    } catch (Exception e) {
+      return null;
+    }
+    String host;
+    int firstUnderscore = instanceId.indexOf('_');
+    if (InstanceTypeUtils.isController(instanceId) || InstanceTypeUtils.isBroker(instanceId) || InstanceTypeUtils
+        .isMinion(instanceId) || instanceId.startsWith("Server_")) {
+      if (firstUnderscore <= 0 || firstUnderscore >= lastUnderscore) {
+        return null;
+      }
+      host = instanceId.substring(firstUnderscore + 1, lastUnderscore);
+    } else {
+      host = instanceId.substring(0, lastUnderscore);
+    }
+    return host.isEmpty() ? null : new HostPort(host, port);
+  }
+}

--- a/pinot-plugins/pinot-system-table/src/main/java/org/apache/pinot/systemtable/provider/InstancesSystemTableProvider.java
+++ b/pinot-plugins/pinot-system-table/src/main/java/org/apache/pinot/systemtable/provider/InstancesSystemTableProvider.java
@@ -41,6 +41,7 @@ import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.InstanceTypeUtils;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
@@ -86,6 +87,10 @@ public final class InstancesSystemTableProvider implements SystemTableProvider {
     if (context.getConfig() != null) {
       _controllerTimeoutMs =
           context.getConfig().getProperty(CONTROLLER_TIMEOUT_MS_PROPERTY, DEFAULT_CONTROLLER_TIMEOUT_MS);
+      String controllerUrl = context.getConfig().getProperty(CommonConstants.Broker.CONTROLLER_URL);
+      if (controllerUrl != null && !controllerUrl.isEmpty()) {
+        _configuredControllerUrls = List.of(controllerUrl.split(","));
+      }
     }
   }
 

--- a/pinot-plugins/pinot-system-table/src/main/java/org/apache/pinot/systemtable/provider/TablesSystemTableProvider.java
+++ b/pinot-plugins/pinot-system-table/src/main/java/org/apache/pinot/systemtable/provider/TablesSystemTableProvider.java
@@ -1,0 +1,576 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.systemtable.provider;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
+import java.util.function.IntFunction;
+import javax.annotation.Nullable;
+import org.apache.helix.HelixAdmin;
+import org.apache.pinot.client.admin.PinotAdminClient;
+import org.apache.pinot.client.admin.PinotAdminTransport;
+import org.apache.pinot.common.config.provider.TableCache;
+import org.apache.pinot.common.systemtable.SystemTable;
+import org.apache.pinot.common.systemtable.SystemTableProvider;
+import org.apache.pinot.common.systemtable.SystemTableProviderContext;
+import org.apache.pinot.common.systemtable.datasource.InMemorySystemTableSegment;
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Basic system table exposing table-level metadata populated from the broker {@link TableCache}.
+ */
+@SystemTable
+public final class TablesSystemTableProvider implements SystemTableProvider {
+  private static final Logger LOGGER = LoggerFactory.getLogger(TablesSystemTableProvider.class);
+  public static final String TABLE_NAME = "system.tables";
+  private static final String SIZE_CACHE_TTL_MS_PROPERTY = "pinot.systemtable.tables.sizeCacheTtlMs";
+  private static final long DEFAULT_SIZE_CACHE_TTL_MS = Duration.ofMinutes(1).toMillis();
+
+  private static final String CONTROLLER_TIMEOUT_MS_PROPERTY = "pinot.systemtable.tables.controllerTimeoutMs";
+  private static final long DEFAULT_CONTROLLER_TIMEOUT_MS = Duration.ofSeconds(5).toMillis();
+
+  private static final long SIZE_FETCH_FAILURE_WARN_INTERVAL_MS = Duration.ofHours(1).toMillis();
+
+  private static final Schema SCHEMA = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
+      .addSingleValueDimension("tableName", FieldSpec.DataType.STRING)
+      .addSingleValueDimension("type", FieldSpec.DataType.STRING)
+      .addSingleValueDimension("status", FieldSpec.DataType.STRING)
+      .addSingleValueDimension("segments", FieldSpec.DataType.INT)
+      .addSingleValueDimension("totalDocs", FieldSpec.DataType.LONG)
+      .addMetric("reportedSizeBytes", FieldSpec.DataType.LONG)
+      .addMetric("estimatedSizeBytes", FieldSpec.DataType.LONG)
+      .addSingleValueDimension("brokerTenant", FieldSpec.DataType.STRING)
+      .addSingleValueDimension("serverTenant", FieldSpec.DataType.STRING)
+      .addSingleValueDimension("replicas", FieldSpec.DataType.INT)
+      .addSingleValueDimension("tableConfig", FieldSpec.DataType.STRING)
+      .build();
+
+  @Nullable
+  private TableCache _tableCache;
+  @Nullable
+  private HelixAdmin _helixAdmin;
+  @Nullable
+  private String _clusterName;
+  @Nullable
+  private Function<String, TableSize> _tableSizeFetcherOverride;
+  private List<String> _configuredControllerUrls = List.of();
+  private long _sizeCacheTtlMs = DEFAULT_SIZE_CACHE_TTL_MS;
+  private long _controllerTimeoutMs = DEFAULT_CONTROLLER_TIMEOUT_MS;
+  private final Map<String, CachedSize> _sizeCache = new ConcurrentHashMap<>();
+  private final Map<String, PinotAdminClient> _adminClientCache = new ConcurrentHashMap<>();
+  private final AtomicLong _lastSizeFetchFailureWarnLogMs = new AtomicLong();
+
+  public TablesSystemTableProvider() {
+  }
+
+  @Override
+  public void init(SystemTableProviderContext context) {
+    _tableCache = context.getTableCache();
+    _helixAdmin = context.getHelixAdmin();
+    _clusterName = context.getClusterName();
+    if (context.getConfig() != null) {
+      _sizeCacheTtlMs = context.getConfig().getProperty(SIZE_CACHE_TTL_MS_PROPERTY, DEFAULT_SIZE_CACHE_TTL_MS);
+      _controllerTimeoutMs =
+          context.getConfig().getProperty(CONTROLLER_TIMEOUT_MS_PROPERTY, DEFAULT_CONTROLLER_TIMEOUT_MS);
+    }
+  }
+
+  /**
+   * Package-private constructor for testing with overrides.
+   */
+  TablesSystemTableProvider(TableCache tableCache, @Nullable HelixAdmin helixAdmin, @Nullable String clusterName,
+      @Nullable Function<String, TableSize> tableSizeFetcherOverride, @Nullable List<String> controllerUrls) {
+    _tableCache = tableCache;
+    _helixAdmin = helixAdmin;
+    _clusterName = clusterName;
+    _tableSizeFetcherOverride = tableSizeFetcherOverride;
+    _configuredControllerUrls = controllerUrls != null ? new ArrayList<>(controllerUrls) : List.of();
+  }
+
+  @Override
+  public String getTableName() {
+    return TABLE_NAME;
+  }
+
+  @Override
+  public Schema getSchema() {
+    return SCHEMA;
+  }
+
+  @Override
+  public TableConfig getTableConfig() {
+    return new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).build();
+  }
+
+  @Override
+  public void close()
+      throws Exception {
+    for (Map.Entry<String, PinotAdminClient> entry : _adminClientCache.entrySet()) {
+      try {
+        entry.getValue().close();
+      } catch (Exception e) {
+        LOGGER.debug("Failed to close admin client for {}: {}", entry.getKey(), e.toString());
+      }
+    }
+    _adminClientCache.clear();
+  }
+
+  @Override
+  public IndexSegment getDataSource() {
+    if (_tableCache == null) {
+      return new InMemorySystemTableSegment(TABLE_NAME, SCHEMA, 0, Collections.emptyMap());
+    }
+
+    Set<String> tableNamesWithType = new LinkedHashSet<>();
+    for (String tableName : _tableCache.getTableNameMap().values()) {
+      if (TableNameBuilder.getTableTypeFromTableName(tableName) != null) {
+        tableNamesWithType.add(tableName);
+      }
+    }
+    List<String> sortedTableNames = new ArrayList<>(tableNamesWithType);
+    sortedTableNames.sort(Comparator.naturalOrder());
+
+    List<String> controllerBaseUrls = getControllerBaseUrls();
+    Function<String, TableSize> sizeFetcher = getSizeFetcher();
+    class TableRow {
+      final String _tableNameWithType;
+      final TableType _tableType;
+      final String _rawTableName;
+      final @Nullable TableConfig _tableConfig;
+      private volatile @Nullable String _tableConfigJson;
+      private volatile @Nullable TableSize _tableSize;
+      private volatile boolean _tableSizeFetched;
+
+      private TableRow(String tableNameWithType, TableType tableType, String rawTableName,
+          @Nullable TableConfig tableConfig) {
+        _tableNameWithType = tableNameWithType;
+        _tableType = tableType;
+        _rawTableName = rawTableName;
+        _tableConfig = tableConfig;
+      }
+
+      @Nullable
+      private TableSize getTableSize() {
+        if (_tableSizeFetched) {
+          return _tableSize;
+        }
+        synchronized (this) {
+          if (_tableSizeFetched) {
+            return _tableSize;
+          }
+          _tableSize = fetchTableSize(_tableNameWithType, sizeFetcher, controllerBaseUrls);
+          _tableSizeFetched = true;
+          return _tableSize;
+        }
+      }
+
+      private String getStatus() {
+        if (_tableConfig != null) {
+          return "ONLINE";
+        }
+        TableSize sizeFromController = getTableSize();
+        int segments = sizeFromController != null ? getSegmentCount(sizeFromController, _tableType) : 0;
+        return segments > 0 ? "ONLINE" : "UNKNOWN";
+      }
+
+      private int getSegments() {
+        TableSize sizeFromController = getTableSize();
+        return sizeFromController != null ? getSegmentCount(sizeFromController, _tableType) : 0;
+      }
+
+      private long getTotalDocs() {
+        TableSize sizeFromController = getTableSize();
+        return sizeFromController != null ? getTotalDocsFromSize(sizeFromController, _tableType) : 0L;
+      }
+
+      private long getReportedSize() {
+        TableSize sizeFromController = getTableSize();
+        if (sizeFromController == null || sizeFromController._reportedSizeInBytes < 0) {
+          return 0L;
+        }
+        return sizeFromController._reportedSizeInBytes;
+      }
+
+      private long getEstimatedSize() {
+        TableSize sizeFromController = getTableSize();
+        if (sizeFromController == null || sizeFromController._estimatedSizeInBytes < 0) {
+          return 0L;
+        }
+        return sizeFromController._estimatedSizeInBytes;
+      }
+
+      private String getBrokerTenant() {
+        if (_tableConfig != null && _tableConfig.getTenantConfig() != null) {
+          String tenant = _tableConfig.getTenantConfig().getBroker();
+          return tenant != null ? tenant : "";
+        }
+        return "";
+      }
+
+      private String getServerTenant() {
+        if (_tableConfig != null && _tableConfig.getTenantConfig() != null) {
+          String tenant = _tableConfig.getTenantConfig().getServer();
+          return tenant != null ? tenant : "";
+        }
+        return "";
+      }
+
+      private int getReplicas() {
+        if (_tableConfig != null && _tableConfig.getValidationConfig() != null) {
+          Integer replicationNumber = _tableConfig.getValidationConfig().getReplicationNumber();
+          if (replicationNumber != null) {
+            return replicationNumber;
+          }
+        }
+        return 0;
+      }
+
+      private String getTableConfigJson() {
+        String cached = _tableConfigJson;
+        if (cached != null) {
+          return cached;
+        }
+        synchronized (this) {
+          cached = _tableConfigJson;
+          if (cached != null) {
+            return cached;
+          }
+          cached = "";
+          if (_tableConfig != null) {
+            try {
+              cached = JsonUtils.objectToString(_tableConfig);
+            } catch (Exception e) {
+              LOGGER.warn("Failed to serialize table config for {}: {}", _tableNameWithType, e.toString());
+              cached = _tableConfig.toString();
+            }
+          }
+          _tableConfigJson = cached;
+          return cached;
+        }
+      }
+    }
+
+    List<TableRow> tableRows = new ArrayList<>(sortedTableNames.size());
+    for (String tableNameWithType : sortedTableNames) {
+      TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableNameWithType);
+      if (tableType == null) {
+        continue;
+      }
+      String rawTableName = TableNameBuilder.extractRawTableName(tableNameWithType);
+      TableConfig tableConfig = _tableCache.getTableConfig(tableNameWithType);
+      tableRows.add(new TableRow(tableNameWithType, tableType, rawTableName, tableConfig));
+    }
+
+    Map<String, IntFunction<Object>> valueProviders = new java.util.HashMap<>();
+    valueProviders.put("tableName", docId -> tableRows.get(docId)._rawTableName);
+    valueProviders.put("type", docId -> tableRows.get(docId)._tableType.name());
+    valueProviders.put("status", docId -> tableRows.get(docId).getStatus());
+    valueProviders.put("segments", docId -> tableRows.get(docId).getSegments());
+    valueProviders.put("totalDocs", docId -> tableRows.get(docId).getTotalDocs());
+    valueProviders.put("reportedSizeBytes", docId -> tableRows.get(docId).getReportedSize());
+    valueProviders.put("estimatedSizeBytes", docId -> tableRows.get(docId).getEstimatedSize());
+    valueProviders.put("brokerTenant", docId -> tableRows.get(docId).getBrokerTenant());
+    valueProviders.put("serverTenant", docId -> tableRows.get(docId).getServerTenant());
+    valueProviders.put("replicas", docId -> tableRows.get(docId).getReplicas());
+    valueProviders.put("tableConfig", docId -> tableRows.get(docId).getTableConfigJson());
+
+    return new InMemorySystemTableSegment(TABLE_NAME, SCHEMA, tableRows.size(), valueProviders);
+  }
+
+  @Nullable
+  private TableSize fetchTableSize(String tableNameWithType,
+      @Nullable Function<String, TableSize> fetcher, List<String> controllerBaseUrls) {
+    boolean cacheEnabled = _sizeCacheTtlMs > 0;
+    TableSize cached = cacheEnabled ? getCachedSize(tableNameWithType) : null;
+    if (cached != null) {
+      return cached;
+    }
+    if (fetcher != null) {
+      try {
+        TableSize fetched = fetcher.apply(tableNameWithType);
+        if (fetched != null) {
+          if (cacheEnabled) {
+            cacheSize(tableNameWithType, fetched);
+          }
+          return fetched;
+        }
+      } catch (Exception e) {
+        LOGGER.warn("Table size fetcher failed for {}: {}", tableNameWithType, e.toString());
+      }
+    }
+    String rawTableName = TableNameBuilder.extractRawTableName(tableNameWithType);
+    TableSize size = fetchTableSizeForName(controllerBaseUrls, rawTableName);
+    if (size == null) {
+      size = fetchTableSizeForName(controllerBaseUrls, tableNameWithType);
+      if (size == null) {
+        if (rawTableName.equals(tableNameWithType)) {
+          logSizeFetchFailure("{}: failed to fetch size for {} from controllers {}",
+              TABLE_NAME, tableNameWithType, controllerBaseUrls);
+        } else {
+          logSizeFetchFailure("{}: failed to fetch size for {} from controllers {} "
+                  + "(tried raw table name '{}' and table name with type '{}')",
+              TABLE_NAME, tableNameWithType, controllerBaseUrls, rawTableName, tableNameWithType);
+        }
+      }
+    }
+    if (size != null && cacheEnabled) {
+      cacheSize(tableNameWithType, size);
+    }
+    return size;
+  }
+
+  @Nullable
+  private TableSize fetchTableSizeForName(List<String> controllerBaseUrls, String tableName) {
+    for (String baseUrl : controllerBaseUrls) {
+      try {
+        PinotAdminClient adminClient = getOrCreateAdminClient(baseUrl);
+        if (adminClient == null) {
+          continue;
+        }
+
+        JsonNode sizeNode = adminClient.getTableSize(tableName, true, false);
+
+        if (sizeNode == null) {
+          continue;
+        }
+
+        TableSize parsed = JsonUtils.stringToObject(sizeNode.toString(), TableSize.class);
+        LOGGER.debug("{}: controller size response for {} via {} -> segments offline={}, realtime={}, "
+                + "reportedSize={}, estimatedSize={}", TABLE_NAME, tableName, baseUrl,
+            parsed._offlineSegments != null && parsed._offlineSegments._segments != null
+                ? parsed._offlineSegments._segments.size() : 0,
+            parsed._realtimeSegments != null && parsed._realtimeSegments._segments != null
+                ? parsed._realtimeSegments._segments.size() : 0,
+            parsed._reportedSizeInBytes, parsed._estimatedSizeInBytes);
+        return parsed;
+      } catch (Exception e) {
+        logSizeFetchFailure("{}: error fetching table size for {} via {} using admin client", TABLE_NAME, tableName,
+            baseUrl, e);
+      }
+    }
+    return null;
+  }
+
+  private List<String> getControllerBaseUrls() {
+    Set<String> urls = new LinkedHashSet<>();
+    if (_helixAdmin != null) {
+      for (String controller : discoverControllersFromHelix()) {
+        String normalized = normalizeControllerUrl(controller);
+        if (normalized != null) {
+          urls.add(normalized);
+        }
+      }
+    }
+    for (String url : _configuredControllerUrls) {
+      String normalized = normalizeControllerUrl(url);
+      if (normalized != null) {
+        urls.add(normalized);
+      }
+    }
+    return new ArrayList<>(urls);
+  }
+
+  private int getSegmentCount(TableSize sizeFromController, TableType tableType) {
+    if (tableType == TableType.OFFLINE && sizeFromController._offlineSegments != null
+        && sizeFromController._offlineSegments._segments != null) {
+      return sizeFromController._offlineSegments._segments.size();
+    }
+    if (tableType == TableType.REALTIME && sizeFromController._realtimeSegments != null
+        && sizeFromController._realtimeSegments._segments != null) {
+      return sizeFromController._realtimeSegments._segments.size();
+    }
+    return 0;
+  }
+
+  private long getTotalDocsFromSize(TableSize sizeFromController, TableType tableType) {
+    if (tableType == TableType.OFFLINE && sizeFromController._offlineSegments != null
+        && sizeFromController._offlineSegments._segments != null) {
+      return sizeFromController._offlineSegments._segments.values().stream()
+          .mapToLong(segmentSize -> segmentSize._totalDocs).sum();
+    }
+    if (tableType == TableType.REALTIME && sizeFromController._realtimeSegments != null
+        && sizeFromController._realtimeSegments._segments != null) {
+      return sizeFromController._realtimeSegments._segments.values().stream()
+          .mapToLong(segmentSize -> segmentSize._totalDocs).sum();
+    }
+    return 0;
+  }
+
+  @Nullable
+  private Function<String, TableSize> getSizeFetcher() {
+    if (_tableSizeFetcherOverride != null) {
+      return _tableSizeFetcherOverride;
+    }
+    return null;
+  }
+
+  private List<String> discoverControllersFromHelix() {
+    if (_helixAdmin == null) {
+      return List.of();
+    }
+    if (_clusterName == null) {
+      LOGGER.warn("Cannot discover controllers without cluster name");
+      return List.of();
+    }
+    return HelixControllerUtils.discoverControllerBaseUrls(_helixAdmin, _clusterName, LOGGER);
+  }
+
+  @Nullable
+  private PinotAdminClient getOrCreateAdminClient(String controllerBaseUrl) {
+    String normalized = normalizeControllerUrl(controllerBaseUrl);
+    if (normalized == null) {
+      return null;
+    }
+    return _adminClientCache.computeIfAbsent(normalized, controller -> {
+      try {
+        String controllerAddress = stripScheme(controller);
+        Properties properties = new Properties();
+        properties.setProperty(PinotAdminTransport.PINOT_ADMIN_REQUEST_TIMEOUT_MS_PROPERTY_KEY,
+            String.valueOf(_controllerTimeoutMs));
+        properties.setProperty(PinotAdminTransport.PINOT_ADMIN_SCHEME_PROPERTY_KEY,
+            controller.startsWith("https://") ? "https" : "http");
+        return new PinotAdminClient(controllerAddress, properties);
+      } catch (Exception e) {
+        LOGGER.warn("Failed to create admin client for {}: {}", controller, e.toString());
+        return null;
+      }
+    });
+  }
+
+  private static String normalizeControllerUrl(@Nullable String controllerUrl) {
+    if (controllerUrl == null || controllerUrl.isEmpty()) {
+      return null;
+    }
+    String normalized = controllerUrl;
+    if (!normalized.startsWith("http://") && !normalized.startsWith("https://")) {
+      normalized = "http://" + normalized;
+    }
+    if (normalized.endsWith("/")) {
+      normalized = normalized.substring(0, normalized.length() - 1);
+    }
+    return normalized;
+  }
+
+  private static String stripScheme(String controllerUrl) {
+    if (controllerUrl.startsWith("http://")) {
+      return controllerUrl.substring("http://".length());
+    }
+    if (controllerUrl.startsWith("https://")) {
+      return controllerUrl.substring("https://".length());
+    }
+    return controllerUrl;
+  }
+
+  /**
+   * Minimal shape of controller table size response.
+   */
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public static final class TableSize {
+    @JsonProperty("reportedSizeInBytes")
+    public long _reportedSizeInBytes = -1;
+
+    @JsonProperty("estimatedSizeInBytes")
+    public long _estimatedSizeInBytes = -1;
+
+    @JsonProperty("offlineSegments")
+    public TableSubType _offlineSegments;
+
+    @JsonProperty("realtimeSegments")
+    public TableSubType _realtimeSegments;
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public static final class TableSubType {
+    @JsonProperty("segments")
+    public Map<String, SegmentSize> _segments;
+  }
+
+  @JsonIgnoreProperties(ignoreUnknown = true)
+  public static final class SegmentSize {
+    @JsonProperty("totalDocs")
+    public long _totalDocs = 0;
+  }
+
+  private void logSizeFetchFailure(String message, Object... args) {
+    long nowMs = System.currentTimeMillis();
+    long lastWarnLogMs = _lastSizeFetchFailureWarnLogMs.get();
+    if (nowMs - lastWarnLogMs >= SIZE_FETCH_FAILURE_WARN_INTERVAL_MS
+        && _lastSizeFetchFailureWarnLogMs.compareAndSet(lastWarnLogMs, nowMs)) {
+      LOGGER.warn(message, args);
+    } else {
+      LOGGER.debug(message, args);
+    }
+  }
+
+  @Nullable
+  private TableSize getCachedSize(String tableNameWithType) {
+    if (_sizeCacheTtlMs <= 0) {
+      return null;
+    }
+    CachedSize cached = _sizeCache.get(tableNameWithType);
+    if (cached == null) {
+      return null;
+    }
+    if (System.currentTimeMillis() - cached._timestampMs > _sizeCacheTtlMs) {
+      _sizeCache.remove(tableNameWithType, cached);
+      return null;
+    }
+    return cached._tableSize;
+  }
+
+  private void cacheSize(String tableNameWithType, TableSize size) {
+    if (_sizeCacheTtlMs <= 0) {
+      return;
+    }
+    _sizeCache.put(tableNameWithType, new CachedSize(size, System.currentTimeMillis()));
+  }
+
+  private static final class CachedSize {
+    private final TableSize _tableSize;
+    private final long _timestampMs;
+
+    CachedSize(TableSize tableSize, long timestampMs) {
+      _tableSize = tableSize;
+      _timestampMs = timestampMs;
+    }
+  }
+}

--- a/pinot-plugins/pinot-system-table/src/main/java/org/apache/pinot/systemtable/provider/TablesSystemTableProvider.java
+++ b/pinot-plugins/pinot-system-table/src/main/java/org/apache/pinot/systemtable/provider/TablesSystemTableProvider.java
@@ -48,6 +48,7 @@ import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
@@ -111,6 +112,10 @@ public final class TablesSystemTableProvider implements SystemTableProvider {
       _sizeCacheTtlMs = context.getConfig().getProperty(SIZE_CACHE_TTL_MS_PROPERTY, DEFAULT_SIZE_CACHE_TTL_MS);
       _controllerTimeoutMs =
           context.getConfig().getProperty(CONTROLLER_TIMEOUT_MS_PROPERTY, DEFAULT_CONTROLLER_TIMEOUT_MS);
+      String controllerUrl = context.getConfig().getProperty(CommonConstants.Broker.CONTROLLER_URL);
+      if (controllerUrl != null && !controllerUrl.isEmpty()) {
+        _configuredControllerUrls = List.of(controllerUrl.split(","));
+      }
     }
   }
 
@@ -374,6 +379,7 @@ public final class TablesSystemTableProvider implements SystemTableProvider {
         }
 
         TableSize parsed = JsonUtils.stringToObject(sizeNode.toString(), TableSize.class);
+        enrichWithTotalDocs(parsed, tableName, adminClient);
         LOGGER.debug("{}: controller size response for {} via {} -> segments offline={}, realtime={}, "
                 + "reportedSize={}, estimatedSize={}", TABLE_NAME, tableName, baseUrl,
             parsed._offlineSegments != null && parsed._offlineSegments._segments != null
@@ -388,6 +394,32 @@ public final class TablesSystemTableProvider implements SystemTableProvider {
       }
     }
     return null;
+  }
+
+  private void enrichWithTotalDocs(TableSize tableSize, String tableName, PinotAdminClient adminClient) {
+    String rawName = TableNameBuilder.extractRawTableName(tableName);
+    enrichSubTypeWithTotalDocs(tableSize._offlineSegments,
+        TableNameBuilder.OFFLINE.tableNameWithType(rawName), adminClient);
+    enrichSubTypeWithTotalDocs(tableSize._realtimeSegments,
+        TableNameBuilder.REALTIME.tableNameWithType(rawName), adminClient);
+  }
+
+  private void enrichSubTypeWithTotalDocs(@Nullable TableSubType subType, String tableNameWithType,
+      PinotAdminClient adminClient) {
+    if (subType == null || subType._segments == null || subType._segments.isEmpty()) {
+      return;
+    }
+    for (Map.Entry<String, SegmentSize> entry : subType._segments.entrySet()) {
+      try {
+        JsonNode metadata = adminClient.getSegmentApiClient().getSegmentMetadata(tableNameWithType, entry.getKey());
+        if (metadata != null && metadata.has(CommonConstants.Segment.TOTAL_DOCS)) {
+          entry.getValue()._totalDocs = metadata.path(CommonConstants.Segment.TOTAL_DOCS).asLong(0);
+        }
+      } catch (Exception e) {
+        LOGGER.debug("{}: failed to fetch segment metadata for {}/{}: {}", TABLE_NAME, tableNameWithType,
+            entry.getKey(), e.toString());
+      }
+    }
   }
 
   private List<String> getControllerBaseUrls() {

--- a/pinot-plugins/pinot-system-table/src/test/java/org/apache/pinot/systemtable/provider/BrokerRuntimeSystemTableProviderTest.java
+++ b/pinot-plugins/pinot-system-table/src/test/java/org/apache/pinot/systemtable/provider/BrokerRuntimeSystemTableProviderTest.java
@@ -1,0 +1,60 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.systemtable.provider;
+
+import java.util.Map;
+import org.apache.pinot.common.systemtable.SystemTableProviderContext;
+import org.apache.pinot.common.version.PinotVersion;
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+
+public class BrokerRuntimeSystemTableProviderTest {
+
+  @Test
+  public void testBrokerRuntimeTableProducesOneRow() {
+    PinotConfiguration config = new PinotConfiguration(Map.of(
+        CommonConstants.Broker.CONFIG_OF_BROKER_ID, "Broker_testHost_1234",
+        CommonConstants.Broker.CONFIG_OF_BROKER_HOSTNAME, "testHost",
+        CommonConstants.Helix.KEY_OF_BROKER_QUERY_PORT, "1234"));
+
+    BrokerRuntimeSystemTableProvider provider = new BrokerRuntimeSystemTableProvider();
+    provider.init(new SystemTableProviderContext(null, null, null, config));
+    assertEquals(provider.getExecutionMode(), BrokerRuntimeSystemTableProvider.ExecutionMode.BROKER_SCATTER_GATHER);
+
+    IndexSegment segment = provider.getDataSource();
+    try {
+      assertEquals(segment.getSegmentMetadata().getTotalDocs(), 1);
+      assertEquals(segment.getValue(0, "brokerId"), "Broker_testHost_1234");
+      assertEquals(segment.getValue(0, "host"), "testHost");
+      assertEquals(segment.getValue(0, "port"), 1234);
+      assertTrue((long) segment.getValue(0, "startTimeMs") > 0);
+      assertTrue((long) segment.getValue(0, "uptimeMs") >= 0);
+      assertTrue((long) segment.getValue(0, "timestampMs") > 0);
+      assertEquals(segment.getValue(0, "pinotVersion"), PinotVersion.VERSION);
+    } finally {
+      segment.destroy();
+    }
+  }
+}

--- a/pinot-plugins/pinot-system-table/src/test/java/org/apache/pinot/systemtable/provider/TablesSystemTableProviderTest.java
+++ b/pinot-plugins/pinot-system-table/src/test/java/org/apache/pinot/systemtable/provider/TablesSystemTableProviderTest.java
@@ -1,0 +1,125 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.systemtable.provider;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+import org.apache.pinot.common.config.provider.TableCache;
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+
+public class TablesSystemTableProviderTest {
+
+  @Test
+  public void testAdminFetcherPopulatesSizes() {
+    TableCache tableCache = mock(TableCache.class);
+    when(tableCache.getTableNameMap()).thenReturn(Map.of("mytable_offline", "mytable_OFFLINE"));
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("mytable")
+        .setBrokerTenant("defaultTenant").setServerTenant("defaultTenant").setNumReplicas(1).build();
+    when(tableCache.getTableConfig("mytable_OFFLINE")).thenReturn(tableConfig);
+
+    TablesSystemTableProvider.TableSubType subType = new TablesSystemTableProvider.TableSubType();
+    TablesSystemTableProvider.SegmentSize seg1 = new TablesSystemTableProvider.SegmentSize();
+    seg1._totalDocs = 10;
+    TablesSystemTableProvider.SegmentSize seg2 = new TablesSystemTableProvider.SegmentSize();
+    seg2._totalDocs = 20;
+    subType._segments = Map.of("seg1", seg1, "seg2", seg2);
+    TablesSystemTableProvider.TableSize tableSize = new TablesSystemTableProvider.TableSize();
+    tableSize._reportedSizeInBytes = 1234L;
+    tableSize._estimatedSizeInBytes = 2000L;
+    tableSize._offlineSegments = subType;
+
+    Function<String, TablesSystemTableProvider.TableSize> fetcher = tableName -> tableSize;
+
+    TablesSystemTableProvider provider =
+        new TablesSystemTableProvider(tableCache, null, null, fetcher, null);
+    IndexSegment segment = provider.getDataSource();
+    try {
+      assertEquals(segment.getSegmentMetadata().getTotalDocs(), 1);
+      assertEquals(segment.getValue(0, "tableName"), "mytable");
+      assertEquals(segment.getValue(0, "type"), "OFFLINE");
+      assertEquals(segment.getValue(0, "status"), "ONLINE");
+      assertEquals(segment.getValue(0, "segments"), 2);
+      assertEquals(segment.getValue(0, "totalDocs"), 30L);
+      assertEquals(segment.getValue(0, "reportedSizeBytes"), 1234L);
+      assertEquals(segment.getValue(0, "estimatedSizeBytes"), 2000L);
+      assertEquals(segment.getValue(0, "brokerTenant"), "defaultTenant");
+      assertEquals(segment.getValue(0, "serverTenant"), "defaultTenant");
+      assertEquals(segment.getValue(0, "replicas"), 1);
+      assertTrue(((String) segment.getValue(0, "tableConfig")).contains("mytable"));
+    } finally {
+      segment.destroy();
+    }
+  }
+
+  @Test
+  public void testSizeCacheAvoidsRepeatedFetcherCalls() {
+    TableCache tableCache = mock(TableCache.class);
+    when(tableCache.getTableNameMap()).thenReturn(Map.of("mytable_offline", "mytable_OFFLINE"));
+    when(tableCache.getTableConfig("mytable_OFFLINE"))
+        .thenReturn(new TableConfigBuilder(TableType.OFFLINE).setTableName("mytable").build());
+
+    TablesSystemTableProvider.TableSize tableSize = tableSizeWithOfflineSegments(Map.of("seg1", 10L));
+    AtomicInteger calls = new AtomicInteger();
+    Function<String, TablesSystemTableProvider.TableSize> fetcher = tableName -> {
+      calls.incrementAndGet();
+      return tableSize;
+    };
+
+    TablesSystemTableProvider provider = new TablesSystemTableProvider(tableCache, null, null, fetcher, null);
+    IndexSegment segment1 = provider.getDataSource();
+    try {
+      segment1.getValue(0, "segments");
+    } finally {
+      segment1.destroy();
+    }
+
+    IndexSegment segment2 = provider.getDataSource();
+    try {
+      segment2.getValue(0, "segments");
+    } finally {
+      segment2.destroy();
+    }
+    assertEquals(calls.get(), 1);
+  }
+
+  private static TablesSystemTableProvider.TableSize tableSizeWithOfflineSegments(Map<String, Long> segmentDocs) {
+    TablesSystemTableProvider.TableSubType subType = new TablesSystemTableProvider.TableSubType();
+    Map<String, TablesSystemTableProvider.SegmentSize> segments = new java.util.HashMap<>();
+    for (Map.Entry<String, Long> entry : segmentDocs.entrySet()) {
+      TablesSystemTableProvider.SegmentSize seg = new TablesSystemTableProvider.SegmentSize();
+      seg._totalDocs = entry.getValue();
+      segments.put(entry.getKey(), seg);
+    }
+    subType._segments = segments;
+    TablesSystemTableProvider.TableSize tableSize = new TablesSystemTableProvider.TableSize();
+    tableSize._offlineSegments = subType;
+    return tableSize;
+  }
+}

--- a/pinot-plugins/pom.xml
+++ b/pinot-plugins/pom.xml
@@ -44,6 +44,7 @@
     <module>pinot-stream-ingestion</module>
     <module>pinot-minion-tasks</module>
     <module>pinot-metrics</module>
+    <module>pinot-system-table</module>
     <module>pinot-segment-writer</module>
     <module>pinot-segment-uploader</module>
     <module>pinot-environment</module>

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/query/QueryExecutionContext.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/query/QueryExecutionContext.java
@@ -46,7 +46,8 @@ public class QueryExecutionContext {
   public enum QueryType {
     SSE,  // Single-stage engine
     MSE,  // Multi-stage engine
-    TSE   // Time-series engine
+    TSE,  // Time-series engine
+    STE   // System table engine (broker-local)
   }
 
   private final QueryType _queryType;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -405,6 +405,11 @@ public class CommonConstants {
         Math.max(1, Math.min(10, Runtime.getRuntime().availableProcessors() / 2));
     // Same logic as CombineOperatorUtils
 
+    // Config for number of threads to use for system table query execution on the broker.
+    public static final String CONFIG_OF_SYSTEM_TABLE_EXECUTOR_POOL_SIZE =
+        "pinot.broker.systemtable.executor.pool.size";
+    public static final int DEFAULT_SYSTEM_TABLE_EXECUTOR_POOL_SIZE = 2;
+
     // Config for Jersey ThreadPoolExecutorProvider.
     // By default, Jersey uses the default unbounded thread pool to process queries.
     // By enabling it, BrokerManagedAsyncExecutorProvider will be used to create a bounded thread pool.

--- a/pinot-tools/pom.xml
+++ b/pinot-tools/pom.xml
@@ -194,6 +194,10 @@
       <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-java-client</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-system-table</artifactId>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/LaunchBackfillIngestionJobCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/LaunchBackfillIngestionJobCommand.java
@@ -159,7 +159,7 @@ public class LaunchBackfillIngestionJobCommand extends LaunchDataIngestionJobCom
   public Properties getTransportProperties(SegmentGenerationJobSpec spec) {
     Properties transportProperties = new Properties();
     URI controllerURI = URI.create(spec.getPinotClusterSpecs()[0].getControllerURI());
-    transportProperties.setProperty(PinotAdminTransport.ADMIN_TRANSPORT_SCHEME, controllerURI.getScheme());
+    transportProperties.setProperty(PinotAdminTransport.PINOT_ADMIN_SCHEME_PROPERTY_KEY, controllerURI.getScheme());
     return transportProperties;
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -601,6 +601,11 @@
       </dependency>
       <dependency>
         <groupId>org.apache.pinot</groupId>
+        <artifactId>pinot-system-table</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.pinot</groupId>
         <artifactId>pinot-jdbc-client</artifactId>
         <version>${project.version}</version>
       </dependency>


### PR DESCRIPTION
### Summary
Add first-class support for querying system tables through the broker, with an SPI/registry for providers and initial built-in tables (`system.tables`, `system.instances`, `system.broker_runtime`).

### Motivation
Today, cluster/table/instance introspection largely requires controller APIs. System tables provide a SQL-native way to inspect Pinot metadata and operational stats.

### Key Changes

#### Core SPI & Registry (`pinot-common`)
- `SystemTableProvider` SPI with `init(SystemTableProviderContext)` lifecycle method — providers declare their table name, schema, config, execution mode, and return an `IndexSegment` for query execution.
- `SystemTableProviderContext` bundles all broker-provided dependencies (`TableCache`, `HelixAdmin`, `clusterName`, `PinotConfiguration`) so providers pick what they need without requiring specific constructor signatures. Forward-compatible: new dependencies can be added without breaking existing providers.
- `@SystemTable` annotation + `SystemTableRegistry` for zero-config auto-discovery via classpath scanning (follows the `@ScalarFunction` pattern). Registry validates `system.` prefix on registration.
- `InMemorySystemTableSegment` — lightweight in-memory `IndexSegment` implementation backed by per-column value functions, enabling system tables to plug directly into the v1 query engine.

#### Broker Wiring
- `SystemTableQueryDetector` — Calcite AST traversal (not string matching) to detect `system.*` table references, resilient to string literals, comments, and formatting.
- `SystemTableBrokerRequestHandler` — executes system table queries using `InstancePlanMakerImplV2` + `BrokerReduceService`, supporting GROUP BY, ORDER BY, aggregations, LIMIT/OFFSET out of the box.
- Two execution modes: `BROKER_LOCAL` (execute on receiving broker) and `BROKER_SCATTER_GATHER` (fan out to all live brokers for tables where each broker owns a shard, e.g. query logs).
- Scatter-gather with timeout control (`Future.get(remainingMs, MILLISECONDS)`) to prevent query hangs.
- `BrokerRequestHandlerDelegate` auto-routes system table queries to the v1 engine regardless of `useMultistageEngine` setting (no error returned when MSE is enabled).
- `DatabaseUtils.translateTableName` bypasses database-prefix validation for `system.*` tables so they can be queried regardless of database header.
- New broker config: `pinot.broker.systemtable.executor.pool.size` (default: 2).

#### Plugin Module (`pinot-plugins/pinot-system-table`)
- `system.tables` — table metadata from broker `TableCache` + controller size API (segments/totalDocs/reportedSize/estimatedSize), with TTL caching and configurable controller timeout.
- `system.instances` — instance metadata/state/tags from controller APIs.
- `system.broker_runtime` — broker-local JVM/runtime metrics (scatter-gather mode), including heap usage, thread counts, uptime, Pinot version.
- All provider config uses `PinotConfiguration` (not JVM system properties), configurable via standard Pinot config.

#### Extensibility
Creating a new system table in a separate plugin module:
```java
@SystemTable
public class MyCustomSystemTable implements SystemTableProvider {
    private TableCache _tableCache;

    @Override
    public void init(SystemTableProviderContext context) {
        _tableCache = context.getTableCache();
    }

    @Override
    public String getTableName() { return "system.my_custom"; }

    @Override
    public Schema getSchema() { return MY_SCHEMA; }

    @Override
    public TableConfig getTableConfig() { return MY_CONFIG; }

    @Override
    public IndexSegment getDataSource() {
        return new InMemorySystemTableSegment("system.my_custom", MY_SCHEMA, numDocs, valueProviders);
    }
}
```
- `InMemorySystemTableSegment` lives in `pinot-common` so any plugin can use it without depending on the system table plugin.
- `SystemTableProvider` SPI + `SystemTableProviderContext` are in `pinot-common`.
- Auto-discovered via `@SystemTable` annotation on classes in `*.systemtable.*` packages.

#### Java Client Extensions
- `PinotAdminClient#getTableSize` / `PinotTableAdminClient#getTableSize`.
- URL-encode path segments for segment-related endpoints.

### Limitations
- System tables are only supported in the single-stage engine (queries auto-route to v1 even when MSE is enabled).
- Joins are not supported for system table queries (single table reference enforced).

### Testing
- Unit tests: `SystemTableQueryDetectorTest`, `SystemTableBrokerRequestHandlerTest`, `SystemTableRegistryTest`, `TablesSystemTableProviderTest`, `BrokerRuntimeSystemTableProviderTest`.
- Integration test: `SystemTableIntegrationTest` validates `system.tables` size/totalDocs fields against controller size + segment metadata.

### Example Queries
```sql
SELECT tableName, type, segments, totalDocs, reportedSizeBytes, estimatedSizeBytes
FROM system.tables ORDER BY tableName

SELECT instanceId, type, state, tags FROM system.instances ORDER BY instanceId

SELECT brokerId, host, port, uptimeMs, jvmHeapUsedBytes, pinotVersion
FROM system.broker_runtime
```

### Release Notes
- New config: `pinot.broker.systemtable.executor.pool.size`
- New plugin: `pinot-system-table`
- New Java client APIs: `PinotAdminClient#getTableSize`, `PinotTableAdminClient#getTableSize`