### PR TITLE
[Real-time Table Replication X clusters][2/n] Create a Controller Job for historical segments backfill

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
@@ -117,6 +117,8 @@ import org.apache.pinot.controller.helix.core.rebalance.TableRebalanceManager;
 import org.apache.pinot.controller.helix.core.rebalance.tenant.TenantRebalanceChecker;
 import org.apache.pinot.controller.helix.core.rebalance.tenant.TenantRebalancer;
 import org.apache.pinot.controller.helix.core.relocation.SegmentRelocator;
+import org.apache.pinot.controller.helix.core.replication.RealtimeSegmentCopier;
+import org.apache.pinot.controller.helix.core.replication.TableReplicator;
 import org.apache.pinot.controller.helix.core.retention.RetentionManager;
 import org.apache.pinot.controller.helix.core.statemodel.LeadControllerResourceMasterSlaveStateModelFactory;
 import org.apache.pinot.controller.helix.core.util.HelixSetupUtils;
@@ -226,6 +228,7 @@ public abstract class BaseControllerStarter implements ServiceStartable {
   protected TaskMetricsEmitter _taskMetricsEmitter;
   protected PoolingHttpClientConnectionManager _connectionManager;
   protected TenantRebalancer _tenantRebalancer;
+  protected TableReplicator _tableReplicator;
   // This executor should be used by all code paths for user initiated rebalances, so that the controller config
   // CONTROLLER_EXECUTOR_REBALANCE_NUM_THREADS is honored.
   protected ExecutorService _rebalancerExecutorService;
@@ -658,6 +661,7 @@ public abstract class BaseControllerStarter implements ServiceStartable {
             _rebalancerExecutorService);
     _tenantRebalancer =
         new TenantRebalancer(_tableRebalanceManager, _helixResourceManager, _rebalancerExecutorService);
+    _tableReplicator = new TableReplicator(_helixResourceManager, _executorService, new RealtimeSegmentCopier(_config));
 
     // Setting up periodic tasks
     List<PeriodicTask> controllerPeriodicTasks = setupControllerPeriodicTasks();
@@ -719,6 +723,7 @@ public abstract class BaseControllerStarter implements ServiceStartable {
         bind(_sqlQueryExecutor).to(SqlQueryExecutor.class);
         bind(_pinotLLCRealtimeSegmentManager).to(PinotLLCRealtimeSegmentManager.class);
         bind(_tenantRebalancer).to(TenantRebalancer.class);
+        bind(_tableReplicator).to(TableReplicator.class);
         bind(_tableSizeReader).to(TableSizeReader.class);
         bind(_storageQuotaChecker).to(StorageQuotaChecker.class);
         bind(_resourceUtilizationManager).to(ResourceUtilizationManager.class);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -447,6 +447,7 @@ public class ControllerConf extends PinotConfiguration {
   public static final String CONFIG_OF_MAX_TENANT_REBALANCE_JOBS_IN_ZK = "controller.tenant.rebalance.maxJobsInZK";
   public static final String CONFIG_OF_MAX_RELOAD_SEGMENT_JOBS_IN_ZK = "controller.reload.segment.maxJobsInZK";
   public static final String CONFIG_OF_MAX_FORCE_COMMIT_JOBS_IN_ZK = "controller.force.commit.maxJobsInZK";
+  public static final String CONFIG_OF_MAX_TABLE_REPLICATION_JOBS_IN_ZK = "controller.table.replication.maxJobsInZK";
 
   private final Map<String, String> _invalidConfigs = new ConcurrentHashMap<>();
 
@@ -1480,5 +1481,9 @@ public class ControllerConf extends PinotConfiguration {
 
   public boolean getSegmentCompletionGroupCommitEnabled() {
     return getProperty(CONTROLLER_SEGMENT_COMPLETION_GROUP_COMMIT_ENABLED, true);
+  }
+
+  public int getMaxTableReplicationZkJobs() {
+    return getProperty(CONFIG_OF_MAX_FORCE_COMMIT_JOBS_IN_ZK, ControllerJob.DEFAULT_MAXIMUM_CONTROLLER_JOBS_IN_ZK);
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/CopyTablePayload.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/CopyTablePayload.java
@@ -25,11 +25,17 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Map;
 import javax.annotation.Nullable;
 
+/**
+ * Payload for the copy table request.
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class CopyTablePayload {
 
   private String _sourceClusterUri;
   private Map<String, String> _headers;
+
+  private String _destinationClusterUri;
+  private Map<String, String> _destinationClusterHeaders;
   /**
    * Broker tenant for the new table.
    * MUST NOT contain the tenant type suffix, i.e. _BROKER.
@@ -51,11 +57,15 @@ public class CopyTablePayload {
   public CopyTablePayload(
       @JsonProperty(value = "sourceClusterUri", required = true) String sourceClusterUri,
       @JsonProperty("sourceClusterHeaders") Map<String, String> headers,
+      @JsonProperty(value = "destinationClusterUri", required = true) String destinationClusterUri,
+      @JsonProperty(value = "destinationClusterHeaders") Map<String, String> destinationClusterHeaders,
       @JsonProperty(value = "brokerTenant", required = true) String brokerTenant,
       @JsonProperty(value = "serverTenant", required = true) String serverTenant,
       @JsonProperty("tagPoolReplacementMap") @Nullable Map<String, String> tagPoolReplacementMap) {
     _sourceClusterUri = sourceClusterUri;
     _headers = headers;
+    _destinationClusterUri = destinationClusterUri;
+    _destinationClusterHeaders = destinationClusterHeaders;
     _brokerTenant = brokerTenant;
     _serverTenant = serverTenant;
     _tagPoolReplacementMap = tagPoolReplacementMap;
@@ -69,6 +79,16 @@ public class CopyTablePayload {
   @JsonGetter("sourceClusterHeaders")
   public Map<String, String> getHeaders() {
     return _headers;
+  }
+
+  @JsonGetter("destinationClusterUri")
+  public String getDestinationClusterUri() {
+    return _sourceClusterUri;
+  }
+
+  @JsonGetter("destinationClusterHeaders")
+  public Map<String, String> getDestinationClusterHeaders() {
+    return _destinationClusterHeaders;
   }
 
   @JsonGetter("brokerTenant")

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/CopyTablePayload.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/CopyTablePayload.java
@@ -31,6 +31,21 @@ import javax.annotation.Nullable;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class CopyTablePayload {
 
+  /**
+   * Job type for table copy operation.
+   */
+  public enum JobType {
+    /**
+     * Controller-based job type (default). The copy job runs on the controller.
+     */
+    CONTROLLER,
+
+    /**
+     * Minion-based job type (not yet supported). The copy job would run on minion workers.
+     */
+    MINION
+  }
+
   private String _sourceClusterUri;
   private Map<String, String> _headers;
 
@@ -49,6 +64,13 @@ public class CopyTablePayload {
   private Integer _backfillParallism;
 
   /**
+   * Job type for the copy operation.
+   * Defaults to CONTROLLER if not specified.
+   * Currently only CONTROLLER is supported.
+   */
+  private JobType _jobType;
+
+  /**
    * The instanceAssignmentConfig's tagPoolConfig contains full tenant name. We will use this field to let user specify
    * the replacement relation from source cluster's full tenant to target cluster's full tenant.
    */
@@ -63,7 +85,8 @@ public class CopyTablePayload {
       @JsonProperty(value = "brokerTenant", required = true) String brokerTenant,
       @JsonProperty(value = "serverTenant", required = true) String serverTenant,
       @JsonProperty("tagPoolReplacementMap") @Nullable Map<String, String> tagPoolReplacementMap,
-      @JsonProperty("backfillParallism") @Nullable Integer backfillParallism) {
+      @JsonProperty("backfillParallism") @Nullable Integer backfillParallism,
+      @JsonProperty("jobType") @Nullable JobType jobType) {
     _sourceClusterUri = sourceClusterUri;
     _headers = headers;
     _destinationClusterUri = destinationClusterUri;
@@ -72,6 +95,7 @@ public class CopyTablePayload {
     _serverTenant = serverTenant;
     _tagPoolReplacementMap = tagPoolReplacementMap;
     _backfillParallism = backfillParallism;
+    _jobType = jobType != null ? jobType : JobType.CONTROLLER;
   }
 
   @JsonGetter("sourceClusterUri")
@@ -112,5 +136,10 @@ public class CopyTablePayload {
   @JsonGetter("tagPoolReplacementMap")
   public Map<String, String> getTagPoolReplacementMap() {
     return _tagPoolReplacementMap;
+  }
+
+  @JsonGetter("jobType")
+  public JobType getJobType() {
+    return _jobType;
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/CopyTablePayload.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/CopyTablePayload.java
@@ -46,6 +46,7 @@ public class CopyTablePayload {
    * MUST NOT contain the tenant type suffix, i.e. _REALTIME or _OFFLINE.
    */
   private String _serverTenant;
+  private Integer _backfillParallism;
 
   /**
    * The instanceAssignmentConfig's tagPoolConfig contains full tenant name. We will use this field to let user specify
@@ -61,7 +62,8 @@ public class CopyTablePayload {
       @JsonProperty(value = "destinationClusterHeaders") Map<String, String> destinationClusterHeaders,
       @JsonProperty(value = "brokerTenant", required = true) String brokerTenant,
       @JsonProperty(value = "serverTenant", required = true) String serverTenant,
-      @JsonProperty("tagPoolReplacementMap") @Nullable Map<String, String> tagPoolReplacementMap) {
+      @JsonProperty("tagPoolReplacementMap") @Nullable Map<String, String> tagPoolReplacementMap,
+      @JsonProperty("backfillParallism") @Nullable Integer backfillParallism) {
     _sourceClusterUri = sourceClusterUri;
     _headers = headers;
     _destinationClusterUri = destinationClusterUri;
@@ -69,6 +71,7 @@ public class CopyTablePayload {
     _brokerTenant = brokerTenant;
     _serverTenant = serverTenant;
     _tagPoolReplacementMap = tagPoolReplacementMap;
+    _backfillParallism = backfillParallism;
   }
 
   @JsonGetter("sourceClusterUri")
@@ -99,6 +102,11 @@ public class CopyTablePayload {
   @JsonGetter("serverTenant")
   public String getServerTenant() {
     return _serverTenant;
+  }
+
+  @JsonGetter("backfillParallism")
+  public Integer getBackfillParallism() {
+    return _backfillParallism;
   }
 
   @JsonGetter("tagPoolReplacementMap")

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/CopyTablePayload.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/CopyTablePayload.java
@@ -83,7 +83,7 @@ public class CopyTablePayload {
 
   @JsonGetter("destinationClusterUri")
   public String getDestinationClusterUri() {
-    return _sourceClusterUri;
+    return _destinationClusterUri;
   }
 
   @JsonGetter("destinationClusterHeaders")

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/CopyTablePayload.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/CopyTablePayload.java
@@ -61,7 +61,7 @@ public class CopyTablePayload {
    * MUST NOT contain the tenant type suffix, i.e. _REALTIME or _OFFLINE.
    */
   private String _serverTenant;
-  private Integer _backfillParallism;
+  private Integer _backfillParallelism;
 
   /**
    * Job type for the copy operation.
@@ -85,7 +85,7 @@ public class CopyTablePayload {
       @JsonProperty(value = "brokerTenant", required = true) String brokerTenant,
       @JsonProperty(value = "serverTenant", required = true) String serverTenant,
       @JsonProperty("tagPoolReplacementMap") @Nullable Map<String, String> tagPoolReplacementMap,
-      @JsonProperty("backfillParallism") @Nullable Integer backfillParallism,
+      @JsonProperty("backfillParallelism") @Nullable Integer backfillParallism,
       @JsonProperty("jobType") @Nullable JobType jobType) {
     _sourceClusterUri = sourceClusterUri;
     _headers = headers;
@@ -94,7 +94,7 @@ public class CopyTablePayload {
     _brokerTenant = brokerTenant;
     _serverTenant = serverTenant;
     _tagPoolReplacementMap = tagPoolReplacementMap;
-    _backfillParallism = backfillParallism;
+    _backfillParallelism = backfillParallism;
     _jobType = jobType != null ? jobType : JobType.CONTROLLER;
   }
 
@@ -128,9 +128,9 @@ public class CopyTablePayload {
     return _serverTenant;
   }
 
-  @JsonGetter("backfillParallism")
-  public Integer getBackfillParallism() {
-    return _backfillParallism;
+  @JsonGetter("backfillParallelism")
+  public Integer getBackfillParallelism() {
+    return _backfillParallelism;
   }
 
   @JsonGetter("tagPoolReplacementMap")

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -309,9 +309,6 @@ public class PinotTableRestletResource {
 
       CopyTablePayload copyTablePayload = JsonUtils.stringToObject(payload, CopyTablePayload.class);
       String sourceControllerUri = copyTablePayload.getSourceClusterUri();
-      if (!sourceControllerUri.startsWith("http://") && !sourceControllerUri.startsWith("https://")) {
-        sourceControllerUri = "http://" + sourceControllerUri;
-      }
       Map<String, String> requestHeaders = copyTablePayload.getHeaders();
 
       LOGGER.info("[copyTable] Start copying table: {} from source: {}", tableName, sourceControllerUri);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -313,6 +313,17 @@ public class PinotTableRestletResource {
       }
 
       CopyTablePayload copyTablePayload = JsonUtils.stringToObject(payload, CopyTablePayload.class);
+
+      // Validate jobType - only CONTROLLER is currently supported
+      CopyTablePayload.JobType jobType = copyTablePayload.getJobType();
+      if (jobType == CopyTablePayload.JobType.MINION) {
+        throw new ControllerApplicationException(LOGGER,
+            String.format("Job type '%s' is not supported. Only 'CONTROLLER' job type is currently supported.",
+                jobType),
+            Response.Status.BAD_REQUEST);
+      }
+      LOGGER.info("[copyTable] Job type: {}", jobType);
+
       String sourceControllerUri = copyTablePayload.getSourceClusterUri();
       Map<String, String> requestHeaders = copyTablePayload.getHeaders();
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -451,6 +451,18 @@ public class PinotTableRestletResource {
     }
   }
 
+  @GET
+  @Path("/tables/copyStatus/{jobId}")
+  @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.GET_TABLE_COPY_STATUS)
+  @Produces(MediaType.APPLICATION_JSON)
+  @ApiOperation(value = "Get status for a submitted table replication job",
+      notes = "Get status for a submitted table replication job")
+  public JsonNode getForceCommitJobStatus(
+      @ApiParam(value = "job id", required = true) @PathParam("jobId") String id) {
+    return JsonUtils.objectToJsonNode(
+        _pinotHelixResourceManager.getControllerJobZKMetadata(id, ControllerJobTypes.TABLE_REPLICATION));
+  }
+
   @PUT
   @Produces(MediaType.APPLICATION_JSON)
   @Path("/tables/recommender")

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -476,10 +476,14 @@ public class PinotTableRestletResource {
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation(value = "Get status for a submitted table replication job",
       notes = "Get status for a submitted table replication job")
-  public JsonNode getForceCommitJobStatus(
+  public JsonNode getTableCopyStatus(
       @ApiParam(value = "job id", required = true) @PathParam("jobId") String id) {
-    return JsonUtils.objectToJsonNode(
-        _pinotHelixResourceManager.getControllerJobZKMetadata(id, ControllerJobTypes.TABLE_REPLICATION));
+    Map<String, String> metadata =
+        _pinotHelixResourceManager.getControllerJobZKMetadata(id, ControllerJobTypes.TABLE_REPLICATION);
+    if (metadata == null) {
+      throw new ControllerApplicationException(LOGGER, "Controller job not found: " + id, Response.Status.NOT_FOUND);
+    }
+    return JsonUtils.objectToJsonNode(metadata);
   }
 
   @PUT

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -48,6 +48,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Future;
@@ -109,6 +110,7 @@ import org.apache.pinot.controller.helix.core.rebalance.RebalanceConfig;
 import org.apache.pinot.controller.helix.core.rebalance.RebalanceResult;
 import org.apache.pinot.controller.helix.core.rebalance.TableRebalanceManager;
 import org.apache.pinot.controller.helix.core.rebalance.TableRebalancer;
+import org.apache.pinot.controller.helix.core.replication.TableReplicator;
 import org.apache.pinot.controller.recommender.RecommenderDriver;
 import org.apache.pinot.controller.tuner.TableConfigTunerUtils;
 import org.apache.pinot.controller.util.CompletionServiceHelper;
@@ -208,6 +210,9 @@ public class PinotTableRestletResource {
 
   @Inject
   HttpClientConnectionManager _connectionManager;
+
+  @Inject
+  TableReplicator _tableReplicator;
 
   /**
    * API to create a table. Before adding, validations will be done (min number of replicas, checking offline and
@@ -372,6 +377,9 @@ public class PinotTableRestletResource {
         response.setTableConfig(realtimeTableConfig);
         response.setWatermarkInductionResult(watermarkInductionResult);
       }
+      String jobID = UUID.randomUUID().toString();
+      _tableReplicator.replicateTable(jobID, realtimeTableConfig.getTableName(), copyTablePayload,
+          watermarkInductionResult);
       return response;
     } catch (Exception e) {
       LOGGER.error("[copyTable] Error copying table: {}", tableName, e);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -309,6 +309,9 @@ public class PinotTableRestletResource {
 
       CopyTablePayload copyTablePayload = JsonUtils.stringToObject(payload, CopyTablePayload.class);
       String sourceControllerUri = copyTablePayload.getSourceClusterUri();
+      if (!sourceControllerUri.startsWith("http://") && !sourceControllerUri.startsWith("https://")) {
+        sourceControllerUri = "http://" + sourceControllerUri;
+      }
       Map<String, String> requestHeaders = copyTablePayload.getHeaders();
 
       LOGGER.info("[copyTable] Start copying table: {} from source: {}", tableName, sourceControllerUri);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -2647,8 +2647,16 @@ public class PinotHelixResourceManager {
     return addControllerJobToZK(jobId, jobMetadata, ControllerJobTypes.FORCE_COMMIT);
   }
 
-  public boolean addNewSegmentCopyXClusterJob(String tableNameWithType, String jobId, long jobSubmissionTimeMs,
-      List<String> consumingSegmentsCommitted)
+  public boolean addNewTableReplicationJob(String tableNameWithType, String jobId, long jobSubmissionTimeMs,
+      WatermarkInductionResult res)
+      throws JsonProcessingException {
+    Map<String, String> jobMetadata =
+        commonTableReplicationJobMetadata(tableNameWithType, jobId, jobSubmissionTimeMs, res);
+    return addControllerJobToZK(jobId, jobMetadata, ControllerJobTypes.TABLE_REPLICATION);
+  }
+
+  public Map<String, String> commonTableReplicationJobMetadata(String tableNameWithType, String jobId,
+      long jobSubmissionTimeMs, WatermarkInductionResult res)
       throws JsonProcessingException {
     Map<String, String> jobMetadata = new HashMap<>();
     jobMetadata.put(CommonConstants.ControllerJob.JOB_ID, jobId);
@@ -2656,8 +2664,10 @@ public class PinotHelixResourceManager {
     jobMetadata.put(CommonConstants.ControllerJob.SUBMISSION_TIME_MS, Long.toString(jobSubmissionTimeMs));
     jobMetadata.put(CommonConstants.ControllerJob.TABLE_NAME_WITH_TYPE, tableNameWithType);
     jobMetadata.put(CommonConstants.ControllerJob.SEGMENTS_TO_BE_COPIED,
-        JsonUtils.objectToString(consumingSegmentsCommitted));
-    return addControllerJobToZK(jobId, jobMetadata, ControllerJobTypes.TABLE_REPLICATION);
+        Integer.toString(res.getHistoricalSegments().size()));
+    jobMetadata.put(CommonConstants.ControllerJob.CONSUMER_WATERMARKS, JsonUtils.objectToString(res.getWatermarks()));
+    jobMetadata.put(CommonConstants.ControllerJob.REPLICATION_JOB_STATUS, "IN_PROGRESS");
+    return jobMetadata;
   }
 
   /**

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -2647,6 +2647,19 @@ public class PinotHelixResourceManager {
     return addControllerJobToZK(jobId, jobMetadata, ControllerJobTypes.FORCE_COMMIT);
   }
 
+  public boolean addNewSegmentCopyXClusterJob(String tableNameWithType, String jobId, long jobSubmissionTimeMs,
+      List<String> consumingSegmentsCommitted)
+      throws JsonProcessingException {
+    Map<String, String> jobMetadata = new HashMap<>();
+    jobMetadata.put(CommonConstants.ControllerJob.JOB_ID, jobId);
+    jobMetadata.put(CommonConstants.ControllerJob.JOB_TYPE, ControllerJobTypes.TABLE_REPLICATION.name());
+    jobMetadata.put(CommonConstants.ControllerJob.SUBMISSION_TIME_MS, Long.toString(jobSubmissionTimeMs));
+    jobMetadata.put(CommonConstants.ControllerJob.TABLE_NAME_WITH_TYPE, tableNameWithType);
+    jobMetadata.put(CommonConstants.ControllerJob.SEGMENTS_TO_BE_COPIED,
+        JsonUtils.objectToString(consumingSegmentsCommitted));
+    return addControllerJobToZK(jobId, jobMetadata, ControllerJobTypes.TABLE_REPLICATION);
+  }
+
   /**
    * Adds a new job metadata for controller job like table rebalance or reload into ZK
    * @param jobId job's UUID
@@ -5060,7 +5073,23 @@ public class PinotHelixResourceManager {
       }
       return new WatermarkInductionResult.Watermark(status.getPartitionGroupId(), seq, startOffset);
     }).collect(Collectors.toList());
-    return new WatermarkInductionResult(watermarks);
+
+    Map<Long, Long> partGroupToLatestSeq = watermarks.stream().collect(
+        Collectors.toMap(WatermarkInductionResult.Watermark::getPartitionGroupId,
+            WatermarkInductionResult.Watermark::getSequenceNumber));
+    List<String> historicalSegments = new ArrayList<>();
+    for (String segment : idealState.getRecord().getMapFields().keySet()) {
+      LLCSegmentName llcSegmentName = LLCSegmentName.of(segment);
+      if (llcSegmentName != null) {
+        long partitionGroupId = llcSegmentName.getPartitionGroupId();
+        int seq = llcSegmentName.getSequenceNumber();
+        if (partGroupToLatestSeq.containsKey(partitionGroupId) && partGroupToLatestSeq.get(partitionGroupId) == seq) {
+          continue;
+        }
+      }
+      historicalSegments.add(segment);
+    }
+    return new WatermarkInductionResult(watermarks, historicalSegments);
   }
 
   /*

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -5084,14 +5084,14 @@ public class PinotHelixResourceManager {
       return new WatermarkInductionResult.Watermark(status.getPartitionGroupId(), seq, startOffset);
     }).collect(Collectors.toList());
 
-    Map<Long, Long> partGroupToLatestSeq = watermarks.stream().collect(
+    Map<Integer, Integer> partGroupToLatestSeq = watermarks.stream().collect(
         Collectors.toMap(WatermarkInductionResult.Watermark::getPartitionGroupId,
             WatermarkInductionResult.Watermark::getSequenceNumber));
     List<String> historicalSegments = new ArrayList<>();
     for (String segment : idealState.getRecord().getMapFields().keySet()) {
       LLCSegmentName llcSegmentName = LLCSegmentName.of(segment);
       if (llcSegmentName != null) {
-        long partitionGroupId = llcSegmentName.getPartitionGroupId();
+        int partitionGroupId = llcSegmentName.getPartitionGroupId();
         int seq = llcSegmentName.getSequenceNumber();
         if (partGroupToLatestSeq.containsKey(partitionGroupId) && partGroupToLatestSeq.get(partitionGroupId) == seq) {
           continue;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/WatermarkInductionResult.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/WatermarkInductionResult.java
@@ -31,6 +31,8 @@ public class WatermarkInductionResult {
 
   private List<Watermark> _watermarks;
 
+  public List<String> _historicalSegments;
+
   /**
    * The @JsonCreator annotation marks this constructor to be used for deserializing
    * a JSON array back into a WaterMarks object.
@@ -38,8 +40,10 @@ public class WatermarkInductionResult {
    * @param watermarks The list of watermarks.
    */
   @JsonCreator
-  public WatermarkInductionResult(@JsonProperty("watermarks") List<Watermark> watermarks) {
+  public WatermarkInductionResult(@JsonProperty("watermarks") List<Watermark> watermarks,
+      @JsonProperty("historicalSegments") List<String> historicalSegments) {
     _watermarks = watermarks;
+    _historicalSegments = historicalSegments;
   }
 
   /**
@@ -50,6 +54,11 @@ public class WatermarkInductionResult {
   @JsonGetter("watermarks")
   public List<Watermark> getWatermarks() {
     return _watermarks;
+  }
+
+  @JsonGetter("historicalSegments")
+  public List<String> getHistoricalSegments() {
+    return _historicalSegments;
   }
 
   /**

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/WatermarkInductionResult.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/WatermarkInductionResult.java
@@ -31,7 +31,7 @@ public class WatermarkInductionResult {
 
   private List<Watermark> _watermarks;
 
-  public List<String> _historicalSegments;
+  private List<String> _historicalSegments;
 
   /**
    * The @JsonCreator annotation marks this constructor to be used for deserializing

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/controllerjob/ControllerJobTypes.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/controllerjob/ControllerJobTypes.java
@@ -40,7 +40,8 @@ public enum ControllerJobTypes implements ControllerJobType {
   RELOAD_SEGMENT,
   FORCE_COMMIT,
   TABLE_REBALANCE,
-  TENANT_REBALANCE;
+  TENANT_REBALANCE,
+  TABLE_REPLICATION;
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ControllerJobTypes.class);
   private static final EnumMap<ControllerJobTypes, Integer> ZK_NUM_JOBS_LIMIT = new EnumMap<>(ControllerJobTypes.class);
@@ -55,6 +56,7 @@ public enum ControllerJobTypes implements ControllerJobType {
     ZK_NUM_JOBS_LIMIT.put(FORCE_COMMIT, controllerConf.getMaxForceCommitZkJobs());
     ZK_NUM_JOBS_LIMIT.put(TABLE_REBALANCE, controllerConf.getMaxTableRebalanceZkJobs());
     ZK_NUM_JOBS_LIMIT.put(TENANT_REBALANCE, controllerConf.getMaxTenantRebalanceZkJobs());
+    ZK_NUM_JOBS_LIMIT.put(TABLE_REPLICATION, controllerConf.getMaxTableReplicationZkJobs());
   }
 
   @Override

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/replication/NoOpSegmentCopier.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/replication/NoOpSegmentCopier.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core.replication;
+
+import java.util.Map;
+import org.apache.pinot.controller.api.resources.CopyTablePayload;
+
+/**
+ * A no-op segment copier for testing purposes.
+ */
+public class NoOpSegmentCopier implements SegmentCopier {
+
+  @Override
+  public void copy(String tableNameWithType, String segmentName, CopyTablePayload copyTablePayload,
+      Map<String, String> segmentZKMetadata) {
+    // No-op
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/replication/RealtimeSegmentCopier.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/replication/RealtimeSegmentCopier.java
@@ -147,7 +147,7 @@ public class RealtimeSegmentCopier implements SegmentCopier {
 
   static ClassicHttpRequest getSendSegmentUriRequest(String controllerUriStr, String downloadUri,
       Map<String, String> headers, String tableNameWithoutType) throws URISyntaxException {
-    URI segmentPushURI = new URI(controllerUriStr + "?tableName=" + tableNameWithoutType);
+    URI segmentPushURI = new URI(controllerUriStr + "/v2/segments?tableName=" + tableNameWithoutType);
     ClassicRequestBuilder requestBuilder = ClassicRequestBuilder.post(segmentPushURI).setVersion(HttpVersion.HTTP_1_1)
         .setHeader(
             FileUploadDownloadClient.CustomHeaders.UPLOAD_TYPE, FileUploadDownloadClient.FileUploadType.URI.toString())

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/replication/RealtimeSegmentCopier.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/replication/RealtimeSegmentCopier.java
@@ -1,0 +1,126 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core.replication;
+
+import java.net.URI;
+import java.util.Map;
+import org.apache.pinot.common.utils.SimpleHttpResponse;
+import org.apache.pinot.common.utils.http.HttpClient;
+import org.apache.pinot.controller.ControllerConf;
+import org.apache.pinot.controller.api.resources.CopyTablePayload;
+import org.apache.pinot.spi.filesystem.PinotFS;
+import org.apache.pinot.spi.filesystem.PinotFSFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Copies a realtime segment from source to destination.
+ */
+public class RealtimeSegmentCopier implements SegmentCopier {
+  private static final Logger LOGGER = LoggerFactory.getLogger(RealtimeSegmentCopier.class);
+  private static final String SEGMENT_UPLOAD_ENDPOINT_TEMPLATE = "/segments?tableName=%s";
+
+  private final String _destinationDeepStoreUri;
+  private final HttpClient _httpClient;
+
+  public RealtimeSegmentCopier(ControllerConf controllerConf) {
+    this(controllerConf, HttpClient.getInstance());
+  }
+
+  public RealtimeSegmentCopier(ControllerConf controllerConf, HttpClient httpClient) {
+    _destinationDeepStoreUri = controllerConf.getDataDir();
+    _httpClient = httpClient;
+  }
+
+
+  /**
+   * Copies a segment to the destination cluster.
+   *
+   * This method performs the following steps:
+   * 1. Get the source segment URI from ZK metadata.
+   * 2. Copy the segment from the source deep store to the destination deep store.
+   * 3. Upload the segment to the destination controller.
+   *
+   * @param tableNameWithType Table name with type suffix
+   * @param segmentName Segment name
+   * @param copyTablePayload Payload for copying a table
+   * @param segmentZKMetadata ZK metadata for the segment
+   */
+  @Override
+  public void copy(String tableNameWithType, String segmentName, CopyTablePayload copyTablePayload,
+      Map<String, String> segmentZKMetadata) {
+    if (!tableNameWithType.endsWith("_REALTIME")) {
+      throw new IllegalArgumentException("Table name must end with _REALTIME");
+    }
+    String tableName = tableNameWithType.substring(0, tableNameWithType.lastIndexOf("_REALTIME"));
+    try {
+      // 1. Get the the source segment uri
+      String downloadUrl = segmentZKMetadata.get("segment.download.url");
+      if (downloadUrl == null) {
+        throw new RuntimeException("Download URL not found in segment ZK metadata for segment: " + segmentName);
+      }
+
+      // 2. Copy the segment from the source deep store to the destination deep store
+      URI sourceSegmentUri = new URI(downloadUrl);
+      PinotFS sourcePinotFS = getPinotFS(sourceSegmentUri);
+      String destSegmentUriStr = _destinationDeepStoreUri + "/" + tableName + "/" + segmentName;
+      URI destSegmentUri = new URI(destSegmentUriStr);
+
+      PinotFS destPinotFS = getPinotFS(destSegmentUri);
+
+      // TODO: use local file system as an intermediate store to support different file system
+      if (sourcePinotFS != destPinotFS) {
+        throw new IllegalArgumentException("Copy files across different file system is not supported");
+      }
+
+      if (!destPinotFS.exists(destSegmentUri)) {
+        sourcePinotFS.copy(sourceSegmentUri, destSegmentUri);
+        LOGGER.info("Copied segment {} from {} to {}", segmentName, sourceSegmentUri, destSegmentUri);
+      } else {
+        LOGGER.info("Segment {} already exists at destination {}", segmentName, destSegmentUri);
+      }
+
+      // 3. Upload the segment to the destination controller
+      String payload = "{\"segmentUri\":\"" + destSegmentUriStr + "\"}";
+      URI uri = new URI(copyTablePayload.getDestinationClusterUri() + String.format(SEGMENT_UPLOAD_ENDPOINT_TEMPLATE,
+          tableName));
+      SimpleHttpResponse response =
+          _httpClient.sendJsonPostRequest(uri, payload, copyTablePayload.getDestinationClusterHeaders());
+      LOGGER.info("Uploaded segment {} to destination controller, status: {}", segmentName, response.getStatusCode());
+    } catch (Exception e) {
+      LOGGER.error("Caught exception while copying segment {}", segmentName, e);
+      throw new RuntimeException(e);
+    }
+  }
+
+  static String getScheme(URI uri) {
+    if (uri.getScheme() != null) {
+      return uri.getScheme();
+    }
+    return PinotFSFactory.LOCAL_PINOT_FS_SCHEME;
+  }
+
+  PinotFS getPinotFS(URI uri) {
+    String scheme = getScheme(uri);
+    if (!PinotFSFactory.isSchemeSupported(scheme)) {
+      throw new IllegalArgumentException("File scheme " + scheme + " is not supported.");
+    }
+    return PinotFSFactory.create(scheme);
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/replication/RealtimeSegmentCopier.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/replication/RealtimeSegmentCopier.java
@@ -118,7 +118,7 @@ public class RealtimeSegmentCopier implements SegmentCopier {
           SimpleHttpResponse response = HttpClient.wrapAndThrowHttpException(
               _httpClient.sendRequest(
                   getSendSegmentUriRequest(dstControllerURIStr, destSegmentUriStr,
-                      copyTablePayload.getDestinationClusterHeaders(), tableName),
+                      copyTablePayload.getDestinationClusterHeaders(), tableName, "REALTIME"),
                   HttpClient.DEFAULT_SOCKET_TIMEOUT_MS));
           LOGGER.info("[copyTable] Response for pushing table {} segment uri {} to location {} - {}: {}", tableName,
               destSegmentUriStr, dstControllerURIStr, response.getStatusCode(),
@@ -146,8 +146,9 @@ public class RealtimeSegmentCopier implements SegmentCopier {
   }
 
   static ClassicHttpRequest getSendSegmentUriRequest(String controllerUriStr, String downloadUri,
-      Map<String, String> headers, String tableNameWithoutType) throws URISyntaxException {
-    URI segmentPushURI = new URI(controllerUriStr + "/v2/segments?tableName=" + tableNameWithoutType);
+      Map<String, String> headers, String tableNameWithoutType, String tableType) throws URISyntaxException {
+    URI segmentPushURI = new URI(controllerUriStr + "/v2/segments?tableName=" + tableNameWithoutType + "&tableType="
+        + tableType);
     ClassicRequestBuilder requestBuilder = ClassicRequestBuilder.post(segmentPushURI).setVersion(HttpVersion.HTTP_1_1)
         .setHeader(
             FileUploadDownloadClient.CustomHeaders.UPLOAD_TYPE, FileUploadDownloadClient.FileUploadType.URI.toString())

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/replication/RealtimeSegmentCopier.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/replication/RealtimeSegmentCopier.java
@@ -33,6 +33,7 @@ import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.api.resources.CopyTablePayload;
 import org.apache.pinot.spi.filesystem.PinotFS;
 import org.apache.pinot.spi.filesystem.PinotFSFactory;
+import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.retry.RetryPolicies;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,7 +43,6 @@ import org.slf4j.LoggerFactory;
  */
 public class RealtimeSegmentCopier implements SegmentCopier {
   private static final Logger LOGGER = LoggerFactory.getLogger(RealtimeSegmentCopier.class);
-  private static final String SEGMENT_UPLOAD_ENDPOINT_TEMPLATE = "/segments?tableName=%s";
 
   private final String _destinationDeepStoreUri;
   private final HttpClient _httpClient;
@@ -79,7 +79,7 @@ public class RealtimeSegmentCopier implements SegmentCopier {
     String tableName = tableNameWithType.substring(0, tableNameWithType.lastIndexOf("_REALTIME"));
     try {
       // 1. Get the the source segment uri
-      String downloadUrl = segmentZKMetadata.get("segment.download.url");
+      String downloadUrl = segmentZKMetadata.get(CommonConstants.Segment.DOWNLOAD_URL);
       if (downloadUrl == null) {
         throw new RuntimeException("Download URL not found in segment ZK metadata for segment: " + segmentName);
       }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/replication/SegmentCopier.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/replication/SegmentCopier.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core.replication;
+
+import java.util.Map;
+import org.apache.pinot.controller.api.resources.CopyTablePayload;
+
+
+/**
+ * An interface to copy a segment to the destination cluster.
+ */
+public interface SegmentCopier {
+
+  /**
+   * Copies a segment to the destination cluster.
+   * @param tableNameWithType Table name with type suffix
+   * @param segmentName Segment name
+   * @param copyTablePayload Payload for copying a table
+   * @param segmentZKMetadata ZK metadata for the segment
+   */
+  void copy(String tableNameWithType, String segmentName, CopyTablePayload copyTablePayload,
+      Map<String, String> segmentZKMetadata);
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/replication/TableReplicationObserver.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/replication/TableReplicationObserver.java
@@ -1,0 +1,30 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core.replication;
+
+public interface TableReplicationObserver {
+
+  enum Trigger {
+    START_TRIGGER,
+    SEGMENT_REPLICATE_COMPLETED_TRIGGER,
+    SEGMENT_REPLICATE_ERRORED_TRIGGER,
+  }
+
+  void onTrigger(Trigger trigger, String segmentName);
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/replication/TableReplicationProgressStats.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/replication/TableReplicationProgressStats.java
@@ -1,0 +1,69 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.controller.helix.core.replication;
+
+import com.fasterxml.jackson.annotation.JsonGetter;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.atomic.AtomicInteger;
+
+
+/**
+ * Tracks the progress of table replication.
+ */
+public class TableReplicationProgressStats {
+
+  public enum SegmentStatus {
+    COMPLETED,
+    ERROR,
+  }
+
+  private final AtomicInteger _remainingSegments;
+  private final BlockingQueue<String> _segmentsFailToCopy = new LinkedBlockingQueue<>();
+
+  public TableReplicationProgressStats(int segmentSize) {
+    _remainingSegments = new AtomicInteger(segmentSize);
+  }
+
+  /**
+   * Updates the status of a segment and returns the number of remaining segments.
+   * @param segment The segment name.
+   * @param status The status of the segment replication.
+   * @return The number of remaining segments to be replicated.
+   */
+  public int updateSegmentStatus(String segment, SegmentStatus status) {
+    if (status == SegmentStatus.ERROR) {
+      _segmentsFailToCopy.add(segment);
+    }
+    return _remainingSegments.addAndGet(-1);
+  }
+
+  @JsonGetter("remainingSegments")
+  public int getRemainingSegments() {
+    return _remainingSegments.get();
+  }
+
+  @JsonGetter("segmentsFailToCopy")
+  public List<String> getSegmentsFailToCopy() {
+    return new ArrayList<>(_segmentsFailToCopy);
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/replication/TableReplicator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/replication/TableReplicator.java
@@ -1,0 +1,124 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core.replication;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutorService;
+import org.apache.pinot.common.utils.SimpleHttpResponse;
+import org.apache.pinot.common.utils.http.HttpClient;
+import org.apache.pinot.controller.api.resources.CopyTablePayload;
+import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
+import org.apache.pinot.controller.helix.core.WatermarkInductionResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Replicates a table from a source cluster to a destination cluster.
+ */
+public class TableReplicator {
+  private static final Logger LOGGER = LoggerFactory.getLogger(TableReplicator.class);
+  private static final String SEGMENT_ZK_METADATA_ENDPOINT_TEMPLATE = "/segments/%s/zkmetadata";
+
+  private final PinotHelixResourceManager _pinotHelixResourceManager;
+  private final ExecutorService _executorService;
+  private final SegmentCopier _segmentCopier;
+  private final HttpClient _httpClient;
+
+  public TableReplicator(PinotHelixResourceManager pinotHelixResourceManager, ExecutorService executorService,
+      SegmentCopier segmentCopier) {
+    this(pinotHelixResourceManager, executorService, segmentCopier, HttpClient.getInstance());
+  }
+
+  public TableReplicator(PinotHelixResourceManager pinotHelixResourceManager, ExecutorService executorService,
+      SegmentCopier segmentCopier, HttpClient httpClient) {
+    _pinotHelixResourceManager = pinotHelixResourceManager;
+    _executorService = executorService;
+    _segmentCopier = segmentCopier;
+    _httpClient = httpClient;
+  }
+
+  /**
+   * Replicates the table by copying segments from source to destination.
+   *
+   * This method performs the following steps:
+   * 1. Fetch ZK metadata for all segments of the table from the source cluster.
+   * 2. Register a new controller job in Zookeeper to track the replication progress.
+   * 3. Initialize a {@link ZkBasedTableReplicationObserver} to update the job status in Zookeeper.
+   * 4. Submit tasks to the executor service to copy segments in parallel.
+   * 5. Each task copies a segment and triggers the observer to update the progress.
+   *
+   * @param jobId The job ID.
+   * @param tableNameWithType The table name with type.
+   * @param copyTablePayload The payload containing the source and destination cluster information.
+   * @param res The watermark induction result.
+   * @throws Exception If an error occurs during replication.
+   */
+  public void replicateTable(String jobId, String tableNameWithType, CopyTablePayload copyTablePayload,
+      WatermarkInductionResult res)
+      throws Exception {
+    // TODO: throw IllegalStateException if any previous jobs doesn't expire.
+    // TODO: replication job canceling mechanism
+    URI zkMetadataUri = new URI(copyTablePayload.getSourceClusterUri()
+        + String.format(SEGMENT_ZK_METADATA_ENDPOINT_TEMPLATE, tableNameWithType));
+    SimpleHttpResponse zkMetadataResponse = HttpClient.wrapAndThrowHttpException(
+        _httpClient.sendGetRequest(zkMetadataUri, copyTablePayload.getHeaders()));
+    String zkMetadataJson = zkMetadataResponse.getResponse();
+    Map<String, Map<String, String>> zkMetadataMap =
+        new ObjectMapper().readValue(zkMetadataJson, new TypeReference<Map<String, Map<String, String>>>() {
+        });
+
+    List<String> segments = new ArrayList<>(zkMetadataMap.keySet());
+    long submitTS = System.currentTimeMillis();
+
+    if (!_pinotHelixResourceManager.addNewSegmentCopyXClusterJob(tableNameWithType, jobId, submitTS, segments)) {
+      throw new Exception("Failed to add segments to replicated table");
+    }
+    ZkBasedTableReplicationObserver observer = new ZkBasedTableReplicationObserver(jobId, tableNameWithType,
+        res.getHistoricalSegments(), _pinotHelixResourceManager);
+    observer.onTrigger(TableReplicationObserver.Trigger.START_TRIGGER, null);
+    ConcurrentLinkedQueue<String> q = new ConcurrentLinkedQueue<>(segments);
+    for (int i = 0; i < 4; i++) {
+      _executorService.submit(() -> {
+        while (true) {
+          String segment = q.poll();
+          if (segment == null) {
+            break;
+          }
+          try {
+            Map<String, String> segmentZKMetadata = zkMetadataMap.get(segment);
+            if (segmentZKMetadata == null) {
+              throw new RuntimeException("Segment ZK metadata not found for segment: " + segment);
+            }
+            _segmentCopier.copy(tableNameWithType, segment, copyTablePayload, segmentZKMetadata);
+            observer.onTrigger(TableReplicationObserver.Trigger.SEGMENT_REPLICATE_COMPLETED_TRIGGER, segment);
+          } catch (Exception e) {
+            LOGGER.error("Caught exception while replicating table segment", e);
+            observer.onTrigger(TableReplicationObserver.Trigger.SEGMENT_REPLICATE_ERRORED_TRIGGER, segment);
+          }
+        }
+      });
+    }
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/replication/TableReplicator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/replication/TableReplicator.java
@@ -31,6 +31,7 @@ import org.apache.pinot.common.utils.http.HttpClient;
 import org.apache.pinot.controller.api.resources.CopyTablePayload;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.helix.core.WatermarkInductionResult;
+import org.apache.pinot.spi.utils.builder.ControllerRequestURLBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,8 +40,6 @@ import org.slf4j.LoggerFactory;
  */
 public class TableReplicator {
   private static final Logger LOGGER = LoggerFactory.getLogger(TableReplicator.class);
-  private static final String SEGMENT_ZK_METADATA_ENDPOINT_TEMPLATE = "/segments/%s/zkmetadata";
-
   private final PinotHelixResourceManager _pinotHelixResourceManager;
   private final ExecutorService _executorService;
   private final SegmentCopier _segmentCopier;
@@ -81,8 +80,9 @@ public class TableReplicator {
     // TODO: throw IllegalStateException if any previous jobs doesn't expire.
     // TODO: replication job canceling mechanism
     LOGGER.info("[copyTable] Start replicating table: {} with jobId: {}", tableNameWithType, jobId);
-    URI zkMetadataUri = new URI(copyTablePayload.getSourceClusterUri()
-        + String.format(SEGMENT_ZK_METADATA_ENDPOINT_TEMPLATE, tableNameWithType));
+    ControllerRequestURLBuilder urlBuilder =
+        ControllerRequestURLBuilder.baseUrl(copyTablePayload.getSourceClusterUri());
+    URI zkMetadataUri = new URI(urlBuilder.forSegmentZkMetadata(tableNameWithType));
     SimpleHttpResponse zkMetadataResponse = HttpClient.wrapAndThrowHttpException(
         _httpClient.sendGetRequest(zkMetadataUri, copyTablePayload.getHeaders()));
     String zkMetadataJson = zkMetadataResponse.getResponse();

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/replication/TableReplicator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/replication/TableReplicator.java
@@ -101,7 +101,10 @@ public class TableReplicator {
         _pinotHelixResourceManager);
     observer.onTrigger(TableReplicationObserver.Trigger.START_TRIGGER, null);
     ConcurrentLinkedQueue<String> q = new ConcurrentLinkedQueue<>(segments);
-    for (int i = 0; i < 4; i++) {
+    int parallelism = copyTablePayload.getBackfillParallism() != null
+        ? copyTablePayload.getBackfillParallism()
+        : res.getWatermarks().size();
+    for (int i = 0; i < parallelism; i++) {
       _executorService.submit(() -> {
         while (true) {
           String segment = q.poll();

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/replication/TableReplicator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/replication/TableReplicator.java
@@ -101,8 +101,8 @@ public class TableReplicator {
         _pinotHelixResourceManager);
     observer.onTrigger(TableReplicationObserver.Trigger.START_TRIGGER, null);
     ConcurrentLinkedQueue<String> q = new ConcurrentLinkedQueue<>(segments);
-    int parallelism = copyTablePayload.getBackfillParallism() != null
-        ? copyTablePayload.getBackfillParallism()
+    int parallelism = copyTablePayload.getBackfillParallelism() != null
+        ? copyTablePayload.getBackfillParallelism()
         : res.getWatermarks().size();
     for (int i = 0; i < parallelism; i++) {
       _executorService.submit(() -> {
@@ -120,7 +120,7 @@ public class TableReplicator {
             _segmentCopier.copy(tableNameWithType, segment, copyTablePayload, segmentZKMetadata);
             observer.onTrigger(TableReplicationObserver.Trigger.SEGMENT_REPLICATE_COMPLETED_TRIGGER, segment);
           } catch (Exception e) {
-            LOGGER.error("Caught exception while replicating table segment", e);
+            LOGGER.error("Caught exception while replicating segment {} for table {}", segment, tableNameWithType, e);
             observer.onTrigger(TableReplicationObserver.Trigger.SEGMENT_REPLICATE_ERRORED_TRIGGER, segment);
           }
         }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/replication/ZkBasedTableReplicationObserver.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/replication/ZkBasedTableReplicationObserver.java
@@ -1,0 +1,94 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.controller.helix.core.replication;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
+import org.apache.pinot.controller.helix.core.controllerjob.ControllerJobTypes;
+import org.apache.pinot.controller.helix.core.rebalance.RebalanceJobConstants;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Observes the table replication progress and updates the status in Zookeeper.
+ */
+public class ZkBasedTableReplicationObserver implements TableReplicationObserver {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ZkBasedTableReplicationObserver.class);
+
+  private final PinotHelixResourceManager _pinotHelixResourceManager;
+  private final String _jobId;
+  private final String _tableNameWithType;
+  private final TableReplicationProgressStats _progressStats;
+  private final List<String> _segmentsToCopy;
+
+  public ZkBasedTableReplicationObserver(String jobId, String tableNameWithType, List<String> segmentsToCopy,
+      PinotHelixResourceManager pinotHelixResourceManager) {
+    _jobId = jobId;
+    _tableNameWithType = tableNameWithType;
+    _segmentsToCopy = segmentsToCopy;
+    _pinotHelixResourceManager = pinotHelixResourceManager;
+    _progressStats = new TableReplicationProgressStats(segmentsToCopy.size());
+  }
+
+  @Override
+  public void onTrigger(Trigger trigger, String segmentName) {
+    switch (trigger) {
+      // Table
+      case START_TRIGGER:
+        break;
+      case SEGMENT_REPLICATE_COMPLETED_TRIGGER:
+        // Update progress stats and track in ZK every 100 segments
+        int remaining = _progressStats.updateSegmentStatus(segmentName,
+            TableReplicationProgressStats.SegmentStatus.COMPLETED);
+        if (remaining % 100 == 0) {
+          trackStatsInZk();
+        }
+        break;
+      case SEGMENT_REPLICATE_ERRORED_TRIGGER:
+        // Update progress stats and track in ZK immediately on error
+        _progressStats.updateSegmentStatus(segmentName, TableReplicationProgressStats.SegmentStatus.ERROR);
+        trackStatsInZk();
+        break;
+      default:
+    }
+  }
+
+  private void trackStatsInZk() {
+    Map<String, String> jobMetadata = new HashMap<>();
+    jobMetadata.put(CommonConstants.ControllerJob.JOB_ID, _jobId);
+    jobMetadata.put(CommonConstants.ControllerJob.JOB_TYPE, ControllerJobTypes.TABLE_REPLICATION.name());
+    jobMetadata.put(CommonConstants.ControllerJob.SUBMISSION_TIME_MS, Long.toString(System.currentTimeMillis()));
+    jobMetadata.put(CommonConstants.ControllerJob.TABLE_NAME_WITH_TYPE, _tableNameWithType);
+    try {
+      jobMetadata.put(CommonConstants.ControllerJob.SEGMENTS_TO_BE_COPIED,
+          JsonUtils.objectToString(_segmentsToCopy));
+      jobMetadata.put(RebalanceJobConstants.JOB_METADATA_KEY_REBALANCE_PROGRESS_STATS,
+          JsonUtils.objectToString(_progressStats));
+    } catch (JsonProcessingException e) {
+      LOGGER.error("Error serialising replication stats to JSON for persisting to ZK {}", _jobId, e);
+    }
+    _pinotHelixResourceManager.addControllerJobToZK(_jobId, jobMetadata, ControllerJobTypes.TABLE_REPLICATION);
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/replication/ZkBasedTableReplicationObserver.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/replication/ZkBasedTableReplicationObserver.java
@@ -85,11 +85,16 @@ public class ZkBasedTableReplicationObserver implements TableReplicationObserver
       jobMetadata.put(CommonConstants.ControllerJob.REPLICATION_PROGRESS, progress);
       int remaining = JsonUtils.stringToObject(progress, JsonNode.class).get("remainingSegments").asInt();
       if (remaining == 0) {
-        jobMetadata.put(CommonConstants.ControllerJob.REPLICATION_JOB_STATUS, "COMPLETED");
+        String status = _progressStats.getSegmentsFailToCopy().isEmpty() ? "COMPLETED" : "COMPLETED_WITH_ERRORS";
+        jobMetadata.put(CommonConstants.ControllerJob.REPLICATION_JOB_STATUS, status);
       } else {
         jobMetadata.put(CommonConstants.ControllerJob.REPLICATION_JOB_STATUS, "IN_PROGRESS");
       }
-      _pinotHelixResourceManager.addControllerJobToZK(_jobId, jobMetadata, ControllerJobTypes.TABLE_REPLICATION);
+      try {
+        _pinotHelixResourceManager.addControllerJobToZK(_jobId, jobMetadata, ControllerJobTypes.TABLE_REPLICATION);
+      } catch (Exception e) {
+        LOGGER.error("Failed to persist replication stats to ZK for job: {}", _jobId, e);
+      }
     } catch (JsonProcessingException e) {
       LOGGER.error("Error serialising replication stats to JSON for persisting to ZK {}", _jobId, e);
     }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/PinotTableRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/PinotTableRestletResourceTest.java
@@ -75,7 +75,7 @@ public class PinotTableRestletResourceTest {
         new WatermarkInductionResult(List.of(
             new WatermarkInductionResult.Watermark(1, 3, 101L),
             new WatermarkInductionResult.Watermark(0, 2, 100L),
-            new WatermarkInductionResult.Watermark(10000, 5, 200L))));
+            new WatermarkInductionResult.Watermark(10000, 5, 200L)), List.of()));
 
     assertEquals(streamMetadataList.size(), 2);
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/PinotTableRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/PinotTableRestletResourceTest.java
@@ -33,6 +33,7 @@ import org.mockito.Mockito;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.expectThrows;
 
 public class PinotTableRestletResourceTest {
 
@@ -46,7 +47,7 @@ public class PinotTableRestletResourceTest {
       String serverTenant = "testServer";
       CopyTablePayload copyTablePayload = new CopyTablePayload("http://localhost:9000", null,
           "http://localhost:9000", null, brokerTenant, serverTenant,
-          Map.of("server1_REALTIME", "testServer_REALTIME"), null);
+          Map.of("server1_REALTIME", "testServer_REALTIME"), null, null);
       PinotTableRestletResource.tweakRealtimeTableConfig(tableConfig, copyTablePayload);
 
       assertEquals(tableConfig.get("tenants").get("broker").asText(), brokerTenant);
@@ -100,5 +101,30 @@ public class PinotTableRestletResourceTest {
     assertEquals(((LongMsgOffset) streamMetadata1.getPartitionGroupMetadataList().get(0).getStartOffset()).getOffset(),
         200L);
     assertEquals(streamMetadata1.getPartitionGroupMetadataList().get(0).getSequenceNumber(), 5);
+  }
+
+  @Test
+  public void testCopyTablePayloadJobType() throws Exception {
+    // Test 1: Backwards compatibility - null jobType defaults to CONTROLLER
+    CopyTablePayload payload1 = new CopyTablePayload("http://src", null, "http://dest", null,
+        "broker", "server", null, null, null);
+    assertEquals(payload1.getJobType(), CopyTablePayload.JobType.CONTROLLER);
+
+    // Test 2: Explicit CONTROLLER (uppercase)
+    String json2 = "{\"sourceClusterUri\":\"http://src\",\"destinationClusterUri\":\"http://dest\","
+        + "\"brokerTenant\":\"broker\",\"serverTenant\":\"server\",\"jobType\":\"CONTROLLER\"}";
+    CopyTablePayload payload2 = JsonUtils.stringToObject(json2, CopyTablePayload.class);
+    assertEquals(payload2.getJobType(), CopyTablePayload.JobType.CONTROLLER);
+
+    // Test 3: MINION enum value deserializes correctly
+    String json3 = "{\"sourceClusterUri\":\"http://src\",\"destinationClusterUri\":\"http://dest\","
+        + "\"brokerTenant\":\"broker\",\"serverTenant\":\"server\",\"jobType\":\"MINION\"}";
+    CopyTablePayload payload3 = JsonUtils.stringToObject(json3, CopyTablePayload.class);
+    assertEquals(payload3.getJobType(), CopyTablePayload.JobType.MINION);
+
+    // Test 4: Invalid job type throws exception during deserialization
+    String json4 = "{\"sourceClusterUri\":\"http://src\",\"destinationClusterUri\":\"http://dest\","
+        + "\"brokerTenant\":\"broker\",\"serverTenant\":\"server\",\"jobType\":\"invalid\"}";
+    expectThrows(Exception.class, () -> JsonUtils.stringToObject(json4, CopyTablePayload.class));
   }
 }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/PinotTableRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/PinotTableRestletResourceTest.java
@@ -44,8 +44,9 @@ public class PinotTableRestletResourceTest {
 
       String brokerTenant = "testBroker";
       String serverTenant = "testServer";
-      CopyTablePayload copyTablePayload = new CopyTablePayload("http://localhost:9000", null, brokerTenant,
-          serverTenant, Map.of("server1_REALTIME", "testServer_REALTIME"));
+      CopyTablePayload copyTablePayload = new CopyTablePayload("http://localhost:9000", null,
+          "http://localhost:9000", null, brokerTenant, serverTenant,
+          Map.of("server1_REALTIME", "testServer_REALTIME"), null);
       PinotTableRestletResource.tweakRealtimeTableConfig(tableConfig, copyTablePayload);
 
       assertEquals(tableConfig.get("tenants").get("broker").asText(), brokerTenant);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerStatelessTest.java
@@ -1712,6 +1712,15 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
     helixAdminField.set(_helixResourceManager, spyHelixAdmin);
 
     IdealState idealState = new IdealState(realtimeTableName);
+    idealState.setPartitionState(new LLCSegmentName(rawTableName, 0, 100,
+        System.currentTimeMillis()).getSegmentName(), SERVER_NAME_TAGGED, "ONLINE");
+    idealState.setPartitionState(new LLCSegmentName(rawTableName, 0, 101,
+        System.currentTimeMillis()).getSegmentName(), SERVER_NAME_TAGGED, "CONSUMING");
+    idealState.setPartitionState(new LLCSegmentName(rawTableName, 1, 199,
+        System.currentTimeMillis()).getSegmentName(), SERVER_NAME_TAGGED, "ONLINE");
+    idealState.setPartitionState(new LLCSegmentName(rawTableName, 1, 200,
+        System.currentTimeMillis()).getSegmentName(), SERVER_NAME_TAGGED, "CONSUMING");
+
     doReturn(idealState).when(spyHelixAdmin).getResourceIdealState(any(), eq(realtimeTableName));
 
     // Test happy path
@@ -1732,6 +1741,17 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
     assertEquals(inProgressWatermark.getPartitionGroupId(), 1);
     assertEquals(inProgressWatermark.getSequenceNumber(), 200L);
     assertEquals(inProgressWatermark.getOffset(), 789L);
+
+    List<String> historicalSegments = waterMarkInductionResult.getHistoricalSegments();
+    assertEquals(historicalSegments.size(), 2);
+    for (String segment : historicalSegments) {
+      LLCSegmentName llcSegmentName = LLCSegmentName.of(segment);
+      if (llcSegmentName.getPartitionGroupId() == 0) {
+        assertEquals(llcSegmentName.getSequenceNumber(), 100);
+      } else {
+        assertEquals(llcSegmentName.getSequenceNumber(), 199);
+      }
+    }
 
     // recover the original values
     helixAdminField.set(_helixResourceManager, originalHelixAdmin);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/replication/RealtimeSegmentCopierTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/replication/RealtimeSegmentCopierTest.java
@@ -22,6 +22,7 @@ import java.net.URI;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import org.apache.hc.core5.http.ClassicHttpRequest;
 import org.apache.pinot.common.utils.SimpleHttpResponse;
 import org.apache.pinot.common.utils.http.HttpClient;
 import org.apache.pinot.controller.ControllerConf;
@@ -34,8 +35,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyMap;
-import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -72,22 +72,24 @@ public class RealtimeSegmentCopierTest {
     String tableNameWithType = "table1_REALTIME";
     String segmentName = "seg1";
     CopyTablePayload payload = new CopyTablePayload("http://src", Collections.emptyMap(),
-        "http://dest", Collections.emptyMap(), "broker", "server", Collections.emptyMap());
+        "http://dest", Collections.emptyMap(), "broker", "server", Collections.emptyMap(), null);
 
     Map<String, String> metadata = new HashMap<>();
     metadata.put("segment.download.url", "hdfs://src/data/seg1");
 
     doReturn(_pinotFS).when(_copier).getPinotFS(any(URI.class));
     when(_pinotFS.exists(any(URI.class))).thenReturn(false);
+    when(_pinotFS.copy(any(URI.class), any(URI.class))).thenReturn(true);
 
     SimpleHttpResponse response = mock(SimpleHttpResponse.class);
     when(response.getStatusCode()).thenReturn(200);
-    when(_httpClient.sendJsonPostRequest(any(URI.class), anyString(), anyMap())).thenReturn(response);
+    when(response.getResponse()).thenReturn("{}");
+    doReturn(response).when(_httpClient).sendRequest(any(ClassicHttpRequest.class), anyLong());
 
     _copier.copy(tableNameWithType, segmentName, payload, metadata);
 
     verify(_pinotFS).copy(any(URI.class), any(URI.class));
-    verify(_httpClient).sendJsonPostRequest(any(URI.class), anyString(), anyMap());
+    verify(_httpClient).sendRequest(any(ClassicHttpRequest.class), anyLong());
   }
 
   @Test
@@ -95,7 +97,7 @@ public class RealtimeSegmentCopierTest {
     String tableNameWithType = "table1_REALTIME";
     String segmentName = "seg1";
     CopyTablePayload payload = new CopyTablePayload("http://src", Collections.emptyMap(),
-        "http://dest", Collections.emptyMap(), "broker", "server", Collections.emptyMap());
+        "http://dest", Collections.emptyMap(), "broker", "server", Collections.emptyMap(), null);
 
     Map<String, String> metadata = new HashMap<>();
     metadata.put("segment.download.url", "hdfs://src/data/seg1");
@@ -105,11 +107,12 @@ public class RealtimeSegmentCopierTest {
 
     SimpleHttpResponse response = mock(SimpleHttpResponse.class);
     when(response.getStatusCode()).thenReturn(200);
-    when(_httpClient.sendJsonPostRequest(any(URI.class), anyString(), anyMap())).thenReturn(response);
+    when(response.getResponse()).thenReturn("{}");
+    doReturn(response).when(_httpClient).sendRequest(any(ClassicHttpRequest.class), anyLong());
 
     _copier.copy(tableNameWithType, segmentName, payload, metadata);
 
     verify(_pinotFS, never()).copy(any(URI.class), any(URI.class));
-    verify(_httpClient).sendJsonPostRequest(any(URI.class), anyString(), anyMap());
+    verify(_httpClient).sendRequest(any(ClassicHttpRequest.class), anyLong());
   }
 }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/replication/RealtimeSegmentCopierTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/replication/RealtimeSegmentCopierTest.java
@@ -72,7 +72,7 @@ public class RealtimeSegmentCopierTest {
     String tableNameWithType = "table1_REALTIME";
     String segmentName = "seg1";
     CopyTablePayload payload = new CopyTablePayload("http://src", Collections.emptyMap(),
-        "http://dest", Collections.emptyMap(), "broker", "server", Collections.emptyMap(), null);
+        "http://dest", Collections.emptyMap(), "broker", "server", Collections.emptyMap(), null, null);
 
     Map<String, String> metadata = new HashMap<>();
     metadata.put("segment.download.url", "hdfs://src/data/seg1");
@@ -97,7 +97,7 @@ public class RealtimeSegmentCopierTest {
     String tableNameWithType = "table1_REALTIME";
     String segmentName = "seg1";
     CopyTablePayload payload = new CopyTablePayload("http://src", Collections.emptyMap(),
-        "http://dest", Collections.emptyMap(), "broker", "server", Collections.emptyMap(), null);
+        "http://dest", Collections.emptyMap(), "broker", "server", Collections.emptyMap(), null, null);
 
     Map<String, String> metadata = new HashMap<>();
     metadata.put("segment.download.url", "hdfs://src/data/seg1");

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/replication/RealtimeSegmentCopierTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/replication/RealtimeSegmentCopierTest.java
@@ -1,0 +1,115 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core.replication;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.pinot.common.utils.SimpleHttpResponse;
+import org.apache.pinot.common.utils.http.HttpClient;
+import org.apache.pinot.controller.ControllerConf;
+import org.apache.pinot.controller.api.resources.CopyTablePayload;
+import org.apache.pinot.spi.filesystem.PinotFS;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyMap;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class RealtimeSegmentCopierTest {
+
+  @Mock
+  private ControllerConf _controllerConf;
+  @Mock
+  private HttpClient _httpClient;
+  @Mock
+  private PinotFS _pinotFS;
+
+  private RealtimeSegmentCopier _copier;
+  private AutoCloseable _mocks;
+
+  @BeforeMethod
+  public void setUp() {
+    _mocks = MockitoAnnotations.openMocks(this);
+    when(_controllerConf.getDataDir()).thenReturn("hdfs://data");
+    _copier = spy(new RealtimeSegmentCopier(_controllerConf, _httpClient));
+  }
+
+  @AfterMethod
+  public void tearDown() throws Exception {
+    _mocks.close();
+  }
+
+  @Test
+  public void testCopy() throws Exception {
+    String tableNameWithType = "table1_REALTIME";
+    String segmentName = "seg1";
+    CopyTablePayload payload = new CopyTablePayload("http://src", Collections.emptyMap(),
+        "http://dest", Collections.emptyMap(), "broker", "server", Collections.emptyMap());
+
+    Map<String, String> metadata = new HashMap<>();
+    metadata.put("segment.download.url", "hdfs://src/data/seg1");
+
+    doReturn(_pinotFS).when(_copier).getPinotFS(any(URI.class));
+    when(_pinotFS.exists(any(URI.class))).thenReturn(false);
+
+    SimpleHttpResponse response = mock(SimpleHttpResponse.class);
+    when(response.getStatusCode()).thenReturn(200);
+    when(_httpClient.sendJsonPostRequest(any(URI.class), anyString(), anyMap())).thenReturn(response);
+
+    _copier.copy(tableNameWithType, segmentName, payload, metadata);
+
+    verify(_pinotFS).copy(any(URI.class), any(URI.class));
+    verify(_httpClient).sendJsonPostRequest(any(URI.class), anyString(), anyMap());
+  }
+
+  @Test
+  public void testCopyExisting() throws Exception {
+    String tableNameWithType = "table1_REALTIME";
+    String segmentName = "seg1";
+    CopyTablePayload payload = new CopyTablePayload("http://src", Collections.emptyMap(),
+        "http://dest", Collections.emptyMap(), "broker", "server", Collections.emptyMap());
+
+    Map<String, String> metadata = new HashMap<>();
+    metadata.put("segment.download.url", "hdfs://src/data/seg1");
+
+    doReturn(_pinotFS).when(_copier).getPinotFS(any(URI.class));
+    when(_pinotFS.exists(any(URI.class))).thenReturn(true);
+
+    SimpleHttpResponse response = mock(SimpleHttpResponse.class);
+    when(response.getStatusCode()).thenReturn(200);
+    when(_httpClient.sendJsonPostRequest(any(URI.class), anyString(), anyMap())).thenReturn(response);
+
+    _copier.copy(tableNameWithType, segmentName, payload, metadata);
+
+    verify(_pinotFS, never()).copy(any(URI.class), any(URI.class));
+    verify(_httpClient).sendJsonPostRequest(any(URI.class), anyString(), anyMap());
+  }
+}

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/replication/RealtimeSegmentCopierTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/replication/RealtimeSegmentCopierTest.java
@@ -28,6 +28,7 @@ import org.apache.pinot.common.utils.http.HttpClient;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.api.resources.CopyTablePayload;
 import org.apache.pinot.spi.filesystem.PinotFS;
+import org.apache.pinot.spi.utils.CommonConstants;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.testng.annotations.AfterMethod;
@@ -75,7 +76,7 @@ public class RealtimeSegmentCopierTest {
         "http://dest", Collections.emptyMap(), "broker", "server", Collections.emptyMap(), null, null);
 
     Map<String, String> metadata = new HashMap<>();
-    metadata.put("segment.download.url", "hdfs://src/data/seg1");
+    metadata.put(CommonConstants.Segment.DOWNLOAD_URL, "hdfs://src/data/seg1");
 
     doReturn(_pinotFS).when(_copier).getPinotFS(any(URI.class));
     when(_pinotFS.exists(any(URI.class))).thenReturn(false);
@@ -100,7 +101,7 @@ public class RealtimeSegmentCopierTest {
         "http://dest", Collections.emptyMap(), "broker", "server", Collections.emptyMap(), null, null);
 
     Map<String, String> metadata = new HashMap<>();
-    metadata.put("segment.download.url", "hdfs://src/data/seg1");
+    metadata.put(CommonConstants.Segment.DOWNLOAD_URL, "hdfs://src/data/seg1");
 
     doReturn(_pinotFS).when(_copier).getPinotFS(any(URI.class));
     when(_pinotFS.exists(any(URI.class))).thenReturn(true);
@@ -114,5 +115,18 @@ public class RealtimeSegmentCopierTest {
 
     verify(_pinotFS, never()).copy(any(URI.class), any(URI.class));
     verify(_httpClient).sendRequest(any(ClassicHttpRequest.class), anyLong());
+  }
+
+  @Test(expectedExceptions = RuntimeException.class, expectedExceptionsMessageRegExp = ".*Download URL not found.*")
+  public void testCopyMissingDownloadUrl() {
+    String tableNameWithType = "table1_REALTIME";
+    String segmentName = "seg1";
+    CopyTablePayload payload = new CopyTablePayload("http://src", Collections.emptyMap(),
+        "http://dest", Collections.emptyMap(), "broker", "server", Collections.emptyMap(), null, null);
+
+    Map<String, String> metadata = new HashMap<>();
+    // No download URL in metadata
+
+    _copier.copy(tableNameWithType, segmentName, payload, metadata);
   }
 }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/replication/TableReplicationProgressStatsTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/replication/TableReplicationProgressStatsTest.java
@@ -1,0 +1,43 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core.replication;
+
+import java.util.List;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+public class TableReplicationProgressStatsTest {
+
+  @Test
+  public void testStats() {
+    TableReplicationProgressStats stats = new TableReplicationProgressStats(10);
+    Assert.assertEquals(stats.getRemainingSegments(), 10);
+    Assert.assertTrue(stats.getSegmentsFailToCopy().isEmpty());
+
+    stats.updateSegmentStatus("seg1", TableReplicationProgressStats.SegmentStatus.COMPLETED);
+    Assert.assertEquals(stats.getRemainingSegments(), 9);
+    Assert.assertTrue(stats.getSegmentsFailToCopy().isEmpty());
+
+    stats.updateSegmentStatus("seg2", TableReplicationProgressStats.SegmentStatus.ERROR);
+    Assert.assertEquals(stats.getRemainingSegments(), 8);
+    List<String> failedSegments = stats.getSegmentsFailToCopy();
+    Assert.assertEquals(failedSegments.size(), 1);
+    Assert.assertEquals(failedSegments.get(0), "seg2");
+  }
+}

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/replication/TableReplicatorTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/replication/TableReplicatorTest.java
@@ -80,9 +80,12 @@ public class TableReplicatorTest {
     String tableName = "table1_REALTIME";
     String sourceClusterUri = "http://localhost:9000";
     CopyTablePayload copyTablePayload = new CopyTablePayload(sourceClusterUri, Collections.emptyMap(),
-        "http://dest", Collections.emptyMap(), "broker", "server", Collections.emptyMap());
+        "http://dest", Collections.emptyMap(), "broker", "server", Collections.emptyMap(), null);
 
-    WatermarkInductionResult watermarkInductionResult = new WatermarkInductionResult(Collections.emptyList(),
+    List<WatermarkInductionResult.Watermark> watermarks = Arrays.asList(
+        new WatermarkInductionResult.Watermark(0, 10, 100L),
+        new WatermarkInductionResult.Watermark(1, 11, 110L));
+    WatermarkInductionResult watermarkInductionResult = new WatermarkInductionResult(watermarks,
         Arrays.asList("seg1", "seg2"));
 
     // Mock HttpClient response for ZK metadata
@@ -115,6 +118,6 @@ public class TableReplicatorTest {
     Assert.assertTrue(capturedSegments.contains("seg1"));
     Assert.assertTrue(capturedSegments.contains("seg2"));
 
-    verify(_executorService, times(4)).submit(any(Runnable.class));
+    verify(_executorService, times(watermarks.size())).submit(any(Runnable.class));
   }
 }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/replication/TableReplicatorTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/replication/TableReplicatorTest.java
@@ -80,7 +80,7 @@ public class TableReplicatorTest {
     String tableName = "table1_REALTIME";
     String sourceClusterUri = "http://localhost:9000";
     CopyTablePayload copyTablePayload = new CopyTablePayload(sourceClusterUri, Collections.emptyMap(),
-        "http://dest", Collections.emptyMap(), "broker", "server", Collections.emptyMap(), null);
+        "http://dest", Collections.emptyMap(), "broker", "server", Collections.emptyMap(), null, null);
 
     List<WatermarkInductionResult.Watermark> watermarks = Arrays.asList(
         new WatermarkInductionResult.Watermark(0, 10, 100L),

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/replication/TableReplicatorTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/replication/TableReplicatorTest.java
@@ -40,7 +40,6 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import static org.mockito.Mockito.any;
-import static org.mockito.Mockito.anyList;
 import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.anyMap;
 import static org.mockito.Mockito.anyString;
@@ -102,16 +101,16 @@ public class TableReplicatorTest {
     when(response.getStatusCode()).thenReturn(200);
 
     when(_httpClient.sendGetRequest(any(URI.class), anyMap())).thenReturn(response);
-    when(_pinotHelixResourceManager.addNewSegmentCopyXClusterJob(anyString(), anyString(), anyLong(), anyList()))
-        .thenReturn(true);
+    when(_pinotHelixResourceManager.addNewTableReplicationJob(anyString(), anyString(), anyLong(),
+        any(WatermarkInductionResult.class))).thenReturn(true);
 
     _tableReplicator.replicateTable(jobId, tableName, copyTablePayload, watermarkInductionResult);
 
-    ArgumentCaptor<List> segmentsCaptor = ArgumentCaptor.forClass(List.class);
-    verify(_pinotHelixResourceManager).addNewSegmentCopyXClusterJob(eq(tableName), eq(jobId), anyLong(),
-        segmentsCaptor.capture());
+    ArgumentCaptor<WatermarkInductionResult> resultCaptor = ArgumentCaptor.forClass(WatermarkInductionResult.class);
+    verify(_pinotHelixResourceManager).addNewTableReplicationJob(eq(tableName), eq(jobId), anyLong(),
+        resultCaptor.capture());
 
-    List<String> capturedSegments = segmentsCaptor.getValue();
+    List<String> capturedSegments = resultCaptor.getValue().getHistoricalSegments();
     Assert.assertEquals(capturedSegments.size(), 2);
     Assert.assertTrue(capturedSegments.contains("seg1"));
     Assert.assertTrue(capturedSegments.contains("seg2"));

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/replication/TableReplicatorTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/replication/TableReplicatorTest.java
@@ -1,0 +1,121 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core.replication;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import org.apache.pinot.common.utils.SimpleHttpResponse;
+import org.apache.pinot.common.utils.http.HttpClient;
+import org.apache.pinot.controller.api.resources.CopyTablePayload;
+import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
+import org.apache.pinot.controller.helix.core.WatermarkInductionResult;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyList;
+import static org.mockito.Mockito.anyLong;
+import static org.mockito.Mockito.anyMap;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class TableReplicatorTest {
+
+  @Mock
+  private PinotHelixResourceManager _pinotHelixResourceManager;
+  @Mock
+  private ExecutorService _executorService;
+  @Mock
+  private SegmentCopier _segmentCopier;
+  @Mock
+  private HttpClient _httpClient;
+
+  private TableReplicator _tableReplicator;
+  private AutoCloseable _mocks;
+
+  @BeforeMethod
+  public void setUp() {
+    _mocks = MockitoAnnotations.openMocks(this);
+    _tableReplicator = new TableReplicator(_pinotHelixResourceManager, _executorService, _segmentCopier, _httpClient);
+  }
+
+  @AfterMethod
+  public void tearDown() throws Exception {
+    _mocks.close();
+  }
+
+  @Test
+  public void testReplicateTable() throws Exception {
+    String jobId = "job1";
+    String tableName = "table1_REALTIME";
+    String sourceClusterUri = "http://localhost:9000";
+    CopyTablePayload copyTablePayload = new CopyTablePayload(sourceClusterUri, Collections.emptyMap(),
+        "http://dest", Collections.emptyMap(), "broker", "server", Collections.emptyMap());
+
+    WatermarkInductionResult watermarkInductionResult = new WatermarkInductionResult(Collections.emptyList(),
+        Arrays.asList("seg1", "seg2"));
+
+    // Mock HttpClient response for ZK metadata
+    Map<String, Map<String, String>> zkMetadataMap = new HashMap<>();
+    Map<String, String> seg1Metadata = new HashMap<>();
+    seg1Metadata.put("k1", "v1");
+    zkMetadataMap.put("seg1", seg1Metadata);
+
+    Map<String, String> seg2Metadata = new HashMap<>();
+    seg2Metadata.put("k2", "v2");
+    zkMetadataMap.put("seg2", seg2Metadata);
+
+    String zkMetadataJson = new ObjectMapper().writeValueAsString(zkMetadataMap);
+    SimpleHttpResponse response = mock(SimpleHttpResponse.class);
+    when(response.getResponse()).thenReturn(zkMetadataJson);
+    when(response.getStatusCode()).thenReturn(200);
+
+    when(_httpClient.sendGetRequest(any(URI.class), anyMap())).thenReturn(response);
+    when(_pinotHelixResourceManager.addNewSegmentCopyXClusterJob(anyString(), anyString(), anyLong(), anyList()))
+        .thenReturn(true);
+
+    _tableReplicator.replicateTable(jobId, tableName, copyTablePayload, watermarkInductionResult);
+
+    ArgumentCaptor<List> segmentsCaptor = ArgumentCaptor.forClass(List.class);
+    verify(_pinotHelixResourceManager).addNewSegmentCopyXClusterJob(eq(tableName), eq(jobId), anyLong(),
+        segmentsCaptor.capture());
+
+    List<String> capturedSegments = segmentsCaptor.getValue();
+    Assert.assertEquals(capturedSegments.size(), 2);
+    Assert.assertTrue(capturedSegments.contains("seg1"));
+    Assert.assertTrue(capturedSegments.contains("seg2"));
+
+    verify(_executorService, times(4)).submit(any(Runnable.class));
+  }
+}

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/replication/ZkBasedTableReplicationObserverTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/replication/ZkBasedTableReplicationObserverTest.java
@@ -19,9 +19,11 @@
 package org.apache.pinot.controller.helix.core.replication;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
+import org.apache.pinot.controller.helix.core.WatermarkInductionResult;
 import org.apache.pinot.controller.helix.core.controllerjob.ControllerJobTypes;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.mockito.ArgumentCaptor;
@@ -61,9 +63,10 @@ public class ZkBasedTableReplicationObserverTest {
     String jobId = "job1";
     String tableName = "table1";
     List<String> segments = Arrays.asList("seg1", "seg2", "seg3");
+    WatermarkInductionResult res = new WatermarkInductionResult(Collections.emptyList(), segments);
 
     ZkBasedTableReplicationObserver observer =
-        new ZkBasedTableReplicationObserver(jobId, tableName, segments, _pinotHelixResourceManager);
+        new ZkBasedTableReplicationObserver(jobId, tableName, res, _pinotHelixResourceManager);
 
     // Trigger completion (1st segment) - no ZK update (only every 100 or error)
     // Total 3. remaining starts at 3.
@@ -93,9 +96,10 @@ public class ZkBasedTableReplicationObserverTest {
     String jobId = "job1";
     String tableName = "table1";
     List<String> segments = Arrays.asList("seg1");
+    WatermarkInductionResult res = new WatermarkInductionResult(Collections.emptyList(), segments);
 
     ZkBasedTableReplicationObserver observer =
-        new ZkBasedTableReplicationObserver(jobId, tableName, segments, _pinotHelixResourceManager);
+        new ZkBasedTableReplicationObserver(jobId, tableName, res, _pinotHelixResourceManager);
 
     observer.onTrigger(TableReplicationObserver.Trigger.SEGMENT_REPLICATE_ERRORED_TRIGGER, "seg1");
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/replication/ZkBasedTableReplicationObserverTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/replication/ZkBasedTableReplicationObserverTest.java
@@ -20,6 +20,7 @@ package org.apache.pinot.controller.helix.core.replication;
 
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
@@ -35,11 +36,13 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.anyMap;
 import static org.mockito.Mockito.anyString;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class ZkBasedTableReplicationObserverTest {
 
@@ -59,11 +62,17 @@ public class ZkBasedTableReplicationObserverTest {
   }
 
   @Test
-  public void testObserver() {
+  public void testObserver() throws Exception {
     String jobId = "job1";
     String tableName = "table1";
     List<String> segments = Arrays.asList("seg1", "seg2", "seg3");
     WatermarkInductionResult res = new WatermarkInductionResult(Collections.emptyList(), segments);
+
+    Map<String, String> baseMetadata = new HashMap<>();
+    baseMetadata.put(CommonConstants.ControllerJob.JOB_ID, jobId);
+    baseMetadata.put(CommonConstants.ControllerJob.TABLE_NAME_WITH_TYPE, tableName);
+    when(_pinotHelixResourceManager.commonTableReplicationJobMetadata(eq(tableName), eq(jobId), anyLong(),
+        eq(res))).thenReturn(baseMetadata);
 
     ZkBasedTableReplicationObserver observer =
         new ZkBasedTableReplicationObserver(jobId, tableName, res, _pinotHelixResourceManager);
@@ -92,11 +101,17 @@ public class ZkBasedTableReplicationObserverTest {
   }
 
   @Test
-  public void testObserverError() {
+  public void testObserverError() throws Exception {
     String jobId = "job1";
     String tableName = "table1";
     List<String> segments = Arrays.asList("seg1");
     WatermarkInductionResult res = new WatermarkInductionResult(Collections.emptyList(), segments);
+
+    Map<String, String> baseMetadata = new HashMap<>();
+    baseMetadata.put(CommonConstants.ControllerJob.JOB_ID, jobId);
+    baseMetadata.put(CommonConstants.ControllerJob.TABLE_NAME_WITH_TYPE, tableName);
+    when(_pinotHelixResourceManager.commonTableReplicationJobMetadata(eq(tableName), eq(jobId), anyLong(),
+        eq(res))).thenReturn(baseMetadata);
 
     ZkBasedTableReplicationObserver observer =
         new ZkBasedTableReplicationObserver(jobId, tableName, res, _pinotHelixResourceManager);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/replication/ZkBasedTableReplicationObserverTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/replication/ZkBasedTableReplicationObserverTest.java
@@ -1,0 +1,105 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core.replication;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
+import org.apache.pinot.controller.helix.core.controllerjob.ControllerJobTypes;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyMap;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+public class ZkBasedTableReplicationObserverTest {
+
+  @Mock
+  private PinotHelixResourceManager _pinotHelixResourceManager;
+
+  private AutoCloseable _mocks;
+
+  @BeforeMethod
+  public void setUp() {
+    _mocks = MockitoAnnotations.openMocks(this);
+  }
+
+  @AfterMethod
+  public void tearDown() throws Exception {
+    _mocks.close();
+  }
+
+  @Test
+  public void testObserver() {
+    String jobId = "job1";
+    String tableName = "table1";
+    List<String> segments = Arrays.asList("seg1", "seg2", "seg3");
+
+    ZkBasedTableReplicationObserver observer =
+        new ZkBasedTableReplicationObserver(jobId, tableName, segments, _pinotHelixResourceManager);
+
+    // Trigger completion (1st segment) - no ZK update (only every 100 or error)
+    // Total 3. remaining starts at 3.
+    // complete seg1 -> remaining 2. 2 % 100 != 0.
+    // complete seg2 -> remaining 1.
+    // complete seg3 -> remaining 0. 0 % 100 == 0 -> ZK update.
+
+    observer.onTrigger(TableReplicationObserver.Trigger.SEGMENT_REPLICATE_COMPLETED_TRIGGER, "seg1");
+    verify(_pinotHelixResourceManager, never()).addControllerJobToZK(anyString(), anyMap(), any());
+
+    observer.onTrigger(TableReplicationObserver.Trigger.SEGMENT_REPLICATE_COMPLETED_TRIGGER, "seg2");
+    verify(_pinotHelixResourceManager, never()).addControllerJobToZK(anyString(), anyMap(), any());
+
+    observer.onTrigger(TableReplicationObserver.Trigger.SEGMENT_REPLICATE_COMPLETED_TRIGGER, "seg3");
+
+    ArgumentCaptor<Map<String, String>> metadataCaptor = ArgumentCaptor.forClass(Map.class);
+    verify(_pinotHelixResourceManager).addControllerJobToZK(eq(jobId), metadataCaptor.capture(),
+        eq(ControllerJobTypes.TABLE_REPLICATION));
+
+    Map<String, String> metadata = metadataCaptor.getValue();
+    Assert.assertEquals(metadata.get(CommonConstants.ControllerJob.JOB_ID), jobId);
+    Assert.assertEquals(metadata.get(CommonConstants.ControllerJob.TABLE_NAME_WITH_TYPE), tableName);
+  }
+
+  @Test
+  public void testObserverError() {
+    String jobId = "job1";
+    String tableName = "table1";
+    List<String> segments = Arrays.asList("seg1");
+
+    ZkBasedTableReplicationObserver observer =
+        new ZkBasedTableReplicationObserver(jobId, tableName, segments, _pinotHelixResourceManager);
+
+    observer.onTrigger(TableReplicationObserver.Trigger.SEGMENT_REPLICATE_ERRORED_TRIGGER, "seg1");
+
+    verify(_pinotHelixResourceManager).addControllerJobToZK(eq(jobId), anyMap(),
+        eq(ControllerJobTypes.TABLE_REPLICATION));
+  }
+}

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/replication/ZkBasedTableReplicationObserverTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/replication/ZkBasedTableReplicationObserverTest.java
@@ -39,6 +39,7 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.anyLong;
 import static org.mockito.Mockito.anyMap;
 import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -120,5 +121,55 @@ public class ZkBasedTableReplicationObserverTest {
 
     verify(_pinotHelixResourceManager).addControllerJobToZK(eq(jobId), anyMap(),
         eq(ControllerJobTypes.TABLE_REPLICATION));
+  }
+
+  @Test
+  public void testObserverCompletedWithErrors() throws Exception {
+    String jobId = "job1";
+    String tableName = "table1";
+    List<String> segments = Arrays.asList("seg1", "seg2");
+    WatermarkInductionResult res = new WatermarkInductionResult(Collections.emptyList(), segments);
+
+    Map<String, String> baseMetadata = new HashMap<>();
+    baseMetadata.put(CommonConstants.ControllerJob.JOB_ID, jobId);
+    baseMetadata.put(CommonConstants.ControllerJob.TABLE_NAME_WITH_TYPE, tableName);
+    when(_pinotHelixResourceManager.commonTableReplicationJobMetadata(eq(tableName), eq(jobId), anyLong(),
+        eq(res))).thenReturn(baseMetadata);
+
+    ZkBasedTableReplicationObserver observer =
+        new ZkBasedTableReplicationObserver(jobId, tableName, res, _pinotHelixResourceManager);
+
+    // seg1 succeeds, seg2 fails -> remaining == 0 but with errors
+    observer.onTrigger(TableReplicationObserver.Trigger.SEGMENT_REPLICATE_COMPLETED_TRIGGER, "seg1");
+    observer.onTrigger(TableReplicationObserver.Trigger.SEGMENT_REPLICATE_ERRORED_TRIGGER, "seg2");
+
+    ArgumentCaptor<Map<String, String>> metadataCaptor = ArgumentCaptor.forClass(Map.class);
+    verify(_pinotHelixResourceManager).addControllerJobToZK(eq(jobId), metadataCaptor.capture(),
+        eq(ControllerJobTypes.TABLE_REPLICATION));
+
+    Map<String, String> metadata = metadataCaptor.getValue();
+    Assert.assertEquals(metadata.get(CommonConstants.ControllerJob.REPLICATION_JOB_STATUS), "COMPLETED_WITH_ERRORS");
+  }
+
+  @Test
+  public void testObserverZkWriteFailureDoesNotPropagate() throws Exception {
+    String jobId = "job1";
+    String tableName = "table1";
+    List<String> segments = Arrays.asList("seg1");
+    WatermarkInductionResult res = new WatermarkInductionResult(Collections.emptyList(), segments);
+
+    Map<String, String> baseMetadata = new HashMap<>();
+    baseMetadata.put(CommonConstants.ControllerJob.JOB_ID, jobId);
+    baseMetadata.put(CommonConstants.ControllerJob.TABLE_NAME_WITH_TYPE, tableName);
+    when(_pinotHelixResourceManager.commonTableReplicationJobMetadata(eq(tableName), eq(jobId), anyLong(),
+        eq(res))).thenReturn(baseMetadata);
+    doThrow(new RuntimeException("ZK unavailable")).when(_pinotHelixResourceManager)
+        .addControllerJobToZK(anyString(), anyMap(), any());
+
+    ZkBasedTableReplicationObserver observer =
+        new ZkBasedTableReplicationObserver(jobId, tableName, res, _pinotHelixResourceManager);
+
+    // Should not throw even when ZK write fails
+    observer.onTrigger(TableReplicationObserver.Trigger.SEGMENT_REPLICATE_ERRORED_TRIGGER, "seg1");
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/auth/Actions.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/auth/Actions.java
@@ -105,6 +105,7 @@ public class Actions {
     public static final String DELETE_QUERY_WORKLOAD_CONFIG = "DeleteQueryWorkloadConfig";
     public static final String GET_GROOVY_STATIC_ANALYZER_CONFIG = "GetGroovyStaticAnalyzerConfig";
     public static final String UPDATE_GROOVY_STATIC_ANALYZER_CONFIG = "UpdateGroovyStaticAnalyzerConfig";
+    public static final String GET_TABLE_COPY_STATUS = "GetTableCopyStatus";
   }
 
   // Action names for table

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -1657,6 +1657,9 @@ public class CommonConstants {
     public static final String NUM_CONSUMING_SEGMENTS_YET_TO_BE_COMMITTED = "numberOfSegmentsYetToBeCommitted";
     // Table Replication job props
     public static final String SEGMENTS_TO_BE_COPIED = "segmentsToBeCopied";
+    public static final String CONSUMER_WATERMARKS = "consumerWatermarks";
+    public static final String REPLICATION_PROGRESS = "replicationProgress";
+    public static final String REPLICATION_JOB_STATUS = "replicationJobStatus";
   }
 
   // prefix for scheduler related features, e.g. query accountant

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -1655,6 +1655,8 @@ public class CommonConstants {
     public static final String CONSUMING_SEGMENTS_FORCE_COMMITTED_LIST = "segmentsForceCommitted";
     public static final String CONSUMING_SEGMENTS_YET_TO_BE_COMMITTED_LIST = "segmentsYetToBeCommitted";
     public static final String NUM_CONSUMING_SEGMENTS_YET_TO_BE_COMMITTED = "numberOfSegmentsYetToBeCommitted";
+    // Table Replication job props
+    public static final String SEGMENTS_TO_BE_COPIED = "segmentsToBeCopied";
   }
 
   // prefix for scheduler related features, e.g. query accountant

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/ControllerRequestURLBuilder.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/ControllerRequestURLBuilder.java
@@ -468,6 +468,10 @@ public class ControllerRequestURLBuilder {
     return StringUtil.join("/", _baseUrl, "segments", tableName, "metadata") + "?type=" + tableType.name();
   }
 
+  public String forSegmentZkMetadata(String tableNameWithType) {
+    return StringUtil.join("/", _baseUrl, "segments", tableNameWithType, "zkmetadata");
+  }
+
   public String forListAllSegmentLineages(String tableName, String tableType) {
     return StringUtil.join("/", _baseUrl, "segments", tableName, "lineage?type=" + tableType);
   }


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Flow for initiating a table replication job: REST call \-&gt; TableReplicator setup \-&gt; parallel segment copying \-&gt; progress updates to ZK via observer\.

```mermaid
flowchart TD
  N0["REST endpoint#58; start copy table #40;F17#41;"]:::stModified
  N1["TableReplicator#58; setup job and tasks #40;F11#41;"]:::stAdded
  N2["Segment copy task#58; copy and report #40;F11#41;"]:::stAdded
  N3["RealtimeSegmentCopier#58; perform segment copy #40;F7#41;"]:::stAdded
  N4["Observer#58; update progress in ZK #40;F12#41;"]:::stAdded
  N0 -->|"Starts replication setup"| N1
  N1 -->|"Submits copy tasks"| N2
  N2 -->|"Requests segment copy"| N3
  N2 -->|"Reports segment copy result"| N4
  N1 -->|"Reports job start"| N4
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F7: pinot\-controller/src/main/java/org/apache/pinot/controller/helix/core/replication/RealtimeSegmentCopier\.java — [after](https://github.com/apache/pinot/blob/a3aa806a0ce96a0b9685b25aeeaa448fb60e54bf/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/replication/RealtimeSegmentCopier.java)
- F11: pinot\-controller/src/main/java/org/apache/pinot/controller/helix/core/replication/TableReplicator\.java — [after](https://github.com/apache/pinot/blob/a3aa806a0ce96a0b9685b25aeeaa448fb60e54bf/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/replication/TableReplicator.java)
- F12: pinot\-controller/src/main/java/org/apache/pinot/controller/helix/core/replication/ZkBasedTableReplicationObserver\.java — [after](https://github.com/apache/pinot/blob/a3aa806a0ce96a0b9685b25aeeaa448fb60e54bf/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/replication/ZkBasedTableReplicationObserver.java)
- F17: pinot\-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource\.java — [before](https://github.com/apache/pinot/blob/1329e1f7f23bf64804ecd918567a1e5a644d9622/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java) · [after](https://github.com/apache/pinot/blob/a3aa806a0ce96a0b9685b25aeeaa448fb60e54bf/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjEzMjllMWY3ZjIzYmY2NDgwNGVjZDkxODU2N2ExZTVhNjQ0ZDk2MjIiLCJjb250ZXh0X2hhc2giOiIwODk5NGJjZTU0ZWY1MmIzMjViY2VlNDQ5ZTI4OTBmMTc0ZTY3NTQ3YWYxNDU0Mzg5Y2IzYmFiMTBiZjdkMGE4IiwiZ2VuZXJhdGVkX2F0IjoxNzg5MTc2NzQ1LCJoZWFkX3NoYSI6ImEzYWE4MDZhMGNlOTZhMGI5Njg1YjI1YWVlYWE0NDhmYjYwZTU0YmYiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiIxMzI5ZTFmN2YyM2JmNjQ4MDRlY2Q5MTg1NjdhMWU1YTY0NGQ5NjIyIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 3a11b99c10113c4fe80a8c3478e2a57c86ab6fd1c369a8e393caa1a85b9eaa32 -->
<!-- pinot-pr-flow:end -->

Check the phase 2 flow chart in the [design doc](https://docs.google.com/document/d/1DDSW8aG1UHa3eCBmecS2Y9zsj7AeP29tCjlCMHW0Q5Q/edit?usp=sharing)
- Create an async controller zk jobs to deeply backfill historical segments prior to the inducted consumer watermarks. The deep copy means replicating segments to a standalone remote storage path.
- Introduced TableReplicator to fetch segment ZK metadata from the source, register a controller job, and submit 4 worker tasks (can be fine tuned in the future) that call a SegmentCopier for each segment; errors immediately trigger job updates and completed segments are batched for ZK updates.  
- Added ZkBasedTableReplicationObserver and TableReplicationProgressStats to keep in-memory progress (remaining count and failed segment list) and persist job metadata to ZK (including a SEGMENTS_TO_BE_COPIED field) every 100 completions or immediately on error.  
- Implemented SegmentCopier interface with RealtimeSegmentCopier (deep-copy mode) that copies segments between the same PinotFS scheme and uploads the segment URI to the destination controller; if a segment lacks a deep-store download URL the code logs the problem and records failures.