### PR TITLE
 Add batch aggregation for sketch ValueAggregators in MergeRollupTask

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
@@ -133,6 +133,15 @@ public class MinionConstants {
     public static final String MAX_NUM_RECORDS_PER_TASK_KEY = "maxNumRecordsPerTask";
     public static final String MAX_NUM_RECORDS_PER_SEGMENT_KEY = "maxNumRecordsPerSegment";
 
+    // Reducer config
+    /**
+     * Maximum number of rows to batch before aggregating during rollup reduce phase.
+     * Higher values improve performance for sketch aggregations but use more memory.
+     * Default is 1000.
+     */
+    public static final String REDUCER_MAX_BATCH_SIZE_KEY = "reducerMaxBatchSize";
+    public static final int DEFAULT_REDUCER_MAX_BATCH_SIZE = 1000;
+
     // See AdaptiveSizeBasedWriter for documentation of these configs
     public static final String SEGMENT_MAPPER_FILE_SIZE_IN_BYTES = "segmentMapperFileSizeThresholdInBytes";
     public static final String MAX_DISK_USAGE_PERCENTAGE = "maxDiskUsagePercentage";

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/aggregator/DistinctCountCPCSketchAggregator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/aggregator/DistinctCountCPCSketchAggregator.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.segment.processing.aggregator;
 
+import java.util.List;
 import java.util.Map;
 import org.apache.datasketches.cpc.CpcSketch;
 import org.apache.datasketches.cpc.CpcUnion;
@@ -47,6 +48,36 @@ public class DistinctCountCPCSketchAggregator implements ValueAggregator {
     }
     union.update(first);
     union.update(second);
+    return ObjectSerDeUtils.DATA_SKETCH_CPC_SER_DE.serialize(union.getResult());
+  }
+
+  @Override
+  public boolean supportsBatchAggregation() {
+    return true;
+  }
+
+  @Override
+  public Object aggregateBatch(List<Object> values, Map<String, String> functionParameters) {
+    if (values == null || values.isEmpty()) {
+      return null;
+    }
+    if (values.size() == 1) {
+      return values.get(0);
+    }
+
+    // Build union once for all values
+    String lgKParam = functionParameters.get(Constants.CPCSKETCH_LGK_KEY);
+    int lgK = lgKParam != null
+        ? Integer.parseInt(lgKParam)
+        : CommonConstants.Helix.DEFAULT_CPC_SKETCH_LGK;
+    CpcUnion union = new CpcUnion(lgK);
+
+    // Deserialize and union all sketches
+    for (Object value : values) {
+      CpcSketch sketch = ObjectSerDeUtils.DATA_SKETCH_CPC_SER_DE.deserialize((byte[]) value);
+      union.update(sketch);
+    }
+
     return ObjectSerDeUtils.DATA_SKETCH_CPC_SER_DE.serialize(union.getResult());
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/aggregator/DistinctCountThetaSketchAggregator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/aggregator/DistinctCountThetaSketchAggregator.java
@@ -18,7 +18,11 @@
  */
 package org.apache.pinot.core.segment.processing.aggregator;
 
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
 import java.util.Map;
+import org.apache.datasketches.memory.Memory;
 import org.apache.datasketches.theta.SetOperationBuilder;
 import org.apache.datasketches.theta.Sketch;
 import org.apache.datasketches.theta.Union;
@@ -58,5 +62,52 @@ public class DistinctCountThetaSketchAggregator implements ValueAggregator {
     Sketch second = ObjectSerDeUtils.DATA_SKETCH_THETA_SER_DE.deserialize((byte[]) value2);
     Sketch result = union.union(first, second);
     return ObjectSerDeUtils.DATA_SKETCH_THETA_SER_DE.serialize(result);
+  }
+
+  @Override
+  public boolean supportsBatchAggregation() {
+    return true;
+  }
+
+  @Override
+  public Object aggregateBatch(List<Object> values, Map<String, String> functionParameters) {
+    if (values == null || values.isEmpty()) {
+      return null;
+    }
+    if (values.size() == 1) {
+      return values.get(0);
+    }
+
+    // Build union once for all values
+    SetOperationBuilder unionBuilder = Union.builder();
+    String nominalEntriesParam = functionParameters.get(Constants.THETA_TUPLE_SKETCH_NOMINAL_ENTRIES);
+    if (nominalEntriesParam != null) {
+      unionBuilder.setNominalEntries(Integer.parseInt(nominalEntriesParam));
+    } else {
+      unionBuilder.setNominalEntries(CommonConstants.Helix.DEFAULT_THETA_SKETCH_NOMINAL_ENTRIES);
+    }
+    String samplingProbabilityParam = functionParameters.get(Constants.THETA_TUPLE_SKETCH_SAMPLING_PROBABILITY);
+    if (samplingProbabilityParam != null) {
+      unionBuilder.setP(Float.parseFloat(samplingProbabilityParam));
+    }
+    Union union = unionBuilder.buildUnion();
+
+    // Wrap all sketches using zero-copy when possible
+    List<Sketch> sketches = new ArrayList<>(values.size());
+    for (Object value : values) {
+      Sketch sketch = Sketch.wrap(Memory.wrap((byte[]) value));
+      sketches.add(sketch);
+    }
+
+    // Sort by theta (ascending) for early-stop optimization (Broder's algorithm)
+    // Sketches with smaller theta values are more selective and should be processed first
+    sketches.sort(Comparator.comparingDouble(Sketch::getTheta));
+
+    // Union all sketches
+    for (Sketch sketch : sketches) {
+      union.union(sketch);
+    }
+
+    return ObjectSerDeUtils.DATA_SKETCH_THETA_SER_DE.serialize(union.getResult());
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/aggregator/IntegerTupleSketchAggregator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/aggregator/IntegerTupleSketchAggregator.java
@@ -18,6 +18,9 @@
  */
 package org.apache.pinot.core.segment.processing.aggregator;
 
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
 import java.util.Map;
 import org.apache.datasketches.tuple.Sketch;
 import org.apache.datasketches.tuple.Union;
@@ -56,5 +59,46 @@ public class IntegerTupleSketchAggregator implements ValueAggregator {
     Sketch<IntegerSummary> second = ObjectSerDeUtils.DATA_SKETCH_INT_TUPLE_SER_DE.deserialize((byte[]) value2);
     Sketch<IntegerSummary> result = integerUnion.union(first, second);
     return ObjectSerDeUtils.DATA_SKETCH_INT_TUPLE_SER_DE.serialize(result);
+  }
+
+  @Override
+  public boolean supportsBatchAggregation() {
+    return true;
+  }
+
+  @Override
+  public Object aggregateBatch(List<Object> values, Map<String, String> functionParameters) {
+    if (values == null || values.isEmpty()) {
+      return null;
+    }
+    if (values.size() == 1) {
+      return values.get(0);
+    }
+
+    // Build union once for all values
+    String nominalEntriesParam = functionParameters.get(Constants.THETA_TUPLE_SKETCH_NOMINAL_ENTRIES);
+    int nominalEntries = nominalEntriesParam != null
+        ? Integer.parseInt(nominalEntriesParam)
+        : (int) Math.pow(2, CommonConstants.Helix.DEFAULT_TUPLE_SKETCH_LGK);
+
+    IntegerSummarySetOperations setOperations = new IntegerSummarySetOperations(_mode, _mode);
+    Union<IntegerSummary> union = new Union<>(nominalEntries, setOperations);
+
+    // Deserialize all sketches
+    List<Sketch<IntegerSummary>> sketches = new ArrayList<>(values.size());
+    for (Object value : values) {
+      Sketch<IntegerSummary> sketch = ObjectSerDeUtils.DATA_SKETCH_INT_TUPLE_SER_DE.deserialize((byte[]) value);
+      sketches.add(sketch);
+    }
+
+    // Sort by theta (ascending) for early-stop optimization
+    sketches.sort(Comparator.comparingDouble(Sketch::getTheta));
+
+    // Union all sketches
+    for (Sketch<IntegerSummary> sketch : sketches) {
+      union.union(sketch);
+    }
+
+    return ObjectSerDeUtils.DATA_SKETCH_INT_TUPLE_SER_DE.serialize(union.getResult());
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/aggregator/ValueAggregator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/aggregator/ValueAggregator.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.segment.processing.aggregator;
 
+import java.util.List;
 import java.util.Map;
 
 
@@ -31,4 +32,39 @@ public interface ValueAggregator {
    * @return aggregated value given two column values
    */
   Object aggregate(Object value1, Object value2, Map<String, String> functionParameters);
+
+  /**
+   * Aggregate multiple values at once. Default implementation falls back to pairwise aggregation.
+   * Sketch implementations can override for optimized batch merging with reduced serialization
+   * overhead and early-stop optimization.
+   *
+   * @param values List of values to aggregate (all same column, same key)
+   * @param functionParameters Aggregation parameters
+   * @return Aggregated result
+   */
+  default Object aggregateBatch(List<Object> values, Map<String, String> functionParameters) {
+    if (values == null || values.isEmpty()) {
+      return null;
+    }
+    if (values.size() == 1) {
+      return values.get(0);
+    }
+    // Default: pairwise aggregation for backwards compatibility
+    Object result = values.get(0);
+    for (int i = 1; i < values.size(); i++) {
+      result = aggregate(result, values.get(i), functionParameters);
+    }
+    return result;
+  }
+
+  /**
+   * Whether this aggregator supports optimized batch aggregation.
+   * When true, the aggregator has an optimized implementation of {@link #aggregateBatch}
+   * that is more efficient than pairwise aggregation.
+   *
+   * @return true if optimized batch aggregation is supported
+   */
+  default boolean supportsBatchAggregation() {
+    return false;
+  }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/framework/SegmentProcessorConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/framework/SegmentProcessorConfig.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 import javax.annotation.Nullable;
+import org.apache.pinot.core.common.MinionConstants;
 import org.apache.pinot.core.segment.processing.partitioner.PartitionerConfig;
 import org.apache.pinot.core.segment.processing.timehandler.TimeHandler;
 import org.apache.pinot.core.segment.processing.timehandler.TimeHandlerConfig;
@@ -48,6 +49,7 @@ public class SegmentProcessorConfig {
   private final Map<String, AggregationFunctionType> _aggregationTypes;
   private final Map<String, Map<String, String>> _aggregationFunctionParameters;
   private final SegmentConfig _segmentConfig;
+  private final int _reducerMaxBatchSize;
   private final Consumer<Object> _progressObserver;
   private final SegmentNameGenerator _segmentNameGenerator;
   private final Long _customCreationTime;
@@ -56,8 +58,8 @@ public class SegmentProcessorConfig {
       List<PartitionerConfig> partitionerConfigs, MergeType mergeType,
       Map<String, AggregationFunctionType> aggregationTypes,
       Map<String, Map<String, String>> aggregationFunctionParameters, SegmentConfig segmentConfig,
-      Consumer<Object> progressObserver, @Nullable SegmentNameGenerator segmentNameGenerator,
-      @Nullable Long customCreationTime) {
+      int reducerMaxBatchSize, Consumer<Object> progressObserver,
+      @Nullable SegmentNameGenerator segmentNameGenerator, @Nullable Long customCreationTime) {
     TimestampIndexUtils.applyTimestampIndex(tableConfig, schema);
     _tableConfig = tableConfig;
     _schema = schema;
@@ -67,6 +69,7 @@ public class SegmentProcessorConfig {
     _aggregationTypes = aggregationTypes;
     _aggregationFunctionParameters = aggregationFunctionParameters;
     _segmentConfig = segmentConfig;
+    _reducerMaxBatchSize = reducerMaxBatchSize;
     _progressObserver = (progressObserver != null) ? progressObserver : p -> {
       // Do nothing.
     };
@@ -130,6 +133,14 @@ public class SegmentProcessorConfig {
     return _segmentConfig;
   }
 
+  /**
+   * Maximum number of rows to batch before aggregating during rollup reduce phase.
+   * Higher values improve performance for sketch aggregations but use more memory.
+   */
+  public int getReducerMaxBatchSize() {
+    return _reducerMaxBatchSize;
+  }
+
   public Consumer<Object> getProgressObserver() {
     return _progressObserver;
   }
@@ -162,6 +173,7 @@ public class SegmentProcessorConfig {
     private Map<String, AggregationFunctionType> _aggregationTypes;
     private Map<String, Map<String, String>> _aggregationFunctionParameters;
     private SegmentConfig _segmentConfig;
+    private int _reducerMaxBatchSize = -1;  // -1 means use default
     private Consumer<Object> _progressObserver;
     private SegmentNameGenerator _segmentNameGenerator;
     private Long _customCreationTime;
@@ -206,6 +218,11 @@ public class SegmentProcessorConfig {
       return this;
     }
 
+    public Builder setReducerMaxBatchSize(int reducerMaxBatchSize) {
+      _reducerMaxBatchSize = reducerMaxBatchSize;
+      return this;
+    }
+
     public Builder setProgressObserver(Consumer<Object> progressObserver) {
       _progressObserver = progressObserver;
       return this;
@@ -243,9 +260,12 @@ public class SegmentProcessorConfig {
       if (_segmentConfig == null) {
         _segmentConfig = new SegmentConfig.Builder().build();
       }
+      int reducerMaxBatchSize = _reducerMaxBatchSize > 0
+          ? _reducerMaxBatchSize
+          : MinionConstants.MergeTask.DEFAULT_REDUCER_MAX_BATCH_SIZE;
       return new SegmentProcessorConfig(_tableConfig, _schema, _timeHandlerConfig, _partitionerConfigs, _mergeType,
-          _aggregationTypes, _aggregationFunctionParameters, _segmentConfig, _progressObserver,
-              _segmentNameGenerator, _customCreationTime);
+          _aggregationTypes, _aggregationFunctionParameters, _segmentConfig, reducerMaxBatchSize, _progressObserver,
+          _segmentNameGenerator, _customCreationTime);
     }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/reducer/ReducerFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/reducer/ReducerFactory.java
@@ -39,7 +39,8 @@ public class ReducerFactory {
         return new ConcatReducer(fileManager);
       case ROLLUP:
         return new RollupReducer(partitionId, fileManager, processorConfig.getAggregationTypes(),
-            processorConfig.getAggregationFunctionParameters(), reducerOutputDir);
+            processorConfig.getAggregationFunctionParameters(), reducerOutputDir,
+            processorConfig.getReducerMaxBatchSize());
       case DEDUP:
         return new DedupReducer(partitionId, fileManager, reducerOutputDir);
       default:

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/reducer/RollupReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/reducer/RollupReducer.java
@@ -118,12 +118,14 @@ public class RollupReducer implements Reducer {
     GenericRowFileWriter rollupFileWriter = _rollupFileManager.getFileWriter();
 
     // Check if any aggregators support batch aggregation
-    boolean useBatchAggregation = aggregatorContextList.stream()
-        .anyMatch(ctx -> ctx._aggregator.supportsBatchAggregation());
+    long batchAggregatorCount = aggregatorContextList.stream()
+        .filter(ctx -> ctx._aggregator.supportsBatchAggregation())
+        .count();
 
-    if (useBatchAggregation) {
-      LOGGER.info("Using batch aggregation for partition: {}", _partitionId);
-      reduceBatch(recordReader, numRows, aggregatorContextList, rollupFileWriter, includeNullFields);
+    if (batchAggregatorCount > 0) {
+      LOGGER.info("Using hybrid aggregation for partition: {} ({} batch, {} pairwise)",
+          _partitionId, batchAggregatorCount, aggregatorContextList.size() - batchAggregatorCount);
+      reduceHybrid(recordReader, numRows, aggregatorContextList, rollupFileWriter, includeNullFields);
     } else {
       reducePairwise(recordReader, numRows, aggregatorContextList, rollupFileWriter, includeNullFields);
     }
@@ -179,27 +181,34 @@ public class RollupReducer implements Reducer {
   }
 
   /**
-   * Batch reduce - collects all rows for the same key before aggregating.
-   * This is more efficient for sketch aggregators that can batch merge.
+   * Hybrid reduce - uses batch aggregation only for aggregators that support it,
+   * pairwise aggregation for others. This optimizes memory usage by only buffering
+   * values for columns that benefit from batch aggregation (e.g., sketches).
    */
-  private void reduceBatch(GenericRowFileRecordReader recordReader, int numRows,
+  private void reduceHybrid(GenericRowFileRecordReader recordReader, int numRows,
       List<AggregatorContext> aggregatorContextList, GenericRowFileWriter rollupFileWriter, boolean includeNullFields)
       throws Exception {
-    // Collect values for each metric column across rows with the same key
+    // Only allocate batch storage for aggregators that support it
     List<List<Object>> batchValues = new ArrayList<>(aggregatorContextList.size());
     for (int j = 0; j < aggregatorContextList.size(); j++) {
-      batchValues.add(new ArrayList<>());
+      if (aggregatorContextList.get(j)._aggregator.supportsBatchAggregation()) {
+        batchValues.add(new ArrayList<>());
+      } else {
+        batchValues.add(null);  // null indicates pairwise aggregation
+      }
     }
 
     GenericRow baseRow = new GenericRow();
     recordReader.read(0, baseRow);
     int baseRowId = 0;
 
-    // Initialize batch with first row's values
+    // Initialize batch values for batch-supporting aggregators
     for (int j = 0; j < aggregatorContextList.size(); j++) {
-      String column = aggregatorContextList.get(j)._column;
-      if (!includeNullFields || !baseRow.isNullValue(column)) {
-        batchValues.get(j).add(baseRow.getValue(column));
+      if (batchValues.get(j) != null) {
+        String column = aggregatorContextList.get(j)._column;
+        if (!includeNullFields || !baseRow.isNullValue(column)) {
+          batchValues.get(j).add(baseRow.getValue(column));
+        }
       }
     }
 
@@ -209,57 +218,80 @@ public class RollupReducer implements Reducer {
       recordReader.read(i, currentRow);
 
       if (recordReader.compare(baseRowId, i) == 0) {
-        // Same key - add values to batch
+        // Same key - batch or aggregate pairwise depending on aggregator
         for (int j = 0; j < aggregatorContextList.size(); j++) {
-          String column = aggregatorContextList.get(j)._column;
-          if (!includeNullFields || !currentRow.isNullValue(column)) {
-            batchValues.get(j).add(currentRow.getValue(column));
+          AggregatorContext ctx = aggregatorContextList.get(j);
+          String column = ctx._column;
+
+          if (batchValues.get(j) != null) {
+            // Batch aggregation - collect value
+            if (!includeNullFields || !currentRow.isNullValue(column)) {
+              batchValues.get(j).add(currentRow.getValue(column));
+            }
+          } else {
+            // Pairwise aggregation - aggregate immediately (O(1) memory)
+            if (includeNullFields) {
+              if (!currentRow.isNullValue(column)) {
+                if (baseRow.removeNullValueField(column)) {
+                  baseRow.putValue(column, currentRow.getValue(column));
+                } else {
+                  baseRow.putValue(column, ctx._aggregator.aggregate(
+                      baseRow.getValue(column), currentRow.getValue(column), ctx._functionParameters));
+                }
+              }
+            } else {
+              baseRow.putValue(column, ctx._aggregator.aggregate(
+                  baseRow.getValue(column), currentRow.getValue(column), ctx._functionParameters));
+            }
           }
         }
 
-        // Memory safety: flush partial result if batch gets too large
+        // Memory safety: flush partial batch results if batch gets too large
         int currentBatchSize = 0;
-        for (int k = 0; k < batchValues.size(); k++) {
-          int size = batchValues.get(k).size();
-          if (size > currentBatchSize) {
-            currentBatchSize = size;
+        for (List<Object> batch : batchValues) {
+          if (batch != null && batch.size() > currentBatchSize) {
+            currentBatchSize = batch.size();
           }
         }
         if (currentBatchSize >= _maxBatchSize) {
           flushBatchToBaseRow(baseRow, batchValues, aggregatorContextList, includeNullFields);
         }
       } else {
-        // Key changed - aggregate batch and write
-        aggregateBatchAndWrite(baseRow, batchValues, aggregatorContextList, rollupFileWriter, includeNullFields);
+        // Key changed - finalize batch aggregations and write
+        finalizeBatchAndWrite(baseRow, batchValues, aggregatorContextList, rollupFileWriter, includeNullFields);
 
-        // Start new batch with current row
+        // Start new key
         baseRowId = i;
         baseRow.clear();
         recordReader.read(i, baseRow);
 
+        // Reset batch values for batch-supporting aggregators
         for (int j = 0; j < aggregatorContextList.size(); j++) {
-          batchValues.get(j).clear();
-          String column = aggregatorContextList.get(j)._column;
-          if (!includeNullFields || !baseRow.isNullValue(column)) {
-            batchValues.get(j).add(baseRow.getValue(column));
+          if (batchValues.get(j) != null) {
+            batchValues.get(j).clear();
+            String column = aggregatorContextList.get(j)._column;
+            if (!includeNullFields || !baseRow.isNullValue(column)) {
+              batchValues.get(j).add(baseRow.getValue(column));
+            }
           }
         }
       }
     }
 
     // Write final key
-    aggregateBatchAndWrite(baseRow, batchValues, aggregatorContextList, rollupFileWriter, includeNullFields);
+    finalizeBatchAndWrite(baseRow, batchValues, aggregatorContextList, rollupFileWriter, includeNullFields);
   }
 
   /**
    * Flush batch values into the base row (partial aggregation for memory safety).
+   * Only processes columns that use batch aggregation.
    */
   private void flushBatchToBaseRow(GenericRow baseRow, List<List<Object>> batchValues,
       List<AggregatorContext> aggregatorContextList, boolean includeNullFields) {
     for (int j = 0; j < aggregatorContextList.size(); j++) {
-      AggregatorContext ctx = aggregatorContextList.get(j);
       List<Object> values = batchValues.get(j);
-      if (!values.isEmpty()) {
+      if (values != null && !values.isEmpty()) {
+        AggregatorContext ctx = aggregatorContextList.get(j);
         Object aggregated = ctx._aggregator.aggregateBatch(values, ctx._functionParameters);
         baseRow.putValue(ctx._column, aggregated);
         if (includeNullFields) {
@@ -272,15 +304,16 @@ public class RollupReducer implements Reducer {
   }
 
   /**
-   * Aggregate batch values and write the result.
+   * Finalize batch aggregations and write the result.
+   * Pairwise columns already have their final values in baseRow.
    */
-  private void aggregateBatchAndWrite(GenericRow baseRow, List<List<Object>> batchValues,
+  private void finalizeBatchAndWrite(GenericRow baseRow, List<List<Object>> batchValues,
       List<AggregatorContext> aggregatorContextList, GenericRowFileWriter rollupFileWriter, boolean includeNullFields)
       throws Exception {
     for (int j = 0; j < aggregatorContextList.size(); j++) {
-      AggregatorContext ctx = aggregatorContextList.get(j);
       List<Object> values = batchValues.get(j);
-      if (!values.isEmpty()) {
+      if (values != null && !values.isEmpty()) {
+        AggregatorContext ctx = aggregatorContextList.get(j);
         Object aggregated = ctx._aggregator.aggregateBatch(values, ctx._functionParameters);
         baseRow.putValue(ctx._column, aggregated);
         if (includeNullFields) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/reducer/RollupReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/reducer/RollupReducer.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.io.FileUtils;
+import org.apache.pinot.core.common.MinionConstants;
 import org.apache.pinot.core.segment.processing.aggregator.ValueAggregator;
 import org.apache.pinot.core.segment.processing.aggregator.ValueAggregatorFactory;
 import org.apache.pinot.core.segment.processing.genericrow.GenericRowFileManager;
@@ -50,16 +51,25 @@ public class RollupReducer implements Reducer {
   private final Map<String, AggregationFunctionType> _aggregationTypes;
   private final Map<String, Map<String, String>> _aggregationFunctionParameters;
   private final File _reducerOutputDir;
+  private final int _maxBatchSize;
   private GenericRowFileManager _rollupFileManager;
 
   public RollupReducer(String partitionId, GenericRowFileManager fileManager,
       Map<String, AggregationFunctionType> aggregationTypes,
       Map<String, Map<String, String>> aggregationFunctionParameters, File reducerOutputDir) {
+    this(partitionId, fileManager, aggregationTypes, aggregationFunctionParameters, reducerOutputDir,
+        MinionConstants.MergeTask.DEFAULT_REDUCER_MAX_BATCH_SIZE);
+  }
+
+  public RollupReducer(String partitionId, GenericRowFileManager fileManager,
+      Map<String, AggregationFunctionType> aggregationTypes,
+      Map<String, Map<String, String>> aggregationFunctionParameters, File reducerOutputDir, int maxBatchSize) {
     _partitionId = partitionId;
     _fileManager = fileManager;
     _aggregationTypes = aggregationTypes;
     _aggregationFunctionParameters = aggregationFunctionParameters;
     _reducerOutputDir = reducerOutputDir;
+    _maxBatchSize = maxBatchSize;
   }
 
   @Override
@@ -106,6 +116,32 @@ public class RollupReducer implements Reducer {
     long rollupFileCreationStartTimeMs = System.currentTimeMillis();
     _rollupFileManager = new GenericRowFileManager(partitionOutputDir, fieldSpecs, includeNullFields, 0);
     GenericRowFileWriter rollupFileWriter = _rollupFileManager.getFileWriter();
+
+    // Check if any aggregators support batch aggregation
+    boolean useBatchAggregation = aggregatorContextList.stream()
+        .anyMatch(ctx -> ctx._aggregator.supportsBatchAggregation());
+
+    if (useBatchAggregation) {
+      LOGGER.info("Using batch aggregation for partition: {}", _partitionId);
+      reduceBatch(recordReader, numRows, aggregatorContextList, rollupFileWriter, includeNullFields);
+    } else {
+      reducePairwise(recordReader, numRows, aggregatorContextList, rollupFileWriter, includeNullFields);
+    }
+
+    _rollupFileManager.closeFileWriter();
+    LOGGER.info("Finish creating rollup file in {}ms", System.currentTimeMillis() - rollupFileCreationStartTimeMs);
+
+    _fileManager.cleanUp();
+    LOGGER.info("Finish reducing in {}ms", System.currentTimeMillis() - reduceStartTimeMs);
+    return _rollupFileManager;
+  }
+
+  /**
+   * Pairwise reduce - the original implementation that aggregates rows one at a time.
+   */
+  private void reducePairwise(GenericRowFileRecordReader recordReader, int numRows,
+      List<AggregatorContext> aggregatorContextList, GenericRowFileWriter rollupFileWriter, boolean includeNullFields)
+      throws Exception {
     GenericRow previousRow = new GenericRow();
     recordReader.read(0, previousRow);
     int previousRowId = 0;
@@ -140,12 +176,112 @@ public class RollupReducer implements Reducer {
       }
     }
     rollupFileWriter.write(previousRow);
-    _rollupFileManager.closeFileWriter();
-    LOGGER.info("Finish creating rollup file in {}ms", System.currentTimeMillis() - rollupFileCreationStartTimeMs);
+  }
 
-    _fileManager.cleanUp();
-    LOGGER.info("Finish reducing in {}ms", System.currentTimeMillis() - reduceStartTimeMs);
-    return _rollupFileManager;
+  /**
+   * Batch reduce - collects all rows for the same key before aggregating.
+   * This is more efficient for sketch aggregators that can batch merge.
+   */
+  private void reduceBatch(GenericRowFileRecordReader recordReader, int numRows,
+      List<AggregatorContext> aggregatorContextList, GenericRowFileWriter rollupFileWriter, boolean includeNullFields)
+      throws Exception {
+    // Collect values for each metric column across rows with the same key
+    List<List<Object>> batchValues = new ArrayList<>(aggregatorContextList.size());
+    for (int j = 0; j < aggregatorContextList.size(); j++) {
+      batchValues.add(new ArrayList<>());
+    }
+
+    GenericRow baseRow = new GenericRow();
+    recordReader.read(0, baseRow);
+    int baseRowId = 0;
+
+    // Initialize batch with first row's values
+    for (int j = 0; j < aggregatorContextList.size(); j++) {
+      String column = aggregatorContextList.get(j)._column;
+      if (!includeNullFields || !baseRow.isNullValue(column)) {
+        batchValues.get(j).add(baseRow.getValue(column));
+      }
+    }
+
+    GenericRow currentRow = new GenericRow();
+    for (int i = 1; i < numRows; i++) {
+      currentRow.clear();
+      recordReader.read(i, currentRow);
+
+      if (recordReader.compare(baseRowId, i) == 0) {
+        // Same key - add values to batch
+        for (int j = 0; j < aggregatorContextList.size(); j++) {
+          String column = aggregatorContextList.get(j)._column;
+          if (!includeNullFields || !currentRow.isNullValue(column)) {
+            batchValues.get(j).add(currentRow.getValue(column));
+          }
+        }
+
+        // Memory safety: flush partial result if batch gets too large
+        if (batchValues.get(0).size() >= _maxBatchSize) {
+          flushBatchToBaseRow(baseRow, batchValues, aggregatorContextList, includeNullFields);
+        }
+      } else {
+        // Key changed - aggregate batch and write
+        aggregateBatchAndWrite(baseRow, batchValues, aggregatorContextList, rollupFileWriter, includeNullFields);
+
+        // Start new batch with current row
+        baseRowId = i;
+        baseRow.clear();
+        recordReader.read(i, baseRow);
+
+        for (int j = 0; j < aggregatorContextList.size(); j++) {
+          batchValues.get(j).clear();
+          String column = aggregatorContextList.get(j)._column;
+          if (!includeNullFields || !baseRow.isNullValue(column)) {
+            batchValues.get(j).add(baseRow.getValue(column));
+          }
+        }
+      }
+    }
+
+    // Write final key
+    aggregateBatchAndWrite(baseRow, batchValues, aggregatorContextList, rollupFileWriter, includeNullFields);
+  }
+
+  /**
+   * Flush batch values into the base row (partial aggregation for memory safety).
+   */
+  private void flushBatchToBaseRow(GenericRow baseRow, List<List<Object>> batchValues,
+      List<AggregatorContext> aggregatorContextList, boolean includeNullFields) {
+    for (int j = 0; j < aggregatorContextList.size(); j++) {
+      AggregatorContext ctx = aggregatorContextList.get(j);
+      List<Object> values = batchValues.get(j);
+      if (!values.isEmpty()) {
+        Object aggregated = ctx._aggregator.aggregateBatch(values, ctx._functionParameters);
+        baseRow.putValue(ctx._column, aggregated);
+        if (includeNullFields) {
+          baseRow.removeNullValueField(ctx._column);
+        }
+        values.clear();
+        values.add(aggregated);  // Continue with partial result
+      }
+    }
+  }
+
+  /**
+   * Aggregate batch values and write the result.
+   */
+  private void aggregateBatchAndWrite(GenericRow baseRow, List<List<Object>> batchValues,
+      List<AggregatorContext> aggregatorContextList, GenericRowFileWriter rollupFileWriter, boolean includeNullFields)
+      throws Exception {
+    for (int j = 0; j < aggregatorContextList.size(); j++) {
+      AggregatorContext ctx = aggregatorContextList.get(j);
+      List<Object> values = batchValues.get(j);
+      if (!values.isEmpty()) {
+        Object aggregated = ctx._aggregator.aggregateBatch(values, ctx._functionParameters);
+        baseRow.putValue(ctx._column, aggregated);
+        if (includeNullFields) {
+          baseRow.removeNullValueField(ctx._column);
+        }
+      }
+    }
+    rollupFileWriter.write(baseRow);
   }
 
   private static void aggregateWithNullFields(GenericRow aggregatedRow, GenericRow rowToAggregate,

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/reducer/RollupReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/reducer/RollupReducer.java
@@ -218,7 +218,14 @@ public class RollupReducer implements Reducer {
         }
 
         // Memory safety: flush partial result if batch gets too large
-        if (batchValues.get(0).size() >= _maxBatchSize) {
+        int currentBatchSize = 0;
+        for (int k = 0; k < batchValues.size(); k++) {
+          int size = batchValues.get(k).size();
+          if (size > currentBatchSize) {
+            currentBatchSize = size;
+          }
+        }
+        if (currentBatchSize >= _maxBatchSize) {
           flushBatchToBaseRow(baseRow, batchValues, aggregatorContextList, includeNullFields);
         }
       } else {

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/processing/aggregator/DistinctCountCPCSketchAggregatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/processing/aggregator/DistinctCountCPCSketchAggregatorTest.java
@@ -19,7 +19,9 @@
 package org.apache.pinot.core.segment.processing.aggregator;
 
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.apache.datasketches.cpc.CpcSketch;
 import org.apache.pinot.core.common.ObjectSerDeUtils;
@@ -68,5 +70,106 @@ public class DistinctCountCPCSketchAggregatorTest {
     CpcSketch resultSketch = ObjectSerDeUtils.DATA_SKETCH_CPC_SER_DE.deserialize(result);
     assertNotNull(resultSketch);
     assertEquals(resultSketch.getLgK(), 15);
+  }
+
+  @Test
+  public void testSupportsBatchAggregation() {
+    assertTrue(_cpcSketchAggregator.supportsBatchAggregation());
+  }
+
+  @Test
+  public void testAggregateBatchWithNull() {
+    Map<String, String> functionParameters = new HashMap<>();
+    assertNull(_cpcSketchAggregator.aggregateBatch(null, functionParameters));
+    assertNull(_cpcSketchAggregator.aggregateBatch(new ArrayList<>(), functionParameters));
+  }
+
+  @Test
+  public void testAggregateBatchWithSingleValue() {
+    CpcSketch sketch = createCpcSketch(12, 100);
+    byte[] value = ObjectSerDeUtils.DATA_SKETCH_CPC_SER_DE.serialize(sketch);
+    List<Object> values = new ArrayList<>();
+    values.add(value);
+    Map<String, String> functionParameters = new HashMap<>();
+
+    byte[] result = (byte[]) _cpcSketchAggregator.aggregateBatch(values, functionParameters);
+
+    assertNotNull(result);
+    CpcSketch resultSketch = ObjectSerDeUtils.DATA_SKETCH_CPC_SER_DE.deserialize(result);
+    assertEquals(resultSketch.getEstimate(), 100.0, 10.0);
+  }
+
+  @Test
+  public void testAggregateBatchWithMultipleValues() {
+    List<Object> values = new ArrayList<>();
+    int totalDistinct = 0;
+    for (int i = 0; i < 5; i++) {
+      CpcSketch sketch = createCpcSketchWithOffset(12, 100, i * 200);
+      values.add(ObjectSerDeUtils.DATA_SKETCH_CPC_SER_DE.serialize(sketch));
+      totalDistinct += 100;
+    }
+    Map<String, String> functionParameters = new HashMap<>();
+
+    byte[] result = (byte[]) _cpcSketchAggregator.aggregateBatch(values, functionParameters);
+
+    CpcSketch resultSketch = ObjectSerDeUtils.DATA_SKETCH_CPC_SER_DE.deserialize(result);
+    assertNotNull(resultSketch);
+    // CPC provides estimate, allow some error margin
+    assertEquals(resultSketch.getEstimate(), totalDistinct, totalDistinct * 0.1);
+  }
+
+  @Test
+  public void testAggregateBatchMatchesPairwise() {
+    List<Object> values = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      CpcSketch sketch = createCpcSketchWithOffset(12, 50, i * 100);
+      values.add(ObjectSerDeUtils.DATA_SKETCH_CPC_SER_DE.serialize(sketch));
+    }
+    Map<String, String> functionParameters = new HashMap<>();
+
+    // Batch aggregation
+    byte[] batchResult = (byte[]) _cpcSketchAggregator.aggregateBatch(values, functionParameters);
+
+    // Pairwise aggregation
+    Object pairwiseResult = values.get(0);
+    for (int i = 1; i < values.size(); i++) {
+      pairwiseResult = _cpcSketchAggregator.aggregate(pairwiseResult, values.get(i), functionParameters);
+    }
+
+    CpcSketch batchSketch = ObjectSerDeUtils.DATA_SKETCH_CPC_SER_DE.deserialize(batchResult);
+    CpcSketch pairwiseSketch = ObjectSerDeUtils.DATA_SKETCH_CPC_SER_DE.deserialize((byte[]) pairwiseResult);
+
+    // Results should be equivalent (CPC is probabilistic, allow small difference)
+    assertEquals(batchSketch.getEstimate(), pairwiseSketch.getEstimate(), pairwiseSketch.getEstimate() * 0.01);
+  }
+
+  @Test
+  public void testAggregateBatchWithLgK() {
+    List<Object> values = new ArrayList<>();
+    for (int i = 0; i < 5; i++) {
+      // Use lgK=14 for input sketches to match the expected output lgK
+      CpcSketch sketch = createCpcSketchWithOffset(14, 100, i * 200);
+      values.add(ObjectSerDeUtils.DATA_SKETCH_CPC_SER_DE.serialize(sketch));
+    }
+    Map<String, String> functionParameters = new HashMap<>();
+    functionParameters.put(Constants.CPCSKETCH_LGK_KEY, "14");
+
+    byte[] result = (byte[]) _cpcSketchAggregator.aggregateBatch(values, functionParameters);
+
+    CpcSketch resultSketch = ObjectSerDeUtils.DATA_SKETCH_CPC_SER_DE.deserialize(result);
+    assertNotNull(resultSketch);
+    assertEquals(resultSketch.getLgK(), 14);
+  }
+
+  private CpcSketch createCpcSketch(int lgK, int numDistinct) {
+    return createCpcSketchWithOffset(lgK, numDistinct, 0);
+  }
+
+  private CpcSketch createCpcSketchWithOffset(int lgK, int numDistinct, int offset) {
+    CpcSketch sketch = new CpcSketch(lgK);
+    for (int i = 0; i < numDistinct; i++) {
+      sketch.update(i + offset);
+    }
+    return sketch;
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/processing/aggregator/DistinctCountThetaSketchAggregatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/processing/aggregator/DistinctCountThetaSketchAggregatorTest.java
@@ -19,7 +19,9 @@
 package org.apache.pinot.core.segment.processing.aggregator;
 
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.apache.datasketches.theta.Sketch;
 import org.apache.datasketches.theta.UpdateSketch;
@@ -88,10 +90,107 @@ public class DistinctCountThetaSketchAggregatorTest {
     assertTrue(resultSketch.getRetainedEntries() < 64);
   }
 
+  @Test
+  public void testSupportsBatchAggregation() {
+    assertTrue(_thetaSketchAggregator.supportsBatchAggregation());
+  }
+
+  @Test
+  public void testAggregateBatchWithNull() {
+    Map<String, String> functionParameters = new HashMap<>();
+    assertNull(_thetaSketchAggregator.aggregateBatch(null, functionParameters));
+    assertNull(_thetaSketchAggregator.aggregateBatch(new ArrayList<>(), functionParameters));
+  }
+
+  @Test
+  public void testAggregateBatchWithSingleValue() {
+    Sketch sketch = createThetaSketch(64);
+    byte[] value = ObjectSerDeUtils.DATA_SKETCH_THETA_SER_DE.serialize(sketch);
+    List<Object> values = new ArrayList<>();
+    values.add(value);
+    Map<String, String> functionParameters = new HashMap<>();
+
+    byte[] result = (byte[]) _thetaSketchAggregator.aggregateBatch(values, functionParameters);
+
+    // Single value should be returned unchanged
+    assertNotNull(result);
+    Sketch resultSketch = ObjectSerDeUtils.DATA_SKETCH_THETA_SER_DE.deserialize(result);
+    assertEquals(resultSketch.getRetainedEntries(), 64);
+  }
+
+  @Test
+  public void testAggregateBatchWithMultipleValues() {
+    // Create 5 sketches with distinct values
+    List<Object> values = new ArrayList<>();
+    int totalDistinct = 0;
+    for (int i = 0; i < 5; i++) {
+      Sketch sketch = createThetaSketchWithOffset(64, i * 100);
+      values.add(ObjectSerDeUtils.DATA_SKETCH_THETA_SER_DE.serialize(sketch));
+      totalDistinct += 64;
+    }
+    Map<String, String> functionParameters = new HashMap<>();
+
+    byte[] result = (byte[]) _thetaSketchAggregator.aggregateBatch(values, functionParameters);
+
+    Sketch resultSketch = ObjectSerDeUtils.DATA_SKETCH_THETA_SER_DE.deserialize(result);
+    assertNotNull(resultSketch);
+    // All values are distinct, so union should have all entries
+    assertEquals(resultSketch.getRetainedEntries(), totalDistinct);
+  }
+
+  @Test
+  public void testAggregateBatchMatchesPairwise() {
+    // Verify batch aggregation produces same result as pairwise
+    List<Object> values = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      Sketch sketch = createThetaSketchWithOffset(32, i * 50);
+      values.add(ObjectSerDeUtils.DATA_SKETCH_THETA_SER_DE.serialize(sketch));
+    }
+    Map<String, String> functionParameters = new HashMap<>();
+
+    // Batch aggregation
+    byte[] batchResult = (byte[]) _thetaSketchAggregator.aggregateBatch(values, functionParameters);
+
+    // Pairwise aggregation
+    Object pairwiseResult = values.get(0);
+    for (int i = 1; i < values.size(); i++) {
+      pairwiseResult = _thetaSketchAggregator.aggregate(pairwiseResult, values.get(i), functionParameters);
+    }
+
+    Sketch batchSketch = ObjectSerDeUtils.DATA_SKETCH_THETA_SER_DE.deserialize(batchResult);
+    Sketch pairwiseSketch = ObjectSerDeUtils.DATA_SKETCH_THETA_SER_DE.deserialize((byte[]) pairwiseResult);
+
+    // Results should be equivalent
+    assertEquals(batchSketch.getRetainedEntries(), pairwiseSketch.getRetainedEntries());
+    assertEquals(batchSketch.getEstimate(), pairwiseSketch.getEstimate(), 0.001);
+  }
+
+  @Test
+  public void testAggregateBatchWithNominalEntries() {
+    List<Object> values = new ArrayList<>();
+    for (int i = 0; i < 5; i++) {
+      Sketch sketch = createThetaSketchWithOffset(64, i * 100);
+      values.add(ObjectSerDeUtils.DATA_SKETCH_THETA_SER_DE.serialize(sketch));
+    }
+    Map<String, String> functionParameters = new HashMap<>();
+    functionParameters.put(Constants.THETA_TUPLE_SKETCH_NOMINAL_ENTRIES, "128");
+
+    byte[] result = (byte[]) _thetaSketchAggregator.aggregateBatch(values, functionParameters);
+
+    Sketch resultSketch = ObjectSerDeUtils.DATA_SKETCH_THETA_SER_DE.deserialize(result);
+    assertNotNull(resultSketch);
+    // With nominal entries of 128, result should be capped
+    assertTrue(resultSketch.getRetainedEntries() <= 128);
+  }
+
   private Sketch createThetaSketch(int nominalEntries) {
+    return createThetaSketchWithOffset(nominalEntries, 0);
+  }
+
+  private Sketch createThetaSketchWithOffset(int nominalEntries, int offset) {
     UpdateSketch updateSketch = UpdateSketch.builder().setNominalEntries(nominalEntries).build();
     for (int i = 0; i < nominalEntries; i++) {
-      updateSketch.update(i);
+      updateSketch.update(i + offset);
     }
     return updateSketch.compact();
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/processing/aggregator/IntegerTupleSketchAggregatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/processing/aggregator/IntegerTupleSketchAggregatorTest.java
@@ -18,7 +18,9 @@
  */
 package org.apache.pinot.core.segment.processing.aggregator;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.apache.datasketches.tuple.CompactSketch;
 import org.apache.datasketches.tuple.Sketch;
@@ -31,6 +33,8 @@ import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 
 public class IntegerTupleSketchAggregatorTest {
@@ -74,11 +78,115 @@ public class IntegerTupleSketchAggregatorTest {
     assertEquals(resultSketch.getRetainedEntries(), 32);
   }
 
+  @Test
+  public void testSupportsBatchAggregation() {
+    assertTrue(_tupleSketchAggregator.supportsBatchAggregation());
+  }
+
+  @Test
+  public void testAggregateBatchWithNull() {
+    Map<String, String> functionParameters = new HashMap<>();
+    assertNull(_tupleSketchAggregator.aggregateBatch(null, functionParameters));
+    assertNull(_tupleSketchAggregator.aggregateBatch(new ArrayList<>(), functionParameters));
+  }
+
+  @Test
+  public void testAggregateBatchWithSingleValue() {
+    Sketch<IntegerSummary> sketch = createTupleSketch(64);
+    byte[] value = ObjectSerDeUtils.DATA_SKETCH_INT_TUPLE_SER_DE.serialize(sketch);
+    List<Object> values = new ArrayList<>();
+    values.add(value);
+    Map<String, String> functionParameters = new HashMap<>();
+
+    byte[] result = (byte[]) _tupleSketchAggregator.aggregateBatch(values, functionParameters);
+
+    assertNotNull(result);
+    Sketch<IntegerSummary> resultSketch = ObjectSerDeUtils.DATA_SKETCH_INT_TUPLE_SER_DE.deserialize(result);
+    assertEquals(resultSketch.getRetainedEntries(), 64);
+  }
+
+  @Test
+  public void testAggregateBatchWithMultipleValues() {
+    List<Object> values = new ArrayList<>();
+    int totalDistinct = 0;
+    for (int i = 0; i < 5; i++) {
+      Sketch<IntegerSummary> sketch = createTupleSketchWithOffset(64, i * 100);
+      values.add(ObjectSerDeUtils.DATA_SKETCH_INT_TUPLE_SER_DE.serialize(sketch));
+      totalDistinct += 64;
+    }
+    Map<String, String> functionParameters = new HashMap<>();
+
+    byte[] result = (byte[]) _tupleSketchAggregator.aggregateBatch(values, functionParameters);
+
+    Sketch<IntegerSummary> resultSketch = ObjectSerDeUtils.DATA_SKETCH_INT_TUPLE_SER_DE.deserialize(result);
+    assertNotNull(resultSketch);
+    assertEquals(resultSketch.getRetainedEntries(), totalDistinct);
+  }
+
+  @Test
+  public void testAggregateBatchMatchesPairwise() {
+    List<Object> values = new ArrayList<>();
+    for (int i = 0; i < 10; i++) {
+      Sketch<IntegerSummary> sketch = createTupleSketchWithOffset(32, i * 50);
+      values.add(ObjectSerDeUtils.DATA_SKETCH_INT_TUPLE_SER_DE.serialize(sketch));
+    }
+    Map<String, String> functionParameters = new HashMap<>();
+
+    // Batch aggregation
+    byte[] batchResult = (byte[]) _tupleSketchAggregator.aggregateBatch(values, functionParameters);
+
+    // Pairwise aggregation
+    Object pairwiseResult = values.get(0);
+    for (int i = 1; i < values.size(); i++) {
+      pairwiseResult = _tupleSketchAggregator.aggregate(pairwiseResult, values.get(i), functionParameters);
+    }
+
+    Sketch<IntegerSummary> batchSketch = ObjectSerDeUtils.DATA_SKETCH_INT_TUPLE_SER_DE.deserialize(batchResult);
+    Sketch<IntegerSummary> pairwiseSketch =
+        ObjectSerDeUtils.DATA_SKETCH_INT_TUPLE_SER_DE.deserialize((byte[]) pairwiseResult);
+
+    assertEquals(batchSketch.getRetainedEntries(), pairwiseSketch.getRetainedEntries());
+    assertEquals(batchSketch.getEstimate(), pairwiseSketch.getEstimate(), 0.001);
+  }
+
+  @Test
+  public void testAggregateBatchWithSumMode() {
+    // Test with Sum mode to verify summary values are aggregated correctly
+    IntegerTupleSketchAggregator sumAggregator = new IntegerTupleSketchAggregator(IntegerSummary.Mode.Sum);
+
+    List<Object> values = new ArrayList<>();
+    // Create 3 sketches with same keys but different summary values
+    for (int i = 0; i < 3; i++) {
+      Sketch<IntegerSummary> sketch = createTupleSketchWithSummaryValue(32, i + 1);
+      values.add(ObjectSerDeUtils.DATA_SKETCH_INT_TUPLE_SER_DE.serialize(sketch));
+    }
+    Map<String, String> functionParameters = new HashMap<>();
+
+    byte[] result = (byte[]) sumAggregator.aggregateBatch(values, functionParameters);
+
+    Sketch<IntegerSummary> resultSketch = ObjectSerDeUtils.DATA_SKETCH_INT_TUPLE_SER_DE.deserialize(result);
+    assertNotNull(resultSketch);
+    assertEquals(resultSketch.getRetainedEntries(), 32);
+  }
+
   private CompactSketch<IntegerSummary> createTupleSketch(int nominalEntries) {
+    return createTupleSketchWithOffset(nominalEntries, 0);
+  }
+
+  private CompactSketch<IntegerSummary> createTupleSketchWithOffset(int nominalEntries, int offset) {
     int lgK = (int) (Math.log(nominalEntries) / Math.log(2));
     IntegerSketch integerSketch = new IntegerSketch(lgK, IntegerSummary.Mode.Max);
     for (int i = 0; i < nominalEntries; i++) {
-      integerSketch.update(i, 1);
+      integerSketch.update(i + offset, 1);
+    }
+    return integerSketch.compact();
+  }
+
+  private CompactSketch<IntegerSummary> createTupleSketchWithSummaryValue(int nominalEntries, int summaryValue) {
+    int lgK = (int) (Math.log(nominalEntries) / Math.log(2));
+    IntegerSketch integerSketch = new IntegerSketch(lgK, IntegerSummary.Mode.Sum);
+    for (int i = 0; i < nominalEntries; i++) {
+      integerSketch.update(i, summaryValue);
     }
     return integerSketch.compact();
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/processing/framework/ReducerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/processing/framework/ReducerTest.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
@@ -31,6 +32,10 @@ import java.util.TreeMap;
 import java.util.TreeSet;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.datasketches.theta.Sketch;
+import org.apache.datasketches.theta.UpdateSketch;
+import org.apache.pinot.core.common.MinionConstants;
+import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.segment.processing.genericrow.GenericRowFileManager;
 import org.apache.pinot.core.segment.processing.genericrow.GenericRowFileReader;
 import org.apache.pinot.core.segment.processing.genericrow.GenericRowFileRecordReader;
@@ -569,5 +574,210 @@ public class ReducerTest {
       assertEquals(fieldToValueMap.get("d1"), dValues[expectedDIndex][0]);
       assertEquals(fieldToValueMap.get("d2"), dValues[expectedDIndex][1]);
     }
+  }
+
+  /**
+   * Test rollup with theta sketch metric to verify batch aggregation path.
+   * This test creates multiple rows per dimension key, each with a theta sketch,
+   * and verifies they are properly aggregated using batch aggregation.
+   */
+  @Test
+  public void testRollupWithThetaSketch()
+      throws Exception {
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build();
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .addSingleValueDimension("d", DataType.INT)
+        .addMetric("sketch", DataType.BYTES)
+        .build();
+    Pair<List<FieldSpec>, Integer> result = SegmentProcessorUtils.getFieldSpecs(schema, MergeType.ROLLUP, null);
+    GenericRowFileManager fileManager =
+        new GenericRowFileManager(FILE_MANAGER_OUTPUT_DIR, result.getLeft(), false, result.getRight());
+
+    GenericRowFileWriter fileWriter = fileManager.getFileWriter();
+    int numRecords = 100;
+    int numDimValues = 5;
+    // Track expected distinct values per dimension
+    Map<Integer, Set<Integer>> expectedDistincts = new TreeMap<>();
+    for (int i = 0; i < numDimValues; i++) {
+      expectedDistincts.put(i, new HashSet<>());
+    }
+
+    GenericRow row = new GenericRow();
+    for (int i = 0; i < numRecords; i++) {
+      row.clear();
+      int d = RANDOM.nextInt(numDimValues);
+      // Create a sketch with some random values
+      UpdateSketch updateSketch = UpdateSketch.builder().setNominalEntries(128).build();
+      int numValues = RANDOM.nextInt(10) + 1;
+      for (int j = 0; j < numValues; j++) {
+        int value = RANDOM.nextInt(1000);
+        updateSketch.update(value);
+        expectedDistincts.get(d).add(value);
+      }
+      byte[] sketchBytes = ObjectSerDeUtils.DATA_SKETCH_THETA_SER_DE.serialize(updateSketch.compact());
+
+      row.putValue("d", d);
+      row.putValue("sketch", sketchBytes);
+      fileWriter.write(row);
+    }
+    fileManager.closeFileWriter();
+
+    Map<String, AggregationFunctionType> aggregationTypes = new HashMap<>();
+    aggregationTypes.put("sketch", AggregationFunctionType.DISTINCTCOUNTTHETASKETCH);
+    SegmentProcessorConfig config = new SegmentProcessorConfig.Builder()
+        .setTableConfig(tableConfig)
+        .setSchema(schema)
+        .setMergeType(MergeType.ROLLUP)
+        .setAggregationTypes(aggregationTypes)
+        .build();
+
+    Reducer reducer = ReducerFactory.getReducer("0", fileManager, config, REDUCER_OUTPUT_DIR);
+    GenericRowFileManager reducedFileManager = reducer.reduce();
+    GenericRowFileReader fileReader = reducedFileManager.getFileReader();
+    assertEquals(fileReader.getNumRows(), numDimValues);
+
+    GenericRowFileRecordReader recordReader = fileReader.getRecordReader();
+    for (int i = 0; i < numDimValues; i++) {
+      row.clear();
+      recordReader.read(i, row);
+      Map<String, Object> fieldToValueMap = row.getFieldToValueMap();
+      assertEquals(fieldToValueMap.size(), 2);
+      int d = (int) fieldToValueMap.get("d");
+      byte[] sketchBytes = (byte[]) fieldToValueMap.get("sketch");
+      Sketch resultSketch = ObjectSerDeUtils.DATA_SKETCH_THETA_SER_DE.deserialize(sketchBytes);
+
+      // Verify the sketch estimate matches expected distinct count
+      int expectedDistinct = expectedDistincts.get(d).size();
+      // Allow 10% error for theta sketch estimation
+      assertEquals(resultSketch.getEstimate(), expectedDistinct, expectedDistinct * 0.1,
+          "Sketch estimate for dimension " + d + " should match expected distinct count");
+    }
+    reducedFileManager.cleanUp();
+  }
+
+  /**
+   * Test rollup with theta sketch using custom batch size configuration.
+   */
+  @Test
+  public void testRollupWithThetaSketchAndCustomBatchSize()
+      throws Exception {
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build();
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .addSingleValueDimension("d", DataType.INT)
+        .addMetric("sketch", DataType.BYTES)
+        .build();
+    Pair<List<FieldSpec>, Integer> result = SegmentProcessorUtils.getFieldSpecs(schema, MergeType.ROLLUP, null);
+    GenericRowFileManager fileManager =
+        new GenericRowFileManager(FILE_MANAGER_OUTPUT_DIR, result.getLeft(), false, result.getRight());
+
+    GenericRowFileWriter fileWriter = fileManager.getFileWriter();
+    // Create many rows with the same dimension to test batch size limit
+    int numRecords = 50;
+    Set<Integer> expectedDistincts = new HashSet<>();
+
+    GenericRow row = new GenericRow();
+    for (int i = 0; i < numRecords; i++) {
+      row.clear();
+      UpdateSketch updateSketch = UpdateSketch.builder().setNominalEntries(128).build();
+      int value = i;  // Each row has a unique value
+      updateSketch.update(value);
+      expectedDistincts.add(value);
+      byte[] sketchBytes = ObjectSerDeUtils.DATA_SKETCH_THETA_SER_DE.serialize(updateSketch.compact());
+
+      row.putValue("d", 0);  // All same dimension
+      row.putValue("sketch", sketchBytes);
+      fileWriter.write(row);
+    }
+    fileManager.closeFileWriter();
+
+    Map<String, AggregationFunctionType> aggregationTypes = new HashMap<>();
+    aggregationTypes.put("sketch", AggregationFunctionType.DISTINCTCOUNTTHETASKETCH);
+    // Use a small batch size to force multiple batch flushes
+    SegmentProcessorConfig config = new SegmentProcessorConfig.Builder()
+        .setTableConfig(tableConfig)
+        .setSchema(schema)
+        .setMergeType(MergeType.ROLLUP)
+        .setAggregationTypes(aggregationTypes)
+        .setReducerMaxBatchSize(10)  // Small batch size
+        .build();
+
+    Reducer reducer = ReducerFactory.getReducer("0", fileManager, config, REDUCER_OUTPUT_DIR);
+    GenericRowFileManager reducedFileManager = reducer.reduce();
+    GenericRowFileReader fileReader = reducedFileManager.getFileReader();
+    assertEquals(fileReader.getNumRows(), 1);  // All rows have same dimension
+
+    GenericRowFileRecordReader recordReader = fileReader.getRecordReader();
+    row.clear();
+    recordReader.read(0, row);
+    byte[] sketchBytes = (byte[]) row.getValue("sketch");
+    Sketch resultSketch = ObjectSerDeUtils.DATA_SKETCH_THETA_SER_DE.deserialize(sketchBytes);
+
+    // Even with small batch size, final result should have all distinct values
+    assertEquals(resultSketch.getEstimate(), expectedDistincts.size(), expectedDistincts.size() * 0.1);
+    reducedFileManager.cleanUp();
+  }
+
+  /**
+   * Test that SegmentProcessorConfig uses default reducerMaxBatchSize when not set.
+   */
+  @Test
+  public void testSegmentProcessorConfigDefaultBatchSize() {
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build();
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .addSingleValueDimension("d", DataType.INT).build();
+
+    SegmentProcessorConfig config = new SegmentProcessorConfig.Builder()
+        .setTableConfig(tableConfig)
+        .setSchema(schema)
+        .build();
+
+    assertEquals(config.getReducerMaxBatchSize(), MinionConstants.MergeTask.DEFAULT_REDUCER_MAX_BATCH_SIZE);
+  }
+
+  /**
+   * Test that SegmentProcessorConfig respects custom reducerMaxBatchSize.
+   */
+  @Test
+  public void testSegmentProcessorConfigCustomBatchSize() {
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build();
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .addSingleValueDimension("d", DataType.INT).build();
+
+    int customBatchSize = 500;
+    SegmentProcessorConfig config = new SegmentProcessorConfig.Builder()
+        .setTableConfig(tableConfig)
+        .setSchema(schema)
+        .setReducerMaxBatchSize(customBatchSize)
+        .build();
+
+    assertEquals(config.getReducerMaxBatchSize(), customBatchSize);
+  }
+
+  /**
+   * Test that invalid batch size (<=0) falls back to default.
+   */
+  @Test
+  public void testSegmentProcessorConfigInvalidBatchSize() {
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build();
+    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable")
+        .addSingleValueDimension("d", DataType.INT).build();
+
+    // Zero should fall back to default
+    SegmentProcessorConfig config = new SegmentProcessorConfig.Builder()
+        .setTableConfig(tableConfig)
+        .setSchema(schema)
+        .setReducerMaxBatchSize(0)
+        .build();
+
+    assertEquals(config.getReducerMaxBatchSize(), MinionConstants.MergeTask.DEFAULT_REDUCER_MAX_BATCH_SIZE);
+
+    // Negative should fall back to default
+    config = new SegmentProcessorConfig.Builder()
+        .setTableConfig(tableConfig)
+        .setSchema(schema)
+        .setReducerMaxBatchSize(-1)
+        .build();
+
+    assertEquals(config.getReducerMaxBatchSize(), MinionConstants.MergeTask.DEFAULT_REDUCER_MAX_BATCH_SIZE);
   }
 }

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/aggregation/BenchmarkSketchBatchAggregation.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/aggregation/BenchmarkSketchBatchAggregation.java
@@ -1,0 +1,189 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.perf.aggregation;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+import org.apache.datasketches.cpc.CpcSketch;
+import org.apache.datasketches.theta.UpdateSketch;
+import org.apache.datasketches.tuple.aninteger.IntegerSketch;
+import org.apache.datasketches.tuple.aninteger.IntegerSummary;
+import org.apache.pinot.core.common.ObjectSerDeUtils;
+import org.apache.pinot.core.segment.processing.aggregator.DistinctCountCPCSketchAggregator;
+import org.apache.pinot.core.segment.processing.aggregator.DistinctCountThetaSketchAggregator;
+import org.apache.pinot.core.segment.processing.aggregator.IntegerTupleSketchAggregator;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.infra.Blackhole;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+
+/**
+ * Benchmark comparing pairwise vs batch aggregation for sketch ValueAggregators.
+ *
+ * <p>Measures the performance improvement from batch aggregation which:
+ * <ul>
+ *   <li>Reduces serialization overhead from O(N-1) to O(1)</li>
+ *   <li>Uses zero-copy sketch wrapping via Memory.wrap()</li>
+ *   <li>Applies theta-based sorting for early termination (Theta/Tuple sketches)</li>
+ * </ul>
+ *
+ * <p>Run with: java -jar pinot-perf/target/benchmarks.jar BenchmarkSketchBatchAggregation
+ */
+@Fork(1)
+@BenchmarkMode(Mode.AverageTime)
+@Warmup(iterations = 3, time = 5, timeUnit = TimeUnit.SECONDS)
+@Measurement(iterations = 5, time = 10, timeUnit = TimeUnit.SECONDS)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+public class BenchmarkSketchBatchAggregation {
+
+  private static final int SKETCH_LG_K = 12;  // 4096 nominal entries
+  private static final int SKETCH_CARDINALITY = 1000;
+  private static final Map<String, String> EMPTY_PARAMS = Collections.emptyMap();
+
+  @Param({"10", "50", "100", "500"})
+  private int _numSketchesPerKey;
+
+  // Theta sketch data
+  private DistinctCountThetaSketchAggregator _thetaAggregator;
+  private List<Object> _thetaSketches;
+
+  // Tuple sketch data
+  private IntegerTupleSketchAggregator _tupleAggregator;
+  private List<Object> _tupleSketches;
+
+  // CPC sketch data
+  private DistinctCountCPCSketchAggregator _cpcAggregator;
+  private List<Object> _cpcSketches;
+
+  public static void main(String[] args)
+      throws RunnerException {
+    Options opt = new OptionsBuilder()
+        .include(BenchmarkSketchBatchAggregation.class.getSimpleName())
+        .build();
+    new Runner(opt).run();
+  }
+
+  @Setup(Level.Trial)
+  public void setUp() {
+    Random random = new Random(42);
+
+    // Initialize Theta sketch aggregator and data
+    _thetaAggregator = new DistinctCountThetaSketchAggregator();
+    _thetaSketches = new ArrayList<>(_numSketchesPerKey);
+    for (int i = 0; i < _numSketchesPerKey; i++) {
+      UpdateSketch sketch = UpdateSketch.builder().setNominalEntries(1 << SKETCH_LG_K).build();
+      int offset = random.nextInt(SKETCH_CARDINALITY * 10);
+      for (int j = 0; j < SKETCH_CARDINALITY; j++) {
+        sketch.update(offset + j);
+      }
+      _thetaSketches.add(ObjectSerDeUtils.DATA_SKETCH_THETA_SER_DE.serialize(sketch.compact()));
+    }
+
+    // Initialize Tuple sketch aggregator and data
+    _tupleAggregator = new IntegerTupleSketchAggregator(IntegerSummary.Mode.Sum);
+    _tupleSketches = new ArrayList<>(_numSketchesPerKey);
+    for (int i = 0; i < _numSketchesPerKey; i++) {
+      IntegerSketch sketch = new IntegerSketch(SKETCH_LG_K, IntegerSummary.Mode.Sum);
+      int offset = random.nextInt(SKETCH_CARDINALITY * 10);
+      for (int j = 0; j < SKETCH_CARDINALITY; j++) {
+        sketch.update(offset + j, 1);
+      }
+      _tupleSketches.add(ObjectSerDeUtils.DATA_SKETCH_INT_TUPLE_SER_DE.serialize(sketch.compact()));
+    }
+
+    // Initialize CPC sketch aggregator and data
+    _cpcAggregator = new DistinctCountCPCSketchAggregator();
+    _cpcSketches = new ArrayList<>(_numSketchesPerKey);
+    for (int i = 0; i < _numSketchesPerKey; i++) {
+      CpcSketch sketch = new CpcSketch(SKETCH_LG_K);
+      int offset = random.nextInt(SKETCH_CARDINALITY * 10);
+      for (int j = 0; j < SKETCH_CARDINALITY; j++) {
+        sketch.update(offset + j);
+      }
+      _cpcSketches.add(ObjectSerDeUtils.DATA_SKETCH_CPC_SER_DE.serialize(sketch));
+    }
+  }
+
+  // ==================== Theta Sketch Benchmarks ====================
+
+  @Benchmark
+  public void thetaPairwise(Blackhole bh) {
+    Object result = _thetaSketches.get(0);
+    for (int i = 1; i < _thetaSketches.size(); i++) {
+      result = _thetaAggregator.aggregate(result, _thetaSketches.get(i), EMPTY_PARAMS);
+    }
+    bh.consume(result);
+  }
+
+  @Benchmark
+  public void thetaBatch(Blackhole bh) {
+    bh.consume(_thetaAggregator.aggregateBatch(_thetaSketches, EMPTY_PARAMS));
+  }
+
+  // ==================== Tuple Sketch Benchmarks ====================
+
+  @Benchmark
+  public void tuplePairwise(Blackhole bh) {
+    Object result = _tupleSketches.get(0);
+    for (int i = 1; i < _tupleSketches.size(); i++) {
+      result = _tupleAggregator.aggregate(result, _tupleSketches.get(i), EMPTY_PARAMS);
+    }
+    bh.consume(result);
+  }
+
+  @Benchmark
+  public void tupleBatch(Blackhole bh) {
+    bh.consume(_tupleAggregator.aggregateBatch(_tupleSketches, EMPTY_PARAMS));
+  }
+
+  // ==================== CPC Sketch Benchmarks ====================
+
+  @Benchmark
+  public void cpcPairwise(Blackhole bh) {
+    Object result = _cpcSketches.get(0);
+    for (int i = 1; i < _cpcSketches.size(); i++) {
+      result = _cpcAggregator.aggregate(result, _cpcSketches.get(i), EMPTY_PARAMS);
+    }
+    bh.consume(result);
+  }
+
+  @Benchmark
+  public void cpcBatch(Blackhole bh) {
+    bh.consume(_cpcAggregator.aggregateBatch(_cpcSketches, EMPTY_PARAMS));
+  }
+}

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskExecutor.java
@@ -101,6 +101,12 @@ public class MergeRollupTaskExecutor extends BaseMultipleSegmentsConversionExecu
     // Segment config
     segmentProcessorConfigBuilder.setSegmentConfig(MergeTaskUtils.getSegmentConfig(configs));
 
+    // Reducer config
+    String reducerMaxBatchSizeStr = configs.get(MinionConstants.MergeTask.REDUCER_MAX_BATCH_SIZE_KEY);
+    if (reducerMaxBatchSizeStr != null) {
+      segmentProcessorConfigBuilder.setReducerMaxBatchSize(Integer.parseInt(reducerMaxBatchSizeStr));
+    }
+
     // Progress observer
     segmentProcessorConfigBuilder.setProgressObserver(p -> _eventObserver.notifyProgress(_pinotTaskConfig, p));
 

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskExecutor.java
@@ -104,7 +104,18 @@ public class MergeRollupTaskExecutor extends BaseMultipleSegmentsConversionExecu
     // Reducer config
     String reducerMaxBatchSizeStr = configs.get(MinionConstants.MergeTask.REDUCER_MAX_BATCH_SIZE_KEY);
     if (reducerMaxBatchSizeStr != null) {
-      segmentProcessorConfigBuilder.setReducerMaxBatchSize(Integer.parseInt(reducerMaxBatchSizeStr));
+      try {
+        int reducerMaxBatchSize = Integer.parseInt(reducerMaxBatchSizeStr);
+        if (reducerMaxBatchSize > 0) {
+          segmentProcessorConfigBuilder.setReducerMaxBatchSize(reducerMaxBatchSize);
+        } else {
+          LOGGER.warn("Invalid value for {}: {}. Expected a positive integer; using default reducer max batch size.",
+              MinionConstants.MergeTask.REDUCER_MAX_BATCH_SIZE_KEY, reducerMaxBatchSizeStr);
+        }
+      } catch (NumberFormatException e) {
+        LOGGER.warn("Failed to parse reducer max batch size for {}: '{}'. Using default reducer max batch size.",
+            MinionConstants.MergeTask.REDUCER_MAX_BATCH_SIZE_KEY, reducerMaxBatchSizeStr, e);
+      }
     }
 
     // Progress observer


### PR DESCRIPTION
 Reduces serialization overhead from O(N-1) to O(1) by merging all
 sketches for a key in a single operation using zero-copy Memory.wrap().

 Changes:
 - Add aggregateBatch() and supportsBatchAggregation() to ValueAggregator interface
 - Implement batch aggregation for DistinctCountThetaSketchAggregator, IntegerTupleSketchAggregator, and DistinctCountCPCSketchAggregator
 - Modify RollupReducer to use batch aggregation when supported
 - Add reducerMaxBatchSize config to SegmentProcessorConfig (default 1000)
 - Add JMH benchmarks comparing pairwise vs batch aggregation

 Batch aggregation optimizations:
 - Zero-copy sketch wrapping via Sketch.wrap(Memory.wrap(bytes))
 - Theta-based sorting for early termination (Theta/Tuple sketches)
 - Single final serialization instead of N-1 intermediate serializations

 Benchmark results (500 sketches per key):
 - Theta sketch: 189ms → 2ms (91x faster)
 - Tuple sketch: 133ms → 11ms (12x faster)
 - CPC sketch: 16ms → 4ms (4x faster)

Tag:
`performance`

`release-notes`:
- New configuration options
- Signature changes to public methods/interfaces
