### PR TITLE
revert removal of query optimization after time boundary for hybrid tables

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseSingleStageBrokerRequestHandler.java
@@ -596,6 +596,7 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
       attachTimeBoundary(offlinePinotQuery, timeBoundaryInfo, true);
       handleExpressionOverride(offlinePinotQuery, _tableCache.getExpressionOverrideMap(offlineTableName));
       handleTimestampIndexOverride(offlinePinotQuery, offlineTableConfig);
+      _queryOptimizer.optimize(offlinePinotQuery, schema);
       offlineBrokerRequest = CalciteSqlCompiler.convertToBrokerRequest(offlinePinotQuery);
 
       PinotQuery realtimePinotQuery = serverPinotQuery.deepCopy();
@@ -603,6 +604,7 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
       attachTimeBoundary(realtimePinotQuery, timeBoundaryInfo, false);
       handleExpressionOverride(realtimePinotQuery, _tableCache.getExpressionOverrideMap(realtimeTableName));
       handleTimestampIndexOverride(realtimePinotQuery, realtimeTableConfig);
+      _queryOptimizer.optimize(offlinePinotQuery, schema);
       realtimeBrokerRequest = CalciteSqlCompiler.convertToBrokerRequest(realtimePinotQuery);
 
       requestContext.setFanoutType(RequestContext.FanoutType.HYBRID);
@@ -613,6 +615,7 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
       setTableName(serverBrokerRequest, offlineTableName);
       handleExpressionOverride(serverPinotQuery, _tableCache.getExpressionOverrideMap(offlineTableName));
       handleTimestampIndexOverride(serverPinotQuery, offlineTableConfig);
+      _queryOptimizer.optimize(offlinePinotQuery, schema);
       offlineBrokerRequest = serverBrokerRequest;
 
       requestContext.setFanoutType(RequestContext.FanoutType.OFFLINE);
@@ -622,6 +625,7 @@ public abstract class BaseSingleStageBrokerRequestHandler extends BaseBrokerRequ
       setTableName(serverBrokerRequest, realtimeTableName);
       handleExpressionOverride(serverPinotQuery, _tableCache.getExpressionOverrideMap(realtimeTableName));
       handleTimestampIndexOverride(serverPinotQuery, realtimeTableConfig);
+      _queryOptimizer.optimize(offlinePinotQuery, schema);
       realtimeBrokerRequest = serverBrokerRequest;
 
       requestContext.setFanoutType(RequestContext.FanoutType.REALTIME);


### PR DESCRIPTION
this addresses https://github.com/apache/pinot/issues/17657. we narrowed down the server latency regression being introduced in https://github.com/apache/pinot/pull/16991 where calls to the query optimizer were removed in the hybrid table path leading to more expensive queries being sent to servers. this PR reverts that change.

claude helped us with the analysis, but effectively the time boundary time filter is no longer being optimized so servers see an additional wider time filter. we primarily see this issue during segment push.

impact of change:
```
OLD (offline sub-query) — optimizer sees everything: 
AND                          ← flat, 2 children 
├── EQUALS(key, '1234') 
└── RANGE(created_15min, [1388563200000 .. 1772265600000])

NEW (offline sub-query) — optimizer never sees time boundary: 
AND                          ← nested, 2 children 
├── AND                    ← inner AND from original query 
│     ├── BETWEEN(created_15min, 1388563200000, 1772351100000) 
│     ├── EQUALS(key, '1234') 
└── LESS_THAN_OR_EQUAL(created_15min, "1772265600000")  ← STRING literal

The FlattenAndOrFilterOptimizer would normally collapse AND(AND(...), X) into a single flat AND(...), but it ran before the time boundary was attached, so the nesting persists. The server's filter evaluation must now traverse an extra AND node on every row.
```

with this revert in place, we no longer see the regression. you can that we no longer see server latency spikes after the brokers were upgraded around 17:00 UTC below. this specific change didn't cause 

<img width="1806" height="414" alt="Screenshot 2026-02-23 at 3 47 42 PM" src="https://github.com/user-attachments/assets/e997b592-37fb-4456-8d24-bc49c42c103c" />

cc @jadami10 @yashmayya @suvodeep-pyne