### PR TITLE
[bugfix] Handling runtime exceptions for RemoteClusterBrokerRoutingManager routing methods

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/manager/RemoteClusterBrokerRoutingManager.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/manager/RemoteClusterBrokerRoutingManager.java
@@ -116,7 +116,8 @@ public class RemoteClusterBrokerRoutingManager extends BaseBrokerRoutingManager 
         removeRouting(table);
       }
     } catch (Exception e) {
-      LOGGER.error("Caught exception while dropping routing for table: {} in cluster: {}", table, _remoteClusterName, e);
+      LOGGER.error("Caught exception while dropping routing for table: {} in cluster: {}", table, _remoteClusterName,
+        e);
     }
   }
 


### PR DESCRIPTION
## Summary 
While testing multi-cluster routing in our internal clusters, we noticed that a bad table (containing segments with invalid partition IDs) was resulting in a runtime error thrown resulting in an empty routing map in RemoteClusterBrokerRoutingManager and lot of error messages in the `determineRoutingChangeForTable`. 

This PR adds an exception check for the `addRouting` and `dropRouting` methods so that one bad table does not block routing builds for other tables.