### PR TITLE
Broker: add SLA-style per-query error metrics

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerMeter.java
@@ -288,8 +288,8 @@ public class BrokerMeter implements AbstractMetrics.Meter {
   /**
    * SLA-style per-query error classification metrics.
    */
-  public static final BrokerMeter QUERY_SYSTEM_ERROR = create("QUERY_SYSTEM_ERROR", "queries", true);
-  public static final BrokerMeter QUERY_USER_ERROR = create("QUERY_USER_ERROR", "queries", true);
+  public static final BrokerMeter QUERY_CRITICAL_ERROR = create("QUERY_CRITICAL_ERROR", "queries", true);
+  public static final BrokerMeter QUERY_NON_CRITICAL_ERROR = create("QUERY_NON_CRITICAL_ERROR", "queries", true);
 
   private static final Map<QueryErrorCode, BrokerMeter> QUERY_ERROR_CODE_METER_MAP;
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/exception/QueryErrorCode.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/exception/QueryErrorCode.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.spi.exception;
 
 import java.util.EnumMap;
+import java.util.EnumSet;
 import java.util.Map;
 import javax.annotation.Nonnegative;
 import javax.ws.rs.core.Response;
@@ -67,6 +68,23 @@ public enum QueryErrorCode {
   private static final Logger LOGGER = LoggerFactory.getLogger(QueryErrorCode.class);
 
   private static final QueryErrorCode[] BY_ID;
+
+  // Static set of SLA-critical (system) error codes
+  private static final EnumSet<QueryErrorCode> CRITICAL_ERROR_CODES = EnumSet.of(
+      SQL_RUNTIME,
+      INTERNAL,
+      QUERY_SCHEDULING_TIMEOUT,
+      EXECUTION_TIMEOUT,
+      BROKER_TIMEOUT,
+      SERVER_SEGMENT_MISSING,
+      BROKER_SEGMENT_UNAVAILABLE,
+      SERVER_NOT_RESPONDING,
+      BROKER_REQUEST_SEND,
+      MERGE_RESPONSE,
+      QUERY_CANCELLATION,
+      SERVER_SHUTTING_DOWN,
+      QUERY_PLANNING
+  );
 
   static {
     int maxId = -1;
@@ -172,5 +190,13 @@ public enum QueryErrorCode {
       default:
         return false;
     }
+  }
+
+  /**
+   * Returns true if the error is considered critical for SLA accounting.
+   * Critical errors represent system-side failures (timeouts, internal errors, infra issues, etc.).
+   */
+  public boolean isCriticalError() {
+    return CRITICAL_ERROR_CODES.contains(this);
   }
 }


### PR DESCRIPTION
## Summary
Introduce two global broker meters to provide a 1:1, SLA-friendly view of query failures:
- queryCriticalError
- queryNonCriticalError

These are emitted once per query response that contains any exception, alongside the existing per-error-code meters.

## Motivation
Per-error-code meters can double-count when a single query surfaces multiple error codes. For SLA/reporting, a single per-query failure signal is desirable. This change adds a clean per-query classification while preserving existing detailed error metrics.

## Changes
- Add QUERY_CRITICAL_ERROR and QUERY_NON_CRITICAL_ERROR in `BrokerMeter`
- Update `BrokerResponse.emitBrokerResponseMetrics` to:
  - Continue emitting existing per-error-code meters for each exception.
  - Emit per query querySystemError or queryUserError
- Centralize system error classification as a static `CRITICAL_ERROR_CODES`

## Critical error classification
A query is counted as system error if any exception has one of:
- SQL_RUNTIME
- INTERNAL
- QUERY_SCHEDULING_TIMEOUT
- EXECUTION_TIMEOUT
- BROKER_TIMEOUT
- SERVER_SEGMENT_MISSING
- BROKER_SEGMENT_UNAVAILABLE
- SERVER_NOT_RESPONDING
- BROKER_REQUEST_SEND
- MERGE_RESPONSE
- QUERY_CANCELLATION
- SERVER_SHUTTING_DOWN
- QUERY_PLANNING

All other error codes are counted as user errors.