### PR TITLE
[Flaky-test] Make simple aggregate query cheaper for accountant test

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseQueryKillingIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseQueryKillingIntegrationTest.java
@@ -77,7 +77,7 @@ public abstract class BaseQueryKillingIntegrationTest extends BaseClusterIntegra
       "SET sortAggregateSingleThreadedNumSegmentsThreshold=10000; SET sortAggregateLimitThreshold=3000001; "
           + "SELECT DISTINCT_COUNT_HLL(intDimSV1, 14), stringDimSV2 FROM mytable GROUP BY 2 ORDER BY 2 LIMIT 3000000";
 
-  protected static final String AGGREGATE_QUERY = "SELECT DISTINCT_COUNT_HLL(intDimSV1, 14) FROM mytable";
+  protected static final String AGGREGATE_QUERY = "SELECT MIN(intDimSV1) FROM mytable";
   protected static final String SELECT_STAR_QUERY = "SELECT * FROM mytable LIMIT 5";
 
   @BeforeClass


### PR DESCRIPTION
Fix the flakiness of:
```
2026-01-08T12:11:11.9644884Z [ERROR] Failures: 
2026-01-08T12:11:11.9656687Z [ERROR]   CpuBasedServerQueryKillingIntegrationTest.testCpuTimeKillMultipleQueries:94 Expected no exceptions for query: SELECT DISTINCT_COUNT_HLL(intDimSV1, 14) FROM mytable, but got: [{"errorCode":245,"message":"CPU time based killed on SERVER: Server_localhost_22001 as it used: 503214032 ns of CPU time (exceeding threshold: 500000000)"}] expected [true] but found [false]
```