### PR TITLE
Add runtime TLS diagnostics for gRPC and HTTPS

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/grpc/BrokerGrpcServer.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/grpc/BrokerGrpcServer.java
@@ -363,9 +363,9 @@ public class BrokerGrpcServer extends PinotQueryBrokerGrpc.PinotQueryBrokerImplB
           RenewableTlsUtils.createSSLFactoryAndEnableAutoRenewalWhenUsingFileStores(tlsConfig);
       // since tlsConfig.getKeyStorePath() is not null, sslFactory.getKeyManagerFactory().get() should not be null
       SslProvider sslProvider = SslProvider.valueOf(tlsConfig.getSslProvider());
-      if (sslProvider != SslProvider.JDK) {
-        LOGGER.warn("Configured SSL provider is {}. For FIPS/BCJSSE environments use JDK provider.", sslProvider);
-      }
+      // Runtime visibility for Platform-FIPS-JDK deployments: warn & log the actual JSSE provider/protocol once.
+      TlsUtils.warnIfNonJdkProviderConfigured("grpc.broker.server", tlsConfig);
+      TlsUtils.logJsseDiagnosticsOnce("grpc.broker.server", sslFactory, tlsConfig);
       SslContextBuilder sslContextBuilder =
           SslContextBuilder.forServer(sslFactory.getKeyManagerFactory().get()).sslProvider(sslProvider);
       sslFactory.getTrustManagerFactory().ifPresent(sslContextBuilder::trustManager);

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/grpc/BaseGrpcQueryClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/grpc/BaseGrpcQueryClient.java
@@ -38,6 +38,7 @@ import org.apache.pinot.common.config.GrpcConfig;
 import org.apache.pinot.common.config.TlsConfig;
 import org.apache.pinot.common.utils.tls.PinotInsecureMode;
 import org.apache.pinot.common.utils.tls.RenewableTlsUtils;
+import org.apache.pinot.common.utils.tls.TlsUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -98,6 +99,9 @@ public abstract class BaseGrpcQueryClient<REQUEST, RESPONSE> implements Closeabl
       try {
         SSLFactory sslFactory = RenewableTlsUtils.createSSLFactoryAndEnableAutoRenewalWhenUsingFileStores(tlsConfig,
             PinotInsecureMode::isPinotInInsecureMode);
+        // Runtime visibility for Platform-FIPS-JDK deployments: warn & log the actual JSSE provider/protocol once.
+        TlsUtils.warnIfNonJdkProviderConfigured("grpc.query.client", tlsConfig);
+        TlsUtils.logJsseDiagnosticsOnce("grpc.query.client", sslFactory, tlsConfig);
         SslContextBuilder sslContextBuilder = SslContextBuilder.forClient();
         sslFactory.getKeyManagerFactory().ifPresent(sslContextBuilder::keyManager);
         sslFactory.getTrustManagerFactory().ifPresent(sslContextBuilder::trustManager);

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/grpc/GrpcQueryServer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/grpc/GrpcQueryServer.java
@@ -53,6 +53,7 @@ import org.apache.pinot.common.proto.Server.ServerRequest;
 import org.apache.pinot.common.proto.Server.ServerResponse;
 import org.apache.pinot.common.utils.tls.PinotInsecureMode;
 import org.apache.pinot.common.utils.tls.RenewableTlsUtils;
+import org.apache.pinot.common.utils.tls.TlsUtils;
 import org.apache.pinot.core.operator.blocks.InstanceResponseBlock;
 import org.apache.pinot.core.operator.streaming.StreamingResponseUtils;
 import org.apache.pinot.core.query.executor.QueryExecutor;
@@ -185,6 +186,9 @@ public class GrpcQueryServer extends PinotQueryServerGrpc.PinotQueryServerImplBa
         SSLFactory sslFactory =
             RenewableTlsUtils.createSSLFactoryAndEnableAutoRenewalWhenUsingFileStores(
                 tlsConfig, PinotInsecureMode::isPinotInInsecureMode);
+        // Runtime visibility for Platform-FIPS-JDK deployments: log the actual JSSE provider/protocol once.
+        TlsUtils.warnIfNonJdkProviderConfigured("grpc.query.server", tlsConfig);
+        TlsUtils.logJsseDiagnosticsOnce("grpc.query.server", sslFactory, tlsConfig);
         SslContextBuilder sslContextBuilder = SslContextBuilder.forServer(sslFactory.getKeyManagerFactory().get())
             .sslProvider(SslProvider.valueOf(tlsConfig.getSslProvider()));
         sslFactory.getTrustManagerFactory().ifPresent(sslContextBuilder::trustManager);


### PR DESCRIPTION
Log once at runtime which JSSE provider/protocol and enabled protocols are active for HTTPS and gRPC TLS contexts. 

Also warn when non-JDK SSL providers are configured, which can conflict with Platform-FIPS-JDK deployments.
