### PR TITLE
Upgrade async profiler version

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -575,7 +575,7 @@ software.amazon.awssdk:third-party-jackson-core:2.31.78
 software.amazon.awssdk:third-party-jackson-dataformat-cbor:2.31.78
 software.amazon.awssdk:utils:2.31.78
 software.amazon.eventstream:eventstream:1.0.1
-tools.profiler:async-profiler:2.9
+tools.profiler:async-profiler:4.3
 xml-apis:xml-apis:1.0.b2
 
 ------------------------------------------------------------------------------------

--- a/docker/images/pinot-base/pinot-base-runtime/amazoncorretto.dockerfile
+++ b/docker/images/pinot-base/pinot-base-runtime/amazoncorretto.dockerfile
@@ -34,7 +34,7 @@ RUN case `uname -m` in \
   *) echo "platform=$(uname -m) un-supported, exit ..."; exit 1; ;; \
   esac \
   && mkdir -p /usr/local/lib/async-profiler \
-  && curl -L https://github.com/jvm-profiling-tools/async-profiler/releases/download/v2.9/async-profiler-2.9-linux-${arch}.tar.gz | tar -xz --strip-components 1 -C /usr/local/lib/async-profiler \
-  && ln -s /usr/local/lib/async-profiler/profiler.sh /usr/local/bin/async-profiler
+  && curl -L https://github.com/async-profiler/async-profiler/releases/download/v4.3/async-profiler-4.3-linux-${arch}.tar.gz | tar -xz --strip-components 1 -C /usr/local/lib/async-profiler \
+  && ln -s /usr/local/lib/async-profiler/bin/asprof /usr/local/bin/async-profiler
 
 CMD ["bash"]

--- a/docker/images/pinot-base/pinot-base-runtime/ms-openjdk.dockerfile
+++ b/docker/images/pinot-base/pinot-base-runtime/ms-openjdk.dockerfile
@@ -41,7 +41,7 @@ RUN case `uname -m` in \
   *) echo "platform=$(uname -m) un-supported, exit ..."; exit 1; ;; \
   esac \
   && mkdir -p /usr/local/lib/async-profiler \
-  && curl -L https://github.com/jvm-profiling-tools/async-profiler/releases/download/v2.9/async-profiler-2.9-linux-${arch}.tar.gz | tar -xz --strip-components 1 -C /usr/local/lib/async-profiler \
-  && ln -s /usr/local/lib/async-profiler/profiler.sh /usr/local/bin/async-profiler
+  && curl -L https://github.com/async-profiler/async-profiler/releases/download/v4.3/async-profiler-4.3-linux-${arch}.tar.gz | tar -xz --strip-components 1 -C /usr/local/lib/async-profiler \
+  && ln -s /usr/local/lib/async-profiler/bin/asprof /usr/local/bin/async-profiler
 
 CMD ["bash"]

--- a/docker/images/pinot-base/pinot-base-runtime/openjdk.dockerfile
+++ b/docker/images/pinot-base/pinot-base-runtime/openjdk.dockerfile
@@ -33,7 +33,7 @@ RUN case `uname -m` in \
   *) echo "platform=$(uname -m) un-supported, exit ..."; exit 1; ;; \
   esac \
   && mkdir -p /usr/local/lib/async-profiler \
-  && curl -L https://github.com/jvm-profiling-tools/async-profiler/releases/download/v2.9/async-profiler-2.9-linux-${arch}.tar.gz | tar -xz --strip-components 1 -C /usr/local/lib/async-profiler \
-  && ln -s /usr/local/lib/async-profiler/profiler.sh /usr/local/bin/async-profiler
+  && curl -L https://github.com/async-profiler/async-profiler/releases/download/v4.3/async-profiler-4.3-linux-${arch}.tar.gz | tar -xz --strip-components 1 -C /usr/local/lib/async-profiler \
+  && ln -s /usr/local/lib/async-profiler/bin/asprof /usr/local/bin/async-profiler
 
 CMD ["bash"]


### PR DESCRIPTION
### Summary
- Upgrade async-profiler from v2.9 to v4.3 (latest stable) in all Docker base runtime images
- Update the GitHub download URL from the old jvm-profiling-tools org to the new async-profiler org
- Update the symlink target from profiler.sh to bin/asprof (renamed in v3.0)
- Update LICENSE-binary to reflect the new version

### Details
The bundled async-profiler in our Docker images was at v2.9, which is over two major versions behind. This PR upgrades to v4.3 which brings significant improvements including:
- Native lock profiling
- CPU/wall profile filtering by latency
- Prometheus metrics format support
- async-profiler.jar as a Java agent with remote JMX control
- FlameGraph improvements (legend, hot keys, new toolbar icons)
- Heatmap timezone switcher (Local/UTC)
- OTLP v1.9.0 compatibility
- Various crash protection and race condition fixes
## Breaking changes addressed:
- The project moved from the jvm-profiling-tools GitHub org to async-profiler -- download URLs updated accordingly.
- The main CLI script was renamed from `profiler.sh` to `bin/asprof` in v3.0 -- symlink target updated. The `/usr/local/bin/async-profiler` symlink name is preserved for backward compatibility.

### Test plan
- [x] Verified both linux-x64 and linux-arm64 download URLs return HTTP 200
- [x] Downloaded the linux-x64 tarball and confirmed bin/asprof exists and is executable after extraction with --strip-components 1
- [x] Docker image build with the updated Dockerfiles
