### PR TITLE
Thread TlsSpec through batch ingestion job runners for mTLS support

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/segment/generation/SegmentGenerationUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/segment/generation/SegmentGenerationUtils.java
@@ -37,6 +37,7 @@ import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nullable;
 import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.KeyManager;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManagerFactory;
 import org.apache.commons.io.IOUtils;
@@ -257,13 +258,19 @@ public class SegmentGenerationUtils {
         HttpsURLConnection httpsConn = (HttpsURLConnection) connection;
 
         if (tlsSpec != null) {
+          KeyManager[] keyManagers = null;
+          if (tlsSpec.getKeyStorePath() != null) {
+            keyManagers = TlsUtils.createKeyManagerFactory(
+                tlsSpec.getKeyStorePath(), tlsSpec.getKeyStorePassword(), tlsSpec.getKeyStoreType())
+                .getKeyManagers();
+          }
           TrustManagerFactory tmf = TlsUtils.createTrustManagerFactory(
               tlsSpec.getTrustStorePath(),
               tlsSpec.getTrustStorePassword(),
               tlsSpec.getTrustStoreType());
 
           SSLContext sslContext = SSLContext.getInstance("TLS");
-          sslContext.init(null, tmf.getTrustManagers(), new SecureRandom());
+          sslContext.init(keyManagers, tmf.getTrustManagers(), new SecureRandom());
 
           httpsConn.setSSLSocketFactory(sslContext.getSocketFactory());
           httpsConn.setConnectTimeout(tlsSpec.getConnectTimeout());

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/main/java/org/apache/pinot/plugin/ingestion/batch/common/BaseSegmentPushJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/main/java/org/apache/pinot/plugin/ingestion/batch/common/BaseSegmentPushJobRunner.java
@@ -67,7 +67,8 @@ public abstract class BaseSegmentPushJobRunner implements IngestionJobRunner {
     // Read Table config
     if (_spec.getTableSpec().getTableConfigURI() != null) {
       _tableConfig =
-          SegmentGenerationUtils.getTableConfig(_spec.getTableSpec().getTableConfigURI(), spec.getAuthToken());
+          SegmentGenerationUtils.getTableConfig(_spec.getTableSpec().getTableConfigURI(), spec.getAuthToken(),
+              spec.getTlsSpec());
       _consistentPushEnabled = ConsistentDataPushUtils.consistentDataPushEnabled(_tableConfig);
     }
   }

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/src/main/java/org/apache/pinot/plugin/ingestion/batch/hadoop/HadoopSegmentCreationMapper.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/src/main/java/org/apache/pinot/plugin/ingestion/batch/hadoop/HadoopSegmentCreationMapper.java
@@ -146,9 +146,11 @@ public class HadoopSegmentCreationMapper extends Mapper<LongWritable, Text, Long
       taskSpec.setInputFilePath(localInputDataFile.getAbsolutePath());
       taskSpec.setOutputDirectoryPath(localOutputTempDir.getAbsolutePath());
       taskSpec.setRecordReaderSpec(_spec.getRecordReaderSpec());
-      taskSpec.setSchema(SegmentGenerationUtils.getSchema(_spec.getTableSpec().getSchemaURI(), _spec.getAuthToken()));
+      taskSpec.setSchema(SegmentGenerationUtils.getSchema(_spec.getTableSpec().getSchemaURI(), _spec.getAuthToken(),
+          _spec.getTlsSpec()));
       taskSpec.setTableConfig(
-          SegmentGenerationUtils.getTableConfig(_spec.getTableSpec().getTableConfigURI(), _spec.getAuthToken()));
+          SegmentGenerationUtils.getTableConfig(_spec.getTableSpec().getTableConfigURI(), _spec.getAuthToken(),
+              _spec.getTlsSpec()));
       taskSpec.setSequenceId(idx);
       taskSpec.setSegmentNameGeneratorSpec(_spec.getSegmentNameGeneratorSpec());
       taskSpec.setFailOnEmptySegment(_spec.isFailOnEmptySegment());

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark3/SparkSegmentGenerationJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark3/SparkSegmentGenerationJobRunner.java
@@ -139,7 +139,8 @@ public class SparkSegmentGenerationJobRunner implements IngestionJobRunner, Seri
     LOGGER.info("Found {} files to create Pinot segments!", filteredFiles.size());
 
     TableConfig tableConfig =
-        SegmentGenerationUtils.getTableConfig(_spec.getTableSpec().getTableConfigURI(), _spec.getAuthToken());
+        SegmentGenerationUtils.getTableConfig(_spec.getTableSpec().getTableConfigURI(), _spec.getAuthToken(),
+            _spec.getTlsSpec());
     boolean consistentPushEnabled = ConsistentDataPushUtils.consistentDataPushEnabled(tableConfig);
 
     if (consistentPushEnabled) {

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark3/SparkSegmentMetadataPushJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark3/SparkSegmentMetadataPushJobRunner.java
@@ -113,7 +113,8 @@ public class SparkSegmentMetadataPushJobRunner implements IngestionJobRunner, Se
 
     // Retrieve table config and check for consistent push
     TableConfig tableConfig =
-        SegmentGenerationUtils.getTableConfig(_spec.getTableSpec().getTableConfigURI(), _spec.getAuthToken());
+        SegmentGenerationUtils.getTableConfig(_spec.getTableSpec().getTableConfigURI(), _spec.getAuthToken(),
+            _spec.getTlsSpec());
     boolean consistentPushEnabled = ConsistentDataPushUtils.consistentDataPushEnabled(tableConfig);
 
     // Determine push parallelism

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentGenerationJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentGenerationJobRunner.java
@@ -143,7 +143,8 @@ public class SegmentGenerationJobRunner implements IngestionJobRunner {
           .generateSchemaURI(pinotClusterSpec.getControllerURI(), _spec.getTableSpec().getTableName());
       _spec.getTableSpec().setSchemaURI(schemaURI);
     }
-    _schema = SegmentGenerationUtils.getSchema(_spec.getTableSpec().getSchemaURI(), _spec.getAuthToken());
+    _schema = SegmentGenerationUtils.getSchema(_spec.getTableSpec().getSchemaURI(), _spec.getAuthToken(),
+        _spec.getTlsSpec());
 
     // Read Table config
     if (_spec.getTableSpec().getTableConfigURI() == null) {
@@ -155,7 +156,8 @@ public class SegmentGenerationJobRunner implements IngestionJobRunner {
           .generateTableConfigURI(pinotClusterSpec.getControllerURI(), _spec.getTableSpec().getTableName());
       _spec.getTableSpec().setTableConfigURI(tableConfigURI);
     }
-    _tableConfig = SegmentGenerationUtils.getTableConfig(_spec.getTableSpec().getTableConfigURI(), spec.getAuthToken());
+    _tableConfig = SegmentGenerationUtils.getTableConfig(_spec.getTableSpec().getTableConfigURI(), spec.getAuthToken(),
+        spec.getTlsSpec());
 
     _consistentPushEnabled = ConsistentDataPushUtils.consistentDataPushEnabled(_tableConfig);
 

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentTarPushJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentTarPushJobRunner.java
@@ -54,7 +54,8 @@ public class SegmentTarPushJobRunner extends BaseSegmentPushJobRunner {
     // Read Table config
     if (_spec.getTableSpec().getTableConfigURI() != null) {
       _tableConfig =
-          SegmentGenerationUtils.getTableConfig(_spec.getTableSpec().getTableConfigURI(), spec.getAuthToken());
+          SegmentGenerationUtils.getTableConfig(_spec.getTableSpec().getTableConfigURI(), spec.getAuthToken(),
+              spec.getTlsSpec());
       _consistentPushEnabled = ConsistentDataPushUtils.consistentDataPushEnabled(_tableConfig);
     }
   }


### PR DESCRIPTION
1. The PR has to be tagged with at least one of the following labels (*):
   1. `feature`
   2. `bugfix`
   3. `security`
  
## Summary
  Batch ingestion jobs (standalone, Hadoop, Spark) now thread the job-level TlsSpec
  through to controller API calls (getTableConfig, getSchema, segment push). This
  enables mTLS client authentication when pushing segments to TLS-enabled controllers.

  ## Changes
  - Resolve `FileUploadDownloadClient` from `TlsSpec` instead of using a static singleton,
    building an SSLContext with both KeyManager and TrustManager when configured
  - Thread `TlsSpec` to `getTableConfig`/`getSchema` calls across all job runners
  - Add KeyManager support to `fetchUrl` in `SegmentGenerationUtils`

  Fixes #17702
