### PR TITLE
Validate gRPC broker connections on connect

### DIFF
--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/grpc/GrpcConnection.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/grpc/GrpcConnection.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -36,6 +37,7 @@ import org.apache.pinot.client.Connection;
 import org.apache.pinot.client.PinotClientException;
 import org.apache.pinot.client.ResultSetGroup;
 import org.apache.pinot.client.SimpleBrokerSelector;
+import org.apache.pinot.client.utils.ConnectionUtils;
 import org.apache.pinot.common.config.GrpcConfig;
 import org.apache.pinot.common.proto.Broker;
 import org.apache.pinot.common.utils.DataSchema;
@@ -51,10 +53,12 @@ import org.slf4j.LoggerFactory;
  */
 public class GrpcConnection implements AutoCloseable {
   public static final String FAIL_ON_EXCEPTIONS = "failOnExceptions";
+  static final String CONNECTION_VALIDATION_QUERY = "select 1;";
   private static final Logger LOGGER = LoggerFactory.getLogger(GrpcConnection.class);
 
   private final BrokerSelector _brokerSelector;
   private final boolean _failOnExceptions;
+  private final Map<String, String> _defaultMetadata;
   private final BrokerStreamingQueryClient _grpcQueryClient;
 
   public GrpcConnection(Properties properties, List<String> brokerList) {
@@ -63,13 +67,73 @@ public class GrpcConnection implements AutoCloseable {
   }
 
   public GrpcConnection(Properties properties, BrokerSelector brokerSelector) {
+    this(properties, brokerSelector, ConnectionUtils.getHeadersFromProperties(properties));
+  }
+
+  GrpcConnection(Properties properties, BrokerSelector brokerSelector, Map<String, String> defaultMetadata) {
+    this(properties, brokerSelector, createGrpcQueryClient(properties), defaultMetadata);
+  }
+
+  GrpcConnection(Properties properties, BrokerSelector brokerSelector, BrokerStreamingQueryClient grpcQueryClient) {
+    this(properties, brokerSelector, grpcQueryClient, ConnectionUtils.getHeadersFromProperties(properties));
+  }
+
+  GrpcConnection(Properties properties, BrokerSelector brokerSelector, BrokerStreamingQueryClient grpcQueryClient,
+      Map<String, String> defaultMetadata) {
     _brokerSelector = brokerSelector;
-    // Convert Properties properties to a Map
-    Map<String, Object> propertiesMap = new HashMap<>();
-    properties.forEach((key, value) -> propertiesMap.put(key.toString(), value));
-    _grpcQueryClient = new BrokerStreamingQueryClient(new GrpcConfig(new PinotConfiguration(propertiesMap)));
+    _grpcQueryClient = grpcQueryClient;
+    _defaultMetadata = Map.copyOf(defaultMetadata);
     // Default fail Pinot query if response contains any exception.
     _failOnExceptions = Boolean.parseBoolean(properties.getProperty(FAIL_ON_EXCEPTIONS, "TRUE"));
+    validateConnection();
+  }
+
+  private static BrokerStreamingQueryClient createGrpcQueryClient(Properties properties) {
+    Map<String, Object> propertiesMap = new HashMap<>();
+    properties.forEach((key, value) -> propertiesMap.put(key.toString(), value));
+    return new BrokerStreamingQueryClient(new GrpcConfig(new PinotConfiguration(propertiesMap)));
+  }
+
+  private void validateConnection() {
+    try {
+      BrokerResponse brokerResponse =
+          BrokerResponse.fromJson(getJsonResponse(CONNECTION_VALIDATION_QUERY, Collections.emptyMap()));
+      if (brokerResponse.hasExceptions()) {
+        throw new PinotClientException(
+            "Failed to establish gRPC broker connection: " + brokerResponse.getExceptions());
+      }
+    } catch (PinotClientException e) {
+      closeQuietly();
+      throw e;
+    } catch (Exception e) {
+      closeQuietly();
+      throw new PinotClientException("Failed to establish gRPC broker connection", e);
+    }
+  }
+
+  private void closeQuietly() {
+    try {
+      _grpcQueryClient.shutdown();
+    } catch (Exception e) {
+      LOGGER.warn("Failed to shut down gRPC query client after connection initialization failure", e);
+    }
+    try {
+      _brokerSelector.close();
+    } catch (Exception e) {
+      LOGGER.warn("Failed to close broker selector after connection initialization failure", e);
+    }
+  }
+
+  private Map<String, String> getRequestMetadata(Map<String, String> metadataMap) {
+    if (_defaultMetadata.isEmpty()) {
+      return metadataMap;
+    }
+    if (metadataMap.isEmpty()) {
+      return _defaultMetadata;
+    }
+    Map<String, String> requestMetadata = new HashMap<>(_defaultMetadata);
+    requestMetadata.putAll(metadataMap);
+    return requestMetadata;
   }
 
   /**
@@ -239,10 +303,11 @@ public class GrpcConnection implements AutoCloseable {
       throw new PinotClientException("Could not find broker to query " + ((tableNames == null) ? "with no tables"
           : "for table(s): " + Arrays.asList(tableNames)));
     }
+    Map<String, String> requestMetadata = getRequestMetadata(metadata);
     String brokerHost = brokerHostPort.split(":")[0];
     int brokerPort = Integer.parseInt(brokerHostPort.split(":")[1]);
     Broker.BrokerRequest brokerRequest =
-        Broker.BrokerRequest.newBuilder().setSql(query).putAllMetadata(metadata).build();
+        Broker.BrokerRequest.newBuilder().setSql(query).putAllMetadata(requestMetadata).build();
     return _grpcQueryClient.submit(brokerHost, brokerPort, brokerRequest);
   }
 

--- a/pinot-clients/pinot-java-client/src/test/java/org/apache/pinot/client/grpc/GrpcConnectionTest.java
+++ b/pinot-clients/pinot-java-client/src/test/java/org/apache/pinot/client/grpc/GrpcConnectionTest.java
@@ -1,0 +1,102 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.client.grpc;
+
+import com.google.protobuf.ByteString;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import org.apache.pinot.client.BrokerSelector;
+import org.apache.pinot.common.config.GrpcConfig;
+import org.apache.pinot.common.proto.Broker;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class GrpcConnectionTest {
+
+  @Test
+  public void testConnectionValidationQueryRunsOnConnectAndMergesDefaultMetadata() {
+    Properties properties = new Properties();
+    properties.setProperty("headers.Authorization", "Bearer token");
+    RecordingBrokerStreamingQueryClient grpcQueryClient = new RecordingBrokerStreamingQueryClient();
+
+    try (GrpcConnection connection =
+        new GrpcConnection(properties, new FixedBrokerSelector("localhost:8099"), grpcQueryClient)) {
+      Assert.assertEquals(grpcQueryClient.getSubmittedRequests().size(), 1);
+      Broker.BrokerRequest validationRequest = grpcQueryClient.getSubmittedRequests().get(0);
+      Assert.assertEquals(validationRequest.getSql(), GrpcConnection.CONNECTION_VALIDATION_QUERY);
+      Assert.assertEquals(validationRequest.getMetadataOrThrow("Authorization"), "Bearer token");
+
+      connection.executeWithIterator("SELECT * FROM testTable", Map.of("trace", "true"));
+
+      Assert.assertEquals(grpcQueryClient.getSubmittedRequests().size(), 2);
+      Broker.BrokerRequest queryRequest = grpcQueryClient.getSubmittedRequests().get(1);
+      Assert.assertEquals(queryRequest.getSql(), "SELECT * FROM testTable");
+      Assert.assertEquals(queryRequest.getMetadataOrThrow("Authorization"), "Bearer token");
+      Assert.assertEquals(queryRequest.getMetadataOrThrow("trace"), "true");
+    }
+  }
+
+  private static final class FixedBrokerSelector implements BrokerSelector {
+    private final String _broker;
+
+    private FixedBrokerSelector(String broker) {
+      _broker = broker;
+    }
+
+    @Override
+    public String selectBroker(String... tableNames) {
+      return _broker;
+    }
+
+    @Override
+    public List<String> getBrokers() {
+      return Collections.singletonList(_broker);
+    }
+
+    @Override
+    public void close() {
+    }
+  }
+
+  private static final class RecordingBrokerStreamingQueryClient extends GrpcConnection.BrokerStreamingQueryClient {
+    private final List<Broker.BrokerRequest> _submittedRequests = new ArrayList<>();
+
+    private RecordingBrokerStreamingQueryClient() {
+      super(new GrpcConfig(Collections.emptyMap()));
+    }
+
+    @Override
+    public Iterator<Broker.BrokerResponse> submit(String brokerHost, int brokerGrpcPort,
+        Broker.BrokerRequest brokerRequest) {
+      _submittedRequests.add(brokerRequest);
+      return Collections.singletonList(Broker.BrokerResponse.newBuilder()
+          .setPayload(ByteString.copyFromUtf8("{}"))
+          .build()).iterator();
+    }
+
+    private List<Broker.BrokerRequest> getSubmittedRequests() {
+      return _submittedRequests;
+    }
+  }
+}

--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/grpc/PinotGrpcConnection.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/grpc/PinotGrpcConnection.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import org.apache.pinot.client.SimpleBrokerSelector;
 import org.apache.pinot.client.base.AbstractBaseConnection;
 import org.apache.pinot.client.controller.PinotControllerTransport;
 import org.apache.pinot.client.controller.PinotControllerTransportFactory;
@@ -72,7 +73,6 @@ public class PinotGrpcConnection extends AbstractBaseConnection {
     } else {
       brokers = getBrokerGrpcList(controllerURL, tenant);
     }
-    _session = new GrpcConnection(properties, brokers);
 
     for (String possibleQueryOption : POSSIBLE_QUERY_OPTIONS) {
       Object property = properties.getProperty(possibleQueryOption);
@@ -90,6 +90,7 @@ public class PinotGrpcConnection extends AbstractBaseConnection {
       }
     }
     DriverUtils.handleAuth(properties, _metadataMap);
+    _session = new GrpcConnection(properties, new SimpleBrokerSelector(brokers), _metadataMap);
   }
 
   public GrpcConnection getSession() {


### PR DESCRIPTION
## Summary
- validate gRPC broker connections by issuing `select 1;` during `GrpcConnection` initialization
- merge default headers into gRPC request metadata and build JDBC gRPC metadata before session creation
- add a unit test covering the connect-time validation query and metadata merge

## Testing
- `gtimeout 600 ./mvnw -pl pinot-clients/pinot-java-client,pinot-clients/pinot-jdbc-client -am test -Dtest=GrpcConnectionTest -Dsurefire.failIfNoSpecifiedTests=false`