### PR TITLE
Refactor ColumnStatistics: clean up interface, add isAscii

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpartition/SegmentPartitionUtils.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpartition/SegmentPartitionUtils.java
@@ -80,8 +80,7 @@ public class SegmentPartitionUtils {
     }
 
     return new SegmentPartitionInfo(partitionColumn,
-        PartitionFunctionFactory.getPartitionFunction(columnPartitionMetadata.getFunctionName(),
-            columnPartitionMetadata.getNumPartitions(), columnPartitionMetadata.getFunctionConfig()),
+        PartitionFunctionFactory.getPartitionFunction(columnPartitionMetadata),
         columnPartitionMetadata.getPartitions());
   }
 
@@ -125,8 +124,7 @@ public class SegmentPartitionUtils {
         continue;
       }
       SegmentPartitionInfo segmentPartitionInfo = new SegmentPartitionInfo(partitionColumn,
-          PartitionFunctionFactory.getPartitionFunction(columnPartitionMetadata.getFunctionName(),
-              columnPartitionMetadata.getNumPartitions(), columnPartitionMetadata.getFunctionConfig()),
+          PartitionFunctionFactory.getPartitionFunction(columnPartitionMetadata),
           columnPartitionMetadata.getPartitions());
       columnSegmentPartitionInfoMap.put(partitionColumn, segmentPartitionInfo);
     }

--- a/pinot-common/src/main/java/org/apache/pinot/common/assignment/InstanceAssignmentConfigUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/assignment/InstanceAssignmentConfigUtils.java
@@ -21,7 +21,9 @@ package org.apache.pinot.common.assignment;
 import com.google.common.base.Preconditions;
 import java.util.Map;
 import org.apache.pinot.common.utils.config.TagNameUtils;
+import org.apache.pinot.spi.config.table.ColumnPartitionConfig;
 import org.apache.pinot.spi.config.table.ReplicaGroupStrategyConfig;
+import org.apache.pinot.spi.config.table.SegmentPartitionConfig;
 import org.apache.pinot.spi.config.table.SegmentsValidationAndRetentionConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
@@ -109,7 +111,12 @@ public class InstanceAssignmentConfigUtils {
     String partitionColumn = replicaGroupStrategyConfig.getPartitionColumn();
     boolean minimizeDataMovement = segmentConfig.isMinimizeDataMovement();
     if (partitionColumn != null) {
-      int numPartitions = tableConfig.getIndexingConfig().getSegmentPartitionConfig().getNumPartitions(partitionColumn);
+      SegmentPartitionConfig segmentPartitionConfig = tableConfig.getIndexingConfig().getSegmentPartitionConfig();
+      Preconditions.checkState(segmentPartitionConfig != null, "Failed to find the segment partition config");
+      ColumnPartitionConfig columnPartitionConfig = segmentPartitionConfig.getColumnPartitionConfig(partitionColumn);
+      Preconditions.checkState(columnPartitionConfig != null,
+          "Failed to find the column partition config for column: %s", partitionColumn);
+      int numPartitions = columnPartitionConfig.getNumPartitions();
       Preconditions.checkState(numPartitions > 0, "Number of partitions for column: %s is not properly configured",
           partitionColumn);
       replicaGroupPartitionConfig = new InstanceReplicaGroupPartitionConfig(true, 0, numReplicaGroups, 0, numPartitions,

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -1225,7 +1225,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
               _defaultNullHandlingEnabled);
       _segmentLogger.info("Trying to build segment");
       try {
-        converter.build(_segmentVersion, _serverMetrics);
+        converter.build(_segmentVersion);
       } catch (Exception e) {
         String errorMessage = "Could not build segment";
         FileUtils.deleteQuietly(tempSegmentFolder);

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/partitioner/TableConfigPartitioner.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/partitioner/TableConfigPartitioner.java
@@ -29,15 +29,12 @@ import org.apache.pinot.spi.data.readers.GenericRow;
  * Partitioner which computes partition values based on the ColumnPartitionConfig from the table config
  */
 public class TableConfigPartitioner implements Partitioner {
-
   private final String _column;
   private final PartitionFunction _partitionFunction;
 
   public TableConfigPartitioner(String columnName, ColumnPartitionConfig columnPartitionConfig) {
     _column = columnName;
-    _partitionFunction = PartitionFunctionFactory
-        .getPartitionFunction(columnPartitionConfig.getFunctionName(), columnPartitionConfig.getNumPartitions(),
-            columnPartitionConfig.getFunctionConfig());
+    _partitionFunction = PartitionFunctionFactory.getPartitionFunction(columnPartitionConfig);
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/converter/RealtimeSegmentConverter.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/converter/RealtimeSegmentConverter.java
@@ -59,6 +59,7 @@ public class RealtimeSegmentConverter {
   private final String _segmentName;
   private final boolean _nullHandlingEnabled;
   private final boolean _enableColumnMajor;
+  private final ServerMetrics _serverMetrics;
 
   public RealtimeSegmentConverter(MutableSegmentImpl realtimeSegment, SegmentZKPropsConfig segmentZKPropsConfig,
       String outputPath, Schema schema, String tableName, TableConfig tableConfig, String segmentName,
@@ -78,9 +79,10 @@ public class RealtimeSegmentConverter {
     } else {
       _enableColumnMajor = _tableConfig.getIndexingConfig().isColumnMajorSegmentBuilderEnabled();
     }
+    _serverMetrics = ServerMetrics.get();
   }
 
-  public void build(@Nullable SegmentVersion segmentVersion, @Nullable ServerMetrics serverMetrics)
+  public void build(@Nullable SegmentVersion segmentVersion)
       throws Exception {
     SegmentGeneratorConfig genConfig = new SegmentGeneratorConfig(_tableConfig, _dataSchema);
     genConfig.setInstanceType(InstanceType.SERVER);
@@ -136,7 +138,7 @@ public class RealtimeSegmentConverter {
       try (CompactedPinotSegmentRecordReader recordReader = new CompactedPinotSegmentRecordReader(validDocIds)) {
         recordReader.init(_realtimeSegmentImpl, sortedDocIds);
         buildSegmentWithReader(driver, genConfig, recordReader, sortedDocIds, sortedColumn, validDocIds);
-        publishCompactionMetrics(serverMetrics, preCommitRowCount, driver, compactionStartTime);
+        publishCompactionMetrics(preCommitRowCount, driver, compactionStartTime);
       }
     } else {
       // Use regular PinotSegmentRecordReader (existing behavior)
@@ -156,11 +158,11 @@ public class RealtimeSegmentConverter {
       }
     }
 
-    if (segmentPartitionConfig != null && serverMetrics != null) {
+    if (segmentPartitionConfig != null) {
       Map<String, ColumnPartitionConfig> columnPartitionMap = segmentPartitionConfig.getColumnPartitionMap();
       for (String columnName : columnPartitionMap.keySet()) {
         int numPartitions = driver.getSegmentStats().getColumnProfileFor(columnName).getPartitions().size();
-        serverMetrics.addValueToTableGauge(_tableName, ServerGauge.REALTIME_SEGMENT_NUM_PARTITIONS, numPartitions);
+        _serverMetrics.addValueToTableGauge(_tableName, ServerGauge.REALTIME_SEGMENT_NUM_PARTITIONS, numPartitions);
       }
     }
   }
@@ -175,11 +177,8 @@ public class RealtimeSegmentConverter {
    * Publishes segment build metrics including common metrics (always published) and compaction-specific metrics
    * (published only when compaction is enabled)
    */
-  private void publishCompactionMetrics(@Nullable ServerMetrics serverMetrics,
-      int preCommitRowCount, SegmentIndexCreationDriverImpl driver, long buildStartTime) {
-    if (serverMetrics == null) {
-      return;
-    }
+  private void publishCompactionMetrics(int preCommitRowCount, SegmentIndexCreationDriverImpl driver,
+      long buildStartTime) {
     try {
       int postCommitRowCount = driver.getSegmentStats().getTotalDocCount();
       long buildProcessingTime = System.currentTimeMillis() - buildStartTime;
@@ -187,24 +186,23 @@ public class RealtimeSegmentConverter {
       int rowsRemoved = preCommitRowCount - postCommitRowCount;
 
       // Only publish compaction-specific metrics when compaction is actually enabled
-      serverMetrics.addMeteredTableValue(_tableName, ServerMeter.COMMIT_TIME_COMPACTION_ENABLED_SEGMENTS, 1L);
-      serverMetrics.addMeteredTableValue(_tableName, ServerMeter.COMMIT_TIME_COMPACTION_ROWS_PRE_COMPACTION,
+      _serverMetrics.addMeteredTableValue(_tableName, ServerMeter.COMMIT_TIME_COMPACTION_ENABLED_SEGMENTS, 1L);
+      _serverMetrics.addMeteredTableValue(_tableName, ServerMeter.COMMIT_TIME_COMPACTION_ROWS_PRE_COMPACTION,
           preCommitRowCount);
-      serverMetrics.addMeteredTableValue(_tableName, ServerMeter.COMMIT_TIME_COMPACTION_ROWS_POST_COMPACTION,
+      _serverMetrics.addMeteredTableValue(_tableName, ServerMeter.COMMIT_TIME_COMPACTION_ROWS_POST_COMPACTION,
           postCommitRowCount);
-      serverMetrics.addMeteredTableValue(_tableName, ServerMeter.COMMIT_TIME_COMPACTION_ROWS_REMOVED, rowsRemoved);
-      serverMetrics.addMeteredTableValue(_tableName, ServerMeter.COMMIT_TIME_COMPACTION_BUILD_TIME_MS,
+      _serverMetrics.addMeteredTableValue(_tableName, ServerMeter.COMMIT_TIME_COMPACTION_ROWS_REMOVED, rowsRemoved);
+      _serverMetrics.addMeteredTableValue(_tableName, ServerMeter.COMMIT_TIME_COMPACTION_BUILD_TIME_MS,
           buildProcessingTime);
 
       // Calculate and publish compaction ratio percentage (only if we had rows to compact)
       if (preCommitRowCount > 0) {
         double compactionRatioPercent = (double) rowsRemoved / preCommitRowCount * 100.0;
-        serverMetrics.setOrUpdateTableGauge(_tableName, ServerGauge.COMMIT_TIME_COMPACTION_RATIO_PERCENT,
+        _serverMetrics.setOrUpdateTableGauge(_tableName, ServerGauge.COMMIT_TIME_COMPACTION_RATIO_PERCENT,
             (long) compactionRatioPercent);
       }
     } catch (Exception e) {
-      LOGGER.warn("Failed to publish segment build metrics for table: {}, segment: {}", _tableName,
-          _segmentName, e);
+      LOGGER.warn("Failed to publish segment build metrics for table: {}, segment: {}", _tableName, _segmentName, e);
     }
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/converter/stats/CompactedColumnStatistics.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/converter/stats/CompactedColumnStatistics.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.segment.local.realtime.converter.stats;
 
+import com.google.common.base.Preconditions;
 import com.google.common.base.Utf8;
 import it.unimi.dsi.fastutil.ints.IntIterator;
 import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
@@ -37,14 +38,13 @@ import org.roaringbitmap.RoaringBitmap;
 /// When commit-time compaction is enabled, only valid (non-deleted) documents should be considered.
 @SuppressWarnings("rawtypes")
 public class CompactedColumnStatistics extends MutableColumnStatistics {
-  @Nullable
-  private final Object _minValue;
-  @Nullable
-  private final Object _maxValue;
+  private final Comparable _minValue;
+  private final Comparable _maxValue;
   private final Object _uniqueValues;
   private final int _cardinality;
   private final int _minElementLength;
   private final int _maxElementLength;
+  private final boolean _isAscii;
   private final boolean _isSorted;
   private final int _totalEntries;
   private final int _maxMultiValues;
@@ -53,13 +53,15 @@ public class CompactedColumnStatistics extends MutableColumnStatistics {
   public CompactedColumnStatistics(DataSource dataSource, @Nullable int[] sortedDocIds, boolean isSortedColumn,
       RoaringBitmap validDocIds) {
     super(dataSource, sortedDocIds, isSortedColumn);
-
-    MutableForwardIndex forwardIndex = (MutableForwardIndex) dataSource.getForwardIndex();
-    Dictionary dictionary = _dictionary;
-    DataType valueType = dictionary.getValueType();
-    boolean isSingleValue = forwardIndex.isSingleValue();
+    Preconditions.checkState(!validDocIds.isEmpty(), "Use EmptyColumnStatistics for empty column: %s",
+        _fieldSpec.getName());
+    DataType valueType = getValueType();
+    boolean isSingleValue = isSingleValue();
     boolean isFixedWidth = valueType.isFixedWidth();
     boolean isVarBytesMV = !isSingleValue && !isFixedWidth;
+    MutableForwardIndex forwardIndex = (MutableForwardIndex) dataSource.getForwardIndex();
+    Preconditions.checkState(forwardIndex != null, "Failed to find forward index for column: %s", _fieldSpec.getName());
+    Dictionary dictionary = _dictionary;
 
     // Single pass over valid documents to collect used dict IDs and entry counts.
     // For SV columns, sort order is tracked inline: when sortedDocIds is provided, iterate in that order; when null,
@@ -69,9 +71,9 @@ public class CompactedColumnStatistics extends MutableColumnStatistics {
     IntOpenHashSet usedDictIds = new IntOpenHashSet();
     boolean isSorted = !_isSortedColumn;
     int prevDictId = -1;
-    int maxRowLength = -1;
+    int maxRowLength = 0;
     int totalEntries = 0;
-    int maxMultiValues = -1;
+    int maxMultiValues = 0;
 
     if (isSingleValue) {
       if (_sortedDocIds != null) {
@@ -127,7 +129,6 @@ public class CompactedColumnStatistics extends MutableColumnStatistics {
     _cardinality = usedDictIds.size();
     _totalEntries = totalEntries;
     _maxMultiValues = maxMultiValues;
-    _maxRowLength = maxRowLength;
 
     // Build a typed array from the used dict IDs, sort it by natural value order, and extract min/max value and element
     // lengths from the sorted results.
@@ -136,6 +137,7 @@ public class CompactedColumnStatistics extends MutableColumnStatistics {
     // For fixed-width types element length is constant; for variable-width it is tracked per entry
     int minElementLength = isFixedWidth ? valueType.size() : Integer.MAX_VALUE;
     int maxElementLength = isFixedWidth ? valueType.size() : 0;
+    boolean isAscii = false;
     switch (valueType) {
       case INT: {
         int[] values = new int[_cardinality];
@@ -205,12 +207,8 @@ public class CompactedColumnStatistics extends MutableColumnStatistics {
           maxValue = values[_cardinality - 1];
           for (BigDecimal value : values) {
             int length = BigDecimalUtils.byteSize(value);
-            if (length < minElementLength) {
-              minElementLength = length;
-            }
-            if (length > maxElementLength) {
-              maxElementLength = length;
-            }
+            minElementLength = Math.min(minElementLength, length);
+            maxElementLength = Math.max(maxElementLength, length);
           }
         }
         _uniqueValues = values;
@@ -226,13 +224,13 @@ public class CompactedColumnStatistics extends MutableColumnStatistics {
           Arrays.sort(values);
           minValue = values[0];
           maxValue = values[_cardinality - 1];
+          isAscii = true;
           for (String value : values) {
             int length = Utf8.encodedLength(value);
-            if (length < minElementLength) {
-              minElementLength = length;
-            }
-            if (length > maxElementLength) {
-              maxElementLength = length;
+            minElementLength = Math.min(minElementLength, length);
+            maxElementLength = Math.max(maxElementLength, length);
+            if (isAscii) {
+              isAscii = length == value.length();
             }
           }
         }
@@ -251,12 +249,8 @@ public class CompactedColumnStatistics extends MutableColumnStatistics {
           maxValue = values[_cardinality - 1];
           for (ByteArray value : values) {
             int length = value.length();
-            if (length < minElementLength) {
-              minElementLength = length;
-            }
-            if (length > maxElementLength) {
-              maxElementLength = length;
-            }
+            minElementLength = Math.min(minElementLength, length);
+            maxElementLength = Math.max(maxElementLength, length);
           }
         }
         _uniqueValues = values;
@@ -269,7 +263,14 @@ public class CompactedColumnStatistics extends MutableColumnStatistics {
     _maxValue = maxValue;
     _minElementLength = minElementLength;
     _maxElementLength = maxElementLength;
-
+    _isAscii = isAscii;
+    if (isSingleValue) {
+      _maxRowLength = maxElementLength;
+    } else if (isVarBytesMV) {
+      _maxRowLength = maxRowLength;
+    } else {
+      _maxRowLength = maxMultiValues * valueType.size();
+    }
     if (_isSortedColumn) {
       _isSorted = true;
     } else if (!isSingleValue) {
@@ -279,15 +280,13 @@ public class CompactedColumnStatistics extends MutableColumnStatistics {
     }
   }
 
-  @Nullable
   @Override
-  public Object getMinValue() {
+  public Comparable getMinValue() {
     return _minValue;
   }
 
-  @Nullable
   @Override
-  public Object getMaxValue() {
+  public Comparable getMaxValue() {
     return _maxValue;
   }
 
@@ -307,8 +306,13 @@ public class CompactedColumnStatistics extends MutableColumnStatistics {
   }
 
   @Override
-  public int getLengthOfLargestElement() {
+  public int getLengthOfLongestElement() {
     return _maxElementLength;
+  }
+
+  @Override
+  public boolean isAscii() {
+    return _isAscii;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/converter/stats/CompactedNoDictColumnStatistics.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/converter/stats/CompactedNoDictColumnStatistics.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.segment.local.realtime.converter.stats;
 
+import com.google.common.base.Preconditions;
 import com.google.common.base.Utf8;
 import java.math.BigDecimal;
 import javax.annotation.Nullable;
@@ -33,12 +34,11 @@ import org.roaringbitmap.RoaringBitmap;
 /// When commit-time compaction is enabled, only valid (non-deleted) documents should be considered.
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class CompactedNoDictColumnStatistics extends MutableNoDictColumnStatistics {
-  @Nullable
-  private final Object _minValue;
-  @Nullable
-  private final Object _maxValue;
+  private final Comparable _minValue;
+  private final Comparable _maxValue;
   private final int _minElementLength;
   private final int _maxElementLength;
+  private final boolean _isAscii;
   private final boolean _isSorted;
   private final int _totalEntries;
   private final int _maxMultiValues;
@@ -47,6 +47,8 @@ public class CompactedNoDictColumnStatistics extends MutableNoDictColumnStatisti
   public CompactedNoDictColumnStatistics(DataSource dataSource, @Nullable int[] sortedDocIds, boolean isSortedColumn,
       RoaringBitmap validDocIds) {
     super(dataSource, sortedDocIds, isSortedColumn);
+    Preconditions.checkState(!validDocIds.isEmpty(), "Use EmptyColumnStatistics for empty column: %s",
+        _fieldSpec.getName());
 
     DataType valueType = _forwardIndex.getStoredType();
     boolean isSingleValue = _forwardIndex.isSingleValue();
@@ -62,11 +64,12 @@ public class CompactedNoDictColumnStatistics extends MutableNoDictColumnStatisti
     // For fixed-width types element length is constant; for variable-width it is tracked per entry
     int minElementLength = isVariableWidth ? Integer.MAX_VALUE : valueType.size();
     int maxElementLength = isVariableWidth ? 0 : valueType.size();
+    boolean isAscii = valueType == DataType.STRING;
     boolean isSorted = !_isSortedColumn;
     Comparable prevValue = null;
     int totalEntries = 0;
-    int maxMultiValues = -1;
-    int maxRowLength = -1;
+    int maxMultiValues = 0;
+    int maxRowLength = 0;
 
     if (isSingleValue) {
       if (_sortedDocIds != null) {
@@ -91,11 +94,10 @@ public class CompactedNoDictColumnStatistics extends MutableNoDictColumnStatisti
           }
           if (isVariableWidth) {
             int length = getElementLength(value, valueType);
-            if (length < minElementLength) {
-              minElementLength = length;
-            }
-            if (length > maxElementLength) {
-              maxElementLength = length;
+            minElementLength = Math.min(minElementLength, length);
+            maxElementLength = Math.max(maxElementLength, length);
+            if (isAscii) {
+              isAscii = length == ((String) value).length();
             }
           }
         }
@@ -119,11 +121,10 @@ public class CompactedNoDictColumnStatistics extends MutableNoDictColumnStatisti
           }
           if (isVariableWidth) {
             int length = getElementLength(value, valueType);
-            if (length < minElementLength) {
-              minElementLength = length;
-            }
-            if (length > maxElementLength) {
-              maxElementLength = length;
+            minElementLength = Math.min(minElementLength, length);
+            maxElementLength = Math.max(maxElementLength, length);
+            if (isAscii) {
+              isAscii = length == ((String) value).length();
             }
           }
         }
@@ -239,11 +240,10 @@ public class CompactedNoDictColumnStatistics extends MutableNoDictColumnStatisti
                 maxString = value;
               }
               int length = Utf8.encodedLength(value);
-              if (length < minElementLength) {
-                minElementLength = length;
-              }
-              if (length > maxElementLength) {
-                maxElementLength = length;
+              minElementLength = Math.min(minElementLength, length);
+              maxElementLength = Math.max(maxElementLength, length);
+              if (isAscii) {
+                isAscii = length == value.length();
               }
               rowLength += length;
             }
@@ -271,12 +271,8 @@ public class CompactedNoDictColumnStatistics extends MutableNoDictColumnStatisti
                 maxByteArray = value;
               }
               int length = bytes.length;
-              if (length < minElementLength) {
-                minElementLength = length;
-              }
-              if (length > maxElementLength) {
-                maxElementLength = length;
-              }
+              minElementLength = Math.min(minElementLength, length);
+              maxElementLength = Math.max(maxElementLength, length);
               rowLength += length;
             }
             maxRowLength = Math.max(maxRowLength, rowLength);
@@ -293,10 +289,17 @@ public class CompactedNoDictColumnStatistics extends MutableNoDictColumnStatisti
     _minValue = minValue;
     _maxValue = maxValue;
     _minElementLength = minElementLength;
+    _isAscii = isAscii;
     _maxElementLength = maxElementLength;
     _totalEntries = totalEntries;
     _maxMultiValues = maxMultiValues;
-    _maxRowLength = maxRowLength;
+    if (isSingleValue) {
+      _maxRowLength = maxElementLength;
+    } else if (isVariableWidth) {
+      _maxRowLength = maxRowLength;
+    } else {
+      _maxRowLength = maxMultiValues * valueType.size();
+    }
 
     if (_isSortedColumn) {
       _isSorted = true;
@@ -307,15 +310,13 @@ public class CompactedNoDictColumnStatistics extends MutableNoDictColumnStatisti
     }
   }
 
-  @Nullable
   @Override
-  public Object getMinValue() {
+  public Comparable getMinValue() {
     return _minValue;
   }
 
-  @Nullable
   @Override
-  public Object getMaxValue() {
+  public Comparable getMaxValue() {
     return _maxValue;
   }
 
@@ -325,8 +326,13 @@ public class CompactedNoDictColumnStatistics extends MutableNoDictColumnStatisti
   }
 
   @Override
-  public int getLengthOfLargestElement() {
+  public int getLengthOfLongestElement() {
     return _maxElementLength;
+  }
+
+  @Override
+  public boolean isAscii() {
+    return _isAscii;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/converter/stats/MutableColumnStatistics.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/converter/stats/MutableColumnStatistics.java
@@ -28,7 +28,9 @@ import org.apache.pinot.segment.spi.datasource.DataSourceMetadata;
 import org.apache.pinot.segment.spi.index.mutable.MutableForwardIndex;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.segment.spi.partition.PartitionFunction;
+import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.utils.Utf8Utils;
 
 
 /**
@@ -36,8 +38,11 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
  *
  * TODO: Gather more info on the fly to avoid scanning the segment
  */
+@SuppressWarnings("rawtypes")
 public class MutableColumnStatistics implements ColumnStatistics {
   protected final DataSource _dataSource;
+  protected final DataSourceMetadata _dataSourceMetadata;
+  protected final FieldSpec _fieldSpec;
   @Nullable
   protected final int[] _sortedDocIds;
   protected final boolean _isSortedColumn;
@@ -48,21 +53,32 @@ public class MutableColumnStatistics implements ColumnStatistics {
 
   private int _minElementLength = -1;
   private int _maxElementLength = -1;
+  private boolean _isAscii;
 
   public MutableColumnStatistics(DataSource dataSource, @Nullable int[] sortedDocIds, boolean isSortedColumn) {
     _dataSource = dataSource;
+    _dataSourceMetadata = dataSource.getDataSourceMetadata();
+    _fieldSpec = _dataSourceMetadata.getFieldSpec();
+    Preconditions.checkState(_dataSourceMetadata.getNumDocs() > 0,
+        "Use EmptyColumnStatistics for empty column: %s", _fieldSpec.getName());
     _sortedDocIds = sortedDocIds;
     _isSortedColumn = isSortedColumn;
     _dictionary = dataSource.getDictionary();
+    Preconditions.checkState(_dictionary != null, "Failed to find dictionary for column: %s", _fieldSpec.getName());
   }
 
   @Override
-  public Object getMinValue() {
+  public FieldSpec getFieldSpec() {
+    return _fieldSpec;
+  }
+
+  @Override
+  public Comparable getMinValue() {
     return _dictionary.getMinVal();
   }
 
   @Override
-  public Object getMaxValue() {
+  public Comparable getMaxValue() {
     return _dictionary.getMaxVal();
   }
 
@@ -83,9 +99,15 @@ public class MutableColumnStatistics implements ColumnStatistics {
   }
 
   @Override
-  public int getLengthOfLargestElement() {
+  public int getLengthOfLongestElement() {
     collectElementLengthIfNeeded();
     return _maxElementLength;
+  }
+
+  @Override
+  public boolean isAscii() {
+    collectElementLengthIfNeeded();
+    return _isAscii;
   }
 
   private void collectElementLengthIfNeeded() {
@@ -100,14 +122,24 @@ public class MutableColumnStatistics implements ColumnStatistics {
       _maxElementLength = length;
     } else {
       // If the stored type is not fixed width, iterate over the dictionary to find the min/max element length
+      // TODO: Collect these stats within Dictionary to avoid an extra scan
       _minElementLength = Integer.MAX_VALUE;
       _maxElementLength = 0;
+      boolean isAscii = valueType == DataType.STRING;
       int length = _dictionary.length();
       for (int i = 0; i < length; i++) {
-        int elementLength = _dictionary.getValueSize(i);
-        _minElementLength = Math.min(_minElementLength, elementLength);
-        _maxElementLength = Math.max(_maxElementLength, elementLength);
+        if (isAscii) {
+          byte[] bytes = _dictionary.getBytesValue(i);
+          _minElementLength = Math.min(_minElementLength, bytes.length);
+          _maxElementLength = Math.max(_maxElementLength, bytes.length);
+          isAscii = Utf8Utils.isAscii(bytes);
+        } else {
+          int elementLength = _dictionary.getValueSize(i);
+          _minElementLength = Math.min(_minElementLength, elementLength);
+          _maxElementLength = Math.max(_maxElementLength, elementLength);
+        }
       }
+      _isAscii = isAscii;
     }
   }
 
@@ -118,37 +150,29 @@ public class MutableColumnStatistics implements ColumnStatistics {
       return true;
     }
 
-    DataSourceMetadata dataSourceMetadata = _dataSource.getDataSourceMetadata();
-
     // Multi-valued column cannot be sorted
-    if (!dataSourceMetadata.isSingleValue()) {
+    if (!isSingleValue()) {
       return false;
     }
 
-    // If there is only one distinct value, then it is sorted
-    if (getCardinality() <= 1) {
-      return true;
-    }
-
     // Iterate over all data to figure out whether or not it's in sorted order
-    MutableForwardIndex mutableForwardIndex = (MutableForwardIndex) _dataSource.getForwardIndex();
-    Preconditions.checkState(mutableForwardIndex != null,
-        String.format("Forward index should not be null for column: %s", dataSourceMetadata.getFieldSpec().getName()));
-    int numDocs = dataSourceMetadata.getNumDocs();
+    MutableForwardIndex forwardIndex = (MutableForwardIndex) _dataSource.getForwardIndex();
+    Preconditions.checkState(forwardIndex != null, "Failed to find forward index for column: %s", _fieldSpec.getName());
+    int numDocs = _dataSourceMetadata.getNumDocs();
     // Iterate with the sorted order if provided
     if (_sortedDocIds != null) {
-      int previousDictId = mutableForwardIndex.getDictId(_sortedDocIds[0]);
+      int previousDictId = forwardIndex.getDictId(_sortedDocIds[0]);
       for (int i = 1; i < numDocs; i++) {
-        int currentDictId = mutableForwardIndex.getDictId(_sortedDocIds[i]);
+        int currentDictId = forwardIndex.getDictId(_sortedDocIds[i]);
         if (_dictionary.compare(previousDictId, currentDictId) > 0) {
           return false;
         }
         previousDictId = currentDictId;
       }
     } else {
-      int previousDictId = mutableForwardIndex.getDictId(0);
+      int previousDictId = forwardIndex.getDictId(0);
       for (int i = 1; i < numDocs; i++) {
-        int currentDictId = mutableForwardIndex.getDictId(i);
+        int currentDictId = forwardIndex.getDictId(i);
         if (_dictionary.compare(previousDictId, currentDictId) > 0) {
           return false;
         }
@@ -161,27 +185,27 @@ public class MutableColumnStatistics implements ColumnStatistics {
 
   @Override
   public int getTotalNumberOfEntries() {
-    return _dataSource.getDataSourceMetadata().getNumValues();
+    return _dataSourceMetadata.getNumValues();
   }
 
   @Override
   public int getMaxNumberOfMultiValues() {
-    return _dataSource.getDataSourceMetadata().getMaxNumValuesPerMVEntry();
+    return _dataSourceMetadata.getMaxNumValuesPerMVEntry();
   }
 
   @Override
   public int getMaxRowLengthInBytes() {
-    return _dataSource.getDataSourceMetadata().getMaxRowLengthInBytes();
+    return _dataSourceMetadata.getMaxRowLengthInBytes();
   }
 
   @Override
   public PartitionFunction getPartitionFunction() {
-    return _dataSource.getDataSourceMetadata().getPartitionFunction();
+    return _dataSourceMetadata.getPartitionFunction();
   }
 
   @Override
   public int getNumPartitions() {
-    PartitionFunction partitionFunction = _dataSource.getDataSourceMetadata().getPartitionFunction();
+    PartitionFunction partitionFunction = _dataSourceMetadata.getPartitionFunction();
     if (partitionFunction != null) {
       return partitionFunction.getNumPartitions();
     } else {
@@ -191,12 +215,12 @@ public class MutableColumnStatistics implements ColumnStatistics {
 
   @Override
   public Map<String, String> getPartitionFunctionConfig() {
-    PartitionFunction partitionFunction = _dataSource.getDataSourceMetadata().getPartitionFunction();
+    PartitionFunction partitionFunction = _dataSourceMetadata.getPartitionFunction();
     return partitionFunction != null ? partitionFunction.getFunctionConfig() : null;
   }
 
   @Override
   public Set<Integer> getPartitions() {
-    return _dataSource.getDataSourceMetadata().getPartitions();
+    return _dataSourceMetadata.getPartitions();
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/converter/stats/MutableColumnStatistics.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/converter/stats/MutableColumnStatistics.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.segment.local.realtime.converter.stats;
 
 import com.google.common.base.Preconditions;
-import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.pinot.segment.spi.creator.ColumnStatistics;
@@ -201,22 +200,6 @@ public class MutableColumnStatistics implements ColumnStatistics {
   @Override
   public PartitionFunction getPartitionFunction() {
     return _dataSourceMetadata.getPartitionFunction();
-  }
-
-  @Override
-  public int getNumPartitions() {
-    PartitionFunction partitionFunction = _dataSourceMetadata.getPartitionFunction();
-    if (partitionFunction != null) {
-      return partitionFunction.getNumPartitions();
-    } else {
-      return 0;
-    }
-  }
-
-  @Override
-  public Map<String, String> getPartitionFunctionConfig() {
-    PartitionFunction partitionFunction = _dataSourceMetadata.getPartitionFunction();
-    return partitionFunction != null ? partitionFunction.getFunctionConfig() : null;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/converter/stats/MutableNoDictColumnStatistics.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/converter/stats/MutableNoDictColumnStatistics.java
@@ -31,35 +31,46 @@ import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.segment.spi.datasource.DataSourceMetadata;
 import org.apache.pinot.segment.spi.index.mutable.MutableForwardIndex;
 import org.apache.pinot.segment.spi.partition.PartitionFunction;
+import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.ByteArray;
 
 import static org.apache.pinot.segment.spi.Constants.UNKNOWN_CARDINALITY;
 
 
+@SuppressWarnings("rawtypes")
 public class MutableNoDictColumnStatistics implements ColumnStatistics, CLPStatsProvider {
   protected final DataSourceMetadata _dataSourceMetadata;
-  protected final MutableForwardIndex _forwardIndex;
+  protected final FieldSpec _fieldSpec;
   @Nullable
   protected final int[] _sortedDocIds;
   protected final boolean _isSortedColumn;
+  protected final MutableForwardIndex _forwardIndex;
 
   public MutableNoDictColumnStatistics(DataSource dataSource, @Nullable int[] sortedDocIds, boolean isSortedColumn) {
     _dataSourceMetadata = dataSource.getDataSourceMetadata();
-    _forwardIndex = (MutableForwardIndex) dataSource.getForwardIndex();
-    Preconditions.checkState(_forwardIndex != null, "Forward index should not be null for column: %s",
-        _dataSourceMetadata.getFieldSpec().getName());
+    _fieldSpec = _dataSourceMetadata.getFieldSpec();
+    Preconditions.checkState(_dataSourceMetadata.getNumDocs() > 0,
+        "Use EmptyColumnStatistics for empty column: %s", _fieldSpec.getName());
     _sortedDocIds = sortedDocIds;
     _isSortedColumn = isSortedColumn;
+    _forwardIndex = (MutableForwardIndex) dataSource.getForwardIndex();
+    Preconditions.checkState(_forwardIndex != null, "Failed to find forward index for column: %s",
+        _fieldSpec.getName());
   }
 
   @Override
-  public Object getMinValue() {
+  public FieldSpec getFieldSpec() {
+    return _fieldSpec;
+  }
+
+  @Override
+  public Comparable getMinValue() {
     return _dataSourceMetadata.getMinValue();
   }
 
   @Override
-  public Object getMaxValue() {
+  public Comparable getMaxValue() {
     return _dataSourceMetadata.getMaxValue();
   }
 
@@ -80,8 +91,13 @@ public class MutableNoDictColumnStatistics implements ColumnStatistics, CLPStats
   }
 
   @Override
-  public int getLengthOfLargestElement() {
+  public int getLengthOfLongestElement() {
     return _forwardIndex.getLengthOfLongestElement();
+  }
+
+  @Override
+  public boolean isAscii() {
+    return _forwardIndex.isAscii();
   }
 
   @Override
@@ -92,17 +108,14 @@ public class MutableNoDictColumnStatistics implements ColumnStatistics, CLPStats
     }
 
     // Multi-valued column cannot be sorted
-    if (!_dataSourceMetadata.isSingleValue()) {
+    if (!isSingleValue()) {
       return false;
     }
 
     int numDocs = _dataSourceMetadata.getNumDocs();
-    if (numDocs <= 1) {
-      return true;
-    }
 
     // Verify that values are non-decreasing when iterated in the given order
-    DataType valueType = _forwardIndex.getStoredType();
+    DataType valueType = getValueType();
     if (_sortedDocIds != null) {
       switch (valueType) {
         case INT: {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/converter/stats/MutableNoDictColumnStatistics.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/converter/stats/MutableNoDictColumnStatistics.java
@@ -20,7 +20,6 @@ package org.apache.pinot.segment.local.realtime.converter.stats;
 
 import com.google.common.base.Preconditions;
 import java.math.BigDecimal;
-import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.pinot.segment.local.realtime.impl.forward.CLPMutableForwardIndex;
@@ -301,22 +300,6 @@ public class MutableNoDictColumnStatistics implements ColumnStatistics, CLPStats
   @Override
   public PartitionFunction getPartitionFunction() {
     return _dataSourceMetadata.getPartitionFunction();
-  }
-
-  @Override
-  public int getNumPartitions() {
-    PartitionFunction partitionFunction = _dataSourceMetadata.getPartitionFunction();
-    if (partitionFunction != null) {
-      return partitionFunction.getNumPartitions();
-    } else {
-      return 0;
-    }
-  }
-
-  @Override
-  public Map<String, String> getPartitionFunctionConfig() {
-    PartitionFunction partitionFunction = _dataSourceMetadata.getPartitionFunction();
-    return partitionFunction != null ? partitionFunction.getFunctionConfig() : null;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/converter/stats/RealtimeSegmentStatsContainer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/converter/stats/RealtimeSegmentStatsContainer.java
@@ -19,9 +19,11 @@
 package org.apache.pinot.segment.local.realtime.converter.stats;
 
 import com.google.common.base.Preconditions;
-import java.util.HashMap;
+import com.google.common.collect.Maps;
 import java.util.Map;
+import java.util.Set;
 import javax.annotation.Nullable;
+import org.apache.pinot.segment.local.segment.creator.impl.stats.EmptyColumnStatistics;
 import org.apache.pinot.segment.local.segment.creator.impl.stats.MapColumnPreIndexStatsCollector;
 import org.apache.pinot.segment.local.segment.index.map.MutableMapDataSource;
 import org.apache.pinot.segment.spi.MutableSegment;
@@ -29,6 +31,7 @@ import org.apache.pinot.segment.spi.creator.ColumnStatistics;
 import org.apache.pinot.segment.spi.creator.SegmentPreIndexStatsContainer;
 import org.apache.pinot.segment.spi.creator.StatsCollectorConfig;
 import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.segment.spi.datasource.DataSourceMetadata;
 import org.apache.pinot.segment.spi.index.reader.ForwardIndexReader;
 import org.apache.pinot.segment.spi.index.reader.ForwardIndexReaderContext;
 import org.roaringbitmap.PeekableIntIterator;
@@ -39,17 +42,19 @@ import org.roaringbitmap.RoaringBitmap;
  * Stats container for an in-memory realtime segment.
  */
 public class RealtimeSegmentStatsContainer implements SegmentPreIndexStatsContainer {
-  private final Map<String, ColumnStatistics> _columnStatisticsMap = new HashMap<>();
+  private final Map<String, ColumnStatistics> _columnStatisticsMap;
   private final int _totalDocCount;
 
   public RealtimeSegmentStatsContainer(MutableSegment mutableSegment, @Nullable int[] sortedDocIds,
       @Nullable String sortedColumn, @Nullable RoaringBitmap validDocIds, StatsCollectorConfig statsCollectorConfig) {
     _totalDocCount = validDocIds != null ? validDocIds.getCardinality() : mutableSegment.getNumDocsIndexed();
 
-    for (String columnName : mutableSegment.getPhysicalColumnNames()) {
-      DataSource dataSource = mutableSegment.getDataSource(columnName);
-      boolean isSortedColumn = columnName.equals(sortedColumn);
-      _columnStatisticsMap.put(columnName,
+    Set<String> columns = mutableSegment.getPhysicalColumnNames();
+    _columnStatisticsMap = Maps.newHashMapWithExpectedSize(columns.size());
+    for (String column : columns) {
+      DataSource dataSource = mutableSegment.getDataSource(column);
+      boolean isSortedColumn = column.equals(sortedColumn);
+      _columnStatisticsMap.put(column,
           createColumnStatistics(dataSource, sortedDocIds, isSortedColumn, validDocIds, statsCollectorConfig));
     }
   }
@@ -60,10 +65,15 @@ public class RealtimeSegmentStatsContainer implements SegmentPreIndexStatsContai
    */
   private ColumnStatistics createColumnStatistics(DataSource dataSource, @Nullable int[] sortedDocIds,
       boolean isSortedColumn, @Nullable RoaringBitmap validDocIds, StatsCollectorConfig statsCollectorConfig) {
-    Preconditions.checkState(!isSortedColumn || dataSource.getDataSourceMetadata().isSingleValue(),
+    DataSourceMetadata dataSourceMetadata = dataSource.getDataSourceMetadata();
+    Preconditions.checkState(!isSortedColumn || dataSourceMetadata.isSingleValue(),
         "Sorted column must be single-valued, but column '%s' is multi-valued",
-        dataSource.getDataSourceMetadata().getFieldSpec().getName());
+        dataSourceMetadata.getFieldSpec().getName());
 
+    if (dataSourceMetadata.getNumDocs() == 0 || (validDocIds != null && validDocIds.isEmpty())) {
+      return new EmptyColumnStatistics(dataSourceMetadata.getFieldSpec());
+    }
+    // TODO: Add compaction support to MAP
     if (dataSource instanceof MutableMapDataSource) {
       return createMapColumnStatistics(dataSource, validDocIds, statsCollectorConfig);
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/converter/stats/RealtimeSegmentStatsContainer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/converter/stats/RealtimeSegmentStatsContainer.java
@@ -71,7 +71,8 @@ public class RealtimeSegmentStatsContainer implements SegmentPreIndexStatsContai
         dataSourceMetadata.getFieldSpec().getName());
 
     if (dataSourceMetadata.getNumDocs() == 0 || (validDocIds != null && validDocIds.isEmpty())) {
-      return new EmptyColumnStatistics(dataSourceMetadata.getFieldSpec());
+      return new EmptyColumnStatistics(dataSourceMetadata.getFieldSpec(), dataSourceMetadata.getPartitionFunction(),
+          dataSourceMetadata.getPartitions());
     }
     // TODO: Add compaction support to MAP
     if (dataSource instanceof MutableMapDataSource) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/dictionary/SameValueMutableDictionary.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/dictionary/SameValueMutableDictionary.java
@@ -22,21 +22,24 @@ import it.unimi.dsi.fastutil.ints.IntSet;
 import java.io.IOException;
 import java.math.BigDecimal;
 import org.apache.pinot.segment.spi.index.mutable.MutableDictionary;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.utils.Utf8Utils;
+
 
 /**
  * SameValueMutableDictionary is used to wrap any MutableDictionary, but store the same value. This is done to
  * allow noRawDataForTextIndex config to work with mutable indexes.
  */
 public class SameValueMutableDictionary implements MutableDictionary {
-
-  private final Object _actualValue;
-  private final Object[] _actualValues;
+  private final String _actualValue;
+  private final String[] _actualValues;
+  private final byte[] _valueBytes;
   private final MutableDictionary _delegate;
 
-  public SameValueMutableDictionary(Object value, MutableDictionary delegate) {
-    _actualValue = value;
-    _actualValues = new Object[]{value};
+  public SameValueMutableDictionary(Object actualValue, MutableDictionary delegate) {
+    _actualValue = actualValue.toString();
+    _actualValues = new String[]{_actualValue};
+    _valueBytes = Utf8Utils.encode(_actualValue);
     _delegate = delegate;
   }
 
@@ -49,7 +52,7 @@ public class SameValueMutableDictionary implements MutableDictionary {
   }
 
   @Override
-  public FieldSpec.DataType getValueType() {
+  public DataType getValueType() {
     return _delegate.getValueType();
   }
 
@@ -75,57 +78,62 @@ public class SameValueMutableDictionary implements MutableDictionary {
 
   @Override
   public String getMinVal() {
-    return _actualValue.toString();
+    return _actualValue;
   }
 
   @Override
   public String getMaxVal() {
-    return _actualValue.toString();
+    return _actualValue;
   }
 
   @Override
-  public Object getSortedValues() {
-    return _delegate.getSortedValues();
+  public String[] getSortedValues() {
+    return _actualValues;
   }
 
   @Override
-  public Object get(int dictId) {
+  public String get(int dictId) {
     return _actualValue;
   }
 
   @Override
   public int getIntValue(int dictId) {
-    return Integer.parseInt(_actualValue.toString());
+    return Integer.parseInt(_actualValue);
   }
 
   @Override
   public long getLongValue(int dictId) {
-    return Long.parseLong(_actualValue.toString());
+    return Long.parseLong(_actualValue);
   }
 
   @Override
   public float getFloatValue(int dictId) {
-    return Float.parseFloat(_actualValue.toString());
+    return Float.parseFloat(_actualValue);
   }
 
   @Override
   public double getDoubleValue(int dictId) {
-    return Double.parseDouble(_actualValue.toString());
+    return Double.parseDouble(_actualValue);
   }
 
   @Override
   public BigDecimal getBigDecimalValue(int dictId) {
-    return BigDecimal.valueOf(getDoubleValue(dictId));
+    return new BigDecimal(_actualValue);
   }
 
   @Override
   public String getStringValue(int dictId) {
-    return _actualValue.toString();
+    return _actualValue;
+  }
+
+  @Override
+  public byte[] getBytesValue(int dictId) {
+    return _valueBytes;
   }
 
   @Override
   public int getValueSize(int dictId) {
-    return _delegate.getValueSize(dictId);
+    return _valueBytes.length;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/forward/CLPMutableForwardIndex.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/forward/CLPMutableForwardIndex.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.segment.local.realtime.impl.forward;
 
+import com.google.common.base.Utf8;
 import com.yscope.clp.compressorfrontend.BuiltInVariableHandlingRuleVersions;
 import com.yscope.clp.compressorfrontend.EncodedMessage;
 import com.yscope.clp.compressorfrontend.MessageDecoder;
@@ -30,7 +31,7 @@ import org.apache.pinot.segment.local.segment.index.forward.ForwardIndexType;
 import org.apache.pinot.segment.spi.index.mutable.MutableDictionary;
 import org.apache.pinot.segment.spi.index.mutable.MutableForwardIndex;
 import org.apache.pinot.segment.spi.memory.PinotDataBufferMemoryManager;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
 public class CLPMutableForwardIndex implements MutableForwardIndex {
@@ -39,7 +40,6 @@ public class CLPMutableForwardIndex implements MutableForwardIndex {
   private static final int ESTIMATED_DICT_VARS_CARDINALITY = 10000;
   private static final int ESTIMATED_LOG_TYPE_LENGTH = 200;
   private static final int ESTIMATED_DICT_VARS_LENGTH = 50;
-  private FieldSpec.DataType _storedType;
   private final EncodedMessage _clpEncodedMessage;
   private final MessageEncoder _clpMessageEncoder;
   private final MessageDecoder _clpMessageDecoder;
@@ -53,11 +53,11 @@ public class CLPMutableForwardIndex implements MutableForwardIndex {
   int _totalNumberOfDictVars = 0;
   int _maxNumberOfEncodedVars = 0;
   int _totalNumberOfEncodedVars = 0;
-  private int _lengthOfShortestElement;
-  private int _lengthOfLongestElement;
+  private int _lengthOfShortestElement = Integer.MAX_VALUE;
+  private int _lengthOfLongestElement = 0;
+  private boolean _isAscii = true;
 
-  public CLPMutableForwardIndex(String columnName, FieldSpec.DataType storedType,
-      PinotDataBufferMemoryManager memoryManager, int capacity) {
+  public CLPMutableForwardIndex(String columnName, PinotDataBufferMemoryManager memoryManager, int capacity) {
     _clpEncodedMessage = new EncodedMessage();
     _clpMessageEncoder = new MessageEncoder(BuiltInVariableHandlingRuleVersions.VariablesSchemaV2,
         BuiltInVariableHandlingRuleVersions.VariableEncodingMethodsV1);
@@ -68,17 +68,16 @@ public class CLPMutableForwardIndex implements MutableForwardIndex {
         new StringOffHeapMutableDictionary(ESTIMATED_DICT_VARS_CARDINALITY, ESTIMATED_DICT_VARS_CARDINALITY / 10,
             memoryManager, columnName + "_dictVars.dict", ESTIMATED_DICT_VARS_LENGTH);
 
-    _logTypeFwdIndex = new FixedByteSVMutableForwardIndex(true, FieldSpec.DataType.INT, capacity, memoryManager,
-        columnName + "_logType.fwd");
+    _logTypeFwdIndex =
+        new FixedByteSVMutableForwardIndex(true, DataType.INT, capacity, memoryManager, columnName + "_logType.fwd");
     _dictVarsFwdIndex =
         new FixedByteMVMutableForwardIndex(ForwardIndexType.MAX_MULTI_VALUES_PER_ROW, 20, capacity, Integer.BYTES,
-            memoryManager, columnName + "_dictVars.fwd", true, FieldSpec.DataType.INT);
+            memoryManager, columnName + "_dictVars.fwd", true, DataType.INT);
     _encodedVarsFwdIndex =
         new FixedByteMVMutableForwardIndex(ForwardIndexType.MAX_MULTI_VALUES_PER_ROW, 20, capacity, Long.BYTES,
-            memoryManager, columnName + "_encodedVars.fwd", true, FieldSpec.DataType.LONG);
+            memoryManager, columnName + "_encodedVars.fwd", true, DataType.LONG);
     _clpMessageDecoder = new MessageDecoder(BuiltInVariableHandlingRuleVersions.VariablesSchemaV2,
         BuiltInVariableHandlingRuleVersions.VariableEncodingMethodsV1);
-    _storedType = storedType;
   }
 
   @Override
@@ -92,6 +91,11 @@ public class CLPMutableForwardIndex implements MutableForwardIndex {
   }
 
   @Override
+  public boolean isAscii() {
+    return _isAscii;
+  }
+
+  @Override
   public boolean isDictionaryEncoded() {
     return false;
   }
@@ -102,8 +106,8 @@ public class CLPMutableForwardIndex implements MutableForwardIndex {
   }
 
   @Override
-  public FieldSpec.DataType getStoredType() {
-    return _storedType;
+  public DataType getStoredType() {
+    return DataType.STRING;
   }
 
   @Override
@@ -112,8 +116,12 @@ public class CLPMutableForwardIndex implements MutableForwardIndex {
     String[] dictVars;
     Long[] encodedVars;
 
-    _lengthOfLongestElement = Math.max(_lengthOfLongestElement, value.length());
-    _lengthOfShortestElement = Math.min(_lengthOfShortestElement, value.length());
+    int length = Utf8.encodedLength(value);
+    _lengthOfShortestElement = Math.min(_lengthOfShortestElement, length);
+    _lengthOfLongestElement = Math.max(_lengthOfLongestElement, length);
+    if (_isAscii) {
+      _isAscii = length == value.length();
+    }
 
     try {
       _clpMessageEncoder.encodeMessage(value, _clpEncodedMessage);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/forward/CLPMutableForwardIndexV2.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/forward/CLPMutableForwardIndexV2.java
@@ -32,7 +32,8 @@ import org.apache.pinot.segment.local.realtime.impl.dictionary.BytesOffHeapMutab
 import org.apache.pinot.segment.local.segment.creator.impl.stats.CLPStatsProvider;
 import org.apache.pinot.segment.spi.index.mutable.MutableForwardIndex;
 import org.apache.pinot.segment.spi.memory.PinotDataBufferMemoryManager;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.utils.Utf8Utils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -114,8 +115,9 @@ public class CLPMutableForwardIndexV2 implements MutableForwardIndex {
   protected int _nextEncodedVarId = 0;
   protected int _bytesRawFwdIndexDocIdStartOffset = Integer.MAX_VALUE;
   protected boolean _isClpEncoded = true;
-  protected int _lengthOfLongestElement;
-  protected int _lengthOfShortestElement;
+  protected int _lengthOfShortestElement = Integer.MAX_VALUE;
+  protected int _lengthOfLongestElement = 0;
+  protected boolean _isAscii = true;
 
   protected int _maxNumDictVarIdPerDoc = 0;
   protected int _maxNumEncodedVarPerDoc = 0;
@@ -173,30 +175,28 @@ public class CLPMutableForwardIndexV2 implements MutableForwardIndex {
     }
 
     // Raw forward index stored as bytes
-    _rawBytes = new VarByteSVMutableForwardIndex(FieldSpec.DataType.BYTES, memoryManager, columnName + "_rawBytes.fwd",
+    _rawBytes = new VarByteSVMutableForwardIndex(DataType.BYTES, memoryManager, columnName + "_rawBytes.fwd",
         _estimatedMaxDocCount, _rawMessageEstimatedAvgEncodedLength);
 
     // LogtypeId + logtype dictionary
-    _logtypeId =
-        new FixedByteSVMutableForwardIndex(false, FieldSpec.DataType.INT, _logtypeIdNumRowsPerChunk, memoryManager,
-            columnName + "_logtypeId.fwd");
+    _logtypeId = new FixedByteSVMutableForwardIndex(false, DataType.INT, _logtypeIdNumRowsPerChunk, memoryManager,
+        columnName + "_logtypeId.fwd");
     _logtypeDict = new BytesOffHeapMutableDictionary(_logtypeDictEstimatedCardinality, _logtypeDictMaxOverflowHashSize,
         memoryManager, columnName + "_logtype.dict", _estimatedLogtypeAvgEncodedLength);
 
     // DictVars
-    _dictVarOffset =
-        new FixedByteSVMutableForwardIndex(false, FieldSpec.DataType.INT, _dictVarOffsetPerChunk, memoryManager,
-            columnName + "_dictVarOffsets.fwd");
-    _dictVarId = new FixedByteSVMutableForwardIndex(false, FieldSpec.DataType.INT, _dictVarIdPerChunk, memoryManager,
+    _dictVarOffset = new FixedByteSVMutableForwardIndex(false, DataType.INT, _dictVarOffsetPerChunk, memoryManager,
+        columnName + "_dictVarOffsets.fwd");
+    _dictVarId = new FixedByteSVMutableForwardIndex(false, DataType.INT, _dictVarIdPerChunk, memoryManager,
         columnName + "_dictVarIds.fwd");
     _dictVarDict = new BytesOffHeapMutableDictionary(_dictVarDictEstimatedCardinality, _dictVarDictMaxOverflowHashSize,
         memoryManager, columnName + "_dictVar.dict", _dictVarEstimatedAverageLength);
 
     // EncodedVars
     _encodedVarOffset =
-        new FixedByteSVMutableForwardIndex(false, FieldSpec.DataType.INT, _encodedVarOffsetPerChunk, memoryManager,
+        new FixedByteSVMutableForwardIndex(false, DataType.INT, _encodedVarOffsetPerChunk, memoryManager,
             columnName + "_encodedVarOffsets.fwd");
-    _encodedVar = new FixedByteSVMutableForwardIndex(false, FieldSpec.DataType.LONG, _encodedVarPerChunk, memoryManager,
+    _encodedVar = new FixedByteSVMutableForwardIndex(false, DataType.LONG, _encodedVarPerChunk, memoryManager,
         columnName + "_encodedVar.fwd");
 
     // Setup offsets used to access flattened dictVarId and encoded var multi-value docs
@@ -238,6 +238,7 @@ public class CLPMutableForwardIndexV2 implements MutableForwardIndex {
    * @param clpEncodedMessage The {@link EncodedMessage} to append.
    */
   public void appendEncodedMessage(EncodedMessage clpEncodedMessage) {
+    byte[] rawMessageBytes = clpEncodedMessage.getMessage();
     if (_isClpEncoded || _forceEnableClpEncoding) {
       _logtypeId.setInt(_nextDocId, _logtypeDict.index(clpEncodedMessage.getLogtype()));
 
@@ -279,13 +280,16 @@ public class CLPMutableForwardIndexV2 implements MutableForwardIndex {
         }
       }
     } else {
-      _rawBytes.setBytes(_nextDocId - _bytesRawFwdIndexDocIdStartOffset, clpEncodedMessage.getMessage());
+      _rawBytes.setBytes(_nextDocId - _bytesRawFwdIndexDocIdStartOffset, rawMessageBytes);
     }
     _nextDocId++;
 
     // Update mutable index statistics for compatibility purposes only
-    _lengthOfLongestElement = Math.max(_lengthOfLongestElement, clpEncodedMessage.getMessage().length);
-    _lengthOfShortestElement = Math.min(_lengthOfShortestElement, clpEncodedMessage.getMessage().length);
+    _lengthOfShortestElement = Math.min(_lengthOfShortestElement, rawMessageBytes.length);
+    _lengthOfLongestElement = Math.max(_lengthOfLongestElement, rawMessageBytes.length);
+    if (_isAscii) {
+      _isAscii = Utf8Utils.isAscii(rawMessageBytes);
+    }
   }
 
   public int getNumDoc() {
@@ -415,13 +419,18 @@ public class CLPMutableForwardIndexV2 implements MutableForwardIndex {
   }
 
   @Override
+  public int getLengthOfShortestElement() {
+    return _lengthOfShortestElement;
+  }
+
+  @Override
   public int getLengthOfLongestElement() {
     return _lengthOfLongestElement;
   }
 
   @Override
-  public int getLengthOfShortestElement() {
-    return _lengthOfShortestElement;
+  public boolean isAscii() {
+    return _isAscii;
   }
 
   public int getMaxNumDictVarIdPerDoc() {
@@ -474,8 +483,8 @@ public class CLPMutableForwardIndexV2 implements MutableForwardIndex {
   }
 
   @Override
-  public FieldSpec.DataType getStoredType() {
-    return FieldSpec.DataType.STRING;
+  public DataType getStoredType() {
+    return DataType.STRING;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/forward/FixedByteMVMutableForwardIndex.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/forward/FixedByteMVMutableForwardIndex.java
@@ -250,6 +250,11 @@ public class FixedByteMVMutableForwardIndex implements MutableForwardIndex {
   }
 
   @Override
+  public boolean isAscii() {
+    return false;
+  }
+
+  @Override
   public int getDictIdMV(int docId, int[] dictIdBuffer) {
     FixedByteSingleValueMultiColReader headerReader = getCurrentReader(docId);
     int rowInCurrentHeader = getRowInCurrentHeader(docId);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/forward/FixedByteSVMutableForwardIndex.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/forward/FixedByteSVMutableForwardIndex.java
@@ -118,6 +118,11 @@ public class FixedByteSVMutableForwardIndex implements MutableForwardIndex {
   }
 
   @Override
+  public boolean isAscii() {
+    return false;
+  }
+
+  @Override
   public int getDictId(int docId) {
     int bufferId = getBufferId(docId);
     return _readers.get(bufferId).getInt(docId);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/forward/SameValueMutableForwardIndex.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/forward/SameValueMutableForwardIndex.java
@@ -18,10 +18,11 @@
  */
 package org.apache.pinot.segment.local.realtime.impl.forward;
 
+import com.google.common.base.Utf8;
 import java.io.IOException;
 import javax.annotation.Nullable;
 import org.apache.pinot.segment.spi.index.mutable.MutableForwardIndex;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
 /**
@@ -29,25 +30,31 @@ import org.apache.pinot.spi.data.FieldSpec;
  * allow noRawDataForTextIndex config to work with mutable indexes.
  */
 public class SameValueMutableForwardIndex implements MutableForwardIndex {
-
-  private final Object _actualValue;
+  private final String _actualValue;
   private final Object[] _actualValues;
+  private final int _valueLength;
   private final MutableForwardIndex _delegate;
 
   public SameValueMutableForwardIndex(Object actualValue, MutableForwardIndex delegate) {
-    _actualValue = actualValue;
-    _actualValues = new Object[]{actualValue};
+    _actualValue = actualValue.toString();
+    _actualValues = new Object[]{_actualValue};
+    _valueLength = Utf8.encodedLength(_actualValue);
     _delegate = delegate;
   }
 
   @Override
   public int getLengthOfShortestElement() {
-    return _actualValue.toString().length();
+    return _valueLength;
   }
 
   @Override
   public int getLengthOfLongestElement() {
-    return _actualValue.toString().length();
+    return _valueLength;
+  }
+
+  @Override
+  public boolean isAscii() {
+    return _valueLength == _actualValue.length();
   }
 
   @Override
@@ -61,7 +68,7 @@ public class SameValueMutableForwardIndex implements MutableForwardIndex {
   }
 
   @Override
-  public FieldSpec.DataType getStoredType() {
+  public DataType getStoredType() {
     return _delegate.getStoredType();
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/forward/VarByteSVMutableForwardIndex.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/forward/VarByteSVMutableForwardIndex.java
@@ -28,6 +28,7 @@ import org.apache.pinot.segment.spi.memory.PinotDataBufferMemoryManager;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.BigDecimalUtils;
 import org.apache.pinot.spi.utils.MapUtils;
+import org.apache.pinot.spi.utils.Utf8Utils;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -38,16 +39,17 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 public class VarByteSVMutableForwardIndex implements MutableForwardIndex {
   private final DataType _storedType;
   private final MutableOffHeapByteArrayStore _byteArrayStore;
-  private int _lengthOfShortestElement;
-  private int _lengthOfLongestElement;
+
+  private int _lengthOfShortestElement = Integer.MAX_VALUE;
+  private int _lengthOfLongestElement = 0;
+  private boolean _isAscii;
 
   public VarByteSVMutableForwardIndex(DataType storedType, PinotDataBufferMemoryManager memoryManager,
       String allocationContext, int estimatedMaxNumberOfValues, int estimatedAverageStringLength) {
     _storedType = storedType;
     _byteArrayStore = new MutableOffHeapByteArrayStore(memoryManager, allocationContext, estimatedMaxNumberOfValues,
         estimatedAverageStringLength);
-    _lengthOfShortestElement = Integer.MAX_VALUE;
-    _lengthOfLongestElement = Integer.MIN_VALUE;
+    _isAscii = storedType == DataType.STRING;
   }
 
   @Override
@@ -73,6 +75,11 @@ public class VarByteSVMutableForwardIndex implements MutableForwardIndex {
   @Override
   public int getLengthOfLongestElement() {
     return _lengthOfLongestElement;
+  }
+
+  @Override
+  public boolean isAscii() {
+    return _isAscii;
   }
 
   @Override
@@ -102,7 +109,11 @@ public class VarByteSVMutableForwardIndex implements MutableForwardIndex {
 
   @Override
   public void setString(int docId, String value) {
-    setBytes(docId, value.getBytes(UTF_8));
+    byte[] bytes = Utf8Utils.encode(value);
+    setBytes(docId, bytes);
+    if (_isAscii) {
+      _isAscii = bytes.length == value.length();
+    }
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/writer/StatelessRealtimeSegmentWriter.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/writer/StatelessRealtimeSegmentWriter.java
@@ -365,7 +365,7 @@ public class StatelessRealtimeSegmentWriter implements Closeable {
               _tableNameWithType, _tableConfig, _segmentZKMetadata.getSegmentName(),
               _tableConfig.getIndexingConfig().isNullHandlingEnabled());
       try {
-        converter.build(null, null);
+        converter.build(null);
       } catch (Exception e) {
         throw new RuntimeException("Failed to build segment", e);
       }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/ColumnarSegmentCreationDataSource.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/ColumnarSegmentCreationDataSource.java
@@ -23,7 +23,7 @@ import java.io.IOException;
 import java.util.Map;
 import org.apache.pinot.segment.local.segment.creator.impl.stats.ColumnarSegmentPreIndexStatsContainer;
 import org.apache.pinot.segment.spi.creator.SegmentCreationDataSource;
-import org.apache.pinot.segment.spi.creator.SegmentPreIndexStatsCollector;
+import org.apache.pinot.segment.spi.creator.SegmentPreIndexStatsContainer;
 import org.apache.pinot.segment.spi.creator.StatsCollectorConfig;
 import org.apache.pinot.spi.data.readers.ColumnReader;
 import org.apache.pinot.spi.data.readers.RecordReader;
@@ -58,14 +58,9 @@ public class ColumnarSegmentCreationDataSource implements SegmentCreationDataSou
   }
 
   @Override
-  public SegmentPreIndexStatsCollector gatherStats(StatsCollectorConfig statsCollectorConfig) {
+  public SegmentPreIndexStatsContainer gatherStats(StatsCollectorConfig statsCollectorConfig) {
     LOGGER.info("Gathering stats using columnar approach for {} columns", _columnReaders.size());
-
-    // Use columnar stats container that efficiently collects statistics column-wise
-    ColumnarSegmentPreIndexStatsContainer columnarSegmentPreIndexStatsContainer =
-        new ColumnarSegmentPreIndexStatsContainer(_columnReaders, statsCollectorConfig);
-    columnarSegmentPreIndexStatsContainer.init();
-    return columnarSegmentPreIndexStatsContainer;
+    return new ColumnarSegmentPreIndexStatsContainer(statsCollectorConfig, _columnReaders);
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/BaseSegmentCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/BaseSegmentCreator.java
@@ -586,10 +586,11 @@ public abstract class BaseSegmentCreator implements SegmentCreator {
     PartitionFunction partitionFunction = columnStatistics.getPartitionFunction();
     if (partitionFunction != null) {
       properties.setProperty(getKeyFor(column, PARTITION_FUNCTION), partitionFunction.getName());
-      properties.setProperty(getKeyFor(column, NUM_PARTITIONS), columnStatistics.getNumPartitions());
+      properties.setProperty(getKeyFor(column, NUM_PARTITIONS), partitionFunction.getNumPartitions());
       properties.setProperty(getKeyFor(column, PARTITION_VALUES), columnStatistics.getPartitions());
-      if (columnStatistics.getPartitionFunctionConfig() != null) {
-        for (Map.Entry<String, String> entry : columnStatistics.getPartitionFunctionConfig().entrySet()) {
+      Map<String, String> partitionFunctionConfig = partitionFunction.getFunctionConfig();
+      if (partitionFunctionConfig != null) {
+        for (Map.Entry<String, String> entry : partitionFunctionConfig.entrySet()) {
           properties.setProperty(getKeyFor(column, String.format("%s.%s", PARTITION_FUNCTION_CONFIG, entry.getKey())),
               entry.getValue());
         }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/AbstractColumnStatisticsCollector.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/AbstractColumnStatisticsCollector.java
@@ -29,6 +29,7 @@ import org.apache.pinot.segment.spi.partition.PartitionFunction;
 import org.apache.pinot.segment.spi.partition.PartitionFunctionFactory;
 import org.apache.pinot.spi.config.table.FieldConfig;
 import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
 /**
@@ -45,26 +46,24 @@ import org.apache.pinot.spi.data.FieldSpec;
 public abstract class AbstractColumnStatisticsCollector implements ColumnStatistics {
   protected static final int INITIAL_HASH_SET_SIZE = 1000;
   protected final FieldSpec _fieldSpec;
+  protected final DataType _valueType;
   protected final FieldConfig _fieldConfig;
-
-  private final Map<String, String> _partitionFunctionConfig;
-  private final PartitionFunction _partitionFunction;
-  private final int _numPartitions;
-  private final Set<Integer> _partitions;
+  protected final Map<String, String> _partitionFunctionConfig;
+  protected final PartitionFunction _partitionFunction;
+  protected final int _numPartitions;
+  protected final Set<Integer> _partitions;
 
   protected int _totalNumberOfEntries = 0;
   protected int _maxNumberOfMultiValues = 0;
-  protected boolean _sorted = true;
-  private Comparable _previousValue = null;
+  protected boolean _sorted;
+  protected Comparable _previousValue = null;
 
   public AbstractColumnStatisticsCollector(String column, StatsCollectorConfig statsCollectorConfig) {
     _fieldSpec = statsCollectorConfig.getFieldSpecForColumn(column);
-    _fieldConfig = statsCollectorConfig.getFieldConfigForColumn(column);
     Preconditions.checkArgument(_fieldSpec != null, "Failed to find column: %s", column);
-    if (!_fieldSpec.isSingleValueField()) {
-      _sorted = false;
-    }
-
+    _valueType = _fieldSpec.getDataType().getStoredType();
+    _sorted = _fieldSpec.isSingleValueField();
+    _fieldConfig = statsCollectorConfig.getFieldConfigForColumn(column);
     String partitionFunctionName = statsCollectorConfig.getPartitionFunctionName(column);
     _numPartitions = statsCollectorConfig.getNumPartitions(column);
     _partitionFunctionConfig = statsCollectorConfig.getPartitionFunctionConfig(column);
@@ -76,22 +75,6 @@ public abstract class AbstractColumnStatisticsCollector implements ColumnStatist
     } else {
       _partitions = null;
     }
-  }
-
-  public int getMaxNumberOfMultiValues() {
-    return _maxNumberOfMultiValues;
-  }
-
-  protected void addressSorted(Comparable entry) {
-    if (_sorted) {
-      _sorted = _previousValue == null || entry.compareTo(_previousValue) >= 0;
-      _previousValue = entry;
-    }
-  }
-
-  @Override
-  public boolean isSorted() {
-    return _sorted;
   }
 
   /**
@@ -133,76 +116,76 @@ public abstract class AbstractColumnStatisticsCollector implements ColumnStatist
     collect((Object) values);
   }
 
-  public int getLengthOfShortestElement() {
-    return -1;
-  }
-
-  public int getLengthOfLargestElement() {
-    return -1;
-  }
-
   public abstract void seal();
 
-  /**
-   * Returns the {@link PartitionFunction} for the column.
-   * @return Partition function for the column.
-   */
+  @Override
+  public FieldSpec getFieldSpec() {
+    return _fieldSpec;
+  }
+
+  @Override
+  public DataType getValueType() {
+    return _valueType;
+  }
+
+  @Override
+  public boolean isSorted() {
+    return _sorted;
+  }
+
+  @Override
+  public int getTotalNumberOfEntries() {
+    return _totalNumberOfEntries;
+  }
+
+  @Override
+  public int getMaxNumberOfMultiValues() {
+    return _maxNumberOfMultiValues;
+  }
+
   @Nullable
+  @Override
   public PartitionFunction getPartitionFunction() {
     return _partitionFunction;
   }
 
-  /**
-   * Returns the number of partitions for this column.
-   *
-   * @return Number of partitions.
-   */
+  @Override
   public int getNumPartitions() {
     return _numPartitions;
   }
 
-  /**
-   * Returns the {@link PartitionFunction}'s functionConfig for the column.
-   *
-   * @return Partition Function config for the column.
-   */
   @Nullable
+  @Override
   public Map<String, String> getPartitionFunctionConfig() {
     return _partitionFunctionConfig;
   }
 
-  /**
-   * Returns the partitions within which the column values exist.
-   *
-   * @return List of ranges for the column values.
-   */
   @Nullable
+  @Override
   public Set<Integer> getPartitions() {
     return _partitions;
   }
 
-  protected boolean isPartitionEnabled() {
-    return _partitionFunction != null;
-  }
-
-  /**
-   * Updates the partition range based on the partition of the given value.
-   *
-   * @param value Column value.
-   */
-  protected void updatePartition(String value) {
-    _partitions.add(_partitionFunction.getPartition(value));
-  }
-
-  protected void updateTotalNumberOfEntries(Object[] entries) {
-    _totalNumberOfEntries += entries.length;
+  protected void addressSorted(Comparable value) {
+    if (_sorted) {
+      _sorted = _previousValue == null || value.compareTo(_previousValue) >= 0;
+      _previousValue = value;
+    }
   }
 
   protected void updateTotalNumberOfEntries(int newEntries) {
     _totalNumberOfEntries += newEntries;
   }
 
-  public int getTotalNumberOfEntries() {
-    return _totalNumberOfEntries;
+  protected void updateTotalNumberOfEntries(Object[] entries) {
+    _totalNumberOfEntries += entries.length;
+  }
+
+  protected boolean isPartitionEnabled() {
+    return _partitionFunction != null;
+  }
+
+  protected void updatePartition(String value) {
+    _partitions.add(_partitionFunction.getPartition(value));
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/AbstractColumnStatisticsCollector.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/AbstractColumnStatisticsCollector.java
@@ -20,13 +20,11 @@ package org.apache.pinot.segment.local.segment.creator.impl.stats;
 
 import com.google.common.base.Preconditions;
 import java.util.HashSet;
-import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.pinot.segment.spi.creator.ColumnStatistics;
 import org.apache.pinot.segment.spi.creator.StatsCollectorConfig;
 import org.apache.pinot.segment.spi.partition.PartitionFunction;
-import org.apache.pinot.segment.spi.partition.PartitionFunctionFactory;
 import org.apache.pinot.spi.config.table.FieldConfig;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
@@ -48,9 +46,7 @@ public abstract class AbstractColumnStatisticsCollector implements ColumnStatist
   protected final FieldSpec _fieldSpec;
   protected final DataType _valueType;
   protected final FieldConfig _fieldConfig;
-  protected final Map<String, String> _partitionFunctionConfig;
   protected final PartitionFunction _partitionFunction;
-  protected final int _numPartitions;
   protected final Set<Integer> _partitions;
 
   protected int _totalNumberOfEntries = 0;
@@ -64,17 +60,8 @@ public abstract class AbstractColumnStatisticsCollector implements ColumnStatist
     _valueType = _fieldSpec.getDataType().getStoredType();
     _sorted = _fieldSpec.isSingleValueField();
     _fieldConfig = statsCollectorConfig.getFieldConfigForColumn(column);
-    String partitionFunctionName = statsCollectorConfig.getPartitionFunctionName(column);
-    _numPartitions = statsCollectorConfig.getNumPartitions(column);
-    _partitionFunctionConfig = statsCollectorConfig.getPartitionFunctionConfig(column);
-    _partitionFunction =
-        (partitionFunctionName != null) ? PartitionFunctionFactory.getPartitionFunction(partitionFunctionName,
-            _numPartitions, _partitionFunctionConfig) : null;
-    if (_partitionFunction != null) {
-      _partitions = new HashSet<>();
-    } else {
-      _partitions = null;
-    }
+    _partitionFunction = statsCollectorConfig.getPartitionFunction(column);
+    _partitions = _partitionFunction != null ? new HashSet<>() : null;
   }
 
   /**
@@ -147,17 +134,6 @@ public abstract class AbstractColumnStatisticsCollector implements ColumnStatist
   @Override
   public PartitionFunction getPartitionFunction() {
     return _partitionFunction;
-  }
-
-  @Override
-  public int getNumPartitions() {
-    return _numPartitions;
-  }
-
-  @Nullable
-  @Override
-  public Map<String, String> getPartitionFunctionConfig() {
-    return _partitionFunctionConfig;
   }
 
   @Nullable

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/BigDecimalColumnPreIndexStatsCollector.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/BigDecimalColumnPreIndexStatsCollector.java
@@ -32,7 +32,6 @@ public class BigDecimalColumnPreIndexStatsCollector extends AbstractColumnStatis
   private ObjectOpenHashSet<BigDecimal> _values = new ObjectOpenHashSet<>(INITIAL_HASH_SET_SIZE);
   private int _minLength = Integer.MAX_VALUE;
   private int _maxLength = 0;
-  private int _maxRowLength = 0;
   private BigDecimal[] _sortedValues;
   private boolean _sealed = false;
 
@@ -56,7 +55,6 @@ public class BigDecimalColumnPreIndexStatsCollector extends AbstractColumnStatis
         }
         _minLength = Math.min(_minLength, length);
         _maxLength = Math.max(_maxLength, length);
-        _maxRowLength = _maxLength;
       }
       _totalNumberOfEntries++;
     }
@@ -88,17 +86,17 @@ public class BigDecimalColumnPreIndexStatsCollector extends AbstractColumnStatis
 
   @Override
   public int getLengthOfShortestElement() {
-    return _minLength;
+    return _minLength != Integer.MAX_VALUE ? _minLength : 0;
   }
 
   @Override
-  public int getLengthOfLargestElement() {
+  public int getLengthOfLongestElement() {
     return _maxLength;
   }
 
   @Override
   public int getMaxRowLengthInBytes() {
-    return _maxRowLength;
+    return _maxLength;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/BytesColumnPreIndexStatsCollector.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/BytesColumnPreIndexStatsCollector.java
@@ -28,7 +28,7 @@ import org.apache.pinot.spi.utils.ByteArray;
 /**
  * Extension of {@link AbstractColumnStatisticsCollector} for byte[] column type.
  */
-public class BytesColumnPredIndexStatsCollector extends AbstractColumnStatisticsCollector {
+public class BytesColumnPreIndexStatsCollector extends AbstractColumnStatisticsCollector {
   private Set<ByteArray> _values = new ObjectOpenHashSet<>(INITIAL_HASH_SET_SIZE);
   private int _minLength = Integer.MAX_VALUE;
   private int _maxLength = 0;
@@ -36,7 +36,7 @@ public class BytesColumnPredIndexStatsCollector extends AbstractColumnStatistics
   private ByteArray[] _sortedValues;
   private boolean _sealed = false;
 
-  public BytesColumnPredIndexStatsCollector(String column, StatsCollectorConfig statsCollectorConfig) {
+  public BytesColumnPreIndexStatsCollector(String column, StatsCollectorConfig statsCollectorConfig) {
     super(column, statsCollectorConfig);
   }
 
@@ -49,10 +49,11 @@ public class BytesColumnPredIndexStatsCollector extends AbstractColumnStatistics
       int rowLength = 0;
       for (Object obj : values) {
         ByteArray value = new ByteArray((byte[]) obj);
-        _values.add(value);
         int length = value.length();
-        _minLength = Math.min(_minLength, length);
-        _maxLength = Math.max(_maxLength, length);
+        if (_values.add(value)) {
+          _minLength = Math.min(_minLength, length);
+          _maxLength = Math.max(_maxLength, length);
+        }
         rowLength += length;
       }
       _maxNumberOfMultiValues = Math.max(_maxNumberOfMultiValues, values.length);
@@ -100,11 +101,11 @@ public class BytesColumnPredIndexStatsCollector extends AbstractColumnStatistics
 
   @Override
   public int getLengthOfShortestElement() {
-    return _minLength;
+    return _minLength != Integer.MAX_VALUE ? _minLength : 0;
   }
 
   @Override
-  public int getLengthOfLargestElement() {
+  public int getLengthOfLongestElement() {
     return _maxLength;
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/ColumnarSegmentPreIndexStatsContainer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/ColumnarSegmentPreIndexStatsContainer.java
@@ -18,20 +18,19 @@
  */
 package org.apache.pinot.segment.local.segment.creator.impl.stats;
 
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Maps;
 import java.io.IOException;
-import java.util.HashMap;
+import java.util.Collection;
 import java.util.Map;
 import org.apache.pinot.segment.spi.creator.ColumnStatistics;
-import org.apache.pinot.segment.spi.creator.SegmentPreIndexStatsCollector;
+import org.apache.pinot.segment.spi.creator.SegmentPreIndexStatsContainer;
 import org.apache.pinot.segment.spi.creator.StatsCollectorConfig;
 import org.apache.pinot.segment.spi.index.FieldIndexConfigs;
 import org.apache.pinot.segment.spi.index.FieldIndexConfigsUtil;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.ColumnReader;
-import org.apache.pinot.spi.data.readers.GenericRow;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 /**
@@ -49,134 +48,67 @@ import org.slf4j.LoggerFactory;
  * <p>The statistics are collected using the same underlying collectors as the row-based approach
  * (SegmentPreIndexStatsCollectorImpl) but with more efficient column-wise iteration.
  */
-public class ColumnarSegmentPreIndexStatsContainer implements SegmentPreIndexStatsCollector {
-  private static final Logger LOGGER = LoggerFactory.getLogger(ColumnarSegmentPreIndexStatsContainer.class);
+public class ColumnarSegmentPreIndexStatsContainer implements SegmentPreIndexStatsContainer {
+  private final Map<String, ColumnStatistics> _columnStatisticsMap;
+  private final int _totalDocCount;
 
-  private final Map<String, ColumnReader> _columnReaders;
-  private final StatsCollectorConfig _statsCollectorConfig;
-  private final Schema _targetSchema;
-  private final Map<String, AbstractColumnStatisticsCollector> _columnStatsCollectorMap;
-  private int _totalDocCount;
-
-  /**
-   * Create a ColumnarSegmentPreIndexStatsContainer.
-   *
-   * @param columnReaders Map of column name to ColumnReader instances
-   * @param statsCollectorConfig Configuration for statistics collection
-   */
-  public ColumnarSegmentPreIndexStatsContainer(Map<String, ColumnReader> columnReaders,
-      StatsCollectorConfig statsCollectorConfig) {
-    _columnReaders = columnReaders;
-    _statsCollectorConfig = statsCollectorConfig;
-    _targetSchema = statsCollectorConfig.getSchema();
-    _columnStatsCollectorMap = new HashMap<>(columnReaders.size());
-    _totalDocCount = -1; // indicates unset
-  }
-
-  /**
-   * Initialize stats collectors for all columns in the target schema.
-   */
-  private void initializeStatsCollectors() {
-    Map<String, FieldIndexConfigs> indexConfigsByCol = FieldIndexConfigsUtil.createIndexConfigsByColName(
-        _statsCollectorConfig.getTableConfig(), _statsCollectorConfig.getSchema());
-    for (FieldSpec fieldSpec : _targetSchema.getAllFieldSpecs()) {
-      if (fieldSpec.isVirtualColumn()) {
-        continue;
+  public ColumnarSegmentPreIndexStatsContainer(StatsCollectorConfig statsCollectorConfig,
+      Map<String, ColumnReader> columnReaders) {
+    int totalDocs = -1;
+    for (ColumnReader columnReader : columnReaders.values()) {
+      if (totalDocs < 0) {
+        totalDocs = columnReader.getTotalDocs();
+      } else {
+        Preconditions.checkState(columnReader.getTotalDocs() == totalDocs,
+            "ColumnReader totalDocs mismatch for column: %s. Expected: %s, got: %s", columnReader.getColumnName(),
+            totalDocs, columnReader.getTotalDocs());
       }
-
-      String columnName = fieldSpec.getName();
-      AbstractColumnStatisticsCollector collector = StatsCollectorUtil.createStatsCollector(
-          columnName, fieldSpec, indexConfigsByCol.get(columnName), _statsCollectorConfig);
-      _columnStatsCollectorMap.put(columnName, collector);
     }
-  }
+    Preconditions.checkState(totalDocs >= 0, "Total docs must not be negative, got: %s", totalDocs);
+    _totalDocCount = totalDocs;
 
-  /**
-   * Collect stats by iterating column-wise using the provided ColumnReader instances.
-   */
-  private void collectColumnStats() {
-    LOGGER.info("Collecting stats for {} columns using column-wise iteration", _columnReaders.size());
-
-    for (String columnName : _columnStatsCollectorMap.keySet()) {
-      AbstractColumnStatisticsCollector statsCollector = _columnStatsCollectorMap.get(columnName);
-      ColumnReader columnReader = _columnReaders.get(columnName);
-
-      if (columnReader == null) {
-        throw new RuntimeException("Column reader for column " + columnName + " not found");
+    Schema schema = statsCollectorConfig.getSchema();
+    Collection<FieldSpec> fieldSpecs = schema.getAllFieldSpecs();
+    _columnStatisticsMap = Maps.newHashMapWithExpectedSize(fieldSpecs.size());
+    if (_totalDocCount == 0) {
+      for (FieldSpec fieldSpec : fieldSpecs) {
+        if (!fieldSpec.isVirtualColumn()) {
+          _columnStatisticsMap.put(fieldSpec.getName(), new EmptyColumnStatistics(fieldSpec));
+        }
       }
-
-      LOGGER.debug("Collecting stats for column: {}", columnName);
-      collectStatsFromColumnReader(columnName, columnReader, statsCollector);
-
-      // Seal the stats collector
-      statsCollector.seal();
-    }
-  }
-
-  /**
-   * Collect stats from a column reader by iterating over all values using the iterator pattern.
-   */
-  private void collectStatsFromColumnReader(String columnName, ColumnReader columnReader,
-      AbstractColumnStatisticsCollector statsCollector) {
-    try {
-      // Reset the column reader to start from the beginning
-      columnReader.rewind();
-
-      int docCount = 0;
-      while (columnReader.hasNext()) {
-        Object value = columnReader.next();
-        statsCollector.collect(value);
-        docCount++;
+    } else {
+      Map<String, FieldIndexConfigs> indexConfigsByCol =
+          FieldIndexConfigsUtil.createIndexConfigsByColName(statsCollectorConfig.getTableConfig(), schema);
+      for (FieldSpec fieldSpec : fieldSpecs) {
+        if (fieldSpec.isVirtualColumn()) {
+          continue;
+        }
+        String columnName = fieldSpec.getName();
+        AbstractColumnStatisticsCollector statsCollector =
+            StatsCollectorUtil.createStatsCollector(columnName, fieldSpec, indexConfigsByCol.get(columnName),
+                statsCollectorConfig);
+        ColumnReader columnReader = columnReaders.get(columnName);
+        Preconditions.checkState(columnReader != null, "Failed to find column reader for column: %s", columnName);
+        try {
+          for (int i = 0; i < _totalDocCount; i++) {
+            statsCollector.collect(columnReader.getValue(i));
+          }
+        } catch (IOException e) {
+          throw new RuntimeException("Caught exception collecting stats for column: " + columnName, e);
+        }
+        statsCollector.seal();
+        _columnStatisticsMap.put(columnName, statsCollector);
       }
-
-      // if totalDocCount is unset then set total doc count from the first column
-      if (_totalDocCount == -1) {
-        _totalDocCount = docCount;
-      } else if (_totalDocCount != docCount) {
-        // all columns should have same count
-        LOGGER.warn("Column {} has {} documents, but expected {} documents",
-            columnName, docCount, _totalDocCount);
-        throw new RuntimeException("Columns have inconsistent document counts");
-      }
-    } catch (IOException e) {
-      LOGGER.error("Failed to collect stats for column: {}", columnName, e);
-      throw new RuntimeException("Failed to collect stats for column: " + columnName, e);
     }
   }
 
   @Override
   public ColumnStatistics getColumnProfileFor(String column) {
-    return _columnStatsCollectorMap.get(column);
+    return _columnStatisticsMap.get(column);
   }
 
   @Override
   public int getTotalDocCount() {
     return _totalDocCount;
-  }
-
-  @Override
-  public void init() {
-    initializeStatsCollectors();
-    collectColumnStats();
-  }
-
-  @Override
-  public void build() {
-    // Stats are already collected in constructor
-  }
-
-  @Override
-  public void logStats() {
-    LOGGER.info("Columnar segment stats collection completed for {} columns with {} documents",
-        _columnStatsCollectorMap.size(), _totalDocCount);
-  }
-
-  @Override
-  public void collectRow(GenericRow row) {
-    // This method is not used in columnar stats collection as we iterate column-wise
-    // instead of row-wise. The stats are collected in the constructor by iterating
-    // over each column using ColumnReader instances.
-    throw new UnsupportedOperationException(
-        "collectRow is not supported in columnar stats collection. Stats are collected column-wise.");
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/ColumnarSegmentPreIndexStatsContainer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/ColumnarSegmentPreIndexStatsContainer.java
@@ -23,11 +23,13 @@ import com.google.common.collect.Maps;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.Map;
+import java.util.Set;
 import org.apache.pinot.segment.spi.creator.ColumnStatistics;
 import org.apache.pinot.segment.spi.creator.SegmentPreIndexStatsContainer;
 import org.apache.pinot.segment.spi.creator.StatsCollectorConfig;
 import org.apache.pinot.segment.spi.index.FieldIndexConfigs;
 import org.apache.pinot.segment.spi.index.FieldIndexConfigsUtil;
+import org.apache.pinot.segment.spi.partition.PartitionFunction;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.ColumnReader;
@@ -73,7 +75,10 @@ public class ColumnarSegmentPreIndexStatsContainer implements SegmentPreIndexSta
     if (_totalDocCount == 0) {
       for (FieldSpec fieldSpec : fieldSpecs) {
         if (!fieldSpec.isVirtualColumn()) {
-          _columnStatisticsMap.put(fieldSpec.getName(), new EmptyColumnStatistics(fieldSpec));
+          String columnName = fieldSpec.getName();
+          PartitionFunction partitionFunction = statsCollectorConfig.getPartitionFunction(columnName);
+          Set<Integer> partitions = partitionFunction != null ? Set.of() : null;
+          _columnStatisticsMap.put(columnName, new EmptyColumnStatistics(fieldSpec, partitionFunction, partitions));
         }
       }
     } else {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/EmptyColumnStatistics.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/EmptyColumnStatistics.java
@@ -1,0 +1,121 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.creator.impl.stats;
+
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.apache.pinot.segment.spi.creator.ColumnStatistics;
+import org.apache.pinot.segment.spi.partition.PartitionFunction;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+
+
+/// Column statistics for an empty column (zero rows).
+@SuppressWarnings("rawtypes")
+public class EmptyColumnStatistics implements ColumnStatistics {
+  private final FieldSpec _fieldSpec;
+
+  public EmptyColumnStatistics(FieldSpec fieldSpec) {
+    _fieldSpec = fieldSpec;
+  }
+
+  @Override
+  public FieldSpec getFieldSpec() {
+    return _fieldSpec;
+  }
+
+  @Nullable
+  @Override
+  public Comparable getMinValue() {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public Comparable getMaxValue() {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public Object getUniqueValuesSet() {
+    return null;
+  }
+
+  @Override
+  public int getCardinality() {
+    return 0;
+  }
+
+  @Override
+  public int getLengthOfShortestElement() {
+    DataType valueType = getValueType();
+    return valueType.isFixedWidth() ? valueType.size() : 0;
+  }
+
+  @Override
+  public int getLengthOfLongestElement() {
+    DataType valueType = getValueType();
+    return valueType.isFixedWidth() ? valueType.size() : 0;
+  }
+
+  @Override
+  public boolean isSorted() {
+    return isSingleValue();
+  }
+
+  @Override
+  public int getTotalNumberOfEntries() {
+    return 0;
+  }
+
+  @Override
+  public int getMaxNumberOfMultiValues() {
+    return 0;
+  }
+
+  @Override
+  public int getMaxRowLengthInBytes() {
+    return 0;
+  }
+
+  @Nullable
+  @Override
+  public PartitionFunction getPartitionFunction() {
+    return null;
+  }
+
+  @Override
+  public int getNumPartitions() {
+    return 0;
+  }
+
+  @Nullable
+  @Override
+  public Map<String, String> getPartitionFunctionConfig() {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public Set<Integer> getPartitions() {
+    return null;
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/EmptyColumnStatistics.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/EmptyColumnStatistics.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.segment.local.segment.creator.impl.stats;
 
-import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.pinot.segment.spi.creator.ColumnStatistics;
@@ -31,9 +30,15 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
 @SuppressWarnings("rawtypes")
 public class EmptyColumnStatistics implements ColumnStatistics {
   private final FieldSpec _fieldSpec;
+  private final PartitionFunction _partitionFunction;
+  private final Set<Integer> _partitions;
 
-  public EmptyColumnStatistics(FieldSpec fieldSpec) {
+  // TODO: Revisit if we need to maintain partition info for empty columns
+  public EmptyColumnStatistics(FieldSpec fieldSpec, @Nullable PartitionFunction partitionFunction,
+      @Nullable Set<Integer> partitions) {
     _fieldSpec = fieldSpec;
+    _partitionFunction = partitionFunction;
+    _partitions = partitions;
   }
 
   @Override
@@ -99,23 +104,12 @@ public class EmptyColumnStatistics implements ColumnStatistics {
   @Nullable
   @Override
   public PartitionFunction getPartitionFunction() {
-    return null;
-  }
-
-  @Override
-  public int getNumPartitions() {
-    return 0;
-  }
-
-  @Nullable
-  @Override
-  public Map<String, String> getPartitionFunctionConfig() {
-    return null;
+    return _partitionFunction;
   }
 
   @Nullable
   @Override
   public Set<Integer> getPartitions() {
-    return null;
+    return _partitions;
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/MapColumnPreIndexStatsCollector.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/MapColumnPreIndexStatsCollector.java
@@ -115,7 +115,7 @@ public class MapColumnPreIndexStatsCollector extends AbstractColumnStatisticsCol
           keyStats.collect(value);
           continue;
         }
-        if (keyStats instanceof BytesColumnPredIndexStatsCollector) {
+        if (keyStats instanceof BytesColumnPreIndexStatsCollector) {
           keyStats.collect(value);
           continue;
         }
@@ -232,11 +232,11 @@ public class MapColumnPreIndexStatsCollector extends AbstractColumnStatisticsCol
 
   @Override
   public int getLengthOfShortestElement() {
-    return _minLength;
+    return _minLength != Integer.MAX_VALUE ? _minLength : 0;
   }
 
   @Override
-  public int getLengthOfLargestElement() {
+  public int getLengthOfLongestElement() {
     return _maxLength;
   }
 
@@ -304,7 +304,7 @@ public class MapColumnPreIndexStatsCollector extends AbstractColumnStatisticsCol
       case BIG_DECIMAL:
         return new BigDecimalColumnPreIndexStatsCollector(key, config);
       case BYTES:
-        return new BytesColumnPredIndexStatsCollector(key, config);
+        return new BytesColumnPreIndexStatsCollector(key, config);
       case STRING:
       case MAP:
         return new StringColumnPreIndexStatsCollector(key, config);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/NoDictColumnStatisticsCollector.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/NoDictColumnStatisticsCollector.java
@@ -25,6 +25,7 @@ import java.util.HashSet;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.pinot.segment.spi.creator.StatsCollectorConfig;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.BigDecimalUtils;
 import org.apache.pinot.spi.utils.ByteArray;
 import org.apache.pinot.spi.utils.CommonConstants;
@@ -43,24 +44,30 @@ import org.slf4j.LoggerFactory;
  *   So if such a case is encountered, it will be raised as an exception during collect()
  * Doesn't handle MAP data type as MapColumnPreIndexStatsCollector is optimized for no-dictionary collection
  */
-@SuppressWarnings({"rawtypes"})
+@SuppressWarnings({"rawtypes", "unchecked"})
 public class NoDictColumnStatisticsCollector extends AbstractColumnStatisticsCollector {
   private static final Logger LOGGER = LoggerFactory.getLogger(NoDictColumnStatisticsCollector.class);
+  // Track exact uniques up to a threshold to avoid small-N underestimation and test flakiness
+  private static final int EXACT_UNIQUE_TRACKING_THRESHOLD = 2048;
+
+  private final boolean _isFixedWidth;
   private Comparable _minValue;
   private Comparable _maxValue;
   private int _minLength = Integer.MAX_VALUE;
-  private int _maxLength = -1; // default return value is -1
-  private int _maxRowLength = -1; // default return value is -1
+  private int _maxLength = 0;
+  private boolean _isAscii;
+  private int _maxRowLength = 0;
   private boolean _sealed = false;
+
   // HLL Plus generally returns approximate cardinality >= actual cardinality which is desired
   private final HyperLogLogPlus _hllPlus;
-  // Track exact uniques up to a threshold to avoid small-N underestimation and test flakiness
-  private static final int EXACT_UNIQUE_TRACKING_THRESHOLD = 2048;
   // Single-threaded: simple Set is sufficient; set to null once threshold exceeded to cap memory
   private Set<Object> _exactUniques = new HashSet<>();
 
   public NoDictColumnStatisticsCollector(String column, StatsCollectorConfig statsCollectorConfig) {
     super(column, statsCollectorConfig);
+    _isFixedWidth = _valueType.isFixedWidth();
+    _isAscii = _valueType == DataType.STRING;
     // Use default p and sp; can be made configurable via StatsCollectorConfig later if needed
     _hllPlus = new HyperLogLogPlus(
         CommonConstants.Helix.DEFAULT_HYPERLOGLOG_PLUS_P,
@@ -75,17 +82,19 @@ public class NoDictColumnStatisticsCollector extends AbstractColumnStatisticsCol
       Object[] values = (Object[]) entry;
       int rowLength = 0;
       for (Object value : values) {
-        if (value instanceof BigDecimal) {
-          // Pinot doesn't support multi-value BigDecimal as of now
-          throw new UnsupportedOperationException();
-        }
-        updateMinMax(value);
+        Comparable comparable = toComparable(value);
+        updateMinMax(comparable);
         updateHllPlus(value);
         trackExactUnique(value);
-        int len = getValueLength(value);
-        _minLength = Math.min(_minLength, len);
-        _maxLength = Math.max(_maxLength, len);
-        rowLength += len;
+        if (!_isFixedWidth) {
+          int length = getValueLength(value);
+          _minLength = Math.min(_minLength, length);
+          _maxLength = Math.max(_maxLength, length);
+          if (_isAscii) {
+            _isAscii = length == ((String) value).length();
+          }
+          rowLength += length;
+        }
       }
       _maxNumberOfMultiValues = Math.max(_maxNumberOfMultiValues, values.length);
       _maxRowLength = Math.max(_maxRowLength, rowLength);
@@ -130,29 +139,32 @@ public class NoDictColumnStatisticsCollector extends AbstractColumnStatisticsCol
       _maxNumberOfMultiValues = Math.max(_maxNumberOfMultiValues, length);
       updateTotalNumberOfEntries(length);
     } else {
-      Comparable value = toComparable(entry);
-      addressSorted(value);
-      updateMinMax(entry);
+      Comparable comparable = toComparable(entry);
+      addressSorted(comparable);
+      updateMinMax(comparable);
       updateHllPlus(entry);
       trackExactUnique(entry);
-      int len = getValueLength(entry);
-      _minLength = Math.min(_minLength, len);
-      _maxLength = Math.max(_maxLength, len);
-      if (isPartitionEnabled()) {
-        updatePartition(value.toString());
+      if (!_isFixedWidth) {
+        int length = getValueLength(entry);
+        _minLength = Math.min(_minLength, length);
+        _maxLength = Math.max(_maxLength, length);
+        if (_isAscii) {
+          _isAscii = length == ((String) entry).length();
+        }
       }
-      _maxRowLength = Math.max(_maxRowLength, len);
+      if (isPartitionEnabled()) {
+        updatePartition(comparable.toString());
+      }
       _totalNumberOfEntries++;
     }
   }
 
-  private void updateMinMax(Object value) {
-    Comparable comp = toComparable(value);
-    if (_minValue == null || comp.compareTo(_minValue) < 0) {
-      _minValue = comp;
+  private void updateMinMax(Comparable value) {
+    if (_minValue == null || value.compareTo(_minValue) < 0) {
+      _minValue = value;
     }
-    if (_maxValue == null || comp.compareTo(_maxValue) > 0) {
-      _maxValue = comp;
+    if (_maxValue == null || value.compareTo(_maxValue) > 0) {
+      _maxValue = value;
     }
   }
 
@@ -167,31 +179,30 @@ public class NoDictColumnStatisticsCollector extends AbstractColumnStatisticsCol
   }
 
   private int getValueLength(Object value) {
-    if (value instanceof byte[]) {
-      return ((byte[]) value).length;
+    switch (_valueType) {
+      case BIG_DECIMAL:
+        return BigDecimalUtils.byteSize((BigDecimal) value);
+      case STRING:
+        return Utf8.encodedLength((String) value);
+      case BYTES:
+        return ((byte[]) value).length;
+      default:
+        throw new IllegalStateException("Unsupported variable-width value type: " + _valueType);
     }
-    if (value instanceof CharSequence) {
-      return Utf8.encodedLength((CharSequence) value);
-    }
-    if (value instanceof BigDecimal) {
-      return BigDecimalUtils.byteSize((BigDecimal) value);
-    }
-    if (value instanceof Number) {
-      return 8; // fixed-width approximation as it's not actually required for numeric fields which are of fixed length
-    }
-    throw new IllegalStateException("Unsupported value type " + value.getClass());
   }
 
+  @Nullable
   @Override
-  public Object getMinValue() {
+  public Comparable getMinValue() {
     if (_sealed) {
       return _minValue;
     }
     throw new IllegalStateException("you must seal the collector first before asking for min value");
   }
 
+  @Nullable
   @Override
-  public Object getMaxValue() {
+  public Comparable getMaxValue() {
     if (_sealed) {
       return _maxValue;
     }
@@ -202,21 +213,6 @@ public class NoDictColumnStatisticsCollector extends AbstractColumnStatisticsCol
   @Override
   public Object getUniqueValuesSet() {
     return null;
-  }
-
-  @Override
-  public int getLengthOfShortestElement() {
-    return _minLength == Integer.MAX_VALUE ? -1 : _minLength;
-  }
-
-  @Override
-  public int getLengthOfLargestElement() {
-    return _maxLength;
-  }
-
-  @Override
-  public int getMaxRowLengthInBytes() {
-    return _maxRowLength;
   }
 
   @Override
@@ -233,19 +229,41 @@ public class NoDictColumnStatisticsCollector extends AbstractColumnStatisticsCol
   }
 
   @Override
+  public int getLengthOfShortestElement() {
+    if (_isFixedWidth) {
+      return _valueType.size();
+    } else {
+      return _minLength != Integer.MAX_VALUE ? _minLength : 0;
+    }
+  }
+
+  @Override
+  public int getLengthOfLongestElement() {
+    return _isFixedWidth ? _valueType.size() : _maxLength;
+  }
+
+  @Override
+  public boolean isAscii() {
+    return _isAscii;
+  }
+
+  @Override
+  public int getMaxRowLengthInBytes() {
+    if (_isFixedWidth) {
+      int elementSize = _valueType.size();
+      return isSingleValue() ? elementSize : _maxNumberOfMultiValues * elementSize;
+    } else {
+      return isSingleValue() ? _maxLength : _maxRowLength;
+    }
+  }
+
+  @Override
   public void seal() {
     _sealed = true;
   }
 
   private void updateHllPlus(Object value) {
-    if (value instanceof BigDecimal) {
-      // Canonicalize BigDecimal as string to avoid scale-related equality issues:
-      // BigDecimals with different scales (e.g., 1.0 vs 1.00) are not equal by default,
-      // but their string representations normalize the value for cardinality tracking.
-      _hllPlus.offer(((BigDecimal) value).toString());
-    } else {
-      _hllPlus.offer(value);
-    }
+    _hllPlus.offer(value);
   }
 
   private void trackExactUnique(Object value) {
@@ -259,7 +277,7 @@ public class NoDictColumnStatisticsCollector extends AbstractColumnStatisticsCol
       // Use string representation to avoid scale-related equality issues:
       // BigDecimals with different scales (e.g., 1.0 vs 1.00) are not equal by default,
       // but their string representations normalize the value for cardinality tracking.
-      key = ((BigDecimal) value).toString();
+      key = value.toString();
     } else {
       key = value;
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/SegmentPreIndexStatsCollectorImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/SegmentPreIndexStatsCollectorImpl.java
@@ -18,7 +18,8 @@
  */
 package org.apache.pinot.segment.local.segment.creator.impl.stats;
 
-import java.util.HashMap;
+import com.google.common.collect.Maps;
+import java.util.Collection;
 import java.util.Map;
 import org.apache.pinot.segment.spi.creator.ColumnStatistics;
 import org.apache.pinot.segment.spi.creator.SegmentPreIndexStatsCollector;
@@ -36,7 +37,7 @@ public class SegmentPreIndexStatsCollectorImpl implements SegmentPreIndexStatsCo
   private static final Logger LOGGER = LoggerFactory.getLogger(SegmentPreIndexStatsCollectorImpl.class);
 
   private final StatsCollectorConfig _statsCollectorConfig;
-  private Map<String, AbstractColumnStatisticsCollector> _columnStatsCollectorMap;
+  private Map<String, ColumnStatistics> _columnStatisticsMap;
   private int _totalDocCount;
 
   public SegmentPreIndexStatsCollectorImpl(StatsCollectorConfig statsCollectorConfig) {
@@ -45,47 +46,47 @@ public class SegmentPreIndexStatsCollectorImpl implements SegmentPreIndexStatsCo
 
   @Override
   public void init() {
-    _columnStatsCollectorMap = new HashMap<>();
-    Map<String, FieldIndexConfigs> indexConfigsByCol = FieldIndexConfigsUtil.createIndexConfigsByColName(
-        _statsCollectorConfig.getTableConfig(), _statsCollectorConfig.getSchema());
-
-    Schema dataSchema = _statsCollectorConfig.getSchema();
-    for (FieldSpec fieldSpec : dataSchema.getAllFieldSpecs()) {
+    Schema schema = _statsCollectorConfig.getSchema();
+    Collection<FieldSpec> fieldSpecs = schema.getAllFieldSpecs();
+    _columnStatisticsMap = Maps.newHashMapWithExpectedSize(fieldSpecs.size());
+    Map<String, FieldIndexConfigs> indexConfigsByCol =
+        FieldIndexConfigsUtil.createIndexConfigsByColName(_statsCollectorConfig.getTableConfig(), schema);
+    for (FieldSpec fieldSpec : fieldSpecs) {
+      if (fieldSpec.isVirtualColumn()) {
+        continue;
+      }
       String column = fieldSpec.getName();
       AbstractColumnStatisticsCollector collector = StatsCollectorUtil.createStatsCollector(
           column, fieldSpec, indexConfigsByCol.get(column), _statsCollectorConfig);
-      _columnStatsCollectorMap.put(column, collector);
+      _columnStatisticsMap.put(column, collector);
     }
   }
 
   @Override
   public void build() {
-    for (AbstractColumnStatisticsCollector columnStatsCollector : _columnStatsCollectorMap.values()) {
-      columnStatsCollector.seal();
+    if (_totalDocCount > 0) {
+      for (ColumnStatistics columnStatistics : _columnStatisticsMap.values()) {
+        ((AbstractColumnStatisticsCollector) columnStatistics).seal();
+      }
+    } else {
+      for (Map.Entry<String, ColumnStatistics> entry : _columnStatisticsMap.entrySet()) {
+        entry.setValue(new EmptyColumnStatistics(entry.getValue().getFieldSpec()));
+      }
     }
   }
 
   @Override
   public ColumnStatistics getColumnProfileFor(String column) {
-    return _columnStatsCollectorMap.get(column);
+    return _columnStatisticsMap.get(column);
   }
 
   @Override
   public void collectRow(GenericRow row) {
-    for (Map.Entry<String, Object> columnNameAndValue : row.getFieldToValueMap().entrySet()) {
-      final String columnName = columnNameAndValue.getKey();
-      final Object value = columnNameAndValue.getValue();
-
-      if (_columnStatsCollectorMap.containsKey(columnName)) {
-        try {
-          _columnStatsCollectorMap.get(columnName).collect(value);
-        } catch (Exception e) {
-          LOGGER.error("Exception while collecting stats for column:{} in row:{}", columnName, row);
-          throw e;
-        }
-      }
+    for (Map.Entry<String, ColumnStatistics> entry : _columnStatisticsMap.entrySet()) {
+      String column = entry.getKey();
+      ColumnStatistics columnStatistics = entry.getValue();
+      ((AbstractColumnStatisticsCollector) columnStatistics).collect(row.getValue(column));
     }
-
     _totalDocCount++;
   }
 
@@ -97,19 +98,19 @@ public class SegmentPreIndexStatsCollectorImpl implements SegmentPreIndexStatsCo
   @Override
   public void logStats() {
     try {
-      for (final String column : _columnStatsCollectorMap.keySet()) {
-        AbstractColumnStatisticsCollector statisticsCollector = _columnStatsCollectorMap.get(column);
+      for (final String column : _columnStatisticsMap.keySet()) {
+        ColumnStatistics columnStatistics = _columnStatisticsMap.get(column);
 
         LOGGER.info("********** logging for column : {} ********************* ", column);
-        LOGGER.info("min value : {}", statisticsCollector.getMinValue());
-        LOGGER.info("max value : {}", statisticsCollector.getMaxValue());
-        LOGGER.info("cardinality : {}", statisticsCollector.getCardinality());
-        LOGGER.info("length of largest column : {}", statisticsCollector.getLengthOfLargestElement());
-        LOGGER.info("is sorted : {}", statisticsCollector.isSorted());
+        LOGGER.info("min value : {}", columnStatistics.getMinValue());
+        LOGGER.info("max value : {}", columnStatistics.getMaxValue());
+        LOGGER.info("cardinality : {}", columnStatistics.getCardinality());
+        LOGGER.info("length of longest element : {}", columnStatistics.getLengthOfLongestElement());
+        LOGGER.info("is sorted : {}", columnStatistics.isSorted());
         LOGGER.info("column type : {}", _statsCollectorConfig.getSchema().getFieldSpecFor(column).getDataType());
 
-        if (statisticsCollector.getPartitionFunction() != null) {
-          LOGGER.info("partitions: {}", statisticsCollector.getPartitions().toString());
+        if (columnStatistics.getPartitionFunction() != null) {
+          LOGGER.info("partitions: {}", columnStatistics.getPartitions().toString());
         }
         LOGGER.info("***********************************************");
       }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/SegmentPreIndexStatsCollectorImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/SegmentPreIndexStatsCollectorImpl.java
@@ -70,7 +70,10 @@ public class SegmentPreIndexStatsCollectorImpl implements SegmentPreIndexStatsCo
       }
     } else {
       for (Map.Entry<String, ColumnStatistics> entry : _columnStatisticsMap.entrySet()) {
-        entry.setValue(new EmptyColumnStatistics(entry.getValue().getFieldSpec()));
+        ColumnStatistics columnStatistics = entry.getValue();
+        entry.setValue(
+            new EmptyColumnStatistics(columnStatistics.getFieldSpec(), columnStatistics.getPartitionFunction(),
+                columnStatistics.getPartitions()));
       }
     }
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/StatsCollectorUtil.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/StatsCollectorUtil.java
@@ -29,9 +29,7 @@ import org.apache.pinot.spi.data.FieldSpec;
  * Utility class for creating column statistics collectors.
  */
 public final class StatsCollectorUtil {
-
   private StatsCollectorUtil() {
-    // Utility class
   }
 
   /**
@@ -67,7 +65,7 @@ public final class StatsCollectorUtil {
       case STRING:
         return new StringColumnPreIndexStatsCollector(columnName, statsCollectorConfig);
       case BYTES:
-        return new BytesColumnPredIndexStatsCollector(columnName, statsCollectorConfig);
+        return new BytesColumnPreIndexStatsCollector(columnName, statsCollectorConfig);
       case MAP:
         return new MapColumnPreIndexStatsCollector(columnName, statsCollectorConfig);
       default:

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/StringColumnPreIndexStatsCollector.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/StringColumnPreIndexStatsCollector.java
@@ -37,6 +37,7 @@ public class StringColumnPreIndexStatsCollector extends AbstractColumnStatistics
   private Set<String> _values = new ObjectOpenHashSet<>(INITIAL_HASH_SET_SIZE);
   private int _minLength = Integer.MAX_VALUE;
   private int _maxLength = 0;
+  private boolean _isAscii = true;
   private int _maxRowLength = 0;
   private String[] _sortedValues;
   private boolean _sealed = false;
@@ -58,17 +59,19 @@ public class StringColumnPreIndexStatsCollector extends AbstractColumnStatistics
       int rowLength = 0;
       for (Object obj : values) {
         String value = (String) obj;
-        _values.add(value);
         if (_clpStatsCollector != null) {
           _clpStatsCollector.collect(value);
         }
-
         int length = Utf8.encodedLength(value);
-        _minLength = Math.min(_minLength, length);
-        _maxLength = Math.max(_maxLength, length);
+        if (_values.add(value)) {
+          _minLength = Math.min(_minLength, length);
+          _maxLength = Math.max(_maxLength, length);
+          if (_isAscii) {
+            _isAscii = length == value.length();
+          }
+        }
         rowLength += length;
       }
-
       _maxNumberOfMultiValues = Math.max(_maxNumberOfMultiValues, values.length);
       _maxRowLength = Math.max(_maxRowLength, rowLength);
       updateTotalNumberOfEntries(values);
@@ -82,9 +85,12 @@ public class StringColumnPreIndexStatsCollector extends AbstractColumnStatistics
         if (isPartitionEnabled()) {
           updatePartition(value);
         }
-        int valueLength = Utf8.encodedLength(value);
-        _minLength = Math.min(_minLength, valueLength);
-        _maxLength = Math.max(_maxLength, valueLength);
+        int length = Utf8.encodedLength(value);
+        if (_isAscii) {
+          _isAscii = length == value.length();
+        }
+        _minLength = Math.min(_minLength, length);
+        _maxLength = Math.max(_maxLength, length);
         _maxRowLength = _maxLength;
       }
       _totalNumberOfEntries++;
@@ -124,23 +130,28 @@ public class StringColumnPreIndexStatsCollector extends AbstractColumnStatistics
   }
 
   @Override
+  public int getCardinality() {
+    return _sealed ? _sortedValues.length : _values.size();
+  }
+
+  @Override
   public int getLengthOfShortestElement() {
     return _minLength;
   }
 
   @Override
-  public int getLengthOfLargestElement() {
+  public int getLengthOfLongestElement() {
     return _maxLength;
+  }
+
+  @Override
+  public boolean isAscii() {
+    return _isAscii;
   }
 
   @Override
   public int getMaxRowLengthInBytes() {
     return _maxRowLength;
-  }
-
-  @Override
-  public int getCardinality() {
-    return _sealed ? _sortedValues.length : _values.size();
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/ForwardIndexHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/ForwardIndexHandler.java
@@ -36,7 +36,7 @@ import org.apache.pinot.segment.local.segment.creator.impl.SegmentDictionaryCrea
 import org.apache.pinot.segment.local.segment.creator.impl.fwd.MultiValueVarByteRawIndexCreator;
 import org.apache.pinot.segment.local.segment.creator.impl.stats.AbstractColumnStatisticsCollector;
 import org.apache.pinot.segment.local.segment.creator.impl.stats.BigDecimalColumnPreIndexStatsCollector;
-import org.apache.pinot.segment.local.segment.creator.impl.stats.BytesColumnPredIndexStatsCollector;
+import org.apache.pinot.segment.local.segment.creator.impl.stats.BytesColumnPreIndexStatsCollector;
 import org.apache.pinot.segment.local.segment.creator.impl.stats.DoubleColumnPreIndexStatsCollector;
 import org.apache.pinot.segment.local.segment.creator.impl.stats.FloatColumnPreIndexStatsCollector;
 import org.apache.pinot.segment.local.segment.creator.impl.stats.IntColumnPreIndexStatsCollector;
@@ -1018,7 +1018,7 @@ public class ForwardIndexHandler extends BaseIndexHandler {
         statsCollector.collect(columnReader.getValue(i));
       }
       // NOTE: No need to seal the stats collector because value length is updated while collecting stats.
-      return columnMetadata.isSingleValue() ? statsCollector.getLengthOfLargestElement()
+      return columnMetadata.isSingleValue() ? statsCollector.getLengthOfLongestElement()
           : statsCollector.getMaxRowLengthInBytes();
     }
   }
@@ -1046,7 +1046,7 @@ public class ForwardIndexHandler extends BaseIndexHandler {
       case STRING:
         return new StringColumnPreIndexStatsCollector(column, statsCollectorConfig);
       case BYTES:
-        return new BytesColumnPredIndexStatsCollector(column, statsCollectorConfig);
+        return new BytesColumnPreIndexStatsCollector(column, statsCollectorConfig);
       case MAP:
         return new MapColumnPreIndexStatsCollector(column, statsCollectorConfig);
       default:

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/defaultcolumn/BaseDefaultColumnHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/defaultcolumn/BaseDefaultColumnHandler.java
@@ -42,7 +42,7 @@ import org.apache.pinot.segment.local.segment.creator.impl.fwd.SingleValueSorted
 import org.apache.pinot.segment.local.segment.creator.impl.inv.OffHeapBitmapInvertedIndexCreator;
 import org.apache.pinot.segment.local.segment.creator.impl.nullvalue.NullValueVectorCreator;
 import org.apache.pinot.segment.local.segment.creator.impl.stats.AbstractColumnStatisticsCollector;
-import org.apache.pinot.segment.local.segment.creator.impl.stats.BytesColumnPredIndexStatsCollector;
+import org.apache.pinot.segment.local.segment.creator.impl.stats.BytesColumnPreIndexStatsCollector;
 import org.apache.pinot.segment.local.segment.creator.impl.stats.DoubleColumnPreIndexStatsCollector;
 import org.apache.pinot.segment.local.segment.creator.impl.stats.FloatColumnPreIndexStatsCollector;
 import org.apache.pinot.segment.local.segment.creator.impl.stats.IntColumnPreIndexStatsCollector;
@@ -81,7 +81,6 @@ import org.apache.pinot.spi.config.table.ingestion.TransformConfig;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.Schema;
-import org.apache.pinot.spi.utils.ByteArray;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -465,50 +464,8 @@ public abstract class BaseDefaultColumnHandler implements DefaultColumnHandler {
 
     // Generate column index creation information.
     int totalDocs = _segmentMetadata.getTotalDocs();
-    DataType dataType = fieldSpec.getDataType();
-    Object defaultValue = fieldSpec.getDefaultNullValue();
-    boolean isSingleValue = fieldSpec.isSingleValueField();
-    int maxNumberOfMultiValueElements = isSingleValue ? 0 : 1;
-
-    Object sortedArray;
-    switch (dataType.getStoredType()) {
-      case INT:
-        Preconditions.checkState(defaultValue instanceof Integer);
-        sortedArray = new int[]{(Integer) defaultValue};
-        break;
-      case LONG:
-        Preconditions.checkState(defaultValue instanceof Long);
-        sortedArray = new long[]{(Long) defaultValue};
-        break;
-      case FLOAT:
-        Preconditions.checkState(defaultValue instanceof Float);
-        sortedArray = new float[]{(Float) defaultValue};
-        break;
-      case DOUBLE:
-        Preconditions.checkState(defaultValue instanceof Double);
-        sortedArray = new double[]{(Double) defaultValue};
-        break;
-      case BIG_DECIMAL:
-        Preconditions.checkState(defaultValue instanceof BigDecimal);
-        sortedArray = new BigDecimal[]{(BigDecimal) defaultValue};
-        break;
-      case STRING:
-        Preconditions.checkState(defaultValue instanceof String);
-        sortedArray = new String[]{(String) defaultValue};
-        break;
-      case BYTES:
-        Preconditions.checkState(defaultValue instanceof byte[]);
-        // Convert byte[] to ByteArray for internal usage
-        ByteArray bytesDefaultValue = new ByteArray((byte[]) defaultValue);
-        defaultValue = bytesDefaultValue;
-        sortedArray = new ByteArray[]{bytesDefaultValue};
-        break;
-      default:
-        throw new UnsupportedOperationException("Unsupported data type: " + dataType + " for column: " + column);
-    }
-    DefaultColumnStatistics columnStatistics =
-        new DefaultColumnStatistics(defaultValue  /* min */, defaultValue  /* max */, sortedArray, isSingleValue,
-            totalDocs, maxNumberOfMultiValueElements);
+    DefaultColumnStatistics columnStatistics = new DefaultColumnStatistics(fieldSpec, totalDocs);
+    Object sortedArray = columnStatistics.getUniqueValuesSet();
 
     // We always create a dictionary for default value columns.
     // We will have only one value in the dictionary.
@@ -519,7 +476,7 @@ public abstract class BaseDefaultColumnHandler implements DefaultColumnHandler {
     }
 
     // Create forward index.
-    if (isSingleValue) {
+    if (fieldSpec.isSingleValueField()) {
       // Single-value column.
 
       try (SingleValueSortedForwardIndexCreator svFwdIndexCreator = new SingleValueSortedForwardIndexCreator(_indexDir,
@@ -776,7 +733,7 @@ public abstract class BaseDefaultColumnHandler implements DefaultColumnHandler {
                 (byte[]) fieldSpec.getDefaultNullValue());
           }
           statsCollector = !useNoDictColumnStatsCollector
-              ? new BytesColumnPredIndexStatsCollector(column, statsCollectorConfig)
+              ? new BytesColumnPreIndexStatsCollector(column, statsCollectorConfig)
               : new NoDictColumnStatisticsCollector(column, statsCollectorConfig);
           for (Object value : outputValues) {
             statsCollector.collect(value);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/defaultcolumn/DefaultColumnStatistics.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/defaultcolumn/DefaultColumnStatistics.java
@@ -18,79 +18,137 @@
  */
 package org.apache.pinot.segment.local.segment.index.loader.defaultcolumn;
 
+import com.google.common.base.Utf8;
+import java.math.BigDecimal;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nullable;
 import org.apache.pinot.segment.spi.creator.ColumnStatistics;
 import org.apache.pinot.segment.spi.partition.PartitionFunction;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.utils.BigDecimalUtils;
+import org.apache.pinot.spi.utils.ByteArray;
 
 
+/// Column statistics for a default-value column.
+@SuppressWarnings("rawtypes")
 public class DefaultColumnStatistics implements ColumnStatistics {
+  private final FieldSpec _fieldSpec;
+  private final int _numDocs;
+  private final Comparable _value;
+  private final Object _valueSet;
+  private final int _valueLength;
+  private final boolean _isAscii;
 
-  private final Object _minValue;
-  private final Object _maxValue;
-  private final Object _uniqueValuesSet;
-  private final int _cardinality = 1;
-  private final int _lengthOfShortestElement = -1;
-  private final int _lengthOfLargestElement = -1;
-  private final boolean _isSorted;
-  private final int _totalNumberOfEntries;
-  private final int _maxNumberOfMultiValues;
+  public DefaultColumnStatistics(FieldSpec fieldSpec, int numDocs) {
+    _fieldSpec = fieldSpec;
+    _numDocs = numDocs;
 
-  public DefaultColumnStatistics(Object minValue, Object maxValue, Object uniqueValuesSet, boolean isSorted,
-      int totalNumberOfEntries, int maxNumberOfMultiValues) {
-    _minValue = minValue;
-    _maxValue = maxValue;
-    _uniqueValuesSet = uniqueValuesSet;
-    _isSorted = isSorted;
-    _totalNumberOfEntries = totalNumberOfEntries;
-    _maxNumberOfMultiValues = maxNumberOfMultiValues;
+    DataType valueType = fieldSpec.getDataType().getStoredType();
+    Object value = fieldSpec.getDefaultNullValue();
+    int length = 0;
+    boolean isAscii = false;
+    switch (valueType) {
+      case INT:
+        _valueSet = new int[]{(Integer) value};
+        break;
+      case LONG:
+        _valueSet = new long[]{(Long) value};
+        break;
+      case FLOAT:
+        _valueSet = new float[]{(Float) value};
+        break;
+      case DOUBLE:
+        _valueSet = new double[]{(Double) value};
+        break;
+      case BIG_DECIMAL:
+        _valueSet = new BigDecimal[]{(BigDecimal) value};
+        length = BigDecimalUtils.byteSize((BigDecimal) value);
+        break;
+      case STRING:
+        String stringValue = (String) value;
+        _valueSet = new String[]{stringValue};
+        length = Utf8.encodedLength(stringValue);
+        isAscii = length == stringValue.length();
+        break;
+      case BYTES:
+        ByteArray byteArrayValue = new ByteArray((byte[]) value);
+        value = byteArrayValue;
+        _valueSet = new ByteArray[]{byteArrayValue};
+        length = byteArrayValue.length();
+        break;
+      // TODO: Support MAP
+      default:
+        throw new IllegalArgumentException(
+            "Unsupported value type: " + valueType + " for column: " + fieldSpec.getName());
+    }
+    _value = (Comparable) value;
+    _valueLength = valueType.isFixedWidth() ? valueType.size() : length;
+    _isAscii = isAscii;
   }
 
   @Override
-  public Object getMinValue() {
-    return _minValue;
+  public FieldSpec getFieldSpec() {
+    return _fieldSpec;
   }
 
   @Override
-  public Object getMaxValue() {
-    return _maxValue;
+  public Comparable getMinValue() {
+    return _value;
+  }
+
+  @Override
+  public Comparable getMaxValue() {
+    return _value;
   }
 
   @Override
   public Object getUniqueValuesSet() {
-    return _uniqueValuesSet;
+    return _valueSet;
   }
 
   @Override
   public int getCardinality() {
-    return _cardinality;
+    return 1;
   }
 
   @Override
   public int getLengthOfShortestElement() {
-    return _lengthOfShortestElement;
+    return _valueLength;
   }
 
   @Override
-  public int getLengthOfLargestElement() {
-    return _lengthOfLargestElement;
+  public int getLengthOfLongestElement() {
+    return _valueLength;
+  }
+
+  @Override
+  public boolean isAscii() {
+    return _isAscii;
   }
 
   @Override
   public boolean isSorted() {
-    return _isSorted;
+    return isSingleValue();
   }
 
   @Override
   public int getTotalNumberOfEntries() {
-    return _totalNumberOfEntries;
+    return _numDocs;
   }
 
   @Override
   public int getMaxNumberOfMultiValues() {
-    return _maxNumberOfMultiValues;
+    return isSingleValue() ? 0 : 1;
   }
 
+  @Override
+  public int getMaxRowLengthInBytes() {
+    return _valueLength;
+  }
+
+  @Nullable
   @Override
   public PartitionFunction getPartitionFunction() {
     return null;
@@ -101,11 +159,13 @@ public class DefaultColumnStatistics implements ColumnStatistics {
     return 0;
   }
 
+  @Nullable
   @Override
   public Map<String, String> getPartitionFunctionConfig() {
     return null;
   }
 
+  @Nullable
   @Override
   public Set<Integer> getPartitions() {
     return null;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/defaultcolumn/DefaultColumnStatistics.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/defaultcolumn/DefaultColumnStatistics.java
@@ -20,7 +20,6 @@ package org.apache.pinot.segment.local.segment.index.loader.defaultcolumn;
 
 import com.google.common.base.Utf8;
 import java.math.BigDecimal;
-import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.pinot.segment.spi.creator.ColumnStatistics;
@@ -151,17 +150,6 @@ public class DefaultColumnStatistics implements ColumnStatistics {
   @Nullable
   @Override
   public PartitionFunction getPartitionFunction() {
-    return null;
-  }
-
-  @Override
-  public int getNumPartitions() {
-    return 0;
-  }
-
-  @Nullable
-  @Override
-  public Map<String, String> getPartitionFunctionConfig() {
     return null;
   }
 

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentEntriesAboveThresholdTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentEntriesAboveThresholdTest.java
@@ -212,6 +212,11 @@ public class MutableSegmentEntriesAboveThresholdTest implements PinotBuffersAfte
     }
 
     @Override
+    public boolean isAscii() {
+      return _mutableForwardIndex.isAscii();
+    }
+
+    @Override
     public void setDictId(int docId, int dictId) {
       _mutableForwardIndex.setDictId(docId, dictId);
     }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/converter/RealtimeSegmentConverterTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/converter/RealtimeSegmentConverterTest.java
@@ -185,7 +185,7 @@ public class RealtimeSegmentConverterTest implements PinotBuffersAfterMethodChec
       RealtimeSegmentConverter converter =
           new RealtimeSegmentConverter(mutableSegmentImpl, segmentZKPropsConfig, outputDir.getAbsolutePath(), schema,
               tableNameWithType, tableConfig, segmentName, false);
-      converter.build(SegmentVersion.v3, null);
+      converter.build(SegmentVersion.v3);
 
       File indexDir = new File(outputDir, segmentName);
       SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(indexDir);
@@ -267,7 +267,7 @@ public class RealtimeSegmentConverterTest implements PinotBuffersAfterMethodChec
       RealtimeSegmentConverter converter =
           new RealtimeSegmentConverter(mutableSegmentImpl, segmentZKPropsConfig, outputDir.getAbsolutePath(), schema,
               tableNameWithType, tableConfig, segmentName, false);
-      converter.build(SegmentVersion.v3, null);
+      converter.build(SegmentVersion.v3);
 
       File indexDir = new File(outputDir, segmentName);
       SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(indexDir);
@@ -351,7 +351,7 @@ public class RealtimeSegmentConverterTest implements PinotBuffersAfterMethodChec
       RealtimeSegmentConverter converter =
           new RealtimeSegmentConverter(mutableSegmentImpl, segmentZKPropsConfig, outputDir.getAbsolutePath(), schema,
               tableNameWithType, tableConfig, segmentName, false);
-      converter.build(SegmentVersion.v3, null);
+      converter.build(SegmentVersion.v3);
 
       File indexDir = new File(outputDir, segmentName);
       SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(indexDir);
@@ -433,7 +433,7 @@ public class RealtimeSegmentConverterTest implements PinotBuffersAfterMethodChec
       RealtimeSegmentConverter converter =
           new RealtimeSegmentConverter(mutableSegmentImpl, segmentZKPropsConfig, outputDir.getAbsolutePath(), schema,
               tableNameWithType, tableConfig, segmentName, false);
-      converter.build(SegmentVersion.v3, null);
+      converter.build(SegmentVersion.v3);
 
       File indexDir = new File(outputDir, segmentName);
       SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(indexDir);
@@ -559,7 +559,7 @@ public class RealtimeSegmentConverterTest implements PinotBuffersAfterMethodChec
       RealtimeSegmentConverter converter =
           new RealtimeSegmentConverter(mutableSegmentImpl, segmentZKPropsConfig, outputDir.getAbsolutePath(), schema,
               tableNameWithType, tableConfig, segmentName, false);
-      converter.build(SegmentVersion.v3, null);
+      converter.build(SegmentVersion.v3);
 
       File indexDir = new File(outputDir, segmentName);
       SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(indexDir);
@@ -685,7 +685,7 @@ public class RealtimeSegmentConverterTest implements PinotBuffersAfterMethodChec
       RealtimeSegmentConverter converter =
           new RealtimeSegmentConverter(mutableSegmentImpl, segmentZKPropsConfig, outputDir.getAbsolutePath(), schema,
               tableNameWithType, tableConfig, segmentName, false);
-      converter.build(SegmentVersion.v3, null);
+      converter.build(SegmentVersion.v3);
 
       File indexDir = new File(outputDir, segmentName);
       SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(indexDir);
@@ -839,7 +839,7 @@ public class RealtimeSegmentConverterTest implements PinotBuffersAfterMethodChec
       RealtimeSegmentConverter converter =
           new RealtimeSegmentConverter(mutableSegmentImpl, segmentZKPropsConfig, outputDir.getAbsolutePath(), schema,
               tableNameWithType, tableConfig, segmentName, false);
-      converter.build(SegmentVersion.v3, null);
+      converter.build(SegmentVersion.v3);
 
       // Verify the converted segment metadata preserves the partition function config
       File indexDir = new File(outputDir, segmentName);
@@ -928,7 +928,7 @@ public class RealtimeSegmentConverterTest implements PinotBuffersAfterMethodChec
       RealtimeSegmentConverter converter =
           new RealtimeSegmentConverter(mutableSegmentImpl, segmentZKPropsConfig, outputDir.getAbsolutePath(), schema,
               tableNameWithType, tableConfig, segmentName, false);
-      converter.build(SegmentVersion.v3, null);
+      converter.build(SegmentVersion.v3);
 
       // Verify the converted segment metadata preserves the Murmur3 function config
       File indexDir = new File(outputDir, segmentName);
@@ -1015,7 +1015,7 @@ public class RealtimeSegmentConverterTest implements PinotBuffersAfterMethodChec
       RealtimeSegmentConverter converter =
           new RealtimeSegmentConverter(mutableSegmentImpl, segmentZKPropsConfig, outputDir.getAbsolutePath(), schema,
               tableNameWithType, tableConfig, segmentName, false);
-      converter.build(SegmentVersion.v3, null);
+      converter.build(SegmentVersion.v3);
 
       File indexDir = new File(outputDir, segmentName);
       SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(indexDir);
@@ -1136,7 +1136,7 @@ public class RealtimeSegmentConverterTest implements PinotBuffersAfterMethodChec
       RealtimeSegmentConverter converter =
           new RealtimeSegmentConverter(mutableSegment, segmentZKPropsConfig, outputDir.getAbsolutePath(), schema,
               tableNameWithType, tableConfig, segmentName, false);
-      converter.build(SegmentVersion.v3, null);
+      converter.build(SegmentVersion.v3);
 
       SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(new File(outputDir, segmentName));
 
@@ -1252,7 +1252,7 @@ public class RealtimeSegmentConverterTest implements PinotBuffersAfterMethodChec
       RealtimeSegmentConverter converter =
           new RealtimeSegmentConverter(mutableSegment, segmentZKPropsConfig, outputDir.getAbsolutePath(), schema,
               tableNameWithType, tableConfig, segmentName, false);
-      converter.build(SegmentVersion.v3, null);
+      converter.build(SegmentVersion.v3);
 
       SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(new File(outputDir, segmentName));
 
@@ -1348,7 +1348,7 @@ public class RealtimeSegmentConverterTest implements PinotBuffersAfterMethodChec
       RealtimeSegmentConverter converter =
           new RealtimeSegmentConverter(mutableSegment, segmentZKPropsConfig, outputDir.getAbsolutePath(), schema,
               tableNameWithType, tableConfig, segmentName, false);
-      converter.build(SegmentVersion.v3, null);
+      converter.build(SegmentVersion.v3);
 
       File indexDir = new File(outputDir, segmentName);
       SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(indexDir);
@@ -1473,7 +1473,7 @@ public class RealtimeSegmentConverterTest implements PinotBuffersAfterMethodChec
       RealtimeSegmentConverter converter =
           new RealtimeSegmentConverter(mutableSegment, segmentZKPropsConfig, outputDir.getAbsolutePath(), schema,
               tableNameWithType, tableConfig, segmentName, false);
-      converter.build(SegmentVersion.v3, null);
+      converter.build(SegmentVersion.v3);
 
       File indexDir = new File(outputDir, segmentName);
       SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(indexDir);

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/converter/stats/CompactedColumnStatisticsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/converter/stats/CompactedColumnStatisticsTest.java
@@ -20,8 +20,11 @@ package org.apache.pinot.segment.local.realtime.converter.stats;
 
 import java.math.BigDecimal;
 import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.segment.spi.datasource.DataSourceMetadata;
 import org.apache.pinot.segment.spi.index.mutable.MutableForwardIndex;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
+import org.apache.pinot.spi.data.DimensionFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.ByteArray;
 import org.roaringbitmap.RoaringBitmap;
@@ -32,7 +35,6 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 
@@ -45,7 +47,7 @@ public class CompactedColumnStatisticsTest {
 
   @Test
   public void testIntSvSortedViaBitmap() {
-    // docs: 0→id0(10), 1→id1(20), 2→id2(30) — bitmap iterates in ascending doc order → sorted
+    // docs: 0->id0(10), 1->id1(20), 2->id2(30) -- bitmap iterates in ascending doc order -> sorted
     MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
     when(forwardIndex.isSingleValue()).thenReturn(true);
     when(forwardIndex.getDictId(0)).thenReturn(0);
@@ -61,17 +63,17 @@ public class CompactedColumnStatisticsTest {
         new CompactedColumnStatistics(mockDataSource(forwardIndex, dictionary), null, false,
             validDocIds);
 
-    assertEquals(stats.getCardinality(), 3);
     assertEquals(stats.getMinValue(), 10);
     assertEquals(stats.getMaxValue(), 30);
-    assertEquals(stats.getTotalNumberOfEntries(), 3);
     assertEquals((int[]) stats.getUniqueValuesSet(), new int[]{10, 20, 30});
+    assertEquals(stats.getCardinality(), 3);
     assertTrue(stats.isSorted());
+    assertEquals(stats.getTotalNumberOfEntries(), 3);
   }
 
   @Test
   public void testIntSvUnsortedViaBitmap() {
-    // docs: 0→id0(10), 1→id2(30), 2→id1(20) — compare(id2,id1): 30>20 → unsorted
+    // docs: 0->id0(10), 1->id2(30), 2->id1(20) -- compare(id2,id1): 30>20 -> unsorted
     MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
     when(forwardIndex.isSingleValue()).thenReturn(true);
     when(forwardIndex.getDictId(0)).thenReturn(0);
@@ -79,24 +81,24 @@ public class CompactedColumnStatisticsTest {
     when(forwardIndex.getDictId(2)).thenReturn(1);
 
     Dictionary dictionary = mockIntDictionary(new int[]{10, 20, 30});
-    when(dictionary.compare(0, 2)).thenReturn(-1); // 10 < 30 — still sorted after doc1
-    when(dictionary.compare(2, 1)).thenReturn(1);  // 30 > 20 — unsorted at doc2
+    when(dictionary.compare(0, 2)).thenReturn(-1); // 10 < 30 -- still sorted after doc1
+    when(dictionary.compare(2, 1)).thenReturn(1);  // 30 > 20 -- unsorted at doc2
 
     RoaringBitmap validDocIds = RoaringBitmap.bitmapOf(0, 1, 2);
     CompactedColumnStatistics stats =
         new CompactedColumnStatistics(mockDataSource(forwardIndex, dictionary), null, false,
             validDocIds);
 
-    assertEquals(stats.getCardinality(), 3);
     assertEquals(stats.getMinValue(), 10);
     assertEquals(stats.getMaxValue(), 30);
     assertEquals((int[]) stats.getUniqueValuesSet(), new int[]{10, 20, 30});
+    assertEquals(stats.getCardinality(), 3);
     assertFalse(stats.isSorted());
   }
 
   @Test
   public void testIntSvSortedWithSortedDocIds() {
-    // sortedDocIds=[2,0,1]: doc2→id0(10), doc0→id1(20), doc1→id2(30) → sorted in that order
+    // sortedDocIds=[2,0,1]: doc2->id0(10), doc0->id1(20), doc1->id2(30) -> sorted in that order
     MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
     when(forwardIndex.isSingleValue()).thenReturn(true);
     when(forwardIndex.getDictId(2)).thenReturn(0);
@@ -111,16 +113,16 @@ public class CompactedColumnStatisticsTest {
     CompactedColumnStatistics stats = new CompactedColumnStatistics(mockDataSource(forwardIndex, dictionary),
         new int[]{2, 0, 1}, false, validDocIds);
 
-    assertEquals(stats.getCardinality(), 3);
     assertEquals(stats.getMinValue(), 10);
     assertEquals(stats.getMaxValue(), 30);
+    assertEquals(stats.getCardinality(), 3);
     assertTrue(stats.isSorted());
   }
 
   @Test
   public void testIntSvWithSortedDocIdsAndPartialValidDocs() {
     // sortedDocIds=[1,3,0,2], validDocIds={0,1,2} (doc3 is invalid, skipped)
-    // filtered order: doc1→id0(10), doc0→id1(20), doc2→id2(30) → sorted
+    // filtered order: doc1->id0(10), doc0->id1(20), doc2->id2(30) -> sorted
     MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
     when(forwardIndex.isSingleValue()).thenReturn(true);
     when(forwardIndex.getDictId(1)).thenReturn(0);
@@ -135,11 +137,11 @@ public class CompactedColumnStatisticsTest {
     CompactedColumnStatistics stats = new CompactedColumnStatistics(mockDataSource(forwardIndex, dictionary),
         new int[]{1, 3, 0, 2}, false, validDocIds);
 
-    assertEquals(stats.getCardinality(), 3);
-    assertEquals(stats.getTotalNumberOfEntries(), 3);
     assertEquals(stats.getMinValue(), 10);
     assertEquals(stats.getMaxValue(), 30);
+    assertEquals(stats.getCardinality(), 3);
     assertTrue(stats.isSorted());
+    assertEquals(stats.getTotalNumberOfEntries(), 3);
   }
 
   // ======== LONG SV ========
@@ -165,12 +167,12 @@ public class CompactedColumnStatisticsTest {
         new CompactedColumnStatistics(mockDataSource(forwardIndex, dictionary), null, false,
             validDocIds);
 
-    assertEquals(stats.getCardinality(), 2);
     assertEquals(stats.getMinValue(), 100L);
     assertEquals(stats.getMaxValue(), 300L);
-    assertEquals(stats.getTotalNumberOfEntries(), 2);
     assertEquals((long[]) stats.getUniqueValuesSet(), new long[]{100L, 300L});
+    assertEquals(stats.getCardinality(), 2);
     assertTrue(stats.isSorted());
+    assertEquals(stats.getTotalNumberOfEntries(), 2);
   }
 
   // ======== FLOAT SV ========
@@ -195,10 +197,10 @@ public class CompactedColumnStatisticsTest {
         new CompactedColumnStatistics(mockDataSource(forwardIndex, dictionary), null, false,
             validDocIds);
 
-    assertEquals(stats.getCardinality(), 2);
     assertEquals(stats.getMinValue(), 1.5f);
     assertEquals(stats.getMaxValue(), 2.5f);
     assertEquals((float[]) stats.getUniqueValuesSet(), new float[]{1.5f, 2.5f});
+    assertEquals(stats.getCardinality(), 2);
     assertTrue(stats.isSorted());
   }
 
@@ -206,7 +208,7 @@ public class CompactedColumnStatisticsTest {
 
   @Test
   public void testDoubleSvUnsorted() {
-    // doc0→id0(3.14), doc1→id1(2.71) → compare(id0,id1): 3.14>2.71 → unsorted
+    // doc0->id0(3.14), doc1->id1(2.71) -> compare(id0,id1): 3.14>2.71 -> unsorted
     MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
     when(forwardIndex.isSingleValue()).thenReturn(true);
     when(forwardIndex.getDictId(0)).thenReturn(0);
@@ -225,11 +227,68 @@ public class CompactedColumnStatisticsTest {
         new CompactedColumnStatistics(mockDataSource(forwardIndex, dictionary), null, false,
             validDocIds);
 
-    assertEquals(stats.getCardinality(), 2);
     assertEquals(stats.getMinValue(), 2.71);
     assertEquals(stats.getMaxValue(), 3.14);
     assertEquals((double[]) stats.getUniqueValuesSet(), new double[]{2.71, 3.14});
+    assertEquals(stats.getCardinality(), 2);
     assertFalse(stats.isSorted());
+  }
+
+  // ======== BOOLEAN SV ========
+
+  @Test
+  public void testBooleanSv() {
+    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
+    when(forwardIndex.isSingleValue()).thenReturn(true);
+    when(forwardIndex.getDictId(0)).thenReturn(0);
+    when(forwardIndex.getDictId(1)).thenReturn(1);
+
+    Dictionary dictionary = mock(Dictionary.class);
+    when(dictionary.getValueType()).thenReturn(DataType.INT);
+    when(dictionary.getInternal(0)).thenReturn(0);
+    when(dictionary.getInternal(1)).thenReturn(1);
+    when(dictionary.getIntValue(0)).thenReturn(0);
+    when(dictionary.getIntValue(1)).thenReturn(1);
+    when(dictionary.compare(0, 1)).thenReturn(-1);
+
+    RoaringBitmap validDocIds = RoaringBitmap.bitmapOf(0, 1);
+    CompactedColumnStatistics stats =
+        new CompactedColumnStatistics(mockDataSource(forwardIndex, dictionary, DataType.BOOLEAN), null, false,
+            validDocIds);
+
+    assertEquals(stats.getMinValue(), 0);
+    assertEquals(stats.getMaxValue(), 1);
+    assertEquals((int[]) stats.getUniqueValuesSet(), new int[]{0, 1});
+    assertEquals(stats.getCardinality(), 2);
+    assertTrue(stats.isSorted());
+  }
+
+  // ======== TIMESTAMP SV ========
+
+  @Test
+  public void testTimestampSv() {
+    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
+    when(forwardIndex.isSingleValue()).thenReturn(true);
+    when(forwardIndex.getDictId(0)).thenReturn(0);
+    when(forwardIndex.getDictId(1)).thenReturn(1);
+
+    Dictionary dictionary = mock(Dictionary.class);
+    when(dictionary.getValueType()).thenReturn(DataType.LONG);
+    when(dictionary.getInternal(0)).thenReturn(1000L);
+    when(dictionary.getInternal(1)).thenReturn(2000L);
+    when(dictionary.getLongValue(0)).thenReturn(1000L);
+    when(dictionary.getLongValue(1)).thenReturn(2000L);
+    when(dictionary.compare(0, 1)).thenReturn(-1);
+
+    RoaringBitmap validDocIds = RoaringBitmap.bitmapOf(0, 1);
+    CompactedColumnStatistics stats =
+        new CompactedColumnStatistics(mockDataSource(forwardIndex, dictionary, DataType.TIMESTAMP), null, false,
+            validDocIds);
+
+    assertEquals(stats.getMinValue(), 1000L);
+    assertEquals(stats.getMaxValue(), 2000L);
+    assertEquals(stats.getCardinality(), 2);
+    assertTrue(stats.isSorted());
   }
 
   // ======== BIG_DECIMAL SV ========
@@ -257,10 +316,10 @@ public class CompactedColumnStatisticsTest {
         new CompactedColumnStatistics(mockDataSource(forwardIndex, dictionary), null, false,
             validDocIds);
 
-    assertEquals(stats.getCardinality(), 2);
     assertEquals(stats.getMinValue(), v0);
     assertEquals(stats.getMaxValue(), v1);
     assertEquals((BigDecimal[]) stats.getUniqueValuesSet(), new BigDecimal[]{v0, v1});
+    assertEquals(stats.getCardinality(), 2);
     assertTrue(stats.isSorted());
   }
 
@@ -290,10 +349,38 @@ public class CompactedColumnStatisticsTest {
         new CompactedColumnStatistics(mockDataSource(forwardIndex, dictionary), null, false,
             validDocIds);
 
-    assertEquals(stats.getCardinality(), 3);
     assertEquals(stats.getMinValue(), "apple");
     assertEquals(stats.getMaxValue(), "cherry");
     assertEquals((String[]) stats.getUniqueValuesSet(), new String[]{"apple", "banana", "cherry"});
+    assertEquals(stats.getCardinality(), 3);
+    assertTrue(stats.isSorted());
+  }
+
+  // ======== JSON SV ========
+
+  @Test
+  public void testJsonSv() {
+    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
+    when(forwardIndex.isSingleValue()).thenReturn(true);
+    when(forwardIndex.getDictId(0)).thenReturn(0);
+    when(forwardIndex.getDictId(1)).thenReturn(1);
+
+    Dictionary dictionary = mock(Dictionary.class);
+    when(dictionary.getValueType()).thenReturn(DataType.STRING);
+    when(dictionary.getInternal(0)).thenReturn("null");
+    when(dictionary.getInternal(1)).thenReturn("{\"a\":1}");
+    when(dictionary.getStringValue(0)).thenReturn("null");
+    when(dictionary.getStringValue(1)).thenReturn("{\"a\":1}");
+    when(dictionary.compare(0, 1)).thenReturn(-1);
+
+    RoaringBitmap validDocIds = RoaringBitmap.bitmapOf(0, 1);
+    CompactedColumnStatistics stats =
+        new CompactedColumnStatistics(mockDataSource(forwardIndex, dictionary, DataType.JSON), null, false,
+            validDocIds);
+
+    assertEquals(stats.getMinValue(), "null");
+    assertEquals(stats.getMaxValue(), "{\"a\":1}");
+    assertEquals(stats.getCardinality(), 2);
     assertTrue(stats.isSorted());
   }
 
@@ -322,19 +409,203 @@ public class CompactedColumnStatisticsTest {
         new CompactedColumnStatistics(mockDataSource(forwardIndex, dictionary), null, false,
             validDocIds);
 
-    assertEquals(stats.getCardinality(), 2);
     assertEquals(stats.getMinValue(), ba0);
     assertEquals(stats.getMaxValue(), ba1);
     assertEquals((ByteArray[]) stats.getUniqueValuesSet(), new ByteArray[]{ba0, ba1});
+    assertEquals(stats.getCardinality(), 2);
     assertTrue(stats.isSorted());
   }
 
-  // ======== Multi-value ========
+  // ======== INT MV ========
+
+  @Test
+  public void testIntMvAllDocs() {
+    // doc0=[20,30] (dictIds 1,2), doc1=[10] (dictId 0)
+    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
+    when(forwardIndex.isSingleValue()).thenReturn(false);
+    when(forwardIndex.getDictIdMV(0)).thenReturn(new int[]{1, 2});
+    when(forwardIndex.getDictIdMV(1)).thenReturn(new int[]{0});
+
+    Dictionary dictionary = mockIntDictionary(new int[]{10, 20, 30});
+
+    RoaringBitmap validDocIds = RoaringBitmap.bitmapOf(0, 1);
+    CompactedColumnStatistics stats =
+        new CompactedColumnStatistics(mockDataSource(forwardIndex, dictionary), null, false,
+            validDocIds);
+
+    assertEquals(stats.getMinValue(), 10);
+    assertEquals(stats.getMaxValue(), 30);
+    assertEquals((int[]) stats.getUniqueValuesSet(), new int[]{10, 20, 30});
+    assertEquals(stats.getCardinality(), 3);
+    assertFalse(stats.isSorted());
+    assertEquals(stats.getTotalNumberOfEntries(), 3); // 2+1
+    assertEquals(stats.getMaxNumberOfMultiValues(), 2);
+  }
+
+  // ======== LONG MV ========
+
+  @Test
+  public void testLongMv() {
+    // doc0=[100L,200L], doc1=[300L]
+    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
+    when(forwardIndex.isSingleValue()).thenReturn(false);
+    when(forwardIndex.getDictIdMV(0)).thenReturn(new int[]{0, 1});
+    when(forwardIndex.getDictIdMV(1)).thenReturn(new int[]{2});
+
+    Dictionary dictionary = mock(Dictionary.class);
+    when(dictionary.getValueType()).thenReturn(DataType.LONG);
+    when(dictionary.getInternal(0)).thenReturn(100L);
+    when(dictionary.getInternal(1)).thenReturn(200L);
+    when(dictionary.getInternal(2)).thenReturn(300L);
+    when(dictionary.getLongValue(0)).thenReturn(100L);
+    when(dictionary.getLongValue(1)).thenReturn(200L);
+    when(dictionary.getLongValue(2)).thenReturn(300L);
+
+    RoaringBitmap validDocIds = RoaringBitmap.bitmapOf(0, 1);
+    CompactedColumnStatistics stats =
+        new CompactedColumnStatistics(mockDataSource(forwardIndex, dictionary), null, false,
+            validDocIds);
+
+    assertEquals(stats.getMinValue(), 100L);
+    assertEquals(stats.getMaxValue(), 300L);
+    assertEquals(stats.getCardinality(), 3);
+    assertFalse(stats.isSorted());
+    assertEquals(stats.getTotalNumberOfEntries(), 3); // 2+1
+    assertEquals(stats.getMaxNumberOfMultiValues(), 2);
+  }
+
+  // ======== FLOAT MV ========
+
+  @Test
+  public void testFloatMv() {
+    // doc0=[1.5f,2.5f], doc1=[3.5f]
+    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
+    when(forwardIndex.isSingleValue()).thenReturn(false);
+    when(forwardIndex.getDictIdMV(0)).thenReturn(new int[]{0, 1});
+    when(forwardIndex.getDictIdMV(1)).thenReturn(new int[]{2});
+
+    Dictionary dictionary = mock(Dictionary.class);
+    when(dictionary.getValueType()).thenReturn(DataType.FLOAT);
+    when(dictionary.getInternal(0)).thenReturn(1.5f);
+    when(dictionary.getInternal(1)).thenReturn(2.5f);
+    when(dictionary.getInternal(2)).thenReturn(3.5f);
+    when(dictionary.getFloatValue(0)).thenReturn(1.5f);
+    when(dictionary.getFloatValue(1)).thenReturn(2.5f);
+    when(dictionary.getFloatValue(2)).thenReturn(3.5f);
+
+    RoaringBitmap validDocIds = RoaringBitmap.bitmapOf(0, 1);
+    CompactedColumnStatistics stats =
+        new CompactedColumnStatistics(mockDataSource(forwardIndex, dictionary), null, false,
+            validDocIds);
+
+    assertEquals(stats.getMinValue(), 1.5f);
+    assertEquals(stats.getMaxValue(), 3.5f);
+    assertEquals(stats.getCardinality(), 3);
+    assertFalse(stats.isSorted());
+    assertEquals(stats.getTotalNumberOfEntries(), 3); // 2+1
+    assertEquals(stats.getMaxNumberOfMultiValues(), 2);
+  }
+
+  // ======== DOUBLE MV ========
+
+  @Test
+  public void testDoubleMv() {
+    // doc0=[1.1,2.2], doc1=[3.3]
+    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
+    when(forwardIndex.isSingleValue()).thenReturn(false);
+    when(forwardIndex.getDictIdMV(0)).thenReturn(new int[]{0, 1});
+    when(forwardIndex.getDictIdMV(1)).thenReturn(new int[]{2});
+
+    Dictionary dictionary = mock(Dictionary.class);
+    when(dictionary.getValueType()).thenReturn(DataType.DOUBLE);
+    when(dictionary.getInternal(0)).thenReturn(1.1);
+    when(dictionary.getInternal(1)).thenReturn(2.2);
+    when(dictionary.getInternal(2)).thenReturn(3.3);
+    when(dictionary.getDoubleValue(0)).thenReturn(1.1);
+    when(dictionary.getDoubleValue(1)).thenReturn(2.2);
+    when(dictionary.getDoubleValue(2)).thenReturn(3.3);
+
+    RoaringBitmap validDocIds = RoaringBitmap.bitmapOf(0, 1);
+    CompactedColumnStatistics stats =
+        new CompactedColumnStatistics(mockDataSource(forwardIndex, dictionary), null, false,
+            validDocIds);
+
+    assertEquals(stats.getMinValue(), 1.1);
+    assertEquals(stats.getMaxValue(), 3.3);
+    assertEquals(stats.getCardinality(), 3);
+    assertFalse(stats.isSorted());
+    assertEquals(stats.getTotalNumberOfEntries(), 3); // 2+1
+    assertEquals(stats.getMaxNumberOfMultiValues(), 2);
+  }
+
+  // ======== BOOLEAN MV ========
+
+  @Test
+  public void testBooleanMv() {
+    // doc0=[0,1], doc1=[0]
+    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
+    when(forwardIndex.isSingleValue()).thenReturn(false);
+    when(forwardIndex.getDictIdMV(0)).thenReturn(new int[]{0, 1});
+    when(forwardIndex.getDictIdMV(1)).thenReturn(new int[]{0});
+
+    Dictionary dictionary = mock(Dictionary.class);
+    when(dictionary.getValueType()).thenReturn(DataType.INT);
+    when(dictionary.getInternal(0)).thenReturn(0);
+    when(dictionary.getInternal(1)).thenReturn(1);
+    when(dictionary.getIntValue(0)).thenReturn(0);
+    when(dictionary.getIntValue(1)).thenReturn(1);
+
+    RoaringBitmap validDocIds = RoaringBitmap.bitmapOf(0, 1);
+    CompactedColumnStatistics stats =
+        new CompactedColumnStatistics(mockDataSource(forwardIndex, dictionary, DataType.BOOLEAN), null, false,
+            validDocIds);
+
+    assertEquals(stats.getMinValue(), 0);
+    assertEquals(stats.getMaxValue(), 1);
+    assertEquals(stats.getCardinality(), 2);
+    assertFalse(stats.isSorted());
+    assertEquals(stats.getTotalNumberOfEntries(), 3); // 2+1
+    assertEquals(stats.getMaxNumberOfMultiValues(), 2);
+  }
+
+  // ======== TIMESTAMP MV ========
+
+  @Test
+  public void testTimestampMv() {
+    // doc0=[1000L,2000L], doc1=[3000L]
+    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
+    when(forwardIndex.isSingleValue()).thenReturn(false);
+    when(forwardIndex.getDictIdMV(0)).thenReturn(new int[]{0, 1});
+    when(forwardIndex.getDictIdMV(1)).thenReturn(new int[]{2});
+
+    Dictionary dictionary = mock(Dictionary.class);
+    when(dictionary.getValueType()).thenReturn(DataType.LONG);
+    when(dictionary.getInternal(0)).thenReturn(1000L);
+    when(dictionary.getInternal(1)).thenReturn(2000L);
+    when(dictionary.getInternal(2)).thenReturn(3000L);
+    when(dictionary.getLongValue(0)).thenReturn(1000L);
+    when(dictionary.getLongValue(1)).thenReturn(2000L);
+    when(dictionary.getLongValue(2)).thenReturn(3000L);
+
+    RoaringBitmap validDocIds = RoaringBitmap.bitmapOf(0, 1);
+    CompactedColumnStatistics stats =
+        new CompactedColumnStatistics(mockDataSource(forwardIndex, dictionary, DataType.TIMESTAMP), null, false,
+            validDocIds);
+
+    assertEquals(stats.getMinValue(), 1000L);
+    assertEquals(stats.getMaxValue(), 3000L);
+    assertEquals(stats.getCardinality(), 3);
+    assertFalse(stats.isSorted());
+    assertEquals(stats.getTotalNumberOfEntries(), 3); // 2+1
+    assertEquals(stats.getMaxNumberOfMultiValues(), 2);
+  }
+
+  // ======== STRING MV ========
 
   @Test
   public void testStringMvPartialValidDocs() {
     // doc0=["a","b"], doc1=["c"] (invalid), doc2=["b","d"]
-    // validDocIds={0,2} → used dictIds: {0,1,3} → values "a","b","d"
+    // validDocIds={0,2} -> used dictIds: {0,1,3} -> values "a","b","d"
     MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
     when(forwardIndex.isSingleValue()).thenReturn(false);
     when(forwardIndex.getDictIdMV(0)).thenReturn(new int[]{0, 1});
@@ -354,42 +625,18 @@ public class CompactedColumnStatisticsTest {
         new CompactedColumnStatistics(mockDataSource(forwardIndex, dictionary), null, false,
             validDocIds);
 
-    assertEquals(stats.getCardinality(), 3);
     assertEquals(stats.getMinValue(), "a");
     assertEquals(stats.getMaxValue(), "d");
+    assertEquals((String[]) stats.getUniqueValuesSet(), new String[]{"a", "b", "d"});
+    assertEquals(stats.getCardinality(), 3);
+    assertFalse(stats.isSorted()); // MV -> always false when cardinality > 1
     assertEquals(stats.getTotalNumberOfEntries(), 4); // 2+2
     assertEquals(stats.getMaxNumberOfMultiValues(), 2);
-    assertEquals((String[]) stats.getUniqueValuesSet(), new String[]{"a", "b", "d"});
-    assertFalse(stats.isSorted()); // MV → always false when cardinality > 1
-  }
-
-  @Test
-  public void testIntMvAllDocs() {
-    // doc0=[20,30] (dictIds 1,2), doc1=[10] (dictId 0)
-    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
-    when(forwardIndex.isSingleValue()).thenReturn(false);
-    when(forwardIndex.getDictIdMV(0)).thenReturn(new int[]{1, 2});
-    when(forwardIndex.getDictIdMV(1)).thenReturn(new int[]{0});
-
-    Dictionary dictionary = mockIntDictionary(new int[]{10, 20, 30});
-
-    RoaringBitmap validDocIds = RoaringBitmap.bitmapOf(0, 1);
-    CompactedColumnStatistics stats =
-        new CompactedColumnStatistics(mockDataSource(forwardIndex, dictionary), null, false,
-            validDocIds);
-
-    assertEquals(stats.getCardinality(), 3);
-    assertEquals(stats.getMinValue(), 10);
-    assertEquals(stats.getMaxValue(), 30);
-    assertEquals(stats.getTotalNumberOfEntries(), 3); // 2+1
-    assertEquals(stats.getMaxNumberOfMultiValues(), 2);
-    assertEquals((int[]) stats.getUniqueValuesSet(), new int[]{10, 20, 30});
-    assertFalse(stats.isSorted()); // MV → always false when cardinality > 1
   }
 
   @Test
   public void testStringMvWithSortedDocIds() {
-    // sortedDocIds provided, MV → isSorted must still be false when cardinality > 1
+    // sortedDocIds provided, MV -> isSorted must still be false when cardinality > 1
     MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
     when(forwardIndex.isSingleValue()).thenReturn(false);
     when(forwardIndex.getDictIdMV(0)).thenReturn(new int[]{0, 1});
@@ -409,32 +656,41 @@ public class CompactedColumnStatisticsTest {
         new int[]{0, 1}, false, validDocIds);
 
     assertEquals(stats.getCardinality(), 3);
+    assertFalse(stats.isSorted()); // MV -> always false when cardinality > 1
     assertEquals(stats.getTotalNumberOfEntries(), 3);
-    assertFalse(stats.isSorted()); // MV → always false when cardinality > 1
   }
+
+  // ======== JSON MV ========
 
   @Test
-  public void testIntSvUnsortedWithSortedDocIds() {
-    // sortedDocIds=[0,1,2] but doc0→id0(30), doc1→id1(10) → compare(id0,id1): 30>10 → unsorted
+  public void testJsonMv() {
+    // doc0=["null","{}"], doc1=["null"]
     MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
-    when(forwardIndex.isSingleValue()).thenReturn(true);
-    when(forwardIndex.getDictId(0)).thenReturn(0);
-    when(forwardIndex.getDictId(1)).thenReturn(1);
-    when(forwardIndex.getDictId(2)).thenReturn(2);
+    when(forwardIndex.isSingleValue()).thenReturn(false);
+    when(forwardIndex.getDictIdMV(0)).thenReturn(new int[]{0, 1});
+    when(forwardIndex.getDictIdMV(1)).thenReturn(new int[]{0});
 
-    Dictionary dictionary = mockIntDictionary(new int[]{30, 10, 20});
-    when(dictionary.compare(0, 1)).thenReturn(1); // 30 > 10 — unsorted at second doc
+    Dictionary dictionary = mock(Dictionary.class);
+    when(dictionary.getValueType()).thenReturn(DataType.STRING);
+    when(dictionary.getInternal(0)).thenReturn("null");
+    when(dictionary.getInternal(1)).thenReturn("{}");
+    when(dictionary.getStringValue(0)).thenReturn("null");
+    when(dictionary.getStringValue(1)).thenReturn("{}");
 
-    RoaringBitmap validDocIds = RoaringBitmap.bitmapOf(0, 1, 2);
-    CompactedColumnStatistics stats = new CompactedColumnStatistics(mockDataSource(forwardIndex, dictionary),
-        new int[]{0, 1, 2}, false, validDocIds);
+    RoaringBitmap validDocIds = RoaringBitmap.bitmapOf(0, 1);
+    CompactedColumnStatistics stats =
+        new CompactedColumnStatistics(mockDataSource(forwardIndex, dictionary, DataType.JSON), null, false,
+            validDocIds);
 
-    assertEquals(stats.getCardinality(), 3);
-    assertEquals(stats.getMinValue(), 10);
-    assertEquals(stats.getMaxValue(), 30);
-    assertEquals((int[]) stats.getUniqueValuesSet(), new int[]{10, 20, 30});
+    assertEquals(stats.getMinValue(), "null");
+    assertEquals(stats.getMaxValue(), "{}");
+    assertEquals(stats.getCardinality(), 2);
     assertFalse(stats.isSorted());
+    assertEquals(stats.getTotalNumberOfEntries(), 3); // 2+1
+    assertEquals(stats.getMaxNumberOfMultiValues(), 2);
   }
+
+  // ======== BYTES MV ========
 
   @Test
   public void testBytesMv() {
@@ -462,61 +718,22 @@ public class CompactedColumnStatisticsTest {
         new CompactedColumnStatistics(mockDataSource(forwardIndex, dictionary), null, false,
             validDocIds);
 
-    assertEquals(stats.getCardinality(), 3);
     assertEquals(stats.getMinValue(), ba0);
     assertEquals(stats.getMaxValue(), ba1);
+    assertEquals((ByteArray[]) stats.getUniqueValuesSet(), new ByteArray[]{ba0, ba2, ba1}); // sorted: {1},{2},{3}
+    assertEquals(stats.getCardinality(), 3);
+    assertFalse(stats.isSorted()); // MV -> always false when cardinality > 1
     assertEquals(stats.getTotalNumberOfEntries(), 3); // 2+1
     assertEquals(stats.getMaxNumberOfMultiValues(), 2);
-    assertEquals((ByteArray[]) stats.getUniqueValuesSet(), new ByteArray[]{ba0, ba2, ba1}); // sorted: {1},{2},{3}
-    assertFalse(stats.isSorted()); // MV → always false when cardinality > 1
   }
 
-  @Test
-  public void testEmptyValidDocsWithSortedDocIds() {
-    // sortedDocIds provided but validDocIds is empty — all docs in sortedDocIds are skipped
-    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
-    when(forwardIndex.isSingleValue()).thenReturn(true);
-
-    Dictionary dictionary = mock(Dictionary.class);
-    when(dictionary.getValueType()).thenReturn(DataType.INT);
-
-    RoaringBitmap validDocIds = new RoaringBitmap();
-    CompactedColumnStatistics stats = new CompactedColumnStatistics(mockDataSource(forwardIndex, dictionary),
-        new int[]{0, 1, 2}, false, validDocIds);
-
-    assertEquals(stats.getCardinality(), 0);
-    assertNull(stats.getMinValue());
-    assertNull(stats.getMaxValue());
-    assertEquals(stats.getTotalNumberOfEntries(), 0);
-    assertTrue(stats.isSorted()); // cardinality <= 1
-  }
+  // Empty validDocIds cases are now handled by EmptyColumnStatistics via RealtimeSegmentStatsContainer
 
   // ======== Edge cases ========
 
   @Test
-  public void testEmptyValidDocs() {
-    // RoaringBitmap is empty — no documents, so nothing is accumulated
-    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
-    when(forwardIndex.isSingleValue()).thenReturn(true);
-
-    Dictionary dictionary = mock(Dictionary.class);
-    when(dictionary.getValueType()).thenReturn(DataType.INT);
-
-    RoaringBitmap validDocIds = new RoaringBitmap();
-    CompactedColumnStatistics stats =
-        new CompactedColumnStatistics(mockDataSource(forwardIndex, dictionary), null, false,
-            validDocIds);
-
-    assertEquals(stats.getCardinality(), 0);
-    assertNull(stats.getMinValue());
-    assertNull(stats.getMaxValue());
-    assertEquals(stats.getTotalNumberOfEntries(), 0);
-    assertTrue(stats.isSorted()); // cardinality <= 1
-  }
-
-  @Test
   public void testSingleValidDoc() {
-    // One valid doc → cardinality=1 → isSorted=true regardless of isSortedColumn
+    // One valid doc -> cardinality=1 -> isSorted=true regardless of isSortedColumn
     MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
     when(forwardIndex.isSingleValue()).thenReturn(true);
     when(forwardIndex.getDictId(0)).thenReturn(0);
@@ -531,23 +748,23 @@ public class CompactedColumnStatisticsTest {
         new CompactedColumnStatistics(mockDataSource(forwardIndex, dictionary), null, false,
             validDocIds);
 
-    assertEquals(stats.getCardinality(), 1);
     assertEquals(stats.getMinValue(), "hello");
     assertEquals(stats.getMaxValue(), "hello");
-    assertEquals(stats.getTotalNumberOfEntries(), 1);
+    assertEquals(stats.getCardinality(), 1);
     assertTrue(stats.isSorted()); // cardinality <= 1
+    assertEquals(stats.getTotalNumberOfEntries(), 1);
   }
 
   @Test
   public void testIsSortedColumnFlagForcesSorted() {
-    // isSortedColumn=true → isSorted=true even if data is descending
+    // isSortedColumn=true -> isSorted=true even if data is descending
     MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
     when(forwardIndex.isSingleValue()).thenReturn(true);
     when(forwardIndex.getDictId(0)).thenReturn(0); // val=30
     when(forwardIndex.getDictId(1)).thenReturn(1); // val=10
 
     Dictionary dictionary = mockIntDictionary(new int[]{30, 10});
-    when(dictionary.compare(0, 1)).thenReturn(1); // 30 > 10 — would be unsorted if not overridden
+    when(dictionary.compare(0, 1)).thenReturn(1); // 30 > 10 -- would be unsorted if not overridden
 
     RoaringBitmap validDocIds = RoaringBitmap.bitmapOf(0, 1);
     CompactedColumnStatistics stats =
@@ -559,7 +776,7 @@ public class CompactedColumnStatisticsTest {
 
   @Test
   public void testDuplicateDictIdsReduceCardinality() {
-    // 3 docs but only 2 distinct dictIds → cardinality=2
+    // 3 docs but only 2 distinct dictIds -> cardinality=2
     // The forward index has doc0 and doc2 both pointing to dictId=0 ("value1");
     // doc1 points to dictId=1 ("value2"). The dictionary maps each dictId to a unique value.
     MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
@@ -583,9 +800,32 @@ public class CompactedColumnStatisticsTest {
         new CompactedColumnStatistics(mockDataSource(forwardIndex, dictionary), null, false,
             validDocIds);
 
+    assertEquals((String[]) stats.getUniqueValuesSet(), new String[]{"value1", "value2"});
     assertEquals(stats.getCardinality(), 2);
     assertEquals(stats.getTotalNumberOfEntries(), 3);
-    assertEquals((String[]) stats.getUniqueValuesSet(), new String[]{"value1", "value2"});
+  }
+
+  @Test
+  public void testIntSvUnsortedWithSortedDocIds() {
+    // sortedDocIds=[0,1,2] but doc0->id0(30), doc1->id1(10) -> compare(id0,id1): 30>10 -> unsorted
+    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
+    when(forwardIndex.isSingleValue()).thenReturn(true);
+    when(forwardIndex.getDictId(0)).thenReturn(0);
+    when(forwardIndex.getDictId(1)).thenReturn(1);
+    when(forwardIndex.getDictId(2)).thenReturn(2);
+
+    Dictionary dictionary = mockIntDictionary(new int[]{30, 10, 20});
+    when(dictionary.compare(0, 1)).thenReturn(1); // 30 > 10 -- unsorted at second doc
+
+    RoaringBitmap validDocIds = RoaringBitmap.bitmapOf(0, 1, 2);
+    CompactedColumnStatistics stats = new CompactedColumnStatistics(mockDataSource(forwardIndex, dictionary),
+        new int[]{0, 1, 2}, false, validDocIds);
+
+    assertEquals(stats.getMinValue(), 10);
+    assertEquals(stats.getMaxValue(), 30);
+    assertEquals((int[]) stats.getUniqueValuesSet(), new int[]{10, 20, 30});
+    assertEquals(stats.getCardinality(), 3);
+    assertFalse(stats.isSorted());
   }
 
   // ======== Element length ========
@@ -607,7 +847,8 @@ public class CompactedColumnStatisticsTest {
             validDocIds);
 
     assertEquals(stats.getLengthOfShortestElement(), Integer.BYTES);
-    assertEquals(stats.getLengthOfLargestElement(), Integer.BYTES);
+    assertEquals(stats.getLengthOfLongestElement(), Integer.BYTES);
+    assertTrue(stats.isFixedLength());
   }
 
   @Test
@@ -633,8 +874,9 @@ public class CompactedColumnStatisticsTest {
         new CompactedColumnStatistics(mockDataSource(forwardIndex, dictionary), null, false,
             validDocIds);
 
-    assertEquals(stats.getLengthOfShortestElement(), 2); // "hi"
-    assertEquals(stats.getLengthOfLargestElement(), 5);  // "hello"
+    assertEquals(stats.getLengthOfShortestElement(), 2);  // "hi"
+    assertEquals(stats.getLengthOfLongestElement(), 5);  // "hello"
+    assertFalse(stats.isFixedLength());
   }
 
   @Test
@@ -661,25 +903,91 @@ public class CompactedColumnStatisticsTest {
             validDocIds);
 
     assertEquals(stats.getLengthOfShortestElement(), 3);
-    assertEquals(stats.getLengthOfLargestElement(), 4);
+    assertEquals(stats.getLengthOfLongestElement(), 4);
+    assertFalse(stats.isFixedLength());
   }
 
+  // testElementLengthEmptyValidDocs removed -- empty case handled by EmptyColumnStatistics
+
+  // ======== isAscii ========
+
   @Test
-  public void testElementLengthEmptyValidDocs() {
-    // No valid docs → cardinality=0 → both element lengths must be 0
+  public void testIsAsciiStringAllAscii() {
     MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
     when(forwardIndex.isSingleValue()).thenReturn(true);
+    when(forwardIndex.getDictId(0)).thenReturn(0);
+    when(forwardIndex.getDictId(1)).thenReturn(1);
 
     Dictionary dictionary = mock(Dictionary.class);
     when(dictionary.getValueType()).thenReturn(DataType.STRING);
+    when(dictionary.getInternal(0)).thenReturn("hello");
+    when(dictionary.getInternal(1)).thenReturn("world");
+    when(dictionary.getStringValue(0)).thenReturn("hello");
+    when(dictionary.getStringValue(1)).thenReturn("world");
+    when(dictionary.compare(0, 1)).thenReturn(-1);
 
-    RoaringBitmap validDocIds = new RoaringBitmap();
+    RoaringBitmap validDocIds = RoaringBitmap.bitmapOf(0, 1);
     CompactedColumnStatistics stats =
-        new CompactedColumnStatistics(mockDataSource(forwardIndex, dictionary), null, false,
-            validDocIds);
+        new CompactedColumnStatistics(mockDataSource(forwardIndex, dictionary), null, false, validDocIds);
 
-    assertEquals(stats.getLengthOfShortestElement(), Integer.MAX_VALUE);
-    assertEquals(stats.getLengthOfLargestElement(), 0);
+    assertTrue(stats.isAscii());
+  }
+
+  @Test
+  public void testIsAsciiStringWithNonAscii() {
+    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
+    when(forwardIndex.isSingleValue()).thenReturn(true);
+    when(forwardIndex.getDictId(0)).thenReturn(0);
+    when(forwardIndex.getDictId(1)).thenReturn(1);
+
+    Dictionary dictionary = mock(Dictionary.class);
+    when(dictionary.getValueType()).thenReturn(DataType.STRING);
+    when(dictionary.getInternal(0)).thenReturn("hello");
+    when(dictionary.getInternal(1)).thenReturn("héllo");
+    when(dictionary.getStringValue(0)).thenReturn("hello");
+    when(dictionary.getStringValue(1)).thenReturn("héllo");
+    when(dictionary.compare(0, 1)).thenReturn(-1);
+
+    RoaringBitmap validDocIds = RoaringBitmap.bitmapOf(0, 1);
+    CompactedColumnStatistics stats =
+        new CompactedColumnStatistics(mockDataSource(forwardIndex, dictionary), null, false, validDocIds);
+
+    assertFalse(stats.isAscii());
+  }
+
+  @Test
+  public void testIsAsciiIntType() {
+    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
+    when(forwardIndex.isSingleValue()).thenReturn(true);
+    when(forwardIndex.getDictId(0)).thenReturn(0);
+
+    Dictionary dictionary = mockIntDictionary(new int[]{42});
+
+    RoaringBitmap validDocIds = RoaringBitmap.bitmapOf(0);
+    CompactedColumnStatistics stats =
+        new CompactedColumnStatistics(mockDataSource(forwardIndex, dictionary), null, false, validDocIds);
+
+    assertFalse(stats.isAscii());
+  }
+
+  @Test
+  public void testIsAsciiBytesType() {
+    ByteArray ba0 = new ByteArray(new byte[]{1, 2});
+
+    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
+    when(forwardIndex.isSingleValue()).thenReturn(true);
+    when(forwardIndex.getDictId(0)).thenReturn(0);
+
+    Dictionary dictionary = mock(Dictionary.class);
+    when(dictionary.getValueType()).thenReturn(DataType.BYTES);
+    when(dictionary.getInternal(0)).thenReturn(ba0);
+    when(dictionary.getByteArrayValue(0)).thenReturn(ba0);
+
+    RoaringBitmap validDocIds = RoaringBitmap.bitmapOf(0);
+    CompactedColumnStatistics stats =
+        new CompactedColumnStatistics(mockDataSource(forwardIndex, dictionary), null, false, validDocIds);
+
+    assertFalse(stats.isAscii());
   }
 
   // ======== Helpers ========
@@ -696,7 +1004,31 @@ public class CompactedColumnStatisticsTest {
   }
 
   private DataSource mockDataSource(MutableForwardIndex forwardIndex, Dictionary dictionary) {
+    DataType type = dictionary.getValueType();
+    boolean sv = forwardIndex.isSingleValue();
+    FieldSpec fieldSpec = new DimensionFieldSpec("col", type, sv);
+
+    DataSourceMetadata metadata = mock(DataSourceMetadata.class);
+    when(metadata.getFieldSpec()).thenReturn(fieldSpec);
+    when(metadata.getNumDocs()).thenReturn(1000); // arbitrary positive to satisfy precondition
+
     DataSource dataSource = mock(DataSource.class);
+    when(dataSource.getDataSourceMetadata()).thenReturn(metadata);
+    doReturn(forwardIndex).when(dataSource).getForwardIndex();
+    when(dataSource.getDictionary()).thenReturn(dictionary);
+    return dataSource;
+  }
+
+  private DataSource mockDataSource(MutableForwardIndex forwardIndex, Dictionary dictionary, DataType logicalType) {
+    boolean sv = forwardIndex.isSingleValue();
+    FieldSpec fieldSpec = new DimensionFieldSpec("col", logicalType, sv);
+
+    DataSourceMetadata metadata = mock(DataSourceMetadata.class);
+    when(metadata.getFieldSpec()).thenReturn(fieldSpec);
+    when(metadata.getNumDocs()).thenReturn(1000);
+
+    DataSource dataSource = mock(DataSource.class);
+    when(dataSource.getDataSourceMetadata()).thenReturn(metadata);
     doReturn(forwardIndex).when(dataSource).getForwardIndex();
     when(dataSource.getDictionary()).thenReturn(dictionary);
     return dataSource;

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/converter/stats/CompactedNoDictColumnStatisticsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/converter/stats/CompactedNoDictColumnStatisticsTest.java
@@ -20,19 +20,20 @@ package org.apache.pinot.segment.local.realtime.converter.stats;
 
 import java.math.BigDecimal;
 import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.segment.spi.datasource.DataSourceMetadata;
 import org.apache.pinot.segment.spi.index.mutable.MutableForwardIndex;
+import org.apache.pinot.spi.data.DimensionFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.ByteArray;
 import org.roaringbitmap.RoaringBitmap;
 import org.testng.annotations.Test;
 
-import static org.mockito.Answers.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 
@@ -57,8 +58,8 @@ public class CompactedNoDictColumnStatisticsTest {
 
     assertEquals(stats.getMinValue(), 10);
     assertEquals(stats.getMaxValue(), 30);
-    assertEquals(stats.getTotalNumberOfEntries(), 3);
     assertTrue(stats.isSorted());
+    assertEquals(stats.getTotalNumberOfEntries(), 3);
   }
 
   @Test
@@ -75,8 +76,8 @@ public class CompactedNoDictColumnStatisticsTest {
 
     assertEquals(stats.getMinValue(), 10);
     assertEquals(stats.getMaxValue(), 30);
-    assertEquals(stats.getTotalNumberOfEntries(), 3);
     assertFalse(stats.isSorted());
+    assertEquals(stats.getTotalNumberOfEntries(), 3);
   }
 
   @Test
@@ -94,8 +95,8 @@ public class CompactedNoDictColumnStatisticsTest {
 
     assertEquals(stats.getMinValue(), 10);
     assertEquals(stats.getMaxValue(), 30);
-    assertEquals(stats.getTotalNumberOfEntries(), 3);
     assertFalse(stats.isSorted());
+    assertEquals(stats.getTotalNumberOfEntries(), 3);
   }
 
   @Test
@@ -112,8 +113,8 @@ public class CompactedNoDictColumnStatisticsTest {
 
     assertEquals(stats.getMinValue(), 10);
     assertEquals(stats.getMaxValue(), 30);
-    assertEquals(stats.getTotalNumberOfEntries(), 3);
     assertTrue(stats.isSorted());
+    assertEquals(stats.getTotalNumberOfEntries(), 3);
   }
 
   @Test
@@ -146,10 +147,10 @@ public class CompactedNoDictColumnStatisticsTest {
     CompactedNoDictColumnStatistics stats =
         new CompactedNoDictColumnStatistics(mockDataSource(forwardIndex), new int[]{1, 3, 0, 2}, false, validDocIds);
 
-    assertEquals(stats.getTotalNumberOfEntries(), 3);
     assertEquals(stats.getMinValue(), 10);
     assertEquals(stats.getMaxValue(), 30);
     assertTrue(stats.isSorted());
+    assertEquals(stats.getTotalNumberOfEntries(), 3);
   }
 
   // ======== LONG SV ========
@@ -166,8 +167,8 @@ public class CompactedNoDictColumnStatisticsTest {
 
     assertEquals(stats.getMinValue(), 100L);
     assertEquals(stats.getMaxValue(), 200L);
-    assertEquals(stats.getTotalNumberOfEntries(), 2);
     assertTrue(stats.isSorted());
+    assertEquals(stats.getTotalNumberOfEntries(), 2);
   }
 
   @Test
@@ -183,8 +184,8 @@ public class CompactedNoDictColumnStatisticsTest {
 
     assertEquals(stats.getMinValue(), 100L);
     assertEquals(stats.getMaxValue(), 300L);
-    assertEquals(stats.getTotalNumberOfEntries(), 2);
     assertTrue(stats.isSorted()); // bitmap order: doc0=100, doc2=300 → ascending
+    assertEquals(stats.getTotalNumberOfEntries(), 2);
   }
 
   // ======== FLOAT SV ========
@@ -219,6 +220,41 @@ public class CompactedNoDictColumnStatisticsTest {
 
     assertEquals(stats.getMinValue(), 1.1);
     assertEquals(stats.getMaxValue(), 2.2);
+    assertTrue(stats.isSorted());
+  }
+
+  // ======== BOOLEAN SV ========
+
+  @Test
+  public void testBooleanSv() {
+    MutableForwardIndex forwardIndex = mockForwardIndex(DataType.INT, true);
+    when(forwardIndex.getInt(0)).thenReturn(0);
+    when(forwardIndex.getInt(1)).thenReturn(1);
+
+    RoaringBitmap validDocIds = RoaringBitmap.bitmapOf(0, 1);
+    CompactedNoDictColumnStatistics stats =
+        new CompactedNoDictColumnStatistics(mockDataSource(forwardIndex, DataType.BOOLEAN), null, false, validDocIds);
+
+    assertEquals(stats.getMinValue(), 0);
+    assertEquals(stats.getMaxValue(), 1);
+    assertTrue(stats.isSorted());
+    assertEquals(stats.getTotalNumberOfEntries(), 2);
+  }
+
+  // ======== TIMESTAMP SV ========
+
+  @Test
+  public void testTimestampSv() {
+    MutableForwardIndex forwardIndex = mockForwardIndex(DataType.LONG, true);
+    when(forwardIndex.getLong(0)).thenReturn(1000L);
+    when(forwardIndex.getLong(1)).thenReturn(2000L);
+
+    RoaringBitmap validDocIds = RoaringBitmap.bitmapOf(0, 1);
+    CompactedNoDictColumnStatistics stats =
+        new CompactedNoDictColumnStatistics(mockDataSource(forwardIndex, DataType.TIMESTAMP), null, false, validDocIds);
+
+    assertEquals(stats.getMinValue(), 1000L);
+    assertEquals(stats.getMaxValue(), 2000L);
     assertTrue(stats.isSorted());
   }
 
@@ -274,7 +310,24 @@ public class CompactedNoDictColumnStatisticsTest {
 
     assertEquals(stats.getMinValue(), "apple");
     assertEquals(stats.getMaxValue(), "cherry");
+    assertTrue(stats.isSorted());
     assertEquals(stats.getTotalNumberOfEntries(), 3);
+  }
+
+  // ======== JSON SV ========
+
+  @Test
+  public void testJsonSv() {
+    MutableForwardIndex forwardIndex = mockForwardIndex(DataType.STRING, true);
+    when(forwardIndex.getString(0)).thenReturn("null");
+    when(forwardIndex.getString(1)).thenReturn("{\"a\":1}");
+
+    RoaringBitmap validDocIds = RoaringBitmap.bitmapOf(0, 1);
+    CompactedNoDictColumnStatistics stats =
+        new CompactedNoDictColumnStatistics(mockDataSource(forwardIndex, DataType.JSON), null, false, validDocIds);
+
+    assertEquals(stats.getMinValue(), "null");
+    assertEquals(stats.getMaxValue(), "{\"a\":1}");
     assertTrue(stats.isSorted());
   }
 
@@ -295,8 +348,8 @@ public class CompactedNoDictColumnStatisticsTest {
 
     assertEquals(stats.getMinValue(), new ByteArray(b0));
     assertEquals(stats.getMaxValue(), new ByteArray(b1));
-    assertEquals(stats.getTotalNumberOfEntries(), 2);
     assertTrue(stats.isSorted());
+    assertEquals(stats.getTotalNumberOfEntries(), 2);
   }
 
   @Test
@@ -315,8 +368,8 @@ public class CompactedNoDictColumnStatisticsTest {
 
     assertEquals(stats.getMinValue(), new ByteArray(b1));
     assertEquals(stats.getMaxValue(), new ByteArray(b0));
-    assertEquals(stats.getTotalNumberOfEntries(), 2);
     assertTrue(stats.isSorted());
+    assertEquals(stats.getTotalNumberOfEntries(), 2);
   }
 
   // ======== Multi-value ========
@@ -334,9 +387,9 @@ public class CompactedNoDictColumnStatisticsTest {
 
     assertEquals(stats.getMinValue(), 5);
     assertEquals(stats.getMaxValue(), 30);
+    assertFalse(stats.isSorted()); // MV with totalEntries > 1 → always false
     assertEquals(stats.getTotalNumberOfEntries(), 4);
     assertEquals(stats.getMaxNumberOfMultiValues(), 2);
-    assertFalse(stats.isSorted()); // MV with totalEntries > 1 → always false
   }
 
   @Test
@@ -352,9 +405,9 @@ public class CompactedNoDictColumnStatisticsTest {
 
     assertEquals(stats.getMinValue(), 5);
     assertEquals(stats.getMaxValue(), 30);
+    assertFalse(stats.isSorted()); // MV with totalEntries > 1 → always false
     assertEquals(stats.getTotalNumberOfEntries(), 5); // 2+3
     assertEquals(stats.getMaxNumberOfMultiValues(), 3);
-    assertFalse(stats.isSorted()); // MV with totalEntries > 1 → always false
   }
 
   @Test
@@ -370,9 +423,9 @@ public class CompactedNoDictColumnStatisticsTest {
 
     assertEquals(stats.getMinValue(), 100L);
     assertEquals(stats.getMaxValue(), 300L);
+    assertFalse(stats.isSorted());
     assertEquals(stats.getTotalNumberOfEntries(), 3);
     assertEquals(stats.getMaxNumberOfMultiValues(), 2);
-    assertFalse(stats.isSorted());
   }
 
   @Test
@@ -387,8 +440,8 @@ public class CompactedNoDictColumnStatisticsTest {
 
     assertEquals(stats.getMinValue(), 1.0f);
     assertEquals(stats.getMaxValue(), 3.0f);
-    assertEquals(stats.getTotalNumberOfEntries(), 3);
     assertFalse(stats.isSorted());
+    assertEquals(stats.getTotalNumberOfEntries(), 3);
   }
 
   @Test
@@ -403,8 +456,42 @@ public class CompactedNoDictColumnStatisticsTest {
 
     assertEquals(stats.getMinValue(), 1.5);
     assertEquals(stats.getMaxValue(), 4.5);
-    assertEquals(stats.getTotalNumberOfEntries(), 3);
     assertFalse(stats.isSorted());
+    assertEquals(stats.getTotalNumberOfEntries(), 3);
+  }
+
+  @Test
+  public void testBooleanMv() {
+    MutableForwardIndex forwardIndex = mockForwardIndex(DataType.INT, false);
+    when(forwardIndex.getIntMV(0)).thenReturn(new int[]{0, 1});
+    when(forwardIndex.getIntMV(1)).thenReturn(new int[]{0});
+
+    RoaringBitmap validDocIds = RoaringBitmap.bitmapOf(0, 1);
+    CompactedNoDictColumnStatistics stats =
+        new CompactedNoDictColumnStatistics(mockDataSource(forwardIndex, DataType.BOOLEAN), null, false, validDocIds);
+
+    assertEquals(stats.getMinValue(), 0);
+    assertEquals(stats.getMaxValue(), 1);
+    assertFalse(stats.isSorted());
+    assertEquals(stats.getTotalNumberOfEntries(), 3);
+    assertEquals(stats.getMaxNumberOfMultiValues(), 2);
+  }
+
+  @Test
+  public void testTimestampMv() {
+    MutableForwardIndex forwardIndex = mockForwardIndex(DataType.LONG, false);
+    when(forwardIndex.getLongMV(0)).thenReturn(new long[]{1000L, 2000L});
+    when(forwardIndex.getLongMV(1)).thenReturn(new long[]{3000L});
+
+    RoaringBitmap validDocIds = RoaringBitmap.bitmapOf(0, 1);
+    CompactedNoDictColumnStatistics stats =
+        new CompactedNoDictColumnStatistics(mockDataSource(forwardIndex, DataType.TIMESTAMP), null, false, validDocIds);
+
+    assertEquals(stats.getMinValue(), 1000L);
+    assertEquals(stats.getMaxValue(), 3000L);
+    assertFalse(stats.isSorted());
+    assertEquals(stats.getTotalNumberOfEntries(), 3);
+    assertEquals(stats.getMaxNumberOfMultiValues(), 2);
   }
 
   @Test
@@ -420,8 +507,25 @@ public class CompactedNoDictColumnStatisticsTest {
 
     assertEquals(stats.getMinValue(), "a");
     assertEquals(stats.getMaxValue(), "c");
-    assertEquals(stats.getTotalNumberOfEntries(), 3);
     assertFalse(stats.isSorted());
+    assertEquals(stats.getTotalNumberOfEntries(), 3);
+  }
+
+  @Test
+  public void testJsonMv() {
+    MutableForwardIndex forwardIndex = mockForwardIndex(DataType.STRING, false);
+    when(forwardIndex.getStringMV(0)).thenReturn(new String[]{"null", "[]"});
+    when(forwardIndex.getStringMV(1)).thenReturn(new String[]{"{}"});
+
+    RoaringBitmap validDocIds = RoaringBitmap.bitmapOf(0, 1);
+    CompactedNoDictColumnStatistics stats =
+        new CompactedNoDictColumnStatistics(mockDataSource(forwardIndex, DataType.JSON), null, false, validDocIds);
+
+    assertEquals(stats.getMinValue(), "[]");
+    assertEquals(stats.getMaxValue(), "{}");
+    assertFalse(stats.isSorted());
+    assertEquals(stats.getTotalNumberOfEntries(), 3);
+    assertEquals(stats.getMaxNumberOfMultiValues(), 2);
   }
 
   @Test
@@ -440,27 +544,14 @@ public class CompactedNoDictColumnStatisticsTest {
 
     assertEquals(stats.getMinValue(), new ByteArray(b0));
     assertEquals(stats.getMaxValue(), new ByteArray(b1));
+    assertFalse(stats.isSorted());
     assertEquals(stats.getTotalNumberOfEntries(), 3);
     assertEquals(stats.getMaxNumberOfMultiValues(), 2);
-    assertFalse(stats.isSorted());
   }
+
+  // Empty validDocIds cases are now handled by EmptyColumnStatistics via RealtimeSegmentStatsContainer
 
   // ======== Edge cases ========
-
-  @Test
-  public void testEmptyValidDocs() {
-    // RoaringBitmap is empty — no entries, min/max remain null, isSorted=true (totalEntries <= 1)
-    MutableForwardIndex forwardIndex = mockForwardIndex(DataType.INT, true);
-
-    RoaringBitmap validDocIds = new RoaringBitmap();
-    CompactedNoDictColumnStatistics stats =
-        new CompactedNoDictColumnStatistics(mockDataSource(forwardIndex), null, false, validDocIds);
-
-    assertNull(stats.getMinValue());
-    assertNull(stats.getMaxValue());
-    assertEquals(stats.getTotalNumberOfEntries(), 0);
-    assertTrue(stats.isSorted()); // totalEntries <= 1
-  }
 
   @Test
   public void testSingleValidDoc() {
@@ -474,8 +565,8 @@ public class CompactedNoDictColumnStatisticsTest {
 
     assertEquals(stats.getMinValue(), 42);
     assertEquals(stats.getMaxValue(), 42);
-    assertEquals(stats.getTotalNumberOfEntries(), 1);
     assertTrue(stats.isSorted()); // totalEntries <= 1
+    assertEquals(stats.getTotalNumberOfEntries(), 1);
   }
 
   @Test
@@ -492,18 +583,7 @@ public class CompactedNoDictColumnStatisticsTest {
     assertTrue(stats.isSorted()); // isSortedColumn=true overrides scan result
   }
 
-  @Test
-  public void testMvWithEmptyValidDocsSorted() {
-    // MV column but zero valid docs → totalEntries=0 → isSorted=true (totalEntries <= 1)
-    MutableForwardIndex forwardIndex = mockForwardIndex(DataType.STRING, false);
-
-    RoaringBitmap validDocIds = new RoaringBitmap();
-    CompactedNoDictColumnStatistics stats =
-        new CompactedNoDictColumnStatistics(mockDataSource(forwardIndex), null, false, validDocIds);
-
-    assertEquals(stats.getTotalNumberOfEntries(), 0);
-    assertFalse(stats.isSorted());
-  }
+  // testMvWithEmptyValidDocsSorted removed — empty case handled by EmptyColumnStatistics
 
   // ======== Element length ========
 
@@ -519,7 +599,8 @@ public class CompactedNoDictColumnStatisticsTest {
         new CompactedNoDictColumnStatistics(mockDataSource(forwardIndex), null, false, validDocIds);
 
     assertEquals(stats.getLengthOfShortestElement(), Integer.BYTES);
-    assertEquals(stats.getLengthOfLargestElement(), Integer.BYTES);
+    assertEquals(stats.getLengthOfLongestElement(), Integer.BYTES);
+    assertTrue(stats.isFixedLength());
   }
 
   @Test
@@ -534,8 +615,9 @@ public class CompactedNoDictColumnStatisticsTest {
     CompactedNoDictColumnStatistics stats =
         new CompactedNoDictColumnStatistics(mockDataSource(forwardIndex), null, false, validDocIds);
 
-    assertEquals(stats.getLengthOfShortestElement(), 2); // "hi"
-    assertEquals(stats.getLengthOfLargestElement(), 5);  // "hello"
+    assertEquals(stats.getLengthOfShortestElement(), 2);
+    assertEquals(stats.getLengthOfLongestElement(), 5);  // "hello"
+    assertFalse(stats.isFixedLength());
   }
 
   @Test
@@ -549,7 +631,8 @@ public class CompactedNoDictColumnStatisticsTest {
         new CompactedNoDictColumnStatistics(mockDataSource(forwardIndex), null, false, validDocIds);
 
     assertEquals(stats.getLengthOfShortestElement(), 3);
-    assertEquals(stats.getLengthOfLargestElement(), 4);
+    assertEquals(stats.getLengthOfLongestElement(), 4);
+    assertFalse(stats.isFixedLength());
   }
 
   @Test
@@ -563,8 +646,9 @@ public class CompactedNoDictColumnStatisticsTest {
     CompactedNoDictColumnStatistics stats =
         new CompactedNoDictColumnStatistics(mockDataSource(forwardIndex), null, false, validDocIds);
 
-    assertEquals(stats.getLengthOfShortestElement(), 2); // "hi"
-    assertEquals(stats.getLengthOfLargestElement(), 5);  // "hello"
+    assertEquals(stats.getLengthOfShortestElement(), 2);
+    assertEquals(stats.getLengthOfLongestElement(), 5);  // "hello"
+    assertFalse(stats.isFixedLength());
   }
 
   @Test
@@ -578,21 +662,11 @@ public class CompactedNoDictColumnStatisticsTest {
         new CompactedNoDictColumnStatistics(mockDataSource(forwardIndex), null, false, validDocIds);
 
     assertEquals(stats.getLengthOfShortestElement(), 2);
-    assertEquals(stats.getLengthOfLargestElement(), 4);
+    assertEquals(stats.getLengthOfLongestElement(), 4);
+    assertFalse(stats.isFixedLength());
   }
 
-  @Test
-  public void testElementLengthEmptyValidDocs() {
-    // No valid docs → variable-width element lengths must be 0
-    MutableForwardIndex forwardIndex = mockForwardIndex(DataType.STRING, true);
-
-    RoaringBitmap validDocIds = new RoaringBitmap();
-    CompactedNoDictColumnStatistics stats =
-        new CompactedNoDictColumnStatistics(mockDataSource(forwardIndex), null, false, validDocIds);
-
-    assertEquals(stats.getLengthOfShortestElement(), Integer.MAX_VALUE);
-    assertEquals(stats.getLengthOfLargestElement(), 0);
-  }
+  // testElementLengthEmptyValidDocs removed — empty case handled by EmptyColumnStatistics
 
   @Test
   public void testElementLengthStringPartialValidDocs() {
@@ -605,8 +679,62 @@ public class CompactedNoDictColumnStatisticsTest {
     CompactedNoDictColumnStatistics stats =
         new CompactedNoDictColumnStatistics(mockDataSource(forwardIndex), null, false, validDocIds);
 
-    assertEquals(stats.getLengthOfShortestElement(), 5); // "short"
-    assertEquals(stats.getLengthOfLargestElement(), 8);  // "medium__"
+    assertEquals(stats.getLengthOfShortestElement(), 5);
+    assertEquals(stats.getLengthOfLongestElement(), 8);  // "medium__"
+    assertFalse(stats.isFixedLength());
+  }
+
+  // ======== isAscii ========
+
+  @Test
+  public void testIsAsciiStringAllAscii() {
+    MutableForwardIndex forwardIndex = mockForwardIndex(DataType.STRING, true);
+    when(forwardIndex.getString(0)).thenReturn("hello");
+    when(forwardIndex.getString(1)).thenReturn("world");
+
+    RoaringBitmap validDocIds = RoaringBitmap.bitmapOf(0, 1);
+    CompactedNoDictColumnStatistics stats =
+        new CompactedNoDictColumnStatistics(mockDataSource(forwardIndex), null, false, validDocIds);
+
+    assertTrue(stats.isAscii());
+  }
+
+  @Test
+  public void testIsAsciiStringWithNonAscii() {
+    MutableForwardIndex forwardIndex = mockForwardIndex(DataType.STRING, true);
+    when(forwardIndex.getString(0)).thenReturn("hello");
+    when(forwardIndex.getString(1)).thenReturn("héllo");
+
+    RoaringBitmap validDocIds = RoaringBitmap.bitmapOf(0, 1);
+    CompactedNoDictColumnStatistics stats =
+        new CompactedNoDictColumnStatistics(mockDataSource(forwardIndex), null, false, validDocIds);
+
+    assertFalse(stats.isAscii());
+  }
+
+  @Test
+  public void testIsAsciiStringMvWithNonAscii() {
+    MutableForwardIndex forwardIndex = mockForwardIndex(DataType.STRING, false);
+    when(forwardIndex.getStringMV(0)).thenReturn(new String[]{"hello", "café"});
+    when(forwardIndex.getStringMV(1)).thenReturn(new String[]{"world"});
+
+    RoaringBitmap validDocIds = RoaringBitmap.bitmapOf(0, 1);
+    CompactedNoDictColumnStatistics stats =
+        new CompactedNoDictColumnStatistics(mockDataSource(forwardIndex), null, false, validDocIds);
+
+    assertFalse(stats.isAscii());
+  }
+
+  @Test
+  public void testIsAsciiIntType() {
+    MutableForwardIndex forwardIndex = mockForwardIndex(DataType.INT, true);
+    when(forwardIndex.getInt(0)).thenReturn(42);
+
+    RoaringBitmap validDocIds = RoaringBitmap.bitmapOf(0);
+    CompactedNoDictColumnStatistics stats =
+        new CompactedNoDictColumnStatistics(mockDataSource(forwardIndex), null, false, validDocIds);
+
+    assertFalse(stats.isAscii());
   }
 
   // ======== Helper ========
@@ -619,7 +747,30 @@ public class CompactedNoDictColumnStatisticsTest {
   }
 
   private DataSource mockDataSource(MutableForwardIndex forwardIndex) {
-    DataSource dataSource = mock(DataSource.class, RETURNS_DEEP_STUBS);
+    DataType type = forwardIndex.getStoredType();
+    boolean sv = forwardIndex.isSingleValue();
+    FieldSpec fieldSpec = new DimensionFieldSpec("col", type, sv);
+
+    DataSourceMetadata metadata = mock(DataSourceMetadata.class);
+    when(metadata.getFieldSpec()).thenReturn(fieldSpec);
+    when(metadata.getNumDocs()).thenReturn(1000); // arbitrary positive to satisfy precondition
+
+    DataSource dataSource = mock(DataSource.class);
+    when(dataSource.getDataSourceMetadata()).thenReturn(metadata);
+    doReturn(forwardIndex).when(dataSource).getForwardIndex();
+    return dataSource;
+  }
+
+  private DataSource mockDataSource(MutableForwardIndex forwardIndex, DataType logicalType) {
+    boolean sv = forwardIndex.isSingleValue();
+    FieldSpec fieldSpec = new DimensionFieldSpec("col", logicalType, sv);
+
+    DataSourceMetadata metadata = mock(DataSourceMetadata.class);
+    when(metadata.getFieldSpec()).thenReturn(fieldSpec);
+    when(metadata.getNumDocs()).thenReturn(1000);
+
+    DataSource dataSource = mock(DataSource.class);
+    when(dataSource.getDataSourceMetadata()).thenReturn(metadata);
     doReturn(forwardIndex).when(dataSource).getForwardIndex();
     return dataSource;
   }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/converter/stats/MutableColumnStatisticsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/converter/stats/MutableColumnStatisticsTest.java
@@ -19,20 +19,718 @@
 package org.apache.pinot.segment.local.realtime.converter.stats;
 
 import com.google.common.base.Utf8;
+import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.segment.spi.datasource.DataSourceMetadata;
+import org.apache.pinot.segment.spi.index.mutable.MutableForwardIndex;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
+import org.apache.pinot.spi.data.DimensionFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.utils.BigDecimalUtils;
+import org.apache.pinot.spi.utils.ByteArray;
+import org.apache.pinot.spi.utils.Utf8Utils;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 
+/// Tests for [MutableColumnStatistics], covering all value types, SV/MV, sorted/unsorted,
+/// element lengths, and isAscii.
+@SuppressWarnings("rawtypes")
 public class MutableColumnStatisticsTest {
+
+  // ======== Fixed-width SV sorted ========
+
+  @DataProvider(name = "fixedWidthTypes")
+  public Object[][] fixedWidthTypes() {
+    return new Object[][]{{DataType.INT}, {DataType.LONG}, {DataType.FLOAT}, {DataType.DOUBLE}};
+  }
+
+  @Test(dataProvider = "fixedWidthTypes")
+  public void testFixedWidthSvSorted(DataType type) {
+    int numDocs = 3;
+    Comparable[] values = fixedWidthValues(type);
+
+    Dictionary dictionary = mock(Dictionary.class);
+    when(dictionary.getValueType()).thenReturn(type);
+    when(dictionary.length()).thenReturn(3);
+    when(dictionary.getMinVal()).thenReturn(values[0]);
+    when(dictionary.getMaxVal()).thenReturn(values[2]);
+    when(dictionary.getSortedValues()).thenReturn(values);
+    when(dictionary.compare(0, 1)).thenReturn(-1);
+    when(dictionary.compare(1, 2)).thenReturn(-1);
+
+    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
+    when(forwardIndex.isSingleValue()).thenReturn(true);
+    when(forwardIndex.getDictId(0)).thenReturn(0);
+    when(forwardIndex.getDictId(1)).thenReturn(1);
+    when(forwardIndex.getDictId(2)).thenReturn(2);
+
+    DataSourceMetadata metadata = mockMetadata(type, true, numDocs);
+    when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(0);
+    when(metadata.getMaxRowLengthInBytes()).thenReturn(type.size());
+
+    MutableColumnStatistics stats =
+        new MutableColumnStatistics(mockDataSource(metadata, forwardIndex, dictionary), null, false);
+
+    assertEquals(stats.getMinValue(), values[0]);
+    assertEquals(stats.getMaxValue(), values[2]);
+    assertNotNull(stats.getUniqueValuesSet());
+    assertEquals(stats.getCardinality(), 3);
+    assertEquals(stats.getLengthOfShortestElement(), type.size());
+    assertEquals(stats.getLengthOfLongestElement(), type.size());
+    assertTrue(stats.isFixedLength());
+    assertFalse(stats.isAscii());
+    assertTrue(stats.isSorted());
+    assertEquals(stats.getMaxNumberOfMultiValues(), 0);
+    assertEquals(stats.getMaxRowLengthInBytes(), type.size());
+  }
+
+  // ======== BigDecimal SV ========
+
+  @Test
+  public void testBigDecimalSv() {
+    BigDecimal v0 = new BigDecimal("10.5");
+    BigDecimal v1 = new BigDecimal("20.75");
+    int numDocs = 2;
+
+    Dictionary dictionary = mock(Dictionary.class);
+    when(dictionary.getValueType()).thenReturn(DataType.BIG_DECIMAL);
+    when(dictionary.length()).thenReturn(2);
+    when(dictionary.getMinVal()).thenReturn(v0);
+    when(dictionary.getMaxVal()).thenReturn(v1);
+    when(dictionary.compare(0, 1)).thenReturn(-1);
+    when(dictionary.getValueSize(0)).thenReturn(BigDecimalUtils.byteSize(v0));
+    when(dictionary.getValueSize(1)).thenReturn(BigDecimalUtils.byteSize(v1));
+
+    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
+    when(forwardIndex.isSingleValue()).thenReturn(true);
+    when(forwardIndex.getDictId(0)).thenReturn(0);
+    when(forwardIndex.getDictId(1)).thenReturn(1);
+
+    DataSourceMetadata metadata = mockMetadata(DataType.BIG_DECIMAL, true, numDocs);
+    when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(0);
+    when(metadata.getMaxRowLengthInBytes()).thenReturn(BigDecimalUtils.byteSize(v1));
+
+    MutableColumnStatistics stats =
+        new MutableColumnStatistics(mockDataSource(metadata, forwardIndex, dictionary), null, false);
+
+    assertEquals(stats.getMinValue(), v0);
+    assertEquals(stats.getMaxValue(), v1);
+    assertEquals(stats.getLengthOfShortestElement(), BigDecimalUtils.byteSize(v0));
+    assertEquals(stats.getLengthOfLongestElement(), BigDecimalUtils.byteSize(v1));
+    assertFalse(stats.isAscii());
+    assertTrue(stats.isSorted());
+  }
+
+  // ======== Boolean SV ========
+
+  @Test
+  public void testBooleanSvSorted() {
+    int numDocs = 2;
+
+    Dictionary dictionary = mock(Dictionary.class);
+    when(dictionary.getValueType()).thenReturn(DataType.INT);
+    when(dictionary.length()).thenReturn(2);
+    when(dictionary.getMinVal()).thenReturn(0);
+    when(dictionary.getMaxVal()).thenReturn(1);
+    when(dictionary.getSortedValues()).thenReturn(new Comparable[]{0, 1});
+    when(dictionary.compare(0, 1)).thenReturn(-1);
+
+    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
+    when(forwardIndex.isSingleValue()).thenReturn(true);
+    when(forwardIndex.getDictId(0)).thenReturn(0);
+    when(forwardIndex.getDictId(1)).thenReturn(1);
+
+    DataSourceMetadata metadata = mockMetadata(DataType.BOOLEAN, true, numDocs);
+    when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(0);
+    when(metadata.getMaxRowLengthInBytes()).thenReturn(Integer.BYTES);
+
+    MutableColumnStatistics stats =
+        new MutableColumnStatistics(mockDataSource(metadata, forwardIndex, dictionary), null, false);
+
+    assertEquals(stats.getMinValue(), 0);
+    assertEquals(stats.getMaxValue(), 1);
+    assertNotNull(stats.getUniqueValuesSet());
+    assertEquals(stats.getCardinality(), 2);
+    assertEquals(stats.getLengthOfShortestElement(), Integer.BYTES);
+    assertEquals(stats.getLengthOfLongestElement(), Integer.BYTES);
+    assertTrue(stats.isFixedLength());
+    assertFalse(stats.isAscii());
+    assertTrue(stats.isSorted());
+    assertEquals(stats.getMaxNumberOfMultiValues(), 0);
+    assertEquals(stats.getMaxRowLengthInBytes(), Integer.BYTES);
+  }
+
+  // ======== Timestamp SV ========
+
+  @Test
+  public void testTimestampSvSorted() {
+    int numDocs = 2;
+
+    Dictionary dictionary = mock(Dictionary.class);
+    when(dictionary.getValueType()).thenReturn(DataType.LONG);
+    when(dictionary.length()).thenReturn(2);
+    when(dictionary.getMinVal()).thenReturn(1000L);
+    when(dictionary.getMaxVal()).thenReturn(2000L);
+    when(dictionary.getSortedValues()).thenReturn(new Comparable[]{1000L, 2000L});
+    when(dictionary.compare(0, 1)).thenReturn(-1);
+
+    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
+    when(forwardIndex.isSingleValue()).thenReturn(true);
+    when(forwardIndex.getDictId(0)).thenReturn(0);
+    when(forwardIndex.getDictId(1)).thenReturn(1);
+
+    DataSourceMetadata metadata = mockMetadata(DataType.TIMESTAMP, true, numDocs);
+    when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(0);
+    when(metadata.getMaxRowLengthInBytes()).thenReturn(Long.BYTES);
+
+    MutableColumnStatistics stats =
+        new MutableColumnStatistics(mockDataSource(metadata, forwardIndex, dictionary), null, false);
+
+    assertEquals(stats.getMinValue(), 1000L);
+    assertEquals(stats.getMaxValue(), 2000L);
+    assertNotNull(stats.getUniqueValuesSet());
+    assertEquals(stats.getCardinality(), 2);
+    assertEquals(stats.getLengthOfShortestElement(), Long.BYTES);
+    assertEquals(stats.getLengthOfLongestElement(), Long.BYTES);
+    assertTrue(stats.isFixedLength());
+    assertFalse(stats.isAscii());
+    assertTrue(stats.isSorted());
+    assertEquals(stats.getMaxNumberOfMultiValues(), 0);
+    assertEquals(stats.getMaxRowLengthInBytes(), Long.BYTES);
+  }
+
+  // ======== String SV ========
+
+  @Test
+  public void testStringSvAscii() {
+    int numDocs = 2;
+    Dictionary dictionary = mock(Dictionary.class);
+    when(dictionary.getValueType()).thenReturn(DataType.STRING);
+    when(dictionary.length()).thenReturn(2);
+    when(dictionary.getMinVal()).thenReturn("apple");
+    when(dictionary.getMaxVal()).thenReturn("banana");
+    when(dictionary.getSortedValues()).thenReturn(new String[]{"apple", "banana"});
+    when(dictionary.compare(0, 1)).thenReturn(-1);
+    // For element length scanning: getBytesValue returns UTF-8 bytes, getValueSize returns byte length
+    when(dictionary.getBytesValue(0)).thenReturn("apple".getBytes(StandardCharsets.UTF_8));
+    when(dictionary.getBytesValue(1)).thenReturn("banana".getBytes(StandardCharsets.UTF_8));
+    when(dictionary.getValueSize(0)).thenReturn(5);
+    when(dictionary.getValueSize(1)).thenReturn(6);
+
+    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
+    when(forwardIndex.isSingleValue()).thenReturn(true);
+    when(forwardIndex.getDictId(0)).thenReturn(0);
+    when(forwardIndex.getDictId(1)).thenReturn(1);
+
+    DataSourceMetadata metadata = mockMetadata(DataType.STRING, true, numDocs);
+    when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(0);
+    when(metadata.getMaxRowLengthInBytes()).thenReturn(6);
+
+    MutableColumnStatistics stats =
+        new MutableColumnStatistics(mockDataSource(metadata, forwardIndex, dictionary), null, false);
+
+    assertEquals(stats.getMinValue(), "apple");
+    assertEquals(stats.getMaxValue(), "banana");
+    assertEquals(stats.getLengthOfShortestElement(), 5);
+    assertEquals(stats.getLengthOfLongestElement(), 6);
+    assertFalse(stats.isFixedLength());
+    assertTrue(stats.isAscii());
+    assertTrue(stats.isSorted());
+  }
+
+  @Test
+  public void testStringSvNonAscii() {
+    int numDocs = 2;
+    String nonAscii = "héllo";
+    byte[] nonAsciiBytes = nonAscii.getBytes(StandardCharsets.UTF_8);
+
+    Dictionary dictionary = mock(Dictionary.class);
+    when(dictionary.getValueType()).thenReturn(DataType.STRING);
+    when(dictionary.length()).thenReturn(2);
+    when(dictionary.getMinVal()).thenReturn("hello");
+    when(dictionary.getMaxVal()).thenReturn(nonAscii);
+    when(dictionary.compare(0, 1)).thenReturn(-1);
+    when(dictionary.getBytesValue(0)).thenReturn("hello".getBytes(StandardCharsets.UTF_8));
+    when(dictionary.getBytesValue(1)).thenReturn(nonAsciiBytes);
+    when(dictionary.getValueSize(0)).thenReturn(5);
+    when(dictionary.getValueSize(1)).thenReturn(nonAsciiBytes.length);
+
+    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
+    when(forwardIndex.isSingleValue()).thenReturn(true);
+    when(forwardIndex.getDictId(0)).thenReturn(0);
+    when(forwardIndex.getDictId(1)).thenReturn(1);
+
+    DataSourceMetadata metadata = mockMetadata(DataType.STRING, true, numDocs);
+    when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(0);
+    when(metadata.getMaxRowLengthInBytes()).thenReturn(nonAsciiBytes.length);
+
+    MutableColumnStatistics stats =
+        new MutableColumnStatistics(mockDataSource(metadata, forwardIndex, dictionary), null, false);
+
+    assertFalse(stats.isAscii());
+  }
+
+  // ======== JSON SV ========
+
+  @Test
+  public void testJsonSvSorted() {
+    int numDocs = 2;
+    String v0 = "null";
+    String v1 = "{\"a\":1}";
+
+    Dictionary dictionary = mock(Dictionary.class);
+    when(dictionary.getValueType()).thenReturn(DataType.STRING);
+    when(dictionary.length()).thenReturn(2);
+    when(dictionary.getMinVal()).thenReturn(v0);
+    when(dictionary.getMaxVal()).thenReturn(v1);
+    when(dictionary.getSortedValues()).thenReturn(new Comparable[]{v0, v1});
+    when(dictionary.compare(0, 1)).thenReturn(-1);
+    when(dictionary.getBytesValue(0)).thenReturn(v0.getBytes(StandardCharsets.UTF_8));
+    when(dictionary.getBytesValue(1)).thenReturn(v1.getBytes(StandardCharsets.UTF_8));
+    when(dictionary.getValueSize(0)).thenReturn(4);
+    when(dictionary.getValueSize(1)).thenReturn(7);
+
+    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
+    when(forwardIndex.isSingleValue()).thenReturn(true);
+    when(forwardIndex.getDictId(0)).thenReturn(0);
+    when(forwardIndex.getDictId(1)).thenReturn(1);
+
+    DataSourceMetadata metadata = mockMetadata(DataType.JSON, true, numDocs);
+    when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(0);
+    when(metadata.getMaxRowLengthInBytes()).thenReturn(7);
+
+    MutableColumnStatistics stats =
+        new MutableColumnStatistics(mockDataSource(metadata, forwardIndex, dictionary), null, false);
+
+    assertEquals(stats.getMinValue(), v0);
+    assertEquals(stats.getMaxValue(), v1);
+    assertEquals(stats.getLengthOfShortestElement(), 4);
+    assertEquals(stats.getLengthOfLongestElement(), 7);
+    assertFalse(stats.isFixedLength());
+    assertTrue(stats.isAscii());
+    assertTrue(stats.isSorted());
+  }
+
+  // ======== Bytes SV ========
+
+  @Test
+  public void testBytesSv() {
+    int numDocs = 2;
+    ByteArray ba0 = new ByteArray(new byte[]{1, 2});
+    ByteArray ba1 = new ByteArray(new byte[]{3, 4, 5});
+
+    Dictionary dictionary = mock(Dictionary.class);
+    when(dictionary.getValueType()).thenReturn(DataType.BYTES);
+    when(dictionary.length()).thenReturn(2);
+    when(dictionary.getMinVal()).thenReturn(ba0);
+    when(dictionary.getMaxVal()).thenReturn(ba1);
+    when(dictionary.compare(0, 1)).thenReturn(-1);
+    when(dictionary.getValueSize(0)).thenReturn(2);
+    when(dictionary.getValueSize(1)).thenReturn(3);
+
+    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
+    when(forwardIndex.isSingleValue()).thenReturn(true);
+    when(forwardIndex.getDictId(0)).thenReturn(0);
+    when(forwardIndex.getDictId(1)).thenReturn(1);
+
+    DataSourceMetadata metadata = mockMetadata(DataType.BYTES, true, numDocs);
+    when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(0);
+    when(metadata.getMaxRowLengthInBytes()).thenReturn(3);
+
+    MutableColumnStatistics stats =
+        new MutableColumnStatistics(mockDataSource(metadata, forwardIndex, dictionary), null, false);
+
+    assertEquals(stats.getMinValue(), ba0);
+    assertEquals(stats.getMaxValue(), ba1);
+    assertEquals(stats.getLengthOfShortestElement(), 2);
+    assertEquals(stats.getLengthOfLongestElement(), 3);
+    assertFalse(stats.isFixedLength());
+    assertFalse(stats.isAscii());
+    assertTrue(stats.isSorted());
+  }
+
+  // ======== Sorted / unsorted / sortedColumnFlag ========
+
+  @Test
+  public void testIntSvUnsorted() {
+    int numDocs = 3;
+    Dictionary dictionary = mock(Dictionary.class);
+    when(dictionary.getValueType()).thenReturn(DataType.INT);
+    when(dictionary.length()).thenReturn(3);
+    when(dictionary.getMinVal()).thenReturn(10);
+    when(dictionary.getMaxVal()).thenReturn(30);
+
+    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
+    when(forwardIndex.isSingleValue()).thenReturn(true);
+    // doc0→dictId2(30), doc1→dictId0(10), doc2→dictId1(20) — unsorted
+    when(forwardIndex.getDictId(0)).thenReturn(2);
+    when(forwardIndex.getDictId(1)).thenReturn(0);
+    when(forwardIndex.getDictId(2)).thenReturn(1);
+    when(dictionary.compare(2, 0)).thenReturn(1); // 30 > 10 — unsorted at doc1
+
+    DataSourceMetadata metadata = mockMetadata(DataType.INT, true, numDocs);
+    when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(0);
+    when(metadata.getMaxRowLengthInBytes()).thenReturn(Integer.BYTES);
+
+    MutableColumnStatistics stats =
+        new MutableColumnStatistics(mockDataSource(metadata, forwardIndex, dictionary), null, false);
+
+    assertFalse(stats.isSorted());
+  }
+
+  @Test
+  public void testIntSvSortedColumnFlag() {
+    int numDocs = 2;
+    Dictionary dictionary = mock(Dictionary.class);
+    when(dictionary.getValueType()).thenReturn(DataType.INT);
+    when(dictionary.length()).thenReturn(2);
+
+    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
+    when(forwardIndex.isSingleValue()).thenReturn(true);
+
+    DataSourceMetadata metadata = mockMetadata(DataType.INT, true, numDocs);
+    when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(0);
+    when(metadata.getMaxRowLengthInBytes()).thenReturn(Integer.BYTES);
+
+    MutableColumnStatistics stats =
+        new MutableColumnStatistics(mockDataSource(metadata, forwardIndex, dictionary), null, true);
+
+    assertTrue(stats.isSorted()); // isSortedColumn=true overrides scan
+  }
+
+  @Test
+  public void testIntSvSortedWithSortedDocIds() {
+    int numDocs = 3;
+    Dictionary dictionary = mock(Dictionary.class);
+    when(dictionary.getValueType()).thenReturn(DataType.INT);
+    when(dictionary.length()).thenReturn(3);
+    when(dictionary.getMinVal()).thenReturn(10);
+    when(dictionary.getMaxVal()).thenReturn(30);
+
+    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
+    when(forwardIndex.isSingleValue()).thenReturn(true);
+    // sortedDocIds=[2,0,1]: doc2→dictId0(10), doc0→dictId1(20), doc1→dictId2(30) → sorted
+    when(forwardIndex.getDictId(2)).thenReturn(0);
+    when(forwardIndex.getDictId(0)).thenReturn(1);
+    when(forwardIndex.getDictId(1)).thenReturn(2);
+    when(dictionary.compare(0, 1)).thenReturn(-1);
+    when(dictionary.compare(1, 2)).thenReturn(-1);
+
+    DataSourceMetadata metadata = mockMetadata(DataType.INT, true, numDocs);
+    when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(0);
+    when(metadata.getMaxRowLengthInBytes()).thenReturn(Integer.BYTES);
+
+    MutableColumnStatistics stats =
+        new MutableColumnStatistics(mockDataSource(metadata, forwardIndex, dictionary),
+            new int[]{2, 0, 1}, false);
+
+    assertTrue(stats.isSorted());
+  }
+
+  // ======== MV ========
+
+  @Test
+  public void testIntMv() {
+    int numDocs = 2;
+    Dictionary dictionary = mock(Dictionary.class);
+    when(dictionary.getValueType()).thenReturn(DataType.INT);
+    when(dictionary.length()).thenReturn(3);
+    when(dictionary.getMinVal()).thenReturn(10);
+    when(dictionary.getMaxVal()).thenReturn(30);
+
+    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
+    when(forwardIndex.isSingleValue()).thenReturn(false);
+
+    DataSourceMetadata metadata = mockMetadata(DataType.INT, false, numDocs);
+    when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(2);
+    when(metadata.getMaxRowLengthInBytes()).thenReturn(Integer.BYTES * 2);
+    when(metadata.getNumValues()).thenReturn(4);
+
+    MutableColumnStatistics stats =
+        new MutableColumnStatistics(mockDataSource(metadata, forwardIndex, dictionary), null, false);
+
+    assertFalse(stats.isSingleValue());
+    assertEquals(stats.getMinValue(), 10);
+    assertEquals(stats.getMaxValue(), 30);
+    assertEquals(stats.getCardinality(), 3);
+    assertEquals(stats.getLengthOfShortestElement(), Integer.BYTES);
+    assertEquals(stats.getLengthOfLongestElement(), Integer.BYTES);
+    assertTrue(stats.isFixedLength());
+    assertFalse(stats.isAscii());
+    assertFalse(stats.isSorted());
+    assertEquals(stats.getTotalNumberOfEntries(), 4);
+    assertEquals(stats.getMaxNumberOfMultiValues(), 2);
+  }
+
+  @Test
+  public void testLongMv() {
+    int numDocs = 2;
+    Dictionary dictionary = mock(Dictionary.class);
+    when(dictionary.getValueType()).thenReturn(DataType.LONG);
+    when(dictionary.length()).thenReturn(3);
+    when(dictionary.getMinVal()).thenReturn(100L);
+    when(dictionary.getMaxVal()).thenReturn(300L);
+
+    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
+    when(forwardIndex.isSingleValue()).thenReturn(false);
+
+    DataSourceMetadata metadata = mockMetadata(DataType.LONG, false, numDocs);
+    when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(2);
+    when(metadata.getMaxRowLengthInBytes()).thenReturn(Long.BYTES * 2);
+    when(metadata.getNumValues()).thenReturn(4);
+
+    MutableColumnStatistics stats =
+        new MutableColumnStatistics(mockDataSource(metadata, forwardIndex, dictionary), null, false);
+
+    assertFalse(stats.isSingleValue());
+    assertEquals(stats.getMinValue(), 100L);
+    assertEquals(stats.getMaxValue(), 300L);
+    assertEquals(stats.getCardinality(), 3);
+    assertEquals(stats.getLengthOfShortestElement(), Long.BYTES);
+    assertEquals(stats.getLengthOfLongestElement(), Long.BYTES);
+    assertTrue(stats.isFixedLength());
+    assertFalse(stats.isAscii());
+    assertFalse(stats.isSorted());
+    assertEquals(stats.getTotalNumberOfEntries(), 4);
+    assertEquals(stats.getMaxNumberOfMultiValues(), 2);
+  }
+
+  @Test
+  public void testFloatMv() {
+    int numDocs = 2;
+    Dictionary dictionary = mock(Dictionary.class);
+    when(dictionary.getValueType()).thenReturn(DataType.FLOAT);
+    when(dictionary.length()).thenReturn(3);
+    when(dictionary.getMinVal()).thenReturn(1.0f);
+    when(dictionary.getMaxVal()).thenReturn(3.0f);
+
+    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
+    when(forwardIndex.isSingleValue()).thenReturn(false);
+
+    DataSourceMetadata metadata = mockMetadata(DataType.FLOAT, false, numDocs);
+    when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(2);
+    when(metadata.getMaxRowLengthInBytes()).thenReturn(Float.BYTES * 2);
+    when(metadata.getNumValues()).thenReturn(4);
+
+    MutableColumnStatistics stats =
+        new MutableColumnStatistics(mockDataSource(metadata, forwardIndex, dictionary), null, false);
+
+    assertFalse(stats.isSingleValue());
+    assertEquals(stats.getMinValue(), 1.0f);
+    assertEquals(stats.getMaxValue(), 3.0f);
+    assertEquals(stats.getCardinality(), 3);
+    assertEquals(stats.getLengthOfShortestElement(), Float.BYTES);
+    assertEquals(stats.getLengthOfLongestElement(), Float.BYTES);
+    assertTrue(stats.isFixedLength());
+    assertFalse(stats.isAscii());
+    assertFalse(stats.isSorted());
+    assertEquals(stats.getTotalNumberOfEntries(), 4);
+    assertEquals(stats.getMaxNumberOfMultiValues(), 2);
+  }
+
+  @Test
+  public void testDoubleMv() {
+    int numDocs = 2;
+    Dictionary dictionary = mock(Dictionary.class);
+    when(dictionary.getValueType()).thenReturn(DataType.DOUBLE);
+    when(dictionary.length()).thenReturn(3);
+    when(dictionary.getMinVal()).thenReturn(1.0);
+    when(dictionary.getMaxVal()).thenReturn(3.0);
+
+    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
+    when(forwardIndex.isSingleValue()).thenReturn(false);
+
+    DataSourceMetadata metadata = mockMetadata(DataType.DOUBLE, false, numDocs);
+    when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(2);
+    when(metadata.getMaxRowLengthInBytes()).thenReturn(Double.BYTES * 2);
+    when(metadata.getNumValues()).thenReturn(4);
+
+    MutableColumnStatistics stats =
+        new MutableColumnStatistics(mockDataSource(metadata, forwardIndex, dictionary), null, false);
+
+    assertFalse(stats.isSingleValue());
+    assertEquals(stats.getMinValue(), 1.0);
+    assertEquals(stats.getMaxValue(), 3.0);
+    assertEquals(stats.getCardinality(), 3);
+    assertEquals(stats.getLengthOfShortestElement(), Double.BYTES);
+    assertEquals(stats.getLengthOfLongestElement(), Double.BYTES);
+    assertTrue(stats.isFixedLength());
+    assertFalse(stats.isAscii());
+    assertFalse(stats.isSorted());
+    assertEquals(stats.getTotalNumberOfEntries(), 4);
+    assertEquals(stats.getMaxNumberOfMultiValues(), 2);
+  }
+
+  @Test
+  public void testBooleanMv() {
+    int numDocs = 2;
+    Dictionary dictionary = mock(Dictionary.class);
+    when(dictionary.getValueType()).thenReturn(DataType.INT);
+    when(dictionary.length()).thenReturn(2);
+    when(dictionary.getMinVal()).thenReturn(0);
+    when(dictionary.getMaxVal()).thenReturn(1);
+
+    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
+    when(forwardIndex.isSingleValue()).thenReturn(false);
+
+    DataSourceMetadata metadata = mockMetadata(DataType.BOOLEAN, false, numDocs);
+    when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(2);
+    when(metadata.getMaxRowLengthInBytes()).thenReturn(Integer.BYTES * 2);
+    when(metadata.getNumValues()).thenReturn(3);
+
+    MutableColumnStatistics stats =
+        new MutableColumnStatistics(mockDataSource(metadata, forwardIndex, dictionary), null, false);
+
+    assertFalse(stats.isSingleValue());
+    assertEquals(stats.getMinValue(), 0);
+    assertEquals(stats.getMaxValue(), 1);
+    assertEquals(stats.getCardinality(), 2);
+    assertEquals(stats.getLengthOfShortestElement(), Integer.BYTES);
+    assertEquals(stats.getLengthOfLongestElement(), Integer.BYTES);
+    assertTrue(stats.isFixedLength());
+    assertFalse(stats.isAscii());
+    assertFalse(stats.isSorted());
+    assertEquals(stats.getTotalNumberOfEntries(), 3);
+    assertEquals(stats.getMaxNumberOfMultiValues(), 2);
+  }
+
+  @Test
+  public void testTimestampMv() {
+    int numDocs = 2;
+    Dictionary dictionary = mock(Dictionary.class);
+    when(dictionary.getValueType()).thenReturn(DataType.LONG);
+    when(dictionary.length()).thenReturn(2);
+    when(dictionary.getMinVal()).thenReturn(1000L);
+    when(dictionary.getMaxVal()).thenReturn(2000L);
+
+    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
+    when(forwardIndex.isSingleValue()).thenReturn(false);
+
+    DataSourceMetadata metadata = mockMetadata(DataType.TIMESTAMP, false, numDocs);
+    when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(2);
+    when(metadata.getMaxRowLengthInBytes()).thenReturn(Long.BYTES * 2);
+    when(metadata.getNumValues()).thenReturn(3);
+
+    MutableColumnStatistics stats =
+        new MutableColumnStatistics(mockDataSource(metadata, forwardIndex, dictionary), null, false);
+
+    assertFalse(stats.isSingleValue());
+    assertEquals(stats.getMinValue(), 1000L);
+    assertEquals(stats.getMaxValue(), 2000L);
+    assertEquals(stats.getCardinality(), 2);
+    assertEquals(stats.getLengthOfShortestElement(), Long.BYTES);
+    assertEquals(stats.getLengthOfLongestElement(), Long.BYTES);
+    assertTrue(stats.isFixedLength());
+    assertFalse(stats.isAscii());
+    assertFalse(stats.isSorted());
+    assertEquals(stats.getTotalNumberOfEntries(), 3);
+    assertEquals(stats.getMaxNumberOfMultiValues(), 2);
+  }
+
+  @Test
+  public void testStringMv() {
+    int numDocs = 2;
+    Dictionary dictionary = mock(Dictionary.class);
+    when(dictionary.getValueType()).thenReturn(DataType.STRING);
+    when(dictionary.length()).thenReturn(3);
+    when(dictionary.getMinVal()).thenReturn("a");
+    when(dictionary.getMaxVal()).thenReturn("c");
+    // All ASCII strings
+    when(dictionary.getBytesValue(0)).thenReturn("a".getBytes(StandardCharsets.UTF_8));
+    when(dictionary.getBytesValue(1)).thenReturn("bb".getBytes(StandardCharsets.UTF_8));
+    when(dictionary.getBytesValue(2)).thenReturn("c".getBytes(StandardCharsets.UTF_8));
+
+    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
+    when(forwardIndex.isSingleValue()).thenReturn(false);
+
+    DataSourceMetadata metadata = mockMetadata(DataType.STRING, false, numDocs);
+    when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(2);
+    when(metadata.getMaxRowLengthInBytes()).thenReturn(3);
+    when(metadata.getNumValues()).thenReturn(4);
+
+    MutableColumnStatistics stats =
+        new MutableColumnStatistics(mockDataSource(metadata, forwardIndex, dictionary), null, false);
+
+    assertFalse(stats.isSingleValue());
+    assertEquals(stats.getLengthOfShortestElement(), 1);
+    assertEquals(stats.getLengthOfLongestElement(), 2);
+    assertTrue(stats.isAscii());
+    assertFalse(stats.isSorted());
+  }
+
+  @Test
+  public void testJsonMv() {
+    int numDocs = 2;
+    Dictionary dictionary = mock(Dictionary.class);
+    when(dictionary.getValueType()).thenReturn(DataType.STRING);
+    when(dictionary.length()).thenReturn(3);
+    when(dictionary.getMinVal()).thenReturn("a");
+    when(dictionary.getMaxVal()).thenReturn("c");
+    when(dictionary.getBytesValue(0)).thenReturn("a".getBytes(StandardCharsets.UTF_8));
+    when(dictionary.getBytesValue(1)).thenReturn("bb".getBytes(StandardCharsets.UTF_8));
+    when(dictionary.getBytesValue(2)).thenReturn("c".getBytes(StandardCharsets.UTF_8));
+
+    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
+    when(forwardIndex.isSingleValue()).thenReturn(false);
+
+    DataSourceMetadata metadata = mockMetadata(DataType.JSON, false, numDocs);
+    when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(2);
+    when(metadata.getMaxRowLengthInBytes()).thenReturn(3);
+    when(metadata.getNumValues()).thenReturn(4);
+
+    MutableColumnStatistics stats =
+        new MutableColumnStatistics(mockDataSource(metadata, forwardIndex, dictionary), null, false);
+
+    assertFalse(stats.isSingleValue());
+    assertEquals(stats.getLengthOfShortestElement(), 1);
+    assertEquals(stats.getLengthOfLongestElement(), 2);
+    assertTrue(stats.isAscii());
+    assertFalse(stats.isSorted());
+  }
+
+  @Test
+  public void testBytesMv() {
+    int numDocs = 2;
+    Dictionary dictionary = mock(Dictionary.class);
+    when(dictionary.getValueType()).thenReturn(DataType.BYTES);
+    when(dictionary.length()).thenReturn(2);
+    when(dictionary.getMinVal()).thenReturn(new ByteArray(new byte[]{1, 2}));
+    when(dictionary.getMaxVal()).thenReturn(new ByteArray(new byte[]{3, 4, 5}));
+    when(dictionary.getValueSize(0)).thenReturn(2);
+    when(dictionary.getValueSize(1)).thenReturn(3);
+
+    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
+    when(forwardIndex.isSingleValue()).thenReturn(false);
+
+    DataSourceMetadata metadata = mockMetadata(DataType.BYTES, false, numDocs);
+    when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(2);
+    when(metadata.getMaxRowLengthInBytes()).thenReturn(3 * 2);
+    when(metadata.getNumValues()).thenReturn(4);
+
+    MutableColumnStatistics stats =
+        new MutableColumnStatistics(mockDataSource(metadata, forwardIndex, dictionary), null, false);
+
+    assertFalse(stats.isSingleValue());
+    assertEquals(stats.getLengthOfShortestElement(), 2);
+    assertEquals(stats.getLengthOfLongestElement(), 3);
+    assertFalse(stats.isAscii());
+    assertFalse(stats.isSorted());
+  }
+
+  // ======== Element length randomized (original test) ========
 
   @Test
   public void testElementLength() {
@@ -40,24 +738,68 @@ public class MutableColumnStatisticsTest {
     String[] elements = new String[numElements];
     int minElementLength = Integer.MAX_VALUE;
     int maxElementLength = 0;
+    RandomStringUtils gen = RandomStringUtils.secure();
     for (int i = 0; i < numElements; i++) {
-      String randomString = RandomStringUtils.random(100);
+      String randomString = gen.next(100);
       elements[i] = randomString;
-      int elementLength = randomString.getBytes(StandardCharsets.UTF_8).length;
+      int elementLength = Utf8.encodedLength(randomString);
       minElementLength = Math.min(minElementLength, elementLength);
       maxElementLength = Math.max(maxElementLength, elementLength);
     }
 
+    FieldSpec fieldSpec = new DimensionFieldSpec("col", DataType.STRING, true);
+    DataSourceMetadata metadata = mock(DataSourceMetadata.class);
+    when(metadata.getFieldSpec()).thenReturn(fieldSpec);
+    when(metadata.getNumDocs()).thenReturn(numElements);
+
     DataSource dataSource = mock(DataSource.class);
+    when(dataSource.getDataSourceMetadata()).thenReturn(metadata);
     Dictionary dictionary = mock(Dictionary.class);
     when(dataSource.getDictionary()).thenReturn(dictionary);
     when(dictionary.getValueType()).thenReturn(DataType.STRING);
     when(dictionary.length()).thenReturn(numElements);
     when(dictionary.getValueSize(anyInt())).thenAnswer(
         invocation -> Utf8.encodedLength(elements[(int) invocation.getArgument(0)]));
+    when(dictionary.getBytesValue(anyInt())).thenAnswer(
+        invocation -> Utf8Utils.encode(elements[(int) invocation.getArgument(0)]));
 
     MutableColumnStatistics columnStatistics = new MutableColumnStatistics(dataSource, null, false);
-    assertEquals(columnStatistics.getLengthOfShortestElement(), minElementLength);
-    assertEquals(columnStatistics.getLengthOfLargestElement(), maxElementLength);
+    assertEquals(columnStatistics.isFixedLength(), minElementLength == maxElementLength);
+    assertEquals(columnStatistics.getLengthOfLongestElement(), maxElementLength);
+  }
+
+  // ======== Helpers ========
+
+  private static DataSourceMetadata mockMetadata(DataType type, boolean sv, int numDocs) {
+    FieldSpec fieldSpec = new DimensionFieldSpec("col", type, sv);
+    DataSourceMetadata metadata = mock(DataSourceMetadata.class);
+    when(metadata.getFieldSpec()).thenReturn(fieldSpec);
+    when(metadata.getNumDocs()).thenReturn(numDocs);
+    when(metadata.getNumValues()).thenReturn(numDocs);
+    return metadata;
+  }
+
+  private static DataSource mockDataSource(DataSourceMetadata metadata, MutableForwardIndex forwardIndex,
+      Dictionary dictionary) {
+    DataSource ds = mock(DataSource.class);
+    when(ds.getDataSourceMetadata()).thenReturn(metadata);
+    when(ds.getDictionary()).thenReturn(dictionary);
+    doReturn(forwardIndex).when(ds).getForwardIndex();
+    return ds;
+  }
+
+  private static Comparable[] fixedWidthValues(DataType type) {
+    switch (type) {
+      case INT:
+        return new Comparable[]{10, 20, 30};
+      case LONG:
+        return new Comparable[]{100L, 200L, 300L};
+      case FLOAT:
+        return new Comparable[]{1.0f, 2.0f, 3.0f};
+      case DOUBLE:
+        return new Comparable[]{1.0, 2.0, 3.0};
+      default:
+        throw new IllegalArgumentException("Not a fixed-width type: " + type);
+    }
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/converter/stats/MutableNoDictColumnStatisticsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/converter/stats/MutableNoDictColumnStatisticsTest.java
@@ -1,0 +1,716 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.realtime.converter.stats;
+
+import com.google.common.base.Utf8;
+import java.math.BigDecimal;
+import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.segment.spi.datasource.DataSourceMetadata;
+import org.apache.pinot.segment.spi.index.mutable.MutableForwardIndex;
+import org.apache.pinot.spi.data.DimensionFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.utils.BigDecimalUtils;
+import org.apache.pinot.spi.utils.ByteArray;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.apache.pinot.segment.spi.Constants.UNKNOWN_CARDINALITY;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+
+/// Tests for [MutableNoDictColumnStatistics], covering all value types, SV/MV, sorted/unsorted,
+/// element lengths, and isAscii.
+@SuppressWarnings("rawtypes")
+public class MutableNoDictColumnStatisticsTest {
+
+  // ======== Fixed-width SV sorted ========
+
+  @DataProvider(name = "fixedWidthTypes")
+  public Object[][] fixedWidthTypes() {
+    return new Object[][]{{DataType.INT}, {DataType.LONG}, {DataType.FLOAT}, {DataType.DOUBLE}};
+  }
+
+  @Test(dataProvider = "fixedWidthTypes")
+  public void testFixedWidthSvSorted(DataType type) {
+    int numDocs = 3;
+    FieldSpec fieldSpec = new DimensionFieldSpec("col", type, true);
+    Comparable[] values = fixedWidthValues(type);
+
+    DataSourceMetadata metadata = mockMetadata(fieldSpec, numDocs);
+    when(metadata.getMinValue()).thenReturn(values[0]);
+    when(metadata.getMaxValue()).thenReturn(values[2]);
+    when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(0);
+    when(metadata.getMaxRowLengthInBytes()).thenReturn(type.size());
+
+    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
+    when(forwardIndex.isSingleValue()).thenReturn(true);
+    when(forwardIndex.getLengthOfShortestElement()).thenReturn(type.size());
+    when(forwardIndex.getLengthOfLongestElement()).thenReturn(type.size());
+    when(forwardIndex.isAscii()).thenReturn(false);
+    stubForwardIndexReads(forwardIndex, type, values);
+
+    MutableNoDictColumnStatistics stats =
+        new MutableNoDictColumnStatistics(mockNoDictDataSource(metadata, forwardIndex), null, false);
+
+    assertEquals(stats.getMinValue(), values[0]);
+    assertEquals(stats.getMaxValue(), values[2]);
+    assertNull(stats.getUniqueValuesSet());
+    assertEquals(stats.getCardinality(), UNKNOWN_CARDINALITY);
+    assertEquals(stats.getLengthOfShortestElement(), type.size());
+    assertEquals(stats.getLengthOfLongestElement(), type.size());
+    assertTrue(stats.isFixedLength());
+    assertFalse(stats.isAscii());
+    assertTrue(stats.isSorted());
+    assertEquals(stats.getTotalNumberOfEntries(), numDocs);
+    assertEquals(stats.getMaxNumberOfMultiValues(), 0);
+    assertEquals(stats.getMaxRowLengthInBytes(), type.size());
+  }
+
+  // ======== BigDecimal SV ========
+
+  @Test
+  public void testBigDecimalSv() {
+    BigDecimal v0 = new BigDecimal("10.5");
+    BigDecimal v1 = new BigDecimal("20.75");
+    int numDocs = 2;
+    FieldSpec fieldSpec = new DimensionFieldSpec("col", DataType.BIG_DECIMAL, true);
+
+    DataSourceMetadata metadata = mockMetadata(fieldSpec, numDocs);
+    when(metadata.getMinValue()).thenReturn(v0);
+    when(metadata.getMaxValue()).thenReturn(v1);
+    when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(0);
+    when(metadata.getMaxRowLengthInBytes()).thenReturn(BigDecimalUtils.byteSize(v1));
+
+    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
+    when(forwardIndex.isSingleValue()).thenReturn(true);
+    when(forwardIndex.getLengthOfShortestElement()).thenReturn(BigDecimalUtils.byteSize(v0));
+    when(forwardIndex.getLengthOfLongestElement()).thenReturn(BigDecimalUtils.byteSize(v1));
+    when(forwardIndex.isAscii()).thenReturn(false);
+    when(forwardIndex.getBigDecimal(0)).thenReturn(v0);
+    when(forwardIndex.getBigDecimal(1)).thenReturn(v1);
+
+    MutableNoDictColumnStatistics stats =
+        new MutableNoDictColumnStatistics(mockNoDictDataSource(metadata, forwardIndex), null, false);
+
+    assertEquals(stats.getMinValue(), v0);
+    assertEquals(stats.getMaxValue(), v1);
+    assertNull(stats.getUniqueValuesSet());
+    assertEquals(stats.getCardinality(), UNKNOWN_CARDINALITY);
+    assertEquals(stats.getLengthOfShortestElement(), BigDecimalUtils.byteSize(v0));
+    assertEquals(stats.getLengthOfLongestElement(), BigDecimalUtils.byteSize(v1));
+    assertFalse(stats.isAscii());
+    assertTrue(stats.isSorted());
+  }
+
+  // ======== Boolean SV ========
+
+  @Test
+  public void testBooleanSvSorted() {
+    int numDocs = 2;
+    FieldSpec fieldSpec = new DimensionFieldSpec("col", DataType.BOOLEAN, true);
+
+    DataSourceMetadata metadata = mockMetadata(fieldSpec, numDocs);
+    when(metadata.getMinValue()).thenReturn(0);
+    when(metadata.getMaxValue()).thenReturn(1);
+    when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(0);
+    when(metadata.getMaxRowLengthInBytes()).thenReturn(Integer.BYTES);
+
+    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
+    when(forwardIndex.isSingleValue()).thenReturn(true);
+    when(forwardIndex.getInt(0)).thenReturn(0);
+    when(forwardIndex.getInt(1)).thenReturn(1);
+    when(forwardIndex.getLengthOfShortestElement()).thenReturn(Integer.BYTES);
+    when(forwardIndex.getLengthOfLongestElement()).thenReturn(Integer.BYTES);
+    when(forwardIndex.isAscii()).thenReturn(false);
+
+    MutableNoDictColumnStatistics stats =
+        new MutableNoDictColumnStatistics(mockNoDictDataSource(metadata, forwardIndex), null, false);
+
+    assertEquals(stats.getMinValue(), 0);
+    assertEquals(stats.getMaxValue(), 1);
+    assertNull(stats.getUniqueValuesSet());
+    assertEquals(stats.getCardinality(), UNKNOWN_CARDINALITY);
+    assertEquals(stats.getLengthOfShortestElement(), Integer.BYTES);
+    assertEquals(stats.getLengthOfLongestElement(), Integer.BYTES);
+    assertTrue(stats.isFixedLength());
+    assertFalse(stats.isAscii());
+    assertTrue(stats.isSorted());
+    assertEquals(stats.getTotalNumberOfEntries(), numDocs);
+    assertEquals(stats.getMaxNumberOfMultiValues(), 0);
+    assertEquals(stats.getMaxRowLengthInBytes(), Integer.BYTES);
+  }
+
+  // ======== Timestamp SV ========
+
+  @Test
+  public void testTimestampSvSorted() {
+    int numDocs = 2;
+    FieldSpec fieldSpec = new DimensionFieldSpec("col", DataType.TIMESTAMP, true);
+
+    DataSourceMetadata metadata = mockMetadata(fieldSpec, numDocs);
+    when(metadata.getMinValue()).thenReturn(1000L);
+    when(metadata.getMaxValue()).thenReturn(2000L);
+    when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(0);
+    when(metadata.getMaxRowLengthInBytes()).thenReturn(Long.BYTES);
+
+    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
+    when(forwardIndex.isSingleValue()).thenReturn(true);
+    when(forwardIndex.getLong(0)).thenReturn(1000L);
+    when(forwardIndex.getLong(1)).thenReturn(2000L);
+    when(forwardIndex.getLengthOfShortestElement()).thenReturn(Long.BYTES);
+    when(forwardIndex.getLengthOfLongestElement()).thenReturn(Long.BYTES);
+    when(forwardIndex.isAscii()).thenReturn(false);
+
+    MutableNoDictColumnStatistics stats =
+        new MutableNoDictColumnStatistics(mockNoDictDataSource(metadata, forwardIndex), null, false);
+
+    assertEquals(stats.getMinValue(), 1000L);
+    assertEquals(stats.getMaxValue(), 2000L);
+    assertNull(stats.getUniqueValuesSet());
+    assertEquals(stats.getCardinality(), UNKNOWN_CARDINALITY);
+    assertEquals(stats.getLengthOfShortestElement(), Long.BYTES);
+    assertEquals(stats.getLengthOfLongestElement(), Long.BYTES);
+    assertTrue(stats.isFixedLength());
+    assertFalse(stats.isAscii());
+    assertTrue(stats.isSorted());
+    assertEquals(stats.getTotalNumberOfEntries(), numDocs);
+    assertEquals(stats.getMaxNumberOfMultiValues(), 0);
+    assertEquals(stats.getMaxRowLengthInBytes(), Long.BYTES);
+  }
+
+  // ======== String SV ========
+
+  @Test
+  public void testStringSvAscii() {
+    int numDocs = 2;
+    FieldSpec fieldSpec = new DimensionFieldSpec("col", DataType.STRING, true);
+
+    DataSourceMetadata metadata = mockMetadata(fieldSpec, numDocs);
+    when(metadata.getMinValue()).thenReturn("apple");
+    when(metadata.getMaxValue()).thenReturn("banana");
+    when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(0);
+    when(metadata.getMaxRowLengthInBytes()).thenReturn(6);
+
+    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
+    when(forwardIndex.isSingleValue()).thenReturn(true);
+    when(forwardIndex.getLengthOfShortestElement()).thenReturn(5);
+    when(forwardIndex.getLengthOfLongestElement()).thenReturn(6);
+    when(forwardIndex.isAscii()).thenReturn(true);
+    when(forwardIndex.getString(0)).thenReturn("apple");
+    when(forwardIndex.getString(1)).thenReturn("banana");
+
+    MutableNoDictColumnStatistics stats =
+        new MutableNoDictColumnStatistics(mockNoDictDataSource(metadata, forwardIndex), null, false);
+
+    assertEquals(stats.getMinValue(), "apple");
+    assertEquals(stats.getMaxValue(), "banana");
+    assertEquals(stats.getLengthOfShortestElement(), 5);
+    assertEquals(stats.getLengthOfLongestElement(), 6);
+    assertFalse(stats.isFixedLength());
+    assertTrue(stats.isAscii());
+    assertTrue(stats.isSorted());
+  }
+
+  @Test
+  public void testStringSvNonAscii() {
+    int numDocs = 2;
+    FieldSpec fieldSpec = new DimensionFieldSpec("col", DataType.STRING, true);
+
+    DataSourceMetadata metadata = mockMetadata(fieldSpec, numDocs);
+    when(metadata.getMinValue()).thenReturn("hello");
+    when(metadata.getMaxValue()).thenReturn("héllo");
+    when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(0);
+    when(metadata.getMaxRowLengthInBytes()).thenReturn(Utf8.encodedLength("héllo"));
+
+    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
+    when(forwardIndex.isSingleValue()).thenReturn(true);
+    when(forwardIndex.getLengthOfShortestElement()).thenReturn(5);
+    when(forwardIndex.getLengthOfLongestElement()).thenReturn(Utf8.encodedLength("héllo"));
+    when(forwardIndex.isAscii()).thenReturn(false);
+    when(forwardIndex.getString(0)).thenReturn("hello");
+    when(forwardIndex.getString(1)).thenReturn("héllo");
+
+    MutableNoDictColumnStatistics stats =
+        new MutableNoDictColumnStatistics(mockNoDictDataSource(metadata, forwardIndex), null, false);
+
+    assertFalse(stats.isAscii());
+  }
+
+  // ======== JSON SV ========
+
+  @Test
+  public void testJsonSvSorted() {
+    int numDocs = 2;
+    FieldSpec fieldSpec = new DimensionFieldSpec("col", DataType.JSON, true);
+
+    DataSourceMetadata metadata = mockMetadata(fieldSpec, numDocs);
+    when(metadata.getMinValue()).thenReturn("null");
+    when(metadata.getMaxValue()).thenReturn("{\"a\":1}");
+    when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(0);
+    when(metadata.getMaxRowLengthInBytes()).thenReturn(7);
+
+    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
+    when(forwardIndex.isSingleValue()).thenReturn(true);
+    when(forwardIndex.getLengthOfShortestElement()).thenReturn(4);
+    when(forwardIndex.getLengthOfLongestElement()).thenReturn(7);
+    when(forwardIndex.isAscii()).thenReturn(true);
+    when(forwardIndex.getString(0)).thenReturn("null");
+    when(forwardIndex.getString(1)).thenReturn("{\"a\":1}");
+
+    MutableNoDictColumnStatistics stats =
+        new MutableNoDictColumnStatistics(mockNoDictDataSource(metadata, forwardIndex), null, false);
+
+    assertEquals(stats.getMinValue(), "null");
+    assertEquals(stats.getMaxValue(), "{\"a\":1}");
+    assertNull(stats.getUniqueValuesSet());
+    assertEquals(stats.getCardinality(), UNKNOWN_CARDINALITY);
+    assertEquals(stats.getLengthOfShortestElement(), 4);
+    assertEquals(stats.getLengthOfLongestElement(), 7);
+    assertFalse(stats.isFixedLength());
+    assertTrue(stats.isAscii());
+    assertTrue(stats.isSorted());
+  }
+
+  // ======== Bytes SV ========
+
+  @Test
+  public void testBytesSv() {
+    byte[] b0 = new byte[]{1, 2};
+    byte[] b1 = new byte[]{3, 4, 5};
+    int numDocs = 2;
+    FieldSpec fieldSpec = new DimensionFieldSpec("col", DataType.BYTES, true);
+
+    DataSourceMetadata metadata = mockMetadata(fieldSpec, numDocs);
+    when(metadata.getMinValue()).thenReturn(new ByteArray(b0));
+    when(metadata.getMaxValue()).thenReturn(new ByteArray(b1));
+    when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(0);
+    when(metadata.getMaxRowLengthInBytes()).thenReturn(3);
+
+    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
+    when(forwardIndex.isSingleValue()).thenReturn(true);
+    when(forwardIndex.getLengthOfShortestElement()).thenReturn(2);
+    when(forwardIndex.getLengthOfLongestElement()).thenReturn(3);
+    when(forwardIndex.isAscii()).thenReturn(false);
+    when(forwardIndex.getBytes(0)).thenReturn(b0);
+    when(forwardIndex.getBytes(1)).thenReturn(b1);
+
+    MutableNoDictColumnStatistics stats =
+        new MutableNoDictColumnStatistics(mockNoDictDataSource(metadata, forwardIndex), null, false);
+
+    assertEquals(stats.getMinValue(), new ByteArray(b0));
+    assertEquals(stats.getMaxValue(), new ByteArray(b1));
+    assertEquals(stats.getLengthOfShortestElement(), 2);
+    assertEquals(stats.getLengthOfLongestElement(), 3);
+    assertFalse(stats.isFixedLength());
+    assertFalse(stats.isAscii());
+    assertTrue(stats.isSorted());
+  }
+
+  // ======== Sorted / unsorted / sortedColumnFlag ========
+
+  @Test
+  public void testIntSvUnsorted() {
+    int numDocs = 3;
+    FieldSpec fieldSpec = new DimensionFieldSpec("col", DataType.INT, true);
+
+    DataSourceMetadata metadata = mockMetadata(fieldSpec, numDocs);
+    when(metadata.getMinValue()).thenReturn(10);
+    when(metadata.getMaxValue()).thenReturn(30);
+    when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(0);
+    when(metadata.getMaxRowLengthInBytes()).thenReturn(Integer.BYTES);
+
+    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
+    when(forwardIndex.isSingleValue()).thenReturn(true);
+    when(forwardIndex.getLengthOfShortestElement()).thenReturn(Integer.BYTES);
+    when(forwardIndex.getLengthOfLongestElement()).thenReturn(Integer.BYTES);
+    when(forwardIndex.isAscii()).thenReturn(false);
+    when(forwardIndex.getInt(0)).thenReturn(30);
+    when(forwardIndex.getInt(1)).thenReturn(10);
+    when(forwardIndex.getInt(2)).thenReturn(20);
+
+    MutableNoDictColumnStatistics stats =
+        new MutableNoDictColumnStatistics(mockNoDictDataSource(metadata, forwardIndex), null, false);
+
+    assertFalse(stats.isSorted());
+  }
+
+  @Test
+  public void testIntSvSortedColumnFlag() {
+    int numDocs = 2;
+    FieldSpec fieldSpec = new DimensionFieldSpec("col", DataType.INT, true);
+
+    DataSourceMetadata metadata = mockMetadata(fieldSpec, numDocs);
+    when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(0);
+    when(metadata.getMaxRowLengthInBytes()).thenReturn(Integer.BYTES);
+
+    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
+    when(forwardIndex.isSingleValue()).thenReturn(true);
+    when(forwardIndex.getLengthOfShortestElement()).thenReturn(Integer.BYTES);
+    when(forwardIndex.getLengthOfLongestElement()).thenReturn(Integer.BYTES);
+    when(forwardIndex.isAscii()).thenReturn(false);
+
+    MutableNoDictColumnStatistics stats =
+        new MutableNoDictColumnStatistics(mockNoDictDataSource(metadata, forwardIndex), null, true);
+
+    assertTrue(stats.isSorted()); // isSortedColumn=true overrides scan
+  }
+
+  // ======== MV ========
+
+  @Test
+  public void testIntMv() {
+    int numDocs = 2;
+    FieldSpec fieldSpec = new DimensionFieldSpec("col", DataType.INT, false);
+
+    DataSourceMetadata metadata = mockMetadata(fieldSpec, numDocs);
+    when(metadata.getMinValue()).thenReturn(10);
+    when(metadata.getMaxValue()).thenReturn(30);
+    when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(2);
+    when(metadata.getMaxRowLengthInBytes()).thenReturn(Integer.BYTES * 2);
+
+    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
+    when(forwardIndex.isSingleValue()).thenReturn(false);
+    when(forwardIndex.getLengthOfShortestElement()).thenReturn(Integer.BYTES);
+    when(forwardIndex.getLengthOfLongestElement()).thenReturn(Integer.BYTES);
+    when(forwardIndex.isAscii()).thenReturn(false);
+
+    MutableNoDictColumnStatistics stats =
+        new MutableNoDictColumnStatistics(mockNoDictDataSource(metadata, forwardIndex), null, false);
+
+    assertFalse(stats.isSingleValue());
+    assertEquals(stats.getMinValue(), 10);
+    assertEquals(stats.getMaxValue(), 30);
+    assertNull(stats.getUniqueValuesSet());
+    assertEquals(stats.getCardinality(), UNKNOWN_CARDINALITY);
+    assertEquals(stats.getLengthOfShortestElement(), Integer.BYTES);
+    assertEquals(stats.getLengthOfLongestElement(), Integer.BYTES);
+    assertTrue(stats.isFixedLength());
+    assertFalse(stats.isAscii());
+    assertFalse(stats.isSorted());
+    assertEquals(stats.getTotalNumberOfEntries(), numDocs);
+    assertEquals(stats.getMaxNumberOfMultiValues(), 2);
+    assertEquals(stats.getMaxRowLengthInBytes(), Integer.BYTES * 2);
+  }
+
+  @Test
+  public void testLongMv() {
+    int numDocs = 2;
+    FieldSpec fieldSpec = new DimensionFieldSpec("col", DataType.LONG, false);
+
+    DataSourceMetadata metadata = mockMetadata(fieldSpec, numDocs);
+    when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(2);
+    when(metadata.getMaxRowLengthInBytes()).thenReturn(Long.BYTES * 2);
+
+    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
+    when(forwardIndex.isSingleValue()).thenReturn(false);
+    when(forwardIndex.getLengthOfShortestElement()).thenReturn(Long.BYTES);
+    when(forwardIndex.getLengthOfLongestElement()).thenReturn(Long.BYTES);
+    when(forwardIndex.isAscii()).thenReturn(false);
+
+    MutableNoDictColumnStatistics stats =
+        new MutableNoDictColumnStatistics(mockNoDictDataSource(metadata, forwardIndex), null, false);
+
+    assertFalse(stats.isSingleValue());
+    assertNull(stats.getUniqueValuesSet());
+    assertEquals(stats.getCardinality(), UNKNOWN_CARDINALITY);
+    assertEquals(stats.getLengthOfShortestElement(), Long.BYTES);
+    assertEquals(stats.getLengthOfLongestElement(), Long.BYTES);
+    assertTrue(stats.isFixedLength());
+    assertFalse(stats.isAscii());
+    assertFalse(stats.isSorted());
+    assertEquals(stats.getTotalNumberOfEntries(), numDocs);
+    assertEquals(stats.getMaxNumberOfMultiValues(), 2);
+    assertEquals(stats.getMaxRowLengthInBytes(), Long.BYTES * 2);
+  }
+
+  @Test
+  public void testFloatMv() {
+    int numDocs = 2;
+    FieldSpec fieldSpec = new DimensionFieldSpec("col", DataType.FLOAT, false);
+
+    DataSourceMetadata metadata = mockMetadata(fieldSpec, numDocs);
+    when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(2);
+    when(metadata.getMaxRowLengthInBytes()).thenReturn(Float.BYTES * 2);
+
+    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
+    when(forwardIndex.isSingleValue()).thenReturn(false);
+    when(forwardIndex.getLengthOfShortestElement()).thenReturn(Float.BYTES);
+    when(forwardIndex.getLengthOfLongestElement()).thenReturn(Float.BYTES);
+    when(forwardIndex.isAscii()).thenReturn(false);
+
+    MutableNoDictColumnStatistics stats =
+        new MutableNoDictColumnStatistics(mockNoDictDataSource(metadata, forwardIndex), null, false);
+
+    assertFalse(stats.isSingleValue());
+    assertNull(stats.getUniqueValuesSet());
+    assertEquals(stats.getCardinality(), UNKNOWN_CARDINALITY);
+    assertEquals(stats.getLengthOfShortestElement(), Float.BYTES);
+    assertEquals(stats.getLengthOfLongestElement(), Float.BYTES);
+    assertTrue(stats.isFixedLength());
+    assertFalse(stats.isAscii());
+    assertFalse(stats.isSorted());
+    assertEquals(stats.getTotalNumberOfEntries(), numDocs);
+    assertEquals(stats.getMaxNumberOfMultiValues(), 2);
+    assertEquals(stats.getMaxRowLengthInBytes(), Float.BYTES * 2);
+  }
+
+  @Test
+  public void testDoubleMv() {
+    int numDocs = 2;
+    FieldSpec fieldSpec = new DimensionFieldSpec("col", DataType.DOUBLE, false);
+
+    DataSourceMetadata metadata = mockMetadata(fieldSpec, numDocs);
+    when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(2);
+    when(metadata.getMaxRowLengthInBytes()).thenReturn(Double.BYTES * 2);
+
+    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
+    when(forwardIndex.isSingleValue()).thenReturn(false);
+    when(forwardIndex.getLengthOfShortestElement()).thenReturn(Double.BYTES);
+    when(forwardIndex.getLengthOfLongestElement()).thenReturn(Double.BYTES);
+    when(forwardIndex.isAscii()).thenReturn(false);
+
+    MutableNoDictColumnStatistics stats =
+        new MutableNoDictColumnStatistics(mockNoDictDataSource(metadata, forwardIndex), null, false);
+
+    assertFalse(stats.isSingleValue());
+    assertNull(stats.getUniqueValuesSet());
+    assertEquals(stats.getCardinality(), UNKNOWN_CARDINALITY);
+    assertEquals(stats.getLengthOfShortestElement(), Double.BYTES);
+    assertEquals(stats.getLengthOfLongestElement(), Double.BYTES);
+    assertTrue(stats.isFixedLength());
+    assertFalse(stats.isAscii());
+    assertFalse(stats.isSorted());
+    assertEquals(stats.getTotalNumberOfEntries(), numDocs);
+    assertEquals(stats.getMaxNumberOfMultiValues(), 2);
+    assertEquals(stats.getMaxRowLengthInBytes(), Double.BYTES * 2);
+  }
+
+  @Test
+  public void testBooleanMv() {
+    int numDocs = 2;
+    FieldSpec fieldSpec = new DimensionFieldSpec("col", DataType.BOOLEAN, false);
+
+    DataSourceMetadata metadata = mockMetadata(fieldSpec, numDocs);
+    when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(2);
+    when(metadata.getMaxRowLengthInBytes()).thenReturn(Integer.BYTES * 2);
+
+    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
+    when(forwardIndex.isSingleValue()).thenReturn(false);
+    when(forwardIndex.getLengthOfShortestElement()).thenReturn(Integer.BYTES);
+    when(forwardIndex.getLengthOfLongestElement()).thenReturn(Integer.BYTES);
+    when(forwardIndex.isAscii()).thenReturn(false);
+
+    MutableNoDictColumnStatistics stats =
+        new MutableNoDictColumnStatistics(mockNoDictDataSource(metadata, forwardIndex), null, false);
+
+    assertFalse(stats.isSingleValue());
+    assertNull(stats.getUniqueValuesSet());
+    assertEquals(stats.getCardinality(), UNKNOWN_CARDINALITY);
+    assertEquals(stats.getLengthOfShortestElement(), Integer.BYTES);
+    assertEquals(stats.getLengthOfLongestElement(), Integer.BYTES);
+    assertTrue(stats.isFixedLength());
+    assertFalse(stats.isAscii());
+    assertFalse(stats.isSorted());
+    assertEquals(stats.getTotalNumberOfEntries(), numDocs);
+    assertEquals(stats.getMaxNumberOfMultiValues(), 2);
+    assertEquals(stats.getMaxRowLengthInBytes(), Integer.BYTES * 2);
+  }
+
+  @Test
+  public void testTimestampMv() {
+    int numDocs = 2;
+    FieldSpec fieldSpec = new DimensionFieldSpec("col", DataType.TIMESTAMP, false);
+
+    DataSourceMetadata metadata = mockMetadata(fieldSpec, numDocs);
+    when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(2);
+    when(metadata.getMaxRowLengthInBytes()).thenReturn(Long.BYTES * 2);
+
+    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
+    when(forwardIndex.isSingleValue()).thenReturn(false);
+    when(forwardIndex.getLengthOfShortestElement()).thenReturn(Long.BYTES);
+    when(forwardIndex.getLengthOfLongestElement()).thenReturn(Long.BYTES);
+    when(forwardIndex.isAscii()).thenReturn(false);
+
+    MutableNoDictColumnStatistics stats =
+        new MutableNoDictColumnStatistics(mockNoDictDataSource(metadata, forwardIndex), null, false);
+
+    assertFalse(stats.isSingleValue());
+    assertNull(stats.getUniqueValuesSet());
+    assertEquals(stats.getCardinality(), UNKNOWN_CARDINALITY);
+    assertEquals(stats.getLengthOfShortestElement(), Long.BYTES);
+    assertEquals(stats.getLengthOfLongestElement(), Long.BYTES);
+    assertTrue(stats.isFixedLength());
+    assertFalse(stats.isAscii());
+    assertFalse(stats.isSorted());
+    assertEquals(stats.getTotalNumberOfEntries(), numDocs);
+    assertEquals(stats.getMaxNumberOfMultiValues(), 2);
+    assertEquals(stats.getMaxRowLengthInBytes(), Long.BYTES * 2);
+  }
+
+  @Test
+  public void testStringMv() {
+    int numDocs = 2;
+    FieldSpec fieldSpec = new DimensionFieldSpec("col", DataType.STRING, false);
+
+    DataSourceMetadata metadata = mockMetadata(fieldSpec, numDocs);
+    when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(3);
+    when(metadata.getMaxRowLengthInBytes()).thenReturn(20);
+
+    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
+    when(forwardIndex.isSingleValue()).thenReturn(false);
+    when(forwardIndex.getLengthOfShortestElement()).thenReturn(2);
+    when(forwardIndex.getLengthOfLongestElement()).thenReturn(8);
+    when(forwardIndex.isAscii()).thenReturn(true);
+
+    MutableNoDictColumnStatistics stats =
+        new MutableNoDictColumnStatistics(mockNoDictDataSource(metadata, forwardIndex), null, false);
+
+    assertFalse(stats.isSingleValue());
+    assertEquals(stats.getLengthOfShortestElement(), 2);
+    assertEquals(stats.getLengthOfLongestElement(), 8);
+    assertFalse(stats.isFixedLength());
+    assertTrue(stats.isAscii());
+    assertFalse(stats.isSorted());
+    assertEquals(stats.getTotalNumberOfEntries(), numDocs);
+    assertEquals(stats.getMaxNumberOfMultiValues(), 3);
+    assertEquals(stats.getMaxRowLengthInBytes(), 20);
+  }
+
+  @Test
+  public void testJsonMv() {
+    int numDocs = 2;
+    FieldSpec fieldSpec = new DimensionFieldSpec("col", DataType.JSON, false);
+
+    DataSourceMetadata metadata = mockMetadata(fieldSpec, numDocs);
+    when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(2);
+    when(metadata.getMaxRowLengthInBytes()).thenReturn(15);
+
+    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
+    when(forwardIndex.isSingleValue()).thenReturn(false);
+    when(forwardIndex.getLengthOfShortestElement()).thenReturn(2);
+    when(forwardIndex.getLengthOfLongestElement()).thenReturn(8);
+    when(forwardIndex.isAscii()).thenReturn(true);
+
+    MutableNoDictColumnStatistics stats =
+        new MutableNoDictColumnStatistics(mockNoDictDataSource(metadata, forwardIndex), null, false);
+
+    assertFalse(stats.isSingleValue());
+    assertNull(stats.getUniqueValuesSet());
+    assertEquals(stats.getCardinality(), UNKNOWN_CARDINALITY);
+    assertEquals(stats.getLengthOfShortestElement(), 2);
+    assertEquals(stats.getLengthOfLongestElement(), 8);
+    assertFalse(stats.isFixedLength());
+    assertTrue(stats.isAscii());
+    assertFalse(stats.isSorted());
+    assertEquals(stats.getTotalNumberOfEntries(), numDocs);
+    assertEquals(stats.getMaxNumberOfMultiValues(), 2);
+    assertEquals(stats.getMaxRowLengthInBytes(), 15);
+  }
+
+  @Test
+  public void testBytesMv() {
+    int numDocs = 2;
+    FieldSpec fieldSpec = new DimensionFieldSpec("col", DataType.BYTES, false);
+
+    DataSourceMetadata metadata = mockMetadata(fieldSpec, numDocs);
+    when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(2);
+    when(metadata.getMaxRowLengthInBytes()).thenReturn(5);
+
+    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
+    when(forwardIndex.isSingleValue()).thenReturn(false);
+    when(forwardIndex.getLengthOfShortestElement()).thenReturn(2);
+    when(forwardIndex.getLengthOfLongestElement()).thenReturn(3);
+    when(forwardIndex.isAscii()).thenReturn(false);
+
+    MutableNoDictColumnStatistics stats =
+        new MutableNoDictColumnStatistics(mockNoDictDataSource(metadata, forwardIndex), null, false);
+
+    assertFalse(stats.isSingleValue());
+    assertNull(stats.getUniqueValuesSet());
+    assertEquals(stats.getCardinality(), UNKNOWN_CARDINALITY);
+    assertEquals(stats.getLengthOfShortestElement(), 2);
+    assertEquals(stats.getLengthOfLongestElement(), 3);
+    assertFalse(stats.isFixedLength());
+    assertFalse(stats.isAscii());
+    assertFalse(stats.isSorted());
+    assertEquals(stats.getTotalNumberOfEntries(), numDocs);
+    assertEquals(stats.getMaxNumberOfMultiValues(), 2);
+    assertEquals(stats.getMaxRowLengthInBytes(), 5);
+  }
+
+  // ======== Helpers ========
+
+  private static DataSourceMetadata mockMetadata(FieldSpec fieldSpec, int numDocs) {
+    DataSourceMetadata metadata = mock(DataSourceMetadata.class);
+    when(metadata.getFieldSpec()).thenReturn(fieldSpec);
+    when(metadata.getNumDocs()).thenReturn(numDocs);
+    return metadata;
+  }
+
+  private static DataSource mockNoDictDataSource(DataSourceMetadata metadata, MutableForwardIndex forwardIndex) {
+    DataSource ds = mock(DataSource.class);
+    when(ds.getDataSourceMetadata()).thenReturn(metadata);
+    when(ds.getDictionary()).thenReturn(null);
+    doReturn(forwardIndex).when(ds).getForwardIndex();
+    return ds;
+  }
+
+  private static Comparable[] fixedWidthValues(DataType type) {
+    switch (type) {
+      case INT:
+        return new Comparable[]{10, 20, 30};
+      case LONG:
+        return new Comparable[]{100L, 200L, 300L};
+      case FLOAT:
+        return new Comparable[]{1.0f, 2.0f, 3.0f};
+      case DOUBLE:
+        return new Comparable[]{1.0, 2.0, 3.0};
+      default:
+        throw new IllegalArgumentException("Not a fixed-width type: " + type);
+    }
+  }
+
+  private static void stubForwardIndexReads(MutableForwardIndex fi, DataType type, Comparable[] values) {
+    for (int i = 0; i < values.length; i++) {
+      switch (type) {
+        case INT:
+          when(fi.getInt(i)).thenReturn((Integer) values[i]);
+          break;
+        case LONG:
+          when(fi.getLong(i)).thenReturn((Long) values[i]);
+          break;
+        case FLOAT:
+          when(fi.getFloat(i)).thenReturn((Float) values[i]);
+          break;
+        case DOUBLE:
+          when(fi.getDouble(i)).thenReturn((Double) values[i]);
+          break;
+        default:
+          throw new IllegalArgumentException("Use type-specific stub for: " + type);
+      }
+    }
+  }
+}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/DictionariesTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/DictionariesTest.java
@@ -41,7 +41,7 @@ import org.apache.pinot.segment.local.segment.creator.impl.SegmentCreationDriver
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentDictionaryCreator;
 import org.apache.pinot.segment.local.segment.creator.impl.stats.AbstractColumnStatisticsCollector;
 import org.apache.pinot.segment.local.segment.creator.impl.stats.BigDecimalColumnPreIndexStatsCollector;
-import org.apache.pinot.segment.local.segment.creator.impl.stats.BytesColumnPredIndexStatsCollector;
+import org.apache.pinot.segment.local.segment.creator.impl.stats.BytesColumnPreIndexStatsCollector;
 import org.apache.pinot.segment.local.segment.creator.impl.stats.DoubleColumnPreIndexStatsCollector;
 import org.apache.pinot.segment.local.segment.creator.impl.stats.FloatColumnPreIndexStatsCollector;
 import org.apache.pinot.segment.local.segment.creator.impl.stats.IntColumnPreIndexStatsCollector;
@@ -542,7 +542,7 @@ public class DictionariesTest implements PinotBuffersAfterMethodCheckRule {
       case STRING:
         return new StringColumnPreIndexStatsCollector(column, statsCollectorConfig);
       case BYTES:
-        return new BytesColumnPredIndexStatsCollector(column, statsCollectorConfig);
+        return new BytesColumnPreIndexStatsCollector(column, statsCollectorConfig);
       default:
         throw new IllegalArgumentException("Illegal data type for stats builder: " + dataType);
     }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/impl/stats/AbstractColumnStatisticsCollectorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/impl/stats/AbstractColumnStatisticsCollectorTest.java
@@ -25,9 +25,11 @@ import org.apache.pinot.segment.spi.creator.StatsCollectorConfig;
 import org.apache.pinot.spi.config.table.ColumnPartitionConfig;
 import org.apache.pinot.spi.config.table.SegmentPartitionConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.DimensionFieldSpec;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.BooleanUtils;
 import org.apache.pinot.spi.utils.ByteArray;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.annotations.DataProvider;
@@ -42,7 +44,6 @@ import static org.testng.Assert.*;
  * single and multi-value scenarios, edge cases, and partition functionality.
  */
 public class AbstractColumnStatisticsCollectorTest {
-
   private static final String COLUMN_NAME = "testColumn";
   private static final String TABLE_NAME = "testTable";
   private static final int NUM_PARTITIONS = 4;
@@ -52,10 +53,9 @@ public class AbstractColumnStatisticsCollectorTest {
   /**
    * Creates a StatsCollectorConfig with optional partitioning.
    */
-  private StatsCollectorConfig createStatsCollectorConfig(FieldSpec.DataType dataType, boolean isSingleValue,
+  private StatsCollectorConfig createStatsCollectorConfig(DataType dataType, boolean isSingleValue,
       boolean withPartitioning) {
-    TableConfigBuilder builder = new TableConfigBuilder(org.apache.pinot.spi.config.table.TableType.OFFLINE)
-        .setTableName(TABLE_NAME);
+    TableConfigBuilder builder = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME);
 
     if (withPartitioning) {
       builder.setSegmentPartitionConfig(new SegmentPartitionConfig(
@@ -73,10 +73,12 @@ public class AbstractColumnStatisticsCollectorTest {
   /**
    * Factory method to create the appropriate collector for a given data type.
    */
-  private AbstractColumnStatisticsCollector createCollector(FieldSpec.DataType dataType, boolean isSingleValue,
+  private AbstractColumnStatisticsCollector createCollector(DataType dataType, boolean isSingleValue,
       boolean withPartitioning) {
     StatsCollectorConfig config = createStatsCollectorConfig(dataType, isSingleValue, withPartitioning);
-    switch (dataType) {
+    // Logical types map to stored types: BOOLEAN->INT, TIMESTAMP->LONG, JSON->STRING
+    DataType storedType = dataType.getStoredType();
+    switch (storedType) {
       case INT:
         return new IntColumnPreIndexStatsCollector(COLUMN_NAME, config);
       case LONG:
@@ -85,12 +87,12 @@ public class AbstractColumnStatisticsCollectorTest {
         return new FloatColumnPreIndexStatsCollector(COLUMN_NAME, config);
       case DOUBLE:
         return new DoubleColumnPreIndexStatsCollector(COLUMN_NAME, config);
+      case BIG_DECIMAL:
+        return new BigDecimalColumnPreIndexStatsCollector(COLUMN_NAME, config);
       case STRING:
         return new StringColumnPreIndexStatsCollector(COLUMN_NAME, config);
       case BYTES:
-        return new BytesColumnPredIndexStatsCollector(COLUMN_NAME, config);
-      case BIG_DECIMAL:
-        return new BigDecimalColumnPreIndexStatsCollector(COLUMN_NAME, config);
+        return new BytesColumnPreIndexStatsCollector(COLUMN_NAME, config);
       default:
         throw new IllegalArgumentException("Unsupported data type: " + dataType);
     }
@@ -98,80 +100,66 @@ public class AbstractColumnStatisticsCollectorTest {
 
   /**
    * Helper method to assert basic statistics after collection.
+   * Assertions follow ColumnStatistics API definition order.
    */
-  private void assertBasicStats(AbstractColumnStatisticsCollector collector, int expectedCardinality,
-      int expectedTotalEntries, Object expectedMin, Object expectedMax, boolean expectedSorted) {
-    assertEquals(collector.getCardinality(), expectedCardinality);
-    assertEquals(collector.getTotalNumberOfEntries(), expectedTotalEntries);
-    assertEquals(collector.isSorted(), expectedSorted);
-
+  private void assertBasicStats(AbstractColumnStatisticsCollector collector, Object expectedMin, Object expectedMax,
+      int expectedCardinality, boolean expectedSorted, int expectedTotalEntries) {
     if (expectedMin != null && expectedMax != null) {
       assertEquals(collector.getMinValue(), expectedMin);
       assertEquals(collector.getMaxValue(), expectedMax);
     }
+    assertEquals(collector.getCardinality(), expectedCardinality);
+    assertEquals(collector.isSorted(), expectedSorted);
+    assertEquals(collector.getTotalNumberOfEntries(), expectedTotalEntries);
   }
-
-  // DataProviders
 
   @DataProvider(name = "allDataTypes")
   public Object[][] allDataTypes() {
-    return new Object[][] {
-        {FieldSpec.DataType.INT},
-        {FieldSpec.DataType.LONG},
-        {FieldSpec.DataType.FLOAT},
-        {FieldSpec.DataType.DOUBLE},
-        {FieldSpec.DataType.STRING},
-        {FieldSpec.DataType.BYTES},
-        {FieldSpec.DataType.BIG_DECIMAL}
+    return new Object[][]{
+        {DataType.INT}, {DataType.LONG}, {DataType.FLOAT}, {DataType.DOUBLE}, {DataType.BIG_DECIMAL},
+        {DataType.BOOLEAN}, {DataType.TIMESTAMP}, {DataType.STRING}, {DataType.JSON}, {DataType.BYTES}
     };
   }
 
   @DataProvider(name = "primitiveDataTypes")
   public Object[][] primitiveDataTypes() {
-    return new Object[][] {
-        {FieldSpec.DataType.INT},
-        {FieldSpec.DataType.LONG},
-        {FieldSpec.DataType.FLOAT},
-        {FieldSpec.DataType.DOUBLE}
+    return new Object[][]{
+        {DataType.INT}, {DataType.LONG}, {DataType.FLOAT}, {DataType.DOUBLE}
     };
   }
 
   @DataProvider(name = "numericDataTypes")
   public Object[][] numericDataTypes() {
-    return new Object[][] {
-        {FieldSpec.DataType.INT},
-        {FieldSpec.DataType.LONG},
-        {FieldSpec.DataType.FLOAT},
-        {FieldSpec.DataType.DOUBLE},
-        {FieldSpec.DataType.BIG_DECIMAL}
+    return new Object[][]{
+        {DataType.INT}, {DataType.LONG}, {DataType.FLOAT}, {DataType.DOUBLE}, {DataType.BIG_DECIMAL}
     };
   }
 
   @DataProvider(name = "multiValueSupportedTypes")
   public Object[][] multiValueSupportedTypes() {
-    return new Object[][] {
-        {FieldSpec.DataType.INT},
-        {FieldSpec.DataType.LONG},
-        {FieldSpec.DataType.FLOAT},
-        {FieldSpec.DataType.DOUBLE},
-        {FieldSpec.DataType.STRING},
-        {FieldSpec.DataType.BYTES}
+    return new Object[][]{
+        {DataType.INT}, {DataType.LONG}, {DataType.FLOAT}, {DataType.DOUBLE}, {DataType.STRING}, {DataType.BYTES}
+    };
+  }
+
+  @DataProvider(name = "logicalDataTypes")
+  public Object[][] logicalDataTypes() {
+    return new Object[][]{
+        {DataType.BOOLEAN}, {DataType.TIMESTAMP}, {DataType.JSON}
     };
   }
 
   @DataProvider(name = "lengthTrackingTypes")
   public Object[][] lengthTrackingTypes() {
-    return new Object[][] {
-        {FieldSpec.DataType.STRING},
-        {FieldSpec.DataType.BYTES},
-        {FieldSpec.DataType.BIG_DECIMAL}
+    return new Object[][]{
+        {DataType.BIG_DECIMAL}, {DataType.STRING}, {DataType.BYTES}
     };
   }
 
   // Test 1: Single-Value Collection using Primitive Methods
 
   @Test(dataProvider = "primitiveDataTypes")
-  public void testSingleValuePrimitiveCollectionSorted(FieldSpec.DataType dataType) {
+  public void testSingleValuePrimitiveCollectionSorted(DataType dataType) {
     AbstractColumnStatisticsCollector collector = createCollector(dataType, true, false);
 
     // Collect sorted values
@@ -206,17 +194,15 @@ public class AbstractColumnStatisticsCollectorTest {
 
     collector.seal();
 
-    // Verify stats
-    assertBasicStats(collector, 3, 4, getMinValue(dataType), getMaxValue(dataType), true);
+    assertBasicStats(collector, getMinValue(dataType), getMaxValue(dataType), 3, true, 4);
 
-    // Verify unique values set
     Object uniqueValuesSet = collector.getUniqueValuesSet();
     assertNotNull(uniqueValuesSet);
     assertEquals(getArrayLength(uniqueValuesSet), 3);
   }
 
   @Test(dataProvider = "primitiveDataTypes")
-  public void testSingleValuePrimitiveCollectionUnsorted(FieldSpec.DataType dataType) {
+  public void testSingleValuePrimitiveCollectionUnsorted(DataType dataType) {
     AbstractColumnStatisticsCollector collector = createCollector(dataType, true, false);
 
     // Collect unsorted values
@@ -251,35 +237,34 @@ public class AbstractColumnStatisticsCollectorTest {
 
     collector.seal();
 
-    // Verify stats - should not be sorted
-    assertBasicStats(collector, 3, 4, getMinValue(dataType), getMaxValue(dataType), false);
+    assertBasicStats(collector, getMinValue(dataType), getMaxValue(dataType), 3, false, 4);
   }
 
   // Test 2: Single-Value Collection using collect(Object)
 
   @Test(dataProvider = "allDataTypes")
-  public void testSingleValueObjectCollection(FieldSpec.DataType dataType) {
-    AbstractColumnStatisticsCollector collector = createCollector(dataType, true, false);
+  public void testSingleValueObjectCollection(DataType dataType) {
+    for (boolean sorted : new boolean[]{false, true}) {
+      AbstractColumnStatisticsCollector collector = createCollector(dataType, true, false);
 
-    // Collect values using Object method
-    Object[] testData = getTestDataForType(dataType, true);
-    for (Object value : testData) {
-      collector.collect(value);
+      // Collect values using Object method
+      Object[] testData = getTestDataForType(dataType, sorted);
+      for (Object value : testData) {
+        collector.collect(value);
+      }
+
+      collector.seal();
+
+      int expectedCardinality = dataType != DataType.BOOLEAN ? 3 : 2;  // BOOLEAN test data has only 2 unique values
+      assertBasicStats(collector, getExpectedMinForType(dataType), getExpectedMaxForType(dataType), expectedCardinality,
+          sorted, 4);
     }
-
-    collector.seal();
-
-    // Verify stats
-    int expectedCardinality = 3;  // test data has 1 duplicate
-    int expectedTotalEntries = 4;
-    assertBasicStats(collector, expectedCardinality, expectedTotalEntries,
-        getExpectedMinForType(dataType), getExpectedMaxForType(dataType), true);
   }
 
   // Test 3: Multi-Value Collection using Primitive Arrays
 
   @Test(dataProvider = "multiValueSupportedTypes")
-  public void testMultiValuePrimitiveArrayCollection(FieldSpec.DataType dataType) {
+  public void testMultiValuePrimitiveArrayCollection(DataType dataType) {
     AbstractColumnStatisticsCollector collector = createCollector(dataType, false, false);
 
     // Collect multi-value entries
@@ -314,49 +299,46 @@ public class AbstractColumnStatisticsCollectorTest {
 
     collector.seal();
 
-    // Verify stats
     assertEquals(collector.getCardinality(), 5);
+    assertFalse(collector.isSorted());  // multi-value is never sorted
     assertEquals(collector.getTotalNumberOfEntries(), 5);
     assertEquals(collector.getMaxNumberOfMultiValues(), 3);
-    assertFalse(collector.isSorted());  // multi-value is never sorted
   }
 
   @Test(dataProvider = "multiValueSupportedTypes")
-  public void testMultiValueObjectArrayCollection(FieldSpec.DataType dataType) {
+  public void testMultiValueObjectArrayCollection(DataType dataType) {
     AbstractColumnStatisticsCollector collector = createCollector(dataType, false, false);
 
     // Collect multi-value entries using Object[]
     Object[][] testData = getMultiValueTestData(dataType);
     for (Object[] values : testData) {
-      collector.collect((Object) values);
+      collector.collect(values);
     }
 
     collector.seal();
 
-    // Verify stats
     assertEquals(collector.getCardinality(), 5);
+    assertFalse(collector.isSorted());
     assertEquals(collector.getTotalNumberOfEntries(), 5);
     assertEquals(collector.getMaxNumberOfMultiValues(), 3);
-    assertFalse(collector.isSorted());
   }
 
   // Test 4: Edge Cases
 
   @Test(dataProvider = "allDataTypes")
-  public void testEmptyCollection(FieldSpec.DataType dataType) {
+  public void testEmptyCollection(DataType dataType) {
     AbstractColumnStatisticsCollector collector = createCollector(dataType, true, false);
 
     // Seal without collecting any data
     collector.seal();
 
-    // Verify stats
     assertEquals(collector.getCardinality(), 0);
-    assertEquals(collector.getTotalNumberOfEntries(), 0);
     assertTrue(collector.isSorted());  // Empty is considered sorted
+    assertEquals(collector.getTotalNumberOfEntries(), 0);
   }
 
   @Test(dataProvider = "allDataTypes")
-  public void testSingleValue(FieldSpec.DataType dataType) {
+  public void testSingleValue(DataType dataType) {
     AbstractColumnStatisticsCollector collector = createCollector(dataType, true, false);
 
     // Collect single value
@@ -364,15 +346,12 @@ public class AbstractColumnStatisticsCollectorTest {
     collector.collect(singleValue);
     collector.seal();
 
-    // Verify stats - for BYTES, need to use ByteArray for comparison
-    Object expectedValue = dataType == FieldSpec.DataType.BYTES
-        ? new ByteArray((byte[]) singleValue)
-        : singleValue;
-    assertBasicStats(collector, 1, 1, expectedValue, expectedValue, true);
+    Object expectedValue = dataType == DataType.BYTES ? new ByteArray((byte[]) singleValue) : singleValue;
+    assertBasicStats(collector, expectedValue, expectedValue, 1, true, 1);
   }
 
   @Test(dataProvider = "allDataTypes")
-  public void testAllDuplicates(FieldSpec.DataType dataType) {
+  public void testAllDuplicates(DataType dataType) {
     AbstractColumnStatisticsCollector collector = createCollector(dataType, true, false);
 
     // Collect same value multiple times
@@ -382,15 +361,12 @@ public class AbstractColumnStatisticsCollectorTest {
     }
     collector.seal();
 
-    // Verify stats - for BYTES, need to use ByteArray for comparison
-    Object expectedValue = dataType == FieldSpec.DataType.BYTES
-        ? new ByteArray((byte[]) value)
-        : value;
-    assertBasicStats(collector, 1, 10, expectedValue, expectedValue, true);
+    Object expectedValue = dataType == DataType.BYTES ? new ByteArray((byte[]) value) : value;
+    assertBasicStats(collector, expectedValue, expectedValue, 1, true, 10);
   }
 
   @Test(dataProvider = "allDataTypes", expectedExceptions = IllegalStateException.class)
-  public void testUnsealedAccessThrowsException(FieldSpec.DataType dataType) {
+  public void testUnsealedAccessThrowsException(DataType dataType) {
     AbstractColumnStatisticsCollector collector = createCollector(dataType, true, false);
 
     // Try to access stats before sealing - should throw
@@ -400,59 +376,77 @@ public class AbstractColumnStatisticsCollectorTest {
   // Test 5: Partition Function Tests
 
   @Test(dataProvider = "allDataTypes")
-  public void testPartitionFunctionEnabled(FieldSpec.DataType dataType) {
-    if (dataType == FieldSpec.DataType.BIG_DECIMAL) {
-      // Skip BigDecimal as partition testing is less relevant
-      return;
-    }
+  public void testPartitionFunctionEnabled(DataType dataType) {
+    for (boolean sorted : new boolean[]{false, true}) {
+      AbstractColumnStatisticsCollector collector = createCollector(dataType, true, true);
 
-    AbstractColumnStatisticsCollector collector = createCollector(dataType, true, true);
+      // Collect values
+      Object[] testData = getTestDataForType(dataType, sorted);
+      for (Object value : testData) {
+        collector.collect(value);
+      }
+      collector.seal();
 
-    // Collect values
-    Object[] testData = getTestDataForType(dataType, true);
-    for (Object value : testData) {
-      collector.collect(value);
-    }
-    collector.seal();
+      assertNotNull(collector.getPartitionFunction());
+      assertEquals(collector.getNumPartitions(), NUM_PARTITIONS);
 
-    // Verify partition function is present
-    assertNotNull(collector.getPartitionFunction());
-    assertEquals(collector.getNumPartitions(), NUM_PARTITIONS);
+      Set<Integer> partitions = collector.getPartitions();
+      assertNotNull(partitions);
+      assertFalse(partitions.isEmpty());
+      assertTrue(partitions.size() <= NUM_PARTITIONS);
 
-    // Verify partitions are populated
-    Set<Integer> partitions = collector.getPartitions();
-    assertNotNull(partitions);
-    assertTrue(partitions.size() > 0);
-    assertTrue(partitions.size() <= NUM_PARTITIONS);
-
-    // All partition values should be within range
-    for (Integer partition : partitions) {
-      assertTrue(partition >= 0 && partition < NUM_PARTITIONS);
+      for (Integer partition : partitions) {
+        assertTrue(partition >= 0 && partition < NUM_PARTITIONS);
+      }
     }
   }
 
   @Test(dataProvider = "allDataTypes")
-  public void testPartitionFunctionDisabled(FieldSpec.DataType dataType) {
-    AbstractColumnStatisticsCollector collector = createCollector(dataType, true, false);
+  public void testPartitionFunctionDisabled(DataType dataType) {
+    for (boolean sorted : new boolean[]{false, true}) {
+      AbstractColumnStatisticsCollector collector = createCollector(dataType, true, false);
 
-    // Collect values
-    Object[] testData = getTestDataForType(dataType, true);
-    for (Object value : testData) {
-      collector.collect(value);
+      // Collect values
+      Object[] testData = getTestDataForType(dataType, sorted);
+      for (Object value : testData) {
+        collector.collect(value);
+      }
+      collector.seal();
+
+      assertNull(collector.getPartitionFunction());
+      assertEquals(collector.getNumPartitions(), -1);
+      assertNull(collector.getPartitions());
     }
-    collector.seal();
-
-    // Verify partition function is not present
-    assertNull(collector.getPartitionFunction());
-    assertNull(collector.getPartitions());
-    assertEquals(collector.getNumPartitions(), -1);
   }
 
-  // Test 6: Type-Specific Tests
+  // Test 6: Type-Specific Length Tracking Tests
+  // (ordered by DataType enum: BIG_DECIMAL, STRING, JSON, BYTES)
+
+  @Test
+  public void testBigDecimalLengthTracking() {
+    AbstractColumnStatisticsCollector collector = createCollector(DataType.BIG_DECIMAL, true, false);
+
+    collector.collect(new BigDecimal("1.0"));
+    collector.collect(new BigDecimal("123456.789"));
+    collector.collect(new BigDecimal("99.99"));
+
+    collector.seal();
+
+    assertTrue(collector.getLengthOfShortestElement() > 0);
+    assertTrue(collector.getLengthOfLongestElement() >= collector.getLengthOfShortestElement());
+  }
+
+  @Test(expectedExceptions = UnsupportedOperationException.class)
+  public void testBigDecimalMultiValueNotSupported() {
+    AbstractColumnStatisticsCollector collector = createCollector(DataType.BIG_DECIMAL, true, false);
+
+    // BigDecimal does not support multi-value
+    collector.collect(new Object[]{new BigDecimal("1.0"), new BigDecimal("2.0")});
+  }
 
   @Test
   public void testStringLengthTracking() {
-    AbstractColumnStatisticsCollector collector = createCollector(FieldSpec.DataType.STRING, true, false);
+    AbstractColumnStatisticsCollector collector = createCollector(DataType.STRING, true, false);
 
     collector.collect("a");          // length 1
     collector.collect("xyz");        // length 3
@@ -460,26 +454,46 @@ public class AbstractColumnStatisticsCollectorTest {
 
     collector.seal();
 
-    assertEquals(collector.getLengthOfLargestElement(), 5);
+    assertEquals(collector.getLengthOfShortestElement(), 1);
+    assertEquals(collector.getLengthOfLongestElement(), 5);
+    assertFalse(collector.isFixedLength());
     assertEquals(collector.getMaxRowLengthInBytes(), 5);
   }
 
   @Test
   public void testStringMultiValueLengthTracking() {
-    AbstractColumnStatisticsCollector collector = createCollector(FieldSpec.DataType.STRING, false, false);
+    AbstractColumnStatisticsCollector collector = createCollector(DataType.STRING, false, false);
 
     collector.collect(new String[]{"a", "xy"});        // row length: 1 + 2 = 3
     collector.collect(new String[]{"hello", "world"}); // row length: 5 + 5 = 10
 
     collector.seal();
 
-    assertEquals(collector.getLengthOfLargestElement(), 5);
+    assertEquals(collector.getLengthOfShortestElement(), 1);
+    assertEquals(collector.getLengthOfLongestElement(), 5);
+    assertFalse(collector.isFixedLength());
     assertEquals(collector.getMaxRowLengthInBytes(), 10);
   }
 
   @Test
+  public void testJsonLengthTracking() {
+    AbstractColumnStatisticsCollector collector = createCollector(DataType.JSON, true, false);
+
+    collector.collect("{\"a\":1}");                    // length 7
+    collector.collect("{\"key\":\"value\"}");          // length 15
+    collector.collect("{\"long_key\":\"long_value\"}"); // length 25
+
+    collector.seal();
+
+    assertEquals(collector.getLengthOfShortestElement(), 7);
+    assertEquals(collector.getLengthOfLongestElement(), 25);
+    assertFalse(collector.isFixedLength());
+    assertEquals(collector.getMaxRowLengthInBytes(), 25);
+  }
+
+  @Test
   public void testBytesLengthTracking() {
-    AbstractColumnStatisticsCollector collector = createCollector(FieldSpec.DataType.BYTES, true, false);
+    AbstractColumnStatisticsCollector collector = createCollector(DataType.BYTES, true, false);
 
     collector.collect(new byte[]{1});           // length 1
     collector.collect(new byte[]{1, 2, 3});     // length 3
@@ -488,13 +502,14 @@ public class AbstractColumnStatisticsCollectorTest {
     collector.seal();
 
     assertEquals(collector.getLengthOfShortestElement(), 1);
-    assertEquals(collector.getLengthOfLargestElement(), 5);
+    assertEquals(collector.getLengthOfLongestElement(), 5);
+    assertFalse(collector.isFixedLength());
     assertEquals(collector.getMaxRowLengthInBytes(), 5);
   }
 
   @Test
   public void testBytesMultiValueLengthTracking() {
-    AbstractColumnStatisticsCollector collector = createCollector(FieldSpec.DataType.BYTES, false, false);
+    AbstractColumnStatisticsCollector collector = createCollector(DataType.BYTES, false, false);
 
     collector.collect(new byte[][]{{1}, {1, 2}});              // row length: 1 + 2 = 3
     collector.collect(new byte[][]{{1, 2, 3, 4, 5}, {1, 2, 3, 4, 5}}); // row length: 5 + 5 = 10
@@ -502,37 +517,205 @@ public class AbstractColumnStatisticsCollectorTest {
     collector.seal();
 
     assertEquals(collector.getLengthOfShortestElement(), 1);
-    assertEquals(collector.getLengthOfLargestElement(), 5);
+    assertEquals(collector.getLengthOfLongestElement(), 5);
+    assertFalse(collector.isFixedLength());
     assertEquals(collector.getMaxRowLengthInBytes(), 10);
   }
 
+  // Test 7: Logical Types (ordered by DataType enum: BOOLEAN, TIMESTAMP, JSON)
+
   @Test
-  public void testBigDecimalLengthTracking() {
-    AbstractColumnStatisticsCollector collector = createCollector(FieldSpec.DataType.BIG_DECIMAL, true, false);
+  public void testBooleanCollectionSorted() {
+    AbstractColumnStatisticsCollector collector = createCollector(DataType.BOOLEAN, true, false);
 
-    collector.collect(new BigDecimal("1.0"));
-    collector.collect(new BigDecimal("123456.789"));
-    collector.collect(new BigDecimal("99.99"));
-
+    // BOOLEAN is stored as INT: 0 = false, 1 = true
+    collector.collect(0);  // false
+    collector.collect(0);  // false (duplicate)
+    collector.collect(1);  // true
+    collector.collect(1);  // true (duplicate)
     collector.seal();
 
-    // BigDecimal tracks length
-    assertTrue(collector.getLengthOfShortestElement() > 0);
-    assertTrue(collector.getLengthOfLargestElement() > 0);
-    assertTrue(collector.getLengthOfLargestElement() >= collector.getLengthOfShortestElement());
+    assertBasicStats(collector, 0, 1, 2, true, 4);
   }
 
-  @Test(expectedExceptions = UnsupportedOperationException.class)
-  public void testBigDecimalMultiValueNotSupported() {
-    AbstractColumnStatisticsCollector collector = createCollector(FieldSpec.DataType.BIG_DECIMAL, true, false);
+  @Test
+  public void testBooleanCollectionUnsorted() {
+    AbstractColumnStatisticsCollector collector = createCollector(DataType.BOOLEAN, true, false);
 
-    // BigDecimal does not support multi-value
-    collector.collect((Object) new Object[]{new BigDecimal("1.0"), new BigDecimal("2.0")});
+    collector.collect(1);  // true
+    collector.collect(0);  // false
+    collector.collect(1);  // true
+    collector.seal();
+
+    assertBasicStats(collector, 0, 1, 2, false, 3);
+  }
+
+  @Test
+  public void testTimestampCollectionSorted() {
+    AbstractColumnStatisticsCollector collector = createCollector(DataType.TIMESTAMP, true, false);
+
+    // TIMESTAMP is stored as LONG (millis since epoch)
+    collector.collect(1000L);
+    collector.collect(2000L);
+    collector.collect(2000L);  // duplicate
+    collector.collect(3000L);
+    collector.seal();
+
+    assertBasicStats(collector, 1000L, 3000L, 3, true, 4);
+  }
+
+  @Test
+  public void testTimestampCollectionUnsorted() {
+    AbstractColumnStatisticsCollector collector = createCollector(DataType.TIMESTAMP, true, false);
+
+    collector.collect(3000L);
+    collector.collect(1000L);
+    collector.collect(2000L);
+    collector.seal();
+
+    assertBasicStats(collector, 1000L, 3000L, 3, false, 3);
+  }
+
+  @Test
+  public void testJsonCollectionSorted() {
+    AbstractColumnStatisticsCollector collector = createCollector(DataType.JSON, true, false);
+
+    // JSON is stored as STRING
+    collector.collect("{\"a\":1}");
+    collector.collect("{\"b\":2}");
+    collector.collect("{\"b\":2}");  // duplicate
+    collector.collect("{\"c\":3}");
+    collector.seal();
+
+    assertBasicStats(collector, "{\"a\":1}", "{\"c\":3}", 3, true, 4);
+  }
+
+  @Test
+  public void testJsonCollectionUnsorted() {
+    AbstractColumnStatisticsCollector collector = createCollector(DataType.JSON, true, false);
+
+    collector.collect("{\"c\":3}");
+    collector.collect("{\"a\":1}");
+    collector.collect("{\"b\":2}");
+    collector.seal();
+
+    assertBasicStats(collector, "{\"a\":1}", "{\"c\":3}", 3, false, 3);
+  }
+
+  @Test(dataProvider = "logicalDataTypes")
+  public void testLogicalTypeStoredTypeMapping(DataType dataType) {
+    AbstractColumnStatisticsCollector collector = createCollector(dataType, true, false);
+
+    // Verify the collector uses the correct stored type
+    DataType expectedStoredType = dataType.getStoredType();
+    assertEquals(collector.getValueType(), expectedStoredType);
+  }
+
+  // Test 8: isAscii Tests
+
+  @Test
+  public void testIsAsciiWithAsciiStrings() {
+    AbstractColumnStatisticsCollector collector = createCollector(DataType.STRING, true, false);
+
+    collector.collect("hello");
+    collector.collect("world");
+    collector.collect("test123");
+    collector.seal();
+
+    assertTrue(collector.isAscii());
+  }
+
+  @Test
+  public void testIsAsciiWithNonAsciiStrings() {
+    AbstractColumnStatisticsCollector collector = createCollector(DataType.STRING, true, false);
+
+    collector.collect("hello");
+    collector.collect("wörld");  // 'ö' is non-ASCII
+    collector.seal();
+
+    assertFalse(collector.isAscii());
+  }
+
+  @Test
+  public void testIsAsciiWithUnicodeStrings() {
+    AbstractColumnStatisticsCollector collector = createCollector(DataType.STRING, true, false);
+
+    collector.collect("世界");  // Chinese characters
+    collector.seal();
+
+    assertFalse(collector.isAscii());
+  }
+
+  @Test
+  public void testIsAsciiWithEmptyStrings() {
+    AbstractColumnStatisticsCollector collector = createCollector(DataType.STRING, true, false);
+
+    collector.collect("");
+    collector.seal();
+
+    // Empty string is ASCII (no non-ASCII bytes)
+    assertTrue(collector.isAscii());
+  }
+
+  @Test
+  public void testIsAsciiWithMixedSingleAndNonAscii() {
+    AbstractColumnStatisticsCollector collector = createCollector(DataType.STRING, true, false);
+
+    // First string is ASCII, second is not - once non-ASCII is detected, isAscii stays false
+    collector.collect("ascii");
+    collector.collect("café");  // 'é' is non-ASCII
+    collector.collect("more_ascii");
+    collector.seal();
+
+    assertFalse(collector.isAscii());
+  }
+
+  @Test
+  public void testIsAsciiMultiValue() {
+    AbstractColumnStatisticsCollector collector = createCollector(DataType.STRING, false, false);
+
+    collector.collect(new String[]{"hello", "world"});
+    collector.collect(new String[]{"test"});
+    collector.seal();
+
+    assertTrue(collector.isAscii());
+  }
+
+  @Test
+  public void testIsAsciiMultiValueWithNonAscii() {
+    AbstractColumnStatisticsCollector collector = createCollector(DataType.STRING, false, false);
+
+    collector.collect(new String[]{"hello", "üöä"});  // German umlauts
+    collector.seal();
+
+    assertFalse(collector.isAscii());
+  }
+
+  @Test
+  public void testIsAsciiJsonColumn() {
+    // JSON columns use StringColumnPreIndexStatsCollector - verify isAscii works
+    AbstractColumnStatisticsCollector collector = createCollector(DataType.JSON, true, false);
+
+    collector.collect("{\"key\":\"value\"}");
+    collector.collect("{\"num\":123}");
+    collector.seal();
+
+    assertTrue(collector.isAscii());
+  }
+
+  @Test
+  public void testIsAsciiJsonColumnWithUnicode() {
+    AbstractColumnStatisticsCollector collector = createCollector(DataType.JSON, true, false);
+
+    collector.collect("{\"name\":\"émile\"}");  // French name with accent
+    collector.seal();
+
+    assertFalse(collector.isAscii());
   }
 
   // Helper methods for test data generation
 
-  private Object[] getTestDataForType(FieldSpec.DataType dataType, boolean sorted) {
+  private Object[] getTestDataForType(DataType dataType, boolean sorted) {
     switch (dataType) {
       case INT:
         return sorted ? new Object[]{1, 5, 5, 10} : new Object[]{10, 1, 5, 5};
@@ -542,63 +725,67 @@ public class AbstractColumnStatisticsCollectorTest {
         return sorted ? new Object[]{1.5f, 5.5f, 5.5f, 10.5f} : new Object[]{10.5f, 1.5f, 5.5f, 5.5f};
       case DOUBLE:
         return sorted ? new Object[]{1.5, 5.5, 5.5, 10.5} : new Object[]{10.5, 1.5, 5.5, 5.5};
-      case STRING:
-        return sorted ? new Object[]{"a", "b", "b", "c"} : new Object[]{"c", "a", "b", "b"};
-      case BYTES:
-        return sorted ? new Object[]{
-            new byte[]{1}, new byte[]{2}, new byte[]{2}, new byte[]{3}
-        } : new Object[]{
-            new byte[]{3}, new byte[]{1}, new byte[]{2}, new byte[]{2}
-        };
       case BIG_DECIMAL:
         return sorted ? new Object[]{
             new BigDecimal("1.0"), new BigDecimal("5.0"), new BigDecimal("5.0"), new BigDecimal("10.0")
         } : new Object[]{
             new BigDecimal("10.0"), new BigDecimal("1.0"), new BigDecimal("5.0"), new BigDecimal("5.0")
         };
+      case BOOLEAN:
+        // BOOLEAN stored as INT: 0 = false, 1 = true
+        return sorted ? new Object[]{0, 0, 1, 1} : new Object[]{1, 0, 1, 0};
+      case TIMESTAMP:
+        // TIMESTAMP stored as LONG (millis since epoch)
+        return sorted ? new Object[]{1000L, 2000L, 2000L, 3000L} : new Object[]{3000L, 1000L, 2000L, 2000L};
+      case STRING:
+        return sorted ? new Object[]{"a", "b", "b", "c"} : new Object[]{"c", "a", "b", "b"};
+      case JSON:
+        // JSON stored as STRING
+        return sorted ? new Object[]{"{\"a\":1}", "{\"b\":2}", "{\"b\":2}", "{\"c\":3}"}
+            : new Object[]{"{\"c\":3}", "{\"a\":1}", "{\"b\":2}", "{\"b\":2}"};
+      case BYTES:
+        return sorted ? new Object[]{
+            new byte[]{1}, new byte[]{2}, new byte[]{2}, new byte[]{3}
+        } : new Object[]{
+            new byte[]{3}, new byte[]{1}, new byte[]{2}, new byte[]{2}
+        };
       default:
         throw new IllegalArgumentException("Unsupported data type: " + dataType);
     }
   }
 
-  private Object[][] getMultiValueTestData(FieldSpec.DataType dataType) {
+  private Object[][] getMultiValueTestData(DataType dataType) {
     switch (dataType) {
       case INT:
         return new Object[][]{
-            {1, 2},
-            {3, 4, 5}
+            {1, 2}, {3, 4, 5}
         };
       case LONG:
         return new Object[][]{
-            {1L, 2L},
-            {3L, 4L, 5L}
+            {1L, 2L}, {3L, 4L, 5L}
         };
       case FLOAT:
         return new Object[][]{
-            {1.5f, 2.5f},
-            {3.5f, 4.5f, 5.5f}
+            {1.5f, 2.5f}, {3.5f, 4.5f, 5.5f}
         };
       case DOUBLE:
         return new Object[][]{
-            {1.5, 2.5},
-            {3.5, 4.5, 5.5}
+            {1.5, 2.5}, {3.5, 4.5, 5.5}
         };
       case STRING:
         return new Object[][]{
-            {"a", "b"},
-            {"c", "d", "e"}
+            {"a", "b"}, {"c", "d", "e"}
         };
       case BYTES:
         return new Object[][]{
-            {new byte[]{1}, new byte[]{2}},
-            {new byte[]{3}, new byte[]{4}, new byte[]{5}}
+            {new byte[]{1}, new byte[]{2}}, {new byte[]{3}, new byte[]{4}, new byte[]{5}}
         };
       default:
         throw new IllegalArgumentException("Unsupported data type: " + dataType);
     }
   }
 
-  private Object getSingleValueForType(FieldSpec.DataType dataType) {
+  private Object getSingleValueForType(DataType dataType) {
     switch (dataType) {
       case INT:
         return 42;
@@ -608,18 +795,24 @@ public class AbstractColumnStatisticsCollectorTest {
         return 42.5f;
       case DOUBLE:
         return 42.5;
-      case STRING:
-        return "test";
-      case BYTES:
-        return new byte[]{1, 2, 3};
       case BIG_DECIMAL:
         return new BigDecimal("42.5");
+      case BOOLEAN:
+        return BooleanUtils.toInt(true);
+      case TIMESTAMP:
+        return 1000L;
+      case STRING:
+        return "test";
+      case JSON:
+        return "{\"key\":\"value\"}";
+      case BYTES:
+        return new byte[]{1, 2, 3};
       default:
         throw new IllegalArgumentException("Unsupported data type: " + dataType);
     }
   }
 
-  private Object getMinValue(FieldSpec.DataType dataType) {
+  private Object getMinValue(DataType dataType) {
     switch (dataType) {
       case INT:
         return 1;
@@ -634,7 +827,7 @@ public class AbstractColumnStatisticsCollectorTest {
     }
   }
 
-  private Object getMaxValue(FieldSpec.DataType dataType) {
+  private Object getMaxValue(DataType dataType) {
     switch (dataType) {
       case INT:
         return 10;
@@ -649,7 +842,7 @@ public class AbstractColumnStatisticsCollectorTest {
     }
   }
 
-  private Object getExpectedMinForType(FieldSpec.DataType dataType) {
+  private Object getExpectedMinForType(DataType dataType) {
     switch (dataType) {
       case INT:
         return 1;
@@ -659,18 +852,24 @@ public class AbstractColumnStatisticsCollectorTest {
         return 1.5f;
       case DOUBLE:
         return 1.5;
-      case STRING:
-        return "a";
-      case BYTES:
-        return new ByteArray(new byte[]{1});
       case BIG_DECIMAL:
         return new BigDecimal("1.0");
+      case BOOLEAN:
+        return 0;
+      case TIMESTAMP:
+        return 1000L;
+      case STRING:
+        return "a";
+      case JSON:
+        return "{\"a\":1}";
+      case BYTES:
+        return new ByteArray(new byte[]{1});
       default:
         throw new IllegalArgumentException("Unsupported data type: " + dataType);
     }
   }
 
-  private Object getExpectedMaxForType(FieldSpec.DataType dataType) {
+  private Object getExpectedMaxForType(DataType dataType) {
     switch (dataType) {
       case INT:
         return 10;
@@ -680,12 +879,18 @@ public class AbstractColumnStatisticsCollectorTest {
         return 10.5f;
       case DOUBLE:
         return 10.5;
-      case STRING:
-        return "c";
-      case BYTES:
-        return new ByteArray(new byte[]{3});
       case BIG_DECIMAL:
         return new BigDecimal("10.0");
+      case BOOLEAN:
+        return 1;
+      case TIMESTAMP:
+        return 3000L;
+      case STRING:
+        return "c";
+      case JSON:
+        return "{\"c\":3}";
+      case BYTES:
+        return new ByteArray(new byte[]{3});
       default:
         throw new IllegalArgumentException("Unsupported data type: " + dataType);
     }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/impl/stats/AbstractColumnStatisticsCollectorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/impl/stats/AbstractColumnStatisticsCollectorTest.java
@@ -22,6 +22,7 @@ import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.Set;
 import org.apache.pinot.segment.spi.creator.StatsCollectorConfig;
+import org.apache.pinot.segment.spi.partition.PartitionFunction;
 import org.apache.pinot.spi.config.table.ColumnPartitionConfig;
 import org.apache.pinot.spi.config.table.SegmentPartitionConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -387,8 +388,9 @@ public class AbstractColumnStatisticsCollectorTest {
       }
       collector.seal();
 
-      assertNotNull(collector.getPartitionFunction());
-      assertEquals(collector.getNumPartitions(), NUM_PARTITIONS);
+      PartitionFunction partitionFunction = collector.getPartitionFunction();
+      assertNotNull(partitionFunction);
+      assertEquals(partitionFunction.getNumPartitions(), NUM_PARTITIONS);
 
       Set<Integer> partitions = collector.getPartitions();
       assertNotNull(partitions);
@@ -414,7 +416,6 @@ public class AbstractColumnStatisticsCollectorTest {
       collector.seal();
 
       assertNull(collector.getPartitionFunction());
-      assertEquals(collector.getNumPartitions(), -1);
       assertNull(collector.getPartitions());
     }
   }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/impl/stats/EmptyColumnStatisticsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/impl/stats/EmptyColumnStatisticsTest.java
@@ -1,0 +1,99 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.creator.impl.stats;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.spi.data.ComplexFieldSpec;
+import org.apache.pinot.spi.data.DimensionFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+
+/// Tests for [EmptyColumnStatistics], covering all value types and SV/MV.
+public class EmptyColumnStatisticsTest {
+
+  private static final DataType[] ALL_TYPES = {
+      DataType.INT, DataType.LONG, DataType.FLOAT, DataType.DOUBLE, DataType.BIG_DECIMAL, DataType.BOOLEAN,
+      DataType.TIMESTAMP, DataType.STRING, DataType.JSON, DataType.BYTES, DataType.MAP
+  };
+
+  @DataProvider(name = "allTypesAndSV")
+  public Object[][] allTypesAndSV() {
+    List<Object[]> params = new ArrayList<>();
+    for (DataType type : ALL_TYPES) {
+      params.add(new Object[]{type, true});
+      // BIG_DECIMAL and MAP do not support MV
+      if (type != DataType.BIG_DECIMAL && type != DataType.MAP) {
+        params.add(new Object[]{type, false});
+      }
+    }
+    return params.toArray(new Object[0][]);
+  }
+
+  @Test(dataProvider = "allTypesAndSV")
+  public void testEmptyColumnStatistics(DataType type, boolean sv) {
+    FieldSpec fieldSpec = type != DataType.MAP ? new DimensionFieldSpec("col", type, sv)
+        : new ComplexFieldSpec("col", DataType.MAP, true, Map.of());
+    EmptyColumnStatistics stats = new EmptyColumnStatistics(fieldSpec);
+    DataType storedType = type.getStoredType();
+
+    // Identity
+    assertEquals(stats.getFieldSpec(), fieldSpec);
+    assertEquals(stats.getValueType(), storedType);
+    assertEquals(stats.isSingleValue(), sv);
+
+    // Empty: no values
+    assertNull(stats.getMinValue());
+    assertNull(stats.getMaxValue());
+    assertNull(stats.getUniqueValuesSet());
+    assertEquals(stats.getCardinality(), 0);
+    assertEquals(stats.getTotalNumberOfEntries(), 0);
+    assertEquals(stats.getMaxNumberOfMultiValues(), 0);
+    assertEquals(stats.getMaxRowLengthInBytes(), 0);
+
+    // Sorted: empty SV is sorted, empty MV is not
+    assertEquals(stats.isSorted(), sv);
+
+    // Element lengths: fixed-width -> type size; var-width -> 0
+    if (storedType.isFixedWidth()) {
+      assertEquals(stats.getLengthOfShortestElement(), storedType.size());
+      assertEquals(stats.getLengthOfLongestElement(), storedType.size());
+    } else {
+      assertEquals(stats.getLengthOfShortestElement(), 0);
+      assertEquals(stats.getLengthOfLongestElement(), 0);
+    }
+    assertTrue(stats.isFixedLength());
+    assertFalse(stats.isAscii());
+
+    // Partition: empty
+    assertNull(stats.getPartitionFunction());
+    assertEquals(stats.getNumPartitions(), 0);
+    assertNull(stats.getPartitionFunctionConfig());
+    assertNull(stats.getPartitions());
+  }
+}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/impl/stats/EmptyColumnStatisticsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/impl/stats/EmptyColumnStatisticsTest.java
@@ -59,7 +59,7 @@ public class EmptyColumnStatisticsTest {
   public void testEmptyColumnStatistics(DataType type, boolean sv) {
     FieldSpec fieldSpec = type != DataType.MAP ? new DimensionFieldSpec("col", type, sv)
         : new ComplexFieldSpec("col", DataType.MAP, true, Map.of());
-    EmptyColumnStatistics stats = new EmptyColumnStatistics(fieldSpec);
+    EmptyColumnStatistics stats = new EmptyColumnStatistics(fieldSpec, null, null);
     DataType storedType = type.getStoredType();
 
     // Identity
@@ -92,8 +92,6 @@ public class EmptyColumnStatisticsTest {
 
     // Partition: empty
     assertNull(stats.getPartitionFunction());
-    assertEquals(stats.getNumPartitions(), 0);
-    assertNull(stats.getPartitionFunctionConfig());
     assertNull(stats.getPartitions());
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/impl/stats/MapColumnPreIndexStatsCollectorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/impl/stats/MapColumnPreIndexStatsCollectorTest.java
@@ -118,7 +118,7 @@ public class MapColumnPreIndexStatsCollectorTest {
     assertEquals(keyStrStats.getTotalNumberOfEntries(), 3);
     assertEquals(keyStrStats.getMaxNumberOfMultiValues(), 0);
     assertFalse(keyStrStats.isSorted());
-    assertEquals(keyStrStats.getLengthOfLargestElement(), 5);
+    assertEquals(keyStrStats.getLengthOfLongestElement(), 5);
     assertTrue(keyStrStats instanceof StringColumnPreIndexStatsCollector);
 
     AbstractColumnStatisticsCollector keyIntStats = mapCollector.getKeyStatistics("kInt");
@@ -221,7 +221,7 @@ public class MapColumnPreIndexStatsCollectorTest {
     assertEquals(mapNoDict.getMaxNumberOfMultiValues(), mapDict.getMaxNumberOfMultiValues());
     assertEquals(mapNoDict.isSorted(), mapDict.isSorted());
     assertEquals(mapNoDict.getLengthOfShortestElement(), mapDict.getLengthOfShortestElement());
-    assertEquals(mapNoDict.getLengthOfLargestElement(), mapDict.getLengthOfLargestElement());
+    assertEquals(mapNoDict.getLengthOfLongestElement(), mapDict.getLengthOfLongestElement());
     assertEquals(mapNoDict.getMaxRowLengthInBytes(), mapDict.getMaxRowLengthInBytes());
 
     // Partition metadata
@@ -309,7 +309,7 @@ public class MapColumnPreIndexStatsCollectorTest {
     int expectedMin = Math.min(l1, Math.min(l2, l3));
     int expectedMax = Math.max(l1, Math.max(l2, l3));
     assertEquals(col.getLengthOfShortestElement(), expectedMin);
-    assertEquals(col.getLengthOfLargestElement(), expectedMax);
+    assertEquals(col.getLengthOfLongestElement(), expectedMax);
     assertEquals(col.getMaxRowLengthInBytes(), expectedMax);
   }
 
@@ -474,7 +474,7 @@ public class MapColumnPreIndexStatsCollectorTest {
 
     AbstractColumnStatisticsCollector keyStats = col.getKeyStatistics("blob");
     assertNotNull(keyStats);
-    assertTrue(keyStats instanceof BytesColumnPredIndexStatsCollector);
+    assertTrue(keyStats instanceof BytesColumnPreIndexStatsCollector);
     assertEquals(keyStats.getMinValue(), new ByteArray(new byte[]{1, 2}));
     assertEquals(keyStats.getMaxValue(), new ByteArray(new byte[]{1, 3}));
     assertEquals(keyStats.getCardinality(), 2);

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/impl/stats/MapColumnPreIndexStatsCollectorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/impl/stats/MapColumnPreIndexStatsCollectorTest.java
@@ -23,7 +23,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.TreeMap;
 import org.apache.pinot.segment.local.segment.index.map.MapIndexReaderWrapper;
 import org.apache.pinot.segment.local.segment.index.map.MapKeyIndexReader;
@@ -232,10 +231,8 @@ public class MapColumnPreIndexStatsCollectorTest {
       assertNull(pfDict);
     } else {
       assertEquals(pfNoDict.getName(), pfDict.getName());
-      assertEquals(mapNoDict.getNumPartitions(), mapDict.getNumPartitions());
-      Set<Integer> partsNoDict = mapNoDict.getPartitions();
-      Set<Integer> partsDict = mapDict.getPartitions();
-      assertEquals(partsNoDict, partsDict);
+      assertEquals(pfNoDict.getNumPartitions(), pfDict.getNumPartitions());
+      assertEquals(mapNoDict.getPartitions(), mapDict.getPartitions());
     }
 
     // Compare per-key collectors exposed via getKeyStatistics

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/impl/stats/NoDictColumnStatisticsCollectorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/impl/stats/NoDictColumnStatisticsCollectorTest.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.segment.local.segment.creator.impl.stats;
 
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -31,52 +32,73 @@ import org.apache.pinot.spi.config.table.ColumnPartitionConfig;
 import org.apache.pinot.spi.config.table.SegmentPartitionConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.DimensionFieldSpec;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.utils.ByteArray;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 
 public class NoDictColumnStatisticsCollectorTest {
 
-  private static StatsCollectorConfig newConfig(FieldSpec.DataType dataType, boolean isSingleValue) {
-    TableConfig tableConfig = new TableConfigBuilder(org.apache.pinot.spi.config.table.TableType.OFFLINE)
-        .setTableName("testTable")
-        .setSegmentPartitionConfig(new SegmentPartitionConfig(
-            Collections.singletonMap("col", new ColumnPartitionConfig("murmur", 4))))
-        .build();
+  private static StatsCollectorConfig newConfig(DataType dataType, boolean isSingleValue) {
+    TableConfig tableConfig =
+        new TableConfigBuilder(org.apache.pinot.spi.config.table.TableType.OFFLINE).setTableName("testTable")
+            .setSegmentPartitionConfig(
+                new SegmentPartitionConfig(Collections.singletonMap("col", new ColumnPartitionConfig("murmur", 4))))
+            .build();
     Schema schema = new Schema();
     schema.addField(new DimensionFieldSpec("col", dataType, isSingleValue));
 
     return new StatsCollectorConfig(tableConfig, schema, tableConfig.getIndexingConfig().getSegmentPartitionConfig());
   }
 
+  // ======== DataProviders ========
+
   @DataProvider(name = "primitiveTypeTestData")
   public Object[][] primitiveTypeTestData() {
-    return new Object[][] {
+    return new Object[][]{
         // Ensure data has exactly 1 duplicate entry and total 4 entries
 
-        // Sorted data
-        {FieldSpec.DataType.INT, new Object[]{5, 5, 10, 20}, true},
-        {FieldSpec.DataType.LONG, new Object[]{1L, 1L, 15L, 25L}, true},
-        {FieldSpec.DataType.FLOAT, new Object[]{1.5f, 1.5f, 3.5f, 7.5f}, true},
-        {FieldSpec.DataType.DOUBLE, new Object[]{2.5, 2.5, 4.5, 8.5}, true},
+        // Sorted data (INT, LONG, FLOAT, DOUBLE)
+        {DataType.INT, new Object[]{5, 5, 10, 20}, true}, {DataType.LONG, new Object[]{1L, 1L, 15L, 25L}, true},
+        {DataType.FLOAT, new Object[]{1.5f, 1.5f, 3.5f, 7.5f}, true}, {DataType.DOUBLE, new Object[]{2.5, 2.5, 4.5,
+        8.5}, true},
 
+        // Unsorted data (INT, LONG, FLOAT, DOUBLE)
+        {DataType.INT, new Object[]{10, 5, 20, 5}, false}, {DataType.LONG, new Object[]{15L, 1L, 25L, 1L}, false},
+        {DataType.FLOAT, new Object[]{3.5f, 1.5f, 7.5f, 1.5f}, false}, {DataType.DOUBLE, new Object[]{4.5, 2.5, 8.5,
+        2.5}, false}
+    };
+  }
+
+  @DataProvider(name = "bigDecimalTypeTestData")
+  public Object[][] bigDecimalTypeTestData() {
+    return new Object[][]{
+        // Ensure data has exactly 1 duplicate entry and total 4 entries
+        // Sorted data
+        {
+            new BigDecimal[]{
+                new BigDecimal("1.23"), new BigDecimal("1.23"), new BigDecimal("2.34"), new BigDecimal("9.99")
+            }, true
+        },
         // Unsorted data
-        {FieldSpec.DataType.INT, new Object[]{10, 5, 20, 5}, false},
-        {FieldSpec.DataType.LONG, new Object[]{15L, 1L, 25L, 1L}, false},
-        {FieldSpec.DataType.FLOAT, new Object[]{3.5f, 1.5f, 7.5f, 1.5f}, false},
-        {FieldSpec.DataType.DOUBLE, new Object[]{4.5, 2.5, 8.5, 2.5}, false}
+        {
+            new BigDecimal[]{
+                new BigDecimal("2.34"), new BigDecimal("1.23"), new BigDecimal("9.99"), new BigDecimal("1.23")
+            }, false
+        }
     };
   }
 
   @DataProvider(name = "stringTypeTestData")
   public Object[][] stringTypeTestData() {
-    return new Object[][] {
+    return new Object[][]{
         // Ensure data has exactly 1 duplicate entry and total 4 entries
         // Sorted data
         {new String[]{"a", "a", "bbb", "ccc"}, true},
@@ -87,7 +109,7 @@ public class NoDictColumnStatisticsCollectorTest {
 
   @DataProvider(name = "bytesTypeTestData")
   public Object[][] bytesTypeTestData() {
-    return new Object[][] {
+    return new Object[][]{
         // Ensure data has exactly 1 duplicate entry and total 4 entries
         // Sorted data
         {new byte[][]{new byte[]{1}, new byte[]{1}, new byte[]{2}, new byte[]{3}}, true},
@@ -96,29 +118,45 @@ public class NoDictColumnStatisticsCollectorTest {
     };
   }
 
-  @DataProvider(name = "bigDecimalTypeTestData")
-  public Object[][] bigDecimalTypeTestData() {
-    return new Object[][] {
-        // Ensure data has exactly 1 duplicate entry and total 4 entries
-        // Sorted data
-        {new BigDecimal[]{
-            new BigDecimal("1.23"), new BigDecimal("1.23"), new BigDecimal("2.34"), new BigDecimal("9.99")}, true},
-        // Unsorted data
-        {new BigDecimal[]{
-            new BigDecimal("2.34"), new BigDecimal("1.23"), new BigDecimal("9.99"), new BigDecimal("1.23")}, false}
+  @DataProvider(name = "primitiveMVTypeTestData")
+  public Object[][] primitiveMVTypeTestData() {
+    return new Object[][]{
+        // Two MV rows with one duplicate across total 4 values -> cardinality 3
+        // (INT, LONG, FLOAT, DOUBLE)
+        {DataType.INT, new int[][]{new int[]{5, 10}, new int[]{5, 20}}},
+        {DataType.LONG, new long[][]{new long[]{1L, 15L}, new long[]{1L, 25L}}},
+        {DataType.FLOAT, new float[][]{new float[]{1.5f, 3.5f}, new float[]{1.5f, 7.5f}}},
+        {DataType.DOUBLE, new double[][]{new double[]{2.5, 4.5}, new double[]{2.5, 8.5}}}
     };
   }
 
+  @DataProvider(name = "stringMVTypeTestData")
+  public Object[][] stringMVTypeTestData() {
+    return new Object[][]{
+        // Two MV rows with one duplicate across total 4 values -> cardinality 3
+        {new String[][]{new String[]{"a", "bbb"}, new String[]{"a", "ccc"}}}
+    };
+  }
+
+  @DataProvider(name = "bytesMVTypeTestData")
+  public Object[][] bytesMVTypeTestData() {
+    return new Object[][]{
+        // Two MV rows with one duplicate across total 4 values
+        {new byte[][][]{new byte[][]{new byte[]{1}, new byte[]{2}}, new byte[][]{new byte[]{1}, new byte[]{3}}}}
+    };
+  }
+
+  // ======== SV Tests ========
+
   @Test(dataProvider = "primitiveTypeTestData")
-  public void testSVPrimitiveTypes(FieldSpec.DataType dataType, Object[] entries, boolean isSorted) {
-    NoDictColumnStatisticsCollector c = new NoDictColumnStatisticsCollector("col",
-        newConfig(dataType, true));
+  public void testSVPrimitiveTypes(DataType dataType, Object[] entries, boolean isSorted) {
+    NoDictColumnStatisticsCollector c = new NoDictColumnStatisticsCollector("col", newConfig(dataType, true));
     for (Object entry : entries) {
       c.collect(entry);
     }
     c.seal();
 
-    AbstractColumnStatisticsCollector expectedStatsCollector = null;
+    AbstractColumnStatisticsCollector expectedStatsCollector;
     switch (dataType) {
       case INT:
         expectedStatsCollector = new IntColumnPreIndexStatsCollector("col", newConfig(dataType, true));
@@ -140,115 +178,108 @@ public class NoDictColumnStatisticsCollectorTest {
     }
     expectedStatsCollector.seal();
 
-    assertEquals(c.getCardinality(), 3);
     assertEquals(c.getMinValue(), expectedStatsCollector.getMinValue());
     assertEquals(c.getMaxValue(), expectedStatsCollector.getMaxValue());
+    assertEquals(c.getCardinality(), 3);
+    assertEquals(c.getLengthOfShortestElement(), dataType.size());
+    assertEquals(c.getLengthOfLongestElement(), dataType.size());
+    assertTrue(c.isFixedLength());
+    assertEquals(c.isSorted(), isSorted);
     assertEquals(c.getTotalNumberOfEntries(), 4);
     assertEquals(c.getMaxNumberOfMultiValues(), 0);
-    assertEquals(c.isSorted(), isSorted);
-    assertEquals(c.getLengthOfShortestElement(), 8);
-    assertEquals(c.getLengthOfLargestElement(), 8);
-    assertEquals(c.getMaxRowLengthInBytes(), 8);
+    assertEquals(c.getMaxRowLengthInBytes(), dataType.size());
     assertEquals(c.getPartitions(), expectedStatsCollector.getPartitions());
+  }
+
+  @Test(dataProvider = "bigDecimalTypeTestData")
+  public void testSVBigDecimal(BigDecimal[] entries, boolean isSorted) {
+    NoDictColumnStatisticsCollector c =
+        new NoDictColumnStatisticsCollector("col", newConfig(DataType.BIG_DECIMAL, true));
+    for (BigDecimal e : entries) {
+      c.collect(e);
+    }
+    c.seal();
+
+    BigDecimalColumnPreIndexStatsCollector bigDecimalStats =
+        new BigDecimalColumnPreIndexStatsCollector("col", newConfig(DataType.BIG_DECIMAL, true));
+    for (BigDecimal e : entries) {
+      bigDecimalStats.collect(e);
+    }
+    bigDecimalStats.seal();
+
+    assertEquals(c.getMinValue(), bigDecimalStats.getMinValue());
+    assertEquals(c.getMaxValue(), bigDecimalStats.getMaxValue());
+    assertEquals(c.getCardinality(), 3);
+    assertEquals(c.getLengthOfShortestElement(), bigDecimalStats.getLengthOfShortestElement());
+    assertEquals(c.getLengthOfLongestElement(), bigDecimalStats.getLengthOfLongestElement());
+    assertEquals(c.isFixedLength(), bigDecimalStats.isFixedLength());
+    assertEquals(c.isSorted(), isSorted);
+    assertEquals(c.getTotalNumberOfEntries(), entries.length);
+    assertEquals(c.getMaxNumberOfMultiValues(), 0);
+    assertEquals(c.getMaxRowLengthInBytes(), bigDecimalStats.getMaxRowLengthInBytes());
+    assertEquals(c.getPartitions(), bigDecimalStats.getPartitions());
   }
 
   @Test(dataProvider = "stringTypeTestData")
   public void testSVString(String[] entries, boolean isSorted) {
-    NoDictColumnStatisticsCollector c = new NoDictColumnStatisticsCollector("col",
-        newConfig(FieldSpec.DataType.STRING, true));
+    NoDictColumnStatisticsCollector c = new NoDictColumnStatisticsCollector("col", newConfig(DataType.STRING, true));
     for (String e : entries) {
       c.collect(e);
     }
     c.seal();
 
-    StringColumnPreIndexStatsCollector stringStats = new StringColumnPreIndexStatsCollector("col",
-        newConfig(FieldSpec.DataType.STRING, true));
+    StringColumnPreIndexStatsCollector stringStats =
+        new StringColumnPreIndexStatsCollector("col", newConfig(DataType.STRING, true));
     for (String e : entries) {
       stringStats.collect(e);
     }
     stringStats.seal();
 
-    assertEquals(c.getCardinality(), 3);
     assertEquals(c.getMinValue(), "a");
     assertEquals(c.getMaxValue(), "ccc");
+    assertEquals(c.getCardinality(), 3);
+    assertEquals(c.getLengthOfShortestElement(), 1);
+    assertEquals(c.getLengthOfLongestElement(), 3);
+    assertFalse(c.isFixedLength());
+    assertEquals(c.isSorted(), isSorted);
     assertEquals(c.getTotalNumberOfEntries(), entries.length);
     assertEquals(c.getMaxNumberOfMultiValues(), 0);
-    assertEquals(c.isSorted(), isSorted);
-    assertEquals(c.getLengthOfShortestElement(), 1);
-    assertEquals(c.getLengthOfLargestElement(), 3);
     assertEquals(c.getMaxRowLengthInBytes(), 3);
     assertEquals(c.getPartitions(), stringStats.getPartitions());
   }
 
   @Test(dataProvider = "bytesTypeTestData")
   public void testSVBytes(byte[][] entries, boolean isSorted) {
-    NoDictColumnStatisticsCollector c = new NoDictColumnStatisticsCollector("col",
-        newConfig(FieldSpec.DataType.BYTES, true));
+    NoDictColumnStatisticsCollector c = new NoDictColumnStatisticsCollector("col", newConfig(DataType.BYTES, true));
     for (byte[] e : entries) {
       c.collect(e);
     }
     c.seal();
 
-    BytesColumnPredIndexStatsCollector bytesStats = new BytesColumnPredIndexStatsCollector("col",
-        newConfig(FieldSpec.DataType.BYTES, true));
+    BytesColumnPreIndexStatsCollector bytesStats =
+        new BytesColumnPreIndexStatsCollector("col", newConfig(DataType.BYTES, true));
     for (byte[] e : entries) {
       bytesStats.collect(e);
     }
     bytesStats.seal();
 
-    assertEquals(c.getCardinality(), bytesStats.getCardinality());
     assertEquals(c.getMinValue(), bytesStats.getMinValue());
     assertEquals(c.getMaxValue(), bytesStats.getMaxValue());
+    assertEquals(c.getCardinality(), bytesStats.getCardinality());
+    assertEquals(c.getLengthOfShortestElement(), bytesStats.getLengthOfShortestElement());
+    assertEquals(c.getLengthOfLongestElement(), bytesStats.getLengthOfLongestElement());
+    assertEquals(c.isFixedLength(), bytesStats.isFixedLength());
+    assertEquals(c.isSorted(), isSorted);
     assertEquals(c.getTotalNumberOfEntries(), entries.length);
     assertEquals(c.getMaxNumberOfMultiValues(), 0);
-    assertEquals(c.isSorted(), isSorted);
-    assertEquals(c.getLengthOfShortestElement(), bytesStats.getLengthOfShortestElement());
-    assertEquals(c.getLengthOfLargestElement(), bytesStats.getLengthOfLargestElement());
     assertEquals(c.getMaxRowLengthInBytes(), bytesStats.getMaxRowLengthInBytes());
     assertEquals(c.getPartitions(), bytesStats.getPartitions());
   }
 
-  @Test(dataProvider = "bigDecimalTypeTestData")
-  public void testSVBigDecimal(BigDecimal[] entries, boolean isSorted) {
-    NoDictColumnStatisticsCollector c = new NoDictColumnStatisticsCollector("col",
-        newConfig(FieldSpec.DataType.BIG_DECIMAL, true));
-    for (BigDecimal e : entries) {
-      c.collect(e);
-    }
-    c.seal();
-
-    BigDecimalColumnPreIndexStatsCollector bigDecimalStats = new BigDecimalColumnPreIndexStatsCollector("col",
-        newConfig(FieldSpec.DataType.BIG_DECIMAL, true));
-    for (BigDecimal e : entries) {
-      bigDecimalStats.collect(e);
-    }
-    bigDecimalStats.seal();
-
-    assertEquals(c.getCardinality(), 3);
-    assertEquals(c.getMinValue(), bigDecimalStats.getMinValue());
-    assertEquals(c.getMaxValue(), bigDecimalStats.getMaxValue());
-    assertEquals(c.getTotalNumberOfEntries(), entries.length);
-    assertEquals(c.getMaxNumberOfMultiValues(), 0);
-    assertEquals(c.isSorted(), isSorted);
-    assertEquals(c.getLengthOfShortestElement(), bigDecimalStats.getLengthOfShortestElement());
-    assertEquals(c.getLengthOfLargestElement(), bigDecimalStats.getLengthOfLargestElement());
-    assertEquals(c.getMaxRowLengthInBytes(), bigDecimalStats.getMaxRowLengthInBytes());
-    assertEquals(c.getPartitions(), bigDecimalStats.getPartitions());
-  }
-
-  @DataProvider(name = "primitiveMVTypeTestData")
-  public Object[][] primitiveMVTypeTestData() {
-    return new Object[][] {
-        // Two MV rows with one duplicate across total 4 values -> cardinality 3
-        {FieldSpec.DataType.INT, new int[][]{new int[]{5, 10}, new int[]{5, 20}}},
-        {FieldSpec.DataType.LONG, new long[][]{new long[]{1L, 15L}, new long[]{1L, 25L}}},
-        {FieldSpec.DataType.FLOAT, new float[][]{new float[]{1.5f, 3.5f}, new float[]{1.5f, 7.5f}}},
-        {FieldSpec.DataType.DOUBLE, new double[][]{new double[]{2.5, 4.5}, new double[]{2.5, 8.5}}}
-    };
-  }
+  // ======== MV Tests ========
 
   @Test(dataProvider = "primitiveMVTypeTestData")
-  public void testMVPrimitiveTypes(FieldSpec.DataType dataType, Object entries) {
+  public void testMVPrimitiveTypes(DataType dataType, Object entries) {
     // Validate MV behavior for numeric primitives using native arrays
     // - isSorted should be false for MV columns
     // - lengths are not tracked for native MV primitives (expect -1)
@@ -287,109 +318,124 @@ public class NoDictColumnStatisticsCollectorTest {
     c.seal();
     expectedStatsCollector.seal();
 
-    assertEquals(c.getCardinality(), expectedStatsCollector.getCardinality());
     assertEquals(c.getMinValue(), expectedStatsCollector.getMinValue());
     assertEquals(c.getMaxValue(), expectedStatsCollector.getMaxValue());
+    assertEquals(c.getCardinality(), expectedStatsCollector.getCardinality());
+    assertEquals(c.getLengthOfShortestElement(), expectedStatsCollector.getLengthOfShortestElement());
+    assertEquals(c.getLengthOfLongestElement(), expectedStatsCollector.getLengthOfLongestElement());
+    assertEquals(c.isFixedLength(), expectedStatsCollector.isFixedLength());
+    assertFalse(c.isSorted());
     assertEquals(c.getTotalNumberOfEntries(), 4);
     assertEquals(c.getMaxNumberOfMultiValues(), 2);
-    assertFalse(c.isSorted());
-    assertEquals(c.getLengthOfShortestElement(), expectedStatsCollector.getLengthOfShortestElement());
-    assertEquals(c.getLengthOfLargestElement(), expectedStatsCollector.getLengthOfLargestElement());
     assertEquals(c.getMaxRowLengthInBytes(), expectedStatsCollector.getMaxRowLengthInBytes());
     assertEquals(c.getPartitions(), expectedStatsCollector.getPartitions());
   }
 
-  @DataProvider(name = "stringMVTypeTestData")
-  public Object[][] stringMVTypeTestData() {
-    return new Object[][] {
-        // Two MV rows with one duplicate across total 4 values -> cardinality 3
-        {new String[][]{new String[]{"a", "bbb"}, new String[]{"a", "ccc"}}}
-    };
-  }
-
   @Test(dataProvider = "stringMVTypeTestData")
   public void testMVString(String[][] rows) {
-    NoDictColumnStatisticsCollector c = new NoDictColumnStatisticsCollector("col",
-        newConfig(FieldSpec.DataType.STRING, false));
+    NoDictColumnStatisticsCollector c = new NoDictColumnStatisticsCollector("col", newConfig(DataType.STRING, false));
     for (String[] r : rows) {
       c.collect(r);
     }
     c.seal();
 
-    StringColumnPreIndexStatsCollector stringStats = new StringColumnPreIndexStatsCollector("col",
-        newConfig(FieldSpec.DataType.STRING, false));
+    StringColumnPreIndexStatsCollector stringStats =
+        new StringColumnPreIndexStatsCollector("col", newConfig(DataType.STRING, false));
     for (String[] r : rows) {
       stringStats.collect(r);
     }
     stringStats.seal();
 
-    assertEquals(c.getCardinality(), stringStats.getCardinality());
     assertEquals(c.getMinValue(), stringStats.getMinValue());
     assertEquals(c.getMaxValue(), stringStats.getMaxValue());
+    assertEquals(c.getCardinality(), stringStats.getCardinality());
+    assertEquals(c.getLengthOfShortestElement(), 1);
+    assertEquals(c.getLengthOfLongestElement(), 3);
+    assertFalse(c.isFixedLength());
+    assertFalse(c.isSorted());
     assertEquals(c.getTotalNumberOfEntries(), 4);
     assertEquals(c.getMaxNumberOfMultiValues(), 2);
-    assertFalse(c.isSorted());
-    assertEquals(c.getLengthOfShortestElement(), 1);
-    assertEquals(c.getLengthOfLargestElement(), 3);
     assertEquals(c.getMaxRowLengthInBytes(), 4);
     assertEquals(c.getPartitions(), stringStats.getPartitions());
   }
 
-  @DataProvider(name = "bytesMVTypeTestData")
-  public Object[][] bytesMVTypeTestData() {
-    return new Object[][] {
-        // Two MV rows with one duplicate across total 4 values
-        {new byte[][][]{new byte[][]{new byte[]{1}, new byte[]{2}}, new byte[][]{new byte[]{1}, new byte[]{3}}}}
-    };
-  }
-
   @Test(dataProvider = "bytesMVTypeTestData")
   public void testMVBytes(byte[][][] rows) {
-    NoDictColumnStatisticsCollector c = new NoDictColumnStatisticsCollector("col",
-        newConfig(FieldSpec.DataType.BYTES, false));
+    NoDictColumnStatisticsCollector c = new NoDictColumnStatisticsCollector("col", newConfig(DataType.BYTES, false));
     for (byte[][] r : rows) {
       c.collect(r);
     }
     c.seal();
 
-    BytesColumnPredIndexStatsCollector bytesStats = new BytesColumnPredIndexStatsCollector("col",
-        newConfig(FieldSpec.DataType.BYTES, false));
+    BytesColumnPreIndexStatsCollector bytesStats =
+        new BytesColumnPreIndexStatsCollector("col", newConfig(DataType.BYTES, false));
     for (byte[][] r : rows) {
       bytesStats.collect(r);
     }
     bytesStats.seal();
 
-    assertEquals(c.getCardinality(), bytesStats.getCardinality());
     assertEquals(c.getMinValue(), bytesStats.getMinValue());
     assertEquals(c.getMaxValue(), bytesStats.getMaxValue());
+    assertEquals(c.getCardinality(), bytesStats.getCardinality());
+    assertEquals(c.getLengthOfShortestElement(), bytesStats.getLengthOfShortestElement());
+    assertEquals(c.getLengthOfLongestElement(), bytesStats.getLengthOfLongestElement());
+    assertEquals(c.isFixedLength(), bytesStats.isFixedLength());
+    assertFalse(c.isSorted());
     assertEquals(c.getTotalNumberOfEntries(), 4);
     assertEquals(c.getMaxNumberOfMultiValues(), 2);
-    assertFalse(c.isSorted());
-    assertEquals(c.getLengthOfShortestElement(), bytesStats.getLengthOfShortestElement());
-    assertEquals(c.getLengthOfLargestElement(), bytesStats.getLengthOfLargestElement());
     assertEquals(c.getMaxRowLengthInBytes(), bytesStats.getMaxRowLengthInBytes());
     assertEquals(c.getPartitions(), bytesStats.getPartitions());
   }
 
+  // ======== isAscii ========
+
   @Test
-  public void testMVBigDecimal()
-      throws Exception {
-    NoDictColumnStatisticsCollector c = new NoDictColumnStatisticsCollector("col",
-        newConfig(FieldSpec.DataType.BIG_DECIMAL, false));
-    try {
-      c.collect(new Object[] {new BigDecimal("1.1"), new BigDecimal("2.2")});
-      fail("Expected UnsupportedOperationException");
-    } catch (UnsupportedOperationException expected) {
-      // expected: BigDecimal MV not supported by NoDict collector by design
-    }
+  public void testIsAsciiStringSvAllAscii() {
+    NoDictColumnStatisticsCollector c = new NoDictColumnStatisticsCollector("col", newConfig(DataType.STRING, true));
+    c.collect("hello");
+    c.collect("world");
+    c.seal();
+
+    assertTrue(c.isAscii());
   }
+
+  @Test
+  public void testIsAsciiStringSvNonAscii() {
+    NoDictColumnStatisticsCollector c = new NoDictColumnStatisticsCollector("col", newConfig(DataType.STRING, true));
+    c.collect("hello");
+    c.collect("café");
+    c.seal();
+
+    assertFalse(c.isAscii());
+  }
+
+  @Test
+  public void testIsAsciiStringMvNonAscii() {
+    NoDictColumnStatisticsCollector c = new NoDictColumnStatisticsCollector("col", newConfig(DataType.STRING, false));
+    c.collect(new String[]{"hello", "world"});
+    c.collect(new String[]{"café"});
+    c.seal();
+
+    assertFalse(c.isAscii());
+  }
+
+  @Test
+  public void testIsAsciiIntType() {
+    NoDictColumnStatisticsCollector c = new NoDictColumnStatisticsCollector("col", newConfig(DataType.INT, true));
+    c.collect(42);
+    c.seal();
+
+    assertFalse(c.isAscii());
+  }
+
+  // ======== Randomized Test ========
 
   // A test that picks a random data type, generates random data for that type (sorted or unsorted,
   // single or multi value, high or low or medium cardinality), collects stats using NoDictColumnStatisticsCollector
   // and the corresponding PreIndexStatsCollector, and compares the stats.
   // Runs this setup multiple times to cover different scenarios.
   @Test
-  public void testRandomizedDataComparison() throws Exception {
+  public void testRandomizedDataComparison() {
     Random random = new Random();
 
     // Run multiple iterations with different random scenarios
@@ -398,17 +444,16 @@ public class NoDictColumnStatisticsCollectorTest {
     }
   }
 
-  private void runRandomizedTest(Random random, int iteration) throws Exception {
+  private void runRandomizedTest(Random random, int iteration) {
     // Randomly select data type (excluding BIG_DECIMAL for MV as it's unsupported)
-    FieldSpec.DataType[] supportedTypes = {
-        FieldSpec.DataType.INT, FieldSpec.DataType.LONG, FieldSpec.DataType.FLOAT,
-        FieldSpec.DataType.DOUBLE, FieldSpec.DataType.STRING, FieldSpec.DataType.BYTES,
-        FieldSpec.DataType.BIG_DECIMAL
+    DataType[] supportedTypes = {
+        DataType.INT, DataType.LONG, DataType.FLOAT, DataType.DOUBLE, DataType.BIG_DECIMAL, DataType.STRING,
+        DataType.BYTES
     };
-    FieldSpec.DataType dataType = supportedTypes[random.nextInt(supportedTypes.length)];
+    DataType dataType = supportedTypes[random.nextInt(supportedTypes.length)];
 
     // Randomly choose single vs multi-value (skip MV for BIG_DECIMAL)
-    boolean isSingleValue = dataType == FieldSpec.DataType.BIG_DECIMAL || random.nextBoolean();
+    boolean isSingleValue = dataType == DataType.BIG_DECIMAL || random.nextBoolean();
 
     // Randomly choose cardinality level
     CardinalityLevel cardinalityLevel = CardinalityLevel.values()[random.nextInt(CardinalityLevel.values().length)];
@@ -419,9 +464,9 @@ public class NoDictColumnStatisticsCollectorTest {
     try {
       runTestForConfiguration(dataType, isSingleValue, cardinalityLevel, shouldBeSorted, random, iteration);
     } catch (Exception e) {
-      throw new RuntimeException(String.format(
-          "Test failed for iteration %d: dataType=%s, isSingleValue=%s, cardinality=%s, sorted=%s",
-          iteration, dataType, isSingleValue, cardinalityLevel, shouldBeSorted), e);
+      throw new RuntimeException(
+          String.format("Test failed for iteration %d: dataType=%s, isSingleValue=%s, cardinality=%s, sorted=%s",
+              iteration, dataType, isSingleValue, cardinalityLevel, shouldBeSorted), e);
     }
   }
 
@@ -443,9 +488,8 @@ public class NoDictColumnStatisticsCollectorTest {
     }
   }
 
-  private void runTestForConfiguration(FieldSpec.DataType dataType, boolean isSingleValue,
-      CardinalityLevel cardinalityLevel, boolean shouldBeSorted, Random random, int iteration) throws Exception {
-
+  private void runTestForConfiguration(DataType dataType, boolean isSingleValue, CardinalityLevel cardinalityLevel,
+      boolean shouldBeSorted, Random random, int iteration) {
     int uniqueValueCount = cardinalityLevel.getUniqueCount(random);
     int totalEntries = uniqueValueCount + random.nextInt(uniqueValueCount * 2); // Add some duplicates
 
@@ -460,8 +504,7 @@ public class NoDictColumnStatisticsCollectorTest {
     // Create collectors
     NoDictColumnStatisticsCollector noDictCollector =
         new NoDictColumnStatisticsCollector("col", newConfig(dataType, isSingleValue));
-    AbstractColumnStatisticsCollector expectedCollector =
-        createDictCollector(dataType, isSingleValue);
+    AbstractColumnStatisticsCollector expectedCollector = createDictCollector(dataType, isSingleValue);
 
     // Collect stats from both collectors
     for (Object entry : testData) {
@@ -476,8 +519,8 @@ public class NoDictColumnStatisticsCollectorTest {
     compareCollectorStats(noDictCollector, expectedCollector, dataType, isSingleValue, iteration, testData);
   }
 
-  private Object[] generateData(FieldSpec.DataType dataType, boolean isSingleValue,
-      int uniqueValueCount, int totalEntries, boolean shouldBeSorted, Random random) {
+  private Object[] generateData(DataType dataType, boolean isSingleValue, int uniqueValueCount, int totalEntries,
+      boolean shouldBeSorted, Random random) {
 
     try {
       switch (dataType) {
@@ -489,12 +532,12 @@ public class NoDictColumnStatisticsCollectorTest {
           return generateFloatData(isSingleValue, uniqueValueCount, totalEntries, shouldBeSorted, random);
         case DOUBLE:
           return generateDoubleData(isSingleValue, uniqueValueCount, totalEntries, shouldBeSorted, random);
+        case BIG_DECIMAL:
+          return generateBigDecimalData(isSingleValue, uniqueValueCount, totalEntries, shouldBeSorted, random);
         case STRING:
           return generateStringData(isSingleValue, uniqueValueCount, totalEntries, shouldBeSorted, random);
         case BYTES:
           return generateBytesData(isSingleValue, uniqueValueCount, totalEntries, shouldBeSorted, random);
-        case BIG_DECIMAL:
-          return generateBigDecimalData(isSingleValue, uniqueValueCount, totalEntries, shouldBeSorted, random);
         default:
           return null;
       }
@@ -564,6 +607,21 @@ public class NoDictColumnStatisticsCollectorTest {
     }
   }
 
+  private Object[] generateBigDecimalData(boolean isSingleValue, int uniqueValueCount, int totalEntries,
+      boolean shouldBeSorted, Random random) {
+    if (!isSingleValue) {
+      throw new UnsupportedOperationException("BigDecimal MV not supported");
+    }
+
+    Set<BigDecimal> uniqueValues = new HashSet<>();
+    while (uniqueValues.size() < uniqueValueCount) {
+      uniqueValues.add(new BigDecimal(random.nextDouble() * 1000).setScale(2, RoundingMode.HALF_UP));
+    }
+    List<BigDecimal> values = new ArrayList<>(uniqueValues);
+
+    return generateSingleValueData(values, totalEntries, shouldBeSorted, random).toArray();
+  }
+
   private Object[] generateStringData(boolean isSingleValue, int uniqueValueCount, int totalEntries,
       boolean shouldBeSorted, Random random) {
     Set<String> uniqueValues = new HashSet<>();
@@ -599,23 +657,8 @@ public class NoDictColumnStatisticsCollectorTest {
     }
   }
 
-  private Object[] generateBigDecimalData(boolean isSingleValue, int uniqueValueCount, int totalEntries,
+  private <T extends Comparable<T>> List<T> generateSingleValueData(List<T> uniqueValues, int totalEntries,
       boolean shouldBeSorted, Random random) {
-    if (!isSingleValue) {
-      throw new UnsupportedOperationException("BigDecimal MV not supported");
-    }
-
-    Set<BigDecimal> uniqueValues = new HashSet<>();
-    while (uniqueValues.size() < uniqueValueCount) {
-      uniqueValues.add(new BigDecimal(random.nextDouble() * 1000).setScale(2, BigDecimal.ROUND_HALF_UP));
-    }
-    List<BigDecimal> values = new ArrayList<>(uniqueValues);
-
-    return generateSingleValueData(values, totalEntries, shouldBeSorted, random).toArray();
-  }
-
-  private <T extends Comparable<T>> List<T> generateSingleValueData(List<T> uniqueValues,
-      int totalEntries, boolean shouldBeSorted, Random random) {
     List<T> result = new ArrayList<>();
     for (int i = 0; i < totalEntries; i++) {
       result.add(uniqueValues.get(random.nextInt(uniqueValues.size())));
@@ -628,8 +671,8 @@ public class NoDictColumnStatisticsCollectorTest {
     return result;
   }
 
-  private Object[] generateSingleValueByteArrayData(List<byte[]> uniqueValues,
-      int totalEntries, boolean shouldBeSorted, Random random) {
+  private Object[] generateSingleValueByteArrayData(List<byte[]> uniqueValues, int totalEntries, boolean shouldBeSorted,
+      Random random) {
     List<byte[]> result = new ArrayList<>();
     for (int i = 0; i < totalEntries; i++) {
       result.add(uniqueValues.get(random.nextInt(uniqueValues.size())));
@@ -753,7 +796,7 @@ public class NoDictColumnStatisticsCollectorTest {
     return bytes;
   }
 
-  private AbstractColumnStatisticsCollector createDictCollector(FieldSpec.DataType dataType, boolean isSingleValue) {
+  private AbstractColumnStatisticsCollector createDictCollector(DataType dataType, boolean isSingleValue) {
     switch (dataType) {
       case INT:
         return new IntColumnPreIndexStatsCollector("col", newConfig(dataType, isSingleValue));
@@ -763,48 +806,47 @@ public class NoDictColumnStatisticsCollectorTest {
         return new FloatColumnPreIndexStatsCollector("col", newConfig(dataType, isSingleValue));
       case DOUBLE:
         return new DoubleColumnPreIndexStatsCollector("col", newConfig(dataType, isSingleValue));
+      case BIG_DECIMAL:
+        return new BigDecimalColumnPreIndexStatsCollector("col", newConfig(dataType, isSingleValue));
       case STRING:
         return new StringColumnPreIndexStatsCollector("col", newConfig(dataType, isSingleValue));
       case BYTES:
-        return new BytesColumnPredIndexStatsCollector("col", newConfig(dataType, isSingleValue));
-      case BIG_DECIMAL:
-        return new BigDecimalColumnPreIndexStatsCollector("col", newConfig(dataType, isSingleValue));
+        return new BytesColumnPreIndexStatsCollector("col", newConfig(dataType, isSingleValue));
       default:
         throw new IllegalArgumentException("Unsupported data type: " + dataType);
     }
   }
 
   private void compareCollectorStats(NoDictColumnStatisticsCollector noDictCollector,
-      AbstractColumnStatisticsCollector expectedCollector, FieldSpec.DataType dataType,
-      boolean isSingleValue, int iteration, Object[] testData) {
+      AbstractColumnStatisticsCollector expectedCollector, DataType dataType, boolean isSingleValue, int iteration,
+      Object[] testData) {
 
-    String context = String.format("Iteration %d, DataType: %s, SingleValue: %s, Data: %s",
-        iteration, dataType, isSingleValue, Arrays.deepToString(testData));
+    String context =
+        String.format("Iteration %d, DataType: %s, SingleValue: %s, Data: %s", iteration, dataType, isSingleValue,
+            Arrays.deepToString(testData));
 
+    assertEquals(noDictCollector.getMinValue(), expectedCollector.getMinValue(), "MinValue mismatch - " + context);
+    assertEquals(noDictCollector.getMaxValue(), expectedCollector.getMaxValue(), "MaxValue mismatch - " + context);
     int approx = noDictCollector.getCardinality();
     int exact = expectedCollector.getCardinality();
     assertTrue(approx >= exact,
-        "Approx Cardinality " + approx + " is lower than actual cardinality "
-            + exact + " for " + context);
-    assertEquals(noDictCollector.getMinValue(), expectedCollector.getMinValue(),
-        "MinValue mismatch - " + context);
-    assertEquals(noDictCollector.getMaxValue(), expectedCollector.getMaxValue(),
-        "MaxValue mismatch - " + context);
+        "Approx Cardinality " + approx + " is lower than actual cardinality " + exact + " for " + context);
+    if (dataType != DataType.INT && dataType != DataType.LONG && dataType != DataType.FLOAT
+        && dataType != DataType.DOUBLE) {
+      assertEquals(noDictCollector.getLengthOfShortestElement(), expectedCollector.getLengthOfShortestElement(),
+          "LengthOfShortestElement mismatch - " + context);
+      assertEquals(noDictCollector.getLengthOfLongestElement(), expectedCollector.getLengthOfLongestElement(),
+          "LengthOfLongestElement mismatch - " + context);
+      assertEquals(noDictCollector.isFixedLength(), expectedCollector.isFixedLength(),
+          "isFixedLength mismatch - " + context);
+    }
+    assertEquals(noDictCollector.isSorted(), expectedCollector.isSorted(), "isSorted mismatch - " + context);
     assertEquals(noDictCollector.getTotalNumberOfEntries(), expectedCollector.getTotalNumberOfEntries(),
         "TotalNumberOfEntries mismatch - " + context);
     assertEquals(noDictCollector.getMaxNumberOfMultiValues(), expectedCollector.getMaxNumberOfMultiValues(),
         "MaxNumberOfMultiValues mismatch - " + context);
-    assertEquals(noDictCollector.isSorted(), expectedCollector.isSorted(),
-        "isSorted mismatch - " + context);
-    if (dataType != FieldSpec.DataType.INT && dataType != FieldSpec.DataType.LONG
-        && dataType != FieldSpec.DataType.FLOAT && dataType != FieldSpec.DataType.DOUBLE) {
-      if (dataType != FieldSpec.DataType.STRING) {
-        // StringCollector currently does not return shortest element length
-        assertEquals(noDictCollector.getLengthOfShortestElement(), expectedCollector.getLengthOfShortestElement(),
-            "LengthOfShortestElement mismatch - " + context);
-      }
-      assertEquals(noDictCollector.getLengthOfLargestElement(), expectedCollector.getLengthOfLargestElement(),
-          "LengthOfLargestElement mismatch - " + context);
+    if (dataType != DataType.INT && dataType != DataType.LONG && dataType != DataType.FLOAT
+        && dataType != DataType.DOUBLE) {
       assertEquals(noDictCollector.getMaxRowLengthInBytes(), expectedCollector.getMaxRowLengthInBytes(),
           "MaxRowLengthInBytes mismatch - " + context);
     }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/ColumnMetadataTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/ColumnMetadataTest.java
@@ -33,10 +33,10 @@ import org.apache.commons.io.FileUtils;
 import org.apache.pinot.segment.local.segment.creator.SegmentTestUtils;
 import org.apache.pinot.segment.local.segment.creator.impl.BaseSegmentCreator;
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentCreationDriverFactory;
-import org.apache.pinot.segment.local.segment.index.loader.defaultcolumn.DefaultColumnStatistics;
 import org.apache.pinot.segment.spi.ColumnMetadata;
 import org.apache.pinot.segment.spi.SegmentMetadata;
 import org.apache.pinot.segment.spi.V1Constants;
+import org.apache.pinot.segment.spi.creator.ColumnStatistics;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
 import org.apache.pinot.segment.spi.creator.SegmentIndexCreationDriver;
 import org.apache.pinot.segment.spi.index.IndexService;
@@ -64,6 +64,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import static org.apache.pinot.segment.spi.V1Constants.MetadataKeys.Segment.SEGMENT_PADDING_CHARACTER;
+import static org.mockito.Mockito.mock;
 import static org.testng.Assert.*;
 
 
@@ -280,10 +281,10 @@ public class ColumnMetadataTest {
     ComplexFieldSpec intMapFieldSpec = new ComplexFieldSpec("intMap", DataType.MAP, true,
         Map.of("key", new DimensionFieldSpec("key", DataType.STRING, true), "value",
             new DimensionFieldSpec("value", DataType.INT, true)));
-    DefaultColumnStatistics columnStatistics = new DefaultColumnStatistics(null, null, null, false, 1, 1);
     PropertiesConfiguration config = new PropertiesConfiguration();
     config.setProperty(SEGMENT_PADDING_CHARACTER, String.valueOf(V1Constants.Str.DEFAULT_STRING_PAD_CHAR));
-    BaseSegmentCreator.addColumnMetadataInfo(config, "intMap", columnStatistics, 1, intMapFieldSpec, false, -1, false);
+    BaseSegmentCreator.addColumnMetadataInfo(config, "intMap", mock(ColumnStatistics.class), 1, intMapFieldSpec, false,
+        -1, false);
     ColumnMetadataImpl intMapColumnMetadata = ColumnMetadataImpl.fromPropertiesConfiguration("intMap", config);
     assertEquals(intMapColumnMetadata.getFieldSpec(), intMapFieldSpec);
   }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/forward/mutable/CLPMutableForwardIndexTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/forward/mutable/CLPMutableForwardIndexTest.java
@@ -29,7 +29,6 @@ import org.apache.pinot.segment.local.segment.creator.impl.stats.CLPStatsProvide
 import org.apache.pinot.segment.local.segment.creator.impl.stats.StringColumnPreIndexStatsCollector;
 import org.apache.pinot.segment.spi.index.mutable.MutableForwardIndex;
 import org.apache.pinot.segment.spi.memory.PinotDataBufferMemoryManager;
-import org.apache.pinot.spi.data.FieldSpec;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -75,8 +74,7 @@ public class CLPMutableForwardIndexTest implements PinotBuffersAfterClassCheckRu
     // use arbitrary cardinality and avg string length
     // we will test with complete randomness
     int initialCapacity = 5;
-    try (CLPMutableForwardIndex readerWriter = new CLPMutableForwardIndex("col1", FieldSpec.DataType.STRING,
-        _memoryManager, initialCapacity)) {
+    try (CLPMutableForwardIndex readerWriter = new CLPMutableForwardIndex("col1", _memoryManager, initialCapacity)) {
       ingestData(readerWriter);
       validateStats(readerWriter.getCLPStats());
     }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/defaultcolumn/DefaultColumnStatisticsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/defaultcolumn/DefaultColumnStatisticsTest.java
@@ -1,0 +1,174 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.loader.defaultcolumn;
+
+import com.google.common.base.Utf8;
+import java.math.BigDecimal;
+import java.util.Arrays;
+import org.apache.pinot.spi.data.DimensionFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.utils.BigDecimalUtils;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+
+/// Tests for [DefaultColumnStatistics], covering all value types for SV and MV cases.
+public class DefaultColumnStatisticsTest {
+
+  @DataProvider(name = "allTypesSV")
+  public Object[][] allTypesSV() {
+    DataType[] types = {
+        DataType.INT, DataType.LONG, DataType.FLOAT, DataType.DOUBLE, DataType.BIG_DECIMAL, DataType.BOOLEAN,
+        DataType.TIMESTAMP, DataType.STRING, DataType.JSON, DataType.BYTES
+    };
+    return Arrays.stream(types).map(t -> new Object[]{t}).toArray(Object[][]::new);
+  }
+
+  @DataProvider(name = "allTypesMV")
+  public Object[][] allTypesMV() {
+    DataType[] types = {
+        DataType.INT, DataType.LONG, DataType.FLOAT, DataType.DOUBLE, DataType.BOOLEAN, DataType.TIMESTAMP,
+        DataType.STRING, DataType.JSON, DataType.BYTES
+    };
+    return Arrays.stream(types).map(t -> new Object[]{t}).toArray(Object[][]::new);
+  }
+
+  @Test(dataProvider = "allTypesSV")
+  public void testSV(DataType type) {
+    int numDocs = 100;
+    FieldSpec fieldSpec = new DimensionFieldSpec("col", type, true);
+    DefaultColumnStatistics stats = new DefaultColumnStatistics(fieldSpec, numDocs);
+    DataType storedType = type.getStoredType();
+
+    // Assertions follow ColumnStatistics API order
+
+    // getFieldSpec, getValueType, isSingleValue
+    assertEquals(stats.getFieldSpec(), fieldSpec);
+    assertEquals(stats.getValueType(), storedType);
+    assertTrue(stats.isSingleValue());
+
+    // getMinValue, getMaxValue — single default value: min == max
+    assertNotNull(stats.getMinValue());
+    assertEquals(stats.getMinValue(), stats.getMaxValue());
+
+    // getUniqueValuesSet, getCardinality
+    assertNotNull(stats.getUniqueValuesSet());
+    assertEquals(stats.getCardinality(), 1);
+
+    // getLengthOfShortestElement, getLengthOfLongestElement, isFixedLength, isAscii per stored type
+    // (switch ordered by DataType enum: BIG_DECIMAL, STRING, BYTES)
+    if (storedType.isFixedWidth()) {
+      assertEquals(stats.getLengthOfShortestElement(), storedType.size());
+      assertEquals(stats.getLengthOfLongestElement(), storedType.size());
+      assertTrue(stats.isFixedLength());
+      assertFalse(stats.isAscii());
+    } else {
+      int expectedLength;
+      switch (storedType) {
+        case BIG_DECIMAL:
+          expectedLength = BigDecimalUtils.byteSize((BigDecimal) fieldSpec.getDefaultNullValue());
+          assertFalse(stats.isAscii());
+          break;
+        case STRING:
+          expectedLength = Utf8.encodedLength((String) fieldSpec.getDefaultNullValue());
+          assertTrue(stats.isAscii()); // default "null" is ASCII
+          break;
+        case BYTES:
+          expectedLength = 0; // default is empty byte array
+          assertFalse(stats.isAscii());
+          break;
+        default:
+          throw new IllegalStateException("Unexpected var-width type: " + storedType);
+      }
+      assertEquals(stats.getLengthOfShortestElement(), expectedLength);
+      assertEquals(stats.getLengthOfLongestElement(), expectedLength);
+      assertTrue(stats.isFixedLength());
+    }
+
+    // isSorted
+    assertTrue(stats.isSorted());
+
+    // getTotalNumberOfEntries, getMaxNumberOfMultiValues, getMaxRowLengthInBytes
+    assertEquals(stats.getTotalNumberOfEntries(), numDocs);
+    assertEquals(stats.getMaxNumberOfMultiValues(), 0);
+    assertEquals(stats.getMaxRowLengthInBytes(), stats.getLengthOfLongestElement());
+  }
+
+  @Test(dataProvider = "allTypesMV")
+  public void testMV(DataType type) {
+    int numDocs = 50;
+    FieldSpec fieldSpec = new DimensionFieldSpec("col", type, false);
+    DefaultColumnStatistics stats = new DefaultColumnStatistics(fieldSpec, numDocs);
+    DataType storedType = type.getStoredType();
+
+    // Assertions follow ColumnStatistics API order
+
+    // getFieldSpec, getValueType, isSingleValue
+    assertEquals(stats.getFieldSpec(), fieldSpec);
+    assertEquals(stats.getValueType(), storedType);
+    assertFalse(stats.isSingleValue());
+
+    // getMinValue, getMaxValue — single default value: min == max
+    assertNotNull(stats.getMinValue());
+    assertEquals(stats.getMinValue(), stats.getMaxValue());
+
+    // getUniqueValuesSet, getCardinality
+    assertNotNull(stats.getUniqueValuesSet());
+    assertEquals(stats.getCardinality(), 1);
+
+    // getLengthOfShortestElement, getLengthOfLongestElement, isFixedLength, isAscii per stored type
+    if (storedType.isFixedWidth()) {
+      assertEquals(stats.getLengthOfShortestElement(), storedType.size());
+      assertEquals(stats.getLengthOfLongestElement(), storedType.size());
+      assertTrue(stats.isFixedLength());
+      assertFalse(stats.isAscii());
+    } else {
+      int expectedLength;
+      switch (storedType) {
+        case STRING:
+          expectedLength = Utf8.encodedLength((String) fieldSpec.getDefaultNullValue());
+          assertTrue(stats.isAscii()); // default "null" is ASCII
+          break;
+        case BYTES:
+          expectedLength = 0; // default is empty byte array
+          assertFalse(stats.isAscii());
+          break;
+        default:
+          throw new IllegalStateException("Unexpected var-width type: " + storedType);
+      }
+      assertEquals(stats.getLengthOfShortestElement(), expectedLength);
+      assertEquals(stats.getLengthOfLongestElement(), expectedLength);
+      assertTrue(stats.isFixedLength());
+    }
+
+    // isSorted — MV is never sorted
+    assertFalse(stats.isSorted());
+
+    // getTotalNumberOfEntries, getMaxNumberOfMultiValues, getMaxRowLengthInBytes
+    assertEquals(stats.getTotalNumberOfEntries(), numDocs);
+    assertEquals(stats.getMaxNumberOfMultiValues(), 1); // each row has 1 default element
+    assertEquals(stats.getMaxRowLengthInBytes(), stats.getLengthOfLongestElement());
+  }
+}

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/ColumnStatistics.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/ColumnStatistics.java
@@ -23,86 +23,125 @@ import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.pinot.segment.spi.partition.PartitionFunction;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
-/**
- * An interface to read the column statistics from statistics collectors.
- *
- * TODO: Unify the behavior for unapplicable stats, e.g. maxRowLength for single-value or fixed-width type.
- */
+/// Statistics for a column, collected before creating indexes.
+/// For MV column, the stats are on individual elements within the MV values.
+@SuppressWarnings("rawtypes")
 public interface ColumnStatistics extends Serializable {
-  /**
-   * @return Minimum value of the column
-   */
-  @Nullable
-  Object getMinValue();
 
-  /**
-   * @return Maximum value of the column
-   */
-  @Nullable
-  Object getMaxValue();
+  /// Returns the [FieldSpec] of the column.
+  FieldSpec getFieldSpec();
 
-  /**
-   * @return An array of elements that has the unique values for this column, sorted order.
-   */
+  /// Returns the stored [DataType] of the column.
+  default DataType getValueType() {
+    return getFieldSpec().getDataType().getStoredType();
+  }
+
+  /// Returns whether the column is single-valued.
+  default boolean isSingleValue() {
+    return getFieldSpec().isSingleValueField();
+  }
+
+  /// Returns the minimum value, or `null` if the column is empty.
+  @Nullable
+  Comparable getMinValue();
+
+  /// Returns the maximum value, or `null` if the column is empty.
+  @Nullable
+  Comparable getMaxValue();
+
+  /// Returns a sorted (ascending) array of all unique values for non-empty dictionary-encoded columns, `null`
+  /// otherwise.
+  /// - INT: int[]
+  /// - LONG: long[]
+  /// - FLOAT: float[]
+  /// - DOUBLE: double[]
+  /// - BIG_DECIMAL: BigDecimal[]
+  /// - STRING: String[]
+  /// - BYTES: ByteArray[]
   @Nullable
   Object getUniqueValuesSet();
 
-  /**
-   *
-   * @return The number of unique values of this column.
-   */
+  /// Returns the cardinality of the column.
+  /// - For dictionary-encoded columns, returns the exact cardinality.
+  /// - For raw columns:
+  ///   - When stats are collected from an input file, returns an estimated cardinality
+  ///   - When stats are derived from a mutable segment, returns
+  ///     [org.apache.pinot.segment.spi.Constants#UNKNOWN_CARDINALITY]
+  // TODO: Consider generating estimated cardinality when converting from a mutable segment
   int getCardinality();
 
-  /**
-   *
-   * @return For variable length objects, returns the length of the shortest value. For others, returns -1.
-   */
-  int getLengthOfShortestElement();
-
-  /**
-   *
-   * @return For variable length objects, returns the length of the longest value. For others, returns -1.
-   */
-  int getLengthOfLargestElement();
-
-  default boolean isFixedLength() {
-    return getLengthOfShortestElement() == getLengthOfLargestElement();
+  /// Returns the minimum serialized byte length across all elements.
+  /// - For fixed-width types, returns the fixed size
+  /// - For empty column of var-length types, returns `0`
+  /// Override it for var-length types.
+  default int getLengthOfShortestElement() {
+    return getValueType().size();
   }
 
-  /**
-   * Whether or not the data in this column is in ascending order.
-   * @return true if the data is in ascending order.
-   */
+  /// Returns the maximum serialized byte length across all elements.
+  /// - For fixed-width types, returns the fixed size
+  /// - For empty column of var-length types, returns `0`
+  /// Override it for var-length types.
+  default int getLengthOfLongestElement() {
+    return getValueType().size();
+  }
+
+  @Deprecated
+  default int getLengthOfLargestElement() {
+    return getLengthOfLongestElement();
+  }
+
+  /// Returns `true` when all the elements are of the same serialized byte length.
+  default boolean isFixedLength() {
+    return getLengthOfShortestElement() == getLengthOfLongestElement();
+  }
+
+  /// Returns `true` when all elements of a non-empty STRING column contain only ASCII characters, `false` otherwise.
+  /// Override it for STRING type.
+  default boolean isAscii() {
+    return false;
+  }
+
+  /// Returns `true` when all values in a SV column are sorted in ascending order, `false` otherwise.
   boolean isSorted();
 
-  /**
-   * @return total number of entries
-   */
+  /// Returns the total number of entries.
+  /// - For SV columns, equals the number of rows
+  /// - For MV columns, sums the number of elements across all rows
   int getTotalNumberOfEntries();
 
-  /**
-   * @return For multi-valued columns, returns the max number of values in a single occurrence of the column,
-   * otherwise 0.
-   */
+  /// Returns the maximum number of elements within a single MV value, or `0` for SV or empty columns.
   int getMaxNumberOfMultiValues();
 
-  /**
-   * @return the length of the largest row in bytes for variable length types
-   */
+  /// Returns the maximum serialized byte length of a single row.
+  /// - For SV columns, row length is the same as value length
+  /// - For MV columns, row length is total length of all elements within the MV value
+  /// - Returns `0` for empty columns
+  /// Override it for MV var-length types.
   default int getMaxRowLengthInBytes() {
-    return -1;
+    if (isSingleValue()) {
+      return getLengthOfLongestElement();
+    } else {
+      return getMaxNumberOfMultiValues() * getValueType().size();
+    }
   }
 
+  /// Returns the [PartitionFunction] for the column.
   @Nullable
   PartitionFunction getPartitionFunction();
 
+  /// Returns the total number of partitions.
   int getNumPartitions();
 
+  /// Returns the config for the partition function.
   @Nullable
   Map<String, String> getPartitionFunctionConfig();
 
+  /// Returns the partitions within which the values exist.
   @Nullable
   Set<Integer> getPartitions();
 }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/ColumnStatistics.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/ColumnStatistics.java
@@ -134,14 +134,20 @@ public interface ColumnStatistics extends Serializable {
   @Nullable
   PartitionFunction getPartitionFunction();
 
-  /// Returns the total number of partitions.
-  int getNumPartitions();
-
-  /// Returns the config for the partition function.
-  @Nullable
-  Map<String, String> getPartitionFunctionConfig();
-
   /// Returns the partitions within which the values exist.
   @Nullable
   Set<Integer> getPartitions();
+
+  @Deprecated
+  default int getNumPartitions() {
+    PartitionFunction partitionFunction = getPartitionFunction();
+    return partitionFunction != null ? partitionFunction.getNumPartitions() : 0;
+  }
+
+  @Deprecated
+  @Nullable
+  default Map<String, String> getPartitionFunctionConfig() {
+    PartitionFunction partitionFunction = getPartitionFunction();
+    return partitionFunction != null ? partitionFunction.getFunctionConfig() : null;
+  }
 }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/IndexCreationContext.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/IndexCreationContext.java
@@ -150,7 +150,7 @@ public interface IndexCreationContext {
       _maxValue = (Comparable<?>) columnStatistics.getMaxValue();
       _sortedUniqueElementsArray = columnStatistics.getUniqueValuesSet();
       _cardinality = columnStatistics.getCardinality();
-      _lengthOfLongestEntry = columnStatistics.getLengthOfLargestElement();
+      _lengthOfLongestEntry = columnStatistics.getLengthOfLongestElement();
       _fixedLength = columnStatistics.isFixedLength();
       _sorted = columnStatistics.isSorted();
       _totalNumberOfEntries = columnStatistics.getTotalNumberOfEntries();

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/StatsCollectorConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/StatsCollectorConfig.java
@@ -47,7 +47,8 @@ public class StatsCollectorConfig {
    * @param schema Data schema
    * @param segmentPartitionConfig Segment partitioning config
    */
-  public StatsCollectorConfig(TableConfig tableConfig, Schema schema, @Nullable SegmentPartitionConfig segmentPartitionConfig) {
+  public StatsCollectorConfig(TableConfig tableConfig, Schema schema,
+      @Nullable SegmentPartitionConfig segmentPartitionConfig) {
     Preconditions.checkNotNull(tableConfig);
     Preconditions.checkNotNull(schema);
     _tableConfig = tableConfig;

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/StatsCollectorConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/StatsCollectorConfig.java
@@ -22,6 +22,9 @@ import com.google.common.base.Preconditions;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
+import org.apache.pinot.segment.spi.partition.PartitionFunction;
+import org.apache.pinot.segment.spi.partition.PartitionFunctionFactory;
+import org.apache.pinot.spi.config.table.ColumnPartitionConfig;
 import org.apache.pinot.spi.config.table.FieldConfig;
 import org.apache.pinot.spi.config.table.SegmentPartitionConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -34,7 +37,6 @@ import org.apache.pinot.spi.data.Schema;
  * the stats collector.
  */
 public class StatsCollectorConfig {
-
   private final TableConfig _tableConfig;
   private final Schema _schema;
   private final SegmentPartitionConfig _segmentPartitionConfig;
@@ -45,8 +47,7 @@ public class StatsCollectorConfig {
    * @param schema Data schema
    * @param segmentPartitionConfig Segment partitioning config
    */
-  public StatsCollectorConfig(TableConfig tableConfig, Schema schema,
-      @Nullable SegmentPartitionConfig segmentPartitionConfig) {
+  public StatsCollectorConfig(TableConfig tableConfig, Schema schema, @Nullable SegmentPartitionConfig segmentPartitionConfig) {
     Preconditions.checkNotNull(tableConfig);
     Preconditions.checkNotNull(schema);
     _tableConfig = tableConfig;
@@ -60,11 +61,36 @@ public class StatsCollectorConfig {
     }
   }
 
+  public TableConfig getTableConfig() {
+    return _tableConfig;
+  }
+
+  public Schema getSchema() {
+    return _schema;
+  }
+
   @Nullable
   public FieldSpec getFieldSpecForColumn(String column) {
     return _schema.getFieldSpecFor(column);
   }
 
+  @Nullable
+  public FieldConfig getFieldConfigForColumn(String column) {
+    return _columnFieldConfigMap.get(column);
+  }
+
+  @Nullable
+  public PartitionFunction getPartitionFunction(String column) {
+    if (_segmentPartitionConfig != null) {
+      ColumnPartitionConfig columnPartitionConfig = _segmentPartitionConfig.getColumnPartitionConfig(column);
+      if (columnPartitionConfig != null) {
+        return PartitionFunctionFactory.getPartitionFunction(columnPartitionConfig);
+      }
+    }
+    return null;
+  }
+
+  @Deprecated
   @Nullable
   public String getPartitionFunctionName(String column) {
     if (_segmentPartitionConfig == null) {
@@ -74,33 +100,15 @@ public class StatsCollectorConfig {
     return _segmentPartitionConfig.getFunctionName(column);
   }
 
-  /**
-   * Returns the number of partitions for the specified column.
-   * If segment partition config does not exist, returns {@link SegmentPartitionConfig#INVALID_NUM_PARTITIONS}.
-   *
-   * @param column Column for which to to return the number of partitions.
-   * @return Number of partitions for the column.
-   */
+  @Deprecated
   public int getNumPartitions(String column) {
     return (_segmentPartitionConfig != null) ? _segmentPartitionConfig.getNumPartitions(column)
         : SegmentPartitionConfig.INVALID_NUM_PARTITIONS;
   }
 
+  @Deprecated
   @Nullable
   public Map<String, String> getPartitionFunctionConfig(String column) {
     return (_segmentPartitionConfig != null) ? _segmentPartitionConfig.getFunctionConfig(column) : null;
-  }
-
-  public Schema getSchema() {
-    return _schema;
-  }
-
-  public TableConfig getTableConfig() {
-    return _tableConfig;
-  }
-
-  @Nullable
-  public FieldConfig getFieldConfigForColumn(String column) {
-    return _columnFieldConfigMap.get(column);
   }
 }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/mutable/MutableForwardIndex.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/mutable/MutableForwardIndex.java
@@ -171,6 +171,9 @@ public interface MutableForwardIndex extends ForwardIndexReader<ForwardIndexRead
    */
   int getLengthOfLongestElement();
 
+  /// Returns `true` when all elements of a STRING raw forward index contain only ASCII characters, `false` otherwise.
+  boolean isAscii();
+
   /**
    * DICTIONARY-ENCODED INDEX APIs
    */

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/PartitionFunctionFactory.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/PartitionFunctionFactory.java
@@ -21,6 +21,8 @@ package org.apache.pinot.segment.spi.partition;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
+import org.apache.pinot.segment.spi.partition.metadata.ColumnPartitionMetadata;
+import org.apache.pinot.spi.config.table.ColumnPartitionConfig;
 
 
 /**
@@ -97,5 +99,13 @@ public class PartitionFunctionFactory {
       default:
         throw new IllegalArgumentException("Illegal partition function name: " + functionName);
     }
+  }
+
+  public static PartitionFunction getPartitionFunction(ColumnPartitionConfig config) {
+    return getPartitionFunction(config.getFunctionName(), config.getNumPartitions(), config.getFunctionConfig());
+  }
+
+  public static PartitionFunction getPartitionFunction(ColumnPartitionMetadata metadata) {
+    return getPartitionFunction(metadata.getFunctionName(), metadata.getNumPartitions(), metadata.getFunctionConfig());
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/SegmentPartitionConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/SegmentPartitionConfig.java
@@ -27,6 +27,7 @@ import org.apache.pinot.spi.config.BaseJsonConfig;
 
 
 public class SegmentPartitionConfig extends BaseJsonConfig {
+  @Deprecated
   public static final int INVALID_NUM_PARTITIONS = -1;
 
   private final Map<String, ColumnPartitionConfig> _columnPartitionMap;
@@ -42,30 +43,25 @@ public class SegmentPartitionConfig extends BaseJsonConfig {
     return _columnPartitionMap;
   }
 
-  /**
-   * Returns the partition function for the given column, null if there isn't one.
-   *
-   * @param column Column for which to return the partition function.
-   * @return Partition function for the column.
-   */
+  @Nullable
+  public ColumnPartitionConfig getColumnPartitionConfig(String column) {
+    return _columnPartitionMap.get(column);
+  }
+
+  @Deprecated
   @Nullable
   public String getFunctionName(String column) {
     ColumnPartitionConfig columnPartitionConfig = _columnPartitionMap.get(column);
     return (columnPartitionConfig != null) ? columnPartitionConfig.getFunctionName() : null;
   }
 
-  /**
-   * Returns the number of partitions for the specified column.
-   * Returns {@link #INVALID_NUM_PARTITIONS} if it does not exist for the column.
-   *
-   * @param column Column for which to get number of partitions.
-   * @return Number of partitions of the column.
-   */
+  @Deprecated
   public int getNumPartitions(String column) {
     ColumnPartitionConfig config = _columnPartitionMap.get(column);
     return (config != null) ? config.getNumPartitions() : INVALID_NUM_PARTITIONS;
   }
 
+  @Deprecated
   @Nullable
   public Map<String, String> getFunctionConfig(String column) {
     ColumnPartitionConfig config = _columnPartitionMap.get(column);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/Utf8Utils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/Utf8Utils.java
@@ -16,27 +16,34 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.segment.spi.creator;
+package org.apache.pinot.spi.utils;
 
-import java.util.Set;
+import com.google.common.base.Utf8;
+import java.nio.charset.StandardCharsets;
 
 
-/**
- * An interface to read the map column statistics from statistics collectors.
- */
-public interface MapColumnStatistics extends ColumnStatistics {
+public class Utf8Utils {
+  private Utf8Utils() {
+  }
 
- Object getMinValueForKey(String key);
+  public static byte[] encode(String s) {
+    return s.getBytes(StandardCharsets.UTF_8);
+  }
 
- Object getMaxValueForKey(String key);
+  public static int encodedLength(String s) {
+    return Utf8.encodedLength(s);
+  }
 
- int getLengthOfShortestElementForKey(String key);
+  public static String decode(byte[] bytes) {
+    return new String(bytes, StandardCharsets.UTF_8);
+  }
 
- int getLengthOfLargestElementForKey(String key);
-
- Set<String> getKeys();
-
- boolean isSortedForKey(String key);
-
- int getTotalNumberOfEntriesForKey(String key);
+  public static boolean isAscii(byte[] bytes) {
+    int or = 0;
+    for (byte b : bytes) {
+      // Do not check within loop because most values are ASCII
+      or |= b;
+    }
+    return (or & 0x80) == 0;
+  }
 }

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/config/table/IndexingConfigTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/config/table/IndexingConfigTest.java
@@ -89,15 +89,7 @@ public class IndexingConfigTest {
 
     IndexingConfig actualIndexingConfig =
         JsonUtils.stringToObject(JsonUtils.objectToString(expectedIndexingConfig), IndexingConfig.class);
-
-    SegmentPartitionConfig actualPartitionConfig = actualIndexingConfig.getSegmentPartitionConfig();
-    Map<String, ColumnPartitionConfig> actualColumnPartitionMap = actualPartitionConfig.getColumnPartitionMap();
-    assertEquals(actualColumnPartitionMap.size(), expectedColumnPartitionMap.size());
-
-    for (String column : expectedColumnPartitionMap.keySet()) {
-      assertEquals(actualPartitionConfig.getFunctionName(column), expectedPartitionConfig.getFunctionName(column));
-      assertEquals(actualPartitionConfig.getNumPartitions(column), expectedPartitionConfig.getNumPartitions(column));
-    }
+    assertEquals(actualIndexingConfig.getSegmentPartitionConfig(), expectedPartitionConfig);
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Refactor `ColumnStatistics` interface: add Javadoc, default methods (`getValueType`, `isSingleValue`, `isFixedLength`, `isAscii`, `getMaxRowLengthInBytes`)
- Clean up stats collectors: rename `BytesColumnPredIndexStatsCollector` → `BytesColumnPreIndexStatsCollector`, extract `EmptyColumnStatistics` for empty columns, simplify `DefaultColumnStatistics` to derive all stats from `FieldSpec`
- Enhance `MutableForwardIndex` to track element lengths and ASCII flag, propagated through `MutableColumnStatistics` and `MutableNoDictColumnStatistics`
- Improve `CompactedColumnStatistics` and `CompactedNoDictColumnStatistics` to compute all stats (min/max, cardinality, element lengths, ASCII, sorted, row lengths) in a single pass over valid documents
- Significantly expand test coverage: add logical type tests (BOOLEAN, TIMESTAMP, JSON), MV tests for all types, assertion ordering aligned with `ColumnStatistics` API, `getLengthOfShortestElement` coverage

## Test plan
- [x] All existing unit tests pass (`pinot-segment-local`, `pinot-segment-spi`)
- [x] New tests: `EmptyColumnStatisticsTest`, `DefaultColumnStatisticsTest`, `MutableNoDictColumnStatisticsTest`
- [x] Enhanced tests: `MutableColumnStatisticsTest`, `CompactedColumnStatisticsTest`, `CompactedNoDictColumnStatisticsTest`, `AbstractColumnStatisticsCollectorTest`, `NoDictColumnStatisticsCollectorTest`

🤖 Generated with [Claude Code](https://claude.com/claude-code)