### PR TITLE
[Enhance] Support display zookeeper browser when using QuickStart

### DIFF
--- a/pinot-controller/src/main/resources/app/App.tsx
+++ b/pinot-controller/src/main/resources/app/App.tsx
@@ -126,7 +126,7 @@ export const App = () => {
   const componentRender = (Component, props, role) => {
     return (
       <div className="p-8">
-        <Layout clusterName={clusterName} {...props} role={role}>
+        <Layout clusterName={clusterName} {...props} role={role} authWorkflow={authWorkflow}>
           <Component {...props} />
         </Layout>
       </div>

--- a/pinot-controller/src/main/resources/app/components/Layout.tsx
+++ b/pinot-controller/src/main/resources/app/components/Layout.tsx
@@ -36,7 +36,11 @@ let navigationItems = [
 
 const Layout = (props) => {
   const role = props.role;
-  if(role === 'ADMIN'){
+  if (props.authWorkflow === 'NONE') {
+    navigationItems.push(
+        {id: 3, name: 'Zookeeper Browser', link: '/zookeeper', icon: <ZookeeperIcon /> }
+    );
+  } else if(role === 'ADMIN'){
     if(navigationItems.length <5){
       navigationItems = [
         ...navigationItems,


### PR DESCRIPTION
This PR adds support for displaying the Zookeeper Browser in the UI when the cluster is started using QuickStart.

<img width="1341" height="516" alt="image" src="https://github.com/user-attachments/assets/45f5efa3-f9e3-43ec-a82f-ec43c9daa683" />
