### PR TITLE
Wrong pinot.minion.tls.keystore.type in TLS Integration Test

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/TlsIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/TlsIntegrationTest.java
@@ -239,7 +239,7 @@ public class TlsIntegrationTest extends BaseClusterIntegrationTest {
 
     minionConf.setProperty("pinot.minion.tls.keystore.path", TLS_STORE_PKCS_12);
     minionConf.setProperty("pinot.minion.tls.keystore.password", "changeit");
-    minionConf.setProperty("pinot.server.tls.keystore.type", "PKCS12");
+    minionConf.setProperty("pinot.minion.tls.keystore.type", "PKCS12");
     minionConf.setProperty("pinot.minion.tls.truststore.path", TLS_STORE_PKCS_12);
     minionConf.setProperty("pinot.minion.tls.truststore.password", "changeit");
     minionConf.setProperty("pinot.minion.tls.truststore.type", "PKCS12");


### PR DESCRIPTION
Instructions:
1. The PR has to be tagged with at least one of the following labels (*):
   1. `feature`
   2. `bugfix`
   3. `performance`
   4. `ui`
   5. `backward-incompat`
   6. `release-notes` (**)
2. Remove these instructions before publishing the PR.
 
(*) Other labels to consider:
- `testing`
- `dependencies`
- `docker`
- `kubernetes`
- `observability`
- `security`
- `code-style`
- `extension-point`
- `refactor`
- `cleanup`

(**) Use `release-notes` label for scenarios like:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
