### PR TITLE
Fix QueryServer _allChannels cleanup on channel close

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/QueryServer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/QueryServer.java
@@ -143,6 +143,7 @@ public class QueryServer {
             @Override
             protected void initChannel(SocketChannel ch) {
               _allChannels.put(ch, true);
+              ch.closeFuture().addListener(f -> _allChannels.remove(ch));
 
               ch.pipeline()
                   .addLast(ChannelHandlerFactory.getDirectOOMHandler(null, null, null, _allChannels, _channel));
@@ -179,5 +180,10 @@ public class QueryServer {
   @VisibleForTesting
   ServerSocketChannel getChannel() {
     return _channel;
+  }
+
+  @VisibleForTesting
+  int getConnectedChannelCount() {
+    return _allChannels.size();
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/transport/QueryServerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/transport/QueryServerTest.java
@@ -28,6 +28,7 @@ import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.metrics.PinotMetricUtils;
 import org.apache.pinot.spi.metrics.PinotMetricsRegistry;
+import org.apache.pinot.util.TestUtils;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -63,6 +64,32 @@ public class QueryServerTest {
 
     server.shutDown();
     assertFalse(connectionOk(serverAddress));
+  }
+
+  @Test
+  public void testAllChannelsCleanupOnClose()
+      throws Exception {
+    PinotMetricUtils.init(new PinotConfiguration());
+    PinotMetricsRegistry registry = PinotMetricUtils.getPinotMetricsRegistry();
+    ServerMetrics.register(new ServerMetrics(registry));
+    QueryServer server = new QueryServer(0, new NettyConfig(), null, mock(ChannelHandler.class));
+    server.start();
+
+    InetSocketAddress serverAddress = server.getChannel().localAddress();
+    Socket socket = new Socket(serverAddress.getHostName(), serverAddress.getPort());
+
+    try {
+      TestUtils.waitForCondition(aVoid -> server.getConnectedChannelCount() > 0, 5_000L,
+          "Channel was not registered in _allChannels");
+
+      socket.close();
+
+      TestUtils.waitForCondition(aVoid -> server.getConnectedChannelCount() == 0, 5_000L,
+          "Channel was not removed from _allChannels after close");
+    } finally {
+      IOUtils.closeQuietly(socket);
+      server.shutDown();
+    }
   }
 
   private static boolean connectionOk(InetSocketAddress address) {


### PR DESCRIPTION
## Summary
- Adds a `closeFuture` listener in `QueryServer.initChannel()` to remove channels from `_allChannels` when they close, preventing indefinite accumulation of closed channel references (memory leak)
- Adds `@VisibleForTesting getConnectedChannelCount()` getter for test access
- Adds `testAllChannelsCleanupOnClose` test validating channels are cleaned up on close

## Test plan
- [x] `QueryServerTest#testAllChannelsCleanupOnClose` — connects a socket, asserts channel registered, closes socket, asserts channel removed
- [x] Run full `QueryServerTest`: `mvn -pl pinot-core test -Dtest=QueryServerTest -Drat.skip=true -Dcheckstyle.skip=true`