### PR TITLE
Deterministic data-only CRC (2/2) - use data-only CRC for realtime committing segments during replace

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metadata/segment/SegmentZKMetadata.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metadata/segment/SegmentZKMetadata.java
@@ -182,19 +182,19 @@ public class SegmentZKMetadata implements ZKMetadata {
     setNonNegativeValue(Segment.DATA_CRC, dataCrc);
   }
 
-  public boolean isUseDataCrcForReplace() {
-    String useDataCrcForReplaceString = _simpleFields.get(Segment.USE_DATA_CRC_FOR_REPLACE);
-    return Boolean.parseBoolean(useDataCrcForReplaceString);
+  public boolean isUseDataCrc() {
+    String useDataCrcString = _simpleFields.get(Segment.USE_DATA_CRC);
+    return Boolean.parseBoolean(useDataCrcString);
   }
 
-  // useDataCrcForReplace is set for consuming segments in realtime table
+  // useDataCrc is set for consuming segments in realtime table
   // that signal replica server to use Data CRC when available for doing any replacement
   // of segments
-  public void setUseDataCrcForReplace(boolean useDataCrcForReplace) {
-    if (useDataCrcForReplace) {
-      _simpleFields.put(Segment.USE_DATA_CRC_FOR_REPLACE, "true");
+  public void setUseDataCrc(boolean useDataCrc) {
+    if (useDataCrc) {
+      _simpleFields.put(Segment.USE_DATA_CRC, "true");
     } else {
-      _simpleFields.remove(Segment.USE_DATA_CRC_FOR_REPLACE);
+      _simpleFields.remove(Segment.USE_DATA_CRC);
     }
   }
 

--- a/pinot-common/src/main/java/org/apache/pinot/common/metadata/segment/SegmentZKMetadataUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metadata/segment/SegmentZKMetadataUtils.java
@@ -94,9 +94,9 @@ public class SegmentZKMetadataUtils {
 
       segmentZKMetadata.setEndOffset(endOffset);
       segmentZKMetadata.setStatus(CommonConstants.Segment.Realtime.Status.DONE);
-      // for committing segments, we use data CRC for replace but only if the data CRC is present for the segment
+      // for committing segments, we use data CRC to replace but only if the data CRC is present for the segment
       if (Long.parseLong(segmentMetadata.getDataCrc()) >= 0) {
-        segmentZKMetadata.setUseDataCrcForReplace(true);
+        segmentZKMetadata.setUseDataCrc(true);
       }
 
       // For committing segment, use current time as start/end time if total docs is 0
@@ -114,10 +114,9 @@ public class SegmentZKMetadataUtils {
       segmentZKMetadata.setTimeUnit(TimeUnit.MILLISECONDS);
     } else {
       // For uploaded segment
-
-      //clear the use data crc flag for uploaded segments
+      // clear the use data crc flag for uploaded segments
       // This flag should ONLY be true for segments committed from CONSUMING state
-      segmentZKMetadata.setUseDataCrcForReplace(false);
+      segmentZKMetadata.setUseDataCrc(false);
       // Set segment status, start/end offset info for real-time table
       if (TableNameBuilder.isRealtimeTableResource(tableNameWithType)) {
         segmentZKMetadata.setStatus(CommonConstants.Segment.Realtime.Status.UPLOADED);

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -1660,13 +1660,13 @@ public abstract class BaseTableDataManager implements TableDataManager {
   }
 
   // CRC check can be performed on both segment CRC and data CRC (if available) based on the ZK property value of
-  // useDataCRCForReplace.
+  // useDataCRC.
   private static boolean hasSameCRC(SegmentZKMetadata zkMetadata, SegmentMetadata localMetadata) {
     if (zkMetadata.getCrc() == Long.parseLong(localMetadata.getCrc())) {
       return true;
     }
-    return zkMetadata.isUseDataCrcForReplace()
-           && zkMetadata.getDataCrc() >= 0
+    return zkMetadata.isUseDataCrc()
+            && zkMetadata.getDataCrc() >= 0
             && Long.parseLong(localMetadata.getDataCrc()) >= 0
             && zkMetadata.getDataCrc() == Long.parseLong(localMetadata.getDataCrc());
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerTest.java
@@ -809,7 +809,7 @@ public class BaseTableDataManagerTest {
     SegmentZKMetadata zkMetadata = createRawSegment(SegmentVersion.v3, 5);
     zkMetadata.setCrc(2048L); // Different from local
     zkMetadata.setDataCrc(99999L);
-    zkMetadata.setUseDataCrcForReplace(false);
+    zkMetadata.setUseDataCrc(false);
 
     ImmutableSegmentDataManager segmentDataManager = createImmutableSegmentDataManager(SEGMENT_NAME, 1024L);
     SegmentMetadata segmentMetadata = segmentDataManager.getSegment().getSegmentMetadata();
@@ -833,7 +833,7 @@ public class BaseTableDataManagerTest {
     SegmentZKMetadata zkMetadata = createRawSegment(SegmentVersion.v3, 5);
     long segmentCrc = zkMetadata.getCrc();
     zkMetadata.setDataCrc(99999L);
-    zkMetadata.setUseDataCrcForReplace(true);
+    zkMetadata.setUseDataCrc(true);
 
     ImmutableSegmentDataManager segmentDataManager = createImmutableSegmentDataManager(SEGMENT_NAME, segmentCrc);
     SegmentMetadata segmentMetadata = segmentDataManager.getSegment().getSegmentMetadata();
@@ -855,7 +855,7 @@ public class BaseTableDataManagerTest {
     SegmentZKMetadata zkMetadata = createRawSegment(SegmentVersion.v3, 5);
     zkMetadata.setCrc(2048L);
     zkMetadata.setDataCrc(-1L);
-    zkMetadata.setUseDataCrcForReplace(true);
+    zkMetadata.setUseDataCrc(true);
 
     ImmutableSegmentDataManager segmentDataManager = createImmutableSegmentDataManager(SEGMENT_NAME, 1024L);
     SegmentMetadata segmentMetadata = segmentDataManager.getSegment().getSegmentMetadata();

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -1782,7 +1782,7 @@ public class CommonConstants {
     public static final String TOTAL_DOCS = "segment.total.docs";
     public static final String CRC = "segment.crc";
     public static final String DATA_CRC = "segment.data.crc";
-    public static final String USE_DATA_CRC_FOR_REPLACE = "segment.use.data.crc";
+    public static final String USE_DATA_CRC = "segment.use.data.crc";
     public static final String TIER = "segment.tier";
     public static final String CREATION_TIME = "segment.creation.time";
     public static final String PUSH_TIME = "segment.push.time";


### PR DESCRIPTION
Motivation

Resolves https://github.com/apache/pinot/issues/17262

**Summary**

This PR is a follow up of https://github.com/apache/pinot/pull/17264 that added a computation of data-only CRC for segments and uploaded it to ZK. It introduces a new property in ZK metadata for segments `segment.use.data.crc` only for realtime committing segments. If this flag is present, the replica servers when downloading and replacing the realtime segments will end up using the data CRC (if also available in ZK) to carry out in place replace. 


**Details**

**When This Optimization Applies**
Only for realtime segments during CONSUMING → ONLINE transition
Only when the flag is set by the controller during segment commit
Only on replica servers that have built the segment locally
Fallback behavior: If data CRCs also don't match, segment is still downloaded (safe)

**When Standard Behavior Still Applies**
Offline table segments (flag never set)
Uploaded LLC segments (flag reverted to false)
Manual segment replacement operations
When instance.check.crc.on.segment.load is disabled

**Testing**

UTs for _replaceSegmentIFCRCMismatch()_ added. 

Ran quick start for realtime tables, 

Data CRC and useDataCRC flag present for realtime committed segments, 
<img width="1500" height="649" alt="Screenshot 2026-01-13 at 11 38 38 AM" src="https://github.com/user-attachments/assets/f0a74ff7-033a-4b78-9845-ddf15b3daa72" />


Flag not present for IN_PROGRESS consuming segments, 
<img width="958" height="480" alt="Screenshot 2025-12-30 at 10 51 35 AM" src="https://github.com/user-attachments/assets/3d02a10b-5258-4769-9e69-e10c37236628" />


Data CRC present but Flag NOT present for offline table segments, 
<img width="1272" height="589" alt="Screenshot 2025-12-30 at 10 57 58 AM" src="https://github.com/user-attachments/assets/2868c576-9311-431b-9998-ec5bd87e4c44" />
