### PR TITLE
Add configs when initing column reader factory

### DIFF
--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/ColumnReaderFactory.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/ColumnReaderFactory.java
@@ -42,6 +42,12 @@ import org.apache.pinot.spi.data.Schema;
 public interface ColumnReaderFactory extends Closeable, Serializable {
 
   /**
+   * Configuration key to enable random access mode for column readers.
+   * When set to "true", implementations may cache data to support non-sequential access patterns.
+   */
+  String CONFIG_ENABLE_RANDOM_ACCESS = "enableRandomAccess";
+
+  /**
    * Initialize the factory with the data source and target schema.
    *
    * @param targetSchema Target schema for the output segment
@@ -58,6 +64,18 @@ public interface ColumnReaderFactory extends Closeable, Serializable {
    */
   void init(Schema targetSchema, Set<String> colsToRead)
       throws IOException;
+
+  /**
+   * Initialize the factory with the data source, target schema, specific columns, and configuration.
+   * @param targetSchema Target schema for the output segment
+   * @param colsToRead Set of target columns to read
+   * @param configs Configuration map for implementation-specific settings
+   * @throws IOException If initialization fails
+   */
+  default void init(Schema targetSchema, Set<String> colsToRead, Map<String, String> configs)
+      throws IOException {
+    init(targetSchema, colsToRead);
+  }
 
   /**
    * Get the set of column names available in the source data.


### PR DESCRIPTION
Add a Configuration map for implementation-specific settings in ColumnReaderFactory initialisation