### PR TITLE
Use ConfluentKafkaContainer in schema-registry tests and bump Testcontainers to 1.21.4

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/kafka/schemaregistry/SchemaRegistryStarter.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/kafka/schemaregistry/SchemaRegistryStarter.java
@@ -23,9 +23,9 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.kafka.ConfluentKafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 
 
@@ -49,7 +49,7 @@ public class SchemaRegistryStarter {
 
   public static class KafkaSchemaRegistryInstance {
     private final int _port;
-    public KafkaContainer _kafkaContainer;
+    public ConfluentKafkaContainer _kafkaContainer;
     private Network _network;
     private GenericContainer _schemaRegistryContainer;
 
@@ -69,8 +69,9 @@ public class SchemaRegistryStarter {
 
       _network = Network.newNetwork();
 
-      _kafkaContainer = new KafkaContainer(KAFKA_DOCKER_IMAGE_NAME).withNetwork(_network).withNetworkAliases("kafka")
-          .withCreateContainerCmdModifier(it -> it.withHostName("kafka")).waitingFor(Wait.forListeningPort());
+      _kafkaContainer =
+          new ConfluentKafkaContainer(KAFKA_DOCKER_IMAGE_NAME).withNetwork(_network).withNetworkAliases("kafka")
+              .withCreateContainerCmdModifier(it -> it.withHostName("kafka")).waitingFor(Wait.forListeningPort());
       _kafkaContainer.start();
 
       Map<String, String> schemaRegistryProps = new HashMap<>();

--- a/pinot-plugins/pinot-input-format/pinot-confluent-protobuf/src/test/java/org/apache/pinot/plugin/inputformat/protobuf/kafka/schemaregistry/SchemaRegistryStarter.java
+++ b/pinot-plugins/pinot-input-format/pinot-confluent-protobuf/src/test/java/org/apache/pinot/plugin/inputformat/protobuf/kafka/schemaregistry/SchemaRegistryStarter.java
@@ -23,9 +23,9 @@ import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testcontainers.containers.GenericContainer;
-import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.containers.wait.strategy.Wait;
+import org.testcontainers.kafka.ConfluentKafkaContainer;
 import org.testcontainers.utility.DockerImageName;
 
 
@@ -49,7 +49,7 @@ public class SchemaRegistryStarter {
 
   public static class KafkaSchemaRegistryInstance {
     private final int _port;
-    public KafkaContainer _kafkaContainer;
+    public ConfluentKafkaContainer _kafkaContainer;
     private Network _network;
     private GenericContainer _schemaRegistryContainer;
 
@@ -69,8 +69,9 @@ public class SchemaRegistryStarter {
 
       _network = Network.newNetwork();
 
-      _kafkaContainer = new KafkaContainer(KAFKA_DOCKER_IMAGE_NAME).withNetwork(_network).withNetworkAliases("kafka")
-          .withCreateContainerCmdModifier(it -> it.withHostName("kafka")).waitingFor(Wait.forListeningPort());
+      _kafkaContainer =
+          new ConfluentKafkaContainer(KAFKA_DOCKER_IMAGE_NAME).withNetwork(_network).withNetworkAliases("kafka")
+              .withCreateContainerCmdModifier(it -> it.withHostName("kafka")).waitingFor(Wait.forListeningPort());
       _kafkaContainer.start();
 
       Map<String, String> schemaRegistryProps = new HashMap<>();

--- a/pom.xml
+++ b/pom.xml
@@ -308,7 +308,7 @@
     <testng.version>7.12.0</testng.version>
     <mockito-core.version>5.17.0</mockito-core.version>
     <equalsverifier.version>3.19.4</equalsverifier.version>
-    <testcontainers.version>1.21.3</testcontainers.version>
+    <testcontainers.version>1.21.4</testcontainers.version>
     <h2.version>2.4.240</h2.version>
     <jnr-posix.version>3.1.21</jnr-posix.version>
     <scalatest.version>3.2.19</scalatest.version>


### PR DESCRIPTION
## Summary
- replace deprecated `org.testcontainers.containers.KafkaContainer` usage in:
  - `org.apache.pinot.integration.tests.kafka.schemaregistry.SchemaRegistryStarter`
  - `org.apache.pinot.plugin.inputformat.protobuf.kafka.schemaregistry.SchemaRegistryStarter`
- switch both to `org.testcontainers.kafka.ConfluentKafkaContainer`
- keep Confluent image usage (`confluentinc/cp-kafka`) for schema-registry compatibility
- bump root `testcontainers.version` from `1.21.3` to `1.21.4`

## Verification
- `./mvnw -pl pinot-plugins/pinot-input-format/pinot-confluent-protobuf -DskipTests -Dcheckstyle.skip=true -Denforcer.skip=true test-compile`
- `./mvnw -pl pinot-integration-tests -DskipTests -Dcheckstyle.skip=true -Denforcer.skip=true test-compile`
