### PR TITLE
Refactor: convert RealtimeOffsetAutoResetHandler to interface with init(); fix nonLeaderCleanup

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/periodictask/RealtimeOffsetAutoResetHandler.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/periodictask/RealtimeOffsetAutoResetHandler.java
@@ -28,31 +28,29 @@ public interface RealtimeOffsetAutoResetHandler {
 
   /**
    * Initialize the handler with the PinotLLCRealtimeSegmentManager and PinotHelixResourceManager.
-   * This is called once in constructor.
+   * This is called once after instantiation.
    */
-  public abstract void init(
-      PinotLLCRealtimeSegmentManager llcRealtimeSegmentManager, PinotHelixResourceManager pinotHelixResourceManager);
+  void init(PinotLLCRealtimeSegmentManager llcRealtimeSegmentManager,
+      PinotHelixResourceManager pinotHelixResourceManager);
 
   /**
    * Trigger the job to backfill the skipped interval due to offset auto reset.
    * It is expected to backfill the [fromOffset, toOffset) interval.
    * @return if successfully started the backfill job
    */
-  public abstract boolean triggerBackfillJob(
-      String tableNameWithType, StreamConfig streamConfig, String topicName, int partitionId, long fromOffset,
-      long toOffset);
+  boolean triggerBackfillJob(String tableNameWithType, StreamConfig streamConfig, String topicName, int partitionId,
+      long fromOffset, long toOffset);
 
   /**
    * Ensure all topics under the table are being backfilled. It is the caller's responsibility to figure out what
    * topic set it should check.
    */
-  public abstract void ensureBackfillJobsRunning(String tableNameWithType, Collection<String> topicNames);
+  void ensureBackfillJobsRunning(String tableNameWithType, Collection<String> topicNames);
 
   /**
    * Return the Collection of completed and cleaned up topicNames from the input.
    */
-  public abstract Collection<String> cleanupCompletedBackfillJobs(
-      String tableNameWithType, Collection<String> topicNames);
+  Collection<String> cleanupCompletedBackfillJobs(String tableNameWithType, Collection<String> topicNames);
 
-  public abstract void close();
+  void close();
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/periodictask/RealtimeOffsetAutoResetKafkaHandler.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/periodictask/RealtimeOffsetAutoResetKafkaHandler.java
@@ -52,11 +52,6 @@ public abstract class RealtimeOffsetAutoResetKafkaHandler implements RealtimeOff
   private static final Logger LOGGER = LoggerFactory.getLogger(RealtimeOffsetAutoResetKafkaHandler.class);
   private static final String STREAM_TYPE = "kafka";
 
-  public RealtimeOffsetAutoResetKafkaHandler(PinotLLCRealtimeSegmentManager llcRealtimeSegmentManager,
-      PinotHelixResourceManager pinotHelixResourceManager) {
-    init(llcRealtimeSegmentManager, pinotHelixResourceManager);
-  }
-
   @Override
   public void init(PinotLLCRealtimeSegmentManager llcRealtimeSegmentManager,
       PinotHelixResourceManager pinotHelixResourceManager) {
@@ -104,7 +99,7 @@ public abstract class RealtimeOffsetAutoResetKafkaHandler implements RealtimeOff
       String tableNameWithType, StreamConfig streamConfig, String topicName, int partitionId, long fromOffset,
       long toOffset);
 
-  public abstract void ensureBackfillJobsRunning(String tableNameWithType, List<String> topicNames);
+  public abstract void ensureBackfillJobsRunning(String tableNameWithType, Collection<String> topicNames);
 
   /**
    * Cleanup completed backfill jobs by checking if the topic is complete.

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/periodictask/RealtimeOffsetAutoResetKafkaHandler.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/periodictask/RealtimeOffsetAutoResetKafkaHandler.java
@@ -52,6 +52,19 @@ public abstract class RealtimeOffsetAutoResetKafkaHandler implements RealtimeOff
   private static final Logger LOGGER = LoggerFactory.getLogger(RealtimeOffsetAutoResetKafkaHandler.class);
   private static final String STREAM_TYPE = "kafka";
 
+  /**
+   * @deprecated Use no-arg constructor + {@link #init} instead.
+   *     Kept for backward compatibility with subclasses compiled against the previous constructor-based contract.
+   */
+  @Deprecated
+  protected RealtimeOffsetAutoResetKafkaHandler(PinotLLCRealtimeSegmentManager llcRealtimeSegmentManager,
+      PinotHelixResourceManager pinotHelixResourceManager) {
+    init(llcRealtimeSegmentManager, pinotHelixResourceManager);
+  }
+
+  protected RealtimeOffsetAutoResetKafkaHandler() {
+  }
+
   @Override
   public void init(PinotLLCRealtimeSegmentManager llcRealtimeSegmentManager,
       PinotHelixResourceManager pinotHelixResourceManager) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/periodictask/RealtimeOffsetAutoResetKafkaHandler.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/periodictask/RealtimeOffsetAutoResetKafkaHandler.java
@@ -99,8 +99,6 @@ public abstract class RealtimeOffsetAutoResetKafkaHandler implements RealtimeOff
       String tableNameWithType, StreamConfig streamConfig, String topicName, int partitionId, long fromOffset,
       long toOffset);
 
-  public abstract void ensureBackfillJobsRunning(String tableNameWithType, Collection<String> topicNames);
-
   /**
    * Cleanup completed backfill jobs by checking if the topic is complete.
    * If it is complete, pause the topic consumption.

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeOffsetAutoResetManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeOffsetAutoResetManager.java
@@ -191,6 +191,7 @@ public class RealtimeOffsetAutoResetManager extends ControllerPeriodicTask<Realt
   protected void nonLeaderCleanup(List<String> tableNamesWithType) {
     for (String tableNameWithType : tableNamesWithType) {
       _tableTopicsUnderBackfill.remove(tableNameWithType);
+      _tableBackfillTopics.remove(tableNameWithType);
       _tableToHandler.remove(tableNameWithType);
     }
   }
@@ -214,13 +215,11 @@ public class RealtimeOffsetAutoResetManager extends ControllerPeriodicTask<Realt
     try {
       Class<?> clazz = Class.forName(className);
       if (!RealtimeOffsetAutoResetHandler.class.isAssignableFrom(clazz)) {
-        String exceptionMessage = "Custom analyzer must be a child of "
-            + RealtimeOffsetAutoResetHandler.class.getCanonicalName();
-        throw new ReflectiveOperationException(exceptionMessage);
+        throw new ReflectiveOperationException("Custom handler must implement "
+            + RealtimeOffsetAutoResetHandler.class.getCanonicalName());
       }
-      handler = (RealtimeOffsetAutoResetHandler) clazz.getConstructor(
-          PinotLLCRealtimeSegmentManager.class, PinotHelixResourceManager.class).newInstance(
-          _llcRealtimeSegmentManager, _pinotHelixResourceManager);
+      handler = (RealtimeOffsetAutoResetHandler) clazz.getConstructor().newInstance();
+      handler.init(_llcRealtimeSegmentManager, _pinotHelixResourceManager);
       _tableToHandler.put(tableConfig.getTableName(), handler);
       return handler;
     } catch (Exception e) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeOffsetAutoResetManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeOffsetAutoResetManager.java
@@ -218,8 +218,19 @@ public class RealtimeOffsetAutoResetManager extends ControllerPeriodicTask<Realt
         throw new ReflectiveOperationException("Custom handler must implement "
             + RealtimeOffsetAutoResetHandler.class.getCanonicalName());
       }
-      handler = (RealtimeOffsetAutoResetHandler) clazz.getConstructor().newInstance();
-      handler.init(_llcRealtimeSegmentManager, _pinotHelixResourceManager);
+      try {
+        // Preferred: no-arg constructor + explicit init()
+        handler = (RealtimeOffsetAutoResetHandler) clazz.getConstructor().newInstance();
+        handler.init(_llcRealtimeSegmentManager, _pinotHelixResourceManager);
+      } catch (NoSuchMethodException e) {
+        // Backward-compatibility fallback: 2-arg constructor (deprecated SPI contract).
+        // Handlers compiled against the previous contract called init() from their own constructor.
+        LOGGER.warn("Handler class {} has no no-arg constructor; falling back to deprecated 2-arg constructor. "
+            + "Please migrate to a no-arg constructor + init() pattern.", className);
+        handler = (RealtimeOffsetAutoResetHandler) clazz.getConstructor(
+            PinotLLCRealtimeSegmentManager.class, PinotHelixResourceManager.class)
+            .newInstance(_llcRealtimeSegmentManager, _pinotHelixResourceManager);
+      }
       _tableToHandler.put(tableConfig.getTableName(), handler);
       return handler;
     } catch (Exception e) {

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/validation/RealtimeOffsetAutoResetManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/validation/RealtimeOffsetAutoResetManagerTest.java
@@ -208,12 +208,18 @@ public class RealtimeOffsetAutoResetManagerTest {
 
   @Test
   public void testNonLeaderCleanup() {
-    List<String> tableNames = Arrays.asList(REALTIME_TABLE_NAME, OFFLINE_TABLE_NAME);
+    // Populate a handler for the realtime table
+    TableConfig tableConfig = createTableConfigWithValidHandlerClass();
+    RealtimeOffsetAutoResetManager.Context context = _realtimeOffsetAutoResetManager.preprocess(new Properties());
+    when(_pinotHelixResourceManager.getTableConfig(REALTIME_TABLE_NAME)).thenReturn(tableConfig);
+    _realtimeOffsetAutoResetManager.processTable(REALTIME_TABLE_NAME, context);
+    Assert.assertNotNull(_realtimeOffsetAutoResetManager.getTableHandler(REALTIME_TABLE_NAME));
 
+    // nonLeaderCleanup should remove the handler and all state for those tables
+    List<String> tableNames = Arrays.asList(REALTIME_TABLE_NAME, OFFLINE_TABLE_NAME);
     _realtimeOffsetAutoResetManager.nonLeaderCleanup(tableNames);
 
-    // The cleanup should remove the tables from internal maps
-    // This is tested indirectly by verifying the method completes without exception
+    Assert.assertNull(_realtimeOffsetAutoResetManager.getTableHandler(REALTIME_TABLE_NAME));
   }
 
   @Test
@@ -305,9 +311,7 @@ public class RealtimeOffsetAutoResetManagerTest {
     public PinotHelixResourceManager _pinotHelixResourceManager;
     public boolean _triggedBackfillJob = false;
 
-    public TestRealtimeOffsetAutoResetHandler(PinotLLCRealtimeSegmentManager llcRealtimeSegmentManager,
-        PinotHelixResourceManager pinotHelixResourceManager) {
-      init(llcRealtimeSegmentManager, pinotHelixResourceManager);
+    public TestRealtimeOffsetAutoResetHandler() {
     }
 
     @Override

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/validation/RealtimeOffsetAutoResetManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/validation/RealtimeOffsetAutoResetManagerTest.java
@@ -57,6 +57,8 @@ public class RealtimeOffsetAutoResetManagerTest {
   private static final String TOPIC_NAME = "testTopic";
   private static final String TEST_HANDLER_CLASS_NAME =
       "org.apache.pinot.controller.validation.RealtimeOffsetAutoResetManagerTest$TestRealtimeOffsetAutoResetHandler";
+  private static final String LEGACY_HANDLER_CLASS_NAME =
+      "org.apache.pinot.controller.validation.RealtimeOffsetAutoResetManagerTest$LegacyRealtimeOffsetAutoResetHandler";
 
   @Mock
   private PinotLLCRealtimeSegmentManager _llcRealtimeSegmentManager;
@@ -302,6 +304,39 @@ public class RealtimeOffsetAutoResetManagerTest {
     return tableConfig;
   }
 
+  @Test
+  public void testGetOrConstructHandlerWithLegacyConstructorFallback() {
+    // Verify that handlers compiled against the old 2-arg constructor contract still load correctly
+    TableConfig tableConfig = createTableConfigWithLegacyHandlerClass();
+    RealtimeOffsetAutoResetManager.Context context = _realtimeOffsetAutoResetManager.preprocess(new Properties());
+    when(_pinotHelixResourceManager.getTableConfig(REALTIME_TABLE_NAME)).thenReturn(tableConfig);
+
+    _realtimeOffsetAutoResetManager.processTable(REALTIME_TABLE_NAME, context);
+
+    RealtimeOffsetAutoResetHandler handler = _realtimeOffsetAutoResetManager.getTableHandler(REALTIME_TABLE_NAME);
+    Assert.assertNotNull(handler, "Legacy handler should be instantiated via 2-arg constructor fallback");
+    Assert.assertTrue(handler instanceof LegacyRealtimeOffsetAutoResetHandler);
+    LegacyRealtimeOffsetAutoResetHandler legacyHandler = (LegacyRealtimeOffsetAutoResetHandler) handler;
+    Assert.assertNotNull(legacyHandler._llcRealtimeSegmentManager, "init() should have been called via constructor");
+    Assert.assertNotNull(legacyHandler._pinotHelixResourceManager, "init() should have been called via constructor");
+  }
+
+  private TableConfig createTableConfigWithLegacyHandlerClass() {
+    TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(REALTIME_TABLE_NAME).build();
+    IngestionConfig ingestionConfig = new IngestionConfig();
+    Map<String, String> streamConfigMap = new HashMap<>();
+    streamConfigMap.put("streamType", "kafka");
+    streamConfigMap.put("stream.kafka.topic.name", TOPIC_NAME);
+    streamConfigMap.put("stream.kafka.consumer.type", "simple");
+    streamConfigMap.put("realtime.segment.offsetAutoReset.timeSecThreshold", "1800");
+    streamConfigMap.put("stream.kafka.decoder.class.name", "testDecoder");
+    StreamIngestionConfig streamIngestionConfig = new StreamIngestionConfig(Collections.singletonList(streamConfigMap));
+    streamIngestionConfig.setRealtimeOffsetAutoResetHandlerClass(LEGACY_HANDLER_CLASS_NAME);
+    ingestionConfig.setStreamIngestionConfig(streamIngestionConfig);
+    tableConfig.setIngestionConfig(ingestionConfig);
+    return tableConfig;
+  }
+
   /**
    * Test implementation of RealtimeOffsetAutoResetHandler for testing purposes
    */
@@ -336,6 +371,47 @@ public class RealtimeOffsetAutoResetManagerTest {
     @Override
     public Collection<String> cleanupCompletedBackfillJobs(String tableNameWithType, Collection<String> topicNames) {
       // Test implementation - return empty collection
+      return Collections.emptyList();
+    }
+
+    @Override
+    public void close() {
+    }
+  }
+
+  /**
+   * Legacy handler that only has a 2-arg constructor (the old SPI contract).
+   * Used to verify backward-compatibility fallback in getOrConstructHandler().
+   */
+  public static class LegacyRealtimeOffsetAutoResetHandler implements RealtimeOffsetAutoResetHandler {
+
+    public PinotLLCRealtimeSegmentManager _llcRealtimeSegmentManager;
+    public PinotHelixResourceManager _pinotHelixResourceManager;
+
+    public LegacyRealtimeOffsetAutoResetHandler(PinotLLCRealtimeSegmentManager llcRealtimeSegmentManager,
+        PinotHelixResourceManager pinotHelixResourceManager) {
+      init(llcRealtimeSegmentManager, pinotHelixResourceManager);
+    }
+
+    @Override
+    public void init(PinotLLCRealtimeSegmentManager llcRealtimeSegmentManager,
+        PinotHelixResourceManager pinotHelixResourceManager) {
+      _llcRealtimeSegmentManager = llcRealtimeSegmentManager;
+      _pinotHelixResourceManager = pinotHelixResourceManager;
+    }
+
+    @Override
+    public boolean triggerBackfillJob(String tableNameWithType, StreamConfig streamConfig, String topicName,
+        int partitionId, long fromOffset, long toOffset) {
+      return true;
+    }
+
+    @Override
+    public void ensureBackfillJobsRunning(String tableNameWithType, Collection<String> topicNames) {
+    }
+
+    @Override
+    public Collection<String> cleanupCompletedBackfillJobs(String tableNameWithType, Collection<String> topicNames) {
       return Collections.emptyList();
     }
 


### PR DESCRIPTION
Addresses review feedback from #15782 (Jackie-Jiang) that was not carried over when the feature was split and merged as #16492, #16692, and #16724:            
                                         
  - Removed redundant `public abstract` modifiers from `RealtimeOffsetAutoResetHandler` interface methods; updated `init()` javadoc to reflect it is called after
   instantiation, not in a constructor                                                                                                                           
  - Removed constructor injection from `RealtimeOffsetAutoResetKafkaHandler`; initialization now happens via `init()` called by the manager after reflective     
  instantiation                                                                                                                                                  
  - Fixed `ensureBackfillJobsRunning` signature: `List<String>` → `Collection<String>` to match the interface contract
  - Updated `RealtimeOffsetAutoResetManager.getOrConstructHandler()` to use no-arg constructor + `init()` instead of constructor injection via reflection        
  - Fixed bug in `nonLeaderCleanup()`: was not clearing `_tableBackfillTopics`, leaving stale state when the controller re-acquires leadership                   
   
                                                                                                                                                               
  ## Changes                                                
                                                                                                                                                                 
  | File | Change |                                         
  |---|---|
  | `RealtimeOffsetAutoResetHandler.java` | Abstract class → interface; added `init()` |
  | `RealtimeOffsetAutoResetKafkaHandler.java` | Implements interface; removed constructor; fixed `Collection<String>` signature |                               
  | `RealtimeOffsetAutoResetManager.java` | Uses no-arg constructor + `init()`; fixed `nonLeaderCleanup()` |

 ## Labels                                                                                                                                                      
  `refactor`, `release-notes`                                             