### PR TITLE
Support v2 gapfill server-side execution

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
@@ -341,6 +341,15 @@ public class QueryOptionsUtils {
     return Boolean.parseBoolean(queryOptions.get(QueryOptionKey.SERVER_RETURN_FINAL_RESULT_KEY_UNPARTITIONED));
   }
 
+  public static boolean isServerSideGapfill(Map<String, String> queryOptions) {
+    return Boolean.parseBoolean(queryOptions.get(QueryOptionKey.SERVER_SIDE_GAPFILL));
+  }
+
+  @Nullable
+  public static String getServerSideGapfillQuery(Map<String, String> queryOptions) {
+    return queryOptions.get(QueryOptionKey.SERVER_SIDE_GAPFILL_QUERY);
+  }
+
   public static boolean isFilteredAggregationsSkipEmptyGroups(Map<String, String> queryOptions) {
     return Boolean.parseBoolean(queryOptions.get(QueryOptionKey.FILTERED_AGGREGATIONS_SKIP_EMPTY_GROUPS));
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/InstancePlanMakerImplV2.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/InstancePlanMakerImplV2.java
@@ -204,8 +204,9 @@ public class InstancePlanMakerImplV2 implements PlanMaker {
     }
 
     CombinePlanNode combinePlanNode = new CombinePlanNode(planNodes, queryContext, executorService, null);
-    return new GlobalPlanImplV0(
-        new InstanceResponsePlanNode(combinePlanNode, segmentContexts, fetchContexts, queryContext));
+    InstanceResponsePlanNode responsePlanNode =
+        new InstanceResponsePlanNode(combinePlanNode, segmentContexts, fetchContexts, queryContext);
+    return new GlobalPlanImplV0(responsePlanNode);
   }
 
   private void applyQueryOptions(QueryContext queryContext) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GapfillProcessorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GapfillProcessorFactory.java
@@ -62,4 +62,20 @@ public final class GapfillProcessorFactory {
 
     return new GapfillProcessor(queryContext, gapfillType);
   }
+
+  public static BaseGapfillProcessor getGapfillProcessorForServer(QueryContext queryContext,
+      GapfillUtils.GapfillType gapfillType) {
+    QueryContext effectiveContext = queryContext;
+    GapfillUtils.GapfillType effectiveGapfillType = gapfillType;
+    if (gapfillType == GapfillUtils.GapfillType.GAP_FILL_SELECT
+        || gapfillType == GapfillUtils.GapfillType.GAP_FILL_AGGREGATE
+        || gapfillType == GapfillUtils.GapfillType.AGGREGATE_GAP_FILL_AGGREGATE) {
+      QueryContext subqueryContext = queryContext.getSubquery();
+      if (subqueryContext != null) {
+        effectiveContext = subqueryContext;
+        effectiveGapfillType = GapfillUtils.getGapfillType(subqueryContext);
+      }
+    }
+    return new GapfillProcessor(effectiveContext, effectiveGapfillType, false, true);
+  }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/SumAvgGapfillProcessor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/SumAvgGapfillProcessor.java
@@ -190,7 +190,9 @@ class SumAvgGapfillProcessor extends BaseGapfillProcessor {
         Object[] aggregatedRow = new Object[_queryContext.getSelectExpressions().size()];
         for (int i = 0; i < _columnTypes.length; i++) {
           if (_columnTypes[i] == 0) {
-            if (dataSchema.getColumnDataType(_timeBucketColumnIndex) == DataSchema.ColumnDataType.LONG) {
+            DataSchema.ColumnDataType timeBucketType = dataSchema.getColumnDataType(_timeBucketColumnIndex);
+            if (timeBucketType == DataSchema.ColumnDataType.LONG
+                || timeBucketType == DataSchema.ColumnDataType.TIMESTAMP) {
               aggregatedRow[i] = time - (_aggregationSize - 1) * _gapfillTimeBucketSize;
             } else {
               aggregatedRow[i] = _dateTimeFormatter.fromMillisToFormat(

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/GapfillIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/GapfillIntegrationTest.java
@@ -1,0 +1,260 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.integration.tests.custom;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.generic.GenericData;
+import org.apache.pinot.spi.config.table.ColumnPartitionConfig;
+import org.apache.pinot.spi.config.table.RoutingConfig;
+import org.apache.pinot.spi.config.table.SegmentPartitionConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+
+/**
+ * Integration test that validates gapfill results against a small, deterministic dataset.
+ *
+ * <p>Not thread-safe.</p>
+ */
+@Test(suiteName = "CustomClusterIntegrationTest")
+public class GapfillIntegrationTest extends CustomDataQueryClusterIntegrationTest {
+
+  private static final String DEFAULT_TABLE_NAME = "GapfillIntegrationTest";
+  private static final String ENTITY_ID_COLUMN = "entityId";
+  private static final String VALUE_COLUMN = "value";
+  private static final int NUM_RECORDS = 5;
+
+  private static final long BASE_MS = 1633078800000L;
+  private static final long START_MS = BASE_MS + 1000L;
+  private static final long END_MS = BASE_MS + 7000L;
+
+  private static final long[][] RAW_ROWS = new long[][]{
+      {BASE_MS + 1000L, 1L, 10L},
+      {BASE_MS + 3000L, 1L, 30L},
+      {BASE_MS + 6000L, 1L, 60L},
+      {BASE_MS + 2000L, 2L, 20L},
+      {BASE_MS + 5000L, 2L, 50L}
+  };
+
+  private static final long[][] EXPECTED_GAPFILL_ROWS = new long[][]{
+      {BASE_MS + 1000L, 1L, 10L},
+      {BASE_MS + 2000L, 1L, 10L},
+      {BASE_MS + 3000L, 1L, 30L},
+      {BASE_MS + 4000L, 1L, 30L},
+      {BASE_MS + 5000L, 1L, 30L},
+      {BASE_MS + 6000L, 1L, 60L},
+      {BASE_MS + 1000L, 2L, 0L},
+      {BASE_MS + 2000L, 2L, 20L},
+      {BASE_MS + 3000L, 2L, 20L},
+      {BASE_MS + 4000L, 2L, 20L},
+      {BASE_MS + 5000L, 2L, 50L},
+      {BASE_MS + 6000L, 2L, 50L}
+  };
+
+  private static final long[][] EXPECTED_GAPFILL_SUM_ROWS = new long[][]{
+      {BASE_MS + 1000L, 10L},
+      {BASE_MS + 2000L, 30L},
+      {BASE_MS + 3000L, 50L},
+      {BASE_MS + 4000L, 50L},
+      {BASE_MS + 5000L, 80L},
+      {BASE_MS + 6000L, 110L}
+  };
+
+  @Override
+  public String getTableName() {
+    return DEFAULT_TABLE_NAME;
+  }
+
+  @Override
+  protected long getCountStarResult() {
+    return NUM_RECORDS;
+  }
+
+  @Override
+  public int getNumAvroFiles() {
+    return 1;
+  }
+
+  @Override
+  public Schema createSchema() {
+    return new Schema.SchemaBuilder().setSchemaName(getTableName())
+        .addDateTime(TIMESTAMP_FIELD_NAME, FieldSpec.DataType.LONG, "1:MILLISECONDS:EPOCH", "1:MILLISECONDS")
+        .addSingleValueDimension(ENTITY_ID_COLUMN, FieldSpec.DataType.INT)
+        .addSingleValueDimension(VALUE_COLUMN, FieldSpec.DataType.INT)
+        .build();
+  }
+
+  @Override
+  public TableConfig createOfflineTableConfig() {
+    Map<String, ColumnPartitionConfig> partitionConfig = new HashMap<>();
+    partitionConfig.put(ENTITY_ID_COLUMN, new ColumnPartitionConfig("Modulo", 1));
+    SegmentPartitionConfig segmentPartitionConfig = new SegmentPartitionConfig(partitionConfig);
+    RoutingConfig routingConfig =
+        new RoutingConfig(null, null, RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE, null);
+
+    return new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName(getTableName())
+        .setTimeColumnName(getTimeColumnName())
+        .setSortedColumn(getSortedColumn())
+        .setInvertedIndexColumns(getInvertedIndexColumns())
+        .setNoDictionaryColumns(getNoDictionaryColumns())
+        .setRangeIndexColumns(getRangeIndexColumns())
+        .setBloomFilterColumns(getBloomFilterColumns())
+        .setFieldConfigList(getFieldConfigs())
+        .setNumReplicas(getNumReplicas())
+        .setSegmentVersion(getSegmentVersion())
+        .setLoadMode(getLoadMode())
+        .setTaskConfig(getTaskConfig())
+        .setBrokerTenant(getBrokerTenant())
+        .setServerTenant(getServerTenant())
+        .setIngestionConfig(getIngestionConfig())
+        .setQueryConfig(getQueryConfig())
+        .setNullHandlingEnabled(getNullHandlingEnabled())
+        .setRoutingConfig(routingConfig)
+        .setSegmentPartitionConfig(segmentPartitionConfig)
+        .setOptimizeNoDictStatsCollection(true)
+        .build();
+  }
+
+  @Override
+  public List<File> createAvroFiles()
+      throws Exception {
+    org.apache.avro.Schema avroSchema = org.apache.avro.Schema.createRecord("gapfillRecord", null, null, false);
+    avroSchema.setFields(List.of(
+        new org.apache.avro.Schema.Field(TIMESTAMP_FIELD_NAME,
+            org.apache.avro.Schema.create(org.apache.avro.Schema.Type.LONG), null, null),
+        new org.apache.avro.Schema.Field(ENTITY_ID_COLUMN,
+            org.apache.avro.Schema.create(org.apache.avro.Schema.Type.INT), null, null),
+        new org.apache.avro.Schema.Field(VALUE_COLUMN,
+            org.apache.avro.Schema.create(org.apache.avro.Schema.Type.INT), null, null)
+    ));
+
+    try (AvroFilesAndWriters avroFilesAndWriters = createAvroFilesAndWriters(avroSchema)) {
+      List<DataFileWriter<GenericData.Record>> writers = avroFilesAndWriters.getWriters();
+      for (long[] rawRow : RAW_ROWS) {
+        GenericData.Record record = new GenericData.Record(avroSchema);
+        record.put(TIMESTAMP_FIELD_NAME, rawRow[0]);
+        record.put(ENTITY_ID_COLUMN, (int) rawRow[1]);
+        record.put(VALUE_COLUMN, (int) rawRow[2]);
+        writers.get(0).append(record);
+      }
+      return avroFilesAndWriters.getAvroFiles();
+    }
+  }
+
+  @Test(dataProvider = "useV2QueryEngine")
+  public void testGapfillAggregateQueryV2(boolean useMultiStageQueryEngine)
+      throws Exception {
+    setUseMultiStageQueryEngine(useMultiStageQueryEngine);
+    String query =
+        String.format("SELECT time_col, SUM(status) AS occupied_slots_count "
+                + "FROM ("
+                + "SELECT GapFill(time_col, '1:MILLISECONDS:EPOCH', '%d', '%d', '1000:MILLISECONDS', "
+                + "FILL(status, 'FILL_PREVIOUS_VALUE'), TIMESERIESON(entityId)) AS time_col, "
+                + "entityId, status "
+                + "FROM ("
+                + "SELECT DATETIMECONVERT(ts, '1:MILLISECONDS:EPOCH', '1:MILLISECONDS:EPOCH', '1000:MILLISECONDS') "
+                + "AS time_col, entityId, MAX(value) AS status "
+                + "FROM %s WHERE ts >= %d AND ts <= %d "
+                + "GROUP BY 1, 2)"
+                + ") "
+                + "GROUP BY 1 LIMIT 20",
+            START_MS, END_MS, getTableName(), START_MS, END_MS - 1000);
+    JsonNode response = postQuery(query);
+    assertNoError(response);
+
+    JsonNode rows = response.get("resultTable").get("rows");
+    assertNotNull(rows);
+
+    List<long[]> actualRows = new ArrayList<>(rows.size());
+    for (JsonNode row : rows) {
+      actualRows.add(new long[]{row.get(0).asLong(), row.get(1).asLong()});
+    }
+
+    List<long[]> expectedRows = new ArrayList<>(EXPECTED_GAPFILL_SUM_ROWS.length);
+    for (long[] row : EXPECTED_GAPFILL_SUM_ROWS) {
+      expectedRows.add(new long[]{row[0], row[1]});
+    }
+
+    Comparator<long[]> rowComparator = Comparator.comparingLong(row -> row[0]);
+    actualRows.sort(rowComparator);
+    expectedRows.sort(rowComparator);
+
+    assertEquals(actualRows.size(), expectedRows.size());
+    for (int i = 0; i < expectedRows.size(); i++) {
+      assertEquals(actualRows.get(i)[0], expectedRows.get(i)[0]);
+      assertEquals(actualRows.get(i)[1], expectedRows.get(i)[1]);
+    }
+  }
+
+
+  @Test(dataProvider = "useBothQueryEngines")
+  public void testSimpleGapfillQuery(boolean useMultiStageQueryEngine)
+      throws Exception {
+    setUseMultiStageQueryEngine(useMultiStageQueryEngine);
+    String query =
+        String.format("SELECT "
+                + "GapFill(ts, '1:MILLISECONDS:EPOCH', '%d', '%d', '1000:MILLISECONDS', "
+                + "FILL(value, 'FILL_PREVIOUS_VALUE'), TIMESERIESON(entityId)) AS time_col, "
+                + "entityId, value "
+                + "FROM %s WHERE ts >= %d AND ts <= %d LIMIT 20",
+            START_MS, END_MS, getTableName(), START_MS, END_MS - 1000);
+    JsonNode response = postQuery(query);
+    assertNoError(response);
+
+    JsonNode rows = response.get("resultTable").get("rows");
+    assertNotNull(rows);
+
+    List<long[]> actualRows = new ArrayList<>(rows.size());
+    for (JsonNode row : rows) {
+      actualRows.add(new long[]{row.get(0).asLong(), row.get(1).asLong(), row.get(2).asLong()});
+    }
+
+    List<long[]> expectedRows = new ArrayList<>(EXPECTED_GAPFILL_ROWS.length);
+    for (long[] row : EXPECTED_GAPFILL_ROWS) {
+      expectedRows.add(new long[]{row[0], row[1], row[2]});
+    }
+
+    Comparator<long[]> rowComparator =
+        Comparator.<long[]>comparingLong(row -> row[1]).thenComparingLong(row -> row[0]);
+    actualRows.sort(rowComparator);
+    expectedRows.sort(rowComparator);
+
+    assertEquals(actualRows.size(), expectedRows.size());
+    for (int i = 0; i < expectedRows.size(); i++) {
+      assertEquals(actualRows.get(i)[0], expectedRows.get(i)[0]);
+      assertEquals(actualRows.get(i)[1], expectedRows.get(i)[1]);
+      assertEquals(actualRows.get(i)[2], expectedRows.get(i)[2]);
+    }
+  }
+}

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/sql/fun/PinotOperatorTable.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/sql/fun/PinotOperatorTable.java
@@ -45,6 +45,7 @@ import org.apache.calcite.sql.fun.SqlStdOperatorTable;
 import org.apache.calcite.sql.type.InferTypes;
 import org.apache.calcite.sql.type.OperandTypes;
 import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlOperandCountRanges;
 import org.apache.calcite.sql.type.SqlReturnTypeInference;
 import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeTransforms;
@@ -310,6 +311,12 @@ public class PinotOperatorTable implements SqlOperatorTable {
       // to 'GTR'
       new PinotSqlFunction("ARRAY_TO_MV", opBinding -> opBinding.getOperandType(0).getComponentType(),
           OperandTypes.ARRAY, false),
+      new PinotSqlFunction("GAPFILL", ReturnTypes.ARG0,
+          OperandTypes.variadic(SqlOperandCountRanges.from(6))),
+      new PinotSqlFunction("FILL", ReturnTypes.ARG0,
+          OperandTypes.variadic(SqlOperandCountRanges.from(2))),
+      new PinotSqlFunction("TIMESERIESON", ReturnTypes.ARG0,
+          OperandTypes.variadic(SqlOperandCountRanges.from(1))),
 
       // SqlStdOperatorTable.COALESCE without rewrite
       new SqlFunction("COALESCE", SqlKind.COALESCE,

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/GapfillOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/GapfillOperator.java
@@ -1,0 +1,520 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.operator;
+
+import com.google.common.base.Preconditions;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.common.datatable.StatMap;
+import org.apache.pinot.common.request.Expression;
+import org.apache.pinot.common.request.ExpressionType;
+import org.apache.pinot.common.request.Function;
+import org.apache.pinot.common.request.PinotQuery;
+import org.apache.pinot.common.response.broker.BrokerResponseNative;
+import org.apache.pinot.common.response.broker.ResultTable;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+import org.apache.pinot.common.utils.config.QueryOptionsUtils;
+import org.apache.pinot.core.query.reduce.BaseGapfillProcessor;
+import org.apache.pinot.core.query.reduce.GapfillProcessorFactory;
+import org.apache.pinot.core.query.request.context.QueryContext;
+import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
+import org.apache.pinot.core.util.GapfillUtils;
+import org.apache.pinot.query.runtime.blocks.MseBlock;
+import org.apache.pinot.query.runtime.blocks.RowHeapDataBlock;
+import org.apache.pinot.query.runtime.blocks.SuccessMseBlock;
+import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
+import org.apache.pinot.segment.local.customobject.ValueLongPair;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.thrift.TDeserializer;
+import org.apache.thrift.TException;
+import org.apache.thrift.protocol.TCompactProtocol;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Applies gapfill to an incoming row set in MSQ.
+ *
+ * <p>This operator expects its input rows to already be projected to match the gapfill query context
+ * (i.e. the {@code gapfill()} wrapper has already been evaluated and removed by the upstream project/transform).</p>
+ */
+public class GapfillOperator extends MultiStageOperator {
+  private static final Logger LOGGER = LoggerFactory.getLogger(GapfillOperator.class);
+  private static final String EXPLAIN_NAME = "GAPFILL";
+
+  private final MultiStageOperator _input;
+  private final DataSchema _schema;
+  private final BaseGapfillProcessor _gapfillProcessor;
+  private MseBlock.Eos _eosBlock;
+  private final StatMap<StatKey> _statMap = new StatMap<>(StatKey.class);
+
+  public GapfillOperator(OpChainExecutionContext context, MultiStageOperator input, DataSchema schema) {
+    super(context);
+    _input = input;
+    _schema = schema;
+    _gapfillProcessor = buildGapfillProcessor(context);
+  }
+
+  /**
+   * Returns {@code true} when the current operator schema contains the columns required to correctly apply gapfill.
+   *
+   * <p>This is used to avoid applying gapfill at an incorrect stage (e.g. after an aggregation) where required columns
+   * such as {@code TIMESERIESON(...)} keys or {@code FILL(...)} target columns are no longer present, which can lead to
+   * silently incorrect results.</p>
+   */
+  public static boolean isApplicable(OpChainExecutionContext context, DataSchema schema) {
+    Map<String, String> queryOptions = context.getOpChainMetadata();
+    if (!QueryOptionsUtils.isServerSideGapfill(queryOptions)) {
+      return false;
+    }
+    String serializedGapfillQuery = QueryOptionsUtils.getServerSideGapfillQuery(queryOptions);
+    if (serializedGapfillQuery == null) {
+      return false;
+    }
+    PinotQuery rootPinotQuery;
+    try {
+      rootPinotQuery = deserializePinotQuery(serializedGapfillQuery);
+    } catch (RuntimeException e) {
+      return false;
+    }
+    PinotQuery gapfillPinotQuery = findGapfillQuery(rootPinotQuery);
+    if (gapfillPinotQuery == null) {
+      return false;
+    }
+    QueryContext gapfillQueryContext;
+    try {
+      gapfillQueryContext = QueryContextConverterUtils.getQueryContext(gapfillPinotQuery);
+    } catch (RuntimeException e) {
+      return false;
+    }
+    GapfillUtils.GapfillType gapfillType;
+    try {
+      gapfillType = GapfillUtils.getGapfillType(gapfillQueryContext);
+    } catch (RuntimeException e) {
+      return false;
+    }
+    if (gapfillType == null) {
+      return false;
+    }
+    org.apache.pinot.common.request.context.ExpressionContext gapfillExpression =
+        GapfillUtils.getGapfillExpressionContext(gapfillQueryContext, gapfillType);
+    if (gapfillExpression == null || gapfillExpression.getFunction() == null) {
+      return false;
+    }
+    // Prefer an order-based check instead of name-based check because MSQ schemas can have compiler-generated names
+    // (e.g. "$f0"). If the schema doesn't have enough columns to accommodate the required selection indices, applying
+    // gapfill here would cause the processor to mis-map columns and silently produce incorrect results.
+    int maxRequiredIndex = GapfillUtils.findTimeBucketColumnIndex(gapfillQueryContext, gapfillType);
+    if (maxRequiredIndex < 0) {
+      return false;
+    }
+
+    // TIMESERIESON columns (partition keys)
+    org.apache.pinot.common.request.context.ExpressionContext timeSeriesOn =
+        GapfillUtils.getTimeSeriesOnExpressionContext(gapfillExpression);
+    if (timeSeriesOn == null || timeSeriesOn.getFunction() == null) {
+      return false;
+    }
+    for (org.apache.pinot.common.request.context.ExpressionContext arg : timeSeriesOn.getFunction().getArguments()) {
+      if (arg.getType() == org.apache.pinot.common.request.context.ExpressionContext.Type.IDENTIFIER) {
+        Integer idx = findSelectionIndex(gapfillQueryContext, arg.getIdentifier());
+        if (idx == null) {
+          return false;
+        }
+        maxRequiredIndex = Math.max(maxRequiredIndex, idx);
+      }
+    }
+
+    // FILL target columns
+    for (String fillColumn : GapfillUtils.getFillExpressions(gapfillExpression).keySet()) {
+      Integer idx = findSelectionIndex(gapfillQueryContext, fillColumn);
+      if (idx == null) {
+        return false;
+      }
+      maxRequiredIndex = Math.max(maxRequiredIndex, idx);
+    }
+
+    return schema.size() > maxRequiredIndex;
+  }
+
+  private static Integer findSelectionIndex(QueryContext queryContext, String columnName) {
+    List<org.apache.pinot.common.request.context.ExpressionContext> selectExpressions =
+        queryContext.getSelectExpressions();
+    if (selectExpressions == null) {
+      return null;
+    }
+    List<String> aliasList = queryContext.getAliasList();
+    for (int i = 0; i < selectExpressions.size(); i++) {
+      if (aliasList != null && aliasList.size() > i && aliasList.get(i) != null
+          && aliasList.get(i).equalsIgnoreCase(columnName)) {
+        return i;
+      }
+      org.apache.pinot.common.request.context.ExpressionContext expressionContext = selectExpressions.get(i);
+      if (GapfillUtils.isGapfill(expressionContext)) {
+        expressionContext = expressionContext.getFunction().getArguments().get(0);
+      }
+      if (expressionContext.getType() == org.apache.pinot.common.request.context.ExpressionContext.Type.IDENTIFIER
+          && expressionContext.getIdentifier().equalsIgnoreCase(columnName)) {
+        return i;
+      }
+      if (expressionContext.toString().equalsIgnoreCase(columnName)) {
+        return i;
+      }
+    }
+    return null;
+  }
+
+  @Override
+  public void registerExecution(long time, int numRows, long memoryUsedBytes, long gcTimeMs) {
+    _statMap.merge(StatKey.EXECUTION_TIME_MS, time);
+    _statMap.merge(StatKey.EMITTED_ROWS, numRows);
+    _statMap.merge(StatKey.ALLOCATED_MEMORY_BYTES, memoryUsedBytes);
+    _statMap.merge(StatKey.GC_TIME_MS, gcTimeMs);
+  }
+
+  @Override
+  protected Logger logger() {
+    return LOGGER;
+  }
+
+  @Override
+  public List<MultiStageOperator> getChildOperators() {
+    return List.of(_input);
+  }
+
+  @Override
+  public Type getOperatorType() {
+    return Type.GAPFILL;
+  }
+
+  @Override
+  public String toExplainString() {
+    return EXPLAIN_NAME;
+  }
+
+  @Override
+  public StatMap<StatKey> copyStatMaps() {
+    return new StatMap<>(_statMap);
+  }
+
+  public enum StatKey implements StatMap.Key {
+    EXECUTION_TIME_MS(StatMap.Type.LONG) {
+      @Override
+      public boolean includeDefaultInJson() {
+        return true;
+      }
+    },
+    EMITTED_ROWS(StatMap.Type.LONG),
+    ALLOCATED_MEMORY_BYTES(StatMap.Type.LONG),
+    GC_TIME_MS(StatMap.Type.LONG);
+
+    private final StatMap.Type _type;
+
+    StatKey(StatMap.Type type) {
+      _type = type;
+    }
+
+    @Override
+    public StatMap.Type getType() {
+      return _type;
+    }
+  }
+
+  @Override
+  protected MseBlock getNextBlock() {
+    if (_eosBlock != null) {
+      return _eosBlock;
+    }
+
+    List<Object[]> inputRows = new ArrayList<>();
+    while (true) {
+      MseBlock block = _input.nextBlock();
+      if (block.isEos()) {
+        _eosBlock = (MseBlock.Eos) block;
+        if (block.isError()) {
+          return block;
+        }
+        break;
+      }
+      inputRows.addAll(((MseBlock.Data) block).asRowHeap().getRows());
+    }
+
+    if (inputRows.isEmpty()) {
+      if (_eosBlock == null) {
+        _eosBlock = SuccessMseBlock.INSTANCE;
+      }
+      return _eosBlock;
+    }
+
+    List<Object[]> coercedRows = coerceObjectValues(_schema, inputRows);
+    sortRowsByTimeBucket(coercedRows);
+    DataSchema schemaForGapfill = coerceObjectColumns(_schema, coercedRows);
+    BrokerResponseNative brokerResponseNative = new BrokerResponseNative();
+    brokerResponseNative.setResultTable(new ResultTable(schemaForGapfill, coercedRows));
+    _gapfillProcessor.process(brokerResponseNative);
+
+    ResultTable resultTable = brokerResponseNative.getResultTable();
+    if (resultTable == null || resultTable.getRows().isEmpty()) {
+      if (_eosBlock == null) {
+        _eosBlock = SuccessMseBlock.INSTANCE;
+      }
+      return _eosBlock;
+    }
+
+    return new RowHeapDataBlock(resultTable.getRows(), resultTable.getDataSchema());
+  }
+
+  private static void sortRowsByTimeBucket(List<Object[]> rows) {
+    // GapfillProcessor expects rows to be ordered by the time-bucket column so it can efficiently short-circuit within
+    // each bucket. In MSQ, upstream operators might not preserve any ordering.
+    rows.sort(Comparator.comparingLong(GapfillOperator::getTimeBucketMillis));
+  }
+
+  private static long getTimeBucketMillis(Object[] row) {
+    // For GAPFILL, the time-bucket column is the first projection (index 0) after stripping the wrapper.
+    Object value = row[0];
+    if (value instanceof Number) {
+      return ((Number) value).longValue();
+    }
+    return Long.parseLong(String.valueOf(value));
+  }
+
+  private static DataSchema coerceObjectColumns(DataSchema schema, List<Object[]> rows) {
+    ColumnDataType[] types = schema.getColumnDataTypes();
+    boolean hasObject = false;
+    for (ColumnDataType type : types) {
+      if (type == ColumnDataType.OBJECT) {
+        hasObject = true;
+        break;
+      }
+    }
+    if (!hasObject) {
+      return schema;
+    }
+
+    String[] columnNames = schema.getColumnNames().clone();
+    ColumnDataType[] columnTypes = types.clone();
+    for (int col = 0; col < columnTypes.length; col++) {
+      if (columnTypes[col] != ColumnDataType.OBJECT) {
+        continue;
+      }
+      ColumnDataType inferred = inferColumnType(rows, col);
+      if (inferred != null) {
+        columnTypes[col] = inferred;
+      }
+    }
+    return new DataSchema(columnNames, columnTypes);
+  }
+
+  private static List<Object[]> coerceObjectValues(DataSchema schema, List<Object[]> rows) {
+    ColumnDataType[] types = schema.getColumnDataTypes();
+    boolean hasObject = false;
+    for (ColumnDataType type : types) {
+      if (type == ColumnDataType.OBJECT) {
+        hasObject = true;
+        break;
+      }
+    }
+    if (!hasObject) {
+      return rows;
+    }
+
+    List<Object[]> coerced = new ArrayList<>(rows.size());
+    for (Object[] row : rows) {
+      if (row == null) {
+        coerced.add(null);
+        continue;
+      }
+      Object[] copy = row.clone();
+      int limit = Math.min(copy.length, types.length);
+      for (int i = 0; i < limit; i++) {
+        if (types[i] != ColumnDataType.OBJECT) {
+          continue;
+        }
+        Object value = copy[i];
+        if (value instanceof ValueLongPair) {
+          copy[i] = ((ValueLongPair<?>) value).getValue();
+        }
+      }
+      coerced.add(copy);
+    }
+    return coerced;
+  }
+
+  private static ColumnDataType inferColumnType(List<Object[]> rows, int col) {
+    for (Object[] row : rows) {
+      if (row == null || col >= row.length) {
+        continue;
+      }
+      Object value = row[col];
+      if (value == null) {
+        continue;
+      }
+      if (value instanceof Integer) {
+        return ColumnDataType.INT;
+      }
+      if (value instanceof Long) {
+        return ColumnDataType.LONG;
+      }
+      if (value instanceof Float) {
+        return ColumnDataType.FLOAT;
+      }
+      if (value instanceof Double) {
+        return ColumnDataType.DOUBLE;
+      }
+      if (value instanceof String) {
+        return ColumnDataType.STRING;
+      }
+      if (value instanceof byte[]) {
+        return ColumnDataType.BYTES;
+      }
+    }
+    return null;
+  }
+
+  private static BaseGapfillProcessor buildGapfillProcessor(OpChainExecutionContext context) {
+    Map<String, String> queryOptions = context.getOpChainMetadata();
+    Preconditions.checkState(QueryOptionsUtils.isServerSideGapfill(queryOptions), "Gapfill query options are missing");
+    String serializedGapfillQuery = QueryOptionsUtils.getServerSideGapfillQuery(queryOptions);
+    Preconditions.checkState(serializedGapfillQuery != null, "Missing server-side gapfill query");
+    PinotQuery rootPinotQuery = deserializePinotQuery(serializedGapfillQuery);
+    maybeOverrideGapfillLimit(rootPinotQuery);
+
+    // Build the processor off the specific query level that contains GAPFILL.
+    PinotQuery gapfillPinotQuery = findGapfillQuery(rootPinotQuery);
+    Preconditions.checkState(gapfillPinotQuery != null, "Gapfill query context missing gapfill expression");
+
+    QueryContext gapfillQueryContext = QueryContextConverterUtils.getQueryContext(gapfillPinotQuery);
+    GapfillUtils.GapfillType gapfillType = GapfillUtils.getGapfillType(gapfillQueryContext);
+    Preconditions.checkState(gapfillType != null, "Gapfill query context missing gapfill expression");
+    return GapfillProcessorFactory.getGapfillProcessorForServer(gapfillQueryContext, gapfillType);
+  }
+
+  private static PinotQuery deserializePinotQuery(String serializedPinotQuery) {
+    try {
+      byte[] bytes = Base64.getDecoder().decode(serializedPinotQuery);
+      PinotQuery pinotQuery = new PinotQuery();
+      new TDeserializer(new TCompactProtocol.Factory()).deserialize(pinotQuery, bytes);
+      return pinotQuery;
+    } catch (IllegalArgumentException | TException e) {
+      throw new IllegalStateException("Failed to deserialize gapfill query", e);
+    }
+  }
+
+  private static void maybeOverrideGapfillLimit(PinotQuery pinotQuery) {
+    PinotQuery gapfillQuery = findGapfillQuery(pinotQuery);
+    if (gapfillQuery == null || gapfillQuery == pinotQuery) {
+      return;
+    }
+    boolean hasExplicitLimit = gapfillQuery.isSetLimit();
+    int existingLimit = gapfillQuery.getLimit();
+    int defaultQueryLimit = CommonConstants.Broker.DEFAULT_BROKER_QUERY_LIMIT;
+    boolean limitIsDefault =
+        !hasExplicitLimit || existingLimit <= 0 || existingLimit == defaultQueryLimit;
+    QueryContext rootContext;
+    GapfillUtils.GapfillType gapfillType;
+    try {
+      rootContext = QueryContextConverterUtils.getQueryContext(pinotQuery);
+      gapfillType = GapfillUtils.getGapfillType(rootContext);
+    } catch (RuntimeException e) {
+      gapfillQuery.setLimit(CommonConstants.Broker.DEFAULT_BROKER_QUERY_RESPONSE_LIMIT);
+      return;
+    }
+    if (gapfillType == null) {
+      if (!hasExplicitLimit) {
+        gapfillQuery.setLimit(defaultQueryLimit);
+      }
+      return;
+    }
+    switch (gapfillType) {
+      case GAP_FILL_AGGREGATE:
+      case AGGREGATE_GAP_FILL_AGGREGATE:
+        // Avoid truncating the gapfill output before the outer aggregation is applied.
+        if (limitIsDefault) {
+          gapfillQuery.setLimit(Integer.MAX_VALUE);
+        }
+        break;
+      case GAP_FILL_SELECT:
+        // Use the outer limit when available; otherwise fall back to the default.
+        int outerLimit = rootContext.getLimit();
+        if (outerLimit > 0) {
+          gapfillQuery.setLimit(outerLimit);
+        } else if (!hasExplicitLimit) {
+          gapfillQuery.setLimit(defaultQueryLimit);
+        }
+        break;
+      default:
+        if (!hasExplicitLimit) {
+          gapfillQuery.setLimit(defaultQueryLimit);
+        }
+        break;
+    }
+  }
+
+  private static PinotQuery findGapfillQuery(PinotQuery pinotQuery) {
+    PinotQuery current = pinotQuery;
+    while (current != null) {
+      if (containsGapfillExpression(current.getSelectList())) {
+        return current;
+      }
+      if (current.getDataSource() == null) {
+        break;
+      }
+      current = current.getDataSource().getSubquery();
+    }
+    return null;
+  }
+
+  private static boolean containsGapfillExpression(List<Expression> selectList) {
+    if (selectList == null) {
+      return false;
+    }
+    for (Expression expression : selectList) {
+      if (containsGapfillExpression(expression)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean containsGapfillExpression(Expression expression) {
+    if (expression == null || expression.getType() != ExpressionType.FUNCTION) {
+      return false;
+    }
+    Function function = expression.getFunctionCall();
+    if (function == null) {
+      return false;
+    }
+    if ("gapfill".equalsIgnoreCase(function.getOperator())) {
+      return true;
+    }
+    if ("as".equalsIgnoreCase(function.getOperator()) && function.getOperandsSize() > 0) {
+      return containsGapfillExpression(function.getOperands().get(0));
+    }
+    for (Expression operand : function.getOperands()) {
+      if (containsGapfillExpression(operand)) {
+        return true;
+      }
+    }
+    return false;
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java
@@ -437,10 +437,18 @@ public abstract class MultiStageOperator implements Operator<MseBlock>, AutoClos
         StatMap<UnnestOperator.StatKey> stats = (StatMap<UnnestOperator.StatKey>) map;
         response.mergeMaxRowsInOperator(stats.getLong(UnnestOperator.StatKey.EMITTED_ROWS));
       }
+    },
+    GAPFILL(16, GapfillOperator.StatKey.class) {
+      @Override
+      public void mergeInto(BrokerResponseNativeV2 response, StatMap<?> map) {
+        @SuppressWarnings("unchecked")
+        StatMap<GapfillOperator.StatKey> stats = (StatMap<GapfillOperator.StatKey>) map;
+        response.mergeMaxRowsInOperator(stats.getLong(GapfillOperator.StatKey.EMITTED_ROWS));
+      }
     };
 
     // When adding new operator types, update MAX_ID if the new ID exceeds the current max
-    private static final int MAX_ID = 15;
+    private static final int MAX_ID = 16;
     private static final Type[] ID_TO_TYPE = new Type[MAX_ID + 1];
 
     static {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -651,6 +651,9 @@ public class CommonConstants {
         public static final String MAX_EXECUTION_THREADS = "maxExecutionThreads";
         public static final String COLLECT_GC_STATS = "collectGCStats";
         public static final String QUERY_HASH = "queryHash";
+        // Enable server-side gapfill processing and carry the original PinotQuery when applicable.
+        public static final String SERVER_SIDE_GAPFILL = "serverSideGapfill";
+        public static final String SERVER_SIDE_GAPFILL_QUERY = "serverSideGapfillQuery";
 
         // For group-by queries with order-by clause, the tail groups are trimmed off to reduce the memory footprint. To
         // ensure the accuracy of the result, {@code max(limit * 5, minTrimSize)} groups are retained. When


### PR DESCRIPTION
### Summary
Add server‑side gapfill support for the v2 engine, including query‑option plumbing, server response handling, and multi‑stage plan/runtime integration.

### Key Changes

- Introduce `serverSideGapfill` and `serverSideGapfillQuery` query options, plus serialization/deserialization of the original PinotQuery for gapfill evaluation.

- Broker handlers (single‑stage and multi‑stage) detect eligible gapfill queries and inject server‑side gapfill options with routing/partition checks.

- Server‑side execution uses new `GapfillInstanceResponseOperator` and `GapfillInstanceResponsePlanNode`; v2 plan maker wires them in.

- Runtime/leaf planning strips `GAPFILL` where needed and applies gapfill in `TransformOperator` for MSE.

- Gapfill reducers and DateTimeConvert updated to align server‑side gapfill behavior; add `GapfillIntegrationTest` coverage.