### PR TITLE
[Timeseries-Storage] enable delta and deltaDelta encoding on raw column

### DIFF
--- a/pinot-core/src/test/java/org/apache/pinot/core/startree/v2/BaseStarTreeV2Test.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/startree/v2/BaseStarTreeV2Test.java
@@ -498,10 +498,10 @@ abstract class BaseStarTreeV2Test<R, A> {
     CompressionCodec[] compressionCodecs = CompressionCodec.values();
     CompressionCodec compressionCodec = compressionCodecs[RANDOM.nextInt(compressionCodecs.length)];
     // Generic byte compressors can be used to compress Star-tree aggregated values.
-    return isApplicableToStartreeIndex(compressionCodec) ? compressionCodec : null;
+    return isApplicableToStarTreeIndex(compressionCodec) ? compressionCodec : null;
   }
 
-  protected boolean isApplicableToStartreeIndex(CompressionCodec compressionCodec) {
+  protected boolean isApplicableToStarTreeIndex(CompressionCodec compressionCodec) {
     // Exclude sequence codecs (Delta, DeltaDelta) that require fixed numeric streams.
     return compressionCodec.isApplicableToRawIndex() && compressionCodec != CompressionCodec.DELTA
         && compressionCodec != CompressionCodec.DELTADELTA;

--- a/pinot-core/src/test/java/org/apache/pinot/core/startree/v2/BaseStarTreeV2Test.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/startree/v2/BaseStarTreeV2Test.java
@@ -497,7 +497,14 @@ abstract class BaseStarTreeV2Test<R, A> {
   CompressionCodec getCompressionCodec() {
     CompressionCodec[] compressionCodecs = CompressionCodec.values();
     CompressionCodec compressionCodec = compressionCodecs[RANDOM.nextInt(compressionCodecs.length)];
-    return compressionCodec.isApplicableToRawIndex() ? compressionCodec : null;
+    // Generic byte compressors can be used to compress Star-tree aggregated values.
+    return isApplicableToStartreeIndex(compressionCodec) ? compressionCodec : null;
+  }
+
+  protected boolean isApplicableToStartreeIndex(CompressionCodec compressionCodec) {
+    // Exclude sequence codecs (Delta, DeltaDelta) that require fixed numeric streams.
+    return compressionCodec.isApplicableToRawIndex() && compressionCodec != CompressionCodec.DELTA
+        && compressionCodec != CompressionCodec.DELTADELTA;
   }
 
   /**

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -1195,6 +1195,15 @@ public class TableConfigUtilsTest {
 
     try {
       FieldConfig fieldConfig =
+          new FieldConfig("intCol", FieldConfig.EncodingType.RAW, null, null, CompressionCodec.DELTADELTA, null, null);
+      tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
+      TableConfigUtils.validate(tableConfig, schema);
+    } catch (Exception e) {
+      fail("DELTADELTA codec should be valid for single-value INT columns", e);
+    }
+
+    try {
+      FieldConfig fieldConfig =
           new FieldConfig("myCol1", FieldConfig.EncodingType.DICTIONARY, FieldConfig.IndexType.FST, null, null);
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FieldConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FieldConfig.java
@@ -152,8 +152,9 @@ public class FieldConfig extends BaseJsonConfig {
     CLPV2_ZSTD(false, false),
     CLPV2_LZ4(false, false),
 
-    DELTA(false, false),
-    DELTADELTA(false, false);
+    // Dictionary-encoded forward index stores dictionary IDs; Gorilla are designed for raw numeric value streams
+    DELTA(true, false),
+    DELTADELTA(true, false);
 
     //@formatter:on
 


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Marking DELTA/DELTADELTA as raw\-index applicable enables their use in field validation and necessitates their exclusion from StarTree aggregated value compression tests\.

```mermaid
flowchart TD
  N0["Mark DELTA#47;DELTADELTA as raw#45;index applicable #40;F1#41;"]:::stModified
  N1["Validate DELTADELTA on single#45;value RAW column passes #40;F3#41;"]:::stModified
  N2["Exclude DELTA#47;DELTADELTA from StarTree test codec selection #40;F2#41;"]:::stModified
  N0 -->|"enables validation pass"| N1
  N0 -->|"requires test exclusion"| N2
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-spi/src/main/java/org/apache/pinot/spi/config/table/FieldConfig\.java — [before](https://github.com/apache/pinot/blob/337faadec0bd749f3c8f44cff857d5bf773fe66a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FieldConfig.java) · [after](https://github.com/apache/pinot/blob/040f667503a90ad148faccae9a84bc9d4c80be76/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FieldConfig.java)
- F2: pinot\-core/src/test/java/org/apache/pinot/core/startree/v2/BaseStarTreeV2Test\.java — [before](https://github.com/apache/pinot/blob/337faadec0bd749f3c8f44cff857d5bf773fe66a/pinot-core/src/test/java/org/apache/pinot/core/startree/v2/BaseStarTreeV2Test.java) · [after](https://github.com/apache/pinot/blob/040f667503a90ad148faccae9a84bc9d4c80be76/pinot-core/src/test/java/org/apache/pinot/core/startree/v2/BaseStarTreeV2Test.java)
- F3: pinot\-segment\-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest\.java — [before](https://github.com/apache/pinot/blob/337faadec0bd749f3c8f44cff857d5bf773fe66a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java) · [after](https://github.com/apache/pinot/blob/040f667503a90ad148faccae9a84bc9d4c80be76/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjMzN2ZhYWRlYzBiZDc0OWYzYzhmNDRjZmY4NTdkNWJmNzczZmU2NmEiLCJjb250ZXh0X2hhc2giOiIzZDI5YzNkZWI0NjQ3OTQ0YmMwNTYyYzRlZjg1ZmRkODM3ZjFjM2RhZmE2M2IzMzNlMzJlNzgxNzU2MGFhZmZiIiwiZ2VuZXJhdGVkX2F0IjoxNzg4OTk1Njk1LCJoZWFkX3NoYSI6IjA0MGY2Njc1MDNhOTBhZDE0OGZhY2NhZTlhODRiYzlkNGM4MGJlNzYiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiI4ZDczZTdjNjJkNzgyYmI5MzhlOWM3ODZjNzViMDE2NTgxYzBkZDI3IiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature b800fe14a26cf9fe35e38bb30424195131bc3906442a337e5e3d2f3f6ce0ce59 -->
<!-- pinot-pr-flow:end -->

`bugfix`: Enable DELTA/DELTADELTA compression codecs on raw forward-index columns.

This change fixes the invalid codec error in tableConfig and marks these codecs as raw-index applicable. 

