### PR TITLE
[federation] Surface warnings in broker query responses when a remote multi-cluster is unreachable

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
@@ -309,9 +309,6 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
     _isStarting = true;
     Utils.logVersions();
 
-    LOGGER.info("Connecting spectator Helix manager");
-    initSpectatorHelixManager();
-
     LOGGER.info("Setting up broker request handler");
     // Set up metric registry and broker metrics
     _metricsRegistry = PinotMetricUtils.getPinotMetricsRegistry(_brokerConf.subset(Broker.METRICS_CONFIG_PREFIX));
@@ -328,6 +325,10 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
         _brokerConf.getProperty(Broker.AdaptiveServerSelector.CONFIG_OF_TYPE,
             Broker.AdaptiveServerSelector.DEFAULT_TYPE), 1);
     BrokerMetrics.register(_brokerMetrics);
+
+    LOGGER.info("Connecting spectator Helix manager");
+    initSpectatorHelixManager();
+
     // Set up request handling classes
     _serverRoutingStatsManager = new ServerRoutingStatsManager(_brokerConf, _brokerMetrics);
     _serverRoutingStatsManager.init();

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/MultiClusterHelixBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/MultiClusterHelixBrokerStarter.java
@@ -22,8 +22,10 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.apache.helix.HelixConstants.ChangeType;
 import org.apache.helix.HelixManager;
 import org.apache.helix.HelixManagerFactory;
@@ -65,6 +67,9 @@ public class MultiClusterHelixBrokerStarter extends BaseBrokerStarter {
   protected MultiClusterRoutingManager _multiClusterRoutingManager;
   protected MultiClusterRoutingContext _multiClusterRoutingContext;
   protected Map<String, ClusterChangeMediator> _remoteClusterChangeMediator;
+
+  // Tracks clusters that failed to connect (for adding warnings to query responses)
+  protected Set<String> _unavailableClusters;
 
   public MultiClusterHelixBrokerStarter() {
   }
@@ -121,6 +126,7 @@ public class MultiClusterHelixBrokerStarter extends BaseBrokerStarter {
   }
 
   private void initRemoteClusterSpectatorHelixManagers() throws Exception {
+    _unavailableClusters = new HashSet<>();
     if (_remoteZkServers == null || _remoteZkServers.isEmpty()) {
       LOGGER.info("[multi-cluster] No remote ZK servers configured - skipping spectator Helix manager init");
       return;
@@ -141,6 +147,7 @@ public class MultiClusterHelixBrokerStarter extends BaseBrokerStarter {
         LOGGER.info("[multi-cluster] Connected to remote cluster '{}' at ZK: {}", clusterName, zkServers);
       } catch (Exception e) {
         LOGGER.error("[multi-cluster] Failed to connect to cluster '{}' at ZK: {}", clusterName, zkServers, e);
+        _unavailableClusters.add(clusterName);
         _brokerMetrics.addMeteredGlobalValue(BrokerMeter.MULTI_CLUSTER_BROKER_STARTUP_FAILURE, 1);
       }
     }
@@ -151,6 +158,10 @@ public class MultiClusterHelixBrokerStarter extends BaseBrokerStarter {
     } else {
       LOGGER.info("[multi-cluster] Connected to {}/{} remote clusters: {}", _remoteSpectatorHelixManager.size(),
         _remoteZkServers.size(), _remoteSpectatorHelixManager.keySet());
+    }
+    if (!_unavailableClusters.isEmpty()) {
+      LOGGER.warn("[multi-cluster] The following clusters are unavailable and will generate warnings "
+          + "in query responses: {}", _unavailableClusters);
     }
   }
 
@@ -271,9 +282,11 @@ public class MultiClusterHelixBrokerStarter extends BaseBrokerStarter {
     }
 
     _multiClusterRoutingContext = new MultiClusterRoutingContext(tableCacheMap, _routingManager,
-        _multiClusterRoutingManager);
-    LOGGER.info("[multi-cluster] Created federation provider with {}/{} clusters (1 primary + {} remote)",
-        tableCacheMap.size(), _remoteSpectatorHelixManager.size() + 1, tableCacheMap.size() - 1);
+        _multiClusterRoutingManager, _unavailableClusters);
+    LOGGER.info("[multi-cluster] Created federation provider with {}/{} clusters (1 primary + {} remote), "
+            + "{} unavailable",
+        tableCacheMap.size(), _remoteSpectatorHelixManager.size() + 1, tableCacheMap.size() - 1,
+        _unavailableClusters.size());
   }
 
   private void initRemoteClusterRouting() {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
@@ -849,6 +849,15 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
     for (QueryProcessingException errorMsg : errorMsgs) {
       brokerResponse.addException(errorMsg);
     }
+
+    // Add warnings for unavailable remote clusters in multi-cluster routing.
+    if (_multiClusterRoutingContext != null && QueryOptionsUtils.isMultiClusterRoutingEnabled(
+        pinotQuery.getQueryOptions(), false)) {
+      for (QueryProcessingException clusterException : _multiClusterRoutingContext.getUnavailableClusterExceptions()) {
+        brokerResponse.addException(clusterException);
+      }
+    }
+
     brokerResponse.setNumSegmentsPrunedByBroker(numPrunedSegmentsTotal);
     long executionEndTimeNs = System.nanoTime();
     _brokerMetrics.addPhaseTiming(rawTableName, BrokerQueryPhase.QUERY_EXECUTION,

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -678,6 +678,15 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
       }
       requestContext.setNumUnavailableSegments(numUnavailableSegments);
 
+      // Add warnings for unavailable remote clusters in multi-cluster routing
+      if (_multiClusterRoutingContext != null && QueryOptionsUtils.isMultiClusterRoutingEnabled(query.getOptions(),
+          false)) {
+        for (QueryProcessingException clusterException
+            : _multiClusterRoutingContext.getUnavailableClusterExceptions()) {
+          brokerResponse.addException(clusterException);
+        }
+      }
+
       fillOldBrokerResponseStats(brokerResponse, queryResults.getQueryStats(), dispatchableSubPlan);
       long totalTimeMs = System.currentTimeMillis() - requestContext.getRequestArrivalTimeMillis();
       _brokerMetrics.addTimedValue(BrokerTimer.MULTI_STAGE_QUERY_TOTAL_TIME_MS, totalTimeMs, TimeUnit.MILLISECONDS);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/exception/QueryErrorCode.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/exception/QueryErrorCode.java
@@ -59,6 +59,7 @@ public enum QueryErrorCode {
   INTERNAL(450, "InternalError", Response.Status.INTERNAL_SERVER_ERROR),
   MERGE_RESPONSE(500, "MergeResponseError", Response.Status.INTERNAL_SERVER_ERROR),
   QUERY_CANCELLATION(503, "QueryCancellationError", Response.Status.SERVICE_UNAVAILABLE),
+  REMOTE_CLUSTER_UNAVAILABLE(510, "RemoteClusterUnavailable", Response.Status.SERVICE_UNAVAILABLE),
   /// Error detected at validation time. For example, type mismatch.
   QUERY_VALIDATION(700, "QueryValidationError", Response.Status.BAD_REQUEST),
   UNKNOWN_COLUMN(710, "UnknownColumnError", Response.Status.BAD_REQUEST),


### PR DESCRIPTION
## Summary

This PR adds explicit query warnings for unreachable remote clusters in multi-cluster routing. The broker now tracks clusters that fail to connect at startup and surfaces a standardized `REMOTE_CLUSTER_UNAVAILABLE (510)` warning in SSE and MSE query responses when multi-cluster routing is enabled. 

Note: `initSpectatorHelixManager()` is moved after `BrokerMetrics` initialization to enable throwing metrics when remote spectator helix connections fail.

## Testing

Added integration tests to simulate a broker with one connected and one unreachable remote cluster, and verify that SSE and MSE returns partial results with the expected warning.