### PR TITLE
[Refactor] Rename duplicated BasicAuthUtils

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BasicAuthAccessControlFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BasicAuthAccessControlFactory.java
@@ -29,9 +29,10 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import javax.ws.rs.NotAuthorizedException;
 import org.apache.pinot.broker.api.AccessControl;
+import org.apache.pinot.common.auth.BasicAuthTokenUtils;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.core.auth.BasicAuthPrincipal;
-import org.apache.pinot.core.auth.BasicAuthUtils;
+import org.apache.pinot.core.auth.BasicAuthPrincipalUtils;
 import org.apache.pinot.spi.auth.AuthorizationResult;
 import org.apache.pinot.spi.auth.TableAuthorizationResult;
 import org.apache.pinot.spi.auth.TableRowColAccessResult;
@@ -62,7 +63,8 @@ public class BasicAuthAccessControlFactory extends AccessControlFactory {
 
   @Override
   public void init(PinotConfiguration configuration) {
-    _accessControl = new BasicAuthAccessControl(BasicAuthUtils.extractBasicAuthPrincipals(configuration, PREFIX));
+    _accessControl = new BasicAuthAccessControl(
+        BasicAuthPrincipalUtils.extractBasicAuthPrincipals(configuration, PREFIX));
   }
 
   @Override
@@ -160,7 +162,7 @@ public class BasicAuthAccessControlFactory extends AccessControlFactory {
       if (tokens.isEmpty()) {
         return Optional.empty();
       }
-      return tokens.stream().map(org.apache.pinot.common.auth.BasicAuthUtils::normalizeBase64Token)
+      return tokens.stream().map(BasicAuthTokenUtils::normalizeBase64Token)
           .map(_token2principal::get).filter(Objects::nonNull)
           .findFirst();
     }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/ZkBasicAuthAccessControlFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/ZkBasicAuthAccessControlFactory.java
@@ -30,11 +30,12 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.pinot.broker.api.AccessControl;
+import org.apache.pinot.common.auth.BasicAuthTokenUtils;
 import org.apache.pinot.common.config.provider.AccessControlUserCache;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.utils.BcryptUtils;
 import org.apache.pinot.core.auth.BasicAuthPrincipal;
-import org.apache.pinot.core.auth.BasicAuthUtils;
+import org.apache.pinot.core.auth.BasicAuthPrincipalUtils;
 import org.apache.pinot.core.auth.ZkBasicAuthPrincipal;
 import org.apache.pinot.spi.auth.AuthorizationResult;
 import org.apache.pinot.spi.auth.TableAuthorizationResult;
@@ -127,12 +128,12 @@ public class ZkBasicAuthAccessControlFactory extends AccessControlFactory {
       }
 
       Map<String, ZkBasicAuthPrincipal> name2principal =
-          BasicAuthUtils.extractBasicAuthPrincipals(_userCache.getAllBrokerUserConfig()).stream()
+          BasicAuthPrincipalUtils.extractBasicAuthPrincipals(_userCache.getAllBrokerUserConfig()).stream()
               .collect(Collectors.toMap(BasicAuthPrincipal::getName, p -> p));
 
       for (String token : tokens) {
-        String username = org.apache.pinot.common.auth.BasicAuthUtils.extractUsername(token);
-        String password = org.apache.pinot.common.auth.BasicAuthUtils.extractPassword(token);
+        String username = BasicAuthTokenUtils.extractUsername(token);
+        String password = BasicAuthTokenUtils.extractPassword(token);
 
         if (StringUtils.isEmpty(username) || StringUtils.isEmpty(password)) {
           continue;

--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/utils/DriverUtils.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/utils/DriverUtils.java
@@ -35,7 +35,7 @@ import org.apache.commons.configuration2.MapConfiguration;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hc.core5.http.NameValuePair;
 import org.apache.hc.core5.net.URLEncodedUtils;
-import org.apache.pinot.common.auth.BasicAuthUtils;
+import org.apache.pinot.common.auth.BasicAuthTokenUtils;
 import org.apache.pinot.common.config.TlsConfig;
 import org.apache.pinot.common.utils.tls.TlsUtils;
 import org.apache.pinot.spi.env.PinotConfiguration;
@@ -79,7 +79,7 @@ public class DriverUtils {
       if (StringUtils.isAnyEmpty(username, password)) {
         throw new SQLException("Empty username or password provided.");
       }
-      String authToken = BasicAuthUtils.toBasicAuthToken(username, password);
+      String authToken = BasicAuthTokenUtils.toBasicAuthToken(username, password);
       headers.put(AUTH_HEADER, authToken);
       info.setProperty(AUTH_HEADER_CONFIG_KEY, authToken);
     }

--- a/pinot-common/src/main/java/org/apache/pinot/common/auth/AuthProviderUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/auth/AuthProviderUtils.java
@@ -221,7 +221,7 @@ public final class AuthProviderUtils {
     }
 
     if (StringUtils.isNotBlank(user)) {
-      return new StaticTokenAuthProvider(BasicAuthUtils.toBasicAuthToken(user, password));
+      return new StaticTokenAuthProvider(BasicAuthTokenUtils.toBasicAuthToken(user, password));
     }
 
     return new NullAuthProvider();

--- a/pinot-common/src/main/java/org/apache/pinot/common/auth/BasicAuthTokenUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/auth/BasicAuthTokenUtils.java
@@ -27,10 +27,10 @@ import org.apache.pinot.common.utils.BcryptUtils;
 /**
  * Utility for configuring basic auth and parsing related http tokens
  */
-public final class BasicAuthUtils {
+public final class BasicAuthTokenUtils {
   private static final String ALL = "*";
 
-  private BasicAuthUtils() {
+  private BasicAuthTokenUtils() {
     // left blank
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/BasicAuthAccessControlFactory.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/BasicAuthAccessControlFactory.java
@@ -26,8 +26,9 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.ws.rs.NotAuthorizedException;
 import javax.ws.rs.core.HttpHeaders;
+import org.apache.pinot.common.auth.BasicAuthTokenUtils;
 import org.apache.pinot.core.auth.BasicAuthPrincipal;
-import org.apache.pinot.core.auth.BasicAuthUtils;
+import org.apache.pinot.core.auth.BasicAuthPrincipalUtils;
 import org.apache.pinot.core.auth.TargetType;
 import org.apache.pinot.spi.env.PinotConfiguration;
 
@@ -54,7 +55,8 @@ public class BasicAuthAccessControlFactory implements AccessControlFactory {
 
   @Override
   public void init(PinotConfiguration configuration) {
-    _accessControl = new BasicAuthAccessControl(BasicAuthUtils.extractBasicAuthPrincipals(configuration, PREFIX));
+    _accessControl = new BasicAuthAccessControl(
+        BasicAuthPrincipalUtils.extractBasicAuthPrincipals(configuration, PREFIX));
   }
 
   @Override
@@ -106,7 +108,7 @@ public class BasicAuthAccessControlFactory implements AccessControlFactory {
         return Optional.empty();
       }
 
-      return authHeaders.stream().map(org.apache.pinot.common.auth.BasicAuthUtils::normalizeBase64Token)
+      return authHeaders.stream().map(BasicAuthTokenUtils::normalizeBase64Token)
           .map(_token2principal::get)
           .filter(Objects::nonNull).findFirst();
     }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/ZkBasicAuthAccessControlFactory.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/ZkBasicAuthAccessControlFactory.java
@@ -26,11 +26,12 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.ws.rs.core.HttpHeaders;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.pinot.common.auth.BasicAuthTokenUtils;
 import org.apache.pinot.common.config.provider.AccessControlUserCache;
 import org.apache.pinot.common.utils.BcryptUtils;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
-import org.apache.pinot.core.auth.BasicAuthUtils;
+import org.apache.pinot.core.auth.BasicAuthPrincipalUtils;
 import org.apache.pinot.core.auth.TargetType;
 import org.apache.pinot.core.auth.ZkBasicAuthPrincipal;
 import org.apache.pinot.spi.env.PinotConfiguration;
@@ -102,8 +103,8 @@ public class ZkBasicAuthAccessControlFactory implements AccessControlFactory {
         return Optional.empty();
       }
 
-      _name2principal = BasicAuthUtils.extractBasicAuthPrincipals(_userCache.getAllControllerUserConfig()).stream()
-          .collect(Collectors.toMap(ZkBasicAuthPrincipal::getName, p -> p));
+      _name2principal = BasicAuthPrincipalUtils.extractBasicAuthPrincipals(_userCache.getAllControllerUserConfig())
+          .stream().collect(Collectors.toMap(ZkBasicAuthPrincipal::getName, p -> p));
 
       List<String> authHeaders = headers.getRequestHeader(HEADER_AUTHORIZATION);
       if (authHeaders == null) {
@@ -111,8 +112,8 @@ public class ZkBasicAuthAccessControlFactory implements AccessControlFactory {
       }
 
       for (String authHeader : authHeaders) {
-        String username = org.apache.pinot.common.auth.BasicAuthUtils.extractUsername(authHeader);
-        String password = org.apache.pinot.common.auth.BasicAuthUtils.extractPassword(authHeader);
+        String username = BasicAuthTokenUtils.extractUsername(authHeader);
+        String password = BasicAuthTokenUtils.extractPassword(authHeader);
         if (StringUtils.isEmpty(username) || StringUtils.isEmpty(password)) {
           continue;
         }

--- a/pinot-core/src/main/java/org/apache/pinot/core/auth/BasicAuthPrincipalUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/auth/BasicAuthPrincipalUtils.java
@@ -28,14 +28,17 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.pinot.common.auth.BasicAuthTokenUtils;
 import org.apache.pinot.spi.config.user.UserConfig;
 import org.apache.pinot.spi.env.PinotConfiguration;
 
 
 /**
- * Utility for configuring basic auth and parsing related http tokens
+ * Utility for extracting and constructing BasicAuth principals
+ * from configuration and user metadata, including permissions,
+ * table access rules, and row-level security (RLS) filters.
  */
-public final class BasicAuthUtils {
+public final class BasicAuthPrincipalUtils {
   private static final String PASSWORD = "password";
   private static final String PERMISSIONS = "permissions";
   private static final String TABLES = "tables";
@@ -43,7 +46,7 @@ public final class BasicAuthUtils {
   private static final String ALL = "*";
   private static final String RLS_FILTER = "rls";
 
-  private BasicAuthUtils() {
+  private BasicAuthPrincipalUtils() {
     // left blank
   }
 
@@ -97,7 +100,7 @@ public final class BasicAuthUtils {
         }
       }
 
-      return new BasicAuthPrincipal(name, org.apache.pinot.common.auth.BasicAuthUtils.toBasicAuthToken(name, password),
+      return new BasicAuthPrincipal(name, BasicAuthTokenUtils.toBasicAuthToken(name, password),
           tables, excludeTables, permissions, tableRlsFilters);
     }).collect(Collectors.toList());
   }
@@ -124,7 +127,7 @@ public final class BasicAuthUtils {
               .collect(Collectors.toSet());
           //todo: Handle RLS filters properly
           return new ZkBasicAuthPrincipal(name,
-              org.apache.pinot.common.auth.BasicAuthUtils.toBasicAuthToken(name, password), password, component, role,
+              BasicAuthTokenUtils.toBasicAuthToken(name, password), password, component, role,
               tables, excludeTables, permissions, Map.of());
         }).collect(Collectors.toList());
   }

--- a/pinot-core/src/main/java/org/apache/pinot/server/access/BasicAuthAccessFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/server/access/BasicAuthAccessFactory.java
@@ -24,8 +24,9 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.pinot.common.auth.BasicAuthTokenUtils;
 import org.apache.pinot.core.auth.BasicAuthPrincipal;
-import org.apache.pinot.core.auth.BasicAuthUtils;
+import org.apache.pinot.core.auth.BasicAuthPrincipalUtils;
 import org.apache.pinot.spi.auth.server.RequesterIdentity;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
@@ -40,7 +41,8 @@ public class BasicAuthAccessFactory implements AccessControlFactory {
 
   @Override
   public void init(PinotConfiguration configuration) {
-    _accessControl = new BasicAuthAccessControl(BasicAuthUtils.extractBasicAuthPrincipals(configuration, PREFIX));
+    _accessControl = new BasicAuthAccessControl(
+        BasicAuthPrincipalUtils.extractBasicAuthPrincipals(configuration, PREFIX));
   }
 
   public AccessControl create() {
@@ -66,7 +68,7 @@ public class BasicAuthAccessFactory implements AccessControlFactory {
     public boolean hasDataAccess(RequesterIdentity requesterIdentity, String tableName) {
       Collection<String> tokens = getTokens(requesterIdentity);
       return tokens.stream()
-          .map(org.apache.pinot.common.auth.BasicAuthUtils::normalizeBase64Token)
+          .map(BasicAuthTokenUtils::normalizeBase64Token)
           .map(_token2principal::get)
           .filter(Objects::nonNull)
           .findFirst()

--- a/pinot-core/src/main/java/org/apache/pinot/server/access/ZkBasicAuthAccessFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/server/access/ZkBasicAuthAccessFactory.java
@@ -25,9 +25,10 @@ import java.util.Objects;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.helix.HelixManager;
+import org.apache.pinot.common.auth.BasicAuthTokenUtils;
 import org.apache.pinot.common.config.provider.AccessControlUserCache;
 import org.apache.pinot.common.utils.BcryptUtils;
-import org.apache.pinot.core.auth.BasicAuthUtils;
+import org.apache.pinot.core.auth.BasicAuthPrincipalUtils;
 import org.apache.pinot.core.auth.ZkBasicAuthPrincipal;
 import org.apache.pinot.spi.auth.server.RequesterIdentity;
 import org.apache.pinot.spi.env.PinotConfiguration;
@@ -91,13 +92,12 @@ public class ZkBasicAuthAccessFactory implements AccessControlFactory {
         initUserCache();
       }
       Collection<String> tokens = getTokens(requesterIdentity);
-      _name2principal = BasicAuthUtils.extractBasicAuthPrincipals(_userCache.getAllServerUserConfig()).stream()
+      _name2principal =
+          BasicAuthPrincipalUtils.extractBasicAuthPrincipals(_userCache.getAllServerUserConfig()).stream()
           .collect(Collectors.toMap(ZkBasicAuthPrincipal::getName, p -> p));
 
       Map<String, String> name2password = tokens.stream().collect(
-          Collectors.toMap(
-              org.apache.pinot.common.auth.BasicAuthUtils::extractUsername,
-              org.apache.pinot.common.auth.BasicAuthUtils::extractPassword,
+          Collectors.toMap(BasicAuthTokenUtils::extractUsername, BasicAuthTokenUtils::extractPassword,
               (v1, v2) -> v2));
       Map<String, ZkBasicAuthPrincipal> password2principal =
           name2password.keySet().stream().collect(Collectors.toMap(name2password::get, _name2principal::get));

--- a/pinot-core/src/test/java/org/apache/pinot/core/auth/BasicAuthTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/auth/BasicAuthTest.java
@@ -88,7 +88,8 @@ public class BasicAuthTest {
     config.put("principals.user.lesserImportantStuff.rls", "region = 'US'");
 
     PinotConfiguration configuration = new PinotConfiguration(config);
-    List<BasicAuthPrincipal> principals = BasicAuthUtils.extractBasicAuthPrincipals(configuration, "principals");
+    List<BasicAuthPrincipal> principals = BasicAuthPrincipalUtils
+        .extractBasicAuthPrincipals(configuration, "principals");
 
     Assert.assertEquals(principals.size(), 2);
 
@@ -145,7 +146,7 @@ public class BasicAuthTest {
   public void testExtractBasicAuthPrincipalsNoPrincipals() {
     Map<String, Object> config = new HashMap<>();
     PinotConfiguration configuration = new PinotConfiguration(config);
-    BasicAuthUtils.extractBasicAuthPrincipals(configuration, "principals");
+    BasicAuthPrincipalUtils.extractBasicAuthPrincipals(configuration, "principals");
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "must provide a "
@@ -154,7 +155,7 @@ public class BasicAuthTest {
     Map<String, Object> config = new HashMap<>();
     config.put("principals", "admin");
     PinotConfiguration configuration = new PinotConfiguration(config);
-    BasicAuthUtils.extractBasicAuthPrincipals(configuration, "principals");
+    BasicAuthPrincipalUtils.extractBasicAuthPrincipals(configuration, "principals");
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = ".* is not a valid name")
@@ -164,6 +165,6 @@ public class BasicAuthTest {
     config.put("principals.admin.password", "secret");
     config.put("principals.user.password", "secret");
     PinotConfiguration configuration = new PinotConfiguration(config);
-    BasicAuthUtils.extractBasicAuthPrincipals(configuration, "principals");
+    BasicAuthPrincipalUtils.extractBasicAuthPrincipals(configuration, "principals");
   }
 }

--- a/pinot-server/src/test/java/org/apache/pinot/server/api/AccessControlTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/api/AccessControlTest.java
@@ -31,7 +31,7 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 import org.apache.commons.io.FileUtils;
 import org.apache.helix.HelixManager;
-import org.apache.pinot.common.auth.BasicAuthUtils;
+import org.apache.pinot.common.auth.BasicAuthTokenUtils;
 import org.apache.pinot.common.config.TlsConfig;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.core.transport.HttpServerThreadPoolConfig;
@@ -134,9 +134,9 @@ public class AccessControlTest {
   @Test
   public void testGrpcBasicAuth() {
     testBasicAuth(new GrpcRequesterIdentity(
-        Map.of("authorization", BasicAuthUtils.toBasicAuthToken("admin123", "verysecret"))), true);
+        Map.of("authorization", BasicAuthTokenUtils.toBasicAuthToken("admin123", "verysecret"))), true);
     testBasicAuth(new GrpcRequesterIdentity(
-        Map.of("authorization", BasicAuthUtils.toBasicAuthToken("user456", "kindasecret"))), false);
+        Map.of("authorization", BasicAuthTokenUtils.toBasicAuthToken("user456", "kindasecret"))), false);
 
     testBasicAuth(new GrpcRequesterIdentity(
         Map.of("authorization", "Basic YWRtaW4xMjM6dmVyeXNlY3JldA")), true);
@@ -149,10 +149,10 @@ public class AccessControlTest {
     HttpHeaders headers = new ContainerRequest(null, null, null, null, new MapPropertiesDelegate());
     headers.getRequestHeaders()
         .put("authorization", Arrays.asList(
-            org.apache.pinot.common.auth.BasicAuthUtils.toBasicAuthToken("admin123", "verysecret")));
+            BasicAuthTokenUtils.toBasicAuthToken("admin123", "verysecret")));
     testBasicAuth(new HttpRequesterIdentity(headers), true);
     headers.getRequestHeaders()
-        .put("authorization", Arrays.asList(BasicAuthUtils.toBasicAuthToken("user456", "kindasecret")));
+        .put("authorization", Arrays.asList(BasicAuthTokenUtils.toBasicAuthToken("user456", "kindasecret")));
     testBasicAuth(new HttpRequesterIdentity(headers), false);
     headers.getRequestHeaders().put("authorization", Arrays.asList("Basic YWRtaW4xMjM6dmVyeXNlY3JldA"));
     testBasicAuth(new HttpRequesterIdentity(headers), true);

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/AuthQuickstart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/AuthQuickstart.java
@@ -23,7 +23,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.pinot.common.auth.AuthProviderUtils;
-import org.apache.pinot.common.auth.BasicAuthUtils;
+import org.apache.pinot.common.auth.BasicAuthTokenUtils;
 import org.apache.pinot.spi.auth.AuthProvider;
 import org.apache.pinot.spi.plugin.PluginManager;
 import org.apache.pinot.tools.utils.AuthUtils;
@@ -37,7 +37,7 @@ public class AuthQuickstart extends Quickstart {
 
   @Override
   public AuthProvider getAuthProvider() {
-    return AuthProviderUtils.makeAuthProvider(BasicAuthUtils.toBasicAuthToken("admin", "verysecret"));
+    return AuthProviderUtils.makeAuthProvider(BasicAuthTokenUtils.toBasicAuthToken("admin", "verysecret"));
   }
 
   @Override

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/AuthZkBasicQuickstart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/AuthZkBasicQuickstart.java
@@ -23,7 +23,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.pinot.common.auth.AuthProviderUtils;
-import org.apache.pinot.common.auth.BasicAuthUtils;
+import org.apache.pinot.common.auth.BasicAuthTokenUtils;
 import org.apache.pinot.spi.auth.AuthProvider;
 import org.apache.pinot.spi.plugin.PluginManager;
 
@@ -36,7 +36,7 @@ public class AuthZkBasicQuickstart extends Quickstart {
 
   @Override
   public AuthProvider getAuthProvider() {
-    return AuthProviderUtils.makeAuthProvider(BasicAuthUtils.toBasicAuthToken("admin", "verysecret"));
+    return AuthProviderUtils.makeAuthProvider(BasicAuthTokenUtils.toBasicAuthToken("admin", "verysecret"));
   }
 
   @Override

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/TimeSeriesEngineAuthQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/TimeSeriesEngineAuthQuickStart.java
@@ -23,7 +23,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.pinot.common.auth.AuthProviderUtils;
-import org.apache.pinot.common.auth.BasicAuthUtils;
+import org.apache.pinot.common.auth.BasicAuthTokenUtils;
 import org.apache.pinot.spi.auth.AuthProvider;
 import org.apache.pinot.spi.plugin.PluginManager;
 import org.apache.pinot.tools.utils.AuthUtils;
@@ -44,7 +44,7 @@ public class TimeSeriesEngineAuthQuickStart extends TimeSeriesEngineQuickStart {
 
   @Override
   public AuthProvider getAuthProvider() {
-    return AuthProviderUtils.makeAuthProvider(BasicAuthUtils.toBasicAuthToken("admin", "verysecret"));
+    return AuthProviderUtils.makeAuthProvider(BasicAuthTokenUtils.toBasicAuthToken("admin", "verysecret"));
   }
 
   @Override


### PR DESCRIPTION
Both pinot-core and pinot-common define a class named BasicAuthUtils, which causes ambiguity in classes that need to use both utilities (e.g. ZkBasicAuthAccessControlFactory).

An initial attempt was made to merge the two classes, but this proved impractical due to Maven dependency constraints between pinot-core and pinot-common.

Further analysis showed that the two classes serve different purposes:
	•	The BasicAuthUtils in pinot-core is used to extract and construct BasicAuth principal information.
	•	The BasicAuthUtils in pinot-common is used to parse and handle HTTP Basic Auth tokens.

To resolve the conflict and better reflect their responsibilities, this **PR** is proposed to:
	•	Renames pinot-core’s BasicAuthUtils to BasicAuthPrincipalUtils
	•	Renames pinot-common’s BasicAuthUtils to BasicAuthTokenUtils
	
Benefits
	•	Eliminates naming conflicts across modules
	•	Improves code readability and maintainability
	•	Preserves clear separation of responsibilities