### PR TITLE
Handle null in ColumnExecutionNode

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/function/InbuiltFunctionEvaluator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/function/InbuiltFunctionEvaluator.java
@@ -376,7 +376,9 @@ public class InbuiltFunctionEvaluator implements FunctionEvaluator {
 
     @Override
     public Object execute(GenericRow row) {
-      return row.getValue(_column);
+      // Pinot segment stores the default value for nulls, so we need to check isNullValue first
+      // to return nulls correctly
+      return row.isNullValue(_column) ? null : row.getValue(_column);
     }
 
     @Override

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/function/InbuiltFunctionEvaluatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/function/InbuiltFunctionEvaluatorTest.java
@@ -130,6 +130,28 @@ public class InbuiltFunctionEvaluatorTest {
   }
 
   @Test
+  public void testColumnExpressionWithNullValue() {
+    String expression = "testColumn";
+    InbuiltFunctionEvaluator evaluator = new InbuiltFunctionEvaluator(expression);
+    assertEquals(evaluator.getArguments(), Collections.singletonList("testColumn"));
+
+    // Test with putDefaultNullValue - column has a default value but is marked as null
+    GenericRow row = new GenericRow();
+    row.putDefaultNullValue("testColumn", "defaultValue");
+    assertNull(evaluator.evaluate(row));
+
+    // Test with addNullValueField - column has a value but is explicitly marked as null
+    row.clear();
+    row.putValue("testColumn", "actualValue");
+    row.addNullValueField("testColumn");
+    assertNull(evaluator.evaluate(row));
+
+    // Test that after removing null marker, value is returned
+    row.removeNullValueField("testColumn");
+    assertEquals(evaluator.evaluate(row), "actualValue");
+  }
+
+  @Test
   public void testLiteralExpression() {
     String expression = "'testValue'";
     InbuiltFunctionEvaluator evaluator = new InbuiltFunctionEvaluator(expression);


### PR DESCRIPTION
Pinot segment stores the default value for nulls. Thus the GenericRow returned by PinotSegmentRecordReader returns the default value in row.getValue(column). 

This leads to an issue when a transformer expression requires such a column because the transform expression is evaluated on the default value. 

eg: `concat(source_column, '_SUFFIX', '')` results in null_SUFFIX rather than null 

This PR fixes that 

Tags -  `bugfix`,`backward-incompat`
 