### PR TITLE
Add batched SegmentZKMetadata iteration API and migrate controller usages

### DIFF
--- a/pinot-common/src/test/java/org/apache/pinot/common/metadata/ZKMetadataProviderTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/metadata/ZKMetadataProviderTest.java
@@ -1,0 +1,108 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.metadata;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import org.apache.helix.AccessOption;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.zookeeper.data.Stat;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+/**
+ * Tests for {@link ZKMetadataProvider}.
+ */
+public class ZKMetadataProviderTest {
+  private static final String TABLE_NAME_WITH_TYPE = "testTable_OFFLINE";
+
+  @Test
+  public void testForEachSegmentZKMetadataEmptySegments() {
+    ZkHelixPropertyStore<ZNRecord> mockPropertyStore = Mockito.mock(ZkHelixPropertyStore.class);
+    String segmentsPath = ZKMetadataProvider.constructPropertyStorePathForResource(TABLE_NAME_WITH_TYPE);
+    Mockito.when(mockPropertyStore.exists(segmentsPath, AccessOption.PERSISTENT)).thenReturn(true);
+    Mockito.when(
+        mockPropertyStore.getChildNames(segmentsPath, AccessOption.PERSISTENT)).thenReturn(Collections.emptyList());
+
+    List<String> segmentNames = new ArrayList<>();
+    ZKMetadataProvider.forEachSegmentZKMetadata(mockPropertyStore, TABLE_NAME_WITH_TYPE, 2,
+        segmentZKMetadata -> segmentNames.add(segmentZKMetadata.getSegmentName()));
+
+    Assert.assertTrue(segmentNames.isEmpty());
+    Mockito.verify(mockPropertyStore, Mockito.never())
+        .get(Mockito.<String>anyList(), Mockito.<Stat>anyList(),
+            ArgumentMatchers.eq(AccessOption.PERSISTENT));
+  }
+
+  @Test
+  public void testForEachSegmentZKMetadataBatchesAndNullRecords() {
+    ZkHelixPropertyStore<ZNRecord> mockPropertyStore = Mockito.mock(ZkHelixPropertyStore.class);
+    String segmentsPath = ZKMetadataProvider.constructPropertyStorePathForResource(TABLE_NAME_WITH_TYPE);
+    List<String> segmentNames = Arrays.asList("segment-1", "segment-2", "segment-3", "segment-4");
+    Mockito.when(mockPropertyStore.exists(segmentsPath, AccessOption.PERSISTENT)).thenReturn(true);
+    Mockito.when(mockPropertyStore.getChildNames(segmentsPath, AccessOption.PERSISTENT)).thenReturn(segmentNames);
+
+    List<List<String>> requestedBatches = new ArrayList<>();
+    Mockito.when(mockPropertyStore.get(Mockito.<String>anyList(), Mockito.isNull(),
+        ArgumentMatchers.eq(AccessOption.PERSISTENT))).thenAnswer(invocation -> {
+      List<String> requestedSegments = invocation.getArgument(0);
+      requestedBatches.add(new ArrayList<>(requestedSegments));
+      if (requestedSegments.equals(Arrays.asList(constructSegmentMetadataPath("segment-1"),
+          constructSegmentMetadataPath("segment-2")))) {
+        return Arrays.asList(createSegmentMetadata("segment-1"), null);
+      }
+      if (requestedSegments.equals(Arrays.asList(constructSegmentMetadataPath("segment-3"),
+          constructSegmentMetadataPath("segment-4")))) {
+        return Collections.singletonList(createSegmentMetadata("segment-3"));
+      }
+      return Collections.emptyList();
+    });
+
+    List<String> consumedSegments = new ArrayList<>();
+    ZKMetadataProvider.forEachSegmentZKMetadata(mockPropertyStore, TABLE_NAME_WITH_TYPE, 2,
+        segmentZKMetadata -> consumedSegments.add(segmentZKMetadata.getSegmentName()));
+
+    Assert.assertEquals(consumedSegments, Arrays.asList("segment-1", "segment-3"));
+    Assert.assertEquals(requestedBatches, Arrays.asList(
+        Arrays.asList(constructSegmentMetadataPath("segment-1"), constructSegmentMetadataPath("segment-2")),
+        Arrays.asList(constructSegmentMetadataPath("segment-3"), constructSegmentMetadataPath("segment-4"))));
+  }
+
+  @Test
+  public void testForEachSegmentZKMetadataRequiresPositiveBatchSize() {
+    ZkHelixPropertyStore<ZNRecord> mockPropertyStore = Mockito.mock(ZkHelixPropertyStore.class);
+    Assert.assertThrows(IllegalArgumentException.class,
+        () -> ZKMetadataProvider.forEachSegmentZKMetadata(mockPropertyStore, TABLE_NAME_WITH_TYPE, 0,
+            segmentZKMetadata -> {
+            }));
+  }
+
+  private ZNRecord createSegmentMetadata(String segmentName) {
+    return new ZNRecord(segmentName);
+  }
+
+  private String constructSegmentMetadataPath(String segmentName) {
+    return ZKMetadataProvider.constructPropertyStorePathForSegment(TABLE_NAME_WITH_TYPE, segmentName);
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -273,6 +273,9 @@ public class ControllerConf extends PinotConfiguration {
     public static final String AGED_SEGMENTS_DELETION_BATCH_SIZE =
         "controller.retentionManager.agedSegmentsDeletionBatchSize";
     public static final int DEFAULT_AGED_SEGMENTS_DELETION_BATCH_SIZE = 1000;
+    public static final String SEGMENTS_ZK_METADATA_BATCH_SIZE =
+        "controller.retentionManager.segmentsZkMetadataBatchSize";
+    public static final int DEFAULT_SEGMENTS_ZK_METADATA_BATCH_SIZE = 1000;
     public static final int MIN_INITIAL_DELAY_IN_SECONDS = 120;
     public static final int MAX_INITIAL_DELAY_IN_SECONDS = 300;
     public static final int DEFAULT_SPLIT_COMMIT_TMP_SEGMENT_LIFETIME_SECOND = 60 * 60; // 1 Hour.
@@ -1224,6 +1227,15 @@ public class ControllerConf extends PinotConfiguration {
 
   public void setAgedSegmentsDeletionBatchSize(int agedSegmentsDeletionBatchSize) {
     setProperty(ControllerPeriodicTasksConf.AGED_SEGMENTS_DELETION_BATCH_SIZE, agedSegmentsDeletionBatchSize);
+  }
+
+  public int getSegmentsZKMetadataBatchSize() {
+    return getProperty(ControllerPeriodicTasksConf.SEGMENTS_ZK_METADATA_BATCH_SIZE,
+        ControllerPeriodicTasksConf.DEFAULT_SEGMENTS_ZK_METADATA_BATCH_SIZE);
+  }
+
+  public void setSegmentsZKMetadataBatchSize(int segmentZKMetadataBatchSize) {
+    setProperty(ControllerPeriodicTasksConf.SEGMENTS_ZK_METADATA_BATCH_SIZE, segmentZKMetadataBatchSize);
   }
 
   public long getPinotTaskManagerInitialDelaySeconds() {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/ClusterInfoAccessor.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/ClusterInfoAccessor.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.Executor;
+import java.util.function.Consumer;
 import javax.annotation.Nullable;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
 import org.apache.helix.HelixDataAccessor;
@@ -113,6 +114,15 @@ public class ClusterInfoAccessor {
    */
   public List<SegmentZKMetadata> getSegmentsZKMetadata(String tableNameWithType) {
     return ZKMetadataProvider.getSegmentsZKMetadata(_pinotHelixResourceManager.getPropertyStore(), tableNameWithType);
+  }
+
+  public void forEachSegmentsZKMetadata(String tableNameWithType, int batchSize,
+      Consumer<SegmentZKMetadata> segmentMetadataConsumer) {
+    _pinotHelixResourceManager.forEachSegmentsZKMetadata(tableNameWithType, batchSize, segmentMetadataConsumer);
+  }
+
+  public void forEachSegmentsZKMetadata(String tableNameWithType, Consumer<SegmentZKMetadata> segmentMetadataConsumer) {
+    _pinotHelixResourceManager.forEachSegmentsZKMetadata(tableNameWithType, segmentMetadataConsumer);
   }
 
   public IdealState getIdealState(String tableNameWithType) {


### PR DESCRIPTION
## Summary
- Add batched/streaming SegmentZKMetadata enumeration API in PinotHelixResourceManager via ZKMetadataProvider
- Add configurable batch size support (default 1000) for retention scanning
- Migrate heavy controller callsites from list-based getSegmentsZKMetadata(...) to iterative processing where applicable
