### PR TITLE
Bump testcontainers to 1.21.4 to fix Docker issue

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -308,7 +308,7 @@
     <testng.version>7.12.0</testng.version>
     <mockito-core.version>5.17.0</mockito-core.version>
     <equalsverifier.version>3.19.4</equalsverifier.version>
-    <testcontainers.version>1.21.3</testcontainers.version>
+    <testcontainers.version>1.21.4</testcontainers.version>
     <h2.version>2.4.240</h2.version>
     <jnr-posix.version>3.1.21</jnr-posix.version>
     <scalatest.version>3.2.19</scalatest.version>


### PR DESCRIPTION
- Attempt to fix errors like:

```
  19:44:52.125 ERROR [DockerClientProviderStrategy] [main] Could not find a valid Docker environment. Please check configuration. Attempted configurations were:
  	UnixSocketClientProviderStrategy: failed with exception BadRequestException (Status 400: {"message":"client version 1.32 is too old. Minimum supported API version is 1.44, please upgrade your client to a newer version"}
  )
  	DockerDesktopClientProviderStrategy: failed with exception NullPointerException (null). Root cause NullPointerException (null)As no valid configuration was found, execution cannot continue.
```

which were probably caused by the GitHub Actions runner being updated to use a newer Docker engine version (which dropped support for the older Docker API version being used by our version of `testcontainers`).


- This is a short term fix. We need to move to the more actively maintained `2.x` line for testcontainers soon.