### PR TITLE
Improve fastdev build cycle performance.

### DIFF
--- a/pinot-common/pom.xml
+++ b/pinot-common/pom.xml
@@ -398,7 +398,7 @@
       <id>sqlparser</id>
       <activation>
         <file>
-          <missing>${project.build.directory}/generated-sources/javacc/Parser.jj</missing>
+          <missing>${basedir}/target/generated-sources/javacc/Parser.jj</missing>
         </file>
       </activation>
       <build>

--- a/pinot-plugins/pinot-input-format/pinot-protobuf/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-protobuf/pom.xml
@@ -56,6 +56,7 @@
         <groupId>org.xolstice.maven.plugins</groupId>
         <artifactId>protobuf-maven-plugin</artifactId>
         <configuration>
+          <checkStaleness>true</checkStaleness>
           <protoTestSourceRoot>${basedir}/src/test/resources</protoTestSourceRoot>
         </configuration>
         <executions>

--- a/pinot-plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/pom.xml
+++ b/pinot-plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/pom.xml
@@ -94,5 +94,11 @@
         <shade.phase.prop>package</shade.phase.prop>
       </properties>
     </profile>
+    <profile>
+      <id>pinot-fastdev</id>
+      <properties>
+        <shade.phase.prop>none</shade.phase.prop>
+      </properties>
+    </profile>
   </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -137,6 +137,10 @@
     <!-- Configuration for Packaging -->
     <shade.prefix>org.apache.pinot.shaded</shade.prefix>
     <shade.phase.prop>none</shade.phase.prop>
+    <!-- Keep these enabled by default; fastdev can disable them for incremental builds. -->
+    <pinot.skip.buildnumber>false</pinot.skip.buildnumber>
+    <package.info.phase>generate-sources</package.info.phase>
+    <pinot.skip.remote.resources>false</pinot.skip.remote.resources>
 
     <arrow.version>19.0.0</arrow.version>
     <avro.version>1.12.1</avro.version>
@@ -368,6 +372,10 @@
         <shade.phase.prop>none</shade.phase.prop>
         <archiver.compress>false</archiver.compress>
         <archiver.recompressZippedFiles>false</archiver.recompressZippedFiles>
+        <!-- Avoid rewriting metadata/generated sources on every local build. -->
+        <pinot.skip.buildnumber>true</pinot.skip.buildnumber>
+        <package.info.phase>none</package.info.phase>
+        <pinot.skip.remote.resources>true</pinot.skip.remote.resources>
       </properties>
     </profile>
     <!--build profile for linux-aarch64. We exclude certain tests as they use runtime JNI bindings not supported for linux-aarch64-->
@@ -2883,6 +2891,9 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>buildnumber-maven-plugin</artifactId>
+        <configuration>
+          <skip>${pinot.skip.buildnumber}</skip>
+        </configuration>
         <executions>
           <execution>
             <phase>validate</phase>
@@ -2970,6 +2981,7 @@
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-remote-resources-plugin</artifactId>
         <configuration>
+          <skip>${pinot.skip.remote.resources}</skip>
           <properties>
             <projectName>Apache Pinot</projectName>
           </properties>
@@ -2981,7 +2993,7 @@
         <version>2.0.0</version>
         <executions>
           <execution>
-            <phase>generate-sources</phase>
+            <phase>${package.info.phase}</phase>
             <goals>
               <goal>package-info</goal>
             </goals>


### PR DESCRIPTION
## Summary
- Improves local Maven iteration speed by adding configurable skips for expensive non-essential build steps.
- Extends the `pinot-fastdev` profile to disable build number generation, remote resource processing, and package-info generation phase work.
- Adds incremental-friendly updates in module poms (`protobuf` staleness check and `pinot-common` JavaCC missing-file path fix) to reduce unnecessary regeneration.

## Why
Local development loops were doing extra work even when source changes didn’t require it. This change keeps default behavior unchanged, while making `pinot-fastdev` meaningfully faster and more predictable for incremental builds.

## Changes Included (with effect)

- `pom.xml`
  - Added property `pinot.skip.buildnumber` and wired it into `buildnumber-maven-plugin`'s `skip` flag.
    - **Effect:** avoids build-number metadata generation in fastdev, reducing per-build overhead and file churn.
  - Added property `pinot.skip.remote.resources` and wired it into `maven-remote-resources-plugin`'s `skip` flag.
    - **Effect:** skips remote-resource processing in fastdev, reducing plugin execution time for local iterations.
  - Added property `package.info.phase` and wired it into `package-info-maven-plugin` execution `phase`.
    - **Effect:** allows disabling package-info generation work in fastdev by setting the phase to `none`, reducing unnecessary generated-source work.
  - Updated `pinot-fastdev` profile to set:
    - `pinot.skip.buildnumber=true`
    - `pinot.skip.remote.resources=true`
    - `package.info.phase=none`
  - **Effect:** centralizes fast local-build behavior behind one profile without changing default build behavior.

- `pinot-common/pom.xml`
  - Changed JavaCC profile activation missing-file path to `${basedir}/target/generated-sources/javacc/Parser.jj`.
  - **Effect:** makes activation check path resolution more reliable in module-local builds, reducing accidental/regressive re-generation behavior.

- `pinot-plugins/pinot-input-format/pinot-protobuf/pom.xml`
  - Enabled protobuf plugin `checkStaleness=true`.
  - **Effect:** avoids regenerating protobuf outputs when inputs are unchanged, improving incremental build performance.

- `pinot-plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/pom.xml`
  - Added `pinot-fastdev` profile override to set `shade.phase.prop=none`.
  - **Effect:** skips shading in fastdev for this module, reducing local build time during edit/compile loops.

## Behavior / Compatibility
- Default builds are unchanged unless `pinot-fastdev` (or the new properties) are explicitly used.
- No runtime/query behavior changes; this PR is build-system-only.

## Test Plan
- Run baseline local build:
  - `./mvnw -pl pinot-common -am -DskipTests compile`
- Run with fastdev profile:
  - `./mvnw -pl pinot-common -am -Ppinot-fastdev -DskipTests compile`
- Re-run same commands without source changes and verify incremental runs avoid unnecessary regeneration/shading/resource work.
- Spot-check protobuf module:
  - `./mvnw -pl pinot-plugins/pinot-input-format/pinot-protobuf -am -DskipTests compile`