### PR TITLE
Handle finalize and null-path instance config callbacks

### DIFF
--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/ServerGrpcChannelBackoffResetHandler.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/ServerGrpcChannelBackoffResetHandler.java
@@ -81,15 +81,24 @@ public class ServerGrpcChannelBackoffResetHandler implements InstanceConfigChang
     // isChildChange: an instance ZK node was added or removed under /CONFIGS/PARTICIPANT.
     // Both require a full scan to rebuild _shuttingDownServers from the current cluster state.
     NotificationContext.Type type = context.getType();
+    if (type == NotificationContext.Type.FINALIZE) {
+      _shuttingDownServers.clear();
+      return;
+    }
     if (type == NotificationContext.Type.INIT || context.getIsChildChange()) {
       handleFullScan();
-    } else {
-      // An existing instance's config changed (e.g. IS_SHUTDOWN_IN_PROGRESS toggled).
-      // pathChanged is the ZK path of the specific instance that changed.
-      String pathChanged = context.getPathChanged();
-      String instanceName = pathChanged.substring(pathChanged.lastIndexOf('/') + 1);
-      handleSingleInstanceChange(instanceName);
+      return;
     }
+    // An existing instance's config changed (e.g. IS_SHUTDOWN_IN_PROGRESS toggled).
+    // pathChanged is the ZK path of the specific instance that changed.
+    String pathChanged = context.getPathChanged();
+    if (pathChanged == null || pathChanged.isEmpty()) {
+      LOGGER.debug("Instance config callback had no changed path; rebuilding shutdown state via full scan");
+      handleFullScan();
+      return;
+    }
+    String instanceName = pathChanged.substring(pathChanged.lastIndexOf('/') + 1);
+    handleSingleInstanceChange(instanceName);
   }
 
   /**

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/ServerGrpcChannelBackoffResetHandler.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/ServerGrpcChannelBackoffResetHandler.java
@@ -82,7 +82,8 @@ public class ServerGrpcChannelBackoffResetHandler implements InstanceConfigChang
     // Both require a full scan to rebuild _shuttingDownServers from the current cluster state.
     NotificationContext.Type type = context.getType();
     if (type == NotificationContext.Type.FINALIZE) {
-      _shuttingDownServers.clear();
+      // Helix also emits FINALIZE during session reset before the next INIT. Preserve tracked shutdown
+      // state so the next full scan can still detect a server that finished startup while we were reconnecting.
       return;
     }
     if (type == NotificationContext.Type.INIT || context.getIsChildChange()) {

--- a/pinot-server/src/test/java/org/apache/pinot/server/starter/helix/ServerGrpcChannelBackoffResetHandlerTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/starter/helix/ServerGrpcChannelBackoffResetHandlerTest.java
@@ -206,6 +206,37 @@ public class ServerGrpcChannelBackoffResetHandlerTest {
     verify(_mailboxService).resetConnectBackoff(OTHER_SERVER_HOST, OTHER_SERVER_MAILBOX_PORT);
   }
 
+  @Test
+  public void testFinalizeCallbackClearsTrackedStateWithoutTouchingMailboxService() {
+    when(_helixAdmin.getInstanceConfig(CLUSTER_NAME, OTHER_SERVER_ID))
+        .thenReturn(createServerConfig(OTHER_SERVER_ID, OTHER_SERVER_HOST, OTHER_SERVER_MAILBOX_PORT, true));
+    _handler.onInstanceConfigChange(Collections.emptyList(), createCallbackContextForInstance(OTHER_SERVER_ID));
+
+    _handler.onInstanceConfigChange(Collections.emptyList(), createFinalizeContext());
+
+    when(_helixAdmin.getInstanceConfig(CLUSTER_NAME, OTHER_SERVER_ID))
+        .thenReturn(createServerConfig(OTHER_SERVER_ID, OTHER_SERVER_HOST, OTHER_SERVER_MAILBOX_PORT, false));
+    _handler.onInstanceConfigChange(Collections.emptyList(), createCallbackContextForInstance(OTHER_SERVER_ID));
+
+    verify(_mailboxService, never()).resetConnectBackoff(any(), anyInt());
+  }
+
+  @Test
+  public void testNullPathCallbackFallsBackToFullScan() {
+    when(_helixAdmin.getInstanceConfig(CLUSTER_NAME, OTHER_SERVER_ID))
+        .thenReturn(createServerConfig(OTHER_SERVER_ID, OTHER_SERVER_HOST, OTHER_SERVER_MAILBOX_PORT, true));
+    _handler.onInstanceConfigChange(Collections.emptyList(), createCallbackContextForInstance(OTHER_SERVER_ID));
+
+    when(_helixAdmin.getInstancesInCluster(CLUSTER_NAME))
+        .thenReturn(Arrays.asList(SELF_INSTANCE_ID, OTHER_SERVER_ID));
+    when(_helixAdmin.getInstanceConfig(CLUSTER_NAME, OTHER_SERVER_ID))
+        .thenReturn(createServerConfig(OTHER_SERVER_ID, OTHER_SERVER_HOST, OTHER_SERVER_MAILBOX_PORT, false));
+
+    _handler.onInstanceConfigChange(Collections.emptyList(), createCallbackContextWithoutPath());
+
+    verify(_mailboxService).resetConnectBackoff(OTHER_SERVER_HOST, OTHER_SERVER_MAILBOX_PORT);
+  }
+
   private InstanceConfig createServerConfig(String instanceId, String hostname, int mailboxPort,
       boolean shutdownInProgress) {
     ZNRecord record = new ZNRecord(instanceId);
@@ -232,6 +263,18 @@ public class ServerGrpcChannelBackoffResetHandlerTest {
   private NotificationContext createInitContext() {
     NotificationContext context = new NotificationContext(_helixManager);
     context.setType(NotificationContext.Type.INIT);
+    return context;
+  }
+
+  private NotificationContext createFinalizeContext() {
+    NotificationContext context = new NotificationContext(_helixManager);
+    context.setType(NotificationContext.Type.FINALIZE);
+    return context;
+  }
+
+  private NotificationContext createCallbackContextWithoutPath() {
+    NotificationContext context = new NotificationContext(_helixManager);
+    context.setType(NotificationContext.Type.CALLBACK);
     return context;
   }
 }

--- a/pinot-server/src/test/java/org/apache/pinot/server/starter/helix/ServerGrpcChannelBackoffResetHandlerTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/starter/helix/ServerGrpcChannelBackoffResetHandlerTest.java
@@ -207,18 +207,20 @@ public class ServerGrpcChannelBackoffResetHandlerTest {
   }
 
   @Test
-  public void testFinalizeCallbackClearsTrackedStateWithoutTouchingMailboxService() {
+  public void testFinalizePreservesTrackedStateForReconnectInit() {
     when(_helixAdmin.getInstanceConfig(CLUSTER_NAME, OTHER_SERVER_ID))
         .thenReturn(createServerConfig(OTHER_SERVER_ID, OTHER_SERVER_HOST, OTHER_SERVER_MAILBOX_PORT, true));
     _handler.onInstanceConfigChange(Collections.emptyList(), createCallbackContextForInstance(OTHER_SERVER_ID));
 
     _handler.onInstanceConfigChange(Collections.emptyList(), createFinalizeContext());
 
+    when(_helixAdmin.getInstancesInCluster(CLUSTER_NAME))
+        .thenReturn(Arrays.asList(SELF_INSTANCE_ID, OTHER_SERVER_ID));
     when(_helixAdmin.getInstanceConfig(CLUSTER_NAME, OTHER_SERVER_ID))
         .thenReturn(createServerConfig(OTHER_SERVER_ID, OTHER_SERVER_HOST, OTHER_SERVER_MAILBOX_PORT, false));
-    _handler.onInstanceConfigChange(Collections.emptyList(), createCallbackContextForInstance(OTHER_SERVER_ID));
+    _handler.onInstanceConfigChange(Collections.emptyList(), createInitContext());
 
-    verify(_mailboxService, never()).resetConnectBackoff(any(), anyInt());
+    verify(_mailboxService).resetConnectBackoff(OTHER_SERVER_HOST, OTHER_SERVER_MAILBOX_PORT);
   }
 
   @Test


### PR DESCRIPTION
## Summary
- handle `NotificationContext.Type.FINALIZE` in `ServerGrpcChannelBackoffResetHandler`
- fall back to a full scan when Helix does not provide `pathChanged`
- keep `_shuttingDownServers` lifecycle-safe instead of assuming every non-init callback is a single-instance update

## Why
`ServerGrpcChannelBackoffResetHandler` currently assumes every non-`INIT` / non-child-change callback has a populated `pathChanged`, and it does not clear local state on `FINALIZE`. That is brittle against Helix callback lifecycle edges.

## Validation
- `./mvnw -pl pinot-server -am -Dtest=ServerGrpcChannelBackoffResetHandlerTest test -Dsurefire.failIfNoSpecifiedTests=false`