### PR TITLE
Adds a broker endpoint to validate query parsing without further validation/execution

### DIFF
--- a/pinot-broker/src/test/java/org/apache/pinot/broker/api/resources/PinotClientRequestTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/api/resources/PinotClientRequestTest.java
@@ -311,4 +311,35 @@ public class PinotClientRequestTest {
     assertEquals(sizeCaptor.getValue().longValue(), expectedSize,
         "Metric should record the actual response size in bytes");
   }
+
+  @Test
+  public void testPinotQueryValidationWithValidQuery() throws Exception {
+    String validQuery = "{\"sql\":\"SELECT * FROM myTable LIMIT 10\"}";
+    PinotClientRequest.QuerySyntaxValidationResponse response =
+            _pinotClientRequest.validateSqlQuerySyntaxPost(validQuery, _httpHeaders);
+
+    Assert.assertTrue(response.isValidQuerySyntax(), "Response value should be valid");
+    Assert.assertNull(response.getErrorMessage());
+    Assert.assertNull(response.getErrorCode());
+  }
+
+  @Test
+  public void testPinotQueryValidationWithInvalidQuery() throws Exception {
+    String invalidQuery = "{\"sql\":\"SELECT select FROM myTable LIMIT 10\"}";
+
+    PinotClientRequest.QuerySyntaxValidationResponse response =
+            _pinotClientRequest.validateSqlQuerySyntaxPost(invalidQuery, _httpHeaders);
+    Assert.assertFalse(response.isValidQuerySyntax(), "Response value should be invalid");
+    assertEquals(response.getErrorCode(), QueryErrorCode.SQL_PARSING);
+  }
+
+  @Test
+  public void testPinotQueryValidationWithInvalidRequestPayload() throws Exception {
+    String invalidQuery = "{\"query\":\"SELECT select FROM myTable LIMIT 10\"}";
+
+    PinotClientRequest.QuerySyntaxValidationResponse response =
+            _pinotClientRequest.validateSqlQuerySyntaxPost(invalidQuery, _httpHeaders);
+    Assert.assertFalse(response.isValidQuerySyntax(), "Response value should be invalid");
+    assertEquals(response.getErrorCode(), QueryErrorCode.JSON_PARSING);
+  }
 }


### PR DESCRIPTION
Addresses https://github.com/apache/pinot/issues/17615 , adding a broker API endpoint that parses a query string only for syntactic validation without further processing

### Testing
Tested the endpoint by running valid/invalid queries

Valid query: `curl -X POST "localhost:8000/query/sql/validateSyntax" \
  -H "Content-Type: application/json" \
  -d '{"sql": "SELECT * FROM meetupRsvp LIMIT 10"}'`
Result: `{"errorCode":null,"validQuery":true,"errorMessage":null}`

Valid query (non existent table): `curl -X POST "localhost:8000/query/sql/validateSyntax" \
  -H "Content-Type: application/json" \
  -d '{"sql": "SELECT * FROM xyz LIMIT 10"}'`
Result: `{"errorCode":null,"validQuery":true,"errorMessage":null}`

Invalid query (reserved keyword): `curl -X POST "localhost:8000/query/sql/validateSyntax" \
  -H "Content-Type: application/json" \
  -d '{
    "sql": "SELECT select FROM airlineStats a JOIN airports b ON a.destAirportCode = b.airportCode"
  }'`
Result: `{"errorCode":"SQL_PARSING","validQuery":false,"errorMessage":"Caught exception while parsing query: SELECT select FROM airlineStats a JOIN airports b ON a.destAirportCode = b.airportCode: Encountered \"\" at line 1, column 8.\nWas expecting one of:\n    "}`