### PR TITLE
Add Row-Level Security (RLS) Support for ZooKeeper-Based Authentication

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/ZkBasicAuthAccessControlFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/ZkBasicAuthAccessControlFactory.java
@@ -18,9 +18,11 @@
  */
 package org.apache.pinot.broker.broker;
 
+import com.google.common.base.Preconditions;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -39,6 +41,8 @@ import org.apache.pinot.core.auth.BasicAuthPrincipalUtils;
 import org.apache.pinot.core.auth.ZkBasicAuthPrincipal;
 import org.apache.pinot.spi.auth.AuthorizationResult;
 import org.apache.pinot.spi.auth.TableAuthorizationResult;
+import org.apache.pinot.spi.auth.TableRowColAccessResult;
+import org.apache.pinot.spi.auth.TableRowColAccessResultImpl;
 import org.apache.pinot.spi.auth.broker.RequesterIdentity;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
@@ -119,6 +123,26 @@ public class ZkBasicAuthAccessControlFactory extends AccessControlFactory {
         return TableAuthorizationResult.success();
       }
       return new TableAuthorizationResult(failedTables);
+    }
+
+    @Override
+    public TableRowColAccessResult getRowColFilters(RequesterIdentity requesterIdentity, String table) {
+      Optional<ZkBasicAuthPrincipal> principalOpt = getPrincipalAuth(requesterIdentity);
+
+      Preconditions.checkState(principalOpt.isPresent(), "Principal is not authorized");
+      Preconditions.checkState(table != null, "Table cannot be null");
+
+      TableRowColAccessResult tableRowColAccessResult = new TableRowColAccessResultImpl();
+      ZkBasicAuthPrincipal principal = principalOpt.get();
+
+      //precondition: The principal should have the table.
+      Preconditions.checkArgument(principal.hasTable(table),
+          "Principal: " + principal.getName() + " does not have access to table: " + table);
+
+      Optional<List<String>> rlsFiltersMaybe = principal.getRLSFilters(table);
+      rlsFiltersMaybe.ifPresent(tableRowColAccessResult::setRLSFilters);
+
+      return tableRowColAccessResult;
     }
 
     private Optional<ZkBasicAuthPrincipal> getPrincipalAuth(RequesterIdentity requesterIdentity) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/AccessControlUserConfigUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/AccessControlUserConfigUtils.java
@@ -19,6 +19,8 @@
 package org.apache.pinot.common.utils.config;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -26,6 +28,8 @@ import java.util.stream.Collectors;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.pinot.spi.config.user.AccessType;
 import org.apache.pinot.spi.config.user.UserConfig;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.slf4j.Logger;
 
 
 /**
@@ -36,6 +40,9 @@ import org.apache.pinot.spi.config.user.UserConfig;
 public class AccessControlUserConfigUtils {
   private AccessControlUserConfigUtils() {
   }
+
+  private static final Logger LOGGER = org.slf4j.LoggerFactory.getLogger(
+      AccessControlUserConfigUtils.class);
 
   public static UserConfig fromZNRecord(ZNRecord znRecord) {
     Map<String, String> simpleFields = znRecord.getSimpleFields();
@@ -49,12 +56,32 @@ public class AccessControlUserConfigUtils {
     List<String> tableList = znRecord.getListField(UserConfig.TABLES_KEY);
     List<String> excludeTableList = znRecord.getListField(UserConfig.EXCLUDE_TABLES_KEY);
 
-    List<String> permissionListFromZNRecord = znRecord.getListField(UserConfig.PERMISSIONS_KEY);
+    List<String> permissionListFromZNRecord = znRecord.getListField(
+        UserConfig.PERMISSIONS_KEY);
     List<AccessType> permissionList = null;
     if (permissionListFromZNRecord != null) {
-      permissionList = permissionListFromZNRecord.stream().map(x -> AccessType.valueOf(x)).collect(Collectors.toList());
+      permissionList = permissionListFromZNRecord.stream()
+          .map(x -> AccessType.valueOf(x))
+          .collect(Collectors.toList());
     }
-    return new UserConfig(username, password, component, role, tableList, excludeTableList, permissionList);
+
+    // Extract RLS filters from simple fields (stored as JSON)
+    Map<String, List<String>> rlsFilters = null;
+    String rlsFiltersJson = simpleFields.get(UserConfig.RLS_FILTERS_KEY);
+    if (rlsFiltersJson != null && !rlsFiltersJson.isEmpty()) {
+      try {
+        rlsFilters = JsonUtils.stringToObject(
+            rlsFiltersJson, new TypeReference<Map<String, List<String>>>() {
+            }
+        );
+      } catch (IOException e) {
+        // Log error but continue - RLS filters are optional
+        LOGGER.error("Failed to deserialize RLS filters for user: {}", username, e);
+      }
+    }
+
+    return new UserConfig(username, password, component, role, tableList,
+        excludeTableList, permissionList, rlsFilters);
   }
 
   public static ZNRecord toZNRecord(UserConfig userConfig)
@@ -79,10 +106,16 @@ public class AccessControlUserConfigUtils {
       listFields.put(UserConfig.EXCLUDE_TABLES_KEY, userConfig.getExcludeTables());
     }
 
-    List<AccessType> permissionList = userConfig.getPermissions();
+    List<AccessType> permissionList = userConfig.getPermissios();
     if (permissionList != null) {
-      listFields.put(UserConfig.PERMISSIONS_KEY,
-          userConfig.getPermissions().stream().map(e -> e.toString()).collect(Collectors.toList()));
+      listFields.put(UserConfig.PERMISSIONS_KEY, userConfig.getPermissios().stream()
+          .map(e -> e.toString()).collect(Collectors.toList()));
+    }
+
+    // Serialize RLS filters as JSON and store in simple fields
+    Map<String, List<String>> rlsFilters = userConfig.getRlsFilters();
+    if (rlsFilters != null && !rlsFilters.isEmpty()) {
+      simpleFields.put(UserConfig.RLS_FILTERS_KEY, JsonUtils.objectToString(rlsFilters));
     }
 
     ZNRecord znRecord = new ZNRecord(userConfig.getUserName());

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/config/AccessControlUserConfigUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/config/AccessControlUserConfigUtilsTest.java
@@ -1,0 +1,559 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.utils.config;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.pinot.spi.config.user.AccessType;
+import org.apache.pinot.spi.config.user.ComponentType;
+import org.apache.pinot.spi.config.user.RoleType;
+import org.apache.pinot.spi.config.user.UserConfig;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.apache.pinot.spi.utils.builder.UserConfigBuilder;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+/**
+ * Tests for {@link AccessControlUserConfigUtils}
+ */
+public class AccessControlUserConfigUtilsTest {
+
+  private static final String TEST_USERNAME = "testUser";
+  private static final String TEST_PASSWORD = "testPassword";
+
+  @Test
+  public void testFromZNRecordWithMandatoryFieldsOnly() {
+    // Create ZNRecord with only mandatory fields
+    ZNRecord znRecord = new ZNRecord(TEST_USERNAME);
+    Map<String, String> simpleFields = new HashMap<>();
+    simpleFields.put(UserConfig.USERNAME_KEY, TEST_USERNAME);
+    simpleFields.put(UserConfig.PASSWORD_KEY, TEST_PASSWORD);
+    simpleFields.put(UserConfig.COMPONET_KEY, ComponentType.BROKER.toString());
+    simpleFields.put(UserConfig.ROLE_KEY, RoleType.USER.toString());
+    znRecord.setSimpleFields(simpleFields);
+
+    UserConfig userConfig = AccessControlUserConfigUtils.fromZNRecord(znRecord);
+
+    Assert.assertNotNull(userConfig, "UserConfig should not be null");
+    Assert.assertEquals(userConfig.getUserName(), TEST_USERNAME, "Username should match");
+    Assert.assertEquals(userConfig.getPassword(), TEST_PASSWORD, "Password should match");
+    Assert.assertEquals(userConfig.getComponentType(), ComponentType.BROKER, "Component type should match");
+    Assert.assertEquals(userConfig.getRoleType(), RoleType.USER, "Role type should match");
+    Assert.assertNull(userConfig.getTables(), "Tables should be null");
+    Assert.assertNull(userConfig.getExcludeTables(), "Exclude tables should be null");
+    Assert.assertNull(userConfig.getPermissios(), "Permissions should be null");
+    Assert.assertNull(userConfig.getRlsFilters(), "RLS filters should be null");
+  }
+
+  @Test
+  public void testFromZNRecordWithTableList() {
+    ZNRecord znRecord = new ZNRecord(TEST_USERNAME);
+    Map<String, String> simpleFields = new HashMap<>();
+    simpleFields.put(UserConfig.USERNAME_KEY, TEST_USERNAME);
+    simpleFields.put(UserConfig.PASSWORD_KEY, TEST_PASSWORD);
+    simpleFields.put(UserConfig.COMPONET_KEY, ComponentType.CONTROLLER.toString());
+    simpleFields.put(UserConfig.ROLE_KEY, RoleType.ADMIN.toString());
+    znRecord.setSimpleFields(simpleFields);
+
+    List<String> tableList = Arrays.asList("table1", "table2", "table3");
+    znRecord.setListField(UserConfig.TABLES_KEY, tableList);
+
+    UserConfig userConfig = AccessControlUserConfigUtils.fromZNRecord(znRecord);
+
+    Assert.assertNotNull(userConfig.getTables(), "Tables should not be null");
+    Assert.assertEquals(userConfig.getTables(), tableList, "Table list should match");
+    Assert.assertEquals(userConfig.getTables().size(), 3, "Table list size should be 3");
+  }
+
+  @Test
+  public void testFromZNRecordWithExcludeTableList() {
+    ZNRecord znRecord = new ZNRecord(TEST_USERNAME);
+    Map<String, String> simpleFields = new HashMap<>();
+    simpleFields.put(UserConfig.USERNAME_KEY, TEST_USERNAME);
+    simpleFields.put(UserConfig.PASSWORD_KEY, TEST_PASSWORD);
+    simpleFields.put(UserConfig.COMPONET_KEY, ComponentType.SERVER.toString());
+    simpleFields.put(UserConfig.ROLE_KEY, RoleType.USER.toString());
+    znRecord.setSimpleFields(simpleFields);
+
+    List<String> excludeTableList = Arrays.asList("excludeTable1", "excludeTable2");
+    znRecord.setListField(UserConfig.EXCLUDE_TABLES_KEY, excludeTableList);
+
+    UserConfig userConfig = AccessControlUserConfigUtils.fromZNRecord(znRecord);
+
+    Assert.assertNotNull(userConfig.getExcludeTables(), "Exclude tables should not be null");
+    Assert.assertEquals(userConfig.getExcludeTables(), excludeTableList, "Exclude table list should match");
+    Assert.assertEquals(userConfig.getExcludeTables().size(), 2, "Exclude table list size should be 2");
+  }
+
+  @Test
+  public void testFromZNRecordWithPermissionList() {
+    ZNRecord znRecord = new ZNRecord(TEST_USERNAME);
+    Map<String, String> simpleFields = new HashMap<>();
+    simpleFields.put(UserConfig.USERNAME_KEY, TEST_USERNAME);
+    simpleFields.put(UserConfig.PASSWORD_KEY, TEST_PASSWORD);
+    simpleFields.put(UserConfig.COMPONET_KEY, ComponentType.MINION.toString());
+    simpleFields.put(UserConfig.ROLE_KEY, RoleType.ADMIN.toString());
+    znRecord.setSimpleFields(simpleFields);
+
+    List<String> permissionListStr = Arrays.asList("READ", "CREATE", "UPDATE");
+    znRecord.setListField(UserConfig.PERMISSIONS_KEY, permissionListStr);
+
+    UserConfig userConfig = AccessControlUserConfigUtils.fromZNRecord(znRecord);
+
+    Assert.assertNotNull(userConfig.getPermissios(), "Permissions should not be null");
+    Assert.assertEquals(userConfig.getPermissios().size(), 3, "Permission list size should be 3");
+    Assert.assertTrue(userConfig.getPermissios().contains(AccessType.READ), "Should contain READ permission");
+    Assert.assertTrue(userConfig.getPermissios().contains(AccessType.CREATE), "Should contain CREATE permission");
+    Assert.assertTrue(userConfig.getPermissios().contains(AccessType.UPDATE), "Should contain UPDATE permission");
+  }
+
+  @Test
+  public void testFromZNRecordWithRlsFilters() throws JsonProcessingException {
+    ZNRecord znRecord = new ZNRecord(TEST_USERNAME);
+    Map<String, String> simpleFields = new HashMap<>();
+    simpleFields.put(UserConfig.USERNAME_KEY, TEST_USERNAME);
+    simpleFields.put(UserConfig.PASSWORD_KEY, TEST_PASSWORD);
+    simpleFields.put(UserConfig.COMPONET_KEY, ComponentType.BROKER.toString());
+    simpleFields.put(UserConfig.ROLE_KEY, RoleType.USER.toString());
+
+    Map<String, List<String>> rlsFilters = new HashMap<>();
+    rlsFilters.put("table1", Arrays.asList("country='US'", "department='Engineering'"));
+    rlsFilters.put("table2", Arrays.asList("region='WEST'"));
+    simpleFields.put(UserConfig.RLS_FILTERS_KEY, JsonUtils.objectToString(rlsFilters));
+
+    znRecord.setSimpleFields(simpleFields);
+
+    UserConfig userConfig = AccessControlUserConfigUtils.fromZNRecord(znRecord);
+
+    Assert.assertNotNull(userConfig.getRlsFilters(), "RLS filters should not be null");
+    Assert.assertEquals(userConfig.getRlsFilters().size(), 2, "RLS filters map size should be 2");
+    Assert.assertTrue(userConfig.getRlsFilters().containsKey("table1"), "Should contain table1 filters");
+    Assert.assertTrue(userConfig.getRlsFilters().containsKey("table2"), "Should contain table2 filters");
+    Assert.assertEquals(userConfig.getRlsFilters().get("table1").size(), 2, "table1 should have 2 filters");
+    Assert.assertEquals(userConfig.getRlsFilters().get("table2").size(), 1, "table2 should have 1 filter");
+    // Verify actual filter values
+    Assert.assertEquals(userConfig.getRlsFilters().get("table1").get(0), "country='US'");
+    Assert.assertEquals(userConfig.getRlsFilters().get("table1").get(1), "department='Engineering'");
+    Assert.assertEquals(userConfig.getRlsFilters().get("table2").get(0), "region='WEST'");
+  }
+
+  @Test
+  public void testFromZNRecordWithMalformedRlsFilters() {
+    ZNRecord znRecord = new ZNRecord(TEST_USERNAME);
+    Map<String, String> simpleFields = new HashMap<>();
+    simpleFields.put(UserConfig.USERNAME_KEY, TEST_USERNAME);
+    simpleFields.put(UserConfig.PASSWORD_KEY, TEST_PASSWORD);
+    simpleFields.put(UserConfig.COMPONET_KEY, ComponentType.BROKER.toString());
+    simpleFields.put(UserConfig.ROLE_KEY, RoleType.USER.toString());
+    simpleFields.put(UserConfig.RLS_FILTERS_KEY, "invalid-json-{malformed");
+    znRecord.setSimpleFields(simpleFields);
+
+    // Should not throw exception, but log error and continue
+    UserConfig userConfig = AccessControlUserConfigUtils.fromZNRecord(znRecord);
+
+    Assert.assertNotNull(userConfig, "UserConfig should not be null");
+    Assert.assertNull(userConfig.getRlsFilters(), "RLS filters should be null due to malformed JSON");
+  }
+
+  @Test
+  public void testFromZNRecordWithAllFields() throws JsonProcessingException {
+    ZNRecord znRecord = new ZNRecord(TEST_USERNAME);
+    Map<String, String> simpleFields = new HashMap<>();
+    simpleFields.put(UserConfig.USERNAME_KEY, "adminUser");
+    simpleFields.put(UserConfig.PASSWORD_KEY, "adminPass123");
+    simpleFields.put(UserConfig.COMPONET_KEY, ComponentType.PROXY.toString());
+    simpleFields.put(UserConfig.ROLE_KEY, RoleType.ADMIN.toString());
+
+    Map<String, List<String>> rlsFilters = new HashMap<>();
+    rlsFilters.put("table1", Arrays.asList("filter1", "filter2"));
+    simpleFields.put(UserConfig.RLS_FILTERS_KEY, JsonUtils.objectToString(rlsFilters));
+    znRecord.setSimpleFields(simpleFields);
+
+    List<String> tableList = Arrays.asList("table1", "table2");
+    List<String> excludeTableList = Arrays.asList("excludeTable1");
+    List<String> permissionListStr = Arrays.asList("READ", "UPDATE", "DELETE");
+
+    znRecord.setListField(UserConfig.TABLES_KEY, tableList);
+    znRecord.setListField(UserConfig.EXCLUDE_TABLES_KEY, excludeTableList);
+    znRecord.setListField(UserConfig.PERMISSIONS_KEY, permissionListStr);
+
+    UserConfig userConfig = AccessControlUserConfigUtils.fromZNRecord(znRecord);
+
+    Assert.assertNotNull(userConfig, "UserConfig should not be null");
+    Assert.assertEquals(userConfig.getUserName(), "adminUser", "Username should match");
+    Assert.assertEquals(userConfig.getPassword(), "adminPass123", "Password should match");
+    Assert.assertEquals(userConfig.getComponentType(), ComponentType.PROXY, "Component type should match");
+    Assert.assertEquals(userConfig.getRoleType(), RoleType.ADMIN, "Role type should match");
+    Assert.assertEquals(userConfig.getTables(), tableList, "Table list should match");
+    Assert.assertEquals(userConfig.getExcludeTables(), excludeTableList, "Exclude table list should match");
+    Assert.assertEquals(userConfig.getPermissios().size(), 3, "Permission list size should match");
+    Assert.assertNotNull(userConfig.getRlsFilters(), "RLS filters should not be null");
+  }
+
+  @Test
+  public void testToZNRecordWithMandatoryFieldsOnly() throws JsonProcessingException {
+    UserConfig userConfig = new UserConfigBuilder()
+        .setUsername(TEST_USERNAME)
+        .setPassword(TEST_PASSWORD)
+        .setComponentType(ComponentType.BROKER)
+        .setRoleType(RoleType.USER)
+        .build();
+
+    ZNRecord znRecord = AccessControlUserConfigUtils.toZNRecord(userConfig);
+
+    Assert.assertNotNull(znRecord, "ZNRecord should not be null");
+    Assert.assertEquals(znRecord.getId(), TEST_USERNAME, "ZNRecord ID should match username");
+    Assert.assertEquals(znRecord.getSimpleField(UserConfig.USERNAME_KEY), TEST_USERNAME, "Username should match");
+    Assert.assertEquals(znRecord.getSimpleField(UserConfig.PASSWORD_KEY), TEST_PASSWORD, "Password should match");
+    Assert.assertEquals(znRecord.getSimpleField(UserConfig.COMPONET_KEY), ComponentType.BROKER.toString(),
+        "Component type should match");
+    Assert.assertEquals(znRecord.getSimpleField(UserConfig.ROLE_KEY), RoleType.USER.toString(),
+        "Role type should match");
+    Assert.assertNull(znRecord.getListField(UserConfig.TABLES_KEY), "Tables should be null");
+    Assert.assertNull(znRecord.getListField(UserConfig.EXCLUDE_TABLES_KEY), "Exclude tables should be null");
+    Assert.assertNull(znRecord.getListField(UserConfig.PERMISSIONS_KEY), "Permissions should be null");
+    Assert.assertNull(znRecord.getSimpleField(UserConfig.RLS_FILTERS_KEY), "RLS filters should be null");
+  }
+
+  @Test
+  public void testToZNRecordWithTableList() throws JsonProcessingException {
+    List<String> tableList = Arrays.asList("table1", "table2", "table3");
+    UserConfig userConfig = new UserConfigBuilder()
+        .setUsername(TEST_USERNAME)
+        .setPassword(TEST_PASSWORD)
+        .setComponentType(ComponentType.CONTROLLER)
+        .setRoleType(RoleType.ADMIN)
+        .setTableList(tableList)
+        .build();
+
+    ZNRecord znRecord = AccessControlUserConfigUtils.toZNRecord(userConfig);
+
+    Assert.assertNotNull(znRecord.getListField(UserConfig.TABLES_KEY), "Tables should not be null");
+    Assert.assertEquals(znRecord.getListField(UserConfig.TABLES_KEY), tableList, "Table list should match");
+    Assert.assertEquals(znRecord.getListField(UserConfig.TABLES_KEY).size(), 3, "Table list size should be 3");
+  }
+
+  @Test
+  public void testToZNRecordWithExcludeTableList() throws JsonProcessingException {
+    List<String> excludeTableList = Arrays.asList("excludeTable1", "excludeTable2");
+    UserConfig userConfig = new UserConfigBuilder()
+        .setUsername(TEST_USERNAME)
+        .setPassword(TEST_PASSWORD)
+        .setComponentType(ComponentType.SERVER)
+        .setRoleType(RoleType.USER)
+        .setExcludeTableList(excludeTableList)
+        .build();
+
+    ZNRecord znRecord = AccessControlUserConfigUtils.toZNRecord(userConfig);
+
+    Assert.assertNotNull(znRecord.getListField(UserConfig.EXCLUDE_TABLES_KEY), "Exclude tables should not be null");
+    Assert.assertEquals(znRecord.getListField(UserConfig.EXCLUDE_TABLES_KEY), excludeTableList,
+        "Exclude table list should match");
+    Assert.assertEquals(znRecord.getListField(UserConfig.EXCLUDE_TABLES_KEY).size(), 2,
+        "Exclude table list size should be 2");
+  }
+
+  @Test
+  public void testToZNRecordWithPermissionList() throws JsonProcessingException {
+    List<AccessType> permissionList = Arrays.asList(AccessType.READ, AccessType.CREATE, AccessType.UPDATE);
+    UserConfig userConfig = new UserConfigBuilder()
+        .setUsername(TEST_USERNAME)
+        .setPassword(TEST_PASSWORD)
+        .setComponentType(ComponentType.MINION)
+        .setRoleType(RoleType.ADMIN)
+        .setPermissionList(permissionList)
+        .build();
+
+    ZNRecord znRecord = AccessControlUserConfigUtils.toZNRecord(userConfig);
+
+    List<String> permissionListStr = znRecord.getListField(UserConfig.PERMISSIONS_KEY);
+    Assert.assertNotNull(permissionListStr, "Permissions should not be null");
+    Assert.assertEquals(permissionListStr.size(), 3, "Permission list size should be 3");
+    Assert.assertTrue(permissionListStr.contains("READ"), "Should contain READ permission");
+    Assert.assertTrue(permissionListStr.contains("CREATE"), "Should contain CREATE permission");
+    Assert.assertTrue(permissionListStr.contains("UPDATE"), "Should contain UPDATE permission");
+  }
+
+  @Test
+  public void testToZNRecordWithRlsFilters() throws IOException {
+    Map<String, List<String>> rlsFilters = new HashMap<>();
+    rlsFilters.put("table1", Arrays.asList("country='US'", "department='Engineering'"));
+    rlsFilters.put("table2", Arrays.asList("region='WEST'"));
+
+    UserConfig userConfig = new UserConfigBuilder()
+        .setUsername(TEST_USERNAME)
+        .setPassword(TEST_PASSWORD)
+        .setComponentType(ComponentType.BROKER)
+        .setRoleType(RoleType.USER)
+        .setRlsFilters(rlsFilters)
+        .build();
+
+    ZNRecord znRecord = AccessControlUserConfigUtils.toZNRecord(userConfig);
+
+    String rlsFiltersJson = znRecord.getSimpleField(UserConfig.RLS_FILTERS_KEY);
+    Assert.assertNotNull(rlsFiltersJson, "RLS filters should not be null");
+
+    // Deserialize and verify
+    Map<String, List<String>> deserializedFilters = JsonUtils.stringToObject(
+        rlsFiltersJson, new com.fasterxml.jackson.core.type.TypeReference<Map<String, List<String>>>() {
+        }
+    );
+    Assert.assertEquals(deserializedFilters.size(), 2, "RLS filters map size should be 2");
+    Assert.assertTrue(deserializedFilters.containsKey("table1"), "Should contain table1 filters");
+    Assert.assertTrue(deserializedFilters.containsKey("table2"), "Should contain table2 filters");
+    // Verify actual filter values
+    Assert.assertEquals(deserializedFilters.get("table1").get(0), "country='US'");
+    Assert.assertEquals(deserializedFilters.get("table1").get(1), "department='Engineering'");
+    Assert.assertEquals(deserializedFilters.get("table2").get(0), "region='WEST'");
+  }
+
+  @Test
+  public void testToZNRecordWithAllFields() throws JsonProcessingException {
+    List<String> tableList = Arrays.asList("table1", "table2");
+    List<String> excludeTableList = Arrays.asList("excludeTable1");
+    List<AccessType> permissionList = Arrays.asList(AccessType.READ, AccessType.UPDATE, AccessType.DELETE);
+    Map<String, List<String>> rlsFilters = new HashMap<>();
+    rlsFilters.put("table1", Arrays.asList("filter1", "filter2"));
+
+    UserConfig userConfig = new UserConfigBuilder()
+        .setUsername("adminUser")
+        .setPassword("adminPass123")
+        .setComponentType(ComponentType.PROXY)
+        .setRoleType(RoleType.ADMIN)
+        .setTableList(tableList)
+        .setExcludeTableList(excludeTableList)
+        .setPermissionList(permissionList)
+        .setRlsFilters(rlsFilters)
+        .build();
+
+    ZNRecord znRecord = AccessControlUserConfigUtils.toZNRecord(userConfig);
+
+    Assert.assertNotNull(znRecord, "ZNRecord should not be null");
+    Assert.assertEquals(znRecord.getId(), "adminUser", "ZNRecord ID should match username");
+    Assert.assertEquals(znRecord.getSimpleField(UserConfig.USERNAME_KEY), "adminUser", "Username should match");
+    Assert.assertEquals(znRecord.getSimpleField(UserConfig.PASSWORD_KEY), "adminPass123", "Password should match");
+    Assert.assertEquals(znRecord.getSimpleField(UserConfig.COMPONET_KEY), ComponentType.PROXY.toString(),
+        "Component type should match");
+    Assert.assertEquals(znRecord.getSimpleField(UserConfig.ROLE_KEY), RoleType.ADMIN.toString(),
+        "Role type should match");
+    Assert.assertEquals(znRecord.getListField(UserConfig.TABLES_KEY), tableList, "Table list should match");
+    Assert.assertEquals(znRecord.getListField(UserConfig.EXCLUDE_TABLES_KEY), excludeTableList,
+        "Exclude table list should match");
+    Assert.assertNotNull(znRecord.getListField(UserConfig.PERMISSIONS_KEY), "Permissions should not be null");
+    Assert.assertNotNull(znRecord.getSimpleField(UserConfig.RLS_FILTERS_KEY), "RLS filters should not be null");
+  }
+
+  @Test
+  public void testRoundTripConversionWithMandatoryFields() throws JsonProcessingException {
+    UserConfig originalConfig = new UserConfigBuilder()
+        .setUsername(TEST_USERNAME)
+        .setPassword(TEST_PASSWORD)
+        .setComponentType(ComponentType.BROKER)
+        .setRoleType(RoleType.USER)
+        .build();
+
+    ZNRecord znRecord = AccessControlUserConfigUtils.toZNRecord(originalConfig);
+    UserConfig reconstructedConfig = AccessControlUserConfigUtils.fromZNRecord(znRecord);
+
+    Assert.assertEquals(reconstructedConfig.getUserName(), originalConfig.getUserName(),
+        "Username should match after round-trip");
+    Assert.assertEquals(reconstructedConfig.getPassword(), originalConfig.getPassword(),
+        "Password should match after round-trip");
+    Assert.assertEquals(reconstructedConfig.getComponentType(), originalConfig.getComponentType(),
+        "Component type should match after round-trip");
+    Assert.assertEquals(reconstructedConfig.getRoleType(), originalConfig.getRoleType(),
+        "Role type should match after round-trip");
+  }
+
+  @Test
+  public void testRoundTripConversionWithAllFields() throws JsonProcessingException {
+    List<String> tableList = Arrays.asList("table1", "table2");
+    List<String> excludeTableList = Arrays.asList("excludeTable1");
+    List<AccessType> permissionList = Arrays.asList(AccessType.CREATE, AccessType.READ, AccessType.UPDATE,
+        AccessType.DELETE);
+    Map<String, List<String>> rlsFilters = new HashMap<>();
+    rlsFilters.put("table1", Arrays.asList("country='US'", "department='Engineering'"));
+    rlsFilters.put("table2", Arrays.asList("region='WEST'"));
+
+    UserConfig originalConfig = new UserConfigBuilder()
+        .setUsername("fullTestUser")
+        .setPassword("fullTestPassword")
+        .setComponentType(ComponentType.CONTROLLER)
+        .setRoleType(RoleType.ADMIN)
+        .setTableList(tableList)
+        .setExcludeTableList(excludeTableList)
+        .setPermissionList(permissionList)
+        .setRlsFilters(rlsFilters)
+        .build();
+
+    ZNRecord znRecord = AccessControlUserConfigUtils.toZNRecord(originalConfig);
+    UserConfig reconstructedConfig = AccessControlUserConfigUtils.fromZNRecord(znRecord);
+
+    Assert.assertEquals(reconstructedConfig.getUserName(), originalConfig.getUserName(),
+        "Username should match after round-trip");
+    Assert.assertEquals(reconstructedConfig.getPassword(), originalConfig.getPassword(),
+        "Password should match after round-trip");
+    Assert.assertEquals(reconstructedConfig.getComponentType(), originalConfig.getComponentType(),
+        "Component type should match after round-trip");
+    Assert.assertEquals(reconstructedConfig.getRoleType(), originalConfig.getRoleType(),
+        "Role type should match after round-trip");
+    Assert.assertEquals(reconstructedConfig.getTables(), originalConfig.getTables(),
+        "Tables should match after round-trip");
+    Assert.assertEquals(reconstructedConfig.getExcludeTables(), originalConfig.getExcludeTables(),
+        "Exclude tables should match after round-trip");
+    Assert.assertEquals(reconstructedConfig.getPermissios().size(), originalConfig.getPermissios().size(),
+        "Permissions size should match after round-trip");
+    Assert.assertEquals(reconstructedConfig.getRlsFilters().size(), originalConfig.getRlsFilters().size(),
+        "RLS filters size should match after round-trip");
+    Assert.assertEquals(reconstructedConfig.getRlsFilters().get("table1"),
+        originalConfig.getRlsFilters().get("table1"), "RLS filters for table1 should match after round-trip");
+    Assert.assertEquals(reconstructedConfig.getRlsFilters().get("table2"),
+        originalConfig.getRlsFilters().get("table2"), "RLS filters for table2 should match after round-trip");
+    // Verify actual filter values
+    Assert.assertEquals(reconstructedConfig.getRlsFilters().get("table1").get(0), "country='US'");
+    Assert.assertEquals(reconstructedConfig.getRlsFilters().get("table1").get(1), "department='Engineering'");
+    Assert.assertEquals(reconstructedConfig.getRlsFilters().get("table2").get(0), "region='WEST'");
+  }
+
+  @Test
+  public void testDifferentComponentTypes() throws JsonProcessingException {
+    ComponentType[] componentTypes = {
+        ComponentType.CONTROLLER, ComponentType.BROKER, ComponentType.SERVER,
+        ComponentType.MINION, ComponentType.PROXY
+    };
+
+    for (ComponentType componentType : componentTypes) {
+      UserConfig userConfig = new UserConfigBuilder()
+          .setUsername(TEST_USERNAME)
+          .setPassword(TEST_PASSWORD)
+          .setComponentType(componentType)
+          .setRoleType(RoleType.USER)
+          .build();
+
+      ZNRecord znRecord = AccessControlUserConfigUtils.toZNRecord(userConfig);
+      UserConfig reconstructedConfig = AccessControlUserConfigUtils.fromZNRecord(znRecord);
+
+      Assert.assertEquals(reconstructedConfig.getComponentType(), componentType,
+          "Component type should match for " + componentType);
+    }
+  }
+
+  @Test
+  public void testDifferentRoleTypes() throws JsonProcessingException {
+    RoleType[] roleTypes = {RoleType.ADMIN, RoleType.USER};
+
+    for (RoleType roleType : roleTypes) {
+      UserConfig userConfig = new UserConfigBuilder()
+          .setUsername(TEST_USERNAME)
+          .setPassword(TEST_PASSWORD)
+          .setComponentType(ComponentType.BROKER)
+          .setRoleType(roleType)
+          .build();
+
+      ZNRecord znRecord = AccessControlUserConfigUtils.toZNRecord(userConfig);
+      UserConfig reconstructedConfig = AccessControlUserConfigUtils.fromZNRecord(znRecord);
+
+      Assert.assertEquals(reconstructedConfig.getRoleType(), roleType, "Role type should match for " + roleType);
+    }
+  }
+
+  @Test
+  public void testAllAccessTypes() throws JsonProcessingException {
+    List<AccessType> allPermissions = Arrays.asList(
+        AccessType.CREATE, AccessType.READ, AccessType.UPDATE, AccessType.DELETE
+    );
+
+    UserConfig userConfig = new UserConfigBuilder()
+        .setUsername(TEST_USERNAME)
+        .setPassword(TEST_PASSWORD)
+        .setComponentType(ComponentType.BROKER)
+        .setRoleType(RoleType.ADMIN)
+        .setPermissionList(allPermissions)
+        .build();
+
+    ZNRecord znRecord = AccessControlUserConfigUtils.toZNRecord(userConfig);
+    UserConfig reconstructedConfig = AccessControlUserConfigUtils.fromZNRecord(znRecord);
+
+    Assert.assertEquals(reconstructedConfig.getPermissios().size(), 4, "Should have all 4 access types");
+    Assert.assertTrue(reconstructedConfig.getPermissios().contains(AccessType.CREATE), "Should contain CREATE");
+    Assert.assertTrue(reconstructedConfig.getPermissios().contains(AccessType.READ), "Should contain READ");
+    Assert.assertTrue(reconstructedConfig.getPermissios().contains(AccessType.UPDATE), "Should contain UPDATE");
+    Assert.assertTrue(reconstructedConfig.getPermissios().contains(AccessType.DELETE), "Should contain DELETE");
+  }
+
+  @Test
+  public void testEmptyRlsFiltersMap() throws JsonProcessingException {
+    // Empty map should not be serialized
+    Map<String, List<String>> emptyRlsFilters = new HashMap<>();
+
+    UserConfig userConfig = new UserConfigBuilder()
+        .setUsername(TEST_USERNAME)
+        .setPassword(TEST_PASSWORD)
+        .setComponentType(ComponentType.BROKER)
+        .setRoleType(RoleType.USER)
+        .setRlsFilters(emptyRlsFilters)
+        .build();
+
+    ZNRecord znRecord = AccessControlUserConfigUtils.toZNRecord(userConfig);
+
+    // Empty map should not be stored in ZNRecord
+    Assert.assertNull(znRecord.getSimpleField(UserConfig.RLS_FILTERS_KEY),
+        "Empty RLS filters map should not be stored");
+  }
+
+  @Test
+  public void testZNRecordStructure() throws JsonProcessingException {
+    List<String> tableList = Arrays.asList("table1", "table2");
+    List<AccessType> permissionList = Arrays.asList(AccessType.READ, AccessType.UPDATE);
+    Map<String, List<String>> rlsFilters = new HashMap<>();
+    rlsFilters.put("table1", Arrays.asList("filter1"));
+
+    UserConfig userConfig = new UserConfigBuilder()
+        .setUsername(TEST_USERNAME)
+        .setPassword(TEST_PASSWORD)
+        .setComponentType(ComponentType.BROKER)
+        .setRoleType(RoleType.USER)
+        .setTableList(tableList)
+        .setPermissionList(permissionList)
+        .setRlsFilters(rlsFilters)
+        .build();
+
+    ZNRecord znRecord = AccessControlUserConfigUtils.toZNRecord(userConfig);
+
+    // Verify structure: simpleFields should contain username, password, component, role, and RLS filters (as JSON)
+    Map<String, String> simpleFields = znRecord.getSimpleFields();
+    Assert.assertTrue(simpleFields.containsKey(UserConfig.USERNAME_KEY), "Simple fields should contain username");
+    Assert.assertTrue(simpleFields.containsKey(UserConfig.PASSWORD_KEY), "Simple fields should contain password");
+    Assert.assertTrue(simpleFields.containsKey(UserConfig.COMPONET_KEY), "Simple fields should contain component");
+    Assert.assertTrue(simpleFields.containsKey(UserConfig.ROLE_KEY), "Simple fields should contain role");
+    Assert.assertTrue(simpleFields.containsKey(UserConfig.RLS_FILTERS_KEY),
+        "Simple fields should contain RLS filters as JSON");
+
+    // Verify structure: listFields should contain tables and permissions
+    Map<String, List<String>> listFields = znRecord.getListFields();
+    Assert.assertTrue(listFields.containsKey(UserConfig.TABLES_KEY), "List fields should contain tables");
+    Assert.assertTrue(listFields.containsKey(UserConfig.PERMISSIONS_KEY), "List fields should contain permissions");
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotAccessControlUserRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotAccessControlUserRestletResource.java
@@ -82,6 +82,9 @@ public class PinotAccessControlUserRestletResource {
    *         "role" : "ADMIN",
    *         "tables": ["table1", "table2"],
    *         "permissions": ["READ"]
+   *         "rlsFilters": {
+   *           "table1": ["column1='value1'"],
+   *           "table2": ["column2='value2' AND column3='value3'"]
    *        }
    *  </pre>
    *

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotAccessControlUserRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotAccessControlUserRestletResourceTest.java
@@ -20,8 +20,13 @@ package org.apache.pinot.controller.api;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.apache.pinot.common.utils.BcryptUtils;
 import org.apache.pinot.controller.helix.ControllerTest;
+import org.apache.pinot.spi.config.user.AccessType;
 import org.apache.pinot.spi.config.user.ComponentType;
 import org.apache.pinot.spi.config.user.RoleType;
 import org.apache.pinot.spi.config.user.UserConfig;
@@ -32,6 +37,8 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.fail;
 
@@ -133,5 +140,491 @@ public class PinotAccessControlUserRestletResourceTest {
     deleteResponse = ControllerTest.sendDeleteRequest(
         StringUtil.join("/", TEST_INSTANCE.getControllerBaseApiUrl(), "users", "user1?component=BROKER"));
     assertEquals(deleteResponse, "{\"status\":\"User: user1_BROKER has been successfully deleted\"}");
+  }
+
+  @Test
+  public void testAddUserWithRlsFilters()
+      throws Exception {
+    String username = "rlsUser1";
+    Map<String, List<String>> rlsFilters = new HashMap<>();
+    rlsFilters.put("table1", Arrays.asList("country='US'"));
+    rlsFilters.put("table2", Arrays.asList("department='Engineering'", "level='Senior'"));
+
+    String userConfigString = _userConfigBuilder.setUsername(username)
+        .setComponentType(ComponentType.BROKER)
+        .setRlsFilters(rlsFilters)
+        .build().toJsonString();
+
+    String creationResponse = ControllerTest.sendPostRequest(_createUserUrl, userConfigString);
+    assertEquals(creationResponse, "{\"status\":\"User " + username + "_BROKER has been successfully added!\"}");
+
+    // Verify the user was created with RLS filters
+    UserConfig userConfig = getUserConfig(username, "BROKER");
+    assertNotNull(userConfig.getRlsFilters());
+    assertEquals(userConfig.getRlsFilters().size(), 2);
+    assertTrue(userConfig.getRlsFilters().containsKey("table1"));
+    assertTrue(userConfig.getRlsFilters().containsKey("table2"));
+    assertEquals(userConfig.getRlsFilters().get("table1").size(), 1);
+    assertEquals(userConfig.getRlsFilters().get("table2").size(), 2);
+    // Verify actual filter values
+    assertEquals(userConfig.getRlsFilters().get("table1").get(0), "country='US'");
+    assertEquals(userConfig.getRlsFilters().get("table2").get(0), "department='Engineering'");
+    assertEquals(userConfig.getRlsFilters().get("table2").get(1), "level='Senior'");
+  }
+
+  @Test
+  public void testAddUserWithComplexRlsFilters()
+      throws Exception {
+    String username = "rlsUser2";
+    Map<String, List<String>> rlsFilters = new HashMap<>();
+    rlsFilters.put("salesTable", Arrays.asList("region='APAC', status='active'"));
+    rlsFilters.put("userTable", Arrays.asList("(role='admin' OR role='manager'), active=true"));
+
+    String userConfigString = _userConfigBuilder.setUsername(username)
+        .setComponentType(ComponentType.BROKER)
+        .setRlsFilters(rlsFilters)
+        .build().toJsonString();
+
+    String creationResponse = ControllerTest.sendPostRequest(_createUserUrl, userConfigString);
+    assertEquals(creationResponse, "{\"status\":\"User " + username + "_BROKER has been successfully added!\"}");
+
+    // Verify complex filters are stored correctly
+    UserConfig userConfig = getUserConfig(username, "BROKER");
+    assertNotNull(userConfig.getRlsFilters());
+    assertEquals(userConfig.getRlsFilters().get("salesTable").get(0), "region='APAC', status='active'");
+    assertEquals(userConfig.getRlsFilters().get("userTable").get(0),
+        "(role='admin' OR role='manager'), active=true");
+  }
+
+  @Test
+  public void testUpdateUserWithRlsFilters()
+      throws Exception {
+    String username = "rlsUpdateUser";
+
+    // Create user without RLS filters - reset the builder first
+    String userConfigString = new UserConfigBuilder()
+        .setUsername(username)
+        .setPassword("123456")
+        .setComponentType(ComponentType.BROKER)
+        .setRoleType(RoleType.USER)
+        .build().toJsonString();
+    ControllerTest.sendPostRequest(_createUserUrl, userConfigString);
+
+    // Verify no RLS filters initially
+    UserConfig userConfig = getUserConfig(username, "BROKER");
+    if (userConfig.getRlsFilters() != null) {
+      assertEquals(userConfig.getRlsFilters().size(), 0);
+    }
+
+    // Update user to add RLS filters
+    Map<String, List<String>> rlsFilters = new HashMap<>();
+    rlsFilters.put("orders", Arrays.asList("customer_id='12345'"));
+    rlsFilters.put("products", Arrays.asList("category='electronics'"));
+
+    userConfig.setPassword("newPassword");
+    UserConfigBuilder builder = new UserConfigBuilder()
+        .setUsername(username)
+        .setPassword(userConfig.getPassword())
+        .setComponentType(ComponentType.BROKER)
+        .setRoleType(userConfig.getRoleType())
+        .setRlsFilters(rlsFilters);
+
+    JsonNode jsonResponse = JsonUtils.stringToJsonNode(ControllerTest.sendPutRequest(
+        TEST_INSTANCE.getControllerRequestURLBuilder().forUpdateUserConfig(username, "BROKER", false),
+        builder.build().toString()));
+    assertTrue(jsonResponse.has("status"));
+
+    // Verify RLS filters were added
+    UserConfig modifiedConfig = getUserConfig(username, "BROKER");
+    assertNotNull(modifiedConfig.getRlsFilters());
+    assertEquals(modifiedConfig.getRlsFilters().size(), 2);
+    assertTrue(modifiedConfig.getRlsFilters().containsKey("orders"));
+    assertTrue(modifiedConfig.getRlsFilters().containsKey("products"));
+    // Verify actual filter values
+    assertEquals(modifiedConfig.getRlsFilters().get("orders").get(0), "customer_id='12345'");
+    assertEquals(modifiedConfig.getRlsFilters().get("products").get(0), "category='electronics'");
+  }
+
+  @Test
+  public void testGetUserWithRlsFilters()
+      throws Exception {
+    String username = "rlsGetUser";
+    Map<String, List<String>> rlsFilters = new HashMap<>();
+    rlsFilters.put("transactions", Arrays.asList("amount > 1000", "status='completed'"));
+
+    String userConfigString = _userConfigBuilder.setUsername(username)
+        .setComponentType(ComponentType.CONTROLLER)
+        .setRlsFilters(rlsFilters)
+        .build().toJsonString();
+
+    ControllerTest.sendPostRequest(_createUserUrl, userConfigString);
+
+    // Get user and verify RLS filters are returned
+    String userConfigResponse = ControllerTest.sendGetRequest(
+        TEST_INSTANCE.getControllerRequestURLBuilder().forUserGet(username, "CONTROLLER"));
+
+    JsonNode responseNode = JsonUtils.stringToJsonNode(userConfigResponse);
+    JsonNode userNode = responseNode.get(username + "_CONTROLLER");
+
+    assertNotNull(userNode);
+    assertTrue(userNode.has("rlsFilters"));
+    JsonNode rlsFiltersNode = userNode.get("rlsFilters");
+    assertTrue(rlsFiltersNode.has("transactions"));
+    assertEquals(rlsFiltersNode.get("transactions").size(), 2);
+    // Verify actual filter values
+    assertEquals(rlsFiltersNode.get("transactions").get(0).asText(), "amount > 1000");
+    assertEquals(rlsFiltersNode.get("transactions").get(1).asText(), "status='completed'");
+  }
+
+  @Test
+  public void testListAllUsers()
+      throws Exception {
+    // Create multiple users with different configurations
+    String user1 = "listUser1";
+    String user2 = "listUser2";
+
+    String userConfig1 = _userConfigBuilder.setUsername(user1)
+        .setComponentType(ComponentType.BROKER)
+        .build().toJsonString();
+    ControllerTest.sendPostRequest(_createUserUrl, userConfig1);
+
+    String userConfig2 = _userConfigBuilder.setUsername(user2)
+        .setComponentType(ComponentType.CONTROLLER)
+        .build().toJsonString();
+    ControllerTest.sendPostRequest(_createUserUrl, userConfig2);
+
+    // List all users
+    String listResponse = ControllerTest.sendGetRequest(
+        StringUtil.join("/", TEST_INSTANCE.getControllerBaseApiUrl(), "users"));
+
+    JsonNode responseNode = JsonUtils.stringToJsonNode(listResponse);
+    assertTrue(responseNode.has("users"));
+    JsonNode usersNode = responseNode.get("users");
+
+    // Verify our created users are in the list
+    assertTrue(usersNode.has(user1 + "_BROKER"));
+    assertTrue(usersNode.has(user2 + "_CONTROLLER"));
+  }
+
+  @Test
+  public void testListUsersWithRlsFilters()
+      throws Exception {
+    String username = "rlsListUser";
+    Map<String, List<String>> rlsFilters = new HashMap<>();
+    rlsFilters.put("inventory", Arrays.asList("warehouse='west'"));
+
+    String userConfigString = _userConfigBuilder.setUsername(username)
+        .setComponentType(ComponentType.BROKER)
+        .setRlsFilters(rlsFilters)
+        .build().toJsonString();
+
+    ControllerTest.sendPostRequest(_createUserUrl, userConfigString);
+
+    // List all users and verify RLS filters are included
+    String listResponse = ControllerTest.sendGetRequest(
+        StringUtil.join("/", TEST_INSTANCE.getControllerBaseApiUrl(), "users"));
+
+    JsonNode responseNode = JsonUtils.stringToJsonNode(listResponse);
+    JsonNode usersNode = responseNode.get("users");
+    JsonNode userNode = usersNode.get(username + "_BROKER");
+
+    assertNotNull(userNode);
+    assertTrue(userNode.has("rlsFilters"));
+    JsonNode rlsFiltersNode = userNode.get("rlsFilters");
+    assertTrue(rlsFiltersNode.has("inventory"));
+    // Verify actual filter value
+    assertEquals(rlsFiltersNode.get("inventory").get(0).asText(), "warehouse='west'");
+  }
+
+  @Test
+  public void testAddUserWithTablesAndPermissions()
+      throws Exception {
+    String username = "tablesPermUser";
+    List<String> tables = Arrays.asList("table1", "table2", "table3");
+    List<String> excludeTables = Arrays.asList("sensitiveTable");
+    List<AccessType> permissions = Arrays.asList(AccessType.READ, AccessType.UPDATE);
+
+    UserConfigBuilder builder = new UserConfigBuilder()
+        .setUsername(username)
+        .setPassword("password123")
+        .setComponentType(ComponentType.BROKER)
+        .setRoleType(RoleType.USER)
+        .setTableList(tables)
+        .setExcludeTableList(excludeTables)
+        .setPermissionList(permissions);
+
+    String userConfigString = builder.build().toJsonString();
+    ControllerTest.sendPostRequest(_createUserUrl, userConfigString);
+
+    // Verify user was created with tables and permissions
+    UserConfig userConfig = getUserConfig(username, "BROKER");
+    assertNotNull(userConfig.getTables());
+    assertEquals(userConfig.getTables().size(), 3);
+    assertNotNull(userConfig.getExcludeTables());
+    assertEquals(userConfig.getExcludeTables().size(), 1);
+    assertNotNull(userConfig.getPermissios());
+    assertEquals(userConfig.getPermissios().size(), 2);
+    assertTrue(userConfig.getPermissios().contains(AccessType.READ));
+    assertTrue(userConfig.getPermissios().contains(AccessType.UPDATE));
+  }
+
+  @Test
+  public void testUpdateUserWithTablesAndPermissions()
+      throws Exception {
+    String username = "updateTablesUser";
+
+    // Create user with initial configuration
+    String userConfigString = _userConfigBuilder.setUsername(username)
+        .setComponentType(ComponentType.BROKER)
+        .build().toJsonString();
+    ControllerTest.sendPostRequest(_createUserUrl, userConfigString);
+
+    // Update user with tables and permissions
+    List<String> tables = Arrays.asList("newTable1", "newTable2");
+    List<AccessType> permissions = Arrays.asList(AccessType.READ, AccessType.CREATE, AccessType.DELETE);
+
+    UserConfig userConfig = getUserConfig(username, "BROKER");
+    UserConfigBuilder builder = new UserConfigBuilder()
+        .setUsername(username)
+        .setPassword(userConfig.getPassword())
+        .setComponentType(ComponentType.BROKER)
+        .setRoleType(userConfig.getRoleType())
+        .setTableList(tables)
+        .setPermissionList(permissions);
+
+    JsonNode jsonResponse = JsonUtils.stringToJsonNode(ControllerTest.sendPutRequest(
+        TEST_INSTANCE.getControllerRequestURLBuilder().forUpdateUserConfig(username, "BROKER", false),
+        builder.build().toString()));
+    assertTrue(jsonResponse.has("status"));
+
+    // Verify updates
+    UserConfig modifiedConfig = getUserConfig(username, "BROKER");
+    assertNotNull(modifiedConfig.getTables());
+    assertEquals(modifiedConfig.getTables().size(), 2);
+    assertNotNull(modifiedConfig.getPermissios());
+    assertEquals(modifiedConfig.getPermissios().size(), 3);
+  }
+
+  @Test
+  public void testAddUserWithDifferentComponentTypes()
+      throws Exception {
+    ComponentType[] componentTypes = {
+        ComponentType.CONTROLLER, ComponentType.BROKER, ComponentType.SERVER
+    };
+
+    for (ComponentType componentType : componentTypes) {
+      String username = "user_" + componentType.name().toLowerCase();
+      String userConfigString = _userConfigBuilder.setUsername(username)
+          .setComponentType(componentType)
+          .build().toJsonString();
+
+      String creationResponse = ControllerTest.sendPostRequest(_createUserUrl, userConfigString);
+      assertEquals(creationResponse,
+          "{\"status\":\"User " + username + "_" + componentType.name() + " has been successfully added!\"}");
+
+      // Verify user was created with correct component type
+      UserConfig userConfig = getUserConfig(username, componentType.name());
+      assertEquals(userConfig.getComponentType(), componentType);
+    }
+  }
+
+  @Test
+  public void testAddUserWithDifferentRoleTypes()
+      throws Exception {
+    // Test ADMIN role
+    String adminUser = "adminRoleUser";
+    String adminConfigString = _userConfigBuilder.setUsername(adminUser)
+        .setComponentType(ComponentType.BROKER)
+        .setRoleType(RoleType.ADMIN)
+        .build().toJsonString();
+    ControllerTest.sendPostRequest(_createUserUrl, adminConfigString);
+
+    UserConfig adminConfig = getUserConfig(adminUser, "BROKER");
+    assertEquals(adminConfig.getRoleType(), RoleType.ADMIN);
+
+    // Test USER role
+    String regularUser = "regularRoleUser";
+    String userConfigString = _userConfigBuilder.setUsername(regularUser)
+        .setComponentType(ComponentType.BROKER)
+        .setRoleType(RoleType.USER)
+        .build().toJsonString();
+    ControllerTest.sendPostRequest(_createUserUrl, userConfigString);
+
+    UserConfig regularConfig = getUserConfig(regularUser, "BROKER");
+    assertEquals(regularConfig.getRoleType(), RoleType.USER);
+  }
+
+  @Test
+  public void testGetNonExistentUser()
+      throws Exception {
+    String nonExistentUser = "nonExistentUser_" + System.currentTimeMillis();
+    String response = ControllerTest.sendGetRequest(
+        TEST_INSTANCE.getControllerRequestURLBuilder().forUserGet(nonExistentUser, "BROKER"));
+
+    // Verify response indicates user doesn't exist
+    JsonNode responseNode = JsonUtils.stringToJsonNode(response);
+    JsonNode userNode = responseNode.get(nonExistentUser + "_BROKER");
+    assertTrue(userNode == null || userNode.isNull());
+  }
+
+  @Test
+  public void testDeleteNonExistentUser()
+      throws Exception {
+    String nonExistentUser = "nonExistentDeleteUser";
+    try {
+      ControllerTest.sendDeleteRequest(
+          StringUtil.join("/", TEST_INSTANCE.getControllerBaseApiUrl(), "users",
+              nonExistentUser + "?component=BROKER"));
+      fail("Deleting a non-existent user should fail");
+    } catch (IOException e) {
+      // Expected exception
+      assertTrue(e.getMessage().contains("does not exist") || e.getMessage().contains("not found")
+          || e.getMessage().contains("404"));
+    }
+  }
+
+  @Test
+  public void testUpdateUserPasswordWithBcrypt()
+      throws Exception {
+    String username = "bcryptUser";
+    String initialPassword = "initialPass123";
+
+    // Create user
+    String userConfigString = _userConfigBuilder.setUsername(username)
+        .setPassword(initialPassword)
+        .setComponentType(ComponentType.BROKER)
+        .build().toJsonString();
+    ControllerTest.sendPostRequest(_createUserUrl, userConfigString);
+
+    // Update password with passwordChanged=true
+    String newPassword = "newSecurePass456";
+    UserConfig userConfig = getUserConfig(username, "BROKER");
+    userConfig.setPassword(newPassword);
+
+    JsonNode jsonResponse = JsonUtils.stringToJsonNode(ControllerTest.sendPutRequest(
+        TEST_INSTANCE.getControllerRequestURLBuilder().forUpdateUserConfig(username, "BROKER", true),
+        userConfig.toString()));
+    assertTrue(jsonResponse.has("status"));
+
+    // Verify password was encrypted
+    UserConfig modifiedConfig = getUserConfig(username, "BROKER");
+    assertFalse(modifiedConfig.getPassword().equals(newPassword)); // Should be encrypted
+    assertTrue(BcryptUtils.checkpw(newPassword, modifiedConfig.getPassword())); // Should match when checked
+  }
+
+  @Test
+  public void testAddUserWithAllFieldsIncludingRls()
+      throws Exception {
+    String username = "completeUser";
+    List<String> tables = Arrays.asList("orders", "customers");
+    List<String> excludeTables = Arrays.asList("internal_logs");
+    List<AccessType> permissions = Arrays.asList(AccessType.READ, AccessType.UPDATE);
+    Map<String, List<String>> rlsFilters = new HashMap<>();
+    rlsFilters.put("orders", Arrays.asList("customer_id='123'", "status='active'"));
+    rlsFilters.put("customers", Arrays.asList("region='US'"));
+
+    UserConfigBuilder builder = new UserConfigBuilder()
+        .setUsername(username)
+        .setPassword("completePass")
+        .setComponentType(ComponentType.BROKER)
+        .setRoleType(RoleType.ADMIN)
+        .setTableList(tables)
+        .setExcludeTableList(excludeTables)
+        .setPermissionList(permissions)
+        .setRlsFilters(rlsFilters);
+
+    String userConfigString = builder.build().toJsonString();
+    String creationResponse = ControllerTest.sendPostRequest(_createUserUrl, userConfigString);
+    assertEquals(creationResponse, "{\"status\":\"User " + username + "_BROKER has been successfully added!\"}");
+
+    // Verify all fields
+    UserConfig userConfig = getUserConfig(username, "BROKER");
+    assertEquals(userConfig.getUserName(), username);
+    assertEquals(userConfig.getRoleType(), RoleType.ADMIN);
+    assertEquals(userConfig.getComponentType(), ComponentType.BROKER);
+    assertNotNull(userConfig.getTables());
+    assertEquals(userConfig.getTables().size(), 2);
+    assertNotNull(userConfig.getExcludeTables());
+    assertEquals(userConfig.getExcludeTables().size(), 1);
+    assertNotNull(userConfig.getPermissios());
+    assertEquals(userConfig.getPermissios().size(), 2);
+    assertNotNull(userConfig.getRlsFilters());
+    assertEquals(userConfig.getRlsFilters().size(), 2);
+    assertEquals(userConfig.getRlsFilters().get("orders").size(), 2);
+    assertEquals(userConfig.getRlsFilters().get("customers").size(), 1);
+    // Verify actual filter values
+    assertEquals(userConfig.getRlsFilters().get("orders").get(0), "customer_id='123'");
+    assertEquals(userConfig.getRlsFilters().get("orders").get(1), "status='active'");
+    assertEquals(userConfig.getRlsFilters().get("customers").get(0), "region='US'");
+  }
+
+  @Test
+  public void testUpdateUserModifyingRlsFilters()
+      throws Exception {
+    String username = "modifyRlsUser";
+
+    // Create user with initial RLS filters
+    Map<String, List<String>> initialRlsFilters = new HashMap<>();
+    initialRlsFilters.put("table1", Arrays.asList("filter1"));
+
+    String userConfigString = _userConfigBuilder.setUsername(username)
+        .setComponentType(ComponentType.BROKER)
+        .setRlsFilters(initialRlsFilters)
+        .build().toJsonString();
+    ControllerTest.sendPostRequest(_createUserUrl, userConfigString);
+
+    // Update with modified RLS filters
+    Map<String, List<String>> modifiedRlsFilters = new HashMap<>();
+    modifiedRlsFilters.put("table1", Arrays.asList("filter1_updated", "filter2"));
+    modifiedRlsFilters.put("table2", Arrays.asList("newFilter"));
+
+    UserConfig userConfig = getUserConfig(username, "BROKER");
+    UserConfigBuilder builder = new UserConfigBuilder()
+        .setUsername(username)
+        .setPassword(userConfig.getPassword())
+        .setComponentType(ComponentType.BROKER)
+        .setRoleType(userConfig.getRoleType())
+        .setRlsFilters(modifiedRlsFilters);
+
+    JsonNode jsonResponse = JsonUtils.stringToJsonNode(ControllerTest.sendPutRequest(
+        TEST_INSTANCE.getControllerRequestURLBuilder().forUpdateUserConfig(username, "BROKER", false),
+        builder.build().toString()));
+    assertTrue(jsonResponse.has("status"));
+
+    // Verify RLS filters were modified
+    UserConfig modifiedConfig = getUserConfig(username, "BROKER");
+    assertNotNull(modifiedConfig.getRlsFilters());
+    assertEquals(modifiedConfig.getRlsFilters().size(), 2);
+    assertEquals(modifiedConfig.getRlsFilters().get("table1").size(), 2);
+    assertTrue(modifiedConfig.getRlsFilters().containsKey("table2"));
+    // Verify actual filter values
+    assertEquals(modifiedConfig.getRlsFilters().get("table1").get(0), "filter1_updated");
+    assertEquals(modifiedConfig.getRlsFilters().get("table1").get(1), "filter2");
+    assertEquals(modifiedConfig.getRlsFilters().get("table2").get(0), "newFilter");
+  }
+
+  @Test
+  public void testGetUserByUsernameAndComponent()
+      throws Exception {
+    String username = "getUserTest";
+
+    // Create users with same username but different components
+    String brokerConfigString = _userConfigBuilder.setUsername(username)
+        .setComponentType(ComponentType.BROKER)
+        .build().toJsonString();
+    ControllerTest.sendPostRequest(_createUserUrl, brokerConfigString);
+
+    String controllerConfigString = _userConfigBuilder.setUsername(username)
+        .setComponentType(ComponentType.CONTROLLER)
+        .build().toJsonString();
+    ControllerTest.sendPostRequest(_createUserUrl, controllerConfigString);
+
+    // Get BROKER user
+    UserConfig brokerConfig = getUserConfig(username, "BROKER");
+    assertEquals(brokerConfig.getComponentType(), ComponentType.BROKER);
+
+    // Get CONTROLLER user
+    UserConfig controllerConfig = getUserConfig(username, "CONTROLLER");
+    assertEquals(controllerConfig.getComponentType(), ComponentType.CONTROLLER);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/auth/BasicAuthPrincipalUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/auth/BasicAuthPrincipalUtils.java
@@ -125,10 +125,13 @@ public final class BasicAuthPrincipalUtils {
               .orElseGet(() -> Collections.emptyList())
               .stream().map(x -> x.toString())
               .collect(Collectors.toSet());
-          //todo: Handle RLS filters properly
+          // Extract RLS filters from UserConfig
+          Map<String, List<String>> rlsFilters = Optional.ofNullable(user.getRlsFilters())
+              .orElseGet(() -> Collections.emptyMap());
+
           return new ZkBasicAuthPrincipal(name,
               BasicAuthTokenUtils.toBasicAuthToken(name, password), password, component, role,
-              tables, excludeTables, permissions, Map.of());
+              tables, excludeTables, permissions, rlsFilters);
         }).collect(Collectors.toList());
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/auth/BasicAuthTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/auth/BasicAuthTest.java
@@ -19,13 +19,20 @@
 package org.apache.pinot.core.auth;
 
 import com.google.common.collect.ImmutableSet;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import org.apache.pinot.spi.config.user.AccessType;
+import org.apache.pinot.spi.config.user.ComponentType;
+import org.apache.pinot.spi.config.user.RoleType;
+import org.apache.pinot.spi.config.user.UserConfig;
 import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.utils.builder.UserConfigBuilder;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -166,5 +173,219 @@ public class BasicAuthTest {
     config.put("principals.user.password", "secret");
     PinotConfiguration configuration = new PinotConfiguration(config);
     BasicAuthPrincipalUtils.extractBasicAuthPrincipals(configuration, "principals");
+  }
+
+  @Test
+  public void testExtractBasicAuthPrincipalsFromUserConfig() {
+    // Test with multiple UserConfig objects with various configurations
+    List<UserConfig> userConfigList = new ArrayList<>();
+
+    // User 1: Admin with minimal configuration
+    UserConfig adminUser = new UserConfigBuilder()
+        .setUsername("admin")
+        .setPassword("adminpass")
+        .setComponentType(ComponentType.BROKER)
+        .setRoleType(RoleType.ADMIN)
+        .build();
+    userConfigList.add(adminUser);
+
+    // User 2: Regular user with tables, excludeTables, and permissions
+    UserConfig regularUser = new UserConfigBuilder()
+        .setUsername("regularUser")
+        .setPassword("userpass")
+        .setComponentType(ComponentType.CONTROLLER)
+        .setRoleType(RoleType.USER)
+        .setTableList(Arrays.asList("table1", "table2", "table3"))
+        .setExcludeTableList(Arrays.asList("excludedTable1"))
+        .setPermissionList(Arrays.asList(AccessType.READ, AccessType.UPDATE))
+        .build();
+    userConfigList.add(regularUser);
+
+    // User 3: User with RLS filters
+    Map<String, List<String>> rlsFilters = new HashMap<>();
+    rlsFilters.put("table1", Arrays.asList("cityID > 100", "status = 'active'"));
+    rlsFilters.put("table2", Arrays.asList("region = 'US'"));
+
+    UserConfig userWithRls = new UserConfigBuilder()
+        .setUsername("rlsUser")
+        .setPassword("rlspass")
+        .setComponentType(ComponentType.SERVER)
+        .setRoleType(RoleType.USER)
+        .setTableList(Arrays.asList("table1", "table2"))
+        .setPermissionList(Arrays.asList(AccessType.READ))
+        .setRlsFilters(rlsFilters)
+        .build();
+    userConfigList.add(userWithRls);
+
+    // User 4: User with all fields populated
+    Map<String, List<String>> fullRlsFilters = new HashMap<>();
+    fullRlsFilters.put("fullTable", Arrays.asList("department = 'Engineering'"));
+
+    UserConfig fullUser = new UserConfigBuilder()
+        .setUsername("fullUser")
+        .setPassword("fullpass")
+        .setComponentType(ComponentType.MINION)
+        .setRoleType(RoleType.ADMIN)
+        .setTableList(Arrays.asList("fullTable", "anotherTable"))
+        .setExcludeTableList(Arrays.asList("excludedTable2", "excludedTable3"))
+        .setPermissionList(Arrays.asList(AccessType.CREATE, AccessType.READ, AccessType.UPDATE, AccessType.DELETE))
+        .setRlsFilters(fullRlsFilters)
+        .build();
+    userConfigList.add(fullUser);
+
+    // Extract principals
+    List<ZkBasicAuthPrincipal> principals = BasicAuthPrincipalUtils.extractBasicAuthPrincipals(userConfigList);
+
+    // Verify the size
+    Assert.assertEquals(principals.size(), 4, "Should have 4 principals");
+
+    // Verify admin user
+    ZkBasicAuthPrincipal adminPrincipal = principals.stream()
+        .filter(p -> p.getName().equals("admin"))
+        .findFirst()
+        .orElse(null);
+    Assert.assertNotNull(adminPrincipal, "Admin principal should exist");
+    Assert.assertEquals(adminPrincipal.getName(), "admin");
+    Assert.assertEquals(adminPrincipal.getPassword(), "adminpass");
+    Assert.assertEquals(adminPrincipal.getComponent(), "BROKER");
+    Assert.assertEquals(adminPrincipal.getRole(), "ADMIN");
+    Assert.assertTrue(adminPrincipal.hasPermission(RoleType.ADMIN, ComponentType.BROKER));
+
+    // Verify regular user
+    ZkBasicAuthPrincipal regularPrincipal = principals.stream()
+        .filter(p -> p.getName().equals("regularUser"))
+        .findFirst()
+        .orElse(null);
+    Assert.assertNotNull(regularPrincipal, "Regular user principal should exist");
+    Assert.assertEquals(regularPrincipal.getName(), "regularUser");
+    Assert.assertEquals(regularPrincipal.getPassword(), "userpass");
+    Assert.assertEquals(regularPrincipal.getComponent(), "CONTROLLER");
+    Assert.assertEquals(regularPrincipal.getRole(), "USER");
+    Assert.assertTrue(regularPrincipal.hasTable("table1"));
+    Assert.assertTrue(regularPrincipal.hasTable("table2"));
+    Assert.assertTrue(regularPrincipal.hasTable("table3"));
+    Assert.assertFalse(regularPrincipal.hasTable("excludedTable1"));
+    Assert.assertTrue(regularPrincipal.hasPermission("READ"));
+    Assert.assertTrue(regularPrincipal.hasPermission("UPDATE"));
+    Assert.assertFalse(regularPrincipal.hasPermission("DELETE"));
+
+    // Verify user with RLS filters
+    ZkBasicAuthPrincipal rlsPrincipal = principals.stream()
+        .filter(p -> p.getName().equals("rlsUser"))
+        .findFirst()
+        .orElse(null);
+    Assert.assertNotNull(rlsPrincipal, "RLS user principal should exist");
+    Assert.assertEquals(rlsPrincipal.getName(), "rlsUser");
+    Assert.assertEquals(rlsPrincipal.getPassword(), "rlspass");
+    Assert.assertEquals(rlsPrincipal.getComponent(), "SERVER");
+    Assert.assertEquals(rlsPrincipal.getRole(), "USER");
+    Assert.assertTrue(rlsPrincipal.hasTable("table1"));
+    Assert.assertTrue(rlsPrincipal.hasTable("table2"));
+
+    // Verify RLS filters for table1
+    Optional<List<String>> table1Filters = rlsPrincipal.getRLSFilters("table1");
+    Assert.assertTrue(table1Filters.isPresent(), "RLS filters for table1 should exist");
+    Assert.assertEquals(table1Filters.get().size(), 2);
+    Assert.assertTrue(table1Filters.get().contains("cityID > 100"));
+    Assert.assertTrue(table1Filters.get().contains("status = 'active'"));
+
+    // Verify RLS filters for table2
+    Optional<List<String>> table2Filters = rlsPrincipal.getRLSFilters("table2");
+    Assert.assertTrue(table2Filters.isPresent(), "RLS filters for table2 should exist");
+    Assert.assertEquals(table2Filters.get().size(), 1);
+    Assert.assertTrue(table2Filters.get().contains("region = 'US'"));
+
+    // Verify full user with all fields
+    ZkBasicAuthPrincipal fullPrincipal = principals.stream()
+        .filter(p -> p.getName().equals("fullUser"))
+        .findFirst()
+        .orElse(null);
+    Assert.assertNotNull(fullPrincipal, "Full user principal should exist");
+    Assert.assertEquals(fullPrincipal.getName(), "fullUser");
+    Assert.assertEquals(fullPrincipal.getPassword(), "fullpass");
+    Assert.assertEquals(fullPrincipal.getComponent(), "MINION");
+    Assert.assertEquals(fullPrincipal.getRole(), "ADMIN");
+    Assert.assertTrue(fullPrincipal.hasTable("fullTable"));
+    Assert.assertTrue(fullPrincipal.hasTable("anotherTable"));
+    Assert.assertFalse(fullPrincipal.hasTable("excludedTable2"));
+    Assert.assertFalse(fullPrincipal.hasTable("excludedTable3"));
+    Assert.assertTrue(fullPrincipal.hasPermission("CREATE"));
+    Assert.assertTrue(fullPrincipal.hasPermission("READ"));
+    Assert.assertTrue(fullPrincipal.hasPermission("UPDATE"));
+    Assert.assertTrue(fullPrincipal.hasPermission("DELETE"));
+
+    // Verify RLS filters for fullTable
+    Optional<List<String>> fullTableFilters = fullPrincipal.getRLSFilters("fullTable");
+    Assert.assertTrue(fullTableFilters.isPresent(), "RLS filters for fullTable should exist");
+    Assert.assertEquals(fullTableFilters.get().size(), 1);
+    Assert.assertTrue(fullTableFilters.get().contains("department = 'Engineering'"));
+
+    // Verify no RLS filters for anotherTable
+    Optional<List<String>> anotherTableFilters = fullPrincipal.getRLSFilters("anotherTable");
+    Assert.assertFalse(anotherTableFilters.isPresent(), "RLS filters for anotherTable should not exist");
+  }
+
+  @Test
+  public void testExtractBasicAuthPrincipalsFromUserConfigEmptyList() {
+    // Test with empty list
+    List<UserConfig> emptyList = new ArrayList<>();
+    List<ZkBasicAuthPrincipal> principals = BasicAuthPrincipalUtils.extractBasicAuthPrincipals(emptyList);
+    Assert.assertNotNull(principals, "Principals list should not be null");
+    Assert.assertEquals(principals.size(), 0, "Principals list should be empty");
+  }
+
+  @Test
+  public void testExtractBasicAuthPrincipalsFromUserConfigNullOptionalFields() {
+    // Test with user having null optional fields
+    List<UserConfig> userConfigList = new ArrayList<>();
+
+    UserConfig userWithNulls = new UserConfigBuilder()
+        .setUsername("userWithNulls")
+        .setPassword("password")
+        .setComponentType(ComponentType.PROXY)
+        .setRoleType(RoleType.USER)
+        .build();
+    userConfigList.add(userWithNulls);
+
+    List<ZkBasicAuthPrincipal> principals = BasicAuthPrincipalUtils.extractBasicAuthPrincipals(userConfigList);
+
+    Assert.assertEquals(principals.size(), 1);
+    ZkBasicAuthPrincipal principal = principals.get(0);
+    Assert.assertEquals(principal.getName(), "userWithNulls");
+    Assert.assertEquals(principal.getPassword(), "password");
+    Assert.assertEquals(principal.getComponent(), "PROXY");
+    Assert.assertEquals(principal.getRole(), "USER");
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = ".* is not a valid "
+      + "username")
+  public void testExtractBasicAuthPrincipalsFromUserConfigBlankUsername() {
+    // Test with blank username
+    List<UserConfig> userConfigList = new ArrayList<>();
+    UserConfig userWithBlankName = new UserConfigBuilder()
+        .setUsername("  ")
+        .setPassword("password")
+        .setComponentType(ComponentType.BROKER)
+        .setRoleType(RoleType.USER)
+        .build();
+    userConfigList.add(userWithBlankName);
+
+    BasicAuthPrincipalUtils.extractBasicAuthPrincipals(userConfigList);
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class, expectedExceptionsMessageRegExp = "must provide a "
+      + "password for.*")
+  public void testExtractBasicAuthPrincipalsFromUserConfigBlankPassword() {
+    // Test with blank password
+    List<UserConfig> userConfigList = new ArrayList<>();
+    UserConfig userWithBlankPassword = new UserConfigBuilder()
+        .setUsername("user")
+        .setPassword("  ")
+        .setComponentType(ComponentType.BROKER)
+        .setRoleType(RoleType.USER)
+        .build();
+    userConfigList.add(userWithBlankPassword);
+
+    BasicAuthPrincipalUtils.extractBasicAuthPrincipals(userConfigList);
   }
 }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/RowLevelSecurityBasicAuthIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/RowLevelSecurityBasicAuthIntegrationTest.java
@@ -1,0 +1,76 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.integration.tests;
+
+import java.util.Map;
+import org.apache.pinot.spi.env.PinotConfiguration;
+
+
+/**
+ * Row Level Security integration test using BasicAuth (file-based configuration).
+ * Users and permissions are configured via properties in controller and broker configuration.
+ */
+public class RowLevelSecurityBasicAuthIntegrationTest extends RowLevelSecurityIntegrationTestBase {
+
+  @Override
+  protected void overrideControllerConf(Map<String, Object> properties) {
+    properties.put("controller.segment.fetcher.auth.token", AUTH_TOKEN);
+    properties.put("controller.admin.access.control.factory.class",
+        "org.apache.pinot.controller.api.access.BasicAuthAccessControlFactory");
+    properties.put("controller.admin.access.control.principals", "admin, user, user2");
+    properties.put("controller.admin.access.control.principals.admin.password", "verysecret");
+    properties.put("controller.admin.access.control.principals.user.password", "secret");
+    properties.put("controller.admin.access.control.principals.user2.password", "notSoSecret");
+    properties.put("controller.admin.access.control.principals.user.tables", "mytable, mytable2, mytable3");
+    properties.put("controller.admin.access.control.principals.user.permissions", "read");
+    properties.put("controller.admin.access.control.principals.user2.tables", "mytable, mytable2, mytable3");
+    properties.put("controller.admin.access.control.principals.user2.permissions", "read");
+  }
+
+  @Override
+  protected void overrideBrokerConf(PinotConfiguration brokerConf) {
+    brokerConf.setProperty("pinot.broker.enable.row.column.level.auth", "true");
+    brokerConf.setProperty("pinot.broker.access.control.class",
+        "org.apache.pinot.broker.broker.BasicAuthAccessControlFactory");
+    brokerConf.setProperty("pinot.broker.access.control.principals", "admin, user, user2");
+    brokerConf.setProperty("pinot.broker.access.control.principals.admin.password", "verysecret");
+    brokerConf.setProperty("pinot.broker.access.control.principals.user.password", "secret");
+    brokerConf.setProperty("pinot.broker.access.control.principals.user2.password", "notSoSecret");
+    brokerConf.setProperty("pinot.broker.access.control.principals.user.tables", "mytable, mytable2, mytable3");
+    brokerConf.setProperty("pinot.broker.access.control.principals.user.permissions", "read");
+    brokerConf.setProperty("pinot.broker.access.control.principals.user.mytable.rls", "AirlineID='19805'");
+    brokerConf.setProperty("pinot.broker.access.control.principals.user.mytable3.rls",
+        "AirlineID='20409' OR AirTime>'300', DestStateName='Florida'");
+    brokerConf.setProperty("pinot.broker.access.control.principals.user2.tables", "mytable, mytable2, mytable3");
+    brokerConf.setProperty("pinot.broker.access.control.principals.user2.permissions", "read");
+    brokerConf.setProperty("pinot.broker.access.control.principals.user2.mytable.rls",
+        "AirlineID='19805', DestStateName='California'");
+    brokerConf.setProperty("pinot.broker.access.control.principals.user2.mytable2.rls",
+        "AirlineID='20409', DestStateName='Florida'");
+    brokerConf.setProperty("pinot.broker.access.control.principals.user2.mytable3.rls",
+        "AirlineID='20409' OR DestStateName='California', DestStateName='Florida'");
+  }
+
+  @Override
+  protected void overrideServerConf(PinotConfiguration serverConf) {
+    serverConf.setProperty("pinot.server.segment.fetcher.auth.token", AUTH_TOKEN);
+    serverConf.setProperty("pinot.server.segment.uploader.auth.token", AUTH_TOKEN);
+    serverConf.setProperty("pinot.server.instance.auth.token", AUTH_TOKEN);
+  }
+}

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/RowLevelSecurityIntegrationTestBase.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/RowLevelSecurityIntegrationTestBase.java
@@ -30,7 +30,6 @@ import org.apache.pinot.client.JsonAsyncHttpPinotClientTransportFactory;
 import org.apache.pinot.controller.helix.ControllerRequestClient;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
-import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.util.TestUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -38,77 +37,31 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import static org.apache.pinot.integration.tests.BasicAuthTestUtils.AUTH_HEADER;
-import static org.apache.pinot.integration.tests.BasicAuthTestUtils.AUTH_HEADER_USER;
-import static org.apache.pinot.integration.tests.BasicAuthTestUtils.AUTH_TOKEN;
 import static org.apache.pinot.integration.tests.ClusterIntegrationTestUtils.getBrokerQueryApiUrl;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 
-public class RowLevelSecurityIntegrationTest extends BaseClusterIntegrationTest {
-  private static final String AUTH_TOKEN_USER_2 = "Basic dXNlcjI6bm90U29TZWNyZXQ";
+/**
+ * Base class for Row Level Security integration tests.
+ * Contains all test logic that is shared between BasicAuth and ZkAuth implementations.
+ */
+public abstract class RowLevelSecurityIntegrationTestBase extends BaseClusterIntegrationTest {
+  public static final String ADMIN_USER = "admin";
+  public static final String ADMIN_PASSWORD = "verysecret";
+  public static final String AUTH_TOKEN = "Basic YWRtaW46dmVyeXNlY3JldA==";
+  public static final Map<String, String> AUTH_HEADER = Map.of("Authorization", AUTH_TOKEN);
+
+  public static final String AUTH_TOKEN_USER = "Basic dXNlcjpzZWNyZXQ=";
+  public static final Map<String, String> AUTH_HEADER_USER = Map.of("Authorization", AUTH_TOKEN_USER);
+
+  private static final String AUTH_TOKEN_USER_2 = "Basic dXNlcjI6bm90U29TZWNyZXQ=";
   public static final Map<String, String> AUTH_HEADER_USER_2 = Map.of("Authorization", AUTH_TOKEN_USER_2);
+
   private static final String DEFAULT_TABLE_NAME_2 = "mytable2";
   private static final String DEFAULT_TABLE_NAME_3 = "mytable3";
-
+  private static final Logger LOGGER = LoggerFactory.getLogger(RowLevelSecurityIntegrationTestBase.class);
   protected List<File> _avroFiles;
-  private static final Logger LOGGER = LoggerFactory.getLogger(RowLevelSecurityIntegrationTest.class);
-
-  @Override
-  protected void overrideControllerConf(Map<String, Object> properties) {
-    properties.put("controller.segment.fetcher.auth.token", AUTH_TOKEN);
-    properties.put("controller.admin.access.control.factory.class",
-        "org.apache.pinot.controller.api.access.BasicAuthAccessControlFactory");
-    properties.put("controller.admin.access.control.principals", "admin, user, user2");
-    properties.put("controller.admin.access.control.principals.admin.password", "verysecret");
-    properties.put("controller.admin.access.control.principals.user.password", "secret");
-    properties.put("controller.admin.access.control.principals.user2.password", "notSoSecret");
-    properties.put("controller.admin.access.control.principals.user.tables", "mytable, mytable2, mytable3");
-    properties.put("controller.admin.access.control.principals.user.permissions", "read");
-    properties.put("controller.admin.access.control.principals.user2.tables", "mytable, mytable2, mytable3");
-    properties.put("controller.admin.access.control.principals.user2.permissions", "read");
-  }
-
-  @Override
-  protected void overrideBrokerConf(PinotConfiguration brokerConf) {
-    brokerConf.setProperty("pinot.broker.enable.row.column.level.auth", "true");
-    brokerConf.setProperty("pinot.broker.access.control.class",
-        "org.apache.pinot.broker.broker.BasicAuthAccessControlFactory");
-    brokerConf.setProperty("pinot.broker.access.control.principals", "admin, user, user2");
-    brokerConf.setProperty("pinot.broker.access.control.principals.admin.password", "verysecret");
-    brokerConf.setProperty("pinot.broker.access.control.principals.user.password", "secret");
-    brokerConf.setProperty("pinot.broker.access.control.principals.user2.password", "notSoSecret");
-    brokerConf.setProperty("pinot.broker.access.control.principals.user.tables", "mytable, mytable2, mytable3");
-    brokerConf.setProperty("pinot.broker.access.control.principals.user.permissions", "read");
-    brokerConf.setProperty("pinot.broker.access.control.principals.user.mytable.rls", "AirlineID='19805'");
-    brokerConf.setProperty("pinot.broker.access.control.principals.user.mytable3.rls",
-        "AirlineID='20409' OR AirTime>'300', DestStateName='Florida'");
-    brokerConf.setProperty("pinot.broker.access.control.principals.user2.tables", "mytable, mytable2, mytable3");
-    brokerConf.setProperty("pinot.broker.access.control.principals.user2.permissions", "read");
-    brokerConf.setProperty("pinot.broker.access.control.principals.user2.mytable.rls",
-        "AirlineID='19805', DestStateName='California'");
-    brokerConf.setProperty("pinot.broker.access.control.principals.user2.mytable2.rls",
-        "AirlineID='20409', DestStateName='Florida'");
-    brokerConf.setProperty("pinot.broker.access.control.principals.user2.mytable3.rls",
-        "AirlineID='20409' OR DestStateName='California', DestStateName='Florida'");
-  }
-
-  @Override
-  protected void overrideServerConf(PinotConfiguration serverConf) {
-    serverConf.setProperty("pinot.server.segment.fetcher.auth.token", AUTH_TOKEN);
-    serverConf.setProperty("pinot.server.segment.uploader.auth.token", AUTH_TOKEN);
-    serverConf.setProperty("pinot.server.instance.auth.token", AUTH_TOKEN);
-  }
-
-  @Override
-  public ControllerRequestClient getControllerRequestClient() {
-    if (_controllerRequestClient == null) {
-      _controllerRequestClient =
-          new ControllerRequestClient(_controllerRequestURLBuilder, getHttpClient(), AUTH_HEADER);
-    }
-    return _controllerRequestClient;
-  }
 
   @Override
   protected Connection getPinotConnection() {
@@ -122,6 +75,15 @@ public class RowLevelSecurityIntegrationTest extends BaseClusterIntegrationTest 
     return _pinotConnection;
   }
 
+  @Override
+  public ControllerRequestClient getControllerRequestClient() {
+    if (_controllerRequestClient == null) {
+      _controllerRequestClient =
+          new ControllerRequestClient(_controllerRequestURLBuilder, getHttpClient(), AUTH_HEADER);
+    }
+    return _controllerRequestClient;
+  }
+
   @BeforeClass
   public void setUp()
       throws Exception {
@@ -131,6 +93,9 @@ public class RowLevelSecurityIntegrationTest extends BaseClusterIntegrationTest 
     startBroker();
     startServer();
 
+    // Allow subclasses to initialize users (for ZkAuth)
+    initializeUsers();
+
     startKafka();
     _avroFiles = unpackAvroData(_tempDir);
     pushAvroIntoKafka(_avroFiles);
@@ -139,10 +104,23 @@ public class RowLevelSecurityIntegrationTest extends BaseClusterIntegrationTest 
     setupTable(DEFAULT_TABLE_NAME);
     setupTable(DEFAULT_TABLE_NAME_2);
     setupTable(DEFAULT_TABLE_NAME_3);
+
+    waitForAllDocsLoaded(600_000L);
+  }
+
+  /**
+   * Hook for subclasses to initialize users.
+   * BasicAuth: no-op (users configured via properties)
+   * ZkAuth: create users via REST API
+   */
+  protected void initializeUsers()
+      throws Exception {
+    // Default implementation does nothing
   }
 
   private void setupTable(String tableName)
       throws Exception {
+
     Schema schema = createSchema();
     schema.setSchemaName(tableName);
     addSchema(schema);
@@ -153,7 +131,7 @@ public class RowLevelSecurityIntegrationTest extends BaseClusterIntegrationTest 
     tableConfig.getValidationConfig().setRetentionTimeValue("100000");
     addTableConfig(tableConfig);
 
-    waitForAllDocsLoaded(tableName, 600_000L);
+    waitForDocsLoaded(600_000L, true, tableConfig.getTableName());
   }
 
   @AfterClass

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/RowLevelSecurityZkAuthIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/RowLevelSecurityZkAuthIntegrationTest.java
@@ -1,0 +1,209 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.integration.tests;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.Map;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Row Level Security integration test using ZkAuth (ZooKeeper-based authentication).
+ * Users and permissions are created dynamically via REST API calls to the controller.
+ * This approach allows for dynamic user management without requiring cluster restarts.
+ */
+public class RowLevelSecurityZkAuthIntegrationTest extends RowLevelSecurityIntegrationTestBase {
+  private static final Logger LOGGER = LoggerFactory.getLogger(RowLevelSecurityZkAuthIntegrationTest.class);
+
+  @Override
+  protected void overrideControllerConf(Map<String, Object> properties) {
+    properties.put("controller.segment.fetcher.auth.token", AUTH_TOKEN);
+    properties.put("controller.admin.access.control.factory.class",
+        "org.apache.pinot.controller.api.access.ZkBasicAuthAccessControlFactory");
+    properties.put("access.control.init.username", ADMIN_USER);
+    properties.put("access.control.init.password", ADMIN_PASSWORD);
+  }
+
+  @Override
+  protected void overrideBrokerConf(PinotConfiguration brokerConf) {
+    brokerConf.setProperty("pinot.broker.enable.row.column.level.auth", "true");
+    brokerConf.setProperty("pinot.broker.access.control.class",
+        "org.apache.pinot.broker.broker.ZkBasicAuthAccessControlFactory");
+  }
+
+  @Override
+  protected void overrideServerConf(PinotConfiguration serverConf) {
+    serverConf.setProperty("pinot.server.segment.fetcher.auth.token", AUTH_TOKEN);
+    serverConf.setProperty("pinot.server.segment.uploader.auth.token", AUTH_TOKEN);
+    serverConf.setProperty("pinot.server.instance.auth.token", AUTH_TOKEN);
+  }
+
+  /**
+   * Initialize users via REST API after the cluster has started.
+   * This creates the same users with the same permissions and RLS filters as BasicAuth test.
+   */
+  @Override
+  protected void initializeUsers()
+      throws Exception {
+    LOGGER.info("Initializing users via REST API for ZkAuth test");
+
+    // Wait for controller to be ready
+    waitForControllerReady();
+
+    // Create users for BROKER component with RLS filters
+    createBrokerUsers();
+
+    // Create users for CONTROLLER component
+    createControllerUsers();
+
+    // Create users for SERVER component
+    createServerUsers();
+
+    LOGGER.info("Successfully initialized all users for ZkAuth test");
+  }
+
+  private void waitForControllerReady()
+      throws Exception {
+    int maxRetries = 30;
+    int retryCount = 0;
+    String healthUrl = "http://localhost:" + getControllerPort() + "/health";
+    while (retryCount < maxRetries) {
+      try {
+        String response = sendGetRequest(healthUrl);
+        if (response != null && !response.isEmpty()) {
+          LOGGER.info("Controller is ready");
+          return;
+        }
+      } catch (Exception e) {
+        // Controller not ready yet
+      }
+      retryCount++;
+      Thread.sleep(2000);
+    }
+    throw new Exception("Controller failed to become ready after " + maxRetries + " attempts");
+  }
+
+  private void createBrokerUsers()
+      throws Exception {
+    LOGGER.info("Creating BROKER users");
+
+    // User with READ permission on mytable, mytable2, mytable3 with RLS filter on mytable
+    createUser("user", "secret", "BROKER", "USER",
+        new String[]{"mytable", "mytable2", "mytable3"},
+        new String[]{"READ"},
+        null,
+        Map.of("mytable", new String[]{"AirlineID='19805'"},
+            "mytable3", new String[]{"AirlineID='20409' OR AirTime>'300'", "DestStateName='Florida'"}));
+
+    // User2 with READ permission on mytable, mytable2, mytable3 with RLS filters
+    createUser("user2", "notSoSecret", "BROKER", "USER",
+        new String[]{"mytable", "mytable2", "mytable3"},
+        new String[]{"READ"},
+        null,
+        Map.of("mytable", new String[]{"AirlineID='19805'", "DestStateName='California'"},
+            "mytable2", new String[]{"AirlineID='20409'", "DestStateName='Florida'"},
+            "mytable3", new String[]{"AirlineID='20409' OR DestStateName='California'", "DestStateName='Florida'"}));
+  }
+
+  private void createControllerUsers()
+      throws Exception {
+    LOGGER.info("Creating CONTROLLER users");
+
+    // User with READ permission on mytable, mytable2, mytable3
+    createUser("user", "secret", "CONTROLLER", "USER",
+        new String[]{"mytable", "mytable2", "mytable3"},
+        new String[]{"READ"},
+        null, null);
+
+    // User2 with READ permission on mytable, mytable2, mytable3
+    createUser("user2", "notSoSecret", "CONTROLLER", "USER",
+        new String[]{"mytable", "mytable2", "mytable3"},
+        new String[]{"READ"},
+        null, null);
+  }
+
+  private void createServerUsers() {
+    // Nothing to do for SERVER users in this test
+    LOGGER.info("No SERVER users to create for this test");
+  }
+
+  /**
+   * Create a user via REST API call to /users endpoint.
+   *
+   * @param username Username
+   * @param password Password
+   * @param component Component (BROKER, CONTROLLER, SERVER)
+   * @param role Role (ADMIN, USER)
+   * @param tables Tables the user has access to (null for all tables)
+   * @param permissions Permissions (READ, CREATE, UPDATE, DELETE)
+   * @param excludeTables Tables to exclude (null if not applicable)
+   * @param rlsFilters Row-level security filters per table (null if not applicable)
+   */
+  private void createUser(String username, String password, String component, String role,
+      String[] tables, String[] permissions, String[] excludeTables, Map<String, String[]> rlsFilters)
+      throws Exception {
+
+    ObjectMapper mapper = new ObjectMapper();
+    ObjectNode userJson = mapper.createObjectNode();
+
+    userJson.put("username", username);
+    userJson.put("password", password);
+    userJson.put("component", component);
+    userJson.put("role", role);
+
+    if (tables != null) {
+      userJson.set("tables", mapper.valueToTree(tables));
+    }
+
+    if (permissions != null) {
+      userJson.set("permissions", mapper.valueToTree(permissions));
+    }
+
+    if (excludeTables != null) {
+      userJson.set("excludeTables", mapper.valueToTree(excludeTables));
+    }
+
+    if (rlsFilters != null) {
+      ObjectNode rlsNode = mapper.createObjectNode();
+      for (Map.Entry<String, String[]> entry : rlsFilters.entrySet()) {
+        rlsNode.set(entry.getKey(), mapper.valueToTree(entry.getValue()));
+      }
+      userJson.set("rlsFilters", rlsNode);
+    }
+
+    String jsonPayload = userJson.toString();
+
+    try {
+      String usersUrl = "http://localhost:" + getControllerPort() + "/users";
+      String response = sendPostRequest(usersUrl, jsonPayload, AUTH_HEADER);
+
+      LOGGER.info("Created user: {}_{} - Response: {}", username, component, response);
+    } catch (Exception e) {
+      // Check if user already exists (409 conflict)
+      if (e.getMessage() != null && e.getMessage().contains("409")) {
+        LOGGER.info("User {}_{} already exists, skipping", username, component);
+      } else {
+        throw e;
+      }
+    }
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/user/UserConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/user/UserConfig.java
@@ -24,6 +24,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.google.common.base.Preconditions;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Nullable;
 import org.apache.pinot.spi.config.BaseJsonConfig;
@@ -38,6 +39,7 @@ public class UserConfig extends BaseJsonConfig {
   public static final String TABLES_KEY = "tables";
   public static final String EXCLUDE_TABLES_KEY = "excludeTables";
   public static final String PERMISSIONS_KEY = "permissions";
+  public static final String RLS_FILTERS_KEY = "rlsFilters";
 
   @JsonPropertyDescription("The name of User")
   private String _username;
@@ -60,6 +62,9 @@ public class UserConfig extends BaseJsonConfig {
   @JsonPropertyDescription("The table permission of User")
   private List<AccessType> _permissions;
 
+  @JsonPropertyDescription("The RLS filters for User per table")
+  private Map<String, List<String>> _rlsFilters;
+
   @JsonCreator
   public UserConfig(@JsonProperty(value = USERNAME_KEY, required = true) String username,
       @JsonProperty(value = PASSWORD_KEY, required = true) String password,
@@ -67,7 +72,9 @@ public class UserConfig extends BaseJsonConfig {
       @JsonProperty(value = ROLE_KEY, required = true) String role,
       @JsonProperty(value = TABLES_KEY) @Nullable List<String> tableList,
       @JsonProperty(value = EXCLUDE_TABLES_KEY) @Nullable List<String> excludeTableList,
-      @JsonProperty(value = PERMISSIONS_KEY) @Nullable List<AccessType> permissionList) {
+      @JsonProperty(value = PERMISSIONS_KEY) @Nullable List<AccessType> permissionList,
+      @JsonProperty(value = RLS_FILTERS_KEY) @Nullable Map<String, List<String>> rlsFilters
+  ) {
     Preconditions.checkArgument(username != null, "'username' must be configured");
     Preconditions.checkArgument(password != null, "'password' must be configured");
 
@@ -79,6 +86,16 @@ public class UserConfig extends BaseJsonConfig {
     _tables = tableList;
     _excludeTables = excludeTableList;
     _permissions = permissionList;
+    _rlsFilters = rlsFilters;
+  }
+
+  /**
+   * Constructor for backward compatibility without RLS filters.
+   * This allows existing code to continue working without modification.
+   */
+  public UserConfig(String username, String password, String component, String role,
+      List<String> tableList, List<String> excludeTableList, List<AccessType> permissionList) {
+    this(username, password, component, role, tableList, excludeTableList, permissionList, null);
   }
 
   @JsonProperty(USERNAME_KEY)
@@ -122,6 +139,11 @@ public class UserConfig extends BaseJsonConfig {
   @Deprecated
   public List<AccessType> getPermissios() {
     return getPermissions();
+  }
+
+  @JsonProperty(RLS_FILTERS_KEY)
+  public Map<String, List<String>> getRlsFilters() {
+    return _rlsFilters;
   }
 
   @JsonProperty(COMPONET_KEY)

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/UserConfigBuilder.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/UserConfigBuilder.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.spi.utils.builder;
 
 import java.util.List;
+import java.util.Map;
 import org.apache.pinot.spi.config.user.AccessType;
 import org.apache.pinot.spi.config.user.ComponentType;
 import org.apache.pinot.spi.config.user.RoleType;
@@ -33,6 +34,7 @@ public class UserConfigBuilder {
   private List<String> _tableList;
   private List<String> _excludeTableList;
   private List<AccessType> _permissionList;
+  private Map<String, List<String>> _rlsFilters;
 
   public UserConfigBuilder setComponentType(ComponentType componentType) {
     _componentType = componentType;
@@ -69,8 +71,13 @@ public class UserConfigBuilder {
     return this;
   }
 
+  public UserConfigBuilder setRlsFilters(Map<String, List<String>> rlsFilters) {
+    _rlsFilters = rlsFilters;
+    return this;
+  }
+
   public UserConfig build() {
     return new UserConfig(_username, _password, _componentType.toString(), _roleType.toString(), _tableList,
-        _excludeTableList, _permissionList);
+        _excludeTableList, _permissionList, _rlsFilters);
   }
 }

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/utils/builder/UserConfigBuilderTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/utils/builder/UserConfigBuilderTest.java
@@ -1,0 +1,261 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.spi.utils.builder;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.spi.config.user.AccessType;
+import org.apache.pinot.spi.config.user.ComponentType;
+import org.apache.pinot.spi.config.user.RoleType;
+import org.apache.pinot.spi.config.user.UserConfig;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+/**
+ * Tests for {@link UserConfigBuilder}
+ */
+public class UserConfigBuilderTest {
+
+  private static final String TEST_USERNAME = "testUser";
+  private static final String TEST_PASSWORD = "testPassword";
+
+  @Test
+  public void testBasicUserConfigBuild() {
+    UserConfig userConfig = new UserConfigBuilder()
+        .setUsername(TEST_USERNAME)
+        .setPassword(TEST_PASSWORD)
+        .setComponentType(ComponentType.BROKER)
+        .setRoleType(RoleType.USER)
+        .build();
+
+    Assert.assertNotNull(userConfig, "UserConfig should not be null");
+    Assert.assertEquals(userConfig.getUserName(), TEST_USERNAME, "Username should match");
+    Assert.assertEquals(userConfig.getPassword(), TEST_PASSWORD, "Password should match");
+    Assert.assertEquals(userConfig.getComponentType(), ComponentType.BROKER, "Component type should match");
+    Assert.assertEquals(userConfig.getRoleType(), RoleType.USER, "Role type should match");
+    Assert.assertNull(userConfig.getTables(), "Tables should be null when not set");
+    Assert.assertNull(userConfig.getExcludeTables(), "Exclude tables should be null when not set");
+    Assert.assertNull(userConfig.getPermissios(), "Permissions should be null when not set");
+    Assert.assertNull(userConfig.getRlsFilters(), "RLS filters should be null when not set");
+  }
+
+  @Test
+  public void testUserConfigWithTableList() {
+    List<String> tableList = Arrays.asList("table1", "table2", "table3");
+
+    UserConfig userConfig = new UserConfigBuilder()
+        .setUsername(TEST_USERNAME)
+        .setPassword(TEST_PASSWORD)
+        .setComponentType(ComponentType.CONTROLLER)
+        .setRoleType(RoleType.ADMIN)
+        .setTableList(tableList)
+        .build();
+
+    Assert.assertNotNull(userConfig.getTables(), "Tables should not be null");
+    Assert.assertEquals(userConfig.getTables(), tableList, "Table list should match");
+    Assert.assertEquals(userConfig.getTables().size(), 3, "Table list size should be 3");
+  }
+
+  @Test
+  public void testUserConfigWithExcludeTableList() {
+    List<String> excludeTableList = Arrays.asList("excludeTable1", "excludeTable2");
+
+    UserConfig userConfig = new UserConfigBuilder()
+        .setUsername(TEST_USERNAME)
+        .setPassword(TEST_PASSWORD)
+        .setComponentType(ComponentType.SERVER)
+        .setRoleType(RoleType.USER)
+        .setExcludeTableList(excludeTableList)
+        .build();
+
+    Assert.assertNotNull(userConfig.getExcludeTables(), "Exclude tables should not be null");
+    Assert.assertEquals(userConfig.getExcludeTables(), excludeTableList, "Exclude table list should match");
+    Assert.assertEquals(userConfig.getExcludeTables().size(), 2, "Exclude table list size should be 2");
+  }
+
+  @Test
+  public void testUserConfigWithPermissionList() {
+    List<AccessType> permissionList = Arrays.asList(AccessType.READ, AccessType.CREATE, AccessType.UPDATE);
+
+    UserConfig userConfig = new UserConfigBuilder()
+        .setUsername(TEST_USERNAME)
+        .setPassword(TEST_PASSWORD)
+        .setComponentType(ComponentType.MINION)
+        .setRoleType(RoleType.ADMIN)
+        .setPermissionList(permissionList)
+        .build();
+
+    Assert.assertNotNull(userConfig.getPermissios(), "Permissions should not be null");
+    Assert.assertEquals(userConfig.getPermissios(), permissionList, "Permission list should match");
+    Assert.assertEquals(userConfig.getPermissios().size(), 3, "Permission list size should be 3");
+    Assert.assertTrue(userConfig.getPermissios().contains(AccessType.READ), "Should contain READ permission");
+    Assert.assertTrue(userConfig.getPermissios().contains(AccessType.CREATE), "Should contain CREATE permission");
+    Assert.assertTrue(userConfig.getPermissios().contains(AccessType.UPDATE), "Should contain UPDATE permission");
+  }
+
+  @Test
+  public void testUserConfigWithRlsFilters() {
+    Map<String, List<String>> rlsFilters = new HashMap<>();
+    rlsFilters.put("table1", Arrays.asList("filter1", "filter2"));
+    rlsFilters.put("table2", Arrays.asList("filter3"));
+
+    UserConfig userConfig = new UserConfigBuilder()
+        .setUsername(TEST_USERNAME)
+        .setPassword(TEST_PASSWORD)
+        .setComponentType(ComponentType.PROXY)
+        .setRoleType(RoleType.USER)
+        .setRlsFilters(rlsFilters)
+        .build();
+
+    Assert.assertNotNull(userConfig.getRlsFilters(), "RLS filters should not be null");
+    Assert.assertEquals(userConfig.getRlsFilters(), rlsFilters, "RLS filters should match");
+    Assert.assertEquals(userConfig.getRlsFilters().size(), 2, "RLS filters map size should be 2");
+    Assert.assertTrue(userConfig.getRlsFilters().containsKey("table1"), "Should contain table1 filters");
+    Assert.assertTrue(userConfig.getRlsFilters().containsKey("table2"), "Should contain table2 filters");
+    Assert.assertEquals(userConfig.getRlsFilters().get("table1").size(), 2, "table1 should have 2 filters");
+    Assert.assertEquals(userConfig.getRlsFilters().get("table2").size(), 1, "table2 should have 1 filter");
+  }
+
+  @Test
+  public void testUserConfigWithAllFields() {
+    List<String> tableList = Arrays.asList("table1", "table2");
+    List<String> excludeTableList = Arrays.asList("excludeTable1");
+    List<AccessType> permissionList = Arrays.asList(AccessType.READ, AccessType.UPDATE, AccessType.DELETE);
+    Map<String, List<String>> rlsFilters = new HashMap<>();
+    rlsFilters.put("table1", Arrays.asList("country='US'", "department='Engineering'"));
+
+    UserConfig userConfig = new UserConfigBuilder()
+        .setUsername("adminUser")
+        .setPassword("adminPass123")
+        .setComponentType(ComponentType.BROKER)
+        .setRoleType(RoleType.ADMIN)
+        .setTableList(tableList)
+        .setExcludeTableList(excludeTableList)
+        .setPermissionList(permissionList)
+        .setRlsFilters(rlsFilters)
+        .build();
+
+    Assert.assertNotNull(userConfig, "UserConfig should not be null");
+    Assert.assertEquals(userConfig.getUserName(), "adminUser", "Username should match");
+    Assert.assertEquals(userConfig.getPassword(), "adminPass123", "Password should match");
+    Assert.assertEquals(userConfig.getComponentType(), ComponentType.BROKER, "Component type should match");
+    Assert.assertEquals(userConfig.getRoleType(), RoleType.ADMIN, "Role type should match");
+    Assert.assertEquals(userConfig.getTables(), tableList, "Table list should match");
+    Assert.assertEquals(userConfig.getExcludeTables(), excludeTableList, "Exclude table list should match");
+    Assert.assertEquals(userConfig.getPermissios(), permissionList, "Permission list should match");
+    Assert.assertEquals(userConfig.getRlsFilters(), rlsFilters, "RLS filters should match");
+  }
+
+  @Test
+  public void testBuilderChaining() {
+    UserConfigBuilder builder = new UserConfigBuilder();
+
+    // Verify that each setter returns the builder instance for chaining
+    UserConfigBuilder result1 = builder.setUsername(TEST_USERNAME);
+    Assert.assertSame(result1, builder, "setUsername should return the builder instance");
+
+    UserConfigBuilder result2 = builder.setPassword(TEST_PASSWORD);
+    Assert.assertSame(result2, builder, "setPassword should return the builder instance");
+
+    UserConfigBuilder result3 = builder.setComponentType(ComponentType.BROKER);
+    Assert.assertSame(result3, builder, "setComponentType should return the builder instance");
+
+    UserConfigBuilder result4 = builder.setRoleType(RoleType.USER);
+    Assert.assertSame(result4, builder, "setRoleType should return the builder instance");
+
+    UserConfigBuilder result5 = builder.setTableList(Arrays.asList("table1"));
+    Assert.assertSame(result5, builder, "setTableList should return the builder instance");
+
+    UserConfigBuilder result6 = builder.setExcludeTableList(Arrays.asList("excludeTable1"));
+    Assert.assertSame(result6, builder, "setExcludeTableList should return the builder instance");
+
+    UserConfigBuilder result7 = builder.setPermissionList(Arrays.asList(AccessType.READ));
+    Assert.assertSame(result7, builder, "setPermissionList should return the builder instance");
+
+    Map<String, List<String>> rlsFilters = new HashMap<>();
+    rlsFilters.put("table1", Arrays.asList("filter1"));
+    UserConfigBuilder result8 = builder.setRlsFilters(rlsFilters);
+    Assert.assertSame(result8, builder, "setRlsFilters should return the builder instance");
+  }
+
+  @Test
+  public void testMultipleComponentTypes() {
+    // Test with different component types
+    ComponentType[] componentTypes = {
+        ComponentType.CONTROLLER, ComponentType.BROKER, ComponentType.SERVER,
+        ComponentType.MINION, ComponentType.PROXY
+    };
+
+    for (ComponentType componentType : componentTypes) {
+      UserConfig userConfig = new UserConfigBuilder()
+          .setUsername(TEST_USERNAME)
+          .setPassword(TEST_PASSWORD)
+          .setComponentType(componentType)
+          .setRoleType(RoleType.USER)
+          .build();
+
+      Assert.assertEquals(userConfig.getComponentType(), componentType,
+          "Component type should match for " + componentType);
+    }
+  }
+
+  @Test
+  public void testMultipleRoleTypes() {
+    // Test with different role types
+    RoleType[] roleTypes = {RoleType.ADMIN, RoleType.USER};
+
+    for (RoleType roleType : roleTypes) {
+      UserConfig userConfig = new UserConfigBuilder()
+          .setUsername(TEST_USERNAME)
+          .setPassword(TEST_PASSWORD)
+          .setComponentType(ComponentType.BROKER)
+          .setRoleType(roleType)
+          .build();
+
+      Assert.assertEquals(userConfig.getRoleType(), roleType,
+          "Role type should match for " + roleType);
+    }
+  }
+
+  @Test
+  public void testAllAccessTypes() {
+    // Test with all access types
+    List<AccessType> allPermissions = Arrays.asList(
+        AccessType.CREATE, AccessType.READ, AccessType.UPDATE, AccessType.DELETE
+    );
+
+    UserConfig userConfig = new UserConfigBuilder()
+        .setUsername(TEST_USERNAME)
+        .setPassword(TEST_PASSWORD)
+        .setComponentType(ComponentType.BROKER)
+        .setRoleType(RoleType.ADMIN)
+        .setPermissionList(allPermissions)
+        .build();
+
+    Assert.assertEquals(userConfig.getPermissios().size(), 4, "Should have all 4 access types");
+    Assert.assertTrue(userConfig.getPermissios().contains(AccessType.CREATE), "Should contain CREATE");
+    Assert.assertTrue(userConfig.getPermissios().contains(AccessType.READ), "Should contain READ");
+    Assert.assertTrue(userConfig.getPermissios().contains(AccessType.UPDATE), "Should contain UPDATE");
+    Assert.assertTrue(userConfig.getPermissios().contains(AccessType.DELETE), "Should contain DELETE");
+  }
+}


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Adds RLS filter flow from user config builder to ZooKeeper auth factory for row\-level security\.

```mermaid
flowchart TD
  N0["UserConfigBuilder adds RLS filters #40;F5#41;"]:::stAdded
  N1["AccessControlUserConfigUtils serializes#47;deserializes RLS filters #40;F2#41;"]:::stModified
  N2["BasicAuthPrincipalUtils creates ZkBasicAuthPrincipal with RLS filters #40;F3#41;"]:::stModified
  N3["ZkBasicAuthAccessControlFactory#46;getRowColFilters returns RLS filters #40;F1#41;"]:::stAdded
  N0 -->|"UserConfig with RLS filters passed to toZNRecord"| N1
  N1 -->|"UserConfig from ZNRecord used to extract principals"| N2
  N2 -->|"ZkBasicAuthPrincipal supplied to getRowColFilters"| N3
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

Partial evidence: 0 file patches omitted; 1 truncated.

<details>
<summary>Diff evidence</summary>

- F1: pinot\-broker/src/main/java/org/apache/pinot/broker/broker/ZkBasicAuthAccessControlFactory\.java — [before](https://github.com/apache/pinot/blob/b07deffb584a24ce139b5aba409e8bbbcbc0fbb0/pinot-broker/src/main/java/org/apache/pinot/broker/broker/ZkBasicAuthAccessControlFactory.java) · [after](https://github.com/apache/pinot/blob/d7d21e59d3d73a1e91da557c8012b71fec45e7bb/pinot-broker/src/main/java/org/apache/pinot/broker/broker/ZkBasicAuthAccessControlFactory.java)
- F2: pinot\-common/src/main/java/org/apache/pinot/common/utils/config/AccessControlUserConfigUtils\.java — [before](https://github.com/apache/pinot/blob/b07deffb584a24ce139b5aba409e8bbbcbc0fbb0/pinot-common/src/main/java/org/apache/pinot/common/utils/config/AccessControlUserConfigUtils.java) · [after](https://github.com/apache/pinot/blob/d7d21e59d3d73a1e91da557c8012b71fec45e7bb/pinot-common/src/main/java/org/apache/pinot/common/utils/config/AccessControlUserConfigUtils.java)
- F3: pinot\-core/src/main/java/org/apache/pinot/core/auth/BasicAuthPrincipalUtils\.java — [before](https://github.com/apache/pinot/blob/b07deffb584a24ce139b5aba409e8bbbcbc0fbb0/pinot-core/src/main/java/org/apache/pinot/core/auth/BasicAuthPrincipalUtils.java) · [after](https://github.com/apache/pinot/blob/d7d21e59d3d73a1e91da557c8012b71fec45e7bb/pinot-core/src/main/java/org/apache/pinot/core/auth/BasicAuthPrincipalUtils.java)
- F5: pinot\-spi/src/main/java/org/apache/pinot/spi/utils/builder/UserConfigBuilder\.java — [before](https://github.com/apache/pinot/blob/b07deffb584a24ce139b5aba409e8bbbcbc0fbb0/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/UserConfigBuilder.java) · [after](https://github.com/apache/pinot/blob/d7d21e59d3d73a1e91da557c8012b71fec45e7bb/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/UserConfigBuilder.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImIwN2RlZmZiNTg0YTI0Y2UxMzliNWFiYTQwOWU4YmJiY2JjMGZiYjAiLCJjb250ZXh0X2hhc2giOiIxMTNlMThlOTYxZjRhNmJmMDdhNzlkOGJiNTNlY2UxM2RjOTcyMjRmNzE5M2ZjZjUwOTBjZWZhMDRhNzIwNjc3IiwiZ2VuZXJhdGVkX2F0IjoxNzg5NjQ0MzcwLCJoZWFkX3NoYSI6ImQ3ZDIxZTU5ZDNkNzNhMWU5MWRhNTU3YzgwMTJiNzFmZWM0NWU3YmIiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiIyZTlmMzVjMWE3Y2YyMmNkOThhYzExZGI3ZjAwMTBkZDYwNzRlYmNmIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 763565163c359a10dc26b3bd1973459214e441dfacc18ab2bf4bab50cbb7a2f3 -->
<!-- pinot-pr-flow:end -->

Fixes #17220

This commit extends Row-Level Security (RLS) functionality to ZooKeeper-based authentication (`ZkBasicAuthAccessControlFactory`), enabling dynamic user management with table-level filter controls via REST API.

Previously, RLS filters were only supported with file-based `BasicAuth` configuration. ZK-based authentication passed empty RLS filter maps, preventing users from applying row-level restrictions when using ZooKeeper for user management.

Changes:
- Extended UserConfig to store RLS filters per table (`Map<String, List<String>>`)
- Updated `AccessControlUserConfigUtils` to serialize/deserialize RLS filters to/from `ZNRecord`
- Modified `BasicAuthUtils` to extract RLS filters from `UserConfig` and pass to `ZkBasicAuthPrincipal`
- Implemented `getRowColFilters()` in `ZkBasicAuthAccessControlFactory` to return RLS filters
- Updated `UserConfigBuilder` to support RLS filter configuration
- Added comprehensive unit tests for `UserConfig`, `UserConfigBuilder`, and `AccessControlUserConfigUtils`
- Added integration tests for ZkAuth RLS scenarios by extracting base class from existing `BasicAuth` tests

Manual Testing:
- Tested REST API create/update/get operations with RLS filters
- Tested queries work as expected with rls for the ZK-based authentication

API Example:
```
POST /users
{
  "username": "user",
  "password": "secret",
  "component": "BROKER",
  "role": "USER",
  "tables": ["table1", "table2"],
  "permissions": ["READ"],
  "rlsFilters": {
    "table1": ["country='US'"],
    "table2": ["department='Engineering'", "level='Senior'"]
  }
}
```
