### PR TITLE
do not log actual data on segment creation

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentDictionaryCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentDictionaryCreator.java
@@ -122,8 +122,7 @@ public class SegmentDictionaryCreator implements IndexCreator {
             writer.writeInt(i, value);
           }
         }
-        LOGGER.info("Created dictionary for INT column: {} with cardinality: {}, range: {} to {}", _columnName,
-            numValues, sortedInts[0], sortedInts[numValues - 1]);
+        LOGGER.info("Created dictionary for INT column: {} with cardinality: {}", _columnName, numValues);
         return;
 
       case LONG:
@@ -142,8 +141,7 @@ public class SegmentDictionaryCreator implements IndexCreator {
             writer.writeLong(i, value);
           }
         }
-        LOGGER.info("Created dictionary for LONG column: {} with cardinality: {}, range: {} to {}", _columnName,
-            numValues, sortedLongs[0], sortedLongs[numValues - 1]);
+        LOGGER.info("Created dictionary for LONG column: {} with cardinality: {}", _columnName, numValues);
         return;
 
       case FLOAT:
@@ -162,8 +160,7 @@ public class SegmentDictionaryCreator implements IndexCreator {
             writer.writeFloat(i, value);
           }
         }
-        LOGGER.info("Created dictionary for FLOAT column: {} with cardinality: {}, range: {} to {}", _columnName,
-            numValues, sortedFloats[0], sortedFloats[numValues - 1]);
+        LOGGER.info("Created dictionary for FLOAT column: {} with cardinality: {}", _columnName, numValues);
         return;
 
       case DOUBLE:
@@ -182,8 +179,7 @@ public class SegmentDictionaryCreator implements IndexCreator {
             writer.writeDouble(i, value);
           }
         }
-        LOGGER.info("Created dictionary for DOUBLE column: {} with cardinality: {}, range: {} to {}", _columnName,
-            numValues, sortedDoubles[0], sortedDoubles[numValues - 1]);
+        LOGGER.info("Created dictionary for DOUBLE column: {} with cardinality: {}", _columnName, numValues);
         return;
 
       case BIG_DECIMAL:
@@ -203,9 +199,8 @@ public class SegmentDictionaryCreator implements IndexCreator {
         }
 
         writeBytesValueDictionary(sortedBigDecimalBytes);
-        LOGGER.info("Created dictionary for BIG_DECIMAL column: {} with cardinality: {}, max length in bytes: {}, "
-                + "range: {} to {}", _columnName, numValues, _numBytesPerEntry, sortedBigDecimals[0],
-            sortedBigDecimals[numValues - 1]);
+        LOGGER.info("Created dictionary for BIG_DECIMAL column: {} with cardinality: {}, max length in bytes: {}",
+            _columnName, numValues, _numBytesPerEntry);
         return;
 
       case STRING:
@@ -225,9 +220,8 @@ public class SegmentDictionaryCreator implements IndexCreator {
         }
 
         writeBytesValueDictionary(sortedStringBytes);
-        LOGGER.info(
-            "Created dictionary for STRING column: {} with cardinality: {}, max length in bytes: {}, range: {} to {}",
-            _columnName, numValues, _numBytesPerEntry, sortedStrings[0], sortedStrings[numValues - 1]);
+        LOGGER.info("Created dictionary for STRING column: {} with cardinality: {}, max length in bytes: {}",
+            _columnName, numValues, _numBytesPerEntry);
         return;
 
       case BYTES:
@@ -246,9 +240,8 @@ public class SegmentDictionaryCreator implements IndexCreator {
         }
 
         writeBytesValueDictionary(sortedByteArrays);
-        LOGGER.info(
-            "Created dictionary for BYTES column: {} with cardinality: {}, max length in bytes: {}, range: {} to {}",
-            _columnName, numValues, _numBytesPerEntry, sortedBytes[0], sortedBytes[numValues - 1]);
+        LOGGER.info("Created dictionary for BYTES column: {} with cardinality: {}, max length in bytes: {}",
+            _columnName, numValues, _numBytesPerEntry);
         return;
 
       default:


### PR DESCRIPTION
This is a `security` fix. While this log can be useful to see the progress of segment creation, we should not be logging raw data. This can included sensitive info, PII, and more.

I considered making this a debug message, but
1. the other info is useful in steady state
2. I still don't think changing log levels leading to sensitive info logging is a desirable default