### PR TITLE
[test] Fix flaky table cleanup 

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/TableRebalancePauselessIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/TableRebalancePauselessIntegrationTest.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.integration.tests;
 
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.helix.core.rebalance.RebalanceConfig;
 import org.apache.pinot.controller.helix.core.rebalance.RebalanceResult;
@@ -41,6 +42,9 @@ import static org.testng.Assert.*;
 
 public class TableRebalancePauselessIntegrationTest extends BasePauselessRealtimeIngestionTest {
   private final static int FORCE_COMMIT_REBALANCE_TIMEOUT_MS = 600_000;
+  private final static int BASELINE_SERVERS = 1;
+  private final static int EXTRA_SERVERS_PER_TEST = 4;
+  private final static AtomicInteger NEXT_SERVER_ID = new AtomicInteger(BASELINE_SERVERS);
 
   @Override
   protected String getFailurePoint() {
@@ -115,13 +119,14 @@ public class TableRebalancePauselessIntegrationTest extends BasePauselessRealtim
       throws Exception {
     final String tenantA = tableConfig.getTenantConfig().getServer();
     final String tenantB = tenantA + "_new";
+    int serverIdStart = NEXT_SERVER_ID.getAndAdd(EXTRA_SERVERS_PER_TEST);
 
-    BaseServerStarter serverStarter0 = startOneServer(0);
-    BaseServerStarter serverStarter1 = startOneServer(1);
+    BaseServerStarter serverStarter0 = startOneServer(serverIdStart);
+    BaseServerStarter serverStarter1 = startOneServer(serverIdStart + 1);
     createServerTenant(tenantA, 0, 2);
 
-    BaseServerStarter serverStarter2 = startOneServer(2);
-    BaseServerStarter serverStarter3 = startOneServer(3);
+    BaseServerStarter serverStarter2 = startOneServer(serverIdStart + 2);
+    BaseServerStarter serverStarter3 = startOneServer(serverIdStart + 3);
     createServerTenant(tenantB, 0, 2);
     RebalanceConfig rebalanceConfig = new RebalanceConfig();
     try {


### PR DESCRIPTION
## Problem
Two flaky test failures were observed in CI:

1. `PinotTableRestletResourceTest#testTableTasksCleanupWithNonActiveTasks`
- Intermittent 500 with `Failed to delete job ... from queue ...` during table deletion.

2. `TruncateDecimalTransformFunctionTest#testTruncateDecimalTransformFunction`
- Intermittent assertion mismatch `expected [0.0] but found [-0.0]`.

## Changes
### 1) Controller test race fix
- In `testTableTasksCleanupWithNonActiveTasks`, keep the minion task queue stopped while table deletion runs.
- Resume queue in a `finally` block to avoid leaking queue state to other tests.

### 2) Truncate signed-zero fix
- In `TruncateDecimalTransformFunction`, changed the single-argument path (`truncate(value)`) to use the same truncation logic as `truncate(value, 0)` via `BigDecimal.setScale(0, RoundingMode.DOWN)`.
- Added explicit regression coverage in `TruncateDecimalTransformFunctionTest` for `truncate(-0.4)` to guarantee canonical `0.0` output (not `-0.0`).

## Why this fixes flakiness
- The first issue removes a task-state transition race during cleanup.
- The second issue removes a signed-zero inconsistency in output formatting and aligns `truncate(value)` with `truncate(value, 0)` semantics.

## Validation
- `./mvnw -pl pinot-controller -Dtest=PinotTableRestletResourceTest#testTableTasksCleanupWithNonActiveTasks -Dsurefire.failIfNoSpecifiedTests=false test -DskipITs -DskipIntegrationTests`
- Repeated runs of the same controller test (9 consecutive successful loop iterations + 1 additional pass)
- `./mvnw -pl pinot-controller -Dtest=PinotTableRestletResourceTest#testTableTasksCleanupWithActiveTasks -Dsurefire.failIfNoSpecifiedTests=false test -DskipITs -DskipIntegrationTests`
- `./mvnw -pl pinot-controller -Dtest=PinotTableRestletResourceTest -Dsurefire.failIfNoSpecifiedTests=false test -DskipITs -DskipIntegrationTests`
- `./mvnw -pl pinot-core -Dtest=TruncateDecimalTransformFunctionTest -Dsurefire.failIfNoSpecifiedTests=false test -DskipITs -DskipIntegrationTests`
- Repeated runs of `TruncateDecimalTransformFunctionTest#testTruncateDecimalTransformFunction` (5 consecutive successful iterations)
