### PR TITLE
Enhance ContinuousJfrStarter to utilize JFR DiagnosticCommand MBean for recording management

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/util/trace/ContinuousJfrStarter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/trace/ContinuousJfrStarter.java
@@ -59,7 +59,8 @@ public class ContinuousJfrStarter implements PinotClusterConfigChangeListener {
   private static final String JFR_STOP_COMMAND = "jfrStop";
   private static final String JFR_DIAGNOSTIC_MBEAN = "com.sun.management:type=DiagnosticCommand";
   private static final Duration REPOSITORY_CLEANUP_INTERVAL = Duration.ofDays(1);
-  private static final ScheduledExecutorService REPOSITORY_CLEANUP_EXECUTOR = Executors.newSingleThreadScheduledExecutor(
+  private static final ScheduledExecutorService REPOSITORY_CLEANUP_EXECUTOR =
+      Executors.newSingleThreadScheduledExecutor(
       runnable -> {
         Thread thread = new Thread(runnable, "pinot-jfr-repository-cleaner");
         thread.setDaemon(true);
@@ -408,7 +409,8 @@ public class ContinuousJfrStarter implements PinotClusterConfigChangeListener {
   }
 
   @GuardedBy("GLOBAL_RECORDING_LOCK")
-  private void updateRepositoryCleanupTask(PinotConfiguration subset, String recordingName, RecordingState recordingState) {
+  private void updateRepositoryCleanupTask(
+      PinotConfiguration subset, String recordingName, RecordingState recordingState) {
     if (!isRepositoryCleanupEnabled()) {
       return;
     }
@@ -457,8 +459,8 @@ public class ContinuousJfrStarter implements PinotClusterConfigChangeListener {
       Path activeRepositoryPath = resolveCurrentRepositoryPath();
       cleanupOldRepositoriesInternal(repositoryRootPath, maxTotalSizeBytes, activeRepositoryPath);
     } catch (Exception e) {
-      LOGGER.warn("Failed to clean up old JFR repositories for recording '{}' under '{}'", recordingName, repositoryRoot,
-          e);
+      LOGGER.warn("Failed to clean up old JFR repositories for recording '{}' under '{}'", recordingName,
+          repositoryRoot, e);
     }
   }
 
@@ -468,7 +470,10 @@ public class ContinuousJfrStarter implements PinotClusterConfigChangeListener {
       return null;
     }
     try {
-      Object result = _mBeanServer.invoke(_diagnosticCommandObjectName, JFR_CONFIGURE_COMMAND, new Object[]{new String[0]},
+      Object result = _mBeanServer.invoke(
+          _diagnosticCommandObjectName,
+          JFR_CONFIGURE_COMMAND,
+          new Object[]{new String[0]},
           new String[]{String[].class.getName()});
       if (result == null) {
         return null;
@@ -503,7 +508,8 @@ public class ContinuousJfrStarter implements PinotClusterConfigChangeListener {
       List<PathWithMetadata> repositories = new ArrayList<>();
       try (java.util.stream.Stream<Path> children = Files.list(repositoryRootPath)) {
         children.filter(path -> activeRepositoryPath == null || !activeRepositoryPath.startsWith(path))
-            .forEach(path -> repositories.add(new PathWithMetadata(path, computePathSize(path), readLastModifiedMillis(path))));
+            .forEach(path -> repositories.add(
+                new PathWithMetadata(path, computePathSize(path), readLastModifiedMillis(path))));
       }
       long totalSizeBytes = repositories.stream().mapToLong(pathWithMetadata -> pathWithMetadata._sizeBytes).sum();
       if (activeRepositoryPath != null) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/util/trace/ContinuousJfrStarterTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/util/trace/ContinuousJfrStarterTest.java
@@ -283,7 +283,8 @@ public class ContinuousJfrStarterTest {
   public void coordinatesPerRecordingName() {
     TestContinuousJfrStarter firstStarter = new TestContinuousJfrStarter();
     TestContinuousJfrStarter secondStarter = new TestContinuousJfrStarter();
-    Map<String, String> enabledFirstConfig = Map.of("pinot.jfr.enabled", "true", "pinot.jfr.name", "pinot-continuous-a");
+    Map<String, String> enabledFirstConfig = Map.of("pinot.jfr.enabled", "true", "pinot.jfr.name",
+        "pinot-continuous-a");
     Map<String, String> enabledSecondConfig = Map.of("pinot.jfr.enabled", "true", "pinot.jfr.name",
         "pinot-continuous-b");
     Map<String, String> disabledFirstConfig =

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/JfrQuickstart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/JfrQuickstart.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.tools;
 
 import java.util.Collections;


### PR DESCRIPTION
## Summary

This PR reworks Pinot's continuous JFR integration to use the JVM DiagnosticCommand MBean (`JFR.configure`, `JFR.start`, `JFR.stop`) instead of the `jdk.jfr.Recording` object API, while keeping cluster-level dynamic control through `ContinuousJfrStarter`.

## Why this change is needed

The previous implementation had correctness and operability issues:

- It used `Recording.setDestination(...)`, which does not match the intended long-running "continuous recording + operator-managed dumps" behavior.
- It mixed concerns by trying to handle dump-file lifecycle/cleanup in Pinot code.
- It did not provide a reliable way to control JFR repository location through Pinot in the way operators need.
- It made semantics around dump boundaries/rotation unclear.

The new approach aligns Pinot with JFR's actual control model and removes behavior that was easy to misinterpret.

## Why we decided not to keep using `Recording`

We moved away from `Recording` API for control flow because important operational knobs we need are in the global JFR control plane, not the per-recording API:

- repository path (`repositorypath`)
- dump path (`dumppath`)
- unified runtime command semantics for start/stop/configure

Using DiagnosticCommand MBean gives one coherent mechanism for all required controls and maps directly to `jcmd` behavior.

## Why we still keep `ContinuousJfrStarter` (instead of only `jcmd` or `JAVA_OPTS`)

We intentionally keep `ContinuousJfrStarter` as Pinot's control plane because it gives cluster-wide operability that `JAVA_OPTS`/manual `jcmd` do not:

- Dynamic reconfiguration without restart via Pinot cluster config updates.
- Single cluster-level control surface for enable/disable and JFR parameters.
- No need to manually run commands on many nodes during incidents.
- Better consistency with Pinot's existing config propagation model across cluster roles.

`JAVA_OPTS` and direct `jcmd` remain valid tools, but they are not sufficient as the primary Pinot control plane for large clusters.

## What changed

### `ContinuousJfrStarter` behavior

- Uses DiagnosticCommand MBean commands:
  - `jfrConfigure` for runtime options (`repositorypath`, `dumppath`)
  - `jfrStart` for recording start
  - `jfrStop` for stop by recording name
- Supports cluster config mapping:
  - `pinot.jfr.directory` -> `repositorypath` (kept for backward compatibility)
  - `pinot.jfr.dumpPath` -> `dumppath`
  - existing keys still supported: `enabled`, `name`, `configuration`, `toDisk`, `maxSize`, `maxAge`, `dumpOnExit`
- Keeps one continuous recording model; no dump rotation/cleanup thread logic.

### Reliability hardening

- If DiagnosticCommand MBean is unavailable, Pinot logs warnings and safely no-ops instead of failing startup/runtime paths.
- Static initialization is safe even if `ObjectName` creation fails (logs warning; does not throw).

### Tests

- Unit-style tests validate command generation and control flow.
- Added integration test that uses the real DiagnosticCommand MBean and verifies recording visibility via `jfrCheck`.
- Added coverage for graceful behavior when MBean is unavailable.

### Docs (See https://github.com/pinot-contrib/pinot-docs/pull/471)

- Updated continuous JFR operator docs to reflect:
  - MBean-based control model
  - `pinot.jfr.directory` compatibility key and `pinot.jfr.dumpPath`
  - graceful degradation when MBean is unavailable
