### PR TITLE
Fix maven-dependency-plugin to 3.8.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
     <groupId>org.apache</groupId>
     <artifactId>apache</artifactId>
     <version>36</version>
-    <relativePath />
+    <relativePath/>
   </parent>
 
   <groupId>org.apache.pinot</groupId>
@@ -965,7 +965,7 @@
         </exclusions>
       </dependency>
 
-     <!-- JMX exporter-->
+      <!-- JMX exporter-->
       <dependency>
         <groupId>io.prometheus.jmx</groupId>
         <artifactId>jmx_prometheus_javaagent</artifactId>
@@ -2180,7 +2180,7 @@
               <importOrder>
                 <order>,\#</order>
               </importOrder>
-              <removeUnusedImports />
+              <removeUnusedImports/>
             </java>
           </configuration>
         </plugin>
@@ -2319,7 +2319,7 @@
               <phase>validate</phase>
               <configuration>
                 <rules>
-                  <dependencyConvergence />
+                  <dependencyConvergence/>
                   <bannedDependencies>
                     <excludes>
                       <!-- Use org.slf4j:jcl-over-slf4j -->
@@ -2871,6 +2871,11 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>3.8.1</version>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
         <dependencies>
           <dependency>
@@ -2893,8 +2898,8 @@
           <transformers>
             <!-- See https://logging.apache.org/log4j/transform for details -->
             <transformer implementation="org.apache.logging.log4j.maven.plugins.shade.transformer.Log4j2PluginCacheFileTransformer"/>
-            <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer" />
-            <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
+            <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
+            <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
             <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
               <mainClass>${mainClass}</mainClass>
               <manifestEntries>


### PR DESCRIPTION
## Description 
Maven 3.9.0 has trouble resolving dependency `assembly-descriptor` in `pinot-metrics` (they are in the same reactor) during `mvn dependency:go-offline`. Fixing the `maven-dependency-plugin` version to 3.8.1 solve the problem.

Related issue: https://github.com/apache/maven-dependency-plugin/issues/1543

Related log:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-dependency-plugin:3.9.0:go-offline (default-cli) on project pinot-dropwizard: The following artifacts could not be resolved: org.apache.pinot:assembly-descriptor:jar:1.5.0-SNAPSHOT (absent): Could not find artifact org.apache.pinot:assembly-descriptor:jar:1.5.0-SNAPSHOT -> [Help 1]
```