### PR TITLE
Change the default segment consumption policy for DropOutOfOrder Tables

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -1877,8 +1877,9 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
     //     TODO: Revisit the non-pauseless handling
     if (_partitionUpsertMetadataManager != null) {
       UpsertContext upsertContext = _partitionUpsertMetadataManager.getContext();
-      if (upsertContext.isAllowPartialUpsertConsumptionDuringCommit()
-          || upsertContext.getUpsertMode() != UpsertConfig.Mode.PARTIAL) {
+      if (upsertContext.isAllowPartialUpsertConsumptionDuringCommit() || (
+          upsertContext.getUpsertMode() != UpsertConfig.Mode.PARTIAL && !upsertContext.isDropOutOfOrderRecord()
+              && upsertContext.getOutOfOrderRecordColumn() == null)) {
         return ParallelSegmentConsumptionPolicy.ALLOW_ALWAYS;
       }
       return pauseless ? ParallelSegmentConsumptionPolicy.ALLOW_DURING_BUILD_ONLY


### PR DESCRIPTION
This change will enable us to change the default segment consumption policy for Upsert tables with dropOutOfOrder=true. When the consumption is enabled on such tables during segment replacement, next consuming segment might see lesser valid docs than actual and might drop the records which shouldn't have been in a replica that's slower. So it is a recommended practice to have this setting to be DISALLOW_ALWAYS rather than having it as ALLOW_ALWAYS in the table config.