### PR TITLE
Fix Flink connector Kafka test dependencies

### DIFF
--- a/pinot-connectors/pinot-flink-connector/pom.xml
+++ b/pinot-connectors/pinot-flink-connector/pom.xml
@@ -60,6 +60,41 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-kafka-3.0</artifactId>
+      <type>test-jar</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka_${scala.compat.version}</artifactId>
+      <classifier>test</classifier>
+      <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-clients</artifactId>
+      <classifier>test</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.kafka</groupId>
+      <artifactId>kafka-server-common</artifactId>
+      <classifier>test</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.jupiter</groupId>
+      <artifactId>junit-jupiter-api</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.testng</groupId>
       <artifactId>testng</artifactId>
       <scope>test</scope>


### PR DESCRIPTION
## Summary
Follow up to fix test failure for https://github.com/apache/pinot/pull/17790
- add the Kafka embedded-cluster test jar to the Flink connector test classpath
- add the Kafka test classifier artifacts required by `EmbeddedKafkaCluster`
- fix `PinotSinkUpsertTableIntegrationTest` failing with `NoClassDefFoundError` for `EmbeddedKafkaCluster`

## Testing
- `./mvnw -pl pinot-connectors/pinot-flink-connector -Dtest=PinotSinkUpsertTableIntegrationTest -Dsurefire.failIfNoSpecifiedTests=false test`