### PR TITLE
Draft of my proposal for #15343

### DIFF
--- a/.github/workflows/build-multi-arch-pinot-docker-image.yml
+++ b/.github/workflows/build-multi-arch-pinot-docker-image.yml
@@ -59,7 +59,7 @@ jobs:
     strategy:
       matrix:
         arch: [ "amd64", "arm64" ]
-        base-image-tag: [ "11-amazoncorretto", "11-ms-openjdk" ]
+        base-image-tag: [ "21-amazoncorretto", "21-ms-openjdk" ]
     name: Build Pinot Docker Image on ${{ matrix.arch }} with base image ${{ matrix.base-image-tag }}
     needs: [ generate-build-info ]
     steps:
@@ -104,5 +104,5 @@ jobs:
         env:
           TAGS: "${{needs.generate-build-info.outputs.tags}}"
           BUILD_PLATFORM: "linux/arm64,linux/amd64"
-          BASE_IMAGE_TAGS: "11-amazoncorretto,11-ms-openjdk"
+          BASE_IMAGE_TAGS: "21-amazoncorretto,21-ms-openjdk"
         run: .github/workflows/scripts/docker/.pinot_multi_arch_docker_image_manifest_package.sh

--- a/.github/workflows/build-pinot-base-docker-image.yml
+++ b/.github/workflows/build-pinot-base-docker-image.yml
@@ -46,5 +46,5 @@ jobs:
           OPEN_JDK_DIST: ${{ matrix.openJdkDist }}
           BASE_IMAGE_TYPE: ${{ matrix.baseImageType }}
           BUILD_PLATFORM: "linux/amd64,linux/arm64"
-          TAG: "11-${{ matrix.openJdkDist }}"
+          TAG: "21-${{ matrix.openJdkDist }}"
         run: .github/workflows/scripts/docker/.pinot_base_docker_image_build_and_push.sh

--- a/.github/workflows/pinot_compatibility_tests.yml
+++ b/.github/workflows/pinot_compatibility_tests.yml
@@ -37,10 +37,10 @@ jobs:
     name: Pinot Compatibility Regression Testing against ${{ github.event.inputs.oldCommit }} and ${{ github.event.inputs.newCommit }} on ${{ matrix.test_suite }}
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 11
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: 21
           distribution: 'temurin'
           cache: 'maven'
       - name: Setup node

--- a/.github/workflows/pinot_multi_stage_query_engine_compatibility_tests.yml
+++ b/.github/workflows/pinot_multi_stage_query_engine_compatibility_tests.yml
@@ -37,10 +37,10 @@ jobs:
     name: Pinot Multi-Stage Query Engine Compatibility Regression Testing against ${{ github.event.inputs.oldCommit }} and ${{ github.event.inputs.newCommit }} on ${{ matrix.test_suite }}
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 11
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: 21
           distribution: 'temurin'
           cache: 'maven'
       - name: Setup node

--- a/.github/workflows/pinot_tests.yml
+++ b/.github/workflows/pinot_tests.yml
@@ -50,10 +50,10 @@ jobs:
     name: Pinot Linter Test Set
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 11
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: 21
           distribution: 'temurin'
           cache: 'maven'
       - name: Install pinot-dependency-verifier into repo
@@ -100,10 +100,12 @@ jobs:
     name: Pinot Binary Compatibility Check
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 11
+      - name: Set up JDK
         uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: |
+            11
+            21
           distribution: 'temurin'
           cache: 'maven'
       # Step that does that actual cache save and restore
@@ -178,7 +180,9 @@ jobs:
       fail-fast: false
       matrix:
         testset: [ 1, 2 ]
-        java: [ 11, 21 ]
+        java: |
+          21
+#          25 # Disable Java 25 tests until we fix the Datasketches compatibility
         distribution: [ "temurin" ]
     name: Pinot Unit Test Set ${{ matrix.testset }} (${{matrix.distribution}}-${{matrix.java}})
     steps:
@@ -186,7 +190,10 @@ jobs:
       - name: Set up JDK ${{ matrix.java }}-${{ matrix.distribution }}
         uses: actions/setup-java@v4
         with:
-          java-version: ${{ matrix.java }}
+          java-version: |
+            11
+            21
+            25
           distribution: ${{ matrix.distribution }}
           cache: 'maven'
       # Step that does that actual cache save and restore
@@ -323,7 +330,9 @@ jobs:
       - name: Set up JDK ${{ matrix.java }}-${{ matrix.distribution }}
         uses: actions/setup-java@v4
         with:
-          java-version: ${{ matrix.java }}
+          java-version: |
+            11
+            ${{ matrix.java }}
           distribution: ${{ matrix.distribution }}
           cache: 'maven'
       # Step that does that actual cache save and restore
@@ -489,10 +498,10 @@ jobs:
     name: Pinot Compatibility Regression Testing against ${{ matrix.old_commit }} on ${{ matrix.test_suite }}
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 11
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: 21
           distribution: 'temurin'
           cache: 'maven'
       - name: Setup node
@@ -554,10 +563,10 @@ jobs:
     name: Pinot Multi-Stage Query Engine Compatibility Regression Testing against ${{ matrix.old_commit }} on ${{ matrix.test_suite }}
     steps:
       - uses: actions/checkout@v4
-      - name: Set up JDK 11
+      - name: Set up JDK 21
         uses: actions/setup-java@v4
         with:
-          java-version: 11
+          java-version: 21
           distribution: 'temurin'
           cache: 'maven'
       - name: Setup node
@@ -612,7 +621,7 @@ jobs:
       # Changed to false in order to improve coverage using unsafe buffers
       fail-fast: false
       matrix:
-        java: [ 11, 21 ]
+        java: [ 21, 25 ]
         distribution: [ "temurin" ]
     name: Pinot Quickstart on JDK ${{ matrix.java }}-${{ matrix.distribution }}
     steps:

--- a/pinot-clients/pinot-java-client/pom.xml
+++ b/pinot-clients/pinot-java-client/pom.xml
@@ -32,6 +32,7 @@
   <properties>
     <pinot.root>${basedir}/../..</pinot.root>
     <shade.phase.prop>package</shade.phase.prop>
+    <jdk.version>11</jdk.version>
   </properties>
   <build>
     <resources>

--- a/pinot-clients/pinot-jdbc-client/pom.xml
+++ b/pinot-clients/pinot-jdbc-client/pom.xml
@@ -31,6 +31,7 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../..</pinot.root>
+    <jdk.version>11</jdk.version>
   </properties>
   <build>
     <resources>

--- a/pinot-common/pom.xml
+++ b/pinot-common/pom.xml
@@ -32,6 +32,8 @@
   <properties>
     <pinot.root>${basedir}/..</pinot.root>
     <thrift.bin.path>/usr/local/bin/thrift</thrift.bin.path>
+    <jdk.version>11</jdk.version>
+    <jdk.test.version>11</jdk.test.version>
   </properties>
 
   <build>

--- a/pinot-connectors/pinot-flink-connector/pom.xml
+++ b/pinot-connectors/pinot-flink-connector/pom.xml
@@ -31,6 +31,8 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../..</pinot.root>
+    <jdk.version>11</jdk.version>
+    <jdk.test.version>11</jdk.test.version>
   </properties>
 
   <dependencies>

--- a/pinot-connectors/pinot-spark-2-connector/pom.xml
+++ b/pinot-connectors/pinot-spark-2-connector/pom.xml
@@ -32,6 +32,8 @@
   <properties>
     <pinot.root>${basedir}/../..</pinot.root>
     <shadeBase>org.apache.pinot.\$internal</shadeBase>
+    <jdk.version>11</jdk.version>
+    <jdk.test.version>11</jdk.test.version>
   </properties>
 
   <profiles>

--- a/pinot-connectors/pinot-spark-3-connector/pom.xml
+++ b/pinot-connectors/pinot-spark-3-connector/pom.xml
@@ -32,6 +32,8 @@
   <properties>
     <pinot.root>${basedir}/../..</pinot.root>
     <shadeBase>org.apache.pinot.\$internal</shadeBase>
+    <jdk.version>11</jdk.version>
+    <jdk.test.version>11</jdk.test.version>
   </properties>
 
   <profiles>

--- a/pinot-connectors/pinot-spark-common/pom.xml
+++ b/pinot-connectors/pinot-spark-common/pom.xml
@@ -31,6 +31,8 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/../..</pinot.root>
+    <jdk.version>11</jdk.version>
+    <jdk.test.version>11</jdk.test.version>
   </properties>
 
   <profiles>

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/ControllerRequestClient.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/ControllerRequestClient.java
@@ -49,6 +49,8 @@ import org.apache.pinot.spi.utils.builder.ControllerRequestURLBuilder;
  *
  * <p>It should be provided with a specified {@link ControllerRequestURLBuilder} for constructing the URL requests
  * as well as a reusable {@link HttpClient} during construction.
+ *
+ * TODO: This should be moved to an external project in order to allow clients to use JDKs older than 21
  */
 public class ControllerRequestClient {
   private final HttpClient _httpClient;

--- a/pinot-core/pom.xml
+++ b/pinot-core/pom.xml
@@ -31,6 +31,8 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/..</pinot.root>
+    <jdk.version>11</jdk.version>
+    <jdk.test.version>21</jdk.test.version>
   </properties>
 
   <dependencies>

--- a/pinot-plugins/pinot-metrics/pinot-yammer/pom.xml
+++ b/pinot-plugins/pinot-metrics/pinot-yammer/pom.xml
@@ -33,6 +33,7 @@
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
     <shade.phase.prop>package</shade.phase.prop>
+    <jdk.version>11</jdk.version>
   </properties>
 
   <dependencies>

--- a/pinot-segment-local/pom.xml
+++ b/pinot-segment-local/pom.xml
@@ -32,6 +32,9 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/..</pinot.root>
+    <jdk.version>11</jdk.version> <!-- Compiles with JDK 11 because it is needed by spark connector -->
+    <!-- Tests with JDK 21 because we include test dependencies that require so (ie pinot-avro) -->
+    <jdk.test.version>21</jdk.test.version>
   </properties>
 
   <dependencies>

--- a/pinot-segment-spi/pom.xml
+++ b/pinot-segment-spi/pom.xml
@@ -32,6 +32,7 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/..</pinot.root>
+    <jdk.version>11</jdk.version>
   </properties>
 
   <dependencies>

--- a/pinot-server/pom.xml
+++ b/pinot-server/pom.xml
@@ -112,6 +112,14 @@
           <repositoryName>lib</repositoryName>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>17</source>
+          <target>17</target>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/pinot-spi/pom.xml
+++ b/pinot-spi/pom.xml
@@ -31,6 +31,8 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/..</pinot.root>
+    <jdk.version>11</jdk.version>
+    <jdk.test.version>11</jdk.test.version>
   </properties>
 
   <build>

--- a/pinot-timeseries/pinot-timeseries-spi/pom.xml
+++ b/pinot-timeseries/pinot-timeseries-spi/pom.xml
@@ -33,6 +33,7 @@
 
   <properties>
     <pinot.root>${basedir}/../..</pinot.root>
+    <jdk.version>11</jdk.version>
   </properties>
   <dependencies>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,22 @@
   <properties>
     <pinot.root>${basedir}</pinot.root>
     <build.profile.id>dev</build.profile.id>
-    <jdk.version>11</jdk.version>
+    <!--
+      By default, the release version is JDK 21.
+      Some projects designed to be used as libraries for external JVMs (like the jdbc driver or the spark connectors)
+      must set their jdk.version to 11 (or whatever they need to support).
+      They also must set jdk.test.version to that same version to be sure test are executed with that version.
+
+      In case these external libraries depend on other internal libraries (ie pinot-common), those libraries need to
+      define jdk.version to the same version as well to avoid compilation issues, but can keep their jdk.test.version
+      to 21 in case they use test dependencies that require so (like pinot-avro).
+
+      This means the internal libraries will be compiled but not verified to be compatible with the lower jdk version.
+      It is the **external library** responsibility to verify that all codepaths of the internal libraries are
+      compatible with the lower jdk version.
+    -->
+    <jdk.version>21</jdk.version>
+    <jdk.test.version>21</jdk.test.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!-- Setting maven.compiler flags to the jdk version. These are used by maven plugins like maven-javadoc-plugin -->
@@ -2297,6 +2312,9 @@
               -Xshare:off
               -XX:+EnableDynamicAgentLoading
             </argLine>
+            <jdkToolchain>
+              <version>${jdk.test.version}</version>
+            </jdkToolchain>
           </configuration>
           <!-- Explicitly select the test provider, instead of relying on the classpath -->
           <dependencies>
@@ -2402,7 +2420,7 @@
             <release>${jdk.version}</release>
             <source>${jdk.version}</source>
             <target>${jdk.version}</target>
-            <fork>true</fork>
+<!--            <fork>true</fork>-->
             <encoding>${project.build.sourceEncoding}</encoding>
             <annotationProcessorPaths>
               <path>
@@ -2424,6 +2442,25 @@
                 <version>${immutables.version}</version>
               </path>
             </annotationProcessorPaths>
+          </configuration>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-toolchains-plugin</artifactId>
+          <version>1.1</version>
+          <executions>
+            <execution>
+              <goals>
+                <goal>toolchain</goal>
+              </goals>
+            </execution>
+          </executions>
+          <configuration>
+            <toolchains>
+              <jdk>
+                <version>${jdk.version}</version>
+              </jdk>
+            </toolchains>
           </configuration>
         </plugin>
         <plugin>
@@ -2590,6 +2627,9 @@
           </excludes>
           <forkCount>1</forkCount>
           <reuseForks>false</reuseForks>
+          <jdkToolchain>
+            <version>${jdk.test.version}</version>
+          </jdkToolchain>
         </configuration>
         <executions>
           <execution>


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Upgrade default JDK to 21 while keeping library compatibility at JDK 11 via properties and updating workflows and compiler configs\.

```mermaid
flowchart TD
  N0["Root POM JDK version props #40;F21#41;"]:::stModified
  N1["Root POM JDK version usage #40;F21#41;"]:::stModified
  N2["Root POM JDK test usage #40;F21#41;"]:::stModified
  N3["Workflow JDK version updates #40;F1#44; F2#44; F3#44; F4#44; F5#41;"]:::stModified
  N4["Module POM JDK version props #40;F6#44; F7#44; F9#44; F10#44; F11#44; F12#44; F13#44; F15#44; F16#44; F17#44; F19#44; F20#41;"]:::stModified
  N5["Module POM JDK test version props #40;F8#44; F10#44; F11#44; F12#44; F14#44; F16#41;"]:::stModified
  N4 -->|"value transfer"| N1
  N5 -->|"value transfer"| N2
  N0 -->|"value transfer"| N1
  N0 -->|"value transfer"| N2
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: \.github/workflows/build\-multi\-arch\-pinot\-docker\-image\.yml — [before](https://github.com/apache/pinot/blob/90bf116554b197a46264a8be679b7402f560ec33/.github/workflows/build-multi-arch-pinot-docker-image.yml) · [after](https://github.com/apache/pinot/blob/169f6aa3c169296ba4ba5d7cb27a78b4f7ab7aea/.github/workflows/build-multi-arch-pinot-docker-image.yml)
- F2: \.github/workflows/build\-pinot\-base\-docker\-image\.yml — [before](https://github.com/apache/pinot/blob/90bf116554b197a46264a8be679b7402f560ec33/.github/workflows/build-pinot-base-docker-image.yml) · [after](https://github.com/apache/pinot/blob/169f6aa3c169296ba4ba5d7cb27a78b4f7ab7aea/.github/workflows/build-pinot-base-docker-image.yml)
- F3: \.github/workflows/pinot\_compatibility\_tests\.yml — [before](https://github.com/apache/pinot/blob/90bf116554b197a46264a8be679b7402f560ec33/.github/workflows/pinot_compatibility_tests.yml) · [after](https://github.com/apache/pinot/blob/169f6aa3c169296ba4ba5d7cb27a78b4f7ab7aea/.github/workflows/pinot_compatibility_tests.yml)
- F4: \.github/workflows/pinot\_multi\_stage\_query\_engine\_compatibility\_tests\.yml — [before](https://github.com/apache/pinot/blob/90bf116554b197a46264a8be679b7402f560ec33/.github/workflows/pinot_multi_stage_query_engine_compatibility_tests.yml) · [after](https://github.com/apache/pinot/blob/169f6aa3c169296ba4ba5d7cb27a78b4f7ab7aea/.github/workflows/pinot_multi_stage_query_engine_compatibility_tests.yml)
- F5: \.github/workflows/pinot\_tests\.yml — [before](https://github.com/apache/pinot/blob/90bf116554b197a46264a8be679b7402f560ec33/.github/workflows/pinot_tests.yml) · [after](https://github.com/apache/pinot/blob/169f6aa3c169296ba4ba5d7cb27a78b4f7ab7aea/.github/workflows/pinot_tests.yml)
- F6: pinot\-clients/pinot\-java\-client/pom\.xml — [before](https://github.com/apache/pinot/blob/90bf116554b197a46264a8be679b7402f560ec33/pinot-clients/pinot-java-client/pom.xml) · [after](https://github.com/apache/pinot/blob/169f6aa3c169296ba4ba5d7cb27a78b4f7ab7aea/pinot-clients/pinot-java-client/pom.xml)
- F7: pinot\-clients/pinot\-jdbc\-client/pom\.xml — [before](https://github.com/apache/pinot/blob/90bf116554b197a46264a8be679b7402f560ec33/pinot-clients/pinot-jdbc-client/pom.xml) · [after](https://github.com/apache/pinot/blob/169f6aa3c169296ba4ba5d7cb27a78b4f7ab7aea/pinot-clients/pinot-jdbc-client/pom.xml)
- F8: pinot\-common/pom\.xml — [before](https://github.com/apache/pinot/blob/90bf116554b197a46264a8be679b7402f560ec33/pinot-common/pom.xml) · [after](https://github.com/apache/pinot/blob/169f6aa3c169296ba4ba5d7cb27a78b4f7ab7aea/pinot-common/pom.xml)
- F9: pinot\-connectors/pinot\-flink\-connector/pom\.xml — [before](https://github.com/apache/pinot/blob/90bf116554b197a46264a8be679b7402f560ec33/pinot-connectors/pinot-flink-connector/pom.xml) · [after](https://github.com/apache/pinot/blob/169f6aa3c169296ba4ba5d7cb27a78b4f7ab7aea/pinot-connectors/pinot-flink-connector/pom.xml)
- F10: pinot\-connectors/pinot\-spark\-2\-connector/pom\.xml — [before](https://github.com/apache/pinot/blob/90bf116554b197a46264a8be679b7402f560ec33/pinot-connectors/pinot-spark-2-connector/pom.xml) · [after](https://github.com/apache/pinot/blob/169f6aa3c169296ba4ba5d7cb27a78b4f7ab7aea/pinot-connectors/pinot-spark-2-connector/pom.xml)
- F11: pinot\-connectors/pinot\-spark\-3\-connector/pom\.xml — [before](https://github.com/apache/pinot/blob/90bf116554b197a46264a8be679b7402f560ec33/pinot-connectors/pinot-spark-3-connector/pom.xml) · [after](https://github.com/apache/pinot/blob/169f6aa3c169296ba4ba5d7cb27a78b4f7ab7aea/pinot-connectors/pinot-spark-3-connector/pom.xml)
- F12: pinot\-connectors/pinot\-spark\-common/pom\.xml — [before](https://github.com/apache/pinot/blob/90bf116554b197a46264a8be679b7402f560ec33/pinot-connectors/pinot-spark-common/pom.xml) · [after](https://github.com/apache/pinot/blob/169f6aa3c169296ba4ba5d7cb27a78b4f7ab7aea/pinot-connectors/pinot-spark-common/pom.xml)
- F13: pinot\-controller/src/main/java/org/apache/pinot/controller/helix/ControllerRequestClient\.java — [before](https://github.com/apache/pinot/blob/90bf116554b197a46264a8be679b7402f560ec33/pinot-controller/src/main/java/org/apache/pinot/controller/helix/ControllerRequestClient.java) · [after](https://github.com/apache/pinot/blob/169f6aa3c169296ba4ba5d7cb27a78b4f7ab7aea/pinot-controller/src/main/java/org/apache/pinot/controller/helix/ControllerRequestClient.java)
- F14: pinot\-core/pom\.xml — [before](https://github.com/apache/pinot/blob/90bf116554b197a46264a8be679b7402f560ec33/pinot-core/pom.xml) · [after](https://github.com/apache/pinot/blob/169f6aa3c169296ba4ba5d7cb27a78b4f7ab7aea/pinot-core/pom.xml)
- F15: pinot\-plugins/pinot\-metrics/pinot\-yammer/pom\.xml — [before](https://github.com/apache/pinot/blob/90bf116554b197a46264a8be679b7402f560ec33/pinot-plugins/pinot-metrics/pinot-yammer/pom.xml) · [after](https://github.com/apache/pinot/blob/169f6aa3c169296ba4ba5d7cb27a78b4f7ab7aea/pinot-plugins/pinot-metrics/pinot-yammer/pom.xml)
- F16: pinot\-segment\-local/pom\.xml — [before](https://github.com/apache/pinot/blob/90bf116554b197a46264a8be679b7402f560ec33/pinot-segment-local/pom.xml) · [after](https://github.com/apache/pinot/blob/169f6aa3c169296ba4ba5d7cb27a78b4f7ab7aea/pinot-segment-local/pom.xml)
- F17: pinot\-segment\-spi/pom\.xml — [before](https://github.com/apache/pinot/blob/90bf116554b197a46264a8be679b7402f560ec33/pinot-segment-spi/pom.xml) · [after](https://github.com/apache/pinot/blob/169f6aa3c169296ba4ba5d7cb27a78b4f7ab7aea/pinot-segment-spi/pom.xml)
- F19: pinot\-spi/pom\.xml — [before](https://github.com/apache/pinot/blob/90bf116554b197a46264a8be679b7402f560ec33/pinot-spi/pom.xml) · [after](https://github.com/apache/pinot/blob/169f6aa3c169296ba4ba5d7cb27a78b4f7ab7aea/pinot-spi/pom.xml)
- F20: pinot\-timeseries/pinot\-timeseries\-spi/pom\.xml — [before](https://github.com/apache/pinot/blob/90bf116554b197a46264a8be679b7402f560ec33/pinot-timeseries/pinot-timeseries-spi/pom.xml) · [after](https://github.com/apache/pinot/blob/169f6aa3c169296ba4ba5d7cb27a78b4f7ab7aea/pinot-timeseries/pinot-timeseries-spi/pom.xml)
- F21: pom\.xml — [before](https://github.com/apache/pinot/blob/90bf116554b197a46264a8be679b7402f560ec33/pom.xml) · [after](https://github.com/apache/pinot/blob/169f6aa3c169296ba4ba5d7cb27a78b4f7ab7aea/pom.xml)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjkwYmYxMTY1NTRiMTk3YTQ2MjY0YThiZTY3OWI3NDAyZjU2MGVjMzMiLCJjb250ZXh0X2hhc2giOiIzM2M3ODMwZDllNTkxMTRlYmE5N2MzN2JjYmYwOTQyODBhMWVhMTM1NjdiMWYyY2M3NjEyZmZmZTAxZGY4NmRjIiwiZ2VuZXJhdGVkX2F0IjoxNzg5MDM1NDkyLCJoZWFkX3NoYSI6IjE2OWY2YWEzYzE2OTI5NmJhNGJhNWQ3Y2IyN2E3OGI0ZjdhYjdhZWEiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiI3NWIzOWJjMmQ0YTkxMWMyNTIzYmZlNGNlNTg2NTkzMjY5M2ZmNjM1IiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 5f4f9f9b1b6c377a91713e575369453af0fbfe5096ec7884867710568b5fcfe8 -->
<!-- pinot-pr-flow:end -->

