### PR TITLE
Add createContext(queryOptions) to ForwardIndexReader 

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/common/DataFetcher.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/DataFetcher.java
@@ -325,10 +325,7 @@ public class DataFetcher implements AutoCloseable {
 
     private ForwardIndexReaderContext getReaderContext() {
       if (!_readerContextCreated) {
-        _readerContext = _reader.createContext();
-        if (_readerContext != null) {
-          _readerContext.applyQueryOptions(_queryOptions);
-        }
+        _readerContext = _reader.createContext(_queryOptions);
         _readerContextCreated = true;
       }
       return _readerContext;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/MVScanDocIdIterator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/MVScanDocIdIterator.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.operator.dociditerators;
 
+import java.util.Map;
 import java.util.OptionalInt;
 import org.apache.pinot.core.operator.filter.predicate.PredicateEvaluator;
 import org.apache.pinot.segment.spi.Constants;
@@ -47,10 +48,11 @@ public final class MVScanDocIdIterator implements ScanBasedDocIdIterator {
   private int _nextDocId = 0;
   private long _numEntriesScanned = 0L;
 
-  public MVScanDocIdIterator(PredicateEvaluator predicateEvaluator, DataSource dataSource, int numDocs) {
+  public MVScanDocIdIterator(PredicateEvaluator predicateEvaluator, DataSource dataSource, int numDocs,
+      Map<String, String> queryOptions) {
     _predicateEvaluator = predicateEvaluator;
     _reader = dataSource.getForwardIndex();
-    _readerContext = _reader.createContext();
+    _readerContext = _reader.createContext(queryOptions);
     _numDocs = numDocs;
     _maxNumValuesPerMVEntry = dataSource.getDataSourceMetadata().getMaxNumValuesPerMVEntry();
     _valueMatcher = getValueMatcher();

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/SVScanDocIdIterator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/SVScanDocIdIterator.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.operator.dociditerators;
 
+import java.util.Map;
 import java.util.OptionalInt;
 import org.apache.pinot.core.common.BlockDocIdIterator;
 import org.apache.pinot.core.operator.filter.predicate.PredicateEvaluator;
@@ -49,11 +50,12 @@ public final class SVScanDocIdIterator implements ScanBasedDocIdIterator {
   private int _nextDocId = 0;
   private long _numEntriesScanned = 0L;
 
-  public SVScanDocIdIterator(PredicateEvaluator predicateEvaluator, DataSource dataSource, int numDocs, int batchSize) {
+  public SVScanDocIdIterator(PredicateEvaluator predicateEvaluator, DataSource dataSource, int numDocs, int batchSize,
+      Map<String, String> queryOptions) {
     _batch = new int[batchSize];
     _predicateEvaluator = predicateEvaluator;
     _reader = dataSource.getForwardIndex();
-    _readerContext = _reader.createContext();
+    _readerContext = _reader.createContext(queryOptions);
     _numDocs = numDocs;
     _valueMatcher = getValueMatcher();
     _cardinality = dataSource.getDataSourceMetadata().getCardinality();

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/MVScanDocIdSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/MVScanDocIdSet.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.operator.docidsets;
 
+import java.util.Map;
 import org.apache.pinot.core.common.BlockDocIdSet;
 import org.apache.pinot.core.operator.dociditerators.MVScanDocIdIterator;
 import org.apache.pinot.core.operator.filter.predicate.PredicateEvaluator;
@@ -27,8 +28,9 @@ import org.apache.pinot.segment.spi.datasource.DataSource;
 public final class MVScanDocIdSet implements BlockDocIdSet {
   private final MVScanDocIdIterator _docIdIterator;
 
-  public MVScanDocIdSet(PredicateEvaluator predicateEvaluator, DataSource dataSource, int numDocs) {
-    _docIdIterator = new MVScanDocIdIterator(predicateEvaluator, dataSource, numDocs);
+  public MVScanDocIdSet(PredicateEvaluator predicateEvaluator, DataSource dataSource, int numDocs,
+      Map<String, String> queryOptions) {
+    _docIdIterator = new MVScanDocIdIterator(predicateEvaluator, dataSource, numDocs, queryOptions);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/SVScanDocIdSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/SVScanDocIdSet.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.operator.docidsets;
 
+import java.util.Map;
 import org.apache.pinot.core.common.BlockDocIdSet;
 import org.apache.pinot.core.operator.dociditerators.SVScanDocIdIterator;
 import org.apache.pinot.core.operator.filter.predicate.PredicateEvaluator;
@@ -27,8 +28,9 @@ import org.apache.pinot.segment.spi.datasource.DataSource;
 public final class SVScanDocIdSet implements BlockDocIdSet {
   private final SVScanDocIdIterator _docIdIterator;
 
-  public SVScanDocIdSet(PredicateEvaluator predicateEvaluator, DataSource dataSource, int numDocs, int batchSize) {
-    _docIdIterator = new SVScanDocIdIterator(predicateEvaluator, dataSource, numDocs, batchSize);
+  public SVScanDocIdSet(PredicateEvaluator predicateEvaluator, DataSource dataSource, int numDocs, int batchSize,
+      Map<String, String> queryOptions) {
+    _docIdIterator = new SVScanDocIdIterator(predicateEvaluator, dataSource, numDocs, batchSize, queryOptions);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/ScanBasedFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/ScanBasedFilterOperator.java
@@ -59,9 +59,10 @@ public class ScanBasedFilterOperator extends BaseColumnFilterOperator {
   protected BlockDocIdSet getNextBlockWithoutNullHandling() {
     DataSourceMetadata dataSourceMetadata = _dataSource.getDataSourceMetadata();
     if (dataSourceMetadata.isSingleValue()) {
-      return new SVScanDocIdSet(_predicateEvaluator, _dataSource, _numDocs, _batchSize);
+      return new SVScanDocIdSet(_predicateEvaluator, _dataSource, _numDocs, _batchSize,
+          _queryContext.getQueryOptions());
     } else {
-      return new MVScanDocIdSet(_predicateEvaluator, _dataSource, _numDocs);
+      return new MVScanDocIdSet(_predicateEvaluator, _dataSource, _numDocs, _queryContext.getQueryOptions());
     }
   }
 

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/ForwardIndexReader.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/ForwardIndexReader.java
@@ -93,6 +93,15 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
   }
 
   /**
+   * Creates a new {@link ForwardIndexReaderContext} with query-level options so that reader implementations can
+   * adjust per-query behavior (e.g., bypassing caches). Falls back to {@link #createContext()} by default.
+   */
+  @Nullable
+  default T createContext(Map<String, String> queryOptions) {
+    return createContext();
+  }
+
+  /**
    * DICTIONARY-ENCODED INDEX APIs
    */
 

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/ForwardIndexReaderContext.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/ForwardIndexReaderContext.java
@@ -18,8 +18,6 @@
  */
 package org.apache.pinot.segment.spi.index.reader;
 
-import java.util.Map;
-
 
 /**
  * Interface for the context of the forward index reader.
@@ -28,13 +26,6 @@ import java.util.Map;
  * inside the context in order to accelerate the following reads.
  */
 public interface ForwardIndexReaderContext extends AutoCloseable {
-
-  /**
-   * Applies query-level options to this context so that reader implementations can adjust behavior per-query
-   * (e.g., bypassing caches). The default implementation is a no-op for backward compatibility.
-   */
-  default void applyQueryOptions(Map<String, String> queryOptions) {
-  }
 
   @Override
   void close();


### PR DESCRIPTION
Adds an overloaded `createContext(Map<String, String> queryOptions)` (default method to ForwardIndexReader that falls back to createContext()). This allows reader implementations to adjust context behavior based on query-level options (e.g., bypassing caches). Query options are now propagated through DataFetcher and ScanBasedFilterOperator to the query-path call sites of createContext.