### PR TITLE
[core] Fix truncate(value) signed-zero and non-finite behavior

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TruncateDecimalTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TruncateDecimalTransformFunction.java
@@ -98,7 +98,22 @@ public class TruncateDecimalTransformFunction extends BaseTransformFunction {
       }
     } else {
       for (int i = 0; i < length; i++) {
-        _doubleValuesSV[i] = Math.signum(leftValues[i]) * Math.floor(Math.abs(leftValues[i]));
+        double value = leftValues[i];
+        if (!Double.isFinite(value)) {
+          // Preserve historical behavior for NaN and infinities.
+          _doubleValuesSV[i] = value;
+          continue;
+        }
+        double truncated;
+        if (value > 0.0d) {
+          truncated = Math.floor(value);
+        } else if (value < 0.0d) {
+          truncated = Math.ceil(value);
+        } else {
+          truncated = 0.0d;
+        }
+        // Normalize -0.0 to +0.0 for deterministic output and test stability.
+        _doubleValuesSV[i] = truncated == 0.0d ? 0.0d : truncated;
       }
     }
     return _doubleValuesSV;


### PR DESCRIPTION
## Summary
This extracts the production truncate(value) behavior fix from #17652 into a standalone PR, per review feedback.

### Changes
- Replace per-row BigDecimal allocation in the no-scale path with allocation-free math truncation (floor/ceil)
- Preserve historical behavior for non-finite inputs (NaN, +Infinity, -Infinity) in the no-scale path
- Canonicalize zero to +0.0 for deterministic output (-0.0 -> +0.0)
- Extend tests with:
  - signed-zero bit-level regression coverage
  - explicit no-scale non-finite coverage

## Validation
- ./mvnw -pl pinot-core -am -Dtest=TruncateDecimalTransformFunctionTest -Dsurefire.failIfNoSpecifiedTests=false test
