### PR TITLE
Raise Pinot Java baseline to 21

### DIFF
--- a/.claude/skills/flaky-analyze/SKILL.md
+++ b/.claude/skills/flaky-analyze/SKILL.md
@@ -46,7 +46,7 @@ If `gh` isn't available, report that and exit. Don't try to fall back to `curl` 
    ```
    If `--pr` is set, filter with `--branch` to the PR's head branch, or use `gh pr view <num> --json headRefName`.
 
-3. **For each failed run, find the failing jobs.** A "Pinot Tests" run has ~10 matrix jobs (test sets 1/2 × java 11/21 × unit/integration). Only some fail.
+3. **For each failed run, find the failing jobs.** A "Pinot Tests" run has matrix jobs (test sets 1/2 × java 21 × unit/integration). Only some fail.
    ```
    gh run view <run-id> --repo apache/pinot --json jobs
    ```

--- a/.claude/skills/review-naming-api/SKILL.md
+++ b/.claude/skills/review-naming-api/SKILL.md
@@ -35,7 +35,7 @@ Severity:
 - Public API surface: if adding a method to an SPI interface, confirm domain-1 backward-compat story (C1.3).
 - Javadoc: new public classes must describe behavior and thread-safety.
 - Imports: `com.foo.Bar foo = new com.foo.Bar()` → use import.
-- CLAUDE.md checks: license header, Java 11 target (no Java 17 syntax), SLF4J logger pattern.
+- CLAUDE.md checks: license header, Java 21 target (Java 11 bytecode for SPI/client modules), SLF4J logger pattern.
 
 ## 3. Findings
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -9,8 +9,7 @@ This document guides AI coding assistants (Copilot, Cursor, etc.) contributing t
 
 ## Libraries and Frameworks
 
-- Most source code is written in Java 11.
-- Code in `pinot-clients` is written in Java 8.
+- Most source code is written in Java 21. `pinot-spi`, `pinot-segment-spi`, `pinot-timeseries-spi`, `pinot-common`, `pinot-java-client`, and `pinot-jdbc-client` target Java 11 bytecode for external consumers.
 - Pinot UI is a React.js frontend. It is stored in `pinot-controller/src/main/resources/`.
 - The code is compiled with Maven and follows a multimodule structure. Use each module's `pom.xml` to
   understand dependencies and configurations.

--- a/.github/workflows/build-all-pinot-docker-image.yml
+++ b/.github/workflows/build-all-pinot-docker-image.yml
@@ -53,7 +53,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java-version: ["11", "17", "21", "25"]
+        java-version: ["21", "25"]
     name: Compile JDK-${{ matrix.java-version }} Pinot
     needs: [generate-build-info]
     steps:
@@ -77,7 +77,7 @@ jobs:
       fail-fast: false
       matrix:
         java-disto: ["ms-openjdk", "amazoncorretto"]
-        java-version: ["11", "17", "21", "25"]
+        java-version: ["21", "25"]
         arch: ["amd64", "arm64"]
         include:
           - arch: amd64
@@ -110,7 +110,7 @@ jobs:
       fail-fast: false
       matrix:
         java-disto: ["ms-openjdk", "amazoncorretto"]
-        java-version: ["11", "17", "21", "25"]
+        java-version: ["21", "25"]
     name: Create ${{ matrix.java-disto }}-${{ matrix.java-version }} Multi-Arch Manifest
     needs: [generate-build-info, package-pinot-docker-image]
     steps:

--- a/.github/workflows/build-pinot-base-docker-image.yml
+++ b/.github/workflows/build-pinot-base-docker-image.yml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       matrix:
         openJdkDist: ["amazoncorretto", "ms-openjdk"]
-        jdk_version: [11, 17, 21, 25]
+        jdk_version: [21, 25]
         arch: [amd64, arm64]
         type: [build, runtime]
         include:
@@ -60,7 +60,7 @@ jobs:
     strategy:
       matrix:
         openJdkDist: ["amazoncorretto", "ms-openjdk"]
-        jdk_version: [11, 17, 21, 25]
+        jdk_version: [21, 25]
         type: [build, runtime]
     steps:
       - name: Login to DockerHub

--- a/.github/workflows/build-pinot-docker-image.yml
+++ b/.github/workflows/build-pinot-docker-image.yml
@@ -33,6 +33,10 @@ on:
         description: "The docker image name, default to 'apachepinot/pinot'."
         default: "apachepinot/pinot"
         required: true
+      jdkVersion:
+        description: "The JDK version to use for the Pinot build and runtime image."
+        default: "21"
+        required: true
       tags:
         description: "Tags to push of the image, comma separated, e.g. tag1,tag2,tag3"
         default: ""
@@ -58,5 +62,6 @@ jobs:
         DOCKER_IMAGE_NAME: ${{ github.event.inputs.dockerImageName }}
         BUILD_PLATFORM: ${{ github.event.inputs.platform }}
         PINOT_GIT_REF: ${{ github.event.inputs.commit }}
+        JDK_VERSION: ${{ github.event.inputs.jdkVersion }}
         TAGS: ${{ github.event.inputs.tags }}
       run: .github/workflows/scripts/docker/.pinot_docker_image_build_and_push.sh

--- a/.github/workflows/nightly-build-all-pinot-docker-image.yml
+++ b/.github/workflows/nightly-build-all-pinot-docker-image.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        java-version: ["11", "17", "21", "25"]
+        java-version: ["21", "25"]
     name: Compile JDK-${{ matrix.java-version }} Pinot
     needs: [generate-build-info]
     steps:
@@ -71,7 +71,7 @@ jobs:
       fail-fast: false
       matrix:
         java-disto: ["ms-openjdk", "amazoncorretto"]
-        java-version: ["11", "17", "21", "25"]
+        java-version: ["21", "25"]
         arch: ["amd64", "arm64"]
         include:
           - arch: amd64
@@ -104,7 +104,7 @@ jobs:
       fail-fast: false
       matrix:
         java-disto: ["ms-openjdk", "amazoncorretto"]
-        java-version: ["11", "17", "21", "25"]
+        java-version: ["21", "25"]
     name: Create ${{ matrix.java-disto }}-${{ matrix.java-version }} Multi-Arch Manifest
     needs: [generate-build-info, package-pinot-docker-image]
     steps:

--- a/.github/workflows/pinot_compatibility_tests.yml
+++ b/.github/workflows/pinot_compatibility_tests.yml
@@ -37,10 +37,10 @@ jobs:
     name: Pinot Compatibility Regression Testing against ${{ github.event.inputs.oldCommit }} and ${{ github.event.inputs.newCommit }} on ${{ matrix.test_suite }}
     steps:
       - uses: actions/checkout@v6
-      - name: Set up JDK 11
+      - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:
-          java-version: 11
+          java-version: 21
           distribution: 'temurin'
           cache: 'maven'
       - name: Setup node

--- a/.github/workflows/pinot_multi_stage_query_engine_compatibility_tests.yml
+++ b/.github/workflows/pinot_multi_stage_query_engine_compatibility_tests.yml
@@ -37,10 +37,10 @@ jobs:
     name: Pinot Multi-Stage Query Engine Compatibility Regression Testing against ${{ github.event.inputs.oldCommit }} and ${{ github.event.inputs.newCommit }} on ${{ matrix.test_suite }}
     steps:
       - uses: actions/checkout@v6
-      - name: Set up JDK 11
+      - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:
-          java-version: 11
+          java-version: 21
           distribution: 'temurin'
           cache: 'maven'
       - name: Setup node

--- a/.github/workflows/pinot_tests.yml
+++ b/.github/workflows/pinot_tests.yml
@@ -54,10 +54,10 @@ jobs:
     name: Pinot Linter Test Set
     steps:
       - uses: actions/checkout@v6
-      - name: Set up JDK 11
+      - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:
-          java-version: 11
+          java-version: 21
           distribution: 'temurin'
           cache: 'maven'
       - name: Install pinot-dependency-verifier into repo
@@ -90,10 +90,10 @@ jobs:
     name: Pinot Binary Compatibility Check
     steps:
       - uses: actions/checkout@v6
-      - name: Set up JDK 11
+      - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:
-          java-version: 11
+          java-version: 21
           distribution: 'temurin'
           cache: 'maven'
       # Step that does that actual cache save and restore
@@ -129,7 +129,7 @@ jobs:
       - name: Download japicmp CLI
         run: |
           JAPICMP_VER=0.23.1
-          curl -fSL \
+          curl -fSL --retry 3 --retry-delay 5 \
           -o japicmp.jar \
           "https://repo1.maven.org/maven2/com/github/siom79/japicmp/japicmp/${JAPICMP_VER}/japicmp-${JAPICMP_VER}-jar-with-dependencies.jar"
       # Locate the old JAR (from master) and the new JAR (PR) and run japicmp to compare
@@ -154,7 +154,7 @@ jobs:
       fail-fast: false
       matrix:
         testset: [ 1, 2 ]
-        java: [ 11, 21 ]
+        java: [ 21 ]
         distribution: [ "temurin" ]
     name: Pinot Unit Test Set ${{ matrix.testset }} (${{matrix.distribution}}-${{matrix.java}})
     steps:
@@ -260,7 +260,7 @@ jobs:
       fail-fast: false
       matrix:
         testset: [ 1, 2 ]
-        java: [ 11, 21 ]
+        java: [ 21 ]
         distribution: [ "temurin" ]
     name: Pinot Integration Test Set ${{ matrix.testset }} (${{matrix.distribution}}-${{matrix.java}})
     steps:
@@ -385,10 +385,10 @@ jobs:
     name: Pinot Compatibility Regression Testing against ${{ matrix.old_commit }} on ${{ matrix.test_suite }}
     steps:
       - uses: actions/checkout@v6
-      - name: Set up JDK 11
+      - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:
-          java-version: 11
+          java-version: 21
           distribution: 'temurin'
           cache: 'maven'
       - name: Setup node
@@ -443,10 +443,10 @@ jobs:
     name: Pinot Multi-Stage Query Engine Compatibility Regression Testing against ${{ matrix.old_commit }} on ${{ matrix.test_suite }}
     steps:
       - uses: actions/checkout@v6
-      - name: Set up JDK 11
+      - name: Set up JDK 21
         uses: actions/setup-java@v5
         with:
-          java-version: 11
+          java-version: 21
           distribution: 'temurin'
           cache: 'maven'
       - name: Setup node
@@ -494,7 +494,7 @@ jobs:
       # Changed to false in order to improve coverage using unsafe buffers
       fail-fast: false
       matrix:
-        java: [ 11, 21 ]
+        java: [ 21 ]
         distribution: [ "temurin" ]
     name: Pinot Quickstart on JDK ${{ matrix.java }}-${{ matrix.distribution }}
     steps:

--- a/.github/workflows/pinot_tests.yml
+++ b/.github/workflows/pinot_tests.yml
@@ -105,13 +105,73 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      # Build the PR branch's module to get a new JAR to compare
-      - name: Build SPI on PR branch
+      # Build the PR branch's Java 11 artifact surface to get new JARs to validate and compare
+      - name: Build Java 11 artifacts on PR branch
         timeout-minutes: 120
         run: |
-          for mod in pinot-spi pinot-segment-spi; do
-            mvn clean package -T1C -pl $mod -am -DskipTests -Dproject.build.finalName="$mod"
-          done
+          JAVA11_MODULES=(
+            pinot-spi
+            pinot-segment-spi
+            pinot-common
+            pinot-timeseries/pinot-timeseries-spi
+            pinot-clients/pinot-java-client
+            pinot-clients/pinot-jdbc-client
+          )
+          mvn clean package -T1C -pl "$(IFS=,; echo "${JAVA11_MODULES[*]}")" -am -DskipTests -DskipShade
+      - name: Validate Java 11 artifact bytecode
+        run: |
+          python3 - <<'PY'
+          import glob
+          import os
+          import struct
+          import sys
+          import zipfile
+
+          modules = {
+              "pinot-spi": "pinot-spi",
+              "pinot-segment-spi": "pinot-segment-spi",
+              "pinot-common": "pinot-common",
+              "pinot-timeseries/pinot-timeseries-spi": "pinot-timeseries-spi",
+              "pinot-clients/pinot-java-client": "pinot-java-client",
+              "pinot-clients/pinot-jdbc-client": "pinot-jdbc-client",
+          }
+          max_major = 55
+          violations = []
+
+          def main_artifact(module, artifact_id):
+              candidates = []
+              for path in glob.glob(f"{module}/target/{artifact_id}-*.jar"):
+                  name = os.path.basename(path)
+                  if name.startswith("original-"):
+                      continue
+                  if name.endswith(("-sources.jar", "-javadoc.jar", "-tests.jar", "-shaded.jar")):
+                      continue
+                  candidates.append(path)
+              if len(candidates) != 1:
+                  raise RuntimeError(f"Expected one main artifact for {module}, found: {candidates}")
+              return candidates[0]
+
+          for module, artifact_id in modules.items():
+              jar_path = main_artifact(module, artifact_id)
+              print(f"Validating {jar_path}")
+              with zipfile.ZipFile(jar_path) as jar:
+                  for entry in jar.namelist():
+                      if not entry.endswith(".class"):
+                          continue
+                      data = jar.read(entry)[:8]
+                      magic, _minor, major = struct.unpack(">IHH", data)
+                      if magic != 0xCAFEBABE:
+                          violations.append(f"{jar_path}!/{entry}: invalid classfile magic")
+                      elif major > max_major:
+                          violations.append(f"{jar_path}!/{entry}: classfile major {major} > {max_major}")
+
+          if violations:
+              print("Found classes above Java 11 bytecode:", file=sys.stderr)
+              print("\n".join(violations[:100]), file=sys.stderr)
+              if len(violations) > 100:
+                  print(f"... and {len(violations) - 100} more", file=sys.stderr)
+              sys.exit(1)
+          PY
       - name: Checkout master into a subfolder
         uses: actions/checkout@v6
         with:

--- a/.github/workflows/scripts/.pinot_quickstart.sh
+++ b/.github/workflows/scripts/.pinot_quickstart.sh
@@ -76,11 +76,11 @@ jdk_version() {
 JAVA_VER="$(jdk_version)"
 
 # Build
-echo "Building Pinot to JAVA 11 source code Using JDK ${JAVA_VER}"
+echo "Building Pinot Using JDK ${JAVA_VER}"
 PASS=0
 for i in $(seq 1 2)
 do
-  mvn clean install -B -ntp -T1C -DskipTests -Pbin-dist -Dmaven.javadoc.skip=true -Djdk.version=11
+  mvn clean install -B -ntp -T1C -DskipTests -Pbin-dist -Dmaven.javadoc.skip=true
   if [ $? -eq 0 ]; then
     PASS=1
     break;

--- a/.github/workflows/scripts/docker/.pinot_base_docker_image_build_and_push.sh
+++ b/.github/workflows/scripts/docker/.pinot_base_docker_image_build_and_push.sh
@@ -35,7 +35,7 @@ docker build \
   --platform=${BUILD_PLATFORM} \
   --file ${OPEN_JDK_DIST}.dockerfile \
   --tag apachepinot/pinot-base-${BASE_IMAGE_TYPE}:${TAG}-${ARCH} \
-  --build-arg JAVA_VERSION=${JDK_VERSION:-11} \
+  --build-arg JAVA_VERSION=${JDK_VERSION:-21} \
   --build-arg ARCH=${ARCH} \
   .
 

--- a/.github/workflows/scripts/docker/.pinot_docker_image_build_and_push.sh
+++ b/.github/workflows/scripts/docker/.pinot_docker_image_build_and_push.sh
@@ -27,6 +27,12 @@ fi
 if [ -z "${BUILD_PLATFORM}" ]; then
   BUILD_PLATFORM="linux/arm64,linux/amd64"
 fi
+if [ -z "${JDK_VERSION}" ]; then
+  JDK_VERSION="21"
+fi
+if [ -z "${PINOT_BASE_IMAGE_TAG}" ]; then
+  PINOT_BASE_IMAGE_TAG="${JDK_VERSION}-amazoncorretto"
+fi
 
 # Get pinot commit id.
 # Use clone + checkout instead of clone -b so that commit SHAs work in
@@ -59,11 +65,14 @@ done
 
 cd ${DOCKER_FILE_BASE_DIR}
 
+echo "Building Pinot Docker image with JDK ${JDK_VERSION} and base image tag ${PINOT_BASE_IMAGE_TAG}"
 docker buildx build \
     --no-cache \
     --platform=${BUILD_PLATFORM} \
     --file Dockerfile \
     --build-arg PINOT_GIT_REF=${PINOT_GIT_REF} \
+    --build-arg JDK_VERSION=${JDK_VERSION} \
+    --build-arg PINOT_BASE_IMAGE_TAG=${PINOT_BASE_IMAGE_TAG} \
     ${DOCKER_BUILD_TAGS} \
     --push \
     .

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -92,8 +92,8 @@ repo. It is intentionally short and focused on day-to-day work.
 - assembly-descriptor: Maven assembly descriptor for plugin packaging.
 
 ## Build and test
-- Build JDK: Use JDK 11+ (CI runs 11/17/21); code targets Java 11.
-- Runtime JRE: Broker/server/controller/minion run on Java 11+.
+- Build JDK: Use JDK 21+ for Pinot services and the default build; client and SPI artifacts still target Java 11 bytecode.
+- Runtime JRE: Broker/server/controller/minion run on Java 21+.
 - Default build: `./mvnw clean install`
 - Faster dev build: `./mvnw verify -Ppinot-fastdev`
 - Full binary/shaded build:
@@ -107,7 +107,7 @@ repo. It is intentionally short and focused on day-to-day work.
 
 ## Coding conventions and hygiene
 - Add class-level Javadoc for new classes; describe behavior and thread-safety.
-- Use Javadoc comments with either `/** ... */` or `///` syntax (per JEP-467); code targets Java 11.
+- Use Javadoc comments with either `/** ... */` or `///` syntax (per JEP-467); service code targets Java 21 by default.
 - Keep license headers on all new source files.
 - Use `./mvnw license:format` to add headers to new files.
 - Preserve backward compatibility across mixed-version broker/server/controller.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -88,7 +88,7 @@ Apache Pinot is a real-time distributed OLAP datastore for low-latency analytics
 - **assembly-descriptor**: Maven assembly descriptor for plugin packaging.
 
 ## Build commands
-- **JDK**: Use JDK 11+ (CI runs 11/21); code targets Java 11.
+- **JDK**: Use JDK 21+ for Pinot services and the default build; client and SPI artifacts still target Java 11 bytecode.
 - **Default build**: `./mvnw clean install`
 - **Fast dev build**: `./mvnw verify -Ppinot-fastdev`
 - **Full binary/shaded build**: `./mvnw clean install -DskipTests -Pbin-dist -Pbuild-shaded-jar`
@@ -106,7 +106,7 @@ Apache Pinot is a real-time distributed OLAP datastore for low-latency analytics
 
 ## Coding conventions
 - Add class-level Javadoc for new classes; describe behavior and thread-safety.
-- Use Javadoc comments (`/** ... */` or `///` syntax); code targets Java 11.
+- Use Javadoc comments (`/** ... */` or `///` syntax); service code targets Java 21 by default.
 - Keep Apache 2.0 license headers on all new source files.
 - Preserve backward compatibility across mixed-version broker/server/controller.
 - Prefer imports over fully qualified class names (e.g., use `import com.foo.Bar` and refer to `Bar`, not `com.foo.Bar` inline).

--- a/README.md
+++ b/README.md
@@ -121,6 +121,9 @@ Drop your video or a link to your session in the [#pinot-youtube-channel](https:
 $ git clone https://github.com/apache/pinot.git
 $ cd pinot
 
+# Pinot services require JDK 21+ to build and run
+# Java/JDBC clients and SPI artifacts continue to target Java 11 bytecode
+
 # Build Pinot
 # -Pbin-dist is required to build the binary distribution
 # -Pbuild-shaded-jar is required to build the shaded jar, which is necessary for some features like spark connectors

--- a/compatibility-verifier/checkoutAndBuild.sh
+++ b/compatibility-verifier/checkoutAndBuild.sh
@@ -76,7 +76,7 @@ function build() {
   local buildId=$3
   local buildCompatibilityVerifier=$4
   local repoOption=""
-  local versionOption="-Djdk.version=11"
+  local versionOption="-Djdk.version=21"
   local maxRetry=5
 
   mkdir -p ${MVN_CACHE_DIR}

--- a/docker/images/pinot-base/README.md
+++ b/docker/images/pinot-base/README.md
@@ -33,22 +33,22 @@ This task can be triggered manually to build the cross platform(amd64 and arm64v
 
 The build shell is:
 
-For Amazon Corretto 11:
+For Amazon Corretto 21:
 
 ```SHELL
-docker buildx build --no-cache --platform=linux/arm64,linux/amd64 --file pinot-base-build/amazoncorretto.dockerfile --tag apachepinot/pinot-base-build:11-amazoncorretto --push .
+docker buildx build --no-cache --platform=linux/arm64,linux/amd64 --file pinot-base-build/amazoncorretto.dockerfile --tag apachepinot/pinot-base-build:21-amazoncorretto --push .
 ```
 
 ```SHELL
-docker buildx build --no-cache --platform=linux/arm64,linux/amd64 --file pinot-base-runtime/amazoncorretto.dockerfile --tag apachepinot/pinot-base-runtime:11-amazoncorretto --push .
+docker buildx build --no-cache --platform=linux/arm64,linux/amd64 --file pinot-base-runtime/amazoncorretto.dockerfile --tag apachepinot/pinot-base-runtime:21-amazoncorretto --push .
 ```
 
 For MS OpenJDK, the build shell is:
 
 ```SHELL
-docker buildx build --no-cache --platform=linux/arm64,linux/amd64 --file pinot-base-build/amazoncorretto.dockerfile --tag apachepinot/pinot-base-build:11-ms-openjdk --push .
+docker buildx build --no-cache --platform=linux/arm64,linux/amd64 --file pinot-base-build/ms-openjdk.dockerfile --tag apachepinot/pinot-base-build:21-ms-openjdk --push .
 ```
 
 ```SHELL
-docker buildx build --no-cache --platform=linux/arm64,linux/amd64 --file pinot-base-runtime/amazoncorretto.dockerfile --tag apachepinot/pinot-base-runtime:11-ms-openjdk --push .
+docker buildx build --no-cache --platform=linux/arm64,linux/amd64 --file pinot-base-runtime/ms-openjdk.dockerfile --tag apachepinot/pinot-base-runtime:21-ms-openjdk --push .
 ```

--- a/docker/images/pinot-base/pinot-base-build/amazoncorretto.dockerfile
+++ b/docker/images/pinot-base/pinot-base-build/amazoncorretto.dockerfile
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-ARG JAVA_VERSION=11
+ARG JAVA_VERSION=21
 FROM debian:bookworm-slim
 
 LABEL MAINTAINER=dev@pinot.apache.org
@@ -45,7 +45,7 @@ RUN set -eux \
 # Install Amazon Corretto.
 # /etc/apt/keyrings/ is the correct path for user-managed keys referenced via
 # signed-by=; apt natively handles ASCII-armored .asc files at that path.
-ARG JAVA_VERSION=11
+ARG JAVA_VERSION=21
 RUN set -eux \
   && mkdir -p /etc/apt/keyrings \
   && wget -qO /etc/apt/keyrings/corretto.asc https://apt.corretto.aws/corretto.key \

--- a/docker/images/pinot-base/pinot-base-build/ms-openjdk.dockerfile
+++ b/docker/images/pinot-base/pinot-base-build/ms-openjdk.dockerfile
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-ARG JAVA_VERSION=11
+ARG JAVA_VERSION=21
 ARG JDK_IMAGE=mcr.microsoft.com/openjdk/jdk
 FROM ${JDK_IMAGE}:${JAVA_VERSION}-ubuntu AS pinot_build_env
 

--- a/docker/images/pinot-base/pinot-base-runtime/amazoncorretto.dockerfile
+++ b/docker/images/pinot-base/pinot-base-runtime/amazoncorretto.dockerfile
@@ -20,7 +20,7 @@
 # AL2023 image to avoid system packages (python3, etc.) that are not needed
 # at runtime and consistently accumulate CVEs. wget is used instead of curl
 # to avoid pulling in libcurl's LDAP/HTTP2 dependencies.
-ARG JAVA_VERSION=11
+ARG JAVA_VERSION=21
 FROM debian:bookworm-slim
 
 LABEL MAINTAINER=dev@pinot.apache.org
@@ -41,7 +41,7 @@ RUN set -eux \
 # Install Amazon Corretto JDK.
 # /etc/apt/keyrings/ is the correct path for user-managed keys referenced via
 # signed-by=; apt natively handles ASCII-armored .asc files at that path.
-ARG JAVA_VERSION=11
+ARG JAVA_VERSION=21
 RUN set -eux \
   && mkdir -p /etc/apt/keyrings \
   && wget -qO /etc/apt/keyrings/corretto.asc https://apt.corretto.aws/corretto.key \

--- a/docker/images/pinot-base/pinot-base-runtime/ms-openjdk.dockerfile
+++ b/docker/images/pinot-base/pinot-base-runtime/ms-openjdk.dockerfile
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-ARG JAVA_VERSION=11
+ARG JAVA_VERSION=21
 ARG JDK_IMAGE=mcr.microsoft.com/openjdk/jdk
 
 FROM ${JDK_IMAGE}:${JAVA_VERSION}-ubuntu AS builder

--- a/docker/images/pinot/Dockerfile
+++ b/docker/images/pinot/Dockerfile
@@ -16,13 +16,13 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-ARG PINOT_BASE_IMAGE_TAG=11-amazoncorretto
+ARG PINOT_BASE_IMAGE_TAG=21-amazoncorretto
 FROM apachepinot/pinot-base-build:${PINOT_BASE_IMAGE_TAG} AS pinot_build_env
 
 LABEL MAINTAINER=dev@pinot.apache.org
 
 ARG PINOT_GIT_REF=master
-ARG JDK_VERSION=11
+ARG JDK_VERSION=21
 ARG CI=true
 
 RUN echo "Build Pinot based on image: apachepinot/pinot-base-build:${PINOT_BASE_IMAGE_TAG}"

--- a/docker/images/pinot/Dockerfile.build
+++ b/docker/images/pinot/Dockerfile.build
@@ -16,13 +16,13 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-ARG PINOT_BASE_IMAGE_TAG=11-amazoncorretto
+ARG PINOT_BASE_IMAGE_TAG=21-amazoncorretto
 FROM apachepinot/pinot-base-build:${PINOT_BASE_IMAGE_TAG} AS pinot_build_env
 
 LABEL MAINTAINER=dev@pinot.apache.org
 
 ARG PINOT_GIT_REF=master
-ARG JDK_VERSION=11
+ARG JDK_VERSION=21
 ARG CI=true
 
 RUN echo "Build Pinot based on image: apachepinot/pinot-base-build:${PINOT_BASE_IMAGE_TAG}"

--- a/docker/images/pinot/Dockerfile.package
+++ b/docker/images/pinot/Dockerfile.package
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-ARG PINOT_BUILD_IMAGE_TAG=11-amazoncorretto
+ARG PINOT_BUILD_IMAGE_TAG=21-amazoncorretto
 ARG PINOT_RUNTIME_IMAGE_TAG=${PINOT_BUILD_IMAGE_TAG}
 FROM --platform=linux/amd64 pinot-build:${PINOT_BUILD_IMAGE_TAG} AS pinot_build_dist
 FROM apachepinot/pinot-base-runtime:${PINOT_RUNTIME_IMAGE_TAG}

--- a/docker/images/pinot/README.md
+++ b/docker/images/pinot/README.md
@@ -24,40 +24,33 @@ This is a docker image of [Apache Pinot](https://github.com/apache/pinot).
 
 ## How to build a docker image
 
-There is a docker build script which will build a given Git repo/branch and tag the image.
+There is a docker build script which will build a given Git ref and tag the image. The script always
+builds from `https://github.com/apache/pinot.git`.
 
 Usage:
 
 ```SHELL
-./docker-build.sh [Docker Tag] [Git Branch] [Pinot Git URL] [Kafka Version] [Java Version] [JDK Version] [OpenJDK Image ]
+./docker-build.sh [Docker Tag] [Git Ref] [Kafka Version] [Java Version]
 ```
-
-This script will check out Pinot Repo `[Pinot Git URL]` on branch `[Git Branch]` and build the docker image for that.
 
 The docker image is tagged as `[Docker Tag]`.
 
 `Docker Tag`: Name and tag your docker image. Default is `pinot:latest`.
 
-`Git Branch`: The Pinot branch to build. Default is `master`.
+`Git Ref`: The Pinot branch, tag, or commit SHA to build. Default is `master`.
 
-`Pinot Git URL`: The Pinot Git Repo to build, users can set it to their own fork. Please note that, the URL is `https://` based, not `git://`. Default is the Apache Repo: `https://github.com/apache/pinot.git`.
+`Kafka Version`: The Kafka version to build Pinot with. Default is `3.0`.
 
-`Kafka Version`: The Kafka Version to build pinot with. Default is `2.0`
+`Java Version`: The Java build and runtime image version. Default is `21`.
 
-`Java Version`: The Java Build and Runtime image version. Default is `11`
-
-`JDK Version`: The JDK parameter to build pinot, set as part of maven build option: `-Djdk.version=${JDK_VERSION}`. Default is `11`
-
-`OpenJDK Image`: Base image to use for Pinot build and runtime. Default is `openjdk`.
-
-* Example of building and tagging a snapshot on your own fork:
+* Example of building and tagging a snapshot:
 ```SHELL
-./docker-build.sh pinot_fork:snapshot-5.2 snapshot-5.2 https://github.com/your_own_fork/pinot.git
+./docker-build.sh pinot:snapshot-5.2 snapshot-5.2
 ```
 
 * Example of building a release version:
 ```SHELL
-./docker-build.sh pinot:release-0.1.0 release-0.1.0 https://github.com/apache/pinot.git
+./docker-build.sh pinot:release-0.1.0 release-0.1.0
 ```
 
 ### Build image for arm64
@@ -66,13 +59,13 @@ On Apple Silicon (M1/M2) or any arm64 host, pass `--platform linux/arm64`:
 
 ```SHELL
 docker build -t pinot:latest --platform linux/arm64 --no-cache --network=host \
-  --build-arg PINOT_GIT_REF=master --build-arg JDK_VERSION=11 -f Dockerfile .
+  --build-arg PINOT_GIT_REF=master --build-arg JDK_VERSION=21 -f Dockerfile .
 ```
 
 On an x86 machine with QEMU installed, add `--platform linux/arm64` the same way:
 ```SHELL
 docker build -t pinot:latest --platform linux/arm64 --no-cache \
-  --build-arg PINOT_GIT_REF=master --build-arg JDK_VERSION=11 -f Dockerfile .
+  --build-arg PINOT_GIT_REF=master --build-arg JDK_VERSION=21 -f Dockerfile .
 ```
 
 ## How to publish a docker image

--- a/docker/images/pinot/docker-build.sh
+++ b/docker/images/pinot/docker-build.sh
@@ -51,4 +51,9 @@ fi
 
 echo "Trying to build Pinot docker image on git ref: [ ${PINOT_GIT_REF} ] and tag it as: [ ${DOCKER_TAG} ]. Kafka Dependencies: [ ${KAFKA_VERSION} ]. Java Version: [ ${JAVA_VERSION} ]."
 
-docker build --no-cache -t ${DOCKER_TAG} --build-arg PINOT_GIT_REF=${PINOT_GIT_REF} --build-arg KAFKA_VERSION=${KAFKA_VERSION} --build-arg JAVA_VERSION=${JAVA_VERSION} -f Dockerfile .
+docker build --no-cache -t ${DOCKER_TAG} \
+  --build-arg PINOT_GIT_REF=${PINOT_GIT_REF} \
+  --build-arg KAFKA_VERSION=${KAFKA_VERSION} \
+  --build-arg JDK_VERSION=${JAVA_VERSION} \
+  --build-arg PINOT_BASE_IMAGE_TAG=${JAVA_VERSION}-amazoncorretto \
+  -f Dockerfile .

--- a/docker/images/pinot/docker-build.sh
+++ b/docker/images/pinot/docker-build.sh
@@ -46,7 +46,7 @@ if [[ "$#" -gt 3 ]]
 then
   JAVA_VERSION=$4
 else
-  JAVA_VERSION=11
+  JAVA_VERSION=21
 fi
 
 echo "Trying to build Pinot docker image on git ref: [ ${PINOT_GIT_REF} ] and tag it as: [ ${DOCKER_TAG} ]. Kafka Dependencies: [ ${KAFKA_VERSION} ]. Java Version: [ ${JAVA_VERSION} ]."

--- a/helm/pinot/values.yaml
+++ b/helm/pinot/values.yaml
@@ -28,12 +28,10 @@ image:
   #   - `latest` tag is always available and points to the nightly pinot master branch build
   #   - `release-x.y.z` or `x.y.z` tags are available for each release, e.g. release-1.0.0, release-0.12.1, 1.0.0, 0.12.1, etc.
   #
-  # Default JDK comes with Amazon Corretto 11, here are also images with different JDKs:
-  #   - Amazon Corretto 11, e.g. `latest-11`, `1.0.0-11`, `latest-11-amazoncorretto`, `1.0.0-11-amazoncorretto`
-  #   - Amazon Corretto 17, e.g. `latest-17-amazoncorretto`, `1.0.0-17-amazoncorretto`
-  #   - MS OpenJDK 11, e.g. `latest-11-ms-openjdk`, `1.0.0-11-ms-openjdk`
-  #   - MS OpenJDK 17, e.g. `latest-17-ms-openjdk`, `1.0.0-17-ms-openjdk`
-  #   - OpenJDK 21, e.g. `latest-21-openjdk`, `1.0.0-21-openjdk`
+  # Default JDK comes with Amazon Corretto 21, here are also images with supported JDK 21 variants:
+  #   - Amazon Corretto 21, e.g. `latest`, `latest-21`, `1.0.0-21`, `latest-21-amazoncorretto`,
+  #     `1.0.0-21-amazoncorretto`
+  #   - MS OpenJDK 21, e.g. `latest-21-ms-openjdk`, `1.0.0-21-ms-openjdk`
   tag: latest # 1.0.0, 0.12.1, latest
   pullPolicy: Always # Use IfNotPresent when you pinged a version of image tag
 

--- a/pinot-clients/pinot-cli/README.md
+++ b/pinot-clients/pinot-cli/README.md
@@ -24,7 +24,7 @@ An interactive and batch command-line client for Apache Pinot. It supports a ric
 
 ## Requirements
 
-- Java 11+ on PATH (Java 22+ recommended for performance)
+- Java 21+ on PATH
 
 ## Build
 
@@ -167,5 +167,4 @@ pinot-clients/pinot-cli/target/pinot-cli-*-executable.jar \
 
 - CLI arguments take precedence over config file values.
 - Pager is only used in interactive mode. Batch mode prints directly to stdout.
-
 

--- a/pinot-clients/pinot-java-client/pom.xml
+++ b/pinot-clients/pinot-java-client/pom.xml
@@ -40,6 +40,20 @@
         <filtering>true</filtering>
       </resource>
     </resources>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <!-- Pinned to Java 11 bytecode for external consumers (e.g. plugins
+               loaded by older JVMs). Hard-coded literal so -Djdk.version=21
+               on the CLI cannot silently bump the bytecode level. -->
+          <release>11</release>
+          <source>11</source>
+          <target>11</target>
+        </configuration>
+      </plugin>
+    </plugins>
   </build>
   <dependencies>
     <dependency>

--- a/pinot-clients/pinot-jdbc-client/pom.xml
+++ b/pinot-clients/pinot-jdbc-client/pom.xml
@@ -46,6 +46,20 @@
         <filtering>true</filtering>
       </resource>
     </resources>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <!-- Pinned to Java 11 bytecode for external consumers (e.g. plugins
+               loaded by older JVMs). Hard-coded literal so -Djdk.version=21
+               on the CLI cannot silently bump the bytecode level. -->
+          <release>11</release>
+          <source>11</source>
+          <target>11</target>
+        </configuration>
+      </plugin>
+    </plugins>
   </build>
   <dependencies>
     <dependency>

--- a/pinot-common/pom.xml
+++ b/pinot-common/pom.xml
@@ -45,6 +45,18 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <!-- Pinned to Java 11 bytecode for external consumers (e.g. plugins
+               loaded by older JVMs). Hard-coded literal so -Djdk.version=21
+               on the CLI cannot silently bump the bytecode level. -->
+          <release>11</release>
+          <source>11</source>
+          <target>11</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <configuration combine.children="override">
           <forkCount>1</forkCount>

--- a/pinot-plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/pom.xml
+++ b/pinot-plugins/pinot-timeseries-lang/pinot-timeseries-m3ql/pom.xml
@@ -31,8 +31,6 @@
 
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/blocks/MseBlock.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/blocks/MseBlock.java
@@ -35,8 +35,8 @@ import org.apache.pinot.core.common.Block;
 /// A MseBlock itself is not very useful, as they have almost no methods.
 /// Instead, they are used as a common sub-interface for [data][Data] and [end-of-stream][Eos] blocks,
 /// which are then subclassed to provide the actual functionality.
-/// This pattern follows the principles of Java 17 sealed interfaces and the intention is implement them as such once
-/// Pinot source code is migrated to Java 17 or newer, specially in Java 21 where pattern matching can also be used,
+/// This pattern follows the principles of sealed interfaces.
+/// Pinot now targets Java 21, so a follow-up could model these blocks with sealed interfaces and pattern matching,
 /// removing the need for the [Visitor] pattern.
 ///
 /// Meanwhile, the API force callers to do some castings, but it is a trade-off to have a more robust and maintainable

--- a/pinot-segment-spi/pom.xml
+++ b/pinot-segment-spi/pom.xml
@@ -34,6 +34,23 @@
     <pinot.root>${basedir}/..</pinot.root>
   </properties>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <!-- Pinned to Java 11 bytecode for external consumers (e.g. plugins
+               loaded by older JVMs). Hard-coded literal so -Djdk.version=21
+               on the CLI cannot silently bump the bytecode level. -->
+          <release>11</release>
+          <source>11</source>
+          <target>11</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.pinot</groupId>

--- a/pinot-spi/pom.xml
+++ b/pinot-spi/pom.xml
@@ -37,6 +37,18 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <!-- Pinned to Java 11 bytecode for external consumers (e.g. plugins
+               loaded by older JVMs). Hard-coded literal so -Djdk.version=21
+               on the CLI cannot silently bump the bytecode level. -->
+          <release>11</release>
+          <source>11</source>
+          <target>11</target>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-dependency-plugin</artifactId>
         <executions>
           <execution>

--- a/pinot-timeseries/pinot-timeseries-planner/pom.xml
+++ b/pinot-timeseries/pinot-timeseries-planner/pom.xml
@@ -31,8 +31,6 @@
 
   <properties>
     <pinot.root>${basedir}/../..</pinot.root>
-    <maven.compiler.source>11</maven.compiler.source>
-    <maven.compiler.target>11</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
   </properties>
 

--- a/pinot-timeseries/pinot-timeseries-spi/pom.xml
+++ b/pinot-timeseries/pinot-timeseries-spi/pom.xml
@@ -32,6 +32,24 @@
   <properties>
     <pinot.root>${basedir}/../..</pinot.root>
   </properties>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <!-- Pinned to Java 11 bytecode for external consumers (e.g. plugins
+               loaded by older JVMs). Hard-coded literal so -Djdk.version=21
+               on the CLI cannot silently bump the bytecode level. -->
+          <release>11</release>
+          <source>11</source>
+          <target>11</target>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
   <dependencies>
     <dependency>
       <groupId>org.apache.pinot</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,13 @@
   <properties>
     <pinot.root>${basedir}</pinot.root>
     <build.profile.id>dev</build.profile.id>
-    <jdk.version>11</jdk.version>
+    <!--
+      Pinot services build against Java 21 by default. SPI/client modules consumed
+      by external JVMs (pinot-spi, pinot-segment-spi, pinot-timeseries-spi,
+      pinot-common, pinot-java-client, pinot-jdbc-client) hard-code Java 11
+      bytecode in their own maven-compiler-plugin configuration.
+    -->
+    <jdk.version>21</jdk.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!-- Setting maven.compiler flags to the jdk version. These are used by maven plugins like maven-javadoc-plugin -->
@@ -2623,6 +2629,28 @@
     </pluginManagement>
 
     <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>enforce-java-version</id>
+            <phase>validate</phase>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <requireJavaVersion>
+                  <version>[21,)</version>
+                  <message>Apache Pinot requires JDK 21 or newer to build.</message>
+                </requireJavaVersion>
+              </rules>
+              <fail>true</fail>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>


### PR DESCRIPTION
## What changed
- raise the Pinot service build and runtime baseline to Java 21 and enforce JDK 21+ during validation
- keep the SPI and Java/JDBC client dependency path (`pinot-spi`, `pinot-segment-spi`, `pinot-timeseries-spi`, `pinot-common`, `pinot-java-client`, `pinot-jdbc-client`) on Java 11 bytecode
- switch CI compatibility workflows, Docker defaults, image tags, Helm guidance, and developer docs to the new split baseline
- update Docker release and nightly publish workflows so JDK 21 is the default release baseline, with JDK 25 kept as the forward-looking variant

## Why
Issue #15343 proposes moving Pinot services to Java 21 while preserving lower-bytecode compatibility for library artifacts consumed from external JVMs. The service modules need the Java 21 baseline, but the SPI and client modules still need to publish lower-target artifacts so consumers do not inherit Java 21-only jars.

## Release changes
- building and running Pinot services now requires JDK 21+
- CI validates the service baseline on JDK 21
- Docker image defaults now use Java 21 base images
- release and nightly Docker publish workflows now build JDK 21 and JDK 25 image variants only
- JDK 11 and JDK 17 Docker images are intentionally removed from the release/nightly publish matrix
- the canonical bare Docker tags continue to be promoted from the `21-ms-openjdk` runtime path
- Helm examples and developer docs now point users at Java 21 images and tooling

## Important notes
- SPI and Java/JDBC client artifacts continue to compile to Java 11 bytecode for external JVM consumers
- this PR changes the Pinot service/runtime baseline, not the client artifact compatibility target
- release managers should use JDK 21+ for local validation and should not publish new JDK 11/17 Docker images from this branch
- deployments pinned to old JDK 11/17 image tags should move to the JDK 21 tags before adopting a release that includes this change
- JDK 25 images remain available as compatibility-forward artifacts, but JDK 21 is the default supported release baseline

## Impact
- service developers need JDK 21+ for normal build and runtime workflows
- CI now exercises the Java 21 service baseline directly
- Docker consumers get Java 21 images by default
- library consumers using the SPI or Java/JDBC clients should continue to receive Java 11-compatible bytecode

## Validation
- `./mvnw -pl pinot-query-runtime,pinot-timeseries/pinot-timeseries-planner,pinot-plugins/pinot-timeseries-lang/pinot-timeseries-m3ql -am spotless:apply -DskipTests`
- `./mvnw -pl pinot-query-runtime,pinot-timeseries/pinot-timeseries-planner,pinot-plugins/pinot-timeseries-lang/pinot-timeseries-m3ql -am checkstyle:check license:format license:check -DskipTests`
- `./mvnw -pl pinot-query-runtime,pinot-timeseries/pinot-timeseries-planner,pinot-plugins/pinot-timeseries-lang/pinot-timeseries-m3ql -am package -DskipTests -DskipShade -T1C`
- `./mvnw -pl pinot-spi,pinot-segment-spi,pinot-common,pinot-timeseries/pinot-timeseries-spi,pinot-clients/pinot-java-client,pinot-clients/pinot-jdbc-client -am spotless:apply -DskipTests`
- `./mvnw -pl pinot-spi,pinot-segment-spi,pinot-common,pinot-timeseries/pinot-timeseries-spi,pinot-clients/pinot-java-client,pinot-clients/pinot-jdbc-client -am checkstyle:check license:format license:check -DskipTests`
- `./mvnw -pl pinot-spi,pinot-segment-spi,pinot-common,pinot-timeseries/pinot-timeseries-spi,pinot-clients/pinot-java-client,pinot-clients/pinot-jdbc-client -am package -DskipTests -DskipShade -T1C`
- `ruby -e 'require "yaml"; ARGV.each { |f| YAML.load_file(f) }' .github/workflows/*docker*.yml`
- `find .github/workflows/scripts/docker -type f -name '*.sh' -print0 | xargs -0 -n1 bash -n`
- `git diff --check`
