### PR TITLE
Make topic exists error silent in Kafka 3.0 createTopic

### DIFF
--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/main/java/org/apache/pinot/plugin/stream/kafka30/server/KafkaServerStartable.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/main/java/org/apache/pinot/plugin/stream/kafka30/server/KafkaServerStartable.java
@@ -170,6 +170,11 @@ public class KafkaServerStartable implements StreamDataServerStartable {
       runAdminWithRetry(() -> adminClient.createTopics(Collections.singletonList(newTopic)).all().get(),
           "create topic: " + topic);
     } catch (Exception e) {
+      if (e instanceof ExecutionException
+          && e.getCause() instanceof org.apache.kafka.common.errors.TopicExistsException) {
+        // Topic already exists, skip creation silently
+        return;
+      }
       throw new RuntimeException("Failed to create topic: " + topic, e);
     }
   }


### PR DESCRIPTION
## Summary
Handle `TopicExistsException` in `KafkaServerStartable.createTopic` by returning silently when the topic already exists, matching the behavior of kafka20 clients.

## Problem
Quickstart fails with `RuntimeException: Failed to create topic: flights-realtime` when the topic already exists (e.g., from a previous run).

## Solution
Catch `ExecutionException` with cause `TopicExistsException` and return silently instead of rethrowing, consistent with kafka20 behavior.

## Testing
- `KafkaServerStartableTest` passes

Made with [Cursor](https://cursor.com)