### PR TITLE
Always use singleton worker for final sort stage to ensure hotspot server rotation

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/DispatchablePlanVisitor.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/DispatchablePlanVisitor.java
@@ -140,7 +140,9 @@ public class DispatchablePlanVisitor implements PlanNodeVisitor<Void, Dispatchab
   public Void visitSort(SortNode node, DispatchablePlanContext context) {
     node.getInputs().get(0).visit(this, context);
     DispatchablePlanMetadata dispatchablePlanMetadata = getOrCreateDispatchablePlanMetadata(node, context);
-    dispatchablePlanMetadata.setRequireSingleton(!node.getCollations().isEmpty() && node.getOffset() != -1);
+    // Final sort (receives from sort exchange) needs singleton worker
+    boolean isFinalSort = node.getInputs().get(0) instanceof MailboxReceiveNode;
+    dispatchablePlanMetadata.setRequireSingleton(isFinalSort);
     return null;
   }
 

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryCompilationTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryCompilationTest.java
@@ -687,6 +687,45 @@ public class QueryCompilationTest extends QueryEnvironmentTestBase {
     _queryEnvironment.planQuery(query);
   }
 
+  /**
+   * Tests that queries with ORDER BY / LIMIT use singleton worker for the intermediate sort stage.
+   */
+  @Test
+  public void testSingletonWorkerForLimitAndOrderByQueries() {
+    String[] queries =
+        new String[]{"SELECT * FROM a LIMIT 10", "SELECT * FROM a OFFSET 10", "SELECT * FROM a ORDER BY col1",
+            "SELECT * FROM a LIMIT 10 OFFSET 5", "SELECT * FROM a ORDER BY col1 LIMIT 10", "SELECT * FROM a ORDER BY "
+            + "col1 OFFSET 10", "SELECT * FROM a ORDER BY col1 LIMIT 10 OFFSET 5"};
+
+    for (String query : queries) {
+      DispatchableSubPlan dispatchableSubPlan = _queryEnvironment.planQuery(query);
+
+      // Find the intermediate stage (non-leaf, non-root)
+      DispatchablePlanFragment intermediateStage = findIntermediateStage(dispatchableSubPlan);
+      assertNotNull(intermediateStage, "Should have an intermediate stage");
+
+      // Should use singleton worker (1 server, 1 worker)
+      assertEquals(intermediateStage.getServerInstanceToWorkerIdMap().size(), 1,
+          "LIMIT / ORDER BY query should use singleton worker for intermediate stage");
+      assertEquals(intermediateStage.getWorkerMetadataList().size(), 1,
+          "LIMIT / ORDER BY query should use singleton worker for intermediate stage");
+    }
+  }
+
+  /**
+   * Helper method to find an intermediate stage (non-leaf, non-root).
+   */
+  private DispatchablePlanFragment findIntermediateStage(DispatchableSubPlan dispatchableSubPlan) {
+    for (DispatchablePlanFragment fragment : dispatchableSubPlan.getQueryStages()) {
+      int stageId = fragment.getPlanFragment().getFragmentId();
+      // Skip stage 0 (broker/root) and leaf stages (have table names)
+      if (stageId > 0 && fragment.getTableName() == null) {
+        return fragment;
+      }
+    }
+    return null;
+  }
+
   // --------------------------------------------------------------------------
   // Test Utils.
   // --------------------------------------------------------------------------


### PR DESCRIPTION
- Currently, `ORDER BY` / `LIMIT` / `OFFSET` queries have two sort stages - a local / initial sort followed by an exchange and a global / final sort.
- The final sort is done on a single worker / server, and since this is a bottleneck, the expectation is to choose a random or different server for each such query (see [https://github.com/apache/pinot/blob/d1497bf77667c165e83c357d3c3fdab5dc957216/pino[…]src/main/java/org/apache/pinot/query/routing/WorkerManager.java](https://github.com/apache/pinot/blob/d1497bf77667c165e83c357d3c3fdab5dc957216/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerManager.java#L238-L243)
[https://github.com/apache/pinot/blame/d1497bf77667c165e83c357d3c3fdab5dc957216/pin[…]pache/pinot/query/planner/physical/DispatchablePlanVisitor.java](https://github.com/apache/pinot/blame/d1497bf77667c165e83c357d3c3fdab5dc957216/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/DispatchablePlanVisitor.java#L144)).
- Currently, this works as expected for queries that have an `ORDER BY` and `LIMIT` / `OFFSET`. However, for queries that only have `ORDER BY`, or only have `LIMIT` / `OFFSET`, the hotspot server is always the same. The reason is that the condition to set the singleton worker constraint on a sort node is `!node.getCollations().isEmpty() && node.getOffset() != -1`. `node.getCollations()` is empty for non `ORDER BY` queries and `node.getOffset()` is -1 for both local and global sort node for `ORDER BY` queries without `LIMIT` and `OFFSET`.
- So what ends up happening in such queries is that we assign multiple workers / servers for the global sort intermediate stage, but only one worker actually ends up receiving and sending all the data (because the hash exchange uses an empty key selector that routes all the data to the first worker / mailbox). And since the worker / mailbox list is usually ordered in the same way, the hotspot server is always the one assigned to the first worker in the list.
- This patch fixes the above issue by always using a singleton worker for the global / final sort stage (which is checked by ensuring the input is a mailbox node).