### PR TITLE
[spi] Fix input format resolution inconsistency between PluginManager and RecordReaderFactory

### DIFF
--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/FileFormat.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/FileFormat.java
@@ -19,5 +19,21 @@
 package org.apache.pinot.spi.data.readers;
 
 public enum FileFormat {
-  AVRO, GZIPPED_AVRO, CSV, JSON, PINOT, THRIFT, PARQUET, ORC, PROTO, OTHER, PROTOBUF
+  AVRO, GZIPPED_AVRO, CSV, JSON, PINOT, THRIFT, PARQUET, ORC, PROTO, OTHER;
+
+  /**
+   * Converts an input format string to the corresponding FileFormat enum.
+   * Handles known aliases (e.g., "protobuf" -> PROTO).
+   *
+   * @param inputFormat the input format string (case-insensitive)
+   * @return the corresponding FileFormat
+   * @throws IllegalArgumentException if the format is unknown
+   */
+  public static FileFormat fromString(String inputFormat) {
+    // Handle known aliases (case-insensitive)
+    if ("protobuf".equalsIgnoreCase(inputFormat)) {
+      return PROTO;
+    }
+    return valueOf(inputFormat.toUpperCase());
+  }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/RecordReaderFactory.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/RecordReaderFactory.java
@@ -75,7 +75,7 @@ public class RecordReaderFactory {
     register(FileFormat.THRIFT, DEFAULT_THRIFT_RECORD_READER_CLASS, DEFAULT_THRIFT_RECORD_READER_CONFIG_CLASS);
     register(FileFormat.ORC, DEFAULT_ORC_RECORD_READER_CLASS, null);
     register(FileFormat.PARQUET, DEFAULT_PARQUET_RECORD_READER_CLASS, DEFAULT_PARQUET_RECORD_READER_CONFIG_CLASS);
-    register(FileFormat.PROTOBUF, DEFAULT_PROTO_RECORD_READER_CLASS, DEFAULT_PROTO_RECORD_READER_CONFIG_CLASS);
+    register(FileFormat.PROTO, DEFAULT_PROTO_RECORD_READER_CLASS, DEFAULT_PROTO_RECORD_READER_CONFIG_CLASS);
   }
 
   /**
@@ -177,20 +177,20 @@ public class RecordReaderFactory {
   }
 
   /**
-   * Get registered RecordReader class name given a file format.
+   * Get registered RecordReader class name given a file format string.
    *
-   * @param fileFormatStr
-   * @return recordReaderClassName
+   * @param fileFormatStr the file format string (case-insensitive)
+   * @return recordReaderClassName or null if not found
    */
   public static String getRecordReaderClassName(String fileFormatStr) {
     return DEFAULT_RECORD_READER_CLASS_MAP.get(fileFormatStr.toUpperCase());
   }
 
   /**
-   * Get registered RecordReaderConfig class name given a file format.
+   * Get registered RecordReaderConfig class name given a file format string.
    *
-   * @param fileFormatStr
-   * @return recordReaderConfigClassName
+   * @param fileFormatStr the file format string (case-insensitive)
+   * @return recordReaderConfigClassName or null if not found
    */
   public static String getRecordReaderConfigClassName(String fileFormatStr) {
     return DEFAULT_RECORD_READER_CONFIG_CLASS_MAP.get(fileFormatStr.toUpperCase());

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/BatchConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/BatchConfig.java
@@ -71,7 +71,7 @@ public class BatchConfig {
 
     String inputFormat = batchConfigsMap.get(BatchConfigProperties.INPUT_FORMAT);
     if (inputFormat != null) {
-      _inputFormat = FileFormat.valueOf(inputFormat.toUpperCase());
+      _inputFormat = FileFormat.fromString(inputFormat);
     } else {
       _inputFormat = null;
     }

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/data/readers/FileFormatTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/data/readers/FileFormatTest.java
@@ -1,0 +1,87 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.data.readers;
+
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+
+public class FileFormatTest {
+
+  @DataProvider(name = "validInputFormats")
+  public Object[][] validInputFormats() {
+    return new Object[][]{
+        {"avro", FileFormat.AVRO},
+        {"AVRO", FileFormat.AVRO},
+        {"Avro", FileFormat.AVRO},
+        {"gzipped_avro", FileFormat.GZIPPED_AVRO},
+        {"GZIPPED_AVRO", FileFormat.GZIPPED_AVRO},
+        {"csv", FileFormat.CSV},
+        {"CSV", FileFormat.CSV},
+        {"json", FileFormat.JSON},
+        {"JSON", FileFormat.JSON},
+        {"orc", FileFormat.ORC},
+        {"ORC", FileFormat.ORC},
+        {"parquet", FileFormat.PARQUET},
+        {"PARQUET", FileFormat.PARQUET},
+        {"proto", FileFormat.PROTO},
+        {"PROTO", FileFormat.PROTO},
+        {"protobuf", FileFormat.PROTO},
+        {"PROTOBUF", FileFormat.PROTO},
+        {"Protobuf", FileFormat.PROTO},
+        {"ProToBuF", FileFormat.PROTO},
+        {"thrift", FileFormat.THRIFT},
+        {"THRIFT", FileFormat.THRIFT},
+        {"pinot", FileFormat.PINOT},
+        {"PINOT", FileFormat.PINOT},
+        {"other", FileFormat.OTHER},
+        {"OTHER", FileFormat.OTHER}
+    };
+  }
+
+  @Test(dataProvider = "validInputFormats")
+  public void testFromString(String inputFormat, FileFormat expectedFileFormat) {
+    FileFormat actualFileFormat = FileFormat.fromString(inputFormat);
+    Assert.assertEquals(actualFileFormat, expectedFileFormat,
+        "FileFormat mismatch for input: " + inputFormat);
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testFromStringWithUnknownFormat() {
+    FileFormat.fromString("unknown");
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testFromStringWithEmptyString() {
+    FileFormat.fromString("");
+  }
+
+  @Test
+  public void testProtobufAlias() {
+    // Verify that "protobuf" is correctly aliased to PROTO
+    Assert.assertEquals(FileFormat.fromString("protobuf"), FileFormat.PROTO);
+    Assert.assertEquals(FileFormat.fromString("PROTOBUF"), FileFormat.PROTO);
+    Assert.assertEquals(FileFormat.fromString("Protobuf"), FileFormat.PROTO);
+
+    // Verify that "proto" also works
+    Assert.assertEquals(FileFormat.fromString("proto"), FileFormat.PROTO);
+    Assert.assertEquals(FileFormat.fromString("PROTO"), FileFormat.PROTO);
+  }
+}

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/data/readers/RecordReaderFactoryTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/data/readers/RecordReaderFactoryTest.java
@@ -22,6 +22,7 @@ import org.testng.annotations.Test;
 
 import static org.apache.pinot.spi.data.readers.RecordReaderFactory.*;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 
 
@@ -36,7 +37,7 @@ public class RecordReaderFactoryTest {
     assertEquals(getRecordReaderClassName("thrift"), DEFAULT_THRIFT_RECORD_READER_CLASS);
     assertEquals(getRecordReaderClassName("orc"), DEFAULT_ORC_RECORD_READER_CLASS);
     assertEquals(getRecordReaderClassName("parquet"), DEFAULT_PARQUET_RECORD_READER_CLASS);
-    assertEquals(getRecordReaderClassName("protobuf"), DEFAULT_PROTO_RECORD_READER_CLASS);
+    assertEquals(getRecordReaderClassName("proto"), DEFAULT_PROTO_RECORD_READER_CLASS);
   }
 
   @Test
@@ -48,6 +49,89 @@ public class RecordReaderFactoryTest {
     assertEquals(getRecordReaderConfigClassName("thrift"), DEFAULT_THRIFT_RECORD_READER_CONFIG_CLASS);
     assertNull(getRecordReaderConfigClassName("orc"));
     assertEquals(getRecordReaderConfigClassName("parquet"), DEFAULT_PARQUET_RECORD_READER_CONFIG_CLASS);
-    assertEquals(getRecordReaderConfigClassName("protobuf"), DEFAULT_PROTO_RECORD_READER_CONFIG_CLASS);
+    assertEquals(getRecordReaderConfigClassName("proto"), DEFAULT_PROTO_RECORD_READER_CONFIG_CLASS);
+  }
+
+  @Test
+  public void testGetRecordReaderClassNameWithUnknownFormat() {
+    // Unknown string formats should return null
+    // Note: "protobuf" is not registered directly - use FileFormat.fromString("protobuf") first
+    assertNull(getRecordReaderClassName("unknown"));
+    assertNull(getRecordReaderClassName("xml"));
+    assertNull(getRecordReaderClassName(""));
+    assertNull(getRecordReaderClassName("protobuf")); // Use FileFormat.fromString("protobuf") -> PROTO instead
+  }
+
+  @Test
+  public void testGetRecordReaderConfigClassNameWithUnknownFormat() {
+    // Unknown string formats should return null
+    assertNull(getRecordReaderConfigClassName("unknown"));
+    assertNull(getRecordReaderConfigClassName("xml"));
+    assertNull(getRecordReaderConfigClassName(""));
+    assertNull(getRecordReaderConfigClassName("protobuf")); // Use FileFormat.fromString("protobuf") -> PROTO instead
+  }
+
+  @Test
+  public void testGetRecordReaderClassNameCaseInsensitivity() {
+    // Test case insensitivity for string-based lookup (uses FileFormat enum names)
+    assertEquals(getRecordReaderClassName("AVRO"), DEFAULT_AVRO_RECORD_READER_CLASS);
+    assertEquals(getRecordReaderClassName("Avro"), DEFAULT_AVRO_RECORD_READER_CLASS);
+    assertEquals(getRecordReaderClassName("avro"), DEFAULT_AVRO_RECORD_READER_CLASS);
+    assertEquals(getRecordReaderClassName("CSV"), DEFAULT_CSV_RECORD_READER_CLASS);
+    assertEquals(getRecordReaderClassName("Csv"), DEFAULT_CSV_RECORD_READER_CLASS);
+    assertEquals(getRecordReaderClassName("PARQUET"), DEFAULT_PARQUET_RECORD_READER_CLASS);
+    assertEquals(getRecordReaderClassName("Parquet"), DEFAULT_PARQUET_RECORD_READER_CLASS);
+    assertEquals(getRecordReaderClassName("PROTO"), DEFAULT_PROTO_RECORD_READER_CLASS);
+    assertEquals(getRecordReaderClassName("Proto"), DEFAULT_PROTO_RECORD_READER_CLASS);
+  }
+
+  @Test
+  public void testGetRecordReaderConfigClassNameCaseInsensitivity() {
+    // Test case insensitivity for string-based lookup (uses FileFormat enum names)
+    assertEquals(getRecordReaderConfigClassName("AVRO"), DEFAULT_AVRO_RECORD_READER_CONFIG_CLASS);
+    assertEquals(getRecordReaderConfigClassName("Avro"), DEFAULT_AVRO_RECORD_READER_CONFIG_CLASS);
+    assertEquals(getRecordReaderConfigClassName("CSV"), DEFAULT_CSV_RECORD_READER_CONFIG_CLASS);
+    assertEquals(getRecordReaderConfigClassName("Csv"), DEFAULT_CSV_RECORD_READER_CONFIG_CLASS);
+    assertEquals(getRecordReaderConfigClassName("PROTO"), DEFAULT_PROTO_RECORD_READER_CONFIG_CLASS);
+    assertEquals(getRecordReaderConfigClassName("Proto"), DEFAULT_PROTO_RECORD_READER_CONFIG_CLASS);
+  }
+
+  @Test
+  public void testProtobufToProtoConversionFlow() {
+    // Demonstrate the intended flow: "protobuf" -> FileFormat.fromString() -> FileFormat.PROTO
+    // Then use FileFormat.PROTO with RecordReaderFactory
+    FileFormat fileFormat = FileFormat.fromString("protobuf");
+    assertEquals(fileFormat, FileFormat.PROTO);
+    assertEquals(getRecordReaderClassName(fileFormat.name()), DEFAULT_PROTO_RECORD_READER_CLASS);
+
+    // "proto" also works via FileFormat.fromString()
+    assertEquals(FileFormat.fromString("proto"), FileFormat.PROTO);
+    assertEquals(FileFormat.fromString("PROTO"), FileFormat.PROTO);
+  }
+
+  @Test
+  public void testDefaultClassConstants() {
+    // Verify the default class constants are set correctly
+    assertNotNull(DEFAULT_AVRO_RECORD_READER_CLASS);
+    assertNotNull(DEFAULT_CSV_RECORD_READER_CLASS);
+    assertNotNull(DEFAULT_JSON_RECORD_READER_CLASS);
+    assertNotNull(DEFAULT_THRIFT_RECORD_READER_CLASS);
+    assertNotNull(DEFAULT_ORC_RECORD_READER_CLASS);
+    assertNotNull(DEFAULT_PARQUET_RECORD_READER_CLASS);
+    assertNotNull(DEFAULT_PROTO_RECORD_READER_CLASS);
+
+    // Verify class name format
+    assertEquals(DEFAULT_AVRO_RECORD_READER_CLASS, "org.apache.pinot.plugin.inputformat.avro.AvroRecordReader");
+    assertEquals(DEFAULT_CSV_RECORD_READER_CLASS, "org.apache.pinot.plugin.inputformat.csv.CSVRecordReader");
+    assertEquals(DEFAULT_JSON_RECORD_READER_CLASS, "org.apache.pinot.plugin.inputformat.json.JSONRecordReader");
+    assertEquals(DEFAULT_PROTO_RECORD_READER_CLASS,
+        "org.apache.pinot.plugin.inputformat.protobuf.ProtoBufRecordReader");
+  }
+
+  @Test
+  public void testFileFormatPinotAndOther() {
+    // PINOT and OTHER formats don't have default record readers
+    assertNull(getRecordReaderClassName("PINOT"));
+    assertNull(getRecordReaderClassName("OTHER"));
   }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/ImportDataCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/ImportDataCommand.java
@@ -379,7 +379,6 @@ public class ImportDataCommand extends AbstractBaseAdminCommand implements Comma
         return "org.apache.pinot.plugin.inputformat.avro.AvroRecordReaderConfig";
       case CSV:
         return "org.apache.pinot.plugin.inputformat.csv.CSVRecordReaderConfig";
-      case PROTOBUF:
       case PROTO:
         return "org.apache.pinot.plugin.inputformat.protobuf.ProtoBufRecordReaderConfig";
       case THRIFT:
@@ -406,7 +405,6 @@ public class ImportDataCommand extends AbstractBaseAdminCommand implements Comma
         return "org.apache.pinot.plugin.inputformat.avro.AvroRecordReader";
       case PARQUET:
         return "org.apache.pinot.plugin.inputformat.parquet.ParquetRecordReader";
-      case PROTOBUF:
       case PROTO:
         return "org.apache.pinot.plugin.inputformat.protobuf.ProtoBufRecordReader";
       case THRIFT:

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/segment/converter/PinotSegmentConvertCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/segment/converter/PinotSegmentConvertCommand.java
@@ -124,7 +124,7 @@ public class PinotSegmentConvertCommand extends AbstractBaseCommand implements C
         String segmentName = entry.getKey();
         String inputPath = entry.getValue();
         String outputPath = new File(outputDir, segmentName).getAbsolutePath();
-        switch (FileFormat.valueOf(_outputFormat.toUpperCase())) {
+        switch (FileFormat.fromString(_outputFormat)) {
           case AVRO:
             outputPath += ".avro";
             new PinotSegmentToAvroConverter(inputPath, outputPath).convert();


### PR DESCRIPTION
### Issue(s)

Inconsistency between `FileFormat` enum and `PluginManager` input format mappings causing protobuf record reader lookup failures.

---

### Description

This pull request fixes a discrepancy between two parallel record reader registration mechanisms in Pinot.

**Background - Two Registration Systems:**

Pinot has two places that maintain record reader class name mappings:

1. **`RecordReaderFactory`** (uses `FileFormat` enum with UPPERCASE keys)
   - Used by: `SegmentIndexCreationDriverImpl`, `RecordReaderFileConfig`, `IngestionUtils`, CLI tools (`CreateSegmentCommand`), and most test classes
   - Purpose: Direct `RecordReader` instantiation via `getRecordReader(FileFormat, ...)`

2. **`PluginManager`** (uses lowercase string keys like `"protobuf"`)
   - Used by: `SegmentGenerationAndPushTaskGenerator`, `FileIngestionTaskConfigUtils`, `BatchTableSampler`, `DeltaTableIngestionTaskExecutor`
   - Purpose: Dynamic plugin loading and class name resolution for task configs

**The Problem:**

| Component | Protobuf Key | Lookup Method |
|-----------|--------------|---------------|
| `FileFormat` enum | `PROTO` | N/A (enum constant) |
| `PluginManager` | `"protobuf"` | `.toLowerCase()` |
| `RecordReaderFactory` | `"PROTO"` (from enum) | `.toUpperCase()` |

When code receives input format as `"protobuf"` or `"PROTOBUF"` (following PluginManager's convention) and tries to convert it to `FileFormat` via `FileFormat.valueOf()`, it fails because `FileFormat` only had `PROTO` as the enum constant.

This caused issues in components like `BatchTableSampler` where the input format string comes from task configs (using PluginManager's `"protobuf"` convention) but needs to be converted to `FileFormat` enum.

**Solution:**

Added `FileFormat.fromString()` adapter method that handles known aliases (e.g., `"protobuf"` → `PROTO`) with case-insensitive matching. Updated all places that convert input format strings to `FileFormat` to use this new method instead of `FileFormat.valueOf()`.

**Changes:**
- Added `FileFormat.fromString(String inputFormat)` method with "protobuf" → `PROTO` alias handling
- Updated `BatchConfig` to use `FileFormat.fromString()` instead of `FileFormat.valueOf()`
- Updated `PinotSegmentConvertCommand` to use `FileFormat.fromString()`

---

### Testing

- [x] UTs for `FileFormat.fromString()` (new `FileFormatTest.java`)
- [x] UTs for `RecordReaderFactory` (enhanced `RecordReaderFactoryTest.java`)
- [x] UTs for `PluginManager` (enhanced `PluginManagerTest.java`)