### PR TITLE
Enable broker gRPC only for quickstarts.

### DIFF
--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/QuickstartRunner.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/QuickstartRunner.java
@@ -54,6 +54,7 @@ public class QuickstartRunner {
 
   public static final int DEFAULT_CONTROLLER_PORT = 9000;
   private static final int DEFAULT_BROKER_PORT = 8000;
+  private static final int DEFAULT_BROKER_GRPC_PORT = 8010;
   private static final int DEFAULT_SERVER_ADMIN_API_PORT = 7500;
   private static final int DEFAULT_SERVER_NETTY_PORT = 7050;
   private static final int DEFAULT_SERVER_GRPC_PORT = 7100;
@@ -164,6 +165,7 @@ public class QuickstartRunner {
     for (int i = 0; i < _numBrokers; i++) {
       StartBrokerCommand brokerStarter = new StartBrokerCommand();
       brokerStarter.setPort(DEFAULT_BROKER_PORT + i)
+          .setGrpcPort(DEFAULT_BROKER_GRPC_PORT + i)
           .setZkAddress(_zkExternalAddress != null ? _zkExternalAddress : ZK_ADDRESS).setClusterName(CLUSTER_NAME)
           .setConfigOverrides(_configOverrides);
       if (!brokerStarter.execute()) {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartBrokerCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartBrokerCommand.java
@@ -48,6 +48,11 @@ public class StartBrokerCommand extends AbstractBaseAdminCommand implements Comm
   @CommandLine.Option(names = {"-brokerPort"}, required = false, description = "Broker port number to use for query.")
   private int _brokerPort = CommonConstants.Helix.DEFAULT_BROKER_QUERY_PORT;
 
+  @CommandLine.Option(names = {"-brokerGrpcPort"}, required = false, description = "Broker gRPC port number to use "
+      + "for query. Positive values enable gRPC on that port, 0 enables gRPC on an available port, and negative "
+      + "values (default -1) disable gRPC.")
+  private int _brokerGrpcPort = -1;
+
   @CommandLine.Option(names = {"-brokerMultiStageRunnerPort"}, required = false,
       description = "Broker port number to use for query.")
   private int _brokerMultiStageRunnerPort = CommonConstants.MultiStageQueryRunner.DEFAULT_QUERY_RUNNER_PORT;
@@ -60,7 +65,7 @@ public class StartBrokerCommand extends AbstractBaseAdminCommand implements Comm
 
   @CommandLine.Option(names = {"-configFileName", "-config", "-configFile", "-brokerConfig", "-brokerConf"},
       required = false, description = "Broker Starter Config file.")
-      // TODO: support forbids = {"-brokerHost", "-brokerPort"})
+  // TODO: support forbids = {"-brokerHost", "-brokerPort"})
   private String _configFileName;
 
   @CommandLine.Option(names = {"-configOverrides"}, required = false, split = ",",
@@ -73,6 +78,10 @@ public class StartBrokerCommand extends AbstractBaseAdminCommand implements Comm
 
   public int getBrokerPort() {
     return _brokerPort;
+  }
+
+  public int getBrokerGrpcPort() {
+    return _brokerGrpcPort;
   }
 
   public int getBrokerMultiStageRunnerPort() {
@@ -105,7 +114,8 @@ public class StartBrokerCommand extends AbstractBaseAdminCommand implements Comm
     if (_configFileName != null) {
       return ("StartBroker -zkAddress " + _zkAddress + " -configFileName " + _configFileName);
     } else {
-      return ("StartBroker -brokerHost " + _brokerHost + " -brokerPort " + _brokerPort + " -zkAddress " + _zkAddress);
+      return ("StartBroker -brokerHost " + _brokerHost + " -brokerPort " + _brokerPort + " -brokerGrpcPort "
+          + _brokerGrpcPort + " -zkAddress " + _zkAddress);
     }
   }
 
@@ -125,6 +135,11 @@ public class StartBrokerCommand extends AbstractBaseAdminCommand implements Comm
 
   public StartBrokerCommand setPort(int port) {
     _brokerPort = port;
+    return this;
+  }
+
+  public StartBrokerCommand setGrpcPort(int grpcPort) {
+    _brokerGrpcPort = grpcPort;
     return this;
   }
 
@@ -152,7 +167,7 @@ public class StartBrokerCommand extends AbstractBaseAdminCommand implements Comm
   public boolean execute()
       throws Exception {
     try {
-      LOGGER.info("Executing command: {}", toString());
+      LOGGER.info("Executing command: {}", this);
       Map<String, Object> brokerConf = getBrokerConf();
       StartServiceManagerCommand startServiceManagerCommand =
           new StartServiceManagerCommand().setZkAddress(_zkAddress).setClusterName(_clusterName).setPort(-1)
@@ -180,7 +195,7 @@ public class StartBrokerCommand extends AbstractBaseAdminCommand implements Comm
       _clusterName = MapUtils.getString(properties, CommonConstants.Helix.CONFIG_OF_CLUSTER_NAME, _clusterName);
     } else {
       properties.putAll(PinotConfigUtils.generateBrokerConf(_clusterName, _zkAddress, _brokerHost, _brokerPort,
-          _brokerMultiStageRunnerPort));
+          _brokerGrpcPort, _brokerMultiStageRunnerPort));
     }
     if (_configOverrides != null) {
       properties.putAll(_configOverrides);

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartServiceManagerCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartServiceManagerCommand.java
@@ -161,7 +161,7 @@ public class StartServiceManagerCommand extends AbstractBaseAdminCommand impleme
   public boolean execute()
       throws Exception {
     try {
-      LOGGER.info("Executing command: {}", toString());
+      LOGGER.info("Executing command: {}", this);
       if (!startPinotService("SERVICE_MANAGER", this::startServiceManager)) {
         return false;
       }
@@ -207,6 +207,7 @@ public class StartServiceManagerCommand extends AbstractBaseAdminCommand impleme
       case BROKER:
         return PinotConfigUtils
             .generateBrokerConf(_clusterName, _zkAddress, null, CommonConstants.Helix.DEFAULT_BROKER_QUERY_PORT,
+                -1,
                 CommonConstants.MultiStageQueryRunner.DEFAULT_QUERY_RUNNER_PORT);
       case SERVER:
         return PinotConfigUtils

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/utils/PinotConfigUtils.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/utils/PinotConfigUtils.java
@@ -152,7 +152,7 @@ public class PinotConfigUtils {
   }
 
   public static Map<String, Object> generateBrokerConf(String clusterName, String zkAddress, String brokerHost,
-      int brokerPort, int brokerMultiStageRunnerPort)
+      int brokerPort, int brokerGrpcPort, int brokerMultiStageRunnerPort)
       throws SocketException, UnknownHostException {
     Map<String, Object> properties = new HashMap<>();
     properties.put(CommonConstants.Helix.CONFIG_OF_CLUSTER_NAME, clusterName);
@@ -160,6 +160,11 @@ public class PinotConfigUtils {
     properties.put(CommonConstants.Broker.CONFIG_OF_BROKER_HOSTNAME,
         !StringUtils.isEmpty(brokerHost) ? brokerHost : NetUtils.getHostAddress());
     properties.put(CommonConstants.Helix.KEY_OF_BROKER_QUERY_PORT, brokerPort != 0 ? brokerPort : getAvailablePort());
+    if (brokerGrpcPort > 0) {
+      properties.put(CommonConstants.Broker.Grpc.KEY_OF_GRPC_PORT, brokerGrpcPort);
+    } else if (brokerGrpcPort == 0) {
+      properties.put(CommonConstants.Broker.Grpc.KEY_OF_GRPC_PORT, getAvailablePort());
+    }
     properties.put(CommonConstants.MultiStageQueryRunner.KEY_OF_QUERY_RUNNER_PORT, brokerMultiStageRunnerPort != 0
         ? brokerMultiStageRunnerPort : getAvailablePort());
     return properties;


### PR DESCRIPTION
Quickstarts now set a default broker gRPC port, while standard broker/service-manager startup keeps gRPC disabled unless explicitly configured. This avoids accidental exposure of query ports while preserving quickstart convenience.
