### PR TITLE
Remove disallowed codecov/test-results-action from CI

### DIFF
--- a/.github/workflows/pinot_tests.yml
+++ b/.github/workflows/pinot_tests.yml
@@ -232,16 +232,6 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
           verbose: true
-      - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
-        timeout-minutes: 5
-        with:
-          flags: unittests,unittests${{ matrix.testset }},${{matrix.distribution}},java-${{matrix.java}}
-          name: codecov-unit-tests
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: false
-          verbose: true
       - name: Generate Surefire Report
         if: ${{ !cancelled() && github.ref == 'refs/heads/master' }}
         continue-on-error: true
@@ -331,17 +321,6 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           fail_ci_if_error: false
           verbose: true
-      - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
-        continue-on-error: true
-        timeout-minutes: 5
-        with:
-          flags: integration,integration${{ matrix.testset }},${{matrix.distribution}},java-${{matrix.java}}
-          name: codecov-integration-tests
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: false
-          verbose: true
       - name: Custom Integration Test
         if : ${{ matrix.testset == 1 }}
         env:
@@ -365,16 +344,6 @@ jobs:
         if : ${{ matrix.testset == 1 }}
         uses: codecov/codecov-action@v5
         continue-on-error: true
-        timeout-minutes: 5
-        with:
-          flags: integration,custom-integration${{ matrix.testset }},${{matrix.distribution}},java-${{matrix.java}}
-          name: codecov-custom-integration-tests
-          token: ${{ secrets.CODECOV_TOKEN }}
-          fail_ci_if_error: false
-          verbose: true
-      - name: Upload test results to Codecov
-        if: ${{ !cancelled() }}
-        uses: codecov/test-results-action@v1
         timeout-minutes: 5
         with:
           flags: integration,custom-integration${{ matrix.testset }},${{matrix.distribution}},java-${{matrix.java}}


### PR DESCRIPTION
## Summary
- Remove `codecov/test-results-action@v1` from the CI workflow, which is not in the Apache org's allowed GitHub Actions list
- Removes all 3 usages: unit tests, integration tests, and custom integration tests steps
- Coverage upload via `codecov/codecov-action@v5` (which is allowed) remains unaffected

## Test plan
- [ ] Verify CI workflow runs without the "action not allowed" error
- [ ] Confirm coverage upload still works via `codecov/codecov-action@v5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)