### PR TITLE
Implement cross-table segment pruning for logical table

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/executor/LogicalTableExecutionInfo.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/executor/LogicalTableExecutionInfo.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.core.query.executor;
 
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -28,7 +27,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.exception.TableNotFoundException;
-import org.apache.pinot.common.metrics.ServerQueryPhase;
 import org.apache.pinot.core.data.manager.InstanceDataManager;
 import org.apache.pinot.core.data.manager.realtime.RealtimeTableDataManager;
 import org.apache.pinot.core.query.pruner.SegmentPrunerService;
@@ -106,16 +104,9 @@ public class LogicalTableExecutionInfo implements TableExecutionInfo {
     int numTotalSegments = allSegments.size();
 
     // Constant false shortcut: skip pruning
-    List<IndexSegment> selectedSegments;
     SegmentPrunerStatistics prunerStats = new SegmentPrunerStatistics();
-    if ((queryContext.getFilter() != null && queryContext.getFilter().isConstantFalse())
-        || (queryContext.getHavingFilter() != null && queryContext.getHavingFilter().isConstantFalse())) {
-      selectedSegments = Collections.emptyList();
-    } else {
-      TimerContext.Timer segmentPruneTimer = timerContext.startNewPhaseTimer(ServerQueryPhase.SEGMENT_PRUNING);
-      selectedSegments = segmentPrunerService.prune(allSegments, queryContext, prunerStats, executorService);
-      segmentPruneTimer.stopAndRecord();
-    }
+    List<IndexSegment> selectedSegments =
+        selectSegments(allSegments, queryContext, timerContext, executorService, segmentPrunerService, prunerStats);
 
     // Build segment contexts for selected segments only, preserving prune order
     List<SegmentContext> selectedSegmentContexts = new ArrayList<>(selectedSegments.size());

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/executor/SingleTableExecutionInfo.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/executor/SingleTableExecutionInfo.java
@@ -20,7 +20,6 @@ package org.apache.pinot.core.query.executor;
 
 import com.google.common.base.Preconditions;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -30,7 +29,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.exception.TableNotFoundException;
-import org.apache.pinot.common.metrics.ServerQueryPhase;
 import org.apache.pinot.core.data.manager.InstanceDataManager;
 import org.apache.pinot.core.data.manager.realtime.RealtimeTableDataManager;
 import org.apache.pinot.core.query.pruner.SegmentPrunerService;
@@ -281,20 +279,5 @@ public class SingleTableExecutionInfo implements TableExecutionInfo {
     }
     return new SelectedSegmentsInfo(indexSegments, numTotalDocs, prunerStats, numTotalSegments, numSelectedSegments,
         selectedSegmentContexts);
-  }
-
-  private List<IndexSegment> selectSegments(List<IndexSegment> indexSegments, QueryContext queryContext,
-      TimerContext timerContext, ExecutorService executorService, SegmentPrunerService segmentPrunerService,
-      SegmentPrunerStatistics prunerStats) {
-    List<IndexSegment> selectedSegments;
-    if ((queryContext.getFilter() != null && queryContext.getFilter().isConstantFalse()) || (
-        queryContext.getHavingFilter() != null && queryContext.getHavingFilter().isConstantFalse())) {
-      selectedSegments = Collections.emptyList();
-    } else {
-      TimerContext.Timer segmentPruneTimer = timerContext.startNewPhaseTimer(ServerQueryPhase.SEGMENT_PRUNING);
-      selectedSegments = segmentPrunerService.prune(indexSegments, queryContext, prunerStats, executorService);
-      segmentPruneTimer.stopAndRecord();
-    }
-    return selectedSegments;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/executor/TableExecutionInfo.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/executor/TableExecutionInfo.java
@@ -19,10 +19,12 @@
 package org.apache.pinot.core.query.executor;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import javax.annotation.Nullable;
+import org.apache.pinot.common.metrics.ServerQueryPhase;
 import org.apache.pinot.core.query.pruner.SegmentPrunerService;
 import org.apache.pinot.core.query.pruner.SegmentPrunerStatistics;
 import org.apache.pinot.core.query.request.context.QueryContext;
@@ -119,6 +121,34 @@ public interface TableExecutionInfo {
    * @return A ConsumingSegmentsInfo object containing the metadata about the consuming segments queried
    */
   ConsumingSegmentsInfo getConsumingSegmentsInfo();
+
+  /**
+   * Selects which segments are needed for the query by applying segment pruning. If the query has a constant-false
+   * filter or having clause, returns an empty list; otherwise delegates to the segment pruner and returns the
+   * selected segments.
+   *
+   * @param indexSegments list of segments to prune
+   * @param queryContext query context used by the pruner
+   * @param timerContext timer context for recording segment pruning time
+   * @param executorService executor used by the pruner if needed
+   * @param segmentPrunerService pruner service that performs the selection
+   * @param prunerStats statistics to record pruning results
+   * @return list of segments selected for the query (possibly empty if filter is constant false)
+   */
+  default List<IndexSegment> selectSegments(List<IndexSegment> indexSegments, QueryContext queryContext,
+      TimerContext timerContext, ExecutorService executorService, SegmentPrunerService segmentPrunerService,
+      SegmentPrunerStatistics prunerStats) {
+    List<IndexSegment> selectedSegments;
+    if ((queryContext.getFilter() != null && queryContext.getFilter().isConstantFalse()) || (
+        queryContext.getHavingFilter() != null && queryContext.getHavingFilter().isConstantFalse())) {
+      selectedSegments = Collections.emptyList();
+    } else {
+      TimerContext.Timer segmentPruneTimer = timerContext.startNewPhaseTimer(ServerQueryPhase.SEGMENT_PRUNING);
+      selectedSegments = segmentPrunerService.prune(indexSegments, queryContext, prunerStats, executorService);
+      segmentPruneTimer.stopAndRecord();
+    }
+    return selectedSegments;
+  }
 
   /**
    * If consuming segments are being queried, this class contains the information about the consuming segments such as

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/executor/LogicalTableExecutionInfoTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/executor/LogicalTableExecutionInfoTest.java
@@ -34,6 +34,8 @@ import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUt
 import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.SegmentContext;
 import org.apache.pinot.segment.spi.SegmentMetadata;
+import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.segment.spi.datasource.DataSourceMetadata;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.CommonConstants.Server;
@@ -42,6 +44,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
@@ -197,11 +200,78 @@ public class LogicalTableExecutionInfoTest {
     }
   }
 
+  private static final String ORDER_BY_COLUMN = "orderByCol";
+
+  /**
+   * Verifies that for ORDER BY col DESC LIMIT 5, the pruner selects exactly two segments that have
+   * overlapping min/max (order-by column) and prunes the rest. Segments have 10 docs each; two segments
+   * overlap in range so both are kept; all others are out of range.
+   * <p>The pruner keeps an extra segment only when its max &gt; current min (strict). So Seg2 uses max=101.
+   */
+  @Test
+  public void testGetSelectedSegmentsInfoOrderByLimitTwoSegmentsOverlap() {
+    // Seg1: [100, 100] 10 docs - first in DESC order, covers LIMIT 10
+    // Seg2: [90, 101] 10 docs - overlaps (max 101 > 100), kept
+    // Seg3, Seg4, Seg5: [1, 50] 10 docs each - max 50 < 100, pruned
+    IndexSegment seg1 = mockIndexSegmentWithOrderByColumn(ORDER_BY_COLUMN, 100L, 100L, 10);
+    IndexSegment seg2 = mockIndexSegmentWithOrderByColumn(ORDER_BY_COLUMN, 90L, 101L, 10);
+    IndexSegment seg3 = mockIndexSegmentWithOrderByColumn(ORDER_BY_COLUMN, 1L, 50L, 10);
+    IndexSegment seg4 = mockIndexSegmentWithOrderByColumn(ORDER_BY_COLUMN, 1L, 50L, 10);
+    IndexSegment seg5 = mockIndexSegmentWithOrderByColumn(ORDER_BY_COLUMN, 1L, 50L, 10);
+
+    List<IndexSegment> allSegments = new ArrayList<>();
+    allSegments.add(seg1);
+    allSegments.add(seg2);
+    allSegments.add(seg3);
+    allSegments.add(seg4);
+    allSegments.add(seg5);
+
+    SingleTableExecutionInfo tableInfo = mockSingleTableExecutionInfo(allSegments, null);
+    LogicalTableExecutionInfo logicalTableExecutionInfo =
+        new LogicalTableExecutionInfo(Collections.singletonList(tableInfo));
+
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContext(
+        "SELECT * FROM logicalTable ORDER BY " + ORDER_BY_COLUMN + " DESC LIMIT 5");
+    queryContext.setSchema(mock(Schema.class));
+
+    TableExecutionInfo.SelectedSegmentsInfo selectedSegmentsInfo =
+        logicalTableExecutionInfo.getSelectedSegmentsInfo(queryContext, _timerContext, _executorService,
+            _segmentPrunerService);
+
+    assertEquals(selectedSegmentsInfo.getNumTotalSegments(), 5);
+    assertEquals(selectedSegmentsInfo.getNumTotalDocs(), 50);
+    assertEquals(selectedSegmentsInfo.getNumSelectedSegments(), 2,
+        "ORDER BY DESC LIMIT 10 with overlapping ranges should select exactly 2 segments");
+    List<SegmentContext> contexts = selectedSegmentsInfo.getSelectedSegmentContexts();
+    assertEquals(contexts.size(), 2);
+    assertSame(contexts.get(0).getIndexSegment(), seg1, "First selected should be Seg1 (min=100)");
+    assertSame(contexts.get(1).getIndexSegment(), seg2, "Second selected should be Seg2 (min=90, max>100 overlaps)");
+  }
+
   private static IndexSegment mockIndexSegment(int totalDocs) {
     IndexSegment indexSegment = mock(IndexSegment.class);
     SegmentMetadata metadata = mock(SegmentMetadata.class);
     when(metadata.getTotalDocs()).thenReturn(totalDocs);
     when(indexSegment.getSegmentMetadata()).thenReturn(metadata);
+    return indexSegment;
+  }
+
+  /**
+   * Mocks an IndexSegment with min/max for the order-by column so SelectionQuerySegmentPruner can prune by range.
+   * Used for ORDER BY + LIMIT tests.
+   */
+  private static IndexSegment mockIndexSegmentWithOrderByColumn(String orderByColumn, Comparable<?> minValue,
+      Comparable<?> maxValue, int totalDocs) {
+    IndexSegment indexSegment = mock(IndexSegment.class);
+    SegmentMetadata segmentMetadata = mock(SegmentMetadata.class);
+    when(segmentMetadata.getTotalDocs()).thenReturn(totalDocs);
+    when(indexSegment.getSegmentMetadata()).thenReturn(segmentMetadata);
+    DataSource dataSource = mock(DataSource.class);
+    when(indexSegment.getDataSource(eq(orderByColumn), any(Schema.class))).thenReturn(dataSource);
+    DataSourceMetadata dataSourceMetadata = mock(DataSourceMetadata.class);
+    when(dataSource.getDataSourceMetadata()).thenReturn(dataSourceMetadata);
+    when(dataSourceMetadata.getMinValue()).thenReturn(minValue);
+    when(dataSourceMetadata.getMaxValue()).thenReturn(maxValue);
     return indexSegment;
   }
 


### PR DESCRIPTION
## Implement cross-table segment pruning for logical table

### Summary

For logical tables, segment pruning is now performed **once** across **all** segments from every physical table (cross-table prune) instead of once per physical table. This allows pruners such as `SelectionQuerySegmentPruner` (ORDER BY + LIMIT) to prune effectively across the logical table, reducing the number of segments processed and aligning behavior with a single physical table holding the same data.

### Problem

- `LogicalTableExecutionInfo.getSelectedSegmentsInfo` previously called `SingleTableExecutionInfo.getSelectedSegmentsInfo` (and thus `segmentPrunerService.prune`) **per physical table**.
- For ORDER BY + LIMIT, each table was pruned in isolation, so the logical table often processed many more segments than a single physical table (e.g. ~3× for 3 physical tables).

### Solution

- **Collect** all segments from all `SingleTableExecutionInfo` instances into one list and maintain a `segmentToTable` map.
- **Prune once**: call `segmentPrunerService.prune(allSegments, queryContext, prunerStats, executorService)` on the combined list.

Single-table execution is unchanged; only the logical-table path in `LogicalTableExecutionInfo` is modified.

### Backward compatibility

- No API changes. Single-table path and `SingleTableExecutionInfo` behavior are unchanged; only the logical-table branch in `LogicalTableExecutionInfo.getSelectedSegmentsInfo` is new.