### PR TITLE
[flaky test ]Increase timeout for distributed locking test in PinotTaskManagerDistributedLockingTest

### DIFF
--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManagerDistributedLockingTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManagerDistributedLockingTest.java
@@ -970,7 +970,7 @@ public class PinotTaskManagerDistributedLockingTest extends ControllerTest {
       startLatch.countDown();
 
       // Wait for completion
-      assertTrue(completionLatch.await(15, TimeUnit.SECONDS), "Tasks should complete within 15 seconds");
+      assertTrue(completionLatch.await(30, TimeUnit.SECONDS), "Tasks should complete within 30 seconds");
 
       executor.shutdownNow();
       assertTrue(executor.awaitTermination(5, TimeUnit.SECONDS), "Executor should terminate");


### PR DESCRIPTION
Per previous log failure:

[6_PinotUnitTestSet2.txt](https://github.com/user-attachments/files/23903796/6_PinotUnitTestSet2.txt)

In testForceReleaseLockDuringTaskExecution each createTask call intentionally sleeps 5s in the controllable generator, the second call waits for the first to start plus an extra 1s+0.5s, and Helix/ZK setup/submission adds a few more seconds (you also see the usual “No instances … leadControllerResource” warnings during boot). On a slower run that all summed to ~18s in your log, so the 15s latch wait fired even though the tasks eventually completed. 