### PR TITLE
Add GitHub Actions workflow to auto-close stale issues

### DIFF
--- a/.github/workflows/close_stale_issues.yml
+++ b/.github/workflows/close_stale_issues.yml
@@ -30,6 +30,7 @@ permissions:
 
 jobs:
   close-stale-issues:
+    if: github.repository == 'apache/pinot'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/stale@v9


### PR DESCRIPTION
## Summary
- Add a new GitHub Actions workflow (`close_stale_issues.yml`) that automatically manages stale issues
- Issues with no activity for 150 days are labeled `stale` with a warning comment
- After 30 more days of inactivity (180 days total), issues are automatically closed
- PRs are excluded from this workflow
- Issues labeled `pinned`, `security`, or `critical` are exempt

## Test plan
- [ ] Verify workflow syntax is valid via GitHub Actions lint
- [ ] Confirm the workflow runs on schedule (daily at 00:00 UTC)
- [ ] Validate manual trigger via `workflow_dispatch` works
- [ ] Confirm PRs are not affected by the stale bot

🤖 Generated with [Claude Code](https://claude.com/claude-code)