### PR TITLE
Propagate query options to ForwardIndexReaderContext via DataFetcher

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/common/DataFetcher.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/DataFetcher.java
@@ -52,13 +52,16 @@ public class DataFetcher implements AutoCloseable {
   private final Map<String, ColumnValueReader> _columnValueReaderMap;
   private final int[] _reusableMVDictIds;
   private final int _maxNumValuesPerMVEntry;
+  private final Map<String, String> _queryOptions;
 
   /**
    * Constructor for DataFetcher.
    *
-   * @param dataSourceMap Map from column to data source
+   * @param dataSourceMap  Map from column to data source
+   * @param queryOptions   Query-level options propagated to reader contexts
    */
-  public DataFetcher(Map<String, DataSource> dataSourceMap) {
+  public DataFetcher(Map<String, DataSource> dataSourceMap, Map<String, String> queryOptions) {
+    _queryOptions = queryOptions;
     _columnValueReaderMap = new HashMap<>();
     int maxNumValuesPerMVEntry = 0;
     for (Map.Entry<String, DataSource> entry : dataSourceMap.entrySet()) {
@@ -321,9 +324,11 @@ public class DataFetcher implements AutoCloseable {
     }
 
     private ForwardIndexReaderContext getReaderContext() {
-      // Create reader context lazily to reduce the duration of existence
       if (!_readerContextCreated) {
         _readerContext = _reader.createContext();
+        if (_readerContext != null) {
+          _readerContext.applyQueryOptions(_queryOptions);
+        }
         _readerContextCreated = true;
       }
       return _readerContext;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/ProjectionOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/ProjectionOperator.java
@@ -50,7 +50,7 @@ public class ProjectionOperator extends BaseProjectOperator<ProjectionBlock> imp
       @Nullable BaseDocIdSetOperator docIdSetOperator, QueryContext queryContext) {
     _dataSourceMap = dataSourceMap;
     _docIdSetOperator = docIdSetOperator;
-    _dataFetcher = new DataFetcher(dataSourceMap);
+    _dataFetcher = new DataFetcher(dataSourceMap, queryContext.getQueryOptions());
     _dataBlockCache = new DataBlockCache(_dataFetcher);
     _columnContextMap = new HashMap<>(HashUtil.getHashMapCapacity(dataSourceMap.size()));
     dataSourceMap.forEach(

--- a/pinot-core/src/test/java/org/apache/pinot/core/common/DataFetcherTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/common/DataFetcherTest.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -147,7 +148,7 @@ public class DataFetcherTest {
     for (String column : _indexSegment.getPhysicalColumnNames()) {
       dataSourceMap.put(column, _indexSegment.getDataSource(column));
     }
-    _dataFetcher = new DataFetcher(dataSourceMap);
+    _dataFetcher = new DataFetcher(dataSourceMap, Collections.emptyMap());
   }
 
   @Test

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/ForwardIndexReaderContext.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/ForwardIndexReaderContext.java
@@ -18,6 +18,9 @@
  */
 package org.apache.pinot.segment.spi.index.reader;
 
+import java.util.Map;
+
+
 /**
  * Interface for the context of the forward index reader.
  * <p>The forward index reader itself is always stateless because it needs to be accessed by multiple threads. The
@@ -25,6 +28,13 @@ package org.apache.pinot.segment.spi.index.reader;
  * inside the context in order to accelerate the following reads.
  */
 public interface ForwardIndexReaderContext extends AutoCloseable {
+
+  /**
+   * Applies query-level options to this context so that reader implementations can adjust behavior per-query
+   * (e.g., bypassing caches). The default implementation is a no-op for backward compatibility.
+   */
+  default void applyQueryOptions(Map<String, String> queryOptions) {
+  }
 
   @Override
   void close();


### PR DESCRIPTION
Adds a applyQueryOptions(Map<String, String>) default method to ForwardIndexReaderContext so that query-level options can reach forward index reader implementations during query processing. DataFetcher now accepts query options and applies them to each reader context after creation. ProjectionOperator passes queryContext.getQueryOptions() through. All existing reader contexts are unaffected (no-op default).