### PR TITLE
Fix funnel aggregation worker threads not responding to query timeout / cancellation

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/window/FunnelCompleteCountAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/window/FunnelCompleteCountAggregationFunction.java
@@ -25,6 +25,7 @@ import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.query.aggregation.function.funnel.FunnelStepEvent;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
+import org.apache.pinot.spi.query.QueryThreadContext;
 
 
 public class FunnelCompleteCountAggregationFunction extends FunnelBaseAggregationFunction<Integer> {
@@ -60,7 +61,10 @@ public class FunnelCompleteCountAggregationFunction extends FunnelBaseAggregatio
 
       int maxStep = 0;
       long previousTimestamp = -1;
+      int numEventsProcessed = 0;
       for (FunnelStepEvent event : slidingWindow) {
+        QueryThreadContext.checkTerminationAndSampleUsagePeriodically(numEventsProcessed++,
+            "FunnelCompleteCountAggregationFunction#extractFinalResult");
         int currentEventStep = event.getStep();
         // If the same condition holds for the sequence of events, then such repeating event interrupts further
         // processing.

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/window/FunnelMatchStepAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/window/FunnelMatchStepAggregationFunction.java
@@ -26,6 +26,7 @@ import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.query.aggregation.function.funnel.FunnelStepEvent;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
+import org.apache.pinot.spi.query.QueryThreadContext;
 
 
 public class FunnelMatchStepAggregationFunction extends FunnelBaseAggregationFunction<IntArrayList> {
@@ -78,7 +79,10 @@ public class FunnelMatchStepAggregationFunction extends FunnelBaseAggregationFun
   protected Integer processWindow(ArrayDeque<FunnelStepEvent> slidingWindow) {
     int maxStep = 0;
     long previousTimestamp = -1;
+    int numEventsProcessed = 0;
     for (FunnelStepEvent event : slidingWindow) {
+      QueryThreadContext.checkTerminationAndSampleUsagePeriodically(numEventsProcessed++,
+          "FunnelMatchStepAggregationFunction#processWindow");
       int currentEventStep = event.getStep();
       // If the same condition holds for the sequence of events, then such repeating event interrupts further
       // processing.

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/window/FunnelMaxStepAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/window/FunnelMaxStepAggregationFunction.java
@@ -25,6 +25,7 @@ import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.query.aggregation.function.funnel.FunnelStepEvent;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
+import org.apache.pinot.spi.query.QueryThreadContext;
 
 
 public class FunnelMaxStepAggregationFunction extends FunnelBaseAggregationFunction<Integer> {
@@ -70,7 +71,10 @@ public class FunnelMaxStepAggregationFunction extends FunnelBaseAggregationFunct
   protected Integer processWindow(ArrayDeque<FunnelStepEvent> slidingWindow) {
     int maxStep = 0;
     long previousTimestamp = -1;
+    int numEventsProcessed = 0;
     for (FunnelStepEvent event : slidingWindow) {
+      QueryThreadContext.checkTerminationAndSampleUsagePeriodically(numEventsProcessed++,
+          "FunnelMaxStepAggregationFunction#processWindow");
       int currentEventStep = event.getStep();
       // If the same condition holds for the sequence of events, then such repeating event interrupts further
       // processing.


### PR DESCRIPTION
  ### Summary

When a query using window funnel aggregation functions (`funnelMaxStep`, `funnelCompleteCount`, `funnelMatchStep`) times out or is cancelled, the worker threads spawned by `IndexedTable.finish()` for the multi-threaded final reduce phase continue running indefinitely. Although `future.cancel(true)` is correctly called on the futures, the underlying `extractFinalResult()` computations are tight CPU-bound loops that never check the thread interrupt flag, so the cancellation has no effect. Repeated timed-out queries compound this, eventually saturating the thread pool and pegging server CPU until a restart.

### Why this was missed

Most aggregation functions have trivial `extractFinalResult()` implementations — `SUM` returns the accumulated value, `COUNT` returns a long, `AVG` does a division, and sketch-based functions like HLL just call `estimate()`. These
complete in O(1) and are never a cancellation concern.

The funnel window functions are unique: they defer the actual computation to `extractFinalResult()`, which performs a
sliding-window pattern match over the full `PriorityQueue` of raw events accumulated during the aggregate/merge phases.
This is the same reason they're the only functions listed in `IndexedTable.containsExpensiveAggregationFunctions()` to
trigger multi-threaded execution — but the corresponding cancellation-awareness was never added to the computation
itself.

### Fix

Add `QueryThreadContext.checkTerminationAndSampleUsagePeriodically()` calls inside every hot loop in the funnel window functions:

  - **`FunnelBaseAggregationFunction.fillWindow()`** — the step-0 seeking loop (can drain millions of non-matching events)
   and the window-filling loop (can move millions of events into the sliding window when the window size is large)
  - **`FunnelMaxStepAggregationFunction.processWindow()`** — iterates the entire sliding window
  - **`FunnelMatchStepAggregationFunction.processWindow()`** — same
  - **`FunnelCompleteCountAggregationFunction.extractFinalResult()`** — inline sliding window iteration

  These checks detect three cancellation signals: the `TerminationException` set by `QueryExecutionContext.terminate()`,
  the thread interrupt flag set by `future.cancel(true)`, and deadline expiration. Any of these causes the worker thread
  to throw and unwind immediately.

  ### Overhead

  `checkTerminationAndSampleUsagePeriodically` uses a bitmask (`& 0x1FFF`) so the actual check only fires every 8,192 loop
   iterations. The remaining iterations reduce to a single integer AND + branch prediction hit. When the check does fire,
  it reads one volatile field, calls `Thread.interrupted()`, and compares `System.currentTimeMillis()` against the
  deadline — all sub-microsecond operations, negligible relative to the per-event `PriorityQueue.poll()` (O(log N)) and
  sliding window processing work done in each iteration.