### PR TITLE
include primary key in the pinot schema ui

### DIFF
--- a/pinot-controller/src/main/resources/app/pages/TenantDetails.tsx
+++ b/pinot-controller/src/main/resources/app/pages/TenantDetails.tsx
@@ -293,7 +293,7 @@ const TenantPageDetails = ({ match }: RouteComponentProps<Props>) => {
     if(result.error){
       setSchemaJSON(null);
       setTableSchema({
-        columns: ['Column', 'Type', 'Field Type', 'Multi Value'],
+        columns: ['Column', 'Type', 'Field Type', 'Multi Value', 'Primary Key'],
         records: []
       });
     } else {

--- a/pinot-controller/src/main/resources/app/utils/Utils.tsx
+++ b/pinot-controller/src/main/resources/app/utils/Utils.tsx
@@ -321,6 +321,7 @@ const syncTableSchemaData = (data, showFieldType) => {
   const metricFields = data.metricFieldSpecs || [];
   const dateTimeField = data.dateTimeFieldSpecs || [];
   const complexFields = data.complexFieldSpecs || [];
+  const primaryKeys = new Set(data.primaryKeyColumns || []);
 
   dimensionFields.map((field) => {
     field.fieldType = 'Dimension';
@@ -341,9 +342,9 @@ const syncTableSchemaData = (data, showFieldType) => {
   const columnList = [...dimensionFields, ...metricFields, ...dateTimeField, ...complexFields];
   if (showFieldType) {
     return {
-      columns: ['Column', 'Type', 'Field Type', 'Multi Value'],
+      columns: ['Column', 'Type', 'Field Type', 'Multi Value', 'Primary Key'],
       records: columnList.map((field) => {
-        return [field.name, field.dataType, field.fieldType, getMultiValueField(field)];
+        return [field.name, field.dataType, field.fieldType, getMultiValueField(field), primaryKeys.has(field.name)];
       }),
     };
   }


### PR DESCRIPTION
this is a small UI improvement to include "Primary Key" in the schema UI. This is useful for upsert and dedup tables so you can see this without having to look at the json format.

I ran this on test cluster where we can see `true` for this case.
<img width="736" height="202" alt="image" src="https://github.com/user-attachments/assets/056477a3-7793-443c-85fc-107ad070545b" />
