### PR TITLE
Give more wait time and retry for kafka setup for ExactlyOnceKafkaRealtimeClusterIntegrationTest and separate it from the test suite run

### DIFF
--- a/pinot-integration-tests/pom.xml
+++ b/pinot-integration-tests/pom.xml
@@ -86,25 +86,57 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-surefire-plugin</artifactId>
-            <configuration>
-              <skipTests>false</skipTests>
-              <includes>
-                <include>**/org/apache/pinot/integration/tests/A*Test.java</include>
-                <include>**/org/apache/pinot/integration/tests/B*Test.java</include>
-                <include>**/org/apache/pinot/integration/tests/C*Test.java</include>
-                <include>**/org/apache/pinot/integration/tests/D*Test.java</include>
-                <include>**/org/apache/pinot/integration/tests/E*Test.java</include>
-                <include>**/org/apache/pinot/integration/tests/F*Test.java</include>
-                <include>**/org/apache/pinot/integration/tests/G*Test.java</include>
-                <include>**/org/apache/pinot/integration/tests/H*Test.java</include>
-                <include>**/org/apache/pinot/integration/tests/I*Test.java</include>
-                <include>**/org/apache/pinot/integration/tests/J*Test.java</include>
-                <include>**/org/apache/pinot/integration/tests/K*Test.java</include>
-                <include>**/org/apache/pinot/integration/tests/L*Test.java</include>
-                <include>**/org/apache/pinot/integration/tests/M*Test.java</include>
-                <include>**/org/apache/pinot/integration/tests/N*Test.java</include>
-              </includes>
-            </configuration>
+            <executions>
+              <!-- Disable default execution so only our custom executions run -->
+              <execution>
+                <id>default-test</id>
+                <phase>none</phase>
+              </execution>
+              <!-- 1) Run the "must-run-first" test -->
+              <execution>
+                <id>run-first-exactly-once</id>
+                <phase>test</phase>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+                <configuration>
+                  <skipTests>false</skipTests>
+                  <includes>
+                    <include>**/org/apache/pinot/integration/tests/ExactlyOnceKafkaRealtimeClusterIntegrationTest.java</include>
+                  </includes>
+                </configuration>
+              </execution>
+              <!-- 2) Run the rest of set-1 -->
+              <execution>
+                <id>run-rest-set-1</id>
+                <phase>test</phase>
+                <goals>
+                  <goal>test</goal>
+                </goals>
+                <configuration>
+                  <skipTests>false</skipTests>
+                  <includes>
+                    <include>**/org/apache/pinot/integration/tests/A*Test.java</include>
+                    <include>**/org/apache/pinot/integration/tests/B*Test.java</include>
+                    <include>**/org/apache/pinot/integration/tests/C*Test.java</include>
+                    <include>**/org/apache/pinot/integration/tests/D*Test.java</include>
+                    <include>**/org/apache/pinot/integration/tests/E*Test.java</include>
+                    <include>**/org/apache/pinot/integration/tests/F*Test.java</include>
+                    <include>**/org/apache/pinot/integration/tests/G*Test.java</include>
+                    <include>**/org/apache/pinot/integration/tests/H*Test.java</include>
+                    <include>**/org/apache/pinot/integration/tests/I*Test.java</include>
+                    <include>**/org/apache/pinot/integration/tests/J*Test.java</include>
+                    <include>**/org/apache/pinot/integration/tests/K*Test.java</include>
+                    <include>**/org/apache/pinot/integration/tests/L*Test.java</include>
+                    <include>**/org/apache/pinot/integration/tests/M*Test.java</include>
+                    <include>**/org/apache/pinot/integration/tests/N*Test.java</include>
+                  </includes>
+                  <excludes>
+                    <exclude>**/org/apache/pinot/integration/tests/ExactlyOnceKafkaRealtimeClusterIntegrationTest.java</exclude>
+                  </excludes>
+                </configuration>
+              </execution>
+            </executions>
           </plugin>
         </plugins>
       </build>

--- a/pinot-integration-tests/src/test/resources/log4j2-test.xml
+++ b/pinot-integration-tests/src/test/resources/log4j2-test.xml
@@ -24,7 +24,7 @@
     <Console name="console" target="SYSTEM_OUT">
       <PatternLayout pattern="%d{HH:mm:ss.SSS} %p [%c{1}] [%t] %m%n"/>
       <Filters>
-        <BurstFilter level="ERROR" rate="5" maxBurst="10"/>
+        <BurstFilter level="INFO" rate="5" maxBurst="10"/>
       </Filters>
     </Console>
     <Console name="spammy" target="SYSTEM_OUT">
@@ -42,7 +42,7 @@
     <Logger name="org.apache.pinot.core.accounting" level="warn" additivity="false">
       <AppenderRef ref="spammy"/>
     </Logger>
-    <Root level="error">
+    <Root level="info">
       <AppenderRef ref="console"/>
     </Root>
   </Loggers>


### PR DESCRIPTION
This pull request improves the reliability and configurability of Kafka cluster startup in integration tests, particularly to better support resource-constrained CI environments. The main changes include making Kafka startup parameters overridable, updating the test execution order in Maven to ensure a specific test runs first, and customizing Kafka startup behavior for CI.

**Kafka startup configurability and reliability:**

* Added new protected methods (`getKafkaStartMaxAttempts`, `getKafkaStartRetryWaitMs`, `getKafkaClusterReadyTimeoutMs`) in `BaseClusterIntegrationTest.java` to allow subclasses to override Kafka broker startup attempts, retry wait time, and cluster readiness timeout. All usages of the previous constants in Kafka startup logic now use these methods. [[1]](diffhunk://#diff-61bad8512fd75458ed8f9de760b7dc036f5a77fe04168153be3b5ad257de2d6eR197-R219) [[2]](diffhunk://#diff-61bad8512fd75458ed8f9de760b7dc036f5a77fe04168153be3b5ad257de2d6eL821-R844) [[3]](diffhunk://#diff-61bad8512fd75458ed8f9de760b7dc036f5a77fe04168153be3b5ad257de2d6eL839-R862) [[4]](diffhunk://#diff-61bad8512fd75458ed8f9de760b7dc036f5a77fe04168153be3b5ad257de2d6eL849-R884) [[5]](diffhunk://#diff-61bad8512fd75458ed8f9de760b7dc036f5a77fe04168153be3b5ad257de2d6eL871-R894) [[6]](diffhunk://#diff-61bad8512fd75458ed8f9de760b7dc036f5a77fe04168153be3b5ad257de2d6eR947-R952)

* Overrode the new Kafka startup configuration methods in `ExactlyOnceKafkaRealtimeClusterIntegrationTest.java` to provide more generous retry and timeout values when running in CI environments (detected via `GITHUB_ACTIONS`), improving test reliability under resource constraints.

**Test execution order improvements:**

* Updated the Maven Surefire plugin configuration in `pinot-integration-tests/pom.xml` to disable the default test execution, and instead:
  - Run `ExactlyOnceKafkaRealtimeClusterIntegrationTest` first in its own execution.
  - Exclude this test from the subsequent set of tests, so it only runs once and before all others. [[1]](diffhunk://#diff-f191832a3b523ff5a1f818baf6a358e449550c34b75171758749e173dc0b37b2R89-R115) [[2]](diffhunk://#diff-f191832a3b523ff5a1f818baf6a358e449550c34b75171758749e173dc0b37b2R134-R139)