### PR TITLE
Reduce array copying for non-equi join condition evaluation for LookupJoinOperator

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/BaseJoinOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/BaseJoinOperator.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.query.runtime.operator;
 
-import java.util.AbstractList;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -35,6 +34,7 @@ import org.apache.pinot.query.planner.plannode.PlanNode;
 import org.apache.pinot.query.runtime.blocks.MseBlock;
 import org.apache.pinot.query.runtime.blocks.RowHeapDataBlock;
 import org.apache.pinot.query.runtime.blocks.SuccessMseBlock;
+import org.apache.pinot.query.runtime.operator.join.JoinedRowView;
 import org.apache.pinot.query.runtime.operator.operands.TransformOperand;
 import org.apache.pinot.query.runtime.operator.operands.TransformOperandFactory;
 import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
@@ -408,106 +408,6 @@ public abstract class BaseJoinOperator extends MultiStageOperator {
     @Override
     public StatMap.Type getType() {
       return _type;
-    }
-  }
-
-  /**
-   * This util class is a view over the left and right row joined together.
-   * Currently, this is used for filtering and input of projection. So if the joined
-   * tuple doesn't pass the predicate, the join result is not materialized into {@code Object[]}.
-   */
-  protected abstract static class JoinedRowView extends AbstractList<Object> implements List<Object> {
-    protected final int _leftSize;
-    protected final int _size;
-
-    protected JoinedRowView(int resultColumnSize, int leftSize) {
-      _leftSize = leftSize;
-      _size = resultColumnSize;
-    }
-
-    private static final class BothNotNullView extends JoinedRowView {
-      private final Object[] _leftRow;
-      private final Object[] _rightRow;
-
-      private BothNotNullView(Object[] leftRow, Object[] rightRow, int resultColumnSize, int leftSize) {
-        super(resultColumnSize, leftSize);
-        _leftRow = leftRow;
-        _rightRow = rightRow;
-      }
-
-      @Override
-      public Object get(int i) {
-        return i < _leftSize ? _leftRow[i] : _rightRow[i - _leftSize];
-      }
-
-      @Override
-      public Object[] toArray() {
-        Object[] resultRow = new Object[_size];
-        System.arraycopy(_leftRow, 0, resultRow, 0, _leftSize);
-        System.arraycopy(_rightRow, 0, resultRow, _leftSize, _rightRow.length);
-        return resultRow;
-      }
-    }
-
-    private static final class RightNotNullView extends JoinedRowView {
-      private final Object[] _rightRow;
-
-      public RightNotNullView(Object[] rightRow, int resultColumnSize, int leftSize) {
-        super(resultColumnSize, leftSize);
-        _rightRow = rightRow;
-      }
-
-      @Override
-      public Object get(int i) {
-        return i < _leftSize ? null : _rightRow[i - _leftSize];
-      }
-
-      @Override
-      public Object[] toArray() {
-        Object[] resultRow = new Object[_size];
-        System.arraycopy(_rightRow, 0, resultRow, _leftSize, _rightRow.length);
-        return resultRow;
-      }
-    }
-
-    private static final class LeftNotNullView extends JoinedRowView {
-      private final Object[] _leftRow;
-
-      public LeftNotNullView(Object[] leftRow, int resultColumnSize, int leftSize) {
-        super(resultColumnSize, leftSize);
-        _leftRow = leftRow;
-      }
-
-      @Override
-      public Object get(int i) {
-        return i < _leftSize ? _leftRow[i] : null;
-      }
-
-      @Override
-      public Object[] toArray() {
-        Object[] resultRow = new Object[_size];
-        System.arraycopy(_leftRow, 0, resultRow, 0, _leftSize);
-        return resultRow;
-      }
-    }
-
-    public static JoinedRowView of(@Nullable Object[] leftRow, @Nullable Object[] rightRow, int resultColumnSize,
-        int leftSize) {
-      if (leftRow == null && rightRow == null) {
-        throw new IllegalStateException("both left and right side of join are null");
-      }
-      if (leftRow == null) {
-        return new RightNotNullView(rightRow, resultColumnSize, leftSize);
-      }
-      if (rightRow == null) {
-        return new LeftNotNullView(leftRow, resultColumnSize, leftSize);
-      }
-      return new BothNotNullView(leftRow, rightRow, resultColumnSize, leftSize);
-    }
-
-    @Override
-    public int size() {
-      return _size;
     }
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/EnrichedHashJoinOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/EnrichedHashJoinOperator.java
@@ -27,6 +27,7 @@ import javax.annotation.Nullable;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.query.planner.plannode.EnrichedJoinNode;
 import org.apache.pinot.query.runtime.blocks.MseBlock;
+import org.apache.pinot.query.runtime.operator.join.JoinedRowView;
 import org.apache.pinot.query.runtime.operator.operands.TransformOperand;
 import org.apache.pinot.query.runtime.operator.operands.TransformOperandFactory;
 import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/factory/DefaultJoinOperatorFactory.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/factory/DefaultJoinOperatorFactory.java
@@ -49,7 +49,7 @@ public class DefaultJoinOperatorFactory implements JoinOperatorFactory {
           return new HashJoinOperator(context, leftOperator, leftSchema, rightOperator, joinNode);
         }
       case LOOKUP:
-        return new LookupJoinOperator(context, leftOperator, rightOperator, joinNode);
+        return new LookupJoinOperator(context, leftOperator, leftSchema, rightOperator, joinNode);
       case ASOF:
         return new AsofJoinOperator(context, leftOperator, leftSchema, rightOperator, joinNode);
       default:

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/JoinedRowView.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/JoinedRowView.java
@@ -1,0 +1,124 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.operator.join;
+
+import java.util.AbstractList;
+import java.util.List;
+import javax.annotation.Nullable;
+
+
+/**
+ * This util class is a view over the left and right row joined together.
+ * Currently, this is used for filtering and input of projection. So if the joined
+ * tuple doesn't pass the predicate, the join result is not materialized into {@code Object[]}.
+ */
+public abstract class JoinedRowView extends AbstractList<Object> implements List<Object> {
+  protected final int _leftSize;
+  protected final int _size;
+
+  protected JoinedRowView(int resultColumnSize, int leftSize) {
+    _leftSize = leftSize;
+    _size = resultColumnSize;
+  }
+
+  private static final class BothNotNullView extends JoinedRowView {
+    private final Object[] _leftRow;
+    private final Object[] _rightRow;
+
+    private BothNotNullView(Object[] leftRow, Object[] rightRow, int resultColumnSize, int leftSize) {
+      super(resultColumnSize, leftSize);
+      _leftRow = leftRow;
+      _rightRow = rightRow;
+    }
+
+    @Override
+    public Object get(int i) {
+      return i < _leftSize ? _leftRow[i] : _rightRow[i - _leftSize];
+    }
+
+    @Override
+    public Object[] toArray() {
+      Object[] resultRow = new Object[_size];
+      System.arraycopy(_leftRow, 0, resultRow, 0, _leftSize);
+      System.arraycopy(_rightRow, 0, resultRow, _leftSize, _rightRow.length);
+      return resultRow;
+    }
+  }
+
+  private static final class RightNotNullView extends JoinedRowView {
+    private final Object[] _rightRow;
+
+    public RightNotNullView(Object[] rightRow, int resultColumnSize, int leftSize) {
+      super(resultColumnSize, leftSize);
+      _rightRow = rightRow;
+    }
+
+    @Override
+    public Object get(int i) {
+      return i < _leftSize ? null : _rightRow[i - _leftSize];
+    }
+
+    @Override
+    public Object[] toArray() {
+      Object[] resultRow = new Object[_size];
+      System.arraycopy(_rightRow, 0, resultRow, _leftSize, _rightRow.length);
+      return resultRow;
+    }
+  }
+
+  private static final class LeftNotNullView extends JoinedRowView {
+    private final Object[] _leftRow;
+
+    public LeftNotNullView(Object[] leftRow, int resultColumnSize, int leftSize) {
+      super(resultColumnSize, leftSize);
+      _leftRow = leftRow;
+    }
+
+    @Override
+    public Object get(int i) {
+      return i < _leftSize ? _leftRow[i] : null;
+    }
+
+    @Override
+    public Object[] toArray() {
+      Object[] resultRow = new Object[_size];
+      System.arraycopy(_leftRow, 0, resultRow, 0, _leftSize);
+      return resultRow;
+    }
+  }
+
+  public static JoinedRowView of(@Nullable Object[] leftRow, @Nullable Object[] rightRow, int resultColumnSize,
+      int leftSize) {
+    if (leftRow == null && rightRow == null) {
+      throw new IllegalStateException("both left and right side of join are null");
+    }
+    if (leftRow == null) {
+      return new RightNotNullView(rightRow, resultColumnSize, leftSize);
+    }
+    if (rightRow == null) {
+      return new LeftNotNullView(leftRow, resultColumnSize, leftSize);
+    }
+    return new BothNotNullView(leftRow, rightRow, resultColumnSize, leftSize);
+  }
+
+  @Override
+  public int size() {
+    return _size;
+  }
+}


### PR DESCRIPTION
- Similar optimization to https://github.com/apache/pinot/pull/16152, but for `LookupJoinOperator`.