### PR TITLE
fix org.codehaus.mojo:animal-sniffer-annotations version to 1.26

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -301,6 +301,7 @@
     <maven.version>3.9.12</maven.version>
     <plexus-component-annotations.version>2.2.0</plexus-component-annotations.version>
     <plexus-utils.version>3.6.0</plexus-utils.version>
+    <animal-sniffer-annotations.version>1.26</animal-sniffer-annotations.version>
 
     <!-- Test Libraries -->
     <testng.version>7.11.0</testng.version>
@@ -2142,6 +2143,11 @@
         <groupId>org.codehaus.plexus</groupId>
         <artifactId>plexus-utils</artifactId>
         <version>${plexus-utils.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>animal-sniffer-annotations</artifactId>
+        <version>${animal-sniffer-annotations.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
fix org.codehaus.mojo:animal-sniffer-annotations version to 1.26