### PR TITLE
Correctly set tier for IndexLoadingConfig used in needReload API

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -1341,6 +1341,7 @@ public abstract class BaseTableDataManager implements TableDataManager {
         IndexSegment segment = segmentDataManager.getSegment();
         if (segment instanceof ImmutableSegmentImpl) {
           ImmutableSegmentImpl immutableSegment = (ImmutableSegmentImpl) segment;
+          indexLoadingConfig.setSegmentTier(immutableSegment.getTier());
           if (immutableSegment.isReloadNeeded(indexLoadingConfig)) {
             needReload = true;
             break;


### PR DESCRIPTION
## Description
For the controller needReload API `GET /segments/<tableNameWithType>/needReload`, the `IndexLoadingConfig` used in checking the need to reload doesn't have the tier information of each segments. This creates misalignment between the actual `IndexLoadingConfig` that loads the segments and the `IndexLoadingConfig` used to check the need to reload, when `tierOverwrites` is present in the table config.

In such case, pinot servers follow the overwritten configs for a segment in remote tier, but `needReload` API answers based on the config of default local tier. 

Notice that this bug is only in the controller API, for the call of `needPreprocess()` during segment reload or load, the tier is correctly set.