### PR TITLE
Allow BIG_DECIMAL data type for dictionary index type

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/bloom/BloomIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/bloom/BloomIndexType.java
@@ -74,14 +74,7 @@ public class BloomIndexType extends AbstractIndexType<BloomFilterConfig, BloomFi
     BloomFilterConfig bloomFilterConfig = indexConfigs.getConfig(StandardIndexes.bloomFilter());
     if (bloomFilterConfig.isEnabled()) {
       DataType dataType = fieldSpec.getDataType();
-      String column = fieldSpec.getName();
       Preconditions.checkState(dataType != DataType.BOOLEAN, "Cannot create bloom filter on BOOLEAN column: %s",
-          column);
-      Preconditions.checkState(dataType != DataType.BIG_DECIMAL, "Cannot create bloom filter on BIG_DECIMAL column: %s",
-          column);
-      Preconditions.checkState(dataType != DataType.TIMESTAMP, "Cannot create bloom filter on TIMESTAMP column: %s",
-          column);
-      Preconditions.checkState(dataType != DataType.JSON, "Cannot create bloom filter on JSON column: %s",
           column);
       Preconditions.checkState(dataType != DataType.MAP, "Cannot create bloom filter on MAP column: %s", column);
     }


### PR DESCRIPTION
 ### Summary
Add table config validation so bloom filter is only allowed on column types supported by the Pinot data-and-index-types compatibility matrix. Bloom filter is not supported on BOOLEAN, BIG_DECIMAL, TIMESTAMP, JSON, or MAP.

Ref: https://docs.pinot.apache.org/basics/getting-started/frequent-questions/ingestion-faq#indexing

### Changes
When bloom filter is enabled on a column, validation now fails with a clear error if the column type is:
- BOOLEAN
- BIG_DECIMAL
- TIMESTAMP
- JSON
- MAP

### Testing
Build should pass successfully

`enhancement` `user-experience`