### PR TITLE
Fix parallel segment reload race on IndexLoadingConfig tier; reuse configs per tier and IndexLoadingConfig.copy()

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -622,7 +622,7 @@ public abstract class BaseTableDataManager implements TableDataManager {
     _logger.info("Reloading all segments with forceDownload: {}", forceDownload);
     List<SegmentDataManager> segmentDataManagers = new ArrayList<>(_segmentDataManagerMap.values());
     if (!segmentDataManagers.isEmpty()) {
-      reloadSegments(segmentDataManagers, forceDownload, reloadJobId);
+      reloadSegmentDataManagersInParallel(segmentDataManagers, forceDownload, reloadJobId);
     }
     _logger.info("Reloaded all {} segments with forceDownload: {}", segmentDataManagers.size(), forceDownload);
   }
@@ -645,7 +645,7 @@ public abstract class BaseTableDataManager implements TableDataManager {
       }
     }
     if (!segmentDataManagers.isEmpty()) {
-      reloadSegments(segmentDataManagers, forceDownload, reloadJobId);
+      reloadSegmentDataManagersInParallel(segmentDataManagers, forceDownload, reloadJobId);
     }
     if (missingSegments.isEmpty()) {
       _logger.info("Reloaded segments: {} with forceDownload: {}", segmentNames, forceDownload);
@@ -926,7 +926,8 @@ public abstract class BaseTableDataManager implements TableDataManager {
     }
   }
 
-  private void reloadSegments(List<SegmentDataManager> segmentDataManagers, boolean forceDownload, String reloadJobId)
+  private void reloadSegmentDataManagersInParallel(List<SegmentDataManager> segmentDataManagers, 
+      boolean forceDownload, String reloadJobId)
       throws Exception {
     IndexLoadingConfig indexLoadingConfigTemplate = fetchIndexLoadingConfig();
     List<String> failedSegments = new ArrayList<>();

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -28,6 +28,7 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -622,7 +623,7 @@ public abstract class BaseTableDataManager implements TableDataManager {
     _logger.info("Reloading all segments with forceDownload: {}", forceDownload);
     List<SegmentDataManager> segmentDataManagers = new ArrayList<>(_segmentDataManagerMap.values());
     if (!segmentDataManagers.isEmpty()) {
-      reloadSegmentDataManagersInParallel(segmentDataManagers, forceDownload, reloadJobId);
+      reloadSegmentDataManagers(segmentDataManagers, forceDownload, reloadJobId);
     }
     _logger.info("Reloaded all {} segments with forceDownload: {}", segmentDataManagers.size(), forceDownload);
   }
@@ -645,7 +646,7 @@ public abstract class BaseTableDataManager implements TableDataManager {
       }
     }
     if (!segmentDataManagers.isEmpty()) {
-      reloadSegmentDataManagersInParallel(segmentDataManagers, forceDownload, reloadJobId);
+      reloadSegmentDataManagers(segmentDataManagers, forceDownload, reloadJobId);
     }
     if (missingSegments.isEmpty()) {
       _logger.info("Reloaded segments: {} with forceDownload: {}", segmentNames, forceDownload);
@@ -926,10 +927,30 @@ public abstract class BaseTableDataManager implements TableDataManager {
     }
   }
 
-  private void reloadSegmentDataManagersInParallel(List<SegmentDataManager> segmentDataManagers,
+  /**
+   * Reloads the given segment data managers. Segments are reloaded in parallel.
+   * Immutable (offline) segment reload mutates {@link IndexLoadingConfig} (tier, etc.), so configs cannot be shared
+   * across concurrent tasks unless guarded. Table config is fetched once; one {@link IndexLoadingConfig} copy is kept
+   * per distinct current segment tier (typically a small set). Reloads for the same tier run serially on that shared
+   * config; different tiers reload in parallel. Realtime consuming segments only read table config from the template
+   * and do not mutate it, so they share the single fetched template safely.
+   */
+  private void reloadSegmentDataManagers(List<SegmentDataManager> segmentDataManagers,
       boolean forceDownload, String reloadJobId)
       throws Exception {
     IndexLoadingConfig indexLoadingConfigTemplate = fetchIndexLoadingConfig();
+    Set<String> offlineTierKeys = new HashSet<>();
+    for (SegmentDataManager sdm : segmentDataManagers) {
+      if (!(sdm instanceof RealtimeSegmentDataManager)) {
+        offlineTierKeys.add(tierKeyForParallelReload(getSegmentCurrentTier(sdm.getSegmentName())));
+      }
+    }
+    Map<String, IndexLoadingConfig> indexLoadingConfigByTierKey = new HashMap<>();
+    for (String tierKey : offlineTierKeys) {
+      IndexLoadingConfig cfg = indexLoadingConfigTemplate.copy();
+      cfg.setSegmentTier(StringUtils.isEmpty(tierKey) ? null : tierKey);
+      indexLoadingConfigByTierKey.put(tierKey, cfg);
+    }
     List<String> failedSegments = new ArrayList<>();
     AtomicReference<Throwable> sampleException = new AtomicReference<>();
     CompletableFuture.allOf(segmentDataManagers.stream().map(segmentDataManager -> CompletableFuture.runAsync(() -> {
@@ -937,7 +958,18 @@ public abstract class BaseTableDataManager implements TableDataManager {
       try {
         _segmentReloadSemaphore.acquire(segmentName, _logger);
         try {
-          reloadSegment(segmentDataManager, indexLoadingConfigTemplate.copy(), forceDownload);
+          if (segmentDataManager instanceof RealtimeSegmentDataManager) {
+            reloadSegment(segmentDataManager, indexLoadingConfigTemplate, forceDownload);
+          } else {
+            String tierKey = tierKeyForParallelReload(getSegmentCurrentTier(segmentName));
+            IndexLoadingConfig tierConfig =
+                Preconditions.checkNotNull(indexLoadingConfigByTierKey.get(tierKey),
+                    "Missing IndexLoadingConfig for tier key %s segment %s table %s", tierKey, segmentName,
+                    _tableNameWithType);
+            synchronized (tierConfig) {
+              reloadSegment(segmentDataManager, tierConfig, forceDownload);
+            }
+          }
         } finally {
           _segmentReloadSemaphore.release();
         }
@@ -1344,6 +1376,13 @@ public abstract class BaseTableDataManager implements TableDataManager {
       return ((ImmutableSegment) segment.getSegment()).getTier();
     }
     return null;
+  }
+
+  /**
+   * Stable non-null key for grouping parallel reload {@link IndexLoadingConfig} copies by current segment tier.
+   */
+  private static String tierKeyForParallelReload(@Nullable String segmentTier) {
+    return segmentTier == null ? "" : segmentTier;
   }
 
   @VisibleForTesting

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -926,7 +926,7 @@ public abstract class BaseTableDataManager implements TableDataManager {
     }
   }
 
-  private void reloadSegmentDataManagersInParallel(List<SegmentDataManager> segmentDataManagers, 
+  private void reloadSegmentDataManagersInParallel(List<SegmentDataManager> segmentDataManagers,
       boolean forceDownload, String reloadJobId)
       throws Exception {
     IndexLoadingConfig indexLoadingConfigTemplate = fetchIndexLoadingConfig();

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -622,7 +622,7 @@ public abstract class BaseTableDataManager implements TableDataManager {
     _logger.info("Reloading all segments with forceDownload: {}", forceDownload);
     List<SegmentDataManager> segmentDataManagers = new ArrayList<>(_segmentDataManagerMap.values());
     if (!segmentDataManagers.isEmpty()) {
-      reloadSegments(segmentDataManagers, fetchIndexLoadingConfig(), forceDownload, reloadJobId);
+      reloadSegments(segmentDataManagers, forceDownload, reloadJobId);
     }
     _logger.info("Reloaded all {} segments with forceDownload: {}", segmentDataManagers.size(), forceDownload);
   }
@@ -645,7 +645,7 @@ public abstract class BaseTableDataManager implements TableDataManager {
       }
     }
     if (!segmentDataManagers.isEmpty()) {
-      reloadSegments(segmentDataManagers, fetchIndexLoadingConfig(), forceDownload, reloadJobId);
+      reloadSegments(segmentDataManagers, forceDownload, reloadJobId);
     }
     if (missingSegments.isEmpty()) {
       _logger.info("Reloaded segments: {} with forceDownload: {}", segmentNames, forceDownload);
@@ -926,9 +926,9 @@ public abstract class BaseTableDataManager implements TableDataManager {
     }
   }
 
-  private void reloadSegments(List<SegmentDataManager> segmentDataManagers, IndexLoadingConfig indexLoadingConfig,
-      boolean forceDownload, String reloadJobId)
+  private void reloadSegments(List<SegmentDataManager> segmentDataManagers, boolean forceDownload, String reloadJobId)
       throws Exception {
+    IndexLoadingConfig indexLoadingConfigTemplate = fetchIndexLoadingConfig();
     List<String> failedSegments = new ArrayList<>();
     AtomicReference<Throwable> sampleException = new AtomicReference<>();
     CompletableFuture.allOf(segmentDataManagers.stream().map(segmentDataManager -> CompletableFuture.runAsync(() -> {
@@ -936,7 +936,7 @@ public abstract class BaseTableDataManager implements TableDataManager {
       try {
         _segmentReloadSemaphore.acquire(segmentName, _logger);
         try {
-          reloadSegment(segmentDataManager, indexLoadingConfig, forceDownload);
+          reloadSegment(segmentDataManager, indexLoadingConfigTemplate.copy(), forceDownload);
         } finally {
           _segmentReloadSemaphore.release();
         }

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.data.manager;
 
+import com.google.common.base.Preconditions;
 import java.io.DataInputStream;
 import java.io.File;
 import java.io.FileInputStream;
@@ -32,7 +33,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
-import com.google.common.base.Preconditions;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.helix.HelixManager;

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerTest.java
@@ -24,13 +24,16 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.helix.HelixManager;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.metrics.ServerMetrics;
@@ -41,6 +44,7 @@ import org.apache.pinot.common.utils.fetcher.SegmentFetcherFactory;
 import org.apache.pinot.core.data.manager.offline.ImmutableSegmentDataManager;
 import org.apache.pinot.core.data.manager.offline.OfflineTableDataManager;
 import org.apache.pinot.segment.local.data.manager.SegmentDataManager;
+import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
 import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
@@ -90,6 +94,7 @@ public class BaseTableDataManagerTest {
   private static final String OFFLINE_TABLE_NAME = TableNameBuilder.OFFLINE.tableNameWithType(RAW_TABLE_NAME);
   private static final File TABLE_DATA_DIR = new File(TEMP_DIR, OFFLINE_TABLE_NAME);
   private static final String SEGMENT_NAME = "testSegment";
+  private static final String SEGMENT_NAME_2 = "testSegment2";
   private static final String TIER_SEGMENT_DIRECTORY_LOADER = "tierBased";
   private static final String TIER_NAME = "coolTier";
   private static final String STRING_COLUMN = "col1";
@@ -869,6 +874,68 @@ public class BaseTableDataManagerTest {
     assertEquals(new SegmentMetadataImpl(dataDir).getTotalDocs(), 5);
   }
 
+    @Test
+  public void testReloadAllSegmentsInvokesParallelReload()
+      throws Exception {
+    OfflineTableDataManagerForParallelReloadTest mgr = createParallelReloadTestTableManager();
+    try {
+      File indexDir = createSegment(SegmentVersion.v3, 5);
+      registerOfflineSegment(mgr, SEGMENT_NAME, indexDir);
+      mgr.reloadAllSegments(false);
+      assertEquals(mgr.getNumSegments(), 1);
+      assertEquals(new SegmentMetadataImpl(indexDir).getTotalDocs(), 5);
+    } finally {
+      mgr.shutDown();
+    }
+  }
+
+  @Test
+  public void testReloadSegmentsByNameInvokesParallelReload()
+      throws Exception {
+    OfflineTableDataManagerForParallelReloadTest mgr = createParallelReloadTestTableManager();
+    try {
+      File indexDir = createSegment(SegmentVersion.v3, 5);
+      registerOfflineSegment(mgr, SEGMENT_NAME, indexDir);
+      mgr.reloadSegments(List.of(SEGMENT_NAME), false);
+      assertEquals(mgr.getNumSegments(), 1);
+      assertEquals(new SegmentMetadataImpl(indexDir).getTotalDocs(), 5);
+    } finally {
+      mgr.shutDown();
+    }
+  }
+
+  @Test
+  public void testReloadSegmentsWithMissingNamesCoversWarnBranch()
+      throws Exception {
+    OfflineTableDataManagerForParallelReloadTest mgr = createParallelReloadTestTableManager();
+    try {
+      File indexDir = createSegment(SegmentVersion.v3, 5);
+      registerOfflineSegment(mgr, SEGMENT_NAME, indexDir);
+      mgr.reloadSegments(Arrays.asList(SEGMENT_NAME, "missingSegment"), false);
+      assertEquals(mgr.getNumSegments(), 1);
+    } finally {
+      mgr.shutDown();
+    }
+  }
+
+  @Test
+  public void testReloadAllSegmentsParallelWithTwoSegments()
+      throws Exception {
+    OfflineTableDataManagerForParallelReloadTest mgr = createParallelReloadTestTableManager();
+    try {
+      File indexDir1 = createSegment(SEGMENT_NAME, SegmentVersion.v3, 5);
+      File indexDir2 = createSegment(SEGMENT_NAME_2, SegmentVersion.v3, 5);
+      registerOfflineSegment(mgr, SEGMENT_NAME, indexDir1);
+      registerOfflineSegment(mgr, SEGMENT_NAME_2, indexDir2);
+      mgr.reloadAllSegments(false);
+      assertEquals(mgr.getNumSegments(), 2);
+      assertEquals(new SegmentMetadataImpl(indexDir1).getTotalDocs(), 5);
+      assertEquals(new SegmentMetadataImpl(indexDir2).getTotalDocs(), 5);
+    } finally {
+      mgr.shutDown();
+    }
+  }
+
   // Has to be public class for the class loader to work.
   public static class FakePinotCrypter implements PinotCrypter {
     private File _origFile;
@@ -925,9 +992,14 @@ public class BaseTableDataManagerTest {
 
   private static File createSegment(SegmentVersion segmentVersion, int numRows)
       throws Exception {
+    return createSegment(SEGMENT_NAME, segmentVersion, numRows);
+  }
+
+  private static File createSegment(String segmentName, SegmentVersion segmentVersion, int numRows)
+      throws Exception {
     SegmentGeneratorConfig config = new SegmentGeneratorConfig(DEFAULT_TABLE_CONFIG, SCHEMA);
     config.setOutDir(TABLE_DATA_DIR.getAbsolutePath());
-    config.setSegmentName(SEGMENT_NAME);
+    config.setSegmentName(segmentName);
     config.setSegmentVersion(segmentVersion);
     List<GenericRow> rows = new ArrayList<>(3);
     for (int i = 0; i < numRows; i++) {
@@ -939,7 +1011,7 @@ public class BaseTableDataManagerTest {
     SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
     driver.init(config, new GenericRowRecordReader(rows));
     driver.build();
-    return new File(TABLE_DATA_DIR, SEGMENT_NAME);
+    return new File(TABLE_DATA_DIR, segmentName);
   }
 
   private static SegmentZKMetadata createRawSegment(SegmentVersion segmentVersion, int numRows)
@@ -997,5 +1069,51 @@ public class BaseTableDataManagerTest {
     File indexMapFile =
         new File(new File(indexDir, SegmentDirectoryPaths.V3_SUBDIRECTORY_NAME), V1Constants.INDEX_MAP_FILE_NAME);
     return FileUtils.readFileToString(indexMapFile, StandardCharsets.UTF_8).contains(columnName + ".inverted_index");
+  }
+
+  private static final class OfflineTableDataManagerForParallelReloadTest extends OfflineTableDataManager {
+    private final Map<String, SegmentZKMetadata> _segmentZkMetadata = new ConcurrentHashMap<>();
+
+    void putZKMetadata(String segmentName, SegmentZKMetadata zkMetadata) {
+      _segmentZkMetadata.put(segmentName, zkMetadata);
+    }
+
+    @Override
+    public SegmentZKMetadata fetchZKMetadata(String segmentName) {
+      SegmentZKMetadata zkMetadata = _segmentZkMetadata.get(segmentName);
+      Preconditions.checkState(zkMetadata != null, "No ZK metadata for segment: %s", segmentName);
+      return zkMetadata;
+    }
+
+    @Override
+    public IndexLoadingConfig fetchIndexLoadingConfig() {
+      Pair<TableConfig, Schema> cached = getCachedTableConfigAndSchema();
+      IndexLoadingConfig indexLoadingConfig =
+          new IndexLoadingConfig(_instanceDataManagerConfig, cached.getLeft(), cached.getRight());
+      indexLoadingConfig.setTableDataDir(getTableDataDir().getAbsolutePath());
+      return indexLoadingConfig;
+    }
+  }
+  
+  private static OfflineTableDataManagerForParallelReloadTest createParallelReloadTestTableManager() {
+    OfflineTableDataManagerForParallelReloadTest tableDataManager = new OfflineTableDataManagerForParallelReloadTest();
+    tableDataManager.init(createDefaultInstanceDataManagerConfig(), mock(HelixManager.class), new SegmentLocks(),
+        DEFAULT_TABLE_CONFIG, SCHEMA, new SegmentReloadSemaphore(1), Executors.newFixedThreadPool(2), null, null,
+        SEGMENT_OPERATIONS_THROTTLER);
+    return tableDataManager;
+  }
+
+  private static void registerOfflineSegment(OfflineTableDataManagerForParallelReloadTest tableDataManager,
+      String segmentName, File indexDir)
+      throws Exception {
+    long crc = getCRC(indexDir);
+    SegmentZKMetadata zkMetadata = new SegmentZKMetadata(segmentName);
+    zkMetadata.setCrc(crc);
+    tableDataManager.putZKMetadata(segmentName, zkMetadata);
+    IndexLoadingConfig loadConfig = new IndexLoadingConfig(DEFAULT_TABLE_CONFIG, SCHEMA);
+    loadConfig.setTableDataDir(tableDataManager.getTableDataDir().getAbsolutePath());
+    ImmutableSegment immutableSegment =
+        ImmutableSegmentLoader.load(indexDir, loadConfig, SEGMENT_OPERATIONS_THROTTLER);
+    tableDataManager.addSegment(immutableSegment, zkMetadata);
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerTest.java
@@ -32,6 +32,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
+import com.google.common.base.Preconditions;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.helix.HelixManager;
@@ -881,7 +882,7 @@ public class BaseTableDataManagerTest {
     try {
       File indexDir = createSegment(SegmentVersion.v3, 5);
       registerOfflineSegment(mgr, SEGMENT_NAME, indexDir);
-      mgr.reloadAllSegments(false);
+      mgr.reloadAllSegments(false, null);
       assertEquals(mgr.getNumSegments(), 1);
       assertEquals(new SegmentMetadataImpl(indexDir).getTotalDocs(), 5);
     } finally {
@@ -896,7 +897,7 @@ public class BaseTableDataManagerTest {
     try {
       File indexDir = createSegment(SegmentVersion.v3, 5);
       registerOfflineSegment(mgr, SEGMENT_NAME, indexDir);
-      mgr.reloadSegments(List.of(SEGMENT_NAME), false);
+      mgr.reloadSegments(List.of(SEGMENT_NAME), false, null);
       assertEquals(mgr.getNumSegments(), 1);
       assertEquals(new SegmentMetadataImpl(indexDir).getTotalDocs(), 5);
     } finally {
@@ -911,7 +912,7 @@ public class BaseTableDataManagerTest {
     try {
       File indexDir = createSegment(SegmentVersion.v3, 5);
       registerOfflineSegment(mgr, SEGMENT_NAME, indexDir);
-      mgr.reloadSegments(Arrays.asList(SEGMENT_NAME, "missingSegment"), false);
+      mgr.reloadSegments(Arrays.asList(SEGMENT_NAME, "missingSegment"), false, null);
       assertEquals(mgr.getNumSegments(), 1);
     } finally {
       mgr.shutDown();
@@ -927,7 +928,7 @@ public class BaseTableDataManagerTest {
       File indexDir2 = createSegment(SEGMENT_NAME_2, SegmentVersion.v3, 5);
       registerOfflineSegment(mgr, SEGMENT_NAME, indexDir1);
       registerOfflineSegment(mgr, SEGMENT_NAME_2, indexDir2);
-      mgr.reloadAllSegments(false);
+      mgr.reloadAllSegments(false, null);
       assertEquals(mgr.getNumSegments(), 2);
       assertEquals(new SegmentMetadataImpl(indexDir1).getTotalDocs(), 5);
       assertEquals(new SegmentMetadataImpl(indexDir2).getTotalDocs(), 5);
@@ -1099,7 +1100,7 @@ public class BaseTableDataManagerTest {
     OfflineTableDataManagerForParallelReloadTest tableDataManager = new OfflineTableDataManagerForParallelReloadTest();
     tableDataManager.init(createDefaultInstanceDataManagerConfig(), mock(HelixManager.class), new SegmentLocks(),
         DEFAULT_TABLE_CONFIG, SCHEMA, new SegmentReloadSemaphore(1), Executors.newFixedThreadPool(2), null, null,
-        SEGMENT_OPERATIONS_THROTTLER);
+        SEGMENT_OPERATIONS_THROTTLER, false, null);
     return tableDataManager;
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerTest.java
@@ -874,7 +874,7 @@ public class BaseTableDataManagerTest {
     assertEquals(new SegmentMetadataImpl(dataDir).getTotalDocs(), 5);
   }
 
-    @Test
+  @Test
   public void testReloadAllSegmentsInvokesParallelReload()
       throws Exception {
     OfflineTableDataManagerForParallelReloadTest mgr = createParallelReloadTestTableManager();

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerTest.java
@@ -1100,7 +1100,7 @@ public class BaseTableDataManagerTest {
     OfflineTableDataManagerForParallelReloadTest tableDataManager = new OfflineTableDataManagerForParallelReloadTest();
     tableDataManager.init(createDefaultInstanceDataManagerConfig(), mock(HelixManager.class), new SegmentLocks(),
         DEFAULT_TABLE_CONFIG, SCHEMA, new SegmentReloadSemaphore(1), Executors.newFixedThreadPool(2), null, null,
-        SEGMENT_OPERATIONS_THROTTLER, false, null);
+        SEGMENT_OPERATIONS_THROTTLER, false, mock(ServerReloadJobStatusCache.class));
     return tableDataManager;
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerTest.java
@@ -1094,7 +1094,7 @@ public class BaseTableDataManagerTest {
       return indexLoadingConfig;
     }
   }
-  
+
   private static OfflineTableDataManagerForParallelReloadTest createParallelReloadTestTableManager() {
     OfflineTableDataManagerForParallelReloadTest tableDataManager = new OfflineTableDataManagerForParallelReloadTest();
     tableDataManager.init(createDefaultInstanceDataManagerConfig(), mock(HelixManager.class), new SegmentLocks(),

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfig.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfig.java
@@ -119,6 +119,12 @@ public class IndexLoadingConfig {
     this(null, null, null);
   }
 
+  public IndexLoadingConfig copy() {
+    IndexLoadingConfig copy = new IndexLoadingConfig(_instanceDataManagerConfig, _tableConfig, _schema);
+    copy.setTableDataDir(_tableDataDir);
+    return copy;
+  }
+
   @Nullable
   public InstanceDataManagerConfig getInstanceDataManagerConfig() {
     return _instanceDataManagerConfig;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfig.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfig.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.segment.local.segment.index.loader;
 
 import com.google.common.annotations.VisibleForTesting;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -119,10 +120,35 @@ public class IndexLoadingConfig {
     this(null, null, null);
   }
 
+  /**
+   * Returns a new instance with the same table/schema/instance references and a full snapshot of all mutable state.
+   * Used when parallel work needs isolated configs without re-fetching ZK-backed table config.
+   */
   public IndexLoadingConfig copy() {
-    IndexLoadingConfig copy = new IndexLoadingConfig(_instanceDataManagerConfig, _tableConfig, _schema);
-    copy.setTableDataDir(_tableDataDir);
-    return copy;
+    IndexLoadingConfig c = new IndexLoadingConfig(_instanceDataManagerConfig, _tableConfig, _schema);
+    c._readMode = _readMode;
+    c._segmentVersion = _segmentVersion;
+    c._segmentTier = _segmentTier;
+    c._knownColumns = _knownColumns == null ? null : new HashSet<>(_knownColumns);
+    c._tableDataDir = _tableDataDir;
+    c._errorOnColumnBuildFailure = _errorOnColumnBuildFailure;
+    c._instanceId = _instanceId;
+    c._isRealtimeOffHeapAllocation = _isRealtimeOffHeapAllocation;
+    c._isDirectRealtimeOffHeapAllocation = _isDirectRealtimeOffHeapAllocation;
+    c._realtimeAvgMultiValueCount = _realtimeAvgMultiValueCount;
+    c._segmentStoreURI = _segmentStoreURI;
+    c._segmentDirectoryLoader = _segmentDirectoryLoader;
+    c._instanceTierConfigs = _instanceTierConfigs;
+    c._sortedColumns = _sortedColumns.isEmpty() ? Collections.emptyList() : new ArrayList<>(_sortedColumns);
+    c._columnMinMaxValueGeneratorMode = _columnMinMaxValueGeneratorMode;
+    c._enableDynamicStarTreeCreation = _enableDynamicStarTreeCreation;
+    c._starTreeIndexConfigs = _starTreeIndexConfigs == null ? null : new ArrayList<>(_starTreeIndexConfigs);
+    c._enableDefaultStarTree = _enableDefaultStarTree;
+    c._indexConfigsByColName =
+        _indexConfigsByColName == null ? new HashMap<>() : new HashMap<>(_indexConfigsByColName);
+    c._dirty = _dirty;
+    c._multiColTextIndexConfig = _multiColTextIndexConfig;
+    return c;
   }
 
   @Nullable

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfigTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfigTest.java
@@ -266,7 +266,7 @@ public class IndexLoadingConfigTest {
     assertSame(copy.getSchema(), base.getSchema());
     assertEquals(copy.getTableDataDir(), base.getTableDataDir());
     assertEquals(copy.getReadMode(), base.getReadMode());
-    assertNull(copy.getSegmentTier());
+    assertEquals(copy.getSegmentTier(), base.getSegmentTier());
 
     copy.setSegmentTier("cold");
     assertEquals(base.getSegmentTier(), "hot");

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfigTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfigTest.java
@@ -36,6 +36,7 @@ import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.JsonUtils;
+import org.apache.pinot.spi.utils.ReadMode;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.annotations.Test;
 
@@ -248,7 +249,7 @@ public class IndexLoadingConfigTest {
   }
 
   @Test
-  public void testCopySharesTableConfigAndIndependentSegmentTier() {
+  public void testCopyPreservesMutableStateAndIndependentTier() {
     InstanceDataManagerConfig idmCfg = mock(InstanceDataManagerConfig.class);
     when(idmCfg.getConfig()).thenReturn(new PinotConfiguration());
     Schema schema =
@@ -258,11 +259,13 @@ public class IndexLoadingConfigTest {
     IndexLoadingConfig base = new IndexLoadingConfig(idmCfg, tableConfig, schema);
     base.setTableDataDir("/tmp/table");
     base.setSegmentTier("hot");
+    base.setReadMode(ReadMode.MMAP);
 
     IndexLoadingConfig copy = base.copy();
     assertSame(copy.getTableConfig(), base.getTableConfig());
     assertSame(copy.getSchema(), base.getSchema());
     assertEquals(copy.getTableDataDir(), base.getTableDataDir());
+    assertEquals(copy.getReadMode(), base.getReadMode());
     assertNull(copy.getSegmentTier());
 
     copy.setSegmentTier("cold");

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfigTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfigTest.java
@@ -259,7 +259,7 @@ public class IndexLoadingConfigTest {
     IndexLoadingConfig base = new IndexLoadingConfig(idmCfg, tableConfig, schema);
     base.setTableDataDir("/tmp/table");
     base.setSegmentTier("hot");
-    base.setReadMode(ReadMode.MMAP);
+    base.setReadMode(ReadMode.mmap);
 
     IndexLoadingConfig copy = base.copy();
     assertSame(copy.getTableConfig(), base.getTableConfig());

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfigTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfigTest.java
@@ -246,4 +246,27 @@ public class IndexLoadingConfigTest {
     assertEquals(forwardIndexConfig.getTargetMaxChunkSize(), ForwardIndexConfig.getDefaultTargetMaxChunkSize());
     assertEquals(forwardIndexConfig.getTargetDocsPerChunk(), ForwardIndexConfig.getDefaultTargetDocsPerChunk());
   }
+
+  @Test
+  public void testCopySharesTableConfigAndIndependentSegmentTier() {
+    InstanceDataManagerConfig idmCfg = mock(InstanceDataManagerConfig.class);
+    when(idmCfg.getConfig()).thenReturn(new PinotConfiguration());
+    Schema schema =
+        new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension("col1", FieldSpec.DataType.INT)
+            .build();
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).build();
+    IndexLoadingConfig base = new IndexLoadingConfig(idmCfg, tableConfig, schema);
+    base.setTableDataDir("/tmp/table");
+    base.setSegmentTier("hot");
+
+    IndexLoadingConfig copy = base.copy();
+    assertSame(copy.getTableConfig(), base.getTableConfig());
+    assertSame(copy.getSchema(), base.getSchema());
+    assertEquals(copy.getTableDataDir(), base.getTableDataDir());
+    assertNull(copy.getSegmentTier());
+
+    copy.setSegmentTier("cold");
+    assertEquals(base.getSegmentTier(), "hot");
+    assertEquals(copy.getSegmentTier(), "cold");
+  }
 }


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Parallel segment reload uses tier\-specific IndexLoadingConfig copies for offline segments \(with locking\) and the template for realtime segments, preventing race conditions\.

```mermaid
flowchart TD
  N0["Fetch indexLoadingConfig template #40;F1#41;"]:::stAdded
  N1["Build tier#45;keyed config map #40;copies of template with tier set#41; #40;F1#44; F2#41;"]:::stAdded
  N2["Check segment type #40;realtime or offline#41; #40;F1#41;"]:::stAdded
  N3["Realtime#58; reload segment with template #40;no lock#41; #40;F1#41;"]:::stAdded
  N4["Offline#58; get tier config from map #40;F1#41;"]:::stAdded
  N5["Offline#58; sync on config and reload segment #40;F1#41;"]:::stAdded
  N0 --> N1
  N1 --> N2
  N2 --> N3
  N2 --> N4
  N4 --> N5
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager\.java — [before](https://github.com/apache/pinot/blob/7e10a36af617134827631980e3701ffa18a39b14/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java) · [after](https://github.com/apache/pinot/blob/3f6b8953e876fda19a1b594ed79481c7613d7d23/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java)
- F2: pinot\-segment\-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfig\.java — [before](https://github.com/apache/pinot/blob/7e10a36af617134827631980e3701ffa18a39b14/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfig.java) · [after](https://github.com/apache/pinot/blob/3f6b8953e876fda19a1b594ed79481c7613d7d23/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfig.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjdlMTBhMzZhZjYxNzEzNDgyNzYzMTk4MGUzNzAxZmZhMThhMzliMTQiLCJjb250ZXh0X2hhc2giOiJmZjFiYmRmMzRkMDI4MTYzZWEzMTY5NDc2MDI2ZjRhY2JhNzBkMTBhZGZkMGM5Yjg3M2Y4NTlhNGMzY2EwOTQyIiwiZ2VuZXJhdGVkX2F0IjoxNzg5MDA2MjMzLCJoZWFkX3NoYSI6IjNmNmI4OTUzZTg3NmZkYTE5YTFiNTk0ZWQ3OTQ4MWM3NjEzZDdkMjMiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiI3ZTEwYTM2YWY2MTcxMzQ4Mjc2MzE5ODBlMzcwMWZmYTE4YTM5YjE0IiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 0c79fa6799a954b8c67b6bde4a92b09b8b23bba5d56cd818e60047d8c6b04a8d -->
<!-- pinot-pr-flow:end -->

### Problem
When multiple segments were reloaded in parallel (reloadAllSegments / batched reloadSegments), all tasks shared a single `IndexLoadingConfig` from one `fetchIndexLoadingConfig()` call. Each reload path calls `setSegmentTier(...)` (and related updates) on that shared instance, so concurrent tasks could overwrite each other’s tier. With tier overrides in table config, that could apply the wrong preprocessing / loading settings (#18164).

### Fix
- `BaseTableDataManager.reloadSegmentDataManagers` (private helper used by parallel reload): Calls `fetchIndexLoadingConfig()` once per batch. For immutable segments, builds a `Map<tierKey, IndexLoadingConfig>` with one `IndexLoadingConfig` per distinct current segment tier (from `getSegmentCurrentTier`), using `template.copy()` plus the tier key. Offline reloads for the same tier use the same config under `synchronized (tierConfig)` so mutations stay correct without one config per segment. Reloads for different tiers can still run in parallel.
- Realtime consuming paths only read `TableConfig` from the template and do not mutate tier, so they reuse the single fetched template without that lock.
- `IndexLoadingConfig.copy()`: Returns a new instance with the same instance / table / schema references and a full snapshot of all mutable fields (including _readMode, _segmentTier, index-config caches, _dirty, etc.), so “copy” matches real semantics and supports the tier-keyed path without N ZK reads.

### Tests
`IndexLoadingConfigTest.testCopyPreservesMutableStateAndIndependentTier`: Asserts shared TableConfig / Schema, matching tableDataDir / readMode / initial tier, and that tier changes on the copy do not affect the original.



Fixes #18164