### PR TITLE
Reject partial upsert for OFFLINE tables

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -789,6 +789,8 @@ public final class TableConfigUtils {
     if (tableConfig.getTableType() == TableType.OFFLINE) {
       Preconditions.checkState(isUpsertEnabled && !isDedupEnabled,
           "Dedup is not supported for OFFLINE table. Only upsert is supported for OFFLINE table");
+      Preconditions.checkState(tableConfig.getUpsertMode() != UpsertConfig.Mode.PARTIAL,
+          "Partial upsert is not supported for OFFLINE table");
       // Offline upsert tables require segment partition config so that segments are assigned to servers
       // based on partition, ensuring all segments of a partition land on the same server for correct dedup.
       IndexingConfig indexingConfig = tableConfig.getIndexingConfig();

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -2125,6 +2125,19 @@ public class TableConfigUtilsTest {
               + "segment assignment. Configure segmentPartitionConfig in the indexingConfig.");
     }
 
+    // OFFLINE table with partial upsert should fail
+    UpsertConfig partialUpsertConfig = new UpsertConfig(UpsertConfig.Mode.PARTIAL);
+    tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
+        .setUpsertConfig(partialUpsertConfig)
+        .setTimeColumnName(TIME_COLUMN)
+        .build();
+    try {
+      TableConfigUtils.validateUpsertAndDedupConfig(tableConfig, schema);
+      fail();
+    } catch (IllegalStateException e) {
+      assertEquals(e.getMessage(), "Partial upsert is not supported for OFFLINE table");
+    }
+
     tableConfig =
         new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setUpsertConfig(upsertConfig).build();
     try {


### PR DESCRIPTION
## Summary

Add validation to reject partial upsert mode for OFFLINE tables at table creation time.

PR #17789 added upsert support for OFFLINE tables with `FULL` mode. However, `PARTIAL` upsert mode is not supported for OFFLINE tables because offline segments are immutable and cannot track per-column merge strategies. Without this validation, users would get a confusing runtime error instead of a clear rejection at table creation time.

## Changes

- Add `Preconditions.checkState` in `TableConfigUtils.validateUpsertAndDedupConfig()` to reject `UpsertConfig.Mode.PARTIAL` for OFFLINE tables
- Add test case in `TableConfigUtilsTest.testValidateUpsertConfig()`

## Test plan

- [x] `TableConfigUtilsTest#testValidateUpsertConfig` passes
- [x] `TableConfigUtilsTest#testValidateDedupConfig` passes (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)