### PR TITLE
Add JsonIndexDistinctOperator for index-based SELECT DISTINCT on JSON columns

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
@@ -165,6 +165,14 @@ public class QueryOptionsUtils {
     return "false".equalsIgnoreCase(queryOptions.get(QueryOptionKey.USE_STAR_TREE));
   }
 
+  /**
+   * When true, use JsonIndexDistinctOperator for SELECT DISTINCT jsonExtractIndex(...) when applicable.
+   * Set via query option useIndexBasedDistinctOperator=true.
+   */
+  public static boolean isUseIndexBasedDistinctOperator(Map<String, String> queryOptions) {
+    return Boolean.parseBoolean(queryOptions.get(QueryOptionKey.USE_INDEX_BASED_DISTINCT_OPERATOR));
+  }
+
   public static boolean isSkipScanFilterReorder(Map<String, String> queryOptions) {
     return "false".equalsIgnoreCase(queryOptions.get(QueryOptionKey.USE_SCAN_REORDER_OPTIMIZATION));
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/JsonIndexDistinctOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/JsonIndexDistinctOperator.java
@@ -1,0 +1,534 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.query;
+
+import com.google.common.base.CaseFormat;
+import java.math.BigDecimal;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import javax.annotation.Nullable;
+import org.apache.pinot.common.function.JsonPathCache;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.common.request.context.OrderByExpressionContext;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+import org.apache.pinot.core.common.Operator;
+import org.apache.pinot.core.operator.BaseOperator;
+import org.apache.pinot.core.operator.ExecutionStatistics;
+import org.apache.pinot.core.operator.ExplainAttributeBuilder;
+import org.apache.pinot.core.operator.blocks.DocIdSetBlock;
+import org.apache.pinot.core.operator.blocks.results.DistinctResultsBlock;
+import org.apache.pinot.core.operator.filter.BaseFilterOperator;
+import org.apache.pinot.core.plan.DocIdSetPlanNode;
+import org.apache.pinot.core.query.distinct.table.BigDecimalDistinctTable;
+import org.apache.pinot.core.query.distinct.table.DistinctTable;
+import org.apache.pinot.core.query.distinct.table.DoubleDistinctTable;
+import org.apache.pinot.core.query.distinct.table.FloatDistinctTable;
+import org.apache.pinot.core.query.distinct.table.IntDistinctTable;
+import org.apache.pinot.core.query.distinct.table.LongDistinctTable;
+import org.apache.pinot.core.query.distinct.table.StringDistinctTable;
+import org.apache.pinot.core.query.request.context.QueryContext;
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.SegmentContext;
+import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.segment.spi.index.IndexService;
+import org.apache.pinot.segment.spi.index.IndexType;
+import org.apache.pinot.segment.spi.index.reader.JsonIndexReader;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.query.QueryThreadContext;
+import org.roaringbitmap.RoaringBitmap;
+
+
+/**
+ * Distinct operator that uses the JSON index value→docId map directly instead of scanning documents.
+ * Avoids the projection/transform pipeline for SELECT DISTINCT jsonExtractIndex(...).
+ */
+public class JsonIndexDistinctOperator extends BaseOperator<DistinctResultsBlock> {
+  private static final String EXPLAIN_NAME = "DISTINCT_JSON_INDEX";
+  private static final String FUNCTION_NAME = "jsonExtractIndex";
+
+  private final IndexSegment _indexSegment;
+  private final SegmentContext _segmentContext;
+  private final QueryContext _queryContext;
+  private final BaseFilterOperator _filterOperator;
+
+  private int _numEntriesExamined = 0;
+  private long _numEntriesScannedInFilter = 0;
+
+  public JsonIndexDistinctOperator(IndexSegment indexSegment, SegmentContext segmentContext,
+      QueryContext queryContext, BaseFilterOperator filterOperator) {
+    _indexSegment = indexSegment;
+    _segmentContext = segmentContext;
+    _queryContext = queryContext;
+    _filterOperator = filterOperator;
+  }
+
+  @Override
+  protected DistinctResultsBlock getNextBlock() {
+    List<ExpressionContext> expressions = _queryContext.getSelectExpressions();
+    if (expressions.size() != 1) {
+      throw new IllegalStateException("JsonIndexDistinctOperator supports single expression only");
+    }
+
+    ExpressionContext expr = expressions.get(0);
+    ParsedJsonExtractIndex parsed = parseJsonExtractIndex(expr);
+    if (parsed == null) {
+      throw new IllegalStateException("Expected jsonExtractIndex expression");
+    }
+
+    // Evaluate the filter first so we can skip the (potentially expensive) index map when no docs match
+    RoaringBitmap filteredDocIds = buildFilteredDocIds();
+    if (filteredDocIds != null && filteredDocIds.isEmpty()) {
+      ColumnDataType earlyColumnDataType = ColumnDataType.fromDataTypeSV(parsed._dataType);
+      DataSchema earlyDataSchema = new DataSchema(
+          new String[]{expr.toString()},
+          new ColumnDataType[]{earlyColumnDataType});
+      OrderByExpressionContext earlyOrderBy = _queryContext.getOrderByExpressions() != null
+          ? _queryContext.getOrderByExpressions().get(0) : null;
+      return new DistinctResultsBlock(
+          createDistinctTable(earlyDataSchema, parsed._dataType, earlyOrderBy), _queryContext);
+    }
+
+    DataSource dataSource = _indexSegment.getDataSource(parsed._columnName, _queryContext.getSchema());
+    JsonIndexReader jsonIndexReader = getJsonIndexReader(dataSource);
+    if (jsonIndexReader == null) {
+      throw new IllegalStateException("Column " + parsed._columnName + " has no JSON index");
+    }
+
+    // Same logic as JsonExtractIndexTransformFunction.getValueToMatchingDocsMap()
+    Map<String, RoaringBitmap> valueToMatchingDocs =
+        jsonIndexReader.getMatchingFlattenedDocsMap(parsed._jsonPathString, parsed._filterExpression);
+    // Always single-value (MV _ARRAY is rejected in parseJsonExtractIndex)
+    jsonIndexReader.convertFlattenedDocIdsToDocIds(valueToMatchingDocs);
+
+    ColumnDataType columnDataType = ColumnDataType.fromDataTypeSV(parsed._dataType);
+    DataSchema dataSchema = new DataSchema(
+        new String[]{expr.toString()},
+        new ColumnDataType[]{columnDataType});
+    OrderByExpressionContext orderByExpression = _queryContext.getOrderByExpressions() != null
+        ? _queryContext.getOrderByExpressions().get(0) : null;
+    DistinctTable distinctTable = createDistinctTable(dataSchema, parsed._dataType, orderByExpression);
+
+    int limit = _queryContext.getLimit();
+    int totalDocs = _indexSegment.getSegmentMetadata().getTotalDocs();
+    // Track uncovered docs: for the no-filter case, build a union and compare against totalDocs.
+    // For the filtered case, use a "remaining" bitmap that shrinks in-place (no per-value allocation).
+    RoaringBitmap allMatchedDocs = filteredDocIds == null ? new RoaringBitmap() : null;
+    RoaringBitmap remainingDocs = filteredDocIds != null ? filteredDocIds.clone() : null;
+    boolean allDocsCovered = filteredDocIds == null ? (totalDocs == 0) : filteredDocIds.isEmpty();
+    boolean earlyBreak = false;
+
+    for (Map.Entry<String, RoaringBitmap> entry : valueToMatchingDocs.entrySet()) {
+      _numEntriesExamined++;
+      QueryThreadContext.checkTerminationAndSampleUsagePeriodically(_numEntriesExamined, EXPLAIN_NAME);
+      String value = entry.getKey();
+      RoaringBitmap docIds = entry.getValue();
+
+      boolean includeValue;
+      if (filteredDocIds == null) {
+        includeValue = true;
+        // Build union for uncovered-docs detection; short-circuit once all segment docs are covered
+        if (!allDocsCovered) {
+          allMatchedDocs.or(docIds);
+          if (allMatchedDocs.getLongCardinality() >= totalDocs) {
+            allDocsCovered = true;
+          }
+        }
+      } else {
+        includeValue = RoaringBitmap.intersects(docIds, filteredDocIds);
+        // Remove matched docs from remaining set in-place (no allocation per value)
+        if (!allDocsCovered && includeValue) {
+          remainingDocs.andNot(docIds);
+          if (remainingDocs.isEmpty()) {
+            allDocsCovered = true;
+          }
+        }
+      }
+
+      if (includeValue) {
+        boolean done = addValueToDistinctTable(distinctTable, value, parsed._dataType, orderByExpression);
+        if (done) {
+          earlyBreak = true;
+          break;
+        }
+      }
+
+      if (orderByExpression == null && distinctTable.hasLimit() && distinctTable.size() >= limit) {
+        earlyBreak = true;
+        break;
+      }
+    }
+
+    // Handle docs not covered by any value in the index.
+    // Baseline JsonExtractIndexTransformFunction throws when a doc is missing the path and no
+    // defaultValue is provided. Match that behavior here unless nullHandling is enabled.
+    // allDocsCovered tracks coverage precisely (against totalDocs or filteredDocIds cardinality).
+    if (!earlyBreak && !allDocsCovered) {
+      if (parsed._defaultValue != null) {
+        addValueToDistinctTable(distinctTable, parsed._defaultValue, parsed._dataType, orderByExpression);
+      } else if (_queryContext.isNullHandlingEnabled()) {
+        distinctTable.addNull();
+      } else {
+        throw new RuntimeException(
+            String.format("Illegal Json Path: [%s], for some docIds in segment [%s]",
+                parsed._jsonPathString, _indexSegment.getSegmentName()));
+      }
+    }
+
+    return new DistinctResultsBlock(distinctTable, _queryContext);
+  }
+
+  private DistinctTable createDistinctTable(DataSchema dataSchema, FieldSpec.DataType dataType,
+      @Nullable OrderByExpressionContext orderByExpression) {
+    int limit = _queryContext.getLimit();
+    boolean nullHandlingEnabled = _queryContext.isNullHandlingEnabled();
+    switch (dataType) {
+      case INT:
+        return new IntDistinctTable(dataSchema, limit, nullHandlingEnabled, orderByExpression);
+      case LONG:
+        return new LongDistinctTable(dataSchema, limit, nullHandlingEnabled, orderByExpression);
+      case FLOAT:
+        return new FloatDistinctTable(dataSchema, limit, nullHandlingEnabled, orderByExpression);
+      case DOUBLE:
+        return new DoubleDistinctTable(dataSchema, limit, nullHandlingEnabled, orderByExpression);
+      case BIG_DECIMAL:
+        return new BigDecimalDistinctTable(dataSchema, limit, nullHandlingEnabled, orderByExpression);
+      case STRING:
+        return new StringDistinctTable(dataSchema, limit, nullHandlingEnabled, orderByExpression);
+      default:
+        throw new IllegalStateException("Unsupported data type for JSON index distinct: " + dataType);
+    }
+  }
+
+  private static boolean addValueToDistinctTable(DistinctTable distinctTable, String stringValue,
+      FieldSpec.DataType dataType, @Nullable OrderByExpressionContext orderByExpression) {
+    switch (dataType) {
+      case INT:
+        return addToTable((IntDistinctTable) distinctTable, Integer.parseInt(stringValue), orderByExpression);
+      case LONG:
+        return addToTable((LongDistinctTable) distinctTable, Long.parseLong(stringValue), orderByExpression);
+      case FLOAT:
+        return addToTable((FloatDistinctTable) distinctTable, Float.parseFloat(stringValue), orderByExpression);
+      case DOUBLE:
+        return addToTable((DoubleDistinctTable) distinctTable, Double.parseDouble(stringValue), orderByExpression);
+      case BIG_DECIMAL:
+        return addToTable((BigDecimalDistinctTable) distinctTable, new BigDecimal(stringValue), orderByExpression);
+      case STRING:
+        return addToTable((StringDistinctTable) distinctTable, stringValue, orderByExpression);
+      default:
+        throw new IllegalStateException("Unsupported data type for JSON index distinct: " + dataType);
+    }
+  }
+
+  private static boolean addToTable(IntDistinctTable table, int value,
+      @Nullable OrderByExpressionContext orderByExpression) {
+    if (table.hasLimit()) {
+      if (orderByExpression != null) {
+        table.addWithOrderBy(value);
+        return false;
+      } else {
+        return table.addWithoutOrderBy(value);
+      }
+    } else {
+      table.addUnbounded(value);
+      return false;
+    }
+  }
+
+  private static boolean addToTable(LongDistinctTable table, long value,
+      @Nullable OrderByExpressionContext orderByExpression) {
+    if (table.hasLimit()) {
+      if (orderByExpression != null) {
+        table.addWithOrderBy(value);
+        return false;
+      } else {
+        return table.addWithoutOrderBy(value);
+      }
+    } else {
+      table.addUnbounded(value);
+      return false;
+    }
+  }
+
+  private static boolean addToTable(FloatDistinctTable table, float value,
+      @Nullable OrderByExpressionContext orderByExpression) {
+    if (table.hasLimit()) {
+      if (orderByExpression != null) {
+        table.addWithOrderBy(value);
+        return false;
+      } else {
+        return table.addWithoutOrderBy(value);
+      }
+    } else {
+      table.addUnbounded(value);
+      return false;
+    }
+  }
+
+  private static boolean addToTable(DoubleDistinctTable table, double value,
+      @Nullable OrderByExpressionContext orderByExpression) {
+    if (table.hasLimit()) {
+      if (orderByExpression != null) {
+        table.addWithOrderBy(value);
+        return false;
+      } else {
+        return table.addWithoutOrderBy(value);
+      }
+    } else {
+      table.addUnbounded(value);
+      return false;
+    }
+  }
+
+  private static boolean addToTable(BigDecimalDistinctTable table, BigDecimal value,
+      @Nullable OrderByExpressionContext orderByExpression) {
+    if (table.hasLimit()) {
+      if (orderByExpression != null) {
+        table.addWithOrderBy(value);
+        return false;
+      } else {
+        return table.addWithoutOrderBy(value);
+      }
+    } else {
+      table.addUnbounded(value);
+      return false;
+    }
+  }
+
+  private static boolean addToTable(StringDistinctTable table, String value,
+      @Nullable OrderByExpressionContext orderByExpression) {
+    if (table.hasLimit()) {
+      if (orderByExpression != null) {
+        table.addWithOrderBy(value);
+        return false;
+      } else {
+        return table.addWithoutOrderBy(value);
+      }
+    } else {
+      table.addUnbounded(value);
+      return false;
+    }
+  }
+
+  @Nullable
+  private static JsonIndexReader getJsonIndexReader(DataSource dataSource) {
+    JsonIndexReader reader = dataSource.getJsonIndex();
+    if (reader == null) {
+      Optional<IndexType<?, ?, ?>> compositeIndex =
+          IndexService.getInstance().getOptional("composite_json_index");
+      if (compositeIndex.isPresent()) {
+        reader = (JsonIndexReader) dataSource.getIndex(compositeIndex.get());
+      }
+    }
+    return reader;
+  }
+
+  @Nullable
+  private RoaringBitmap buildFilteredDocIds() {
+    if (_filterOperator.isResultMatchingAll()) {
+      return null;
+    }
+
+    if (_filterOperator.canProduceBitmaps()) {
+      // Bitmap-capable filters (inverted index, JSON index, etc.) produce bitmaps without scanning
+      // docs, so _numEntriesScannedInFilter correctly stays 0 for this path.
+      return _filterOperator.getBitmaps().reduce().toRoaringBitmap();
+    }
+
+    if (_filterOperator.isResultEmpty()) {
+      return new RoaringBitmap();
+    }
+
+    RoaringBitmap bitmap = new RoaringBitmap();
+    DocIdSetPlanNode docIdSetPlanNode = new DocIdSetPlanNode(
+        _segmentContext, _queryContext, DocIdSetPlanNode.MAX_DOC_PER_CALL, _filterOperator);
+    var docIdSetOperator = docIdSetPlanNode.run();
+    DocIdSetBlock block;
+    while ((block = docIdSetOperator.nextBlock()) != null) {
+      int[] docIds = block.getDocIds();
+      int length = block.getLength();
+      bitmap.addN(docIds, 0, length);
+    }
+    _numEntriesScannedInFilter = docIdSetOperator.getExecutionStatistics().getNumEntriesScannedInFilter();
+    return bitmap;
+  }
+
+  @Nullable
+  private static ParsedJsonExtractIndex parseJsonExtractIndex(ExpressionContext expr) {
+    if (expr.getType() != ExpressionContext.Type.FUNCTION) {
+      return null;
+    }
+    if (!FUNCTION_NAME.equalsIgnoreCase(expr.getFunction().getFunctionName())) {
+      return null;
+    }
+    List<ExpressionContext> args = expr.getFunction().getArguments();
+    if (args.size() < 3 || args.size() > 5) {
+      return null;
+    }
+    if (args.get(0).getType() != ExpressionContext.Type.IDENTIFIER) {
+      return null;
+    }
+    if (args.get(1).getType() != ExpressionContext.Type.LITERAL
+        || args.get(2).getType() != ExpressionContext.Type.LITERAL) {
+      return null;
+    }
+
+    String columnName = args.get(0).getIdentifier();
+    String jsonPathString = args.get(1).getLiteral().getStringValue();
+    String resultsType = args.get(2).getLiteral().getStringValue().toUpperCase();
+    // Only single-value types are supported; MV (_ARRAY) would have incorrect flattened-to-real
+    // docId intersection since convertFlattenedDocIdsToDocIds is skipped for MV.
+    if (resultsType.endsWith("_ARRAY")) {
+      return null;
+    }
+    if (jsonPathString.contains("[*]")) {
+      return null;
+    }
+
+    FieldSpec.DataType dataType;
+    try {
+      dataType = FieldSpec.DataType.valueOf(resultsType);
+    } catch (IllegalArgumentException e) {
+      return null;
+    }
+    // Only types with a corresponding DistinctTable implementation are supported
+    switch (dataType) {
+      case INT:
+      case LONG:
+      case FLOAT:
+      case DOUBLE:
+      case BIG_DECIMAL:
+      case STRING:
+        break;
+      default:
+        return null;
+    }
+
+    try {
+      JsonPathCache.INSTANCE.getOrCompute(jsonPathString);
+    } catch (Exception e) {
+      return null;
+    }
+
+    String defaultValue = null;
+    if (args.size() >= 4) {
+      if (args.get(3).getType() != ExpressionContext.Type.LITERAL) {
+        return null;
+      }
+      defaultValue = args.get(3).getLiteral().getStringValue();
+    }
+
+    String filterExpression = null;
+    if (args.size() == 5) {
+      if (args.get(4).getType() != ExpressionContext.Type.LITERAL) {
+        return null;
+      }
+      filterExpression = args.get(4).getLiteral().getStringValue();
+    }
+
+    return new ParsedJsonExtractIndex(columnName, jsonPathString, dataType, defaultValue, filterExpression);
+  }
+
+  private static final class ParsedJsonExtractIndex {
+    final String _columnName;
+    final String _jsonPathString;
+    final FieldSpec.DataType _dataType;
+    @Nullable
+    final String _defaultValue;
+    @Nullable
+    final String _filterExpression;
+
+    ParsedJsonExtractIndex(String columnName, String jsonPathString,
+        FieldSpec.DataType dataType, @Nullable String defaultValue, @Nullable String filterExpression) {
+      _columnName = columnName;
+      _jsonPathString = jsonPathString;
+      _dataType = dataType;
+      _defaultValue = defaultValue;
+      _filterExpression = filterExpression;
+    }
+  }
+
+  @Override
+  public List<Operator> getChildOperators() {
+    return Collections.singletonList(_filterOperator);
+  }
+
+  @Override
+  public IndexSegment getIndexSegment() {
+    return _indexSegment;
+  }
+
+  @Override
+  public ExecutionStatistics getExecutionStatistics() {
+    int numTotalDocs = _indexSegment.getSegmentMetadata().getTotalDocs();
+    // Index-only operator: no docs scanned, no entries scanned post-filter.
+    // Filter-phase stats are tracked when buildFilteredDocIds falls back to DocIdSetPlanNode.
+    return new ExecutionStatistics(0, _numEntriesScannedInFilter, 0, numTotalDocs);
+  }
+
+  @Override
+  public String toExplainString() {
+    List<ExpressionContext> expressions = _queryContext.getSelectExpressions();
+    return EXPLAIN_NAME + "(keyColumns:" + (expressions.isEmpty() ? "" : expressions.get(0).toString()) + ")";
+  }
+
+  @Override
+  protected String getExplainName() {
+    return CaseFormat.UPPER_UNDERSCORE.to(CaseFormat.UPPER_CAMEL, EXPLAIN_NAME);
+  }
+
+  @Override
+  protected void explainAttributes(ExplainAttributeBuilder attributeBuilder) {
+    super.explainAttributes(attributeBuilder);
+    List<ExpressionContext> selectExpressions = _queryContext.getSelectExpressions();
+    if (!selectExpressions.isEmpty()) {
+      attributeBuilder.putStringList("keyColumns",
+          List.of(selectExpressions.get(0).toString()));
+    }
+  }
+
+  /**
+   * Returns true if the expression is jsonExtractIndex on a column with JSON index and the path is indexed.
+   * For OSS JSON index all paths are indexed. For composite JSON index, only paths in invertedIndexConfigs
+   * are indexed per key.
+   */
+  public static boolean canUseJsonIndexDistinct(IndexSegment indexSegment, ExpressionContext expr) {
+    ParsedJsonExtractIndex parsed = parseJsonExtractIndex(expr);
+    if (parsed == null) {
+      return false;
+    }
+    DataSource dataSource = indexSegment.getDataSourceNullable(parsed._columnName);
+    if (dataSource == null) {
+      return false;
+    }
+    JsonIndexReader reader = getJsonIndexReader(dataSource);
+    if (reader == null) {
+      return false;
+    }
+    if (!reader.isPathIndexed(parsed._jsonPathString)) {
+      return false;
+    }
+    // The 5th arg (_filterExpression) is a JSON filter expression, not a plain JSON path,
+    // so isPathIndexed() is not appropriate for it. The reader's getMatchingFlattenedDocsMap()
+    // handles filter expressions internally.
+    return true;
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/DistinctPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/DistinctPlanNode.java
@@ -20,11 +20,14 @@ package org.apache.pinot.core.plan;
 
 import java.util.List;
 import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.common.utils.config.QueryOptionsUtils;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.operator.BaseProjectOperator;
 import org.apache.pinot.core.operator.blocks.results.DistinctResultsBlock;
+import org.apache.pinot.core.operator.filter.BaseFilterOperator;
 import org.apache.pinot.core.operator.query.DictionaryBasedDistinctOperator;
 import org.apache.pinot.core.operator.query.DistinctOperator;
+import org.apache.pinot.core.operator.query.JsonIndexDistinctOperator;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.SegmentContext;
@@ -69,6 +72,16 @@ public class DistinctPlanNode implements PlanNode {
             return new DictionaryBasedDistinctOperator(dataSource, _queryContext);
           }
         }
+      }
+    }
+
+    // Use JSON index directly for DISTINCT jsonExtractIndex when query option useIndexBasedDistinctOperator=true
+    // (disabled by default; opt-in via query option)
+    if (QueryOptionsUtils.isUseIndexBasedDistinctOperator(_queryContext.getQueryOptions()) && expressions.size() == 1) {
+      ExpressionContext expr = expressions.get(0);
+      if (JsonIndexDistinctOperator.canUseJsonIndexDistinct(_indexSegment, expr)) {
+        BaseFilterOperator filterOperator = new FilterPlanNode(_segmentContext, _queryContext).run();
+        return new JsonIndexDistinctOperator(_indexSegment, _segmentContext, _queryContext, filterOperator);
       }
     }
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/JsonPathTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/JsonPathTest.java
@@ -44,6 +44,8 @@ import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import static org.apache.pinot.spi.utils.CommonConstants.Broker.Request.QueryOptionKey.USE_INDEX_BASED_DISTINCT_OPERATOR;
+
 
 @Test(suiteName = "CustomClusterIntegrationTest")
 public class JsonPathTest extends CustomDataQueryClusterIntegrationTest {
@@ -90,6 +92,7 @@ public class JsonPathTest extends CustomDataQueryClusterIntegrationTest {
     IngestionConfig ingestionConfig = new IngestionConfig();
     ingestionConfig.setTransformConfigs(transformConfigs);
     return new TableConfigBuilder(TableType.OFFLINE).setTableName(getTableName()).setIngestionConfig(ingestionConfig)
+        .setJsonIndexColumns(Collections.singletonList(MY_MAP_STR_FIELD_NAME))
         .build();
   }
 
@@ -592,5 +595,151 @@ public class JsonPathTest extends CustomDataQueryClusterIntegrationTest {
     // Should default to JsonPath format
     Assert.assertTrue(keyList.contains("$['k1']"));
     Assert.assertTrue(keyList.contains("$['k2']"));
+  }
+
+  // --- JsonIndexDistinctOperator tests (useIndexBasedDistinctOperator) ---
+
+  /**
+   * Without useIndexBasedDistinctOperator (disabled by default), SELECT DISTINCT jsonExtractIndex(...) uses
+   * default DistinctOperator and returns correct results.
+   */
+  @Test(dataProvider = "useBothQueryEngines")
+  public void testJsonIndexDistinctOperatorDisabledByDefault(boolean useMultiStageQueryEngine)
+      throws Exception {
+    setUseMultiStageQueryEngine(useMultiStageQueryEngine);
+
+    String query = "SELECT DISTINCT jsonExtractIndex(" + MY_MAP_STR_FIELD_NAME + ", '$.k1', 'STRING') FROM "
+        + getTableName() + " ORDER BY jsonExtractIndex(" + MY_MAP_STR_FIELD_NAME + ", '$.k1', 'STRING') LIMIT 10000";
+    JsonNode response = postQuery(query);
+    Assert.assertEquals(response.get("exceptions").size(), 0);
+    List<String> values = extractOrderedDistinctValues(response);
+    Assert.assertFalse(values.isEmpty(),
+        "Baseline (operator disabled) should return distinct values. Engine="
+            + (useMultiStageQueryEngine ? "MSE" : "SSE"));
+  }
+
+  /**
+   * With useIndexBasedDistinctOperator, JsonIndexDistinctOperator produces same results as baseline.
+   * Compares ordered rows (not just sets) to verify ORDER BY semantics.
+   * For SSE, verifies numEntriesScannedPostFilter=0 (index path, no doc scan).
+   */
+  @Test(dataProvider = "useBothQueryEngines")
+  public void testJsonIndexDistinctOperatorWithPinotJsonIndex(boolean useMultiStageQueryEngine)
+      throws Exception {
+    setUseMultiStageQueryEngine(useMultiStageQueryEngine);
+
+    String query = "SELECT DISTINCT jsonExtractIndex(" + MY_MAP_STR_FIELD_NAME + ", '$.k1', 'STRING') FROM "
+        + getTableName() + " ORDER BY jsonExtractIndex(" + MY_MAP_STR_FIELD_NAME + ", '$.k1', 'STRING') LIMIT 10000";
+
+    JsonNode baselineResponse = postQuery(query);
+    Assert.assertEquals(baselineResponse.get("exceptions").size(), 0);
+
+    JsonNode optimizedResponse = postQueryWithOptions(query, USE_INDEX_BASED_DISTINCT_OPERATOR + "=true");
+    Assert.assertEquals(optimizedResponse.get("exceptions").size(), 0);
+
+    List<String> baselineRows = extractOrderedDistinctValues(baselineResponse);
+    List<String> optimizedRows = extractOrderedDistinctValues(optimizedResponse);
+    Assert.assertEquals(optimizedRows, baselineRows,
+        "JsonIndexDistinctOperator should produce same ordered results as baseline. "
+            + "Engine=" + (useMultiStageQueryEngine ? "MSE" : "SSE"));
+
+    if (!useMultiStageQueryEngine) {
+      Assert.assertEquals(optimizedResponse.get("numEntriesScannedPostFilter").asLong(), 0L,
+          "JsonIndexDistinctOperator (SSE) uses index only (numEntriesScannedPostFilter=0).");
+    }
+  }
+
+  /**
+   * JsonIndexDistinctOperator with filter produces same ordered results as baseline.
+   * For SSE, verifies numEntriesScannedPostFilter=0 (index path, no doc scan).
+   */
+  @Test(dataProvider = "useBothQueryEngines")
+  public void testJsonIndexDistinctOperatorWithFilter(boolean useMultiStageQueryEngine)
+      throws Exception {
+    setUseMultiStageQueryEngine(useMultiStageQueryEngine);
+
+    String query = "SELECT DISTINCT jsonExtractIndex(" + MY_MAP_STR_FIELD_NAME + ", '$.k1', 'STRING') FROM "
+        + getTableName() + " WHERE jsonExtractIndex(" + MY_MAP_STR_FIELD_NAME + ", '$.k2', 'STRING') = 'value-k2-0'"
+        + " ORDER BY jsonExtractIndex(" + MY_MAP_STR_FIELD_NAME + ", '$.k1', 'STRING') LIMIT 10000";
+    JsonNode baselineResponse = postQuery(query);
+    Assert.assertEquals(baselineResponse.get("exceptions").size(), 0);
+
+    JsonNode optimizedResponse = postQueryWithOptions(query, USE_INDEX_BASED_DISTINCT_OPERATOR + "=true");
+    Assert.assertEquals(optimizedResponse.get("exceptions").size(), 0);
+
+    List<String> baselineRows = extractOrderedDistinctValues(baselineResponse);
+    List<String> optimizedRows = extractOrderedDistinctValues(optimizedResponse);
+    Assert.assertEquals(optimizedRows, baselineRows,
+        "JsonIndexDistinctOperator with filter should match baseline. Engine="
+            + (useMultiStageQueryEngine ? "MSE" : "SSE"));
+
+    if (!useMultiStageQueryEngine) {
+      Assert.assertEquals(optimizedResponse.get("numEntriesScannedPostFilter").asLong(), 0L,
+          "JsonIndexDistinctOperator with filter (SSE) uses index only (numEntriesScannedPostFilter=0).");
+    }
+  }
+
+  /**
+   * Verifies that JsonIndexDistinctOperator correctly materializes the defaultValue for docs where the JSON path
+   * is absent, matching baseline JsonExtractIndexTransformFunction behavior.
+   */
+  @Test(dataProvider = "useBothQueryEngines")
+  public void testJsonIndexDistinctOperatorWithDefaultValue(boolean useMultiStageQueryEngine)
+      throws Exception {
+    setUseMultiStageQueryEngine(useMultiStageQueryEngine);
+
+    // Query a non-existent path with a defaultValue — all docs should produce the default
+    String query = "SELECT DISTINCT jsonExtractIndex(" + MY_MAP_STR_FIELD_NAME
+        + ", '$.nonexistent', 'STRING', 'N/A') FROM " + getTableName()
+        + " ORDER BY jsonExtractIndex(" + MY_MAP_STR_FIELD_NAME + ", '$.nonexistent', 'STRING', 'N/A') LIMIT 10";
+
+    JsonNode baselineResponse = postQuery(query);
+    Assert.assertEquals(baselineResponse.get("exceptions").size(), 0);
+
+    JsonNode optimizedResponse = postQueryWithOptions(query, USE_INDEX_BASED_DISTINCT_OPERATOR + "=true");
+    Assert.assertEquals(optimizedResponse.get("exceptions").size(), 0);
+
+    List<String> baselineRows = extractOrderedDistinctValues(baselineResponse);
+    List<String> optimizedRows = extractOrderedDistinctValues(optimizedResponse);
+    Assert.assertEquals(optimizedRows, baselineRows,
+        "JsonIndexDistinctOperator with defaultValue should match baseline. Engine="
+            + (useMultiStageQueryEngine ? "MSE" : "SSE"));
+    Assert.assertTrue(optimizedRows.contains("N/A"),
+        "defaultValue 'N/A' should appear in results for non-existent path. Engine="
+            + (useMultiStageQueryEngine ? "MSE" : "SSE"));
+  }
+
+  /**
+   * Verifies that JsonIndexDistinctOperator throws when the JSON path is absent for some docs and no defaultValue
+   * is provided (matching baseline JsonExtractIndexTransformFunction behavior which throws "Illegal Json Path").
+   * Only tested on SSE because MSE may handle errors differently.
+   */
+  @Test(dataProvider = "useV1QueryEngine")
+  public void testJsonIndexDistinctOperatorMissingPathNoDefault(boolean useMultiStageQueryEngine)
+      throws Exception {
+    setUseMultiStageQueryEngine(useMultiStageQueryEngine);
+
+    // Query a non-existent path WITHOUT defaultValue — should produce an error
+    String query = "SELECT DISTINCT jsonExtractIndex(" + MY_MAP_STR_FIELD_NAME
+        + ", '$.nonexistent', 'STRING') FROM " + getTableName() + " LIMIT 10";
+
+    // Baseline also throws for missing path without defaultValue
+    JsonNode baselineResponse = postQuery(query);
+    Assert.assertTrue(baselineResponse.get("exceptions").size() > 0,
+        "Baseline should throw for missing JSON path without defaultValue");
+
+    JsonNode optimizedResponse = postQueryWithOptions(query, USE_INDEX_BASED_DISTINCT_OPERATOR + "=true");
+    Assert.assertTrue(optimizedResponse.get("exceptions").size() > 0,
+        "JsonIndexDistinctOperator should throw for missing JSON path without defaultValue");
+  }
+
+  private static List<String> extractOrderedDistinctValues(JsonNode response) {
+    List<String> values = new ArrayList<>();
+    JsonNode rows = response.get("resultTable").get("rows");
+    for (int i = 0; i < rows.size(); i++) {
+      JsonNode cell = rows.get(i).get(0);
+      values.add(cell.isNull() ? null : cell.asText());
+    }
+    return values;
   }
 }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/JsonIndexReader.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/JsonIndexReader.java
@@ -77,4 +77,14 @@ public interface JsonIndexReader extends IndexReader {
    * Converts the flattened docIds to real docIds using the map returned by getMatchingFlattenedDocsMap
    */
   void convertFlattenedDocIdsToDocIds(Map<String, RoaringBitmap> flattenedDocIdsMap);
+
+  /**
+   * Returns true if the given JSON path is indexed and can be used for index-based operations
+   * (e.g. getMatchingFlattenedDocsMap, JsonIndexDistinctOperator).
+   * OSS JSON index indexes all paths, so always returns true. Composite JSON index with
+   * selective indexing returns true only for paths in invertedIndexConfigs.
+   */
+  default boolean isPathIndexed(String jsonPath) {
+    return true;
+  }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -654,6 +654,10 @@ public class CommonConstants {
         public static final String SKIP_UPSERT_VIEW = "skipUpsertView";
         public static final String UPSERT_VIEW_FRESHNESS_MS = "upsertViewFreshnessMs";
         public static final String USE_STAR_TREE = "useStarTree";
+        /**
+         * When true, use index-based distinct (JsonIndexDistinctOperator) when applicable.
+         */
+        public static final String USE_INDEX_BASED_DISTINCT_OPERATOR = "useIndexBasedDistinctOperator";
         public static final String SCAN_STAR_TREE_NODES = "scanStarTreeNodes";
         public static final String ROUTING_OPTIONS = "routingOptions";
         public static final String TABLE_SAMPLER = "sampler";


### PR DESCRIPTION
## Summary

Add `JsonIndexDistinctOperator` — an index-only execution path for `SELECT DISTINCT jsonExtractIndex(...)` queries on columns with a JSON index. Instead of scanning documents through the projection/transform pipeline, the operator reads distinct values directly from the JSON index's value→docId map, avoiding per-doc evaluation entirely.

The operator is **disabled by default** and opt-in via a query option.

### Key changes

- **`JsonIndexDistinctOperator`** (`pinot-core`): New operator that reads the JSON index value→docId map directly, intersects with the filter bitmap, and populates a typed `DistinctTable` (supports `INT`, `LONG`, `FLOAT`, `DOUBLE`, `BIG_DECIMAL`, `STRING`). Handles `defaultValue` semantics and `nullHandlingEnabled` for docs where the JSON path is absent.
- **`DistinctPlanNode`**: Routes to `JsonIndexDistinctOperator` when the query option is enabled and the expression is eligible.
- **`QueryOptionsUtils` / `CommonConstants`**: New query option `useIndexBasedDistinctOperator`.
- **`JsonIndexReader.isPathIndexed()`**: New default method so the operator can check whether a path is indexed (always `true` for OSS JSON index; selective for composite JSON index).
- **Integration tests** (`JsonPathTest`): Validates baseline vs optimized results match, with and without filters, for both SSE and MSE.

### Usage

Enable via query option:

```sql
SET useIndexBasedDistinctOperator = true;

SELECT DISTINCT jsonExtractIndex(myJsonCol, '$.path.to.field', 'STRING')
FROM myTable
ORDER BY jsonExtractIndex(myJsonCol, '$.path.to.field', 'STRING')
LIMIT 1000;
```

Or per-query via REST API:

```
POST /query/sql
{
  "sql": "SELECT DISTINCT jsonExtractIndex(myJsonCol, '$.name', 'STRING') FROM myTable",
  "queryOptions": "useIndexBasedDistinctOperator=true"
}
```

### Prerequisites

- The column must have a JSON index configured in the table config:

```json
{
  "tableName": "myTable_OFFLINE",
  "tableType": "OFFLINE",
  "fieldConfigList": [
    {
      "name": "myJsonCol",
      "encodingType": "RAW",
      "indexTypes": ["JSON"]
    }
  ]
}
```

Or via the legacy shorthand:

```json
{
  "tableIndexConfig": {
    "jsonIndexColumns": ["myJsonCol"]
  }
}
```

### Supported query patterns

| Pattern | Supported |
|---|---|
| `SELECT DISTINCT jsonExtractIndex(col, '$.path', 'STRING')` | Yes |
| `SELECT DISTINCT jsonExtractIndex(col, '$.path', 'INT')` | Yes (all SV types) |
| `SELECT DISTINCT jsonExtractIndex(col, '$.path', 'STRING', 'default')` | Yes (defaultValue) |
| `SELECT DISTINCT jsonExtractIndex(col, '$.path', 'STRING', 'default', '$.filter')` | Yes (with filter JSON path) |
| With `WHERE` clause filters | Yes |
| With `ORDER BY` | Yes |
| Multi-value (`STRING_ARRAY`, etc.) | No (falls back to baseline) |
| Multiple columns in `SELECT DISTINCT` | No (falls back to baseline) |

### Performance

For SSE queries, `numEntriesScannedPostFilter = 0` — the operator reads entirely from the index without scanning any documents.

## Test plan

- [x] Integration tests validate optimized results match baseline (with and without filters, SSE and MSE)
- [x] Integration tests verify `numEntriesScannedPostFilter = 0` for SSE
- [x] Existing `JsonExtractIndexTransformFunctionTest` unit tests pass (31/31)
- [ ] Verify defaultValue semantics with docs that have missing JSON paths
- [ ] Verify null handling when `SET enableNullHandling = true` and JSON path is absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)