### PR TITLE
S3PinotFS  'Failed to delete' log should only log when there are failures

### DIFF
--- a/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3PinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3PinotFS.java
@@ -568,7 +568,9 @@ public class S3PinotFS extends BasePinotFS {
         .build();
 
     DeleteObjectsResponse deleteResponse = retryWithS3CredentialRefresh(() -> _s3Client.deleteObjects(deleteRequest));
-    LOGGER.info("Failed to delete {} objects", deleteResponse.hasErrors() ? deleteResponse.errors().size() : 0);
+    if (deleteResponse.hasErrors()) {
+      LOGGER.info("Failed to delete {} objects", deleteResponse.errors().size());
+    }
     return deleteResponse.deleted().size() == objectsToDelete.size();
   }
 


### PR DESCRIPTION
Reduces logging noise by only logging the 'Failed to delete' message when deleteResponse actually has errors, rather than always logging with a count of 0 on success.
