### PR TITLE
Improve integration CI diagnostics for surefire fork startup failures

### DIFF
--- a/.github/workflows/scripts/pr-tests/.pinot_tests_integration.sh
+++ b/.github/workflows/scripts/pr-tests/.pinot_tests_integration.sh
@@ -25,13 +25,50 @@ java -version
 ifconfig
 netstat -i
 
+print_surefire_dumps() {
+  local reports_dir="target/surefire-reports"
+  local dump_files
+
+  if [ ! -d "${reports_dir}" ]; then
+    echo "Surefire reports directory not found: ${reports_dir}"
+    return
+  fi
+
+  dump_files="$(find "${reports_dir}" -maxdepth 1 -type f \
+    \( -name "*.dump" -o -name "*.dumpstream" -o -name "*jvmRun*" \) | sort)"
+  if [ -z "${dump_files}" ]; then
+    echo "No Surefire dump files found under ${reports_dir}"
+    return
+  fi
+
+  echo "Printing Surefire dump files from ${reports_dir}"
+  while IFS= read -r dump_file; do
+    [ -z "${dump_file}" ] && continue
+    echo "===== BEGIN ${dump_file} ====="
+    cat "${dump_file}"
+    echo "===== END ${dump_file} ====="
+  done <<< "${dump_files}"
+}
+
 # Integration Tests
 cd pinot-integration-tests || exit 1
 if [ "$RUN_TEST_SET" == "1" ]; then
   mvn test \
-      -P github-actions,codecoverage,integration-tests-set-1 && exit 0 || exit 1
+      -P github-actions,codecoverage,integration-tests-set-1 || {
+    print_surefire_dumps
+    exit 1
+  }
+  exit 0
 fi
 if [ "$RUN_TEST_SET" == "2" ]; then
   mvn test \
-      -P github-actions,codecoverage,integration-tests-set-2 && exit 0 || exit 1
+      -DargLine="-Xms1g -Xmx2g -Dlog4j2.configurationFile=log4j2.xml" \
+      -P github-actions,codecoverage,integration-tests-set-2 || {
+    print_surefire_dumps
+    exit 1
+  }
+  exit 0
 fi
+
+echo "Unsupported RUN_TEST_SET value: ${RUN_TEST_SET}"
+exit 1


### PR DESCRIPTION
## What
This updates the integration test runner script used in GitHub Actions to make surefire fork startup failures easier to diagnose and reduce fork startup memory pressure for set 2.

### Changes
- Add `print_surefire_dumps()` in `.github/workflows/scripts/pr-tests/.pinot_tests_integration.sh`
- On integration-test failure, print surefire dump artifacts from `target/surefire-reports` (`*.dump`, `*.dumpstream`, `*jvmRun*`)
- For `RUN_TEST_SET=2`, pass `-DargLine="-Xms1g -Xmx2g -Dlog4j2.configurationFile=log4j2.xml"` to lower fork JVM heap from default 4g/4g

## Why
We saw CI fail with:
- `ExecutionException Error occurred in starting fork`
- `SurefireBooterForkException`

The dump files are the primary source of root-cause details for this class of error. Lowering surefire fork heap for set 2 should also reduce startup failures due to memory pressure on GitHub runners.

## Validation
- `bash -n .github/workflows/scripts/pr-tests/.pinot_tests_integration.sh`
