### PR TITLE
TableNameExtractor: handle cases where CTE has same name as table

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/parser/TableNameExtractor.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/parser/TableNameExtractor.java
@@ -146,14 +146,15 @@ public class TableNameExtractor {
   }
 
   private void visitWithItem(SqlWithItem withItem) {
-    // Track the CTE name so we don't treat it as a table later
+    // Extract table names from the CTE query definition before adding the CTE alias to
+    // filter. This handles cases where the CTE has the same name as the original table.
+    // Otherwise the table won't be added to the result.
+    if (withItem.query != null) {
+      extractTableNames(withItem.query);
+    }
     if (withItem.name != null) {
       String cteName = withItem.name.getSimple();
       _cteNames.add(cteName);
-    }
-    // Extract table names from the CTE query definition, not the CTE alias
-    if (withItem.query != null) {
-      extractTableNames(withItem.query);
     }
   }
 

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/parser/TableNameExtractorTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/parser/TableNameExtractorTest.java
@@ -181,6 +181,21 @@ public class TableNameExtractorTest {
   }
 
   @Test
+  public void testResolveTableNameWithCTESameNameAsTable() {
+    // Test when CTE has the same name as the table it references (shadowing case)
+    String cteQuery = "WITH users AS ("
+        + "  SELECT * FROM users WHERE active = true"
+        + ") "
+        + "SELECT * FROM users";
+
+    String[] tableNames = TableNameExtractor.resolveTableName(cteQuery);
+
+    assertNotNull(tableNames, "Table names should not be null");
+    assertEquals(tableNames.length, 1, "Should resolve exactly one table");
+    assertEquals(tableNames[0], "users", "Should resolve the actual table name when CTE has same name");
+  }
+
+  @Test
   public void testResolveTableNameWithSubqueryAlias() {
     // Test with subquery alias
     String subqueryQuery = "SELECT t.name FROM (SELECT * FROM users WHERE active = true) AS t "


### PR DESCRIPTION
we're using this code in a library and noticed it didn't handle extracting table names when the CTE name is the same as the table name. this example query would return no table names in the result, but is considered a valid query in pinot.

```sql
WITH users AS (
  SELECT * FROM users WHERE active = true"
)
SELECT * FROM users;
```

cc @xiangfu0 @Jackie-Jiang 