### PR TITLE
Rebuild BloomFilter index on segment reload if bloom filter config is updated

### DIFF
--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkBloomFilter.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkBloomFilter.java
@@ -117,7 +117,7 @@ public class BenchmarkBloomFilter {
     List<String> words =
         IntStream.generate(r::nextInt).limit(_cardinality).mapToObj(Integer::toString).collect(Collectors.toList());
 
-    double fpp = Math.max(0.01d, GuavaBloomFilterReaderUtils.computeFPP(_maxSizeInBytes, _cardinality));
+    double fpp = GuavaBloomFilterReaderUtils.computeFPP(0.01d, _maxSizeInBytes, _cardinality);
     BloomFilter<CharSequence> bloomFilter = BloomFilter.create(
         Funnels.stringFunnel(StandardCharsets.UTF_8), _cardinality, fpp);
     words.forEach(bloomFilter::put);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/bloom/BaseGuavaBloomFilterReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/bloom/BaseGuavaBloomFilterReader.java
@@ -38,6 +38,7 @@ public abstract class BaseGuavaBloomFilterReader implements BloomFilterReader {
   private static final int NUM_LONGS_OFFSET = 2;
   private static final int HEADER_SIZE = 6;
 
+  private double _fpp;
   protected final int _numHashFunctions;
   protected final long _numBits;
   protected final PinotDataBuffer _valueBuffer;
@@ -48,6 +49,15 @@ public abstract class BaseGuavaBloomFilterReader implements BloomFilterReader {
     _numHashFunctions = dataBuffer.getByte(NUM_HASH_FUNCTIONS_OFFSET) & 0xFF;
     _numBits = (long) dataBuffer.getInt(NUM_LONGS_OFFSET) * Long.SIZE;
     _valueBuffer = dataBuffer.view(HEADER_SIZE, dataBuffer.size());
+  }
+
+  public void setFPP(double fpp) {
+    _fpp = fpp;
+  }
+
+  @Override
+  public double getFPP() {
+    return _fpp;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/bloom/GuavaBloomFilterReaderUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/bloom/GuavaBloomFilterReaderUtils.java
@@ -68,10 +68,14 @@ public class GuavaBloomFilterReaderUtils {
   /**
    * Calculates the fpp (false positive probability) based on the given bloom filter size and number of insertions.
    */
-  public static double computeFPP(int sizeInBytes, int numInsertions) {
-    double b = (double) sizeInBytes * Byte.SIZE / numInsertions;
-    double k = b * Math.log(2);
-    return Math.pow(2, -k);
+  public static double computeFPP(double fpp, int sizeInBytes, int numInsertions) {
+    if (sizeInBytes > 0) {
+      double b = (double) sizeInBytes * Byte.SIZE / numInsertions;
+      double k = b * Math.log(2);
+      double minFpp = Math.pow(2, -k);
+      fpp = Math.max(fpp, minFpp);
+    }
+    return fpp;
   }
 
   public static class Hash128AsLongs {

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/BloomFilterReader.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/BloomFilterReader.java
@@ -27,6 +27,11 @@ import org.apache.pinot.segment.spi.index.IndexReader;
 public interface BloomFilterReader extends IndexReader {
 
   /**
+   * @return The False Positive Probability (FPP) of this bloom filter, or -1.0 if not available (version 1 filters)
+   */
+  double getFPP();
+
+  /**
    * Returns {@code true} if the given value might have been put in this bloom filer, {@code false} otherwise.
    */
   boolean mightContain(String value);


### PR DESCRIPTION
This PR adds the feature changes described in issue: https://github.com/apache/pinot/issues/17137

**Changes:**

- Stored fpp value in the header of bloomFilter index as metadata
- Set the bloom filter version to 2 to achieve above and to maintain backward compatibility
- Changes to rebuild bloom filter index on it's config change and segment reload