### PR TITLE
[Draft] [Do not merge] Fix deleted keys workflow to prevent stale record resurrection during restarts

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
@@ -69,6 +69,7 @@ public enum ServerMeter implements AbstractMetrics.Meter {
   TOTAL_KEYS_MARKED_FOR_DELETION("rows", false),
   DELETED_KEYS_WITHIN_TTL_WINDOW("rows", false),
   DELETED_TTL_KEYS_IN_MULTIPLE_SEGMENTS("rows", false),
+  DELETED_KEYS_SKIPPED_SEGMENT_LOADING("rows", false),
   METADATA_TTL_PRIMARY_KEYS_REMOVED("rows", false),
   UPSERT_MISSED_VALID_DOC_ID_SNAPSHOT_COUNT("segments", false),
   UPSERT_MISSED_QUERYABLE_DOC_ID_SNAPSHOT_COUNT("segments", false),


### PR DESCRIPTION
Added checks to ensure all segments are loaded before removing deleted primary keys from memory during TTL cleanup. This prevents out-of-order segment loading during server restart from causing deleted records to incorrectly reappear in query results.

Issue scenario (step-by-step):

- Server restart begins, segments load in arbitrary order
- Segment S2 loads first (contains delete record R2 for PK1)
- Pinot processes R2 and marks the PK as deleted (not queryable)
- Consumption starts because S2 is loaded, even though S1 hasn't loaded yet
- During consumption loop, `doRemoveExpiredPrimaryKeys()` runs and removes the PK from memory (outside TTL + only in one segment S2). So the PK is deleted even though the `enableDeletedKeysCompactionConsistency` is set to true.
- Segment S1 loads later (contains original insert record R1 for same PK)
- Pinot processes R1, but the PK is no longer in memory. R1 is incorrectly treated as a new record and becomes queryable
- Previously deleted record now reappears in query results on this server

Fix: Defer PK removal until TableStateUtils.isAllSegmentsLoaded() returns true, ensuring all historical data is loaded before cleanup. Introduces DELETED_KEYS_SKIPPED_SEGMENT_LOADING metric for observability.