### PR TITLE
Fix default HTTPS protocol to use HttpsSegmentFetcher

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/HttpsSegmentFetcher.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/HttpsSegmentFetcher.java
@@ -73,6 +73,12 @@ public class HttpsSegmentFetcher extends HttpSegmentFetcher {
     SSLContext sslContext;
     if (config.getProperty(CommonConstants.CONFIG_OF_SSL_USE_RENEWABLE_CONTEXT, false)) {
       sslContext = TlsUtils.getSslContext();
+    } else if (sslConfig.getKeys().isEmpty()) {
+      // No explicit ssl.* config provided for the segment fetcher; use the globally-installed
+      // SSL context which is initialized from the component's tls.* config (keystore + truststore).
+      // This is needed because the default fetcher config namespace (e.g. pinot.server.segment.fetcher)
+      // typically does not contain ssl.* keys — the TLS config lives under pinot.server.tls.*.
+      sslContext = TlsUtils.getSslContext();
     } else {
       sslContext = new ClientSSLContextGenerator(sslConfig).generate();
     }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/SegmentFetcherFactory.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/SegmentFetcherFactory.java
@@ -48,6 +48,7 @@ public class SegmentFetcherFactory {
   private static final Logger LOGGER = LoggerFactory.getLogger(SegmentFetcherFactory.class);
   private static final Map<String, SegmentFetcher> SEGMENT_FETCHER_MAP = new HashMap<>();
   private static final SegmentFetcher HTTP_SEGMENT_FETCHER = new HttpSegmentFetcher();
+  private static final SegmentFetcher HTTPS_SEGMENT_FETCHER = new HttpsSegmentFetcher();
   private static final SegmentFetcher PINOT_FS_SEGMENT_FETCHER = new PinotFSSegmentFetcher();
 
   /**
@@ -56,6 +57,7 @@ public class SegmentFetcherFactory {
   public static void init(PinotConfiguration config)
       throws Exception {
     HTTP_SEGMENT_FETCHER.init(config); // directly, without sub-namespace
+    HTTPS_SEGMENT_FETCHER.init(config); // directly, without sub-namespace
     PINOT_FS_SEGMENT_FETCHER.init(config); // directly, without sub-namespace
 
     List<String> protocols = config.getProperty(PROTOCOLS_KEY, Collections.emptyList());
@@ -98,7 +100,8 @@ public class SegmentFetcherFactory {
 
   /**
    * Returns the segment fetcher associated with the given protocol, or the default segment fetcher
-   * ({@link HttpSegmentFetcher} for "http" and "https", {@link PinotFSSegmentFetcher} for other protocols).
+   * ({@link HttpSegmentFetcher} for "http", {@link HttpsSegmentFetcher} for "https",
+   * {@link PinotFSSegmentFetcher} for other protocols).
    */
   public static SegmentFetcher getSegmentFetcher(String protocol) {
     SegmentFetcher segmentFetcher = SEGMENT_FETCHER_MAP.get(protocol);
@@ -111,8 +114,9 @@ public class SegmentFetcherFactory {
       }
       switch (protocol) {
         case CommonConstants.HTTP_PROTOCOL:
-        case CommonConstants.HTTPS_PROTOCOL:
           return HTTP_SEGMENT_FETCHER;
+        case CommonConstants.HTTPS_PROTOCOL:
+          return HTTPS_SEGMENT_FETCHER;
         default:
           return PINOT_FS_SEGMENT_FETCHER;
       }

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/fetcher/SegmentFetcherFactoryTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/fetcher/SegmentFetcherFactoryTest.java
@@ -44,7 +44,7 @@ public class SegmentFetcherFactoryTest {
   @Test
   public void testDefaultSegmentFetcherFactory() {
     assertEquals(SegmentFetcherFactory.getSegmentFetcher(HTTP_PROTOCOL).getClass(), HttpSegmentFetcher.class);
-    assertEquals(SegmentFetcherFactory.getSegmentFetcher(HTTPS_PROTOCOL).getClass(), HttpSegmentFetcher.class);
+    assertEquals(SegmentFetcherFactory.getSegmentFetcher(HTTPS_PROTOCOL).getClass(), HttpsSegmentFetcher.class);
     assertEquals(SegmentFetcherFactory.getSegmentFetcher(FILE_PROTOCOL).getClass(), PinotFSSegmentFetcher.class);
     assertEquals(SegmentFetcherFactory.getSegmentFetcher("foo").getClass(), PinotFSSegmentFetcher.class);
   }


### PR DESCRIPTION
The default segment fetcher for HTTPS protocol incorrectly returns HttpSegmentFetcher instead of HttpsSegmentFetcher. This means SSL configuration options in HttpsSegmentFetcher (including the renewable SSL context added in #17315) are never used for default HTTPS fetches.

This change:
- Adds a dedicated HTTPS_SEGMENT_FETCHER instance
- Initializes it alongside other default fetchers
- Returns it for HTTPS protocol in getSegmentFetcher()
- Updates javadoc and test to reflect correct behavior