### PR TITLE
Add X-Correlation-Id header to Java client HTTP requests

### DIFF
--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/JsonAsyncHttpPinotClientTransport.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/JsonAsyncHttpPinotClientTransport.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 import java.util.concurrent.TimeUnit;
@@ -118,8 +119,10 @@ public class JsonAsyncHttpPinotClientTransport implements PinotClientTransport<C
       if (_headers != null) {
         _headers.forEach((k, v) -> requestBuilder.addHeader(k, v));
       }
-      LOGGER.debug("Sending query {} to {}", query, url);
-      return requestBuilder.addHeader("Content-Type", "application/json; charset=utf-8").setBody(json.toString())
+      String correlationId = UUID.randomUUID().toString();
+      LOGGER.debug("Sending query {} to {} with correlationId {}", query, url, correlationId);
+      return requestBuilder.addHeader("Content-Type", "application/json; charset=utf-8")
+          .addHeader("X-Correlation-Id", correlationId).setBody(json.toString())
           .execute().toCompletableFuture().thenApply(httpResponse -> {
             LOGGER.debug("Completed query, HTTP status is {}", httpResponse.getStatusCode());
 


### PR DESCRIPTION
Generate a UUID per request and send it as the X-Correlation-Id header in JsonAsyncHttpPinotClientTransport. This enables request tracing across proxies, load balancers, and broker access logs.


(**) Use `release-notes` label for scenarios like:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
