### PR TITLE
freshness checkers uses minimum ingestion lag

### DIFF
--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/SegmentMetadata.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/SegmentMetadata.java
@@ -95,6 +95,15 @@ public interface SegmentMetadata {
    */
   long getLatestIngestionTimestamp();
 
+  /**
+   * Return the minimum ingestion lag recorded for this segment. Ingestion lag is
+   * the difference between the record ingestion timestamp and current system time.
+   * Applicable for MutableSegments.
+   *
+   * @return minimum ingestion lag recorded for this segment
+   */
+  long getMinimumIngestionLagMs();
+
   @Nullable
   List<StarTreeV2Metadata> getStarTreeV2MetadataList();
 

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/metadata/SegmentMetadataImpl.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/metadata/SegmentMetadataImpl.java
@@ -438,6 +438,11 @@ public class SegmentMetadataImpl implements SegmentMetadata {
     return Long.MIN_VALUE;
   }
 
+  @Override
+  public long getMinimumIngestionLagMs() {
+    return Long.MAX_VALUE;
+  }
+
   @Nullable
   @Override
   public List<StarTreeV2Metadata> getStarTreeV2MetadataList() {


### PR DESCRIPTION
The freshness checker was something we added almost 4 years ago to better control ingestion lag as servers restarted. Since then, we've discovered using "latest" as the threshold led to unexpected results. Pinot ingestion is done in a fairly sawtooth pattern:
- request data from kafka
- transform
- index

The time spent transforming and indexing leads to lag which in turn leads to a sawtooth lag. For most use cases, this is imperceptible. The sawtooth amplitude will be seconds to milliseconds. But there are use cases where the sawtooth can have an extremely large amplitude (minutes or more):
- extremely slowness on Pinot or the upstream stream provider. this one is rare.
- transactional publishes upstream. This one is more common. If you have a flink app with a 1 minute checkpoint, the freshest data you see will at most be 1 minute old.  And if you're not sampling quickly enough in the freshness check, you may miss the case where the "latest" event was fresh enough.

All of that said, "minimum" freshness is really what we intended in the first place when making this feature. This issue was just exposed later.

We've run this internally at Stripe for over a year with no issue and no unexplained ingestion lag. I (and claude) finally had time now to reconcile these changes into an OSS PR.