### PR TITLE
Fix BasicAuth token configuration naming consistency across Pinot com…

### DIFF
--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerTest.java
@@ -1268,7 +1268,7 @@ public class ControllerTest {
     properties.put(ControllerConf.TABLE_MIN_REPLICAS, DEFAULT_MIN_NUM_REPLICAS);
 
     // Used in PinotControllerAppConfigsTest to test obfuscation
-    properties.put("controller.segment.fetcher.auth.token", "*personal*");
+    properties.put("pinot.controller.segment.fetcher.auth.token", "*personal*");
     properties.put("controller.admin.access.control.principals.user.password", "*personal*");
 
     return properties;

--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/BasicAuthTestUtils.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/BasicAuthTestUtils.java
@@ -27,18 +27,20 @@ public final class BasicAuthTestUtils {
   private BasicAuthTestUtils() {
   }
 
-  public static final String AUTH_TOKEN = "Basic YWRtaW46dmVyeXNlY3JldA=====";
+  public static final String AUTH_TOKEN = "Basic YWRtaW46dmVyeXNlY3JldA==";
   public static final String AUTH_TOKEN_USER = "Basic dXNlcjpzZWNyZXQ==";
   public static final Map<String, String> AUTH_HEADER = Map.of("Authorization", AUTH_TOKEN);
   public static final BasicHeader AUTH_HEADER_BASIC = new BasicHeader("Authorization", AUTH_TOKEN);
   public static final Map<String, String> AUTH_HEADER_USER = Map.of("Authorization", AUTH_TOKEN_USER);
 
   public static void addControllerConfiguration(Map<String, Object> properties) {
-    properties.put("controller.segment.fetcher.auth.token", AUTH_TOKEN);
+    properties.put("pinot.controller.segment.fetcher.auth.token", AUTH_TOKEN);
     properties.put("controller.admin.access.control.factory.class",
         "org.apache.pinot.controller.api.access.BasicAuthAccessControlFactory");
     properties.put("controller.admin.access.control.principals", "admin, user");
     properties.put("controller.admin.access.control.principals.admin.password", "verysecret");
+    // Admin user has access to all tables (no tables restriction means all tables)
+    // Admin user has all permissions (no permissions restriction means all permissions)
     properties.put("controller.admin.access.control.principals.user.password", "secret");
     properties.put("controller.admin.access.control.principals.user.tables", "userTableOnly");
     properties.put("controller.admin.access.control.principals.user.permissions", "read");
@@ -61,7 +63,7 @@ public final class BasicAuthTestUtils {
   }
 
   public static void addMinionConfiguration(PinotConfiguration minionConf) {
-    minionConf.setProperty("segment.fetcher.auth.token", AUTH_TOKEN);
-    minionConf.setProperty("task.auth.token", AUTH_TOKEN);
+    minionConf.setProperty("pinot.minion.segment.fetcher.auth.token", AUTH_TOKEN);
+    minionConf.setProperty("pinot.minion.task.auth.token", AUTH_TOKEN);
   }
 }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/CursorWithAuthIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/CursorWithAuthIntegrationTest.java
@@ -48,9 +48,9 @@ public class CursorWithAuthIntegrationTest extends CursorIntegrationTest {
   @Override
   protected void overrideControllerConf(Map<String, Object> properties) {
     BasicAuthTestUtils.addControllerConfiguration(properties);
-    properties.put("controller.segment.fetcher.auth.provider.class", AUTH_PROVIDER_CLASS);
-    properties.put("controller.segment.fetcher.auth.url", AUTH_URL);
-    properties.put("controller.segment.fetcher.auth.prefix", AUTH_PREFIX);
+    properties.put("pinot.controller.segment.fetcher.auth.provider.class", AUTH_PROVIDER_CLASS);
+    properties.put("pinot.controller.segment.fetcher.auth.url", AUTH_URL);
+    properties.put("pinot.controller.segment.fetcher.auth.prefix", AUTH_PREFIX);
     properties.put(ControllerConf.CONTROLLER_BROKER_AUTH_PREFIX + ".provider.class", AUTH_PROVIDER_CLASS);
     properties.put(ControllerConf.CONTROLLER_BROKER_AUTH_PREFIX + ".url", AUTH_URL);
     properties.put(ControllerConf.CONTROLLER_BROKER_AUTH_PREFIX + ".prefix", AUTH_PREFIX);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/RowLevelSecurityIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/RowLevelSecurityIntegrationTest.java
@@ -57,7 +57,7 @@ public class RowLevelSecurityIntegrationTest extends BaseClusterIntegrationTest 
 
   @Override
   protected void overrideControllerConf(Map<String, Object> properties) {
-    properties.put("controller.segment.fetcher.auth.token", AUTH_TOKEN);
+    properties.put("pinot.controller.segment.fetcher.auth.token", AUTH_TOKEN);
     properties.put("controller.admin.access.control.factory.class",
         "org.apache.pinot.controller.api.access.BasicAuthAccessControlFactory");
     properties.put("controller.admin.access.control.principals", "admin, user, user2");

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/TlsIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/TlsIntegrationTest.java
@@ -482,6 +482,7 @@ public class TlsIntegrationTest extends BaseClusterIntegrationTest {
     Assert.assertNotNull(_controllerStarter.getTaskManager().scheduleTasks(new TaskSchedulingContext()));
 
     // wait for offline segments
+    // Increased timeout from 30s to 90s to account for CI resource contention when running parallel test sets
     JsonNode offlineSegments = TestUtils.waitForResult(() -> {
       JsonNode segmentSets = JsonUtils.stringToJsonNode(
           sendGetRequest(_controllerRequestURLBuilder.forSegmentListAPI(getTableName()), AUTH_HEADER));
@@ -490,7 +491,7 @@ public class TlsIntegrationTest extends BaseClusterIntegrationTest {
               .map(s -> s.get("OFFLINE")).findFirst().get();
       Assert.assertFalse(currentOfflineSegments.isEmpty());
       return currentOfflineSegments;
-    }, 30000);
+    }, 90000);
 
     // Verify constant row count
     ResultSetGroup resultAfterOffline = getPinotConnection().execute(query);

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/AuthZkBasicQuickstart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/AuthZkBasicQuickstart.java
@@ -59,8 +59,8 @@ public class AuthZkBasicQuickstart extends Quickstart {
     properties.put("pinot.server.segment.uploader.auth.token", "Basic YWRtaW46dmVyeXNlY3JldA==");
 
     // minion
-    properties.put("segment.fetcher.auth.token", "Basic YWRtaW46dmVyeXNlY3JldA==");
-    properties.put("task.auth.token", "Basic YWRtaW46dmVyeXNlY3JldA==");
+    properties.put("pinot.minion.segment.fetcher.auth.token", "Basic YWRtaW46dmVyeXNlY3JldA==");
+    properties.put("pinot.minion.task.auth.token", "Basic YWRtaW46dmVyeXNlY3JldA==");
 
     return properties;
   }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/utils/AuthUtils.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/utils/AuthUtils.java
@@ -58,8 +58,8 @@ public class AuthUtils {
     properties.put("pinot.server.instance.auth.token", DEFAULT_AUTH_TOKEN);
 
     // minion
-    properties.put("segment.fetcher.auth.token", DEFAULT_AUTH_TOKEN);
-    properties.put("task.auth.token", DEFAULT_AUTH_TOKEN);
+    properties.put("pinot.minion.segment.fetcher.auth.token", DEFAULT_AUTH_TOKEN);
+    properties.put("pinot.minion.task.auth.token", DEFAULT_AUTH_TOKEN);
 
     // loggers
     properties.put("pinot.controller.logger.root.dir", "logs");


### PR DESCRIPTION
…ponents(Controller, minion,server)

Instructions:
1. The PR has to be tagged with at least one of the following labels (*):
   1. `feature`
   2. `bugfix`
   3. `performance`
   4. `ui`
   5. `backward-incompat`
   6. `release-notes` (**)
2. Remove these instructions before publishing the PR.
 
(*) Other labels to consider:
- `testing`
- `dependencies`
- `docker`
- `kubernetes`
- `observability`
- `security`
- `code-style`
- `extension-point`
- `refactor`
- `cleanup`

(**) Use `release-notes` label for scenarios like:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
