### PR TITLE
Add OOM pause mechanism to pause query threads before killing on critical heap

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/accounting/PerQueryCPUMemAccountantFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/accounting/PerQueryCPUMemAccountantFactory.java
@@ -404,6 +404,8 @@ public class PerQueryCPUMemAccountantFactory implements ThreadAccountantFactory 
         LOGGER.info("_minMemoryFootprintForKill: {}", queryMonitorConfig.getMinMemoryFootprintForKill());
         LOGGER.info("_cpuTimeBasedKillingEnabled: {}", queryMonitorConfig.isCpuTimeBasedKillingEnabled());
         LOGGER.info("_cpuTimeBasedKillingThresholdNs: {}", queryMonitorConfig.getCpuTimeBasedKillingThresholdNs());
+        LOGGER.info("_oomPauseEnabled: {}", queryMonitorConfig.isOomPauseEnabled());
+        LOGGER.info("_oomPauseTimeoutMs: {}", queryMonitorConfig.getOomPauseTimeoutMs());
       }
 
       @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/accounting/PerQueryCPUMemAccountantFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/accounting/PerQueryCPUMemAccountantFactory.java
@@ -404,8 +404,6 @@ public class PerQueryCPUMemAccountantFactory implements ThreadAccountantFactory 
         LOGGER.info("_minMemoryFootprintForKill: {}", queryMonitorConfig.getMinMemoryFootprintForKill());
         LOGGER.info("_cpuTimeBasedKillingEnabled: {}", queryMonitorConfig.isCpuTimeBasedKillingEnabled());
         LOGGER.info("_cpuTimeBasedKillingThresholdNs: {}", queryMonitorConfig.getCpuTimeBasedKillingThresholdNs());
-        LOGGER.info("_oomPauseEnabled: {}", queryMonitorConfig.isOomPauseEnabled());
-        LOGGER.info("_oomPauseTimeoutMs: {}", queryMonitorConfig.getOomPauseTimeoutMs());
       }
 
       @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/accounting/QueryMonitorConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/accounting/QueryMonitorConfig.java
@@ -62,6 +62,12 @@ public class QueryMonitorConfig {
 
   private final boolean _queryKilledMetricEnabled;
 
+  // if we want to pause query threads before killing to allow the JVM to reclaim memory
+  private final boolean _oomPauseEnabled;
+
+  // how long to pause query threads (ms) before proceeding with kill
+  private final long _oomPauseTimeoutMs;
+
   private final int _workloadSleepTimeMs;
 
   private final boolean _workloadCostEnforcementEnabled;
@@ -110,6 +116,12 @@ public class QueryMonitorConfig {
 
     _queryKilledMetricEnabled = config.getProperty(CommonConstants.Accounting.CONFIG_OF_QUERY_KILLED_METRIC_ENABLED,
         CommonConstants.Accounting.DEFAULT_QUERY_KILLED_METRIC_ENABLED);
+
+    _oomPauseEnabled = config.getProperty(CommonConstants.Accounting.CONFIG_OF_OOM_PAUSE_ENABLED,
+        CommonConstants.Accounting.DEFAULT_OOM_PAUSE_ENABLED);
+
+    _oomPauseTimeoutMs = config.getProperty(CommonConstants.Accounting.CONFIG_OF_OOM_PAUSE_TIMEOUT_MS,
+        CommonConstants.Accounting.DEFAULT_OOM_PAUSE_TIMEOUT_MS);
 
     _workloadSleepTimeMs = config.getProperty(CommonConstants.Accounting.CONFIG_OF_WORKLOAD_SLEEP_TIME_MS,
         CommonConstants.Accounting.DEFAULT_WORKLOAD_SLEEP_TIME_MS);
@@ -257,6 +269,30 @@ public class QueryMonitorConfig {
       _queryKilledMetricEnabled = oldConfig._queryKilledMetricEnabled;
     }
 
+    if (changedConfigs.contains(CommonConstants.Accounting.CONFIG_OF_OOM_PAUSE_ENABLED)) {
+      if (clusterConfigs == null || !clusterConfigs.containsKey(
+          CommonConstants.Accounting.CONFIG_OF_OOM_PAUSE_ENABLED)) {
+        _oomPauseEnabled = CommonConstants.Accounting.DEFAULT_OOM_PAUSE_ENABLED;
+      } else {
+        _oomPauseEnabled =
+            Boolean.parseBoolean(clusterConfigs.get(CommonConstants.Accounting.CONFIG_OF_OOM_PAUSE_ENABLED));
+      }
+    } else {
+      _oomPauseEnabled = oldConfig._oomPauseEnabled;
+    }
+
+    if (changedConfigs.contains(CommonConstants.Accounting.CONFIG_OF_OOM_PAUSE_TIMEOUT_MS)) {
+      if (clusterConfigs == null || !clusterConfigs.containsKey(
+          CommonConstants.Accounting.CONFIG_OF_OOM_PAUSE_TIMEOUT_MS)) {
+        _oomPauseTimeoutMs = CommonConstants.Accounting.DEFAULT_OOM_PAUSE_TIMEOUT_MS;
+      } else {
+        _oomPauseTimeoutMs =
+            Long.parseLong(clusterConfigs.get(CommonConstants.Accounting.CONFIG_OF_OOM_PAUSE_TIMEOUT_MS));
+      }
+    } else {
+      _oomPauseTimeoutMs = oldConfig._oomPauseTimeoutMs;
+    }
+
     if (changedConfigs.contains(CommonConstants.Accounting.CONFIG_OF_WORKLOAD_SLEEP_TIME_MS)) {
       if (clusterConfigs == null || !clusterConfigs.containsKey(
           CommonConstants.Accounting.CONFIG_OF_WORKLOAD_SLEEP_TIME_MS)) {
@@ -328,6 +364,14 @@ public class QueryMonitorConfig {
 
   public boolean isQueryKilledMetricEnabled() {
     return _queryKilledMetricEnabled;
+  }
+
+  public boolean isOomPauseEnabled() {
+    return _oomPauseEnabled;
+  }
+
+  public long getOomPauseTimeoutMs() {
+    return _oomPauseTimeoutMs;
   }
 
   public int getWorkloadSleepTimeMs() {

--- a/pinot-core/src/main/java/org/apache/pinot/core/accounting/QueryMonitorConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/accounting/QueryMonitorConfig.java
@@ -62,10 +62,7 @@ public class QueryMonitorConfig {
 
   private final boolean _queryKilledMetricEnabled;
 
-  // if we want to pause query threads before killing to allow the JVM to reclaim memory
-  private final boolean _oomPauseEnabled;
-
-  // how long to pause query threads (ms) before proceeding with kill
+  // how long to pause query threads (ms) before proceeding with kill; non-positive means disabled
   private final long _oomPauseTimeoutMs;
 
   private final int _workloadSleepTimeMs;
@@ -116,9 +113,6 @@ public class QueryMonitorConfig {
 
     _queryKilledMetricEnabled = config.getProperty(CommonConstants.Accounting.CONFIG_OF_QUERY_KILLED_METRIC_ENABLED,
         CommonConstants.Accounting.DEFAULT_QUERY_KILLED_METRIC_ENABLED);
-
-    _oomPauseEnabled = config.getProperty(CommonConstants.Accounting.CONFIG_OF_OOM_PAUSE_ENABLED,
-        CommonConstants.Accounting.DEFAULT_OOM_PAUSE_ENABLED);
 
     _oomPauseTimeoutMs = config.getProperty(CommonConstants.Accounting.CONFIG_OF_OOM_PAUSE_TIMEOUT_MS,
         CommonConstants.Accounting.DEFAULT_OOM_PAUSE_TIMEOUT_MS);
@@ -269,18 +263,6 @@ public class QueryMonitorConfig {
       _queryKilledMetricEnabled = oldConfig._queryKilledMetricEnabled;
     }
 
-    if (changedConfigs.contains(CommonConstants.Accounting.CONFIG_OF_OOM_PAUSE_ENABLED)) {
-      if (clusterConfigs == null || !clusterConfigs.containsKey(
-          CommonConstants.Accounting.CONFIG_OF_OOM_PAUSE_ENABLED)) {
-        _oomPauseEnabled = CommonConstants.Accounting.DEFAULT_OOM_PAUSE_ENABLED;
-      } else {
-        _oomPauseEnabled =
-            Boolean.parseBoolean(clusterConfigs.get(CommonConstants.Accounting.CONFIG_OF_OOM_PAUSE_ENABLED));
-      }
-    } else {
-      _oomPauseEnabled = oldConfig._oomPauseEnabled;
-    }
-
     if (changedConfigs.contains(CommonConstants.Accounting.CONFIG_OF_OOM_PAUSE_TIMEOUT_MS)) {
       if (clusterConfigs == null || !clusterConfigs.containsKey(
           CommonConstants.Accounting.CONFIG_OF_OOM_PAUSE_TIMEOUT_MS)) {
@@ -367,7 +349,7 @@ public class QueryMonitorConfig {
   }
 
   public boolean isOomPauseEnabled() {
-    return _oomPauseEnabled;
+    return _oomPauseTimeoutMs > 0;
   }
 
   public long getOomPauseTimeoutMs() {

--- a/pinot-core/src/main/java/org/apache/pinot/core/accounting/QueryMonitorConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/accounting/QueryMonitorConfig.java
@@ -122,7 +122,7 @@ public class QueryMonitorConfig {
         CommonConstants.Accounting.DEFAULT_OOM_PRE_QUERY_KILL_PAUSE_DURATION_MS);
 
     _oomPanicPreQueryKillPauseEnabled = config.getProperty(
-        CommonConstants.Accounting.CONFIG_OF_OOM_PANIC_PRE_QUERY_KILL_PAUSE_ENABLED,
+        CommonConstants.Accounting.CONFIG_OF_OOM_PANIC_ALLOW_PRE_QUERY_KILL_PAUSE,
         CommonConstants.Accounting.DEFAULT_OOM_PANIC_PRE_QUERY_KILL_PAUSE_ENABLED);
 
     _workloadSleepTimeMs = config.getProperty(CommonConstants.Accounting.CONFIG_OF_WORKLOAD_SLEEP_TIME_MS,
@@ -283,13 +283,13 @@ public class QueryMonitorConfig {
       _oomPreQueryKillPauseDurationMs = oldConfig._oomPreQueryKillPauseDurationMs;
     }
 
-    if (changedConfigs.contains(CommonConstants.Accounting.CONFIG_OF_OOM_PANIC_PRE_QUERY_KILL_PAUSE_ENABLED)) {
+    if (changedConfigs.contains(CommonConstants.Accounting.CONFIG_OF_OOM_PANIC_ALLOW_PRE_QUERY_KILL_PAUSE)) {
       if (clusterConfigs == null || !clusterConfigs.containsKey(
-          CommonConstants.Accounting.CONFIG_OF_OOM_PANIC_PRE_QUERY_KILL_PAUSE_ENABLED)) {
+          CommonConstants.Accounting.CONFIG_OF_OOM_PANIC_ALLOW_PRE_QUERY_KILL_PAUSE)) {
         _oomPanicPreQueryKillPauseEnabled = CommonConstants.Accounting.DEFAULT_OOM_PANIC_PRE_QUERY_KILL_PAUSE_ENABLED;
       } else {
         _oomPanicPreQueryKillPauseEnabled = Boolean.parseBoolean(
-            clusterConfigs.get(CommonConstants.Accounting.CONFIG_OF_OOM_PANIC_PRE_QUERY_KILL_PAUSE_ENABLED));
+            clusterConfigs.get(CommonConstants.Accounting.CONFIG_OF_OOM_PANIC_ALLOW_PRE_QUERY_KILL_PAUSE));
       }
     } else {
       _oomPanicPreQueryKillPauseEnabled = oldConfig._oomPanicPreQueryKillPauseEnabled;

--- a/pinot-core/src/main/java/org/apache/pinot/core/accounting/QueryMonitorConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/accounting/QueryMonitorConfig.java
@@ -65,6 +65,9 @@ public class QueryMonitorConfig {
   // how long to pause query threads (ms) before proceeding with kill; non-positive means disabled
   private final long _oomPauseTimeoutMs;
 
+  // whether to also apply the OOM pause before killing at panic level
+  private final boolean _oomPauseOnPanicEnabled;
+
   private final int _workloadSleepTimeMs;
 
   private final boolean _workloadCostEnforcementEnabled;
@@ -114,8 +117,12 @@ public class QueryMonitorConfig {
     _queryKilledMetricEnabled = config.getProperty(CommonConstants.Accounting.CONFIG_OF_QUERY_KILLED_METRIC_ENABLED,
         CommonConstants.Accounting.DEFAULT_QUERY_KILLED_METRIC_ENABLED);
 
-    _oomPauseTimeoutMs = config.getProperty(CommonConstants.Accounting.CONFIG_OF_OOM_PAUSE_TIMEOUT_MS,
-        CommonConstants.Accounting.DEFAULT_OOM_PAUSE_TIMEOUT_MS);
+    _oomPauseTimeoutMs = config.getProperty(CommonConstants.Accounting.CONFIG_OF_OOM_PRE_QUERY_KILL_PAUSE_DURATION_MS,
+        CommonConstants.Accounting.DEFAULT_OOM_PRE_QUERY_KILL_PAUSE_DURATION_MS);
+
+    _oomPauseOnPanicEnabled = config.getProperty(
+        CommonConstants.Accounting.CONFIG_OF_OOM_PANIC_PRE_QUERY_KILL_PAUSE_ENABLED,
+        CommonConstants.Accounting.DEFAULT_OOM_PANIC_PRE_QUERY_KILL_PAUSE_ENABLED);
 
     _workloadSleepTimeMs = config.getProperty(CommonConstants.Accounting.CONFIG_OF_WORKLOAD_SLEEP_TIME_MS,
         CommonConstants.Accounting.DEFAULT_WORKLOAD_SLEEP_TIME_MS);
@@ -263,16 +270,28 @@ public class QueryMonitorConfig {
       _queryKilledMetricEnabled = oldConfig._queryKilledMetricEnabled;
     }
 
-    if (changedConfigs.contains(CommonConstants.Accounting.CONFIG_OF_OOM_PAUSE_TIMEOUT_MS)) {
+    if (changedConfigs.contains(CommonConstants.Accounting.CONFIG_OF_OOM_PRE_QUERY_KILL_PAUSE_DURATION_MS)) {
       if (clusterConfigs == null || !clusterConfigs.containsKey(
-          CommonConstants.Accounting.CONFIG_OF_OOM_PAUSE_TIMEOUT_MS)) {
-        _oomPauseTimeoutMs = CommonConstants.Accounting.DEFAULT_OOM_PAUSE_TIMEOUT_MS;
+          CommonConstants.Accounting.CONFIG_OF_OOM_PRE_QUERY_KILL_PAUSE_DURATION_MS)) {
+        _oomPauseTimeoutMs = CommonConstants.Accounting.DEFAULT_OOM_PRE_QUERY_KILL_PAUSE_DURATION_MS;
       } else {
-        _oomPauseTimeoutMs =
-            Long.parseLong(clusterConfigs.get(CommonConstants.Accounting.CONFIG_OF_OOM_PAUSE_TIMEOUT_MS));
+        _oomPauseTimeoutMs = Long.parseLong(
+            clusterConfigs.get(CommonConstants.Accounting.CONFIG_OF_OOM_PRE_QUERY_KILL_PAUSE_DURATION_MS));
       }
     } else {
       _oomPauseTimeoutMs = oldConfig._oomPauseTimeoutMs;
+    }
+
+    if (changedConfigs.contains(CommonConstants.Accounting.CONFIG_OF_OOM_PANIC_PRE_QUERY_KILL_PAUSE_ENABLED)) {
+      if (clusterConfigs == null || !clusterConfigs.containsKey(
+          CommonConstants.Accounting.CONFIG_OF_OOM_PANIC_PRE_QUERY_KILL_PAUSE_ENABLED)) {
+        _oomPauseOnPanicEnabled = CommonConstants.Accounting.DEFAULT_OOM_PANIC_PRE_QUERY_KILL_PAUSE_ENABLED;
+      } else {
+        _oomPauseOnPanicEnabled = Boolean.parseBoolean(
+            clusterConfigs.get(CommonConstants.Accounting.CONFIG_OF_OOM_PANIC_PRE_QUERY_KILL_PAUSE_ENABLED));
+      }
+    } else {
+      _oomPauseOnPanicEnabled = oldConfig._oomPauseOnPanicEnabled;
     }
 
     if (changedConfigs.contains(CommonConstants.Accounting.CONFIG_OF_WORKLOAD_SLEEP_TIME_MS)) {
@@ -354,6 +373,10 @@ public class QueryMonitorConfig {
 
   public long getOomPauseTimeoutMs() {
     return _oomPauseTimeoutMs;
+  }
+
+  public boolean isOomPauseOnPanicEnabled() {
+    return _oomPauseOnPanicEnabled;
   }
 
   public int getWorkloadSleepTimeMs() {

--- a/pinot-core/src/main/java/org/apache/pinot/core/accounting/QueryMonitorConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/accounting/QueryMonitorConfig.java
@@ -63,10 +63,10 @@ public class QueryMonitorConfig {
   private final boolean _queryKilledMetricEnabled;
 
   // how long to pause query threads (ms) before proceeding with kill; non-positive means disabled
-  private final long _oomPauseTimeoutMs;
+  private final long _oomPreQueryKillPauseDurationMs;
 
   // whether to also apply the OOM pause before killing at panic level
-  private final boolean _oomPauseOnPanicEnabled;
+  private final boolean _oomPanicPreQueryKillPauseEnabled;
 
   private final int _workloadSleepTimeMs;
 
@@ -117,10 +117,11 @@ public class QueryMonitorConfig {
     _queryKilledMetricEnabled = config.getProperty(CommonConstants.Accounting.CONFIG_OF_QUERY_KILLED_METRIC_ENABLED,
         CommonConstants.Accounting.DEFAULT_QUERY_KILLED_METRIC_ENABLED);
 
-    _oomPauseTimeoutMs = config.getProperty(CommonConstants.Accounting.CONFIG_OF_OOM_PRE_QUERY_KILL_PAUSE_DURATION_MS,
+    _oomPreQueryKillPauseDurationMs = config.getProperty(
+        CommonConstants.Accounting.CONFIG_OF_OOM_PRE_QUERY_KILL_PAUSE_DURATION_MS,
         CommonConstants.Accounting.DEFAULT_OOM_PRE_QUERY_KILL_PAUSE_DURATION_MS);
 
-    _oomPauseOnPanicEnabled = config.getProperty(
+    _oomPanicPreQueryKillPauseEnabled = config.getProperty(
         CommonConstants.Accounting.CONFIG_OF_OOM_PANIC_PRE_QUERY_KILL_PAUSE_ENABLED,
         CommonConstants.Accounting.DEFAULT_OOM_PANIC_PRE_QUERY_KILL_PAUSE_ENABLED);
 
@@ -273,25 +274,25 @@ public class QueryMonitorConfig {
     if (changedConfigs.contains(CommonConstants.Accounting.CONFIG_OF_OOM_PRE_QUERY_KILL_PAUSE_DURATION_MS)) {
       if (clusterConfigs == null || !clusterConfigs.containsKey(
           CommonConstants.Accounting.CONFIG_OF_OOM_PRE_QUERY_KILL_PAUSE_DURATION_MS)) {
-        _oomPauseTimeoutMs = CommonConstants.Accounting.DEFAULT_OOM_PRE_QUERY_KILL_PAUSE_DURATION_MS;
+        _oomPreQueryKillPauseDurationMs = CommonConstants.Accounting.DEFAULT_OOM_PRE_QUERY_KILL_PAUSE_DURATION_MS;
       } else {
-        _oomPauseTimeoutMs = Long.parseLong(
+        _oomPreQueryKillPauseDurationMs = Long.parseLong(
             clusterConfigs.get(CommonConstants.Accounting.CONFIG_OF_OOM_PRE_QUERY_KILL_PAUSE_DURATION_MS));
       }
     } else {
-      _oomPauseTimeoutMs = oldConfig._oomPauseTimeoutMs;
+      _oomPreQueryKillPauseDurationMs = oldConfig._oomPreQueryKillPauseDurationMs;
     }
 
     if (changedConfigs.contains(CommonConstants.Accounting.CONFIG_OF_OOM_PANIC_PRE_QUERY_KILL_PAUSE_ENABLED)) {
       if (clusterConfigs == null || !clusterConfigs.containsKey(
           CommonConstants.Accounting.CONFIG_OF_OOM_PANIC_PRE_QUERY_KILL_PAUSE_ENABLED)) {
-        _oomPauseOnPanicEnabled = CommonConstants.Accounting.DEFAULT_OOM_PANIC_PRE_QUERY_KILL_PAUSE_ENABLED;
+        _oomPanicPreQueryKillPauseEnabled = CommonConstants.Accounting.DEFAULT_OOM_PANIC_PRE_QUERY_KILL_PAUSE_ENABLED;
       } else {
-        _oomPauseOnPanicEnabled = Boolean.parseBoolean(
+        _oomPanicPreQueryKillPauseEnabled = Boolean.parseBoolean(
             clusterConfigs.get(CommonConstants.Accounting.CONFIG_OF_OOM_PANIC_PRE_QUERY_KILL_PAUSE_ENABLED));
       }
     } else {
-      _oomPauseOnPanicEnabled = oldConfig._oomPauseOnPanicEnabled;
+      _oomPanicPreQueryKillPauseEnabled = oldConfig._oomPanicPreQueryKillPauseEnabled;
     }
 
     if (changedConfigs.contains(CommonConstants.Accounting.CONFIG_OF_WORKLOAD_SLEEP_TIME_MS)) {
@@ -367,16 +368,16 @@ public class QueryMonitorConfig {
     return _queryKilledMetricEnabled;
   }
 
-  public boolean isOomPauseEnabled() {
-    return _oomPauseTimeoutMs > 0;
+  public boolean isOomPreQueryKillPauseEnabled() {
+    return _oomPreQueryKillPauseDurationMs > 0;
   }
 
-  public long getOomPauseTimeoutMs() {
-    return _oomPauseTimeoutMs;
+  public long getOomPreQueryKillPauseDurationMs() {
+    return _oomPreQueryKillPauseDurationMs;
   }
 
-  public boolean isOomPauseOnPanicEnabled() {
-    return _oomPauseOnPanicEnabled;
+  public boolean isOomPanicPreQueryKillPauseEnabled() {
+    return _oomPanicPreQueryKillPauseEnabled;
   }
 
   public int getWorkloadSleepTimeMs() {

--- a/pinot-core/src/main/java/org/apache/pinot/core/accounting/QueryResourceAggregator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/accounting/QueryResourceAggregator.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.accounting;
 
+import com.google.common.annotations.VisibleForTesting;
 import it.unimi.dsi.fastutil.longs.LongLongMutablePair;
 import java.util.Comparator;
 import java.util.HashMap;
@@ -25,7 +26,10 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.Condition;
+import java.util.concurrent.locks.ReentrantLock;
 import org.apache.pinot.common.metrics.AbstractMetrics;
 import org.apache.pinot.common.metrics.BrokerGauge;
 import org.apache.pinot.common.metrics.BrokerMeter;
@@ -74,6 +78,15 @@ public class QueryResourceAggregator implements ResourceAggregator {
   // Key is query id.
   private Map<String, QueryResourceTrackerImpl> _queryResourceUsages;
   private TriggeringLevel _triggeringLevel = TriggeringLevel.Normal;
+
+  // Track previous triggering level to detect transitions into critical
+  private TriggeringLevel _previousTriggeringLevel = TriggeringLevel.Normal;
+
+  // OOM pause state - lock+condition for blocking query threads at critical heap level
+  private final ReentrantLock _pauseLock = new ReentrantLock();
+  private final Condition _pauseCondition = _pauseLock.newCondition();
+  private volatile boolean _pauseActive = false;
+  private volatile long _pauseDeadlineMs = 0;
 
   // metrics class
   private final AbstractMetrics _metrics;
@@ -133,12 +146,20 @@ public class QueryResourceAggregator implements ResourceAggregator {
     QueryMonitorConfig config = _queryMonitorConfig.get();
     _sleepTime = config.getNormalSleepTime();
     _queryResourceUsages = null;
+    _previousTriggeringLevel = _triggeringLevel;
     collectTriggerMetrics();
     evalTriggers();
     // Prioritize the panic check, kill ALL QUERIES immediately if triggered
     if (_triggeringLevel == TriggeringLevel.HeapMemoryPanic) {
       killAllQueries(threadTrackers);
+      if (_pauseActive) {
+        clearPause();
+      }
       return;
+    }
+    // If heap recovered below critical while an OOM pause is active, clear it
+    if (_pauseActive && _triggeringLevel.ordinal() < TriggeringLevel.HeapMemoryCritical.ordinal()) {
+      clearPause();
     }
     // Track aggregated query resource usage if triggered
     if (_triggeringLevel.ordinal() > TriggeringLevel.Normal.ordinal()) {
@@ -179,7 +200,22 @@ public class QueryResourceAggregator implements ResourceAggregator {
     }
     switch (_triggeringLevel) {
       case HeapMemoryCritical:
-        killMostExpensiveQuery();
+        QueryMonitorConfig config = _queryMonitorConfig.get();
+        if (_pauseActive) {
+          // Pause is active - check if grace period expired
+          if (System.currentTimeMillis() >= _pauseDeadlineMs) {
+            clearPause();
+            killMostExpensiveQuery();
+          }
+          // else: still in grace period, skip kill this cycle
+        } else if (config.isOomPauseEnabled()
+            && _previousTriggeringLevel.ordinal() < TriggeringLevel.HeapMemoryCritical.ordinal()) {
+          // Just transitioned to critical - activate pause instead of killing
+          activatePause(config.getOomPauseTimeoutMs());
+        } else {
+          // Pause disabled, or already been through a pause cycle - kill
+          killMostExpensiveQuery();
+        }
         break;
       case CPUTimeBasedKilling:
         killCPUTimeExceedQueries();
@@ -263,6 +299,60 @@ public class QueryResourceAggregator implements ResourceAggregator {
         default:
           throw new IllegalStateException("Unsupported triggering level: " + _triggeringLevel);
       }
+    }
+  }
+
+  /**
+   * Activates an OOM pause. Query threads calling {@link #waitIfPaused()} will block until the pause is cleared or the
+   * deadline expires. Also hints the JVM to run garbage collection.
+   */
+  private void activatePause(long timeoutMs) {
+    LOGGER.warn("Activating OOM pause for {}ms to allow garbage collection before killing queries. "
+        + "Heap used bytes: {}", timeoutMs, _usedBytes);
+    // Write deadline before the flag - volatile ordering guarantees any thread that reads
+    // _pauseActive == true will also see the updated _pauseDeadlineMs.
+    _pauseDeadlineMs = System.currentTimeMillis() + timeoutMs;
+    _pauseActive = true;
+    // Hint the JVM to run GC while query threads are pausing
+    System.gc();
+  }
+
+  /**
+   * Clears the OOM pause and wakes all blocked query threads.
+   */
+  private void clearPause() {
+    LOGGER.info("Clearing OOM pause. Heap used bytes: {}", _usedBytes);
+    _pauseLock.lock();
+    try {
+      _pauseActive = false;
+      _pauseCondition.signalAll();
+    } finally {
+      _pauseLock.unlock();
+    }
+  }
+
+  /**
+   * Called by query threads at sampling checkpoints. Blocks if an OOM pause is active. Fast-path: single volatile read
+   * when no pause is active.
+   */
+  void waitIfPaused() {
+    if (!_pauseActive) {
+      return;
+    }
+    _pauseLock.lock();
+    try {
+      while (_pauseActive) {
+        long remaining = _pauseDeadlineMs - System.currentTimeMillis();
+        if (remaining <= 0) {
+          break;
+        }
+        _pauseCondition.await(remaining, TimeUnit.MILLISECONDS);
+      }
+    } catch (InterruptedException e) {
+      // Query was killed during pause - restore interrupt flag so the next checkTermination() call detects it
+      Thread.currentThread().interrupt();
+    } finally {
+      _pauseLock.unlock();
     }
   }
 
@@ -392,6 +482,20 @@ public class QueryResourceAggregator implements ResourceAggregator {
     }
     _inactiveQueries.clear();
     _inactiveQueries.addAll(_untrackedCpuMemUsage.keySet());
+  }
+
+  boolean isPauseActive() {
+    return _pauseActive;
+  }
+
+  @VisibleForTesting
+  TriggeringLevel getTriggeringLevel() {
+    return _triggeringLevel;
+  }
+
+  @VisibleForTesting
+  TriggeringLevel getPreviousTriggeringLevel() {
+    return _previousTriggeringLevel;
   }
 
   public long getHeapUsageBytes() {

--- a/pinot-core/src/main/java/org/apache/pinot/core/accounting/QueryResourceAggregator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/accounting/QueryResourceAggregator.java
@@ -150,7 +150,7 @@ public class QueryResourceAggregator implements ResourceAggregator {
     evalTriggers();
     // Prioritize the panic check
     if (_triggeringLevel == TriggeringLevel.HeapMemoryPanic) {
-      boolean pauseOnPanic = config.isOomPauseEnabled() && config.isOomPauseOnPanicEnabled();
+      boolean pauseOnPanic = config.isOomPreQueryKillPauseEnabled() && config.isOomPanicPreQueryKillPauseEnabled();
       if (_pauseActive) {
         if (System.currentTimeMillis() >= _pauseDeadlineMs || !pauseOnPanic) {
           // Grace period expired, or panic-pause disabled — kill all and clear
@@ -161,7 +161,7 @@ public class QueryResourceAggregator implements ResourceAggregator {
       } else if (pauseOnPanic
           && _previousTriggeringLevel.ordinal() < TriggeringLevel.HeapMemoryCritical.ordinal()) {
         // Fresh jump to panic bypassing critical — activate pause before killing
-        activatePause(config.getOomPauseTimeoutMs());
+        activatePause(config.getOomPreQueryKillPauseDurationMs());
       } else {
         // Pause-on-panic disabled, or already been through a pause cycle — kill immediately
         killAllQueries(threadTrackers);
@@ -219,10 +219,10 @@ public class QueryResourceAggregator implements ResourceAggregator {
             clearPause();
           }
           // else: still in grace period, skip kill this cycle
-        } else if (config.isOomPauseEnabled()
+        } else if (config.isOomPreQueryKillPauseEnabled()
             && _previousTriggeringLevel.ordinal() < TriggeringLevel.HeapMemoryCritical.ordinal()) {
           // Just transitioned to critical - activate pause instead of killing
-          activatePause(config.getOomPauseTimeoutMs());
+          activatePause(config.getOomPreQueryKillPauseDurationMs());
         } else {
           // Pause disabled, or already been through a pause cycle - kill
           killMostExpensiveQuery();

--- a/pinot-core/src/main/java/org/apache/pinot/core/accounting/QueryResourceAggregator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/accounting/QueryResourceAggregator.java
@@ -81,11 +81,17 @@ public class QueryResourceAggregator implements ResourceAggregator {
   // Track previous triggering level to detect transitions into critical
   private TriggeringLevel _previousTriggeringLevel = TriggeringLevel.Normal;
 
-  // OOM pause state - lock+condition for blocking query threads at critical heap level
+  // OOM pause state - lock+condition for blocking query threads at critical heap level.
+  // _pauseLock / _pauseCondition are used to coordinate blocking query threads and signaling them from the watcher
+  // thread when the pause is cleared.
   private final ReentrantLock _pauseLock = new ReentrantLock();
   private final Condition _pauseCondition = _pauseLock.newCondition();
+  // Shared between the watcher thread (writer) and query threads (readers). Volatile enables the fast-path in
+  // waitIfPaused() to avoid acquiring the lock when no pause is active.
   private volatile boolean _pauseActive = false;
-  private volatile long _pauseDeadlineMs = 0;
+  // Local state for the watcher thread only (similar to _triggeringLevel) - read/written only from preAggregate and
+  // postAggregate, never by query threads.
+  private long _pauseDeadlineMs = 0;
 
   // metrics class
   private final AbstractMetrics _metrics;
@@ -245,8 +251,6 @@ public class QueryResourceAggregator implements ResourceAggregator {
   }
 
   private void evalTriggers() {
-    TriggeringLevel previousTriggeringLevel = _triggeringLevel;
-
     // Compute the new triggering level based on the current heap usage
     QueryMonitorConfig config = _queryMonitorConfig.get();
     if (_usedBytes > config.getPanicLevel()) {
@@ -281,7 +285,7 @@ public class QueryResourceAggregator implements ResourceAggregator {
     }
 
     // Log the triggering level change
-    if (previousTriggeringLevel != _triggeringLevel) {
+    if (_previousTriggeringLevel != _triggeringLevel) {
       switch (_triggeringLevel) {
         case HeapMemoryPanic:
           LOGGER.error("Heap used bytes: {} exceeds panic level: {}, killing all queries", _usedBytes,
@@ -320,8 +324,6 @@ public class QueryResourceAggregator implements ResourceAggregator {
   private void activatePause(long timeoutMs) {
     LOGGER.warn("Activating OOM pause for {}ms to allow garbage collection before killing queries. "
         + "Heap used bytes: {}", timeoutMs, _usedBytes);
-    // Write deadline before the flag - volatile ordering guarantees any thread that reads
-    // _pauseActive == true will also see the updated _pauseDeadlineMs.
     _pauseDeadlineMs = System.currentTimeMillis() + timeoutMs;
     _pauseActive = true;
     // Hint the JVM to run GC while query threads are pausing
@@ -331,6 +333,7 @@ public class QueryResourceAggregator implements ResourceAggregator {
   /**
    * Clears the OOM pause and wakes all blocked query threads.
    */
+  @VisibleForTesting
   void clearPause() {
     LOGGER.info("Clearing OOM pause. Heap used bytes: {}", _usedBytes);
     _pauseLock.lock();
@@ -346,6 +349,7 @@ public class QueryResourceAggregator implements ResourceAggregator {
    * Called by query threads at sampling checkpoints. Blocks if an OOM pause is active. Fast-path: single volatile read
    * when no pause is active.
    */
+  @VisibleForTesting
   void waitIfPaused() {
     if (!_pauseActive) {
       return;
@@ -491,6 +495,7 @@ public class QueryResourceAggregator implements ResourceAggregator {
     _inactiveQueries.addAll(_untrackedCpuMemUsage.keySet());
   }
 
+  @VisibleForTesting
   boolean isPauseActive() {
     return _pauseActive;
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/accounting/QueryResourceAggregator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/accounting/QueryResourceAggregator.java
@@ -26,7 +26,6 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
@@ -149,11 +148,23 @@ public class QueryResourceAggregator implements ResourceAggregator {
     _previousTriggeringLevel = _triggeringLevel;
     collectTriggerMetrics();
     evalTriggers();
-    // Prioritize the panic check, kill ALL QUERIES immediately if triggered
+    // Prioritize the panic check
     if (_triggeringLevel == TriggeringLevel.HeapMemoryPanic) {
-      killAllQueries(threadTrackers);
+      boolean pauseOnPanic = config.isOomPauseEnabled() && config.isOomPauseOnPanicEnabled();
       if (_pauseActive) {
-        clearPause();
+        if (System.currentTimeMillis() >= _pauseDeadlineMs || !pauseOnPanic) {
+          // Grace period expired, or panic-pause disabled — kill all and clear
+          killAllQueries(threadTrackers);
+          clearPause();
+        }
+        // else: still in grace period and panic-pause is enabled
+      } else if (pauseOnPanic
+          && _previousTriggeringLevel.ordinal() < TriggeringLevel.HeapMemoryCritical.ordinal()) {
+        // Fresh jump to panic bypassing critical — activate pause before killing
+        activatePause(config.getOomPauseTimeoutMs());
+      } else {
+        // Pause-on-panic disabled, or already been through a pause cycle — kill immediately
+        killAllQueries(threadTrackers);
       }
       return;
     }
@@ -320,7 +331,7 @@ public class QueryResourceAggregator implements ResourceAggregator {
   /**
    * Clears the OOM pause and wakes all blocked query threads.
    */
-  private void clearPause() {
+  void clearPause() {
     LOGGER.info("Clearing OOM pause. Heap used bytes: {}", _usedBytes);
     _pauseLock.lock();
     try {
@@ -342,11 +353,7 @@ public class QueryResourceAggregator implements ResourceAggregator {
     _pauseLock.lock();
     try {
       while (_pauseActive) {
-        long remaining = _pauseDeadlineMs - System.currentTimeMillis();
-        if (remaining <= 0) {
-          break;
-        }
-        _pauseCondition.await(remaining, TimeUnit.MILLISECONDS);
+        _pauseCondition.await();
       }
     } catch (InterruptedException e) {
       // Query was killed during pause - restore interrupt flag so the next checkTermination() call detects it

--- a/pinot-core/src/main/java/org/apache/pinot/core/accounting/QueryResourceAggregator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/accounting/QueryResourceAggregator.java
@@ -204,8 +204,8 @@ public class QueryResourceAggregator implements ResourceAggregator {
         if (_pauseActive) {
           // Pause is active - check if grace period expired
           if (System.currentTimeMillis() >= _pauseDeadlineMs) {
-            clearPause();
             killMostExpensiveQuery();
+            clearPause();
           }
           // else: still in grace period, skip kill this cycle
         } else if (config.isOomPauseEnabled()

--- a/pinot-core/src/main/java/org/apache/pinot/core/accounting/QueryResourceAggregator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/accounting/QueryResourceAggregator.java
@@ -348,11 +348,13 @@ public class QueryResourceAggregator implements ResourceAggregator {
   /**
    * Called by query threads at sampling checkpoints. Blocks if an OOM pause is active. Fast-path: single volatile read
    * when no pause is active.
+   * @return {@code true} if the thread entered the slow path (i.e. a pause was active when called), {@code false} if
+   *         the fast-path was taken and the thread did not block.
    */
   @VisibleForTesting
-  void waitIfPaused() {
+  boolean waitIfPaused() {
     if (!_pauseActive) {
-      return;
+      return false;
     }
     _pauseLock.lock();
     try {
@@ -365,6 +367,7 @@ public class QueryResourceAggregator implements ResourceAggregator {
     } finally {
       _pauseLock.unlock();
     }
+    return true;
   }
 
   private void killAllQueries(Iterable<ThreadResourceTrackerImpl> threadTrackers) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/accounting/ResourceUsageAccountantFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/accounting/ResourceUsageAccountantFactory.java
@@ -133,6 +133,8 @@ public class ResourceUsageAccountantFactory implements ThreadAccountantFactory {
       if (_memorySamplingEnabled) {
         threadTracker.updateMemorySnapshot();
       }
+      // Block if an OOM pause is active (fast-path: single volatile read)
+      _queryResourceAggregator.waitIfPaused();
     }
 
     @Override
@@ -330,6 +332,8 @@ public class ResourceUsageAccountantFactory implements ThreadAccountantFactory {
         LOGGER.info("_minMemoryFootprintForKill: {}", queryMonitorConfig.getMinMemoryFootprintForKill());
         LOGGER.info("_cpuTimeBasedKillingEnabled: {}", queryMonitorConfig.isCpuTimeBasedKillingEnabled());
         LOGGER.info("_cpuTimeBasedKillingThresholdNs: {}", queryMonitorConfig.getCpuTimeBasedKillingThresholdNs());
+        LOGGER.info("_oomPauseEnabled: {}", queryMonitorConfig.isOomPauseEnabled());
+        LOGGER.info("_oomPauseTimeoutMs: {}", queryMonitorConfig.getOomPauseTimeoutMs());
         LOGGER.info("_workloadSleepTimeMs: {}", queryMonitorConfig.getWorkloadSleepTimeMs());
         LOGGER.info("_workloadCostEnforcementEnabled: {}", queryMonitorConfig.isWorkloadCostEnforcementEnabled());
       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/accounting/ResourceUsageAccountantFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/accounting/ResourceUsageAccountantFactory.java
@@ -136,8 +136,8 @@ public class ResourceUsageAccountantFactory implements ThreadAccountantFactory {
     }
 
     @Override
-    public void waitIfPaused() {
-      _queryResourceAggregator.waitIfPaused();
+    public boolean waitIfPaused() {
+      return _queryResourceAggregator.waitIfPaused();
     }
 
     @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/accounting/ResourceUsageAccountantFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/accounting/ResourceUsageAccountantFactory.java
@@ -332,7 +332,6 @@ public class ResourceUsageAccountantFactory implements ThreadAccountantFactory {
         LOGGER.info("_minMemoryFootprintForKill: {}", queryMonitorConfig.getMinMemoryFootprintForKill());
         LOGGER.info("_cpuTimeBasedKillingEnabled: {}", queryMonitorConfig.isCpuTimeBasedKillingEnabled());
         LOGGER.info("_cpuTimeBasedKillingThresholdNs: {}", queryMonitorConfig.getCpuTimeBasedKillingThresholdNs());
-        LOGGER.info("_oomPauseEnabled: {}", queryMonitorConfig.isOomPauseEnabled());
         LOGGER.info("_oomPauseTimeoutMs: {}", queryMonitorConfig.getOomPauseTimeoutMs());
         LOGGER.info("_workloadSleepTimeMs: {}", queryMonitorConfig.getWorkloadSleepTimeMs());
         LOGGER.info("_workloadCostEnforcementEnabled: {}", queryMonitorConfig.isWorkloadCostEnforcementEnabled());

--- a/pinot-core/src/main/java/org/apache/pinot/core/accounting/ResourceUsageAccountantFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/accounting/ResourceUsageAccountantFactory.java
@@ -335,8 +335,8 @@ public class ResourceUsageAccountantFactory implements ThreadAccountantFactory {
         LOGGER.info("_minMemoryFootprintForKill: {}", queryMonitorConfig.getMinMemoryFootprintForKill());
         LOGGER.info("_cpuTimeBasedKillingEnabled: {}", queryMonitorConfig.isCpuTimeBasedKillingEnabled());
         LOGGER.info("_cpuTimeBasedKillingThresholdNs: {}", queryMonitorConfig.getCpuTimeBasedKillingThresholdNs());
-        LOGGER.info("_oomPauseTimeoutMs: {}", queryMonitorConfig.getOomPauseTimeoutMs());
-        LOGGER.info("_oomPauseOnPanicEnabled: {}", queryMonitorConfig.isOomPauseOnPanicEnabled());
+        LOGGER.info("_oomPreQueryKillPauseDurationMs: {}", queryMonitorConfig.getOomPreQueryKillPauseDurationMs());
+        LOGGER.info("_oomPanicPreQueryKillPauseEnabled: {}", queryMonitorConfig.isOomPanicPreQueryKillPauseEnabled());
         LOGGER.info("_workloadSleepTimeMs: {}", queryMonitorConfig.getWorkloadSleepTimeMs());
         LOGGER.info("_workloadCostEnforcementEnabled: {}", queryMonitorConfig.isWorkloadCostEnforcementEnabled());
       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/accounting/ResourceUsageAccountantFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/accounting/ResourceUsageAccountantFactory.java
@@ -133,7 +133,10 @@ public class ResourceUsageAccountantFactory implements ThreadAccountantFactory {
       if (_memorySamplingEnabled) {
         threadTracker.updateMemorySnapshot();
       }
-      // Block if an OOM pause is active (fast-path: single volatile read)
+    }
+
+    @Override
+    public void waitIfPaused() {
       _queryResourceAggregator.waitIfPaused();
     }
 
@@ -333,6 +336,7 @@ public class ResourceUsageAccountantFactory implements ThreadAccountantFactory {
         LOGGER.info("_cpuTimeBasedKillingEnabled: {}", queryMonitorConfig.isCpuTimeBasedKillingEnabled());
         LOGGER.info("_cpuTimeBasedKillingThresholdNs: {}", queryMonitorConfig.getCpuTimeBasedKillingThresholdNs());
         LOGGER.info("_oomPauseTimeoutMs: {}", queryMonitorConfig.getOomPauseTimeoutMs());
+        LOGGER.info("_oomPauseOnPanicEnabled: {}", queryMonitorConfig.isOomPauseOnPanicEnabled());
         LOGGER.info("_workloadSleepTimeMs: {}", queryMonitorConfig.getWorkloadSleepTimeMs());
         LOGGER.info("_workloadCostEnforcementEnabled: {}", queryMonitorConfig.isWorkloadCostEnforcementEnabled());
       }

--- a/pinot-core/src/test/java/org/apache/pinot/core/accounting/QueryMonitorConfigTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/accounting/QueryMonitorConfigTest.java
@@ -52,6 +52,9 @@ public class QueryMonitorConfigTest {
     return CommonConstants.PINOT_QUERY_SCHEDULER_PREFIX + "." + config;
   }
 
+  private static final boolean EXPECTED_OOM_PAUSE_ENABLED = true;
+  private static final long EXPECTED_OOM_PAUSE_TIMEOUT_MS = 2000;
+
   @BeforeClass
   public void setUp() {
     CLUSTER_CONFIGS.put(getFullyQualifiedConfigName(Accounting.CONFIG_OF_OOM_PROTECTION_KILLING_QUERY),
@@ -76,6 +79,10 @@ public class QueryMonitorConfigTest {
         Double.toString(EXPECTED_MIN_MEMORY_FOOTPRINT_FOR_KILL));
     CLUSTER_CONFIGS.put(getFullyQualifiedConfigName(Accounting.CONFIG_OF_QUERY_KILLED_METRIC_ENABLED),
         Boolean.toString(EXPECTED_IS_QUERY_KILLED_METRIC_ENABLED));
+    CLUSTER_CONFIGS.put(getFullyQualifiedConfigName(Accounting.CONFIG_OF_OOM_PAUSE_ENABLED),
+        Boolean.toString(EXPECTED_OOM_PAUSE_ENABLED));
+    CLUSTER_CONFIGS.put(getFullyQualifiedConfigName(Accounting.CONFIG_OF_OOM_PAUSE_TIMEOUT_MS),
+        Long.toString(EXPECTED_OOM_PAUSE_TIMEOUT_MS));
   }
 
   @Test
@@ -218,5 +225,28 @@ public class QueryMonitorConfigTest {
         .onChange(Set.of(getFullyQualifiedConfigName(Accounting.CONFIG_OF_QUERY_KILLED_METRIC_ENABLED)),
             CLUSTER_CONFIGS);
     assertTrue(accountant.getQueryMonitorConfig().isQueryKilledMetricEnabled());
+  }
+
+  @Test
+  void testOomPauseEnabledConfigChange() {
+    PerQueryCPUMemResourceUsageAccountant accountant =
+        new PerQueryCPUMemResourceUsageAccountant(new PinotConfiguration(), "test", InstanceType.SERVER);
+
+    assertFalse(accountant.getQueryMonitorConfig().isOomPauseEnabled());
+    accountant.getWatcherTask()
+        .onChange(Set.of(getFullyQualifiedConfigName(Accounting.CONFIG_OF_OOM_PAUSE_ENABLED)), CLUSTER_CONFIGS);
+    assertTrue(accountant.getQueryMonitorConfig().isOomPauseEnabled());
+  }
+
+  @Test
+  void testOomPauseTimeoutMsConfigChange() {
+    PerQueryCPUMemResourceUsageAccountant accountant =
+        new PerQueryCPUMemResourceUsageAccountant(new PinotConfiguration(), "test", InstanceType.SERVER);
+
+    assertEquals(accountant.getQueryMonitorConfig().getOomPauseTimeoutMs(),
+        Accounting.DEFAULT_OOM_PAUSE_TIMEOUT_MS);
+    accountant.getWatcherTask()
+        .onChange(Set.of(getFullyQualifiedConfigName(Accounting.CONFIG_OF_OOM_PAUSE_TIMEOUT_MS)), CLUSTER_CONFIGS);
+    assertEquals(accountant.getQueryMonitorConfig().getOomPauseTimeoutMs(), EXPECTED_OOM_PAUSE_TIMEOUT_MS);
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/accounting/QueryMonitorConfigTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/accounting/QueryMonitorConfigTest.java
@@ -53,6 +53,7 @@ public class QueryMonitorConfigTest {
   }
 
   private static final long EXPECTED_OOM_PAUSE_TIMEOUT_MS = 2000;
+  private static final boolean EXPECTED_OOM_PAUSE_ON_PANIC_ENABLED = true;
 
   @BeforeClass
   public void setUp() {
@@ -78,8 +79,10 @@ public class QueryMonitorConfigTest {
         Double.toString(EXPECTED_MIN_MEMORY_FOOTPRINT_FOR_KILL));
     CLUSTER_CONFIGS.put(getFullyQualifiedConfigName(Accounting.CONFIG_OF_QUERY_KILLED_METRIC_ENABLED),
         Boolean.toString(EXPECTED_IS_QUERY_KILLED_METRIC_ENABLED));
-    CLUSTER_CONFIGS.put(getFullyQualifiedConfigName(Accounting.CONFIG_OF_OOM_PAUSE_TIMEOUT_MS),
+    CLUSTER_CONFIGS.put(getFullyQualifiedConfigName(Accounting.CONFIG_OF_OOM_PRE_QUERY_KILL_PAUSE_DURATION_MS),
         Long.toString(EXPECTED_OOM_PAUSE_TIMEOUT_MS));
+    CLUSTER_CONFIGS.put(getFullyQualifiedConfigName(Accounting.CONFIG_OF_OOM_PANIC_PRE_QUERY_KILL_PAUSE_ENABLED),
+        Boolean.toString(EXPECTED_OOM_PAUSE_ON_PANIC_ENABLED));
   }
 
   @Test
@@ -230,9 +233,24 @@ public class QueryMonitorConfigTest {
         new PerQueryCPUMemResourceUsageAccountant(new PinotConfiguration(), "test", InstanceType.SERVER);
 
     assertEquals(accountant.getQueryMonitorConfig().getOomPauseTimeoutMs(),
-        Accounting.DEFAULT_OOM_PAUSE_TIMEOUT_MS);
+        Accounting.DEFAULT_OOM_PRE_QUERY_KILL_PAUSE_DURATION_MS);
     accountant.getWatcherTask()
-        .onChange(Set.of(getFullyQualifiedConfigName(Accounting.CONFIG_OF_OOM_PAUSE_TIMEOUT_MS)), CLUSTER_CONFIGS);
+        .onChange(
+            Set.of(getFullyQualifiedConfigName(Accounting.CONFIG_OF_OOM_PRE_QUERY_KILL_PAUSE_DURATION_MS)),
+            CLUSTER_CONFIGS);
     assertEquals(accountant.getQueryMonitorConfig().getOomPauseTimeoutMs(), EXPECTED_OOM_PAUSE_TIMEOUT_MS);
+  }
+
+  @Test
+  void testOomPauseOnPanicEnabledConfigChange() {
+    PerQueryCPUMemResourceUsageAccountant accountant =
+        new PerQueryCPUMemResourceUsageAccountant(new PinotConfiguration(), "test", InstanceType.SERVER);
+
+    assertFalse(accountant.getQueryMonitorConfig().isOomPauseOnPanicEnabled());
+    accountant.getWatcherTask()
+        .onChange(
+            Set.of(getFullyQualifiedConfigName(Accounting.CONFIG_OF_OOM_PANIC_PRE_QUERY_KILL_PAUSE_ENABLED)),
+            CLUSTER_CONFIGS);
+    assertTrue(accountant.getQueryMonitorConfig().isOomPauseOnPanicEnabled());
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/accounting/QueryMonitorConfigTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/accounting/QueryMonitorConfigTest.java
@@ -232,13 +232,13 @@ public class QueryMonitorConfigTest {
     PerQueryCPUMemResourceUsageAccountant accountant =
         new PerQueryCPUMemResourceUsageAccountant(new PinotConfiguration(), "test", InstanceType.SERVER);
 
-    assertEquals(accountant.getQueryMonitorConfig().getOomPauseTimeoutMs(),
+    assertEquals(accountant.getQueryMonitorConfig().getOomPreQueryKillPauseDurationMs(),
         Accounting.DEFAULT_OOM_PRE_QUERY_KILL_PAUSE_DURATION_MS);
     accountant.getWatcherTask()
         .onChange(
             Set.of(getFullyQualifiedConfigName(Accounting.CONFIG_OF_OOM_PRE_QUERY_KILL_PAUSE_DURATION_MS)),
             CLUSTER_CONFIGS);
-    assertEquals(accountant.getQueryMonitorConfig().getOomPauseTimeoutMs(), EXPECTED_OOM_PAUSE_TIMEOUT_MS);
+    assertEquals(accountant.getQueryMonitorConfig().getOomPreQueryKillPauseDurationMs(), EXPECTED_OOM_PAUSE_TIMEOUT_MS);
   }
 
   @Test
@@ -246,11 +246,11 @@ public class QueryMonitorConfigTest {
     PerQueryCPUMemResourceUsageAccountant accountant =
         new PerQueryCPUMemResourceUsageAccountant(new PinotConfiguration(), "test", InstanceType.SERVER);
 
-    assertFalse(accountant.getQueryMonitorConfig().isOomPauseOnPanicEnabled());
+    assertFalse(accountant.getQueryMonitorConfig().isOomPanicPreQueryKillPauseEnabled());
     accountant.getWatcherTask()
         .onChange(
             Set.of(getFullyQualifiedConfigName(Accounting.CONFIG_OF_OOM_PANIC_PRE_QUERY_KILL_PAUSE_ENABLED)),
             CLUSTER_CONFIGS);
-    assertTrue(accountant.getQueryMonitorConfig().isOomPauseOnPanicEnabled());
+    assertTrue(accountant.getQueryMonitorConfig().isOomPanicPreQueryKillPauseEnabled());
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/accounting/QueryMonitorConfigTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/accounting/QueryMonitorConfigTest.java
@@ -81,7 +81,7 @@ public class QueryMonitorConfigTest {
         Boolean.toString(EXPECTED_IS_QUERY_KILLED_METRIC_ENABLED));
     CLUSTER_CONFIGS.put(getFullyQualifiedConfigName(Accounting.CONFIG_OF_OOM_PRE_QUERY_KILL_PAUSE_DURATION_MS),
         Long.toString(EXPECTED_OOM_PAUSE_TIMEOUT_MS));
-    CLUSTER_CONFIGS.put(getFullyQualifiedConfigName(Accounting.CONFIG_OF_OOM_PANIC_PRE_QUERY_KILL_PAUSE_ENABLED),
+    CLUSTER_CONFIGS.put(getFullyQualifiedConfigName(Accounting.CONFIG_OF_OOM_PANIC_ALLOW_PRE_QUERY_KILL_PAUSE),
         Boolean.toString(EXPECTED_OOM_PAUSE_ON_PANIC_ENABLED));
   }
 
@@ -249,7 +249,7 @@ public class QueryMonitorConfigTest {
     assertFalse(accountant.getQueryMonitorConfig().isOomPanicPreQueryKillPauseEnabled());
     accountant.getWatcherTask()
         .onChange(
-            Set.of(getFullyQualifiedConfigName(Accounting.CONFIG_OF_OOM_PANIC_PRE_QUERY_KILL_PAUSE_ENABLED)),
+            Set.of(getFullyQualifiedConfigName(Accounting.CONFIG_OF_OOM_PANIC_ALLOW_PRE_QUERY_KILL_PAUSE)),
             CLUSTER_CONFIGS);
     assertTrue(accountant.getQueryMonitorConfig().isOomPanicPreQueryKillPauseEnabled());
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/accounting/QueryMonitorConfigTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/accounting/QueryMonitorConfigTest.java
@@ -52,7 +52,6 @@ public class QueryMonitorConfigTest {
     return CommonConstants.PINOT_QUERY_SCHEDULER_PREFIX + "." + config;
   }
 
-  private static final boolean EXPECTED_OOM_PAUSE_ENABLED = true;
   private static final long EXPECTED_OOM_PAUSE_TIMEOUT_MS = 2000;
 
   @BeforeClass
@@ -79,8 +78,6 @@ public class QueryMonitorConfigTest {
         Double.toString(EXPECTED_MIN_MEMORY_FOOTPRINT_FOR_KILL));
     CLUSTER_CONFIGS.put(getFullyQualifiedConfigName(Accounting.CONFIG_OF_QUERY_KILLED_METRIC_ENABLED),
         Boolean.toString(EXPECTED_IS_QUERY_KILLED_METRIC_ENABLED));
-    CLUSTER_CONFIGS.put(getFullyQualifiedConfigName(Accounting.CONFIG_OF_OOM_PAUSE_ENABLED),
-        Boolean.toString(EXPECTED_OOM_PAUSE_ENABLED));
     CLUSTER_CONFIGS.put(getFullyQualifiedConfigName(Accounting.CONFIG_OF_OOM_PAUSE_TIMEOUT_MS),
         Long.toString(EXPECTED_OOM_PAUSE_TIMEOUT_MS));
   }
@@ -225,17 +222,6 @@ public class QueryMonitorConfigTest {
         .onChange(Set.of(getFullyQualifiedConfigName(Accounting.CONFIG_OF_QUERY_KILLED_METRIC_ENABLED)),
             CLUSTER_CONFIGS);
     assertTrue(accountant.getQueryMonitorConfig().isQueryKilledMetricEnabled());
-  }
-
-  @Test
-  void testOomPauseEnabledConfigChange() {
-    PerQueryCPUMemResourceUsageAccountant accountant =
-        new PerQueryCPUMemResourceUsageAccountant(new PinotConfiguration(), "test", InstanceType.SERVER);
-
-    assertFalse(accountant.getQueryMonitorConfig().isOomPauseEnabled());
-    accountant.getWatcherTask()
-        .onChange(Set.of(getFullyQualifiedConfigName(Accounting.CONFIG_OF_OOM_PAUSE_ENABLED)), CLUSTER_CONFIGS);
-    assertTrue(accountant.getQueryMonitorConfig().isOomPauseEnabled());
   }
 
   @Test

--- a/pinot-core/src/test/java/org/apache/pinot/core/accounting/QueryResourceAggregatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/accounting/QueryResourceAggregatorTest.java
@@ -1,0 +1,140 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.accounting;
+
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.pinot.spi.config.instance.InstanceType;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+
+public class QueryResourceAggregatorTest {
+
+  // Use 0 for critical ratio to guarantee heap always exceeds the threshold in tests, regardless of JVM
+  // configuration. Use a very high panic ratio (1.1) to prevent hitting panic level.
+  private static final float TEST_CRITICAL_RATIO = 0f;
+  private static final float TEST_PANIC_RATIO = 1.1f;
+
+  private QueryResourceAggregator createAggregator(boolean oomPauseEnabled, long oomPauseTimeoutMs) {
+    PinotConfiguration config = new PinotConfiguration();
+    config.setProperty(CommonConstants.Accounting.CONFIG_OF_OOM_PAUSE_ENABLED, oomPauseEnabled);
+    config.setProperty(CommonConstants.Accounting.CONFIG_OF_OOM_PAUSE_TIMEOUT_MS, oomPauseTimeoutMs);
+    config.setProperty(CommonConstants.Accounting.CONFIG_OF_CRITICAL_LEVEL_HEAP_USAGE_RATIO, TEST_CRITICAL_RATIO);
+    config.setProperty(CommonConstants.Accounting.CONFIG_OF_PANIC_LEVEL_HEAP_USAGE_RATIO, TEST_PANIC_RATIO);
+    config.setProperty(CommonConstants.Accounting.CONFIG_OF_OOM_PROTECTION_KILLING_QUERY, true);
+    config.setProperty(CommonConstants.Accounting.CONFIG_OF_ALARMING_LEVEL_HEAP_USAGE_RATIO, 0f);
+
+    long maxHeapSize = org.apache.pinot.spi.utils.ResourceUsageUtils.getMaxHeapSize();
+    AtomicReference<QueryMonitorConfig> configRef =
+        new AtomicReference<>(new QueryMonitorConfig(config, maxHeapSize));
+
+    return new QueryResourceAggregator("test-instance", InstanceType.SERVER, false, true, configRef);
+  }
+
+  @Test
+  public void testConfigReadsOomPauseEnabled() {
+    PinotConfiguration config = new PinotConfiguration();
+    config.setProperty(CommonConstants.Accounting.CONFIG_OF_OOM_PAUSE_ENABLED, true);
+    config.setProperty(CommonConstants.Accounting.CONFIG_OF_OOM_PAUSE_TIMEOUT_MS, 2000L);
+
+    long maxHeapSize = org.apache.pinot.spi.utils.ResourceUsageUtils.getMaxHeapSize();
+    QueryMonitorConfig qmc = new QueryMonitorConfig(config, maxHeapSize);
+
+    assertTrue(qmc.isOomPauseEnabled(), "OOM pause should be enabled");
+    assertEquals(qmc.getOomPauseTimeoutMs(), 2000L, "OOM pause timeout should be 2000ms");
+  }
+
+  @Test
+  public void testPauseActivatedOnTransitionToCritical() {
+    QueryResourceAggregator aggregator = createAggregator(true, 5000);
+
+    assertFalse(aggregator.isPauseActive(), "Pause should not be active initially");
+
+    aggregator.preAggregate(Collections.emptyList());
+    assertEquals(aggregator.getTriggeringLevel(), QueryResourceAggregator.TriggeringLevel.HeapMemoryCritical,
+        "Triggering level should be HeapMemoryCritical");
+    assertEquals(aggregator.getPreviousTriggeringLevel(), QueryResourceAggregator.TriggeringLevel.Normal,
+        "Previous triggering level should be Normal");
+
+    aggregator.postAggregate();
+    assertTrue(aggregator.isPauseActive(),
+        "Pause should be active after transitioning to critical with OOM pause enabled");
+  }
+
+  @Test
+  public void testWaitIfPausedFastPathWhenNotActive() {
+    QueryResourceAggregator aggregator = createAggregator(true, 1000);
+    long start = System.nanoTime();
+    aggregator.waitIfPaused();
+    long elapsed = System.nanoTime() - start;
+    assertTrue(elapsed < 1_000_000, "Fast path should complete in under 1ms, took " + elapsed + "ns");
+  }
+
+  @Test
+  public void testWaitIfPausedBlocksForTimeout() {
+    QueryResourceAggregator aggregator = createAggregator(true, 300);
+
+    aggregator.preAggregate(Collections.emptyList());
+    aggregator.postAggregate();
+    assertTrue(aggregator.isPauseActive(), "Pause should be active");
+
+    long start = System.currentTimeMillis();
+    aggregator.waitIfPaused();
+    long elapsed = System.currentTimeMillis() - start;
+
+    assertTrue(elapsed >= 200,
+        "waitIfPaused should have blocked for ~300ms, but only blocked for " + elapsed + "ms");
+  }
+
+  @Test
+  public void testNoPauseWhenDisabled() {
+    QueryResourceAggregator aggregator = createAggregator(false, 1000);
+
+    aggregator.preAggregate(Collections.emptyList());
+    aggregator.postAggregate();
+
+    assertFalse(aggregator.isPauseActive(), "Pause should not be active when feature is disabled");
+  }
+
+  @Test
+  public void testNoPauseWhenAlreadyAtCritical() {
+    QueryResourceAggregator aggregator = createAggregator(true, 200);
+
+    // First cycle: transitions Normal -> Critical, activates pause
+    aggregator.preAggregate(Collections.emptyList());
+    aggregator.postAggregate();
+    assertTrue(aggregator.isPauseActive(), "Pause should be active after first cycle");
+
+    // Wait out the pause
+    aggregator.waitIfPaused();
+
+    // Second cycle: stays at Critical -> Critical, should NOT re-pause
+    aggregator.preAggregate(Collections.emptyList());
+    aggregator.postAggregate();
+
+    assertFalse(aggregator.isPauseActive(),
+        "Should not re-pause when already at critical level");
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/accounting/QueryResourceAggregatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/accounting/QueryResourceAggregatorTest.java
@@ -68,12 +68,12 @@ public class QueryResourceAggregatorTest {
     long maxHeapSize = org.apache.pinot.spi.utils.ResourceUsageUtils.getMaxHeapSize();
     QueryMonitorConfig qmc = new QueryMonitorConfig(config, maxHeapSize);
 
-    assertTrue(qmc.isOomPauseEnabled(), "OOM pause should be enabled when timeout > 0");
-    assertEquals(qmc.getOomPauseTimeoutMs(), 2000L, "OOM pause timeout should be 2000ms");
+    assertTrue(qmc.isOomPreQueryKillPauseEnabled(), "OOM pause should be enabled when timeout > 0");
+    assertEquals(qmc.getOomPreQueryKillPauseDurationMs(), 2000L, "OOM pause timeout should be 2000ms");
 
     PinotConfiguration disabledConfig = new PinotConfiguration();
     QueryMonitorConfig disabledQmc = new QueryMonitorConfig(disabledConfig, maxHeapSize);
-    assertFalse(disabledQmc.isOomPauseEnabled(), "OOM pause should be disabled by default");
+    assertFalse(disabledQmc.isOomPreQueryKillPauseEnabled(), "OOM pause should be disabled by default");
   }
 
   @Test

--- a/pinot-core/src/test/java/org/apache/pinot/core/accounting/QueryResourceAggregatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/accounting/QueryResourceAggregatorTest.java
@@ -37,9 +37,8 @@ public class QueryResourceAggregatorTest {
   private static final float TEST_CRITICAL_RATIO = 0f;
   private static final float TEST_PANIC_RATIO = 1.1f;
 
-  private QueryResourceAggregator createAggregator(boolean oomPauseEnabled, long oomPauseTimeoutMs) {
+  private QueryResourceAggregator createAggregator(long oomPauseTimeoutMs) {
     PinotConfiguration config = new PinotConfiguration();
-    config.setProperty(CommonConstants.Accounting.CONFIG_OF_OOM_PAUSE_ENABLED, oomPauseEnabled);
     config.setProperty(CommonConstants.Accounting.CONFIG_OF_OOM_PAUSE_TIMEOUT_MS, oomPauseTimeoutMs);
     config.setProperty(CommonConstants.Accounting.CONFIG_OF_CRITICAL_LEVEL_HEAP_USAGE_RATIO, TEST_CRITICAL_RATIO);
     config.setProperty(CommonConstants.Accounting.CONFIG_OF_PANIC_LEVEL_HEAP_USAGE_RATIO, TEST_PANIC_RATIO);
@@ -54,21 +53,24 @@ public class QueryResourceAggregatorTest {
   }
 
   @Test
-  public void testConfigReadsOomPauseEnabled() {
+  public void testConfigReadsOomPauseTimeout() {
     PinotConfiguration config = new PinotConfiguration();
-    config.setProperty(CommonConstants.Accounting.CONFIG_OF_OOM_PAUSE_ENABLED, true);
     config.setProperty(CommonConstants.Accounting.CONFIG_OF_OOM_PAUSE_TIMEOUT_MS, 2000L);
 
     long maxHeapSize = org.apache.pinot.spi.utils.ResourceUsageUtils.getMaxHeapSize();
     QueryMonitorConfig qmc = new QueryMonitorConfig(config, maxHeapSize);
 
-    assertTrue(qmc.isOomPauseEnabled(), "OOM pause should be enabled");
+    assertTrue(qmc.isOomPauseEnabled(), "OOM pause should be enabled when timeout > 0");
     assertEquals(qmc.getOomPauseTimeoutMs(), 2000L, "OOM pause timeout should be 2000ms");
+
+    PinotConfiguration disabledConfig = new PinotConfiguration();
+    QueryMonitorConfig disabledQmc = new QueryMonitorConfig(disabledConfig, maxHeapSize);
+    assertFalse(disabledQmc.isOomPauseEnabled(), "OOM pause should be disabled by default");
   }
 
   @Test
   public void testPauseActivatedOnTransitionToCritical() {
-    QueryResourceAggregator aggregator = createAggregator(true, 5000);
+    QueryResourceAggregator aggregator = createAggregator(5000);
 
     assertFalse(aggregator.isPauseActive(), "Pause should not be active initially");
 
@@ -85,7 +87,7 @@ public class QueryResourceAggregatorTest {
 
   @Test
   public void testWaitIfPausedFastPathWhenNotActive() {
-    QueryResourceAggregator aggregator = createAggregator(true, 1000);
+    QueryResourceAggregator aggregator = createAggregator(1000);
     long start = System.nanoTime();
     aggregator.waitIfPaused();
     long elapsed = System.nanoTime() - start;
@@ -94,7 +96,7 @@ public class QueryResourceAggregatorTest {
 
   @Test
   public void testWaitIfPausedBlocksForTimeout() {
-    QueryResourceAggregator aggregator = createAggregator(true, 300);
+    QueryResourceAggregator aggregator = createAggregator(300);
 
     aggregator.preAggregate(Collections.emptyList());
     aggregator.postAggregate();
@@ -110,7 +112,7 @@ public class QueryResourceAggregatorTest {
 
   @Test
   public void testNoPauseWhenDisabled() {
-    QueryResourceAggregator aggregator = createAggregator(false, 1000);
+    QueryResourceAggregator aggregator = createAggregator(-1);
 
     aggregator.preAggregate(Collections.emptyList());
     aggregator.postAggregate();
@@ -120,7 +122,7 @@ public class QueryResourceAggregatorTest {
 
   @Test
   public void testNoPauseWhenAlreadyAtCritical() {
-    QueryResourceAggregator aggregator = createAggregator(true, 200);
+    QueryResourceAggregator aggregator = createAggregator(200);
 
     // First cycle: transitions Normal -> Critical, activates pause
     aggregator.preAggregate(Collections.emptyList());

--- a/pinot-core/src/test/java/org/apache/pinot/core/accounting/QueryResourceAggregatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/accounting/QueryResourceAggregatorTest.java
@@ -38,12 +38,20 @@ public class QueryResourceAggregatorTest {
   private static final float TEST_PANIC_RATIO = 1.1f;
 
   private QueryResourceAggregator createAggregator(long oomPauseTimeoutMs) {
+    return createAggregator(oomPauseTimeoutMs, false);
+  }
+
+  /// Creates an aggregator that always hits critical level. When {@code pauseOnPanic} is true, the panic ratio is
+  /// also set to 0 so that the aggregator always hits panic level instead.
+  private QueryResourceAggregator createAggregator(long oomPauseTimeoutMs, boolean pauseOnPanic) {
     PinotConfiguration config = new PinotConfiguration();
-    config.setProperty(CommonConstants.Accounting.CONFIG_OF_OOM_PAUSE_TIMEOUT_MS, oomPauseTimeoutMs);
+    config.setProperty(CommonConstants.Accounting.CONFIG_OF_OOM_PRE_QUERY_KILL_PAUSE_DURATION_MS, oomPauseTimeoutMs);
     config.setProperty(CommonConstants.Accounting.CONFIG_OF_CRITICAL_LEVEL_HEAP_USAGE_RATIO, TEST_CRITICAL_RATIO);
-    config.setProperty(CommonConstants.Accounting.CONFIG_OF_PANIC_LEVEL_HEAP_USAGE_RATIO, TEST_PANIC_RATIO);
+    config.setProperty(CommonConstants.Accounting.CONFIG_OF_PANIC_LEVEL_HEAP_USAGE_RATIO,
+        pauseOnPanic ? 0f : TEST_PANIC_RATIO);
     config.setProperty(CommonConstants.Accounting.CONFIG_OF_OOM_PROTECTION_KILLING_QUERY, true);
     config.setProperty(CommonConstants.Accounting.CONFIG_OF_ALARMING_LEVEL_HEAP_USAGE_RATIO, 0f);
+    config.setProperty(CommonConstants.Accounting.CONFIG_OF_OOM_PANIC_PRE_QUERY_KILL_PAUSE_ENABLED, pauseOnPanic);
 
     long maxHeapSize = org.apache.pinot.spi.utils.ResourceUsageUtils.getMaxHeapSize();
     AtomicReference<QueryMonitorConfig> configRef =
@@ -55,7 +63,7 @@ public class QueryResourceAggregatorTest {
   @Test
   public void testConfigReadsOomPauseTimeout() {
     PinotConfiguration config = new PinotConfiguration();
-    config.setProperty(CommonConstants.Accounting.CONFIG_OF_OOM_PAUSE_TIMEOUT_MS, 2000L);
+    config.setProperty(CommonConstants.Accounting.CONFIG_OF_OOM_PRE_QUERY_KILL_PAUSE_DURATION_MS, 2000L);
 
     long maxHeapSize = org.apache.pinot.spi.utils.ResourceUsageUtils.getMaxHeapSize();
     QueryMonitorConfig qmc = new QueryMonitorConfig(config, maxHeapSize);
@@ -95,19 +103,34 @@ public class QueryResourceAggregatorTest {
   }
 
   @Test
-  public void testWaitIfPausedBlocksForTimeout() {
-    QueryResourceAggregator aggregator = createAggregator(300);
+  public void testWaitIfPausedBlocksUntilSignaled()
+      throws Exception {
+    QueryResourceAggregator aggregator = createAggregator(5000);
 
     aggregator.preAggregate(Collections.emptyList());
     aggregator.postAggregate();
     assertTrue(aggregator.isPauseActive(), "Pause should be active");
 
+    // Clear the pause from a background thread after 200ms
+    Thread signaler = new Thread(() -> {
+      try {
+        Thread.sleep(200);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+      aggregator.clearPause();
+    });
+    signaler.start();
+
     long start = System.currentTimeMillis();
     aggregator.waitIfPaused();
     long elapsed = System.currentTimeMillis() - start;
+    signaler.join(1000);
 
-    assertTrue(elapsed >= 200,
-        "waitIfPaused should have blocked for ~300ms, but only blocked for " + elapsed + "ms");
+    assertTrue(elapsed >= 150,
+        "waitIfPaused should have blocked until signaled (~200ms), but only blocked for " + elapsed + "ms");
+    assertTrue(elapsed < 2000,
+        "waitIfPaused should have unblocked promptly after signal, but took " + elapsed + "ms");
   }
 
   @Test
@@ -129,8 +152,8 @@ public class QueryResourceAggregatorTest {
     aggregator.postAggregate();
     assertTrue(aggregator.isPauseActive(), "Pause should be active after first cycle");
 
-    // Wait out the pause
-    aggregator.waitIfPaused();
+    // Explicitly clear the pause (simulating the watcher clearing after timeout)
+    aggregator.clearPause();
 
     // Second cycle: stays at Critical -> Critical, should NOT re-pause
     aggregator.preAggregate(Collections.emptyList());
@@ -138,5 +161,63 @@ public class QueryResourceAggregatorTest {
 
     assertFalse(aggregator.isPauseActive(),
         "Should not re-pause when already at critical level");
+  }
+
+  @Test
+  public void testPauseActivatedOnFreshJumpToPanic() {
+    QueryResourceAggregator aggregator = createAggregator(5000, true);
+
+    assertFalse(aggregator.isPauseActive(), "Pause should not be active initially");
+
+    aggregator.preAggregate(Collections.emptyList());
+    assertEquals(aggregator.getTriggeringLevel(), QueryResourceAggregator.TriggeringLevel.HeapMemoryPanic,
+        "Triggering level should be HeapMemoryPanic");
+    assertEquals(aggregator.getPreviousTriggeringLevel(), QueryResourceAggregator.TriggeringLevel.Normal,
+        "Previous triggering level should be Normal");
+
+    assertTrue(aggregator.isPauseActive(),
+        "Pause should be active after fresh jump to panic with pause-on-panic enabled");
+  }
+
+  @Test
+  public void testNoPanicPauseWhenDisabled() {
+    // Create aggregator that hits panic but with pauseOnPanic=false
+    PinotConfiguration config = new PinotConfiguration();
+    config.setProperty(CommonConstants.Accounting.CONFIG_OF_OOM_PRE_QUERY_KILL_PAUSE_DURATION_MS, 5000L);
+    config.setProperty(CommonConstants.Accounting.CONFIG_OF_CRITICAL_LEVEL_HEAP_USAGE_RATIO, 0f);
+    config.setProperty(CommonConstants.Accounting.CONFIG_OF_PANIC_LEVEL_HEAP_USAGE_RATIO, 0f);
+    config.setProperty(CommonConstants.Accounting.CONFIG_OF_OOM_PROTECTION_KILLING_QUERY, true);
+    config.setProperty(CommonConstants.Accounting.CONFIG_OF_ALARMING_LEVEL_HEAP_USAGE_RATIO, 0f);
+    config.setProperty(CommonConstants.Accounting.CONFIG_OF_OOM_PANIC_PRE_QUERY_KILL_PAUSE_ENABLED, false);
+
+    long maxHeapSize = org.apache.pinot.spi.utils.ResourceUsageUtils.getMaxHeapSize();
+    AtomicReference<QueryMonitorConfig> configRef =
+        new AtomicReference<>(new QueryMonitorConfig(config, maxHeapSize));
+    QueryResourceAggregator aggregator =
+        new QueryResourceAggregator("test-instance", InstanceType.SERVER, false, true, configRef);
+
+    aggregator.preAggregate(Collections.emptyList());
+
+    assertFalse(aggregator.isPauseActive(),
+        "Pause should not be active at panic level when pause-on-panic is disabled");
+  }
+
+  @Test
+  public void testNoPanicRePauseAfterFirstPause() {
+    QueryResourceAggregator aggregator = createAggregator(5000, true);
+
+    // First cycle: Normal → Panic, activates pause
+    aggregator.preAggregate(Collections.emptyList());
+    assertTrue(aggregator.isPauseActive(), "Pause should be active from first panic transition");
+
+    // Simulate the watcher clearing the pause after timeout
+    aggregator.clearPause();
+
+    // Second cycle: Panic → Panic, should NOT re-pause
+    aggregator.preAggregate(Collections.emptyList());
+    assertEquals(aggregator.getPreviousTriggeringLevel(),
+        QueryResourceAggregator.TriggeringLevel.HeapMemoryPanic);
+    assertFalse(aggregator.isPauseActive(),
+        "Should not re-pause on Panic→Panic transition");
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/accounting/QueryResourceAggregatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/accounting/QueryResourceAggregatorTest.java
@@ -51,7 +51,7 @@ public class QueryResourceAggregatorTest {
         pauseOnPanic ? 0f : TEST_PANIC_RATIO);
     config.setProperty(CommonConstants.Accounting.CONFIG_OF_OOM_PROTECTION_KILLING_QUERY, true);
     config.setProperty(CommonConstants.Accounting.CONFIG_OF_ALARMING_LEVEL_HEAP_USAGE_RATIO, 0f);
-    config.setProperty(CommonConstants.Accounting.CONFIG_OF_OOM_PANIC_PRE_QUERY_KILL_PAUSE_ENABLED, pauseOnPanic);
+    config.setProperty(CommonConstants.Accounting.CONFIG_OF_OOM_PANIC_ALLOW_PRE_QUERY_KILL_PAUSE, pauseOnPanic);
 
     long maxHeapSize = org.apache.pinot.spi.utils.ResourceUsageUtils.getMaxHeapSize();
     AtomicReference<QueryMonitorConfig> configRef =
@@ -188,7 +188,7 @@ public class QueryResourceAggregatorTest {
     config.setProperty(CommonConstants.Accounting.CONFIG_OF_PANIC_LEVEL_HEAP_USAGE_RATIO, 0f);
     config.setProperty(CommonConstants.Accounting.CONFIG_OF_OOM_PROTECTION_KILLING_QUERY, true);
     config.setProperty(CommonConstants.Accounting.CONFIG_OF_ALARMING_LEVEL_HEAP_USAGE_RATIO, 0f);
-    config.setProperty(CommonConstants.Accounting.CONFIG_OF_OOM_PANIC_PRE_QUERY_KILL_PAUSE_ENABLED, false);
+    config.setProperty(CommonConstants.Accounting.CONFIG_OF_OOM_PANIC_ALLOW_PRE_QUERY_KILL_PAUSE, false);
 
     long maxHeapSize = org.apache.pinot.spi.utils.ResourceUsageUtils.getMaxHeapSize();
     AtomicReference<QueryMonitorConfig> configRef =

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/accounting/ThreadAccountant.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/accounting/ThreadAccountant.java
@@ -41,6 +41,11 @@ public interface ThreadAccountant {
   void updateUntrackedResourceUsage(String identifier, long cpuTimeNs, long allocatedBytes,
       TrackingScope trackingScope);
 
+  /// Blocks the current thread if the OOM protection framework has activated a pause. Implementations should use a
+  /// fast-path (e.g. single volatile read) so that there is zero overhead when no pause is active.
+  default void waitIfPaused() {
+  }
+
   /// Returns `true` when the query submission should be throttled, `false` otherwise.
   default boolean throttleQuerySubmission() {
     return false;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/accounting/ThreadAccountant.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/accounting/ThreadAccountant.java
@@ -43,7 +43,11 @@ public interface ThreadAccountant {
 
   /// Blocks the current thread if the OOM protection framework has activated a pause. Implementations should use a
   /// fast-path (e.g. single volatile read) so that there is zero overhead when no pause is active.
-  default void waitIfPaused() {
+  /// @return {@code true} if the thread entered the slow path (i.e. a pause was active when called), {@code false} if
+  ///         the fast-path was taken. Callers can use this to decide whether follow-up work (e.g. re-checking
+  ///         termination) is warranted.
+  default boolean waitIfPaused() {
+    return false;
   }
 
   /// Returns `true` when the query submission should be throttled, `false` otherwise.

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/query/QueryThreadContext.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/query/QueryThreadContext.java
@@ -106,8 +106,27 @@ public class QueryThreadContext implements AutoCloseable {
     _accountant.sampleUsage();
   }
 
-  private void waitIfPausedInternal() {
+  // Blocks the thread if the accountant has activated a pause, then re-checks termination before returning. The
+  // re-check catches the case where the watcher terminated this query while the thread was paused, allowing the
+  // thread to throw immediately instead of proceeding with more work.
+  private void waitIfPausedInternal(String scope) {
     _accountant.waitIfPaused();
+    checkTerminationInternal(scope);
+  }
+
+  private void waitIfPausedInternal(Supplier<String> scopeSupplier) {
+    _accountant.waitIfPaused();
+    checkTerminationInternal(scopeSupplier);
+  }
+
+  private void waitIfPausedInternal(String scope, long deadlineMs) {
+    _accountant.waitIfPaused();
+    checkTerminationInternal(scope, deadlineMs);
+  }
+
+  private void waitIfPausedInternal(Supplier<String> scopeSupplier, long deadlineMs) {
+    _accountant.waitIfPaused();
+    checkTerminationInternal(scopeSupplier, deadlineMs);
   }
 
   private void checkTerminationInternal(String scope) {
@@ -263,8 +282,8 @@ public class QueryThreadContext implements AutoCloseable {
     // NOTE: In production code, threadContext should never be null. It might be null in tests when QueryThreadContext
     //       is not set up.
     if (threadContext != null) {
-      threadContext.waitIfPausedInternal();
       threadContext.checkTerminationInternal(scopeSupplier);
+      threadContext.waitIfPausedInternal(scopeSupplier);
     }
   }
 
@@ -277,8 +296,8 @@ public class QueryThreadContext implements AutoCloseable {
     // NOTE: In production code, threadContext should never be null. It might be null in tests when QueryThreadContext
     //       is not set up.
     if (threadContext != null) {
-      threadContext.waitIfPausedInternal();
       threadContext.checkTerminationInternal(scopeSupplier, deadlineMs);
+      threadContext.waitIfPausedInternal(scopeSupplier, deadlineMs);
     }
   }
 
@@ -299,9 +318,9 @@ public class QueryThreadContext implements AutoCloseable {
     // NOTE: In production code, threadContext should never be null. It might be null in tests when QueryThreadContext
     //       is not set up.
     if (threadContext != null) {
-      threadContext.sampleUsageInternal();
-      threadContext.waitIfPausedInternal();
       threadContext.checkTerminationInternal(scope);
+      threadContext.sampleUsageInternal();
+      threadContext.waitIfPausedInternal(scope);
     }
   }
 
@@ -312,9 +331,9 @@ public class QueryThreadContext implements AutoCloseable {
     // NOTE: In production code, threadContext should never be null. It might be null in tests when QueryThreadContext
     //       is not set up.
     if (threadContext != null) {
-      threadContext.sampleUsageInternal();
-      threadContext.waitIfPausedInternal();
       threadContext.checkTerminationInternal(scopeSupplier);
+      threadContext.sampleUsageInternal();
+      threadContext.waitIfPausedInternal(scopeSupplier);
     }
   }
 
@@ -325,9 +344,9 @@ public class QueryThreadContext implements AutoCloseable {
     // NOTE: In production code, threadContext should never be null. It might be null in tests when QueryThreadContext
     //       is not set up.
     if (threadContext != null) {
-      threadContext.sampleUsageInternal();
-      threadContext.waitIfPausedInternal();
       threadContext.checkTerminationInternal(scope, deadlineMs);
+      threadContext.sampleUsageInternal();
+      threadContext.waitIfPausedInternal(scope, deadlineMs);
     }
   }
 
@@ -338,9 +357,9 @@ public class QueryThreadContext implements AutoCloseable {
     // NOTE: In production code, threadContext should never be null. It might be null in tests when QueryThreadContext
     //       is not set up.
     if (threadContext != null) {
-      threadContext.sampleUsageInternal();
-      threadContext.waitIfPausedInternal();
       threadContext.checkTerminationInternal(scopeSupplier, deadlineMs);
+      threadContext.sampleUsageInternal();
+      threadContext.waitIfPausedInternal(scopeSupplier, deadlineMs);
     }
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/query/QueryThreadContext.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/query/QueryThreadContext.java
@@ -106,6 +106,10 @@ public class QueryThreadContext implements AutoCloseable {
     _accountant.sampleUsage();
   }
 
+  private void waitIfPausedInternal() {
+    _accountant.waitIfPaused();
+  }
+
   private void checkTerminationInternal(String scope) {
     checkTerminationInternal(scope, _executionContext.getActiveDeadlineMs());
   }
@@ -259,6 +263,7 @@ public class QueryThreadContext implements AutoCloseable {
     // NOTE: In production code, threadContext should never be null. It might be null in tests when QueryThreadContext
     //       is not set up.
     if (threadContext != null) {
+      threadContext.waitIfPausedInternal();
       threadContext.checkTerminationInternal(scopeSupplier);
     }
   }
@@ -272,6 +277,7 @@ public class QueryThreadContext implements AutoCloseable {
     // NOTE: In production code, threadContext should never be null. It might be null in tests when QueryThreadContext
     //       is not set up.
     if (threadContext != null) {
+      threadContext.waitIfPausedInternal();
       threadContext.checkTerminationInternal(scopeSupplier, deadlineMs);
     }
   }
@@ -293,8 +299,9 @@ public class QueryThreadContext implements AutoCloseable {
     // NOTE: In production code, threadContext should never be null. It might be null in tests when QueryThreadContext
     //       is not set up.
     if (threadContext != null) {
-      threadContext.checkTerminationInternal(scope);
       threadContext.sampleUsageInternal();
+      threadContext.waitIfPausedInternal();
+      threadContext.checkTerminationInternal(scope);
     }
   }
 
@@ -305,8 +312,9 @@ public class QueryThreadContext implements AutoCloseable {
     // NOTE: In production code, threadContext should never be null. It might be null in tests when QueryThreadContext
     //       is not set up.
     if (threadContext != null) {
-      threadContext.checkTerminationInternal(scopeSupplier);
       threadContext.sampleUsageInternal();
+      threadContext.waitIfPausedInternal();
+      threadContext.checkTerminationInternal(scopeSupplier);
     }
   }
 
@@ -317,8 +325,9 @@ public class QueryThreadContext implements AutoCloseable {
     // NOTE: In production code, threadContext should never be null. It might be null in tests when QueryThreadContext
     //       is not set up.
     if (threadContext != null) {
-      threadContext.checkTerminationInternal(scope, deadlineMs);
       threadContext.sampleUsageInternal();
+      threadContext.waitIfPausedInternal();
+      threadContext.checkTerminationInternal(scope, deadlineMs);
     }
   }
 
@@ -329,8 +338,9 @@ public class QueryThreadContext implements AutoCloseable {
     // NOTE: In production code, threadContext should never be null. It might be null in tests when QueryThreadContext
     //       is not set up.
     if (threadContext != null) {
-      threadContext.checkTerminationInternal(scopeSupplier, deadlineMs);
       threadContext.sampleUsageInternal();
+      threadContext.waitIfPausedInternal();
+      threadContext.checkTerminationInternal(scopeSupplier, deadlineMs);
     }
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/query/QueryThreadContext.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/query/QueryThreadContext.java
@@ -106,27 +106,33 @@ public class QueryThreadContext implements AutoCloseable {
     _accountant.sampleUsage();
   }
 
-  // Blocks the thread if the accountant has activated a pause, then re-checks termination before returning. The
-  // re-check catches the case where the watcher terminated this query while the thread was paused, allowing the
-  // thread to throw immediately instead of proceeding with more work.
+  // Blocks the thread if the accountant has activated a pause, then re-checks termination before returning if the
+  // thread actually entered the slow path. The re-check catches the case where the watcher terminated this query
+  // while the thread was paused, allowing the thread to throw immediately instead of proceeding with more work. When
+  // the fast-path is taken (no pause was active), the re-check is skipped since termination was just checked by the
+  // caller.
   private void waitIfPausedInternal(String scope) {
-    _accountant.waitIfPaused();
-    checkTerminationInternal(scope);
+    if (_accountant.waitIfPaused()) {
+      checkTerminationInternal(scope);
+    }
   }
 
   private void waitIfPausedInternal(Supplier<String> scopeSupplier) {
-    _accountant.waitIfPaused();
-    checkTerminationInternal(scopeSupplier);
+    if (_accountant.waitIfPaused()) {
+      checkTerminationInternal(scopeSupplier);
+    }
   }
 
   private void waitIfPausedInternal(String scope, long deadlineMs) {
-    _accountant.waitIfPaused();
-    checkTerminationInternal(scope, deadlineMs);
+    if (_accountant.waitIfPaused()) {
+      checkTerminationInternal(scope, deadlineMs);
+    }
   }
 
   private void waitIfPausedInternal(Supplier<String> scopeSupplier, long deadlineMs) {
-    _accountant.waitIfPaused();
-    checkTerminationInternal(scopeSupplier, deadlineMs);
+    if (_accountant.waitIfPaused()) {
+      checkTerminationInternal(scopeSupplier, deadlineMs);
+    }
   }
 
   private void checkTerminationInternal(String scope) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -1763,8 +1763,8 @@ public class CommonConstants {
         "accounting.oom.pre.query.kill.pause.duration.ms";
     public static final long DEFAULT_OOM_PRE_QUERY_KILL_PAUSE_DURATION_MS = -1;
 
-    public static final String CONFIG_OF_OOM_PANIC_PRE_QUERY_KILL_PAUSE_ENABLED =
-        "accounting.oom.panic.pre.query.kill.pause.enabled";
+    public static final String CONFIG_OF_OOM_PANIC_ALLOW_PRE_QUERY_KILL_PAUSE =
+        "accounting.oom.panic.allow.pre.query.kill.pause";
     public static final boolean DEFAULT_OOM_PANIC_PRE_QUERY_KILL_PAUSE_ENABLED = false;
 
     /**

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -1759,6 +1759,12 @@ public class CommonConstants {
     public static final String CONFIG_OF_QUERY_KILLED_METRIC_ENABLED = "accounting.query.killed.metric.enabled";
     public static final boolean DEFAULT_QUERY_KILLED_METRIC_ENABLED = false;
 
+    public static final String CONFIG_OF_OOM_PAUSE_ENABLED = "accounting.oom.critical.query.pause.enabled";
+    public static final boolean DEFAULT_OOM_PAUSE_ENABLED = false;
+
+    public static final String CONFIG_OF_OOM_PAUSE_TIMEOUT_MS = "accounting.oom.critical.query.pause.timeout.ms";
+    public static final long DEFAULT_OOM_PAUSE_TIMEOUT_MS = 1000;
+
     /**
      * QUERY WORKLOAD ISOLATION Configs
      *

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -1759,11 +1759,8 @@ public class CommonConstants {
     public static final String CONFIG_OF_QUERY_KILLED_METRIC_ENABLED = "accounting.query.killed.metric.enabled";
     public static final boolean DEFAULT_QUERY_KILLED_METRIC_ENABLED = false;
 
-    public static final String CONFIG_OF_OOM_PAUSE_ENABLED = "accounting.oom.critical.query.pause.enabled";
-    public static final boolean DEFAULT_OOM_PAUSE_ENABLED = false;
-
     public static final String CONFIG_OF_OOM_PAUSE_TIMEOUT_MS = "accounting.oom.critical.query.pause.timeout.ms";
-    public static final long DEFAULT_OOM_PAUSE_TIMEOUT_MS = 1000;
+    public static final long DEFAULT_OOM_PAUSE_TIMEOUT_MS = -1;
 
     /**
      * QUERY WORKLOAD ISOLATION Configs

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -1759,8 +1759,13 @@ public class CommonConstants {
     public static final String CONFIG_OF_QUERY_KILLED_METRIC_ENABLED = "accounting.query.killed.metric.enabled";
     public static final boolean DEFAULT_QUERY_KILLED_METRIC_ENABLED = false;
 
-    public static final String CONFIG_OF_OOM_PAUSE_TIMEOUT_MS = "accounting.oom.critical.query.pause.timeout.ms";
-    public static final long DEFAULT_OOM_PAUSE_TIMEOUT_MS = -1;
+    public static final String CONFIG_OF_OOM_PRE_QUERY_KILL_PAUSE_DURATION_MS =
+        "accounting.oom.pre.query.kill.pause.duration.ms";
+    public static final long DEFAULT_OOM_PRE_QUERY_KILL_PAUSE_DURATION_MS = -1;
+
+    public static final String CONFIG_OF_OOM_PANIC_PRE_QUERY_KILL_PAUSE_ENABLED =
+        "accounting.oom.panic.pre.query.kill.pause.enabled";
+    public static final boolean DEFAULT_OOM_PANIC_PRE_QUERY_KILL_PAUSE_ENABLED = false;
 
     /**
      * QUERY WORKLOAD ISOLATION Configs


### PR DESCRIPTION
### Summary

- When heap transitions from below-critical to critical, pauses all query execution threads for a configurable duration and calls `System.gc()` (only once, on first transition into critical), giving the JVM breathing room to reclaim memory before resorting to query kills.
- If heap recovers below critical during the pause window, threads resume with no query killed.
- If heap stays critical after the pause expires, the existing kill-most-expensive-query logic proceeds.
- Optionally also applies the pause on a fresh jump straight to panic level (bypassing critical), before killing all queries.
- Off by default, dynamically toggleable via cluster config (no restart required).

<hr>

### Overhead

- Happy path (no OOM pressure): `waitIfPaused()` is called at every sampling checkpoint and costs a single volatile read of `_pauseActive`. No lock, no contention.
- Triggering path (critical heap): Query threads block on a `ReentrantLock` + `Condition`. Lock contention is not a concern because:
  - Threads acquire the lock only to enter `Condition.await()`, releasing it immediately - hold time is near-zero.
  - `activatePause()` (watcher thread) is lock-free - it writes two fields (one volatile) with correct ordering.
  - This only activates when the JVM is already under critical/panic heap pressure and queries are about to be killed anyway.

<hr>

### Configuration

```
┌─────────────────────────────────────────────────┬─────────┬─────────┬──────────────────────────────────────────────────────────┐
│                   Config key                    │  Type   │ Default │                       Description                        │
├─────────────────────────────────────────────────┼─────────┼─────────┼──────────────────────────────────────────────────────────┤
│ accounting.oom.pre.query.kill.pause.duration.ms │ long    │ -1      │ How long (ms) to pause query threads before proceeding   │
│                                                 │         │         │ with kill. Non-positive value disables the feature.      │
├─────────────────────────────────────────────────┼─────────┼─────────┼──────────────────────────────────────────────────────────┤
│ accounting.oom.panic.allow.pre.query.kill.pause │ boolean │ false   │ Whether to also apply the pause before killing at panic  │
│                                                 │         │         │ level (only effective when the pause feature is enabled  │
│                                                 │         │         │ via the duration config above).                          │
└─────────────────────────────────────────────────┴─────────┴─────────┴──────────────────────────────────────────────────────────┘
```

Both are dynamically updatable via Helix cluster config.

<hr>

### State transitions

- Below critical → Critical (pause enabled): Activate pause, call `System.gc()`
- Critical → Critical (within pause window): No-op, let GC work
- Critical → Critical (pause expired): Clear pause, kill most expensive query
- Critical → Below critical (pause active): Clear pause, resume threads, no kill
- Below critical → Panic (pause + panic-pause enabled): Activate pause, call `System.gc()` (skip immediate kill-all)
- Panic → Panic (within pause window, panic-pause enabled): No-op
- Panic → Panic (pause expired, or panic-pause disabled): Clear pause, kill all queries
- Critical → Panic (pause already active): Existing pause carries over; kill all on expiry
- Below critical → Critical (pause disabled): Existing behavior (immediate kill of most expensive query)
- Below critical → Panic (panic-pause disabled): Existing behavior (immediate kill of all queries)
