### PR TITLE
Add quickstart process-specific config override hooks.

### DIFF
--- a/pinot-tools/src/main/java/org/apache/pinot/tools/Quickstart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/Quickstart.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.spi.auth.AuthProvider;
@@ -57,6 +58,14 @@ public class Quickstart extends QuickStartBase {
     return null;
   }
 
+  protected Map<String, Object> getIndividualBrokerConfigOverridesFunction(int brokerId) {
+    return Map.of();
+  }
+
+  protected Map<String, Object> getIndividualServerConfigOverridesFunction(int serverId) {
+    return Map.of();
+  }
+
   public void execute()
       throws Exception {
     File quickstartTmpDir =
@@ -67,7 +76,9 @@ public class Quickstart extends QuickStartBase {
 
     QuickstartRunner runner =
         new QuickstartRunner(quickstartTableRequests, 1, 1, getNumQuickstartRunnerServers(), 1, quickstartRunnerDir,
-            true, getAuthProvider(), getConfigOverrides(), _zkExternalAddress, true, getClusterConfigOverrides());
+            true, getAuthProvider(),
+            getConfigOverrides(), _zkExternalAddress, true, getClusterConfigOverrides(),
+            this::getIndividualBrokerConfigOverridesFunction, this::getIndividualServerConfigOverridesFunction);
 
     printStatus(Color.CYAN, "***** Starting Zookeeper, controller, broker, server and minion *****");
     runner.startAll();

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/QuickstartRunner.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/QuickstartRunner.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.function.IntFunction;
 import org.apache.commons.io.FileUtils;
 import org.apache.helix.HelixManager;
 import org.apache.helix.HelixManagerFactory;
@@ -75,6 +76,8 @@ public class QuickstartRunner {
   private final AuthProvider _authProvider;
   private final Map<String, Object> _configOverrides;
   private final Map<String, String> _clusterConfigOverrides;
+  private final IntFunction<Map<String, Object>> _individualBrokerConfigOverridesFunction;
+  private final IntFunction<Map<String, Object>> _individualServerConfigOverridesFunction;
   private final boolean _deleteExistingData;
 
   // If this field is non-null, an embedded Zookeeper instance will not be launched
@@ -103,6 +106,18 @@ public class QuickstartRunner {
       Map<String, Object> configOverrides, String zkExternalAddress, boolean deleteExistingData,
       Map<String, String> clusterConfigOverrides)
       throws Exception {
+    this(tableRequests, numControllers, numBrokers, numServers, numMinions, tempDir, enableIsolation, authProvider,
+        configOverrides, zkExternalAddress, deleteExistingData, clusterConfigOverrides, i -> Map.of(),
+        i -> Map.of());
+  }
+
+  public QuickstartRunner(List<QuickstartTableRequest> tableRequests, int numControllers, int numBrokers,
+      int numServers, int numMinions, File tempDir, boolean enableIsolation, AuthProvider authProvider,
+      Map<String, Object> configOverrides, String zkExternalAddress, boolean deleteExistingData,
+      Map<String, String> clusterConfigOverrides,
+      IntFunction<Map<String, Object>> individualBrokerConfigOverridesFunction,
+      IntFunction<Map<String, Object>> individualServerConfigOverridesFunction
+  ) throws Exception {
     _tableRequests = tableRequests;
     _numControllers = numControllers;
     _numBrokers = numBrokers;
@@ -113,6 +128,8 @@ public class QuickstartRunner {
     _authProvider = authProvider;
     _configOverrides = new HashMap<>(configOverrides);
     _clusterConfigOverrides = clusterConfigOverrides;
+    _individualBrokerConfigOverridesFunction = individualBrokerConfigOverridesFunction;
+    _individualServerConfigOverridesFunction = individualServerConfigOverridesFunction;
     if (numMinions > 0) {
       // configure the controller to schedule tasks when minion is enabled
       _configOverrides.put("controller.task.scheduler.enabled", true);
@@ -164,10 +181,19 @@ public class QuickstartRunner {
       throws Exception {
     for (int i = 0; i < _numBrokers; i++) {
       StartBrokerCommand brokerStarter = new StartBrokerCommand();
-      brokerStarter.setPort(DEFAULT_BROKER_PORT + i)
+      brokerStarter
+          .setPort(DEFAULT_BROKER_PORT + i)
           .setGrpcPort(DEFAULT_BROKER_GRPC_PORT + i)
-          .setZkAddress(_zkExternalAddress != null ? _zkExternalAddress : ZK_ADDRESS).setClusterName(CLUSTER_NAME)
-          .setConfigOverrides(_configOverrides);
+          .setZkAddress(_zkExternalAddress != null ? _zkExternalAddress : ZK_ADDRESS).setClusterName(CLUSTER_NAME);
+
+      Map<String, Object> individualBrokerConfigOverrides = _individualBrokerConfigOverridesFunction.apply(i);
+      if (!individualBrokerConfigOverrides.isEmpty()) {
+        Map<String, Object> config = new HashMap<>(_configOverrides);
+        config.putAll(individualBrokerConfigOverrides);
+        brokerStarter.setConfigOverrides(config);
+      } else {
+        brokerStarter.setConfigOverrides(_configOverrides);
+      }
       if (!brokerStarter.execute()) {
         throw new RuntimeException("Failed to start Broker");
       }
@@ -179,12 +205,22 @@ public class QuickstartRunner {
       throws Exception {
     for (int i = 0; i < _numServers; i++) {
       StartServerCommand serverStarter = new StartServerCommand();
-      serverStarter.setPort(DEFAULT_SERVER_NETTY_PORT + i).setAdminPort(DEFAULT_SERVER_ADMIN_API_PORT + i)
+      serverStarter
+          .setPort(DEFAULT_SERVER_NETTY_PORT + i)
+          .setAdminPort(DEFAULT_SERVER_ADMIN_API_PORT + i)
           .setGrpcPort(DEFAULT_SERVER_GRPC_PORT + i)
           .setZkAddress(_zkExternalAddress != null ? _zkExternalAddress : ZK_ADDRESS).setClusterName(CLUSTER_NAME)
           .setDataDir(new File(_tempDir, DEFAULT_SERVER_DATA_DIR + i).getAbsolutePath())
-          .setSegmentDir(new File(_tempDir, DEFAULT_SERVER_SEGMENT_DIR + i).getAbsolutePath())
-          .setConfigOverrides(_configOverrides);
+          .setSegmentDir(new File(_tempDir, DEFAULT_SERVER_SEGMENT_DIR + i).getAbsolutePath());
+
+      Map<String, Object> individualControllerConfigOverrides = _individualServerConfigOverridesFunction.apply(i);
+      if (!individualControllerConfigOverrides.isEmpty()) {
+        Map<String, Object> config = new HashMap<>(_configOverrides);
+        config.putAll(individualControllerConfigOverrides);
+        serverStarter.setConfigOverrides(config);
+      } else {
+        serverStarter.setConfigOverrides(_configOverrides);
+      }
       if (!serverStarter.execute()) {
         throw new RuntimeException("Failed to start Server");
       }


### PR DESCRIPTION
## Summary
- Adds process-specific config override hooks to quickstart startup wiring.
- Enables supplying different config maps for broker and server processes at launch time.
- Keeps existing quickstart behavior intact when no overrides are provided.

## Why
Quickstart currently uses mostly shared/default process config at startup. To support extension scenarios and targeted local testing, we need a simple way to inject per-process overrides (for example, different broker/server settings) without rewriting quickstart flows.

This, for example, opens the ability to explicitly set the ports used by each service.

## Changes Included (with effect)

- `pinot-tools/src/main/java/org/apache/pinot/tools/Quickstart.java`
  - Added wiring to pass broker/server-specific override maps into runner startup.
  - Introduced/used hooks to construct per-process override config when launching components.
  - **Effect:** quickstart can now customize broker and server runtime properties independently.

- `pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/QuickstartRunner.java`
  - Added constructor/path support for functional config providers (e.g., `IntFunction<Map<String, Object>>`) for broker/server process overrides.
  - Integrated override maps into process launch config assembly.
  - Preserved existing constructor/default behavior for call sites that do not provide overrides.
  - **Effect:** extends quickstart runner in a backward-compatible way while enabling more flexible local startup configuration.

## Behavior / Compatibility
- Backward compatible: existing quickstart commands behave the same unless override hooks are used.
- No query engine semantics change; this is tooling/startup configuration plumbing.
- Improves local dev/test ergonomics for scenarios requiring role-specific settings.

## Test Plan
- Build affected module:
  - `./mvnw -pl pinot-tools -am -DskipTests compile`
- Run quickstart command(s) without overrides and verify unchanged startup behavior.
- Run quickstart command(s) with broker/server override maps and verify the overrides are applied to the intended process only.