### PR TITLE
Add Prometheus export rule for tasksTrackedForTaskType

### DIFF
--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/controller.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/controller.yml
@@ -17,7 +17,7 @@ rules:
     tableType: "$6"
     partition: "$7"
 # Gauges that accept the controller taskType
-- pattern: "\"org\\.apache\\.pinot\\.common\\.metrics\"<type=\"ControllerMetrics\", name=\"pinot\\.controller\\.(numMinionTasksInProgress|numMinionSubtasksRunning|numMinionSubtasksWaiting|numMinionSubtasksError|numMinionSubtasksUnknown|numMinionSubtasksDropped|numMinionSubtasksTimedOut|numMinionSubtasksAborted|percentMinionSubtasksInQueue|percentMinionSubtasksInError)\\.(\\w+)\"><>(\\w+)"
+- pattern: "\"org\\.apache\\.pinot\\.common\\.metrics\"<type=\"ControllerMetrics\", name=\"pinot\\.controller\\.(numMinionTasksInProgress|numMinionSubtasksRunning|numMinionSubtasksWaiting|numMinionSubtasksError|numMinionSubtasksUnknown|numMinionSubtasksDropped|numMinionSubtasksTimedOut|numMinionSubtasksAborted|percentMinionSubtasksInQueue|percentMinionSubtasksInError|tasksTrackedForTaskType)\\.(\\w+)\"><>(\\w+)"
   name: "pinot_controller_$1_$3"
   cache: true
   labels:

--- a/pinot-common/src/test/java/org/apache/pinot/common/metrics/prometheus/ControllerPrometheusMetricsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/metrics/prometheus/ControllerPrometheusMetricsTest.java
@@ -178,6 +178,10 @@ public abstract class ControllerPrometheusMetricsTest extends PinotPrometheusMet
             String.format("%s.%s", ExportedLabelValues.CONTROLLER_PERIODIC_TASK_CHC, TaskState.IN_PROGRESS));
         assertGaugeExportedCorrectly(ControllerGauge.TASK_STATUS.getGaugeName(),
             ExportedLabels.JOBSTATUS_CONTROLLER_TASKTYPE, EXPORTED_METRIC_PREFIX);
+      } else if (controllerGauge == ControllerGauge.TASKS_TRACKED_FOR_TASK_TYPE) {
+        addGaugeWithLabels(controllerGauge, ExportedLabelValues.CONTROLLER_PERIODIC_TASK_CHC);
+        assertGaugeExportedCorrectly(controllerGauge.getGaugeName(),
+            List.of(LABEL_KEY_TASK_TYPE, ExportedLabelValues.CONTROLLER_PERIODIC_TASK_CHC), EXPORTED_METRIC_PREFIX);
       } else {
         addGaugeWithLabels(controllerGauge, TABLE_NAME_WITH_TYPE);
         assertGaugeExportedCorrectly(controllerGauge.getGaugeName(), ExportedLabels.TABLENAME_TABLETYPE,


### PR DESCRIPTION
## Summary

- Add `tasksTrackedForTaskType` to the existing task-type regex pattern in `controller.yml` so the `TASKS_TRACKED_FOR_TASK_TYPE` gauge (introduced in #17741) is exported as `pinot_controller_tasksTrackedForTaskType_Value{taskType="..."}`.
- Add corresponding test coverage in `ControllerPrometheusMetricsTest` to verify the gauge is exported with the correct `taskType` label.

## Test plan

- [x] `YammerControllerPrometheusMetricsTest` passes with the new assertion for `TASKS_TRACKED_FOR_TASK_TYPE`
- [x] Manually verified with local QuickStart + JMX Prometheus agent that `pinot_controller_tasksTrackedForTaskType_Value{taskType="HelloWorld"}`  appears at `localhost:9021/metrics` after scheduling a task
```
❯ curl -s http://localhost:9021/metrics | grep -i tasksTrackedForTaskType
# HELP pinot_controller_tasksTrackedForTaskType_Value Attribute exposed for management "org.apache.pinot.common.metrics":name="pinot.controller.tasksTrackedForTaskType.MergeRollupTask",type="ControllerMetrics",attribute=Value
# TYPE pinot_controller_tasksTrackedForTaskType_Value untyped
pinot_controller_tasksTrackedForTaskType_Value{taskType="MergeRollupTask",} 1.0
pinot_controller_tasksTrackedForTaskType_Value{taskType="RealtimeToOfflineSegmentsTask",} 2.0
```