### PR TITLE
[BugFix] fix off-heap memory spike issue

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/segment/SizeBasedSegmentFlushThresholdComputer.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/segment/SizeBasedSegmentFlushThresholdComputer.java
@@ -44,7 +44,7 @@ class SizeBasedSegmentFlushThresholdComputer {
   private final Clock _clock;
 
   private long _timeConsumedForLastSegment;
-  private int _rowsConsumedForLastSegment;
+  private int _rowsIndexedForLastSegment;
   private long _sizeForLastSegment;
   private int _rowsThresholdForLastSegment;
   private double _segmentRowsToSizeRatio;
@@ -115,7 +115,7 @@ class SizeBasedSegmentFlushThresholdComputer {
 
     // Store values using the actual rows consumed for threshold calculations
     _timeConsumedForLastSegment = timeConsumed;
-    _rowsConsumedForLastSegment = (int) rowsForCalculation;
+    _rowsIndexedForLastSegment = (int) rowsForCalculation;
     _sizeForLastSegment = sizeForCalculation;
     _rowsThresholdForLastSegment = rowsThreshold;
 
@@ -171,9 +171,9 @@ class SizeBasedSegmentFlushThresholdComputer {
     // .getSizeThresholdToFlushSegment(),
     // we might end up using a lot more memory than required for the segment Using a minor bump strategy, until
     // we add feature to adjust time We will only slightly bump the threshold based on numRowsConsumed
-    if (_rowsConsumedForLastSegment < _rowsThresholdForLastSegment && _sizeForLastSegment < desiredSegmentSizeBytes) {
+    if (_rowsIndexedForLastSegment < _rowsThresholdForLastSegment && _sizeForLastSegment < desiredSegmentSizeBytes) {
       long timeThresholdMs = streamConfig.getFlushThresholdTimeMillis();
-      long rowsConsumed = _rowsConsumedForLastSegment;
+      long rowsConsumed = _rowsIndexedForLastSegment;
       StringBuilder logStringBuilder = new StringBuilder().append("Time threshold reached. ");
       if (timeThresholdMs < _timeConsumedForLastSegment) {
         // The administrator has reduced the time threshold. Adjust the
@@ -195,9 +195,9 @@ class SizeBasedSegmentFlushThresholdComputer {
     double optimalSegmentSizeBytesMax = desiredSegmentSizeBytes * 1.5;
     long targetRows;
     if (_sizeForLastSegment < optimalSegmentSizeBytesMin) {
-      targetRows = (long) (_rowsConsumedForLastSegment * 1.5);
+      targetRows = (long) (_rowsIndexedForLastSegment * 1.5);
     } else if (_sizeForLastSegment > optimalSegmentSizeBytesMax) {
-      targetRows = _rowsConsumedForLastSegment / 2;
+      targetRows = _rowsIndexedForLastSegment / 2;
     } else {
       targetRows = (long) (desiredSegmentSizeBytes * _segmentRowsToSizeRatio);
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -1009,7 +1009,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
   private boolean startSegmentCommit() {
     SegmentCompletionProtocol.Request.Params params = new SegmentCompletionProtocol.Request.Params();
     params.withSegmentName(_segmentNameStr).withStreamPartitionMsgOffset(_currentOffset.toString())
-        .withNumRows(_numRowsConsumed).withInstanceId(_instanceId).withReason(_stopReason);
+        .withNumRows(_numRowsIndexed).withInstanceId(_instanceId).withReason(_stopReason);
     if (_isOffHeap) {
       params.withMemoryUsedBytes(_memoryManager.getTotalAllocatedBytes());
     }
@@ -1295,7 +1295,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
     SegmentCompletionProtocol.Request.Params params = new SegmentCompletionProtocol.Request.Params();
 
     params.withSegmentName(_segmentNameStr).withStreamPartitionMsgOffset(_currentOffset.toString())
-        .withNumRows(_numRowsConsumed).withInstanceId(_instanceId);
+        .withNumRows(_numRowsIndexed).withInstanceId(_instanceId);
     if (_isOffHeap) {
       params.withMemoryUsedBytes(_memoryManager.getTotalAllocatedBytes());
     }
@@ -1308,7 +1308,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
     SegmentCompletionProtocol.Request.Params params = new SegmentCompletionProtocol.Request.Params();
 
     params.withSegmentName(_segmentNameStr).withStreamPartitionMsgOffset(_currentOffset.toString())
-        .withNumRows(_numRowsConsumed).withInstanceId(_instanceId).withReason(_stopReason)
+        .withNumRows(_numRowsIndexed).withInstanceId(_instanceId).withReason(_stopReason)
         .withBuildTimeMillis(_segmentBuildDescriptor.getBuildTimeMillis())
         .withSegmentSizeBytes(_segmentBuildDescriptor.getSegmentSizeBytes())
         .withWaitTimeMillis(_segmentBuildDescriptor.getWaitTimeMillis());
@@ -1447,7 +1447,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
     // Retry maybe once if leader is not found.
     SegmentCompletionProtocol.Request.Params params = new SegmentCompletionProtocol.Request.Params();
     params.withStreamPartitionMsgOffset(_currentOffset.toString()).withSegmentName(_segmentNameStr)
-        .withReason(_stopReason).withNumRows(_numRowsConsumed).withInstanceId(_instanceId);
+        .withReason(_stopReason).withNumRows(_numRowsIndexed).withInstanceId(_instanceId);
     if (_isOffHeap) {
       params.withMemoryUsedBytes(_memoryManager.getTotalAllocatedBytes());
     }


### PR DESCRIPTION
### BackGround

This change fixes the bug introduced by PR: https://github.com/apache/pinot/pull/16344

After upgrading pinot to 1.4.0, a group of machines experienced a signicicat increase in off-heap memory usage, growing from less thatn 10GB to more than **50+ GB.**



<img width="1713" height="340" alt="image" src="https://github.com/user-attachments/assets/a16e059a-3e74-4009-a937-81dd66fba2b3" />

----

### Analysis 
After troubleshooting, I found the issue is the error of SegmentSizeBasedFlushThresholdUpdater. This algorithm use preCommitRows and other parameters to estimate sizeForCalculation. and preCommitRows is assigned by _numRowsConsumed from Server(RealtimeSegmentDataManager). But

```
_numRowsConsumed = _numRowsIndexed + _numRowsErrored + _numRowsFiltered + .... 
```

If we use filterConfig to extract part data from Kafka topic. Using _numRowsConsumed to estimate the number of rows for the next segment is fundamentally incorrect. In one of our real production cases, a table needs to consume approximately 13 million Kafka records to generate a segment with only 200 thousand indexed documents—a difference of nearly 60×. This means that a table which originally required around 100 MB of memory would instead request nearly 6 GB of off-heap memory.

Therefore, this PR was introduced to correct this behavior.
