### PR TITLE
Automatically generate package-info.java with not null annotations

### DIFF
--- a/pinot-dependency-verifier/pom.xml
+++ b/pinot-dependency-verifier/pom.xml
@@ -37,6 +37,10 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.google.code.findbugs</groupId>
+      <artifactId>jsr305</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.maven.enforcer</groupId>
       <artifactId>enforcer-api</artifactId>
       <scope>provided</scope>

--- a/pom.xml
+++ b/pom.xml
@@ -2944,6 +2944,29 @@
           </properties>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>de.shadowhunt.maven.plugins</groupId>
+        <artifactId>package-info-maven-plugin</artifactId>
+        <version>2.0.0</version>
+        <executions>
+          <execution>
+            <phase>generate-sources</phase>
+            <goals>
+              <goal>package-info</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <packages>
+            <package regex="org.apache.pinot.**">
+              <annotations>
+                <annotation>@javax.annotation.ParametersAreNonnullByDefault</annotation>
+                <annotation>@org.jspecify.annotations.NullMarked</annotation>
+              </annotations>
+            </package>
+          </packages>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
This can be used by the tools (including the IDE) to find bugs