### PR TITLE
feat: ability to validate partial table configs

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -241,7 +241,7 @@ public class PinotTableRestletResource {
       TableConfigTunerUtils.applyTunerConfigs(_pinotHelixResourceManager, tableConfig, schema, Collections.emptyMap());
 
       // TableConfigUtils.validate(...) is used across table create/update.
-      TableConfigUtils.validate(tableConfig, schema, typesToSkip);
+      TableConfigUtils.validate(tableConfig, schema, typesToSkip, null);
       TableConfigUtils.validateTableName(tableConfig);
     } catch (TableAlreadyExistsException e) {
       throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.CONFLICT, e);
@@ -253,7 +253,7 @@ public class PinotTableRestletResource {
         TableConfigUtils.ensureMinReplicas(tableConfig, _controllerConf.getDefaultTableMinReplicas());
         TableConfigUtils.ensureStorageQuotaConstraints(tableConfig, _controllerConf.getDimTableMaxSize());
         checkHybridTableConfig(TableNameBuilder.extractRawTableName(tableNameWithType), tableConfig);
-        TaskConfigUtils.validateTaskConfigs(tableConfig, schema, _pinotTaskManager, typesToSkip);
+        TaskConfigUtils.validateTaskConfigs(tableConfig, schema, _pinotTaskManager, typesToSkip, null);
         validateInstanceAssignment(tableConfig);
       } catch (Exception e) {
         throw new InvalidTableConfigException(e);
@@ -617,7 +617,7 @@ public class PinotTableRestletResource {
 
       schema = _pinotHelixResourceManager.getTableSchema(tableNameWithType);
       Preconditions.checkState(schema != null, "Failed to find schema for table: %s", tableNameWithType);
-      TableConfigUtils.validate(tableConfig, schema, typesToSkip);
+      TableConfigUtils.validate(tableConfig, schema, typesToSkip, null);
     } catch (Exception e) {
       String msg = String.format("Invalid table config: %s with error: %s", tableName, e.getMessage());
       throw new ControllerApplicationException(LOGGER, msg, Response.Status.BAD_REQUEST, e);
@@ -633,7 +633,7 @@ public class PinotTableRestletResource {
         TableConfigUtils.ensureMinReplicas(tableConfig, _controllerConf.getDefaultTableMinReplicas());
         TableConfigUtils.ensureStorageQuotaConstraints(tableConfig, _controllerConf.getDimTableMaxSize());
         checkHybridTableConfig(TableNameBuilder.extractRawTableName(tableNameWithType), tableConfig);
-        TaskConfigUtils.validateTaskConfigs(tableConfig, schema, _pinotTaskManager, typesToSkip);
+        TaskConfigUtils.validateTaskConfigs(tableConfig, schema, _pinotTaskManager, typesToSkip, null);
         validateInstanceAssignment(tableConfig);
       } catch (Exception e) {
         throw new InvalidTableConfigException(e);
@@ -692,8 +692,8 @@ public class PinotTableRestletResource {
       if (schema == null) {
         throw new SchemaNotFoundException("Failed to find schema for table: " + tableNameWithType);
       }
-      TableConfigUtils.validate(tableConfig, schema, typesToSkip);
-      TaskConfigUtils.validateTaskConfigs(tableConfig, schema, _pinotTaskManager, typesToSkip);
+      TableConfigUtils.validate(tableConfig, schema, typesToSkip, null);
+      TaskConfigUtils.validateTaskConfigs(tableConfig, schema, _pinotTaskManager, typesToSkip, null);
       ObjectNode tableConfigValidateStr = JsonUtils.newObjectNode();
       if (tableConfig.getTableType() == TableType.OFFLINE) {
         tableConfigValidateStr.set(TableType.OFFLINE.name(), tableConfig.toJsonNode());

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/TaskConfigUtils.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/TaskConfigUtils.java
@@ -42,7 +42,7 @@ public class TaskConfigUtils {
   }
 
   public static void validateTaskConfigs(TableConfig tableConfig, Schema schema, PinotTaskManager pinotTaskManager,
-      String validationTypesToSkip) {
+      String validationTypesToSkip, String validateOnlyTypes) {
     if (tableConfig == null || tableConfig.getTaskConfig() == null) {
       return;
     }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/util/TaskConfigUtilsTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/util/TaskConfigUtilsTest.java
@@ -79,7 +79,7 @@ public class TaskConfigUtilsTest {
         new TableTaskConfig(Map.of(TEST_TASK_TYPE, Map.of("schedule", "0 */10 * ? * * *")));
     TableConfig tableConfig =
         new TableConfigBuilder(TableType.OFFLINE).setTableName(TEST_TABLE_NAME).setTaskConfig(tableTaskConfig).build();
-    TaskConfigUtils.validateTaskConfigs(tableConfig, new Schema(), _mockTaskManager, null);
+    TaskConfigUtils.validateTaskConfigs(tableConfig, new Schema(), _mockTaskManager, null, null);
   }
 
   @Test(expectedExceptions = RuntimeException.class)
@@ -88,7 +88,7 @@ public class TaskConfigUtilsTest {
         new TableTaskConfig(Map.of("otherTask", Map.of("schedule", "0 */10 * ? * * *")));
     TableConfig tableConfig =
         new TableConfigBuilder(TableType.OFFLINE).setTableName(TEST_TABLE_NAME).setTaskConfig(tableTaskConfig).build();
-    TaskConfigUtils.validateTaskConfigs(tableConfig, new Schema(), _mockTaskManager, null);
+    TaskConfigUtils.validateTaskConfigs(tableConfig, new Schema(), _mockTaskManager, null, null);
   }
 
   @Test

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -150,7 +150,7 @@ public final class TableConfigUtils {
    * @see TableConfigUtils#validate(TableConfig, Schema, String)
    */
   public static void validate(TableConfig tableConfig, Schema schema) {
-    validate(tableConfig, schema, null);
+    validate(tableConfig, schema, null, null);
   }
 
   /**
@@ -164,37 +164,84 @@ public final class TableConfigUtils {
    *
    * TODO: Add more validations for each section (e.g. validate conditions are met for aggregateMetrics)
    */
-  public static void validate(TableConfig tableConfig, Schema schema, @Nullable String typesToSkip) {
+  public static void validate(TableConfig tableConfig, Schema schema, @Nullable String typesToSkip, @Nullable String validateOnlyTypes) {
     Preconditions.checkArgument(schema != null, "Schema should not be null");
-    Set<ValidationType> skipTypes = parseTypesToSkipString(typesToSkip);
     // Sanitize the table config before validation
     sanitize(tableConfig);
 
-    if (skipTypes.contains(ValidationType.ALL)) {
-      return;
+    // validate retention and validation config
+    if (shouldValidate(typesToSkip, validateOnlyTypes, ValidationType.RETENTION)) {
+      validateValidationConfig(tableConfig, schema);
     }
 
-    validateValidationConfig(tableConfig, schema);
-    validateIngestionConfig(tableConfig, schema);
-    if (tableConfig.getTableType() == TableType.REALTIME) {
-      validateStreamConfigMaps(tableConfig);
+    // validate ingestion config
+    if (shouldValidate(typesToSkip, validateOnlyTypes, ValidationType.INGESTION)) {
+      validateIngestionConfig(tableConfig, schema);
+      if (tableConfig.getTableType() == TableType.REALTIME) {
+        validateStreamConfigMaps(tableConfig);
+      }
     }
-    validateTierConfigList(tableConfig.getTierConfigsList());
-    validateIndexingConfigAndFieldConfigList(tableConfig, schema);
-    validateInstancePartitionsTypeMapConfig(tableConfig);
-    validatePartitionedReplicaGroupInstance(tableConfig);
-    validateInstanceAssignmentConfigs(tableConfig);
+   
+    // validate tier config
+    if (shouldValidate(typesToSkip, validateOnlyTypes, ValidationType.TIER)) {
+      validateTierConfigList(tableConfig.getTierConfigsList());
+    }
 
-    if (!skipTypes.contains(ValidationType.UPSERT)) {
+    // validate indexing config
+    if (shouldValidate(typesToSkip, validateOnlyTypes, ValidationType.INDEXING)) {
+      validateIndexingConfigAndFieldConfigList(tableConfig, schema);
+    }
+
+    // validate upsert config
+    if (shouldValidate(typesToSkip, validateOnlyTypes, ValidationType.UPSERT)) {
       validateUpsertAndDedupConfig(tableConfig, schema);
       validatePartialUpsertStrategies(tableConfig, schema);
     }
 
-    validateTaskConfig(tableConfig);
-
-    if (_enforcePoolBasedAssignment) {
-      validateInstancePoolsAndReplicaGroups(tableConfig);
+    // validate task config
+    if (shouldValidate(typesToSkip, validateOnlyTypes, ValidationType.TASK)) {
+      validateTaskConfig(tableConfig);
     }
+
+    // validate instance pool and replica group
+    if (shouldValidate(typesToSkip, validateOnlyTypes, ValidationType.INSTANCE_ASSIGNMENT)) {
+      if (_enforcePoolBasedAssignment) {
+        validateInstancePoolsAndReplicaGroups(tableConfig);
+      }
+      validateInstancePartitionsTypeMapConfig(tableConfig);
+      validatePartitionedReplicaGroupInstance(tableConfig);
+      validateInstanceAssignmentConfigs(tableConfig);
+    }
+  }
+
+  public static boolean shouldValidate(@Nullable String typesToSkip, @Nullable String validateOnlyTypes,
+      ValidationType validationType) {
+    Set<ValidationType> skipTypes = parseValidationTypesFromStringToSet(typesToSkip);
+    Set<ValidationType> includeTypes = parseValidationTypesFromStringToSet(validateOnlyTypes); // renamed
+
+    // If both are provided, throw exception (mutually exclusive)
+    if (!skipTypes.isEmpty() && !includeTypes.isEmpty()) {
+      throw new IllegalArgumentException("Cannot specify both validationTypesToSkip and validationTypesToValidateOnly");
+    }
+
+    // Both empty: validate everything
+    if (skipTypes.isEmpty() && includeTypes.isEmpty()) {
+      return true;
+    }
+
+    // Include mode: only return true if type is in includeTypes (or ALL is in
+    // includeTypes)
+    if (!includeTypes.isEmpty()) {
+      return includeTypes.contains(ValidationType.ALL) || includeTypes.contains(validationType);
+    }
+
+    // Skip mode: return false if type is in skipTypes (or ALL is in skipTypes)
+    if (!skipTypes.isEmpty()) {
+      return !skipTypes.contains(ValidationType.ALL) && !skipTypes.contains(validationType);
+    }
+
+    // Both empty: validate everything
+    return true;
   }
 
   /**
@@ -236,10 +283,24 @@ public final class TableConfigUtils {
         "Instance pool and replica group configurations must be enabled");
   }
 
-  private static Set<ValidationType> parseTypesToSkipString(@Nullable String typesToSkip) {
-    return typesToSkip == null ? Collections.emptySet()
-        : Arrays.stream(typesToSkip.split(",")).map(s -> ValidationType.valueOf(s.toUpperCase()))
-            .collect(Collectors.toSet());
+  private static Set<ValidationType> parseValidationTypesFromStringToSet(@Nullable String typesToSkip) {
+    if (typesToSkip == null) {
+      return Collections.emptySet();
+    }
+    
+    return Arrays.stream(typesToSkip.split(","))
+        .map(String::trim)
+        .filter(s -> !s.isEmpty())
+        .map(s -> {
+          try {
+            return ValidationType.valueOf(s.toUpperCase());
+          } catch (IllegalArgumentException e) {
+            throw new IllegalArgumentException(
+                String.format("Invalid validation type: '%s'. Valid types are: %s", 
+                    s, Arrays.toString(ValidationType.values())), e);
+          }
+        })
+        .collect(Collectors.toSet());
   }
 
   /**
@@ -1611,9 +1672,9 @@ public final class TableConfigUtils {
                 && tableConfig.getUpsertConfig().getConsistencyMode() == UpsertConfig.ConsistencyMode.NONE));
   }
 
-  // enum of all the skip-able validation types.
+  // enum of all the skip or validate only types.
   public enum ValidationType {
-    ALL, TASK, UPSERT
+    ALL, TASK, UPSERT, INGESTION, INDEXING, TIER, RETENTION, INSTANCE_ASSIGNMENT, SCHEMA
   }
 
   /**

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -3599,4 +3599,162 @@ public class TableConfigUtilsTest {
     // Should not throw
     TableConfigUtils.validateTaskConfig(tableConfigOnlyCompactMerge);
   }
+
+  // ==================== Validation Types Tests ====================
+
+  @Test
+  public void testShouldValidate_NoParameters() {
+    // When both parameters are null, all validation types should run
+    assertTrue(TableConfigUtils.shouldValidate(null, null, TableConfigUtils.ValidationType.TASK));
+    assertTrue(TableConfigUtils.shouldValidate(null, null, TableConfigUtils.ValidationType.UPSERT));
+    assertTrue(TableConfigUtils.shouldValidate(null, null, TableConfigUtils.ValidationType.SCHEMA));
+    assertTrue(TableConfigUtils.shouldValidate(null, null, TableConfigUtils.ValidationType.INGESTION));
+    assertTrue(TableConfigUtils.shouldValidate(null, null, TableConfigUtils.ValidationType.INDEXING));
+    assertTrue(TableConfigUtils.shouldValidate(null, null, TableConfigUtils.ValidationType.TIER));
+    assertTrue(TableConfigUtils.shouldValidate(null, null, TableConfigUtils.ValidationType.RETENTION));
+    assertTrue(TableConfigUtils.shouldValidate(null, null, TableConfigUtils.ValidationType.INSTANCE_ASSIGNMENT));
+  }
+
+  @Test
+  public void testShouldValidate_SkipSingleType() {
+    // Skip TASK, others should run
+    assertFalse(TableConfigUtils.shouldValidate("TASK", null, TableConfigUtils.ValidationType.TASK));
+    assertTrue(TableConfigUtils.shouldValidate("TASK", null, TableConfigUtils.ValidationType.UPSERT));
+    assertTrue(TableConfigUtils.shouldValidate("TASK", null, TableConfigUtils.ValidationType.SCHEMA));
+    assertTrue(TableConfigUtils.shouldValidate("TASK", null, TableConfigUtils.ValidationType.INGESTION));
+  }
+
+  @Test
+  public void testShouldValidate_SkipMultipleTypes() {
+    // Skip TASK and INGESTION
+    String typesToSkip = "TASK,INGESTION";
+    assertFalse(TableConfigUtils.shouldValidate(typesToSkip, null, TableConfigUtils.ValidationType.TASK));
+    assertFalse(TableConfigUtils.shouldValidate(typesToSkip, null, TableConfigUtils.ValidationType.INGESTION));
+    assertTrue(TableConfigUtils.shouldValidate(typesToSkip, null, TableConfigUtils.ValidationType.UPSERT));
+    assertTrue(TableConfigUtils.shouldValidate(typesToSkip, null, TableConfigUtils.ValidationType.SCHEMA));
+    assertTrue(TableConfigUtils.shouldValidate(typesToSkip, null, TableConfigUtils.ValidationType.TIER));
+  }
+
+  @Test
+  public void testShouldValidate_SkipAll() {
+    // Skip ALL - nothing should run
+    assertFalse(TableConfigUtils.shouldValidate("ALL", null, TableConfigUtils.ValidationType.TASK));
+    assertFalse(TableConfigUtils.shouldValidate("ALL", null, TableConfigUtils.ValidationType.UPSERT));
+    assertFalse(TableConfigUtils.shouldValidate("ALL", null, TableConfigUtils.ValidationType.SCHEMA));
+    assertFalse(TableConfigUtils.shouldValidate("ALL", null, TableConfigUtils.ValidationType.INGESTION));
+    assertFalse(TableConfigUtils.shouldValidate("ALL", null, TableConfigUtils.ValidationType.INDEXING));
+    assertFalse(TableConfigUtils.shouldValidate("ALL", null, TableConfigUtils.ValidationType.TIER));
+    assertFalse(TableConfigUtils.shouldValidate("ALL", null, TableConfigUtils.ValidationType.RETENTION));
+    assertFalse(TableConfigUtils.shouldValidate("ALL", null, TableConfigUtils.ValidationType.INSTANCE_ASSIGNMENT));
+  }
+
+  @Test
+  public void testShouldValidate_ValidateOnlySingleType() {
+    // Only validate SCHEMA, skip others
+    assertTrue(TableConfigUtils.shouldValidate(null, "SCHEMA", TableConfigUtils.ValidationType.SCHEMA));
+    assertFalse(TableConfigUtils.shouldValidate(null, "SCHEMA", TableConfigUtils.ValidationType.TASK));
+    assertFalse(TableConfigUtils.shouldValidate(null, "SCHEMA", TableConfigUtils.ValidationType.UPSERT));
+    assertFalse(TableConfigUtils.shouldValidate(null, "SCHEMA", TableConfigUtils.ValidationType.INGESTION));
+  }
+
+  @Test
+  public void testShouldValidate_ValidateOnlyMultipleTypes() {
+    // Only validate SCHEMA and TIER
+    String validateOnly = "SCHEMA,TIER";
+    assertTrue(TableConfigUtils.shouldValidate(null, validateOnly, TableConfigUtils.ValidationType.SCHEMA));
+    assertTrue(TableConfigUtils.shouldValidate(null, validateOnly, TableConfigUtils.ValidationType.TIER));
+    assertFalse(TableConfigUtils.shouldValidate(null, validateOnly, TableConfigUtils.ValidationType.TASK));
+    assertFalse(TableConfigUtils.shouldValidate(null, validateOnly, TableConfigUtils.ValidationType.UPSERT));
+    assertFalse(TableConfigUtils.shouldValidate(null, validateOnly, TableConfigUtils.ValidationType.INGESTION));
+  }
+
+  @Test
+  public void testShouldValidate_ValidateOnlyAll() {
+    // Validate ALL - everything should run (equivalent to no parameters)
+    assertTrue(TableConfigUtils.shouldValidate(null, "ALL", TableConfigUtils.ValidationType.TASK));
+    assertTrue(TableConfigUtils.shouldValidate(null, "ALL", TableConfigUtils.ValidationType.UPSERT));
+    assertTrue(TableConfigUtils.shouldValidate(null, "ALL", TableConfigUtils.ValidationType.SCHEMA));
+    assertTrue(TableConfigUtils.shouldValidate(null, "ALL", TableConfigUtils.ValidationType.INGESTION));
+    assertTrue(TableConfigUtils.shouldValidate(null, "ALL", TableConfigUtils.ValidationType.INDEXING));
+    assertTrue(TableConfigUtils.shouldValidate(null, "ALL", TableConfigUtils.ValidationType.TIER));
+    assertTrue(TableConfigUtils.shouldValidate(null, "ALL", TableConfigUtils.ValidationType.RETENTION));
+    assertTrue(TableConfigUtils.shouldValidate(null, "ALL", TableConfigUtils.ValidationType.INSTANCE_ASSIGNMENT));
+  }
+
+  @Test
+  public void testShouldValidate_MutuallyExclusive() {
+    // Providing both skip and validateOnly should throw exception
+    try {
+      TableConfigUtils.shouldValidate("TASK", "SCHEMA", TableConfigUtils.ValidationType.TASK);
+      fail("Should have thrown IllegalArgumentException");
+    } catch (IllegalArgumentException e) {
+      assertTrue(e.getMessage().contains("Cannot specify both"));
+    }
+  }
+
+  @Test
+  public void testShouldValidate_CaseInsensitive() {
+    // Test case insensitivity
+    assertFalse(TableConfigUtils.shouldValidate("task", null, TableConfigUtils.ValidationType.TASK));
+    assertFalse(TableConfigUtils.shouldValidate("TASK", null, TableConfigUtils.ValidationType.TASK));
+    assertFalse(TableConfigUtils.shouldValidate("TaSk", null, TableConfigUtils.ValidationType.TASK));
+    assertFalse(TableConfigUtils.shouldValidate("task,ingestion", null, TableConfigUtils.ValidationType.TASK));
+    assertFalse(TableConfigUtils.shouldValidate("task,ingestion", null, TableConfigUtils.ValidationType.INGESTION));
+  }
+
+  @Test
+  public void testShouldValidate_WithWhitespace() {
+    // Test whitespace handling
+    String typesWithSpaces = "TASK, INGESTION , TIER";
+    assertFalse(TableConfigUtils.shouldValidate(typesWithSpaces, null, TableConfigUtils.ValidationType.TASK));
+    assertFalse(TableConfigUtils.shouldValidate(typesWithSpaces, null, TableConfigUtils.ValidationType.INGESTION));
+    assertFalse(TableConfigUtils.shouldValidate(typesWithSpaces, null, TableConfigUtils.ValidationType.TIER));
+    assertTrue(TableConfigUtils.shouldValidate(typesWithSpaces, null, TableConfigUtils.ValidationType.UPSERT));
+  }
+
+  @Test
+  public void testShouldValidate_EmptyStrings() {
+    // Test handling of empty strings in comma-separated list
+    String typesWithEmpty = "TASK,,,INGESTION";
+    assertFalse(TableConfigUtils.shouldValidate(typesWithEmpty, null, TableConfigUtils.ValidationType.TASK));
+    assertFalse(TableConfigUtils.shouldValidate(typesWithEmpty, null, TableConfigUtils.ValidationType.INGESTION));
+    assertTrue(TableConfigUtils.shouldValidate(typesWithEmpty, null, TableConfigUtils.ValidationType.UPSERT));
+  }
+
+  @Test
+  public void testShouldValidate_DuplicateTypes() {
+    // Test handling of duplicate types (should work fine due to Set)
+    String typesWithDuplicates = "TASK,TASK,INGESTION,TASK";
+    assertFalse(TableConfigUtils.shouldValidate(typesWithDuplicates, null, TableConfigUtils.ValidationType.TASK));
+    assertFalse(TableConfigUtils.shouldValidate(typesWithDuplicates, null, TableConfigUtils.ValidationType.INGESTION));
+    assertTrue(TableConfigUtils.shouldValidate(typesWithDuplicates, null, TableConfigUtils.ValidationType.UPSERT));
+  }
+
+  @Test
+  public void testShouldValidate_InvalidType() {
+    // Test invalid validation type
+    try {
+      TableConfigUtils.shouldValidate("INVALID_TYPE", null, TableConfigUtils.ValidationType.TASK);
+      fail("Should have thrown IllegalArgumentException");
+    } catch (IllegalArgumentException e) {
+      assertTrue(e.getMessage().contains("Invalid validation type"));
+      assertTrue(e.getMessage().contains("INVALID_TYPE"));
+      assertTrue(e.getMessage().contains("Valid types are"));
+    }
+  }
+
+  @Test
+  public void testShouldValidate_AllValidationTypes() {
+    // Test all validation types work correctly
+    for (TableConfigUtils.ValidationType type : TableConfigUtils.ValidationType.values()) {
+      if (type != TableConfigUtils.ValidationType.ALL) {
+        // Skip the type
+        assertFalse(TableConfigUtils.shouldValidate(type.name(), null, type),
+            "Type " + type + " should be skipped");
+        // Validate only the type
+        assertTrue(TableConfigUtils.shouldValidate(null, type.name(), type),
+            "Type " + type + " should be validated");
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Why

Building UI flows that need to validate specific parts of table configuration 
independently. For example, validating only schema + ingestion configs without 
running all validations (indexing, upsert, tasks, etc.). 

Currently, table config validation is all-or-nothing, making it difficult to 
provide targeted validation feedback in UIs or validate incomplete draft configs.

## What

Added query parameters to validation APIs:
- `validationTypesToSkip` - Skip specific validations (e.g., `TASK,UPSERT`)
- `validationTypesToValidateOnly` - Validate only specific types (e.g., `SCHEMA,INGESTION`)

Supported types: SCHEMA, INGESTION, INDEXING, TIER, RETENTION, UPSERT, TASK, 
INSTANCE_ASSIGNMENT, ALL

## Benefits

- Faster validation by skipping unnecessary checks
- Targeted validation feedback for UIs
- Support for partial/draft configuration validation
- Backward compatible (parameters are optional)