### PR TITLE
Simplify FilterMvScalarFunction: replace static Guava cache with instance-level caching

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/function/scalar/FilterMvScalarFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/function/scalar/FilterMvScalarFunction.java
@@ -18,15 +18,11 @@
  */
 package org.apache.pinot.core.function.scalar;
 
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
 import java.util.EnumMap;
 import java.util.Map;
-import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.function.FunctionInfo;
 import org.apache.pinot.common.function.PinotScalarFunction;
-import org.apache.pinot.common.function.sql.PinotSqlFunction;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.operator.transform.function.FilterMvPredicateEvaluator;
 import org.apache.pinot.spi.annotations.ScalarFunction;
@@ -36,14 +32,14 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
 /**
  * Scalar wrapper for filterMv so FunctionRegistry can expose type signatures for query planning and execution paths
  * that resolve scalar functions.
+ *
+ * <p>Each FunctionInvoker creates a new instance of this class, so instance fields are safe to use without
+ * synchronization. The evaluator is cached per instance to avoid repeated creation for the same predicate.</p>
  */
-@ScalarFunction(names = {"filterMv"})
+@ScalarFunction
 public class FilterMvScalarFunction implements PinotScalarFunction {
-  private static final int MAX_CACHED_EVALUATORS = 10_000;
   private static final Map<ColumnDataType, FunctionInfo> TYPE_FUNCTION_INFO_MAP =
       new EnumMap<>(ColumnDataType.class);
-  private static final Cache<CacheKey, FilterMvPredicateEvaluator> EVALUATOR_CACHE =
-      CacheBuilder.newBuilder().maximumSize(MAX_CACHED_EVALUATORS).build();
 
   static {
     try {
@@ -70,21 +66,13 @@ public class FilterMvScalarFunction implements PinotScalarFunction {
     }
   }
 
+  private String _predicate;
+  private DataType _dataType;
+  private FilterMvPredicateEvaluator _evaluator;
+
   @Override
   public String getName() {
     return "filterMv";
-  }
-
-  @Override
-  public Set<String> getNames() {
-    return Set.of("filterMv");
-  }
-
-  @Nullable
-  @Override
-  public PinotSqlFunction toPinotSqlFunction() {
-    // Should already be registered in PinotOperatorTable by the transform function implementation
-    return null;
   }
 
   @Nullable
@@ -109,7 +97,7 @@ public class FilterMvScalarFunction implements PinotScalarFunction {
     return getFunctionInfo(new ColumnDataType[]{ColumnDataType.STRING_ARRAY, ColumnDataType.STRING});
   }
 
-  public static int[] filterMv(int[] values, String predicate) {
+  public int[] filterMv(int[] values, String predicate) {
     FilterMvPredicateEvaluator evaluator = evaluatorFor(predicate, DataType.INT);
     int numValues = values.length;
     int count = 0;
@@ -131,7 +119,7 @@ public class FilterMvScalarFunction implements PinotScalarFunction {
     return filtered;
   }
 
-  public static long[] filterMv(long[] values, String predicate) {
+  public long[] filterMv(long[] values, String predicate) {
     FilterMvPredicateEvaluator evaluator = evaluatorFor(predicate, DataType.LONG);
     int numValues = values.length;
     int count = 0;
@@ -153,7 +141,7 @@ public class FilterMvScalarFunction implements PinotScalarFunction {
     return filtered;
   }
 
-  public static float[] filterMv(float[] values, String predicate) {
+  public float[] filterMv(float[] values, String predicate) {
     FilterMvPredicateEvaluator evaluator = evaluatorFor(predicate, DataType.FLOAT);
     int numValues = values.length;
     int count = 0;
@@ -175,7 +163,7 @@ public class FilterMvScalarFunction implements PinotScalarFunction {
     return filtered;
   }
 
-  public static double[] filterMv(double[] values, String predicate) {
+  public double[] filterMv(double[] values, String predicate) {
     FilterMvPredicateEvaluator evaluator = evaluatorFor(predicate, DataType.DOUBLE);
     int numValues = values.length;
     int count = 0;
@@ -197,7 +185,7 @@ public class FilterMvScalarFunction implements PinotScalarFunction {
     return filtered;
   }
 
-  public static String[] filterMv(String[] values, String predicate) {
+  public String[] filterMv(String[] values, String predicate) {
     FilterMvPredicateEvaluator evaluator = evaluatorFor(predicate, DataType.STRING);
     int numValues = values.length;
     int count = 0;
@@ -219,7 +207,7 @@ public class FilterMvScalarFunction implements PinotScalarFunction {
     return filtered;
   }
 
-  public static byte[][] filterMv(byte[][] values, String predicate) {
+  public byte[][] filterMv(byte[][] values, String predicate) {
     FilterMvPredicateEvaluator evaluator = evaluatorFor(predicate, DataType.BYTES);
     int numValues = values.length;
     int count = 0;
@@ -241,46 +229,14 @@ public class FilterMvScalarFunction implements PinotScalarFunction {
     return filtered;
   }
 
-  private static FilterMvPredicateEvaluator evaluatorFor(String predicate, DataType dataType) {
-    CacheKey key = new CacheKey(predicate, dataType);
-    try {
-      return EVALUATOR_CACHE.get(key,
-          () -> FilterMvPredicateEvaluator.forPredicate(predicate, dataType, null));
-    } catch (Exception e) {
-      Throwable cause = e.getCause() != null ? e.getCause() : e;
-      if (cause instanceof RuntimeException) {
-        throw (RuntimeException) cause;
-      }
-      throw new IllegalArgumentException("Failed to create predicate evaluator for: " + predicate, cause);
-    }
-  }
-
-  private static final class CacheKey {
-    private final String _predicate;
-    private final DataType _dataType;
-
-    private CacheKey(String predicate, DataType dataType) {
+  private FilterMvPredicateEvaluator evaluatorFor(String predicate, DataType dataType) {
+    if (_evaluator == null || _dataType != dataType || !_predicate.equals(predicate)) {
+      // Build the new evaluator first so cached state is only updated after successful creation
+      FilterMvPredicateEvaluator newEvaluator = FilterMvPredicateEvaluator.forPredicate(predicate, dataType, null);
       _predicate = predicate;
       _dataType = dataType;
+      _evaluator = newEvaluator;
     }
-
-    @Override
-    public boolean equals(Object obj) {
-      if (this == obj) {
-        return true;
-      }
-      if (!(obj instanceof CacheKey)) {
-        return false;
-      }
-      CacheKey other = (CacheKey) obj;
-      return _dataType == other._dataType && _predicate.equals(other._predicate);
-    }
-
-    @Override
-    public int hashCode() {
-      int result = _predicate.hashCode();
-      result = 31 * result + _dataType.hashCode();
-      return result;
-    }
+    return _evaluator;
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/FilterMvTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/FilterMvTransformFunctionTest.java
@@ -256,39 +256,42 @@ public class FilterMvTransformFunctionTest extends BaseTransformFunctionTest {
 
   @Test
   public void testFilterMvScalarFunctionInt() {
+    FilterMvScalarFunction function = new FilterMvScalarFunction();
     // Test the scalar function INT overload directly
     int[] values = new int[]{1, 2, 3, 4, 5};
-    int[] filtered = FilterMvScalarFunction.filterMv(values, "v > 3");
+    int[] filtered = function.filterMv(values, "v > 3");
     assertEquals(filtered.length, 2);
     assertEquals(filtered[0], 4);
     assertEquals(filtered[1], 5);
 
     // No match
-    int[] filteredNone = FilterMvScalarFunction.filterMv(values, "v > 100");
+    int[] filteredNone = function.filterMv(values, "v > 100");
     assertEquals(filteredNone.length, 0);
 
     // All match
-    int[] filteredAll = FilterMvScalarFunction.filterMv(values, "v > 0");
+    int[] filteredAll = function.filterMv(values, "v > 0");
     assertEquals(filteredAll.length, 5);
   }
 
   @Test
   public void testFilterMvScalarFunctionLong() {
+    FilterMvScalarFunction function = new FilterMvScalarFunction();
     long[] values = new long[]{10L, 20L, 30L, 40L, 50L};
-    long[] filtered = FilterMvScalarFunction.filterMv(values, "v > 25");
+    long[] filtered = function.filterMv(values, "v > 25");
     assertEquals(filtered.length, 3);
     assertEquals(filtered[0], 30L);
     assertEquals(filtered[1], 40L);
     assertEquals(filtered[2], 50L);
 
-    long[] filteredNone = FilterMvScalarFunction.filterMv(values, "v > 100");
+    long[] filteredNone = function.filterMv(values, "v > 100");
     assertEquals(filteredNone.length, 0);
   }
 
   @Test
   public void testFilterMvScalarFunctionFloat() {
+    FilterMvScalarFunction function = new FilterMvScalarFunction();
     float[] values = new float[]{1.1f, 2.2f, 3.3f, 4.4f};
-    float[] filtered = FilterMvScalarFunction.filterMv(values, "v > 2.5");
+    float[] filtered = function.filterMv(values, "v > 2.5");
     assertEquals(filtered.length, 2);
     assertEquals(filtered[0], 3.3f);
     assertEquals(filtered[1], 4.4f);
@@ -296,8 +299,9 @@ public class FilterMvTransformFunctionTest extends BaseTransformFunctionTest {
 
   @Test
   public void testFilterMvScalarFunctionDouble() {
+    FilterMvScalarFunction function = new FilterMvScalarFunction();
     double[] values = new double[]{1.1, 2.2, 3.3, 4.4};
-    double[] filtered = FilterMvScalarFunction.filterMv(values, "v > 2.5");
+    double[] filtered = function.filterMv(values, "v > 2.5");
     assertEquals(filtered.length, 2);
     assertEquals(filtered[0], 3.3);
     assertEquals(filtered[1], 4.4);
@@ -305,14 +309,15 @@ public class FilterMvTransformFunctionTest extends BaseTransformFunctionTest {
 
   @Test
   public void testFilterMvScalarFunctionString() {
+    FilterMvScalarFunction function = new FilterMvScalarFunction();
     String[] values = new String[]{"apple", "banana", "cherry", "date"};
-    String[] filtered = FilterMvScalarFunction.filterMv(values, "v IN ('apple', 'cherry')");
+    String[] filtered = function.filterMv(values, "v IN ('apple', 'cherry')");
     assertEquals(filtered.length, 2);
     assertEquals(filtered[0], "apple");
     assertEquals(filtered[1], "cherry");
 
     // REGEXP_LIKE
-    String[] filteredRegex = FilterMvScalarFunction.filterMv(values, "REGEXP_LIKE(v, '^[a-b].*')");
+    String[] filteredRegex = function.filterMv(values, "REGEXP_LIKE(v, '^[a-b].*')");
     assertEquals(filteredRegex.length, 2);
     assertEquals(filteredRegex[0], "apple");
     assertEquals(filteredRegex[1], "banana");
@@ -326,17 +331,19 @@ public class FilterMvTransformFunctionTest extends BaseTransformFunctionTest {
     byte[] val3 = BytesUtils.toBytes("eeff");
     byte[][] values = new byte[][]{val1, val2, val3};
 
+    FilterMvScalarFunction function = new FilterMvScalarFunction();
+
     // Positive match: filter to values equal to 'ccdd'
-    byte[][] filtered = FilterMvScalarFunction.filterMv(values, "v = 'ccdd'");
+    byte[][] filtered = function.filterMv(values, "v = 'ccdd'");
     assertEquals(filtered.length, 1);
     assertEquals(filtered[0], val2);
 
     // Negative match: filter to values equal to non-existent value
-    byte[][] filteredNone = FilterMvScalarFunction.filterMv(values, "v = '0000'");
+    byte[][] filteredNone = function.filterMv(values, "v = '0000'");
     assertEquals(filteredNone.length, 0);
 
     // All match: always-true predicate returns original array
-    byte[][] filteredAll = FilterMvScalarFunction.filterMv(values, "v != '0000'");
+    byte[][] filteredAll = function.filterMv(values, "v != '0000'");
     assertEquals(filteredAll.length, 3);
   }
 


### PR DESCRIPTION
## Summary
Follow-up cleanup to #17659.

- Remove static Guava `Cache` and `CacheKey` class; replace with simple instance-level evaluator caching
- Remove redundant `getNames()` and `toPinotSqlFunction()` overrides that duplicate default behavior
- Use bare `@ScalarFunction` annotation since `getName()` already returns `"filterMv"`
- Convert static `filterMv` methods to instance methods so the evaluator can be reused per instance
- Update test to instantiate `FilterMvScalarFunction` instead of using static calls
- Each `FunctionInvoker` creates its own instance, so instance fields are thread-safe without synchronization

## Test plan
- [x] `FilterMvTransformFunctionTest` — all 34 tests pass (updated to use instance methods)
- [ ] Integration tests in `ArrayTest` validate end-to-end MV filtering

🤖 Generated with [Claude Code](https://claude.com/claude-code)