### PR TITLE
Fix broker write failure handling in ServerChannels

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerMeter.java
@@ -207,6 +207,8 @@ public class BrokerMeter implements AbstractMetrics.Meter {
       "NETTY_CONNECTION_BYTES_SENT", "nettyConnection", true);
   public static final BrokerMeter NETTY_CONNECTION_BYTES_RECEIVED = create(
       "NETTY_CONNECTION_BYTES_RECEIVED", "nettyConnection", true);
+  public static final BrokerMeter NETTY_CONNECTION_SEND_REQUEST_FAILURES = create(
+      "NETTY_CONNECTION_SEND_REQUEST_FAILURES", "nettyConnection", true);
 
   public static final BrokerMeter PROACTIVE_CLUSTER_CHANGE_CHECK = create(
       "PROACTIVE_CLUSTER_CHANGE_CHECK", "proactiveClusterChangeCheck", true);

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/ServerChannels.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/ServerChannels.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.transport;
 
+import com.google.common.annotations.VisibleForTesting;
 import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.buffer.PooledByteBufAllocatorMetric;
@@ -149,6 +150,11 @@ public class ServerChannels {
     _eventLoopGroup.shutdownGracefully(0, 0, TimeUnit.SECONDS);
   }
 
+  @VisibleForTesting
+  ServerChannel getOrCreateServerChannel(ServerRoutingInstance instance) {
+    return _serverToChannelMap.computeIfAbsent(instance, ServerChannel::new);
+  }
+
   @ThreadSafe
   class ServerChannel {
     final ServerRoutingInstance _serverRoutingInstance;
@@ -204,6 +210,11 @@ public class ServerChannels {
       }
     }
 
+    @VisibleForTesting
+    void setChannel(Channel channel) {
+      _channel = channel;
+    }
+
     void setSilentShutdown() {
       if (_channel != null) {
         DirectOOMHandler directOOMHandler = _channel.pipeline().get(DirectOOMHandler.class);
@@ -242,10 +253,18 @@ public class ServerChannels {
         ServerRoutingInstance serverRoutingInstance, byte[] requestBytes) {
       long startTimeMs = System.currentTimeMillis();
       _channel.writeAndFlush(Unpooled.wrappedBuffer(requestBytes)).addListener(f -> {
-        int requestSentLatencyMs = (int) (System.currentTimeMillis() - startTimeMs);
-        _brokerMetrics.addTimedTableValue(rawTableName, BrokerTimer.NETTY_CONNECTION_SEND_REQUEST_LATENCY,
-            requestSentLatencyMs, TimeUnit.MILLISECONDS);
-        asyncQueryResponse.markRequestSent(serverRoutingInstance, requestSentLatencyMs);
+        if (f.isSuccess()) {
+          int requestSentLatencyMs = (int) (System.currentTimeMillis() - startTimeMs);
+          _brokerMetrics.addTimedTableValue(rawTableName, BrokerTimer.NETTY_CONNECTION_SEND_REQUEST_LATENCY,
+              requestSentLatencyMs, TimeUnit.MILLISECONDS);
+          asyncQueryResponse.markRequestSent(serverRoutingInstance, requestSentLatencyMs);
+        } else {
+          LOGGER.error("Write failure to server: {} for table: {}", serverRoutingInstance, rawTableName, f.cause());
+          _brokerMetrics.addMeteredGlobalValue(BrokerMeter.NETTY_CONNECTION_SEND_REQUEST_FAILURES, 1);
+          asyncQueryResponse.markServerDown(serverRoutingInstance,
+              new RuntimeException("Failed to send request to server: " + serverRoutingInstance, f.cause()));
+          _channel.close();
+        }
       });
       _brokerMetrics.addMeteredGlobalValue(BrokerMeter.NETTY_CONNECTION_REQUESTS_SENT, 1);
       _brokerMetrics.addMeteredGlobalValue(BrokerMeter.NETTY_CONNECTION_BYTES_SENT, requestBytes.length);

--- a/pinot-core/src/test/java/org/apache/pinot/core/transport/ServerChannelsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/transport/ServerChannelsTest.java
@@ -19,22 +19,32 @@
 package org.apache.pinot.core.transport;
 
 import com.sun.net.httpserver.HttpServer;
+import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
+import io.netty.util.concurrent.GenericFutureListener;
 import java.net.InetSocketAddress;
 import org.apache.pinot.common.config.NettyConfig;
+import org.apache.pinot.common.metrics.BrokerMetrics;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.request.InstanceRequest;
 import org.apache.pinot.spi.accounting.ThreadAccountantUtils;
 import org.apache.pinot.spi.config.table.TableType;
-import org.testng.annotations.AfterClass;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.metrics.PinotMetricUtils;
+import org.apache.pinot.spi.metrics.PinotMetricsRegistry;
+import org.mockito.ArgumentCaptor;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 
 public class ServerChannelsTest {
-  private static HttpServer _dummyServer;
 
   @DataProvider
   public Object[][] parameters() {
@@ -44,42 +54,115 @@ public class ServerChannelsTest {
   }
 
   @BeforeClass
-  public void setUp()
-      throws Exception {
-    _dummyServer = HttpServer.create();
-    _dummyServer.bind(new InetSocketAddress("localhost", 0), 0);
-    _dummyServer.start();
-  }
-
-  @AfterClass
-  public void tearDown()
-      throws Exception {
-    if (_dummyServer != null) {
-      _dummyServer.stop(0);
-    }
+  public void setUp() {
+    PinotMetricUtils.init(new PinotConfiguration());
+    PinotMetricsRegistry registry = PinotMetricUtils.getPinotMetricsRegistry();
+    BrokerMetrics.register(new BrokerMetrics(registry));
   }
 
   @Test(dataProvider = "parameters")
   public void testConnect(boolean nativeTransportEnabled)
       throws Exception {
-    NettyConfig nettyConfig = new NettyConfig();
-    nettyConfig.setNativeTransportsEnabled(nativeTransportEnabled);
+    HttpServer dummyServer = HttpServer.create();
+    dummyServer.bind(new InetSocketAddress("localhost", 0), 0);
+    dummyServer.start();
+    try {
+      NettyConfig nettyConfig = new NettyConfig();
+      nettyConfig.setNativeTransportsEnabled(nativeTransportEnabled);
+      QueryRouter queryRouter = mock(QueryRouter.class);
+
+      ServerRoutingInstance serverRoutingInstance =
+          new ServerRoutingInstance("localhost", dummyServer.getAddress().getPort(), TableType.REALTIME);
+      ServerChannels serverChannels =
+          new ServerChannels(queryRouter, nettyConfig, null, ThreadAccountantUtils.getNoOpAccountant());
+      serverChannels.connect(serverRoutingInstance);
+
+      final long requestId = System.currentTimeMillis();
+
+      AsyncQueryResponse asyncQueryResponse = mock(AsyncQueryResponse.class);
+      BrokerRequest brokerRequest = new BrokerRequest();
+      InstanceRequest instanceRequest = new InstanceRequest();
+      instanceRequest.setRequestId(requestId);
+      instanceRequest.setQuery(brokerRequest);
+      serverChannels.sendRequest("dummy_table_name", asyncQueryResponse, serverRoutingInstance, instanceRequest, 1000);
+      serverChannels.shutDown();
+    } finally {
+      dummyServer.stop(0);
+    }
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void testWriteFailureClosesChannelAndFailsQuery() {
     QueryRouter queryRouter = mock(QueryRouter.class);
-
-    ServerRoutingInstance serverRoutingInstance =
-        new ServerRoutingInstance("localhost", _dummyServer.getAddress().getPort(), TableType.REALTIME);
     ServerChannels serverChannels =
-        new ServerChannels(queryRouter, nettyConfig, null, ThreadAccountantUtils.getNoOpAccountant());
-    serverChannels.connect(serverRoutingInstance);
+        new ServerChannels(queryRouter, null, null, ThreadAccountantUtils.getNoOpAccountant());
 
-    final long requestId = System.currentTimeMillis();
+    ServerRoutingInstance routingInstance = new ServerRoutingInstance("localhost", 12345, TableType.OFFLINE);
+    ServerChannels.ServerChannel serverChannel = serverChannels.getOrCreateServerChannel(routingInstance);
+
+    Channel mockChannel = mock(Channel.class);
+    ChannelFuture mockFuture = mock(ChannelFuture.class);
+    when(mockChannel.writeAndFlush(any())).thenReturn(mockFuture);
+    serverChannel.setChannel(mockChannel);
+
+    ArgumentCaptor<GenericFutureListener> listenerCaptor = ArgumentCaptor.forClass(GenericFutureListener.class);
+    when(mockFuture.addListener(listenerCaptor.capture())).thenReturn(mockFuture);
 
     AsyncQueryResponse asyncQueryResponse = mock(AsyncQueryResponse.class);
-    BrokerRequest brokerRequest = new BrokerRequest();
-    InstanceRequest instanceRequest = new InstanceRequest();
-    instanceRequest.setRequestId(requestId);
-    instanceRequest.setQuery(brokerRequest);
-    serverChannels.sendRequest("dummy_table_name", asyncQueryResponse, serverRoutingInstance, instanceRequest, 1000);
+    serverChannel.sendRequestWithoutLocking("test_table", asyncQueryResponse, routingInstance, new byte[]{1, 2, 3});
+
+    // Simulate write failure
+    when(mockFuture.isSuccess()).thenReturn(false);
+    when(mockFuture.cause()).thenReturn(new OutOfMemoryError("Direct buffer memory"));
+
+    try {
+      listenerCaptor.getValue().operationComplete(mockFuture);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+
+    verify(mockChannel).close();
+    verify(asyncQueryResponse).markServerDown(any(ServerRoutingInstance.class), any(Exception.class));
+    verify(asyncQueryResponse, never()).markRequestSent(any(ServerRoutingInstance.class), any(Integer.class));
+
+    serverChannels.shutDown();
+  }
+
+  @SuppressWarnings("unchecked")
+  @Test
+  public void testWriteSuccessMarksRequestSent() {
+    QueryRouter queryRouter = mock(QueryRouter.class);
+    ServerChannels serverChannels =
+        new ServerChannels(queryRouter, null, null, ThreadAccountantUtils.getNoOpAccountant());
+
+    ServerRoutingInstance routingInstance = new ServerRoutingInstance("localhost", 12345, TableType.OFFLINE);
+    ServerChannels.ServerChannel serverChannel = serverChannels.getOrCreateServerChannel(routingInstance);
+
+    Channel mockChannel = mock(Channel.class);
+    ChannelFuture mockFuture = mock(ChannelFuture.class);
+    when(mockChannel.writeAndFlush(any())).thenReturn(mockFuture);
+    serverChannel.setChannel(mockChannel);
+
+    ArgumentCaptor<GenericFutureListener> listenerCaptor = ArgumentCaptor.forClass(GenericFutureListener.class);
+    when(mockFuture.addListener(listenerCaptor.capture())).thenReturn(mockFuture);
+
+    AsyncQueryResponse asyncQueryResponse = mock(AsyncQueryResponse.class);
+    serverChannel.sendRequestWithoutLocking("test_table", asyncQueryResponse, routingInstance, new byte[]{1, 2, 3});
+
+    // Simulate write success
+    when(mockFuture.isSuccess()).thenReturn(true);
+
+    try {
+      listenerCaptor.getValue().operationComplete(mockFuture);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+
+    verify(asyncQueryResponse).markRequestSent(any(ServerRoutingInstance.class), any(Integer.class));
+    verify(asyncQueryResponse, never()).markServerDown(any(ServerRoutingInstance.class), any(Exception.class));
+    verify(mockChannel, never()).close();
+
     serverChannels.shutDown();
   }
 }


### PR DESCRIPTION
## Summary
- **Fix unguarded `writeAndFlush()` in `ServerChannels.sendRequestWithoutLocking()`**: The write listener never checked `f.isSuccess()`, so on write failure `markRequestSent()` was called anyway (false positive), no channel close occurred (zombie channel), no logging/metrics, and queries waited for full timeout instead of failing fast.
- **Add `f.isSuccess()` check**: On failure, logs the error, increments `NETTY_CONNECTION_SEND_REQUEST_FAILURES` metric, calls `markServerDown()` for fast query failure, and closes the channel to prevent zombies. On success, existing behavior is preserved.
- **Add `NETTY_CONNECTION_SEND_REQUEST_FAILURES` broker metric** for observability of write failures.
- This is the broker-side counterpart to the server-side fix in PR #17845 / #17854.

## Design Decisions
- **`markServerDown()` over `markQueryFailed()`**: Race-safe — if server already responded, it's a no-op. The `_channel.close()` also triggers `channelInactive()` → `markServerDown()` for all in-flight queries. Double invocation is safe (idempotent).
- **Wrap `f.cause()` in RuntimeException**: `markServerDown` expects `Exception` but `f.cause()` returns `Throwable` (could be `OutOfMemoryError`).
- **`REQUESTS_SENT`/`BYTES_SENT` kept outside listener**: They're incremented synchronously before write completes. Moving them inside the success path would be a separate behavioral change.

## Test plan
- [x] Added `testWriteFailureClosesChannelAndFailsQuery` — verifies channel close, markServerDown called, markRequestSent never called
- [x] Added `testWriteSuccessMarksRequestSent` — verifies markRequestSent called, markServerDown never called, close never called
- [x] Point-compiled pinot-common and pinot-core
- [x] All ServerChannelsTest tests pass
- [x] license:format and spotless:apply pass