### PR TITLE
Logical tables MSE test

### DIFF
--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
@@ -335,40 +335,17 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
   /**
    * Creates a new OFFLINE table config.
    */
-  protected TableConfig createOfflineTableConfig(String tableName) {
-    // @formatter:off
-    return new TableConfigBuilder(TableType.OFFLINE)
-        .setTableName(tableName)
-        .setTimeColumnName(getTimeColumnName())
-        .setSortedColumn(getSortedColumn())
-        .setInvertedIndexColumns(getInvertedIndexColumns())
-//        .setCreateInvertedIndexDuringSegmentGeneration(isCreateInvertedIndexDuringSegmentGeneration())
-        .setNoDictionaryColumns(getNoDictionaryColumns())
-        .setRangeIndexColumns(getRangeIndexColumns())
-        .setBloomFilterColumns(getBloomFilterColumns())
-        .setFieldConfigList(getFieldConfigs())
-        .setNumReplicas(getNumReplicas())
-        .setSegmentVersion(getSegmentVersion())
-        .setLoadMode(getLoadMode())
-        .setTaskConfig(getTaskConfig())
-        .setBrokerTenant(getBrokerTenant())
-        .setServerTenant(getServerTenant())
-        .setIngestionConfig(getIngestionConfig())
-        .setQueryConfig(getQueryConfig())
-        .setNullHandlingEnabled(getNullHandlingEnabled())
-        .setSegmentPartitionConfig(getSegmentPartitionConfig())
-//        .setOptimizeNoDictStatsCollection(true)
-        .build();
-    // @formatter:on
+  protected TableConfig createOfflineTableConfig() {
+    return createOfflineTableConfig(getTableName());
   }
 
   /**
    * Creates a new OFFLINE table config.
    */
-  protected TableConfig createOfflineTableConfig() {
+  protected TableConfig createOfflineTableConfig(String tableName) {
     // @formatter:off
     return new TableConfigBuilder(TableType.OFFLINE)
-        .setTableName(getTableName())
+        .setTableName(tableName)
         .setTimeColumnName(getTimeColumnName())
         .setSortedColumn(getSortedColumn())
         .setInvertedIndexColumns(getInvertedIndexColumns())

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java
@@ -169,7 +169,7 @@ public class MultiStageEngineIntegrationTest extends BaseClusterIntegrationTestS
     return timeoutProperties;
   }
 
-  protected void setupTableWithNonDefaultDatabase(List<File> avroFiles)
+  private void setupTableWithNonDefaultDatabase(List<File> avroFiles)
       throws Exception {
     _tableName = TABLE_NAME_WITH_DATABASE;
     String defaultCol = "ActualElapsedTime";

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java
@@ -158,7 +158,7 @@ public class MultiStageEngineIntegrationTest extends BaseClusterIntegrationTestS
     return timeoutProperties;
   }
 
-  private void setupTableWithNonDefaultDatabase(List<File> avroFiles)
+  protected void setupTableWithNonDefaultDatabase(List<File> avroFiles)
       throws Exception {
     _tableName = TABLE_NAME_WITH_DATABASE;
     String defaultCol = "ActualElapsedTime";

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/TlsIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/TlsIntegrationTest.java
@@ -279,6 +279,12 @@ public class TlsIntegrationTest extends BaseClusterIntegrationTest {
   }
 
   @Override
+  protected LogicalTableConfig createLogicalTableConfig() {
+    String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(getTableName());
+    return createLogicalTableConfig(List.of(), List.of(realtimeTableName));
+  }
+
+  @Override
   protected void createLogicalTable()
       throws IOException {
     LogicalTableConfig logicalTableConfig = createLogicalTableConfig();

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/logicaltable/BaseLogicalTableIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/logicaltable/BaseLogicalTableIntegrationTest.java
@@ -54,6 +54,7 @@ import org.testng.annotations.BeforeSuite;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.expectThrows;
 
@@ -459,10 +460,13 @@ public abstract class BaseLogicalTableIntegrationTest extends BaseClusterIntegra
     updateLogicalTableConfig(logicalTableConfig);
     JsonNode response = postQuery(starQuery);
     JsonNode exceptions = response.get("exceptions");
-    assertTrue(
-        !exceptions.isEmpty() && (exceptions.get(0).get("errorCode").asInt() == QueryErrorCode.BROKER_TIMEOUT.getId()
-            // Timeout may occur just before submitting the request. Then this error code is thrown.
-            || exceptions.get(0).get("errorCode").asInt() == QueryErrorCode.SERVER_NOT_RESPONDING.getId()));
+    assertFalse(exceptions.isEmpty());
+    int exceptionCode = exceptions.get(0).get("errorCode").asInt();
+    assertTrue(exceptionCode == QueryErrorCode.BROKER_TIMEOUT.getId()
+        // Timeout may occur just before submitting the request. Then this error code is thrown.
+        || exceptionCode == QueryErrorCode.SERVER_NOT_RESPONDING.getId()
+        || exceptionCode == QueryErrorCode.EXECUTION_TIMEOUT.getId()
+    );
 
     // Query Succeeds with a high limit.
     queryConfig = new QueryConfig(1000000L, null, null, null, null, null);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/logicaltable/LogicalTableMultiStageEngineIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/logicaltable/LogicalTableMultiStageEngineIntegrationTest.java
@@ -91,6 +91,9 @@ public class LogicalTableMultiStageEngineIntegrationTest extends MultiStageEngin
     //  This needs to be fixed
   }
 
+  // These validate tests are applicable only for physical table and not logical table, so ignoring them here.
+  // These tests get the table config of the physical table and send it in the request,
+  // which doesn't work for logical table.
   @Override
   @Ignore
   public void testValidateQueryApiBatchMixedResults() {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/logicaltable/LogicalTableMultiStageEngineIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/logicaltable/LogicalTableMultiStageEngineIntegrationTest.java
@@ -1,0 +1,133 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.integration.tests.logicaltable;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.helix.model.HelixConfigScope;
+import org.apache.helix.model.builder.HelixConfigScopeBuilder;
+import org.apache.pinot.integration.tests.ClusterIntegrationTestUtils;
+import org.apache.pinot.integration.tests.MultiStageEngineIntegrationTest;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.data.LogicalTableConfig;
+import org.apache.pinot.spi.data.PhysicalTableConfig;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.builder.LogicalTableConfigBuilder;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+import org.apache.pinot.util.TestUtils;
+import org.testng.annotations.BeforeClass;
+
+
+public class LogicalTableMultiStageEngineIntegrationTest extends MultiStageEngineIntegrationTest {
+
+  @BeforeClass
+  @Override
+  public void setUp()
+      throws Exception {
+    TestUtils.ensureDirectoriesExistAndEmpty(_tempDir, _segmentDir, _tarDir);
+
+    // Start the Pinot cluster
+    startZk();
+    startController();
+
+    // Set the multi-stage max server query threads for the cluster, so that we can test the query queueing logic
+    // in the MultiStageBrokerRequestHandler
+    HelixConfigScope scope =
+        new HelixConfigScopeBuilder(HelixConfigScope.ConfigScopeProperty.CLUSTER).forCluster(getHelixClusterName())
+            .build();
+    _helixManager.getConfigAccessor()
+        .set(scope, CommonConstants.Helix.CONFIG_OF_MULTI_STAGE_ENGINE_MAX_SERVER_QUERY_THREADS, "30");
+
+    startBroker();
+    startServer(); // TODO - Do we want 2 servers similar to BaseLogicalTableIntegrationTest ?
+    setupTenants();
+
+    List<File> avroFiles = unpackAvroData(_tempDir);
+    List<String> physicalTableNames = getOfflineTableNames();
+    Map<String, List<File>> offlineTableDataFiles = distributeFilesToTables(physicalTableNames, avroFiles);
+    for (Map.Entry<String, List<File>> entry : offlineTableDataFiles.entrySet()) {
+      String tableName = entry.getKey();
+      List<File> avroFilesForTable = entry.getValue();
+
+      File tarDir = new File(_tarDir, tableName);
+
+      TestUtils.ensureDirectoriesExistAndEmpty(tarDir);
+
+      // Create and upload the schema and table config
+      Schema schema = createSchema(getSchemaFileName());
+      schema.setSchemaName(tableName);
+      addSchema(schema);
+      TableConfig offlineTableConfig = createOfflineTableConfig(tableName);
+      addTableConfig(offlineTableConfig);
+
+      // Create and upload segments
+      ClusterIntegrationTestUtils.buildSegmentsFromAvro(avroFilesForTable, offlineTableConfig, schema, 0, _segmentDir,
+          tarDir);
+      uploadSegments(tableName, tarDir);
+    }
+
+    createLogicalTableAndSchema();
+
+    // Set up the H2 connection
+    setUpH2Connection(avroFiles);
+
+    // Initialize the query generator
+    setUpQueryGenerator(avroFiles);
+
+    // Wait for all documents loaded
+    waitForAllDocsLoaded(600_000L);
+//    setupTableWithNonDefaultDatabase(avroFiles); TODO - Fix this
+  }
+
+  private List<String> getOfflineTableNames() {
+    return List.of("physicalTable_0", "physicalTable_1");
+  }
+
+  @Override
+  protected String getTableName() {
+    return DEFAULT_TABLE_NAME;
+  }
+
+  @Override
+  protected String getLogicalTableName() {
+    return getTableName();
+  }
+
+  @Override
+  protected LogicalTableConfig createLogicalTableConfig() {
+    List<String> offlineTableNames = getOfflineTableNames().stream().map(TableNameBuilder.OFFLINE::tableNameWithType)
+        .collect(Collectors.toList());
+    Map<String, PhysicalTableConfig> physicalTableConfigMap = new HashMap<>();
+    for (String physicalTableName : offlineTableNames) {
+      physicalTableConfigMap.put(physicalTableName, new PhysicalTableConfig());
+    }
+    LogicalTableConfigBuilder builder =
+        new LogicalTableConfigBuilder().setTableName(getTableName())
+            .setBrokerTenant(getBrokerTenant())
+            .setRefOfflineTableName(offlineTableNames.get(0))
+            .setRefRealtimeTableName(null)
+            .setPhysicalTableConfigMap(physicalTableConfigMap);
+    return builder.build();
+  }
+
+}


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Logical table MSE test setup and testBetween execution skipping explain plan validation for not\-between queries\.

```mermaid
flowchart TD
  N0["initCluster#40;#41; #40;F2#41;"]:::stModified
  N1["unpackAvroData#40;#41; #40;F5#41;"]:::stAdded
  N2["initTables#40;avroFiles#41; #40;F5#41;"]:::stModified
  N3["initOtherDependencies#40;avroFiles#41; #40;F5#41;"]:::stAdded
  N4["testBetween#40;#41; #40;F5#41;"]:::stModified
  N5["testBetween#40;boolean#41; #40;F2#41;"]:::stModified
  N0 --> N1
  N1 --> N2
  N2 --> N3
  N3 --> N4
  N4 --> N5
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F2: pinot\-integration\-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest\.java — [before](https://github.com/apache/pinot/blob/76cd3e69a4bbdc7823923ef6ef275b36ba44795a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java) · [after](https://github.com/apache/pinot/blob/6bf0eeb3279ef94fcc3472fefbede1a197ba72b9/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java)
- F5: pinot\-integration\-tests/src/test/java/org/apache/pinot/integration/tests/logicaltable/LogicalTableMultiStageEngineIntegrationTest\.java — [after](https://github.com/apache/pinot/blob/6bf0eeb3279ef94fcc3472fefbede1a197ba72b9/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/logicaltable/LogicalTableMultiStageEngineIntegrationTest.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6Ijc2Y2QzZTY5YTRiYmRjNzgyMzkyM2VmNmVmMjc1YjM2YmE0NDc5NWEiLCJjb250ZXh0X2hhc2giOiJiMjNhMGVmZjJhZDdkNjViODg0NjcxZWEyNmE4MTliZmMyMDcxNzZmM2JmMjFhZjE3ZWViZjA1NDg1OTVlNjhmIiwiZ2VuZXJhdGVkX2F0IjoxNzg5Nzk5ODkyLCJoZWFkX3NoYSI6IjZiZjBlZWIzMjc5ZWY5NGZjYzM0NzJmZWZiZWRlMWExOTdiYTcyYjkiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiI3NmNkM2U2OWE0YmJkYzc4MjM5MjNlZjZlZjI3NWIzNmJhNDQ3OTVhIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 7a208f219526fb48640cc6317bdb6027780d62b6082abf9375b3d6d90a5313ec -->
<!-- pinot-pr-flow:end -->

1. Add multi-stage engine tests for logical tables. 
2. Refactor few test classes (BaseLogicalTableIntegrationTest) to avoid duplicate code. 

The primary gap is in "testBetween" test. The explain plan for a "not-between" query is different when queried via Logical tables vs without Logical tables. The results are consistent, but the explained plan is different. For now, I am filtering the validation for logical tables. 

Explain plan for "not-between" query for logical table
```
PinotLogicalAggregate(group=[{}], agg#0=[COUNT($0)], aggType=[FINAL])
        PlanWithNoSegments(table=[mytable])
```

Explain plan for "not-between" query for physical table
```
  PinotLogicalAggregate(group=[{}], agg#0=[COUNT($0)], aggType=[FINAL])
    PinotLogicalExchange(distribution=[hash])
      LeafStageCombineOperator(table=[mytable])
        StreamingInstanceResponse
          CombineAggregate
            Aggregate(aggregations=[[count(*)]])
              Project(columns=[[]])
                DocIdSet(maxDocs=[120000])
                  FilterNot
                    FilterFullScan(predicate=[RandomAirports BETWEEN 'GTR' AND 'SUN'], operator=[RANGE])
```