### PR TITLE
Support forcing pre-partitioned exchanges for window functions to avoid data shuffle using query hint

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/hint/PinotHintOptions.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/hint/PinotHintOptions.java
@@ -23,6 +23,7 @@ import javax.annotation.Nullable;
 import org.apache.calcite.rel.RelDistribution;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Join;
+import org.apache.calcite.rel.core.Window;
 import org.apache.calcite.rel.hint.RelHint;
 
 
@@ -77,6 +78,17 @@ public class PinotHintOptions {
      *   BREAK: Break window cache build process, continue to perform WINDOW operation, results might be partial.
      */
     public static final String WINDOW_OVERFLOW_MODE = "window_overflow_mode";
+
+    /// Indicates that the input to the window is already partitioned by the window keys, so we should avoid shuffling
+    /// to repartition.
+    public static final String IS_PARTITIONED_BY_WINDOW_KEYS = "is_partitioned_by_window_keys";
+
+    @Nullable
+    public static Boolean isPartitionedByWindowKeys(Window window) {
+      String hint =
+          PinotHintStrategyTable.getHintOption(window.getHints(), WINDOW_HINT_OPTIONS, IS_PARTITIONED_BY_WINDOW_KEYS);
+      return hint != null ? Boolean.parseBoolean(hint) : null;
+    }
   }
 
   public static class JoinHintOptions {

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/hint/PinotHintStrategyTable.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/hint/PinotHintStrategyTable.java
@@ -40,6 +40,7 @@ public class PinotHintStrategyTable {
       .hintStrategy(PinotHintOptions.AGGREGATE_HINT_OPTIONS, HintPredicates.AGGREGATE)
       .hintStrategy(PinotHintOptions.JOIN_HINT_OPTIONS, HintPredicates.JOIN)
       .hintStrategy(PinotHintOptions.TABLE_HINT_OPTIONS, HintPredicates.TABLE_SCAN)
+      .hintStrategy(PinotHintOptions.WINDOW_HINT_OPTIONS, HintPredicates.WINDOW)
       .build();
 
   /**

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotRelDistributionTraitRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotRelDistributionTraitRule.java
@@ -36,6 +36,7 @@ import org.apache.calcite.rel.core.TableScan;
 import org.apache.calcite.rel.logical.LogicalFilter;
 import org.apache.calcite.rel.logical.LogicalJoin;
 import org.apache.calcite.rel.logical.LogicalProject;
+import org.apache.calcite.rel.logical.LogicalWindow;
 import org.apache.calcite.rel.type.RelDataTypeField;
 import org.apache.calcite.tools.RelBuilderFactory;
 import org.apache.calcite.util.mapping.IntPair;
@@ -156,6 +157,13 @@ public class PinotRelDistributionTraitRule extends RelOptRule {
       if (inputRelDistribution != null) {
         // Since we only support LEFT RelTrait propagation, the inputRelDistribution can directly be applied
         // b/c the Join node always puts left relation RowTypes then right relation RowTypes sequentially.
+        return inputRelDistribution;
+      }
+    } else if (node instanceof LogicalWindow) {
+      assert inputs.size() == 1;
+      // Window input should be an exchange node that is hash distributed by the window's partition keys
+      RelDistribution inputRelDistribution = inputs.get(0).getTraitSet().getDistribution();
+      if (inputRelDistribution != null) {
         return inputRelDistribution;
       }
     }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RelToPlanNodeConverter.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RelToPlanNodeConverter.java
@@ -581,7 +581,7 @@ public final class RelToPlanNodeConverter {
       PinotLogicalSortExchange sortExchange = (PinotLogicalSortExchange) node;
       exchangeType = sortExchange.getExchangeType();
       keys = distribution.getKeys();
-      prePartitioned = null;
+      prePartitioned = sortExchange.getPrePartitioned();
       collations = sortExchange.getCollation().getFieldCollations();
       sortOnSender = sortExchange.isSortOnSender();
       sortOnReceiver = sortExchange.isSortOnReceiver();

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryCompilationTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryCompilationTest.java
@@ -38,8 +38,10 @@ import org.apache.pinot.query.planner.plannode.BasePlanNode;
 import org.apache.pinot.query.planner.plannode.FilterNode;
 import org.apache.pinot.query.planner.plannode.JoinNode;
 import org.apache.pinot.query.planner.plannode.MailboxReceiveNode;
+import org.apache.pinot.query.planner.plannode.MailboxSendNode;
 import org.apache.pinot.query.planner.plannode.PlanNode;
 import org.apache.pinot.query.planner.plannode.ProjectNode;
+import org.apache.pinot.query.planner.plannode.WindowNode;
 import org.apache.pinot.query.routing.QueryServerInstance;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Ignore;
@@ -951,6 +953,103 @@ public class QueryCompilationTest extends QueryEnvironmentTestBase {
         "LEFT side of RIGHT non-equi join should be BROADCAST");
     assertEquals(rightInput.getDistributionType(), RelDistribution.Type.RANDOM_DISTRIBUTED,
         "RIGHT side of RIGHT non-equi join should be RANDOM");
+  }
+
+  /**
+   * The {@code windowOptions(is_partitioned_by_window_keys='true')} hint forces a pre-partitioned (direct) exchange
+   * below the window, avoiding a data shuffle. Here the window partitions by {@code col1}, which is NOT table a's
+   * partition column ({@code col2}), so without the hint the planner would shuffle. This exercises the
+   * {@link org.apache.pinot.calcite.rel.logical.PinotLogicalExchange} path (PARTITION BY only).
+   */
+  @Test
+  public void testWindowPartitionByKeysHintForcesPrePartitionedExchange() {
+    String query = "SELECT /*+ windowOptions(is_partitioned_by_window_keys='true') */ "
+        + "col1, SUM(col3) OVER (PARTITION BY col1) FROM a";
+    MailboxSendNode sendNode = findWindowInputSendNode(_queryEnvironment.planQuery(query));
+    assertEquals(sendNode.getDistributionType(), RelDistribution.Type.HASH_DISTRIBUTED);
+    assertTrue(sendNode.isPrePartitioned(),
+        "windowOptions(is_partitioned_by_window_keys='true') should force a pre-partitioned exchange");
+  }
+
+  /**
+   * Without the hint and with a window partition key that does not match the table's partitioning, the exchange below
+   * the window must be a regular (shuffled) exchange.
+   */
+  @Test
+  public void testWindowWithoutHintIsNotPrePartitioned() {
+    String query = "SELECT col1, SUM(col3) OVER (PARTITION BY col1) FROM a";
+    MailboxSendNode sendNode = findWindowInputSendNode(_queryEnvironment.planQuery(query));
+    assertFalse(sendNode.isPrePartitioned(),
+        "Without the hint and matching partitioning, the window exchange should be a full shuffle");
+  }
+
+  /**
+   * The hint must also flow through the {@link org.apache.pinot.calcite.rel.logical.PinotLogicalSortExchange} path,
+   * used when PARTITION BY and ORDER BY are on different keys. This is the path the PR fixes: previously
+   * {@code RelToPlanNodeConverter} hardcoded {@code prePartitioned = null} for sort exchanges, dropping the hint.
+   */
+  @Test
+  public void testWindowPartitionByKeysHintForcesPrePartitionedSortExchange() {
+    String query = "SELECT /*+ windowOptions(is_partitioned_by_window_keys='true') */ "
+        + "col1, SUM(col3) OVER (PARTITION BY col1 ORDER BY col3) FROM a";
+    MailboxSendNode sendNode = findWindowInputSendNode(_queryEnvironment.planQuery(query));
+    assertEquals(sendNode.getDistributionType(), RelDistribution.Type.HASH_DISTRIBUTED);
+    assertTrue(sendNode.isPrePartitioned(),
+        "windowOptions hint should force a pre-partitioned sort exchange (PARTITION BY + ORDER BY on different keys)");
+  }
+
+  /**
+   * Setting the hint to {@code 'false'} overrides the planner's automatic detection of pre-partitioning. Here table a
+   * is declared partitioned by {@code col2} (via tableOptions) and the window also partitions by {@code col2}, so the
+   * planner would otherwise auto-detect a pre-partitioned exchange; the hint disables it.
+   */
+  @Test
+  public void testWindowPartitionByKeysHintFalseDisablesAutoDetectedPrePartitioning() {
+    String query = "SELECT /*+ windowOptions(is_partitioned_by_window_keys='false') */ "
+        + "col1, SUM(col3) OVER (PARTITION BY col2) "
+        + "FROM a /*+ tableOptions(partition_function='hashcode', partition_key='col2', partition_size='4') */";
+    MailboxSendNode sendNode = findWindowInputSendNode(_queryEnvironment.planQuery(query));
+    assertFalse(sendNode.isPrePartitioned(),
+        "windowOptions(is_partitioned_by_window_keys='false') should disable auto-detected pre-partitioning");
+  }
+
+  /**
+   * With matching tableOptions partitioning and no window hint, the planner auto-detects pre-partitioning. This must
+   * hold for both window exchange paths: PinotLogicalExchange (PARTITION BY only) and PinotLogicalSortExchange
+   * (PARTITION BY + ORDER BY). The latter verifies the PR preserves the {@code null -> auto-detect} behavior.
+   */
+  @Test
+  public void testWindowAutoDetectsPrePartitioningWithoutHint() {
+    String partitionOnly = "SELECT col1, SUM(col3) OVER (PARTITION BY col2) "
+        + "FROM a /*+ tableOptions(partition_function='hashcode', partition_key='col2', partition_size='4') */";
+    assertTrue(findWindowInputSendNode(_queryEnvironment.planQuery(partitionOnly)).isPrePartitioned(),
+        "PARTITION BY on the table's partition column should auto-detect a pre-partitioned exchange");
+
+    String partitionAndOrder = "SELECT col1, SUM(col3) OVER (PARTITION BY col2 ORDER BY col3) "
+        + "FROM a /*+ tableOptions(partition_function='hashcode', partition_key='col2', partition_size='4') */";
+    assertTrue(findWindowInputSendNode(_queryEnvironment.planQuery(partitionAndOrder)).isPrePartitioned(),
+        "Sort exchange should also auto-detect pre-partitioning when the table is partitioned by the window key");
+  }
+
+  /**
+   * Finds the {@link MailboxSendNode} that feeds the (single) WINDOW stage's input exchange, i.e. the sender side of
+   * the exchange inserted directly below the window. The {@code prePartitioned} flag lives on this send node.
+   */
+  private MailboxSendNode findWindowInputSendNode(DispatchableSubPlan dispatchableSubPlan) {
+    WindowNode window = null;
+    for (DispatchablePlanFragment fragment : dispatchableSubPlan.getQueryStages()) {
+      window = findNodeOfType(fragment.getPlanFragment().getFragmentRoot(), WindowNode.class);
+      if (window != null) {
+        break;
+      }
+    }
+    assertNotNull(window, "Expected a WINDOW node in the plan");
+    MailboxReceiveNode receiveNode = findNodeOfType(window, MailboxReceiveNode.class);
+    assertNotNull(receiveNode, "Expected the WINDOW input to be a mailbox exchange");
+    PlanNode senderRoot =
+        dispatchableSubPlan.getQueryStageMap().get(receiveNode.getSenderStageId()).getPlanFragment().getFragmentRoot();
+    assertTrue(senderRoot instanceof MailboxSendNode, "Sender fragment root should be a MailboxSendNode");
+    return (MailboxSendNode) senderRoot;
   }
 
   /**

--- a/pinot-query-planner/src/test/resources/queries/ExplainPhysicalPlans.json
+++ b/pinot-query-planner/src/test/resources/queries/ExplainPhysicalPlans.json
@@ -714,6 +714,40 @@
           "\n                                    └── [5]@localhost:1|[0] TABLE SCAN (b) null",
           "\n"
         ]
+      },
+      {
+        "description": "window function (PARTITION BY) without hint shuffles (hash redistributes) its input to all window-stage workers",
+        "sql": "EXPLAIN IMPLEMENTATION PLAN FOR SELECT col1, SUM(col3) OVER (PARTITION BY col1) FROM a",
+        "output": [
+          "[0]@localhost:3|[0] MAIL_RECEIVE(BROADCAST_DISTRIBUTED)",
+          "\n├── [1]@localhost:2|[1] MAIL_SEND(BROADCAST_DISTRIBUTED)->{[0]@localhost:3|[0]} (Subtree Omitted)",
+          "\n└── [1]@localhost:1|[0] MAIL_SEND(BROADCAST_DISTRIBUTED)->{[0]@localhost:3|[0]}",
+          "\n    └── [1]@localhost:1|[0] PROJECT",
+          "\n        └── [1]@localhost:1|[0] WINDOW",
+          "\n            └── [1]@localhost:1|[0] MAIL_RECEIVE(HASH_DISTRIBUTED)",
+          "\n                ├── [2]@localhost:2|[1] MAIL_SEND(HASH_DISTRIBUTED)->{[1]@localhost:1|[0],[1]@localhost:2|[1]} (Subtree Omitted)",
+          "\n                └── [2]@localhost:1|[0] MAIL_SEND(HASH_DISTRIBUTED)->{[1]@localhost:1|[0],[1]@localhost:2|[1]}",
+          "\n                    └── [2]@localhost:1|[0] PROJECT",
+          "\n                        └── [2]@localhost:1|[0] TABLE SCAN (a) null",
+          "\n"
+        ]
+      },
+      {
+        "description": "window function (PARTITION BY) with is_partitioned_by_window_keys hint uses a pre-partitioned (direct, 1-to-1) exchange to avoid the shuffle",
+        "sql": "EXPLAIN IMPLEMENTATION PLAN FOR SELECT /*+ windowOptions(is_partitioned_by_window_keys='true') */ col1, SUM(col3) OVER (PARTITION BY col1) FROM a",
+        "output": [
+          "[0]@localhost:3|[0] MAIL_RECEIVE(BROADCAST_DISTRIBUTED)",
+          "\n├── [1]@localhost:2|[1] MAIL_SEND(BROADCAST_DISTRIBUTED)->{[0]@localhost:3|[0]} (Subtree Omitted)",
+          "\n└── [1]@localhost:1|[0] MAIL_SEND(BROADCAST_DISTRIBUTED)->{[0]@localhost:3|[0]}",
+          "\n    └── [1]@localhost:1|[0] PROJECT",
+          "\n        └── [1]@localhost:1|[0] WINDOW",
+          "\n            └── [1]@localhost:1|[0] MAIL_RECEIVE(HASH_DISTRIBUTED)",
+          "\n                ├── [2]@localhost:2|[1] MAIL_SEND(HASH_DISTRIBUTED)[PARTITIONED]->{[1]@localhost:2|[1]} (Subtree Omitted)",
+          "\n                └── [2]@localhost:1|[0] MAIL_SEND(HASH_DISTRIBUTED)[PARTITIONED]->{[1]@localhost:1|[0]}",
+          "\n                    └── [2]@localhost:1|[0] PROJECT",
+          "\n                        └── [2]@localhost:1|[0] TABLE SCAN (a) null",
+          "\n"
+        ]
       }
     ]
   }

--- a/pinot-query-runtime/src/test/resources/queries/QueryHints.json
+++ b/pinot-query-runtime/src/test/resources/queries/QueryHints.json
@@ -659,6 +659,18 @@
     {
       "description": "Local replicated JOIN with partition hint and parallelism",
       "sql": "SELECT /*+ joinOptions(left_distribution_type = 'local', right_distribution_type = 'local') */ {tbl1}.num, {tbl1}.name, {tbl2}.num, {tbl2}.val FROM {tbl1} /*+ tableOptions(partition_function='hashcode', partition_key='num', partition_size='4', partition_parallelism='2') */ JOIN {tbl2} /*+ tableOptions(is_replicated='true') */ ON {tbl1}.num = {tbl2}.num"
+    },
+    {
+      "description": "Window PARTITION BY the table's partition column with is_partitioned_by_window_keys hint forces a pre-partitioned (direct) exchange; tbl1 is partitioned by num so results stay correct",
+      "sql": "SELECT /*+ windowOptions(is_partitioned_by_window_keys='true') */ {tbl1}.num, SUM({tbl1}.num) OVER (PARTITION BY {tbl1}.num) FROM {tbl1}"
+    },
+    {
+      "description": "Window PARTITION BY + ORDER BY on different keys with is_partitioned_by_window_keys hint forces a pre-partitioned sort exchange; tbl1 is partitioned by num so results stay correct",
+      "sql": "SELECT /*+ windowOptions(is_partitioned_by_window_keys='true') */ {tbl1}.num, {tbl1}.name, SUM({tbl1}.num) OVER (PARTITION BY {tbl1}.num ORDER BY {tbl1}.name) FROM {tbl1}"
+    },
+    {
+      "description": "Window with is_partitioned_by_window_keys='false' disables the auto-detected pre-partitioning (tbl1 is partitioned by num) and falls back to a shuffle; results stay correct",
+      "sql": "SELECT /*+ windowOptions(is_partitioned_by_window_keys='false') */ {tbl1}.num, SUM({tbl1}.num) OVER (PARTITION BY {tbl1}.num) FROM {tbl1} /*+ tableOptions(partition_function='hashcode', partition_key='num', partition_size='4') */"
     }
   ]}
 }


### PR DESCRIPTION
- Adds a new window option query hint `is_partitioned_by_window_keys` that can be used to force (or disable) pre-partitioned exchanges for window functions in order to avoid data shuffle when we know that the input is already partitioned by the window's partition keys. This is the window-function equivalent of the existing `is_colocated_by_join_keys` join hint.
- In most scenarios where the input is a table that is explicitly partitioned by the window's partition keys, we can use the `/*+ tableOptions(partition_key='...', partition_size='...') */` hint on the table scan so that the planner can automatically determine that the partitioning matches and the two stages should be colocated. However, in certain scenarios like implicit partitioning and also for debugging / iterating on queries, this new hint to force enable or disable the pre-partitioned exchanges can be useful.
- Like the equivalent join / aggregate hints, this is opt-in and trusts the user's assertion: forcing `is_partitioned_by_window_keys='true'` when the data is not actually partitioned by the window's partition keys will produce incorrect results (rows sharing a partition key but landing on different senders are never reconciled on a single window worker). The hint is honored by the V1 query planner; the V2 physical optimizer determines colocation on its own.
- This also registers the `windowOptions` hint strategy (`HintPredicates.WINDOW`), which was previously not registered at all. That registration is required for the new hint, and as a side effect it lets the pre-existing `max_rows_in_window` / `window_overflow_mode` window options attach to the window node.

**Update:** window function hints were broken in Calcite ([CALCITE-7338](https://issues.apache.org/jira/browse/CALCITE-7338)), which originally blocked this PR. That has been fixed as part of the Calcite 1.42.0 upgrade, so the PR is now unblocked and rebased on top of it. Tests added:
- Planner unit tests in `QueryCompilationTest` asserting the hint forces / disables a pre-partitioned exchange across both the `PinotLogicalExchange` (PARTITION BY only) and `PinotLogicalSortExchange` (PARTITION BY + ORDER BY on different keys) paths, plus the no-hint baseline and auto-detection cases.
- A physical-plan contrast pair in `ExplainPhysicalPlans.json` showing the hint turn a full shuffle into a `[PARTITIONED]` (direct, 1-to-1) exchange.
- Runtime, H2-validated cases in `QueryHints.json` on a physically-partitioned table, covering both `='true'` and `='false'`.
