### PR TITLE
Add polymorphic window functions

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/aggregate/BoolAndWindowValueAggregator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/aggregate/BoolAndWindowValueAggregator.java
@@ -19,44 +19,58 @@
 package org.apache.pinot.query.runtime.operator.window.aggregate;
 
 import javax.annotation.Nullable;
+import org.apache.pinot.spi.utils.BooleanUtils;
 
 
 /**
- * Window value aggregator for SUM window function.
+ * Window value aggregator for BOOL_AND window function.
  */
-public class SumWindowValueAggregator implements WindowValueAggregator<Object> {
-  private double _sum = 0.0;
-  private int _count = 0;
+public class BoolAndWindowValueAggregator implements WindowValueAggregator<Object> {
+  private int _numFalse = 0;
+  private int _numTrue = 0;
+  private int _numNull = 0;
 
   @Override
   public void addValue(@Nullable Object value) {
-    if (value != null) {
-      _count++;
-      _sum += ((Number) value).doubleValue();
+    if (value == null) {
+      _numNull++;
+    } else if (BooleanUtils.isFalseInternalValue(value)) {
+      _numFalse++;
+    } else {
+      _numTrue++;
     }
   }
 
   @Override
   public void removeValue(@Nullable Object value) {
-    if (value != null) {
-      _count--;
-      _sum -= ((Number) value).doubleValue();
+    if (value == null) {
+      _numNull--;
+    } else if (BooleanUtils.isFalseInternalValue(value)) {
+      _numFalse--;
+    } else {
+      _numTrue--;
     }
   }
 
-  @Override
   @Nullable
+  @Override
   public Object getCurrentAggregatedValue() {
-    if (_count == 0) {
-      return null;
-    } else {
-      return _sum;
+    if (_numFalse > 0) {
+      return BooleanUtils.INTERNAL_FALSE;
     }
+    if (_numNull > 0) {
+      return null;
+    }
+    if (_numTrue > 0) {
+      return BooleanUtils.INTERNAL_TRUE;
+    }
+    return null;
   }
 
   @Override
   public void clear() {
-    _sum = 0.0;
-    _count = 0;
+    _numFalse = 0;
+    _numTrue = 0;
+    _numNull = 0;
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/aggregate/BoolOrWindowValueAggregator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/aggregate/BoolOrWindowValueAggregator.java
@@ -1,0 +1,76 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.operator.window.aggregate;
+
+import javax.annotation.Nullable;
+import org.apache.pinot.spi.utils.BooleanUtils;
+
+
+/**
+ * Window value aggregator for BOOL_OR window function.
+ */
+public class BoolOrWindowValueAggregator implements WindowValueAggregator<Object> {
+  private int _numFalse = 0;
+  private int _numTrue = 0;
+  private int _numNull = 0;
+
+  @Override
+  public void addValue(@Nullable Object value) {
+    if (value == null) {
+      _numNull++;
+    } else if (BooleanUtils.isFalseInternalValue(value)) {
+      _numFalse++;
+    } else {
+      _numTrue++;
+    }
+  }
+
+  @Override
+  public void removeValue(@Nullable Object value) {
+    if (value == null) {
+      _numNull--;
+    } else if (BooleanUtils.isFalseInternalValue(value)) {
+      _numFalse--;
+    } else {
+      _numTrue--;
+    }
+  }
+
+  @Nullable
+  @Override
+  public Object getCurrentAggregatedValue() {
+    if (_numTrue > 0) {
+      return BooleanUtils.INTERNAL_TRUE;
+    }
+    if (_numNull > 0) {
+      return null;
+    }
+    if (_numFalse > 0) {
+      return BooleanUtils.INTERNAL_FALSE;
+    }
+    return null;
+  }
+
+  @Override
+  public void clear() {
+    _numFalse = 0;
+    _numTrue = 0;
+    _numNull = 0;
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/aggregate/MaxComparableWindowValueAggregator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/aggregate/MaxComparableWindowValueAggregator.java
@@ -18,18 +18,19 @@
  */
 package org.apache.pinot.query.runtime.operator.window.aggregate;
 
-import it.unimi.dsi.fastutil.doubles.DoubleArrayFIFOQueue;
+import java.util.ArrayDeque;
 import javax.annotation.Nullable;
 
 
 /**
- * Window value aggregator for MIN window function.
+ * Window value aggregator for MAX window function that preserves the input type by using {@link Comparable} for
+ * comparisons. Used for types like BIG_DECIMAL that don't have a dedicated primitive-typed aggregator.
  */
-public class MinWindowValueAggregator implements WindowValueAggregator<Object> {
+public class MaxComparableWindowValueAggregator implements WindowValueAggregator<Object> {
 
   private final boolean _supportRemoval;
-  private final DoubleArrayFIFOQueue _deque = new DoubleArrayFIFOQueue();
-  private Double _minValue = null;
+  private final ArrayDeque<Object> _deque = new ArrayDeque<>();
+  private Object _maxValue = null;
 
   /**
    * @param supportRemoval whether this window value aggregator should support removal of values. Some cases require
@@ -37,23 +38,22 @@ public class MinWindowValueAggregator implements WindowValueAggregator<Object> {
    *                       if {@code supportRemoval} is true, this value aggregator will have O(K) space complexity
    *                       (where K is the max size of the window).
    */
-  public MinWindowValueAggregator(boolean supportRemoval) {
+  public MaxComparableWindowValueAggregator(boolean supportRemoval) {
     _supportRemoval = supportRemoval;
   }
 
   @Override
   public void addValue(@Nullable Object value) {
     if (value != null) {
-      double doubleValue = ((Number) value).doubleValue();
       if (_supportRemoval) {
-        // Remove previously added elements if they're > than the current element since they're no longer useful
-        while (!_deque.isEmpty() && _deque.lastDouble() > doubleValue) {
-          _deque.dequeueLastDouble();
+        // Remove previously added elements if they're < than the current element since they're no longer useful
+        while (!_deque.isEmpty() && compare(_deque.peekLast(), value) < 0) {
+          _deque.pollLast();
         }
-        _deque.enqueue(doubleValue);
+        _deque.addLast(value);
       } else {
-        if (_minValue == null || doubleValue < _minValue) {
-          _minValue = doubleValue;
+        if (_maxValue == null || compare(value, _maxValue) > 0) {
+          _maxValue = value;
         }
       }
     }
@@ -66,28 +66,30 @@ public class MinWindowValueAggregator implements WindowValueAggregator<Object> {
     }
 
     if (value != null) {
-      double doubleValue = ((Number) value).doubleValue();
-      if (!_deque.isEmpty() && _deque.firstDouble() == doubleValue) {
-        _deque.dequeueDouble();
+      if (!_deque.isEmpty() && compare(_deque.peekFirst(), value) == 0) {
+        _deque.pollFirst();
       }
     }
   }
 
+  @Nullable
   @Override
   public Object getCurrentAggregatedValue() {
     if (_supportRemoval) {
-      if (_deque.isEmpty()) {
-        return null;
-      }
-      return _deque.firstDouble();
+      return _deque.peekFirst();
     } else {
-      return _minValue;
+      return _maxValue;
     }
   }
 
   @Override
   public void clear() {
     _deque.clear();
-    _minValue = null;
+    _maxValue = null;
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  private static int compare(Object a, Object b) {
+    return ((Comparable) a).compareTo(b);
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/aggregate/MaxDoubleWindowValueAggregator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/aggregate/MaxDoubleWindowValueAggregator.java
@@ -1,0 +1,94 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.operator.window.aggregate;
+
+import it.unimi.dsi.fastutil.doubles.DoubleArrayFIFOQueue;
+import javax.annotation.Nullable;
+
+
+/**
+ * Window value aggregator for MAX window function.
+ */
+public class MaxDoubleWindowValueAggregator implements WindowValueAggregator<Object> {
+
+  private final boolean _supportRemoval;
+  private final DoubleArrayFIFOQueue _deque = new DoubleArrayFIFOQueue();
+  private Double _maxValue = null;
+
+  /**
+   * @param supportRemoval whether this window value aggregator should support removal of values. Some cases require
+   *                       only addition of values in which case this value aggregator will have O(1) space complexity;
+   *                       if {@code supportRemoval} is true, this value aggregator will have O(K) space complexity
+   *                       (where K is the max size of the window).
+   */
+  public MaxDoubleWindowValueAggregator(boolean supportRemoval) {
+    _supportRemoval = supportRemoval;
+  }
+
+  @Override
+  public void addValue(@Nullable Object value) {
+    if (value != null) {
+      double doubleValue = ((Number) value).doubleValue();
+      if (_supportRemoval) {
+        // Remove previously added elements if they're < than the current element since they're no longer useful
+        while (!_deque.isEmpty() && _deque.lastDouble() < doubleValue) {
+          _deque.dequeueLastDouble();
+        }
+        _deque.enqueue(doubleValue);
+      } else {
+        if (_maxValue == null || doubleValue > _maxValue) {
+          _maxValue = doubleValue;
+        }
+      }
+    }
+  }
+
+  @Override
+  public void removeValue(@Nullable Object value) {
+    if (!_supportRemoval) {
+      throw new UnsupportedOperationException();
+    }
+
+    if (value != null) {
+      double doubleValue = ((Number) value).doubleValue();
+      if (!_deque.isEmpty() && _deque.firstDouble() == doubleValue) {
+        _deque.dequeueDouble();
+      }
+    }
+  }
+
+  @Nullable
+  @Override
+  public Object getCurrentAggregatedValue() {
+    if (_supportRemoval) {
+      if (_deque.isEmpty()) {
+        return null;
+      }
+      return _deque.firstDouble();
+    } else {
+      return _maxValue;
+    }
+  }
+
+  @Override
+  public void clear() {
+    _deque.clear();
+    _maxValue = null;
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/aggregate/MaxIntWindowValueAggregator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/aggregate/MaxIntWindowValueAggregator.java
@@ -1,0 +1,96 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.operator.window.aggregate;
+
+import it.unimi.dsi.fastutil.ints.IntArrayFIFOQueue;
+import javax.annotation.Nullable;
+
+
+/**
+ * Window value aggregator for MAX window function over INT types.
+ * Uses primitive {@code int} operations and {@link IntArrayFIFOQueue} to avoid boxing overhead and improve cache
+ * locality compared to the {@link Comparable}-based aggregator.
+ */
+public class MaxIntWindowValueAggregator implements WindowValueAggregator<Object> {
+
+  private final boolean _supportRemoval;
+  private final IntArrayFIFOQueue _deque = new IntArrayFIFOQueue();
+  private Integer _maxValue = null;
+
+  /**
+   * @param supportRemoval whether this window value aggregator should support removal of values. Some cases require
+   *                       only addition of values in which case this value aggregator will have O(1) space complexity;
+   *                       if {@code supportRemoval} is true, this value aggregator will have O(K) space complexity
+   *                       (where K is the max size of the window).
+   */
+  public MaxIntWindowValueAggregator(boolean supportRemoval) {
+    _supportRemoval = supportRemoval;
+  }
+
+  @Override
+  public void addValue(@Nullable Object value) {
+    if (value != null) {
+      int intValue = ((Number) value).intValue();
+      if (_supportRemoval) {
+        // Remove previously added elements if they're < than the current element since they're no longer useful
+        while (!_deque.isEmpty() && _deque.lastInt() < intValue) {
+          _deque.dequeueLastInt();
+        }
+        _deque.enqueue(intValue);
+      } else {
+        if (_maxValue == null || intValue > _maxValue) {
+          _maxValue = intValue;
+        }
+      }
+    }
+  }
+
+  @Override
+  public void removeValue(@Nullable Object value) {
+    if (!_supportRemoval) {
+      throw new UnsupportedOperationException();
+    }
+
+    if (value != null) {
+      int intValue = ((Number) value).intValue();
+      if (!_deque.isEmpty() && _deque.firstInt() == intValue) {
+        _deque.dequeueInt();
+      }
+    }
+  }
+
+  @Nullable
+  @Override
+  public Object getCurrentAggregatedValue() {
+    if (_supportRemoval) {
+      if (_deque.isEmpty()) {
+        return null;
+      }
+      return _deque.firstInt();
+    } else {
+      return _maxValue;
+    }
+  }
+
+  @Override
+  public void clear() {
+    _deque.clear();
+    _maxValue = null;
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/aggregate/MaxLongWindowValueAggregator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/aggregate/MaxLongWindowValueAggregator.java
@@ -1,0 +1,97 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.operator.window.aggregate;
+
+import it.unimi.dsi.fastutil.longs.LongArrayFIFOQueue;
+import javax.annotation.Nullable;
+
+
+/**
+ * Window value aggregator for MAX window function over LONG types.
+ * Uses primitive {@code long} operations and {@link LongArrayFIFOQueue} to avoid boxing overhead and improve cache
+ * locality compared to the {@link Comparable}-based aggregator. Also avoids precision loss that occurs when converting
+ * large long values to double.
+ */
+public class MaxLongWindowValueAggregator implements WindowValueAggregator<Object> {
+
+  private final boolean _supportRemoval;
+  private final LongArrayFIFOQueue _deque = new LongArrayFIFOQueue();
+  private Long _maxValue = null;
+
+  /**
+   * @param supportRemoval whether this window value aggregator should support removal of values. Some cases require
+   *                       only addition of values in which case this value aggregator will have O(1) space complexity;
+   *                       if {@code supportRemoval} is true, this value aggregator will have O(K) space complexity
+   *                       (where K is the max size of the window).
+   */
+  public MaxLongWindowValueAggregator(boolean supportRemoval) {
+    _supportRemoval = supportRemoval;
+  }
+
+  @Override
+  public void addValue(@Nullable Object value) {
+    if (value != null) {
+      long longValue = ((Number) value).longValue();
+      if (_supportRemoval) {
+        // Remove previously added elements if they're < than the current element since they're no longer useful
+        while (!_deque.isEmpty() && _deque.lastLong() < longValue) {
+          _deque.dequeueLastLong();
+        }
+        _deque.enqueue(longValue);
+      } else {
+        if (_maxValue == null || longValue > _maxValue) {
+          _maxValue = longValue;
+        }
+      }
+    }
+  }
+
+  @Override
+  public void removeValue(@Nullable Object value) {
+    if (!_supportRemoval) {
+      throw new UnsupportedOperationException();
+    }
+
+    if (value != null) {
+      long longValue = ((Number) value).longValue();
+      if (!_deque.isEmpty() && _deque.firstLong() == longValue) {
+        _deque.dequeueLong();
+      }
+    }
+  }
+
+  @Nullable
+  @Override
+  public Object getCurrentAggregatedValue() {
+    if (_supportRemoval) {
+      if (_deque.isEmpty()) {
+        return null;
+      }
+      return _deque.firstLong();
+    } else {
+      return _maxValue;
+    }
+  }
+
+  @Override
+  public void clear() {
+    _deque.clear();
+    _maxValue = null;
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/aggregate/MinComparableWindowValueAggregator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/aggregate/MinComparableWindowValueAggregator.java
@@ -1,0 +1,95 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.operator.window.aggregate;
+
+import java.util.ArrayDeque;
+import javax.annotation.Nullable;
+
+
+/**
+ * Window value aggregator for MIN window function that preserves the input type by using {@link Comparable} for
+ * comparisons. Used for types like BIG_DECIMAL that don't have a dedicated primitive-typed aggregator.
+ */
+public class MinComparableWindowValueAggregator implements WindowValueAggregator<Object> {
+
+  private final boolean _supportRemoval;
+  private final ArrayDeque<Object> _deque = new ArrayDeque<>();
+  private Object _minValue = null;
+
+  /**
+   * @param supportRemoval whether this window value aggregator should support removal of values. Some cases require
+   *                       only addition of values in which case this value aggregator will have O(1) space complexity;
+   *                       if {@code supportRemoval} is true, this value aggregator will have O(K) space complexity
+   *                       (where K is the max size of the window).
+   */
+  public MinComparableWindowValueAggregator(boolean supportRemoval) {
+    _supportRemoval = supportRemoval;
+  }
+
+  @Override
+  public void addValue(@Nullable Object value) {
+    if (value != null) {
+      if (_supportRemoval) {
+        // Remove previously added elements if they're > than the current element since they're no longer useful
+        while (!_deque.isEmpty() && compare(_deque.peekLast(), value) > 0) {
+          _deque.pollLast();
+        }
+        _deque.addLast(value);
+      } else {
+        if (_minValue == null || compare(value, _minValue) < 0) {
+          _minValue = value;
+        }
+      }
+    }
+  }
+
+  @Override
+  public void removeValue(@Nullable Object value) {
+    if (!_supportRemoval) {
+      throw new UnsupportedOperationException();
+    }
+
+    if (value != null) {
+      if (!_deque.isEmpty() && compare(_deque.peekFirst(), value) == 0) {
+        _deque.pollFirst();
+      }
+    }
+  }
+
+  @Nullable
+  @Override
+  public Object getCurrentAggregatedValue() {
+    if (_supportRemoval) {
+      return _deque.peekFirst();
+    } else {
+      return _minValue;
+    }
+  }
+
+  @Override
+  public void clear() {
+    _deque.clear();
+    _minValue = null;
+  }
+
+  @SuppressWarnings({"unchecked", "rawtypes"})
+  private static int compare(Object a, Object b) {
+    return ((Comparable) a).compareTo(b);
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/aggregate/MinDoubleWindowValueAggregator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/aggregate/MinDoubleWindowValueAggregator.java
@@ -23,13 +23,13 @@ import javax.annotation.Nullable;
 
 
 /**
- * Window value aggregator for MAX window function.
+ * Window value aggregator for MIN window function.
  */
-public class MaxWindowValueAggregator implements WindowValueAggregator<Object> {
+public class MinDoubleWindowValueAggregator implements WindowValueAggregator<Object> {
 
   private final boolean _supportRemoval;
   private final DoubleArrayFIFOQueue _deque = new DoubleArrayFIFOQueue();
-  private Double _maxValue = null;
+  private Double _minValue = null;
 
   /**
    * @param supportRemoval whether this window value aggregator should support removal of values. Some cases require
@@ -37,7 +37,7 @@ public class MaxWindowValueAggregator implements WindowValueAggregator<Object> {
    *                       if {@code supportRemoval} is true, this value aggregator will have O(K) space complexity
    *                       (where K is the max size of the window).
    */
-  public MaxWindowValueAggregator(boolean supportRemoval) {
+  public MinDoubleWindowValueAggregator(boolean supportRemoval) {
     _supportRemoval = supportRemoval;
   }
 
@@ -46,14 +46,14 @@ public class MaxWindowValueAggregator implements WindowValueAggregator<Object> {
     if (value != null) {
       double doubleValue = ((Number) value).doubleValue();
       if (_supportRemoval) {
-        // Remove previously added elements if they're < than the current element since they're no longer useful
-        while (!_deque.isEmpty() && _deque.lastDouble() < doubleValue) {
+        // Remove previously added elements if they're > than the current element since they're no longer useful
+        while (!_deque.isEmpty() && _deque.lastDouble() > doubleValue) {
           _deque.dequeueLastDouble();
         }
         _deque.enqueue(doubleValue);
       } else {
-        if (_maxValue == null || doubleValue > _maxValue) {
-          _maxValue = doubleValue;
+        if (_minValue == null || doubleValue < _minValue) {
+          _minValue = doubleValue;
         }
       }
     }
@@ -73,6 +73,7 @@ public class MaxWindowValueAggregator implements WindowValueAggregator<Object> {
     }
   }
 
+  @Nullable
   @Override
   public Object getCurrentAggregatedValue() {
     if (_supportRemoval) {
@@ -81,13 +82,13 @@ public class MaxWindowValueAggregator implements WindowValueAggregator<Object> {
       }
       return _deque.firstDouble();
     } else {
-      return _maxValue;
+      return _minValue;
     }
   }
 
   @Override
   public void clear() {
     _deque.clear();
-    _maxValue = null;
+    _minValue = null;
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/aggregate/MinIntWindowValueAggregator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/aggregate/MinIntWindowValueAggregator.java
@@ -1,0 +1,96 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.operator.window.aggregate;
+
+import it.unimi.dsi.fastutil.ints.IntArrayFIFOQueue;
+import javax.annotation.Nullable;
+
+
+/**
+ * Window value aggregator for MIN window function over INT types.
+ * Uses primitive {@code int} operations and {@link IntArrayFIFOQueue} to avoid boxing overhead and improve cache
+ * locality compared to the {@link Comparable}-based aggregator.
+ */
+public class MinIntWindowValueAggregator implements WindowValueAggregator<Object> {
+
+  private final boolean _supportRemoval;
+  private final IntArrayFIFOQueue _deque = new IntArrayFIFOQueue();
+  private Integer _minValue = null;
+
+  /**
+   * @param supportRemoval whether this window value aggregator should support removal of values. Some cases require
+   *                       only addition of values in which case this value aggregator will have O(1) space complexity;
+   *                       if {@code supportRemoval} is true, this value aggregator will have O(K) space complexity
+   *                       (where K is the max size of the window).
+   */
+  public MinIntWindowValueAggregator(boolean supportRemoval) {
+    _supportRemoval = supportRemoval;
+  }
+
+  @Override
+  public void addValue(@Nullable Object value) {
+    if (value != null) {
+      int intValue = ((Number) value).intValue();
+      if (_supportRemoval) {
+        // Remove previously added elements if they're > than the current element since they're no longer useful
+        while (!_deque.isEmpty() && _deque.lastInt() > intValue) {
+          _deque.dequeueLastInt();
+        }
+        _deque.enqueue(intValue);
+      } else {
+        if (_minValue == null || intValue < _minValue) {
+          _minValue = intValue;
+        }
+      }
+    }
+  }
+
+  @Override
+  public void removeValue(@Nullable Object value) {
+    if (!_supportRemoval) {
+      throw new UnsupportedOperationException();
+    }
+
+    if (value != null) {
+      int intValue = ((Number) value).intValue();
+      if (!_deque.isEmpty() && _deque.firstInt() == intValue) {
+        _deque.dequeueInt();
+      }
+    }
+  }
+
+  @Nullable
+  @Override
+  public Object getCurrentAggregatedValue() {
+    if (_supportRemoval) {
+      if (_deque.isEmpty()) {
+        return null;
+      }
+      return _deque.firstInt();
+    } else {
+      return _minValue;
+    }
+  }
+
+  @Override
+  public void clear() {
+    _deque.clear();
+    _minValue = null;
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/aggregate/MinLongWindowValueAggregator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/aggregate/MinLongWindowValueAggregator.java
@@ -1,0 +1,97 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.operator.window.aggregate;
+
+import it.unimi.dsi.fastutil.longs.LongArrayFIFOQueue;
+import javax.annotation.Nullable;
+
+
+/**
+ * Window value aggregator for MIN window function over LONG types.
+ * Uses primitive {@code long} operations and {@link LongArrayFIFOQueue} to avoid boxing overhead and improve cache
+ * locality compared to the {@link Comparable}-based aggregator. Also avoids precision loss that occurs when converting
+ * large long values to double.
+ */
+public class MinLongWindowValueAggregator implements WindowValueAggregator<Object> {
+
+  private final boolean _supportRemoval;
+  private final LongArrayFIFOQueue _deque = new LongArrayFIFOQueue();
+  private Long _minValue = null;
+
+  /**
+   * @param supportRemoval whether this window value aggregator should support removal of values. Some cases require
+   *                       only addition of values in which case this value aggregator will have O(1) space complexity;
+   *                       if {@code supportRemoval} is true, this value aggregator will have O(K) space complexity
+   *                       (where K is the max size of the window).
+   */
+  public MinLongWindowValueAggregator(boolean supportRemoval) {
+    _supportRemoval = supportRemoval;
+  }
+
+  @Override
+  public void addValue(@Nullable Object value) {
+    if (value != null) {
+      long longValue = ((Number) value).longValue();
+      if (_supportRemoval) {
+        // Remove previously added elements if they're > than the current element since they're no longer useful
+        while (!_deque.isEmpty() && _deque.lastLong() > longValue) {
+          _deque.dequeueLastLong();
+        }
+        _deque.enqueue(longValue);
+      } else {
+        if (_minValue == null || longValue < _minValue) {
+          _minValue = longValue;
+        }
+      }
+    }
+  }
+
+  @Override
+  public void removeValue(@Nullable Object value) {
+    if (!_supportRemoval) {
+      throw new UnsupportedOperationException();
+    }
+
+    if (value != null) {
+      long longValue = ((Number) value).longValue();
+      if (!_deque.isEmpty() && _deque.firstLong() == longValue) {
+        _deque.dequeueLong();
+      }
+    }
+  }
+
+  @Nullable
+  @Override
+  public Object getCurrentAggregatedValue() {
+    if (_supportRemoval) {
+      if (_deque.isEmpty()) {
+        return null;
+      }
+      return _deque.firstLong();
+    } else {
+      return _minValue;
+    }
+  }
+
+  @Override
+  public void clear() {
+    _deque.clear();
+    _minValue = null;
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/aggregate/SumBigDecimalWindowValueAggregator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/aggregate/SumBigDecimalWindowValueAggregator.java
@@ -18,59 +18,54 @@
  */
 package org.apache.pinot.query.runtime.operator.window.aggregate;
 
+import java.math.BigDecimal;
 import javax.annotation.Nullable;
-import org.apache.pinot.spi.utils.BooleanUtils;
 
 
 /**
- * Window value aggregator for BOOL_OR window function.
+ * Window value aggregator for SUM window function over BIG_DECIMAL types.
+ * Accumulates as {@link BigDecimal} to preserve full precision.
  */
-public class BoolOrValueAggregator implements WindowValueAggregator<Object> {
-  private int _numFalse = 0;
-  private int _numTrue = 0;
-  private int _numNull = 0;
+public class SumBigDecimalWindowValueAggregator implements WindowValueAggregator<Object> {
+  private BigDecimal _sum = BigDecimal.ZERO;
+  private int _count = 0;
 
   @Override
   public void addValue(@Nullable Object value) {
-    if (value == null) {
-      _numNull++;
-    } else if (BooleanUtils.isFalseInternalValue(value)) {
-      _numFalse++;
-    } else {
-      _numTrue++;
+    if (value != null) {
+      _count++;
+      _sum = _sum.add(toBigDecimal(value));
     }
   }
 
   @Override
   public void removeValue(@Nullable Object value) {
-    if (value == null) {
-      _numNull--;
-    } else if (BooleanUtils.isFalseInternalValue(value)) {
-      _numFalse--;
-    } else {
-      _numTrue--;
+    if (value != null) {
+      _count--;
+      _sum = _sum.subtract(toBigDecimal(value));
     }
   }
 
-  @Nullable
   @Override
+  @Nullable
   public Object getCurrentAggregatedValue() {
-    if (_numTrue > 0) {
-      return BooleanUtils.INTERNAL_TRUE;
-    }
-    if (_numNull > 0) {
+    if (_count == 0) {
       return null;
+    } else {
+      return _sum;
     }
-    if (_numFalse > 0) {
-      return BooleanUtils.INTERNAL_FALSE;
-    }
-    return null;
   }
 
   @Override
   public void clear() {
-    _numFalse = 0;
-    _numTrue = 0;
-    _numNull = 0;
+    _sum = BigDecimal.ZERO;
+    _count = 0;
+  }
+
+  private static BigDecimal toBigDecimal(Object value) {
+    if (value instanceof BigDecimal) {
+      return (BigDecimal) value;
+    }
+    return BigDecimal.valueOf(((Number) value).doubleValue());
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/aggregate/SumBigDecimalWindowValueAggregator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/aggregate/SumBigDecimalWindowValueAggregator.java
@@ -66,6 +66,10 @@ public class SumBigDecimalWindowValueAggregator implements WindowValueAggregator
     if (value instanceof BigDecimal) {
       return (BigDecimal) value;
     }
-    return BigDecimal.valueOf(((Number) value).doubleValue());
+    Number number = (Number) value;
+    if (number instanceof Long || number instanceof Integer || number instanceof Short || number instanceof Byte) {
+      return BigDecimal.valueOf(number.longValue());
+    }
+    return BigDecimal.valueOf(number.doubleValue());
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/aggregate/SumDoubleWindowValueAggregator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/aggregate/SumDoubleWindowValueAggregator.java
@@ -19,58 +19,44 @@
 package org.apache.pinot.query.runtime.operator.window.aggregate;
 
 import javax.annotation.Nullable;
-import org.apache.pinot.spi.utils.BooleanUtils;
 
 
 /**
- * Window value aggregator for BOOL_AND window function.
+ * Window value aggregator for SUM window function.
  */
-public class BoolAndValueAggregator implements WindowValueAggregator<Object> {
-  private int _numFalse = 0;
-  private int _numTrue = 0;
-  private int _numNull = 0;
+public class SumDoubleWindowValueAggregator implements WindowValueAggregator<Object> {
+  private double _sum = 0.0;
+  private int _count = 0;
 
   @Override
   public void addValue(@Nullable Object value) {
-    if (value == null) {
-      _numNull++;
-    } else if (BooleanUtils.isFalseInternalValue(value)) {
-      _numFalse++;
-    } else {
-      _numTrue++;
+    if (value != null) {
+      _count++;
+      _sum += ((Number) value).doubleValue();
     }
   }
 
   @Override
   public void removeValue(@Nullable Object value) {
-    if (value == null) {
-      _numNull--;
-    } else if (BooleanUtils.isFalseInternalValue(value)) {
-      _numFalse--;
-    } else {
-      _numTrue--;
+    if (value != null) {
+      _count--;
+      _sum -= ((Number) value).doubleValue();
     }
   }
 
-  @Nullable
   @Override
+  @Nullable
   public Object getCurrentAggregatedValue() {
-    if (_numFalse > 0) {
-      return BooleanUtils.INTERNAL_FALSE;
-    }
-    if (_numNull > 0) {
+    if (_count == 0) {
       return null;
+    } else {
+      return _sum;
     }
-    if (_numTrue > 0) {
-      return BooleanUtils.INTERNAL_TRUE;
-    }
-    return null;
   }
 
   @Override
   public void clear() {
-    _numFalse = 0;
-    _numTrue = 0;
-    _numNull = 0;
+    _sum = 0.0;
+    _count = 0;
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/aggregate/SumLongWindowValueAggregator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/aggregate/SumLongWindowValueAggregator.java
@@ -1,0 +1,63 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.operator.window.aggregate;
+
+import javax.annotation.Nullable;
+
+
+/**
+ * Window value aggregator for SUM window function over integer types (INT, LONG).
+ * Accumulates as {@code long} to avoid precision loss that occurs when converting large long values to double.
+ */
+public class SumLongWindowValueAggregator implements WindowValueAggregator<Object> {
+  private long _sum = 0L;
+  private int _count = 0;
+
+  @Override
+  public void addValue(@Nullable Object value) {
+    if (value != null) {
+      _count++;
+      _sum += ((Number) value).longValue();
+    }
+  }
+
+  @Override
+  public void removeValue(@Nullable Object value) {
+    if (value != null) {
+      _count--;
+      _sum -= ((Number) value).longValue();
+    }
+  }
+
+  @Override
+  @Nullable
+  public Object getCurrentAggregatedValue() {
+    if (_count == 0) {
+      return null;
+    } else {
+      return _sum;
+    }
+  }
+
+  @Override
+  public void clear() {
+    _sum = 0L;
+    _count = 0;
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/aggregate/WindowValueAggregatorFactory.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/aggregate/WindowValueAggregatorFactory.java
@@ -38,28 +38,70 @@ public class WindowValueAggregatorFactory {
    */
   public static WindowValueAggregator<Object> getWindowValueAggregator(String functionName,
       DataSchema.ColumnDataType columnDataType, boolean supportRemoval) {
-    // TODO: Add type specific aggregator implementations
+    DataSchema.ColumnDataType storedType = columnDataType.getStoredType();
     switch (functionName) {
       // NOTE: Keep both 'SUM0' and '$SUM0' for backward compatibility where 'SUM0' is SqlKind and '$SUM0' is function
       // name.
       case "SUM":
       case "SUM0":
       case "$SUM0":
-        return new SumWindowValueAggregator();
+        return createSumAggregator(storedType);
       case "AVG":
         return new AvgWindowValueAggregator();
       case "MIN":
-        return new MinWindowValueAggregator(supportRemoval);
+        return createMinAggregator(storedType, supportRemoval);
       case "MAX":
-        return new MaxWindowValueAggregator(supportRemoval);
+        return createMaxAggregator(storedType, supportRemoval);
       case "COUNT":
         return new CountWindowValueAggregator();
       case "BOOLAND":
-        return new BoolAndValueAggregator();
+        return new BoolAndWindowValueAggregator();
       case "BOOLOR":
-        return new BoolOrValueAggregator();
+        return new BoolOrWindowValueAggregator();
       default:
         throw new IllegalArgumentException("Unsupported aggregate function: " + functionName);
+    }
+  }
+
+  private static WindowValueAggregator<Object> createMinAggregator(DataSchema.ColumnDataType storedType,
+      boolean supportRemoval) {
+    switch (storedType) {
+      case INT:
+        return new MinIntWindowValueAggregator(supportRemoval);
+      case LONG:
+        return new MinLongWindowValueAggregator(supportRemoval);
+      case FLOAT:
+      case DOUBLE:
+        return new MinDoubleWindowValueAggregator(supportRemoval);
+      default:
+        return new MinComparableWindowValueAggregator(supportRemoval);
+    }
+  }
+
+  private static WindowValueAggregator<Object> createMaxAggregator(DataSchema.ColumnDataType storedType,
+      boolean supportRemoval) {
+    switch (storedType) {
+      case INT:
+        return new MaxIntWindowValueAggregator(supportRemoval);
+      case LONG:
+        return new MaxLongWindowValueAggregator(supportRemoval);
+      case FLOAT:
+      case DOUBLE:
+        return new MaxDoubleWindowValueAggregator(supportRemoval);
+      default:
+        return new MaxComparableWindowValueAggregator(supportRemoval);
+    }
+  }
+
+  private static WindowValueAggregator<Object> createSumAggregator(DataSchema.ColumnDataType storedType) {
+    switch (storedType) {
+      case INT:
+      case LONG:
+        return new SumLongWindowValueAggregator();
+      case BIG_DECIMAL:
+        return new SumBigDecimalWindowValueAggregator();
+      default:
+        return new SumDoubleWindowValueAggregator();
     }
   }
 }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/window/aggregate/WindowValueAggregatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/window/aggregate/WindowValueAggregatorTest.java
@@ -1,0 +1,717 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.operator.window.aggregate;
+
+import java.math.BigDecimal;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+
+public class WindowValueAggregatorTest {
+
+  // ========================
+  // Factory dispatch tests
+  // ========================
+
+  @Test
+  public void testFactoryReturnsSumAggregatorByType() {
+    assertTrue(
+        WindowValueAggregatorFactory.getWindowValueAggregator("SUM", ColumnDataType.INT, false)
+            instanceof SumLongWindowValueAggregator);
+    assertTrue(
+        WindowValueAggregatorFactory.getWindowValueAggregator("SUM", ColumnDataType.LONG, false)
+            instanceof SumLongWindowValueAggregator);
+    assertTrue(
+        WindowValueAggregatorFactory.getWindowValueAggregator("SUM", ColumnDataType.DOUBLE, false)
+            instanceof SumDoubleWindowValueAggregator);
+    assertTrue(
+        WindowValueAggregatorFactory.getWindowValueAggregator("SUM", ColumnDataType.FLOAT, false)
+            instanceof SumDoubleWindowValueAggregator);
+    assertTrue(
+        WindowValueAggregatorFactory.getWindowValueAggregator("SUM", ColumnDataType.BIG_DECIMAL, false)
+            instanceof SumBigDecimalWindowValueAggregator);
+  }
+
+  @Test
+  public void testFactoryReturnsSumAggregatorForStoredTypes() {
+    // BOOLEAN stored as INT → LongSum
+    assertTrue(
+        WindowValueAggregatorFactory.getWindowValueAggregator("SUM", ColumnDataType.BOOLEAN, false)
+            instanceof SumLongWindowValueAggregator);
+    // TIMESTAMP stored as LONG → LongSum
+    assertTrue(
+        WindowValueAggregatorFactory.getWindowValueAggregator("SUM", ColumnDataType.TIMESTAMP, false)
+            instanceof SumLongWindowValueAggregator);
+  }
+
+  @Test
+  public void testFactoryReturnsSum0AggregatorByType() {
+    assertTrue(
+        WindowValueAggregatorFactory.getWindowValueAggregator("SUM0", ColumnDataType.INT, false)
+            instanceof SumLongWindowValueAggregator);
+    assertTrue(
+        WindowValueAggregatorFactory.getWindowValueAggregator("$SUM0", ColumnDataType.LONG, false)
+            instanceof SumLongWindowValueAggregator);
+    assertTrue(
+        WindowValueAggregatorFactory.getWindowValueAggregator("SUM0", ColumnDataType.DOUBLE, false)
+            instanceof SumDoubleWindowValueAggregator);
+  }
+
+  @Test
+  public void testFactoryReturnsMinAggregatorByType() {
+    assertTrue(
+        WindowValueAggregatorFactory.getWindowValueAggregator("MIN", ColumnDataType.INT, false)
+            instanceof MinIntWindowValueAggregator);
+    assertTrue(
+        WindowValueAggregatorFactory.getWindowValueAggregator("MIN", ColumnDataType.LONG, false)
+            instanceof MinLongWindowValueAggregator);
+    assertTrue(
+        WindowValueAggregatorFactory.getWindowValueAggregator("MIN", ColumnDataType.FLOAT, false)
+            instanceof MinDoubleWindowValueAggregator);
+    assertTrue(
+        WindowValueAggregatorFactory.getWindowValueAggregator("MIN", ColumnDataType.DOUBLE, false)
+            instanceof MinDoubleWindowValueAggregator);
+    assertTrue(
+        WindowValueAggregatorFactory.getWindowValueAggregator("MIN", ColumnDataType.BIG_DECIMAL, false)
+            instanceof MinComparableWindowValueAggregator);
+  }
+
+  @Test
+  public void testFactoryReturnsMaxAggregatorByType() {
+    assertTrue(
+        WindowValueAggregatorFactory.getWindowValueAggregator("MAX", ColumnDataType.INT, false)
+            instanceof MaxIntWindowValueAggregator);
+    assertTrue(
+        WindowValueAggregatorFactory.getWindowValueAggregator("MAX", ColumnDataType.LONG, false)
+            instanceof MaxLongWindowValueAggregator);
+    assertTrue(
+        WindowValueAggregatorFactory.getWindowValueAggregator("MAX", ColumnDataType.FLOAT, false)
+            instanceof MaxDoubleWindowValueAggregator);
+    assertTrue(
+        WindowValueAggregatorFactory.getWindowValueAggregator("MAX", ColumnDataType.DOUBLE, false)
+            instanceof MaxDoubleWindowValueAggregator);
+    assertTrue(
+        WindowValueAggregatorFactory.getWindowValueAggregator("MAX", ColumnDataType.BIG_DECIMAL, false)
+            instanceof MaxComparableWindowValueAggregator);
+  }
+
+  // ========================
+  // SumLongWindowValueAggregator tests
+  // ========================
+
+  @Test
+  public void testLongSumWithIntValues() {
+    WindowValueAggregator<Object> agg = new SumLongWindowValueAggregator();
+    agg.addValue(1);
+    agg.addValue(2);
+    agg.addValue(3);
+    assertEquals(agg.getCurrentAggregatedValue(), 6L);
+    assertTrue(agg.getCurrentAggregatedValue() instanceof Long);
+  }
+
+  @Test
+  public void testLongSumWithLongValues() {
+    WindowValueAggregator<Object> agg = new SumLongWindowValueAggregator();
+    // Use values that would lose precision if converted to double
+    long largeValue = (1L << 53) + 1;  // 9007199254740993
+    agg.addValue(largeValue);
+    agg.addValue(1L);
+    assertEquals(agg.getCurrentAggregatedValue(), largeValue + 1);
+    assertTrue(agg.getCurrentAggregatedValue() instanceof Long);
+  }
+
+  @Test
+  public void testLongSumNullHandling() {
+    WindowValueAggregator<Object> agg = new SumLongWindowValueAggregator();
+    assertNull(agg.getCurrentAggregatedValue());
+    agg.addValue(null);
+    assertNull(agg.getCurrentAggregatedValue());
+    agg.addValue(5);
+    assertEquals(agg.getCurrentAggregatedValue(), 5L);
+    agg.addValue(null);
+    assertEquals(agg.getCurrentAggregatedValue(), 5L);
+  }
+
+  @Test
+  public void testLongSumRemoval() {
+    WindowValueAggregator<Object> agg = new SumLongWindowValueAggregator();
+    agg.addValue(10L);
+    agg.addValue(20L);
+    agg.addValue(30L);
+    assertEquals(agg.getCurrentAggregatedValue(), 60L);
+    agg.removeValue(10L);
+    assertEquals(agg.getCurrentAggregatedValue(), 50L);
+    agg.removeValue(20L);
+    assertEquals(agg.getCurrentAggregatedValue(), 30L);
+    agg.removeValue(30L);
+    assertNull(agg.getCurrentAggregatedValue());
+  }
+
+  @Test
+  public void testLongSumClear() {
+    WindowValueAggregator<Object> agg = new SumLongWindowValueAggregator();
+    agg.addValue(100L);
+    agg.clear();
+    assertNull(agg.getCurrentAggregatedValue());
+  }
+
+  // ========================
+  // SumBigDecimalWindowValueAggregator tests
+  // ========================
+
+  @Test
+  public void testBigDecimalSumWithBigDecimalValues() {
+    WindowValueAggregator<Object> agg = new SumBigDecimalWindowValueAggregator();
+    agg.addValue(new BigDecimal("123456789.123456789"));
+    agg.addValue(new BigDecimal("987654321.987654321"));
+    Object result = agg.getCurrentAggregatedValue();
+    assertTrue(result instanceof BigDecimal);
+    assertEquals(result, new BigDecimal("1111111111.111111110"));
+  }
+
+  @Test
+  public void testBigDecimalSumWithNumberValues() {
+    WindowValueAggregator<Object> agg = new SumBigDecimalWindowValueAggregator();
+    agg.addValue(1.5);
+    agg.addValue(2.5);
+    Object result = agg.getCurrentAggregatedValue();
+    assertTrue(result instanceof BigDecimal);
+    assertEquals(((BigDecimal) result).doubleValue(), 4.0);
+  }
+
+  @Test
+  public void testBigDecimalSumNullHandling() {
+    WindowValueAggregator<Object> agg = new SumBigDecimalWindowValueAggregator();
+    assertNull(agg.getCurrentAggregatedValue());
+    agg.addValue(null);
+    assertNull(agg.getCurrentAggregatedValue());
+    agg.addValue(BigDecimal.TEN);
+    assertEquals(agg.getCurrentAggregatedValue(), BigDecimal.TEN);
+  }
+
+  @Test
+  public void testBigDecimalSumRemoval() {
+    WindowValueAggregator<Object> agg = new SumBigDecimalWindowValueAggregator();
+    agg.addValue(new BigDecimal("10"));
+    agg.addValue(new BigDecimal("20"));
+    assertEquals(agg.getCurrentAggregatedValue(), new BigDecimal("30"));
+    agg.removeValue(new BigDecimal("10"));
+    assertEquals(agg.getCurrentAggregatedValue(), new BigDecimal("20"));
+  }
+
+  @Test
+  public void testBigDecimalSumClear() {
+    WindowValueAggregator<Object> agg = new SumBigDecimalWindowValueAggregator();
+    agg.addValue(BigDecimal.ONE);
+    agg.clear();
+    assertNull(agg.getCurrentAggregatedValue());
+  }
+
+  // ========================
+  // MinIntWindowValueAggregator tests
+  // ========================
+
+  @Test
+  public void testIntMinBasic() {
+    WindowValueAggregator<Object> agg = new MinIntWindowValueAggregator(false);
+    agg.addValue(3);
+    agg.addValue(1);
+    agg.addValue(2);
+    assertEquals(agg.getCurrentAggregatedValue(), 1);
+    assertTrue(agg.getCurrentAggregatedValue() instanceof Integer);
+  }
+
+  @Test
+  public void testIntMinNullHandling() {
+    WindowValueAggregator<Object> agg = new MinIntWindowValueAggregator(false);
+    assertNull(agg.getCurrentAggregatedValue());
+    agg.addValue(null);
+    assertNull(agg.getCurrentAggregatedValue());
+    agg.addValue(5);
+    assertEquals(agg.getCurrentAggregatedValue(), 5);
+  }
+
+  @Test
+  public void testIntMinWithRemovalSupport() {
+    WindowValueAggregator<Object> agg = new MinIntWindowValueAggregator(true);
+    agg.addValue(10);
+    agg.addValue(5);
+    agg.addValue(8);
+    assertEquals(agg.getCurrentAggregatedValue(), 5);
+
+    agg.removeValue(10);
+    assertEquals(agg.getCurrentAggregatedValue(), 5);
+
+    agg.removeValue(5);
+    assertEquals(agg.getCurrentAggregatedValue(), 8);
+  }
+
+  @Test
+  public void testIntMinRemovalToEmpty() {
+    WindowValueAggregator<Object> agg = new MinIntWindowValueAggregator(true);
+    agg.addValue(5);
+    agg.removeValue(5);
+    assertNull(agg.getCurrentAggregatedValue());
+  }
+
+  // ========================
+  // MaxIntWindowValueAggregator tests
+  // ========================
+
+  @Test
+  public void testIntMaxBasic() {
+    WindowValueAggregator<Object> agg = new MaxIntWindowValueAggregator(false);
+    agg.addValue(1);
+    agg.addValue(3);
+    agg.addValue(2);
+    assertEquals(agg.getCurrentAggregatedValue(), 3);
+    assertTrue(agg.getCurrentAggregatedValue() instanceof Integer);
+  }
+
+  @Test
+  public void testIntMaxWithRemovalSupport() {
+    WindowValueAggregator<Object> agg = new MaxIntWindowValueAggregator(true);
+    agg.addValue(5);
+    agg.addValue(10);
+    agg.addValue(8);
+    assertEquals(agg.getCurrentAggregatedValue(), 10);
+
+    agg.removeValue(5);
+    assertEquals(agg.getCurrentAggregatedValue(), 10);
+
+    agg.removeValue(10);
+    assertEquals(agg.getCurrentAggregatedValue(), 8);
+  }
+
+  // ========================
+  // MinLongWindowValueAggregator tests
+  // ========================
+
+  @Test
+  public void testLongMinBasic() {
+    WindowValueAggregator<Object> agg = new MinLongWindowValueAggregator(false);
+    agg.addValue(300L);
+    agg.addValue(100L);
+    agg.addValue(200L);
+    assertEquals(agg.getCurrentAggregatedValue(), 100L);
+    assertTrue(agg.getCurrentAggregatedValue() instanceof Long);
+  }
+
+  @Test
+  public void testLongMinNullHandling() {
+    WindowValueAggregator<Object> agg = new MinLongWindowValueAggregator(false);
+    assertNull(agg.getCurrentAggregatedValue());
+    agg.addValue(null);
+    assertNull(agg.getCurrentAggregatedValue());
+    agg.addValue(5L);
+    assertEquals(agg.getCurrentAggregatedValue(), 5L);
+  }
+
+  @Test
+  public void testLongMinWithRemovalSupport() {
+    WindowValueAggregator<Object> agg = new MinLongWindowValueAggregator(true);
+    agg.addValue(10L);
+    agg.addValue(5L);
+    agg.addValue(8L);
+    assertEquals(agg.getCurrentAggregatedValue(), 5L);
+
+    agg.removeValue(10L);
+    assertEquals(agg.getCurrentAggregatedValue(), 5L);
+
+    agg.removeValue(5L);
+    assertEquals(agg.getCurrentAggregatedValue(), 8L);
+  }
+
+  @Test
+  public void testLongMinPreservesPrecision() {
+    WindowValueAggregator<Object> agg = new MinLongWindowValueAggregator(false);
+    long largeVal = (1L << 53) + 1;
+    agg.addValue(largeVal);
+    agg.addValue(largeVal + 1);
+    assertEquals(agg.getCurrentAggregatedValue(), largeVal);
+    assertTrue(agg.getCurrentAggregatedValue() instanceof Long);
+  }
+
+  // ========================
+  // MaxLongWindowValueAggregator tests
+  // ========================
+
+  @Test
+  public void testLongMaxBasic() {
+    WindowValueAggregator<Object> agg = new MaxLongWindowValueAggregator(false);
+    agg.addValue(100L);
+    agg.addValue(300L);
+    agg.addValue(200L);
+    assertEquals(agg.getCurrentAggregatedValue(), 300L);
+    assertTrue(agg.getCurrentAggregatedValue() instanceof Long);
+  }
+
+  @Test
+  public void testLongMaxWithRemovalSupport() {
+    WindowValueAggregator<Object> agg = new MaxLongWindowValueAggregator(true);
+    agg.addValue(5L);
+    agg.addValue(10L);
+    agg.addValue(8L);
+    assertEquals(agg.getCurrentAggregatedValue(), 10L);
+
+    agg.removeValue(5L);
+    assertEquals(agg.getCurrentAggregatedValue(), 10L);
+
+    agg.removeValue(10L);
+    assertEquals(agg.getCurrentAggregatedValue(), 8L);
+  }
+
+  @Test
+  public void testLongMaxPreservesPrecision() {
+    WindowValueAggregator<Object> agg = new MaxLongWindowValueAggregator(false);
+    long largeVal = (1L << 53) + 1;
+    agg.addValue(largeVal);
+    agg.addValue(largeVal - 1);
+    assertEquals(agg.getCurrentAggregatedValue(), largeVal);
+    assertTrue(agg.getCurrentAggregatedValue() instanceof Long);
+  }
+
+  // ========================
+  // MinComparableWindowValueAggregator tests
+  // ========================
+
+  @Test
+  public void testComparableMinWithIntValues() {
+    WindowValueAggregator<Object> agg = new MinComparableWindowValueAggregator(false);
+    agg.addValue(3);
+    agg.addValue(1);
+    agg.addValue(2);
+    assertEquals(agg.getCurrentAggregatedValue(), 1);
+    assertTrue(agg.getCurrentAggregatedValue() instanceof Integer);
+  }
+
+  @Test
+  public void testComparableMinWithLongValues() {
+    WindowValueAggregator<Object> agg = new MinComparableWindowValueAggregator(false);
+    agg.addValue(300L);
+    agg.addValue(100L);
+    agg.addValue(200L);
+    assertEquals(agg.getCurrentAggregatedValue(), 100L);
+    assertTrue(agg.getCurrentAggregatedValue() instanceof Long);
+  }
+
+  @Test
+  public void testComparableMinWithBigDecimalValues() {
+    WindowValueAggregator<Object> agg = new MinComparableWindowValueAggregator(false);
+    agg.addValue(new BigDecimal("3.0"));
+    agg.addValue(new BigDecimal("1.0"));
+    agg.addValue(new BigDecimal("2.0"));
+    assertEquals(agg.getCurrentAggregatedValue(), new BigDecimal("1.0"));
+    assertTrue(agg.getCurrentAggregatedValue() instanceof BigDecimal);
+  }
+
+  @Test
+  public void testComparableMinNullHandling() {
+    WindowValueAggregator<Object> agg = new MinComparableWindowValueAggregator(false);
+    assertNull(agg.getCurrentAggregatedValue());
+    agg.addValue(null);
+    assertNull(agg.getCurrentAggregatedValue());
+    agg.addValue(5);
+    assertEquals(agg.getCurrentAggregatedValue(), 5);
+    agg.addValue(null);
+    assertEquals(agg.getCurrentAggregatedValue(), 5);
+  }
+
+  @Test
+  public void testComparableMinWithRemovalSupport() {
+    WindowValueAggregator<Object> agg = new MinComparableWindowValueAggregator(true);
+    // Simulate sliding window: [3, 1, 4, 1, 5]
+    agg.addValue(3);
+    agg.addValue(1);
+    assertEquals(agg.getCurrentAggregatedValue(), 1);
+
+    // Remove 3 (oldest), add 4
+    agg.removeValue(3);
+    agg.addValue(4);
+    assertEquals(agg.getCurrentAggregatedValue(), 1);
+
+    // Remove 1, add 1
+    agg.removeValue(1);
+    agg.addValue(1);
+    assertEquals(agg.getCurrentAggregatedValue(), 1);
+
+    // Remove 4, add 5
+    agg.removeValue(4);
+    agg.addValue(5);
+    assertEquals(agg.getCurrentAggregatedValue(), 1);
+  }
+
+  @Test
+  public void testComparableMinRemovalToEmpty() {
+    WindowValueAggregator<Object> agg = new MinComparableWindowValueAggregator(true);
+    agg.addValue(5L);
+    agg.removeValue(5L);
+    assertNull(agg.getCurrentAggregatedValue());
+  }
+
+  @Test(expectedExceptions = UnsupportedOperationException.class)
+  public void testComparableMinRemovalUnsupported() {
+    WindowValueAggregator<Object> agg = new MinComparableWindowValueAggregator(false);
+    agg.addValue(1);
+    agg.removeValue(1);
+  }
+
+  @Test
+  public void testComparableMinClear() {
+    WindowValueAggregator<Object> agg = new MinComparableWindowValueAggregator(false);
+    agg.addValue(42);
+    agg.clear();
+    assertNull(agg.getCurrentAggregatedValue());
+  }
+
+  @Test
+  public void testComparableMinMonotonicDequeWithLong() {
+    // Test the monotonic deque behavior preserves long type through sliding window
+    WindowValueAggregator<Object> agg = new MinComparableWindowValueAggregator(true);
+    agg.addValue(10L);
+    agg.addValue(5L);
+    agg.addValue(8L);
+    assertEquals(agg.getCurrentAggregatedValue(), 5L);
+    assertTrue(agg.getCurrentAggregatedValue() instanceof Long);
+
+    // Remove 10 (was already discarded from deque since 5 < 10)
+    agg.removeValue(10L);
+    assertEquals(agg.getCurrentAggregatedValue(), 5L);
+
+    // Remove 5
+    agg.removeValue(5L);
+    assertEquals(agg.getCurrentAggregatedValue(), 8L);
+    assertTrue(agg.getCurrentAggregatedValue() instanceof Long);
+  }
+
+  // ========================
+  // MaxComparableWindowValueAggregator tests
+  // ========================
+
+  @Test
+  public void testComparableMaxWithIntValues() {
+    WindowValueAggregator<Object> agg = new MaxComparableWindowValueAggregator(false);
+    agg.addValue(1);
+    agg.addValue(3);
+    agg.addValue(2);
+    assertEquals(agg.getCurrentAggregatedValue(), 3);
+    assertTrue(agg.getCurrentAggregatedValue() instanceof Integer);
+  }
+
+  @Test
+  public void testComparableMaxWithLongValues() {
+    WindowValueAggregator<Object> agg = new MaxComparableWindowValueAggregator(false);
+    agg.addValue(100L);
+    agg.addValue(300L);
+    agg.addValue(200L);
+    assertEquals(agg.getCurrentAggregatedValue(), 300L);
+    assertTrue(agg.getCurrentAggregatedValue() instanceof Long);
+  }
+
+  @Test
+  public void testComparableMaxWithBigDecimalValues() {
+    WindowValueAggregator<Object> agg = new MaxComparableWindowValueAggregator(false);
+    agg.addValue(new BigDecimal("1.0"));
+    agg.addValue(new BigDecimal("3.0"));
+    agg.addValue(new BigDecimal("2.0"));
+    assertEquals(agg.getCurrentAggregatedValue(), new BigDecimal("3.0"));
+    assertTrue(agg.getCurrentAggregatedValue() instanceof BigDecimal);
+  }
+
+  @Test
+  public void testComparableMaxNullHandling() {
+    WindowValueAggregator<Object> agg = new MaxComparableWindowValueAggregator(false);
+    assertNull(agg.getCurrentAggregatedValue());
+    agg.addValue(null);
+    assertNull(agg.getCurrentAggregatedValue());
+    agg.addValue(5);
+    assertEquals(agg.getCurrentAggregatedValue(), 5);
+    agg.addValue(null);
+    assertEquals(agg.getCurrentAggregatedValue(), 5);
+  }
+
+  @Test
+  public void testComparableMaxWithRemovalSupport() {
+    WindowValueAggregator<Object> agg = new MaxComparableWindowValueAggregator(true);
+    agg.addValue(3);
+    agg.addValue(5);
+    assertEquals(agg.getCurrentAggregatedValue(), 5);
+
+    // Remove 3 (was already discarded from deque since 5 > 3)
+    agg.removeValue(3);
+    assertEquals(agg.getCurrentAggregatedValue(), 5);
+
+    // Remove 5, add 2
+    agg.removeValue(5);
+    agg.addValue(2);
+    assertEquals(agg.getCurrentAggregatedValue(), 2);
+  }
+
+  @Test
+  public void testComparableMaxRemovalToEmpty() {
+    WindowValueAggregator<Object> agg = new MaxComparableWindowValueAggregator(true);
+    agg.addValue(5L);
+    agg.removeValue(5L);
+    assertNull(agg.getCurrentAggregatedValue());
+  }
+
+  @Test(expectedExceptions = UnsupportedOperationException.class)
+  public void testComparableMaxRemovalUnsupported() {
+    WindowValueAggregator<Object> agg = new MaxComparableWindowValueAggregator(false);
+    agg.addValue(1);
+    agg.removeValue(1);
+  }
+
+  @Test
+  public void testComparableMaxClear() {
+    WindowValueAggregator<Object> agg = new MaxComparableWindowValueAggregator(false);
+    agg.addValue(42);
+    agg.clear();
+    assertNull(agg.getCurrentAggregatedValue());
+  }
+
+  @Test
+  public void testComparableMaxMonotonicDequeWithLong() {
+    WindowValueAggregator<Object> agg = new MaxComparableWindowValueAggregator(true);
+    agg.addValue(5L);
+    agg.addValue(10L);
+    agg.addValue(8L);
+    assertEquals(agg.getCurrentAggregatedValue(), 10L);
+    assertTrue(agg.getCurrentAggregatedValue() instanceof Long);
+
+    agg.removeValue(5L);
+    assertEquals(agg.getCurrentAggregatedValue(), 10L);
+
+    agg.removeValue(10L);
+    assertEquals(agg.getCurrentAggregatedValue(), 8L);
+    assertTrue(agg.getCurrentAggregatedValue() instanceof Long);
+  }
+
+  // ========================
+  // Existing aggregator tests (regression)
+  // ========================
+
+  @Test
+  public void testDoubleSumAggregator() {
+    WindowValueAggregator<Object> agg = new SumDoubleWindowValueAggregator();
+    agg.addValue(1.5);
+    agg.addValue(2.5);
+    assertEquals(agg.getCurrentAggregatedValue(), 4.0);
+    assertTrue(agg.getCurrentAggregatedValue() instanceof Double);
+  }
+
+  @Test
+  public void testDoubleSumNullReturnsNull() {
+    WindowValueAggregator<Object> agg = new SumDoubleWindowValueAggregator();
+    assertNull(agg.getCurrentAggregatedValue());
+  }
+
+  @Test
+  public void testComparableMinWithDoubleValues() {
+    WindowValueAggregator<Object> agg = new MinComparableWindowValueAggregator(false);
+    agg.addValue(3.0);
+    agg.addValue(1.0);
+    agg.addValue(2.0);
+    assertEquals(agg.getCurrentAggregatedValue(), 1.0);
+    assertTrue(agg.getCurrentAggregatedValue() instanceof Double);
+  }
+
+  @Test
+  public void testComparableMaxWithDoubleValues() {
+    WindowValueAggregator<Object> agg = new MaxComparableWindowValueAggregator(false);
+    agg.addValue(1.0);
+    agg.addValue(3.0);
+    agg.addValue(2.0);
+    assertEquals(agg.getCurrentAggregatedValue(), 3.0);
+    assertTrue(agg.getCurrentAggregatedValue() instanceof Double);
+  }
+
+  @Test
+  public void testAvgAggregator() {
+    WindowValueAggregator<Object> agg = new AvgWindowValueAggregator();
+    agg.addValue(2.0);
+    agg.addValue(4.0);
+    assertEquals(agg.getCurrentAggregatedValue(), 3.0);
+    assertTrue(agg.getCurrentAggregatedValue() instanceof Double);
+  }
+
+  @Test
+  public void testCountAggregator() {
+    WindowValueAggregator<Object> agg = new CountWindowValueAggregator();
+    agg.addValue(1);
+    agg.addValue(null);
+    agg.addValue(3);
+    assertEquals(agg.getCurrentAggregatedValue(), 2L);
+  }
+
+  // ========================
+  // Precision preservation tests
+  // ========================
+
+  @Test
+  public void testLongSumPreservesPrecisionBeyondDoubleRange() {
+    WindowValueAggregator<Object> agg = new SumLongWindowValueAggregator();
+    // 2^53 + 1 = 9007199254740993, which cannot be exactly represented as double
+    long val1 = (1L << 53) + 1;
+    long val2 = 1L;
+    agg.addValue(val1);
+    agg.addValue(val2);
+
+    long result = (Long) agg.getCurrentAggregatedValue();
+    assertEquals(result, val1 + val2);
+
+    // Verify that double would have lost precision
+    double doubleSum = (double) val1 + (double) val2;
+    assertNotEquals((long) doubleSum, val1 + val2,
+        "Double should lose precision for this value, confirming the need for LongSum");
+  }
+
+  @Test
+  public void testBigDecimalSumPreservesScale() {
+    WindowValueAggregator<Object> agg = new SumBigDecimalWindowValueAggregator();
+    agg.addValue(new BigDecimal("0.1"));
+    agg.addValue(new BigDecimal("0.2"));
+    BigDecimal result = (BigDecimal) agg.getCurrentAggregatedValue();
+    assertEquals(result, new BigDecimal("0.3"));
+  }
+
+  @Test
+  public void testComparableMinPreservesLongType() {
+    WindowValueAggregator<Object> agg = new MinComparableWindowValueAggregator(false);
+    long largeVal = (1L << 53) + 1;
+    agg.addValue(largeVal);
+    agg.addValue(largeVal + 1);
+    Object result = agg.getCurrentAggregatedValue();
+    assertTrue(result instanceof Long);
+    assertEquals(result, largeVal);
+  }
+
+  @Test
+  public void testComparableMaxPreservesLongType() {
+    WindowValueAggregator<Object> agg = new MaxComparableWindowValueAggregator(false);
+    long largeVal = (1L << 53) + 1;
+    agg.addValue(largeVal);
+    agg.addValue(largeVal - 1);
+    Object result = agg.getCurrentAggregatedValue();
+    assertTrue(result instanceof Long);
+    assertEquals(result, largeVal);
+  }
+}

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/window/aggregate/WindowValueAggregatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/window/aggregate/WindowValueAggregatorTest.java
@@ -218,6 +218,17 @@ public class WindowValueAggregatorTest {
   }
 
   @Test
+  public void testBigDecimalSumPreservesLongPrecision() {
+    WindowValueAggregator<Object> agg = new SumBigDecimalWindowValueAggregator();
+    // Value beyond double precision range (9007199254740993)
+    long largeValue = (1L << 53) + 1;
+    agg.addValue(largeValue);
+    agg.addValue(1L);
+    BigDecimal result = (BigDecimal) agg.getCurrentAggregatedValue();
+    assertEquals(result, BigDecimal.valueOf(largeValue + 1));
+  }
+
+  @Test
   public void testBigDecimalSumClear() {
     WindowValueAggregator<Object> agg = new SumBigDecimalWindowValueAggregator();
     agg.addValue(BigDecimal.ONE);
@@ -272,6 +283,13 @@ public class WindowValueAggregatorTest {
     assertNull(agg.getCurrentAggregatedValue());
   }
 
+  @Test(expectedExceptions = UnsupportedOperationException.class)
+  public void testIntMinRemovalUnsupported() {
+    WindowValueAggregator<Object> agg = new MinIntWindowValueAggregator(false);
+    agg.addValue(1);
+    agg.removeValue(1);
+  }
+
   // ========================
   // MaxIntWindowValueAggregator tests
   // ========================
@@ -299,6 +317,13 @@ public class WindowValueAggregatorTest {
 
     agg.removeValue(10);
     assertEquals(agg.getCurrentAggregatedValue(), 8);
+  }
+
+  @Test(expectedExceptions = UnsupportedOperationException.class)
+  public void testIntMaxRemovalUnsupported() {
+    WindowValueAggregator<Object> agg = new MaxIntWindowValueAggregator(false);
+    agg.addValue(1);
+    agg.removeValue(1);
   }
 
   // ========================
@@ -350,6 +375,13 @@ public class WindowValueAggregatorTest {
     assertTrue(agg.getCurrentAggregatedValue() instanceof Long);
   }
 
+  @Test(expectedExceptions = UnsupportedOperationException.class)
+  public void testLongMinRemovalUnsupported() {
+    WindowValueAggregator<Object> agg = new MinLongWindowValueAggregator(false);
+    agg.addValue(1L);
+    agg.removeValue(1L);
+  }
+
   // ========================
   // MaxLongWindowValueAggregator tests
   // ========================
@@ -387,6 +419,13 @@ public class WindowValueAggregatorTest {
     agg.addValue(largeVal - 1);
     assertEquals(agg.getCurrentAggregatedValue(), largeVal);
     assertTrue(agg.getCurrentAggregatedValue() instanceof Long);
+  }
+
+  @Test(expectedExceptions = UnsupportedOperationException.class)
+  public void testLongMaxRemovalUnsupported() {
+    WindowValueAggregator<Object> agg = new MaxLongWindowValueAggregator(false);
+    agg.addValue(1L);
+    agg.removeValue(1L);
   }
 
   // ========================


### PR DESCRIPTION
  - Resolve TODO in `WindowValueAggregatorFactory` by adding type-specific window value aggregator implementations                                                
  - Add `SumLongWindowValueAggregator` for `INT`/`LONG` to avoid precision loss when summing large long values (> 2^53)                                               
  - Add `SumBigDecimalWindowValueAggregator` for `BIG_DECIMAL` to preserve full decimal precision                                                                   
  - Add primitive `MinIntWindowValueAggregator` / `MaxIntWindowValueAggregator` using fastutil `IntArrayFIFOQueue`                                                
  - Add primitive `MinLongWindowValueAggregator` / `MaxLongWindowValueAggregator` using fastutil `LongArrayFIFOQueue`                                             
  - Add `MinComparableWindowValueAggregator` / `MaxComparableWindowValueAggregator` as fallback for types like `BIG_DECIMAL`                                                                                                                                            
  - Factory now dispatches based on `columnDataType.getStoredType()` instead of always using double-based aggregators                                             
  - Add 56 unit tests covering factory dispatch, all new aggregators, null handling, removal support, and precision preservation 