### PR TITLE
[spi] Stringify defaultNullValue for Map & List type

### DIFF
--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/FieldSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/FieldSpec.java
@@ -418,9 +418,9 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
         case COMPLEX:
           switch (dataType) {
             case MAP:
-              return DEFAULT_COMPLEX_NULL_VALUE_OF_MAP;
+              return DEFAULT_COMPLEX_NULL_VALUE_OF_MAP.toString();
             case LIST:
-              return DEFAULT_COMPLEX_NULL_VALUE_OF_LIST;
+              return DEFAULT_COMPLEX_NULL_VALUE_OF_LIST.toString();
             case STRUCT:
             default:
               throw new IllegalStateException("Unsupported complex data type: " + dataType);


### PR DESCRIPTION
## Issue

`FieldSpec.getStringValue()` fails to serialize empty Map object `{}` in defaultNullValue

## Description

When `jackson-module-scala` is on the classpath (via Kafka connectors), Jackson deserializes empty JSON objects `{}` as Scala collections instead of Java collections. The existing `getStringValue()` method only handles Java `Map`/`List` via `instanceof` checks, but **Scala collections don't implement `java.util.Map` or `java.util.List`**, causing them to fall through to `toString()` which produces invalid JSON.

For example, a schema with ComplexFieldSpec:

```
"complexFieldSpecs": [
    {
        "name": "dimensions",
        "dataType": "MAP",
        "defaultNullValue": {}
    }
]
```
When Jackson deserializes this with `jackson-module-scala` on the classpath:
1. "defaultNullValue": {} → scala.collection.immutable.Map$EmptyMap$
2. `setDefaultNullValue(scalaMap)` calls `getStringValue(scalaMap)`
3. instanceof Map returns false (Scala Map ≠ java.util.Map)
4. Falls through to `scalaMap.toString()` → "Map()"
5. Later, `setDataType(DataType.MAP)` triggers `getDefaultNullValue()` which calls `DataType.MAP.convert("Map()")`
6. `JsonUtils.stringToObject("Map()", Map.class)` fails because "Map()" is not valid JSON
```
Caused by: com.fasterxml.jackson.databind.exc.MismatchedInputException: Cannot convert value: 'Map()' to type: MAP
 at [Source: REDACTED; line: 333, column: 33] (through reference chain: 
   TablePreviewApi["tableConfigs"]->TableConfigs["schema"]->Schema["complexFieldSpecs"]
   ->ArrayList[0]->ComplexFieldSpec["dataType"])
```

## Bug

[FieldSpec.getStringValue()](https://github.com/startreedata/pinot/blob/3bb68a04bb03dd108030fd2280aee1701bb46058/pinot-spi/src/main/java/org/apache/pinot/spi/data/FieldSpec.java#L347):
```
public static String getStringValue(Object value) {
    if (value instanceof BigDecimal) {
      return ((BigDecimal) value).toPlainString();
    }
    if (value instanceof byte[]) {
      return BytesUtils.toHexString((byte[]) value);
    }
    return value.toString();  // ← BUG: Scala Map.toString() = "Map()"
}
```

The issue is that Schema should be serialized/deserialized using Schema.toJsonObject() and Schema.fromString(), 
but Preview API Request (which contains Schema object) allows Jackson to directly deserialize it.

When Jackson deserializes {} as defaultNullValue, if `jackson-module-scala` is on the classpath, it creates a Scala Map instead of a Java Map. 

Then getStringValue() calls toString() on it (since scala.Map doesn't pass instanceof java.util.Map), producing "Map()" which isn't valid JSON.

## Fix

This PR fixes the serialization of default null values for MAP and LIST data types by ensuring they are converted to strings. Previously, these complex types returned their object representations instead of string representations, which could cause issues during serialization or persistence.

**Changes:**
- Modified `getDefaultNullValue` to return stringified versions of MAP and LIST default null values
- Added comprehensive test coverage for default null value handling across all FieldType and DataType combinations
- Added tests for round-trip string conversion and custom default null values

## Testing
- [X] UTs
- [X] Lint Check
- [X] Ran STP locally and validated Preview API with following block
```
{
    "schema": {
        ...
        ...
        "complexFieldSpecs": [
            {
                "fieldType": "COMPLEX",
                "childFieldSpecs": {
                    ...
                    ...
                },
                "singleValueField": true,
                "notNull": false,
                "allowTrailingZeros": false,
                "defaultNullValueString": "{}",
                "name": "address",
                "defaultNullValue": {},
                "dataType": "MAP"
            }
        ]
    }
}
```

