### PR TITLE
resume partially offline replicas in controller validation

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -224,6 +224,8 @@ public class ControllerConf extends PinotConfiguration {
         "controller.segment.level.validation.intervalPeriod";
     public static final String AUTO_RESET_ERROR_SEGMENTS_VALIDATION =
         "controller.segment.error.autoReset";
+    public static final String ENABLE_PARTIAL_OFFLINE_REPLICA_REPAIR =
+        "controller.realtime.segment.partialOfflineReplicaRepairEnabled";
     public static final String DISASTER_RECOVERY_MODE_CONFIG_KEY = "controller.segment.disaster.recovery.mode";
 
     // Initial delays
@@ -1131,6 +1133,10 @@ public class ControllerConf extends PinotConfiguration {
 
   public boolean isAutoResetErrorSegmentsOnValidationEnabled() {
     return getProperty(ControllerPeriodicTasksConf.AUTO_RESET_ERROR_SEGMENTS_VALIDATION, true);
+  }
+
+  public boolean isPartialOfflineReplicaRepairEnabled() {
+    return getProperty(ControllerPeriodicTasksConf.ENABLE_PARTIAL_OFFLINE_REPLICA_REPAIR, false);
   }
 
   public DisasterRecoveryMode getDisasterRecoveryMode() {


### PR DESCRIPTION
## Description

This change introduces automated repair for partially offline replicas in realtime segment consumption for both pauseless and non-pausless Realtime tables. This addresses scenarios(issue: #11314) where some replicas fail during initialization (e.g., KafkaConsumer errors) and mark themselves OFFLINE while other replicas continue consuming normally.

### Changes

- Added new configuration flag `controller.realtime.segment.partialOfflineReplicaRepairEnabled` (defaults to `false`)
- Enhanced `PinotLLCRealtimeSegmentManager` validation to detect and repair mixed CONSUMING/OFFLINE replica states
- When enabled, controller automatically resets OFFLINE replicas back to CONSUMING state for IN_PROGRESS segments, allowing retry

### Implementation Details

**Configuration:**
- New property: `controller.realtime.segment.partialOfflineReplicaRepairEnabled` in `ControllerConf`
- Default: `false` (opt-in for backward compatibility)

**Repair Logic:**
- Detects segments with mixed CONSUMING/OFFLINE replica states during validation
- Logs repair actions with details (segment name, offline count, instance list)
- Resets identified OFFLINE replicas to CONSUMING state

**Testing:**
Unit Tests:
- Added unit tests for enabled scenario (verifies OFFLINE→CONSUMING transition)
- Added unit tests for disabled scenario (verifies no-op behavior)

Local cluster test pLan:
- Set up realtime table(kafka) with two servers and two replicas, partialOfflineReplicaRepairEnabled = true
- Mangle DNS config: `echo "nameserver 0.0.0.0" > /etc/resolv.conf` in server-1
- Force commit, new consuming server on server-1 comes up in error state and moves to OFFLINE state while server-2 is in CONSUMING state
- Run controller validation job: RealtimeSegmentValidationManager
- The replica becomes healthy in CONSUMING state.


## Upgrade Notes

This feature is disabled by default. To enable, set:
`controller.realtime.segment.partialOfflineReplicaRepairEnabled=true`
