### PR TITLE
Supporting multi-cluster routing for debug endpoints in broker

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotBrokerDebug.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotBrokerDebug.java
@@ -46,14 +46,18 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.apache.pinot.broker.broker.AccessControlFactory;
+import org.apache.pinot.broker.broker.MultiClusterRoutingContextProvider;
 import org.apache.pinot.broker.queryquota.QueryQuotaManager;
 import org.apache.pinot.broker.routing.manager.BrokerRoutingManager;
+import org.apache.pinot.common.config.provider.TableCache;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.utils.DatabaseUtils;
 import org.apache.pinot.core.auth.Actions;
 import org.apache.pinot.core.auth.Authorize;
 import org.apache.pinot.core.auth.ManualAuthorization;
 import org.apache.pinot.core.auth.TargetType;
+import org.apache.pinot.core.routing.MultiClusterRoutingContext;
+import org.apache.pinot.core.routing.RoutingManager;
 import org.apache.pinot.core.routing.RoutingTable;
 import org.apache.pinot.core.routing.SegmentsToQuery;
 import org.apache.pinot.core.routing.timeboundary.TimeBoundaryInfo;
@@ -64,8 +68,11 @@ import org.apache.pinot.spi.accounting.QueryResourceTracker;
 import org.apache.pinot.spi.accounting.ThreadAccountant;
 import org.apache.pinot.spi.accounting.ThreadResourceTracker;
 import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.LogicalTableConfig;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.sql.parsers.CalciteSqlCompiler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.apache.pinot.spi.utils.CommonConstants.DATABASE;
 import static org.apache.pinot.spi.utils.CommonConstants.SWAGGER_AUTHORIZATION_KEY;
@@ -83,12 +90,19 @@ import static org.apache.pinot.spi.utils.CommonConstants.SWAGGER_AUTHORIZATION_K
 @Path("/")
 // TODO: Add APIs to return the RoutingTable (with unavailable segments)
 public class PinotBrokerDebug {
+  private static final Logger LOGGER = LoggerFactory.getLogger(PinotBrokerDebug.class);
 
   // Request ID is passed to the RoutingManager to rotate the selected replica-group.
   private final static AtomicLong REQUEST_ID_GENERATOR = new AtomicLong();
 
   @Inject
   private BrokerRoutingManager _routingManager;
+
+  @Inject
+  private MultiClusterRoutingContextProvider _multiClusterRoutingContextProvider;
+
+  @Inject
+  private TableCache _tableCache;
 
   @Inject
   private ServerRoutingStatsManager _serverRoutingStatsManager;
@@ -138,11 +152,19 @@ public class PinotBrokerDebug {
   })
   public Map<String, Map<ServerInstance, List<String>>> getRoutingTable(
       @ApiParam(value = "Name of the table") @PathParam("tableName") String tableName,
+      @ApiParam(value = "Use multi-cluster routing manager instead of local")
+      @QueryParam("useMultiClusterRouting") boolean useMultiClusterRouting,
       @Context HttpHeaders headers) {
     tableName = DatabaseUtils.translateTableName(tableName, headers);
+    RoutingManager routingManager = resolveRoutingManager(useMultiClusterRouting, tableName);
     Map<String, Map<ServerInstance, List<String>>> result = new TreeMap<>();
-    getRoutingTable(tableName, (tableNameWithType, routingTable) -> result.put(tableNameWithType,
-        removeOptionalSegments(routingTable.getServerInstanceToSegmentsMap())));
+    if (useMultiClusterRouting) {
+      getPhysicalRoutingTablesForLogical(routingManager, tableName, (tableNameWithType, routingTable) -> result.put(
+          tableNameWithType, removeOptionalSegments(routingTable.getServerInstanceToSegmentsMap())));
+    } else {
+      getRoutingTable(routingManager, tableName, (tableNameWithType, routingTable) -> result.put(tableNameWithType,
+          removeOptionalSegments(routingTable.getServerInstanceToSegmentsMap())));
+    }
     if (!result.isEmpty()) {
       return result;
     } else {
@@ -162,11 +184,20 @@ public class PinotBrokerDebug {
   })
   public Map<String, Map<ServerInstance, SegmentsToQuery>> getRoutingTableWithOptionalSegments(
       @ApiParam(value = "Name of the table") @PathParam("tableName") String tableName,
+      @ApiParam(value = "Use multi-cluster routing manager instead of local")
+      @QueryParam("useMultiClusterRouting") boolean useMultiClusterRouting,
       @Context HttpHeaders headers) {
     tableName = DatabaseUtils.translateTableName(tableName, headers);
+    RoutingManager routingManager = resolveRoutingManager(useMultiClusterRouting, tableName);
     Map<String, Map<ServerInstance, SegmentsToQuery>> result = new TreeMap<>();
-    getRoutingTable(tableName, (tableNameWithType, routingTable) -> result.put(tableNameWithType,
-        routingTable.getServerInstanceToSegmentsMap()));
+    if (useMultiClusterRouting) {
+      getPhysicalRoutingTablesForLogical(routingManager, tableName,
+          (tableNameWithType, routingTable) -> result.put(tableNameWithType,
+              routingTable.getServerInstanceToSegmentsMap()));
+    } else {
+      getRoutingTable(routingManager, tableName, (tableNameWithType, routingTable) -> result.put(tableNameWithType,
+          routingTable.getServerInstanceToSegmentsMap()));
+    }
     if (!result.isEmpty()) {
       return result;
     } else {
@@ -174,14 +205,39 @@ public class PinotBrokerDebug {
     }
   }
 
-  private void getRoutingTable(String tableName, BiConsumer<String, RoutingTable> consumer) {
+  /**
+   * For a logical table with multi-cluster routing, iterates over every physical table in the logical table config
+   * and invokes the consumer with the per-physical-table routing result. This is needed because the underlying
+   * {@link RoutingManager} works with physical table names; passing a logical table name to it returns nothing.
+   */
+  private void getPhysicalRoutingTablesForLogical(RoutingManager routingManager, String logicalTableName,
+      BiConsumer<String, RoutingTable> consumer) {
+    String rawTableName = TableNameBuilder.extractRawTableName(logicalTableName);
+    LogicalTableConfig config = _tableCache.getLogicalTableConfig(rawTableName);
+    if (config == null) {
+      throw new WebApplicationException("Logical table config not found for: " + rawTableName,
+          Response.Status.NOT_FOUND);
+    }
+    for (String physicalTableWithType : config.getPhysicalTableConfigMap().keySet()) {
+      RoutingTable routingTable = routingManager.getRoutingTable(
+          CalciteSqlCompiler.compileToBrokerRequest("SELECT * FROM " + physicalTableWithType), getRequestId());
+      if (routingTable != null) {
+        consumer.accept(physicalTableWithType, routingTable);
+      } else {
+        LOGGER.warn("No routing found in multi-cluster manager for physical table: {}", physicalTableWithType);
+      }
+    }
+  }
+
+  private void getRoutingTable(RoutingManager routingManager, String tableName,
+      BiConsumer<String, RoutingTable> consumer) {
     // Use a single requestId for both OFFLINE and REALTIME routing so that replica-group selection rotates properly
     // for raw table names (no suffix) and stays consistent for hybrid tables.
     long requestId = getRequestId();
     TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableName);
     if (tableType != TableType.REALTIME) {
       String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(tableName);
-      RoutingTable routingTable = _routingManager.getRoutingTable(
+      RoutingTable routingTable = routingManager.getRoutingTable(
           CalciteSqlCompiler.compileToBrokerRequest("SELECT * FROM " + offlineTableName), requestId);
       if (routingTable != null) {
         consumer.accept(offlineTableName, routingTable);
@@ -189,12 +245,40 @@ public class PinotBrokerDebug {
     }
     if (tableType != TableType.OFFLINE) {
       String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(tableName);
-      RoutingTable routingTable = _routingManager.getRoutingTable(
+      RoutingTable routingTable = routingManager.getRoutingTable(
           CalciteSqlCompiler.compileToBrokerRequest("SELECT * FROM " + realtimeTableName), requestId);
       if (routingTable != null) {
         consumer.accept(realtimeTableName, routingTable);
       }
     }
+  }
+
+  /**
+   * Returns the multi-cluster routing manager if requested and configured, otherwise falls back to the local
+   * routing manager. Throws a 400 error if multi-cluster routing is requested but not configured, or if the
+   * given table is not a logical table.
+   */
+  private RoutingManager resolveRoutingManager(boolean useMultiClusterRouting, String tableName) {
+    if (!useMultiClusterRouting) {
+      return _routingManager;
+    }
+    MultiClusterRoutingContext context = _multiClusterRoutingContextProvider.get();
+    if (context == null) {
+      throw new WebApplicationException("Multi-cluster routing is not configured on this broker",
+          Response.Status.BAD_REQUEST);
+    }
+    RoutingManager multiClusterRoutingManager = context.getMultiClusterRoutingManager();
+    if (multiClusterRoutingManager == null) {
+      throw new WebApplicationException("Multi-cluster routing is not configured on this broker",
+          Response.Status.BAD_REQUEST);
+    }
+    String rawTableName = TableNameBuilder.extractRawTableName(tableName);
+    if (!_tableCache.isLogicalTable(rawTableName)) {
+      throw new WebApplicationException(
+          "Multi-cluster routing is only supported for logical tables, but '" + rawTableName + "' is not a logical "
+              + "table", Response.Status.BAD_REQUEST);
+    }
+    return multiClusterRoutingManager;
   }
 
   private static Map<ServerInstance, List<String>> removeOptionalSegments(

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotBrokerDebug.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotBrokerDebug.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.BiConsumer;
+import javax.annotation.Nullable;
 import javax.inject.Inject;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
@@ -46,14 +47,18 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.apache.pinot.broker.broker.AccessControlFactory;
+import org.apache.pinot.broker.broker.MultiClusterRoutingContextProvider;
 import org.apache.pinot.broker.queryquota.QueryQuotaManager;
 import org.apache.pinot.broker.routing.manager.BrokerRoutingManager;
+import org.apache.pinot.common.config.provider.TableCache;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.utils.DatabaseUtils;
 import org.apache.pinot.core.auth.Actions;
 import org.apache.pinot.core.auth.Authorize;
 import org.apache.pinot.core.auth.ManualAuthorization;
 import org.apache.pinot.core.auth.TargetType;
+import org.apache.pinot.core.routing.MultiClusterRoutingContext;
+import org.apache.pinot.core.routing.RoutingManager;
 import org.apache.pinot.core.routing.RoutingTable;
 import org.apache.pinot.core.routing.SegmentsToQuery;
 import org.apache.pinot.core.routing.timeboundary.TimeBoundaryInfo;
@@ -64,8 +69,12 @@ import org.apache.pinot.spi.accounting.QueryResourceTracker;
 import org.apache.pinot.spi.accounting.ThreadAccountant;
 import org.apache.pinot.spi.accounting.ThreadResourceTracker;
 import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.LogicalTableConfig;
+import org.apache.pinot.spi.data.PhysicalTableConfig;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.sql.parsers.CalciteSqlCompiler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.apache.pinot.spi.utils.CommonConstants.DATABASE;
 import static org.apache.pinot.spi.utils.CommonConstants.SWAGGER_AUTHORIZATION_KEY;
@@ -83,12 +92,19 @@ import static org.apache.pinot.spi.utils.CommonConstants.SWAGGER_AUTHORIZATION_K
 @Path("/")
 // TODO: Add APIs to return the RoutingTable (with unavailable segments)
 public class PinotBrokerDebug {
+  private static final Logger LOGGER = LoggerFactory.getLogger(PinotBrokerDebug.class);
 
   // Request ID is passed to the RoutingManager to rotate the selected replica-group.
   private final static AtomicLong REQUEST_ID_GENERATOR = new AtomicLong();
 
   @Inject
   private BrokerRoutingManager _routingManager;
+
+  @Inject
+  private MultiClusterRoutingContextProvider _multiClusterRoutingContextProvider;
+
+  @Inject
+  private TableCache _tableCache;
 
   @Inject
   private ServerRoutingStatsManager _serverRoutingStatsManager;
@@ -141,8 +157,8 @@ public class PinotBrokerDebug {
       @Context HttpHeaders headers) {
     tableName = DatabaseUtils.translateTableName(tableName, headers);
     Map<String, Map<ServerInstance, List<String>>> result = new TreeMap<>();
-    getRoutingTable(tableName, (tableNameWithType, routingTable) -> result.put(tableNameWithType,
-        removeOptionalSegments(routingTable.getServerInstanceToSegmentsMap())));
+    getRoutingTable(tableName, (tableNameWithType, routingTable) ->
+        result.put(tableNameWithType, removeOptionalSegments(routingTable.getServerInstanceToSegmentsMap())));
     if (!result.isEmpty()) {
       return result;
     } else {
@@ -165,8 +181,8 @@ public class PinotBrokerDebug {
       @Context HttpHeaders headers) {
     tableName = DatabaseUtils.translateTableName(tableName, headers);
     Map<String, Map<ServerInstance, SegmentsToQuery>> result = new TreeMap<>();
-    getRoutingTable(tableName, (tableNameWithType, routingTable) -> result.put(tableNameWithType,
-        routingTable.getServerInstanceToSegmentsMap()));
+    getRoutingTable(tableName, (tableNameWithType, routingTable) ->
+        result.put(tableNameWithType, routingTable.getServerInstanceToSegmentsMap()));
     if (!result.isEmpty()) {
       return result;
     } else {
@@ -195,6 +211,62 @@ public class PinotBrokerDebug {
         consumer.accept(realtimeTableName, routingTable);
       }
     }
+  }
+
+  /**
+   * Iterates over every physical table in the logical table's config, looking up its routing entry by physical table
+   * name. When {@code brokerRequest} is non-null it is passed through (preserving WHERE predicates for segment
+   * pruners); when null, a bare {@code SELECT *} is compiled per physical table.
+   *
+   * <p>When {@code brokerRequest} carries the logical table name in its {@code QuerySource}, that is safe: the
+   * routing-entry lookup is driven by the explicit {@code physicalTableWithType} argument to
+   * {@link RoutingManager#getRoutingTable(BrokerRequest, String, long)}, and segment pruners read only the filter
+   * expression from the request, not the table name.
+   */
+  private void getPhysicalRoutingTablesForLogical(RoutingManager routingManager, String logicalTableName,
+      @Nullable BrokerRequest brokerRequest, BiConsumer<String, RoutingTable> consumer) {
+    String rawTableName = TableNameBuilder.extractRawTableName(logicalTableName);
+    LogicalTableConfig config = _tableCache.getLogicalTableConfig(rawTableName);
+    if (config == null) {
+      throw new WebApplicationException("Logical table config not found for: " + rawTableName,
+          Response.Status.NOT_FOUND);
+    }
+    // Use a single requestId across all physical tables so replica-group selection is consistent.
+    long requestId = getRequestId();
+    Map<String, PhysicalTableConfig> physicalTableConfigMap = config.getPhysicalTableConfigMap();
+    if (physicalTableConfigMap == null || physicalTableConfigMap.isEmpty()) {
+      throw new WebApplicationException("Logical table '" + rawTableName + "' has no physical tables configured",
+          Response.Status.NOT_FOUND);
+    }
+    for (String physicalTableWithType : physicalTableConfigMap.keySet()) {
+      BrokerRequest request = brokerRequest != null ? brokerRequest
+          : CalciteSqlCompiler.compileToBrokerRequest("SELECT * FROM " + physicalTableWithType);
+      RoutingTable routingTable = routingManager.getRoutingTable(request, physicalTableWithType, requestId);
+      if (routingTable != null) {
+        consumer.accept(physicalTableWithType, routingTable);
+      } else {
+        LOGGER.warn("No routing found for physical table: {}", physicalTableWithType);
+      }
+    }
+  }
+
+  // Returns the local or multi-cluster routing manager for a logical table endpoint, validating both the logical table
+  // type and (when requested) multi-cluster configuration. Throws 400 on invalid input.
+  private RoutingManager resolveRoutingManagerForLogical(boolean enableMultiClusterRouting, String tableName) {
+    String rawTableName = TableNameBuilder.extractRawTableName(tableName);
+    if (!_tableCache.isLogicalTable(rawTableName)) {
+      throw new WebApplicationException(
+          "Table '" + rawTableName + "' is not a logical table", Response.Status.BAD_REQUEST);
+    }
+    if (!enableMultiClusterRouting) {
+      return _routingManager;
+    }
+    MultiClusterRoutingContext context = _multiClusterRoutingContextProvider.get();
+    if (context == null || context.getMultiClusterRoutingManager() == null) {
+      throw new WebApplicationException("Multi-cluster routing is not configured on this broker",
+          Response.Status.BAD_REQUEST);
+    }
+    return context.getMultiClusterRoutingManager();
   }
 
   private static Map<ServerInstance, List<String>> removeOptionalSegments(
@@ -245,6 +317,134 @@ public class PinotBrokerDebug {
     RoutingTable routingTable = _routingManager.getRoutingTable(brokerRequest, getRequestId());
     if (routingTable != null) {
       return routingTable.getServerInstanceToSegmentsMap();
+    } else {
+      throw new WebApplicationException("Cannot find routing for query: " + query, Response.Status.NOT_FOUND);
+    }
+  }
+
+  @GET
+  @Produces(MediaType.APPLICATION_JSON)
+  @Path("/debug/routingTable/logical/{tableName}")
+  @Authorize(targetType = TargetType.TABLE, paramName = "tableName", action = Actions.Table.GET_ROUTING_TABLE)
+  @ApiOperation(value = "Get the routing table for a logical table, always expanding to physical tables")
+  @ApiResponses(value = {
+      @ApiResponse(code = 200, message = "Routing table"),
+      @ApiResponse(code = 400, message = "Bad request — table is not a logical table, or multi-cluster routing "
+          + "requested but not configured"),
+      @ApiResponse(code = 404, message = "Routing not found"),
+      @ApiResponse(code = 500, message = "Internal server error")
+  })
+  public Map<String, Map<ServerInstance, List<String>>> getLogicalRoutingTable(
+      @ApiParam(value = "Name of the logical table") @PathParam("tableName") String tableName,
+      @ApiParam(value = "When true, use the multi-cluster routing manager; when false (default) the local routing "
+          + "manager is used but the logical table is still expanded to its physical tables")
+      @QueryParam("enableMultiClusterRouting") boolean enableMultiClusterRouting,
+      @Context HttpHeaders headers) {
+    tableName = DatabaseUtils.translateTableName(tableName, headers);
+    RoutingManager routingManager = resolveRoutingManagerForLogical(enableMultiClusterRouting, tableName);
+    Map<String, Map<ServerInstance, List<String>>> result = new TreeMap<>();
+    getPhysicalRoutingTablesForLogical(routingManager, tableName, null, (tableNameWithType, routingTable) ->
+        result.put(tableNameWithType, removeOptionalSegments(routingTable.getServerInstanceToSegmentsMap())));
+    if (!result.isEmpty()) {
+      return result;
+    } else {
+      throw new WebApplicationException("Cannot find routing for logical table: " + tableName,
+          Response.Status.NOT_FOUND);
+    }
+  }
+
+  @GET
+  @Produces(MediaType.APPLICATION_JSON)
+  @Path("/debug/routingTableWithOptionalSegments/logical/{tableName}")
+  @Authorize(targetType = TargetType.TABLE, paramName = "tableName", action = Actions.Table.GET_ROUTING_TABLE)
+  @ApiOperation(value = "Get the routing table for a logical table including optional segments, always expanding "
+      + "to physical tables")
+  @ApiResponses(value = {
+      @ApiResponse(code = 200, message = "Routing table"),
+      @ApiResponse(code = 400, message = "Bad request — table is not a logical table, or multi-cluster routing "
+          + "requested but not configured"),
+      @ApiResponse(code = 404, message = "Routing not found"),
+      @ApiResponse(code = 500, message = "Internal server error")
+  })
+  public Map<String, Map<ServerInstance, SegmentsToQuery>> getLogicalRoutingTableWithOptionalSegments(
+      @ApiParam(value = "Name of the logical table") @PathParam("tableName") String tableName,
+      @ApiParam(value = "When true, use the multi-cluster routing manager; when false (default) the local routing "
+          + "manager is used but the logical table is still expanded to its physical tables")
+      @QueryParam("enableMultiClusterRouting") boolean enableMultiClusterRouting,
+      @Context HttpHeaders headers) {
+    tableName = DatabaseUtils.translateTableName(tableName, headers);
+    RoutingManager routingManager = resolveRoutingManagerForLogical(enableMultiClusterRouting, tableName);
+    Map<String, Map<ServerInstance, SegmentsToQuery>> result = new TreeMap<>();
+    getPhysicalRoutingTablesForLogical(routingManager, tableName, null, (tableNameWithType, routingTable) ->
+        result.put(tableNameWithType, routingTable.getServerInstanceToSegmentsMap()));
+    if (!result.isEmpty()) {
+      return result;
+    } else {
+      throw new WebApplicationException("Cannot find routing for logical table: " + tableName,
+          Response.Status.NOT_FOUND);
+    }
+  }
+
+  @GET
+  @Produces(MediaType.APPLICATION_JSON)
+  @Path("/debug/routingTable/logical/sql")
+  @ManualAuthorization
+  @ApiOperation(value = "Get the routing table for a logical table query, always expanding to physical tables")
+  @ApiResponses(value = {
+      @ApiResponse(code = 200, message = "Routing table"),
+      @ApiResponse(code = 400, message = "Bad request — table is not a logical table, or multi-cluster routing "
+          + "requested but not configured"),
+      @ApiResponse(code = 404, message = "Routing not found"),
+      @ApiResponse(code = 500, message = "Internal server error")
+  })
+  public Map<String, Map<ServerInstance, List<String>>> getLogicalRoutingTableForQuery(
+      @ApiParam(value = "SQL query whose FROM table must be a logical table") @QueryParam("query") String query,
+      @ApiParam(value = "When true, use the multi-cluster routing manager; when false (default) the local routing "
+          + "manager is used but the logical table is still expanded to its physical tables")
+      @QueryParam("enableMultiClusterRouting") boolean enableMultiClusterRouting,
+      @Context HttpHeaders httpHeaders) {
+    BrokerRequest brokerRequest = CalciteSqlCompiler.compileToBrokerRequest(query);
+    checkAccessControl(brokerRequest, httpHeaders);
+    String tableName = brokerRequest.getQuerySource().getTableName();
+    RoutingManager routingManager = resolveRoutingManagerForLogical(enableMultiClusterRouting, tableName);
+    Map<String, Map<ServerInstance, List<String>>> result = new TreeMap<>();
+    getPhysicalRoutingTablesForLogical(routingManager, tableName, brokerRequest, (tableNameWithType, routingTable) ->
+        result.put(tableNameWithType, removeOptionalSegments(routingTable.getServerInstanceToSegmentsMap())));
+    if (!result.isEmpty()) {
+      return result;
+    } else {
+      throw new WebApplicationException("Cannot find routing for query: " + query, Response.Status.NOT_FOUND);
+    }
+  }
+
+  @GET
+  @Produces(MediaType.APPLICATION_JSON)
+  @Path("/debug/routingTableWithOptionalSegments/logical/sql")
+  @ManualAuthorization
+  @ApiOperation(value = "Get the routing table for a logical table query including optional segments, always "
+      + "expanding to physical tables")
+  @ApiResponses(value = {
+      @ApiResponse(code = 200, message = "Routing table"),
+      @ApiResponse(code = 400, message = "Bad request — table is not a logical table, or multi-cluster routing "
+          + "requested but not configured"),
+      @ApiResponse(code = 404, message = "Routing not found"),
+      @ApiResponse(code = 500, message = "Internal server error")
+  })
+  public Map<String, Map<ServerInstance, SegmentsToQuery>> getLogicalRoutingTableForQueryWithOptionalSegments(
+      @ApiParam(value = "SQL query whose FROM table must be a logical table") @QueryParam("query") String query,
+      @ApiParam(value = "When true, use the multi-cluster routing manager; when false (default) the local routing "
+          + "manager is used but the logical table is still expanded to its physical tables")
+      @QueryParam("enableMultiClusterRouting") boolean enableMultiClusterRouting,
+      @Context HttpHeaders httpHeaders) {
+    BrokerRequest brokerRequest = CalciteSqlCompiler.compileToBrokerRequest(query);
+    checkAccessControl(brokerRequest, httpHeaders);
+    String tableName = brokerRequest.getQuerySource().getTableName();
+    RoutingManager routingManager = resolveRoutingManagerForLogical(enableMultiClusterRouting, tableName);
+    Map<String, Map<ServerInstance, SegmentsToQuery>> result = new TreeMap<>();
+    getPhysicalRoutingTablesForLogical(routingManager, tableName, brokerRequest, (tableNameWithType, routingTable) ->
+        result.put(tableNameWithType, routingTable.getServerInstanceToSegmentsMap()));
+    if (!result.isEmpty()) {
+      return result;
     } else {
       throw new WebApplicationException("Cannot find routing for query: " + query, Response.Status.NOT_FOUND);
     }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
@@ -27,6 +27,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
 import org.apache.hc.client5.http.io.HttpClientConnectionManager;
 import org.apache.hc.core5.http.io.SocketConfig;
@@ -36,6 +37,7 @@ import org.apache.pinot.broker.queryquota.QueryQuotaManager;
 import org.apache.pinot.broker.requesthandler.BrokerRequestHandler;
 import org.apache.pinot.broker.routing.manager.BrokerRoutingManager;
 import org.apache.pinot.common.audit.AuditLogFilter;
+import org.apache.pinot.common.config.provider.TableCache;
 import org.apache.pinot.common.cursors.AbstractResponseStore;
 import org.apache.pinot.common.http.PoolingHttpClientConnectionManagerHelper;
 import org.apache.pinot.common.metrics.BrokerMetrics;
@@ -46,6 +48,7 @@ import org.apache.pinot.common.utils.log.LocalLogFileServer;
 import org.apache.pinot.common.utils.log.LogFileServer;
 import org.apache.pinot.core.api.ServiceAutoDiscoveryFeature;
 import org.apache.pinot.core.query.executor.sql.SqlQueryExecutor;
+import org.apache.pinot.core.routing.MultiClusterRoutingContext;
 import org.apache.pinot.core.transport.ListenerConfig;
 import org.apache.pinot.core.transport.server.routing.stats.ServerRoutingStatsManager;
 import org.apache.pinot.core.util.ListenerConfigUtil;
@@ -79,7 +82,8 @@ public class BrokerAdminApiApplication extends ResourceConfig {
       BrokerMetrics brokerMetrics, PinotConfiguration brokerConf, SqlQueryExecutor sqlQueryExecutor,
       ServerRoutingStatsManager serverRoutingStatsManager, AccessControlFactory accessFactory,
       HelixManager helixManager, QueryQuotaManager queryQuotaManager, ThreadAccountant threadAccountant,
-      AbstractResponseStore responseStore) {
+      AbstractResponseStore responseStore, @Nullable MultiClusterRoutingContext multiClusterRoutingContext,
+      TableCache tableCache) {
     _brokerResourcePackages = brokerConf.getProperty(CommonConstants.Broker.BROKER_RESOURCE_PACKAGES,
         CommonConstants.Broker.DEFAULT_BROKER_RESOURCE_PACKAGES);
     String[] pkgs = _brokerResourcePackages.split(",");
@@ -123,6 +127,9 @@ public class BrokerAdminApiApplication extends ResourceConfig {
         bind(threadAccountant).to(ThreadAccountant.class);
         bind(responseStore).to(AbstractResponseStore.class);
         bind(brokerConf).to(PinotConfiguration.class);
+        bind(new MultiClusterRoutingContextProvider(multiClusterRoutingContext))
+            .to(MultiClusterRoutingContextProvider.class);
+        bind(tableCache).to(TableCache.class);
       }
     });
     boolean enableBoundedJerseyThreadPoolExecutor =

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/MultiClusterRoutingContextProvider.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/MultiClusterRoutingContextProvider.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.broker;
+
+import javax.annotation.Nullable;
+import org.apache.pinot.core.routing.MultiClusterRoutingContext;
+
+
+/**
+ * Wraps a nullable {@link MultiClusterRoutingContext} for Jersey/HK2 injection (always bound; value may be null).
+ */
+public final class MultiClusterRoutingContextProvider {
+  @Nullable
+  private final MultiClusterRoutingContext _context;
+
+  public MultiClusterRoutingContextProvider(@Nullable MultiClusterRoutingContext context) {
+    _context = context;
+  }
+
+  @Nullable
+  public MultiClusterRoutingContext get() {
+    return _context;
+  }
+}

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
@@ -161,6 +161,7 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
   protected PinotMetricsRegistry _metricsRegistry;
   protected BrokerMetrics _brokerMetrics;
   protected BrokerRoutingManager _routingManager;
+  protected MultiClusterRoutingContext _multiClusterRoutingContext;
   protected AccessControlFactory _accessControlFactory;
   protected BrokerRequestHandler _brokerRequestHandler;
   protected SqlQueryExecutor _sqlQueryExecutor;
@@ -403,8 +404,7 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
       _clusterConfigChangeHandler.registerClusterConfigChangeListener(threadAccountantListener);
     }
 
-    // TODO: Hook multiClusterRoutingContext into request handlers subsequently.
-    MultiClusterRoutingContext multiClusterRoutingContext = getMultiClusterRoutingContext();
+    _multiClusterRoutingContext = getMultiClusterRoutingContext();
 
     // Create Broker request handler.
     String brokerId = _brokerConf.getProperty(Broker.CONFIG_OF_BROKER_ID, getDefaultBrokerId());
@@ -416,7 +416,7 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
       singleStageBrokerRequestHandler =
           new GrpcBrokerRequestHandler(_brokerConf, brokerId, requestIdGenerator, _routingManager,
               _accessControlFactory, _queryQuotaManager, _tableCache, _failureDetector, _threadAccountant,
-              multiClusterRoutingContext);
+              _multiClusterRoutingContext);
     } else {
       // Default request handler type, i.e. netty
       NettyConfig nettyDefaults = NettyConfig.extractNettyConfig(_brokerConf, Broker.BROKER_NETTY_PREFIX);
@@ -441,7 +441,7 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
       singleStageBrokerRequestHandler =
           new SingleConnectionBrokerRequestHandler(_brokerConf, brokerId, requestIdGenerator, _routingManager,
               _accessControlFactory, _queryQuotaManager, _tableCache, nettyDefaults, tlsDefaults,
-              _serverRoutingStatsManager, _failureDetector, _threadAccountant, multiClusterRoutingContext);
+              _serverRoutingStatsManager, _failureDetector, _threadAccountant, _multiClusterRoutingContext);
     }
     MultiStageBrokerRequestHandler multiStageBrokerRequestHandler = null;
     if (_brokerConf.getProperty(Helix.CONFIG_OF_MULTI_STAGE_ENGINE_ENABLED, Helix.DEFAULT_MULTI_STAGE_ENGINE_ENABLED)) {
@@ -455,16 +455,16 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
       WorkerManager workerManager =
           createWorkerManager(brokerId, queryRunnerHostname, queryRunnerPort, _routingManager);
       WorkerManager multiClusterWorkerManager;
-      if (multiClusterRoutingContext != null) {
+      if (_multiClusterRoutingContext != null) {
         multiClusterWorkerManager = createWorkerManager(brokerId, queryRunnerHostname, queryRunnerPort,
-            multiClusterRoutingContext.getMultiClusterRoutingManager());
+            _multiClusterRoutingContext.getMultiClusterRoutingManager());
       } else {
         multiClusterWorkerManager = workerManager;
       }
       multiStageBrokerRequestHandler =
           new MultiStageBrokerRequestHandler(_brokerConf, brokerId, requestIdGenerator, _routingManager,
               _accessControlFactory, _queryQuotaManager, _tableCache, _multiStageQueryThrottler, _failureDetector,
-              _threadAccountant, multiClusterRoutingContext, workerManager, multiClusterWorkerManager);
+              _threadAccountant, _multiClusterRoutingContext, workerManager, multiClusterWorkerManager);
       MultiStageBrokerRequestHandler finalHandler = multiStageBrokerRequestHandler;
       _routingManager.setServerReenableCallback(
           serverInstance -> finalHandler.getQueryDispatcher().resetClientConnectionBackoff(serverInstance));
@@ -474,7 +474,7 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
       timeSeriesRequestHandler =
           new TimeSeriesRequestHandler(_brokerConf, brokerId, requestIdGenerator, _routingManager,
               _accessControlFactory, _queryQuotaManager, _tableCache, _threadAccountant,
-              multiClusterRoutingContext);
+              _multiClusterRoutingContext);
     }
 
     LOGGER.info("Initializing PinotFSFactory");
@@ -868,7 +868,7 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
     BrokerAdminApiApplication brokerAdminApiApplication =
         new BrokerAdminApiApplication(_routingManager, _brokerRequestHandler, _brokerMetrics, _brokerConf,
             _sqlQueryExecutor, _serverRoutingStatsManager, _accessControlFactory, _spectatorHelixManager,
-            _queryQuotaManager, _threadAccountant, _responseStore);
+            _queryQuotaManager, _threadAccountant, _responseStore, _multiClusterRoutingContext, _tableCache);
     brokerAdminApiApplication.register(
         new AuditServiceBinder(_clusterConfigChangeHandler, getServiceRole(), _brokerMetrics));
     registerExtraComponents(brokerAdminApiApplication);

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
@@ -174,6 +174,7 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
   protected PinotMetricsRegistry _metricsRegistry;
   protected BrokerMetrics _brokerMetrics;
   protected BrokerRoutingManager _routingManager;
+  protected MultiClusterRoutingContext _multiClusterRoutingContext;
   protected AccessControlFactory _accessControlFactory;
   protected BrokerRequestHandler _brokerRequestHandler;
   protected SqlQueryExecutor _sqlQueryExecutor;
@@ -467,8 +468,7 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
       _clusterConfigChangeHandler.registerClusterConfigChangeListener(threadAccountantListener);
     }
 
-    // TODO: Hook multiClusterRoutingContext into request handlers subsequently.
-    MultiClusterRoutingContext multiClusterRoutingContext = getMultiClusterRoutingContext();
+    _multiClusterRoutingContext = getMultiClusterRoutingContext();
 
     // Create Broker request handler.
     String brokerId = _brokerConf.getProperty(Broker.CONFIG_OF_BROKER_ID, getDefaultBrokerId());
@@ -480,7 +480,7 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
       singleStageBrokerRequestHandler =
           createGrpcBrokerRequestHandler(_brokerConf, brokerId, requestIdGenerator, _routingManager,
               _accessControlFactory, _queryQuotaManager, _tableCache, _failureDetector, _threadAccountant,
-              multiClusterRoutingContext);
+              _multiClusterRoutingContext);
     } else {
       // Default request handler type, i.e. netty
       NettyConfig nettyDefaults = NettyConfig.extractNettyConfig(_brokerConf, Broker.BROKER_NETTY_PREFIX);
@@ -505,7 +505,7 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
       singleStageBrokerRequestHandler =
           createSingleStageBrokerRequestHandler(_brokerConf, brokerId, requestIdGenerator, _routingManager,
               _accessControlFactory, _queryQuotaManager, _tableCache, nettyDefaults, tlsDefaults,
-              _serverRoutingStatsManager, _failureDetector, _threadAccountant, multiClusterRoutingContext);
+              _serverRoutingStatsManager, _failureDetector, _threadAccountant, _multiClusterRoutingContext);
     }
     MultiStageBrokerRequestHandler multiStageBrokerRequestHandler = null;
     if (_brokerConf.getProperty(Helix.CONFIG_OF_MULTI_STAGE_ENGINE_ENABLED, Helix.DEFAULT_MULTI_STAGE_ENGINE_ENABLED)) {
@@ -519,16 +519,16 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
       WorkerManager workerManager =
           createWorkerManager(brokerId, queryRunnerHostname, queryRunnerPort, _routingManager);
       WorkerManager multiClusterWorkerManager;
-      if (multiClusterRoutingContext != null) {
+      if (_multiClusterRoutingContext != null) {
         multiClusterWorkerManager = createWorkerManager(brokerId, queryRunnerHostname, queryRunnerPort,
-            multiClusterRoutingContext.getMultiClusterRoutingManager());
+            _multiClusterRoutingContext.getMultiClusterRoutingManager());
       } else {
         multiClusterWorkerManager = workerManager;
       }
       multiStageBrokerRequestHandler =
           createMultiStageBrokerRequestHandler(_brokerConf, brokerId, requestIdGenerator, _routingManager,
               _accessControlFactory, _queryQuotaManager, _tableCache, _multiStageQueryThrottler, _failureDetector,
-              _threadAccountant, multiClusterRoutingContext, workerManager, multiClusterWorkerManager);
+              _threadAccountant, _multiClusterRoutingContext, workerManager, multiClusterWorkerManager);
       MultiStageBrokerRequestHandler finalHandler = multiStageBrokerRequestHandler;
       _routingManager.setServerReenableCallback(
           serverInstance -> finalHandler.getQueryDispatcher().resetClientConnectionBackoff(serverInstance));
@@ -538,7 +538,7 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
       timeSeriesRequestHandler =
           new TimeSeriesRequestHandler(_brokerConf, brokerId, requestIdGenerator, _routingManager,
               _accessControlFactory, _queryQuotaManager, _tableCache, _threadAccountant,
-              multiClusterRoutingContext);
+              _multiClusterRoutingContext);
     }
 
     LOGGER.info("Initializing PinotFSFactory");
@@ -983,7 +983,7 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
     BrokerAdminApiApplication brokerAdminApiApplication =
         new BrokerAdminApiApplication(_routingManager, _brokerRequestHandler, _brokerMetrics, _brokerConf,
             _sqlQueryExecutor, _serverRoutingStatsManager, _accessControlFactory, _spectatorHelixManager,
-            _queryQuotaManager, _threadAccountant, _responseStore);
+            _queryQuotaManager, _threadAccountant, _responseStore, _multiClusterRoutingContext, _tableCache);
     brokerAdminApiApplication.register(
         new AuditServiceBinder(_clusterConfigChangeHandler, getServiceRole(), _brokerMetrics));
     registerExtraComponents(brokerAdminApiApplication);

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/api/resources/PinotBrokerDebugTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/api/resources/PinotBrokerDebugTest.java
@@ -21,10 +21,17 @@ package org.apache.pinot.broker.api.resources;
 import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.HttpHeaders;
+import org.apache.pinot.broker.broker.MultiClusterRoutingContextProvider;
 import org.apache.pinot.broker.routing.manager.BrokerRoutingManager;
+import org.apache.pinot.common.config.provider.TableCache;
 import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.core.routing.MultiClusterRoutingContext;
 import org.apache.pinot.core.routing.RoutingTable;
+import org.apache.pinot.spi.data.LogicalTableConfig;
+import org.apache.pinot.spi.data.PhysicalTableConfig;
 import org.mockito.ArgumentCaptor;
 import org.testng.annotations.Test;
 
@@ -36,9 +43,26 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
 
 
 public class PinotBrokerDebugTest {
+
+  private PinotBrokerDebug createBrokerDebug(BrokerRoutingManager routingManager)
+      throws Exception {
+    PinotBrokerDebug brokerDebug = new PinotBrokerDebug();
+    setField(brokerDebug, "_routingManager", routingManager);
+    setField(brokerDebug, "_multiClusterRoutingContextProvider", new MultiClusterRoutingContextProvider(null));
+    setField(brokerDebug, "_tableCache", mock(TableCache.class));
+    return brokerDebug;
+  }
+
+  private static void setField(Object target, String fieldName, Object value)
+      throws Exception {
+    Field field = target.getClass().getDeclaredField(fieldName);
+    field.setAccessible(true);
+    field.set(target, value);
+  }
 
   @Test
   public void testGetRoutingTableUsesSameRequestIdForOfflineAndRealtime()
@@ -47,12 +71,9 @@ public class PinotBrokerDebugTest {
     when(routingManager.getRoutingTable(any(BrokerRequest.class), anyLong()))
         .thenReturn(new RoutingTable(Collections.emptyMap(), Collections.emptyList(), 0));
 
-    PinotBrokerDebug brokerDebug = new PinotBrokerDebug();
-    Field routingManagerField = PinotBrokerDebug.class.getDeclaredField("_routingManager");
-    routingManagerField.setAccessible(true);
-    routingManagerField.set(brokerDebug, routingManager);
+    PinotBrokerDebug brokerDebug = createBrokerDebug(routingManager);
 
-    brokerDebug.getRoutingTable("testTable", (HttpHeaders) null);
+    brokerDebug.getRoutingTable("testTable", false, (HttpHeaders) null);
 
     ArgumentCaptor<Long> requestIdCaptor = ArgumentCaptor.forClass(Long.class);
     verify(routingManager, times(2)).getRoutingTable(any(BrokerRequest.class), requestIdCaptor.capture());
@@ -74,13 +95,10 @@ public class PinotBrokerDebugTest {
       return null;
     });
 
-    PinotBrokerDebug brokerDebug = new PinotBrokerDebug();
-    Field routingManagerField = PinotBrokerDebug.class.getDeclaredField("_routingManager");
-    routingManagerField.setAccessible(true);
-    routingManagerField.set(brokerDebug, routingManager);
+    PinotBrokerDebug brokerDebug = createBrokerDebug(routingManager);
 
-    brokerDebug.getRoutingTable("testTable", (HttpHeaders) null);
-    brokerDebug.getRoutingTable("testTable", (HttpHeaders) null);
+    brokerDebug.getRoutingTable("testTable", false, (HttpHeaders) null);
+    brokerDebug.getRoutingTable("testTable", false, (HttpHeaders) null);
 
     ArgumentCaptor<BrokerRequest> brokerRequestCaptor = ArgumentCaptor.forClass(BrokerRequest.class);
     ArgumentCaptor<Long> requestIdCaptor = ArgumentCaptor.forClass(Long.class);
@@ -106,5 +124,75 @@ public class PinotBrokerDebugTest {
     assertTrue(firstRealtimeRequestId != null);
     assertTrue(secondRealtimeRequestId != null);
     assertEquals((long) secondRealtimeRequestId, firstRealtimeRequestId + 1);
+  }
+
+  @Test
+  public void testMultiClusterRoutingRejectsWhenNotConfigured()
+      throws Exception {
+    BrokerRoutingManager routingManager = mock(BrokerRoutingManager.class);
+    PinotBrokerDebug brokerDebug = createBrokerDebug(routingManager);
+
+    WebApplicationException ex = expectThrows(WebApplicationException.class,
+        () -> brokerDebug.getRoutingTable("testTable", true, (HttpHeaders) null));
+    assertEquals(ex.getResponse().getStatus(), 400);
+    assertTrue(ex.getMessage().contains("Multi-cluster routing is not configured"));
+  }
+
+  @Test
+  public void testMultiClusterRoutingRejectsNonLogicalTable()
+      throws Exception {
+    BrokerRoutingManager routingManager = mock(BrokerRoutingManager.class);
+    BrokerRoutingManager multiClusterManager = mock(BrokerRoutingManager.class);
+    MultiClusterRoutingContext context =
+        new MultiClusterRoutingContext(Collections.emptyMap(), routingManager, multiClusterManager,
+            Collections.emptySet());
+
+    TableCache tableCache = mock(TableCache.class);
+    when(tableCache.isLogicalTable("physicalTable")).thenReturn(false);
+
+    PinotBrokerDebug brokerDebug = new PinotBrokerDebug();
+    setField(brokerDebug, "_routingManager", routingManager);
+    setField(brokerDebug, "_multiClusterRoutingContextProvider", new MultiClusterRoutingContextProvider(context));
+    setField(brokerDebug, "_tableCache", tableCache);
+
+    WebApplicationException ex = expectThrows(WebApplicationException.class,
+        () -> brokerDebug.getRoutingTable("physicalTable", true, (HttpHeaders) null));
+    assertEquals(ex.getResponse().getStatus(), 400);
+    assertTrue(ex.getMessage().contains("not a logical table"));
+  }
+
+  @Test
+  public void testMultiClusterRoutingSucceedsForLogicalTable()
+      throws Exception {
+    BrokerRoutingManager routingManager = mock(BrokerRoutingManager.class);
+    BrokerRoutingManager multiClusterManager = mock(BrokerRoutingManager.class);
+    when(multiClusterManager.getRoutingTable(any(BrokerRequest.class), anyLong()))
+        .thenReturn(new RoutingTable(Collections.emptyMap(), Collections.emptyList(), 0));
+
+    MultiClusterRoutingContext context =
+        new MultiClusterRoutingContext(Collections.emptyMap(), routingManager, multiClusterManager,
+            Collections.emptySet());
+
+    // Logical table with two physical tables (one OFFLINE each) in the config map
+    LogicalTableConfig logicalTableConfig = new LogicalTableConfig();
+    logicalTableConfig.setTableName("logicalTable");
+    logicalTableConfig.setPhysicalTableConfigMap(Map.of(
+        "physicalTable1_OFFLINE", new PhysicalTableConfig(false),
+        "physicalTable2_OFFLINE", new PhysicalTableConfig(true)));
+
+    TableCache tableCache = mock(TableCache.class);
+    when(tableCache.isLogicalTable("logicalTable")).thenReturn(true);
+    when(tableCache.getLogicalTableConfig("logicalTable")).thenReturn(logicalTableConfig);
+
+    PinotBrokerDebug brokerDebug = new PinotBrokerDebug();
+    setField(brokerDebug, "_routingManager", routingManager);
+    setField(brokerDebug, "_multiClusterRoutingContextProvider", new MultiClusterRoutingContextProvider(context));
+    setField(brokerDebug, "_tableCache", tableCache);
+
+    brokerDebug.getRoutingTable("logicalTable", true, (HttpHeaders) null);
+
+    // One call per physical table in the config; the local routingManager is never touched
+    verify(multiClusterManager, times(2)).getRoutingTable(any(BrokerRequest.class), anyLong());
+    verify(routingManager, times(0)).getRoutingTable(any(BrokerRequest.class), anyLong());
   }
 }

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/api/resources/PinotBrokerDebugTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/api/resources/PinotBrokerDebugTest.java
@@ -21,24 +21,81 @@ package org.apache.pinot.broker.api.resources;
 import java.lang.reflect.Field;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.HttpHeaders;
+import org.apache.pinot.broker.api.AccessControl;
+import org.apache.pinot.broker.broker.AccessControlFactory;
+import org.apache.pinot.broker.broker.MultiClusterRoutingContextProvider;
 import org.apache.pinot.broker.routing.manager.BrokerRoutingManager;
+import org.apache.pinot.common.config.provider.TableCache;
 import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.core.routing.MultiClusterRoutingContext;
 import org.apache.pinot.core.routing.RoutingTable;
+import org.apache.pinot.core.transport.ServerInstance;
+import org.apache.pinot.spi.data.LogicalTableConfig;
+import org.apache.pinot.spi.data.PhysicalTableConfig;
 import org.mockito.ArgumentCaptor;
 import org.testng.annotations.Test;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
 
 
+/**
+ * Unit tests for {@link PinotBrokerDebug} covering request-ID consistency, multi-cluster routing dispatch,
+ * and the SQL-based routing endpoints (single-table and logical-table expansion).
+ */
 public class PinotBrokerDebugTest {
+
+  private PinotBrokerDebug createBrokerDebug(BrokerRoutingManager routingManager)
+      throws Exception {
+    return createBrokerDebug(routingManager, mock(TableCache.class), null);
+  }
+
+  private PinotBrokerDebug createBrokerDebug(BrokerRoutingManager routingManager, TableCache tableCache)
+      throws Exception {
+    return createBrokerDebug(routingManager, tableCache, null);
+  }
+
+  private PinotBrokerDebug createBrokerDebug(BrokerRoutingManager routingManager, TableCache tableCache,
+      MultiClusterRoutingContext context)
+      throws Exception {
+    PinotBrokerDebug brokerDebug = new PinotBrokerDebug();
+    setField(brokerDebug, "_routingManager", routingManager);
+    setField(brokerDebug, "_multiClusterRoutingContextProvider", new MultiClusterRoutingContextProvider(context));
+    setField(brokerDebug, "_tableCache", tableCache);
+    return brokerDebug;
+  }
+
+  /** Returns a mock {@link TableCache} that reports {@code rawName} as a logical table with two physical tables. */
+  private static TableCache logicalTableCache(String rawName) {
+    LogicalTableConfig cfg = new LogicalTableConfig();
+    cfg.setTableName(rawName);
+    cfg.setPhysicalTableConfigMap(Map.of(
+        "physicalTable1_OFFLINE", new PhysicalTableConfig(false),
+        "physicalTable2_OFFLINE", new PhysicalTableConfig(true)));
+    TableCache tc = mock(TableCache.class);
+    when(tc.isLogicalTable(rawName)).thenReturn(true);
+    when(tc.getLogicalTableConfig(rawName)).thenReturn(cfg);
+    return tc;
+  }
+
+  private static void setField(Object target, String fieldName, Object value)
+      throws Exception {
+    Field field = target.getClass().getDeclaredField(fieldName);
+    field.setAccessible(true);
+    field.set(target, value);
+  }
 
   @Test
   public void testGetRoutingTableUsesSameRequestIdForOfflineAndRealtime()
@@ -47,10 +104,7 @@ public class PinotBrokerDebugTest {
     when(routingManager.getRoutingTable(any(BrokerRequest.class), anyLong()))
         .thenReturn(new RoutingTable(Collections.emptyMap(), Collections.emptyList(), 0));
 
-    PinotBrokerDebug brokerDebug = new PinotBrokerDebug();
-    Field routingManagerField = PinotBrokerDebug.class.getDeclaredField("_routingManager");
-    routingManagerField.setAccessible(true);
-    routingManagerField.set(brokerDebug, routingManager);
+    PinotBrokerDebug brokerDebug = createBrokerDebug(routingManager);
 
     brokerDebug.getRoutingTable("testTable", (HttpHeaders) null);
 
@@ -74,10 +128,7 @@ public class PinotBrokerDebugTest {
       return null;
     });
 
-    PinotBrokerDebug brokerDebug = new PinotBrokerDebug();
-    Field routingManagerField = PinotBrokerDebug.class.getDeclaredField("_routingManager");
-    routingManagerField.setAccessible(true);
-    routingManagerField.set(brokerDebug, routingManager);
+    PinotBrokerDebug brokerDebug = createBrokerDebug(routingManager);
 
     brokerDebug.getRoutingTable("testTable", (HttpHeaders) null);
     brokerDebug.getRoutingTable("testTable", (HttpHeaders) null);
@@ -103,8 +154,133 @@ public class PinotBrokerDebugTest {
       }
     }
 
-    assertTrue(firstRealtimeRequestId != null);
-    assertTrue(secondRealtimeRequestId != null);
+    assertNotNull(firstRealtimeRequestId);
+    assertNotNull(secondRealtimeRequestId);
     assertEquals((long) secondRealtimeRequestId, firstRealtimeRequestId + 1);
+  }
+
+  /** Creates a PinotBrokerDebug with a permissive access control factory for SQL endpoint tests. */
+  private PinotBrokerDebug createBrokerDebugWithAccessControl(BrokerRoutingManager routingManager,
+      MultiClusterRoutingContext multiClusterContext, TableCache tableCache)
+      throws Exception {
+    AccessControl accessControl = mock(AccessControl.class);
+    when(accessControl.hasAccess(any(), any(), any(), any())).thenReturn(true);
+    AccessControlFactory accessControlFactory = mock(AccessControlFactory.class);
+    when(accessControlFactory.create()).thenReturn(accessControl);
+
+    PinotBrokerDebug brokerDebug = createBrokerDebug(routingManager, tableCache, multiClusterContext);
+    setField(brokerDebug, "_accessControlFactory", accessControlFactory);
+    return brokerDebug;
+  }
+
+  // ---- /debug/routingTable/logical/{tableName} and /debug/routingTable/logical/sql tests ----
+
+  @Test
+  public void testLogicalRoutingTableRejectsNonLogicalTable()
+      throws Exception {
+    // Default mock returns false for isLogicalTable
+    PinotBrokerDebug brokerDebug = createBrokerDebug(mock(BrokerRoutingManager.class));
+    WebApplicationException ex = expectThrows(WebApplicationException.class,
+        () -> brokerDebug.getLogicalRoutingTable("physicalTable", false, (HttpHeaders) null));
+    assertEquals(ex.getResponse().getStatus(), 400);
+    assertTrue(ex.getMessage().contains("not a logical table"));
+  }
+
+  @Test
+  public void testLogicalRoutingTableWithLocalRoutingExpandsPhysicalTables()
+      throws Exception {
+    BrokerRoutingManager routingManager = mock(BrokerRoutingManager.class);
+    when(routingManager.getRoutingTable(any(BrokerRequest.class), anyString(), anyLong()))
+        .thenReturn(new RoutingTable(Collections.emptyMap(), Collections.emptyList(), 0));
+
+    Map<String, Map<ServerInstance, List<String>>> result =
+        createBrokerDebug(routingManager, logicalTableCache("logicalTable"))
+            .getLogicalRoutingTable("logicalTable", false, (HttpHeaders) null);
+
+    assertEquals(result.size(), 2);
+    assertTrue(result.containsKey("physicalTable1_OFFLINE"));
+    assertTrue(result.containsKey("physicalTable2_OFFLINE"));
+    verify(routingManager, times(2)).getRoutingTable(any(BrokerRequest.class), anyString(), anyLong());
+  }
+
+  @Test
+  public void testLogicalRoutingTableWithMultiClusterRoutingUsesMultiClusterManager()
+      throws Exception {
+    BrokerRoutingManager routingManager = mock(BrokerRoutingManager.class);
+    BrokerRoutingManager multiClusterManager = mock(BrokerRoutingManager.class);
+    when(multiClusterManager.getRoutingTable(any(BrokerRequest.class), anyString(), anyLong()))
+        .thenReturn(new RoutingTable(Collections.emptyMap(), Collections.emptyList(), 0));
+    MultiClusterRoutingContext context =
+        new MultiClusterRoutingContext(Collections.emptyMap(), routingManager, multiClusterManager,
+            Collections.emptySet());
+
+    createBrokerDebug(routingManager, logicalTableCache("logicalTable"), context)
+        .getLogicalRoutingTable("logicalTable", true, (HttpHeaders) null);
+
+    verify(multiClusterManager, times(2)).getRoutingTable(any(BrokerRequest.class), anyString(), anyLong());
+    verify(routingManager, times(0)).getRoutingTable(any(BrokerRequest.class), anyString(), anyLong());
+  }
+
+  @Test
+  public void testLogicalRoutingTableMultiClusterRejectsWhenNotConfigured()
+      throws Exception {
+    // Provider wraps null context → multi-cluster routing not configured
+    PinotBrokerDebug brokerDebug =
+        createBrokerDebug(mock(BrokerRoutingManager.class), logicalTableCache("logicalTable"));
+    WebApplicationException ex = expectThrows(WebApplicationException.class,
+        () -> brokerDebug.getLogicalRoutingTable("logicalTable", true, (HttpHeaders) null));
+    assertEquals(ex.getResponse().getStatus(), 400);
+    assertTrue(ex.getMessage().contains("Multi-cluster routing is not configured"));
+  }
+
+  @Test
+  public void testLogicalSqlRoutingTableRejectsNonLogicalTable()
+      throws Exception {
+    // Default mock returns false for isLogicalTable
+    PinotBrokerDebug brokerDebug = createBrokerDebugWithAccessControl(
+        mock(BrokerRoutingManager.class), null, mock(TableCache.class));
+    WebApplicationException ex = expectThrows(WebApplicationException.class,
+        () -> brokerDebug.getLogicalRoutingTableForQuery("SELECT * FROM myTable_OFFLINE", false, (HttpHeaders) null));
+    assertEquals(ex.getResponse().getStatus(), 400);
+    assertTrue(ex.getMessage().contains("not a logical table"));
+  }
+
+  @Test
+  public void testLogicalSqlRoutingTableWithLocalRoutingExpandsPhysicalTables()
+      throws Exception {
+    BrokerRoutingManager routingManager = mock(BrokerRoutingManager.class);
+    when(routingManager.getRoutingTable(any(BrokerRequest.class), anyString(), anyLong()))
+        .thenReturn(new RoutingTable(Collections.emptyMap(), Collections.emptyList(), 0));
+
+    Map<String, Map<ServerInstance, List<String>>> result =
+        createBrokerDebugWithAccessControl(routingManager, null, logicalTableCache("logicalTable"))
+            .getLogicalRoutingTableForQuery("SELECT * FROM logicalTable_OFFLINE", false, (HttpHeaders) null);
+
+    assertEquals(result.size(), 2);
+    assertTrue(result.containsKey("physicalTable1_OFFLINE"));
+    assertTrue(result.containsKey("physicalTable2_OFFLINE"));
+    verify(routingManager, times(2)).getRoutingTable(any(BrokerRequest.class), anyString(), anyLong());
+  }
+
+  @Test
+  public void testLogicalSqlRoutingTableWithMultiClusterRoutingUsesMultiClusterManager()
+      throws Exception {
+    BrokerRoutingManager routingManager = mock(BrokerRoutingManager.class);
+    BrokerRoutingManager multiClusterManager = mock(BrokerRoutingManager.class);
+    when(multiClusterManager.getRoutingTable(any(BrokerRequest.class), anyString(), anyLong()))
+        .thenReturn(new RoutingTable(Collections.emptyMap(), Collections.emptyList(), 0));
+    MultiClusterRoutingContext context =
+        new MultiClusterRoutingContext(Collections.emptyMap(), routingManager, multiClusterManager,
+            Collections.emptySet());
+
+    Map<String, Map<ServerInstance, List<String>>> result =
+        createBrokerDebugWithAccessControl(routingManager, context, logicalTableCache("logicalTable"))
+            .getLogicalRoutingTableForQuery("SELECT * FROM logicalTable_OFFLINE", true, (HttpHeaders) null);
+
+    assertEquals(result.size(), 2);
+    assertTrue(result.containsKey("physicalTable1_OFFLINE"));
+    assertTrue(result.containsKey("physicalTable2_OFFLINE"));
+    verify(routingManager, times(0)).getRoutingTable(any(BrokerRequest.class), anyString(), anyLong());
+    verify(multiClusterManager, times(2)).getRoutingTable(any(BrokerRequest.class), anyString(), anyLong());
   }
 }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/multicluster/MultiClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/multicluster/MultiClusterIntegrationTest.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import java.io.IOException;
 import java.util.Map;
+import org.apache.pinot.controller.helix.ControllerTest;
 import org.apache.pinot.spi.data.PhysicalTableConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -99,6 +100,39 @@ public class MultiClusterIntegrationTest extends BaseMultiClusterIntegrationTest
     assertEquals(count2, TABLE_SIZE_CLUSTER_2);
 
     LOGGER.info("Multi-cluster broker test passed: both clusters started and queryable");
+  }
+
+  @Test(groups = "query")
+  public void testMultiClusterRoutingTableDebugEndpoint() throws Exception {
+    String logicalTable = getLogicalTableName();
+    String brokerBase = "http://localhost:" + _cluster1._brokerPort;
+
+    // Local routing for a physical table should work without the multi-cluster flag
+    String physicalTable = getPhysicalTable1InCluster1();
+    String localRouting = ControllerTest.sendGetRequest(
+        brokerBase + "/debug/routingTable/" + physicalTable);
+    JsonMapper mapper = JsonMapper.builder().build();
+    JsonNode localJson = mapper.readTree(localRouting);
+    String physicalOfflineKey = physicalTable + "_OFFLINE";
+    assertTrue(localJson.has(physicalOfflineKey),
+        "Local routing should include physical offline table: " + localRouting);
+
+    // Multi-cluster routing for a logical table
+    String multiRouting = ControllerTest.sendGetRequest(
+        brokerBase + "/debug/routingTable/" + logicalTable + "?useMultiClusterRouting=true");
+    JsonNode multiJson = mapper.readTree(multiRouting);
+
+    // The logical table expands to its physical tables; verify both physical tables are represented.
+    String phys1OfflineKey = getPhysicalTable1InCluster1() + "_OFFLINE";
+    String phys2OfflineKey = getPhysicalTable1InCluster2() + "_OFFLINE";
+    assertTrue(multiJson.has(phys1OfflineKey),
+        "Multi-cluster routing should include physical table from cluster 1: " + multiRouting);
+    assertTrue(multiJson.has(phys2OfflineKey),
+        "Multi-cluster routing should include physical table from cluster 2: " + multiRouting);
+    assertTrue(multiJson.get(phys1OfflineKey).size() >= 1,
+        "Cluster 1 physical table should have at least one server");
+    assertTrue(multiJson.get(phys2OfflineKey).size() >= 1,
+        "Cluster 2 physical table should have at least one server");
   }
 
   @BeforeGroups("query")

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/multicluster/MultiClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/multicluster/MultiClusterIntegrationTest.java
@@ -21,7 +21,10 @@ package org.apache.pinot.integration.tests.multicluster;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import java.io.IOException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.util.Map;
+import org.apache.pinot.controller.helix.ControllerTest;
 import org.apache.pinot.spi.data.PhysicalTableConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,8 +33,10 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 /**
  * Integration tests for multi-cluster routing and federation.
@@ -99,6 +104,116 @@ public class MultiClusterIntegrationTest extends BaseMultiClusterIntegrationTest
     assertEquals(count2, TABLE_SIZE_CLUSTER_2);
 
     LOGGER.info("Multi-cluster broker test passed: both clusters started and queryable");
+  }
+
+  @Test(groups = "query")
+  public void testLogicalRoutingTableEndpointLocalRouting() throws Exception {
+    String brokerBase = "http://localhost:" + _cluster1._brokerPort;
+    JsonNode json = fetchLogicalRoutingJson(brokerBase, getLogicalTableName(), false);
+    assertFalse(json.has("error"), "Expected routing result: " + json);
+    assertTrue(json.has(getPhysicalTable1InCluster1() + "_OFFLINE"),
+        "Local routing should include local physical table: " + json);
+  }
+
+  @Test(groups = "query")
+  public void testLogicalRoutingTableEndpointMultiClusterRouting() throws Exception {
+    String brokerBase = "http://localhost:" + _cluster1._brokerPort;
+    JsonNode json = fetchLogicalRoutingJson(brokerBase, getLogicalTableName(), true);
+    assertFalse(json.has("error"), "Expected routing result: " + json);
+    String phys1Key = getPhysicalTable1InCluster1() + "_OFFLINE";
+    String phys2Key = getPhysicalTable1InCluster2() + "_OFFLINE";
+    assertTrue(json.has(phys1Key), "Multi-cluster routing should include cluster 1 physical table: " + json);
+    assertTrue(json.has(phys2Key), "Multi-cluster routing should include cluster 2 physical table: " + json);
+    assertTrue(json.get(phys1Key).size() >= 1, "Cluster 1 physical table should have at least one server");
+    assertTrue(json.get(phys2Key).size() >= 1, "Cluster 2 physical table should have at least one server");
+  }
+
+  @Test(groups = "query")
+  public void testLogicalRoutingTableEndpointRejectsPhysicalTable() throws Exception {
+    String brokerBase = "http://localhost:" + _cluster1._brokerPort;
+    assertLogicalEndpointRejectsPhysicalTable(
+        brokerBase + "/debug/routingTable/logical/" + getPhysicalTable1InCluster1()
+            + "?enableMultiClusterRouting=false");
+  }
+
+  @Test(groups = "query")
+  public void testLogicalSqlRoutingTableEndpointLocalRouting() throws Exception {
+    String brokerBase = "http://localhost:" + _cluster1._brokerPort;
+    JsonNode json = fetchLogicalSqlRoutingJson(brokerBase,
+        "SELECT * FROM " + getLogicalTableName() + "_OFFLINE", false);
+    assertFalse(json.has("error"), "Expected routing result: " + json);
+    assertTrue(json.has(getPhysicalTable1InCluster1() + "_OFFLINE"),
+        "Local SQL routing should include local physical table: " + json);
+  }
+
+  @Test(groups = "query")
+  public void testLogicalSqlRoutingTableEndpointMultiClusterRouting() throws Exception {
+    String brokerBase = "http://localhost:" + _cluster1._brokerPort;
+    JsonNode json = fetchLogicalSqlRoutingJson(brokerBase, "SELECT * FROM " + getLogicalTableName() + "_OFFLINE", true);
+    assertFalse(json.has("error"), "Expected routing result: " + json);
+    String phys1Key = getPhysicalTable1InCluster1() + "_OFFLINE";
+    String phys2Key = getPhysicalTable1InCluster2() + "_OFFLINE";
+    assertTrue(json.has(phys1Key), "Multi-cluster SQL routing should include cluster 1 physical table: " + json);
+    assertTrue(json.has(phys2Key), "Multi-cluster SQL routing should include cluster 2 physical table: " + json);
+    assertTrue(json.get(phys1Key).size() >= 1, "Cluster 1 physical table should have at least one server");
+    assertTrue(json.get(phys2Key).size() >= 1, "Cluster 2 physical table should have at least one server");
+  }
+
+  @Test(groups = "query")
+  public void testLogicalSqlRoutingTableEndpointRejectsPhysicalTable() throws Exception {
+    String brokerBase = "http://localhost:" + _cluster1._brokerPort;
+    String sql = "SELECT * FROM " + getPhysicalTable1InCluster1() + "_OFFLINE";
+    assertLogicalEndpointRejectsPhysicalTable(brokerBase + "/debug/routingTable/logical/sql?query="
+        + URLEncoder.encode(sql, StandardCharsets.UTF_8) + "&enableMultiClusterRouting=false");
+  }
+
+  @Test(groups = "query")
+  public void testLogicalSqlRoutingWithPredicatePrunesSegments() throws Exception {
+    String brokerBase = "http://localhost:" + _cluster1._brokerPort;
+    String table = getLogicalTableName() + "_OFFLINE";
+    JsonNode unprunedJson = fetchLogicalSqlRoutingJson(brokerBase, "SELECT * FROM " + table, true);
+    int unprunedCount = totalSegmentCount(unprunedJson);
+
+    JsonNode prunedJson = fetchLogicalSqlRoutingJson(brokerBase,
+        "SELECT * FROM " + table + " WHERE DaysSinceEpoch = 1", true);
+    assertFalse(prunedJson.has("error"), "Pruned routing should not error: " + prunedJson);
+    assertTrue(totalSegmentCount(prunedJson) <= unprunedCount,
+        "Pruned segment count should be <= unpruned (" + unprunedCount + ")");
+  }
+
+  private JsonNode fetchLogicalRoutingJson(String brokerBase, String table, boolean multiCluster) throws Exception {
+    return JsonMapper.builder().build().readTree(ControllerTest.sendGetRequest(
+        brokerBase + "/debug/routingTable/logical/" + table + "?enableMultiClusterRouting=" + multiCluster));
+  }
+
+  private JsonNode fetchLogicalSqlRoutingJson(String brokerBase, String sql, boolean multiCluster) throws Exception {
+    String encoded = URLEncoder.encode(sql, StandardCharsets.UTF_8);
+    return JsonMapper.builder().build().readTree(ControllerTest.sendGetRequest(
+        brokerBase + "/debug/routingTable/logical/sql?query=" + encoded
+            + "&enableMultiClusterRouting=" + multiCluster));
+  }
+
+  private void assertLogicalEndpointRejectsPhysicalTable(String url) {
+    try {
+      ControllerTest.sendGetRequest(url);
+      fail("Expected HTTP 400 for non-logical table");
+    } catch (Exception e) {
+      assertTrue(e.getMessage().contains("400") || e.getMessage().contains("Bad Request"),
+          "Expected 400 error: " + e.getMessage());
+      assertTrue(e.getMessage().contains("not a logical table"),
+          "Expected 'not a logical table' in error: " + e.getMessage());
+    }
+  }
+
+  /** Sums the total number of segments across all physical tables in a routing response. */
+  private static int totalSegmentCount(JsonNode routingJson) {
+    int total = 0;
+    for (JsonNode servers : routingJson) {
+      for (JsonNode segments : servers) {
+        total += segments.size();
+      }
+    }
+    return total;
   }
 
   @BeforeGroups("query")


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Adds logical\-table debug endpoints that optionally use multi\-cluster routing manager to return per\-physical\-table routing info\.

```mermaid
flowchart TD
  N0["getLogicalRoutingTable #40;F4#41;"]:::stAdded
  N1["resolveRoutingManagerForLogical #40;F4#41;"]:::stAdded
  N2["MultiClusterRoutingContextProvider#46;get #40;F2#44; F4#41;"]:::stAdded
  N3["MultiClusterRoutingContext#46;getMultiClusterRoutingManager #40;F4#41;"]:::stAdded
  N4["TableCache#46;isLogicalTable #40;F4#41;"]:::stAdded
  N5["TableCache#46;getLogicalTableConfig #40;F4#41;"]:::stAdded
  N6["TableCache#46;getPhysicalTableConfigMap #40;F4#41;"]:::stAdded
  N7["getPhysicalRoutingTablesForLogical #40;F4#41;"]:::stAdded
  N8["CalciteSqlCompiler#46;compileToBrokerRequest #40;F4#41;"]:::stAdded
  N9["routingManager#46;getRoutingTable #40;F4#41;"]:::stAdded
  N10["removeOptionalSegments #40;F4#41;"]:::stAdded
  N0 -->|"calls"| N1
  N1 -->|"calls"| N4
  N1 -->|"calls when enableMultiClusterRouting#61;true"| N2
  N1 -->|"calls after getting context"| N3
  N0 -->|"calls"| N7
  N7 -->|"calls"| N5
  N7 -->|"calls"| N6
  N7 -->|"calls when brokerRequest is null"| N8
  N7 -->|"calls for each physical table"| N9
  N7 -->|"calls via consumer lambda"| N10
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F2: pinot\-broker/src/main/java/org/apache/pinot/broker/broker/MultiClusterRoutingContextProvider\.java — [after](https://github.com/apache/pinot/blob/4a7b05f7415a14d46e102cd3ea2640a434a1e892/pinot-broker/src/main/java/org/apache/pinot/broker/broker/MultiClusterRoutingContextProvider.java)
- F4: pinot\-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotBrokerDebug\.java — [before](https://github.com/apache/pinot/blob/dc4251af4c68d1c6f85045c487f62653be454e95/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotBrokerDebug.java) · [after](https://github.com/apache/pinot/blob/4a7b05f7415a14d46e102cd3ea2640a434a1e892/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotBrokerDebug.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImRjNDI1MWFmNGM2OGQxYzZmODUwNDVjNDg3ZjYyNjUzYmU0NTRlOTUiLCJjb250ZXh0X2hhc2giOiJhNGU4ZmFiZDAwMmRiNmJiMmUyMjI0MDhkZDg5MzBhOGUxZDg2NzZhZjM4OTcyMWQ1MTMyYzRhMjg4ZTBmYmMwIiwiZ2VuZXJhdGVkX2F0IjoxNzg5MTE5MDU4LCJoZWFkX3NoYSI6IjRhN2IwNWY3NDE1YTE0ZDQ2ZTEwMmNkM2VhMjY0MGE0MzRhMWU4OTIiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiIyMWM4OGY3MTZmMzc2YmI3YTAyMzhlMGZlZWVmZjEyYjA4OGY1NWY3IiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 974797aaccfd8a28ce0586f3544e4ad1a15d5927ade02a5161ad2714ce220a3f -->
<!-- pinot-pr-flow:end -->

## Summary 

This PR extends the broker's existing routing debug APIs (`/debug/routingTable/tableName` and its variant with optional segments) to support returning the routing table for logical tables with multi-cluster routing enabled. 
The multi-cluster routing is only enabled if queried with `useMultiClusterRouting` query param.
This is required since it is very helpful to debug which servers and segments are selected for a multi-cluster routing at runtime.

## Testing
Added an integration test for the `debug` endpoint to verify that the routing table returned contains servers from multiple clusters.                                                                              

Also verified by running the `MULTI_CLUSTER` quickstart and verifying the debug endpoint returns correctly.
```
$ curl -s "http://localhost:8000/debug/routingTableWithOptionalSegments/unified_orders?useMultiClusterRouting=true" | jq .
{
  "orders_cluster1_OFFLINE": {
    "Server_localhost_7010": {
      "segments": [
        "orders_cluster1_1777424982379"
      ],
      "optionalSegments": []
    }
  },
  "orders_cluster2_OFFLINE": {
    "Server_localhost_7110": {
      "segments": [
        "orders_cluster2_1777424982856"
      ],
      "optionalSegments": []
    }
  }
}
$ curl -s "http://localhost:8100/debug/routingTableWithOptionalSegments/unified_orders?useMultiClusterRouting=true" | jq .
{
  "orders_cluster1_OFFLINE": {
    "Server_localhost_7010": {
      "segments": [
        "orders_cluster1_1777424982379"
      ],
      "optionalSegments": []
    }
  },
  "orders_cluster2_OFFLINE": {
    "Server_localhost_7110": {
      "segments": [
        "orders_cluster2_1777424982856"
      ],
      "optionalSegments": []
    }
  }
}
```
