### PR TITLE
Implement multiple correlate keys functionality for FUNNEL_COUNT

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/AggregationStrategy.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/AggregationStrategy.java
@@ -45,33 +45,32 @@ public abstract class AggregationStrategy<A> {
   protected final int _numSteps;
   private final List<ExpressionContext> _stepExpressions;
   private final List<ExpressionContext> _correlateByExpressions;
-  private final ExpressionContext _primaryCorrelationCol;
 
   public AggregationStrategy(List<ExpressionContext> stepExpressions, List<ExpressionContext> correlateByExpressions) {
     _stepExpressions = stepExpressions;
     _correlateByExpressions = correlateByExpressions;
-    _primaryCorrelationCol = _correlateByExpressions.get(0);
     _numSteps = _stepExpressions.size();
   }
 
   /**
    * Returns an aggregation result for this aggregation strategy to be kept in a result holder (aggregation only).
    */
-  abstract A createAggregationResult(Dictionary dictionary);
+  abstract A createAggregationResult(Dictionary[] dictionaries);
 
-  public A getAggregationResultGroupBy(Dictionary dictionary, GroupByResultHolder groupByResultHolder, int groupKey) {
+  public A getAggregationResultGroupBy(Dictionary[] dictionaries, GroupByResultHolder groupByResultHolder,
+      int groupKey) {
     A aggResult = groupByResultHolder.getResult(groupKey);
     if (aggResult == null) {
-      aggResult = createAggregationResult(dictionary);
+      aggResult = createAggregationResult(dictionaries);
       groupByResultHolder.setValueForKey(groupKey, aggResult);
     }
     return aggResult;
   }
 
-  public A getAggregationResult(Dictionary dictionary, AggregationResultHolder aggregationResultHolder) {
+  public A getAggregationResult(Dictionary[] dictionaries, AggregationResultHolder aggregationResultHolder) {
     A aggResult = aggregationResultHolder.getResult();
     if (aggResult == null) {
-      aggResult = createAggregationResult(dictionary);
+      aggResult = createAggregationResult(dictionaries);
       aggregationResultHolder.setValue(aggResult);
     }
     return aggResult;
@@ -82,15 +81,20 @@ public abstract class AggregationStrategy<A> {
    */
   public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    final Dictionary dictionary = getDictionary(blockValSetMap);
-    final int[] correlationIds = getCorrelationIds(blockValSetMap);
+    final Dictionary[] dictionaries = getDictionaries(blockValSetMap);
+    final int[][] allCorrelationIds = getAllCorrelationDictIds(blockValSetMap);
     final int[][] steps = getSteps(blockValSetMap);
+    final int numKeys = _correlateByExpressions.size();
 
-    final A aggResult = getAggregationResult(dictionary, aggregationResultHolder);
+    final A aggResult = getAggregationResult(dictionaries, aggregationResultHolder);
+    final int[] rowDictIds = new int[numKeys];
     for (int i = 0; i < length; i++) {
+      for (int k = 0; k < numKeys; k++) {
+        rowDictIds[k] = allCorrelationIds[k][i];
+      }
       for (int n = 0; n < _numSteps; n++) {
         if (steps[n][i] > 0) {
-          add(dictionary, aggResult, n, correlationIds[i]);
+          add(aggResult, n, dictionaries, rowDictIds);
         }
       }
     }
@@ -102,16 +106,21 @@ public abstract class AggregationStrategy<A> {
    */
   public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    final Dictionary dictionary = getDictionary(blockValSetMap);
-    final int[] correlationIds = getCorrelationIds(blockValSetMap);
+    final Dictionary[] dictionaries = getDictionaries(blockValSetMap);
+    final int[][] allCorrelationIds = getAllCorrelationDictIds(blockValSetMap);
     final int[][] steps = getSteps(blockValSetMap);
+    final int numKeys = _correlateByExpressions.size();
 
+    final int[] rowDictIds = new int[numKeys];
     for (int i = 0; i < length; i++) {
+      for (int k = 0; k < numKeys; k++) {
+        rowDictIds[k] = allCorrelationIds[k][i];
+      }
+      final int groupKey = groupKeyArray[i];
+      final A aggResult = getAggregationResultGroupBy(dictionaries, groupByResultHolder, groupKey);
       for (int n = 0; n < _numSteps; n++) {
-        final int groupKey = groupKeyArray[i];
-        final A aggResult = getAggregationResultGroupBy(dictionary, groupByResultHolder, groupKey);
         if (steps[n][i] > 0) {
-          add(dictionary, aggResult, n, correlationIds[i]);
+          add(aggResult, n, dictionaries, rowDictIds);
         }
       }
     }
@@ -123,16 +132,21 @@ public abstract class AggregationStrategy<A> {
    */
   public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    final Dictionary dictionary = getDictionary(blockValSetMap);
-    final int[] correlationIds = getCorrelationIds(blockValSetMap);
+    final Dictionary[] dictionaries = getDictionaries(blockValSetMap);
+    final int[][] allCorrelationIds = getAllCorrelationDictIds(blockValSetMap);
     final int[][] steps = getSteps(blockValSetMap);
+    final int numKeys = _correlateByExpressions.size();
 
+    final int[] rowDictIds = new int[numKeys];
     for (int i = 0; i < length; i++) {
-      for (int n = 0; n < _numSteps; n++) {
-        for (int groupKey : groupKeysArray[i]) {
-          final A aggResult = getAggregationResultGroupBy(dictionary, groupByResultHolder, groupKey);
+      for (int k = 0; k < numKeys; k++) {
+        rowDictIds[k] = allCorrelationIds[k][i];
+      }
+      for (int groupKey : groupKeysArray[i]) {
+        final A aggResult = getAggregationResultGroupBy(dictionaries, groupByResultHolder, groupKey);
+        for (int n = 0; n < _numSteps; n++) {
           if (steps[n][i] > 0) {
-            add(dictionary, aggResult, n, correlationIds[i]);
+            add(aggResult, n, dictionaries, rowDictIds);
           }
         }
       }
@@ -140,20 +154,36 @@ public abstract class AggregationStrategy<A> {
   }
 
   /**
-   * Adds a correlation id to the aggregation counter for a given step in the funnel.
+   * Adds a row's correlation identity to the aggregation counter for a given step in the funnel.
+   *
+   * @param aggResult    the aggregation result to update
+   * @param step         the funnel step index
+   * @param dictionaries one dictionary per correlate-by column
+   * @param correlationDictIds one dictionary ID per correlate-by column for the current row
+   *                           (this array is reused across rows; implementations must not hold a reference)
    */
-  abstract void add(Dictionary dictionary, A aggResult, int step, int correlationId);
+  abstract void add(A aggResult, int step, Dictionary[] dictionaries, int[] correlationDictIds);
 
-  private Dictionary getDictionary(Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    final Dictionary primaryCorrelationDictionary = blockValSetMap.get(_primaryCorrelationCol).getDictionary();
-    Preconditions.checkArgument(primaryCorrelationDictionary != null,
-        "CORRELATE_BY column in FUNNELCOUNT aggregation function not supported, please use a dictionary encoded "
-            + "column.");
-    return primaryCorrelationDictionary;
+  protected Dictionary[] getDictionaries(Map<ExpressionContext, BlockValSet> blockValSetMap) {
+    int numKeys = _correlateByExpressions.size();
+    Dictionary[] dictionaries = new Dictionary[numKeys];
+    for (int k = 0; k < numKeys; k++) {
+      Dictionary d = blockValSetMap.get(_correlateByExpressions.get(k)).getDictionary();
+      Preconditions.checkArgument(d != null,
+          "CORRELATE_BY column in FUNNELCOUNT aggregation function not supported, please use a dictionary encoded "
+              + "column.");
+      dictionaries[k] = d;
+    }
+    return dictionaries;
   }
 
-  private int[] getCorrelationIds(Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    return blockValSetMap.get(_primaryCorrelationCol).getDictionaryIdsSV();
+  private int[][] getAllCorrelationDictIds(Map<ExpressionContext, BlockValSet> blockValSetMap) {
+    int numKeys = _correlateByExpressions.size();
+    int[][] allIds = new int[numKeys][];
+    for (int k = 0; k < numKeys; k++) {
+      allIds[k] = blockValSetMap.get(_correlateByExpressions.get(k)).getDictionaryIdsSV();
+    }
+    return allIds;
   }
 
   private int[][] getSteps(Map<ExpressionContext, BlockValSet> blockValSetMap) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/AggregationStrategy.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/AggregationStrategy.java
@@ -164,7 +164,7 @@ public abstract class AggregationStrategy<A> {
    */
   abstract void add(A aggResult, int step, Dictionary[] dictionaries, int[] correlationDictIds);
 
-  protected Dictionary[] getDictionaries(Map<ExpressionContext, BlockValSet> blockValSetMap) {
+  private Dictionary[] getDictionaries(Map<ExpressionContext, BlockValSet> blockValSetMap) {
     int numKeys = _correlateByExpressions.size();
     Dictionary[] dictionaries = new Dictionary[numKeys];
     for (int k = 0; k < numKeys; k++) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/BitmapAggregationStrategy.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/BitmapAggregationStrategy.java
@@ -33,12 +33,12 @@ class BitmapAggregationStrategy extends AggregationStrategy<DictIdsWrapper> {
   }
 
   @Override
-  public DictIdsWrapper createAggregationResult(Dictionary dictionary) {
-    return new DictIdsWrapper(_numSteps, dictionary);
+  public DictIdsWrapper createAggregationResult(Dictionary[] dictionaries) {
+    return new DictIdsWrapper(_numSteps, dictionaries);
   }
 
   @Override
-  protected void add(Dictionary dictionary, DictIdsWrapper dictIdsWrapper, int step, int correlationId) {
-    dictIdsWrapper._stepsBitmaps[step].add(correlationId);
+  protected void add(DictIdsWrapper dictIdsWrapper, int step, Dictionary[] dictionaries, int[] correlationDictIds) {
+    dictIdsWrapper._stepsBitmaps[step].add(dictIdsWrapper.getCorrelationId(correlationDictIds));
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/BitmapResultExtractionStrategy.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/BitmapResultExtractionStrategy.java
@@ -26,6 +26,14 @@ import org.roaringbitmap.PeekableIntIterator;
 import org.roaringbitmap.RoaringBitmap;
 
 
+/**
+ * Extracts intermediate bitmap results for cross-segment merging.
+ *
+ * <p>The bitmap strategy stores entities as 32-bit hash codes in a {@link RoaringBitmap}. This is inherently
+ * approximate for non-INT single-key columns (STRING, LONG, FLOAT, DOUBLE use {@code hashCode()}) and for all
+ * multi-key composite keys. Hash collisions can cause two distinct entities to be treated as one, leading to
+ * incorrect funnel step counts. For exact results, use the {@code 'set'} or {@code 'theta_sketch'} strategy.
+ */
 class BitmapResultExtractionStrategy implements ResultExtractionStrategy<DictIdsWrapper, List<RoaringBitmap>> {
   protected final int _numSteps;
 
@@ -42,12 +50,30 @@ class BitmapResultExtractionStrategy implements ResultExtractionStrategy<DictIds
       }
       return result;
     }
-    Dictionary dictionary = dictIdsWrapper._dictionary;
     List<RoaringBitmap> result = new ArrayList<>(_numSteps);
-    for (RoaringBitmap dictIdBitmap : dictIdsWrapper._stepsBitmaps) {
-      result.add(convertToValueBitmap(dictionary, dictIdBitmap));
+    if (dictIdsWrapper.isMultiKey()) {
+      for (RoaringBitmap compositeIdBitmap : dictIdsWrapper._stepsBitmaps) {
+        result.add(convertCompositeToValueBitmap(dictIdsWrapper, compositeIdBitmap));
+      }
+    } else {
+      Dictionary dictionary = dictIdsWrapper._dictionaries[0];
+      for (RoaringBitmap dictIdBitmap : dictIdsWrapper._stepsBitmaps) {
+        result.add(convertToValueBitmap(dictionary, dictIdBitmap));
+      }
     }
     return result;
+  }
+
+  private RoaringBitmap convertCompositeToValueBitmap(DictIdsWrapper wrapper, RoaringBitmap compositeIdBitmap) {
+    RoaringBitmap valueBitmap = new RoaringBitmap();
+    PeekableIntIterator iterator = compositeIdBitmap.getIntIterator();
+    int numKeys = wrapper._dictionaries.length;
+    int[] dictIds = new int[numKeys];
+    while (iterator.hasNext()) {
+      wrapper.reverseDictIds(iterator.next(), dictIds);
+      valueBitmap.add(DictIdsWrapper.toCompositeString(wrapper._dictionaries, dictIds).hashCode());
+    }
+    return valueBitmap;
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/DictIdsWrapper.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/DictIdsWrapper.java
@@ -18,19 +18,138 @@
  */
 package org.apache.pinot.core.query.aggregation.function.funnel;
 
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.roaringbitmap.RoaringBitmap;
 
 
+/**
+ * Holds per-step RoaringBitmaps keyed by correlation dictionary IDs.
+ * For multi-key correlate-by, composite IDs are assigned via stride-based
+ * arithmetic (when the combined key space fits in int) or a HashMap fallback.
+ */
 final class DictIdsWrapper {
-  final Dictionary _dictionary;
+  final Dictionary[] _dictionaries;
   final RoaringBitmap[] _stepsBitmaps;
 
-  DictIdsWrapper(int numSteps, Dictionary dictionary) {
-    _dictionary = dictionary;
+  // Stride-based composite mapping (non-null when product of dict sizes fits in int)
+  private final int[] _strides;
+
+  // HashMap-based composite mapping (non-null when stride overflows int)
+  private final Map<IntArrayList, Integer> _compositeKeyMap;
+  private final List<int[]> _compositeKeyReverse;
+  private final IntArrayList _lookupKey;
+
+  DictIdsWrapper(int numSteps, Dictionary[] dictionaries) {
+    _dictionaries = dictionaries;
     _stepsBitmaps = new RoaringBitmap[numSteps];
     for (int n = 0; n < numSteps; n++) {
       _stepsBitmaps[n] = new RoaringBitmap();
     }
+
+    if (dictionaries.length > 1) {
+      long totalSpace = 1;
+      boolean fitsInInt = true;
+      for (Dictionary d : dictionaries) {
+        totalSpace *= d.length();
+        if (totalSpace > Integer.MAX_VALUE) {
+          fitsInInt = false;
+          break;
+        }
+      }
+
+      if (fitsInInt) {
+        _strides = new int[dictionaries.length];
+        _strides[dictionaries.length - 1] = 1;
+        for (int k = dictionaries.length - 2; k >= 0; k--) {
+          _strides[k] = _strides[k + 1] * dictionaries[k + 1].length();
+        }
+        _compositeKeyMap = null;
+        _compositeKeyReverse = null;
+        _lookupKey = null;
+      } else {
+        _strides = null;
+        _compositeKeyMap = new HashMap<>();
+        _compositeKeyReverse = new ArrayList<>();
+        _lookupKey = new IntArrayList(dictionaries.length);
+      }
+    } else {
+      _strides = null;
+      _compositeKeyMap = null;
+      _compositeKeyReverse = null;
+      _lookupKey = null;
+    }
+  }
+
+  boolean isMultiKey() {
+    return _dictionaries.length > 1;
+  }
+
+  /**
+   * Maps a tuple of per-column dictionary IDs to a single composite int suitable for RoaringBitmap.
+   * For single-key, returns the dict ID directly.
+   */
+  int getCorrelationId(int[] dictIds) {
+    if (dictIds.length == 1) {
+      return dictIds[0];
+    }
+    if (_strides != null) {
+      int id = 0;
+      for (int k = 0; k < dictIds.length; k++) {
+        id += dictIds[k] * _strides[k];
+      }
+      return id;
+    }
+    _lookupKey.clear();
+    for (int dictId : dictIds) {
+      _lookupKey.add(dictId);
+    }
+    Integer existingId = _compositeKeyMap.get(_lookupKey);
+    if (existingId != null) {
+      return existingId;
+    }
+    IntArrayList insertKey = new IntArrayList(dictIds);
+    int id = _compositeKeyReverse.size();
+    _compositeKeyMap.put(insertKey, id);
+    _compositeKeyReverse.add(dictIds.clone());
+    return id;
+  }
+
+  /**
+   * Builds a collision-free composite string from dictionary values using length-prefix encoding.
+   * Each component is encoded as {@code length:value}, e.g. ("alice", "home") becomes "5:alice4:home".
+   */
+  static String toCompositeString(Dictionary[] dictionaries, int[] dictIds) {
+    StringBuilder sb = new StringBuilder();
+    for (int k = 0; k < dictionaries.length; k++) {
+      String val = dictionaries[k].getStringValue(dictIds[k]);
+      sb.append(val.length()).append(':').append(val);
+    }
+    return sb.toString();
+  }
+
+  /**
+   * Reverse-maps a composite ID back to per-column dictionary IDs.
+   */
+  void reverseDictIds(int compositeId, int[] outDictIds) {
+    if (outDictIds.length == 1) {
+      outDictIds[0] = compositeId;
+      return;
+    }
+    if (_strides != null) {
+      int remaining = compositeId;
+      for (int k = 0; k < outDictIds.length - 1; k++) {
+        outDictIds[k] = remaining / _strides[k];
+        remaining %= _strides[k];
+      }
+      outDictIds[outDictIds.length - 1] = remaining;
+      return;
+    }
+    int[] stored = _compositeKeyReverse.get(compositeId);
+    System.arraycopy(stored, 0, outDictIds, 0, outDictIds.length);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/FunnelCountSortedAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/FunnelCountSortedAggregationFunction.java
@@ -34,6 +34,8 @@ import org.apache.pinot.segment.spi.index.reader.Dictionary;
  * It leverages a more efficient counting strategy for segments sorted by correlate_by column, falls back to a regular
  * counting strategy for unsorted segments (e.g. uncommitted segments).
  *
+ * <p>For multi-key correlate-by, the sorted/partitioned optimization applies to the first (primary) column only.
+ *
  * Example:
  *   SELECT
  *    dateTrunc('day', timestamp) AS ts,
@@ -59,14 +61,14 @@ public class FunnelCountSortedAggregationFunction<A> extends FunnelCountAggregat
     super(expressions, stepExpressions, correlateByExpressions, aggregationStrategy, resultExtractionStrategy,
         mergeStrategy);
     _sortedAggregationStrategy = new SortedAggregationStrategy(stepExpressions, correlateByExpressions);
-    _sortedResultExtractionStrategy = SortedAggregationResult::extractResult;;
+    _sortedResultExtractionStrategy = SortedAggregationResult::extractResult;
     _primaryCorrelationCol = correlateByExpressions.get(0);
   }
 
   @Override
   public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    if (isSortedDictionary(blockValSetMap)) {
+    if (isPrimarySortedDictionary(blockValSetMap)) {
       _sortedAggregationStrategy.aggregate(length, aggregationResultHolder, blockValSetMap);
     } else {
       super.aggregate(length, aggregationResultHolder, blockValSetMap);
@@ -76,7 +78,7 @@ public class FunnelCountSortedAggregationFunction<A> extends FunnelCountAggregat
   @Override
   public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    if (isSortedDictionary(blockValSetMap)) {
+    if (isPrimarySortedDictionary(blockValSetMap)) {
       _sortedAggregationStrategy.aggregateGroupBySV(length, groupKeyArray, groupByResultHolder, blockValSetMap);
     } else {
       super.aggregateGroupBySV(length, groupKeyArray, groupByResultHolder, blockValSetMap);
@@ -86,7 +88,7 @@ public class FunnelCountSortedAggregationFunction<A> extends FunnelCountAggregat
   @Override
   public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    if (isSortedDictionary(blockValSetMap)) {
+    if (isPrimarySortedDictionary(blockValSetMap)) {
       _sortedAggregationStrategy.aggregateGroupByMV(length, groupKeysArray, groupByResultHolder, blockValSetMap);
     } else {
       super.aggregateGroupByMV(length, groupKeysArray, groupByResultHolder, blockValSetMap);
@@ -111,15 +113,15 @@ public class FunnelCountSortedAggregationFunction<A> extends FunnelCountAggregat
     }
   }
 
-  private boolean isSortedDictionary(Map<ExpressionContext, BlockValSet> blockValSetMap) {
-    return getDictionary(blockValSetMap).isSorted();
+  private boolean isPrimarySortedDictionary(Map<ExpressionContext, BlockValSet> blockValSetMap) {
+    return getPrimaryDictionary(blockValSetMap).isSorted();
   }
 
   private boolean isSortedAggResult(Object aggResult) {
     return aggResult instanceof SortedAggregationResult;
   }
 
-  private Dictionary getDictionary(Map<ExpressionContext, BlockValSet> blockValSetMap) {
+  private Dictionary getPrimaryDictionary(Map<ExpressionContext, BlockValSet> blockValSetMap) {
     final Dictionary primaryCorrelationDictionary = blockValSetMap.get(_primaryCorrelationCol).getDictionary();
     Preconditions.checkArgument(primaryCorrelationDictionary != null,
         "CORRELATE_BY column in FUNNELCOUNT aggregation function not supported for sorted setting, "

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/SetResultExtractionStrategy.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/SetResultExtractionStrategy.java
@@ -51,12 +51,31 @@ class SetResultExtractionStrategy implements ResultExtractionStrategy<DictIdsWra
       }
       return result;
     }
-    Dictionary dictionary = dictIdsWrapper._dictionary;
     List<Set> result = new ArrayList<>(_numSteps);
-    for (RoaringBitmap dictIdBitmap : dictIdsWrapper._stepsBitmaps) {
-      result.add(convertToValueSet(dictionary, dictIdBitmap));
+    if (dictIdsWrapper.isMultiKey()) {
+      for (RoaringBitmap compositeIdBitmap : dictIdsWrapper._stepsBitmaps) {
+        result.add(convertCompositeToValueSet(dictIdsWrapper, compositeIdBitmap));
+      }
+    } else {
+      Dictionary dictionary = dictIdsWrapper._dictionaries[0];
+      for (RoaringBitmap dictIdBitmap : dictIdsWrapper._stepsBitmaps) {
+        result.add(convertToValueSet(dictionary, dictIdBitmap));
+      }
     }
     return result;
+  }
+
+  private Set<String> convertCompositeToValueSet(DictIdsWrapper wrapper, RoaringBitmap compositeIdBitmap) {
+    int numValues = compositeIdBitmap.getCardinality();
+    int numKeys = wrapper._dictionaries.length;
+    int[] dictIds = new int[numKeys];
+    ObjectOpenHashSet<String> stringSet = new ObjectOpenHashSet<>(numValues);
+    PeekableIntIterator iterator = compositeIdBitmap.getIntIterator();
+    while (iterator.hasNext()) {
+      wrapper.reverseDictIds(iterator.next(), dictIds);
+      stringSet.add(DictIdsWrapper.toCompositeString(wrapper._dictionaries, dictIds));
+    }
+    return stringSet;
   }
 
   private Set convertToValueSet(Dictionary dictionary, RoaringBitmap dictIdBitmap) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/SortedAggregationResult.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/SortedAggregationResult.java
@@ -18,30 +18,55 @@
  */
 package org.apache.pinot.core.query.aggregation.function.funnel;
 
+import it.unimi.dsi.fastutil.ints.IntArrayList;
 import it.unimi.dsi.fastutil.longs.LongArrayList;
+import java.util.HashMap;
+import java.util.Map;
 
 
 /**
  * Aggregation result data structure leveraged by sorted aggregation strategy.
+ *
+ * <p>For single-key, uses simple last-ID tracking since data is sorted by the
+ * correlation column. For multi-key, data is sorted by the primary (first)
+ * correlation column only; secondary keys are tracked via a HashMap within
+ * each primary-key group.
  */
 class SortedAggregationResult {
   final int _numSteps;
   final long[] _stepCounters;
+  private final int _numKeys;
+
+  // Single-key tracking
   final boolean[] _correlatedSteps;
   int _lastCorrelationId = Integer.MIN_VALUE;
 
+  // Multi-key tracking
+  private int _lastPrimaryId = Integer.MIN_VALUE;
+  private Map<IntArrayList, boolean[]> _secondaryKeySteps;
+  private final IntArrayList _lookupKey;
+
   SortedAggregationResult(int numSteps) {
+    this(numSteps, 1);
+  }
+
+  SortedAggregationResult(int numSteps, int numKeys) {
     _numSteps = numSteps;
+    _numKeys = numKeys;
     _stepCounters = new long[_numSteps];
-    _correlatedSteps = new boolean[_numSteps];
+    if (numKeys == 1) {
+      _correlatedSteps = new boolean[_numSteps];
+      _lookupKey = null;
+    } else {
+      _correlatedSteps = null;
+      _secondaryKeySteps = new HashMap<>();
+      _lookupKey = new IntArrayList(numKeys - 1);
+    }
   }
 
   public void add(int step, int correlationId) {
     if (correlationId != _lastCorrelationId) {
-      // End of correlation group, calculate funnel conversion counts
       incrStepCounters();
-
-      // initialize next correlation group
       for (int n = 0; n < _numSteps; n++) {
         _correlatedSteps[n] = false;
       }
@@ -50,7 +75,53 @@ class SortedAggregationResult {
     _correlatedSteps[step] = true;
   }
 
+  /**
+   * Multi-key add. Data must be sorted by correlationIds[0] (primary key).
+   * Secondary keys are tracked via HashMap within each primary-key group.
+   *
+   * <p>Within a primary-key group, rows for the same (primary, secondary) combination may appear
+   * non-contiguously (e.g. interleaved with other secondary keys). This is handled correctly
+   * because the HashMap accumulates all step observations per secondary key regardless of row order.
+   */
+  public void addMultiKey(int step, int[] correlationIds) {
+    int primaryId = correlationIds[0];
+    if (primaryId != _lastPrimaryId) {
+      flushMultiKeyGroup();
+      _lastPrimaryId = primaryId;
+      _secondaryKeySteps.clear();
+    }
+
+    _lookupKey.clear();
+    for (int k = 1; k < correlationIds.length; k++) {
+      _lookupKey.add(correlationIds[k]);
+    }
+
+    boolean[] steps = _secondaryKeySteps.get(_lookupKey);
+    if (steps == null) {
+      steps = new boolean[_numSteps];
+      _secondaryKeySteps.put(new IntArrayList(_lookupKey), steps);
+    }
+    steps[step] = true;
+  }
+
+  private void flushMultiKeyGroup() {
+    if (_secondaryKeySteps == null) {
+      return;
+    }
+    for (boolean[] steps : _secondaryKeySteps.values()) {
+      for (int n = 0; n < _numSteps; n++) {
+        if (!steps[n]) {
+          break;
+        }
+        _stepCounters[n]++;
+      }
+    }
+  }
+
   void incrStepCounters() {
+    if (_correlatedSteps == null) {
+      return;
+    }
     for (int n = 0; n < _numSteps; n++) {
       if (!_correlatedSteps[n]) {
         break;
@@ -60,8 +131,11 @@ class SortedAggregationResult {
   }
 
   public LongArrayList extractResult() {
-    // count last correlation id left open
-    incrStepCounters();
+    if (_numKeys > 1) {
+      flushMultiKeyGroup();
+    } else {
+      incrStepCounters();
+    }
     return LongArrayList.wrap(_stepCounters);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/SortedAggregationResult.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/SortedAggregationResult.java
@@ -46,10 +46,6 @@ class SortedAggregationResult {
   private Map<IntArrayList, boolean[]> _secondaryKeySteps;
   private final IntArrayList _lookupKey;
 
-  SortedAggregationResult(int numSteps) {
-    this(numSteps, 1);
-  }
-
   SortedAggregationResult(int numSteps, int numKeys) {
     _numSteps = numSteps;
     _numKeys = numKeys;
@@ -105,9 +101,6 @@ class SortedAggregationResult {
   }
 
   private void flushMultiKeyGroup() {
-    if (_secondaryKeySteps == null) {
-      return;
-    }
     for (boolean[] steps : _secondaryKeySteps.values()) {
       for (int n = 0; n < _numSteps; n++) {
         if (!steps[n]) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/SortedAggregationStrategy.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/SortedAggregationStrategy.java
@@ -25,6 +25,8 @@ import org.apache.pinot.segment.spi.index.reader.Dictionary;
 
 /**
  * Aggregation strategy for segments partitioned and sorted by the main correlation column.
+ * For multi-key correlate-by, data must be sorted by the first (primary) column; secondary
+ * keys are handled within each primary-key group by {@link SortedAggregationResult}.
  */
 class SortedAggregationStrategy extends AggregationStrategy<SortedAggregationResult> {
   public SortedAggregationStrategy(List<ExpressionContext> stepExpressions,
@@ -33,12 +35,16 @@ class SortedAggregationStrategy extends AggregationStrategy<SortedAggregationRes
   }
 
   @Override
-  public SortedAggregationResult createAggregationResult(Dictionary dictionary) {
-    return new SortedAggregationResult(_numSteps);
+  public SortedAggregationResult createAggregationResult(Dictionary[] dictionaries) {
+    return new SortedAggregationResult(_numSteps, dictionaries.length);
   }
 
   @Override
-  void add(Dictionary dictionary, SortedAggregationResult aggResult, int step, int correlationId) {
-    aggResult.add(step, correlationId);
+  void add(SortedAggregationResult aggResult, int step, Dictionary[] dictionaries, int[] correlationDictIds) {
+    if (correlationDictIds.length == 1) {
+      aggResult.add(step, correlationDictIds[0]);
+    } else {
+      aggResult.addMultiKey(step, correlationDictIds);
+    }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/ThetaSketchAggregationStrategy.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/funnel/ThetaSketchAggregationStrategy.java
@@ -38,7 +38,7 @@ class ThetaSketchAggregationStrategy extends AggregationStrategy<UpdateSketch[]>
   }
 
   @Override
-  public UpdateSketch[] createAggregationResult(Dictionary dictionary) {
+  public UpdateSketch[] createAggregationResult(Dictionary[] dictionaries) {
     final UpdateSketch[] stepsSketches = new UpdateSketch[_numSteps];
     for (int n = 0; n < _numSteps; n++) {
       stepsSketches[n] = _updateSketchBuilder.build();
@@ -47,8 +47,16 @@ class ThetaSketchAggregationStrategy extends AggregationStrategy<UpdateSketch[]>
   }
 
   @Override
-  void add(Dictionary dictionary, UpdateSketch[] stepsSketches, int step, int correlationId) {
+  void add(UpdateSketch[] stepsSketches, int step, Dictionary[] dictionaries, int[] correlationDictIds) {
     final UpdateSketch sketch = stepsSketches[step];
+    if (dictionaries.length == 1) {
+      addSingleKey(sketch, dictionaries[0], correlationDictIds[0]);
+    } else {
+      addCompositeKey(sketch, dictionaries, correlationDictIds);
+    }
+  }
+
+  private void addSingleKey(UpdateSketch sketch, Dictionary dictionary, int correlationId) {
     switch (dictionary.getValueType()) {
       case INT:
         sketch.update(dictionary.getIntValue(correlationId));
@@ -66,8 +74,13 @@ class ThetaSketchAggregationStrategy extends AggregationStrategy<UpdateSketch[]>
         sketch.update(dictionary.getStringValue(correlationId));
         break;
       default:
-        throw new IllegalStateException("Illegal CORRELATED_BY column data type for FUNNEL_COUNT aggregation function: "
-            + dictionary.getValueType());
+        throw new IllegalStateException(
+            "Illegal CORRELATED_BY column data type for FUNNEL_COUNT aggregation function: "
+                + dictionary.getValueType());
     }
+  }
+
+  private void addCompositeKey(UpdateSketch sketch, Dictionary[] dictionaries, int[] correlationDictIds) {
+    sketch.update(DictIdsWrapper.toCompositeString(dictionaries, correlationDictIds));
   }
 }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/FunnelCountTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/FunnelCountTest.java
@@ -46,8 +46,8 @@ import static org.testng.Assert.assertNotNull;
  *
  * <p>Each segment contains multiple category values (electronics, clothing, home) to
  * exercise GROUP BY across categories within a single segment. Users 3 and 9 are
- * "cross-category" — their funnel actions span two categories, which is specifically
- * designed to support future "hold constant columns" feature testing.
+ * "cross-category" — their funnel actions span two categories, which specifically
+ * tests the multi-key correlate-by feature.
  *
  * <h3>Test data layout (2 segments)</h3>
  * <pre>
@@ -93,10 +93,17 @@ import static org.testng.Assert.assertNotNull;
  *
  * <h3>Expected funnel counts</h3>
  * <pre>
- * Overall:       [12, 10, 6, 3]
- * clothing:      [ 4,  4, 2, 2]
- * electronics:   [ 5,  4, 2, 1]
- * home:          [ 3,  2, 0, 0]
+ * Single-key CORRELATE_BY(user_id):
+ *   Overall:       [12, 10, 6, 3]
+ *   clothing:      [ 4,  4, 2, 2]
+ *   electronics:   [ 5,  4, 2, 1]
+ *   home:          [ 3,  2, 0, 0]
+ *
+ * Multi-key CORRELATE_BY(user_id, category):
+ *   Overall:       [12, 10, 4, 3]   (step 3 drops from 6→4: users 3,9 cross-category)
+ *   clothing:      [ 4,  4, 2, 2]   (same — grouping already separates by category)
+ *   electronics:   [ 5,  4, 2, 1]   (same)
+ *   home:          [ 3,  2, 0, 0]   (same)
  * </pre>
  */
 @Test(suiteName = "CustomClusterIntegrationTest")
@@ -117,6 +124,11 @@ public class FunnelCountTest extends CustomDataQueryClusterIntegrationTest {
   private static final long[] EXPECTED_ELECTRONICS = {5, 4, 2, 1};
   private static final long[] EXPECTED_CLOTHING = {4, 4, 2, 2};
   private static final long[] EXPECTED_HOME = {3, 2, 0, 0};
+
+  // Multi-key: CORRELATE_BY(user_id, category)
+  // Cross-category users 3 and 9 no longer complete checkout within a single category.
+  private static final long[] EXPECTED_MULTI_KEY_OVERALL = {12, 10, 4, 3};
+  private static final long[] EXPECTED_MULTI_KEY_FILTERED = {7, 6, 3, 3};
 
   @Override
   protected long getCountStarResult() {
@@ -222,6 +234,14 @@ public class FunnelCountTest extends CustomDataQueryClusterIntegrationTest {
         + "%7$s)", ACTION_COL, VIEW, CART, CHECKOUT, PURCHASE, USER_ID_COL, settingsClause);
   }
 
+  private String funnelCountMultiKeyAggregation(String settings) {
+    String settingsClause = (settings == null) ? "" : ", SETTINGS(" + settings + ")";
+    return String.format("FUNNEL_COUNT("
+        + "STEPS(%1$s = '%2$s', %1$s = '%3$s', %1$s = '%4$s', %1$s = '%5$s'), "
+        + "CORRELATE_BY(%6$s, %7$s)"
+        + "%8$s)", ACTION_COL, VIEW, CART, CHECKOUT, PURCHASE, USER_ID_COL, CATEGORY_COL, settingsClause);
+  }
+
   private String overallQuery(String settings) {
     return String.format("SELECT %s FROM %s", funnelCountAggregation(settings), TABLE_NAME);
   }
@@ -229,6 +249,15 @@ public class FunnelCountTest extends CustomDataQueryClusterIntegrationTest {
   private String groupByQuery(String settings) {
     return String.format("SELECT %s, %s FROM %s GROUP BY %s ORDER BY %s",
         CATEGORY_COL, funnelCountAggregation(settings), TABLE_NAME, CATEGORY_COL, CATEGORY_COL);
+  }
+
+  private String overallMultiKeyQuery(String settings) {
+    return String.format("SELECT %s FROM %s", funnelCountMultiKeyAggregation(settings), TABLE_NAME);
+  }
+
+  private String groupByMultiKeyQuery(String settings) {
+    return String.format("SELECT %s, %s FROM %s GROUP BY %s ORDER BY %s",
+        CATEGORY_COL, funnelCountMultiKeyAggregation(settings), TABLE_NAME, CATEGORY_COL, CATEGORY_COL);
   }
 
   // ---------- assertion helpers ----------
@@ -275,6 +304,8 @@ public class FunnelCountTest extends CustomDataQueryClusterIntegrationTest {
         {"'partitioned'"}, {"'partitioned', 'theta_sketch'"}, {"'partitioned', 'sorted'"}
     };
   }
+
+  // ===================== Single-key tests =====================
 
   @Test(dataProvider = "allStrategies")
   public void testOverall(String settings)
@@ -338,7 +369,7 @@ public class FunnelCountTest extends CustomDataQueryClusterIntegrationTest {
     return new Object[][]{{null}, {"'partitioned'"}, {"'partitioned', 'sorted'"}};
   }
 
-  @Test(dataProvider = "filteredStrategies")
+  @Test(dataProvider = "allStrategies")
   public void testWithFilter(String settings)
       throws Exception {
     setUseMultiStageQueryEngine(false);
@@ -393,5 +424,38 @@ public class FunnelCountTest extends CustomDataQueryClusterIntegrationTest {
     setUseMultiStageQueryEngine(false);
     JsonNode rows = getRows(postQuery(emptyResultGroupByQuery(settings)));
     assertEquals(rows.size(), 0, "Expected zero groups when all rows are filtered");
+  }
+
+  // ===================== Multi-key CORRELATE_BY tests =====================
+
+  @Test(dataProvider = "allStrategies")
+  public void testMultiKeyOverall(String settings)
+      throws Exception {
+    setUseMultiStageQueryEngine(false);
+    JsonNode rows = getRows(postQuery(overallMultiKeyQuery(settings)));
+    assertOverallResult(rows, EXPECTED_MULTI_KEY_OVERALL);
+  }
+
+  @Test(dataProvider = "allStrategies")
+  public void testMultiKeyGroupBy(String settings)
+      throws Exception {
+    setUseMultiStageQueryEngine(false);
+    JsonNode rows = getRows(postQuery(groupByMultiKeyQuery(settings)));
+    // Group-by category with CORRELATE_BY(user_id, category) produces the same results
+    // as single-key because grouping already separates rows by category.
+    assertGroupByResult(rows);
+  }
+
+  private String filteredMultiKeyQuery(String settings) {
+    return overallMultiKeyQuery(settings) + " WHERE " + USER_ID_COL + " <= 7";
+  }
+
+  @Test(dataProvider = "filteredStrategies")
+  public void testMultiKeyWithFilter(String settings)
+      throws Exception {
+    setUseMultiStageQueryEngine(false);
+    JsonNode rows = getRows(postQuery(filteredMultiKeyQuery(settings)));
+    assertEquals(rows.size(), 1);
+    assertStepCounts(rows.get(0).get(0), EXPECTED_MULTI_KEY_FILTERED);
   }
 }


### PR DESCRIPTION
  ## Summary                                                                                                                                                                      
                                                                                                                                                                                 
  Extends `FUNNEL_COUNT` to accept multiple columns in `CORRELATE_BY(col1, col2, ...)`, enabling funnel                                                                          
  analysis that tracks users through steps within a composite key (e.g., per user per category), not just                                                                        
  a single dimension.                                                                                                                                                            
                                                                  
  ### Changes                                                                                                                                                                     
                                                                  
  - **`AggregationStrategy`**: Generalized all aggregation paths (`aggregate`, `aggregateGroupBySV`,                                                                             
    `aggregateGroupByMV`) from a single `Dictionary`/`correlationId` to `Dictionary[]`/`int[]` tuples.
    The `add` abstract method signature updated accordingly across all strategy implementations                                                                                  
    (`BitmapAggregationStrategy`, `SortedAggregationStrategy`, `ThetaSketchAggregationStrategy`).                                                                                
  - **`DictIdsWrapper`**: Added composite-key mapping for multi-column `CORRELATE_BY`. Uses stride-based                                                                         
    arithmetic when the product of dictionary sizes fits in `int`, falling back to a                                                                                             
    `HashMap<IntArrayList, Integer>` for large key spaces. Also adds `toCompositeString` for                                                                                     
    length-prefix encoded composite string keys (used by `SetResultExtractionStrategy` /                                                                                         
    `BitmapResultExtractionStrategy`).                                                                                                                                           
  - **`SortedAggregationResult`**: Updated to carry `Dictionary[]` and handle multi-key extraction at                                                                            
    result merge time.                                                                                                                                                           
  - **`FunnelCountSortedAggregationFunction`**, **`SetResultExtractionStrategy`**,
    **`BitmapResultExtractionStrategy`**: Updated to propagate the multi-dictionary context through the                                                                          
    result extraction pipeline.                                   
  - **`FunnelCountTest`** (integration test): Added `testMultiKeyOverall`, `testMultiKeyGroupBy`, and                                                                            
    `testMultiKeyWithFilter` covering all aggregation strategies, with expected results documented inline                                                                        
    against a cross-category user dataset.                                                                                                                                       
                                                                                                                                                                                 
  ## Test Plan                                                                                                                                                                   
                                                                  
  - [x] Run existing single-key funnel integration tests:                                                                                                                        
    ./mvnw -pl pinot-integration-tests -am -Dtest=FunnelCountTest -Dsurefire.failIfNoSpecifiedTests=false test
  - [x] New multi-key tests (`testMultiKeyOverall`, `testMultiKeyGroupBy`, `testMultiKeyWithFilter`) pass                                                                        
  for all strategies (BITMAP, SORTED, THETA_SKETCH, SET)                                                 
  - [x] Verify single-key `CORRELATE_BY` behavior is unchanged (stride path reduces to identity for a                                                                            
  single dictionary)    