### PR TITLE
[BugFix] Fix field spec sort order

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/utils/SegmentProcessorUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/utils/SegmentProcessorUtils.java
@@ -73,9 +73,9 @@ public final class SegmentProcessorUtils {
       }
     }
 
-    metricFieldSpecs.sort(Comparator.comparing(FieldSpec::getName));
-    fieldSpecs.addAll(nonMetricFieldSpecs);
     nonMetricFieldSpecs.sort(Comparator.comparing(FieldSpec::getName));
+    fieldSpecs.addAll(nonMetricFieldSpecs);
+    metricFieldSpecs.sort(Comparator.comparing(FieldSpec::getName));
     fieldSpecs.addAll(metricFieldSpecs);
 
     int numSortFields;


### PR DESCRIPTION
In SegmentProcessorUtils, fields are classified and sorted when collecting all FieldSpecs.
However, there is a logical issue in the current implementation: although fields are added in the intended order, the sorting of nonMetricFieldSpecs happens after they are added to the final list, so the sort has no effect.
While this does not currently impact downstream behavior, the logic is incorrect and potentially misleading. This PR fixes the ordering to ensure the sorting is applied as intended.

Hi @Jackie-Jiang @xiangfu0 , please help review this PR when you are free. 