### PR TITLE
Fix SegmentPurger to prevent unintended star-tree modification during purge

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/minion/SegmentPurger.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/minion/SegmentPurger.java
@@ -91,7 +91,7 @@ public class SegmentPurger {
         return null;
       }
 
-      initSegmentGeneratorConfig(segmentName);
+      initSegmentGeneratorConfig(segmentName, segmentMetadata);
 
       // Keep index creation time the same as original segment because both segments use the same raw data.
       // This way, for REFRESH case, when new segment gets pushed to controller, we can use index creation time to
@@ -120,15 +120,18 @@ public class SegmentPurger {
   }
 
   @VisibleForTesting
-  void initSegmentGeneratorConfig(String segmentName) {
+  void initSegmentGeneratorConfig(String segmentName, SegmentMetadataImpl segmentMetadata) {
     _segmentGeneratorConfig = new SegmentGeneratorConfig(_tableConfig, _schema);
     _segmentGeneratorConfig.setOutDir(_workingDir.getPath());
 
-    // Skip star-tree index creation during purge unless enableDynamicStarTreeCreation is set.
-    // This prevents unintended star-tree creation when segments are rebuilt for compliance/purge purposes.
-    if (!_tableConfig.getIndexingConfig().isEnableDynamicStarTreeCreation()) {
+    // When enableDynamicStarTreeCreation is false and the segment doesn't already have star-tree, clear
+    // star-tree configs to prevent unintended addition. This is consistent with SegmentPreProcessor which
+    // skips all star-tree processing when enableDynamicStarTreeCreation is false.
+    // For segments that already have star-tree, the table config (already loaded by SegmentGeneratorConfig)
+    // is used as-is since it represents the config that originally created the star-tree.
+    if (!_tableConfig.getIndexingConfig().isEnableDynamicStarTreeCreation()
+        && segmentMetadata.getStarTreeV2MetadataList() == null) {
       _segmentGeneratorConfig.setStarTreeIndexConfigs(null);
-      _segmentGeneratorConfig.setEnableDefaultStarTree(false);
     }
 
     if (_segmentGeneratorCustomConfigs != null && StringUtils.isNotEmpty(

--- a/pinot-core/src/main/java/org/apache/pinot/core/minion/SegmentPurger.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/minion/SegmentPurger.java
@@ -22,15 +22,18 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import java.io.File;
 import java.io.IOException;
+import java.util.List;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.pinot.core.startree.StarTreeUtils;
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import org.apache.pinot.segment.local.segment.readers.PinotSegmentRecordReader;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorCustomConfigs;
 import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.spi.config.instance.InstanceType;
+import org.apache.pinot.segment.spi.index.startree.StarTreeV2Metadata;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
@@ -124,14 +127,17 @@ public class SegmentPurger {
     _segmentGeneratorConfig = new SegmentGeneratorConfig(_tableConfig, _schema);
     _segmentGeneratorConfig.setOutDir(_workingDir.getPath());
 
-    // When enableDynamicStarTreeCreation is false and the segment doesn't already have star-tree, clear
-    // star-tree configs to prevent unintended addition. This is consistent with SegmentPreProcessor which
-    // skips all star-tree processing when enableDynamicStarTreeCreation is false.
-    // For segments that already have star-tree, the table config (already loaded by SegmentGeneratorConfig)
-    // is used as-is since it represents the config that originally created the star-tree.
-    if (!_tableConfig.getIndexingConfig().isEnableDynamicStarTreeCreation()
-        && segmentMetadata.getStarTreeV2MetadataList() == null) {
-      _segmentGeneratorConfig.setStarTreeIndexConfigs(null);
+    // When enableDynamicStarTreeCreation is false, preserve the original segment's star-tree state exactly,
+    // consistent with SegmentPreProcessor which skips all star-tree additions, deletions, and modifications.
+    // When enableDynamicStarTreeCreation is true, use the table config to allow star-tree changes.
+    if (!_tableConfig.getIndexingConfig().isEnableDynamicStarTreeCreation()) {
+      List<StarTreeV2Metadata> starTreeV2MetadataList = segmentMetadata.getStarTreeV2MetadataList();
+      if (starTreeV2MetadataList == null) {
+        _segmentGeneratorConfig.setStarTreeIndexConfigs(null);
+      } else {
+        _segmentGeneratorConfig.setStarTreeIndexConfigs(StarTreeUtils.toStarTreeIndexConfigs(starTreeV2MetadataList));
+      }
+      _segmentGeneratorConfig.setEnableDefaultStarTree(false);
     }
 
     if (_segmentGeneratorCustomConfigs != null && StringUtils.isNotEmpty(

--- a/pinot-core/src/main/java/org/apache/pinot/core/minion/SegmentPurger.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/minion/SegmentPurger.java
@@ -124,6 +124,13 @@ public class SegmentPurger {
     _segmentGeneratorConfig = new SegmentGeneratorConfig(_tableConfig, _schema);
     _segmentGeneratorConfig.setOutDir(_workingDir.getPath());
 
+    // Skip star-tree index creation during purge unless enableDynamicStarTreeCreation is set.
+    // This prevents unintended star-tree creation when segments are rebuilt for compliance/purge purposes.
+    if (!_tableConfig.getIndexingConfig().isEnableDynamicStarTreeCreation()) {
+      _segmentGeneratorConfig.setStarTreeIndexConfigs(null);
+      _segmentGeneratorConfig.setEnableDefaultStarTree(false);
+    }
+
     if (_segmentGeneratorCustomConfigs != null && StringUtils.isNotEmpty(
         _segmentGeneratorCustomConfigs.getSegmentName())) {
       _segmentGeneratorConfig.setSegmentName(_segmentGeneratorCustomConfigs.getSegmentName());

--- a/pinot-core/src/main/java/org/apache/pinot/core/startree/StarTreeUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/startree/StarTreeUtils.java
@@ -46,6 +46,9 @@ import org.apache.pinot.segment.spi.index.startree.AggregationFunctionColumnPair
 import org.apache.pinot.segment.spi.index.startree.AggregationSpec;
 import org.apache.pinot.segment.spi.index.startree.StarTreeV2;
 import org.apache.pinot.segment.spi.index.startree.StarTreeV2Metadata;
+import org.apache.pinot.spi.config.table.StarTreeAggregationConfig;
+import org.apache.pinot.spi.config.table.StarTreeIndexConfig;
+import org.apache.pinot.spi.utils.DataSizeUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -462,5 +465,39 @@ public class StarTreeUtils {
       }
     }
     return null;
+  }
+
+  /**
+   * Converts star-tree metadata from an existing segment back to {@link StarTreeIndexConfig} so the rebuilt segment
+   * preserves the original star-tree configuration exactly.
+   */
+  public static List<StarTreeIndexConfig> toStarTreeIndexConfigs(List<StarTreeV2Metadata> metadataList) {
+    List<StarTreeIndexConfig> configs = new ArrayList<>(metadataList.size());
+    for (StarTreeV2Metadata metadata : metadataList) {
+      List<String> functionColumnPairs = new ArrayList<>();
+      List<StarTreeAggregationConfig> aggregationConfigs = new ArrayList<>();
+      for (Map.Entry<AggregationFunctionColumnPair, AggregationSpec> entry
+          : metadata.getAggregationSpecs().entrySet()) {
+        AggregationFunctionColumnPair pair = entry.getKey();
+        AggregationSpec spec = entry.getValue();
+        functionColumnPairs.add(pair.toColumnName());
+        aggregationConfigs.add(new StarTreeAggregationConfig(
+            pair.getColumn(),
+            pair.getFunctionType().getName(),
+            spec.getFunctionParameters().isEmpty() ? null : spec.getFunctionParameters(),
+            spec.getCompressionCodec(),
+            spec.isDeriveNumDocsPerChunk(),
+            spec.getIndexVersion(),
+            DataSizeUtils.fromBytes(spec.getTargetMaxChunkSizeBytes()),
+            spec.getTargetDocsPerChunk()));
+      }
+      configs.add(new StarTreeIndexConfig(
+          metadata.getDimensionsSplitOrder(),
+          new ArrayList<>(metadata.getSkipStarNodeCreationForDimensions()),
+          functionColumnPairs.isEmpty() ? null : functionColumnPairs,
+          aggregationConfigs.isEmpty() ? null : aggregationConfigs,
+          metadata.getMaxLeafRecords()));
+    }
+    return configs;
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/minion/SegmentPurgerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/minion/SegmentPurgerTest.java
@@ -206,7 +206,7 @@ public class SegmentPurgerTest {
     TableConfig tableConfigWithStarTree = new TableConfigBuilder(TableType.OFFLINE)
         .setTableName(TABLE_NAME)
         .setStarTreeIndexConfigs(Collections.singletonList(
-            new StarTreeIndexConfig(List.of(D1, D2), null, null, List.of("SUM__d2"), 10000)))
+            new StarTreeIndexConfig(List.of(D1, D2), null, List.of("SUM__d2"), null, 10000)))
         .build();
 
     SegmentPurger.RecordPurger recordPurger = row -> row.getValue(D1).equals(0);
@@ -225,7 +225,7 @@ public class SegmentPurgerTest {
     TableConfig tableConfigWithStarTree = new TableConfigBuilder(TableType.OFFLINE)
         .setTableName(TABLE_NAME)
         .setStarTreeIndexConfigs(Collections.singletonList(
-            new StarTreeIndexConfig(List.of(D1, D2), null, null, List.of("SUM__d2"), 10000)))
+            new StarTreeIndexConfig(List.of(D1, D2), null, List.of("SUM__d2"), null, 10000)))
         .build();
     tableConfigWithStarTree.getIndexingConfig().setEnableDynamicStarTreeCreation(true);
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/minion/SegmentPurgerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/minion/SegmentPurgerTest.java
@@ -38,6 +38,7 @@ import org.apache.pinot.segment.spi.loader.SegmentDirectoryLoaderContext;
 import org.apache.pinot.segment.spi.loader.SegmentDirectoryLoaderRegistry;
 import org.apache.pinot.segment.spi.store.SegmentDirectory;
 import org.apache.pinot.spi.config.instance.InstanceType;
+import org.apache.pinot.spi.config.table.StarTreeIndexConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.FieldSpec;
@@ -53,6 +54,8 @@ import org.testng.annotations.Test;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 
@@ -195,6 +198,45 @@ public class SegmentPurgerTest {
             segmentGeneratorCustomConfigs);
     segmentPurger2.initSegmentGeneratorConfig("currentSegmentName");
     assertEquals(segmentPurger2.getSegmentGeneratorConfig().getSegmentName(), newSegmentName);
+  }
+
+  @Test
+  public void testStarTreeSkippedWhenDynamicCreationDisabled() {
+    // Table config has starTreeIndexConfigs but enableDynamicStarTreeCreation is false (default)
+    TableConfig tableConfigWithStarTree = new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName(TABLE_NAME)
+        .setStarTreeIndexConfigs(Collections.singletonList(
+            new StarTreeIndexConfig(List.of(D1, D2), null, null, List.of("SUM__d2"), 10000)))
+        .build();
+
+    SegmentPurger.RecordPurger recordPurger = row -> row.getValue(D1).equals(0);
+    SegmentPurger segmentPurger = new SegmentPurger(
+        _originalIndexDir, PURGED_SEGMENT_DIR, tableConfigWithStarTree, _schema, recordPurger, null, null);
+    segmentPurger.initSegmentGeneratorConfig(SEGMENT_NAME);
+
+    // Star tree should be skipped since enableDynamicStarTreeCreation is false
+    assertNull(segmentPurger.getSegmentGeneratorConfig().getStarTreeIndexConfigs());
+    assertFalse(segmentPurger.getSegmentGeneratorConfig().isEnableDefaultStarTree());
+  }
+
+  @Test
+  public void testStarTreeBuiltWhenDynamicCreationEnabled() {
+    // Table config has starTreeIndexConfigs and enableDynamicStarTreeCreation is true
+    TableConfig tableConfigWithStarTree = new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName(TABLE_NAME)
+        .setStarTreeIndexConfigs(Collections.singletonList(
+            new StarTreeIndexConfig(List.of(D1, D2), null, null, List.of("SUM__d2"), 10000)))
+        .build();
+    tableConfigWithStarTree.getIndexingConfig().setEnableDynamicStarTreeCreation(true);
+
+    SegmentPurger.RecordPurger recordPurger = row -> row.getValue(D1).equals(0);
+    SegmentPurger segmentPurger = new SegmentPurger(
+        _originalIndexDir, PURGED_SEGMENT_DIR, tableConfigWithStarTree, _schema, recordPurger, null, null);
+    segmentPurger.initSegmentGeneratorConfig(SEGMENT_NAME);
+
+    // Star tree should be present since enableDynamicStarTreeCreation is true
+    assertNotNull(segmentPurger.getSegmentGeneratorConfig().getStarTreeIndexConfigs());
+    assertEquals(segmentPurger.getSegmentGeneratorConfig().getStarTreeIndexConfigs().size(), 1);
   }
 
   @AfterClass

--- a/pinot-core/src/test/java/org/apache/pinot/core/minion/SegmentPurgerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/minion/SegmentPurgerTest.java
@@ -25,19 +25,29 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.Set;
+import java.util.TreeMap;
+import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.apache.commons.io.FileUtils;
+import org.apache.pinot.core.startree.StarTreeUtils;
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
 import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
 import org.apache.pinot.segment.local.segment.readers.PinotSegmentRecordReader;
+import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorCustomConfigs;
 import org.apache.pinot.segment.spi.index.StandardIndexes;
 import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;
+import org.apache.pinot.segment.spi.index.startree.AggregationFunctionColumnPair;
+import org.apache.pinot.segment.spi.index.startree.AggregationSpec;
+import org.apache.pinot.segment.spi.index.startree.StarTreeV2Metadata;
 import org.apache.pinot.segment.spi.loader.SegmentDirectoryLoaderContext;
 import org.apache.pinot.segment.spi.loader.SegmentDirectoryLoaderRegistry;
 import org.apache.pinot.segment.spi.store.SegmentDirectory;
 import org.apache.pinot.spi.config.instance.InstanceType;
+import org.apache.pinot.spi.config.table.FieldConfig.CompressionCodec;
+import org.apache.pinot.spi.config.table.StarTreeAggregationConfig;
 import org.apache.pinot.spi.config.table.StarTreeIndexConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
@@ -49,6 +59,7 @@ import org.apache.pinot.spi.utils.ReadMode;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
@@ -62,18 +73,25 @@ import static org.testng.Assert.assertTrue;
 public class SegmentPurgerTest {
   private static final File TEMP_DIR = new File(FileUtils.getTempDirectory(), "SegmentPurgerTest");
   private static final File ORIGINAL_SEGMENT_DIR = new File(TEMP_DIR, "originalSegment");
+  private static final File STAR_TREE_SEGMENT_DIR = new File(TEMP_DIR, "starTreeSegment");
   private static final File PURGED_SEGMENT_DIR = new File(TEMP_DIR, "purgedSegment");
   private static final Random RANDOM = new Random();
 
   private static final int NUM_ROWS = 10000;
   private static final String TABLE_NAME = "testTable";
   private static final String SEGMENT_NAME = "testSegment";
+  private static final String STAR_TREE_SEGMENT_NAME = "starTreeSegment";
   private static final String D1 = "d1";
   private static final String D2 = "d2";
+  private static final StarTreeIndexConfig STAR_TREE_CONFIG_A =
+      new StarTreeIndexConfig(List.of(D1, D2), null, List.of("SUM__d2"), null, 10000);
+  private static final StarTreeIndexConfig STAR_TREE_CONFIG_B =
+      new StarTreeIndexConfig(List.of(D2, D1), null, List.of("SUM__d1"), null, 5000);
 
   private TableConfig _tableConfig;
   private Schema _schema;
   private File _originalIndexDir;
+  private File _starTreeIndexDir;
   private int _expectedNumRecordsPurged;
   private int _expectedNumRecordsModified;
 
@@ -112,6 +130,18 @@ public class SegmentPurgerTest {
     driver.init(config, genericRowRecordReader, InstanceType.MINION);
     driver.build();
     _originalIndexDir = new File(ORIGINAL_SEGMENT_DIR, SEGMENT_NAME);
+
+    // Create a segment WITH star tree index
+    TableConfig starTreeTableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
+        .setStarTreeIndexConfigs(Collections.singletonList(STAR_TREE_CONFIG_A)).build();
+    SegmentGeneratorConfig starTreeConfig = new SegmentGeneratorConfig(starTreeTableConfig, _schema);
+    starTreeConfig.setOutDir(STAR_TREE_SEGMENT_DIR.getPath());
+    starTreeConfig.setSegmentName(STAR_TREE_SEGMENT_NAME);
+    genericRowRecordReader = new GenericRowRecordReader(rows);
+    SegmentIndexCreationDriverImpl starTreeDriver = new SegmentIndexCreationDriverImpl();
+    starTreeDriver.init(starTreeConfig, genericRowRecordReader);
+    starTreeDriver.build();
+    _starTreeIndexDir = new File(STAR_TREE_SEGMENT_DIR, STAR_TREE_SEGMENT_NAME);
   }
 
   @Test
@@ -202,51 +232,121 @@ public class SegmentPurgerTest {
     assertEquals(segmentPurger2.getSegmentGeneratorConfig().getSegmentName(), newSegmentName);
   }
 
-  @Test
-  public void testStarTreeSkippedForSegmentWithoutStarTree()
+  // Each row: {segmentHasStarTree, tableStarTreeConfigs, enableDynamic, expectedNull, expectedMaxLeaf}
+  // expectedMaxLeaf is only checked when expectedNull=false
+  @DataProvider(name = "starTreePreservationCases")
+  public Object[][] starTreePreservationCases() {
+    return new Object[][]{
+        // Segment without star tree, table has config A, dynamic=false → skip (preserve no-star-tree state)
+        {false, List.of(STAR_TREE_CONFIG_A), false, true, -1},
+        // Segment without star tree, table has config A, dynamic=true → add from table config
+        {false, List.of(STAR_TREE_CONFIG_A), true, false, 10000},
+        // Segment with star tree (A), table updated to config B, dynamic=false → preserve original A
+        {true, List.of(STAR_TREE_CONFIG_B), false, false, 10000},
+        // Segment with star tree (A), table updated to config B, dynamic=true → use B
+        {true, List.of(STAR_TREE_CONFIG_B), true, false, 5000},
+        // Segment with star tree, table removed config, dynamic=false → preserve original
+        {true, null, false, false, 10000},
+        // Segment with star tree, table removed config, dynamic=true → remove
+        {true, null, true, true, -1},
+    };
+  }
+
+  @Test(dataProvider = "starTreePreservationCases")
+  public void testStarTreePreservation(boolean segmentHasStarTree, List<StarTreeIndexConfig> tableStarTreeConfigs,
+      boolean enableDynamic, boolean expectedNull, int expectedMaxLeaf)
       throws Exception {
-    // Table config has starTreeIndexConfigs but the original segment has no star tree
-    // and enableDynamicStarTreeCreation is false (default). Star tree should NOT be added.
-    TableConfig tableConfigWithStarTree = new TableConfigBuilder(TableType.OFFLINE)
-        .setTableName(TABLE_NAME)
-        .setStarTreeIndexConfigs(Collections.singletonList(
-            new StarTreeIndexConfig(List.of(D1, D2), null, List.of("SUM__d2"), null, 10000)))
-        .build();
-    SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(_originalIndexDir);
-    // Original segment was created without star tree
-    assertNull(segmentMetadata.getStarTreeV2MetadataList());
+    File indexDir = segmentHasStarTree ? _starTreeIndexDir : _originalIndexDir;
+    String segmentName = segmentHasStarTree ? STAR_TREE_SEGMENT_NAME : SEGMENT_NAME;
 
+    TableConfigBuilder builder = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME);
+    if (tableStarTreeConfigs != null) {
+      builder.setStarTreeIndexConfigs(tableStarTreeConfigs);
+    }
+    TableConfig tableConfig = builder.build();
+    if (enableDynamic) {
+      tableConfig.getIndexingConfig().setEnableDynamicStarTreeCreation(true);
+    }
+
+    SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(indexDir);
     SegmentPurger.RecordPurger recordPurger = row -> row.getValue(D1).equals(0);
-    SegmentPurger segmentPurger = new SegmentPurger(
-        _originalIndexDir, PURGED_SEGMENT_DIR, tableConfigWithStarTree, _schema, recordPurger, null, null);
-    segmentPurger.initSegmentGeneratorConfig(SEGMENT_NAME, segmentMetadata);
+    SegmentPurger segmentPurger =
+        new SegmentPurger(indexDir, PURGED_SEGMENT_DIR, tableConfig, _schema, recordPurger, null, null);
+    segmentPurger.initSegmentGeneratorConfig(segmentName, segmentMetadata);
 
-    // Star tree should be skipped: segment didn't have it and enableDynamicStarTreeCreation is false
-    assertNull(segmentPurger.getSegmentGeneratorConfig().getStarTreeIndexConfigs());
-    assertFalse(segmentPurger.getSegmentGeneratorConfig().isEnableDefaultStarTree());
+    List<StarTreeIndexConfig> resultConfigs = segmentPurger.getSegmentGeneratorConfig().getStarTreeIndexConfigs();
+    if (expectedNull) {
+      assertNull(resultConfigs);
+      assertFalse(segmentPurger.getSegmentGeneratorConfig().isEnableDefaultStarTree());
+    } else {
+      assertNotNull(resultConfigs);
+      assertEquals(resultConfigs.size(), 1);
+      assertEquals(resultConfigs.get(0).getMaxLeafRecords(), expectedMaxLeaf);
+    }
   }
 
   @Test
-  public void testStarTreeAddedWhenDynamicCreationEnabled()
-      throws Exception {
-    // Table config has starTreeIndexConfigs, enableDynamicStarTreeCreation is true.
-    // Even though the segment has no star tree, it should be added because dynamic creation is enabled.
-    TableConfig tableConfigWithStarTree = new TableConfigBuilder(TableType.OFFLINE)
-        .setTableName(TABLE_NAME)
-        .setStarTreeIndexConfigs(Collections.singletonList(
-            new StarTreeIndexConfig(List.of(D1, D2), null, List.of("SUM__d2"), null, 10000)))
-        .build();
-    tableConfigWithStarTree.getIndexingConfig().setEnableDynamicStarTreeCreation(true);
-    SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(_originalIndexDir);
+  public void testToStarTreeIndexConfigs() {
+    // Tree 1: two aggregations with default spec and skip dimensions
+    TreeMap<AggregationFunctionColumnPair, AggregationSpec> specs1 = new TreeMap<>();
+    specs1.put(new AggregationFunctionColumnPair(AggregationFunctionType.SUM, "d2"), AggregationSpec.DEFAULT);
+    specs1.put(new AggregationFunctionColumnPair(AggregationFunctionType.COUNT, "*"), AggregationSpec.DEFAULT);
+    StarTreeV2Metadata metadata1 = createStarTreeMetadata(List.of("d1", "d2"), specs1, 10000, Set.of("d2"));
 
-    SegmentPurger.RecordPurger recordPurger = row -> row.getValue(D1).equals(0);
-    SegmentPurger segmentPurger = new SegmentPurger(
-        _originalIndexDir, PURGED_SEGMENT_DIR, tableConfigWithStarTree, _schema, recordPurger, null, null);
-    segmentPurger.initSegmentGeneratorConfig(SEGMENT_NAME, segmentMetadata);
+    // Tree 2: single aggregation, different dimension order
+    TreeMap<AggregationFunctionColumnPair, AggregationSpec> specs2 = new TreeMap<>();
+    specs2.put(new AggregationFunctionColumnPair(AggregationFunctionType.SUM, "d1"), AggregationSpec.DEFAULT);
+    StarTreeV2Metadata metadata2 = createStarTreeMetadata(List.of("d2", "d1"), specs2, 5000, Set.of());
 
-    // Star tree should be present since enableDynamicStarTreeCreation is true
-    assertNotNull(segmentPurger.getSegmentGeneratorConfig().getStarTreeIndexConfigs());
-    assertEquals(segmentPurger.getSegmentGeneratorConfig().getStarTreeIndexConfigs().size(), 1);
+    List<StarTreeIndexConfig> configs = StarTreeUtils.toStarTreeIndexConfigs(List.of(metadata1, metadata2));
+    assertEquals(configs.size(), 2);
+
+    // Verify tree 1
+    StarTreeIndexConfig config1 = configs.get(0);
+    assertEquals(config1.getDimensionsSplitOrder(), List.of("d1", "d2"));
+    assertNotNull(config1.getSkipStarNodeCreationForDimensions());
+    assertEquals(config1.getSkipStarNodeCreationForDimensions(), List.of("d2"));
+    assertEquals(config1.getMaxLeafRecords(), 10000);
+    assertNotNull(config1.getFunctionColumnPairs());
+    assertTrue(config1.getFunctionColumnPairs().contains("count__*"));
+    assertTrue(config1.getFunctionColumnPairs().contains("sum__d2"));
+    assertEquals(config1.getAggregationConfigs().size(), 2);
+
+    // Verify tree 2
+    StarTreeIndexConfig config2 = configs.get(1);
+    assertEquals(config2.getDimensionsSplitOrder(), List.of("d2", "d1"));
+    assertNull(config2.getSkipStarNodeCreationForDimensions());
+    assertEquals(config2.getMaxLeafRecords(), 5000);
+  }
+
+  @Test
+  public void testToStarTreeIndexConfigsWithCustomSpec() {
+    TreeMap<AggregationFunctionColumnPair, AggregationSpec> aggregationSpecs = new TreeMap<>();
+    aggregationSpecs.put(new AggregationFunctionColumnPair(AggregationFunctionType.SUM, "d2"),
+        new AggregationSpec(CompressionCodec.LZ4, true, 4, 4096, 1000, Map.of("param1", "value1")));
+    StarTreeV2Metadata metadata = createStarTreeMetadata(List.of("d1"), aggregationSpecs, 5000, Set.of());
+
+    List<StarTreeIndexConfig> configs = StarTreeUtils.toStarTreeIndexConfigs(List.of(metadata));
+    assertEquals(configs.size(), 1);
+    assertEquals(configs.get(0).getMaxLeafRecords(), 5000);
+
+    StarTreeAggregationConfig aggConfig = configs.get(0).getAggregationConfigs().get(0);
+    assertEquals(aggConfig.getColumnName(), "d2");
+    assertEquals(aggConfig.getAggregationFunction(), "sum");
+    assertEquals(aggConfig.getCompressionCodec(), CompressionCodec.LZ4);
+    assertTrue(aggConfig.getDeriveNumDocsPerChunk());
+    assertEquals((int) aggConfig.getIndexVersion(), 4);
+    assertEquals((int) aggConfig.getTargetDocsPerChunk(), 1000);
+    assertEquals(aggConfig.getFunctionParameters().get("param1"), "value1");
+  }
+
+  private static StarTreeV2Metadata createStarTreeMetadata(List<String> dimensions,
+      TreeMap<AggregationFunctionColumnPair, AggregationSpec> aggregationSpecs, int maxLeafRecords,
+      Set<String> skipStarNodeCreationForDimensions) {
+    PropertiesConfiguration props = new PropertiesConfiguration();
+    StarTreeV2Metadata.writeMetadata(props, 100, dimensions, aggregationSpecs, maxLeafRecords,
+        skipStarNodeCreationForDimensions);
+    return new StarTreeV2Metadata(props);
   }
 
   @AfterClass

--- a/pinot-core/src/test/java/org/apache/pinot/core/minion/SegmentPurgerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/minion/SegmentPurgerTest.java
@@ -180,12 +180,14 @@ public class SegmentPurgerTest {
   }
 
   @Test
-  public void testSegmentPurgerWithCustomSegmentGeneratorConfig() {
+  public void testSegmentPurgerWithCustomSegmentGeneratorConfig()
+      throws Exception {
     SegmentPurger.RecordPurger recordPurger = row -> row.getValue(D1).equals(0);
+    SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(_originalIndexDir);
 
     SegmentPurger segmentPurger =
         new SegmentPurger(_originalIndexDir, PURGED_SEGMENT_DIR, _tableConfig, _schema, recordPurger, null, null);
-    segmentPurger.initSegmentGeneratorConfig("currentSegmentName");
+    segmentPurger.initSegmentGeneratorConfig("currentSegmentName", segmentMetadata);
     assertEquals(segmentPurger.getSegmentGeneratorConfig().getSegmentName(), "currentSegmentName");
 
     String newSegmentName = "myTable_segment_001";
@@ -196,43 +198,51 @@ public class SegmentPurgerTest {
     SegmentPurger segmentPurger2 =
         new SegmentPurger(_originalIndexDir, PURGED_SEGMENT_DIR, _tableConfig, _schema, recordPurger, null,
             segmentGeneratorCustomConfigs);
-    segmentPurger2.initSegmentGeneratorConfig("currentSegmentName");
+    segmentPurger2.initSegmentGeneratorConfig("currentSegmentName", segmentMetadata);
     assertEquals(segmentPurger2.getSegmentGeneratorConfig().getSegmentName(), newSegmentName);
   }
 
   @Test
-  public void testStarTreeSkippedWhenDynamicCreationDisabled() {
-    // Table config has starTreeIndexConfigs but enableDynamicStarTreeCreation is false (default)
+  public void testStarTreeSkippedForSegmentWithoutStarTree()
+      throws Exception {
+    // Table config has starTreeIndexConfigs but the original segment has no star tree
+    // and enableDynamicStarTreeCreation is false (default). Star tree should NOT be added.
     TableConfig tableConfigWithStarTree = new TableConfigBuilder(TableType.OFFLINE)
         .setTableName(TABLE_NAME)
         .setStarTreeIndexConfigs(Collections.singletonList(
             new StarTreeIndexConfig(List.of(D1, D2), null, List.of("SUM__d2"), null, 10000)))
         .build();
+    SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(_originalIndexDir);
+    // Original segment was created without star tree
+    assertNull(segmentMetadata.getStarTreeV2MetadataList());
 
     SegmentPurger.RecordPurger recordPurger = row -> row.getValue(D1).equals(0);
     SegmentPurger segmentPurger = new SegmentPurger(
         _originalIndexDir, PURGED_SEGMENT_DIR, tableConfigWithStarTree, _schema, recordPurger, null, null);
-    segmentPurger.initSegmentGeneratorConfig(SEGMENT_NAME);
+    segmentPurger.initSegmentGeneratorConfig(SEGMENT_NAME, segmentMetadata);
 
-    // Star tree should be skipped since enableDynamicStarTreeCreation is false
+    // Star tree should be skipped: segment didn't have it and enableDynamicStarTreeCreation is false
     assertNull(segmentPurger.getSegmentGeneratorConfig().getStarTreeIndexConfigs());
     assertFalse(segmentPurger.getSegmentGeneratorConfig().isEnableDefaultStarTree());
   }
 
   @Test
-  public void testStarTreeBuiltWhenDynamicCreationEnabled() {
-    // Table config has starTreeIndexConfigs and enableDynamicStarTreeCreation is true
+  public void testStarTreeAddedWhenDynamicCreationEnabled()
+      throws Exception {
+    // Table config has starTreeIndexConfigs, enableDynamicStarTreeCreation is true.
+    // Even though the segment has no star tree, it should be added because dynamic creation is enabled.
     TableConfig tableConfigWithStarTree = new TableConfigBuilder(TableType.OFFLINE)
         .setTableName(TABLE_NAME)
         .setStarTreeIndexConfigs(Collections.singletonList(
             new StarTreeIndexConfig(List.of(D1, D2), null, List.of("SUM__d2"), null, 10000)))
         .build();
     tableConfigWithStarTree.getIndexingConfig().setEnableDynamicStarTreeCreation(true);
+    SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(_originalIndexDir);
 
     SegmentPurger.RecordPurger recordPurger = row -> row.getValue(D1).equals(0);
     SegmentPurger segmentPurger = new SegmentPurger(
         _originalIndexDir, PURGED_SEGMENT_DIR, tableConfigWithStarTree, _schema, recordPurger, null, null);
-    segmentPurger.initSegmentGeneratorConfig(SEGMENT_NAME);
+    segmentPurger.initSegmentGeneratorConfig(SEGMENT_NAME, segmentMetadata);
 
     // Star tree should be present since enableDynamicStarTreeCreation is true
     assertNotNull(segmentPurger.getSegmentGeneratorConfig().getStarTreeIndexConfigs());


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

SegmentPurger now uses existing segment's star\-tree metadata to preserve star\-tree state when dynamic star tree creation is disabled\.

```mermaid
flowchart TD
  N0["purgeSegment calls initSegmentGeneratorConfig#40;segName#44; segMeta#41; #91;F1#93;#39; #40;F1#41;"]:::stAdded
  N1["initSegmentGeneratorConfig#58; check #33;enableDynamicStarTreeCreation #91;F1#93;#39;  #44;  #40;F1#41;"]:::stModified
  N2["#91;if true#93; get starTreeV2MetaList from segMeta #91;F1#93;#39;  #44;  #40;F1#41;"]:::stAdded
  N3["#91;if true#93; check starTreeV2MetaList #61;#61; null #91;F1#93;#39;  #44;  #40;F1#41;"]:::stAdded
  N4["#91;if true#93; set starTreeIdxConfigs #61; null #91;F1#93;#39;  #44;  #40;F1#41;"]:::stAdded
  N5["#91;if false#93; set starTreeIdxConfigs #61; StarTreeUtils#46;toStarTreeIdxConfigs#40;starTreeV #40;F1#44; F2#41;"]:::stAdded
  N6["#91;if true#93; set enableDefaultStarTree #61; false #91;F1#93;#39;  #44;  #40;F1#41;"]:::stAdded
  N0 --> N1
  N1 -->|"true"| N2
  N2 --> N3
  N3 -->|"true"| N4
  N3 -->|"false"| N5
  N4 --> N6
  N5 --> N6
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-core/src/main/java/org/apache/pinot/core/minion/SegmentPurger\.java — [before](https://github.com/apache/pinot/blob/3ca14f9b13401071e4f469674e5ae429fab2909b/pinot-core/src/main/java/org/apache/pinot/core/minion/SegmentPurger.java) · [after](https://github.com/apache/pinot/blob/bf933eedc802f690565f7b6378a1871985a489ee/pinot-core/src/main/java/org/apache/pinot/core/minion/SegmentPurger.java)
- F2: pinot\-core/src/main/java/org/apache/pinot/core/startree/StarTreeUtils\.java — [before](https://github.com/apache/pinot/blob/3ca14f9b13401071e4f469674e5ae429fab2909b/pinot-core/src/main/java/org/apache/pinot/core/startree/StarTreeUtils.java) · [after](https://github.com/apache/pinot/blob/bf933eedc802f690565f7b6378a1871985a489ee/pinot-core/src/main/java/org/apache/pinot/core/startree/StarTreeUtils.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjNjYTE0ZjliMTM0MDEwNzFlNGY0Njk2NzRlNWFlNDI5ZmFiMjkwOWIiLCJjb250ZXh0X2hhc2giOiJhNzIwOWRmZWEwYzMzODFiOWVjMmU5YzNiZThiZmNkOTE3OTAwMzI1NDRjYTI4ZmFlYjJhY2Y2Mzg2NTI0NDczIiwiZ2VuZXJhdGVkX2F0IjoxNzg4OTkyODYwLCJoZWFkX3NoYSI6ImJmOTMzZWVkYzgwMmY2OTA1NjVmN2I2Mzc4YTE4NzE5ODVhNDg5ZWUiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiIzY2ExNGY5YjEzNDAxMDcxZTRmNDY5Njc0ZTVhZTQyOWZhYjI5MDliIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 7c1222239ba7316c04a2cced5e13865d3017d12672530546fb1e2513cc9af2c9 -->
<!-- pinot-pr-flow:end -->

 ## Summary
  - When PurgeTask rebuilds a segment (after purging compliance/late-event records), SegmentPurger creates a new segment via SegmentGeneratorConfig which unconditionally picks up starTreeIndexConfigs from the table config. This causes old segments to unexpectedly gain star-tree indexes during purge, even when `enableDynamicStarTreeCreation` is false.
  - This change makes SegmentPurger.initSegmentGeneratorConfig() respect enableDynamicStarTreeCreation — if it's false (default), star-tree configs are cleared before segment generation, preventing unintended star-tree  add/remove/modify  during purge rebuilds.
  
https://github.com/apache/pinot/issues/17821 
 ## Test plan
unit test