### PR TITLE
[ui] Fixing segment search bar width issue in table page

### DIFF
--- a/pinot-controller/src/main/resources/app/components/SimpleAccordion.tsx
+++ b/pinot-controller/src/main/resources/app/components/SimpleAccordion.tsx
@@ -68,6 +68,11 @@ const useStyles = makeStyles((theme: Theme) =>
       display: 'flex',
       alignItems: 'center',
       gap: theme.spacing(1),
+      flex: 1,
+      minWidth: 0,
+      '& > div': {
+        width: '100%',
+      },
     },
     additionalControlsContainer: {
       marginLeft: 'auto',


### PR DESCRIPTION
## Summary

The segment search bar within the Table View page does not fill up to the size of the container div, causing the segment names (usually longer) to truncate very early. This poses as a bad user experience since editing something in the middle or the beginning of the search string requires the cursor to be moved.

https://github.com/user-attachments/assets/65fc52f4-5056-404b-85c6-7d83fd9c8315


This PR fixes it by allowing the search bar to expand fully to the parent container size.

## Testing
Successfully tested on Quickstart.

https://github.com/user-attachments/assets/98ed8a0f-e677-4890-9e7d-cc42e4a2719a




