### PR TITLE
[bugfix] Propagate error messages correctly in timeseries engine

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/TimeSeriesRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/TimeSeriesRequestHandler.java
@@ -150,7 +150,8 @@ public class TimeSeriesRequestHandler extends BaseBrokerRequestHandler {
       try {
         timeSeriesRequest = buildRangeTimeSeriesRequest(lang, rawQueryParamString, queryParams);
       } catch (URISyntaxException e) {
-        throw new QueryException(QueryErrorCode.TIMESERIES_PARSING, "Error building RangeTimeSeriesRequest: " + e.getMessage(), e);
+        throw new QueryException(QueryErrorCode.TIMESERIES_PARSING, "Error building RangeTimeSeriesRequest: "
+            + e.getMessage(), e);
       }
       requestContext.setQuery(timeSeriesRequest.getQuery());
 


### PR DESCRIPTION
## Summary

For non `QueryException` exceptions thrown in the time series handler flow, the engine returns a default "Error processing time-series query" error instead of the underlying message of the exception. This PR fixes that.