### PR TITLE
Adding new API to register backward compatible class names

### DIFF
--- a/pinot-spi/src/main/java/org/apache/pinot/spi/plugin/PluginManager.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/plugin/PluginManager.java
@@ -496,4 +496,16 @@ public class PluginManager {
       INPUT_FORMAT_TO_RECORD_READER_CONFIG_CLASS_NAME_MAP.put(inputFormat.toLowerCase(), recordReaderConfigClass);
     }
   }
+
+  // Register plugin class names when users try to deprecate old plugins/libraries.
+  public void registerBackwardCompatibleClassName(String oldClassName, String newClassName) {
+    String existingNewClassName = PLUGINS_BACKWARD_COMPATIBLE_CLASS_NAME_MAP.put(oldClassName, newClassName);
+    if (existingNewClassName != null) {
+      LOGGER.warn("There is already a mapping for backward compatible class from old [{}] to [{}], override it to [{}]",
+          oldClassName, existingNewClassName, newClassName);
+    } else {
+      LOGGER.info("Registered backward compatible class name mapping from old [{}] to new [{}]", oldClassName,
+          newClassName);
+    }
+  }
 }


### PR DESCRIPTION
This pull request introduces a new method to the `PluginManager` class to support backward compatibility for plugin class names. This allows users to register mappings from deprecated class names to their new equivalents, helping maintain compatibility when plugins or libraries are updated.

**Backward compatibility support:**

* Added a `registerBackwardCompatibleClassName` method to `PluginManager` that lets users map old plugin class names to new ones for smoother deprecation and migration processes.