### PR TITLE
feat(helm): add pdb for minion and minion-stateless

### DIFF
--- a/helm/pinot/templates/minion-stateless/poddisruptionbudget.yaml
+++ b/helm/pinot/templates/minion-stateless/poddisruptionbudget.yaml
@@ -1,0 +1,44 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+{{- $pdb := .Values.minionStateless.pdb }}
+
+{{- if $pdb.enabled }}
+{{- if and $pdb.minAvailable $pdb.maxUnavailable }}
+{{- fail "minionStateless.pdb: specify only one of minAvailable or maxUnavailable" }}
+{{- end }}
+{{- if not (or $pdb.minAvailable $pdb.maxUnavailable) }}
+{{- fail "minionStateless.pdb: when enabled is true, you must set either minAvailable or maxUnavailable" }}
+{{- end }}
+
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "pinot.minionStateless.fullname" . }}
+  namespace: {{ include "pinot.namespace" . }}
+spec:
+  {{- if $pdb.minAvailable }}
+  minAvailable: {{ $pdb.minAvailable }}
+  {{- else }}
+  maxUnavailable: {{ $pdb.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "pinot.minionStatelessMatchLabels" . | nindent 6 }}
+{{- end }}

--- a/helm/pinot/templates/minion/poddisruptionbudget.yaml
+++ b/helm/pinot/templates/minion/poddisruptionbudget.yaml
@@ -1,0 +1,44 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+{{- $pdb := .Values.minion.pdb }}
+
+{{- if $pdb.enabled }}
+{{- if and $pdb.minAvailable $pdb.maxUnavailable }}
+{{- fail "minion.pdb: specify only one of minAvailable or maxUnavailable" }}
+{{- end }}
+{{- if not (or $pdb.minAvailable $pdb.maxUnavailable) }}
+{{- fail "minion.pdb: when enabled is true, you must set either minAvailable or maxUnavailable" }}
+{{- end }}
+
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "pinot.minion.fullname" . }}
+  namespace: {{ include "pinot.namespace" . }}
+spec:
+  {{- if $pdb.minAvailable }}
+  minAvailable: {{ $pdb.minAvailable }}
+  {{- else }}
+  maxUnavailable: {{ $pdb.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "pinot.minionMatchLabels" . | nindent 6 }}
+{{- end }}

--- a/helm/pinot/values.yaml
+++ b/helm/pinot/values.yaml
@@ -150,7 +150,7 @@ controller:
   pluginsDir: /opt/pinot/plugins
 
   pdb:
-    enabled: false 
+    enabled: false
     minAvailable: ""
     maxUnavailable: 50%
 
@@ -445,7 +445,7 @@ server:
   pluginsDir: /opt/pinot/plugins
 
   pdb:
-    enabled: false 
+    enabled: false
     minAvailable: ""
     maxUnavailable: 1
 
@@ -631,6 +631,11 @@ minion:
     configs: |-
       pinot.set.instance.id.to.hostname=true
 
+  # In a PodDisruptionBudget, only one of minAvailable or maxUnavailable may be set.
+  # By default we use maxUnavailable; override this section if you prefer minAvailable.
+  pdb:
+    enabled: false
+    maxUnavailable: 1
 
 # ------------------------------------------------------------------------------
 # Pinot Minion Stateless:
@@ -699,7 +704,7 @@ minionStateless:
       # - containerPort: 1234
       #   protocol: PROTOCOL
       #   name: extra-port
-      
+
   resources:
     requests:
       memory: "1.25Gi"
@@ -735,6 +740,12 @@ minionStateless:
   extra:
     configs: |-
       pinot.set.instance.id.to.hostname=true
+
+  # In a PodDisruptionBudget, only one of minAvailable or maxUnavailable may be set.
+  # By default we use maxUnavailable; override this section if you prefer minAvailable.
+  pdb:
+    enabled: false
+    maxUnavailable: 1
 
 # ------------------------------------------------------------------------------
 # Zookeeper:


### PR DESCRIPTION
# Add PodDisruptionBudget support for Minion components

## Summary
Adds PDB configuration support for `minion` and `minionStateless` components to match existing controller/broker/server functionality.

## Changes
- Added `pdb` section to `minion` in `values.yaml`
- Added `pdb` section to `minionStateless` in `values.yaml`
- Disabled by default for backward compatibility

## Use Case
Ensures minimum minion availability during voluntary disruptions, especially useful when running on spot/preemptible VMs.

```yaml
minionStateless:
  pdb:
    enabled: true
    minAvailable: 2
```