### PR TITLE
[feature] Add Kafka microbatch ingestion plugin

### DIFF
--- a/pinot-integration-tests/pom.xml
+++ b/pinot-integration-tests/pom.xml
@@ -259,6 +259,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-kafka-3.0-microbatch</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>com.h2database</groupId>
       <artifactId>h2</artifactId>
       <scope>test</scope>

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MicroBatchRealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MicroBatchRealtimeClusterIntegrationTest.java
@@ -1,0 +1,401 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.integration.tests;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.File;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import java.util.Set;
+import org.apache.avro.file.DataFileReader;
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.generic.GenericDatumReader;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.commons.io.FileUtils;
+import org.apache.helix.model.IdealState;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.pinot.common.metadata.ZKMetadataProvider;
+import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
+import org.apache.pinot.controller.helix.core.controllerjob.ControllerJobTypes;
+import org.apache.pinot.plugin.stream.microbatch.kafka30.MicroBatchPayloadV1;
+import org.apache.pinot.plugin.stream.microbatch.kafka30.MicroBatchProtocol;
+import org.apache.pinot.segment.spi.index.StandardIndexes;
+import org.apache.pinot.spi.config.table.IndexingConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.filesystem.LocalPinotFS;
+import org.apache.pinot.spi.filesystem.PinotFSFactory;
+import org.apache.pinot.spi.stream.StreamConfig;
+import org.apache.pinot.spi.stream.StreamConfigProperties;
+import org.apache.pinot.spi.stream.StreamMessageDecoder;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+import org.apache.pinot.util.TestUtils;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+
+/**
+ * Integration test for MicroBatch consumer.
+ * This test validates end-to-end ingestion using the MicroBatch pattern where Kafka messages
+ * contain JSON protocol references to batch files (stored in PinotFS) rather than raw records.
+ */
+public class MicroBatchRealtimeClusterIntegrationTest extends BaseRealtimeClusterIntegrationTest {
+  private File _microBatchDataDir;
+  private long _expectedRecordCount;
+  private long _startTime;
+
+  @BeforeClass
+  @Override
+  public void setUp()
+      throws Exception {
+    _startTime = System.currentTimeMillis();
+    // Register LocalPinotFS for file:// URIs before parent setUp
+    PinotFSFactory.register("file", LocalPinotFS.class.getName(), new PinotConfiguration());
+    _microBatchDataDir = new File(FileUtils.getTempDirectory(), "microbatch-" + System.currentTimeMillis());
+    _microBatchDataDir.mkdirs();
+    super.setUp();
+  }
+
+  @Override
+  protected long getCountStarResult() {
+    // Return the actual count we calculated during pushAvroIntoKafka
+    return _expectedRecordCount;
+  }
+
+  @Override
+  protected Map<String, String> getStreamConfigMap() {
+    Map<String, String> streamConfigMap = super.getStreamConfigMap();
+    String streamType = streamConfigMap.get(StreamConfigProperties.STREAM_TYPE);
+    // Override consumer factory to use MicroBatch consumer
+    streamConfigMap.put(
+        StreamConfigProperties.constructStreamProperty(streamType,
+            StreamConfigProperties.STREAM_CONSUMER_FACTORY_CLASS),
+        "org.apache.pinot.plugin.stream.microbatch.kafka30.KafkaMicroBatchConsumerFactory");
+    // Use passthrough decoder since MicroBatch consumer returns GenericRow directly
+    streamConfigMap.put(
+        StreamConfigProperties.constructStreamProperty(streamType,
+            StreamConfigProperties.STREAM_DECODER_CLASS),
+        GenericRowPassThroughDecoder.class.getName());
+    return streamConfigMap;
+  }
+
+  @Override
+  protected void pushAvroIntoKafka(List<File> avroFiles)
+      throws Exception {
+    Properties props = new Properties();
+    props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:" + getKafkaPort());
+    props.put(ProducerConfig.CLIENT_ID_CONFIG, "microbatch-integration-test-producer");
+    props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+    props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
+
+    try (KafkaProducer<String, byte[]> producer = new KafkaProducer<>(props)) {
+      int messageIndex = 0;
+      long totalRecords = 0;
+      for (File avroFile : avroFiles) {
+        // Copy the Avro file to the microbatch data directory and count records
+        File destFile = new File(_microBatchDataDir, "batch-" + messageIndex + ".avro");
+        long recordCount = copyAvroFile(avroFile, destFile);
+        totalRecords += recordCount;
+
+        // Create JSON protocol message with file:// URI and numRecords
+        byte[] protocolMessage = MicroBatchProtocol.createUriMessage(
+            destFile.toURI().toString(), MicroBatchPayloadV1.Format.AVRO, recordCount);
+
+        // Send protocol message to Kafka - distribute across partitions for parallel consumption
+        int partition = messageIndex % getNumKafkaPartitions();
+        producer.send(
+            new ProducerRecord<>(getKafkaTopic(), partition, System.currentTimeMillis(),
+                "key_" + messageIndex, protocolMessage));
+        messageIndex++;
+      }
+      producer.flush();
+      _expectedRecordCount = totalRecords;
+    }
+  }
+
+  /**
+   * Copy Avro file to destination, preserving the schema and records.
+   * @return the number of records copied
+   */
+  private long copyAvroFile(File sourceFile, File destFile)
+      throws Exception {
+    long recordCount = 0;
+    try (DataFileReader<GenericRecord> reader =
+             new DataFileReader<>(sourceFile, new GenericDatumReader<>())) {
+      try (DataFileWriter<GenericRecord> writer =
+               new DataFileWriter<>(new GenericDatumWriter<>(reader.getSchema()))) {
+        writer.create(reader.getSchema(), destFile);
+        while (reader.hasNext()) {
+          writer.append(reader.next());
+          recordCount++;
+        }
+      }
+    }
+    return recordCount;
+  }
+
+  @AfterClass
+  @Override
+  public void tearDown()
+      throws Exception {
+    super.tearDown();
+    if (_microBatchDataDir != null && _microBatchDataDir.exists()) {
+      FileUtils.deleteDirectory(_microBatchDataDir);
+    }
+  }
+
+  // ==================== Additional Tests ====================
+
+  @Test
+  public void testSegmentFlushSize() {
+    String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(getTableName());
+    List<SegmentZKMetadata> segmentsZKMetadata =
+        ZKMetadataProvider.getSegmentsZKMetadata(_propertyStore, realtimeTableName);
+    for (SegmentZKMetadata segMetadata : segmentsZKMetadata) {
+      if (segMetadata.getStatus() != CommonConstants.Segment.Realtime.Status.UPLOADED) {
+        assertEquals(segMetadata.getSizeThresholdToFlushSegment(),
+            getRealtimeSegmentFlushSize() / getNumKafkaPartitions());
+      }
+    }
+  }
+
+  @Test
+  public void testReload()
+      throws Exception {
+    testReload(false);
+  }
+
+  @Test
+  public void testSortedColumn()
+      throws Exception {
+    // There should be no inverted index or range index because the sorted column is not configured with them
+    JsonNode columnIndexSize = getColumnIndexSize(getSortedColumn());
+    assertFalse(columnIndexSize.has(StandardIndexes.INVERTED_ID));
+    assertFalse(columnIndexSize.has(StandardIndexes.RANGE_ID));
+
+    // For point lookup query on sorted column:
+    // - Committed segments have sorted index (no scan needed)
+    // - Consuming segments have inverted index (no scan needed)
+    String query = "SELECT COUNT(*) FROM myTable WHERE Carrier = 'DL'";
+    JsonNode response = postQuery(query);
+    long numEntriesScannedInFilter = response.get("numEntriesScannedInFilter").asLong();
+    // With sorted/inverted index, scan should be minimal or zero
+    long numTotalDocs = getCountStarResult();
+    assertTrue(numEntriesScannedInFilter < numTotalDocs,
+        "Expected minimal scan with sorted/inverted index, but got " + numEntriesScannedInFilter);
+  }
+
+  @Test(dataProvider = "useBothQueryEngines")
+  public void testAddRemoveDictionaryAndInvertedIndex(boolean useMultiStageQueryEngine)
+      throws Exception {
+    setUseMultiStageQueryEngine(useMultiStageQueryEngine);
+    notSupportedInV2();
+    String query = "SELECT COUNT(*) FROM myTable WHERE ActualElapsedTime = -9999";
+    long numTotalDocs = getCountStarResult();
+
+    JsonNode queryResponse = postQuery(query);
+    assertEquals(queryResponse.get("totalDocs").asLong(), numTotalDocs);
+    // Full table scan without dictionary
+    assertEquals(queryResponse.get("numEntriesScannedInFilter").asLong(), numTotalDocs);
+    long queryResult = queryResponse.get("resultTable").get("rows").get(0).get(0).asLong();
+
+    // Enable dictionary and inverted index
+    TableConfig tableConfig = getRealtimeTableConfig();
+    IndexingConfig indexingConfig = tableConfig.getIndexingConfig();
+    assertNotNull(indexingConfig.getNoDictionaryColumns());
+    assertNotNull(indexingConfig.getInvertedIndexColumns());
+    indexingConfig.getNoDictionaryColumns().remove("ActualElapsedTime");
+    indexingConfig.getInvertedIndexColumns().add("ActualElapsedTime");
+    updateTableConfig(tableConfig);
+    String enableDictReloadId = reloadTableAndValidateResponse(getTableName(), TableType.REALTIME, false);
+    TestUtils.waitForCondition(aVoid -> {
+      try {
+        // Query result and total docs should not change during reload
+        JsonNode queryResponse1 = postQuery(query);
+        assertEquals(queryResponse1.get("resultTable").get("rows").get(0).get(0).asLong(), queryResult);
+        assertEquals(queryResponse1.get("totalDocs").asLong(), numTotalDocs);
+
+        long numConsumingSegmentsQueried = queryResponse1.get("numConsumingSegmentsQueried").asLong();
+        long minConsumingFreshnessTimeMs = queryResponse1.get("minConsumingFreshnessTimeMs").asLong();
+        return numConsumingSegmentsQueried == getNumKafkaPartitions()
+            && minConsumingFreshnessTimeMs > _startTime
+            && minConsumingFreshnessTimeMs < System.currentTimeMillis()
+            && isReloadJobCompleted(enableDictReloadId);
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }, 600_000L, "Failed to generate dictionary and inverted index");
+    // numEntriesScannedInFilter should be zero with inverted index
+    queryResponse = postQuery(query);
+    assertEquals(queryResponse.get("numEntriesScannedInFilter").asLong(), 0L);
+
+    // Disable dictionary and inverted index
+    indexingConfig.getNoDictionaryColumns().add("ActualElapsedTime");
+    indexingConfig.getInvertedIndexColumns().remove("ActualElapsedTime");
+    updateTableConfig(tableConfig);
+    String disableDictReloadId = reloadTableAndValidateResponse(getTableName(), TableType.REALTIME, false);
+    TestUtils.waitForCondition(aVoid -> {
+      try {
+        // Query result and total docs should not change during reload
+        JsonNode queryResponse1 = postQuery(query);
+        assertEquals(queryResponse1.get("resultTable").get("rows").get(0).get(0).asLong(), queryResult);
+        assertEquals(queryResponse1.get("totalDocs").asLong(), numTotalDocs);
+        return isReloadJobCompleted(disableDictReloadId);
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }, 60_000L, "Failed to remove dictionary and inverted index");
+    // Should get back to full table scan
+    queryResponse = postQuery(query);
+    assertEquals(queryResponse.get("numEntriesScannedInFilter").asLong(), numTotalDocs);
+  }
+
+  @Test
+  public void testReset() {
+    testReset(TableType.REALTIME);
+  }
+
+  @Test
+  public void testForceCommit()
+      throws Exception {
+    String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(getTableName());
+    Set<String> consumingSegments = getConsumingSegmentsFromIdealState(realtimeTableName);
+    // Use regular force commit without batch
+    String jobId = forceCommit(realtimeTableName);
+    testForceCommitInternal(realtimeTableName, jobId, consumingSegments, 60000L);
+  }
+
+  private Set<String> getConsumingSegmentsFromIdealState(String realtimeTableName) {
+    IdealState idealState = _helixResourceManager.getTableIdealState(realtimeTableName);
+    assertNotNull(idealState);
+    Set<String> consumingSegments = new HashSet<>();
+    for (Map.Entry<String, Map<String, String>> entry : idealState.getRecord().getMapFields().entrySet()) {
+      if (entry.getValue().containsValue(CommonConstants.Helix.StateModel.SegmentStateModel.CONSUMING)) {
+        consumingSegments.add(entry.getKey());
+      }
+    }
+    return consumingSegments;
+  }
+
+  private String forceCommit(String tableName)
+      throws Exception {
+    String response = sendPostRequest(_controllerRequestURLBuilder.forTableForceCommit(tableName), null);
+    return JsonUtils.stringToJsonNode(response).get("forceCommitJobId").asText();
+  }
+
+  private void testForceCommitInternal(String realtimeTableName, String jobId, Set<String> consumingSegments,
+      long timeoutMs) {
+    Map<String, String> jobMetadata =
+        _helixResourceManager.getControllerJobZKMetadata(jobId, ControllerJobTypes.FORCE_COMMIT);
+    assertNotNull(jobMetadata);
+    assertNotNull(jobMetadata.get(CommonConstants.ControllerJob.CONSUMING_SEGMENTS_FORCE_COMMITTED_LIST));
+
+    TestUtils.waitForCondition(aVoid -> {
+      try {
+        if (isForceCommitJobCompleted(jobId)) {
+          for (String segmentName : consumingSegments) {
+            SegmentZKMetadata segmentZKMetadata =
+                _helixResourceManager.getSegmentZKMetadata(realtimeTableName, segmentName);
+            assertNotNull(segmentZKMetadata);
+            assertEquals(segmentZKMetadata.getStatus(), CommonConstants.Segment.Realtime.Status.DONE);
+          }
+          return true;
+        }
+        return false;
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }, timeoutMs, "Error verifying force commit operation on table!");
+  }
+
+  private boolean isForceCommitJobCompleted(String forceCommitJobId)
+      throws Exception {
+    String jobStatusResponse = sendGetRequest(_controllerRequestURLBuilder.forForceCommitJobStatus(forceCommitJobId));
+    JsonNode jobStatus = JsonUtils.stringToJsonNode(jobStatusResponse);
+
+    assertEquals(jobStatus.get("jobId").asText(), forceCommitJobId);
+    assertEquals(jobStatus.get("jobType").asText(), "FORCE_COMMIT");
+
+    Set<String> allSegments = JsonUtils.stringToObject(
+        jobStatus.get(CommonConstants.ControllerJob.CONSUMING_SEGMENTS_FORCE_COMMITTED_LIST).asText(), HashSet.class);
+    Set<String> pendingSegments = new HashSet<>();
+    for (JsonNode element : jobStatus.get(CommonConstants.ControllerJob.CONSUMING_SEGMENTS_YET_TO_BE_COMMITTED_LIST)) {
+      pendingSegments.add(element.asText());
+    }
+
+    assertTrue(pendingSegments.size() <= allSegments.size());
+    assertEquals(jobStatus.get(CommonConstants.ControllerJob.NUM_CONSUMING_SEGMENTS_YET_TO_BE_COMMITTED).asInt(-1),
+        pendingSegments.size());
+
+    return pendingSegments.isEmpty();
+  }
+
+  // ==================== Helper Classes ====================
+
+  /**
+   * Pass-through decoder for MicroBatch consumer.
+   * MicroBatch consumer returns GenericRow directly (already decoded from Avro files),
+   * so this decoder simply passes through the GenericRow without additional decoding.
+   */
+  public static class GenericRowPassThroughDecoder implements StreamMessageDecoder<GenericRow> {
+
+    @Override
+    public void init(Map<String, String> props, Set<String> fieldsToRead, String topicName)
+        throws Exception {
+      // No initialization needed
+    }
+
+    @Override
+    public void init(Set<String> fieldsToRead, StreamConfig streamConfig, TableConfig tableConfig, Schema schema)
+        throws Exception {
+      // No initialization needed
+    }
+
+    @Override
+    public GenericRow decode(GenericRow payload, GenericRow destination) {
+      // Copy all fields from payload to destination
+      destination.init(payload);
+      return destination;
+    }
+
+    @Override
+    public GenericRow decode(GenericRow payload, int offset, int length, GenericRow destination) {
+      // offset and length are not applicable for GenericRow
+      return decode(payload, destination);
+    }
+  }
+}

--- a/pinot-plugins/pinot-microbatch-ingestion/pinot-kafka-3.0-microbatch/CONFIGURATION.md
+++ b/pinot-plugins/pinot-microbatch-ingestion/pinot-kafka-3.0-microbatch/CONFIGURATION.md
@@ -1,0 +1,380 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+# Kafka Microbatch Ingestion Configuration
+
+## Overview
+
+The Kafka Microbatch module enables batch-oriented ingestion from Kafka topics where messages contain references to batch files (URI) or inline encoded data. This is useful for scenarios where:
+
+- Batch files are written to object storage (S3, GCS, Azure, HDFS) and only references are sent to Kafka
+- Large batches need to be grouped and sent as single Kafka messages
+- External batch processing systems produce output files that need to be ingested
+
+## Protocol Format
+
+Messages in Kafka must follow the JSON protocol format (version 1.0):
+
+### Type 1: File Reference (URI)
+```json
+{
+  "version": "1.0",
+  "type": "uri",
+  "format": "avro",
+  "uri": "s3://bucket/path/to/batch-12345.avro"
+}
+```
+
+### Type 2: Inline Data
+```json
+{
+  "version": "1.0",
+  "type": "data",
+  "format": "avro",
+  "data": "<base64-encoded-avro-bytes>"
+}
+```
+
+### Required Fields
+- `version` (string): Protocol version, must be "1.0"
+- `type` (string): Message type - "uri" or "data"
+- `format` (string): Data format - "avro", "parquet", or "json"
+- `uri` (string): File URI (required when type="uri")
+- `data` (string): Base64-encoded data (required when type="data")
+
+## Table Configuration
+
+### Minimum Configuration
+
+```json
+{
+  "tableName": "myTable",
+  "tableType": "REALTIME",
+  "segmentsConfig": {
+    "timeColumnName": "timestamp",
+    "replication": "1",
+    "schemaName": "myTable"
+  },
+  "tableIndexConfig": {
+    "loadMode": "MMAP",
+    "streamConfigs": {
+      "streamType": "kafka",
+      "stream.kafka.topic.name": "microbatch-topic",
+      "stream.kafka.broker.list": "localhost:9092",
+      "stream.kafka.consumer.type": "lowlevel",
+      "stream.kafka.consumer.factory.class.name":
+        "org.apache.pinot.plugin.stream.microbatch.kafka30.KafkaMicroBatchConsumerFactory",
+      "realtime.segment.flush.threshold.rows": "5000000",
+      "realtime.segment.flush.threshold.time": "3600000"
+    }
+  },
+  "tenants": {},
+  "metadata": {}
+}
+```
+
+### Key Configuration Parameters
+
+| Parameter | Required | Description |
+|-----------|----------|-------------|
+| `stream.kafka.consumer.factory.class.name` | Yes | Must be `org.apache.pinot.plugin.stream.microbatch.kafka30.KafkaMicroBatchConsumerFactory` |
+| `stream.kafka.topic.name` | Yes | Kafka topic containing microbatch protocol messages |
+| `stream.kafka.broker.list` | Yes | Kafka broker addresses |
+
+## PinotFS Configuration
+
+For URI-based messages, configure the appropriate PinotFS implementation based on your storage system.
+
+### S3 Configuration
+
+**Server/Controller startup properties:**
+```properties
+# S3 Filesystem
+pinot.fs.s3.class=org.apache.pinot.plugin.filesystem.S3PinotFS
+pinot.fs.s3.region=us-west-2
+pinot.fs.s3.accessKey=<access-key>
+pinot.fs.s3.secretKey=<secret-key>
+
+# Or use IAM roles (recommended)
+pinot.fs.s3.region=us-west-2
+```
+
+**Maven dependency:**
+```xml
+<dependency>
+  <groupId>org.apache.pinot</groupId>
+  <artifactId>pinot-s3</artifactId>
+  <version>${pinot.version}</version>
+</dependency>
+```
+
+**Example URI in protocol:**
+```json
+{
+  "version": "1.0",
+  "type": "uri",
+  "format": "avro",
+  "uri": "s3://my-bucket/batches/batch-20250110-123456.avro"
+}
+```
+
+### HDFS Configuration
+
+**Server/Controller startup properties:**
+```properties
+# HDFS Filesystem
+pinot.fs.hdfs.class=org.apache.pinot.plugin.filesystem.HadoopPinotFS
+pinot.fs.hdfs.hadoop.conf.path=/etc/hadoop/conf
+```
+
+**Maven dependency:**
+```xml
+<dependency>
+  <groupId>org.apache.pinot</groupId>
+  <artifactId>pinot-hdfs</artifactId>
+  <version>${pinot.version}</version>
+</dependency>
+```
+
+**Example URI in protocol:**
+```json
+{
+  "version": "1.0",
+  "type": "uri",
+  "format": "parquet",
+  "uri": "hdfs://namenode:9000/user/pinot/batches/batch-001.parquet"
+}
+```
+
+### Google Cloud Storage (GCS)
+
+**Server/Controller startup properties:**
+```properties
+# GCS Filesystem
+pinot.fs.gs.class=org.apache.pinot.plugin.filesystem.GcsPinotFS
+pinot.fs.gs.projectId=my-project-id
+pinot.fs.gs.gcpKey=<service-account-json>
+```
+
+**Maven dependency:**
+```xml
+<dependency>
+  <groupId>org.apache.pinot</groupId>
+  <artifactId>pinot-gcs</artifactId>
+  <version>${pinot.version}</version>
+</dependency>
+```
+
+**Example URI in protocol:**
+```json
+{
+  "version": "1.0",
+  "type": "uri",
+  "format": "avro",
+  "uri": "gs://my-gcs-bucket/batches/batch-202501.avro"
+}
+```
+
+### Azure Blob Storage (ABFS)
+
+**Server/Controller startup properties:**
+```properties
+# Azure Filesystem
+pinot.fs.abfs.class=org.apache.pinot.plugin.filesystem.AzurePinotFS
+pinot.fs.abfs.accountName=myaccount
+pinot.fs.abfs.accessKey=<access-key>
+```
+
+**Maven dependency:**
+```xml
+<dependency>
+  <groupId>org.apache.pinot</groupId>
+  <artifactId>pinot-azure</artifactId>
+  <version>${pinot.version}</version>
+</dependency>
+```
+
+**Example URI in protocol:**
+```json
+{
+  "version": "1.0",
+  "type": "uri",
+  "format": "json",
+  "uri": "abfs://container@myaccount.dfs.core.windows.net/batches/batch.json"
+}
+```
+
+### Local Filesystem
+
+**Server/Controller startup properties:**
+```properties
+# Local Filesystem (for testing)
+pinot.fs.file.class=org.apache.pinot.spi.filesystem.LocalPinotFS
+```
+
+**Example URI in protocol:**
+```json
+{
+  "version": "1.0",
+  "type": "uri",
+  "format": "avro",
+  "uri": "file:///data/batches/batch-test.avro"
+}
+```
+
+## Supported Data Formats
+
+### AVRO
+- Format: `"avro"`
+- Decoder: `org.apache.pinot.plugin.inputformat.avro.AvroRecordExtractor`
+- File extension: `.avro`
+
+### Parquet
+- Format: `"parquet"`
+- Decoder: `org.apache.pinot.plugin.inputformat.parquet.ParquetRecordExtractor`
+- File extension: `.parquet`
+
+### JSON
+- Format: `"json"`
+- Decoder: `org.apache.pinot.plugin.inputformat.json.JSONRecordExtractor`
+- File extension: `.json`
+
+## Producer Configuration
+
+### Java Producer Example
+
+```java
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import java.util.Properties;
+
+// Using the MicroBatchProtocol helper
+byte[] protocolMessage = MicroBatchProtocol.createUriMessage(
+    "s3://my-bucket/batch-123.avro",
+    MicroBatchProtocol.Format.AVRO
+);
+
+Properties props = new Properties();
+props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
+    "org.apache.kafka.common.serialization.StringSerializer");
+props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
+    "org.apache.kafka.common.serialization.ByteArraySerializer");
+
+try (KafkaProducer<String, byte[]> producer = new KafkaProducer<>(props)) {
+    producer.send(new ProducerRecord<>(
+        "microbatch-topic",
+        "batch-123",
+        protocolMessage
+    ));
+}
+```
+
+### Python Producer Example
+
+```python
+from kafka import KafkaProducer
+import json
+import base64
+
+def create_uri_message(uri, format_type="avro"):
+    return json.dumps({
+        "version": "1.0",
+        "type": "uri",
+        "format": format_type,
+        "uri": uri
+    }).encode('utf-8')
+
+def create_data_message(data_bytes, format_type="avro"):
+    return json.dumps({
+        "version": "1.0",
+        "type": "data",
+        "format": format_type,
+        "data": base64.b64encode(data_bytes).decode('utf-8')
+    }).encode('utf-8')
+
+producer = KafkaProducer(
+    bootstrap_servers=['localhost:9092'],
+    value_serializer=lambda v: v
+)
+
+# Send URI message
+uri_message = create_uri_message("s3://bucket/batch.avro")
+producer.send('microbatch-topic', key=b'batch-1', value=uri_message)
+
+# Send inline data message
+with open('batch.avro', 'rb') as f:
+    data_message = create_data_message(f.read())
+    producer.send('microbatch-topic', key=b'batch-2', value=data_message)
+
+producer.flush()
+```
+
+## Best Practices
+
+1. **File Naming**: Use timestamped or sequential batch file names for easier tracking
+   - Example: `batch-{timestamp}-{sequence}.avro`
+
+2. **File Size**: Keep batch files reasonably sized (10MB - 1GB) to balance:
+   - Kafka message size limits (for inline data)
+   - Download time and memory usage
+   - Parallelism and throughput
+
+3. **Cleanup**: Implement lifecycle policies on your storage:
+   - S3: Use lifecycle rules to archive/delete old batches
+   - HDFS: Use scheduled cleanup jobs
+   - Ensure Pinot has processed batches before deletion
+
+4. **Monitoring**: Track key metrics:
+   - Kafka consumer lag
+   - File download latency
+   - Processing throughput
+   - Failed protocol parsing attempts
+
+5. **Error Handling**:
+   - Invalid protocol messages will fail with clear error messages
+   - Missing files will fail the consumer - ensure files exist before sending URIs
+   - Use Kafka retries and dead letter queues for production
+
+## Troubleshooting
+
+### Issue: "Failed to parse microbatch protocol"
+**Cause**: Kafka message doesn't follow the JSON protocol format
+**Solution**: Verify message structure includes all required fields (version, type, format, uri/data)
+
+### Issue: "Unsupported protocol version"
+**Cause**: Message has version other than "1.0"
+**Solution**: Ensure producer creates messages with version "1.0"
+
+### Issue: "Failed to download file from PinotFS"
+**Cause**: File doesn't exist or PinotFS not configured
+**Solution**:
+- Verify file exists at the URI
+- Check PinotFS configuration for the URI scheme (s3://, hdfs://, etc.)
+- Verify authentication/permissions
+
+### Issue: "Invalid format"
+**Cause**: Unsupported format specified
+**Solution**: Use only supported formats: avro, parquet, json
+
+## Migration from Legacy Approach
+
+If you were previously sending raw URIs or data as Kafka messages (without JSON protocol), update your producers to use the protocol format. The microbatch module does not support legacy formats - all messages must use the JSON protocol.

--- a/pinot-plugins/pinot-microbatch-ingestion/pinot-kafka-3.0-microbatch/pom.xml
+++ b/pinot-plugins/pinot-microbatch-ingestion/pinot-kafka-3.0-microbatch/pom.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>pinot-microbatch-ingestion</artifactId>
+    <groupId>org.apache.pinot</groupId>
+    <version>1.5.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>pinot-kafka-3.0-microbatch</artifactId>
+  <name>Pinot Kafka 3.x Microbatch</name>
+  <url>https://pinot.apache.org/</url>
+  <properties>
+    <pinot.root>${basedir}/../../..</pinot.root>
+    <shade.phase.prop>package</shade.phase.prop>
+  </properties>
+
+  <dependencies>
+    <!-- Pinot dependencies -->
+    <dependency>
+      <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-kafka-base</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-kafka-3.0</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+
+    <!-- PinotFS dependencies -->
+    <dependency>
+      <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-common</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- Test dependencies -->
+    <dependency>
+      <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-kafka-base</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-avro</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/pinot-plugins/pinot-microbatch-ingestion/pinot-kafka-3.0-microbatch/src/main/java/org/apache/pinot/plugin/stream/microbatch/kafka30/GenericRowMessageBatch.java
+++ b/pinot-plugins/pinot-microbatch-ingestion/pinot-kafka-3.0-microbatch/src/main/java/org/apache/pinot/plugin/stream/microbatch/kafka30/GenericRowMessageBatch.java
@@ -1,0 +1,88 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.stream.microbatch.kafka30;
+
+import java.util.List;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.stream.MessageBatch;
+import org.apache.pinot.spi.stream.StreamMessage;
+import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
+
+
+/**
+ * Implementation of {@link MessageBatch} that holds {@link GenericRow} messages.
+ *
+ * <p>This class is used by the MicroBatch consumer to return decoded records from batch files.
+ * Each batch contains a list of stream messages with their associated metadata, including
+ * composite offsets that track both the Kafka message offset and the record position within
+ * the batch file.
+ *
+ * @see KafkaPartitionLevelMicroBatchConsumer
+ * @see MessageBatchReader
+ */
+public class GenericRowMessageBatch implements MessageBatch<GenericRow> {
+  private final List<StreamMessage<GenericRow>> _messages;
+  private final int _unfilteredMessageCount;
+  private final boolean _hasDataLoss;
+  private final long _sizeInBytes;
+  private final StreamPartitionMsgOffset _offsetOfNextBatch;
+
+  public GenericRowMessageBatch(
+      List<StreamMessage<GenericRow>> messages,
+      int unfilteredMessageCount,
+      boolean hasDataLoss,
+      long sizeInBytes,
+      StreamPartitionMsgOffset offsetOfNextBatch) {
+    _messages = messages;
+    _unfilteredMessageCount = unfilteredMessageCount;
+    _hasDataLoss = hasDataLoss;
+    _sizeInBytes = sizeInBytes;
+    _offsetOfNextBatch = offsetOfNextBatch;
+  }
+
+  @Override
+  public int getMessageCount() {
+    return _messages.size();
+  }
+
+  @Override
+  public int getUnfilteredMessageCount() {
+    return _unfilteredMessageCount;
+  }
+
+  @Override
+  public StreamMessage<GenericRow> getStreamMessage(int index) {
+    return _messages.get(index);
+  }
+
+  @Override
+  public StreamPartitionMsgOffset getOffsetOfNextBatch() {
+    return _offsetOfNextBatch;
+  }
+
+  @Override
+  public boolean hasDataLoss() {
+    return _hasDataLoss;
+  }
+
+  @Override
+  public long getSizeInBytes() {
+    return _sizeInBytes;
+  }
+}

--- a/pinot-plugins/pinot-microbatch-ingestion/pinot-kafka-3.0-microbatch/src/main/java/org/apache/pinot/plugin/stream/microbatch/kafka30/KafkaMicroBatchConsumerFactory.java
+++ b/pinot-plugins/pinot-microbatch-ingestion/pinot-kafka-3.0-microbatch/src/main/java/org/apache/pinot/plugin/stream/microbatch/kafka30/KafkaMicroBatchConsumerFactory.java
@@ -1,0 +1,129 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.stream.microbatch.kafka30;
+
+import org.apache.pinot.plugin.stream.kafka.KafkaConfigBackwardCompatibleUtils;
+import org.apache.pinot.plugin.stream.kafka30.KafkaStreamMetadataProvider;
+import org.apache.pinot.spi.stream.PartitionGroupConsumer;
+import org.apache.pinot.spi.stream.PartitionGroupConsumptionStatus;
+import org.apache.pinot.spi.stream.StreamConfig;
+import org.apache.pinot.spi.stream.StreamConsumerFactory;
+import org.apache.pinot.spi.stream.StreamMetadataProvider;
+import org.apache.pinot.spi.stream.StreamPartitionMsgOffsetFactory;
+import org.apache.pinot.spi.utils.retry.RetryPolicy;
+
+
+/**
+ * Consumer factory for Kafka microbatch ingestion.
+ *
+ * <p>This factory creates consumers that expect Kafka messages in binary protocol format
+ * (version byte + JSON payload) with references to batch files (URIs) or inline data.
+ *
+ * <p>Configuration example:
+ * <pre>
+ * {
+ *   "streamType": "kafka",
+ *   "stream.kafka.topic.name": "microbatch-topic",
+ *   "stream.kafka.broker.list": "localhost:9092",
+ *   "stream.kafka.consumer.factory.class.name":
+ *     "org.apache.pinot.plugin.stream.microbatch.kafka30.KafkaMicroBatchConsumerFactory",
+ *   "stream.microbatch.kafka.file.fetch.threads": "4"
+ * }
+ * </pre>
+ *
+ * <p>For file URIs in protocol messages, configure PinotFS:
+ * <pre>
+ * # For S3
+ * pinot.fs.s3.class=org.apache.pinot.plugin.filesystem.S3PinotFS
+ * pinot.fs.s3.region=us-west-2
+ *
+ * # For HDFS
+ * pinot.fs.hdfs.class=org.apache.pinot.plugin.filesystem.HadoopPinotFS
+ * </pre>
+ *
+ * @see MicroBatchConfigProperties for all available configuration options
+ */
+public class KafkaMicroBatchConsumerFactory extends StreamConsumerFactory {
+
+  private int _numFileFetchThreads = MicroBatchConfigProperties.DEFAULT_FILE_FETCH_THREADS;
+
+  @Override
+  protected void init(StreamConfig streamConfig) {
+    KafkaConfigBackwardCompatibleUtils.handleStreamConfig(streamConfig);
+    super.init(streamConfig);
+
+    // Parse parallel dataloaders config
+    int fileFetchThreads = MicroBatchConfigProperties.getIntProperty(
+        streamConfig,
+        MicroBatchConfigProperties.FILE_FETCH_THREADS,
+        MicroBatchConfigProperties.DEFAULT_FILE_FETCH_THREADS);
+
+    if (fileFetchThreads < 1) {
+      throw new IllegalArgumentException(
+          MicroBatchConfigProperties.FILE_FETCH_THREADS + " must be >= 1, got: " + fileFetchThreads);
+    }
+    _numFileFetchThreads = fileFetchThreads;
+  }
+
+  @Override
+  public StreamMetadataProvider createPartitionMetadataProvider(String clientId, int partition) {
+    return new MicroBatchStreamMetadataProvider(
+        new KafkaStreamMetadataProvider(clientId, _streamConfig, partition));
+  }
+
+  @Override
+  public StreamMetadataProvider createStreamMetadataProvider(String clientId) {
+    return new MicroBatchStreamMetadataProvider(
+        new KafkaStreamMetadataProvider(clientId, _streamConfig));
+  }
+
+  @Override
+  public StreamMetadataProvider createStreamMetadataProvider(
+      String clientId, boolean concurrentAccessExpected) {
+    if (concurrentAccessExpected) {
+      return new SynchronizedKafkaStreamMetadataProvider(
+          new KafkaStreamMetadataProvider(clientId, _streamConfig));
+    } else {
+      return createStreamMetadataProvider(clientId);
+    }
+  }
+
+  @Override
+  public StreamPartitionMsgOffsetFactory createStreamMsgOffsetFactory() {
+    return new MicroBatchStreamPartitionMsgOffsetFactory();
+  }
+
+  @Override
+  public PartitionGroupConsumer createPartitionGroupConsumer(
+      String clientId, PartitionGroupConsumptionStatus partitionGroupConsumptionStatus) {
+    return new KafkaPartitionLevelMicroBatchConsumer(
+        clientId, _streamConfig, partitionGroupConsumptionStatus.getStreamPartitionGroupId(),
+        _numFileFetchThreads);
+  }
+
+  @Override
+  public PartitionGroupConsumer createPartitionGroupConsumer(
+      String clientId,
+      PartitionGroupConsumptionStatus partitionGroupConsumptionStatus,
+      RetryPolicy retryPolicy) {
+    return new KafkaPartitionLevelMicroBatchConsumer(
+        clientId, _streamConfig, partitionGroupConsumptionStatus.getStreamPartitionGroupId(),
+        retryPolicy, _numFileFetchThreads);
+  }
+}

--- a/pinot-plugins/pinot-microbatch-ingestion/pinot-kafka-3.0-microbatch/src/main/java/org/apache/pinot/plugin/stream/microbatch/kafka30/KafkaPartitionLevelMicroBatchConsumer.java
+++ b/pinot-plugins/pinot-microbatch-ingestion/pinot-kafka-3.0-microbatch/src/main/java/org/apache/pinot/plugin/stream/microbatch/kafka30/KafkaPartitionLevelMicroBatchConsumer.java
@@ -1,0 +1,238 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.stream.microbatch.kafka30;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.common.header.Header;
+import org.apache.kafka.common.header.Headers;
+import org.apache.kafka.common.utils.Bytes;
+import org.apache.pinot.plugin.stream.kafka.KafkaStreamConfigProperties;
+import org.apache.pinot.plugin.stream.kafka.KafkaStreamMessageMetadata;
+import org.apache.pinot.plugin.stream.kafka30.KafkaPartitionLevelConnectionHandler;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.stream.MessageBatch;
+import org.apache.pinot.spi.stream.PartitionGroupConsumer;
+import org.apache.pinot.spi.stream.StreamConfig;
+import org.apache.pinot.spi.stream.StreamMessageMetadata;
+import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
+import org.apache.pinot.spi.utils.retry.RetryPolicy;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Kafka partition-level consumer for MicroBatch ingestion.
+ *
+ * <p>This consumer reads Kafka messages containing MicroBatch protocol payloads (references to
+ * batch files in PinotFS or inline data) and returns decoded {@link GenericRow} records. Unlike
+ * traditional Kafka consumers that process individual records, this consumer:
+ *
+ * <ol>
+ *   <li>Polls Kafka for protocol messages containing file URIs or inline data</li>
+ *   <li>Downloads batch files from PinotFS (S3, HDFS, GCS, etc.) via {@link MicroBatchQueueManager}</li>
+ *   <li>Parses files using Pinot's {@link org.apache.pinot.spi.data.readers.RecordReader}</li>
+ *   <li>Returns records as {@link MessageBatch} with composite offsets for mid-batch resume</li>
+ * </ol>
+ *
+ * <p>The consumer maintains state to support mid-batch resume after segment commits. When
+ * restarting from a composite offset like {@code {"kmo":5,"mbro":100}}, it seeks to Kafka
+ * offset 5 and skips the first 100 records in that batch file.
+ *
+ * <p>Threading: This consumer delegates file downloads to {@link MicroBatchQueueManager},
+ * which uses a configurable thread pool for parallel processing.
+ *
+ * @see MicroBatchProtocol for the wire protocol format
+ * @see MicroBatchStreamPartitionMsgOffset for the composite offset format
+ * @see MicroBatchQueueManager for batch file processing
+ */
+public class KafkaPartitionLevelMicroBatchConsumer extends KafkaPartitionLevelConnectionHandler
+    implements PartitionGroupConsumer {
+  private static final Logger LOGGER =
+      LoggerFactory.getLogger(KafkaPartitionLevelMicroBatchConsumer.class);
+
+  private final MicroBatchQueueManager _providerManager;
+
+  private MicroBatchStreamPartitionMsgOffset _lastFetchedOffset = null;
+
+  public KafkaPartitionLevelMicroBatchConsumer(
+      String clientId, StreamConfig streamConfig, int partition, int numFileFetchThreads) {
+    super(clientId, streamConfig, partition);
+    _providerManager = new MicroBatchQueueManager(partition, numFileFetchThreads);
+  }
+
+  public KafkaPartitionLevelMicroBatchConsumer(
+      String clientId,
+      StreamConfig streamConfig,
+      int partition,
+      RetryPolicy retryPolicy,
+      int numFileFetchThreads) {
+    super(clientId, streamConfig, partition, retryPolicy);
+    _providerManager = new MicroBatchQueueManager(partition, numFileFetchThreads);
+  }
+
+  @Override
+  public synchronized MessageBatch<GenericRow> fetchMessages(
+      StreamPartitionMsgOffset startMsgOffset, int timeoutMs) {
+    MicroBatchStreamPartitionMsgOffset mbStartOffset =
+        (MicroBatchStreamPartitionMsgOffset) startMsgOffset;
+    if (_lastFetchedOffset == null || !isContinuation(_lastFetchedOffset, mbStartOffset)) {
+      LOGGER.debug(
+          "Seeking to offset {} (last fetched offset was {})", mbStartOffset, _lastFetchedOffset);
+      _providerManager.clear();
+      long kafkaOffset = mbStartOffset.getKafkaMessageOffset();
+      _consumer.seek(_topicPartition, kafkaOffset);
+    }
+    MessageBatch<GenericRow> messageBatch;
+    if (!_providerManager.hasData()) {
+      // Pass the startRecordOffset for mid-batch resume - only applies to the first Kafka message
+      int startRecordOffset = (int) mbStartOffset.getRecordOffsetInMicroBatch();
+      pollKafka(mbStartOffset.getKafkaMessageOffset(), startRecordOffset, timeoutMs);
+    }
+    messageBatch = _providerManager.getNextMessageBatch();
+    if (messageBatch != null) {
+      // Update _lastFetchedOffset from the last message in the batch
+      if (messageBatch.getMessageCount() > 0) {
+        int lastIndex = messageBatch.getMessageCount() - 1;
+        _lastFetchedOffset = (MicroBatchStreamPartitionMsgOffset)
+            messageBatch.getStreamMessage(lastIndex).getMetadata().getOffset();
+      }
+      return messageBatch;
+    }
+    _lastFetchedOffset =
+        new MicroBatchStreamPartitionMsgOffset(mbStartOffset.getKafkaMessageOffset(), -1);
+    return new GenericRowMessageBatch(Collections.emptyList(), 0, false, 0, mbStartOffset);
+  }
+
+  private boolean isContinuation(
+      MicroBatchStreamPartitionMsgOffset lastFetchedOffset,
+      MicroBatchStreamPartitionMsgOffset mbStartOffset) {
+    return lastFetchedOffset.getKafkaMessageOffset() == mbStartOffset.getKafkaMessageOffset()
+        && lastFetchedOffset.getRecordOffsetInMicroBatch()
+            == mbStartOffset.getRecordOffsetInMicroBatch() - 1;
+  }
+
+  /**
+   * Poll Kafka for messages and submit them to the queue manager.
+   *
+   * @param targetKafkaOffset the expected Kafka offset (for data loss detection)
+   * @param startRecordOffset for the first Kafka message at targetKafkaOffset, skip this many
+   *                          records (for mid-batch resume). Subsequent messages start from 0.
+   * @param timeoutMs poll timeout in milliseconds
+   */
+  private void pollKafka(long targetKafkaOffset, int startRecordOffset, int timeoutMs) {
+    ConsumerRecords<String, Bytes> consumerRecords = _consumer.poll(Duration.ofMillis(timeoutMs));
+    List<ConsumerRecord<String, Bytes>> records = consumerRecords.records(_topicPartition);
+    if (records.isEmpty()) {
+      return;
+    }
+
+    // In case read_committed is enabled, the messages consumed are not guaranteed to have
+    // consecutive offsets.
+    // TODO: A better solution would be to fetch earliest offset from topic and see if it is greater
+    // than startOffset.
+    // However, this would require and additional call to Kafka which we want to avoid.
+    long firstOffset = records.get(0).offset();
+    boolean hasDataLoss = false;
+    if (_config.getKafkaIsolationLevel() == null
+        || _config
+            .getKafkaIsolationLevel()
+            .equals(
+                KafkaStreamConfigProperties.LowLevelConsumer
+                    .KAFKA_ISOLATION_LEVEL_READ_UNCOMMITTED)) {
+      hasDataLoss = firstOffset > targetKafkaOffset;
+    }
+
+    int nullMessages = 0;
+    for (ConsumerRecord<String, Bytes> record : records) {
+      StreamMessageMetadata messageMetadata = extractMessageMetadata(record);
+      String key = record.key();
+      byte[] keyBytes = key != null ? key.getBytes(StandardCharsets.UTF_8) : null;
+      Bytes message = record.value();
+      if (message == null) {
+        LOGGER.debug("Tombstone message at offset: {}", record.offset());
+        nullMessages++;
+        continue;
+      }
+      try {
+        // Parse JSON protocol - will throw exception if invalid
+        MicroBatchProtocol protocol = MicroBatchProtocol.parse(message.get());
+
+        // For the first message at targetKafkaOffset, use startRecordOffset to skip records.
+        // Subsequent messages start from record 0.
+        int recordsToSkip = (record.offset() == targetKafkaOffset) ? startRecordOffset : 0;
+
+        MicroBatch microBatch =
+            new MicroBatch(
+                keyBytes, nullMessages + 1, protocol, messageMetadata, hasDataLoss, recordsToSkip);
+        nullMessages = 0;
+        hasDataLoss = false;
+
+        _providerManager.submitBatch(microBatch);
+      } catch (Exception e) {
+        throw new RuntimeException(
+            "Failed to parse microbatch protocol at offset: " + record.offset(), e);
+      }
+    }
+  }
+
+  private StreamMessageMetadata extractMessageMetadata(ConsumerRecord<String, Bytes> record) {
+    long timestamp = record.timestamp();
+    long offset = record.offset();
+
+    StreamMessageMetadata.Builder builder =
+        new StreamMessageMetadata.Builder()
+            .setRecordIngestionTimeMs(timestamp)
+            .setOffset(
+                MicroBatchStreamPartitionMsgOffset.of(offset),
+                MicroBatchStreamPartitionMsgOffset.of(offset + 1))
+            .setSerializedValueSize(record.serializedValueSize());
+    if (_config.isPopulateMetadata()) {
+      Headers headers = record.headers();
+      if (headers != null) {
+        GenericRow headerGenericRow = new GenericRow();
+        for (Header header : headers.toArray()) {
+          headerGenericRow.putValue(header.key(), header.value());
+        }
+        builder.setHeaders(headerGenericRow);
+      }
+      builder.setMetadata(
+          Map.of(
+              KafkaStreamMessageMetadata.RECORD_TIMESTAMP_KEY,
+              String.valueOf(timestamp),
+              KafkaStreamMessageMetadata.METADATA_OFFSET_KEY,
+              String.valueOf(offset),
+              KafkaStreamMessageMetadata.METADATA_PARTITION_KEY,
+              String.valueOf(record.partition())));
+    }
+    return builder.build();
+  }
+
+  @Override
+  public void close() throws IOException {
+    _providerManager.close();
+    super.close();
+  }
+}

--- a/pinot-plugins/pinot-microbatch-ingestion/pinot-kafka-3.0-microbatch/src/main/java/org/apache/pinot/plugin/stream/microbatch/kafka30/MessageBatchReader.java
+++ b/pinot-plugins/pinot-microbatch-ingestion/pinot-kafka-3.0-microbatch/src/main/java/org/apache/pinot/plugin/stream/microbatch/kafka30/MessageBatchReader.java
@@ -1,0 +1,245 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.stream.microbatch.kafka30;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+import org.apache.kafka.common.utils.CloseableIterator;
+import org.apache.pinot.spi.data.readers.FileFormat;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.data.readers.RecordReader;
+import org.apache.pinot.spi.data.readers.RecordReaderFileConfig;
+import org.apache.pinot.spi.stream.MessageBatch;
+import org.apache.pinot.spi.stream.StreamMessage;
+import org.apache.pinot.spi.stream.StreamMessageMetadata;
+import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Reads batch files and converts them into {@link MessageBatch} objects.
+ *
+ * <p>This utility class handles the conversion of downloaded batch files (Avro, Parquet, JSON)
+ * into streams of {@link GenericRow} records wrapped in {@link MessageBatch} containers. It uses
+ * Pinot's {@link RecordReader} infrastructure to parse files and generates composite offsets
+ * for each record to enable mid-batch resume.
+ *
+ * <p>Key features:
+ * <ul>
+ *   <li>Lazy iteration: Records are read on-demand, not loaded entirely into memory</li>
+ *   <li>Mid-batch resume: Supports skipping records for restart after segment commit</li>
+ *   <li>Batch sizing: Groups records into configurable batch sizes (default 500)</li>
+ *   <li>Offset tracking: Each record gets a composite offset (Kafka offset + record index)</li>
+ * </ul>
+ *
+ * <p>Usage:
+ * <pre>
+ * try (CloseableIterator&lt;MessageBatch&lt;GenericRow&gt;&gt; iterator =
+ *     MessageBatchReader.read(microBatch, dataFile, batchSize, totalRecords, recordsToSkip)) {
+ *   while (iterator.hasNext()) {
+ *     MessageBatch&lt;GenericRow&gt; batch = iterator.next();
+ *     // process batch
+ *   }
+ * }
+ * </pre>
+ *
+ * @see MicroBatchQueueManager which uses this class to process downloaded files
+ */
+public final class MessageBatchReader {
+  private static final Logger LOGGER = LoggerFactory.getLogger(MessageBatchReader.class);
+
+  private MessageBatchReader() {
+  }
+
+  public static CloseableIterator<MessageBatch<GenericRow>> read(
+      MicroBatch microBatch,
+      File dataFile,
+      int messageBatchSize,
+      int totalRecordCount,
+      int recordsToSkip) {
+    try {
+      FileFormat fileFormat =
+          convertProtocolFormatToFileFormat(microBatch.getProtocol().getFormat());
+      RecordReaderFileConfig recordReaderFileConfig =
+          new RecordReaderFileConfig(fileFormat, dataFile, null, null, null);
+      RecordReader recordReader = recordReaderFileConfig.getRecordReader();
+      return new LazyMessageBatchIterator(
+          microBatch,
+          dataFile.length(),
+          recordReader,
+          messageBatchSize,
+          totalRecordCount,
+          recordsToSkip);
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to parse records from file: " + dataFile, e);
+    }
+  }
+
+  private static class LazyMessageBatchIterator
+      implements CloseableIterator<MessageBatch<GenericRow>> {
+    private final MicroBatch _microBatch;
+    private final long _dataSize;
+    private final RecordReader _recordReader;
+    private final int _messageBatchSize;
+    private final int _totalRecordCount;
+    private final StreamMessageMetadata _microBatchMetadata;
+    private final int _valueSize;
+
+    private int _currentRecordIndex;
+    private boolean _closed;
+
+    public LazyMessageBatchIterator(
+        MicroBatch microBatch,
+        long dataSize,
+        RecordReader recordReader,
+        int messageBatchSize,
+        int totalRecordCount,
+        int recordsToSkip) {
+      _microBatch = microBatch;
+      _dataSize = dataSize;
+      _recordReader = recordReader;
+      _messageBatchSize = messageBatchSize;
+      _totalRecordCount = totalRecordCount;
+      _microBatchMetadata = microBatch.getMessageMetadata();
+
+      _valueSize = Math.toIntExact(_totalRecordCount == 0 ? 0 : _dataSize / _totalRecordCount);
+      _closed = false;
+
+      // Skip records for mid-batch resume
+      _currentRecordIndex = skipRecords(recordsToSkip);
+    }
+
+    /**
+     * Skip the specified number of records in the file.
+     * @return the actual number of records skipped (may be less if file has fewer records)
+     */
+    private int skipRecords(int recordsToSkip) {
+      try {
+        int skipped = 0;
+        while (skipped < recordsToSkip && _recordReader.hasNext()) {
+          _recordReader.next();  // Read and discard
+          skipped++;
+        }
+        return skipped;
+      } catch (Exception e) {
+        throw new RuntimeException("Failed to skip records", e);
+      }
+    }
+
+    @Override
+    public boolean hasNext() {
+      return !_closed && _currentRecordIndex < _totalRecordCount && _recordReader.hasNext();
+    }
+
+    @Override
+    public MessageBatch next() {
+      if (!hasNext()) {
+        throw new NoSuchElementException("No more message batches available");
+      }
+
+      try {
+        int startIndex = _currentRecordIndex;
+        int batchSize = Math.min(_messageBatchSize, _totalRecordCount - _currentRecordIndex);
+
+        List<StreamMessage<GenericRow>> streamMessageList = new ArrayList<>(batchSize);
+        for (int i = 0; i < batchSize && _recordReader.hasNext(); i++) {
+          GenericRow row = _recordReader.next();
+          int recordIndex = startIndex + i;
+
+          long kafkaMessageOffset =
+              ((MicroBatchStreamPartitionMsgOffset) _microBatchMetadata.getOffset()).getKafkaMessageOffset();
+          long nextKafkaMessageOffset =
+              ((MicroBatchStreamPartitionMsgOffset) _microBatchMetadata.getNextOffset()).getKafkaMessageOffset();
+
+          StreamPartitionMsgOffset msgOffset =
+              new MicroBatchStreamPartitionMsgOffset(kafkaMessageOffset, recordIndex);
+          StreamPartitionMsgOffset nextOffset;
+          if (recordIndex == _totalRecordCount - 1) {
+            nextOffset = new MicroBatchStreamPartitionMsgOffset(nextKafkaMessageOffset, 0);
+          } else {
+            nextOffset =
+                new MicroBatchStreamPartitionMsgOffset(kafkaMessageOffset, recordIndex + 1);
+          }
+
+          StreamMessageMetadata metadata =
+              new StreamMessageMetadata.Builder()
+                  .setRecordIngestionTimeMs(_microBatchMetadata.getRecordIngestionTimeMs())
+                  .setFirstStreamRecordIngestionTimeMs(
+                      _microBatchMetadata.getFirstStreamRecordIngestionTimeMs())
+                  .setOffset(msgOffset, nextOffset)
+                  .setSerializedValueSize(_valueSize)
+                  .setHeaders(_microBatchMetadata.getHeaders())
+                  .setMetadata(_microBatchMetadata.getRecordMetadata())
+                  .build();
+
+          streamMessageList.add(
+              new StreamMessage<>(_microBatch.getKey(), row, _valueSize, metadata));
+          _currentRecordIndex++;
+        }
+
+        return new GenericRowMessageBatch(
+            streamMessageList,
+            _microBatch.getUnfilteredMessageCount(),
+            _microBatch.hasDataLoss(),
+            (long) streamMessageList.size() * _valueSize,
+            streamMessageList.get(streamMessageList.size() - 1).getMetadata().getNextOffset());
+      } catch (Exception e) {
+        throw new RuntimeException("Failed to build message batch", e);
+      }
+    }
+
+    @Override
+    public void close() {
+      if (_closed) {
+        return;
+      }
+      try {
+        // Validate that we didn't encounter more records than expected
+        if (_recordReader.hasNext()) {
+          LOGGER.error("RecordReader has more records than expected totalRecordCount={}. "
+              + "Processed {} records so far. This indicates a mismatch between numRecords in the "
+              + "protocol message and actual file contents.", _totalRecordCount, _currentRecordIndex);
+        }
+        _recordReader.close();
+      } catch (IOException e) {
+        throw new RuntimeException("Failed to close record reader", e);
+      } finally {
+        _closed = true;
+      }
+    }
+  }
+
+  private static FileFormat convertProtocolFormatToFileFormat(
+      MicroBatchPayloadV1.Format protocolFormat) {
+    switch (protocolFormat) {
+      case AVRO:
+        return FileFormat.AVRO;
+      case PARQUET:
+        return FileFormat.PARQUET;
+      case JSON:
+        return FileFormat.JSON;
+      default:
+        throw new IllegalArgumentException("Unsupported format: " + protocolFormat);
+    }
+  }
+}

--- a/pinot-plugins/pinot-microbatch-ingestion/pinot-kafka-3.0-microbatch/src/main/java/org/apache/pinot/plugin/stream/microbatch/kafka30/MicroBatch.java
+++ b/pinot-plugins/pinot-microbatch-ingestion/pinot-kafka-3.0-microbatch/src/main/java/org/apache/pinot/plugin/stream/microbatch/kafka30/MicroBatch.java
@@ -1,0 +1,85 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.stream.microbatch.kafka30;
+
+import org.apache.pinot.spi.stream.StreamMessageMetadata;
+
+/**
+ * Represents a microbatch message with protocol information
+ */
+public class MicroBatch {
+  private final byte[] _key;
+  private final int _unfilteredMessageCount;
+  private final MicroBatchProtocol _protocol;
+  private final StreamMessageMetadata _messageMetadata;
+  private final boolean _hasDataLoss;
+  private final int _recordsToSkip;
+
+  public MicroBatch(
+      byte[] key,
+      int unfilteredMessageCount,
+      MicroBatchProtocol protocol,
+      StreamMessageMetadata messageMetadata,
+      boolean hasDataLoss) {
+    this(key, unfilteredMessageCount, protocol, messageMetadata, hasDataLoss, 0);
+  }
+
+  public MicroBatch(
+      byte[] key,
+      int unfilteredMessageCount,
+      MicroBatchProtocol protocol,
+      StreamMessageMetadata messageMetadata,
+      boolean hasDataLoss,
+      int recordsToSkip) {
+    _key = key;
+    _unfilteredMessageCount = unfilteredMessageCount;
+    _protocol = protocol;
+    _messageMetadata = messageMetadata;
+    _hasDataLoss = hasDataLoss;
+    _recordsToSkip = recordsToSkip;
+  }
+
+  public byte[] getKey() {
+    return _key;
+  }
+
+  public MicroBatchProtocol getProtocol() {
+    return _protocol;
+  }
+
+  public StreamMessageMetadata getMessageMetadata() {
+    return _messageMetadata;
+  }
+
+  public int getUnfilteredMessageCount() {
+    return _unfilteredMessageCount;
+  }
+
+  public boolean hasDataLoss() {
+    return _hasDataLoss;
+  }
+
+  /**
+   * Number of records to skip when reading this microbatch.
+   * Used for mid-batch resume after a segment commit.
+   */
+  public int getRecordsToSkip() {
+    return _recordsToSkip;
+  }
+}

--- a/pinot-plugins/pinot-microbatch-ingestion/pinot-kafka-3.0-microbatch/src/main/java/org/apache/pinot/plugin/stream/microbatch/kafka30/MicroBatchConfigProperties.java
+++ b/pinot-plugins/pinot-microbatch-ingestion/pinot-kafka-3.0-microbatch/src/main/java/org/apache/pinot/plugin/stream/microbatch/kafka30/MicroBatchConfigProperties.java
@@ -1,0 +1,106 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.stream.microbatch.kafka30;
+
+import org.apache.pinot.spi.stream.StreamConfig;
+
+
+/**
+ * Configuration properties for MicroBatch Kafka consumer.
+ *
+ * <p>Config key format: {@code stream.microbatch.kafka.<property>}
+ *
+ * <p>Example configuration in table config:
+ * <pre>
+ * {
+ *   "streamConfigs": {
+ *     "streamType": "kafka",
+ *     "stream.kafka.topic.name": "microbatch-topic",
+ *     "stream.kafka.broker.list": "localhost:9092",
+ *     "stream.kafka.consumer.factory.class.name":
+ *       "org.apache.pinot.plugin.stream.microbatch.kafka30.KafkaMicroBatchConsumerFactory",
+ *     "stream.microbatch.kafka.file.fetch.threads": "4"
+ *   }
+ * }
+ * </pre>
+ */
+public final class MicroBatchConfigProperties {
+
+  private MicroBatchConfigProperties() {
+    // Utility class
+  }
+
+  /**
+   * Config key prefix: stream.microbatch.kafka
+   */
+  public static final String CONFIG_PREFIX = "stream.microbatch.kafka.";
+
+  /**
+   * Number of parallel threads for fetching batch files from PinotFS.
+   * Higher values provide better throughput but increase disk I/O and memory usage.
+   *
+   * <p>Key: stream.microbatch.kafka.file.fetch.threads
+   * <p>Default: 2
+   * <p>Range: 1 to N (recommended: 1-8 depending on disk I/O capacity)
+   */
+  public static final String FILE_FETCH_THREADS = "file.fetch.threads";
+
+  /**
+   * Default number of file fetch threads.
+   */
+  public static final int DEFAULT_FILE_FETCH_THREADS = 2;
+
+  /**
+   * Number of records to include in each MessageBatch returned from fetchMessages().
+   * Matches Kafka's default max.poll.records (500), which is the typical MessageBatch size
+   * returned in the direct streaming path.
+   */
+  public static final int DEFAULT_MESSAGE_BATCH_SIZE = 500;
+
+  /**
+   * Gets the value of a microbatch config property from the stream config.
+   *
+   * @param streamConfig the stream config
+   * @param property the property name (e.g., "parallelDataloaders")
+   * @return the property value, or null if not set
+   */
+  public static String getProperty(StreamConfig streamConfig, String property) {
+    return streamConfig.getStreamConfigsMap().get(CONFIG_PREFIX + property);
+  }
+
+  /**
+   * Gets the value of a microbatch config property as an integer.
+   *
+   * @param streamConfig the stream config
+   * @param property the property name
+   * @param defaultValue the default value if not set or invalid
+   * @return the property value as an integer
+   */
+  public static int getIntProperty(StreamConfig streamConfig, String property, int defaultValue) {
+    String value = getProperty(streamConfig, property);
+    if (value == null) {
+      return defaultValue;
+    }
+    try {
+      return Integer.parseInt(value);
+    } catch (NumberFormatException e) {
+      return defaultValue;
+    }
+  }
+}

--- a/pinot-plugins/pinot-microbatch-ingestion/pinot-kafka-3.0-microbatch/src/main/java/org/apache/pinot/plugin/stream/microbatch/kafka30/MicroBatchPayloadV1.java
+++ b/pinot-plugins/pinot-microbatch-ingestion/pinot-kafka-3.0-microbatch/src/main/java/org/apache/pinot/plugin/stream/microbatch/kafka30/MicroBatchPayloadV1.java
@@ -1,0 +1,212 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.stream.microbatch.kafka30;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
+import java.util.Base64;
+
+
+/**
+ * Version 1 payload for MicroBatch protocol.
+ *
+ * <p>Supports two message types:
+ * <ul>
+ *   <li>URI - reference to a file (file://, s3://, hdfs://, etc.)</li>
+ *   <li>DATA - inline base64-encoded data</li>
+ * </ul>
+ *
+ * <p>Example JSON payloads:
+ * <pre>
+ * // URI type
+ * {"type":"uri","format":"avro","uri":"s3://bucket/file.avro","numRecords":1000}
+ *
+ * // DATA type
+ * {"type":"data","format":"avro","data":"<base64>","numRecords":100}
+ * </pre>
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class MicroBatchPayloadV1 {
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  public enum Type {
+    URI, DATA
+  }
+
+  public enum Format {
+    AVRO, PARQUET, JSON
+  }
+
+  @JsonProperty("type")
+  private String _typeStr;
+
+  @JsonProperty("format")
+  private String _formatStr;
+
+  @JsonProperty("uri")
+  private String _uri;
+
+  @JsonProperty("data")
+  private String _dataBase64;
+
+  @JsonProperty("numRecords")
+  private int _numRecords;
+
+  // Cached parsed values
+  private transient Type _type;
+  private transient Format _format;
+  private transient byte[] _decodedData;
+
+  // Default constructor for Jackson
+  public MicroBatchPayloadV1() {
+  }
+
+  /**
+   * Parse payload from JSON bytes.
+   */
+  public static MicroBatchPayloadV1 parse(byte[] jsonBytes) throws IOException {
+    MicroBatchPayloadV1 payload = MAPPER.readValue(jsonBytes, MicroBatchPayloadV1.class);
+    payload.validate();
+    return payload;
+  }
+
+  /**
+   * Validate the payload after deserialization.
+   */
+  private void validate() {
+    if (_typeStr == null) {
+      throw new IllegalArgumentException("Missing required field: 'type'");
+    }
+    if (_formatStr == null) {
+      throw new IllegalArgumentException("Missing required field: 'format'");
+    }
+
+    // Parse and validate type
+    try {
+      _type = Type.valueOf(_typeStr.toUpperCase());
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException("Invalid type: " + _typeStr + ". Valid values: uri, data");
+    }
+
+    // Parse and validate format
+    try {
+      _format = Format.valueOf(_formatStr.toUpperCase());
+    } catch (IllegalArgumentException e) {
+      throw new IllegalArgumentException(
+          "Invalid format: " + _formatStr + ". Valid values: avro, parquet, json");
+    }
+
+    // Validate numRecords is provided and positive
+    if (_numRecords <= 0) {
+      throw new IllegalArgumentException(
+          "Missing or invalid required field 'numRecords': must be a positive integer, got: " + _numRecords);
+    }
+
+    // Validate type-specific fields - ensure only the appropriate field is set for each type
+    switch (_type) {
+      case URI:
+        if (_uri == null || _uri.isEmpty()) {
+          throw new IllegalArgumentException("Missing required field 'uri' for type=uri");
+        }
+        if (_dataBase64 != null) {
+          throw new IllegalArgumentException("Field 'data' must not be set when type=uri");
+        }
+        break;
+      case DATA:
+        if (_dataBase64 == null) {
+          throw new IllegalArgumentException("Missing required field 'data' for type=data");
+        }
+        if (_uri != null && !_uri.isEmpty()) {
+          throw new IllegalArgumentException("Field 'uri' must not be set when type=data");
+        }
+        // Decode base64 data (empty string is valid - decodes to empty byte array)
+        try {
+          _decodedData = Base64.getDecoder().decode(_dataBase64);
+        } catch (IllegalArgumentException e) {
+          throw new IllegalArgumentException("Invalid base64 encoding in 'data' field", e);
+        }
+        break;
+      default:
+        throw new IllegalArgumentException("Unknown type: " + _typeStr);
+    }
+  }
+
+  /**
+   * Create a URI payload.
+   */
+  public static MicroBatchPayloadV1 createUri(String uri, Format format, int numRecords) {
+    MicroBatchPayloadV1 payload = new MicroBatchPayloadV1();
+    payload._type = Type.URI;
+    payload._typeStr = "uri";
+    payload._format = format;
+    payload._formatStr = format.name().toLowerCase();
+    payload._uri = uri;
+    payload._numRecords = numRecords;
+    return payload;
+  }
+
+  /**
+   * Create a DATA payload.
+   */
+  public static MicroBatchPayloadV1 createData(byte[] data, Format format, int numRecords) {
+    MicroBatchPayloadV1 payload = new MicroBatchPayloadV1();
+    payload._type = Type.DATA;
+    payload._typeStr = "data";
+    payload._format = format;
+    payload._formatStr = format.name().toLowerCase();
+    payload._decodedData = data;
+    payload._dataBase64 = Base64.getEncoder().encodeToString(data);
+    payload._numRecords = numRecords;
+    return payload;
+  }
+
+  /**
+   * Serialize payload to JSON bytes.
+   */
+  public byte[] toJsonBytes() throws IOException {
+    return MAPPER.writeValueAsBytes(this);
+  }
+
+  // Getters
+
+  public Type getType() {
+    return _type;
+  }
+
+  public Format getFormat() {
+    return _format;
+  }
+
+  public String getUri() {
+    return _uri;
+  }
+
+  /**
+   * Get the decoded data bytes (for type=DATA).
+   */
+  public byte[] getData() {
+    return _decodedData;
+  }
+
+  public int getNumRecords() {
+    return _numRecords;
+  }
+}

--- a/pinot-plugins/pinot-microbatch-ingestion/pinot-kafka-3.0-microbatch/src/main/java/org/apache/pinot/plugin/stream/microbatch/kafka30/MicroBatchPayloadV1.java
+++ b/pinot-plugins/pinot-microbatch-ingestion/pinot-kafka-3.0-microbatch/src/main/java/org/apache/pinot/plugin/stream/microbatch/kafka30/MicroBatchPayloadV1.java
@@ -70,6 +70,9 @@ public class MicroBatchPayloadV1 {
   @JsonProperty("numRecords")
   private int _numRecords;
 
+  @JsonProperty("checksum")
+  private String _checksum;
+
   // Cached parsed values
   private transient Type _type;
   private transient Format _format;
@@ -153,6 +156,16 @@ public class MicroBatchPayloadV1 {
    * Create a URI payload.
    */
   public static MicroBatchPayloadV1 createUri(String uri, Format format, int numRecords) {
+    return createUri(uri, format, numRecords, null);
+  }
+
+  /**
+   * Create a URI payload with an optional CRC32 checksum.
+   *
+   * @param checksum CRC32 checksum of the file as a hex string, or null to skip validation
+   */
+  public static MicroBatchPayloadV1 createUri(String uri, Format format, int numRecords,
+      String checksum) {
     MicroBatchPayloadV1 payload = new MicroBatchPayloadV1();
     payload._type = Type.URI;
     payload._typeStr = "uri";
@@ -160,6 +173,7 @@ public class MicroBatchPayloadV1 {
     payload._formatStr = format.name().toLowerCase();
     payload._uri = uri;
     payload._numRecords = numRecords;
+    payload._checksum = checksum;
     return payload;
   }
 
@@ -208,5 +222,15 @@ public class MicroBatchPayloadV1 {
 
   public int getNumRecords() {
     return _numRecords;
+  }
+
+  /**
+   * Get the CRC32 checksum of the file as a hex string.
+   * Only applicable for URI-type messages.
+   *
+   * @return the checksum hex string, or null if not provided
+   */
+  public String getChecksum() {
+    return _checksum;
   }
 }

--- a/pinot-plugins/pinot-microbatch-ingestion/pinot-kafka-3.0-microbatch/src/main/java/org/apache/pinot/plugin/stream/microbatch/kafka30/MicroBatchProtocol.java
+++ b/pinot-plugins/pinot-microbatch-ingestion/pinot-kafka-3.0-microbatch/src/main/java/org/apache/pinot/plugin/stream/microbatch/kafka30/MicroBatchProtocol.java
@@ -1,0 +1,248 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.stream.microbatch.kafka30;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.Arrays;
+
+
+/**
+ * MicroBatch protocol message format.
+ *
+ * <h2>Wire Format</h2>
+ * <pre>
+ * +----------+---------------------------+
+ * | version  | payload bytes             |
+ * | (1 byte) | (variable length)         |
+ * +----------+---------------------------+
+ * </pre>
+ *
+ * <h2>Versioning Scheme</h2>
+ * <p>The first byte indicates the protocol version (0-255), which determines how to parse
+ * the remaining payload bytes. This design:
+ * <ul>
+ *   <li>Enables efficient version detection without parsing the payload</li>
+ *   <li>Allows future protocol evolution while maintaining backward compatibility</li>
+ *   <li>Supports up to 255 protocol versions</li>
+ * </ul>
+ *
+ * <p>Version allocation:
+ * <ul>
+ *   <li>Version 1: JSON payload parsed as {@link MicroBatchPayloadV1}</li>
+ *   <li>Versions 2-255: Reserved for future use</li>
+ * </ul>
+ *
+ * <p>When adding a new version:
+ * <ol>
+ *   <li>Define a new VERSION_N constant</li>
+ *   <li>Create a new payload class (e.g., MicroBatchPayloadV2)</li>
+ *   <li>Update {@link #parse(byte[])} to handle the new version</li>
+ *   <li>Add accessor method (e.g., getPayloadV2())</li>
+ * </ol>
+ *
+ * <h2>Usage</h2>
+ * <pre>
+ * // Parsing
+ * MicroBatchProtocol protocol = MicroBatchProtocol.parse(kafkaMessageBytes);
+ * MicroBatchPayloadV1 payload = protocol.getPayloadV1();
+ *
+ * // Creating
+ * byte[] message = MicroBatchProtocol.createUriMessage("s3://bucket/file.avro", Format.AVRO, 1000);
+ * </pre>
+ */
+public class MicroBatchProtocol {
+
+  public static final int VERSION_1 = 1;
+  public static final int CURRENT_VERSION = VERSION_1;
+
+  private final int _version;
+  private final MicroBatchPayloadV1 _payloadV1;
+
+  private MicroBatchProtocol(int version, MicroBatchPayloadV1 payloadV1) {
+    _version = version;
+    _payloadV1 = payloadV1;
+  }
+
+  /**
+   * Parse a MicroBatch protocol message from raw bytes.
+   *
+   * @param bytes the raw message bytes (version byte + payload)
+   * @return parsed protocol message
+   * @throws IOException if parsing fails
+   * @throws IllegalArgumentException if version is unsupported or payload is invalid
+   */
+  public static MicroBatchProtocol parse(byte[] bytes) throws IOException {
+    if (bytes == null || bytes.length < 2) {
+      throw new IllegalArgumentException(
+          "Invalid MicroBatch message: must have at least 2 bytes (version + payload)");
+    }
+
+    int version = Byte.toUnsignedInt(bytes[0]);
+    byte[] payloadBytes = Arrays.copyOfRange(bytes, 1, bytes.length);
+
+    switch (version) {
+      case VERSION_1:
+        MicroBatchPayloadV1 payload = MicroBatchPayloadV1.parse(payloadBytes);
+        return new MicroBatchProtocol(version, payload);
+
+      default:
+        throw new IllegalArgumentException(
+            "Unsupported MicroBatch protocol version: " + version
+                + ". Supported versions: " + VERSION_1);
+    }
+  }
+
+  /**
+   * Create a URI message with the current protocol version.
+   *
+   * @param uri the file URI (s3://, hdfs://, file://, etc.)
+   * @param format the data format
+   * @return serialized protocol message bytes
+   */
+  public static byte[] createUriMessage(String uri, MicroBatchPayloadV1.Format format)
+      throws IOException {
+    return createUriMessage(uri, format, 0);
+  }
+
+  /**
+   * Create a URI message with the current protocol version.
+   *
+   * @param uri the file URI (s3://, hdfs://, file://, etc.)
+   * @param format the data format
+   * @param numRecords number of records in the file (0 if unknown)
+   * @return serialized protocol message bytes
+   */
+  public static byte[] createUriMessage(String uri, MicroBatchPayloadV1.Format format,
+      long numRecords) throws IOException {
+    MicroBatchPayloadV1 payload =
+        MicroBatchPayloadV1.createUri(uri, format, (int) numRecords);
+    return createMessage(CURRENT_VERSION, payload.toJsonBytes());
+  }
+
+  /**
+   * Create a DATA message with inline data.
+   *
+   * @param data the raw data bytes
+   * @param format the data format
+   * @return serialized protocol message bytes
+   */
+  public static byte[] createDataMessage(byte[] data, MicroBatchPayloadV1.Format format)
+      throws IOException {
+    return createDataMessage(data, format, 0);
+  }
+
+  /**
+   * Create a DATA message with inline data.
+   *
+   * @param data the raw data bytes
+   * @param format the data format
+   * @param numRecords number of records in the data (0 if unknown)
+   * @return serialized protocol message bytes
+   */
+  public static byte[] createDataMessage(byte[] data, MicroBatchPayloadV1.Format format,
+      long numRecords) throws IOException {
+    MicroBatchPayloadV1 payload =
+        MicroBatchPayloadV1.createData(data, format, (int) numRecords);
+    return createMessage(CURRENT_VERSION, payload.toJsonBytes());
+  }
+
+  /**
+   * Create a protocol message with the given version and payload.
+   */
+  private static byte[] createMessage(int version, byte[] payloadBytes) throws IOException {
+    ByteArrayOutputStream out = new ByteArrayOutputStream(1 + payloadBytes.length);
+    out.write(version);
+    out.write(payloadBytes);
+    return out.toByteArray();
+  }
+
+  /**
+   * Check if the given bytes look like a valid MicroBatch protocol message.
+   * This performs a quick check without full parsing.
+   *
+   * @param bytes the bytes to check
+   * @return true if the bytes appear to be a MicroBatch protocol message
+   */
+  public static boolean isProtocol(byte[] bytes) {
+    if (bytes == null || bytes.length < 2) {
+      return false;
+    }
+    int version = Byte.toUnsignedInt(bytes[0]);
+    // Check for known versions and that payload starts with '{'
+    return version == VERSION_1 && bytes[1] == '{';
+  }
+
+  // Getters
+
+  public int getVersion() {
+    return _version;
+  }
+
+  /**
+   * Get the V1 payload. Only valid if version == 1.
+   *
+   * @return the V1 payload
+   * @throws IllegalStateException if version is not 1
+   */
+  public MicroBatchPayloadV1 getPayloadV1() {
+    if (_version != VERSION_1) {
+      throw new IllegalStateException(
+          "Cannot get V1 payload for version " + _version);
+    }
+    return _payloadV1;
+  }
+
+  // Convenience methods that delegate to the payload
+
+  /**
+   * Get the message type (URI or DATA).
+   */
+  public MicroBatchPayloadV1.Type getType() {
+    return _payloadV1.getType();
+  }
+
+  /**
+   * Get the data format (AVRO, PARQUET, JSON).
+   */
+  public MicroBatchPayloadV1.Format getFormat() {
+    return _payloadV1.getFormat();
+  }
+
+  /**
+   * Get the URI (for type=URI).
+   */
+  public String getUri() {
+    return _payloadV1.getUri();
+  }
+
+  /**
+   * Get the decoded data bytes (for type=DATA).
+   */
+  public byte[] getData() {
+    return _payloadV1.getData();
+  }
+
+  /**
+   * Get the number of records (0 if unknown).
+   */
+  public int getNumRecords() {
+    return _payloadV1.getNumRecords();
+  }
+}

--- a/pinot-plugins/pinot-microbatch-ingestion/pinot-kafka-3.0-microbatch/src/main/java/org/apache/pinot/plugin/stream/microbatch/kafka30/MicroBatchProtocol.java
+++ b/pinot-plugins/pinot-microbatch-ingestion/pinot-kafka-3.0-microbatch/src/main/java/org/apache/pinot/plugin/stream/microbatch/kafka30/MicroBatchProtocol.java
@@ -131,8 +131,22 @@ public class MicroBatchProtocol {
    */
   public static byte[] createUriMessage(String uri, MicroBatchPayloadV1.Format format,
       long numRecords) throws IOException {
+    return createUriMessage(uri, format, numRecords, null);
+  }
+
+  /**
+   * Create a URI message with the current protocol version and optional checksum.
+   *
+   * @param uri the file URI (s3://, hdfs://, file://, etc.)
+   * @param format the data format
+   * @param numRecords number of records in the file (0 if unknown)
+   * @param checksum CRC32 checksum of the file as a hex string, or null to skip validation
+   * @return serialized protocol message bytes
+   */
+  public static byte[] createUriMessage(String uri, MicroBatchPayloadV1.Format format,
+      long numRecords, String checksum) throws IOException {
     MicroBatchPayloadV1 payload =
-        MicroBatchPayloadV1.createUri(uri, format, (int) numRecords);
+        MicroBatchPayloadV1.createUri(uri, format, (int) numRecords, checksum);
     return createMessage(CURRENT_VERSION, payload.toJsonBytes());
   }
 
@@ -244,5 +258,15 @@ public class MicroBatchProtocol {
    */
   public int getNumRecords() {
     return _payloadV1.getNumRecords();
+  }
+
+  /**
+   * Get the CRC32 checksum of the file as a hex string.
+   * Only applicable for URI-type messages.
+   *
+   * @return the checksum hex string, or null if not provided
+   */
+  public String getChecksum() {
+    return _payloadV1.getChecksum();
   }
 }

--- a/pinot-plugins/pinot-microbatch-ingestion/pinot-kafka-3.0-microbatch/src/main/java/org/apache/pinot/plugin/stream/microbatch/kafka30/MicroBatchQueueManager.java
+++ b/pinot-plugins/pinot-microbatch-ingestion/pinot-kafka-3.0-microbatch/src/main/java/org/apache/pinot/plugin/stream/microbatch/kafka30/MicroBatchQueueManager.java
@@ -1,0 +1,331 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.stream.microbatch.kafka30;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Queue;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.SynchronousQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.commons.io.FileUtils;
+import org.apache.kafka.common.utils.CloseableIterator;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.filesystem.PinotFS;
+import org.apache.pinot.spi.filesystem.PinotFSFactory;
+import org.apache.pinot.spi.stream.MessageBatch;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Orchestrates MicroBatch downloads and message batch creation.
+ *
+ * <p>This class manages the lifecycle of microbatch processing:
+ * <ol>
+ *   <li>Accepts submitted microbatches via {@link #submitBatch(MicroBatch)}</li>
+ *   <li>Downloads batch files from PinotFS (S3, HDFS, GCS, etc.) or decodes inline data</li>
+ *   <li>Converts downloaded files into {@link MessageBatch} objects</li>
+ *   <li>Provides batches to consumers via {@link #getNextMessageBatch()}</li>
+ * </ol>
+ *
+ * <p>Threading model:
+ * <ul>
+ *   <li>Data loader threads: Fixed pool that processes microbatches (download + convert)</li>
+ *   <li>Download executor: Cached pool for individual downloads with timeout support</li>
+ *   <li>Uses {@link SynchronousQueue} for backpressure to prevent memory exhaustion</li>
+ * </ul>
+ *
+ * <p>Configuration:
+ * <ul>
+ *   <li>{@code stream.microbatch.kafka.file.fetch.threads}: Number of parallel data loaders</li>
+ *   <li>{@code stream.microbatch.kafka.file.download.timeout.ms}: Download timeout (default 5 min)</li>
+ * </ul>
+ *
+ * @see MicroBatchConfigProperties for configuration options
+ */
+public class MicroBatchQueueManager implements AutoCloseable {
+  private static final Logger LOGGER = LoggerFactory.getLogger(MicroBatchQueueManager.class);
+  private static final long POLL_TIMEOUT_MS = 1000;
+
+  /**
+   * Global counter to ensure unique thread names within a JVM.
+   * Incremented each time a new MicroBatchQueueManager is created for any partition.
+   */
+  private static final AtomicLong INSTANCE_COUNTER = new AtomicLong(0);
+
+  private final Queue<MicroBatchState> _microBatchQueue = new ConcurrentLinkedQueue<>();
+  private final ExecutorService _dataLoaderExecutor;
+
+  /**
+   * Creates a MicroBatchQueueManager with named threads for debugging.
+   *
+   * @param partition the Kafka partition number this manager handles
+   * @param numFileFetchThreads number of parallel threads for fetching and processing batch files
+   */
+  public MicroBatchQueueManager(int partition, int numFileFetchThreads) {
+    long instanceId = INSTANCE_COUNTER.incrementAndGet();
+    String threadNamePrefix = String.format("microbatch-p%d-i%d", partition, instanceId);
+    _dataLoaderExecutor = Executors.newFixedThreadPool(numFileFetchThreads,
+        new NamedThreadFactory(threadNamePrefix));
+  }
+
+  /**
+   * Thread factory that creates named daemon threads for easier debugging.
+   */
+  private static class NamedThreadFactory implements ThreadFactory {
+    private final String _namePrefix;
+    private final AtomicInteger _threadNumber = new AtomicInteger(1);
+
+    NamedThreadFactory(String namePrefix) {
+      _namePrefix = namePrefix;
+    }
+
+    @Override
+    public Thread newThread(Runnable r) {
+      Thread t = new Thread(r, _namePrefix + "-t" + _threadNumber.getAndIncrement());
+      t.setDaemon(true);
+      return t;
+    }
+  }
+
+  /**
+   * Submit a MicroBatch for processing. Immediately starts download if quota allows and batch has
+   * remote URI.
+   *
+   * @param microBatch the microbatch to process
+   */
+  public void submitBatch(MicroBatch microBatch) {
+    MicroBatchState microBatchState = new MicroBatchState(microBatch);
+    _microBatchQueue.add(microBatchState);
+    _dataLoaderExecutor.submit(() -> process(microBatchState));
+  }
+
+  /**
+   * Checks if there are any microbatches being processed or waiting to be consumed.
+   *
+   * @return true if there are microbatches in the queue, false otherwise
+   */
+  public boolean hasData() {
+    return !_microBatchQueue.isEmpty();
+  }
+
+  /**
+   * Retrieves the next available message batch from the queue.
+   *
+   * <p>This method will block for up to {@link #POLL_TIMEOUT_MS} milliseconds waiting for
+   * a batch to become available. If no batch is available after the timeout, it returns null.
+   *
+   * <p>When a microbatch has been fully consumed (all messages read), it is automatically
+   * removed from the queue and its resources are cleaned up.
+   *
+   * @return the next MessageBatch, or null if no batch is currently available
+   */
+  public MessageBatch<GenericRow> getNextMessageBatch() {
+    while (!_microBatchQueue.isEmpty()) {
+      MicroBatchState state = _microBatchQueue.peek();
+      if (state == null) {
+        return null;
+      }
+      // Try to get a message batch with a timeout - wait longer to ensure data is ready
+      try {
+        MessageBatch<GenericRow> batch = state._messages.poll(POLL_TIMEOUT_MS, TimeUnit.MILLISECONDS);
+        if (batch != null) {
+          return batch;
+        }
+        // If no batch available and all messages have been read, move to next microbatch
+        if (state._allMessagesReadFromFile && state._messages.isEmpty()) {
+          _microBatchQueue.poll();
+          state.clear();
+          continue;
+        }
+        // Still processing, return null to let caller retry
+        return null;
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return null;
+      }
+    }
+    return null;
+  }
+
+  private void process(MicroBatchState state) {
+    try {
+      if (state._isAbandoned) {
+        return;
+      }
+      fetchDataForMicroBatch(state);
+      convertDataToMessageBatches(state);
+    } catch (Exception e) {
+      LOGGER.error("Caught exception while processing data for MicroBatch", e);
+      // TODO: Review error handling behavior - currently we mark the batch as read to prevent
+      // blocking the queue, but this may cause silent data loss
+      state._allMessagesReadFromFile = true;
+    }
+  }
+
+  // TODO: Should temp files use a configurable directory instead of system temp?
+  private void fetchDataForMicroBatch(MicroBatchState state)
+      throws IOException {
+    MicroBatchProtocol protocol = state._microBatch.getProtocol();
+    switch (protocol.getType()) {
+      case URI:
+        URI uri = URI.create(protocol.getUri());
+        state._dataFile = downloadFromPinotFS(uri);
+        return;
+      case DATA:
+        File tempFile = null;
+        try {
+          tempFile = new File(FileUtils.getTempDirectory(), "microbatch-inline-" + UUID.randomUUID());
+          FileUtils.writeByteArrayToFile(tempFile, state._microBatch.getProtocol().getData());
+          state._dataFile = tempFile;
+          tempFile = null; // Transfer ownership to state, prevent cleanup
+        } finally {
+          // Clean up temp file if it wasn't successfully assigned to state
+          if (tempFile != null) {
+            FileUtils.deleteQuietly(tempFile);
+          }
+        }
+        return;
+      default:
+        throw new IllegalStateException("Unsupported protocol type: " + protocol.getType());
+    }
+  }
+
+  private void convertDataToMessageBatches(MicroBatchState state) {
+    if (state._dataFile == null || !state._dataFile.exists()) {
+      LOGGER.error("Data file is null or does not exist, skipping batch");
+      return;
+    }
+    int totalRecordCount = state._microBatch.getProtocol().getNumRecords();
+    int recordsToSkip = state._microBatch.getRecordsToSkip();
+    try (CloseableIterator<MessageBatch<GenericRow>> iterator =
+        MessageBatchReader.read(
+            state._microBatch, state._dataFile,
+            MicroBatchConfigProperties.DEFAULT_MESSAGE_BATCH_SIZE, totalRecordCount, recordsToSkip)) {
+      while (iterator.hasNext() && !state._isAbandoned) {
+        try {
+          boolean enqueued;
+          MessageBatch<GenericRow> messageBatch = iterator.next();
+          do {
+            enqueued = state._messages.offer(messageBatch, 100, TimeUnit.MILLISECONDS);
+          } while (!enqueued && !state._isAbandoned);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          break;
+        }
+      }
+
+      if (!iterator.hasNext()) {
+        state._allMessagesReadFromFile = true;
+      }
+    }
+  }
+
+  private File downloadFromPinotFS(URI uri) {
+    // TODO: Should we add disk space checks before downloading batch files?
+
+    // TODO: Should we add a configurable download timeout? PinotFS implementations don't have
+    // built-in download timeouts.
+    try {
+      PinotFS pinotFS = PinotFSFactory.create(uri.getScheme());
+      File tempFile = new File(FileUtils.getTempDirectory(), "microbatch-" + UUID.randomUUID());
+      LOGGER.debug("Downloading from {} to {}", uri, tempFile.getAbsolutePath());
+      pinotFS.copyToLocalFile(uri, tempFile);
+      if (!tempFile.exists()) {
+        throw new RuntimeException("Failed to download file - temp file not created: " + tempFile);
+      }
+      LOGGER.debug("Downloaded {} bytes from {} to {}",
+          tempFile.length(), uri, tempFile.getAbsolutePath());
+      return tempFile;
+    } catch (Exception e) {
+      throw new RuntimeException("Failed to download file from PinotFS: " + uri, e);
+    }
+  }
+
+  /**
+   * Clears all pending microbatches from the queue.
+   *
+   * <p>This method marks all queued microbatches as abandoned and cleans up their
+   * associated temp files. Use this when seeking to a new offset or resetting
+   * the consumer state.
+   */
+  public void clear() {
+    _microBatchQueue.forEach(MicroBatchState::abandon);
+    _microBatchQueue.clear();
+  }
+
+  /**
+   * Closes the queue manager and releases all resources.
+   *
+   * <p>This method:
+   * <ul>
+   *   <li>Clears all pending microbatches</li>
+   *   <li>Shuts down the data loader executor pool</li>
+   *   <li>Waits up to 5 seconds for executor termination</li>
+   * </ul>
+   */
+  @Override
+  public void close() {
+    clear();
+    _dataLoaderExecutor.shutdownNow();
+    try {
+      if (!_dataLoaderExecutor.awaitTermination(5, TimeUnit.SECONDS)) {
+        LOGGER.warn("Data loader executor did not terminate within timeout");
+      }
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      LOGGER.warn("Interrupted while waiting for data loader executor to terminate");
+    }
+  }
+
+  static class MicroBatchState {
+    final MicroBatch _microBatch;
+    volatile boolean _allMessagesReadFromFile = false;
+    volatile boolean _isAbandoned = false;
+    volatile File _dataFile = null;
+
+    // DESIGN DECISION: Using SynchronousQueue instead of ArrayBlockingQueue is intentional.
+    // SynchronousQueue provides natural backpressure - producer blocks until consumer takes the item.
+    // This ensures only the current microbatch's loader thread is actively producing while
+    // other threads wait, preventing eager loading of all microbatches into memory.
+    // An ArrayBlockingQueue with capacity would allow multiple batches to be loaded into memory
+    // simultaneously, which could cause OOM issues with large batch files.
+    final SynchronousQueue<MessageBatch<GenericRow>> _messages = new SynchronousQueue<>();
+
+    public MicroBatchState(MicroBatch microBatch) {
+      _microBatch = microBatch;
+    }
+
+    public void abandon() {
+      _isAbandoned = true;
+      clear();
+    }
+
+    public void clear() {
+      FileUtils.deleteQuietly(_dataFile);
+    }
+  }
+}

--- a/pinot-plugins/pinot-microbatch-ingestion/pinot-kafka-3.0-microbatch/src/main/java/org/apache/pinot/plugin/stream/microbatch/kafka30/MicroBatchQueueManager.java
+++ b/pinot-plugins/pinot-microbatch-ingestion/pinot-kafka-3.0-microbatch/src/main/java/org/apache/pinot/plugin/stream/microbatch/kafka30/MicroBatchQueueManager.java
@@ -19,7 +19,9 @@
 package org.apache.pinot.plugin.stream.microbatch.kafka30;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.util.Queue;
 import java.util.UUID;
@@ -31,6 +33,7 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.zip.CRC32;
 import org.apache.commons.io.FileUtils;
 import org.apache.kafka.common.utils.CloseableIterator;
 import org.apache.pinot.spi.data.readers.GenericRow;
@@ -194,6 +197,7 @@ public class MicroBatchQueueManager implements AutoCloseable {
       case URI:
         URI uri = URI.create(protocol.getUri());
         state._dataFile = downloadFromPinotFS(uri);
+        validateChecksum(state._dataFile, protocol.getChecksum(), uri.toString());
         return;
       case DATA:
         File tempFile = null;
@@ -263,6 +267,46 @@ public class MicroBatchQueueManager implements AutoCloseable {
     } catch (Exception e) {
       throw new RuntimeException("Failed to download file from PinotFS: " + uri, e);
     }
+  }
+
+  /**
+   * Validates the CRC32 checksum of a downloaded file against the expected value.
+   * Skips validation if no checksum was provided in the protocol message.
+   *
+   * @param file the downloaded file to validate
+   * @param expectedChecksum the expected CRC32 hex string, or null to skip
+   * @param sourceUri the source URI (for error messages)
+   * @throws IOException if the file cannot be read or checksum doesn't match
+   */
+  static void validateChecksum(File file, String expectedChecksum, String sourceUri)
+      throws IOException {
+    if (expectedChecksum == null || expectedChecksum.isEmpty()) {
+      return;
+    }
+    String actualChecksum = computeCrc32Hex(file);
+    if (!expectedChecksum.equalsIgnoreCase(actualChecksum)) {
+      throw new IOException(
+          "Checksum mismatch for file downloaded from " + sourceUri
+              + ": expected=" + expectedChecksum + ", actual=" + actualChecksum);
+    }
+    LOGGER.debug("Checksum verified for {}: {}", sourceUri, actualChecksum);
+  }
+
+  private static final int CHECKSUM_BUFFER_SIZE = 65536;
+
+  /**
+   * Computes the CRC32 checksum of a file and returns it as a lowercase hex string.
+   */
+  static String computeCrc32Hex(File file) throws IOException {
+    CRC32 crc32 = new CRC32();
+    byte[] buffer = new byte[CHECKSUM_BUFFER_SIZE];
+    try (InputStream is = new FileInputStream(file)) {
+      int bytesRead;
+      while ((bytesRead = is.read(buffer)) != -1) {
+        crc32.update(buffer, 0, bytesRead);
+      }
+    }
+    return Long.toHexString(crc32.getValue());
   }
 
   /**

--- a/pinot-plugins/pinot-microbatch-ingestion/pinot-kafka-3.0-microbatch/src/main/java/org/apache/pinot/plugin/stream/microbatch/kafka30/MicroBatchStreamMetadataProvider.java
+++ b/pinot-plugins/pinot-microbatch-ingestion/pinot-kafka-3.0-microbatch/src/main/java/org/apache/pinot/plugin/stream/microbatch/kafka30/MicroBatchStreamMetadataProvider.java
@@ -1,0 +1,143 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.stream.microbatch.kafka30;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.pinot.plugin.stream.kafka30.KafkaStreamMetadataProvider;
+import org.apache.pinot.spi.stream.LongMsgOffset;
+import org.apache.pinot.spi.stream.OffsetCriteria;
+import org.apache.pinot.spi.stream.StreamMetadataProvider;
+import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
+
+
+/**
+ * Metadata provider for MicroBatch streams that wraps Kafka offsets in composite format.
+ *
+ * <p>This provider delegates to {@link KafkaStreamMetadataProvider} for partition and offset
+ * discovery, then wraps the returned Kafka offsets into {@link MicroBatchStreamPartitionMsgOffset}
+ * format. This ensures that all offsets used by the MicroBatch consumer are in the composite
+ * format required for mid-batch resume.
+ *
+ * <p>Key behaviors:
+ * <ul>
+ *   <li>Partition operations (count, IDs, topics) delegate directly to Kafka provider</li>
+ *   <li>Offset operations wrap Kafka's {@link LongMsgOffset} into composite format with mbro=0</li>
+ *   <li>{@link #supportsOffsetLag()} returns false since lag estimation requires knowing
+ *       record counts in unconsumed batches</li>
+ * </ul>
+ *
+ * @see MicroBatchStreamPartitionMsgOffset for the composite offset format
+ * @see KafkaMicroBatchConsumerFactory which creates instances of this provider
+ */
+public class MicroBatchStreamMetadataProvider implements StreamMetadataProvider {
+
+  private final KafkaStreamMetadataProvider _kafkaStreamMetadataProvider;
+
+  public MicroBatchStreamMetadataProvider(KafkaStreamMetadataProvider kafkaStreamMetadataProvider) {
+    _kafkaStreamMetadataProvider = kafkaStreamMetadataProvider;
+  }
+
+  @Override
+  public int fetchPartitionCount(long timeoutMillis) {
+    return _kafkaStreamMetadataProvider.fetchPartitionCount(timeoutMillis);
+  }
+
+  @Override
+  public Set<Integer> fetchPartitionIds(long timeoutMillis) {
+    return _kafkaStreamMetadataProvider.fetchPartitionIds(timeoutMillis);
+  }
+
+  @Override
+  public Map<Integer, StreamPartitionMsgOffset> fetchLatestStreamOffset(
+      Set<Integer> partitionIds, long timeoutMillis) {
+    Map<Integer, StreamPartitionMsgOffset> kafkaStreamPartitionMsgOffsets =
+        _kafkaStreamMetadataProvider.fetchLatestStreamOffset(partitionIds, timeoutMillis);
+    Map<Integer, StreamPartitionMsgOffset> microBatchStreamPartitionMsgOffset = new HashMap<>();
+    kafkaStreamPartitionMsgOffsets.forEach(
+        (partitionId, offset) -> microBatchStreamPartitionMsgOffset.put(partitionId, wrap(offset)));
+    return microBatchStreamPartitionMsgOffset;
+  }
+
+  @Override
+  public StreamPartitionMsgOffset fetchStreamPartitionOffset(
+      OffsetCriteria offsetCriteria, long timeoutMillis) {
+    return wrap(
+        _kafkaStreamMetadataProvider.fetchStreamPartitionOffset(offsetCriteria, timeoutMillis));
+  }
+
+  @Override
+  public List<TopicMetadata> getTopics() {
+    return _kafkaStreamMetadataProvider.getTopics();
+  }
+
+  @Override
+  public boolean supportsOffsetLag() {
+    // We wouldn't be able to estimate offset lag accurately because we don't know how many records
+    // are in each microbatch.
+    // That's why we return false here and don't override getCurrentPartitionLagState(Map<String,
+    // ConsumerPartitionState> currentPartitionStateMap) even when KafkaStreamMetadataProvider has a
+    // method override.
+    // TODO: should we return batches count instead of records count?
+    return false;
+  }
+
+  @Override
+  public StreamPartitionMsgOffset getOffsetAtTimestamp(
+      int partitionId, long timestampMillis, long timeoutMillis) {
+    return wrap(
+        _kafkaStreamMetadataProvider.getOffsetAtTimestamp(
+            partitionId, timestampMillis, timeoutMillis));
+  }
+
+  @Override
+  public Map<String, StreamPartitionMsgOffset> getStreamStartOffsets() {
+    Map<String, StreamPartitionMsgOffset> kafkaStreamPartitionMsgOffsets =
+        _kafkaStreamMetadataProvider.getStreamStartOffsets();
+    Map<String, StreamPartitionMsgOffset> microBatchStreamPartitionMsgOffset = new HashMap<>();
+    kafkaStreamPartitionMsgOffsets.forEach(
+        (partitionId, offset) -> microBatchStreamPartitionMsgOffset.put(partitionId, wrap(offset)));
+    return microBatchStreamPartitionMsgOffset;
+  }
+
+  @Override
+  public Map<String, StreamPartitionMsgOffset> getStreamEndOffsets() {
+    Map<String, StreamPartitionMsgOffset> kafkaStreamPartitionMsgOffsets =
+        _kafkaStreamMetadataProvider.getStreamEndOffsets();
+    Map<String, StreamPartitionMsgOffset> microBatchStreamPartitionMsgOffset = new HashMap<>();
+    kafkaStreamPartitionMsgOffsets.forEach(
+        (partitionId, offset) -> microBatchStreamPartitionMsgOffset.put(partitionId, wrap(offset)));
+    return microBatchStreamPartitionMsgOffset;
+  }
+
+  @Override
+  public void close() throws IOException {
+    _kafkaStreamMetadataProvider.close();
+  }
+
+  private StreamPartitionMsgOffset wrap(StreamPartitionMsgOffset offset) {
+    if (!(offset instanceof LongMsgOffset)) {
+      throw new IllegalStateException("Expected LongMsgOffset but got: " + offset.getClass());
+    }
+    return MicroBatchStreamPartitionMsgOffset.of(((LongMsgOffset) offset).getOffset());
+  }
+}

--- a/pinot-plugins/pinot-microbatch-ingestion/pinot-kafka-3.0-microbatch/src/main/java/org/apache/pinot/plugin/stream/microbatch/kafka30/MicroBatchStreamPartitionMsgOffset.java
+++ b/pinot-plugins/pinot-microbatch-ingestion/pinot-kafka-3.0-microbatch/src/main/java/org/apache/pinot/plugin/stream/microbatch/kafka30/MicroBatchStreamPartitionMsgOffset.java
@@ -1,0 +1,131 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.stream.microbatch.kafka30;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.Comparator;
+import java.util.Objects;
+import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
+import org.apache.pinot.spi.utils.JsonUtils;
+
+
+/**
+ * Composite offset for MicroBatch streams containing both Kafka message offset and record position.
+ *
+ * <h2>Serialization Format</h2>
+ * <p>Offsets are serialized as JSON with abbreviated field names to minimize storage overhead:
+ * <pre>
+ * {"kmo":&lt;kafka_offset&gt;,"mbro":&lt;record_offset&gt;}
+ * </pre>
+ *
+ * <p>Field definitions:
+ * <ul>
+ *   <li>{@code kmo} (Kafka Message Offset): The Kafka partition offset of the microbatch message</li>
+ *   <li>{@code mbro} (MicroBatch Record Offset): Zero-based index of the record within the batch file</li>
+ * </ul>
+ *
+ * <p>Examples:
+ * <ul>
+ *   <li>{@code {"kmo":0,"mbro":0}} - First record of first microbatch</li>
+ *   <li>{@code {"kmo":5,"mbro":100}} - 101st record of microbatch at Kafka offset 5</li>
+ *   <li>{@code {"kmo":10,"mbro":0}} - First record of microbatch at Kafka offset 10</li>
+ * </ul>
+ *
+ * <h2>Deserialization</h2>
+ * <p>The {@link MicroBatchStreamPartitionMsgOffsetFactory} handles two input formats:
+ * <ul>
+ *   <li>JSON format: {@code {"kmo":X,"mbro":Y}} - Full composite offset</li>
+ *   <li>Numeric string: {@code "123"} - Interpreted as Kafka offset with mbro=0</li>
+ * </ul>
+ *
+ * <h2>Ordering</h2>
+ * <p>Offsets are ordered first by {@code kmo}, then by {@code mbro}. This ensures correct
+ * resume behavior when restarting mid-batch after a segment commit.
+ *
+ * <h2>Compatibility</h2>
+ * <p>This offset format is specific to MicroBatch consumers and is NOT compatible with
+ * standard Kafka consumer offsets. Mixing consumers on the same table will cause issues.
+ */
+public class MicroBatchStreamPartitionMsgOffset implements StreamPartitionMsgOffset {
+
+  private final long _kafkaMessageOffset;
+  private final long _recordOffsetInMicroBatch;
+
+  /**
+   * Create an offset with just the Kafka message offset (record offset defaults to 0).
+   */
+  public static MicroBatchStreamPartitionMsgOffset of(long kafkaMessageOffset) {
+    return new MicroBatchStreamPartitionMsgOffset(kafkaMessageOffset, 0);
+  }
+
+  @JsonCreator
+  public MicroBatchStreamPartitionMsgOffset(
+      @JsonProperty("kmo") long kafkaMessageOffset,
+      @JsonProperty("mbro") long microBatchRecordOffset) {
+    _kafkaMessageOffset = kafkaMessageOffset;
+    _recordOffsetInMicroBatch = microBatchRecordOffset;
+  }
+
+  @JsonProperty("kmo")
+  public long getKafkaMessageOffset() {
+    return _kafkaMessageOffset;
+  }
+
+  @JsonProperty("mbro")
+  public long getRecordOffsetInMicroBatch() {
+    return _recordOffsetInMicroBatch;
+  }
+
+  @Override
+  public String toString() {
+    try {
+      return JsonUtils.objectToString(this);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public int compareTo(StreamPartitionMsgOffset o) {
+    MicroBatchStreamPartitionMsgOffset other = (MicroBatchStreamPartitionMsgOffset) o;
+    return Comparator.comparing(MicroBatchStreamPartitionMsgOffset::getKafkaMessageOffset)
+        .thenComparing(MicroBatchStreamPartitionMsgOffset::getRecordOffsetInMicroBatch)
+        .compare(this, other);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    MicroBatchStreamPartitionMsgOffset that = (MicroBatchStreamPartitionMsgOffset) o;
+    return _kafkaMessageOffset == that._kafkaMessageOffset
+        && _recordOffsetInMicroBatch == that._recordOffsetInMicroBatch;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_kafkaMessageOffset, _recordOffsetInMicroBatch);
+  }
+}

--- a/pinot-plugins/pinot-microbatch-ingestion/pinot-kafka-3.0-microbatch/src/main/java/org/apache/pinot/plugin/stream/microbatch/kafka30/MicroBatchStreamPartitionMsgOffsetFactory.java
+++ b/pinot-plugins/pinot-microbatch-ingestion/pinot-kafka-3.0-microbatch/src/main/java/org/apache/pinot/plugin/stream/microbatch/kafka30/MicroBatchStreamPartitionMsgOffsetFactory.java
@@ -1,0 +1,54 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.stream.microbatch.kafka30;
+
+import org.apache.pinot.spi.stream.StreamConfig;
+import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
+import org.apache.pinot.spi.stream.StreamPartitionMsgOffsetFactory;
+import org.apache.pinot.spi.utils.JsonUtils;
+
+
+/**
+ * Factory to create MicroBatchStreamPartitionMsgOffset from serialized strings.
+ */
+public class MicroBatchStreamPartitionMsgOffsetFactory implements StreamPartitionMsgOffsetFactory {
+
+  @Override
+  public void init(StreamConfig streamConfig) {
+  }
+
+  @Override
+  public StreamPartitionMsgOffset create(String offsetStr) {
+    // Handle simple numeric offsets (e.g., "0" from smallest offset criteria)
+    if (offsetStr != null && !offsetStr.startsWith("{")) {
+      try {
+        long offset = Long.parseLong(offsetStr.trim());
+        return MicroBatchStreamPartitionMsgOffset.of(offset);
+      } catch (NumberFormatException ignored) {
+        // Fall through to JSON parsing
+      }
+    }
+    // Parse JSON format: {"kmo":0,"mbro":0}
+    try {
+      return JsonUtils.stringToObject(offsetStr, MicroBatchStreamPartitionMsgOffset.class);
+    } catch (Exception e) {
+      throw new IllegalArgumentException("Failed to parse MicroBatchStreamPartitionMsgOffset from: " + offsetStr, e);
+    }
+  }
+}

--- a/pinot-plugins/pinot-microbatch-ingestion/pinot-kafka-3.0-microbatch/src/main/java/org/apache/pinot/plugin/stream/microbatch/kafka30/SynchronizedKafkaStreamMetadataProvider.java
+++ b/pinot-plugins/pinot-microbatch-ingestion/pinot-kafka-3.0-microbatch/src/main/java/org/apache/pinot/plugin/stream/microbatch/kafka30/SynchronizedKafkaStreamMetadataProvider.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.stream.microbatch.kafka30;
+
+import java.util.Map;
+import java.util.Set;
+import org.apache.pinot.plugin.stream.kafka30.KafkaStreamMetadataProvider;
+import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
+
+/**
+ * A thread-safe variant of {@link MicroBatchStreamMetadataProvider} that synchronizes access to
+ * metadata fetch operations. This is particularly useful when a shared instance of {@link
+ * MicroBatchStreamMetadataProvider} is accessed concurrently by multiple threads.
+ */
+public class SynchronizedKafkaStreamMetadataProvider extends MicroBatchStreamMetadataProvider {
+
+  public SynchronizedKafkaStreamMetadataProvider(
+      KafkaStreamMetadataProvider kafkaStreamMetadataProvider) {
+    super(kafkaStreamMetadataProvider);
+  }
+
+  @Override
+  public Map<Integer, StreamPartitionMsgOffset> fetchLatestStreamOffset(
+      Set<Integer> partitionIds, long timeoutMillis) {
+    synchronized (this) {
+      return super.fetchLatestStreamOffset(partitionIds, timeoutMillis);
+    }
+  }
+}

--- a/pinot-plugins/pinot-microbatch-ingestion/pinot-kafka-3.0-microbatch/src/test/java/org/apache/pinot/plugin/stream/kafka30/utils/MiniKafkaCluster.java
+++ b/pinot-plugins/pinot-microbatch-ingestion/pinot-kafka-3.0-microbatch/src/test/java/org/apache/pinot/plugin/stream/kafka30/utils/MiniKafkaCluster.java
@@ -1,0 +1,138 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.stream.kafka30.utils;
+
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.net.ServerSocket;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Properties;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import kafka.server.KafkaConfig;
+import kafka.server.KafkaServer;
+import org.apache.commons.io.FileUtils;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.admin.RecordsToDelete;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.utils.Time;
+import org.apache.pinot.plugin.stream.kafka.utils.EmbeddedZooKeeper;
+import scala.Option;
+
+
+public final class MiniKafkaCluster implements Closeable {
+  private static final File TEMP_DIR = new File(FileUtils.getTempDirectory(), "MiniKafkaCluster-" + UUID.randomUUID());
+
+  private final EmbeddedZooKeeper _zkServer;
+  private final KafkaServer _kafkaServer;
+  private final String _kafkaServerAddress;
+  private final AdminClient _adminClient;
+
+  public MiniKafkaCluster(String brokerId)
+      throws IOException, InterruptedException {
+    _zkServer = new EmbeddedZooKeeper(new File(TEMP_DIR, "zk"));
+    int kafkaServerPort = getAvailablePort();
+    KafkaConfig kafkaBrokerConfig = new KafkaConfig(createBrokerConfig(brokerId, kafkaServerPort));
+    _kafkaServer = new KafkaServer(kafkaBrokerConfig, Time.SYSTEM, Option.empty(), false);
+    _kafkaServerAddress = "localhost:" + kafkaServerPort;
+    Properties kafkaClientConfig = new Properties();
+    kafkaClientConfig.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, _kafkaServerAddress);
+    _adminClient = AdminClient.create(kafkaClientConfig);
+  }
+
+  private static int getAvailablePort() {
+    try {
+      try (ServerSocket socket = new ServerSocket(0)) {
+        return socket.getLocalPort();
+      }
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to find available port to use", e);
+    }
+  }
+
+  private Properties createBrokerConfig(String brokerId, int port) {
+    Properties props = new Properties();
+    props.put("broker.id", brokerId);
+    props.put("host.name", "localhost");
+    props.put("port", Integer.toString(port));
+    props.put("listeners", "PLAINTEXT://localhost:" + port);
+    props.put("log.dir", new File(TEMP_DIR, "log").getPath());
+    props.put("zookeeper.connect", _zkServer.getZkAddress());
+    props.put("zookeeper.session.timeout.ms", "30000");
+    props.put("controlled.shutdown.enable", "true");
+    props.put("delete.topic.enable", "true");
+    props.put("auto.create.topics.enable", "true");
+    props.put("offsets.topic.replication.factor", "1");
+    props.put("log.cleaner.dedupe.buffer.size", "2097152");
+    return props;
+  }
+
+  public void start() {
+    _kafkaServer.startup();
+  }
+
+  @Override
+  public void close()
+      throws IOException {
+    _kafkaServer.shutdown();
+    _zkServer.close();
+    FileUtils.deleteDirectory(TEMP_DIR);
+  }
+
+  public String getKafkaServerAddress() {
+    return _kafkaServerAddress;
+  }
+
+  public void createTopic(String topicName, int numPartitions, int replicationFactor)
+      throws ExecutionException, InterruptedException {
+    NewTopic newTopic = new NewTopic(topicName, numPartitions, (short) replicationFactor);
+    int retries = 5;
+    while (retries > 0) {
+      try {
+        _adminClient.createTopics(Collections.singletonList(newTopic)).all().get();
+        return;
+      } catch (ExecutionException e) {
+        if (e.getCause() instanceof org.apache.kafka.common.errors.TimeoutException) {
+          retries--;
+          TimeUnit.SECONDS.sleep(1);
+        } else {
+          throw e;
+        }
+      }
+    }
+    throw new ExecutionException("Failed to create topic after retries", null);
+  }
+
+  public void deleteTopic(String topicName)
+      throws ExecutionException, InterruptedException {
+    _adminClient.deleteTopics(Collections.singletonList(topicName)).all().get();
+  }
+
+  public void deleteRecordsBeforeOffset(String topicName, int partitionId, long offset) {
+    Map<TopicPartition, RecordsToDelete> recordsToDelete = new HashMap<>();
+    recordsToDelete.put(new TopicPartition(topicName, partitionId), RecordsToDelete.beforeOffset(offset));
+    _adminClient.deleteRecords(recordsToDelete);
+  }
+}

--- a/pinot-plugins/pinot-microbatch-ingestion/pinot-kafka-3.0-microbatch/src/test/java/org/apache/pinot/plugin/stream/microbatch/kafka30/KafkaPartitionLevelMicroBatchConsumerTest.java
+++ b/pinot-plugins/pinot-microbatch-ingestion/pinot-kafka-3.0-microbatch/src/test/java/org/apache/pinot/plugin/stream/microbatch/kafka30/KafkaPartitionLevelMicroBatchConsumerTest.java
@@ -1,0 +1,288 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.stream.microbatch.kafka30;
+
+import java.io.File;
+import java.io.IOException;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import org.apache.avro.Schema;
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.commons.io.FileUtils;
+import org.apache.kafka.clients.producer.KafkaProducer;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.ByteArraySerializer;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.apache.pinot.plugin.stream.kafka30.utils.MiniKafkaCluster;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.filesystem.LocalPinotFS;
+import org.apache.pinot.spi.filesystem.PinotFSFactory;
+import org.apache.pinot.spi.stream.MessageBatch;
+import org.apache.pinot.spi.stream.StreamConfig;
+import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.apache.avro.Schema.create;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+public class KafkaPartitionLevelMicroBatchConsumerTest {
+  private static final long STABILIZE_SLEEP_DELAYS = 3000;
+  private static final String TEST_TOPIC = "microbatch_avro_topic";
+  private static final int NUM_MESSAGES = 5;
+  private static final int NUM_AVRO_RECORDS_PER_MESSAGE = 10;
+  private static final long TIMESTAMP = Instant.now().toEpochMilli();
+
+  private MiniKafkaCluster _kafkaCluster;
+  private String _kafkaBrokerAddress;
+  private Schema _avroSchema;
+  private File _tempDir;
+
+  @BeforeClass
+  public void setUp() throws Exception {
+    // Initialize PinotFS for local file system
+    PinotConfiguration pinotFSConfig = new PinotConfiguration();
+    PinotFSFactory.register("file", LocalPinotFS.class.getName(), pinotFSConfig);
+
+    // Create temp directory for test files
+    _tempDir = new File(FileUtils.getTempDirectory(), "microbatch-test-" + System.currentTimeMillis());
+    _tempDir.mkdirs();
+
+    _kafkaCluster = new MiniKafkaCluster("0");
+    _kafkaCluster.start();
+    _kafkaBrokerAddress = _kafkaCluster.getKafkaServerAddress();
+    _kafkaCluster.createTopic(TEST_TOPIC, 1, 1);
+    Thread.sleep(STABILIZE_SLEEP_DELAYS);
+
+    // Create Avro schema
+    _avroSchema = Schema.createRecord("TestRecord", null, null, false);
+    List<Schema.Field> fields = new ArrayList<>();
+    fields.add(new Schema.Field("id", create(Schema.Type.INT), null, null));
+    fields.add(new Schema.Field("name", create(Schema.Type.STRING), null, null));
+    fields.add(new Schema.Field("value", create(Schema.Type.DOUBLE), null, null));
+    _avroSchema.setFields(fields);
+
+    produceMicroBatchMessagesToKafka();
+    Thread.sleep(STABILIZE_SLEEP_DELAYS);
+  }
+
+  private void produceMicroBatchMessagesToKafka() throws IOException {
+    Properties props = new Properties();
+    props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, _kafkaBrokerAddress);
+    props.put(ProducerConfig.CLIENT_ID_CONFIG, "microbatch-test-producer");
+    props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class.getName());
+    props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, ByteArraySerializer.class.getName());
+
+    try (KafkaProducer<String, byte[]> producer = new KafkaProducer<>(props)) {
+      for (int msgIdx = 0; msgIdx < NUM_MESSAGES; msgIdx++) {
+        // Write Avro records to a file
+        File avroFile = writeAvroRecordBatchToFile(msgIdx);
+
+        // Create JSON protocol message with numRecords
+        byte[] protocolMessage = MicroBatchProtocol.createUriMessage(
+            avroFile.toURI().toString(), MicroBatchPayloadV1.Format.AVRO, NUM_AVRO_RECORDS_PER_MESSAGE);
+
+        producer.send(
+            new ProducerRecord<>(TEST_TOPIC, 0, TIMESTAMP + msgIdx, "key_" + msgIdx, protocolMessage));
+      }
+      producer.flush();
+    }
+  }
+
+  private File writeAvroRecordBatchToFile(int batchIndex) throws IOException {
+    File avroFile = new File(_tempDir, "batch-" + batchIndex + ".avro");
+
+    GenericDatumWriter<GenericRecord> datumWriter = new GenericDatumWriter<>(_avroSchema);
+    try (DataFileWriter<GenericRecord> dataFileWriter = new DataFileWriter<>(datumWriter)) {
+      dataFileWriter.create(_avroSchema, avroFile);
+
+      // Write 10 Avro records to the file
+      for (int i = 0; i < NUM_AVRO_RECORDS_PER_MESSAGE; i++) {
+        GenericRecord record = new GenericData.Record(_avroSchema);
+        int recordId = batchIndex * NUM_AVRO_RECORDS_PER_MESSAGE + i;
+        record.put("id", recordId);
+        record.put("name", "record_" + recordId);
+        record.put("value", recordId * 1.5);
+        dataFileWriter.append(record);
+      }
+    }
+
+    return avroFile;
+  }
+
+  @AfterClass
+  public void tearDown() throws Exception {
+    try {
+      _kafkaCluster.deleteTopic(TEST_TOPIC);
+    } finally {
+      _kafkaCluster.close();
+    }
+
+    // Clean up temp directory
+    if (_tempDir != null && _tempDir.exists()) {
+      FileUtils.deleteDirectory(_tempDir);
+    }
+  }
+
+  @Test
+  public void testConsumeMessagesWithSerializedAvroRecords() throws Exception {
+    String streamType = "kafka";
+    String clientId = "microbatch-test-client";
+    String tableNameWithType = "testTable_REALTIME";
+
+    Map<String, String> streamConfigMap = new HashMap<>();
+    streamConfigMap.put("streamType", streamType);
+    streamConfigMap.put("stream.kafka.topic.name", TEST_TOPIC);
+    streamConfigMap.put("stream.kafka.broker.list", _kafkaBrokerAddress);
+    streamConfigMap.put("stream.kafka.consumer.factory.class.name",
+        "org.apache.pinot.plugin.stream.kafka30.KafkaConsumerFactory");
+    streamConfigMap.put("stream.kafka.decoder.class.name", "decoderClass");
+    StreamConfig streamConfig = new StreamConfig(tableNameWithType, streamConfigMap);
+
+    KafkaPartitionLevelMicroBatchConsumer consumer =
+        new KafkaPartitionLevelMicroBatchConsumer(clientId, streamConfig, 0, 2);
+
+    // Fetch messages starting from offset 0
+    MicroBatchStreamPartitionMsgOffset startOffset = MicroBatchStreamPartitionMsgOffset.of(0);
+    MessageBatch<GenericRow> messageBatch = consumer.fetchMessages(startOffset, 10000);
+
+    assertNotNull(messageBatch);
+    // Each fetchMessages call returns one batch from one Kafka message (one Avro file with 10 records)
+    assertEquals(messageBatch.getMessageCount(), NUM_AVRO_RECORDS_PER_MESSAGE);
+
+    // Verify the records from the first batch
+    for (int i = 0; i < messageBatch.getMessageCount(); i++) {
+      GenericRow row = messageBatch.getStreamMessage(i).getValue();
+      assertNotNull(row);
+      assertNotNull(row.getValue("id"));
+      assertNotNull(row.getValue("name"));
+      assertNotNull(row.getValue("value"));
+      assert row.getValue("name").toString().startsWith("record_")
+          : "Record " + i + " should have name starting with 'record_'";
+    }
+
+    // Fetch and verify all messages
+    int totalRecords = messageBatch.getMessageCount();
+    while (totalRecords < NUM_MESSAGES * NUM_AVRO_RECORDS_PER_MESSAGE) {
+      StreamPartitionMsgOffset nextOffset = messageBatch.getOffsetOfNextBatch();
+      messageBatch = consumer.fetchMessages(nextOffset, 10000);
+      if (messageBatch.getMessageCount() == 0) {
+        break;
+      }
+      totalRecords += messageBatch.getMessageCount();
+    }
+
+    // Verify we got all records
+    assertEquals(totalRecords, NUM_MESSAGES * NUM_AVRO_RECORDS_PER_MESSAGE);
+
+    consumer.close();
+  }
+
+  /**
+   * Test that mid-batch resume works correctly.
+   * This simulates what happens after a segment commit when we need to resume
+   * from a specific record offset within a Kafka message.
+   */
+  @Test
+  public void testMidBatchResume() throws Exception {
+    String streamType = "kafka";
+    String clientId = "microbatch-test-client-midbatch";
+    String tableNameWithType = "testTable_REALTIME";
+
+    Map<String, String> streamConfigMap = new HashMap<>();
+    streamConfigMap.put("streamType", streamType);
+    streamConfigMap.put("stream.kafka.topic.name", TEST_TOPIC);
+    streamConfigMap.put("stream.kafka.broker.list", _kafkaBrokerAddress);
+    streamConfigMap.put("stream.kafka.consumer.factory.class.name",
+        "org.apache.pinot.plugin.stream.kafka30.KafkaConsumerFactory");
+    streamConfigMap.put("stream.kafka.decoder.class.name", "decoderClass");
+    StreamConfig streamConfig = new StreamConfig(tableNameWithType, streamConfigMap);
+
+    KafkaPartitionLevelMicroBatchConsumer consumer =
+        new KafkaPartitionLevelMicroBatchConsumer(clientId, streamConfig, 0, 2);
+
+    // First, consume from the beginning to establish context
+    MicroBatchStreamPartitionMsgOffset startOffset = MicroBatchStreamPartitionMsgOffset.of(0);
+    MessageBatch<GenericRow> messageBatch = consumer.fetchMessages(startOffset, 10000);
+    assertNotNull(messageBatch);
+    assertEquals(messageBatch.getMessageCount(), NUM_AVRO_RECORDS_PER_MESSAGE);
+
+    // Verify first record starts with id=0
+    GenericRow firstRow = messageBatch.getStreamMessage(0).getValue();
+    assertEquals(firstRow.getValue("id"), 0);
+
+    consumer.close();
+
+    // Now simulate a new consumer (like after segment commit) starting mid-batch
+    // Start from kafka offset 0, but record offset 5 (skip first 5 records)
+    KafkaPartitionLevelMicroBatchConsumer consumer2 =
+        new KafkaPartitionLevelMicroBatchConsumer(clientId + "-2", streamConfig, 0, 2);
+
+    int skipRecords = 5;
+    MicroBatchStreamPartitionMsgOffset midBatchOffset =
+        new MicroBatchStreamPartitionMsgOffset(0, skipRecords);
+    MessageBatch<GenericRow> resumedBatch = consumer2.fetchMessages(midBatchOffset, 10000);
+
+    assertNotNull(resumedBatch);
+    // Should get remaining records: 10 - 5 = 5
+    assertEquals(resumedBatch.getMessageCount(), NUM_AVRO_RECORDS_PER_MESSAGE - skipRecords);
+
+    // Verify first record after resume has id=5 (the 6th record, 0-indexed as 5)
+    GenericRow firstResumedRow = resumedBatch.getStreamMessage(0).getValue();
+    assertEquals(firstResumedRow.getValue("id"), skipRecords,
+        "First record after mid-batch resume should have id=" + skipRecords);
+
+    // Verify the offset of the first resumed record
+    StreamPartitionMsgOffset firstResumedOffset =
+        resumedBatch.getStreamMessage(0).getMetadata().getOffset();
+    assertNotNull(firstResumedOffset);
+    MicroBatchStreamPartitionMsgOffset mbOffset = (MicroBatchStreamPartitionMsgOffset) firstResumedOffset;
+    assertEquals(mbOffset.getKafkaMessageOffset(), 0);
+    assertEquals(mbOffset.getRecordOffsetInMicroBatch(), skipRecords);
+
+    // Continue consuming to verify we get all remaining records
+    int totalRecords = resumedBatch.getMessageCount();
+    StreamPartitionMsgOffset nextOffset = resumedBatch.getOffsetOfNextBatch();
+
+    while (totalRecords < (NUM_MESSAGES * NUM_AVRO_RECORDS_PER_MESSAGE) - skipRecords) {
+      messageBatch = consumer2.fetchMessages(nextOffset, 10000);
+      if (messageBatch.getMessageCount() == 0) {
+        break;
+      }
+      totalRecords += messageBatch.getMessageCount();
+      nextOffset = messageBatch.getOffsetOfNextBatch();
+    }
+
+    // Should have all records minus the skipped ones from the first batch
+    assertEquals(totalRecords, (NUM_MESSAGES * NUM_AVRO_RECORDS_PER_MESSAGE) - skipRecords);
+
+    consumer2.close();
+  }
+}

--- a/pinot-plugins/pinot-microbatch-ingestion/pinot-kafka-3.0-microbatch/src/test/java/org/apache/pinot/plugin/stream/microbatch/kafka30/MicroBatchProtocolTest.java
+++ b/pinot-plugins/pinot-microbatch-ingestion/pinot-kafka-3.0-microbatch/src/test/java/org/apache/pinot/plugin/stream/microbatch/kafka30/MicroBatchProtocolTest.java
@@ -1,0 +1,474 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.stream.microbatch.kafka30;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+
+public class MicroBatchProtocolTest {
+
+  @Test
+  public void testCreateUriMessage() throws IOException {
+    String uri = "file:///tmp/test.avro";
+    byte[] message = MicroBatchProtocol.createUriMessage(uri, MicroBatchPayloadV1.Format.AVRO, 100);
+
+    assertNotNull(message);
+    // First byte should be version
+    assertEquals(message[0], MicroBatchProtocol.VERSION_1);
+    // Rest should be JSON payload starting with '{'
+    assertEquals(message[1], '{');
+
+    // Parse and verify
+    MicroBatchProtocol protocol = MicroBatchProtocol.parse(message);
+    assertEquals(protocol.getVersion(), MicroBatchProtocol.VERSION_1);
+    assertEquals(protocol.getType(), MicroBatchPayloadV1.Type.URI);
+    assertEquals(protocol.getFormat(), MicroBatchPayloadV1.Format.AVRO);
+    assertEquals(protocol.getUri(), uri);
+    assertEquals(protocol.getNumRecords(), 100);
+  }
+
+  @Test
+  public void testCreateUriMessageWithDifferentFormats() throws IOException {
+    // Test AVRO
+    byte[] avroMessage = MicroBatchProtocol.createUriMessage(
+        "s3://bucket/test.avro", MicroBatchPayloadV1.Format.AVRO, 100);
+    MicroBatchProtocol avroProtocol = MicroBatchProtocol.parse(avroMessage);
+    assertEquals(avroProtocol.getFormat(), MicroBatchPayloadV1.Format.AVRO);
+
+    // Test PARQUET
+    byte[] parquetMessage = MicroBatchProtocol.createUriMessage(
+        "hdfs://cluster/test.parquet", MicroBatchPayloadV1.Format.PARQUET, 200);
+    MicroBatchProtocol parquetProtocol = MicroBatchProtocol.parse(parquetMessage);
+    assertEquals(parquetProtocol.getFormat(), MicroBatchPayloadV1.Format.PARQUET);
+
+    // Test JSON
+    byte[] jsonMessage = MicroBatchProtocol.createUriMessage(
+        "gs://bucket/test.json", MicroBatchPayloadV1.Format.JSON, 300);
+    MicroBatchProtocol jsonProtocol = MicroBatchProtocol.parse(jsonMessage);
+    assertEquals(jsonProtocol.getFormat(), MicroBatchPayloadV1.Format.JSON);
+  }
+
+  @Test
+  public void testCreateDataMessage() throws IOException {
+    byte[] testData = "test data content".getBytes(StandardCharsets.UTF_8);
+    byte[] message = MicroBatchProtocol.createDataMessage(testData, MicroBatchPayloadV1.Format.AVRO, 50);
+
+    assertNotNull(message);
+    assertEquals(message[0], MicroBatchProtocol.VERSION_1);
+
+    MicroBatchProtocol protocol = MicroBatchProtocol.parse(message);
+    assertEquals(protocol.getType(), MicroBatchPayloadV1.Type.DATA);
+    assertEquals(protocol.getFormat(), MicroBatchPayloadV1.Format.AVRO);
+    assertEquals(new String(protocol.getData(), StandardCharsets.UTF_8), "test data content");
+    assertEquals(protocol.getNumRecords(), 50);
+  }
+
+  @Test
+  public void testCreateUriMessageWithNumRecords() throws IOException {
+    String uri = "s3://bucket/batch.avro";
+    byte[] message = MicroBatchProtocol.createUriMessage(uri, MicroBatchPayloadV1.Format.AVRO, 1000);
+
+    MicroBatchProtocol protocol = MicroBatchProtocol.parse(message);
+    assertEquals(protocol.getNumRecords(), 1000);
+    assertEquals(protocol.getUri(), uri);
+  }
+
+  @Test
+  public void testCreateDataMessageWithNumRecords() throws IOException {
+    byte[] testData = "test".getBytes(StandardCharsets.UTF_8);
+    byte[] message = MicroBatchProtocol.createDataMessage(testData, MicroBatchPayloadV1.Format.AVRO, 500);
+
+    MicroBatchProtocol protocol = MicroBatchProtocol.parse(message);
+    assertEquals(protocol.getNumRecords(), 500);
+  }
+
+  @Test
+  public void testParseUriMessage() throws IOException {
+    String uri = "file:///tmp/batch-123.avro";
+    byte[] message = MicroBatchProtocol.createUriMessage(uri, MicroBatchPayloadV1.Format.AVRO, 100);
+
+    MicroBatchProtocol protocol = MicroBatchProtocol.parse(message);
+
+    assertEquals(protocol.getVersion(), MicroBatchProtocol.VERSION_1);
+    assertEquals(protocol.getType(), MicroBatchPayloadV1.Type.URI);
+    assertEquals(protocol.getFormat(), MicroBatchPayloadV1.Format.AVRO);
+    assertEquals(protocol.getUri(), uri);
+    assertNull(protocol.getData());
+  }
+
+  @Test
+  public void testParseDataMessage() throws IOException {
+    byte[] testData = "test data".getBytes(StandardCharsets.UTF_8);
+    byte[] message = MicroBatchProtocol.createDataMessage(testData, MicroBatchPayloadV1.Format.AVRO, 10);
+
+    MicroBatchProtocol protocol = MicroBatchProtocol.parse(message);
+
+    assertEquals(protocol.getVersion(), MicroBatchProtocol.VERSION_1);
+    assertEquals(protocol.getType(), MicroBatchPayloadV1.Type.DATA);
+    assertEquals(protocol.getFormat(), MicroBatchPayloadV1.Format.AVRO);
+    assertNull(protocol.getUri());
+    assertNotNull(protocol.getData());
+    assertEquals(new String(protocol.getData(), StandardCharsets.UTF_8), "test data");
+  }
+
+  @Test
+  public void testIsProtocol() throws IOException {
+    // Valid protocol message
+    byte[] validMessage = MicroBatchProtocol.createUriMessage(
+        "file:///tmp/test.avro", MicroBatchPayloadV1.Format.AVRO, 100);
+    assertTrue(MicroBatchProtocol.isProtocol(validMessage));
+
+    // Invalid - no version byte (raw JSON)
+    byte[] rawJson = "{\"type\":\"uri\"}".getBytes(StandardCharsets.UTF_8);
+    assertFalse(MicroBatchProtocol.isProtocol(rawJson));
+
+    // Invalid - unknown version
+    byte[] unknownVersion = createRawMessage(99, "{\"type\":\"uri\"}".getBytes());
+    assertFalse(MicroBatchProtocol.isProtocol(unknownVersion));
+
+    // Invalid - too short
+    assertFalse(MicroBatchProtocol.isProtocol(new byte[]{1}));
+    assertFalse(MicroBatchProtocol.isProtocol(null));
+  }
+
+  @Test
+  public void testParseMissingType() {
+    byte[] message = createRawMessage(1, "{\"format\":\"avro\",\"uri\":\"file:///tmp/test.avro\"}".getBytes());
+    try {
+      MicroBatchProtocol.parse(message);
+      fail("Should throw exception for missing type");
+    } catch (Exception e) {
+      assertTrue(e.getMessage().contains("type"));
+    }
+  }
+
+  @Test
+  public void testParseMissingFormat() {
+    byte[] message = createRawMessage(1, "{\"type\":\"uri\",\"uri\":\"file:///tmp/test.avro\"}".getBytes());
+    try {
+      MicroBatchProtocol.parse(message);
+      fail("Should throw exception for missing format");
+    } catch (Exception e) {
+      assertTrue(e.getMessage().contains("format"));
+    }
+  }
+
+  @Test
+  public void testParseUnsupportedVersion() {
+    String json = "{\"type\":\"uri\",\"format\":\"avro\",\"uri\":\"file:///tmp/test.avro\"}";
+    byte[] message = createRawMessage(99, json.getBytes());
+    try {
+      MicroBatchProtocol.parse(message);
+      fail("Should throw exception for unsupported version");
+    } catch (Exception e) {
+      assertTrue(e.getMessage().contains("Unsupported MicroBatch protocol version: 99"));
+    }
+  }
+
+  @Test
+  public void testParseInvalidType() {
+    String json = "{\"type\":\"invalid\",\"format\":\"avro\",\"uri\":\"file:///tmp/test.avro\"}";
+    byte[] message = createRawMessage(1, json.getBytes());
+    try {
+      MicroBatchProtocol.parse(message);
+      fail("Should throw exception for invalid type");
+    } catch (Exception e) {
+      assertTrue(e.getMessage().contains("Invalid type: invalid"));
+    }
+  }
+
+  @Test
+  public void testParseInvalidFormat() {
+    String json = "{\"type\":\"uri\",\"format\":\"xml\",\"uri\":\"file:///tmp/test.avro\"}";
+    byte[] message = createRawMessage(1, json.getBytes());
+    try {
+      MicroBatchProtocol.parse(message);
+      fail("Should throw exception for invalid format");
+    } catch (Exception e) {
+      assertTrue(e.getMessage().contains("Invalid format: xml"));
+    }
+  }
+
+  @Test
+  public void testParseUriTypeMissingUri() {
+    byte[] message = createRawMessage(1,
+        "{\"type\":\"uri\",\"format\":\"avro\",\"numRecords\":100}".getBytes());
+    try {
+      MicroBatchProtocol.parse(message);
+      fail("Should throw exception for missing uri when type=uri");
+    } catch (Exception e) {
+      assertTrue(e.getMessage().contains("uri"));
+    }
+  }
+
+  @Test
+  public void testParseDataTypeMissingData() {
+    byte[] message = createRawMessage(1,
+        "{\"type\":\"data\",\"format\":\"avro\",\"numRecords\":100}".getBytes());
+    try {
+      MicroBatchProtocol.parse(message);
+      fail("Should throw exception for missing data when type=data");
+    } catch (Exception e) {
+      assertTrue(e.getMessage().contains("data"));
+    }
+  }
+
+  @Test
+  public void testParseDataWithInvalidBase64() {
+    String json = "{\"type\":\"data\",\"format\":\"avro\",\"data\":\"not-valid-base64!!!\"}";
+    byte[] message = createRawMessage(1, json.getBytes());
+    try {
+      MicroBatchProtocol.parse(message);
+      fail("Should throw exception for invalid base64");
+    } catch (Exception e) {
+      assertTrue(e.getMessage().contains("base64") || e instanceof IllegalArgumentException);
+    }
+  }
+
+  @Test
+  public void testParseWithS3Uri() throws IOException {
+    String s3Uri = "s3://my-bucket/path/to/batch-456.avro";
+    byte[] message = MicroBatchProtocol.createUriMessage(s3Uri, MicroBatchPayloadV1.Format.AVRO, 456);
+
+    MicroBatchProtocol protocol = MicroBatchProtocol.parse(message);
+
+    assertEquals(protocol.getUri(), s3Uri);
+    assertEquals(protocol.getType(), MicroBatchPayloadV1.Type.URI);
+  }
+
+  @Test
+  public void testParseWithHdfsUri() throws IOException {
+    String hdfsUri = "hdfs://namenode:9000/user/pinot/batch-789.parquet";
+    byte[] message = MicroBatchProtocol.createUriMessage(hdfsUri, MicroBatchPayloadV1.Format.PARQUET, 789);
+
+    MicroBatchProtocol protocol = MicroBatchProtocol.parse(message);
+
+    assertEquals(protocol.getUri(), hdfsUri);
+    assertEquals(protocol.getFormat(), MicroBatchPayloadV1.Format.PARQUET);
+  }
+
+  @Test
+  public void testParseWithGcsUri() throws IOException {
+    String gcsUri = "gs://my-gcs-bucket/data/batch-999.json";
+    byte[] message = MicroBatchProtocol.createUriMessage(gcsUri, MicroBatchPayloadV1.Format.JSON, 999);
+
+    MicroBatchProtocol protocol = MicroBatchProtocol.parse(message);
+
+    assertEquals(protocol.getUri(), gcsUri);
+    assertEquals(protocol.getFormat(), MicroBatchPayloadV1.Format.JSON);
+  }
+
+  @Test
+  public void testParseLargeBinaryData() throws IOException {
+    // Test with 1MB of data
+    byte[] largeData = new byte[1024 * 1024];
+    for (int i = 0; i < largeData.length; i++) {
+      largeData[i] = (byte) (i % 256);
+    }
+
+    byte[] message = MicroBatchProtocol.createDataMessage(largeData, MicroBatchPayloadV1.Format.AVRO, 10000);
+    MicroBatchProtocol protocol = MicroBatchProtocol.parse(message);
+
+    assertEquals(protocol.getType(), MicroBatchPayloadV1.Type.DATA);
+    assertEquals(protocol.getData().length, largeData.length);
+
+    // Verify data integrity
+    for (int i = 0; i < 1000; i++) {
+      assertEquals(protocol.getData()[i], largeData[i]);
+    }
+  }
+
+  @Test
+  public void testCaseInsensitiveTypeParsing() throws IOException {
+    // Type should be case-insensitive
+    String json = "{\"type\":\"URI\",\"format\":\"avro\",\"uri\":\"file:///tmp/test.avro\",\"numRecords\":100}";
+    byte[] message = createRawMessage(1, json.getBytes());
+    MicroBatchProtocol protocol = MicroBatchProtocol.parse(message);
+    assertEquals(protocol.getType(), MicroBatchPayloadV1.Type.URI);
+
+    String base64Data = Base64.getEncoder().encodeToString("test".getBytes());
+    String json2 = "{\"type\":\"Data\",\"format\":\"avro\",\"data\":\"" + base64Data + "\",\"numRecords\":50}";
+    message = createRawMessage(1, json2.getBytes());
+    protocol = MicroBatchProtocol.parse(message);
+    assertEquals(protocol.getType(), MicroBatchPayloadV1.Type.DATA);
+  }
+
+  @Test
+  public void testCaseInsensitiveFormatParsing() throws IOException {
+    String json = "{\"type\":\"uri\",\"format\":\"AVRO\",\"uri\":\"file:///tmp/test.avro\",\"numRecords\":100}";
+    byte[] message = createRawMessage(1, json.getBytes());
+    MicroBatchProtocol protocol = MicroBatchProtocol.parse(message);
+    assertEquals(protocol.getFormat(), MicroBatchPayloadV1.Format.AVRO);
+
+    String json2 = "{\"type\":\"uri\",\"format\":\"Parquet\",\"uri\":\"file:///tmp/test.parquet\",\"numRecords\":200}";
+    message = createRawMessage(1, json2.getBytes());
+    protocol = MicroBatchProtocol.parse(message);
+    assertEquals(protocol.getFormat(), MicroBatchPayloadV1.Format.PARQUET);
+  }
+
+  @Test
+  public void testEmptyData() throws IOException {
+    // Empty data with numRecords=1 (edge case - file exists but has no actual content)
+    byte[] emptyData = new byte[0];
+    byte[] message = MicroBatchProtocol.createDataMessage(emptyData, MicroBatchPayloadV1.Format.AVRO, 1);
+
+    MicroBatchProtocol protocol = MicroBatchProtocol.parse(message);
+
+    assertEquals(protocol.getType(), MicroBatchPayloadV1.Type.DATA);
+    assertNotNull(protocol.getData());
+    assertEquals(protocol.getData().length, 0);
+  }
+
+  @Test
+  public void testRoundTripUriMessage() throws IOException {
+    String originalUri = "abfs://container@account.dfs.core.windows.net/path/batch.avro";
+    byte[] message = MicroBatchProtocol.createUriMessage(
+        originalUri, MicroBatchPayloadV1.Format.AVRO, 500);
+    MicroBatchProtocol protocol = MicroBatchProtocol.parse(message);
+
+    // Create another message from the parsed protocol
+    byte[] message2 = MicroBatchProtocol.createUriMessage(
+        protocol.getUri(), protocol.getFormat(), protocol.getNumRecords());
+    MicroBatchProtocol protocol2 = MicroBatchProtocol.parse(message2);
+
+    assertEquals(protocol2.getUri(), originalUri);
+    assertEquals(protocol2.getType(), MicroBatchPayloadV1.Type.URI);
+    assertEquals(protocol2.getFormat(), MicroBatchPayloadV1.Format.AVRO);
+    assertEquals(protocol2.getNumRecords(), 500);
+  }
+
+  @Test
+  public void testRoundTripDataMessage() throws IOException {
+    byte[] originalData = "original test data with special chars: !@#$%^&*()".getBytes(
+        StandardCharsets.UTF_8);
+    byte[] message = MicroBatchProtocol.createDataMessage(
+        originalData, MicroBatchPayloadV1.Format.JSON, 1);
+    MicroBatchProtocol protocol = MicroBatchProtocol.parse(message);
+
+    // Create another message from the parsed protocol
+    byte[] message2 = MicroBatchProtocol.createDataMessage(
+        protocol.getData(), protocol.getFormat(), protocol.getNumRecords());
+    MicroBatchProtocol protocol2 = MicroBatchProtocol.parse(message2);
+
+    assertEquals(new String(protocol2.getData(), StandardCharsets.UTF_8),
+        "original test data with special chars: !@#$%^&*()");
+    assertEquals(protocol2.getType(), MicroBatchPayloadV1.Type.DATA);
+    assertEquals(protocol2.getFormat(), MicroBatchPayloadV1.Format.JSON);
+  }
+
+  @Test
+  public void testGetPayloadV1() throws IOException {
+    byte[] message = MicroBatchProtocol.createUriMessage("s3://bucket/file.avro", MicroBatchPayloadV1.Format.AVRO, 100);
+    MicroBatchProtocol protocol = MicroBatchProtocol.parse(message);
+
+    MicroBatchPayloadV1 payload = protocol.getPayloadV1();
+    assertNotNull(payload);
+    assertEquals(payload.getType(), MicroBatchPayloadV1.Type.URI);
+    assertEquals(payload.getFormat(), MicroBatchPayloadV1.Format.AVRO);
+    assertEquals(payload.getUri(), "s3://bucket/file.avro");
+    assertEquals(payload.getNumRecords(), 100);
+  }
+
+  @Test
+  public void testMessageTooShort() {
+    try {
+      MicroBatchProtocol.parse(new byte[]{1});
+      fail("Should throw exception for message too short");
+    } catch (Exception e) {
+      assertTrue(e.getMessage().contains("at least 2 bytes"));
+    }
+  }
+
+  @Test
+  public void testNullMessage() {
+    try {
+      MicroBatchProtocol.parse(null);
+      fail("Should throw exception for null message");
+    } catch (Exception e) {
+      assertTrue(e.getMessage().contains("at least 2 bytes"));
+    }
+  }
+
+  @Test
+  public void testUnknownFieldsIgnored() throws IOException {
+    // JSON with extra unknown fields should be ignored
+    String json = "{\"type\":\"uri\",\"format\":\"avro\",\"uri\":\"file:///test.avro\","
+        + "\"unknownField\":\"value\",\"anotherUnknown\":123,\"numRecords\":100}";
+    byte[] message = createRawMessage(1, json.getBytes());
+    MicroBatchProtocol protocol = MicroBatchProtocol.parse(message);
+
+    assertEquals(protocol.getType(), MicroBatchPayloadV1.Type.URI);
+    assertEquals(protocol.getUri(), "file:///test.avro");
+  }
+
+  @Test
+  public void testUriTypeWithDataFieldFails() {
+    // URI type should not have 'data' field set
+    String base64Data = Base64.getEncoder().encodeToString("test".getBytes());
+    String json = "{\"type\":\"uri\",\"format\":\"avro\",\"uri\":\"file:///test.avro\","
+        + "\"data\":\"" + base64Data + "\",\"numRecords\":100}";
+    byte[] message = createRawMessage(1, json.getBytes());
+    try {
+      MicroBatchProtocol.parse(message);
+      fail("Should throw exception when both uri and data are set for type=uri");
+    } catch (Exception e) {
+      assertTrue(e.getMessage().contains("'data' must not be set when type=uri"));
+    }
+  }
+
+  @Test
+  public void testDataTypeWithUriFieldFails() {
+    // DATA type should not have 'uri' field set
+    String base64Data = Base64.getEncoder().encodeToString("test".getBytes());
+    String json = "{\"type\":\"data\",\"format\":\"avro\",\"data\":\"" + base64Data + "\","
+        + "\"uri\":\"file:///test.avro\",\"numRecords\":100}";
+    byte[] message = createRawMessage(1, json.getBytes());
+    try {
+      MicroBatchProtocol.parse(message);
+      fail("Should throw exception when both uri and data are set for type=data");
+    } catch (Exception e) {
+      assertTrue(e.getMessage().contains("'uri' must not be set when type=data"));
+    }
+  }
+
+  /**
+   * Helper to create raw protocol message with version byte + payload.
+   */
+  private byte[] createRawMessage(int version, byte[] payload) {
+    try {
+      ByteArrayOutputStream out = new ByteArrayOutputStream(1 + payload.length);
+      out.write(version);
+      out.write(payload);
+      return out.toByteArray();
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/pinot-plugins/pinot-microbatch-ingestion/pinot-kafka-3.0-microbatch/src/test/java/org/apache/pinot/plugin/stream/microbatch/kafka30/MicroBatchProtocolTest.java
+++ b/pinot-plugins/pinot-microbatch-ingestion/pinot-kafka-3.0-microbatch/src/test/java/org/apache/pinot/plugin/stream/microbatch/kafka30/MicroBatchProtocolTest.java
@@ -458,6 +458,52 @@ public class MicroBatchProtocolTest {
     }
   }
 
+  @Test
+  public void testCreateUriMessageWithChecksum() throws IOException {
+    String uri = "s3://bucket/batch.avro";
+    String checksum = "a1b2c3d4";
+    byte[] message = MicroBatchProtocol.createUriMessage(
+        uri, MicroBatchPayloadV1.Format.AVRO, 100, checksum);
+
+    MicroBatchProtocol protocol = MicroBatchProtocol.parse(message);
+    assertEquals(protocol.getUri(), uri);
+    assertEquals(protocol.getNumRecords(), 100);
+    assertEquals(protocol.getChecksum(), checksum);
+  }
+
+  @Test
+  public void testCreateUriMessageWithNullChecksum() throws IOException {
+    byte[] message = MicroBatchProtocol.createUriMessage(
+        "s3://bucket/file.avro", MicroBatchPayloadV1.Format.AVRO, 50, null);
+
+    MicroBatchProtocol protocol = MicroBatchProtocol.parse(message);
+    assertNull(protocol.getChecksum());
+  }
+
+  @Test
+  public void testChecksumNotPresentForDataType() throws IOException {
+    byte[] testData = "test".getBytes(StandardCharsets.UTF_8);
+    byte[] message = MicroBatchProtocol.createDataMessage(
+        testData, MicroBatchPayloadV1.Format.AVRO, 1);
+
+    MicroBatchProtocol protocol = MicroBatchProtocol.parse(message);
+    assertNull(protocol.getChecksum());
+  }
+
+  @Test
+  public void testChecksumPreservedInRoundTrip() throws IOException {
+    String checksum = "deadbeef";
+    byte[] message = MicroBatchProtocol.createUriMessage(
+        "s3://bucket/file.avro", MicroBatchPayloadV1.Format.AVRO, 200, checksum);
+    MicroBatchProtocol protocol = MicroBatchProtocol.parse(message);
+
+    byte[] message2 = MicroBatchProtocol.createUriMessage(
+        protocol.getUri(), protocol.getFormat(), protocol.getNumRecords(), protocol.getChecksum());
+    MicroBatchProtocol protocol2 = MicroBatchProtocol.parse(message2);
+
+    assertEquals(protocol2.getChecksum(), checksum);
+  }
+
   /**
    * Helper to create raw protocol message with version byte + payload.
    */

--- a/pinot-plugins/pinot-microbatch-ingestion/pinot-kafka-3.0-microbatch/src/test/java/org/apache/pinot/plugin/stream/microbatch/kafka30/MicroBatchQueueManagerTest.java
+++ b/pinot-plugins/pinot-microbatch-ingestion/pinot-kafka-3.0-microbatch/src/test/java/org/apache/pinot/plugin/stream/microbatch/kafka30/MicroBatchQueueManagerTest.java
@@ -1,0 +1,317 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.stream.microbatch.kafka30;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.apache.avro.Schema;
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.filesystem.LocalPinotFS;
+import org.apache.pinot.spi.filesystem.PinotFSFactory;
+import org.apache.pinot.spi.stream.MessageBatch;
+import org.apache.pinot.spi.stream.StreamMessageMetadata;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+
+public class MicroBatchQueueManagerTest {
+
+  private static final int TEST_PARTITION = 0;
+  private static final int NUM_FILE_FETCH_THREADS = 2;
+
+  private MicroBatchQueueManager _queueManager;
+  private File _tempDir;
+  private Schema _avroSchema;
+
+  @BeforeClass
+  public void setUpClass() {
+    // Initialize PinotFS for local file system
+    PinotConfiguration pinotFSConfig = new PinotConfiguration();
+    PinotFSFactory.register("file", LocalPinotFS.class.getName(), pinotFSConfig);
+
+    // Create Avro schema for test files
+    _avroSchema = Schema.createRecord("TestRecord", null, null, false);
+    _avroSchema.setFields(java.util.Arrays.asList(
+        new Schema.Field("id", Schema.create(Schema.Type.INT), null, null),
+        new Schema.Field("name", Schema.create(Schema.Type.STRING), null, null)
+    ));
+  }
+
+  @BeforeMethod
+  public void setUp() throws IOException {
+    _queueManager = new MicroBatchQueueManager(TEST_PARTITION, NUM_FILE_FETCH_THREADS);
+    _tempDir = new File(FileUtils.getTempDirectory(), "microbatch-test-" + System.currentTimeMillis());
+    _tempDir.mkdirs();
+  }
+
+  @AfterMethod
+  public void tearDown() throws IOException {
+    if (_queueManager != null) {
+      _queueManager.close();
+    }
+    if (_tempDir != null && _tempDir.exists()) {
+      FileUtils.deleteDirectory(_tempDir);
+    }
+  }
+
+  @Test
+  public void testSubmitAndRetrieveBatch() throws Exception {
+    // Create a valid Avro file
+    File avroFile = createAvroFile("test-batch.avro", 5);
+    MicroBatch microBatch = createMicroBatch(avroFile.toURI().toString(), 5);
+
+    _queueManager.submitBatch(microBatch);
+    assertTrue(_queueManager.hasData());
+
+    // Wait for processing and retrieve
+    MessageBatch<GenericRow> messageBatch = null;
+    long startTime = System.currentTimeMillis();
+    while (messageBatch == null && System.currentTimeMillis() - startTime < 10000) {
+      messageBatch = _queueManager.getNextMessageBatch();
+      if (messageBatch == null) {
+        Thread.sleep(100);
+      }
+    }
+
+    assertNotNull(messageBatch, "Should retrieve a message batch");
+    assertEquals(messageBatch.getMessageCount(), 5);
+  }
+
+  @Test
+  public void testFileNotFound() throws Exception {
+    // Create a MicroBatch pointing to a non-existent file
+    String nonExistentUri = "file:///non/existent/path/batch.avro";
+    MicroBatch microBatch = createMicroBatch(nonExistentUri, 10);
+
+    _queueManager.submitBatch(microBatch);
+    assertTrue(_queueManager.hasData(), "Queue should have the submitted batch");
+
+    // Wait for the error to be processed - the batch should be marked as read
+    // after the download failure (current error handling behavior)
+    long startTime = System.currentTimeMillis();
+    while (_queueManager.hasData() && System.currentTimeMillis() - startTime < 5000) {
+      _queueManager.getNextMessageBatch();
+      Thread.sleep(100);
+    }
+
+    // After error handling, queue should be empty (batch marked as processed)
+    assertFalse(_queueManager.hasData(),
+        "Queue should be empty after failed batch is processed");
+
+    // No message batch should be returned since download failed
+    MessageBatch<GenericRow> batch = _queueManager.getNextMessageBatch();
+    assertNull(batch, "Should return null when queue is empty after error");
+  }
+
+  @Test
+  public void testInvalidFileFormat() throws Exception {
+    // Create a file with invalid content (not valid Avro)
+    File invalidFile = new File(_tempDir, "invalid.avro");
+    FileUtils.writeStringToFile(invalidFile, "This is not valid Avro content", StandardCharsets.UTF_8);
+
+    MicroBatch microBatch = createMicroBatch(invalidFile.toURI().toString(), 10);
+    _queueManager.submitBatch(microBatch);
+    assertTrue(_queueManager.hasData(), "Queue should have the submitted batch");
+
+    // Wait for the error to be processed
+    long startTime = System.currentTimeMillis();
+    while (_queueManager.hasData() && System.currentTimeMillis() - startTime < 5000) {
+      _queueManager.getNextMessageBatch();
+      Thread.sleep(100);
+    }
+
+    // After error handling, queue should be empty (batch marked as processed)
+    assertFalse(_queueManager.hasData(),
+        "Queue should be empty after invalid batch is processed");
+  }
+
+  @Test
+  public void testClearQueue() throws Exception {
+    File avroFile = createAvroFile("test-clear.avro", 5);
+    MicroBatch microBatch = createMicroBatch(avroFile.toURI().toString(), 5);
+
+    _queueManager.submitBatch(microBatch);
+    assertTrue(_queueManager.hasData());
+
+    _queueManager.clear();
+    assertFalse(_queueManager.hasData());
+  }
+
+  @Test
+  public void testCloseWhileProcessing() throws Exception {
+    File avroFile = createAvroFile("test-close.avro", 100);
+    MicroBatch microBatch = createMicroBatch(avroFile.toURI().toString(), 100);
+
+    _queueManager.submitBatch(microBatch);
+
+    // Close immediately while processing might still be happening
+    _queueManager.close();
+
+    // Should not throw exception
+    assertFalse(_queueManager.hasData());
+  }
+
+  @Test
+  public void testMultipleBatches() throws Exception {
+    // Submit multiple batches
+    for (int i = 0; i < 3; i++) {
+      File avroFile = createAvroFile("batch-" + i + ".avro", 5);
+      MicroBatch microBatch = createMicroBatch(avroFile.toURI().toString(), 5);
+      _queueManager.submitBatch(microBatch);
+    }
+
+    assertTrue(_queueManager.hasData());
+
+    // Retrieve all batches
+    int totalRecords = 0;
+    int batchCount = 0;
+    long startTime = System.currentTimeMillis();
+
+    while (System.currentTimeMillis() - startTime < 30000) {
+      MessageBatch<GenericRow> batch = _queueManager.getNextMessageBatch();
+      if (batch != null && batch.getMessageCount() > 0) {
+        totalRecords += batch.getMessageCount();
+        batchCount++;
+      }
+      if (totalRecords >= 15) {
+        break;
+      }
+      if (!_queueManager.hasData() && batch == null) {
+        break;
+      }
+      Thread.sleep(100);
+    }
+
+    assertEquals(totalRecords, 15, "Should process all 15 records from 3 batches");
+  }
+
+  @Test
+  public void testInlineDataBatch() throws Exception {
+    // Create a small Avro file and encode it as inline data
+    File avroFile = createAvroFile("inline-test.avro", 3);
+    byte[] fileContent = FileUtils.readFileToByteArray(avroFile);
+
+    MicroBatch microBatch = createInlineDataMicroBatch(fileContent, 3);
+    _queueManager.submitBatch(microBatch);
+
+    // Wait for processing
+    MessageBatch<GenericRow> batch = null;
+    long startTime = System.currentTimeMillis();
+    while (batch == null && System.currentTimeMillis() - startTime < 10000) {
+      batch = _queueManager.getNextMessageBatch();
+      if (batch == null) {
+        Thread.sleep(100);
+      }
+    }
+
+    assertNotNull(batch, "Should retrieve inline data batch");
+    assertEquals(batch.getMessageCount(), 3);
+  }
+
+  @Test
+  public void testEmptyQueueReturnsNull() {
+    assertFalse(_queueManager.hasData());
+    MessageBatch<GenericRow> batch = _queueManager.getNextMessageBatch();
+    assertNull(batch);
+  }
+
+  @Test
+  public void testThreadInterruptionHandling() throws Exception {
+    File avroFile = createAvroFile("interrupt-test.avro", 5);
+    MicroBatch microBatch = createMicroBatch(avroFile.toURI().toString(), 5);
+
+    _queueManager.submitBatch(microBatch);
+
+    // Interrupt the current thread
+    Thread.currentThread().interrupt();
+
+    // Should handle interruption gracefully
+    MessageBatch<GenericRow> batch = _queueManager.getNextMessageBatch();
+
+    // Clear interrupt flag
+    Thread.interrupted();
+  }
+
+  // Helper methods
+
+  private File createAvroFile(String filename, int numRecords) throws IOException {
+    File avroFile = new File(_tempDir, filename);
+    GenericDatumWriter<GenericRecord> datumWriter = new GenericDatumWriter<>(_avroSchema);
+
+    try (DataFileWriter<GenericRecord> dataFileWriter = new DataFileWriter<>(datumWriter)) {
+      dataFileWriter.create(_avroSchema, avroFile);
+
+      for (int i = 0; i < numRecords; i++) {
+        GenericRecord record = new GenericData.Record(_avroSchema);
+        record.put("id", i);
+        record.put("name", "record_" + i);
+        dataFileWriter.append(record);
+      }
+    }
+
+    return avroFile;
+  }
+
+  private MicroBatch createMicroBatch(String uri, int numRecords) throws IOException {
+    byte[] protocolMessage = MicroBatchProtocol.createUriMessage(
+        uri, MicroBatchPayloadV1.Format.AVRO, numRecords);
+    MicroBatchProtocol protocol = MicroBatchProtocol.parse(protocolMessage);
+
+    MicroBatchStreamPartitionMsgOffset offset = new MicroBatchStreamPartitionMsgOffset(0, 0);
+    MicroBatchStreamPartitionMsgOffset nextOffset = new MicroBatchStreamPartitionMsgOffset(1, 0);
+
+    StreamMessageMetadata metadata = new StreamMessageMetadata.Builder()
+        .setRecordIngestionTimeMs(System.currentTimeMillis())
+        .setOffset(offset, nextOffset)
+        .build();
+
+    return new MicroBatch(null, 1, protocol, metadata, false, 0);
+  }
+
+  private MicroBatch createInlineDataMicroBatch(byte[] data, int numRecords) throws IOException {
+    byte[] protocolMessage = MicroBatchProtocol.createDataMessage(
+        data, MicroBatchPayloadV1.Format.AVRO, numRecords);
+    MicroBatchProtocol protocol = MicroBatchProtocol.parse(protocolMessage);
+
+    MicroBatchStreamPartitionMsgOffset offset = new MicroBatchStreamPartitionMsgOffset(0, 0);
+    MicroBatchStreamPartitionMsgOffset nextOffset = new MicroBatchStreamPartitionMsgOffset(1, 0);
+
+    StreamMessageMetadata metadata = new StreamMessageMetadata.Builder()
+        .setRecordIngestionTimeMs(System.currentTimeMillis())
+        .setOffset(offset, nextOffset)
+        .build();
+
+    return new MicroBatch(null, 1, protocol, metadata, false, 0);
+  }
+}

--- a/pinot-plugins/pinot-microbatch-ingestion/pinot-kafka-3.0-microbatch/src/test/java/org/apache/pinot/plugin/stream/microbatch/kafka30/MicroBatchQueueManagerTest.java
+++ b/pinot-plugins/pinot-microbatch-ingestion/pinot-kafka-3.0-microbatch/src/test/java/org/apache/pinot/plugin/stream/microbatch/kafka30/MicroBatchQueueManagerTest.java
@@ -21,6 +21,7 @@ package org.apache.pinot.plugin.stream.microbatch.kafka30;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.zip.CRC32;
 import org.apache.avro.Schema;
 import org.apache.avro.file.DataFileWriter;
 import org.apache.avro.generic.GenericData;
@@ -263,6 +264,93 @@ public class MicroBatchQueueManagerTest {
     Thread.interrupted();
   }
 
+  @Test
+  public void testChecksumValidationSuccess() throws Exception {
+    File avroFile = createAvroFile("checksum-valid.avro", 5);
+    String checksum = MicroBatchQueueManager.computeCrc32Hex(avroFile);
+
+    MicroBatch microBatch = createMicroBatchWithChecksum(avroFile.toURI().toString(), 5, checksum);
+    _queueManager.submitBatch(microBatch);
+
+    MessageBatch<GenericRow> batch = null;
+    long startTime = System.currentTimeMillis();
+    while (batch == null && System.currentTimeMillis() - startTime < 10000) {
+      batch = _queueManager.getNextMessageBatch();
+      if (batch == null) {
+        Thread.sleep(100);
+      }
+    }
+
+    assertNotNull(batch, "Should retrieve batch when checksum is valid");
+    assertEquals(batch.getMessageCount(), 5);
+  }
+
+  @Test
+  public void testChecksumValidationFailure() throws Exception {
+    File avroFile = createAvroFile("checksum-invalid.avro", 5);
+    String wrongChecksum = "deadbeef";
+
+    MicroBatch microBatch = createMicroBatchWithChecksum(avroFile.toURI().toString(), 5, wrongChecksum);
+    _queueManager.submitBatch(microBatch);
+    assertTrue(_queueManager.hasData());
+
+    // Wait for error to be processed (checksum mismatch causes error handling path)
+    long startTime = System.currentTimeMillis();
+    while (_queueManager.hasData() && System.currentTimeMillis() - startTime < 5000) {
+      _queueManager.getNextMessageBatch();
+      Thread.sleep(100);
+    }
+
+    assertFalse(_queueManager.hasData(),
+        "Queue should be empty after checksum mismatch is processed");
+  }
+
+  @Test
+  public void testChecksumSkippedWhenNull() throws Exception {
+    File avroFile = createAvroFile("checksum-null.avro", 5);
+
+    // null checksum should skip validation entirely
+    MicroBatch microBatch = createMicroBatchWithChecksum(avroFile.toURI().toString(), 5, null);
+    _queueManager.submitBatch(microBatch);
+
+    MessageBatch<GenericRow> batch = null;
+    long startTime = System.currentTimeMillis();
+    while (batch == null && System.currentTimeMillis() - startTime < 10000) {
+      batch = _queueManager.getNextMessageBatch();
+      if (batch == null) {
+        Thread.sleep(100);
+      }
+    }
+
+    assertNotNull(batch, "Should retrieve batch when checksum is null (skipped)");
+    assertEquals(batch.getMessageCount(), 5);
+  }
+
+  @Test
+  public void testComputeCrc32Hex() throws Exception {
+    File testFile = new File(_tempDir, "crc-test.bin");
+    byte[] content = "hello world".getBytes(StandardCharsets.UTF_8);
+    FileUtils.writeByteArrayToFile(testFile, content);
+
+    // Compute expected CRC32
+    CRC32 crc32 = new CRC32();
+    crc32.update(content);
+    String expected = Long.toHexString(crc32.getValue());
+
+    String actual = MicroBatchQueueManager.computeCrc32Hex(testFile);
+    assertEquals(actual, expected);
+  }
+
+  @Test
+  public void testValidateChecksumCaseInsensitive() throws Exception {
+    File testFile = new File(_tempDir, "crc-case-test.bin");
+    FileUtils.writeByteArrayToFile(testFile, "test data".getBytes(StandardCharsets.UTF_8));
+
+    String checksum = MicroBatchQueueManager.computeCrc32Hex(testFile);
+    // Should not throw with uppercase variant
+    MicroBatchQueueManager.validateChecksum(testFile, checksum.toUpperCase(), "test://uri");
+  }
+
   // Helper methods
 
   private File createAvroFile(String filename, int numRecords) throws IOException {
@@ -286,6 +374,23 @@ public class MicroBatchQueueManagerTest {
   private MicroBatch createMicroBatch(String uri, int numRecords) throws IOException {
     byte[] protocolMessage = MicroBatchProtocol.createUriMessage(
         uri, MicroBatchPayloadV1.Format.AVRO, numRecords);
+    MicroBatchProtocol protocol = MicroBatchProtocol.parse(protocolMessage);
+
+    MicroBatchStreamPartitionMsgOffset offset = new MicroBatchStreamPartitionMsgOffset(0, 0);
+    MicroBatchStreamPartitionMsgOffset nextOffset = new MicroBatchStreamPartitionMsgOffset(1, 0);
+
+    StreamMessageMetadata metadata = new StreamMessageMetadata.Builder()
+        .setRecordIngestionTimeMs(System.currentTimeMillis())
+        .setOffset(offset, nextOffset)
+        .build();
+
+    return new MicroBatch(null, 1, protocol, metadata, false, 0);
+  }
+
+  private MicroBatch createMicroBatchWithChecksum(String uri, int numRecords, String checksum)
+      throws IOException {
+    byte[] protocolMessage = MicroBatchProtocol.createUriMessage(
+        uri, MicroBatchPayloadV1.Format.AVRO, numRecords, checksum);
     MicroBatchProtocol protocol = MicroBatchProtocol.parse(protocolMessage);
 
     MicroBatchStreamPartitionMsgOffset offset = new MicroBatchStreamPartitionMsgOffset(0, 0);

--- a/pinot-plugins/pinot-microbatch-ingestion/pinot-kafka-3.0-microbatch/src/test/java/org/apache/pinot/plugin/stream/microbatch/kafka30/MicroBatchStreamMetadataProviderTest.java
+++ b/pinot-plugins/pinot-microbatch-ingestion/pinot-kafka-3.0-microbatch/src/test/java/org/apache/pinot/plugin/stream/microbatch/kafka30/MicroBatchStreamMetadataProviderTest.java
@@ -1,0 +1,218 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.stream.microbatch.kafka30;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.apache.pinot.plugin.stream.kafka30.KafkaStreamMetadataProvider;
+import org.apache.pinot.spi.stream.LongMsgOffset;
+import org.apache.pinot.spi.stream.OffsetCriteria;
+import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+
+public class MicroBatchStreamMetadataProviderTest {
+
+  @Mock
+  private KafkaStreamMetadataProvider _mockKafkaProvider;
+
+  private MicroBatchStreamMetadataProvider _provider;
+
+  @BeforeMethod
+  public void setUp() {
+    MockitoAnnotations.openMocks(this);
+    _provider = new MicroBatchStreamMetadataProvider(_mockKafkaProvider);
+  }
+
+  @Test
+  public void testSupportsOffsetLagReturnsFalse() {
+    // MicroBatch cannot accurately estimate offset lag because it doesn't know
+    // how many records are in each microbatch
+    assertFalse(_provider.supportsOffsetLag());
+  }
+
+  @Test
+  public void testFetchPartitionCountDelegatesToKafkaProvider() {
+    when(_mockKafkaProvider.fetchPartitionCount(5000L)).thenReturn(4);
+
+    int count = _provider.fetchPartitionCount(5000L);
+
+    assertEquals(count, 4);
+    verify(_mockKafkaProvider).fetchPartitionCount(5000L);
+  }
+
+  @Test
+  public void testFetchPartitionIdsDelegatesToKafkaProvider() {
+    Set<Integer> expectedPartitions = new HashSet<>();
+    expectedPartitions.add(0);
+    expectedPartitions.add(1);
+    expectedPartitions.add(2);
+    when(_mockKafkaProvider.fetchPartitionIds(5000L)).thenReturn(expectedPartitions);
+
+    Set<Integer> partitions = _provider.fetchPartitionIds(5000L);
+
+    assertEquals(partitions, expectedPartitions);
+    verify(_mockKafkaProvider).fetchPartitionIds(5000L);
+  }
+
+  @Test
+  public void testFetchLatestStreamOffsetWrapsOffsets() {
+    // Setup mock to return LongMsgOffset
+    Map<Integer, StreamPartitionMsgOffset> kafkaOffsets = new HashMap<>();
+    kafkaOffsets.put(0, new LongMsgOffset(100L));
+    kafkaOffsets.put(1, new LongMsgOffset(200L));
+
+    Set<Integer> partitionIds = new HashSet<>();
+    partitionIds.add(0);
+    partitionIds.add(1);
+
+    when(_mockKafkaProvider.fetchLatestStreamOffset(anySet(), anyLong())).thenReturn(kafkaOffsets);
+
+    Map<Integer, StreamPartitionMsgOffset> result = _provider.fetchLatestStreamOffset(partitionIds, 5000L);
+
+    assertNotNull(result);
+    assertEquals(result.size(), 2);
+
+    // Verify offsets are wrapped as MicroBatchStreamPartitionMsgOffset
+    assertTrue(result.get(0) instanceof MicroBatchStreamPartitionMsgOffset);
+    assertTrue(result.get(1) instanceof MicroBatchStreamPartitionMsgOffset);
+
+    MicroBatchStreamPartitionMsgOffset offset0 = (MicroBatchStreamPartitionMsgOffset) result.get(0);
+    assertEquals(offset0.getKafkaMessageOffset(), 100L);
+    assertEquals(offset0.getRecordOffsetInMicroBatch(), 0L);
+
+    MicroBatchStreamPartitionMsgOffset offset1 = (MicroBatchStreamPartitionMsgOffset) result.get(1);
+    assertEquals(offset1.getKafkaMessageOffset(), 200L);
+    assertEquals(offset1.getRecordOffsetInMicroBatch(), 0L);
+  }
+
+  @Test
+  public void testFetchStreamPartitionOffsetWrapsOffset() {
+    when(_mockKafkaProvider.fetchStreamPartitionOffset(any(OffsetCriteria.class), anyLong()))
+        .thenReturn(new LongMsgOffset(500L));
+
+    StreamPartitionMsgOffset result = _provider.fetchStreamPartitionOffset(
+        OffsetCriteria.SMALLEST_OFFSET_CRITERIA, 5000L);
+
+    assertNotNull(result);
+    assertTrue(result instanceof MicroBatchStreamPartitionMsgOffset);
+
+    MicroBatchStreamPartitionMsgOffset mbOffset = (MicroBatchStreamPartitionMsgOffset) result;
+    assertEquals(mbOffset.getKafkaMessageOffset(), 500L);
+    assertEquals(mbOffset.getRecordOffsetInMicroBatch(), 0L);
+  }
+
+  @Test
+  public void testGetOffsetAtTimestampWrapsOffset() {
+    when(_mockKafkaProvider.getOffsetAtTimestamp(anyInt(), anyLong(), anyLong()))
+        .thenReturn(new LongMsgOffset(750L));
+
+    StreamPartitionMsgOffset result = _provider.getOffsetAtTimestamp(0, 1234567890L, 5000L);
+
+    assertNotNull(result);
+    assertTrue(result instanceof MicroBatchStreamPartitionMsgOffset);
+
+    MicroBatchStreamPartitionMsgOffset mbOffset = (MicroBatchStreamPartitionMsgOffset) result;
+    assertEquals(mbOffset.getKafkaMessageOffset(), 750L);
+    assertEquals(mbOffset.getRecordOffsetInMicroBatch(), 0L);
+  }
+
+  @Test
+  public void testGetStreamStartOffsetsWrapsOffsets() {
+    Map<String, StreamPartitionMsgOffset> kafkaOffsets = new HashMap<>();
+    kafkaOffsets.put("0", new LongMsgOffset(0L));
+    kafkaOffsets.put("1", new LongMsgOffset(10L));
+
+    when(_mockKafkaProvider.getStreamStartOffsets()).thenReturn(kafkaOffsets);
+
+    Map<String, StreamPartitionMsgOffset> result = _provider.getStreamStartOffsets();
+
+    assertNotNull(result);
+    assertEquals(result.size(), 2);
+
+    assertTrue(result.get("0") instanceof MicroBatchStreamPartitionMsgOffset);
+    MicroBatchStreamPartitionMsgOffset offset0 = (MicroBatchStreamPartitionMsgOffset) result.get("0");
+    assertEquals(offset0.getKafkaMessageOffset(), 0L);
+  }
+
+  @Test
+  public void testGetStreamEndOffsetsWrapsOffsets() {
+    Map<String, StreamPartitionMsgOffset> kafkaOffsets = new HashMap<>();
+    kafkaOffsets.put("0", new LongMsgOffset(1000L));
+    kafkaOffsets.put("1", new LongMsgOffset(2000L));
+
+    when(_mockKafkaProvider.getStreamEndOffsets()).thenReturn(kafkaOffsets);
+
+    Map<String, StreamPartitionMsgOffset> result = _provider.getStreamEndOffsets();
+
+    assertNotNull(result);
+    assertEquals(result.size(), 2);
+
+    assertTrue(result.get("0") instanceof MicroBatchStreamPartitionMsgOffset);
+    MicroBatchStreamPartitionMsgOffset offset0 = (MicroBatchStreamPartitionMsgOffset) result.get("0");
+    assertEquals(offset0.getKafkaMessageOffset(), 1000L);
+
+    MicroBatchStreamPartitionMsgOffset offset1 = (MicroBatchStreamPartitionMsgOffset) result.get("1");
+    assertEquals(offset1.getKafkaMessageOffset(), 2000L);
+  }
+
+  @Test
+  public void testGetTopicsDelegatesToKafkaProvider() {
+    _provider.getTopics();
+    verify(_mockKafkaProvider).getTopics();
+  }
+
+  @Test
+  public void testCloseDelegatesToKafkaProvider() throws IOException {
+    _provider.close();
+    verify(_mockKafkaProvider).close();
+  }
+
+  @Test
+  public void testWrappedOffsetHasZeroRecordOffset() {
+    // All wrapped offsets should have recordOffsetInMicroBatch = 0
+    // because we're wrapping Kafka offsets which don't have microbatch record info
+    when(_mockKafkaProvider.fetchStreamPartitionOffset(any(OffsetCriteria.class), anyLong()))
+        .thenReturn(new LongMsgOffset(999L));
+
+    StreamPartitionMsgOffset result = _provider.fetchStreamPartitionOffset(
+        OffsetCriteria.LARGEST_OFFSET_CRITERIA, 5000L);
+
+    MicroBatchStreamPartitionMsgOffset mbOffset = (MicroBatchStreamPartitionMsgOffset) result;
+    assertEquals(mbOffset.getRecordOffsetInMicroBatch(), 0L,
+        "Wrapped offsets should always have recordOffsetInMicroBatch = 0");
+  }
+}

--- a/pinot-plugins/pinot-microbatch-ingestion/pinot-kafka-3.0-microbatch/src/test/java/org/apache/pinot/plugin/stream/microbatch/kafka30/MicroBatchStreamPartitionMsgOffsetFactoryTest.java
+++ b/pinot-plugins/pinot-microbatch-ingestion/pinot-kafka-3.0-microbatch/src/test/java/org/apache/pinot/plugin/stream/microbatch/kafka30/MicroBatchStreamPartitionMsgOffsetFactoryTest.java
@@ -1,0 +1,187 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.stream.microbatch.kafka30;
+
+import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+
+public class MicroBatchStreamPartitionMsgOffsetFactoryTest {
+
+  private MicroBatchStreamPartitionMsgOffsetFactory _factory;
+
+  @BeforeMethod
+  public void setUp() {
+    _factory = new MicroBatchStreamPartitionMsgOffsetFactory();
+    _factory.init(null);
+  }
+
+  @Test
+  public void testCreateFromNumericString() {
+    // Test parsing simple numeric offset (e.g., "0" from smallest offset criteria)
+    StreamPartitionMsgOffset offset = _factory.create("0");
+    assertNotNull(offset);
+    assertTrue(offset instanceof MicroBatchStreamPartitionMsgOffset);
+
+    MicroBatchStreamPartitionMsgOffset mbOffset = (MicroBatchStreamPartitionMsgOffset) offset;
+    assertEquals(mbOffset.getKafkaMessageOffset(), 0L);
+    assertEquals(mbOffset.getRecordOffsetInMicroBatch(), 0L);
+  }
+
+  @Test
+  public void testCreateFromLargeNumericString() {
+    StreamPartitionMsgOffset offset = _factory.create("9876543210");
+    assertNotNull(offset);
+
+    MicroBatchStreamPartitionMsgOffset mbOffset = (MicroBatchStreamPartitionMsgOffset) offset;
+    assertEquals(mbOffset.getKafkaMessageOffset(), 9876543210L);
+    assertEquals(mbOffset.getRecordOffsetInMicroBatch(), 0L);
+  }
+
+  @Test
+  public void testCreateFromNumericStringWithWhitespace() {
+    // Should handle whitespace around numeric values
+    StreamPartitionMsgOffset offset = _factory.create("  123  ");
+    assertNotNull(offset);
+
+    MicroBatchStreamPartitionMsgOffset mbOffset = (MicroBatchStreamPartitionMsgOffset) offset;
+    assertEquals(mbOffset.getKafkaMessageOffset(), 123L);
+  }
+
+  @Test
+  public void testCreateFromJsonFormat() {
+    // Test parsing JSON format: {"kmo":0,"mbro":5}
+    StreamPartitionMsgOffset offset = _factory.create("{\"kmo\":100,\"mbro\":50}");
+    assertNotNull(offset);
+
+    MicroBatchStreamPartitionMsgOffset mbOffset = (MicroBatchStreamPartitionMsgOffset) offset;
+    assertEquals(mbOffset.getKafkaMessageOffset(), 100L);
+    assertEquals(mbOffset.getRecordOffsetInMicroBatch(), 50L);
+  }
+
+  @Test
+  public void testCreateFromJsonFormatWithZeroValues() {
+    StreamPartitionMsgOffset offset = _factory.create("{\"kmo\":0,\"mbro\":0}");
+    assertNotNull(offset);
+
+    MicroBatchStreamPartitionMsgOffset mbOffset = (MicroBatchStreamPartitionMsgOffset) offset;
+    assertEquals(mbOffset.getKafkaMessageOffset(), 0L);
+    assertEquals(mbOffset.getRecordOffsetInMicroBatch(), 0L);
+  }
+
+  @Test
+  public void testCreateFromJsonFormatWithLargeValues() {
+    StreamPartitionMsgOffset offset = _factory.create("{\"kmo\":9999999999,\"mbro\":1000000}");
+    assertNotNull(offset);
+
+    MicroBatchStreamPartitionMsgOffset mbOffset = (MicroBatchStreamPartitionMsgOffset) offset;
+    assertEquals(mbOffset.getKafkaMessageOffset(), 9999999999L);
+    assertEquals(mbOffset.getRecordOffsetInMicroBatch(), 1000000L);
+  }
+
+  @Test
+  public void testRoundTrip() {
+    // Create offset, serialize to string, parse back
+    MicroBatchStreamPartitionMsgOffset original = new MicroBatchStreamPartitionMsgOffset(42, 7);
+    String serialized = original.toString();
+
+    StreamPartitionMsgOffset parsed = _factory.create(serialized);
+    assertNotNull(parsed);
+
+    MicroBatchStreamPartitionMsgOffset mbParsed = (MicroBatchStreamPartitionMsgOffset) parsed;
+    assertEquals(mbParsed.getKafkaMessageOffset(), 42L);
+    assertEquals(mbParsed.getRecordOffsetInMicroBatch(), 7L);
+  }
+
+  @Test
+  public void testCreateFromInvalidJson() {
+    try {
+      _factory.create("{invalid json}");
+      fail("Should throw exception for invalid JSON");
+    } catch (IllegalArgumentException e) {
+      assertTrue(e.getMessage().contains("Failed to parse"));
+    }
+  }
+
+  @Test
+  public void testCreateFromEmptyString() {
+    try {
+      _factory.create("");
+      fail("Should throw exception for empty string");
+    } catch (IllegalArgumentException e) {
+      // Expected
+    }
+  }
+
+  @Test
+  public void testCreateFromNullString() {
+    try {
+      _factory.create((String) null);
+      fail("Should throw exception for null string");
+    } catch (Exception e) {
+      // Expected - either NullPointerException or IllegalArgumentException
+    }
+  }
+
+  @Test
+  public void testCreateFromMalformedNumeric() {
+    // Non-numeric string that doesn't start with '{' should fall through to JSON parsing
+    try {
+      _factory.create("not-a-number");
+      fail("Should throw exception for malformed input");
+    } catch (IllegalArgumentException e) {
+      assertTrue(e.getMessage().contains("Failed to parse"));
+    }
+  }
+
+  @Test
+  public void testCreateFromJsonMissingFields() {
+    // JSON with missing fields
+    try {
+      _factory.create("{\"kmo\":100}");
+      // This might succeed with default value for mbro, or fail - depends on implementation
+      // If it succeeds, mbro should default to 0
+    } catch (IllegalArgumentException e) {
+      // Also acceptable if it requires both fields
+    }
+  }
+
+  @Test
+  public void testCreateFromNegativeOffset() {
+    // Negative offset in JSON format
+    StreamPartitionMsgOffset offset = _factory.create("{\"kmo\":-1,\"mbro\":0}");
+    assertNotNull(offset);
+
+    MicroBatchStreamPartitionMsgOffset mbOffset = (MicroBatchStreamPartitionMsgOffset) offset;
+    assertEquals(mbOffset.getKafkaMessageOffset(), -1L);
+  }
+
+  @Test
+  public void testInitWithNullConfig() {
+    // init() should handle null config gracefully
+    MicroBatchStreamPartitionMsgOffsetFactory factory = new MicroBatchStreamPartitionMsgOffsetFactory();
+    factory.init(null); // Should not throw
+  }
+}

--- a/pinot-plugins/pinot-microbatch-ingestion/pom.xml
+++ b/pinot-plugins/pinot-microbatch-ingestion/pom.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>pinot-plugins</artifactId>
+    <groupId>org.apache.pinot</groupId>
+    <version>1.5.0-SNAPSHOT</version>
+  </parent>
+  <artifactId>pinot-microbatch-ingestion</artifactId>
+  <packaging>pom</packaging>
+  <name>Pinot Microbatch Ingestion</name>
+  <url>https://pinot.apache.org/</url>
+  <properties>
+    <pinot.root>${basedir}/../..</pinot.root>
+    <plugin.type>pinot-microbatch-ingestion</plugin.type>
+  </properties>
+
+  <modules>
+    <module>pinot-kafka-3.0-microbatch</module>
+  </modules>
+
+</project>

--- a/pinot-plugins/pom.xml
+++ b/pinot-plugins/pom.xml
@@ -42,6 +42,7 @@
     <module>pinot-file-system</module>
     <module>pinot-batch-ingestion</module>
     <module>pinot-stream-ingestion</module>
+    <module>pinot-microbatch-ingestion</module>
     <module>pinot-minion-tasks</module>
     <module>pinot-metrics</module>
     <module>pinot-segment-writer</module>

--- a/pom.xml
+++ b/pom.xml
@@ -692,6 +692,11 @@
       </dependency>
       <dependency>
         <groupId>org.apache.pinot</groupId>
+        <artifactId>pinot-kafka-3.0-microbatch</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.pinot</groupId>
         <artifactId>pinot-kinesis</artifactId>
         <version>${project.version}</version>
       </dependency>


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Adds Kafka microbatch ingestion: consumer reads protocol messages, fetches batch files, decodes records, returns MessageBatch with composite offsets\.

```mermaid
flowchart TD
  N0["fetchMessages #40;F6#41;"]:::stAdded
  N1["pollKafka #40;F6#41;"]:::stAdded
  N2["parse protocol #40;F11#41;"]:::stAdded
  N3["create MicroBatch #40;F8#41;"]:::stAdded
  N4["submit batch #40;F12#41;"]:::stAdded
  N5["fetch data #40;F12#41;"]:::stAdded
  N6["convert to batches #40;F12#41;"]:::stAdded
  N7["read MessageBatch #40;F7#41;"]:::stAdded
  N8["GenericRowMessageBatch #40;F4#41;"]:::stAdded
  N9["composite offset #40;F14#41;"]:::stAdded
  N0 -->|"calls pollKafka"| N1
  N1 -->|"parses protocol"| N2
  N2 -->|"creates MicroBatch"| N3
  N3 -->|"submits to queue"| N4
  N4 -->|"triggers data fetch"| N5
  N5 -->|"triggers conversion"| N6
  N6 -->|"delegates to reader"| N7
  N7 -->|"produces batch"| N8
  N8 -->|"provides next offset"| N9
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

Partial evidence: 2 file patches omitted; 0 truncated.

<details>
<summary>Diff evidence</summary>

- F4: pinot\-plugins/pinot\-microbatch\-ingestion/pinot\-kafka\-3\.0\-microbatch/src/main/java/org/apache/pinot/plugin/stream/microbatch/kafka30/GenericRowMessageBatch\.java — [after](https://github.com/apache/pinot/blob/a6313c897d11444e2f6e4e7224b6fe38e7c80be5/pinot-plugins/pinot-microbatch-ingestion/pinot-kafka-3.0-microbatch/src/main/java/org/apache/pinot/plugin/stream/microbatch/kafka30/GenericRowMessageBatch.java)
- F6: pinot\-plugins/pinot\-microbatch\-ingestion/pinot\-kafka\-3\.0\-microbatch/src/main/java/org/apache/pinot/plugin/stream/microbatch/kafka30/KafkaPartitionLevelMicroBatchConsumer\.java — [after](https://github.com/apache/pinot/blob/a6313c897d11444e2f6e4e7224b6fe38e7c80be5/pinot-plugins/pinot-microbatch-ingestion/pinot-kafka-3.0-microbatch/src/main/java/org/apache/pinot/plugin/stream/microbatch/kafka30/KafkaPartitionLevelMicroBatchConsumer.java)
- F7: pinot\-plugins/pinot\-microbatch\-ingestion/pinot\-kafka\-3\.0\-microbatch/src/main/java/org/apache/pinot/plugin/stream/microbatch/kafka30/MessageBatchReader\.java — [after](https://github.com/apache/pinot/blob/a6313c897d11444e2f6e4e7224b6fe38e7c80be5/pinot-plugins/pinot-microbatch-ingestion/pinot-kafka-3.0-microbatch/src/main/java/org/apache/pinot/plugin/stream/microbatch/kafka30/MessageBatchReader.java)
- F8: pinot\-plugins/pinot\-microbatch\-ingestion/pinot\-kafka\-3\.0\-microbatch/src/main/java/org/apache/pinot/plugin/stream/microbatch/kafka30/MicroBatch\.java — [after](https://github.com/apache/pinot/blob/a6313c897d11444e2f6e4e7224b6fe38e7c80be5/pinot-plugins/pinot-microbatch-ingestion/pinot-kafka-3.0-microbatch/src/main/java/org/apache/pinot/plugin/stream/microbatch/kafka30/MicroBatch.java)
- F11: pinot\-plugins/pinot\-microbatch\-ingestion/pinot\-kafka\-3\.0\-microbatch/src/main/java/org/apache/pinot/plugin/stream/microbatch/kafka30/MicroBatchProtocol\.java — [after](https://github.com/apache/pinot/blob/a6313c897d11444e2f6e4e7224b6fe38e7c80be5/pinot-plugins/pinot-microbatch-ingestion/pinot-kafka-3.0-microbatch/src/main/java/org/apache/pinot/plugin/stream/microbatch/kafka30/MicroBatchProtocol.java)
- F12: pinot\-plugins/pinot\-microbatch\-ingestion/pinot\-kafka\-3\.0\-microbatch/src/main/java/org/apache/pinot/plugin/stream/microbatch/kafka30/MicroBatchQueueManager\.java — [after](https://github.com/apache/pinot/blob/a6313c897d11444e2f6e4e7224b6fe38e7c80be5/pinot-plugins/pinot-microbatch-ingestion/pinot-kafka-3.0-microbatch/src/main/java/org/apache/pinot/plugin/stream/microbatch/kafka30/MicroBatchQueueManager.java)
- F14: pinot\-plugins/pinot\-microbatch\-ingestion/pinot\-kafka\-3\.0\-microbatch/src/main/java/org/apache/pinot/plugin/stream/microbatch/kafka30/MicroBatchStreamPartitionMsgOffset\.java — [after](https://github.com/apache/pinot/blob/a6313c897d11444e2f6e4e7224b6fe38e7c80be5/pinot-plugins/pinot-microbatch-ingestion/pinot-kafka-3.0-microbatch/src/main/java/org/apache/pinot/plugin/stream/microbatch/kafka30/MicroBatchStreamPartitionMsgOffset.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjBmOTNkNTJlZjBiZmExYzJkYzM2N2IzMWYxMzdhNjNiZDI1ZjlkMmYiLCJjb250ZXh0X2hhc2giOiJkY2U4ZTk4MWZhMGNhZmVlMjg3ZDM3ZjZhYjRiMjA1OTNmODJiNGY2ZDQwZDJiMTgyYjI5MDcxYzRlOGE0N2UyIiwiZ2VuZXJhdGVkX2F0IjoxNzg5NDU1MjQxLCJoZWFkX3NoYSI6ImE2MzEzYzg5N2QxMTQ0NGUyZjZlNGU3MjI0YjZmZTM4ZTdjODBiZTUiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJiOGVhZmMxYmY1NGQ4YTgwNzcwYTk0YmUyZTBmZTU5ZTdlMDRlMTNjIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 6524aead2d0b38ab4dce1f13e9455b079bc5506d8ebb5140e07c2384c9983cb3 -->
<!-- pinot-pr-flow:end -->

This PR introduces a new streaming ingestion pattern for Apache Pinot - MicroBatch ingestion from Kafka. Instead of processing individual records from Kafka messages, this consumer reads Kafka messages containing JSON protocol references to batch files stored in PinotFS (S3, HDFS, GCS, Azure, etc.) or inline base64-encoded data. See https://github.com/apache/pinot/issues/17331 for motivation.

### Design Overview

**Wire Protocol (Version 1):**
```
+----------+---------------------------+
| version  | JSON payload bytes        |
| (1 byte) |                           |
+----------+---------------------------+
```

**JSON Payload Examples:**
```json
// URI type - reference to file in PinotFS
{"type":"uri","format":"avro","uri":"s3://bucket/batch.avro","numRecords":1000}

// DATA type - inline base64-encoded data
{"type":"data","format":"avro","data":"<base64>","numRecords":100}
```

**Key Components:**
- `KafkaMicroBatchConsumerFactory` - Factory that creates MicroBatch consumers
- `MicroBatchProtocol` / `MicroBatchPayloadV1` - Protocol parsing and validation
- `MicroBatchQueueManager` - Orchestrates parallel file downloads and batch conversion
- `MicroBatchStreamPartitionMsgOffset` - Composite offset (Kafka offset + record offset within batch) enabling mid-batch resume after segment commits
- `MessageBatchReader` - Converts downloaded files to `MessageBatch<GenericRow>` using Pinot's RecordReader

**Supported Formats:** AVRO, Parquet, JSON

### Configuration

```json
{
  "streamConfigs": {
    "streamType": "kafka",
    "stream.kafka.topic.name": "microbatch-topic",
    "stream.kafka.broker.list": "localhost:9092",
    "stream.kafka.consumer.factory.class.name":
      "org.apache.pinot.plugin.stream.microbatch.kafka30.KafkaMicroBatchConsumerFactory",
    "stream.microbatch.kafka.file.fetch.threads": "2"
  }
}
```

See `CONFIGURATION.md` for complete documentation including PinotFS setup for S3/HDFS/GCS/Azure.

### Testing

- **Unit tests:** `MicroBatchProtocolTest` (30+ test cases), `MicroBatchStreamPartitionMsgOffsetFactoryTest`, `MicroBatchStreamMetadataProviderTest`, `MicroBatchQueueManagerTest`
- **Integration test:** `KafkaPartitionLevelMicroBatchConsumerTest` - Tests with real embedded Kafka, including mid-batch resume scenarios
- **Cluster integration test:** `MicroBatchRealtimeClusterIntegrationTest` - End-to-end test with full Pinot cluster

### Compatibility Notes

- This is a new plugin module - no changes to existing APIs or behavior
- The composite offset format (`{"kmo":X,"mbro":Y}`) is specific to MicroBatch consumers and not compatible with standard Kafka consumer offsets
- `supportsOffsetLag()` returns false since we cannot accurately estimate lag without knowing record counts in unconsumed batches. We can have it return batch counts if needed.

### Open Questions for Reviewers

I’ve added TODOs in the code to highlight open questions for reviewers, please take a look.

---

## Checklist

- [x] Code compiles and follows Pinot style guidelines
- [x] Unit tests added and passing
- [x] Integration tests added and passing
- [x] Documentation added (`CONFIGURATION.md`)
- [x] No new external dependencies introduced