### PR TITLE
Fix BasicAuth token configuration naming consistency across Pinot components (#17506)

### DIFF
--- a/pinot-common/src/test/java/org/apache/pinot/common/auth/AuthProviderUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/auth/AuthProviderUtilsTest.java
@@ -52,7 +52,10 @@ public class AuthProviderUtilsTest {
 
     Map<String, Object> headers = authProvider.getRequestHeaders();
     assertNotNull(headers, "Auth headers must be present when correct key is used");
-    assertTrue(headers.containsValue("my-secret-token"),
+    // StaticTokenAuthProvider prefixes with "Basic ", so the stored value is "Basic my-secret-token"
+    Object authHeader = headers.get("Authorization");
+    assertNotNull(authHeader, "Authorization header must be present when correct key is used");
+    assertTrue(authHeader.toString().contains("my-secret-token"),
         "Token value must appear in request headers");
   }
 

--- a/pinot-common/src/test/java/org/apache/pinot/common/auth/AuthProviderUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/auth/AuthProviderUtilsTest.java
@@ -1,0 +1,84 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.auth;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.pinot.spi.auth.AuthProvider;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+
+/**
+ * Unit tests for {@link AuthProviderUtils#extractAuthProvider(PinotConfiguration, String)}.
+ *
+ * <p>These tests specifically guard against a regression where the controller segment-fetcher auth
+ * token was silently ignored because callers used the wrong config key prefix. The correct key for
+ * the controller is {@code pinot.controller.segment.fetcher.auth.token}; the wrong (legacy) key
+ * {@code controller.segment.fetcher.auth.token} must NOT produce an auth header.
+ */
+public class AuthProviderUtilsTest {
+
+  private static final String CONTROLLER_SEGMENT_FETCHER_AUTH_NAMESPACE =
+      "pinot.controller.segment.fetcher.auth";
+
+  @Test
+  public void testCorrectKeyProducesAuthHeader() {
+    Map<String, Object> props = new HashMap<>();
+    props.put("pinot.controller.segment.fetcher.auth.token", "my-secret-token");
+    PinotConfiguration config = new PinotConfiguration(props);
+
+    AuthProvider authProvider =
+        AuthProviderUtils.extractAuthProvider(config, CONTROLLER_SEGMENT_FETCHER_AUTH_NAMESPACE);
+
+    Map<String, Object> headers = authProvider.getRequestHeaders();
+    assertNotNull(headers, "Auth headers must be present when correct key is used");
+    assertTrue(headers.containsValue("my-secret-token"),
+        "Token value must appear in request headers");
+  }
+
+  @Test
+  public void testWrongKeyProducesNoAuthHeader() {
+    // Old / wrong key that lacks the "pinot." prefix — must NOT be picked up
+    Map<String, Object> props = new HashMap<>();
+    props.put("controller.segment.fetcher.auth.token", "should-be-ignored");
+    PinotConfiguration config = new PinotConfiguration(props);
+
+    AuthProvider authProvider =
+        AuthProviderUtils.extractAuthProvider(config, CONTROLLER_SEGMENT_FETCHER_AUTH_NAMESPACE);
+
+    Map<String, Object> headers = authProvider.getRequestHeaders();
+    assertTrue(headers == null || headers.isEmpty(),
+        "Wrong key must not produce auth headers; got: " + headers);
+  }
+
+  @Test
+  public void testNullConfigProducesNoAuthHeader() {
+    AuthProvider authProvider =
+        AuthProviderUtils.extractAuthProvider(null, CONTROLLER_SEGMENT_FETCHER_AUTH_NAMESPACE);
+
+    Map<String, Object> headers = authProvider.getRequestHeaders();
+    assertTrue(headers == null || headers.isEmpty(),
+        "Null config must produce no auth headers");
+  }
+}

--- a/pinot-common/src/test/java/org/apache/pinot/common/auth/AuthProviderUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/auth/AuthProviderUtilsTest.java
@@ -25,7 +25,6 @@ import org.apache.pinot.spi.env.PinotConfiguration;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerTest.java
@@ -1523,7 +1523,7 @@ public class ControllerTest {
     properties.put(ControllerConf.TABLE_MIN_REPLICAS, DEFAULT_MIN_NUM_REPLICAS);
 
     // Used in PinotControllerAppConfigsTest to test obfuscation
-    properties.put("controller.segment.fetcher.auth.token", "*personal*");
+    properties.put("pinot.controller.segment.fetcher.auth.token", "*personal*");
     properties.put("controller.admin.access.control.principals.user.password", "*personal*");
 
     return properties;

--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/BasicAuthTestUtils.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/BasicAuthTestUtils.java
@@ -27,14 +27,14 @@ public final class BasicAuthTestUtils {
   private BasicAuthTestUtils() {
   }
 
-  public static final String AUTH_TOKEN = "Basic YWRtaW46dmVyeXNlY3JldA=====";
+  public static final String AUTH_TOKEN = "Basic YWRtaW46dmVyeXNlY3JldA==";
   public static final String AUTH_TOKEN_USER = "Basic dXNlcjpzZWNyZXQ==";
   public static final Map<String, String> AUTH_HEADER = Map.of("Authorization", AUTH_TOKEN);
   public static final BasicHeader AUTH_HEADER_BASIC = new BasicHeader("Authorization", AUTH_TOKEN);
   public static final Map<String, String> AUTH_HEADER_USER = Map.of("Authorization", AUTH_TOKEN_USER);
 
   public static void addControllerConfiguration(Map<String, Object> properties) {
-    properties.put("controller.segment.fetcher.auth.token", AUTH_TOKEN);
+    properties.put("pinot.controller.segment.fetcher.auth.token", AUTH_TOKEN);
     properties.put("controller.admin.access.control.factory.class",
         "org.apache.pinot.controller.api.access.BasicAuthAccessControlFactory");
     properties.put("controller.admin.access.control.principals", "admin, user");
@@ -61,7 +61,7 @@ public final class BasicAuthTestUtils {
   }
 
   public static void addMinionConfiguration(PinotConfiguration minionConf) {
-    minionConf.setProperty("segment.fetcher.auth.token", AUTH_TOKEN);
-    minionConf.setProperty("task.auth.token", AUTH_TOKEN);
+    minionConf.setProperty("pinot.minion.segment.fetcher.auth.token", AUTH_TOKEN);
+    minionConf.setProperty("pinot.minion.task.auth.token", AUTH_TOKEN);
   }
 }

--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/BasicAuthTestUtils.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/BasicAuthTestUtils.java
@@ -33,6 +33,15 @@ public final class BasicAuthTestUtils {
   public static final BasicHeader AUTH_HEADER_BASIC = new BasicHeader("Authorization", AUTH_TOKEN);
   public static final Map<String, String> AUTH_HEADER_USER = Map.of("Authorization", AUTH_TOKEN_USER);
 
+  /**
+   * Applies BasicAuth configuration for the controller component.
+   *
+   * <p>The segment fetcher auth token uses the {@code pinot.controller.segment.fetcher.*} prefix,
+   * consistent with {@code CommonConstants.Controller.PREFIX_OF_CONFIG_OF_SEGMENT_FETCHER_FACTORY}.
+   * Note: the previously documented key {@code controller.segment.fetcher.auth.token} (without the
+   * {@code pinot.} prefix) was never functional — it was silently ignored by the controller's
+   * segment fetcher factory.
+   */
   public static void addControllerConfiguration(Map<String, Object> properties) {
     properties.put("pinot.controller.segment.fetcher.auth.token", AUTH_TOKEN);
     properties.put("controller.admin.access.control.factory.class",
@@ -60,6 +69,20 @@ public final class BasicAuthTestUtils {
     serverConf.setProperty("pinot.server.instance.auth.token", AUTH_TOKEN);
   }
 
+  /**
+   * Applies BasicAuth configuration for the minion component.
+   *
+   * <p>Two auth token keys are set:
+   * <ul>
+   *   <li>{@code pinot.minion.segment.fetcher.auth.token} — used by the segment fetcher factory
+   *       ({@code CommonConstants.Minion.PREFIX_OF_CONFIG_OF_SEGMENT_FETCHER_FACTORY}).</li>
+   *   <li>{@code pinot.minion.task.auth.token} — used by minion tasks to call protected controller
+   *       APIs ({@code CommonConstants.Minion.CONFIG_TASK_AUTH_NAMESPACE}).</li>
+   * </ul>
+   * Note: the previous keys {@code segment.fetcher.auth.token} and {@code task.auth.token}
+   * (without the {@code pinot.minion.} prefix) are deprecated. Existing deployments using those
+   * keys will still work but will receive a deprecation warning at startup.
+   */
   public static void addMinionConfiguration(PinotConfiguration minionConf) {
     minionConf.setProperty("pinot.minion.segment.fetcher.auth.token", AUTH_TOKEN);
     minionConf.setProperty("pinot.minion.task.auth.token", AUTH_TOKEN);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BasicAuthBatchIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BasicAuthBatchIntegrationTest.java
@@ -229,8 +229,10 @@ public class BasicAuthBatchIntegrationTest extends ClusterTest {
     // The segment download URL is auth-protected (BasicAuth is enabled on the controller).
     // The controller will fetch from this URL using SegmentFetcherFactory, which must be
     // initialized with pinot.controller.segment.fetcher.auth.token to pass credentials.
+    // NOTE: the download endpoint stores and looks up segment files by rawTableName ("baseballStats"),
+    // not by tableNameWithType ("baseballStats_OFFLINE"), so we use rawTableName in the URL.
     String segmentDownloadUrl =
-        "http://localhost:" + getControllerPort() + "/segments/baseballStats_OFFLINE/" + segmentName;
+        "http://localhost:" + getControllerPort() + "/segments/baseballStats/" + segmentName;
 
     // Pass tableName as a URL query parameter directly in the URI.
     // ClassicRequestBuilder.addParameter() adds form data to the POST body, but the controller's

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BasicAuthBatchIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BasicAuthBatchIntegrationTest.java
@@ -32,9 +32,7 @@ import java.util.Map;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.hc.core5.http.Header;
-import org.apache.hc.core5.http.NameValuePair;
 import org.apache.hc.core5.http.message.BasicHeader;
-import org.apache.hc.core5.http.message.BasicNameValuePair;
 import org.apache.pinot.common.auth.AuthProviderUtils;
 import org.apache.pinot.common.exception.HttpErrorStatusException;
 import org.apache.pinot.common.utils.FileUploadDownloadClient;
@@ -234,14 +232,17 @@ public class BasicAuthBatchIntegrationTest extends ClusterTest {
     String segmentDownloadUrl =
         "http://localhost:" + getControllerPort() + "/segments/baseballStats_OFFLINE/" + segmentName;
 
-    URI uploadUri = URI.create("http://localhost:" + getControllerPort() + "/v2/segments");
+    // Pass tableName as a URL query parameter directly in the URI.
+    // ClassicRequestBuilder.addParameter() adds form data to the POST body, but the controller's
+    // FineGrainedAuthUtils reads uriInfo.getQueryParameters() (URL query string only), so
+    // parameters must be embedded in the URI rather than passed as form params.
+    URI uploadUri = URI.create(
+        "http://localhost:" + getControllerPort() + "/v2/segments?tableName=baseballStats");
     List<Header> authHeaders = Arrays.asList(new BasicHeader("Authorization", AUTH_TOKEN));
-    List<NameValuePair> params =
-        Arrays.asList(new BasicNameValuePair(FileUploadDownloadClient.QueryParameters.TABLE_NAME, "baseballStats"));
 
     try (FileUploadDownloadClient fileUploadDownloadClient = new FileUploadDownloadClient()) {
       int statusCode =
-          fileUploadDownloadClient.sendSegmentUri(uploadUri, segmentDownloadUrl, authHeaders, params,
+          fileUploadDownloadClient.sendSegmentUri(uploadUri, segmentDownloadUrl, authHeaders, null,
               HttpClient.DEFAULT_SOCKET_TIMEOUT_MS).getStatusCode();
       Assert.assertEquals(statusCode, 200,
           "Controller should successfully fetch segment from auth-protected URI using configured auth token");

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BasicAuthBatchIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BasicAuthBatchIntegrationTest.java
@@ -24,12 +24,23 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
+import org.apache.hc.core5.http.Header;
+import org.apache.hc.core5.http.NameValuePair;
+import org.apache.hc.core5.http.message.BasicHeader;
+import org.apache.hc.core5.http.message.BasicNameValuePair;
 import org.apache.pinot.common.auth.AuthProviderUtils;
 import org.apache.pinot.common.exception.HttpErrorStatusException;
+import org.apache.pinot.common.utils.FileUploadDownloadClient;
+import org.apache.pinot.common.utils.http.HttpClient;
+import org.apache.pinot.controller.helix.core.minion.generator.PinotTaskGenerator;
+import org.apache.pinot.minion.executor.PinotTaskExecutor;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.tools.BootstrapTableTool;
@@ -182,6 +193,58 @@ public class BasicAuthBatchIntegrationTest extends ClusterTest {
     } catch (IOException e) {
       HttpErrorStatusException httpErrorStatusException = (HttpErrorStatusException) e.getCause();
       Assert.assertEquals(httpErrorStatusException.getStatusCode(), 403, "must return 403");
+    }
+  }
+
+  /**
+   * Verifies that the controller's segment fetcher auth token ({@code pinot.controller.segment.fetcher.auth.token})
+   * is correctly used when the controller fetches a segment via URI.
+   *
+   * <p>The controller's {@code SegmentFetcherFactory} is initialized with this token at startup.
+   * When a segment is uploaded via a download URI pointing to an auth-protected endpoint (such as
+   * the controller's own segment download endpoint), the fetcher must present the configured token
+   * or the fetch will fail with HTTP 401.
+   *
+   * <p>If the config key were wrong (e.g. the old {@code controller.segment.fetcher.auth.token}
+   * without the {@code pinot.} prefix), the fetcher would initialize without credentials, the
+   * controller-to-controller download would return 401, and this test would fail.
+   */
+  @Test(dependsOnMethods = "testIngestionBatch")
+  public void testControllerSegmentFetcherUsesAuthToken()
+      throws Exception {
+    // List segments in the baseballStats_OFFLINE table (populated by testIngestionBatch).
+    // The response format is: [{"OFFLINE": ["seg1", "seg2"]}, ...]
+    JsonNode segmentSets = JsonUtils.stringToJsonNode(
+        sendGetRequest("http://localhost:" + getControllerPort() + "/segments/baseballStats_OFFLINE", AUTH_HEADER));
+    Assert.assertTrue(segmentSets.isArray() && segmentSets.size() > 0, "Expected at least one segment set");
+
+    // Extract any offline segment name
+    String segmentName = null;
+    for (JsonNode segmentSet : segmentSets) {
+      if (segmentSet.has("OFFLINE") && segmentSet.get("OFFLINE").size() > 0) {
+        segmentName = segmentSet.get("OFFLINE").get(0).asText();
+        break;
+      }
+    }
+    Assert.assertNotNull(segmentName, "Could not find any offline segment in baseballStats_OFFLINE");
+
+    // The segment download URL is auth-protected (BasicAuth is enabled on the controller).
+    // The controller will fetch from this URL using SegmentFetcherFactory, which must be
+    // initialized with pinot.controller.segment.fetcher.auth.token to pass credentials.
+    String segmentDownloadUrl =
+        "http://localhost:" + getControllerPort() + "/segments/baseballStats_OFFLINE/" + segmentName;
+
+    URI uploadUri = URI.create("http://localhost:" + getControllerPort() + "/v2/segments");
+    List<Header> authHeaders = Arrays.asList(new BasicHeader("Authorization", AUTH_TOKEN));
+    List<NameValuePair> params =
+        Arrays.asList(new BasicNameValuePair(FileUploadDownloadClient.QueryParameters.TABLE_NAME, "baseballStats"));
+
+    try (FileUploadDownloadClient fileUploadDownloadClient = new FileUploadDownloadClient()) {
+      int statusCode =
+          fileUploadDownloadClient.sendSegmentUri(uploadUri, segmentDownloadUrl, authHeaders, params,
+              HttpClient.DEFAULT_SOCKET_TIMEOUT_MS).getStatusCode();
+      Assert.assertEquals(statusCode, 200,
+          "Controller should successfully fetch segment from auth-protected URI using configured auth token");
     }
   }
 }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/RowLevelSecurityIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/RowLevelSecurityIntegrationTest.java
@@ -56,7 +56,7 @@ public class RowLevelSecurityIntegrationTest extends BaseClusterIntegrationTest 
 
   @Override
   protected void overrideControllerConf(Map<String, Object> properties) {
-    properties.put("controller.segment.fetcher.auth.token", AUTH_TOKEN);
+    properties.put("pinot.controller.segment.fetcher.auth.token", AUTH_TOKEN);
     properties.put("controller.admin.access.control.factory.class",
         "org.apache.pinot.controller.api.access.BasicAuthAccessControlFactory");
     properties.put("controller.admin.access.control.principals", "admin, user, user2");

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/BaseMinionStarter.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/BaseMinionStarter.java
@@ -251,8 +251,26 @@ public abstract class BaseMinionStarter implements ServiceStartable {
     }
 
     // initialize authentication
-    minionContext.setTaskAuthProvider(
-        AuthProviderUtils.extractAuthProvider(_config, CommonConstants.Minion.CONFIG_TASK_AUTH_NAMESPACE));
+    // Try the new namespace first; fall back to the legacy "task.auth" namespace for backward compatibility.
+    PinotConfiguration taskAuthConfig = _config.subset(CommonConstants.Minion.CONFIG_TASK_AUTH_NAMESPACE);
+    if (taskAuthConfig.isEmpty()) {
+      PinotConfiguration deprecatedTaskAuthConfig =
+          _config.subset(CommonConstants.Minion.DEPRECATED_CONFIG_TASK_AUTH_NAMESPACE);
+      if (!deprecatedTaskAuthConfig.isEmpty()) {
+        LOGGER.warn("Minion task auth is configured under the deprecated namespace '{}'. "
+                + "Please migrate to the new namespace '{}'.",
+            CommonConstants.Minion.DEPRECATED_CONFIG_TASK_AUTH_NAMESPACE,
+            CommonConstants.Minion.CONFIG_TASK_AUTH_NAMESPACE);
+        minionContext.setTaskAuthProvider(AuthProviderUtils.extractAuthProvider(_config,
+            CommonConstants.Minion.DEPRECATED_CONFIG_TASK_AUTH_NAMESPACE));
+      } else {
+        minionContext.setTaskAuthProvider(
+            AuthProviderUtils.extractAuthProvider(_config, CommonConstants.Minion.CONFIG_TASK_AUTH_NAMESPACE));
+      }
+    } else {
+      minionContext.setTaskAuthProvider(
+          AuthProviderUtils.extractAuthProvider(_config, CommonConstants.Minion.CONFIG_TASK_AUTH_NAMESPACE));
+    }
 
     // Start all components
     LOGGER.info("Initializing PinotFSFactory");

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/BaseMinionStarter.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/BaseMinionStarter.java
@@ -250,8 +250,11 @@ public abstract class BaseMinionStarter implements ServiceStartable {
       TlsUtils.installDefaultSSLSocketFactory(tlsDefaults);
     }
 
-    // initialize authentication
-    // Try the new namespace first; fall back to the legacy "task.auth" namespace for backward compatibility.
+    // Initialize task authentication.
+    // Prefer the current namespace (pinot.minion.task.auth.*). If nothing is configured there,
+    // fall back to the deprecated namespace (task.auth.*) for deployments that have not yet
+    // migrated their config files, and log a warning so operators know migration is needed.
+    // See CommonConstants.Minion.DEPRECATED_CONFIG_TASK_AUTH_NAMESPACE for migration instructions.
     PinotConfiguration taskAuthConfig = _config.subset(CommonConstants.Minion.CONFIG_TASK_AUTH_NAMESPACE);
     if (taskAuthConfig.isEmpty()) {
       PinotConfiguration deprecatedTaskAuthConfig =

--- a/pinot-minion/src/test/java/org/apache/pinot/minion/MinionConfTest.java
+++ b/pinot-minion/src/test/java/org/apache/pinot/minion/MinionConfTest.java
@@ -72,4 +72,51 @@ public class MinionConfTest {
     Assert.assertEquals(subcfg.subset("class").getProperty("nooppinotcrypter"),
         "org.apache.pinot.core.crypt.NoOpPinotCrypter");
   }
+
+  /**
+   * Verifies backward compatibility for the task auth namespace rename.
+   *
+   * <p>Prior to this change, minion task auth was configured under the {@code task.auth} namespace
+   * (e.g. {@code task.auth.token=Basic ...}). It has been renamed to
+   * {@code pinot.minion.task.auth} for consistency with other component prefixes.
+   *
+   * <p>This test checks that:
+   * <ul>
+   *   <li>The old {@code task.auth.*} keys are NOT picked up under the new namespace, so existing
+   *       configs that have not yet been migrated are detectable.</li>
+   *   <li>The new {@code pinot.minion.task.auth.*} keys ARE resolved under the new namespace.</li>
+   * </ul>
+   *
+   * <p>The runtime fallback that reads {@code DEPRECATED_CONFIG_TASK_AUTH_NAMESPACE} when the new
+   * namespace is empty is exercised in {@link org.apache.pinot.minion.BaseMinionStarter}.
+   */
+  @Test
+  public void testDeprecatedTaskAuthNamespace()
+      throws ConfigurationException {
+    // Old config: task.auth.token (deprecated namespace, no pinot.minion prefix)
+    PropertiesConfiguration oldRaw = CommonsConfigurationUtils.fromPath(
+        PropertiesConfiguration.class.getClassLoader().getResource("pinot-configuration-old-minion.properties")
+            .getFile());
+    MinionConf oldConfig = new MinionConf(new PinotConfiguration(oldRaw).toMap());
+
+    // The deprecated "task.auth" namespace resolves the token.
+    Assert.assertFalse(oldConfig.subset(CommonConstants.Minion.DEPRECATED_CONFIG_TASK_AUTH_NAMESPACE).isEmpty(),
+        "Deprecated task.auth namespace must resolve in old-style config");
+    // The new "pinot.minion.task.auth" namespace does NOT find the token (migration is pending).
+    Assert.assertTrue(oldConfig.subset(CommonConstants.Minion.CONFIG_TASK_AUTH_NAMESPACE).isEmpty(),
+        "New pinot.minion.task.auth namespace must be empty for old-style config");
+
+    // New config: pinot.minion.task.auth.token (current namespace)
+    PropertiesConfiguration newRaw = CommonsConfigurationUtils.fromPath(
+        PropertiesConfiguration.class.getClassLoader().getResource("pinot-configuration-new-minion.properties")
+            .getFile());
+    MinionConf newConfig = new MinionConf(new PinotConfiguration(newRaw).toMap());
+
+    // The new "pinot.minion.task.auth" namespace resolves the token.
+    Assert.assertFalse(newConfig.subset(CommonConstants.Minion.CONFIG_TASK_AUTH_NAMESPACE).isEmpty(),
+        "New pinot.minion.task.auth namespace must resolve in new-style config");
+    // The deprecated "task.auth" namespace is empty (no stale keys).
+    Assert.assertTrue(newConfig.subset(CommonConstants.Minion.DEPRECATED_CONFIG_TASK_AUTH_NAMESPACE).isEmpty(),
+        "Deprecated task.auth namespace must be empty for new-style config");
+  }
 }

--- a/pinot-minion/src/test/resources/pinot-configuration-new-minion.properties
+++ b/pinot-minion/src/test/resources/pinot-configuration-new-minion.properties
@@ -22,3 +22,4 @@ pinot.minion.segment.fetcher.protocols=file,http,s3
 pinot.minion.segment.uploader.https.enabled=true
 pinot.minion.crypter.class.nooppinotcrypter=org.apache.pinot.core.crypt.NoOpPinotCrypter
 pinot.minion.metrics.prefix=pinot.minion.new.custom.metrics.
+pinot.minion.task.auth.token=Basic YWRtaW46dmVyeXNlY3JldA==

--- a/pinot-minion/src/test/resources/pinot-configuration-old-minion.properties
+++ b/pinot-minion/src/test/resources/pinot-configuration-old-minion.properties
@@ -22,3 +22,4 @@ segment.fetcher.protocols=file,http,s3
 segment.uploader.https.enabled=true
 crypter.class.nooppinotcrypter=org.apache.pinot.core.crypt.NoOpPinotCrypter
 metricsPrefix=pinot.minion.old.custom.metrics.
+task.auth.token=Basic YWRtaW46dmVyeXNlY3JldA==

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -1779,14 +1779,34 @@ public class CommonConstants {
     @Deprecated
     public static final String DEPRECATED_PREFIX_OF_CONFIG_OF_PINOT_CRYPTER = "crypter";
 
-    /// Service token for accessing protected controller APIs.
-    /// E.g. null (auth disabled), "Basic abcdef..." (basic auth), "Bearer 123def..." (oauth2)
-    public static final String CONFIG_TASK_AUTH_NAMESPACE = "pinot.minion.task.auth";
-    /// Legacy config namespace for task auth settings, superseded by [#CONFIG_TASK_AUTH_NAMESPACE].
-    /// Kept for backward compatibility: if no config is found under the new namespace, the minion
-    /// starter will fall back to this namespace and emit a deprecation warning.
+    /// Namespace prefix for minion task authentication settings. Used by
+    /// [org.apache.pinot.minion.BaseMinionStarter] to extract the
+    /// [org.apache.pinot.common.auth.AuthProvider] that minion tasks use when calling
+    /// protected controller APIs.
     ///
-    /// @deprecated Use [#CONFIG_TASK_AUTH_NAMESPACE] instead.
+    /// Example config key: `pinot.minion.task.auth.token=Basic YWRtaW46dmVyeXNlY3JldA==`
+    ///
+    /// Accepted token formats:
+    /// - absent / `null` — auth disabled
+    /// - `Basic <base64(user:password)>` — HTTP Basic auth
+    /// - `Bearer <token>` — OAuth2 bearer token
+    public static final String CONFIG_TASK_AUTH_NAMESPACE = "pinot.minion.task.auth";
+
+    /// Legacy namespace prefix for minion task auth settings, kept for backward compatibility.
+    ///
+    /// Before this change, minion task auth was configured under the unprefixed `task.auth`
+    /// namespace (e.g. `task.auth.token=Basic ...`). It has been renamed to
+    /// `pinot.minion.task.auth` (see [#CONFIG_TASK_AUTH_NAMESPACE]) for consistency
+    /// with the `pinot.<component>.*` convention used by controller and server.
+    ///
+    /// [org.apache.pinot.minion.BaseMinionStarter] reads [#CONFIG_TASK_AUTH_NAMESPACE]
+    /// first. When that namespace is empty, it falls back to this deprecated namespace and logs a
+    /// warning so operators know a config migration is needed.
+    ///
+    /// Migration: rename `task.auth.token` to `pinot.minion.task.auth.token` in your
+    /// minion configuration file.
+    ///
+    /// @deprecated Use [#CONFIG_TASK_AUTH_NAMESPACE] (`pinot.minion.task.auth`) instead.
     @Deprecated
     public static final String DEPRECATED_CONFIG_TASK_AUTH_NAMESPACE = "task.auth";
     public static final String MINION_TLS_PREFIX = "pinot.minion.tls";

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -1781,7 +1781,14 @@ public class CommonConstants {
 
     /// Service token for accessing protected controller APIs.
     /// E.g. null (auth disabled), "Basic abcdef..." (basic auth), "Bearer 123def..." (oauth2)
-    public static final String CONFIG_TASK_AUTH_NAMESPACE = "task.auth";
+    public static final String CONFIG_TASK_AUTH_NAMESPACE = "pinot.minion.task.auth";
+    /// Legacy config namespace for task auth settings, superseded by [#CONFIG_TASK_AUTH_NAMESPACE].
+    /// Kept for backward compatibility: if no config is found under the new namespace, the minion
+    /// starter will fall back to this namespace and emit a deprecation warning.
+    ///
+    /// @deprecated Use [#CONFIG_TASK_AUTH_NAMESPACE] instead.
+    @Deprecated
+    public static final String DEPRECATED_CONFIG_TASK_AUTH_NAMESPACE = "task.auth";
     public static final String MINION_TLS_PREFIX = "pinot.minion.tls";
     public static final String CONFIG_OF_MINION_QUERY_REWRITER_CLASS_NAMES = "pinot.minion.query.rewriter.class.names";
     public static final String CONFIG_OF_LOGGER_ROOT_DIR = "pinot.minion.logger.root.dir";

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/AuthZkBasicQuickstart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/AuthZkBasicQuickstart.java
@@ -58,8 +58,8 @@ public class AuthZkBasicQuickstart extends Quickstart {
     properties.put("pinot.server.segment.uploader.auth.token", "Basic YWRtaW46dmVyeXNlY3JldA==");
 
     // minion
-    properties.put("segment.fetcher.auth.token", "Basic YWRtaW46dmVyeXNlY3JldA==");
-    properties.put("task.auth.token", "Basic YWRtaW46dmVyeXNlY3JldA==");
+    properties.put("pinot.minion.segment.fetcher.auth.token", "Basic YWRtaW46dmVyeXNlY3JldA==");
+    properties.put("pinot.minion.task.auth.token", "Basic YWRtaW46dmVyeXNlY3JldA==");
 
     return properties;
   }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/utils/AuthUtils.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/utils/AuthUtils.java
@@ -58,8 +58,8 @@ public class AuthUtils {
     properties.put("pinot.server.instance.auth.token", DEFAULT_AUTH_TOKEN);
 
     // minion
-    properties.put("segment.fetcher.auth.token", DEFAULT_AUTH_TOKEN);
-    properties.put("task.auth.token", DEFAULT_AUTH_TOKEN);
+    properties.put("pinot.minion.segment.fetcher.auth.token", DEFAULT_AUTH_TOKEN);
+    properties.put("pinot.minion.task.auth.token", DEFAULT_AUTH_TOKEN);
 
     // loggers
     properties.put("pinot.controller.logger.root.dir", "logs");


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

PR updates BasicAuth token config keys for controller and minion, adds minion fallback, and shows usage in segment fetcher and task auth\.

```mermaid
flowchart TD
  N0["Controller config#58; pinot#46;controller#46;segment#46;fetcher#46;auth#46;token #40;F6#44; F7#44; F8#41;"]:::stAdded
  N1["AuthProviderUtils extracts controller auth #40;F5#41;"]:::stAdded
  N2["Controller segment fetcher adds Authorization header #40;F8#41;"]:::stAdded
  N3["Minion task auth config#58; pinot#46;minion#46;task#46;auth#46;token #40;F1#44; F2#44; F3#44; F4#44; F7#44; F10#44; F11#44; F12#41;"]:::stAdded
  N4["Fallback to deprecated task#46;auth namespace #40;F1#44; F2#41;"]:::stAdded
  N5["AuthProviderUtils extracts minion task auth #40;F1#41;"]:::stAdded
  N6["Minion context set task auth provider #40;F1#44; F2#41;"]:::stAdded
  N7["Minion task calls protected controller API with auth #40;F2#41;"]:::stAdded
  N0 --> N1
  N1 --> N2
  N3 --> N4
  N4 --> N5
  N3 --> N5
  N5 --> N6
  N6 --> N7
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-minion/src/main/java/org/apache/pinot/minion/BaseMinionStarter\.java — [before](https://github.com/apache/pinot/blob/62b42630a0b32998ca39d4c09a0114704b09367a/pinot-minion/src/main/java/org/apache/pinot/minion/BaseMinionStarter.java) · [after](https://github.com/apache/pinot/blob/36276e9c9cca302b3001e6e34886a72643e18e03/pinot-minion/src/main/java/org/apache/pinot/minion/BaseMinionStarter.java)
- F2: pinot\-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants\.java — [before](https://github.com/apache/pinot/blob/62b42630a0b32998ca39d4c09a0114704b09367a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java) · [after](https://github.com/apache/pinot/blob/36276e9c9cca302b3001e6e34886a72643e18e03/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java)
- F3: pinot\-tools/src/main/java/org/apache/pinot/tools/AuthZkBasicQuickstart\.java — [before](https://github.com/apache/pinot/blob/62b42630a0b32998ca39d4c09a0114704b09367a/pinot-tools/src/main/java/org/apache/pinot/tools/AuthZkBasicQuickstart.java) · [after](https://github.com/apache/pinot/blob/36276e9c9cca302b3001e6e34886a72643e18e03/pinot-tools/src/main/java/org/apache/pinot/tools/AuthZkBasicQuickstart.java)
- F4: pinot\-tools/src/main/java/org/apache/pinot/tools/utils/AuthUtils\.java — [before](https://github.com/apache/pinot/blob/62b42630a0b32998ca39d4c09a0114704b09367a/pinot-tools/src/main/java/org/apache/pinot/tools/utils/AuthUtils.java) · [after](https://github.com/apache/pinot/blob/36276e9c9cca302b3001e6e34886a72643e18e03/pinot-tools/src/main/java/org/apache/pinot/tools/utils/AuthUtils.java)
- F5: pinot\-common/src/test/java/org/apache/pinot/common/auth/AuthProviderUtilsTest\.java — [after](https://github.com/apache/pinot/blob/36276e9c9cca302b3001e6e34886a72643e18e03/pinot-common/src/test/java/org/apache/pinot/common/auth/AuthProviderUtilsTest.java)
- F6: pinot\-controller/src/test/java/org/apache/pinot/controller/helix/ControllerTest\.java — [before](https://github.com/apache/pinot/blob/62b42630a0b32998ca39d4c09a0114704b09367a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerTest.java) · [after](https://github.com/apache/pinot/blob/36276e9c9cca302b3001e6e34886a72643e18e03/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerTest.java)
- F7: pinot\-integration\-test\-base/src/test/java/org/apache/pinot/integration/tests/BasicAuthTestUtils\.java — [before](https://github.com/apache/pinot/blob/62b42630a0b32998ca39d4c09a0114704b09367a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/BasicAuthTestUtils.java) · [after](https://github.com/apache/pinot/blob/36276e9c9cca302b3001e6e34886a72643e18e03/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/BasicAuthTestUtils.java)
- F8: pinot\-integration\-tests/src/test/java/org/apache/pinot/integration/tests/BasicAuthBatchIntegrationTest\.java — [before](https://github.com/apache/pinot/blob/62b42630a0b32998ca39d4c09a0114704b09367a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BasicAuthBatchIntegrationTest.java) · [after](https://github.com/apache/pinot/blob/36276e9c9cca302b3001e6e34886a72643e18e03/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BasicAuthBatchIntegrationTest.java)
- F10: pinot\-minion/src/test/java/org/apache/pinot/minion/MinionConfTest\.java — [before](https://github.com/apache/pinot/blob/62b42630a0b32998ca39d4c09a0114704b09367a/pinot-minion/src/test/java/org/apache/pinot/minion/MinionConfTest.java) · [after](https://github.com/apache/pinot/blob/36276e9c9cca302b3001e6e34886a72643e18e03/pinot-minion/src/test/java/org/apache/pinot/minion/MinionConfTest.java)
- F11: pinot\-minion/src/test/resources/pinot\-configuration\-new\-minion\.properties — [before](https://github.com/apache/pinot/blob/62b42630a0b32998ca39d4c09a0114704b09367a/pinot-minion/src/test/resources/pinot-configuration-new-minion.properties) · [after](https://github.com/apache/pinot/blob/36276e9c9cca302b3001e6e34886a72643e18e03/pinot-minion/src/test/resources/pinot-configuration-new-minion.properties)
- F12: pinot\-minion/src/test/resources/pinot\-configuration\-old\-minion\.properties — [before](https://github.com/apache/pinot/blob/62b42630a0b32998ca39d4c09a0114704b09367a/pinot-minion/src/test/resources/pinot-configuration-old-minion.properties) · [after](https://github.com/apache/pinot/blob/36276e9c9cca302b3001e6e34886a72643e18e03/pinot-minion/src/test/resources/pinot-configuration-old-minion.properties)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjYyYjQyNjMwYTBiMzI5OThjYTM5ZDRjMDlhMDExNDcwNGIwOTM2N2EiLCJjb250ZXh0X2hhc2giOiIxYjUyMDMxMDQ3OTk5MmY0Y2U4MDRmZDZkMDNkYzVhY2Y5MGRiZGM3M2FmMmVhMTY4Nzk1MjRjZDE5NzVlYTc4IiwiZ2VuZXJhdGVkX2F0IjoxNzg5NTU4MDQ4LCJoZWFkX3NoYSI6IjM2Mjc2ZTljOWNjYTMwMmIzMDAxZTZlMzQ4ODZhNzI2NDNlMThlMDMiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiIwYzJmZDIzOWQ3ODhjN2UyMzM2NjA3MjMyMTY0YmQ1ZTg1ZjlmNzMwIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 176ca66259789dbc0deeae1be3a24bfa6368ef5cd5ce5aba797304357f87a0e0 -->
<!-- pinot-pr-flow:end -->



This commit establishes consistent BasicAuth token configuration naming across all Apache Pinot components:

- Controller: pinot.controller.segment.fetcher.auth.token (was controller.segment.fetcher.auth.token)
- Server: pinot.server.segment.fetcher.auth.token (already correct)
- Minion: pinot.minion.segment.fetcher.auth.token & pinot.minion.task.auth.token (were segment.fetcher.auth.token & task.auth.token)

Changes Made:
- Fixed BasicAuthTestUtils.java - corrected controller and minion token configurations
- Fixed ControllerTest.java - corrected obfuscation test configuration

Fixes #17506

Instructions:
1. The PR has to be tagged with at least one of the following labels (*):
   1. `feature`
   2. `bugfix`
   3. `performance`
   4. `ui`
   5. `backward-incompat`
   6. `release-notes` (**)
2. Remove these instructions before publishing the PR.
 
(*) Other labels to consider:
- `testing`
- `dependencies`
- `docker`
- `kubernetes`
- `observability`
- `security`
- `code-style`
- `extension-point`
- `refactor`
- `cleanup`

(**) Use `release-notes` label for scenarios like:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
