### PR TITLE
Add batch planFetchForProcessing API to FetchPlanner

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/InstancePlanMakerImplV2.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/InstancePlanMakerImplV2.java
@@ -187,14 +187,12 @@ public class InstancePlanMakerImplV2 implements PlanMaker {
     List<PlanNode> planNodes = new ArrayList<>(numSegments);
     List<FetchContext> fetchContexts;
     if (queryContext.isEnablePrefetch()) {
-      fetchContexts = new ArrayList<>(numSegments);
-      for (SegmentContext segmentContext : segmentContexts) {
-        FetchContext fetchContext =
-            _fetchPlanner.planFetchForProcessing(segmentContext.getIndexSegment(), queryContext);
-        fetchContexts.add(fetchContext);
+      fetchContexts = _fetchPlanner.planFetchForProcessing(segmentContexts, queryContext);
+      for (int i = 0; i < numSegments; i++) {
+        SegmentContext segmentContext = segmentContexts.get(i);
         planNodes.add(
             new AcquireReleaseColumnsSegmentPlanNode(makeSegmentPlanNode(segmentContext, queryContext), segmentContext,
-                fetchContext));
+                fetchContexts.get(i)));
       }
     } else {
       fetchContexts = Collections.emptyList();
@@ -334,14 +332,12 @@ public class InstancePlanMakerImplV2 implements PlanMaker {
     List<PlanNode> planNodes = new ArrayList<>(numSegments);
     List<FetchContext> fetchContexts;
     if (queryContext.isEnablePrefetch()) {
-      fetchContexts = new ArrayList<>(numSegments);
-      for (SegmentContext segmentContext : segmentContexts) {
-        FetchContext fetchContext =
-            _fetchPlanner.planFetchForProcessing(segmentContext.getIndexSegment(), queryContext);
-        fetchContexts.add(fetchContext);
+      fetchContexts = _fetchPlanner.planFetchForProcessing(segmentContexts, queryContext);
+      for (int i = 0; i < numSegments; i++) {
+        SegmentContext segmentContext = segmentContexts.get(i);
         planNodes.add(
             new AcquireReleaseColumnsSegmentPlanNode(makeStreamingSegmentPlanNode(segmentContext, queryContext),
-                segmentContext, fetchContext));
+                segmentContext, fetchContexts.get(i)));
       }
     } else {
       fetchContexts = Collections.emptyList();

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/prefetch/DefaultFetchPlanner.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/prefetch/DefaultFetchPlanner.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.query.prefetch;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -32,6 +33,7 @@ import org.apache.pinot.common.request.context.predicate.Predicate;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.segment.spi.FetchContext;
 import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.SegmentContext;
 import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.segment.spi.index.IndexType;
 import org.apache.pinot.segment.spi.index.StandardIndexes;
@@ -89,8 +91,14 @@ public class DefaultFetchPlanner implements FetchPlanner {
    * Fetch all kinds of index for columns accessed by the query.
    */
   @Override
-  public FetchContext planFetchForProcessing(IndexSegment indexSegment, QueryContext queryContext) {
-    return new FetchContext(UUID.randomUUID(), indexSegment.getSegmentName(), getColumns(indexSegment, queryContext));
+  public List<FetchContext> planFetchForProcessing(List<SegmentContext> segmentContexts, QueryContext queryContext) {
+    List<FetchContext> result = new ArrayList<>(segmentContexts.size());
+    for (SegmentContext segmentContext : segmentContexts) {
+      IndexSegment indexSegment = segmentContext.getIndexSegment();
+      result.add(
+          new FetchContext(UUID.randomUUID(), indexSegment.getSegmentName(), getColumns(indexSegment, queryContext)));
+    }
+    return result;
   }
 
   private Set<String> getColumns(IndexSegment indexSegment, QueryContext queryContext) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/prefetch/FetchPlanner.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/prefetch/FetchPlanner.java
@@ -18,9 +18,11 @@
  */
 package org.apache.pinot.core.query.prefetch;
 
+import java.util.List;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.segment.spi.FetchContext;
 import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.SegmentContext;
 
 
 /**
@@ -42,12 +44,13 @@ public interface FetchPlanner {
   FetchContext planFetchForPruning(IndexSegment indexSegment, QueryContext queryContext);
 
   /**
-   * Plan what index data to prefetch to process it. For example, one can fetch all types of index for columns tracked
-   * in QueryContext.
+   * Plan what index data to prefetch to process the segments. For example, one can fetch all types of index for
+   * columns tracked in QueryContext. Taking all segments at once allows implementations to precompute query-derived
+   * information once rather than per segment.
    *
-   * @param indexSegment segment to be processed.
-   * @param queryContext context extracted from the query.
-   * @return context to guide data prefetching.
+   * @param segmentContexts segments to be processed.
+   * @param queryContext    context extracted from the query.
+   * @return list of contexts to guide data prefetching, one per segment.
    */
-  FetchContext planFetchForProcessing(IndexSegment indexSegment, QueryContext queryContext);
+  List<FetchContext> planFetchForProcessing(List<SegmentContext> segmentContexts, QueryContext queryContext);
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/prefetch/DefaultFetchPlannerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/prefetch/DefaultFetchPlannerTest.java
@@ -19,12 +19,14 @@
 package org.apache.pinot.core.query.prefetch;
 
 import com.google.common.collect.ImmutableSet;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
 import org.apache.pinot.segment.spi.FetchContext;
 import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.SegmentContext;
 import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.segment.spi.index.IndexType;
 import org.apache.pinot.segment.spi.index.StandardIndexes;
@@ -48,7 +50,10 @@ public class DefaultFetchPlannerTest {
     when(indexSegment.getColumnNames()).thenReturn(ImmutableSet.of("c0", "c1", "c2"));
     String query = "SELECT COUNT(*) FROM testTable WHERE c0 = 0 OR (c1 < 10 AND c2 IN (1, 2))";
     QueryContext queryContext = QueryContextConverterUtils.getQueryContext(query);
-    FetchContext fetchContext = planner.planFetchForProcessing(indexSegment, queryContext);
+    SegmentContext segmentContext = mock(SegmentContext.class);
+    when(segmentContext.getIndexSegment()).thenReturn(indexSegment);
+    FetchContext fetchContext =
+        planner.planFetchForProcessing(Collections.singletonList(segmentContext), queryContext).get(0);
     assertEquals(fetchContext.getSegmentName(), "s0");
     Map<String, List<IndexType<?, ?, ?>>> columns = fetchContext.getColumnToIndexList();
     assertEquals(columns.size(), 3);


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Replaced per‑segment fetch planning with a batch API, allowing FetchPlanner to compute prefetch context once for all segments\.

```mermaid
flowchart TD
  N0["InstancePlanMakerImplV2#46;makeInstancePlan #40;F1#41;"]:::stModified
  N1["InstancePlanMakerImplV2#46;makeStreamingInstancePlan #40;F1#41;"]:::stModified
  N2["Call FetchPlanner#46;planFetchForProcessing #40;F1#41;"]:::stModified
  N3["DefaultFetchPlanner#46;planFetchForProcessing #40;F2#41;"]:::stModified
  N4["FetchPlanner#46;planFetchForProcessing #40;interface#41; #40;F3#41;"]:::stModified
  N5["Build PlanNodes with per#8209;segment FetchContext #40;F1#41;"]:::stModified
  N0 -->|"calls"| N2
  N1 -->|"calls"| N2
  N2 -->|"invokes interface"| N4
  N4 -->|"implemented by"| N3
  N2 -->|"provides fetchContexts list"| N5
  N3 -->|"returns list used"| N5
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-core/src/main/java/org/apache/pinot/core/plan/maker/InstancePlanMakerImplV2\.java — [before](https://github.com/apache/pinot/blob/9b35755402dcecd0dc9a5ce0a7f8688e4a328201/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/InstancePlanMakerImplV2.java) · [after](https://github.com/apache/pinot/blob/b5cac3f6b644ceebc819ad6cc7c8016619e5fb79/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/InstancePlanMakerImplV2.java)
- F2: pinot\-core/src/main/java/org/apache/pinot/core/query/prefetch/DefaultFetchPlanner\.java — [before](https://github.com/apache/pinot/blob/9b35755402dcecd0dc9a5ce0a7f8688e4a328201/pinot-core/src/main/java/org/apache/pinot/core/query/prefetch/DefaultFetchPlanner.java) · [after](https://github.com/apache/pinot/blob/b5cac3f6b644ceebc819ad6cc7c8016619e5fb79/pinot-core/src/main/java/org/apache/pinot/core/query/prefetch/DefaultFetchPlanner.java)
- F3: pinot\-core/src/main/java/org/apache/pinot/core/query/prefetch/FetchPlanner\.java — [before](https://github.com/apache/pinot/blob/9b35755402dcecd0dc9a5ce0a7f8688e4a328201/pinot-core/src/main/java/org/apache/pinot/core/query/prefetch/FetchPlanner.java) · [after](https://github.com/apache/pinot/blob/b5cac3f6b644ceebc819ad6cc7c8016619e5fb79/pinot-core/src/main/java/org/apache/pinot/core/query/prefetch/FetchPlanner.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjliMzU3NTU0MDJkY2VjZDBkYzlhNWNlMGE3Zjg2ODhlNGEzMjgyMDEiLCJjb250ZXh0X2hhc2giOiI3YTNmZmJlZDYwMTYzMmE2OGZkM2NhZjgyNGU3NjhkYzgzOTJlOTcxN2Q3MTA5NzZmOGIzODI2NmEyOTllYTA3IiwiZ2VuZXJhdGVkX2F0IjoxNzg5OTMyMDg2LCJoZWFkX3NoYSI6ImI1Y2FjM2Y2YjY0NGNlZWJjODE5YWQ2Y2M3YzgwMTY2MTllNWZiNzkiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiIzY2ExNGY5YjEzNDAxMDcxZTRmNDY5Njc0ZTVhZTQyOWZhYjI5MDliIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 5ab0b59572aea5a550025856832f9c2e0eefd165ec9f088735247e59d770e696 -->
<!-- pinot-pr-flow:end -->

Replace per-segment planFetchForProcessing(IndexSegment, QueryContext) with a batch planFetchForProcessing(List<SegmentContext>, QueryContext) on the FetchPlanner interface. This allows implementations to precompute query-derived information once instead of redundantly per segment.