### PR TITLE
[spi] Add Custom Deserializer for Schema

### DIFF
--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
@@ -21,6 +21,7 @@ package org.apache.pinot.spi.data;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Preconditions;
@@ -62,6 +63,7 @@ import org.slf4j.LoggerFactory;
  */
 @SuppressWarnings("unused")
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonDeserialize(using = SchemaDeserializer.class)
 public final class Schema implements Serializable {
   private static final Logger LOGGER = LoggerFactory.getLogger(Schema.class);
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/SchemaDeserializer.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/SchemaDeserializer.java
@@ -1,0 +1,73 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.data;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import java.io.IOException;
+
+
+/**
+ * Custom deserializer for {@link Schema} that properly handles ComplexFieldSpec with MAP/LIST types.
+ *
+ * <p>This deserializer reads the JSON as a tree and re-parses it using a clean ObjectMapper,
+ * ensuring that empty objects {} and arrays [] are properly handled as Java collections
+ * rather than Scala collections (which can happen when jackson-module-scala is on the classpath).
+ */
+public class SchemaDeserializer extends StdDeserializer<Schema> {
+
+  // Use a clean ObjectMapper without any auto-discovered modules (including jackson-module-scala).
+  // JsonMapper.builder() creates a mapper without auto-registering modules from classpath.
+  // We add a MixIn to override the @JsonDeserialize annotation on Schema to avoid infinite recursion.
+  private static final ObjectMapper CLEAN_MAPPER = createCleanMapper();
+
+  private static ObjectMapper createCleanMapper() {
+    final ObjectMapper mapper = JsonMapper.builder().build();
+    // Override the @JsonDeserialize annotation on Schema to use default Jackson deserialization
+    mapper.addMixIn(Schema.class, SchemaDeserializerOverrideMixin.class);
+    return mapper;
+  }
+
+  /**
+   * MixIn class that overrides the @JsonDeserialize annotation on Schema.
+   * An empty @JsonDeserialize means "use default Jackson deserialization".
+   */
+  @JsonDeserialize
+  abstract static class SchemaDeserializerOverrideMixin {
+  }
+
+  public SchemaDeserializer() {
+    super(Schema.class);
+  }
+
+  @Override
+  public Schema deserialize(final JsonParser p, final DeserializationContext ctxt)
+      throws IOException {
+    // Read the JSON tree - this normalizes any Scala collections to JsonNode
+    final JsonNode node = p.readValueAsTree();
+
+    // Use CLEAN_MAPPER to deserialize directly from JsonNode - avoids Scala collections and infinite recursion
+    return CLEAN_MAPPER.treeToValue(node, Schema.class);
+  }
+}

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/data/SchemaDeserializerTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/data/SchemaDeserializerTest.java
@@ -1,0 +1,335 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.data;
+
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+
+/**
+ * Tests for {@link SchemaDeserializer}.
+ *
+ * These tests verify that Schema deserialization properly handles ComplexFieldSpec
+ * with MAP/LIST types, ensuring empty objects {} and arrays [] are deserialized
+ * as Java collections rather than Scala collections.
+ */
+public class SchemaDeserializerTest {
+
+  @Test
+  public void testDeserializeSchemaWithMapType() throws Exception {
+    final String json = "{"
+        + "\"schemaName\": \"testSchema\","
+        + "\"complexFieldSpecs\": [{"
+        + "  \"name\": \"mapField\","
+        + "  \"dataType\": \"MAP\","
+        + "  \"defaultNullValue\": \"{}\""
+        + "}]"
+        + "}";
+
+    final Schema schema = JsonUtils.stringToObject(json, Schema.class);
+
+    assertNotNull(schema);
+    assertEquals(schema.getSchemaName(), "testSchema");
+    assertEquals(schema.getComplexFieldSpecs().size(), 1);
+
+    final ComplexFieldSpec fieldSpec = schema.getComplexFieldSpecs().get(0);
+    assertEquals(fieldSpec.getName(), "mapField");
+    assertEquals(fieldSpec.getDataType(), DataType.MAP);
+  }
+
+  @Test
+  public void testDeserializeSchemaWithMapTypeEmptyObjectDefault() throws Exception {
+    final String json = "{"
+        + "\"schemaName\": \"mapDefaultSchema\","
+        + "\"complexFieldSpecs\": [{"
+        + "  \"name\": \"dimensions\","
+        + "  \"dataType\": \"MAP\","
+        + "  \"childFieldSpecs\": {"
+        + "    \"key\": {\"name\": \"key\", \"dataType\": \"STRING\", \"fieldType\": \"DIMENSION\"},"
+        + "    \"value\": {\"name\": \"value\", \"dataType\": \"STRING\", \"fieldType\": \"DIMENSION\"}"
+        + "  },"
+        + "  \"defaultNullValue\": {}"
+        + "}]"
+        + "}";
+
+    final Schema schema = JsonUtils.stringToObject(json, Schema.class);
+
+    assertNotNull(schema);
+    assertEquals(schema.getComplexFieldSpecs().size(), 1);
+
+    final ComplexFieldSpec fieldSpec = schema.getComplexFieldSpecs().get(0);
+    assertEquals(fieldSpec.getName(), "dimensions");
+    assertEquals(fieldSpec.getDataType(), DataType.MAP);
+
+    // Verify defaultNullValue is a Java Map, not Scala Map
+    final Object defaultValue = fieldSpec.getDefaultNullValue();
+    assertNotNull(defaultValue);
+    assertTrue(defaultValue instanceof Map,
+        "defaultNullValue should be java.util.Map, got: " + defaultValue.getClass().getName());
+  }
+
+  @Test
+  public void testDeserializeSchemaWithListType() throws Exception {
+    final String json = "{"
+        + "\"schemaName\": \"listSchema\","
+        + "\"complexFieldSpecs\": [{"
+        + "  \"name\": \"listField\","
+        + "  \"dataType\": \"LIST\","
+        + "  \"defaultNullValue\": \"[]\""
+        + "}]"
+        + "}";
+
+    final Schema schema = JsonUtils.stringToObject(json, Schema.class);
+
+    assertNotNull(schema);
+    assertEquals(schema.getComplexFieldSpecs().size(), 1);
+
+    final ComplexFieldSpec fieldSpec = schema.getComplexFieldSpecs().get(0);
+    assertEquals(fieldSpec.getName(), "listField");
+    assertEquals(fieldSpec.getDataType(), DataType.LIST);
+  }
+
+  @Test
+  public void testDeserializeSchemaWithListTypeEmptyArrayDefault() throws Exception {
+    final String json = "{"
+        + "\"schemaName\": \"listDefaultSchema\","
+        + "\"complexFieldSpecs\": [{"
+        + "  \"name\": \"items\","
+        + "  \"dataType\": \"LIST\","
+        + "  \"defaultNullValue\": []"
+        + "}]"
+        + "}";
+
+    final Schema schema = JsonUtils.stringToObject(json, Schema.class);
+
+    assertNotNull(schema);
+    assertEquals(schema.getComplexFieldSpecs().size(), 1);
+
+    final ComplexFieldSpec fieldSpec = schema.getComplexFieldSpecs().get(0);
+    assertEquals(fieldSpec.getName(), "items");
+    assertEquals(fieldSpec.getDataType(), DataType.LIST);
+
+    // Verify defaultNullValue is a Java List, not Scala List
+    final Object defaultValue = fieldSpec.getDefaultNullValue();
+    assertNotNull(defaultValue);
+    assertTrue(defaultValue instanceof List,
+        "defaultNullValue should be java.util.List, got: " + defaultValue.getClass().getName());
+  }
+
+  @Test
+  public void testEmptyMapDefaultValueIsJavaMap() throws Exception {
+    final String json = "{"
+        + "\"schemaName\": \"javaMapTest\","
+        + "\"complexFieldSpecs\": [{"
+        + "  \"name\": \"testMap\","
+        + "  \"dataType\": \"MAP\","
+        + "  \"defaultNullValue\": {}"
+        + "}]"
+        + "}";
+
+    final Schema schema = JsonUtils.stringToObject(json, Schema.class);
+    final Object defaultValue = schema.getComplexFieldSpecs().get(0).getDefaultNullValue();
+
+    // Must be a Java Map implementation, not Scala
+    assertTrue(defaultValue instanceof java.util.Map,
+        "Expected java.util.Map but got: " + defaultValue.getClass().getName());
+
+    // Verify it's not a Scala collection by checking class name
+    final String className = defaultValue.getClass().getName();
+    assertTrue(className.startsWith("java.") || className.startsWith("com.fasterxml."),
+        "Expected Java class but got: " + className);
+  }
+
+  @Test
+  public void testEmptyListDefaultValueIsJavaList() throws Exception {
+    final String json = "{"
+        + "\"schemaName\": \"javaListTest\","
+        + "\"complexFieldSpecs\": [{"
+        + "  \"name\": \"testList\","
+        + "  \"dataType\": \"LIST\","
+        + "  \"defaultNullValue\": []"
+        + "}]"
+        + "}";
+
+    final Schema schema = JsonUtils.stringToObject(json, Schema.class);
+    final Object defaultValue = schema.getComplexFieldSpecs().get(0).getDefaultNullValue();
+
+    // Must be a Java List implementation, not Scala
+    assertTrue(defaultValue instanceof java.util.List,
+        "Expected java.util.List but got: " + defaultValue.getClass().getName());
+
+    // Verify it's not a Scala collection by checking class name
+    final String className = defaultValue.getClass().getName();
+    assertTrue(className.startsWith("java.") || className.startsWith("com.fasterxml."),
+        "Expected Java class but got: " + className);
+  }
+
+  @Test
+  public void testDeserializeFullSchemaWithAllFieldTypes() throws Exception {
+    final String json = "{"
+        + "\"schemaName\": \"fullSchema\","
+        + "\"primaryKeyColumns\": [\"id\"],"
+        + "\"dimensionFieldSpecs\": ["
+        + "  {\"name\": \"id\", \"dataType\": \"LONG\"},"
+        + "  {\"name\": \"name\", \"dataType\": \"STRING\"}"
+        + "],"
+        + "\"metricFieldSpecs\": ["
+        + "  {\"name\": \"count\", \"dataType\": \"LONG\"}"
+        + "],"
+        + "\"dateTimeFieldSpecs\": ["
+        + "  {\"name\": \"ts\", \"dataType\": \"LONG\", "
+        + "  \"format\": \"EPOCH|MILLISECONDS\", \"granularity\": \"1:MILLISECONDS\"}"
+        + "],"
+        + "\"complexFieldSpecs\": ["
+        + "  {\"name\": \"metadata\", \"dataType\": \"MAP\", \"defaultNullValue\": {}}"
+        + "]"
+        + "}";
+
+    final Schema schema = JsonUtils.stringToObject(json, Schema.class);
+
+    assertNotNull(schema);
+    assertEquals(schema.getSchemaName(), "fullSchema");
+    assertEquals(schema.getPrimaryKeyColumns().size(), 1);
+    assertEquals(schema.getDimensionFieldSpecs().size(), 2);
+    assertEquals(schema.getMetricFieldSpecs().size(), 1);
+    assertEquals(schema.getDateTimeFieldSpecs().size(), 1);
+    assertEquals(schema.getComplexFieldSpecs().size(), 1);
+
+    // Verify MAP field has Java Map as default
+    final Object mapDefault = schema.getComplexFieldSpecs().get(0).getDefaultNullValue();
+    assertTrue(mapDefault instanceof java.util.Map);
+  }
+
+  @Test
+  public void testSchemaRoundTripSerialization() throws Exception {
+    // Create schema programmatically
+    final Schema originalSchema = new Schema.SchemaBuilder()
+        .setSchemaName("roundTripSchema")
+        .addSingleValueDimension("dim1", DataType.STRING)
+        .addMetric("metric1", DataType.LONG)
+        .addDateTime("ts", DataType.LONG, "EPOCH|MILLISECONDS", "1:MILLISECONDS")
+        .build();
+
+    // Serialize to JSON
+    final String json = originalSchema.toJsonObject().toString();
+
+    // Deserialize back
+    final Schema deserializedSchema = JsonUtils.stringToObject(json, Schema.class);
+
+    assertNotNull(deserializedSchema);
+    assertEquals(deserializedSchema.getSchemaName(), originalSchema.getSchemaName());
+    assertEquals(deserializedSchema.getDimensionFieldSpecs().size(), originalSchema.getDimensionFieldSpecs().size());
+    assertEquals(deserializedSchema.getMetricFieldSpecs().size(), originalSchema.getMetricFieldSpecs().size());
+    assertEquals(deserializedSchema.getDateTimeFieldSpecs().size(), originalSchema.getDateTimeFieldSpecs().size());
+  }
+
+  @Test
+  public void testDeserializeSchemaWithComplexMapFieldAndChildSpecs() throws Exception {
+    final String json = "{"
+        + "\"schemaName\": \"preview_table\","
+        + "\"dimensionFieldSpecs\": ["
+        + "  {\"name\": \"firstName\", \"dataType\": \"STRING\"},"
+        + "  {\"name\": \"lastName\", \"dataType\": \"STRING\"}"
+        + "],"
+        + "\"metricFieldSpecs\": ["
+        + "  {\"name\": \"studentID\", \"dataType\": \"LONG\"}"
+        + "],"
+        + "\"dateTimeFieldSpecs\": ["
+        + "  {\"name\": \"timestamp\", \"dataType\": \"LONG\", "
+        + "  \"format\": \"EPOCH|MILLISECONDS\", \"granularity\": \"1:MILLISECONDS\"}"
+        + "],"
+        + "\"complexFieldSpecs\": [{"
+        + "  \"name\": \"address\","
+        + "  \"dataType\": \"MAP\","
+        + "  \"childFieldSpecs\": {"
+        + "    \"key\": {\"name\": \"key\", \"dataType\": \"STRING\", \"fieldType\": \"DIMENSION\"},"
+        + "    \"value\": {\"name\": \"value\", \"dataType\": \"STRING\", \"fieldType\": \"DIMENSION\"}"
+        + "  },"
+        + "  \"defaultNullValueString\": \"{}\","
+        + "  \"defaultNullValue\": {}"
+        + "}]"
+        + "}";
+
+    final Schema schema = JsonUtils.stringToObject(json, Schema.class);
+
+    assertNotNull(schema);
+    assertEquals(schema.getSchemaName(), "preview_table");
+    assertEquals(schema.getDimensionFieldSpecs().size(), 2);
+    assertEquals(schema.getMetricFieldSpecs().size(), 1);
+    assertEquals(schema.getDateTimeFieldSpecs().size(), 1);
+    assertEquals(schema.getComplexFieldSpecs().size(), 1);
+
+    // Verify the MAP field is properly deserialized
+    final ComplexFieldSpec mapField = schema.getComplexFieldSpecs().get(0);
+    assertEquals(mapField.getName(), "address");
+    assertEquals(mapField.getDataType(), DataType.MAP);
+
+    // Verify defaultNullValue is Java Map
+    final Object defaultValue = mapField.getDefaultNullValue();
+    assertTrue(defaultValue instanceof java.util.Map,
+        "Expected java.util.Map but got: " + defaultValue.getClass().getName());
+  }
+
+  @Test
+  public void testGetStringValueReturnsValidJsonForEmptyMapDefault() throws Exception {
+    final String json = "{"
+        + "\"schemaName\": \"stringValueTest\","
+        + "\"complexFieldSpecs\": [{"
+        + "  \"name\": \"testMap\","
+        + "  \"dataType\": \"MAP\","
+        + "  \"defaultNullValue\": {}"
+        + "}]"
+        + "}";
+
+    final Schema schema = JsonUtils.stringToObject(json, Schema.class);
+    final Object defaultValue = schema.getComplexFieldSpecs().get(0).getDefaultNullValue();
+
+    // getStringValue should produce valid JSON
+    final String stringValue = FieldSpec.getStringValue(defaultValue);
+    assertEquals(stringValue, "{}",
+        "getStringValue should return '{}' for empty Map, got: " + stringValue);
+  }
+
+  @Test
+  public void testGetStringValueReturnsValidJsonForEmptyListDefault() throws Exception {
+    final String json = "{"
+        + "\"schemaName\": \"stringValueTest\","
+        + "\"complexFieldSpecs\": [{"
+        + "  \"name\": \"testList\","
+        + "  \"dataType\": \"LIST\","
+        + "  \"defaultNullValue\": []"
+        + "}]"
+        + "}";
+
+    final Schema schema = JsonUtils.stringToObject(json, Schema.class);
+    final Object defaultValue = schema.getComplexFieldSpecs().get(0).getDefaultNullValue();
+
+    // getStringValue should produce valid JSON
+    final String stringValue = FieldSpec.getStringValue(defaultValue);
+    assertEquals(stringValue, "[]",
+        "getStringValue should return '[]' for empty List, got: " + stringValue);
+  }
+}


### PR DESCRIPTION
## Issue

`FieldSpec.getStringValue()` fails to serialize empty Map object `{}` in defaultNullValue

## Description

When `jackson-module-scala` is on the classpath (via Kafka connectors), Jackson deserializes empty JSON objects `{}` as Scala collections instead of Java collections. The existing `getStringValue()` method only handles Java `Map`/`List` via `instanceof` checks, but **Scala collections don't implement `java.util.Map` or `java.util.List`**, causing them to fall through to `toString()` which produces invalid JSON.

For example, a schema with ComplexFieldSpec:

```
"complexFieldSpecs": [
    {
        "name": "dimensions",
        "dataType": "MAP",
        "defaultNullValue": {}
    }
]
```
When Jackson deserializes this with `jackson-module-scala` on the classpath:
1. "defaultNullValue": {} → scala.collection.immutable.Map$EmptyMap$
2. `setDefaultNullValue(scalaMap)` calls `getStringValue(scalaMap)`
3. instanceof Map returns false (Scala Map ≠ java.util.Map)
4. Falls through to `scalaMap.toString()` → "Map()"
5. Later, `setDataType(DataType.MAP)` triggers `getDefaultNullValue()` which calls `DataType.MAP.convert("Map()")`
6. `JsonUtils.stringToObject("Map()", Map.class)` fails because "Map()" is not valid JSON
```
Caused by: com.fasterxml.jackson.databind.exc.MismatchedInputException: Cannot convert value: 'Map()' to type: MAP
 at [Source: REDACTED; line: 333, column: 33] (through reference chain: 
   TablePreviewApi["tableConfigs"]->TableConfigs["schema"]->Schema["complexFieldSpecs"]
   ->ArrayList[0]->ComplexFieldSpec["dataType"])
```

## Bug

[FieldSpec.getStringValue()](https://github.com/startreedata/pinot/blob/3bb68a04bb03dd108030fd2280aee1701bb46058/pinot-spi/src/main/java/org/apache/pinot/spi/data/FieldSpec.java#L347):
```
public static String getStringValue(Object value) {
    if (value instanceof BigDecimal) {
      return ((BigDecimal) value).toPlainString();
    }
    if (value instanceof byte[]) {
      return BytesUtils.toHexString((byte[]) value);
    }
    return value.toString();  // ← BUG: Scala Map.toString() = "Map()"
}
```

The issue is that Schema should be serialized/deserialized using Schema.toJsonObject() and Schema.fromString(), 
but Preview API Request (which contains Schema object) allows Jackson to directly deserialize it.

When Jackson deserializes {} as defaultNullValue, if `jackson-module-scala` is on the classpath, it creates a Scala Map instead of a Java Map. 

Then getStringValue() calls toString() on it (since scala.Map doesn't pass instanceof java.util.Map), producing "Map()" which isn't valid JSON.

## Fix

This PR introduces a custom JSON deserializer for the `Schema` class to address issues with deserialization when `jackson-module-scala` is on the classpath. The custom deserializer ensures that empty objects and arrays are properly handled as Java collections rather than Scala collections.

**Changes:**
- Added `SchemaDeserializer` class that extends `StdDeserializer<Schema>` with special handling for JSON deserialization
- Annotated the `Schema` class with `@JsonDeserialize` to use the new custom deserializer

## Testing
- [X] UTs
- [X] Lint Check
- [X] Ran STP locally and validated Preview API with following block
```
{
    "schema": {
        ...
        ...
        "complexFieldSpecs": [
            {
                "fieldType": "COMPLEX",
                "childFieldSpecs": {
                    ...
                    ...
                },
                "singleValueField": true,
                "notNull": false,
                "allowTrailingZeros": false,
                "defaultNullValueString": "{}",
                "name": "address",
                "defaultNullValue": {},
                "dataType": "MAP"
            }
        ]
    }
}
```

