### PR TITLE
Fix #17615: Add broker endpoint to parse SQL queries without execution

### DIFF
--- a/pinot-broker/pom.xml
+++ b/pinot-broker/pom.xml
@@ -100,5 +100,11 @@
       <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
+      <dependency>
+          <groupId>junit</groupId>
+          <artifactId>junit</artifactId>
+          <version>4.13.1</version>
+          <scope>test</scope>
+      </dependency>
   </dependencies>
 </project>

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/QueryParseResource.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/QueryParseResource.java
@@ -1,0 +1,33 @@
+package org.apache.pinot.broker.api.resources;
+
+import java.util.Collections;
+import java.util.Map;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
+
+import org.apache.pinot.sql.parsers.CalciteSqlParser;
+
+@Path("/query/parse")
+@Produces(MediaType.APPLICATION_JSON)
+public class QueryParseResource {
+
+    @POST
+    public Response parseQuery(String query) {
+        try {
+            // Parse SQL only
+            CalciteSqlParser.compileToSqlNodeAndOptions(query);
+            Map<String, Object> response =
+                    Collections.singletonMap("parsed", true);
+            return Response.ok(response).build();
+        } catch (Exception e) {
+            Map<String, Object> error =
+                    Collections.singletonMap("error", e.getMessage());
+            return Response.status(Response.Status.BAD_REQUEST)
+                    .entity(error)
+                    .build();
+        }
+    }
+}

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/api/resources/QueryParseResourceTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/api/resources/QueryParseResourceTest.java
@@ -1,0 +1,31 @@
+package org.apache.pinot.broker.api.resources;
+
+import javax.ws.rs.core.Response;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public class QueryParseResourceTest {
+
+    @Test
+    public void testValidQuery() {
+        QueryParseResource resource = new QueryParseResource();
+
+        Response response =
+                resource.parseQuery("SELECT * FROM myTable LIMIT 10");
+
+        assertEquals(response.getStatus(),
+                Response.Status.OK.getStatusCode());
+    }
+
+    @Test
+    public void testInvalidQuery() {
+        QueryParseResource resource = new QueryParseResource();
+
+        Response response =
+                resource.parseQuery("SELECT FROM WHERE");
+
+        assertEquals(response.getStatus(),
+                Response.Status.BAD_REQUEST.getStatusCode());
+    }
+}


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Broker parse\-only SQL endpoint flow with success/error paths and unit test validation\.

```mermaid
flowchart TD
  N0["parseQuery method #40;F2#41;"]:::stModified
  N1["Call CalciteSqlParser#46;compileToSqlNodeAndOptions #40;F2#41;"]:::stModified
  N2["Build success map #123;parsed#58;true#125; #40;F2#41;"]:::stModified
  N3["Return Response#46;ok #40;F2#41;"]:::stModified
  N4["Build error map #123;error#58;e#46;getMessage#40;#41;#125; #40;F2#41;"]:::stModified
  N5["Return Response#46;status BAD#95;REQUEST #40;F2#41;"]:::stModified
  N6["testValidQuery method #40;F3#41;"]:::stAdded
  N7["Call resource#46;parseQuery #40;valid#41; #40;F3#41;"]:::stAdded
  N8["assertEquals status OK #40;F3#41;"]:::stAdded
  N9["testInvalidQuery method #40;F3#41;"]:::stAdded
  N10["Call resource#46;parseQuery #40;invalid#41; #40;F3#41;"]:::stAdded
  N11["assertEquals status BAD#95;REQUEST #40;F3#41;"]:::stAdded
  N0 -->|"calls"| N1
  N1 -->|"no exception"| N2
  N1 -->|"exception"| N4
  N2 -->|"then"| N3
  N4 -->|"then"| N5
  N6 -->|"calls"| N7
  N7 -->|"calls"| N0
  N3 -->|"response used"| N8
  N9 -->|"calls"| N10
  N10 -->|"calls"| N0
  N5 -->|"response used"| N11
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F2: pinot\-broker/src/main/java/org/apache/pinot/broker/api/resources/QueryParseResource\.java — [after](https://github.com/apache/pinot/blob/ee99cf27b51805655e20d8931bc4c96bc84ecc9c/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/QueryParseResource.java)
- F3: pinot\-broker/src/test/java/org/apache/pinot/broker/api/resources/QueryParseResourceTest\.java — [after](https://github.com/apache/pinot/blob/ee99cf27b51805655e20d8931bc4c96bc84ecc9c/pinot-broker/src/test/java/org/apache/pinot/broker/api/resources/QueryParseResourceTest.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjRlZjhlM2VhZmQxNGEzYzY1NjY4OWFmZTkxMGJjM2EzYzYxNTc3M2QiLCJjb250ZXh0X2hhc2giOiJlM2Q3ZDExZWJkODIyMDYwY2NmMzQwZWViNGVhYzAzYWQ3ZTVmNGMxMDBlYmU4YzhiNzE0NjBjZjQwOGE5ZDZmIiwiZ2VuZXJhdGVkX2F0IjoxNzg5MDk0MjM3LCJoZWFkX3NoYSI6ImVlOTljZjI3YjUxODA1NjU1ZTIwZDg5MzFiYzRjOTZiYzg0ZWNjOWMiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiI0ZWY4ZTNlYWZkMTRhM2M2NTY2ODlhZmU5MTBiYzNhM2M2MTU3NzNkIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 8a23e93ab32d2ede4676dbcb753703feeadf6b966e4d2336d243b7ffa4b5ad74 -->
<!-- pinot-pr-flow:end -->

### Description
This PR adds a new parse-only SQL endpoint to the Pinot Broker that validates SQL syntax without planning or executing the query.

The endpoint allows SQL parsing to be tested independently and helps catch parser regressions early, especially during SQL / Calcite upgrades.

### Motivation
Currently, SQL parsing errors can only be detected during query execution. This makes it difficult to isolate parser-level regressions.

Issue #17615 requested a broker endpoint that only parses SQL and reports success or failure without executing the query.

### Changes
- Added a new broker REST endpoint:
  - `POST /query/parse`
  - Parses SQL syntax only
  - Returns HTTP 200 for valid SQL
  - Returns HTTP 400 with error message for invalid SQL
- Added unit tests covering valid and invalid SQL parsing

### Testing
- Added `QueryParseResourceTest`
- Tests executed locally using: