### PR TITLE
make rule timings log debug

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/context/RuleTimingPlannerListener.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/context/RuleTimingPlannerListener.java
@@ -90,7 +90,7 @@ public class RuleTimingPlannerListener implements RelOptListener {
   }
 
   public void printRuleTimings() {
-    LOGGER.info(getRuleTimings(SqlExplainFormat.DOT));
+    LOGGER.debug(getRuleTimings(SqlExplainFormat.DOT));
   }
 
   public void populateRuleTimings() {


### PR DESCRIPTION
This is a small bugfix to mark, what I assume was an unintentional log, as debug. This log is accounting for 99% of our logging volume from brokers.