### PR TITLE
fix: align ZooKeeper port in config files with documentation (#16674)

### DIFF
--- a/pinot-tools/src/main/resources/conf/pinot-broker.conf
+++ b/pinot-tools/src/main/resources/conf/pinot-broker.conf
@@ -24,7 +24,7 @@ pinot.service.role=BROKER
 pinot.cluster.name=pinot-quickstart
 
 # Pinot Zookeeper Server
-pinot.zk.server=localhost:2181
+pinot.zk.server=localhost:2191
 
 # Use hostname as Pinot Instance ID other than IP
 pinot.set.instance.id.to.hostname=true

--- a/pinot-tools/src/main/resources/conf/pinot-controller.conf
+++ b/pinot-tools/src/main/resources/conf/pinot-controller.conf
@@ -24,7 +24,7 @@ pinot.service.role=CONTROLLER
 pinot.cluster.name=pinot-quickstart
 
 # Pinot Zookeeper Server
-pinot.zk.server=localhost:2181
+pinot.zk.server=localhost:2191
 
 # Use hostname as Pinot Instance ID other than IP
 pinot.set.instance.id.to.hostname=true

--- a/pinot-tools/src/main/resources/conf/pinot-minion.conf
+++ b/pinot-tools/src/main/resources/conf/pinot-minion.conf
@@ -24,7 +24,7 @@ pinot.service.role=MINION
 pinot.cluster.name=pinot-quickstart
 
 # Pinot Zookeeper Server
-pinot.zk.server=localhost:2181
+pinot.zk.server=localhost:2191
 
 # Use hostname as Pinot Instance ID other than IP
 pinot.set.instance.id.to.hostname=true

--- a/pinot-tools/src/main/resources/conf/pinot-server.conf
+++ b/pinot-tools/src/main/resources/conf/pinot-server.conf
@@ -24,7 +24,7 @@ pinot.service.role=SERVER
 pinot.cluster.name=pinot-quickstart
 
 # Pinot Zookeeper Server
-pinot.zk.server=localhost:2181
+pinot.zk.server=localhost:2191
 
 # Use hostname as Pinot Instance ID other than IP
 pinot.set.instance.id.to.hostname=true


### PR DESCRIPTION
## Which issue does this PR close?                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                     
  Closes #16674                                                                                                                                                                                                                                      
                                                                                                                                                                                                                                                     
  ## Rationale for this change                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                     
  The quickstart documentation instructs users to start ZooKeeper on port 2191, but all configuration files were configured to use port 2181. This port mismatch caused confusion and failures for new users following the quickstart guide.         
                                                                                                                                                                                                                                                     
  ## What changes are included in this PR?                                                                                                                                                                                                           
                                                                                                                                                                                                                                                     
  Update ZooKeeper port from 2181 to 2191 in all quickstart configuration files to match the documentation and avoid confusion for new users.                                                                                                        
                                                                                                                                                                                                                                                     
  This fixes the port mismatch that was causing quickstart setup failures when users followed the documented instructions.                                                                                                                           
                                                                                                                                                                                                                                                     
  **Changed files:**                                                                                                                                                                                                                                 
  - `pinot-tools/src/main/resources/conf/pinot-broker.conf`                                                                                                                                                                                          
  - `pinot-tools/src/main/resources/conf/pinot-controller.conf`                                                                                                                                                                                      
  - `pinot-tools/src/main/resources/conf/pinot-minion.conf`                                                                                                                                                                                          
  - `pinot-tools/src/main/resources/conf/pinot-server.conf`                                                                                                                                                                                          
                                                                                                                                                                                                                                                     
  ## Are these changes tested?                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                     
  This is a configuration alignment fix. The changes ensure that:                                                                                                                                                                                    
  1. Users following the documentation will have a working quickstart setup                                                                                                                                                                          
  2. ZooKeeper port is consistent across all component configurations                                                                                                                                                                                
  3. No code logic changes - only configuration values updated