### PR TITLE
Add COLUMNAR_MAP index for per-key columnar storage for dense key and JSON storage for sparse key for MAP datatype

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/BaseSegmentCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/BaseSegmentCreator.java
@@ -331,9 +331,18 @@ public abstract class BaseSegmentCreator implements SegmentCreator {
   private <C extends IndexConfig> void tryCreateIndexCreator(Map<IndexType<?, ?, ?>, IndexCreator> creatorsByIndex,
       IndexType<C, ?, ?> index, IndexCreationContext.Common context, FieldIndexConfigs fieldIndexConfigs)
       throws Exception {
+    // Skip forward index for MAP columns that have columnar map index enabled
+    if (index == StandardIndexes.forward()
+        && context.getFieldSpec().getDataType() == FieldSpec.DataType.MAP
+        && fieldIndexConfigs.getConfig(StandardIndexes.columnarMap()).isEnabled()) {
+      return;
+    }
     C config = fieldIndexConfigs.getConfig(index);
     if (config.isEnabled()) {
-      creatorsByIndex.put(index, index.createIndexCreator(context, config));
+      IndexCreator creator = index.createIndexCreator(context, config);
+      if (creator != null) {
+        creatorsByIndex.put(index, creator);
+      }
     }
   }
 
@@ -420,6 +429,7 @@ public abstract class BaseSegmentCreator implements SegmentCreator {
     properties.setProperty(METRICS, _config.getMetrics());
     properties.setProperty(DATETIME_COLUMNS, _config.getDateTimeColumnNames());
     properties.setProperty(COMPLEX_COLUMNS, _config.getComplexColumnNames());
+    properties.setProperty(COLUMNAR_MAP_COLUMNS, _config.getColumnarMapColumnNames());
     String timeColumnName = _config.getTimeColumnName();
     properties.setProperty(TIME_COLUMN_NAME, timeColumnName);
     properties.setProperty(SEGMENT_TOTAL_DOCS, String.valueOf(_totalDocs));
@@ -602,6 +612,29 @@ public abstract class BaseSegmentCreator implements SegmentCreator {
       DateTimeFieldSpec dateTimeFieldSpec = (DateTimeFieldSpec) fieldSpec;
       properties.setProperty(getKeyFor(column, DATETIME_FORMAT), dateTimeFieldSpec.getFormat());
       properties.setProperty(getKeyFor(column, DATETIME_GRANULARITY), dateTimeFieldSpec.getGranularity());
+    }
+
+    // MAP field with columnar map index: persist key-type declarations so they survive segment reload.
+    // Each key name and its type are stored as separate properties to avoid comma-delimiter
+    // issues in PropertiesConfiguration multi-value parsing.
+    if (dataType == DataType.MAP && fieldSpec instanceof ComplexFieldSpec) {
+      ComplexFieldSpec complexSpec = (ComplexFieldSpec) fieldSpec;
+      ComplexFieldSpec.MapFieldSpec mapFieldSpec = ComplexFieldSpec.toMapFieldSpec(complexSpec);
+      Map<String, DataType> keyTypes = mapFieldSpec.getKeyTypes();
+      if (keyTypes != null && !keyTypes.isEmpty()) {
+        properties.setProperty(getKeyFor(column, COLUMNAR_MAP_KEY_NAMES),
+            new ArrayList<>(keyTypes.keySet()));
+        for (Map.Entry<String, DataType> entry : keyTypes.entrySet()) {
+          properties.setProperty(
+              getKeyFor(column, COLUMNAR_MAP_KEY_TYPE_PREFIX + "." + entry.getKey()),
+              entry.getValue().name());
+        }
+      }
+      DataType defaultValueType = mapFieldSpec.getDefaultValueType();
+      if (defaultValueType != null) {
+        properties.setProperty(getKeyFor(column, COLUMNAR_MAP_DEFAULT_VALUE_TYPE),
+            defaultValueType.name());
+      }
     }
 
     if (fieldType != FieldType.COMPLEX) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/ColumnarMapColumnPreIndexStatsCollector.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/ColumnarMapColumnPreIndexStatsCollector.java
@@ -1,0 +1,79 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.creator.impl.stats;
+
+import org.apache.pinot.segment.spi.creator.StatsCollectorConfig;
+
+
+/**
+ * Statistics collector for MAP columns with columnar map index.
+ *
+ * <p>Unlike regular columns, MAP columns with columnar map index store all per-key data in the ColumnarMapIndex itself.
+ * This collector only tracks document count; no min/max/cardinality/dictionary is needed.
+ */
+public class ColumnarMapColumnPreIndexStatsCollector extends AbstractColumnStatisticsCollector {
+
+  private boolean _sealed = false;
+
+  public ColumnarMapColumnPreIndexStatsCollector(String column, StatsCollectorConfig statsCollectorConfig) {
+    super(column, statsCollectorConfig);
+    _sorted = false;
+  }
+
+  @Override
+  public void collect(Object entry) {
+    assert !_sealed;
+    _totalNumberOfEntries++;
+  }
+
+  @Override
+  public Comparable getMinValue() {
+    return null;
+  }
+
+  @Override
+  public Comparable getMaxValue() {
+    return null;
+  }
+
+  @Override
+  public Object getUniqueValuesSet() {
+    return null;
+  }
+
+  @Override
+  public int getCardinality() {
+    return 0;
+  }
+
+  @Override
+  public int getLengthOfLongestElement() {
+    return 0;
+  }
+
+  @Override
+  public int getLengthOfShortestElement() {
+    return 0;
+  }
+
+  @Override
+  public void seal() {
+    _sealed = true;
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/StatsCollectorUtil.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/StatsCollectorUtil.java
@@ -44,7 +44,7 @@ public final class StatsCollectorUtil {
       FieldIndexConfigs indexConfig, StatsCollectorConfig statsCollectorConfig) {
     boolean dictionaryEnabled = indexConfig.getConfig(StandardIndexes.dictionary()).isEnabled();
     if (!dictionaryEnabled) {
-      // MAP collector is optimised for no-dictionary collection
+      // MAP collectors are optimised for no-dictionary collection
       if (!fieldSpec.getDataType().getStoredType().equals(FieldSpec.DataType.MAP)) {
         if (ClusterConfigForTable.useOptimizedNoDictCollector(statsCollectorConfig.getTableConfig())) {
           return new NoDictColumnStatisticsCollector(columnName, statsCollectorConfig);
@@ -67,6 +67,9 @@ public final class StatsCollectorUtil {
       case BYTES:
         return new BytesColumnPreIndexStatsCollector(columnName, statsCollectorConfig);
       case MAP:
+        if (indexConfig.getConfig(StandardIndexes.columnarMap()).isEnabled()) {
+          return new ColumnarMapColumnPreIndexStatsCollector(columnName, statsCollectorConfig);
+        }
         return new MapColumnPreIndexStatsCollector(columnName, statsCollectorConfig);
       default:
         throw new IllegalStateException("Unsupported data type: " + fieldSpec.getDataType());

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/columnarmap/ColumnarMapIndexHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/columnarmap/ColumnarMapIndexHandler.java
@@ -1,0 +1,104 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.columnarmap;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.apache.pinot.segment.local.segment.index.loader.BaseIndexHandler;
+import org.apache.pinot.segment.spi.index.FieldIndexConfigs;
+import org.apache.pinot.segment.spi.index.FieldIndexConfigsUtil;
+import org.apache.pinot.segment.spi.index.StandardIndexes;
+import org.apache.pinot.segment.spi.store.SegmentDirectory;
+import org.apache.pinot.spi.config.table.ColumnarMapIndexConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.data.Schema;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Handles loading, adding and removing ColumnarMap indexes during segment reload.
+ *
+ * <p>Note: ColumnarMap indexes are created during segment ingestion only. This handler manages
+ * removal of the index when the table config disables it. Creating a new ColumnarMap index
+ * from an existing segment is not supported (requires re-ingestion).
+ *
+ * <p>Segment merge: when segments are merged (e.g., via the Minion merge task), the sparse map
+ * index is rebuilt from scratch by re-ingesting all documents through
+ * {@link OnHeapColumnarMapIndexCreator}. The resulting merged index contains the union of all
+ * keys observed across the merged segments, subject to the {@code maxKeys} limit configured
+ * for the merged segment. No explicit merge handler is needed; the creator handles key-set
+ * union naturally as documents are added in sequence.
+ */
+public class ColumnarMapIndexHandler extends BaseIndexHandler {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ColumnarMapIndexHandler.class);
+
+  private final Map<String, ColumnarMapIndexConfig> _columnarMapIndexConfigs;
+
+  public ColumnarMapIndexHandler(SegmentDirectory segmentDirectory, Map<String, FieldIndexConfigs> fieldIndexConfigs,
+      TableConfig tableConfig, Schema schema) {
+    super(segmentDirectory, fieldIndexConfigs, tableConfig, schema);
+    _columnarMapIndexConfigs =
+        FieldIndexConfigsUtil.enableConfigByColumn(StandardIndexes.columnarMap(), _fieldIndexConfigs);
+  }
+
+  @Override
+  public boolean needUpdateIndices(SegmentDirectory.Reader segmentReader) {
+    String segmentName = _segmentDirectory.getSegmentMetadata().getName();
+    Set<String> columnsToAddIdx = new HashSet<>(_columnarMapIndexConfigs.keySet());
+    Set<String> existingColumns =
+        segmentReader.toSegmentDirectory().getColumnsWithIndex(StandardIndexes.columnarMap());
+    for (String column : existingColumns) {
+      if (!columnsToAddIdx.contains(column)) {
+        LOGGER.info("Need to remove existing ColumnarMap index from segment: {}, column: {}", segmentName, column);
+        return true;
+      }
+    }
+    return false;
+  }
+
+  @Override
+  public void updateIndices(SegmentDirectory.Writer segmentWriter)
+      throws Exception {
+    String segmentName = _segmentDirectory.getSegmentMetadata().getName();
+    Set<String> columnsToAddIdx = new HashSet<>(_columnarMapIndexConfigs.keySet());
+    Set<String> existingColumns =
+        segmentWriter.toSegmentDirectory().getColumnsWithIndex(StandardIndexes.columnarMap());
+    for (String column : existingColumns) {
+      if (!columnsToAddIdx.contains(column)) {
+        LOGGER.info("Removing existing ColumnarMap index from segment: {}, column: {}", segmentName, column);
+        segmentWriter.removeIndex(column, StandardIndexes.columnarMap());
+        LOGGER.info("Removed ColumnarMap index from segment: {}, column: {}", segmentName, column);
+      }
+    }
+    for (String column : columnsToAddIdx) {
+      if (!existingColumns.contains(column)) {
+        LOGGER.warn(
+            "Cannot add ColumnarMap index to existing segment: {}, column: {}. Re-ingest the segment to create the "
+                + "ColumnarMap index.", segmentName, column);
+      }
+    }
+  }
+
+  @Override
+  public void postUpdateIndicesCleanup(SegmentDirectory.Writer segmentWriter) {
+    // No temporary forward index to clean up for ColumnarMap indexes.
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/columnarmap/ColumnarMapIndexPlugin.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/columnarmap/ColumnarMapIndexPlugin.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.columnarmap;
+
+import com.google.auto.service.AutoService;
+import org.apache.pinot.segment.spi.index.IndexPlugin;
+
+
+/** Registers {@link ColumnarMapIndexType} via AutoService for SPI discovery. */
+@AutoService(IndexPlugin.class)
+public class ColumnarMapIndexPlugin implements IndexPlugin<ColumnarMapIndexType> {
+  public static final ColumnarMapIndexType INSTANCE = new ColumnarMapIndexType();
+
+  @Override
+  public ColumnarMapIndexType getIndexType() {
+    return INSTANCE;
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/columnarmap/ColumnarMapIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/columnarmap/ColumnarMapIndexType.java
@@ -1,0 +1,147 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.columnarmap;
+
+import com.google.common.base.Preconditions;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.apache.pinot.segment.spi.ColumnMetadata;
+import org.apache.pinot.segment.spi.V1Constants;
+import org.apache.pinot.segment.spi.creator.IndexCreationContext;
+import org.apache.pinot.segment.spi.index.AbstractIndexType;
+import org.apache.pinot.segment.spi.index.ColumnConfigDeserializer;
+import org.apache.pinot.segment.spi.index.FieldIndexConfigs;
+import org.apache.pinot.segment.spi.index.IndexConfigDeserializer;
+import org.apache.pinot.segment.spi.index.IndexHandler;
+import org.apache.pinot.segment.spi.index.IndexReaderConstraintException;
+import org.apache.pinot.segment.spi.index.IndexReaderFactory;
+import org.apache.pinot.segment.spi.index.IndexType;
+import org.apache.pinot.segment.spi.index.StandardIndexes;
+import org.apache.pinot.segment.spi.index.creator.ColumnarMapIndexCreator;
+import org.apache.pinot.segment.spi.index.mutable.MutableIndex;
+import org.apache.pinot.segment.spi.index.mutable.provider.MutableIndexContext;
+import org.apache.pinot.segment.spi.index.reader.ColumnarMapIndexReader;
+import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
+import org.apache.pinot.segment.spi.store.SegmentDirectory;
+import org.apache.pinot.spi.config.table.ColumnarMapIndexConfig;
+import org.apache.pinot.spi.config.table.FieldConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+
+
+/**
+ * Index type for MAP columns with columnar map index. Provides per-key columnar storage with presence bitmaps,
+ * typed forward indexes, and optional inverted indexes for fast value-based filtering.
+ */
+public class ColumnarMapIndexType
+    extends AbstractIndexType<ColumnarMapIndexConfig, ColumnarMapIndexReader, ColumnarMapIndexCreator> {
+  public static final String INDEX_DISPLAY_NAME = "columnar_map";
+  private static final List<String> EXTENSIONS =
+      Collections.singletonList(V1Constants.Indexes.COLUMNAR_MAP_INDEX_FILE_EXTENSION);
+
+  protected ColumnarMapIndexType() {
+    super(StandardIndexes.COLUMNAR_MAP_ID);
+  }
+
+  @Override
+  public Class<ColumnarMapIndexConfig> getIndexConfigClass() {
+    return ColumnarMapIndexConfig.class;
+  }
+
+  @Override
+  public ColumnarMapIndexConfig getDefaultConfig() {
+    return ColumnarMapIndexConfig.DISABLED;
+  }
+
+  @Override
+  protected ColumnConfigDeserializer<ColumnarMapIndexConfig> createDeserializerForLegacyConfigs() {
+    return IndexConfigDeserializer.fromIndexTypes(FieldConfig.IndexType.COLUMNAR_MAP,
+        (tableConfig, fieldConfig) -> ColumnarMapIndexConfig.fromProperties(fieldConfig.getProperties()));
+  }
+
+  @Override
+  public void validate(FieldIndexConfigs indexConfigs, FieldSpec fieldSpec, TableConfig tableConfig) {
+    ColumnarMapIndexConfig config = indexConfigs.getConfig(this);
+    if (config.isEnabled()) {
+      String column = fieldSpec.getName();
+      Preconditions.checkState(fieldSpec.isSingleValueField(),
+          "Cannot create ColumnarMap index on multi-value column: %s", column);
+      Preconditions.checkState(fieldSpec.getDataType() == FieldSpec.DataType.MAP,
+          "ColumnarMap index can only be created on MAP columns, got: %s for column: %s",
+          fieldSpec.getDataType(), column);
+    }
+  }
+
+  @Override
+  public String getPrettyName() {
+    return INDEX_DISPLAY_NAME;
+  }
+
+  @Override
+  public ColumnarMapIndexCreator createIndexCreator(IndexCreationContext context, ColumnarMapIndexConfig indexConfig)
+      throws IOException {
+    return new OnHeapColumnarMapIndexCreator(context, indexConfig);
+  }
+
+  @Override
+  protected IndexReaderFactory<ColumnarMapIndexReader> createReaderFactory() {
+    return new IndexReaderFactory.Default<ColumnarMapIndexConfig, ColumnarMapIndexReader>() {
+      @Override
+      protected IndexType<ColumnarMapIndexConfig, ColumnarMapIndexReader, ?> getIndexType() {
+        return ColumnarMapIndexType.this;
+      }
+
+      @Override
+      protected ColumnarMapIndexReader createIndexReader(PinotDataBuffer dataBuffer, ColumnMetadata metadata,
+          ColumnarMapIndexConfig indexConfig)
+          throws IOException, IndexReaderConstraintException {
+        return new ImmutableColumnarMapIndexReader(dataBuffer, metadata);
+      }
+    };
+  }
+
+  @Override
+  public List<String> getFileExtensions(@Nullable ColumnMetadata columnMetadata) {
+    return EXTENSIONS;
+  }
+
+  @Override
+  public IndexHandler createIndexHandler(SegmentDirectory segmentDirectory, Map<String, FieldIndexConfigs> configsByCol,
+      Schema schema, TableConfig tableConfig) {
+    return new ColumnarMapIndexHandler(segmentDirectory, configsByCol, tableConfig, schema);
+  }
+
+  @Nullable
+  @Override
+  public MutableIndex createMutableIndex(MutableIndexContext context, ColumnarMapIndexConfig config) {
+    if (!config.isEnabled()) {
+      return null;
+    }
+    if (context.getFieldSpec().getDataType() != FieldSpec.DataType.MAP) {
+      return null;
+    }
+    // TODO: Implement MutableColumnarMapIndexImpl in PR 2 (query layer).
+    //  Until then, REALTIME tables with COLUMNAR_MAP will fail at segment creation.
+    throw new UnsupportedOperationException("Mutable COLUMNAR_MAP index not available in this build");
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/columnarmap/ColumnarMapKeyDictionary.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/columnarmap/ColumnarMapKeyDictionary.java
@@ -1,0 +1,336 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.columnarmap;
+
+import com.google.common.base.Preconditions;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.ints.IntSet;
+import it.unimi.dsi.fastutil.ints.IntSets;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Comparator;
+import org.apache.pinot.common.request.context.predicate.RangePredicate;
+import org.apache.pinot.segment.spi.index.reader.Dictionary;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.utils.ByteArray;
+import org.apache.pinot.spi.utils.BytesUtils;
+
+
+/**
+ * In-memory {@link Dictionary} implementation backed by sorted distinct values extracted from the
+ * columnar map value dictionary section. Enables dictionary-based GROUP BY for columnar map key columns.
+ *
+ * <p>All values are stored as sorted strings regardless of the key's declared type, with typed
+ * parsing on demand (e.g. {@code Integer.parseInt} in {@link #getIntValue}). This string-based
+ * approach was chosen because:
+ * <ul>
+ *   <li>SQL predicates arrive as strings ({@code WHERE metrics['clicks'] = '42'}) — even with
+ *       native typed arrays, the predicate string would need parsing for binary search</li>
+ *   <li>Dictionary value reads only happen when materializing final results (small result set);
+ *       the hot path for GROUP BY is {@code readDictIds()} on the bit-packed forward index</li>
+ *   <li>A single code path for all types keeps the writer, reader, and dictionary simple —
+ *       typed arrays would mean 4+ code paths with more surface area for bugs</li>
+ * </ul>
+ *
+ * <p>TODO: If profiling shows dictionary value access is a bottleneck, switch to native typed
+ * arrays (int[], long[], double[], String[]) for zero-parse forward lookups and type-aware
+ * binary search for indexOf. This would require corresponding changes in
+ * {@link OnHeapColumnarMapIndexCreator#buildValueDictionarySection} (write fixed-width values)
+ * and {@link ImmutableColumnarMapIndexReader} (read into typed arrays).
+ *
+ * <p>The reverse map provides O(1) string-to-dictId lookup. Since the source values come from a
+ * sorted inverted index (TreeMap or sorted binary scan), the dictionary is always sorted.
+ *
+ * <p>Thread safety: this class is immutable after construction and safe for concurrent reads.
+ */
+public class ColumnarMapKeyDictionary implements Dictionary {
+
+  private final DataType _valueType;
+  private final String[] _sortedValues;
+  private final Object2IntOpenHashMap<String> _valueToIdMap;
+
+  public ColumnarMapKeyDictionary(DataType valueType, String[] sortedDistinctValues) {
+    _valueType = valueType;
+    _sortedValues = sortedDistinctValues;
+    _valueToIdMap = new Object2IntOpenHashMap<>(sortedDistinctValues.length);
+    _valueToIdMap.defaultReturnValue(NULL_VALUE_INDEX);
+    for (int i = 0; i < sortedDistinctValues.length; i++) {
+      _valueToIdMap.put(sortedDistinctValues[i], i);
+    }
+  }
+
+  @Override
+  public boolean isSorted() {
+    return true;
+  }
+
+  @Override
+  public DataType getValueType() {
+    return _valueType;
+  }
+
+  @Override
+  public int length() {
+    return _sortedValues.length;
+  }
+
+  @Override
+  public int indexOf(String stringValue) {
+    return _valueToIdMap.getInt(stringValue);
+  }
+
+  @Override
+  public int indexOf(int intValue) {
+    return indexOf(String.valueOf(intValue));
+  }
+
+  @Override
+  public int indexOf(long longValue) {
+    return indexOf(String.valueOf(longValue));
+  }
+
+  @Override
+  public int indexOf(float floatValue) {
+    return indexOf(String.valueOf(floatValue));
+  }
+
+  @Override
+  public int indexOf(double doubleValue) {
+    return indexOf(String.valueOf(doubleValue));
+  }
+
+  @Override
+  public int indexOf(BigDecimal bigDecimalValue) {
+    return indexOf(bigDecimalValue.toPlainString());
+  }
+
+  @Override
+  public int indexOf(ByteArray bytesValue) {
+    return indexOf(bytesValue.toHexString());
+  }
+
+  @Override
+  public int insertionIndexOf(String stringValue) {
+    int index = _valueToIdMap.getInt(stringValue);
+    if (index != NULL_VALUE_INDEX) {
+      return index;
+    }
+    Comparator<String> cmp = getComparator(_valueType);
+    if (cmp != null) {
+      return Arrays.binarySearch(_sortedValues, stringValue, cmp);
+    }
+    return Arrays.binarySearch(_sortedValues, stringValue);
+  }
+
+  @Override
+  public IntSet getDictIdsInRange(String lower, String upper, boolean includeLower, boolean includeUpper) {
+    int numValues = _sortedValues.length;
+    if (numValues == 0) {
+      return IntSets.EMPTY_SET;
+    }
+
+    // Determine the start index (inclusive) using binary search on the sorted array.
+    int startIndex;
+    if (lower.equals(RangePredicate.UNBOUNDED)) {
+      startIndex = 0;
+    } else {
+      int idx = binarySearch(lower);
+      if (idx >= 0) {
+        // Exact match found
+        startIndex = includeLower ? idx : idx + 1;
+      } else {
+        // Not found: insertion point is -(idx + 1), the first element greater than lower
+        startIndex = -(idx + 1);
+      }
+    }
+
+    // Determine the end index (exclusive) using binary search on the sorted array.
+    int endIndex;
+    if (upper.equals(RangePredicate.UNBOUNDED)) {
+      endIndex = numValues;
+    } else {
+      int idx = binarySearch(upper);
+      if (idx >= 0) {
+        // Exact match found
+        endIndex = includeUpper ? idx + 1 : idx;
+      } else {
+        // Not found: insertion point is the first element greater than upper
+        endIndex = -(idx + 1);
+      }
+    }
+
+    int count = endIndex - startIndex;
+    if (count <= 0) {
+      return IntSets.EMPTY_SET;
+    }
+    IntSet dictIds = new IntOpenHashSet(count);
+    for (int i = startIndex; i < endIndex; i++) {
+      dictIds.add(i);
+    }
+    return dictIds;
+  }
+
+  /// Performs a binary search on the sorted values array using the type-appropriate comparator.
+  private int binarySearch(String value) {
+    Comparator<String> cmp = getComparator(_valueType);
+    if (cmp != null) {
+      return Arrays.binarySearch(_sortedValues, value, cmp);
+    }
+    return Arrays.binarySearch(_sortedValues, value);
+  }
+
+  @Override
+  public int compare(int dictId1, int dictId2) {
+    return Integer.compare(dictId1, dictId2);
+  }
+
+  @Override
+  public Comparable getMinVal() {
+    if (_sortedValues.length == 0) {
+      return null;
+    }
+    return parseValue(_sortedValues[0]);
+  }
+
+  @Override
+  public Comparable getMaxVal() {
+    if (_sortedValues.length == 0) {
+      return null;
+    }
+    return parseValue(_sortedValues[_sortedValues.length - 1]);
+  }
+
+  @Override
+  public Object getSortedValues() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Object get(int dictId) {
+    checkDictId(dictId);
+    return parseValue(_sortedValues[dictId]);
+  }
+
+  @Override
+  public int getIntValue(int dictId) {
+    checkDictId(dictId);
+    return Integer.parseInt(_sortedValues[dictId]);
+  }
+
+  @Override
+  public long getLongValue(int dictId) {
+    checkDictId(dictId);
+    return Long.parseLong(_sortedValues[dictId]);
+  }
+
+  @Override
+  public float getFloatValue(int dictId) {
+    checkDictId(dictId);
+    return Float.parseFloat(_sortedValues[dictId]);
+  }
+
+  @Override
+  public double getDoubleValue(int dictId) {
+    checkDictId(dictId);
+    return Double.parseDouble(_sortedValues[dictId]);
+  }
+
+  @Override
+  public BigDecimal getBigDecimalValue(int dictId) {
+    checkDictId(dictId);
+    return new BigDecimal(_sortedValues[dictId]);
+  }
+
+  @Override
+  public String getStringValue(int dictId) {
+    checkDictId(dictId);
+    return _sortedValues[dictId];
+  }
+
+  @Override
+  public byte[] getBytesValue(int dictId) {
+    checkDictId(dictId);
+    return BytesUtils.toBytes(_sortedValues[dictId]);
+  }
+
+  private void checkDictId(int dictId) {
+    Preconditions.checkArgument(dictId >= 0 && dictId < _sortedValues.length,
+        "Invalid dictId: %s, dictionary size: %s", dictId, _sortedValues.length);
+  }
+
+  @Override
+  public void close()
+      throws IOException {
+    // no-op: in-memory dictionary
+  }
+
+  private Comparable parseValue(String stringValue) {
+    switch (_valueType) {
+      case INT:
+        return Integer.parseInt(stringValue);
+      case LONG:
+        return Long.parseLong(stringValue);
+      case FLOAT:
+        return Float.parseFloat(stringValue);
+      case DOUBLE:
+        return Double.parseDouble(stringValue);
+      default:
+        return stringValue;
+    }
+  }
+
+  /**
+   * Returns the string representation of the default (null-substitute) value for the given type.
+   * INT/LONG default to "0", FLOAT/DOUBLE to "0.0", and STRING/BYTES to "".
+   */
+  static String getDefaultValueString(DataType dataType) {
+    switch (dataType) {
+      case INT:
+        return "0";
+      case LONG:
+        return "0";
+      case FLOAT:
+        return "0.0";
+      case DOUBLE:
+        return "0.0";
+      default:
+        return "";
+    }
+  }
+
+  /**
+   * Returns a numeric comparator for the given type, or null for STRING/BYTES (lexicographic).
+   */
+  static Comparator<String> getComparator(DataType valueType) {
+    switch (valueType) {
+      case INT:
+        return Comparator.comparingInt(Integer::parseInt);
+      case LONG:
+        return Comparator.comparingLong(Long::parseLong);
+      case FLOAT:
+        return (a, b) -> Float.compare(Float.parseFloat(a), Float.parseFloat(b));
+      case DOUBLE:
+        return Comparator.comparingDouble(Double::parseDouble);
+      default:
+        return null;
+    }
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/columnarmap/ColumnarMapKeyForwardIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/columnarmap/ColumnarMapKeyForwardIndexReader.java
@@ -1,0 +1,223 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.columnarmap;
+
+import java.io.IOException;
+import javax.annotation.Nullable;
+import org.apache.pinot.segment.local.io.util.FixedBitIntReaderWriter;
+import org.apache.pinot.segment.spi.index.reader.ColumnarMapIndexReader;
+import org.apache.pinot.segment.spi.index.reader.ForwardIndexReader;
+import org.apache.pinot.segment.spi.index.reader.ForwardIndexReaderContext;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.roaringbitmap.PeekableIntIterator;
+import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
+
+
+/**
+ * A per-key {@link ForwardIndexReader} backed by a {@link ColumnarMapIndexReader}.
+ *
+ * <p>Each instance is bound to a single key within a MAP column. Reads for document IDs
+ * that do not contain the key return the type-appropriate zero/empty default value; the caller can
+ * combine this with the presence bitmap ({@link ColumnarMapIndexReader#getPresenceBitmap}) when null
+ * semantics are required.
+ *
+ * <p>When a {@link ColumnarMapKeyDictionary} is provided, this reader supports dictionary-encoded
+ * access via {@link #readDictIds}, enabling dictionary-based GROUP BY operations.
+ *
+ * <p>No context is needed because the {@link ColumnarMapIndexReader} implementations maintain their
+ * own internal state; {@link #createContext()} therefore returns {@code null}.
+ *
+ * <p>Lifecycle: this reader does NOT own the underlying {@link ColumnarMapIndexReader}—closing this
+ * reader is a no-op. The owning {@link ColumnarMapDataSource} is responsible for closing the reader.
+ */
+public class ColumnarMapKeyForwardIndexReader implements ForwardIndexReader<ForwardIndexReaderContext> {
+
+  private final ColumnarMapIndexReader _columnarMapIndexReader;
+  private final String _key;
+  private final DataType _storedType;
+  @Nullable
+  private final ColumnarMapKeyDictionary _dictionary;
+  @Nullable
+  private final FixedBitIntReaderWriter _dictIdReader;
+  private final ImmutableRoaringBitmap _presenceBitmap;
+  private final int _defaultDictId;
+  private final boolean _isDense;
+
+  public ColumnarMapKeyForwardIndexReader(ColumnarMapIndexReader columnarMapIndexReader, String key,
+      DataType storedType) {
+    this(columnarMapIndexReader, key, storedType, null, null, null, false);
+  }
+
+  public ColumnarMapKeyForwardIndexReader(ColumnarMapIndexReader columnarMapIndexReader, String key,
+      DataType storedType, @Nullable ColumnarMapKeyDictionary dictionary) {
+    this(columnarMapIndexReader, key, storedType, dictionary, null, null, false);
+  }
+
+  public ColumnarMapKeyForwardIndexReader(ColumnarMapIndexReader columnarMapIndexReader, String key,
+      DataType storedType, @Nullable ColumnarMapKeyDictionary dictionary,
+      @Nullable FixedBitIntReaderWriter dictIdReader) {
+    this(columnarMapIndexReader, key, storedType, dictionary, dictIdReader, null, false);
+  }
+
+  public ColumnarMapKeyForwardIndexReader(ColumnarMapIndexReader columnarMapIndexReader, String key,
+      DataType storedType, @Nullable ColumnarMapKeyDictionary dictionary,
+      @Nullable FixedBitIntReaderWriter dictIdReader,
+      @Nullable ImmutableRoaringBitmap presenceBitmap) {
+    this(columnarMapIndexReader, key, storedType, dictionary, dictIdReader, presenceBitmap, false);
+  }
+
+  public ColumnarMapKeyForwardIndexReader(ColumnarMapIndexReader columnarMapIndexReader, String key,
+      DataType storedType, @Nullable ColumnarMapKeyDictionary dictionary,
+      @Nullable FixedBitIntReaderWriter dictIdReader,
+      @Nullable ImmutableRoaringBitmap presenceBitmap, boolean isDense) {
+    _columnarMapIndexReader = columnarMapIndexReader;
+    _key = key;
+    _storedType = storedType;
+    _dictionary = dictionary;
+    _dictIdReader = dictIdReader;
+    _presenceBitmap = presenceBitmap != null ? presenceBitmap : ImmutableRoaringBitmap.bitmapOf();
+    _isDense = isDense;
+    if (dictionary != null) {
+      String defaultValueStr = ColumnarMapKeyDictionary.getDefaultValueString(storedType);
+      _defaultDictId = dictionary.indexOf(defaultValueStr);
+    } else {
+      _defaultDictId = 0;
+    }
+  }
+
+  @Override
+  public boolean isDictionaryEncoded() {
+    return _dictionary != null;
+  }
+
+  @Override
+  public boolean isSingleValue() {
+    return true;
+  }
+
+  @Override
+  public DataType getStoredType() {
+    return _storedType;
+  }
+
+  /**
+   * Batch-reads dictionary IDs for a sorted array of document IDs.
+   *
+   * <p>When a sparse dictId forward index is available, this method uses a co-iteration
+   * strategy instead of per-document {@code rank()} calls. A single {@code rankLong()} seeds
+   * the ordinal for the first docId in the batch, then a {@link PeekableIntIterator} walks
+   * the presence bitmap forward alongside the sorted docIds. This reduces per-block cost
+   * from O(blockSize × numContainers) to O(numContainers + blockSize).
+   *
+   * <p>Absent docs return {@code _defaultDictId} — the dictId of the type's default value
+   * (0 for INT/LONG, 0.0 for FLOAT/DOUBLE, "" for STRING). This matches Pinot's standard
+   * nullable column behavior where nulls are indistinguishable from the default value when
+   * null handling is not enabled.
+   *
+   * <p><b>Contract:</b> {@code docIds} must be in ascending order (always true for Pinot
+   * query blocks).
+   */
+  @Override
+  public void readDictIds(int[] docIds, int length, int[] dictIdBuffer, ForwardIndexReaderContext context) {
+    if (_dictionary == null) {
+      throw new UnsupportedOperationException("Dictionary not available for key: " + _key);
+    }
+    if (_dictIdReader != null) {
+      if (_isDense) {
+        // Dense key: direct docId access (full forward index with numDocs entries)
+        // Use batch read when docIds are contiguous (common in full-scan GROUP BY)
+        if (length > 1 && docIds[length - 1] - docIds[0] == length - 1) {
+          _dictIdReader.readInt(docIds[0], length, dictIdBuffer);
+        } else {
+          for (int i = 0; i < length; i++) {
+            dictIdBuffer[i] = _dictIdReader.readInt(docIds[i]);
+          }
+        }
+        return;
+      }
+      // Sparse key: co-iterate sorted docIds with presence bitmap iterator.
+      // Seed ordinal with one rankLong() call for the first docId, then walk forward.
+      int firstDocId = docIds[0];
+      PeekableIntIterator iter = _presenceBitmap.getIntIterator();
+      iter.advanceIfNeeded(firstDocId);
+      int ordinal = (firstDocId == 0) ? 0 : (int) _presenceBitmap.rankLong(firstDocId - 1);
+
+      for (int i = 0; i < length; i++) {
+        int docId = docIds[i];
+        while (iter.hasNext() && iter.peekNext() < docId) {
+          iter.next();
+          ordinal++;
+        }
+        if (iter.hasNext() && iter.peekNext() == docId) {
+          dictIdBuffer[i] = _dictIdReader.readInt(ordinal);
+          iter.next();
+          ordinal++;
+        } else {
+          dictIdBuffer[i] = _defaultDictId;
+        }
+      }
+    } else {
+      // Slow path: getString + indexOf for mutable segments
+      for (int i = 0; i < length; i++) {
+        String rawValue = _columnarMapIndexReader.getString(docIds[i], _key);
+        if (rawValue == null || rawValue.isEmpty()) {
+          dictIdBuffer[i] = _defaultDictId;
+        } else {
+          dictIdBuffer[i] = _dictionary.indexOf(rawValue);
+        }
+      }
+    }
+  }
+
+  @Override
+  public int getInt(int docId, ForwardIndexReaderContext context) {
+    return _columnarMapIndexReader.getInt(docId, _key);
+  }
+
+  @Override
+  public long getLong(int docId, ForwardIndexReaderContext context) {
+    return _columnarMapIndexReader.getLong(docId, _key);
+  }
+
+  @Override
+  public float getFloat(int docId, ForwardIndexReaderContext context) {
+    return _columnarMapIndexReader.getFloat(docId, _key);
+  }
+
+  @Override
+  public double getDouble(int docId, ForwardIndexReaderContext context) {
+    return _columnarMapIndexReader.getDouble(docId, _key);
+  }
+
+  @Override
+  public String getString(int docId, ForwardIndexReaderContext context) {
+    return _columnarMapIndexReader.getString(docId, _key);
+  }
+
+  @Override
+  public byte[] getBytes(int docId, ForwardIndexReaderContext context) {
+    return _columnarMapIndexReader.getBytes(docId, _key);
+  }
+
+  @Override
+  public void close()
+      throws IOException {
+    // no-op: the underlying reader is owned by ColumnarMapDataSource
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/columnarmap/ColumnarMapKeyInvertedIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/columnarmap/ColumnarMapKeyInvertedIndexReader.java
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.columnarmap;
+
+import java.io.IOException;
+import org.apache.pinot.segment.spi.index.reader.InvertedIndexReader;
+import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
+
+
+/**
+ * Adapts the per-key inverted index from {@link ImmutableColumnarMapIndexReader} into the
+ * standard {@link InvertedIndexReader} interface expected by {@code InvertedIndexFilterOperator}.
+ *
+ * <p>Maps dictId → value string (via dictionary) → docId bitmap (via getDocsWithKeyValue).
+ */
+public class ColumnarMapKeyInvertedIndexReader implements InvertedIndexReader<ImmutableRoaringBitmap> {
+
+  private final ImmutableColumnarMapIndexReader _reader;
+  private final String _key;
+  private final ColumnarMapKeyDictionary _dictionary;
+
+  public ColumnarMapKeyInvertedIndexReader(ImmutableColumnarMapIndexReader reader, String key,
+      ColumnarMapKeyDictionary dictionary) {
+    _reader = reader;
+    _key = key;
+    _dictionary = dictionary;
+  }
+
+  @Override
+  public ImmutableRoaringBitmap getDocIds(int dictId) {
+    String value = _dictionary.getStringValue(dictId);
+    ImmutableRoaringBitmap bitmap = _reader.getDocsWithKeyValue(_key, value);
+    return bitmap != null ? bitmap : ImmutableRoaringBitmap.bitmapOf();
+  }
+
+  @Override
+  public void close()
+      throws IOException {
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/columnarmap/ImmutableColumnarMapIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/columnarmap/ImmutableColumnarMapIndexReader.java
@@ -1,0 +1,799 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.columnarmap;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.apache.pinot.segment.local.io.util.FixedBitIntReaderWriter;
+import org.apache.pinot.segment.local.io.util.PinotDataBitSet;
+import org.apache.pinot.segment.spi.ColumnMetadata;
+import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.segment.spi.index.reader.ColumnarMapIndexReader;
+import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
+import org.apache.pinot.spi.data.ComplexFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Memory-mapped immutable reader for the ColumnarMap index.
+ * Provides O(1) typed key lookup via presence bitmap rank operations.
+ *
+ * <p>Binary format (CMAP, written by {@link OnHeapColumnarMapIndexCreator}):
+ * <ul>
+ *   <li>Header (72 bytes): magic(int), version(int), numKeys(int), numDocs(int),
+ *       numDenseKeys(int), numSparseKeys(int), keyDictOffset(long),
+ *       keyMetaOffset(long), perKeyDataOffset(long), valueDictOffset(long),
+ *       sparseDataOffset(long), sparseDataLength(long)</li>
+ *   <li>Key dictionary: numKeys(int), per key: keyLen(int) + keyBytes</li>
+ *   <li>Key metadata (70 bytes/key, big-endian): tierFlag(byte), storedTypeOrdinal(byte),
+ *       numDocs(int), nullBitmapOffset(long), nullBitmapLen(long), fwdOffset(long),
+ *       fwdLen(long), invOffset(long), invLen(long), dictIdFwdOffset(long),
+ *       dictIdFwdLen(long)</li>
+ *   <li>Per-key data: null bitmap (RLE-optimized Roaring) + forward index + optional
+ *       inverted index + optional dictId forward index. Dense keys only; sparse keys
+ *       store just a presence bitmap here (reusing the nullBitmap slot).</li>
+ *   <li>Value dictionary: per-key sorted distinct values for dictionary-encoded keys</li>
+ *   <li>Sparse data (5th section): per-doc JSON blobs for sparse-tier keys.
+ *       Layout: numDocs(int) + offsets[(numDocs+1) x int] + UTF-8 JSON blobs.
+ *       Section length is recorded in the header (sparseDataLength); 0 if no sparse keys.</li>
+ * </ul>
+ * <p>Null-means-absent policy: keys with null values are not recorded during ingestion.
+ * A key absent from the presence bitmap is indistinguishable from a key explicitly set to null.
+ */
+public class ImmutableColumnarMapIndexReader implements ColumnarMapIndexReader {
+
+  private static final int MAGIC = 0x434D4150;   // "CMAP" (Columnar MAP)
+  private static final int CURRENT_VERSION = 1;
+  private static final int HEADER_SIZE = 72;
+  private static final int KEY_METADATA_ENTRY_SIZE = 70;
+
+  public static final byte TIER_DENSE = OnHeapColumnarMapIndexCreator.TIER_DENSE;
+  public static final byte TIER_SPARSE = OnHeapColumnarMapIndexCreator.TIER_SPARSE;
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ImmutableColumnarMapIndexReader.class);
+
+  private final PinotDataBuffer _dataBuffer;
+  private final int _numDocs;
+  private final int _numKeys;
+
+  // per-key data (indexed by keyId)
+  private final String[] _keys;
+  private final Map<String, Integer> _keyToId;
+  private final DataType[] _keyStoredTypes;
+  private final int[] _numDocsPerKey;
+  private final byte[] _tierFlags;
+  private final ImmutableRoaringBitmap[] _nullBitmaps;   // null bitmap for dense keys (absent docs)
+  private final ImmutableRoaringBitmap[] _presenceBitmaps;
+
+  // offsets/lengths within _dataBuffer for forward and inverted indexes
+  private final long _perKeyDataSectionOffset;
+  private final long[] _fwdOffsets;
+  private final long[] _fwdLengths;
+  private final long[] _invOffsets;
+  private final long[] _invLengths;
+  private final long[] _dictIdFwdOffsets;
+  private final long[] _dictIdFwdLengths;
+
+  // value dictionary section
+  private final long _valueDictionarySectionOffset;
+  private final Map<String, ColumnarMapKeyDictionary> _keyDictionaries;
+
+  // Pre-built dictId readers for keys with dictionary encoding (indexed by keyId)
+  private final FixedBitIntReaderWriter[] _dictIdReaders;
+
+  // Cached inverted index entry offsets per keyId (avoids O(numUnique) scan per query)
+  private final long[][] _invEntryOffsets;
+
+  // Sparse-tier data: lives at the end of the CMAP byte stream (5th section after value
+  // dictionary). Sliced from _dataBuffer in the constructor when sparseDataLength > 0.
+  // Per-doc JSON blobs are read from the buffer on demand via getSparseJsonBlob(docId).
+  private final PinotDataBuffer _sparseDataBuffer;     // mmapped view, null if no sparse keys
+  private final int[] _sparseOffsets;                  // numDocs+1 offsets into the JSON-data sub-region
+  private final int _sparseDataRegionStart;            // byte offset within _sparseDataBuffer where
+                                                        // the JSON blob bytes begin (after numDocs(4) +
+                                                        // (numDocs+1) * 4 bytes of offsets)
+
+  // Default value type for keys not found in CMAP metadata (from schema's ComplexFieldSpec)
+  @Nullable
+  private final DataType _defaultValueType;
+  private int _numSparseKeys;
+
+  public ImmutableColumnarMapIndexReader(PinotDataBuffer dataBuffer, ColumnMetadata metadata)
+      throws IOException {
+    _dataBuffer = dataBuffer;
+
+    // Extract defaultValueType from schema's ComplexFieldSpec if available
+    if (metadata != null) {
+      FieldSpec fieldSpec = metadata.getFieldSpec();
+      if (fieldSpec instanceof ComplexFieldSpec) {
+        _defaultValueType = ((ComplexFieldSpec) fieldSpec).getDefaultValueType();
+      } else {
+        _defaultValueType = null;
+      }
+    } else {
+      _defaultValueType = null;
+    }
+
+    // ---- Parse Header (BIG_ENDIAN throughout) ----
+    byte[] headerBytes = new byte[HEADER_SIZE];
+    dataBuffer.copyTo(0, headerBytes, 0, HEADER_SIZE);
+    ByteBuffer headerBuf = ByteBuffer.wrap(headerBytes).order(ByteOrder.BIG_ENDIAN);
+    int magic = headerBuf.getInt();
+    if (magic != MAGIC) {
+      throw new IOException(
+          String.format("Invalid ColumnarMap index: expected magic 0x%08X but got 0x%08X", MAGIC, magic));
+    }
+    int version = headerBuf.getInt();
+    if (version != CURRENT_VERSION) {
+      throw new IOException(
+          String.format("CMAP version %d not supported (expected %d). Re-ingest segment to upgrade.",
+              version, CURRENT_VERSION));
+    }
+    _numKeys = headerBuf.getInt();
+    _numDocs = headerBuf.getInt();
+    int numDenseKeys = headerBuf.getInt();
+    int numSparseKeys = headerBuf.getInt();
+    long keyDictOffset = headerBuf.getLong();
+    long keyMetaOffset = headerBuf.getLong();
+    _perKeyDataSectionOffset = headerBuf.getLong();
+    _valueDictionarySectionOffset = headerBuf.getLong();
+    long sparseDataOffset = headerBuf.getLong();
+    long sparseDataLength = headerBuf.getLong();
+    _numSparseKeys = numSparseKeys;
+
+    // ---- Parse Key Dictionary (big-endian) ----
+    _keys = new String[_numKeys];
+    _keyToId = new HashMap<>(_numKeys * 2);
+    long dictPos = keyDictOffset;
+    int dictNumKeys = _dataBuffer.getInt(dictPos);
+    if (dictNumKeys != _numKeys) {
+      throw new IOException("Key dictionary count mismatch: header=" + _numKeys + ", dict=" + dictNumKeys);
+    }
+    dictPos += 4;
+    for (int i = 0; i < _numKeys; i++) {
+      int keyLen = _dataBuffer.getInt(dictPos);
+      dictPos += 4;
+      byte[] keyBytes = new byte[keyLen];
+      dataBuffer.copyTo(dictPos, keyBytes, 0, keyLen);
+      _keys[i] = new String(keyBytes, StandardCharsets.UTF_8);
+      _keyToId.put(_keys[i], i);
+      dictPos += keyLen;
+    }
+
+    // ---- Parse Key Metadata (BIG_ENDIAN, 70 bytes per key) ----
+    _keyStoredTypes = new DataType[_numKeys];
+    _numDocsPerKey = new int[_numKeys];
+    _tierFlags = new byte[_numKeys];
+    _nullBitmaps = new ImmutableRoaringBitmap[_numKeys];
+    _presenceBitmaps = new ImmutableRoaringBitmap[_numKeys];
+    _fwdOffsets = new long[_numKeys];
+    _fwdLengths = new long[_numKeys];
+    _invOffsets = new long[_numKeys];
+    _invLengths = new long[_numKeys];
+    _dictIdFwdOffsets = new long[_numKeys];
+    _dictIdFwdLengths = new long[_numKeys];
+
+    byte[] metaBlock = new byte[_numKeys * KEY_METADATA_ENTRY_SIZE];
+    dataBuffer.copyTo(keyMetaOffset, metaBlock, 0, metaBlock.length);
+    ByteBuffer metaBuf = ByteBuffer.wrap(metaBlock).order(ByteOrder.BIG_ENDIAN);
+    DataType[] allTypes = DataType.values();
+
+    for (int i = 0; i < _numKeys; i++) {
+      _tierFlags[i] = metaBuf.get();
+      int storedTypeOrdinal = metaBuf.get() & 0xFF;
+      if (storedTypeOrdinal >= allTypes.length) {
+        throw new IOException(
+            "Invalid ColumnarMap index: unknown DataType ordinal " + storedTypeOrdinal
+                + " for key index " + i + " (max=" + (allTypes.length - 1) + ")");
+      }
+      _keyStoredTypes[i] = allTypes[storedTypeOrdinal];
+      _numDocsPerKey[i] = metaBuf.getInt();
+      long nullBitmapOffset = metaBuf.getLong();
+      long nullBitmapLen = metaBuf.getLong();
+      _fwdOffsets[i] = metaBuf.getLong();
+      _fwdLengths[i] = metaBuf.getLong();
+      _invOffsets[i] = metaBuf.getLong();
+      _invLengths[i] = metaBuf.getLong();
+      _dictIdFwdOffsets[i] = metaBuf.getLong();
+      _dictIdFwdLengths[i] = metaBuf.getLong();
+
+      if (_tierFlags[i] == TIER_DENSE && nullBitmapLen > 0) {
+        // Dense key: load null bitmap (docs where key is absent)
+        byte[] bitmapBytes = new byte[(int) nullBitmapLen];
+        dataBuffer.copyTo(_perKeyDataSectionOffset + nullBitmapOffset, bitmapBytes, 0, bitmapBytes.length);
+        _nullBitmaps[i] = new ImmutableRoaringBitmap(ByteBuffer.wrap(bitmapBytes));
+        _presenceBitmaps[i] = ImmutableRoaringBitmap.flip(_nullBitmaps[i], 0L, (long) _numDocs);
+      } else if (_tierFlags[i] == TIER_SPARSE) {
+        // Sparse key: no per-key data in CMAP
+        _presenceBitmaps[i] = ImmutableRoaringBitmap.bitmapOf();
+        _nullBitmaps[i] = null;
+      }
+    }
+
+    // ---- Parse Value Dictionary Section ----
+    _keyDictionaries = new HashMap<>();
+    if (_valueDictionarySectionOffset > 0) {
+      long pos = _valueDictionarySectionOffset;
+      for (int i = 0; i < _numKeys; i++) {
+        if (_dictIdFwdLengths[i] == 0 && _invLengths[i] == 0) {
+          continue;
+        }
+        int numDistinctValues = dataBuffer.getInt(pos);
+        pos += 4;
+
+        // skip numBitsPerValue (recomputed from dictionary size when needed)
+        pos += 4;
+
+        String[] values = new String[numDistinctValues];
+        for (int v = 0; v < numDistinctValues; v++) {
+          int vLen = dataBuffer.getInt(pos);
+          pos += 4;
+          byte[] vBytes = new byte[vLen];
+          dataBuffer.copyTo(pos, vBytes, 0, vLen);
+          values[v] = new String(vBytes, StandardCharsets.UTF_8);
+          pos += vLen;
+        }
+        _keyDictionaries.put(_keys[i], new ColumnarMapKeyDictionary(_keyStoredTypes[i], values));
+      }
+    }
+
+    // Pre-build dictId readers for all keys with dictId forward index.
+    // Dense keys: full forward index with _numDocs entries (direct docId access).
+    // Sparse keys: no forward index in CMAP (handled by JSON column).
+    _dictIdReaders = new FixedBitIntReaderWriter[_numKeys];
+    for (int i = 0; i < _numKeys; i++) {
+      if (_dictIdFwdLengths[i] > 0) {
+        ColumnarMapKeyDictionary dict = _keyDictionaries.get(_keys[i]);
+        if (dict != null) {
+          int numBitsPerValue = PinotDataBitSet.getNumBitsPerValue(Math.max(dict.length() - 1, 0));
+          long offset = _perKeyDataSectionOffset + _dictIdFwdOffsets[i];
+          PinotDataBuffer slice = _dataBuffer.view(offset, offset + _dictIdFwdLengths[i]);
+          // Dense keys have _numDocs entries (full forward index)
+          int numEntries = (_tierFlags[i] == TIER_DENSE) ? _numDocs : _numDocsPerKey[i];
+          _dictIdReaders[i] = new FixedBitIntReaderWriter(slice, numEntries, numBitsPerValue);
+        }
+      }
+    }
+
+    // Pre-build inverted index entry offset tables for keys with inverted indexes.
+    // This avoids rebuilding the O(numUnique) offset table on every getDocsWithKeyValue() call.
+    _invEntryOffsets = new long[_numKeys][];
+    for (int i = 0; i < _numKeys; i++) {
+      if (_invLengths[i] > 0) {
+        long invBase = _perKeyDataSectionOffset + _invOffsets[i];
+        int numUnique = _dataBuffer.getInt(invBase);
+        long[] offsets = new long[numUnique];
+        long pos = invBase + 4;
+        for (int j = 0; j < numUnique; j++) {
+          offsets[j] = pos;
+          int vLen = _dataBuffer.getInt(pos);
+          pos += 4 + vLen;
+          int bLen = _dataBuffer.getInt(pos);
+          pos += 4 + bLen;
+        }
+        _invEntryOffsets[i] = offsets;
+      }
+    }
+
+    // ---- Initialize sparse-tier view from CMAP 5th section ----
+    if (sparseDataLength > 0) {
+      _sparseDataBuffer = _dataBuffer.view(sparseDataOffset, sparseDataOffset + sparseDataLength);
+      int sparseNumDocs = _sparseDataBuffer.getInt(0);
+      if (sparseNumDocs != _numDocs) {
+        throw new IOException(String.format(
+            "Sparse section numDocs mismatch: header numDocs=%d, sparse section numDocs=%d",
+            _numDocs, sparseNumDocs));
+      }
+      _sparseOffsets = new int[_numDocs + 1];
+      long offsetTableStart = 4L;  // after numDocs(4)
+      for (int i = 0; i <= _numDocs; i++) {
+        _sparseOffsets[i] = _sparseDataBuffer.getInt(offsetTableStart + 4L * i);
+      }
+      _sparseDataRegionStart = (int) (offsetTableStart + 4L * (_numDocs + 1));
+    } else {
+      _sparseDataBuffer = null;
+      _sparseOffsets = null;
+      _sparseDataRegionStart = 0;
+    }
+  }
+
+  /**
+   * Returns the raw JSON blob string for sparse keys at the given docId,
+   * or null if no sparse keys exist for this doc.
+   */
+  @Nullable
+  public String getSparseJsonBlob(int docId) {
+    if (_sparseDataBuffer == null || _sparseOffsets == null) {
+      return null;
+    }
+    int start = _sparseOffsets[docId];
+    int end = _sparseOffsets[docId + 1];
+    if (start == end) {
+      return null;
+    }
+    int len = end - start;
+    byte[] blobBytes = new byte[len];
+    _sparseDataBuffer.copyTo(_sparseDataRegionStart + start, blobBytes, 0, len);
+    return new String(blobBytes, StandardCharsets.UTF_8);
+  }
+
+  /**
+   * Parses the sparse JSON blob at the given docId and returns a map of key-value pairs.
+   * Returns empty map if no sparse keys exist for this doc.
+   */
+  public Map<String, Object> getSparseMap(int docId) {
+    String json = getSparseJsonBlob(docId);
+    if (json == null) {
+      return Collections.emptyMap();
+    }
+    try {
+      @SuppressWarnings("unchecked")
+      Map<String, Object> result = JsonUtils.stringToObject(json, Map.class);
+      return result;
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to parse sparse JSON blob for docId " + docId, e);
+    }
+  }
+
+  @Override
+  public Set<String> getKeys() {
+    Set<String> keys = new HashSet<>(_numKeys * 2);
+    for (String key : _keys) {
+      keys.add(key);
+    }
+    return keys;
+  }
+
+  /**
+   * Returns the tier flag for the given key: TIER_DENSE or TIER_SPARSE.
+   * Returns 0 if the key is not found.
+   */
+  public byte getTierFlag(String key) {
+    Integer keyId = _keyToId.get(key);
+    return keyId != null ? _tierFlags[keyId] : 0;
+  }
+
+  /**
+   * Returns the null bitmap for a dense key (docs where the key is absent).
+   * Returns null if the key is not found or is sparse.
+   */
+  @Nullable
+  public ImmutableRoaringBitmap getNullBitmap(String key) {
+    Integer keyId = _keyToId.get(key);
+    return keyId != null ? _nullBitmaps[keyId] : null;
+  }
+
+  @Nullable
+  @Override
+  public DataType getKeyValueType(String key) {
+    Integer keyId = _keyToId.get(key);
+    if (keyId != null) {
+      return _keyStoredTypes[keyId];
+    }
+    // Key not found in this segment's CMAP — fall back to schema's defaultValueType.
+    // This avoids NPE in buildKeyDataSource() when querying keys that exist in other segments
+    // but not this one (MAP keys are discovered dynamically during ingestion).
+    return _defaultValueType;
+  }
+
+  @Override
+  public int getNumDocsWithKey(String key) {
+    Integer keyId = _keyToId.get(key);
+    return keyId != null ? _numDocsPerKey[keyId] : 0;
+  }
+
+  @Override
+  public ImmutableRoaringBitmap getPresenceBitmap(String key) {
+    Integer keyId = _keyToId.get(key);
+    return keyId != null ? _presenceBitmaps[keyId] : ImmutableRoaringBitmap.bitmapOf();
+  }
+
+  @Override
+  public int getInt(int docId, String key) {
+    Integer keyId = _keyToId.get(key);
+    if (keyId == null || _tierFlags[keyId] == TIER_SPARSE) {
+      return 0;
+    }
+    // Dense key: direct docId access (no rank())
+    if (_nullBitmaps[keyId] != null && _nullBitmaps[keyId].contains(docId)) {
+      return 0;
+    }
+    if (_dictIdReaders[keyId] != null) {
+      int dictId = _dictIdReaders[keyId].readInt(docId);
+      return _keyDictionaries.get(_keys[keyId]).getIntValue(dictId);
+    }
+    long bufOffset = _perKeyDataSectionOffset + _fwdOffsets[keyId] + (long) docId * Integer.BYTES;
+    return _dataBuffer.getInt(bufOffset);
+  }
+
+  @Override
+  public long getLong(int docId, String key) {
+    Integer keyId = _keyToId.get(key);
+    if (keyId == null || _tierFlags[keyId] == TIER_SPARSE) {
+      return 0L;
+    }
+    if (_nullBitmaps[keyId] != null && _nullBitmaps[keyId].contains(docId)) {
+      return 0L;
+    }
+    if (_dictIdReaders[keyId] != null) {
+      int dictId = _dictIdReaders[keyId].readInt(docId);
+      return _keyDictionaries.get(_keys[keyId]).getLongValue(dictId);
+    }
+    long bufOffset = _perKeyDataSectionOffset + _fwdOffsets[keyId] + (long) docId * Long.BYTES;
+    return _dataBuffer.getLong(bufOffset);
+  }
+
+  @Override
+  public float getFloat(int docId, String key) {
+    Integer keyId = _keyToId.get(key);
+    if (keyId == null || _tierFlags[keyId] == TIER_SPARSE) {
+      return 0.0f;
+    }
+    if (_nullBitmaps[keyId] != null && _nullBitmaps[keyId].contains(docId)) {
+      return 0.0f;
+    }
+    if (_dictIdReaders[keyId] != null) {
+      int dictId = _dictIdReaders[keyId].readInt(docId);
+      return _keyDictionaries.get(_keys[keyId]).getFloatValue(dictId);
+    }
+    long bufOffset = _perKeyDataSectionOffset + _fwdOffsets[keyId] + (long) docId * Float.BYTES;
+    return _dataBuffer.getFloat(bufOffset);
+  }
+
+  @Override
+  public double getDouble(int docId, String key) {
+    Integer keyId = _keyToId.get(key);
+    if (keyId == null || _tierFlags[keyId] == TIER_SPARSE) {
+      return 0.0;
+    }
+    if (_nullBitmaps[keyId] != null && _nullBitmaps[keyId].contains(docId)) {
+      return 0.0;
+    }
+    if (_dictIdReaders[keyId] != null) {
+      int dictId = _dictIdReaders[keyId].readInt(docId);
+      return _keyDictionaries.get(_keys[keyId]).getDoubleValue(dictId);
+    }
+    long bufOffset = _perKeyDataSectionOffset + _fwdOffsets[keyId] + (long) docId * Double.BYTES;
+    return _dataBuffer.getDouble(bufOffset);
+  }
+
+  @Override
+  public String getString(int docId, String key) {
+    Integer keyId = _keyToId.get(key);
+    if (keyId == null || _tierFlags[keyId] == TIER_SPARSE) {
+      return "";
+    }
+    if (_nullBitmaps[keyId] != null && _nullBitmaps[keyId].contains(docId)) {
+      return "";
+    }
+    if (_dictIdReaders[keyId] != null) {
+      int dictId = _dictIdReaders[keyId].readInt(docId);
+      return _keyDictionaries.get(_keys[keyId]).getStringValue(dictId);
+    }
+    return readStringAtOrdinal(keyId, docId);
+  }
+
+  @Override
+  public byte[] getBytes(int docId, String key) {
+    Integer keyId = _keyToId.get(key);
+    if (keyId == null || _tierFlags[keyId] == TIER_SPARSE) {
+      return new byte[0];
+    }
+    if (_nullBitmaps[keyId] != null && _nullBitmaps[keyId].contains(docId)) {
+      return new byte[0];
+    }
+    if (_dictIdReaders[keyId] != null) {
+      int dictId = _dictIdReaders[keyId].readInt(docId);
+      return _keyDictionaries.get(_keys[keyId]).getBytesValue(dictId);
+    }
+    return readBytesAtOrdinal(keyId, docId);
+  }
+
+  private String readStringAtOrdinal(int keyId, int ordinal) {
+    byte[] raw = readBytesAtOrdinal(keyId, ordinal);
+    return new String(raw, StandardCharsets.UTF_8);
+  }
+
+  /**
+   * Reads variable-length bytes from the STRING/BYTES forward index at the given ordinal.
+   * Format: numValues(int), offsets(int[numValues+1]), data(bytes)
+   */
+  private byte[] readBytesAtOrdinal(int keyId, int ordinal) {
+    // Header: numValues(4 bytes), then offsets array ((numValues+1)*4 bytes), then data
+    long fwdBase = _perKeyDataSectionOffset + _fwdOffsets[keyId];
+    byte[] numValBytes = new byte[4];
+    _dataBuffer.copyTo(fwdBase, numValBytes, 0, 4);
+    int numValues = ByteBuffer.wrap(numValBytes).order(ByteOrder.BIG_ENDIAN).getInt();
+    // Dense keys have numDocs entries, sparse would have numDocsPerKey
+    int expectedCount = (_tierFlags[keyId] == TIER_DENSE) ? _numDocs : _numDocsPerKey[keyId];
+    if (numValues != expectedCount) {
+      throw new IllegalStateException(
+          "ColumnarMap forward index corrupt for key '" + _keys[keyId]
+              + "': numValues=" + numValues + " but expected=" + expectedCount);
+    }
+
+    // Read the two offsets for this ordinal: offsets[ordinal] and offsets[ordinal+1]
+    long offsetBase = fwdBase + 4 + (long) ordinal * Integer.BYTES;
+    byte[] offsetBytes = new byte[8];
+    _dataBuffer.copyTo(offsetBase, offsetBytes, 0, 8);
+    ByteBuffer ob = ByteBuffer.wrap(offsetBytes).order(ByteOrder.BIG_ENDIAN);
+    int startOffset = ob.getInt();
+    int endOffset = ob.getInt();
+
+    int dataLen = endOffset - startOffset;
+    if (dataLen <= 0) {
+      return new byte[0];
+    }
+
+    // Data starts after the offsets array: fwdBase + 4 (numValues) + (numValues+1)*4 (offsets)
+    long dataBase = fwdBase + 4 + (long) (numValues + 1) * Integer.BYTES;
+    byte[] result = new byte[dataLen];
+    _dataBuffer.copyTo(dataBase + startOffset, result, 0, dataLen);
+    return result;
+  }
+
+  @Nullable
+  @Override
+  public ImmutableRoaringBitmap getDocsWithKeyValue(String key, Object value) {
+    Integer keyId = _keyToId.get(key);
+    if (keyId == null || _invLengths[keyId] == 0) {
+      return null;
+    }
+    String valueStr = _keyStoredTypes[keyId].toString(value);
+
+    // Fast O(1) negative check: if the in-memory value dictionary is loaded and does not
+    // contain the value, we can return null immediately without any I/O.
+    ColumnarMapKeyDictionary dict = _keyDictionaries.get(key);
+    if (dict != null && dict.indexOf(valueStr) < 0) {
+      return null;
+    }
+
+    // Scan the inverted index entries using binary search on the sorted values.
+    // Format: numUnique(int), then per entry: valueLen(int), valueBytes, bitmapLen(int), bitmapBytes.
+    // Values are sorted (lexicographic for STRING, numeric order for numeric types via TreeMap),
+    // so we first load all entry offsets, then binary search by value.
+    byte[] valueBytes = valueStr.getBytes(StandardCharsets.UTF_8);
+    long[] entryOffsets = _invEntryOffsets[keyId];
+    if (entryOffsets == null) {
+      return null;
+    }
+    int numUnique = entryOffsets.length;
+
+    // Binary search over the sorted inverted index entries.
+    // The inverted index uses a TreeMap which sorts lexicographically for all types.
+    int lo = 0;
+    int hi = numUnique - 1;
+    while (lo <= hi) {
+      int mid = (lo + hi) >>> 1;
+      long entryPos = entryOffsets[mid];
+      int vLen = _dataBuffer.getInt(entryPos);
+      entryPos += 4;
+      byte[] vBytes = new byte[vLen];
+      _dataBuffer.copyTo(entryPos, vBytes, 0, vLen);
+      entryPos += vLen;
+
+      int cmp = compareBytes(vBytes, valueBytes);
+      if (cmp < 0) {
+        lo = mid + 1;
+      } else if (cmp > 0) {
+        hi = mid - 1;
+      } else {
+        // Found the matching value; read the bitmap
+        int bLen = _dataBuffer.getInt(entryPos);
+        entryPos += 4;
+        byte[] bitmapBytes = new byte[bLen];
+        _dataBuffer.copyTo(entryPos, bitmapBytes, 0, bLen);
+        return new ImmutableRoaringBitmap(ByteBuffer.wrap(bitmapBytes));
+      }
+    }
+    return null;
+  }
+
+  /// Lexicographic comparison of two byte arrays, equivalent to comparing the UTF-8 strings.
+  private static int compareBytes(byte[] a, byte[] b) {
+    int len = Math.min(a.length, b.length);
+    for (int i = 0; i < len; i++) {
+      int diff = (a[i] & 0xFF) - (b[i] & 0xFF);
+      if (diff != 0) {
+        return diff;
+      }
+    }
+    return a.length - b.length;
+  }
+
+  @Override
+  public boolean hasInvertedIndex(String key) {
+    Integer keyId = _keyToId.get(key);
+    return keyId != null && _invLengths[keyId] > 0;
+  }
+
+  @Override
+  @Nullable
+  public String[] getDistinctValuesForKey(String key) {
+    Integer keyId = _keyToId.get(key);
+    if (keyId == null || _invLengths[keyId] == 0) {
+      return null;
+    }
+
+    long invBase = _perKeyDataSectionOffset + _invOffsets[keyId];
+    int numUnique = _dataBuffer.getInt(invBase);
+
+    String[] distinctValues = new String[numUnique];
+    long pos = invBase + 4;
+    for (int i = 0; i < numUnique; i++) {
+      int vLen = _dataBuffer.getInt(pos);
+      pos += 4;
+
+      byte[] vBytes = new byte[vLen];
+      _dataBuffer.copyTo(pos, vBytes, 0, vLen);
+      distinctValues[i] = new String(vBytes, StandardCharsets.UTF_8);
+      pos += vLen;
+
+      // Skip bitmap: read bLen and advance past bitmap bytes
+      int bLen = _dataBuffer.getInt(pos);
+      pos += 4 + bLen;
+    }
+    return distinctValues;
+  }
+
+  @Override
+  public DataSource getKeyDataSource(String key) {
+    // Implemented in ColumnarMapDataSource (Task 15)
+    return null;
+  }
+
+  /// Returns a FixedBitIntReaderWriter for reading bit-packed dictIds for the given key,
+  /// or null if no dictId forward index is available.
+  @Nullable
+  public FixedBitIntReaderWriter getDictIdReader(String key) {
+    Integer keyId = _keyToId.get(key);
+    return keyId != null ? _dictIdReaders[keyId] : null;
+  }
+
+  /// Returns the cached ColumnarMapKeyDictionary for the given key, or null if not available.
+  @Nullable
+  public ColumnarMapKeyDictionary getKeyDictionary(String key) {
+    return _keyDictionaries.get(key);
+  }
+
+  /**
+   * Returns a PinotDataBuffer view over the dictId forward index for the given dense key,
+   * suitable for creating a FixedBitSVForwardIndexReaderV2. Returns null if the key is not
+   * found or has no dictId forward index.
+   */
+  @Nullable
+  public PinotDataBuffer getDictIdFwdBuffer(String key) {
+    Integer keyId = _keyToId.get(key);
+    if (keyId == null || _dictIdFwdLengths[keyId] == 0) {
+      return null;
+    }
+    long offset = _perKeyDataSectionOffset + _dictIdFwdOffsets[keyId];
+    return _dataBuffer.view(offset, offset + _dictIdFwdLengths[keyId]);
+  }
+
+  /**
+   * Returns the number of bits per dictId value for the given key's dictionary,
+   * or 0 if the key has no dictionary.
+   */
+  public int getNumBitsPerDictId(String key) {
+    ColumnarMapKeyDictionary dict = _keyDictionaries.get(key);
+    if (dict == null) {
+      return 0;
+    }
+    return PinotDataBitSet.getNumBitsPerValue(Math.max(dict.length() - 1, 0));
+  }
+
+  /// Returns the total number of documents in this index.
+  public int getNumDocs() {
+    return _numDocs;
+  }
+
+  /**
+   * Returns the value for the given (docId, keyId) pair without any HashMap lookup.
+   * The keyId must be valid and the caller must have already confirmed the doc is present
+   * via the presence bitmap. The ordinal (rank - 1) is computed here.
+   */
+  private Object getValueByKeyId(int docId, int keyId) {
+    // For dense keys: docId IS the index into the full forward index (no rank() needed)
+    // For sparse keys: this method should not be called (handled by JSON column)
+    if (_dictIdReaders[keyId] != null) {
+      int dictId = _dictIdReaders[keyId].readInt(docId);
+      ColumnarMapKeyDictionary dict = _keyDictionaries.get(_keys[keyId]);
+      switch (_keyStoredTypes[keyId]) {
+        case INT:
+          return dict.getIntValue(dictId);
+        case LONG:
+          return dict.getLongValue(dictId);
+        case FLOAT:
+          return dict.getFloatValue(dictId);
+        case DOUBLE:
+          return dict.getDoubleValue(dictId);
+        case BYTES:
+          return dict.getBytesValue(dictId);
+        default:
+          return dict.getStringValue(dictId);
+      }
+    }
+    // Raw forward index path — direct docId access
+    switch (_keyStoredTypes[keyId]) {
+      case INT: {
+        long bufOffset = _perKeyDataSectionOffset + _fwdOffsets[keyId] + (long) docId * Integer.BYTES;
+        return _dataBuffer.getInt(bufOffset);
+      }
+      case LONG: {
+        long bufOffset = _perKeyDataSectionOffset + _fwdOffsets[keyId] + (long) docId * Long.BYTES;
+        return _dataBuffer.getLong(bufOffset);
+      }
+      case FLOAT: {
+        long bufOffset = _perKeyDataSectionOffset + _fwdOffsets[keyId] + (long) docId * Float.BYTES;
+        return _dataBuffer.getFloat(bufOffset);
+      }
+      case DOUBLE: {
+        long bufOffset = _perKeyDataSectionOffset + _fwdOffsets[keyId] + (long) docId * Double.BYTES;
+        return _dataBuffer.getDouble(bufOffset);
+      }
+      case BYTES:
+        return readBytesAtOrdinal(keyId, docId);
+      default:
+        return readStringAtOrdinal(keyId, docId);
+    }
+  }
+
+  @Override
+  public Map<String, Object> getMap(int docId) {
+    Map<String, Object> result = new HashMap<>();
+    // Dense keys from CMAP
+    for (int i = 0; i < _numKeys; i++) {
+      if (_tierFlags[i] == TIER_SPARSE) {
+        continue;
+      }
+      if (_nullBitmaps[i] != null && _nullBitmaps[i].contains(docId)) {
+        continue;
+      }
+      result.put(_keys[i], getValueByKeyId(docId, i));
+    }
+    // Sparse keys from sidecar
+    Map<String, Object> sparseMap = getSparseMap(docId);
+    result.putAll(sparseMap);
+    return result;
+  }
+
+  @Override
+  public void close()
+      throws IOException {
+    for (FixedBitIntReaderWriter reader : _dictIdReaders) {
+      if (reader != null) {
+        reader.close();
+      }
+    }
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/columnarmap/OnHeapColumnarMapIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/columnarmap/OnHeapColumnarMapIndexCreator.java
@@ -1,0 +1,925 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.columnarmap;
+
+import com.google.common.base.Preconditions;
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import javax.annotation.Nullable;
+import org.apache.pinot.common.utils.RoaringBitmapUtils;
+import org.apache.pinot.segment.local.io.util.PinotDataBitSet;
+import org.apache.pinot.segment.spi.V1Constants;
+import org.apache.pinot.segment.spi.creator.IndexCreationContext;
+import org.apache.pinot.segment.spi.index.creator.ColumnarMapIndexCreator;
+import org.apache.pinot.spi.config.table.ColumnarMapIndexConfig;
+import org.apache.pinot.spi.data.ComplexFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.roaringbitmap.RoaringBitmap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * On-heap implementation of {@link ColumnarMapIndexCreator} for immutable (offline) segments.
+ * Accumulates per-document sparse maps in memory and writes a binary index file on seal.
+ * Uses more heap memory but avoids disk I/O during indexing.
+ */
+public class OnHeapColumnarMapIndexCreator implements ColumnarMapIndexCreator {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(OnHeapColumnarMapIndexCreator.class);
+
+  private static final int MAGIC = 0x434D4150;   // "CMAP" (Columnar MAP)
+  private static final int VERSION = 1;
+  private static final int HEADER_SIZE = 72;
+  private static final int KEY_METADATA_ENTRY_SIZE = 70;
+
+  public static final byte TIER_DENSE = 0x01;
+  public static final byte TIER_SPARSE = 0x02;
+
+  private final File _indexDir;
+  private final String _columnName;
+  private final Map<String, DataType> _keyTypes;
+  private final DataType _defaultValueType;
+  private final ColumnarMapIndexConfig _config;
+  private final Set<String> _indexedKeys;
+  private final int _maxKeys;
+  private final Set<String> _configDenseKeys;
+  private final double _denseKeyThreshold;
+
+  private static final double NO_DICTIONARY_SIZE_RATIO_THRESHOLD = 0.85;
+
+  private final Map<String, RoaringBitmap> _presenceBitmaps = new HashMap<>();
+  private final Map<String, List<Object>> _values = new HashMap<>();
+  private final Map<String, Set<String>> _distinctValuesPerKey = new HashMap<>();
+  private final Map<String, Long> _totalRawBytesPerKey = new HashMap<>();
+  private int _numDocs;
+  private int _distinctKeyCount;
+  private final Set<String> _droppedKeys = new HashSet<>();
+  private Set<String> _resolvedDenseKeys;  // computed at seal() time
+
+  public OnHeapColumnarMapIndexCreator(IndexCreationContext context, ColumnarMapIndexConfig config)
+      throws IOException {
+    this(context.getIndexDir(), context.getFieldSpec().getName(),
+        context.getFieldSpec(), config);
+  }
+
+  public OnHeapColumnarMapIndexCreator(File indexDir, String columnName, FieldSpec fieldSpec,
+      ColumnarMapIndexConfig config)
+      throws IOException {
+    this(indexDir, columnName, fieldSpec, config, null, null);
+  }
+
+  public OnHeapColumnarMapIndexCreator(File indexDir, String columnName, FieldSpec fieldSpec,
+      ColumnarMapIndexConfig config,
+      @Nullable Map<String, FieldSpec.DataType> explicitKeyTypes,
+      @Nullable FieldSpec.DataType explicitDefaultValueType)
+      throws IOException {
+    _indexDir = indexDir;
+    _columnName = columnName;
+    _config = config;
+    _indexedKeys = config.getIndexedKeys();
+    _maxKeys = config.getMaxKeys();
+    _configDenseKeys = config.getDenseKeys();
+    _denseKeyThreshold = config.getDenseKeyThreshold();
+
+    Map<String, FieldSpec.DataType> keyTypes = explicitKeyTypes;
+    FieldSpec.DataType defaultType = explicitDefaultValueType;
+    if (keyTypes == null && fieldSpec instanceof ComplexFieldSpec) {
+      ComplexFieldSpec.MapFieldSpec mapSpec = ComplexFieldSpec.toMapFieldSpec((ComplexFieldSpec) fieldSpec);
+      keyTypes = mapSpec.getKeyTypes();
+      defaultType = mapSpec.getDefaultValueType();
+    }
+    _keyTypes = keyTypes != null ? new HashMap<>(keyTypes) : new HashMap<>();
+    _defaultValueType = defaultType != null ? defaultType : FieldSpec.DataType.STRING;
+  }
+
+  @Override
+  public void add(Map<String, Object> columnarMap)
+      throws IOException {
+    if (columnarMap != null && !columnarMap.isEmpty()) {
+      for (Map.Entry<String, Object> entry : columnarMap.entrySet()) {
+        String key = entry.getKey();
+        if (_indexedKeys != null && !_indexedKeys.contains(key)) {
+          continue;
+        }
+        Object rawValue = entry.getValue();
+        if (rawValue == null) {
+          // Null values are treated as absent: the key is not recorded for this document.
+          // There is no distinction between "key absent" and "key present with null value".
+          continue;
+        }
+        if (!_presenceBitmaps.containsKey(key) && _distinctKeyCount >= _maxKeys) {
+          if (_droppedKeys.add(key)) {
+            LOGGER.warn(
+                "ColumnarMap index for column '{}' reached maxKeys limit ({}). Dropping key '{}'. "
+                    + "Total distinct dropped keys so far: {}.",
+                _columnName, _maxKeys, key, _droppedKeys.size());
+          }
+          continue;
+        }
+        DataType valueType = _keyTypes.getOrDefault(key, _defaultValueType);
+        if (!_presenceBitmaps.containsKey(key)) {
+          _presenceBitmaps.put(key, new RoaringBitmap());
+          _values.put(key, new ArrayList<>());
+          _distinctKeyCount++;
+        }
+        _presenceBitmaps.get(key).add(_numDocs);
+        Object coerced;
+        try {
+          coerced = coerceValue(rawValue, valueType);
+        } catch (ClassCastException | NumberFormatException e) {
+          LOGGER.warn(
+              "OnHeapColumnarMapIndexCreator for column '{}': failed to coerce value '{}' (type {}) to {} for key '{}'."
+                  + " Skipping key for this document.",
+              _columnName, rawValue, rawValue.getClass().getSimpleName(), valueType, key, e);
+          _presenceBitmaps.get(key).remove(_numDocs);
+          continue;
+        }
+        _values.get(key).add(coerced);
+
+        // Track per-key stats for dictionary optimization decision
+        DataType storedType = valueType.getStoredType();
+        String stringRep = storedType.toString(coerced);
+        _distinctValuesPerKey.computeIfAbsent(key, k -> new HashSet<>()).add(stringRep);
+        if (storedType == DataType.STRING || storedType == DataType.BYTES) {
+          byte[] rawBytes;
+          if (storedType == DataType.BYTES) {
+            rawBytes = (byte[]) coerced;
+          } else {
+            rawBytes = ((String) coerced).getBytes(StandardCharsets.UTF_8);
+          }
+          _totalRawBytesPerKey.merge(key, (long) rawBytes.length, Long::sum);
+        }
+      }
+    }
+    _numDocs++;
+  }
+
+  @Override
+  public void add(Object value, int dictId)
+      throws IOException {
+    if (!(value instanceof Map)) {
+      return;
+    }
+    @SuppressWarnings("unchecked")
+    Map<String, Object> columnarMap = (Map<String, Object>) value;
+    add(columnarMap);
+  }
+
+  @Override
+  public void add(Object[] values, @Nullable int[] dictIds)
+      throws IOException {
+    throw new UnsupportedOperationException("MAP with columnar map index is single-value only");
+  }
+
+  private Object coerceValue(Object value, DataType dataType) {
+    if (value == null) {
+      return coerceValueForType(dataType, null);
+    }
+    DataType storedType = dataType.getStoredType();
+    switch (storedType) {
+      case INT:
+        if (value instanceof Boolean) {
+          return (Boolean) value ? 1 : 0;
+        }
+        if (value instanceof Number) {
+          return ((Number) value).intValue();
+        }
+        return Integer.parseInt(value.toString().trim());
+      case LONG:
+        if (value instanceof Number) {
+          return ((Number) value).longValue();
+        }
+        return Long.parseLong(value.toString().trim());
+      case FLOAT:
+        if (value instanceof Number) {
+          return ((Number) value).floatValue();
+        }
+        return Float.parseFloat(value.toString().trim());
+      case DOUBLE:
+        if (value instanceof Number) {
+          return ((Number) value).doubleValue();
+        }
+        return Double.parseDouble(value.toString().trim());
+      case STRING:
+        return value.toString();
+      case BYTES:
+        if (value instanceof byte[]) {
+          return value;
+        }
+        return value.toString().getBytes(StandardCharsets.UTF_8);
+      default:
+        return value.toString();
+    }
+  }
+
+  private Object coerceValueForType(DataType dataType, Object nullValue) {
+    DataType storedType = dataType.getStoredType();
+    switch (storedType) {
+      case INT:
+        return nullValue != null ? ((Number) nullValue).intValue() : 0;
+      case LONG:
+        return nullValue != null ? ((Number) nullValue).longValue() : 0L;
+      case FLOAT:
+        return nullValue != null ? ((Number) nullValue).floatValue() : 0.0f;
+      case DOUBLE:
+        return nullValue != null ? ((Number) nullValue).doubleValue() : 0.0;
+      case STRING:
+        return nullValue != null ? nullValue.toString() : "";
+      case BYTES:
+        return nullValue instanceof byte[] ? nullValue : new byte[0];
+      default:
+        return "";
+    }
+  }
+
+  /**
+   * Decides whether to use dictionary encoding for a sparse map key.
+   * Mirrors the logic in DictionaryIndexType.canSafelyCreateDictionaryWithinThreshold.
+   * Returns true if dictionary+dictIdFwd is more compact than raw forward index.
+   */
+  private boolean shouldUseDictionary(String key, DataType storedType, int numDocsForKey) {
+    // Keys with inverted index always get dictionary (inverted index requires it)
+    if (_config.shouldEnableInvertedIndexForKey(key)) {
+      return true;
+    }
+
+    // Explicit override: noDictionaryKeys forces raw encoding
+    if (!_config.shouldUseDictionaryForKey(key)) {
+      return false;
+    }
+
+    Set<String> distinctValues = _distinctValuesPerKey.get(key);
+    if (distinctValues == null || distinctValues.isEmpty()) {
+      return false;
+    }
+
+    // Cardinality is just the distinct values (no default value in sparse dictId forward index)
+    int cardinality = distinctValues.size();
+    if (cardinality == 0) {
+      return false;
+    }
+
+    int numBitsPerValue = PinotDataBitSet.getNumBitsPerValue(Math.max(cardinality - 1, 0));
+    // Sparse dictId forward index: only stores entries for docs that have the key,
+    // same as the raw forward index. Both cover numDocsForKey entries.
+    long dictIdFwdSize = ((long) numDocsForKey * numBitsPerValue + Byte.SIZE - 1) / Byte.SIZE;
+
+    long rawSize;
+    long dictSize;
+
+    switch (storedType) {
+      case INT:
+        rawSize = (long) numDocsForKey * Integer.BYTES;
+        dictSize = (long) cardinality * Integer.BYTES;
+        break;
+      case LONG:
+        rawSize = (long) numDocsForKey * Long.BYTES;
+        dictSize = (long) cardinality * Long.BYTES;
+        break;
+      case FLOAT:
+        rawSize = (long) numDocsForKey * Float.BYTES;
+        dictSize = (long) cardinality * Float.BYTES;
+        break;
+      case DOUBLE:
+        rawSize = (long) numDocsForKey * Double.BYTES;
+        dictSize = (long) cardinality * Double.BYTES;
+        break;
+      case STRING:
+      case BYTES: {
+        // Raw size: numValues(int) + offsets[numDocsForKey+1](int[]) + totalRawBytes
+        long totalRawBytes = _totalRawBytesPerKey.getOrDefault(key, 0L);
+        rawSize = Integer.BYTES + (long) (numDocsForKey + 1) * Integer.BYTES + totalRawBytes;
+        // Dict size: sum of (int + bytes) per distinct value in the value dictionary section
+        dictSize = 0;
+        for (String v : distinctValues) {
+          dictSize += Integer.BYTES + v.getBytes(StandardCharsets.UTF_8).length;
+        }
+        break;
+      }
+      default:
+        return true;
+    }
+
+    // If raw is cheaper than dict+dictIdFwd (within threshold), use raw
+    double ratio = (double) rawSize / (dictSize + dictIdFwdSize);
+    return ratio > NO_DICTIONARY_SIZE_RATIO_THRESHOLD;
+  }
+
+  @Override
+  public void seal()
+      throws IOException {
+    List<String> sortedKeys = new ArrayList<>(_presenceBitmaps.keySet());
+    Collections.sort(sortedKeys);
+    int numKeys = sortedKeys.size();
+
+    // Compute tier assignment: a key is dense if fillRate > threshold OR in configDenseKeys
+    _resolvedDenseKeys = new HashSet<>(_configDenseKeys);
+    for (String key : sortedKeys) {
+      int numDocsForKey = _presenceBitmaps.get(key).getCardinality();
+      double fillRate = _numDocs > 0 ? (double) numDocsForKey / _numDocs : 0;
+      if (fillRate > _denseKeyThreshold) {
+        _resolvedDenseKeys.add(key);
+      }
+    }
+
+    int numDenseKeys = 0;
+    int numSparseKeys = 0;
+    for (String key : sortedKeys) {
+      if (_resolvedDenseKeys.contains(key)) {
+        numDenseKeys++;
+      } else {
+        numSparseKeys++;
+      }
+    }
+
+    byte[] keyDictionarySection = buildKeyDictionarySection(sortedKeys);
+    byte[] keyMetadataSection = new byte[numKeys * KEY_METADATA_ENTRY_SIZE];
+    Map<String, TreeMap<String, RoaringBitmap>> cachedValueToDocIds = new HashMap<>();
+    byte[] perKeyDataSection = buildPerKeyDataSection(sortedKeys, keyMetadataSection, cachedValueToDocIds);
+    byte[] valueDictionarySection = buildValueDictionarySection(sortedKeys, cachedValueToDocIds);
+    byte[] sparseDataSection = buildSparseSection(sortedKeys);
+
+    long keyDictionaryOffset = HEADER_SIZE;
+    long keyMetadataOffset = keyDictionaryOffset + keyDictionarySection.length;
+    long perKeyDataOffset = keyMetadataOffset + keyMetadataSection.length;
+    long valueDictionaryOffset = perKeyDataOffset + perKeyDataSection.length;
+    long sparseDataOffset = valueDictionaryOffset + valueDictionarySection.length;
+    long sparseDataLength = sparseDataSection.length;
+
+    File indexFile = new File(_indexDir, _columnName + V1Constants.Indexes.COLUMNAR_MAP_INDEX_FILE_EXTENSION);
+    try (FileOutputStream fos = new FileOutputStream(indexFile);
+        DataOutputStream dos = new DataOutputStream(fos)) {
+      writeHeader(dos, numKeys, numDenseKeys, numSparseKeys,
+          keyDictionaryOffset, keyMetadataOffset, perKeyDataOffset, valueDictionaryOffset,
+          sparseDataOffset, sparseDataLength);
+      dos.write(keyDictionarySection);
+      dos.write(keyMetadataSection);
+      dos.write(perKeyDataSection);
+      dos.write(valueDictionarySection);
+      dos.write(sparseDataSection);
+    }
+  }
+
+  /**
+   * Builds the sparse-tier section bytes that are appended to the CMAP file.
+   * Layout: numDocs(int) + offsets[(numDocs+1) x int] + concatenated UTF-8 JSON blobs.
+   * Returns an empty byte[] if no sparse keys exist.
+   * NOTE: no MAGIC prefix - section length is recorded in the CMAP header.
+   */
+  private byte[] buildSparseSection(List<String> sortedKeys)
+      throws IOException {
+    List<String> sparseKeys = new ArrayList<>();
+    for (String key : sortedKeys) {
+      if (!_resolvedDenseKeys.contains(key)) {
+        sparseKeys.add(key);
+      }
+    }
+    if (sparseKeys.isEmpty()) {
+      return new byte[0];
+    }
+
+    ByteArrayOutputStream dataBaos = new ByteArrayOutputStream();
+    int[] offsets = new int[_numDocs + 1];
+    int dataOffset = 0;
+
+    for (int docId = 0; docId < _numDocs; docId++) {
+      offsets[docId] = dataOffset;
+      Map<String, Object> sparseEntries = new LinkedHashMap<>();
+      for (String key : sparseKeys) {
+        RoaringBitmap presence = _presenceBitmaps.get(key);
+        if (presence != null && presence.contains(docId)) {
+          int ordinal = presence.rank(docId) - 1;
+          Object value = _values.get(key).get(ordinal);
+          sparseEntries.put(key, value);
+        }
+      }
+      if (!sparseEntries.isEmpty()) {
+        byte[] jsonBytes = serializeSparseEntries(sparseEntries).getBytes(StandardCharsets.UTF_8);
+        dataBaos.write(jsonBytes);
+        dataOffset += jsonBytes.length;
+      }
+    }
+    offsets[_numDocs] = dataOffset;
+
+    ByteArrayOutputStream sectionBaos = new ByteArrayOutputStream();
+    try (DataOutputStream dos = new DataOutputStream(sectionBaos)) {
+      dos.writeInt(_numDocs);
+      for (int offset : offsets) {
+        dos.writeInt(offset);
+      }
+      dos.write(dataBaos.toByteArray());
+    }
+    return sectionBaos.toByteArray();
+  }
+
+  /**
+   * Serializes sparse key entries as a JSON object string using Jackson.
+   */
+  private String serializeSparseEntries(Map<String, Object> entries) {
+    try {
+      return JsonUtils.objectToString(entries);
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to serialize sparse entries", e);
+    }
+  }
+
+  private byte[] buildKeyDictionarySection(List<String> sortedKeys)
+      throws IOException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    try (DataOutputStream dos = new DataOutputStream(baos)) {
+      dos.writeInt(sortedKeys.size());
+      for (String key : sortedKeys) {
+        byte[] keyBytes = key.getBytes(StandardCharsets.UTF_8);
+        dos.writeInt(keyBytes.length);
+        dos.write(keyBytes);
+      }
+    }
+    return baos.toByteArray();
+  }
+
+  private byte[] buildPerKeyDataSection(List<String> sortedKeys, byte[] keyMetadataSection,
+      Map<String, TreeMap<String, RoaringBitmap>> cachedValueToDocIds)
+      throws IOException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    try (DataOutputStream dos = new DataOutputStream(baos)) {
+      long currentOffset = 0;
+
+      for (int i = 0; i < sortedKeys.size(); i++) {
+        String key = sortedKeys.get(i);
+        RoaringBitmap presence = _presenceBitmaps.get(key);
+        List<Object> values = _values.get(key);
+        DataType dataType = _keyTypes.getOrDefault(key, _defaultValueType);
+        DataType storedType = dataType.getStoredType();
+
+        boolean isDense = _resolvedDenseKeys.contains(key);
+        byte tierFlag = isDense ? TIER_DENSE : TIER_SPARSE;
+
+        if (!isDense) {
+          // Sparse key: no per-key data in CMAP, all offsets/lengths are 0
+          int entryOffset = i * KEY_METADATA_ENTRY_SIZE;
+          keyMetadataSection[entryOffset] = tierFlag;
+          keyMetadataSection[entryOffset + 1] = (byte) storedType.ordinal();
+          writeInt(keyMetadataSection, entryOffset + 2, values.size());
+          // All 4 offset/length pairs are 0 (already zeroed by array initialization)
+          continue;
+        }
+
+        // Dense key: write null bitmap + full forward index (numDocs entries)
+
+        // 1. Build and write null bitmap (docs where key is ABSENT)
+        RoaringBitmap nullBitmap = new RoaringBitmap();
+        for (int docId = 0; docId < _numDocs; docId++) {
+          if (!presence.contains(docId)) {
+            nullBitmap.add(docId);
+          }
+        }
+        nullBitmap.runOptimize();
+        byte[] nullBitmapBytes = RoaringBitmapUtils.serialize(nullBitmap);
+        long nullBitmapOffset = currentOffset;
+        dos.write(nullBitmapBytes);
+        currentOffset += nullBitmapBytes.length;
+
+        boolean useDictionary = shouldUseDictionary(key, storedType, values.size());
+        boolean enableInverted = _config.shouldEnableInvertedIndexForKey(key);
+
+        // 2. Write forward index: either raw OR dictId, never both
+        long forwardOffset = 0;
+        long forwardLength = 0;
+        long dictIdFwdOffset = 0;
+        long dictIdFwdLength = 0;
+
+        TreeMap<String, RoaringBitmap> valueToDocIds = null;
+
+        if (useDictionary) {
+          // Dictionary-encoded path: build valueToDocIds and FULL dictId forward index
+          valueToDocIds = buildValueToDocIds(presence, values, storedType);
+          cachedValueToDocIds.put(key, valueToDocIds);
+
+          byte[] dictIdFwdBytes = buildFullDictIdForwardIndex(valueToDocIds, storedType, presence, values);
+          dictIdFwdOffset = currentOffset;
+          dictIdFwdLength = dictIdFwdBytes.length;
+          dos.write(dictIdFwdBytes);
+          currentOffset += dictIdFwdBytes.length;
+        } else {
+          // Raw forward index path — full (numDocs entries, defaults for absent)
+          byte[] forwardBytes = buildFullRawForwardIndex(values, storedType, presence);
+          forwardOffset = currentOffset;
+          forwardLength = forwardBytes.length;
+          dos.write(forwardBytes);
+          currentOffset += forwardBytes.length;
+        }
+
+        // 3. Inverted index (independent of dictionary decision)
+        long invertedOffset = 0;
+        long invertedLength = 0;
+        if (enableInverted) {
+          if (valueToDocIds == null) {
+            valueToDocIds = buildValueToDocIds(presence, values, storedType);
+            cachedValueToDocIds.put(key, valueToDocIds);
+          }
+          byte[] invertedBytes = serializeInvertedIndex(valueToDocIds);
+          invertedOffset = currentOffset;
+          invertedLength = invertedBytes.length;
+          dos.write(invertedBytes);
+          currentOffset += invertedBytes.length;
+        }
+
+        // Write key metadata entry (70 bytes)
+        int entryOffset = i * KEY_METADATA_ENTRY_SIZE;
+        keyMetadataSection[entryOffset] = tierFlag;
+        keyMetadataSection[entryOffset + 1] = (byte) storedType.ordinal();
+        writeInt(keyMetadataSection, entryOffset + 2, values.size());
+        writeLong(keyMetadataSection, entryOffset + 6, nullBitmapOffset);
+        writeLong(keyMetadataSection, entryOffset + 14, nullBitmapBytes.length);
+        writeLong(keyMetadataSection, entryOffset + 22, forwardOffset);
+        writeLong(keyMetadataSection, entryOffset + 30, forwardLength);
+        writeLong(keyMetadataSection, entryOffset + 38, invertedOffset);
+        writeLong(keyMetadataSection, entryOffset + 46, invertedLength);
+        writeLong(keyMetadataSection, entryOffset + 54, dictIdFwdOffset);
+        writeLong(keyMetadataSection, entryOffset + 62, dictIdFwdLength);
+      }
+    }
+    return baos.toByteArray();
+  }
+
+  private static void writeInt(byte[] buf, int offset, int value) {
+    buf[offset] = (byte) (value >> 24);
+    buf[offset + 1] = (byte) (value >> 16);
+    buf[offset + 2] = (byte) (value >> 8);
+    buf[offset + 3] = (byte) (value);
+  }
+
+  private static void writeLong(byte[] buf, int offset, long value) {
+    for (int i = 0; i < 8; i++) {
+      buf[offset + i] = (byte) (value >> ((7 - i) * 8));
+    }
+  }
+
+  private byte[] buildForwardIndex(List<Object> values, DataType storedType)
+      throws IOException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    try (DataOutputStream dos = new DataOutputStream(baos)) {
+      writeForwardIndex(dos, values, storedType);
+    }
+    return baos.toByteArray();
+  }
+
+  private void writeForwardIndex(DataOutputStream dos, List<Object> values, DataType storedType)
+      throws IOException {
+    switch (storedType) {
+      case INT:
+        for (Object v : values) {
+          dos.writeInt((Integer) v);
+        }
+        break;
+      case LONG:
+        for (Object v : values) {
+          dos.writeLong((Long) v);
+        }
+        break;
+      case FLOAT:
+        for (Object v : values) {
+          dos.writeFloat((Float) v);
+        }
+        break;
+      case DOUBLE:
+        for (Object v : values) {
+          dos.writeDouble((Double) v);
+        }
+        break;
+      case STRING: {
+        int numValues = values.size();
+        dos.writeInt(numValues);
+        ByteArrayOutputStream dataBaos = new ByteArrayOutputStream();
+        int[] offsets = new int[numValues + 1];
+        int offset = 0;
+        for (int i = 0; i < numValues; i++) {
+          offsets[i] = offset;
+          byte[] b = ((String) values.get(i)).getBytes(StandardCharsets.UTF_8);
+          dataBaos.write(b);
+          offset += b.length;
+        }
+        offsets[numValues] = offset;
+        for (int o : offsets) {
+          dos.writeInt(o);
+        }
+        dos.write(dataBaos.toByteArray());
+        break;
+      }
+      case BYTES: {
+        int numValues = values.size();
+        dos.writeInt(numValues);
+        ByteArrayOutputStream dataBaos = new ByteArrayOutputStream();
+        int[] offsets = new int[numValues + 1];
+        int offset = 0;
+        for (int i = 0; i < numValues; i++) {
+          offsets[i] = offset;
+          byte[] b = (byte[]) values.get(i);
+          dataBaos.write(b);
+          offset += b.length;
+        }
+        offsets[numValues] = offset;
+        for (int o : offsets) {
+          dos.writeInt(o);
+        }
+        dos.write(dataBaos.toByteArray());
+        break;
+      }
+      default:
+        throw new IllegalStateException("Unsupported stored type for forward index: " + storedType);
+    }
+  }
+
+  private TreeMap<String, RoaringBitmap> buildValueToDocIds(RoaringBitmap presence, List<Object> values,
+      DataType storedType) {
+    TreeMap<String, RoaringBitmap> valueToDocIds = new TreeMap<>();
+    int ordinal = 0;
+    for (int docId : presence) {
+      Object value = values.get(ordinal);
+      String keyRep = storedType.toString(value);
+      valueToDocIds.computeIfAbsent(keyRep, k -> new RoaringBitmap()).add(docId);
+      ordinal++;
+    }
+    return valueToDocIds;
+  }
+
+  private byte[] serializeInvertedIndex(TreeMap<String, RoaringBitmap> valueToDocIds)
+      throws IOException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    try (DataOutputStream dos = new DataOutputStream(baos)) {
+      dos.writeInt(valueToDocIds.size());
+      for (Map.Entry<String, RoaringBitmap> entry : valueToDocIds.entrySet()) {
+        byte[] valueBytes = entry.getKey().getBytes(StandardCharsets.UTF_8);
+        dos.writeInt(valueBytes.length);
+        dos.write(valueBytes);
+        byte[] bitmapBytes = RoaringBitmapUtils.serialize(entry.getValue());
+        dos.writeInt(bitmapBytes.length);
+        dos.write(bitmapBytes);
+      }
+    }
+    return baos.toByteArray();
+  }
+
+  /// Builds a FULL bit-packed dictId forward index for dense keys (numDocs entries).
+  /// Absent docs get the default value's dictId (dictId 0).
+  private byte[] buildFullDictIdForwardIndex(TreeMap<String, RoaringBitmap> valueToDocIds,
+      DataType storedType, RoaringBitmap presence, List<Object> valueList)
+      throws IOException {
+    // Ensure the default value is in the dictionary
+    String defaultValue = ColumnarMapKeyDictionary.getDefaultValueString(storedType);
+    valueToDocIds.putIfAbsent(defaultValue, new RoaringBitmap());
+
+    String[] distinctValues = valueToDocIds.keySet().toArray(new String[0]);
+    sortValues(distinctValues, storedType);
+
+    // Build value → dictId mapping
+    Map<String, Integer> valueToDictId = new HashMap<>();
+    for (int i = 0; i < distinctValues.length; i++) {
+      valueToDictId.put(distinctValues[i], i);
+    }
+
+    int defaultDictId = valueToDictId.getOrDefault(defaultValue, 0);
+    int numBitsPerValue = PinotDataBitSet.getNumBitsPerValue(Math.max(distinctValues.length - 1, 0));
+
+    // Build FULL dictId array: one entry per segment doc (numDocs entries)
+    int[] dictIdArray = new int[_numDocs];
+    int ordinal = 0;
+    for (int docId = 0; docId < _numDocs; docId++) {
+      if (presence.contains(docId)) {
+        Object value = valueList.get(ordinal);
+        String strValue = storedType.toString(value);
+        Integer dictId = valueToDictId.get(strValue);
+        dictIdArray[docId] = dictId != null ? dictId : defaultDictId;
+        ordinal++;
+      } else {
+        dictIdArray[docId] = defaultDictId;
+      }
+    }
+
+    // Write bit-packed
+    long bufferSize = ((long) _numDocs * numBitsPerValue + Byte.SIZE - 1) / Byte.SIZE;
+    Preconditions.checkState(bufferSize <= Integer.MAX_VALUE,
+        "DictId forward index too large for column '%s': %s bytes", _columnName, bufferSize);
+    byte[] buffer = new byte[(int) bufferSize];
+    writeBitPacked(buffer, dictIdArray, _numDocs, numBitsPerValue);
+    return buffer;
+  }
+
+  /// Builds a FULL raw forward index for dense keys (numDocs entries).
+  /// Absent docs get the type's default value.
+  private byte[] buildFullRawForwardIndex(List<Object> values, DataType storedType, RoaringBitmap presence)
+      throws IOException {
+    // Build full list with defaults for absent docs
+    List<Object> fullValues = new ArrayList<>(_numDocs);
+    int ordinal = 0;
+    for (int docId = 0; docId < _numDocs; docId++) {
+      if (presence.contains(docId)) {
+        fullValues.add(values.get(ordinal));
+        ordinal++;
+      } else {
+        fullValues.add(getDefaultValue(storedType));
+      }
+    }
+    return buildForwardIndex(fullValues, storedType);
+  }
+
+  private static Object getDefaultValue(DataType storedType) {
+    switch (storedType) {
+      case INT:
+        return 0;
+      case LONG:
+        return 0L;
+      case FLOAT:
+        return 0.0f;
+      case DOUBLE:
+        return 0.0;
+      case STRING:
+        return "";
+      case BYTES:
+        return new byte[0];
+      default:
+        return "";
+    }
+  }
+
+  /// Builds a sparse bit-packed dictId forward index for only the docs that have the key.
+  /// Uses presence bitmap rank to map docId → ordinal, same as the raw forward index.
+  /// This preserves the space benefit of columnar_map by not wasting space on absent docs.
+  private byte[] buildDictIdForwardIndex(TreeMap<String, RoaringBitmap> valueToDocIds,
+      DataType storedType, RoaringBitmap presence, List<Object> valueList)
+      throws IOException {
+    // Ensure the default value is in the dictionary so absent docs can map to it at query time.
+    // This matches Pinot's standard nullable column behavior where nulls get the default value's dictId.
+    String defaultValue = ColumnarMapKeyDictionary.getDefaultValueString(storedType);
+    valueToDocIds.putIfAbsent(defaultValue, new RoaringBitmap());
+
+    String[] distinctValues = valueToDocIds.keySet().toArray(new String[0]);
+    sortValues(distinctValues, storedType);
+
+    // Build value → dictId mapping
+    Map<String, Integer> valueToDictId = new HashMap<>();
+    for (int i = 0; i < distinctValues.length; i++) {
+      valueToDictId.put(distinctValues[i], i);
+    }
+
+    int numDocsForKey = (int) presence.getCardinality();
+    int numBitsPerValue = PinotDataBitSet.getNumBitsPerValue(Math.max(distinctValues.length - 1, 0));
+
+    // Build sparse dictId array: one entry per doc that has the key, in bitmap iteration order.
+    // Use ordinal-indexed _values list for O(N) instead of brute-force O(N*K).
+    int[] dictIdArray = new int[numDocsForKey];
+    for (int ordinal = 0; ordinal < numDocsForKey; ordinal++) {
+      Object value = valueList.get(ordinal);
+      String strValue = storedType.toString(value);
+      Integer dictId = valueToDictId.get(strValue);
+      dictIdArray[ordinal] = dictId != null ? dictId : 0;
+    }
+
+    // Write bit-packed
+    long bufferSize = ((long) numDocsForKey * numBitsPerValue + Byte.SIZE - 1) / Byte.SIZE;
+    Preconditions.checkState(bufferSize <= Integer.MAX_VALUE,
+        "DictId forward index too large for column '%s': %s bytes", _columnName, bufferSize);
+    byte[] buffer = new byte[(int) bufferSize];
+    writeBitPacked(buffer, dictIdArray, numDocsForKey, numBitsPerValue);
+    return buffer;
+  }
+
+  /// Writes bit-packed integers into a byte array (big-endian bit order).
+  private static void writeBitPacked(byte[] buffer, int[] values, int numValues, int numBitsPerValue) {
+    long bitOffset = 0;
+    for (int i = 0; i < numValues; i++) {
+      int value = values[i];
+      for (int bit = numBitsPerValue - 1; bit >= 0; bit--) {
+        if (((value >> bit) & 1) == 1) {
+          int byteIndex = (int) (bitOffset / 8);
+          int bitIndex = (int) (7 - (bitOffset % 8));
+          buffer[byteIndex] |= (1 << bitIndex);
+        }
+        bitOffset++;
+      }
+    }
+  }
+
+  /**
+   * Sorts string-encoded dictionary values using the type-appropriate comparator.
+   * Numeric types (INT, LONG, FLOAT, DOUBLE) are sorted by parsed numeric value;
+   * STRING and BYTES types are sorted lexicographically.
+   * This must match the comparator used by {@link ColumnarMapKeyDictionary} to ensure
+   * dictId assignment, binary search, and range lookups are consistent.
+   */
+  private static void sortValues(String[] values, DataType storedType) {
+    Comparator<String> cmp = ColumnarMapKeyDictionary.getComparator(storedType);
+    if (cmp != null) {
+      Arrays.sort(values, cmp);
+    } else {
+      Arrays.sort(values);
+    }
+  }
+
+  /// Builds the value dictionary section written after all per-key data.
+  /// For each key with dictionary encoding: numDistinctValues(int), numBitsPerValue(int),
+  /// then [valueLen(int) + valueBytes] × numDistinctValues.
+  private byte[] buildValueDictionarySection(List<String> sortedKeys,
+      Map<String, TreeMap<String, RoaringBitmap>> cachedValueToDocIds)
+      throws IOException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    DataOutputStream dos = new DataOutputStream(baos);
+
+    for (String key : sortedKeys) {
+      // Write value dictionary for all keys that have cached valueToDocIds
+      // (includes both dictionary-encoded keys and inverted-index keys)
+      if (!cachedValueToDocIds.containsKey(key)) {
+        continue;
+      }
+
+      DataType dataType = _keyTypes.getOrDefault(key, _defaultValueType);
+      DataType storedType = dataType.getStoredType();
+
+      TreeMap<String, RoaringBitmap> valueToDocIds = cachedValueToDocIds.get(key);
+
+      // Use only the actual distinct values (no default value needed for sparse dictId forward index)
+      String[] allValues = valueToDocIds != null ? valueToDocIds.keySet().toArray(new String[0]) : new String[0];
+
+      // Sort numerically for numeric types, lexicographically for strings
+      sortValues(allValues, storedType);
+
+      int numBitsPerValue = PinotDataBitSet.getNumBitsPerValue(Math.max(allValues.length - 1, 0));
+      dos.writeInt(allValues.length);
+      dos.writeInt(numBitsPerValue);
+      for (String v : allValues) {
+        byte[] vBytes = v.getBytes(StandardCharsets.UTF_8);
+        dos.writeInt(vBytes.length);
+        dos.write(vBytes);
+      }
+    }
+    return baos.toByteArray();
+  }
+
+  private void writeHeader(DataOutputStream dos, int numKeys, int numDenseKeys, int numSparseKeys,
+      long keyDictOffset, long keyMetaOffset, long perKeyOffset, long valueDictOffset,
+      long sparseDataOffset, long sparseDataLength)
+      throws IOException {
+    dos.writeInt(MAGIC);
+    dos.writeInt(VERSION);
+    dos.writeInt(numKeys);
+    dos.writeInt(_numDocs);
+    dos.writeInt(numDenseKeys);
+    dos.writeInt(numSparseKeys);
+    dos.writeLong(keyDictOffset);
+    dos.writeLong(keyMetaOffset);
+    dos.writeLong(perKeyOffset);
+    dos.writeLong(valueDictOffset);
+    dos.writeLong(sparseDataOffset);
+    dos.writeLong(sparseDataLength);
+    // Header is exactly 72 bytes: 6 ints (24B) + 6 longs (48B) = 72B, no padding
+  }
+
+  @Override
+  public void close()
+      throws IOException {
+  }
+
+  /**
+   * Returns the set of keys resolved as dense after seal().
+   * A key is dense if its fill rate exceeds the threshold OR it's in the configured denseKeys.
+   * Returns null if seal() has not been called yet.
+   */
+  @Nullable
+  public Set<String> getResolvedDenseKeys() {
+    return _resolvedDenseKeys;
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/columnminmaxvalue/ColumnMinMaxValueGenerator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/columnminmaxvalue/ColumnMinMaxValueGenerator.java
@@ -135,17 +135,19 @@ public class ColumnMinMaxValueGenerator {
   }
 
   private boolean needAddColumnMinMaxValueForColumn(String columnName) {
-    return needAddColumnMinMaxValueForColumn(_segmentMetadata.getColumnMetadataFor(columnName));
-  }
-
-  private boolean needAddColumnMinMaxValueForColumn(ColumnMetadata columnMetadata) {
+    ColumnMetadata columnMetadata = _segmentMetadata.getColumnMetadataFor(columnName);
+    // Only skip min/max for MAP columns that have a columnar map index
+    if (columnMetadata.getFieldSpec().getDataType() == FieldSpec.DataType.MAP
+        && _segmentWriter.hasIndexFor(columnName, StandardIndexes.columnarMap())) {
+      return false;
+    }
     return columnMetadata.getMinValue() == null && columnMetadata.getMaxValue() == null
         && !columnMetadata.isMinMaxValueInvalid();
   }
 
   private void addColumnMinMaxValueForColumn(String columnName) {
     ColumnMetadata columnMetadata = _segmentMetadata.getColumnMetadataFor(columnName);
-    if (!needAddColumnMinMaxValueForColumn(columnMetadata)) {
+    if (!needAddColumnMinMaxValueForColumn(columnName)) {
       return;
     }
     try {

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/columnarmap/ColumnarMapSegmentCreationTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/columnarmap/ColumnarMapSegmentCreationTest.java
@@ -1,0 +1,195 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.columnarmap;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
+import org.apache.pinot.segment.spi.index.StandardIndexes;
+import org.apache.pinot.spi.config.table.FieldConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.ComplexFieldSpec;
+import org.apache.pinot.spi.data.DimensionFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.data.readers.RecordReader;
+import org.apache.pinot.spi.data.readers.RecordReaderConfig;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+
+/**
+ * Tests full segment creation pipeline for MAP columns with sparse map index.
+ * Verifies that OnHeapColumnarMapIndexCreator is properly invoked and produces an index file.
+ */
+public class ColumnarMapSegmentCreationTest {
+
+  private static final File SEGMENT_DIR = new File(FileUtils.getTempDirectory(), "ColumnarMapSegmentCreationTest");
+  private static final String TABLE_NAME = "userMetrics";
+
+  @BeforeMethod
+  public void setUp()
+      throws Exception {
+    FileUtils.forceMkdir(SEGMENT_DIR);
+  }
+
+  @AfterMethod
+  public void tearDown()
+      throws Exception {
+    FileUtils.deleteDirectory(SEGMENT_DIR);
+  }
+
+  @Test
+  public void testColumnarMapIndexCreatedInSegment()
+      throws Exception {
+    // Build schema with a MAP column
+    Map<String, FieldSpec.DataType> keyTypes = new HashMap<>();
+    keyTypes.put("clicks", FieldSpec.DataType.LONG);
+    keyTypes.put("spend", FieldSpec.DataType.DOUBLE);
+
+    Map<String, FieldSpec> childFieldSpecs = Map.of(
+        "key", new DimensionFieldSpec("key", FieldSpec.DataType.STRING, true),
+        "value", new DimensionFieldSpec("value", FieldSpec.DataType.STRING, true)
+    );
+    ComplexFieldSpec metricsSpec = new ComplexFieldSpec("metrics", FieldSpec.DataType.MAP, true, childFieldSpecs);
+
+    Schema schema = new Schema.SchemaBuilder()
+        .setSchemaName(TABLE_NAME)
+        .addField(new DimensionFieldSpec("userId", FieldSpec.DataType.STRING, true))
+        .addField(metricsSpec)
+        .build();
+
+    // Build table config with columnar_map index in fieldConfigList
+    ObjectNode columnarMapNode = JsonUtils.newObjectNode();
+    columnarMapNode.put("enabled", true);
+    columnarMapNode.put("enableInvertedIndexForAll", false);
+    columnarMapNode.put("maxKeys", 100);
+    ObjectNode indexesNode = JsonUtils.newObjectNode();
+    indexesNode.set("columnar_map", columnarMapNode);
+    FieldConfig metricsFieldConfig = new FieldConfig.Builder("metrics")
+        .withIndexes(indexesNode)
+        .build();
+
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName(TABLE_NAME)
+        .setFieldConfigList(List.of(metricsFieldConfig))
+        .build();
+
+    // Build test rows
+    List<Map<String, Object>> rows = new ArrayList<>();
+    rows.add(buildRow("user1", Map.of("clicks", 100L, "spend", 5.5)));
+    rows.add(buildRow("user2", Map.of("clicks", 200L)));
+    rows.add(buildRow("user3", Map.of("spend", 12.75)));
+    rows.add(buildRow("user4", new HashMap<>()));
+
+    // Create segment generator config
+    SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(tableConfig, schema);
+    segmentGeneratorConfig.setTableName(TABLE_NAME);
+    segmentGeneratorConfig.setSegmentName(TABLE_NAME + "_0");
+    segmentGeneratorConfig.setOutDir(SEGMENT_DIR.getAbsolutePath());
+
+    // Create segment with test reader
+    SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+    driver.init(segmentGeneratorConfig, new TestRecordReader(rows));
+    driver.build();
+
+    // Verify the segment was created
+    File segmentDir = new File(SEGMENT_DIR, TABLE_NAME + "_0");
+    assertTrue(segmentDir.exists(), "Segment directory should exist: " + segmentDir);
+
+    // Verify the sparse map index file exists in the V3 segment
+    File v3Dir = new File(segmentDir, "v3");
+    assertTrue(v3Dir.exists(), "V3 directory should exist: " + v3Dir);
+
+    File indexMap = new File(v3Dir, "index_map");
+    assertTrue(indexMap.exists(), "index_map should exist");
+
+    String indexMapContent = org.apache.commons.io.FileUtils.readFileToString(indexMap,
+        java.nio.charset.StandardCharsets.UTF_8);
+
+    // The sparse map index should be present in the index_map
+    assertTrue(indexMapContent.contains("metrics." + StandardIndexes.COLUMNAR_MAP_ID),
+        "index_map should contain metrics columnar_map_index entry but got:\n" + indexMapContent);
+  }
+
+  private Map<String, Object> buildRow(String userId, Map<String, Object> metrics) {
+    Map<String, Object> row = new HashMap<>();
+    row.put("userId", userId);
+    row.put("metrics", metrics);
+    return row;
+  }
+
+  /**
+   * Simple in-memory record reader for testing.
+   */
+  private static class TestRecordReader implements RecordReader {
+    private final List<Map<String, Object>> _rows;
+    private int _index = 0;
+
+    TestRecordReader(List<Map<String, Object>> rows) {
+      _rows = rows;
+    }
+
+    @Override
+    public void init(File dataFile, Set<String> fieldsToRead, RecordReaderConfig recordReaderConfig)
+        throws IOException {
+    }
+
+    @Override
+    public boolean hasNext() {
+      return _index < _rows.size();
+    }
+
+    @Override
+    public GenericRow next(GenericRow reuse)
+        throws IOException {
+      Map<String, Object> rowData = _rows.get(_index++);
+      reuse.clear();
+      for (Map.Entry<String, Object> entry : rowData.entrySet()) {
+        reuse.putValue(entry.getKey(), entry.getValue());
+      }
+      return reuse;
+    }
+
+    @Override
+    public void rewind()
+        throws IOException {
+      _index = 0;
+    }
+
+    @Override
+    public void close() {
+    }
+  }
+}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/columnarmap/ColumnarMapSparseRoundTripTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/columnarmap/ColumnarMapSparseRoundTripTest.java
@@ -1,0 +1,164 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.columnarmap;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.segment.spi.V1Constants;
+import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
+import org.apache.pinot.spi.config.table.ColumnarMapIndexConfig;
+import org.apache.pinot.spi.data.ComplexFieldSpec;
+import org.apache.pinot.spi.data.DimensionFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+
+/**
+ * Verifies that sparse-tier per-doc JSON blobs round-trip through the SPMX file
+ * without using a separate .columnarmap.sparse sidecar.
+ */
+public class ColumnarMapSparseRoundTripTest {
+
+  private static final File INDEX_DIR =
+      new File(FileUtils.getTempDirectory(), "ColumnarMapSparseRoundTripTest");
+  private static final String COLUMN_NAME = "sparseCol";
+
+  @BeforeMethod
+  public void setUp()
+      throws IOException {
+    FileUtils.forceMkdir(INDEX_DIR);
+  }
+
+  @AfterMethod
+  public void tearDown()
+      throws IOException {
+    FileUtils.deleteDirectory(INDEX_DIR);
+  }
+
+  private static ComplexFieldSpec buildMapFieldSpec(String columnName) {
+    Map<String, FieldSpec> childFieldSpecs = Map.of(
+        "key", new DimensionFieldSpec("key", FieldSpec.DataType.STRING, true),
+        "value", new DimensionFieldSpec("value", FieldSpec.DataType.STRING, true)
+    );
+    return new ComplexFieldSpec(columnName, FieldSpec.DataType.MAP, true, childFieldSpecs);
+  }
+
+  private File createIndex(ComplexFieldSpec fieldSpec, ColumnarMapIndexConfig config,
+      Map<String, FieldSpec.DataType> keyTypes, Map<String, Object>[] docs)
+      throws IOException {
+    File indexFile =
+        new File(INDEX_DIR, COLUMN_NAME + V1Constants.Indexes.COLUMNAR_MAP_INDEX_FILE_EXTENSION);
+
+    try (OnHeapColumnarMapIndexCreator creator =
+        new OnHeapColumnarMapIndexCreator(INDEX_DIR, COLUMN_NAME, fieldSpec, config,
+            keyTypes, FieldSpec.DataType.STRING)) {
+      for (Map<String, Object> doc : docs) {
+        creator.add(doc);
+      }
+      creator.seal();
+    }
+
+    assertTrue(indexFile.exists(), "Index file should exist after sealing");
+    return indexFile;
+  }
+
+  @Test
+  public void testSparseDataPackedInSPMX()
+      throws IOException {
+    Map<String, FieldSpec.DataType> keyTypes = new HashMap<>();
+    keyTypes.put("color", FieldSpec.DataType.STRING);
+
+    @SuppressWarnings("unchecked")
+    Map<String, Object>[] docs = new Map[]{
+        Map.of("color", "red", "rare_flag", "true", "debug", "x"),  // doc 0
+        Map.of("color", "blue"),                                      // doc 1
+        Map.of("rare_flag", "false"),                                 // doc 2
+        Map.of("color", "red"),                                       // doc 3
+    };
+
+    ComplexFieldSpec fieldSpec = buildMapFieldSpec(COLUMN_NAME);
+    // denseKeyThreshold=1.0 disables auto-detection; only "color" is dense via denseKeys
+    ColumnarMapIndexConfig config = new ColumnarMapIndexConfig(true, null, false, null, null, 1000,
+        Set.of("color"), 1.0);
+    File indexFile = createIndex(fieldSpec, config, keyTypes, docs);
+
+    // Sparse data must be inside SPMX, not a separate sidecar file
+    File sidecarFile = new File(INDEX_DIR, COLUMN_NAME + ".columnarmap.sparse");
+    assertFalse(sidecarFile.exists(), "Sparse data must be inside SPMX, not a separate sidecar file");
+
+    try (PinotDataBuffer buffer = PinotDataBuffer.mapReadOnlyBigEndianFile(indexFile);
+        ImmutableColumnarMapIndexReader reader = new ImmutableColumnarMapIndexReader(buffer, null)) {
+
+      assertEquals(reader.getTierFlag("color"), ImmutableColumnarMapIndexReader.TIER_DENSE);
+      assertEquals(reader.getTierFlag("rare_flag"), ImmutableColumnarMapIndexReader.TIER_SPARSE);
+      assertEquals(reader.getTierFlag("debug"), ImmutableColumnarMapIndexReader.TIER_SPARSE);
+
+      // Dense key still works
+      assertEquals(reader.getString(0, "color"), "red");
+      assertEquals(reader.getString(1, "color"), "blue");
+
+      // Sparse key values round-trip via getSparseJsonBlob
+      String doc0Blob = reader.getSparseJsonBlob(0);
+      assertNotNull(doc0Blob, "doc 0 has sparse keys");
+      assertTrue(doc0Blob.contains("\"rare_flag\":\"true\""), "got: " + doc0Blob);
+      assertTrue(doc0Blob.contains("\"debug\":\"x\""), "got: " + doc0Blob);
+
+      assertNull(reader.getSparseJsonBlob(1), "doc 1 has no sparse keys");
+
+      String doc2Blob = reader.getSparseJsonBlob(2);
+      assertNotNull(doc2Blob, "doc 2 has sparse keys");
+      assertTrue(doc2Blob.contains("\"rare_flag\":\"false\""), "got: " + doc2Blob);
+
+      assertNull(reader.getSparseJsonBlob(3), "doc 3 has no sparse keys");
+    }
+  }
+
+  @Test
+  public void testNoSparseSidecarWhenAllKeysDense()
+      throws IOException {
+    @SuppressWarnings("unchecked")
+    Map<String, Object>[] docs = new Map[]{
+        Map.of("a", "1"),
+        Map.of("a", "2"),
+    };
+
+    ComplexFieldSpec fieldSpec = buildMapFieldSpec(COLUMN_NAME);
+    // denseKeyThreshold=0.0 makes all keys dense
+    ColumnarMapIndexConfig config = new ColumnarMapIndexConfig(true, null, false, null, null, 1000,
+        null, 0.0);
+    File indexFile = createIndex(fieldSpec, config, null, docs);
+
+    File sidecarFile = new File(INDEX_DIR, COLUMN_NAME + ".columnarmap.sparse");
+    assertFalse(sidecarFile.exists(), "No sparse sidecar — never created in any case");
+
+    try (PinotDataBuffer buffer = PinotDataBuffer.mapReadOnlyBigEndianFile(indexFile);
+        ImmutableColumnarMapIndexReader reader = new ImmutableColumnarMapIndexReader(buffer, null)) {
+      assertNull(reader.getSparseJsonBlob(0), "no sparse data when all keys dense");
+      assertNull(reader.getSparseJsonBlob(1), "no sparse data when all keys dense");
+    }
+  }
+}

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/V1Constants.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/V1Constants.java
@@ -46,6 +46,7 @@ public class V1Constants {
     public static final String BITMAP_INVERTED_INDEX_FILE_EXTENSION = ".bitmap.inv";
     public static final String BITMAP_RANGE_INDEX_FILE_EXTENSION = ".bitmap.range";
     public static final String JSON_INDEX_FILE_EXTENSION = ".json.idx";
+    public static final String COLUMNAR_MAP_INDEX_FILE_EXTENSION = ".columnarmap.idx";
     /** @deprecated Legacy native text index file extension kept only for cleanup and migration logic. */
     @Deprecated
     public static final String DEPRECATED_NATIVE_TEXT_INDEX_FILE_EXTENSION = ".nativetext.idx";
@@ -98,6 +99,7 @@ public class V1Constants {
       public static final String SEGMENT_TOTAL_DOCS = "segment.total.docs";
       public static final String SEGMENT_PADDING_CHARACTER = "segment.padding.character";
       public static final String COMPLEX_COLUMNS = "segment.complex.column.names";
+      public static final String COLUMNAR_MAP_COLUMNS = "segment.columnarmap.column.names";
 
       public static final String CUSTOM_SUBSET = "custom";
 
@@ -132,6 +134,9 @@ public class V1Constants {
       public static final String DATETIME_FORMAT = "datetimeFormat";
       public static final String DATETIME_GRANULARITY = "datetimeGranularity";
       public static final String COMPLEX_CHILD_FIELD_NAMES = "complexChildFieldNames";
+      public static final String COLUMNAR_MAP_KEY_NAMES = "columnarMapKeyNames";
+      public static final String COLUMNAR_MAP_KEY_TYPE_PREFIX = "columnarMapKeyType";
+      public static final String COLUMNAR_MAP_DEFAULT_VALUE_TYPE = "columnarMapDefaultValueType";
 
       public static final String COLUMN_PROPS_KEY_PREFIX = "column.";
       public static final String SCHEMA_MAX_LENGTH = "schemaMaxLength";

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/SegmentGeneratorConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/SegmentGeneratorConfig.java
@@ -36,6 +36,7 @@ import org.apache.pinot.segment.spi.creator.name.SimpleSegmentNameGenerator;
 import org.apache.pinot.segment.spi.creator.name.UploadedRealtimeSegmentNameGenerator;
 import org.apache.pinot.segment.spi.index.FieldIndexConfigs;
 import org.apache.pinot.segment.spi.index.FieldIndexConfigsUtil;
+import org.apache.pinot.segment.spi.index.StandardIndexes;
 import org.apache.pinot.spi.config.instance.InstanceType;
 import org.apache.pinot.spi.config.table.FieldConfig;
 import org.apache.pinot.spi.config.table.IndexingConfig;
@@ -528,6 +529,23 @@ public class SegmentGeneratorConfig implements Serializable {
 
   public List<String> getComplexColumnNames() {
     return getQualifyingFields(FieldType.COMPLEX, true);
+  }
+
+  public List<String> getColumnarMapColumnNames() {
+    List<String> fields = new ArrayList<>();
+    for (FieldSpec fieldSpec : getSchema().getAllFieldSpecs()) {
+      if (fieldSpec.isVirtualColumn()) {
+        continue;
+      }
+      if (fieldSpec.getDataType() == FieldSpec.DataType.MAP) {
+        FieldIndexConfigs indexConfigs = _indexConfigsByColName.get(fieldSpec.getName());
+        if (indexConfigs != null && indexConfigs.getConfig(StandardIndexes.columnarMap()).isEnabled()) {
+          fields.add(fieldSpec.getName());
+        }
+      }
+    }
+    Collections.sort(fields);
+    return fields;
   }
 
   public void setSegmentPartitionConfig(SegmentPartitionConfig segmentPartitionConfig) {

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/StandardIndexes.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/StandardIndexes.java
@@ -20,6 +20,7 @@
 package org.apache.pinot.segment.spi.index;
 
 import org.apache.pinot.segment.spi.index.creator.BloomFilterCreator;
+import org.apache.pinot.segment.spi.index.creator.ColumnarMapIndexCreator;
 import org.apache.pinot.segment.spi.index.creator.CombinedInvertedIndexCreator;
 import org.apache.pinot.segment.spi.index.creator.DictionaryBasedInvertedIndexCreator;
 import org.apache.pinot.segment.spi.index.creator.FSTIndexCreator;
@@ -31,6 +32,7 @@ import org.apache.pinot.segment.spi.index.creator.TextIndexCreator;
 import org.apache.pinot.segment.spi.index.creator.VectorIndexConfig;
 import org.apache.pinot.segment.spi.index.creator.VectorIndexCreator;
 import org.apache.pinot.segment.spi.index.reader.BloomFilterReader;
+import org.apache.pinot.segment.spi.index.reader.ColumnarMapIndexReader;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.segment.spi.index.reader.ForwardIndexReader;
 import org.apache.pinot.segment.spi.index.reader.H3IndexReader;
@@ -41,6 +43,7 @@ import org.apache.pinot.segment.spi.index.reader.RangeIndexReader;
 import org.apache.pinot.segment.spi.index.reader.TextIndexReader;
 import org.apache.pinot.segment.spi.index.reader.VectorIndexReader;
 import org.apache.pinot.spi.config.table.BloomFilterConfig;
+import org.apache.pinot.spi.config.table.ColumnarMapIndexConfig;
 import org.apache.pinot.spi.config.table.IndexConfig;
 import org.apache.pinot.spi.config.table.JsonIndexConfig;
 
@@ -79,6 +82,7 @@ public class StandardIndexes {
   public static final String TEXT_ID = "text_index";
   public static final String H3_ID = "h3_index";
   public static final String VECTOR_ID = "vector_index";
+  public static final String COLUMNAR_MAP_ID = "columnar_map_index";
 
   private StandardIndexes() {
   }
@@ -141,5 +145,11 @@ public class StandardIndexes {
   public static IndexType<VectorIndexConfig, VectorIndexReader, VectorIndexCreator> vector() {
     return (IndexType<VectorIndexConfig, VectorIndexReader, VectorIndexCreator>)
         IndexService.getInstance().get(VECTOR_ID);
+  }
+
+  @SuppressWarnings("unchecked")
+  public static IndexType<ColumnarMapIndexConfig, ColumnarMapIndexReader, ColumnarMapIndexCreator> columnarMap() {
+    return (IndexType<ColumnarMapIndexConfig, ColumnarMapIndexReader, ColumnarMapIndexCreator>)
+        IndexService.getInstance().get(COLUMNAR_MAP_ID);
   }
 }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/creator/ColumnarMapIndexCreator.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/creator/ColumnarMapIndexCreator.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.spi.index.creator;
+
+import java.io.IOException;
+import java.util.Map;
+import org.apache.pinot.segment.spi.index.IndexCreator;
+
+
+/**
+ * Creator for the ColumnarMap index. Accepts a Map per document during segment creation and
+ * decomposes it into per-key columnar storage (presence bitmaps, typed forward indexes,
+ * optional inverted indexes) on seal().
+ */
+public interface ColumnarMapIndexCreator extends IndexCreator {
+
+  /**
+   * Adds a document's sparse map data. The map may be null or empty if the document has no keys.
+   * Keys in the map that match declared key types are stored with typed per-key forward indexes.
+   * Undeclared keys are stored using the default value type (STRING if not configured).
+   */
+  void add(Map<String, Object> columnarMap)
+      throws IOException;
+
+  /**
+   * Finalizes the index, writing per-key presence bitmaps, typed forward indexes, and optional
+   * inverted indexes to the index file.
+   */
+  @Override
+  void seal()
+      throws IOException;
+}

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/metadata/ColumnMetadataImpl.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/metadata/ColumnMetadataImpl.java
@@ -381,6 +381,27 @@ public class ColumnMetadataImpl implements ColumnMetadata {
               generateFieldSpec(ComplexFieldSpec.getFullChildName(column, childField), config));
         }
         fieldSpec = new ComplexFieldSpec(fieldName, dataType, true, childFieldSpecs);
+        // Restore keyTypes and defaultValueType from segment metadata for MAP columns
+        if (dataType == DataType.MAP) {
+          List<String> keyNames = config.getList(String.class,
+              Column.getKeyFor(column, Column.COLUMNAR_MAP_KEY_NAMES), null);
+          if (keyNames != null && !keyNames.isEmpty()) {
+            Map<String, DataType> keyTypes = new HashMap<>();
+            for (String keyName : keyNames) {
+              String typeStr = config.getString(
+                  Column.getKeyFor(column, Column.COLUMNAR_MAP_KEY_TYPE_PREFIX + "." + keyName), null);
+              if (typeStr != null) {
+                keyTypes.put(keyName, DataType.valueOf(typeStr));
+              }
+            }
+            ((ComplexFieldSpec) fieldSpec).setKeyTypes(keyTypes);
+          }
+          String defaultTypeStr = config.getString(
+              Column.getKeyFor(column, Column.COLUMNAR_MAP_DEFAULT_VALUE_TYPE), null);
+          if (defaultTypeStr != null) {
+            ((ComplexFieldSpec) fieldSpec).setDefaultValueType(DataType.valueOf(defaultTypeStr));
+          }
+        }
         break;
       default:
         throw new IllegalStateException("Unsupported field type: " + fieldType);

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/metadata/SegmentMetadataImpl.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/metadata/SegmentMetadataImpl.java
@@ -236,6 +236,7 @@ public class SegmentMetadataImpl implements SegmentMetadata {
     addPhysicalColumns(segmentMetadata.getList(Segment.TIME_COLUMN_NAME), physicalColumns);
     addPhysicalColumns(segmentMetadata.getList(Segment.DATETIME_COLUMNS), physicalColumns);
     addPhysicalColumns(segmentMetadata.getList(Segment.COMPLEX_COLUMNS), physicalColumns);
+    addPhysicalColumns(segmentMetadata.getList(Segment.COLUMNAR_MAP_COLUMNS), physicalColumns);
 
     // Set the table name (for backward compatibility)
     String tableName = segmentMetadata.getString(Segment.TABLE_NAME);

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/ColumnarMapIndexReader.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/ColumnarMapIndexReader.java
@@ -1,0 +1,110 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.spi.index.reader;
+
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.segment.spi.index.IndexReader;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
+
+
+/**
+ * Reader for the ColumnarMap index. Provides O(1) typed key lookup per document via presence bitmap
+ * rank operations. Each key has its own presence bitmap and typed forward index, allowing direct
+ * typed reads without full map deserialization.
+ */
+public interface ColumnarMapIndexReader extends IndexReader {
+
+  /**
+   * Returns the set of all indexed key names.
+   */
+  Set<String> getKeys();
+
+  /**
+   * Returns the value DataType for the given key, or null if the key is not indexed.
+   */
+  @Nullable
+  DataType getKeyValueType(String key);
+
+  /**
+   * Returns the number of documents that have the given key (i.e., the size of the presence bitmap).
+   */
+  int getNumDocsWithKey(String key);
+
+  /**
+   * Returns the presence bitmap for the given key. A document is present in this bitmap if and
+   * only if it has a non-null value for the key. This bitmap is the inverted null bitmap.
+   */
+  ImmutableRoaringBitmap getPresenceBitmap(String key);
+
+  // Typed value access -- O(1) per doc via presence bitmap rank
+  // Returns the default value (0, 0L, 0.0f, 0.0, "", new byte[0]) if the doc does not have the key.
+
+  int getInt(int docId, String key);
+
+  long getLong(int docId, String key);
+
+  float getFloat(int docId, String key);
+
+  double getDouble(int docId, String key);
+
+  String getString(int docId, String key);
+
+  byte[] getBytes(int docId, String key);
+
+  /**
+   * Returns a bitmap of docIds that have the given key-value pair.
+   * Only available if per-key inverted index is enabled (enableInvertedIndexForAll=true or key in invertedIndexKeys).
+   * Returns null if inverted index is not available for this key.
+   */
+  @Nullable
+  ImmutableRoaringBitmap getDocsWithKeyValue(String key, Object value);
+
+  /**
+   * Returns a DataSource for the given key, suitable for use with ItemTransformFunction and
+   * MapFilterOperator. The DataSource provides typed single-value access backed by the per-key
+   * forward index.
+   */
+  DataSource getKeyDataSource(String key);
+
+  /**
+   * Reconstructs the full map for a document from per-key data. Used for SELECT sparse_col queries
+   * and data table transport to the broker.
+   */
+  Map<String, Object> getMap(int docId);
+
+  /**
+   * Returns whether the given key has an inverted index available.
+   */
+  default boolean hasInvertedIndex(String key) {
+    return false;
+  }
+
+  /**
+   * Returns the sorted distinct values for the given key from the inverted index, or null if no
+   * inverted index is available. Used to build a dictionary for dictionary-based GROUP BY.
+   */
+  @Nullable
+  default String[] getDistinctValuesForKey(String key) {
+    return null;
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ColumnarMapIndexConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ColumnarMapIndexConfig.java
@@ -1,0 +1,218 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.config.table;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+
+
+/**
+ * Configuration for the ColumnarMap index on a MAP column.
+ * Controls which keys are indexed per-key in columnar storage and whether
+ * per-key inverted indexes are enabled for fast value-based filtering.
+ *
+ * <p>Inverted index control:
+ * <ul>
+ *   <li>{@code enableInvertedIndexForAll: true} — inverted index on ALL keys
+ *       ({@code invertedIndexKeys} is ignored)</li>
+ *   <li>{@code enableInvertedIndexForAll: false} + {@code invertedIndexKeys: [...]} —
+ *       only the listed keys get inverted indexes</li>
+ *   <li>{@code enableInvertedIndexForAll: false} + no {@code invertedIndexKeys} —
+ *       no inverted indexes</li>
+ * </ul>
+ */
+public class ColumnarMapIndexConfig extends IndexConfig {
+  public static final ColumnarMapIndexConfig DISABLED = new ColumnarMapIndexConfig(false);
+  public static final ColumnarMapIndexConfig DEFAULT = new ColumnarMapIndexConfig(true);
+
+  public static final double DEFAULT_DENSE_KEY_THRESHOLD = 0.5;
+
+  private final Set<String> _indexedKeys;
+  private final boolean _enableInvertedIndexForAll;
+  private final Set<String> _invertedIndexKeys;
+  private final Set<String> _noDictionaryKeys;
+  private final int _maxKeys;
+  private final Set<String> _denseKeys;
+  private final double _denseKeyThreshold;
+
+  /**
+   * Creates a ColumnarMapIndexConfig from FieldConfig properties map.
+   * Reads the COLUMNAR_MAP_INDEX_* property constants from {@link FieldConfig}.
+   */
+  public static ColumnarMapIndexConfig fromProperties(@Nullable Map<String, String> properties) {
+    if (properties == null || properties.isEmpty()) {
+      return DEFAULT;
+    }
+    int maxKeys = Integer.parseInt(
+        properties.getOrDefault(FieldConfig.COLUMNAR_MAP_INDEX_MAX_KEYS, "1000"));
+    Set<String> invertedIndexKeys = parseCommaSeparated(
+        properties.get(FieldConfig.COLUMNAR_MAP_INDEX_INVERTED_INDEX_KEYS));
+    Set<String> noDictionaryKeys = parseCommaSeparated(
+        properties.get(FieldConfig.COLUMNAR_MAP_INDEX_NO_DICTIONARY_KEYS));
+    boolean enableInvertedForAll = Boolean.parseBoolean(
+        properties.getOrDefault(FieldConfig.COLUMNAR_MAP_INDEX_ENABLE_INVERTED_FOR_ALL, "false"));
+    Set<String> denseKeys = parseCommaSeparated(
+        properties.get(FieldConfig.COLUMNAR_MAP_INDEX_DENSE_KEYS));
+    double denseKeyThreshold = Double.parseDouble(
+        properties.getOrDefault(FieldConfig.COLUMNAR_MAP_INDEX_DENSE_KEY_THRESHOLD,
+            String.valueOf(DEFAULT_DENSE_KEY_THRESHOLD)));
+    return new ColumnarMapIndexConfig(true, null, enableInvertedForAll, invertedIndexKeys, noDictionaryKeys, maxKeys,
+        denseKeys, denseKeyThreshold);
+  }
+
+  @Nullable
+  private static Set<String> parseCommaSeparated(@Nullable String value) {
+    if (value == null || value.trim().isEmpty()) {
+      return null;
+    }
+    Set<String> result = new HashSet<>();
+    for (String part : value.split(FieldConfig.COLUMNAR_MAP_INDEX_KEY_SEPARATOR)) {
+      String trimmed = part.trim();
+      if (!trimmed.isEmpty()) {
+        result.add(trimmed);
+      }
+    }
+    return result.isEmpty() ? null : result;
+  }
+
+  public ColumnarMapIndexConfig(boolean enabled) {
+    this(enabled, null, false, null, null, 1000, null, DEFAULT_DENSE_KEY_THRESHOLD);
+  }
+
+  public ColumnarMapIndexConfig(boolean enabled, @Nullable Set<String> indexedKeys,
+      boolean enableInvertedIndexForAll, @Nullable Set<String> invertedIndexKeys, int maxKeys) {
+    this(enabled, indexedKeys, enableInvertedIndexForAll, invertedIndexKeys, null, maxKeys,
+        null, DEFAULT_DENSE_KEY_THRESHOLD);
+  }
+
+  public ColumnarMapIndexConfig(boolean enabled, @Nullable Set<String> indexedKeys,
+      boolean enableInvertedIndexForAll, @Nullable Set<String> invertedIndexKeys,
+      @Nullable Set<String> noDictionaryKeys, int maxKeys) {
+    this(enabled, indexedKeys, enableInvertedIndexForAll, invertedIndexKeys, noDictionaryKeys, maxKeys,
+        null, DEFAULT_DENSE_KEY_THRESHOLD);
+  }
+
+  @JsonCreator
+  public ColumnarMapIndexConfig(
+      @JsonProperty("enabled") boolean enabled,
+      @JsonProperty("indexedKeys") @Nullable Set<String> indexedKeys,
+      @JsonProperty("enableInvertedIndexForAll") boolean enableInvertedIndexForAll,
+      @JsonProperty("invertedIndexKeys") @Nullable Set<String> invertedIndexKeys,
+      @JsonProperty("noDictionaryKeys") @Nullable Set<String> noDictionaryKeys,
+      @JsonProperty("maxKeys") int maxKeys,
+      @JsonProperty("denseKeys") @Nullable Set<String> denseKeys,
+      @JsonProperty("denseKeyThreshold") double denseKeyThreshold) {
+    super(!enabled);
+    _indexedKeys = indexedKeys;
+    _enableInvertedIndexForAll = enableInvertedIndexForAll;
+    _invertedIndexKeys = invertedIndexKeys;
+    _noDictionaryKeys = noDictionaryKeys;
+    _maxKeys = maxKeys > 0 ? maxKeys : 1000;
+    _denseKeys = denseKeys;
+    _denseKeyThreshold = denseKeyThreshold >= 0 ? denseKeyThreshold : DEFAULT_DENSE_KEY_THRESHOLD;
+  }
+
+  /**
+   * Returns the set of keys to index, or null if all keys should be indexed.
+   */
+  @Nullable
+  public Set<String> getIndexedKeys() {
+    return _indexedKeys;
+  }
+
+  /**
+   * Returns true if inverted indexes should be created for ALL keys.
+   */
+  public boolean isEnableInvertedIndexForAll() {
+    return _enableInvertedIndexForAll;
+  }
+
+  /**
+   * Returns the set of keys that should have inverted indexes, or null if not specified.
+   * Only consulted when {@link #isEnableInvertedIndexForAll()} is false.
+   */
+  @Nullable
+  public Set<String> getInvertedIndexKeys() {
+    return _invertedIndexKeys;
+  }
+
+  /**
+   * Returns true if an inverted index should be created for the given key.
+   * Returns true if {@code enableInvertedIndexForAll} is set, or if the key
+   * is in the {@code invertedIndexKeys} set.
+   */
+  public boolean shouldEnableInvertedIndexForKey(String key) {
+    return _enableInvertedIndexForAll
+        || (_invertedIndexKeys != null && _invertedIndexKeys.contains(key));
+  }
+
+  /**
+   * Returns the set of keys that should always use raw encoding (no dictionary),
+   * or null if not specified (all keys eligible for dictionary encoding).
+   */
+  @Nullable
+  public Set<String> getNoDictionaryKeys() {
+    return _noDictionaryKeys;
+  }
+
+  /**
+   * Returns true if dictionary encoding is allowed for the given key.
+   * Returns false if the key is in the {@code noDictionaryKeys} set.
+   */
+  public boolean shouldUseDictionaryForKey(String key) {
+    return _noDictionaryKeys == null || !_noDictionaryKeys.contains(key);
+  }
+
+  /**
+   * Returns the maximum number of distinct keys allowed. Keys beyond this cap fall back to
+   * the forward index blob. Default is 1000.
+   */
+  public int getMaxKeys() {
+    return _maxKeys;
+  }
+
+  /**
+   * Returns the set of keys that are always stored as dense (full forward index),
+   * regardless of fill rate. Returns empty set if not specified.
+   */
+  public Set<String> getDenseKeys() {
+    return _denseKeys != null ? _denseKeys : Set.of();
+  }
+
+  /**
+   * Returns the fill-rate threshold for automatic dense tier assignment.
+   * Keys present in more than {@code denseKeyThreshold * numDocs} documents are
+   * automatically promoted to dense tier. Default is 0.5 (50%).
+   */
+  public double getDenseKeyThreshold() {
+    return _denseKeyThreshold;
+  }
+
+  /**
+   * Returns true if the given key is explicitly declared as dense via config.
+   * Note: keys may also be auto-promoted to dense based on fill rate at segment creation time.
+   */
+  public boolean isDenseKey(String key) {
+    return _denseKeys != null && _denseKeys.contains(key);
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FieldConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FieldConfig.java
@@ -65,6 +65,15 @@ public class FieldConfig extends BaseJsonConfig {
   // Config to disable forward index
   public static final String FORWARD_INDEX_DISABLED = "forwardIndexDisabled";
   public static final String DEFAULT_FORWARD_INDEX_DISABLED = Boolean.FALSE.toString();
+
+  // Config for COLUMNAR_MAP index (columnar per-key storage for MAP columns)
+  public static final String COLUMNAR_MAP_INDEX_MAX_KEYS = "maxKeys";
+  public static final String COLUMNAR_MAP_INDEX_INVERTED_INDEX_KEYS = "invertedIndexKeys";
+  public static final String COLUMNAR_MAP_INDEX_NO_DICTIONARY_KEYS = "noDictionaryKeys";
+  public static final String COLUMNAR_MAP_INDEX_ENABLE_INVERTED_FOR_ALL = "enableInvertedIndexForAll";
+  public static final String COLUMNAR_MAP_INDEX_DENSE_KEYS = "denseKeys";
+  public static final String COLUMNAR_MAP_INDEX_DENSE_KEY_THRESHOLD = "denseKeyThreshold";
+  public static final String COLUMNAR_MAP_INDEX_KEY_SEPARATOR = ",";
   public static final String TEXT_INDEX_ENABLE_PREFIX_SUFFIX_PHRASE_QUERIES =
       "enablePrefixSuffixMatchingInPhraseQueries";
   public static final String TEXT_INDEX_LUCENE_REUSE_MUTABLE_INDEX = "reuseMutableIndex";
@@ -128,7 +137,7 @@ public class FieldConfig extends BaseJsonConfig {
   // If null, there won't be any index
   // NOTE: TIMESTAMP is ignored. In order to create TIMESTAMP index, configure 'timestampConfig' instead.
   public enum IndexType {
-    INVERTED, SORTED, TEXT, FST, IFST, H3, JSON, TIMESTAMP, VECTOR, RANGE
+    INVERTED, SORTED, TEXT, FST, IFST, H3, JSON, TIMESTAMP, VECTOR, RANGE, COLUMNAR_MAP
   }
 
   public enum CompressionCodec {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/ComplexFieldSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/ComplexFieldSpec.java
@@ -20,10 +20,13 @@ package org.apache.pinot.spi.data;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Preconditions;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
+import javax.annotation.Nullable;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.StringUtil;
 
@@ -52,11 +55,14 @@ import org.apache.pinot.spi.utils.StringUtil;
  * to model the hierarchy
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonTypeName("COMPLEX")
 public final class ComplexFieldSpec extends FieldSpec {
   public static final String KEY_FIELD = "key";
   public static final String VALUE_FIELD = "value";
 
   private final Map<String, FieldSpec> _childFieldSpecs;
+  private Map<String, DataType> _keyTypes;
+  private DataType _defaultValueType;
 
   // Default constructor required by JSON de-serializer
   public ComplexFieldSpec() {
@@ -68,7 +74,7 @@ public final class ComplexFieldSpec extends FieldSpec {
       Map<String, FieldSpec> childFieldSpecs) {
     super(name, dataType, isSingleValueField);
     Preconditions.checkArgument(dataType == DataType.STRUCT || dataType == DataType.MAP || dataType == DataType.LIST);
-    _childFieldSpecs = childFieldSpecs;
+    _childFieldSpecs = new HashMap<>(childFieldSpecs);
   }
 
   public static String[] getColumnPath(String column) {
@@ -76,11 +82,40 @@ public final class ComplexFieldSpec extends FieldSpec {
   }
 
   public FieldSpec getChildFieldSpec(String child) {
-    return _childFieldSpecs.get(child);
+    return getChildFieldSpecs().get(child);
   }
 
+  public void addChildFieldSpec(String child, FieldSpec fieldSpec) {
+    _childFieldSpecs.put(child, fieldSpec);
+  }
+
+  @JsonIgnore
   public Map<String, FieldSpec> getChildFieldSpecs() {
+    if (_childFieldSpecs.isEmpty() && _dataType == DataType.MAP) {
+      Map<String, FieldSpec> defaults = new HashMap<>();
+      defaults.put(KEY_FIELD, new DimensionFieldSpec(KEY_FIELD, DataType.STRING, true));
+      defaults.put(VALUE_FIELD, new DimensionFieldSpec(VALUE_FIELD, DataType.STRING, true));
+      return defaults;
+    }
     return _childFieldSpecs;
+  }
+
+  @Nullable
+  public Map<String, DataType> getKeyTypes() {
+    return _keyTypes;
+  }
+
+  public void setKeyTypes(@Nullable Map<String, DataType> keyTypes) {
+    _keyTypes = keyTypes;
+  }
+
+  @Nullable
+  public DataType getDefaultValueType() {
+    return _defaultValueType;
+  }
+
+  public void setDefaultValueType(@Nullable DataType defaultValueType) {
+    _defaultValueType = defaultValueType;
   }
 
   @JsonIgnore
@@ -99,15 +134,30 @@ public final class ComplexFieldSpec extends FieldSpec {
     private final String _fieldName;
     private final FieldSpec _keyFieldSpec;
     private final FieldSpec _valueFieldSpec;
+    private final Map<String, FieldSpec.DataType> _keyTypes;
+    private final FieldSpec.DataType _defaultValueType;
 
     private MapFieldSpec(ComplexFieldSpec complexFieldSpec) {
-      Preconditions.checkState(complexFieldSpec.getChildFieldSpecs().containsKey(KEY_FIELD),
-          "Missing 'key' in the 'childFieldSpec'");
-      Preconditions.checkState(complexFieldSpec.getChildFieldSpecs().containsKey(VALUE_FIELD),
-          "Missing 'value' in the 'childFieldSpec'");
-      _keyFieldSpec = complexFieldSpec.getChildFieldSpec(KEY_FIELD);
-      _valueFieldSpec = complexFieldSpec.getChildFieldSpec(VALUE_FIELD);
+      this(complexFieldSpec, null, null);
+    }
+
+    private MapFieldSpec(ComplexFieldSpec complexFieldSpec,
+        @Nullable Map<String, FieldSpec.DataType> keyTypes,
+        @Nullable FieldSpec.DataType defaultValueType) {
+      Map<String, FieldSpec> children = complexFieldSpec.getChildFieldSpecs();
+      if (children.containsKey(KEY_FIELD)) {
+        _keyFieldSpec = complexFieldSpec.getChildFieldSpec(KEY_FIELD);
+      } else {
+        _keyFieldSpec = new DimensionFieldSpec(KEY_FIELD, DataType.STRING, true);
+      }
+      if (children.containsKey(VALUE_FIELD)) {
+        _valueFieldSpec = complexFieldSpec.getChildFieldSpec(VALUE_FIELD);
+      } else {
+        _valueFieldSpec = new DimensionFieldSpec(VALUE_FIELD, DataType.STRING, true);
+      }
       _fieldName = complexFieldSpec.getName();
+      _keyTypes = keyTypes != null ? keyTypes : complexFieldSpec.getKeyTypes();
+      _defaultValueType = defaultValueType != null ? defaultValueType : complexFieldSpec.getDefaultValueType();
     }
 
     public String getFieldName() {
@@ -121,10 +171,30 @@ public final class ComplexFieldSpec extends FieldSpec {
     public FieldSpec getValueFieldSpec() {
       return _valueFieldSpec;
     }
+
+    @Nullable
+    public Map<String, FieldSpec.DataType> getKeyTypes() {
+      return _keyTypes;
+    }
+
+    @Nullable
+    public FieldSpec.DataType getDefaultValueType() {
+      return _defaultValueType;
+    }
+
+    public FieldSpec.DataType getEffectiveDefaultValueType() {
+      return _defaultValueType != null ? _defaultValueType : FieldSpec.DataType.STRING;
+    }
   }
 
   public static MapFieldSpec toMapFieldSpec(ComplexFieldSpec complexFieldSpec) {
     return new MapFieldSpec(complexFieldSpec);
+  }
+
+  public static MapFieldSpec toMapFieldSpec(ComplexFieldSpec complexFieldSpec,
+      @Nullable Map<String, FieldSpec.DataType> keyTypes,
+      @Nullable FieldSpec.DataType defaultValueType) {
+    return new MapFieldSpec(complexFieldSpec, keyTypes, defaultValueType);
   }
 
   public static ComplexFieldSpec fromMapFieldSpec(MapFieldSpec mapFieldSpec) {
@@ -141,13 +211,43 @@ public final class ComplexFieldSpec extends FieldSpec {
     return StringUtil.join("$$", columns);
   }
 
+  @Override
+  public boolean equals(Object o) {
+    if (!super.equals(o)) {
+      return false;
+    }
+    ComplexFieldSpec that = (ComplexFieldSpec) o;
+    return Objects.equals(_keyTypes, that._keyTypes)
+        && Objects.equals(_defaultValueType, that._defaultValueType);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = super.hashCode();
+    result = 31 * result + Objects.hashCode(_keyTypes);
+    result = 31 * result + Objects.hashCode(_defaultValueType);
+    return result;
+  }
+
   public ObjectNode toJsonObject() {
     ObjectNode jsonObject = super.toJsonObject();
-    ObjectNode childFieldSpecsNode = JsonUtils.newObjectNode();
-    for (Map.Entry<String, FieldSpec> entry : _childFieldSpecs.entrySet()) {
-      childFieldSpecsNode.put(entry.getKey(), entry.getValue().toJsonObject());
+    if (!_childFieldSpecs.isEmpty()) {
+      ObjectNode childFieldSpecsNode = JsonUtils.newObjectNode();
+      for (Map.Entry<String, FieldSpec> entry : _childFieldSpecs.entrySet()) {
+        childFieldSpecsNode.put(entry.getKey(), entry.getValue().toJsonObject());
+      }
+      jsonObject.put("childFieldSpecs", childFieldSpecsNode);
     }
-    jsonObject.put("childFieldSpecs", childFieldSpecsNode);
+    if (_keyTypes != null && !_keyTypes.isEmpty()) {
+      ObjectNode keyTypesNode = JsonUtils.newObjectNode();
+      for (Map.Entry<String, DataType> entry : _keyTypes.entrySet()) {
+        keyTypesNode.put(entry.getKey(), entry.getValue().name());
+      }
+      jsonObject.set("keyTypes", keyTypesNode);
+    }
+    if (_defaultValueType != null) {
+      jsonObject.put("defaultValueType", _defaultValueType.name());
+    }
     return jsonObject;
   }
 }

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/config/table/ColumnarMapIndexConfigTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/config/table/ColumnarMapIndexConfigTest.java
@@ -1,0 +1,110 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.config.table;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+
+/** Tests for {@link ColumnarMapIndexConfig} deserialization, defaults, and property round-trips. */
+public class ColumnarMapIndexConfigTest {
+
+  @Test
+  public void testDenseKeysFromProperties() {
+    Map<String, String> props = new HashMap<>();
+    props.put("denseKeys", "country,tenancy,device_os");
+    props.put("denseKeyThreshold", "0.3");
+    props.put("maxKeys", "500");
+
+    ColumnarMapIndexConfig config = ColumnarMapIndexConfig.fromProperties(props);
+
+    assertEquals(config.getDenseKeys(), Set.of("country", "tenancy", "device_os"));
+    assertEquals(config.getDenseKeyThreshold(), 0.3, 0.001);
+    assertEquals(config.getMaxKeys(), 500);
+  }
+
+  @Test
+  public void testDenseKeysDefaults() {
+    ColumnarMapIndexConfig config = ColumnarMapIndexConfig.fromProperties(Map.of());
+
+    assertTrue(config.getDenseKeys().isEmpty());
+    assertEquals(config.getDenseKeyThreshold(), 0.5, 0.001);
+  }
+
+  @Test
+  public void testIsDenseKey() {
+    Map<String, String> props = new HashMap<>();
+    props.put("denseKeys", "country,tenancy");
+
+    ColumnarMapIndexConfig config = ColumnarMapIndexConfig.fromProperties(props);
+
+    assertTrue(config.isDenseKey("country"));
+    assertTrue(config.isDenseKey("tenancy"));
+    assertFalse(config.isDenseKey("rare_flag"));
+  }
+
+  @Test
+  public void testDenseKeysWithInvertedIndex() {
+    Map<String, String> props = new HashMap<>();
+    props.put("denseKeys", "country");
+    props.put("invertedIndexKeys", "country,status");
+    props.put("denseKeyThreshold", "0.8");
+
+    ColumnarMapIndexConfig config = ColumnarMapIndexConfig.fromProperties(props);
+
+    assertTrue(config.isDenseKey("country"));
+    assertFalse(config.isDenseKey("status"));
+    assertTrue(config.shouldEnableInvertedIndexForKey("country"));
+    assertTrue(config.shouldEnableInvertedIndexForKey("status"));
+    assertFalse(config.shouldEnableInvertedIndexForKey("unknown"));
+    assertEquals(config.getDenseKeyThreshold(), 0.8, 0.001);
+  }
+
+  @Test
+  public void testDefaultConstructorDenseKeyDefaults() {
+    ColumnarMapIndexConfig config = new ColumnarMapIndexConfig(true);
+
+    assertTrue(config.getDenseKeys().isEmpty());
+    assertEquals(config.getDenseKeyThreshold(), 0.5, 0.001);
+    assertFalse(config.isDenseKey("anything"));
+  }
+
+  @Test
+  public void testNullPropertiesReturnDefault() {
+    ColumnarMapIndexConfig config = ColumnarMapIndexConfig.fromProperties(null);
+
+    assertTrue(config.getDenseKeys().isEmpty());
+    assertEquals(config.getDenseKeyThreshold(), 0.5, 0.001);
+  }
+
+  @Test
+  public void testDenseKeyThresholdZeroMakesAllDense() {
+    Map<String, String> props = new HashMap<>();
+    props.put("denseKeyThreshold", "0.0");
+
+    ColumnarMapIndexConfig config = ColumnarMapIndexConfig.fromProperties(props);
+
+    // Threshold of 0 means any key with >0% fill rate is auto-dense
+    assertEquals(config.getDenseKeyThreshold(), 0.0, 0.001);
+  }
+}

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/data/ColumnarMapDataTypeTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/data/ColumnarMapDataTypeTest.java
@@ -1,0 +1,250 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.data;
+
+import java.util.Map;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+
+/**
+ * Unit tests for MAP DataType and Schema integration using ComplexFieldSpec.
+ */
+public class ColumnarMapDataTypeTest {
+
+  @Test
+  public void testMapDataTypeProperties() {
+    FieldSpec.DataType dt = FieldSpec.DataType.MAP;
+    assertEquals(dt.getStoredType(), FieldSpec.DataType.MAP);
+    assertFalse(dt.isFixedWidth());
+    assertFalse(dt.isNumeric());
+  }
+
+  @Test
+  public void testSchemaValidationAcceptsMapField() {
+    Schema schema = new Schema();
+    Map<String, FieldSpec> childFieldSpecs = Map.of(
+        "key", new DimensionFieldSpec("key", FieldSpec.DataType.STRING, true),
+        "value", new DimensionFieldSpec("value", FieldSpec.DataType.STRING, true)
+    );
+    ComplexFieldSpec spec = new ComplexFieldSpec("features", FieldSpec.DataType.MAP, true, childFieldSpecs);
+    schema.addField(spec);
+    schema.validate();
+    assertNotNull(schema.getFieldSpecFor("features"));
+    assertEquals(schema.getFieldSpecFor("features").getDataType(), FieldSpec.DataType.MAP);
+    assertEquals(schema.getFieldSpecFor("features").getFieldType(), FieldSpec.FieldType.COMPLEX);
+  }
+
+  @Test
+  public void testSchemaMultipleMapColumns() {
+    Schema schema = new Schema();
+
+    Map<String, FieldSpec> childFieldSpecs = Map.of(
+        "key", new DimensionFieldSpec("key", FieldSpec.DataType.STRING, true),
+        "value", new DimensionFieldSpec("value", FieldSpec.DataType.STRING, true)
+    );
+    ComplexFieldSpec features = new ComplexFieldSpec("features", FieldSpec.DataType.MAP, true, childFieldSpecs);
+    schema.addField(features);
+
+    ComplexFieldSpec labels = new ComplexFieldSpec("labels", FieldSpec.DataType.MAP, true, childFieldSpecs);
+    schema.addField(labels);
+
+    schema.addField(new DimensionFieldSpec("userId", FieldSpec.DataType.STRING, true));
+    schema.validate();
+    assertNotNull(schema.getFieldSpecFor("features"));
+    assertNotNull(schema.getFieldSpecFor("labels"));
+    assertEquals(schema.getFieldSpecFor("features").getDataType(), FieldSpec.DataType.MAP);
+    assertEquals(schema.getFieldSpecFor("features").getFieldType(), FieldSpec.FieldType.COMPLEX);
+  }
+
+  @Test
+  public void testComplexFieldSpecIsSingleValue() {
+    Map<String, FieldSpec> childFieldSpecs = Map.of(
+        "key", new DimensionFieldSpec("key", FieldSpec.DataType.STRING, true),
+        "value", new DimensionFieldSpec("value", FieldSpec.DataType.STRING, true)
+    );
+    ComplexFieldSpec spec = new ComplexFieldSpec("col", FieldSpec.DataType.MAP, true, childFieldSpecs);
+    assertTrue(spec.isSingleValueField());
+  }
+
+  @Test
+  public void testSchemaRoundTripPreservesMapField()
+      throws Exception {
+    Schema original = new Schema();
+    original.setSchemaName("roundTripSchema");
+    Map<String, FieldSpec> childFieldSpecs = Map.of(
+        "key", new DimensionFieldSpec("key", FieldSpec.DataType.STRING, true),
+        "value", new DimensionFieldSpec("value", FieldSpec.DataType.STRING, true)
+    );
+    ComplexFieldSpec spec = new ComplexFieldSpec("metrics", FieldSpec.DataType.MAP, true, childFieldSpecs);
+    original.addField(spec);
+
+    String jsonStr = original.toJsonObject().toString();
+    Schema reloaded = Schema.fromString(jsonStr);
+
+    reloaded.validate();
+    FieldSpec reloadedSpec = reloaded.getFieldSpecFor("metrics");
+    assertNotNull(reloadedSpec);
+    assertEquals(reloadedSpec.getDataType(), FieldSpec.DataType.MAP);
+    assertEquals(reloadedSpec.getFieldType(), FieldSpec.FieldType.COMPLEX);
+  }
+
+  // ---- Tests for ComplexFieldSpec.equals() including keyTypes and defaultValueType ----
+
+  @Test
+  public void testComplexFieldSpecEqualsDiffersOnKeyTypes() {
+    Map<String, FieldSpec> children = Map.of(
+        "key", new DimensionFieldSpec("key", FieldSpec.DataType.STRING, true),
+        "value", new DimensionFieldSpec("value", FieldSpec.DataType.STRING, true)
+    );
+    ComplexFieldSpec spec1 = new ComplexFieldSpec("col", FieldSpec.DataType.MAP, true, children);
+    ComplexFieldSpec spec2 = new ComplexFieldSpec("col", FieldSpec.DataType.MAP, true, children);
+
+    // Without keyTypes, they should be equal
+    assertEquals(spec1, spec2);
+
+    // Set keyTypes on spec1 only
+    spec1.setKeyTypes(Map.of("k1", FieldSpec.DataType.INT));
+    assertNotEquals(spec1, spec2, "ComplexFieldSpecs with different keyTypes must not be equal");
+  }
+
+  @Test
+  public void testComplexFieldSpecEqualsDiffersOnDefaultValueType() {
+    Map<String, FieldSpec> children = Map.of(
+        "key", new DimensionFieldSpec("key", FieldSpec.DataType.STRING, true),
+        "value", new DimensionFieldSpec("value", FieldSpec.DataType.STRING, true)
+    );
+    ComplexFieldSpec spec1 = new ComplexFieldSpec("col", FieldSpec.DataType.MAP, true, children);
+    ComplexFieldSpec spec2 = new ComplexFieldSpec("col", FieldSpec.DataType.MAP, true, children);
+
+    spec1.setDefaultValueType(FieldSpec.DataType.STRING);
+    assertNotEquals(spec1, spec2, "ComplexFieldSpecs with different defaultValueType must not be equal");
+  }
+
+  @Test
+  public void testComplexFieldSpecEqualsMatchingKeyTypesAreEqual() {
+    Map<String, FieldSpec> children = Map.of(
+        "key", new DimensionFieldSpec("key", FieldSpec.DataType.STRING, true),
+        "value", new DimensionFieldSpec("value", FieldSpec.DataType.STRING, true)
+    );
+    ComplexFieldSpec spec1 = new ComplexFieldSpec("col", FieldSpec.DataType.MAP, true, children);
+    ComplexFieldSpec spec2 = new ComplexFieldSpec("col", FieldSpec.DataType.MAP, true, children);
+
+    Map<String, FieldSpec.DataType> keyTypes = Map.of("k1", FieldSpec.DataType.INT, "k2", FieldSpec.DataType.STRING);
+    spec1.setKeyTypes(keyTypes);
+    spec2.setKeyTypes(keyTypes);
+    spec1.setDefaultValueType(FieldSpec.DataType.STRING);
+    spec2.setDefaultValueType(FieldSpec.DataType.STRING);
+
+    assertEquals(spec1, spec2);
+    assertEquals(spec1.hashCode(), spec2.hashCode());
+  }
+
+  @Test
+  public void testSchemaEqualsDetectsKeyTypesChange() {
+    Schema schema1 = new Schema();
+    schema1.setSchemaName("test");
+    ComplexFieldSpec spec1 = new ComplexFieldSpec("col", FieldSpec.DataType.MAP, true, Map.of());
+    schema1.addField(spec1);
+
+    Schema schema2 = new Schema();
+    schema2.setSchemaName("test");
+    ComplexFieldSpec spec2 = new ComplexFieldSpec("col", FieldSpec.DataType.MAP, true, Map.of());
+    spec2.setKeyTypes(Map.of("tenant", FieldSpec.DataType.STRING));
+    schema2.addField(spec2);
+
+    assertNotEquals(schema1, schema2, "Schema.equals must detect keyTypes difference");
+  }
+
+  // ---- Test for fieldType: COMPLEX deserialization without explicit fieldType ----
+
+  @Test
+  public void testSchemaDeserializationWithoutFieldTypePreservesKeyTypes()
+      throws Exception {
+    // Simulate user-provided schema JSON without "fieldType": "COMPLEX"
+    String schemaJson = "{"
+        + "\"schemaName\": \"testSchema\","
+        + "\"complexFieldSpecs\": [{"
+        + "  \"name\": \"metadata\","
+        + "  \"dataType\": \"MAP\","
+        + "  \"keyTypes\": {\"tenant\": \"STRING\", \"count\": \"INT\"},"
+        + "  \"defaultValueType\": \"STRING\""
+        + "}]"
+        + "}";
+
+    Schema schema = Schema.fromString(schemaJson);
+    FieldSpec fieldSpec = schema.getFieldSpecFor("metadata");
+    assertNotNull(fieldSpec, "metadata field should be deserialized");
+    assertTrue(fieldSpec instanceof ComplexFieldSpec, "Should be ComplexFieldSpec");
+
+    ComplexFieldSpec complexSpec = (ComplexFieldSpec) fieldSpec;
+    assertNotNull(complexSpec.getKeyTypes(), "keyTypes should be preserved");
+    assertEquals(complexSpec.getKeyTypes().size(), 2);
+    assertEquals(complexSpec.getKeyTypes().get("tenant"), FieldSpec.DataType.STRING);
+    assertEquals(complexSpec.getKeyTypes().get("count"), FieldSpec.DataType.INT);
+    assertEquals(complexSpec.getDefaultValueType(), FieldSpec.DataType.STRING);
+  }
+
+  @Test
+  public void testSchemaDeserializationWithFieldTypePreservesKeyTypes()
+      throws Exception {
+    // Schema JSON with "fieldType": "COMPLEX" — the standard path
+    String schemaJson = "{"
+        + "\"schemaName\": \"testSchema\","
+        + "\"complexFieldSpecs\": [{"
+        + "  \"name\": \"metadata\","
+        + "  \"dataType\": \"MAP\","
+        + "  \"fieldType\": \"COMPLEX\","
+        + "  \"keyTypes\": {\"tenant\": \"STRING\"},"
+        + "  \"defaultValueType\": \"STRING\""
+        + "}]"
+        + "}";
+
+    Schema schema = Schema.fromString(schemaJson);
+    ComplexFieldSpec complexSpec = (ComplexFieldSpec) schema.getFieldSpecFor("metadata");
+    assertNotNull(complexSpec.getKeyTypes());
+    assertEquals(complexSpec.getKeyTypes().get("tenant"), FieldSpec.DataType.STRING);
+    assertEquals(complexSpec.getDefaultValueType(), FieldSpec.DataType.STRING);
+  }
+
+  @Test
+  public void testSchemaRoundTripPreservesKeyTypes()
+      throws Exception {
+    // Build schema programmatically with keyTypes
+    Schema original = new Schema();
+    original.setSchemaName("roundTripKeyTypes");
+    ComplexFieldSpec spec = new ComplexFieldSpec("metrics", FieldSpec.DataType.MAP, true, Map.of());
+    spec.setKeyTypes(Map.of("tenant", FieldSpec.DataType.STRING, "count", FieldSpec.DataType.INT));
+    spec.setDefaultValueType(FieldSpec.DataType.STRING);
+    original.addField(spec);
+
+    // Serialize and deserialize
+    String json = original.toPrettyJsonString();
+    Schema reloaded = Schema.fromString(json);
+
+    ComplexFieldSpec reloadedSpec = (ComplexFieldSpec) reloaded.getFieldSpecFor("metrics");
+    assertNotNull(reloadedSpec);
+    assertEquals(reloadedSpec.getKeyTypes(), spec.getKeyTypes());
+    assertEquals(reloadedSpec.getDefaultValueType(), FieldSpec.DataType.STRING);
+
+    // Schema.equals should confirm they're equal
+    assertEquals(original, reloaded);
+  }
+}


### PR DESCRIPTION
### Summary
 
This is PR 1 of 2 introducing **columnar MAP storage** — an opt-in index for MAP columns in Apache Pinot that stores each key in its own columnar format with two-tier (dense/sparse) storage. This PR covers the full storage layer: SPI interfaces, binary format, segment creation, immutable reader, dictionary encoding, and lifecycle wiring.
 
### Stack
- **PR 1 (this):** Storage layer — SPI, index format, segment creation, immutable read path
- **PR 2:** Query layer — DataSource, mutable segments, filter operators, optimizations
 
### Motivation
 
Many Pinot use cases need to store and query semi-structured map data (e.g., user metrics, event properties, feature stores) where the set of keys varies across records. Today users must flatten maps into individual columns at ingestion time or store them as opaque JSON blobs without query pushdown. The columnar MAP index solves this by storing maps in a columnar per-key format that supports typed access, filtering, and GROUP BY at query time — without requiring schema changes when new keys appear.
 
Discussed the benefits in detail in #17894.
RFC: https://docs.google.com/document/d/14kPmjDTKbO8l0ql4rrN7I5Yki5pqMw6GeGmxxc9grsU/edit?tab=t.0
 
### What's in this PR
 
#### Schema & Config (pinot-spi)
 
- **No new DataType** — uses existing `DataType.MAP` from `ComplexFieldSpec`. Columnar storage is an opt-in index via `indexTypes: ["COLUMNAR_MAP"]` in table config
- `ComplexFieldSpec.MapFieldSpec` — extended with optional `keyTypes` (per-key type declarations) and `defaultValueType` for undeclared keys
- `ColumnarMapIndexConfig` — controls `denseKeyThreshold`, explicit `denseKeys`, `maxKeys`, inverted index enablement, and `noDictionaryKeys`
- `FieldConfig.IndexType.COLUMNAR_MAP` — explicit index type enum for opt-in
 
#### SPI Interfaces (pinot-segment-spi)
 
- `ColumnarMapIndexCreator` — segment-build-time interface: `add(Map<String, Object>)` per doc, `seal()` to flush
- `ColumnarMapIndexReader` — query-time interface: typed getters (`getInt`, `getString`, ...), presence bitmaps, inverted index lookups, per-key DataSource access
- Constants in `V1Constants` and `StandardIndexes` for index type registration
- `ColumnMetadataImpl` — extended to persist per-key type declarations in segment metadata
 
#### Index Implementation (pinot-segment-local)
 
Binary format (`.columnarmap.idx`, SPMX v3) with two-tier storage:
 
```
+-------------------------+----------------------------------------------------------+
|         Section         |                        Contents                          |
+-------------------------+----------------------------------------------------------+
| Header (56 bytes)       | Magic 0x53504D58, version=3, numKeys, numDocs,          |
|                         | numDenseKeys, numSparseKeys, 4 offset pointers           |
+-------------------------+----------------------------------------------------------+
| Key Dictionary          | Sorted key name strings (dense + sparse)                 |
+-------------------------+----------------------------------------------------------+
| Key Metadata (70 B/key) | tierFlag (1B), storedType (1B), numDocsForKey (4B),      |
|                         | nullBitmapOffset/Len, fwdIndexOffset/Len,                |
|                         | invertedIndexOffset/Len, dictIdFwdOffset/Len             |
+-------------------------+----------------------------------------------------------+
| Per-Key Data (dense)    | Null bitmap (RLE-optimized Roaring) + forward index      |
|                         | (one entry per segment doc, indexed by docId) +          |
|                         | optional inverted index + dictId forward index           |
+-------------------------+----------------------------------------------------------+
| Value Dictionary        | Per-key sorted distinct values for dict-encoded keys     |
+-------------------------+----------------------------------------------------------+
```
 
Sparse sidecar file (`.columnarmap.sparse`):
```
+-------------------------+----------------------------------------------------------+
| Header                  | Magic 0x534D5350, numDocs                                |
+-------------------------+----------------------------------------------------------+
| Offset table            | int[numDocs+1] byte offsets into JSON blob section        |
+-------------------------+----------------------------------------------------------+
| JSON blobs              | Per-doc JSON containing only the sparse key/value pairs   |
+-------------------------+----------------------------------------------------------+
```
 
**Two-tier storage design:**
- **Dense tier** — keys with fill rate > `denseKeyThreshold` (default 0.5) or explicitly listed in `denseKeys`. One forward index entry per segment document, O(1) access by docId, null bitmap tracks absent documents
- **Sparse tier** — all remaining keys. Metadata-only in the SPMX file, data stored in sidecar JSON blobs. Optimizes storage for keys present in a small fraction of documents
 
Key storage features:
- **Dictionary encoding by default** — per-key dictionary with 0.85 size-ratio heuristic. `noDictionaryKeys` forces raw encoding
- **Dense forward index** — direct docId-indexed access (no `rank()` call), with optimized null bitmaps for absent documents
- **Per-key inverted index** — optional, for fast value-based filtering on dense keys
- **Co-iterator for absent-doc handling** — uses presence bitmap to return default values for documents missing a key, avoiding full-segment-sized forward index for sparse keys
 
#### Segment Creation Wiring
 
- `BaseSegmentCreator` — skips forward index creation for MAP columns with COLUMNAR_MAP enabled; persists per-key type metadata in segment properties
- `ColumnarMapColumnPreIndexStatsCollector` — lightweight stats collector (doc count only, no min/max/cardinality)
- `StatsCollectorUtil` — routes MAP columns to the columnar map stats collector
- `ColumnMinMaxValueGenerator` — skips min/max generation for MAP columns
- `SegmentGeneratorConfig` — exposes `getColumnarMapColumnNames()` for metadata persistence
 
### How to Use
 
#### 1. Schema definition (`complexFieldSpecs`)
 
```json
{
  "schemaName": "myTable",
  "complexFieldSpecs": [
    {
      "name": "metrics",
      "dataType": "MAP",
      "keyTypes": {
        "clicks": "LONG",
        "spend": "DOUBLE",
        "country": "STRING"
      },
      "defaultValueType": "STRING"
    }
  ]
}
```
 
- `keyTypes` (optional) — declares known keys and their data types for type coercion
- `defaultValueType` (optional) — type for undeclared/dynamic keys (defaults to STRING)
 
#### 2. Table config (`fieldConfigList` with `COLUMNAR_MAP` index)
 
```json
{
  "fieldConfigList": [
    {
      "name": "metrics",
      "indexTypes": ["COLUMNAR_MAP"],
      "properties": {
        "maxKeys": "1000",
        "denseKeyThreshold": "0.5",
        "denseKeys": "country,sessions",
        "enableInvertedIndexForAll": "false",
        "invertedIndexKeys": "country,sessions"
      }
    }
  ]
}
```
 
### What's NOT in this PR (comes in PR 2)
 
- `ColumnarMapDataSource` — per-key query routing and DataSource construction
- `MutableColumnarMapIndexImpl` — consuming segment support with O(1) lock-free reads
- `MapFilterOperator` — per-key inverted index filter strategy, IS NULL/IS NOT NULL
- `ItemTransformFunction` — null bitmap propagation for item() expressions
- `ImmutableSegmentImpl` / `MutableSegmentImpl` — segment loading wiring
- Performance optimizations (TransformBlock bypass, NonScanBasedAggregation, FixedBitSVForwardIndexReaderV2)
 
### Test plan
 
- `ColumnarMapDataTypeTest` — 11 tests (schema serialization, ComplexFieldSpec round-trip, keyTypes/defaultValueType)
- `ColumnarMapIndexConfigTest` — 8 tests (config deserialization, denseKeys, properties round-trip)
- `ColumnarMapSegmentCreationTest` — 1 test (end-to-end segment build pipeline with COLUMNAR_MAP index)
- All 20 tests pass