### PR TITLE
Add controller execution time tracking to query responses

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNative.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNative.java
@@ -44,7 +44,9 @@ import org.apache.pinot.spi.utils.JsonUtils;
  */
 @JsonPropertyOrder({
     "resultTable", "numRowsResultSet", "partialResult", "exceptions", "numGroupsLimitReached",
-    "numGroupsWarningLimitReached", "timeUsedMs", "requestId", "clientRequestId", "brokerId", "numDocsScanned",
+    "numGroupsWarningLimitReached", "timeUsedMs", "controllerExecutionTimeMs",
+    "requestId", "clientRequestId", "brokerId",
+    "numDocsScanned",
     "totalDocs", "numEntriesScannedInFilter", "numEntriesScannedPostFilter", "numServersQueried", "numServersResponded",
     "numSegmentsQueried", "numSegmentsProcessed", "numSegmentsMatched", "numConsumingSegmentsQueried",
     "numConsumingSegmentsProcessed", "numConsumingSegmentsMatched", "minConsumingFreshnessTimeMs",
@@ -116,6 +118,7 @@ public class BrokerResponseNative implements BrokerResponse {
 
   private Set<Integer> _pools = Set.of();
   private boolean _rlsFiltersApplied = false;
+  private long _controllerExecutionTimeMs = -1L;
 
   public BrokerResponseNative() {
   }
@@ -598,5 +601,26 @@ public class BrokerResponseNative implements BrokerResponse {
   @Override
   public boolean getRLSFiltersApplied() {
     return _rlsFiltersApplied;
+  }
+
+  /**
+   * Get the controller execution time in milliseconds.
+   * Returns -1 if not set (when query doesn't go through controller).
+   * This field is only included in the JSON response when set (i.e., when queries go through the controller).
+   *
+   * @return controller execution time in milliseconds, or -1 if not applicable
+   */
+  @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+  public long getControllerExecutionTimeMs() {
+    return _controllerExecutionTimeMs;
+  }
+
+  /**
+   * Set the controller execution time in milliseconds.
+   *
+   * @param controllerExecutionTimeMs the execution time in milliseconds
+   */
+  public void setControllerExecutionTimeMs(long controllerExecutionTimeMs) {
+    _controllerExecutionTimeMs = controllerExecutionTimeMs;
   }
 }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/TimeSeriesIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/TimeSeriesIntegrationTest.java
@@ -198,7 +198,11 @@ public class TimeSeriesIntegrationTest extends BaseClusterIntegrationTest {
     );
     JsonNode result = getTimeseriesQuery(getControllerBaseApiUrl(), query, QUERY_START_TIME_SEC, QUERY_END_TIME_SEC,
         getHeaders());
-    assertEquals(result.get("status").asText(), "success");
+
+    // Add null check for status field
+    JsonNode statusNode = result.get("status");
+    assertNotNull(statusNode, "Status field should not be null in timeseries query response");
+    assertEquals(statusNode.asText(), "success");
 
     // Call /timeseries/languages.
     var statusCodeAndResponse = sendGetRequestWithStatusCode(


### PR DESCRIPTION
- Add controllerExecutionTimeMs field to BrokerResponseNative
- Include in JSON serialization order after timeUsedMs
- Initialize to -1 to indicate when not applicable
- Add getter/setter methods with proper JavaDoc

This provides visibility into controller-level query performance for monitoring and debugging purposes.

Instructions:
1. The PR has to be tagged with at least one of the following labels (*):
   1. `feature`
   2. `bugfix`
   3. `performance`
   4. `ui`
   5. `backward-incompat`
   6. `release-notes` (**)
2. Remove these instructions before publishing the PR.
 
(*) Other labels to consider:
- `testing`
- `dependencies`
- `docker`
- `kubernetes`
- `observability`
- `security`
- `code-style`
- `extension-point`
- `refactor`
- `cleanup`

(**) Use `release-notes` label for scenarios like:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
