### PR TITLE
Revert "Use stats cache on error instead of the chained mechanism (#15992)"

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
@@ -165,7 +165,11 @@ public class QueryDispatcher {
     Set<QueryServerInstance> servers = new HashSet<>();
     try {
       submit(requestId, dispatchableSubPlan, timeoutMs, servers, queryOptions);
-      return runReducer(dispatchableSubPlan, queryOptions, _mailboxService);
+      QueryResult result = runReducer(dispatchableSubPlan, queryOptions, _mailboxService);
+      if (result.getProcessingException() != null) {
+        cancel(requestId);
+      }
+      return result;
     } catch (Exception ex) {
       return tryRecover(context.getRequestId(), servers, ex);
     } catch (Throwable e) {

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/dispatch/QueryDispatcherTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/dispatch/QueryDispatcherTest.java
@@ -73,7 +73,8 @@ public class QueryDispatcherTest extends QueryTestSet {
     _queryEnvironment = QueryEnvironmentTestBase.getQueryEnvironment(1, portList.get(0), portList.get(1),
         QueryEnvironmentTestBase.TABLE_SCHEMAS, QueryEnvironmentTestBase.SERVER1_SEGMENTS,
         QueryEnvironmentTestBase.SERVER2_SEGMENTS, null);
-    _queryDispatcher = new QueryDispatcher(Mockito.mock(MailboxService.class), Mockito.mock(FailureDetector.class));
+    _queryDispatcher =
+        new QueryDispatcher(Mockito.mock(MailboxService.class), Mockito.mock(FailureDetector.class), null, true);
   }
 
   @AfterClass
@@ -140,7 +141,7 @@ public class QueryDispatcherTest extends QueryTestSet {
   }
 
   @Test
-  public void testQueryDispatcherCancelWhenQueryReducerThrowsError()
+  public void testQueryDispatcherCancelWhenQueryReducerReturnsError()
       throws Exception {
     String sql = "SELECT * FROM a";
     long requestId = REQUEST_ID_GEN.getAndIncrement();


### PR DESCRIPTION
This PR reverts #15992. We found some installations where the extra cancel call is more expensive than expected, especially because the server code executed during cancellation is quite costly. The long-term plan is to improve the server code, but right now it is safer not to call cancel that often