### PR TITLE
Support TLS routing for logical tables

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/routing/LogicalTableRouteInfo.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/routing/LogicalTableRouteInfo.java
@@ -99,14 +99,12 @@ public class LogicalTableRouteInfo implements TableRouteInfo {
     Map<ServerRoutingInstance, InstanceRequest> requestMap = new HashMap<>();
 
     for (Map.Entry<ServerInstance, List<TableSegmentsInfo>> entry : offlineTableRouteInfo.entrySet()) {
-      requestMap.put(
-          new ServerRoutingInstance(entry.getKey().getHostname(), entry.getKey().getPort(), TableType.OFFLINE),
+      requestMap.put(entry.getKey().toServerRoutingInstance(TableType.OFFLINE, preferTls),
           getInstanceRequest(requestId, brokerId, _offlineBrokerRequest, entry.getValue()));
     }
 
     for (Map.Entry<ServerInstance, List<TableSegmentsInfo>> entry : realtimeTableRouteInfo.entrySet()) {
-      requestMap.put(
-          new ServerRoutingInstance(entry.getKey().getHostname(), entry.getKey().getPort(), TableType.REALTIME),
+      requestMap.put(entry.getKey().toServerRoutingInstance(TableType.REALTIME, preferTls),
           getInstanceRequest(requestId, brokerId, _realtimeBrokerRequest, entry.getValue()));
     }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/routing/LogicalTableRouteProviderCalculateRouteTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/routing/LogicalTableRouteProviderCalculateRouteTest.java
@@ -18,11 +18,16 @@
  */
 package org.apache.pinot.core.routing;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.apache.helix.model.InstanceConfig;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.pinot.common.request.InstanceRequest;
 import org.apache.pinot.core.transport.ServerInstance;
 import org.apache.pinot.core.transport.ServerRoutingInstance;
+import org.apache.pinot.spi.utils.CommonConstants;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.*;
@@ -113,5 +118,71 @@ public class LogicalTableRouteProviderCalculateRouteTest extends BaseTableRouteT
   @Test(dataProvider = "disabledTableProvider")
   void testDisabledTable(String tableName) {
     assertTableRoute(tableName, "disabledTableProvider", null, null, false, false);
+  }
+
+  @Test
+  void testGetRequestMapWithTlsEnabled() {
+    int server1NettyPort = 1;
+    int server2NettyPort = 2;
+    int server1TlsPort = 8091;
+    int server2TlsPort = 8092;
+
+    ServerInstance server1 = createServerInstanceWithTls("localhost", server1NettyPort, server1TlsPort);
+    ServerInstance server2 = createServerInstanceWithTls("localhost", server2NettyPort, server2TlsPort);
+
+    // Create offline physical table with routing table
+    ImplicitHybridTableRouteInfo offlinePhysical = new ImplicitHybridTableRouteInfo();
+    offlinePhysical.setOfflineTableName("physical_OFFLINE");
+    offlinePhysical.setOfflineRoutingTable(Map.of(
+        server1, new SegmentsToQuery(new ArrayList<>(List.of("seg1")), null),
+        server2, new SegmentsToQuery(new ArrayList<>(List.of("seg2")), null)));
+
+    // Create realtime physical table with routing table
+    ImplicitHybridTableRouteInfo realtimePhysical = new ImplicitHybridTableRouteInfo();
+    realtimePhysical.setRealtimeTableName("physical_REALTIME");
+    realtimePhysical.setRealtimeRoutingTable(Map.of(
+        server1, new SegmentsToQuery(new ArrayList<>(List.of("seg3")), null)));
+
+    // Build logical table route info
+    LogicalTableRouteInfo logicalRouteInfo = new LogicalTableRouteInfo();
+    logicalRouteInfo.setLogicalTableName("testLogicalTable");
+    logicalRouteInfo.setOfflineTables(List.of(offlinePhysical));
+    logicalRouteInfo.setRealtimeTables(List.of(realtimePhysical));
+
+    BrokerRequestPair pair = getBrokerRequestPair("testLogicalTable", true, true,
+        "testLogicalTable_OFFLINE", "testLogicalTable_REALTIME");
+    logicalRouteInfo.setOfflineBrokerRequest(pair._offlineBrokerRequest);
+    logicalRouteInfo.setRealtimeBrokerRequest(pair._realtimeBrokerRequest);
+
+    // Verify preferTls=true uses TLS port and enables TLS
+    Map<ServerRoutingInstance, InstanceRequest> tlsRequestMap = logicalRouteInfo.getRequestMap(0, "broker", true);
+    assertNotNull(tlsRequestMap);
+    assertEquals(tlsRequestMap.size(), 3); // 2 offline + 1 realtime
+    for (ServerRoutingInstance routingInstance : tlsRequestMap.keySet()) {
+      assertTrue(routingInstance.isTlsEnabled(), "TLS should be enabled when preferTls=true");
+      int port = routingInstance.getPort();
+      assertTrue(port == server1TlsPort || port == server2TlsPort,
+          "Port should be TLS port, got: " + port);
+    }
+
+    // Verify preferTls=false uses regular port without TLS
+    Map<ServerRoutingInstance, InstanceRequest> nonTlsRequestMap = logicalRouteInfo.getRequestMap(0, "broker", false);
+    assertNotNull(nonTlsRequestMap);
+    assertEquals(nonTlsRequestMap.size(), 3);
+    for (ServerRoutingInstance routingInstance : nonTlsRequestMap.keySet()) {
+      assertFalse(routingInstance.isTlsEnabled(), "TLS should be disabled when preferTls=false");
+      int port = routingInstance.getPort();
+      assertTrue(port == server1NettyPort || port == server2NettyPort,
+          "Port should be regular netty port, got: " + port);
+    }
+  }
+
+  private static ServerInstance createServerInstanceWithTls(String hostname, int nettyPort, int tlsPort) {
+    String server = String.format("%s%s_%d", CommonConstants.Helix.PREFIX_OF_SERVER_INSTANCE, hostname, nettyPort);
+    InstanceConfig instanceConfig = InstanceConfig.toInstanceConfig(server);
+    ZNRecord znRecord = instanceConfig.getRecord();
+    Map<String, String> simpleFields = znRecord.getSimpleFields();
+    simpleFields.put(CommonConstants.Helix.Instance.NETTY_TLS_PORT_KEY, String.valueOf(tlsPort));
+    return new ServerInstance(instanceConfig);
   }
 }


### PR DESCRIPTION
Currently logical tables doesn't support TLS routing, due to which we get below exception when querying logical table

```
  io.netty.channel.AbstractChannel$AnnotatedConnectException: Connection refused: localhost/127.0.0.1:8098
      Suppressed: java.lang.RuntimeException: Rethrowing promise failure cause
          at io.netty.util.concurrent.DefaultPromise.rethrowIfFailed(DefaultPromise.java:685)
          at io.netty.util.concurrent.DefaultPromise.sync(DefaultPromise.java:419)
          at io.netty.channel.DefaultChannelPromise.sync(DefaultChannelPromise.java:119)
          at io.netty.channel.DefaultChannelPromise.sync(DefaultChannelPromise.java:30)
          at org.apache.pinot.core.transport.ServerChannels$ServerChannel.connectWithoutLocking(ServerChannels.java:235)
          at org.apache.pinot.core.transport.ServerChannels$ServerChannel.sendRequest(ServerChannels.java:221)
          at org.apache.pinot.core.transport.ServerChannels.sendRequest(ServerChannels.java:135)
          at org.apache.pinot.core.transport.QueryRouter.submitQuery(QueryRouter.java:112)
          at org.apache.pinot.broker.requesthandler.SingleConnectionBrokerRequestHandler.processBrokerRequest(SingleConnectionBrokerRequestHandler.java:115)
          at org.apache.pinot.broker.requesthandler.BaseSingleStageBrokerRequestHandler.doHandleRequest(BaseSingleStageBrokerRequestHandler.java:831)
          at org.apache.pinot.broker.requesthandler.BaseSingleStageBrokerRequestHandler.handleRequest(BaseSingleStageBrokerRequestHandler.java:367)
          at org.apache.pinot.broker.requesthandler.BaseBrokerRequestHandler.handleRequest(BaseBrokerRequestHandler.java:217)
          at org.apache.pinot.broker.requesthandler.BrokerRequestHandlerDelegate.handleRequest(BrokerRequestHandlerDelegate.java:118)
          at org.apache.pinot.broker.api.resources.PinotClientRequest.executeSqlQuery(PinotClientRequest.java:601)
          at org.apache.pinot.broker.api.resources.PinotClientRequest.processSqlQueryPost(PinotClientRequest.java:195)
```

Tested by enabling TLS via below confs. 

server-conf
```
pinot.server.netty.enabled=false
pinot.server.nettytls.enabled=true
pinot.server.nettytls.port=8091
pinot.server.tls.keystore.path=<path>
pinot.server.tls.keystore.password=<pwd>
pinot.server.tls.keystore.type=PKCS12
pinot.server.tls.truststore.path=<path>
pinot.server.tls.truststore.password=<pwd>
pinot.server.tls.truststore.type=PKCS12
```

broker-conf
```

pinot.broker.nettytls.enabled=true
pinot.broker.tls.keystore.path=<path>
pinot.broker.tls.keystore.password=<pwd>
pinot.broker.tls.keystore.type=PKCS12
pinot.broker.tls.truststore.path=<path>
pinot.broker.tls.truststore.password=<pwd>
pinot.broker.tls.truststore.type=PKCS12
```