### PR TITLE
Set merging segment creation time = max(creationTime) + 1

### DIFF
--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompactmerge/UpsertCompactMergeTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompactmerge/UpsertCompactMergeTaskExecutor.java
@@ -133,7 +133,7 @@ public class UpsertCompactMergeTaskExecutor extends BaseMultipleSegmentsConversi
     }
 
     // create new UploadedRealtimeSegment
-    // set the creation time to maxCreationTimeOfMergingSegments + 1 to ensure that the all records in merging
+    // set the creation time to maxCreationTimeOfMergingSegments + 1 to ensure that all records in merging
     // segments are replaced with new merged segment
     segmentProcessorConfigBuilder.setCustomCreationTime(maxCreationTimeOfMergingSegments + 1);
     segmentProcessorConfigBuilder.setSegmentNameGenerator(


### PR DESCRIPTION
### Problem
During upsert compact merge operations, merged segment are created with the same creation time as the maximum creation time of the merging segments. If the merging segment are UPLOADED segment (merged earlier), they share the same create time as merged segment. This means that records in segment with highest creation time is not replaced due to the tie-breaking logic in [shouldReplaceOnComparisonTie](https://github.com/apache/pinot/blob/52db36c816f91ef8887fddd0beade5d169824296/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java#L518).
Not replacing records from this segment could lead to dataloss as discussed in in #17337.

### Solution
We set the creation time of merged segment = max(creation time of all segment) + 1. 
This ensures that the merging segment takes priority and all records in existing segment are replaced with records in new merged segment. 

### Test
Tested in a test cluster. Verified that the new merging segment has the creation time as expected. Validated that all records from merging segment were replaced with merged segment. 
All compacted segments were deleted successfully in next task iteration. 
