### PR TITLE
Add debug logging option for rate-limited queries in QueryLogger

### DIFF
--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -362,6 +362,10 @@ public class CommonConstants {
     public static final String CONFIG_OF_BROKER_QUERY_LOG_BEFORE_PROCESSING =
         "pinot.broker.query.log.logBeforeProcessing";
     public static final boolean DEFAULT_BROKER_QUERY_LOG_BEFORE_PROCESSING = true;
+    public static final String CONFIG_OF_BROKER_QUERY_LOG_ON_RATE_LIMIT =
+        "broker.query.log.on.rate.limit";
+    public static final String DEFAULT_BROKER_QUERY_LOG_ON_RATE_LIMIT = "drop";
+
     public static final String CONFIG_OF_BROKER_QUERY_ENABLE_NULL_HANDLING = "pinot.broker.query.enable.null.handling";
     /// Provide broker level default for query option [Request.QueryOptionKey#REGEX_DICT_SIZE_THRESHOLD]
     public static final String CONFIG_OF_BROKER_QUERY_REGEX_DICT_SIZE_THRESHOLD =


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Adds debug logging option for rate\-limited queries: config \-&gt; flag \-&gt; mode selection \-&gt; conditional INFO/DEBUG logging\.

```mermaid
flowchart TD
  N0["Read broker#46;query#46;log#46;on#46;rate#46;limit config and set #95;debugInsteadOfDrop #40;F1#44; F2#41;"]:::stAdded
  N1["Determine LogMode based on rate limiter and #95;debugInsteadOfDrop #40;F1#41;"]:::stModified
  N2["Log query receipt#58; use LogMode to INFO#45;log and return allowance #40;F1#41;"]:::stModified
  N3["Log query completion#58; use LogMode to INFO#47;DEBUG#45;log or drop #40;F1#41;"]:::stModified
  N4["LogMode enum#58; invoke logger#46;info#47;debug or no#45;op #40;F1#41;"]:::stAdded
  N0 -->|"#95;debugInsteadOfDrop flag"| N1
  N1 -->|"LogMode"| N2
  N2 -->|"log#40;#41; call"| N4
  N1 -->|"LogMode"| N3
  N3 -->|"log#40;#41; call"| N4
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-broker/src/main/java/org/apache/pinot/broker/querylog/QueryLogger\.java — [before](https://github.com/apache/pinot/blob/3a536f304038e5069c7acaa3f88197b4b7935950/pinot-broker/src/main/java/org/apache/pinot/broker/querylog/QueryLogger.java) · [after](https://github.com/apache/pinot/blob/3a17676a44cc339d281856ee5b4dc9ee745e464b/pinot-broker/src/main/java/org/apache/pinot/broker/querylog/QueryLogger.java)
- F2: pinot\-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants\.java — [before](https://github.com/apache/pinot/blob/3a536f304038e5069c7acaa3f88197b4b7935950/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java) · [after](https://github.com/apache/pinot/blob/3a17676a44cc339d281856ee5b4dc9ee745e464b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjNhNTM2ZjMwNDAzOGU1MDY5YzdhY2FhM2Y4ODE5N2I0Yjc5MzU5NTAiLCJjb250ZXh0X2hhc2giOiI2ZDhiOWRlMmIwMDY4NmI3NjFiZmNjNTMxNGE0MWIyNTA2NjIzNjJkZTUwN2ZiOTZkNzJjYTcyZjJjYmRhZDBhIiwiZ2VuZXJhdGVkX2F0IjoxNzg5MDk0Mjk5LCJoZWFkX3NoYSI6IjNhMTc2NzZhNDRjYzMzOWQyODE4NTZlZTViNGRjOWVlNzQ1ZTQ2NGIiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJjZDQ4ZDVlOGMwYjI2NTEwMDhkNWY4OTAxOTk3MTJjZTgzYjc0YzJkIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature e6731a7295e5e879d6b7f92a27c65c3b8c2d3a0a7d5e6b4ace7d6ab8e1036d6b -->
<!-- pinot-pr-flow:end -->

## Summary
This PR introduces a new mode for query logging when the broker query log rate limit is reached. The behavior is controlled by the `broker.query.log.on.rate.limit` configuration property, which now supports a new value: `debug`. The default remains `drop`.

## Motivation
Previously, when the rate limit was reached, QueryLogger would drop query logs entirely. This made it difficult to capture and forward all query logs for further analysis or external processing (e.g., to separate files, syslog, or other appenders).

## Changes
* Added support for a new value debug for the broker.query.log.on.rate.limit property.
* When set to debug, logs are emitted at the INFO level until the rate limit is reached, after which they are logged at the DEBUG level instead of being dropped.
* Any value other than debug retains the existing behavior (logs are dropped after the rate limit is reached).

## Impact
* Backward compatible: the default remains drop, so existing deployments are unaffected unless the new mode is explicitly enabled.
* Provides more flexibility for operators to capture and route all query logs, even under high load.