### PR TITLE
Remove text Index from index map when storeInSegmentFile flag is true.

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/TextIndexHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/TextIndexHandler.java
@@ -127,6 +127,9 @@ public class TextIndexHandler extends BaseIndexHandler {
     Set<String> existingColumns = segmentWriter.toSegmentDirectory().getColumnsWithIndex(StandardIndexes.text());
     // Handle configuration changes for existing indexes
     for (String column : existingColumns) {
+      if (!columnsToAddIdx.contains(column)) {
+        continue;
+      }
       ColumnMetadata columnMetadata = _segmentDirectory.getSegmentMetadata().getColumnMetadataFor(column);
       if (columnMetadata != null && hasTextIndexConfigurationChanged(column, segmentWriter)) {
         LOGGER.info("Updating text index configuration for segment: {}, column: {}", segmentName, column);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/SingleFileIndexDirectory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/SingleFileIndexDirectory.java
@@ -449,7 +449,6 @@ class SingleFileIndexDirectory extends ColumnIndexDirectory {
     // Text index is kept in its own files, thus can be removed directly.
     if (indexType == StandardIndexes.text()) {
       TextIndexUtils.cleanupTextIndex(_segmentDirectory, columnName);
-      return;
     }
     if (indexType == StandardIndexes.vector()) {
       VectorIndexUtils.cleanupVectorIndex(_segmentDirectory, columnName);


### PR DESCRIPTION
When storeInSegmentFile=true, Text Index files are combined into the segment with an Index_map entry. Previously, disabling Text Index only removed standalone Text Index files outside the segment, leaving combined Text Index data inside the segment intact.

Fix: Ensures combined Text Index data within the segment is also removed when Text Index is disabled, and avoids unnecessary processing when Text Index is not configured.
