### PR TITLE
Make _pattern final to avoid unsafe initialization

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/regex/JavaUtilPattern.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/regex/JavaUtilPattern.java
@@ -21,7 +21,7 @@ package org.apache.pinot.common.utils.regex;
 import java.util.regex.Pattern;
 
 public class JavaUtilPattern implements org.apache.pinot.common.utils.regex.Pattern {
-  Pattern _pattern;
+  final Pattern _pattern;
 
   public JavaUtilPattern(String regex) {
     _pattern = Pattern.compile(regex, 0);


### PR DESCRIPTION
We have detected that sometimes queries fail with:

```
java.lang.RuntimeException: Got error block: {QUERY_VALIDATION=Cannot invoke "java.util.regex.Pattern.matcher(java.lang.CharSequence)" because the return value of "org.apache.pinot.common.utils.regex.JavaUtilPattern.getPattern()" is null}
```

As shown in the code, getPattern should always be not null, as there are only 2 constructors and both set the attribute to a not null value. But as explained in https://shipilev.net/blog/2014/safe-public-construction/, when one thread instantiates an object and another reads its values, the second may receive the instance before it is completely instanciated.

This can be solved, as indicated on that blog post, by making the attribute final. Specifically:

>  Java Memory Model guarantees this if all the fields in object are final and there is no leakage of the under-initialized object from constructor.