### PR TITLE
Add SEMANTIC_MATCH filter predicate for hidden semantic search layer

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/sql/FilterKind.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/FilterKind.java
@@ -39,7 +39,8 @@ public enum FilterKind {
   IS_NULL,
   IS_NOT_NULL,
   VECTOR_SIMILARITY,
-  VECTOR_SIMILARITY_RADIUS;
+  VECTOR_SIMILARITY_RADIUS,
+  SEMANTIC_MATCH;
 
   /**
    * Helper method that returns true if the enum maps to a Range.

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -271,6 +271,25 @@ public class CalciteSqlParser {
       for (Expression filter : filterExpression.getFunctionCall().getOperands()) {
         validateFilter(filter);
       }
+    } else if (operator.equals(FilterKind.SEMANTIC_MATCH.name())) {
+      // SEMANTIC_MATCH(column, 'query text', topK) — validated here, rewritten by QueryRewriter
+      List<Expression> smOperands = filterExpression.getFunctionCall().getOperands();
+      if (smOperands.size() < 2 || smOperands.size() > 3) {
+        throw new IllegalStateException(
+            "SEMANTIC_MATCH requires 2 or 3 arguments: SEMANTIC_MATCH(column, 'query text'[, topK])");
+      }
+      if (!smOperands.get(0).isSetIdentifier()) {
+        throw new IllegalStateException(
+            "The first argument of SEMANTIC_MATCH must be a column identifier");
+      }
+      if (!smOperands.get(1).isSetLiteral() || smOperands.get(1).getLiteral().isSetNullValue()) {
+        throw new IllegalStateException(
+            "The second argument of SEMANTIC_MATCH must be a non-null string literal (query text)");
+      }
+      if (smOperands.size() == 3 && !smOperands.get(2).isSetLiteral()) {
+        throw new IllegalStateException(
+            "The third argument of SEMANTIC_MATCH must be an integer literal (topK)");
+      }
     } else if (operator.equals(FilterKind.VECTOR_SIMILARITY.name())) {
       Expression vectorIdentifier = filterExpression.getFunctionCall().getOperands().get(0);
       if (!vectorIdentifier.isSetIdentifier()) {

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/PredicateComparisonRewriter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/PredicateComparisonRewriter.java
@@ -123,6 +123,12 @@ public class PredicateComparisonRewriter implements QueryRewriter {
             break;
           }
           break;
+        case SEMANTIC_MATCH: {
+          // SEMANTIC_MATCH(column, 'query text', topK) — pass through, rewritten by semantic rewriter
+          Preconditions.checkArgument(operands.size() >= 2 && operands.size() <= 3,
+              "For %s predicate, the number of operands must be 2 or 3, got: %s", filterKind, expression);
+          break;
+        }
         case VECTOR_SIMILARITY: {
           Preconditions.checkArgument(operands.size() >= 2 && operands.size() <= 3,
               "For %s predicate, the number of operands must be at either 2 or 3, got: %s", filterKind, expression);

--- a/pinot-core/src/test/java/org/apache/pinot/core/function/FunctionRegistryTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/function/FunctionRegistryTest.java
@@ -57,6 +57,7 @@ public class FunctionRegistryTest {
   private static final EnumSet<FilterKind> IGNORED_FILTER_KINDS = EnumSet.of(
       // Special filter functions without implementation
       FilterKind.TEXT_MATCH, FilterKind.JSON_MATCH, FilterKind.VECTOR_SIMILARITY, FilterKind.VECTOR_SIMILARITY_RADIUS,
+      FilterKind.SEMANTIC_MATCH,
       // TODO: Support these functions
       FilterKind.RANGE, FilterKind.IN, FilterKind.NOT_IN);
 

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/sql/fun/PinotOperatorTable.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/sql/fun/PinotOperatorTable.java
@@ -296,6 +296,9 @@ public class PinotOperatorTable implements SqlOperatorTable {
           OperandTypes.family(List.of(SqlTypeFamily.ARRAY, SqlTypeFamily.ARRAY, SqlTypeFamily.INTEGER), i -> i == 2)),
       new PinotSqlFunction("VECTOR_SIMILARITY_RADIUS", ReturnTypes.BOOLEAN,
           OperandTypes.family(List.of(SqlTypeFamily.ARRAY, SqlTypeFamily.ARRAY, SqlTypeFamily.NUMERIC), i -> i == 2)),
+      new PinotSqlFunction("SEMANTIC_MATCH", ReturnTypes.BOOLEAN,
+          OperandTypes.family(
+              List.of(SqlTypeFamily.CHARACTER, SqlTypeFamily.CHARACTER, SqlTypeFamily.INTEGER), i -> i == 2)),
 
       // Placeholder for special functions to handle MV
       // NOTE:


### PR DESCRIPTION
## Summary

- Registers `SEMANTIC_MATCH(column, 'query text'[, topK])` as a Calcite SQL function in `PinotOperatorTable`
- Adds `SEMANTIC_MATCH` to `FilterKind` enum so it flows through the standard predicate pipeline
- Adds argument validation in `CalciteSqlParser.validateFilter()`: requires 2–3 args, column identifier as first arg, non-null string literal as second
- Adds a pass-through case in `PredicateComparisonRewriter` so the predicate is preserved for downstream rewriters

## Test plan

- [ ] Existing unit tests pass: `CalciteSqlParser`, `PredicateComparisonRewriter`, `FilterKind` usages
- [ ] Manual: verify `SELECT ... FROM t WHERE SEMANTIC_MATCH(embedding_col, 'some query', 10)` parses without error and round-trips through the rewriter chain unchanged
- [ ] Verify that an invalid call (wrong arg count, non-column first arg) throws `IllegalStateException` at parse time

🤖 Generated with [Claude Code](https://claude.com/claude-code)