### PR TITLE
Removing unnecessary RESOURCE_CONFIG change type for MultiClusterHelixBrokerStarter

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/MultiClusterHelixBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/MultiClusterHelixBrokerStarter.java
@@ -331,7 +331,6 @@ public class MultiClusterHelixBrokerStarter extends BaseBrokerStarter {
         handlers.put(ChangeType.IDEAL_STATE, Collections.singletonList(routingManager));
         handlers.put(ChangeType.EXTERNAL_VIEW, Collections.singletonList(routingManager));
         handlers.put(ChangeType.INSTANCE_CONFIG, Collections.singletonList(routingManager));
-        handlers.put(ChangeType.RESOURCE_CONFIG, Collections.singletonList(routingManager));
 
         ClusterChangeMediator mediator = new ClusterChangeMediator(handlers, _brokerMetrics);
         mediator.start();


### PR DESCRIPTION
While running broker in multi-cluster mode, received periodic exceptions for:
```
java.lang.IllegalArgumentException: Illegal change type: RESOURCE_CONFIG 
at org.apache.pinot.broker.routing.manager.BaseBrokerRoutingManager.processClusterChange(BaseBrokerRoutingManager.java:204) 
at org.apache.pinot.broker.broker.helix.ClusterChangeMediator.processClusterChange(ClusterChangeMediator.java:137) 
at org.apache.pinot.broker.broker.helix.ClusterChangeMediator.lambda$new$0(ClusterChangeMediator.java:104) at java.base/java.lang.Thread.run(Thread.java:1583)
```

It turns out `RESOURCE_CONFIG` was incorrectly added to the `ClusterChangeMediator` in `MultiClusterHelixBrokerStarter`. This PR fixes that.