### PR TITLE
Add controller execution time tracking to query responses 

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/TimeSeriesIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/TimeSeriesIntegrationTest.java
@@ -198,7 +198,11 @@ public class TimeSeriesIntegrationTest extends BaseClusterIntegrationTest {
     );
     JsonNode result = getTimeseriesQuery(getControllerBaseApiUrl(), query, QUERY_START_TIME_SEC, QUERY_END_TIME_SEC,
         getHeaders());
-    assertEquals(result.get("status").asText(), "success");
+
+    // Add null check for status field
+    JsonNode statusNode = result.get("status");
+    assertNotNull(statusNode, "Status field should not be null in timeseries query response");
+    assertEquals(statusNode.asText(), "success");
 
     // Call /timeseries/languages.
     var statusCodeAndResponse = sendGetRequestWithStatusCode(


### PR DESCRIPTION
…meseries responses

- Add sendTimeSeriesRequestRaw method to handle timeseries responses without parsing as BrokerResponseNative
- Update sendTimeSeriesRequestToBroker to use raw forwarding for both GET and POST endpoints
- Fix GET endpoint method signature to use proper executeTimeSeriesQueryCatching parameters
- Ensures controller preserves broker's PinotBrokerTimeSeriesResponse structure with status field
- Resolves test failure: 'Status field should not be null in timeseries query response'

The issue was that controller was incorrectly trying to parse timeseries responses as BrokerResponseNative and add execution time, but timeseries responses use PinotBrokerTimeSeriesResponse with different structure. This fix preserves the original Prometheus-compatible response format from the broker.

Instructions:
1. The PR has to be tagged with at least one of the following labels (*):
   1. `feature`
   2. `bugfix`
   3. `performance`
   4. `ui`
   5. `backward-incompat`
   6. `release-notes` (**)
2. Remove these instructions before publishing the PR.
 
(*) Other labels to consider:
- `testing`
- `dependencies`
- `docker`
- `kubernetes`
- `observability`
- `security`
- `code-style`
- `extension-point`
- `refactor`
- `cleanup`

(**) Use `release-notes` label for scenarios like:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
