### PR TITLE
[bugfix] Initialize LogicalTableMetadataCache with existing logical tables

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/config/provider/LogicalTableMetadataCache.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/config/provider/LogicalTableMetadataCache.java
@@ -75,8 +75,8 @@ public class LogicalTableMetadataCache {
     // Initialize the cache with existing logical table configs.
     List<String> existingLogicalTables = _propertyStore.getChildNames(ZkPaths.LOGICAL_TABLE_PARENT_PATH,
         AccessOption.PERSISTENT);
-    LOGGER.info("Found {} existing logical tables in the property store, initializing", existingLogicalTables.size());
     if (CollectionUtils.isNotEmpty(existingLogicalTables)) {
+      LOGGER.info("Found {} existing logical tables in the property store, initializing", existingLogicalTables.size());
       _zkLogicalTableConfigChangeListener.handleChildChange(ZkPaths.LOGICAL_TABLE_PARENT_PATH, existingLogicalTables);
     }
 


### PR DESCRIPTION
## Summary

A bug was discovered for MSE queries on logical tables with the error "LogicalTableContext not found for logical table name". On further investigation, this turned out to be for servers which were restarted or newly init after the logical table(s) were already created.

The bug occurs because at the time of creation of `LogicalTableMetadataCache`, the `init()` subscribes to updates in the  logical table path but does not initialize the already existing set of logical tables, causing any query on logical tables to fail until there is a change on the logical table ZK path and all the tables are then updated.

This PR simply fixes it by manually triggering `_zkLogicalTableConfigChangeListener.handleChildChange` for existing logical tables. This is also done in [ZkTableCache](https://github.com/apache/pinot/blob/master/pinot-common/src/main/java/org/apache/pinot/common/config/provider/ZkTableCache.java#L105) to ensure the existing tables are correctly inited.

### Trigger Condition

This bug can trigger when a server is restarted or a new server is inited.

## Testing

Successfully validated that this fix internally at Uber by deploying this change and verifying that MSE on logical tables is robust to new servers and server restarts.