### PR TITLE
[refactor] Add Controller/Broker/Server contexts for operator factories and simplify runtime wiring

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
@@ -86,6 +86,9 @@ import org.apache.pinot.core.transport.server.routing.stats.ServerRoutingStatsMa
 import org.apache.pinot.core.util.ListenerConfigUtil;
 import org.apache.pinot.core.util.trace.ContinuousJfrStarter;
 import org.apache.pinot.query.mailbox.MailboxService;
+import org.apache.pinot.query.runtime.context.BrokerContext;
+import org.apache.pinot.query.runtime.operator.factory.DefaultQueryOperatorFactoryProvider;
+import org.apache.pinot.query.runtime.operator.factory.QueryOperatorFactoryProvider;
 import org.apache.pinot.query.service.dispatch.QueryDispatcher;
 import org.apache.pinot.segment.local.function.GroovyFunctionEvaluator;
 import org.apache.pinot.spi.accounting.ThreadAccountant;
@@ -175,6 +178,7 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
     _clusterName = brokerConf.getProperty(Helix.CONFIG_OF_CLUSTER_NAME);
     ServiceStartableUtils.applyClusterConfig(_brokerConf, _zkServers, _clusterName, ServiceRole.BROKER);
     applyCustomConfigs(brokerConf);
+    BrokerContext.getInstance().setQueryOperatorFactoryProvider(createQueryOperatorFactoryProvider(_brokerConf));
 
     PinotInsecureMode.setPinotInInsecureMode(
         _brokerConf.getProperty(CommonConstants.CONFIG_OF_PINOT_INSECURE_MODE, false));
@@ -215,6 +219,13 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
 
   /// Can be overridden to apply custom configs to the broker conf.
   protected void applyCustomConfigs(PinotConfiguration brokerConf) {
+  }
+
+  /**
+   * Override to customize the query operator factory provider used by the broker multi-stage engine.
+   */
+  protected QueryOperatorFactoryProvider createQueryOperatorFactoryProvider(PinotConfiguration brokerConf) {
+    return DefaultQueryOperatorFactoryProvider.INSTANCE;
   }
 
   private void setupHelixSystemProperties() {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/context/BrokerContext.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/context/BrokerContext.java
@@ -1,0 +1,55 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.context;
+
+import java.util.Objects;
+import javax.annotation.Nullable;
+import org.apache.pinot.query.runtime.operator.factory.QueryOperatorFactoryProvider;
+
+
+/**
+ * The <code>BrokerContext</code> class is a singleton class which contains all broker related context.
+ */
+public class BrokerContext {
+  private static final BrokerContext INSTANCE = new BrokerContext();
+
+  private BrokerContext() {
+  }
+
+  public static BrokerContext getInstance() {
+    return INSTANCE;
+  }
+
+  // Must be set during broker initialization; null indicates no provider configured yet.
+  @Nullable
+  private QueryOperatorFactoryProvider _queryOperatorFactoryProvider;
+
+  /**
+   * Returns the configured provider or null if none has been set yet.
+   */
+  @Nullable
+  public QueryOperatorFactoryProvider getQueryOperatorFactoryProvider() {
+    return _queryOperatorFactoryProvider;
+  }
+
+  public void setQueryOperatorFactoryProvider(QueryOperatorFactoryProvider queryOperatorFactoryProvider) {
+    _queryOperatorFactoryProvider =
+        Objects.requireNonNull(queryOperatorFactoryProvider, "queryOperatorFactoryProvider must be set");
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/context/ControllerContext.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/context/ControllerContext.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.context;
+
+/**
+ * The <code>ControllerContext</code> class is a singleton class which contains all controller related context.
+ */
+public class ControllerContext {
+  private static final ControllerContext INSTANCE = new ControllerContext();
+
+  private ControllerContext() {
+  }
+
+  public static ControllerContext getInstance() {
+    return INSTANCE;
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/context/ServerContext.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/context/ServerContext.java
@@ -1,0 +1,55 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.context;
+
+import java.util.Objects;
+import javax.annotation.Nullable;
+import org.apache.pinot.query.runtime.operator.factory.QueryOperatorFactoryProvider;
+
+
+/**
+ * The <code>ServerContext</code> class is a singleton class which contains all server related context.
+ */
+public class ServerContext {
+  private static final ServerContext INSTANCE = new ServerContext();
+
+  private ServerContext() {
+  }
+
+  public static ServerContext getInstance() {
+    return INSTANCE;
+  }
+
+  // Must be set during server initialization; null indicates no provider configured yet.
+  @Nullable
+  private QueryOperatorFactoryProvider _queryOperatorFactoryProvider;
+
+  /**
+   * Returns the configured provider or null if none has been set yet.
+   */
+  @Nullable
+  public QueryOperatorFactoryProvider getQueryOperatorFactoryProvider() {
+    return _queryOperatorFactoryProvider;
+  }
+
+  public void setQueryOperatorFactoryProvider(QueryOperatorFactoryProvider queryOperatorFactoryProvider) {
+    _queryOperatorFactoryProvider =
+        Objects.requireNonNull(queryOperatorFactoryProvider, "queryOperatorFactoryProvider must be set");
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/factory/AggregateOperatorFactory.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/factory/AggregateOperatorFactory.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.operator.factory;
+
+import org.apache.pinot.query.planner.plannode.AggregateNode;
+import org.apache.pinot.query.planner.plannode.PlanNode;
+import org.apache.pinot.query.planner.plannode.WindowNode;
+import org.apache.pinot.query.runtime.operator.MultiStageOperator;
+import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
+
+
+/**
+ * Factory for aggregation related operators.
+ */
+public interface AggregateOperatorFactory {
+
+  MultiStageOperator createAggregateOperator(OpChainExecutionContext context, MultiStageOperator inputOperator,
+      PlanNode inputPlanNode, AggregateNode aggregateNode);
+
+  MultiStageOperator createWindowAggregateOperator(OpChainExecutionContext context, MultiStageOperator inputOperator,
+      PlanNode inputPlanNode, WindowNode windowNode);
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/factory/DefaultAggregateOperatorFactory.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/factory/DefaultAggregateOperatorFactory.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.operator.factory;
+
+import org.apache.pinot.query.planner.plannode.AggregateNode;
+import org.apache.pinot.query.planner.plannode.PlanNode;
+import org.apache.pinot.query.planner.plannode.WindowNode;
+import org.apache.pinot.query.runtime.operator.AggregateOperator;
+import org.apache.pinot.query.runtime.operator.MultiStageOperator;
+import org.apache.pinot.query.runtime.operator.WindowAggregateOperator;
+import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
+
+
+/**
+ * Default implementation that constructs the built-in aggregation operators.
+ */
+public class DefaultAggregateOperatorFactory implements AggregateOperatorFactory {
+  @Override
+  public MultiStageOperator createAggregateOperator(OpChainExecutionContext context, MultiStageOperator inputOperator,
+      PlanNode inputPlanNode, AggregateNode aggregateNode) {
+    return new AggregateOperator(context, inputOperator, aggregateNode);
+  }
+
+  @Override
+  public MultiStageOperator createWindowAggregateOperator(OpChainExecutionContext context,
+      MultiStageOperator inputOperator, PlanNode inputPlanNode, WindowNode windowNode) {
+    return new WindowAggregateOperator(context, inputOperator, inputPlanNode.getDataSchema(), windowNode);
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/factory/DefaultJoinOperatorFactory.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/factory/DefaultJoinOperatorFactory.java
@@ -1,0 +1,81 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.operator.factory;
+
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.query.planner.plannode.EnrichedJoinNode;
+import org.apache.pinot.query.planner.plannode.JoinNode;
+import org.apache.pinot.query.planner.plannode.PlanNode;
+import org.apache.pinot.query.runtime.operator.AsofJoinOperator;
+import org.apache.pinot.query.runtime.operator.EnrichedHashJoinOperator;
+import org.apache.pinot.query.runtime.operator.HashJoinOperator;
+import org.apache.pinot.query.runtime.operator.LookupJoinOperator;
+import org.apache.pinot.query.runtime.operator.MultiStageOperator;
+import org.apache.pinot.query.runtime.operator.NonEquiJoinOperator;
+import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
+
+
+/**
+ * Default implementation that constructs the built-in join operators.
+ */
+public class DefaultJoinOperatorFactory implements JoinOperatorFactory {
+  @Override
+  public MultiStageOperator createJoinOperator(OpChainExecutionContext context, MultiStageOperator leftOperator,
+      PlanNode leftPlanNode, MultiStageOperator rightOperator, PlanNode rightPlanNode, JoinNode joinNode) {
+    JoinNode.JoinStrategy joinStrategy = joinNode.getJoinStrategy();
+    DataSchema leftSchema = leftPlanNode.getDataSchema();
+    switch (joinStrategy) {
+      case HASH:
+        if (joinNode.getLeftKeys().isEmpty()) {
+          // TODO: Consider adding non-equi as a separate join strategy.
+          return new NonEquiJoinOperator(context, leftOperator, leftSchema, rightOperator, joinNode);
+        } else {
+          return new HashJoinOperator(context, leftOperator, leftSchema, rightOperator, joinNode);
+        }
+      case LOOKUP:
+        return new LookupJoinOperator(context, leftOperator, rightOperator, joinNode);
+      case ASOF:
+        return new AsofJoinOperator(context, leftOperator, leftSchema, rightOperator, joinNode);
+      default:
+        throw new IllegalStateException("Unsupported JoinStrategy: " + joinStrategy);
+    }
+  }
+
+  @Override
+  public MultiStageOperator createEnrichedJoinOperator(OpChainExecutionContext context,
+      MultiStageOperator leftOperator, PlanNode leftPlanNode, MultiStageOperator rightOperator, PlanNode rightPlanNode,
+      EnrichedJoinNode joinNode) {
+    JoinNode.JoinStrategy joinStrategy = joinNode.getJoinStrategy();
+    DataSchema leftSchema = leftPlanNode.getDataSchema();
+    switch (joinStrategy) {
+      case HASH:
+        if (joinNode.getLeftKeys().isEmpty()) {
+          throw new UnsupportedOperationException("NonEquiJoin yet to be supported for EnrichedJoin");
+        } else {
+          return new EnrichedHashJoinOperator(context, leftOperator, leftSchema, rightOperator, joinNode);
+        }
+      case LOOKUP:
+        throw new UnsupportedOperationException("LookupJoin yet to be supported for EnrichedJoin");
+      case ASOF:
+        throw new UnsupportedOperationException("AsOfJoin yet to be supported for EnrichedJoin");
+      default:
+        throw new IllegalStateException("Unsupported JoinStrategy for EnrichedJoin: " + joinStrategy);
+    }
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/factory/DefaultQueryOperatorFactoryProvider.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/factory/DefaultQueryOperatorFactoryProvider.java
@@ -1,0 +1,43 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.operator.factory;
+
+
+/**
+ * Default provider that exposes the built-in Pinot query operator factories.
+ */
+public class DefaultQueryOperatorFactoryProvider implements QueryOperatorFactoryProvider {
+  public static final DefaultQueryOperatorFactoryProvider INSTANCE = new DefaultQueryOperatorFactoryProvider();
+
+  private final JoinOperatorFactory _joinOperatorFactory = new DefaultJoinOperatorFactory();
+  private final AggregateOperatorFactory _aggregateOperatorFactory = new DefaultAggregateOperatorFactory();
+
+  private DefaultQueryOperatorFactoryProvider() {
+  }
+
+  @Override
+  public JoinOperatorFactory getJoinOperatorFactory() {
+    return _joinOperatorFactory;
+  }
+
+  @Override
+  public AggregateOperatorFactory getAggregateOperatorFactory() {
+    return _aggregateOperatorFactory;
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/factory/JoinOperatorFactory.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/factory/JoinOperatorFactory.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.operator.factory;
+
+import org.apache.pinot.query.planner.plannode.EnrichedJoinNode;
+import org.apache.pinot.query.planner.plannode.JoinNode;
+import org.apache.pinot.query.planner.plannode.PlanNode;
+import org.apache.pinot.query.runtime.operator.MultiStageOperator;
+import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
+
+
+/**
+ * Factory for join operators.
+ */
+public interface JoinOperatorFactory {
+
+  MultiStageOperator createJoinOperator(OpChainExecutionContext context, MultiStageOperator leftOperator,
+      PlanNode leftPlanNode, MultiStageOperator rightOperator, PlanNode rightPlanNode, JoinNode joinNode);
+
+  MultiStageOperator createEnrichedJoinOperator(OpChainExecutionContext context, MultiStageOperator leftOperator,
+      PlanNode leftPlanNode, MultiStageOperator rightOperator, PlanNode rightPlanNode, EnrichedJoinNode joinNode);
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/factory/QueryOperatorFactoryProvider.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/factory/QueryOperatorFactoryProvider.java
@@ -1,0 +1,29 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.operator.factory;
+
+
+/**
+ * Provider for operator factories used to construct multi-stage query operators.
+ */
+public interface QueryOperatorFactoryProvider {
+  JoinOperatorFactory getJoinOperatorFactory();
+
+  AggregateOperatorFactory getAggregateOperatorFactory();
+}

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
@@ -85,6 +85,9 @@ import org.apache.pinot.core.query.scheduler.resources.ResourceManager;
 import org.apache.pinot.core.transport.ListenerConfig;
 import org.apache.pinot.core.util.ListenerConfigUtil;
 import org.apache.pinot.core.util.trace.ContinuousJfrStarter;
+import org.apache.pinot.query.runtime.context.ServerContext;
+import org.apache.pinot.query.runtime.operator.factory.DefaultQueryOperatorFactoryProvider;
+import org.apache.pinot.query.runtime.operator.factory.QueryOperatorFactoryProvider;
 import org.apache.pinot.segment.local.realtime.impl.invertedindex.RealtimeLuceneIndexRefreshManager;
 import org.apache.pinot.segment.local.realtime.impl.invertedindex.RealtimeLuceneTextIndexSearcherPool;
 import org.apache.pinot.segment.local.segment.store.TextIndexUtils;
@@ -190,6 +193,7 @@ public abstract class BaseServerStarter implements ServiceStartable {
     _helixClusterName = _serverConf.getProperty(CommonConstants.Helix.CONFIG_OF_CLUSTER_NAME);
     ServiceStartableUtils.applyClusterConfig(_serverConf, _zkAddress, _helixClusterName, ServiceRole.SERVER);
     applyCustomConfigs(_serverConf);
+    ServerContext.getInstance().setQueryOperatorFactoryProvider(createQueryOperatorFactoryProvider(_serverConf));
 
     PinotInsecureMode.setPinotInInsecureMode(
         _serverConf.getProperty(CommonConstants.CONFIG_OF_PINOT_INSECURE_MODE, false));
@@ -282,6 +286,13 @@ public abstract class BaseServerStarter implements ServiceStartable {
 
   /// Can be overridden to apply custom configs to the server conf.
   protected void applyCustomConfigs(PinotConfiguration serverConf) {
+  }
+
+  /**
+   * Override to customize the query operator factory provider used by the multi-stage engine.
+   */
+  protected QueryOperatorFactoryProvider createQueryOperatorFactoryProvider(PinotConfiguration serverConf) {
+    return DefaultQueryOperatorFactoryProvider.INSTANCE;
   }
 
   /**


### PR DESCRIPTION
Summary:

- Introduce `ControllerContext`/`BrokerContext`/`ServerContext` singletons to hold the instance level sharable context/resources to simplify code for class constructor.
- `QueryOperatorFactoryProvider` is set during broker/server startup to avoid config flags and argument plumbing.
- `OpChainExecutionContext` now resolves the provider from these contexts; public factory methods no longer accept external providers.
- `PlanNodeToOpChain` fetches `join`/`aggregate`/`window` factories directly from the execution context (no stored provider in the visitor).