### PR TITLE
Remove compatibility verifier for 1.3.0

### DIFF
--- a/.github/workflows/pinot_tests.yml
+++ b/.github/workflows/pinot_tests.yml
@@ -549,7 +549,7 @@ jobs:
       matrix:
         test_suite: [ "compatibility-verifier/multi-stage-query-engine-test-suite" ]
         old_commit: [
-          "release-1.3.0", "release-1.4.0", "master"
+          "release-1.4.0", "master"
         ]
     name: Pinot Multi-Stage Query Engine Compatibility Regression Testing against ${{ matrix.old_commit }} on ${{ matrix.test_suite }}
     steps:


### PR DESCRIPTION
- https://github.com/apache/pinot/pull/17649/ actually missed out on removing the test for MSQE, which was the intended change.