### PR TITLE
Add filterMv for element-level MV filtering in aggregation and GROUP BY

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
@@ -169,6 +169,8 @@ public enum TransformFunctionType {
 
   // Special functions
   VALUE_IN("valueIn", ReturnTypes.ARG0, OperandTypes.variadic(SqlOperandCountRanges.from(2))),
+  FILTER_MV("filterMv", ReturnTypes.ARG0,
+      OperandTypes.family(List.of(SqlTypeFamily.ARRAY, SqlTypeFamily.CHARACTER))),
   MAP_VALUE("mapValue",
       ReturnTypes.cascade(opBinding -> positionalComponentType(opBinding, 2), SqlTypeTransforms.FORCE_NULLABLE),
       OperandTypes.family(List.of(SqlTypeFamily.ARRAY, SqlTypeFamily.ANY, SqlTypeFamily.ARRAY))),

--- a/pinot-core/src/main/java/org/apache/pinot/core/function/scalar/FilterMvScalarFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/function/scalar/FilterMvScalarFunction.java
@@ -1,0 +1,286 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.function.scalar;
+
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
+import java.util.EnumMap;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.apache.pinot.common.function.FunctionInfo;
+import org.apache.pinot.common.function.PinotScalarFunction;
+import org.apache.pinot.common.function.sql.PinotSqlFunction;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+import org.apache.pinot.core.operator.transform.function.FilterMvPredicateEvaluator;
+import org.apache.pinot.spi.annotations.ScalarFunction;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+
+
+/**
+ * Scalar wrapper for filterMv so FunctionRegistry can expose type signatures for query planning and execution paths
+ * that resolve scalar functions.
+ */
+@ScalarFunction(names = {"filterMv"})
+public class FilterMvScalarFunction implements PinotScalarFunction {
+  private static final int MAX_CACHED_EVALUATORS = 10_000;
+  private static final Map<ColumnDataType, FunctionInfo> TYPE_FUNCTION_INFO_MAP =
+      new EnumMap<>(ColumnDataType.class);
+  private static final Cache<CacheKey, FilterMvPredicateEvaluator> EVALUATOR_CACHE =
+      CacheBuilder.newBuilder().maximumSize(MAX_CACHED_EVALUATORS).build();
+
+  static {
+    try {
+      TYPE_FUNCTION_INFO_MAP.put(ColumnDataType.INT_ARRAY,
+          new FunctionInfo(FilterMvScalarFunction.class.getMethod("filterMv", int[].class, String.class),
+              FilterMvScalarFunction.class, false));
+      TYPE_FUNCTION_INFO_MAP.put(ColumnDataType.LONG_ARRAY,
+          new FunctionInfo(FilterMvScalarFunction.class.getMethod("filterMv", long[].class, String.class),
+              FilterMvScalarFunction.class, false));
+      TYPE_FUNCTION_INFO_MAP.put(ColumnDataType.FLOAT_ARRAY,
+          new FunctionInfo(FilterMvScalarFunction.class.getMethod("filterMv", float[].class, String.class),
+              FilterMvScalarFunction.class, false));
+      TYPE_FUNCTION_INFO_MAP.put(ColumnDataType.DOUBLE_ARRAY,
+          new FunctionInfo(FilterMvScalarFunction.class.getMethod("filterMv", double[].class, String.class),
+              FilterMvScalarFunction.class, false));
+      TYPE_FUNCTION_INFO_MAP.put(ColumnDataType.STRING_ARRAY,
+          new FunctionInfo(FilterMvScalarFunction.class.getMethod("filterMv", String[].class, String.class),
+              FilterMvScalarFunction.class, false));
+      TYPE_FUNCTION_INFO_MAP.put(ColumnDataType.BYTES_ARRAY,
+          new FunctionInfo(FilterMvScalarFunction.class.getMethod("filterMv", byte[][].class, String.class),
+              FilterMvScalarFunction.class, false));
+    } catch (NoSuchMethodException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public String getName() {
+    return "filterMv";
+  }
+
+  @Override
+  public Set<String> getNames() {
+    return Set.of("filterMv");
+  }
+
+  @Nullable
+  @Override
+  public PinotSqlFunction toPinotSqlFunction() {
+    // Should already be registered in PinotOperatorTable by the transform function implementation
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public FunctionInfo getFunctionInfo(ColumnDataType[] argumentTypes) {
+    if (argumentTypes.length != 2) {
+      return null;
+    }
+    if (argumentTypes[1] != ColumnDataType.STRING) {
+      return null;
+    }
+    return TYPE_FUNCTION_INFO_MAP.get(argumentTypes[0].getStoredType());
+  }
+
+  @Nullable
+  @Override
+  public FunctionInfo getFunctionInfo(int numArguments) {
+    if (numArguments != 2) {
+      return null;
+    }
+    // Fall back to string
+    return getFunctionInfo(new ColumnDataType[]{ColumnDataType.STRING_ARRAY, ColumnDataType.STRING});
+  }
+
+  public static int[] filterMv(int[] values, String predicate) {
+    FilterMvPredicateEvaluator evaluator = evaluatorFor(predicate, DataType.INT);
+    int numValues = values.length;
+    int count = 0;
+    for (int value : values) {
+      if (evaluator.matchesInt(value)) {
+        count++;
+      }
+    }
+    if (count == numValues) {
+      return values;
+    }
+    int[] filtered = new int[count];
+    int idx = 0;
+    for (int value : values) {
+      if (evaluator.matchesInt(value)) {
+        filtered[idx++] = value;
+      }
+    }
+    return filtered;
+  }
+
+  public static long[] filterMv(long[] values, String predicate) {
+    FilterMvPredicateEvaluator evaluator = evaluatorFor(predicate, DataType.LONG);
+    int numValues = values.length;
+    int count = 0;
+    for (long value : values) {
+      if (evaluator.matchesLong(value)) {
+        count++;
+      }
+    }
+    if (count == numValues) {
+      return values;
+    }
+    long[] filtered = new long[count];
+    int idx = 0;
+    for (long value : values) {
+      if (evaluator.matchesLong(value)) {
+        filtered[idx++] = value;
+      }
+    }
+    return filtered;
+  }
+
+  public static float[] filterMv(float[] values, String predicate) {
+    FilterMvPredicateEvaluator evaluator = evaluatorFor(predicate, DataType.FLOAT);
+    int numValues = values.length;
+    int count = 0;
+    for (float value : values) {
+      if (evaluator.matchesFloat(value)) {
+        count++;
+      }
+    }
+    if (count == numValues) {
+      return values;
+    }
+    float[] filtered = new float[count];
+    int idx = 0;
+    for (float value : values) {
+      if (evaluator.matchesFloat(value)) {
+        filtered[idx++] = value;
+      }
+    }
+    return filtered;
+  }
+
+  public static double[] filterMv(double[] values, String predicate) {
+    FilterMvPredicateEvaluator evaluator = evaluatorFor(predicate, DataType.DOUBLE);
+    int numValues = values.length;
+    int count = 0;
+    for (double value : values) {
+      if (evaluator.matchesDouble(value)) {
+        count++;
+      }
+    }
+    if (count == numValues) {
+      return values;
+    }
+    double[] filtered = new double[count];
+    int idx = 0;
+    for (double value : values) {
+      if (evaluator.matchesDouble(value)) {
+        filtered[idx++] = value;
+      }
+    }
+    return filtered;
+  }
+
+  public static String[] filterMv(String[] values, String predicate) {
+    FilterMvPredicateEvaluator evaluator = evaluatorFor(predicate, DataType.STRING);
+    int numValues = values.length;
+    int count = 0;
+    for (String value : values) {
+      if (evaluator.matchesString(value)) {
+        count++;
+      }
+    }
+    if (count == numValues) {
+      return values;
+    }
+    String[] filtered = new String[count];
+    int idx = 0;
+    for (String value : values) {
+      if (evaluator.matchesString(value)) {
+        filtered[idx++] = value;
+      }
+    }
+    return filtered;
+  }
+
+  public static byte[][] filterMv(byte[][] values, String predicate) {
+    FilterMvPredicateEvaluator evaluator = evaluatorFor(predicate, DataType.BYTES);
+    int numValues = values.length;
+    int count = 0;
+    for (byte[] value : values) {
+      if (evaluator.matchesBytes(value)) {
+        count++;
+      }
+    }
+    if (count == numValues) {
+      return values;
+    }
+    byte[][] filtered = new byte[count][];
+    int idx = 0;
+    for (byte[] value : values) {
+      if (evaluator.matchesBytes(value)) {
+        filtered[idx++] = value;
+      }
+    }
+    return filtered;
+  }
+
+  private static FilterMvPredicateEvaluator evaluatorFor(String predicate, DataType dataType) {
+    CacheKey key = new CacheKey(predicate, dataType);
+    try {
+      return EVALUATOR_CACHE.get(key,
+          () -> FilterMvPredicateEvaluator.forPredicate(predicate, dataType, null));
+    } catch (Exception e) {
+      Throwable cause = e.getCause() != null ? e.getCause() : e;
+      if (cause instanceof RuntimeException) {
+        throw (RuntimeException) cause;
+      }
+      throw new IllegalArgumentException("Failed to create predicate evaluator for: " + predicate, cause);
+    }
+  }
+
+  private static final class CacheKey {
+    private final String _predicate;
+    private final DataType _dataType;
+
+    private CacheKey(String predicate, DataType dataType) {
+      _predicate = predicate;
+      _dataType = dataType;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      if (this == obj) {
+        return true;
+      }
+      if (!(obj instanceof CacheKey)) {
+        return false;
+      }
+      CacheKey other = (CacheKey) obj;
+      return _dataType == other._dataType && _predicate.equals(other._predicate);
+    }
+
+    @Override
+    public int hashCode() {
+      int result = _predicate.hashCode();
+      result = 31 * result + _dataType.hashCode();
+      return result;
+    }
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/FilterMvPredicateEvaluator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/FilterMvPredicateEvaluator.java
@@ -1,0 +1,450 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.transform.function;
+
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import javax.annotation.Nullable;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.pinot.common.request.Expression;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.common.request.context.FilterContext;
+import org.apache.pinot.common.request.context.RequestContextUtils;
+import org.apache.pinot.common.request.context.predicate.Predicate;
+import org.apache.pinot.core.operator.filter.predicate.PredicateEvaluator;
+import org.apache.pinot.core.operator.filter.predicate.PredicateEvaluatorProvider;
+import org.apache.pinot.segment.spi.index.reader.Dictionary;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.sql.parsers.CalciteSqlParser;
+
+
+public final class FilterMvPredicateEvaluator {
+  private static final String VALUE_PLACEHOLDER = "v";
+  private static final EnumSet<Predicate.Type> SUPPORTED_PREDICATE_TYPES =
+      EnumSet.of(Predicate.Type.EQ, Predicate.Type.NOT_EQ, Predicate.Type.IN, Predicate.Type.NOT_IN,
+          Predicate.Type.RANGE, Predicate.Type.REGEXP_LIKE);
+
+  private final EvalNode _root;
+
+  private FilterMvPredicateEvaluator(EvalNode root) {
+    _root = root;
+  }
+
+  public static FilterMvPredicateEvaluator forPredicate(String predicate, DataType dataType,
+      @Nullable Dictionary dictionary) {
+    if (StringUtils.isBlank(predicate)) {
+      throw new IllegalArgumentException("filterMv predicate must be a non-empty string");
+    }
+    FilterContext filterContext = parseFilterContext(predicate);
+    validateFilter(filterContext);
+    EvalNode root = buildNode(filterContext, dictionary, dataType);
+    return new FilterMvPredicateEvaluator(root);
+  }
+
+  private static FilterContext parseFilterContext(String predicate) {
+    Expression expression = CalciteSqlParser.compileToExpression(predicate);
+    ExpressionContext expressionContext = RequestContextUtils.getExpression(expression);
+    return RequestContextUtils.getFilter(expressionContext);
+  }
+
+  private static void validateFilter(FilterContext filterContext) {
+    switch (filterContext.getType()) {
+      case CONSTANT:
+        return;
+      case PREDICATE:
+        Predicate predicate = filterContext.getPredicate();
+        ExpressionContext lhs = predicate.getLhs();
+        if (lhs.getType() != ExpressionContext.Type.IDENTIFIER) {
+          throw new IllegalArgumentException(
+              "filterMv only supports predicates on placeholder '" + VALUE_PLACEHOLDER + "' without functions");
+        }
+        if (!StringUtils.equalsIgnoreCase(lhs.getIdentifier(), VALUE_PLACEHOLDER)) {
+          throw new IllegalArgumentException(
+              "filterMv predicate must reference placeholder '" + VALUE_PLACEHOLDER + "', but found '"
+                  + lhs.getIdentifier() + "'");
+        }
+        return;
+      case AND:
+      case OR:
+        for (FilterContext child : filterContext.getChildren()) {
+          validateFilter(child);
+        }
+        return;
+      case NOT:
+        validateFilter(filterContext.getChildren().get(0));
+        return;
+      default:
+        throw new IllegalArgumentException("Unsupported filter type: " + filterContext.getType());
+    }
+  }
+
+  private static EvalNode buildNode(FilterContext filterContext, @Nullable Dictionary dictionary, DataType dataType) {
+    switch (filterContext.getType()) {
+      case CONSTANT:
+        return EvalNode.constant(filterContext.isConstantTrue());
+      case PREDICATE:
+        Predicate predicate = filterContext.getPredicate();
+        if (!SUPPORTED_PREDICATE_TYPES.contains(predicate.getType())) {
+          throw new IllegalArgumentException(
+              "filterMv does not support predicate type: " + predicate.getType());
+        }
+        PredicateEvaluator evaluator =
+            PredicateEvaluatorProvider.getPredicateEvaluator(predicate, dictionary, dataType);
+        if (evaluator.isAlwaysTrue()) {
+          return EvalNode.constant(true);
+        }
+        if (evaluator.isAlwaysFalse()) {
+          return EvalNode.constant(false);
+        }
+        return EvalNode.predicate(evaluator);
+      case AND: {
+        List<EvalNode> children = new ArrayList<>();
+        for (FilterContext child : filterContext.getChildren()) {
+          EvalNode node = buildNode(child, dictionary, dataType);
+          if (node.isConstantFalse()) {
+            return EvalNode.constant(false);
+          }
+          if (!node.isConstantTrue()) {
+            children.add(node);
+          }
+        }
+        if (children.isEmpty()) {
+          return EvalNode.constant(true);
+        }
+        if (children.size() == 1) {
+          return children.get(0);
+        }
+        return EvalNode.and(children);
+      }
+      case OR: {
+        List<EvalNode> children = new ArrayList<>();
+        for (FilterContext child : filterContext.getChildren()) {
+          EvalNode node = buildNode(child, dictionary, dataType);
+          if (node.isConstantTrue()) {
+            return EvalNode.constant(true);
+          }
+          if (!node.isConstantFalse()) {
+            children.add(node);
+          }
+        }
+        if (children.isEmpty()) {
+          return EvalNode.constant(false);
+        }
+        if (children.size() == 1) {
+          return children.get(0);
+        }
+        return EvalNode.or(children);
+      }
+      case NOT: {
+        EvalNode child = buildNode(filterContext.getChildren().get(0), dictionary, dataType);
+        if (child.isConstant()) {
+          return EvalNode.constant(!child.getConstantValue());
+        }
+        return EvalNode.not(child);
+      }
+      default:
+        throw new IllegalArgumentException("Unsupported filter type: " + filterContext.getType());
+    }
+  }
+
+  public boolean matchesDictId(int dictId) {
+    return evalDictId(_root, dictId);
+  }
+
+  public boolean matchesInt(int value) {
+    return evalInt(_root, value);
+  }
+
+  public boolean matchesLong(long value) {
+    return evalLong(_root, value);
+  }
+
+  public boolean matchesFloat(float value) {
+    return evalFloat(_root, value);
+  }
+
+  public boolean matchesDouble(double value) {
+    return evalDouble(_root, value);
+  }
+
+  public boolean matchesString(@Nullable String value) {
+    if (value == null) {
+      return false;
+    }
+    return evalString(_root, value);
+  }
+
+  public boolean matchesBytes(@Nullable byte[] value) {
+    if (value == null) {
+      return false;
+    }
+    return evalBytes(_root, value);
+  }
+
+  private static boolean evalDictId(EvalNode node, int dictId) {
+    switch (node._type) {
+      case CONSTANT:
+        return node._constant;
+      case PREDICATE:
+        return node._evaluator.applySV(dictId);
+      case AND:
+        for (EvalNode child : node._children) {
+          if (!evalDictId(child, dictId)) {
+            return false;
+          }
+        }
+        return true;
+      case OR:
+        for (EvalNode child : node._children) {
+          if (evalDictId(child, dictId)) {
+            return true;
+          }
+        }
+        return false;
+      case NOT:
+        return !evalDictId(node._child, dictId);
+      default:
+        throw new IllegalStateException("Unsupported node type: " + node._type);
+    }
+  }
+
+  private static boolean evalInt(EvalNode node, int value) {
+    switch (node._type) {
+      case CONSTANT:
+        return node._constant;
+      case PREDICATE:
+        return node._evaluator.applySV(value);
+      case AND:
+        for (EvalNode child : node._children) {
+          if (!evalInt(child, value)) {
+            return false;
+          }
+        }
+        return true;
+      case OR:
+        for (EvalNode child : node._children) {
+          if (evalInt(child, value)) {
+            return true;
+          }
+        }
+        return false;
+      case NOT:
+        return !evalInt(node._child, value);
+      default:
+        throw new IllegalStateException("Unsupported node type: " + node._type);
+    }
+  }
+
+  private static boolean evalLong(EvalNode node, long value) {
+    switch (node._type) {
+      case CONSTANT:
+        return node._constant;
+      case PREDICATE:
+        return node._evaluator.applySV(value);
+      case AND:
+        for (EvalNode child : node._children) {
+          if (!evalLong(child, value)) {
+            return false;
+          }
+        }
+        return true;
+      case OR:
+        for (EvalNode child : node._children) {
+          if (evalLong(child, value)) {
+            return true;
+          }
+        }
+        return false;
+      case NOT:
+        return !evalLong(node._child, value);
+      default:
+        throw new IllegalStateException("Unsupported node type: " + node._type);
+    }
+  }
+
+  private static boolean evalFloat(EvalNode node, float value) {
+    switch (node._type) {
+      case CONSTANT:
+        return node._constant;
+      case PREDICATE:
+        return node._evaluator.applySV(value);
+      case AND:
+        for (EvalNode child : node._children) {
+          if (!evalFloat(child, value)) {
+            return false;
+          }
+        }
+        return true;
+      case OR:
+        for (EvalNode child : node._children) {
+          if (evalFloat(child, value)) {
+            return true;
+          }
+        }
+        return false;
+      case NOT:
+        return !evalFloat(node._child, value);
+      default:
+        throw new IllegalStateException("Unsupported node type: " + node._type);
+    }
+  }
+
+  private static boolean evalDouble(EvalNode node, double value) {
+    switch (node._type) {
+      case CONSTANT:
+        return node._constant;
+      case PREDICATE:
+        return node._evaluator.applySV(value);
+      case AND:
+        for (EvalNode child : node._children) {
+          if (!evalDouble(child, value)) {
+            return false;
+          }
+        }
+        return true;
+      case OR:
+        for (EvalNode child : node._children) {
+          if (evalDouble(child, value)) {
+            return true;
+          }
+        }
+        return false;
+      case NOT:
+        return !evalDouble(node._child, value);
+      default:
+        throw new IllegalStateException("Unsupported node type: " + node._type);
+    }
+  }
+
+  private static boolean evalString(EvalNode node, String value) {
+    switch (node._type) {
+      case CONSTANT:
+        return node._constant;
+      case PREDICATE:
+        return node._evaluator.applySV(value);
+      case AND:
+        for (EvalNode child : node._children) {
+          if (!evalString(child, value)) {
+            return false;
+          }
+        }
+        return true;
+      case OR:
+        for (EvalNode child : node._children) {
+          if (evalString(child, value)) {
+            return true;
+          }
+        }
+        return false;
+      case NOT:
+        return !evalString(node._child, value);
+      default:
+        throw new IllegalStateException("Unsupported node type: " + node._type);
+    }
+  }
+
+  private static boolean evalBytes(EvalNode node, byte[] value) {
+    switch (node._type) {
+      case CONSTANT:
+        return node._constant;
+      case PREDICATE:
+        return node._evaluator.applySV(value);
+      case AND:
+        for (EvalNode child : node._children) {
+          if (!evalBytes(child, value)) {
+            return false;
+          }
+        }
+        return true;
+      case OR:
+        for (EvalNode child : node._children) {
+          if (evalBytes(child, value)) {
+            return true;
+          }
+        }
+        return false;
+      case NOT:
+        return !evalBytes(node._child, value);
+      default:
+        throw new IllegalStateException("Unsupported node type: " + node._type);
+    }
+  }
+
+  private static final class EvalNode {
+    private enum Type {
+      CONSTANT,
+      PREDICATE,
+      AND,
+      OR,
+      NOT
+    }
+
+    private final Type _type;
+    private final boolean _constant;
+    private final PredicateEvaluator _evaluator;
+    private final List<EvalNode> _children;
+    private final EvalNode _child;
+
+    private EvalNode(Type type, boolean constant, PredicateEvaluator evaluator, List<EvalNode> children,
+        EvalNode child) {
+      _type = type;
+      _constant = constant;
+      _evaluator = evaluator;
+      _children = children;
+      _child = child;
+    }
+
+    private static EvalNode constant(boolean value) {
+      return new EvalNode(Type.CONSTANT, value, null, null, null);
+    }
+
+    private static EvalNode predicate(PredicateEvaluator evaluator) {
+      return new EvalNode(Type.PREDICATE, false, evaluator, null, null);
+    }
+
+    private static EvalNode and(List<EvalNode> children) {
+      return new EvalNode(Type.AND, false, null, children, null);
+    }
+
+    private static EvalNode or(List<EvalNode> children) {
+      return new EvalNode(Type.OR, false, null, children, null);
+    }
+
+    private static EvalNode not(EvalNode child) {
+      return new EvalNode(Type.NOT, false, null, null, child);
+    }
+
+    private boolean isConstant() {
+      return _type == Type.CONSTANT;
+    }
+
+    private boolean isConstantTrue() {
+      return _type == Type.CONSTANT && _constant;
+    }
+
+    private boolean isConstantFalse() {
+      return _type == Type.CONSTANT && !_constant;
+    }
+
+    private boolean getConstantValue() {
+      return _constant;
+    }
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/FilterMvTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/FilterMvTransformFunction.java
@@ -1,0 +1,337 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.transform.function;
+
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.apache.pinot.core.operator.ColumnContext;
+import org.apache.pinot.core.operator.blocks.ValueBlock;
+import org.apache.pinot.core.operator.transform.TransformResultMetadata;
+import org.apache.pinot.segment.spi.index.reader.Dictionary;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+
+
+/**
+ * This class implements the filterMv function for multi-valued columns. It takes 2 arguments, where the first
+ * argument is a multi-valued column, and the second argument is a predicate string. The transform function filters
+ * values from the multi-valued column based on the predicate.
+ */
+public class FilterMvTransformFunction extends BaseTransformFunction {
+  public static final String FUNCTION_NAME = "filterMv";
+
+  private TransformFunction _mainTransformFunction;
+  private TransformResultMetadata _resultMetadata;
+  private Dictionary _dictionary;
+  private DataType _dataType;
+  private FilterMvPredicateEvaluator _predicateEvaluator;
+
+  private int[][] _dictIdsMV;
+
+  @Override
+  public String getName() {
+    return FUNCTION_NAME;
+  }
+
+  @Override
+  public void init(List<TransformFunction> arguments, Map<String, ColumnContext> columnContextMap) {
+    super.init(arguments, columnContextMap);
+    int numArguments = arguments.size();
+    if (numArguments != 2) {
+      throw new IllegalArgumentException("Exactly 2 arguments are required for filterMv transform function");
+    }
+
+    TransformFunction firstArgument = arguments.get(0);
+    if (firstArgument instanceof LiteralTransformFunction || firstArgument.getResultMetadata().isSingleValue()) {
+      throw new IllegalArgumentException(
+          "The first argument of filterMv transform function must be a multi-valued column or a transform function");
+    }
+    _mainTransformFunction = firstArgument;
+    _resultMetadata = _mainTransformFunction.getResultMetadata();
+    _dictionary = _mainTransformFunction.getDictionary();
+    _dataType = _resultMetadata.getDataType();
+
+    TransformFunction predicateArgument = arguments.get(1);
+    if (!(predicateArgument instanceof LiteralTransformFunction) || !predicateArgument.getResultMetadata()
+        .isSingleValue() || predicateArgument.getResultMetadata().getDataType() != DataType.STRING) {
+      throw new IllegalArgumentException(
+          "The second argument of filterMv transform function must be a single-valued string literal");
+    }
+    String predicate = ((LiteralTransformFunction) predicateArgument).getStringLiteral();
+    _predicateEvaluator = FilterMvPredicateEvaluator.forPredicate(predicate, _dataType, _dictionary);
+  }
+
+  @Override
+  public TransformResultMetadata getResultMetadata() {
+    return _resultMetadata;
+  }
+
+  @Nullable
+  @Override
+  public Dictionary getDictionary() {
+    return _dictionary;
+  }
+
+  @Override
+  public int[][] transformToDictIdsMV(ValueBlock valueBlock) {
+    if (_dictionary == null) {
+      return super.transformToDictIdsMV(valueBlock);
+    }
+    int length = valueBlock.getNumDocs();
+    if (_dictIdsMV == null || _dictIdsMV.length < length) {
+      _dictIdsMV = new int[length][];
+    }
+    int[][] unfilteredDictIds = _mainTransformFunction.transformToDictIdsMV(valueBlock);
+    for (int i = 0; i < length; i++) {
+      _dictIdsMV[i] = filterDictIds(unfilteredDictIds[i]);
+    }
+    return _dictIdsMV;
+  }
+
+  @Override
+  public int[][] transformToIntValuesMV(ValueBlock valueBlock) {
+    if (_dictionary != null || _dataType.getStoredType() != DataType.INT) {
+      return super.transformToIntValuesMV(valueBlock);
+    }
+    int length = valueBlock.getNumDocs();
+    initIntValuesMV(length);
+    int[][] unfilteredValues = _mainTransformFunction.transformToIntValuesMV(valueBlock);
+    for (int i = 0; i < length; i++) {
+      _intValuesMV[i] = filterInts(unfilteredValues[i]);
+    }
+    return _intValuesMV;
+  }
+
+  @Override
+  public long[][] transformToLongValuesMV(ValueBlock valueBlock) {
+    if (_dictionary != null || _dataType.getStoredType() != DataType.LONG) {
+      return super.transformToLongValuesMV(valueBlock);
+    }
+    int length = valueBlock.getNumDocs();
+    initLongValuesMV(length);
+    long[][] unfilteredValues = _mainTransformFunction.transformToLongValuesMV(valueBlock);
+    for (int i = 0; i < length; i++) {
+      _longValuesMV[i] = filterLongs(unfilteredValues[i]);
+    }
+    return _longValuesMV;
+  }
+
+  @Override
+  public float[][] transformToFloatValuesMV(ValueBlock valueBlock) {
+    if (_dictionary != null || _dataType.getStoredType() != DataType.FLOAT) {
+      return super.transformToFloatValuesMV(valueBlock);
+    }
+    int length = valueBlock.getNumDocs();
+    initFloatValuesMV(length);
+    float[][] unfilteredValues = _mainTransformFunction.transformToFloatValuesMV(valueBlock);
+    for (int i = 0; i < length; i++) {
+      _floatValuesMV[i] = filterFloats(unfilteredValues[i]);
+    }
+    return _floatValuesMV;
+  }
+
+  @Override
+  public double[][] transformToDoubleValuesMV(ValueBlock valueBlock) {
+    if (_dictionary != null || _dataType.getStoredType() != DataType.DOUBLE) {
+      return super.transformToDoubleValuesMV(valueBlock);
+    }
+    int length = valueBlock.getNumDocs();
+    initDoubleValuesMV(length);
+    double[][] unfilteredValues = _mainTransformFunction.transformToDoubleValuesMV(valueBlock);
+    for (int i = 0; i < length; i++) {
+      _doubleValuesMV[i] = filterDoubles(unfilteredValues[i]);
+    }
+    return _doubleValuesMV;
+  }
+
+  @Override
+  public String[][] transformToStringValuesMV(ValueBlock valueBlock) {
+    if (_dictionary != null || _dataType.getStoredType() != DataType.STRING) {
+      return super.transformToStringValuesMV(valueBlock);
+    }
+    int length = valueBlock.getNumDocs();
+    initStringValuesMV(length);
+    String[][] unfilteredValues = _mainTransformFunction.transformToStringValuesMV(valueBlock);
+    for (int i = 0; i < length; i++) {
+      _stringValuesMV[i] = filterStrings(unfilteredValues[i]);
+    }
+    return _stringValuesMV;
+  }
+
+  @Override
+  public byte[][][] transformToBytesValuesMV(ValueBlock valueBlock) {
+    if (_dictionary != null || _dataType.getStoredType() != DataType.BYTES) {
+      return super.transformToBytesValuesMV(valueBlock);
+    }
+    int length = valueBlock.getNumDocs();
+    initBytesValuesMV(length);
+    byte[][][] unfilteredValues = _mainTransformFunction.transformToBytesValuesMV(valueBlock);
+    for (int i = 0; i < length; i++) {
+      _bytesValuesMV[i] = filterBytes(unfilteredValues[i]);
+    }
+    return _bytesValuesMV;
+  }
+
+  private int[] filterDictIds(int[] source) {
+    int numValues = source.length;
+    int count = 0;
+    for (int value : source) {
+      if (_predicateEvaluator.matchesDictId(value)) {
+        count++;
+      }
+    }
+    if (count == numValues) {
+      return source;
+    }
+    int[] filtered = new int[count];
+    int idx = 0;
+    for (int value : source) {
+      if (_predicateEvaluator.matchesDictId(value)) {
+        filtered[idx++] = value;
+      }
+    }
+    return filtered;
+  }
+
+  private int[] filterInts(int[] source) {
+    int numValues = source.length;
+    int count = 0;
+    for (int value : source) {
+      if (_predicateEvaluator.matchesInt(value)) {
+        count++;
+      }
+    }
+    if (count == numValues) {
+      return source;
+    }
+    int[] filtered = new int[count];
+    int idx = 0;
+    for (int value : source) {
+      if (_predicateEvaluator.matchesInt(value)) {
+        filtered[idx++] = value;
+      }
+    }
+    return filtered;
+  }
+
+  private long[] filterLongs(long[] source) {
+    int numValues = source.length;
+    int count = 0;
+    for (long value : source) {
+      if (_predicateEvaluator.matchesLong(value)) {
+        count++;
+      }
+    }
+    if (count == numValues) {
+      return source;
+    }
+    long[] filtered = new long[count];
+    int idx = 0;
+    for (long value : source) {
+      if (_predicateEvaluator.matchesLong(value)) {
+        filtered[idx++] = value;
+      }
+    }
+    return filtered;
+  }
+
+  private float[] filterFloats(float[] source) {
+    int numValues = source.length;
+    int count = 0;
+    for (float value : source) {
+      if (_predicateEvaluator.matchesFloat(value)) {
+        count++;
+      }
+    }
+    if (count == numValues) {
+      return source;
+    }
+    float[] filtered = new float[count];
+    int idx = 0;
+    for (float value : source) {
+      if (_predicateEvaluator.matchesFloat(value)) {
+        filtered[idx++] = value;
+      }
+    }
+    return filtered;
+  }
+
+  private double[] filterDoubles(double[] source) {
+    int numValues = source.length;
+    int count = 0;
+    for (double value : source) {
+      if (_predicateEvaluator.matchesDouble(value)) {
+        count++;
+      }
+    }
+    if (count == numValues) {
+      return source;
+    }
+    double[] filtered = new double[count];
+    int idx = 0;
+    for (double value : source) {
+      if (_predicateEvaluator.matchesDouble(value)) {
+        filtered[idx++] = value;
+      }
+    }
+    return filtered;
+  }
+
+  private String[] filterStrings(String[] source) {
+    int numValues = source.length;
+    int count = 0;
+    for (String value : source) {
+      if (_predicateEvaluator.matchesString(value)) {
+        count++;
+      }
+    }
+    if (count == numValues) {
+      return source;
+    }
+    String[] filtered = new String[count];
+    int idx = 0;
+    for (String value : source) {
+      if (_predicateEvaluator.matchesString(value)) {
+        filtered[idx++] = value;
+      }
+    }
+    return filtered;
+  }
+
+  private byte[][] filterBytes(byte[][] source) {
+    int numValues = source.length;
+    int count = 0;
+    for (byte[] value : source) {
+      if (_predicateEvaluator.matchesBytes(value)) {
+        count++;
+      }
+    }
+    if (count == numValues) {
+      return source;
+    }
+    byte[][] filtered = new byte[count][];
+    int idx = 0;
+    for (byte[] value : source) {
+      if (_predicateEvaluator.matchesBytes(value)) {
+        filtered[idx++] = value;
+      }
+    }
+    return filtered;
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
@@ -151,6 +151,7 @@ public class TransformFunctionFactory {
     typeToImplementation.put(TransformFunctionType.MILLISECOND, DateTimeTransformFunction.Millisecond.class);
     typeToImplementation.put(TransformFunctionType.ARRAY_LENGTH, ArrayLengthTransformFunction.class);
     typeToImplementation.put(TransformFunctionType.VALUE_IN, ValueInTransformFunction.class);
+    typeToImplementation.put(TransformFunctionType.FILTER_MV, FilterMvTransformFunction.class);
     typeToImplementation.put(TransformFunctionType.MAP_VALUE, MapValueTransformFunction.class);
     typeToImplementation.put(TransformFunctionType.IN_ID_SET, InIdSetTransformFunction.class);
     typeToImplementation.put(TransformFunctionType.LOOKUP, LookupTransformFunction.class);

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/FilterMvTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/FilterMvTransformFunctionTest.java
@@ -1,0 +1,359 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.transform.function;
+
+import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
+import it.unimi.dsi.fastutil.doubles.DoubleList;
+import it.unimi.dsi.fastutil.floats.FloatArrayList;
+import it.unimi.dsi.fastutil.floats.FloatList;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntList;
+import it.unimi.dsi.fastutil.longs.LongArrayList;
+import it.unimi.dsi.fastutil.longs.LongList;
+import java.util.function.DoublePredicate;
+import java.util.function.IntPredicate;
+import java.util.function.LongPredicate;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.common.request.context.RequestContextUtils;
+import org.apache.pinot.core.function.scalar.FilterMvScalarFunction;
+import org.apache.pinot.core.operator.transform.TransformResultMetadata;
+import org.apache.pinot.segment.spi.index.reader.Dictionary;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.exception.BadQueryRequestException;
+import org.apache.pinot.spi.utils.BytesUtils;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+
+public class FilterMvTransformFunctionTest extends BaseTransformFunctionTest {
+
+  @Test
+  public void testFilterMvTransformFunctionInt() {
+    assertFilterMvTransformFunctionInt("v > 5", value -> value > 5);
+  }
+
+  @Test(dataProvider = "filterMvIntPredicates")
+  public void testFilterMvTransformFunctionIntPredicates(String predicate, IntPredicate matcher) {
+    assertFilterMvTransformFunctionInt(predicate, matcher);
+  }
+
+  @DataProvider(name = "filterMvIntPredicates")
+  public Object[][] provideFilterMvIntPredicates() {
+    return new Object[][]{
+        new Object[]{"v != 5", (IntPredicate) value -> value != 5},
+        new Object[]{"v > 5", (IntPredicate) value -> value > 5},
+        new Object[]{"v >= 5", (IntPredicate) value -> value >= 5},
+        new Object[]{"v < 5", (IntPredicate) value -> value < 5},
+        new Object[]{"v <= 5", (IntPredicate) value -> value <= 5},
+        new Object[]{"v IN (1, 3, 5)", (IntPredicate) value -> value == 1 || value == 3 || value == 5},
+        new Object[]{"v NOT IN (1, 3, 5)", (IntPredicate) value -> value != 1 && value != 3 && value != 5},
+        new Object[]{"v BETWEEN 3 AND 7", (IntPredicate) value -> value >= 3 && value <= 7},
+        new Object[]{"v > 3 AND v < 7", (IntPredicate) value -> value > 3 && value < 7},
+        new Object[]{"v < 2 OR v > 9", (IntPredicate) value -> value < 2 || value > 9},
+        new Object[]{"NOT (v = 1)", (IntPredicate) value -> value != 1}
+    };
+  }
+
+  private void assertFilterMvTransformFunctionInt(String predicate, IntPredicate matcher) {
+    String escaped = predicate.replace("'", "''");
+    String expressionStr = String.format("filterMv(%s, '%s')", INT_MV_COLUMN, escaped);
+    ExpressionContext expression = RequestContextUtils.getExpression(expressionStr);
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    assertTrue(transformFunction instanceof FilterMvTransformFunction);
+    assertEquals(transformFunction.getName(), FilterMvTransformFunction.FUNCTION_NAME);
+    TransformResultMetadata resultMetadata = transformFunction.getResultMetadata();
+    assertEquals(resultMetadata.getDataType(), DataType.INT);
+    assertFalse(resultMetadata.isSingleValue());
+    assertTrue(resultMetadata.hasDictionary());
+
+    int[][] dictIdsMV = transformFunction.transformToDictIdsMV(_projectionBlock);
+    int[][] intValuesMV = transformFunction.transformToIntValuesMV(_projectionBlock);
+    long[][] longValuesMV = transformFunction.transformToLongValuesMV(_projectionBlock);
+    float[][] floatValuesMV = transformFunction.transformToFloatValuesMV(_projectionBlock);
+    double[][] doubleValuesMV = transformFunction.transformToDoubleValuesMV(_projectionBlock);
+    String[][] stringValuesMV = transformFunction.transformToStringValuesMV(_projectionBlock);
+
+    Dictionary dictionary = transformFunction.getDictionary();
+    for (int i = 0; i < NUM_ROWS; i++) {
+      IntList expectedList = new IntArrayList();
+      for (int value : _intMVValues[i]) {
+        if (matcher.test(value)) {
+          expectedList.add(value);
+        }
+      }
+      int[] expectedValues = expectedList.toIntArray();
+
+      int numValues = expectedValues.length;
+      assertEquals(dictIdsMV[i].length, numValues);
+      assertEquals(intValuesMV[i].length, numValues);
+      assertEquals(longValuesMV[i].length, numValues);
+      assertEquals(floatValuesMV[i].length, numValues);
+      assertEquals(doubleValuesMV[i].length, numValues);
+      assertEquals(stringValuesMV[i].length, numValues);
+      for (int j = 0; j < numValues; j++) {
+        int expected = expectedValues[j];
+        assertEquals(dictIdsMV[i][j], dictionary.indexOf(expected));
+        assertEquals(intValuesMV[i][j], expected);
+        assertEquals(longValuesMV[i][j], expected);
+        assertEquals(floatValuesMV[i][j], (float) expected);
+        assertEquals(doubleValuesMV[i][j], (double) expected);
+        assertEquals(stringValuesMV[i][j], Integer.toString(expected));
+      }
+    }
+  }
+
+  @Test(dataProvider = "filterMvStringPredicates")
+  public void testFilterMvTransformFunctionString(String predicate, boolean expectMatch) {
+    String escaped = predicate.replace("'", "''");
+    String expressionStr = String.format("filterMv(%s, '%s')", STRING_ALPHANUM_MV_COLUMN_2, escaped);
+    ExpressionContext expression = RequestContextUtils.getExpression(expressionStr);
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    assertTrue(transformFunction instanceof FilterMvTransformFunction);
+    TransformResultMetadata resultMetadata = transformFunction.getResultMetadata();
+    assertEquals(resultMetadata.getDataType(), DataType.STRING);
+    assertFalse(resultMetadata.isSingleValue());
+    assertTrue(resultMetadata.hasDictionary());
+
+    String[][] stringValuesMV = transformFunction.transformToStringValuesMV(_projectionBlock);
+    Dictionary dictionary = transformFunction.getDictionary();
+    for (int i = 0; i < NUM_ROWS; i++) {
+      int expectedLength = expectMatch ? _stringAlphaNumericMV2Values[i].length : 0;
+      assertEquals(stringValuesMV[i].length, expectedLength);
+      for (int j = 0; j < expectedLength; j++) {
+        assertEquals(stringValuesMV[i][j], "a");
+        assertEquals(dictionary.indexOf(stringValuesMV[i][j]), dictionary.indexOf("a"));
+      }
+    }
+  }
+
+  @DataProvider(name = "filterMvStringPredicates")
+  public Object[][] provideFilterMvStringPredicates() {
+    return new Object[][]{
+        new Object[]{"v = 'a'", true},
+        new Object[]{"v = 'b'", false},
+        new Object[]{"REGEXP_LIKE(v, '^a$')", true},
+        new Object[]{"REGEXP_LIKE(v, '^b$')", false}
+    };
+  }
+
+  @Test(dataProvider = "filterMvLongPredicates")
+  public void testFilterMvTransformFunctionLong(String predicate, LongPredicate matcher) {
+    String escaped = predicate.replace("'", "''");
+    String expressionStr = String.format("filterMv(%s, '%s')", LONG_MV_COLUMN, escaped);
+    ExpressionContext expression = RequestContextUtils.getExpression(expressionStr);
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    assertTrue(transformFunction instanceof FilterMvTransformFunction);
+    TransformResultMetadata resultMetadata = transformFunction.getResultMetadata();
+    assertEquals(resultMetadata.getDataType(), DataType.LONG);
+    assertFalse(resultMetadata.isSingleValue());
+
+    long[][] longValuesMV = transformFunction.transformToLongValuesMV(_projectionBlock);
+    for (int i = 0; i < NUM_ROWS; i++) {
+      LongList expectedList = new LongArrayList();
+      for (long value : _longMVValues[i]) {
+        if (matcher.test(value)) {
+          expectedList.add(value);
+        }
+      }
+      long[] expectedValues = expectedList.toLongArray();
+      assertEquals(longValuesMV[i].length, expectedValues.length);
+      for (int j = 0; j < expectedValues.length; j++) {
+        assertEquals(longValuesMV[i][j], expectedValues[j]);
+      }
+    }
+  }
+
+  @DataProvider(name = "filterMvLongPredicates")
+  public Object[][] provideFilterMvLongPredicates() {
+    return new Object[][]{
+        new Object[]{"v > 0", (LongPredicate) value -> value > 0},
+        new Object[]{"v != 0", (LongPredicate) value -> value != 0},
+        new Object[]{"v IN (1, 2, 3)", (LongPredicate) value -> value == 1 || value == 2 || value == 3},
+        new Object[]{"v NOT IN (1, 2, 3)", (LongPredicate) value -> value != 1 && value != 2 && value != 3}
+    };
+  }
+
+  @Test
+  public void testFilterMvTransformFunctionFloat() {
+    String expressionStr = String.format("filterMv(%s, 'v > 1.0')", FLOAT_MV_COLUMN);
+    ExpressionContext expression = RequestContextUtils.getExpression(expressionStr);
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    assertTrue(transformFunction instanceof FilterMvTransformFunction);
+    TransformResultMetadata resultMetadata = transformFunction.getResultMetadata();
+    assertEquals(resultMetadata.getDataType(), DataType.FLOAT);
+    assertFalse(resultMetadata.isSingleValue());
+
+    float[][] floatValuesMV = transformFunction.transformToFloatValuesMV(_projectionBlock);
+    for (int i = 0; i < NUM_ROWS; i++) {
+      FloatList expectedList = new FloatArrayList();
+      for (float value : _floatMVValues[i]) {
+        if (value > 1.0f) {
+          expectedList.add(value);
+        }
+      }
+      float[] expectedValues = expectedList.toFloatArray();
+      assertEquals(floatValuesMV[i].length, expectedValues.length);
+      for (int j = 0; j < expectedValues.length; j++) {
+        assertEquals(floatValuesMV[i][j], expectedValues[j]);
+      }
+    }
+  }
+
+  @Test(dataProvider = "filterMvDoublePredicates")
+  public void testFilterMvTransformFunctionDouble(String predicate, DoublePredicate matcher) {
+    String escaped = predicate.replace("'", "''");
+    String expressionStr = String.format("filterMv(%s, '%s')", DOUBLE_MV_COLUMN, escaped);
+    ExpressionContext expression = RequestContextUtils.getExpression(expressionStr);
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    assertTrue(transformFunction instanceof FilterMvTransformFunction);
+    TransformResultMetadata resultMetadata = transformFunction.getResultMetadata();
+    assertEquals(resultMetadata.getDataType(), DataType.DOUBLE);
+    assertFalse(resultMetadata.isSingleValue());
+
+    double[][] doubleValuesMV = transformFunction.transformToDoubleValuesMV(_projectionBlock);
+    for (int i = 0; i < NUM_ROWS; i++) {
+      DoubleList expectedList = new DoubleArrayList();
+      for (double value : _doubleMVValues[i]) {
+        if (matcher.test(value)) {
+          expectedList.add(value);
+        }
+      }
+      double[] expectedValues = expectedList.toDoubleArray();
+      assertEquals(doubleValuesMV[i].length, expectedValues.length);
+      for (int j = 0; j < expectedValues.length; j++) {
+        assertEquals(doubleValuesMV[i][j], expectedValues[j]);
+      }
+    }
+  }
+
+  @DataProvider(name = "filterMvDoublePredicates")
+  public Object[][] provideFilterMvDoublePredicates() {
+    return new Object[][]{
+        new Object[]{"v > 1.0", (DoublePredicate) value -> value > 1.0},
+        new Object[]{"v != 1.0", (DoublePredicate) value -> Double.compare(value, 1.0) != 0}
+    };
+  }
+
+  @Test
+  public void testFilterMvScalarFunctionInt() {
+    // Test the scalar function INT overload directly
+    int[] values = new int[]{1, 2, 3, 4, 5};
+    int[] filtered = FilterMvScalarFunction.filterMv(values, "v > 3");
+    assertEquals(filtered.length, 2);
+    assertEquals(filtered[0], 4);
+    assertEquals(filtered[1], 5);
+
+    // No match
+    int[] filteredNone = FilterMvScalarFunction.filterMv(values, "v > 100");
+    assertEquals(filteredNone.length, 0);
+
+    // All match
+    int[] filteredAll = FilterMvScalarFunction.filterMv(values, "v > 0");
+    assertEquals(filteredAll.length, 5);
+  }
+
+  @Test
+  public void testFilterMvScalarFunctionLong() {
+    long[] values = new long[]{10L, 20L, 30L, 40L, 50L};
+    long[] filtered = FilterMvScalarFunction.filterMv(values, "v > 25");
+    assertEquals(filtered.length, 3);
+    assertEquals(filtered[0], 30L);
+    assertEquals(filtered[1], 40L);
+    assertEquals(filtered[2], 50L);
+
+    long[] filteredNone = FilterMvScalarFunction.filterMv(values, "v > 100");
+    assertEquals(filteredNone.length, 0);
+  }
+
+  @Test
+  public void testFilterMvScalarFunctionFloat() {
+    float[] values = new float[]{1.1f, 2.2f, 3.3f, 4.4f};
+    float[] filtered = FilterMvScalarFunction.filterMv(values, "v > 2.5");
+    assertEquals(filtered.length, 2);
+    assertEquals(filtered[0], 3.3f);
+    assertEquals(filtered[1], 4.4f);
+  }
+
+  @Test
+  public void testFilterMvScalarFunctionDouble() {
+    double[] values = new double[]{1.1, 2.2, 3.3, 4.4};
+    double[] filtered = FilterMvScalarFunction.filterMv(values, "v > 2.5");
+    assertEquals(filtered.length, 2);
+    assertEquals(filtered[0], 3.3);
+    assertEquals(filtered[1], 4.4);
+  }
+
+  @Test
+  public void testFilterMvScalarFunctionString() {
+    String[] values = new String[]{"apple", "banana", "cherry", "date"};
+    String[] filtered = FilterMvScalarFunction.filterMv(values, "v IN ('apple', 'cherry')");
+    assertEquals(filtered.length, 2);
+    assertEquals(filtered[0], "apple");
+    assertEquals(filtered[1], "cherry");
+
+    // REGEXP_LIKE
+    String[] filteredRegex = FilterMvScalarFunction.filterMv(values, "REGEXP_LIKE(v, '^[a-b].*')");
+    assertEquals(filteredRegex.length, 2);
+    assertEquals(filteredRegex[0], "apple");
+    assertEquals(filteredRegex[1], "banana");
+  }
+
+  @Test
+  public void testFilterMvScalarFunctionBytes() {
+    // Test the scalar function BYTES overload directly since the base test class has no BYTES MV column
+    byte[] val1 = BytesUtils.toBytes("aabb");
+    byte[] val2 = BytesUtils.toBytes("ccdd");
+    byte[] val3 = BytesUtils.toBytes("eeff");
+    byte[][] values = new byte[][]{val1, val2, val3};
+
+    // Positive match: filter to values equal to 'ccdd'
+    byte[][] filtered = FilterMvScalarFunction.filterMv(values, "v = 'ccdd'");
+    assertEquals(filtered.length, 1);
+    assertEquals(filtered[0], val2);
+
+    // Negative match: filter to values equal to non-existent value
+    byte[][] filteredNone = FilterMvScalarFunction.filterMv(values, "v = '0000'");
+    assertEquals(filteredNone.length, 0);
+
+    // All match: always-true predicate returns original array
+    byte[][] filteredAll = FilterMvScalarFunction.filterMv(values, "v != '0000'");
+    assertEquals(filteredAll.length, 3);
+  }
+
+  @Test(dataProvider = "illegalArguments", expectedExceptions = {BadQueryRequestException.class})
+  public void testIllegalArguments(String expressionStr) {
+    ExpressionContext expression = RequestContextUtils.getExpression(expressionStr);
+    TransformFunctionFactory.get(expression, _dataSourceMap);
+  }
+
+  @DataProvider(name = "illegalArguments")
+  public Object[][] provideIllegalArguments() {
+    return new Object[][]{
+        new Object[]{String.format("filterMv(%s)", INT_MV_COLUMN)},
+        new Object[]{String.format("filterMv(%s, 'v > 0')", INT_SV_COLUMN)},
+        new Object[]{String.format("filterMv(%s, %s)", INT_MV_COLUMN, LONG_MV_COLUMN)},
+        new Object[]{String.format("filterMv(%s, '%s > 0')", INT_MV_COLUMN, LONG_MV_COLUMN)},
+        new Object[]{String.format("filterMv(%s, 'abs(v) > 0')", INT_MV_COLUMN)}
+    };
+  }
+}

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/ArrayTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/ArrayTest.java
@@ -54,6 +54,7 @@ public class ArrayTest extends CustomDataQueryClusterIntegrationTest {
   private static final String BOOLEAN_FROM_STRING_ARRAY_COLUMN = "booleanArrayColFromStringArray";
   private static final String LONG_ARRAY_COLUMN = "longArrayCol";
   private static final String DOUBLE_ARRAY_COLUMN = "doubleArrayCol";
+  private static final String STRING_ARRAY_COLUMN = "stringArrayCol";
 
   @Override
   protected long getCountStarResult() {
@@ -728,6 +729,176 @@ public class ArrayTest extends CustomDataQueryClusterIntegrationTest {
   }
 
   @Test(dataProvider = "useBothQueryEngines")
+  public void testFilterMvLongArrayFilterValues(boolean useMultiStageQueryEngine)
+      throws Exception {
+    setUseMultiStageQueryEngine(useMultiStageQueryEngine);
+    String query = String.format("SELECT filterMv(%s, 'v > 1') FROM %s WHERE %s = 0 LIMIT 1", LONG_ARRAY_COLUMN,
+        getTableName(), INT_COLUMN);
+    JsonNode result = postQuery(query).get("resultTable");
+    assertEquals(result.get("dataSchema").get("columnDataTypes").get(0).textValue(), "LONG_ARRAY");
+    JsonNode rows = result.get("rows");
+    assertEquals(rows.size(), 1);
+    JsonNode row = rows.get(0);
+    assertEquals(row.size(), 1);
+    JsonNode values = row.get(0);
+    assertEquals(values.size(), 2);
+    assertEquals(values.get(0).longValue(), 2L);
+    assertEquals(values.get(1).longValue(), 3L);
+  }
+
+  @Test(dataProvider = "useBothQueryEngines")
+  public void testFilterMvLongArrayFilterPredicate(boolean useMultiStageQueryEngine)
+      throws Exception {
+    setUseMultiStageQueryEngine(useMultiStageQueryEngine);
+    String query = String.format("SELECT COUNT(*) FROM %s WHERE arrayLength(filterMv(%s, 'v > 1')) = 2",
+        getTableName(), LONG_ARRAY_COLUMN);
+    JsonNode jsonNode = postQuery(query);
+    assertEquals(jsonNode.get("resultTable").get("rows").get(0).get(0).asLong(), getCountStarResult());
+  }
+
+  @Test(dataProvider = "useBothQueryEngines")
+  public void testFilterMvRegexpLikeFilterValues(boolean useMultiStageQueryEngine)
+      throws Exception {
+    setUseMultiStageQueryEngine(useMultiStageQueryEngine);
+    String query = String.format("SELECT filterMv(%s, 'REGEXP_LIKE(v, ''^/api/.*'')') FROM %s WHERE %s = 0 LIMIT 1",
+        STRING_ARRAY_COLUMN, getTableName(), INT_COLUMN);
+    JsonNode result = postQuery(query).get("resultTable");
+    assertEquals(result.get("dataSchema").get("columnDataTypes").get(0).textValue(), "STRING_ARRAY");
+    JsonNode rows = result.get("rows");
+    assertEquals(rows.size(), 1);
+    JsonNode row = rows.get(0);
+    assertEquals(row.size(), 1);
+    JsonNode values = row.get(0);
+    assertEquals(values.size(), 2);
+    assertEquals(values.get(0).textValue(), "/api/v1");
+    assertEquals(values.get(1).textValue(), "/api/v2");
+  }
+
+  @Test(dataProvider = "useBothQueryEngines")
+  public void testFilterMvRegexpLikeFilterPredicate(boolean useMultiStageQueryEngine)
+      throws Exception {
+    setUseMultiStageQueryEngine(useMultiStageQueryEngine);
+    String query = String.format(
+        "SELECT COUNT(*) FROM %s WHERE arrayLength(filterMv(%s, 'REGEXP_LIKE(v, ''^/api/.*'')')) = 2",
+        getTableName(), STRING_ARRAY_COLUMN);
+    JsonNode jsonNode = postQuery(query);
+    assertEquals(jsonNode.get("resultTable").get("rows").get(0).get(0).asLong(), getCountStarResult());
+  }
+
+  @Test(dataProvider = "useBothQueryEngines")
+  public void testFilterMvBooleanArrayFilterValues(boolean useMultiStageQueryEngine)
+      throws Exception {
+    setUseMultiStageQueryEngine(useMultiStageQueryEngine);
+    // BOOLEAN_ARRAY_COLUMN contains [true, true, false, false] for all rows
+    // Filter to only true values
+    String query = String.format("SELECT filterMv(%s, 'v = 1') FROM %s WHERE %s = 0 LIMIT 1",
+        BOOLEAN_ARRAY_COLUMN, getTableName(), INT_COLUMN);
+    JsonNode result = postQuery(query).get("resultTable");
+    assertEquals(result.get("dataSchema").get("columnDataTypes").get(0).textValue(), "BOOLEAN_ARRAY");
+    JsonNode rows = result.get("rows");
+    assertEquals(rows.size(), 1);
+    JsonNode values = rows.get(0).get(0);
+    assertEquals(values.size(), 2);
+    assertTrue(values.get(0).asBoolean());
+    assertTrue(values.get(1).asBoolean());
+  }
+
+  @Test(dataProvider = "useBothQueryEngines")
+  public void testFilterMvBooleanArrayFilterPredicate(boolean useMultiStageQueryEngine)
+      throws Exception {
+    setUseMultiStageQueryEngine(useMultiStageQueryEngine);
+    // All rows have [true, true, false, false], so filterMv(col, 'v = 1') returns [true, true] with length 2
+    String query = String.format(
+        "SELECT COUNT(*) FROM %s WHERE arrayLength(filterMv(%s, 'v = 1')) = 2",
+        getTableName(), BOOLEAN_ARRAY_COLUMN);
+    JsonNode jsonNode = postQuery(query);
+    assertEquals(jsonNode.get("resultTable").get("rows").get(0).get(0).asLong(), getCountStarResult());
+  }
+
+  @Test(dataProvider = "useBothQueryEngines")
+  public void testFilterMvDoubleArrayFilterValues(boolean useMultiStageQueryEngine)
+      throws Exception {
+    setUseMultiStageQueryEngine(useMultiStageQueryEngine);
+    // DOUBLE_ARRAY_COLUMN contains [0.0, 0.1, 0.2, 0.3] for all rows
+    // Filter to values > 0.15
+    String query = String.format("SELECT filterMv(%s, 'v > 0.15') FROM %s WHERE %s = 0 LIMIT 1",
+        DOUBLE_ARRAY_COLUMN, getTableName(), INT_COLUMN);
+    JsonNode result = postQuery(query).get("resultTable");
+    assertEquals(result.get("dataSchema").get("columnDataTypes").get(0).textValue(), "DOUBLE_ARRAY");
+    JsonNode rows = result.get("rows");
+    assertEquals(rows.size(), 1);
+    JsonNode values = rows.get(0).get(0);
+    assertEquals(values.size(), 2);
+    assertEquals(values.get(0).doubleValue(), 0.2);
+    assertEquals(values.get(1).doubleValue(), 0.3);
+  }
+
+  @Test(dataProvider = "useBothQueryEngines")
+  public void testFilterMvDoubleArrayFilterPredicate(boolean useMultiStageQueryEngine)
+      throws Exception {
+    setUseMultiStageQueryEngine(useMultiStageQueryEngine);
+    // All rows have [0.0, 0.1, 0.2, 0.3], so filterMv(col, 'v > 0.15') returns [0.2, 0.3] with length 2
+    String query = String.format(
+        "SELECT COUNT(*) FROM %s WHERE arrayLength(filterMv(%s, 'v > 0.15')) = 2",
+        getTableName(), DOUBLE_ARRAY_COLUMN);
+    JsonNode jsonNode = postQuery(query);
+    assertEquals(jsonNode.get("resultTable").get("rows").get(0).get(0).asLong(), getCountStarResult());
+  }
+
+  @Test(dataProvider = "useBothQueryEngines")
+  public void testFilterMvLongArrayInPredicate(boolean useMultiStageQueryEngine)
+      throws Exception {
+    setUseMultiStageQueryEngine(useMultiStageQueryEngine);
+    // LONG_ARRAY_COLUMN contains [0, 1, 2, 3] for all rows
+    // Filter to values IN (1, 3)
+    String query = String.format("SELECT filterMv(%s, 'v IN (1, 3)') FROM %s WHERE %s = 0 LIMIT 1",
+        LONG_ARRAY_COLUMN, getTableName(), INT_COLUMN);
+    JsonNode result = postQuery(query).get("resultTable");
+    assertEquals(result.get("dataSchema").get("columnDataTypes").get(0).textValue(), "LONG_ARRAY");
+    JsonNode rows = result.get("rows");
+    assertEquals(rows.size(), 1);
+    JsonNode values = rows.get(0).get(0);
+    assertEquals(values.size(), 2);
+    assertEquals(values.get(0).longValue(), 1L);
+    assertEquals(values.get(1).longValue(), 3L);
+  }
+
+  @Test(dataProvider = "useBothQueryEngines")
+  public void testFilterMvStringArrayNotEqPredicate(boolean useMultiStageQueryEngine)
+      throws Exception {
+    setUseMultiStageQueryEngine(useMultiStageQueryEngine);
+    // STRING_ARRAY_COLUMN contains ["/api/v1", "/home", "/api/v2", "/metrics"]
+    // Filter to values != '/home'
+    String query = String.format(
+        "SELECT filterMv(%s, 'v != ''/home''') FROM %s WHERE %s = 0 LIMIT 1",
+        STRING_ARRAY_COLUMN, getTableName(), INT_COLUMN);
+    JsonNode result = postQuery(query).get("resultTable");
+    assertEquals(result.get("dataSchema").get("columnDataTypes").get(0).textValue(), "STRING_ARRAY");
+    JsonNode rows = result.get("rows");
+    assertEquals(rows.size(), 1);
+    JsonNode values = rows.get(0).get(0);
+    assertEquals(values.size(), 3);
+    assertEquals(values.get(0).textValue(), "/api/v1");
+    assertEquals(values.get(1).textValue(), "/api/v2");
+    assertEquals(values.get(2).textValue(), "/metrics");
+  }
+
+  @Test(dataProvider = "useBothQueryEngines")
+  public void testFilterMvLongArrayCompoundPredicate(boolean useMultiStageQueryEngine)
+      throws Exception {
+    setUseMultiStageQueryEngine(useMultiStageQueryEngine);
+    // LONG_ARRAY_COLUMN contains [0, 1, 2, 3]
+    // Filter to values > 0 AND v < 3
+    String query = String.format("SELECT filterMv(%s, 'v > 0 AND v < 3') FROM %s WHERE %s = 0 LIMIT 1",
+        LONG_ARRAY_COLUMN, getTableName(), INT_COLUMN);
+    JsonNode result = postQuery(query).get("resultTable");
+    JsonNode values = result.get("rows").get(0).get(0);
+    assertEquals(values.size(), 2);
+    assertEquals(values.get(0).longValue(), 1L);
+    assertEquals(values.get(1).longValue(), 2L);
+  }
+
+  @Test(dataProvider = "useBothQueryEngines")
   public void testStringArrayLiteral(boolean useMultiStageQueryEngine)
       throws Exception {
     setUseMultiStageQueryEngine(useMultiStageQueryEngine);
@@ -1099,6 +1270,7 @@ public class ArrayTest extends CustomDataQueryClusterIntegrationTest {
         .addMultiValueDimension(BOOLEAN_FROM_STRING_ARRAY_COLUMN, FieldSpec.DataType.BOOLEAN)
         .addMultiValueDimension(LONG_ARRAY_COLUMN, FieldSpec.DataType.LONG)
         .addMultiValueDimension(DOUBLE_ARRAY_COLUMN, FieldSpec.DataType.DOUBLE)
+        .addMultiValueDimension(STRING_ARRAY_COLUMN, FieldSpec.DataType.STRING)
         .build();
   }
 
@@ -1149,6 +1321,9 @@ public class ArrayTest extends CustomDataQueryClusterIntegrationTest {
             null, null),
         new org.apache.avro.Schema.Field(DOUBLE_ARRAY_COLUMN,
             org.apache.avro.Schema.createArray(org.apache.avro.Schema.create(org.apache.avro.Schema.Type.DOUBLE)),
+            null, null),
+        new org.apache.avro.Schema.Field(STRING_ARRAY_COLUMN,
+            org.apache.avro.Schema.createArray(org.apache.avro.Schema.create(org.apache.avro.Schema.Type.STRING)),
             null, null)
     ));
 
@@ -1177,6 +1352,7 @@ public class ArrayTest extends CustomDataQueryClusterIntegrationTest {
                   record.put(BOOLEAN_FROM_STRING_ARRAY_COLUMN, List.of("true", "true", "false", "false"));
                   record.put(LONG_ARRAY_COLUMN, List.of(0, 1, 2, 3));
                   record.put(DOUBLE_ARRAY_COLUMN, List.of(0.0, 0.1, 0.2, 0.3));
+                  record.put(STRING_ARRAY_COLUMN, List.of("/api/v1", "/home", "/api/v2", "/metrics"));
                   return record;
                 }
             ));


### PR DESCRIPTION
## What does this PR change?
- Adds MV element-level filtering via `filterMv`.
- Implements execution via `FilterMvTransformFunction`.
- Provides scalar-function signatures via `FilterMvScalarFunction` for function-resolution paths.
- Registers the function as `FILTER_MV` in `TransformFunctionType` and `TransformFunctionFactory`.
- Uses `FilterMvPredicateEvaluator` for predicate parsing/evaluation with these semantics:
  - predicate must use placeholder identifier `v` on the left-hand side
  - supports `=`, `!=`, `>`, `>=`, `<`, `<=`, `IN`, `NOT IN`, `BETWEEN`, `REGEXP_LIKE`, and `AND` / `OR` / `NOT`
- Scalar-function updates include:
  - `BYTES_ARRAY` support
  - `getStoredType()`-based function lookup (covers stored aliases like boolean/timestamp arrays)

`filterMv(mv_col, 'predicate_on_v')` evaluates each MV element against the predicate and returns a filtered MV array.

## Why?
This closes MV filtering semantics gaps (including MSE + MV scenarios) where row-level matching can retain all MV elements once any element matches. `filterMv` provides explicit per-element filtering without requiring `CROSS JOIN UNNEST`.

Related issues: #5069, #12230, #12429

## Query examples

### 1) Filter MV values with `REGEXP_LIKE`
```sql
SELECT filterMv(stringArrayCol, 'REGEXP_LIKE(v, ''^/api/.*'')')
FROM ArrayTest
LIMIT 1
```
Expected first-row output: `['/api/v1', '/api/v2']` for source `['/api/v1', '/home', '/api/v2', '/metrics']`.

### 2) Use filtered MV result in row predicate
```sql
SELECT COUNT(*)
FROM ArrayTest
WHERE arrayLength(filterMv(stringArrayCol, 'REGEXP_LIKE(v, ''^/api/.*'')')) = 2
```

### 3) GROUP BY with filtered MV values
A common problem is that GROUP BY on an MV column explodes elements into separate groups, and filtering in WHERE still retains all MV values in the group keys. `filterMv` lets you control exactly which elements appear in the GROUP BY:
```sql
SELECT filterMv(array_col, 'v = 1') AS filtered, COUNT(foo)
FROM myTable
GROUP BY filterMv(array_col, 'v = 1')
```
Only elements matching the predicate participate in grouping — non-matching elements are excluded from the result.

### 4) Aggregation over filtered MV elements
Use `filterMv` to narrow down MV values before applying an MV aggregation function:
```sql
SELECT SUMMV(filterMv(array_col, 'v > 10'))
FROM myTable
```
This sums only elements greater than 10 rather than all elements in the MV column.

### 5) DISTINCTCOUNTMV on filtered MV values
When DISTINCTCOUNTMV is used alongside GROUP BY on the same MV column, the count can be inflated because MV explosion groups each element separately. Wrapping with `filterMv` lets you restrict which elements are counted:
```sql
SELECT filterMv(tags, 'v IN (''a'', ''b'')') AS filtered_tags,
       DISTINCTCOUNTMV(filterMv(tags, 'v IN (''a'', ''b'')'))
FROM myTable
GROUP BY filterMv(tags, 'v IN (''a'', ''b'')')
```

### 6) Compound predicates
`filterMv` supports `AND`, `OR`, and `NOT` for complex element-level conditions:
```sql
SELECT filterMv(intArrayCol, 'v >= 5 AND v <= 20')
FROM myTable
```

## Validation
- `./mvnw -pl pinot-core -am -Dtest=FilterMvTransformFunctionTest,FunctionRegistryTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -pl pinot-common,pinot-core,pinot-integration-tests -DskipTests checkstyle:check`