### PR TITLE
remove compatibility verifier for 1.3.0

### DIFF
--- a/.github/workflows/pinot_tests.yml
+++ b/.github/workflows/pinot_tests.yml
@@ -484,7 +484,7 @@ jobs:
       matrix:
         test_suite: [ "compatibility-verifier/sample-test-suite" ]
         old_commit: [
-          "release-1.3.0", "release-1.4.0", "master"
+          "release-1.4.0", "master"
         ]
     name: Pinot Compatibility Regression Testing against ${{ matrix.old_commit }} on ${{ matrix.test_suite }}
     steps:


### PR DESCRIPTION
In https://github.com/apache/pinot/pull/17576 we detected an issue that proves we cannot downgrade from 1.4 or 1.5 to 1.3 without downtime, as MSE queries may be broken due to an incompatibility in the stage stats. It is important to know the issue is not introduced by https://github.com/apache/pinot/pull/17576 but detected by it.

The main issue is that in 1.4 we introduced a cluster listener that detects whether the cluster is homogeneous or not, and in case it is not, MSE doesn't send stage stats. We did that because in 1.3 we detected a bug and the only way to fix it was to change the stats in 1.4 in a way that 1.3 fails when they are received. This worked fine during the system upgrade, but the listener is based on a version-specific Helix property we started setting in 1.4. When rolling back to 1.3, that property is not changed (as it is unknown to 1.3), so the other nodes see the old value, which means they think the cluster is homogeneous.

Fixing this issue may be complex and given we don't expect people to downgrade from 1.5 to 1.3, we think it is just better to remove that check here. As always, it is recommended to upgrade one version at a time, so in case you need to downgrade from 1.5, you should go to 1.4, which is still tested.

## Release noted
Apache Pinot 1.5 can be rolled back to 1.4 without downtime, but not to earlier versions. It is recommended to upgrade one version at a time.