### PR TITLE
Bump parquet from 1.16.0 to 1.17.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -140,7 +140,7 @@
 
     <arrow.version>18.3.0</arrow.version>
     <avro.version>1.12.1</avro.version>
-    <parquet.version>1.16.0</parquet.version>
+    <parquet.version>1.17.0</parquet.version>
     <orc.version>1.9.8</orc.version>
     <hive.version>2.8.1</hive.version>
     <helix.version>1.3.2</helix.version>


### PR DESCRIPTION
Fix the way to identify the `INT96` field

The old way breaks because of this bug fix: https://github.com/apache/parquet-java/pull/3311
The name of the field is no longer `"INT96"`