### PR TITLE
Revert "Add authz action checks to missing APIs (#17725)"

### DIFF
--- a/pinot-minion/src/main/java/org/apache/pinot/minion/api/resources/PinotMinionAppConfigs.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/api/resources/PinotMinionAppConfigs.java
@@ -31,9 +31,6 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import org.apache.pinot.common.utils.PinotAppConfigs;
-import org.apache.pinot.core.auth.Actions;
-import org.apache.pinot.core.auth.Authorize;
-import org.apache.pinot.core.auth.TargetType;
 import org.apache.pinot.minion.MinionAdminApiApplication;
 import org.apache.pinot.spi.env.PinotConfiguration;
 
@@ -56,7 +53,6 @@ public class PinotMinionAppConfigs {
   @GET
   @Path("/appconfigs")
   @Produces(MediaType.APPLICATION_JSON)
-  @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.GET_APP_CONFIG)
   public String getAppConfigs() {
     PinotConfiguration pinotConfiguration =
         (PinotConfiguration) _application.getProperties().get(MinionAdminApiApplication.PINOT_CONFIGURATION);

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/api/resources/PinotMinionLogger.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/api/resources/PinotMinionLogger.java
@@ -43,9 +43,6 @@ import javax.ws.rs.core.Response;
 import org.apache.pinot.common.utils.LoggerUtils;
 import org.apache.pinot.common.utils.log.DummyLogFileServer;
 import org.apache.pinot.common.utils.log.LogFileServer;
-import org.apache.pinot.core.auth.Actions;
-import org.apache.pinot.core.auth.Authorize;
-import org.apache.pinot.core.auth.TargetType;
 
 import static org.apache.pinot.spi.utils.CommonConstants.SWAGGER_AUTHORIZATION_KEY;
 
@@ -66,7 +63,6 @@ public class PinotMinionLogger {
   @GET
   @Path("/loggers")
   @Produces(MediaType.APPLICATION_JSON)
-  @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.GET_LOGGER)
   @ApiOperation(value = "Get all the loggers", notes = "Return all the logger names")
   public List<String> getLoggers() {
     return LoggerUtils.getAllConfiguredLoggers();
@@ -75,7 +71,6 @@ public class PinotMinionLogger {
   @GET
   @Path("/loggers/{loggerName}")
   @Produces(MediaType.APPLICATION_JSON)
-  @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.GET_LOGGER)
   @ApiOperation(value = "Get logger configs", notes = "Return logger info")
   public Map<String, String> getLogger(
       @ApiParam(value = "Logger name", required = true) @PathParam("loggerName") String loggerName) {
@@ -89,7 +84,6 @@ public class PinotMinionLogger {
   @PUT
   @Path("/loggers/{loggerName}")
   @Produces(MediaType.APPLICATION_JSON)
-  @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.UPDATE_LOGGER)
   @ApiOperation(value = "Set logger level", notes = "Set logger level for a given logger")
   public Map<String, String> setLoggerLevel(@ApiParam(value = "Logger name") @PathParam("loggerName") String loggerName,
       @ApiParam(value = "Logger level") @QueryParam("level") String level) {
@@ -99,7 +93,6 @@ public class PinotMinionLogger {
   @GET
   @Path("/loggers/files")
   @Produces(MediaType.APPLICATION_JSON)
-  @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.GET_LOG_FILE)
   @ApiOperation(value = "Get all local log files")
   public Set<String> getLocalLogFiles() {
     try {
@@ -115,7 +108,6 @@ public class PinotMinionLogger {
   @GET
   @Path("/loggers/download")
   @Produces(MediaType.APPLICATION_OCTET_STREAM)
-  @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.GET_LOG_FILE)
   @ApiOperation(value = "Download a log file")
   public Response downloadLogFile(
       @ApiParam(value = "Log file path", required = true) @QueryParam("filePath") String filePath) {

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/api/resources/PinotMinionMetricsResource.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/api/resources/PinotMinionMetricsResource.java
@@ -35,9 +35,6 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import org.apache.pinot.common.metrics.MinionMetrics;
-import org.apache.pinot.core.auth.Actions;
-import org.apache.pinot.core.auth.Authorize;
-import org.apache.pinot.core.auth.TargetType;
 import org.apache.pinot.spi.utils.JsonUtils;
 
 import static org.apache.pinot.spi.utils.CommonConstants.SWAGGER_AUTHORIZATION_KEY;
@@ -55,7 +52,6 @@ public class PinotMinionMetricsResource {
   @GET
   @Path("/gauge/{gaugeName}")
   @Produces(MediaType.APPLICATION_JSON)
-  @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.GET_HEALTH)
   @ApiOperation("Get gauge value for the provided minion gauge name")
   public String getMinionGaugeValue(@ApiParam(value = "Gauge name") @PathParam("gaugeName") String gaugeName)
       throws JsonProcessingException {

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/api/resources/PinotTaskProgressResource.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/api/resources/PinotTaskProgressResource.java
@@ -42,9 +42,6 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.pinot.core.auth.Actions;
-import org.apache.pinot.core.auth.Authorize;
-import org.apache.pinot.core.auth.TargetType;
 import org.apache.pinot.minion.event.MinionEventObserver;
 import org.apache.pinot.minion.event.MinionEventObservers;
 import org.apache.pinot.minion.event.MinionTaskState;
@@ -71,7 +68,6 @@ public class PinotTaskProgressResource {
   @GET
   @Path("/tasks/subtask/progress")
   @Produces(MediaType.APPLICATION_JSON)
-  @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.GET_TASK)
   @ApiOperation("Get finer grained task progress tracked in memory for the given subtasks")
   @ApiResponses(value = {
       @ApiResponse(code = 200, message = "Success"), @ApiResponse(code = 500, message = "Internal server error")
@@ -99,7 +95,6 @@ public class PinotTaskProgressResource {
   @GET
   @Path("/tasks/subtask/state/progress")
   @Produces(MediaType.APPLICATION_JSON)
-  @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.GET_TASK)
   @ApiOperation("Get finer grained task progress tracked in memory for given subtasks or given state")
   @ApiResponses(value = {
       @ApiResponse(code = 200, message = "Success"), @ApiResponse(code = 500, message = "Internal server error")
@@ -153,7 +148,6 @@ public class PinotTaskProgressResource {
   @GET
   @Path("/tasks/subtask/progressStats")
   @Produces(MediaType.APPLICATION_JSON)
-  @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.GET_TASK)
   @ApiOperation("Get task progress stats tracked for the given subtasks")
   @ApiResponses(value = {
       @ApiResponse(code = 200, message = "Success"), @ApiResponse(code = 500, message = "Internal server error")

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/ControllerJobStatusResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/ControllerJobStatusResource.java
@@ -37,9 +37,6 @@ import javax.ws.rs.core.MediaType;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.response.server.ServerReloadStatusResponse;
 import org.apache.pinot.common.utils.DatabaseUtils;
-import org.apache.pinot.core.auth.Actions;
-import org.apache.pinot.core.auth.Authorize;
-import org.apache.pinot.core.auth.TargetType;
 import org.apache.pinot.segment.local.data.manager.SegmentDataManager;
 import org.apache.pinot.segment.local.data.manager.TableDataManager;
 import org.apache.pinot.segment.local.utils.ServerReloadJobStatusCache;
@@ -66,8 +63,6 @@ public class ControllerJobStatusResource {
   @GET
   @Path("/controllerJob/reloadStatus/{tableNameWithType}")
   @Produces(MediaType.APPLICATION_JSON)
-  @Authorize(targetType = TargetType.TABLE, paramName = "tableNameWithType",
-      action = Actions.Table.GET_CONTROLLER_JOBS)
   @ApiOperation(value = "Task status", notes = "Return the status of a given reload job")
   public String reloadJobStatus(@PathParam("tableNameWithType") String tableNameWithType,
       @QueryParam("reloadJobTimestamp") long reloadJobSubmissionTimestamp,

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/DebugResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/DebugResource.java
@@ -52,9 +52,6 @@ import org.apache.pinot.common.restlet.resources.SegmentConsumerInfo;
 import org.apache.pinot.common.restlet.resources.SegmentErrorInfo;
 import org.apache.pinot.common.restlet.resources.SegmentServerDebugInfo;
 import org.apache.pinot.common.utils.DatabaseUtils;
-import org.apache.pinot.core.auth.Actions;
-import org.apache.pinot.core.auth.Authorize;
-import org.apache.pinot.core.auth.TargetType;
 import org.apache.pinot.core.data.manager.offline.ImmutableSegmentDataManager;
 import org.apache.pinot.core.data.manager.realtime.RealtimeSegmentDataManager;
 import org.apache.pinot.core.data.manager.realtime.RealtimeSegmentMetadataUtils;
@@ -105,7 +102,6 @@ public class DebugResource {
   @GET
   @Path("tables/{tableName}")
   @Produces(MediaType.APPLICATION_JSON)
-  @Authorize(targetType = TargetType.TABLE, paramName = "tableName", action = Actions.Table.GET_DEBUG_INFO)
   @ApiOperation(value = "Get segments debug info for this table",
       notes = "This is a debug endpoint, and won't maintain backward compatibility")
   public List<SegmentServerDebugInfo> getSegmentsDebugInfo(
@@ -119,7 +115,6 @@ public class DebugResource {
   @GET
   @Path("segments/{tableName}/{segmentName}")
   @Produces(MediaType.APPLICATION_JSON)
-  @Authorize(targetType = TargetType.TABLE, paramName = "tableName", action = Actions.Table.GET_DEBUG_INFO)
   @ApiOperation(value = "Get segment debug info",
       notes = "This is a debug endpoint, and won't maintain backward compatibility")
   public SegmentServerDebugInfo getSegmentDebugInfo(
@@ -152,7 +147,6 @@ public class DebugResource {
   @GET
   @Path("threads/resourceUsage")
   @Produces(MediaType.APPLICATION_JSON)
-  @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.DEBUG_RESOURCE_USAGE)
   @ApiOperation(value = "Get current resource usage of threads",
       notes = "This is a debug endpoint, and won't maintain backward compatibility")
   public Collection<? extends ThreadResourceTracker> getThreadUsage() {
@@ -162,7 +156,6 @@ public class DebugResource {
   @GET
   @Path("queries/resourceUsage")
   @Produces(MediaType.APPLICATION_JSON)
-  @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.DEBUG_RESOURCE_USAGE)
   @ApiOperation(value = "Get current resource usage of queries in this service",
       notes = "This is a debug endpoint, and won't maintain backward compatibility")
   public Collection<? extends QueryResourceTracker> getQueryUsage() {
@@ -284,7 +277,6 @@ public class DebugResource {
    */
   @GET
   @Path("queryWorkloadCost/{workloadName}")
-  @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.DEBUG_RESOURCE_USAGE)
   @ApiOperation(value = "Get instance cost information for a specific workload")
   @ApiResponses(value = {
       @ApiResponse(code = 200, message = "Success"),
@@ -348,7 +340,6 @@ public class DebugResource {
    */
   @GET
   @Path("queryWorkloadCosts")
-  @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.DEBUG_RESOURCE_USAGE)
   @ApiOperation(value = "Get instance cost information for all workloads")
   @ApiResponses(value = {
       @ApiResponse(code = 200, message = "Success"),

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/InstanceResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/InstanceResource.java
@@ -49,9 +49,6 @@ import org.apache.pinot.common.restlet.resources.PrimaryKeyCountInfo;
 import org.apache.pinot.common.restlet.resources.ResourceUtils;
 import org.apache.pinot.common.utils.config.InstanceUtils;
 import org.apache.pinot.common.utils.helix.HelixHelper;
-import org.apache.pinot.core.auth.Actions;
-import org.apache.pinot.core.auth.Authorize;
-import org.apache.pinot.core.auth.TargetType;
 import org.apache.pinot.core.data.manager.InstanceDataManager;
 import org.apache.pinot.server.api.AdminApiApplication;
 import org.apache.pinot.server.starter.ServerInstance;
@@ -79,7 +76,6 @@ public class InstanceResource {
 
   @GET
   @Path("tags")
-  @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.GET_INSTANCE)
   @ApiOperation(value = "Tenant tags for current instance")
   @ApiResponses(value = {
       @ApiResponse(code = 200, message = "Success"), @ApiResponse(code = 500, message = "Internal server error")
@@ -100,7 +96,6 @@ public class InstanceResource {
    */
   @GET
   @Path("pools")
-  @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.GET_INSTANCE)
   @ApiOperation(value = "Tenant pools for current instance")
   @ApiResponses(value = {
       @ApiResponse(code = 200, message = "Success"), @ApiResponse(code = 500, message = "Internal server error")
@@ -118,7 +113,6 @@ public class InstanceResource {
   @GET
   @Produces(MediaType.APPLICATION_JSON)
   @Path("/diskUtilization")
-  @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.GET_INSTANCE)
   @ApiOperation(value = "Show disk utilization", notes = "Disk capacity and usage shown in bytes")
   @ApiResponses(value = {
       @ApiResponse(code = 200, message = "Success"),
@@ -139,7 +133,6 @@ public class InstanceResource {
   @GET
   @Produces(MediaType.APPLICATION_JSON)
   @Path("/primaryKeyCount")
-  @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.GET_INSTANCE)
   @ApiOperation(value = "Show number of primary keys", notes = "Total number of upsert / dedup primary keys")
   @ApiResponses(value = {
       @ApiResponse(code = 200, message = "Success"), @ApiResponse(code = 500, message = "Internal server error")

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/MmapDebugResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/MmapDebugResource.java
@@ -41,9 +41,6 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.apache.pinot.common.restlet.resources.ResourceUtils;
 import org.apache.pinot.common.utils.DatabaseUtils;
-import org.apache.pinot.core.auth.Actions;
-import org.apache.pinot.core.auth.Authorize;
-import org.apache.pinot.core.auth.TargetType;
 import org.apache.pinot.core.data.manager.InstanceDataManager;
 import org.apache.pinot.core.data.manager.realtime.RealtimeTableDataManager;
 import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
@@ -76,7 +73,6 @@ public class MmapDebugResource {
 
   @GET
   @Path("memory/offheap")
-  @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.DEBUG_RESOURCE_USAGE)
   @ApiOperation(value = "View current off-heap allocations", notes = "Lists all off-heap allocations and their "
       + "associated sizes")
   @ApiResponses(value = {@ApiResponse(code = 200, message = "Success")})
@@ -88,7 +84,6 @@ public class MmapDebugResource {
   @GET
   @Produces(MediaType.APPLICATION_JSON)
   @Path("/memory/offheap/table/{tableName}")
-  @Authorize(targetType = TargetType.TABLE, paramName = "tableName", action = Actions.Table.GET_SIZE)
   @ApiOperation(value = "Show off heap memory consumed by latest mutable segment",
       notes = "Returns off heap memory consumed by latest consuming segment of realtime table")
   @ApiResponses(value = {

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/PinotServerAppConfigs.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/PinotServerAppConfigs.java
@@ -31,9 +31,6 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import org.apache.pinot.common.utils.PinotAppConfigs;
-import org.apache.pinot.core.auth.Actions;
-import org.apache.pinot.core.auth.Authorize;
-import org.apache.pinot.core.auth.TargetType;
 import org.apache.pinot.server.api.AdminApiApplication;
 import org.apache.pinot.spi.env.PinotConfiguration;
 
@@ -57,7 +54,6 @@ public class PinotServerAppConfigs {
   @GET
   @Path("/appconfigs")
   @Produces(MediaType.APPLICATION_JSON)
-  @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.GET_APP_CONFIG)
   public String getAppConfigs() {
     PinotConfiguration pinotConfiguration =
         (PinotConfiguration) _application.getProperties().get(AdminApiApplication.PINOT_CONFIGURATION);

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/PinotServerLogger.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/PinotServerLogger.java
@@ -43,9 +43,6 @@ import javax.ws.rs.core.Response;
 import org.apache.pinot.common.utils.LoggerUtils;
 import org.apache.pinot.common.utils.log.DummyLogFileServer;
 import org.apache.pinot.common.utils.log.LogFileServer;
-import org.apache.pinot.core.auth.Actions;
-import org.apache.pinot.core.auth.Authorize;
-import org.apache.pinot.core.auth.TargetType;
 
 import static org.apache.pinot.spi.utils.CommonConstants.SWAGGER_AUTHORIZATION_KEY;
 
@@ -66,7 +63,6 @@ public class PinotServerLogger {
   @GET
   @Path("/loggers")
   @Produces(MediaType.APPLICATION_JSON)
-  @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.GET_LOGGER)
   @ApiOperation(value = "Get all the loggers", notes = "Return all the logger names")
   public List<String> getLoggers() {
     return LoggerUtils.getAllConfiguredLoggers();
@@ -75,7 +71,6 @@ public class PinotServerLogger {
   @GET
   @Path("/loggers/{loggerName}")
   @Produces(MediaType.APPLICATION_JSON)
-  @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.GET_LOGGER)
   @ApiOperation(value = "Get logger configs", notes = "Return logger info")
   public Map<String, String> getLogger(
       @ApiParam(value = "Logger name", required = true) @PathParam("loggerName") String loggerName) {
@@ -89,7 +84,6 @@ public class PinotServerLogger {
   @PUT
   @Path("/loggers/{loggerName}")
   @Produces(MediaType.APPLICATION_JSON)
-  @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.UPDATE_LOGGER)
   @ApiOperation(value = "Set logger level", notes = "Set logger level for a given logger")
   public Map<String, String> setLoggerLevel(@ApiParam(value = "Logger name") @PathParam("loggerName") String loggerName,
       @ApiParam(value = "Logger level") @QueryParam("level") String level) {
@@ -99,7 +93,6 @@ public class PinotServerLogger {
   @GET
   @Path("/loggers/files")
   @Produces(MediaType.APPLICATION_JSON)
-  @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.GET_LOG_FILE)
   @ApiOperation(value = "Get all local log files")
   public Set<String> getLocalLogFiles() {
     try {
@@ -115,7 +108,6 @@ public class PinotServerLogger {
   @GET
   @Path("/loggers/download")
   @Produces(MediaType.APPLICATION_OCTET_STREAM)
-  @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.GET_LOG_FILE)
   @ApiOperation(value = "Download a log file")
   public Response downloadLogFile(
       @ApiParam(value = "Log file path", required = true) @QueryParam("filePath") String filePath) {

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/QueryResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/QueryResource.java
@@ -38,9 +38,6 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import org.apache.pinot.core.auth.Actions;
-import org.apache.pinot.core.auth.Authorize;
-import org.apache.pinot.core.auth.TargetType;
 import org.apache.pinot.core.query.utils.QueryIdUtils;
 import org.apache.pinot.core.transport.InstanceRequestHandler;
 import org.apache.pinot.server.starter.ServerInstance;
@@ -63,7 +60,6 @@ public class QueryResource {
   @DELETE
   @Path("/query/{queryId}")
   @Produces(MediaType.APPLICATION_JSON)
-  @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.CANCEL_QUERY)
   @ApiOperation(value = "Cancel a query running on the server as identified by the queryId", notes = "No effect if "
       + "no query exists for the given queryId. Query may continue to run for a short while after calling cancel as "
       + "it's done in a non-blocking manner. The cancel API can be called multiple times.")
@@ -101,7 +97,6 @@ public class QueryResource {
   @GET
   @Path("/queries/id")
   @Produces(MediaType.APPLICATION_JSON)
-  @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.GET_RUNNING_QUERY)
   @ApiOperation(value = "Get queryIds of running queries on the server", notes = "QueryIds are in the format of "
       + "<brokerId>_<requestId>_(O|R)")
   @ApiResponses(value = {

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/ReingestionResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/ReingestionResource.java
@@ -56,9 +56,6 @@ import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.metrics.ServerMeter;
 import org.apache.pinot.common.utils.LLCSegmentName;
 import org.apache.pinot.common.utils.URIUtils;
-import org.apache.pinot.core.auth.Actions;
-import org.apache.pinot.core.auth.Authorize;
-import org.apache.pinot.core.auth.TargetType;
 import org.apache.pinot.core.data.manager.realtime.RealtimeTableDataManager;
 import org.apache.pinot.segment.local.realtime.writer.StatelessRealtimeSegmentWriter;
 import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
@@ -137,7 +134,6 @@ public class ReingestionResource {
   @GET
   @Path("/reingestSegment/jobs")
   @Produces(MediaType.APPLICATION_JSON)
-  @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.GET_TASK)
   @ApiOperation("Get all running re-ingestion jobs along with job IDs")
   public Response getAllRunningReingestionJobs() {
     // Filter only the jobs still marked as running
@@ -148,7 +144,6 @@ public class ReingestionResource {
   @POST
   @Path("/reingestSegment/{segmentName}")
   @Produces(MediaType.APPLICATION_JSON)
-  @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.UPLOAD_SEGMENT)
   @ApiOperation(value = "Re-ingest segment asynchronously", notes = "Returns a jobId immediately; ingestion runs in "
       + "background.")
   @ApiResponses(value = {

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TableSizeResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TableSizeResource.java
@@ -45,9 +45,6 @@ import org.apache.pinot.common.restlet.resources.ResourceUtils;
 import org.apache.pinot.common.restlet.resources.SegmentSizeInfo;
 import org.apache.pinot.common.restlet.resources.TableSizeInfo;
 import org.apache.pinot.common.utils.DatabaseUtils;
-import org.apache.pinot.core.auth.Actions;
-import org.apache.pinot.core.auth.Authorize;
-import org.apache.pinot.core.auth.TargetType;
 import org.apache.pinot.core.data.manager.InstanceDataManager;
 import org.apache.pinot.core.data.manager.offline.ImmutableSegmentDataManager;
 import org.apache.pinot.segment.local.data.manager.SegmentDataManager;
@@ -80,7 +77,6 @@ public class TableSizeResource {
   @GET
   @Produces(MediaType.APPLICATION_JSON)
   @Path("/tables/{tableName}/size")
-  @Authorize(targetType = TargetType.TABLE, paramName = "tableName", action = Actions.Table.GET_SIZE)
   @ApiOperation(value = "Show table storage size", notes = "Lists size of all the segments of the table")
   @ApiResponses(value = {
       @ApiResponse(code = 200, message = "Success"),
@@ -138,7 +134,6 @@ public class TableSizeResource {
   @GET
   @Produces(MediaType.APPLICATION_JSON)
   @Path("/table/{tableName}/size")
-  @Authorize(targetType = TargetType.TABLE, paramName = "tableName", action = Actions.Table.GET_SIZE)
   @ApiOperation(value = "Show table storage size", notes = "Lists size of all the segments of the table")
   @ApiResponses(value = {
       @ApiResponse(code = 200, message = "Success"),

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TableTierResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TableTierResource.java
@@ -47,9 +47,6 @@ import org.apache.pinot.common.restlet.resources.ResourceUtils;
 import org.apache.pinot.common.restlet.resources.TableTierInfo;
 import org.apache.pinot.common.utils.DatabaseUtils;
 import org.apache.pinot.common.utils.URIUtils;
-import org.apache.pinot.core.auth.Actions;
-import org.apache.pinot.core.auth.Authorize;
-import org.apache.pinot.core.auth.TargetType;
 import org.apache.pinot.core.data.manager.InstanceDataManager;
 import org.apache.pinot.core.data.manager.offline.ImmutableSegmentDataManager;
 import org.apache.pinot.segment.local.data.manager.SegmentDataManager;
@@ -82,7 +79,6 @@ public class TableTierResource {
   @GET
   @Produces(MediaType.APPLICATION_JSON)
   @Path("/tables/{tableNameWithType}/tiers")
-  @Authorize(targetType = TargetType.TABLE, paramName = "tableNameWithType", action = Actions.Table.GET_STORAGE_TIER)
   @ApiOperation(value = "Get storage tiers of immutable segments of the given table", notes = "Get storage tiers of "
       + "immutable segments of the given table")
   @ApiResponses(value = {
@@ -125,7 +121,6 @@ public class TableTierResource {
   @GET
   @Produces(MediaType.APPLICATION_JSON)
   @Path("/segments/{tableNameWithType}/{segmentName}/tiers")
-  @Authorize(targetType = TargetType.TABLE, paramName = "tableNameWithType", action = Actions.Table.GET_STORAGE_TIER)
   @ApiOperation(value = "Get storage tiers of the immutable segment of the given table", notes = "Get storage tiers "
       + "of the immutable segment of the given table")
   @ApiResponses(value = {

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
@@ -153,7 +153,6 @@ public class TablesResource {
   @GET
   @Path("/tables")
   @Produces(MediaType.APPLICATION_JSON)
-  @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.GET_TABLE)
   //swagger annotations
   @ApiOperation(value = "List tables", notes = "List all the tables on this server")
   @ApiResponses(value = {
@@ -169,7 +168,6 @@ public class TablesResource {
   @GET
   @Path("/tables/{tableName}/segments")
   @Produces(MediaType.APPLICATION_JSON)
-  @Authorize(targetType = TargetType.TABLE, paramName = "tableName", action = Actions.Table.GET_SEGMENT)
   @ApiOperation(value = "List table segments", notes = "List segments of table hosted on this server")
   @ApiResponses(value = {
       @ApiResponse(code = 200, message = "Success", response = TableSegments.class),
@@ -197,7 +195,6 @@ public class TablesResource {
   @GET
   @Produces(MediaType.APPLICATION_JSON)
   @Path("/tables/{tableName}/metadata")
-  @Authorize(targetType = TargetType.TABLE, paramName = "tableName", action = Actions.Table.GET_METADATA)
   @ApiOperation(value = "List metadata for all segments of a given table", notes = "List segments metadata of table "
       + "hosted on this server")
   @ApiResponses(value = {
@@ -322,7 +319,6 @@ public class TablesResource {
   @GET
   @Path("/tables/{tableName}/indexes")
   @Produces(MediaType.APPLICATION_JSON)
-  @Authorize(targetType = TargetType.TABLE, paramName = "tableName", action = Actions.Table.GET_METADATA)
   @ApiOperation(value = "Provide index metadata", notes = "Provide index details for the table")
   @ApiResponses(value = {
       @ApiResponse(code = 200, message = "Success"),
@@ -368,7 +364,6 @@ public class TablesResource {
   @GET
   @Path("/tables/{tableName}/segments/{segmentName}/metadata")
   @Produces(MediaType.APPLICATION_JSON)
-  @Authorize(targetType = TargetType.TABLE, paramName = "tableName", action = Actions.Table.GET_METADATA)
   @ApiOperation(value = "Provide segment metadata", notes = "Provide segments metadata for the segment on server")
   @ApiResponses(value = {
       @ApiResponse(code = 200, message = "Success"),
@@ -405,7 +400,6 @@ public class TablesResource {
   @GET
   @Path("/tables/{tableName}/segments/metadata")
   @Produces(MediaType.APPLICATION_JSON)
-  @Authorize(targetType = TargetType.TABLE, paramName = "tableName", action = Actions.Table.GET_METADATA)
   @ApiOperation(value = "Provide segments metadata", notes = "Provide segments metadata for the segments on server")
   @ApiResponses(value = {
       @ApiResponse(code = 200, message = "Success"),
@@ -452,7 +446,6 @@ public class TablesResource {
   @GET
   @Path("/tables/{tableName}/segments/crc")
   @Produces(MediaType.APPLICATION_JSON)
-  @Authorize(targetType = TargetType.TABLE, paramName = "tableName", action = Actions.Table.GET_METADATA)
   @ApiOperation(value = "Provide segment crc information", notes = "Provide crc information for the segments on server")
   @ApiResponses(value = {
       @ApiResponse(code = 200, message = "Success"),
@@ -541,7 +534,6 @@ public class TablesResource {
   @GET
   @Produces(MediaType.APPLICATION_JSON)
   @Path("/segments/{tableNameWithType}/{segmentName}/validDocIdsBitmap")
-  @Authorize(targetType = TargetType.TABLE, paramName = "tableNameWithType", action = Actions.Table.GET_SEGMENT)
   @ApiOperation(value = "Download validDocIds bitmap for an REALTIME immutable segment", notes =
       "Download validDocIds for " + "an immutable segment in bitmap format.")
   public ValidDocIdsBitmapResponse downloadValidDocIdsBitmap(
@@ -604,7 +596,6 @@ public class TablesResource {
   @GET
   @Produces(MediaType.APPLICATION_OCTET_STREAM)
   @Path("/segments/{tableNameWithType}/{segmentName}/validDocIds")
-  @Authorize(targetType = TargetType.TABLE, paramName = "tableNameWithType", action = Actions.Table.GET_SEGMENT)
   @ApiOperation(value = "Download validDocIds for an REALTIME immutable segment", notes = "Download validDocIds for "
       + "an immutable segment in bitmap format.")
   public Response downloadValidDocIds(
@@ -661,7 +652,6 @@ public class TablesResource {
   @GET
   @Path("/tables/{tableNameWithType}/validDocIdMetadata")
   @Produces(MediaType.APPLICATION_JSON)
-  @Authorize(targetType = TargetType.TABLE, paramName = "tableNameWithType", action = Actions.Table.GET_METADATA)
   @ApiOperation(value = "Provides segment validDocId metadata", notes = "Provides segment validDocId metadata")
   @ApiResponses(value = {
       @ApiResponse(code = 200, message = "Success"),
@@ -682,7 +672,6 @@ public class TablesResource {
   @POST
   @Path("/tables/{tableNameWithType}/validDocIdsMetadata")
   @Produces(MediaType.APPLICATION_JSON)
-  @Authorize(targetType = TargetType.TABLE, paramName = "tableNameWithType", action = Actions.Table.GET_METADATA)
   @ApiOperation(value = "Provides segment validDocIds metadata", notes = "Provides segment validDocIds metadata")
   @ApiResponses(value = {
       @ApiResponse(code = 200, message = "Success"),
@@ -841,7 +830,6 @@ public class TablesResource {
   @POST
   @Path("/segments/{realtimeTableName}/{segmentName}/upload")
   @Produces(MediaType.APPLICATION_JSON)
-  @Authorize(targetType = TargetType.TABLE, paramName = "realtimeTableName", action = Actions.Table.UPLOAD_SEGMENT)
   @ApiOperation(value = "Upload a low level consumer segment to segment store and return the segment download url",
       notes = "Upload a low level consumer segment to segment store and return the segment download url")
   @ApiResponses(value = {
@@ -915,8 +903,6 @@ public class TablesResource {
   @POST
   @Path("/segments/{realtimeTableNameWithType}/{segmentName}/uploadLLCSegment")
   @Produces(MediaType.APPLICATION_JSON)
-  @Authorize(targetType = TargetType.TABLE, paramName = "realtimeTableNameWithType",
-      action = Actions.Table.UPLOAD_SEGMENT)
   @ApiOperation(value = "Upload a low level consumer segment to segment store and return the segment download url,"
       + "crc and other segment metadata",
       notes = "Upload a low level consumer segment to segment store and return the segment download url, crc, data crc "
@@ -994,7 +980,6 @@ public class TablesResource {
   @POST
   @Path("/segments/{realtimeTableName}/{segmentName}/uploadCommittedSegment")
   @Produces(MediaType.APPLICATION_JSON)
-  @Authorize(targetType = TargetType.TABLE, paramName = "realtimeTableName", action = Actions.Table.UPLOAD_SEGMENT)
   @ApiOperation(value = "Upload a real-time committed segment to segment store and return the segment ZK metadata",
       notes = "Upload a real-time committed segment to segment store and return the segment ZK metadata")
   @ApiResponses(value = {
@@ -1103,8 +1088,6 @@ public class TablesResource {
   @GET
   @Path("tables/{realtimeTableName}/consumingSegmentsInfo")
   @Produces(MediaType.APPLICATION_JSON)
-  @Authorize(targetType = TargetType.TABLE, paramName = "realtimeTableName",
-      action = Actions.Table.GET_CONSUMING_SEGMENTS)
   @ApiOperation(value = "Get the info for consumers of this REALTIME table", notes =
       "Get consumers info from the table data manager. Note that the partitionToOffsetMap has been deprecated "
           + "and will be removed in the next release. The info is now embedded within each partition's state as "
@@ -1165,7 +1148,6 @@ public class TablesResource {
   @GET
   @Path("tables/{tableNameWithType}/allSegmentsLoaded")
   @Produces(MediaType.APPLICATION_JSON)
-  @Authorize(targetType = TargetType.TABLE, paramName = "tableNameWithType", action = Actions.Table.GET_SEGMENT_STATUS)
   @ApiOperation(value = "Validates if the ideal state matches with the segment state on this server", notes =
       "Validates if the ideal state matches with the segment state on this server")
   public TableSegmentValidationInfo validateTableSegmentState(
@@ -1233,7 +1215,6 @@ public class TablesResource {
   @GET
   @Path("/tables/{tableName}/segments/needReload")
   @Produces(MediaType.APPLICATION_JSON)
-  @Authorize(targetType = TargetType.TABLE, paramName = "tableName", action = Actions.Table.GET_SEGMENT)
   @ApiOperation(value = "Checks if reload is needed on any segment", notes = "Returns true if reload is required on"
       + " any segment in this server")
   @ApiResponses(value = {
@@ -1258,7 +1239,6 @@ public class TablesResource {
   @GET
   @Path("/tables/{tableName}/segments/isStale")
   @Produces(MediaType.APPLICATION_JSON)
-  @Authorize(targetType = TargetType.TABLE, paramName = "tableName", action = Actions.Table.GET_SEGMENT)
   @ApiOperation(value = "Get the list of segments that are stale or deviated from table config.",
       notes = "Get the list of segments that are stale or deviated from table config")
   @ApiResponses(value = {
@@ -1280,7 +1260,6 @@ public class TablesResource {
   @DELETE
   @Path("/tables/{tableName}/ingestionMetrics")
   @Produces(MediaType.APPLICATION_JSON)
-  @Authorize(targetType = TargetType.TABLE, paramName = "tableName", action = Actions.Table.DELETE_INGESTION_METRICS)
   @ApiOperation(value = "Remove ingestion metrics for partition(s)", notes = "Removes ingestion-related metrics for "
       + "the given table. If no partitionId is provided, metrics for all partitions hosted by this server will be "
       + "removed.")


### PR DESCRIPTION
This reverts #17725 which added `@Authorize` annotations to server and minion API endpoints.

The annotations are causing issues in environments where the authorization infrastructure is not fully configured, blocking legitimate API access. Reverting to restore availability while we work on a proper fix.

Made with [Cursor](https://cursor.com)