### PR TITLE
Export Adaptive Routing Stats as broker metrics

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerGauge.java
@@ -65,6 +65,13 @@ public enum BrokerGauge implements AbstractMetrics.Gauge {
   ADAPTIVE_SERVER_SELECTOR_TYPE("adaptiveServerSelectorType", true),
 
   /**
+   * Per-server adaptive routing stats exported as metrics.
+   */
+  ADAPTIVE_SERVER_NUM_IN_FLIGHT_REQUESTS("adaptiveServerNumInFlightRequests", false),
+  ADAPTIVE_SERVER_LATENCY_EMA("adaptiveServerLatencyEma", false),
+  ADAPTIVE_SERVER_HYBRID_SCORE("adaptiveServerHybridScore", false),
+
+  /**
    * The queue size of ServerRoutingStatsManager main executor service.
    */
   ROUTING_STATS_MANAGER_QUEUE_SIZE("routingStatsManagerQueueSize", true),

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsManager.java
@@ -28,6 +28,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pinot.common.metrics.BrokerGauge;
@@ -63,6 +64,7 @@ public class ServerRoutingStatsManager {
   private long _warmupDurationMs;
   private double _avgInitializationVal;
   private int _hybridScoreExponent;
+  private boolean _enableStatsMetricExport;
 
   public ServerRoutingStatsManager(PinotConfiguration pinotConfig, BrokerMetrics brokerMetrics) {
     _config = pinotConfig;
@@ -99,6 +101,16 @@ public class ServerRoutingStatsManager {
     // Entries in this map are never deleted unless the broker process restarts. This is okay for now because the
     // number of servers will be finite and should not cause memory bloat.
     _serverQueryStatsMap = new ConcurrentHashMap<>();
+
+    _enableStatsMetricExport = _config.getProperty(AdaptiveServerSelector.CONFIG_OF_ENABLE_STATS_METRIC_EXPORT,
+        AdaptiveServerSelector.DEFAULT_ENABLE_STATS_METRIC_EXPORT);
+    if (_enableStatsMetricExport) {
+      long intervalMs = _config.getProperty(AdaptiveServerSelector.CONFIG_OF_STATS_METRIC_EXPORT_INTERVAL_MS,
+          AdaptiveServerSelector.DEFAULT_STATS_METRIC_EXPORT_INTERVAL_MS);
+      _periodicTaskExecutor.scheduleAtFixedRate(this::exportStatsAsMetrics, intervalMs, intervalMs,
+          TimeUnit.MILLISECONDS);
+      LOGGER.info("Adaptive server routing stats metric export enabled with interval {}ms.", intervalMs);
+    }
   }
 
   public boolean isEnabled() {
@@ -389,5 +401,36 @@ public class ServerRoutingStatsManager {
   private void recordQueueSizeMetrics() {
     int queueSize = getQueueSize();
     _brokerMetrics.setValueOfGlobalGauge(BrokerGauge.ROUTING_STATS_MANAGER_QUEUE_SIZE, queueSize);
+  }
+
+  private void exportStatsAsMetrics() {
+    try {
+      for (Map.Entry<String, ServerRoutingStatsEntry> entry : _serverQueryStatsMap.entrySet()) {
+        String serverInstanceId = entry.getKey();
+        ServerRoutingStatsEntry stats = entry.getValue();
+
+        int numInFlightRequests;
+        double latencyEma;
+        double hybridScore;
+
+        stats.getServerReadLock().lock();
+        try {
+          numInFlightRequests = stats.getNumInFlightRequests();
+          latencyEma = stats.getLatencyEMA();
+          hybridScore = stats.computeHybridScore();
+        } finally {
+          stats.getServerReadLock().unlock();
+        }
+
+        _brokerMetrics.setValueOfGlobalGauge(BrokerGauge.ADAPTIVE_SERVER_NUM_IN_FLIGHT_REQUESTS,
+            "server." + serverInstanceId, numInFlightRequests);
+        _brokerMetrics.setValueOfGlobalGauge(BrokerGauge.ADAPTIVE_SERVER_LATENCY_EMA, "server." + serverInstanceId,
+            (long) latencyEma);
+        _brokerMetrics.setValueOfGlobalGauge(BrokerGauge.ADAPTIVE_SERVER_HYBRID_SCORE, "server." + serverInstanceId,
+            (long) hybridScore);
+      }
+    } catch (Exception e) {
+      LOGGER.error("Exception caught while exporting routing stats as metrics.", e);
+    }
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsManagerTest.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.pinot.common.metrics.BrokerGauge;
 import org.apache.pinot.common.metrics.BrokerMetrics;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.metrics.PinotMetricUtils;
@@ -311,6 +312,103 @@ public class ServerRoutingStatsManagerTest {
     assertEquals(score, 10.0);
     score = manager.fetchHybridScoreForServer("server1");
     assertEquals(score, 54.0);
+
+    // assert true to ensure server1 is in the stats map
+    assertTrue(manager.resetServerStats("server1"));
+
+    // ensure server2 has not changeed
+    score = manager.fetchHybridScoreForServer("server2");
+    assertEquals(score, 10.0);
+    assertStatsNullForInstance(manager, "server1");
+
+    manager.resetAllServersStats();
+    assertStatsNullForInstance(manager, "server1");
+    assertStatsNullForInstance(manager, "server2");
+  }
+
+  @Test
+  public void testStatsMetricExportEnabled() {
+    Map<String, Object> properties = new HashMap<>();
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_ENABLE_STATS_COLLECTION, true);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_EWMA_ALPHA, 1.0);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_AUTODECAY_WINDOW_MS, -1);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_WARMUP_DURATION_MS, 0);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_AVG_INITIALIZATION_VAL, 0.0);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_HYBRID_SCORE_EXPONENT, 3);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_ENABLE_STATS_METRIC_EXPORT, true);
+    // Use a short export interval so the test doesn't wait long.
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_STATS_METRIC_EXPORT_INTERVAL_MS, 50L);
+    ServerRoutingStatsManager manager = new ServerRoutingStatsManager(new PinotConfiguration(properties),
+        _brokerMetrics);
+    manager.init();
+
+    int requestId = 0;
+    // Submit a query and then record a response with 100ms latency, leaving 0 in-flight requests.
+    manager.recordStatsForQuerySubmission(requestId++, "metricExportServer1");
+    waitForStatsUpdate(manager, requestId);
+    manager.recordStatsUponResponseArrival(requestId++, "metricExportServer1", 100);
+    waitForStatsUpdate(manager, requestId);
+
+    String numInFlightKey = BrokerGauge.ADAPTIVE_SERVER_NUM_IN_FLIGHT_REQUESTS.getGaugeName()
+        + ".server.metricExportServer1";
+    String latencyKey = BrokerGauge.ADAPTIVE_SERVER_LATENCY_EMA.getGaugeName() + ".server.metricExportServer1";
+    String hybridScoreKey = BrokerGauge.ADAPTIVE_SERVER_HYBRID_SCORE.getGaugeName() + ".server.metricExportServer1";
+
+    // Wait for the periodic export task to fire and populate the gauges.
+    TestUtils.waitForCondition(aVoid -> _brokerMetrics.getGaugeValue(numInFlightKey) != null,
+        50L, 5000, "Timed out waiting for adaptive server stats metrics to be exported");
+
+    // alpha=1.0 means EMA equals the last observed value.
+    assertEquals((long) _brokerMetrics.getGaugeValue(numInFlightKey), 0L);
+    assertEquals((long) _brokerMetrics.getGaugeValue(latencyKey), 100L);
+    assertNotNull(_brokerMetrics.getGaugeValue(hybridScoreKey));
+  }
+
+  @Test
+  public void testStatsMetricExportWhenStatsCollectionDisabled() throws InterruptedException {
+    // When stats collection is off, init() returns early — no executor is created and no metrics are exported,
+    // regardless of the enable.stats.metric.export flag.
+    Map<String, Object> properties = new HashMap<>();
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_ENABLE_STATS_COLLECTION, false);
+    ServerRoutingStatsManager manager = new ServerRoutingStatsManager(new PinotConfiguration(properties),
+        _brokerMetrics);
+    manager.init();
+
+    Thread.sleep(200);
+    String numInFlightKey = BrokerGauge.ADAPTIVE_SERVER_NUM_IN_FLIGHT_REQUESTS.getGaugeName()
+        + ".server.statsCollectionDisabledServer";
+    assertNull(_brokerMetrics.getGaugeValue(numInFlightKey));
+  }
+
+  @Test
+  public void testStatsMetricExportDisabled() throws InterruptedException {
+    Map<String, Object> properties = new HashMap<>();
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_ENABLE_STATS_COLLECTION, true);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_ENABLE_STATS_METRIC_EXPORT, false);
+    ServerRoutingStatsManager manager = new ServerRoutingStatsManager(new PinotConfiguration(properties),
+        _brokerMetrics);
+    manager.init();
+
+    int requestId = 0;
+    manager.recordStatsForQuerySubmission(requestId++, "metricExportDisabledServer");
+    waitForStatsUpdate(manager, requestId);
+
+    // Wait briefly and confirm that no gauges were exported.
+    Thread.sleep(200);
+    String numInFlightKey = BrokerGauge.ADAPTIVE_SERVER_NUM_IN_FLIGHT_REQUESTS.getGaugeName()
+        + ".server.metricExportDisabledServer";
+    assertNull(_brokerMetrics.getGaugeValue(numInFlightKey));
+  }
+
+  private void assertStatsNullForInstance(ServerRoutingStatsManager manager, String instanceId) {
+    Integer numInFlightReq = manager.fetchNumInFlightRequestsForServer(instanceId);
+    assertNull(numInFlightReq);
+
+    Double latency = manager.fetchEMALatencyForServer(instanceId);
+    assertNull(latency);
+
+    Double score = manager.fetchHybridScoreForServer(instanceId);
+    assertNull(score);
   }
 
   private void waitForStatsUpdate(ServerRoutingStatsManager serverRoutingStatsManager, long taskCount) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsManagerTest.java
@@ -312,18 +312,6 @@ public class ServerRoutingStatsManagerTest {
     assertEquals(score, 10.0);
     score = manager.fetchHybridScoreForServer("server1");
     assertEquals(score, 54.0);
-
-    // assert true to ensure server1 is in the stats map
-    assertTrue(manager.resetServerStats("server1"));
-
-    // ensure server2 has not changeed
-    score = manager.fetchHybridScoreForServer("server2");
-    assertEquals(score, 10.0);
-    assertStatsNullForInstance(manager, "server1");
-
-    manager.resetAllServersStats();
-    assertStatsNullForInstance(manager, "server1");
-    assertStatsNullForInstance(manager, "server2");
   }
 
   @Test

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -1070,6 +1070,16 @@ public class CommonConstants {
       public static final String CONFIG_OF_STATS_MANAGER_THREADPOOL_SIZE =
           CONFIG_PREFIX + ".stats.manager.threadpool.size";
       public static final int DEFAULT_STATS_MANAGER_THREADPOOL_SIZE = 2;
+
+      // Determines whether routing stats are exported as broker metrics (gauges) on a periodic basis.
+      public static final String CONFIG_OF_ENABLE_STATS_METRIC_EXPORT =
+          CONFIG_PREFIX + ".enable.stats.metric.export";
+      public static final boolean DEFAULT_ENABLE_STATS_METRIC_EXPORT = false;
+
+      // Interval in milliseconds at which routing stats are exported as broker metrics.
+      public static final String CONFIG_OF_STATS_METRIC_EXPORT_INTERVAL_MS =
+          CONFIG_PREFIX + ".stats.metric.export.interval.ms";
+      public static final long DEFAULT_STATS_METRIC_EXPORT_INTERVAL_MS = 10 * 1000;
     }
 
     public static class Grpc {


### PR DESCRIPTION
When multistage adaptive server selector stats collection is enabled (`pinot.broker.adaptive.server.selector.enable.stats.collection=true`), the broker tracks per-server routing stats (in-flight request count, latency EMA, hybrid score) in memory but has no way to observe them externally without hitting the broker's debug API. This makes it difficult to monitor the health and behavior of adaptive routing in production.

We add new metrics for the stats:
* adaptiveServerNumInFlightRequests
* adaptiveServerLatencyEma
* adaptiveServerHybridScore

This introduces 3 new metrics for each broker x server combination on a tenant. Not all users / usecases will want or warrant this, **so we disable it by default.** 

The resulting Pinot metric names are of the form: `pinot.broker.adaptiveServerLatencyEma.server.Server_pinotdb1_8098`

### Hybrid Score Range
`ServerRoutingStatsEntry.java::computeHybridScore` defines a hybrid score as:

```java
  public double computeHybridScore() {
    double estimatedQSize = _numInFlightRequests + _inFlighRequestsEMA.getAverage();
    return Math.pow(estimatedQSize, _hybridScoreExponent) * _latencyMsEMA.getAverage();
  }
```
_hybridScoreExponent defaults to 3.

The hybrid score could be as low as 0 if there are no inflight requests, but as soon as there is an inflight request, we jump to at least _latencyMsEMA.getAverage(). An unhealthy server would be much higher because it would have an increased number of inflight requests (~ `(inflight_reqs * infight_reqs_ema) ^ 3` => a server with 5 inflight requests would have it's latency_ema multiplied by  ~ `(5 + 5) ^ 3 = 1000`. 

Using a decimal data type would only help differentiate scores among servers with very low inflight requests, which isn't too helpful. 

### Testing
Unit tests verify that we:
* don't export when adaptive routing stats are disabled
* don't export when adaptive routing stats metric export is disabled

We deployed this to an internal stripe cluster with adaptive routing stats enabled, and saw metrics appearing in Grafana. 

### Setting the value
Currently this requires restarting the brokers. https://github.com/apache/pinot/pull/18135 will allow these values to be toggled without a restart. 

