### PR TITLE
Option to use TlsUtils renewable ssl context in HttpsSegmentFetcher

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/HttpsSegmentFetcher.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/HttpsSegmentFetcher.java
@@ -23,6 +23,7 @@ import javax.net.ssl.SSLContext;
 import org.apache.pinot.common.utils.ClientSSLContextGenerator;
 import org.apache.pinot.common.utils.FileUploadDownloadClient;
 import org.apache.pinot.common.utils.http.HttpClientConfig;
+import org.apache.pinot.common.utils.tls.TlsUtils;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.CommonConstants;
 
@@ -69,7 +70,12 @@ public class HttpsSegmentFetcher extends HttpSegmentFetcher {
       }
     }
 
-    SSLContext sslContext = new ClientSSLContextGenerator(sslConfig).generate();
+    SSLContext sslContext;
+    if (config.getProperty(CommonConstants.CONFIG_OF_SSL_USE_RENEWABLE_CONTEXT, false)) {
+      sslContext = TlsUtils.getSslContext();
+    } else {
+      sslContext = new ClientSSLContextGenerator(sslConfig).generate();
+    }
     _httpClient = new FileUploadDownloadClient(HttpClientConfig.newBuilder(config).build(), sslContext);
     super.doInit(config);
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -36,6 +36,7 @@ public class CommonConstants {
   public static final String DEFAULT_FAILURE_DOMAIN = "No such domain";
 
   public static final String PREFIX_OF_SSL_SUBSET = "ssl";
+  public static final String CONFIG_OF_SSL_USE_RENEWABLE_CONTEXT = "ssl.use.renewable.context";
   public static final String HTTP_PROTOCOL = "http";
   public static final String HTTPS_PROTOCOL = "https";
 


### PR DESCRIPTION
### Context

This change moves the [HttpsSegmentFetcher](https://github.com/apache/pinot/blob/master/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/HttpsSegmentFetcher.java#L59) to be able to use the renewable SSL context from `TlsUtils`. We found that peer fetching was not working for our setup which is using `TlsUtils` everywhere else for communication with SSL. The `ClientSSLContextGenerator` relies on [old configuration](https://github.com/apache/pinot/blob/master/pinot-common/src/main/java/org/apache/pinot/common/utils/ClientSSLContextGenerator.java#L46-L47) which we do not use anymore, like `client.pkcs12.file` etc.

### Testing

I tested this explicitly by deleting a realtime segment in our S3 deep store, and deleting the segment from a server directly (`rm -rf ...`) and then resetting the segment. The server was able to successfully fetch the segment from its online peer.

### Alternatives / Questions

1. An alternative would be to change this without an optional config, but I wanted to keep this backwards compatible.
2. Is there a different config I should be re-using here that already covers this? I see some code paths [checking for tls keystore path](https://github.com/apache/pinot/blob/master/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java#L636-L638) and others just relying on a null value like here: https://github.com/apache/pinot/blob/master/pinot-common/src/main/java/org/apache/pinot/common/utils/http/HttpClient.java#L106 . In this case, the change could be just 
`_httpClient = new FileUploadDownloadClient(HttpClientConfig.newBuilder(config).build());`


