### PR TITLE
fix: add IVF_ON_DISK case to VectorIndexUtils.getIndexFileExtension()

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/VectorIndexUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/VectorIndexUtils.java
@@ -98,6 +98,9 @@ public class VectorIndexUtils {
         return Indexes.VECTOR_IVF_FLAT_INDEX_FILE_EXTENSION;
       case IVF_PQ:
         return Indexes.VECTOR_IVF_PQ_INDEX_FILE_EXTENSION;
+      case IVF_ON_DISK:
+        // IVF_ON_DISK reuses the IVF_FLAT file format with FileChannel random-access reads
+        return Indexes.VECTOR_IVF_FLAT_INDEX_FILE_EXTENSION;
       default:
         throw new IllegalStateException("Unsupported vector backend type: " + backendType);
     }


### PR DESCRIPTION
## Summary

- `VectorIndexUtils.getIndexFileExtension()` had a `switch` over `VectorBackendType` with cases for `HNSW`, `IVF_FLAT`, and `IVF_PQ`, but fell through to `default` for `IVF_ON_DISK`, throwing `IllegalStateException: Unsupported vector backend type: IVF_ON_DISK`
- This caused all IVF_ON_DISK segments to enter **ERROR** state on the server and be unavailable for queries
- Fix adds `case IVF_ON_DISK:` returning `VECTOR_IVF_FLAT_INDEX_FILE_EXTENSION`, consistent with `SegmentDirectoryPaths.findVectorIndexIndexFile()` which already handles IVF_ON_DISK correctly (IVF_ON_DISK reuses the IVF_FLAT binary format at build time and uses FileChannel random-access reads at query time)

## Test plan

- [x] Verified IVF_ON_DISK segments now load successfully after this fix
- [x] Ran VectorDBBench end-to-end with IVF_ON_DISK index: 100% recall, ~692 QPS on 10K×128D L2 dataset
- [ ] Existing unit/integration tests for vector index loading

🤖 Generated with [Claude Code](https://claude.com/claude-code)