### PR TITLE
Expose Reload Executor from TableDataManager

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -759,6 +759,11 @@ public abstract class BaseTableDataManager implements TableDataManager {
   }
 
   @Override
+  public ExecutorService getSegmentReloadRefreshExecutor() {
+    return _segmentReloadRefreshExecutor;
+  }
+
+  @Override
   public boolean isDeleted() {
     return _isDeleted;
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManager.java
@@ -298,6 +298,12 @@ public interface TableDataManager {
   ExecutorService getSegmentPreloadExecutor();
 
   /**
+   * Returns the executor used for segment reload and refresh operations.
+   * Can be used to submit work that should run with the same concurrency controls as segment reloads.
+   */
+  ExecutorService getSegmentReloadRefreshExecutor();
+
+  /**
    * Add error related to segment, if any. The implementation
    * is expected to cache last 'N' errors for the table, related to
    * segment transitions.


### PR DESCRIPTION
## Description
This PR exposes the interface to get the reload/refresh executor, so that it can be accessed outside of the table data manager, allowing tasks from outside of table data manager to share the same resource.