### PR TITLE
Add experimental openCypher graph query frontend

### DIFF
--- a/pinot-bom/pom.xml
+++ b/pinot-bom/pom.xml
@@ -210,6 +210,16 @@
       </dependency>
       <dependency>
         <groupId>org.apache.pinot</groupId>
+        <artifactId>pinot-graph-spi</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.pinot</groupId>
+        <artifactId>pinot-graph-planner</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.pinot</groupId>
         <artifactId>pinot-sql-ddl</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/pinot-broker/pom.xml
+++ b/pinot-broker/pom.xml
@@ -50,6 +50,14 @@
       <artifactId>pinot-timeseries-planner</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-graph-spi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-graph-planner</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotClientRequest.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotClientRequest.java
@@ -64,6 +64,7 @@ import org.apache.hc.client5.http.io.HttpClientConnectionManager;
 import org.apache.pinot.broker.api.HttpRequesterIdentity;
 import org.apache.pinot.broker.broker.BrokerAdminApiApplication;
 import org.apache.pinot.broker.requesthandler.BrokerRequestHandler;
+import org.apache.pinot.broker.requesthandler.GraphRequestHandler;
 import org.apache.pinot.common.metrics.BrokerMeter;
 import org.apache.pinot.common.metrics.BrokerMetrics;
 import org.apache.pinot.common.response.BrokerResponse;
@@ -137,6 +138,8 @@ public class PinotClientRequest {
   @Inject
   @Named(BrokerAdminApiApplication.BROKER_INSTANCE_ID)
   private String _instanceId;
+
+  private volatile GraphRequestHandler _graphRequestHandler;
 
   @GET
   @ManagedAsync
@@ -488,6 +491,66 @@ public class PinotClientRequest {
   }
 
   @POST
+  @ManagedAsync
+  @Produces(MediaType.APPLICATION_JSON)
+  @Path("query/graph")
+  @ApiOperation(value = "Query Pinot using graph (Cypher) queries (experimental)")
+  @ApiResponses(value = {
+      @ApiResponse(code = 200, message = "Query response"),
+      @ApiResponse(code = 400, message = "Graph query feature is disabled or invalid request"),
+      @ApiResponse(code = 500, message = "Internal Server Error")
+  })
+  @ManualAuthorization
+  public void processGraphQuery(String requestBody, @Suspended AsyncResponse asyncResponse,
+      @Context org.glassfish.grizzly.http.server.Request requestContext,
+      @Context HttpHeaders httpHeaders) {
+    try {
+      boolean graphEnabled = _brokerConf.getProperty(CommonConstants.Graph.CONFIG_OF_GRAPH_QUERY_ENABLED,
+          CommonConstants.Graph.DEFAULT_GRAPH_QUERY_ENABLED);
+      if (!graphEnabled) {
+        asyncResponse.resume(Response.status(Response.Status.BAD_REQUEST)
+            .entity("{\"error\": \"Graph query feature is not enabled. "
+                + "Set 'pinot.graph.enabled=true' in broker configuration to enable it.\"}")
+            .type(MediaType.APPLICATION_JSON)
+            .build());
+        return;
+      }
+
+      JsonNode requestJson = JsonUtils.stringToJsonNode(requestBody);
+      if (!requestJson.has("query")) {
+        throw new IllegalArgumentException("Payload is missing the required 'query' field (Cypher query string)");
+      }
+      if (!requestJson.has("graphSchema")) {
+        throw new IllegalArgumentException("Payload is missing the required 'graphSchema' field");
+      }
+
+      String cypherQuery = requestJson.get("query").asText();
+      JsonNode graphSchemaJson = requestJson.get("graphSchema");
+
+      GraphRequestHandler graphHandler = getOrCreateGraphRequestHandler();
+
+      try (RequestScope requestScope = Tracing.getTracer().createRequestScope()) {
+        requestScope.setRequestArrivalTimeMillis(System.currentTimeMillis());
+        BrokerResponse brokerResponse = graphHandler.handleRequest(cypherQuery, graphSchemaJson,
+            makeHttpIdentity(requestContext), requestScope, httpHeaders);
+        brokerResponse.emitBrokerResponseMetrics(_brokerMetrics);
+        asyncResponse.resume(getPinotQueryResponse(brokerResponse, httpHeaders, _brokerMetrics));
+      }
+    } catch (IllegalArgumentException e) {
+      LOGGER.warn("Invalid graph query request", e);
+      asyncResponse.resume(Response.status(Response.Status.BAD_REQUEST)
+          .entity("{\"error\": \"" + e.getMessage().replace("\"", "'") + "\"}")
+          .type(MediaType.APPLICATION_JSON)
+          .build());
+    } catch (Exception e) {
+      LOGGER.error("Caught exception while processing graph query request", e);
+      _brokerMetrics.addMeteredGlobalValue(BrokerMeter.UNCAUGHT_POST_EXCEPTIONS, 1L);
+      asyncResponse.resume(new WebApplicationException(e,
+          Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(e.getMessage()).build()));
+    }
+  }
+
+  @POST
   @Produces(MediaType.APPLICATION_JSON)
   @Path("query/compare")
   @ApiOperation(value = "Query Pinot using both the single-stage query engine and the multi-stage query engine and "
@@ -645,6 +708,20 @@ public class PinotClientRequest {
       throw new WebApplicationException(Response.status(Response.Status.INTERNAL_SERVER_ERROR)
           .entity("Failed to get running queries on the broker due to error: " + e.getMessage()).build());
     }
+  }
+
+  private GraphRequestHandler getOrCreateGraphRequestHandler() {
+    GraphRequestHandler handler = _graphRequestHandler;
+    if (handler == null) {
+      synchronized (this) {
+        handler = _graphRequestHandler;
+        if (handler == null) {
+          handler = new GraphRequestHandler(_requestHandler);
+          _graphRequestHandler = handler;
+        }
+      }
+    }
+    return handler;
   }
 
   private BrokerResponse executeSqlQuery(ObjectNode sqlRequestJson, HttpRequesterIdentity httpRequesterIdentity,

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/GraphRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/GraphRequestHandler.java
@@ -1,0 +1,199 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.requesthandler;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import javax.annotation.Nullable;
+import javax.ws.rs.core.HttpHeaders;
+import org.apache.pinot.common.response.BrokerResponse;
+import org.apache.pinot.graph.planner.CypherToSqlTranslator;
+import org.apache.pinot.graph.spi.GraphSchemaConfig;
+import org.apache.pinot.spi.auth.broker.RequesterIdentity;
+import org.apache.pinot.spi.trace.RequestContext;
+import org.apache.pinot.spi.utils.CommonConstants.Broker.Request;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Handles graph (Cypher) query requests by translating them to SQL and delegating
+ * to the multi-stage query engine (MSE) broker request handler.
+ *
+ * <p>This handler is instantiated only when the {@code pinot.graph.enabled} feature flag
+ * is set to {@code true}. It is thread-safe because it delegates all state to the
+ * underlying {@link BrokerRequestHandler}.
+ */
+public class GraphRequestHandler {
+  private static final Logger LOGGER = LoggerFactory.getLogger(GraphRequestHandler.class);
+
+  private final BrokerRequestHandler _requestHandler;
+
+  public GraphRequestHandler(BrokerRequestHandler requestHandler) {
+    _requestHandler = requestHandler;
+  }
+
+  /**
+   * Handles a graph query request by translating Cypher to SQL and delegating to the MSE handler.
+   *
+   * @param cypherQuery the Cypher query string
+   * @param graphSchemaJson the inline graph schema as a JSON node
+   * @param requesterIdentity the identity of the requester, may be null
+   * @param requestContext the request context for tracing
+   * @param httpHeaders the HTTP headers from the original request, may be null
+   * @return the broker response from executing the translated SQL query
+   * @throws Exception if translation or query execution fails
+   */
+  public BrokerResponse handleRequest(String cypherQuery, JsonNode graphSchemaJson,
+      @Nullable RequesterIdentity requesterIdentity, RequestContext requestContext,
+      @Nullable HttpHeaders httpHeaders)
+      throws Exception {
+    // Parse the graph schema from JSON
+    GraphSchemaConfig schemaConfig = parseGraphSchema(graphSchemaJson);
+
+    // Translate Cypher to SQL
+    String sql;
+    try {
+      CypherToSqlTranslator translator = new CypherToSqlTranslator(schemaConfig);
+      sql = translator.translate(cypherQuery);
+    } catch (Exception e) {
+      LOGGER.error("Failed to translate Cypher query to SQL: {}", cypherQuery, e);
+      throw new IllegalArgumentException("Failed to translate Cypher query to SQL: " + e.getMessage(), e);
+    }
+    LOGGER.debug("Translated Cypher query [{}] to SQL [{}]", cypherQuery, sql);
+
+    // Build a SQL request JSON and delegate to the request handler.
+    // The translated SQL uses JOINs, which requires the multi-stage engine.
+    ObjectNode sqlRequestJson = JsonUtils.newObjectNode();
+    sqlRequestJson.put(Request.SQL, sql);
+
+    // Force multi-stage engine for graph queries since they require JOINs.
+    // Query options are passed as a semicolon-delimited string.
+    sqlRequestJson.put(Request.QUERY_OPTIONS,
+        Request.QueryOptionKey.USE_MULTISTAGE_ENGINE + "=true");
+
+    return _requestHandler.handleRequest(sqlRequestJson, null, requesterIdentity, requestContext,
+        httpHeaders);
+  }
+
+  /**
+   * Parses the inline graph schema JSON into a {@link GraphSchemaConfig}.
+   *
+   * <p>Expected JSON format:</p>
+   * <pre>
+   * {
+   *   "vertexLabels": {
+   *     "User": {
+   *       "tableName": "users",
+   *       "primaryKey": "id",
+   *       "properties": { "id": "id", "name": "user_name" }
+   *     }
+   *   },
+   *   "edgeLabels": {
+   *     "FOLLOWS": {
+   *       "tableName": "follows",
+   *       "sourceVertexLabel": "User",
+   *       "sourceKey": "follower_id",
+   *       "targetVertexLabel": "User",
+   *       "targetKey": "followee_id",
+   *       "properties": {}
+   *     }
+   *   }
+   * }
+   * </pre>
+   */
+  static GraphSchemaConfig parseGraphSchema(JsonNode schemaJson) {
+    if (schemaJson == null) {
+      throw new IllegalArgumentException("Graph schema JSON must not be null");
+    }
+
+    // Parse vertex labels
+    Map<String, GraphSchemaConfig.VertexLabel> vertexLabels = new HashMap<>();
+    JsonNode vertexLabelsNode = schemaJson.get("vertexLabels");
+    if (vertexLabelsNode != null && vertexLabelsNode.isObject()) {
+      Iterator<Map.Entry<String, JsonNode>> fields = vertexLabelsNode.fields();
+      while (fields.hasNext()) {
+        Map.Entry<String, JsonNode> entry = fields.next();
+        String labelName = entry.getKey();
+        JsonNode labelNode = entry.getValue();
+
+        String tableName = getRequiredField(labelNode, "tableName", "vertexLabels." + labelName);
+        String primaryKey = getRequiredField(labelNode, "primaryKey", "vertexLabels." + labelName);
+        Map<String, String> properties = parseStringMap(labelNode.get("properties"));
+
+        vertexLabels.put(labelName, new GraphSchemaConfig.VertexLabel(tableName, primaryKey, properties));
+      }
+    }
+
+    // Parse edge labels
+    Map<String, GraphSchemaConfig.EdgeLabel> edgeLabels = new HashMap<>();
+    JsonNode edgeLabelsNode = schemaJson.get("edgeLabels");
+    if (edgeLabelsNode != null && edgeLabelsNode.isObject()) {
+      Iterator<Map.Entry<String, JsonNode>> fields = edgeLabelsNode.fields();
+      while (fields.hasNext()) {
+        Map.Entry<String, JsonNode> entry = fields.next();
+        String labelName = entry.getKey();
+        JsonNode labelNode = entry.getValue();
+
+        String tableName = getRequiredField(labelNode, "tableName", "edgeLabels." + labelName);
+        String sourceVertexLabel = getRequiredField(labelNode, "sourceVertexLabel", "edgeLabels." + labelName);
+        String sourceKey = getRequiredField(labelNode, "sourceKey", "edgeLabels." + labelName);
+        String targetVertexLabel = getRequiredField(labelNode, "targetVertexLabel", "edgeLabels." + labelName);
+        String targetKey = getRequiredField(labelNode, "targetKey", "edgeLabels." + labelName);
+        Map<String, String> properties = parseStringMap(labelNode.get("properties"));
+
+        edgeLabels.put(labelName, new GraphSchemaConfig.EdgeLabel(
+            tableName, sourceVertexLabel, sourceKey, targetVertexLabel, targetKey, properties));
+      }
+    }
+
+    if (vertexLabels.isEmpty()) {
+      throw new IllegalArgumentException("Graph schema must define at least one vertex label");
+    }
+    if (edgeLabels.isEmpty()) {
+      throw new IllegalArgumentException("Graph schema must define at least one edge label");
+    }
+
+    return new GraphSchemaConfig(vertexLabels, edgeLabels);
+  }
+
+  private static String getRequiredField(JsonNode node, String fieldName, String parentPath) {
+    JsonNode field = node.get(fieldName);
+    if (field == null || field.isNull()) {
+      throw new IllegalArgumentException("Missing required field '" + fieldName + "' in " + parentPath);
+    }
+    return field.asText();
+  }
+
+  private static Map<String, String> parseStringMap(JsonNode node) {
+    Map<String, String> map = new HashMap<>();
+    if (node != null && node.isObject()) {
+      Iterator<Map.Entry<String, JsonNode>> fields = node.fields();
+      while (fields.hasNext()) {
+        Map.Entry<String, JsonNode> entry = fields.next();
+        map.put(entry.getKey(), entry.getValue().asText());
+      }
+    }
+    return map;
+  }
+}

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/GraphRequestHandlerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/GraphRequestHandlerTest.java
@@ -1,0 +1,262 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.requesthandler;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.pinot.common.response.BrokerResponse;
+import org.apache.pinot.common.response.broker.BrokerResponseNative;
+import org.apache.pinot.graph.spi.GraphSchemaConfig;
+import org.apache.pinot.spi.trace.RequestContext;
+import org.apache.pinot.spi.utils.CommonConstants.Broker.Request;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.*;
+
+
+/**
+ * Tests the {@link GraphRequestHandler} translation logic in isolation, without
+ * requiring a running Pinot cluster.
+ *
+ * <p>The handler's job is to: (1) parse the inline graph schema, (2) translate
+ * Cypher to SQL, and (3) forward the request to the underlying broker handler
+ * with {@code useMultistageEngine=true}. These tests verify all three steps.</p>
+ */
+public class GraphRequestHandlerTest {
+
+  private AutoCloseable _mocks;
+
+  @Mock
+  private BrokerRequestHandler _mockBrokerRequestHandler;
+
+  @Mock
+  private RequestContext _mockRequestContext;
+
+  private GraphRequestHandler _graphRequestHandler;
+
+  @BeforeMethod
+  public void setUp()
+      throws Exception {
+    _mocks = MockitoAnnotations.openMocks(this);
+    _graphRequestHandler = new GraphRequestHandler(_mockBrokerRequestHandler);
+
+    // Default: the mock broker handler returns an empty success response
+    when(_mockBrokerRequestHandler.handleRequest(any(JsonNode.class), isNull(), isNull(), any(), isNull()))
+        .thenReturn(BrokerResponseNative.empty());
+  }
+
+  @AfterMethod
+  public void tearDown()
+      throws Exception {
+    _mocks.close();
+  }
+
+  // ---- Schema parsing tests ----
+
+  @Test
+  public void testParseGraphSchemaValid()
+      throws Exception {
+    JsonNode schemaJson = JsonUtils.stringToJsonNode(buildSchemaJson());
+    GraphSchemaConfig config = GraphRequestHandler.parseGraphSchema(schemaJson);
+
+    assertEquals(config.getVertexLabels().size(), 1);
+    assertTrue(config.getVertexLabels().containsKey("User"));
+    assertEquals(config.getVertexLabels().get("User").getTableName(), "users");
+    assertEquals(config.getVertexLabels().get("User").getPrimaryKey(), "id");
+
+    assertEquals(config.getEdgeLabels().size(), 1);
+    assertTrue(config.getEdgeLabels().containsKey("FOLLOWS"));
+    assertEquals(config.getEdgeLabels().get("FOLLOWS").getTableName(), "follows");
+    assertEquals(config.getEdgeLabels().get("FOLLOWS").getSourceVertexLabel(), "User");
+    assertEquals(config.getEdgeLabels().get("FOLLOWS").getSourceKey(), "follower_id");
+    assertEquals(config.getEdgeLabels().get("FOLLOWS").getTargetVertexLabel(), "User");
+    assertEquals(config.getEdgeLabels().get("FOLLOWS").getTargetKey(), "followee_id");
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class,
+      expectedExceptionsMessageRegExp = ".*must not be null.*")
+  public void testParseGraphSchemaNullInput() {
+    GraphRequestHandler.parseGraphSchema(null);
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class,
+      expectedExceptionsMessageRegExp = ".*at least one vertex label.*")
+  public void testParseGraphSchemaNoVertexLabels()
+      throws Exception {
+    String json = "{ \"vertexLabels\": {}, "
+        + "\"edgeLabels\": { \"E\": { \"tableName\": \"e\", \"sourceVertexLabel\": \"A\", "
+        + "\"sourceKey\": \"a\", \"targetVertexLabel\": \"B\", \"targetKey\": \"b\" } } }";
+    GraphRequestHandler.parseGraphSchema(JsonUtils.stringToJsonNode(json));
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class,
+      expectedExceptionsMessageRegExp = ".*at least one edge label.*")
+  public void testParseGraphSchemaNoEdgeLabels()
+      throws Exception {
+    String json = "{ \"vertexLabels\": { \"A\": { \"tableName\": \"a\", \"primaryKey\": \"pk\" } }, "
+        + "\"edgeLabels\": {} }";
+    GraphRequestHandler.parseGraphSchema(JsonUtils.stringToJsonNode(json));
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class,
+      expectedExceptionsMessageRegExp = ".*Missing required field 'tableName'.*")
+  public void testParseGraphSchemaMissingRequiredField()
+      throws Exception {
+    String json = "{ \"vertexLabels\": { \"A\": { \"primaryKey\": \"pk\" } }, "
+        + "\"edgeLabels\": { \"E\": { \"tableName\": \"e\", \"sourceVertexLabel\": \"A\", "
+        + "\"sourceKey\": \"a\", \"targetVertexLabel\": \"B\", \"targetKey\": \"b\" } } }";
+    GraphRequestHandler.parseGraphSchema(JsonUtils.stringToJsonNode(json));
+  }
+
+  // ---- Translation and delegation tests ----
+
+  @Test
+  public void testHandleRequestTranslatesCypherToSql()
+      throws Exception {
+    String cypher = "MATCH (a:User {id: '123'})-[:FOLLOWS]->(b:User) RETURN b.id LIMIT 100";
+    JsonNode schemaJson = JsonUtils.stringToJsonNode(buildSchemaJson());
+
+    _graphRequestHandler.handleRequest(cypher, schemaJson, null, _mockRequestContext, null);
+
+    // Capture the JSON sent to the mock broker handler
+    ArgumentCaptor<JsonNode> captor = ArgumentCaptor.forClass(JsonNode.class);
+    verify(_mockBrokerRequestHandler).handleRequest(captor.capture(), isNull(), isNull(), any(), isNull());
+
+    JsonNode sqlRequest = captor.getValue();
+
+    // Verify the SQL field is set and contains JOIN (graph lowering)
+    assertTrue(sqlRequest.has(Request.SQL), "SQL field must be present in forwarded request");
+    String sql = sqlRequest.get(Request.SQL).asText();
+    assertTrue(sql.contains("SELECT"), "Generated SQL must contain SELECT");
+    assertTrue(sql.contains("JOIN"), "Generated SQL must contain JOIN for graph traversal");
+    assertTrue(sql.contains("follows"), "Generated SQL must reference the edge table");
+    assertTrue(sql.contains("users"), "Generated SQL must reference the vertex table");
+    assertTrue(sql.contains("LIMIT 100"), "Generated SQL must preserve LIMIT clause");
+    assertTrue(sql.contains("'123'"), "Generated SQL must include the property filter value");
+  }
+
+  @Test
+  public void testHandleRequestSetsMultistageEngine()
+      throws Exception {
+    String cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User) RETURN b.id";
+    JsonNode schemaJson = JsonUtils.stringToJsonNode(buildSchemaJson());
+
+    _graphRequestHandler.handleRequest(cypher, schemaJson, null, _mockRequestContext, null);
+
+    ArgumentCaptor<JsonNode> captor = ArgumentCaptor.forClass(JsonNode.class);
+    verify(_mockBrokerRequestHandler).handleRequest(captor.capture(), isNull(), isNull(), any(), isNull());
+
+    JsonNode sqlRequest = captor.getValue();
+
+    // Verify useMultistageEngine=true is set in query options
+    assertTrue(sqlRequest.has(Request.QUERY_OPTIONS),
+        "queryOptions field must be present in forwarded request");
+    String queryOptions = sqlRequest.get(Request.QUERY_OPTIONS).asText();
+    assertTrue(queryOptions.contains("useMultistageEngine=true"),
+        "queryOptions must contain useMultistageEngine=true");
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class,
+      expectedExceptionsMessageRegExp = ".*Failed to translate Cypher query.*")
+  public void testHandleRequestInvalidCypher()
+      throws Exception {
+    // This uses unsupported CREATE syntax
+    String cypher = "CREATE (n:User {id: '1'}) RETURN n";
+    JsonNode schemaJson = JsonUtils.stringToJsonNode(buildSchemaJson());
+
+    _graphRequestHandler.handleRequest(cypher, schemaJson, null, _mockRequestContext, null);
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class,
+      expectedExceptionsMessageRegExp = ".*Failed to translate Cypher query.*")
+  public void testHandleRequestUnknownVertexLabel()
+      throws Exception {
+    String cypher = "MATCH (a:UnknownLabel)-[:FOLLOWS]->(b:User) RETURN b.id";
+    JsonNode schemaJson = JsonUtils.stringToJsonNode(buildSchemaJson());
+
+    _graphRequestHandler.handleRequest(cypher, schemaJson, null, _mockRequestContext, null);
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class,
+      expectedExceptionsMessageRegExp = ".*Failed to translate Cypher query.*")
+  public void testHandleRequestUnknownEdgeType()
+      throws Exception {
+    String cypher = "MATCH (a:User)-[:UNKNOWN_EDGE]->(b:User) RETURN b.id";
+    JsonNode schemaJson = JsonUtils.stringToJsonNode(buildSchemaJson());
+
+    _graphRequestHandler.handleRequest(cypher, schemaJson, null, _mockRequestContext, null);
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class,
+      expectedExceptionsMessageRegExp = ".*must not be null.*")
+  public void testHandleRequestNullSchema()
+      throws Exception {
+    _graphRequestHandler.handleRequest("MATCH (a:User)-[:FOLLOWS]->(b:User) RETURN b.id",
+        null, null, _mockRequestContext, null);
+  }
+
+  @Test
+  public void testHandleRequestReturnsResponse()
+      throws Exception {
+    BrokerResponseNative expectedResponse = BrokerResponseNative.empty();
+    when(_mockBrokerRequestHandler.handleRequest(any(JsonNode.class), isNull(), isNull(), any(), isNull()))
+        .thenReturn(expectedResponse);
+
+    String cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User) RETURN b.id";
+    JsonNode schemaJson = JsonUtils.stringToJsonNode(buildSchemaJson());
+
+    BrokerResponse response = _graphRequestHandler.handleRequest(cypher, schemaJson, null,
+        _mockRequestContext, null);
+
+    assertSame(response, expectedResponse, "Handler must return the response from the underlying broker handler");
+  }
+
+  // ---- Helper methods ----
+
+  private static String buildSchemaJson() {
+    return "{"
+        + "  \"vertexLabels\": {"
+        + "    \"User\": {"
+        + "      \"tableName\": \"users\","
+        + "      \"primaryKey\": \"id\","
+        + "      \"properties\": { \"id\": \"id\", \"name\": \"user_name\" }"
+        + "    }"
+        + "  },"
+        + "  \"edgeLabels\": {"
+        + "    \"FOLLOWS\": {"
+        + "      \"tableName\": \"follows\","
+        + "      \"sourceVertexLabel\": \"User\","
+        + "      \"sourceKey\": \"follower_id\","
+        + "      \"targetVertexLabel\": \"User\","
+        + "      \"targetKey\": \"followee_id\","
+        + "      \"properties\": {}"
+        + "    }"
+        + "  }"
+        + "}";
+  }
+}

--- a/pinot-graph/README.md
+++ b/pinot-graph/README.md
@@ -1,0 +1,129 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+
+# pinot-graph -- Experimental openCypher Support for Apache Pinot
+
+This module provides **experimental** graph query support for Apache Pinot by
+translating a minimal openCypher subset into multi-stage SQL (JOINs) against
+existing Pinot tables. No native graph operator is introduced; the feature is
+implemented entirely as a Cypher-to-SQL transpiler.
+
+## Status
+
+**Experimental.** Gated behind `pinot.graph.enabled=true` in the broker
+configuration. Disabled by default.
+
+## Enabling
+
+Add to broker configuration:
+
+```properties
+pinot.graph.enabled=true
+```
+
+## Supported Query Syntax
+
+Only single-hop MATCH patterns are supported:
+
+```
+MATCH (source:Label {prop: value})-[:EDGE_TYPE]->(target:Label)
+RETURN target.property [, ...]
+[LIMIT n]
+```
+
+Supported features:
+- **Outgoing edges:** `(a)-[:TYPE]->(b)`
+- **Incoming edges:** `(a)<-[:TYPE]-(b)`
+- **Undirected edges:** `(a)-[:TYPE]-(b)`
+- **Inline property filters:** `(a:User {id: '123'})`
+- **Multiple return items:** `RETURN b.id, b.name`
+- **LIMIT clause**
+- **Named edge aliases:** `-[r:TYPE]->`
+- **Case-insensitive keywords**
+- **String and integer property values**
+
+## Request Format
+
+`POST /query/graph` with JSON body:
+
+```json
+{
+  "query": "MATCH (a:User {id: '123'})-[:FOLLOWS]->(b:User) RETURN b.name LIMIT 10",
+  "graphSchema": {
+    "vertexLabels": {
+      "User": {
+        "tableName": "users_table",
+        "primaryKey": "user_id",
+        "properties": {
+          "id": "user_id",
+          "name": "user_name"
+        }
+      }
+    },
+    "edgeLabels": {
+      "FOLLOWS": {
+        "tableName": "follows_table",
+        "sourceVertexLabel": "User",
+        "sourceKey": "follower_id",
+        "targetVertexLabel": "User",
+        "targetKey": "followee_id",
+        "properties": {}
+      }
+    }
+  }
+}
+```
+
+The `graphSchema` maps graph labels to Pinot tables and columns. It is passed
+inline with each request (no server-side schema registration).
+
+## Example
+
+Given the request above, the transpiler generates:
+
+```sql
+SELECT b.user_name FROM follows_table AS e
+  JOIN users_table AS a ON e.follower_id = a.user_id
+  JOIN users_table AS b ON e.followee_id = b.user_id
+  WHERE a.user_id = '123'
+  LIMIT 10
+```
+
+This SQL is executed via the multi-stage query engine (`useMultistageEngine=true`).
+
+## Limitations
+
+- Only **1-hop** traversals are supported. Multi-hop and variable-length paths
+  are rejected.
+- No `WHERE` clause -- use inline property filters `{key: value}` instead.
+- No `ORDER BY`, `SKIP`, `DISTINCT`, `WITH`, `UNION`, or `OPTIONAL MATCH`.
+- No write operations (`CREATE`, `MERGE`, `DELETE`, `SET`, `REMOVE`).
+- No `RETURN *` -- return items must be explicit.
+- No aggregation functions in `RETURN`.
+- The graph schema must be supplied inline with each request.
+- Requires the multi-stage query engine to be available (JOIN support).
+
+## Module Structure
+
+| Module                  | Purpose                                         |
+|-------------------------|-------------------------------------------------|
+| `pinot-graph-spi`       | Schema config POJOs (`GraphSchemaConfig`)        |
+| `pinot-graph-planner`   | Parser, validator, SQL generator, translator     |

--- a/pinot-graph/pinot-graph-planner/pom.xml
+++ b/pinot-graph/pinot-graph-planner/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.pinot</groupId>
+    <artifactId>pinot-graph</artifactId>
+    <version>1.6.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>pinot-graph-planner</artifactId>
+
+  <properties>
+    <pinot.root>${basedir}/../..</pinot.root>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-graph-spi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.testng</groupId>
+      <artifactId>testng</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/pinot-graph/pinot-graph-planner/src/main/java/org/apache/pinot/graph/planner/CypherIR.java
+++ b/pinot-graph/pinot-graph-planner/src/main/java/org/apache/pinot/graph/planner/CypherIR.java
@@ -1,0 +1,697 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.graph.planner;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+
+/**
+ * Intermediate representation (IR) for a parsed openCypher query.
+ *
+ * <p>This IR captures the minimal subset of Cypher supported by Pinot's graph query MVP:
+ * a single MATCH clause with one hop, a RETURN clause, and an optional LIMIT.</p>
+ *
+ * <p>All classes here are immutable value objects.</p>
+ */
+public final class CypherIR {
+
+  private CypherIR() {
+    // Namespace class; do not instantiate.
+  }
+
+  /**
+   * Represents a complete parsed Cypher query.
+   */
+  public static class CypherQuery {
+    private final MatchClause _matchClause;
+    private final WhereClause _whereClause;
+    private final ReturnClause _returnClause;
+    private final OrderByClause _orderByClause;
+    private final SkipClause _skipClause;
+    private final LimitClause _limitClause;
+
+    public CypherQuery(MatchClause matchClause, ReturnClause returnClause, LimitClause limitClause) {
+      this(matchClause, null, returnClause, null, null, limitClause);
+    }
+
+    public CypherQuery(MatchClause matchClause, WhereClause whereClause,
+        ReturnClause returnClause, LimitClause limitClause) {
+      this(matchClause, whereClause, returnClause, null, null, limitClause);
+    }
+
+    public CypherQuery(MatchClause matchClause, WhereClause whereClause,
+        ReturnClause returnClause, OrderByClause orderByClause, LimitClause limitClause) {
+      this(matchClause, whereClause, returnClause, orderByClause, null, limitClause);
+    }
+
+    /**
+     * @param matchClause   the MATCH clause
+     * @param whereClause   the WHERE clause, or {@code null}
+     * @param returnClause  the RETURN clause
+     * @param orderByClause the ORDER BY clause, or {@code null}
+     * @param skipClause    the SKIP clause, or {@code null}
+     * @param limitClause   the LIMIT clause, or {@code null}
+     */
+    public CypherQuery(MatchClause matchClause, WhereClause whereClause,
+        ReturnClause returnClause, OrderByClause orderByClause,
+        SkipClause skipClause, LimitClause limitClause) {
+      _matchClause = matchClause;
+      _whereClause = whereClause;
+      _returnClause = returnClause;
+      _orderByClause = orderByClause;
+      _skipClause = skipClause;
+      _limitClause = limitClause;
+    }
+
+    public MatchClause getMatchClause() {
+      return _matchClause;
+    }
+
+    /**
+     * @return the WHERE clause, or {@code null} if no WHERE was specified
+     */
+    public WhereClause getWhereClause() {
+      return _whereClause;
+    }
+
+    public ReturnClause getReturnClause() {
+      return _returnClause;
+    }
+
+    /**
+     * @return the ORDER BY clause, or {@code null} if no ORDER BY was specified
+     */
+    public OrderByClause getOrderByClause() {
+      return _orderByClause;
+    }
+
+    /**
+     * @return the SKIP clause, or {@code null} if no SKIP was specified
+     */
+    public SkipClause getSkipClause() {
+      return _skipClause;
+    }
+
+    /**
+     * @return the LIMIT clause, or {@code null} if no LIMIT was specified
+     */
+    public LimitClause getLimitClause() {
+      return _limitClause;
+    }
+  }
+
+  /**
+   * Represents a MATCH clause with one or more hops.
+   *
+   * <p>For a single hop {@code (source)-[edge]->(target)}, the clause contains
+   * two nodes and one edge. For a two-hop pattern like
+   * {@code (a)-[e1]->(b)-[e2]->(c)}, it contains three nodes and two edges.</p>
+   *
+   * <p>Invariant: {@code _nodes.size() == _edges.size() + 1}.</p>
+   */
+  public static class MatchClause {
+    private final List<NodePattern> _nodes;
+    private final List<RelationshipPattern> _edges;
+
+    /**
+     * Creates a single-hop match clause (backward compatible).
+     *
+     * @param source the source node pattern
+     * @param edge   the relationship pattern
+     * @param target the target node pattern
+     */
+    public MatchClause(NodePattern source, RelationshipPattern edge, NodePattern target) {
+      List<NodePattern> nodes = new ArrayList<>(2);
+      nodes.add(source);
+      nodes.add(target);
+      _nodes = Collections.unmodifiableList(nodes);
+      _edges = Collections.singletonList(edge);
+    }
+
+    /**
+     * Creates a multi-hop match clause.
+     *
+     * @param nodes the node patterns (size must be edges.size() + 1)
+     * @param edges the relationship patterns
+     */
+    public MatchClause(List<NodePattern> nodes, List<RelationshipPattern> edges) {
+      if (nodes.size() != edges.size() + 1) {
+        throw new IllegalArgumentException(
+            "nodes.size() must be edges.size() + 1, got " + nodes.size() + " nodes and " + edges.size() + " edges");
+      }
+      _nodes = Collections.unmodifiableList(new ArrayList<>(nodes));
+      _edges = Collections.unmodifiableList(new ArrayList<>(edges));
+    }
+
+    /**
+     * Returns the source node (first node in the chain).
+     * Provided for backward compatibility with single-hop queries.
+     */
+    public NodePattern getSource() {
+      return _nodes.get(0);
+    }
+
+    /**
+     * Returns the single edge in a 1-hop query.
+     * Provided for backward compatibility with single-hop queries.
+     *
+     * @throws IllegalStateException if this is a multi-hop match clause
+     */
+    public RelationshipPattern getEdge() {
+      if (_edges.size() != 1) {
+        throw new IllegalStateException(
+            "getEdge() is only valid for single-hop patterns; use getEdges() for multi-hop.");
+      }
+      return _edges.get(0);
+    }
+
+    /**
+     * Returns the target node (last node in the chain).
+     * Provided for backward compatibility with single-hop queries.
+     */
+    public NodePattern getTarget() {
+      return _nodes.get(_nodes.size() - 1);
+    }
+
+    /**
+     * Returns all node patterns in the chain.
+     */
+    public List<NodePattern> getNodes() {
+      return _nodes;
+    }
+
+    /**
+     * Returns all relationship patterns in the chain.
+     */
+    public List<RelationshipPattern> getEdges() {
+      return _edges;
+    }
+
+    /**
+     * Returns the number of hops (edges) in this match clause.
+     */
+    public int getHopCount() {
+      return _edges.size();
+    }
+  }
+
+  /**
+   * Represents a node pattern such as {@code (a:User {id: '123'})}.
+   */
+  public static class NodePattern {
+    private final String _alias;
+    private final String _label;
+    private final Map<String, Object> _properties;
+
+    /**
+     * @param alias      the variable alias (e.g. "a"), or {@code null} if anonymous
+     * @param label      the node label (e.g. "User"), or {@code null} if unspecified
+     * @param properties inline property filters (e.g. {id: '123'})
+     */
+    public NodePattern(String alias, String label, Map<String, Object> properties) {
+      _alias = alias;
+      _label = label;
+      _properties = properties == null ? Map.of() : Collections.unmodifiableMap(properties);
+    }
+
+    public String getAlias() {
+      return _alias;
+    }
+
+    public String getLabel() {
+      return _label;
+    }
+
+    public Map<String, Object> getProperties() {
+      return _properties;
+    }
+  }
+
+  /**
+   * Represents a relationship pattern such as {@code -[:FOLLOWS]->}.
+   */
+  public static class RelationshipPattern {
+    private final String _alias;
+    private final String _type;
+    private final Direction _direction;
+
+    /**
+     * @param alias     the variable alias, or {@code null} if anonymous
+     * @param type      the relationship type (e.g. "FOLLOWS"), or {@code null} if unspecified
+     * @param direction the traversal direction
+     */
+    public RelationshipPattern(String alias, String type, Direction direction) {
+      _alias = alias;
+      _type = type;
+      _direction = direction;
+    }
+
+    public String getAlias() {
+      return _alias;
+    }
+
+    public String getType() {
+      return _type;
+    }
+
+    public Direction getDirection() {
+      return _direction;
+    }
+  }
+
+  /**
+   * Edge traversal direction.
+   */
+  public enum Direction {
+    /** {@code -[]-&gt;} */
+    OUTGOING,
+    /** {@code &lt;-[]-} */
+    INCOMING,
+    /** {@code -[]-} */
+    UNDIRECTED
+  }
+
+  /**
+   * Sort direction for ORDER BY items.
+   */
+  public enum SortDirection {
+    /** Ascending sort order (default). */
+    ASC,
+    /** Descending sort order. */
+    DESC
+  }
+
+  /**
+   * Represents a RETURN clause with a list of return items and an optional DISTINCT modifier.
+   */
+  public static class ReturnClause {
+    private final List<ReturnItem> _items;
+    private final boolean _distinct;
+
+    public ReturnClause(List<ReturnItem> items) {
+      this(items, false);
+    }
+
+    /**
+     * @param items    the return items
+     * @param distinct whether DISTINCT was specified
+     */
+    public ReturnClause(List<ReturnItem> items, boolean distinct) {
+      _items = Collections.unmodifiableList(items);
+      _distinct = distinct;
+    }
+
+    public List<ReturnItem> getItems() {
+      return _items;
+    }
+
+    /**
+     * @return {@code true} if the DISTINCT modifier was specified
+     */
+    public boolean isDistinct() {
+      return _distinct;
+    }
+  }
+
+  /**
+   * Aggregation functions supported in RETURN items.
+   */
+  public enum AggregationFunction {
+    /** No aggregation; a plain column reference. */
+    NONE,
+    /** {@code COUNT(expr)} */
+    COUNT,
+    /** {@code COUNT(DISTINCT expr)} */
+    COUNT_DISTINCT,
+    /** {@code SUM(expr)} */
+    SUM,
+    /** {@code AVG(expr)} */
+    AVG,
+    /** {@code MIN(expr)} */
+    MIN,
+    /** {@code MAX(expr)} */
+    MAX
+  }
+
+  /**
+   * A single item in a RETURN clause, such as {@code b.id}, {@code b.id AS userId},
+   * or {@code count(b.id)}.
+   */
+  public static class ReturnItem {
+    private final String _alias;
+    private final String _property;
+    private final AggregationFunction _aggregation;
+    private final String _resultAlias;
+
+    /**
+     * @param alias    the node/relationship alias being referenced (e.g. "b")
+     * @param property the property name (e.g. "id"), or {@code null} to return the alias itself
+     */
+    public ReturnItem(String alias, String property) {
+      this(alias, property, AggregationFunction.NONE, null);
+    }
+
+    /**
+     * @param alias       the node/relationship alias being referenced (e.g. "b"),
+     *                    or {@code null} for {@code count(*)}
+     * @param property    the property name (e.g. "id"), or {@code null}
+     * @param aggregation the aggregation function to apply
+     */
+    public ReturnItem(String alias, String property, AggregationFunction aggregation) {
+      this(alias, property, aggregation, null);
+    }
+
+    /**
+     * @param alias       the node/relationship alias being referenced (e.g. "b"),
+     *                    or {@code null} for {@code count(*)}
+     * @param property    the property name (e.g. "id"), or {@code null}
+     * @param aggregation the aggregation function to apply
+     * @param resultAlias the AS alias (e.g. "userId"), or {@code null} if not specified
+     */
+    public ReturnItem(String alias, String property, AggregationFunction aggregation,
+        String resultAlias) {
+      _alias = alias;
+      _property = property;
+      _aggregation = aggregation;
+      _resultAlias = resultAlias;
+    }
+
+    public String getAlias() {
+      return _alias;
+    }
+
+    public String getProperty() {
+      return _property;
+    }
+
+    public AggregationFunction getAggregation() {
+      return _aggregation;
+    }
+
+    /**
+     * @return the AS alias, or {@code null} if no alias was specified
+     */
+    public String getResultAlias() {
+      return _resultAlias;
+    }
+  }
+
+  /**
+   * Represents an ORDER BY clause with a list of order items.
+   */
+  public static class OrderByClause {
+    private final List<OrderByItem> _items;
+
+    public OrderByClause(List<OrderByItem> items) {
+      _items = Collections.unmodifiableList(items);
+    }
+
+    public List<OrderByItem> getItems() {
+      return _items;
+    }
+  }
+
+  /**
+   * A single item in an ORDER BY clause, such as {@code b.name DESC}.
+   */
+  public static class OrderByItem {
+    private final String _alias;
+    private final String _property;
+    private final SortDirection _direction;
+
+    /**
+     * @param alias     the node/relationship alias being referenced (e.g. "b")
+     * @param property  the property name (e.g. "name"), or {@code null} to sort by the alias itself
+     * @param direction the sort direction (ASC or DESC)
+     */
+    public OrderByItem(String alias, String property, SortDirection direction) {
+      _alias = alias;
+      _property = property;
+      _direction = direction;
+    }
+
+    public String getAlias() {
+      return _alias;
+    }
+
+    public String getProperty() {
+      return _property;
+    }
+
+    public SortDirection getDirection() {
+      return _direction;
+    }
+  }
+
+  /**
+   * Represents a LIMIT clause.
+   */
+  public static class LimitClause {
+    private final int _count;
+
+    public LimitClause(int count) {
+      _count = count;
+    }
+
+    public int getCount() {
+      return _count;
+    }
+  }
+
+  /**
+   * Represents a SKIP clause (pagination offset).
+   */
+  public static class SkipClause {
+    private final int _count;
+
+    public SkipClause(int count) {
+      _count = count;
+    }
+
+    public int getCount() {
+      return _count;
+    }
+  }
+
+  /**
+   * Represents a WHERE clause containing a single predicate tree.
+   */
+  public static class WhereClause {
+    private final Predicate _predicate;
+
+    public WhereClause(Predicate predicate) {
+      _predicate = predicate;
+    }
+
+    public Predicate getPredicate() {
+      return _predicate;
+    }
+  }
+
+  /**
+   * Base interface for predicate expressions in a WHERE clause.
+   */
+  public interface Predicate {
+  }
+
+  /**
+   * A comparison predicate: {@code alias.property operator value}.
+   *
+   * <p>Supported operators: {@code =}, {@code <>}, {@code <}, {@code >},
+   * {@code <=}, {@code >=}.</p>
+   */
+  public static class ComparisonPredicate implements Predicate {
+    private final String _alias;
+    private final String _property;
+    private final String _operator;
+    private final Object _value;
+
+    /**
+     * @param alias    the node alias (e.g. "a")
+     * @param property the property name (e.g. "id")
+     * @param operator the comparison operator (e.g. "=", "<>", "<", ">", "<=", ">=")
+     * @param value    the literal value (String or Long)
+     */
+    public ComparisonPredicate(String alias, String property, String operator, Object value) {
+      _alias = alias;
+      _property = property;
+      _operator = operator;
+      _value = value;
+    }
+
+    public String getAlias() {
+      return _alias;
+    }
+
+    public String getProperty() {
+      return _property;
+    }
+
+    public String getOperator() {
+      return _operator;
+    }
+
+    public Object getValue() {
+      return _value;
+    }
+  }
+
+  /**
+   * A conjunction predicate: {@code left AND right}.
+   */
+  public static class AndPredicate implements Predicate {
+    private final Predicate _left;
+    private final Predicate _right;
+
+    public AndPredicate(Predicate left, Predicate right) {
+      _left = left;
+      _right = right;
+    }
+
+    public Predicate getLeft() {
+      return _left;
+    }
+
+    public Predicate getRight() {
+      return _right;
+    }
+  }
+
+  /**
+   * A disjunction predicate: {@code left OR right}.
+   */
+  public static class OrPredicate implements Predicate {
+    private final Predicate _left;
+    private final Predicate _right;
+
+    public OrPredicate(Predicate left, Predicate right) {
+      _left = left;
+      _right = right;
+    }
+
+    public Predicate getLeft() {
+      return _left;
+    }
+
+    public Predicate getRight() {
+      return _right;
+    }
+  }
+
+  /**
+   * A negation predicate: {@code NOT inner}.
+   */
+  public static class NotPredicate implements Predicate {
+    private final Predicate _inner;
+
+    public NotPredicate(Predicate inner) {
+      _inner = inner;
+    }
+
+    public Predicate getInner() {
+      return _inner;
+    }
+  }
+
+  /**
+   * Operators for string predicates.
+   */
+  public enum StringOperator {
+    /** {@code STARTS WITH} */
+    STARTS_WITH,
+    /** {@code ENDS WITH} */
+    ENDS_WITH,
+    /** {@code CONTAINS} */
+    CONTAINS
+  }
+
+  /**
+   * A string predicate: {@code alias.property STARTS WITH|ENDS WITH|CONTAINS value}.
+   */
+  public static class StringPredicate implements Predicate {
+    private final String _alias;
+    private final String _property;
+    private final StringOperator _operator;
+    private final String _value;
+
+    /**
+     * @param alias    the node alias (e.g. "a")
+     * @param property the property name (e.g. "name")
+     * @param operator the string operator (STARTS_WITH, ENDS_WITH, CONTAINS)
+     * @param value    the string value to match against
+     */
+    public StringPredicate(String alias, String property, StringOperator operator, String value) {
+      _alias = alias;
+      _property = property;
+      _operator = operator;
+      _value = value;
+    }
+
+    public String getAlias() {
+      return _alias;
+    }
+
+    public String getProperty() {
+      return _property;
+    }
+
+    public StringOperator getOperator() {
+      return _operator;
+    }
+
+    public String getValue() {
+      return _value;
+    }
+  }
+
+  /**
+   * An IN list predicate: {@code alias.property IN [value1, value2, ...]}.
+   */
+  public static class InPredicate implements Predicate {
+    private final String _alias;
+    private final String _property;
+    private final List<Object> _values;
+
+    /**
+     * @param alias    the node alias (e.g. "a")
+     * @param property the property name (e.g. "id")
+     * @param values   the list of literal values (Strings, Longs, or Booleans)
+     */
+    public InPredicate(String alias, String property, List<Object> values) {
+      _alias = alias;
+      _property = property;
+      _values = Collections.unmodifiableList(values);
+    }
+
+    public String getAlias() {
+      return _alias;
+    }
+
+    public String getProperty() {
+      return _property;
+    }
+
+    public List<Object> getValues() {
+      return _values;
+    }
+  }
+}

--- a/pinot-graph/pinot-graph-planner/src/main/java/org/apache/pinot/graph/planner/CypherParseException.java
+++ b/pinot-graph/pinot-graph-planner/src/main/java/org/apache/pinot/graph/planner/CypherParseException.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.graph.planner;
+
+
+/**
+ * Exception thrown when a Cypher query cannot be parsed or contains
+ * unsupported constructs.
+ */
+public class CypherParseException extends RuntimeException {
+
+  public CypherParseException(String message) {
+    super(message);
+  }
+
+  public CypherParseException(String message, Throwable cause) {
+    super(message, cause);
+  }
+}

--- a/pinot-graph/pinot-graph-planner/src/main/java/org/apache/pinot/graph/planner/CypherParser.java
+++ b/pinot-graph/pinot-graph-planner/src/main/java/org/apache/pinot/graph/planner/CypherParser.java
@@ -1,0 +1,1060 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.graph.planner;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+
+/**
+ * Hand-written recursive descent parser for the minimal openCypher subset
+ * supported by Pinot's graph query MVP.
+ *
+ * <p>Supported query shape:</p>
+ * <pre>
+ *   MATCH (alias:Label {prop: value})-[:TYPE]-&gt;(alias:Label)
+ *   [WHERE predicate]
+ *   RETURN alias.property [AS resultAlias] [, ...]
+ *   [ORDER BY alias.property [ASC|DESC] [, ...]]
+ *   [SKIP integer]
+ *   [LIMIT integer]
+ * </pre>
+ *
+ * <p>This parser first tokenizes the input string, then parses the token stream
+ * using recursive descent. Unsupported Cypher constructs are rejected early with
+ * clear error messages.</p>
+ *
+ * <p>Thread-safety: instances are not reusable; create a new parser per query.</p>
+ */
+public class CypherParser {
+
+  // ---- Token types ----
+  enum TokenType {
+    // Keywords
+    MATCH, RETURN, LIMIT, WHERE, AND, OR, NOT, TRUE, FALSE,
+    AS, ASC, DESC,
+    // String predicate and IN list keywords
+    STARTS, ENDS, CONTAINS, IN, WITH,
+    // Unsupported keywords (detected to produce clear error messages)
+    OPTIONAL, CREATE, MERGE, DELETE, SET, REMOVE, UNION,
+    ORDER, BY, SKIP, DISTINCT,
+    // Literals
+    STRING_LITERAL, INTEGER_LITERAL, IDENTIFIER,
+    // Punctuation
+    LPAREN, RPAREN,       // ( )
+    LBRACKET, RBRACKET,   // [ ]
+    LBRACE, RBRACE,       // { }
+    COLON, COMMA, DOT,
+    DASH, ARROW_RIGHT,    // - ->
+    ARROW_LEFT,           // <-
+    STAR,                 // *
+    EQUALS,               // =
+    LESS_THAN,            // <
+    GREATER_THAN,         // >
+    NOT_EQUALS,           // <>
+    LESS_EQUAL,           // <=
+    GREATER_EQUAL,        // >=
+    // End of input
+    EOF
+  }
+
+  static class Token {
+    final TokenType _type;
+    final String _value;
+    final int _position;
+
+    Token(TokenType type, String value, int position) {
+      _type = type;
+      _value = value;
+      _position = position;
+    }
+
+    @Override
+    public String toString() {
+      return _type + "(" + _value + ")@" + _position;
+    }
+  }
+
+  private final String _input;
+  private List<Token> _tokens;
+  private int _pos;
+
+  public CypherParser(String input) {
+    _input = input;
+  }
+
+  /**
+   * Parses the input Cypher query and returns the IR.
+   *
+   * @return a parsed {@link CypherIR.CypherQuery}
+   * @throws CypherParseException if the query is malformed or uses unsupported syntax
+   */
+  public CypherIR.CypherQuery parse() {
+    _tokens = tokenize(_input);
+    _pos = 0;
+
+    // Reject unsupported top-level keywords early
+    rejectUnsupportedKeywords();
+
+    CypherIR.MatchClause matchClause = parseMatchClause();
+
+    CypherIR.WhereClause whereClause = null;
+    if (peek()._type == TokenType.WHERE) {
+      whereClause = parseWhereClause();
+    }
+
+    CypherIR.ReturnClause returnClause = parseReturnClause();
+
+    CypherIR.OrderByClause orderByClause = null;
+    if (peek()._type == TokenType.ORDER) {
+      orderByClause = parseOrderByClause();
+    }
+
+    CypherIR.SkipClause skipClause = null;
+    if (peek()._type == TokenType.SKIP) {
+      skipClause = parseSkipClause();
+    }
+
+    CypherIR.LimitClause limitClause = null;
+    if (peek()._type == TokenType.LIMIT) {
+      limitClause = parseLimitClause();
+    }
+
+    expectEof();
+    return new CypherIR.CypherQuery(matchClause, whereClause, returnClause, orderByClause,
+        skipClause, limitClause);
+  }
+
+  // ---- Tokenizer ----
+
+  static List<Token> tokenize(String input) {
+    List<Token> tokens = new ArrayList<>();
+    int i = 0;
+    int len = input.length();
+
+    while (i < len) {
+      char c = input.charAt(i);
+
+      // Skip whitespace
+      if (Character.isWhitespace(c)) {
+        i++;
+        continue;
+      }
+
+      // Single-line comment: //
+      if (c == '/' && i + 1 < len && input.charAt(i + 1) == '/') {
+        while (i < len && input.charAt(i) != '\n') {
+          i++;
+        }
+        continue;
+      }
+
+      // String literal (single-quoted)
+      if (c == '\'') {
+        int start = i;
+        i++; // skip opening quote
+        StringBuilder sb = new StringBuilder();
+        while (i < len && input.charAt(i) != '\'') {
+          if (input.charAt(i) == '\\' && i + 1 < len) {
+            i++;
+            sb.append(input.charAt(i));
+          } else {
+            sb.append(input.charAt(i));
+          }
+          i++;
+        }
+        if (i >= len) {
+          throw new CypherParseException("Unterminated string literal starting at position " + start);
+        }
+        i++; // skip closing quote
+        tokens.add(new Token(TokenType.STRING_LITERAL, sb.toString(), start));
+        continue;
+      }
+
+      // String literal (double-quoted)
+      if (c == '"') {
+        int start = i;
+        i++; // skip opening quote
+        StringBuilder sb = new StringBuilder();
+        while (i < len && input.charAt(i) != '"') {
+          if (input.charAt(i) == '\\' && i + 1 < len) {
+            i++;
+            sb.append(input.charAt(i));
+          } else {
+            sb.append(input.charAt(i));
+          }
+          i++;
+        }
+        if (i >= len) {
+          throw new CypherParseException("Unterminated string literal starting at position " + start);
+        }
+        i++; // skip closing quote
+        tokens.add(new Token(TokenType.STRING_LITERAL, sb.toString(), start));
+        continue;
+      }
+
+      // Integer literal
+      if (Character.isDigit(c)) {
+        int start = i;
+        while (i < len && Character.isDigit(input.charAt(i))) {
+          i++;
+        }
+        tokens.add(new Token(TokenType.INTEGER_LITERAL, input.substring(start, i), start));
+        continue;
+      }
+
+      // Identifiers and keywords
+      if (Character.isLetter(c) || c == '_') {
+        int start = i;
+        while (i < len && (Character.isLetterOrDigit(input.charAt(i)) || input.charAt(i) == '_')) {
+          i++;
+        }
+        String word = input.substring(start, i);
+        TokenType type = resolveKeyword(word);
+        tokens.add(new Token(type, word, start));
+        continue;
+      }
+
+      // Punctuation
+      int start = i;
+      switch (c) {
+        case '(':
+          tokens.add(new Token(TokenType.LPAREN, "(", start));
+          i++;
+          break;
+        case ')':
+          tokens.add(new Token(TokenType.RPAREN, ")", start));
+          i++;
+          break;
+        case '[':
+          tokens.add(new Token(TokenType.LBRACKET, "[", start));
+          i++;
+          break;
+        case ']':
+          tokens.add(new Token(TokenType.RBRACKET, "]", start));
+          i++;
+          break;
+        case '{':
+          tokens.add(new Token(TokenType.LBRACE, "{", start));
+          i++;
+          break;
+        case '}':
+          tokens.add(new Token(TokenType.RBRACE, "}", start));
+          i++;
+          break;
+        case ':':
+          tokens.add(new Token(TokenType.COLON, ":", start));
+          i++;
+          break;
+        case ',':
+          tokens.add(new Token(TokenType.COMMA, ",", start));
+          i++;
+          break;
+        case '.':
+          tokens.add(new Token(TokenType.DOT, ".", start));
+          i++;
+          break;
+        case '*':
+          tokens.add(new Token(TokenType.STAR, "*", start));
+          i++;
+          break;
+        case '=':
+          tokens.add(new Token(TokenType.EQUALS, "=", start));
+          i++;
+          break;
+        case '-':
+          if (i + 1 < len && input.charAt(i + 1) == '>') {
+            tokens.add(new Token(TokenType.ARROW_RIGHT, "->", start));
+            i += 2;
+          } else {
+            tokens.add(new Token(TokenType.DASH, "-", start));
+            i++;
+          }
+          break;
+        case '<':
+          if (i + 1 < len && input.charAt(i + 1) == '-') {
+            tokens.add(new Token(TokenType.ARROW_LEFT, "<-", start));
+            i += 2;
+          } else if (i + 1 < len && input.charAt(i + 1) == '>') {
+            tokens.add(new Token(TokenType.NOT_EQUALS, "<>", start));
+            i += 2;
+          } else if (i + 1 < len && input.charAt(i + 1) == '=') {
+            tokens.add(new Token(TokenType.LESS_EQUAL, "<=", start));
+            i += 2;
+          } else {
+            tokens.add(new Token(TokenType.LESS_THAN, "<", start));
+            i++;
+          }
+          break;
+        case '>':
+          if (i + 1 < len && input.charAt(i + 1) == '=') {
+            tokens.add(new Token(TokenType.GREATER_EQUAL, ">=", start));
+            i += 2;
+          } else {
+            tokens.add(new Token(TokenType.GREATER_THAN, ">", start));
+            i++;
+          }
+          break;
+        default:
+          throw new CypherParseException("Unexpected character '" + c + "' at position " + start);
+      }
+    }
+
+    tokens.add(new Token(TokenType.EOF, "", len));
+    return tokens;
+  }
+
+  private static TokenType resolveKeyword(String word) {
+    switch (word.toUpperCase()) {
+      case "MATCH":
+        return TokenType.MATCH;
+      case "RETURN":
+        return TokenType.RETURN;
+      case "LIMIT":
+        return TokenType.LIMIT;
+      case "WHERE":
+        return TokenType.WHERE;
+      case "AND":
+        return TokenType.AND;
+      case "OR":
+        return TokenType.OR;
+      case "NOT":
+        return TokenType.NOT;
+      case "TRUE":
+        return TokenType.TRUE;
+      case "FALSE":
+        return TokenType.FALSE;
+      case "AS":
+        return TokenType.AS;
+      case "ASC":
+        return TokenType.ASC;
+      case "DESC":
+        return TokenType.DESC;
+      case "OPTIONAL":
+        return TokenType.OPTIONAL;
+      case "CREATE":
+        return TokenType.CREATE;
+      case "MERGE":
+        return TokenType.MERGE;
+      case "DELETE":
+        return TokenType.DELETE;
+      case "SET":
+        return TokenType.SET;
+      case "REMOVE":
+        return TokenType.REMOVE;
+      case "STARTS":
+        return TokenType.STARTS;
+      case "ENDS":
+        return TokenType.ENDS;
+      case "CONTAINS":
+        return TokenType.CONTAINS;
+      case "IN":
+        return TokenType.IN;
+      case "WITH":
+        return TokenType.WITH;
+      case "UNION":
+        return TokenType.UNION;
+      case "ORDER":
+        return TokenType.ORDER;
+      case "BY":
+        return TokenType.BY;
+      case "SKIP":
+        return TokenType.SKIP;
+      case "DISTINCT":
+        return TokenType.DISTINCT;
+      default:
+        return TokenType.IDENTIFIER;
+    }
+  }
+
+  // ---- Parser helpers ----
+
+  private Token peek() {
+    return _tokens.get(_pos);
+  }
+
+  private Token advance() {
+    Token token = _tokens.get(_pos);
+    _pos++;
+    return token;
+  }
+
+  private Token expect(TokenType type) {
+    Token token = peek();
+    if (token._type != type) {
+      throw new CypherParseException(
+          "Expected " + type + " but found " + token._type + " ('" + token._value + "') at position "
+              + token._position);
+    }
+    return advance();
+  }
+
+  private void expectEof() {
+    Token token = peek();
+    if (token._type != TokenType.EOF) {
+      throw new CypherParseException("Unexpected token '" + token._value + "' at position " + token._position
+          + ". Expected end of query.");
+    }
+  }
+
+  /**
+   * Checks whether a token type represents an identifier or a keyword that can
+   * be used as an identifier in certain contexts (e.g. as a return-item alias
+   * after AS, or as a property name).
+   */
+  private static boolean isIdentifierLike(TokenType type) {
+    switch (type) {
+      case IDENTIFIER:
+      case AS:
+      case ASC:
+      case DESC:
+      case BY:
+        return true;
+      default:
+        return false;
+    }
+  }
+
+  private void rejectUnsupportedKeywords() {
+    for (Token token : _tokens) {
+      switch (token._type) {
+        case OPTIONAL:
+          throw new CypherParseException("OPTIONAL MATCH is not supported. Only single MATCH clauses are supported.");
+        case CREATE:
+          throw new CypherParseException("CREATE is not supported. Only read queries (MATCH ... RETURN) are allowed.");
+        case MERGE:
+          throw new CypherParseException("MERGE is not supported. Only read queries (MATCH ... RETURN) are allowed.");
+        case DELETE:
+          throw new CypherParseException(
+              "DELETE is not supported. Only read queries (MATCH ... RETURN) are allowed.");
+        case SET:
+          throw new CypherParseException("SET is not supported. Only read queries (MATCH ... RETURN) are allowed.");
+        case REMOVE:
+          throw new CypherParseException(
+              "REMOVE is not supported. Only read queries (MATCH ... RETURN) are allowed.");
+        case UNION:
+          throw new CypherParseException("UNION is not supported.");
+        default:
+          break;
+      }
+    }
+  }
+
+  // ---- Grammar rules ----
+
+  /** Maximum number of hops supported in a single MATCH clause. */
+  private static final int MAX_HOPS = 2;
+
+  /**
+   * Parse: MATCH (source)-[edge]-&gt;(target) or multi-hop chains such as
+   * {@code MATCH (a)-[e1]-&gt;(b)-[e2]-&gt;(c)}.
+   *
+   * <p>Currently supports up to {@value #MAX_HOPS} hops.</p>
+   */
+  private CypherIR.MatchClause parseMatchClause() {
+    expect(TokenType.MATCH);
+
+    // Check for multiple MATCH clauses by scanning ahead
+    for (int i = _pos; i < _tokens.size(); i++) {
+      if (_tokens.get(i)._type == TokenType.MATCH) {
+        throw new CypherParseException("Multiple MATCH clauses are not supported. Use a single MATCH clause.");
+      }
+    }
+
+    List<CypherIR.NodePattern> nodes = new ArrayList<>();
+    List<CypherIR.RelationshipPattern> edges = new ArrayList<>();
+
+    // Parse the first node
+    nodes.add(parseNodePattern());
+
+    // Parse one or more edge-node pairs
+    while (peek()._type == TokenType.DASH || peek()._type == TokenType.ARROW_LEFT) {
+      if (edges.size() >= MAX_HOPS) {
+        throw new CypherParseException(
+            "At most " + MAX_HOPS + "-hop patterns are supported. "
+                + "Found more than " + MAX_HOPS + " relationship patterns.");
+      }
+
+      CypherIR.RelationshipPattern edge = parseRelationshipWithDirection();
+      edges.add(edge);
+      nodes.add(parseNodePattern());
+    }
+
+    if (edges.isEmpty()) {
+      throw new CypherParseException(
+          "Expected relationship pattern ('-' or '<-') after node pattern at position " + peek()._position);
+    }
+
+    return new CypherIR.MatchClause(nodes, edges);
+  }
+
+  /**
+   * Parse a relationship pattern with its direction arrows.
+   * Handles outgoing ({@code -[...]-&gt;}), incoming ({@code &lt;-[...]-}),
+   * and undirected ({@code -[...]-}) patterns.
+   */
+  private CypherIR.RelationshipPattern parseRelationshipWithDirection() {
+    Token next = peek();
+    CypherIR.RelationshipPattern edge;
+
+    if (next._type == TokenType.DASH) {
+      // Outgoing: -[...]->(target)  or Undirected: -[...]-(target)
+      advance(); // consume '-'
+      edge = parseRelationshipDetail();
+
+      Token afterBracket = peek();
+      if (afterBracket._type == TokenType.ARROW_RIGHT) {
+        advance(); // consume '->'
+        edge = new CypherIR.RelationshipPattern(edge.getAlias(), edge.getType(), CypherIR.Direction.OUTGOING);
+      } else if (afterBracket._type == TokenType.DASH) {
+        advance(); // consume '-'
+        edge = new CypherIR.RelationshipPattern(edge.getAlias(), edge.getType(), CypherIR.Direction.UNDIRECTED);
+      } else {
+        throw new CypherParseException(
+            "Expected '->' or '-' after relationship pattern at position " + afterBracket._position);
+      }
+    } else if (next._type == TokenType.ARROW_LEFT) {
+      // Incoming: <-[...]-(target)
+      advance(); // consume '<-'
+      edge = parseRelationshipDetail();
+      expect(TokenType.DASH);
+      edge = new CypherIR.RelationshipPattern(edge.getAlias(), edge.getType(), CypherIR.Direction.INCOMING);
+    } else {
+      throw new CypherParseException(
+          "Expected relationship pattern ('-' or '<-') after node pattern at position " + next._position);
+    }
+
+    return edge;
+  }
+
+  /**
+   * Parse: (alias:Label {prop: value, ...})
+   */
+  private CypherIR.NodePattern parseNodePattern() {
+    expect(TokenType.LPAREN);
+
+    String alias = null;
+    String label = null;
+    Map<String, Object> properties = null;
+
+    // Parse optional alias
+    if (peek()._type == TokenType.IDENTIFIER) {
+      alias = advance()._value;
+    }
+
+    // Parse optional :Label
+    if (peek()._type == TokenType.COLON) {
+      advance(); // consume ':'
+      label = expect(TokenType.IDENTIFIER)._value;
+    }
+
+    // Parse optional {prop: value, ...}
+    if (peek()._type == TokenType.LBRACE) {
+      properties = parsePropertyMap();
+    }
+
+    expect(TokenType.RPAREN);
+    return new CypherIR.NodePattern(alias, label, properties);
+  }
+
+  /**
+   * Parse the inside of a relationship bracket: [{@code [:TYPE]}]
+   */
+  private CypherIR.RelationshipPattern parseRelationshipDetail() {
+    expect(TokenType.LBRACKET);
+
+    String alias = null;
+    String type = null;
+
+    // Parse optional alias
+    if (peek()._type == TokenType.IDENTIFIER) {
+      alias = advance()._value;
+    }
+
+    // Parse optional :TYPE
+    if (peek()._type == TokenType.COLON) {
+      advance(); // consume ':'
+      type = expect(TokenType.IDENTIFIER)._value;
+    }
+
+    // Reject variable-length paths like [*1..3]
+    if (peek()._type == TokenType.STAR) {
+      throw new CypherParseException(
+          "Variable-length paths (e.g. [*1..3]) are not supported. Only single-hop relationships are allowed.");
+    }
+
+    expect(TokenType.RBRACKET);
+
+    // Direction will be set by the caller based on arrow direction
+    return new CypherIR.RelationshipPattern(alias, type, null);
+  }
+
+  /**
+   * Parse: {key: value, key: value, ...}
+   */
+  private Map<String, Object> parsePropertyMap() {
+    expect(TokenType.LBRACE);
+    Map<String, Object> properties = new LinkedHashMap<>();
+
+    if (peek()._type != TokenType.RBRACE) {
+      parseProperty(properties);
+      while (peek()._type == TokenType.COMMA) {
+        advance(); // consume ','
+        parseProperty(properties);
+      }
+    }
+
+    expect(TokenType.RBRACE);
+    return properties;
+  }
+
+  /**
+   * Parse: key: value
+   */
+  private void parseProperty(Map<String, Object> properties) {
+    String key = expect(TokenType.IDENTIFIER)._value;
+    expect(TokenType.COLON);
+    Object value = parseValue();
+    properties.put(key, value);
+  }
+
+  /**
+   * Parse a property value: string literal, integer literal, or boolean literal.
+   */
+  private Object parseValue() {
+    Token token = peek();
+    switch (token._type) {
+      case STRING_LITERAL:
+        advance();
+        return token._value;
+      case INTEGER_LITERAL:
+        advance();
+        return Long.parseLong(token._value);
+      case TRUE:
+        advance();
+        return Boolean.TRUE;
+      case FALSE:
+        advance();
+        return Boolean.FALSE;
+      default:
+        throw new CypherParseException(
+            "Expected string, integer, or boolean value but found '" + token._value + "' at position "
+                + token._position);
+    }
+  }
+
+  /**
+   * Parse: WHERE predicate
+   *
+   * <p>Predicates support: comparison operators ({@code =}, {@code <>}, {@code <}, {@code >},
+   * {@code <=}, {@code >=}), boolean connectives ({@code AND}, {@code OR}),
+   * negation ({@code NOT}), and parenthesized sub-expressions.</p>
+   */
+  private CypherIR.WhereClause parseWhereClause() {
+    expect(TokenType.WHERE);
+    CypherIR.Predicate predicate = parseOrExpression();
+    return new CypherIR.WhereClause(predicate);
+  }
+
+  /**
+   * Parse: orExpr = andExpr (OR andExpr)*
+   */
+  private CypherIR.Predicate parseOrExpression() {
+    CypherIR.Predicate left = parseAndExpression();
+    while (peek()._type == TokenType.OR) {
+      advance(); // consume OR
+      CypherIR.Predicate right = parseAndExpression();
+      left = new CypherIR.OrPredicate(left, right);
+    }
+    return left;
+  }
+
+  /**
+   * Parse: andExpr = notExpr (AND notExpr)*
+   */
+  private CypherIR.Predicate parseAndExpression() {
+    CypherIR.Predicate left = parseNotExpression();
+    while (peek()._type == TokenType.AND) {
+      advance(); // consume AND
+      CypherIR.Predicate right = parseNotExpression();
+      left = new CypherIR.AndPredicate(left, right);
+    }
+    return left;
+  }
+
+  /**
+   * Parse: notExpr = NOT notExpr | primaryPredicate
+   */
+  private CypherIR.Predicate parseNotExpression() {
+    if (peek()._type == TokenType.NOT) {
+      advance(); // consume NOT
+      CypherIR.Predicate inner = parseNotExpression();
+      return new CypherIR.NotPredicate(inner);
+    }
+    return parsePrimaryPredicate();
+  }
+
+  /**
+   * Parse: primaryPredicate = LPAREN orExpr RPAREN | comparison
+   */
+  private CypherIR.Predicate parsePrimaryPredicate() {
+    if (peek()._type == TokenType.LPAREN) {
+      advance(); // consume '('
+      CypherIR.Predicate inner = parseOrExpression();
+      expect(TokenType.RPAREN);
+      return inner;
+    }
+    return parseComparison();
+  }
+
+  /**
+   * Parse: alias.property operator value
+   *      | alias.property STARTS WITH stringValue
+   *      | alias.property ENDS WITH stringValue
+   *      | alias.property CONTAINS stringValue
+   *      | alias.property IN [value, ...]
+   */
+  private CypherIR.Predicate parseComparison() {
+    String alias = expect(TokenType.IDENTIFIER)._value;
+    expect(TokenType.DOT);
+    String property = expect(TokenType.IDENTIFIER)._value;
+
+    // Check for string predicates: STARTS WITH, ENDS WITH, CONTAINS
+    Token next = peek();
+    if (next._type == TokenType.STARTS) {
+      advance(); // consume STARTS
+      expect(TokenType.WITH);
+      Token valueToken = expect(TokenType.STRING_LITERAL);
+      return new CypherIR.StringPredicate(alias, property,
+          CypherIR.StringOperator.STARTS_WITH, valueToken._value);
+    }
+    if (next._type == TokenType.ENDS) {
+      advance(); // consume ENDS
+      expect(TokenType.WITH);
+      Token valueToken = expect(TokenType.STRING_LITERAL);
+      return new CypherIR.StringPredicate(alias, property,
+          CypherIR.StringOperator.ENDS_WITH, valueToken._value);
+    }
+    if (next._type == TokenType.CONTAINS) {
+      advance(); // consume CONTAINS
+      Token valueToken = expect(TokenType.STRING_LITERAL);
+      return new CypherIR.StringPredicate(alias, property,
+          CypherIR.StringOperator.CONTAINS, valueToken._value);
+    }
+
+    // Check for IN list predicate
+    if (next._type == TokenType.IN) {
+      advance(); // consume IN
+      expect(TokenType.LBRACKET);
+      List<Object> values = new ArrayList<>();
+      if (peek()._type != TokenType.RBRACKET) {
+        values.add(parseValue());
+        while (peek()._type == TokenType.COMMA) {
+          advance(); // consume ','
+          values.add(parseValue());
+        }
+      }
+      expect(TokenType.RBRACKET);
+      return new CypherIR.InPredicate(alias, property, values);
+    }
+
+    // Standard comparison operator
+    String operator = parseComparisonOperator();
+    Object value = parseValue();
+    return new CypherIR.ComparisonPredicate(alias, property, operator, value);
+  }
+
+  /**
+   * Parse a comparison operator: {@code =}, {@code <>}, {@code <}, {@code >},
+   * {@code <=}, {@code >=}.
+   */
+  private String parseComparisonOperator() {
+    Token token = peek();
+    switch (token._type) {
+      case EQUALS:
+        advance();
+        return "=";
+      case NOT_EQUALS:
+        advance();
+        return "<>";
+      case LESS_THAN:
+        advance();
+        return "<";
+      case GREATER_THAN:
+        advance();
+        return ">";
+      case LESS_EQUAL:
+        advance();
+        return "<=";
+      case GREATER_EQUAL:
+        advance();
+        return ">=";
+      default:
+        throw new CypherParseException(
+            "Expected comparison operator (=, <>, <, >, <=, >=) but found '" + token._value
+                + "' at position " + token._position);
+    }
+  }
+
+  /**
+   * Parse: RETURN [DISTINCT] alias.prop [AS resultAlias] [, alias.prop [AS resultAlias], ...]
+   */
+  private CypherIR.ReturnClause parseReturnClause() {
+    expect(TokenType.RETURN);
+
+    // Parse optional DISTINCT modifier
+    boolean distinct = false;
+    if (peek()._type == TokenType.DISTINCT) {
+      advance();
+      distinct = true;
+    }
+
+    // Reject RETURN *
+    if (peek()._type == TokenType.STAR) {
+      throw new CypherParseException("RETURN * is not supported. Specify explicit return items.");
+    }
+
+    List<CypherIR.ReturnItem> items = new ArrayList<>();
+    items.add(parseReturnItem());
+
+    while (peek()._type == TokenType.COMMA) {
+      advance(); // consume ','
+      items.add(parseReturnItem());
+    }
+
+    return new CypherIR.ReturnClause(items, distinct);
+  }
+
+  /**
+   * Parse a return item: {@code alias.property [AS resultAlias]},
+   * {@code alias [AS resultAlias]}, or an aggregation such as
+   * {@code count(alias.property) [AS resultAlias]}, {@code count(alias)},
+   * {@code count(*)}, or {@code count(DISTINCT alias.property)}.
+   */
+  private CypherIR.ReturnItem parseReturnItem() {
+    Token identToken = expect(TokenType.IDENTIFIER);
+    String identValue = identToken._value;
+
+    // Check if this identifier is an aggregation function name followed by '('
+    if (peek()._type == TokenType.LPAREN) {
+      if (identValue.equalsIgnoreCase("count")) {
+        return parseCountAggregation();
+      }
+      CypherIR.AggregationFunction aggFunc = resolveAggregationFunction(identValue);
+      if (aggFunc != null) {
+        return parseAggregation(aggFunc);
+      }
+    }
+
+    // Regular return item: alias.property or alias
+    String property = null;
+    if (peek()._type == TokenType.DOT) {
+      advance(); // consume '.'
+      property = expect(TokenType.IDENTIFIER)._value;
+    }
+
+    // Parse optional AS alias
+    String resultAlias = parseOptionalAsAlias();
+
+    return new CypherIR.ReturnItem(identValue, property, CypherIR.AggregationFunction.NONE, resultAlias);
+  }
+
+  /**
+   * Parse a COUNT aggregation after the function name has been consumed:
+   * {@code (alias.property)}, {@code (*)}, {@code (alias)}, or
+   * {@code (DISTINCT alias.property)}.
+   */
+  private CypherIR.ReturnItem parseCountAggregation() {
+    expect(TokenType.LPAREN);
+
+    // count(*)
+    if (peek()._type == TokenType.STAR) {
+      advance(); // consume '*'
+      expect(TokenType.RPAREN);
+      String resultAlias = parseOptionalAsAlias();
+      return new CypherIR.ReturnItem(null, null, CypherIR.AggregationFunction.COUNT, resultAlias);
+    }
+
+    // Check for DISTINCT modifier
+    CypherIR.AggregationFunction aggregation = CypherIR.AggregationFunction.COUNT;
+    if (peek()._type == TokenType.DISTINCT) {
+      advance(); // consume 'DISTINCT'
+      aggregation = CypherIR.AggregationFunction.COUNT_DISTINCT;
+    }
+
+    // Parse alias.property or alias
+    String alias = expect(TokenType.IDENTIFIER)._value;
+    String property = null;
+    if (peek()._type == TokenType.DOT) {
+      advance(); // consume '.'
+      property = expect(TokenType.IDENTIFIER)._value;
+    }
+
+    expect(TokenType.RPAREN);
+    String resultAlias = parseOptionalAsAlias();
+    return new CypherIR.ReturnItem(alias, property, aggregation, resultAlias);
+  }
+
+  /**
+   * Resolves an identifier to an aggregation function (SUM, AVG, MIN, MAX),
+   * or returns {@code null} if the identifier is not a recognized aggregation.
+   */
+  private static CypherIR.AggregationFunction resolveAggregationFunction(String name) {
+    switch (name.toUpperCase()) {
+      case "SUM":
+        return CypherIR.AggregationFunction.SUM;
+      case "AVG":
+        return CypherIR.AggregationFunction.AVG;
+      case "MIN":
+        return CypherIR.AggregationFunction.MIN;
+      case "MAX":
+        return CypherIR.AggregationFunction.MAX;
+      default:
+        return null;
+    }
+  }
+
+  /**
+   * Parse a SUM, AVG, MIN, or MAX aggregation after the function name has been consumed:
+   * {@code (alias.property)} or {@code (alias)}.
+   *
+   * <p>Unlike COUNT, these aggregations do not support {@code (*)} or
+   * {@code (DISTINCT ...)}.</p>
+   */
+  private CypherIR.ReturnItem parseAggregation(CypherIR.AggregationFunction func) {
+    expect(TokenType.LPAREN);
+
+    // Reject func(*)
+    if (peek()._type == TokenType.STAR) {
+      throw new CypherParseException(
+          func.name() + "(*) is not supported. Specify a property, e.g. "
+              + func.name().toLowerCase() + "(alias.property).");
+    }
+
+    // Reject func(DISTINCT ...)
+    if (peek()._type == TokenType.DISTINCT) {
+      throw new CypherParseException(
+          func.name() + "(DISTINCT ...) is not supported.");
+    }
+
+    // Parse alias.property or alias
+    String alias = expect(TokenType.IDENTIFIER)._value;
+    String property = null;
+    if (peek()._type == TokenType.DOT) {
+      advance(); // consume '.'
+      property = expect(TokenType.IDENTIFIER)._value;
+    }
+
+    expect(TokenType.RPAREN);
+    String resultAlias = parseOptionalAsAlias();
+    return new CypherIR.ReturnItem(alias, property, func, resultAlias);
+  }
+
+  /**
+   * Parse an optional {@code AS resultAlias} suffix.
+   *
+   * @return the alias name, or {@code null} if no AS clause is present
+   */
+  private String parseOptionalAsAlias() {
+    if (peek()._type == TokenType.AS) {
+      advance(); // consume 'AS'
+      Token aliasToken = peek();
+      if (!isIdentifierLike(aliasToken._type)) {
+        throw new CypherParseException(
+            "Expected identifier after AS but found '" + aliasToken._value + "' at position "
+                + aliasToken._position);
+      }
+      return advance()._value;
+    }
+    return null;
+  }
+
+  /**
+   * Parse: ORDER BY orderItem (, orderItem)*
+   *
+   * <p>Each order item is: {@code alias.property [ASC|DESC]}</p>
+   */
+  private CypherIR.OrderByClause parseOrderByClause() {
+    expect(TokenType.ORDER);
+    expect(TokenType.BY);
+
+    List<CypherIR.OrderByItem> items = new ArrayList<>();
+    items.add(parseOrderByItem());
+
+    while (peek()._type == TokenType.COMMA) {
+      advance(); // consume ','
+      items.add(parseOrderByItem());
+    }
+
+    return new CypherIR.OrderByClause(items);
+  }
+
+  /**
+   * Parse: alias.property [ASC|DESC]
+   */
+  private CypherIR.OrderByItem parseOrderByItem() {
+    String alias = expect(TokenType.IDENTIFIER)._value;
+    String property = null;
+
+    if (peek()._type == TokenType.DOT) {
+      advance(); // consume '.'
+      property = expect(TokenType.IDENTIFIER)._value;
+    }
+
+    // Parse optional sort direction, default to ASC
+    CypherIR.SortDirection direction = CypherIR.SortDirection.ASC;
+    if (peek()._type == TokenType.ASC) {
+      advance(); // consume 'ASC'
+      direction = CypherIR.SortDirection.ASC;
+    } else if (peek()._type == TokenType.DESC) {
+      advance(); // consume 'DESC'
+      direction = CypherIR.SortDirection.DESC;
+    }
+
+    return new CypherIR.OrderByItem(alias, property, direction);
+  }
+
+  /**
+   * Parse: SKIP integer
+   */
+  private CypherIR.SkipClause parseSkipClause() {
+    expect(TokenType.SKIP);
+    Token countToken = expect(TokenType.INTEGER_LITERAL);
+    int count = Integer.parseInt(countToken._value);
+    if (count < 0) {
+      throw new CypherParseException("SKIP must be a non-negative integer, got " + count);
+    }
+    return new CypherIR.SkipClause(count);
+  }
+
+  /**
+   * Parse: LIMIT integer
+   */
+  private CypherIR.LimitClause parseLimitClause() {
+    expect(TokenType.LIMIT);
+    Token countToken = expect(TokenType.INTEGER_LITERAL);
+    int count = Integer.parseInt(countToken._value);
+    if (count <= 0) {
+      throw new CypherParseException("LIMIT must be a positive integer, got " + count);
+    }
+    return new CypherIR.LimitClause(count);
+  }
+}

--- a/pinot-graph/pinot-graph-planner/src/main/java/org/apache/pinot/graph/planner/CypherSemanticValidator.java
+++ b/pinot-graph/pinot-graph-planner/src/main/java/org/apache/pinot/graph/planner/CypherSemanticValidator.java
@@ -1,0 +1,194 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.graph.planner;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.graph.spi.GraphSchemaConfig;
+
+
+/**
+ * Validates a parsed Cypher IR against a graph schema configuration.
+ *
+ * <p>Checks performed:</p>
+ * <ul>
+ *   <li>All node labels referenced in MATCH exist as vertex labels in the schema.</li>
+ *   <li>All relationship types referenced in MATCH exist as edge labels in the schema.</li>
+ *   <li>All aliases in RETURN items reference aliases defined in the MATCH clause.</li>
+ *   <li>Edge direction is consistent with the edge label definition.</li>
+ * </ul>
+ *
+ * <p>Thread-safety: instances are reusable and thread-safe.</p>
+ */
+public class CypherSemanticValidator {
+
+  private final GraphSchemaConfig _schemaConfig;
+
+  public CypherSemanticValidator(GraphSchemaConfig schemaConfig) {
+    _schemaConfig = schemaConfig;
+  }
+
+  /**
+   * Validates the given Cypher query IR against the schema.
+   *
+   * @param query the parsed Cypher query
+   * @throws CypherParseException if validation fails
+   */
+  public void validate(CypherIR.CypherQuery query) {
+    CypherIR.MatchClause matchClause = query.getMatchClause();
+    Map<String, String> aliasToLabel = new HashMap<>();
+
+    // Validate all nodes in the chain
+    List<CypherIR.NodePattern> nodes = matchClause.getNodes();
+    for (CypherIR.NodePattern node : nodes) {
+      validateNodePattern(node, aliasToLabel);
+    }
+
+    // Validate all edges in the chain
+    List<CypherIR.RelationshipPattern> edges = matchClause.getEdges();
+    for (int i = 0; i < edges.size(); i++) {
+      validateRelationship(edges.get(i), nodes.get(i), nodes.get(i + 1));
+    }
+
+    // Validate WHERE clause aliases reference known MATCH aliases
+    if (query.getWhereClause() != null) {
+      validatePredicateAliases(query.getWhereClause().getPredicate(), aliasToLabel);
+    }
+
+    // Validate return items reference known aliases
+    for (CypherIR.ReturnItem item : query.getReturnClause().getItems()) {
+      // Skip validation for count(*) which has no alias
+      if (item.getAlias() != null && !aliasToLabel.containsKey(item.getAlias())) {
+        throw new CypherParseException(
+            "RETURN item references unknown alias '" + item.getAlias() + "'. "
+                + "Known aliases: " + aliasToLabel.keySet());
+      }
+    }
+
+    // Validate ORDER BY items reference known aliases
+    if (query.getOrderByClause() != null) {
+      for (CypherIR.OrderByItem item : query.getOrderByClause().getItems()) {
+        if (!aliasToLabel.containsKey(item.getAlias())) {
+          throw new CypherParseException(
+              "ORDER BY item references unknown alias '" + item.getAlias() + "'. "
+                  + "Known aliases: " + aliasToLabel.keySet());
+        }
+      }
+    }
+  }
+
+  /**
+   * Recursively validates that all aliases in a predicate tree reference
+   * aliases defined in the MATCH clause.
+   */
+  private void validatePredicateAliases(CypherIR.Predicate predicate, Map<String, String> aliasToLabel) {
+    if (predicate instanceof CypherIR.ComparisonPredicate) {
+      CypherIR.ComparisonPredicate comp = (CypherIR.ComparisonPredicate) predicate;
+      if (!aliasToLabel.containsKey(comp.getAlias())) {
+        throw new CypherParseException(
+            "WHERE clause references unknown alias '" + comp.getAlias() + "'. "
+                + "Known aliases: " + aliasToLabel.keySet());
+      }
+    } else if (predicate instanceof CypherIR.AndPredicate) {
+      CypherIR.AndPredicate and = (CypherIR.AndPredicate) predicate;
+      validatePredicateAliases(and.getLeft(), aliasToLabel);
+      validatePredicateAliases(and.getRight(), aliasToLabel);
+    } else if (predicate instanceof CypherIR.OrPredicate) {
+      CypherIR.OrPredicate or = (CypherIR.OrPredicate) predicate;
+      validatePredicateAliases(or.getLeft(), aliasToLabel);
+      validatePredicateAliases(or.getRight(), aliasToLabel);
+    } else if (predicate instanceof CypherIR.NotPredicate) {
+      CypherIR.NotPredicate not = (CypherIR.NotPredicate) predicate;
+      validatePredicateAliases(not.getInner(), aliasToLabel);
+    } else if (predicate instanceof CypherIR.StringPredicate) {
+      CypherIR.StringPredicate sp = (CypherIR.StringPredicate) predicate;
+      if (!aliasToLabel.containsKey(sp.getAlias())) {
+        throw new CypherParseException(
+            "WHERE clause references unknown alias '" + sp.getAlias() + "'. "
+                + "Known aliases: " + aliasToLabel.keySet());
+      }
+    } else if (predicate instanceof CypherIR.InPredicate) {
+      CypherIR.InPredicate in = (CypherIR.InPredicate) predicate;
+      if (!aliasToLabel.containsKey(in.getAlias())) {
+        throw new CypherParseException(
+            "WHERE clause references unknown alias '" + in.getAlias() + "'. "
+                + "Known aliases: " + aliasToLabel.keySet());
+      }
+    }
+  }
+
+  private void validateNodePattern(CypherIR.NodePattern node, Map<String, String> aliasToLabel) {
+    String label = node.getLabel();
+    if (label != null && !_schemaConfig.getVertexLabels().containsKey(label)) {
+      throw new CypherParseException(
+          "Unknown vertex label '" + label + "'. Available labels: " + _schemaConfig.getVertexLabels().keySet());
+    }
+
+    String alias = node.getAlias();
+    if (alias != null) {
+      if (aliasToLabel.containsKey(alias)) {
+        throw new CypherParseException("Duplicate alias '" + alias + "' in MATCH clause.");
+      }
+      aliasToLabel.put(alias, label);
+    }
+  }
+
+  private void validateRelationship(CypherIR.RelationshipPattern edge,
+      CypherIR.NodePattern source, CypherIR.NodePattern target) {
+    String type = edge.getType();
+    if (type == null) {
+      throw new CypherParseException(
+          "Relationship type must be specified (e.g. -[:FOLLOWS]->). Untyped relationships are not supported.");
+    }
+
+    if (!_schemaConfig.getEdgeLabels().containsKey(type)) {
+      throw new CypherParseException(
+          "Unknown relationship type '" + type + "'. Available types: " + _schemaConfig.getEdgeLabels().keySet());
+    }
+
+    // Validate that source and target labels match the edge definition
+    GraphSchemaConfig.EdgeLabel edgeLabel = _schemaConfig.getEdgeLabels().get(type);
+    if (edge.getDirection() == CypherIR.Direction.OUTGOING) {
+      validateEdgeEndpoints(edgeLabel, source, target);
+    } else if (edge.getDirection() == CypherIR.Direction.INCOMING) {
+      // For incoming edges, the source in the query is the target in the schema
+      validateEdgeEndpoints(edgeLabel, target, source);
+    }
+    // For undirected, we allow either direction
+  }
+
+  private void validateEdgeEndpoints(GraphSchemaConfig.EdgeLabel edgeLabel,
+      CypherIR.NodePattern source, CypherIR.NodePattern target) {
+    String sourceLabel = source.getLabel();
+    String targetLabel = target.getLabel();
+
+    if (sourceLabel != null && !sourceLabel.equals(edgeLabel.getSourceVertexLabel())) {
+      throw new CypherParseException(
+          "Source node label '" + sourceLabel + "' does not match edge definition. "
+              + "Expected source label: '" + edgeLabel.getSourceVertexLabel() + "'.");
+    }
+
+    if (targetLabel != null && !targetLabel.equals(edgeLabel.getTargetVertexLabel())) {
+      throw new CypherParseException(
+          "Target node label '" + targetLabel + "' does not match edge definition. "
+              + "Expected target label: '" + edgeLabel.getTargetVertexLabel() + "'.");
+    }
+  }
+}

--- a/pinot-graph/pinot-graph-planner/src/main/java/org/apache/pinot/graph/planner/CypherToSqlTranslator.java
+++ b/pinot-graph/pinot-graph-planner/src/main/java/org/apache/pinot/graph/planner/CypherToSqlTranslator.java
@@ -1,0 +1,330 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.graph.planner;
+
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.apache.pinot.graph.spi.GraphSchemaConfig;
+
+
+/**
+ * Top-level coordinator that translates an openCypher query into a SQL string
+ * executable against Pinot tables.
+ *
+ * <p>The translation pipeline is:
+ * <ol>
+ *   <li>Parse the Cypher query into an IR ({@link CypherParser})</li>
+ *   <li>Validate the IR against the graph schema ({@link CypherSemanticValidator})</li>
+ *   <li>Generate SQL from the validated IR ({@link SqlGenerator})</li>
+ * </ol>
+ *
+ * <p>Thread-safety: instances are reusable and thread-safe provided the
+ * underlying {@link GraphSchemaConfig} is not modified concurrently.</p>
+ */
+public class CypherToSqlTranslator {
+
+  private final GraphSchemaConfig _schemaConfig;
+
+  public CypherToSqlTranslator(GraphSchemaConfig schemaConfig) {
+    _schemaConfig = schemaConfig;
+  }
+
+  /**
+   * Translates an openCypher query into a SQL string.
+   *
+   * @param cypherQuery the Cypher query text
+   * @return the equivalent SQL query
+   * @throws CypherParseException if parsing, validation, or generation fails
+   */
+  public String translate(String cypherQuery) {
+    // Step 1: Parse
+    CypherParser parser = new CypherParser(cypherQuery);
+    CypherIR.CypherQuery ir = parser.parse();
+
+    // Step 2: Validate
+    CypherSemanticValidator validator = new CypherSemanticValidator(_schemaConfig);
+    validator.validate(ir);
+
+    // Step 3: Generate SQL
+    SqlGenerator generator = new SqlGenerator(_schemaConfig);
+    return generator.generate(ir);
+  }
+
+  /**
+   * Parses and returns the IR without validation or SQL generation.
+   * Useful for testing and debugging.
+   *
+   * @param cypherQuery the Cypher query text
+   * @return the parsed IR
+   * @throws CypherParseException if parsing fails
+   */
+  public CypherIR.CypherQuery parseOnly(String cypherQuery) {
+    CypherParser parser = new CypherParser(cypherQuery);
+    return parser.parse();
+  }
+
+  /**
+   * Returns a human-readable explanation of how a Cypher query is lowered to SQL.
+   * This shows the parsed AST summary, schema bindings, generated SQL, and join
+   * structure, making the lowered plan inspectable for debugging.
+   *
+   * @param cypherQuery the Cypher query text
+   * @return a multi-line explanation string
+   * @throws CypherParseException if parsing, validation, or generation fails
+   */
+  public String explain(String cypherQuery) {
+    // Step 1: Parse
+    CypherParser parser = new CypherParser(cypherQuery);
+    CypherIR.CypherQuery ir = parser.parse();
+
+    // Step 2: Validate
+    CypherSemanticValidator validator = new CypherSemanticValidator(_schemaConfig);
+    validator.validate(ir);
+
+    // Step 3: Generate SQL
+    SqlGenerator generator = new SqlGenerator(_schemaConfig);
+    String sql = generator.generate(ir);
+
+    // Step 4: Build explanation
+    StringBuilder explanation = new StringBuilder();
+    explanation.append("=== Cypher to SQL Explain ===\n\n");
+
+    // AST summary
+    appendAstSummary(explanation, ir);
+
+    // Schema bindings
+    appendSchemaBindings(explanation, ir);
+
+    // Join structure
+    appendJoinStructure(explanation, ir);
+
+    // Generated SQL
+    explanation.append("--- Generated SQL ---\n");
+    explanation.append(sql).append('\n');
+
+    return explanation.toString();
+  }
+
+  private void appendAstSummary(StringBuilder sb, CypherIR.CypherQuery query) {
+    sb.append("--- Parsed AST Summary ---\n");
+
+    CypherIR.MatchClause match = query.getMatchClause();
+    java.util.List<CypherIR.NodePattern> nodes = match.getNodes();
+    java.util.List<CypherIR.RelationshipPattern> edges = match.getEdges();
+
+    // MATCH pattern
+    sb.append("MATCH: (");
+    appendNodeSummary(sb, nodes.get(0));
+    sb.append(')');
+
+    for (int i = 0; i < edges.size(); i++) {
+      CypherIR.RelationshipPattern edge = edges.get(i);
+      if (edge.getDirection() == CypherIR.Direction.INCOMING) {
+        sb.append("<-[:").append(edge.getType()).append("]-(");
+      } else if (edge.getDirection() == CypherIR.Direction.OUTGOING) {
+        sb.append("-[:").append(edge.getType()).append("]->(");
+      } else {
+        sb.append("-[:").append(edge.getType()).append("]-(");
+      }
+      appendNodeSummary(sb, nodes.get(i + 1));
+      sb.append(')');
+    }
+    sb.append('\n');
+
+    // RETURN items
+    sb.append("RETURN: ");
+    sb.append(query.getReturnClause().getItems().stream()
+        .map(item -> formatReturnItem(item))
+        .collect(Collectors.joining(", ")));
+    sb.append('\n');
+
+    // LIMIT
+    if (query.getLimitClause() != null) {
+      sb.append("LIMIT: ").append(query.getLimitClause().getCount()).append('\n');
+    }
+    sb.append('\n');
+  }
+
+  private void appendNodeSummary(StringBuilder sb, CypherIR.NodePattern node) {
+    if (node.getAlias() != null) {
+      sb.append(node.getAlias());
+    }
+    if (node.getLabel() != null) {
+      sb.append(':').append(node.getLabel());
+    }
+    if (!node.getProperties().isEmpty()) {
+      sb.append(" {");
+      sb.append(node.getProperties().entrySet().stream()
+          .map(e -> e.getKey() + ": " + formatValue(e.getValue()))
+          .collect(Collectors.joining(", ")));
+      sb.append('}');
+    }
+  }
+
+  /**
+   * Formats a single return item for the explain output, handling aggregation
+   * functions and the count(*) sentinel.
+   */
+  private static String formatReturnItem(CypherIR.ReturnItem item) {
+    String ref;
+    if (item.getAlias() == null) {
+      ref = "*";
+    } else if (item.getProperty() != null) {
+      ref = item.getAlias() + "." + item.getProperty();
+    } else {
+      ref = item.getAlias();
+    }
+
+    switch (item.getAggregation()) {
+      case COUNT:
+        return "count(" + ref + ")";
+      case COUNT_DISTINCT:
+        return "count(DISTINCT " + ref + ")";
+      default:
+        return ref;
+    }
+  }
+
+  private static String formatValue(Object value) {
+    if (value instanceof String) {
+      return "'" + value + "'";
+    }
+    return String.valueOf(value);
+  }
+
+  private void appendSchemaBindings(StringBuilder sb, CypherIR.CypherQuery query) {
+    sb.append("--- Schema Bindings ---\n");
+
+    CypherIR.MatchClause match = query.getMatchClause();
+    java.util.List<CypherIR.NodePattern> nodes = match.getNodes();
+    java.util.List<CypherIR.RelationshipPattern> edges = match.getEdges();
+
+    // Vertex bindings (deduplicate by label)
+    java.util.Set<String> seenLabels = new java.util.HashSet<>();
+    for (CypherIR.NodePattern node : nodes) {
+      if (node.getLabel() != null && seenLabels.add(node.getLabel())) {
+        GraphSchemaConfig.VertexLabel vertexLabel = _schemaConfig.getVertexLabels().get(node.getLabel());
+        if (vertexLabel != null) {
+          sb.append("Vertex ").append(node.getLabel())
+              .append(" -> table '").append(vertexLabel.getTableName())
+              .append("' (pk: ").append(vertexLabel.getPrimaryKey()).append(")\n");
+        }
+      }
+    }
+
+    // Edge bindings
+    for (CypherIR.RelationshipPattern edge : edges) {
+      if (edge.getType() != null) {
+        GraphSchemaConfig.EdgeLabel edgeLabel = _schemaConfig.getEdgeLabels().get(edge.getType());
+        if (edgeLabel != null) {
+          sb.append("Edge ").append(edge.getType())
+              .append(" -> table '").append(edgeLabel.getTableName())
+              .append("' (").append(edgeLabel.getSourceVertexLabel())
+              .append('.').append(edgeLabel.getSourceKey())
+              .append(" -> ").append(edgeLabel.getTargetVertexLabel())
+              .append('.').append(edgeLabel.getTargetKey())
+              .append(")\n");
+        }
+      }
+    }
+    sb.append('\n');
+  }
+
+  private void appendJoinStructure(StringBuilder sb, CypherIR.CypherQuery query) {
+    sb.append("--- Join Structure ---\n");
+
+    CypherIR.MatchClause match = query.getMatchClause();
+    java.util.List<CypherIR.NodePattern> nodes = match.getNodes();
+    java.util.List<CypherIR.RelationshipPattern> edges = match.getEdges();
+    int hopCount = match.getHopCount();
+
+    if (hopCount == 1) {
+      // Single-hop: backward-compatible output format
+      CypherIR.RelationshipPattern edge = edges.get(0);
+      GraphSchemaConfig.EdgeLabel edgeLabel = _schemaConfig.getEdgeLabels().get(edge.getType());
+      if (edgeLabel != null) {
+        String direction = edge.getDirection().name().toLowerCase();
+        sb.append("Direction: ").append(direction).append('\n');
+        sb.append("Strategy: 1-hop relational join via edge table\n");
+
+        if (edge.getDirection() == CypherIR.Direction.INCOMING) {
+          sb.append("  Edge.").append(edgeLabel.getTargetKey())
+              .append(" = source_vertex.pk  (reversed for INCOMING)\n");
+          sb.append("  Edge.").append(edgeLabel.getSourceKey())
+              .append(" = target_vertex.pk  (reversed for INCOMING)\n");
+        } else {
+          sb.append("  Edge.").append(edgeLabel.getSourceKey())
+              .append(" = source_vertex.pk\n");
+          sb.append("  Edge.").append(edgeLabel.getTargetKey())
+              .append(" = target_vertex.pk\n");
+        }
+      }
+    } else {
+      // Multi-hop
+      sb.append("Strategy: ").append(hopCount).append("-hop relational join via edge tables\n");
+      for (int i = 0; i < edges.size(); i++) {
+        CypherIR.RelationshipPattern edge = edges.get(i);
+        GraphSchemaConfig.EdgeLabel edgeLabel = _schemaConfig.getEdgeLabels().get(edge.getType());
+        if (edgeLabel == null) {
+          continue;
+        }
+        String direction = edge.getDirection().name().toLowerCase();
+        sb.append("Hop ").append(i + 1).append(": direction=").append(direction).append('\n');
+        if (edge.getDirection() == CypherIR.Direction.INCOMING) {
+          sb.append("  Edge.").append(edgeLabel.getTargetKey())
+              .append(" = source_vertex.pk  (reversed for INCOMING)\n");
+          sb.append("  Edge.").append(edgeLabel.getSourceKey())
+              .append(" = target_vertex.pk  (reversed for INCOMING)\n");
+        } else {
+          sb.append("  Edge.").append(edgeLabel.getSourceKey())
+              .append(" = source_vertex.pk\n");
+          sb.append("  Edge.").append(edgeLabel.getTargetKey())
+              .append(" = target_vertex.pk\n");
+        }
+      }
+    }
+
+    // Filters
+    boolean hasFilters = false;
+    for (CypherIR.NodePattern node : nodes) {
+      if (!node.getProperties().isEmpty()) {
+        hasFilters = true;
+        break;
+      }
+    }
+    if (hasFilters) {
+      sb.append("Filters:\n");
+      for (int i = 0; i < nodes.size(); i++) {
+        CypherIR.NodePattern node = nodes.get(i);
+        // For 1-hop backward compat, use "source"/"target"; for multi-hop use alias
+        String prefix;
+        if (hopCount == 1) {
+          prefix = (i == 0) ? "source" : "target";
+        } else {
+          prefix = node.getAlias() != null ? node.getAlias() : ("node" + i);
+        }
+        for (Map.Entry<String, Object> entry : node.getProperties().entrySet()) {
+          sb.append("  ").append(prefix).append('.').append(entry.getKey())
+              .append(" = ").append(formatValue(entry.getValue())).append('\n');
+        }
+      }
+    }
+    sb.append('\n');
+  }
+}

--- a/pinot-graph/pinot-graph-planner/src/main/java/org/apache/pinot/graph/planner/SqlGenerator.java
+++ b/pinot-graph/pinot-graph-planner/src/main/java/org/apache/pinot/graph/planner/SqlGenerator.java
@@ -1,0 +1,557 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.graph.planner;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.pinot.graph.spi.GraphSchemaConfig;
+
+
+/**
+ * Converts a validated Cypher IR into a SQL query string that can be
+ * executed against Pinot tables.
+ *
+ * <p>The generated SQL follows this pattern for a single-hop traversal:</p>
+ * <pre>
+ *   SELECT target_alias.column AS return_alias
+ *   FROM edge_table AS e
+ *   JOIN source_table AS source_alias ON e.source_key = source_alias.primary_key
+ *   JOIN target_table AS target_alias ON e.target_key = target_alias.primary_key
+ *   WHERE source_alias.prop = 'value'
+ *   LIMIT n
+ * </pre>
+ *
+ * <p>Thread-safety: instances are reusable and thread-safe.</p>
+ */
+public class SqlGenerator {
+
+  private final GraphSchemaConfig _schemaConfig;
+
+  public SqlGenerator(GraphSchemaConfig schemaConfig) {
+    _schemaConfig = schemaConfig;
+  }
+
+  /**
+   * Generates a SQL query from the given Cypher IR.
+   *
+   * <p>Supports both single-hop and multi-hop traversal patterns.</p>
+   *
+   * @param query the validated Cypher query IR
+   * @return a SQL string
+   */
+  public String generate(CypherIR.CypherQuery query) {
+    CypherIR.MatchClause matchClause = query.getMatchClause();
+    List<CypherIR.NodePattern> nodes = matchClause.getNodes();
+    List<CypherIR.RelationshipPattern> edges = matchClause.getEdges();
+    int hopCount = matchClause.getHopCount();
+
+    // Build alias-to-VertexLabel map and validate/assign all aliases
+    Map<String, GraphSchemaConfig.VertexLabel> aliasToVertexLabel = new HashMap<>();
+    Set<String> allAliases = new HashSet<>();
+    String[] nodeAliases = new String[nodes.size()];
+    String[] edgeAliases = new String[edges.size()];
+
+    // Assign node aliases
+    for (int i = 0; i < nodes.size(); i++) {
+      CypherIR.NodePattern node = nodes.get(i);
+      String alias = node.getAlias() != null ? node.getAlias() : ("n" + i);
+      validateIdentifier(alias, "node alias");
+      if (!allAliases.add(alias)) {
+        throw new CypherParseException(
+            "Alias '" + alias + "' conflicts with another alias. Use distinct aliases.");
+      }
+      nodeAliases[i] = alias;
+
+      // Resolve the vertex label for this node
+      GraphSchemaConfig.VertexLabel vertexLabel = resolveVertexLabelForNode(node, edges, nodes, i);
+      aliasToVertexLabel.put(alias, vertexLabel);
+    }
+
+    // Assign edge aliases
+    for (int i = 0; i < edges.size(); i++) {
+      CypherIR.RelationshipPattern edge = edges.get(i);
+      String alias;
+      if (edge.getAlias() != null) {
+        alias = edge.getAlias();
+      } else if (hopCount == 1) {
+        alias = "e";
+      } else {
+        alias = "e" + (i + 1);
+      }
+      validateIdentifier(alias, "edge alias");
+      if (!allAliases.add(alias)) {
+        throw new CypherParseException(
+            "Edge alias '" + alias + "' conflicts with another alias. Use distinct aliases.");
+      }
+      edgeAliases[i] = alias;
+    }
+
+    StringBuilder sql = new StringBuilder();
+
+    // SELECT clause
+    if (query.getReturnClause().isDistinct()) {
+      sql.append("SELECT DISTINCT ");
+    } else {
+      sql.append("SELECT ");
+    }
+    sql.append(buildSelectList(query.getReturnClause(), aliasToVertexLabel));
+
+    // FROM clause: start from first edge table
+    GraphSchemaConfig.EdgeLabel firstEdgeLabel = resolveEdgeLabel(edges.get(0));
+    sql.append(" FROM ");
+    sql.append(firstEdgeLabel.getTableName());
+    sql.append(" AS ");
+    sql.append(edgeAliases[0]);
+
+    // For each hop, generate the JOINs
+    // Hop 0: FROM e1 JOIN node[0] ON ... JOIN node[1] ON ...
+    // Hop 1: JOIN e2 ON ... JOIN node[2] ON ...
+    for (int i = 0; i < hopCount; i++) {
+      CypherIR.RelationshipPattern edge = edges.get(i);
+      GraphSchemaConfig.EdgeLabel edgeLabel = resolveEdgeLabel(edge);
+      String edgeAlias = edgeAliases[i];
+      String sourceNodeAlias = nodeAliases[i];
+      String targetNodeAlias = nodeAliases[i + 1];
+      GraphSchemaConfig.VertexLabel sourceVertexLabel = aliasToVertexLabel.get(sourceNodeAlias);
+      GraphSchemaConfig.VertexLabel targetVertexLabel = aliasToVertexLabel.get(targetNodeAlias);
+
+      // Determine join keys based on direction
+      String sourceJoinKey;
+      String targetJoinKey;
+      if (edge.getDirection() == CypherIR.Direction.INCOMING) {
+        sourceJoinKey = edgeLabel.getTargetKey();
+        targetJoinKey = edgeLabel.getSourceKey();
+      } else {
+        sourceJoinKey = edgeLabel.getSourceKey();
+        targetJoinKey = edgeLabel.getTargetKey();
+      }
+
+      // For hops after the first, JOIN the edge table first
+      if (i > 0) {
+        sql.append(" JOIN ");
+        sql.append(edgeLabel.getTableName());
+        sql.append(" AS ");
+        sql.append(edgeAlias);
+        sql.append(" ON ");
+        sql.append(edgeAlias).append('.').append(sourceJoinKey);
+        sql.append(" = ");
+        sql.append(sourceNodeAlias).append('.').append(sourceVertexLabel.getPrimaryKey());
+      }
+
+      // JOIN source node table (only for the first hop)
+      if (i == 0) {
+        sql.append(" JOIN ");
+        sql.append(sourceVertexLabel.getTableName());
+        sql.append(" AS ");
+        sql.append(sourceNodeAlias);
+        sql.append(" ON ");
+        sql.append(edgeAlias).append('.').append(sourceJoinKey);
+        sql.append(" = ");
+        sql.append(sourceNodeAlias).append('.').append(sourceVertexLabel.getPrimaryKey());
+      }
+
+      // JOIN target node table
+      sql.append(" JOIN ");
+      sql.append(targetVertexLabel.getTableName());
+      sql.append(" AS ");
+      sql.append(targetNodeAlias);
+      sql.append(" ON ");
+      sql.append(edgeAlias).append('.').append(targetJoinKey);
+      sql.append(" = ");
+      sql.append(targetNodeAlias).append('.').append(targetVertexLabel.getPrimaryKey());
+    }
+
+    // WHERE clause from inline property filters and WHERE clause predicates
+    List<String> whereConditions = new ArrayList<>();
+    for (int i = 0; i < nodes.size(); i++) {
+      addPropertyFilters(whereConditions, nodes.get(i), nodeAliases[i], aliasToVertexLabel.get(nodeAliases[i]));
+    }
+
+    if (query.getWhereClause() != null) {
+      String predicateSql = predicateToSql(query.getWhereClause().getPredicate(), aliasToVertexLabel);
+      whereConditions.add(predicateSql);
+    }
+
+    if (!whereConditions.isEmpty()) {
+      sql.append(" WHERE ");
+      sql.append(String.join(" AND ", whereConditions));
+    }
+
+    // GROUP BY clause (when aggregations are mixed with non-aggregated columns)
+    sql.append(buildGroupByClause(query.getReturnClause(), aliasToVertexLabel));
+
+    // ORDER BY clause
+    if (query.getOrderByClause() != null) {
+      sql.append(buildOrderByClause(query.getOrderByClause(), aliasToVertexLabel));
+    }
+
+    // LIMIT clause
+    if (query.getLimitClause() != null) {
+      sql.append(" LIMIT ");
+      sql.append(query.getLimitClause().getCount());
+    }
+
+    // OFFSET clause (from Cypher SKIP)
+    if (query.getSkipClause() != null) {
+      sql.append(" OFFSET ");
+      sql.append(query.getSkipClause().getCount());
+    }
+
+    return sql.toString();
+  }
+
+  /**
+   * Resolves the vertex label for a node at a given position in the chain,
+   * using the node's own label or inferring it from adjacent edge definitions.
+   */
+  private GraphSchemaConfig.VertexLabel resolveVertexLabelForNode(
+      CypherIR.NodePattern node, List<CypherIR.RelationshipPattern> edges,
+      List<CypherIR.NodePattern> nodes, int nodeIndex) {
+    // If the node has an explicit label, use it
+    if (node.getLabel() != null) {
+      GraphSchemaConfig.VertexLabel vertexLabel = _schemaConfig.getVertexLabels().get(node.getLabel());
+      if (vertexLabel == null) {
+        throw new CypherParseException("Unknown vertex label: " + node.getLabel());
+      }
+      return vertexLabel;
+    }
+
+    // Infer from adjacent edges
+    // Check the edge to the left (nodeIndex - 1)
+    if (nodeIndex > 0 && nodeIndex - 1 < edges.size()) {
+      CypherIR.RelationshipPattern leftEdge = edges.get(nodeIndex - 1);
+      GraphSchemaConfig.EdgeLabel edgeLabel = resolveEdgeLabel(leftEdge);
+      String vertexLabelName;
+      if (leftEdge.getDirection() == CypherIR.Direction.INCOMING) {
+        vertexLabelName = edgeLabel.getSourceVertexLabel();
+      } else {
+        vertexLabelName = edgeLabel.getTargetVertexLabel();
+      }
+      return _schemaConfig.getVertexLabels().get(vertexLabelName);
+    }
+
+    // Check the edge to the right (nodeIndex)
+    if (nodeIndex < edges.size()) {
+      CypherIR.RelationshipPattern rightEdge = edges.get(nodeIndex);
+      GraphSchemaConfig.EdgeLabel edgeLabel = resolveEdgeLabel(rightEdge);
+      String vertexLabelName;
+      if (rightEdge.getDirection() == CypherIR.Direction.INCOMING) {
+        vertexLabelName = edgeLabel.getTargetVertexLabel();
+      } else {
+        vertexLabelName = edgeLabel.getSourceVertexLabel();
+      }
+      return _schemaConfig.getVertexLabels().get(vertexLabelName);
+    }
+
+    throw new CypherParseException("Cannot resolve vertex label for node at position " + nodeIndex);
+  }
+
+  private GraphSchemaConfig.EdgeLabel resolveEdgeLabel(CypherIR.RelationshipPattern edge) {
+    GraphSchemaConfig.EdgeLabel edgeLabel = _schemaConfig.getEdgeLabels().get(edge.getType());
+    if (edgeLabel == null) {
+      throw new CypherParseException("Unknown relationship type: " + edge.getType());
+    }
+    return edgeLabel;
+  }
+
+  private String buildSelectList(CypherIR.ReturnClause returnClause,
+      Map<String, GraphSchemaConfig.VertexLabel> aliasToVertexLabel) {
+    List<String> columns = new ArrayList<>();
+
+    for (CypherIR.ReturnItem item : returnClause.getItems()) {
+      String columnExpr = resolveReturnItemColumn(item, aliasToVertexLabel);
+      columns.add(columnExpr);
+    }
+
+    return String.join(", ", columns);
+  }
+
+  /**
+   * Resolves a single return item to a SQL column expression, applying
+   * aggregation wrappers when present.
+   */
+  private String resolveReturnItemColumn(CypherIR.ReturnItem item,
+      Map<String, GraphSchemaConfig.VertexLabel> aliasToVertexLabel) {
+    CypherIR.AggregationFunction aggregation = item.getAggregation();
+
+    // count(*) — no alias or property
+    if (aggregation == CypherIR.AggregationFunction.COUNT && item.getAlias() == null) {
+      return "COUNT(*)";
+    }
+
+    // Resolve the column reference
+    String alias = item.getAlias();
+    String property = item.getProperty();
+    String columnRef;
+
+    if (property == null) {
+      // Returning the alias itself — use primary key as default
+      GraphSchemaConfig.VertexLabel vertexLabel = resolveVertexLabelForAlias(alias, aliasToVertexLabel);
+      columnRef = alias + "." + vertexLabel.getPrimaryKey();
+    } else {
+      // Returning a specific property
+      GraphSchemaConfig.VertexLabel vertexLabel = resolveVertexLabelForAlias(alias, aliasToVertexLabel);
+      String columnName = resolvePropertyColumn(vertexLabel, property);
+      columnRef = alias + "." + columnName;
+    }
+
+    // Apply aggregation wrapper
+    String expr;
+    switch (aggregation) {
+      case COUNT:
+        expr = "COUNT(" + columnRef + ")";
+        break;
+      case COUNT_DISTINCT:
+        expr = "COUNT(DISTINCT " + columnRef + ")";
+        break;
+      case SUM:
+        expr = "SUM(" + columnRef + ")";
+        break;
+      case AVG:
+        expr = "AVG(" + columnRef + ")";
+        break;
+      case MIN:
+        expr = "MIN(" + columnRef + ")";
+        break;
+      case MAX:
+        expr = "MAX(" + columnRef + ")";
+        break;
+      default:
+        expr = columnRef;
+        break;
+    }
+
+    // Apply result alias (AS)
+    if (item.getResultAlias() != null) {
+      expr = expr + " AS " + item.getResultAlias();
+    }
+
+    return expr;
+  }
+
+  /**
+   * Builds a GROUP BY clause when the return clause contains a mix of aggregated
+   * and non-aggregated items. Returns an empty string if no GROUP BY is needed.
+   */
+  private String buildGroupByClause(CypherIR.ReturnClause returnClause,
+      Map<String, GraphSchemaConfig.VertexLabel> aliasToVertexLabel) {
+    boolean hasAggregation = false;
+    List<String> groupByColumns = new ArrayList<>();
+
+    for (CypherIR.ReturnItem item : returnClause.getItems()) {
+      if (item.getAggregation() != CypherIR.AggregationFunction.NONE) {
+        hasAggregation = true;
+      } else {
+        // Non-aggregated item — resolve its column reference for GROUP BY
+        String alias = item.getAlias();
+        String property = item.getProperty();
+        if (property == null) {
+          GraphSchemaConfig.VertexLabel vertexLabel = resolveVertexLabelForAlias(alias, aliasToVertexLabel);
+          groupByColumns.add(alias + "." + vertexLabel.getPrimaryKey());
+        } else {
+          GraphSchemaConfig.VertexLabel vertexLabel = resolveVertexLabelForAlias(alias, aliasToVertexLabel);
+          String columnName = resolvePropertyColumn(vertexLabel, property);
+          groupByColumns.add(alias + "." + columnName);
+        }
+      }
+    }
+
+    if (hasAggregation && !groupByColumns.isEmpty()) {
+      return " GROUP BY " + String.join(", ", groupByColumns);
+    }
+    return "";
+  }
+
+  /**
+   * Builds an ORDER BY clause from the order-by items.
+   */
+  private String buildOrderByClause(CypherIR.OrderByClause orderByClause,
+      Map<String, GraphSchemaConfig.VertexLabel> aliasToVertexLabel) {
+    List<String> orderItems = new ArrayList<>();
+
+    for (CypherIR.OrderByItem item : orderByClause.getItems()) {
+      String alias = item.getAlias();
+      String property = item.getProperty();
+      String columnRef;
+
+      if (property == null) {
+        GraphSchemaConfig.VertexLabel vertexLabel = resolveVertexLabelForAlias(alias, aliasToVertexLabel);
+        columnRef = alias + "." + vertexLabel.getPrimaryKey();
+      } else {
+        GraphSchemaConfig.VertexLabel vertexLabel = resolveVertexLabelForAlias(alias, aliasToVertexLabel);
+        String columnName = resolvePropertyColumn(vertexLabel, property);
+        columnRef = alias + "." + columnName;
+      }
+
+      if (item.getDirection() == CypherIR.SortDirection.DESC) {
+        orderItems.add(columnRef + " DESC");
+      } else {
+        orderItems.add(columnRef + " ASC");
+      }
+    }
+
+    return " ORDER BY " + String.join(", ", orderItems);
+  }
+
+  private GraphSchemaConfig.VertexLabel resolveVertexLabelForAlias(String alias,
+      Map<String, GraphSchemaConfig.VertexLabel> aliasToVertexLabel) {
+    GraphSchemaConfig.VertexLabel vertexLabel = aliasToVertexLabel.get(alias);
+    if (vertexLabel == null) {
+      throw new CypherParseException("Cannot resolve alias '" + alias + "' to a vertex table.");
+    }
+    return vertexLabel;
+  }
+
+  private String resolvePropertyColumn(GraphSchemaConfig.VertexLabel vertexLabel, String property) {
+    // Check explicit property mapping first
+    Map<String, String> properties = vertexLabel.getProperties();
+    if (properties.containsKey(property)) {
+      return properties.get(property);
+    }
+    // Fall back to using the property name as the column name
+    return property;
+  }
+
+  private void addPropertyFilters(List<String> conditions, CypherIR.NodePattern node,
+      String alias, GraphSchemaConfig.VertexLabel vertexLabel) {
+    for (Map.Entry<String, Object> entry : node.getProperties().entrySet()) {
+      String columnName = resolvePropertyColumn(vertexLabel, entry.getKey());
+      Object value = entry.getValue();
+      if (value instanceof String) {
+        conditions.add(alias + "." + columnName + " = '" + escapeString((String) value) + "'");
+      } else {
+        conditions.add(alias + "." + columnName + " = " + value);
+      }
+    }
+  }
+
+  /**
+   * Recursively converts a predicate tree into a SQL condition string.
+   */
+  private String predicateToSql(CypherIR.Predicate predicate,
+      Map<String, GraphSchemaConfig.VertexLabel> aliasToVertexLabel) {
+    if (predicate instanceof CypherIR.ComparisonPredicate) {
+      CypherIR.ComparisonPredicate comp = (CypherIR.ComparisonPredicate) predicate;
+      GraphSchemaConfig.VertexLabel vertexLabel = resolveVertexLabelForAlias(comp.getAlias(), aliasToVertexLabel);
+      String columnName = resolvePropertyColumn(vertexLabel, comp.getProperty());
+      String formattedValue = formatSqlValue(comp.getValue());
+      return comp.getAlias() + "." + columnName + " " + comp.getOperator() + " " + formattedValue;
+    } else if (predicate instanceof CypherIR.AndPredicate) {
+      CypherIR.AndPredicate and = (CypherIR.AndPredicate) predicate;
+      String left = predicateToSql(and.getLeft(), aliasToVertexLabel);
+      String right = predicateToSql(and.getRight(), aliasToVertexLabel);
+      return "(" + left + " AND " + right + ")";
+    } else if (predicate instanceof CypherIR.OrPredicate) {
+      CypherIR.OrPredicate or = (CypherIR.OrPredicate) predicate;
+      String left = predicateToSql(or.getLeft(), aliasToVertexLabel);
+      String right = predicateToSql(or.getRight(), aliasToVertexLabel);
+      return "(" + left + " OR " + right + ")";
+    } else if (predicate instanceof CypherIR.NotPredicate) {
+      CypherIR.NotPredicate not = (CypherIR.NotPredicate) predicate;
+      String inner = predicateToSql(not.getInner(), aliasToVertexLabel);
+      return "(NOT " + inner + ")";
+    } else if (predicate instanceof CypherIR.StringPredicate) {
+      CypherIR.StringPredicate sp = (CypherIR.StringPredicate) predicate;
+      GraphSchemaConfig.VertexLabel vertexLabel = resolveVertexLabelForAlias(sp.getAlias(), aliasToVertexLabel);
+      String columnName = resolvePropertyColumn(vertexLabel, sp.getProperty());
+      String escapedValue = escapeLikePattern(sp.getValue());
+      String likePattern;
+      switch (sp.getOperator()) {
+        case STARTS_WITH:
+          likePattern = escapedValue + "%";
+          break;
+        case ENDS_WITH:
+          likePattern = "%" + escapedValue;
+          break;
+        case CONTAINS:
+          likePattern = "%" + escapedValue + "%";
+          break;
+        default:
+          throw new CypherParseException("Unsupported string operator: " + sp.getOperator());
+      }
+      // Only escape single quotes in the LIKE pattern; backslashes are intentional escape chars
+      return sp.getAlias() + "." + columnName + " LIKE '" + likePattern.replace("'", "''") + "'";
+    } else if (predicate instanceof CypherIR.InPredicate) {
+      CypherIR.InPredicate in = (CypherIR.InPredicate) predicate;
+      GraphSchemaConfig.VertexLabel vertexLabel = resolveVertexLabelForAlias(in.getAlias(), aliasToVertexLabel);
+      String columnName = resolvePropertyColumn(vertexLabel, in.getProperty());
+      StringBuilder sb = new StringBuilder();
+      sb.append(in.getAlias()).append('.').append(columnName).append(" IN (");
+      for (int i = 0; i < in.getValues().size(); i++) {
+        if (i > 0) {
+          sb.append(", ");
+        }
+        sb.append(formatSqlValue(in.getValues().get(i)));
+      }
+      sb.append(')');
+      return sb.toString();
+    } else {
+      throw new CypherParseException("Unsupported predicate type: " + predicate.getClass().getSimpleName());
+    }
+  }
+
+  /**
+   * Formats a literal value for embedding in a SQL string.
+   */
+  private static String formatSqlValue(Object value) {
+    if (value instanceof String) {
+      return "'" + escapeString((String) value) + "'";
+    } else if (value instanceof Boolean) {
+      return value.toString();
+    } else {
+      return String.valueOf(value);
+    }
+  }
+
+  private static String escapeString(String value) {
+    // Escape backslashes first, then single quotes, to prevent
+    // backslash-based SQL injection in dialects that interpret \'
+    return value.replace("\\", "\\\\").replace("'", "''");
+  }
+
+  /**
+   * Escapes special LIKE pattern characters ({@code %}, {@code _}) in a
+   * user-supplied string value so it is treated as a literal substring.
+   */
+  static String escapeLikePattern(String value) {
+    return value.replace("%", "\\%").replace("_", "\\_");
+  }
+
+  /**
+   * Validates that a string is a safe SQL identifier (letters, digits, underscores only).
+   * Prevents SQL injection through crafted Cypher aliases.
+   */
+  private static void validateIdentifier(String identifier, String context) {
+    if (identifier == null || identifier.isEmpty()) {
+      throw new CypherParseException("Empty " + context + " is not allowed.");
+    }
+    for (int i = 0; i < identifier.length(); i++) {
+      char c = identifier.charAt(i);
+      if (!Character.isLetterOrDigit(c) && c != '_') {
+        throw new CypherParseException(
+            "Invalid character '" + c + "' in " + context + " '" + identifier
+                + "'. Only letters, digits, and underscores are allowed.");
+      }
+    }
+  }
+}

--- a/pinot-graph/pinot-graph-planner/src/test/java/org/apache/pinot/graph/planner/CypherParserTest.java
+++ b/pinot-graph/pinot-graph-planner/src/test/java/org/apache/pinot/graph/planner/CypherParserTest.java
@@ -1,0 +1,1204 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.graph.planner;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+
+/**
+ * Tests for the hand-written Cypher parser.
+ */
+public class CypherParserTest {
+
+  @Test
+  public void testBasicMatchReturnLimit() {
+    String cypher = "MATCH (a:User {id: '123'})-[:FOLLOWS]->(b:User) RETURN b.id LIMIT 100";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    // Match clause
+    CypherIR.MatchClause match = query.getMatchClause();
+    assertNotNull(match);
+
+    // Source node
+    CypherIR.NodePattern source = match.getSource();
+    assertEquals(source.getAlias(), "a");
+    assertEquals(source.getLabel(), "User");
+    assertEquals(source.getProperties().size(), 1);
+    assertEquals(source.getProperties().get("id"), "123");
+
+    // Edge
+    CypherIR.RelationshipPattern edge = match.getEdge();
+    assertNull(edge.getAlias());
+    assertEquals(edge.getType(), "FOLLOWS");
+    assertEquals(edge.getDirection(), CypherIR.Direction.OUTGOING);
+
+    // Target node
+    CypherIR.NodePattern target = match.getTarget();
+    assertEquals(target.getAlias(), "b");
+    assertEquals(target.getLabel(), "User");
+    assertTrue(target.getProperties().isEmpty());
+
+    // Return clause
+    CypherIR.ReturnClause returnClause = query.getReturnClause();
+    assertEquals(returnClause.getItems().size(), 1);
+    assertEquals(returnClause.getItems().get(0).getAlias(), "b");
+    assertEquals(returnClause.getItems().get(0).getProperty(), "id");
+
+    // Limit clause
+    assertNotNull(query.getLimitClause());
+    assertEquals(query.getLimitClause().getCount(), 100);
+  }
+
+  @Test
+  public void testMultipleReturnItems() {
+    String cypher = "MATCH (a:User {id: '1'})-[:FOLLOWS]->(b:User) RETURN b.id, b.name, a.id";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    CypherIR.ReturnClause returnClause = query.getReturnClause();
+    assertEquals(returnClause.getItems().size(), 3);
+
+    assertEquals(returnClause.getItems().get(0).getAlias(), "b");
+    assertEquals(returnClause.getItems().get(0).getProperty(), "id");
+
+    assertEquals(returnClause.getItems().get(1).getAlias(), "b");
+    assertEquals(returnClause.getItems().get(1).getProperty(), "name");
+
+    assertEquals(returnClause.getItems().get(2).getAlias(), "a");
+    assertEquals(returnClause.getItems().get(2).getProperty(), "id");
+  }
+
+  @Test
+  public void testNoLimit() {
+    String cypher = "MATCH (a:User {id: '1'})-[:FOLLOWS]->(b:User) RETURN b.id";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    assertNull(query.getLimitClause());
+  }
+
+  @Test
+  public void testIntegerPropertyValue() {
+    String cypher = "MATCH (a:User {age: 25})-[:FOLLOWS]->(b:User) RETURN b.id";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    assertEquals(query.getMatchClause().getSource().getProperties().get("age"), 25L);
+  }
+
+  @Test
+  public void testMultiplePropertyFilters() {
+    String cypher = "MATCH (a:User {id: '123', name: 'alice'})-[:FOLLOWS]->(b:User) RETURN b.id";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    CypherIR.NodePattern source = query.getMatchClause().getSource();
+    assertEquals(source.getProperties().size(), 2);
+    assertEquals(source.getProperties().get("id"), "123");
+    assertEquals(source.getProperties().get("name"), "alice");
+  }
+
+  @Test
+  public void testIncomingRelationship() {
+    String cypher = "MATCH (a:User)<-[:FOLLOWS]-(b:User) RETURN b.id";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    assertEquals(query.getMatchClause().getEdge().getDirection(), CypherIR.Direction.INCOMING);
+  }
+
+  @Test
+  public void testUndirectedRelationship() {
+    String cypher = "MATCH (a:User)-[:FOLLOWS]-(b:User) RETURN b.id";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    assertEquals(query.getMatchClause().getEdge().getDirection(), CypherIR.Direction.UNDIRECTED);
+  }
+
+  @Test
+  public void testRelationshipWithAlias() {
+    String cypher = "MATCH (a:User)-[r:FOLLOWS]->(b:User) RETURN b.id";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    assertEquals(query.getMatchClause().getEdge().getAlias(), "r");
+    assertEquals(query.getMatchClause().getEdge().getType(), "FOLLOWS");
+  }
+
+  @Test
+  public void testNodeWithoutProperties() {
+    String cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User) RETURN b.id";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    assertTrue(query.getMatchClause().getSource().getProperties().isEmpty());
+  }
+
+  @Test
+  public void testCaseInsensitiveKeywords() {
+    String cypher = "match (a:User)-[:FOLLOWS]->(b:User) return b.id limit 10";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    assertNotNull(query.getMatchClause());
+    assertNotNull(query.getReturnClause());
+    assertEquals(query.getLimitClause().getCount(), 10);
+  }
+
+  @Test
+  public void testReturnAliasWithoutProperty() {
+    String cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User) RETURN b";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    CypherIR.ReturnItem item = query.getReturnClause().getItems().get(0);
+    assertEquals(item.getAlias(), "b");
+    assertNull(item.getProperty());
+  }
+
+  // ---- Rejection tests ----
+
+  @Test(expectedExceptions = CypherParseException.class, expectedExceptionsMessageRegExp = ".*OPTIONAL MATCH.*")
+  public void testRejectOptionalMatch() {
+    new CypherParser("OPTIONAL MATCH (a:User)-[:FOLLOWS]->(b:User) RETURN b.id").parse();
+  }
+
+  @Test(expectedExceptions = CypherParseException.class, expectedExceptionsMessageRegExp = ".*CREATE.*")
+  public void testRejectCreate() {
+    new CypherParser("CREATE (a:User {id: '1'})").parse();
+  }
+
+  @Test(expectedExceptions = CypherParseException.class, expectedExceptionsMessageRegExp = ".*MERGE.*")
+  public void testRejectMerge() {
+    new CypherParser("MERGE (a:User {id: '1'})").parse();
+  }
+
+  @Test(expectedExceptions = CypherParseException.class, expectedExceptionsMessageRegExp = ".*DELETE.*")
+  public void testRejectDelete() {
+    new CypherParser("MATCH (a:User) DELETE a").parse();
+  }
+
+  @Test(expectedExceptions = CypherParseException.class, expectedExceptionsMessageRegExp = ".*SET.*")
+  public void testRejectSet() {
+    new CypherParser("MATCH (a:User) SET a.name = 'bob'").parse();
+  }
+
+  @Test(expectedExceptions = CypherParseException.class, expectedExceptionsMessageRegExp = ".*REMOVE.*")
+  public void testRejectRemove() {
+    new CypherParser("MATCH (a:User) REMOVE a.name").parse();
+  }
+
+  @Test(expectedExceptions = CypherParseException.class,
+      expectedExceptionsMessageRegExp = ".*Multiple MATCH clauses.*")
+  public void testRejectWith() {
+    // WITH is no longer rejected at the keyword level (needed for STARTS WITH / ENDS WITH),
+    // but the WITH clause usage still fails because the grammar does not support it.
+    new CypherParser("MATCH (a:User) WITH a MATCH (a)-[:FOLLOWS]->(b:User) RETURN b.id").parse();
+  }
+
+  @Test(expectedExceptions = CypherParseException.class, expectedExceptionsMessageRegExp = ".*UNION.*")
+  public void testRejectUnion() {
+    new CypherParser(
+        "MATCH (a:User)-[:FOLLOWS]->(b:User) RETURN b.id UNION MATCH (a:User)-[:LIKES]->(b:User) RETURN b.id")
+        .parse();
+  }
+
+  // ---- SKIP tests ----
+
+  @Test
+  public void testSkipAfterOrderBy() {
+    String cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User) RETURN b.id ORDER BY b.id SKIP 20 LIMIT 100";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    assertNotNull(query.getSkipClause());
+    assertEquals(query.getSkipClause().getCount(), 20);
+    assertNotNull(query.getLimitClause());
+    assertEquals(query.getLimitClause().getCount(), 100);
+  }
+
+  @Test
+  public void testSkipWithoutLimit() {
+    String cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User) RETURN b.id SKIP 10";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    assertNotNull(query.getSkipClause());
+    assertEquals(query.getSkipClause().getCount(), 10);
+    assertNull(query.getLimitClause());
+  }
+
+  @Test
+  public void testSkipWithLimitNoOrderBy() {
+    String cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User) RETURN b.id SKIP 5 LIMIT 50";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    assertNull(query.getOrderByClause());
+    assertNotNull(query.getSkipClause());
+    assertEquals(query.getSkipClause().getCount(), 5);
+    assertNotNull(query.getLimitClause());
+    assertEquals(query.getLimitClause().getCount(), 50);
+  }
+
+  @Test
+  public void testSkipZero() {
+    String cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User) RETURN b.id SKIP 0 LIMIT 10";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    assertNotNull(query.getSkipClause());
+    assertEquals(query.getSkipClause().getCount(), 0);
+  }
+
+  @Test
+  public void testNoSkipClause() {
+    String cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User) RETURN b.id LIMIT 100";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    assertNull(query.getSkipClause());
+  }
+
+  @Test
+  public void testSkipCaseInsensitive() {
+    String cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User) RETURN b.id skip 20 limit 100";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    assertNotNull(query.getSkipClause());
+    assertEquals(query.getSkipClause().getCount(), 20);
+  }
+
+  @Test
+  public void testReturnDistinct() {
+    String cypher = "MATCH (a:User {id: 1})-[:FOLLOWS]->(b:User) RETURN DISTINCT b.id LIMIT 100";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    assertTrue(query.getReturnClause().isDistinct());
+    assertEquals(query.getReturnClause().getItems().size(), 1);
+    assertEquals(query.getReturnClause().getItems().get(0).getAlias(), "b");
+    assertEquals(query.getReturnClause().getItems().get(0).getProperty(), "id");
+  }
+
+  @Test
+  public void testReturnWithoutDistinct() {
+    String cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User) RETURN b.id";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    assertFalse(query.getReturnClause().isDistinct());
+  }
+
+  @Test
+  public void testBooleanTruePropertyValue() {
+    String cypher = "MATCH (a:User {active: true})-[:FOLLOWS]->(b:User) RETURN b.id";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    assertEquals(query.getMatchClause().getSource().getProperties().get("active"), Boolean.TRUE);
+  }
+
+  @Test
+  public void testBooleanFalsePropertyValue() {
+    String cypher = "MATCH (a:User {active: false})-[:FOLLOWS]->(b:User) RETURN b.id";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    assertEquals(query.getMatchClause().getSource().getProperties().get("active"), Boolean.FALSE);
+  }
+
+  @Test
+  public void testBooleanCaseInsensitive() {
+    // TRUE, True, true should all work
+    for (String variant : new String[]{"TRUE", "True", "true"}) {
+      String cypher = "MATCH (a:User {active: " + variant + "})-[:FOLLOWS]->(b:User) RETURN b.id";
+      CypherParser parser = new CypherParser(cypher);
+      CypherIR.CypherQuery query = parser.parse();
+
+      assertEquals(query.getMatchClause().getSource().getProperties().get("active"), Boolean.TRUE,
+          "Failed for variant: " + variant);
+    }
+  }
+
+  @Test
+  public void testDistinctCaseInsensitive() {
+    String cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User) RETURN distinct b.id";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    assertTrue(query.getReturnClause().isDistinct());
+  }
+
+  @Test(expectedExceptions = CypherParseException.class,
+      expectedExceptionsMessageRegExp = ".*Variable-length paths.*")
+  public void testRejectVariableLengthPaths() {
+    new CypherParser("MATCH (a:User)-[*1..3]->(b:User) RETURN b.id").parse();
+  }
+
+  @Test(expectedExceptions = CypherParseException.class,
+      expectedExceptionsMessageRegExp = ".*Multiple MATCH clauses.*")
+  public void testRejectMultipleMatchClauses() {
+    new CypherParser("MATCH (a:User)-[:FOLLOWS]->(b:User) MATCH (b)-[:LIKES]->(c:Post) RETURN c.id").parse();
+  }
+
+  @Test(expectedExceptions = CypherParseException.class, expectedExceptionsMessageRegExp = ".*Expected MATCH.*")
+  public void testRejectEmptyQuery() {
+    new CypherParser("").parse();
+  }
+
+  @Test(expectedExceptions = CypherParseException.class,
+      expectedExceptionsMessageRegExp = ".*Unterminated string.*")
+  public void testRejectUnterminatedString() {
+    new CypherParser("MATCH (a:User {id: 'abc})-[:FOLLOWS]->(b:User) RETURN b.id").parse();
+  }
+
+  @Test(expectedExceptions = CypherParseException.class,
+      expectedExceptionsMessageRegExp = ".*RETURN \\* is not supported.*")
+  public void testRejectReturnStar() {
+    new CypherParser("MATCH (a:User)-[:FOLLOWS]->(b:User) RETURN *").parse();
+  }
+
+  // ---- WHERE clause tests ----
+
+  @Test
+  public void testWhereEquals() {
+    String cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User) WHERE a.id = 1 RETURN b.id LIMIT 100";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    assertNotNull(query.getWhereClause());
+    CypherIR.Predicate pred = query.getWhereClause().getPredicate();
+    assertTrue(pred instanceof CypherIR.ComparisonPredicate);
+    CypherIR.ComparisonPredicate comp = (CypherIR.ComparisonPredicate) pred;
+    assertEquals(comp.getAlias(), "a");
+    assertEquals(comp.getProperty(), "id");
+    assertEquals(comp.getOperator(), "=");
+    assertEquals(comp.getValue(), 1L);
+  }
+
+  @Test
+  public void testWhereStringValue() {
+    String cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User) WHERE a.name = 'Alice' RETURN b.id";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    CypherIR.ComparisonPredicate comp = (CypherIR.ComparisonPredicate) query.getWhereClause().getPredicate();
+    assertEquals(comp.getAlias(), "a");
+    assertEquals(comp.getProperty(), "name");
+    assertEquals(comp.getOperator(), "=");
+    assertEquals(comp.getValue(), "Alice");
+  }
+
+  @Test
+  public void testWhereNotEquals() {
+    String cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User) WHERE a.id <> 1 RETURN b.id";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    CypherIR.ComparisonPredicate comp = (CypherIR.ComparisonPredicate) query.getWhereClause().getPredicate();
+    assertEquals(comp.getOperator(), "<>");
+  }
+
+  @Test
+  public void testWhereLessThan() {
+    String cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User) WHERE a.age < 30 RETURN b.id";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    CypherIR.ComparisonPredicate comp = (CypherIR.ComparisonPredicate) query.getWhereClause().getPredicate();
+    assertEquals(comp.getOperator(), "<");
+    assertEquals(comp.getValue(), 30L);
+  }
+
+  @Test
+  public void testWhereGreaterThan() {
+    String cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User) WHERE a.age > 25 RETURN b.id";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    CypherIR.ComparisonPredicate comp = (CypherIR.ComparisonPredicate) query.getWhereClause().getPredicate();
+    assertEquals(comp.getOperator(), ">");
+    assertEquals(comp.getValue(), 25L);
+  }
+
+  @Test
+  public void testWhereLessEqual() {
+    String cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User) WHERE a.age <= 30 RETURN b.id";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    CypherIR.ComparisonPredicate comp = (CypherIR.ComparisonPredicate) query.getWhereClause().getPredicate();
+    assertEquals(comp.getOperator(), "<=");
+  }
+
+  @Test
+  public void testWhereGreaterEqual() {
+    String cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User) WHERE a.age >= 25 RETURN b.id";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    CypherIR.ComparisonPredicate comp = (CypherIR.ComparisonPredicate) query.getWhereClause().getPredicate();
+    assertEquals(comp.getOperator(), ">=");
+  }
+
+  @Test
+  public void testWhereAnd() {
+    String cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User) WHERE a.age > 25 AND b.age < 30 RETURN b.name";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    CypherIR.Predicate pred = query.getWhereClause().getPredicate();
+    assertTrue(pred instanceof CypherIR.AndPredicate);
+    CypherIR.AndPredicate and = (CypherIR.AndPredicate) pred;
+
+    CypherIR.ComparisonPredicate left = (CypherIR.ComparisonPredicate) and.getLeft();
+    assertEquals(left.getAlias(), "a");
+    assertEquals(left.getProperty(), "age");
+    assertEquals(left.getOperator(), ">");
+    assertEquals(left.getValue(), 25L);
+
+    CypherIR.ComparisonPredicate right = (CypherIR.ComparisonPredicate) and.getRight();
+    assertEquals(right.getAlias(), "b");
+    assertEquals(right.getProperty(), "age");
+    assertEquals(right.getOperator(), "<");
+    assertEquals(right.getValue(), 30L);
+  }
+
+  @Test
+  public void testWhereOr() {
+    String cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User) WHERE a.name = 'Alice' OR a.name = 'Bob' RETURN b.id";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    CypherIR.Predicate pred = query.getWhereClause().getPredicate();
+    assertTrue(pred instanceof CypherIR.OrPredicate);
+    CypherIR.OrPredicate or = (CypherIR.OrPredicate) pred;
+
+    CypherIR.ComparisonPredicate left = (CypherIR.ComparisonPredicate) or.getLeft();
+    assertEquals(left.getValue(), "Alice");
+
+    CypherIR.ComparisonPredicate right = (CypherIR.ComparisonPredicate) or.getRight();
+    assertEquals(right.getValue(), "Bob");
+  }
+
+  @Test
+  public void testWhereNot() {
+    String cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User) WHERE NOT a.active = false RETURN b.id";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    CypherIR.Predicate pred = query.getWhereClause().getPredicate();
+    assertTrue(pred instanceof CypherIR.NotPredicate);
+    CypherIR.NotPredicate not = (CypherIR.NotPredicate) pred;
+
+    CypherIR.ComparisonPredicate inner = (CypherIR.ComparisonPredicate) not.getInner();
+    assertEquals(inner.getAlias(), "a");
+    assertEquals(inner.getProperty(), "active");
+    assertEquals(inner.getOperator(), "=");
+    assertEquals(inner.getValue(), Boolean.FALSE);
+  }
+
+  @Test
+  public void testWhereParentheses() {
+    String cypher =
+        "MATCH (a:User)-[:FOLLOWS]->(b:User) WHERE a.id = 1 AND (b.name = 'Bob' OR b.name = 'Charlie') RETURN b.id";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    // Top level should be AND
+    CypherIR.AndPredicate and = (CypherIR.AndPredicate) query.getWhereClause().getPredicate();
+
+    // Left side: a.id = 1
+    CypherIR.ComparisonPredicate left = (CypherIR.ComparisonPredicate) and.getLeft();
+    assertEquals(left.getAlias(), "a");
+    assertEquals(left.getValue(), 1L);
+
+    // Right side: (b.name = 'Bob' OR b.name = 'Charlie')
+    CypherIR.OrPredicate or = (CypherIR.OrPredicate) and.getRight();
+    CypherIR.ComparisonPredicate orLeft = (CypherIR.ComparisonPredicate) or.getLeft();
+    assertEquals(orLeft.getValue(), "Bob");
+    CypherIR.ComparisonPredicate orRight = (CypherIR.ComparisonPredicate) or.getRight();
+    assertEquals(orRight.getValue(), "Charlie");
+  }
+
+  @Test
+  public void testWhereWithBooleanTrue() {
+    String cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User) WHERE a.active = true RETURN b.id";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    CypherIR.ComparisonPredicate comp = (CypherIR.ComparisonPredicate) query.getWhereClause().getPredicate();
+    assertEquals(comp.getValue(), Boolean.TRUE);
+  }
+
+  @Test
+  public void testNoWhereClause() {
+    String cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User) RETURN b.id";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    assertNull(query.getWhereClause());
+  }
+
+  // ---- COUNT aggregation tests ----
+
+  @Test
+  public void testCountAggregation() {
+    String cypher = "MATCH (a:User {id: 1})-[:FOLLOWS]->(b:User) RETURN count(b.id) LIMIT 100";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    CypherIR.ReturnClause returnClause = query.getReturnClause();
+    assertEquals(returnClause.getItems().size(), 1);
+
+    CypherIR.ReturnItem item = returnClause.getItems().get(0);
+    assertEquals(item.getAlias(), "b");
+    assertEquals(item.getProperty(), "id");
+    assertEquals(item.getAggregation(), CypherIR.AggregationFunction.COUNT);
+  }
+
+  @Test
+  public void testCountStar() {
+    String cypher = "MATCH (a:User {id: 1})-[:FOLLOWS]->(b:User) RETURN count(*) LIMIT 100";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    CypherIR.ReturnItem item = query.getReturnClause().getItems().get(0);
+    assertNull(item.getAlias());
+    assertNull(item.getProperty());
+    assertEquals(item.getAggregation(), CypherIR.AggregationFunction.COUNT);
+  }
+
+  @Test
+  public void testCountDistinct() {
+    String cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User) RETURN count(DISTINCT b.id) LIMIT 100";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    CypherIR.ReturnItem item = query.getReturnClause().getItems().get(0);
+    assertEquals(item.getAlias(), "b");
+    assertEquals(item.getProperty(), "id");
+    assertEquals(item.getAggregation(), CypherIR.AggregationFunction.COUNT_DISTINCT);
+  }
+
+  @Test
+  public void testMixedReturnItemsWithCount() {
+    String cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User) RETURN a.name, count(b.id) LIMIT 100";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    CypherIR.ReturnClause returnClause = query.getReturnClause();
+    assertEquals(returnClause.getItems().size(), 2);
+
+    // First item: plain a.name
+    CypherIR.ReturnItem first = returnClause.getItems().get(0);
+    assertEquals(first.getAlias(), "a");
+    assertEquals(first.getProperty(), "name");
+    assertEquals(first.getAggregation(), CypherIR.AggregationFunction.NONE);
+
+    // Second item: count(b.id)
+    CypherIR.ReturnItem second = returnClause.getItems().get(1);
+    assertEquals(second.getAlias(), "b");
+    assertEquals(second.getProperty(), "id");
+    assertEquals(second.getAggregation(), CypherIR.AggregationFunction.COUNT);
+  }
+
+  @Test
+  public void testCountAlias() {
+    String cypher = "MATCH (a:User {id: 1})-[:FOLLOWS]->(b:User) RETURN count(b) LIMIT 100";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    CypherIR.ReturnItem item = query.getReturnClause().getItems().get(0);
+    assertEquals(item.getAlias(), "b");
+    assertNull(item.getProperty());
+    assertEquals(item.getAggregation(), CypherIR.AggregationFunction.COUNT);
+  }
+
+  @Test
+  public void testCountCaseInsensitive() {
+    // COUNT, Count, count should all work
+    for (String variant : new String[]{"COUNT", "Count", "count"}) {
+      String cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User) RETURN " + variant + "(b.id) LIMIT 10";
+      CypherParser parser = new CypherParser(cypher);
+      CypherIR.CypherQuery query = parser.parse();
+
+      CypherIR.ReturnItem item = query.getReturnClause().getItems().get(0);
+      assertEquals(item.getAggregation(), CypherIR.AggregationFunction.COUNT,
+          "Failed for variant: " + variant);
+    }
+  }
+
+  @Test
+  public void testCountDistinctCaseInsensitive() {
+    // DISTINCT inside count should be case-insensitive
+    String cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User) RETURN count(distinct b.id) LIMIT 10";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    CypherIR.ReturnItem item = query.getReturnClause().getItems().get(0);
+    assertEquals(item.getAggregation(), CypherIR.AggregationFunction.COUNT_DISTINCT);
+  }
+
+  @Test
+  public void testNonAggregatedReturnItemHasNoneAggregation() {
+    String cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User) RETURN b.id";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    CypherIR.ReturnItem item = query.getReturnClause().getItems().get(0);
+    assertEquals(item.getAggregation(), CypherIR.AggregationFunction.NONE);
+  }
+
+  @Test
+  public void testWhereOperatorPrecedence() {
+    // AND binds tighter than OR: a.x = 1 OR a.y = 2 AND a.z = 3 => a.x = 1 OR (a.y = 2 AND a.z = 3)
+    String cypher =
+        "MATCH (a:User)-[:FOLLOWS]->(b:User) WHERE a.x = 1 OR a.y = 2 AND a.z = 3 RETURN b.id";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    // Top level should be OR
+    CypherIR.OrPredicate or = (CypherIR.OrPredicate) query.getWhereClause().getPredicate();
+
+    // Left: a.x = 1
+    assertTrue(or.getLeft() instanceof CypherIR.ComparisonPredicate);
+
+    // Right: a.y = 2 AND a.z = 3
+    assertTrue(or.getRight() instanceof CypherIR.AndPredicate);
+  }
+
+  // ---- ORDER BY tests ----
+
+  @Test
+  public void testOrderByBasic() {
+    String cypher = "MATCH (a:User {id: 1})-[:FOLLOWS]->(b:User) RETURN b.id ORDER BY b.name LIMIT 100";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    assertNotNull(query.getOrderByClause());
+    assertEquals(query.getOrderByClause().getItems().size(), 1);
+
+    CypherIR.OrderByItem item = query.getOrderByClause().getItems().get(0);
+    assertEquals(item.getAlias(), "b");
+    assertEquals(item.getProperty(), "name");
+    assertEquals(item.getDirection(), CypherIR.SortDirection.ASC);
+  }
+
+  @Test
+  public void testOrderByDesc() {
+    String cypher = "MATCH (a:User {id: 1})-[:FOLLOWS]->(b:User) RETURN b.name ORDER BY b.name DESC LIMIT 100";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    CypherIR.OrderByItem item = query.getOrderByClause().getItems().get(0);
+    assertEquals(item.getAlias(), "b");
+    assertEquals(item.getProperty(), "name");
+    assertEquals(item.getDirection(), CypherIR.SortDirection.DESC);
+  }
+
+  @Test
+  public void testOrderByMultipleItems() {
+    String cypher =
+        "MATCH (a:User)-[:FOLLOWS]->(b:User) RETURN a.id, b.id ORDER BY a.id ASC, b.id DESC LIMIT 100";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    assertNotNull(query.getOrderByClause());
+    assertEquals(query.getOrderByClause().getItems().size(), 2);
+
+    CypherIR.OrderByItem first = query.getOrderByClause().getItems().get(0);
+    assertEquals(first.getAlias(), "a");
+    assertEquals(first.getProperty(), "id");
+    assertEquals(first.getDirection(), CypherIR.SortDirection.ASC);
+
+    CypherIR.OrderByItem second = query.getOrderByClause().getItems().get(1);
+    assertEquals(second.getAlias(), "b");
+    assertEquals(second.getProperty(), "id");
+    assertEquals(second.getDirection(), CypherIR.SortDirection.DESC);
+  }
+
+  @Test
+  public void testOrderByDefaultAsc() {
+    String cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User) RETURN b.id ORDER BY b.id";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    CypherIR.OrderByItem item = query.getOrderByClause().getItems().get(0);
+    assertEquals(item.getDirection(), CypherIR.SortDirection.ASC);
+  }
+
+  @Test
+  public void testNoOrderByClause() {
+    String cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User) RETURN b.id";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    assertNull(query.getOrderByClause());
+  }
+
+  @Test
+  public void testOrderByCaseInsensitive() {
+    String cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User) RETURN b.id order by b.id desc";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    assertNotNull(query.getOrderByClause());
+    CypherIR.OrderByItem item = query.getOrderByClause().getItems().get(0);
+    assertEquals(item.getDirection(), CypherIR.SortDirection.DESC);
+  }
+
+  // ---- RETURN AS alias tests ----
+
+  @Test
+  public void testReturnAsAlias() {
+    String cypher = "MATCH (a:User {id: 1})-[:FOLLOWS]->(b:User) RETURN b.id AS userId LIMIT 100";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    CypherIR.ReturnItem item = query.getReturnClause().getItems().get(0);
+    assertEquals(item.getAlias(), "b");
+    assertEquals(item.getProperty(), "id");
+    assertEquals(item.getResultAlias(), "userId");
+  }
+
+  @Test
+  public void testReturnMultipleAsAliases() {
+    String cypher =
+        "MATCH (a:User {id: 1})-[:FOLLOWS]->(b:User) RETURN b.id AS userId, b.name AS userName LIMIT 100";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    CypherIR.ReturnClause returnClause = query.getReturnClause();
+    assertEquals(returnClause.getItems().size(), 2);
+
+    assertEquals(returnClause.getItems().get(0).getResultAlias(), "userId");
+    assertEquals(returnClause.getItems().get(1).getResultAlias(), "userName");
+  }
+
+  @Test
+  public void testReturnWithoutAsAlias() {
+    String cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User) RETURN b.id";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    CypherIR.ReturnItem item = query.getReturnClause().getItems().get(0);
+    assertNull(item.getResultAlias());
+  }
+
+  @Test
+  public void testReturnAsWithOrderByAndLimit() {
+    String cypher =
+        "MATCH (a:User {id: 1})-[:FOLLOWS]->(b:User) RETURN b.id AS userId ORDER BY b.name LIMIT 10";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    assertEquals(query.getReturnClause().getItems().get(0).getResultAlias(), "userId");
+    assertNotNull(query.getOrderByClause());
+    assertEquals(query.getOrderByClause().getItems().get(0).getProperty(), "name");
+    assertEquals(query.getLimitClause().getCount(), 10);
+  }
+
+  @Test
+  public void testReturnAsCaseInsensitive() {
+    String cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User) RETURN b.id as userId";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    assertEquals(query.getReturnClause().getItems().get(0).getResultAlias(), "userId");
+  }
+
+  // ---- SUM, AVG, MIN, MAX aggregation tests ----
+
+  @Test
+  public void testSumAggregation() {
+    String cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User) RETURN sum(b.age) LIMIT 100";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    CypherIR.ReturnItem item = query.getReturnClause().getItems().get(0);
+    assertEquals(item.getAlias(), "b");
+    assertEquals(item.getProperty(), "age");
+    assertEquals(item.getAggregation(), CypherIR.AggregationFunction.SUM);
+  }
+
+  @Test
+  public void testAvgAggregation() {
+    String cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User) RETURN avg(b.age) LIMIT 100";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    CypherIR.ReturnItem item = query.getReturnClause().getItems().get(0);
+    assertEquals(item.getAlias(), "b");
+    assertEquals(item.getProperty(), "age");
+    assertEquals(item.getAggregation(), CypherIR.AggregationFunction.AVG);
+  }
+
+  @Test
+  public void testMinAggregation() {
+    String cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User) RETURN min(b.age) LIMIT 100";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    CypherIR.ReturnItem item = query.getReturnClause().getItems().get(0);
+    assertEquals(item.getAlias(), "b");
+    assertEquals(item.getProperty(), "age");
+    assertEquals(item.getAggregation(), CypherIR.AggregationFunction.MIN);
+  }
+
+  @Test
+  public void testMaxAggregation() {
+    String cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User) RETURN max(b.age) LIMIT 100";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    CypherIR.ReturnItem item = query.getReturnClause().getItems().get(0);
+    assertEquals(item.getAlias(), "b");
+    assertEquals(item.getProperty(), "age");
+    assertEquals(item.getAggregation(), CypherIR.AggregationFunction.MAX);
+  }
+
+  @Test
+  public void testSumAggregationAlias() {
+    String cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User) RETURN sum(b) LIMIT 100";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    CypherIR.ReturnItem item = query.getReturnClause().getItems().get(0);
+    assertEquals(item.getAlias(), "b");
+    assertNull(item.getProperty());
+    assertEquals(item.getAggregation(), CypherIR.AggregationFunction.SUM);
+  }
+
+  @Test
+  public void testMixedReturnItemsWithSum() {
+    String cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User) RETURN a.name, sum(b.age) LIMIT 100";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    CypherIR.ReturnClause returnClause = query.getReturnClause();
+    assertEquals(returnClause.getItems().size(), 2);
+
+    CypherIR.ReturnItem first = returnClause.getItems().get(0);
+    assertEquals(first.getAlias(), "a");
+    assertEquals(first.getProperty(), "name");
+    assertEquals(first.getAggregation(), CypherIR.AggregationFunction.NONE);
+
+    CypherIR.ReturnItem second = returnClause.getItems().get(1);
+    assertEquals(second.getAlias(), "b");
+    assertEquals(second.getProperty(), "age");
+    assertEquals(second.getAggregation(), CypherIR.AggregationFunction.SUM);
+  }
+
+  @Test
+  public void testSumCaseInsensitive() {
+    for (String variant : new String[]{"SUM", "Sum", "sum"}) {
+      String cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User) RETURN " + variant + "(b.age) LIMIT 10";
+      CypherParser parser = new CypherParser(cypher);
+      CypherIR.CypherQuery query = parser.parse();
+
+      CypherIR.ReturnItem item = query.getReturnClause().getItems().get(0);
+      assertEquals(item.getAggregation(), CypherIR.AggregationFunction.SUM,
+          "Failed for variant: " + variant);
+    }
+  }
+
+  @Test
+  public void testAvgCaseInsensitive() {
+    for (String variant : new String[]{"AVG", "Avg", "avg"}) {
+      String cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User) RETURN " + variant + "(b.age) LIMIT 10";
+      CypherParser parser = new CypherParser(cypher);
+      CypherIR.CypherQuery query = parser.parse();
+
+      CypherIR.ReturnItem item = query.getReturnClause().getItems().get(0);
+      assertEquals(item.getAggregation(), CypherIR.AggregationFunction.AVG,
+          "Failed for variant: " + variant);
+    }
+  }
+
+  @Test(expectedExceptions = CypherParseException.class,
+      expectedExceptionsMessageRegExp = ".*SUM\\(\\*\\) is not supported.*")
+  public void testRejectSumStar() {
+    new CypherParser("MATCH (a:User)-[:FOLLOWS]->(b:User) RETURN sum(*) LIMIT 10").parse();
+  }
+
+  @Test(expectedExceptions = CypherParseException.class,
+      expectedExceptionsMessageRegExp = ".*AVG\\(DISTINCT.*")
+  public void testRejectAvgDistinct() {
+    new CypherParser("MATCH (a:User)-[:FOLLOWS]->(b:User) RETURN avg(DISTINCT b.age) LIMIT 10").parse();
+  }
+
+  @Test
+  public void testAggregationWithResultAlias() {
+    String cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User) RETURN sum(b.age) AS totalAge LIMIT 100";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    CypherIR.ReturnItem item = query.getReturnClause().getItems().get(0);
+    assertEquals(item.getAggregation(), CypherIR.AggregationFunction.SUM);
+    assertEquals(item.getResultAlias(), "totalAge");
+  }
+
+  // ---- String predicate tests ----
+
+  @Test
+  public void testWhereStartsWith() {
+    String cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User) WHERE a.name STARTS WITH 'Al' RETURN b.id";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    CypherIR.Predicate pred = query.getWhereClause().getPredicate();
+    assertTrue(pred instanceof CypherIR.StringPredicate);
+    CypherIR.StringPredicate sp = (CypherIR.StringPredicate) pred;
+    assertEquals(sp.getAlias(), "a");
+    assertEquals(sp.getProperty(), "name");
+    assertEquals(sp.getOperator(), CypherIR.StringOperator.STARTS_WITH);
+    assertEquals(sp.getValue(), "Al");
+  }
+
+  @Test
+  public void testWhereEndsWith() {
+    String cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User) WHERE a.name ENDS WITH 'ice' RETURN b.id";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    CypherIR.Predicate pred = query.getWhereClause().getPredicate();
+    assertTrue(pred instanceof CypherIR.StringPredicate);
+    CypherIR.StringPredicate sp = (CypherIR.StringPredicate) pred;
+    assertEquals(sp.getAlias(), "a");
+    assertEquals(sp.getProperty(), "name");
+    assertEquals(sp.getOperator(), CypherIR.StringOperator.ENDS_WITH);
+    assertEquals(sp.getValue(), "ice");
+  }
+
+  @Test
+  public void testWhereContains() {
+    String cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User) WHERE a.name CONTAINS 'lic' RETURN b.id";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    CypherIR.Predicate pred = query.getWhereClause().getPredicate();
+    assertTrue(pred instanceof CypherIR.StringPredicate);
+    CypherIR.StringPredicate sp = (CypherIR.StringPredicate) pred;
+    assertEquals(sp.getAlias(), "a");
+    assertEquals(sp.getProperty(), "name");
+    assertEquals(sp.getOperator(), CypherIR.StringOperator.CONTAINS);
+    assertEquals(sp.getValue(), "lic");
+  }
+
+  // ---- IN list predicate tests ----
+
+  @Test
+  public void testWhereInIntegerList() {
+    String cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User) WHERE a.id IN [1, 2, 3] RETURN b.id";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    CypherIR.Predicate pred = query.getWhereClause().getPredicate();
+    assertTrue(pred instanceof CypherIR.InPredicate);
+    CypherIR.InPredicate in = (CypherIR.InPredicate) pred;
+    assertEquals(in.getAlias(), "a");
+    assertEquals(in.getProperty(), "id");
+    assertEquals(in.getValues().size(), 3);
+    assertEquals(in.getValues().get(0), 1L);
+    assertEquals(in.getValues().get(1), 2L);
+    assertEquals(in.getValues().get(2), 3L);
+  }
+
+  @Test
+  public void testWhereInStringList() {
+    String cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User) WHERE a.name IN ['Alice', 'Bob'] RETURN b.id";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    CypherIR.Predicate pred = query.getWhereClause().getPredicate();
+    assertTrue(pred instanceof CypherIR.InPredicate);
+    CypherIR.InPredicate in = (CypherIR.InPredicate) pred;
+    assertEquals(in.getAlias(), "a");
+    assertEquals(in.getProperty(), "name");
+    assertEquals(in.getValues().size(), 2);
+    assertEquals(in.getValues().get(0), "Alice");
+    assertEquals(in.getValues().get(1), "Bob");
+  }
+
+  @Test
+  public void testWhereStartsWithAndIn() {
+    String cypher =
+        "MATCH (a:User)-[:FOLLOWS]->(b:User) WHERE a.name STARTS WITH 'A' AND a.id IN [1, 2] RETURN b.id";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    CypherIR.Predicate pred = query.getWhereClause().getPredicate();
+    assertTrue(pred instanceof CypherIR.AndPredicate);
+    CypherIR.AndPredicate and = (CypherIR.AndPredicate) pred;
+
+    assertTrue(and.getLeft() instanceof CypherIR.StringPredicate);
+    CypherIR.StringPredicate sp = (CypherIR.StringPredicate) and.getLeft();
+    assertEquals(sp.getOperator(), CypherIR.StringOperator.STARTS_WITH);
+    assertEquals(sp.getValue(), "A");
+
+    assertTrue(and.getRight() instanceof CypherIR.InPredicate);
+    CypherIR.InPredicate in = (CypherIR.InPredicate) and.getRight();
+    assertEquals(in.getValues().size(), 2);
+  }
+
+  @Test
+  public void testWhereStringPredicateCaseInsensitive() {
+    // Keywords STARTS, ENDS, CONTAINS, WITH, IN should be case-insensitive
+    String cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User) WHERE a.name starts with 'Al' RETURN b.id";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    CypherIR.StringPredicate sp = (CypherIR.StringPredicate) query.getWhereClause().getPredicate();
+    assertEquals(sp.getOperator(), CypherIR.StringOperator.STARTS_WITH);
+  }
+
+  // ---- 2-hop pattern tests ----
+
+  @Test
+  public void testTwoHopOutgoing() {
+    String cypher =
+        "MATCH (a:User {id: 1})-[:FOLLOWS]->(b:User)-[:FOLLOWS]->(c:User) RETURN c.id LIMIT 100";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    CypherIR.MatchClause match = query.getMatchClause();
+    assertEquals(match.getHopCount(), 2);
+    assertEquals(match.getNodes().size(), 3);
+    assertEquals(match.getEdges().size(), 2);
+
+    // First node
+    assertEquals(match.getNodes().get(0).getAlias(), "a");
+    assertEquals(match.getNodes().get(0).getLabel(), "User");
+    assertEquals(match.getNodes().get(0).getProperties().get("id"), 1L);
+
+    // Second node
+    assertEquals(match.getNodes().get(1).getAlias(), "b");
+    assertEquals(match.getNodes().get(1).getLabel(), "User");
+
+    // Third node
+    assertEquals(match.getNodes().get(2).getAlias(), "c");
+    assertEquals(match.getNodes().get(2).getLabel(), "User");
+
+    // First edge
+    assertEquals(match.getEdges().get(0).getType(), "FOLLOWS");
+    assertEquals(match.getEdges().get(0).getDirection(), CypherIR.Direction.OUTGOING);
+
+    // Second edge
+    assertEquals(match.getEdges().get(1).getType(), "FOLLOWS");
+    assertEquals(match.getEdges().get(1).getDirection(), CypherIR.Direction.OUTGOING);
+
+    // Backward compat: getSource() and getTarget() still work
+    assertEquals(match.getSource().getAlias(), "a");
+    assertEquals(match.getTarget().getAlias(), "c");
+  }
+
+  @Test
+  public void testTwoHopMixedDirection() {
+    // Friends-of-friends who follow b
+    String cypher =
+        "MATCH (a:User)-[:FOLLOWS]->(b:User)<-[:FOLLOWS]-(c:User) RETURN c.id LIMIT 100";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    CypherIR.MatchClause match = query.getMatchClause();
+    assertEquals(match.getHopCount(), 2);
+
+    // First edge: outgoing
+    assertEquals(match.getEdges().get(0).getDirection(), CypherIR.Direction.OUTGOING);
+    assertEquals(match.getEdges().get(0).getType(), "FOLLOWS");
+
+    // Second edge: incoming
+    assertEquals(match.getEdges().get(1).getDirection(), CypherIR.Direction.INCOMING);
+    assertEquals(match.getEdges().get(1).getType(), "FOLLOWS");
+  }
+
+  @Test
+  public void testTwoHopWithInlinePropertiesOnFirstNode() {
+    String cypher =
+        "MATCH (a:User {id: '42', name: 'alice'})-[:FOLLOWS]->(b:User)-[:FOLLOWS]->(c:User) RETURN c.id";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    CypherIR.MatchClause match = query.getMatchClause();
+    assertEquals(match.getHopCount(), 2);
+    assertEquals(match.getNodes().get(0).getProperties().size(), 2);
+    assertEquals(match.getNodes().get(0).getProperties().get("id"), "42");
+    assertEquals(match.getNodes().get(0).getProperties().get("name"), "alice");
+  }
+
+  @Test
+  public void testTwoHopWithDifferentEdgeTypes() {
+    String cypher =
+        "MATCH (a:User {id: 1})-[:FOLLOWS]->(b:User)-[:LIKES]->(c:Post) RETURN c.id LIMIT 100";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    CypherIR.MatchClause match = query.getMatchClause();
+    assertEquals(match.getHopCount(), 2);
+
+    assertEquals(match.getEdges().get(0).getType(), "FOLLOWS");
+    assertEquals(match.getEdges().get(1).getType(), "LIKES");
+
+    assertEquals(match.getNodes().get(0).getLabel(), "User");
+    assertEquals(match.getNodes().get(1).getLabel(), "User");
+    assertEquals(match.getNodes().get(2).getLabel(), "Post");
+  }
+
+  @Test(expectedExceptions = CypherParseException.class,
+      expectedExceptionsMessageRegExp = ".*At most 2-hop patterns are supported.*")
+  public void testRejectThreeHopPattern() {
+    new CypherParser(
+        "MATCH (a:User)-[:FOLLOWS]->(b:User)-[:FOLLOWS]->(c:User)-[:FOLLOWS]->(d:User) RETURN d.id"
+    ).parse();
+  }
+
+  @Test
+  public void testTwoHopWithEdgeAliases() {
+    String cypher =
+        "MATCH (a:User)-[r1:FOLLOWS]->(b:User)-[r2:FOLLOWS]->(c:User) RETURN c.id LIMIT 100";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    CypherIR.MatchClause match = query.getMatchClause();
+    assertEquals(match.getEdges().get(0).getAlias(), "r1");
+    assertEquals(match.getEdges().get(1).getAlias(), "r2");
+  }
+
+  @Test
+  public void testOneHopBackwardCompat() {
+    // Verify that 1-hop getEdge() still works
+    String cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User) RETURN b.id";
+    CypherParser parser = new CypherParser(cypher);
+    CypherIR.CypherQuery query = parser.parse();
+
+    CypherIR.MatchClause match = query.getMatchClause();
+    assertEquals(match.getHopCount(), 1);
+    assertNotNull(match.getEdge()); // single-hop accessor
+    assertEquals(match.getEdge().getType(), "FOLLOWS");
+    assertEquals(match.getNodes().size(), 2);
+    assertEquals(match.getEdges().size(), 1);
+  }
+}

--- a/pinot-graph/pinot-graph-planner/src/test/java/org/apache/pinot/graph/planner/CypherToSqlTranslatorTest.java
+++ b/pinot-graph/pinot-graph-planner/src/test/java/org/apache/pinot/graph/planner/CypherToSqlTranslatorTest.java
@@ -1,0 +1,778 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.graph.planner;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.pinot.graph.spi.GraphSchemaConfig;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+
+/**
+ * End-to-end tests: Cypher query in, SQL string out.
+ */
+public class CypherToSqlTranslatorTest {
+
+  private CypherToSqlTranslator _translator;
+
+  @BeforeMethod
+  public void setUp() {
+    _translator = new CypherToSqlTranslator(createTestSchema());
+  }
+
+  @Test
+  public void testEndToEndBasicQuery() {
+    String cypher = "MATCH (a:User {id: '123'})-[:FOLLOWS]->(b:User) RETURN b.id LIMIT 100";
+    String sql = _translator.translate(cypher);
+
+    assertEquals(sql,
+        "SELECT b.user_id FROM follows_table AS e "
+            + "JOIN users_table AS a ON e.follower_id = a.user_id "
+            + "JOIN users_table AS b ON e.followee_id = b.user_id "
+            + "WHERE a.user_id = '123' "
+            + "LIMIT 100");
+  }
+
+  @Test
+  public void testEndToEndMultipleReturnItems() {
+    String cypher = "MATCH (a:User {id: '42'})-[:FOLLOWS]->(b:User) RETURN b.id, b.name";
+    String sql = _translator.translate(cypher);
+
+    assertEquals(sql,
+        "SELECT b.user_id, b.user_name FROM follows_table AS e "
+            + "JOIN users_table AS a ON e.follower_id = a.user_id "
+            + "JOIN users_table AS b ON e.followee_id = b.user_id "
+            + "WHERE a.user_id = '42'");
+  }
+
+  @Test
+  public void testEndToEndNoFilters() {
+    String cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User) RETURN b.id LIMIT 50";
+    String sql = _translator.translate(cypher);
+
+    assertEquals(sql,
+        "SELECT b.user_id FROM follows_table AS e "
+            + "JOIN users_table AS a ON e.follower_id = a.user_id "
+            + "JOIN users_table AS b ON e.followee_id = b.user_id "
+            + "LIMIT 50");
+  }
+
+  @Test
+  public void testEndToEndIncomingEdge() {
+    String cypher = "MATCH (a:User {id: '99'})<-[:FOLLOWS]-(b:User) RETURN b.id";
+    String sql = _translator.translate(cypher);
+
+    // Incoming: a is the followee (target in schema), b is the follower (source in schema)
+    assertEquals(sql,
+        "SELECT b.user_id FROM follows_table AS e "
+            + "JOIN users_table AS a ON e.followee_id = a.user_id "
+            + "JOIN users_table AS b ON e.follower_id = b.user_id "
+            + "WHERE a.user_id = '99'");
+  }
+
+  @Test
+  public void testEndToEndCaseInsensitiveKeywords() {
+    String cypher = "match (a:User {id: '1'})-[:FOLLOWS]->(b:User) return b.id limit 10";
+    String sql = _translator.translate(cypher);
+
+    assertTrue(sql.contains("SELECT b.user_id"));
+    assertTrue(sql.contains("LIMIT 10"));
+  }
+
+  @Test(expectedExceptions = CypherParseException.class, expectedExceptionsMessageRegExp = ".*Unknown vertex label.*")
+  public void testRejectUnknownVertexLabel() {
+    _translator.translate("MATCH (a:Unknown {id: '1'})-[:FOLLOWS]->(b:User) RETURN b.id");
+  }
+
+  @Test(expectedExceptions = CypherParseException.class,
+      expectedExceptionsMessageRegExp = ".*Unknown relationship type.*")
+  public void testRejectUnknownEdgeType() {
+    _translator.translate("MATCH (a:User {id: '1'})-[:UNKNOWN]->(b:User) RETURN b.id");
+  }
+
+  @Test(expectedExceptions = CypherParseException.class, expectedExceptionsMessageRegExp = ".*unknown alias.*")
+  public void testRejectInvalidReturnAlias() {
+    _translator.translate("MATCH (a:User)-[:FOLLOWS]->(b:User) RETURN c.id");
+  }
+
+  @Test(expectedExceptions = CypherParseException.class,
+      expectedExceptionsMessageRegExp = ".*Relationship type must be specified.*")
+  public void testRejectUntypedRelationship() {
+    _translator.translate("MATCH (a:User)-[]->(b:User) RETURN b.id");
+  }
+
+  @Test(expectedExceptions = CypherParseException.class,
+      expectedExceptionsMessageRegExp = ".*Source node label.*does not match.*")
+  public void testRejectMismatchedSourceLabel() {
+    // Create a schema where FOLLOWS goes from User to User, but query says Post->User
+    CypherToSqlTranslator translator = new CypherToSqlTranslator(createSchemaWithPost());
+    translator.translate("MATCH (a:Post)-[:FOLLOWS]->(b:User) RETURN b.id");
+  }
+
+  @Test
+  public void testEndToEndWithDifferentVertexLabels() {
+    CypherToSqlTranslator translator = new CypherToSqlTranslator(createSchemaWithPost());
+    String sql = translator.translate("MATCH (a:User {id: '1'})-[:AUTHORED]->(b:Post) RETURN b.title");
+
+    assertEquals(sql,
+        "SELECT b.post_title FROM authored_table AS e "
+            + "JOIN users_table AS a ON e.author_id = a.user_id "
+            + "JOIN posts_table AS b ON e.post_id = b.post_id "
+            + "WHERE a.user_id = '1'");
+  }
+
+  @Test
+  public void testEndToEndDistinct() {
+    String cypher = "MATCH (a:User {id: 1})-[:FOLLOWS]->(b:User) RETURN DISTINCT b.id LIMIT 100";
+    String sql = _translator.translate(cypher);
+
+    assertEquals(sql,
+        "SELECT DISTINCT b.user_id FROM follows_table AS e "
+            + "JOIN users_table AS a ON e.follower_id = a.user_id "
+            + "JOIN users_table AS b ON e.followee_id = b.user_id "
+            + "WHERE a.user_id = 1 "
+            + "LIMIT 100");
+  }
+
+  @Test
+  public void testEndToEndBooleanProperty() {
+    String cypher = "MATCH (a:User {active: true})-[:FOLLOWS]->(b:User) RETURN b.id LIMIT 100";
+    String sql = _translator.translate(cypher);
+
+    assertEquals(sql,
+        "SELECT b.user_id FROM follows_table AS e "
+            + "JOIN users_table AS a ON e.follower_id = a.user_id "
+            + "JOIN users_table AS b ON e.followee_id = b.user_id "
+            + "WHERE a.active = true "
+            + "LIMIT 100");
+  }
+
+  @Test
+  public void testEndToEndBooleanFalseWithDistinct() {
+    String cypher = "MATCH (a:User {active: false})-[:FOLLOWS]->(b:User) RETURN DISTINCT b.name LIMIT 100";
+    String sql = _translator.translate(cypher);
+
+    assertEquals(sql,
+        "SELECT DISTINCT b.user_name FROM follows_table AS e "
+            + "JOIN users_table AS a ON e.follower_id = a.user_id "
+            + "JOIN users_table AS b ON e.followee_id = b.user_id "
+            + "WHERE a.active = false "
+            + "LIMIT 100");
+  }
+
+  // ---- WHERE clause end-to-end tests ----
+
+  @Test
+  public void testEndToEndWhereEquals() {
+    String cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User) WHERE a.id = 1 RETURN b.id LIMIT 100";
+    String sql = _translator.translate(cypher);
+
+    assertEquals(sql,
+        "SELECT b.user_id FROM follows_table AS e "
+            + "JOIN users_table AS a ON e.follower_id = a.user_id "
+            + "JOIN users_table AS b ON e.followee_id = b.user_id "
+            + "WHERE a.user_id = 1 "
+            + "LIMIT 100");
+  }
+
+  @Test
+  public void testEndToEndWhereAnd() {
+    String cypher =
+        "MATCH (a:User)-[:FOLLOWS]->(b:User) WHERE a.age > 25 AND b.age < 30 RETURN b.name LIMIT 100";
+    String sql = _translator.translate(cypher);
+
+    assertEquals(sql,
+        "SELECT b.user_name FROM follows_table AS e "
+            + "JOIN users_table AS a ON e.follower_id = a.user_id "
+            + "JOIN users_table AS b ON e.followee_id = b.user_id "
+            + "WHERE (a.age > 25 AND b.age < 30) "
+            + "LIMIT 100");
+  }
+
+  @Test
+  public void testEndToEndWhereOr() {
+    String cypher =
+        "MATCH (a:User)-[:FOLLOWS]->(b:User) WHERE a.name = 'Alice' OR a.name = 'Bob' RETURN b.id LIMIT 100";
+    String sql = _translator.translate(cypher);
+
+    assertEquals(sql,
+        "SELECT b.user_id FROM follows_table AS e "
+            + "JOIN users_table AS a ON e.follower_id = a.user_id "
+            + "JOIN users_table AS b ON e.followee_id = b.user_id "
+            + "WHERE (a.user_name = 'Alice' OR a.user_name = 'Bob') "
+            + "LIMIT 100");
+  }
+
+  @Test
+  public void testEndToEndWhereNot() {
+    String cypher =
+        "MATCH (a:User)-[:FOLLOWS]->(b:User) WHERE NOT a.active = false RETURN b.id LIMIT 100";
+    String sql = _translator.translate(cypher);
+
+    assertEquals(sql,
+        "SELECT b.user_id FROM follows_table AS e "
+            + "JOIN users_table AS a ON e.follower_id = a.user_id "
+            + "JOIN users_table AS b ON e.followee_id = b.user_id "
+            + "WHERE (NOT a.active = false) "
+            + "LIMIT 100");
+  }
+
+  @Test
+  public void testEndToEndWhereWithParentheses() {
+    String cypher =
+        "MATCH (a:User)-[:FOLLOWS]->(b:User) "
+            + "WHERE a.id = 1 AND (b.name = 'Bob' OR b.name = 'Charlie') RETURN b.id LIMIT 100";
+    String sql = _translator.translate(cypher);
+
+    assertEquals(sql,
+        "SELECT b.user_id FROM follows_table AS e "
+            + "JOIN users_table AS a ON e.follower_id = a.user_id "
+            + "JOIN users_table AS b ON e.followee_id = b.user_id "
+            + "WHERE (a.user_id = 1 AND (b.user_name = 'Bob' OR b.user_name = 'Charlie')) "
+            + "LIMIT 100");
+  }
+
+  @Test
+  public void testEndToEndWhereWithInlineFilters() {
+    String cypher =
+        "MATCH (a:User {id: '123'})-[:FOLLOWS]->(b:User) WHERE b.name = 'Alice' RETURN b.id";
+    String sql = _translator.translate(cypher);
+
+    // Both inline filter and WHERE condition should appear in WHERE clause
+    assertTrue(sql.contains("a.user_id = '123'"));
+    assertTrue(sql.contains("b.user_name = 'Alice'"));
+  }
+
+  @Test(expectedExceptions = CypherParseException.class,
+      expectedExceptionsMessageRegExp = ".*unknown alias.*")
+  public void testRejectWhereWithUnknownAlias() {
+    _translator.translate(
+        "MATCH (a:User)-[:FOLLOWS]->(b:User) WHERE c.id = 1 RETURN b.id");
+  }
+
+  // ---- COUNT aggregation end-to-end tests ----
+
+  @Test
+  public void testEndToEndCountAggregation() {
+    String cypher = "MATCH (a:User {id: 1})-[:FOLLOWS]->(b:User) RETURN count(b.id) LIMIT 100";
+    String sql = _translator.translate(cypher);
+
+    assertEquals(sql,
+        "SELECT COUNT(b.user_id) FROM follows_table AS e "
+            + "JOIN users_table AS a ON e.follower_id = a.user_id "
+            + "JOIN users_table AS b ON e.followee_id = b.user_id "
+            + "WHERE a.user_id = 1 "
+            + "LIMIT 100");
+  }
+
+  @Test
+  public void testEndToEndCountStar() {
+    String cypher = "MATCH (a:User {id: 1})-[:FOLLOWS]->(b:User) RETURN count(*) LIMIT 100";
+    String sql = _translator.translate(cypher);
+
+    assertEquals(sql,
+        "SELECT COUNT(*) FROM follows_table AS e "
+            + "JOIN users_table AS a ON e.follower_id = a.user_id "
+            + "JOIN users_table AS b ON e.followee_id = b.user_id "
+            + "WHERE a.user_id = 1 "
+            + "LIMIT 100");
+  }
+
+  @Test
+  public void testEndToEndCountDistinct() {
+    String cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User) RETURN a.name, count(DISTINCT b.id) LIMIT 100";
+    String sql = _translator.translate(cypher);
+
+    assertEquals(sql,
+        "SELECT a.user_name, COUNT(DISTINCT b.user_id) FROM follows_table AS e "
+            + "JOIN users_table AS a ON e.follower_id = a.user_id "
+            + "JOIN users_table AS b ON e.followee_id = b.user_id "
+            + "GROUP BY a.user_name "
+            + "LIMIT 100");
+  }
+
+  @Test
+  public void testEndToEndMixedReturnWithCount() {
+    String cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User) RETURN a.id, count(b.id) LIMIT 100";
+    String sql = _translator.translate(cypher);
+
+    assertEquals(sql,
+        "SELECT a.user_id, COUNT(b.user_id) FROM follows_table AS e "
+            + "JOIN users_table AS a ON e.follower_id = a.user_id "
+            + "JOIN users_table AS b ON e.followee_id = b.user_id "
+            + "GROUP BY a.user_id "
+            + "LIMIT 100");
+  }
+
+  @Test
+  public void testEndToEndCountAlias() {
+    String cypher = "MATCH (a:User {id: 1})-[:FOLLOWS]->(b:User) RETURN count(b) LIMIT 100";
+    String sql = _translator.translate(cypher);
+
+    assertEquals(sql,
+        "SELECT COUNT(b.user_id) FROM follows_table AS e "
+            + "JOIN users_table AS a ON e.follower_id = a.user_id "
+            + "JOIN users_table AS b ON e.followee_id = b.user_id "
+            + "WHERE a.user_id = 1 "
+            + "LIMIT 100");
+  }
+
+  // ---- ORDER BY end-to-end tests ----
+
+  @Test
+  public void testEndToEndOrderBy() {
+    String cypher = "MATCH (a:User {id: 1})-[:FOLLOWS]->(b:User) RETURN b.id ORDER BY b.name LIMIT 100";
+    String sql = _translator.translate(cypher);
+
+    assertEquals(sql,
+        "SELECT b.user_id FROM follows_table AS e "
+            + "JOIN users_table AS a ON e.follower_id = a.user_id "
+            + "JOIN users_table AS b ON e.followee_id = b.user_id "
+            + "WHERE a.user_id = 1 "
+            + "ORDER BY b.user_name ASC "
+            + "LIMIT 100");
+  }
+
+  @Test
+  public void testEndToEndOrderByDesc() {
+    String cypher = "MATCH (a:User {id: 1})-[:FOLLOWS]->(b:User) RETURN b.name ORDER BY b.name DESC LIMIT 100";
+    String sql = _translator.translate(cypher);
+
+    assertEquals(sql,
+        "SELECT b.user_name FROM follows_table AS e "
+            + "JOIN users_table AS a ON e.follower_id = a.user_id "
+            + "JOIN users_table AS b ON e.followee_id = b.user_id "
+            + "WHERE a.user_id = 1 "
+            + "ORDER BY b.user_name DESC "
+            + "LIMIT 100");
+  }
+
+  @Test
+  public void testEndToEndOrderByMultipleItems() {
+    String cypher =
+        "MATCH (a:User)-[:FOLLOWS]->(b:User) RETURN a.id, b.id ORDER BY a.id ASC, b.id DESC LIMIT 100";
+    String sql = _translator.translate(cypher);
+
+    assertEquals(sql,
+        "SELECT a.user_id, b.user_id FROM follows_table AS e "
+            + "JOIN users_table AS a ON e.follower_id = a.user_id "
+            + "JOIN users_table AS b ON e.followee_id = b.user_id "
+            + "ORDER BY a.user_id ASC, b.user_id DESC "
+            + "LIMIT 100");
+  }
+
+  // ---- RETURN AS alias end-to-end tests ----
+
+  @Test
+  public void testEndToEndReturnAs() {
+    String cypher =
+        "MATCH (a:User {id: 1})-[:FOLLOWS]->(b:User) RETURN b.id AS userId, b.name AS userName ORDER BY b.name "
+            + "LIMIT 100";
+    String sql = _translator.translate(cypher);
+
+    assertEquals(sql,
+        "SELECT b.user_id AS userId, b.user_name AS userName FROM follows_table AS e "
+            + "JOIN users_table AS a ON e.follower_id = a.user_id "
+            + "JOIN users_table AS b ON e.followee_id = b.user_id "
+            + "WHERE a.user_id = 1 "
+            + "ORDER BY b.user_name ASC "
+            + "LIMIT 100");
+  }
+
+  @Test
+  public void testEndToEndReturnAsWithoutOrderBy() {
+    String cypher = "MATCH (a:User {id: 1})-[:FOLLOWS]->(b:User) RETURN b.id AS userId LIMIT 100";
+    String sql = _translator.translate(cypher);
+
+    assertEquals(sql,
+        "SELECT b.user_id AS userId FROM follows_table AS e "
+            + "JOIN users_table AS a ON e.follower_id = a.user_id "
+            + "JOIN users_table AS b ON e.followee_id = b.user_id "
+            + "WHERE a.user_id = 1 "
+            + "LIMIT 100");
+  }
+
+  @Test(expectedExceptions = CypherParseException.class,
+      expectedExceptionsMessageRegExp = ".*ORDER BY item references unknown alias.*")
+  public void testRejectOrderByWithUnknownAlias() {
+    _translator.translate(
+        "MATCH (a:User)-[:FOLLOWS]->(b:User) RETURN b.id ORDER BY c.id");
+  }
+
+  // ---- SKIP end-to-end tests ----
+
+  @Test
+  public void testEndToEndSkip() {
+    String cypher =
+        "MATCH (a:User {id: 1})-[:FOLLOWS]->(b:User) RETURN b.id ORDER BY b.name SKIP 20 LIMIT 100";
+    String sql = _translator.translate(cypher);
+
+    assertEquals(sql,
+        "SELECT b.user_id FROM follows_table AS e "
+            + "JOIN users_table AS a ON e.follower_id = a.user_id "
+            + "JOIN users_table AS b ON e.followee_id = b.user_id "
+            + "WHERE a.user_id = 1 "
+            + "ORDER BY b.user_name ASC "
+            + "LIMIT 100 OFFSET 20");
+  }
+
+  @Test
+  public void testEndToEndSkipWithoutLimit() {
+    String cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User) RETURN b.id SKIP 10";
+    String sql = _translator.translate(cypher);
+
+    assertTrue(sql.contains("OFFSET 10"));
+    assertFalse(sql.contains("LIMIT"));
+  }
+
+  @Test
+  public void testEndToEndSkipWithLimit() {
+    String cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User) RETURN b.id SKIP 5 LIMIT 50";
+    String sql = _translator.translate(cypher);
+
+    assertTrue(sql.contains("LIMIT 50 OFFSET 5"));
+  }
+
+  // ---- SUM/AVG/MIN/MAX end-to-end tests ----
+
+  @Test
+  public void testEndToEndSumAggregation() {
+    String cypher = "MATCH (a:User {id: 1})-[:FOLLOWS]->(b:User) RETURN sum(b.age) LIMIT 100";
+    String sql = _translator.translate(cypher);
+
+    assertEquals(sql,
+        "SELECT SUM(b.age) FROM follows_table AS e "
+            + "JOIN users_table AS a ON e.follower_id = a.user_id "
+            + "JOIN users_table AS b ON e.followee_id = b.user_id "
+            + "WHERE a.user_id = 1 "
+            + "LIMIT 100");
+  }
+
+  @Test
+  public void testEndToEndAvgAggregation() {
+    String cypher = "MATCH (a:User {id: 1})-[:FOLLOWS]->(b:User) RETURN avg(b.age) LIMIT 100";
+    String sql = _translator.translate(cypher);
+
+    assertEquals(sql,
+        "SELECT AVG(b.age) FROM follows_table AS e "
+            + "JOIN users_table AS a ON e.follower_id = a.user_id "
+            + "JOIN users_table AS b ON e.followee_id = b.user_id "
+            + "WHERE a.user_id = 1 "
+            + "LIMIT 100");
+  }
+
+  @Test
+  public void testEndToEndMinAggregation() {
+    String cypher = "MATCH (a:User {id: 1})-[:FOLLOWS]->(b:User) RETURN min(b.age) LIMIT 100";
+    String sql = _translator.translate(cypher);
+
+    assertEquals(sql,
+        "SELECT MIN(b.age) FROM follows_table AS e "
+            + "JOIN users_table AS a ON e.follower_id = a.user_id "
+            + "JOIN users_table AS b ON e.followee_id = b.user_id "
+            + "WHERE a.user_id = 1 "
+            + "LIMIT 100");
+  }
+
+  @Test
+  public void testEndToEndMaxAggregation() {
+    String cypher = "MATCH (a:User {id: 1})-[:FOLLOWS]->(b:User) RETURN max(b.age) LIMIT 100";
+    String sql = _translator.translate(cypher);
+
+    assertEquals(sql,
+        "SELECT MAX(b.age) FROM follows_table AS e "
+            + "JOIN users_table AS a ON e.follower_id = a.user_id "
+            + "JOIN users_table AS b ON e.followee_id = b.user_id "
+            + "WHERE a.user_id = 1 "
+            + "LIMIT 100");
+  }
+
+  @Test
+  public void testEndToEndMixedReturnWithSum() {
+    String cypher = "MATCH (a:User)-[:FOLLOWS]->(b:User) RETURN a.id, sum(b.age) LIMIT 100";
+    String sql = _translator.translate(cypher);
+
+    assertEquals(sql,
+        "SELECT a.user_id, SUM(b.age) FROM follows_table AS e "
+            + "JOIN users_table AS a ON e.follower_id = a.user_id "
+            + "JOIN users_table AS b ON e.followee_id = b.user_id "
+            + "GROUP BY a.user_id "
+            + "LIMIT 100");
+  }
+
+  @Test
+  public void testEndToEndSumWithResultAlias() {
+    String cypher =
+        "MATCH (a:User {id: 1})-[:FOLLOWS]->(b:User) RETURN sum(b.age) AS totalAge LIMIT 100";
+    String sql = _translator.translate(cypher);
+
+    assertEquals(sql,
+        "SELECT SUM(b.age) AS totalAge FROM follows_table AS e "
+            + "JOIN users_table AS a ON e.follower_id = a.user_id "
+            + "JOIN users_table AS b ON e.followee_id = b.user_id "
+            + "WHERE a.user_id = 1 "
+            + "LIMIT 100");
+  }
+
+  // ---- String predicate end-to-end tests ----
+
+  @Test
+  public void testEndToEndStartsWith() {
+    String cypher =
+        "MATCH (a:User)-[:FOLLOWS]->(b:User) WHERE a.name STARTS WITH 'Al' RETURN b.id LIMIT 100";
+    String sql = _translator.translate(cypher);
+
+    assertEquals(sql,
+        "SELECT b.user_id FROM follows_table AS e "
+            + "JOIN users_table AS a ON e.follower_id = a.user_id "
+            + "JOIN users_table AS b ON e.followee_id = b.user_id "
+            + "WHERE a.user_name LIKE 'Al%' "
+            + "LIMIT 100");
+  }
+
+  @Test
+  public void testEndToEndEndsWith() {
+    String cypher =
+        "MATCH (a:User)-[:FOLLOWS]->(b:User) WHERE a.name ENDS WITH 'ice' RETURN b.id LIMIT 100";
+    String sql = _translator.translate(cypher);
+
+    assertEquals(sql,
+        "SELECT b.user_id FROM follows_table AS e "
+            + "JOIN users_table AS a ON e.follower_id = a.user_id "
+            + "JOIN users_table AS b ON e.followee_id = b.user_id "
+            + "WHERE a.user_name LIKE '%ice' "
+            + "LIMIT 100");
+  }
+
+  @Test
+  public void testEndToEndContains() {
+    String cypher =
+        "MATCH (a:User)-[:FOLLOWS]->(b:User) WHERE a.name CONTAINS 'lic' RETURN b.id LIMIT 100";
+    String sql = _translator.translate(cypher);
+
+    assertEquals(sql,
+        "SELECT b.user_id FROM follows_table AS e "
+            + "JOIN users_table AS a ON e.follower_id = a.user_id "
+            + "JOIN users_table AS b ON e.followee_id = b.user_id "
+            + "WHERE a.user_name LIKE '%lic%' "
+            + "LIMIT 100");
+  }
+
+  // ---- IN list predicate end-to-end tests ----
+
+  @Test
+  public void testEndToEndInIntegerList() {
+    String cypher =
+        "MATCH (a:User)-[:FOLLOWS]->(b:User) WHERE a.id IN [1, 2, 3] RETURN b.id LIMIT 100";
+    String sql = _translator.translate(cypher);
+
+    assertEquals(sql,
+        "SELECT b.user_id FROM follows_table AS e "
+            + "JOIN users_table AS a ON e.follower_id = a.user_id "
+            + "JOIN users_table AS b ON e.followee_id = b.user_id "
+            + "WHERE a.user_id IN (1, 2, 3) "
+            + "LIMIT 100");
+  }
+
+  @Test
+  public void testEndToEndInStringList() {
+    String cypher =
+        "MATCH (a:User)-[:FOLLOWS]->(b:User) WHERE a.name IN ['Alice', 'Bob'] RETURN b.id LIMIT 100";
+    String sql = _translator.translate(cypher);
+
+    assertEquals(sql,
+        "SELECT b.user_id FROM follows_table AS e "
+            + "JOIN users_table AS a ON e.follower_id = a.user_id "
+            + "JOIN users_table AS b ON e.followee_id = b.user_id "
+            + "WHERE a.user_name IN ('Alice', 'Bob') "
+            + "LIMIT 100");
+  }
+
+  @Test
+  public void testEndToEndStartsWithAndIn() {
+    String cypher =
+        "MATCH (a:User)-[:FOLLOWS]->(b:User) WHERE a.name STARTS WITH 'A' AND a.id IN [1, 2] RETURN b.id LIMIT 100";
+    String sql = _translator.translate(cypher);
+
+    assertEquals(sql,
+        "SELECT b.user_id FROM follows_table AS e "
+            + "JOIN users_table AS a ON e.follower_id = a.user_id "
+            + "JOIN users_table AS b ON e.followee_id = b.user_id "
+            + "WHERE (a.user_name LIKE 'A%' AND a.user_id IN (1, 2)) "
+            + "LIMIT 100");
+  }
+
+  // ---- 2-hop end-to-end tests ----
+
+  @Test
+  public void testEndToEndTwoHopOutgoing() {
+    CypherToSqlTranslator translator = new CypherToSqlTranslator(createTestSchema());
+    String sql = translator.translate(
+        "MATCH (a:User {id: 1})-[:FOLLOWS]->(b:User)-[:FOLLOWS]->(c:User) RETURN c.id LIMIT 100");
+
+    assertEquals(sql,
+        "SELECT c.user_id FROM follows_table AS e1 "
+            + "JOIN users_table AS a ON e1.follower_id = a.user_id "
+            + "JOIN users_table AS b ON e1.followee_id = b.user_id "
+            + "JOIN follows_table AS e2 ON e2.follower_id = b.user_id "
+            + "JOIN users_table AS c ON e2.followee_id = c.user_id "
+            + "WHERE a.user_id = 1 "
+            + "LIMIT 100");
+  }
+
+  @Test
+  public void testEndToEndTwoHopWithDifferentVertexLabels() {
+    CypherToSqlTranslator translator = new CypherToSqlTranslator(createSchemaWithLikes());
+    String sql = translator.translate(
+        "MATCH (a:User {id: 1})-[:FOLLOWS]->(b:User)-[:LIKES]->(c:Post) RETURN c.title LIMIT 100");
+
+    assertEquals(sql,
+        "SELECT c.post_title FROM follows_table AS e1 "
+            + "JOIN users_table AS a ON e1.follower_id = a.user_id "
+            + "JOIN users_table AS b ON e1.followee_id = b.user_id "
+            + "JOIN likes_table AS e2 ON e2.liker_id = b.user_id "
+            + "JOIN posts_table AS c ON e2.post_id = c.post_id "
+            + "WHERE a.user_id = 1 "
+            + "LIMIT 100");
+  }
+
+  @Test
+  public void testEndToEndTwoHopMixedDirection() {
+    CypherToSqlTranslator translator = new CypherToSqlTranslator(createTestSchema());
+    String sql = translator.translate(
+        "MATCH (a:User {id: 1})-[:FOLLOWS]->(b:User)<-[:FOLLOWS]-(c:User) RETURN c.id LIMIT 100");
+
+    assertEquals(sql,
+        "SELECT c.user_id FROM follows_table AS e1 "
+            + "JOIN users_table AS a ON e1.follower_id = a.user_id "
+            + "JOIN users_table AS b ON e1.followee_id = b.user_id "
+            + "JOIN follows_table AS e2 ON e2.followee_id = b.user_id "
+            + "JOIN users_table AS c ON e2.follower_id = c.user_id "
+            + "WHERE a.user_id = 1 "
+            + "LIMIT 100");
+  }
+
+  @Test
+  public void testEndToEndTwoHopWithWhereOnLastNode() {
+    CypherToSqlTranslator translator = new CypherToSqlTranslator(createTestSchema());
+    String sql = translator.translate(
+        "MATCH (a:User {id: 1})-[:FOLLOWS]->(b:User)-[:FOLLOWS]->(c:User) "
+            + "WHERE c.name = 'Alice' RETURN c.id LIMIT 100");
+
+    assertTrue(sql.contains("a.user_id = 1"));
+    assertTrue(sql.contains("c.user_name = 'Alice'"));
+  }
+
+  @Test(expectedExceptions = CypherParseException.class,
+      expectedExceptionsMessageRegExp = ".*At most 2-hop patterns are supported.*")
+  public void testEndToEndRejectThreeHop() {
+    _translator.translate(
+        "MATCH (a:User)-[:FOLLOWS]->(b:User)-[:FOLLOWS]->(c:User)-[:FOLLOWS]->(d:User) RETURN d.id");
+  }
+
+  // ---- Helper methods ----
+
+  private static GraphSchemaConfig createSchemaWithLikes() {
+    Map<String, String> userProperties = new HashMap<>();
+    userProperties.put("id", "user_id");
+    userProperties.put("name", "user_name");
+
+    Map<String, String> postProperties = new HashMap<>();
+    postProperties.put("id", "post_id");
+    postProperties.put("title", "post_title");
+
+    GraphSchemaConfig.VertexLabel userLabel =
+        new GraphSchemaConfig.VertexLabel("users_table", "user_id", userProperties);
+    GraphSchemaConfig.VertexLabel postLabel =
+        new GraphSchemaConfig.VertexLabel("posts_table", "post_id", postProperties);
+
+    Map<String, GraphSchemaConfig.VertexLabel> vertexLabels = new HashMap<>();
+    vertexLabels.put("User", userLabel);
+    vertexLabels.put("Post", postLabel);
+
+    GraphSchemaConfig.EdgeLabel followsLabel =
+        new GraphSchemaConfig.EdgeLabel("follows_table", "User", "follower_id", "User", "followee_id",
+            Map.of());
+    GraphSchemaConfig.EdgeLabel likesLabel =
+        new GraphSchemaConfig.EdgeLabel("likes_table", "User", "liker_id", "Post", "post_id",
+            Map.of());
+
+    Map<String, GraphSchemaConfig.EdgeLabel> edgeLabels = new HashMap<>();
+    edgeLabels.put("FOLLOWS", followsLabel);
+    edgeLabels.put("LIKES", likesLabel);
+
+    return new GraphSchemaConfig(vertexLabels, edgeLabels);
+  }
+
+  private static GraphSchemaConfig createTestSchema() {
+    Map<String, String> userProperties = new HashMap<>();
+    userProperties.put("id", "user_id");
+    userProperties.put("name", "user_name");
+
+    GraphSchemaConfig.VertexLabel userLabel =
+        new GraphSchemaConfig.VertexLabel("users_table", "user_id", userProperties);
+
+    Map<String, GraphSchemaConfig.VertexLabel> vertexLabels = new HashMap<>();
+    vertexLabels.put("User", userLabel);
+
+    GraphSchemaConfig.EdgeLabel followsLabel =
+        new GraphSchemaConfig.EdgeLabel("follows_table", "User", "follower_id", "User", "followee_id",
+            Map.of());
+
+    Map<String, GraphSchemaConfig.EdgeLabel> edgeLabels = new HashMap<>();
+    edgeLabels.put("FOLLOWS", followsLabel);
+
+    return new GraphSchemaConfig(vertexLabels, edgeLabels);
+  }
+
+  private static GraphSchemaConfig createSchemaWithPost() {
+    Map<String, String> userProperties = new HashMap<>();
+    userProperties.put("id", "user_id");
+    userProperties.put("name", "user_name");
+
+    Map<String, String> postProperties = new HashMap<>();
+    postProperties.put("id", "post_id");
+    postProperties.put("title", "post_title");
+
+    GraphSchemaConfig.VertexLabel userLabel =
+        new GraphSchemaConfig.VertexLabel("users_table", "user_id", userProperties);
+    GraphSchemaConfig.VertexLabel postLabel =
+        new GraphSchemaConfig.VertexLabel("posts_table", "post_id", postProperties);
+
+    Map<String, GraphSchemaConfig.VertexLabel> vertexLabels = new HashMap<>();
+    vertexLabels.put("User", userLabel);
+    vertexLabels.put("Post", postLabel);
+
+    GraphSchemaConfig.EdgeLabel followsLabel =
+        new GraphSchemaConfig.EdgeLabel("follows_table", "User", "follower_id", "User", "followee_id",
+            Map.of());
+    GraphSchemaConfig.EdgeLabel authoredLabel =
+        new GraphSchemaConfig.EdgeLabel("authored_table", "User", "author_id", "Post", "post_id",
+            Map.of());
+
+    Map<String, GraphSchemaConfig.EdgeLabel> edgeLabels = new HashMap<>();
+    edgeLabels.put("FOLLOWS", followsLabel);
+    edgeLabels.put("AUTHORED", authoredLabel);
+
+    return new GraphSchemaConfig(vertexLabels, edgeLabels);
+  }
+}

--- a/pinot-graph/pinot-graph-planner/src/test/java/org/apache/pinot/graph/planner/LoweringGoldenTest.java
+++ b/pinot-graph/pinot-graph-planner/src/test/java/org/apache/pinot/graph/planner/LoweringGoldenTest.java
@@ -1,0 +1,365 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.graph.planner;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.pinot.graph.spi.GraphSchemaConfig;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+
+/**
+ * Golden tests for the Cypher-to-SQL lowering pipeline.
+ *
+ * <p>Each test verifies the exact SQL output produced from a Cypher query,
+ * ensuring the full end-to-end lowering is correct and stable.</p>
+ */
+public class LoweringGoldenTest {
+
+  // ---- Schema: social network (User -FOLLOWS-> User) ----
+
+  private static GraphSchemaConfig createSocialSchema() {
+    Map<String, String> userProperties = new HashMap<>();
+    userProperties.put("id", "user_id");
+    userProperties.put("name", "user_name");
+
+    GraphSchemaConfig.VertexLabel userLabel =
+        new GraphSchemaConfig.VertexLabel("users_table", "user_id", userProperties);
+
+    Map<String, GraphSchemaConfig.VertexLabel> vertexLabels = new HashMap<>();
+    vertexLabels.put("User", userLabel);
+
+    GraphSchemaConfig.EdgeLabel followsLabel =
+        new GraphSchemaConfig.EdgeLabel("follows_table", "User", "follower_id", "User", "followee_id",
+            Map.of());
+
+    Map<String, GraphSchemaConfig.EdgeLabel> edgeLabels = new HashMap<>();
+    edgeLabels.put("FOLLOWS", followsLabel);
+
+    return new GraphSchemaConfig(vertexLabels, edgeLabels);
+  }
+
+  // ---- Schema: content platform (User -AUTHORED-> Article) ----
+
+  private static GraphSchemaConfig createContentSchema() {
+    Map<String, String> userProperties = new HashMap<>();
+    userProperties.put("id", "uid");
+    userProperties.put("email", "email_addr");
+
+    Map<String, String> articleProperties = new HashMap<>();
+    articleProperties.put("id", "article_id");
+    articleProperties.put("title", "headline");
+    articleProperties.put("body", "content_body");
+
+    GraphSchemaConfig.VertexLabel userLabel =
+        new GraphSchemaConfig.VertexLabel("members", "uid", userProperties);
+    GraphSchemaConfig.VertexLabel articleLabel =
+        new GraphSchemaConfig.VertexLabel("articles", "article_id", articleProperties);
+
+    Map<String, GraphSchemaConfig.VertexLabel> vertexLabels = new HashMap<>();
+    vertexLabels.put("Author", userLabel);
+    vertexLabels.put("Article", articleLabel);
+
+    GraphSchemaConfig.EdgeLabel wroteLabel =
+        new GraphSchemaConfig.EdgeLabel("writes", "Author", "writer_uid", "Article", "written_article_id",
+            Map.of());
+
+    Map<String, GraphSchemaConfig.EdgeLabel> edgeLabels = new HashMap<>();
+    edgeLabels.put("WROTE", wroteLabel);
+
+    return new GraphSchemaConfig(vertexLabels, edgeLabels);
+  }
+
+  // ---- Test 1: Basic 1-hop outgoing query ----
+
+  @Test
+  public void testBasicOneHopOutgoing() {
+    CypherToSqlTranslator translator = new CypherToSqlTranslator(createSocialSchema());
+    String sql = translator.translate(
+        "MATCH (a:User {id: '123'})-[:FOLLOWS]->(b:User) RETURN b.id LIMIT 100");
+
+    assertEquals(sql,
+        "SELECT b.user_id FROM follows_table AS e "
+            + "JOIN users_table AS a ON e.follower_id = a.user_id "
+            + "JOIN users_table AS b ON e.followee_id = b.user_id "
+            + "WHERE a.user_id = '123' "
+            + "LIMIT 100");
+  }
+
+  // ---- Test 2: 1-hop incoming query (reversed join direction) ----
+
+  @Test
+  public void testOneHopIncoming() {
+    CypherToSqlTranslator translator = new CypherToSqlTranslator(createSocialSchema());
+    String sql = translator.translate(
+        "MATCH (a:User {id: '456'})<-[:FOLLOWS]-(b:User) RETURN b.id LIMIT 50");
+
+    // Incoming: a is the followee (target in schema), b is the follower (source in schema)
+    // JOIN keys are swapped: source uses targetKey, target uses sourceKey
+    assertEquals(sql,
+        "SELECT b.user_id FROM follows_table AS e "
+            + "JOIN users_table AS a ON e.followee_id = a.user_id "
+            + "JOIN users_table AS b ON e.follower_id = b.user_id "
+            + "WHERE a.user_id = '456' "
+            + "LIMIT 50");
+  }
+
+  // ---- Test 3: Multiple property filters on source node ----
+
+  @Test
+  public void testMultiplePropertyFiltersOnSource() {
+    CypherToSqlTranslator translator = new CypherToSqlTranslator(createSocialSchema());
+    String sql = translator.translate(
+        "MATCH (a:User {id: '789', name: 'alice'})-[:FOLLOWS]->(b:User) RETURN b.name LIMIT 10");
+
+    assertEquals(sql,
+        "SELECT b.user_name FROM follows_table AS e "
+            + "JOIN users_table AS a ON e.follower_id = a.user_id "
+            + "JOIN users_table AS b ON e.followee_id = b.user_id "
+            + "WHERE a.user_id = '789' AND a.user_name = 'alice' "
+            + "LIMIT 10");
+  }
+
+  // ---- Test 4: Multiple return columns ----
+
+  @Test
+  public void testMultipleReturnColumns() {
+    CypherToSqlTranslator translator = new CypherToSqlTranslator(createSocialSchema());
+    String sql = translator.translate(
+        "MATCH (a:User {id: '42'})-[:FOLLOWS]->(b:User) RETURN b.id, b.name, a.name");
+
+    assertEquals(sql,
+        "SELECT b.user_id, b.user_name, a.user_name FROM follows_table AS e "
+            + "JOIN users_table AS a ON e.follower_id = a.user_id "
+            + "JOIN users_table AS b ON e.followee_id = b.user_id "
+            + "WHERE a.user_id = '42'");
+  }
+
+  // ---- Test 5: Query without LIMIT ----
+
+  @Test
+  public void testQueryWithoutLimit() {
+    CypherToSqlTranslator translator = new CypherToSqlTranslator(createSocialSchema());
+    String sql = translator.translate(
+        "MATCH (a:User {id: '1'})-[:FOLLOWS]->(b:User) RETURN b.id");
+
+    assertEquals(sql,
+        "SELECT b.user_id FROM follows_table AS e "
+            + "JOIN users_table AS a ON e.follower_id = a.user_id "
+            + "JOIN users_table AS b ON e.followee_id = b.user_id "
+            + "WHERE a.user_id = '1'");
+  }
+
+  // ---- Test 6: Different table/column names in schema ----
+
+  @Test
+  public void testDifferentSchemaTableColumnNames() {
+    CypherToSqlTranslator translator = new CypherToSqlTranslator(createContentSchema());
+    String sql = translator.translate(
+        "MATCH (a:Author {id: '99'})-[:WROTE]->(b:Article) RETURN b.title LIMIT 25");
+
+    assertEquals(sql,
+        "SELECT b.headline FROM writes AS e "
+            + "JOIN members AS a ON e.writer_uid = a.uid "
+            + "JOIN articles AS b ON e.written_article_id = b.article_id "
+            + "WHERE a.uid = '99' "
+            + "LIMIT 25");
+  }
+
+  // ---- Test 7: String values with special characters (single quotes) ----
+
+  @Test
+  public void testStringWithSingleQuotes() {
+    CypherToSqlTranslator translator = new CypherToSqlTranslator(createSocialSchema());
+    String sql = translator.translate(
+        "MATCH (a:User {name: 'O\\'Brien'})-[:FOLLOWS]->(b:User) RETURN b.id LIMIT 10");
+
+    // Single quote in the value should be escaped as '' in the SQL output
+    assertEquals(sql,
+        "SELECT b.user_id FROM follows_table AS e "
+            + "JOIN users_table AS a ON e.follower_id = a.user_id "
+            + "JOIN users_table AS b ON e.followee_id = b.user_id "
+            + "WHERE a.user_name = 'O''Brien' "
+            + "LIMIT 10");
+  }
+
+  // ---- Test 8: String values with backslashes ----
+
+  @Test
+  public void testStringWithBackslashes() {
+    CypherToSqlTranslator translator = new CypherToSqlTranslator(createSocialSchema());
+    String sql = translator.translate(
+        "MATCH (a:User {name: 'path\\\\to\\\\file'})-[:FOLLOWS]->(b:User) RETURN b.id");
+
+    // Backslashes in the value should be escaped as \\\\ in the SQL output
+    assertEquals(sql,
+        "SELECT b.user_id FROM follows_table AS e "
+            + "JOIN users_table AS a ON e.follower_id = a.user_id "
+            + "JOIN users_table AS b ON e.followee_id = b.user_id "
+            + "WHERE a.user_name = 'path\\\\to\\\\file'");
+  }
+
+  // ---- Test 9: Integer property values ----
+
+  @Test
+  public void testIntegerPropertyValue() {
+    CypherToSqlTranslator translator = new CypherToSqlTranslator(createSocialSchema());
+    // 'age' is not in the property map, so it falls back to column name 'age'
+    String sql = translator.translate(
+        "MATCH (a:User {age: 30})-[:FOLLOWS]->(b:User) RETURN b.name LIMIT 5");
+
+    assertEquals(sql,
+        "SELECT b.user_name FROM follows_table AS e "
+            + "JOIN users_table AS a ON e.follower_id = a.user_id "
+            + "JOIN users_table AS b ON e.followee_id = b.user_id "
+            + "WHERE a.age = 30 "
+            + "LIMIT 5");
+  }
+
+  // ---- Test 10: No property filters at all ----
+
+  @Test
+  public void testNoPropertyFilters() {
+    CypherToSqlTranslator translator = new CypherToSqlTranslator(createSocialSchema());
+    String sql = translator.translate(
+        "MATCH (a:User)-[:FOLLOWS]->(b:User) RETURN b.id LIMIT 200");
+
+    assertEquals(sql,
+        "SELECT b.user_id FROM follows_table AS e "
+            + "JOIN users_table AS a ON e.follower_id = a.user_id "
+            + "JOIN users_table AS b ON e.followee_id = b.user_id "
+            + "LIMIT 200");
+  }
+
+  // ---- Test 11: Incoming with different vertex labels ----
+
+  @Test
+  public void testIncomingWithDifferentVertexLabels() {
+    CypherToSqlTranslator translator = new CypherToSqlTranslator(createContentSchema());
+    // "Who wrote this article?" — incoming from Article perspective
+    String sql = translator.translate(
+        "MATCH (b:Article {id: '500'})<-[:WROTE]-(a:Author) RETURN a.email");
+
+    // Incoming: b is the article (target in schema), a is the author (source in schema)
+    assertEquals(sql,
+        "SELECT a.email_addr FROM writes AS e "
+            + "JOIN articles AS b ON e.written_article_id = b.article_id "
+            + "JOIN members AS a ON e.writer_uid = a.uid "
+            + "WHERE b.article_id = '500'");
+  }
+
+  // ---- Test 12: Return alias without property (returns primary key) ----
+
+  @Test
+  public void testReturnAliasWithoutProperty() {
+    CypherToSqlTranslator translator = new CypherToSqlTranslator(createSocialSchema());
+    String sql = translator.translate(
+        "MATCH (a:User {id: '1'})-[:FOLLOWS]->(b:User) RETURN b LIMIT 10");
+
+    // When no property specified, should return primary key
+    assertEquals(sql,
+        "SELECT b.user_id FROM follows_table AS e "
+            + "JOIN users_table AS a ON e.follower_id = a.user_id "
+            + "JOIN users_table AS b ON e.followee_id = b.user_id "
+            + "WHERE a.user_id = '1' "
+            + "LIMIT 10");
+  }
+
+  // ---- Test 13: Edge with named alias ----
+
+  @Test
+  public void testEdgeWithNamedAlias() {
+    CypherToSqlTranslator translator = new CypherToSqlTranslator(createSocialSchema());
+    String sql = translator.translate(
+        "MATCH (a:User {id: '1'})-[r:FOLLOWS]->(b:User) RETURN b.id LIMIT 10");
+
+    // The edge alias 'r' should be used as the edge table alias
+    assertEquals(sql,
+        "SELECT b.user_id FROM follows_table AS r "
+            + "JOIN users_table AS a ON r.follower_id = a.user_id "
+            + "JOIN users_table AS b ON r.followee_id = b.user_id "
+            + "WHERE a.user_id = '1' "
+            + "LIMIT 10");
+  }
+
+  // ---- Test 14: Explain output contains expected sections ----
+
+  @Test
+  public void testExplainContainsSections() {
+    CypherToSqlTranslator translator = new CypherToSqlTranslator(createSocialSchema());
+    String explain = translator.explain(
+        "MATCH (a:User {id: '123'})-[:FOLLOWS]->(b:User) RETURN b.id LIMIT 100");
+
+    assertTrue(explain.contains("=== Cypher to SQL Explain ==="));
+    assertTrue(explain.contains("--- Parsed AST Summary ---"));
+    assertTrue(explain.contains("--- Schema Bindings ---"));
+    assertTrue(explain.contains("--- Join Structure ---"));
+    assertTrue(explain.contains("--- Generated SQL ---"));
+
+    // Verify AST summary content
+    assertTrue(explain.contains("MATCH:"));
+    assertTrue(explain.contains(":User"));
+    assertTrue(explain.contains("FOLLOWS"));
+    assertTrue(explain.contains("RETURN: b.id"));
+    assertTrue(explain.contains("LIMIT: 100"));
+
+    // Verify schema bindings content
+    assertTrue(explain.contains("Vertex User -> table 'users_table'"));
+    assertTrue(explain.contains("Edge FOLLOWS -> table 'follows_table'"));
+
+    // Verify join structure content
+    assertTrue(explain.contains("Direction: outgoing"));
+    assertTrue(explain.contains("1-hop relational join"));
+
+    // Verify SQL is included
+    assertTrue(explain.contains("SELECT b.user_id FROM follows_table"));
+  }
+
+  // ---- Test 15: Explain for incoming edge ----
+
+  @Test
+  public void testExplainIncoming() {
+    CypherToSqlTranslator translator = new CypherToSqlTranslator(createSocialSchema());
+    String explain = translator.explain(
+        "MATCH (a:User {id: '99'})<-[:FOLLOWS]-(b:User) RETURN b.id");
+
+    assertTrue(explain.contains("Direction: incoming"));
+    assertTrue(explain.contains("reversed for INCOMING"));
+    assertTrue(explain.contains("Filters:"));
+    assertTrue(explain.contains("source.id = '99'"));
+  }
+
+  // ---- Test 16: Property that maps to a different column name ----
+
+  @Test
+  public void testPropertyColumnMapping() {
+    CypherToSqlTranslator translator = new CypherToSqlTranslator(createContentSchema());
+    String sql = translator.translate(
+        "MATCH (a:Author {email: 'test@example.com'})-[:WROTE]->(b:Article) RETURN b.title, b.body");
+
+    // 'email' maps to 'email_addr', 'title' maps to 'headline', 'body' maps to 'content_body'
+    assertEquals(sql,
+        "SELECT b.headline, b.content_body FROM writes AS e "
+            + "JOIN members AS a ON e.writer_uid = a.uid "
+            + "JOIN articles AS b ON e.written_article_id = b.article_id "
+            + "WHERE a.email_addr = 'test@example.com'");
+  }
+}

--- a/pinot-graph/pinot-graph-planner/src/test/java/org/apache/pinot/graph/planner/SqlGeneratorTest.java
+++ b/pinot-graph/pinot-graph-planner/src/test/java/org/apache/pinot/graph/planner/SqlGeneratorTest.java
@@ -1,0 +1,1260 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.graph.planner;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.apache.pinot.graph.spi.GraphSchemaConfig;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+
+/**
+ * Tests for SQL generation from Cypher IR.
+ */
+public class SqlGeneratorTest {
+
+  private GraphSchemaConfig _schemaConfig;
+  private SqlGenerator _sqlGenerator;
+
+  @BeforeMethod
+  public void setUp() {
+    _schemaConfig = createTestSchema();
+    _sqlGenerator = new SqlGenerator(_schemaConfig);
+  }
+
+  @Test
+  public void testBasicOutgoingTraversal() {
+    // MATCH (a:User {id: '123'})-[:FOLLOWS]->(b:User) RETURN b.id LIMIT 100
+    Map<String, Object> sourceProps = new LinkedHashMap<>();
+    sourceProps.put("id", "123");
+
+    CypherIR.NodePattern source = new CypherIR.NodePattern("a", "User", sourceProps);
+    CypherIR.RelationshipPattern edge =
+        new CypherIR.RelationshipPattern(null, "FOLLOWS", CypherIR.Direction.OUTGOING);
+    CypherIR.NodePattern target = new CypherIR.NodePattern("b", "User", null);
+
+    CypherIR.MatchClause matchClause = new CypherIR.MatchClause(source, edge, target);
+    CypherIR.ReturnClause returnClause = new CypherIR.ReturnClause(
+        Collections.singletonList(new CypherIR.ReturnItem("b", "id")));
+    CypherIR.LimitClause limitClause = new CypherIR.LimitClause(100);
+
+    CypherIR.CypherQuery query = new CypherIR.CypherQuery(matchClause, returnClause, limitClause);
+
+    String sql = _sqlGenerator.generate(query);
+
+    assertEquals(sql,
+        "SELECT b.user_id FROM follows_table AS e "
+            + "JOIN users_table AS a ON e.follower_id = a.user_id "
+            + "JOIN users_table AS b ON e.followee_id = b.user_id "
+            + "WHERE a.user_id = '123' "
+            + "LIMIT 100");
+  }
+
+  @Test
+  public void testMultipleReturnColumns() {
+    Map<String, Object> sourceProps = new LinkedHashMap<>();
+    sourceProps.put("id", "123");
+
+    CypherIR.NodePattern source = new CypherIR.NodePattern("a", "User", sourceProps);
+    CypherIR.RelationshipPattern edge =
+        new CypherIR.RelationshipPattern(null, "FOLLOWS", CypherIR.Direction.OUTGOING);
+    CypherIR.NodePattern target = new CypherIR.NodePattern("b", "User", null);
+
+    CypherIR.MatchClause matchClause = new CypherIR.MatchClause(source, edge, target);
+    CypherIR.ReturnClause returnClause = new CypherIR.ReturnClause(
+        Arrays.asList(new CypherIR.ReturnItem("b", "id"), new CypherIR.ReturnItem("b", "name")));
+
+    CypherIR.CypherQuery query = new CypherIR.CypherQuery(matchClause, returnClause, null);
+
+    String sql = _sqlGenerator.generate(query);
+
+    assertEquals(sql,
+        "SELECT b.user_id, b.user_name FROM follows_table AS e "
+            + "JOIN users_table AS a ON e.follower_id = a.user_id "
+            + "JOIN users_table AS b ON e.followee_id = b.user_id "
+            + "WHERE a.user_id = '123'");
+  }
+
+  @Test
+  public void testNoPropertyFilters() {
+    CypherIR.NodePattern source = new CypherIR.NodePattern("a", "User", null);
+    CypherIR.RelationshipPattern edge =
+        new CypherIR.RelationshipPattern(null, "FOLLOWS", CypherIR.Direction.OUTGOING);
+    CypherIR.NodePattern target = new CypherIR.NodePattern("b", "User", null);
+
+    CypherIR.MatchClause matchClause = new CypherIR.MatchClause(source, edge, target);
+    CypherIR.ReturnClause returnClause = new CypherIR.ReturnClause(
+        Collections.singletonList(new CypherIR.ReturnItem("b", "id")));
+
+    CypherIR.CypherQuery query = new CypherIR.CypherQuery(matchClause, returnClause, null);
+
+    String sql = _sqlGenerator.generate(query);
+
+    // No WHERE clause expected
+    assertFalse(sql.contains("WHERE"));
+    assertTrue(sql.startsWith("SELECT b.user_id FROM follows_table AS e"));
+  }
+
+  @Test
+  public void testIncomingTraversal() {
+    Map<String, Object> sourceProps = new LinkedHashMap<>();
+    sourceProps.put("id", "456");
+
+    CypherIR.NodePattern source = new CypherIR.NodePattern("a", "User", sourceProps);
+    CypherIR.RelationshipPattern edge =
+        new CypherIR.RelationshipPattern(null, "FOLLOWS", CypherIR.Direction.INCOMING);
+    CypherIR.NodePattern target = new CypherIR.NodePattern("b", "User", null);
+
+    CypherIR.MatchClause matchClause = new CypherIR.MatchClause(source, edge, target);
+    CypherIR.ReturnClause returnClause = new CypherIR.ReturnClause(
+        Collections.singletonList(new CypherIR.ReturnItem("b", "id")));
+
+    CypherIR.CypherQuery query = new CypherIR.CypherQuery(matchClause, returnClause, null);
+
+    String sql = _sqlGenerator.generate(query);
+
+    // For incoming: source in query maps to target in schema, so:
+    // JOIN source on e.followee_id = a.user_id (source sees the target key)
+    // JOIN target on e.follower_id = b.user_id (target sees the source key)
+    assertEquals(sql,
+        "SELECT b.user_id FROM follows_table AS e "
+            + "JOIN users_table AS a ON e.followee_id = a.user_id "
+            + "JOIN users_table AS b ON e.follower_id = b.user_id "
+            + "WHERE a.user_id = '456'");
+  }
+
+  @Test
+  public void testIntegerPropertyFilter() {
+    Map<String, Object> sourceProps = new LinkedHashMap<>();
+    sourceProps.put("age", 25L);
+
+    CypherIR.NodePattern source = new CypherIR.NodePattern("a", "User", sourceProps);
+    CypherIR.RelationshipPattern edge =
+        new CypherIR.RelationshipPattern(null, "FOLLOWS", CypherIR.Direction.OUTGOING);
+    CypherIR.NodePattern target = new CypherIR.NodePattern("b", "User", null);
+
+    CypherIR.MatchClause matchClause = new CypherIR.MatchClause(source, edge, target);
+    CypherIR.ReturnClause returnClause = new CypherIR.ReturnClause(
+        Collections.singletonList(new CypherIR.ReturnItem("b", "id")));
+
+    CypherIR.CypherQuery query = new CypherIR.CypherQuery(matchClause, returnClause, null);
+
+    String sql = _sqlGenerator.generate(query);
+
+    // 'age' is not in the property map, so it falls back to column name 'age'
+    assertTrue(sql.contains("WHERE a.age = 25"));
+  }
+
+  @Test
+  public void testStringEscaping() {
+    Map<String, Object> sourceProps = new LinkedHashMap<>();
+    sourceProps.put("name", "O'Brien");
+
+    CypherIR.NodePattern source = new CypherIR.NodePattern("a", "User", sourceProps);
+    CypherIR.RelationshipPattern edge =
+        new CypherIR.RelationshipPattern(null, "FOLLOWS", CypherIR.Direction.OUTGOING);
+    CypherIR.NodePattern target = new CypherIR.NodePattern("b", "User", null);
+
+    CypherIR.MatchClause matchClause = new CypherIR.MatchClause(source, edge, target);
+    CypherIR.ReturnClause returnClause = new CypherIR.ReturnClause(
+        Collections.singletonList(new CypherIR.ReturnItem("b", "id")));
+
+    CypherIR.CypherQuery query = new CypherIR.CypherQuery(matchClause, returnClause, null);
+
+    String sql = _sqlGenerator.generate(query);
+
+    assertTrue(sql.contains("O''Brien"));
+  }
+
+  @Test
+  public void testReturnAliasWithoutProperty() {
+    CypherIR.NodePattern source = new CypherIR.NodePattern("a", "User", null);
+    CypherIR.RelationshipPattern edge =
+        new CypherIR.RelationshipPattern(null, "FOLLOWS", CypherIR.Direction.OUTGOING);
+    CypherIR.NodePattern target = new CypherIR.NodePattern("b", "User", null);
+
+    CypherIR.MatchClause matchClause = new CypherIR.MatchClause(source, edge, target);
+    CypherIR.ReturnClause returnClause = new CypherIR.ReturnClause(
+        Collections.singletonList(new CypherIR.ReturnItem("b", null)));
+
+    CypherIR.CypherQuery query = new CypherIR.CypherQuery(matchClause, returnClause, null);
+
+    String sql = _sqlGenerator.generate(query);
+
+    // When no property is specified, should return primary key
+    assertTrue(sql.contains("SELECT b.user_id"));
+  }
+
+  @Test
+  public void testDistinctSelect() {
+    CypherIR.NodePattern source = new CypherIR.NodePattern("a", "User", null);
+    CypherIR.RelationshipPattern edge =
+        new CypherIR.RelationshipPattern(null, "FOLLOWS", CypherIR.Direction.OUTGOING);
+    CypherIR.NodePattern target = new CypherIR.NodePattern("b", "User", null);
+
+    CypherIR.MatchClause matchClause = new CypherIR.MatchClause(source, edge, target);
+    CypherIR.ReturnClause returnClause = new CypherIR.ReturnClause(
+        Collections.singletonList(new CypherIR.ReturnItem("b", "id")), true);
+    CypherIR.LimitClause limitClause = new CypherIR.LimitClause(100);
+
+    CypherIR.CypherQuery query = new CypherIR.CypherQuery(matchClause, returnClause, limitClause);
+
+    String sql = _sqlGenerator.generate(query);
+
+    assertEquals(sql,
+        "SELECT DISTINCT b.user_id FROM follows_table AS e "
+            + "JOIN users_table AS a ON e.follower_id = a.user_id "
+            + "JOIN users_table AS b ON e.followee_id = b.user_id "
+            + "LIMIT 100");
+  }
+
+  @Test
+  public void testBooleanPropertyFilter() {
+    Map<String, Object> sourceProps = new LinkedHashMap<>();
+    sourceProps.put("active", Boolean.TRUE);
+
+    CypherIR.NodePattern source = new CypherIR.NodePattern("a", "User", sourceProps);
+    CypherIR.RelationshipPattern edge =
+        new CypherIR.RelationshipPattern(null, "FOLLOWS", CypherIR.Direction.OUTGOING);
+    CypherIR.NodePattern target = new CypherIR.NodePattern("b", "User", null);
+
+    CypherIR.MatchClause matchClause = new CypherIR.MatchClause(source, edge, target);
+    CypherIR.ReturnClause returnClause = new CypherIR.ReturnClause(
+        Collections.singletonList(new CypherIR.ReturnItem("b", "id")));
+
+    CypherIR.CypherQuery query = new CypherIR.CypherQuery(matchClause, returnClause, null);
+
+    String sql = _sqlGenerator.generate(query);
+
+    assertTrue(sql.contains("WHERE a.active = true"));
+  }
+
+  @Test
+  public void testBooleanFalsePropertyFilter() {
+    Map<String, Object> sourceProps = new LinkedHashMap<>();
+    sourceProps.put("active", Boolean.FALSE);
+
+    CypherIR.NodePattern source = new CypherIR.NodePattern("a", "User", sourceProps);
+    CypherIR.RelationshipPattern edge =
+        new CypherIR.RelationshipPattern(null, "FOLLOWS", CypherIR.Direction.OUTGOING);
+    CypherIR.NodePattern target = new CypherIR.NodePattern("b", "User", null);
+
+    CypherIR.MatchClause matchClause = new CypherIR.MatchClause(source, edge, target);
+    CypherIR.ReturnClause returnClause = new CypherIR.ReturnClause(
+        Collections.singletonList(new CypherIR.ReturnItem("b", "id")));
+
+    CypherIR.CypherQuery query = new CypherIR.CypherQuery(matchClause, returnClause, null);
+
+    String sql = _sqlGenerator.generate(query);
+
+    assertTrue(sql.contains("WHERE a.active = false"));
+  }
+
+  // ---- WHERE clause tests ----
+
+  @Test
+  public void testWhereClauseSimpleEquals() {
+    CypherIR.NodePattern source = new CypherIR.NodePattern("a", "User", null);
+    CypherIR.RelationshipPattern edge =
+        new CypherIR.RelationshipPattern(null, "FOLLOWS", CypherIR.Direction.OUTGOING);
+    CypherIR.NodePattern target = new CypherIR.NodePattern("b", "User", null);
+
+    CypherIR.MatchClause matchClause = new CypherIR.MatchClause(source, edge, target);
+    CypherIR.ReturnClause returnClause = new CypherIR.ReturnClause(
+        Collections.singletonList(new CypherIR.ReturnItem("b", "id")));
+    CypherIR.WhereClause whereClause = new CypherIR.WhereClause(
+        new CypherIR.ComparisonPredicate("a", "id", "=", 1L));
+    CypherIR.LimitClause limitClause = new CypherIR.LimitClause(100);
+
+    CypherIR.CypherQuery query = new CypherIR.CypherQuery(matchClause, whereClause, returnClause, limitClause);
+
+    String sql = _sqlGenerator.generate(query);
+
+    assertEquals(sql,
+        "SELECT b.user_id FROM follows_table AS e "
+            + "JOIN users_table AS a ON e.follower_id = a.user_id "
+            + "JOIN users_table AS b ON e.followee_id = b.user_id "
+            + "WHERE a.user_id = 1 "
+            + "LIMIT 100");
+  }
+
+  @Test
+  public void testWhereClauseWithAndPredicate() {
+    CypherIR.NodePattern source = new CypherIR.NodePattern("a", "User", null);
+    CypherIR.RelationshipPattern edge =
+        new CypherIR.RelationshipPattern(null, "FOLLOWS", CypherIR.Direction.OUTGOING);
+    CypherIR.NodePattern target = new CypherIR.NodePattern("b", "User", null);
+
+    CypherIR.MatchClause matchClause = new CypherIR.MatchClause(source, edge, target);
+    CypherIR.ReturnClause returnClause = new CypherIR.ReturnClause(
+        Collections.singletonList(new CypherIR.ReturnItem("b", "name")));
+    CypherIR.WhereClause whereClause = new CypherIR.WhereClause(
+        new CypherIR.AndPredicate(
+            new CypherIR.ComparisonPredicate("a", "age", ">", 25L),
+            new CypherIR.ComparisonPredicate("b", "age", "<", 30L)));
+
+    CypherIR.CypherQuery query = new CypherIR.CypherQuery(matchClause, whereClause, returnClause, null);
+
+    String sql = _sqlGenerator.generate(query);
+
+    assertTrue(sql.contains("WHERE (a.age > 25 AND b.age < 30)"));
+  }
+
+  @Test
+  public void testWhereClauseWithOrPredicate() {
+    CypherIR.NodePattern source = new CypherIR.NodePattern("a", "User", null);
+    CypherIR.RelationshipPattern edge =
+        new CypherIR.RelationshipPattern(null, "FOLLOWS", CypherIR.Direction.OUTGOING);
+    CypherIR.NodePattern target = new CypherIR.NodePattern("b", "User", null);
+
+    CypherIR.MatchClause matchClause = new CypherIR.MatchClause(source, edge, target);
+    CypherIR.ReturnClause returnClause = new CypherIR.ReturnClause(
+        Collections.singletonList(new CypherIR.ReturnItem("b", "id")));
+    CypherIR.WhereClause whereClause = new CypherIR.WhereClause(
+        new CypherIR.OrPredicate(
+            new CypherIR.ComparisonPredicate("a", "name", "=", "Alice"),
+            new CypherIR.ComparisonPredicate("a", "name", "=", "Bob")));
+
+    CypherIR.CypherQuery query = new CypherIR.CypherQuery(matchClause, whereClause, returnClause, null);
+
+    String sql = _sqlGenerator.generate(query);
+
+    assertTrue(sql.contains("WHERE (a.user_name = 'Alice' OR a.user_name = 'Bob')"));
+  }
+
+  @Test
+  public void testWhereClauseWithNotPredicate() {
+    CypherIR.NodePattern source = new CypherIR.NodePattern("a", "User", null);
+    CypherIR.RelationshipPattern edge =
+        new CypherIR.RelationshipPattern(null, "FOLLOWS", CypherIR.Direction.OUTGOING);
+    CypherIR.NodePattern target = new CypherIR.NodePattern("b", "User", null);
+
+    CypherIR.MatchClause matchClause = new CypherIR.MatchClause(source, edge, target);
+    CypherIR.ReturnClause returnClause = new CypherIR.ReturnClause(
+        Collections.singletonList(new CypherIR.ReturnItem("b", "id")));
+    CypherIR.WhereClause whereClause = new CypherIR.WhereClause(
+        new CypherIR.NotPredicate(
+            new CypherIR.ComparisonPredicate("a", "active", "=", Boolean.FALSE)));
+
+    CypherIR.CypherQuery query = new CypherIR.CypherQuery(matchClause, whereClause, returnClause, null);
+
+    String sql = _sqlGenerator.generate(query);
+
+    assertTrue(sql.contains("WHERE (NOT a.active = false)"));
+  }
+
+  @Test
+  public void testWhereClauseCombinedWithInlineFilters() {
+    Map<String, Object> sourceProps = new LinkedHashMap<>();
+    sourceProps.put("id", "123");
+
+    CypherIR.NodePattern source = new CypherIR.NodePattern("a", "User", sourceProps);
+    CypherIR.RelationshipPattern edge =
+        new CypherIR.RelationshipPattern(null, "FOLLOWS", CypherIR.Direction.OUTGOING);
+    CypherIR.NodePattern target = new CypherIR.NodePattern("b", "User", null);
+
+    CypherIR.MatchClause matchClause = new CypherIR.MatchClause(source, edge, target);
+    CypherIR.ReturnClause returnClause = new CypherIR.ReturnClause(
+        Collections.singletonList(new CypherIR.ReturnItem("b", "id")));
+    CypherIR.WhereClause whereClause = new CypherIR.WhereClause(
+        new CypherIR.ComparisonPredicate("b", "name", "=", "Alice"));
+
+    CypherIR.CypherQuery query = new CypherIR.CypherQuery(matchClause, whereClause, returnClause, null);
+
+    String sql = _sqlGenerator.generate(query);
+
+    // Both inline filter and WHERE clause condition should be present
+    assertTrue(sql.contains("a.user_id = '123'"));
+    assertTrue(sql.contains("b.user_name = 'Alice'"));
+    assertTrue(sql.contains("WHERE"));
+  }
+
+  @Test
+  public void testWhereClausePropertyMapping() {
+    // 'name' maps to 'user_name' in schema; WHERE should use the mapped column
+    CypherIR.NodePattern source = new CypherIR.NodePattern("a", "User", null);
+    CypherIR.RelationshipPattern edge =
+        new CypherIR.RelationshipPattern(null, "FOLLOWS", CypherIR.Direction.OUTGOING);
+    CypherIR.NodePattern target = new CypherIR.NodePattern("b", "User", null);
+
+    CypherIR.MatchClause matchClause = new CypherIR.MatchClause(source, edge, target);
+    CypherIR.ReturnClause returnClause = new CypherIR.ReturnClause(
+        Collections.singletonList(new CypherIR.ReturnItem("b", "id")));
+    CypherIR.WhereClause whereClause = new CypherIR.WhereClause(
+        new CypherIR.ComparisonPredicate("a", "name", "<>", "test"));
+
+    CypherIR.CypherQuery query = new CypherIR.CypherQuery(matchClause, whereClause, returnClause, null);
+
+    String sql = _sqlGenerator.generate(query);
+
+    assertTrue(sql.contains("a.user_name <> 'test'"));
+  }
+
+  // ---- COUNT aggregation tests ----
+
+  @Test
+  public void testCountAggregation() {
+    CypherIR.NodePattern source = new CypherIR.NodePattern("a", "User", null);
+    CypherIR.RelationshipPattern edge =
+        new CypherIR.RelationshipPattern(null, "FOLLOWS", CypherIR.Direction.OUTGOING);
+    CypherIR.NodePattern target = new CypherIR.NodePattern("b", "User", null);
+
+    CypherIR.MatchClause matchClause = new CypherIR.MatchClause(source, edge, target);
+    CypherIR.ReturnClause returnClause = new CypherIR.ReturnClause(
+        Collections.singletonList(
+            new CypherIR.ReturnItem("b", "id", CypherIR.AggregationFunction.COUNT)));
+
+    CypherIR.CypherQuery query = new CypherIR.CypherQuery(matchClause, returnClause, null);
+
+    String sql = _sqlGenerator.generate(query);
+
+    assertTrue(sql.contains("SELECT COUNT(b.user_id)"));
+    assertFalse(sql.contains("GROUP BY"));
+  }
+
+  @Test
+  public void testCountStar() {
+    CypherIR.NodePattern source = new CypherIR.NodePattern("a", "User", null);
+    CypherIR.RelationshipPattern edge =
+        new CypherIR.RelationshipPattern(null, "FOLLOWS", CypherIR.Direction.OUTGOING);
+    CypherIR.NodePattern target = new CypherIR.NodePattern("b", "User", null);
+
+    CypherIR.MatchClause matchClause = new CypherIR.MatchClause(source, edge, target);
+    CypherIR.ReturnClause returnClause = new CypherIR.ReturnClause(
+        Collections.singletonList(
+            new CypherIR.ReturnItem(null, null, CypherIR.AggregationFunction.COUNT)));
+
+    CypherIR.CypherQuery query = new CypherIR.CypherQuery(matchClause, returnClause, null);
+
+    String sql = _sqlGenerator.generate(query);
+
+    assertTrue(sql.contains("SELECT COUNT(*)"));
+    assertFalse(sql.contains("GROUP BY"));
+  }
+
+  @Test
+  public void testCountDistinct() {
+    CypherIR.NodePattern source = new CypherIR.NodePattern("a", "User", null);
+    CypherIR.RelationshipPattern edge =
+        new CypherIR.RelationshipPattern(null, "FOLLOWS", CypherIR.Direction.OUTGOING);
+    CypherIR.NodePattern target = new CypherIR.NodePattern("b", "User", null);
+
+    CypherIR.MatchClause matchClause = new CypherIR.MatchClause(source, edge, target);
+    CypherIR.ReturnClause returnClause = new CypherIR.ReturnClause(
+        Collections.singletonList(
+            new CypherIR.ReturnItem("b", "id", CypherIR.AggregationFunction.COUNT_DISTINCT)));
+
+    CypherIR.CypherQuery query = new CypherIR.CypherQuery(matchClause, returnClause, null);
+
+    String sql = _sqlGenerator.generate(query);
+
+    assertTrue(sql.contains("SELECT COUNT(DISTINCT b.user_id)"));
+    assertFalse(sql.contains("GROUP BY"));
+  }
+
+  @Test
+  public void testMixedReturnItemsWithGroupBy() {
+    CypherIR.NodePattern source = new CypherIR.NodePattern("a", "User", null);
+    CypherIR.RelationshipPattern edge =
+        new CypherIR.RelationshipPattern(null, "FOLLOWS", CypherIR.Direction.OUTGOING);
+    CypherIR.NodePattern target = new CypherIR.NodePattern("b", "User", null);
+
+    CypherIR.MatchClause matchClause = new CypherIR.MatchClause(source, edge, target);
+    CypherIR.ReturnClause returnClause = new CypherIR.ReturnClause(
+        Arrays.asList(
+            new CypherIR.ReturnItem("a", "name"),
+            new CypherIR.ReturnItem("b", "id", CypherIR.AggregationFunction.COUNT)));
+    CypherIR.LimitClause limitClause = new CypherIR.LimitClause(100);
+
+    CypherIR.CypherQuery query = new CypherIR.CypherQuery(matchClause, returnClause, limitClause);
+
+    String sql = _sqlGenerator.generate(query);
+
+    assertEquals(sql,
+        "SELECT a.user_name, COUNT(b.user_id) FROM follows_table AS e "
+            + "JOIN users_table AS a ON e.follower_id = a.user_id "
+            + "JOIN users_table AS b ON e.followee_id = b.user_id "
+            + "GROUP BY a.user_name "
+            + "LIMIT 100");
+  }
+
+  @Test
+  public void testMixedReturnItemsCountDistinctWithGroupBy() {
+    CypherIR.NodePattern source = new CypherIR.NodePattern("a", "User", null);
+    CypherIR.RelationshipPattern edge =
+        new CypherIR.RelationshipPattern(null, "FOLLOWS", CypherIR.Direction.OUTGOING);
+    CypherIR.NodePattern target = new CypherIR.NodePattern("b", "User", null);
+
+    CypherIR.MatchClause matchClause = new CypherIR.MatchClause(source, edge, target);
+    CypherIR.ReturnClause returnClause = new CypherIR.ReturnClause(
+        Arrays.asList(
+            new CypherIR.ReturnItem("a", "name"),
+            new CypherIR.ReturnItem("b", "id", CypherIR.AggregationFunction.COUNT_DISTINCT)));
+    CypherIR.LimitClause limitClause = new CypherIR.LimitClause(100);
+
+    CypherIR.CypherQuery query = new CypherIR.CypherQuery(matchClause, returnClause, limitClause);
+
+    String sql = _sqlGenerator.generate(query);
+
+    assertEquals(sql,
+        "SELECT a.user_name, COUNT(DISTINCT b.user_id) FROM follows_table AS e "
+            + "JOIN users_table AS a ON e.follower_id = a.user_id "
+            + "JOIN users_table AS b ON e.followee_id = b.user_id "
+            + "GROUP BY a.user_name "
+            + "LIMIT 100");
+  }
+
+  @Test
+  public void testCountAliasWithoutProperty() {
+    CypherIR.NodePattern source = new CypherIR.NodePattern("a", "User", null);
+    CypherIR.RelationshipPattern edge =
+        new CypherIR.RelationshipPattern(null, "FOLLOWS", CypherIR.Direction.OUTGOING);
+    CypherIR.NodePattern target = new CypherIR.NodePattern("b", "User", null);
+
+    CypherIR.MatchClause matchClause = new CypherIR.MatchClause(source, edge, target);
+    CypherIR.ReturnClause returnClause = new CypherIR.ReturnClause(
+        Collections.singletonList(
+            new CypherIR.ReturnItem("b", null, CypherIR.AggregationFunction.COUNT)));
+
+    CypherIR.CypherQuery query = new CypherIR.CypherQuery(matchClause, returnClause, null);
+
+    String sql = _sqlGenerator.generate(query);
+
+    // count(b) uses primary key
+    assertTrue(sql.contains("SELECT COUNT(b.user_id)"));
+  }
+
+  // ---- ORDER BY tests ----
+
+  @Test
+  public void testOrderByAsc() {
+    CypherIR.NodePattern source = new CypherIR.NodePattern("a", "User", null);
+    CypherIR.RelationshipPattern edge =
+        new CypherIR.RelationshipPattern(null, "FOLLOWS", CypherIR.Direction.OUTGOING);
+    CypherIR.NodePattern target = new CypherIR.NodePattern("b", "User", null);
+
+    CypherIR.MatchClause matchClause = new CypherIR.MatchClause(source, edge, target);
+    CypherIR.ReturnClause returnClause = new CypherIR.ReturnClause(
+        Collections.singletonList(new CypherIR.ReturnItem("b", "id")));
+    CypherIR.OrderByClause orderByClause = new CypherIR.OrderByClause(
+        Collections.singletonList(new CypherIR.OrderByItem("b", "name", CypherIR.SortDirection.ASC)));
+    CypherIR.LimitClause limitClause = new CypherIR.LimitClause(100);
+
+    CypherIR.CypherQuery query = new CypherIR.CypherQuery(
+        matchClause, null, returnClause, orderByClause, limitClause);
+
+    String sql = _sqlGenerator.generate(query);
+
+    assertEquals(sql,
+        "SELECT b.user_id FROM follows_table AS e "
+            + "JOIN users_table AS a ON e.follower_id = a.user_id "
+            + "JOIN users_table AS b ON e.followee_id = b.user_id "
+            + "ORDER BY b.user_name ASC "
+            + "LIMIT 100");
+  }
+
+  @Test
+  public void testOrderByDesc() {
+    CypherIR.NodePattern source = new CypherIR.NodePattern("a", "User", null);
+    CypherIR.RelationshipPattern edge =
+        new CypherIR.RelationshipPattern(null, "FOLLOWS", CypherIR.Direction.OUTGOING);
+    CypherIR.NodePattern target = new CypherIR.NodePattern("b", "User", null);
+
+    CypherIR.MatchClause matchClause = new CypherIR.MatchClause(source, edge, target);
+    CypherIR.ReturnClause returnClause = new CypherIR.ReturnClause(
+        Collections.singletonList(new CypherIR.ReturnItem("b", "name")));
+    CypherIR.OrderByClause orderByClause = new CypherIR.OrderByClause(
+        Collections.singletonList(new CypherIR.OrderByItem("b", "name", CypherIR.SortDirection.DESC)));
+
+    CypherIR.CypherQuery query = new CypherIR.CypherQuery(
+        matchClause, null, returnClause, orderByClause, null);
+
+    String sql = _sqlGenerator.generate(query);
+
+    assertTrue(sql.contains("ORDER BY b.user_name DESC"));
+  }
+
+  @Test
+  public void testOrderByMultipleItems() {
+    CypherIR.NodePattern source = new CypherIR.NodePattern("a", "User", null);
+    CypherIR.RelationshipPattern edge =
+        new CypherIR.RelationshipPattern(null, "FOLLOWS", CypherIR.Direction.OUTGOING);
+    CypherIR.NodePattern target = new CypherIR.NodePattern("b", "User", null);
+
+    CypherIR.MatchClause matchClause = new CypherIR.MatchClause(source, edge, target);
+    CypherIR.ReturnClause returnClause = new CypherIR.ReturnClause(
+        Arrays.asList(new CypherIR.ReturnItem("a", "id"), new CypherIR.ReturnItem("b", "id")));
+    CypherIR.OrderByClause orderByClause = new CypherIR.OrderByClause(
+        Arrays.asList(
+            new CypherIR.OrderByItem("a", "id", CypherIR.SortDirection.ASC),
+            new CypherIR.OrderByItem("b", "id", CypherIR.SortDirection.DESC)));
+    CypherIR.LimitClause limitClause = new CypherIR.LimitClause(100);
+
+    CypherIR.CypherQuery query = new CypherIR.CypherQuery(
+        matchClause, null, returnClause, orderByClause, limitClause);
+
+    String sql = _sqlGenerator.generate(query);
+
+    assertTrue(sql.contains("ORDER BY a.user_id ASC, b.user_id DESC"));
+  }
+
+  // ---- RETURN AS alias tests ----
+
+  @Test
+  public void testReturnAsAlias() {
+    CypherIR.NodePattern source = new CypherIR.NodePattern("a", "User", null);
+    CypherIR.RelationshipPattern edge =
+        new CypherIR.RelationshipPattern(null, "FOLLOWS", CypherIR.Direction.OUTGOING);
+    CypherIR.NodePattern target = new CypherIR.NodePattern("b", "User", null);
+
+    CypherIR.MatchClause matchClause = new CypherIR.MatchClause(source, edge, target);
+    CypherIR.ReturnClause returnClause = new CypherIR.ReturnClause(
+        Collections.singletonList(
+            new CypherIR.ReturnItem("b", "id", CypherIR.AggregationFunction.NONE, "userId")));
+
+    CypherIR.CypherQuery query = new CypherIR.CypherQuery(matchClause, returnClause, null);
+
+    String sql = _sqlGenerator.generate(query);
+
+    assertTrue(sql.contains("SELECT b.user_id AS userId"));
+  }
+
+  @Test
+  public void testReturnMultipleAsAliases() {
+    CypherIR.NodePattern source = new CypherIR.NodePattern("a", "User", null);
+    CypherIR.RelationshipPattern edge =
+        new CypherIR.RelationshipPattern(null, "FOLLOWS", CypherIR.Direction.OUTGOING);
+    CypherIR.NodePattern target = new CypherIR.NodePattern("b", "User", null);
+
+    CypherIR.MatchClause matchClause = new CypherIR.MatchClause(source, edge, target);
+    CypherIR.ReturnClause returnClause = new CypherIR.ReturnClause(
+        Arrays.asList(
+            new CypherIR.ReturnItem("b", "id", CypherIR.AggregationFunction.NONE, "userId"),
+            new CypherIR.ReturnItem("b", "name", CypherIR.AggregationFunction.NONE, "userName")));
+
+    CypherIR.CypherQuery query = new CypherIR.CypherQuery(matchClause, returnClause, null);
+
+    String sql = _sqlGenerator.generate(query);
+
+    assertEquals(sql,
+        "SELECT b.user_id AS userId, b.user_name AS userName FROM follows_table AS e "
+            + "JOIN users_table AS a ON e.follower_id = a.user_id "
+            + "JOIN users_table AS b ON e.followee_id = b.user_id");
+  }
+
+  @Test
+  public void testReturnAsWithOrderByAndLimit() {
+    Map<String, Object> sourceProps = new LinkedHashMap<>();
+    sourceProps.put("id", 1L);
+
+    CypherIR.NodePattern source = new CypherIR.NodePattern("a", "User", sourceProps);
+    CypherIR.RelationshipPattern edge =
+        new CypherIR.RelationshipPattern(null, "FOLLOWS", CypherIR.Direction.OUTGOING);
+    CypherIR.NodePattern target = new CypherIR.NodePattern("b", "User", null);
+
+    CypherIR.MatchClause matchClause = new CypherIR.MatchClause(source, edge, target);
+    CypherIR.ReturnClause returnClause = new CypherIR.ReturnClause(
+        Arrays.asList(
+            new CypherIR.ReturnItem("b", "id", CypherIR.AggregationFunction.NONE, "userId"),
+            new CypherIR.ReturnItem("b", "name", CypherIR.AggregationFunction.NONE, "userName")));
+    CypherIR.OrderByClause orderByClause = new CypherIR.OrderByClause(
+        Collections.singletonList(new CypherIR.OrderByItem("b", "name", CypherIR.SortDirection.ASC)));
+    CypherIR.LimitClause limitClause = new CypherIR.LimitClause(100);
+
+    CypherIR.CypherQuery query = new CypherIR.CypherQuery(
+        matchClause, null, returnClause, orderByClause, limitClause);
+
+    String sql = _sqlGenerator.generate(query);
+
+    assertEquals(sql,
+        "SELECT b.user_id AS userId, b.user_name AS userName FROM follows_table AS e "
+            + "JOIN users_table AS a ON e.follower_id = a.user_id "
+            + "JOIN users_table AS b ON e.followee_id = b.user_id "
+            + "WHERE a.user_id = 1 "
+            + "ORDER BY b.user_name ASC "
+            + "LIMIT 100");
+  }
+
+  // ---- SKIP / OFFSET tests ----
+
+  @Test
+  public void testSkipGeneratesOffset() {
+    CypherIR.NodePattern source = new CypherIR.NodePattern("a", "User", null);
+    CypherIR.RelationshipPattern edge =
+        new CypherIR.RelationshipPattern(null, "FOLLOWS", CypherIR.Direction.OUTGOING);
+    CypherIR.NodePattern target = new CypherIR.NodePattern("b", "User", null);
+
+    CypherIR.MatchClause matchClause = new CypherIR.MatchClause(source, edge, target);
+    CypherIR.ReturnClause returnClause = new CypherIR.ReturnClause(
+        Collections.singletonList(new CypherIR.ReturnItem("b", "id")));
+    CypherIR.SkipClause skipClause = new CypherIR.SkipClause(20);
+    CypherIR.LimitClause limitClause = new CypherIR.LimitClause(100);
+
+    CypherIR.CypherQuery query = new CypherIR.CypherQuery(
+        matchClause, null, returnClause, null, skipClause, limitClause);
+
+    String sql = _sqlGenerator.generate(query);
+
+    assertTrue(sql.contains("LIMIT 100 OFFSET 20"));
+  }
+
+  @Test
+  public void testSkipWithOrderBy() {
+    CypherIR.NodePattern source = new CypherIR.NodePattern("a", "User", null);
+    CypherIR.RelationshipPattern edge =
+        new CypherIR.RelationshipPattern(null, "FOLLOWS", CypherIR.Direction.OUTGOING);
+    CypherIR.NodePattern target = new CypherIR.NodePattern("b", "User", null);
+
+    CypherIR.MatchClause matchClause = new CypherIR.MatchClause(source, edge, target);
+    CypherIR.ReturnClause returnClause = new CypherIR.ReturnClause(
+        Collections.singletonList(new CypherIR.ReturnItem("b", "id")));
+    CypherIR.OrderByClause orderByClause = new CypherIR.OrderByClause(
+        Collections.singletonList(new CypherIR.OrderByItem("b", "id", CypherIR.SortDirection.ASC)));
+    CypherIR.SkipClause skipClause = new CypherIR.SkipClause(10);
+    CypherIR.LimitClause limitClause = new CypherIR.LimitClause(50);
+
+    CypherIR.CypherQuery query = new CypherIR.CypherQuery(
+        matchClause, null, returnClause, orderByClause, skipClause, limitClause);
+
+    String sql = _sqlGenerator.generate(query);
+
+    assertEquals(sql,
+        "SELECT b.user_id FROM follows_table AS e "
+            + "JOIN users_table AS a ON e.follower_id = a.user_id "
+            + "JOIN users_table AS b ON e.followee_id = b.user_id "
+            + "ORDER BY b.user_id ASC "
+            + "LIMIT 50 OFFSET 10");
+  }
+
+  @Test
+  public void testNoSkipNoOffset() {
+    CypherIR.NodePattern source = new CypherIR.NodePattern("a", "User", null);
+    CypherIR.RelationshipPattern edge =
+        new CypherIR.RelationshipPattern(null, "FOLLOWS", CypherIR.Direction.OUTGOING);
+    CypherIR.NodePattern target = new CypherIR.NodePattern("b", "User", null);
+
+    CypherIR.MatchClause matchClause = new CypherIR.MatchClause(source, edge, target);
+    CypherIR.ReturnClause returnClause = new CypherIR.ReturnClause(
+        Collections.singletonList(new CypherIR.ReturnItem("b", "id")));
+    CypherIR.LimitClause limitClause = new CypherIR.LimitClause(100);
+
+    CypherIR.CypherQuery query = new CypherIR.CypherQuery(matchClause, returnClause, limitClause);
+
+    String sql = _sqlGenerator.generate(query);
+
+    assertTrue(sql.contains("LIMIT 100"));
+    assertFalse(sql.contains("OFFSET"));
+  }
+
+  // ---- SUM, AVG, MIN, MAX aggregation tests ----
+
+  @Test
+  public void testSumAggregation() {
+    CypherIR.NodePattern source = new CypherIR.NodePattern("a", "User", null);
+    CypherIR.RelationshipPattern edge =
+        new CypherIR.RelationshipPattern(null, "FOLLOWS", CypherIR.Direction.OUTGOING);
+    CypherIR.NodePattern target = new CypherIR.NodePattern("b", "User", null);
+
+    CypherIR.MatchClause matchClause = new CypherIR.MatchClause(source, edge, target);
+    CypherIR.ReturnClause returnClause = new CypherIR.ReturnClause(
+        Collections.singletonList(
+            new CypherIR.ReturnItem("b", "name", CypherIR.AggregationFunction.SUM)));
+
+    CypherIR.CypherQuery query = new CypherIR.CypherQuery(matchClause, returnClause, null);
+
+    String sql = _sqlGenerator.generate(query);
+
+    assertTrue(sql.contains("SELECT SUM(b.user_name)"));
+    assertFalse(sql.contains("GROUP BY"));
+  }
+
+  @Test
+  public void testAvgAggregation() {
+    CypherIR.NodePattern source = new CypherIR.NodePattern("a", "User", null);
+    CypherIR.RelationshipPattern edge =
+        new CypherIR.RelationshipPattern(null, "FOLLOWS", CypherIR.Direction.OUTGOING);
+    CypherIR.NodePattern target = new CypherIR.NodePattern("b", "User", null);
+
+    CypherIR.MatchClause matchClause = new CypherIR.MatchClause(source, edge, target);
+    CypherIR.ReturnClause returnClause = new CypherIR.ReturnClause(
+        Collections.singletonList(
+            new CypherIR.ReturnItem("b", "id", CypherIR.AggregationFunction.AVG)));
+
+    CypherIR.CypherQuery query = new CypherIR.CypherQuery(matchClause, returnClause, null);
+
+    String sql = _sqlGenerator.generate(query);
+
+    assertTrue(sql.contains("SELECT AVG(b.user_id)"));
+  }
+
+  @Test
+  public void testMinAggregation() {
+    CypherIR.NodePattern source = new CypherIR.NodePattern("a", "User", null);
+    CypherIR.RelationshipPattern edge =
+        new CypherIR.RelationshipPattern(null, "FOLLOWS", CypherIR.Direction.OUTGOING);
+    CypherIR.NodePattern target = new CypherIR.NodePattern("b", "User", null);
+
+    CypherIR.MatchClause matchClause = new CypherIR.MatchClause(source, edge, target);
+    CypherIR.ReturnClause returnClause = new CypherIR.ReturnClause(
+        Collections.singletonList(
+            new CypherIR.ReturnItem("b", "id", CypherIR.AggregationFunction.MIN)));
+
+    CypherIR.CypherQuery query = new CypherIR.CypherQuery(matchClause, returnClause, null);
+
+    String sql = _sqlGenerator.generate(query);
+
+    assertTrue(sql.contains("SELECT MIN(b.user_id)"));
+  }
+
+  @Test
+  public void testMaxAggregation() {
+    CypherIR.NodePattern source = new CypherIR.NodePattern("a", "User", null);
+    CypherIR.RelationshipPattern edge =
+        new CypherIR.RelationshipPattern(null, "FOLLOWS", CypherIR.Direction.OUTGOING);
+    CypherIR.NodePattern target = new CypherIR.NodePattern("b", "User", null);
+
+    CypherIR.MatchClause matchClause = new CypherIR.MatchClause(source, edge, target);
+    CypherIR.ReturnClause returnClause = new CypherIR.ReturnClause(
+        Collections.singletonList(
+            new CypherIR.ReturnItem("b", "id", CypherIR.AggregationFunction.MAX)));
+
+    CypherIR.CypherQuery query = new CypherIR.CypherQuery(matchClause, returnClause, null);
+
+    String sql = _sqlGenerator.generate(query);
+
+    assertTrue(sql.contains("SELECT MAX(b.user_id)"));
+  }
+
+  @Test
+  public void testMixedReturnItemsWithSumAndGroupBy() {
+    CypherIR.NodePattern source = new CypherIR.NodePattern("a", "User", null);
+    CypherIR.RelationshipPattern edge =
+        new CypherIR.RelationshipPattern(null, "FOLLOWS", CypherIR.Direction.OUTGOING);
+    CypherIR.NodePattern target = new CypherIR.NodePattern("b", "User", null);
+
+    CypherIR.MatchClause matchClause = new CypherIR.MatchClause(source, edge, target);
+    CypherIR.ReturnClause returnClause = new CypherIR.ReturnClause(
+        Arrays.asList(
+            new CypherIR.ReturnItem("a", "name"),
+            new CypherIR.ReturnItem("b", "id", CypherIR.AggregationFunction.SUM)));
+    CypherIR.LimitClause limitClause = new CypherIR.LimitClause(100);
+
+    CypherIR.CypherQuery query = new CypherIR.CypherQuery(matchClause, returnClause, limitClause);
+
+    String sql = _sqlGenerator.generate(query);
+
+    assertEquals(sql,
+        "SELECT a.user_name, SUM(b.user_id) FROM follows_table AS e "
+            + "JOIN users_table AS a ON e.follower_id = a.user_id "
+            + "JOIN users_table AS b ON e.followee_id = b.user_id "
+            + "GROUP BY a.user_name "
+            + "LIMIT 100");
+  }
+
+  @Test
+  public void testSumAggregationWithResultAlias() {
+    CypherIR.NodePattern source = new CypherIR.NodePattern("a", "User", null);
+    CypherIR.RelationshipPattern edge =
+        new CypherIR.RelationshipPattern(null, "FOLLOWS", CypherIR.Direction.OUTGOING);
+    CypherIR.NodePattern target = new CypherIR.NodePattern("b", "User", null);
+
+    CypherIR.MatchClause matchClause = new CypherIR.MatchClause(source, edge, target);
+    CypherIR.ReturnClause returnClause = new CypherIR.ReturnClause(
+        Collections.singletonList(
+            new CypherIR.ReturnItem("b", "id", CypherIR.AggregationFunction.SUM, "total")));
+
+    CypherIR.CypherQuery query = new CypherIR.CypherQuery(matchClause, returnClause, null);
+
+    String sql = _sqlGenerator.generate(query);
+
+    assertTrue(sql.contains("SELECT SUM(b.user_id) AS total"));
+  }
+
+  // ---- String predicate tests ----
+
+  @Test
+  public void testStringPredicateStartsWith() {
+    CypherIR.NodePattern source = new CypherIR.NodePattern("a", "User", null);
+    CypherIR.RelationshipPattern edge =
+        new CypherIR.RelationshipPattern(null, "FOLLOWS", CypherIR.Direction.OUTGOING);
+    CypherIR.NodePattern target = new CypherIR.NodePattern("b", "User", null);
+
+    CypherIR.MatchClause matchClause = new CypherIR.MatchClause(source, edge, target);
+    CypherIR.ReturnClause returnClause = new CypherIR.ReturnClause(
+        Collections.singletonList(new CypherIR.ReturnItem("b", "id")));
+    CypherIR.WhereClause whereClause = new CypherIR.WhereClause(
+        new CypherIR.StringPredicate("a", "name", CypherIR.StringOperator.STARTS_WITH, "Al"));
+
+    CypherIR.CypherQuery query = new CypherIR.CypherQuery(matchClause, whereClause, returnClause, null);
+
+    String sql = _sqlGenerator.generate(query);
+
+    assertTrue(sql.contains("a.user_name LIKE 'Al%'"));
+  }
+
+  @Test
+  public void testStringPredicateEndsWith() {
+    CypherIR.NodePattern source = new CypherIR.NodePattern("a", "User", null);
+    CypherIR.RelationshipPattern edge =
+        new CypherIR.RelationshipPattern(null, "FOLLOWS", CypherIR.Direction.OUTGOING);
+    CypherIR.NodePattern target = new CypherIR.NodePattern("b", "User", null);
+
+    CypherIR.MatchClause matchClause = new CypherIR.MatchClause(source, edge, target);
+    CypherIR.ReturnClause returnClause = new CypherIR.ReturnClause(
+        Collections.singletonList(new CypherIR.ReturnItem("b", "id")));
+    CypherIR.WhereClause whereClause = new CypherIR.WhereClause(
+        new CypherIR.StringPredicate("a", "name", CypherIR.StringOperator.ENDS_WITH, "ice"));
+
+    CypherIR.CypherQuery query = new CypherIR.CypherQuery(matchClause, whereClause, returnClause, null);
+
+    String sql = _sqlGenerator.generate(query);
+
+    assertTrue(sql.contains("a.user_name LIKE '%ice'"));
+  }
+
+  @Test
+  public void testStringPredicateContains() {
+    CypherIR.NodePattern source = new CypherIR.NodePattern("a", "User", null);
+    CypherIR.RelationshipPattern edge =
+        new CypherIR.RelationshipPattern(null, "FOLLOWS", CypherIR.Direction.OUTGOING);
+    CypherIR.NodePattern target = new CypherIR.NodePattern("b", "User", null);
+
+    CypherIR.MatchClause matchClause = new CypherIR.MatchClause(source, edge, target);
+    CypherIR.ReturnClause returnClause = new CypherIR.ReturnClause(
+        Collections.singletonList(new CypherIR.ReturnItem("b", "id")));
+    CypherIR.WhereClause whereClause = new CypherIR.WhereClause(
+        new CypherIR.StringPredicate("a", "name", CypherIR.StringOperator.CONTAINS, "lic"));
+
+    CypherIR.CypherQuery query = new CypherIR.CypherQuery(matchClause, whereClause, returnClause, null);
+
+    String sql = _sqlGenerator.generate(query);
+
+    assertTrue(sql.contains("a.user_name LIKE '%lic%'"));
+  }
+
+  @Test
+  public void testStringPredicateLikeEscaping() {
+    // Value containing LIKE special chars % and _ should be escaped
+    CypherIR.NodePattern source = new CypherIR.NodePattern("a", "User", null);
+    CypherIR.RelationshipPattern edge =
+        new CypherIR.RelationshipPattern(null, "FOLLOWS", CypherIR.Direction.OUTGOING);
+    CypherIR.NodePattern target = new CypherIR.NodePattern("b", "User", null);
+
+    CypherIR.MatchClause matchClause = new CypherIR.MatchClause(source, edge, target);
+    CypherIR.ReturnClause returnClause = new CypherIR.ReturnClause(
+        Collections.singletonList(new CypherIR.ReturnItem("b", "id")));
+    CypherIR.WhereClause whereClause = new CypherIR.WhereClause(
+        new CypherIR.StringPredicate("a", "name", CypherIR.StringOperator.CONTAINS, "100%_done"));
+
+    CypherIR.CypherQuery query = new CypherIR.CypherQuery(matchClause, whereClause, returnClause, null);
+
+    String sql = _sqlGenerator.generate(query);
+
+    // The % and _ in the value should be escaped
+    assertTrue(sql.contains("LIKE '%100\\%\\_done%'"));
+  }
+
+  // ---- IN list predicate tests ----
+
+  @Test
+  public void testInPredicateIntegerList() {
+    CypherIR.NodePattern source = new CypherIR.NodePattern("a", "User", null);
+    CypherIR.RelationshipPattern edge =
+        new CypherIR.RelationshipPattern(null, "FOLLOWS", CypherIR.Direction.OUTGOING);
+    CypherIR.NodePattern target = new CypherIR.NodePattern("b", "User", null);
+
+    CypherIR.MatchClause matchClause = new CypherIR.MatchClause(source, edge, target);
+    CypherIR.ReturnClause returnClause = new CypherIR.ReturnClause(
+        Collections.singletonList(new CypherIR.ReturnItem("b", "id")));
+    CypherIR.WhereClause whereClause = new CypherIR.WhereClause(
+        new CypherIR.InPredicate("a", "id", Arrays.asList(1L, 2L, 3L)));
+
+    CypherIR.CypherQuery query = new CypherIR.CypherQuery(matchClause, whereClause, returnClause, null);
+
+    String sql = _sqlGenerator.generate(query);
+
+    assertTrue(sql.contains("a.user_id IN (1, 2, 3)"));
+  }
+
+  @Test
+  public void testInPredicateStringList() {
+    CypherIR.NodePattern source = new CypherIR.NodePattern("a", "User", null);
+    CypherIR.RelationshipPattern edge =
+        new CypherIR.RelationshipPattern(null, "FOLLOWS", CypherIR.Direction.OUTGOING);
+    CypherIR.NodePattern target = new CypherIR.NodePattern("b", "User", null);
+
+    CypherIR.MatchClause matchClause = new CypherIR.MatchClause(source, edge, target);
+    CypherIR.ReturnClause returnClause = new CypherIR.ReturnClause(
+        Collections.singletonList(new CypherIR.ReturnItem("b", "id")));
+    CypherIR.WhereClause whereClause = new CypherIR.WhereClause(
+        new CypherIR.InPredicate("a", "name", Arrays.asList("Alice", "Bob")));
+
+    CypherIR.CypherQuery query = new CypherIR.CypherQuery(matchClause, whereClause, returnClause, null);
+
+    String sql = _sqlGenerator.generate(query);
+
+    assertTrue(sql.contains("a.user_name IN ('Alice', 'Bob')"));
+  }
+
+  @Test
+  public void testEscapeLikePattern() {
+    assertEquals(SqlGenerator.escapeLikePattern("hello"), "hello");
+    assertEquals(SqlGenerator.escapeLikePattern("100%"), "100\\%");
+    assertEquals(SqlGenerator.escapeLikePattern("a_b"), "a\\_b");
+    assertEquals(SqlGenerator.escapeLikePattern("100%_x"), "100\\%\\_x");
+  }
+
+  // ---- 2-hop SQL generation tests ----
+
+  @Test
+  public void testTwoHopOutgoingGeneratesFourJoins() {
+    // MATCH (a:User {id: 1})-[:FOLLOWS]->(b:User)-[:FOLLOWS]->(c:User) RETURN c.id LIMIT 100
+    Map<String, Object> sourceProps = new LinkedHashMap<>();
+    sourceProps.put("id", 1L);
+
+    CypherIR.NodePattern nodeA = new CypherIR.NodePattern("a", "User", sourceProps);
+    CypherIR.NodePattern nodeB = new CypherIR.NodePattern("b", "User", null);
+    CypherIR.NodePattern nodeC = new CypherIR.NodePattern("c", "User", null);
+
+    CypherIR.RelationshipPattern edge1 =
+        new CypherIR.RelationshipPattern(null, "FOLLOWS", CypherIR.Direction.OUTGOING);
+    CypherIR.RelationshipPattern edge2 =
+        new CypherIR.RelationshipPattern(null, "FOLLOWS", CypherIR.Direction.OUTGOING);
+
+    CypherIR.MatchClause matchClause = new CypherIR.MatchClause(
+        Arrays.asList(nodeA, nodeB, nodeC), Arrays.asList(edge1, edge2));
+    CypherIR.ReturnClause returnClause = new CypherIR.ReturnClause(
+        Collections.singletonList(new CypherIR.ReturnItem("c", "id")));
+    CypherIR.LimitClause limitClause = new CypherIR.LimitClause(100);
+
+    CypherIR.CypherQuery query = new CypherIR.CypherQuery(matchClause, returnClause, limitClause);
+
+    String sql = _sqlGenerator.generate(query);
+
+    assertEquals(sql,
+        "SELECT c.user_id FROM follows_table AS e1 "
+            + "JOIN users_table AS a ON e1.follower_id = a.user_id "
+            + "JOIN users_table AS b ON e1.followee_id = b.user_id "
+            + "JOIN follows_table AS e2 ON e2.follower_id = b.user_id "
+            + "JOIN users_table AS c ON e2.followee_id = c.user_id "
+            + "WHERE a.user_id = 1 "
+            + "LIMIT 100");
+  }
+
+  @Test
+  public void testTwoHopIncomingSecondEdge() {
+    // MATCH (a:User)-[:FOLLOWS]->(b:User)<-[:FOLLOWS]-(c:User) RETURN c.id LIMIT 100
+    CypherIR.NodePattern nodeA = new CypherIR.NodePattern("a", "User", null);
+    CypherIR.NodePattern nodeB = new CypherIR.NodePattern("b", "User", null);
+    CypherIR.NodePattern nodeC = new CypherIR.NodePattern("c", "User", null);
+
+    CypherIR.RelationshipPattern edge1 =
+        new CypherIR.RelationshipPattern(null, "FOLLOWS", CypherIR.Direction.OUTGOING);
+    CypherIR.RelationshipPattern edge2 =
+        new CypherIR.RelationshipPattern(null, "FOLLOWS", CypherIR.Direction.INCOMING);
+
+    CypherIR.MatchClause matchClause = new CypherIR.MatchClause(
+        Arrays.asList(nodeA, nodeB, nodeC), Arrays.asList(edge1, edge2));
+    CypherIR.ReturnClause returnClause = new CypherIR.ReturnClause(
+        Collections.singletonList(new CypherIR.ReturnItem("c", "id")));
+    CypherIR.LimitClause limitClause = new CypherIR.LimitClause(100);
+
+    CypherIR.CypherQuery query = new CypherIR.CypherQuery(matchClause, returnClause, limitClause);
+
+    String sql = _sqlGenerator.generate(query);
+
+    // For the second edge (incoming), the join keys are reversed:
+    // b is the "target" of the incoming edge (maps to followee_id)
+    // c is the "source" of the incoming edge (maps to follower_id)
+    assertEquals(sql,
+        "SELECT c.user_id FROM follows_table AS e1 "
+            + "JOIN users_table AS a ON e1.follower_id = a.user_id "
+            + "JOIN users_table AS b ON e1.followee_id = b.user_id "
+            + "JOIN follows_table AS e2 ON e2.followee_id = b.user_id "
+            + "JOIN users_table AS c ON e2.follower_id = c.user_id "
+            + "LIMIT 100");
+  }
+
+  @Test
+  public void testTwoHopWithWhereClause() {
+    // MATCH (a:User {id: 1})-[:FOLLOWS]->(b:User)-[:FOLLOWS]->(c:User) WHERE c.name = 'Alice' RETURN c.id
+    Map<String, Object> sourceProps = new LinkedHashMap<>();
+    sourceProps.put("id", 1L);
+
+    CypherIR.NodePattern nodeA = new CypherIR.NodePattern("a", "User", sourceProps);
+    CypherIR.NodePattern nodeB = new CypherIR.NodePattern("b", "User", null);
+    CypherIR.NodePattern nodeC = new CypherIR.NodePattern("c", "User", null);
+
+    CypherIR.RelationshipPattern edge1 =
+        new CypherIR.RelationshipPattern(null, "FOLLOWS", CypherIR.Direction.OUTGOING);
+    CypherIR.RelationshipPattern edge2 =
+        new CypherIR.RelationshipPattern(null, "FOLLOWS", CypherIR.Direction.OUTGOING);
+
+    CypherIR.MatchClause matchClause = new CypherIR.MatchClause(
+        Arrays.asList(nodeA, nodeB, nodeC), Arrays.asList(edge1, edge2));
+    CypherIR.ReturnClause returnClause = new CypherIR.ReturnClause(
+        Collections.singletonList(new CypherIR.ReturnItem("c", "id")));
+    CypherIR.WhereClause whereClause = new CypherIR.WhereClause(
+        new CypherIR.ComparisonPredicate("c", "name", "=", "Alice"));
+
+    CypherIR.CypherQuery query = new CypherIR.CypherQuery(matchClause, whereClause, returnClause, null);
+
+    String sql = _sqlGenerator.generate(query);
+
+    // Both inline filter on a and WHERE clause on c should appear
+    assertTrue(sql.contains("a.user_id = 1"));
+    assertTrue(sql.contains("c.user_name = 'Alice'"));
+    assertTrue(sql.contains("WHERE"));
+  }
+
+  @Test
+  public void testTwoHopWithDifferentEdgeTypes() {
+    // MATCH (a:User {id: 1})-[:FOLLOWS]->(b:User)-[:LIKES]->(c:Post) RETURN c.id LIMIT 100
+    SqlGenerator generator = new SqlGenerator(createSchemaWithPost());
+
+    Map<String, Object> sourceProps = new LinkedHashMap<>();
+    sourceProps.put("id", 1L);
+
+    CypherIR.NodePattern nodeA = new CypherIR.NodePattern("a", "User", sourceProps);
+    CypherIR.NodePattern nodeB = new CypherIR.NodePattern("b", "User", null);
+    CypherIR.NodePattern nodeC = new CypherIR.NodePattern("c", "Post", null);
+
+    CypherIR.RelationshipPattern edge1 =
+        new CypherIR.RelationshipPattern(null, "FOLLOWS", CypherIR.Direction.OUTGOING);
+    CypherIR.RelationshipPattern edge2 =
+        new CypherIR.RelationshipPattern(null, "LIKES", CypherIR.Direction.OUTGOING);
+
+    CypherIR.MatchClause matchClause = new CypherIR.MatchClause(
+        Arrays.asList(nodeA, nodeB, nodeC), Arrays.asList(edge1, edge2));
+    CypherIR.ReturnClause returnClause = new CypherIR.ReturnClause(
+        Collections.singletonList(new CypherIR.ReturnItem("c", "id")));
+    CypherIR.LimitClause limitClause = new CypherIR.LimitClause(100);
+
+    CypherIR.CypherQuery query = new CypherIR.CypherQuery(matchClause, returnClause, limitClause);
+
+    String sql = generator.generate(query);
+
+    assertEquals(sql,
+        "SELECT c.post_id FROM follows_table AS e1 "
+            + "JOIN users_table AS a ON e1.follower_id = a.user_id "
+            + "JOIN users_table AS b ON e1.followee_id = b.user_id "
+            + "JOIN likes_table AS e2 ON e2.liker_id = b.user_id "
+            + "JOIN posts_table AS c ON e2.post_id = c.post_id "
+            + "WHERE a.user_id = 1 "
+            + "LIMIT 100");
+  }
+
+  @Test
+  public void testTwoHopWithCustomEdgeAliases() {
+    // MATCH (a:User)-[r1:FOLLOWS]->(b:User)-[r2:FOLLOWS]->(c:User) RETURN c.id LIMIT 100
+    CypherIR.NodePattern nodeA = new CypherIR.NodePattern("a", "User", null);
+    CypherIR.NodePattern nodeB = new CypherIR.NodePattern("b", "User", null);
+    CypherIR.NodePattern nodeC = new CypherIR.NodePattern("c", "User", null);
+
+    CypherIR.RelationshipPattern edge1 =
+        new CypherIR.RelationshipPattern("r1", "FOLLOWS", CypherIR.Direction.OUTGOING);
+    CypherIR.RelationshipPattern edge2 =
+        new CypherIR.RelationshipPattern("r2", "FOLLOWS", CypherIR.Direction.OUTGOING);
+
+    CypherIR.MatchClause matchClause = new CypherIR.MatchClause(
+        Arrays.asList(nodeA, nodeB, nodeC), Arrays.asList(edge1, edge2));
+    CypherIR.ReturnClause returnClause = new CypherIR.ReturnClause(
+        Collections.singletonList(new CypherIR.ReturnItem("c", "id")));
+    CypherIR.LimitClause limitClause = new CypherIR.LimitClause(100);
+
+    CypherIR.CypherQuery query = new CypherIR.CypherQuery(matchClause, returnClause, limitClause);
+
+    String sql = _sqlGenerator.generate(query);
+
+    // Custom edge aliases r1, r2 should be used
+    assertTrue(sql.contains("follows_table AS r1"));
+    assertTrue(sql.contains("follows_table AS r2"));
+    assertTrue(sql.contains("r1.follower_id"));
+    assertTrue(sql.contains("r2.follower_id"));
+  }
+
+  // ---- Helper methods ----
+
+  /**
+   * Creates a test schema with:
+   * - Vertex label "User" backed by "users_table" with primary key "user_id"
+   * - Edge label "FOLLOWS" backed by "follows_table" connecting User -> User
+   */
+  private static GraphSchemaConfig createTestSchema() {
+    Map<String, String> userProperties = new HashMap<>();
+    userProperties.put("id", "user_id");
+    userProperties.put("name", "user_name");
+
+    GraphSchemaConfig.VertexLabel userLabel =
+        new GraphSchemaConfig.VertexLabel("users_table", "user_id", userProperties);
+
+    Map<String, GraphSchemaConfig.VertexLabel> vertexLabels = new HashMap<>();
+    vertexLabels.put("User", userLabel);
+
+    GraphSchemaConfig.EdgeLabel followsLabel =
+        new GraphSchemaConfig.EdgeLabel("follows_table", "User", "follower_id", "User", "followee_id",
+            Map.of());
+
+    Map<String, GraphSchemaConfig.EdgeLabel> edgeLabels = new HashMap<>();
+    edgeLabels.put("FOLLOWS", followsLabel);
+
+    return new GraphSchemaConfig(vertexLabels, edgeLabels);
+  }
+
+  /**
+   * Creates a test schema with User, Post vertices and FOLLOWS, LIKES edges.
+   */
+  private static GraphSchemaConfig createSchemaWithPost() {
+    Map<String, String> userProperties = new HashMap<>();
+    userProperties.put("id", "user_id");
+    userProperties.put("name", "user_name");
+
+    Map<String, String> postProperties = new HashMap<>();
+    postProperties.put("id", "post_id");
+    postProperties.put("title", "post_title");
+
+    GraphSchemaConfig.VertexLabel userLabel =
+        new GraphSchemaConfig.VertexLabel("users_table", "user_id", userProperties);
+    GraphSchemaConfig.VertexLabel postLabel =
+        new GraphSchemaConfig.VertexLabel("posts_table", "post_id", postProperties);
+
+    Map<String, GraphSchemaConfig.VertexLabel> vertexLabels = new HashMap<>();
+    vertexLabels.put("User", userLabel);
+    vertexLabels.put("Post", postLabel);
+
+    GraphSchemaConfig.EdgeLabel followsLabel =
+        new GraphSchemaConfig.EdgeLabel("follows_table", "User", "follower_id", "User", "followee_id",
+            Map.of());
+    GraphSchemaConfig.EdgeLabel likesLabel =
+        new GraphSchemaConfig.EdgeLabel("likes_table", "User", "liker_id", "Post", "post_id",
+            Map.of());
+
+    Map<String, GraphSchemaConfig.EdgeLabel> edgeLabels = new HashMap<>();
+    edgeLabels.put("FOLLOWS", followsLabel);
+    edgeLabels.put("LIKES", likesLabel);
+
+    return new GraphSchemaConfig(vertexLabels, edgeLabels);
+  }
+}

--- a/pinot-graph/pinot-graph-spi/pom.xml
+++ b/pinot-graph/pinot-graph-spi/pom.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.pinot</groupId>
+    <artifactId>pinot-graph</artifactId>
+    <version>1.6.0-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>pinot-graph-spi</artifactId>
+
+  <properties>
+    <pinot.root>${basedir}/../..</pinot.root>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-spi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.testng</groupId>
+      <artifactId>testng</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/pinot-graph/pinot-graph-spi/src/main/java/org/apache/pinot/graph/spi/GraphSchemaConfig.java
+++ b/pinot-graph/pinot-graph-spi/src/main/java/org/apache/pinot/graph/spi/GraphSchemaConfig.java
@@ -1,0 +1,134 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.graph.spi;
+
+import java.util.Collections;
+import java.util.Map;
+
+
+/**
+ * Graph schema configuration that defines vertex labels and edge labels,
+ * mapping them to underlying Pinot tables and columns.
+ *
+ * <p>This POJO is the bridge between the graph model (vertices, edges, labels)
+ * and the relational model (tables, columns, joins) used by Pinot.</p>
+ */
+public class GraphSchemaConfig {
+  private final Map<String, VertexLabel> _vertexLabels;
+  private final Map<String, EdgeLabel> _edgeLabels;
+
+  public GraphSchemaConfig(Map<String, VertexLabel> vertexLabels, Map<String, EdgeLabel> edgeLabels) {
+    _vertexLabels = Collections.unmodifiableMap(vertexLabels);
+    _edgeLabels = Collections.unmodifiableMap(edgeLabels);
+  }
+
+  public Map<String, VertexLabel> getVertexLabels() {
+    return _vertexLabels;
+  }
+
+  public Map<String, EdgeLabel> getEdgeLabels() {
+    return _edgeLabels;
+  }
+
+  /**
+   * Defines a vertex label backed by a Pinot table.
+   */
+  public static class VertexLabel {
+    private final String _tableName;
+    private final String _primaryKey;
+    private final Map<String, String> _properties;
+
+    /**
+     * @param tableName  the Pinot table backing this vertex label
+     * @param primaryKey the column used as the vertex identifier
+     * @param properties map from property name to column name
+     */
+    public VertexLabel(String tableName, String primaryKey, Map<String, String> properties) {
+      _tableName = tableName;
+      _primaryKey = primaryKey;
+      _properties = Collections.unmodifiableMap(properties);
+    }
+
+    public String getTableName() {
+      return _tableName;
+    }
+
+    public String getPrimaryKey() {
+      return _primaryKey;
+    }
+
+    public Map<String, String> getProperties() {
+      return _properties;
+    }
+  }
+
+  /**
+   * Defines an edge label backed by a Pinot table, connecting two vertex labels.
+   */
+  public static class EdgeLabel {
+    private final String _tableName;
+    private final String _sourceVertexLabel;
+    private final String _sourceKey;
+    private final String _targetVertexLabel;
+    private final String _targetKey;
+    private final Map<String, String> _properties;
+
+    /**
+     * @param tableName         the Pinot table backing this edge label
+     * @param sourceVertexLabel the label of the source vertex
+     * @param sourceKey         the column in the edge table referencing the source vertex
+     * @param targetVertexLabel the label of the target vertex
+     * @param targetKey         the column in the edge table referencing the target vertex
+     * @param properties        map from property name to column name
+     */
+    public EdgeLabel(String tableName, String sourceVertexLabel, String sourceKey,
+        String targetVertexLabel, String targetKey, Map<String, String> properties) {
+      _tableName = tableName;
+      _sourceVertexLabel = sourceVertexLabel;
+      _sourceKey = sourceKey;
+      _targetVertexLabel = targetVertexLabel;
+      _targetKey = targetKey;
+      _properties = Collections.unmodifiableMap(properties);
+    }
+
+    public String getTableName() {
+      return _tableName;
+    }
+
+    public String getSourceVertexLabel() {
+      return _sourceVertexLabel;
+    }
+
+    public String getSourceKey() {
+      return _sourceKey;
+    }
+
+    public String getTargetVertexLabel() {
+      return _targetVertexLabel;
+    }
+
+    public String getTargetKey() {
+      return _targetKey;
+    }
+
+    public Map<String, String> getProperties() {
+      return _properties;
+    }
+  }
+}

--- a/pinot-graph/pinot-graph-spi/src/main/java/org/apache/pinot/graph/spi/PinotGraphConfiguration.java
+++ b/pinot-graph/pinot-graph-spi/src/main/java/org/apache/pinot/graph/spi/PinotGraphConfiguration.java
@@ -1,0 +1,43 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.graph.spi;
+
+
+/**
+ * Configuration key constants for the Pinot graph query feature.
+ *
+ * <p>Thread-safe: this class holds only constants.</p>
+ */
+public final class PinotGraphConfiguration {
+
+  /**
+   * Feature flag key to enable or disable graph query support.
+   * When set to {@code true}, the broker will accept openCypher queries.
+   */
+  public static final String GRAPH_ENABLED_KEY = "pinot.graph.enabled";
+
+  /**
+   * Configuration key prefix for graph schema definitions.
+   */
+  public static final String GRAPH_SCHEMA_PREFIX = "pinot.graph.schema";
+
+  private PinotGraphConfiguration() {
+    // Utility class; do not instantiate.
+  }
+}

--- a/pinot-graph/pom.xml
+++ b/pinot-graph/pom.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.pinot</groupId>
+    <artifactId>pinot</artifactId>
+    <version>1.6.0-SNAPSHOT</version>
+  </parent>
+  <packaging>pom</packaging>
+
+  <artifactId>pinot-graph</artifactId>
+
+  <properties>
+    <pinot.root>${basedir}/..</pinot.root>
+  </properties>
+
+  <modules>
+    <module>pinot-graph-spi</module>
+    <module>pinot-graph-planner</module>
+  </modules>
+
+</project>

--- a/pinot-integration-tests/pom.xml
+++ b/pinot-integration-tests/pom.xml
@@ -184,6 +184,14 @@
       <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-timeseries-planner</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-graph-spi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-graph-planner</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.apache.pinot</groupId>

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/GraphQueryIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/GraphQueryIntegrationTest.java
@@ -1,0 +1,397 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.integration.tests;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.File;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.avro.Schema.Field;
+import org.apache.avro.Schema.Type;
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.apache.pinot.util.TestUtils;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+
+/**
+ * Integration test for the experimental graph query feature with distributed data.
+ *
+ * <p>Creates a standalone cluster with 2 servers, loads vertex and edge tables
+ * with multiple segments each, then validates graph queries produce correct results
+ * when data is distributed across servers.</p>
+ *
+ * <p>Graph (50 users, 200 follow edges):
+ * <ul>
+ *   <li>Users 1..50 with names user_1..user_50</li>
+ *   <li>Each user i follows (i%50)+1, (i%50)+2, ..., (i%50)+4</li>
+ *   <li>Data split across 4 Avro files per table</li>
+ * </ul>
+ * </p>
+ */
+public class GraphQueryIntegrationTest extends BaseClusterIntegrationTest {
+
+  private static final String USERS_TABLE = "graphUsers";
+  private static final String FOLLOWS_TABLE = "graphFollows";
+
+  private static final int NUM_USERS = 50;
+  private static final int FOLLOWS_PER_USER = 4;
+  private static final int NUM_FOLLOWS = NUM_USERS * FOLLOWS_PER_USER;
+  private static final int NUM_AVRO_FILES = 4;
+
+  private static final String GRAPH_SCHEMA_JSON = "{"
+      + "\"vertexLabels\": {"
+      + "  \"User\": {"
+      + "    \"tableName\": \"graphUsers\","
+      + "    \"primaryKey\": \"user_id\","
+      + "    \"properties\": {\"id\": \"user_id\", \"name\": \"user_name\"}"
+      + "  }"
+      + "},"
+      + "\"edgeLabels\": {"
+      + "  \"FOLLOWS\": {"
+      + "    \"tableName\": \"graphFollows\","
+      + "    \"sourceVertexLabel\": \"User\","
+      + "    \"sourceKey\": \"follower_id\","
+      + "    \"targetVertexLabel\": \"User\","
+      + "    \"targetKey\": \"followee_id\","
+      + "    \"properties\": {}"
+      + "  }"
+      + "}"
+      + "}";
+
+  private final Map<Integer, Set<Integer>> _expectedFollowees = new HashMap<>();
+  private final Map<Integer, Set<Integer>> _expectedFollowers = new HashMap<>();
+
+  public GraphQueryIntegrationTest() {
+    for (int i = 1; i <= NUM_USERS; i++) {
+      _expectedFollowees.put(i, new HashSet<>());
+      _expectedFollowers.put(i, new HashSet<>());
+    }
+    for (int i = 1; i <= NUM_USERS; i++) {
+      for (int j = 1; j <= FOLLOWS_PER_USER; j++) {
+        int target = ((i - 1 + j) % NUM_USERS) + 1;
+        _expectedFollowees.get(i).add(target);
+        _expectedFollowers.get(target).add(i);
+      }
+    }
+  }
+
+  @Override
+  protected void overrideBrokerConf(PinotConfiguration brokerConf) {
+    brokerConf.setProperty(CommonConstants.Graph.CONFIG_OF_GRAPH_QUERY_ENABLED, true);
+  }
+
+  @BeforeClass
+  public void setUp()
+      throws Exception {
+    TestUtils.ensureDirectoriesExistAndEmpty(_tempDir, _segmentDir, _tarDir);
+
+    // Start cluster with 2 servers for distributed execution
+    startZk();
+    startController();
+    startBroker();
+    startServers(2);
+
+    // Set up vertex table
+    Schema usersSchema = new Schema.SchemaBuilder().setSchemaName(USERS_TABLE)
+        .addSingleValueDimension("user_id", FieldSpec.DataType.INT)
+        .addSingleValueDimension("user_name", FieldSpec.DataType.STRING)
+        .build();
+    addSchema(usersSchema);
+    TableConfig usersConfig = new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName(USERS_TABLE).build();
+    addTableConfig(usersConfig);
+
+    List<File> usersAvroFiles = generateUsersAvroFiles();
+    ClusterIntegrationTestUtils.buildSegmentsFromAvro(usersAvroFiles, usersConfig, usersSchema,
+        0, _segmentDir, _tarDir);
+    uploadSegments(USERS_TABLE, _tarDir);
+
+    // Wait for users to load
+    TestUtils.waitForCondition(
+        () -> getCurrentCountStarResult(USERS_TABLE) == NUM_USERS,
+        100L, 120_000L, "Failed to load user records",
+        Duration.ofSeconds(10));
+
+    // Set up edge table
+    Schema followsSchema = new Schema.SchemaBuilder().setSchemaName(FOLLOWS_TABLE)
+        .addSingleValueDimension("follower_id", FieldSpec.DataType.INT)
+        .addSingleValueDimension("followee_id", FieldSpec.DataType.INT)
+        .build();
+    addSchema(followsSchema);
+    TableConfig followsConfig = new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName(FOLLOWS_TABLE).build();
+    addTableConfig(followsConfig);
+
+    TestUtils.ensureDirectoriesExistAndEmpty(_segmentDir, _tarDir);
+    List<File> followsAvroFiles = generateFollowsAvroFiles();
+    ClusterIntegrationTestUtils.buildSegmentsFromAvro(followsAvroFiles, followsConfig, followsSchema,
+        0, _segmentDir, _tarDir);
+    uploadSegments(FOLLOWS_TABLE, _tarDir);
+
+    // Wait for follows to load
+    TestUtils.waitForCondition(
+        () -> getCurrentCountStarResult(FOLLOWS_TABLE) == NUM_FOLLOWS,
+        100L, 120_000L, "Failed to load follow records",
+        Duration.ofSeconds(10));
+  }
+
+  @AfterClass
+  public void tearDown()
+      throws Exception {
+    dropOfflineTable(USERS_TABLE);
+    dropOfflineTable(FOLLOWS_TABLE);
+    stopServer();
+    stopBroker();
+    stopController();
+    stopZk();
+    FileUtils.deleteDirectory(_tempDir);
+  }
+
+  private List<File> generateUsersAvroFiles()
+      throws Exception {
+    org.apache.avro.Schema avroSchema = org.apache.avro.Schema.createRecord("User", null, null, false);
+    avroSchema.setFields(List.of(
+        new Field("user_id", org.apache.avro.Schema.create(Type.INT), null, null),
+        new Field("user_name", org.apache.avro.Schema.create(Type.STRING), null, null)
+    ));
+
+    List<File> avroFiles = new ArrayList<>();
+    List<DataFileWriter<GenericData.Record>> writers = new ArrayList<>();
+    for (int s = 0; s < NUM_AVRO_FILES; s++) {
+      File avroFile = new File(_tempDir, "users-" + s + ".avro");
+      avroFiles.add(avroFile);
+      DataFileWriter<GenericData.Record> writer = new DataFileWriter<>(new GenericDatumWriter<>(avroSchema));
+      writer.create(avroSchema, avroFile);
+      writers.add(writer);
+    }
+    for (int i = 1; i <= NUM_USERS; i++) {
+      GenericData.Record record = new GenericData.Record(avroSchema);
+      record.put("user_id", i);
+      record.put("user_name", "user_" + i);
+      writers.get((i - 1) % NUM_AVRO_FILES).append(record);
+    }
+    for (DataFileWriter<GenericData.Record> writer : writers) {
+      writer.close();
+    }
+    return avroFiles;
+  }
+
+  private List<File> generateFollowsAvroFiles()
+      throws Exception {
+    org.apache.avro.Schema avroSchema = org.apache.avro.Schema.createRecord("Follows", null, null, false);
+    avroSchema.setFields(List.of(
+        new Field("follower_id", org.apache.avro.Schema.create(Type.INT), null, null),
+        new Field("followee_id", org.apache.avro.Schema.create(Type.INT), null, null)
+    ));
+
+    List<File> avroFiles = new ArrayList<>();
+    List<DataFileWriter<GenericData.Record>> writers = new ArrayList<>();
+    for (int s = 0; s < NUM_AVRO_FILES; s++) {
+      File avroFile = new File(_tempDir, "follows-" + s + ".avro");
+      avroFiles.add(avroFile);
+      DataFileWriter<GenericData.Record> writer = new DataFileWriter<>(new GenericDatumWriter<>(avroSchema));
+      writer.create(avroSchema, avroFile);
+      writers.add(writer);
+    }
+    int edgeIdx = 0;
+    for (int i = 1; i <= NUM_USERS; i++) {
+      for (int j = 1; j <= FOLLOWS_PER_USER; j++) {
+        int target = ((i - 1 + j) % NUM_USERS) + 1;
+        GenericData.Record record = new GenericData.Record(avroSchema);
+        record.put("follower_id", i);
+        record.put("followee_id", target);
+        writers.get(edgeIdx % NUM_AVRO_FILES).append(record);
+        edgeIdx++;
+      }
+    }
+    for (DataFileWriter<GenericData.Record> writer : writers) {
+      writer.close();
+    }
+    return avroFiles;
+  }
+
+  // ---- Data verification tests ----
+
+  @Test
+  public void testTablesLoaded()
+      throws Exception {
+    // Use SSE for simple count queries
+    setUseMultiStageQueryEngine(false);
+    JsonNode usersResponse = postQuery("SELECT COUNT(*) FROM " + USERS_TABLE);
+    assertEquals(usersResponse.get("resultTable").get("rows").get(0).get(0).asLong(), NUM_USERS);
+
+    JsonNode followsResponse = postQuery("SELECT COUNT(*) FROM " + FOLLOWS_TABLE);
+    assertEquals(followsResponse.get("resultTable").get("rows").get(0).get(0).asLong(), (long) NUM_FOLLOWS);
+  }
+
+  @Test
+  public void testDistributedSqlJoinWorks()
+      throws Exception {
+    setUseMultiStageQueryEngine(false);
+    String sql = "SET useMultistageEngine=true; "
+        + "SELECT b.user_id FROM graphFollows AS e"
+        + " JOIN graphUsers AS a ON e.follower_id = a.user_id"
+        + " JOIN graphUsers AS b ON e.followee_id = b.user_id"
+        + " WHERE a.user_id = 1 LIMIT 100";
+    JsonNode response = postQuery(sql);
+    assertNotNull(response.get("resultTable"),
+        "Expected resultTable in response, got: " + response);
+    Set<Integer> followees = collectIntColumn(response.get("resultTable").get("rows"), 0);
+    assertEquals(followees, _expectedFollowees.get(1),
+        "SQL JOIN should return correct followees for user 1");
+  }
+
+  // ---- Graph query tests ----
+
+  @Test
+  public void testGraphQueryBasicOneHop()
+      throws Exception {
+    String cypher = "MATCH (a:User {id: 1})-[:FOLLOWS]->(b:User) RETURN b.id LIMIT 100";
+    JsonNode response = postGraphQuery(cypher);
+    Set<Integer> followees = collectIntColumn(response.get("resultTable").get("rows"), 0);
+    assertEquals(followees, _expectedFollowees.get(1));
+  }
+
+  @Test
+  public void testGraphQueryMultipleUsers()
+      throws Exception {
+    for (int userId : List.of(1, 13, 25, 37, 49)) {
+      String cypher = String.format(
+          "MATCH (a:User {id: %d})-[:FOLLOWS]->(b:User) RETURN b.id LIMIT 100", userId);
+      JsonNode response = postGraphQuery(cypher);
+      Set<Integer> followees = collectIntColumn(response.get("resultTable").get("rows"), 0);
+      assertEquals(followees, _expectedFollowees.get(userId),
+          "User " + userId + " followees mismatch");
+    }
+  }
+
+  @Test
+  public void testGraphQueryIncomingEdge()
+      throws Exception {
+    for (int userId : List.of(1, 25, 50)) {
+      String cypher = String.format(
+          "MATCH (a:User {id: %d})<-[:FOLLOWS]-(b:User) RETURN b.id LIMIT 100", userId);
+      JsonNode response = postGraphQuery(cypher);
+      Set<Integer> followers = collectIntColumn(response.get("resultTable").get("rows"), 0);
+      assertEquals(followers, _expectedFollowers.get(userId),
+          "User " + userId + " followers mismatch");
+    }
+  }
+
+  @Test
+  public void testGraphQueryWithLimit()
+      throws Exception {
+    String cypher = "MATCH (a:User {id: 1})-[:FOLLOWS]->(b:User) RETURN b.id LIMIT 2";
+    JsonNode response = postGraphQuery(cypher);
+    JsonNode rows = response.get("resultTable").get("rows");
+    assertEquals(rows.size(), 2, "LIMIT 2 should return exactly 2 results");
+    Set<Integer> followees = collectIntColumn(rows, 0);
+    assertTrue(_expectedFollowees.get(1).containsAll(followees));
+  }
+
+  @Test
+  public void testGraphQueryMultipleReturnColumns()
+      throws Exception {
+    String cypher = "MATCH (a:User {id: 1})-[:FOLLOWS]->(b:User) RETURN b.id, b.name LIMIT 100";
+    JsonNode response = postGraphQuery(cypher);
+    JsonNode rows = response.get("resultTable").get("rows");
+    assertEquals(rows.size(), FOLLOWS_PER_USER);
+    for (int i = 0; i < rows.size(); i++) {
+      int userId = rows.get(i).get(0).asInt();
+      assertEquals(rows.get(i).get(1).asText(), "user_" + userId);
+    }
+  }
+
+  @Test
+  public void testGraphQueryNoResults()
+      throws Exception {
+    String cypher = "MATCH (a:User {id: 999})-[:FOLLOWS]->(b:User) RETURN b.id LIMIT 100";
+    JsonNode response = postGraphQuery(cypher);
+    assertEquals(response.get("resultTable").get("rows").size(), 0);
+  }
+
+  // ---- Error handling tests ----
+
+  @Test
+  public void testGraphQueryInvalidCypher()
+      throws Exception {
+    try {
+      postGraphQuery("CREATE (n:User {id: 1})");
+    } catch (Exception e) {
+      assertTrue(e.getMessage().contains("400") || e.getMessage().contains("Unsupported"),
+          "Unsupported CREATE should return error: " + e.getMessage());
+    }
+  }
+
+  @Test
+  public void testGraphQueryMissingSchema()
+      throws Exception {
+    String url = getBrokerBaseApiUrl() + "/query/graph";
+    String payload = "{\"query\": \"MATCH (a:User)-[:FOLLOWS]->(b:User) RETURN b.id LIMIT 10\"}";
+    try {
+      sendPostRequest(url, payload);
+    } catch (Exception e) {
+      assertTrue(e.getMessage().contains("400") || e.getMessage().contains("graphSchema"),
+          "Missing schema should return 400: " + e.getMessage());
+    }
+  }
+
+  // ---- Helpers ----
+
+  private JsonNode postGraphQuery(String cypherQuery)
+      throws Exception {
+    String url = getBrokerBaseApiUrl() + "/query/graph";
+    String payload = "{\"query\": " + JsonUtils.objectToString(cypherQuery)
+        + ", \"graphSchema\": " + GRAPH_SCHEMA_JSON + "}";
+    String response = sendPostRequest(url, payload);
+    return JsonUtils.stringToJsonNode(response);
+  }
+
+  private static Set<Integer> collectIntColumn(JsonNode rows, int colIndex) {
+    Set<Integer> values = new HashSet<>();
+    if (rows != null) {
+      for (int i = 0; i < rows.size(); i++) {
+        values.add(rows.get(i).get(colIndex).asInt());
+      }
+    }
+    return values;
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -2839,6 +2839,17 @@ public class CommonConstants {
   }
 
   /**
+   * Constants for graph query configuration.
+   */
+  public static class Graph {
+    public static final String CONFIG_OF_GRAPH_QUERY_ENABLED = "pinot.graph.enabled";
+    public static final boolean DEFAULT_GRAPH_QUERY_ENABLED = false;
+
+    private Graph() {
+    }
+  }
+
+  /**
    * Constants for cluster config change listeners.
    */
   public static class ConfigChangeListenerConstants {

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,7 @@
     <module>pinot-query-planner</module>
     <module>pinot-query-runtime</module>
     <module>pinot-timeseries</module>
+    <module>pinot-graph</module>
     <module>pinot-udf-test</module>
     <module>pinot-sql-ddl</module>
   </modules>


### PR DESCRIPTION
## Summary

Adds an experimental graph query feature that translates a subset of openCypher into SQL JOINs and executes via Pinot's multi-stage engine. This enables graph-style traversal queries over existing Pinot tables without native graph runtime operators.

- New `pinot-graph` module (SPI + planner) with hand-written Cypher parser → IR → SQL transpiler
- `POST /query/graph` broker endpoint behind `pinot.graph.enabled` feature flag (default: false)
- Supports 1-hop and 2-hop traversals, WHERE (comparisons, AND/OR/NOT, STARTS WITH, ENDS WITH, CONTAINS, IN), RETURN (DISTINCT, AS aliases, COUNT/SUM/AVG/MIN/MAX with GROUP BY), ORDER BY, SKIP, LIMIT
- Graph schema passed inline in request JSON mapping vertex/edge labels to Pinot tables
- Zero impact on existing SQL query path — purely additive changes

Design doc posted on #17935: https://github.com/apache/pinot/issues/17935#issuecomment-4108165599

Closes #17935

## Test plan

- [x] 211 unit tests (parser: 94, SQL generator: 49, translator: 52, golden: 16) — all pass
- [x] 12 broker handler tests — all pass
- [x] 10 E2E integration tests with 2 servers and distributed data (50 users, 200 edges, 4 segments/table) — all pass
- [x] spotless, checkstyle, license checks — all clean
- [x] Existing SQL path unaffected (no modifications to query execution)
- [x] Feature disabled by default; returns clear 400 error when disabled
- [x] Unsupported Cypher syntax rejected with clear error messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)