### PR TITLE
skip trying to generate min max if buffer is EmptyIndexBuffer

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/columnminmaxvalue/ColumnMinMaxValueGenerator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/columnminmaxvalue/ColumnMinMaxValueGenerator.java
@@ -40,6 +40,7 @@ import org.apache.pinot.segment.spi.index.StandardIndexes;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.segment.spi.index.reader.ForwardIndexReader;
 import org.apache.pinot.segment.spi.index.reader.ForwardIndexReaderContext;
+import org.apache.pinot.segment.spi.memory.EmptyIndexBuffer;
 import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
 import org.apache.pinot.segment.spi.store.SegmentDirectory;
 import org.apache.pinot.segment.spi.utils.SegmentMetadataUtils;
@@ -204,6 +205,9 @@ public class ColumnMinMaxValueGenerator {
     DataType storedType = dataType.getStoredType();
     boolean isSingleValue = columnMetadata.isSingleValue();
     PinotDataBuffer rawIndexBuffer = _segmentWriter.getIndexFor(columnName, StandardIndexes.forward());
+    if (rawIndexBuffer instanceof EmptyIndexBuffer) {
+      return;
+    }
     try (ForwardIndexReader rawIndexReader = ForwardIndexReaderFactory.getInstance()
         .createIndexReader(rawIndexBuffer, columnMetadata);
         ForwardIndexReaderContext readerContext = rawIndexReader.createContext()) {


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Add early return for EmptyIndexBuffer to skip min/max value generation\.

```mermaid
flowchart TD
  N0["Obtain rawIndexBuffer #40;F1#41;"]:::stAdded
  N1["Check instanceof EmptyIndexBuffer #40;F1#41;"]:::stAdded
  N2["Return early #40;skip#41; #40;F1#41;"]:::stAdded
  N3["Proceed to try block #40;F1#41;"]:::stAdded
  N0 -->|"value transfer"| N1
  N1 -->|"branch true"| N2
  N1 -->|"branch false"| N3
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-segment\-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/columnminmaxvalue/ColumnMinMaxValueGenerator\.java — [before](https://github.com/apache/pinot/blob/ecaf0f8017aeb11d61c9fdd0ca253faa7336fc70/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/columnminmaxvalue/ColumnMinMaxValueGenerator.java) · [after](https://github.com/apache/pinot/blob/67bb5037c5e8496b3c86b28c9ebdad1d101d70dd/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/columnminmaxvalue/ColumnMinMaxValueGenerator.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImVjYWYwZjgwMTdhZWIxMWQ2MWM5ZmRkMGNhMjUzZmFhNzMzNmZjNzAiLCJjb250ZXh0X2hhc2giOiIxMTY3Y2E3Y2M3OTgxYjkxYWI3ZjkxZDkzNmVhN2U3YzlmNzE2NzMwNmEzODFkNTZmODgzY2NlOWFmNTNkODlkIiwiZ2VuZXJhdGVkX2F0IjoxNzg5MjY3MDE0LCJoZWFkX3NoYSI6IjY3YmI1MDM3YzVlODQ5NmIzYzg2YjI4YzllYmRhZDFkMTAxZDcwZGQiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiIxNDRkYWEwNDQzNmJjMjY4OTY1N2ZjMjQwNTljYTkxMDdmMGI3ZDQyIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 22d4ad0388c023cca68c925662aca879a1e3a06fac89d5f43079161b8f880f80 -->
<!-- pinot-pr-flow:end -->

This pull request introduces a safeguard in the `ColumnMinMaxValueGenerator` to ensure that the min/max value calculation is skipped for columns whose forward index is an `EmptyIndexBuffer`. This helps prevent unnecessary processing and potential errors for columns that do not have a forward index.

**Robustness improvement:**

* Added a check in `addColumnMinMaxValueWithoutDictionary` to return early if the forward index buffer is an instance of `EmptyIndexBuffer`, preventing further processing on empty indexes.
* Imported `EmptyIndexBuffer` in `ColumnMinMaxValueGenerator.java` to support the new check.