### PR TITLE
Fix incorrect stream partition id for multi-stream realtime consumption

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -1756,7 +1756,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
     String streamTopic = _streamConfig.getTopicName();
     _segmentNameStr = _segmentZKMetadata.getSegmentName();
     _partitionGroupConsumptionStatus =
-        new PartitionGroupConsumptionStatus(_partitionGroupId, llcSegmentName.getSequenceNumber(),
+        new PartitionGroupConsumptionStatus(_partitionGroupId, _streamPartitionId, llcSegmentName.getSequenceNumber(),
             _streamPartitionMsgOffsetFactory.create(_segmentZKMetadata.getStartOffset()),
             _segmentZKMetadata.getEndOffset() == null ? null
                 : _streamPartitionMsgOffsetFactory.create(_segmentZKMetadata.getEndOffset()),


### PR DESCRIPTION

<img width="2193" height="160" alt="Screenshot 2026-03-24 at 10 42 21" src="https://github.com/user-attachments/assets/a5ab4afb-b9e7-4153-9758-d3592f2f0bb2" />

### Summary

This PR fixes a bug in multi-stream realtime consumption where the server can use the Pinot `partitionGroupId`
instead of the actual upstream `streamPartitionId` when creating the consuming state for a segment.

The server already derives the correct `_streamPartitionId`, but when constructing
`PartitionGroupConsumptionStatus` in `RealtimeSegmentDataManager`, it previously used the constructor that defaults:

`streamPartitionId = partitionGroupId`

As a result, the Kafka consumer could incorrectly consume partition `10000` instead of partition `0`.

This change updates `RealtimeSegmentDataManager` to explicitly pass the derived `_streamPartitionId`
when creating `PartitionGroupConsumptionStatus`.