### PR TITLE
[spi] Fix Asymmetric Serialization in TextIndexConfig

### DIFF
--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/TextIndexConfigTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/TextIndexConfigTest.java
@@ -121,4 +121,119 @@ public class TextIndexConfigTest {
     assertFalse(config.isLuceneUseCompoundFile(), "Unexpected luceneUseCompoundFile");
     assertEquals(config.getLuceneMaxBufferSizeMB(), 1024, "Unexpected luceneMaxBufferSize");
   }
+
+  @Test
+  public void testRoundTripSerializationWithArrayValues()
+      throws JsonProcessingException {
+    // This test verifies that TextIndexConfig can be round-tripped through JSON serialization.
+    // When serialized, luceneAnalyzerClassArgs/ArgTypes are output as arrays (from List<String> getters).
+    // When deserialized, the constructor must accept both String (CSV) and Array (List) formats.
+    final String confStrWithArrays = "{\n"
+        + "        \"disabled\": false,\n"
+        + "        \"luceneUseCompoundFile\": true,\n"
+        + "        \"luceneMaxBufferSizeMB\": 500,\n"
+        + "        \"luceneAnalyzerClass\": \"org.apache.lucene.analysis.standard.StandardAnalyzer\",\n"
+        + "        \"luceneAnalyzerClassArgs\": [],\n"
+        + "        \"luceneAnalyzerClassArgTypes\": []\n"
+        + "}";
+    final TextIndexConfig config = JsonUtils.stringToObject(confStrWithArrays, TextIndexConfig.class);
+
+    assertFalse(config.isDisabled(), "Unexpected disabled");
+    assertTrue(config.isLuceneUseCompoundFile(), "Unexpected luceneUseCompoundFile");
+    assertEquals(config.getLuceneMaxBufferSizeMB(), 500, "Unexpected luceneMaxBufferSizeMB");
+    assertEquals(config.getLuceneAnalyzerClass(),
+        "org.apache.lucene.analysis.standard.StandardAnalyzer", "Unexpected luceneAnalyzerClass");
+    assertTrue(config.getLuceneAnalyzerClassArgs().isEmpty(), "Unexpected luceneAnalyzerClassArgs");
+    assertTrue(config.getLuceneAnalyzerClassArgTypes().isEmpty(), "Unexpected luceneAnalyzerClassArgTypes");
+
+    // Now test with non-empty arrays
+    final String confStrWithNonEmptyArrays = "{\n"
+        + "        \"luceneAnalyzerClassArgs\": [\"arg1\", \"arg2\"],\n"
+        + "        \"luceneAnalyzerClassArgTypes\": [\"java.lang.String\", \"java.lang.Integer\"]\n"
+        + "}";
+    final TextIndexConfig configWithArgs = JsonUtils.stringToObject(confStrWithNonEmptyArrays, TextIndexConfig.class);
+
+    assertEquals(configWithArgs.getLuceneAnalyzerClassArgs(), Lists.newArrayList("arg1", "arg2"),
+        "Unexpected luceneAnalyzerClassArgs");
+    assertEquals(configWithArgs.getLuceneAnalyzerClassArgTypes(),
+        Lists.newArrayList("java.lang.String", "java.lang.Integer"),
+        "Unexpected luceneAnalyzerClassArgTypes");
+  }
+
+  @Test
+  public void testRoundTripSerializationWithStringValues()
+      throws JsonProcessingException {
+    // Test backward compatibility - original CSV string format should still work
+    final String confStrWithStrings = "{\n"
+        + "        \"luceneAnalyzerClassArgs\": \"arg1,arg2\",\n"
+        + "        \"luceneAnalyzerClassArgTypes\": \"java.lang.String,java.lang.Integer\"\n"
+        + "}";
+    final TextIndexConfig config = JsonUtils.stringToObject(confStrWithStrings, TextIndexConfig.class);
+
+    assertEquals(config.getLuceneAnalyzerClassArgs(), Lists.newArrayList("arg1", "arg2"),
+        "Unexpected luceneAnalyzerClassArgs");
+    assertEquals(config.getLuceneAnalyzerClassArgTypes(),
+        Lists.newArrayList("java.lang.String", "java.lang.Integer"),
+        "Unexpected luceneAnalyzerClassArgTypes");
+  }
+
+  @Test
+  public void testFullRoundTrip()
+      throws JsonProcessingException {
+    // Create config, serialize to JSON, deserialize back - should work
+    final String originalConfStr = "{\n"
+        + "        \"luceneAnalyzerClassArgs\": \"arg1,arg2\",\n"
+        + "        \"luceneAnalyzerClassArgTypes\": \"java.lang.String,java.lang.Integer\"\n"
+        + "}";
+    final TextIndexConfig originalConfig = JsonUtils.stringToObject(originalConfStr, TextIndexConfig.class);
+
+    // Serialize to JSON (getters return List<String>, so it becomes JSON arrays)
+    final String serialized = JsonUtils.objectToString(originalConfig);
+
+    // Deserialize back - this was the failing case before the fix
+    final TextIndexConfig deserializedConfig = JsonUtils.stringToObject(serialized, TextIndexConfig.class);
+
+    assertEquals(deserializedConfig.getLuceneAnalyzerClassArgs(), originalConfig.getLuceneAnalyzerClassArgs(),
+        "Round-trip failed for luceneAnalyzerClassArgs");
+    assertEquals(deserializedConfig.getLuceneAnalyzerClassArgTypes(), originalConfig.getLuceneAnalyzerClassArgTypes(),
+        "Round-trip failed for luceneAnalyzerClassArgTypes");
+  }
+
+  @Test
+  public void testEmptyTextConfigRoundTrip()
+      throws JsonProcessingException {
+    // When an empty text config is created from "{}", it gets default values.
+    // When serialized, luceneAnalyzerClassArgs becomes [] (empty array).
+    // When deserialized, this was failing with:
+    // "Cannot deserialize value of type `java.lang.String` from Array value"
+    final String emptyConfig = "{}";
+    final TextIndexConfig originalConfig = JsonUtils.stringToObject(emptyConfig, TextIndexConfig.class);
+
+    // Verify defaults are applied
+    assertFalse(originalConfig.isDisabled());
+    assertEquals(originalConfig.getLuceneAnalyzerClass(),
+        "org.apache.lucene.analysis.standard.StandardAnalyzer");
+    assertTrue(originalConfig.getLuceneAnalyzerClassArgs().isEmpty());
+    assertTrue(originalConfig.getLuceneAnalyzerClassArgTypes().isEmpty());
+
+    // Serialize to JSON - this produces the problematic format with empty arrays
+    final String serialized = JsonUtils.objectToString(originalConfig);
+
+    // Verify serialized JSON contains the array format that was causing the bug
+    assertTrue(serialized.contains("\"luceneAnalyzerClassArgs\":[]"),
+        "Serialized JSON should contain luceneAnalyzerClassArgs as empty array");
+    assertTrue(serialized.contains("\"luceneAnalyzerClassArgTypes\":[]"),
+        "Serialized JSON should contain luceneAnalyzerClassArgTypes as empty array");
+
+    // Deserialize back
+    final TextIndexConfig deserializedConfig = JsonUtils.stringToObject(serialized, TextIndexConfig.class);
+
+    // Verify round-trip preserves the config
+    assertEquals(deserializedConfig.isDisabled(), originalConfig.isDisabled());
+    assertEquals(deserializedConfig.getLuceneAnalyzerClass(), originalConfig.getLuceneAnalyzerClass());
+    assertEquals(deserializedConfig.getLuceneAnalyzerClassArgs(), originalConfig.getLuceneAnalyzerClassArgs());
+    assertEquals(deserializedConfig.getLuceneAnalyzerClassArgTypes(), originalConfig.getLuceneAnalyzerClassArgTypes());
+    assertEquals(deserializedConfig.isLuceneUseCompoundFile(), originalConfig.isLuceneUseCompoundFile());
+    assertEquals(deserializedConfig.getLuceneMaxBufferSizeMB(), originalConfig.getLuceneMaxBufferSizeMB());
+  }
 }


### PR DESCRIPTION
### Issue(s)

`TextIndexConfig` deserialization fails with `MismatchedInputException` when `luceneAnalyzerClassArgs` is serialized as JSON array instead of CSV string.

### Description

This pull request fixes an asymmetric serialization/deserialization issue in `TextIndexConfig` that causes failures when processing text index configurations.

**Background - The Serialization Asymmetry:**

`TextIndexConfig` has two fields that exhibit asymmetric behavior:
| Aspect | luceneAnalyzerClassArgs | luceneAnalyzerClassArgTypes |
|-----------|--------------|---------------|
| Constructor Input (@JsonCreator) | String (CSV format) | String (CSV format) |
| Internal Storage | List<String> | List<String> |
| Getter Output | List<String> | List<String> |
| JSON Serialization | [] (JSON array) | [] (JSON array) |

**The Problem**

When `TextIndexConfig` is round-tripped through JSON serialization:
```
Original Input: "arg1,arg2" (CSV String)
         ↓
    CsvParser.parse()
         ↓
Internal State: ["arg1", "arg2"] (List<String>)
         ↓
    Jackson Serialization (via getter)
         ↓
JSON Output: ["arg1", "arg2"] (JSON Array)
         ↓
    Jackson Deserialization (via constructor)
         ↓
FAILS! Constructor expects String, receives Array
```

**Solution:**

Modified the `@JsonCreator` constructor to accept `Object` type instead of `String` for both fields, with a helper method that handles both formats:

1. String input → Parsed using `CsvParser.parse()` (backward compatible with original CSV format)
2. List input → Used directly (handles round-trip scenario with JSON arrays)

### Testing

Added 4 new test cases:
- `testRoundTripSerializationWithArrayValue`s - Verifies JSON array input works
- `testRoundTripSerializationWithStringValues` - Verifies CSV string input still works (backward compatibility)
- `testFullRoundTrip` - Verifies serialize → deserialize works correctly
- `testEmptyTextConfigRoundTrip` - Reproduces the exact bug scenario with `"text": {}`
