### PR TITLE
Best-effort warmup of compile pipeline on MSE broker startup

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -202,8 +202,10 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
   }
 
   /**
-   * Best-effort warmup of the Calcite compile pipeline before serving traffic. Reduces but does
-   * not guarantee that cold-start compilation times won't breach the timeout limit enforced in #14946.
+   * Best-effort warmup of the Calcite compile pipeline at broker startup. Running a trivial compile
+   * early ensures that JVM class-loading and Calcite initialization costs are paid before real
+   * queries arrive, so that the first MSE queries do not fail due to tight per-query timeout
+   * constraints.
    */
   private void warmupCompile() {
     try {
@@ -212,14 +214,14 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
       long startMs = System.currentTimeMillis();
       LOGGER.info("MSE startup warmup: compiling query");
       ExecutorService exec = Executors.newSingleThreadExecutor();
-      try {
-        exec.submit(() -> warmupEnv.compile("SELECT 1")).get(30, TimeUnit.SECONDS);
+      try (var compiled = exec.submit(() -> warmupEnv.compile("SELECT 1")).get(5, TimeUnit.SECONDS)) {
+        // result discarded; compile call is for JVM warmup only
       } finally {
         exec.shutdownNow();
       }
       LOGGER.info("MSE startup warmup completed in {}ms", System.currentTimeMillis() - startMs);
     } catch (Exception e) {
-      LOGGER.error("MSE broker startup warmup failed", e);
+      LOGGER.warn("MSE broker startup warmup failed", e);
     }
   }
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -198,6 +198,23 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
   @Override
   public void start() {
     _queryDispatcher.start();
+    warmupCompile();
+  }
+
+  /**
+   * Best-effort warmup of the Calcite compile pipeline before serving traffic. Reduces but does
+   * not guarantee that cold-start compilation times won't breach the timeout limit enforced in #14946.
+   */
+  private void warmupCompile() {
+    try {
+      ImmutableQueryEnvironment.Config warmupConf = getQueryEnvConf(null, Map.of(), -1L);
+      QueryEnvironment warmupEnv = new QueryEnvironment(warmupConf, _multiClusterRoutingContext);
+      long startMs = System.currentTimeMillis();
+      _queryCompileExecutor.submit(() -> warmupEnv.compile("SELECT 1")).get(30, TimeUnit.SECONDS);
+      LOGGER.info("MSE startup warmup completed in {}ms", System.currentTimeMillis() - startMs);
+    } catch (Exception e) {
+      LOGGER.warn("MSE broker startup warmup failed", e);
+    }
   }
 
   @Override

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -210,10 +210,11 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
       ImmutableQueryEnvironment.Config warmupConf = getQueryEnvConf(null, Map.of(), -1L);
       QueryEnvironment warmupEnv = new QueryEnvironment(warmupConf, _multiClusterRoutingContext);
       long startMs = System.currentTimeMillis();
-      _queryCompileExecutor.submit(() -> warmupEnv.compile("SELECT 1")).get(30, TimeUnit.SECONDS);
+      LOGGER.info("MSE startup warmup: compiling query");
+      warmupEnv.compile("SELECT 1");
       LOGGER.info("MSE startup warmup completed in {}ms", System.currentTimeMillis() - startMs);
     } catch (Exception e) {
-      LOGGER.warn("MSE broker startup warmup failed", e);
+      LOGGER.error("MSE broker startup warmup failed", e);
     }
   }
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -208,6 +208,8 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
    * constraints.
    */
   private void warmupCompile() {
+    // TODO: extend warmup to exercise the full query execution path (planning + dispatch + execution),
+    //       not just compilation, to amortize all cold-start costs before serving traffic.
     try {
       ImmutableQueryEnvironment.Config warmupConf = getQueryEnvConf(null, Map.of(), -1L);
       QueryEnvironment warmupEnv = new QueryEnvironment(warmupConf, _multiClusterRoutingContext);

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -211,7 +211,12 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
       QueryEnvironment warmupEnv = new QueryEnvironment(warmupConf, _multiClusterRoutingContext);
       long startMs = System.currentTimeMillis();
       LOGGER.info("MSE startup warmup: compiling query");
-      warmupEnv.compile("SELECT 1");
+      ExecutorService exec = Executors.newSingleThreadExecutor();
+      try {
+        exec.submit(() -> warmupEnv.compile("SELECT 1")).get(30, TimeUnit.SECONDS);
+      } finally {
+        exec.shutdownNow();
+      }
       LOGGER.info("MSE startup warmup completed in {}ms", System.currentTimeMillis() - startMs);
     } catch (Exception e) {
       LOGGER.error("MSE broker startup warmup failed", e);


### PR DESCRIPTION
Partial solution for https://github.com/apache/pinot/issues/18110

Adds a best-effort warmup of the multistage query compilation path in broker startup.

This is not a readiness check since
- Control planes can also be responsible for warming up query paths, so this is a lightweight solution within Pinot
- A readiness check requires a more nuanced approach:
  -  It should likely be a full query execution warmup and if so, how are edge cases like no tables on new clusters handled?
  - Does it keep attempting warmups until the compilation converges on a specific time?
  - How long do we wait on convergence?
  - What do we do if it does take too long?


Restarting brokers with this change does not result in any `Timed out while planning query` errors mentioned in the issue, nor did we detect any other degradations due to this on our clusters.
