### PR TITLE
Explicitly configure gRPC to use pooled direct buffers

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/channel/ChannelManager.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/channel/ChannelManager.java
@@ -19,8 +19,9 @@
 package org.apache.pinot.query.mailbox.channel;
 
 import io.grpc.ManagedChannel;
-import io.grpc.ManagedChannelBuilder;
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
+import io.grpc.netty.shaded.io.netty.buffer.PooledByteBufAllocator;
+import io.grpc.netty.shaded.io.netty.channel.ChannelOption;
 import java.time.Duration;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
@@ -51,22 +52,30 @@ public class ChannelManager {
    */
   private final Duration _idleTimeout;
   private final int _maxInboundMessageSize;
+  /**
+   * Buffer allocator configured to prefer direct (off-heap) buffers for better performance.
+   * Using a single allocator instance across all channels allows for better memory pooling and reduces fragmentation.
+   */
+  private final PooledByteBufAllocator _bufAllocator;
 
   public ChannelManager(@Nullable TlsConfig tlsConfig, int maxInboundMessageSize, Duration idleTimeout) {
     _tlsConfig = tlsConfig;
     _maxInboundMessageSize = maxInboundMessageSize;
     _idleTimeout = idleTimeout;
+    // Use direct buffers (off-heap) for better performance - matches server-side configuration
+    _bufAllocator = new PooledByteBufAllocator(true);
   }
 
   public ManagedChannel getChannel(String hostname, int port) {
-    // TODO: Revisit parameters
+    // Always use NettyChannelBuilder to allow setting Netty-specific channel options like the buffer allocator.
+    // This ensures we can explicitly configure direct (off-heap) buffers for better performance.
     if (_tlsConfig != null) {
       return _channelMap.computeIfAbsent(Pair.of(hostname, port),
           (k) -> {
             NettyChannelBuilder channelBuilder = NettyChannelBuilder
                 .forAddress(k.getLeft(), k.getRight())
-                .maxInboundMessageSize(
-                    _maxInboundMessageSize)
+                .maxInboundMessageSize(_maxInboundMessageSize)
+                .withOption(ChannelOption.ALLOCATOR, _bufAllocator)
                 .sslContext(ServerGrpcQueryClient.buildSslContext(_tlsConfig));
             return decorate(channelBuilder).build();
           }
@@ -74,17 +83,17 @@ public class ChannelManager {
     } else {
       return _channelMap.computeIfAbsent(Pair.of(hostname, port),
           (k) -> {
-            ManagedChannelBuilder<?> channelBuilder = ManagedChannelBuilder
+            NettyChannelBuilder channelBuilder = NettyChannelBuilder
                 .forAddress(k.getLeft(), k.getRight())
-                .maxInboundMessageSize(
-                    _maxInboundMessageSize)
+                .maxInboundMessageSize(_maxInboundMessageSize)
+                .withOption(ChannelOption.ALLOCATOR, _bufAllocator)
                 .usePlaintext();
             return decorate(channelBuilder).build();
           });
     }
   }
 
-  private ManagedChannelBuilder<?> decorate(ManagedChannelBuilder<?> builder) {
+  private NettyChannelBuilder decorate(NettyChannelBuilder builder) {
     return builder.idleTimeout(_idleTimeout.getSeconds(), TimeUnit.SECONDS);
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/DispatchClient.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/DispatchClient.java
@@ -20,8 +20,9 @@ package org.apache.pinot.query.service.dispatch;
 
 import io.grpc.Deadline;
 import io.grpc.ManagedChannel;
-import io.grpc.ManagedChannelBuilder;
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
+import io.grpc.netty.shaded.io.netty.buffer.PooledByteBufAllocator;
+import io.grpc.netty.shaded.io.netty.channel.ChannelOption;
 import io.grpc.stub.StreamObserver;
 import java.util.List;
 import java.util.function.Consumer;
@@ -41,16 +42,27 @@ import org.apache.pinot.query.routing.QueryServerInstance;
  */
 class DispatchClient {
   private static final StreamObserver<Worker.CancelResponse> NO_OP_CANCEL_STREAM_OBSERVER = new CancelObserver();
+  /**
+   * Shared buffer allocator configured to prefer direct (off-heap) buffers for better performance.
+   * Using a static allocator allows for better memory pooling across all DispatchClient instances.
+   */
+  private static final PooledByteBufAllocator BUF_ALLOCATOR = new PooledByteBufAllocator(true);
 
   private final ManagedChannel _channel;
   private final PinotQueryWorkerGrpc.PinotQueryWorkerStub _dispatchStub;
 
   public DispatchClient(String host, int port, @Nullable TlsConfig tlsConfig) {
+    // Always use NettyChannelBuilder to allow setting Netty-specific channel options like the buffer allocator.
+    // This ensures we can explicitly configure direct (off-heap) buffers for better performance.
     if (tlsConfig == null) {
-      _channel = ManagedChannelBuilder.forAddress(host, port).usePlaintext().build();
+      _channel = NettyChannelBuilder.forAddress(host, port)
+          .usePlaintext()
+          .withOption(ChannelOption.ALLOCATOR, BUF_ALLOCATOR)
+          .build();
     } else {
       _channel = NettyChannelBuilder.forAddress(host, port)
           .sslContext(ServerGrpcQueryClient.buildSslContext(tlsConfig))
+          .withOption(ChannelOption.ALLOCATOR, BUF_ALLOCATOR)
           .build();
     }
     _dispatchStub = PinotQueryWorkerGrpc.newStub(_channel);


### PR DESCRIPTION
- Explicitly configure gRPC to use pooled direct buffers on both client side and server side wherever applicable.