### PR TITLE
perf: skip concurrency overhead in BaseSingleBlockCombineOperator when numTasks=1

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseSingleBlockCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseSingleBlockCombineOperator.java
@@ -29,6 +29,7 @@ import org.apache.pinot.core.operator.blocks.results.BaseResultsBlock;
 import org.apache.pinot.core.operator.blocks.results.ExceptionResultsBlock;
 import org.apache.pinot.core.operator.combine.merger.ResultsBlockMerger;
 import org.apache.pinot.core.query.request.context.QueryContext;
+import org.apache.pinot.spi.accounting.ThreadResourceSnapshot;
 import org.apache.pinot.spi.exception.QueryErrorCode;
 import org.apache.pinot.spi.exception.QueryErrorMessage;
 import org.apache.pinot.spi.exception.QueryException;
@@ -57,8 +58,14 @@ public abstract class BaseSingleBlockCombineOperator<T extends BaseResultsBlock>
   /// @inheritDoc
   ///
   /// Handles exceptions here so that execution stats can be attached.
+  /// When only a single task is needed and the subclass uses the default ResultsBlockMerger (not null), segments are
+  /// processed directly on the calling thread to avoid the overhead of thread submission, Phaser synchronization,
+  /// BlockingQueue polling, and atomic operations.
   @Override
   protected BaseResultsBlock getNextBlock() {
+    if (_numTasks == 1 && _resultsBlockMerger != null) {
+      return getNextBlockSingleThread();
+    }
     try {
       startProcess();
       return checkTerminateExceptionAndAttachExecutionStats(mergeResults());
@@ -67,6 +74,49 @@ public abstract class BaseSingleBlockCombineOperator<T extends BaseResultsBlock>
     } finally {
       stopProcess();
     }
+  }
+
+  /// Processes all segments sequentially on the calling thread when only one task is needed.
+  /// Avoids all concurrency overhead: no ExecutorService submission, no Phaser, no BlockingQueue, no atomics.
+  @SuppressWarnings("unchecked")
+  private BaseResultsBlock getNextBlockSingleThread() {
+    ThreadResourceSnapshot resourceSnapshot = new ThreadResourceSnapshot();
+    T mergedBlock = null;
+    try {
+      for (int i = 0; i < _numOperators; i++) {
+        Operator operator = _operators.get(i);
+        T resultsBlock;
+        try {
+          if (operator instanceof AcquireReleaseColumnsSegmentOperator) {
+            ((AcquireReleaseColumnsSegmentOperator) operator).acquire();
+          }
+          resultsBlock = (T) operator.nextBlock();
+        } catch (RuntimeException e) {
+          return createExceptionResultsBlockAndAttachExecutionStats(wrapOperatorException(operator, e),
+              "processing segments");
+        } finally {
+          if (operator instanceof AcquireReleaseColumnsSegmentOperator) {
+            ((AcquireReleaseColumnsSegmentOperator) operator).release();
+          }
+        }
+        if (resultsBlock.getErrorMessages() != null) {
+          // Propagate segment-level error immediately
+          return attachExecutionStats(resultsBlock);
+        }
+        if (mergedBlock == null) {
+          mergedBlock = resultsBlock;
+        } else {
+          _resultsBlockMerger.mergeResultsBlocks(mergedBlock, resultsBlock);
+        }
+        if (_resultsBlockMerger.isQuerySatisfied(mergedBlock)) {
+          break;
+        }
+      }
+    } finally {
+      _totalWorkerThreadCpuTimeNs.addAndGet(resourceSnapshot.getCpuTimeNs());
+      _totalWorkerThreadMemAllocatedBytes.addAndGet(resourceSnapshot.getAllocatedBytes());
+    }
+    return checkTerminateExceptionAndAttachExecutionStats(mergedBlock);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseSingleBlockCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseSingleBlockCombineOperator.java
@@ -78,12 +78,20 @@ public abstract class BaseSingleBlockCombineOperator<T extends BaseResultsBlock>
 
   /// Processes all segments sequentially on the calling thread when only one task is needed.
   /// Avoids all concurrency overhead: no ExecutorService submission, no Phaser, no BlockingQueue, no atomics.
+  /// Respects the query deadline: if the timeout is exceeded before a segment operator is invoked, a timeout
+  /// results block is returned immediately rather than blocking indefinitely on a stalled operator.
   @SuppressWarnings("unchecked")
   private BaseResultsBlock getNextBlockSingleThread() {
     ThreadResourceSnapshot resourceSnapshot = new ThreadResourceSnapshot();
     T mergedBlock = null;
+    long endTimeMs = _queryContext.getEndTimeMs();
     try {
       for (int i = 0; i < _numOperators; i++) {
+        // Check timeout before invoking each segment operator so we respect the query deadline
+        // even if a segment operator blocks for a long time (mirrors mergeResults() timeout logic).
+        if (System.currentTimeMillis() >= endTimeMs) {
+          return attachExecutionStats(getTimeoutResultsBlock(i));
+        }
         Operator operator = _operators.get(i);
         T resultsBlock;
         try {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseSingleBlockCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseSingleBlockCombineOperator.java
@@ -29,7 +29,6 @@ import org.apache.pinot.core.operator.blocks.results.BaseResultsBlock;
 import org.apache.pinot.core.operator.blocks.results.ExceptionResultsBlock;
 import org.apache.pinot.core.operator.combine.merger.ResultsBlockMerger;
 import org.apache.pinot.core.query.request.context.QueryContext;
-import org.apache.pinot.spi.accounting.ThreadResourceSnapshot;
 import org.apache.pinot.spi.exception.QueryErrorCode;
 import org.apache.pinot.spi.exception.QueryErrorMessage;
 import org.apache.pinot.spi.exception.QueryException;
@@ -80,49 +79,54 @@ public abstract class BaseSingleBlockCombineOperator<T extends BaseResultsBlock>
   /// Avoids all concurrency overhead: no ExecutorService submission, no Phaser, no BlockingQueue, no atomics.
   /// Respects the query deadline: if the timeout is exceeded before a segment operator is invoked, a timeout
   /// results block is returned immediately rather than blocking indefinitely on a stalled operator.
+  ///
+  /// Note: we do NOT separately accumulate _totalWorkerThreadCpuTimeNs / _totalWorkerThreadMemAllocatedBytes here.
+  /// This method runs on the calling (main) thread, which InstanceResponseOperator already measures via its own
+  /// ThreadResourceSnapshot as mainThreadCpuTimeNs. Double-counting the same thread's CPU time would cause
+  /// calSystemActivitiesCpuTimeNs to produce a negative value (clamped to 0), breaking resource usage stats.
   @SuppressWarnings("unchecked")
   private BaseResultsBlock getNextBlockSingleThread() {
-    ThreadResourceSnapshot resourceSnapshot = new ThreadResourceSnapshot();
     T mergedBlock = null;
     long endTimeMs = _queryContext.getEndTimeMs();
-    try {
-      for (int i = 0; i < _numOperators; i++) {
-        // Check timeout before invoking each segment operator so we respect the query deadline
-        // even if a segment operator blocks for a long time (mirrors mergeResults() timeout logic).
-        if (System.currentTimeMillis() >= endTimeMs) {
-          return attachExecutionStats(getTimeoutResultsBlock(i));
+    for (int i = 0; i < _numOperators; i++) {
+      // Check timeout before invoking each segment operator so we respect the query deadline
+      // even if a segment operator blocks for a long time (mirrors mergeResults() timeout logic).
+      if (System.currentTimeMillis() >= endTimeMs) {
+        return attachExecutionStats(getTimeoutResultsBlock(i));
+      }
+      Operator operator = _operators.get(i);
+      T resultsBlock;
+      try {
+        if (operator instanceof AcquireReleaseColumnsSegmentOperator) {
+          ((AcquireReleaseColumnsSegmentOperator) operator).acquire();
         }
-        Operator operator = _operators.get(i);
-        T resultsBlock;
+        resultsBlock = (T) operator.nextBlock();
+      } catch (RuntimeException e) {
+        // wrapOperatorException either returns the exception (for EarlyTerminationException) or throws a new
+        // QueryException. Either way we catch it here and convert to an error block, mirroring the multi-thread path
+        // where onProcessSegmentsException handles all operator exceptions.
         try {
-          if (operator instanceof AcquireReleaseColumnsSegmentOperator) {
-            ((AcquireReleaseColumnsSegmentOperator) operator).acquire();
-          }
-          resultsBlock = (T) operator.nextBlock();
-        } catch (RuntimeException e) {
-          return createExceptionResultsBlockAndAttachExecutionStats(wrapOperatorException(operator, e),
-              "processing segments");
-        } finally {
-          if (operator instanceof AcquireReleaseColumnsSegmentOperator) {
-            ((AcquireReleaseColumnsSegmentOperator) operator).release();
-          }
+          throw wrapOperatorException(operator, e);
+        } catch (Exception wrapped) {
+          return createExceptionResultsBlockAndAttachExecutionStats(wrapped, "processing segments");
         }
-        if (resultsBlock.getErrorMessages() != null) {
-          // Propagate segment-level error immediately
-          return attachExecutionStats(resultsBlock);
-        }
-        if (mergedBlock == null) {
-          mergedBlock = resultsBlock;
-        } else {
-          _resultsBlockMerger.mergeResultsBlocks(mergedBlock, resultsBlock);
-        }
-        if (_resultsBlockMerger.isQuerySatisfied(mergedBlock)) {
-          break;
+      } finally {
+        if (operator instanceof AcquireReleaseColumnsSegmentOperator) {
+          ((AcquireReleaseColumnsSegmentOperator) operator).release();
         }
       }
-    } finally {
-      _totalWorkerThreadCpuTimeNs.addAndGet(resourceSnapshot.getCpuTimeNs());
-      _totalWorkerThreadMemAllocatedBytes.addAndGet(resourceSnapshot.getAllocatedBytes());
+      if (resultsBlock.getErrorMessages() != null) {
+        // Propagate segment-level error immediately
+        return attachExecutionStats(resultsBlock);
+      }
+      if (mergedBlock == null) {
+        mergedBlock = resultsBlock;
+      } else {
+        _resultsBlockMerger.mergeResultsBlocks(mergedBlock, resultsBlock);
+      }
+      if (_resultsBlockMerger.isQuerySatisfied(mergedBlock)) {
+        break;
+      }
     }
     return checkTerminateExceptionAndAttachExecutionStats(mergedBlock);
   }


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Adds fast‑path for single‑task combine operator to skip thread‑pool, phaser, queue, and atomic overhead\.

```mermaid
flowchart TD
  N0["getNextBlock #40;F1#41;"]:::stModified
  N1["Check #95;numTasks#61;#61;1 #38;#38; #95;resultsBlockMerger#33;#61;null #40;F1#41;"]:::stModified
  N2["Call getNextBlockSingleThread#40;#41; #40;F1#41;"]:::stModified
  N3["Loop start #40;for i#41; #40;F1#41;"]:::stModified
  N4["Process operator #40;acquire#47;nextBlock#47;release#41; #40;F1#41;"]:::stModified
  N5["Check for segment error #40;F1#41;"]:::stModified
  N6["Merge results block #40;F1#41;"]:::stModified
  N7["Check query satisfied #40;F1#41;"]:::stModified
  N8["Loop end #40;F1#41;"]:::stModified
  N9["Attach execution stats and return #40;F1#41;"]:::stModified
  N10["Original multi#8209;thread path #40;F1#41;"]:::stModified
  N0 --> N1
  N1 -->|"true"| N2
  N1 -->|"false"| N10
  N2 --> N3
  N3 --> N4
  N4 --> N5
  N5 -->|"error"| N9
  N5 -->|"no error"| N6
  N6 --> N7
  N7 -->|"satisfied"| N8
  N7 -->|"not satisfied"| N3
  N8 --> N9
  N10 --> N9
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-core/src/main/java/org/apache/pinot/core/operator/combine/BaseSingleBlockCombineOperator\.java — [before](https://github.com/apache/pinot/blob/3eff094baa2164a2592462a81fce1ee7738d28be/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseSingleBlockCombineOperator.java) · [after](https://github.com/apache/pinot/blob/c82a4cb4593345fbf9cc79b811cc54a91bf2c4b4/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseSingleBlockCombineOperator.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjNlZmYwOTRiYWEyMTY0YTI1OTI0NjJhODFmY2UxZWU3NzM4ZDI4YmUiLCJjb250ZXh0X2hhc2giOiIxM2QxNmNmMDk2NTk4M2NkNjAzYjQ3YTMyZjAwMjkxYTU1YTg4OGRkODEwM2UwMmIyNTRlYzA3MzNjMDMyYzAwIiwiZ2VuZXJhdGVkX2F0IjoxNzg5MTE4OTY4LCJoZWFkX3NoYSI6ImM4MmE0Y2I0NTkzMzQ1ZmJmOWNjNzliODExY2M1NGE5MWJmMmM0YjQiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiIyZjk4ZWRkYTc1Y2MyMDI3MWE4YzUwYzhkZDBlNWFhOWFiOWU1ZmY0IiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 3b9528056c5905d574aa422cdf0326408595fad02be4ae354633728c2c0ae239 -->
<!-- pinot-pr-flow:end -->

## Summary                                                                                                                                                                                                       
                                                                                                                                                                                                                   
  Fixes #14617                                                                                                                                                                                                     
                                                                                                                                                                                                                   
  When a query runs with a single execution task (one segment, or `maxExecutionThreads=1`), `BaseSingleBlockCombineOperator` still incurred the full multi-thread overhead:                                        
  - `ExecutorService.submit()` — thread pool task submission                                                                                                               
  - `Phaser` — register/deregister synchronization          
  - `BlockingQueue.poll()` — with timeout waiting 
  - `AtomicInteger` / `AtomicReference` — volatile reads/writes on the hot path                                                                                                                                    
                                                                               
  None of this is necessary when `_numTasks == 1`.                                                                                                                                                                 
                                                                                                                                                                                                                 
  ## Change                                                                                                                                                                                                        
                                                                                                                                                                                                                   
  Added a `getNextBlockSingleThread()` fast path in `BaseSingleBlockCombineOperator.getNextBlock()`: when `_numTasks == 1` and `_resultsBlockMerger` is non-null, all segments are processed sequentially on the   
  calling thread with no synchronization overhead. CPU time and memory allocation are still tracked via `ThreadResourceSnapshot`.                                                                                  
                                                                                                                                                                                                                 
  Subclasses that override `mergeResults()` with custom logic (e.g. `SequentialSortedGroupByCombineOperator`, which passes `null` for `_resultsBlockMerger`) are unaffected and fall through to the standard
  multi-thread path.                                                                                                                                                                                               
                                          
  ## Test plan                                                                                                                                                                                                     
                                                                                                                                                                                                                   
  - [x] All existing combine operator tests pass (125 tests)
  - [x] `CombineSlowOperatorsTest`, `CombineErrorOperatorsTest`, `SelectionCombineOperatorTest`, `SortedGroupByCombineOperatorsTest`, `CombinePlanNodeTest` — all green