### PR TITLE
Improve GcsPinotFS deleteBatch resiliency

### DIFF
--- a/pinot-plugins/pinot-file-system/pinot-gcs/src/main/java/org/apache/pinot/plugin/filesystem/GcsPinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-gcs/src/main/java/org/apache/pinot/plugin/filesystem/GcsPinotFS.java
@@ -153,8 +153,11 @@ public class GcsPinotFS extends BasePinotFS {
       if (existsDirectoryOrBucket(gcsUri)) {
         result &= delete(gcsUri, forceDelete);
       } else {
-        blobIds.add(getBlob(gcsUri).getBlobId());
-        if (blobIds.size() >= DELETE_BATCH_LIMIT || !iterator.hasNext()) {
+        Blob blob = getBlob(gcsUri);
+        if (blob != null) {
+          blobIds.add(blob.getBlobId());
+        }
+        if (blobIds.size() >= DELETE_BATCH_LIMIT || (!blobIds.isEmpty() && !iterator.hasNext())) {
           List<Boolean> deleted = _storage.delete(blobIds);
           result &= deleted.stream().allMatch(Boolean::booleanValue);
           blobIds.clear();


### PR DESCRIPTION
`Storage.get(BlobId)` returns null when the blob does not exist in GCS [1].
The `delete()` method already handles this with a null check `(blob != null && blob.delete())`,
but `deleteBatch()` did not, causing a NPE when calling getBlobId() on the null return value.

- Added null check in `deleteBatch` to gracefully skip non-existent blobs
- Added guard to avoid calling `_storage.delete()` with an empty list

[1] [https://docs.cloud.google.com/java/docs/reference/google-cloud-storage/latest/com.google.cloud.storage.Storage#com_google_cloud_storage_Storage_get_com_google_cloud_storage_BlobId_](https://docs.cloud.google.com/java/docs/reference/google-cloud-storage/latest/com.google.cloud.storage.Storage#com_google_cloud_storage_Storage_get_com_google_cloud_storage_BlobId_)