### PR TITLE
Fix Netty 4.2 shutdown and TLS compatibility gaps

### DIFF
--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/BrokerCache.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/BrokerCache.java
@@ -20,8 +20,6 @@ package org.apache.pinot.client;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.core.type.TypeReference;
-import io.netty.handler.ssl.ClientAuth;
-import io.netty.handler.ssl.JdkSslContext;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -40,6 +38,7 @@ import javax.annotation.Nullable;
 import javax.net.ssl.SSLContext;
 import org.apache.pinot.client.utils.BrokerSelectorUtils;
 import org.apache.pinot.client.utils.ConnectionUtils;
+import org.apache.pinot.common.config.TlsConfig;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.builder.ControllerRequestURLBuilder;
@@ -56,6 +55,7 @@ import org.asynchttpclient.Response;
  * TODO can we introduce a SSE based controller endpoint to make the update reactive in the client?
  */
 public class BrokerCache {
+  private static final SslContextProvider SSL_CONTEXT_PROVIDER = SslContextProviderFactory.create();
 
   @JsonIgnoreProperties(ignoreUnknown = true)
   private static class BrokerInstance {
@@ -107,11 +107,6 @@ public class BrokerCache {
   public BrokerCache(Properties properties, String controllerUrl) {
     String scheme = properties.getProperty(SCHEME, CommonConstants.HTTP_PROTOCOL);
     DefaultAsyncHttpClientConfig.Builder builder = Dsl.config();
-    if (scheme.contentEquals(CommonConstants.HTTPS_PROTOCOL)) {
-      SSLContext sslContext = ConnectionUtils.getSSLContextFromProperties(properties);
-      builder.setSslContext(new JdkSslContext(sslContext, true, ClientAuth.OPTIONAL));
-    }
-
     int readTimeoutMs = Integer.parseInt(properties.getProperty("controllerReadTimeoutMs",
         DEFAULT_CONTROLLER_READ_TIMEOUT_MS));
     int connectTimeoutMs = Integer.parseInt(properties.getProperty("controllerConnectTimeoutMs",
@@ -125,6 +120,11 @@ public class BrokerCache {
         DEFAULT_CONTROLLER_TLS_V10_ENABLED));
 
     TlsProtocols tlsProtocols = TlsProtocols.defaultProtocols(tlsV10Enabled);
+    if (scheme.contentEquals(CommonConstants.HTTPS_PROTOCOL)) {
+      TlsConfig tlsConfig = ConnectionUtils.getTlsConfigFromProperties(properties);
+      SSLContext sslContext = ConnectionUtils.getSSLContextFromProperties(properties);
+      SSL_CONTEXT_PROVIDER.configure(builder, sslContext, tlsProtocols, tlsConfig.getEndpointIdentificationAlgorithm());
+    }
     builder.setReadTimeout(Duration.ofMillis(readTimeoutMs))
         .setConnectTimeout(Duration.ofMillis(connectTimeoutMs))
         .setHandshakeTimeout(handshakeTimeoutMs)

--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/DefaultSslContextProvider.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/DefaultSslContextProvider.java
@@ -22,6 +22,7 @@ import java.util.List;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLParameters;
 import org.asynchttpclient.DefaultAsyncHttpClientConfig;
 
 
@@ -33,6 +34,13 @@ public class DefaultSslContextProvider implements SslContextProvider {
   @Override
   public DefaultAsyncHttpClientConfig.Builder configure(DefaultAsyncHttpClientConfig.Builder builder,
       @Nullable SSLContext sslContext, TlsProtocols tlsProtocols) {
+    return configure(builder, sslContext, tlsProtocols, null);
+  }
+
+  @Override
+  public DefaultAsyncHttpClientConfig.Builder configure(DefaultAsyncHttpClientConfig.Builder builder,
+      @Nullable SSLContext sslContext, @Nullable TlsProtocols tlsProtocols,
+      @Nullable String endpointIdentificationAlgorithm) {
     builder.setUseOpenSsl(false);
 
     List<String> enabledProtocolList = List.of();
@@ -47,6 +55,10 @@ public class DefaultSslContextProvider implements SslContextProvider {
       builder.setSslEngineFactory((config, peerHost, peerPort) -> {
         SSLEngine engine = sslContext.createSSLEngine(peerHost, peerPort);
         engine.setUseClientMode(true);
+        SSLParameters sslParameters = engine.getSSLParameters();
+        sslParameters.setEndpointIdentificationAlgorithm(normalizeEndpointIdentificationAlgorithm(
+            endpointIdentificationAlgorithm));
+        engine.setSSLParameters(sslParameters);
         if (enabledProtocols.length > 0) {
           engine.setEnabledProtocols(enabledProtocols);
         }
@@ -57,5 +69,13 @@ public class DefaultSslContextProvider implements SslContextProvider {
       builder.setEnabledProtocols(enabledProtocols);
     }
     return builder;
+  }
+
+  @Nullable
+  private static String normalizeEndpointIdentificationAlgorithm(@Nullable String endpointIdentificationAlgorithm) {
+    if (endpointIdentificationAlgorithm == null || endpointIdentificationAlgorithm.isBlank()) {
+      return null;
+    }
+    return endpointIdentificationAlgorithm;
   }
 }

--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/JsonAsyncHttpPinotClientTransport.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/JsonAsyncHttpPinotClientTransport.java
@@ -82,6 +82,13 @@ public class JsonAsyncHttpPinotClientTransport implements PinotClientTransport<C
 
   public JsonAsyncHttpPinotClientTransport(Map<String, String> headers, String scheme, String extraOptionString,
       boolean useMultistageEngine, @Nullable SSLContext sslContext, ConnectionTimeouts connectionTimeouts,
+      TlsProtocols tlsProtocols) {
+    this(headers, scheme, extraOptionString, useMultistageEngine, sslContext, connectionTimeouts, tlsProtocols, null,
+        null);
+  }
+
+  public JsonAsyncHttpPinotClientTransport(Map<String, String> headers, String scheme, String extraOptionString,
+      boolean useMultistageEngine, @Nullable SSLContext sslContext, ConnectionTimeouts connectionTimeouts,
       TlsProtocols tlsProtocols, @Nullable String appId, @Nullable String endpointIdentificationAlgorithm) {
     _brokerReadTimeout = connectionTimeouts.getReadTimeoutMs();
     _headers = headers;

--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/JsonAsyncHttpPinotClientTransport.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/JsonAsyncHttpPinotClientTransport.java
@@ -67,7 +67,7 @@ public class JsonAsyncHttpPinotClientTransport implements PinotClientTransport<C
     _scheme = CommonConstants.HTTP_PROTOCOL;
     _extraOptionStr = DEFAULT_EXTRA_QUERY_OPTION_STRING;
     Builder builder = Dsl.config();
-    SSL_CONTEXT_PROVIDER.configure(builder, null, TlsProtocols.defaultProtocols(false));
+    SSL_CONTEXT_PROVIDER.configure(builder, null, TlsProtocols.defaultProtocols(false), null);
     _httpClient =
         Dsl.asyncHttpClient(builder.setRequestTimeout(Duration.ofMillis(_brokerReadTimeout)).build());
     _useMultistageEngine = false;
@@ -76,6 +76,13 @@ public class JsonAsyncHttpPinotClientTransport implements PinotClientTransport<C
   public JsonAsyncHttpPinotClientTransport(Map<String, String> headers, String scheme, String extraOptionString,
       boolean useMultistageEngine, @Nullable SSLContext sslContext, ConnectionTimeouts connectionTimeouts,
       TlsProtocols tlsProtocols, @Nullable String appId) {
+    this(headers, scheme, extraOptionString, useMultistageEngine, sslContext, connectionTimeouts, tlsProtocols, appId,
+        null);
+  }
+
+  public JsonAsyncHttpPinotClientTransport(Map<String, String> headers, String scheme, String extraOptionString,
+      boolean useMultistageEngine, @Nullable SSLContext sslContext, ConnectionTimeouts connectionTimeouts,
+      TlsProtocols tlsProtocols, @Nullable String appId, @Nullable String endpointIdentificationAlgorithm) {
     _brokerReadTimeout = connectionTimeouts.getReadTimeoutMs();
     _headers = headers;
     _scheme = scheme;
@@ -83,7 +90,7 @@ public class JsonAsyncHttpPinotClientTransport implements PinotClientTransport<C
     _useMultistageEngine = useMultistageEngine;
 
     Builder builder = Dsl.config();
-    SSL_CONTEXT_PROVIDER.configure(builder, sslContext, tlsProtocols);
+    SSL_CONTEXT_PROVIDER.configure(builder, sslContext, tlsProtocols, endpointIdentificationAlgorithm);
     builder.setRequestTimeout(Duration.ofMillis(_brokerReadTimeout))
         .setReadTimeout(Duration.ofMillis(connectionTimeouts.getReadTimeoutMs()))
         .setConnectTimeout(Duration.ofMillis(connectionTimeouts.getConnectTimeoutMs()))

--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/JsonAsyncHttpPinotClientTransportFactory.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/JsonAsyncHttpPinotClientTransportFactory.java
@@ -39,6 +39,7 @@ public class JsonAsyncHttpPinotClientTransportFactory implements PinotClientTran
   private Map<String, String> _headers = new HashMap<>();
   private String _scheme = CommonConstants.HTTP_PROTOCOL;
   private SSLContext _sslContext = null;
+  private String _endpointIdentificationAlgorithm = "";
   private boolean _tlsV10Enabled = false;
   private int _readTimeoutMs = Integer.parseInt(DEFAULT_BROKER_READ_TIMEOUT_MS);
   private int _connectTimeoutMs = Integer.parseInt(DEFAULT_BROKER_READ_TIMEOUT_MS);
@@ -53,7 +54,7 @@ public class JsonAsyncHttpPinotClientTransportFactory implements PinotClientTran
         ConnectionTimeouts.create(_readTimeoutMs, _connectTimeoutMs, _handshakeTimeoutMs);
     TlsProtocols tlsProtocols = TlsProtocols.defaultProtocols(_tlsV10Enabled);
     return new JsonAsyncHttpPinotClientTransport(_headers, _scheme, _extraOptionString, _useMultistageEngine,
-        _sslContext, connectionTimeouts, tlsProtocols, _appId);
+        _sslContext, connectionTimeouts, tlsProtocols, _appId, _endpointIdentificationAlgorithm);
   }
 
   public Map<String, String> getHeaders() {
@@ -80,6 +81,10 @@ public class JsonAsyncHttpPinotClientTransportFactory implements PinotClientTran
     _sslContext = sslContext;
   }
 
+  public void setEndpointIdentificationAlgorithm(String endpointIdentificationAlgorithm) {
+    _endpointIdentificationAlgorithm = endpointIdentificationAlgorithm;
+  }
+
   public JsonAsyncHttpPinotClientTransportFactory withConnectionProperties(Properties properties) {
     if (_headers == null || _headers.isEmpty()) {
       _headers = ConnectionUtils.getHeadersFromProperties(properties);
@@ -90,8 +95,14 @@ public class JsonAsyncHttpPinotClientTransportFactory implements PinotClientTran
       _scheme = CommonConstants.HTTP_PROTOCOL;
     }
 
-    if (_sslContext == null && _scheme.contentEquals(CommonConstants.HTTPS_PROTOCOL)) {
-      _sslContext = ConnectionUtils.getSSLContextFromProperties(properties);
+    if (_scheme.contentEquals(CommonConstants.HTTPS_PROTOCOL)) {
+      _endpointIdentificationAlgorithm =
+          ConnectionUtils.getTlsConfigFromProperties(properties).getEndpointIdentificationAlgorithm();
+      if (_sslContext == null) {
+        _sslContext = ConnectionUtils.getSSLContextFromProperties(properties);
+      }
+    } else {
+      _endpointIdentificationAlgorithm = "";
     }
 
     _readTimeoutMs = Integer.parseInt(properties.getProperty("brokerReadTimeoutMs", DEFAULT_BROKER_READ_TIMEOUT_MS));

--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/SslContextProvider.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/SslContextProvider.java
@@ -42,4 +42,19 @@ public interface SslContextProvider {
    */
   DefaultAsyncHttpClientConfig.Builder configure(DefaultAsyncHttpClientConfig.Builder builder,
       @Nullable SSLContext sslContext, TlsProtocols tlsProtocols);
+
+  /**
+   * Configure the AsyncHttpClient builder with SSL/TLS settings and an explicit endpoint identification algorithm.
+   *
+   * @param builder the client config builder to update
+   * @param sslContext optional SSL context to use
+   * @param tlsProtocols configured TLS protocol list; {@code null} means protocols should not be configured
+   * @param endpointIdentificationAlgorithm endpoint identification algorithm for hostname verification
+   * @return the same builder for chaining
+   */
+  default DefaultAsyncHttpClientConfig.Builder configure(DefaultAsyncHttpClientConfig.Builder builder,
+      @Nullable SSLContext sslContext, @Nullable TlsProtocols tlsProtocols,
+      @Nullable String endpointIdentificationAlgorithm) {
+    return configure(builder, sslContext, tlsProtocols);
+  }
 }

--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/admin/PinotAdminTransport.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/admin/PinotAdminTransport.java
@@ -100,12 +100,8 @@ public class PinotAdminTransport implements AutoCloseable {
     if (CommonConstants.HTTPS_PROTOCOL.equalsIgnoreCase(scheme)) {
       try {
         TlsConfig tlsConfig = ConnectionUtils.getTlsConfigFromProperties(properties);
-        // NOTE: ConnectionUtils.getSSLContextFromProperties(...) installs a JVM-global default SSLSocketFactory
-        // and updates the shared TlsUtils SSLContext. PinotAdminTransport has historically inherited that process-
-        // wide side effect from the shared helper, so callers enabling HTTPS here should treat the TLS config as
-        // affecting other HttpsURLConnection-based clients in the same JVM.
         SSLContext sslContext =
-            _sslContext != null ? _sslContext : ConnectionUtils.getSSLContextFromProperties(properties);
+            _sslContext != null ? _sslContext : ConnectionUtils.createSSLContextFromProperties(properties);
         SSL_CONTEXT_PROVIDER.configure(builder, sslContext, null, tlsConfig.getEndpointIdentificationAlgorithm());
       } catch (Exception e) {
         LOGGER.warn("Failed to configure SSL context, proceeding without SSL", e);

--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/admin/PinotAdminTransport.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/admin/PinotAdminTransport.java
@@ -32,7 +32,10 @@ import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import javax.net.ssl.SSLContext;
+import org.apache.pinot.client.SslContextProvider;
+import org.apache.pinot.client.SslContextProviderFactory;
 import org.apache.pinot.client.utils.ConnectionUtils;
+import org.apache.pinot.common.config.TlsConfig;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.asynchttpclient.AsyncHttpClient;
 import org.asynchttpclient.BoundRequestBuilder;
@@ -51,6 +54,7 @@ import org.slf4j.LoggerFactory;
 public class PinotAdminTransport implements AutoCloseable {
   private static final Logger LOGGER = LoggerFactory.getLogger(PinotAdminTransport.class);
   private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+  private static final SslContextProvider SSL_CONTEXT_PROVIDER = SslContextProviderFactory.create();
   public static final String ADMIN_TRANSPORT_REQUEST_TIMEOUT_MS = "pinot.admin.request.timeout.ms";
   public static final String ADMIN_TRANSPORT_SCHEME = "pinot.admin.scheme";
 
@@ -95,9 +99,14 @@ public class PinotAdminTransport implements AutoCloseable {
     // Configure SSL if needed
     if (CommonConstants.HTTPS_PROTOCOL.equalsIgnoreCase(scheme)) {
       try {
-        SSLContext contextToUse = _sslContext != null ? _sslContext : SSLContext.getDefault();
-        builder.setSslContext(new io.netty.handler.ssl.JdkSslContext(contextToUse, true,
-            io.netty.handler.ssl.ClientAuth.OPTIONAL));
+        TlsConfig tlsConfig = ConnectionUtils.getTlsConfigFromProperties(properties);
+        // NOTE: ConnectionUtils.getSSLContextFromProperties(...) installs a JVM-global default SSLSocketFactory
+        // and updates the shared TlsUtils SSLContext. PinotAdminTransport has historically inherited that process-
+        // wide side effect from the shared helper, so callers enabling HTTPS here should treat the TLS config as
+        // affecting other HttpsURLConnection-based clients in the same JVM.
+        SSLContext sslContext =
+            _sslContext != null ? _sslContext : ConnectionUtils.getSSLContextFromProperties(properties);
+        SSL_CONTEXT_PROVIDER.configure(builder, sslContext, null, tlsConfig.getEndpointIdentificationAlgorithm());
       } catch (Exception e) {
         LOGGER.warn("Failed to configure SSL context, proceeding without SSL", e);
       }

--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/admin/PinotAdminTransport.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/admin/PinotAdminTransport.java
@@ -100,9 +100,9 @@ public class PinotAdminTransport implements AutoCloseable {
     if (CommonConstants.HTTPS_PROTOCOL.equalsIgnoreCase(scheme)) {
       try {
         TlsConfig tlsConfig = ConnectionUtils.getTlsConfigFromProperties(properties);
-        SSLContext sslContext =
+        SSLContext contextToUse =
             _sslContext != null ? _sslContext : ConnectionUtils.createSSLContextFromProperties(properties);
-        SSL_CONTEXT_PROVIDER.configure(builder, sslContext, null, tlsConfig.getEndpointIdentificationAlgorithm());
+        SSL_CONTEXT_PROVIDER.configure(builder, contextToUse, null, tlsConfig.getEndpointIdentificationAlgorithm());
       } catch (Exception e) {
         LOGGER.warn("Failed to configure SSL context, proceeding without SSL", e);
       }

--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/utils/ConnectionUtils.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/utils/ConnectionUtils.java
@@ -52,10 +52,13 @@ public class ConnectionUtils {
   }
 
   public static SSLContext getSSLContextFromProperties(Properties properties) {
-    TlsConfig tlsConfig = TlsUtils.extractTlsConfig(
-        new PinotConfiguration(new MapConfiguration(properties)), PINOT_JAVA_TLS_PREFIX);
+    TlsConfig tlsConfig = getTlsConfigFromProperties(properties);
     TlsUtils.installDefaultSSLSocketFactory(tlsConfig);
     return TlsUtils.getSslContext();
+  }
+
+  public static TlsConfig getTlsConfigFromProperties(Properties properties) {
+    return TlsUtils.extractTlsConfig(new PinotConfiguration(new MapConfiguration(properties)), PINOT_JAVA_TLS_PREFIX);
   }
 
 

--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/utils/ConnectionUtils.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/utils/ConnectionUtils.java
@@ -28,6 +28,7 @@ import org.apache.commons.configuration2.MapConfiguration;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pinot.common.config.TlsConfig;
+import org.apache.pinot.common.utils.tls.RenewableTlsUtils;
 import org.apache.pinot.common.utils.tls.TlsUtils;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.slf4j.Logger;
@@ -55,6 +56,18 @@ public class ConnectionUtils {
     TlsConfig tlsConfig = getTlsConfigFromProperties(properties);
     TlsUtils.installDefaultSSLSocketFactory(tlsConfig);
     return TlsUtils.getSslContext();
+  }
+
+  public static SSLContext createSSLContextFromProperties(Properties properties) {
+    TlsConfig tlsConfig = getTlsConfigFromProperties(properties);
+    if (!tlsConfig.isCustomized() && !tlsConfig.isInsecure()) {
+      try {
+        return SSLContext.getDefault();
+      } catch (Exception e) {
+        throw new IllegalStateException("Could not initialize default SSL support", e);
+      }
+    }
+    return RenewableTlsUtils.createSSLFactoryAndEnableAutoRenewalWhenUsingFileStores(tlsConfig).getSslContext();
   }
 
   public static TlsConfig getTlsConfigFromProperties(Properties properties) {

--- a/pinot-clients/pinot-java-client/src/test/java/org/apache/pinot/client/JsonAsyncHttpPinotClientTransportTest.java
+++ b/pinot-clients/pinot-java-client/src/test/java/org/apache/pinot/client/JsonAsyncHttpPinotClientTransportTest.java
@@ -118,18 +118,23 @@ public class JsonAsyncHttpPinotClientTransportTest implements HttpHandler {
     SSLContext sslContext = SSLContext.getInstance("TLS");
     sslContext.init(null, null, null);
 
-    JsonAsyncHttpPinotClientTransport transport =
-        new JsonAsyncHttpPinotClientTransport(null, "https", "", false, sslContext,
-            ConnectionTimeouts.create(1000, 1000, 1000), TlsProtocols.defaultProtocols(false), null);
+    JsonAsyncHttpPinotClientTransport transport = null;
+    try {
+      transport =
+          new JsonAsyncHttpPinotClientTransport(null, "https", "", false, sslContext,
+              ConnectionTimeouts.create(1000, 1000, 1000), TlsProtocols.defaultProtocols(false), null);
 
-    Field httpClientField = JsonAsyncHttpPinotClientTransport.class.getDeclaredField("_httpClient");
-    httpClientField.setAccessible(true);
-    AsyncHttpClient httpClient = (AsyncHttpClient) httpClientField.get(transport);
+      Field httpClientField = JsonAsyncHttpPinotClientTransport.class.getDeclaredField("_httpClient");
+      httpClientField.setAccessible(true);
+      AsyncHttpClient httpClient = (AsyncHttpClient) httpClientField.get(transport);
 
-    assertNull(httpClient.getConfig().getSslEngineFactory().newSslEngine(httpClient.getConfig(), "localhost", 443)
-        .getSSLParameters().getEndpointIdentificationAlgorithm());
-
-    transport.close();
+      assertNull(httpClient.getConfig().getSslEngineFactory().newSslEngine(httpClient.getConfig(), "localhost", 443)
+          .getSSLParameters().getEndpointIdentificationAlgorithm());
+    } finally {
+      if (transport != null) {
+        transport.close();
+      }
+    }
   }
 
   @Test

--- a/pinot-clients/pinot-java-client/src/test/java/org/apache/pinot/client/JsonAsyncHttpPinotClientTransportTest.java
+++ b/pinot-clients/pinot-java-client/src/test/java/org/apache/pinot/client/JsonAsyncHttpPinotClientTransportTest.java
@@ -26,11 +26,14 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.OutputStream;
 import java.io.OutputStreamWriter;
+import java.lang.reflect.Field;
 import java.net.InetSocketAddress;
 import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
+import javax.net.ssl.SSLContext;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.pinot.spi.utils.CommonConstants;
+import org.asynchttpclient.AsyncHttpClient;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
@@ -39,6 +42,7 @@ import org.testng.annotations.Test;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
@@ -106,6 +110,26 @@ public class JsonAsyncHttpPinotClientTransportTest implements HttpHandler {
     ExecutionStats stats = response.getExecutionStats();
     assertEquals(stats.getTotalDocs(), 115545);
     assertEquals(stats.getNumServersResponded(), 99);
+  }
+
+  @Test
+  public void testLegacyConstructorLeavesEndpointIdentificationAlgorithmUnset()
+      throws Exception {
+    SSLContext sslContext = SSLContext.getInstance("TLS");
+    sslContext.init(null, null, null);
+
+    JsonAsyncHttpPinotClientTransport transport =
+        new JsonAsyncHttpPinotClientTransport(null, "https", "", false, sslContext,
+            ConnectionTimeouts.create(1000, 1000, 1000), TlsProtocols.defaultProtocols(false), null);
+
+    Field httpClientField = JsonAsyncHttpPinotClientTransport.class.getDeclaredField("_httpClient");
+    httpClientField.setAccessible(true);
+    AsyncHttpClient httpClient = (AsyncHttpClient) httpClientField.get(transport);
+
+    assertNull(httpClient.getConfig().getSslEngineFactory().newSslEngine(httpClient.getConfig(), "localhost", 443)
+        .getSSLParameters().getEndpointIdentificationAlgorithm());
+
+    transport.close();
   }
 
   @Test

--- a/pinot-clients/pinot-java-client/src/test/java/org/apache/pinot/client/SslContextProviderTest.java
+++ b/pinot-clients/pinot-java-client/src/test/java/org/apache/pinot/client/SslContextProviderTest.java
@@ -33,6 +33,7 @@ import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
+import javax.net.ssl.SSLParameters;
 import javax.tools.JavaCompiler;
 import javax.tools.ToolProvider;
 import org.asynchttpclient.DefaultAsyncHttpClientConfig;
@@ -43,6 +44,7 @@ import org.testng.annotations.Test;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 
@@ -76,7 +78,7 @@ public class SslContextProviderTest {
     String protocol = selectSupportedProtocol(sslContext);
 
     SslContextProvider provider = new DefaultSslContextProvider();
-    provider.configure(builder, sslContext, tlsProtocolsWith(protocol));
+    provider.configure(builder, sslContext, tlsProtocolsWith(protocol), "HTTPS");
 
     DefaultAsyncHttpClientConfig config = builder.build();
     assertFalse(config.isUseOpenSsl());
@@ -85,8 +87,29 @@ public class SslContextProviderTest {
     SslEngineFactory engineFactory = config.getSslEngineFactory();
     assertNotNull(engineFactory);
     SSLEngine engine = engineFactory.newSslEngine(config, "localhost", 443);
+    SSLParameters sslParameters = engine.getSSLParameters();
     assertTrue(engine.getUseClientMode());
+    assertEquals(engine.getPeerHost(), "localhost");
+    assertEquals(engine.getPeerPort(), 443);
     assertEquals(engine.getEnabledProtocols(), new String[] {protocol});
+    assertEquals(sslParameters.getEndpointIdentificationAlgorithm(), "HTTPS");
+  }
+
+  @Test
+  public void testDefaultProviderLeavesEndpointIdentificationAlgorithmUnsetWhenBlank()
+      throws Exception {
+    DefaultAsyncHttpClientConfig.Builder builder = Dsl.config();
+
+    SSLContext sslContext = SSLContext.getInstance("TLS");
+    sslContext.init(null, null, null);
+    String protocol = selectSupportedProtocol(sslContext);
+
+    SslContextProvider provider = new DefaultSslContextProvider();
+    provider.configure(builder, sslContext, tlsProtocolsWith(protocol), " ");
+
+    DefaultAsyncHttpClientConfig config = builder.build();
+    SSLEngine engine = config.getSslEngineFactory().newSslEngine(config, "localhost", 443);
+    assertNull(engine.getSSLParameters().getEndpointIdentificationAlgorithm());
   }
 
   @Test

--- a/pinot-clients/pinot-java-client/src/test/java/org/apache/pinot/client/utils/ConnectionUtilsTest.java
+++ b/pinot-clients/pinot-java-client/src/test/java/org/apache/pinot/client/utils/ConnectionUtilsTest.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.client.utils;
+
+import java.util.Properties;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
+import org.apache.pinot.common.utils.tls.TlsUtils;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertSame;
+
+
+public class ConnectionUtilsTest {
+
+  @Test
+  public void testCreateSslContextFromPropertiesDoesNotMutateGlobalTlsState() {
+    SSLSocketFactory originalSocketFactory = HttpsURLConnection.getDefaultSSLSocketFactory();
+    SSLContext originalSslContext = TlsUtils.getSslContext();
+
+    SSLContext sslContext = ConnectionUtils.createSSLContextFromProperties(new Properties());
+
+    assertNotNull(sslContext);
+    assertSame(HttpsURLConnection.getDefaultSSLSocketFactory(), originalSocketFactory);
+    assertSame(TlsUtils.getSslContext(), originalSslContext);
+  }
+}

--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/PinotDriver.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/PinotDriver.java
@@ -39,7 +39,6 @@ import org.apache.pinot.client.controller.PinotControllerTransport;
 import org.apache.pinot.client.controller.PinotControllerTransportFactory;
 import org.apache.pinot.client.grpc.PinotGrpcConnection;
 import org.apache.pinot.client.utils.DriverUtils;
-import org.apache.pinot.common.utils.tls.TlsUtils;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.slf4j.LoggerFactory;
 
@@ -103,8 +102,9 @@ public class PinotDriver implements Driver {
         pinotControllerTransportFactory.setScheme(info.getProperty(INFO_SCHEME));
         if (info.getProperty(INFO_SCHEME).contentEquals(CommonConstants.HTTPS_PROTOCOL)) {
           if (_sslContext == null) {
-            factory.setSslContext(DriverUtils.getSSLContextFromJDBCProps(info));
-            pinotControllerTransportFactory.setSslContext(TlsUtils.getSslContext());
+            SSLContext sslContext = DriverUtils.getSSLContextFromJDBCProps(info);
+            factory.setSslContext(sslContext);
+            pinotControllerTransportFactory.setSslContext(sslContext);
           } else {
             factory.setSslContext(_sslContext);
             pinotControllerTransportFactory.setSslContext(_sslContext);

--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/controller/PinotControllerTransport.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/controller/PinotControllerTransport.java
@@ -18,8 +18,6 @@
  */
 package org.apache.pinot.client.controller;
 
-import io.netty.handler.ssl.ClientAuth;
-import io.netty.handler.ssl.JdkSslContext;
 import java.io.IOException;
 import java.time.Duration;
 import java.util.Map;
@@ -31,6 +29,8 @@ import javax.net.ssl.SSLContext;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.client.ConnectionTimeouts;
 import org.apache.pinot.client.PinotClientException;
+import org.apache.pinot.client.SslContextProvider;
+import org.apache.pinot.client.SslContextProviderFactory;
 import org.apache.pinot.client.TlsProtocols;
 import org.apache.pinot.client.controller.response.ControllerTenantBrokerResponse;
 import org.apache.pinot.client.controller.response.SchemaResponse;
@@ -47,6 +47,7 @@ import org.slf4j.LoggerFactory;
 public class PinotControllerTransport {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(PinotControllerTransport.class);
+  private static final SslContextProvider SSL_CONTEXT_PROVIDER = SslContextProviderFactory.create();
 
   Map<String, String> _headers;
   private final String _scheme;
@@ -54,13 +55,17 @@ public class PinotControllerTransport {
 
   public PinotControllerTransport(Map<String, String> headers, String scheme, @Nullable SSLContext sslContext,
       ConnectionTimeouts connectionTimeouts, TlsProtocols tlsProtocols, @Nullable String appId) {
+    this(headers, scheme, sslContext, connectionTimeouts, tlsProtocols, appId, null);
+  }
+
+  public PinotControllerTransport(Map<String, String> headers, String scheme, @Nullable SSLContext sslContext,
+      ConnectionTimeouts connectionTimeouts, TlsProtocols tlsProtocols, @Nullable String appId,
+      @Nullable String endpointIdentificationAlgorithm) {
     _headers = headers;
     _scheme = scheme;
 
     DefaultAsyncHttpClientConfig.Builder builder = Dsl.config();
-    if (sslContext != null) {
-      builder.setSslContext(new JdkSslContext(sslContext, true, ClientAuth.OPTIONAL));
-    }
+    SSL_CONTEXT_PROVIDER.configure(builder, sslContext, tlsProtocols, endpointIdentificationAlgorithm);
 
     builder.setReadTimeout(Duration.ofMillis(connectionTimeouts.getReadTimeoutMs()))
         .setConnectTimeout(Duration.ofMillis(connectionTimeouts.getConnectTimeoutMs()))

--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/controller/PinotControllerTransport.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/controller/PinotControllerTransport.java
@@ -54,6 +54,11 @@ public class PinotControllerTransport {
   private final AsyncHttpClient _httpClient;
 
   public PinotControllerTransport(Map<String, String> headers, String scheme, @Nullable SSLContext sslContext,
+      ConnectionTimeouts connectionTimeouts, TlsProtocols tlsProtocols) {
+    this(headers, scheme, sslContext, connectionTimeouts, tlsProtocols, null, null);
+  }
+
+  public PinotControllerTransport(Map<String, String> headers, String scheme, @Nullable SSLContext sslContext,
       ConnectionTimeouts connectionTimeouts, TlsProtocols tlsProtocols, @Nullable String appId) {
     this(headers, scheme, sslContext, connectionTimeouts, tlsProtocols, appId, null);
   }

--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/controller/PinotControllerTransportFactory.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/controller/PinotControllerTransportFactory.java
@@ -24,6 +24,7 @@ import java.util.Properties;
 import javax.net.ssl.SSLContext;
 import org.apache.pinot.client.ConnectionTimeouts;
 import org.apache.pinot.client.TlsProtocols;
+import org.apache.pinot.client.utils.DriverUtils;
 import org.apache.pinot.spi.utils.CommonConstants;
 
 
@@ -36,6 +37,7 @@ public class PinotControllerTransportFactory {
   private Map<String, String> _headers = new HashMap<>();
   private String _scheme = CommonConstants.HTTP_PROTOCOL;
   private SSLContext _sslContext = null;
+  private String _endpointIdentificationAlgorithm = "";
 
   private boolean _tlsV10Enabled = false;
   private int _readTimeoutMs = Integer.parseInt(DEFAULT_CONTROLLER_READ_TIMEOUT_MS);
@@ -47,7 +49,8 @@ public class PinotControllerTransportFactory {
     ConnectionTimeouts connectionTimeouts =
         ConnectionTimeouts.create(_readTimeoutMs, _connectTimeoutMs, _handshakeTimeoutMs);
     TlsProtocols tlsProtocols = TlsProtocols.defaultProtocols(_tlsV10Enabled);
-    return new PinotControllerTransport(_headers, _scheme, _sslContext, connectionTimeouts, tlsProtocols, _appId);
+    return new PinotControllerTransport(_headers, _scheme, _sslContext, connectionTimeouts, tlsProtocols, _appId,
+        _endpointIdentificationAlgorithm);
   }
 
   public Map<String, String> getHeaders() {
@@ -74,6 +77,10 @@ public class PinotControllerTransportFactory {
     _sslContext = sslContext;
   }
 
+  public void setEndpointIdentificationAlgorithm(String endpointIdentificationAlgorithm) {
+    _endpointIdentificationAlgorithm = endpointIdentificationAlgorithm;
+  }
+
   public PinotControllerTransportFactory withConnectionProperties(Properties properties) {
     _readTimeoutMs =
         Integer.parseInt(properties.getProperty("controllerReadTimeoutMs", DEFAULT_CONTROLLER_READ_TIMEOUT_MS));
@@ -86,6 +93,12 @@ public class PinotControllerTransportFactory {
         Boolean.parseBoolean(properties.getProperty("controllerTlsV10Enabled", DEFAULT_CONTROLLER_TLS_V10_ENABLED))
             || Boolean.parseBoolean(
             System.getProperties().getProperty("controller.tlsV10Enabled", DEFAULT_CONTROLLER_TLS_V10_ENABLED));
+    if (_scheme.contentEquals(CommonConstants.HTTPS_PROTOCOL)) {
+      _endpointIdentificationAlgorithm = DriverUtils.getTlsConfigFromJDBCProps(properties)
+          .getEndpointIdentificationAlgorithm();
+    } else {
+      _endpointIdentificationAlgorithm = "";
+    }
     return this;
   }
 }

--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/utils/DriverUtils.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/utils/DriverUtils.java
@@ -63,10 +63,13 @@ public class DriverUtils {
   }
 
   public static SSLContext getSSLContextFromJDBCProps(Properties properties) {
-    TlsConfig tlsConfig =
-        TlsUtils.extractTlsConfig(new PinotConfiguration(new MapConfiguration(properties)), PINOT_JDBC_TLS_PREFIX);
+    TlsConfig tlsConfig = getTlsConfigFromJDBCProps(properties);
     TlsUtils.installDefaultSSLSocketFactory(tlsConfig);
     return TlsUtils.getSslContext();
+  }
+
+  public static TlsConfig getTlsConfigFromJDBCProps(Properties properties) {
+    return TlsUtils.extractTlsConfig(new PinotConfiguration(new MapConfiguration(properties)), PINOT_JDBC_TLS_PREFIX);
   }
 
   public static void handleAuth(Properties info, Map<String, String> headers)

--- a/pinot-clients/pinot-jdbc-client/src/test/java/org/apache/pinot/client/DummyPinotControllerTransport.java
+++ b/pinot-clients/pinot-jdbc-client/src/test/java/org/apache/pinot/client/DummyPinotControllerTransport.java
@@ -32,7 +32,7 @@ public class DummyPinotControllerTransport extends PinotControllerTransport {
   public DummyPinotControllerTransport(Map<String, String> headers, String scheme, @Nullable SSLContext sslContext,
       @Nullable String appId) {
     super(headers, scheme, sslContext, ConnectionTimeouts.create(1000, 1000, 1000), TlsProtocols.defaultProtocols(true),
-        appId);
+        appId, "");
   }
 
   @Override

--- a/pinot-clients/pinot-jdbc-client/src/test/java/org/apache/pinot/client/controller/PinotControllerTransportTest.java
+++ b/pinot-clients/pinot-jdbc-client/src/test/java/org/apache/pinot/client/controller/PinotControllerTransportTest.java
@@ -1,0 +1,57 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.client.controller;
+
+import java.lang.reflect.Field;
+import javax.net.ssl.SSLContext;
+import org.apache.pinot.client.ConnectionTimeouts;
+import org.apache.pinot.client.TlsProtocols;
+import org.asynchttpclient.AsyncHttpClient;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertNull;
+
+
+public class PinotControllerTransportTest {
+
+  @Test
+  public void testLegacyConstructorLeavesEndpointIdentificationAlgorithmUnset()
+      throws Exception {
+    SSLContext sslContext = SSLContext.getInstance("TLS");
+    sslContext.init(null, null, null);
+
+    PinotControllerTransport transport = null;
+    try {
+      transport =
+          new PinotControllerTransport(null, "https", sslContext, ConnectionTimeouts.create(1000, 1000, 1000),
+              TlsProtocols.defaultProtocols(false), null);
+
+      Field httpClientField = PinotControllerTransport.class.getDeclaredField("_httpClient");
+      httpClientField.setAccessible(true);
+      AsyncHttpClient httpClient = (AsyncHttpClient) httpClientField.get(transport);
+
+      assertNull(httpClient.getConfig().getSslEngineFactory().newSslEngine(httpClient.getConfig(), "localhost", 443)
+          .getSSLParameters().getEndpointIdentificationAlgorithm());
+    } finally {
+      if (transport != null) {
+        transport.close();
+      }
+    }
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/config/TlsConfig.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/config/TlsConfig.java
@@ -43,6 +43,8 @@ public class TlsConfig {
   // Allowed TLS protocols (optional, if not set uses default)
   @Nullable
   private String[] _allowedProtocols = null;
+  @Nullable
+  private String _endpointIdentificationAlgorithm = null;
 
   public TlsConfig() {
     // left blank
@@ -61,6 +63,7 @@ public class TlsConfig {
     _allowedProtocols = tlsConfig._allowedProtocols != null
         ? Arrays.copyOf(tlsConfig._allowedProtocols, tlsConfig._allowedProtocols.length)
         : null;
+    _endpointIdentificationAlgorithm = tlsConfig._endpointIdentificationAlgorithm;
   }
 
   public boolean isClientAuthEnabled() {
@@ -150,6 +153,15 @@ public class TlsConfig {
         : null;
   }
 
+  @Nullable
+  public String getEndpointIdentificationAlgorithm() {
+    return _endpointIdentificationAlgorithm;
+  }
+
+  public void setEndpointIdentificationAlgorithm(@Nullable String endpointIdentificationAlgorithm) {
+    _endpointIdentificationAlgorithm = endpointIdentificationAlgorithm;
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -168,13 +180,14 @@ public class TlsConfig {
         && Objects.equals(_trustStorePath, tlsConfig._trustStorePath)
         && Objects.equals(_trustStorePassword, tlsConfig._trustStorePassword)
         && Objects.equals(_sslProvider, tlsConfig._sslProvider)
+        && Objects.equals(_endpointIdentificationAlgorithm, tlsConfig._endpointIdentificationAlgorithm)
         && Arrays.equals(_allowedProtocols, tlsConfig._allowedProtocols);
   }
 
   @Override
   public int hashCode() {
     int result = Objects.hash(_clientAuthEnabled, _keyStoreType, _keyStorePath, _keyStorePassword, _trustStoreType,
-        _trustStorePath, _trustStorePassword, _sslProvider, _insecure);
+        _trustStorePath, _trustStorePassword, _sslProvider, _insecure, _endpointIdentificationAlgorithm);
     result = 31 * result + Arrays.hashCode(_allowedProtocols);
     return result;
   }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/tls/TlsUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/tls/TlsUtils.java
@@ -74,6 +74,7 @@ public final class TlsUtils {
   private static final String FILE_SCHEME_PREFIX_WITHOUT_SLASH = FILE_SCHEME + ":";
   private static final String INSECURE = "insecure";
   private static final String PROTOCOLS = "protocols";
+  private static final String ENDPOINT_IDENTIFICATION_ALGORITHM = "endpointIdentificationAlgorithm";
 
   private static final AtomicReference<SSLContext> SSL_CONTEXT_REF = new AtomicReference<>();
   private static final Set<String> LOGGED_TLS_DIAGNOSTICS_KEYS = ConcurrentHashMap.newKeySet();
@@ -123,6 +124,8 @@ public final class TlsUtils {
         pinotConfig.getProperty(key(namespace, SSL_PROVIDER), defaultConfig.getSslProvider()));
     tlsConfig.setInsecure(
         pinotConfig.getProperty(key(namespace, INSECURE), defaultConfig.isInsecure()));
+    tlsConfig.setEndpointIdentificationAlgorithm(pinotConfig.getProperty(
+        key(namespace, ENDPOINT_IDENTIFICATION_ALGORITHM), defaultConfig.getEndpointIdentificationAlgorithm()));
 
     // Read allowed TLS protocols from config (e.g., "TLSv1.2,TLSv1.3")
     String protocolsConfig = pinotConfig.getProperty(key(namespace, PROTOCOLS));

--- a/pinot-common/src/test/java/org/apache/pinot/common/config/TlsConfigTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/config/TlsConfigTest.java
@@ -23,14 +23,16 @@ import org.testng.annotations.Test;
 
 public class TlsConfigTest {
   @Test
-  public void copyConstructorShouldCopyInsecureAndAllowedProtocols() {
+  public void copyConstructorShouldCopyInsecureAllowedProtocolsAndEndpointIdentificationAlgorithm() {
     TlsConfig original = new TlsConfig();
     original.setInsecure(true);
     original.setAllowedProtocols(new String[]{"TLSv1.2", "TLSv1.3"});
+    original.setEndpointIdentificationAlgorithm("HTTPS");
 
     TlsConfig copy = new TlsConfig(original);
     Assert.assertTrue(copy.isInsecure());
     Assert.assertEquals(copy.getAllowedProtocols(), new String[]{"TLSv1.2", "TLSv1.3"});
+    Assert.assertEquals(copy.getEndpointIdentificationAlgorithm(), "HTTPS");
 
     // Ensure returned array is a defensive copy
     String[] protocols = copy.getAllowedProtocols();
@@ -39,19 +41,25 @@ public class TlsConfigTest {
   }
 
   @Test
-  public void equalsAndHashCodeShouldIncludeAllowedProtocols() {
+  public void equalsAndHashCodeShouldIncludeAllowedProtocolsAndEndpointIdentificationAlgorithm() {
     TlsConfig a = new TlsConfig();
     a.setInsecure(true);
     a.setAllowedProtocols(new String[]{"TLSv1.2"});
+    a.setEndpointIdentificationAlgorithm("HTTPS");
 
     TlsConfig b = new TlsConfig();
     b.setInsecure(true);
     b.setAllowedProtocols(new String[]{"TLSv1.2"});
+    b.setEndpointIdentificationAlgorithm("HTTPS");
 
     Assert.assertEquals(a, b);
     Assert.assertEquals(a.hashCode(), b.hashCode());
 
     b.setAllowedProtocols(new String[]{"TLSv1.3"});
+    Assert.assertNotEquals(a, b);
+
+    b.setAllowedProtocols(new String[]{"TLSv1.2"});
+    b.setEndpointIdentificationAlgorithm("LDAPS");
     Assert.assertNotEquals(a, b);
   }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/tls/TlsUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/tls/TlsUtilsTest.java
@@ -49,4 +49,20 @@ public class TlsUtilsTest {
     TlsConfig tlsConfig = TlsUtils.extractTlsConfig(new PinotConfiguration(props), "tls", defaultConfig);
     Assert.assertEquals(tlsConfig.getAllowedProtocols(), new String[]{"TLSv1.2"});
   }
+
+  @Test
+  public void extractTlsConfigShouldReadEndpointIdentificationAlgorithm() {
+    Map<String, Object> props = new HashMap<>();
+    props.put("tls.endpointIdentificationAlgorithm", "HTTPS");
+    TlsConfig tlsConfig = TlsUtils.extractTlsConfig(new PinotConfiguration(props), "tls");
+    Assert.assertEquals(tlsConfig.getEndpointIdentificationAlgorithm(), "HTTPS");
+  }
+
+  @Test
+  public void extractTlsConfigShouldFallbackToDefaultEndpointIdentificationAlgorithm() {
+    TlsConfig defaultConfig = new TlsConfig();
+    defaultConfig.setEndpointIdentificationAlgorithm("HTTPS");
+    TlsConfig tlsConfig = TlsUtils.extractTlsConfig(new PinotConfiguration(new HashMap<>()), "tls", defaultConfig);
+    Assert.assertEquals(tlsConfig.getEndpointIdentificationAlgorithm(), "HTTPS");
+  }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/ChannelHandlerFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/ChannelHandlerFactory.java
@@ -24,8 +24,10 @@ import io.netty.channel.socket.SocketChannel;
 import io.netty.handler.codec.LengthFieldBasedFrameDecoder;
 import io.netty.handler.codec.LengthFieldPrepender;
 import io.netty.handler.ssl.SslContext;
+import io.netty.handler.ssl.SslHandler;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import javax.net.ssl.SSLParameters;
 import org.apache.pinot.common.config.TlsConfig;
 import org.apache.pinot.common.utils.tls.TlsUtils;
 import org.apache.pinot.core.query.scheduler.QueryScheduler;
@@ -72,7 +74,26 @@ public class ChannelHandlerFactory {
   public static ChannelHandler getClientTlsHandler(TlsConfig tlsConfig, SocketChannel ch) {
     SslContext sslContext = CLIENT_SSL_CONTEXTS_CACHE
         .computeIfAbsent(tlsConfig.hashCode(), tlsConfigHashCode -> TlsUtils.buildClientContext(tlsConfig));
-    return sslContext.newHandler(ch.alloc());
+    return configureClientTlsHandler(tlsConfig, sslContext.newHandler(ch.alloc()));
+  }
+
+  public static ChannelHandler getClientTlsHandler(TlsConfig tlsConfig, SocketChannel ch, String peerHost,
+      int peerPort) {
+    SslContext sslContext = CLIENT_SSL_CONTEXTS_CACHE
+        .computeIfAbsent(tlsConfig.hashCode(), tlsConfigHashCode -> TlsUtils.buildClientContext(tlsConfig));
+    return configureClientTlsHandler(tlsConfig, sslContext.newHandler(ch.alloc(), peerHost, peerPort));
+  }
+
+  private static SslHandler configureClientTlsHandler(TlsConfig tlsConfig, SslHandler sslHandler) {
+    String endpointIdentificationAlgorithm = tlsConfig.getEndpointIdentificationAlgorithm();
+    SSLParameters sslParameters = sslHandler.engine().getSSLParameters();
+    if (endpointIdentificationAlgorithm == null || endpointIdentificationAlgorithm.isBlank()) {
+      sslParameters.setEndpointIdentificationAlgorithm(null);
+    } else {
+      sslParameters.setEndpointIdentificationAlgorithm(endpointIdentificationAlgorithm);
+    }
+    sslHandler.engine().setSSLParameters(sslParameters);
+    return sslHandler;
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/QueryRouter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/QueryRouter.java
@@ -179,6 +179,9 @@ public class QueryRouter {
   }
 
   public void shutDown() {
+    if (_serverChannelsTls != null) {
+      _serverChannelsTls.shutDown();
+    }
     _serverChannels.shutDown();
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/QueryServer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/QueryServer.java
@@ -55,6 +55,7 @@ import org.slf4j.LoggerFactory;
  */
 public class QueryServer {
   private static final Logger LOGGER = LoggerFactory.getLogger(QueryServer.class);
+  private static final long CHANNEL_SHUTDOWN_TIMEOUT_MS = 5_000L;
   private final int _port;
   private final TlsConfig _tlsConfig;
 
@@ -64,6 +65,7 @@ public class QueryServer {
   private final ChannelHandler _instanceRequestHandler;
   private ServerSocketChannel _channel;
   private final ConcurrentHashMap<SocketChannel, Boolean> _allChannels = new ConcurrentHashMap<>();
+  private volatile boolean _shuttingDown;
 
 
   /**
@@ -135,6 +137,7 @@ public class QueryServer {
 
       _channel = (ServerSocketChannel) serverBootstrap.group(_bossGroup, _workerGroup).channel(_channelClass)
           .option(ChannelOption.SO_BACKLOG, 128)
+          .option(ChannelOption.SO_REUSEADDR, true)
           .childOption(ChannelOption.SO_KEEPALIVE, true)
           .option(ChannelOption.ALLOCATOR, bufAllocatorWithLimits)
           .childOption(ChannelOption.ALLOCATOR, bufAllocatorWithLimits)
@@ -143,6 +146,10 @@ public class QueryServer {
             protected void initChannel(SocketChannel ch) {
               _allChannels.put(ch, true);
               ch.closeFuture().addListener(f -> _allChannels.remove(ch));
+              if (_shuttingDown) {
+                ch.close();
+                return;
+              }
 
               ch.pipeline()
                   .addLast(ChannelHandlerFactory.getDirectOOMHandler(null, null, null, _allChannels, _channel));
@@ -166,13 +173,44 @@ public class QueryServer {
   }
 
   public void shutDown() {
+    _shuttingDown = true;
     try {
-      _channel.close().sync();
+      if (_channel != null) {
+        _channel.close().sync();
+      }
     } catch (Exception e) {
       throw new RuntimeException(e);
     } finally {
-      _workerGroup.shutdownGracefully(0, 0, TimeUnit.SECONDS);
-      _bossGroup.shutdownGracefully(0, 0, TimeUnit.SECONDS);
+      closeAcceptedChannels();
+      _workerGroup.shutdownGracefully(0, 0, TimeUnit.SECONDS).syncUninterruptibly();
+      _bossGroup.shutdownGracefully(0, 0, TimeUnit.SECONDS).syncUninterruptibly();
+    }
+  }
+
+  private void closeAcceptedChannels() {
+    long deadlineMs = System.currentTimeMillis() + CHANNEL_SHUTDOWN_TIMEOUT_MS;
+    while (!_allChannels.isEmpty() && System.currentTimeMillis() < deadlineMs) {
+      SocketChannel[] channels = _allChannels.keySet().toArray(new SocketChannel[0]);
+      if (channels.length == 0) {
+        break;
+      }
+      closeAcceptedChannelSnapshot(channels, deadlineMs);
+    }
+    if (!_allChannels.isEmpty()) {
+      LOGGER.warn("Timed out waiting for {} client channels to close during shutdown", _allChannels.size());
+    }
+  }
+
+  @VisibleForTesting
+  void closeAcceptedChannelSnapshot(SocketChannel[] channels, long deadlineMs) {
+    for (SocketChannel ch : channels) {
+      ch.close();
+    }
+    for (SocketChannel ch : channels) {
+      long remainingMs = Math.max(1L, deadlineMs - System.currentTimeMillis());
+      if (!ch.closeFuture().awaitUninterruptibly(remainingMs)) {
+        LOGGER.warn("Timed out waiting for client channel to close during shutdown: {}", ch);
+      }
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/ServerChannels.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/ServerChannels.java
@@ -24,6 +24,7 @@ import io.netty.buffer.PooledByteBufAllocator;
 import io.netty.buffer.PooledByteBufAllocatorMetric;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
+import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.EventLoopGroup;
@@ -158,8 +159,15 @@ public class ServerChannels {
   }
 
   public void shutDown() {
-    // Shut down immediately
-    _eventLoopGroup.shutdownGracefully(0, 0, TimeUnit.SECONDS);
+    _serverToChannelMap.forEach((serverRoutingInstance, serverChannel) -> {
+      try {
+        serverChannel.closeChannel(true);
+      } catch (Exception e) {
+        LOGGER.warn("Failed to close channel to server: {}", serverRoutingInstance, e);
+      }
+    });
+    _serverToChannelMap.clear();
+    _eventLoopGroup.shutdownGracefully(0, 0, TimeUnit.SECONDS).syncUninterruptibly();
   }
 
   @VisibleForTesting
@@ -184,8 +192,9 @@ public class ServerChannels {
             protected void initChannel(SocketChannel ch) {
               if (_tlsConfig != null) {
                 // Add SSL handler first to encrypt and decrypt everything.
-                ch.pipeline()
-                    .addLast(ChannelHandlerFactory.SSL, ChannelHandlerFactory.getClientTlsHandler(_tlsConfig, ch));
+                ch.pipeline().addLast(ChannelHandlerFactory.SSL,
+                    ChannelHandlerFactory.getClientTlsHandler(_tlsConfig, ch, serverRoutingInstance.getHostname(),
+                        serverRoutingInstance.getPort()));
               }
 
               ch.pipeline().addLast(ChannelHandlerFactory.getLengthFieldBasedFrameDecoder());
@@ -203,8 +212,28 @@ public class ServerChannels {
     }
 
     void closeChannel() {
-      if (_channel != null) {
-        _channel.close();
+      closeChannel(false);
+    }
+
+    void closeChannel(boolean silentShutdown) {
+      Channel channel = _channel;
+      if (channel == null) {
+        return;
+      }
+      if (silentShutdown) {
+        setSilentShutdown();
+      }
+      ChannelFuture closeFuture = channel.close();
+      if (closeFuture != null) {
+        closeFuture.addListener(future -> {
+          if (!future.isSuccess()) {
+            LOGGER.warn("Failed to close channel for server routing instance: {}", _serverRoutingInstance,
+                future.cause());
+          }
+        });
+        if (!channel.eventLoop().inEventLoop()) {
+          closeFuture.syncUninterruptibly();
+        }
       }
     }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/transport/QueryServerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/transport/QueryServerTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.transport;
 
+import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandler;
 import io.netty.channel.socket.SocketChannel;
 import java.net.InetSocketAddress;
@@ -33,7 +34,11 @@ import org.apache.pinot.util.TestUtils;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
@@ -99,6 +104,58 @@ public class QueryServerTest {
           "Channel was not removed from _allChannels after close");
     } finally {
       IOUtils.closeQuietly(socket);
+      server.shutDown();
+    }
+  }
+
+  @Test
+  public void testServerCanRestartOnSamePortImmediately() {
+    PinotMetricUtils.init(new PinotConfiguration());
+    PinotMetricsRegistry registry = PinotMetricUtils.getPinotMetricsRegistry();
+    ServerMetrics.register(new ServerMetrics(registry));
+
+    QueryServer firstServer = new QueryServer(0, new NettyConfig(), null, mock(ChannelHandler.class));
+    firstServer.start();
+    int port = firstServer.getChannel().localAddress().getPort();
+    firstServer.shutDown();
+
+    QueryServer secondServer = new QueryServer(port, new NettyConfig(), null, mock(ChannelHandler.class));
+    secondServer.start();
+    try {
+      assertTrue(connectionOk(secondServer.getChannel().localAddress()));
+    } finally {
+      secondServer.shutDown();
+    }
+  }
+
+  @Test
+  public void testCloseAcceptedChannelSnapshotClosesRemainingChannelsAfterTimeout() {
+    QueryServer server = new QueryServer(0, new NettyConfig(), null, mock(ChannelHandler.class));
+    try {
+      SocketChannel slowChannel = mock(SocketChannel.class);
+      SocketChannel fastChannel = mock(SocketChannel.class);
+      ChannelFuture slowCloseFuture = mock(ChannelFuture.class);
+      ChannelFuture fastCloseFuture = mock(ChannelFuture.class);
+
+      org.mockito.InOrder inOrder = inOrder(slowChannel, fastChannel, slowCloseFuture, fastCloseFuture);
+      when(slowChannel.close()).thenReturn(slowCloseFuture);
+      when(fastChannel.close()).thenReturn(fastCloseFuture);
+      when(slowChannel.closeFuture()).thenReturn(slowCloseFuture);
+      when(fastChannel.closeFuture()).thenReturn(fastCloseFuture);
+      when(slowCloseFuture.awaitUninterruptibly(anyLong())).thenReturn(false);
+      when(fastCloseFuture.awaitUninterruptibly(anyLong())).thenReturn(true);
+
+      server.closeAcceptedChannelSnapshot(new SocketChannel[]{slowChannel, fastChannel},
+          System.currentTimeMillis() + 1_000L);
+
+      inOrder.verify(slowChannel).close();
+      inOrder.verify(fastChannel).close();
+      inOrder.verify(slowChannel).closeFuture();
+      inOrder.verify(slowCloseFuture).awaitUninterruptibly(anyLong());
+      inOrder.verify(fastChannel).closeFuture();
+      inOrder.verify(fastCloseFuture).awaitUninterruptibly(anyLong());
+      verify(fastChannel).close();
+    } finally {
       server.shutDown();
     }
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/transport/ServerChannelsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/transport/ServerChannelsTest.java
@@ -23,12 +23,20 @@ import io.netty.buffer.ByteBufAllocator;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelOption;
+import io.netty.channel.ChannelPipeline;
+import io.netty.channel.EventLoop;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.socket.SocketChannel;
+import io.netty.handler.ssl.SslHandler;
 import io.netty.util.concurrent.GenericFutureListener;
+import java.lang.reflect.Field;
 import java.net.InetSocketAddress;
 import org.apache.pinot.common.config.NettyConfig;
+import org.apache.pinot.common.config.TlsConfig;
 import org.apache.pinot.common.metrics.BrokerMetrics;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.request.InstanceRequest;
+import org.apache.pinot.core.transport.server.routing.stats.ServerRoutingStatsManager;
 import org.apache.pinot.spi.accounting.ThreadAccountantUtils;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.env.PinotConfiguration;
@@ -44,8 +52,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
 
 
 public class ServerChannelsTest {
@@ -80,6 +90,10 @@ public class ServerChannelsTest {
       ServerChannels serverChannels =
           new ServerChannels(queryRouter, nettyConfig, null, ThreadAccountantUtils.getNoOpAccountant());
       serverChannels.connect(serverRoutingInstance);
+      ServerChannels.ServerChannel serverChannel = serverChannels.getOrCreateServerChannel(serverRoutingInstance);
+      Channel connectedChannel = serverChannel._channel;
+      org.testng.Assert.assertNotNull(connectedChannel);
+      org.testng.Assert.assertTrue(connectedChannel.isOpen());
 
       final long requestId = System.currentTimeMillis();
 
@@ -88,8 +102,10 @@ public class ServerChannelsTest {
       InstanceRequest instanceRequest = new InstanceRequest();
       instanceRequest.setRequestId(requestId);
       instanceRequest.setQuery(brokerRequest);
-      serverChannels.sendRequest("dummy_table_name", asyncQueryResponse, serverRoutingInstance, instanceRequest, 1000);
+      serverChannels.sendRequest("dummy_table_name", asyncQueryResponse, serverRoutingInstance, instanceRequest,
+          1000);
       serverChannels.shutDown();
+      org.testng.Assert.assertFalse(connectedChannel.isOpen());
     } finally {
       dummyServer.stop(0);
     }
@@ -122,6 +138,54 @@ public class ServerChannelsTest {
     return (ByteBufAllocator) serverChannel._bootstrap.config().options().get(ChannelOption.ALLOCATOR);
   }
 
+  @Test
+  public void testClientTlsHandlerUsesPeerAddressForHostnameVerification() {
+    TlsConfig tlsConfig = new TlsConfig();
+    tlsConfig.setEndpointIdentificationAlgorithm("HTTPS");
+    tlsConfig.setInsecure(true);
+
+    SocketChannel channel = mock(SocketChannel.class);
+    when(channel.alloc()).thenReturn(ByteBufAllocator.DEFAULT);
+
+    SslHandler sslHandler =
+        (SslHandler) ChannelHandlerFactory.getClientTlsHandler(tlsConfig, channel, "example.com", 8443);
+    assertEquals(sslHandler.engine().getPeerHost(), "example.com");
+    assertEquals(sslHandler.engine().getPeerPort(), 8443);
+    assertEquals(sslHandler.engine().getSSLParameters().getEndpointIdentificationAlgorithm(), "HTTPS");
+  }
+
+  @Test
+  public void testClientTlsHandlerClearsEndpointIdentificationAlgorithmWhenDisabled() {
+    TlsConfig tlsConfig = new TlsConfig();
+    tlsConfig.setEndpointIdentificationAlgorithm(" ");
+    tlsConfig.setInsecure(true);
+
+    SocketChannel channel = mock(SocketChannel.class);
+    when(channel.alloc()).thenReturn(ByteBufAllocator.DEFAULT);
+
+    SslHandler sslHandler =
+        (SslHandler) ChannelHandlerFactory.getClientTlsHandler(tlsConfig, channel, "example.com", 8443);
+    assertEquals(sslHandler.engine().getPeerHost(), "example.com");
+    assertEquals(sslHandler.engine().getPeerPort(), 8443);
+    String endpointIdentificationAlgorithm =
+        sslHandler.engine().getSSLParameters().getEndpointIdentificationAlgorithm();
+    assertTrue(endpointIdentificationAlgorithm == null || endpointIdentificationAlgorithm.isBlank());
+  }
+
+  @Test
+  public void testQueryRouterShutDownTerminatesPlainAndTlsEventLoops()
+      throws Exception {
+    QueryRouter queryRouter = new QueryRouter("broker", null, new TlsConfig(), mock(ServerRoutingStatsManager.class),
+        ThreadAccountantUtils.getNoOpAccountant());
+    try {
+      queryRouter.shutDown();
+      assertTrue(getEventLoopGroup(queryRouter, "_serverChannels").isTerminated());
+      assertTrue(getEventLoopGroup(queryRouter, "_serverChannelsTls").isTerminated());
+    } finally {
+      queryRouter.shutDown();
+    }
+  }
+
   @SuppressWarnings("unchecked")
   @Test
   public void testWriteFailureClosesChannelAndFailsQuery() {
@@ -134,7 +198,15 @@ public class ServerChannelsTest {
 
     Channel mockChannel = mock(Channel.class);
     ChannelFuture mockFuture = mock(ChannelFuture.class);
+    EventLoop mockEventLoop = mock(EventLoop.class);
+    ChannelPipeline mockPipeline = mock(ChannelPipeline.class);
     when(mockChannel.writeAndFlush(any())).thenReturn(mockFuture);
+    when(mockChannel.pipeline()).thenReturn(mockPipeline);
+    when(mockChannel.eventLoop()).thenReturn(mockEventLoop);
+    when(mockEventLoop.inEventLoop()).thenReturn(false);
+    when(mockPipeline.get(DirectOOMHandler.class)).thenReturn(null);
+    when(mockChannel.close()).thenReturn(mockFuture);
+    when(mockFuture.syncUninterruptibly()).thenReturn(mockFuture);
     serverChannel.setChannel(mockChannel);
 
     ArgumentCaptor<GenericFutureListener> listenerCaptor = ArgumentCaptor.forClass(GenericFutureListener.class);
@@ -172,7 +244,15 @@ public class ServerChannelsTest {
 
     Channel mockChannel = mock(Channel.class);
     ChannelFuture mockFuture = mock(ChannelFuture.class);
+    EventLoop mockEventLoop = mock(EventLoop.class);
+    ChannelPipeline mockPipeline = mock(ChannelPipeline.class);
     when(mockChannel.writeAndFlush(any())).thenReturn(mockFuture);
+    when(mockChannel.pipeline()).thenReturn(mockPipeline);
+    when(mockChannel.eventLoop()).thenReturn(mockEventLoop);
+    when(mockEventLoop.inEventLoop()).thenReturn(false);
+    when(mockPipeline.get(DirectOOMHandler.class)).thenReturn(null);
+    when(mockChannel.close()).thenReturn(mockFuture);
+    when(mockFuture.syncUninterruptibly()).thenReturn(mockFuture);
     serverChannel.setChannel(mockChannel);
 
     ArgumentCaptor<GenericFutureListener> listenerCaptor = ArgumentCaptor.forClass(GenericFutureListener.class);
@@ -195,5 +275,46 @@ public class ServerChannelsTest {
     verify(mockChannel, never()).close();
 
     serverChannels.shutDown();
+  }
+
+  @Test
+  public void testCloseChannelDoesNotBlockOnEventLoopThread() {
+    QueryRouter queryRouter = mock(QueryRouter.class);
+    ServerChannels serverChannels =
+        new ServerChannels(queryRouter, null, null, ThreadAccountantUtils.getNoOpAccountant());
+
+    ServerRoutingInstance routingInstance = new ServerRoutingInstance("localhost", 12345, TableType.OFFLINE);
+    ServerChannels.ServerChannel serverChannel = serverChannels.getOrCreateServerChannel(routingInstance);
+
+    Channel mockChannel = mock(Channel.class);
+    ChannelFuture mockFuture = mock(ChannelFuture.class);
+    EventLoop mockEventLoop = mock(EventLoop.class);
+    ChannelPipeline mockPipeline = mock(ChannelPipeline.class);
+    when(mockChannel.close()).thenReturn(mockFuture);
+    when(mockChannel.eventLoop()).thenReturn(mockEventLoop);
+    when(mockChannel.pipeline()).thenReturn(mockPipeline);
+    when(mockEventLoop.inEventLoop()).thenReturn(true);
+    when(mockPipeline.get(DirectOOMHandler.class)).thenReturn(null);
+    serverChannel.setChannel(mockChannel);
+
+    serverChannel.closeChannel();
+
+    verify(mockChannel).close();
+    verify(mockFuture).addListener(any());
+    verify(mockFuture, never()).syncUninterruptibly();
+
+    serverChannel.setChannel(null);
+    serverChannels.shutDown();
+  }
+
+  private static EventLoopGroup getEventLoopGroup(QueryRouter queryRouter, String fieldName)
+      throws ReflectiveOperationException {
+    Field serverChannelsField = QueryRouter.class.getDeclaredField(fieldName);
+    serverChannelsField.setAccessible(true);
+    ServerChannels serverChannels = (ServerChannels) serverChannelsField.get(queryRouter);
+
+    Field eventLoopGroupField = ServerChannels.class.getDeclaredField("_eventLoopGroup");
+    eventLoopGroupField.setAccessible(true);
+    return (EventLoopGroup) eventLoopGroupField.get(serverChannels);
   }
 }


### PR DESCRIPTION
## Summary
- keep `QueryServer` shutdown deterministic under Netty 4.2 by rejecting late child channels, draining tracked channels, and awaiting event-loop termination
- close broker-side plain and TLS `ServerChannels` during `QueryRouter` shutdown so broker-to-server sockets do not outlive the broker
- plumb peer host/port and `endpointIdentificationAlgorithm` through the Netty and AsyncHttpClient TLS paths used by the broker, Java client, JDBC client, and admin client

## How to reproduce the issue
- check out `master` after PR #17980 but before this PR
- run `./mvnw -pl pinot-core -Dtest=QueryRoutingTest test` repeatedly and observe intermittent failures in `testValidResponse`, `testServerDown`, or `testSkipUnavailableServer`
- configure broker/server or Java/JDBC/admin HTTPS clients with `endpointIdentificationAlgorithm=HTTPS`
- observe that the affected transports created `SSLEngine`s without the peer host/port, so explicit hostname verification and SNI could not be applied consistently
- stop a broker with active server channels and observe that broker-side Netty channel pools relied on pre-4.2 shutdown behavior and were not fully drained or awaited

## Testing
- `./mvnw -pl pinot-core,pinot-clients/pinot-java-client,pinot-clients/pinot-jdbc-client spotless:apply`
- `./mvnw -pl pinot-core,pinot-clients/pinot-java-client,pinot-clients/pinot-jdbc-client checkstyle:check`
- `./mvnw -pl pinot-core,pinot-clients/pinot-java-client,pinot-clients/pinot-jdbc-client license:format`
- `./mvnw -pl pinot-core,pinot-clients/pinot-java-client,pinot-clients/pinot-jdbc-client license:check`
- `./mvnw -pl pinot-core,pinot-clients/pinot-java-client,pinot-clients/pinot-jdbc-client -am -Dtest=ServerChannelsTest,QueryRoutingTest,SslContextProviderTest test -Dsurefire.failIfNoSpecifiedTests=false -rf :pinot-core`