### PR TITLE
[multistage] add lookup join support to physical optimizer

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/traits/TraitAssignment.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/traits/TraitAssignment.java
@@ -21,7 +21,6 @@ package org.apache.pinot.calcite.rel.traits;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.function.Supplier;
 import org.apache.calcite.plan.RelTraitSet;
@@ -43,9 +42,7 @@ import org.apache.pinot.query.planner.physical.v2.PRelNode;
 import org.apache.pinot.query.planner.physical.v2.nodes.PhysicalAggregate;
 import org.apache.pinot.query.planner.physical.v2.nodes.PhysicalAsOfJoin;
 import org.apache.pinot.query.planner.physical.v2.nodes.PhysicalJoin;
-import org.apache.pinot.query.planner.physical.v2.nodes.PhysicalProject;
 import org.apache.pinot.query.planner.physical.v2.nodes.PhysicalSort;
-import org.apache.pinot.query.planner.physical.v2.nodes.PhysicalTableScan;
 import org.apache.pinot.query.planner.physical.v2.nodes.PhysicalWindow;
 
 
@@ -134,9 +131,11 @@ public class TraitAssignment {
    */
   @VisibleForTesting
   RelNode assignJoin(Join join) {
-    // Case-1: Handle lookup joins.
+    // Case-1: Lookup joins — no distribution traits needed. LookupJoinRule (post-pass) handles
+    // fragment isolation by converting the right exchange to LOOKUP_LOCAL_EXCHANGE, ensuring the
+    // left has an exchange, and wrapping the join with IDENTITY_EXCHANGE above.
     if (PinotHintOptions.JoinHintOptions.useLookupJoinStrategy(join)) {
-      return assignLookupJoin(join);
+      return join;
     }
     // Case-2: Handle dynamic filter for semi joins.
     JoinInfo joinInfo = join.analyzeCondition();
@@ -257,28 +256,6 @@ public class TraitAssignment {
     return window.copy(window.getTraitSet(), List.of(input));
   }
 
-  private RelNode assignLookupJoin(Join join) {
-    /*
-     * Lookup join expects right input to have project and table-scan nodes exactly. Moreover, lookup join is used
-     * with Dimension tables only. Given this, we expect the entire right input to be available in all workers
-     * selected for the left input. For now, we will assign broadcast trait to the entire right input. Worker
-     * assignment will have to handle this explicitly regardless.
-     */
-    RelNode leftInput = join.getInputs().get(0);
-    RelNode rightInput = join.getInputs().get(1);
-    Preconditions.checkState(rightInput instanceof PhysicalProject, "Expected project as right input of table scan");
-    Preconditions.checkState(rightInput.getInput(0) instanceof PhysicalTableScan,
-        "Expected table scan under project for right input of lookup join");
-    PhysicalProject oldProject = (PhysicalProject) rightInput;
-    PhysicalTableScan oldTableScan = (PhysicalTableScan) oldProject.getInput(0);
-    PhysicalTableScan newTableScan =
-        (PhysicalTableScan) oldTableScan.copy(oldTableScan.getTraitSet().plus(
-            RelDistributions.BROADCAST_DISTRIBUTED), Collections.emptyList());
-    PhysicalProject newProject =
-        (PhysicalProject) oldProject.copy(oldProject.getTraitSet().plus(RelDistributions.BROADCAST_DISTRIBUTED),
-            List.of(newTableScan));
-    return join.copy(join.getTraitSet(), List.of(leftInput, newProject));
-  }
 
   @SuppressWarnings("unused")
   private RelNode assignDynamicFilterSemiJoin(PhysicalJoin join) {

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/ExchangeStrategy.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/ExchangeStrategy.java
@@ -68,7 +68,13 @@ public enum ExchangeStrategy {
   /**
    * Records are sent randomly from a given worker in the sender to some worker in the receiver.
    */
-  RANDOM_EXCHANGE(false);
+  RANDOM_EXCHANGE(false),
+  /**
+   * Pseudo-exchange for lookup join right side. The dim table stays in the same plan fragment as
+   * the join (no fragment split). Inserted by {@code LookupJoinRule} after worker/exchange assignment;
+   * handled transparently by {@code PlanFragmentAndMailboxAssignment.processLookupLocalExchange}.
+   */
+  LOOKUP_LOCAL_EXCHANGE(false);
 
   /**
    * This is true when the Exchange Strategy is such that it requires a List&lt;Integer&gt; representing the
@@ -109,6 +115,12 @@ public enum ExchangeStrategy {
       case SUB_PARTITIONING_RR_EXCHANGE:
         return RelDistributions.ROUND_ROBIN_DISTRIBUTED;
       case RANDOM_EXCHANGE:
+        return RelDistributions.RANDOM_DISTRIBUTED;
+      case LOOKUP_LOCAL_EXCHANGE:
+        // LOOKUP_LOCAL is a pseudo-exchange (no fragment split, no mailbox). This mapping is only used
+        // by the PhysicalExchange constructor to satisfy the Calcite Exchange superclass — it has no
+        // runtime significance since PlanFragmentAndMailboxAssignment handles LOOKUP_LOCAL transparently.
+        // Uses RANDOM_DISTRIBUTED as placeholder (Calcite's Exchange constructor rejects ANY).
         return RelDistributions.RANDOM_DISTRIBUTED;
       default:
         throw new IllegalStateException(String.format("Unexpected exchange strategy: %s", exchangeStrategy));

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/PlanFragmentAndMailboxAssignment.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/PlanFragmentAndMailboxAssignment.java
@@ -44,6 +44,7 @@ import org.apache.pinot.query.routing.MailboxInfo;
 import org.apache.pinot.query.routing.MailboxInfos;
 import org.apache.pinot.query.routing.QueryServerInstance;
 import org.apache.pinot.query.routing.SharedMailboxInfos;
+import org.apache.pinot.spi.config.table.TableType;
 
 
 /**
@@ -87,11 +88,15 @@ public class PlanFragmentAndMailboxAssignment {
       processTableScan((PhysicalTableScan) pRelNode.unwrap(), currentFragmentId, context);
     }
     if (pRelNode.unwrap() instanceof PhysicalExchange) {
+      PhysicalExchange physicalExchange = (PhysicalExchange) pRelNode.unwrap();
+      if (physicalExchange.getExchangeStrategy() == ExchangeStrategy.LOOKUP_LOCAL_EXCHANGE) {
+        processLookupLocalExchange(pRelNode, parent, currentFragmentId, context);
+        return;
+      }
       // Split an exchange into two fragments: one for the sender and one for the receiver.
       // The sender fragment will have a MailboxSendNode and receiver a MailboxReceiveNode.
       // It is possible that the receiver fragment doesn't exist yet (e.g. when PhysicalExchange is the root node).
       // In that case, we also create it here. If it exists already, we simply re-use it.
-      PhysicalExchange physicalExchange = (PhysicalExchange) pRelNode.unwrap();
       PlanFragment receiverFragment = context._planFragmentMap.get(currentFragmentId);
       int senderFragmentId = context._planFragmentMap.size() + (receiverFragment == null ? 1 : 0);
       final DataSchema inputFragmentSchema = PRelToPlanNodeConverter.toDataSchema(
@@ -173,6 +178,77 @@ public class PlanFragmentAndMailboxAssignment {
     }
   }
 
+  /**
+   * Handles LOOKUP_LOCAL_EXCHANGE: a pseudo-exchange that does NOT split fragments. The dim table
+   * stays in the join's fragment. This method:
+   * <ol>
+   *   <li>Registers the dim table name so the fragment is classified as a leaf stage</li>
+   *   <li>Sets fake empty segments per worker (the dim table is accessed via
+   *       {@code DimensionTableDataManager} at runtime, not via segment routing)</li>
+   *   <li>Converts children to PlanNodes in the same fragment (no MailboxSend/Receive)</li>
+   * </ol>
+   * This matches V1's behavior in {@code WorkerManager.assignWorkersToNonRootFragment} where
+   * lookup joins are detected and the dim table is registered with empty segments.
+   */
+  private void processLookupLocalExchange(PRelNode pRelNode, @Nullable PlanNode parent, int currentFragmentId,
+      Context context) {
+    // Find the dim table scan in the exchange's children and register it with empty segments.
+    DispatchablePlanMetadata fragmentMetadata = context._fragmentMetadataMap.get(currentFragmentId);
+    for (PRelNode child : pRelNode.getPRelInputs()) {
+      registerDimTableInFragment(child, fragmentMetadata);
+    }
+    // Process children in the same fragment (no MailboxSend/Receive), but skip processTableScan
+    // by converting PRelNodes to PlanNodes directly. The right side of a lookup join is always
+    // [Project →] TableScan (at most 2 levels deep) — Calcite pushes dim-side filters to post-join.
+    for (PRelNode child : pRelNode.getPRelInputs()) {
+      PlanNode planNode = PRelToPlanNodeConverter.toPlanNode(child, currentFragmentId);
+      for (PRelNode grandChild : child.getPRelInputs()) {
+        Preconditions.checkState(grandChild.getPRelInputs().isEmpty(),
+            "LOOKUP_LOCAL_EXCHANGE right side deeper than 2 levels: found children under %s. "
+                + "Expected [Project →] TableScan only.", grandChild.unwrap().getClass().getSimpleName());
+        PlanNode grandChildNode = PRelToPlanNodeConverter.toPlanNode(grandChild, currentFragmentId);
+        planNode.getInputs().add(grandChildNode);
+      }
+      if (parent != null) {
+        parent.getInputs().add(planNode);
+      }
+    }
+  }
+
+  /**
+   * Recursively find TableScan nodes and register the dim table name in the fragment metadata with
+   * fake empty segments per worker, matching V1's {@code WorkerManager.assignWorkersToNonRootFragment}
+   * behavior for lookup joins.
+   */
+  private void registerDimTableInFragment(PRelNode pRelNode, DispatchablePlanMetadata fragmentMetadata) {
+    if (pRelNode.unwrap() instanceof TableScan) {
+      PhysicalTableScan tableScan = (PhysicalTableScan) pRelNode.unwrap();
+      TableScanMetadata tableScanMetadata = Objects.requireNonNull(tableScan.getTableScanMetadata(),
+          "No metadata in table scan PRelNode");
+      String tableName = tableScanMetadata.getScannedTables().stream().findFirst().orElseThrow();
+      fragmentMetadata.addScannedTable(tableName);
+      // Set fake empty segments for each worker so isLeafStageWorker() returns true.
+      // The actual dim table data comes from DimensionTableDataManager at runtime.
+      // Use putIfAbsent rather than overwrite to be defensive if called multiple times.
+      Map<Integer, QueryServerInstance> workers = fragmentMetadata.getWorkerIdToServerInstanceMap();
+      if (workers != null) {
+        Map<Integer, Map<String, List<String>>> existing = fragmentMetadata.getWorkerIdToSegmentsMap();
+        Map<Integer, Map<String, List<String>>> fakeSegmentsMap =
+            existing != null ? new HashMap<>(existing) : new HashMap<>();
+        for (Integer workerId : workers.keySet()) {
+          fakeSegmentsMap.putIfAbsent(workerId, Map.of(TableType.OFFLINE.name(), List.of()));
+        }
+        fragmentMetadata.setWorkerIdToSegmentsMap(fakeSegmentsMap);
+      }
+      NodeHint nodeHint = NodeHint.fromRelHints(tableScan.getHints());
+      fragmentMetadata.setTableOptions(nodeHint.getHintOptions().get(PinotHintOptions.TABLE_HINT_OPTIONS));
+      return;
+    }
+    for (PRelNode child : pRelNode.getPRelInputs()) {
+      registerDimTableInFragment(child, fragmentMetadata);
+    }
+  }
+
   private PlanFragment createFragment(int fragmentId, PlanNode planNode, List<PlanFragment> inputFragments,
       Context context, List<String> workers) {
     // track new plan fragment
@@ -248,6 +324,9 @@ public class PlanFragmentAndMailboxAssignment {
         }
         break;
       }
+      case LOOKUP_LOCAL_EXCHANGE:
+        throw new IllegalStateException("LOOKUP_LOCAL_EXCHANGE should not reach computeMailboxInfos — "
+            + "it must be handled as transparent in process() before fragment splitting");
       default:
         throw new UnsupportedOperationException("exchange desc not supported yet: " + exchangeDesc);
     }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/opt/PhysicalOptRuleSet.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/opt/PhysicalOptRuleSet.java
@@ -28,6 +28,7 @@ import org.apache.pinot.query.planner.physical.v2.opt.rules.LeafStageBoundaryRul
 import org.apache.pinot.query.planner.physical.v2.opt.rules.LeafStageWorkerAssignmentRule;
 import org.apache.pinot.query.planner.physical.v2.opt.rules.LiteModeSortInsertRule;
 import org.apache.pinot.query.planner.physical.v2.opt.rules.LiteModeWorkerAssignmentRule;
+import org.apache.pinot.query.planner.physical.v2.opt.rules.LookupJoinRule;
 import org.apache.pinot.query.planner.physical.v2.opt.rules.RootExchangeInsertRule;
 import org.apache.pinot.query.planner.physical.v2.opt.rules.SortPushdownRule;
 import org.apache.pinot.query.planner.physical.v2.opt.rules.WorkerExchangeAssignmentRule;
@@ -44,6 +45,7 @@ public class PhysicalOptRuleSet {
         context));
     transformers.add(create(new LeafStageAggregateRule(context), RuleExecutors.Type.POST_ORDER, context));
     transformers.add(createWorkerAssignmentRule(context));
+    transformers.add(new LookupJoinRule(context));
     transformers.add(create(new AggregatePushdownRule(context), RuleExecutors.Type.POST_ORDER, context));
     transformers.add(create(new SortPushdownRule(context), RuleExecutors.Type.POST_ORDER, context));
     if (context.isUseLiteMode()) {

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/opt/rules/LookupJoinRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/opt/rules/LookupJoinRule.java
@@ -1,0 +1,189 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.planner.physical.v2.opt.rules;
+
+import java.util.ArrayList;
+import java.util.List;
+import javax.annotation.Nullable;
+import org.apache.calcite.rel.RelDistribution;
+import org.apache.calcite.rel.core.Join;
+import org.apache.pinot.calcite.rel.hint.PinotHintOptions;
+import org.apache.pinot.calcite.rel.traits.PinotExecStrategyTrait;
+import org.apache.pinot.query.context.PhysicalPlannerContext;
+import org.apache.pinot.query.planner.physical.v2.ExchangeStrategy;
+import org.apache.pinot.query.planner.physical.v2.PRelNode;
+import org.apache.pinot.query.planner.physical.v2.PinotDataDistribution;
+import org.apache.pinot.query.planner.physical.v2.nodes.PhysicalExchange;
+import org.apache.pinot.query.planner.physical.v2.opt.PRelNodeTransformer;
+
+
+/**
+ * Post-pass rule that isolates every lookup join in its own plan fragment.
+ *
+ * <p>Runs after {@link WorkerExchangeAssignmentRule}, which assigns workers and exchanges generically (with zero
+ * lookup join awareness). This rule then post-processes lookup joins to ensure:</p>
+ * <ol>
+ *   <li><b>Right side</b>: Exchange converted to {@link ExchangeStrategy#LOOKUP_LOCAL_EXCHANGE} — a pseudo-exchange
+ *       that does not split fragments. Later, during plan fragment assignment,
+ *       {@code PlanFragmentAndMailboxAssignment.processLookupLocalExchange} registers the dim table with fake
+ *       segments so the fragment is classified as a leaf stage for {@code DimensionTableDataManager} access.</li>
+ *   <li><b>Left side</b>: Exchange exists (inserts {@link ExchangeStrategy#IDENTITY_EXCHANGE} if missing, e.g. when
+ *       the left input is an intermediate node like a hash join with the same workers).</li>
+ *   <li><b>Above</b>: Lookup join wrapped in {@link ExchangeStrategy#IDENTITY_EXCHANGE} so downstream nodes
+ *       (other joins, sorts) are not absorbed into the lookup join's leaf fragment.</li>
+ * </ol>
+ *
+ * <p>This achieves the same outcome as V1, where {@code WorkerManager.assignWorkersToNonRootFragment} detects
+ * lookup joins and assigns the same workers as the fact table while registering fake empty segments for the
+ * dim table.</p>
+ */
+public class LookupJoinRule implements PRelNodeTransformer {
+  private final PhysicalPlannerContext _context;
+
+  public LookupJoinRule(PhysicalPlannerContext context) {
+    _context = context;
+  }
+
+  @Override
+  public PRelNode execute(PRelNode rootNode) {
+    // TODO: Support lookup joins in Lite mode. Currently fails with "Right input must be leaf
+    //  operator" because the broker lacks DimensionTableDataManager.
+    if (_context.isUseLiteMode()) {
+      return rootNode;
+    }
+    return transform(rootNode, null);
+  }
+
+  private PRelNode transform(PRelNode node, @Nullable PRelNode parent) {
+    // Post-order: transform children first
+    List<PRelNode> newInputs = new ArrayList<>();
+    boolean changed = false;
+    for (PRelNode input : node.getPRelInputs()) {
+      PRelNode transformed = transform(input, node);
+      newInputs.add(transformed);
+      if (transformed != input) {
+        changed = true;
+      }
+    }
+    if (changed) {
+      node = node.with(newInputs);
+    }
+
+    if (!isLookupJoin(node)) {
+      return node;
+    }
+
+    // Right side: convert existing exchange to LOOKUP_LOCAL_EXCHANGE
+    node = convertRightExchange(node);
+
+    // Left side: ensure exchange exists (insert IDENTITY if missing)
+    node = ensureLeftExchange(node);
+
+    // Above: wrap this node in IDENTITY_EXCHANGE so downstream nodes don't enter the leaf fragment
+    if (parent != null) {
+      return wrapWithIdentityExchange(node);
+    }
+    return node;
+  }
+
+  /**
+   * Converts the right-side exchange to LOOKUP_LOCAL_EXCHANGE. The right side should already have an exchange
+   * from {@link WorkerExchangeAssignmentRule} (IDENTITY at leaf boundary, or RANDOM/BROADCAST if workers differ).
+   * If no exchange exists (shouldn't happen), inserts LOOKUP_LOCAL_EXCHANGE directly.
+   */
+  private PRelNode convertRightExchange(PRelNode joinNode) {
+    if (joinNode.getPRelInputs().size() < 2) {
+      return joinNode;
+    }
+    PRelNode rightInput = joinNode.getPRelInput(1);
+
+    if (!(rightInput instanceof PhysicalExchange)) {
+      // No exchange on right side — insert LOOKUP_LOCAL_EXCHANGE wrapping the right input.
+      return joinNode.with(replaceInput(joinNode, 1, createLookupLocalExchange(rightInput, joinNode)));
+    }
+
+    PhysicalExchange existing = (PhysicalExchange) rightInput;
+    if (existing.getExchangeStrategy() == ExchangeStrategy.LOOKUP_LOCAL_EXCHANGE) {
+      return joinNode; // already converted (idempotent)
+    }
+
+    // Replace with LOOKUP_LOCAL_EXCHANGE using the JOIN's distribution (not the existing exchange's).
+    // The existing exchange may carry the dim table's leaf-stage distribution (different workers/hash),
+    // but LOOKUP_LOCAL needs the join's workers since the dim table is accessed locally on each join worker
+    // via DimensionTableDataManager. Any collation from the existing exchange is intentionally dropped —
+    // lookup joins don't require sorted dim table input.
+    return joinNode.with(replaceInput(joinNode, 1,
+        createLookupLocalExchange(existing.getPRelInput(0), joinNode)));
+  }
+
+  /**
+   * Ensures the left input has an exchange. If the left input is already a PhysicalExchange (e.g. IDENTITY from
+   * leaf boundary), do nothing. Otherwise insert IDENTITY_EXCHANGE to create a fragment boundary.
+   */
+  private PRelNode ensureLeftExchange(PRelNode joinNode) {
+    if (joinNode.getPRelInputs().isEmpty()) {
+      return joinNode;
+    }
+    PRelNode leftInput = joinNode.getPRelInput(0);
+    if (leftInput instanceof PhysicalExchange) {
+      return joinNode; // already has exchange
+    }
+    PhysicalExchange identity = new PhysicalExchange(nodeId(), leftInput,
+        leftInput.getPinotDataDistributionOrThrow(), List.of(), ExchangeStrategy.IDENTITY_EXCHANGE, null,
+        PinotExecStrategyTrait.getDefaultExecStrategy(), _context.getDefaultHashFunction());
+    return joinNode.with(replaceInput(joinNode, 0, identity));
+  }
+
+  /**
+   * Wraps the lookup join node in an IDENTITY_EXCHANGE, creating a fragment boundary above it.
+   */
+  private PhysicalExchange wrapWithIdentityExchange(PRelNode joinNode) {
+    return new PhysicalExchange(nodeId(), joinNode, joinNode.getPinotDataDistributionOrThrow(), List.of(),
+        ExchangeStrategy.IDENTITY_EXCHANGE, null, PinotExecStrategyTrait.getDefaultExecStrategy(),
+        _context.getDefaultHashFunction());
+  }
+
+  /**
+   * Creates a LOOKUP_LOCAL_EXCHANGE wrapping the given child node, using the join's worker distribution.
+   */
+  private PhysicalExchange createLookupLocalExchange(PRelNode child, PRelNode joinNode) {
+    PinotDataDistribution joinDist = joinNode.getPinotDataDistributionOrThrow();
+    RelDistribution.Type distType = joinDist.getWorkers().size() == 1
+        ? RelDistribution.Type.SINGLETON : RelDistribution.Type.RANDOM_DISTRIBUTED;
+    PinotDataDistribution newDist = new PinotDataDistribution(distType,
+        joinDist.getWorkers(), joinDist.getWorkerHash(), null, null);
+    return new PhysicalExchange(nodeId(), child, newDist, List.of(), ExchangeStrategy.LOOKUP_LOCAL_EXCHANGE, null,
+        PinotExecStrategyTrait.getDefaultExecStrategy(), _context.getDefaultHashFunction());
+  }
+
+  private static List<PRelNode> replaceInput(PRelNode node, int index, PRelNode newInput) {
+    List<PRelNode> inputs = new ArrayList<>(node.getPRelInputs());
+    inputs.set(index, newInput);
+    return inputs;
+  }
+
+  private static boolean isLookupJoin(PRelNode node) {
+    return node.unwrap() instanceof Join
+        && PinotHintOptions.JoinHintOptions.useLookupJoinStrategy((Join) node.unwrap());
+  }
+
+  private int nodeId() {
+    return _context.getNodeIdGenerator().get();
+  }
+}

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/planner/physical/v2/ExchangeStrategyTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/planner/physical/v2/ExchangeStrategyTest.java
@@ -66,4 +66,13 @@ public class ExchangeStrategyTest {
       ExchangeStrategy.getRelDistribution(ExchangeStrategy.IDENTITY_EXCHANGE, List.of(1));
     });
   }
+
+  @Test
+  public void testLookupLocalExchangeRelDistribution() {
+    // LOOKUP_LOCAL_EXCHANGE maps to RANDOM_DISTRIBUTED — a placeholder for the Calcite Exchange
+    // superclass constructor (which rejects ANY). Has no runtime significance.
+    assertEquals(
+        ExchangeStrategy.getRelDistribution(ExchangeStrategy.LOOKUP_LOCAL_EXCHANGE, List.of()).getType(),
+        RelDistribution.Type.RANDOM_DISTRIBUTED);
+  }
 }

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/planner/physical/v2/LookupJoinPlanTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/planner/physical/v2/LookupJoinPlanTest.java
@@ -1,0 +1,411 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.planner.physical.v2;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import org.apache.pinot.common.config.provider.TableCache;
+import org.apache.pinot.core.routing.MockRoutingManagerFactory;
+import org.apache.pinot.core.routing.RoutingManager;
+import org.apache.pinot.query.QueryEnvironment;
+import org.apache.pinot.query.QueryEnvironmentTestBase;
+import org.apache.pinot.query.planner.physical.DispatchablePlanFragment;
+import org.apache.pinot.query.planner.physical.DispatchableSubPlan;
+import org.apache.pinot.query.planner.plannode.JoinNode;
+import org.apache.pinot.query.planner.plannode.MailboxReceiveNode;
+import org.apache.pinot.query.planner.plannode.PlanNode;
+import org.apache.pinot.query.planner.plannode.TableScanNode;
+import org.apache.pinot.query.routing.WorkerManager;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+
+public class LookupJoinPlanTest {
+
+  private QueryEnvironment _queryEnvironment;
+
+  @BeforeClass
+  public void setUp() {
+    // Set up the query environment with V2 optimizer enabled
+    MockRoutingManagerFactory factory = new MockRoutingManagerFactory(1, 2);
+    for (Map.Entry<String, Schema> entry : QueryEnvironmentTestBase.TABLE_SCHEMAS.entrySet()) {
+      factory.registerTable(entry.getValue(), entry.getKey());
+    }
+    for (Map.Entry<String, List<String>> entry : QueryEnvironmentTestBase.SERVER1_SEGMENTS.entrySet()) {
+      for (String segment : entry.getValue()) {
+        factory.registerSegment(1, entry.getKey(), segment);
+      }
+    }
+    for (Map.Entry<String, List<String>> entry : QueryEnvironmentTestBase.SERVER2_SEGMENTS.entrySet()) {
+      for (String segment : entry.getValue()) {
+        factory.registerSegment(2, entry.getKey(), segment);
+      }
+    }
+    RoutingManager routingManager = factory.buildRoutingManager(null);
+    TableCache tableCache = factory.buildTableCache();
+    WorkerManager workerManager = new WorkerManager("Broker_localhost", "localhost", 3, routingManager);
+
+    _queryEnvironment = new QueryEnvironment(
+        QueryEnvironment.configBuilder()
+            .requestId(-1L)
+            .database(CommonConstants.DEFAULT_DATABASE)
+            .tableCache(tableCache)
+            .workerManager(workerManager)
+            .defaultUsePhysicalOptimizer(true)
+            .defaultInferPartitionHint(true)
+            .build());
+  }
+
+  @Test
+  public void testLookupJoinPlanStructure() {
+    // Plan a lookup join query with the lookup hint
+    String query = "SELECT /*+ joinOptions(join_strategy='lookup') */ a.col1, b.col2 FROM a_REALTIME a "
+        + "JOIN b_REALTIME b ON a.col1 = b.col1";
+    DispatchableSubPlan plan = _queryEnvironment.planQuery(query);
+
+    assertNotNull(plan);
+
+    // Find the join node and verify its structure
+    JoinNode joinNode = null;
+    for (DispatchablePlanFragment fragment : plan.getQueryStageMap().values()) {
+      PlanNode root = fragment.getPlanFragment().getFragmentRoot();
+      joinNode = findJoinNode(root);
+      if (joinNode != null) {
+        break;
+      }
+    }
+    assertNotNull(joinNode, "Should find a JoinNode in the plan");
+
+    // Verify the join strategy is LOOKUP
+    assertEquals(joinNode.getJoinStrategy(), JoinNode.JoinStrategy.LOOKUP,
+        "Join strategy should be LOOKUP");
+
+    // JoinNode inputs: index 0 = left, index 1 = right
+    assertTrue(joinNode.getInputs().size() >= 2, "Join should have at least 2 inputs");
+    PlanNode leftInput = joinNode.getInputs().get(0);
+    PlanNode rightInput = joinNode.getInputs().get(1);
+
+    // Verify the left input is a MailboxReceiveNode (from IDENTITY exchange — each server processes
+    // its own fact data locally, no SINGLETON bottleneck)
+    assertTrue(leftInput instanceof MailboxReceiveNode,
+        "Left input should be a MailboxReceiveNode (from IDENTITY exchange)");
+    boolean foundTableScanInRight = false;
+    boolean foundMailboxInRight = false;
+    PlanNode current = rightInput;
+    while (current != null) {
+      if (current instanceof TableScanNode) {
+        foundTableScanInRight = true;
+        break;
+      }
+      if (current instanceof MailboxReceiveNode) {
+        foundMailboxInRight = true;
+        break;
+      }
+      // Continue down the right input chain (Project, Filter, etc.)
+      if (current.getInputs().isEmpty()) {
+        break;
+      }
+      current = current.getInputs().get(0);
+    }
+    assertTrue(foundTableScanInRight,
+        "Right input chain should contain a TableScanNode (dim table local to join)");
+    assertFalse(foundMailboxInRight,
+        "Right input chain should NOT contain a MailboxReceiveNode (dim table not from remote exchange)");
+  }
+
+  @Test
+  public void testNonLookupJoinPlanStructure() {
+    // Plan the same join WITHOUT the lookup hint for comparison
+    String query = "SELECT a.col1, b.col2 FROM a_REALTIME a JOIN b_REALTIME b ON a.col1 = b.col1";
+    DispatchableSubPlan plan = _queryEnvironment.planQuery(query);
+
+    assertNotNull(plan);
+
+    // Find the join node and verify its structure
+    JoinNode joinNode = null;
+    for (DispatchablePlanFragment fragment : plan.getQueryStageMap().values()) {
+      PlanNode root = fragment.getPlanFragment().getFragmentRoot();
+      joinNode = findJoinNode(root);
+      if (joinNode != null) {
+        break;
+      }
+    }
+    assertNotNull(joinNode, "Should find a JoinNode in the plan");
+
+    // Verify the join strategy is HASH (non-lookup)
+    assertEquals(joinNode.getJoinStrategy(), JoinNode.JoinStrategy.HASH,
+        "Join strategy should be HASH for non-lookup join");
+
+    // JoinNode inputs: index 0 = left, index 1 = right
+    assertTrue(joinNode.getInputs().size() >= 2, "Join should have at least 2 inputs");
+
+    // Verify both inputs are MailboxReceiveNodes (from exchanges)
+    assertTrue(joinNode.getInputs().get(0) instanceof MailboxReceiveNode,
+        "Left input should be a MailboxReceiveNode (from exchange)");
+    assertTrue(joinNode.getInputs().get(1) instanceof MailboxReceiveNode,
+        "Right input should be a MailboxReceiveNode (from exchange)");
+  }
+
+  /**
+   * Verify EXPLAIN output shows the dim table in the same stage as the join (no exchange between them).
+   * This is the V2 equivalent of QueryCompilationTest.testJoinPushTransitivePredicateLookupJoin().
+   */
+  @Test
+  public void testLookupJoinExplainPlan() {
+    String query = "EXPLAIN PLAN FOR "
+        + "SELECT /*+ joinOptions(join_strategy='lookup') */ a.col1, b.col2 "
+        + "FROM a_REALTIME a JOIN b_REALTIME b ON a.col1 = b.col1";
+    long requestId = new Random().nextLong();
+    String explain = _queryEnvironment.explainQuery(query, requestId);
+
+    // Expected plan structure:
+    //   PhysicalExchange(SINGLETON_EXCHANGE)           ← root
+    //     PhysicalProject(...)
+    //       PhysicalExchange(IDENTITY_EXCHANGE)         ← above lookup join (isolation)
+    //         PhysicalJoin(...)                          ← the lookup join
+    //           PhysicalExchange(IDENTITY_EXCHANGE)      ← left (leaf boundary)
+    //             PhysicalProject(...)
+    //               PhysicalTableScan(a_REALTIME)
+    //           PhysicalExchange(LOOKUP_LOCAL_EXCHANGE)  ← right (dim table, no split)
+    //             PhysicalProject(...)
+    //               PhysicalTableScan(b_REALTIME)
+    String[] lines = explain.split("\n");
+
+    // Find the PhysicalJoin line and verify its children
+    int joinLineIdx = -1;
+    for (int i = 0; i < lines.length; i++) {
+      if (lines[i].contains("PhysicalJoin")) {
+        joinLineIdx = i;
+        break;
+      }
+    }
+    assertTrue(joinLineIdx >= 0, "EXPLAIN should contain PhysicalJoin. Output:\n" + explain);
+
+    // The line ABOVE the join should be IDENTITY_EXCHANGE (above isolation)
+    boolean foundAboveIdentity = false;
+    for (int i = joinLineIdx - 1; i >= 0; i--) {
+      if (lines[i].contains("Exchange")) {
+        assertTrue(lines[i].contains("IDENTITY_EXCHANGE"),
+            "Exchange above the join should be IDENTITY_EXCHANGE (isolation), found: " + lines[i].trim()
+                + "\nEXPLAIN output:\n" + explain);
+        foundAboveIdentity = true;
+        break;
+      }
+    }
+    assertTrue(foundAboveIdentity, "Should find an exchange above the join. Output:\n" + explain);
+
+    // The join's first child exchange should be IDENTITY_EXCHANGE (left, leaf boundary)
+    // The join's second child exchange should be LOOKUP_LOCAL_EXCHANGE (right, dim table)
+    int joinIndent = lines[joinLineIdx].indexOf("PhysicalJoin");
+    int childExchangeCount = 0;
+    String[] expectedChildExchanges = {"IDENTITY_EXCHANGE", "LOOKUP_LOCAL_EXCHANGE"};
+    for (int i = joinLineIdx + 1; i < lines.length; i++) {
+      String trimmed = lines[i].trim();
+      if (trimmed.startsWith("PhysicalExchange")) {
+        // Check indent — must be a direct child of the join (one indent level deeper)
+        int indent = lines[i].indexOf("PhysicalExchange");
+        if (indent > joinIndent && childExchangeCount < 2) {
+          assertTrue(trimmed.contains(expectedChildExchanges[childExchangeCount]),
+              "Join child exchange #" + childExchangeCount + " should be "
+                  + expectedChildExchanges[childExchangeCount] + ", found: " + trimmed
+                  + "\nEXPLAIN output:\n" + explain);
+          childExchangeCount++;
+        }
+      }
+    }
+    assertEquals(childExchangeCount, 2,
+        "Join should have exactly 2 child exchanges. EXPLAIN output:\n" + explain);
+  }
+
+  /**
+   * When a hash join feeds into a lookup join (hash+lookup against same dim table),
+   * the hash join must be in a separate stage — not absorbed into the lookup join's leaf fragment.
+   */
+  @Test
+  public void testLookupJoinAfterHashJoin() {
+    // hash_join(a, b) → lookup_join(result, b)
+    String query = "SELECT /*+ joinOptions(join_strategy='lookup') */ "
+        + "t.col1, d.col2 FROM "
+        + "(SELECT /*+ joinOptions(join_strategy='hash') */ a.col1, b.col2 "
+        + " FROM a_REALTIME a JOIN b_REALTIME b ON a.col1 = b.col1) t "
+        + "JOIN b_REALTIME d ON t.col1 = d.col1";
+    DispatchableSubPlan plan = _queryEnvironment.planQuery(query);
+    assertNotNull(plan);
+
+    // Find the lookup join node
+    JoinNode lookupJoin = null;
+    for (DispatchablePlanFragment fragment : plan.getQueryStageMap().values()) {
+      PlanNode root = fragment.getPlanFragment().getFragmentRoot();
+      lookupJoin = findLookupJoinNode(root);
+      if (lookupJoin != null) {
+        break;
+      }
+    }
+    assertNotNull(lookupJoin, "Should find a lookup JoinNode");
+    assertEquals(lookupJoin.getJoinStrategy(), JoinNode.JoinStrategy.LOOKUP);
+
+    // Left input must be a MailboxReceiveNode (stage boundary separating the hash join)
+    assertTrue(lookupJoin.getInputs().get(0) instanceof MailboxReceiveNode,
+        "Left input of lookup join must be MailboxReceiveNode "
+            + "(hash join should be in a separate stage)");
+  }
+
+  /**
+   * When a lookup join's result feeds into another join (e.g., LEFT JOIN active_subs),
+   * the lookup join must be in its own isolated fragment. The outer join must NOT be absorbed
+   * into the lookup join's leaf stage.
+   */
+  @Test
+  public void testJoinAboveLookupJoin() {
+    // lookup_join(a, b) → regular_join(result, a)
+    // The outer join should be in a separate stage from the lookup join.
+    String query = "SELECT t.col1, c.col2 FROM "
+        + "(SELECT /*+ joinOptions(join_strategy='lookup') */ a.col1, b.col2 "
+        + " FROM a_REALTIME a JOIN b_REALTIME b ON a.col1 = b.col1) t "
+        + "JOIN a_REALTIME c ON t.col1 = c.col1";
+    DispatchableSubPlan plan = _queryEnvironment.planQuery(query);
+    assertNotNull(plan);
+
+    // Find the NON-lookup join (the outer join)
+    JoinNode outerJoin = null;
+    for (DispatchablePlanFragment fragment : plan.getQueryStageMap().values()) {
+      PlanNode root = fragment.getPlanFragment().getFragmentRoot();
+      outerJoin = findNonLookupJoinNode(root);
+      if (outerJoin != null) {
+        break;
+      }
+    }
+    assertNotNull(outerJoin, "Should find a non-lookup JoinNode (the outer join)");
+    assertEquals(outerJoin.getJoinStrategy(), JoinNode.JoinStrategy.HASH);
+
+    // The outer join's inputs should both be MailboxReceiveNodes — it should NOT
+    // be in the same fragment as the lookup join
+    assertTrue(outerJoin.getInputs().get(0) instanceof MailboxReceiveNode,
+        "Left input of outer join must be MailboxReceiveNode "
+            + "(lookup join result should be in a separate stage)");
+  }
+
+  /**
+   * Verify that the lookup join fragment is properly structured: has a table name (from the dim
+   * table registered via LOOKUP_LOCAL_EXCHANGE), right input is a TableScanNode (in same fragment),
+   * and left input is a MailboxReceiveNode (separate fragment).
+   */
+  @Test
+  public void testLookupJoinFragmentIsolation() {
+    String query = "SELECT /*+ joinOptions(join_strategy='lookup') */ a.col1, b.col2 FROM a_REALTIME a "
+        + "JOIN b_REALTIME b ON a.col1 = b.col1";
+    DispatchableSubPlan plan = _queryEnvironment.planQuery(query);
+    assertNotNull(plan);
+
+    // Find the fragment containing the lookup join
+    for (DispatchablePlanFragment fragment : plan.getQueryStageMap().values()) {
+      PlanNode root = fragment.getPlanFragment().getFragmentRoot();
+      JoinNode join = findLookupJoinNode(root);
+      if (join != null) {
+        // Fragment should have a table name set (from dim table registered via LOOKUP_LOCAL_EXCHANGE)
+        String tableName = fragment.getTableName();
+        assertNotNull(tableName, "Lookup join fragment should have a table name (dim table)");
+        // The join's right input should be a TableScanNode (not MailboxReceive)
+        assertTrue(join.getInputs().get(1) instanceof TableScanNode
+                || hasTableScanChild(join.getInputs().get(1)),
+            "Right input should contain TableScanNode in same fragment");
+        // The join's left input should be a MailboxReceiveNode (from exchange)
+        assertTrue(join.getInputs().get(0) instanceof MailboxReceiveNode,
+            "Left input should be MailboxReceiveNode (separate fragment)");
+        return;
+      }
+    }
+    fail("Should find a fragment containing a lookup JoinNode");
+  }
+
+  /**
+   * Verify that a non-lookup join is completely unaffected by LookupJoinRule.
+   * Both inputs should be MailboxReceiveNodes (standard exchange behavior).
+   */
+  @Test
+  public void testNonLookupJoinUnaffected() {
+    // Same query as testNonLookupJoinPlanStructure but explicitly checking no LOOKUP_LOCAL_EXCHANGE
+    String query = "SELECT a.col1, b.col2 FROM a_REALTIME a JOIN b_REALTIME b ON a.col1 = b.col1";
+    DispatchableSubPlan plan = _queryEnvironment.planQuery(query);
+    assertNotNull(plan);
+
+    // No fragment should have a lookup join
+    for (DispatchablePlanFragment fragment : plan.getQueryStageMap().values()) {
+      PlanNode root = fragment.getPlanFragment().getFragmentRoot();
+      assertNull(findLookupJoinNode(root),
+          "Non-lookup query should not contain any lookup JoinNode");
+    }
+  }
+
+  private boolean hasTableScanChild(PlanNode node) {
+    if (node instanceof TableScanNode) {
+      return true;
+    }
+    for (PlanNode input : node.getInputs()) {
+      if (hasTableScanChild(input)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private JoinNode findNonLookupJoinNode(PlanNode node) {
+    if (node instanceof JoinNode && ((JoinNode) node).getJoinStrategy() != JoinNode.JoinStrategy.LOOKUP) {
+      return (JoinNode) node;
+    }
+    for (PlanNode input : node.getInputs()) {
+      JoinNode found = findNonLookupJoinNode(input);
+      if (found != null) {
+        return found;
+      }
+    }
+    return null;
+  }
+
+  private JoinNode findJoinNode(PlanNode node) {
+    if (node instanceof JoinNode) {
+      return (JoinNode) node;
+    }
+    for (PlanNode input : node.getInputs()) {
+      JoinNode found = findJoinNode(input);
+      if (found != null) {
+        return found;
+      }
+    }
+    return null;
+  }
+
+  private JoinNode findLookupJoinNode(PlanNode node) {
+    if (node instanceof JoinNode && ((JoinNode) node).getJoinStrategy() == JoinNode.JoinStrategy.LOOKUP) {
+      return (JoinNode) node;
+    }
+    for (PlanNode input : node.getInputs()) {
+      JoinNode found = findLookupJoinNode(input);
+      if (found != null) {
+        return found;
+      }
+    }
+    return null;
+  }
+}

--- a/pinot-query-planner/src/test/resources/queries/PhysicalOptimizerPlans.json
+++ b/pinot-query-planner/src/test/resources/queries/PhysicalOptimizerPlans.json
@@ -1023,5 +1023,109 @@
         ]
       }
     ]
+  },
+  "physical_opt_lookup_join": {
+    "queries": [
+      {
+        "description": "Simple lookup join — dim table uses LOOKUP_LOCAL_EXCHANGE, join is isolated by IDENTITY_EXCHANGE above and on the left",
+        "sql": "SET usePhysicalOptimizer=true; EXPLAIN PLAN FOR SELECT /*+ joinOptions(join_strategy='lookup') */ a.col1, b.col2 FROM a JOIN b ON a.col1 = b.col1",
+        "output": [
+          "Execution Plan",
+          "\nPhysicalExchange(exchangeStrategy=[SINGLETON_EXCHANGE])",
+          "\n  PhysicalProject(col1=[$0], col2=[$2])",
+          "\n    PhysicalExchange(exchangeStrategy=[IDENTITY_EXCHANGE])",
+          "\n      PhysicalJoin(condition=[=($0, $1)], joinType=[inner])",
+          "\n        PhysicalExchange(exchangeStrategy=[IDENTITY_EXCHANGE])",
+          "\n          PhysicalProject(col1=[$0])",
+          "\n            PhysicalTableScan(table=[[default, a]])",
+          "\n        PhysicalExchange(exchangeStrategy=[LOOKUP_LOCAL_EXCHANGE])",
+          "\n          PhysicalProject(col1=[$0], col2=[$1])",
+          "\n            PhysicalTableScan(table=[[default, b]])",
+          "\n"
+        ]
+      },
+      {
+        "description": "Lookup join with aggregation — lookup join feeds into GROUP BY with leaf/final aggregate split",
+        "sql": "SET usePhysicalOptimizer=true; EXPLAIN PLAN FOR SELECT /*+ joinOptions(join_strategy='lookup') */ a.col1, SUM(b.col3) FROM a JOIN b ON a.col1 = b.col1 GROUP BY a.col1",
+        "output": [
+          "Execution Plan",
+          "\nPhysicalExchange(exchangeStrategy=[SINGLETON_EXCHANGE])",
+          "\n  PhysicalAggregate(group=[{0}], agg#0=[$SUM0($1)], aggType=[FINAL])",
+          "\n    PhysicalExchange(exchangeStrategy=[PARTITIONING_EXCHANGE], distKeys=[[0]])",
+          "\n      PhysicalAggregate(group=[{0}], agg#0=[$SUM0($2)], aggType=[LEAF])",
+          "\n        PhysicalExchange(exchangeStrategy=[IDENTITY_EXCHANGE])",
+          "\n          PhysicalJoin(condition=[=($0, $1)], joinType=[inner])",
+          "\n            PhysicalExchange(exchangeStrategy=[IDENTITY_EXCHANGE])",
+          "\n              PhysicalProject(col1=[$0])",
+          "\n                PhysicalTableScan(table=[[default, a]])",
+          "\n            PhysicalExchange(exchangeStrategy=[LOOKUP_LOCAL_EXCHANGE])",
+          "\n              PhysicalProject(col1=[$0], col3=[$2])",
+          "\n                PhysicalTableScan(table=[[default, b]])",
+          "\n"
+        ]
+      },
+      {
+        "description": "Lookup join with filter on fact table — filter is pushed to the left/fact side scan",
+        "sql": "SET usePhysicalOptimizer=true; EXPLAIN PLAN FOR SELECT /*+ joinOptions(join_strategy='lookup') */ a.col1, b.col2 FROM a JOIN b ON a.col1 = b.col1 WHERE a.col3 >= 0",
+        "output": [
+          "Execution Plan",
+          "\nPhysicalExchange(exchangeStrategy=[SINGLETON_EXCHANGE])",
+          "\n  PhysicalProject(col1=[$0], col2=[$3])",
+          "\n    PhysicalExchange(exchangeStrategy=[IDENTITY_EXCHANGE])",
+          "\n      PhysicalJoin(condition=[=($0, $2)], joinType=[inner])",
+          "\n        PhysicalExchange(exchangeStrategy=[IDENTITY_EXCHANGE])",
+          "\n          PhysicalProject(col1=[$0], col3=[$2])",
+          "\n            PhysicalFilter(condition=[>=($2, 0)])",
+          "\n              PhysicalTableScan(table=[[default, a]])",
+          "\n        PhysicalExchange(exchangeStrategy=[LOOKUP_LOCAL_EXCHANGE])",
+          "\n          PhysicalProject(col1=[$0], col2=[$1])",
+          "\n            PhysicalTableScan(table=[[default, b]])",
+          "\n"
+        ]
+      },
+      {
+        "description": "Lookup join with subquery on fact side — subquery with filter feeds into lookup join",
+        "sql": "SET usePhysicalOptimizer=true; EXPLAIN PLAN FOR SELECT /*+ joinOptions(join_strategy='lookup') */ t.col1, d.col2 FROM (SELECT a.col1, a.col2 FROM a WHERE a.col3 > 0) t JOIN b d ON t.col1 = d.col1",
+        "output": [
+          "Execution Plan",
+          "\nPhysicalExchange(exchangeStrategy=[SINGLETON_EXCHANGE])",
+          "\n  PhysicalProject(col1=[$0], col2=[$2])",
+          "\n    PhysicalExchange(exchangeStrategy=[IDENTITY_EXCHANGE])",
+          "\n      PhysicalJoin(condition=[=($0, $1)], joinType=[inner])",
+          "\n        PhysicalExchange(exchangeStrategy=[IDENTITY_EXCHANGE])",
+          "\n          PhysicalProject(col1=[$0])",
+          "\n            PhysicalFilter(condition=[>($2, 0)])",
+          "\n              PhysicalTableScan(table=[[default, a]])",
+          "\n        PhysicalExchange(exchangeStrategy=[LOOKUP_LOCAL_EXCHANGE])",
+          "\n          PhysicalProject(col1=[$0], col2=[$1])",
+          "\n            PhysicalTableScan(table=[[default, b]])",
+          "\n"
+        ]
+      },
+      {
+        "description": "Lookup join feeding into outer join — lookup join is isolated in its own fragment, outer join is in a separate stage",
+        "sql": "SET usePhysicalOptimizer=true; EXPLAIN PLAN FOR SELECT t.col1, c.col2 FROM (SELECT /*+ joinOptions(join_strategy='lookup') */ a.col1, b.col2 FROM a JOIN b ON a.col1 = b.col1) t JOIN a c ON t.col1 = c.col1",
+        "output": [
+          "Execution Plan",
+          "\nPhysicalExchange(exchangeStrategy=[SINGLETON_EXCHANGE])",
+          "\n  PhysicalProject(col1=[$0], col2=[$2])",
+          "\n    PhysicalJoin(condition=[=($0, $1)], joinType=[inner])",
+          "\n      PhysicalExchange(exchangeStrategy=[PARTITIONING_EXCHANGE], distKeys=[[0]])",
+          "\n        PhysicalProject(col1=[$0])",
+          "\n          PhysicalExchange(exchangeStrategy=[IDENTITY_EXCHANGE])",
+          "\n            PhysicalJoin(condition=[=($0, $1)], joinType=[inner])",
+          "\n              PhysicalExchange(exchangeStrategy=[IDENTITY_EXCHANGE])",
+          "\n                PhysicalProject(col1=[$0])",
+          "\n                  PhysicalTableScan(table=[[default, a]])",
+          "\n              PhysicalExchange(exchangeStrategy=[LOOKUP_LOCAL_EXCHANGE])",
+          "\n                PhysicalProject(col1=[$0])",
+          "\n                  PhysicalTableScan(table=[[default, b]])",
+          "\n      PhysicalExchange(exchangeStrategy=[PARTITIONING_EXCHANGE], distKeys=[[0]])",
+          "\n        PhysicalProject(col1=[$0], col2=[$1])",
+          "\n          PhysicalTableScan(table=[[default, a]])",
+          "\n"
+        ]
+      }
+    ]
   }
 }

--- a/pinot-query-planner/src/test/resources/queries/PhysicalOptimizerPlans.json
+++ b/pinot-query-planner/src/test/resources/queries/PhysicalOptimizerPlans.json
@@ -1125,6 +1125,76 @@
           "\n          PhysicalTableScan(table=[[default, a]])",
           "\n"
         ]
+      },
+      {
+        "description": "Two lookup joins on different dimension tables in one query",
+        "sql": "SET usePhysicalOptimizer=true; EXPLAIN PLAN FOR SELECT /*+ joinOptions(join_strategy='lookup') */ a.col1, b.col2, c.col2 FROM a JOIN b ON a.col1 = b.col1 JOIN c ON a.col2 = c.col1",
+        "output": [
+          "Execution Plan",
+          "\nPhysicalExchange(exchangeStrategy=[SINGLETON_EXCHANGE])",
+          "\n  PhysicalProject(col1=[$0], col2=[$3], col20=[$5])",
+          "\n    PhysicalExchange(exchangeStrategy=[IDENTITY_EXCHANGE])",
+          "\n      PhysicalJoin(condition=[=($1, $4)], joinType=[inner])",
+          "\n        PhysicalExchange(exchangeStrategy=[IDENTITY_EXCHANGE])",
+          "\n          PhysicalJoin(condition=[=($0, $2)], joinType=[inner])",
+          "\n            PhysicalExchange(exchangeStrategy=[IDENTITY_EXCHANGE])",
+          "\n              PhysicalProject(col1=[$0], col2=[$1])",
+          "\n                PhysicalTableScan(table=[[default, a]])",
+          "\n            PhysicalExchange(exchangeStrategy=[LOOKUP_LOCAL_EXCHANGE])",
+          "\n              PhysicalProject(col1=[$0], col2=[$1])",
+          "\n                PhysicalTableScan(table=[[default, b]])",
+          "\n        PhysicalExchange(exchangeStrategy=[LOOKUP_LOCAL_EXCHANGE])",
+          "\n          PhysicalProject(col1=[$0], col2=[$1])",
+          "\n            PhysicalTableScan(table=[[default, c]])",
+          "\n"
+        ]
+      },
+      {
+        "description": "Hash join then lookup join on same table with aggregation",
+        "sql": "SET usePhysicalOptimizer=true; EXPLAIN PLAN FOR SELECT /*+ joinOptions(join_strategy='lookup') */ t.col1, SUM(t.col3) FROM (SELECT /*+ joinOptions(join_strategy='hash') */ a.col1, a.col3, b.col2 AS dim1 FROM a JOIN b ON a.col2 = b.col1) t JOIN b dim2 ON t.col1 = dim2.col1 GROUP BY t.col1",
+        "output": [
+          "Execution Plan",
+          "\nPhysicalExchange(exchangeStrategy=[SINGLETON_EXCHANGE])",
+          "\n  PhysicalAggregate(group=[{0}], agg#0=[$SUM0($1)], aggType=[FINAL])",
+          "\n    PhysicalExchange(exchangeStrategy=[PARTITIONING_EXCHANGE], distKeys=[[0]])",
+          "\n      PhysicalAggregate(group=[{0}], agg#0=[$SUM0($1)], aggType=[LEAF])",
+          "\n        PhysicalExchange(exchangeStrategy=[IDENTITY_EXCHANGE])",
+          "\n          PhysicalJoin(condition=[=($0, $2)], joinType=[inner])",
+          "\n            PhysicalExchange(exchangeStrategy=[IDENTITY_EXCHANGE])",
+          "\n              PhysicalProject(col1=[$0], col3=[$2])",
+          "\n                PhysicalJoin(condition=[=($1, $3)], joinType=[inner])",
+          "\n                  PhysicalExchange(exchangeStrategy=[IDENTITY_EXCHANGE])",
+          "\n                    PhysicalProject(col1=[$0], col2=[$1], col3=[$2])",
+          "\n                      PhysicalTableScan(table=[[default, a]])",
+          "\n                  PhysicalExchange(exchangeStrategy=[PARTITIONING_EXCHANGE], distKeys=[[0]])",
+          "\n                    PhysicalProject(col1=[$0])",
+          "\n                      PhysicalTableScan(table=[[default, b]])",
+          "\n            PhysicalExchange(exchangeStrategy=[LOOKUP_LOCAL_EXCHANGE])",
+          "\n              PhysicalProject(col1=[$0])",
+          "\n                PhysicalTableScan(table=[[default, b]])",
+          "\n"
+        ]
+      },
+      {
+        "description": "Window function feeding into lookup join",
+        "sql": "SET usePhysicalOptimizer=true; EXPLAIN PLAN FOR SELECT /*+ joinOptions(join_strategy='lookup') */ t.col1, t.running_total, b.col2 FROM (SELECT col1, col2, SUM(col3) OVER (PARTITION BY col1 ORDER BY col2) AS running_total FROM a) t JOIN b ON t.col1 = b.col1",
+        "output": [
+          "Execution Plan",
+          "\nPhysicalExchange(exchangeStrategy=[SINGLETON_EXCHANGE])",
+          "\n  PhysicalProject(col1=[$0], running_total=[$1], col2=[$3])",
+          "\n    PhysicalExchange(exchangeStrategy=[IDENTITY_EXCHANGE])",
+          "\n      PhysicalJoin(condition=[=($0, $2)], joinType=[inner])",
+          "\n        PhysicalExchange(exchangeStrategy=[IDENTITY_EXCHANGE])",
+          "\n          PhysicalProject(col1=[$0], $1=[$3])",
+          "\n            PhysicalWindow(window#0=[window(partition {0} order by [1] aggs [SUM($2)])])",
+          "\n              PhysicalExchange(exchangeStrategy=[PARTITIONING_EXCHANGE], distKeys=[[0]], collation=[[1]])",
+          "\n                PhysicalProject(col1=[$0], col2=[$1], col3=[$2])",
+          "\n                  PhysicalTableScan(table=[[default, a]])",
+          "\n        PhysicalExchange(exchangeStrategy=[LOOKUP_LOCAL_EXCHANGE])",
+          "\n          PhysicalProject(col1=[$0], col2=[$1])",
+          "\n            PhysicalTableScan(table=[[default, b]])",
+          "\n"
+        ]
       }
     ]
   }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/QueryRunnerTestBase.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/QueryRunnerTestBase.java
@@ -583,6 +583,10 @@ public abstract class QueryRunnerTestBase extends QueryTestSet {
       public Integer _partitionCount;
       @JsonProperty("replicated")
       public boolean _replicated;
+      @JsonProperty("isDimTable")
+      public boolean _isDimTable;
+      @JsonProperty("primaryKeyColumns")
+      public List<String> _primaryKeyColumns;
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)
@@ -606,6 +610,8 @@ public abstract class QueryRunnerTestBase extends QueryTestSet {
       public Integer _expectedNumSegments;
       @JsonProperty("ignoreV2Optimizer")
       public Boolean _ignoreV2Optimizer = false;
+      @JsonProperty("ignoreLiteMode")
+      public Boolean _ignoreLiteMode = false;
     }
 
     public static class ColumnAndType {

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/ResourceBasedQueriesTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/ResourceBasedQueriesTest.java
@@ -40,6 +40,7 @@ import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pinot.common.response.broker.BrokerResponseNativeV2;
+import org.apache.pinot.core.data.manager.offline.DimensionTableDataManager;
 import org.apache.pinot.query.QueryEnvironmentTestBase;
 import org.apache.pinot.query.QueryServerEnclosure;
 import org.apache.pinot.query.mailbox.MailboxService;
@@ -56,11 +57,14 @@ import org.apache.pinot.spi.config.instance.InstanceType;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.data.readers.PrimaryKey;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.CommonConstants.MultiStageQueryRunner;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.assertj.core.api.Assertions;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.SkipException;
 import org.testng.annotations.AfterClass;
@@ -119,6 +123,9 @@ public class ResourceBasedQueriesTest extends QueryRunnerTestBase {
         QueryTestCase.Table table = entry.getValue();
         Schema schema = constructSchema(tableName, table._schema);
         schema.setEnableColumnBasedNullHandling(testCase._extraProps.isEnableColumnBasedNullHandling());
+        if (table._primaryKeyColumns != null && !table._primaryKeyColumns.isEmpty()) {
+          schema.setPrimaryKeyColumns(table._primaryKeyColumns);
+        }
         schemaMap.put(tableName, schema);
         factory1.registerTable(schema, offlineTableName);
         factory2.registerTable(schema, offlineTableName);
@@ -126,6 +133,9 @@ public class ResourceBasedQueriesTest extends QueryRunnerTestBase {
         List<GenericRow> genericRows = toRow(columnAndTypes, table._inputs);
         if (table._replicated) {
           addSegmentReplicated(factory1, factory2, offlineTableName, genericRows);
+          if (table._isDimTable) {
+            registerMockDimensionTable(offlineTableName, schema, table, genericRows);
+          }
           continue;
         }
         // generate segments and dump into server1 and server2
@@ -256,6 +266,50 @@ public class ResourceBasedQueriesTest extends QueryRunnerTestBase {
     factory2.addSegment(offlineTableName, segment);
   }
 
+  /**
+   * Registers a mock DimensionTableDataManager for lookup join testing.
+   * The mock stores all rows in a HashMap keyed by primary key, supporting lookupValues() and containsKey().
+   */
+  private void registerMockDimensionTable(String offlineTableName, Schema schema, QueryTestCase.Table table,
+      List<GenericRow> rows) {
+    List<String> primaryKeyColumns = table._primaryKeyColumns;
+    if (primaryKeyColumns == null || primaryKeyColumns.isEmpty()) {
+      throw new IllegalStateException(
+          "isDimTable=true requires primaryKeyColumns to be set for table: " + offlineTableName);
+    }
+    // Build an in-memory lookup map: PrimaryKey -> GenericRow
+    Map<PrimaryKey, GenericRow> lookupMap = new HashMap<>();
+    for (GenericRow row : rows) {
+      Object[] pkValues = new Object[primaryKeyColumns.size()];
+      for (int i = 0; i < primaryKeyColumns.size(); i++) {
+        pkValues[i] = row.getValue(primaryKeyColumns.get(i));
+      }
+      lookupMap.put(new PrimaryKey(pkValues), row);
+    }
+    // Create and register a mock DimensionTableDataManager
+    DimensionTableDataManager mockDimManager = Mockito.mock(DimensionTableDataManager.class);
+    Mockito.when(mockDimManager.containsKey(ArgumentMatchers.any(PrimaryKey.class)))
+        .thenAnswer(invocation -> {
+          PrimaryKey pk = invocation.getArgument(0);
+          return lookupMap.containsKey(pk);
+        });
+    Mockito.when(mockDimManager.lookupValues(ArgumentMatchers.any(PrimaryKey.class),
+        ArgumentMatchers.any(String[].class))).thenAnswer(invocation -> {
+          PrimaryKey pk = invocation.getArgument(0);
+          String[] columns = invocation.getArgument(1);
+          GenericRow row = lookupMap.get(pk);
+          if (row == null) {
+            return null;
+          }
+          Object[] values = new Object[columns.length];
+          for (int i = 0; i < columns.length; i++) {
+            values[i] = row.getValue(columns[i]);
+          }
+          return values;
+        });
+    DimensionTableDataManager.registerDimensionTable(offlineTableName, mockDimManager);
+  }
+
   @AfterClass
   public void tearDown() {
     // Restore the original default timezone
@@ -269,7 +323,7 @@ public class ResourceBasedQueriesTest extends QueryRunnerTestBase {
   // TODO: name the test using testCaseName for testng reports
   @Test(dataProvider = "testResourceQueryTestCaseProviderInputOnly")
   public void testQueryTestCasesWithH2(String testCaseName, boolean isIgnored, String sql, String h2Sql,
-      @Nullable String expectErrorMsg, boolean keepOutputRowOrder, boolean ignoreV2Optimizer)
+      @Nullable String expectErrorMsg, boolean keepOutputRowOrder, boolean ignoreV2Optimizer, boolean ignoreLiteMode)
       throws Exception {
     // query pinot
     runQuery(sql, expectErrorMsg, false).ifPresent(queryResult -> {
@@ -285,7 +339,7 @@ public class ResourceBasedQueriesTest extends QueryRunnerTestBase {
   // TODO: name the test using testCaseName for testng reports
   @Test(dataProvider = "testResourceQueryTestCaseProviderInputOnly")
   public void testQueryTestCasesWithH2WithNewOptimizer(String testCaseName, boolean isIgnored, String sql, String h2Sql,
-      String expect, boolean keepOutputRowOrder, boolean ignoreV2Optimizer)
+      String expect, boolean keepOutputRowOrder, boolean ignoreV2Optimizer, boolean ignoreLiteMode)
       throws Exception {
     // query pinot
     if (ignoreV2Optimizer) {
@@ -304,7 +358,8 @@ public class ResourceBasedQueriesTest extends QueryRunnerTestBase {
 
   @Test(dataProvider = "testResourceQueryTestCaseProviderBoth")
   public void testQueryTestCasesWithOutput(String testCaseName, boolean isIgnored, String sql, String h2Sql,
-      List<Object[]> expectedRows, String expect, boolean keepOutputRowOrder, boolean ignoreV2Optimizer)
+      List<Object[]> expectedRows, String expect, boolean keepOutputRowOrder, boolean ignoreV2Optimizer,
+      boolean ignoreLiteMode)
       throws Exception {
     runQuery(sql, expect, false).ifPresent(
         queryResult -> compareRowEquals(queryResult.getResultTable(), expectedRows, keepOutputRowOrder));
@@ -312,7 +367,8 @@ public class ResourceBasedQueriesTest extends QueryRunnerTestBase {
 
   @Test(dataProvider = "testResourceQueryTestCaseProviderBoth")
   public void testQueryTestCasesWithNewOptimizerWithOutput(String testCaseName, boolean isIgnored, String sql,
-      String h2Sql, List<Object[]> expectedRows, String expect, boolean keepOutputRowOrder, boolean ignoreV2Optimizer)
+      String h2Sql, List<Object[]> expectedRows, String expect, boolean keepOutputRowOrder, boolean ignoreV2Optimizer,
+      boolean ignoreLiteMode)
       throws Exception {
     if (ignoreV2Optimizer) {
       throw new SkipException(
@@ -325,11 +381,12 @@ public class ResourceBasedQueriesTest extends QueryRunnerTestBase {
 
   @Test(dataProvider = "testResourceQueryTestCaseProviderBoth")
   public void testQueryTestCasesWithLiteModeWithOutput(String testCaseName, boolean isIgnored, String sql,
-      String h2Sql, List<Object[]> expectedRows, String expect, boolean keepOutputRowOrder, boolean ignoreV2Optimizer)
+      String h2Sql, List<Object[]> expectedRows, String expect, boolean keepOutputRowOrder, boolean ignoreV2Optimizer,
+      boolean ignoreLiteMode)
       throws Exception {
-    if (ignoreV2Optimizer) {
+    if (ignoreV2Optimizer || ignoreLiteMode) {
       throw new SkipException(
-          "Ignoring query for test-case with v2 optimizer, testCase: " + testCaseName + ", SQL: " + sql);
+          "Ignoring query for test-case with lite mode, testCase: " + testCaseName + ", SQL: " + sql);
     }
     final String finalSql = String.format("SET usePhysicalOptimizer=true; SET useLiteMode=true; %s", sql);
     runQuery(finalSql, expect, false).ifPresent(
@@ -457,7 +514,7 @@ public class ResourceBasedQueriesTest extends QueryRunnerTestBase {
           }
           Object[] testEntry = new Object[]{
               testCaseName, queryCase._ignored, sql, h2Sql, expectedRows, queryCase._expectedException,
-              queryCase._keepOutputRowOrder, queryCase._ignoreV2Optimizer
+              queryCase._keepOutputRowOrder, queryCase._ignoreV2Optimizer, queryCase._ignoreLiteMode
           };
           providerContent.add(testEntry);
         }
@@ -535,7 +592,7 @@ public class ResourceBasedQueriesTest extends QueryRunnerTestBase {
               : replaceTableName(testCaseName, queryCase._sql);
           Object[] testEntry = new Object[]{
               testCaseName, queryCase._ignored, sql, h2Sql, queryCase._expectedException, queryCase._keepOutputRowOrder,
-              queryCase._ignoreV2Optimizer
+              queryCase._ignoreV2Optimizer, queryCase._ignoreLiteMode
           };
           providerContent.add(testEntry);
         }

--- a/pinot-query-runtime/src/test/resources/queries/LookupJoin.json
+++ b/pinot-query-runtime/src/test/resources/queries/LookupJoin.json
@@ -1,0 +1,47 @@
+{
+  "lookup_join_basic": {
+    "comment": "Tests lookup join with a dimension table. V1 and V2 pass end-to-end. Lite mode is skipped because the broker lacks DimensionTableDataManager. The V2 path is additionally validated at the planner level by LookupJoinPlanTest.",
+    "tables": {
+      "fact_tbl": {
+        "schema": [
+          {"name": "dim_key", "type": "INT"},
+          {"name": "metric", "type": "INT"}
+        ],
+        "inputs": [
+          [1, 100],
+          [2, 200],
+          [3, 300],
+          [1, 400],
+          [4, 500]
+        ]
+      },
+      "dim_tbl": {
+        "schema": [
+          {"name": "id", "type": "INT"},
+          {"name": "name", "type": "STRING"}
+        ],
+        "inputs": [
+          [1, "alpha"],
+          [2, "beta"],
+          [3, "gamma"]
+        ],
+        "replicated": true,
+        "isDimTable": true,
+        "primaryKeyColumns": ["id"]
+      }
+    },
+    "queries": [
+      {
+        "description": "Basic lookup join - inner join with dim table",
+        "sql": "SELECT /*+ joinOptions(join_strategy='lookup') */ {fact_tbl}.dim_key, {dim_tbl}.name FROM {fact_tbl} JOIN {dim_tbl} ON {fact_tbl}.dim_key = {dim_tbl}.id ORDER BY {fact_tbl}.dim_key, {dim_tbl}.name",
+        "outputs": [
+          [1, "alpha"],
+          [1, "alpha"],
+          [2, "beta"],
+          [3, "gamma"]
+        ],
+        "ignoreLiteMode": true
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Addresses: https://github.com/apache/pinot/issues/17961

## Problem

Using lookup joins in the physical optimizer via query hint `joinOptions(join_strategy='lookup')` would fail with `"Right input must be leaf operator"`. The optimizer inserted a `BROADCAST_EXCHANGE` on the dimension table side, splitting it into a separate fragment, but `LookupJoinOperator` needs the dimension table as a `LeafOperator` in the same fragment because it expects to have access to a `DimensionTableDataManager`.

## Solution

This adds lookup join support to the V2 physical optimizer by:

* Adds a `LOOKUP_LOCAL_EXCHANGE` which acts as a pseudo-exchange so the fragment is classified as a leaf stage and the dim table is visible in EXPLAIN plans
* Adding a `LookupJoinRule` to isolate every lookup join in its own plan fragment with exchanges on all sides (IDENTITY_EXCHANGE above the join and for non-dim table, LOOKUP_LOCAL_EXCHANGE for dim table)

```mermaid
  graph TD
      subgraph before ["Before: Dim table split into separate fragment"]
          A0[Downstream operators] --> A1["PhysicalJoin<br/>join_strategy=lookup"]
          A1 --> B1[IDENTITY_EXCHANGE]
          A1 --> C1["IDENTITY_EXCHANGE<br/>❌ splits dim into separate fragment"]
          B1 --> D1[FactTableScan]
          C1 --> E1[DimTableScan]
          style C1 fill:#f88,stroke:#c00
          style E1 fill:#f88,stroke:#c00
      end

      subgraph after ["After: LookupJoinRule isolates the lookup join"]
          A2[Downstream operators] --> IX_ABOVE["IDENTITY_EXCHANGE<br/>(above — isolation)"]
          IX_ABOVE --> J2["PhysicalJoin<br/>join_strategy=lookup"]
          J2 --> IX_LEFT["IDENTITY_EXCHANGE<br/>(left — leaf boundary)"]
          J2 --> LLE["LOOKUP_LOCAL_EXCHANGE<br/>(right — pseudo, no split)"]
          IX_LEFT --> FS2[FactTableScan]
          LLE --> DS2[DimTableScan]
          style LLE fill:#8f8,stroke:#0a0
          style IX_ABOVE fill:#8cf,stroke:#06c
          style IX_LEFT fill:#8cf,stroke:#06c
      end

      before ~~~ after
```

Another alternative was to match MSE v1 behavior by skipping exchange on right side, but I didn't go down this path since omitting exchanges could break assumptions in other rules (every stage boundary has a PhysicalExchange) and we wouldn't get visibility in explain plans.

## Future work

* Support lookup joins in MSE lite mode
* Auto-detect lookup joins when either side of join is dim table joining on primary keys

## Testing

We've deployed this on our production clusters and have compared production query results (multiple chained joins using dim tables for date spines and fx rates) with and without the physical optimizer. We haven't seen issues with correctness.

cc @ankitsultana @shauryachats 