### PR TITLE
Expose test cancellation hook.

### DIFF
--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/QueryServerEnclosure.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/QueryServerEnclosure.java
@@ -78,6 +78,10 @@ public class QueryServerEnclosure {
     _queryRunner.shutDown();
   }
 
+  public void cancel(long requestId) {
+    _queryRunner.cancel(requestId);
+  }
+
   public CompletableFuture<Void> processQuery(WorkerMetadata workerMetadata, StagePlan stagePlan,
       Map<String, String> requestMetadataMap) {
     QueryExecutionContext executionContext = QueryExecutionContext.forMseServerRequest(requestMetadataMap, "serverId");


### PR DESCRIPTION
A simple change that allows server enclosures to cancel queries.