### PR TITLE
Add license header to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,3 +1,24 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+
 # Apache Pinot - AGENTS Guide
 
 This file provides quick, practical guidance for coding agents working in this


### PR DESCRIPTION
- Fix failing Maven RAT plugin check:
```
  Warning:  Files with unapproved licenses:
    AGENTS.md
  
  [INFO] ------------------------------------------------------------------------
  [INFO] Reactor Summary for Pinot 1.5.0-SNAPSHOT:
  [INFO] 
  [INFO] Pinot .............................................. FAILURE [  5.447 s]
  [INFO] Pinot Dependency Verifier .......................... SKIPPED
  [INFO] ------------------------------------------------------------------------
  [INFO] BUILD FAILURE
  [INFO] ------------------------------------------------------------------------
  [INFO] Total time:  7.146 s
  [INFO] Finished at: 2026-01-10T17:13:19Z
  [INFO] ------------------------------------------------------------------------
  [INFO] 12 goals, 12 executed
  Error:  Failed to execute goal org.apache.rat:apache-rat-plugin:0.16.1:check (default) on project pinot: Too many files with unapproved license: 1 See RAT report in: /home/runner/work/pinot/pinot/target/rat.txt -> [Help 1]
  Error:  
  Error:  To see the full stack trace of the errors, re-run Maven with the -e switch.
  Error:  Re-run Maven using the -X switch to enable full debug logging.
  Error:  
  Error:  For more information about the errors and possible solutions, please read the following articles:
  Error:  [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException

```