### PR TITLE
Adaptive merge rollup segment sizing

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
@@ -128,12 +128,10 @@ public class MinionConstants {
     // Segment config
     public static final String MAX_NUM_RECORDS_PER_TASK_KEY = "maxNumRecordsPerTask";
     public static final String MAX_NUM_RECORDS_PER_SEGMENT_KEY = "maxNumRecordsPerSegment";
-    /**
-     * maximum total size in bytes of input segments to process in a single task.
-     * When set, this takes precedence over MAX_NUM_RECORDS_PER_TASK_KEY for grouping segments into tasks.
-     * This provides more predictable memory usage and output sizes, especially for tables with variable
-     * row sizes (e.g., tables with theta sketches, HLL, or other large column types).
-     */
+    /// maximum total size in bytes of input segments to process in a single task.
+    /// When set, this takes precedence over MAX_NUM_RECORDS_PER_TASK_KEY for grouping segments into tasks.
+    /// This provides more predictable memory usage and output sizes, especially for tables with variable
+    /// row sizes (e.g., tables with theta sketches, HLL, or other large column types).
     public static final String MAX_SEGMENT_SIZE_BYTES_PER_TASK_KEY = "maxSegmentSizeBytesPerTask";
 
     // See AdaptiveSizeBasedWriter for documentation of these configs

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
@@ -128,6 +128,13 @@ public class MinionConstants {
     // Segment config
     public static final String MAX_NUM_RECORDS_PER_TASK_KEY = "maxNumRecordsPerTask";
     public static final String MAX_NUM_RECORDS_PER_SEGMENT_KEY = "maxNumRecordsPerSegment";
+    /**
+     * maximum total size in bytes of input segments to process in a single task.
+     * When set, this takes precedence over MAX_NUM_RECORDS_PER_TASK_KEY for grouping segments into tasks.
+     * This provides more predictable memory usage and output sizes, especially for tables with variable
+     * row sizes (e.g., tables with theta sketches, HLL, or other large column types).
+     */
+    public static final String MAX_SEGMENT_SIZE_BYTES_PER_TASK_KEY = "maxSegmentSizeBytesPerTask";
 
     // See AdaptiveSizeBasedWriter for documentation of these configs
     public static final String SEGMENT_MAPPER_FILE_SIZE_IN_BYTES = "segmentMapperFileSizeThresholdInBytes";

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
@@ -170,6 +170,11 @@ public class MinionConstants {
             DISTINCTCOUNTRAWHLLPLUS, DISTINCTCOUNTCPCSKETCH, DISTINCTCOUNTRAWCPCSKETCH, DISTINCTCOUNTULL,
             DISTINCTCOUNTRAWULL, PERCENTILEKLL, PERCENTILERAWKLL, PERCENTILETDIGEST, PERCENTILERAWTDIGEST,
             FIRSTWITHTIME, LASTWITHTIME);
+    // Adaptive segment sizing configuration (specific to MergeRollupTask)
+    public static final String DESIRED_SEGMENT_SIZE_BYTES_KEY = "desiredSegmentSizeBytes";
+    public static final String SEGMENT_SIZING_STRATEGY_KEY = "segmentSizingStrategy";
+    public static final String SIZING_PERCENTILE_KEY = "sizingPercentile";
+    public static final String SIZING_LEARNING_RATE_KEY = "sizingLearningRate";
   }
 
   /// Creates segments for the OFFLINE table, using completed segments from the corresponding REALTIME table

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/framework/AdaptiveSegmentNumRowProvider.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/framework/AdaptiveSegmentNumRowProvider.java
@@ -1,0 +1,226 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.segment.processing.framework;
+
+import com.google.common.base.Preconditions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Adaptive segment num row provider that dynamically adjusts the number of rows per segment
+ * based on actual segment sizes observed during segment generation. This provider uses an
+ * Exponential Moving Average (EMA) to learn from each segment's actual size and continuously
+ * refine the estimate of bytes per row.
+ *
+ * <p>This is particularly useful for tables with variable-sized columns (e.g., Theta sketches,
+ * large text fields, or binary data) where the number of rows alone is not a reliable indicator
+ * of segment size.</p>
+ *
+ * <h3>Algorithm:</h3>
+ * <ol>
+ *   <li>Starts with a conservative initial estimate of bytes per row</li>
+ *   <li>After each segment is created, observes the actual segment size and row count</li>
+ *   <li>Updates the bytes-per-row estimate using EMA:
+ *       <code>estimate = α * measured + (1-α) * estimate</code></li>
+ *   <li>Calculates the next segment's row count as:
+ *       <code>desiredSegmentSize / estimatedBytesPerRow</code></li>
+ *   <li>Applies the configured maximum row limit as a ceiling</li>
+ * </ol>
+ *
+ * <h3>Configuration:</h3>
+ * <ul>
+ *   <li><b>desiredSegmentSizeBytes:</b> Target segment size in bytes (e.g., 200MB)</li>
+ *   <li><b>maxNumRecordsPerSegment:</b> Hard ceiling on rows per segment (safety limit)</li>
+ *   <li><b>learningRate:</b> EMA alpha parameter (0-1); higher = faster adaptation to changes</li>
+ *   <li><b>initialBytesPerRowEstimate:</b> Conservative starting estimate</li>
+ * </ul>
+ *
+ * <h3>Example Configuration:</h3>
+ * <pre>
+ * {
+ *   "desiredSegmentSizeBytes": "209715200",  // 200MB
+ *   "maxNumRecordsPerSegment": "2000000",    // 2M rows ceiling
+ *   "segmentSizingStrategy": "ADAPTIVE"
+ * }
+ * </pre>
+ *
+ * <h3>Thread Safety:</h3>
+ * This class is NOT thread-safe. It should be used by a single thread during segment processing.
+ *
+ * @see PercentileAdaptiveSegmentNumRowProvider for handling heterogeneous data with high variance
+ */
+public class AdaptiveSegmentNumRowProvider implements SegmentNumRowProvider {
+  private static final Logger LOGGER = LoggerFactory.getLogger(AdaptiveSegmentNumRowProvider.class);
+
+  // Default initial estimate: 5KB per row (conservative for tables with binary data)
+  private static final double DEFAULT_INITIAL_BYTES_PER_ROW = 5000.0;
+
+  // Default learning rate for EMA (0.3 = 30% weight to new observation, 70% to history)
+  private static final double DEFAULT_LEARNING_RATE = 0.3;
+
+  // Minimum rows per segment to avoid degenerate cases
+  private static final int MIN_ROWS_PER_SEGMENT = 1;
+
+  private final long _desiredSegmentSizeBytes;
+  private final int _maxNumRecordsPerSegment;
+  private final double _learningRate;
+
+  private double _estimatedBytesPerRow;
+  private int _currentRowCount;
+  private int _segmentsProcessed;
+  private long _totalBytesProcessed;
+  private long _totalRowsProcessed;
+
+  /**
+   * Creates an AdaptiveSegmentNumRowProvider with default learning rate and initial estimate.
+   *
+   * @param desiredSegmentSizeBytes target segment size in bytes (must be positive)
+   * @param maxNumRecordsPerSegment maximum rows per segment (must be positive)
+   */
+  public AdaptiveSegmentNumRowProvider(long desiredSegmentSizeBytes, int maxNumRecordsPerSegment) {
+    this(desiredSegmentSizeBytes, maxNumRecordsPerSegment, DEFAULT_LEARNING_RATE, DEFAULT_INITIAL_BYTES_PER_ROW);
+  }
+
+  /**
+   * Creates an AdaptiveSegmentNumRowProvider with custom parameters.
+   *
+   * @param desiredSegmentSizeBytes target segment size in bytes (must be positive)
+   * @param maxNumRecordsPerSegment maximum rows per segment (must be positive)
+   * @param learningRate EMA alpha parameter (0.0 to 1.0); higher values adapt faster
+   * @param initialBytesPerRowEstimate starting estimate of bytes per row (must be positive)
+   */
+  public AdaptiveSegmentNumRowProvider(long desiredSegmentSizeBytes, int maxNumRecordsPerSegment,
+      double learningRate, double initialBytesPerRowEstimate) {
+    Preconditions.checkArgument(desiredSegmentSizeBytes > 0,
+        "Desired segment size must be positive, got: %s", desiredSegmentSizeBytes);
+    Preconditions.checkArgument(maxNumRecordsPerSegment > 0,
+        "Max records per segment must be positive, got: %s", maxNumRecordsPerSegment);
+    Preconditions.checkArgument(learningRate > 0.0 && learningRate <= 1.0,
+        "Learning rate must be in (0.0, 1.0], got: %s", learningRate);
+    Preconditions.checkArgument(initialBytesPerRowEstimate > 0,
+        "Initial bytes per row estimate must be positive, got: %s", initialBytesPerRowEstimate);
+
+    _desiredSegmentSizeBytes = desiredSegmentSizeBytes;
+    _maxNumRecordsPerSegment = maxNumRecordsPerSegment;
+    _learningRate = learningRate;
+    _estimatedBytesPerRow = initialBytesPerRowEstimate;
+    _currentRowCount = calculateRowCount();
+    _segmentsProcessed = 0;
+    _totalBytesProcessed = 0;
+    _totalRowsProcessed = 0;
+
+    LOGGER.info("Initialized AdaptiveSegmentNumRowProvider with desiredSegmentSize={}MB, "
+            + "maxRecordsPerSegment={}, learningRate={}, initialBytesPerRow={}",
+        desiredSegmentSizeBytes / (1024 * 1024), maxNumRecordsPerSegment, learningRate,
+        initialBytesPerRowEstimate);
+  }
+
+  @Override
+  public int getNumRows() {
+    return _currentRowCount;
+  }
+
+  @Override
+  public void updateSegmentInfo(int actualNumRows, long actualSegmentSize) {
+    if (actualNumRows <= 0 || actualSegmentSize <= 0) {
+      LOGGER.warn("Received invalid segment info: numRows={}, segmentSize={}. Skipping update.",
+          actualNumRows, actualSegmentSize);
+      return;
+    }
+
+    // Calculate measured bytes per row for this segment
+    double measuredBytesPerRow = (double) actualSegmentSize / actualNumRows;
+
+    // Update estimate using Exponential Moving Average
+    double previousEstimate = _estimatedBytesPerRow;
+    _estimatedBytesPerRow = (_learningRate * measuredBytesPerRow)
+        + ((1.0 - _learningRate) * _estimatedBytesPerRow);
+
+    // Update statistics
+    _segmentsProcessed++;
+    _totalBytesProcessed += actualSegmentSize;
+    _totalRowsProcessed += actualNumRows;
+
+    // Recalculate row count for next segment
+    int previousRowCount = _currentRowCount;
+    _currentRowCount = calculateRowCount();
+
+    LOGGER.info("Segment {} processed: actualRows={}, actualSize={}MB, measuredBytesPerRow={}, "
+            + "previousEstimate={}, newEstimate={}, previousRowCount={}, newRowCount={}",
+        _segmentsProcessed, actualNumRows, actualSegmentSize / (1024 * 1024),
+        String.format("%.2f", measuredBytesPerRow), String.format("%.2f", previousEstimate),
+        String.format("%.2f", _estimatedBytesPerRow), previousRowCount, _currentRowCount);
+  }
+
+  /**
+   * Calculates the number of rows for the next segment based on current estimate.
+   *
+   * @return number of rows, guaranteed to be between MIN_ROWS_PER_SEGMENT and maxNumRecordsPerSegment
+   */
+  private int calculateRowCount() {
+    int calculatedRows = (int) (_desiredSegmentSizeBytes / _estimatedBytesPerRow);
+
+    // Apply bounds: at least MIN_ROWS_PER_SEGMENT, at most maxNumRecordsPerSegment
+    int boundedRows = Math.max(MIN_ROWS_PER_SEGMENT,
+        Math.min(_maxNumRecordsPerSegment, calculatedRows));
+
+    return boundedRows;
+  }
+
+  /**
+   * Gets the current estimated bytes per row.
+   *
+   * @return current estimate of bytes per row
+   */
+  public double getEstimatedBytesPerRow() {
+    return _estimatedBytesPerRow;
+  }
+
+  /**
+   * Gets the number of segments processed so far.
+   *
+   * @return segment count
+   */
+  public int getSegmentsProcessed() {
+    return _segmentsProcessed;
+  }
+
+  /**
+   * Gets the overall average bytes per row across all processed segments.
+   *
+   * @return average bytes per row, or 0 if no segments processed
+   */
+  public double getOverallAverageBytesPerRow() {
+    return _totalRowsProcessed > 0 ? (double) _totalBytesProcessed / _totalRowsProcessed : 0.0;
+  }
+
+  /**
+   * Gets statistics about the adaptation process.
+   *
+   * @return human-readable statistics string
+   */
+  public String getStatistics() {
+    return String.format(
+        "AdaptiveSegmentNumRowProvider Stats: segments=%d, currentEstimate=%.2f bytes/row, "
+            + "overallAverage=%.2f bytes/row, currentRowCount=%d, totalRowsProcessed=%d, totalBytesProcessed=%dMB",
+        _segmentsProcessed, _estimatedBytesPerRow, getOverallAverageBytesPerRow(),
+        _currentRowCount, _totalRowsProcessed, _totalBytesProcessed / (1024 * 1024));
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/framework/AdaptiveSegmentNumRowProvider.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/framework/AdaptiveSegmentNumRowProvider.java
@@ -23,49 +23,47 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
-/**
- * Adaptive segment num row provider that dynamically adjusts the number of rows per segment
- * based on actual segment sizes observed during segment generation. This provider uses an
- * Exponential Moving Average (EMA) to learn from each segment's actual size and continuously
- * refine the estimate of bytes per row.
- *
- * <p>This is particularly useful for tables with variable-sized columns (e.g., Theta sketches,
- * large text fields, or binary data) where the number of rows alone is not a reliable indicator
- * of segment size.</p>
- *
- * <h3>Algorithm:</h3>
- * <ol>
- *   <li>Starts with a conservative initial estimate of bytes per row</li>
- *   <li>After each segment is created, observes the actual segment size and row count</li>
- *   <li>Updates the bytes-per-row estimate using EMA:
- *       <code>estimate = α * measured + (1-α) * estimate</code></li>
- *   <li>Calculates the next segment's row count as:
- *       <code>desiredSegmentSize / estimatedBytesPerRow</code></li>
- *   <li>Applies the configured maximum row limit as a ceiling</li>
- * </ol>
- *
- * <h3>Configuration:</h3>
- * <ul>
- *   <li><b>desiredSegmentSizeBytes:</b> Target segment size in bytes (e.g., 200MB)</li>
- *   <li><b>maxNumRecordsPerSegment:</b> Hard ceiling on rows per segment (safety limit)</li>
- *   <li><b>learningRate:</b> EMA alpha parameter (0-1); higher = faster adaptation to changes</li>
- *   <li><b>initialBytesPerRowEstimate:</b> Conservative starting estimate</li>
- * </ul>
- *
- * <h3>Example Configuration:</h3>
- * <pre>
- * {
- *   "desiredSegmentSizeBytes": "209715200",  // 200MB
- *   "maxNumRecordsPerSegment": "2000000",    // 2M rows ceiling
- *   "segmentSizingStrategy": "ADAPTIVE"
- * }
- * </pre>
- *
- * <h3>Thread Safety:</h3>
- * This class is NOT thread-safe. It should be used by a single thread during segment processing.
- *
- * @see PercentileAdaptiveSegmentNumRowProvider for handling heterogeneous data with high variance
- */
+/// Adaptive segment num row provider that dynamically adjusts the number of rows per segment
+/// based on actual segment sizes observed during segment generation. This provider uses an
+/// Exponential Moving Average (EMA) to learn from each segment's actual size and continuously
+/// refine the estimate of bytes per row.
+///
+/// <p>This is particularly useful for tables with variable-sized columns (e.g., Theta sketches,
+/// large text fields, or binary data) where the number of rows alone is not a reliable indicator
+/// of segment size.</p>
+///
+/// <h3>Algorithm:</h3>
+/// <ol>
+///   <li>Starts with a conservative initial estimate of bytes per row</li>
+///   <li>After each segment is created, observes the actual segment size and row count</li>
+///   <li>Updates the bytes-per-row estimate using EMA:
+///       <code>estimate = α * measured + (1-α) * estimate</code></li>
+///   <li>Calculates the next segment's row count as:
+///       <code>desiredSegmentSize / estimatedBytesPerRow</code></li>
+///   <li>Applies the configured maximum row limit as a ceiling</li>
+/// </ol>
+///
+/// <h3>Configuration:</h3>
+/// <ul>
+///   <li><b>desiredSegmentSizeBytes:</b> Target segment size in bytes (e.g., 200MB)</li>
+///   <li><b>maxNumRecordsPerSegment:</b> Hard ceiling on rows per segment (safety limit)</li>
+///   <li><b>learningRate:</b> EMA alpha parameter (0-1); higher = faster adaptation to changes</li>
+///   <li><b>initialBytesPerRowEstimate:</b> Conservative starting estimate</li>
+/// </ul>
+///
+/// <h3>Example Configuration:</h3>
+/// <pre>
+/// {
+///   "desiredSegmentSizeBytes": "209715200",  // 200MB
+///   "maxNumRecordsPerSegment": "2000000",    // 2M rows ceiling
+///   "segmentSizingStrategy": "ADAPTIVE"
+/// }
+/// </pre>
+///
+/// <h3>Thread Safety:</h3>
+/// This class is NOT thread-safe. It should be used by a single thread during segment processing.
+///
+/// @see PercentileAdaptiveSegmentNumRowProvider for handling heterogeneous data with high variance
 public class AdaptiveSegmentNumRowProvider implements SegmentNumRowProvider {
   private static final Logger LOGGER = LoggerFactory.getLogger(AdaptiveSegmentNumRowProvider.class);
 
@@ -88,24 +86,20 @@ public class AdaptiveSegmentNumRowProvider implements SegmentNumRowProvider {
   private long _totalBytesProcessed;
   private long _totalRowsProcessed;
 
-  /**
-   * Creates an AdaptiveSegmentNumRowProvider with default learning rate and initial estimate.
-   *
-   * @param desiredSegmentSizeBytes target segment size in bytes (must be positive)
-   * @param maxNumRecordsPerSegment maximum rows per segment (must be positive)
-   */
+  /// Creates an AdaptiveSegmentNumRowProvider with default learning rate and initial estimate.
+  ///
+  /// @param desiredSegmentSizeBytes target segment size in bytes (must be positive)
+  /// @param maxNumRecordsPerSegment maximum rows per segment (must be positive)
   public AdaptiveSegmentNumRowProvider(long desiredSegmentSizeBytes, int maxNumRecordsPerSegment) {
     this(desiredSegmentSizeBytes, maxNumRecordsPerSegment, DEFAULT_LEARNING_RATE, DEFAULT_INITIAL_BYTES_PER_ROW);
   }
 
-  /**
-   * Creates an AdaptiveSegmentNumRowProvider with custom parameters.
-   *
-   * @param desiredSegmentSizeBytes target segment size in bytes (must be positive)
-   * @param maxNumRecordsPerSegment maximum rows per segment (must be positive)
-   * @param learningRate EMA alpha parameter (0.0 to 1.0); higher values adapt faster
-   * @param initialBytesPerRowEstimate starting estimate of bytes per row (must be positive)
-   */
+  /// Creates an AdaptiveSegmentNumRowProvider with custom parameters.
+  ///
+  /// @param desiredSegmentSizeBytes target segment size in bytes (must be positive)
+  /// @param maxNumRecordsPerSegment maximum rows per segment (must be positive)
+  /// @param learningRate EMA alpha parameter (0.0 to 1.0); higher values adapt faster
+  /// @param initialBytesPerRowEstimate starting estimate of bytes per row (must be positive)
   public AdaptiveSegmentNumRowProvider(long desiredSegmentSizeBytes, int maxNumRecordsPerSegment,
       double learningRate, double initialBytesPerRowEstimate) {
     Preconditions.checkArgument(desiredSegmentSizeBytes > 0,
@@ -169,11 +163,9 @@ public class AdaptiveSegmentNumRowProvider implements SegmentNumRowProvider {
         String.format("%.2f", _estimatedBytesPerRow), previousRowCount, _currentRowCount);
   }
 
-  /**
-   * Calculates the number of rows for the next segment based on current estimate.
-   *
-   * @return number of rows, guaranteed to be between MIN_ROWS_PER_SEGMENT and maxNumRecordsPerSegment
-   */
+  /// Calculates the number of rows for the next segment based on current estimate.
+  ///
+  /// @return number of rows, guaranteed to be between MIN_ROWS_PER_SEGMENT and maxNumRecordsPerSegment
   private int calculateRowCount() {
     int calculatedRows = (int) (_desiredSegmentSizeBytes / _estimatedBytesPerRow);
 
@@ -184,38 +176,30 @@ public class AdaptiveSegmentNumRowProvider implements SegmentNumRowProvider {
     return boundedRows;
   }
 
-  /**
-   * Gets the current estimated bytes per row.
-   *
-   * @return current estimate of bytes per row
-   */
+  /// Gets the current estimated bytes per row.
+  ///
+  /// @return current estimate of bytes per row
   public double getEstimatedBytesPerRow() {
     return _estimatedBytesPerRow;
   }
 
-  /**
-   * Gets the number of segments processed so far.
-   *
-   * @return segment count
-   */
+  /// Gets the number of segments processed so far.
+  ///
+  /// @return segment count
   public int getSegmentsProcessed() {
     return _segmentsProcessed;
   }
 
-  /**
-   * Gets the overall average bytes per row across all processed segments.
-   *
-   * @return average bytes per row, or 0 if no segments processed
-   */
+  /// Gets the overall average bytes per row across all processed segments.
+  ///
+  /// @return average bytes per row, or 0 if no segments processed
   public double getOverallAverageBytesPerRow() {
     return _totalRowsProcessed > 0 ? (double) _totalBytesProcessed / _totalRowsProcessed : 0.0;
   }
 
-  /**
-   * Gets statistics about the adaptation process.
-   *
-   * @return human-readable statistics string
-   */
+  /// Gets statistics about the adaptation process.
+  ///
+  /// @return human-readable statistics string
   public String getStatistics() {
     return String.format(
         "AdaptiveSegmentNumRowProvider Stats: segments=%d, currentEstimate=%.2f bytes/row, "

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/framework/PercentileAdaptiveSegmentNumRowProvider.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/framework/PercentileAdaptiveSegmentNumRowProvider.java
@@ -1,0 +1,354 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.segment.processing.framework;
+
+import com.google.common.base.Preconditions;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Percentile-based adaptive segment num row provider that handles heterogeneous data with
+ * high variance in row sizes. Unlike {@link AdaptiveSegmentNumRowProvider} which uses a simple
+ * moving average, this provider uses reservoir sampling to maintain a representative sample
+ * of observed bytes-per-row values and calculates row counts based on a configurable percentile.
+ *
+ * <p>This is especially useful for tables where different subsets of data have vastly different
+ * sizes, such as:</p>
+ * <ul>
+ *   <li>Multi-tenant tables where some customers have large Theta sketches and others have small ones</li>
+ *   <li>Tables with variable-length text where some rows have huge documents</li>
+ *   <li>Tables with optional binary fields that may or may not be populated</li>
+ * </ul>
+ *
+ * <h3>Algorithm:</h3>
+ * <ol>
+ *   <li>Maintains a reservoir of up to N observed bytes-per-row values using reservoir sampling</li>
+ *   <li>After each segment is created, adds the measured bytes-per-row to the reservoir</li>
+ *   <li>Calculates the configured percentile (e.g., P75, P90) from the reservoir</li>
+ *   <li>Uses the percentile value to calculate the next segment's row count</li>
+ *   <li>Using a higher percentile (e.g., P75 or P90) biases toward creating smaller segments,
+ *       which is safer for heterogeneous data</li>
+ * </ol>
+ *
+ * <h3>Why Percentiles vs Mean:</h3>
+ * <ul>
+ *   <li><b>Robustness:</b> Percentiles are resistant to outliers</li>
+ *   <li><b>Safety:</b> Using P75 means 75% of segments will be smaller than target, preventing oversized segments</li>
+ *   <li><b>Predictability:</b> More stable estimates when data has high variance</li>
+ * </ul>
+ *
+ * <h3>Configuration:</h3>
+ * <ul>
+ *   <li><b>desiredSegmentSizeBytes:</b> Target segment size in bytes (e.g., 200MB)</li>
+ *   <li><b>maxNumRecordsPerSegment:</b> Hard ceiling on rows per segment</li>
+ *   <li><b>percentile:</b> Which percentile to use (0-100); recommended: 75 or 90</li>
+ *   <li><b>reservoirSize:</b> Number of observations to keep (default: 1000)</li>
+ * </ul>
+ *
+ * <h3>Example Configuration:</h3>
+ * <pre>
+ * {
+ *   "desiredSegmentSizeBytes": "209715200",  // 200MB
+ *   "maxNumRecordsPerSegment": "2000000",    // 2M rows ceiling
+ *   "segmentSizingStrategy": "PERCENTILE",
+ *   "sizingPercentile": "75"                 // Use P75
+ * }
+ * </pre>
+ *
+ * <h3>Percentile Selection Guide:</h3>
+ * <ul>
+ *   <li><b>P75 (recommended):</b> Balanced approach, 75% of segments under target</li>
+ *   <li><b>P90:</b> More conservative, prevents most oversized segments but may create smaller segments</li>
+ *   <li><b>P50 (median):</b> Half over, half under - only use if you're okay with 50% oversized segments</li>
+ * </ul>
+ *
+ * <h3>Thread Safety:</h3>
+ * This class is NOT thread-safe. It should be used by a single thread during segment processing.
+ *
+ * @see AdaptiveSegmentNumRowProvider for simpler EMA-based approach suitable for homogeneous data
+ */
+public class PercentileAdaptiveSegmentNumRowProvider implements SegmentNumRowProvider {
+  private static final Logger LOGGER = LoggerFactory.getLogger(PercentileAdaptiveSegmentNumRowProvider.class);
+
+  // Default reservoir size (maintains last 1000 observations with uniform probability)
+  private static final int DEFAULT_RESERVOIR_SIZE = 1000;
+
+  // Default percentile (P75 = 75th percentile)
+  private static final int DEFAULT_PERCENTILE = 75;
+
+  // Default initial estimate: 5KB per row (conservative for tables with binary data)
+  private static final double DEFAULT_INITIAL_BYTES_PER_ROW = 5000.0;
+
+  // Minimum number of observations before switching from initial estimate to percentile
+  private static final int MIN_OBSERVATIONS_FOR_PERCENTILE = 5;
+
+  // Minimum rows per segment to avoid degenerate cases
+  private static final int MIN_ROWS_PER_SEGMENT = 1;
+
+  private final long _desiredSegmentSizeBytes;
+  private final int _maxNumRecordsPerSegment;
+  private final int _percentile;
+  private final int _reservoirSize;
+  private final double _initialBytesPerRowEstimate;
+
+  private final List<Long> _reservoir;
+  private final Random _random;
+  private int _observationCount;
+  private int _currentRowCount;
+  private long _totalBytesProcessed;
+  private long _totalRowsProcessed;
+
+  /**
+   * Creates a PercentileAdaptiveSegmentNumRowProvider with default parameters.
+   *
+   * @param desiredSegmentSizeBytes target segment size in bytes (must be positive)
+   * @param maxNumRecordsPerSegment maximum rows per segment (must be positive)
+   */
+  public PercentileAdaptiveSegmentNumRowProvider(long desiredSegmentSizeBytes, int maxNumRecordsPerSegment) {
+    this(desiredSegmentSizeBytes, maxNumRecordsPerSegment, DEFAULT_PERCENTILE, DEFAULT_RESERVOIR_SIZE,
+        DEFAULT_INITIAL_BYTES_PER_ROW);
+  }
+
+  /**
+   * Creates a PercentileAdaptiveSegmentNumRowProvider with custom percentile.
+   *
+   * @param desiredSegmentSizeBytes target segment size in bytes (must be positive)
+   * @param maxNumRecordsPerSegment maximum rows per segment (must be positive)
+   * @param percentile percentile to use (1-99); recommended: 75 or 90
+   */
+  public PercentileAdaptiveSegmentNumRowProvider(long desiredSegmentSizeBytes, int maxNumRecordsPerSegment,
+      int percentile) {
+    this(desiredSegmentSizeBytes, maxNumRecordsPerSegment, percentile, DEFAULT_RESERVOIR_SIZE,
+        DEFAULT_INITIAL_BYTES_PER_ROW);
+  }
+
+  /**
+   * Creates a PercentileAdaptiveSegmentNumRowProvider with full customization.
+   *
+   * @param desiredSegmentSizeBytes target segment size in bytes (must be positive)
+   * @param maxNumRecordsPerSegment maximum rows per segment (must be positive)
+   * @param percentile percentile to use (1-99)
+   * @param reservoirSize number of observations to maintain (must be positive)
+   * @param initialBytesPerRowEstimate starting estimate before sufficient observations (must be positive)
+   */
+  public PercentileAdaptiveSegmentNumRowProvider(long desiredSegmentSizeBytes, int maxNumRecordsPerSegment,
+      int percentile, int reservoirSize, double initialBytesPerRowEstimate) {
+    Preconditions.checkArgument(desiredSegmentSizeBytes > 0,
+        "Desired segment size must be positive, got: %s", desiredSegmentSizeBytes);
+    Preconditions.checkArgument(maxNumRecordsPerSegment > 0,
+        "Max records per segment must be positive, got: %s", maxNumRecordsPerSegment);
+    Preconditions.checkArgument(percentile > 0 && percentile < 100,
+        "Percentile must be in (0, 100), got: %s", percentile);
+    Preconditions.checkArgument(reservoirSize > 0,
+        "Reservoir size must be positive, got: %s", reservoirSize);
+    Preconditions.checkArgument(initialBytesPerRowEstimate > 0,
+        "Initial bytes per row estimate must be positive, got: %s", initialBytesPerRowEstimate);
+
+    _desiredSegmentSizeBytes = desiredSegmentSizeBytes;
+    _maxNumRecordsPerSegment = maxNumRecordsPerSegment;
+    _percentile = percentile;
+    _reservoirSize = reservoirSize;
+    _initialBytesPerRowEstimate = initialBytesPerRowEstimate;
+
+    _reservoir = new ArrayList<>(_reservoirSize);
+    _random = new Random();
+    _observationCount = 0;
+    _totalBytesProcessed = 0;
+    _totalRowsProcessed = 0;
+    _currentRowCount = calculateRowCount();
+
+    LOGGER.info("Initialized PercentileAdaptiveSegmentNumRowProvider with desiredSegmentSize={}MB, "
+            + "maxRecordsPerSegment={}, percentile=P{}, reservoirSize={}, initialBytesPerRow={}",
+        desiredSegmentSizeBytes / (1024 * 1024), maxNumRecordsPerSegment, percentile,
+        reservoirSize, initialBytesPerRowEstimate);
+  }
+
+  @Override
+  public int getNumRows() {
+    return _currentRowCount;
+  }
+
+  @Override
+  public void updateSegmentInfo(int actualNumRows, long actualSegmentSize) {
+    if (actualNumRows <= 0 || actualSegmentSize <= 0) {
+      LOGGER.warn("Received invalid segment info: numRows={}, segmentSize={}. Skipping update.",
+          actualNumRows, actualSegmentSize);
+      return;
+    }
+
+    // Calculate bytes per row for this segment
+    long bytesPerRow = actualSegmentSize / actualNumRows;
+
+    // Update reservoir using reservoir sampling algorithm
+    updateReservoir(bytesPerRow);
+
+    // Update statistics
+    _observationCount++;
+    _totalBytesProcessed += actualSegmentSize;
+    _totalRowsProcessed += actualNumRows;
+
+    // Recalculate row count for next segment
+    int previousRowCount = _currentRowCount;
+    _currentRowCount = calculateRowCount();
+
+    double currentPercentileValue = getPercentileBytesPerRow();
+
+    LOGGER.info("Segment {} processed: actualRows={}, actualSize={}MB, bytesPerRow={}, "
+            + "P{}={}, reservoirSize={}/{}, previousRowCount={}, newRowCount={}",
+        _observationCount, actualNumRows, actualSegmentSize / (1024 * 1024),
+        bytesPerRow, _percentile, String.format("%.2f", currentPercentileValue),
+        _reservoir.size(), _reservoirSize, previousRowCount, _currentRowCount);
+  }
+
+  /**
+   * Updates the reservoir with a new observation using the reservoir sampling algorithm.
+   * This ensures uniform probability for all observations while maintaining fixed memory usage.
+   *
+   * @param bytesPerRow the new observation to potentially add to reservoir
+   */
+  private void updateReservoir(long bytesPerRow) {
+    if (_reservoir.size() < _reservoirSize) {
+      // Reservoir not full yet, just add
+      _reservoir.add(bytesPerRow);
+    } else {
+      // Reservoir full, use reservoir sampling: replace a random element with probability k/n
+      int randomIndex = _random.nextInt(_observationCount + 1);
+      if (randomIndex < _reservoirSize) {
+        _reservoir.set(randomIndex, bytesPerRow);
+      }
+      // Otherwise, the new observation is discarded (part of the algorithm)
+    }
+  }
+
+  /**
+   * Calculates the number of rows for the next segment based on the current percentile estimate.
+   *
+   * @return number of rows, guaranteed to be between MIN_ROWS_PER_SEGMENT and maxNumRecordsPerSegment
+   */
+  private int calculateRowCount() {
+    double bytesPerRowEstimate = getPercentileBytesPerRow();
+    int calculatedRows = (int) (_desiredSegmentSizeBytes / bytesPerRowEstimate);
+
+    // Apply bounds: at least MIN_ROWS_PER_SEGMENT, at most maxNumRecordsPerSegment
+    int boundedRows = Math.max(MIN_ROWS_PER_SEGMENT,
+        Math.min(_maxNumRecordsPerSegment, calculatedRows));
+
+    return boundedRows;
+  }
+
+  /**
+   * Calculates the configured percentile from the reservoir.
+   * If insufficient observations, returns the initial estimate.
+   *
+   * @return the percentile bytes-per-row value
+   */
+  private double getPercentileBytesPerRow() {
+    if (_reservoir.size() < MIN_OBSERVATIONS_FOR_PERCENTILE) {
+      // Not enough observations yet, use initial estimate
+      return _initialBytesPerRowEstimate;
+    }
+
+    // Create a sorted copy of reservoir
+    List<Long> sorted = new ArrayList<>(_reservoir);
+    Collections.sort(sorted);
+
+    // Calculate percentile index using (percentile * (N-1)) / 100
+    // This gives the correct position where percentile% of values are <= result
+    int index = (_percentile * (sorted.size() - 1)) / 100;
+
+    return sorted.get(index).doubleValue();
+  }
+
+  /**
+   * Gets the current percentile bytes per row estimate.
+   *
+   * @return current percentile estimate
+   */
+  public double getPercentileEstimate() {
+    return getPercentileBytesPerRow();
+  }
+
+  /**
+   * Gets the number of segments processed so far.
+   *
+   * @return segment count
+   */
+  public int getSegmentsProcessed() {
+    return _observationCount;
+  }
+
+  /**
+   * Gets the overall average bytes per row across all processed segments.
+   *
+   * @return average bytes per row, or 0 if no segments processed
+   */
+  public double getOverallAverageBytesPerRow() {
+    return _totalRowsProcessed > 0 ? (double) _totalBytesProcessed / _totalRowsProcessed : 0.0;
+  }
+
+  /**
+   * Gets the current reservoir size.
+   *
+   * @return number of observations currently in reservoir
+   */
+  public int getReservoirCurrentSize() {
+    return _reservoir.size();
+  }
+
+  /**
+   * Gets statistics about the adaptation process.
+   *
+   * @return human-readable statistics string
+   */
+  public String getStatistics() {
+    return String.format(
+        "PercentileAdaptiveSegmentNumRowProvider Stats: segments=%d, P%d=%.2f bytes/row, "
+            + "overallAverage=%.2f bytes/row, currentRowCount=%d, reservoirSize=%d/%d, "
+            + "totalRowsProcessed=%d, totalBytesProcessed=%dMB",
+        _observationCount, _percentile, getPercentileBytesPerRow(), getOverallAverageBytesPerRow(),
+        _currentRowCount, _reservoir.size(), _reservoirSize,
+        _totalRowsProcessed, _totalBytesProcessed / (1024 * 1024));
+  }
+
+  /**
+   * Gets the minimum, median, and maximum values from the reservoir for debugging.
+   *
+   * @return string with min/median/max statistics, or empty string if insufficient data
+   */
+  public String getReservoirStatistics() {
+    if (_reservoir.isEmpty()) {
+      return "Reservoir empty";
+    }
+
+    List<Long> sorted = new ArrayList<>(_reservoir);
+    Collections.sort(sorted);
+
+    long min = sorted.get(0);
+    long median = sorted.get(sorted.size() / 2);
+    long max = sorted.get(sorted.size() - 1);
+
+    return String.format("Reservoir: min=%d, median=%d, max=%d, size=%d",
+        min, median, max, sorted.size());
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/framework/PercentileAdaptiveSegmentNumRowProvider.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/framework/PercentileAdaptiveSegmentNumRowProvider.java
@@ -27,67 +27,65 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
-/**
- * Percentile-based adaptive segment num row provider that handles heterogeneous data with
- * high variance in row sizes. Unlike {@link AdaptiveSegmentNumRowProvider} which uses a simple
- * moving average, this provider uses reservoir sampling to maintain a representative sample
- * of observed bytes-per-row values and calculates row counts based on a configurable percentile.
- *
- * <p>This is especially useful for tables where different subsets of data have vastly different
- * sizes, such as:</p>
- * <ul>
- *   <li>Multi-tenant tables where some customers have large Theta sketches and others have small ones</li>
- *   <li>Tables with variable-length text where some rows have huge documents</li>
- *   <li>Tables with optional binary fields that may or may not be populated</li>
- * </ul>
- *
- * <h3>Algorithm:</h3>
- * <ol>
- *   <li>Maintains a reservoir of up to N observed bytes-per-row values using reservoir sampling</li>
- *   <li>After each segment is created, adds the measured bytes-per-row to the reservoir</li>
- *   <li>Calculates the configured percentile (e.g., P75, P90) from the reservoir</li>
- *   <li>Uses the percentile value to calculate the next segment's row count</li>
- *   <li>Using a higher percentile (e.g., P75 or P90) biases toward creating smaller segments,
- *       which is safer for heterogeneous data</li>
- * </ol>
- *
- * <h3>Why Percentiles vs Mean:</h3>
- * <ul>
- *   <li><b>Robustness:</b> Percentiles are resistant to outliers</li>
- *   <li><b>Safety:</b> Using P75 means 75% of segments will be smaller than target, preventing oversized segments</li>
- *   <li><b>Predictability:</b> More stable estimates when data has high variance</li>
- * </ul>
- *
- * <h3>Configuration:</h3>
- * <ul>
- *   <li><b>desiredSegmentSizeBytes:</b> Target segment size in bytes (e.g., 200MB)</li>
- *   <li><b>maxNumRecordsPerSegment:</b> Hard ceiling on rows per segment</li>
- *   <li><b>percentile:</b> Which percentile to use (0-100); recommended: 75 or 90</li>
- *   <li><b>reservoirSize:</b> Number of observations to keep (default: 1000)</li>
- * </ul>
- *
- * <h3>Example Configuration:</h3>
- * <pre>
- * {
- *   "desiredSegmentSizeBytes": "209715200",  // 200MB
- *   "maxNumRecordsPerSegment": "2000000",    // 2M rows ceiling
- *   "segmentSizingStrategy": "PERCENTILE",
- *   "sizingPercentile": "75"                 // Use P75
- * }
- * </pre>
- *
- * <h3>Percentile Selection Guide:</h3>
- * <ul>
- *   <li><b>P75 (recommended):</b> Balanced approach, 75% of segments under target</li>
- *   <li><b>P90:</b> More conservative, prevents most oversized segments but may create smaller segments</li>
- *   <li><b>P50 (median):</b> Half over, half under - only use if you're okay with 50% oversized segments</li>
- * </ul>
- *
- * <h3>Thread Safety:</h3>
- * This class is NOT thread-safe. It should be used by a single thread during segment processing.
- *
- * @see AdaptiveSegmentNumRowProvider for simpler EMA-based approach suitable for homogeneous data
- */
+/// Percentile-based adaptive segment num row provider that handles heterogeneous data with
+/// high variance in row sizes. Unlike {@link AdaptiveSegmentNumRowProvider} which uses a simple
+/// moving average, this provider uses reservoir sampling to maintain a representative sample
+/// of observed bytes-per-row values and calculates row counts based on a configurable percentile.
+///
+/// <p>This is especially useful for tables where different subsets of data have vastly different
+/// sizes, such as:</p>
+/// <ul>
+///   <li>Multi-tenant tables where some customers have large Theta sketches and others have small ones</li>
+///   <li>Tables with variable-length text where some rows have huge documents</li>
+///   <li>Tables with optional binary fields that may or may not be populated</li>
+/// </ul>
+///
+/// <h3>Algorithm:</h3>
+/// <ol>
+///   <li>Maintains a reservoir of up to N observed bytes-per-row values using reservoir sampling</li>
+///   <li>After each segment is created, adds the measured bytes-per-row to the reservoir</li>
+///   <li>Calculates the configured percentile (e.g., P75, P90) from the reservoir</li>
+///   <li>Uses the percentile value to calculate the next segment's row count</li>
+///   <li>Using a higher percentile (e.g., P75 or P90) biases toward creating smaller segments,
+///       which is safer for heterogeneous data</li>
+/// </ol>
+///
+/// <h3>Why Percentiles vs Mean:</h3>
+/// <ul>
+///   <li><b>Robustness:</b> Percentiles are resistant to outliers</li>
+///   <li><b>Safety:</b> Using P75 means 75% of segments will be smaller than target, preventing oversized segments</li>
+///   <li><b>Predictability:</b> More stable estimates when data has high variance</li>
+/// </ul>
+///
+/// <h3>Configuration:</h3>
+/// <ul>
+///   <li><b>desiredSegmentSizeBytes:</b> Target segment size in bytes (e.g., 200MB)</li>
+///   <li><b>maxNumRecordsPerSegment:</b> Hard ceiling on rows per segment</li>
+///   <li><b>percentile:</b> Which percentile to use (0-100); recommended: 75 or 90</li>
+///   <li><b>reservoirSize:</b> Number of observations to keep (default: 1000)</li>
+/// </ul>
+///
+/// <h3>Example Configuration:</h3>
+/// <pre>
+/// {
+///   "desiredSegmentSizeBytes": "209715200",  // 200MB
+///   "maxNumRecordsPerSegment": "2000000",    // 2M rows ceiling
+///   "segmentSizingStrategy": "PERCENTILE",
+///   "sizingPercentile": "75"                 // Use P75
+/// }
+/// </pre>
+///
+/// <h3>Percentile Selection Guide:</h3>
+/// <ul>
+///   <li><b>P75 (recommended):</b> Balanced approach, 75% of segments under target</li>
+///   <li><b>P90:</b> More conservative, prevents most oversized segments but may create smaller segments</li>
+///   <li><b>P50 (median):</b> Half over, half under - only use if you're okay with 50% oversized segments</li>
+/// </ul>
+///
+/// <h3>Thread Safety:</h3>
+/// This class is NOT thread-safe. It should be used by a single thread during segment processing.
+///
+/// @see AdaptiveSegmentNumRowProvider for simpler EMA-based approach suitable for homogeneous data
 public class PercentileAdaptiveSegmentNumRowProvider implements SegmentNumRowProvider {
   private static final Logger LOGGER = LoggerFactory.getLogger(PercentileAdaptiveSegmentNumRowProvider.class);
 
@@ -119,39 +117,33 @@ public class PercentileAdaptiveSegmentNumRowProvider implements SegmentNumRowPro
   private long _totalBytesProcessed;
   private long _totalRowsProcessed;
 
-  /**
-   * Creates a PercentileAdaptiveSegmentNumRowProvider with default parameters.
-   *
-   * @param desiredSegmentSizeBytes target segment size in bytes (must be positive)
-   * @param maxNumRecordsPerSegment maximum rows per segment (must be positive)
-   */
+  /// Creates a PercentileAdaptiveSegmentNumRowProvider with default parameters.
+  ///
+  /// @param desiredSegmentSizeBytes target segment size in bytes (must be positive)
+  /// @param maxNumRecordsPerSegment maximum rows per segment (must be positive)
   public PercentileAdaptiveSegmentNumRowProvider(long desiredSegmentSizeBytes, int maxNumRecordsPerSegment) {
     this(desiredSegmentSizeBytes, maxNumRecordsPerSegment, DEFAULT_PERCENTILE, DEFAULT_RESERVOIR_SIZE,
         DEFAULT_INITIAL_BYTES_PER_ROW);
   }
 
-  /**
-   * Creates a PercentileAdaptiveSegmentNumRowProvider with custom percentile.
-   *
-   * @param desiredSegmentSizeBytes target segment size in bytes (must be positive)
-   * @param maxNumRecordsPerSegment maximum rows per segment (must be positive)
-   * @param percentile percentile to use (1-99); recommended: 75 or 90
-   */
+  /// Creates a PercentileAdaptiveSegmentNumRowProvider with custom percentile.
+  ///
+  /// @param desiredSegmentSizeBytes target segment size in bytes (must be positive)
+  /// @param maxNumRecordsPerSegment maximum rows per segment (must be positive)
+  /// @param percentile percentile to use (1-99); recommended: 75 or 90
   public PercentileAdaptiveSegmentNumRowProvider(long desiredSegmentSizeBytes, int maxNumRecordsPerSegment,
       int percentile) {
     this(desiredSegmentSizeBytes, maxNumRecordsPerSegment, percentile, DEFAULT_RESERVOIR_SIZE,
         DEFAULT_INITIAL_BYTES_PER_ROW);
   }
 
-  /**
-   * Creates a PercentileAdaptiveSegmentNumRowProvider with full customization.
-   *
-   * @param desiredSegmentSizeBytes target segment size in bytes (must be positive)
-   * @param maxNumRecordsPerSegment maximum rows per segment (must be positive)
-   * @param percentile percentile to use (1-99)
-   * @param reservoirSize number of observations to maintain (must be positive)
-   * @param initialBytesPerRowEstimate starting estimate before sufficient observations (must be positive)
-   */
+  /// Creates a PercentileAdaptiveSegmentNumRowProvider with full customization.
+  ///
+  /// @param desiredSegmentSizeBytes target segment size in bytes (must be positive)
+  /// @param maxNumRecordsPerSegment maximum rows per segment (must be positive)
+  /// @param percentile percentile to use (1-99)
+  /// @param reservoirSize number of observations to maintain (must be positive)
+  /// @param initialBytesPerRowEstimate starting estimate before sufficient observations (must be positive)
   public PercentileAdaptiveSegmentNumRowProvider(long desiredSegmentSizeBytes, int maxNumRecordsPerSegment,
       int percentile, int reservoirSize, double initialBytesPerRowEstimate) {
     Preconditions.checkArgument(desiredSegmentSizeBytes > 0,
@@ -221,12 +213,10 @@ public class PercentileAdaptiveSegmentNumRowProvider implements SegmentNumRowPro
         _reservoir.size(), _reservoirSize, previousRowCount, _currentRowCount);
   }
 
-  /**
-   * Updates the reservoir with a new observation using the reservoir sampling algorithm.
-   * This ensures uniform probability for all observations while maintaining fixed memory usage.
-   *
-   * @param bytesPerRow the new observation to potentially add to reservoir
-   */
+  /// Updates the reservoir with a new observation using the reservoir sampling algorithm.
+  /// This ensures uniform probability for all observations while maintaining fixed memory usage.
+  ///
+  /// @param bytesPerRow the new observation to potentially add to reservoir
   private void updateReservoir(long bytesPerRow) {
     if (_reservoir.size() < _reservoirSize) {
       // Reservoir not full yet, just add
@@ -241,11 +231,9 @@ public class PercentileAdaptiveSegmentNumRowProvider implements SegmentNumRowPro
     }
   }
 
-  /**
-   * Calculates the number of rows for the next segment based on the current percentile estimate.
-   *
-   * @return number of rows, guaranteed to be between MIN_ROWS_PER_SEGMENT and maxNumRecordsPerSegment
-   */
+  /// Calculates the number of rows for the next segment based on the current percentile estimate.
+  ///
+  /// @return number of rows, guaranteed to be between MIN_ROWS_PER_SEGMENT and maxNumRecordsPerSegment
   private int calculateRowCount() {
     double bytesPerRowEstimate = getPercentileBytesPerRow();
     int calculatedRows = (int) (_desiredSegmentSizeBytes / bytesPerRowEstimate);
@@ -257,12 +245,10 @@ public class PercentileAdaptiveSegmentNumRowProvider implements SegmentNumRowPro
     return boundedRows;
   }
 
-  /**
-   * Calculates the configured percentile from the reservoir.
-   * If insufficient observations, returns the initial estimate.
-   *
-   * @return the percentile bytes-per-row value
-   */
+  /// Calculates the configured percentile from the reservoir.
+  /// If insufficient observations, returns the initial estimate.
+  ///
+  /// @return the percentile bytes-per-row value
   private double getPercentileBytesPerRow() {
     if (_reservoir.size() < MIN_OBSERVATIONS_FOR_PERCENTILE) {
       // Not enough observations yet, use initial estimate
@@ -280,47 +266,37 @@ public class PercentileAdaptiveSegmentNumRowProvider implements SegmentNumRowPro
     return sorted.get(index).doubleValue();
   }
 
-  /**
-   * Gets the current percentile bytes per row estimate.
-   *
-   * @return current percentile estimate
-   */
+  /// Gets the current percentile bytes per row estimate.
+  ///
+  /// @return current percentile estimate
   public double getPercentileEstimate() {
     return getPercentileBytesPerRow();
   }
 
-  /**
-   * Gets the number of segments processed so far.
-   *
-   * @return segment count
-   */
+  /// Gets the number of segments processed so far.
+  ///
+  /// @return segment count
   public int getSegmentsProcessed() {
     return _observationCount;
   }
 
-  /**
-   * Gets the overall average bytes per row across all processed segments.
-   *
-   * @return average bytes per row, or 0 if no segments processed
-   */
+  /// Gets the overall average bytes per row across all processed segments.
+  ///
+  /// @return average bytes per row, or 0 if no segments processed
   public double getOverallAverageBytesPerRow() {
     return _totalRowsProcessed > 0 ? (double) _totalBytesProcessed / _totalRowsProcessed : 0.0;
   }
 
-  /**
-   * Gets the current reservoir size.
-   *
-   * @return number of observations currently in reservoir
-   */
+  /// Gets the current reservoir size.
+  ///
+  /// @return number of observations currently in reservoir
   public int getReservoirCurrentSize() {
     return _reservoir.size();
   }
 
-  /**
-   * Gets statistics about the adaptation process.
-   *
-   * @return human-readable statistics string
-   */
+  /// Gets statistics about the adaptation process.
+  ///
+  /// @return human-readable statistics string
   public String getStatistics() {
     return String.format(
         "PercentileAdaptiveSegmentNumRowProvider Stats: segments=%d, P%d=%.2f bytes/row, "
@@ -331,11 +307,9 @@ public class PercentileAdaptiveSegmentNumRowProvider implements SegmentNumRowPro
         _totalRowsProcessed, _totalBytesProcessed / (1024 * 1024));
   }
 
-  /**
-   * Gets the minimum, median, and maximum values from the reservoir for debugging.
-   *
-   * @return string with min/median/max statistics, or empty string if insufficient data
-   */
+  /// Gets the minimum, median, and maximum values from the reservoir for debugging.
+  ///
+  /// @return string with min/median/max statistics, or empty string if insufficient data
   public String getReservoirStatistics() {
     if (_reservoir.isEmpty()) {
       return "Reservoir empty";

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/processing/framework/AdaptiveSegmentNumRowProviderTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/processing/framework/AdaptiveSegmentNumRowProviderTest.java
@@ -1,0 +1,347 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.segment.processing.framework;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
+
+
+/**
+ * Unit tests for AdaptiveSegmentNumRowProvider
+ */
+public class AdaptiveSegmentNumRowProviderTest {
+
+  @Test
+  public void testConstructorWithDefaults() {
+    long desiredSize = 200 * 1024 * 1024; // 200MB
+    int maxRows = 2_000_000;
+
+    AdaptiveSegmentNumRowProvider provider = new AdaptiveSegmentNumRowProvider(desiredSize, maxRows);
+
+    // With default 5000 bytes/row estimate, should calculate 200MB / 5000 = ~40,000 rows
+    int initialRows = provider.getNumRows();
+    assertTrue(initialRows > 0 && initialRows <= maxRows,
+        "Initial row count should be positive and <= max");
+    assertEquals(provider.getSegmentsProcessed(), 0);
+    assertEquals(provider.getEstimatedBytesPerRow(), 5000.0, 0.01);
+  }
+
+  @Test
+  public void testConstructorWithCustomParameters() {
+    long desiredSize = 100 * 1024 * 1024; // 100MB
+    int maxRows = 1_000_000;
+    double learningRate = 0.5;
+    double initialEstimate = 10000.0;
+
+    AdaptiveSegmentNumRowProvider provider =
+        new AdaptiveSegmentNumRowProvider(desiredSize, maxRows, learningRate, initialEstimate);
+
+    assertEquals(provider.getEstimatedBytesPerRow(), initialEstimate, 0.01);
+    // 100MB / 10000 = 10,000 rows
+    assertEquals(provider.getNumRows(), 10_485);
+  }
+
+  @Test
+  public void testInvalidConstructorArguments() {
+    // Negative desired size
+    assertThrows(IllegalArgumentException.class, () ->
+        new AdaptiveSegmentNumRowProvider(-1, 1_000_000));
+
+    // Zero max rows
+    assertThrows(IllegalArgumentException.class, () ->
+        new AdaptiveSegmentNumRowProvider(100_000_000, 0));
+
+    // Invalid learning rate (too low)
+    assertThrows(IllegalArgumentException.class, () ->
+        new AdaptiveSegmentNumRowProvider(100_000_000, 1_000_000, 0.0, 5000));
+
+    // Invalid learning rate (too high)
+    assertThrows(IllegalArgumentException.class, () ->
+        new AdaptiveSegmentNumRowProvider(100_000_000, 1_000_000, 1.5, 5000));
+
+    // Negative initial estimate
+    assertThrows(IllegalArgumentException.class, () ->
+        new AdaptiveSegmentNumRowProvider(100_000_000, 1_000_000, 0.3, -100));
+  }
+
+  @Test
+  public void testAdaptationWithConsistentSizes() {
+    long desiredSize = 200 * 1024 * 1024; // 200MB
+    int maxRows = 5_000_000;
+    double learningRate = 0.3;
+    double initialEstimate = 5000.0;
+
+    AdaptiveSegmentNumRowProvider provider =
+        new AdaptiveSegmentNumRowProvider(desiredSize, maxRows, learningRate, initialEstimate);
+
+    // Simulate segments with consistent 10KB per row
+    int actualRows1 = 20_000;
+    long actualSize1 = 20_000L * 10_000; // 200MB exactly
+
+    provider.updateSegmentInfo(actualRows1, actualSize1);
+
+    // After first update: estimate should move toward 10000
+    // New estimate = 0.3 * 10000 + 0.7 * 5000 = 3000 + 3500 = 6500
+    assertEquals(provider.getEstimatedBytesPerRow(), 6500.0, 0.01);
+    assertEquals(provider.getSegmentsProcessed(), 1);
+
+    // Next segment row count should be 200MB / 6500 = ~30,769 rows
+    int nextRows = provider.getNumRows();
+    assertTrue(nextRows > 20_000 && nextRows < 35_000,
+        "Row count should increase since we underestimated bytes/row");
+
+    // Simulate another segment with same 10KB per row
+    provider.updateSegmentInfo(nextRows, nextRows * 10_000L);
+
+    // Estimate should continue converging toward 10000
+    assertTrue(provider.getEstimatedBytesPerRow() > 6500.0,
+        "Estimate should increase toward actual 10000");
+    assertTrue(provider.getEstimatedBytesPerRow() < 10000.0,
+        "Estimate hasn't converged fully yet");
+    assertEquals(provider.getSegmentsProcessed(), 2);
+  }
+
+  @Test
+  public void testAdaptationWithIncreasingSize() {
+    long desiredSize = 100 * 1024 * 1024; // 100MB
+    int maxRows = 2_000_000;
+    double learningRate = 0.5; // Higher learning rate for faster adaptation
+
+    AdaptiveSegmentNumRowProvider provider =
+        new AdaptiveSegmentNumRowProvider(desiredSize, maxRows, learningRate, 5000.0);
+
+    // First segment: 2KB per row
+    provider.updateSegmentInfo(50_000, 50_000L * 2_000);
+    double estimateAfter1 = provider.getEstimatedBytesPerRow();
+    // estimate = 0.5 * 2000 + 0.5 * 5000 = 1000 + 2500 = 3500
+    assertEquals(estimateAfter1, 3500.0, 0.01);
+
+    // Second segment: 4KB per row
+    provider.updateSegmentInfo(30_000, 30_000L * 4_000);
+    double estimateAfter2 = provider.getEstimatedBytesPerRow();
+    // estimate = 0.5 * 4000 + 0.5 * 3500 = 2000 + 1750 = 3750
+    assertEquals(estimateAfter2, 3750.0, 0.01);
+
+    // Third segment: 8KB per row
+    provider.updateSegmentInfo(15_000, 15_000L * 8_000);
+    double estimateAfter3 = provider.getEstimatedBytesPerRow();
+    // estimate = 0.5 * 8000 + 0.5 * 3750 = 4000 + 1875 = 5875
+    assertEquals(estimateAfter3, 5875.0, 0.01);
+
+    // Row count should decrease as estimate increases
+    assertTrue(provider.getNumRows() < 25_000,
+        "Row count should decrease as bytes/row estimate increases");
+  }
+
+  @Test
+  public void testMaxRowsEnforcement() {
+    long desiredSize = 1_000 * 1024 * 1024; // 1GB
+    int maxRows = 50_000;
+    double initialEstimate = 100.0; // Very small estimate
+
+    AdaptiveSegmentNumRowProvider provider =
+        new AdaptiveSegmentNumRowProvider(desiredSize, maxRows, 0.3, initialEstimate);
+
+    // With 100 bytes/row estimate and 1GB desired: would calculate 10M rows
+    // But should be capped at maxRows
+    assertEquals(provider.getNumRows(), maxRows,
+        "Row count should be capped at maxRows");
+
+    // Even after learning about larger sizes, should still respect max
+    provider.updateSegmentInfo(maxRows, maxRows * 1000L);
+    assertEquals(provider.getNumRows(), maxRows,
+        "Row count should still be capped after update");
+  }
+
+  @Test
+  public void testMinRowsEnforcement() {
+    long desiredSize = 1024; // 1KB desired size
+    int maxRows = 1_000_000;
+    double initialEstimate = 10_000.0; // Large estimate
+
+    AdaptiveSegmentNumRowProvider provider =
+        new AdaptiveSegmentNumRowProvider(desiredSize, maxRows, 0.3, initialEstimate);
+
+    // With 10KB bytes/row estimate and 1KB desired: would calculate < 1 row
+    // But should be at least 1
+    assertTrue(provider.getNumRows() >= 1,
+        "Row count should be at least 1");
+  }
+
+  @Test
+  public void testInvalidUpdateArguments() {
+    long desiredSize = 200 * 1024 * 1024;
+    int maxRows = 2_000_000;
+
+    AdaptiveSegmentNumRowProvider provider = new AdaptiveSegmentNumRowProvider(desiredSize, maxRows);
+
+    // Should log warning but not crash
+    int rowsBefore = provider.getNumRows();
+    provider.updateSegmentInfo(0, 100_000); // Zero rows
+    assertEquals(provider.getNumRows(), rowsBefore, "Row count should not change on invalid update");
+    assertEquals(provider.getSegmentsProcessed(), 0, "Should not count invalid update");
+
+    provider.updateSegmentInfo(1000, 0); // Zero size
+    assertEquals(provider.getNumRows(), rowsBefore, "Row count should not change on invalid update");
+    assertEquals(provider.getSegmentsProcessed(), 0, "Should not count invalid update");
+
+    provider.updateSegmentInfo(-100, 100_000); // Negative rows
+    assertEquals(provider.getNumRows(), rowsBefore, "Row count should not change on invalid update");
+    assertEquals(provider.getSegmentsProcessed(), 0, "Should not count invalid update");
+  }
+
+  @Test
+  public void testConvergenceWithMultipleUpdates() {
+    long desiredSize = 200 * 1024 * 1024; // 200MB
+    int maxRows = 2_000_000;
+    double learningRate = 0.2; // Lower learning rate for stable convergence
+
+    AdaptiveSegmentNumRowProvider provider =
+        new AdaptiveSegmentNumRowProvider(desiredSize, maxRows, learningRate, 5000.0);
+
+    // Actual data has 8KB per row
+    long actualBytesPerRow = 8000;
+
+    // Simulate 10 segments
+    for (int i = 0; i < 10; i++) {
+      int numRows = provider.getNumRows();
+      long segmentSize = numRows * actualBytesPerRow;
+      provider.updateSegmentInfo(numRows, segmentSize);
+    }
+
+    // After 10 segments, estimate should be close to actual
+    double finalEstimate = provider.getEstimatedBytesPerRow();
+    assertTrue(Math.abs(finalEstimate - actualBytesPerRow) < 1000,
+        "Estimate should converge close to actual: expected ~8000, got " + finalEstimate);
+
+    // Final row count should be close to optimal
+    int finalRowCount = provider.getNumRows();
+    int optimalRowCount = (int) (desiredSize / actualBytesPerRow); // 200MB / 8KB = 25,000
+    assertTrue(Math.abs(finalRowCount - optimalRowCount) < 3000,
+        "Row count should converge to optimal: expected ~25000, got " + finalRowCount);
+  }
+
+  @Test
+  public void testOverallAverageTracking() {
+    long desiredSize = 100 * 1024 * 1024; // 100MB
+    int maxRows = 1_000_000;
+
+    AdaptiveSegmentNumRowProvider provider = new AdaptiveSegmentNumRowProvider(desiredSize, maxRows);
+
+    // Initially no data
+    assertEquals(provider.getOverallAverageBytesPerRow(), 0.0, 0.01);
+
+    // Add varied segment sizes
+    provider.updateSegmentInfo(10_000, 10_000L * 5_000); // 5KB/row
+    provider.updateSegmentInfo(20_000, 20_000L * 10_000); // 10KB/row
+    provider.updateSegmentInfo(15_000, 15_000L * 8_000); // 8KB/row
+
+    // Overall average = (50MB + 200MB + 120MB) / (10k + 20k + 15k) = 370MB / 45k = ~8222 bytes/row
+    double totalBytes = 10_000L * 5_000 + 20_000L * 10_000 + 15_000L * 8_000;
+    double totalRows = 10_000 + 20_000 + 15_000;
+    double expectedAverage = totalBytes / totalRows;
+
+    assertEquals(provider.getOverallAverageBytesPerRow(), expectedAverage, 1.0);
+  }
+
+  @Test
+  public void testStatisticsOutput() {
+    long desiredSize = 200 * 1024 * 1024;
+    int maxRows = 2_000_000;
+
+    AdaptiveSegmentNumRowProvider provider = new AdaptiveSegmentNumRowProvider(desiredSize, maxRows);
+
+    provider.updateSegmentInfo(20_000, 20_000L * 8_000);
+    provider.updateSegmentInfo(25_000, 25_000L * 8_000);
+
+    String stats = provider.getStatistics();
+
+    // Verify statistics string contains key information
+    assertTrue(stats.contains("segments=2"), "Stats should show 2 segments processed");
+    assertTrue(stats.contains("currentEstimate"), "Stats should show current estimate");
+    assertTrue(stats.contains("overallAverage"), "Stats should show overall average");
+    assertTrue(stats.contains("currentRowCount"), "Stats should show current row count");
+  }
+
+  @Test
+  public void testLearningRateImpact() {
+    long desiredSize = 100 * 1024 * 1024; // 100MB
+    int maxRows = 1_000_000;
+
+    // Provider with fast learning (high rate)
+    AdaptiveSegmentNumRowProvider fastLearner =
+        new AdaptiveSegmentNumRowProvider(desiredSize, maxRows, 0.9, 5000.0);
+
+    // Provider with slow learning (low rate)
+    AdaptiveSegmentNumRowProvider slowLearner =
+        new AdaptiveSegmentNumRowProvider(desiredSize, maxRows, 0.1, 5000.0);
+
+    // Both see segment with 10KB per row
+    fastLearner.updateSegmentInfo(10_000, 10_000L * 10_000);
+    slowLearner.updateSegmentInfo(10_000, 10_000L * 10_000);
+
+    // Fast learner should adapt more quickly
+    // Fast: 0.9 * 10000 + 0.1 * 5000 = 9500
+    // Slow: 0.1 * 10000 + 0.9 * 5000 = 5500
+    assertEquals(fastLearner.getEstimatedBytesPerRow(), 9500.0, 0.01);
+    assertEquals(slowLearner.getEstimatedBytesPerRow(), 5500.0, 0.01);
+
+    assertTrue(fastLearner.getEstimatedBytesPerRow() > slowLearner.getEstimatedBytesPerRow(),
+        "Fast learner should adapt more toward observed value");
+  }
+
+  @Test
+  public void testRealWorldScenarioWithThetaSketches() {
+    // Simulate real-world scenario with variable Theta sketch sizes
+    long desiredSize = 200 * 1024 * 1024; // 200MB target
+    int maxRows = 2_000_000;
+    double learningRate = 0.3;
+
+    AdaptiveSegmentNumRowProvider provider =
+        new AdaptiveSegmentNumRowProvider(desiredSize, maxRows, learningRate, 5000.0);
+
+    // Simulate segments with varying sketch sizes
+    // Small sketches: ~2KB per row
+    provider.updateSegmentInfo(80_000, 80_000L * 2_000);
+
+    // Medium sketches: ~5KB per row
+    provider.updateSegmentInfo(50_000, 50_000L * 5_000);
+
+    // Large sketches: ~15KB per row
+    provider.updateSegmentInfo(15_000, 15_000L * 15_000);
+
+    // Another large sketch segment
+    provider.updateSegmentInfo(14_000, 14_000L * 15_000);
+
+    // Estimate should reflect the observed distribution
+    double finalEstimate = provider.getEstimatedBytesPerRow();
+    assertTrue(finalEstimate > 5000 && finalEstimate < 15000,
+        "Estimate should be between min and max observed values");
+
+    // Provider should now suggest reasonable row counts
+    int suggestedRows = provider.getNumRows();
+    assertTrue(suggestedRows > 10_000 && suggestedRows < 100_000,
+        "Suggested row count should be reasonable for mixed sketch sizes");
+
+    assertEquals(provider.getSegmentsProcessed(), 4);
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/processing/framework/AdaptiveSegmentNumRowProviderTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/processing/framework/AdaptiveSegmentNumRowProviderTest.java
@@ -25,9 +25,7 @@ import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 
 
-/**
- * Unit tests for AdaptiveSegmentNumRowProvider
- */
+/// Unit tests for AdaptiveSegmentNumRowProvider
 public class AdaptiveSegmentNumRowProviderTest {
 
   @Test

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/processing/framework/PercentileAdaptiveSegmentNumRowProviderTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/processing/framework/PercentileAdaptiveSegmentNumRowProviderTest.java
@@ -1,0 +1,482 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.segment.processing.framework;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
+
+
+/**
+ * Unit tests for PercentileAdaptiveSegmentNumRowProvider
+ */
+public class PercentileAdaptiveSegmentNumRowProviderTest {
+
+  @Test
+  public void testConstructorWithDefaults() {
+    long desiredSize = 200 * 1024 * 1024; // 200MB
+    int maxRows = 2_000_000;
+
+    PercentileAdaptiveSegmentNumRowProvider provider =
+        new PercentileAdaptiveSegmentNumRowProvider(desiredSize, maxRows);
+
+    // Should use default P75 percentile
+    // With default 5000 bytes/row estimate, should calculate 200MB / 5000 = ~40,000 rows
+    int initialRows = provider.getNumRows();
+    assertTrue(initialRows > 0 && initialRows <= maxRows,
+        "Initial row count should be positive and <= max");
+    assertEquals(provider.getSegmentsProcessed(), 0);
+    assertEquals(provider.getReservoirCurrentSize(), 0);
+  }
+
+  @Test
+  public void testConstructorWithCustomPercentile() {
+    long desiredSize = 100 * 1024 * 1024; // 100MB
+    int maxRows = 1_000_000;
+    int percentile = 90; // P90
+
+    PercentileAdaptiveSegmentNumRowProvider provider =
+        new PercentileAdaptiveSegmentNumRowProvider(desiredSize, maxRows, percentile);
+
+    // Verify construction succeeded (percentile validation happens internally)
+    assertTrue(provider.getNumRows() > 0);
+  }
+
+  @Test
+  public void testConstructorWithFullCustomization() {
+    long desiredSize = 100 * 1024 * 1024; // 100MB
+    int maxRows = 1_000_000;
+    int percentile = 80;
+    int reservoirSize = 500;
+    double initialEstimate = 8000.0;
+
+    PercentileAdaptiveSegmentNumRowProvider provider =
+        new PercentileAdaptiveSegmentNumRowProvider(desiredSize, maxRows, percentile,
+            reservoirSize, initialEstimate);
+
+    // 100MB (104,857,600 bytes) / 8,000 bytes/row = 13,107 rows
+    assertEquals(provider.getNumRows(), 13_107);
+  }
+
+  @Test
+  public void testInvalidConstructorArguments() {
+    // Negative desired size
+    assertThrows(IllegalArgumentException.class, () ->
+        new PercentileAdaptiveSegmentNumRowProvider(-1, 1_000_000));
+
+    // Zero max rows
+    assertThrows(IllegalArgumentException.class, () ->
+        new PercentileAdaptiveSegmentNumRowProvider(100_000_000, 0));
+
+    // Invalid percentile (too low)
+    assertThrows(IllegalArgumentException.class, () ->
+        new PercentileAdaptiveSegmentNumRowProvider(100_000_000, 1_000_000, 0));
+
+    // Invalid percentile (too high)
+    assertThrows(IllegalArgumentException.class, () ->
+        new PercentileAdaptiveSegmentNumRowProvider(100_000_000, 1_000_000, 100));
+
+    // Invalid reservoir size
+    assertThrows(IllegalArgumentException.class, () ->
+        new PercentileAdaptiveSegmentNumRowProvider(100_000_000, 1_000_000, 75, 0, 5000));
+
+    // Invalid initial estimate
+    assertThrows(IllegalArgumentException.class, () ->
+        new PercentileAdaptiveSegmentNumRowProvider(100_000_000, 1_000_000, 75, 1000, -100));
+  }
+
+  @Test
+  public void testReservoirFilling() {
+    long desiredSize = 100 * 1024 * 1024;
+    int maxRows = 1_000_000;
+    int reservoirSize = 10; // Small reservoir for testing
+
+    PercentileAdaptiveSegmentNumRowProvider provider =
+        new PercentileAdaptiveSegmentNumRowProvider(desiredSize, maxRows, 75, reservoirSize, 5000.0);
+
+    assertEquals(provider.getReservoirCurrentSize(), 0);
+
+    // Add observations up to reservoir size
+    for (int i = 0; i < reservoirSize; i++) {
+      provider.updateSegmentInfo(10_000, 10_000L * 5_000);
+      assertEquals(provider.getReservoirCurrentSize(), i + 1);
+    }
+
+    // Reservoir should be full
+    assertEquals(provider.getReservoirCurrentSize(), reservoirSize);
+
+    // Add more observations - reservoir size should stay constant
+    for (int i = 0; i < 5; i++) {
+      provider.updateSegmentInfo(10_000, 10_000L * 5_000);
+      assertEquals(provider.getReservoirCurrentSize(), reservoirSize,
+          "Reservoir size should stay at max");
+    }
+
+    assertEquals(provider.getSegmentsProcessed(), reservoirSize + 5);
+  }
+
+  @Test
+  public void testPercentileCalculationWithUniformData() {
+    long desiredSize = 200 * 1024 * 1024; // 200MB
+    int maxRows = 2_000_000;
+    int percentile = 75;
+
+    PercentileAdaptiveSegmentNumRowProvider provider =
+        new PercentileAdaptiveSegmentNumRowProvider(desiredSize, maxRows, percentile);
+
+    // All segments have exactly 8KB per row
+    for (int i = 0; i < 20; i++) {
+      provider.updateSegmentInfo(25_000, 25_000L * 8_000);
+    }
+
+    // With uniform data, all percentiles should equal the value
+    double p75 = provider.getPercentileEstimate();
+    assertEquals(p75, 8000.0, 0.01, "P75 should equal the uniform value");
+
+    // Row count should be 200MB (209,715,200 bytes) / 8,000 bytes/row = 26,214 rows
+    assertEquals(provider.getNumRows(), 26_214);
+  }
+
+  @Test
+  public void testPercentileCalculationWithVariedData() {
+    long desiredSize = 100 * 1024 * 1024; // 100MB
+    int maxRows = 1_000_000;
+    int percentile = 75;
+
+    PercentileAdaptiveSegmentNumRowProvider provider =
+        new PercentileAdaptiveSegmentNumRowProvider(desiredSize, maxRows, percentile);
+
+    // Add segments with varying bytes per row: 2KB, 4KB, 8KB, 16KB
+    // Pattern: 25% at 2KB, 25% at 4KB, 25% at 8KB, 25% at 16KB
+    for (int i = 0; i < 10; i++) {
+      provider.updateSegmentInfo(10_000, 10_000L * 2_000);  // 2KB/row
+    }
+    for (int i = 0; i < 10; i++) {
+      provider.updateSegmentInfo(10_000, 10_000L * 4_000);  // 4KB/row
+    }
+    for (int i = 0; i < 10; i++) {
+      provider.updateSegmentInfo(10_000, 10_000L * 8_000);  // 8KB/row
+    }
+    for (int i = 0; i < 10; i++) {
+      provider.updateSegmentInfo(10_000, 10_000L * 16_000); // 16KB/row
+    }
+
+    // P75 should be at or near 8KB (75% of values are <= 8KB)
+    double p75 = provider.getPercentileEstimate();
+    assertTrue(p75 >= 6_000 && p75 <= 10_000,
+        "P75 should be around 8KB for this distribution, got: " + p75);
+
+    assertEquals(provider.getSegmentsProcessed(), 40);
+  }
+
+  @Test
+  public void testPercentileRobustnessToOutliers() {
+    long desiredSize = 100 * 1024 * 1024; // 100MB
+    int maxRows = 1_000_000;
+    int percentile = 75;
+
+    PercentileAdaptiveSegmentNumRowProvider provider =
+        new PercentileAdaptiveSegmentNumRowProvider(desiredSize, maxRows, percentile);
+
+    // Most segments have ~5KB per row
+    for (int i = 0; i < 30; i++) {
+      provider.updateSegmentInfo(20_000, 20_000L * 5_000);
+    }
+
+    // Add a few outliers with very large sizes (e.g., one customer with huge sketches)
+    for (int i = 0; i < 5; i++) {
+      provider.updateSegmentInfo(2_000, 2_000L * 100_000); // 100KB/row - outlier!
+    }
+
+    // P75 should still be close to 5KB, not affected much by outliers
+    double p75 = provider.getPercentileEstimate();
+    assertTrue(p75 < 20_000,
+        "P75 should not be heavily influenced by outliers, got: " + p75);
+
+    // Overall average would be significantly higher due to outliers
+    double overallAvg = provider.getOverallAverageBytesPerRow();
+    assertTrue(overallAvg > p75,
+        "Overall average should be higher than P75 due to outliers");
+  }
+
+  @Test
+  public void testDifferentPercentiles() {
+    long desiredSize = 100 * 1024 * 1024;
+    int maxRows = 1_000_000;
+
+    // Create providers with different percentiles
+    PercentileAdaptiveSegmentNumRowProvider p50 =
+        new PercentileAdaptiveSegmentNumRowProvider(desiredSize, maxRows, 50);
+    PercentileAdaptiveSegmentNumRowProvider p75 =
+        new PercentileAdaptiveSegmentNumRowProvider(desiredSize, maxRows, 75);
+    PercentileAdaptiveSegmentNumRowProvider p90 =
+        new PercentileAdaptiveSegmentNumRowProvider(desiredSize, maxRows, 90);
+
+    // Feed same data to all: values from 1KB to 10KB
+    for (int bytesPerRow = 1000; bytesPerRow <= 10_000; bytesPerRow += 1000) {
+      p50.updateSegmentInfo(10_000, 10_000L * bytesPerRow);
+      p75.updateSegmentInfo(10_000, 10_000L * bytesPerRow);
+      p90.updateSegmentInfo(10_000, 10_000L * bytesPerRow);
+    }
+
+    // P90 should have highest estimate
+    // P50 should have lowest estimate
+    double est50 = p50.getPercentileEstimate();
+    double est75 = p75.getPercentileEstimate();
+    double est90 = p90.getPercentileEstimate();
+
+    assertTrue(est50 < est75, "P50 should be less than P75");
+    assertTrue(est75 < est90, "P75 should be less than P90");
+
+    // Higher percentile = higher bytes/row estimate = fewer rows
+    assertTrue(p90.getNumRows() < p75.getNumRows(), "P90 should suggest fewer rows");
+    assertTrue(p75.getNumRows() < p50.getNumRows(), "P75 should suggest fewer rows than P50");
+  }
+
+  @Test
+  public void testMaxRowsEnforcement() {
+    long desiredSize = 1_000 * 1024 * 1024; // 1GB
+    int maxRows = 50_000;
+    int percentile = 75;
+
+    // Very small initial estimate
+    PercentileAdaptiveSegmentNumRowProvider provider =
+        new PercentileAdaptiveSegmentNumRowProvider(desiredSize, maxRows, percentile, 1000, 100.0);
+
+    // Should be capped at maxRows
+    assertEquals(provider.getNumRows(), maxRows);
+
+    // Even after learning, should respect max
+    provider.updateSegmentInfo(maxRows, maxRows * 1000L);
+    assertTrue(provider.getNumRows() <= maxRows);
+  }
+
+  @Test
+  public void testMinRowsEnforcement() {
+    long desiredSize = 1024; // 1KB
+    int maxRows = 1_000_000;
+    int percentile = 90;
+
+    // Large initial estimate
+    PercentileAdaptiveSegmentNumRowProvider provider =
+        new PercentileAdaptiveSegmentNumRowProvider(desiredSize, maxRows, percentile, 1000, 100_000.0);
+
+    // Should be at least 1 row
+    assertTrue(provider.getNumRows() >= 1);
+  }
+
+  @Test
+  public void testInvalidUpdateArguments() {
+    long desiredSize = 100 * 1024 * 1024;
+    int maxRows = 1_000_000;
+
+    PercentileAdaptiveSegmentNumRowProvider provider =
+        new PercentileAdaptiveSegmentNumRowProvider(desiredSize, maxRows);
+
+    int rowsBefore = provider.getNumRows();
+
+    // Invalid updates should be ignored
+    provider.updateSegmentInfo(0, 100_000); // Zero rows
+    assertEquals(provider.getSegmentsProcessed(), 0);
+    assertEquals(provider.getReservoirCurrentSize(), 0);
+
+    provider.updateSegmentInfo(1000, 0); // Zero size
+    assertEquals(provider.getSegmentsProcessed(), 0);
+
+    provider.updateSegmentInfo(-100, 100_000); // Negative
+    assertEquals(provider.getSegmentsProcessed(), 0);
+
+    // Row count should not change
+    assertEquals(provider.getNumRows(), rowsBefore);
+  }
+
+  @Test
+  public void testInitialEstimateUsedBeforeSufficientData() {
+    long desiredSize = 100 * 1024 * 1024;
+    int maxRows = 1_000_000;
+    double initialEstimate = 10_000.0;
+
+    PercentileAdaptiveSegmentNumRowProvider provider =
+        new PercentileAdaptiveSegmentNumRowProvider(desiredSize, maxRows, 75, 1000, initialEstimate);
+
+    // Before any updates, should use initial estimate
+    assertEquals(provider.getPercentileEstimate(), initialEstimate, 0.01);
+
+    // Add just 1-2 observations (less than MIN_OBSERVATIONS_FOR_PERCENTILE)
+    provider.updateSegmentInfo(10_000, 10_000L * 5_000);
+    provider.updateSegmentInfo(10_000, 10_000L * 5_000);
+
+    // Should still use initial estimate (need at least 5 observations)
+    assertEquals(provider.getPercentileEstimate(), initialEstimate, 0.01);
+
+    // Add more to reach threshold
+    for (int i = 0; i < 5; i++) {
+      provider.updateSegmentInfo(10_000, 10_000L * 5_000);
+    }
+
+    // Now should use actual percentile calculation
+    double newEstimate = provider.getPercentileEstimate();
+    assertTrue(newEstimate < initialEstimate,
+        "Should switch to percentile calculation after sufficient data");
+  }
+
+  @Test
+  public void testOverallAverageTracking() {
+    long desiredSize = 100 * 1024 * 1024;
+    int maxRows = 1_000_000;
+
+    PercentileAdaptiveSegmentNumRowProvider provider =
+        new PercentileAdaptiveSegmentNumRowProvider(desiredSize, maxRows);
+
+    assertEquals(provider.getOverallAverageBytesPerRow(), 0.0, 0.01);
+
+    // Add varied segments
+    provider.updateSegmentInfo(10_000, 10_000L * 5_000);  // 5KB/row
+    provider.updateSegmentInfo(20_000, 20_000L * 10_000); // 10KB/row
+    provider.updateSegmentInfo(15_000, 15_000L * 8_000);  // 8KB/row
+
+    double expectedAvg = (10_000.0 * 5_000 + 20_000.0 * 10_000 + 15_000.0 * 8_000) / (10_000 + 20_000 + 15_000);
+    assertEquals(provider.getOverallAverageBytesPerRow(), expectedAvg, 1.0);
+  }
+
+  @Test
+  public void testStatisticsOutput() {
+    long desiredSize = 200 * 1024 * 1024;
+    int maxRows = 2_000_000;
+
+    PercentileAdaptiveSegmentNumRowProvider provider =
+        new PercentileAdaptiveSegmentNumRowProvider(desiredSize, maxRows, 75);
+
+    provider.updateSegmentInfo(20_000, 20_000L * 8_000);
+    provider.updateSegmentInfo(25_000, 25_000L * 8_000);
+
+    String stats = provider.getStatistics();
+    assertTrue(stats.contains("segments=2"));
+    assertTrue(stats.contains("P75"));
+    assertTrue(stats.contains("overallAverage"));
+    assertTrue(stats.contains("currentRowCount"));
+    assertTrue(stats.contains("reservoirSize"));
+
+    String reservoirStats = provider.getReservoirStatistics();
+    assertTrue(reservoirStats.contains("min"));
+    assertTrue(reservoirStats.contains("median"));
+    assertTrue(reservoirStats.contains("max"));
+  }
+
+  @Test
+  public void testReservoirStatisticsEmpty() {
+    long desiredSize = 100 * 1024 * 1024;
+    int maxRows = 1_000_000;
+
+    PercentileAdaptiveSegmentNumRowProvider provider =
+        new PercentileAdaptiveSegmentNumRowProvider(desiredSize, maxRows);
+
+    String reservoirStats = provider.getReservoirStatistics();
+    assertEquals(reservoirStats, "Reservoir empty");
+  }
+
+  @Test
+  public void testRealWorldMultiTenantScenario() {
+    // Simulate multi-tenant table where different customers have vastly different sketch sizes
+    long desiredSize = 200 * 1024 * 1024; // 200MB
+    int maxRows = 2_000_000;
+    int percentile = 75; // P75 = 75% of segments will be under target
+
+    PercentileAdaptiveSegmentNumRowProvider provider =
+        new PercentileAdaptiveSegmentNumRowProvider(desiredSize, maxRows, percentile);
+
+    // Customer A: Small sketches (10 segments at ~500 bytes per row)
+    for (int i = 0; i < 10; i++) {
+      provider.updateSegmentInfo(100_000, 100_000L * 500);
+    }
+
+    // Customer B: Medium sketches (10 segments at ~5KB per row)
+    for (int i = 0; i < 10; i++) {
+      provider.updateSegmentInfo(40_000, 40_000L * 5_000);
+    }
+
+    // Customer C: Large sketches (10 segments at ~50KB per row)
+    for (int i = 0; i < 10; i++) {
+      provider.updateSegmentInfo(4_000, 4_000L * 50_000);
+    }
+
+    // Customer D: Very large sketches (5 segments at ~120KB per row - at capacity)
+    for (int i = 0; i < 5; i++) {
+      provider.updateSegmentInfo(1_500, 1_500L * 120_000);
+    }
+
+    // P75 should be closer to the median/upper-medium range, not heavily influenced by largest
+    double p75 = provider.getPercentileEstimate();
+
+    // With this distribution: sorted values are mostly 500, 5000, 50000, 120000
+    // 75th percentile should be around 50KB (between medium and large)
+    assertTrue(p75 > 5_000 && p75 < 120_000,
+        "P75 should be in reasonable middle range, got: " + p75);
+
+    // Suggested row count should be conservative
+    int suggestedRows = provider.getNumRows();
+    long projectedSize = (long) suggestedRows * (long) p75;
+    assertTrue(projectedSize <= desiredSize * 1.5,
+        "Projected segment size should be reasonable: " + (projectedSize / (1024 * 1024)) + "MB");
+
+    assertEquals(provider.getSegmentsProcessed(), 35);
+  }
+
+  @Test
+  public void testComparisonWithAdaptiveProvider() {
+    // Demonstrate that percentile-based is more robust than simple EMA for heterogeneous data
+    long desiredSize = 100 * 1024 * 1024;
+    int maxRows = 1_000_000;
+
+    // Percentile provider (P75)
+    PercentileAdaptiveSegmentNumRowProvider percentileProvider =
+        new PercentileAdaptiveSegmentNumRowProvider(desiredSize, maxRows, 75);
+
+    // EMA-based provider for comparison
+    AdaptiveSegmentNumRowProvider emaProvider =
+        new AdaptiveSegmentNumRowProvider(desiredSize, maxRows, 0.3, 5000.0);
+
+    // Simulate highly variable data
+    // 20 segments with small sizes (2KB/row)
+    for (int i = 0; i < 20; i++) {
+      percentileProvider.updateSegmentInfo(40_000, 40_000L * 2_000);
+      emaProvider.updateSegmentInfo(40_000, 40_000L * 2_000);
+    }
+
+    // Then 5 segments with huge sizes (100KB/row)
+    for (int i = 0; i < 5; i++) {
+      percentileProvider.updateSegmentInfo(1_000, 1_000L * 100_000);
+      emaProvider.updateSegmentInfo(1_000, 1_000L * 100_000);
+    }
+
+    // Percentile (P75) should still be close to 2KB since 80% of segments are at 2KB
+    double percentileEst = percentileProvider.getPercentileEstimate();
+    assertTrue(percentileEst < 10_000,
+        "Percentile estimate should be robust to outliers: " + percentileEst);
+
+    // EMA will be more influenced by the large values
+    double emaEst = emaProvider.getEstimatedBytesPerRow();
+
+    // Percentile should suggest more rows (smaller per-row estimate)
+    assertTrue(percentileProvider.getNumRows() > emaProvider.getNumRows(),
+        "Percentile provider should be less affected by outliers");
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/processing/framework/PercentileAdaptiveSegmentNumRowProviderTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/processing/framework/PercentileAdaptiveSegmentNumRowProviderTest.java
@@ -25,9 +25,7 @@ import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 
 
-/**
- * Unit tests for PercentileAdaptiveSegmentNumRowProvider
- */
+/// Unit tests for PercentileAdaptiveSegmentNumRowProvider
 public class PercentileAdaptiveSegmentNumRowProviderTest {
 
   @Test

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskExecutor.java
@@ -28,6 +28,11 @@ import org.apache.pinot.common.metadata.segment.SegmentZKMetadataCustomMapModifi
 import org.apache.pinot.core.common.MinionConstants;
 import org.apache.pinot.core.common.MinionConstants.MergeRollupTask;
 import org.apache.pinot.core.minion.PinotTaskConfig;
+import org.apache.pinot.core.segment.processing.framework.AdaptiveSegmentNumRowProvider;
+import org.apache.pinot.core.segment.processing.framework.DefaultSegmentNumRowProvider;
+import org.apache.pinot.core.segment.processing.framework.PercentileAdaptiveSegmentNumRowProvider;
+import org.apache.pinot.core.segment.processing.framework.SegmentConfig;
+import org.apache.pinot.core.segment.processing.framework.SegmentNumRowProvider;
 import org.apache.pinot.core.segment.processing.framework.SegmentProcessorConfig;
 import org.apache.pinot.core.segment.processing.framework.SegmentProcessorFramework;
 import org.apache.pinot.minion.MinionConf;
@@ -117,9 +122,11 @@ public class MergeRollupTaskExecutor extends BaseMultipleSegmentsConversionExecu
     List<File> outputSegmentDirs;
     try {
       _eventObserver.notifyProgress(_pinotTaskConfig, "Generating segments");
+      SegmentNumRowProvider segmentNumRowProvider =
+          createSegmentNumRowProvider(configs, segmentProcessorConfig.getSegmentConfig());
       SegmentProcessorFramework framework = new SegmentProcessorFramework(segmentProcessorConfig, workingDir,
           SegmentProcessorFramework.convertRecordReadersToRecordReaderFileConfig(recordReaders),
-          customRecordTransformers, null);
+          customRecordTransformers, segmentNumRowProvider);
       outputSegmentDirs = framework.process();
       _eventObserver.notifyProgress(pinotTaskConfig,
           "Segment processing stats - incomplete rows:" + framework.getIncompleteRowsFound() + ", dropped rows:"
@@ -152,5 +159,68 @@ public class MergeRollupTaskExecutor extends BaseMultipleSegmentsConversionExecu
         pinotTaskConfig.getConfigs().get(MergeRollupTask.MERGE_LEVEL_KEY));
     updateMap.put(MergeRollupTask.SEGMENT_ZK_METADATA_TIME_KEY, String.valueOf(System.currentTimeMillis()));
     return new SegmentZKMetadataCustomMapModifier(SegmentZKMetadataCustomMapModifier.ModifyMode.UPDATE, updateMap);
+  }
+
+  /**
+   * Creates the appropriate SegmentNumRowProvider based on the task configuration for merge rollup tasks.
+   * <p>
+   * This method enables adaptive segment sizing by examining the task configuration and creating
+   * the corresponding provider:
+   * <ul>
+   *   <li>If desiredSegmentSizeBytes is not configured: uses DefaultSegmentNumRowProvider (static sizing)</li>
+   *   <li>If ADAPTIVE strategy: uses AdaptiveSegmentNumRowProvider with EMA-based learning</li>
+   *   <li>If PERCENTILE strategy: uses PercentileAdaptiveSegmentNumRowProvider for heterogeneous data</li>
+   *   <li>If DEFAULT strategy: uses DefaultSegmentNumRowProvider even if size configured</li>
+   * </ul>
+   *
+   * <p>Similar to how eraseDimensionValues is handled, this reads directly from the task config map
+   * rather than going through SegmentConfig, since it's specific to MergeRollupTask.</p>
+   *
+   * @param taskConfig the task configuration map
+   * @param segmentConfig the segment configuration (used for maxNumRecordsPerSegment)
+   * @return the appropriate SegmentNumRowProvider instance
+   */
+  private static SegmentNumRowProvider createSegmentNumRowProvider(Map<String, String> taskConfig,
+      SegmentConfig segmentConfig) {
+    int maxNumRecordsPerSegment = segmentConfig.getMaxNumRecordsPerSegment();
+
+    // Read adaptive sizing configuration from task config
+    String desiredSegmentSizeBytesStr = taskConfig.get(MergeRollupTask.DESIRED_SEGMENT_SIZE_BYTES_KEY);
+    if (desiredSegmentSizeBytesStr == null) {
+      LOGGER.info("Using DefaultSegmentNumRowProvider with maxRecordsPerSegment={}", maxNumRecordsPerSegment);
+      return new DefaultSegmentNumRowProvider(maxNumRecordsPerSegment);
+    }
+
+    long desiredSegmentSizeBytes = Long.parseLong(desiredSegmentSizeBytesStr);
+
+    // Read strategy (defaults to PERCENTILE for adaptive sizing)
+    String strategyStr = taskConfig.get(MergeRollupTask.SEGMENT_SIZING_STRATEGY_KEY);
+    String strategy = strategyStr != null ? strategyStr : "PERCENTILE";
+
+    switch (strategy) {
+      case "ADAPTIVE":
+        String learningRateStr = taskConfig.get(MergeRollupTask.SIZING_LEARNING_RATE_KEY);
+        double learningRate = learningRateStr != null ? Double.parseDouble(learningRateStr) : 0.3;
+        LOGGER.info("Using AdaptiveSegmentNumRowProvider for merge rollup with desiredSegmentSize={}MB, "
+                + "maxRecordsPerSegment={}, learningRate={}",
+            desiredSegmentSizeBytes / (1024 * 1024), maxNumRecordsPerSegment, learningRate);
+        return new AdaptiveSegmentNumRowProvider(desiredSegmentSizeBytes, maxNumRecordsPerSegment,
+            learningRate, 5000.0);
+
+      case "PERCENTILE":
+        String percentileStr = taskConfig.get(MergeRollupTask.SIZING_PERCENTILE_KEY);
+        int percentile = percentileStr != null ? Integer.parseInt(percentileStr) : 75;
+        LOGGER.info("Using PercentileAdaptiveSegmentNumRowProvider for merge rollup with desiredSegmentSize={}MB, "
+                + "maxRecordsPerSegment={}, percentile=P{}",
+            desiredSegmentSizeBytes / (1024 * 1024), maxNumRecordsPerSegment, percentile);
+        return new PercentileAdaptiveSegmentNumRowProvider(desiredSegmentSizeBytes, maxNumRecordsPerSegment,
+            percentile);
+
+      case "DEFAULT":
+      default:
+        LOGGER.info("Using DefaultSegmentNumRowProvider with maxRecordsPerSegment={} "
+            + "(desiredSegmentSizeBytes configured but strategy is DEFAULT)", maxNumRecordsPerSegment);
+        return new DefaultSegmentNumRowProvider(maxNumRecordsPerSegment);
+    }
   }
 }

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskExecutor.java
@@ -161,25 +161,23 @@ public class MergeRollupTaskExecutor extends BaseMultipleSegmentsConversionExecu
     return new SegmentZKMetadataCustomMapModifier(SegmentZKMetadataCustomMapModifier.ModifyMode.UPDATE, updateMap);
   }
 
-  /**
-   * Creates the appropriate SegmentNumRowProvider based on the task configuration for merge rollup tasks.
-   * <p>
-   * This method enables adaptive segment sizing by examining the task configuration and creating
-   * the corresponding provider:
-   * <ul>
-   *   <li>If desiredSegmentSizeBytes is not configured: uses DefaultSegmentNumRowProvider (static sizing)</li>
-   *   <li>If ADAPTIVE strategy: uses AdaptiveSegmentNumRowProvider with EMA-based learning</li>
-   *   <li>If PERCENTILE strategy: uses PercentileAdaptiveSegmentNumRowProvider for heterogeneous data</li>
-   *   <li>If DEFAULT strategy: uses DefaultSegmentNumRowProvider even if size configured</li>
-   * </ul>
-   *
-   * <p>Similar to how eraseDimensionValues is handled, this reads directly from the task config map
-   * rather than going through SegmentConfig, since it's specific to MergeRollupTask.</p>
-   *
-   * @param taskConfig the task configuration map
-   * @param segmentConfig the segment configuration (used for maxNumRecordsPerSegment)
-   * @return the appropriate SegmentNumRowProvider instance
-   */
+  /// Creates the appropriate SegmentNumRowProvider based on the task configuration for merge rollup tasks.
+  /// <p>
+  /// This method enables adaptive segment sizing by examining the task configuration and creating
+  /// the corresponding provider:
+  /// <ul>
+  ///   <li>If desiredSegmentSizeBytes is not configured: uses DefaultSegmentNumRowProvider (static sizing)</li>
+  ///   <li>If ADAPTIVE strategy: uses AdaptiveSegmentNumRowProvider with EMA-based learning</li>
+  ///   <li>If PERCENTILE strategy: uses PercentileAdaptiveSegmentNumRowProvider for heterogeneous data</li>
+  ///   <li>If DEFAULT strategy: uses DefaultSegmentNumRowProvider even if size configured</li>
+  /// </ul>
+  ///
+  /// <p>Similar to how eraseDimensionValues is handled, this reads directly from the task config map
+  /// rather than going through SegmentConfig, since it's specific to MergeRollupTask.</p>
+  ///
+  /// @param taskConfig the task configuration map
+  /// @param segmentConfig the segment configuration (used for maxNumRecordsPerSegment)
+  /// @return the appropriate SegmentNumRowProvider instance
   private static SegmentNumRowProvider createSegmentNumRowProvider(Map<String, String> taskConfig,
       SegmentConfig segmentConfig) {
     int maxNumRecordsPerSegment = segmentConfig.getMaxNumRecordsPerSegment();

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskExecutor.java
@@ -184,8 +184,10 @@ public class MergeRollupTaskExecutor extends BaseMultipleSegmentsConversionExecu
       SegmentConfig segmentConfig) {
     int maxNumRecordsPerSegment = segmentConfig.getMaxNumRecordsPerSegment();
 
-    // Read adaptive sizing configuration from task config
-    String desiredSegmentSizeBytesStr = taskConfig.get(MergeRollupTask.DESIRED_SEGMENT_SIZE_BYTES_KEY);
+    // Read adaptive sizing configuration from task config with merge level prefix
+    String desiredSegmentSizeBytesKey = MergeRollupTaskUtils.buildMergeLevelKeyPrefix(
+        MergeRollupTask.DESIRED_SEGMENT_SIZE_BYTES_KEY, taskConfig);
+    String desiredSegmentSizeBytesStr = taskConfig.get(desiredSegmentSizeBytesKey);
     if (desiredSegmentSizeBytesStr == null) {
       LOGGER.info("Using DefaultSegmentNumRowProvider with maxRecordsPerSegment={}", maxNumRecordsPerSegment);
       return new DefaultSegmentNumRowProvider(maxNumRecordsPerSegment);
@@ -194,12 +196,16 @@ public class MergeRollupTaskExecutor extends BaseMultipleSegmentsConversionExecu
     long desiredSegmentSizeBytes = Long.parseLong(desiredSegmentSizeBytesStr);
 
     // Read strategy (defaults to PERCENTILE for adaptive sizing)
-    String strategyStr = taskConfig.get(MergeRollupTask.SEGMENT_SIZING_STRATEGY_KEY);
+    String segmentSizingStrategyKey = MergeRollupTaskUtils.buildMergeLevelKeyPrefix(
+        MergeRollupTask.SEGMENT_SIZING_STRATEGY_KEY, taskConfig);
+    String strategyStr = taskConfig.get(segmentSizingStrategyKey);
     String strategy = strategyStr != null ? strategyStr : "PERCENTILE";
 
     switch (strategy) {
       case "ADAPTIVE":
-        String learningRateStr = taskConfig.get(MergeRollupTask.SIZING_LEARNING_RATE_KEY);
+        String sizingLearningRateKey = MergeRollupTaskUtils.buildMergeLevelKeyPrefix(
+            MergeRollupTask.SIZING_LEARNING_RATE_KEY, taskConfig);
+        String learningRateStr = taskConfig.get(sizingLearningRateKey);
         double learningRate = learningRateStr != null ? Double.parseDouble(learningRateStr) : 0.3;
         LOGGER.info("Using AdaptiveSegmentNumRowProvider for merge rollup with desiredSegmentSize={}MB, "
                 + "maxRecordsPerSegment={}, learningRate={}",
@@ -208,7 +214,9 @@ public class MergeRollupTaskExecutor extends BaseMultipleSegmentsConversionExecu
             learningRate, 5000.0);
 
       case "PERCENTILE":
-        String percentileStr = taskConfig.get(MergeRollupTask.SIZING_PERCENTILE_KEY);
+        String sizingPercentileKey = MergeRollupTaskUtils.buildMergeLevelKeyPrefix(
+            MergeRollupTask.SIZING_PERCENTILE_KEY, taskConfig);
+        String percentileStr = taskConfig.get(sizingPercentileKey);
         int percentile = percentileStr != null ? Integer.parseInt(percentileStr) : 75;
         LOGGER.info("Using PercentileAdaptiveSegmentNumRowProvider for merge rollup with desiredSegmentSize={}MB, "
                 + "maxRecordsPerSegment={}, percentile=P{}",

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskGenerator.java
@@ -865,10 +865,8 @@ public class MergeRollupTaskGenerator extends BaseTaskGenerator {
     return pinotTaskConfigs;
   }
 
-  /**
-   * Get maxSegmentSizeBytesPerTask from merge configs.
-   * Returns 0 if not configured (indicating row-based grouping should be used).
-   */
+  /// Get maxSegmentSizeBytesPerTask from merge configs.
+  /// Returns 0 if not configured (indicating row-based grouping should be used).
   private long getMaxSegmentSizeBytesPerTask(Map<String, String> mergeConfigs) {
     String value = mergeConfigs.get(MergeTask.MAX_SEGMENT_SIZE_BYTES_PER_TASK_KEY);
     if (value != null) {

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskGenerator.java
@@ -759,45 +759,62 @@ public class MergeRollupTaskGenerator extends BaseTaskGenerator {
 
       for (int i = 0; i < segments.size(); i++) {
         SegmentZKMetadata targetSegment = segments.get(i);
-        segmentNames.add(targetSegment.getSegmentName());
-        downloadURLs.add(targetSegment.getDownloadUrl());
-
-        boolean shouldCreateTask = false;
+        long segmentSizeBytes = targetSegment.getSizeInBytes();
+        boolean isLastSegment = (i == segments.size() - 1);
 
         if (useSizeBasedGrouping) {
-          // Size-based grouping: accumulate segment sizes
-          long segmentSizeBytes = targetSegment.getSizeInBytes();
-          currentTaskSizeBytes += segmentSizeBytes;
-          // Check if adding this segment would exceed the limit (and we already have segments in the task)
-          boolean wouldExceedLimit = (currentTaskSizeBytes > maxSegmentSizeBytesPerTask) && (segmentNames.size() > 1);
-          boolean isLastSegment = (i == segments.size() - 1);
-          shouldCreateTask = wouldExceedLimit || isLastSegment;
+          // Size-based grouping: check if adding this segment would exceed the limit BEFORE adding it
+          boolean wouldExceedLimit = !segmentNames.isEmpty()
+              && (currentTaskSizeBytes + segmentSizeBytes > maxSegmentSizeBytesPerTask);
 
-          if (shouldCreateTask) {
+          if (wouldExceedLimit) {
+            // Create task with current segments (WITHOUT this segment that would exceed the limit)
+            LOGGER.info("Creating task for table {}, mergeLevel {}: {} segments, {} bytes ({} MB), {} records",
+                tableNameWithType, mergeLevel, segmentNames.size(), currentTaskSizeBytes,
+                currentTaskSizeBytes / (1024 * 1024),
+                segments.subList(i - segmentNames.size(), i).stream()
+                    .mapToLong(SegmentZKMetadata::getTotalDocs).sum());
+            segmentNamesList.add(segmentNames);
+            downloadURLsList.add(downloadURLs);
+            currentTaskSizeBytes = 0;
+            segmentNames = new ArrayList<>();
+            downloadURLs = new ArrayList<>();
+          }
+
+          // Now add this segment to the (possibly new) current task
+          segmentNames.add(targetSegment.getSegmentName());
+          downloadURLs.add(targetSegment.getDownloadUrl());
+          currentTaskSizeBytes += segmentSizeBytes;
+
+          // Create task if this is the last segment
+          if (isLastSegment) {
             LOGGER.info("Creating task for table {}, mergeLevel {}: {} segments, {} bytes ({} MB), {} records",
                 tableNameWithType, mergeLevel, segmentNames.size(), currentTaskSizeBytes,
                 currentTaskSizeBytes / (1024 * 1024),
                 segments.subList(i - segmentNames.size() + 1, i + 1).stream()
                     .mapToLong(SegmentZKMetadata::getTotalDocs).sum());
+            segmentNamesList.add(segmentNames);
+            downloadURLsList.add(downloadURLs);
+            currentTaskSizeBytes = 0;
+            segmentNames = new ArrayList<>();
+            downloadURLs = new ArrayList<>();
           }
         } else {
           // Row-based grouping: accumulate record counts
+          segmentNames.add(targetSegment.getSegmentName());
+          downloadURLs.add(targetSegment.getDownloadUrl());
           numRecordsPerTask += targetSegment.getTotalDocs();
-          shouldCreateTask = (numRecordsPerTask >= maxNumRecordsPerTask) || (i == segments.size() - 1);
+          boolean shouldCreateTask = (numRecordsPerTask >= maxNumRecordsPerTask) || isLastSegment;
 
           if (shouldCreateTask) {
             LOGGER.info("Creating task for table {}, mergeLevel {}: {} segments, {} records",
                 tableNameWithType, mergeLevel, segmentNames.size(), numRecordsPerTask);
+            segmentNamesList.add(segmentNames);
+            downloadURLsList.add(downloadURLs);
+            numRecordsPerTask = 0;
+            segmentNames = new ArrayList<>();
+            downloadURLs = new ArrayList<>();
           }
-        }
-
-        if (shouldCreateTask) {
-          segmentNamesList.add(segmentNames);
-          downloadURLsList.add(downloadURLs);
-          currentTaskSizeBytes = 0;
-          numRecordsPerTask = 0;
-          segmentNames = new ArrayList<>();
-          downloadURLs = new ArrayList<>();
         }
       }
 

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskGenerator.java
@@ -737,7 +737,20 @@ public class MergeRollupTaskGenerator extends BaseTaskGenerator {
         .getSegmentGroups(tableConfig, _clusterInfoAccessor, selectedSegments);
     List<PinotTaskConfig> pinotTaskConfigs = new ArrayList<>();
 
+    // Check if size-based grouping is configured
+    long maxSegmentSizeBytesPerTask = getMaxSegmentSizeBytesPerTask(mergeConfigs);
+    boolean useSizeBasedGrouping = maxSegmentSizeBytesPerTask > 0;
+
+    if (useSizeBasedGrouping) {
+      LOGGER.info("Using size-based grouping for table {}, mergeLevel {}: maxSegmentSizeBytesPerTask={} bytes ({} MB)",
+          tableNameWithType, mergeLevel, maxSegmentSizeBytesPerTask, maxSegmentSizeBytesPerTask / (1024 * 1024));
+    } else {
+      LOGGER.info("Using row-based grouping for table {}, mergeLevel {}: maxNumRecordsPerTask={}",
+          tableNameWithType, mergeLevel, maxNumRecordsPerTask);
+    }
+
     for (List<SegmentZKMetadata> segments : segmentGroups) {
+      long currentTaskSizeBytes = 0;
       int numRecordsPerTask = 0;
       List<List<String>> segmentNamesList = new ArrayList<>();
       List<List<String>> downloadURLsList = new ArrayList<>();
@@ -748,10 +761,37 @@ public class MergeRollupTaskGenerator extends BaseTaskGenerator {
         SegmentZKMetadata targetSegment = segments.get(i);
         segmentNames.add(targetSegment.getSegmentName());
         downloadURLs.add(targetSegment.getDownloadUrl());
-        numRecordsPerTask += targetSegment.getTotalDocs();
-        if (numRecordsPerTask >= maxNumRecordsPerTask || i == segments.size() - 1) {
+
+        boolean shouldCreateTask = false;
+
+        if (useSizeBasedGrouping) {
+          // Size-based grouping: accumulate segment sizes
+          long segmentSizeBytes = targetSegment.getSizeInBytes();
+          currentTaskSizeBytes += segmentSizeBytes;
+          shouldCreateTask = (currentTaskSizeBytes >= maxSegmentSizeBytesPerTask) || (i == segments.size() - 1);
+
+          if (shouldCreateTask) {
+            LOGGER.info("Creating task for table {}, mergeLevel {}: {} segments, {} bytes ({} MB), {} records",
+                tableNameWithType, mergeLevel, segmentNames.size(), currentTaskSizeBytes,
+                currentTaskSizeBytes / (1024 * 1024),
+                segments.subList(i - segmentNames.size() + 1, i + 1).stream()
+                    .mapToLong(SegmentZKMetadata::getTotalDocs).sum());
+          }
+        } else {
+          // Row-based grouping: accumulate record counts
+          numRecordsPerTask += targetSegment.getTotalDocs();
+          shouldCreateTask = (numRecordsPerTask >= maxNumRecordsPerTask) || (i == segments.size() - 1);
+
+          if (shouldCreateTask) {
+            LOGGER.info("Creating task for table {}, mergeLevel {}: {} segments, {} records",
+                tableNameWithType, mergeLevel, segmentNames.size(), numRecordsPerTask);
+          }
+        }
+
+        if (shouldCreateTask) {
           segmentNamesList.add(segmentNames);
           downloadURLsList.add(downloadURLs);
+          currentTaskSizeBytes = 0;
           numRecordsPerTask = 0;
           segmentNames = new ArrayList<>();
           downloadURLs = new ArrayList<>();
@@ -803,6 +843,25 @@ public class MergeRollupTaskGenerator extends BaseTaskGenerator {
     }
 
     return pinotTaskConfigs;
+  }
+
+  /**
+   * Get maxSegmentSizeBytesPerTask from merge configs.
+   * Returns 0 if not configured (indicating row-based grouping should be used).
+   */
+  private long getMaxSegmentSizeBytesPerTask(Map<String, String> mergeConfigs) {
+    String value = mergeConfigs.get(MergeTask.MAX_SEGMENT_SIZE_BYTES_PER_TASK_KEY);
+    if (value != null) {
+      try {
+        long bytes = Long.parseLong(value);
+        if (bytes > 0) {
+          return bytes;
+        }
+      } catch (NumberFormatException e) {
+        LOGGER.warn("Invalid maxSegmentSizeBytesPerTask value: {}", value, e);
+      }
+    }
+    return 0;  // Not configured, use row-based grouping
   }
 
   private long getMergeRollupTaskDelayInNumTimeBuckets(long watermarkMs, @Nullable Long maxEndTimeMsOfCurrentLevel,

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskGenerator.java
@@ -768,7 +768,10 @@ public class MergeRollupTaskGenerator extends BaseTaskGenerator {
           // Size-based grouping: accumulate segment sizes
           long segmentSizeBytes = targetSegment.getSizeInBytes();
           currentTaskSizeBytes += segmentSizeBytes;
-          shouldCreateTask = (currentTaskSizeBytes >= maxSegmentSizeBytesPerTask) || (i == segments.size() - 1);
+          // Check if adding this segment would exceed the limit (and we already have segments in the task)
+          boolean wouldExceedLimit = (currentTaskSizeBytes > maxSegmentSizeBytesPerTask) && (segmentNames.size() > 1);
+          boolean isLastSegment = (i == segments.size() - 1);
+          shouldCreateTask = wouldExceedLimit || isLastSegment;
 
           if (shouldCreateTask) {
             LOGGER.info("Creating task for table {}, mergeLevel {}: {} segments, {} bytes ({} MB), {} records",

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskUtils.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskUtils.java
@@ -45,6 +45,7 @@ public class MergeRollupTaskUtils {
       MergeTask.MERGE_TYPE_KEY,
       MergeTask.MAX_NUM_RECORDS_PER_SEGMENT_KEY,
       MergeTask.MAX_NUM_RECORDS_PER_TASK_KEY,
+      MergeTask.MAX_SEGMENT_SIZE_BYTES_PER_TASK_KEY,
       MergeTask.MAX_NUM_PARALLEL_BUCKETS,
       MinionConstants.MergeRollupTask.ERASE_DIMENSION_VALUES_KEY,
       MinionConstants.MergeRollupTask.DESIRED_SEGMENT_SIZE_BYTES_KEY,

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskUtils.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskUtils.java
@@ -47,6 +47,10 @@ public class MergeRollupTaskUtils {
       MergeTask.MAX_NUM_RECORDS_PER_TASK_KEY,
       MergeTask.MAX_NUM_PARALLEL_BUCKETS,
       MinionConstants.MergeRollupTask.ERASE_DIMENSION_VALUES_KEY,
+      MinionConstants.MergeRollupTask.DESIRED_SEGMENT_SIZE_BYTES_KEY,
+      MinionConstants.MergeRollupTask.SEGMENT_SIZING_STRATEGY_KEY,
+      MinionConstants.MergeRollupTask.SIZING_PERCENTILE_KEY,
+      MinionConstants.MergeRollupTask.SIZING_LEARNING_RATE_KEY,
   };
   //@formatter:on
 

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskGeneratorTest.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskGeneratorTest.java
@@ -636,6 +636,112 @@ public class MergeRollupTaskGeneratorTest {
     checkPinotTaskConfig(pinotTaskConfigs.get(1).getConfigs(), segmentName3, DAILY, "concat", "1d", null, "1000000");
   }
 
+  /**
+   * Test max segment size bytes per task
+   */
+  @Test
+  public void testMaxSegmentSizeBytesPerTask() {
+    Map<String, Map<String, String>> taskConfigsMap = new HashMap<>();
+    Map<String, String> tableTaskConfigs = new HashMap<>();
+    tableTaskConfigs.put(DAILY + ".mergeType", "concat");
+    tableTaskConfigs.put(DAILY + ".bufferTimePeriod", "2d");
+    tableTaskConfigs.put(DAILY + ".bucketTimePeriod", "1d");
+    tableTaskConfigs.put(DAILY + ".maxNumRecordsPerSegment", "1000000");
+    tableTaskConfigs.put(DAILY + ".maxSegmentSizeBytesPerTask", "104857600"); // 100MB
+    taskConfigsMap.put(MinionConstants.MergeRollupTask.TASK_TYPE, tableTaskConfigs);
+    TableConfig offlineTableConfig = getTableConfig(TableType.OFFLINE, taskConfigsMap);
+    ClusterInfoAccessor mockClusterInfoProvide = mock(ClusterInfoAccessor.class);
+
+    String segmentName1 = "testTable__1";
+    String segmentName2 = "testTable__2";
+    SegmentZKMetadata metadata1 =
+        getSegmentZKMetadata(segmentName1, 86_400_000L, 90_000_000L, TimeUnit.MILLISECONDS, "download1");
+    metadata1.setTotalDocs(2000000L);
+    metadata1.setSizeInBytes(52428800L); // 50MB
+    SegmentZKMetadata metadata2 =
+        getSegmentZKMetadata(segmentName2, 86_400_000L, 100_000_000L, TimeUnit.MILLISECONDS, "download2");
+    metadata2.setTotalDocs(4000000L);
+    metadata2.setSizeInBytes(62914560L); // 60MB
+    when(mockClusterInfoProvide.getSegmentsZKMetadata(OFFLINE_TABLE_NAME)).thenReturn(
+        Lists.newArrayList(metadata1, metadata2));
+    when(mockClusterInfoProvide.getIdealState(OFFLINE_TABLE_NAME)).thenReturn(
+        getIdealState(OFFLINE_TABLE_NAME, Lists.newArrayList(segmentName1, segmentName2)));
+
+    // Single task (both segments fit under 100MB limit)
+    MergeRollupTaskGenerator generator = new MergeRollupTaskGenerator();
+    generator.init(mockClusterInfoProvide);
+    List<PinotTaskConfig> pinotTaskConfigs = generator.generateTasks(Lists.newArrayList(offlineTableConfig));
+    assertEquals(pinotTaskConfigs.size(), 1);
+    checkPinotTaskConfig(pinotTaskConfigs.get(0).getConfigs(), segmentName1 + "," + segmentName2, DAILY, "concat", "1d",
+        null, "1000000");
+    assertEquals(pinotTaskConfigs.get(0).getConfigs().get(MinionConstants.DOWNLOAD_URL_KEY), "download1,download2");
+
+    // Multiple tasks when segments exceed size limit
+    String segmentName3 = "testTable__3";
+    String segmentName4 = "testTable__4";
+    SegmentZKMetadata metadata3 =
+        getSegmentZKMetadata(segmentName3, 86_400_000L, 110_000_000L, TimeUnit.MILLISECONDS, null);
+    metadata3.setTotalDocs(3000000L);
+    metadata3.setSizeInBytes(52428800L); // 50MB
+    SegmentZKMetadata metadata4 =
+        getSegmentZKMetadata(segmentName4, 86_400_000L, 120_000_000L, TimeUnit.MILLISECONDS, null);
+    metadata4.setTotalDocs(4000000L);
+    metadata4.setSizeInBytes(62914560L); // 60MB
+    when(mockClusterInfoProvide.getSegmentsZKMetadata(OFFLINE_TABLE_NAME)).thenReturn(
+        Lists.newArrayList(metadata1, metadata2, metadata3, metadata4));
+    when(mockClusterInfoProvide.getIdealState(OFFLINE_TABLE_NAME)).thenReturn(
+        getIdealState(OFFLINE_TABLE_NAME, Lists.newArrayList(segmentName1, segmentName2, segmentName3, segmentName4)));
+
+    // With 4 segments @ 50+60+50+60 MB, should create: task1=(seg1+seg2=110MB), task2=(seg3+seg4=110MB)
+    pinotTaskConfigs = generator.generateTasks(Lists.newArrayList(offlineTableConfig));
+    assertEquals(pinotTaskConfigs.size(), 2);
+    checkPinotTaskConfig(pinotTaskConfigs.get(0).getConfigs(), segmentName1 + "," + segmentName2, DAILY, "concat", "1d",
+        null, "1000000");
+    checkPinotTaskConfig(pinotTaskConfigs.get(1).getConfigs(), segmentName3 + "," + segmentName4, DAILY, "concat", "1d",
+        null, "1000000");
+  }
+
+  /**
+   * Test backwards compatibility: when maxSegmentSizeBytesPerTask is not set, fall back to row-based grouping
+   */
+  @Test
+  public void testBackwardsCompatibilityWithRowBasedGrouping() {
+    Map<String, Map<String, String>> taskConfigsMap = new HashMap<>();
+    Map<String, String> tableTaskConfigs = new HashMap<>();
+    tableTaskConfigs.put(DAILY + ".mergeType", "concat");
+    tableTaskConfigs.put(DAILY + ".bufferTimePeriod", "2d");
+    tableTaskConfigs.put(DAILY + ".bucketTimePeriod", "1d");
+    tableTaskConfigs.put(DAILY + ".maxNumRecordsPerSegment", "1000000");
+    tableTaskConfigs.put(DAILY + ".maxNumRecordsPerTask", "5000000");
+    // Note: maxSegmentSizeBytesPerTask NOT set
+    taskConfigsMap.put(MinionConstants.MergeRollupTask.TASK_TYPE, tableTaskConfigs);
+    TableConfig offlineTableConfig = getTableConfig(TableType.OFFLINE, taskConfigsMap);
+    ClusterInfoAccessor mockClusterInfoProvide = mock(ClusterInfoAccessor.class);
+
+    String segmentName1 = "testTable__1";
+    String segmentName2 = "testTable__2";
+    SegmentZKMetadata metadata1 =
+        getSegmentZKMetadata(segmentName1, 86_400_000L, 90_000_000L, TimeUnit.MILLISECONDS, "download1");
+    metadata1.setTotalDocs(2000000L);
+    metadata1.setSizeInBytes(52428800L); // 50MB
+    SegmentZKMetadata metadata2 =
+        getSegmentZKMetadata(segmentName2, 86_400_000L, 100_000_000L, TimeUnit.MILLISECONDS, "download2");
+    metadata2.setTotalDocs(4000000L);
+    metadata2.setSizeInBytes(62914560L); // 60MB
+    when(mockClusterInfoProvide.getSegmentsZKMetadata(OFFLINE_TABLE_NAME)).thenReturn(
+        Lists.newArrayList(metadata1, metadata2));
+    when(mockClusterInfoProvide.getIdealState(OFFLINE_TABLE_NAME)).thenReturn(
+        getIdealState(OFFLINE_TABLE_NAME, Lists.newArrayList(segmentName1, segmentName2)));
+
+    // Should use row-based grouping (both segments have 6M total rows, under 5M limit per task)
+    MergeRollupTaskGenerator generator = new MergeRollupTaskGenerator();
+    generator.init(mockClusterInfoProvide);
+    List<PinotTaskConfig> pinotTaskConfigs = generator.generateTasks(Lists.newArrayList(offlineTableConfig));
+    assertEquals(pinotTaskConfigs.size(), 1);
+    checkPinotTaskConfig(pinotTaskConfigs.get(0).getConfigs(), segmentName1 + "," + segmentName2, DAILY, "concat", "1d",
+        null, "1000000");
+  }
+
   /// Test num parallel buckets
   @Test
   public void testNumParallelBuckets() {

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskGeneratorTest.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskGeneratorTest.java
@@ -636,9 +636,7 @@ public class MergeRollupTaskGeneratorTest {
     checkPinotTaskConfig(pinotTaskConfigs.get(1).getConfigs(), segmentName3, DAILY, "concat", "1d", null, "1000000");
   }
 
-  /**
-   * Test max segment size bytes per task
-   */
+  /// Test max segment size bytes per task
   @Test
   public void testMaxSegmentSizeBytesPerTask() {
     Map<String, Map<String, String>> taskConfigsMap = new HashMap<>();
@@ -667,14 +665,15 @@ public class MergeRollupTaskGeneratorTest {
     when(mockClusterInfoProvide.getIdealState(OFFLINE_TABLE_NAME)).thenReturn(
         getIdealState(OFFLINE_TABLE_NAME, Lists.newArrayList(segmentName1, segmentName2)));
 
-    // Single task (both segments fit under 100MB limit)
+    // Each segment lands in its own task: 50MB + 60MB would exceed the 100MB cap.
     MergeRollupTaskGenerator generator = new MergeRollupTaskGenerator();
     generator.init(mockClusterInfoProvide);
     List<PinotTaskConfig> pinotTaskConfigs = generator.generateTasks(Lists.newArrayList(offlineTableConfig));
-    assertEquals(pinotTaskConfigs.size(), 1);
-    checkPinotTaskConfig(pinotTaskConfigs.get(0).getConfigs(), segmentName1 + "," + segmentName2, DAILY, "concat", "1d",
-        null, "1000000");
-    assertEquals(pinotTaskConfigs.get(0).getConfigs().get(MinionConstants.DOWNLOAD_URL_KEY), "download1,download2");
+    assertEquals(pinotTaskConfigs.size(), 2);
+    checkPinotTaskConfig(pinotTaskConfigs.get(0).getConfigs(), segmentName1, DAILY, "concat", "1d", null, "1000000");
+    checkPinotTaskConfig(pinotTaskConfigs.get(1).getConfigs(), segmentName2, DAILY, "concat", "1d", null, "1000000");
+    assertEquals(pinotTaskConfigs.get(0).getConfigs().get(MinionConstants.DOWNLOAD_URL_KEY), "download1");
+    assertEquals(pinotTaskConfigs.get(1).getConfigs().get(MinionConstants.DOWNLOAD_URL_KEY), "download2");
 
     // Multiple tasks when segments exceed size limit
     String segmentName3 = "testTable__3";
@@ -692,18 +691,16 @@ public class MergeRollupTaskGeneratorTest {
     when(mockClusterInfoProvide.getIdealState(OFFLINE_TABLE_NAME)).thenReturn(
         getIdealState(OFFLINE_TABLE_NAME, Lists.newArrayList(segmentName1, segmentName2, segmentName3, segmentName4)));
 
-    // With 4 segments @ 50+60+50+60 MB, should create: task1=(seg1+seg2=110MB), task2=(seg3+seg4=110MB)
+    // No two of these segments fit under the cap, so each gets its own task.
     pinotTaskConfigs = generator.generateTasks(Lists.newArrayList(offlineTableConfig));
-    assertEquals(pinotTaskConfigs.size(), 2);
-    checkPinotTaskConfig(pinotTaskConfigs.get(0).getConfigs(), segmentName1 + "," + segmentName2, DAILY, "concat", "1d",
-        null, "1000000");
-    checkPinotTaskConfig(pinotTaskConfigs.get(1).getConfigs(), segmentName3 + "," + segmentName4, DAILY, "concat", "1d",
-        null, "1000000");
+    assertEquals(pinotTaskConfigs.size(), 4);
+    checkPinotTaskConfig(pinotTaskConfigs.get(0).getConfigs(), segmentName1, DAILY, "concat", "1d", null, "1000000");
+    checkPinotTaskConfig(pinotTaskConfigs.get(1).getConfigs(), segmentName2, DAILY, "concat", "1d", null, "1000000");
+    checkPinotTaskConfig(pinotTaskConfigs.get(2).getConfigs(), segmentName3, DAILY, "concat", "1d", null, "1000000");
+    checkPinotTaskConfig(pinotTaskConfigs.get(3).getConfigs(), segmentName4, DAILY, "concat", "1d", null, "1000000");
   }
 
-  /**
-   * Test backwards compatibility: when maxSegmentSizeBytesPerTask is not set, fall back to row-based grouping
-   */
+  /// Test backwards compatibility: when maxSegmentSizeBytesPerTask is not set, fall back to row-based grouping
   @Test
   public void testBackwardsCompatibilityWithRowBasedGrouping() {
     Map<String, Map<String, String>> taskConfigsMap = new HashMap<>();


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Adds adaptive segment sizing providers and size\-based task grouping to MergeRollupTask for variable\-sized data\.

```mermaid
flowchart TD
  N0["MergeRollupTaskExecutor#46;convert #40;F4#41;"]:::stModified
  N1["createSegmentNumRowProvider #40;F4#41;"]:::stModified
  N2["AdaptiveSegmentNumRowProvider #40;F2#41;"]:::stAdded
  N3["PercentileAdaptiveSegmentNumRowProvider #40;F3#41;"]:::stAdded
  N4["SegmentProcessorFramework #40;F4#41;"]:::stModified
  N5["MergeRollupTaskGenerator#46;createPinotTaskConfigs #40;F5#41;"]:::stModified
  N6["Size#45;based segment grouping #40;F5#41;"]:::stModified
  N7["Row#45;based segment grouping #40;F5#41;"]:::stModified
  N8["getMaxSegmentSizeBytesPerTask #40;F5#41;"]:::stModified
  N0 -->|"calls"| N1
  N0 -->|"calls"| N4
  N1 -->|"returns"| N2
  N1 -->|"returns"| N3
  N1 -->|"provides"| N4
  N5 -->|"calls"| N8
  N8 -->|"influences"| N6
  N8 -->|"influences"| N7
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F2: pinot\-core/src/main/java/org/apache/pinot/core/segment/processing/framework/AdaptiveSegmentNumRowProvider\.java — [after](https://github.com/apache/pinot/blob/d19193eb011775f700a1b0c274749a7f5f2aa46e/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/framework/AdaptiveSegmentNumRowProvider.java)
- F3: pinot\-core/src/main/java/org/apache/pinot/core/segment/processing/framework/PercentileAdaptiveSegmentNumRowProvider\.java — [after](https://github.com/apache/pinot/blob/d19193eb011775f700a1b0c274749a7f5f2aa46e/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/framework/PercentileAdaptiveSegmentNumRowProvider.java)
- F4: pinot\-plugins/pinot\-minion\-tasks/pinot\-minion\-builtin\-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskExecutor\.java — [before](https://github.com/apache/pinot/blob/f5fee8e7023af2af57e249493da1c8649a33ecb5/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskExecutor.java) · [after](https://github.com/apache/pinot/blob/d19193eb011775f700a1b0c274749a7f5f2aa46e/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskExecutor.java)
- F5: pinot\-plugins/pinot\-minion\-tasks/pinot\-minion\-builtin\-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskGenerator\.java — [before](https://github.com/apache/pinot/blob/f5fee8e7023af2af57e249493da1c8649a33ecb5/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskGenerator.java) · [after](https://github.com/apache/pinot/blob/d19193eb011775f700a1b0c274749a7f5f2aa46e/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskGenerator.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImY1ZmVlOGU3MDIzYWYyYWY1N2UyNDk0OTNkYTFjODY0OWEzM2VjYjUiLCJjb250ZXh0X2hhc2giOiIzM2M0ZDQxMjkzOThlN2NlY2I3NmNiMGM1OTJiZDMxMTI3MGQ3OTI4OWVjYWI3MmJlNjNmYzljYWVmMjdhZjY5IiwiZ2VuZXJhdGVkX2F0IjoxNzg5ODk2NjE5LCJoZWFkX3NoYSI6ImQxOTE5M2ViMDExNzc1ZjcwMGExYjBjMjc0NzQ5YTdmNWYyYWE0NmUiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJmNWZlZThlNzAyM2FmMmFmNTdlMjQ5NDkzZGExYzg2NDlhMzNlY2I1IiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 23f0fb70b1465c799e2f825663404e7320d00dea5270604ebf10494572cdf990 -->
<!-- pinot-pr-flow:end -->

Summary
----------

Enable size-based segment generation for tables with variable-sized data
(e.g., Theta sketches) where static row counts produce inconsistent segment
sizes.  Finally, adds size-based segment grouping for MergeRollupTask.

Implemented two strategies:

- AdaptiveSegmentNumRowProvider: EMA-based learning for homogeneous data
- PercentileAdaptiveSegmentNumRowProvider: Reservoir sampling with percentile
  estimation for heterogeneous/multi-tenant data (resistant to outliers)

Configuration reads directly from MergeRollupTask config map, following the
eraseDimensionValues pattern. No changes to shared SegmentConfig or framework.

```
Example config:
{
  "MergeRollupTask": {
    "maxSegmentSizeBytesPerTask": "4194000",
    "desiredSegmentSizeBytes": "209715200",
    "segmentSizingStrategy": "PERCENTILE",
    "sizingPercentile": "75"
  }
}
```

Instructions:
------------

The PR has to be tagged with at least one of the following labels (*):
- `feature`
- `performance`
- `release-notes` - New configuration options
