### PR TITLE
Deterministically order dimension-table segments during lookup loading

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/DimensionTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/DimensionTableDataManager.java
@@ -214,7 +214,9 @@ public class DimensionTableDataManager extends OfflineTableDataManager {
         "Primary key columns must be configured for dimension table: %s", _tableNameWithType);
 
     List<SegmentDataManager> segmentDataManagers = acquireAllSegments();
-    sortSegmentsForUpsert(segmentDataManagers);
+    if (!_errorOnDuplicatePrimaryKey) {
+      sortSegmentsForUpsert(segmentDataManagers);
+    }
     try {
       // count all documents to limit map re-sizings
       int totalDocs = 0;
@@ -290,7 +292,9 @@ public class DimensionTableDataManager extends OfflineTableDataManager {
         "Primary key columns must be configured for dimension table: %s", _tableNameWithType);
 
     List<SegmentDataManager> segmentDataManagers = acquireAllSegments();
-    sortSegmentsForUpsert(segmentDataManagers);
+    if (!_errorOnDuplicatePrimaryKey) {
+      sortSegmentsForUpsert(segmentDataManagers);
+    }
     List<PinotSegmentRecordReader> recordReaders = new ArrayList<>(segmentDataManagers.size());
 
     int totalDocs = 0;


### PR DESCRIPTION
This pull request introduces improvements to the dimension table creation logic in `DimensionTableDataManager.java`, focusing on ensuring correct segment ordering and stricter duplicate primary key handling. The main changes are the addition of a segment sorting method to ensure upsert consistency and enhanced error checking for duplicate primary keys.

**Segment ordering for upsert consistency:**

* Added a new private method `sortSegmentsForUpsert` that sorts `SegmentDataManager` instances by segment creation time and, as a tiebreaker, by segment name. This method is now called before processing segments in both `createFastLookupDimensionTable` and `createMemOptimisedDimensionTable`, ensuring a deterministic and correct upsert order. [[1]](diffhunk://#diff-efcd33566d6644e01aeb51d761dc4036bb4e4419694d843c87ea6dc186cb6ebcR29) [[2]](diffhunk://#diff-efcd33566d6644e01aeb51d761dc4036bb4e4419694d843c87ea6dc186cb6ebcR217) [[3]](diffhunk://#diff-efcd33566d6644e01aeb51d761dc4036bb4e4419694d843c87ea6dc186cb6ebcR293) [[4]](diffhunk://#diff-efcd33566d6644e01aeb51d761dc4036bb4e4419694d843c87ea6dc186cb6ebcR343-R349)

**Duplicate primary key handling:**

* Improved the error handling logic to throw a clear exception if a duplicate primary key is encountered during dimension table creation, both in the fast lookup and memory-optimized paths. The error message has been clarified for readability. [[1]](diffhunk://#diff-efcd33566d6644e01aeb51d761dc4036bb4e4419694d843c87ea6dc186cb6ebcL252-R254) [[2]](diffhunk://#diff-efcd33566d6644e01aeb51d761dc4036bb4e4419694d843c87ea6dc186cb6ebcL323-R331)