### PR TITLE
Add nested dictionary encoding support for Apache Arrow

### DIFF
--- a/pinot-plugins/pinot-input-format/pinot-arrow/src/main/java/org/apache/pinot/plugin/inputformat/arrow/ArrowToGenericRowConverter.java
+++ b/pinot-plugins/pinot-input-format/pinot-arrow/src/main/java/org/apache/pinot/plugin/inputformat/arrow/ArrowToGenericRowConverter.java
@@ -32,6 +32,7 @@ import org.apache.arrow.vector.VectorSchemaRoot;
 import org.apache.arrow.vector.complex.ListVector;
 import org.apache.arrow.vector.complex.MapVector;
 import org.apache.arrow.vector.complex.StructVector;
+import org.apache.arrow.vector.dictionary.Dictionary;
 import org.apache.arrow.vector.dictionary.DictionaryEncoder;
 import org.apache.arrow.vector.ipc.ArrowStreamReader;
 import org.apache.arrow.vector.types.pojo.Field;
@@ -120,22 +121,7 @@ public class ArrowToGenericRowConverter {
       String fieldName = fieldVector.getField().getName();
 
       try {
-        Object value;
-
-        // Handle complex types with potential nested dictionary encoding
-        if (fieldVector instanceof ListVector) {
-          value = extractListValue((ListVector) fieldVector, rowIndex, reader);
-        } else if (fieldVector instanceof MapVector) {
-          value = extractMapValue((MapVector) fieldVector, rowIndex, reader);
-        } else if (fieldVector instanceof StructVector) {
-          value = extractStructValue((StructVector) fieldVector, rowIndex, reader);
-        } else {
-          // Handle simple types and top-level dictionary encoding
-          value = extractValueFromVector(fieldVector, rowIndex, reader);
-          // Convert Arrow-specific types to Pinot-compatible types
-          value = convertArrowTypeToPinotCompatible(value);
-        }
-
+        Object value = extractValueFromVector(fieldVector, rowIndex, reader);
         if (value != null) {
           row.putValue(fieldName, value);
           convertedFields++;
@@ -165,22 +151,36 @@ public class ArrowToGenericRowConverter {
       return null;
     }
 
+    // 1. Handle complex types for TRUE recursion.
+    // CRITICAL: MapVector must be checked BEFORE ListVector!
+    if (vector instanceof MapVector) {
+      return extractMapValue((MapVector) vector, index, reader);
+    } else if (vector instanceof ListVector) {
+      return extractListValue((ListVector) vector, index, reader);
+    } else if (vector instanceof StructVector) {
+      return extractStructValue((StructVector) vector, index, reader);
+    }
+
+    // 2. Handle primitive types and dictionary decoding
     try {
-      // Decode dictionary if present at this level
+      Object value;
       if (vector.getField().getDictionary() != null) {
         long dictionaryId = vector.getField().getDictionary().getId();
-        ValueVector dictionaryVector = reader.getDictionaryVectors().get(dictionaryId);
-        if (dictionaryVector == null) {
+        Dictionary dictionary = reader.getDictionaryVectors().get(dictionaryId);
+        if (dictionary == null) {
           logger.error("Dictionary ID {} not found for field {}", dictionaryId, vector.getField().getName());
           return null;
         }
-        try (ValueVector decodedVector = DictionaryEncoder.decode(vector, dictionaryVector)) {
-          return decodedVector.getObject(index);
+        try (ValueVector decodedVector = DictionaryEncoder.decode(vector, dictionary)) {
+          value = decodedVector.getObject(index);
         }
+      } else {
+        // No dictionary encoding at this level
+        value = vector.getObject(index);
       }
 
-      // No dictionary encoding at this level
-      return vector.getObject(index);
+      // 3. Convert leaf values to Pinot compatible types (e.g., Text -> String)
+      return convertArrowTypeToPinotCompatible(value);
     } catch (Exception e) {
       logger.error("Error decoding value for field {} at index {}", vector.getField().getName(), index, e);
       return null;
@@ -210,7 +210,7 @@ public class ArrowToGenericRowConverter {
     for (int i = 0; i < elementCount; i++) {
       int elementIndex = startOffset + i;
       Object elementValue = extractValueFromVector(dataVector, elementIndex, reader);
-      result.add(convertArrowTypeToPinotCompatible(elementValue));
+      result.add(elementValue);
     }
 
     return result;
@@ -234,7 +234,7 @@ public class ArrowToGenericRowConverter {
       FieldVector childVector = structVector.getChild(fieldName);
       if (childVector != null) {
         Object childValue = extractValueFromVector(childVector, index, reader);
-        result.put(fieldName, convertArrowTypeToPinotCompatible(childValue));
+        result.put(fieldName, childValue);
       }
     }
 
@@ -269,9 +269,7 @@ public class ArrowToGenericRowConverter {
       Object key = extractValueFromVector(keyVector, entryIndex, reader);
       Object value = extractValueFromVector(valueVector, entryIndex, reader);
 
-      Object convertedKey = convertArrowTypeToPinotCompatible(key);
-      Object convertedValue = convertArrowTypeToPinotCompatible(value);
-      result.put(String.valueOf(convertedKey), convertedValue);
+      result.put(String.valueOf(key), value);
     }
 
     return result;

--- a/pinot-plugins/pinot-input-format/pinot-arrow/src/test/java/org/apache/pinot/plugin/inputformat/arrow/ArrowMessageDecoderTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-arrow/src/test/java/org/apache/pinot/plugin/inputformat/arrow/ArrowMessageDecoderTest.java
@@ -759,4 +759,143 @@ public class ArrowMessageDecoderTest {
         "All nested structure types are compatible with ArrowMessageDecoder and produce valid GenericRow objects");
     decoder.close();
   }
+
+  @Test
+  public void testListWithDictEncodedElements()
+      throws Exception {
+    ArrowMessageDecoder decoder = new ArrowMessageDecoder();
+
+    Map<String, String> props = new HashMap<>();
+    Set<String> fieldsToRead = Sets.newHashSet("id", "tags");
+    String topicName = "test-list-dict-encoded";
+
+    decoder.init(props, fieldsToRead, topicName);
+
+    byte[] arrowData = ArrowTestDataUtil.createListWithDictEncodedElementsData(3);
+    GenericRow result = decoder.decode(arrowData, null);
+
+    assertNotNull(result);
+    @SuppressWarnings("unchecked")
+    List<GenericRow> rows = (List<GenericRow>) result.getValue(GenericRow.MULTIPLE_RECORDS_KEY);
+    assertNotNull(rows);
+    assertEquals(3, rows.size());
+
+    // Verify list elements are decoded strings, not indices
+    GenericRow row0 = rows.get(0);
+    assertEquals(1, row0.getValue("id"));
+    Object tags0 = row0.getValue("tags");
+    assertNotNull(tags0);
+    assertTrue(tags0 instanceof List);
+    @SuppressWarnings("unchecked")
+    List<Object> tagsList0 = (List<Object>) tags0;
+    assertEquals(2, tagsList0.size());
+    assertEquals("new", tagsList0.get(0));
+    assertEquals("sale", tagsList0.get(1));
+
+    GenericRow row1 = rows.get(1);
+    assertEquals(2, row1.getValue("id"));
+    @SuppressWarnings("unchecked")
+    List<Object> tagsList1 = (List<Object>) row1.getValue("tags");
+    assertEquals(3, tagsList1.size());
+    assertEquals("sale", tagsList1.get(0));
+    assertEquals("featured", tagsList1.get(1));
+    assertEquals("bestseller", tagsList1.get(2));
+
+    LOGGER.info("Successfully decoded List with dictionary-encoded elements");
+    decoder.close();
+  }
+
+  @Test
+  public void testStructWithDictEncodedFields()
+      throws Exception {
+    ArrowMessageDecoder decoder = new ArrowMessageDecoder();
+
+    Map<String, String> props = new HashMap<>();
+    Set<String> fieldsToRead = Sets.newHashSet("id", "person");
+    String topicName = "test-struct-dict-encoded";
+
+    decoder.init(props, fieldsToRead, topicName);
+
+    byte[] arrowData = ArrowTestDataUtil.createStructWithDictEncodedFieldsData(4);
+    GenericRow result = decoder.decode(arrowData, null);
+
+    assertNotNull(result);
+    @SuppressWarnings("unchecked")
+    List<GenericRow> rows = (List<GenericRow>) result.getValue(GenericRow.MULTIPLE_RECORDS_KEY);
+    assertNotNull(rows);
+    assertEquals(4, rows.size());
+
+    // Verify struct fields are decoded, not indices
+    GenericRow row0 = rows.get(0);
+    assertEquals(1, row0.getValue("id"));
+    Object person0 = row0.getValue("person");
+    assertNotNull(person0);
+    assertTrue(person0 instanceof Map);
+    @SuppressWarnings("unchecked")
+    Map<String, Object> personMap0 = (Map<String, Object>) person0;
+    assertEquals("Alice", personMap0.get("name"));
+    assertEquals(25, personMap0.get("age"));
+
+    GenericRow row1 = rows.get(1);
+    @SuppressWarnings("unchecked")
+    Map<String, Object> personMap1 = (Map<String, Object>) row1.getValue("person");
+    assertEquals("Bob", personMap1.get("name"));
+    assertEquals(26, personMap1.get("age"));
+
+    GenericRow row2 = rows.get(2);
+    @SuppressWarnings("unchecked")
+    Map<String, Object> personMap2 = (Map<String, Object>) row2.getValue("person");
+    assertEquals("Charlie", personMap2.get("name"));
+    assertEquals(27, personMap2.get("age"));
+
+    LOGGER.info("Successfully decoded Struct with dictionary-encoded fields");
+    decoder.close();
+  }
+
+  @Test
+  public void testMapWithDictEncodedKeys()
+      throws Exception {
+    ArrowMessageDecoder decoder = new ArrowMessageDecoder();
+
+    Map<String, String> props = new HashMap<>();
+    Set<String> fieldsToRead = Sets.newHashSet("id", "metadata");
+    String topicName = "test-map-dict-encoded";
+
+    decoder.init(props, fieldsToRead, topicName);
+
+    byte[] arrowData = ArrowTestDataUtil.createMapWithDictEncodedKeysData(3);
+    GenericRow result = decoder.decode(arrowData, null);
+
+    assertNotNull(result);
+    @SuppressWarnings("unchecked")
+    List<GenericRow> rows = (List<GenericRow>) result.getValue(GenericRow.MULTIPLE_RECORDS_KEY);
+    assertNotNull(rows);
+    assertEquals(3, rows.size());
+
+    // Verify map keys are decoded strings, not indices
+    GenericRow row0 = rows.get(0);
+    assertEquals(1, row0.getValue("id"));
+    Object metadata0 = row0.getValue("metadata");
+    assertNotNull(metadata0);
+    assertTrue(metadata0 instanceof Map);
+    @SuppressWarnings("unchecked")
+    Map<String, Object> metadataMap0 = (Map<String, Object>) metadata0;
+    assertEquals(2, metadataMap0.size());
+    assertTrue(metadataMap0.containsKey("status"));
+    assertTrue(metadataMap0.containsKey("priority"));
+    assertEquals(0, metadataMap0.get("status"));
+    assertEquals(1, metadataMap0.get("priority"));
+
+    GenericRow row1 = rows.get(1);
+    @SuppressWarnings("unchecked")
+    Map<String, Object> metadataMap1 = (Map<String, Object>) row1.getValue("metadata");
+    assertEquals(3, metadataMap1.size());
+    assertTrue(metadataMap1.containsKey("priority"));
+    assertTrue(metadataMap1.containsKey("category"));
+    assertTrue(metadataMap1.containsKey("region"));
+
+    LOGGER.info("Successfully decoded Map with dictionary-encoded keys");
+    decoder.close();
+  }
 }
+

--- a/pinot-plugins/pinot-input-format/pinot-arrow/src/test/java/org/apache/pinot/plugin/inputformat/arrow/util/ArrowTestDataUtil.java
+++ b/pinot-plugins/pinot-input-format/pinot-arrow/src/test/java/org/apache/pinot/plugin/inputformat/arrow/util/ArrowTestDataUtil.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import java.util.List;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.BitVector;
+import org.apache.arrow.vector.FieldVector;
 import org.apache.arrow.vector.Float8Vector;
 import org.apache.arrow.vector.IntVector;
 import org.apache.arrow.vector.TimeStampMilliVector;
@@ -602,8 +603,7 @@ public class ArrowTestDataUtil {
         new DictionaryEncoding(1L, false, new ArrowType.Int(32, true));
 
     try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE);
-        VarCharVector dictionaryVector = new VarCharVector("tags_dict", allocator);
-        IntVector idVector = new IntVector("id", allocator)) {
+        VarCharVector dictionaryVector = new VarCharVector("tags_dict", allocator)) {
 
       // Create dictionary
       dictionaryVector.allocateNew();
@@ -627,7 +627,7 @@ public class ArrowTestDataUtil {
       Schema schema = new Schema(Arrays.asList(idField, tagsField));
 
       try (VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator)) {
-        idVector = (IntVector) root.getVector("id");
+        IntVector idVector = (IntVector) root.getVector("id");
         ListVector tagsVector = (ListVector) root.getVector("tags");
         VarCharVector tagsChild = (VarCharVector) tagsVector.getDataVector();
 
@@ -653,8 +653,10 @@ public class ArrowTestDataUtil {
         root.setRowCount(numRows);
 
         // Encode the list elements
-        try (VarCharVector encodedTagsChild = (VarCharVector) DictionaryEncoder.encode(tagsChild, dictionary)) {
-          tagsVector.replaceDataVector(encodedTagsChild);
+        try (FieldVector encodedTagsChild = (FieldVector) DictionaryEncoder.encode(tagsChild, dictionary)) {
+          java.lang.reflect.Method replaceDataVectorMethod = org.apache.arrow.vector.complex.BaseRepeatedValueVector.class.getDeclaredMethod("replaceDataVector", FieldVector.class);
+          replaceDataVectorMethod.setAccessible(true);
+          replaceDataVectorMethod.invoke(tagsVector, encodedTagsChild);
           return writeArrowDataToBytes(root, dictionaryProvider);
         }
       }
@@ -671,8 +673,7 @@ public class ArrowTestDataUtil {
         new DictionaryEncoding(1L, false, new ArrowType.Int(32, true));
 
     try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE);
-        VarCharVector nameDictionaryVector = new VarCharVector("name_dict", allocator);
-        IntVector idVector = new IntVector("id", allocator)) {
+        VarCharVector nameDictionaryVector = new VarCharVector("name_dict", allocator)) {
 
       // Create dictionary
       nameDictionaryVector.allocateNew();
@@ -696,7 +697,7 @@ public class ArrowTestDataUtil {
       Schema schema = new Schema(Arrays.asList(idField, personField));
 
       try (VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator)) {
-        idVector = (IntVector) root.getVector("id");
+        IntVector idVector = (IntVector) root.getVector("id");
         StructVector personVector = (StructVector) root.getVector("person");
         VarCharVector nameVector = (VarCharVector) personVector.getChild("name");
         IntVector ageVector = (IntVector) personVector.getChild("age");
@@ -719,8 +720,10 @@ public class ArrowTestDataUtil {
         root.setRowCount(numRows);
 
         // Encode the name field
-        try (VarCharVector encodedNameVector = (VarCharVector) DictionaryEncoder.encode(nameVector, dictionary)) {
-          personVector.putChild("name", encodedNameVector);
+        try (FieldVector encodedNameVector = (FieldVector) DictionaryEncoder.encode(nameVector, dictionary)) {
+          java.lang.reflect.Method putChildMethod = org.apache.arrow.vector.complex.AbstractStructVector.class.getDeclaredMethod("putChild", String.class, FieldVector.class);
+          putChildMethod.setAccessible(true);
+          putChildMethod.invoke(personVector, "name", encodedNameVector);
           return writeArrowDataToBytes(root, dictionaryProvider);
         }
       }
@@ -737,8 +740,7 @@ public class ArrowTestDataUtil {
         new DictionaryEncoding(1L, false, new ArrowType.Int(32, true));
 
     try (RootAllocator allocator = new RootAllocator(Long.MAX_VALUE);
-        VarCharVector keyDictionaryVector = new VarCharVector("key_dict", allocator);
-        IntVector idVector = new IntVector("id", allocator)) {
+        VarCharVector keyDictionaryVector = new VarCharVector("key_dict", allocator)) {
 
       // Create dictionary
       keyDictionaryVector.allocateNew();
@@ -767,7 +769,7 @@ public class ArrowTestDataUtil {
       Schema schema = new Schema(Arrays.asList(idField, mapField));
 
       try (VectorSchemaRoot root = VectorSchemaRoot.create(schema, allocator)) {
-        idVector = (IntVector) root.getVector("id");
+        IntVector idVector = (IntVector) root.getVector("id");
         MapVector mapVector = (MapVector) root.getVector("metadata");
         StructVector entriesVector = (StructVector) mapVector.getDataVector();
         VarCharVector keyVector = (VarCharVector) entriesVector.getChild(MapVector.KEY_NAME);
@@ -800,8 +802,10 @@ public class ArrowTestDataUtil {
         root.setRowCount(numRows);
 
         // Encode the key vector
-        try (VarCharVector encodedKeyVector = (VarCharVector) DictionaryEncoder.encode(keyVector, dictionary)) {
-          entriesVector.putChild(MapVector.KEY_NAME, encodedKeyVector);
+        try (FieldVector encodedKeyVector = (FieldVector) DictionaryEncoder.encode(keyVector, dictionary)) {
+          java.lang.reflect.Method putChildMethod = org.apache.arrow.vector.complex.AbstractStructVector.class.getDeclaredMethod("putChild", String.class, FieldVector.class);
+          putChildMethod.setAccessible(true);
+          putChildMethod.invoke(entriesVector, MapVector.KEY_NAME, encodedKeyVector);
           return writeArrowDataToBytes(root, dictionaryProvider);
         }
       }


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Recursive dictionary decoding for nested Arrow structures \(List, Struct, Map\) with null handling\.

```mermaid
flowchart TD
  N0["convertSingleRow #40;F1#41;"]:::stModified
  N1["extractValueFromVector #40;F1#41;"]:::stAdded
  N2["extractListValue #40;F1#41;"]:::stAdded
  N3["extractStructValue #40;F1#41;"]:::stAdded
  N4["extractMapValue #40;F1#41;"]:::stAdded
  N0 -->|"calls"| N1
  N1 -->|"for ListVector"| N2
  N1 -->|"for StructVector"| N3
  N1 -->|"for MapVector"| N4
  N2 -->|"for each element"| N1
  N3 -->|"for each child"| N1
  N4 -->|"for key and value"| N1
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-plugins/pinot\-input\-format/pinot\-arrow/src/main/java/org/apache/pinot/plugin/inputformat/arrow/ArrowToGenericRowConverter\.java — [before](https://github.com/apache/pinot/blob/042549dd64508852c3e4edb24942c08b3499f720/pinot-plugins/pinot-input-format/pinot-arrow/src/main/java/org/apache/pinot/plugin/inputformat/arrow/ArrowToGenericRowConverter.java) · [after](https://github.com/apache/pinot/blob/e42afe031e18b6c0053bed7a639f7575c2a361bb/pinot-plugins/pinot-input-format/pinot-arrow/src/main/java/org/apache/pinot/plugin/inputformat/arrow/ArrowToGenericRowConverter.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjA0MjU0OWRkNjQ1MDg4NTJjM2U0ZWRiMjQ5NDJjMDhiMzQ5OWY3MjAiLCJjb250ZXh0X2hhc2giOiI5ZTMxYmQ5NDhjMjExMGJjMjI5YTFlZTM3ZmJhMTRkNWVlNTcxMWI1NzFiMDYzMjZmNWQwYzU0NGM2ZWJhMWI3IiwiZ2VuZXJhdGVkX2F0IjoxNzg5MDMyODk4LCJoZWFkX3NoYSI6ImU0MmFmZTAzMWUxOGI2YzAwNTNiZWQ3YTYzOWY3NTc1YzJhMzYxYmIiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiI4MmI3ZDJhNjYzMjU5YzA4MTljZjYwNTAxZDJiY2RmODQ5YWMzY2VmIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 306b17589f8c8061cd501469c2e7329d827bb902a4771e7748c1d55607526a0c -->
<!-- pinot-pr-flow:end -->

## Summary

  This PR implements nested dictionary encoding support for Apache Arrow format in Pinot, addressing the limitation noted in PR #17031.

  ## Changes

  ### Core Implementation
  - **ArrowToGenericRowConverter.java**: Added recursive dictionary decoding methods
    - `extractValueFromVector()`: Core helper for dictionary decoding with null handling
    - `extractListValue()`: Support for `List<DictEncodedType>`
    - `extractStructValue()`: Support for `Struct` with dict-encoded fields
    - `extractMapValue()`: Support for `Map<DictEncodedKey/Value>`
    - Modified `convertSingleRow()` to route complex types appropriately

  ### Test Coverage
  - **ArrowTestDataUtil.java**: Added test data generators
    - `createListWithDictEncodedElementsData()`
    - `createStructWithDictEncodedFieldsData()`
    - `createMapWithDictEncodedKeysData()`

  - **ArrowMessageDecoderTest.java**: Added unit tests
    - `testListWithDictEncodedElements()`
    - `testStructWithDictEncodedFields()`
    - `testMapWithDictEncodedKeys()`

  ## Features

  - ✅ Recursive dictionary decoding for nested structures
  - ✅ Null value preservation throughout decoding
  - ✅ Support for arbitrary nesting depth
  - ✅ Backwards compatible with existing code
  - ✅ Error handling with contextual logging

  ## Testing

  **Patterns Tested:**
  - List<DictString>
  - Struct<name: DictString, age: int>
  - Map<DictString, int>

  **Backwards Compatibility:**
  - All existing tests should pass (existing flat dictionary encoding and non-dictionary nested structures unchanged)

  ## Known Limitations

  **Not Yet Tested (Future Work):**
  - Deep nesting (3-4 levels)
  - Complex nested combinations (List<Struct<field: DictString>>)
  - Error edge cases (invalid dict ID, out-of-bounds index)

  ## Test Plan

  1. Run existing Arrow decoder tests to verify no regressions
  2. Run new nested dictionary tests to verify functionality
  3. Test with real Arrow data containing nested dictionary-encoded structures

  ## Related

  - Addresses limitation from PR #17031