### PR TITLE
Handle mixed-type map key stats by promoting numeric values to string (fixed review comments)

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/MapFieldTypeMixedValueIngestingIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/MapFieldTypeMixedValueIngestingIntegrationTest.java
@@ -1,0 +1,144 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.integration.tests.custom;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeType;
+import java.io.File;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.generic.GenericData;
+import org.apache.pinot.spi.data.ComplexFieldSpec;
+import org.apache.pinot.spi.data.DimensionFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.testng.annotations.Test;
+
+import static org.apache.avro.Schema.create;
+import static org.testng.Assert.assertEquals;
+
+
+@Test(suiteName = "CustomClusterIntegrationTest")
+public class MapFieldTypeMixedValueIngestingIntegrationTest extends CustomDataQueryClusterIntegrationTest {
+
+  private static final String DEFAULT_TABLE_NAME = "MapFieldTypeMixedValueIngestingIntegrationTest";
+  private static final String MAP_FIELD_NAME = "tracingContext";
+  private static final String TRACE_ID_KEY = "traceId";
+  private static final int NUM_RECORDS = 1000;
+  private static final int FLUSH_SIZE = 100;
+  private static final long NUMERIC_TRACE_ID = 9876543210L;
+  private static final String STRING_TRACE_ID = "c69b6613-e174-49f1-ac47-4e9ab98e513f";
+
+  @Override
+  protected long getCountStarResult() {
+    return NUM_RECORDS;
+  }
+
+  @Override
+  public String getTableName() {
+    return DEFAULT_TABLE_NAME;
+  }
+
+  @Override
+  public Schema createSchema() {
+    ComplexFieldSpec tracingContextFieldSpec = new ComplexFieldSpec(MAP_FIELD_NAME, FieldSpec.DataType.MAP, true,
+        Map.of(
+            ComplexFieldSpec.KEY_FIELD,
+            new DimensionFieldSpec(ComplexFieldSpec.KEY_FIELD, FieldSpec.DataType.STRING, true),
+            ComplexFieldSpec.VALUE_FIELD,
+            new DimensionFieldSpec(ComplexFieldSpec.VALUE_FIELD, FieldSpec.DataType.STRING, true)
+        ));
+    return new Schema.SchemaBuilder().setSchemaName(getTableName())
+        .addField(tracingContextFieldSpec)
+        .addDateTimeField(TIMESTAMP_FIELD_NAME, FieldSpec.DataType.TIMESTAMP, "1:MILLISECONDS", "1:MILLISECONDS")
+        .build();
+  }
+
+  public List<File> createAvroFiles()
+      throws Exception {
+    org.apache.avro.Schema avroSchema = org.apache.avro.Schema.createRecord("myRecord", null, null, false);
+    org.apache.avro.Schema mapValueSchema =
+        org.apache.avro.Schema.createUnion(Arrays.asList(create(org.apache.avro.Schema.Type.LONG),
+            create(org.apache.avro.Schema.Type.STRING)));
+    org.apache.avro.Schema mapAvroSchema = org.apache.avro.Schema.createMap(mapValueSchema);
+    List<org.apache.avro.Schema.Field> fields =
+        Arrays.asList(
+            new org.apache.avro.Schema.Field(MAP_FIELD_NAME, mapAvroSchema, null, null),
+            new org.apache.avro.Schema.Field(TIMESTAMP_FIELD_NAME, create(org.apache.avro.Schema.Type.LONG), null, null)
+        );
+    avroSchema.setFields(fields);
+
+    try (AvroFilesAndWriters avroFilesAndWriters = createAvroFilesAndWriters(avroSchema)) {
+      long tsBase = System.currentTimeMillis();
+      List<DataFileWriter<GenericData.Record>> writers = avroFilesAndWriters.getWriters();
+      for (int i = 0; i < NUM_RECORDS; i++) {
+        Map<String, Object> mixedMapRecord = new HashMap<>();
+        if (i % 100 == 99) {
+          mixedMapRecord.put(TRACE_ID_KEY, STRING_TRACE_ID);
+        } else {
+          mixedMapRecord.put(TRACE_ID_KEY, NUMERIC_TRACE_ID);
+        }
+        GenericData.Record mapRecord = new GenericData.Record(avroSchema);
+        mapRecord.put(MAP_FIELD_NAME, mixedMapRecord);
+        mapRecord.put(TIMESTAMP_FIELD_NAME, tsBase + i);
+        writers.get(0).append(mapRecord);
+      }
+      return avroFilesAndWriters.getAvroFiles();
+    }
+  }
+
+  @Override
+  protected int getRealtimeSegmentFlushSize() {
+    return FLUSH_SIZE;
+  }
+
+  @Test(dataProvider = "useBothQueryEngines")
+  public void testNumericMixedMapKeyValuesAsString(boolean useMultiStageQueryEngine)
+      throws Exception {
+    setUseMultiStageQueryEngine(useMultiStageQueryEngine);
+    String query = "SELECT " + MAP_FIELD_NAME + "['" + TRACE_ID_KEY + "'] FROM " + getTableName()
+        + " ORDER BY " + TIMESTAMP_FIELD_NAME + " LIMIT " + NUM_RECORDS;
+    JsonNode pinotResponse = postQuery(query);
+    assertEquals(pinotResponse.get("exceptions").size(), 0);
+    JsonNode rows = pinotResponse.get("resultTable").get("rows");
+    assertEquals(rows.size(), NUM_RECORDS);
+    for (int i = 0; i < NUM_RECORDS; i++) {
+      assertEquals(rows.get(i).get(0).getNodeType(), JsonNodeType.STRING);
+      if (i % 100 == 99) {
+        assertEquals(rows.get(i).get(0).textValue(), STRING_TRACE_ID);
+      } else {
+        assertEquals(rows.get(i).get(0).textValue(), Long.toString(NUMERIC_TRACE_ID));
+      }
+    }
+
+    query = "SELECT COUNT(*) FROM " + getTableName() + " WHERE " + MAP_FIELD_NAME + "['" + TRACE_ID_KEY
+        + "'] = '" + STRING_TRACE_ID + "'";
+    pinotResponse = postQuery(query);
+    assertEquals(pinotResponse.get("exceptions").size(), 0);
+    assertEquals(pinotResponse.get("resultTable").get("rows").get(0).get(0).intValue(), NUM_RECORDS / FLUSH_SIZE);
+  }
+
+  @Override
+  public boolean isRealtimeTable() {
+    return true;
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/BigDecimalColumnPreIndexStatsCollector.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/BigDecimalColumnPreIndexStatsCollector.java
@@ -106,6 +106,10 @@ public class BigDecimalColumnPreIndexStatsCollector extends AbstractColumnStatis
     return _sealed ? _sortedValues.length : _values.size();
   }
 
+  BigDecimal[] getValues() {
+    return _values.toArray(new BigDecimal[0]);
+  }
+
   @Override
   public void seal() {
     if (!_sealed) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/DoubleColumnPreIndexStatsCollector.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/DoubleColumnPreIndexStatsCollector.java
@@ -110,6 +110,10 @@ public class DoubleColumnPreIndexStatsCollector extends AbstractColumnStatistics
     return _sealed ? _sortedValues.length : _values.size();
   }
 
+  double[] getValues() {
+    return _values.toDoubleArray();
+  }
+
   @Override
   public void seal() {
     if (!_sealed) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/FloatColumnPreIndexStatsCollector.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/FloatColumnPreIndexStatsCollector.java
@@ -110,6 +110,10 @@ public class FloatColumnPreIndexStatsCollector extends AbstractColumnStatisticsC
     return _sealed ? _sortedValues.length : _values.size();
   }
 
+  float[] getValues() {
+    return _values.toFloatArray();
+  }
+
   @Override
   public void seal() {
     if (!_sealed) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/IntColumnPreIndexStatsCollector.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/IntColumnPreIndexStatsCollector.java
@@ -110,6 +110,10 @@ public class IntColumnPreIndexStatsCollector extends AbstractColumnStatisticsCol
     return _sealed ? _sortedValues.length : _values.size();
   }
 
+  int[] getValues() {
+    return _values.toIntArray();
+  }
+
   @Override
   public void seal() {
     if (!_sealed) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/LongColumnPreIndexStatsCollector.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/LongColumnPreIndexStatsCollector.java
@@ -110,6 +110,10 @@ public class LongColumnPreIndexStatsCollector extends AbstractColumnStatisticsCo
     return _sealed ? _sortedValues.length : _values.size();
   }
 
+  long[] getValues() {
+    return _values.toLongArray();
+  }
+
   @Override
   public void seal() {
     if (!_sealed) {


### PR DESCRIPTION
## Summary
- Fix mixed-type map key values in map column stats collection
- Promote numeric key collectors to STRING on parse failures while preserving prior numeric collector counters
- Preserve no-dict behavior when promoting collectors for map keys
- Add regression coverage for promotion counters and mixed-type path

## Testing
- ./mvnw spotless:apply checkstyle:check -T1C -pl pinot-segment-local -am
