### PR TITLE
[fs] Optimize cloud file listing with per-page filtering and early termination in PinotFS

### DIFF
--- a/pinot-plugins/pinot-file-system/pinot-adls/src/main/java/org/apache/pinot/plugin/filesystem/ADLSGen2PinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-adls/src/main/java/org/apache/pinot/plugin/filesystem/ADLSGen2PinotFS.java
@@ -480,6 +480,10 @@ public class ADLSGen2PinotFS extends BasePinotFS {
   public List<FileMetadata> listFilesWithMetadata(final URI fileUri, final boolean recursive,
       final Predicate<String> pathFilter, final int maxResults)
       throws IOException {
+    if (maxResults <= 0) {
+      LOGGER.warn("listFilesWithMetadata called with maxResults={}, returning empty list", maxResults);
+      return new ArrayList<>();
+    }
     LOGGER.debug("listFilesWithMetadata (paginated) is called with fileUri='{}', recursive='{}', maxResults={}",
         fileUri, recursive, maxResults);
     final List<FileMetadata> result = new ArrayList<>();

--- a/pinot-plugins/pinot-file-system/pinot-adls/src/test/java/org/apache/pinot/plugin/filesystem/test/ADLSGen2PinotFSPaginatedListTest.java
+++ b/pinot-plugins/pinot-file-system/pinot-adls/src/test/java/org/apache/pinot/plugin/filesystem/test/ADLSGen2PinotFSPaginatedListTest.java
@@ -233,6 +233,24 @@ public class ADLSGen2PinotFSPaginatedListTest {
   }
 
   @Test
+  public void testMaxResultsZeroReturnsEmpty() throws IOException {
+    final List<FileMetadata> result = _adlsPinotFS.listFilesWithMetadata(
+        URI.create("abfss://container@account.dfs.core.windows.net/data/"),
+        true, ACCEPT_ALL, 0);
+
+    assertEquals(result.size(), 0);
+  }
+
+  @Test
+  public void testMaxResultsNegativeReturnsEmpty() throws IOException {
+    final List<FileMetadata> result = _adlsPinotFS.listFilesWithMetadata(
+        URI.create("abfss://container@account.dfs.core.windows.net/data/"),
+        true, ACCEPT_ALL, -3);
+
+    assertEquals(result.size(), 0);
+  }
+
+  @Test
   public void testEarlyTerminationWithFilterAndDirectories() throws IOException {
     // Mix of dirs, matching files, and non-matching files; maxResults=2
     setupIterator(

--- a/pinot-plugins/pinot-file-system/pinot-gcs/src/main/java/org/apache/pinot/plugin/filesystem/GcsPinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-gcs/src/main/java/org/apache/pinot/plugin/filesystem/GcsPinotFS.java
@@ -263,6 +263,10 @@ public class GcsPinotFS extends BasePinotFS {
   public List<FileMetadata> listFilesWithMetadata(final URI fileUri, final boolean recursive,
       final Predicate<String> pathFilter, final int maxResults)
       throws IOException {
+    if (maxResults <= 0) {
+      LOGGER.warn("listFilesWithMetadata called with maxResults={}, returning empty list", maxResults);
+      return new ArrayList<>();
+    }
     final List<FileMetadata> result = new ArrayList<>();
     final GcsUri gcsFileUri = new GcsUri(fileUri);
     final String prefix = gcsFileUri.getPrefix();

--- a/pinot-plugins/pinot-file-system/pinot-gcs/src/test/java/org/apache/pinot/plugin/filesystem/GcsPinotFSPaginatedListTest.java
+++ b/pinot-plugins/pinot-file-system/pinot-gcs/src/test/java/org/apache/pinot/plugin/filesystem/GcsPinotFSPaginatedListTest.java
@@ -220,6 +220,24 @@ public class GcsPinotFSPaginatedListTest {
     assertEquals(result.size(), 0);
   }
 
+  @Test
+  public void testMaxResultsZeroReturnsEmpty() throws IOException {
+    final List<FileMetadata> result = _gcsPinotFS.listFilesWithMetadata(
+        URI.create("gs://bucket/data/"), true, ACCEPT_ALL, 0);
+
+    assertEquals(result.size(), 0);
+    verify(_mockStorage, never()).list(anyString(), (Storage.BlobListOption[]) any());
+  }
+
+  @Test
+  public void testMaxResultsNegativeReturnsEmpty() throws IOException {
+    final List<FileMetadata> result = _gcsPinotFS.listFilesWithMetadata(
+        URI.create("gs://bucket/data/"), true, ACCEPT_ALL, -1);
+
+    assertEquals(result.size(), 0);
+    verify(_mockStorage, never()).list(anyString(), (Storage.BlobListOption[]) any());
+  }
+
   @SuppressWarnings("unchecked")
   @Test
   public void testFileMetadataAttributes() throws IOException {

--- a/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3PinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3PinotFS.java
@@ -725,6 +725,10 @@ public class S3PinotFS extends BasePinotFS {
   public List<FileMetadata> listFilesWithMetadata(final URI fileUri, final boolean recursive,
       final Predicate<String> pathFilter, final int maxResults)
       throws IOException {
+    if (maxResults <= 0) {
+      LOGGER.warn("listFilesWithMetadata called with maxResults={}, returning empty list", maxResults);
+      return new ArrayList<>();
+    }
     final List<FileMetadata> result = new ArrayList<>();
     final String scheme = fileUri.getScheme();
     Preconditions.checkArgument(scheme.equals(S3_SCHEME) || scheme.equals(S3A_SCHEME));

--- a/pinot-plugins/pinot-file-system/pinot-s3/src/test/java/org/apache/pinot/plugin/filesystem/S3PinotFSPaginatedListTest.java
+++ b/pinot-plugins/pinot-file-system/pinot-s3/src/test/java/org/apache/pinot/plugin/filesystem/S3PinotFSPaginatedListTest.java
@@ -323,6 +323,24 @@ public class S3PinotFSPaginatedListTest {
   }
 
   @Test
+  public void testMaxResultsZeroReturnsEmpty() throws IOException {
+    final List<FileMetadata> result = _s3PinotFS.listFilesWithMetadata(
+        URI.create("s3://bucket/data/"), true, ACCEPT_ALL, 0);
+
+    assertEquals(result.size(), 0);
+    verify(_mockS3Client, times(0)).listObjectsV2(any(ListObjectsV2Request.class));
+  }
+
+  @Test
+  public void testMaxResultsNegativeReturnsEmpty() throws IOException {
+    final List<FileMetadata> result = _s3PinotFS.listFilesWithMetadata(
+        URI.create("s3://bucket/data/"), true, ACCEPT_ALL, -5);
+
+    assertEquals(result.size(), 0);
+    verify(_mockS3Client, times(0)).listObjectsV2(any(ListObjectsV2Request.class));
+  }
+
+  @Test
   public void testPrefixSentToS3() throws IOException {
     when(_mockS3Client.listObjectsV2(any(ListObjectsV2Request.class)))
         .thenReturn(page(Collections.emptyList(), false, null));

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/NoClosePinotFS.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/NoClosePinotFS.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.util.List;
+import java.util.function.Predicate;
 import org.apache.pinot.spi.env.PinotConfiguration;
 
 
@@ -96,6 +97,13 @@ public class NoClosePinotFS implements PinotFS {
   public List<FileMetadata> listFilesWithMetadata(URI fileUri, boolean recursive)
       throws IOException {
     return _delegate.listFilesWithMetadata(fileUri, recursive);
+  }
+
+  @Override
+  public List<FileMetadata> listFilesWithMetadata(URI fileUri, boolean recursive,
+      Predicate<String> pathFilter, int maxResults)
+      throws IOException {
+    return _delegate.listFilesWithMetadata(fileUri, recursive, pathFilter, maxResults);
   }
 
   @Override

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/PinotFS.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/filesystem/PinotFS.java
@@ -197,6 +197,9 @@ public interface PinotFS extends Closeable, Serializable {
   default List<FileMetadata> listFilesWithMetadata(URI fileUri, boolean recursive,
       Predicate<String> pathFilter, int maxResults)
       throws IOException {
+    if (maxResults <= 0) {
+      return new ArrayList<>();
+    }
     final List<FileMetadata> all = listFilesWithMetadata(fileUri, recursive);
     final List<FileMetadata> result = new ArrayList<>();
     for (final FileMetadata fm : all) {

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/filesystem/PinotFSPaginatedListTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/filesystem/PinotFSPaginatedListTest.java
@@ -1,0 +1,129 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.filesystem;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.List;
+import java.util.function.Predicate;
+import org.testng.annotations.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+
+/**
+ * Tests for the 4-arg listFilesWithMetadata: default method guard clause and NoClosePinotFS delegation.
+ */
+public class PinotFSPaginatedListTest {
+
+  private static final URI TEST_URI = URI.create("s3://bucket/data/");
+  private static final Predicate<String> ACCEPT_ALL = path -> true;
+
+  // --- PinotFS default method: maxResults <= 0 guard ---
+
+  @Test
+  public void testDefaultMethodMaxResultsZeroReturnsEmpty() throws IOException {
+    final PinotFS mockFS = mock(PinotFS.class);
+    when(mockFS.listFilesWithMetadata(any(URI.class), anyBoolean(), any(), anyInt()))
+        .thenCallRealMethod();
+
+    final List<FileMetadata> result = mockFS.listFilesWithMetadata(TEST_URI, true, ACCEPT_ALL, 0);
+
+    assertEquals(result.size(), 0);
+    // 2-arg method should never be called when maxResults <= 0
+    verify(mockFS, never()).listFilesWithMetadata(any(URI.class), anyBoolean());
+  }
+
+  @Test
+  public void testDefaultMethodMaxResultsNegativeReturnsEmpty() throws IOException {
+    final PinotFS mockFS = mock(PinotFS.class);
+    when(mockFS.listFilesWithMetadata(any(URI.class), anyBoolean(), any(), anyInt()))
+        .thenCallRealMethod();
+
+    final List<FileMetadata> result = mockFS.listFilesWithMetadata(TEST_URI, true, ACCEPT_ALL, -10);
+
+    assertEquals(result.size(), 0);
+    verify(mockFS, never()).listFilesWithMetadata(any(URI.class), anyBoolean());
+  }
+
+  @Test
+  public void testDefaultMethodPositiveMaxResultsDelegatesToTwoArg() throws IOException {
+    final PinotFS mockFS = mock(PinotFS.class);
+    when(mockFS.listFilesWithMetadata(any(URI.class), anyBoolean(), any(), anyInt()))
+        .thenCallRealMethod();
+    when(mockFS.listFilesWithMetadata(any(URI.class), anyBoolean()))
+        .thenReturn(Arrays.asList(
+            new FileMetadata.Builder().setFilePath("s3://bucket/data/f1.parquet")
+                .setLength(100).setIsDirectory(false).build(),
+            new FileMetadata.Builder().setFilePath("s3://bucket/data/f2.parquet")
+                .setLength(200).setIsDirectory(false).build()
+        ));
+
+    final List<FileMetadata> result = mockFS.listFilesWithMetadata(TEST_URI, true, ACCEPT_ALL, 10);
+
+    assertEquals(result.size(), 2);
+    verify(mockFS).listFilesWithMetadata(any(URI.class), anyBoolean());
+  }
+
+  // --- NoClosePinotFS delegation ---
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void testNoClosePinotFSDelegatesToUnderlyingFS() throws IOException {
+    final PinotFS mockDelegate = mock(PinotFS.class);
+    final List<FileMetadata> expected = Arrays.asList(
+        new FileMetadata.Builder().setFilePath("s3://bucket/data/f1.parquet")
+            .setLength(100).setIsDirectory(false).build()
+    );
+    when(mockDelegate.listFilesWithMetadata(any(URI.class), anyBoolean(), any(), anyInt()))
+        .thenReturn(expected);
+
+    final NoClosePinotFS noCloseFS = new NoClosePinotFS(mockDelegate);
+    final Predicate<String> filter = path -> path.endsWith(".parquet");
+    final List<FileMetadata> result = noCloseFS.listFilesWithMetadata(TEST_URI, true, filter, 5);
+
+    assertEquals(result, expected);
+    verify(mockDelegate).listFilesWithMetadata(TEST_URI, true, filter, 5);
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void testNoClosePinotFSPassesExactArguments() throws IOException {
+    final PinotFS mockDelegate = mock(PinotFS.class);
+    when(mockDelegate.listFilesWithMetadata(any(URI.class), anyBoolean(), any(), anyInt()))
+        .thenReturn(Arrays.asList());
+
+    final NoClosePinotFS noCloseFS = new NoClosePinotFS(mockDelegate);
+    final URI uri = URI.create("gs://my-bucket/prefix/");
+    final Predicate<String> filter = path -> false;
+    noCloseFS.listFilesWithMetadata(uri, false, filter, 42);
+
+    verify(mockDelegate).listFilesWithMetadata(uri, false, filter, 42);
+    // 2-arg should NOT be called — delegation should go directly to the optimized 4-arg on delegate
+    verify(mockDelegate, never()).listFilesWithMetadata(any(URI.class), anyBoolean());
+  }
+}


### PR DESCRIPTION
### Issue(s)

The existing `PinotFS.listFilesWithMetadata(URI, boolean)` eagerly fetches **all** objects from cloud storage into memory before any filtering is applied. For buckets with millions of objects, this causes OOM risk, high API costs, and unnecessary latency — even when the caller only needs a handful of matching files.

---

### Description

This pull request adds a new **paginated, filtered** `listFilesWithMetadata` overload to the `PinotFS` SPI and provides optimized implementations for S3, GCS, and ADLS Gen2 that apply per-page filtering and **early termination** — stopping cloud API calls as soon as enough matching files are found.

**New SPI method:**

```java
default List<FileMetadata> listFilesWithMetadata(
    URI fileUri, boolean recursive,
    Predicate<String> pathFilter, int maxResults)
    throws IOException
```

The default implementation falls back to the existing 2-arg method (fetch-all → filter in memory), so existing `PinotFS` implementations remain backward-compatible without changes.

---

### The Problem

| Step | Operation | Cost |
|------|-----------|------|
| 1 | `listFilesWithMetadata(uri, true)` — list ALL files recursively | O(all files in prefix) |
| 2 | Caller applies glob/exclude filter in memory | O(n) |
| 3 | Caller takes first N results | — |

When the bucket contains millions of objects but the caller only needs 10 matching files (e.g., preview), the full listing is wasteful:
- **S3**: Paginated `ListObjectsV2` must exhaust all pages before returning
- **GCS**: All `Page<Blob>` pages are fetched eagerly
- **ADLS**: `PagedIterable<PathItem>` is fully consumed

---

### Solution

Each cloud implementation now overrides the new 4-arg method to:

1. **Apply the filter per page** — test each object against the `Predicate<String>` as it's received
2. **Skip directories explicitly** — `s3Object.key().endsWith("/")`, `blob.getName().endsWith("/")`, `item.isDirectory()`
3. **Terminate early** — break out of the pagination loop once `maxResults` is reached, abandoning further API calls
4. **Guard against invalid input** — return immediately with a warning log if `maxResults <= 0`

**Implementation details per cloud provider:**

| Provider | Pagination Mechanism | Early Termination |
|----------|---------------------|-------------------|
| **S3** | `continuationToken` + `isTruncated` loop | Breaks inner `for` (page objects) + outer `while` (pages) |
| **GCS** | `Page<Blob>.getNextPage()` loop | Breaks inner `for` (blobs) + stops calling `getNextPage()` |
| **ADLS Gen2** | `PagedIterable<PathItem>` lazy iterator | `break` from `for-each` abandons the iterator, stopping further Azure API calls |

**Additional changes:**

- **`NoClosePinotFS`** — overrides the new 4-arg method to delegate to the underlying `_delegate`, ensuring the optimized cloud-specific implementation is invoked instead of falling back to the default fetch-all-then-filter path.
- **`maxResults <= 0` sanity check** — the default method in `PinotFS` and all three cloud overrides return an empty list immediately when `maxResults <= 0`, avoiding unnecessary cloud API calls.

**Code example (S3):**

```java
@Override
public List<FileMetadata> listFilesWithMetadata(URI fileUri, boolean recursive,
    Predicate<String> pathFilter, int maxResults) throws IOException {
  if (maxResults <= 0) {
    LOGGER.warn("listFilesWithMetadata called with maxResults={}, returning empty list", maxResults);
    return new ArrayList<>();
  }
  List<FileMetadata> result = new ArrayList<>();
  String continuationToken = null;
  boolean isDone = false;
  while (!isDone && result.size() < maxResults) {
    // Build and execute ListObjectsV2Request with continuationToken
    ListObjectsV2Response response = ...;
    for (S3Object s3Object : response.contents()) {
      if (s3Object.key().endsWith(DELIMITER)) continue; // skip directories
      String filePath = scheme + "://" + host + "/" + key;
      if (pathFilter.test(filePath)) {
        result.add(buildFileMetadata(s3Object, filePath));
        if (result.size() >= maxResults) break; // early termination
      }
    }
    isDone = !response.isTruncated();
    continuationToken = response.nextContinuationToken();
  }
  return result;
}
```

---

### Testing

- **`PinotFSPaginatedListTest`** (pinot-spi) — 5 tests: default method returns empty for `maxResults=0` and `maxResults<0` without calling the 2-arg fallback, positive `maxResults` correctly delegates to 2-arg, `NoClosePinotFS` delegates 4-arg call to underlying `_delegate` with exact arguments, `NoClosePinotFS` does not fall back to 2-arg method
- **`S3PinotFSPaginatedListTest`** — 16 tests: single-page/multi-page listing, early termination (across pages, within a page, `maxResults=1`), `continuationToken` passing, predicate filtering, directory skipping, metadata attributes, S3a scheme support, prefix sent to S3, `maxResults=0` returns empty without S3 API calls, `maxResults<0` returns empty without S3 API calls
- **`GcsPinotFSPaginatedListTest`** — 11 tests: single-page/multi-page, early termination (verifies `page2.getValues()` is never called), filtering, directory skipping (including prefix directory markers), null update time handling, metadata attributes, `maxResults=0` returns empty without `Storage.list()` calls, `maxResults<0` returns empty without `Storage.list()` calls
- **`ADLSGen2PinotFSPaginatedListTest`** — 12 tests: all-match, early termination, `maxResults=1`, filtering, directory skipping, empty listings, metadata attributes, `IOException` wrapping `DataLakeStorageException`, combined filter with early termination, `maxResults=0` returns empty, `maxResults<0` returns empty

---
