### PR TITLE
Remove version fix on maven-dependency-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2871,11 +2871,6 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-dependency-plugin</artifactId>
-        <version>3.9.0</version>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
         <dependencies>
           <dependency>


### PR DESCRIPTION
Revert the change in https://github.com/apache/pinot/pull/17483
This is not a crucial part of Pinot. People who need `dependency:go-offline` can fix the version of the plugin themselves.