### PR TITLE
Enhance ThreadResourceUsageProvider setup and getCurrentThreadAllocatedBytes()

### DIFF
--- a/pinot-core/src/test/java/org/apache/pinot/core/accounting/TestThreadMXBean.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/accounting/TestThreadMXBean.java
@@ -43,6 +43,40 @@ public class TestThreadMXBean {
     ThreadResourceUsageProvider.setThreadMemoryMeasurementEnabled(true);
   }
 
+  @Test
+  public void testDisableThenEnableCpuTimeMeasurement() {
+    if (!ThreadResourceUsageProvider.isThreadCpuTimeMeasurementEnabled()) {
+      return;
+    }
+
+    Assert.assertTrue(ThreadResourceUsageProvider.getCurrentThreadCpuTime() > 0);
+
+    ThreadResourceUsageProvider.setThreadCpuTimeMeasurementEnabled(false);
+    Assert.assertFalse(ThreadResourceUsageProvider.isThreadCpuTimeMeasurementEnabled());
+    Assert.assertEquals(ThreadResourceUsageProvider.getCurrentThreadCpuTime(), 0);
+
+    ThreadResourceUsageProvider.setThreadCpuTimeMeasurementEnabled(true);
+    Assert.assertTrue(ThreadResourceUsageProvider.isThreadCpuTimeMeasurementEnabled());
+    Assert.assertTrue(ThreadResourceUsageProvider.getCurrentThreadCpuTime() > 0);
+  }
+
+  @Test
+  public void testDisableThenEnableMemoryMeasurement() {
+    if (!ThreadResourceUsageProvider.isThreadMemoryMeasurementEnabled()) {
+      return;
+    }
+
+    Assert.assertTrue(ThreadResourceUsageProvider.getCurrentThreadAllocatedBytes() > 0);
+
+    ThreadResourceUsageProvider.setThreadMemoryMeasurementEnabled(false);
+    Assert.assertFalse(ThreadResourceUsageProvider.isThreadMemoryMeasurementEnabled());
+    Assert.assertEquals(ThreadResourceUsageProvider.getCurrentThreadAllocatedBytes(), 0);
+
+    ThreadResourceUsageProvider.setThreadMemoryMeasurementEnabled(true);
+    Assert.assertTrue(ThreadResourceUsageProvider.isThreadMemoryMeasurementEnabled());
+    Assert.assertTrue(ThreadResourceUsageProvider.getCurrentThreadAllocatedBytes() > 0);
+  }
+
   /**
    * simple memory allocation
    */

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/accounting/ThreadResourceUsageProvider.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/accounting/ThreadResourceUsageProvider.java
@@ -21,17 +21,13 @@ package org.apache.pinot.spi.accounting;
 import java.lang.management.GarbageCollectorMXBean;
 import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadMXBean;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
-/**
- * The {@code ThreadResourceUsageProvider} class providing the functionality of measuring the CPU time
- * and allocateBytes (JVM heap) for the current thread.
- */
+/// This class provides the functionality of measuring the CPU time and allocateBytes (JVM heap) for current thread.
 public class ThreadResourceUsageProvider {
   private ThreadResourceUsageProvider() {
   }
@@ -40,21 +36,135 @@ public class ThreadResourceUsageProvider {
 
   // used for getting the memory allocation function in hotspot jvm through reflection
   private static final String SUN_THREAD_MXBEAN_CLASS_NAME = "com.sun.management.ThreadMXBean";
-  private static final String SUN_THREAD_MXBEAN_IS_THREAD_ALLOCATED_MEMORY_SUPPORTED_NAME
-      = "isThreadAllocatedMemorySupported";
-  private static final String SUN_THREAD_MXBEAN_IS_THREAD_ALLOCATED_MEMORY_ENABLED_NAME
-      = "isThreadAllocatedMemoryEnabled";
-  private static final String SUN_THREAD_MXBEAN_SET_THREAD_ALLOCATED_MEMORY_ENABLED_NAME
-      = "setThreadAllocatedMemoryEnabled";
-  private static final String SUN_THREAD_MXBEAN_GET_BYTES_ALLOCATED_NAME = "getThreadAllocatedBytes";
-  private static final Method SUN_THREAD_MXBEAN_GET_BYTES_ALLOCATED_METHOD;
+  private static final String SUN_IS_THREAD_ALLOCATED_MEMORY_SUPPORTED_NAME = "isThreadAllocatedMemorySupported";
+  private static final String SUN_SET_THREAD_ALLOCATED_MEMORY_ENABLED_NAME = "setThreadAllocatedMemoryEnabled";
+  private static final String SUN_GET_CURRENT_THREAD_ALLOCATED_BYTES_NAME = "getCurrentThreadAllocatedBytes";
+  private static final String SUN_GET_THREAD_ALLOCATED_BYTES_NAME = "getThreadAllocatedBytes";
 
   private static final ThreadMXBean MX_BEAN = ManagementFactory.getThreadMXBean();
   private static final boolean IS_CURRENT_THREAD_CPU_TIME_SUPPORTED = MX_BEAN.isCurrentThreadCpuTimeSupported();
   private static final boolean IS_THREAD_ALLOCATED_MEMORY_SUPPORTED;
-  private static final boolean IS_THREAD_ALLOCATED_MEMORY_ENABLED_DEFAULT;
-  private static boolean _isThreadCpuTimeMeasurementEnabled = false;
-  private static boolean _isThreadMemoryMeasurementEnabled = false;
+  private static final Method SUN_SET_THREAD_ALLOCATED_MEMORY_ENABLED_METHOD;
+  private static final Method SUN_GET_THREAD_ALLOCATED_BYTES_METHOD;
+  private static final Method SUN_GET_CURRENT_THREAD_ALLOCATED_BYTES_METHOD;
+
+  private static boolean _isThreadCpuTimeMeasurementEnabled;
+  private static boolean _isThreadMemoryMeasurementEnabled;
+
+  // Initialize the com.sun.management.ThreadMXBean related variables using reflection
+  static {
+    Class<?> sunThreadMXBeanClass = null;
+    try {
+      sunThreadMXBeanClass = Class.forName(SUN_THREAD_MXBEAN_CLASS_NAME);
+    } catch (Exception e) {
+      LOGGER.error("Caught exception while loading: {}, you are probably not using Hotspot jvm",
+          SUN_THREAD_MXBEAN_CLASS_NAME, e);
+    }
+
+    boolean isThreadAllocatedMemorySupported = false;
+    Method setThreadAllocatedMemoryEnabled = null;
+    Method getCurrentThreadAllocatedBytes = null;
+    Method getThreadAllocatedBytes = null;
+    if (sunThreadMXBeanClass != null) {
+      try {
+        isThreadAllocatedMemorySupported =
+            (boolean) sunThreadMXBeanClass.getMethod(SUN_IS_THREAD_ALLOCATED_MEMORY_SUPPORTED_NAME).invoke(MX_BEAN);
+      } catch (Exception e) {
+        LOGGER.error("Caught exception invoking method: {}", SUN_IS_THREAD_ALLOCATED_MEMORY_SUPPORTED_NAME, e);
+      }
+      if (isThreadAllocatedMemorySupported) {
+        try {
+          setThreadAllocatedMemoryEnabled =
+              sunThreadMXBeanClass.getMethod(SUN_SET_THREAD_ALLOCATED_MEMORY_ENABLED_NAME, boolean.class);
+        } catch (Exception e) {
+          LOGGER.error("Caught exception loading method: {}", SUN_SET_THREAD_ALLOCATED_MEMORY_ENABLED_NAME, e);
+          isThreadAllocatedMemorySupported = false;
+        }
+      }
+      if (isThreadAllocatedMemorySupported) {
+        try {
+          getCurrentThreadAllocatedBytes = sunThreadMXBeanClass.getMethod(SUN_GET_CURRENT_THREAD_ALLOCATED_BYTES_NAME);
+        } catch (Exception e1) {
+          LOGGER.info("Failed to load method: {}, loading: {} instead", SUN_GET_CURRENT_THREAD_ALLOCATED_BYTES_NAME,
+              SUN_GET_THREAD_ALLOCATED_BYTES_NAME);
+          try {
+            getThreadAllocatedBytes = sunThreadMXBeanClass.getMethod(SUN_GET_THREAD_ALLOCATED_BYTES_NAME, long.class);
+          } catch (Exception e2) {
+            LOGGER.error("Caught exception loading method: {}", SUN_GET_THREAD_ALLOCATED_BYTES_NAME, e2);
+            isThreadAllocatedMemorySupported = false;
+          }
+        }
+      }
+    }
+
+    LOGGER.info("Current thread CPU time supported: {}", IS_CURRENT_THREAD_CPU_TIME_SUPPORTED);
+    LOGGER.info("Thread allocated memory supported: {}", isThreadAllocatedMemorySupported);
+    if (isThreadAllocatedMemorySupported) {
+      LOGGER.info("Using: {} to read current thread allocated bytes",
+          getCurrentThreadAllocatedBytes != null ? SUN_GET_CURRENT_THREAD_ALLOCATED_BYTES_NAME
+              : SUN_GET_THREAD_ALLOCATED_BYTES_NAME);
+    }
+    IS_THREAD_ALLOCATED_MEMORY_SUPPORTED = isThreadAllocatedMemorySupported;
+    SUN_SET_THREAD_ALLOCATED_MEMORY_ENABLED_METHOD = setThreadAllocatedMemoryEnabled;
+    SUN_GET_CURRENT_THREAD_ALLOCATED_BYTES_METHOD = getCurrentThreadAllocatedBytes;
+    SUN_GET_THREAD_ALLOCATED_BYTES_METHOD = getThreadAllocatedBytes;
+  }
+
+  public static boolean isThreadCpuTimeMeasurementEnabled() {
+    return _isThreadCpuTimeMeasurementEnabled;
+  }
+
+  public static void setThreadCpuTimeMeasurementEnabled(boolean enable) {
+    if (!IS_CURRENT_THREAD_CPU_TIME_SUPPORTED) {
+      assert !_isThreadCpuTimeMeasurementEnabled;
+      if (enable) {
+        LOGGER.error("Not enabling thread CPU time measurement because it is not supported");
+      }
+      return;
+    }
+    if (_isThreadCpuTimeMeasurementEnabled != enable) {
+      if (enable) {
+        LOGGER.info("Enabling thread CPU time measurement");
+      } else {
+        LOGGER.info("Disabling thread CPU time measurement");
+      }
+    }
+    try {
+      MX_BEAN.setThreadCpuTimeEnabled(enable);
+      _isThreadCpuTimeMeasurementEnabled = enable;
+    } catch (Exception e) {
+      LOGGER.error("Caught exception {} thread CPU time measurement", enable ? "enabling" : "disabling", e);
+      _isThreadCpuTimeMeasurementEnabled = false;
+    }
+  }
+
+  public static boolean isThreadMemoryMeasurementEnabled() {
+    return _isThreadMemoryMeasurementEnabled;
+  }
+
+  public static void setThreadMemoryMeasurementEnabled(boolean enable) {
+    if (!IS_THREAD_ALLOCATED_MEMORY_SUPPORTED) {
+      assert !_isThreadMemoryMeasurementEnabled;
+      if (enable) {
+        LOGGER.error("Not enabling thread memory measurement because it is not supported");
+      }
+      return;
+    }
+    if (_isThreadMemoryMeasurementEnabled != enable) {
+      if (enable) {
+        LOGGER.info("Enabling thread memory measurement");
+      } else {
+        LOGGER.info("Disabling thread memory measurement");
+      }
+    }
+    try {
+      SUN_SET_THREAD_ALLOCATED_MEMORY_ENABLED_METHOD.invoke(MX_BEAN, enable);
+      _isThreadMemoryMeasurementEnabled = enable;
+    } catch (Exception e) {
+      LOGGER.error("Caught exception {} thread memory measurement", enable ? "enabling" : "disabling", e);
+      _isThreadMemoryMeasurementEnabled = false;
+    }
+  }
 
   public static int getThreadCount() {
     return MX_BEAN.getThreadCount();
@@ -69,12 +179,24 @@ public class ThreadResourceUsageProvider {
   }
 
   public static long getCurrentThreadAllocatedBytes() {
-    try {
-      return _isThreadMemoryMeasurementEnabled ? (long) SUN_THREAD_MXBEAN_GET_BYTES_ALLOCATED_METHOD
-          .invoke(MX_BEAN, Thread.currentThread().getId()) : 0;
-    } catch (IllegalAccessException | InvocationTargetException e) {
-      LOGGER.error("Exception happened during the invocation of getting current bytes allocated", e);
+    if (!_isThreadMemoryMeasurementEnabled) {
       return 0;
+    }
+    if (SUN_GET_CURRENT_THREAD_ALLOCATED_BYTES_METHOD != null) {
+      try {
+        return (long) SUN_GET_CURRENT_THREAD_ALLOCATED_BYTES_METHOD.invoke(MX_BEAN);
+      } catch (Exception e) {
+        LOGGER.error("Caught exception invoking method: {}", SUN_GET_CURRENT_THREAD_ALLOCATED_BYTES_NAME, e);
+        return 0;
+      }
+    } else {
+      assert SUN_GET_THREAD_ALLOCATED_BYTES_METHOD != null;
+      try {
+        return (long) SUN_GET_THREAD_ALLOCATED_BYTES_METHOD.invoke(MX_BEAN, Thread.currentThread().getId());
+      } catch (Exception e) {
+        LOGGER.error("Caught exception invoking method: {}", SUN_GET_THREAD_ALLOCATED_BYTES_NAME, e);
+        return 0;
+      }
     }
   }
 
@@ -89,86 +211,5 @@ public class ThreadResourceUsageProvider {
       }
     }
     return totalGCTime;
-  }
-
-  public static boolean isThreadCpuTimeMeasurementEnabled() {
-    return _isThreadCpuTimeMeasurementEnabled;
-  }
-
-  public static void setThreadCpuTimeMeasurementEnabled(boolean enable) {
-    _isThreadCpuTimeMeasurementEnabled = enable && IS_CURRENT_THREAD_CPU_TIME_SUPPORTED;
-  }
-
-  public static boolean isThreadMemoryMeasurementEnabled() {
-    return _isThreadMemoryMeasurementEnabled;
-  }
-
-  public static void setThreadMemoryMeasurementEnabled(boolean enable) {
-
-    boolean isThreadAllocateMemoryEnabled = IS_THREAD_ALLOCATED_MEMORY_ENABLED_DEFAULT;
-    // if the jvm default enabling config is different
-    if (enable != IS_THREAD_ALLOCATED_MEMORY_ENABLED_DEFAULT) {
-      try {
-        Class<?> sunThreadMXBeanClass = Class.forName(SUN_THREAD_MXBEAN_CLASS_NAME);
-        sunThreadMXBeanClass.getMethod(SUN_THREAD_MXBEAN_SET_THREAD_ALLOCATED_MEMORY_ENABLED_NAME, Boolean.TYPE)
-            .invoke(MX_BEAN, enable);
-        isThreadAllocateMemoryEnabled = (boolean) sunThreadMXBeanClass
-            .getMethod(SUN_THREAD_MXBEAN_IS_THREAD_ALLOCATED_MEMORY_ENABLED_NAME)
-            .invoke(MX_BEAN);
-      } catch (ClassNotFoundException | IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
-        LOGGER.error("Not able to call isThreadAllocatedMemoryEnabled or setThreadAllocatedMemoryEnabled, ", e);
-      }
-    }
-    _isThreadMemoryMeasurementEnabled = enable && IS_THREAD_ALLOCATED_MEMORY_SUPPORTED && isThreadAllocateMemoryEnabled;
-  }
-
-  //initialize the com.sun.management.ThreadMXBean related variables using reflection
-  static {
-    Class<?> sunThreadMXBeanClass;
-    try {
-      sunThreadMXBeanClass = Class.forName(SUN_THREAD_MXBEAN_CLASS_NAME);
-    } catch (ClassNotFoundException e) {
-      LOGGER.error("Not able to load com.sun.management.ThreadMXBean, you are probably not using Hotspot jvm");
-      sunThreadMXBeanClass = null;
-    }
-
-    boolean isThreadAllocateMemorySupported = false;
-    try {
-      isThreadAllocateMemorySupported =
-          sunThreadMXBeanClass != null && (boolean) sunThreadMXBeanClass
-              .getMethod(SUN_THREAD_MXBEAN_IS_THREAD_ALLOCATED_MEMORY_SUPPORTED_NAME)
-              .invoke(MX_BEAN);
-    } catch (IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
-      LOGGER.error("Not able to call isThreadAllocatedMemorySupported, ", e);
-    }
-    IS_THREAD_ALLOCATED_MEMORY_SUPPORTED = isThreadAllocateMemorySupported;
-
-    boolean isThreadAllocateMemoryEnabled = false;
-    try {
-      isThreadAllocateMemoryEnabled =
-          sunThreadMXBeanClass != null && (boolean) sunThreadMXBeanClass
-              .getMethod(SUN_THREAD_MXBEAN_IS_THREAD_ALLOCATED_MEMORY_ENABLED_NAME)
-              .invoke(MX_BEAN);
-    } catch (IllegalAccessException | NoSuchMethodException | InvocationTargetException e) {
-      LOGGER.error("Not able to call isThreadAllocatedMemoryEnabled, ", e);
-    }
-    IS_THREAD_ALLOCATED_MEMORY_ENABLED_DEFAULT = isThreadAllocateMemoryEnabled;
-
-    Method threadAllocateBytes = null;
-    if (IS_THREAD_ALLOCATED_MEMORY_SUPPORTED) {
-      try {
-        threadAllocateBytes = sunThreadMXBeanClass
-            .getMethod(SUN_THREAD_MXBEAN_GET_BYTES_ALLOCATED_NAME, long.class);
-      } catch (NoSuchMethodException ignored) {
-      }
-    }
-    SUN_THREAD_MXBEAN_GET_BYTES_ALLOCATED_METHOD = threadAllocateBytes;
-  }
-
-  static {
-    LOGGER.info("Current thread cpu time measurement supported: {}", IS_CURRENT_THREAD_CPU_TIME_SUPPORTED);
-    LOGGER.info("Current thread allocated bytes measurement supported: {}", IS_THREAD_ALLOCATED_MEMORY_SUPPORTED);
-    LOGGER.info("Current thread allocated bytes measurement enabled default: {}",
-        IS_THREAD_ALLOCATED_MEMORY_ENABLED_DEFAULT);
   }
 }


### PR DESCRIPTION
- Fix the setup of `ThreadResourceUsageProvider` so that enabling/disabling CPU/memory measurement is idempotent
- Use `MXBean.getCurrentThreadAllocatedBytes()` to read current thread allocated bytes when available. It is about 10% more efficient than `MXBean.getThreadAllocatedBytes(long threadId)`
- Enhance logging