### PR TITLE
Fix MissingFormatArgumentException due to log

### DIFF
--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/memory/EmptyIndexBuffer.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/memory/EmptyIndexBuffer.java
@@ -60,128 +60,110 @@ public class EmptyIndexBuffer extends PinotDataBuffer {
   @Override
   public byte getByte(long offset) {
     throw new UnsupportedOperationException(
-        String.format("Cannot read from empty buffer for index: %s, segment: %s, table: %s", _segmentName,
-            _tableNameWithType));
+        "Cannot read from empty buffer for segment: " + _segmentName + ", table: " + _tableNameWithType);
   }
 
   @Override
   public void putByte(long offset, byte value) {
     throw new UnsupportedOperationException(
-        String.format("Cannot write to empty buffer for index: %s, segment: %s, table: %s", _segmentName,
-            _tableNameWithType));
+        "Cannot write to empty buffer for segment: " + _segmentName + ", table: " + _tableNameWithType);
   }
 
   @Override
   public char getChar(long offset) {
     throw new UnsupportedOperationException(
-        String.format("Cannot read from empty buffer for index: %s, segment: %s, table: %s", _segmentName,
-            _tableNameWithType));
+        "Cannot read from empty buffer for segment: " + _segmentName + ", table: " + _tableNameWithType);
   }
 
   @Override
   public void putChar(long offset, char value) {
     throw new UnsupportedOperationException(
-        String.format("Cannot write to empty buffer for index: %s, segment: %s, table: %s", _segmentName,
-            _tableNameWithType));
+        "Cannot write to empty buffer for segment: " + _segmentName + ", table: " + _tableNameWithType);
   }
 
   @Override
   public short getShort(long offset) {
     throw new UnsupportedOperationException(
-        String.format("Cannot read from empty buffer for index: %s, segment: %s, table: %s", _segmentName,
-            _tableNameWithType));
+        "Cannot read from empty buffer for segment: " + _segmentName + ", table: " + _tableNameWithType);
   }
 
   @Override
   public void putShort(long offset, short value) {
     throw new UnsupportedOperationException(
-        String.format("Cannot write to empty buffer for index: %s, segment: %s, table: %s", _segmentName,
-            _tableNameWithType));
+        "Cannot write to empty buffer for segment: " + _segmentName + ", table: " + _tableNameWithType);
   }
 
   @Override
   public int getInt(long offset) {
     throw new UnsupportedOperationException(
-        String.format("Cannot read from empty buffer for index: %s, segment: %s, table: %s", _segmentName,
-            _tableNameWithType));
+        "Cannot read from empty buffer for segment: " + _segmentName + ", table: " + _tableNameWithType);
   }
 
   @Override
   public void putInt(long offset, int value) {
     throw new UnsupportedOperationException(
-        String.format("Cannot write to empty buffer for index: %s, segment: %s, table: %s", _segmentName,
-            _tableNameWithType));
+        "Cannot write to empty buffer for segment: " + _segmentName + ", table: " + _tableNameWithType);
   }
 
   @Override
   public long getLong(long offset) {
     throw new UnsupportedOperationException(
-        String.format("Cannot read from empty buffer for index: %s, segment: %s, table: %s", _segmentName,
-            _tableNameWithType));
+        "Cannot read from empty buffer for segment: " + _segmentName + ", table: " + _tableNameWithType);
   }
 
   @Override
   public void putLong(long offset, long value) {
     throw new UnsupportedOperationException(
-        String.format("Cannot write to empty buffer for index: %s, segment: %s, table: %s", _segmentName,
-            _tableNameWithType));
+        "Cannot write to empty buffer for segment: " + _segmentName + ", table: " + _tableNameWithType);
   }
 
   @Override
   public float getFloat(long offset) {
     throw new UnsupportedOperationException(
-        String.format("Cannot read from empty buffer for index: %s, segment: %s, table: %s", _segmentName,
-            _tableNameWithType));
+        "Cannot read from empty buffer for segment: " + _segmentName + ", table: " + _tableNameWithType);
   }
 
   @Override
   public void putFloat(long offset, float value) {
     throw new UnsupportedOperationException(
-        String.format("Cannot write to empty buffer for index: %s, segment: %s, table: %s", _segmentName,
-            _tableNameWithType));
+        "Cannot write to empty buffer for segment: " + _segmentName + ", table: " + _tableNameWithType);
   }
 
   @Override
   public double getDouble(long offset) {
     throw new UnsupportedOperationException(
-        String.format("Cannot read from empty buffer for index: %s, segment: %s, table: %s", _segmentName,
-            _tableNameWithType));
+        "Cannot read from empty buffer for segment: " + _segmentName + ", table: " + _tableNameWithType);
   }
 
   @Override
   public void putDouble(long offset, double value) {
     throw new UnsupportedOperationException(
-        String.format("Cannot write to empty buffer for index: %s, segment: %s, table: %s", _segmentName,
-            _tableNameWithType));
+        "Cannot write to empty buffer for segment: " + _segmentName + ", table: " + _tableNameWithType);
   }
 
   @Override
   public void copyTo(long offset, byte[] buffer, int destOffset, int size) {
     throw new UnsupportedOperationException(
-        String.format("Cannot copy from empty buffer for index: %s, segment: %s, table: %s", _segmentName,
-            _tableNameWithType));
+        "Cannot copy from empty buffer for segment: " + _segmentName + ", table: " + _tableNameWithType);
   }
 
   @Override
   public void readFrom(long offset, byte[] buffer, int srcOffset, int size) {
     throw new UnsupportedOperationException(
-        String.format("Cannot write to empty buffer for index: %s, segment: %s, table: %s", _segmentName,
-            _tableNameWithType));
+        "Cannot write to empty buffer for segment: " + _segmentName + ", table: " + _tableNameWithType);
   }
 
   @Override
   public void readFrom(long offset, ByteBuffer buffer) {
     throw new UnsupportedOperationException(
-        String.format("Cannot write to empty buffer for index: %s, segment: %s, table: %s", _segmentName,
-            _tableNameWithType));
+        "Cannot write to empty buffer for segment: " + _segmentName + ", table: " + _tableNameWithType);
   }
 
   @Override
   public void readFrom(long offset, java.io.File file, long srcOffset, long size)
       throws IOException {
     throw new UnsupportedOperationException(
-        String.format("Cannot write to empty buffer for index: %s, segment: %s, table: %s", _segmentName,
-            _tableNameWithType));
+        "Cannot write to empty buffer for segment: " + _segmentName + ", table: " + _tableNameWithType);
   }
 
   @Override
@@ -200,8 +182,8 @@ public class EmptyIndexBuffer extends PinotDataBuffer {
       return this; // Return self for zero-size view
     }
     throw new IllegalArgumentException(
-        String.format("Invalid view range [%d, %d) for empty buffer. Index: %s, segment: %s, table: %s", start, end,
-            _segmentName, _tableNameWithType));
+        "Invalid view range [" + start + ", " + end + ") for empty buffer. Segment: " + _segmentName
+            + ", table: " + _tableNameWithType);
   }
 
   @Override
@@ -221,15 +203,15 @@ public class EmptyIndexBuffer extends PinotDataBuffer {
       return ByteBuffer.allocate(0).order(byteOrder);
     }
     throw new IllegalArgumentException(
-        String.format("Cannot create ByteBuffer of size %d from empty buffer. Index: %s, segment: %s, table: %s", size,
-            _segmentName, _tableNameWithType));
+        "Cannot create ByteBuffer of size " + size + " from empty buffer. Segment: " + _segmentName
+            + ", table: " + _tableNameWithType);
   }
 
   @Override
   public ImmutableRoaringBitmap viewAsRoaringBitmap(long offset, int length) {
     throw new IllegalArgumentException(
-        String.format("Cannot create RoaringBitmap of length %d from empty buffer. Index: %s, segment: %s, table: %s",
-            length, _segmentName, _tableNameWithType));
+        "Cannot create RoaringBitmap of length " + length + " from empty buffer. Segment: " + _segmentName
+            + ", table: " + _tableNameWithType);
   }
 
   @Override
@@ -256,8 +238,7 @@ public class EmptyIndexBuffer extends PinotDataBuffer {
 
   @Override
   public String toString() {
-    return String.format("EmptyIndexBuffer{ segmentName=%s, tableNameWithType=%s, segmentPath=%s, size=0}",
-        _segmentName, _tableNameWithType);
+    return "EmptyIndexBuffer{segmentName=" + _segmentName + ", tableNameWithType=" + _tableNameWithType + ", size=0}";
   }
 
   @Override


### PR DESCRIPTION
```
ERROR [ColumnMinMaxValueGenerator] [HelixTaskExecutor-message_handle_thread_10] Caught exception while generating min/max value for column: id in segment: <Redacted>, continuing without persisting them
java.util.MissingFormatArgumentException: Format specifier '%s'
	at java.base/java.util.Formatter.format(Formatter.java:2790)
	at java.base/java.util.Formatter.format(Formatter.java:2728)
	at java.base/java.lang.String.format(String.java:4379)
	at org.apache.pinot.segment.spi.memory.EmptyIndexBuffer.getInt(EmptyIndexBuffer.java:105)
	at org.apache.pinot.segment.spi.memory.PinotDataBuffer.getInt(PinotDataBuffer.java:441)
```