### PR TITLE
Enable dynamic toggling of adaptive routing stats metrics export

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
@@ -527,6 +527,7 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
       System.currentTimeMillis() - startTimeMs, TimeUnit.MILLISECONDS);
 
     _defaultClusterConfigChangeHandler.registerClusterConfigChangeListener(ContinuousJfrStarter.INSTANCE);
+    _defaultClusterConfigChangeHandler.registerClusterConfigChangeListener(_serverRoutingStatsManager);
 
     NettyInspector.registerMetrics(_brokerMetrics);
 

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerGauge.java
@@ -65,6 +65,13 @@ public enum BrokerGauge implements AbstractMetrics.Gauge {
   ADAPTIVE_SERVER_SELECTOR_TYPE("adaptiveServerSelectorType", true),
 
   /**
+   * Per-server adaptive routing stats exported as metrics.
+   */
+  ADAPTIVE_SERVER_NUM_IN_FLIGHT_REQUESTS("adaptiveServerNumInFlightRequests", false),
+  ADAPTIVE_SERVER_LATENCY_EMA("adaptiveServerLatencyEma", false),
+  ADAPTIVE_SERVER_HYBRID_SCORE("adaptiveServerHybridScore", false),
+
+  /**
    * The queue size of ServerRoutingStatsManager main executor service.
    */
   ROUTING_STATS_MANAGER_QUEUE_SIZE("routingStatsManagerQueueSize", true),

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsManager.java
@@ -23,16 +23,19 @@ import com.google.common.base.Preconditions;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pinot.common.metrics.BrokerGauge;
 import org.apache.pinot.common.metrics.BrokerMetrics;
+import org.apache.pinot.spi.config.provider.PinotClusterConfigChangeListener;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.CommonConstants.Broker.AdaptiveServerSelector;
 import org.slf4j.Logger;
@@ -45,7 +48,7 @@ import org.slf4j.LoggerFactory;
  *  Server Selection feature (when enabled). The stats are maintained at the broker and are updated when a query is
  *  submitted to a server and when a server responds after processing a query.
  */
-public class ServerRoutingStatsManager {
+public class ServerRoutingStatsManager implements PinotClusterConfigChangeListener {
   private static final Logger LOGGER = LoggerFactory.getLogger(ServerRoutingStatsManager.class);
 
   private final PinotConfiguration _config;
@@ -65,6 +68,8 @@ public class ServerRoutingStatsManager {
   private double _avgInitializationVal;
   private int _hybridScoreExponent;
   private boolean _enableStatsMetricExport;
+  private long _statsMetricExportIntervalMs;
+  private volatile ScheduledFuture<?> _metricExportFuture;
 
   public ServerRoutingStatsManager(PinotConfiguration pinotConfig, BrokerMetrics brokerMetrics) {
     _config = pinotConfig;
@@ -104,12 +109,42 @@ public class ServerRoutingStatsManager {
 
     _enableStatsMetricExport = _config.getProperty(AdaptiveServerSelector.CONFIG_OF_ENABLE_STATS_METRIC_EXPORT,
         AdaptiveServerSelector.DEFAULT_ENABLE_STATS_METRIC_EXPORT);
-    if (_enableStatsMetricExport) {
-      long intervalMs = _config.getProperty(AdaptiveServerSelector.CONFIG_OF_STATS_METRIC_EXPORT_INTERVAL_MS,
-          AdaptiveServerSelector.DEFAULT_STATS_METRIC_EXPORT_INTERVAL_MS);
-      _periodicTaskExecutor.scheduleAtFixedRate(this::exportStatsAsMetrics, intervalMs, intervalMs,
-          TimeUnit.MILLISECONDS);
-      LOGGER.info("Adaptive server routing stats metric export enabled with interval {}ms.", intervalMs);
+    _statsMetricExportIntervalMs = _config.getProperty(AdaptiveServerSelector.CONFIG_OF_STATS_METRIC_EXPORT_INTERVAL_MS,
+        AdaptiveServerSelector.DEFAULT_STATS_METRIC_EXPORT_INTERVAL_MS);
+    _metricExportFuture = _periodicTaskExecutor.scheduleAtFixedRate(this::exportStatsAsMetrics,
+        _statsMetricExportIntervalMs, _statsMetricExportIntervalMs, TimeUnit.MILLISECONDS);
+    LOGGER.info("Adaptive server routing stats metric export scheduled with interval {}ms (enabled={}).",
+        _statsMetricExportIntervalMs, _enableStatsMetricExport);
+  }
+
+  @Override
+  public void onChange(Set<String> changedConfigs, Map<String, String> clusterConfigs) {
+    if (changedConfigs.contains(AdaptiveServerSelector.CONFIG_OF_ENABLE_STATS_METRIC_EXPORT)) {
+      String value = clusterConfigs.get(AdaptiveServerSelector.CONFIG_OF_ENABLE_STATS_METRIC_EXPORT);
+      if (value != null) {
+        _enableStatsMetricExport = Boolean.parseBoolean(value);
+      } else {
+        // Key was removed from cluster config — fall back to the static broker config value.
+        _enableStatsMetricExport = _config.getProperty(AdaptiveServerSelector.CONFIG_OF_ENABLE_STATS_METRIC_EXPORT,
+            AdaptiveServerSelector.DEFAULT_ENABLE_STATS_METRIC_EXPORT);
+      }
+      LOGGER.info("Updated enableStatsMetricExport to {} from cluster config.", _enableStatsMetricExport);
+      if (!_enableStatsMetricExport) {
+        removeAllServerStatsGauges();
+      }
+    }
+    if (changedConfigs.contains(AdaptiveServerSelector.CONFIG_OF_STATS_METRIC_EXPORT_INTERVAL_MS)) {
+      String value = clusterConfigs.get(AdaptiveServerSelector.CONFIG_OF_STATS_METRIC_EXPORT_INTERVAL_MS);
+      long newIntervalMs = value != null ? Long.parseLong(value)
+          : _config.getProperty(AdaptiveServerSelector.CONFIG_OF_STATS_METRIC_EXPORT_INTERVAL_MS,
+              AdaptiveServerSelector.DEFAULT_STATS_METRIC_EXPORT_INTERVAL_MS);
+      if (newIntervalMs != _statsMetricExportIntervalMs) {
+        _statsMetricExportIntervalMs = newIntervalMs;
+        _metricExportFuture.cancel(false);
+        _metricExportFuture = _periodicTaskExecutor.scheduleAtFixedRate(this::exportStatsAsMetrics,
+            newIntervalMs, newIntervalMs, TimeUnit.MILLISECONDS);
+        LOGGER.info("Rescheduled adaptive server routing stats metric export with new interval {}ms.", newIntervalMs);
+      }
     }
   }
 
@@ -398,12 +433,28 @@ public class ServerRoutingStatsManager {
     }
   }
 
+  private void removeAllServerStatsGauges() {
+    if (_serverQueryStatsMap == null) {
+      return;
+    }
+    for (String serverInstanceId : _serverQueryStatsMap.keySet()) {
+      String serverTag = "server." + serverInstanceId;
+      _brokerMetrics.removeGauge(BrokerGauge.ADAPTIVE_SERVER_NUM_IN_FLIGHT_REQUESTS.getGaugeName() + "." + serverTag);
+      _brokerMetrics.removeGauge(BrokerGauge.ADAPTIVE_SERVER_LATENCY_EMA.getGaugeName() + "." + serverTag);
+      _brokerMetrics.removeGauge(BrokerGauge.ADAPTIVE_SERVER_HYBRID_SCORE.getGaugeName() + "." + serverTag);
+    }
+    LOGGER.info("Removed adaptive server routing stats gauges for {} servers.", _serverQueryStatsMap.size());
+  }
+
   private void recordQueueSizeMetrics() {
     int queueSize = getQueueSize();
     _brokerMetrics.setValueOfGlobalGauge(BrokerGauge.ROUTING_STATS_MANAGER_QUEUE_SIZE, queueSize);
   }
 
   private void exportStatsAsMetrics() {
+    if (!_enableStatsMetricExport) {
+      return;
+    }
     try {
       for (Map.Entry<String, ServerRoutingStatsEntry> entry : _serverQueryStatsMap.entrySet()) {
         String serverInstanceId = entry.getKey();

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsManager.java
@@ -28,6 +28,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pinot.common.metrics.BrokerGauge;
@@ -63,6 +64,7 @@ public class ServerRoutingStatsManager {
   private long _warmupDurationMs;
   private double _avgInitializationVal;
   private int _hybridScoreExponent;
+  private boolean _enableStatsMetricExport;
 
   public ServerRoutingStatsManager(PinotConfiguration pinotConfig, BrokerMetrics brokerMetrics) {
     _config = pinotConfig;
@@ -99,6 +101,16 @@ public class ServerRoutingStatsManager {
     // Entries in this map are never deleted unless the broker process restarts. This is okay for now because the
     // number of servers will be finite and should not cause memory bloat.
     _serverQueryStatsMap = new ConcurrentHashMap<>();
+
+    _enableStatsMetricExport = _config.getProperty(AdaptiveServerSelector.CONFIG_OF_ENABLE_STATS_METRIC_EXPORT,
+        AdaptiveServerSelector.DEFAULT_ENABLE_STATS_METRIC_EXPORT);
+    if (_enableStatsMetricExport) {
+      long intervalMs = _config.getProperty(AdaptiveServerSelector.CONFIG_OF_STATS_METRIC_EXPORT_INTERVAL_MS,
+          AdaptiveServerSelector.DEFAULT_STATS_METRIC_EXPORT_INTERVAL_MS);
+      _periodicTaskExecutor.scheduleAtFixedRate(this::exportStatsAsMetrics, intervalMs, intervalMs,
+          TimeUnit.MILLISECONDS);
+      LOGGER.info("Adaptive server routing stats metric export enabled with interval {}ms.", intervalMs);
+    }
   }
 
   public boolean isEnabled() {
@@ -389,5 +401,36 @@ public class ServerRoutingStatsManager {
   private void recordQueueSizeMetrics() {
     int queueSize = getQueueSize();
     _brokerMetrics.setValueOfGlobalGauge(BrokerGauge.ROUTING_STATS_MANAGER_QUEUE_SIZE, queueSize);
+  }
+
+  private void exportStatsAsMetrics() {
+    try {
+      for (Map.Entry<String, ServerRoutingStatsEntry> entry : _serverQueryStatsMap.entrySet()) {
+        String serverInstanceId = entry.getKey();
+        ServerRoutingStatsEntry stats = entry.getValue();
+
+        int numInFlightRequests;
+        double latencyEma;
+        double hybridScore;
+
+        stats.getServerReadLock().lock();
+        try {
+          numInFlightRequests = stats.getNumInFlightRequests();
+          latencyEma = stats.getLatencyEMA();
+          hybridScore = stats.computeHybridScore();
+        } finally {
+          stats.getServerReadLock().unlock();
+        }
+
+        _brokerMetrics.setValueOfGlobalGauge(BrokerGauge.ADAPTIVE_SERVER_NUM_IN_FLIGHT_REQUESTS,
+            "server." + serverInstanceId, numInFlightRequests);
+        _brokerMetrics.setValueOfGlobalGauge(BrokerGauge.ADAPTIVE_SERVER_LATENCY_EMA, "server." + serverInstanceId,
+            (long) latencyEma);
+        _brokerMetrics.setValueOfGlobalGauge(BrokerGauge.ADAPTIVE_SERVER_HYBRID_SCORE, "server." + serverInstanceId,
+            (long) hybridScore);
+      }
+    } catch (Exception e) {
+      LOGGER.error("Exception caught while exporting routing stats as metrics.", e);
+    }
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsManagerTest.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pinot.common.metrics.BrokerGauge;
 import org.apache.pinot.common.metrics.BrokerMetrics;
@@ -398,6 +399,89 @@ public class ServerRoutingStatsManagerTest {
     String numInFlightKey = BrokerGauge.ADAPTIVE_SERVER_NUM_IN_FLIGHT_REQUESTS.getGaugeName()
         + ".server.metricExportDisabledServer";
     assertNull(_brokerMetrics.getGaugeValue(numInFlightKey));
+  }
+
+  @Test
+  public void testStatsMetricExportDynamicToggle() throws InterruptedException {
+    Map<String, Object> properties = new HashMap<>();
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_ENABLE_STATS_COLLECTION, true);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_EWMA_ALPHA, 1.0);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_AUTODECAY_WINDOW_MS, -1);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_WARMUP_DURATION_MS, 0);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_AVG_INITIALIZATION_VAL, 0.0);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_HYBRID_SCORE_EXPONENT, 3);
+    // Start with metric export disabled.
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_ENABLE_STATS_METRIC_EXPORT, false);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_STATS_METRIC_EXPORT_INTERVAL_MS, 50L);
+    ServerRoutingStatsManager manager = new ServerRoutingStatsManager(new PinotConfiguration(properties),
+        _brokerMetrics);
+    manager.init();
+
+    int requestId = 0;
+    manager.recordStatsForQuerySubmission(requestId++, "dynamicToggleServer");
+    waitForStatsUpdate(manager, requestId);
+    manager.recordStatsUponResponseArrival(requestId++, "dynamicToggleServer", 100);
+    waitForStatsUpdate(manager, requestId);
+
+    String numInFlightKey = BrokerGauge.ADAPTIVE_SERVER_NUM_IN_FLIGHT_REQUESTS.getGaugeName() + "."
+        + "server.dynamicToggleServer";
+
+    // Confirm no metrics while disabled.
+    Thread.sleep(200);
+    assertNull(_brokerMetrics.getGaugeValue(numInFlightKey));
+
+    // Enable via cluster config change and verify metrics are now exported.
+    manager.onChange(
+        Set.of(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_ENABLE_STATS_METRIC_EXPORT),
+        Map.of(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_ENABLE_STATS_METRIC_EXPORT, "true"));
+
+    TestUtils.waitForCondition(aVoid -> _brokerMetrics.getGaugeValue(numInFlightKey) != null,
+        50L, 5000, "Timed out waiting for metrics after dynamic enable");
+
+    // Disable again and verify the gauges are removed from the registry.
+    manager.onChange(
+        Set.of(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_ENABLE_STATS_METRIC_EXPORT),
+        Map.of(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_ENABLE_STATS_METRIC_EXPORT, "false"));
+
+    assertNull(_brokerMetrics.getGaugeValue(numInFlightKey));
+  }
+
+  @Test
+  public void testStatsMetricExportIntervalDynamicUpdate() throws InterruptedException {
+    Map<String, Object> properties = new HashMap<>();
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_ENABLE_STATS_COLLECTION, true);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_EWMA_ALPHA, 1.0);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_AUTODECAY_WINDOW_MS, -1);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_WARMUP_DURATION_MS, 0);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_AVG_INITIALIZATION_VAL, 0.0);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_HYBRID_SCORE_EXPONENT, 3);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_ENABLE_STATS_METRIC_EXPORT, true);
+    // Start with a very long interval so the task won't fire during the test.
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_STATS_METRIC_EXPORT_INTERVAL_MS, 100000L);
+    ServerRoutingStatsManager manager = new ServerRoutingStatsManager(new PinotConfiguration(properties),
+        _brokerMetrics);
+    manager.init();
+
+    int requestId = 0;
+    manager.recordStatsForQuerySubmission(requestId++, "intervalUpdateServer");
+    waitForStatsUpdate(manager, requestId);
+    manager.recordStatsUponResponseArrival(requestId++, "intervalUpdateServer", 100);
+    waitForStatsUpdate(manager, requestId);
+
+    String numInFlightKey = BrokerGauge.ADAPTIVE_SERVER_NUM_IN_FLIGHT_REQUESTS.getGaugeName()
+        + ".server.intervalUpdateServer";
+
+    // No export yet — interval is too long.
+    Thread.sleep(200);
+    assertNull(_brokerMetrics.getGaugeValue(numInFlightKey));
+
+    // Shorten the interval via cluster config change and verify metrics are now exported.
+    manager.onChange(
+        Set.of(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_STATS_METRIC_EXPORT_INTERVAL_MS),
+        Map.of(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_STATS_METRIC_EXPORT_INTERVAL_MS, "50"));
+
+    TestUtils.waitForCondition(aVoid -> _brokerMetrics.getGaugeValue(numInFlightKey) != null,
+        50L, 5000, "Timed out waiting for metrics after interval update");
   }
 
   private void assertStatsNullForInstance(ServerRoutingStatsManager manager, String instanceId) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsManagerTest.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.pinot.common.metrics.BrokerGauge;
 import org.apache.pinot.common.metrics.BrokerMetrics;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.metrics.PinotMetricUtils;
@@ -311,6 +312,103 @@ public class ServerRoutingStatsManagerTest {
     assertEquals(score, 10.0);
     score = manager.fetchHybridScoreForServer("server1");
     assertEquals(score, 54.0);
+
+    // assert true to ensure server1 is in the stats map
+    assertTrue(manager.resetServerStats("server1"));
+
+    // ensure server2 has not changeed
+    score = manager.fetchHybridScoreForServer("server2");
+    assertEquals(score, 10.0);
+    assertStatsNullForInstance(manager, "server1");
+
+    manager.resetAllServersStats();
+    assertStatsNullForInstance(manager, "server1");
+    assertStatsNullForInstance(manager, "server2");
+  }
+
+  @Test
+  public void testStatsMetricExportEnabled() {
+    Map<String, Object> properties = new HashMap<>();
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_ENABLE_STATS_COLLECTION, true);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_EWMA_ALPHA, 1.0);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_AUTODECAY_WINDOW_MS, -1);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_WARMUP_DURATION_MS, 0);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_AVG_INITIALIZATION_VAL, 0.0);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_HYBRID_SCORE_EXPONENT, 3);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_ENABLE_STATS_METRIC_EXPORT, true);
+    // Use a short export interval so the test doesn't wait long.
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_STATS_METRIC_EXPORT_INTERVAL_MS, 50L);
+    ServerRoutingStatsManager manager = new ServerRoutingStatsManager(new PinotConfiguration(properties),
+        _brokerMetrics);
+    manager.init();
+
+    int requestId = 0;
+    // Submit a query and then record a response with 100ms latency, leaving 0 in-flight requests.
+    manager.recordStatsForQuerySubmission(requestId++, "metricExportServer1");
+    waitForStatsUpdate(manager, requestId);
+    manager.recordStatsUponResponseArrival(requestId++, "metricExportServer1", 100);
+    waitForStatsUpdate(manager, requestId);
+
+    String numInFlightKey = BrokerGauge.ADAPTIVE_SERVER_NUM_IN_FLIGHT_REQUESTS.getGaugeName()
+        + ".server.metricExportServer1";
+    String latencyKey = BrokerGauge.ADAPTIVE_SERVER_LATENCY_EMA.getGaugeName() + ".server.metricExportServer1";
+    String hybridScoreKey = BrokerGauge.ADAPTIVE_SERVER_HYBRID_SCORE.getGaugeName() + ".server.metricExportServer1";
+
+    // Wait for the periodic export task to fire and populate the gauges.
+    TestUtils.waitForCondition(aVoid -> _brokerMetrics.getGaugeValue(numInFlightKey) != null,
+        50L, 5000, "Timed out waiting for adaptive server stats metrics to be exported");
+
+    // alpha=1.0 means EMA equals the last observed value.
+    assertEquals((long) _brokerMetrics.getGaugeValue(numInFlightKey), 0L);
+    assertEquals((long) _brokerMetrics.getGaugeValue(latencyKey), 100L);
+    assertNotNull(_brokerMetrics.getGaugeValue(hybridScoreKey));
+  }
+
+  @Test
+  public void testStatsMetricExportWhenStatsCollectionDisabled() throws InterruptedException {
+    // When stats collection is off, init() returns early — no executor is created and no metrics are exported,
+    // regardless of the enable.stats.metric.export flag.
+    Map<String, Object> properties = new HashMap<>();
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_ENABLE_STATS_COLLECTION, false);
+    ServerRoutingStatsManager manager = new ServerRoutingStatsManager(new PinotConfiguration(properties),
+        _brokerMetrics);
+    manager.init();
+
+    Thread.sleep(200);
+    String numInFlightKey = BrokerGauge.ADAPTIVE_SERVER_NUM_IN_FLIGHT_REQUESTS.getGaugeName()
+        + ".server.statsCollectionDisabledServer";
+    assertNull(_brokerMetrics.getGaugeValue(numInFlightKey));
+  }
+
+  @Test
+  public void testStatsMetricExportDisabled() throws InterruptedException {
+    Map<String, Object> properties = new HashMap<>();
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_ENABLE_STATS_COLLECTION, true);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_ENABLE_STATS_METRIC_EXPORT, false);
+    ServerRoutingStatsManager manager = new ServerRoutingStatsManager(new PinotConfiguration(properties),
+        _brokerMetrics);
+    manager.init();
+
+    int requestId = 0;
+    manager.recordStatsForQuerySubmission(requestId++, "metricExportDisabledServer");
+    waitForStatsUpdate(manager, requestId);
+
+    // Wait briefly and confirm that no gauges were exported.
+    Thread.sleep(200);
+    String numInFlightKey = BrokerGauge.ADAPTIVE_SERVER_NUM_IN_FLIGHT_REQUESTS.getGaugeName()
+        + ".server.metricExportDisabledServer";
+    assertNull(_brokerMetrics.getGaugeValue(numInFlightKey));
+  }
+
+  private void assertStatsNullForInstance(ServerRoutingStatsManager manager, String instanceId) {
+    Integer numInFlightReq = manager.fetchNumInFlightRequestsForServer(instanceId);
+    assertNull(numInFlightReq);
+
+    Double latency = manager.fetchEMALatencyForServer(instanceId);
+    assertNull(latency);
+
+    Double score = manager.fetchHybridScoreForServer(instanceId);
+    assertNull(score);
   }
 
   private void waitForStatsUpdate(ServerRoutingStatsManager serverRoutingStatsManager, long taskCount) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -1070,6 +1070,16 @@ public class CommonConstants {
       public static final String CONFIG_OF_STATS_MANAGER_THREADPOOL_SIZE =
           CONFIG_PREFIX + ".stats.manager.threadpool.size";
       public static final int DEFAULT_STATS_MANAGER_THREADPOOL_SIZE = 2;
+
+      // Determines whether routing stats are exported as broker metrics (gauges) on a periodic basis.
+      public static final String CONFIG_OF_ENABLE_STATS_METRIC_EXPORT =
+          CONFIG_PREFIX + ".enable.stats.metric.export";
+      public static final boolean DEFAULT_ENABLE_STATS_METRIC_EXPORT = false;
+
+      // Interval in milliseconds at which routing stats are exported as broker metrics.
+      public static final String CONFIG_OF_STATS_METRIC_EXPORT_INTERVAL_MS =
+          CONFIG_PREFIX + ".stats.metric.export.interval.ms";
+      public static final long DEFAULT_STATS_METRIC_EXPORT_INTERVAL_MS = 10 * 1000;
     }
 
     public static class Grpc {


### PR DESCRIPTION
https://github.com/apache/pinot/pull/18134 adds metrics for adaptive routing stats.

We may want to toggle whether or not stats are exported as metrics without needing to rolling restart the brokers. 

ServerRoutingStatsManager now implements PinotClusterConfigChangeListener. The periodic export task is always scheduled when stats collection is enabled; the enable.stats.metric.export flag is checked inside the task and can be updated at runtime via the Helix cluster config (PUT /cluster/configs) without a broker restart.

We also allow updating the metrics export frequency at runtime.

### Testing
Deployed to an internal Stripe cluster. 

`ssh`ed onto one of the controllers and ran
```
curl -X POST localhost:9000/cluster/configs -H "Content-Type: application/json" -d '{"pinot.broker.adaptive.server.selector.enable.stats.metric.export": "false"}'
# wait a bit
curl -X POST localhost:9000/cluster/configs -H "Content-Type: application/json" -d '{"pinot.broker.adaptive.server.selector.enable.stats.metric.export": "true"}'
# wait a bit more
curl -X POST localhost:9000/cluster/configs -H "Content-Type: application/json" -d '{"pinot.broker.adaptive.server.selector.enable.stats.metric.export": "false"}'
```

Saw the metrics start/stop as expected. 