### PR TITLE
Upgrade 1.5 rc0 fix npe

### DIFF
--- a/docker/images/pinot/docker-build.sh
+++ b/docker/images/pinot/docker-build.sh
@@ -39,7 +39,7 @@ if [[ "$#" -gt 2 ]]
 then
   PINOT_GIT_URL=$3
 else
-  PINOT_GIT_URL="https://github.com/apache/pinot.git"
+  PINOT_GIT_URL="https://github.com/reelevant-tech/pinot.git"
 fi
 
 if [[ "$#" -gt 3 ]]
@@ -53,9 +53,9 @@ if [[ "$#" -gt 4 ]]
 then
   JAVA_VERSION=$5
 else
-  JAVA_VERSION=11
+  JAVA_VERSION=21
 fi
 
 echo "Trying to build Pinot docker image from Git URL: [ ${PINOT_GIT_URL} ] on branch: [ ${PINOT_BRANCH} ] and tag it as: [ ${DOCKER_TAG} ]. Kafka Dependencies: [ ${KAFKA_VERSION} ]. Java Version: [ ${JAVA_VERSION} ]."
 
-docker build --no-cache -t ${DOCKER_TAG} --build-arg PINOT_BRANCH=${PINOT_BRANCH} --build-arg PINOT_GIT_URL=${PINOT_GIT_URL} --build-arg KAFKA_VERSION=${KAFKA_VERSION} --build-arg JAVA_VERSION=${JAVA_VERSION} -f Dockerfile .
+docker build --progress=plain --platform linux/amd64 --no-cache -t ${DOCKER_TAG} --build-arg PINOT_BRANCH=${PINOT_BRANCH} --build-arg PINOT_GIT_URL=${PINOT_GIT_URL} --build-arg KAFKA_VERSION=${KAFKA_VERSION} --build-arg JAVA_VERSION=${JAVA_VERSION} -f Dockerfile .

--- a/docker/images/pinot/docker-build.sh
+++ b/docker/images/pinot/docker-build.sh
@@ -58,4 +58,4 @@ fi
 
 echo "Trying to build Pinot docker image from Git URL: [ ${PINOT_GIT_URL} ] on branch: [ ${PINOT_BRANCH} ] and tag it as: [ ${DOCKER_TAG} ]. Kafka Dependencies: [ ${KAFKA_VERSION} ]. Java Version: [ ${JAVA_VERSION} ]."
 
-docker build --progress=plain --platform linux/amd64 --no-cache -t ${DOCKER_TAG} --build-arg PINOT_BRANCH=${PINOT_BRANCH} --build-arg PINOT_GIT_URL=${PINOT_GIT_URL} --build-arg KAFKA_VERSION=${KAFKA_VERSION} --build-arg JAVA_VERSION=${JAVA_VERSION} -f Dockerfile .
+docker buildx build --progress=plain --platform linux/amd64 --no-cache -t ${DOCKER_TAG} --build-arg PINOT_BRANCH=${PINOT_BRANCH} --build-arg PINOT_GIT_URL=${PINOT_GIT_URL} --build-arg KAFKA_VERSION=${KAFKA_VERSION} --build-arg JAVA_VERSION=${JAVA_VERSION} --push -f Dockerfile  .

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/HelixHelper.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/HelixHelper.java
@@ -280,6 +280,10 @@ public class HelixHelper {
     Function<IdealState, IdealState> updater = new Function<IdealState, IdealState>() {
       @Override
       public IdealState apply(IdealState idealState) {
+        if (idealState == null) {
+          LOGGER.warn("Broker IdealState is null, skipping removal of resource: {}", resourceTag);
+          return null;
+        }
         if (idealState.getPartitionSet().contains(resourceTag)) {
           idealState.getPartitionSet().remove(resourceTag);
           return idealState;

--- a/pinot-controller/src/main/resources/app/components/Table.tsx
+++ b/pinot-controller/src/main/resources/app/components/Table.tsx
@@ -76,7 +76,8 @@ type Props = {
     toggleValue: boolean;
   },
   tooltipData?: string[],
-  additionalControls?: React.ReactNode
+  additionalControls?: React.ReactNode,
+  onRowsRendered?: (rows: any[]) => void
 };
 
 // These sort functions are applied to any columns with these names. Otherwise, we just
@@ -313,7 +314,8 @@ export default function CustomizedTables({
   regexReplace,
   accordionToggleObject,
   tooltipData,
-  additionalControls
+  additionalControls,
+  onRowsRendered
 }: Props) {
   // Separate the initial and final data into two separated state variables.
   // This way we can filter and sort the data without affecting the original data.
@@ -340,6 +342,16 @@ export default function CustomizedTables({
   const classes = useStyles();
   const [rowsPerPage, setRowsPerPage] = React.useState(defaultRowsPerPage || 10);
   const [page, setPage] = React.useState(0);
+  // compute which table are on screen
+  const currentlyRenderedRows = React.useMemo(() => {
+    return finalData.slice(page * rowsPerPage, page * rowsPerPage + rowsPerPage)
+  }, [finalData, page, rowsPerPage])
+
+  React.useEffect(() => {
+    if (typeof onRowsRendered === 'function' && page > 0) {
+      onRowsRendered(currentlyRenderedRows)
+    }
+  }, [page, rowsPerPage])
 
   const handleChangeRowsPerPage = (
     event: React.ChangeEvent<HTMLInputElement>

--- a/pinot-controller/src/main/resources/app/pages/TablesListingPage.tsx
+++ b/pinot-controller/src/main/resources/app/pages/TablesListingPage.tsx
@@ -98,8 +98,6 @@ const TablesListingPage = () => {
         title="Tables"
         baseUrl="/tenants/table/"
       />
-      <AsyncLogicalTables />
-      <AsyncPinotSchemas key={`schema-${schemasKey}`} />
       {showSchemaModal && (
         <AddSchemaOp
           hideModal={() => {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/executor/SingleTableExecutionInfo.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/executor/SingleTableExecutionInfo.java
@@ -20,6 +20,7 @@ package org.apache.pinot.core.query.executor;
 
 import com.google.common.base.Preconditions;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -185,7 +186,7 @@ public class SingleTableExecutionInfo implements TableExecutionInfo {
 
   @Override
   public List<String> getOptionalSegments() {
-    return _optionalSegments;
+    return _optionalSegments != null ? _optionalSegments : Collections.emptyList();
   }
 
   @Override

--- a/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3Config.java
+++ b/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3Config.java
@@ -88,7 +88,7 @@ public class S3Config {
   public static final String RESPONSE_CHECKSUM_VALIDATION = "responseChecksumValidation";
   public static final String USE_LEGACY_MD5_PLUGIN = "useLegacyMd5Plugin";
   public static final String DISABLE_MULTIPART_UPLOAD = "disableMultipartUpload";
-  private static final boolean DEFAULT_DISABLE_MULTIPART_UPLOAD = false;
+  private static final boolean DEFAULT_DISABLE_MULTIPART_UPLOAD = true;
 
 
   private final String _accessKey;

--- a/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3Config.java
+++ b/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3Config.java
@@ -87,6 +87,8 @@ public class S3Config {
   public static final String REQUEST_CHECKSUM_CALCULATION = "requestChecksumCalculation";
   public static final String RESPONSE_CHECKSUM_VALIDATION = "responseChecksumValidation";
   public static final String USE_LEGACY_MD5_PLUGIN = "useLegacyMd5Plugin";
+  public static final String DISABLE_MULTIPART_UPLOAD = "disableMultipartUpload";
+  private static final boolean DEFAULT_DISABLE_MULTIPART_UPLOAD = false;
 
 
   private final String _accessKey;
@@ -114,6 +116,7 @@ public class S3Config {
   private final RequestChecksumCalculation _requestChecksumCalculationWhenRequired;
   private final ResponseChecksumValidation _responseChecksumValidationWhenRequired;
   private final boolean _useLegacyMd5Plugin;
+  private final boolean _disableMultipartUpload;
 
   public S3Config(PinotConfiguration pinotConfig) {
     _disableAcl = pinotConfig.getProperty(DISABLE_ACL_CONFIG_KEY, DEFAULT_DISABLE_ACL);
@@ -132,6 +135,8 @@ public class S3Config {
       throw new IllegalStateException(String.format("S3 config '%s=true' is not allowed when '%s=true'",
           USE_LEGACY_MD5_PLUGIN, CommonConstants.CONFIG_OF_PINOT_MD5_DISABLED));
     }
+    _disableMultipartUpload = Boolean.parseBoolean(
+        pinotConfig.getProperty(DISABLE_MULTIPART_UPLOAD, String.valueOf(DEFAULT_DISABLE_MULTIPART_UPLOAD)));
 
     _storageClass = pinotConfig.getProperty(STORAGE_CLASS);
     if (_storageClass != null) {
@@ -314,5 +319,9 @@ public class S3Config {
 
   public boolean useLegacyMd5Plugin() {
     return _useLegacyMd5Plugin;
+  }
+
+  public boolean isMultipartUploadDisabled() {
+    return _disableMultipartUpload;
   }
 }

--- a/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3PinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3PinotFS.java
@@ -113,6 +113,7 @@ public class S3PinotFS extends BasePinotFS {
   private String _ssekmsEncryptionContext;
   private long _minObjectSizeToUploadInParts;
   private long _multiPartUploadPartSize;
+  private boolean _disableMultipartUpload;
   private @Nullable StorageClass _storageClass;
   private StsClient _stsClient;
   private StsAssumeRoleCredentialsProvider _stsCredentialsProvider;
@@ -214,7 +215,9 @@ public class S3PinotFS extends BasePinotFS {
         throw new RuntimeException("Could not initialize S3PinotFS", e);
       }
 
-      // Close old resources after new client is live (order: provider → STS client → S3 client)
+      _disableMultipartUpload = _s3Config.isMultipartUploadDisabled();
+
+      // Close old resources after new client is live (order: provider -> STS client -> S3 client)
       closeQuietly(oldStsCredentialsProvider, "oldStsCredentialsProvider");
       closeQuietly(oldStsClient, "oldStsClient");
       closeQuietly(oldS3Client, "oldS3Client");
@@ -320,6 +323,7 @@ public class S3PinotFS extends BasePinotFS {
     setServerSideEncryption(serverSideEncryption, s3Config);
     setMultiPartUploadConfigs(s3Config);
     setDisableAcl(s3Config);
+    _disableMultipartUpload = s3Config.isMultipartUploadDisabled();
   }
 
   @VisibleForTesting
@@ -884,7 +888,7 @@ public class S3PinotFS extends BasePinotFS {
   @Override
   public void copyFromLocalFile(File srcFile, URI dstUri)
       throws Exception {
-    if (_minObjectSizeToUploadInParts > 0 && srcFile.length() > _minObjectSizeToUploadInParts) {
+    if (!_disableMultipartUpload && _minObjectSizeToUploadInParts > 0 && srcFile.length() > _minObjectSizeToUploadInParts) {
       LOGGER.info("Copy {} from local to {} in parts", srcFile.getAbsolutePath(), dstUri);
       uploadFileInParts(srcFile, dstUri);
     } else {
@@ -959,6 +963,11 @@ public class S3PinotFS extends BasePinotFS {
   void setMultiPartUploadConfigs(long minObjectSizeToUploadInParts, long multiPartUploadPartSize) {
     _minObjectSizeToUploadInParts = minObjectSizeToUploadInParts;
     _multiPartUploadPartSize = multiPartUploadPartSize;
+  }
+
+  @VisibleForTesting
+  void setDisableMultipartUpload(boolean disableMultipartUpload) {
+    _disableMultipartUpload = disableMultipartUpload;
   }
 
   @Override

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segmentgenerationandpush/SegmentGenerationAndPushTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segmentgenerationandpush/SegmentGenerationAndPushTaskExecutor.java
@@ -169,9 +169,24 @@ public class SegmentGenerationAndPushTaskExecutor extends BaseTaskExecutor {
     LOGGER.info("Trying to push Pinot segment with push mode {} from {}", pushMode, outputSegmentTarURI);
 
     PushJobSpec pushJobSpec = new PushJobSpec();
-    pushJobSpec.setPushAttempts(DEFUALT_PUSH_ATTEMPTS);
-    pushJobSpec.setPushParallelism(DEFAULT_PUSH_PARALLELISM);
-    pushJobSpec.setPushRetryIntervalMillis(DEFAULT_PUSH_RETRY_INTERVAL_MILLIS);
+    // Read push attempts from task config, default to 5 if not specified
+    int pushAttempts = DEFUALT_PUSH_ATTEMPTS;
+    if (taskConfigs.containsKey(BatchConfigProperties.PUSH_ATTEMPTS)) {
+      pushAttempts = Integer.parseInt(taskConfigs.get(BatchConfigProperties.PUSH_ATTEMPTS));
+    }
+    pushJobSpec.setPushAttempts(pushAttempts);
+    // Read push parallelism from task config, default to 1 if not specified
+    int pushParallelism = DEFAULT_PUSH_PARALLELISM;
+    if (taskConfigs.containsKey(BatchConfigProperties.PUSH_PARALLELISM)) {
+      pushParallelism = Integer.parseInt(taskConfigs.get(BatchConfigProperties.PUSH_PARALLELISM));
+    }
+    pushJobSpec.setPushParallelism(pushParallelism);
+    // Read push retry interval from task config, default to 1000ms if not specified
+    long pushRetryIntervalMillis = DEFAULT_PUSH_RETRY_INTERVAL_MILLIS;
+    if (taskConfigs.containsKey(BatchConfigProperties.PUSH_RETRY_INTERVAL_MILLIS)) {
+      pushRetryIntervalMillis = Long.parseLong(taskConfigs.get(BatchConfigProperties.PUSH_RETRY_INTERVAL_MILLIS));
+    }
+    pushJobSpec.setPushRetryIntervalMillis(pushRetryIntervalMillis);
     pushJobSpec.setSegmentUriPrefix(taskConfigs.get(BatchConfigProperties.PUSH_SEGMENT_URI_PREFIX));
     pushJobSpec.setSegmentUriSuffix(taskConfigs.get(BatchConfigProperties.PUSH_SEGMENT_URI_SUFFIX));
 

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segmentgenerationandpush/SegmentGenerationAndPushTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segmentgenerationandpush/SegmentGenerationAndPushTaskGenerator.java
@@ -180,8 +180,11 @@ public class SegmentGenerationAndPushTaskGenerator extends BaseTaskGenerator {
     Map<String, String> batchConfigMap = new HashMap<>();
     TableTaskConfig tableTaskConfig = tableConfig.getTaskConfig();
     if (tableTaskConfig != null) {
-      batchConfigMap.putAll(
-          tableTaskConfig.getConfigsForTaskType(MinionConstants.SegmentGenerationAndPushTask.TASK_TYPE));
+      Map<String, String> taskTypeConfig =
+      tableTaskConfig.getConfigsForTaskType(MinionConstants.SegmentGenerationAndPushTask.TASK_TYPE);
+      if (taskTypeConfig != null) {
+        batchConfigMap.putAll(taskTypeConfig);
+      }
     }
     batchConfigMap.putAll(taskConfigs);
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SegmentPushUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SegmentPushUtils.java
@@ -197,8 +197,8 @@ public class SegmentPushUtils implements Serializable {
             return true;
           } catch (HttpErrorStatusException e) {
             int statusCode = e.getStatusCode();
-            if (statusCode >= 500) {
-              // Temporary exception
+            if (statusCode >= 400) {
+              // Temporary exception - retry on both 4xx and 5xx errors
               LOGGER.warn("Caught temporary exception while pushing table: {} segment: {} to {}, will retry", tableName,
                   segmentName, controllerURI, e);
               return false;
@@ -254,8 +254,8 @@ public class SegmentPushUtils implements Serializable {
             return true;
           } catch (HttpErrorStatusException e) {
             int statusCode = e.getStatusCode();
-            if (statusCode >= 500) {
-              // Temporary exception
+            if (statusCode >= 400) {
+              // Temporary exception - retry on both 4xx and 5xx errors
               LOGGER.warn("Caught temporary exception while pushing table: {} segment uri: {} to {}, will retry",
                   tableName, segmentUri, controllerURI, e);
               return false;
@@ -355,8 +355,8 @@ public class SegmentPushUtils implements Serializable {
               return true;
             } catch (HttpErrorStatusException e) {
               int statusCode = e.getStatusCode();
-              if (statusCode >= 500) {
-                // Temporary exception
+              if (statusCode >= 400) {
+                // Temporary exception - retry on both 4xx and 5xx errors
                 LOGGER.warn("Caught temporary exception while pushing table: {} segment: {} to {}, will retry",
                     tableName, segmentName, controllerURI, e);
                 return false;
@@ -426,8 +426,8 @@ public class SegmentPushUtils implements Serializable {
             return true;
           } catch (HttpErrorStatusException e) {
             int statusCode = e.getStatusCode();
-            if (statusCode >= 500) {
-              // Temporary exception
+            if (statusCode >= 400) {
+              // Temporary exception - retry on both 4xx and 5xx errors
               LOGGER.warn("Caught temporary exception while pushing table: {} segments: {} to {}, will retry",
                   tableName, segmentMetadataFileMap.keySet(), controllerURI, e);
               return false;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/IndexingConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/IndexingConfig.java
@@ -47,6 +47,10 @@ public class IndexingConfig extends BaseJsonConfig {
   private List<String> _sortedColumn;
   private List<String> _bloomFilterColumns;
   private Map<String, BloomFilterConfig> _bloomFilterConfigs;
+  // Map index configs - kept for backward compatibility with Pinot 1.3
+  // Map indexes are now handled through the FieldConfig/indexes system
+  @Deprecated
+  private Map<String, IndexConfig> _mapIndexConfigs;
   private String _loadMode;
   @Deprecated // Moved to {@link IngestionConfig#getStreamIngestionConfig}
   private Map<String, String> _streamConfigs;
@@ -196,6 +200,31 @@ public class IndexingConfig extends BaseJsonConfig {
 
   public void setBloomFilterConfigs(Map<String, BloomFilterConfig> bloomFilterConfigs) {
     _bloomFilterConfigs = bloomFilterConfigs;
+  }
+
+  /**
+   * Returns map index configurations.
+   * 
+   * @deprecated Map indexes are now configured through the FieldConfig/indexes system.
+   * This method is kept for backward compatibility with Pinot 1.3.
+   * @return map of column names to map index configurations, or null if not set
+   */
+  @Deprecated
+  @Nullable
+  public Map<String, IndexConfig> getMapIndexConfigs() {
+    return _mapIndexConfigs;
+  }
+
+  /**
+   * Sets map index configurations.
+   * 
+   * @deprecated Map indexes are now configured through the FieldConfig/indexes system.
+   * This method is kept for backward compatibility with Pinot 1.3.
+   * @param mapIndexConfigs map of column names to map index configurations
+   */
+  @Deprecated
+  public void setMapIndexConfigs(Map<String, IndexConfig> mapIndexConfigs) {
+    _mapIndexConfigs = mapIndexConfigs;
   }
 
   @Nullable
@@ -448,6 +477,9 @@ public class IndexingConfig extends BaseJsonConfig {
     }
     if (_bloomFilterConfigs != null) {
       allColumns.addAll(_bloomFilterConfigs.keySet());
+    }
+    if (_mapIndexConfigs != null) {
+      allColumns.addAll(_mapIndexConfigs.keySet());
     }
     if (_noDictionaryColumns != null) {
       allColumns.addAll(_noDictionaryColumns);

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
   <properties>
     <pinot.root>${basedir}</pinot.root>
     <build.profile.id>dev</build.profile.id>
-    <jdk.version>11</jdk.version>
+    <jdk.version>21</jdk.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
     <!-- Setting maven.compiler flags to the jdk version. These are used by maven plugins like maven-javadoc-plugin -->

--- a/pom.xml
+++ b/pom.xml
@@ -2624,35 +2624,6 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-checkstyle-plugin</artifactId>
-        <configuration>
-          <configLocation>${pinot.root}/config/checkstyle.xml</configLocation>
-          <suppressionsLocation>${pinot.root}/config/suppressions.xml</suppressionsLocation>
-          <propertyExpansion>config_loc=${pinot.root}/config</propertyExpansion>
-          <logViolationsToConsole>true</logViolationsToConsole>
-          <violationSeverity>${checkstyle.violation.severity}</violationSeverity>
-          <failOnViolation>${checkstyle.fail.on.violation}</failOnViolation>
-          <includeTestSourceDirectory>true</includeTestSourceDirectory>
-        </configuration>
-        <dependencies>
-          <dependency>
-            <groupId>com.puppycrawl.tools</groupId>
-            <artifactId>checkstyle</artifactId>
-            <version>10.26.1</version>
-          </dependency>
-        </dependencies>
-        <executions>
-          <execution>
-            <id>checkstyle</id>
-            <phase>validate</phase>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-surefire-plugin</artifactId>
         <!--
           Configuration for unit/integration tests section 2 of 3 (plugins) STARTS HERE.


### PR DESCRIPTION
## Summary
- Rebased all custom reelevant patches on top of the latest Apache Pinot upstream master (`22b3b6fe66`), bringing in ~575 new upstream commits since Dec 2025.
- Added a fix for an NPE when querying a Logical Table backed by an upsert-enabled physical table: `SingleTableExecutionInfo.getOptionalSegments()` now returns `Collections.emptyList()` instead of null.
## Custom patches carried forward
1. **chore(minion): fix npe when generating task**
2. **chore: target java 21**
3. **chore: fix ui for high tables count + build** -- removed `AsyncPinotSchemas` and `AsyncLogicalTables` to avoid fetching all table details at once
4. **chore(helix): fix NPE**
5. **chore(config): support backward index config**
6. **chore(pinot-s3): allow to disable multipart upload**
7. **chore(pinot-minion): add configurable retry**
8. **chore(fs-s3): disable multipart by default**
9. **chore: fix docker**
10. **fix(logical-table): avoid NPE on getOptionalSegments for upsert queries** (new)
## Conflicts resolved during rebase
- `TablesListingPage.tsx` -- upstream added `AsyncLogicalTables`; removed along with `AsyncPinotSchemas` to stay consistent with our UI patch.
- `S3Config.java` / `S3PinotFS.java` -- upstream refactored S3 client init with MD5 plugin validation and resource cleanup; integrated our `disableMultipartUpload` config into the new code.
