### PR TITLE
[ui] Added primary key icon for easy identification in schema view

### DIFF
--- a/pinot-controller/src/main/resources/app/utils/Utils.tsx
+++ b/pinot-controller/src/main/resources/app/utils/Utils.tsx
@@ -34,6 +34,8 @@ import Loading from '../components/Loading';
 import moment from "moment";
 import {RebalanceServerOption} from "../components/Homepage/Operations/RebalanceServer/RebalanceServerOptions";
 import { formatTimeInTimezone } from './TimezoneUtils';
+import VpnKeyIcon from '@material-ui/icons/VpnKey';
+import { Tooltip, Box } from '@material-ui/core';
 
 const getRebalanceConfigValue = (
     rebalanceConfig: { [optionName: string]: string | boolean | number },
@@ -316,11 +318,12 @@ const navigateToPreviousPage = (location, popTwice) => {
   return hasharr.join('/');
 };
 
-const syncTableSchemaData = (data, showFieldType) => {
+const syncTableSchemaData = (data, showFieldType, primaryKeyColumns?: string[]) => {
   const dimensionFields = data.dimensionFieldSpecs || [];
   const metricFields = data.metricFieldSpecs || [];
   const dateTimeField = data.dateTimeFieldSpecs || [];
   const complexFields = data.complexFieldSpecs || [];
+  const pkColumns = primaryKeyColumns || data.primaryKeyColumns || [];
 
   dimensionFields.map((field) => {
     field.fieldType = 'Dimension';
@@ -339,18 +342,37 @@ const syncTableSchemaData = (data, showFieldType) => {
   })
 
   const columnList = [...dimensionFields, ...metricFields, ...dateTimeField, ...complexFields];
+
+  const renderColumnName = (name: string) => {
+    const isPrimaryKey = pkColumns.includes(name);
+    if (isPrimaryKey) {
+      return {
+        customRenderer: (
+          <Box display="flex" alignItems="center">
+            <span>{name}</span>
+            <Tooltip title="Primary Key" arrow placement="top">
+              <VpnKeyIcon style={{ fontSize: 16, marginLeft: 4, color: '#f9a825' }} />
+            </Tooltip>
+          </Box>
+        ),
+        value: name
+      };
+    }
+    return name;
+  };
+
   if (showFieldType) {
     return {
       columns: ['Column', 'Type', 'Field Type', 'Multi Value'],
       records: columnList.map((field) => {
-        return [field.name, field.dataType, field.fieldType, getMultiValueField(field)];
+        return [renderColumnName(field.name), field.dataType, field.fieldType, getMultiValueField(field)];
       }),
     };
   }
   return {
     columns: ['Column', 'Type'],
     records: columnList.map((field) => {
-      return [field.name, field.dataType];
+      return [renderColumnName(field.name), field.dataType];
     }),
   };
 };


### PR DESCRIPTION
## Summary

While the current schema view in the table page in Pinot Controller has a few columns for each column denoting its metadata, there is no easy visual way to see if a column is a primary key or not (we need to toggle JSON to view the primary keys). This PR adds a key icon after the columns which are a part of the primary keys for that table.

## Testing

Successfully tested in Quickstart.
<img width="729" height="643" alt="Screenshot 2026-01-20 at 4 00 05 PM" src="https://github.com/user-attachments/assets/642de40d-1620-4c53-8d2f-0b84a9a10559" />
