### PR TITLE
QueryLogger consistently logs received/completed respecting rate limiter

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/querylog/QueryLogger.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/querylog/QueryLogger.java
@@ -79,20 +79,40 @@ public class QueryLogger {
     _logBeforeProcessing = logBeforeProcessing;
   }
 
-  public void log(long requestId, String query) {
-    if (!_logBeforeProcessing || !checkRateLimiter(null)) {
-      return;
+  /**
+   * Logs the query received message before processing begins.
+   * This method checks the rate limiter and returns whether logging was allowed.
+   * The return value should be passed to logQueryCompleted.
+   *
+   * @param requestId the request ID
+   * @param query the SQL query
+   * @return true if the rate limiter allowed this query (not rate-limited), false if rate-limited
+   */
+  public boolean logQueryReceived(long requestId, String query) {
+    if (!checkRateLimiter()) {
+      return false;
     }
 
-    _logger.info("SQL query for request {}: {}", requestId, query);
+    if (_logBeforeProcessing) {
+      _logger.info("SQL query for request {}: {}", requestId, query);
+    }
 
     tryLogDropped();
+    return true;
   }
 
-  public void log(QueryLogParams params) {
+  /**
+   * Logs the query completion stats after processing completes.
+   *
+   * @param params the query log parameters
+   * @param wasLogged true if logQueryReceived returned true, false otherwise.
+   *                  When false, the completion log will only be emitted if force-log
+   *                  conditions are met (exceptions, slow queries).
+   */
+  public void logQueryCompleted(QueryLogParams params, boolean wasLogged) {
     _logger.debug("Broker Response: {}", params._response);
 
-    if (!checkRateLimiter(params)) {
+    if (!wasLogged && !shouldForceLog(params)) {
       return;
     }
 
@@ -110,8 +130,8 @@ public class QueryLogger {
     tryLogDropped();
   }
 
-  private boolean checkRateLimiter(@Nullable QueryLogParams params) {
-    boolean allowed = _logRateLimiter.tryAcquire() || shouldForceLog(params);
+  private boolean checkRateLimiter() {
+    boolean allowed = _logRateLimiter.tryAcquire();
     if (!allowed) {
       _numDroppedLogs.incrementAndGet();
     }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -308,7 +308,7 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
   protected BrokerResponse handleRequestThrowing(long requestId, String query, SqlNodeAndOptions sqlNodeAndOptions,
       @Nullable RequesterIdentity requesterIdentity, RequestContext requestContext, HttpHeaders httpHeaders)
       throws QueryException, WebApplicationException {
-    _queryLogger.log(requestId, query);
+    boolean queryWasLogged = _queryLogger.logQueryReceived(requestId, query);
 
     String queryHash = CommonConstants.Broker.DEFAULT_QUERY_HASH;
     if (_enableQueryFingerprinting) {
@@ -349,7 +349,7 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
         return explain(compiledQuery, requestId, requestContext, queryTimer);
       } else {
         return query(compiledQuery, requestId, requesterIdentity, requestContext, httpHeaders, queryTimer,
-            rlsFiltersApplied.get());
+            rlsFiltersApplied.get(), queryWasLogged);
       }
     }
   }
@@ -522,7 +522,7 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
 
   private BrokerResponse query(QueryEnvironment.CompiledQuery query, long requestId,
       RequesterIdentity requesterIdentity, RequestContext requestContext, HttpHeaders httpHeaders, Timer timer,
-      boolean rlsFiltersApplied)
+      boolean rlsFiltersApplied, boolean queryWasLogged)
       throws QueryException, WebApplicationException {
     QueryEnvironment.QueryPlannerResult queryPlanResult = callAsync(requestId, query.getTextQuery(),
         () -> query.planQuery(requestId), timer);
@@ -674,9 +674,10 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
       brokerResponse.setRLSFiltersApplied(rlsFiltersApplied);
 
       // Log query and stats
-      _queryLogger.log(
+      _queryLogger.logQueryCompleted(
           new QueryLogger.QueryLogParams(requestContext, tableNames.toString(), brokerResponse,
-              QueryLogger.QueryLogParams.QueryEngine.MULTI_STAGE, requesterIdentity, null));
+              QueryLogger.QueryLogParams.QueryEngine.MULTI_STAGE, requesterIdentity, null),
+          queryWasLogged);
 
       return brokerResponse;
     } finally {


### PR DESCRIPTION
This is a potential bugfix addressing #16801.

I know we've been saying to use log4j, but query logs need to be correlated since we log once when the query is received and once when it is completed. Also, this feature already exists, and log4j is tedious to configure/test. #15264 switched the received query logs to `.info` and to not respect rate limiting. Instead, "received" logs just consume rate limiting which, for high QPS clusters, leads to the majority of logs just being "received" logs.

In this PR, the rate limiting is determined up front when the query received is logged. We choose whether to log "received", and that determines whether we log "completed" as well. This way, you should always get both logs for a given query rather than some arbitrary mix of both.

This is slightly backwards incompatible. For clusters with default settings or low RPS, they won't notice a differences. They will continue to see all logs. For clusters where "log before query" is `false`, this will continue to work the same way.

For clusters with higher RPS, `CONFIG_OF_BROKER_QUERY_LOG_MAX_RATE_PER_SECOND` is semantically changing to control the number of queries logged per second rather than the number of logs per second. For clusters where rate limit == RPS, they may see 2x the logs since this change will effectively cause "completed" to show up for each received query. For clusters where RPS >> rate limit, they will see a reduction in logs since the "received" query logs will not be rate limited, but the trade off is they will consistently see received/completed per query.

I specifically tested this on an internal cluster that only saw intermittent rate limiting every hour.
<img width="1603" height="415" alt="image" src="https://github.com/user-attachments/assets/22d6da32-5c67-44ad-934b-0abc8610c750" />

After my change, you can see the log volume doubled during rate limiting, but there's no longer a mismatch between the number of "received" vs "completed" logs.