### PR TITLE
Push element length and ASCII stats into Dictionary implementations

### DIFF
--- a/pinot-perf/src/main/java/org/apache/pinot/perf/aggregation/BenchmarkDistinctCountHLLThreshold.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/aggregation/BenchmarkDistinctCountHLLThreshold.java
@@ -201,15 +201,6 @@ public class BenchmarkDistinctCountHLLThreshold {
     }
 
     @Override
-    public Object getSortedValues() {
-      String[] values = new String[_length];
-      for (int i = 0; i < _length; i++) {
-        values[i] = "value_" + i;
-      }
-      return values;
-    }
-
-    @Override
     public Object get(int dictId) {
       return dictId;
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/converter/stats/MutableColumnStatistics.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/converter/stats/MutableColumnStatistics.java
@@ -28,14 +28,10 @@ import org.apache.pinot.segment.spi.index.mutable.MutableForwardIndex;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.segment.spi.partition.PartitionFunction;
 import org.apache.pinot.spi.data.FieldSpec;
-import org.apache.pinot.spi.data.FieldSpec.DataType;
-import org.apache.pinot.spi.utils.Utf8Utils;
 
 
 /**
  * Column statistics for a column coming from an in-memory realtime segment.
- *
- * TODO: Gather more info on the fly to avoid scanning the segment
  */
 @SuppressWarnings("rawtypes")
 public class MutableColumnStatistics implements ColumnStatistics {
@@ -49,10 +45,6 @@ public class MutableColumnStatistics implements ColumnStatistics {
   // NOTE: For new added columns during the ingestion, this will be constant value dictionary instead of mutable
   //       dictionary.
   protected final Dictionary _dictionary;
-
-  private int _minElementLength = -1;
-  private int _maxElementLength = -1;
-  private boolean _isAscii;
 
   public MutableColumnStatistics(DataSource dataSource, @Nullable int[] sortedDocIds, boolean isSortedColumn) {
     _dataSource = dataSource;
@@ -93,53 +85,17 @@ public class MutableColumnStatistics implements ColumnStatistics {
 
   @Override
   public int getLengthOfShortestElement() {
-    collectElementLengthIfNeeded();
-    return _minElementLength;
+    return _dictionary.getLengthOfShortestElement();
   }
 
   @Override
   public int getLengthOfLongestElement() {
-    collectElementLengthIfNeeded();
-    return _maxElementLength;
+    return _dictionary.getLengthOfLongestElement();
   }
 
   @Override
   public boolean isAscii() {
-    collectElementLengthIfNeeded();
-    return _isAscii;
-  }
-
-  private void collectElementLengthIfNeeded() {
-    if (_minElementLength >= 0) {
-      return;
-    }
-
-    DataType valueType = _dictionary.getValueType();
-    if (valueType.isFixedWidth()) {
-      int length = valueType.size();
-      _minElementLength = length;
-      _maxElementLength = length;
-    } else {
-      // If the stored type is not fixed width, iterate over the dictionary to find the min/max element length
-      // TODO: Collect these stats within Dictionary to avoid an extra scan
-      _minElementLength = Integer.MAX_VALUE;
-      _maxElementLength = 0;
-      boolean isAscii = valueType == DataType.STRING;
-      int length = _dictionary.length();
-      for (int i = 0; i < length; i++) {
-        if (isAscii) {
-          byte[] bytes = _dictionary.getBytesValue(i);
-          _minElementLength = Math.min(_minElementLength, bytes.length);
-          _maxElementLength = Math.max(_maxElementLength, bytes.length);
-          isAscii = Utf8Utils.isAscii(bytes);
-        } else {
-          int elementLength = _dictionary.getValueSize(i);
-          _minElementLength = Math.min(_minElementLength, elementLength);
-          _maxElementLength = Math.max(_maxElementLength, elementLength);
-        }
-      }
-      _isAscii = isAscii;
-    }
+    return _dictionary.isAscii();
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/dictionary/BigDecimalOffHeapMutableDictionary.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/dictionary/BigDecimalOffHeapMutableDictionary.java
@@ -37,6 +37,8 @@ public class BigDecimalOffHeapMutableDictionary extends BaseOffHeapMutableDictio
 
   private volatile BigDecimal _min = null;
   private volatile BigDecimal _max = null;
+  private volatile int _lengthOfShortestElement = Integer.MAX_VALUE;
+  private volatile int _lengthOfLongestElement = 0;
 
   public BigDecimalOffHeapMutableDictionary(int estimatedCardinality, int maxOverflowHashSize,
       PinotDataBufferMemoryManager memoryManager, String allocationContext, int avgBigDecimalLen) {
@@ -48,7 +50,7 @@ public class BigDecimalOffHeapMutableDictionary extends BaseOffHeapMutableDictio
   @Override
   public int index(Object value) {
     BigDecimal bigDecimalValue = (BigDecimal) value;
-    updateMinMax(bigDecimalValue);
+    updateStats(bigDecimalValue);
     return indexValue(bigDecimalValue, BigDecimalUtils.serialize(bigDecimalValue));
   }
 
@@ -58,10 +60,26 @@ public class BigDecimalOffHeapMutableDictionary extends BaseOffHeapMutableDictio
     int[] dictIds = new int[numValues];
     for (int i = 0; i < numValues; i++) {
       BigDecimal bigDecimalValue = (BigDecimal) values[i];
-      updateMinMax(bigDecimalValue);
+      updateStats(bigDecimalValue);
       dictIds[i] = indexValue(bigDecimalValue, BigDecimalUtils.serialize(bigDecimalValue));
     }
     return dictIds;
+  }
+
+  @Override
+  public DataType getValueType() {
+    return DataType.BIG_DECIMAL;
+  }
+
+  @Override
+  public int indexOf(String stringValue) {
+    BigDecimal bigDecimalValue = new BigDecimal(stringValue);
+    return getDictId(bigDecimalValue, BigDecimalUtils.serialize(bigDecimalValue));
+  }
+
+  @Override
+  public int indexOf(BigDecimal bigDecimalValue) {
+    return getDictId(bigDecimalValue, BigDecimalUtils.serialize(bigDecimalValue));
   }
 
   @Override
@@ -171,21 +189,16 @@ public class BigDecimalOffHeapMutableDictionary extends BaseOffHeapMutableDictio
   }
 
   @Override
-  public DataType getValueType() {
-    return DataType.BIG_DECIMAL;
+  public int getLengthOfShortestElement() {
+    return _lengthOfShortestElement;
   }
 
   @Override
-  public int indexOf(String stringValue) {
-    BigDecimal bigDecimalValue = new BigDecimal(stringValue);
-    return getDictId(bigDecimalValue, BigDecimalUtils.serialize(bigDecimalValue));
+  public int getLengthOfLongestElement() {
+    return _lengthOfLongestElement;
   }
 
   @Override
-  public int indexOf(BigDecimal bigDecimalValue) {
-    return getDictId(bigDecimalValue, BigDecimalUtils.serialize(bigDecimalValue));
-  }
-
   public BigDecimal get(int dictId) {
     return getBigDecimalValue(dictId);
   }
@@ -251,16 +264,25 @@ public class BigDecimalOffHeapMutableDictionary extends BaseOffHeapMutableDictio
     _byteStore.close();
   }
 
-  private void updateMinMax(BigDecimal value) {
+  private void updateStats(BigDecimal value) {
+    int byteSize = BigDecimalUtils.byteSize(value);
     if (_min == null) {
       _min = value;
       _max = value;
+      _lengthOfShortestElement = byteSize;
+      _lengthOfLongestElement = byteSize;
     } else {
       if (value.compareTo(_min) < 0) {
         _min = value;
       }
       if (value.compareTo(_max) > 0) {
         _max = value;
+      }
+      if (byteSize < _lengthOfShortestElement) {
+        _lengthOfShortestElement = byteSize;
+      }
+      if (byteSize > _lengthOfLongestElement) {
+        _lengthOfLongestElement = byteSize;
       }
     }
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/dictionary/BigDecimalOnHeapMutableDictionary.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/dictionary/BigDecimalOnHeapMutableDictionary.java
@@ -32,11 +32,13 @@ import org.apache.pinot.spi.utils.BigDecimalUtils;
 public class BigDecimalOnHeapMutableDictionary extends BaseOnHeapMutableDictionary {
   private volatile BigDecimal _min = null;
   private volatile BigDecimal _max = null;
+  private volatile int _lengthOfShortestElement = Integer.MAX_VALUE;
+  private volatile int _lengthOfLongestElement = 0;
 
   @Override
   public int index(Object value) {
     BigDecimal bigDecimalValue = (BigDecimal) value;
-    updateMinMax(bigDecimalValue);
+    updateStats(bigDecimalValue);
     return indexValue(bigDecimalValue);
   }
 
@@ -46,10 +48,25 @@ public class BigDecimalOnHeapMutableDictionary extends BaseOnHeapMutableDictiona
     int[] dictIds = new int[numValues];
     for (int i = 0; i < numValues; i++) {
       BigDecimal bigDecimalValue = (BigDecimal) values[i];
-      updateMinMax(bigDecimalValue);
+      updateStats(bigDecimalValue);
       dictIds[i] = indexValue(bigDecimalValue);
     }
     return dictIds;
+  }
+
+  @Override
+  public DataType getValueType() {
+    return DataType.BIG_DECIMAL;
+  }
+
+  @Override
+  public int indexOf(String stringValue) {
+    return getDictId(new BigDecimal(stringValue));
+  }
+
+  @Override
+  public int indexOf(BigDecimal bigDecimalValue) {
+    return getDictId(bigDecimalValue);
   }
 
   @Override
@@ -159,18 +176,13 @@ public class BigDecimalOnHeapMutableDictionary extends BaseOnHeapMutableDictiona
   }
 
   @Override
-  public DataType getValueType() {
-    return DataType.BIG_DECIMAL;
+  public int getLengthOfShortestElement() {
+    return _lengthOfShortestElement;
   }
 
   @Override
-  public int indexOf(String stringValue) {
-    return getDictId(new BigDecimal(stringValue));
-  }
-
-  @Override
-  public int indexOf(BigDecimal bigDecimalValue) {
-    return getDictId(bigDecimalValue);
+  public int getLengthOfLongestElement() {
+    return _lengthOfLongestElement;
   }
 
   @Override
@@ -213,16 +225,25 @@ public class BigDecimalOnHeapMutableDictionary extends BaseOnHeapMutableDictiona
     return BigDecimalUtils.byteSize(getBigDecimalValue(dictId));
   }
 
-  private void updateMinMax(BigDecimal value) {
+  private void updateStats(BigDecimal value) {
+    int byteSize = BigDecimalUtils.byteSize(value);
     if (_min == null) {
       _min = value;
       _max = value;
+      _lengthOfShortestElement = byteSize;
+      _lengthOfLongestElement = byteSize;
     } else {
       if (value.compareTo(_min) < 0) {
         _min = value;
       }
       if (value.compareTo(_max) > 0) {
         _max = value;
+      }
+      if (byteSize < _lengthOfShortestElement) {
+        _lengthOfShortestElement = byteSize;
+      }
+      if (byteSize > _lengthOfLongestElement) {
+        _lengthOfLongestElement = byteSize;
       }
     }
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/dictionary/BytesOffHeapMutableDictionary.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/dictionary/BytesOffHeapMutableDictionary.java
@@ -39,6 +39,8 @@ public class BytesOffHeapMutableDictionary extends BaseOffHeapMutableDictionary 
 
   private volatile byte[] _min = null;
   private volatile byte[] _max = null;
+  private volatile int _lengthOfShortestElement = Integer.MAX_VALUE;
+  private volatile int _lengthOfLongestElement = 0;
 
   /**
    * Constructor the class.
@@ -58,13 +60,29 @@ public class BytesOffHeapMutableDictionary extends BaseOffHeapMutableDictionary 
   @Override
   public int index(Object value) {
     byte[] bytesValue = (byte[]) value;
-    updateMinMax(bytesValue);
+    updateStats(bytesValue);
     return indexValue(new ByteArray(bytesValue), bytesValue);
   }
 
   @Override
   public int[] index(Object[] values) {
     throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public DataType getValueType() {
+    return DataType.BYTES;
+  }
+
+  @Override
+  public int indexOf(String stringValue) {
+    byte[] bytesValue = BytesUtils.toBytes(stringValue);
+    return getDictId(new ByteArray(bytesValue), bytesValue);
+  }
+
+  @Override
+  public int indexOf(ByteArray bytesValue) {
+    return getDictId(bytesValue, bytesValue.getBytes());
   }
 
   @Override
@@ -136,19 +154,13 @@ public class BytesOffHeapMutableDictionary extends BaseOffHeapMutableDictionary 
   }
 
   @Override
-  public DataType getValueType() {
-    return DataType.BYTES;
+  public int getLengthOfShortestElement() {
+    return _lengthOfShortestElement;
   }
 
   @Override
-  public int indexOf(String stringValue) {
-    byte[] bytesValue = BytesUtils.toBytes(stringValue);
-    return getDictId(new ByteArray(bytesValue), bytesValue);
-  }
-
-  @Override
-  public int indexOf(ByteArray bytesValue) {
-    return getDictId(bytesValue, bytesValue.getBytes());
+  public int getLengthOfLongestElement() {
+    return _lengthOfLongestElement;
   }
 
   @Override
@@ -227,16 +239,25 @@ public class BytesOffHeapMutableDictionary extends BaseOffHeapMutableDictionary 
     _byteStore.close();
   }
 
-  private void updateMinMax(byte[] value) {
+  private void updateStats(byte[] value) {
+    int length = value.length;
     if (_min == null) {
       _min = value;
       _max = value;
+      _lengthOfShortestElement = length;
+      _lengthOfLongestElement = length;
     } else {
       if (ByteArray.compare(value, _min) < 0) {
         _min = value;
       }
       if (ByteArray.compare(value, _max) > 0) {
         _max = value;
+      }
+      if (length < _lengthOfShortestElement) {
+        _lengthOfShortestElement = length;
+      }
+      if (length > _lengthOfLongestElement) {
+        _lengthOfLongestElement = length;
       }
     }
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/dictionary/BytesOnHeapMutableDictionary.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/dictionary/BytesOnHeapMutableDictionary.java
@@ -34,17 +34,34 @@ import org.apache.pinot.spi.utils.BytesUtils;
 public class BytesOnHeapMutableDictionary extends BaseOnHeapMutableDictionary {
   private volatile byte[] _min = null;
   private volatile byte[] _max = null;
+  private volatile int _lengthOfShortestElement = Integer.MAX_VALUE;
+  private volatile int _lengthOfLongestElement = 0;
 
   @Override
   public int index(Object value) {
     byte[] bytesValue = (byte[]) value;
-    updateMinMax(bytesValue);
+    updateStats(bytesValue);
     return indexValue(new ByteArray(bytesValue));
   }
 
   @Override
   public int[] index(Object[] values) {
     throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public DataType getValueType() {
+    return DataType.BYTES;
+  }
+
+  @Override
+  public int indexOf(String stringValue) {
+    return getDictId(BytesUtils.toByteArray(stringValue));
+  }
+
+  @Override
+  public int indexOf(ByteArray bytesValue) {
+    return getDictId(bytesValue);
   }
 
   @Override
@@ -116,18 +133,13 @@ public class BytesOnHeapMutableDictionary extends BaseOnHeapMutableDictionary {
   }
 
   @Override
-  public DataType getValueType() {
-    return DataType.BYTES;
+  public int getLengthOfShortestElement() {
+    return _lengthOfShortestElement;
   }
 
   @Override
-  public int indexOf(String stringValue) {
-    return getDictId(BytesUtils.toByteArray(stringValue));
-  }
-
-  @Override
-  public int indexOf(ByteArray bytesValue) {
-    return getDictId(bytesValue);
+  public int getLengthOfLongestElement() {
+    return _lengthOfLongestElement;
   }
 
   @Override
@@ -185,16 +197,25 @@ public class BytesOnHeapMutableDictionary extends BaseOnHeapMutableDictionary {
     return (ByteArray) super.get(dictId);
   }
 
-  private void updateMinMax(byte[] value) {
+  private void updateStats(byte[] value) {
+    int length = value.length;
     if (_min == null) {
       _min = value;
       _max = value;
+      _lengthOfShortestElement = length;
+      _lengthOfLongestElement = length;
     } else {
       if (ByteArray.compare(value, _min) < 0) {
         _min = value;
       }
       if (ByteArray.compare(value, _max) > 0) {
         _max = value;
+      }
+      if (length < _lengthOfShortestElement) {
+        _lengthOfShortestElement = length;
+      }
+      if (length > _lengthOfLongestElement) {
+        _lengthOfLongestElement = length;
       }
     }
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/dictionary/DoubleOffHeapMutableDictionary.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/dictionary/DoubleOffHeapMutableDictionary.java
@@ -65,6 +65,21 @@ public class DoubleOffHeapMutableDictionary extends BaseOffHeapMutableDictionary
   }
 
   @Override
+  public DataType getValueType() {
+    return DataType.DOUBLE;
+  }
+
+  @Override
+  public int indexOf(String stringValue) {
+    return getDictId(Double.valueOf(stringValue), null);
+  }
+
+  @Override
+  public int indexOf(double doubleValue) {
+    return getDictId(doubleValue, null);
+  }
+
+  @Override
   public int compare(int dictId1, int dictId2) {
     return Double.compare(getDoubleValue(dictId1), getDoubleValue(dictId2));
   }
@@ -171,20 +186,6 @@ public class DoubleOffHeapMutableDictionary extends BaseOffHeapMutableDictionary
   }
 
   @Override
-  public DataType getValueType() {
-    return DataType.DOUBLE;
-  }
-
-  @Override
-  public int indexOf(String stringValue) {
-    return getDictId(Double.valueOf(stringValue), null);
-  }
-
-  @Override
-  public int indexOf(double doubleValue) {
-    return getDictId(doubleValue, null);
-  }
-
   public Double get(int dictId) {
     return getDoubleValue(dictId);
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/dictionary/DoubleOnHeapMutableDictionary.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/dictionary/DoubleOnHeapMutableDictionary.java
@@ -52,6 +52,21 @@ public class DoubleOnHeapMutableDictionary extends BaseOnHeapMutableDictionary {
   }
 
   @Override
+  public DataType getValueType() {
+    return DataType.DOUBLE;
+  }
+
+  @Override
+  public int indexOf(String stringValue) {
+    return getDictId(Double.valueOf(stringValue));
+  }
+
+  @Override
+  public int indexOf(double doubleValue) {
+    return getDictId(doubleValue);
+  }
+
+  @Override
   public int compare(int dictId1, int dictId2) {
     return Double.compare(getDoubleValue(dictId1), getDoubleValue(dictId2));
   }
@@ -155,21 +170,6 @@ public class DoubleOnHeapMutableDictionary extends BaseOnHeapMutableDictionary {
 
     Arrays.sort(sortedValues);
     return sortedValues;
-  }
-
-  @Override
-  public DataType getValueType() {
-    return DataType.DOUBLE;
-  }
-
-  @Override
-  public int indexOf(String stringValue) {
-    return getDictId(Double.valueOf(stringValue));
-  }
-
-  @Override
-  public int indexOf(double doubleValue) {
-    return getDictId(doubleValue);
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/dictionary/FloatOffHeapMutableDictionary.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/dictionary/FloatOffHeapMutableDictionary.java
@@ -65,6 +65,21 @@ public class FloatOffHeapMutableDictionary extends BaseOffHeapMutableDictionary 
   }
 
   @Override
+  public DataType getValueType() {
+    return DataType.FLOAT;
+  }
+
+  @Override
+  public int indexOf(String stringValue) {
+    return getDictId(Float.valueOf(stringValue), null);
+  }
+
+  @Override
+  public int indexOf(float floatValue) {
+    return getDictId(floatValue, null);
+  }
+
+  @Override
   public int compare(int dictId1, int dictId2) {
     return Float.compare(getFloatValue(dictId1), getFloatValue(dictId2));
   }
@@ -171,20 +186,6 @@ public class FloatOffHeapMutableDictionary extends BaseOffHeapMutableDictionary 
   }
 
   @Override
-  public DataType getValueType() {
-    return DataType.FLOAT;
-  }
-
-  @Override
-  public int indexOf(String stringValue) {
-    return getDictId(Float.valueOf(stringValue), null);
-  }
-
-  @Override
-  public int indexOf(float floatValue) {
-    return getDictId(floatValue, null);
-  }
-
   public Float get(int dictId) {
     return getFloatValue(dictId);
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/dictionary/FloatOnHeapMutableDictionary.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/dictionary/FloatOnHeapMutableDictionary.java
@@ -52,6 +52,21 @@ public class FloatOnHeapMutableDictionary extends BaseOnHeapMutableDictionary {
   }
 
   @Override
+  public DataType getValueType() {
+    return DataType.FLOAT;
+  }
+
+  @Override
+  public int indexOf(String stringValue) {
+    return getDictId(Float.valueOf(stringValue));
+  }
+
+  @Override
+  public int indexOf(float floatValue) {
+    return getDictId(floatValue);
+  }
+
+  @Override
   public int compare(int dictId1, int dictId2) {
     return Float.compare(getFloatValue(dictId1), getFloatValue(dictId2));
   }
@@ -155,21 +170,6 @@ public class FloatOnHeapMutableDictionary extends BaseOnHeapMutableDictionary {
 
     Arrays.sort(sortedValues);
     return sortedValues;
-  }
-
-  @Override
-  public DataType getValueType() {
-    return DataType.FLOAT;
-  }
-
-  @Override
-  public int indexOf(String stringValue) {
-    return getDictId(Float.valueOf(stringValue));
-  }
-
-  @Override
-  public int indexOf(float floatValue) {
-    return getDictId(floatValue);
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/dictionary/IntOffHeapMutableDictionary.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/dictionary/IntOffHeapMutableDictionary.java
@@ -65,6 +65,21 @@ public class IntOffHeapMutableDictionary extends BaseOffHeapMutableDictionary {
   }
 
   @Override
+  public DataType getValueType() {
+    return DataType.INT;
+  }
+
+  @Override
+  public int indexOf(String stringValue) {
+    return getDictId(Integer.valueOf(stringValue), null);
+  }
+
+  @Override
+  public int indexOf(int intValue) {
+    return getDictId(intValue, null);
+  }
+
+  @Override
   public int compare(int dictId1, int dictId2) {
     return Integer.compare(getIntValue(dictId1), getIntValue(dictId2));
   }
@@ -171,20 +186,6 @@ public class IntOffHeapMutableDictionary extends BaseOffHeapMutableDictionary {
   }
 
   @Override
-  public DataType getValueType() {
-    return DataType.INT;
-  }
-
-  @Override
-  public int indexOf(String stringValue) {
-    return getDictId(Integer.valueOf(stringValue), null);
-  }
-
-  @Override
-  public int indexOf(int intValue) {
-    return getDictId(intValue, null);
-  }
-
   public Integer get(int dictId) {
     return getIntValue(dictId);
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/dictionary/IntOnHeapMutableDictionary.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/dictionary/IntOnHeapMutableDictionary.java
@@ -52,6 +52,21 @@ public class IntOnHeapMutableDictionary extends BaseOnHeapMutableDictionary {
   }
 
   @Override
+  public DataType getValueType() {
+    return DataType.INT;
+  }
+
+  @Override
+  public int indexOf(String stringValue) {
+    return getDictId(Integer.valueOf(stringValue));
+  }
+
+  @Override
+  public int indexOf(int intValue) {
+    return getDictId(intValue);
+  }
+
+  @Override
   public int compare(int dictId1, int dictId2) {
     return Integer.compare(getIntValue(dictId1), getIntValue(dictId2));
   }
@@ -155,21 +170,6 @@ public class IntOnHeapMutableDictionary extends BaseOnHeapMutableDictionary {
 
     Arrays.sort(sortedValues);
     return sortedValues;
-  }
-
-  @Override
-  public DataType getValueType() {
-    return DataType.INT;
-  }
-
-  @Override
-  public int indexOf(String stringValue) {
-    return getDictId(Integer.valueOf(stringValue));
-  }
-
-  @Override
-  public int indexOf(int intValue) {
-    return getDictId(intValue);
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/dictionary/LongOffHeapMutableDictionary.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/dictionary/LongOffHeapMutableDictionary.java
@@ -65,6 +65,21 @@ public class LongOffHeapMutableDictionary extends BaseOffHeapMutableDictionary {
   }
 
   @Override
+  public DataType getValueType() {
+    return DataType.LONG;
+  }
+
+  @Override
+  public int indexOf(String stringValue) {
+    return getDictId(Long.valueOf(stringValue), null);
+  }
+
+  @Override
+  public int indexOf(long longValue) {
+    return getDictId(longValue, null);
+  }
+
+  @Override
   public int compare(int dictId1, int dictId2) {
     return Long.compare(getLongValue(dictId1), getLongValue(dictId2));
   }
@@ -168,21 +183,6 @@ public class LongOffHeapMutableDictionary extends BaseOffHeapMutableDictionary {
 
     Arrays.sort(sortedValues);
     return sortedValues;
-  }
-
-  @Override
-  public DataType getValueType() {
-    return DataType.LONG;
-  }
-
-  @Override
-  public int indexOf(String stringValue) {
-    return getDictId(Long.valueOf(stringValue), null);
-  }
-
-  @Override
-  public int indexOf(long longValue) {
-    return getDictId(longValue, null);
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/dictionary/LongOnHeapMutableDictionary.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/dictionary/LongOnHeapMutableDictionary.java
@@ -52,6 +52,21 @@ public class LongOnHeapMutableDictionary extends BaseOnHeapMutableDictionary {
   }
 
   @Override
+  public DataType getValueType() {
+    return DataType.LONG;
+  }
+
+  @Override
+  public int indexOf(String stringValue) {
+    return getDictId(Long.valueOf(stringValue));
+  }
+
+  @Override
+  public int indexOf(long longValue) {
+    return getDictId(longValue);
+  }
+
+  @Override
   public int compare(int dictId1, int dictId2) {
     return Long.compare(getLongValue(dictId1), getLongValue(dictId2));
   }
@@ -155,21 +170,6 @@ public class LongOnHeapMutableDictionary extends BaseOnHeapMutableDictionary {
 
     Arrays.sort(sortedValues);
     return sortedValues;
-  }
-
-  @Override
-  public DataType getValueType() {
-    return DataType.LONG;
-  }
-
-  @Override
-  public int indexOf(String stringValue) {
-    return getDictId(Long.valueOf(stringValue));
-  }
-
-  @Override
-  public int indexOf(long longValue) {
-    return getDictId(longValue);
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/dictionary/SameValueMutableDictionary.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/dictionary/SameValueMutableDictionary.java
@@ -92,6 +92,21 @@ public class SameValueMutableDictionary implements MutableDictionary {
   }
 
   @Override
+  public int getLengthOfShortestElement() {
+    return _valueBytes.length;
+  }
+
+  @Override
+  public int getLengthOfLongestElement() {
+    return _valueBytes.length;
+  }
+
+  @Override
+  public boolean isAscii() {
+    return _valueBytes.length == _actualValue.length();
+  }
+
+  @Override
   public String get(int dictId) {
     return _actualValue;
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/dictionary/StringOffHeapMutableDictionary.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/dictionary/StringOffHeapMutableDictionary.java
@@ -28,8 +28,7 @@ import org.apache.pinot.common.request.context.predicate.RangePredicate;
 import org.apache.pinot.segment.local.io.writer.impl.MutableOffHeapByteArrayStore;
 import org.apache.pinot.segment.spi.memory.PinotDataBufferMemoryManager;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
+import org.apache.pinot.spi.utils.Utf8Utils;
 
 
 @SuppressWarnings("Duplicates")
@@ -38,6 +37,9 @@ public class StringOffHeapMutableDictionary extends BaseOffHeapMutableDictionary
 
   private volatile String _min = null;
   private volatile String _max = null;
+  private volatile int _lengthOfShortestElement = Integer.MAX_VALUE;
+  private volatile int _lengthOfLongestElement = 0;
+  private volatile boolean _isAscii = true;
 
   public StringOffHeapMutableDictionary(int estimatedCardinality, int maxOverflowHashSize,
       PinotDataBufferMemoryManager memoryManager, String allocationContext, int avgStringLen) {
@@ -48,8 +50,9 @@ public class StringOffHeapMutableDictionary extends BaseOffHeapMutableDictionary
   @Override
   public int index(Object value) {
     String stringValue = (String) value;
-    updateMinMax(stringValue);
-    return indexValue(stringValue, stringValue.getBytes(UTF_8));
+    byte[] utf8Bytes = Utf8Utils.encode(stringValue);
+    updateStats(stringValue, utf8Bytes.length);
+    return indexValue(stringValue, utf8Bytes);
   }
 
   @Override
@@ -58,10 +61,21 @@ public class StringOffHeapMutableDictionary extends BaseOffHeapMutableDictionary
     int[] dictIds = new int[numValues];
     for (int i = 0; i < numValues; i++) {
       String stringValue = (String) values[i];
-      updateMinMax(stringValue);
-      dictIds[i] = indexValue(stringValue, stringValue.getBytes(UTF_8));
+      byte[] utf8Bytes = Utf8Utils.encode(stringValue);
+      updateStats(stringValue, utf8Bytes.length);
+      dictIds[i] = indexValue(stringValue, utf8Bytes);
     }
     return dictIds;
+  }
+
+  @Override
+  public DataType getValueType() {
+    return DataType.STRING;
+  }
+
+  @Override
+  public int indexOf(String stringValue) {
+    return getDictId(stringValue, Utf8Utils.encode(stringValue));
   }
 
   @Override
@@ -128,13 +142,18 @@ public class StringOffHeapMutableDictionary extends BaseOffHeapMutableDictionary
   }
 
   @Override
-  public DataType getValueType() {
-    return DataType.STRING;
+  public int getLengthOfShortestElement() {
+    return _lengthOfShortestElement;
   }
 
   @Override
-  public int indexOf(String stringValue) {
-    return getDictId(stringValue, stringValue.getBytes(UTF_8));
+  public int getLengthOfLongestElement() {
+    return _lengthOfLongestElement;
+  }
+
+  @Override
+  public boolean isAscii() {
+    return _isAscii;
   }
 
   @Override
@@ -169,7 +188,7 @@ public class StringOffHeapMutableDictionary extends BaseOffHeapMutableDictionary
 
   @Override
   public String getStringValue(int dictId) {
-    return new String(_byteStore.get(dictId), UTF_8);
+    return Utf8Utils.decode(_byteStore.get(dictId));
   }
 
   @Override
@@ -208,16 +227,28 @@ public class StringOffHeapMutableDictionary extends BaseOffHeapMutableDictionary
     _byteStore.close();
   }
 
-  private void updateMinMax(String value) {
+  private void updateStats(String value, int utf8Length) {
     if (_min == null) {
       _min = value;
       _max = value;
+      _lengthOfShortestElement = utf8Length;
+      _lengthOfLongestElement = utf8Length;
+      _isAscii = utf8Length == value.length();
     } else {
       if (value.compareTo(_min) < 0) {
         _min = value;
       }
       if (value.compareTo(_max) > 0) {
         _max = value;
+      }
+      if (utf8Length < _lengthOfShortestElement) {
+        _lengthOfShortestElement = utf8Length;
+      }
+      if (utf8Length > _lengthOfLongestElement) {
+        _lengthOfLongestElement = utf8Length;
+      }
+      if (_isAscii) {
+        _isAscii = utf8Length == value.length();
       }
     }
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/dictionary/StringOnHeapMutableDictionary.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/dictionary/StringOnHeapMutableDictionary.java
@@ -26,19 +26,21 @@ import java.math.BigDecimal;
 import java.util.Arrays;
 import org.apache.pinot.common.request.context.predicate.RangePredicate;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
+import org.apache.pinot.spi.utils.Utf8Utils;
 
 
 @SuppressWarnings("Duplicates")
 public class StringOnHeapMutableDictionary extends BaseOnHeapMutableDictionary {
   private volatile String _min = null;
   private volatile String _max = null;
+  private volatile int _lengthOfShortestElement = Integer.MAX_VALUE;
+  private volatile int _lengthOfLongestElement = 0;
+  private volatile boolean _isAscii = true;
 
   @Override
   public int index(Object value) {
     String stringValue = (String) value;
-    updateMinMax(stringValue);
+    updateStats(stringValue);
     return indexValue(stringValue);
   }
 
@@ -48,10 +50,20 @@ public class StringOnHeapMutableDictionary extends BaseOnHeapMutableDictionary {
     int[] dictIds = new int[numValues];
     for (int i = 0; i < numValues; i++) {
       String stringValue = (String) values[i];
-      updateMinMax(stringValue);
+      updateStats(stringValue);
       dictIds[i] = indexValue(stringValue);
     }
     return dictIds;
+  }
+
+  @Override
+  public DataType getValueType() {
+    return DataType.STRING;
+  }
+
+  @Override
+  public int indexOf(String stringValue) {
+    return getDictId(stringValue);
   }
 
   @Override
@@ -118,13 +130,18 @@ public class StringOnHeapMutableDictionary extends BaseOnHeapMutableDictionary {
   }
 
   @Override
-  public DataType getValueType() {
-    return DataType.STRING;
+  public int getLengthOfShortestElement() {
+    return _lengthOfShortestElement;
   }
 
   @Override
-  public int indexOf(String stringValue) {
-    return getDictId(stringValue);
+  public int getLengthOfLongestElement() {
+    return _lengthOfLongestElement;
+  }
+
+  @Override
+  public boolean isAscii() {
+    return _isAscii;
   }
 
   @Override
@@ -159,7 +176,7 @@ public class StringOnHeapMutableDictionary extends BaseOnHeapMutableDictionary {
 
   @Override
   public byte[] getBytesValue(int dictId) {
-    return getStringValue(dictId).getBytes(UTF_8);
+    return Utf8Utils.encode(getStringValue(dictId));
   }
 
   @Override
@@ -167,16 +184,29 @@ public class StringOnHeapMutableDictionary extends BaseOnHeapMutableDictionary {
     return Utf8.encodedLength(getStringValue(dictId));
   }
 
-  private void updateMinMax(String value) {
+  private void updateStats(String value) {
+    int utf8Length = Utf8.encodedLength(value);
     if (_min == null) {
       _min = value;
       _max = value;
+      _lengthOfShortestElement = utf8Length;
+      _lengthOfLongestElement = utf8Length;
+      _isAscii = utf8Length == value.length();
     } else {
       if (value.compareTo(_min) < 0) {
         _min = value;
       }
       if (value.compareTo(_max) > 0) {
         _max = value;
+      }
+      if (utf8Length < _lengthOfShortestElement) {
+        _lengthOfShortestElement = utf8Length;
+      }
+      if (utf8Length > _lengthOfLongestElement) {
+        _lengthOfLongestElement = utf8Length;
+      }
+      if (_isAscii) {
+        _isAscii = utf8Length == value.length();
       }
     }
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/BaseConstantValueDictionary.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/BaseConstantValueDictionary.java
@@ -16,58 +16,57 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.segment.spi.index.mutable;
+package org.apache.pinot.segment.local.segment.index.readers;
 
+import it.unimi.dsi.fastutil.ints.IntSet;
+import java.io.IOException;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 
 
-/**
- * Interface for mutable dictionary (for CONSUMING segment).
- */
-public interface MutableDictionary extends Dictionary {
-
-  /**
-   * Indexes a single-value entry (a value of the dictionary type) into the dictionary, and returns the dictId of the
-   * value.
-   */
-  int index(Object value);
-
-  /**
-   * Indexes a multi-value entry (an array of values of the dictionary type) into the dictionary, and returns an array
-   * of dictIds for each value.
-   */
-  int[] index(Object[] values);
+/// Base class for constant-value (single-value) dictionaries.
+///
+/// Unlike [BaseImmutableDictionary] which is backed by a segment data buffer, constant-value dictionaries hold exactly
+/// one value in memory and support the stats-collection APIs needed when sealing a consuming segment.
+public abstract class BaseConstantValueDictionary implements Dictionary {
 
   @Override
-  default boolean isSorted() {
-    return false;
+  public boolean isSorted() {
+    return true;
   }
 
   @Override
-  default int insertionIndexOf(String stringValue) {
-    // This method should not be called for unsorted dictionary.
+  public int length() {
+    return 1;
+  }
+
+  @Override
+  public IntSet getDictIdsInRange(String lower, String upper, boolean includeLower, boolean includeUpper) {
+    // This method should not be called for sorted dictionary.
     throw new UnsupportedOperationException();
   }
 
   @Override
-  default int getLengthOfShortestElement() {
+  public int compare(int dictId1, int dictId2) {
+    return 0;
+  }
+
+  @Override
+  public int getLengthOfShortestElement() {
     return getValueType().size();
   }
 
   @Override
-  default int getLengthOfLongestElement() {
+  public int getLengthOfLongestElement() {
     return getValueType().size();
   }
 
   @Override
-  default boolean isAscii() {
+  public boolean isAscii() {
     return false;
   }
 
-  /**
-   * Return true if the mutable dictionary can consume an additional row.
-   */
-  default boolean canAddMore() {
-    return true;
+  @Override
+  public void close()
+      throws IOException {
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/BaseImmutableDictionary.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/BaseImmutableDictionary.java
@@ -107,13 +107,6 @@ public abstract class BaseImmutableDictionary implements Dictionary {
   }
 
   @Override
-  public Object getSortedValues() {
-    // This method is for the stats collection phase when sealing the consuming segment, so it is not required for
-    // regular immutable dictionary within the immutable segment.
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
   public void close()
       throws IOException {
     if (_valueReader != null) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/ConstantValueBigDecimalDictionary.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/ConstantValueBigDecimalDictionary.java
@@ -26,12 +26,11 @@ import org.apache.pinot.spi.utils.BigDecimalUtils;
 /**
  * Dictionary of a single BIG_DECIMAL value.
  */
-public class ConstantValueBigDecimalDictionary extends BaseImmutableDictionary {
+public class ConstantValueBigDecimalDictionary extends BaseConstantValueDictionary {
   private final BigDecimal _value;
   private final byte[] _bytes;
 
   public ConstantValueBigDecimalDictionary(BigDecimal value) {
-    super(1);
     _value = value;
     _bytes = BigDecimalUtils.serialize(_value);
   }
@@ -77,6 +76,16 @@ public class ConstantValueBigDecimalDictionary extends BaseImmutableDictionary {
   @Override
   public BigDecimal[] getSortedValues() {
     return new BigDecimal[]{_value};
+  }
+
+  @Override
+  public int getLengthOfShortestElement() {
+    return _bytes.length;
+  }
+
+  @Override
+  public int getLengthOfLongestElement() {
+    return _bytes.length;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/ConstantValueBytesDictionary.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/ConstantValueBytesDictionary.java
@@ -29,11 +29,10 @@ import org.apache.pinot.spi.utils.BytesUtils;
 /**
  * Dictionary of a single bytes ({@code byte[]}) value.
  */
-public class ConstantValueBytesDictionary extends BaseImmutableDictionary {
+public class ConstantValueBytesDictionary extends BaseConstantValueDictionary {
   private final byte[] _value;
 
   public ConstantValueBytesDictionary(byte[] value) {
-    super(1);
     _value = value;
   }
 
@@ -77,6 +76,16 @@ public class ConstantValueBytesDictionary extends BaseImmutableDictionary {
   @Override
   public Object getSortedValues() {
     return new ByteArray[]{new ByteArray(_value)};
+  }
+
+  @Override
+  public int getLengthOfShortestElement() {
+    return _value.length;
+  }
+
+  @Override
+  public int getLengthOfLongestElement() {
+    return _value.length;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/ConstantValueDoubleDictionary.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/ConstantValueDoubleDictionary.java
@@ -25,11 +25,10 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
 /**
  * Dictionary of a single double value.
  */
-public class ConstantValueDoubleDictionary extends BaseImmutableDictionary {
+public class ConstantValueDoubleDictionary extends BaseConstantValueDictionary {
   private final double _value;
 
   public ConstantValueDoubleDictionary(double value) {
-    super(1);
     _value = value;
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/ConstantValueFloatDictionary.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/ConstantValueFloatDictionary.java
@@ -25,11 +25,10 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
 /**
  * Dictionary of a single float value.
  */
-public class ConstantValueFloatDictionary extends BaseImmutableDictionary {
+public class ConstantValueFloatDictionary extends BaseConstantValueDictionary {
   private final float _value;
 
   public ConstantValueFloatDictionary(float value) {
-    super(1);
     _value = value;
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/ConstantValueIntDictionary.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/ConstantValueIntDictionary.java
@@ -25,11 +25,10 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
 /**
  * Dictionary of a single int value.
  */
-public class ConstantValueIntDictionary extends BaseImmutableDictionary {
+public class ConstantValueIntDictionary extends BaseConstantValueDictionary {
   private final int _value;
 
   public ConstantValueIntDictionary(int value) {
-    super(1);
     _value = value;
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/ConstantValueLongDictionary.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/ConstantValueLongDictionary.java
@@ -25,11 +25,10 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
 /**
  * Dictionary of a single long value.
  */
-public class ConstantValueLongDictionary extends BaseImmutableDictionary {
+public class ConstantValueLongDictionary extends BaseConstantValueDictionary {
   private final long _value;
 
   public ConstantValueLongDictionary(long value) {
-    super(1);
     _value = value;
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/ConstantValueStringDictionary.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/ConstantValueStringDictionary.java
@@ -23,21 +23,19 @@ import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.List;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
+import org.apache.pinot.spi.utils.Utf8Utils;
 
 
 /**
  * Dictionary of a single string value.
  */
-public class ConstantValueStringDictionary extends BaseImmutableDictionary {
+public class ConstantValueStringDictionary extends BaseConstantValueDictionary {
   private final String _value;
   private final byte[] _bytes;
 
   public ConstantValueStringDictionary(String value) {
-    super(1);
     _value = value;
-    _bytes = value.getBytes(UTF_8);
+    _bytes = Utf8Utils.encode(value);
   }
 
   @Override
@@ -75,6 +73,21 @@ public class ConstantValueStringDictionary extends BaseImmutableDictionary {
   @Override
   public String[] getSortedValues() {
     return new String[]{_value};
+  }
+
+  @Override
+  public int getLengthOfShortestElement() {
+    return _bytes.length;
+  }
+
+  @Override
+  public int getLengthOfLongestElement() {
+    return _bytes.length;
+  }
+
+  @Override
+  public boolean isAscii() {
+    return _bytes.length == _value.length();
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/DocIdDictionary.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/DocIdDictionary.java
@@ -26,11 +26,16 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
  * DocId dictionary for the segment
  */
 public class DocIdDictionary extends BaseImmutableDictionary {
-  final int _numDocs;
+  private final int _numDocs;
 
   public DocIdDictionary(int numDocs) {
     super(numDocs);
     _numDocs = numDocs;
+  }
+
+  @Override
+  public DataType getValueType() {
+    return DataType.INT;
   }
 
   @Override
@@ -47,12 +52,7 @@ public class DocIdDictionary extends BaseImmutableDictionary {
 
   @Override
   public int indexOf(int value) {
-    return insertionIndexOf(Integer.toString(value));
-  }
-
-  @Override
-  public DataType getValueType() {
-    return DataType.INT;
+    return (value >= 0 && value < _numDocs) ? value : NULL_VALUE_INDEX;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/FixedIntArrayOffHeapIdMap.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/FixedIntArrayOffHeapIdMap.java
@@ -127,11 +127,6 @@ public class FixedIntArrayOffHeapIdMap extends BaseOffHeapMutableDictionary impl
   }
 
   @Override
-  public Object getSortedValues() {
-    throw new UnsupportedOperationException();
-  }
-
-  @Override
   public DataType getValueType() {
     throw new UnsupportedOperationException();
   }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/converter/stats/MutableColumnStatisticsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/converter/stats/MutableColumnStatisticsTest.java
@@ -18,24 +18,45 @@
  */
 package org.apache.pinot.segment.local.realtime.converter.stats;
 
-import com.google.common.base.Utf8;
 import java.math.BigDecimal;
-import java.nio.charset.StandardCharsets;
-import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.pinot.segment.local.PinotBuffersAfterClassCheckRule;
+import org.apache.pinot.segment.local.io.writer.impl.DirectMemoryManager;
+import org.apache.pinot.segment.local.realtime.impl.dictionary.BigDecimalOffHeapMutableDictionary;
+import org.apache.pinot.segment.local.realtime.impl.dictionary.BigDecimalOnHeapMutableDictionary;
+import org.apache.pinot.segment.local.realtime.impl.dictionary.BytesOffHeapMutableDictionary;
+import org.apache.pinot.segment.local.realtime.impl.dictionary.BytesOnHeapMutableDictionary;
+import org.apache.pinot.segment.local.realtime.impl.dictionary.DoubleOffHeapMutableDictionary;
+import org.apache.pinot.segment.local.realtime.impl.dictionary.DoubleOnHeapMutableDictionary;
+import org.apache.pinot.segment.local.realtime.impl.dictionary.FloatOffHeapMutableDictionary;
+import org.apache.pinot.segment.local.realtime.impl.dictionary.FloatOnHeapMutableDictionary;
+import org.apache.pinot.segment.local.realtime.impl.dictionary.IntOffHeapMutableDictionary;
+import org.apache.pinot.segment.local.realtime.impl.dictionary.IntOnHeapMutableDictionary;
+import org.apache.pinot.segment.local.realtime.impl.dictionary.LongOffHeapMutableDictionary;
+import org.apache.pinot.segment.local.realtime.impl.dictionary.LongOnHeapMutableDictionary;
+import org.apache.pinot.segment.local.realtime.impl.dictionary.StringOffHeapMutableDictionary;
+import org.apache.pinot.segment.local.realtime.impl.dictionary.StringOnHeapMutableDictionary;
+import org.apache.pinot.segment.local.segment.index.readers.ConstantValueBigDecimalDictionary;
+import org.apache.pinot.segment.local.segment.index.readers.ConstantValueBytesDictionary;
+import org.apache.pinot.segment.local.segment.index.readers.ConstantValueDoubleDictionary;
+import org.apache.pinot.segment.local.segment.index.readers.ConstantValueFloatDictionary;
+import org.apache.pinot.segment.local.segment.index.readers.ConstantValueIntDictionary;
+import org.apache.pinot.segment.local.segment.index.readers.ConstantValueLongDictionary;
+import org.apache.pinot.segment.local.segment.index.readers.ConstantValueStringDictionary;
 import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.segment.spi.datasource.DataSourceMetadata;
+import org.apache.pinot.segment.spi.index.mutable.MutableDictionary;
 import org.apache.pinot.segment.spi.index.mutable.MutableForwardIndex;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
+import org.apache.pinot.segment.spi.memory.PinotDataBufferMemoryManager;
 import org.apache.pinot.spi.data.DimensionFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.BigDecimalUtils;
 import org.apache.pinot.spi.utils.ByteArray;
-import org.apache.pinot.spi.utils.Utf8Utils;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -45,730 +66,593 @@ import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
 
-/// Tests for [MutableColumnStatistics], covering all value types, SV/MV, sorted/unsorted,
-/// element lengths, and isAscii.
+/// Tests for [MutableColumnStatistics] with real dictionary implementations: on-heap mutable,
+/// off-heap mutable, and constant-value dictionaries.
+///
+/// Each test simulates the real ingestion flow: a value is first indexed into the dictionary
+/// (which returns a dictId), then that dictId is written into the forward index. Values may
+/// repeat across rows — the dictionary deduplicates and returns the same dictId.
 @SuppressWarnings("rawtypes")
-public class MutableColumnStatisticsTest {
+public class MutableColumnStatisticsTest implements PinotBuffersAfterClassCheckRule {
+  private static final int EST_CARDINALITY = 10;
 
-  // ======== Fixed-width SV sorted ========
+  private final PinotDataBufferMemoryManager _memoryManager =
+      new DirectMemoryManager(MutableColumnStatisticsTest.class.getName());
+
+  // ======== Data providers ========
+
+  @DataProvider(name = "mutableDictTypes")
+  public Object[][] mutableDictTypes() {
+    return new Object[][]{{"onHeap"}, {"offHeap"}};
+  }
+
+  @DataProvider(name = "fixedWidthMutableCases")
+  public Object[][] fixedWidthMutableCases() {
+    DataType[] types = {DataType.INT, DataType.LONG, DataType.FLOAT, DataType.DOUBLE};
+    Object[][] cases = new Object[types.length * 2][2];
+    int i = 0;
+    for (DataType type : types) {
+      cases[i++] = new Object[]{type, "onHeap"};
+      cases[i++] = new Object[]{type, "offHeap"};
+    }
+    return cases;
+  }
 
   @DataProvider(name = "fixedWidthTypes")
   public Object[][] fixedWidthTypes() {
     return new Object[][]{{DataType.INT}, {DataType.LONG}, {DataType.FLOAT}, {DataType.DOUBLE}};
   }
 
+  // ======== Fixed-width SV sorted (onHeap / offHeap) ========
+
+  @Test(dataProvider = "fixedWidthMutableCases")
+  public void testFixedWidthSvSorted(DataType type, String dictType)
+      throws Exception {
+    Comparable[] sorted = fixedWidthSortedValues(type);
+    int typeSize = type.size();
+
+    try (MutableDictionary dictionary = createMutableDictionary(type, dictType)) {
+      // Simulate 5 rows arriving out of order, with duplicates
+      int dictId0 = dictionary.index(sorted[2]);
+      int dictId1 = dictionary.index(sorted[0]);
+      int dictId2 = dictionary.index(sorted[1]);
+      int dictId3 = dictionary.index(sorted[0]); // duplicate
+      int dictId4 = dictionary.index(sorted[2]); // duplicate
+      assertEquals(dictId3, dictId1); // same dictId for same value
+      assertEquals(dictId4, dictId0);
+
+      int numDocs = 5;
+      // Forward index stores dictIds in row arrival order
+      MutableForwardIndex forwardIndex = mockSvForwardIndex(dictId0, dictId1, dictId2, dictId3, dictId4);
+      DataSourceMetadata metadata = mockMetadata(type, true, numDocs);
+      when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(0);
+      when(metadata.getMaxRowLengthInBytes()).thenReturn(typeSize);
+
+      // sortedDocIds reorders to value-sorted: doc1(sorted[0]), doc3(sorted[0]),
+      // doc2(sorted[1]), doc0(sorted[2]), doc4(sorted[2])
+      MutableColumnStatistics stats =
+          new MutableColumnStatistics(mockDataSource(metadata, forwardIndex, dictionary),
+              new int[]{1, 3, 2, 0, 4}, false);
+
+      assertEquals(stats.getMinValue(), sorted[0]);
+      assertEquals(stats.getMaxValue(), sorted[2]);
+      assertNotNull(stats.getUniqueValuesSet());
+      assertEquals(stats.getCardinality(), 3);
+      assertEquals(stats.getLengthOfShortestElement(), typeSize);
+      assertEquals(stats.getLengthOfLongestElement(), typeSize);
+      assertTrue(stats.isFixedLength());
+      assertFalse(stats.isAscii());
+      assertTrue(stats.isSorted());
+      assertEquals(stats.getMaxNumberOfMultiValues(), 0);
+      assertEquals(stats.getMaxRowLengthInBytes(), typeSize);
+    }
+  }
+
+  // ======== Fixed-width constant value ========
+
   @Test(dataProvider = "fixedWidthTypes")
-  public void testFixedWidthSvSorted(DataType type) {
-    int numDocs = 3;
-    Comparable[] values = fixedWidthValues(type);
+  public void testFixedWidthConstantValue(DataType type)
+      throws Exception {
+    Comparable value = fixedWidthSortedValues(type)[1];
+    int typeSize = type.size();
 
-    Dictionary dictionary = mock(Dictionary.class);
-    when(dictionary.getValueType()).thenReturn(type);
-    when(dictionary.length()).thenReturn(3);
-    when(dictionary.getMinVal()).thenReturn(values[0]);
-    when(dictionary.getMaxVal()).thenReturn(values[2]);
-    when(dictionary.getSortedValues()).thenReturn(values);
-    when(dictionary.compare(0, 1)).thenReturn(-1);
-    when(dictionary.compare(1, 2)).thenReturn(-1);
+    try (Dictionary dictionary = createConstantValueDictionary(type, value)) {
+      MutableForwardIndex forwardIndex = mockSvForwardIndex(0, 0, 0);
+      DataSourceMetadata metadata = mockMetadata(type, true, 3);
+      when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(0);
+      when(metadata.getMaxRowLengthInBytes()).thenReturn(typeSize);
 
-    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
-    when(forwardIndex.isSingleValue()).thenReturn(true);
-    when(forwardIndex.getDictId(0)).thenReturn(0);
-    when(forwardIndex.getDictId(1)).thenReturn(1);
-    when(forwardIndex.getDictId(2)).thenReturn(2);
+      MutableColumnStatistics stats =
+          new MutableColumnStatistics(mockDataSource(metadata, forwardIndex, dictionary), null, false);
 
-    DataSourceMetadata metadata = mockMetadata(type, true, numDocs);
-    when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(0);
-    when(metadata.getMaxRowLengthInBytes()).thenReturn(type.size());
-
-    MutableColumnStatistics stats =
-        new MutableColumnStatistics(mockDataSource(metadata, forwardIndex, dictionary), null, false);
-
-    assertEquals(stats.getMinValue(), values[0]);
-    assertEquals(stats.getMaxValue(), values[2]);
-    assertNotNull(stats.getUniqueValuesSet());
-    assertEquals(stats.getCardinality(), 3);
-    assertEquals(stats.getLengthOfShortestElement(), type.size());
-    assertEquals(stats.getLengthOfLongestElement(), type.size());
-    assertTrue(stats.isFixedLength());
-    assertFalse(stats.isAscii());
-    assertTrue(stats.isSorted());
-    assertEquals(stats.getMaxNumberOfMultiValues(), 0);
-    assertEquals(stats.getMaxRowLengthInBytes(), type.size());
+      assertEquals(stats.getMinValue(), value);
+      assertEquals(stats.getMaxValue(), value);
+      assertEquals(stats.getCardinality(), 1);
+      assertEquals(stats.getLengthOfShortestElement(), typeSize);
+      assertEquals(stats.getLengthOfLongestElement(), typeSize);
+      assertTrue(stats.isFixedLength());
+      assertFalse(stats.isAscii());
+      assertTrue(stats.isSorted());
+    }
   }
 
   // ======== BigDecimal SV ========
 
-  @Test
-  public void testBigDecimalSv() {
-    BigDecimal v0 = new BigDecimal("10.5");
-    BigDecimal v1 = new BigDecimal("20.75");
-    int numDocs = 2;
+  @Test(dataProvider = "mutableDictTypes")
+  public void testBigDecimalSv(String dictType)
+      throws Exception {
+    BigDecimal min = new BigDecimal("10.5");
+    BigDecimal max = new BigDecimal("20.75");
 
-    Dictionary dictionary = mock(Dictionary.class);
-    when(dictionary.getValueType()).thenReturn(DataType.BIG_DECIMAL);
-    when(dictionary.length()).thenReturn(2);
-    when(dictionary.getMinVal()).thenReturn(v0);
-    when(dictionary.getMaxVal()).thenReturn(v1);
-    when(dictionary.compare(0, 1)).thenReturn(-1);
-    when(dictionary.getValueSize(0)).thenReturn(BigDecimalUtils.byteSize(v0));
-    when(dictionary.getValueSize(1)).thenReturn(BigDecimalUtils.byteSize(v1));
+    try (MutableDictionary dictionary = createMutableDictionary(DataType.BIG_DECIMAL, dictType)) {
+      // Rows arrive out of order with duplicates
+      int dictId0 = dictionary.index(max);
+      int dictId1 = dictionary.index(min);
+      int dictId2 = dictionary.index(max); // duplicate
+      int dictId3 = dictionary.index(min); // duplicate
+      assertEquals(dictId2, dictId0);
+      assertEquals(dictId3, dictId1);
 
-    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
-    when(forwardIndex.isSingleValue()).thenReturn(true);
-    when(forwardIndex.getDictId(0)).thenReturn(0);
-    when(forwardIndex.getDictId(1)).thenReturn(1);
+      // Forward index stores dictIds in row arrival order
+      MutableForwardIndex forwardIndex = mockSvForwardIndex(dictId0, dictId1, dictId2, dictId3);
+      DataSourceMetadata metadata = mockMetadata(DataType.BIG_DECIMAL, true, 4);
+      when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(0);
+      when(metadata.getMaxRowLengthInBytes()).thenReturn(BigDecimalUtils.byteSize(max));
 
-    DataSourceMetadata metadata = mockMetadata(DataType.BIG_DECIMAL, true, numDocs);
-    when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(0);
-    when(metadata.getMaxRowLengthInBytes()).thenReturn(BigDecimalUtils.byteSize(v1));
+      // sortedDocIds: doc1(min), doc3(min), doc0(max), doc2(max)
+      MutableColumnStatistics stats =
+          new MutableColumnStatistics(mockDataSource(metadata, forwardIndex, dictionary),
+              new int[]{1, 3, 0, 2}, false);
 
-    MutableColumnStatistics stats =
-        new MutableColumnStatistics(mockDataSource(metadata, forwardIndex, dictionary), null, false);
-
-    assertEquals(stats.getMinValue(), v0);
-    assertEquals(stats.getMaxValue(), v1);
-    assertEquals(stats.getLengthOfShortestElement(), BigDecimalUtils.byteSize(v0));
-    assertEquals(stats.getLengthOfLongestElement(), BigDecimalUtils.byteSize(v1));
-    assertFalse(stats.isAscii());
-    assertTrue(stats.isSorted());
+      assertEquals(stats.getMinValue(), min);
+      assertEquals(stats.getMaxValue(), max);
+      assertEquals(stats.getLengthOfShortestElement(), BigDecimalUtils.byteSize(min));
+      assertEquals(stats.getLengthOfLongestElement(), BigDecimalUtils.byteSize(max));
+      assertFalse(stats.isAscii());
+      assertTrue(stats.isSorted());
+    }
   }
 
-  // ======== Boolean SV ========
-
   @Test
-  public void testBooleanSvSorted() {
-    int numDocs = 2;
+  public void testBigDecimalConstantValue()
+      throws Exception {
+    BigDecimal value = new BigDecimal("10.5");
+    int byteSize = BigDecimalUtils.byteSize(value);
 
-    Dictionary dictionary = mock(Dictionary.class);
-    when(dictionary.getValueType()).thenReturn(DataType.INT);
-    when(dictionary.length()).thenReturn(2);
-    when(dictionary.getMinVal()).thenReturn(0);
-    when(dictionary.getMaxVal()).thenReturn(1);
-    when(dictionary.getSortedValues()).thenReturn(new Comparable[]{0, 1});
-    when(dictionary.compare(0, 1)).thenReturn(-1);
+    try (Dictionary dictionary = new ConstantValueBigDecimalDictionary(value)) {
+      MutableForwardIndex forwardIndex = mockSvForwardIndex(0, 0);
+      DataSourceMetadata metadata = mockMetadata(DataType.BIG_DECIMAL, true, 2);
+      when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(0);
+      when(metadata.getMaxRowLengthInBytes()).thenReturn(byteSize);
 
-    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
-    when(forwardIndex.isSingleValue()).thenReturn(true);
-    when(forwardIndex.getDictId(0)).thenReturn(0);
-    when(forwardIndex.getDictId(1)).thenReturn(1);
+      MutableColumnStatistics stats =
+          new MutableColumnStatistics(mockDataSource(metadata, forwardIndex, dictionary), null, false);
 
-    DataSourceMetadata metadata = mockMetadata(DataType.BOOLEAN, true, numDocs);
-    when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(0);
-    when(metadata.getMaxRowLengthInBytes()).thenReturn(Integer.BYTES);
-
-    MutableColumnStatistics stats =
-        new MutableColumnStatistics(mockDataSource(metadata, forwardIndex, dictionary), null, false);
-
-    assertEquals(stats.getMinValue(), 0);
-    assertEquals(stats.getMaxValue(), 1);
-    assertNotNull(stats.getUniqueValuesSet());
-    assertEquals(stats.getCardinality(), 2);
-    assertEquals(stats.getLengthOfShortestElement(), Integer.BYTES);
-    assertEquals(stats.getLengthOfLongestElement(), Integer.BYTES);
-    assertTrue(stats.isFixedLength());
-    assertFalse(stats.isAscii());
-    assertTrue(stats.isSorted());
-    assertEquals(stats.getMaxNumberOfMultiValues(), 0);
-    assertEquals(stats.getMaxRowLengthInBytes(), Integer.BYTES);
-  }
-
-  // ======== Timestamp SV ========
-
-  @Test
-  public void testTimestampSvSorted() {
-    int numDocs = 2;
-
-    Dictionary dictionary = mock(Dictionary.class);
-    when(dictionary.getValueType()).thenReturn(DataType.LONG);
-    when(dictionary.length()).thenReturn(2);
-    when(dictionary.getMinVal()).thenReturn(1000L);
-    when(dictionary.getMaxVal()).thenReturn(2000L);
-    when(dictionary.getSortedValues()).thenReturn(new Comparable[]{1000L, 2000L});
-    when(dictionary.compare(0, 1)).thenReturn(-1);
-
-    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
-    when(forwardIndex.isSingleValue()).thenReturn(true);
-    when(forwardIndex.getDictId(0)).thenReturn(0);
-    when(forwardIndex.getDictId(1)).thenReturn(1);
-
-    DataSourceMetadata metadata = mockMetadata(DataType.TIMESTAMP, true, numDocs);
-    when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(0);
-    when(metadata.getMaxRowLengthInBytes()).thenReturn(Long.BYTES);
-
-    MutableColumnStatistics stats =
-        new MutableColumnStatistics(mockDataSource(metadata, forwardIndex, dictionary), null, false);
-
-    assertEquals(stats.getMinValue(), 1000L);
-    assertEquals(stats.getMaxValue(), 2000L);
-    assertNotNull(stats.getUniqueValuesSet());
-    assertEquals(stats.getCardinality(), 2);
-    assertEquals(stats.getLengthOfShortestElement(), Long.BYTES);
-    assertEquals(stats.getLengthOfLongestElement(), Long.BYTES);
-    assertTrue(stats.isFixedLength());
-    assertFalse(stats.isAscii());
-    assertTrue(stats.isSorted());
-    assertEquals(stats.getMaxNumberOfMultiValues(), 0);
-    assertEquals(stats.getMaxRowLengthInBytes(), Long.BYTES);
+      assertEquals(stats.getMinValue(), value);
+      assertEquals(stats.getMaxValue(), value);
+      assertEquals(stats.getLengthOfShortestElement(), byteSize);
+      assertEquals(stats.getLengthOfLongestElement(), byteSize);
+      assertTrue(stats.isFixedLength());
+      assertFalse(stats.isAscii());
+    }
   }
 
   // ======== String SV ========
 
-  @Test
-  public void testStringSvAscii() {
-    int numDocs = 2;
-    Dictionary dictionary = mock(Dictionary.class);
-    when(dictionary.getValueType()).thenReturn(DataType.STRING);
-    when(dictionary.length()).thenReturn(2);
-    when(dictionary.getMinVal()).thenReturn("apple");
-    when(dictionary.getMaxVal()).thenReturn("banana");
-    when(dictionary.getSortedValues()).thenReturn(new String[]{"apple", "banana"});
-    when(dictionary.compare(0, 1)).thenReturn(-1);
-    // For element length scanning: getBytesValue returns UTF-8 bytes, getValueSize returns byte length
-    when(dictionary.getBytesValue(0)).thenReturn("apple".getBytes(StandardCharsets.UTF_8));
-    when(dictionary.getBytesValue(1)).thenReturn("banana".getBytes(StandardCharsets.UTF_8));
-    when(dictionary.getValueSize(0)).thenReturn(5);
-    when(dictionary.getValueSize(1)).thenReturn(6);
+  @Test(dataProvider = "mutableDictTypes")
+  public void testStringSvAscii(String dictType)
+      throws Exception {
+    try (MutableDictionary dictionary = createMutableDictionary(DataType.STRING, dictType)) {
+      // Rows arrive out of order with duplicates
+      int dictId0 = dictionary.index("banana");
+      int dictId1 = dictionary.index("apple");
+      int dictId2 = dictionary.index("banana"); // duplicate
+      int dictId3 = dictionary.index("apple"); // duplicate
+      assertEquals(dictId2, dictId0);
+      assertEquals(dictId3, dictId1);
 
-    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
-    when(forwardIndex.isSingleValue()).thenReturn(true);
-    when(forwardIndex.getDictId(0)).thenReturn(0);
-    when(forwardIndex.getDictId(1)).thenReturn(1);
+      // Forward index stores dictIds in row arrival order
+      MutableForwardIndex forwardIndex = mockSvForwardIndex(dictId0, dictId1, dictId2, dictId3);
+      DataSourceMetadata metadata = mockMetadata(DataType.STRING, true, 4);
+      when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(0);
+      when(metadata.getMaxRowLengthInBytes()).thenReturn(6);
 
-    DataSourceMetadata metadata = mockMetadata(DataType.STRING, true, numDocs);
-    when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(0);
-    when(metadata.getMaxRowLengthInBytes()).thenReturn(6);
+      // sortedDocIds: doc1(apple), doc3(apple), doc0(banana), doc2(banana)
+      MutableColumnStatistics stats =
+          new MutableColumnStatistics(mockDataSource(metadata, forwardIndex, dictionary),
+              new int[]{1, 3, 0, 2}, false);
 
-    MutableColumnStatistics stats =
-        new MutableColumnStatistics(mockDataSource(metadata, forwardIndex, dictionary), null, false);
+      assertEquals(stats.getMinValue(), "apple");
+      assertEquals(stats.getMaxValue(), "banana");
+      assertEquals(stats.getLengthOfShortestElement(), 5);
+      assertEquals(stats.getLengthOfLongestElement(), 6);
+      assertFalse(stats.isFixedLength());
+      assertTrue(stats.isAscii());
+      assertTrue(stats.isSorted());
+    }
+  }
 
-    assertEquals(stats.getMinValue(), "apple");
-    assertEquals(stats.getMaxValue(), "banana");
-    assertEquals(stats.getLengthOfShortestElement(), 5);
-    assertEquals(stats.getLengthOfLongestElement(), 6);
-    assertFalse(stats.isFixedLength());
-    assertTrue(stats.isAscii());
-    assertTrue(stats.isSorted());
+  @Test(dataProvider = "mutableDictTypes")
+  public void testStringSvNonAscii(String dictType)
+      throws Exception {
+    try (MutableDictionary dictionary = createMutableDictionary(DataType.STRING, dictType)) {
+      // Rows arrive with non-ASCII and duplicates
+      int dictId0 = dictionary.index("héllo"); // non-ASCII, 6 UTF-8 bytes
+      int dictId1 = dictionary.index("hello");
+      int dictId2 = dictionary.index("héllo"); // duplicate
+      assertEquals(dictId2, dictId0);
+
+      // Forward index in arrival order
+      MutableForwardIndex forwardIndex = mockSvForwardIndex(dictId0, dictId1, dictId2);
+      DataSourceMetadata metadata = mockMetadata(DataType.STRING, true, 3);
+      when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(0);
+      when(metadata.getMaxRowLengthInBytes()).thenReturn(6);
+
+      MutableColumnStatistics stats =
+          new MutableColumnStatistics(mockDataSource(metadata, forwardIndex, dictionary), null, false);
+
+      assertFalse(stats.isAscii());
+    }
   }
 
   @Test
-  public void testStringSvNonAscii() {
-    int numDocs = 2;
+  public void testStringConstantValueAscii()
+      throws Exception {
+    try (Dictionary dictionary = new ConstantValueStringDictionary("hello")) {
+      MutableForwardIndex forwardIndex = mockSvForwardIndex(0, 0);
+      DataSourceMetadata metadata = mockMetadata(DataType.STRING, true, 2);
+      when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(0);
+      when(metadata.getMaxRowLengthInBytes()).thenReturn(5);
+
+      MutableColumnStatistics stats =
+          new MutableColumnStatistics(mockDataSource(metadata, forwardIndex, dictionary), null, false);
+
+      assertEquals(stats.getMinValue(), "hello");
+      assertEquals(stats.getMaxValue(), "hello");
+      assertEquals(stats.getLengthOfShortestElement(), 5);
+      assertEquals(stats.getLengthOfLongestElement(), 5);
+      assertTrue(stats.isFixedLength());
+      assertTrue(stats.isAscii());
+    }
+  }
+
+  @Test
+  public void testStringConstantValueNonAscii()
+      throws Exception {
     String nonAscii = "héllo";
-    byte[] nonAsciiBytes = nonAscii.getBytes(StandardCharsets.UTF_8);
 
-    Dictionary dictionary = mock(Dictionary.class);
-    when(dictionary.getValueType()).thenReturn(DataType.STRING);
-    when(dictionary.length()).thenReturn(2);
-    when(dictionary.getMinVal()).thenReturn("hello");
-    when(dictionary.getMaxVal()).thenReturn(nonAscii);
-    when(dictionary.compare(0, 1)).thenReturn(-1);
-    when(dictionary.getBytesValue(0)).thenReturn("hello".getBytes(StandardCharsets.UTF_8));
-    when(dictionary.getBytesValue(1)).thenReturn(nonAsciiBytes);
-    when(dictionary.getValueSize(0)).thenReturn(5);
-    when(dictionary.getValueSize(1)).thenReturn(nonAsciiBytes.length);
+    try (Dictionary dictionary = new ConstantValueStringDictionary(nonAscii)) {
+      MutableForwardIndex forwardIndex = mockSvForwardIndex(0, 0);
+      DataSourceMetadata metadata = mockMetadata(DataType.STRING, true, 2);
+      when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(0);
+      when(metadata.getMaxRowLengthInBytes()).thenReturn(6);
 
-    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
-    when(forwardIndex.isSingleValue()).thenReturn(true);
-    when(forwardIndex.getDictId(0)).thenReturn(0);
-    when(forwardIndex.getDictId(1)).thenReturn(1);
+      MutableColumnStatistics stats =
+          new MutableColumnStatistics(mockDataSource(metadata, forwardIndex, dictionary), null, false);
 
-    DataSourceMetadata metadata = mockMetadata(DataType.STRING, true, numDocs);
-    when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(0);
-    when(metadata.getMaxRowLengthInBytes()).thenReturn(nonAsciiBytes.length);
-
-    MutableColumnStatistics stats =
-        new MutableColumnStatistics(mockDataSource(metadata, forwardIndex, dictionary), null, false);
-
-    assertFalse(stats.isAscii());
-  }
-
-  // ======== JSON SV ========
-
-  @Test
-  public void testJsonSvSorted() {
-    int numDocs = 2;
-    String v0 = "null";
-    String v1 = "{\"a\":1}";
-
-    Dictionary dictionary = mock(Dictionary.class);
-    when(dictionary.getValueType()).thenReturn(DataType.STRING);
-    when(dictionary.length()).thenReturn(2);
-    when(dictionary.getMinVal()).thenReturn(v0);
-    when(dictionary.getMaxVal()).thenReturn(v1);
-    when(dictionary.getSortedValues()).thenReturn(new Comparable[]{v0, v1});
-    when(dictionary.compare(0, 1)).thenReturn(-1);
-    when(dictionary.getBytesValue(0)).thenReturn(v0.getBytes(StandardCharsets.UTF_8));
-    when(dictionary.getBytesValue(1)).thenReturn(v1.getBytes(StandardCharsets.UTF_8));
-    when(dictionary.getValueSize(0)).thenReturn(4);
-    when(dictionary.getValueSize(1)).thenReturn(7);
-
-    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
-    when(forwardIndex.isSingleValue()).thenReturn(true);
-    when(forwardIndex.getDictId(0)).thenReturn(0);
-    when(forwardIndex.getDictId(1)).thenReturn(1);
-
-    DataSourceMetadata metadata = mockMetadata(DataType.JSON, true, numDocs);
-    when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(0);
-    when(metadata.getMaxRowLengthInBytes()).thenReturn(7);
-
-    MutableColumnStatistics stats =
-        new MutableColumnStatistics(mockDataSource(metadata, forwardIndex, dictionary), null, false);
-
-    assertEquals(stats.getMinValue(), v0);
-    assertEquals(stats.getMaxValue(), v1);
-    assertEquals(stats.getLengthOfShortestElement(), 4);
-    assertEquals(stats.getLengthOfLongestElement(), 7);
-    assertFalse(stats.isFixedLength());
-    assertTrue(stats.isAscii());
-    assertTrue(stats.isSorted());
+      assertFalse(stats.isAscii());
+      assertEquals(stats.getLengthOfShortestElement(), 6);
+      assertEquals(stats.getLengthOfLongestElement(), 6);
+    }
   }
 
   // ======== Bytes SV ========
 
-  @Test
-  public void testBytesSv() {
-    int numDocs = 2;
-    ByteArray ba0 = new ByteArray(new byte[]{1, 2});
-    ByteArray ba1 = new ByteArray(new byte[]{3, 4, 5});
-
-    Dictionary dictionary = mock(Dictionary.class);
-    when(dictionary.getValueType()).thenReturn(DataType.BYTES);
-    when(dictionary.length()).thenReturn(2);
-    when(dictionary.getMinVal()).thenReturn(ba0);
-    when(dictionary.getMaxVal()).thenReturn(ba1);
-    when(dictionary.compare(0, 1)).thenReturn(-1);
-    when(dictionary.getValueSize(0)).thenReturn(2);
-    when(dictionary.getValueSize(1)).thenReturn(3);
-
-    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
-    when(forwardIndex.isSingleValue()).thenReturn(true);
-    when(forwardIndex.getDictId(0)).thenReturn(0);
-    when(forwardIndex.getDictId(1)).thenReturn(1);
-
-    DataSourceMetadata metadata = mockMetadata(DataType.BYTES, true, numDocs);
-    when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(0);
-    when(metadata.getMaxRowLengthInBytes()).thenReturn(3);
-
-    MutableColumnStatistics stats =
-        new MutableColumnStatistics(mockDataSource(metadata, forwardIndex, dictionary), null, false);
-
-    assertEquals(stats.getMinValue(), ba0);
-    assertEquals(stats.getMaxValue(), ba1);
-    assertEquals(stats.getLengthOfShortestElement(), 2);
-    assertEquals(stats.getLengthOfLongestElement(), 3);
-    assertFalse(stats.isFixedLength());
-    assertFalse(stats.isAscii());
-    assertTrue(stats.isSorted());
-  }
-
-  // ======== Sorted / unsorted / sortedColumnFlag ========
-
-  @Test
-  public void testIntSvUnsorted() {
-    int numDocs = 3;
-    Dictionary dictionary = mock(Dictionary.class);
-    when(dictionary.getValueType()).thenReturn(DataType.INT);
-    when(dictionary.length()).thenReturn(3);
-    when(dictionary.getMinVal()).thenReturn(10);
-    when(dictionary.getMaxVal()).thenReturn(30);
-
-    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
-    when(forwardIndex.isSingleValue()).thenReturn(true);
-    // doc0→dictId2(30), doc1→dictId0(10), doc2→dictId1(20) — unsorted
-    when(forwardIndex.getDictId(0)).thenReturn(2);
-    when(forwardIndex.getDictId(1)).thenReturn(0);
-    when(forwardIndex.getDictId(2)).thenReturn(1);
-    when(dictionary.compare(2, 0)).thenReturn(1); // 30 > 10 — unsorted at doc1
-
-    DataSourceMetadata metadata = mockMetadata(DataType.INT, true, numDocs);
-    when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(0);
-    when(metadata.getMaxRowLengthInBytes()).thenReturn(Integer.BYTES);
-
-    MutableColumnStatistics stats =
-        new MutableColumnStatistics(mockDataSource(metadata, forwardIndex, dictionary), null, false);
-
-    assertFalse(stats.isSorted());
-  }
-
-  @Test
-  public void testIntSvSortedColumnFlag() {
-    int numDocs = 2;
-    Dictionary dictionary = mock(Dictionary.class);
-    when(dictionary.getValueType()).thenReturn(DataType.INT);
-    when(dictionary.length()).thenReturn(2);
-
-    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
-    when(forwardIndex.isSingleValue()).thenReturn(true);
-
-    DataSourceMetadata metadata = mockMetadata(DataType.INT, true, numDocs);
-    when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(0);
-    when(metadata.getMaxRowLengthInBytes()).thenReturn(Integer.BYTES);
-
-    MutableColumnStatistics stats =
-        new MutableColumnStatistics(mockDataSource(metadata, forwardIndex, dictionary), null, true);
-
-    assertTrue(stats.isSorted()); // isSortedColumn=true overrides scan
-  }
-
-  @Test
-  public void testIntSvSortedWithSortedDocIds() {
-    int numDocs = 3;
-    Dictionary dictionary = mock(Dictionary.class);
-    when(dictionary.getValueType()).thenReturn(DataType.INT);
-    when(dictionary.length()).thenReturn(3);
-    when(dictionary.getMinVal()).thenReturn(10);
-    when(dictionary.getMaxVal()).thenReturn(30);
-
-    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
-    when(forwardIndex.isSingleValue()).thenReturn(true);
-    // sortedDocIds=[2,0,1]: doc2→dictId0(10), doc0→dictId1(20), doc1→dictId2(30) → sorted
-    when(forwardIndex.getDictId(2)).thenReturn(0);
-    when(forwardIndex.getDictId(0)).thenReturn(1);
-    when(forwardIndex.getDictId(1)).thenReturn(2);
-    when(dictionary.compare(0, 1)).thenReturn(-1);
-    when(dictionary.compare(1, 2)).thenReturn(-1);
-
-    DataSourceMetadata metadata = mockMetadata(DataType.INT, true, numDocs);
-    when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(0);
-    when(metadata.getMaxRowLengthInBytes()).thenReturn(Integer.BYTES);
-
-    MutableColumnStatistics stats =
-        new MutableColumnStatistics(mockDataSource(metadata, forwardIndex, dictionary),
-            new int[]{2, 0, 1}, false);
-
-    assertTrue(stats.isSorted());
-  }
-
-  // ======== MV ========
-
-  @Test
-  public void testIntMv() {
-    int numDocs = 2;
-    Dictionary dictionary = mock(Dictionary.class);
-    when(dictionary.getValueType()).thenReturn(DataType.INT);
-    when(dictionary.length()).thenReturn(3);
-    when(dictionary.getMinVal()).thenReturn(10);
-    when(dictionary.getMaxVal()).thenReturn(30);
-
-    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
-    when(forwardIndex.isSingleValue()).thenReturn(false);
-
-    DataSourceMetadata metadata = mockMetadata(DataType.INT, false, numDocs);
-    when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(2);
-    when(metadata.getMaxRowLengthInBytes()).thenReturn(Integer.BYTES * 2);
-    when(metadata.getNumValues()).thenReturn(4);
-
-    MutableColumnStatistics stats =
-        new MutableColumnStatistics(mockDataSource(metadata, forwardIndex, dictionary), null, false);
-
-    assertFalse(stats.isSingleValue());
-    assertEquals(stats.getMinValue(), 10);
-    assertEquals(stats.getMaxValue(), 30);
-    assertEquals(stats.getCardinality(), 3);
-    assertEquals(stats.getLengthOfShortestElement(), Integer.BYTES);
-    assertEquals(stats.getLengthOfLongestElement(), Integer.BYTES);
-    assertTrue(stats.isFixedLength());
-    assertFalse(stats.isAscii());
-    assertFalse(stats.isSorted());
-    assertEquals(stats.getTotalNumberOfEntries(), 4);
-    assertEquals(stats.getMaxNumberOfMultiValues(), 2);
-  }
-
-  @Test
-  public void testLongMv() {
-    int numDocs = 2;
-    Dictionary dictionary = mock(Dictionary.class);
-    when(dictionary.getValueType()).thenReturn(DataType.LONG);
-    when(dictionary.length()).thenReturn(3);
-    when(dictionary.getMinVal()).thenReturn(100L);
-    when(dictionary.getMaxVal()).thenReturn(300L);
-
-    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
-    when(forwardIndex.isSingleValue()).thenReturn(false);
-
-    DataSourceMetadata metadata = mockMetadata(DataType.LONG, false, numDocs);
-    when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(2);
-    when(metadata.getMaxRowLengthInBytes()).thenReturn(Long.BYTES * 2);
-    when(metadata.getNumValues()).thenReturn(4);
-
-    MutableColumnStatistics stats =
-        new MutableColumnStatistics(mockDataSource(metadata, forwardIndex, dictionary), null, false);
-
-    assertFalse(stats.isSingleValue());
-    assertEquals(stats.getMinValue(), 100L);
-    assertEquals(stats.getMaxValue(), 300L);
-    assertEquals(stats.getCardinality(), 3);
-    assertEquals(stats.getLengthOfShortestElement(), Long.BYTES);
-    assertEquals(stats.getLengthOfLongestElement(), Long.BYTES);
-    assertTrue(stats.isFixedLength());
-    assertFalse(stats.isAscii());
-    assertFalse(stats.isSorted());
-    assertEquals(stats.getTotalNumberOfEntries(), 4);
-    assertEquals(stats.getMaxNumberOfMultiValues(), 2);
-  }
-
-  @Test
-  public void testFloatMv() {
-    int numDocs = 2;
-    Dictionary dictionary = mock(Dictionary.class);
-    when(dictionary.getValueType()).thenReturn(DataType.FLOAT);
-    when(dictionary.length()).thenReturn(3);
-    when(dictionary.getMinVal()).thenReturn(1.0f);
-    when(dictionary.getMaxVal()).thenReturn(3.0f);
-
-    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
-    when(forwardIndex.isSingleValue()).thenReturn(false);
-
-    DataSourceMetadata metadata = mockMetadata(DataType.FLOAT, false, numDocs);
-    when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(2);
-    when(metadata.getMaxRowLengthInBytes()).thenReturn(Float.BYTES * 2);
-    when(metadata.getNumValues()).thenReturn(4);
-
-    MutableColumnStatistics stats =
-        new MutableColumnStatistics(mockDataSource(metadata, forwardIndex, dictionary), null, false);
-
-    assertFalse(stats.isSingleValue());
-    assertEquals(stats.getMinValue(), 1.0f);
-    assertEquals(stats.getMaxValue(), 3.0f);
-    assertEquals(stats.getCardinality(), 3);
-    assertEquals(stats.getLengthOfShortestElement(), Float.BYTES);
-    assertEquals(stats.getLengthOfLongestElement(), Float.BYTES);
-    assertTrue(stats.isFixedLength());
-    assertFalse(stats.isAscii());
-    assertFalse(stats.isSorted());
-    assertEquals(stats.getTotalNumberOfEntries(), 4);
-    assertEquals(stats.getMaxNumberOfMultiValues(), 2);
-  }
-
-  @Test
-  public void testDoubleMv() {
-    int numDocs = 2;
-    Dictionary dictionary = mock(Dictionary.class);
-    when(dictionary.getValueType()).thenReturn(DataType.DOUBLE);
-    when(dictionary.length()).thenReturn(3);
-    when(dictionary.getMinVal()).thenReturn(1.0);
-    when(dictionary.getMaxVal()).thenReturn(3.0);
-
-    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
-    when(forwardIndex.isSingleValue()).thenReturn(false);
-
-    DataSourceMetadata metadata = mockMetadata(DataType.DOUBLE, false, numDocs);
-    when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(2);
-    when(metadata.getMaxRowLengthInBytes()).thenReturn(Double.BYTES * 2);
-    when(metadata.getNumValues()).thenReturn(4);
-
-    MutableColumnStatistics stats =
-        new MutableColumnStatistics(mockDataSource(metadata, forwardIndex, dictionary), null, false);
-
-    assertFalse(stats.isSingleValue());
-    assertEquals(stats.getMinValue(), 1.0);
-    assertEquals(stats.getMaxValue(), 3.0);
-    assertEquals(stats.getCardinality(), 3);
-    assertEquals(stats.getLengthOfShortestElement(), Double.BYTES);
-    assertEquals(stats.getLengthOfLongestElement(), Double.BYTES);
-    assertTrue(stats.isFixedLength());
-    assertFalse(stats.isAscii());
-    assertFalse(stats.isSorted());
-    assertEquals(stats.getTotalNumberOfEntries(), 4);
-    assertEquals(stats.getMaxNumberOfMultiValues(), 2);
-  }
-
-  @Test
-  public void testBooleanMv() {
-    int numDocs = 2;
-    Dictionary dictionary = mock(Dictionary.class);
-    when(dictionary.getValueType()).thenReturn(DataType.INT);
-    when(dictionary.length()).thenReturn(2);
-    when(dictionary.getMinVal()).thenReturn(0);
-    when(dictionary.getMaxVal()).thenReturn(1);
-
-    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
-    when(forwardIndex.isSingleValue()).thenReturn(false);
-
-    DataSourceMetadata metadata = mockMetadata(DataType.BOOLEAN, false, numDocs);
-    when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(2);
-    when(metadata.getMaxRowLengthInBytes()).thenReturn(Integer.BYTES * 2);
-    when(metadata.getNumValues()).thenReturn(3);
-
-    MutableColumnStatistics stats =
-        new MutableColumnStatistics(mockDataSource(metadata, forwardIndex, dictionary), null, false);
-
-    assertFalse(stats.isSingleValue());
-    assertEquals(stats.getMinValue(), 0);
-    assertEquals(stats.getMaxValue(), 1);
-    assertEquals(stats.getCardinality(), 2);
-    assertEquals(stats.getLengthOfShortestElement(), Integer.BYTES);
-    assertEquals(stats.getLengthOfLongestElement(), Integer.BYTES);
-    assertTrue(stats.isFixedLength());
-    assertFalse(stats.isAscii());
-    assertFalse(stats.isSorted());
-    assertEquals(stats.getTotalNumberOfEntries(), 3);
-    assertEquals(stats.getMaxNumberOfMultiValues(), 2);
-  }
-
-  @Test
-  public void testTimestampMv() {
-    int numDocs = 2;
-    Dictionary dictionary = mock(Dictionary.class);
-    when(dictionary.getValueType()).thenReturn(DataType.LONG);
-    when(dictionary.length()).thenReturn(2);
-    when(dictionary.getMinVal()).thenReturn(1000L);
-    when(dictionary.getMaxVal()).thenReturn(2000L);
-
-    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
-    when(forwardIndex.isSingleValue()).thenReturn(false);
-
-    DataSourceMetadata metadata = mockMetadata(DataType.TIMESTAMP, false, numDocs);
-    when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(2);
-    when(metadata.getMaxRowLengthInBytes()).thenReturn(Long.BYTES * 2);
-    when(metadata.getNumValues()).thenReturn(3);
-
-    MutableColumnStatistics stats =
-        new MutableColumnStatistics(mockDataSource(metadata, forwardIndex, dictionary), null, false);
-
-    assertFalse(stats.isSingleValue());
-    assertEquals(stats.getMinValue(), 1000L);
-    assertEquals(stats.getMaxValue(), 2000L);
-    assertEquals(stats.getCardinality(), 2);
-    assertEquals(stats.getLengthOfShortestElement(), Long.BYTES);
-    assertEquals(stats.getLengthOfLongestElement(), Long.BYTES);
-    assertTrue(stats.isFixedLength());
-    assertFalse(stats.isAscii());
-    assertFalse(stats.isSorted());
-    assertEquals(stats.getTotalNumberOfEntries(), 3);
-    assertEquals(stats.getMaxNumberOfMultiValues(), 2);
-  }
-
-  @Test
-  public void testStringMv() {
-    int numDocs = 2;
-    Dictionary dictionary = mock(Dictionary.class);
-    when(dictionary.getValueType()).thenReturn(DataType.STRING);
-    when(dictionary.length()).thenReturn(3);
-    when(dictionary.getMinVal()).thenReturn("a");
-    when(dictionary.getMaxVal()).thenReturn("c");
-    // All ASCII strings
-    when(dictionary.getBytesValue(0)).thenReturn("a".getBytes(StandardCharsets.UTF_8));
-    when(dictionary.getBytesValue(1)).thenReturn("bb".getBytes(StandardCharsets.UTF_8));
-    when(dictionary.getBytesValue(2)).thenReturn("c".getBytes(StandardCharsets.UTF_8));
-
-    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
-    when(forwardIndex.isSingleValue()).thenReturn(false);
-
-    DataSourceMetadata metadata = mockMetadata(DataType.STRING, false, numDocs);
-    when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(2);
-    when(metadata.getMaxRowLengthInBytes()).thenReturn(3);
-    when(metadata.getNumValues()).thenReturn(4);
-
-    MutableColumnStatistics stats =
-        new MutableColumnStatistics(mockDataSource(metadata, forwardIndex, dictionary), null, false);
-
-    assertFalse(stats.isSingleValue());
-    assertEquals(stats.getLengthOfShortestElement(), 1);
-    assertEquals(stats.getLengthOfLongestElement(), 2);
-    assertTrue(stats.isAscii());
-    assertFalse(stats.isSorted());
-  }
-
-  @Test
-  public void testJsonMv() {
-    int numDocs = 2;
-    Dictionary dictionary = mock(Dictionary.class);
-    when(dictionary.getValueType()).thenReturn(DataType.STRING);
-    when(dictionary.length()).thenReturn(3);
-    when(dictionary.getMinVal()).thenReturn("a");
-    when(dictionary.getMaxVal()).thenReturn("c");
-    when(dictionary.getBytesValue(0)).thenReturn("a".getBytes(StandardCharsets.UTF_8));
-    when(dictionary.getBytesValue(1)).thenReturn("bb".getBytes(StandardCharsets.UTF_8));
-    when(dictionary.getBytesValue(2)).thenReturn("c".getBytes(StandardCharsets.UTF_8));
-
-    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
-    when(forwardIndex.isSingleValue()).thenReturn(false);
-
-    DataSourceMetadata metadata = mockMetadata(DataType.JSON, false, numDocs);
-    when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(2);
-    when(metadata.getMaxRowLengthInBytes()).thenReturn(3);
-    when(metadata.getNumValues()).thenReturn(4);
-
-    MutableColumnStatistics stats =
-        new MutableColumnStatistics(mockDataSource(metadata, forwardIndex, dictionary), null, false);
-
-    assertFalse(stats.isSingleValue());
-    assertEquals(stats.getLengthOfShortestElement(), 1);
-    assertEquals(stats.getLengthOfLongestElement(), 2);
-    assertTrue(stats.isAscii());
-    assertFalse(stats.isSorted());
-  }
-
-  @Test
-  public void testBytesMv() {
-    int numDocs = 2;
-    Dictionary dictionary = mock(Dictionary.class);
-    when(dictionary.getValueType()).thenReturn(DataType.BYTES);
-    when(dictionary.length()).thenReturn(2);
-    when(dictionary.getMinVal()).thenReturn(new ByteArray(new byte[]{1, 2}));
-    when(dictionary.getMaxVal()).thenReturn(new ByteArray(new byte[]{3, 4, 5}));
-    when(dictionary.getValueSize(0)).thenReturn(2);
-    when(dictionary.getValueSize(1)).thenReturn(3);
-
-    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
-    when(forwardIndex.isSingleValue()).thenReturn(false);
-
-    DataSourceMetadata metadata = mockMetadata(DataType.BYTES, false, numDocs);
-    when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(2);
-    when(metadata.getMaxRowLengthInBytes()).thenReturn(3 * 2);
-    when(metadata.getNumValues()).thenReturn(4);
-
-    MutableColumnStatistics stats =
-        new MutableColumnStatistics(mockDataSource(metadata, forwardIndex, dictionary), null, false);
-
-    assertFalse(stats.isSingleValue());
-    assertEquals(stats.getLengthOfShortestElement(), 2);
-    assertEquals(stats.getLengthOfLongestElement(), 3);
-    assertFalse(stats.isAscii());
-    assertFalse(stats.isSorted());
-  }
-
-  // ======== Element length randomized (original test) ========
-
-  @Test
-  public void testElementLength() {
-    int numElements = 10;
-    String[] elements = new String[numElements];
-    int minElementLength = Integer.MAX_VALUE;
-    int maxElementLength = 0;
-    RandomStringUtils gen = RandomStringUtils.secure();
-    for (int i = 0; i < numElements; i++) {
-      String randomString = gen.next(100);
-      elements[i] = randomString;
-      int elementLength = Utf8.encodedLength(randomString);
-      minElementLength = Math.min(minElementLength, elementLength);
-      maxElementLength = Math.max(maxElementLength, elementLength);
+  @Test(dataProvider = "mutableDictTypes")
+  public void testBytesSv(String dictType)
+      throws Exception {
+    byte[] smaller = {1, 2};
+    byte[] larger = {3, 4, 5};
+
+    try (MutableDictionary dictionary = createMutableDictionary(DataType.BYTES, dictType)) {
+      // Rows arrive out of order with duplicates
+      int dictId0 = dictionary.index(larger);
+      int dictId1 = dictionary.index(smaller);
+      int dictId2 = dictionary.index(larger); // duplicate
+      assertEquals(dictId2, dictId0);
+
+      // Forward index in arrival order
+      MutableForwardIndex forwardIndex = mockSvForwardIndex(dictId0, dictId1, dictId2);
+      DataSourceMetadata metadata = mockMetadata(DataType.BYTES, true, 3);
+      when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(0);
+      when(metadata.getMaxRowLengthInBytes()).thenReturn(3);
+
+      // sortedDocIds: doc1(smaller), doc0(larger), doc2(larger)
+      MutableColumnStatistics stats =
+          new MutableColumnStatistics(mockDataSource(metadata, forwardIndex, dictionary),
+              new int[]{1, 0, 2}, false);
+
+      assertEquals(stats.getMinValue(), new ByteArray(smaller));
+      assertEquals(stats.getMaxValue(), new ByteArray(larger));
+      assertEquals(stats.getLengthOfShortestElement(), 2);
+      assertEquals(stats.getLengthOfLongestElement(), 3);
+      assertFalse(stats.isFixedLength());
+      assertFalse(stats.isAscii());
+      assertTrue(stats.isSorted());
     }
+  }
 
-    FieldSpec fieldSpec = new DimensionFieldSpec("col", DataType.STRING, true);
-    DataSourceMetadata metadata = mock(DataSourceMetadata.class);
-    when(metadata.getFieldSpec()).thenReturn(fieldSpec);
-    when(metadata.getNumDocs()).thenReturn(numElements);
+  @Test
+  public void testBytesConstantValue()
+      throws Exception {
+    byte[] value = {1, 2, 3};
 
-    DataSource dataSource = mock(DataSource.class);
-    when(dataSource.getDataSourceMetadata()).thenReturn(metadata);
-    Dictionary dictionary = mock(Dictionary.class);
-    when(dataSource.getDictionary()).thenReturn(dictionary);
-    when(dictionary.getValueType()).thenReturn(DataType.STRING);
-    when(dictionary.length()).thenReturn(numElements);
-    when(dictionary.getValueSize(anyInt())).thenAnswer(
-        invocation -> Utf8.encodedLength(elements[(int) invocation.getArgument(0)]));
-    when(dictionary.getBytesValue(anyInt())).thenAnswer(
-        invocation -> Utf8Utils.encode(elements[(int) invocation.getArgument(0)]));
+    try (Dictionary dictionary = new ConstantValueBytesDictionary(value)) {
+      MutableForwardIndex forwardIndex = mockSvForwardIndex(0, 0);
+      DataSourceMetadata metadata = mockMetadata(DataType.BYTES, true, 2);
+      when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(0);
+      when(metadata.getMaxRowLengthInBytes()).thenReturn(3);
 
-    MutableColumnStatistics columnStatistics = new MutableColumnStatistics(dataSource, null, false);
-    assertEquals(columnStatistics.isFixedLength(), minElementLength == maxElementLength);
-    assertEquals(columnStatistics.getLengthOfLongestElement(), maxElementLength);
+      MutableColumnStatistics stats =
+          new MutableColumnStatistics(mockDataSource(metadata, forwardIndex, dictionary), null, false);
+
+      assertEquals(stats.getMinValue(), new ByteArray(value));
+      assertEquals(stats.getMaxValue(), new ByteArray(value));
+      assertEquals(stats.getLengthOfShortestElement(), 3);
+      assertEquals(stats.getLengthOfLongestElement(), 3);
+      assertTrue(stats.isFixedLength());
+      assertFalse(stats.isAscii());
+    }
+  }
+
+  // ======== Sorted / unsorted ========
+
+  @Test
+  public void testSvUnsorted()
+      throws Exception {
+    try (MutableDictionary dictionary = new IntOnHeapMutableDictionary()) {
+      // Rows arrive out of order with duplicates
+      int dictId0 = dictionary.index(30);
+      int dictId1 = dictionary.index(10);
+      int dictId2 = dictionary.index(20);
+      int dictId3 = dictionary.index(10); // duplicate
+      assertEquals(dictId3, dictId1);
+
+      // Forward index NOT sorted by value: doc0=10, doc1=30, doc2=20, doc3=10
+      MutableForwardIndex forwardIndex = mockSvForwardIndex(dictId1, dictId0, dictId2, dictId3);
+      DataSourceMetadata metadata = mockMetadata(DataType.INT, true, 4);
+      when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(0);
+      when(metadata.getMaxRowLengthInBytes()).thenReturn(Integer.BYTES);
+
+      MutableColumnStatistics stats =
+          new MutableColumnStatistics(mockDataSource(metadata, forwardIndex, dictionary), null, false);
+
+      assertFalse(stats.isSorted());
+    }
+  }
+
+  @Test
+  public void testSvSortedColumnFlag()
+      throws Exception {
+    try (MutableDictionary dictionary = new IntOnHeapMutableDictionary()) {
+      int dictId0 = dictionary.index(20);
+      int dictId1 = dictionary.index(10);
+
+      // Forward index NOT sorted, but isSortedColumn=true overrides
+      MutableForwardIndex forwardIndex = mockSvForwardIndex(dictId0, dictId1);
+      DataSourceMetadata metadata = mockMetadata(DataType.INT, true, 2);
+      when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(0);
+      when(metadata.getMaxRowLengthInBytes()).thenReturn(Integer.BYTES);
+
+      MutableColumnStatistics stats =
+          new MutableColumnStatistics(mockDataSource(metadata, forwardIndex, dictionary), null, true);
+
+      assertTrue(stats.isSorted()); // isSortedColumn=true overrides scan
+    }
+  }
+
+  @Test
+  public void testSvSortedWithSortedDocIds()
+      throws Exception {
+    try (MutableDictionary dictionary = new IntOnHeapMutableDictionary()) {
+      int dictId0 = dictionary.index(30);
+      int dictId1 = dictionary.index(10);
+      int dictId2 = dictionary.index(20);
+
+      // Physical forward index: doc0=30, doc1=20, doc2=10
+      MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
+      when(forwardIndex.isSingleValue()).thenReturn(true);
+      when(forwardIndex.getDictId(0)).thenReturn(dictId0);
+      when(forwardIndex.getDictId(1)).thenReturn(dictId2);
+      when(forwardIndex.getDictId(2)).thenReturn(dictId1);
+
+      // sortedDocIds=[2,1,0]: logical order doc2(10), doc1(20), doc0(30) — sorted by value
+      DataSourceMetadata metadata = mockMetadata(DataType.INT, true, 3);
+      when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(0);
+      when(metadata.getMaxRowLengthInBytes()).thenReturn(Integer.BYTES);
+
+      MutableColumnStatistics stats =
+          new MutableColumnStatistics(mockDataSource(metadata, forwardIndex, dictionary),
+              new int[]{2, 1, 0}, false);
+
+      assertTrue(stats.isSorted());
+    }
+  }
+
+  // ======== MV fixed-width ========
+
+  @Test(dataProvider = "fixedWidthMutableCases")
+  public void testFixedWidthMv(DataType type, String dictType)
+      throws Exception {
+    Comparable[] sorted = fixedWidthSortedValues(type);
+    int typeSize = type.size();
+
+    try (MutableDictionary dictionary = createMutableDictionary(type, dictType)) {
+      // Index out of order with duplicates
+      dictionary.index(sorted[2]);
+      dictionary.index(sorted[0]);
+      dictionary.index(sorted[1]);
+      dictionary.index(sorted[0]); // dup
+
+      MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
+      when(forwardIndex.isSingleValue()).thenReturn(false);
+
+      DataSourceMetadata metadata = mockMetadata(type, false, 2);
+      when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(2);
+      when(metadata.getMaxRowLengthInBytes()).thenReturn(typeSize * 2);
+      when(metadata.getNumValues()).thenReturn(4);
+
+      MutableColumnStatistics stats =
+          new MutableColumnStatistics(mockDataSource(metadata, forwardIndex, dictionary), null, false);
+
+      assertFalse(stats.isSingleValue());
+      assertEquals(stats.getMinValue(), sorted[0]);
+      assertEquals(stats.getMaxValue(), sorted[2]);
+      assertEquals(stats.getCardinality(), 3);
+      assertEquals(stats.getLengthOfShortestElement(), typeSize);
+      assertEquals(stats.getLengthOfLongestElement(), typeSize);
+      assertTrue(stats.isFixedLength());
+      assertFalse(stats.isAscii());
+      assertFalse(stats.isSorted());
+      assertEquals(stats.getTotalNumberOfEntries(), 4);
+      assertEquals(stats.getMaxNumberOfMultiValues(), 2);
+    }
+  }
+
+  // ======== MV string ========
+
+  @Test(dataProvider = "mutableDictTypes")
+  public void testStringMv(String dictType)
+      throws Exception {
+    try (MutableDictionary dictionary = createMutableDictionary(DataType.STRING, dictType)) {
+      // Index out of order with duplicates
+      dictionary.index("c");
+      dictionary.index("bb");
+      dictionary.index("a");
+      dictionary.index("bb"); // dup
+
+      MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
+      when(forwardIndex.isSingleValue()).thenReturn(false);
+
+      DataSourceMetadata metadata = mockMetadata(DataType.STRING, false, 2);
+      when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(2);
+      when(metadata.getMaxRowLengthInBytes()).thenReturn(3);
+      when(metadata.getNumValues()).thenReturn(4);
+
+      MutableColumnStatistics stats =
+          new MutableColumnStatistics(mockDataSource(metadata, forwardIndex, dictionary), null, false);
+
+      assertFalse(stats.isSingleValue());
+      assertEquals(stats.getLengthOfShortestElement(), 1);
+      assertEquals(stats.getLengthOfLongestElement(), 2);
+      assertTrue(stats.isAscii());
+      assertFalse(stats.isSorted());
+    }
+  }
+
+  // ======== MV bytes ========
+
+  @Test(dataProvider = "mutableDictTypes")
+  public void testBytesMv(String dictType)
+      throws Exception {
+    try (MutableDictionary dictionary = createMutableDictionary(DataType.BYTES, dictType)) {
+      // Index out of order with duplicates
+      dictionary.index(new byte[]{3, 4, 5});
+      dictionary.index(new byte[]{1, 2});
+      dictionary.index(new byte[]{3, 4, 5}); // dup
+
+      MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
+      when(forwardIndex.isSingleValue()).thenReturn(false);
+
+      DataSourceMetadata metadata = mockMetadata(DataType.BYTES, false, 2);
+      when(metadata.getMaxNumValuesPerMVEntry()).thenReturn(2);
+      when(metadata.getMaxRowLengthInBytes()).thenReturn(3 * 2);
+      when(metadata.getNumValues()).thenReturn(4);
+
+      MutableColumnStatistics stats =
+          new MutableColumnStatistics(mockDataSource(metadata, forwardIndex, dictionary), null, false);
+
+      assertFalse(stats.isSingleValue());
+      assertEquals(stats.getLengthOfShortestElement(), 2);
+      assertEquals(stats.getLengthOfLongestElement(), 3);
+      assertFalse(stats.isAscii());
+      assertFalse(stats.isSorted());
+    }
   }
 
   // ======== Helpers ========
+
+  @AfterClass
+  public void tearDown()
+      throws Exception {
+    _memoryManager.close();
+  }
+
+  private MutableDictionary createMutableDictionary(DataType type, String dictType) {
+    if ("onHeap".equals(dictType)) {
+      return createOnHeapDictionary(type);
+    } else if ("offHeap".equals(dictType)) {
+      return createOffHeapDictionary(type);
+    }
+    throw new IllegalArgumentException("Unknown dict type: " + dictType);
+  }
+
+  private static MutableDictionary createOnHeapDictionary(DataType type) {
+    switch (type) {
+      case INT:
+        return new IntOnHeapMutableDictionary();
+      case LONG:
+        return new LongOnHeapMutableDictionary();
+      case FLOAT:
+        return new FloatOnHeapMutableDictionary();
+      case DOUBLE:
+        return new DoubleOnHeapMutableDictionary();
+      case BIG_DECIMAL:
+        return new BigDecimalOnHeapMutableDictionary();
+      case STRING:
+        return new StringOnHeapMutableDictionary();
+      case BYTES:
+        return new BytesOnHeapMutableDictionary();
+      default:
+        throw new UnsupportedOperationException("Unsupported: " + type);
+    }
+  }
+
+  private MutableDictionary createOffHeapDictionary(DataType type) {
+    String ctx = type.name().toLowerCase() + "Column";
+    switch (type) {
+      case INT:
+        return new IntOffHeapMutableDictionary(EST_CARDINALITY, 10, _memoryManager, ctx);
+      case LONG:
+        return new LongOffHeapMutableDictionary(EST_CARDINALITY, 10, _memoryManager, ctx);
+      case FLOAT:
+        return new FloatOffHeapMutableDictionary(EST_CARDINALITY, 10, _memoryManager, ctx);
+      case DOUBLE:
+        return new DoubleOffHeapMutableDictionary(EST_CARDINALITY, 10, _memoryManager, ctx);
+      case BIG_DECIMAL:
+        return new BigDecimalOffHeapMutableDictionary(EST_CARDINALITY, 10, _memoryManager, ctx, 32);
+      case STRING:
+        return new StringOffHeapMutableDictionary(EST_CARDINALITY, 10, _memoryManager, ctx, 32);
+      case BYTES:
+        return new BytesOffHeapMutableDictionary(EST_CARDINALITY, 10, _memoryManager, ctx, 32);
+      default:
+        throw new UnsupportedOperationException("Unsupported: " + type);
+    }
+  }
+
+  private static Dictionary createConstantValueDictionary(DataType type, Object value) {
+    switch (type) {
+      case INT:
+        return new ConstantValueIntDictionary((int) value);
+      case LONG:
+        return new ConstantValueLongDictionary((long) value);
+      case FLOAT:
+        return new ConstantValueFloatDictionary((float) value);
+      case DOUBLE:
+        return new ConstantValueDoubleDictionary((double) value);
+      default:
+        throw new UnsupportedOperationException("Unsupported: " + type);
+    }
+  }
+
+  private static MutableForwardIndex mockSvForwardIndex(int... dictIds) {
+    MutableForwardIndex forwardIndex = mock(MutableForwardIndex.class);
+    when(forwardIndex.isSingleValue()).thenReturn(true);
+    for (int doc = 0; doc < dictIds.length; doc++) {
+      when(forwardIndex.getDictId(doc)).thenReturn(dictIds[doc]);
+    }
+    return forwardIndex;
+  }
 
   private static DataSourceMetadata mockMetadata(DataType type, boolean sv, int numDocs) {
     FieldSpec fieldSpec = new DimensionFieldSpec("col", type, sv);
@@ -788,7 +672,7 @@ public class MutableColumnStatisticsTest {
     return ds;
   }
 
-  private static Comparable[] fixedWidthValues(DataType type) {
+  private static Comparable[] fixedWidthSortedValues(DataType type) {
     switch (type) {
       case INT:
         return new Comparable[]{10, 20, 30};

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/Dictionary.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/Dictionary.java
@@ -138,13 +138,39 @@ public interface Dictionary extends IndexReader {
    */
   Comparable getMaxVal();
 
-  /**
-   * Returns a sorted array of all values in the dictionary. For type INT/LONG/FLOAT/DOUBLE, primitive type array will
-   * be returned; for type BIG_DECIMAL, {@code BigDecimal[]} will be returned; for type STRING, {@code String[]} will be
-   * returned; for type BYTES, {@code ByteArray[]} will be returned.
-   * This method is for the stats collection phase when sealing the consuming segment.
-   */
-  Object getSortedValues();
+  /// Returns a sorted array of all values in the dictionary. For type INT/LONG/FLOAT/DOUBLE, primitive type array
+  /// will be returned; for type BIG_DECIMAL, `BigDecimal[]` will be returned; for type STRING, `String[]` will be
+  /// returned; for type BYTES, `ByteArray[]` will be returned.
+  ///
+  /// This method is for the stats-collection phase when sealing the consuming segment. It should be overridden when
+  /// the dictionary is used in a mutable segment.
+  default Object getSortedValues() {
+    throw new UnsupportedOperationException();
+  }
+
+  /// Returns the length (in bytes) of the shortest element in the dictionary.
+  ///
+  /// This method is for the stats-collection phase when sealing the consuming segment. It should be overridden when
+  /// the dictionary is used in a mutable segment.
+  default int getLengthOfShortestElement() {
+    throw new UnsupportedOperationException();
+  }
+
+  /// Returns the length (in bytes) of the longest element in the dictionary.
+  ///
+  /// This method is for the stats-collection phase when sealing the consuming segment. It should be overridden when
+  /// the dictionary is used in a mutable segment.
+  default int getLengthOfLongestElement() {
+    throw new UnsupportedOperationException();
+  }
+
+  /// Returns `true` when all elements in a STRING dictionary contain only ASCII characters, `false` otherwise.
+  ///
+  /// This method is for the stats-collection phase when sealing the consuming segment. It should be overridden when
+  /// the dictionary is used in a mutable segment.
+  default boolean isAscii() {
+    throw new UnsupportedOperationException();
+  }
 
   // Single-value read APIs
 


### PR DESCRIPTION
## Summary
- Move incremental computation of `getLengthOfShortestElement`, `getLengthOfLongestElement` and `isAscii` out of `MutableColumnStatistics` and into the `Dictionary` hierarchy, eliminating the segment-scan TODO
- Add `BaseConstantValueDictionary` as abstract base for all constant-value dictionaries, providing default implementations for stats methods
- Track element length and ASCII stats incrementally during `index()` in all `MutableDictionary` implementations (Int/Long/Float/Double/BigDecimal/String/Bytes × OnHeap/OffHeap)
- Simplify `MutableColumnStatistics` to delegate stats to `Dictionary` instead of computing them via segment scan
- Rewrite `MutableColumnStatisticsTest` to use real dictionary implementations instead of mocks, covering onHeap mutable, offHeap mutable, and constant-value dictionaries

## Test plan
- [x] Existing unit tests pass (`MutableColumnStatisticsTest` rewritten with real dictionaries)
- [x] Verify `MutableDictionaryTest` still passes
- [x] Run `pinot-segment-local` and `pinot-segment-spi` module tests
- [x] Verify no downstream compile breaks in `startree-pinot` modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>