### PR TITLE
[ui] Add header links next to cluster name

### DIFF
--- a/pinot-controller/src/main/resources/app/components/Header.tsx
+++ b/pinot-controller/src/main/resources/app/components/Header.tsx
@@ -33,6 +33,51 @@ type Props = {
 };
 
 const useStyles = makeStyles((theme) => ({
+  clusterContainer: {
+    display: 'flex',
+    alignItems: 'center',
+    marginRight: theme.spacing(2),
+  },
+  clusterBox: {
+    textAlign: 'center',
+    margin: '11.5px 0',
+    paddingLeft: theme.spacing(2),
+    borderLeft: '1px solid rgba(255,255,255,0.5)',
+  },
+  linkGroup: {
+    display: 'flex',
+    alignItems: 'center',
+    gap: theme.spacing(1),
+    fontSize: '0.85rem',
+    paddingLeft: theme.spacing(1.5),
+    whiteSpace: 'nowrap',
+    borderLeft: '1px solid rgba(255,255,255,0.5)',
+  },
+  linkColumn: {
+    display: 'flex',
+    flexDirection: 'column',
+    height: theme.spacing(5),
+    minWidth: theme.spacing(9),
+  },
+  linkItem: {
+    flex: 1,
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: theme.spacing(0, 1),
+  },
+  linkItemTop: {
+    borderBottom: '1px solid rgba(255, 255, 255, 0.2)',
+  },
+  link: {
+    color: 'rgba(255, 255, 255, 0.9)',
+    textDecoration: 'none',
+    fontWeight: 700,
+    '&:hover': {
+      color: '#fff',
+      textDecoration: 'underline',
+    },
+  },
   breadcrumbRoot:{
     flexGrow: 1
   },
@@ -102,11 +147,34 @@ const Header = ({ highlightSidebarLink, showHideSideBarHandler, openSidebar, clu
             <TimezoneSelector variant="outlined" size="small" showIcon={false} />
           </Box>
         </Box>
-        <Box textAlign="center" marginY="11.5px" borderLeft="1px solid rgba(255,255,255,0.5)">
-          <Paper className={classes.paper}>
-            <h4>Cluster Name</h4>
-            <h2>{clusterName}</h2>
-          </Paper>
+        <Box className={classes.clusterContainer}>
+          <Box className={classes.clusterBox}>
+            <Paper className={classes.paper}>
+              <h4>Cluster Name</h4>
+              <h2>{clusterName}</h2>
+            </Paper>
+          </Box>
+          <Box className={classes.linkGroup}>
+            <Logo style={{ width: 18, height: 18, fill: '#fff' }} />
+            <Box className={classes.linkColumn}>
+              <a
+                className={`${classes.link} ${classes.linkItem} ${classes.linkItemTop}`}
+                href="https://pinot.apache.org/"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Website
+              </a>
+              <a
+                className={`${classes.link} ${classes.linkItem}`}
+                href="https://docs.pinot.apache.org/"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                Docs
+              </a>
+            </Box>
+          </Box>
         </Box>
       </Box>
     </AppBar>


### PR DESCRIPTION
Add pinot site and docs into UI page right upper corner for quick links
<img width="1921" height="640" alt="image" src="https://github.com/user-attachments/assets/75b8c710-640f-43c0-adb6-eee91473a63b" />
