### PR TITLE
Fix integration test slowdown caused by embedded Kafka fsyncing every…

### DIFF
--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/test/java/org/apache/pinot/plugin/stream/kafka30/server/EmbeddedKafkaCluster.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-3.0/src/test/java/org/apache/pinot/plugin/stream/kafka30/server/EmbeddedKafkaCluster.java
@@ -74,7 +74,7 @@ public class EmbeddedKafkaCluster implements StreamDataServerStartable {
           .setConfigProp("transaction.state.log.min.isr", "1")
           .setConfigProp("transaction.state.log.num.partitions", "1")
           .setConfigProp("group.initial.rebalance.delay.ms", "0")
-          .setConfigProp("log.flush.interval.messages", "10000")
+
           .build();
 
       _cluster.format();


### PR DESCRIPTION
  ## Summary
  - Change `log.flush.interval.messages` from `1` to `10000` in `EmbeddedKafkaCluster`
  - The value of `1` forces Kafka to fsync to disk after every single produced message, which is catastrophically slow for tests that push large volumes of data (e.g. ~100K records)
  - This was introduced in #17790 when replacing Docker-based Kafka with the embedded KRaft broker