### PR TITLE
Fix UUID gRPC query path to emit string literals for UUID columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,5 +187,55 @@ Check out [Pinot documentation](https://docs.pinot.apache.org/) for a complete d
 - [Pinot Architecture](https://docs.pinot.apache.org/basics/architecture)
 - [Pinot Query Language](https://docs.pinot.apache.org/users/user-guide-query/pinot-query-language)
 
+### UUID Logical Type
+
+Pinot supports a logical `UUID` type for single-value columns. In v1, Pinot stores `UUID` values using the existing
+16-byte `BYTES` representation, while schema definitions and query results use canonical lowercase RFC 4122 strings.
+
+Schema example:
+```json
+{
+  "schemaName": "events",
+  "dimensionFieldSpecs": [
+    {
+      "name": "eventId",
+      "dataType": "UUID"
+    }
+  ]
+}
+```
+
+Query example:
+```sql
+SELECT eventId
+FROM events
+WHERE eventId = CAST('550e8400-e29b-41d4-a716-446655440000' AS UUID)
+```
+
+UUID conversion helpers:
+```sql
+SELECT
+  TO_UUID('550E8400-E29B-41D4-A716-446655440000'),
+  UUID_TO_STRING(eventId),
+  UUID_TO_BYTES(eventId),
+  BYTES_TO_UUID(eventIdBytes),
+  IS_UUID(eventIdBytes)
+FROM events
+```
+
+Behavior notes:
+- Pinot accepts canonical RFC 4122 UUID strings in either upper or lower case on ingest and in functions/casts.
+- Pinot always renders `UUID` results as canonical lowercase strings.
+- `CAST(... AS UUID)` accepts canonical strings and 16-byte `BYTES` values.
+
+Migration notes:
+- Existing `BYTES` columns keep returning hex strings. Pinot only renders canonical UUID strings for columns declared as `UUID`.
+- Pinot does not support changing the data type of an existing column in place. To adopt `UUID` for existing
+  `STRING` or `BYTES` UUID-shaped data, create a new `UUID` column or a new table/schema and reingest/backfill the
+  data into it.
+- The `UUID` type itself does not require a segment or wire format bump in v1, but migration still requires rebuild or
+  reingest because schema type mutation is unsupported.
+- Multi-value UUID columns are not supported in v1.
+
 ## License
 Apache Pinot is under [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionUtils.java
@@ -23,6 +23,7 @@ import java.sql.Timestamp;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
 import javax.annotation.Nullable;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
@@ -52,6 +53,7 @@ public class FunctionUtils {
     put(Timestamp.class, PinotDataType.TIMESTAMP);
     put(String.class, PinotDataType.STRING);
     put(byte[].class, PinotDataType.BYTES);
+    put(UUID.class, PinotDataType.UUID);
     put(int[].class, PinotDataType.PRIMITIVE_INT_ARRAY);
     put(long[].class, PinotDataType.PRIMITIVE_LONG_ARRAY);
     put(float[].class, PinotDataType.PRIMITIVE_FLOAT_ARRAY);
@@ -75,6 +77,7 @@ public class FunctionUtils {
     put(Timestamp.class, PinotDataType.TIMESTAMP);
     put(String.class, PinotDataType.STRING);
     put(byte[].class, PinotDataType.BYTES);
+    put(UUID.class, PinotDataType.UUID);
     put(int[].class, PinotDataType.PRIMITIVE_INT_ARRAY);
     put(Integer[].class, PinotDataType.INTEGER_ARRAY);
     put(long[].class, PinotDataType.PRIMITIVE_LONG_ARRAY);
@@ -103,6 +106,7 @@ public class FunctionUtils {
     put(Timestamp.class, DataType.TIMESTAMP);
     put(String.class, DataType.STRING);
     put(byte[].class, DataType.BYTES);
+    put(UUID.class, DataType.UUID);
     put(int[].class, DataType.INT);
     put(long[].class, DataType.LONG);
     put(float[].class, DataType.FLOAT);
@@ -125,6 +129,7 @@ public class FunctionUtils {
     put(Timestamp.class, ColumnDataType.TIMESTAMP);
     put(String.class, ColumnDataType.STRING);
     put(byte[].class, ColumnDataType.BYTES);
+    put(UUID.class, ColumnDataType.UUID);
     put(int[].class, ColumnDataType.INT_ARRAY);
     put(long[].class, ColumnDataType.LONG_ARRAY);
     put(float[].class, ColumnDataType.FLOAT_ARRAY);
@@ -197,6 +202,8 @@ public class FunctionUtils {
       case STRING:
       case JSON:
         return typeFactory.createSqlType(SqlTypeName.VARCHAR);
+      case UUID:
+        return typeFactory.createSqlType(SqlTypeName.UUID);
       case BYTES:
         return typeFactory.createSqlType(SqlTypeName.VARBINARY);
       case INT_ARRAY:

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
@@ -20,7 +20,6 @@ package org.apache.pinot.common.function.scalar;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.io.UnsupportedEncodingException;
-import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.text.Normalizer;
 import java.util.Base64;
@@ -30,6 +29,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.utils.URIUtils;
 import org.apache.pinot.spi.annotations.ScalarFunction;
 import org.apache.pinot.spi.utils.JsonUtils;
+import org.apache.pinot.spi.utils.UuidUtils;
 
 
 /**
@@ -442,12 +442,8 @@ public class StringFunctions {
   @ScalarFunction
   public static byte[] toUUIDBytes(String input) {
     try {
-      UUID uuid = UUID.fromString(input);
-      ByteBuffer bb = ByteBuffer.wrap(new byte[16]);
-      bb.putLong(uuid.getMostSignificantBits());
-      bb.putLong(uuid.getLeastSignificantBits());
-      return bb.array();
-    } catch (IllegalArgumentException e) {
+      return UuidUtils.toBytes(UUID.fromString(input));
+    } catch (Exception e) {
       return null;
     }
   }
@@ -459,10 +455,7 @@ public class StringFunctions {
    */
   @ScalarFunction
   public static String fromUUIDBytes(byte[] input) {
-    ByteBuffer bb = ByteBuffer.wrap(input);
-    long firstLong = bb.getLong();
-    long secondLong = bb.getLong();
-    return new UUID(firstLong, secondLong).toString();
+    return UuidUtils.toString(input);
   }
 
   /**

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/uuid/IsUuidScalarFunction.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/uuid/IsUuidScalarFunction.java
@@ -1,0 +1,105 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.function.scalar.uuid;
+
+import java.util.List;
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlTypeFamily;
+import org.apache.pinot.common.function.FunctionInfo;
+import org.apache.pinot.common.function.PinotScalarFunction;
+import org.apache.pinot.common.function.sql.PinotSqlFunction;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+import org.apache.pinot.spi.annotations.ScalarFunction;
+import org.apache.pinot.spi.utils.UuidUtils;
+
+
+/**
+ * Polymorphic scalar function that validates string or bytes values as UUID inputs.
+ *
+ * <p>This implementation is stateless and thread-safe.
+ */
+@ScalarFunction(names = {"IS_UUID"})
+public class IsUuidScalarFunction implements PinotScalarFunction {
+  private static final FunctionInfo STRING_FUNCTION_INFO;
+  private static final FunctionInfo BYTES_FUNCTION_INFO;
+
+  static {
+    try {
+      STRING_FUNCTION_INFO =
+          new FunctionInfo(IsUuidScalarFunction.class.getMethod("isUuid", String.class), IsUuidScalarFunction.class,
+              true);
+      BYTES_FUNCTION_INFO =
+          new FunctionInfo(IsUuidScalarFunction.class.getMethod("isUuid", byte[].class), IsUuidScalarFunction.class,
+              true);
+    } catch (NoSuchMethodException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public String getName() {
+    return "IS_UUID";
+  }
+
+  @Override
+  public Set<String> getNames() {
+    return Set.of("IS_UUID", "ISUUID");
+  }
+
+  @Nullable
+  @Override
+  public PinotSqlFunction toPinotSqlFunction() {
+    return new PinotSqlFunction("IS_UUID", ReturnTypes.BOOLEAN,
+        OperandTypes.or(OperandTypes.family(List.of(SqlTypeFamily.CHARACTER)),
+            OperandTypes.family(List.of(SqlTypeFamily.BINARY))));
+  }
+
+  @Nullable
+  @Override
+  public FunctionInfo getFunctionInfo(ColumnDataType[] argumentTypes) {
+    if (argumentTypes.length != 1) {
+      return null;
+    }
+    switch (argumentTypes[0]) {
+      case STRING:
+        return STRING_FUNCTION_INFO;
+      case BYTES:
+        return BYTES_FUNCTION_INFO;
+      default:
+        return null;
+    }
+  }
+
+  @Nullable
+  @Override
+  public FunctionInfo getFunctionInfo(int numArguments) {
+    return numArguments == 1 ? STRING_FUNCTION_INFO : null;
+  }
+
+  public static boolean isUuid(String value) {
+    return UuidUtils.isUuid(value);
+  }
+
+  public static boolean isUuid(byte[] value) {
+    return UuidUtils.isUuid(value);
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/uuid/ToUuidScalarFunction.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/uuid/ToUuidScalarFunction.java
@@ -1,0 +1,106 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.function.scalar.uuid;
+
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+import javax.annotation.Nullable;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlTypeFamily;
+import org.apache.pinot.common.function.FunctionInfo;
+import org.apache.pinot.common.function.PinotScalarFunction;
+import org.apache.pinot.common.function.sql.PinotSqlFunction;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+import org.apache.pinot.spi.annotations.ScalarFunction;
+import org.apache.pinot.spi.utils.UuidUtils;
+
+
+/**
+ * Polymorphic scalar function that converts string or bytes inputs into Pinot's logical UUID type.
+ *
+ * <p>This implementation is stateless and thread-safe.
+ */
+@ScalarFunction(names = {"TO_UUID"})
+public class ToUuidScalarFunction implements PinotScalarFunction {
+  private static final FunctionInfo STRING_FUNCTION_INFO;
+  private static final FunctionInfo BYTES_FUNCTION_INFO;
+
+  static {
+    try {
+      STRING_FUNCTION_INFO =
+          new FunctionInfo(ToUuidScalarFunction.class.getMethod("toUuid", String.class), ToUuidScalarFunction.class,
+              true);
+      BYTES_FUNCTION_INFO =
+          new FunctionInfo(ToUuidScalarFunction.class.getMethod("toUuid", byte[].class), ToUuidScalarFunction.class,
+              true);
+    } catch (NoSuchMethodException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public String getName() {
+    return "TO_UUID";
+  }
+
+  @Override
+  public Set<String> getNames() {
+    return Set.of("TO_UUID", "TOUUID");
+  }
+
+  @Nullable
+  @Override
+  public PinotSqlFunction toPinotSqlFunction() {
+    return new PinotSqlFunction("TO_UUID", ReturnTypes.explicit(org.apache.calcite.sql.type.SqlTypeName.UUID),
+        OperandTypes.or(OperandTypes.family(List.of(SqlTypeFamily.CHARACTER)),
+            OperandTypes.family(List.of(SqlTypeFamily.BINARY))));
+  }
+
+  @Nullable
+  @Override
+  public FunctionInfo getFunctionInfo(ColumnDataType[] argumentTypes) {
+    if (argumentTypes.length != 1) {
+      return null;
+    }
+    switch (argumentTypes[0]) {
+      case STRING:
+        return STRING_FUNCTION_INFO;
+      case BYTES:
+        return BYTES_FUNCTION_INFO;
+      default:
+        return null;
+    }
+  }
+
+  @Nullable
+  @Override
+  public FunctionInfo getFunctionInfo(int numArguments) {
+    return numArguments == 1 ? STRING_FUNCTION_INFO : null;
+  }
+
+  public static UUID toUuid(String value) {
+    return value != null ? UuidUtils.toUUID(value) : null;
+  }
+
+  public static UUID toUuid(byte[] value) {
+    return value != null ? UuidUtils.toUUID(value) : null;
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/uuid/UuidConversionFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/uuid/UuidConversionFunctions.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.function.scalar.uuid;
+
+import java.util.UUID;
+import org.apache.pinot.spi.annotations.ScalarFunction;
+import org.apache.pinot.spi.utils.UuidUtils;
+
+
+/**
+ * UUID conversion scalar functions.
+ *
+ * <p>These functions are stateless and thread-safe.
+ */
+public final class UuidConversionFunctions {
+  private UuidConversionFunctions() {
+  }
+
+  @ScalarFunction(names = {"UUID_TO_BYTES"}, nullableParameters = true)
+  public static byte[] uuidToBytes(UUID uuid) {
+    return uuid != null ? UuidUtils.toBytes(uuid) : null;
+  }
+
+  @ScalarFunction(names = {"BYTES_TO_UUID"}, nullableParameters = true)
+  public static UUID bytesToUuid(byte[] bytes) {
+    return bytes != null ? UuidUtils.toUUID(bytes) : null;
+  }
+
+  @ScalarFunction(names = {"UUID_TO_STRING"}, nullableParameters = true)
+  public static String uuidToString(UUID uuid) {
+    return uuid != null ? UuidUtils.toString(uuid) : null;
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/request/context/LiteralContext.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/request/context/LiteralContext.java
@@ -171,6 +171,9 @@ public class LiteralContext {
         return PinotDataType.BIG_DECIMAL;
       case STRING:
         return singleValue ? PinotDataType.STRING : PinotDataType.STRING_ARRAY;
+      case UUID:
+        Preconditions.checkState(singleValue, "UUID array is not supported");
+        return PinotDataType.UUID;
       default:
         throw new IllegalStateException("Unsupported DataType: " + type);
     }

--- a/pinot-common/src/main/java/org/apache/pinot/common/request/context/RequestContextUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/request/context/RequestContextUtils.java
@@ -22,7 +22,9 @@ import com.google.common.base.Preconditions;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import org.apache.commons.lang3.EnumUtils;
+import org.apache.pinot.common.function.FunctionRegistry;
 import org.apache.pinot.common.request.Expression;
 import org.apache.pinot.common.request.ExpressionType;
 import org.apache.pinot.common.request.Function;
@@ -42,12 +44,18 @@ import org.apache.pinot.common.request.context.predicate.VectorSimilarityRadiusP
 import org.apache.pinot.common.utils.RegexpPatternConverterUtils;
 import org.apache.pinot.common.utils.request.RequestUtils;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.exception.BadQueryRequestException;
+import org.apache.pinot.spi.utils.BytesUtils;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.apache.pinot.sql.FilterKind;
 import org.apache.pinot.sql.parsers.CalciteSqlParser;
 
 
 public class RequestContextUtils {
+  private static final String UNSUPPORTED_RHS_MESSAGE =
+      "Pinot does not support column or function on the right-hand side of the predicate";
+
   private RequestContextUtils() {
   }
 
@@ -128,6 +136,18 @@ public class RequestContextUtils {
         return FilterContext.forConstant(new LiteralContext(thriftExpression.getLiteral()).getBooleanValue());
       default:
         throw new IllegalStateException();
+    }
+  }
+
+  /**
+   * Returns {@code true} when the expression can be reduced to a literal value without accessing columns.
+   */
+  public static boolean canEvaluateLiteral(Expression thriftExpression) {
+    try {
+      evaluateLiteralValue(thriftExpression);
+      return true;
+    } catch (RuntimeException e) {
+      return false;
     }
   }
 
@@ -218,23 +238,23 @@ public class RequestContextUtils {
       case GREATER_THAN:
         return FilterContext.forPredicate(
             new RangePredicate(getExpression(operands.get(0)), false, getStringValue(operands.get(1)), false,
-                RangePredicate.UNBOUNDED, new LiteralContext(operands.get(1).getLiteral()).getType()));
+                RangePredicate.UNBOUNDED, getLiteralType(operands.get(1))));
       case GREATER_THAN_OR_EQUAL:
         return FilterContext.forPredicate(
             new RangePredicate(getExpression(operands.get(0)), true, getStringValue(operands.get(1)), false,
-                RangePredicate.UNBOUNDED, new LiteralContext(operands.get(1).getLiteral()).getType()));
+                RangePredicate.UNBOUNDED, getLiteralType(operands.get(1))));
       case LESS_THAN:
         return FilterContext.forPredicate(
             new RangePredicate(getExpression(operands.get(0)), false, RangePredicate.UNBOUNDED, false,
-                getStringValue(operands.get(1)), new LiteralContext(operands.get(1).getLiteral()).getType()));
+                getStringValue(operands.get(1)), getLiteralType(operands.get(1))));
       case LESS_THAN_OR_EQUAL:
         return FilterContext.forPredicate(
             new RangePredicate(getExpression(operands.get(0)), false, RangePredicate.UNBOUNDED, true,
-                getStringValue(operands.get(1)), new LiteralContext(operands.get(1).getLiteral()).getType()));
+                getStringValue(operands.get(1)), getLiteralType(operands.get(1))));
       case BETWEEN:
         return FilterContext.forPredicate(
             new RangePredicate(getExpression(operands.get(0)), true, getStringValue(operands.get(1)), true,
-                getStringValue(operands.get(2)), new LiteralContext(operands.get(1).getLiteral()).getType()));
+                getStringValue(operands.get(2)), getLiteralType(operands.get(1))));
       case RANGE:
         return FilterContext.forPredicate(
             new RangePredicate(getExpression(operands.get(0)), getStringValue(operands.get(1))));
@@ -288,12 +308,7 @@ public class RequestContextUtils {
   }
 
   public static String getStringValue(Expression thriftExpression) {
-    Literal literal = thriftExpression.getLiteral();
-    if (literal == null) {
-      throw new BadQueryRequestException(
-          "Pinot does not support column or function on the right-hand side of the predicate");
-    }
-    return RequestUtils.getLiteralString(literal);
+    return evaluateLiteralValue(thriftExpression).getStringValue();
   }
 
   /**
@@ -412,23 +427,23 @@ public class RequestContextUtils {
       case GREATER_THAN:
         return FilterContext.forPredicate(
             new RangePredicate(operands.get(0), false, getStringValue(operands.get(1)), false, RangePredicate.UNBOUNDED,
-                operands.get(1).getLiteral().getType()));
+                getLiteralType(operands.get(1))));
       case GREATER_THAN_OR_EQUAL:
         return FilterContext.forPredicate(
             new RangePredicate(operands.get(0), true, getStringValue(operands.get(1)), false, RangePredicate.UNBOUNDED,
-                operands.get(1).getLiteral().getType()));
+                getLiteralType(operands.get(1))));
       case LESS_THAN:
         return FilterContext.forPredicate(
             new RangePredicate(operands.get(0), false, RangePredicate.UNBOUNDED, false, getStringValue(operands.get(1)),
-                operands.get(1).getLiteral().getType()));
+                getLiteralType(operands.get(1))));
       case LESS_THAN_OR_EQUAL:
         return FilterContext.forPredicate(
             new RangePredicate(operands.get(0), false, RangePredicate.UNBOUNDED, true, getStringValue(operands.get(1)),
-                operands.get(1).getLiteral().getType()));
+                getLiteralType(operands.get(1))));
       case BETWEEN:
         return FilterContext.forPredicate(
             new RangePredicate(operands.get(0), true, getStringValue(operands.get(1)), true,
-                getStringValue(operands.get(2)), operands.get(1).getLiteral().getType()));
+                getStringValue(operands.get(2)), getLiteralType(operands.get(1))));
       case RANGE:
         return FilterContext.forPredicate(new RangePredicate(operands.get(0), getStringValue(operands.get(1))));
       case REGEXP_LIKE:
@@ -479,11 +494,190 @@ public class RequestContextUtils {
   //       literal context doesn't support float, and we cannot differentiate explicit string literal and literal
   //       without explicit type, so we always convert the literal into string.
   private static String getStringValue(ExpressionContext expressionContext) {
-    if (expressionContext.getType() != ExpressionContext.Type.LITERAL) {
-      throw new BadQueryRequestException(
-          "Pinot does not support column or function on the right-hand side of the predicate");
+    return evaluateLiteralValue(expressionContext).getStringValue();
+  }
+
+  private static DataType getLiteralType(Expression thriftExpression) {
+    return evaluateLiteralValue(thriftExpression).getType();
+  }
+
+  private static DataType getLiteralType(ExpressionContext expressionContext) {
+    return evaluateLiteralValue(expressionContext).getType();
+  }
+
+  private static EvaluatedLiteralValue evaluateLiteralValue(Expression thriftExpression) {
+    Literal literal = thriftExpression.getLiteral();
+    if (literal != null) {
+      return fromLiteralContext(new LiteralContext(literal));
     }
-    return expressionContext.getLiteral().getStringValue();
+    Function function = thriftExpression.getFunctionCall();
+    if (function != null) {
+      return evaluateFunctionLiteral(function.getOperator(), function.getOperands(),
+          RequestContextUtils::evaluateLiteralValue);
+    }
+    throw new BadQueryRequestException(UNSUPPORTED_RHS_MESSAGE);
+  }
+
+  private static EvaluatedLiteralValue evaluateLiteralValue(ExpressionContext expressionContext) {
+    if (expressionContext.getType() == ExpressionContext.Type.LITERAL) {
+      return fromLiteralContext(expressionContext.getLiteral());
+    }
+    if (expressionContext.getType() == ExpressionContext.Type.FUNCTION) {
+      FunctionContext function = expressionContext.getFunction();
+      return evaluateFunctionLiteral(function.getFunctionName(), function.getArguments(),
+          RequestContextUtils::evaluateLiteralValue);
+    }
+    throw new BadQueryRequestException(UNSUPPORTED_RHS_MESSAGE);
+  }
+
+  private static <T> EvaluatedLiteralValue evaluateFunctionLiteral(String functionName, List<T> operands,
+      java.util.function.Function<T, EvaluatedLiteralValue> evaluator) {
+    String canonicalName = FunctionRegistry.canonicalize(functionName);
+    switch (canonicalName) {
+      case "cast": {
+        validateFunctionArity("CAST", operands, 2);
+        EvaluatedLiteralValue source = evaluator.apply(operands.get(0));
+        EvaluatedLiteralValue target = evaluator.apply(operands.get(1));
+        return evaluateCastLiteral(source, getCastTargetType(target.getStringValue()));
+      }
+      case "touuid":
+        validateFunctionArity("TO_UUID", operands, 1);
+        return evaluateToUuidLiteral(evaluator.apply(operands.get(0)));
+      case "uuidtobytes":
+        validateFunctionArity("UUID_TO_BYTES", operands, 1);
+        return evaluateUuidToBytesLiteral(evaluator.apply(operands.get(0)));
+      case "bytestouuid":
+        validateFunctionArity("BYTES_TO_UUID", operands, 1);
+        return evaluateBytesToUuidLiteral(evaluator.apply(operands.get(0)));
+      case "uuidtostring":
+        validateFunctionArity("UUID_TO_STRING", operands, 1);
+        return evaluateUuidToStringLiteral(evaluator.apply(operands.get(0)));
+      case "isuuid":
+        validateFunctionArity("IS_UUID", operands, 1);
+        return evaluateIsUuidLiteral(evaluator.apply(operands.get(0)));
+      default:
+        throw new BadQueryRequestException(UNSUPPORTED_RHS_MESSAGE);
+    }
+  }
+
+  private static EvaluatedLiteralValue evaluateCastLiteral(EvaluatedLiteralValue source, DataType targetType) {
+    if (source.getType() == DataType.UNKNOWN) {
+      return new EvaluatedLiteralValue(source.getStringValue(), targetType);
+    }
+
+    if (targetType == DataType.UUID) {
+      return new EvaluatedLiteralValue(convertToCanonicalUuidString(source), DataType.UUID);
+    }
+    if (targetType == DataType.STRING && source.getType() == DataType.UUID) {
+      return new EvaluatedLiteralValue(convertToCanonicalUuidString(source), DataType.STRING);
+    }
+    if (targetType == DataType.BYTES && source.getType() == DataType.UUID) {
+      return new EvaluatedLiteralValue(BytesUtils.toHexString(UuidUtils.toBytes(convertToCanonicalUuidString(source))),
+          DataType.BYTES);
+    }
+
+    Object converted = targetType.convert(source.getStringValue());
+    return new EvaluatedLiteralValue(targetType.toString(converted), targetType);
+  }
+
+  private static EvaluatedLiteralValue evaluateToUuidLiteral(EvaluatedLiteralValue source) {
+    return new EvaluatedLiteralValue(convertToCanonicalUuidString(source), DataType.UUID);
+  }
+
+  private static EvaluatedLiteralValue evaluateUuidToBytesLiteral(EvaluatedLiteralValue source) {
+    Preconditions.checkArgument(source.getType() == DataType.UUID, "UUID_TO_BYTES requires a UUID operand");
+    return new EvaluatedLiteralValue(BytesUtils.toHexString(UuidUtils.toBytes(source.getStringValue())),
+        DataType.BYTES);
+  }
+
+  private static EvaluatedLiteralValue evaluateBytesToUuidLiteral(EvaluatedLiteralValue source) {
+    Preconditions.checkArgument(source.getType() == DataType.BYTES, "BYTES_TO_UUID requires a BYTES operand");
+    return new EvaluatedLiteralValue(convertToCanonicalUuidString(source), DataType.UUID);
+  }
+
+  private static EvaluatedLiteralValue evaluateUuidToStringLiteral(EvaluatedLiteralValue source) {
+    Preconditions.checkArgument(source.getType() == DataType.UUID, "UUID_TO_STRING requires a UUID operand");
+    return new EvaluatedLiteralValue(convertToCanonicalUuidString(source), DataType.STRING);
+  }
+
+  private static EvaluatedLiteralValue evaluateIsUuidLiteral(EvaluatedLiteralValue source) {
+    boolean isUuid;
+    switch (source.getType()) {
+      case STRING:
+        isUuid = UuidUtils.isUuid(source.getStringValue());
+        break;
+      case BYTES:
+        isUuid = UuidUtils.isUuid(BytesUtils.toBytes(source.getStringValue()));
+        break;
+      case UUID:
+        isUuid = true;
+        break;
+      case UNKNOWN:
+        isUuid = false;
+        break;
+      default:
+        throw new IllegalArgumentException("IS_UUID only supports STRING, BYTES, or UUID operands");
+    }
+    return new EvaluatedLiteralValue(Boolean.toString(isUuid), DataType.BOOLEAN);
+  }
+
+  private static String convertToCanonicalUuidString(EvaluatedLiteralValue source) {
+    switch (source.getType()) {
+      case STRING:
+      case UUID:
+        return UuidUtils.toString(UuidUtils.toBytes(source.getStringValue()));
+      case BYTES:
+        return UuidUtils.toString(BytesUtils.toBytes(source.getStringValue()));
+      default:
+        throw new IllegalArgumentException("Cannot convert " + source.getType() + " literal to UUID");
+    }
+  }
+
+  private static DataType getCastTargetType(String targetTypeString) {
+    switch (targetTypeString.toUpperCase(Locale.ROOT)) {
+      case "INT":
+      case "INTEGER":
+        return DataType.INT;
+      case "LONG":
+      case "BIGINT":
+        return DataType.LONG;
+      case "FLOAT":
+        return DataType.FLOAT;
+      case "DOUBLE":
+        return DataType.DOUBLE;
+      case "DECIMAL":
+      case "BIGDECIMAL":
+      case "BIG_DECIMAL":
+        return DataType.BIG_DECIMAL;
+      case "BOOL":
+      case "BOOLEAN":
+        return DataType.BOOLEAN;
+      case "TIMESTAMP":
+        return DataType.TIMESTAMP;
+      case "STRING":
+      case "VARCHAR":
+        return DataType.STRING;
+      case "JSON":
+        return DataType.JSON;
+      case "BYTES":
+      case "VARBINARY":
+        return DataType.BYTES;
+      case "UUID":
+        return DataType.UUID;
+      default:
+        throw new BadQueryRequestException("Unable to cast expression to type - " + targetTypeString);
+    }
+  }
+
+  private static void validateFunctionArity(String functionName, List<?> operands, int expectedArity) {
+    if (operands.size() != expectedArity) {
+      throw new BadQueryRequestException(functionName + " function must have exactly " + expectedArity + " operand"
+          + (expectedArity == 1 ? "" : "s"));
+    }
+  }
+
+  private static EvaluatedLiteralValue fromLiteralContext(LiteralContext literalContext) {
+    return new EvaluatedLiteralValue(literalContext.getStringValue(), literalContext.getType());
   }
 
   private static float[] getVectorValue(ExpressionContext expressionContext) {
@@ -571,6 +765,24 @@ public class RequestContextUtils {
         return (float) literal.getDoubleValue();
       default:
         throw new IllegalStateException("Unsupported literal type: " + type);
+    }
+  }
+
+  private static final class EvaluatedLiteralValue {
+    private final String _stringValue;
+    private final DataType _type;
+
+    private EvaluatedLiteralValue(String stringValue, DataType type) {
+      _stringValue = stringValue;
+      _type = type;
+    }
+
+    private String getStringValue() {
+      return _stringValue;
+    }
+
+    private DataType getType() {
+      return _type;
     }
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/request/context/predicate/BaseInPredicate.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/request/context/predicate/BaseInPredicate.java
@@ -25,6 +25,7 @@ import org.apache.pinot.spi.utils.BooleanUtils;
 import org.apache.pinot.spi.utils.ByteArray;
 import org.apache.pinot.spi.utils.BytesUtils;
 import org.apache.pinot.spi.utils.TimestampUtils;
+import org.apache.pinot.spi.utils.UuidUtils;
 
 
 /**
@@ -42,6 +43,7 @@ public abstract class BaseInPredicate extends BasePredicate {
   private int[] _booleanValues;
   private long[] _timestampValues;
   private ByteArray[] _bytesValues;
+  private ByteArray[] _uuidValues;
 
   public BaseInPredicate(ExpressionContext lhs, List<String> values) {
     super(lhs);
@@ -154,5 +156,18 @@ public abstract class BaseInPredicate extends BasePredicate {
       _bytesValues = bigDecimalValues;
     }
     return bigDecimalValues;
+  }
+
+  public ByteArray[] getUuidValues() {
+    ByteArray[] uuidValues = _uuidValues;
+    if (uuidValues == null) {
+      int numValues = _values.size();
+      uuidValues = new ByteArray[numValues];
+      for (int i = 0; i < numValues; i++) {
+        uuidValues[i] = new ByteArray(UuidUtils.toBytes(_values.get(i)));
+      }
+      _uuidValues = uuidValues;
+    }
+    return uuidValues;
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/encoder/ArrowResponseEncoder.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/encoder/ArrowResponseEncoder.java
@@ -22,6 +22,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -48,6 +49,7 @@ import org.apache.arrow.vector.types.pojo.Schema;
 import org.apache.arrow.vector.util.JsonStringArrayList;
 import org.apache.pinot.common.response.broker.ResultTable;
 import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.spi.utils.ByteArray;
 import org.apache.pinot.spi.utils.MapUtils;
 
 
@@ -104,6 +106,7 @@ public class ArrowResponseEncoder implements ResponseEncoder {
           vector = new Float8Vector(colName, ALLOCATOR);
           break;
         case TIMESTAMP:
+        case UUID:
         case STRING:
         case BYTES:
         case BIG_DECIMAL:
@@ -230,12 +233,13 @@ public class ArrowResponseEncoder implements ResponseEncoder {
               ((Float8Vector) vector).setSafe(rowIndex, ((Number) value).doubleValue());
               break;
             case TIMESTAMP:
+            case UUID:
             case STRING:
             case BYTES:
             case BIG_DECIMAL:
             case JSON:
             case OBJECT:
-              byte[] bytes = ((String) value).getBytes(StandardCharsets.UTF_8);
+              byte[] bytes = getVarCharValue(colType, value).getBytes(StandardCharsets.UTF_8);
               ((VarCharVector) vector).setSafe(rowIndex, bytes);
               break;
             case MAP:
@@ -406,6 +410,7 @@ public class ArrowResponseEncoder implements ResponseEncoder {
               row[col] = ((BitVector) vector).get(i) == 1;
               break;
             case TIMESTAMP:
+            case UUID:
             case STRING:
             case BYTES:
             case BIG_DECIMAL:
@@ -484,6 +489,30 @@ public class ArrowResponseEncoder implements ResponseEncoder {
       }
       // Construct a Pinot ResultTable from the DataSchema and rows.
       return new ResultTable(schema, rows);
+    }
+  }
+
+  private static String getVarCharValue(DataSchema.ColumnDataType columnDataType, Object value) {
+    if (value instanceof String) {
+      return (String) value;
+    }
+    switch (columnDataType) {
+      case TIMESTAMP:
+        return value instanceof Timestamp ? columnDataType.format(value).toString()
+            : columnDataType.convertAndFormat(value).toString();
+      case UUID:
+        return columnDataType.format(value).toString();
+      case BYTES:
+        return value instanceof ByteArray ? columnDataType.convertAndFormat(value).toString()
+            : columnDataType.format(value).toString();
+      case BIG_DECIMAL:
+        return columnDataType.format(value).toString();
+      case STRING:
+      case JSON:
+      case OBJECT:
+        return value.toString();
+      default:
+        throw new IllegalStateException("Unsupported column type for var char encoding: " + columnDataType);
     }
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/encoder/JsonResponseEncoder.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/encoder/JsonResponseEncoder.java
@@ -220,6 +220,7 @@ public class JsonResponseEncoder implements ResponseEncoder {
       case DOUBLE:
         return jsonValue.asDouble();
       case STRING:
+      case UUID:
       case BYTES:
       case TIMESTAMP:
       case JSON:

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/DataSchema.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/DataSchema.java
@@ -40,6 +40,7 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.sql.type.SqlTypeName;
@@ -50,6 +51,7 @@ import org.apache.pinot.spi.utils.ByteArray;
 import org.apache.pinot.spi.utils.BytesUtils;
 import org.apache.pinot.spi.utils.CommonConstants.NullValuePlaceHolder;
 import org.apache.pinot.spi.utils.EqualityUtils;
+import org.apache.pinot.spi.utils.UuidUtils;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -302,6 +304,12 @@ public class DataSchema {
         return typeFactory.createSqlType(SqlTypeName.VARBINARY);
       }
     },
+    UUID(BYTES, NullValuePlaceHolder.INTERNAL_UUID_BYTES) {
+      @Override
+      public RelDataType toType(RelDataTypeFactory typeFactory) {
+        return typeFactory.createSqlType(SqlTypeName.UUID);
+      }
+    },
     OBJECT(null) {
       @Override
       public RelDataType toType(RelDataTypeFactory typeFactory) {
@@ -452,6 +460,8 @@ public class DataSchema {
           return DataType.STRING;
         case JSON:
           return DataType.JSON;
+        case UUID:
+          return DataType.UUID;
         case BYTES:
         case BYTES_ARRAY:
           return DataType.BYTES;
@@ -490,6 +500,8 @@ public class DataSchema {
           return ((boolean) value) ? 1 : 0;
         case TIMESTAMP:
           return ((Timestamp) value).getTime();
+        case UUID:
+          return new ByteArray(UuidUtils.toBytes(value));
         case BYTES:
           return new ByteArray((byte[]) value);
         case BOOLEAN_ARRAY:
@@ -504,6 +516,9 @@ public class DataSchema {
           }
           if (value instanceof Timestamp) {
             return ((Timestamp) value).getTime();
+          }
+          if (value instanceof UUID) {
+            return new ByteArray(UuidUtils.toBytes((UUID) value));
           }
           if (value instanceof byte[]) {
             return new ByteArray((byte[]) value);
@@ -538,6 +553,8 @@ public class DataSchema {
           return ((int) value) == 1;
         case TIMESTAMP:
           return new Timestamp((long) value);
+        case UUID:
+          return UuidUtils.toUUID((ByteArray) value);
         case BYTES:
           return ((ByteArray) value).getBytes();
         case BOOLEAN_ARRAY:
@@ -569,6 +586,8 @@ public class DataSchema {
           return ((int) value) == 1;
         case TIMESTAMP:
           return new Timestamp((long) value);
+        case UUID:
+          return UuidUtils.toUUID((ByteArray) value);
         case STRING:
         case JSON:
           return value.toString();
@@ -609,6 +628,8 @@ public class DataSchema {
         case TIMESTAMP:
           assert value instanceof Timestamp;
           return value.toString();
+        case UUID:
+          return formatUuid(value);
         case BYTES:
           return BytesUtils.toHexString((byte[]) value);
         case TIMESTAMP_ARRAY:
@@ -639,6 +660,8 @@ public class DataSchema {
           return ((int) value) == 1;
         case TIMESTAMP:
           return new Timestamp((long) value).toString();
+        case UUID:
+          return UuidUtils.toString((ByteArray) value);
         case STRING:
         case JSON:
           return value.toString();
@@ -844,6 +867,8 @@ public class DataSchema {
           return STRING;
         case JSON:
           return JSON;
+        case UUID:
+          return UUID;
         case BYTES:
           return BYTES;
         case MAP:
@@ -876,6 +901,19 @@ public class DataSchema {
         default:
           throw new IllegalStateException("Unsupported data type: " + dataType);
       }
+    }
+
+    private static String formatUuid(Object value) {
+      if (value instanceof UUID) {
+        return ((UUID) value).toString();
+      }
+      if (value instanceof byte[]) {
+        return UuidUtils.toString((byte[]) value);
+      }
+      if (value instanceof ByteArray) {
+        return UuidUtils.toString((ByteArray) value);
+      }
+      return UuidUtils.toString(UuidUtils.toBytes(value));
     }
 
     public abstract RelDataType toType(RelDataTypeFactory typeFactory);

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/PinotDataType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/PinotDataType.java
@@ -24,6 +24,7 @@ import java.sql.Timestamp;
 import java.util.Base64;
 import java.util.Collection;
 import java.util.Map;
+import java.util.UUID;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.spi.data.FieldSpec;
@@ -34,6 +35,7 @@ import org.apache.pinot.spi.utils.BytesUtils;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.MapUtils;
 import org.apache.pinot.spi.utils.TimestampUtils;
+import org.apache.pinot.spi.utils.UuidUtils;
 
 
 /**
@@ -650,6 +652,11 @@ public enum PinotDataType {
     }
 
     @Override
+    public UUID toUUID(Object value) {
+      return UuidUtils.toUUID(value.toString());
+    }
+
+    @Override
     public String convert(Object value, PinotDataType sourceType) {
       return sourceType.toString(value);
     }
@@ -761,8 +768,75 @@ public enum PinotDataType {
     }
 
     @Override
+    public UUID toUUID(Object value) {
+      return UuidUtils.toUUID(value);
+    }
+
+    @Override
     public Object convert(Object value, PinotDataType sourceType) {
       return sourceType.toBytes(value);
+    }
+  },
+
+  UUID {
+    @Override
+    public int toInt(Object value) {
+      throw new UnsupportedOperationException("Cannot convert value from UUID to INTEGER");
+    }
+
+    @Override
+    public long toLong(Object value) {
+      throw new UnsupportedOperationException("Cannot convert value from UUID to LONG");
+    }
+
+    @Override
+    public float toFloat(Object value) {
+      throw new UnsupportedOperationException("Cannot convert value from UUID to FLOAT");
+    }
+
+    @Override
+    public double toDouble(Object value) {
+      throw new UnsupportedOperationException("Cannot convert value from UUID to DOUBLE");
+    }
+
+    @Override
+    public BigDecimal toBigDecimal(Object value) {
+      throw new UnsupportedOperationException("Cannot convert value from UUID to BIG_DECIMAL");
+    }
+
+    @Override
+    public boolean toBoolean(Object value) {
+      throw new UnsupportedOperationException("Cannot convert value from UUID to BOOLEAN");
+    }
+
+    @Override
+    public Timestamp toTimestamp(Object value) {
+      throw new UnsupportedOperationException("Cannot convert value from UUID to TIMESTAMP");
+    }
+
+    @Override
+    public String toString(Object value) {
+      return UuidUtils.toUUID(value).toString();
+    }
+
+    @Override
+    public byte[] toBytes(Object value) {
+      return UuidUtils.toBytes(value);
+    }
+
+    @Override
+    public UUID toUUID(Object value) {
+      return UuidUtils.toUUID(value);
+    }
+
+    @Override
+    public UUID convert(Object value, PinotDataType sourceType) {
+      return sourceType.toUUID(value);
+    }
+
+    @Override
+    public byte[] toInternal(Object value) {
+      return UuidUtils.toBytes(value);
     }
   },
 
@@ -810,6 +884,11 @@ public enum PinotDataType {
     @Override
     public byte[] toBytes(Object value) {
       throw new UnsupportedOperationException("Cannot convert value from OBJECT to BYTES");
+    }
+
+    @Override
+    public UUID toUUID(Object value) {
+      return UuidUtils.toUUID(value);
     }
 
     @Override
@@ -1050,6 +1129,10 @@ public enum PinotDataType {
 
   public byte[] toBytes(Object value) {
     return getSingleValueType().toBytes(toObjectArray(value)[0]);
+  }
+
+  public UUID toUUID(Object value) {
+    return getSingleValueType().toUUID(toObjectArray(value)[0]);
   }
 
   public int[] toPrimitiveIntArray(Object value) {
@@ -1403,6 +1486,9 @@ public enum PinotDataType {
     if (cls == byte[].class) {
       return BYTES;
     }
+    if (cls == UUID.class) {
+      return UUID;
+    }
     if (cls == Boolean.class) {
       return BOOLEAN;
     }
@@ -1508,6 +1594,11 @@ public enum PinotDataType {
         throw new IllegalStateException("There is no multi-value type for JSON");
       case STRING:
         return fieldSpec.isSingleValueField() ? STRING : STRING_ARRAY;
+      case UUID:
+        if (fieldSpec.isSingleValueField()) {
+          return UUID;
+        }
+        throw new IllegalStateException("UUID data type only supports single-value fields");
       case BYTES:
         return fieldSpec.isSingleValueField() ? BYTES : BYTES_ARRAY;
       case MAP:
@@ -1547,6 +1638,8 @@ public enum PinotDataType {
         return JSON;
       case BYTES:
         return BYTES;
+      case UUID:
+        return UUID;
       case OBJECT:
         return OBJECT;
       case INT_ARRAY:

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/PredicateComparisonRewriter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/PredicateComparisonRewriter.java
@@ -25,6 +25,7 @@ import org.apache.pinot.common.request.Expression;
 import org.apache.pinot.common.request.ExpressionType;
 import org.apache.pinot.common.request.Function;
 import org.apache.pinot.common.request.PinotQuery;
+import org.apache.pinot.common.request.context.RequestContextUtils;
 import org.apache.pinot.common.utils.request.RequestUtils;
 import org.apache.pinot.sql.FilterKind;
 import org.apache.pinot.sql.parsers.SqlCompilationException;
@@ -104,10 +105,12 @@ public class PredicateComparisonRewriter implements QueryRewriter {
         case LESS_THAN_OR_EQUAL:
           Expression firstOperand = operands.get(0);
           Expression secondOperand = operands.get(1);
+          boolean firstOperandIsLiteral = RequestContextUtils.canEvaluateLiteral(firstOperand);
+          boolean secondOperandIsLiteral = RequestContextUtils.canEvaluateLiteral(secondOperand);
 
           // Handle predicate like '10 = a' -> 'a = 10'
-          if (firstOperand.isSetLiteral()) {
-            if (!secondOperand.isSetLiteral()) {
+          if (firstOperandIsLiteral) {
+            if (!secondOperandIsLiteral) {
               function.setOperator(getOppositeOperator(filterKind).name());
               operands.set(0, secondOperand);
               operands.set(1, firstOperand);
@@ -116,7 +119,7 @@ public class PredicateComparisonRewriter implements QueryRewriter {
           }
 
           // Handle predicate like 'a > b' -> 'a - b > 0'
-          if (!secondOperand.isSetLiteral()) {
+          if (!secondOperandIsLiteral) {
             Expression minusExpression = RequestUtils.getFunctionExpression("minus", firstOperand, secondOperand);
             operands.set(0, minusExpression);
             operands.set(1, RequestUtils.getLiteralExpression(0));
@@ -170,7 +173,7 @@ public class PredicateComparisonRewriter implements QueryRewriter {
         default:
           int numOperands = operands.size();
           for (int i = 1; i < numOperands; i++) {
-            if (!operands.get(i).isSetLiteral()) {
+            if (!RequestContextUtils.canEvaluateLiteral(operands.get(i))) {
               throw new SqlCompilationException(
                   String.format("For %s predicate, the operands except for the first one must be literal, got: %s",
                       filterKind, expression));

--- a/pinot-common/src/main/proto/expressions.proto
+++ b/pinot-common/src/main/proto/expressions.proto
@@ -43,6 +43,7 @@ enum ColumnDataType {
   BYTES_ARRAY = 18;
   UNKNOWN = 19;
   MAP = 20;
+  UUID = 21;
 }
 
 message InputRef {

--- a/pinot-common/src/test/java/org/apache/pinot/common/function/FunctionUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/function/FunctionUtilsTest.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.function;
+
+import org.apache.calcite.jdbc.JavaTypeFactoryImpl;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+import org.apache.pinot.common.utils.PinotDataType;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class FunctionUtilsTest {
+  @Test
+  public void testUUIDMappings() {
+    Assert.assertEquals(FunctionUtils.getParameterType(java.util.UUID.class), PinotDataType.UUID);
+    Assert.assertEquals(FunctionUtils.getArgumentType(java.util.UUID.class), PinotDataType.UUID);
+    Assert.assertEquals(FunctionUtils.getDataType(java.util.UUID.class), DataType.UUID);
+    Assert.assertEquals(FunctionUtils.getColumnDataType(java.util.UUID.class), ColumnDataType.UUID);
+    Assert.assertEquals(FunctionUtils.getRelDataType(new JavaTypeFactoryImpl(), java.util.UUID.class).getSqlTypeName(),
+        SqlTypeName.UUID);
+  }
+}

--- a/pinot-common/src/test/java/org/apache/pinot/common/function/scalar/StringFunctionsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/function/scalar/StringFunctionsTest.java
@@ -24,6 +24,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 
 
 public class StringFunctionsTest {
@@ -232,6 +233,15 @@ public class StringFunctionsTest {
         {"hello@world.com", "Hello@world.com"},
         {"one,two,three", "One,two,three"}
     };
+  }
+
+  @Test
+  public void testToUuidBytesAcceptsMixedCaseInput() {
+    String mixedCaseUuid = "550E8400-E29B-41D4-A716-446655440000";
+    byte[] uuidBytes = StringFunctions.toUUIDBytes(mixedCaseUuid);
+
+    assertNotNull(uuidBytes);
+    assertEquals(StringFunctions.fromUUIDBytes(uuidBytes), "550e8400-e29b-41d4-a716-446655440000");
   }
 
   @DataProvider(name = "levenshteinDistanceTestCases")

--- a/pinot-common/src/test/java/org/apache/pinot/common/function/scalar/uuid/UuidConversionFunctionsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/function/scalar/uuid/UuidConversionFunctionsTest.java
@@ -1,0 +1,108 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.function.scalar.uuid;
+
+import java.util.UUID;
+import org.apache.pinot.spi.utils.UuidUtils;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+
+public class UuidConversionFunctionsTest {
+  private static final String UUID_VALUE = "550e8400-e29b-41d4-a716-446655440000";
+  private static final String MIXED_CASE_UUID_VALUE = "550E8400-E29B-41D4-A716-446655440000";
+
+  @DataProvider(name = "invalidUuidStrings")
+  public Object[][] invalidUuidStrings() {
+    return new Object[][]{
+        {"550e8400-e29b-41d4-a716-44665544000"},
+        {"550e8400-e29b-41d4-a716-4466554400000"},
+        {"550e8400-e29b-41d4-a716-44665544000g"},
+        {"550e8400e29b41d4a716446655440000"},
+        {""}
+    };
+  }
+
+  @DataProvider(name = "invalidUuidBytes")
+  public Object[][] invalidUuidBytes() {
+    return new Object[][]{
+        {new byte[15]},
+        {new byte[17]}
+    };
+  }
+
+  @Test
+  public void testToUuidFromStringNormalizesToLowerCase() {
+    assertEquals(ToUuidScalarFunction.toUuid(MIXED_CASE_UUID_VALUE), UUID.fromString(UUID_VALUE));
+  }
+
+  @Test
+  public void testToUuidFromBytes() {
+    byte[] bytes = UuidUtils.toBytes(UUID_VALUE);
+
+    assertEquals(ToUuidScalarFunction.toUuid(bytes), UUID.fromString(UUID_VALUE));
+    assertEquals(UuidConversionFunctions.bytesToUuid(bytes), UUID.fromString(UUID_VALUE));
+  }
+
+  @Test
+  public void testUuidToBytesAndString() {
+    UUID uuid = UUID.fromString(UUID_VALUE);
+
+    assertEquals(UuidConversionFunctions.uuidToBytes(uuid), UuidUtils.toBytes(UUID_VALUE));
+    assertEquals(UuidConversionFunctions.uuidToString(uuid), UUID_VALUE);
+  }
+
+  @Test
+  public void testIsUuid() {
+    assertTrue(IsUuidScalarFunction.isUuid(UUID_VALUE));
+    assertTrue(IsUuidScalarFunction.isUuid(UuidUtils.toBytes(UUID_VALUE)));
+    assertFalse(IsUuidScalarFunction.isUuid("not-a-uuid"));
+    assertFalse(IsUuidScalarFunction.isUuid(new byte[15]));
+  }
+
+  @Test(dataProvider = "invalidUuidStrings")
+  public void testToUuidRejectsInvalidString(String invalidUuid) {
+    Assert.expectThrows(IllegalArgumentException.class, () -> ToUuidScalarFunction.toUuid(invalidUuid));
+    assertFalse(IsUuidScalarFunction.isUuid(invalidUuid));
+  }
+
+  @Test(dataProvider = "invalidUuidBytes")
+  public void testBytesToUuidRejectsInvalidBytes(byte[] invalidBytes) {
+    Assert.expectThrows(IllegalArgumentException.class, () -> ToUuidScalarFunction.toUuid(invalidBytes));
+    Assert.expectThrows(IllegalArgumentException.class, () -> UuidConversionFunctions.bytesToUuid(invalidBytes));
+    assertFalse(IsUuidScalarFunction.isUuid(invalidBytes));
+  }
+
+  @Test
+  public void testNullInputs() {
+    assertNull(ToUuidScalarFunction.toUuid((String) null));
+    assertNull(ToUuidScalarFunction.toUuid((byte[]) null));
+    assertNull(UuidConversionFunctions.uuidToBytes(null));
+    assertNull(UuidConversionFunctions.bytesToUuid(null));
+    assertNull(UuidConversionFunctions.uuidToString(null));
+    assertFalse(IsUuidScalarFunction.isUuid((String) null));
+    assertFalse(IsUuidScalarFunction.isUuid((byte[]) null));
+  }
+}

--- a/pinot-common/src/test/java/org/apache/pinot/common/request/context/LiteralContextTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/request/context/LiteralContextTest.java
@@ -25,6 +25,7 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.BigDecimalUtils;
 import org.apache.pinot.spi.utils.BytesUtils;
 import org.apache.pinot.spi.utils.CommonConstants.NullValuePlaceHolder;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.*;
@@ -221,5 +222,17 @@ public class LiteralContextTest {
     assertEquals(literalContext.getBytesValue(), BytesUtils.toBytes("deadbeef"));
     assertFalse(literalContext.isNull());
     assertEquals(literalContext.toString(), "'deadbeef'");
+  }
+
+  @Test
+  public void testUuidLiteral() {
+    String mixedCaseUuid = "550E8400-E29B-41D4-A716-446655440000";
+    String canonicalUuid = "550e8400-e29b-41d4-a716-446655440000";
+    LiteralContext literalContext = new LiteralContext(DataType.UUID, mixedCaseUuid);
+
+    assertEquals(literalContext.getStringValue(), canonicalUuid);
+    assertEquals(literalContext.getBytesValue(), UuidUtils.toBytes(canonicalUuid));
+    assertFalse(literalContext.isNull());
+    assertEquals(literalContext.toString(), "'" + canonicalUuid + "'");
   }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/common/request/context/RequestContextUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/request/context/RequestContextUtilsTest.java
@@ -1,0 +1,125 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.request.context;
+
+import java.util.List;
+import java.util.Locale;
+import org.apache.pinot.common.request.context.predicate.EqPredicate;
+import org.apache.pinot.common.request.context.predicate.InPredicate;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.exception.BadQueryRequestException;
+import org.apache.pinot.spi.utils.BytesUtils;
+import org.apache.pinot.spi.utils.UuidUtils;
+import org.apache.pinot.sql.parsers.CalciteSqlParser;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+/**
+ * Tests filter conversion for literal-only expressions on the right-hand side.
+ */
+public class RequestContextUtilsTest {
+  private static final String UUID_1 = "550e8400-e29b-41d4-a716-446655440000";
+  private static final String UUID_2 = "550e8400-e29b-41d4-a716-446655440001";
+
+  @Test
+  public void testGetFilterWithUuidCastLiteralRhs() {
+    FilterContext filter =
+        RequestContextUtils.getFilter(CalciteSqlParser.compileToExpression("uuidCol = CAST('" + UUID_1 + "' AS UUID)"));
+
+    Assert.assertEquals(filter.getType(), FilterContext.Type.PREDICATE);
+    EqPredicate predicate = (EqPredicate) filter.getPredicate();
+    Assert.assertEquals(predicate.getLhs().getIdentifier(), "uuidCol");
+    Assert.assertEquals(predicate.getValue(), UUID_1);
+  }
+
+  @Test
+  public void testGetFilterExpressionContextWithUuidCastLiteralIn() {
+    FilterContext filter = RequestContextUtils.getFilter(
+        RequestContextUtils.getExpression("uuidCol IN (CAST('" + UUID_1 + "' AS UUID), CAST('" + UUID_2 + "' AS UUID))"));
+
+    Assert.assertEquals(filter.getType(), FilterContext.Type.PREDICATE);
+    InPredicate predicate = (InPredicate) filter.getPredicate();
+    Assert.assertEquals(predicate.getLhs().getIdentifier(), "uuidCol");
+    Assert.assertEquals(predicate.getValues(), List.of(UUID_1, UUID_2));
+  }
+
+  @Test
+  public void testGetFilterWithToUuidLiteralRhsNormalizesCase() {
+    FilterContext filter = RequestContextUtils.getFilter(
+        CalciteSqlParser.compileToExpression("uuidCol = TO_UUID('550E8400-E29B-41D4-A716-446655440000')"));
+
+    Assert.assertEquals(filter.getType(), FilterContext.Type.PREDICATE);
+    EqPredicate predicate = (EqPredicate) filter.getPredicate();
+    Assert.assertEquals(predicate.getLhs().getIdentifier(), "uuidCol");
+    Assert.assertEquals(predicate.getValue(), UUID_1);
+  }
+
+  @Test
+  public void testGetFilterWithUuidToBytesNestedLiteralRhs() {
+    FilterContext filter = RequestContextUtils.getFilter(
+        CalciteSqlParser.compileToExpression("bytesCol = UUID_TO_BYTES(CAST('" + UUID_1 + "' AS UUID))"));
+
+    Assert.assertEquals(filter.getType(), FilterContext.Type.PREDICATE);
+    EqPredicate predicate = (EqPredicate) filter.getPredicate();
+    Assert.assertEquals(predicate.getLhs().getIdentifier(), "bytesCol");
+    Assert.assertEquals(predicate.getValue(), BytesUtils.toHexString(UuidUtils.toBytes(UUID_1)));
+  }
+
+  @Test
+  public void testGetFilterWithBytesToUuidNestedLiteralRhs() {
+    String bytesLiteral = BytesUtils.toHexString(UuidUtils.toBytes(UUID_2));
+    FilterContext filter = RequestContextUtils.getFilter(
+        CalciteSqlParser.compileToExpression("uuidCol = BYTES_TO_UUID(CAST('" + bytesLiteral + "' AS BYTES))"));
+
+    Assert.assertEquals(filter.getType(), FilterContext.Type.PREDICATE);
+    EqPredicate predicate = (EqPredicate) filter.getPredicate();
+    Assert.assertEquals(predicate.getLhs().getIdentifier(), "uuidCol");
+    Assert.assertEquals(predicate.getValue(), UUID_2);
+  }
+
+  @Test
+  public void testUuidCastLiteralUsesLocaleIndependentTypeParsing() {
+    Locale originalDefault = Locale.getDefault();
+    Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+    try {
+      FilterContext filter = RequestContextUtils.getFilter(
+          CalciteSqlParser.compileToExpression("uuidCol = CAST('" + UUID_1 + "' AS uuid)"));
+
+      Assert.assertEquals(filter.getType(), FilterContext.Type.PREDICATE);
+      EqPredicate predicate = (EqPredicate) filter.getPredicate();
+      Assert.assertEquals(predicate.getValue(), UUID_1);
+    } finally {
+      Locale.setDefault(originalDefault);
+    }
+  }
+
+  @Test
+  public void testInvalidUuidFunctionArityThrowsBadQueryRequest() {
+    FunctionContext castFunction = new FunctionContext(FunctionContext.Type.TRANSFORM, "cast",
+        List.of(ExpressionContext.forLiteral(DataType.STRING, UUID_1)));
+    ExpressionContext filterExpression = ExpressionContext.forFunction(
+        new FunctionContext(FunctionContext.Type.TRANSFORM, "equals",
+            List.of(ExpressionContext.forIdentifier("uuidCol"), ExpressionContext.forFunction(castFunction))));
+
+    BadQueryRequestException exception =
+        Assert.expectThrows(BadQueryRequestException.class, () -> RequestContextUtils.getFilter(filterExpression));
+    Assert.assertEquals(exception.getMessage(), "CAST function must have exactly 2 operands");
+  }
+}

--- a/pinot-common/src/test/java/org/apache/pinot/common/response/encoder/ArrowResponseEncoderTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/response/encoder/ArrowResponseEncoderTest.java
@@ -23,9 +23,11 @@ import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import org.apache.pinot.common.response.broker.ResultTable;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
@@ -112,6 +114,45 @@ public class ArrowResponseEncoderTest {
         assertEquals(actual, expected, "Row " + (i + 1) + " should match");
       }
     }
+  }
+
+  @Test
+  public void testEncodeDecodeUuidColumn()
+      throws IOException {
+    DataSchema schema = new DataSchema(new String[]{"uuidCol"}, new ColumnDataType[]{ColumnDataType.UUID});
+    List<Object[]> rows = Arrays.asList(
+        new Object[]{"550e8400-e29b-41d4-a716-446655440000"},
+        new Object[]{"f81d4fae-7dec-11d0-a765-00a0c91e6bf6"}
+    );
+
+    ResultTable resultTable = new ResultTable(schema, rows);
+    ArrowResponseEncoder encoder = new ArrowResponseEncoder();
+    byte[] encodedBytes = encoder.encodeResultTable(resultTable, 0, rows.size());
+    ResultTable decodedTable = encoder.decodeResultTable(encodedBytes, rows.size(), schema);
+
+    assertEquals(decodedTable.getRows().size(), rows.size(), "Row count should match");
+    for (int i = 0; i < rows.size(); i++) {
+      assertEquals(decodedTable.getRows().get(i)[0], rows.get(i)[0], "UUID row " + i + " should match");
+    }
+  }
+
+  @Test
+  public void testEncodeDecodeUuidColumnWithInternalValue()
+      throws IOException {
+    String uuidValue = "550e8400-e29b-41d4-a716-446655440000";
+    DataSchema schema = new DataSchema(new String[]{"uuidCol", "cnt"},
+        new ColumnDataType[]{ColumnDataType.UUID, ColumnDataType.LONG});
+    List<Object[]> rows =
+        Collections.singletonList(new Object[]{ColumnDataType.UUID.toInternal(UUID.fromString(uuidValue)), 3L});
+
+    ResultTable resultTable = new ResultTable(schema, rows);
+    ArrowResponseEncoder encoder = new ArrowResponseEncoder();
+    byte[] encodedBytes = encoder.encodeResultTable(resultTable, 0, rows.size());
+    ResultTable decodedTable = encoder.decodeResultTable(encodedBytes, rows.size(), schema);
+
+    assertEquals(decodedTable.getRows().size(), 1, "Row count should match");
+    assertEquals(decodedTable.getRows().get(0)[0], uuidValue, "UUID value should round-trip as canonical string");
+    assertEquals(decodedTable.getRows().get(0)[1], 3L, "Non-UUID columns should be preserved");
   }
 
   @Test

--- a/pinot-common/src/test/java/org/apache/pinot/common/response/encoder/JsonResponseEncoderTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/response/encoder/JsonResponseEncoderTest.java
@@ -26,6 +26,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import org.apache.pinot.common.response.broker.ResultTable;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
@@ -108,6 +109,26 @@ public class JsonResponseEncoderTest {
         assertEquals(actual, expected, "Row " + (i + 1) + " should match");
       }
     }
+  }
+
+  @Test
+  public void testEncodeDecodeUuidColumn() throws IOException {
+    DataSchema schema = new DataSchema(
+        new String[] {"uuidCol"},
+        new ColumnDataType[] {ColumnDataType.UUID});
+    String uuidValue = "550e8400-e29b-41d4-a716-446655440000";
+
+    List<Object[]> rows = new ArrayList<>();
+    rows.add(new Object[] {ColumnDataType.UUID.format(UUID.fromString(uuidValue))});
+
+    ResultTable resultTable = new ResultTable(schema, rows);
+    JsonResponseEncoder encoder = new JsonResponseEncoder();
+
+    byte[] encodedBytes = encoder.encodeResultTable(resultTable, 0, rows.size());
+    ResultTable decodedTable = encoder.decodeResultTable(encodedBytes, rows.size(), schema);
+
+    assertEquals(decodedTable.getRows().size(), 1, "Row count should be 1");
+    assertEquals(decodedTable.getRows().get(0)[0], uuidValue, "UUID value should round-trip as canonical string");
   }
 
   @Test

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/DataSchemaTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/DataSchemaTest.java
@@ -22,7 +22,9 @@ import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.sql.Timestamp;
 import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.utils.ByteArray;
 import org.apache.pinot.spi.utils.BytesUtils;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -31,14 +33,15 @@ import static org.apache.pinot.common.utils.DataSchema.ColumnDataType.*;
 
 public class DataSchemaTest {
   private static final String[] COLUMN_NAMES = {
-      "int", "long", "float", "double", "string", "object", "int_array", "long_array", "float_array", "double_array",
-      "string_array", "boolean_array", "timestamp_array", "bytes_array"
+      "int", "long", "float", "double", "string", "uuid", "object", "int_array", "long_array", "float_array",
+      "double_array", "string_array", "boolean_array", "timestamp_array", "bytes_array"
   };
   private static final int NUM_COLUMNS = COLUMN_NAMES.length;
   private static final DataSchema.ColumnDataType[] COLUMN_DATA_TYPES = {
-      INT, LONG, FLOAT, DOUBLE, STRING, OBJECT, INT_ARRAY, LONG_ARRAY, FLOAT_ARRAY, DOUBLE_ARRAY, STRING_ARRAY,
+      INT, LONG, FLOAT, DOUBLE, STRING, UUID, OBJECT, INT_ARRAY, LONG_ARRAY, FLOAT_ARRAY, DOUBLE_ARRAY, STRING_ARRAY,
       BOOLEAN_ARRAY, TIMESTAMP_ARRAY, BYTES_ARRAY
   };
+  private static final String UUID_VALUE = "550e8400-e29b-41d4-a716-446655440000";
 
   @Test
   public void testGetters() {
@@ -71,9 +74,10 @@ public class DataSchemaTest {
   public void testToString() {
     DataSchema dataSchema = new DataSchema(COLUMN_NAMES, COLUMN_DATA_TYPES);
     Assert.assertEquals(dataSchema.toString(),
-        "[int(INT),long(LONG),float(FLOAT),double(DOUBLE),string(STRING),object(OBJECT),int_array(INT_ARRAY),"
-            + "long_array(LONG_ARRAY),float_array(FLOAT_ARRAY),double_array(DOUBLE_ARRAY),string_array(STRING_ARRAY),"
-            + "boolean_array(BOOLEAN_ARRAY),timestamp_array(TIMESTAMP_ARRAY),bytes_array(BYTES_ARRAY)]");
+        "[int(INT),long(LONG),float(FLOAT),double(DOUBLE),string(STRING),uuid(UUID),object(OBJECT),"
+            + "int_array(INT_ARRAY),long_array(LONG_ARRAY),float_array(FLOAT_ARRAY),double_array(DOUBLE_ARRAY),"
+            + "string_array(STRING_ARRAY),boolean_array(BOOLEAN_ARRAY),timestamp_array(TIMESTAMP_ARRAY),"
+            + "bytes_array(BYTES_ARRAY)]");
   }
 
   @Test
@@ -114,6 +118,16 @@ public class DataSchemaTest {
     Assert.assertFalse(STRING.isCompatible(DOUBLE_ARRAY));
     Assert.assertFalse(STRING.isCompatible(STRING_ARRAY));
     Assert.assertFalse(STRING.isCompatible(BYTES_ARRAY));
+
+    Assert.assertFalse(UUID.isNumber());
+    Assert.assertFalse(UUID.isWholeNumber());
+    Assert.assertFalse(UUID.isArray());
+    Assert.assertFalse(UUID.isNumberArray());
+    Assert.assertFalse(UUID.isWholeNumberArray());
+    Assert.assertFalse(UUID.isCompatible(DOUBLE));
+    Assert.assertTrue(UUID.isCompatible(UUID));
+    Assert.assertFalse(UUID.isCompatible(BYTES));
+    Assert.assertFalse(UUID.isCompatible(STRING));
 
     Assert.assertFalse(OBJECT.isNumber());
     Assert.assertFalse(OBJECT.isWholeNumber());
@@ -178,6 +192,7 @@ public class DataSchemaTest {
     Assert.assertEquals(fromDataType(FieldSpec.DataType.DOUBLE, false), DOUBLE_ARRAY);
     Assert.assertEquals(fromDataType(FieldSpec.DataType.STRING, true), STRING);
     Assert.assertEquals(fromDataType(FieldSpec.DataType.STRING, false), STRING_ARRAY);
+    Assert.assertEquals(fromDataType(FieldSpec.DataType.UUID, true), UUID);
     Assert.assertEquals(fromDataType(FieldSpec.DataType.BOOLEAN, false), BOOLEAN_ARRAY);
     Assert.assertEquals(fromDataType(FieldSpec.DataType.TIMESTAMP, false), TIMESTAMP_ARRAY);
     Assert.assertEquals(fromDataType(FieldSpec.DataType.BYTES, false), BYTES_ARRAY);
@@ -186,6 +201,11 @@ public class DataSchemaTest {
     Assert.assertEquals(BIG_DECIMAL.format(bigDecimalValue), bigDecimalValue.toPlainString());
     Timestamp timestampValue = new Timestamp(1234567890123L);
     Assert.assertEquals(TIMESTAMP.format(timestampValue), timestampValue.toString());
+    byte[] uuidBytes = UuidUtils.toBytes(UUID_VALUE);
+    ByteArray uuidValue = new ByteArray(uuidBytes);
+    Assert.assertEquals(UUID.convert(uuidValue), java.util.UUID.fromString(UUID_VALUE));
+    Assert.assertEquals(UUID.format(uuidValue), UUID_VALUE);
+    Assert.assertEquals(UUID.convertAndFormat(uuidValue), UUID_VALUE);
     byte[] bytesValue = {12, 34, 56};
     Assert.assertEquals(BYTES.format(bytesValue), BytesUtils.toHexString(bytesValue));
   }

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/PinotDataTypeTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/PinotDataTypeTest.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.pinot.spi.utils.JsonUtils;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -37,6 +38,7 @@ import static org.testng.Assert.fail;
 
 
 public class PinotDataTypeTest {
+  private static final String UUID_VALUE = "550e8400-e29b-41d4-a716-446655440000";
   private static final PinotDataType[] SOURCE_TYPES = {
       BYTE, CHARACTER, SHORT, INTEGER, LONG, FLOAT, DOUBLE, BIG_DECIMAL, STRING, JSON,
       BYTE_ARRAY, CHARACTER_ARRAY, SHORT_ARRAY, INTEGER_ARRAY, LONG_ARRAY, FLOAT_ARRAY, DOUBLE_ARRAY, STRING_ARRAY
@@ -202,6 +204,20 @@ public class PinotDataTypeTest {
   }
 
   @Test
+  public void testUUID() {
+    java.util.UUID uuid = java.util.UUID.fromString(UUID_VALUE);
+    byte[] uuidBytes = UuidUtils.toBytes(UUID_VALUE);
+    String mixedCaseUuid = UUID_VALUE.toUpperCase();
+
+    assertEquals(UUID.convert(UUID_VALUE, STRING), uuid);
+    assertEquals(UUID.convert(mixedCaseUuid, STRING), uuid);
+    assertEquals(UUID.convert(uuid, UUID), uuid);
+    assertEquals(UUID.convert(uuidBytes, BYTES), uuid);
+    assertEquals(STRING.convert(uuid, UUID), UUID_VALUE);
+    assertEquals(BYTES.convert(uuid, UUID), uuidBytes);
+  }
+
+  @Test
   public void testTimestamp() {
     Timestamp timestamp = new Timestamp(System.currentTimeMillis());
     assertEquals(TIMESTAMP.convert(timestamp.getTime(), LONG), timestamp);
@@ -278,6 +294,7 @@ public class PinotDataTypeTest {
     testCases.put(Timestamp.class, TIMESTAMP);
     testCases.put(String.class, STRING);
     testCases.put(byte[].class, BYTES);
+    testCases.put(java.util.UUID.class, UUID);
 
     for (Map.Entry<Class<?>, PinotDataType> tc : testCases.entrySet()) {
       assertEquals(getSingleValueType(tc.getKey()), tc.getValue());
@@ -327,7 +344,7 @@ public class PinotDataTypeTest {
   public void testInvalidConversion() {
     for (PinotDataType sourceType : values()) {
       if (sourceType.isSingleValue() && sourceType != STRING && sourceType != BYTES && sourceType != JSON
-          && sourceType != BIG_DECIMAL) {
+          && sourceType != BIG_DECIMAL && sourceType != UUID) {
         assertInvalidConversion(null, sourceType, BYTES, UnsupportedOperationException.class);
       }
     }

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/rewriter/PredicateComparisonRewriterTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/rewriter/PredicateComparisonRewriterTest.java
@@ -179,4 +179,66 @@ public class PredicateComparisonRewriterTest {
         CalciteSqlParser.compileToPinotQueryWithoutRewrites("SELECT * FROM mytable WHERE col1 BETWEEN col2 AND col3");
     assertThrows(SqlCompilationException.class, () -> _predicateComparisonRewriter.rewrite(betweenQuery));
   }
+
+  @Test
+  public void testUuidComparisonWithLiteralFunctionRhsIsNotRewrittenToMinus() {
+    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQueryWithoutRewrites(
+        "SELECT * FROM mytable WHERE uuidCol = CAST('550e8400-e29b-41d4-a716-446655440000' AS UUID)");
+
+    PinotQuery rewrittenQuery = _predicateComparisonRewriter.rewrite(pinotQuery);
+    assertEquals(rewrittenQuery.getFilterExpression().getFunctionCall().getOperator(), "EQUALS");
+    assertEquals(rewrittenQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getIdentifier().getName(),
+        "uuidCol");
+    assertEquals(
+        rewrittenQuery.getFilterExpression().getFunctionCall().getOperands().get(1).getFunctionCall().getOperator()
+            .toLowerCase(), "cast");
+  }
+
+  @Test
+  public void testUuidComparisonWithLiteralFunctionLhsIsSwapped() {
+    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQueryWithoutRewrites(
+        "SELECT * FROM mytable WHERE TO_UUID('550e8400-e29b-41d4-a716-446655440000') = uuidCol");
+
+    PinotQuery rewrittenQuery = _predicateComparisonRewriter.rewrite(pinotQuery);
+    assertEquals(rewrittenQuery.getFilterExpression().getFunctionCall().getOperator(), "EQUALS");
+    assertEquals(rewrittenQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getIdentifier().getName(),
+        "uuidCol");
+    String operator =
+        rewrittenQuery.getFilterExpression().getFunctionCall().getOperands().get(1).getFunctionCall().getOperator()
+            .toLowerCase();
+    Assert.assertTrue(operator.equals("touuid") || operator.equals("to_uuid"), operator);
+  }
+
+  @Test
+  public void testUuidInPredicateAcceptsLiteralFunctions() {
+    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQueryWithoutRewrites(
+        "SELECT * FROM mytable WHERE uuidCol IN (CAST('550e8400-e29b-41d4-a716-446655440000' AS UUID),"
+            + " TO_UUID('550e8400-e29b-41d4-a716-446655440001'))");
+
+    PinotQuery rewrittenQuery = _predicateComparisonRewriter.rewrite(pinotQuery);
+    assertEquals(rewrittenQuery.getFilterExpression().getFunctionCall().getOperator(), "IN");
+    assertEquals(rewrittenQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getIdentifier().getName(),
+        "uuidCol");
+    assertEquals(
+        rewrittenQuery.getFilterExpression().getFunctionCall().getOperands().get(1).getFunctionCall().getOperator()
+            .toLowerCase(), "cast");
+    String operator =
+        rewrittenQuery.getFilterExpression().getFunctionCall().getOperands().get(2).getFunctionCall().getOperator()
+            .toLowerCase();
+    Assert.assertTrue(operator.equals("touuid") || operator.equals("to_uuid"), operator);
+  }
+
+  @Test
+  public void testUuidNotInPredicateAcceptsLiteralFunctions() {
+    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQueryWithoutRewrites(
+        "SELECT * FROM mytable WHERE uuidCol NOT IN (CAST('550e8400-e29b-41d4-a716-446655440000' AS UUID))");
+
+    PinotQuery rewrittenQuery = _predicateComparisonRewriter.rewrite(pinotQuery);
+    assertEquals(rewrittenQuery.getFilterExpression().getFunctionCall().getOperator(), "NOT_IN");
+    assertEquals(rewrittenQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getIdentifier().getName(),
+        "uuidCol");
+    assertEquals(
+        rewrittenQuery.getFilterExpression().getFunctionCall().getOperands().get(1).getFunctionCall().getOperator()
+            .toLowerCase(), "cast");
+  }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/RawValueInvertedIndexFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/RawValueInvertedIndexFilterOperator.java
@@ -36,6 +36,8 @@ import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.segment.local.segment.index.readers.RawValueBitmapInvertedIndexReader;
 import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.utils.BytesUtils;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
 import org.roaringbitmap.buffer.MutableRoaringBitmap;
 
@@ -137,6 +139,12 @@ public class RawValueInvertedIndexFilterOperator extends BaseColumnFilterOperato
         break;
       case STRING:
         valueBitmap = _invertedIndexReader.getDocIdsForString(value);
+        break;
+      case BYTES:
+        valueBitmap = _invertedIndexReader.getDocIdsForBytes(BytesUtils.toBytes(value));
+        break;
+      case UUID:
+        valueBitmap = _invertedIndexReader.getDocIdsForBytes(UuidUtils.toBytes(value));
         break;
       default:
         throw new IllegalStateException("Unsupported data type for raw inverted index: " + _dataType);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/EqualsPredicateEvaluatorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/EqualsPredicateEvaluatorFactory.java
@@ -31,8 +31,10 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.MultiValueVisitor;
 import org.apache.pinot.spi.data.SingleValueVisitor;
 import org.apache.pinot.spi.utils.BooleanUtils;
+import org.apache.pinot.spi.utils.ByteArray;
 import org.apache.pinot.spi.utils.BytesUtils;
 import org.apache.pinot.spi.utils.TimestampUtils;
+import org.apache.pinot.spi.utils.UuidUtils;
 
 
 /**
@@ -84,6 +86,8 @@ public class EqualsPredicateEvaluatorFactory {
         return new StringRawValueBasedEqPredicateEvaluator(eqPredicate, value);
       case BYTES:
         return new BytesRawValueBasedEqPredicateEvaluator(eqPredicate, BytesUtils.toBytes(value));
+      case UUID:
+        return new BytesRawValueBasedEqPredicateEvaluator(eqPredicate, UuidUtils.toBytes(value), DataType.UUID);
       default:
         throw new IllegalStateException("Unsupported data type: " + dataType);
     }
@@ -95,8 +99,12 @@ public class EqualsPredicateEvaluatorFactory {
 
     DictionaryBasedEqPredicateEvaluator(EqPredicate eqPredicate, Dictionary dictionary, DataType dataType) {
       super(eqPredicate, dictionary);
-      String predicateValue = PredicateUtils.getStoredValue(eqPredicate.getValue(), dataType);
-      _matchingDictId = dictionary.indexOf(predicateValue);
+      if (dataType == DataType.UUID) {
+        _matchingDictId = dictionary.indexOf(new ByteArray(UuidUtils.toBytes(eqPredicate.getValue())));
+      } else {
+        String predicateValue = PredicateUtils.getStoredValue(eqPredicate.getValue(), dataType);
+        _matchingDictId = dictionary.indexOf(predicateValue);
+      }
       if (_matchingDictId >= 0) {
         _matchingDictIds = new int[]{_matchingDictId};
         if (dictionary.length() == 1) {
@@ -416,10 +424,16 @@ public class EqualsPredicateEvaluatorFactory {
 
   private static final class BytesRawValueBasedEqPredicateEvaluator extends EqRawPredicateEvaluator {
     final byte[] _matchingValue;
+    final DataType _dataType;
 
     BytesRawValueBasedEqPredicateEvaluator(EqPredicate eqPredicate, byte[] matchingValue) {
+      this(eqPredicate, matchingValue, DataType.BYTES);
+    }
+
+    BytesRawValueBasedEqPredicateEvaluator(EqPredicate eqPredicate, byte[] matchingValue, DataType dataType) {
       super(eqPredicate);
       _matchingValue = matchingValue;
+      _dataType = dataType;
     }
 
     @Override
@@ -434,7 +448,7 @@ public class EqualsPredicateEvaluatorFactory {
 
     @Override
     public DataType getDataType() {
-      return DataType.BYTES;
+      return _dataType;
     }
 
     @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/InPredicateEvaluatorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/InPredicateEvaluatorFactory.java
@@ -41,6 +41,7 @@ import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.MultiValueVisitor;
 import org.apache.pinot.spi.utils.ByteArray;
+import org.apache.pinot.spi.utils.UuidUtils.UuidKey;
 
 
 /**
@@ -149,6 +150,14 @@ public class InPredicateEvaluatorFactory {
           matchingValues.add(value);
         }
         return new BytesRawValueBasedInPredicateEvaluator(inPredicate, matchingValues);
+      }
+      case UUID: {
+        ByteArray[] uuidValues = inPredicate.getUuidValues();
+        Set<UuidKey> matchingValues = new ObjectOpenHashSet<>(HashUtil.getMinHashSetSize(uuidValues.length));
+        for (ByteArray value : uuidValues) {
+          matchingValues.add(UuidKey.fromByteArray(value));
+        }
+        return new UuidRawValueBasedInPredicateEvaluator(inPredicate, matchingValues);
       }
       default:
         throw new IllegalStateException("Unsupported data type: " + dataType);
@@ -470,6 +479,36 @@ public class InPredicateEvaluatorFactory {
     @Override
     public <R> R accept(MultiValueVisitor<R> visitor) {
       byte[][] bytes = _matchingValues.stream().map(ByteArray::getBytes).toArray(byte[][]::new);
+      return visitor.visitBytes(bytes);
+    }
+  }
+
+  private static final class UuidRawValueBasedInPredicateEvaluator extends InRawPredicateEvaluator {
+    final Set<UuidKey> _matchingValues;
+
+    UuidRawValueBasedInPredicateEvaluator(InPredicate inPredicate, Set<UuidKey> matchingValues) {
+      super(inPredicate);
+      _matchingValues = matchingValues;
+    }
+
+    @Override
+    public int getNumMatchingItems() {
+      return _matchingValues.size();
+    }
+
+    @Override
+    public DataType getDataType() {
+      return DataType.UUID;
+    }
+
+    @Override
+    public boolean applySV(byte[] value) {
+      return _matchingValues.contains(UuidKey.fromBytes(value));
+    }
+
+    @Override
+    public <R> R accept(MultiValueVisitor<R> visitor) {
+      byte[][] bytes = _matchingValues.stream().map(UuidKey::toBytes).toArray(byte[][]::new);
       return visitor.visitBytes(bytes);
     }
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/NotEqualsPredicateEvaluatorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/NotEqualsPredicateEvaluatorFactory.java
@@ -27,8 +27,10 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.MultiValueVisitor;
 import org.apache.pinot.spi.data.SingleValueVisitor;
 import org.apache.pinot.spi.utils.BooleanUtils;
+import org.apache.pinot.spi.utils.ByteArray;
 import org.apache.pinot.spi.utils.BytesUtils;
 import org.apache.pinot.spi.utils.TimestampUtils;
+import org.apache.pinot.spi.utils.UuidUtils;
 
 
 /**
@@ -80,6 +82,8 @@ public class NotEqualsPredicateEvaluatorFactory {
         return new StringRawValueBasedNeqPredicateEvaluator(notEqPredicate, value);
       case BYTES:
         return new BytesRawValueBasedNeqPredicateEvaluator(notEqPredicate, BytesUtils.toBytes(value));
+      case UUID:
+        return new BytesRawValueBasedNeqPredicateEvaluator(notEqPredicate, UuidUtils.toBytes(value), DataType.UUID);
       default:
         throw new IllegalStateException("Unsupported data type: " + dataType);
     }
@@ -90,8 +94,12 @@ public class NotEqualsPredicateEvaluatorFactory {
 
     DictionaryBasedNeqPredicateEvaluator(NotEqPredicate notEqPredicate, Dictionary dictionary, DataType dataType) {
       super(notEqPredicate, dictionary);
-      String predicateValue = PredicateUtils.getStoredValue(notEqPredicate.getValue(), dataType);
-      _nonMatchingDictId = dictionary.indexOf(predicateValue);
+      if (dataType == DataType.UUID) {
+        _nonMatchingDictId = dictionary.indexOf(new ByteArray(UuidUtils.toBytes(notEqPredicate.getValue())));
+      } else {
+        String predicateValue = PredicateUtils.getStoredValue(notEqPredicate.getValue(), dataType);
+        _nonMatchingDictId = dictionary.indexOf(predicateValue);
+      }
       if (_nonMatchingDictId >= 0) {
         _nonMatchingDictIds = new int[]{_nonMatchingDictId};
         if (dictionary.length() == 1) {
@@ -378,10 +386,17 @@ public class NotEqualsPredicateEvaluatorFactory {
 
   private static final class BytesRawValueBasedNeqPredicateEvaluator extends NeqRawPredicateEvaluator {
     final byte[] _nonMatchingValue;
+    final DataType _dataType;
 
     BytesRawValueBasedNeqPredicateEvaluator(NotEqPredicate notEqPredicate, byte[] nonMatchingValue) {
+      this(notEqPredicate, nonMatchingValue, DataType.BYTES);
+    }
+
+    BytesRawValueBasedNeqPredicateEvaluator(NotEqPredicate notEqPredicate, byte[] nonMatchingValue,
+        DataType dataType) {
       super(notEqPredicate);
       _nonMatchingValue = nonMatchingValue;
+      _dataType = dataType;
     }
 
     @Override
@@ -391,7 +406,7 @@ public class NotEqualsPredicateEvaluatorFactory {
 
     @Override
     public DataType getDataType() {
-      return DataType.BYTES;
+      return _dataType;
     }
 
     @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/NotInPredicateEvaluatorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/NotInPredicateEvaluatorFactory.java
@@ -41,6 +41,7 @@ import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.MultiValueVisitor;
 import org.apache.pinot.spi.utils.ByteArray;
+import org.apache.pinot.spi.utils.UuidUtils.UuidKey;
 
 
 /**
@@ -149,6 +150,14 @@ public class NotInPredicateEvaluatorFactory {
           nonMatchingValues.add(value);
         }
         return new BytesRawValueBasedNotInPredicateEvaluator(notInPredicate, nonMatchingValues);
+      }
+      case UUID: {
+        ByteArray[] uuidValues = notInPredicate.getUuidValues();
+        Set<UuidKey> nonMatchingValues = new ObjectOpenHashSet<>(HashUtil.getMinHashSetSize(uuidValues.length));
+        for (ByteArray value : uuidValues) {
+          nonMatchingValues.add(UuidKey.fromByteArray(value));
+        }
+        return new UuidRawValueBasedNotInPredicateEvaluator(notInPredicate, nonMatchingValues);
       }
       default:
         throw new IllegalStateException("Unsupported data type: " + dataType);
@@ -471,6 +480,36 @@ public class NotInPredicateEvaluatorFactory {
     @Override
     public <R> R accept(MultiValueVisitor<R> visitor) {
       byte[][] bytes = _nonMatchingValues.stream().map(ByteArray::getBytes).toArray(byte[][]::new);
+      return visitor.visitBytes(bytes);
+    }
+  }
+
+  private static final class UuidRawValueBasedNotInPredicateEvaluator extends NotInRawPredicateEvaluator {
+    final Set<UuidKey> _nonMatchingValues;
+
+    UuidRawValueBasedNotInPredicateEvaluator(NotInPredicate notInPredicate, Set<UuidKey> nonMatchingValues) {
+      super(notInPredicate);
+      _nonMatchingValues = nonMatchingValues;
+    }
+
+    @Override
+    public int getNumMatchingItems() {
+      return -_nonMatchingValues.size();
+    }
+
+    @Override
+    public DataType getDataType() {
+      return DataType.UUID;
+    }
+
+    @Override
+    public boolean applySV(byte[] value) {
+      return !_nonMatchingValues.contains(UuidKey.fromBytes(value));
+    }
+
+    @Override
+    public <R> R accept(MultiValueVisitor<R> visitor) {
+      byte[][] bytes = _nonMatchingValues.stream().map(UuidKey::toBytes).toArray(byte[][]::new);
       return visitor.visitBytes(bytes);
     }
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/PredicateUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/PredicateUtils.java
@@ -185,6 +185,15 @@ public class PredicateUtils {
           }
         }
         break;
+      case UUID:
+        ByteArray[] uuidValues = inPredicate.getUuidValues();
+        for (ByteArray value : uuidValues) {
+          int dictId = dictionary.indexOf(value);
+          if (dictId >= 0) {
+            dictIdSet.add(dictId);
+          }
+        }
+        break;
       default:
         throw new IllegalStateException("Unsupported data type: " + dataType);
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/BaseTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/BaseTransformFunction.java
@@ -30,6 +30,7 @@ import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.ArrayCopyUtils;
 import org.apache.pinot.spi.utils.CommonConstants.NullValuePlaceHolder;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.roaringbitmap.RoaringBitmap;
 
 
@@ -57,6 +58,8 @@ public abstract class BaseTransformFunction implements TransformFunction {
       new TransformResultMetadata(DataType.JSON, true, false);
   protected static final TransformResultMetadata BYTES_SV_NO_DICTIONARY_METADATA =
       new TransformResultMetadata(DataType.BYTES, true, false);
+  protected static final TransformResultMetadata UUID_SV_NO_DICTIONARY_METADATA =
+      new TransformResultMetadata(DataType.UUID, true, false);
 
   protected static final TransformResultMetadata INT_MV_NO_DICTIONARY_METADATA =
       new TransformResultMetadata(DataType.INT, false, false);
@@ -408,12 +411,19 @@ public abstract class BaseTransformFunction implements TransformFunction {
   public String[] transformToStringValuesSV(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
     initStringValuesSV(length);
+    DataType resultDataType = getResultMetadata().getDataType();
+    if (resultDataType == DataType.UUID) {
+      byte[][] bytesValues = transformToBytesValuesSV(valueBlock);
+      for (int i = 0; i < length; i++) {
+        _stringValuesSV[i] = UuidUtils.toString(bytesValues[i]);
+      }
+      return _stringValuesSV;
+    }
     Dictionary dictionary = getDictionary();
     if (dictionary != null) {
       int[] dictIds = transformToDictIdsSV(valueBlock);
       dictionary.readStringValues(dictIds, length, _stringValuesSV);
     } else {
-      DataType resultDataType = getResultMetadata().getDataType();
       switch (resultDataType.getStoredType()) {
         case INT:
           int[] intValues = transformToIntValuesSV(valueBlock);
@@ -468,6 +478,9 @@ public abstract class BaseTransformFunction implements TransformFunction {
       dictionary.readBytesValues(dictIds, length, _bytesValuesSV);
     } else {
       DataType resultDataType = getResultMetadata().getDataType();
+      if (resultDataType == DataType.UUID) {
+        throw new IllegalStateException("Cannot read SV UUID as BYTES without an override");
+      }
       switch (resultDataType.getStoredType()) {
         case BIG_DECIMAL:
           BigDecimal[] bigDecimalValues = transformToBigDecimalValuesSV(valueBlock);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/BinaryOperatorTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/BinaryOperatorTransformFunction.java
@@ -40,6 +40,7 @@ import org.apache.pinot.core.query.optimizer.filter.NumericalFilterOptimizer;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.ByteArray;
+import org.apache.pinot.spi.utils.UuidUtils;
 
 
 /**
@@ -68,6 +69,7 @@ public abstract class BinaryOperatorTransformFunction extends BaseTransformFunct
   protected boolean _alwaysTrue;
   protected boolean _alwaysFalse;
   protected boolean _alwaysNull;
+  protected boolean _useUuidComparison;
 
   protected BinaryOperatorTransformFunction(TransformFunctionType transformFunctionType) {
     // translate to integer in [0, 5] for guaranteed tableswitch
@@ -110,15 +112,17 @@ public abstract class BinaryOperatorTransformFunction extends BaseTransformFunct
     _leftTransformFunction = arguments.get(0);
     _rightTransformFunction = arguments.get(1);
     DataType leftDataType = _leftTransformFunction.getResultMetadata().getDataType();
+    DataType rightDataType = _rightTransformFunction.getResultMetadata().getDataType();
     _leftStoredType = leftDataType.getStoredType();
-    _rightStoredType = _rightTransformFunction.getResultMetadata().getDataType().getStoredType();
+    _rightStoredType = rightDataType.getStoredType();
+    _useUuidComparison = leftDataType == DataType.UUID && rightDataType == DataType.UUID;
 
     // Data type check: left and right types should be compatible.
     if (_leftStoredType == DataType.BYTES || _rightStoredType == DataType.BYTES) {
       Preconditions.checkState(_leftStoredType == _rightStoredType, String.format(
           "Unsupported data type for comparison: [Left Transform Function [%s] result type is [%s], Right Transform "
-              + "Function [%s] result type is [%s]]", _leftTransformFunction.getName(), _leftStoredType,
-          _rightTransformFunction.getName(), _rightStoredType));
+              + "Function [%s] result type is [%s]]", getTransformFunctionDisplayName(_leftTransformFunction),
+          _leftStoredType, getTransformFunctionDisplayName(_rightTransformFunction), _rightStoredType));
     }
 
     // Create predicate evaluator when the right side is a literal
@@ -697,8 +701,15 @@ public abstract class BinaryOperatorTransformFunction extends BaseTransformFunct
   private IllegalStateException illegalState() {
     throw new IllegalStateException(String.format(
         "Unsupported data type for comparison: [Left Transform Function [%s] result type is [%s], Right "
-            + "Transform Function [%s] result type is [%s]]", _leftTransformFunction.getName(), _leftStoredType,
-        _rightTransformFunction.getName(), _rightStoredType));
+            + "Transform Function [%s] result type is [%s]]", getTransformFunctionDisplayName(_leftTransformFunction),
+        _leftStoredType, getTransformFunctionDisplayName(_rightTransformFunction), _rightStoredType));
+  }
+
+  private static String getTransformFunctionDisplayName(TransformFunction transformFunction) {
+    if (transformFunction instanceof IdentifierTransformFunction) {
+      return ((IdentifierTransformFunction) transformFunction).getColumnName();
+    }
+    return transformFunction.getName();
   }
 
   private void fillResultString(ValueBlock valueBlock, int length) {
@@ -713,7 +724,9 @@ public abstract class BinaryOperatorTransformFunction extends BaseTransformFunct
     byte[][] leftBytesValues = _leftTransformFunction.transformToBytesValuesSV(valueBlock);
     byte[][] rightBytesValues = _rightTransformFunction.transformToBytesValuesSV(valueBlock);
     for (int i = 0; i < length; i++) {
-      _intValuesSV[i] = getIntResult((ByteArray.compare(leftBytesValues[i], rightBytesValues[i])));
+      _intValuesSV[i] = getIntResult(
+          _useUuidComparison ? UuidUtils.compare(leftBytesValues[i], rightBytesValues[i])
+              : ByteArray.compare(leftBytesValues[i], rightBytesValues[i]));
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CaseTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CaseTransformFunction.java
@@ -36,6 +36,7 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.BytesUtils;
 import org.apache.pinot.spi.utils.CommonConstants.NullValuePlaceHolder;
 import org.apache.pinot.spi.utils.TimestampUtils;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.roaringbitmap.RoaringBitmap;
 
 
@@ -213,6 +214,13 @@ public class CaseTransformFunction extends ComputeDifferentlyWhenNullHandlingEna
           BytesUtils.toBytes(literal);
         } catch (Exception e) {
           throw new IllegalArgumentException("Invalid literal: " + literal + " for BYTES");
+        }
+        break;
+      case UUID:
+        try {
+          UuidUtils.toBytes(literal);
+        } catch (Exception e) {
+          throw new IllegalArgumentException("Invalid literal: " + literal + " for UUID");
         }
         break;
       default:
@@ -802,7 +810,7 @@ public class CaseTransformFunction extends ComputeDifferentlyWhenNullHandlingEna
     Map<Integer, byte[][]> thenStatementsIndexToValues = new HashMap<>();
     for (int i = 0; i < numThenStatements; i++) {
       if (_computeThenStatements[i]) {
-        thenStatementsIndexToValues.put(i, _thenStatements.get(i).transformToBytesValuesSV(valueBlock));
+        thenStatementsIndexToValues.put(i, getBytesValues(_thenStatements.get(i), valueBlock));
       }
     }
     for (int docId = 0; docId < numDocs; docId++) {
@@ -817,7 +825,7 @@ public class CaseTransformFunction extends ComputeDifferentlyWhenNullHandlingEna
           _bytesValuesSV[docId] = NullValuePlaceHolder.BYTES;
         }
       } else {
-        byte[][] bytesValues = _elseStatement.transformToBytesValuesSV(valueBlock);
+        byte[][] bytesValues = getBytesValues(_elseStatement, valueBlock);
         for (int docId = unselectedDocs.nextSetBit(0); docId >= 0; docId = unselectedDocs.nextSetBit(docId + 1)) {
           _bytesValuesSV[docId] = bytesValues[docId];
         }
@@ -831,14 +839,14 @@ public class CaseTransformFunction extends ComputeDifferentlyWhenNullHandlingEna
     final RoaringBitmap bitmap = new RoaringBitmap();
     int[] selected = getSelectedArray(valueBlock, true);
     int numDocs = valueBlock.getNumDocs();
-    initStringValuesSV(numDocs);
+    initBytesValuesSV(numDocs);
     int numThenStatements = _thenStatements.size();
     BitSet unselectedDocs = new BitSet();
     unselectedDocs.set(0, numDocs);
     Map<Integer, Pair<byte[][], RoaringBitmap>> thenStatementsIndexToValues = new HashMap<>();
     for (int i = 0; i < numThenStatements; i++) {
       if (_computeThenStatements[i]) {
-        thenStatementsIndexToValues.put(i, ImmutablePair.of(_thenStatements.get(i).transformToBytesValuesSV(valueBlock),
+        thenStatementsIndexToValues.put(i, ImmutablePair.of(getBytesValues(_thenStatements.get(i), valueBlock),
             _thenStatements.get(i).getNullBitmap(valueBlock)));
       }
     }
@@ -863,7 +871,7 @@ public class CaseTransformFunction extends ComputeDifferentlyWhenNullHandlingEna
           bitmap.add(docId);
         }
       } else {
-        byte[][] bytesValues = _elseStatement.transformToBytesValuesSV(valueBlock);
+        byte[][] bytesValues = getBytesValues(_elseStatement, valueBlock);
         RoaringBitmap nullBitmap = _elseStatement.getNullBitmap(valueBlock);
         for (int docId = unselectedDocs.nextSetBit(0); docId >= 0; docId = unselectedDocs.nextSetBit(docId + 1)) {
           _bytesValuesSV[docId] = bytesValues[docId];
@@ -874,6 +882,22 @@ public class CaseTransformFunction extends ComputeDifferentlyWhenNullHandlingEna
       }
     }
     return _bytesValuesSV;
+  }
+
+  private byte[][] getBytesValues(TransformFunction transformFunction, ValueBlock valueBlock) {
+    if (_resultMetadata.getDataType() != DataType.UUID || !(transformFunction instanceof LiteralTransformFunction)) {
+      return transformFunction.transformToBytesValuesSV(valueBlock);
+    }
+    LiteralTransformFunction literalTransformFunction = (LiteralTransformFunction) transformFunction;
+    if (literalTransformFunction.isNull()
+        || literalTransformFunction.getResultMetadata().getDataType() != DataType.STRING) {
+      return transformFunction.transformToBytesValuesSV(valueBlock);
+    }
+    int numDocs = valueBlock.getNumDocs();
+    byte[][] bytesValues = new byte[numDocs][];
+    byte[] uuidBytes = UuidUtils.toBytes(literalTransformFunction.getStringLiteral());
+    Arrays.fill(bytesValues, uuidBytes);
+    return bytesValues;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CastTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CastTransformFunction.java
@@ -29,6 +29,7 @@ import org.apache.pinot.core.operator.transform.TransformResultMetadata;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.ArrayCopyUtils;
 import org.apache.pinot.spi.utils.TimestampUtils;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.roaringbitmap.RoaringBitmap;
 
 
@@ -98,6 +99,10 @@ public class CastTransformFunction extends BaseTransformFunction {
         case "BYTES":
         case "VARBINARY":
           _resultMetadata = sourceSV ? BYTES_SV_NO_DICTIONARY_METADATA : BYTES_MV_NO_DICTIONARY_METADATA;
+          break;
+        case "UUID":
+          Preconditions.checkState(sourceSV, "Cannot cast from MV to UUID");
+          _resultMetadata = UUID_SV_NO_DICTIONARY_METADATA;
           break;
         case "INT_ARRAY":
         case "INTEGER_ARRAY":
@@ -298,11 +303,47 @@ public class CastTransformFunction extends BaseTransformFunction {
           byte[][] bytesValues = transformToBytesValuesSV(valueBlock);
           ArrayCopyUtils.copy(bytesValues, _stringValuesSV, length);
           break;
+        case UUID:
+          byte[][] uuidValues = transformToBytesValuesSV(valueBlock);
+          for (int i = 0; i < length; i++) {
+            _stringValuesSV[i] = UuidUtils.toString(uuidValues[i]);
+          }
+          break;
         default:
           throw new IllegalStateException(String.format("Cannot cast from SV %s to STRING", resultDataType));
       }
     }
     return _stringValuesSV;
+  }
+
+  @Override
+  public byte[][] transformToBytesValuesSV(ValueBlock valueBlock) {
+    DataType resultDataType = _resultMetadata.getDataType();
+    if (resultDataType != DataType.UUID) {
+      if (resultDataType.getStoredType() == DataType.BYTES) {
+        return _transformFunction.transformToBytesValuesSV(valueBlock);
+      }
+      return super.transformToBytesValuesSV(valueBlock);
+    }
+
+    int length = valueBlock.getNumDocs();
+    initBytesValuesSV(length);
+    switch (_sourceDataType.getStoredType()) {
+      case STRING:
+        String[] stringValues = _transformFunction.transformToStringValuesSV(valueBlock);
+        for (int i = 0; i < length; i++) {
+          _bytesValuesSV[i] = UuidUtils.toBytes(stringValues[i]);
+        }
+        return _bytesValuesSV;
+      case BYTES:
+        byte[][] bytesValues = _transformFunction.transformToBytesValuesSV(valueBlock);
+        for (int i = 0; i < length; i++) {
+          _bytesValuesSV[i] = UuidUtils.toBytes(bytesValues[i]);
+        }
+        return _bytesValuesSV;
+      default:
+        throw new IllegalStateException(String.format("Cannot cast from SV %s to UUID", _sourceDataType));
+    }
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IdentifierTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IdentifierTransformFunction.java
@@ -26,6 +26,8 @@ import org.apache.pinot.core.operator.ColumnContext;
 import org.apache.pinot.core.operator.blocks.ValueBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.roaringbitmap.RoaringBitmap;
 
 
@@ -37,6 +39,7 @@ public class IdentifierTransformFunction implements TransformFunction {
   private final String _columnName;
   private final Dictionary _dictionary;
   private final TransformResultMetadata _resultMetadata;
+  private volatile String[] _uuidStringValuesSV;
 
   public IdentifierTransformFunction(String columnName, ColumnContext columnContext) {
     _columnName = columnName;
@@ -107,6 +110,19 @@ public class IdentifierTransformFunction implements TransformFunction {
 
   @Override
   public String[] transformToStringValuesSV(ValueBlock valueBlock) {
+    if (_resultMetadata.getDataType() == DataType.UUID) {
+      int numDocs = valueBlock.getNumDocs();
+      String[] uuidStringValuesSV = _uuidStringValuesSV;
+      if (uuidStringValuesSV == null || uuidStringValuesSV.length < numDocs) {
+        uuidStringValuesSV = new String[numDocs];
+        _uuidStringValuesSV = uuidStringValuesSV;
+      }
+      byte[][] bytesValues = valueBlock.getBlockValueSet(_columnName).getBytesValuesSV();
+      for (int i = 0; i < numDocs; i++) {
+        uuidStringValuesSV[i] = UuidUtils.toString(bytesValues[i]);
+      }
+      return uuidStringValuesSV;
+    }
     return valueBlock.getBlockValueSet(_columnName).getStringValuesSV();
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/InTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/InTransformFunction.java
@@ -36,6 +36,7 @@ import org.apache.pinot.core.operator.transform.TransformResultMetadata;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.ByteArray;
 import org.apache.pinot.spi.utils.BytesUtils;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.roaringbitmap.RoaringBitmap;
 
 
@@ -120,7 +121,11 @@ public class InTransformFunction extends BaseTransformFunction {
         case BYTES:
           ObjectOpenHashSet<ByteArray> bytesValues = new ObjectOpenHashSet<>(numValues);
           for (String stringValue : stringValues) {
-            bytesValues.add(BytesUtils.toByteArray(stringValue));
+            if (_mainFunction.getResultMetadata().getDataType() == DataType.UUID) {
+              bytesValues.add(new ByteArray(UuidUtils.toBytes(stringValue)));
+            } else {
+              bytesValues.add(BytesUtils.toByteArray(stringValue));
+            }
           }
           _valueSet = bytesValues;
           break;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ScalarTransformFunctionWrapper.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ScalarTransformFunctionWrapper.java
@@ -23,6 +23,7 @@ import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.pinot.common.function.FunctionInfo;
 import org.apache.pinot.common.function.FunctionUtils;
@@ -35,6 +36,7 @@ import org.apache.pinot.core.operator.transform.TransformResultMetadata;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.ByteArray;
 import org.apache.pinot.spi.utils.CommonConstants.NullValuePlaceHolder;
+import org.apache.pinot.spi.utils.UuidUtils;
 
 
 /**
@@ -424,6 +426,16 @@ public class ScalarTransformFunctionWrapper extends BaseTransformFunction {
         case BYTES:
           _nonLiteralValues[i] = transformFunction.transformToBytesValuesSV(valueBlock);
           break;
+        case UUID: {
+          byte[][] bytesValues = transformFunction.transformToBytesValuesSV(valueBlock);
+          int numValues = bytesValues.length;
+          UUID[] uuidValues = new UUID[numValues];
+          for (int j = 0; j < numValues; j++) {
+            uuidValues[j] = UuidUtils.toUUID(bytesValues[j]);
+          }
+          _nonLiteralValues[i] = uuidValues;
+          break;
+        }
         case PRIMITIVE_INT_ARRAY:
           _nonLiteralValues[i] = transformFunction.transformToIntValuesMV(valueBlock);
           break;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/NoDictionaryMultiColumnGroupKeyGenerator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/NoDictionaryMultiColumnGroupKeyGenerator.java
@@ -36,6 +36,7 @@ import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.ByteArray;
 import org.apache.pinot.spi.utils.FixedIntArray;
+import org.apache.pinot.spi.utils.UuidUtils.UuidKey;
 import org.roaringbitmap.RoaringBitmap;
 
 
@@ -53,7 +54,7 @@ public class NoDictionaryMultiColumnGroupKeyGenerator implements GroupKeyGenerat
 
   private final ExpressionContext[] _groupByExpressions;
   private final int _numGroupByExpressions;
-  private final DataType[] _storedTypes;
+  private final DataType[] _dataTypes;
   private final Dictionary[] _dictionaries;
   private final ValueToIdMap[] _onTheFlyDictionaries;
   private final Object2IntOpenHashMap<FixedIntArray> _groupKeyMap;
@@ -67,7 +68,7 @@ public class NoDictionaryMultiColumnGroupKeyGenerator implements GroupKeyGenerat
       Map<ExpressionContext, Integer> groupByExpressionSizesFromPredicates) {
     _groupByExpressions = groupByExpressions;
     _numGroupByExpressions = groupByExpressions.length;
-    _storedTypes = new DataType[_numGroupByExpressions];
+    _dataTypes = new DataType[_numGroupByExpressions];
     _dictionaries = new Dictionary[_numGroupByExpressions];
     _onTheFlyDictionaries = new ValueToIdMap[_numGroupByExpressions];
     _isSingleValueExpressions = new boolean[_numGroupByExpressions];
@@ -77,12 +78,14 @@ public class NoDictionaryMultiColumnGroupKeyGenerator implements GroupKeyGenerat
     for (int i = 0; i < _numGroupByExpressions; i++) {
       ExpressionContext groupByExpression = groupByExpressions[i];
       ColumnContext columnContext = projectOperator.getResultColumnContext(groupByExpression);
-      _storedTypes[i] = columnContext.getDataType().getStoredType();
+      DataType logicalType = columnContext.getDataType();
+      // Normalize to stored type, but preserve UUID so it uses UuidKey instead of ByteArray
+      _dataTypes[i] = logicalType == DataType.UUID ? DataType.UUID : logicalType.getStoredType();
       Dictionary dictionary = _nullHandlingEnabled ? null : columnContext.getDictionary();
       if (dictionary != null) {
         _dictionaries[i] = dictionary;
       } else {
-        _onTheFlyDictionaries[i] = ValueToIdMapFactory.get(_storedTypes[i]);
+        _onTheFlyDictionaries[i] = ValueToIdMapFactory.get(_dataTypes[i]);
       }
       if (canOptimizeGroupByUpperBound) {
         Integer size = groupByExpressionSizesFromPredicates.get(groupByExpression);
@@ -119,7 +122,7 @@ public class NoDictionaryMultiColumnGroupKeyGenerator implements GroupKeyGenerat
       if (_dictionaries[i] != null) {
         values[i] = blockValSet.getDictionaryIdsSV();
       } else {
-        switch (_storedTypes[i]) {
+        switch (_dataTypes[i]) {
           case INT:
             values[i] = blockValSet.getIntValuesSV();
             break;
@@ -138,11 +141,12 @@ public class NoDictionaryMultiColumnGroupKeyGenerator implements GroupKeyGenerat
           case STRING:
             values[i] = blockValSet.getStringValuesSV();
             break;
+          case UUID:
           case BYTES:
             values[i] = blockValSet.getBytesValuesSV();
             break;
           default:
-            throw new IllegalArgumentException("Illegal data type for no-dictionary key generator: " + _storedTypes[i]);
+            throw new IllegalArgumentException("Illegal data type for no-dictionary key generator: " + _dataTypes[i]);
         }
       }
     }
@@ -174,7 +178,7 @@ public class NoDictionaryMultiColumnGroupKeyGenerator implements GroupKeyGenerat
               } else if (columnValues instanceof double[]) {
                 keyValue = onTheFlyDictionary.put(((double[]) columnValues)[row]);
               } else if (columnValues instanceof byte[][]) {
-                keyValue = onTheFlyDictionary.put(new ByteArray(((byte[][]) columnValues)[row]));
+                keyValue = putBytesValue(onTheFlyDictionary, (byte[][]) columnValues, row, _dataTypes[col]);
               } else {
                 keyValue = onTheFlyDictionary.put(((Object[]) columnValues)[row]);
               }
@@ -198,7 +202,7 @@ public class NoDictionaryMultiColumnGroupKeyGenerator implements GroupKeyGenerat
               } else if (columnValues instanceof double[]) {
                 keyValue = onTheFlyDictionary.getId(((double[]) columnValues)[row]);
               } else if (columnValues instanceof byte[][]) {
-                keyValue = onTheFlyDictionary.getId(new ByteArray(((byte[][]) columnValues)[row]));
+                keyValue = getBytesValueId(onTheFlyDictionary, (byte[][]) columnValues, row, _dataTypes[col]);
               } else {
                 keyValue = onTheFlyDictionary.getId(((Object[]) columnValues)[row]);
               }
@@ -240,7 +244,7 @@ public class NoDictionaryMultiColumnGroupKeyGenerator implements GroupKeyGenerat
             } else if (columnValues instanceof double[]) {
               keyValue = onTheFlyDictionary.put(((double[]) columnValues)[row]);
             } else if (columnValues instanceof byte[][]) {
-              keyValue = onTheFlyDictionary.put(new ByteArray(((byte[][]) columnValues)[row]));
+              keyValue = putBytesValue(onTheFlyDictionary, (byte[][]) columnValues, row, _dataTypes[col]);
             } else {
               keyValue = onTheFlyDictionary.put(((Object[]) columnValues)[row]);
             }
@@ -261,7 +265,7 @@ public class NoDictionaryMultiColumnGroupKeyGenerator implements GroupKeyGenerat
             } else if (columnValues instanceof double[]) {
               keyValue = onTheFlyDictionary.getId(((double[]) columnValues)[row]);
             } else if (columnValues instanceof byte[][]) {
-              keyValue = onTheFlyDictionary.getId(new ByteArray(((byte[][]) columnValues)[row]));
+              keyValue = getBytesValueId(onTheFlyDictionary, (byte[][]) columnValues, row, _dataTypes[col]);
             } else {
               keyValue = onTheFlyDictionary.getId(((Object[]) columnValues)[row]);
             }
@@ -308,7 +312,7 @@ public class NoDictionaryMultiColumnGroupKeyGenerator implements GroupKeyGenerat
       } else {
         ValueToIdMap onTheFlyDictionary = _onTheFlyDictionaries[i];
         if (_isSingleValueExpressions[i]) {
-          switch (_storedTypes[i]) {
+          switch (_dataTypes[i]) {
             case INT:
               int[] intValues = blockValSet.getIntValuesSV();
               for (int j = 0; j < numDocs; j++) {
@@ -339,6 +343,12 @@ public class NoDictionaryMultiColumnGroupKeyGenerator implements GroupKeyGenerat
                 keys[j][i] = new int[]{onTheFlyDictionary.put(stringValues[j])};
               }
               break;
+            case UUID:
+              byte[][] uuidValues = blockValSet.getBytesValuesSV();
+              for (int j = 0; j < numDocs; j++) {
+                keys[j][i] = new int[]{onTheFlyDictionary.put(UuidKey.fromBytes(uuidValues[j]))};
+              }
+              break;
             case BYTES:
               byte[][] bytesValues = blockValSet.getBytesValuesSV();
               for (int j = 0; j < numDocs; j++) {
@@ -347,10 +357,10 @@ public class NoDictionaryMultiColumnGroupKeyGenerator implements GroupKeyGenerat
               break;
             default:
               throw new IllegalArgumentException(
-                  "Illegal data type for no-dictionary key generator: " + _storedTypes[i]);
+                  "Illegal data type for no-dictionary key generator: " + _dataTypes[i]);
           }
         } else {
-          switch (_storedTypes[i]) {
+          switch (_dataTypes[i]) {
             case INT:
               int[][] intValues = blockValSet.getIntValuesMV();
               for (int j = 0; j < numDocs; j++) {
@@ -408,7 +418,7 @@ public class NoDictionaryMultiColumnGroupKeyGenerator implements GroupKeyGenerat
               break;
             default:
               throw new IllegalArgumentException(
-                  "Illegal data type for no-dictionary key generator: " + _storedTypes[i]);
+                  "Illegal data type for no-dictionary key generator: " + _dataTypes[i]);
           }
         }
       }
@@ -519,5 +529,20 @@ public class NoDictionaryMultiColumnGroupKeyGenerator implements GroupKeyGenerat
       }
     }
     return keys;
+  }
+
+  private static int putBytesValue(ValueToIdMap onTheFlyDictionary, byte[][] columnValues, int row, DataType dataType) {
+    if (dataType == DataType.UUID) {
+      return onTheFlyDictionary.put(UuidKey.fromBytes(columnValues[row]));
+    }
+    return onTheFlyDictionary.put(new ByteArray(columnValues[row]));
+  }
+
+  private static int getBytesValueId(ValueToIdMap onTheFlyDictionary, byte[][] columnValues, int row,
+      DataType dataType) {
+    if (dataType == DataType.UUID) {
+      return onTheFlyDictionary.getId(UuidKey.fromBytes(columnValues[row]));
+    }
+    return onTheFlyDictionary.getId(new ByteArray(columnValues[row]));
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/NoDictionarySingleColumnGroupKeyGenerator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/NoDictionarySingleColumnGroupKeyGenerator.java
@@ -41,6 +41,7 @@ import org.apache.pinot.core.operator.ColumnContext;
 import org.apache.pinot.core.operator.blocks.ValueBlock;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.ByteArray;
+import org.apache.pinot.spi.utils.UuidUtils.UuidKey;
 import org.roaringbitmap.RoaringBitmap;
 
 
@@ -52,7 +53,7 @@ import org.roaringbitmap.RoaringBitmap;
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class NoDictionarySingleColumnGroupKeyGenerator implements GroupKeyGenerator {
   private final ExpressionContext _groupByExpression;
-  private final DataType _storedType;
+  private final DataType _dataType;
   private final Map _groupKeyMap;
   private final int _globalGroupIdUpperBound;
   // TODO(nhejazi): Most of the logic between _nullHandlingEnabled=true/false is not sharable, so consider making a
@@ -69,8 +70,10 @@ public class NoDictionarySingleColumnGroupKeyGenerator implements GroupKeyGenera
       @Nullable Map<ExpressionContext, Integer> groupByExpressionSizesFromPredicates) {
     _groupByExpression = groupByExpression;
     ColumnContext columnContext = projectOperator.getResultColumnContext(groupByExpression);
-    _storedType = columnContext.getDataType().getStoredType();
-    _groupKeyMap = createGroupKeyMap(_storedType);
+    DataType logicalType = columnContext.getDataType();
+    // Normalize to stored type, but preserve UUID so it uses UuidKey instead of ByteArray
+    _dataType = logicalType == DataType.UUID ? DataType.UUID : logicalType.getStoredType();
+    _groupKeyMap = createGroupKeyMap(_dataType);
     if (groupByExpressionSizesFromPredicates != null) {
       Integer size = groupByExpressionSizesFromPredicates.get(groupByExpression);
       _globalGroupIdUpperBound = size != null ? Math.min(size, numGroupsLimit) : numGroupsLimit;
@@ -98,7 +101,7 @@ public class NoDictionarySingleColumnGroupKeyGenerator implements GroupKeyGenera
     }
     int numDocs = valueBlock.getNumDocs();
 
-    switch (_storedType) {
+    switch (_dataType) {
       case INT:
         int[] intValues = blockValSet.getIntValuesSV();
         for (int i = 0; i < numDocs; i++) {
@@ -135,6 +138,12 @@ public class NoDictionarySingleColumnGroupKeyGenerator implements GroupKeyGenera
           groupKeys[i] = getKeyForValue(stringValues[i]);
         }
         break;
+      case UUID:
+        byte[][] uuidValues = blockValSet.getBytesValuesSV();
+        for (int i = 0; i < numDocs; i++) {
+          groupKeys[i] = getKeyForValue(UuidKey.fromBytes(uuidValues[i]));
+        }
+        break;
       case BYTES:
         byte[][] bytesValues = blockValSet.getBytesValuesSV();
         for (int i = 0; i < numDocs; i++) {
@@ -142,7 +151,7 @@ public class NoDictionarySingleColumnGroupKeyGenerator implements GroupKeyGenera
         }
         break;
       default:
-        throw new IllegalArgumentException("Illegal data type for no-dictionary key generator: " + _storedType);
+        throw new IllegalArgumentException("Illegal data type for no-dictionary key generator: " + _dataType);
     }
   }
 
@@ -152,7 +161,7 @@ public class NoDictionarySingleColumnGroupKeyGenerator implements GroupKeyGenera
     BlockValSet blockValSet = valueBlock.getBlockValueSet(_groupByExpression);
     int numDocs = valueBlock.getNumDocs();
 
-    switch (_storedType) {
+    switch (_dataType) {
       case INT:
         int[] intValues = blockValSet.getIntValuesSV();
         if (nullBitmap.getCardinality() < numDocs) {
@@ -213,6 +222,16 @@ public class NoDictionarySingleColumnGroupKeyGenerator implements GroupKeyGenera
           Arrays.fill(groupKeys, 0, numDocs, getKeyForValue((String) null));
         }
         break;
+      case UUID:
+        byte[][] uuidValues = blockValSet.getBytesValuesSV();
+        if (nullBitmap.getCardinality() < numDocs) {
+          for (int i = 0; i < numDocs; i++) {
+            groupKeys[i] = getKeyForValue(nullBitmap.contains(i) ? null : UuidKey.fromBytes(uuidValues[i]));
+          }
+        } else if (numDocs > 0) {
+          Arrays.fill(groupKeys, 0, numDocs, getKeyForValue((UuidKey) null));
+        }
+        break;
       case BYTES:
         byte[][] bytesValues = blockValSet.getBytesValuesSV();
         if (nullBitmap.getCardinality() < numDocs) {
@@ -224,7 +243,7 @@ public class NoDictionarySingleColumnGroupKeyGenerator implements GroupKeyGenera
         }
         break;
       default:
-        throw new IllegalArgumentException("Illegal data type for no-dictionary key generator: " + _storedType);
+        throw new IllegalArgumentException("Illegal data type for no-dictionary key generator: " + _dataType);
     }
   }
 
@@ -261,6 +280,10 @@ public class NoDictionarySingleColumnGroupKeyGenerator implements GroupKeyGenera
         Object2IntOpenHashMap<String> stringMap = new Object2IntOpenHashMap<>();
         stringMap.defaultReturnValue(INVALID_ID);
         return stringMap;
+      case UUID:
+        Object2IntOpenHashMap<UuidKey> uuidMap = new Object2IntOpenHashMap<>();
+        uuidMap.defaultReturnValue(INVALID_ID);
+        return uuidMap;
       case BYTES:
         Object2IntOpenHashMap<ByteArray> bytesMap = new Object2IntOpenHashMap<>();
         bytesMap.defaultReturnValue(INVALID_ID);
@@ -276,7 +299,7 @@ public class NoDictionarySingleColumnGroupKeyGenerator implements GroupKeyGenera
     BlockValSet blockValSet = valueBlock.getBlockValueSet(_groupByExpression);
 
     if (_isSingleValueExpression) {
-      switch (_storedType) {
+      switch (_dataType) {
         case INT:
           int[] intValues = blockValSet.getIntValuesSV();
           for (int i = 0; i < numDocs; i++) {
@@ -307,6 +330,12 @@ public class NoDictionarySingleColumnGroupKeyGenerator implements GroupKeyGenera
             groupKeys[i] = new int[]{getKeyForValue(stringValues[i])};
           }
           break;
+        case UUID:
+          byte[][] uuidValues = blockValSet.getBytesValuesSV();
+          for (int i = 0; i < numDocs; i++) {
+            groupKeys[i] = new int[]{getKeyForValue(UuidKey.fromBytes(uuidValues[i]))};
+          }
+          break;
         case BYTES:
           byte[][] byteValues = blockValSet.getBytesValuesSV();
           for (int i = 0; i < numDocs; i++) {
@@ -314,10 +343,10 @@ public class NoDictionarySingleColumnGroupKeyGenerator implements GroupKeyGenera
           }
           break;
         default:
-          throw new IllegalArgumentException("Illegal data type for no-dictionary key generator: " + _storedType);
+          throw new IllegalArgumentException("Illegal data type for no-dictionary key generator: " + _dataType);
       }
     } else {
-      switch (_storedType) {
+      switch (_dataType) {
         case INT:
           int[][] intValues = blockValSet.getIntValuesMV();
           for (int i = 0; i < numDocs; i++) {
@@ -374,7 +403,7 @@ public class NoDictionarySingleColumnGroupKeyGenerator implements GroupKeyGenera
           }
           break;
         default:
-          throw new IllegalArgumentException("Illegal data type for no-dictionary key generator: " + _storedType);
+          throw new IllegalArgumentException("Illegal data type for no-dictionary key generator: " + _dataType);
       }
     }
   }
@@ -386,7 +415,7 @@ public class NoDictionarySingleColumnGroupKeyGenerator implements GroupKeyGenera
 
   @Override
   public Iterator<GroupKey> getGroupKeys() {
-    switch (_storedType) {
+    switch (_dataType) {
       case INT:
         return new IntGroupKeyIterator((Int2IntOpenHashMap) _groupKeyMap, _groupIdForNullValue);
       case LONG:
@@ -397,8 +426,9 @@ public class NoDictionarySingleColumnGroupKeyGenerator implements GroupKeyGenera
         return new DoubleGroupKeyIterator((Double2IntOpenHashMap) _groupKeyMap, _groupIdForNullValue);
       case BIG_DECIMAL:
       case STRING:
+      case UUID:
       case BYTES:
-        return new ObjectGroupKeyIterator((Object2IntOpenHashMap) _groupKeyMap);
+        return new ObjectGroupKeyIterator((Object2IntOpenHashMap) _groupKeyMap, _dataType);
       default:
         throw new IllegalStateException();
     }
@@ -482,6 +512,16 @@ public class NoDictionarySingleColumnGroupKeyGenerator implements GroupKeyGenera
 
   private int getKeyForValue(ByteArray value) {
     Object2IntMap<ByteArray> map = (Object2IntMap<ByteArray>) _groupKeyMap;
+    int groupId = map.getInt(value);
+    if (groupId == INVALID_ID && _numGroups < _globalGroupIdUpperBound) {
+      groupId = _numGroups++;
+      map.put(value, groupId);
+    }
+    return groupId;
+  }
+
+  private int getKeyForValue(UuidKey value) {
+    Object2IntMap<UuidKey> map = (Object2IntMap<UuidKey>) _groupKeyMap;
     int groupId = map.getInt(value);
     if (groupId == INVALID_ID && _numGroups < _globalGroupIdUpperBound) {
       groupId = _numGroups++;
@@ -638,10 +678,12 @@ public class NoDictionarySingleColumnGroupKeyGenerator implements GroupKeyGenera
   private static class ObjectGroupKeyIterator implements Iterator<GroupKey> {
     final ObjectIterator<Object2IntMap.Entry> _iterator;
     final GroupKey _groupKey;
+    final DataType _dataType;
 
-    ObjectGroupKeyIterator(Object2IntOpenHashMap objectMap) {
+    ObjectGroupKeyIterator(Object2IntOpenHashMap objectMap, DataType dataType) {
       _iterator = objectMap.object2IntEntrySet().fastIterator();
       _groupKey = new GroupKey();
+      _dataType = dataType;
     }
 
     @Override
@@ -653,7 +695,11 @@ public class NoDictionarySingleColumnGroupKeyGenerator implements GroupKeyGenera
     public GroupKey next() {
       Object2IntMap.Entry entry = _iterator.next();
       _groupKey._groupId = entry.getIntValue();
-      _groupKey._keys = new Object[]{entry.getKey()};
+      Object key = entry.getKey();
+      if (_dataType == DataType.UUID && key != null) {
+        key = ((UuidKey) key).toByteArray();
+      }
+      _groupKey._keys = new Object[]{key};
       return _groupKey;
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/utils/UuidToIdMap.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/utils/UuidToIdMap.java
@@ -1,0 +1,60 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.aggregation.groupby.utils;
+
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+import java.util.ArrayList;
+import org.apache.pinot.spi.utils.ByteArray;
+import org.apache.pinot.spi.utils.UuidUtils.UuidKey;
+
+
+/**
+ * Implementation of {@link ValueToIdMap} for Pinot's logical UUID type.
+ */
+public class UuidToIdMap implements ValueToIdMap {
+  private final Object2IntOpenHashMap<UuidKey> _valueToIdMap;
+  private final ArrayList<ByteArray> _idToValueMap;
+
+  public UuidToIdMap() {
+    _valueToIdMap = new Object2IntOpenHashMap<>();
+    _valueToIdMap.defaultReturnValue(INVALID_KEY);
+    _idToValueMap = new ArrayList<>();
+  }
+
+  @Override
+  public int put(Object value) {
+    UuidKey uuidKey = UuidKey.fromObject(value);
+    int numValues = _valueToIdMap.size();
+    int id = _valueToIdMap.computeIntIfAbsent(uuidKey, ignored -> numValues);
+    if (id == numValues) {
+      _idToValueMap.add(uuidKey.toByteArray());
+    }
+    return id;
+  }
+
+  @Override
+  public int getId(Object value) {
+    return _valueToIdMap.getInt(UuidKey.fromObject(value));
+  }
+
+  @Override
+  public Object get(int id) {
+    return _idToValueMap.get(id);
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/utils/ValueToIdMapFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/utils/ValueToIdMapFactory.java
@@ -38,6 +38,8 @@ public class ValueToIdMapFactory {
         return new FloatToIdMap();
       case DOUBLE:
         return new DoubleToIdMap();
+      case UUID:
+        return new UuidToIdMap();
       default:
         return new ObjectToIdMap();
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/table/BytesDistinctTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/table/BytesDistinctTable.java
@@ -291,12 +291,13 @@ public class BytesDistinctTable extends DistinctTable {
       rows = new ArrayList<>(numValues);
       addRows(sortedValues, numValues, rows);
     }
+    formatRows(rows);
     return new ResultTable(_dataSchema, rows);
   }
 
   private static void addRows(ByteArray[] values, int length, List<Object[]> rows) {
     for (int i = 0; i < length; i++) {
-      rows.add(new Object[]{values[i].toHexString()});
+      rows.add(new Object[]{values[i]});
     }
   }
 
@@ -312,12 +313,23 @@ public class BytesDistinctTable extends DistinctTable {
       rows = new ArrayList<>(numValues);
       addRows(_valueSet, rows);
     }
+    formatRows(rows);
     return new ResultTable(_dataSchema, rows);
   }
 
   private static void addRows(HashSet<ByteArray> values, List<Object[]> rows) {
     for (ByteArray value : values) {
-      rows.add(new Object[]{value.toHexString()});
+      rows.add(new Object[]{value});
+    }
+  }
+
+  private void formatRows(List<Object[]> rows) {
+    DataSchema.ColumnDataType columnDataType = _dataSchema.getColumnDataType(0);
+    for (Object[] row : rows) {
+      Object value = row[0];
+      if (value != null) {
+        row[0] = columnDataType.convertAndFormat(value);
+      }
     }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/ValueBasedSegmentPruner.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/ValueBasedSegmentPruner.java
@@ -236,7 +236,7 @@ abstract public class ValueBasedSegmentPruner implements SegmentPruner {
       public boolean mightBeContained(BloomFilterReader bloomFilter) {
         if (!_hashed) {
           GuavaBloomFilterReaderUtils.Hash128AsLongs hash128AsLongs =
-              GuavaBloomFilterReaderUtils.hashAsLongs(_comparableValue.toString());
+              GuavaBloomFilterReaderUtils.hashAsLongs(_dt.toString(_comparableValue));
           _hash1 = hash128AsLongs.getHash1();
           _hash2 = hash128AsLongs.getHash2();
           _hashed = true;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GroupByDataTableReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GroupByDataTableReducer.java
@@ -470,6 +470,7 @@ public class GroupByDataTableReducer implements DataTableReducer {
       case STRING:
       case JSON:
         return dataTable.getString(rowId, colId);
+      case UUID:
       case BYTES:
         return dataTable.getBytes(rowId, colId).getBytes();
       default:

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/filter/PredicateRowMatcher.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/filter/PredicateRowMatcher.java
@@ -25,6 +25,7 @@ import org.apache.pinot.common.request.context.predicate.Predicate;
 import org.apache.pinot.core.operator.filter.predicate.PredicateEvaluator;
 import org.apache.pinot.core.operator.filter.predicate.PredicateEvaluatorProvider;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.utils.UuidUtils;
 
 
 /**
@@ -80,6 +81,8 @@ public class PredicateRowMatcher implements RowMatcher {
         return _predicateEvaluator.applySV((String) value);
       case BYTES:
         return _predicateEvaluator.applySV((byte[]) value);
+      case UUID:
+        return _predicateEvaluator.applySV(UuidUtils.toBytes(value));
       default:
         throw new IllegalStateException();
     }

--- a/pinot-core/src/test/java/org/apache/pinot/core/common/datablock/DataBlockTestUtils.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/common/datablock/DataBlockTestUtils.java
@@ -24,11 +24,13 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.UUID;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.pinot.common.datablock.DataBlock;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.spi.utils.ByteArray;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.roaringbitmap.RoaringBitmap;
 
 
@@ -72,6 +74,9 @@ public class DataBlockTestUtils {
           break;
         case BYTES:
           row[colId] = new ByteArray(RandomStringUtils.random(RANDOM.nextInt(20)).getBytes());
+          break;
+        case UUID:
+          row[colId] = new ByteArray(UuidUtils.toBytes(new UUID(RANDOM.nextLong(), RANDOM.nextLong())));
           break;
         case INT_ARRAY:
           int length = RANDOM.nextInt(ARRAY_SIZE);

--- a/pinot-core/src/test/java/org/apache/pinot/core/common/datatable/DataTableSerDeTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/common/datatable/DataTableSerDeTest.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
+import java.util.UUID;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.datatable.DataTable;
@@ -33,6 +34,7 @@ import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.spi.accounting.ThreadResourceUsageProvider;
 import org.apache.pinot.spi.exception.QueryErrorCode;
 import org.apache.pinot.spi.utils.ByteArray;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.roaringbitmap.RoaringBitmap;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
@@ -59,6 +61,7 @@ public class DataTableSerDeTest {
   private static final String[] STRINGS = new String[NUM_ROWS];
   private static final String[] JSONS = new String[NUM_ROWS];
   private static final byte[][] BYTES = new byte[NUM_ROWS][];
+  private static final byte[][] UUIDS = new byte[NUM_ROWS][];
   private static final Object[] OBJECTS = new Object[NUM_ROWS];
   private static final int[][] INT_ARRAYS = new int[NUM_ROWS][];
   private static final long[][] LONG_ARRAYS = new long[NUM_ROWS][];
@@ -364,6 +367,11 @@ public class DataTableSerDeTest {
             BYTES[rowId] = isNull ? new byte[0] : RandomStringUtils.random(RANDOM.nextInt(20)).getBytes();
             dataTableBuilder.setColumn(colId, new ByteArray(BYTES[rowId]));
             break;
+          case UUID:
+            UUIDS[rowId] = isNull ? UuidUtils.nullUuidBytes()
+                : UuidUtils.toBytes(new UUID(RANDOM.nextLong(), RANDOM.nextLong()));
+            dataTableBuilder.setColumn(colId, new ByteArray(UUIDS[rowId]));
+            break;
           case INT_ARRAY:
             int length = RANDOM.nextInt(20);
             int[] intArray = new int[length];
@@ -500,6 +508,10 @@ public class DataTableSerDeTest {
           case BYTES:
             Assert.assertEquals(newDataTable.getBytes(rowId, colId).getBytes(), isNull ? new byte[0] : BYTES[rowId],
                 ERROR_MESSAGE);
+            break;
+          case UUID:
+            Assert.assertEquals(newDataTable.getBytes(rowId, colId).getBytes(),
+                isNull ? UuidUtils.nullUuidBytes() : UUIDS[rowId], ERROR_MESSAGE);
             break;
           case INT_ARRAY:
             Assert.assertTrue(Arrays.equals(newDataTable.getIntArray(rowId, colId), INT_ARRAYS[rowId]), ERROR_MESSAGE);

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/TableIndexingTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/TableIndexingTest.java
@@ -159,7 +159,10 @@ public class TableIndexingTest {
 
   protected void createSchemas() {
     for (DataType type : DataType.values()) {
-      if (type == DataType.UNKNOWN || type == DataType.LIST || type == DataType.MAP || type == DataType.STRUCT) {
+      if (type == DataType.UNKNOWN || type == DataType.LIST || type == DataType.MAP || type == DataType.STRUCT
+          || type == DataType.UUID) {
+        // UUID v1 is SV-only and its supported behavior is covered by dedicated UUID tests rather than this static
+        // all-type/all-index expectation matrix.
         continue;
       }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/predicate/NoDictionaryInPredicateEvaluatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/predicate/NoDictionaryInPredicateEvaluatorTest.java
@@ -39,6 +39,7 @@ import org.apache.pinot.common.request.context.predicate.InPredicate;
 import org.apache.pinot.common.request.context.predicate.NotInPredicate;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.utils.BytesUtils;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -364,5 +365,41 @@ public class NoDictionaryInPredicateEvaluatorTest {
 
     Assert.assertTrue(inPredicateEvaluator.applyMV(multiValues, NUM_MULTI_VALUES));
     Assert.assertFalse(notInPredicateEvaluator.applyMV(multiValues, NUM_MULTI_VALUES));
+  }
+
+  @Test
+  public void testUuidPredicateEvaluators() {
+    List<String> uuidStrings = new ArrayList<>(NUM_PREDICATE_VALUES);
+    Set<String> uuidStringSet = new HashSet<>();
+
+    for (int i = 0; i < NUM_PREDICATE_VALUES; i++) {
+      String uuidString = java.util.UUID.randomUUID().toString();
+      uuidStrings.add(uuidString);
+      uuidStringSet.add(uuidString);
+    }
+
+    InPredicate inPredicate = new InPredicate(COLUMN_EXPRESSION, uuidStrings);
+    PredicateEvaluator inPredicateEvaluator =
+        InPredicateEvaluatorFactory.newRawValueBasedEvaluator(inPredicate, FieldSpec.DataType.UUID);
+
+    NotInPredicate notInPredicate = new NotInPredicate(COLUMN_EXPRESSION, uuidStrings);
+    PredicateEvaluator notInPredicateEvaluator =
+        NotInPredicateEvaluatorFactory.newRawValueBasedEvaluator(notInPredicate, FieldSpec.DataType.UUID);
+
+    Assert.assertEquals(inPredicateEvaluator.getDataType(), FieldSpec.DataType.UUID);
+    Assert.assertEquals(notInPredicateEvaluator.getDataType(), FieldSpec.DataType.UUID);
+
+    for (String uuidString : uuidStringSet) {
+      byte[] uuidBytes = UuidUtils.toBytes(uuidString);
+      Assert.assertTrue(inPredicateEvaluator.applySV(uuidBytes));
+      Assert.assertFalse(notInPredicateEvaluator.applySV(uuidBytes));
+    }
+
+    for (int i = 0; i < NUM_PREDICATE_VALUES; i++) {
+      byte[] value = UuidUtils.toBytes(java.util.UUID.randomUUID());
+      boolean expected = uuidStringSet.contains(UuidUtils.toString(value));
+      Assert.assertEquals(inPredicateEvaluator.applySV(value), expected);
+      Assert.assertEquals(notInPredicateEvaluator.applySV(value), !expected);
+    }
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/BaseTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/BaseTransformFunctionTest.java
@@ -32,6 +32,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.ArrayUtils;
@@ -59,6 +60,7 @@ import org.apache.pinot.spi.utils.BigDecimalUtils;
 import org.apache.pinot.spi.utils.BytesUtils;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.ReadMode;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.roaringbitmap.RoaringBitmap;
 import org.testng.annotations.AfterClass;
@@ -83,6 +85,7 @@ public abstract class BaseTransformFunctionTest {
   protected static final String JSON_STRING_SV_COLUMN = "jsonSV";
   protected static final String STRING_SV_NULL_COLUMN = "stringSVNull";
   protected static final String BYTES_SV_COLUMN = "bytesSV";
+  protected static final String UUID_SV_COLUMN = "uuidSV";
   protected static final String VECTOR_1_COLUMN = "vector1";
   protected static final String VECTOR_2_COLUMN = "vector2";
   protected static final String ZERO_VECTOR_COLUMN = "zeroVector";
@@ -121,6 +124,7 @@ public abstract class BaseTransformFunctionTest {
   protected final String[] _jsonArrayValues = new String[NUM_ROWS];
   protected final String[] _stringAlphaNumericSVValues = new String[NUM_ROWS];
   protected final byte[][] _bytesSVValues = new byte[NUM_ROWS][];
+  protected final byte[][] _uuidSVValues = new byte[NUM_ROWS][];
   protected final int[][] _intMVValues = new int[NUM_ROWS][];
   protected final long[][] _longMVValues = new long[NUM_ROWS][];
   protected final float[][] _floatMVValues = new float[NUM_ROWS][];
@@ -170,6 +174,9 @@ public abstract class BaseTransformFunctionTest {
           df.format(RANDOM.nextInt() * RANDOM.nextDouble()));
       _stringAlphaNumericSVValues[i] = RandomStringUtils.randomAlphanumeric(26);
       _bytesSVValues[i] = RandomStringUtils.randomAlphanumeric(26).getBytes();
+      long mostSignificantBits = (i % 2 == 0) ? Long.MIN_VALUE + i : Long.MAX_VALUE - i;
+      long leastSignificantBits = ((long) i << Integer.SIZE) | i;
+      _uuidSVValues[i] = UuidUtils.toBytes(new UUID(mostSignificantBits, leastSignificantBits));
 
       int numValues = 1 + RANDOM.nextInt(MAX_NUM_MULTI_VALUES);
       _intMVValues[i] = new int[numValues];
@@ -240,6 +247,7 @@ public abstract class BaseTransformFunctionTest {
         map.put(STRING_ALPHANUM_NULL_SV_COLUMN, _stringAlphaNumericSVValues[i]);
       }
       map.put(BYTES_SV_COLUMN, _bytesSVValues[i]);
+      map.put(UUID_SV_COLUMN, _uuidSVValues[i]);
 
       map.put(INT_MV_COLUMN, ArrayUtils.toObject(_intMVValues[i]));
       if (isNullRow(i)) {
@@ -289,6 +297,7 @@ public abstract class BaseTransformFunctionTest {
         .addSingleValueDimension(STRING_ALPHANUM_SV_COLUMN, FieldSpec.DataType.STRING)
         .addSingleValueDimension(STRING_ALPHANUM_NULL_SV_COLUMN, FieldSpec.DataType.STRING)
         .addSingleValueDimension(BYTES_SV_COLUMN, FieldSpec.DataType.BYTES)
+        .addSingleValueDimension(UUID_SV_COLUMN, FieldSpec.DataType.UUID)
         .addSingleValueDimension(JSON_COLUMN, FieldSpec.DataType.JSON)
         .addSingleValueDimension(DEFAULT_JSON_COLUMN, FieldSpec.DataType.JSON)
         .addMultiValueDimension(INT_MV_COLUMN, FieldSpec.DataType.INT)
@@ -620,8 +629,13 @@ public abstract class BaseTransformFunctionTest {
   protected void testTransformFunction(TransformFunction transformFunction, byte[][] expectedValues) {
     String[] stringValues = transformFunction.transformToStringValuesSV(_projectionBlock);
     byte[][] bytesValues = transformFunction.transformToBytesValuesSV(_projectionBlock);
+    FieldSpec.DataType resultDataType = transformFunction.getResultMetadata().getDataType();
     for (int i = 0; i < NUM_ROWS; i++) {
-      assertEquals(bytesValues[i], BytesUtils.toBytes(stringValues[i]));
+      if (resultDataType == FieldSpec.DataType.UUID) {
+        assertEquals(bytesValues[i], UuidUtils.toBytes(stringValues[i]));
+      } else {
+        assertEquals(bytesValues[i], BytesUtils.toBytes(stringValues[i]));
+      }
       assertEquals(bytesValues[i], expectedValues[i]);
     }
     testNullBitmap(transformFunction, null);

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/BinaryOperatorTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/BinaryOperatorTransformFunctionTest.java
@@ -23,6 +23,7 @@ import org.apache.pinot.common.request.context.RequestContextUtils;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.exception.BadQueryRequestException;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.roaringbitmap.RoaringBitmap;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -261,6 +262,35 @@ public abstract class BinaryOperatorTransformFunctionTest extends BaseTransformF
       }
     }
     testTransformFunctionWithNull(transformFunction, expectedValues, bitmap);
+  }
+
+  @Test
+  public void testBinaryOperatorTransformFunctionUUID() {
+    String functionName = getFunctionName();
+    String uuidLiteral = UuidUtils.toString(_uuidSVValues[0]);
+    ExpressionContext expression = RequestContextUtils.getExpression(
+        String.format("%s(%s, CAST('%s' AS UUID))", functionName, UUID_SV_COLUMN, uuidLiteral));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    boolean[] expectedValues = new boolean[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = getExpectedValue(UuidUtils.compare(_uuidSVValues[i], _uuidSVValues[0]));
+    }
+    testTransformFunction(transformFunction, expectedValues);
+  }
+
+  @Test
+  public void testBinaryOperatorTransformFunctionUUIDNoDict() {
+    String functionName = getFunctionName();
+    String uuidLiteral = UuidUtils.toString(_uuidSVValues[0]);
+    ExpressionContext expression = RequestContextUtils.getExpression(
+        String.format("%s(CAST(CAST(%s AS STRING) AS UUID), CAST('%s' AS UUID))", functionName, UUID_SV_COLUMN,
+            uuidLiteral));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    boolean[] expectedValues = new boolean[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = getExpectedValue(UuidUtils.compare(_uuidSVValues[i], _uuidSVValues[0]));
+    }
+    testTransformFunction(transformFunction, expectedValues);
   }
 
   @Test(dataProvider = "testIllegalArguments", expectedExceptions = {BadQueryRequestException.class})

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/CaseTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/CaseTransformFunctionTest.java
@@ -30,6 +30,7 @@ import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.RequestContextUtils;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.BytesUtils;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.roaringbitmap.RoaringBitmap;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
@@ -168,7 +169,8 @@ public class CaseTransformFunctionTest extends BaseTransformFunctionTest {
         String.format("CASE WHEN true THEN %s ELSE %s END", INT_SV_COLUMN, BYTES_SV_COLUMN),
         String.format("CASE WHEN true THEN 100 ELSE %s END", TIMESTAMP_COLUMN),
         String.format("CASE WHEN true THEN 100 ELSE %s END", STRING_SV_COLUMN),
-        String.format("CASE WHEN true THEN 100 ELSE %s END", BYTES_SV_COLUMN)
+        String.format("CASE WHEN true THEN 100 ELSE %s END", BYTES_SV_COLUMN),
+        "CASE WHEN true THEN CAST('550e8400-e29b-41d4-a716-446655440000' AS UUID) ELSE 'not-a-uuid' END"
     };
     //@formatter:on
   }
@@ -176,6 +178,42 @@ public class CaseTransformFunctionTest extends BaseTransformFunctionTest {
   @Test(dataProvider = "illegalExpressions", expectedExceptions = Exception.class)
   public void testInvalidCaseTransformFunction(String expression) {
     TransformFunctionFactory.get(RequestContextUtils.getExpression(expression), _dataSourceMap);
+  }
+
+  @Test
+  public void testCaseTransformFunctionWithUuidResults() {
+    String uuidValue = "550e8400-e29b-41d4-a716-446655440000";
+    ExpressionContext expression = RequestContextUtils.getExpression(
+        "CASE WHEN true THEN CAST('" + uuidValue.toUpperCase() + "' AS UUID) ELSE '" + uuidValue + "' END");
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    Assert.assertTrue(transformFunction instanceof CaseTransformFunction);
+    assertEquals(transformFunction.getResultMetadata().getDataType(), DataType.UUID);
+    byte[][] expectedValues = new byte[NUM_ROWS][];
+    byte[] uuidBytes = UuidUtils.toBytes(uuidValue);
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = uuidBytes;
+    }
+    testTransformFunction(transformFunction, expectedValues);
+  }
+
+  @Test
+  public void testCaseTransformFunctionWithUuidStringLiteralBranch() {
+    String whenUuidValue = "550e8400-e29b-41d4-a716-446655440000";
+    String elseUuidValue = "550e8400-e29b-41d4-a716-446655440001";
+    ExpressionContext expression = RequestContextUtils.getExpression(
+        String.format("CASE WHEN %s < 2 THEN '%s' ELSE CAST('%s' AS UUID) END", INT_SV_COLUMN,
+            whenUuidValue.toUpperCase(), elseUuidValue));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    Assert.assertTrue(transformFunction instanceof CaseTransformFunction);
+    assertEquals(transformFunction.getResultMetadata().getDataType(), DataType.UUID);
+
+    byte[][] expectedValues = new byte[NUM_ROWS][];
+    byte[] whenUuidBytes = UuidUtils.toBytes(whenUuidValue);
+    byte[] elseUuidBytes = UuidUtils.toBytes(elseUuidValue);
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = _intSVValues[i] < 2 ? whenUuidBytes : elseUuidBytes;
+    }
+    testTransformFunction(transformFunction, expectedValues);
   }
 
   @Test

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/CastTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/CastTransformFunctionTest.java
@@ -24,7 +24,9 @@ import java.util.Arrays;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.RequestContextUtils;
 import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.exception.BadQueryRequestException;
 import org.apache.pinot.spi.utils.ArrayCopyUtils;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.roaringbitmap.RoaringBitmap;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -35,6 +37,8 @@ import static org.testng.Assert.assertTrue;
 
 
 public class CastTransformFunctionTest extends BaseTransformFunctionTest {
+  private static final String UUID_VALUE = "550e8400-e29b-41d4-a716-446655440000";
+
   @Test
   public void testCastTransformFunction() {
     ExpressionContext expression =
@@ -170,6 +174,52 @@ public class CastTransformFunctionTest extends BaseTransformFunctionTest {
   }
 
   @Test
+  public void testCastTransformFunctionUUID() {
+    ExpressionContext expression =
+        RequestContextUtils.getExpression(String.format("CAST('%s' AS UUID)", UUID_VALUE.toUpperCase()));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    assertTrue(transformFunction instanceof CastTransformFunction);
+    assertEquals(transformFunction.getResultMetadata().getDataType(), FieldSpec.DataType.UUID);
+
+    byte[][] bytesValues = transformFunction.transformToBytesValuesSV(_projectionBlock);
+    String[] stringValues = transformFunction.transformToStringValuesSV(_projectionBlock);
+    byte[] expectedBytes = UuidUtils.toBytes(UUID_VALUE);
+    for (int i = 0; i < NUM_ROWS; i++) {
+      Assert.assertEquals(bytesValues[i], expectedBytes);
+      Assert.assertEquals(stringValues[i], UUID_VALUE);
+    }
+  }
+
+  @Test
+  public void testCastTransformFunctionUuidRoundTrips() {
+    String bytesHex = org.apache.pinot.spi.utils.BytesUtils.toHexString(UuidUtils.toBytes(UUID_VALUE));
+
+    ExpressionContext expression = RequestContextUtils.getExpression(
+        String.format("CAST(CAST('%s' AS BYTES) AS UUID)", bytesHex));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    byte[] expectedBytes = UuidUtils.toBytes(UUID_VALUE);
+    byte[][] expectedUuidValues = new byte[NUM_ROWS][];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedUuidValues[i] = expectedBytes;
+    }
+    testTransformFunction(transformFunction, expectedUuidValues);
+
+    expression = RequestContextUtils.getExpression(String.format("CAST(CAST('%s' AS UUID) AS STRING)", UUID_VALUE));
+    transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    String[] expectedStringValues = new String[NUM_ROWS];
+    Arrays.fill(expectedStringValues, UUID_VALUE);
+    testTransformFunction(transformFunction, expectedStringValues);
+
+    expression = RequestContextUtils.getExpression(String.format("CAST(CAST('%s' AS UUID) AS BYTES)", UUID_VALUE));
+    transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    byte[][] expectedBytesValues = new byte[NUM_ROWS][];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedBytesValues[i] = expectedBytes;
+    }
+    testTransformFunction(transformFunction, expectedBytesValues);
+  }
+
+  @Test
   public void testCastTransformFunctionMV() {
     ExpressionContext expression =
         RequestContextUtils.getExpression(String.format("CAST(%s AS LONG)", STRING_LONG_MV_COLUMN));
@@ -255,6 +305,37 @@ public class CastTransformFunctionTest extends BaseTransformFunctionTest {
       expectedArraySums[i] = Arrays.stream(afterCast[i]).sum();
     }
     testTransformFunction(transformFunction, expectedArraySums);
+  }
+
+  @Test
+  public void testCastTransformFunctionUUIDRejectsInvalidLiteral() {
+    ExpressionContext expression = RequestContextUtils.getExpression("CAST('not-a-uuid' AS UUID)");
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    Assert.assertTrue(transformFunction instanceof CastTransformFunction);
+
+    IllegalArgumentException exception = Assert.expectThrows(IllegalArgumentException.class,
+        () -> transformFunction.transformToBytesValuesSV(_projectionBlock));
+    Assert.assertTrue(exception.getMessage().contains("Invalid UUID"));
+  }
+
+  @Test
+  public void testCastTransformFunctionUUIDRejectsInvalidBytesLiteral() {
+    ExpressionContext expression = RequestContextUtils.getExpression("CAST(CAST('0011' AS BYTES) AS UUID)");
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    Assert.assertTrue(transformFunction instanceof CastTransformFunction);
+
+    IllegalArgumentException exception = Assert.expectThrows(IllegalArgumentException.class,
+        () -> transformFunction.transformToBytesValuesSV(_projectionBlock));
+    Assert.assertTrue(exception.getMessage().contains("Invalid UUID byte length"));
+  }
+
+  @Test
+  public void testCastTransformFunctionUUIDRejectsMVSource() {
+    ExpressionContext expression =
+        RequestContextUtils.getExpression(String.format("CAST(%s AS UUID)", STRING_MV_COLUMN));
+    BadQueryRequestException exception = Assert.expectThrows(BadQueryRequestException.class,
+        () -> TransformFunctionFactory.get(expression, _dataSourceMap));
+    Assert.assertTrue(exception.getMessage().contains("Cannot cast from MV to UUID"));
   }
 
   @Test

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/ScalarTransformFunctionWrapperTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/ScalarTransformFunctionWrapperTest.java
@@ -24,17 +24,23 @@ import java.nio.charset.StandardCharsets;
 import java.text.Normalizer;
 import java.util.Arrays;
 import java.util.Base64;
+import java.util.Collections;
 import java.util.Random;
+import java.util.UUID;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.pinot.common.function.FunctionInfo;
 import org.apache.pinot.common.function.scalar.ArithmeticFunctions;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.RequestContextUtils;
+import org.apache.pinot.core.operator.blocks.ValueBlock;
+import org.apache.pinot.core.operator.transform.TransformResultMetadata;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.ArrayCopyUtils;
 import org.apache.pinot.spi.utils.BigDecimalUtils;
 import org.apache.pinot.spi.utils.CommonConstants.NullValuePlaceHolder;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.roaringbitmap.RoaringBitmap;
 import org.testng.annotations.Test;
 
@@ -1178,6 +1184,28 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
   }
 
   @Test
+  public void testUuidColumnArgumentTransformFunction()
+      throws NoSuchMethodException {
+    byte[][] uuidValues = new byte[NUM_ROWS][];
+    String[] expectedValues = new String[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      UUID uuid = new UUID(i, i + 1L);
+      uuidValues[i] = UuidUtils.toBytes(uuid);
+      expectedValues[i] = uuid.toString();
+    }
+
+    ScalarTransformFunctionWrapper transformFunction =
+        new ScalarTransformFunctionWrapper(FunctionInfo.fromMethod(
+            ScalarTransformFunctionWrapperTest.class.getDeclaredMethod("uuidToString", UUID.class)));
+    StaticUuidTransformFunction uuidTransformFunction = new StaticUuidTransformFunction(uuidValues);
+    uuidTransformFunction.init(Collections.emptyList(), Collections.emptyMap());
+    transformFunction.init(Arrays.asList(uuidTransformFunction), Collections.emptyMap());
+
+    assertEquals(transformFunction.getName(), "uuidToString");
+    testTransformFunction(transformFunction, expectedValues);
+  }
+
+  @Test
   public void testStringLowerTransformFunctionNullLiteral() {
     ExpressionContext expression =
         RequestContextUtils.getExpression("lower(null)");
@@ -1207,5 +1235,34 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
       }
     }
     testTransformFunctionWithNull(transformFunction, expectedValues, bitmap);
+  }
+
+  public static String uuidToString(UUID uuid) {
+    return uuid.toString();
+  }
+
+  private static class StaticUuidTransformFunction extends BaseTransformFunction {
+    private static final TransformResultMetadata RESULT_METADATA = new TransformResultMetadata(DataType.UUID, true,
+        false);
+    private final byte[][] _uuidValues;
+
+    private StaticUuidTransformFunction(byte[][] uuidValues) {
+      _uuidValues = uuidValues;
+    }
+
+    @Override
+    public String getName() {
+      return "staticUuid";
+    }
+
+    @Override
+    public TransformResultMetadata getResultMetadata() {
+      return RESULT_METADATA;
+    }
+
+    @Override
+    public byte[][] transformToBytesValuesSV(ValueBlock valueBlock) {
+      return _uuidValues;
+    }
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/groupby/NoDictionaryGroupKeyGeneratorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/groupby/NoDictionaryGroupKeyGeneratorTest.java
@@ -27,6 +27,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Random;
 import java.util.Set;
+import java.util.UUID;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -51,6 +52,7 @@ import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.utils.BytesUtils;
 import org.apache.pinot.spi.utils.CommonConstants.Server;
 import org.apache.pinot.spi.utils.ReadMode;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -77,12 +79,19 @@ public class NoDictionaryGroupKeyGeneratorTest {
   private static final String STRING_COLUMN = "stringColumn";
   private static final String BYTES_COLUMN = "bytesColumn";
   private static final String BYTES_DICT_COLUMN = "bytesDictColumn";
+  private static final String UUID_COLUMN = "uuidColumn";
+  private static final String BOOLEAN_COLUMN = "booleanColumn";
+  private static final String TIMESTAMP_COLUMN = "timestampColumn";
+  private static final String UUID_DICT_COLUMN = "uuidDictColumn";
   private static final List<String> COLUMNS =
       Arrays.asList(INT_COLUMN, LONG_COLUMN, FLOAT_COLUMN, DOUBLE_COLUMN, STRING_COLUMN, BYTES_COLUMN,
-          BYTES_DICT_COLUMN);
+          BYTES_DICT_COLUMN, UUID_COLUMN, BOOLEAN_COLUMN, TIMESTAMP_COLUMN, UUID_DICT_COLUMN);
   private static final int NUM_COLUMNS = COLUMNS.size();
+  private static final Set<String> UUID_COLUMNS = Set.of(UUID_COLUMN, UUID_DICT_COLUMN);
   private static final TableConfig TABLE_CONFIG = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME)
-      .setNoDictionaryColumns(COLUMNS.subList(0, NUM_COLUMNS - 1)).build();
+      .setNoDictionaryColumns(
+          List.of(INT_COLUMN, LONG_COLUMN, FLOAT_COLUMN, DOUBLE_COLUMN, STRING_COLUMN, BYTES_COLUMN, UUID_COLUMN,
+              BOOLEAN_COLUMN, TIMESTAMP_COLUMN)).build();
   private static final Schema SCHEMA =
       new Schema.SchemaBuilder().addSingleValueDimension(INT_COLUMN, FieldSpec.DataType.INT)
           .addSingleValueDimension(LONG_COLUMN, FieldSpec.DataType.LONG)
@@ -90,7 +99,11 @@ public class NoDictionaryGroupKeyGeneratorTest {
           .addSingleValueDimension(DOUBLE_COLUMN, FieldSpec.DataType.DOUBLE)
           .addSingleValueDimension(STRING_COLUMN, FieldSpec.DataType.STRING)
           .addSingleValueDimension(BYTES_COLUMN, FieldSpec.DataType.BYTES)
-          .addSingleValueDimension(BYTES_DICT_COLUMN, FieldSpec.DataType.BYTES).build();
+          .addSingleValueDimension(BYTES_DICT_COLUMN, FieldSpec.DataType.BYTES)
+          .addSingleValueDimension(UUID_COLUMN, FieldSpec.DataType.UUID)
+          .addSingleValueDimension(BOOLEAN_COLUMN, FieldSpec.DataType.BOOLEAN)
+          .addSingleValueDimension(TIMESTAMP_COLUMN, FieldSpec.DataType.TIMESTAMP)
+          .addSingleValueDimension(UUID_DICT_COLUMN, FieldSpec.DataType.UUID).build();
 
   private static final int NUM_RECORDS = 1000;
   private static final int NUM_UNIQUE_RECORDS = 100;
@@ -131,6 +144,19 @@ public class NoDictionaryGroupKeyGeneratorTest {
       record.putValue(BYTES_DICT_COLUMN, bytesValue);
       values[5] = BytesUtils.toHexString(bytesValue);
       values[6] = values[5];
+      byte[] uuidBytes = UuidUtils.toBytes(new UUID(RANDOM.nextLong(), RANDOM.nextLong()));
+      record.putValue(UUID_COLUMN, uuidBytes);
+      values[7] = UuidUtils.toString(uuidBytes);
+      // BOOLEAN stored as INT (0/1) — exercises the logical→stored-type normalization fix
+      int boolIntValue = RANDOM.nextBoolean() ? 1 : 0;
+      record.putValue(BOOLEAN_COLUMN, boolIntValue);
+      values[8] = Integer.toString(boolIntValue);
+      // TIMESTAMP stored as LONG — exercises the logical→stored-type normalization fix
+      long timestampValue = Math.abs(RANDOM.nextLong());
+      record.putValue(TIMESTAMP_COLUMN, timestampValue);
+      values[9] = Long.toString(timestampValue);
+      record.putValue(UUID_DICT_COLUMN, uuidBytes);
+      values[10] = values[7];
       for (int j = 0; j < NUM_RECORDS / NUM_UNIQUE_RECORDS; j++) {
         records.add(record);
       }
@@ -179,9 +205,12 @@ public class NoDictionaryGroupKeyGeneratorTest {
     testGroupKeyGenerator(new int[]{0, 1});
     testGroupKeyGenerator(new int[]{2, 3});
     testGroupKeyGenerator(new int[]{4, 5});
+    testGroupKeyGenerator(new int[]{7, 10});
+    testGroupKeyGenerator(new int[]{8, 9});
     testGroupKeyGenerator(new int[]{1, 2, 3});
     testGroupKeyGenerator(new int[]{4, 5, 0});
-    testGroupKeyGenerator(new int[]{5, 4, 3, 2, 1, 0});
+    testGroupKeyGenerator(new int[]{7, 5, 4});
+    testGroupKeyGenerator(new int[]{7, 5, 4, 3, 2, 1, 0});
   }
 
   /**
@@ -220,7 +249,7 @@ public class NoDictionaryGroupKeyGeneratorTest {
     Iterator<GroupKeyGenerator.GroupKey> groupKeys = groupKeyGenerator.getGroupKeys();
     while (groupKeys.hasNext()) {
       GroupKeyGenerator.GroupKey groupKey = groupKeys.next();
-      assertTrue(expectedGroupKeys.contains(getActualGroupKey(groupKey._keys)));
+      assertTrue(expectedGroupKeys.contains(getActualGroupKey(groupKey._keys, groupByColumnIndexes)));
     }
   }
 
@@ -242,13 +271,18 @@ public class NoDictionaryGroupKeyGeneratorTest {
     return groupKeys;
   }
 
-  private String getActualGroupKey(Object[] groupKeys) {
+  private String getActualGroupKey(Object[] groupKeys, int[] groupByColumnIndexes) {
     StringBuilder stringBuilder = new StringBuilder();
     for (int i = 0; i < groupKeys.length; i++) {
       if (i > 0) {
         stringBuilder.append(GroupKeyGenerator.DELIMITER);
       }
-      stringBuilder.append(groupKeys[i]);
+      int columnIndex = groupByColumnIndexes[i];
+      if (UUID_COLUMNS.contains(COLUMNS.get(columnIndex))) {
+        stringBuilder.append(UuidUtils.toString(((org.apache.pinot.spi.utils.ByteArray) groupKeys[i]).getBytes()));
+      } else {
+        stringBuilder.append(groupKeys[i]);
+      }
     }
     return stringBuilder.toString();
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/distinct/table/BytesDistinctTableTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/distinct/table/BytesDistinctTableTest.java
@@ -1,0 +1,72 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.distinct.table;
+
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.common.request.context.OrderByExpressionContext;
+import org.apache.pinot.common.response.broker.ResultTable;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+import org.apache.pinot.spi.utils.ByteArray;
+import org.apache.pinot.spi.utils.BytesUtils;
+import org.apache.pinot.spi.utils.UuidUtils;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+
+/**
+ * Tests for {@link BytesDistinctTable}.
+ */
+public class BytesDistinctTableTest {
+  private static final String UUID_COLUMN = "uuidCol";
+  private static final String UUID_VALUE_1 = "550e8400-e29b-41d4-a716-446655440000";
+  private static final String UUID_VALUE_2 = "550e8400-e29b-41d4-a716-446655440001";
+
+  @Test
+  public void testToResultTableFormatsUuidAndBytesWithoutOrderBy() {
+    BytesDistinctTable uuidTable = new BytesDistinctTable(
+        new DataSchema(new String[]{UUID_COLUMN}, new ColumnDataType[]{ColumnDataType.UUID}), 10, false, null);
+    uuidTable.addUnbounded(new ByteArray(UuidUtils.toBytes(UUID_VALUE_1)));
+
+    ResultTable uuidResultTable = uuidTable.toResultTable();
+    assertEquals(uuidResultTable.getRows().get(0)[0], UUID_VALUE_1);
+
+    byte[] bytesValue = new byte[]{0x01, 0x23, 0x45};
+    BytesDistinctTable bytesTable = new BytesDistinctTable(
+        new DataSchema(new String[]{"bytesCol"}, new ColumnDataType[]{ColumnDataType.BYTES}), 10, false, null);
+    bytesTable.addUnbounded(new ByteArray(bytesValue));
+
+    ResultTable bytesResultTable = bytesTable.toResultTable();
+    assertEquals(bytesResultTable.getRows().get(0)[0], BytesUtils.toHexString(bytesValue));
+  }
+
+  @Test
+  public void testToResultTableFormatsUuidWithOrderBy() {
+    BytesDistinctTable uuidTable = new BytesDistinctTable(
+        new DataSchema(new String[]{UUID_COLUMN}, new ColumnDataType[]{ColumnDataType.UUID}), 10, false,
+        new OrderByExpressionContext(ExpressionContext.forIdentifier(UUID_COLUMN), true));
+    uuidTable.addUnbounded(new ByteArray(UuidUtils.toBytes(UUID_VALUE_2)));
+    uuidTable.addUnbounded(new ByteArray(UuidUtils.toBytes(UUID_VALUE_1)));
+
+    ResultTable resultTable = uuidTable.toResultTable();
+    assertEquals(resultTable.getRows().get(0)[0], UUID_VALUE_1);
+    assertEquals(resultTable.getRows().get(1)[0], UUID_VALUE_2);
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/pruner/BloomFilterSegmentPrunerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/pruner/BloomFilterSegmentPrunerTest.java
@@ -96,6 +96,22 @@ public class BloomFilterSegmentPrunerTest {
     assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column = 21.0 AND column = 30.0"));
   }
 
+  @Test
+  public void testUuidBloomFilterPruning()
+      throws IOException {
+    IndexSegment indexSegment = mockIndexSegment(new String[]{
+        "550e8400-e29b-41d4-a716-446655440000",
+        "550e8400-e29b-41d4-a716-446655440001"
+    }, DataType.UUID);
+
+    assertFalse(runPruner(indexSegment,
+        "SELECT COUNT(*) FROM testTable WHERE column = '550e8400-e29b-41d4-a716-446655440000'"));
+    assertFalse(runPruner(indexSegment,
+        "SELECT COUNT(*) FROM testTable WHERE column IN ('550e8400-e29b-41d4-a716-446655440001')"));
+    assertTrue(runPruner(indexSegment,
+        "SELECT COUNT(*) FROM testTable WHERE column = '550e8400-e29b-41d4-a716-44665544ffff'"));
+  }
+
   @Test(expectedExceptions = RuntimeException.class)
   public void testQueryTimeoutOnPruning()
       throws IOException {
@@ -162,6 +178,11 @@ public class BloomFilterSegmentPrunerTest {
 
   private IndexSegment mockIndexSegment(String[] values)
       throws IOException {
+    return mockIndexSegment(values, DataType.DOUBLE);
+  }
+
+  private IndexSegment mockIndexSegment(String[] values, DataType dataType)
+      throws IOException {
     IndexSegment indexSegment = mock(IndexSegment.class);
     when(indexSegment.getColumnNames()).thenReturn(ImmutableSet.of("column"));
     SegmentMetadata segmentMetadata = mock(SegmentMetadata.class);
@@ -176,7 +197,7 @@ public class BloomFilterSegmentPrunerTest {
     for (String v : values) {
       builder.put(v);
     }
-    when(dataSourceMetadata.getDataType()).thenReturn(DataType.DOUBLE);
+    when(dataSourceMetadata.getDataType()).thenReturn(dataType);
     when(dataSource.getDataSourceMetadata()).thenReturn(dataSourceMetadata);
     when(dataSource.getBloomFilter()).thenReturn(builder.build());
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/selection/SelectionOperatorUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/selection/SelectionOperatorUtilsTest.java
@@ -18,17 +18,23 @@
  */
 package org.apache.pinot.core.query.selection;
 
+import java.util.Collections;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.pinot.common.response.broker.ResultTable;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
+import org.apache.pinot.spi.utils.ByteArray;
+import org.apache.pinot.spi.utils.BytesUtils;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
 
 
 public class SelectionOperatorUtilsTest {
+  private static final String UUID_VALUE = "550e8400-e29b-41d4-a716-446655440000";
 
   @Test
   public void testGetResultTableColumnIndices() {
@@ -206,5 +212,22 @@ public class SelectionOperatorUtilsTest {
         new DataSchema(new String[]{"plus(col1,'1')", "plus(col2,'2')", "plus(col1,'1')"}, new ColumnDataType[]{
             ColumnDataType.STRING, ColumnDataType.STRING, ColumnDataType.STRING
         }));
+  }
+
+  @Test
+  public void testRenderResultTableWithoutOrderingFormatsUUIDAndBytes() {
+    byte[] bytesValue = new byte[]{0x01, 0x23, 0x45};
+    DataSchema dataSchema = new DataSchema(new String[]{"uuidCol", "bytesCol"},
+        new ColumnDataType[]{ColumnDataType.UUID, ColumnDataType.BYTES});
+
+    ResultTable resultTable = SelectionOperatorUtils.renderResultTableWithoutOrdering(
+        Collections.singletonList(
+            new Object[]{new ByteArray(UuidUtils.toBytes(UUID_VALUE)), new ByteArray(bytesValue)}),
+        dataSchema,
+        new int[]{0, 1});
+
+    Object[] row = resultTable.getRows().get(0);
+    assertEquals(row[0], UUID_VALUE);
+    assertEquals(row[1], BytesUtils.toHexString(bytesValue));
   }
 }

--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
@@ -783,6 +783,7 @@ public abstract class ClusterTest extends ControllerTest {
         object = jsonValue.asDouble();
         break;
       case STRING:
+      case UUID:
       case BYTES:
       case TIMESTAMP:
       case JSON:

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/UuidTypeRealtimeTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/UuidTypeRealtimeTest.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.integration.tests.custom;
+
+
+public class UuidTypeRealtimeTest extends UuidTypeTest {
+  private static final String REALTIME_TABLE_NAME = "UuidTypeRealtimeTest";
+
+  @Override
+  public String getTableName() {
+    return REALTIME_TABLE_NAME;
+  }
+
+  @Override
+  public boolean isRealtimeTable() {
+    return true;
+  }
+}

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/UuidTypeTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/UuidTypeTest.java
@@ -1,0 +1,355 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.integration.tests.custom;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.File;
+import java.nio.ByteBuffer;
+import java.util.List;
+import org.apache.avro.Schema.Field;
+import org.apache.avro.Schema.Type;
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.generic.GenericData;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.BytesUtils;
+import org.apache.pinot.spi.utils.UuidUtils;
+import org.testng.annotations.Test;
+
+import static org.apache.avro.Schema.create;
+import static org.testng.Assert.assertEquals;
+
+
+@Test(suiteName = "CustomClusterIntegrationTest")
+public class UuidTypeTest extends CustomDataQueryClusterIntegrationTest {
+  private static final String DEFAULT_TABLE_NAME = "UuidTypeTest";
+  private static final String ID_COLUMN = "id";
+  private static final String UUID_FROM_STRING_COLUMN = "uuidFromString";
+  private static final String UUID_FROM_BYTES_COLUMN = "uuidFromBytes";
+  private static final String UUID_AS_BYTES_COLUMN = "uuidAsBytes";
+  private static final String TIME_COLUMN = "ts";
+  private static final List<String> UUID_INPUT_VALUES = List.of(
+      "550E8400-E29B-41D4-A716-446655440000",
+      "550e8400-e29b-41d4-a716-446655440001",
+      "550e8400-E29B-41D4-A716-446655440000",
+      "550e8400-e29b-41d4-a716-446655440002",
+      "550E8400-E29B-41D4-A716-446655440001",
+      "550e8400-e29b-41d4-a716-446655440003");
+  private static final List<String> UUID_VALUES = List.of(
+      "550e8400-e29b-41d4-a716-446655440000",
+      "550e8400-e29b-41d4-a716-446655440001",
+      "550e8400-e29b-41d4-a716-446655440000",
+      "550e8400-e29b-41d4-a716-446655440002",
+      "550e8400-e29b-41d4-a716-446655440001",
+      "550e8400-e29b-41d4-a716-446655440003");
+  private static final List<String> DISTINCT_UUID_VALUES = List.of(
+      "550e8400-e29b-41d4-a716-446655440000",
+      "550e8400-e29b-41d4-a716-446655440001",
+      "550e8400-e29b-41d4-a716-446655440002",
+      "550e8400-e29b-41d4-a716-446655440003");
+  private static final List<Integer> SORTED_UUID_IDS = List.of(0, 2, 1, 4, 3, 5);
+  private static final long BASE_TIMESTAMP_MILLIS = 1_700_000_000_000L;
+
+  @Override
+  public String getTableName() {
+    return DEFAULT_TABLE_NAME;
+  }
+
+  @Override
+  public String getTimeColumnName() {
+    return TIME_COLUMN;
+  }
+
+  @Override
+  protected long getCountStarResult() {
+    return UUID_VALUES.size();
+  }
+
+  @Override
+  public int getNumAvroFiles() {
+    return 1;
+  }
+
+  @Override
+  protected int getRealtimeSegmentFlushSize() {
+    return 2;
+  }
+
+  @Override
+  protected List<String> getInvertedIndexColumns() {
+    return List.of(UUID_FROM_STRING_COLUMN);
+  }
+
+  @Override
+  protected List<String> getNoDictionaryColumns() {
+    return List.of(UUID_FROM_BYTES_COLUMN, UUID_AS_BYTES_COLUMN);
+  }
+
+  @Override
+  protected List<String> getBloomFilterColumns() {
+    return List.of(UUID_FROM_STRING_COLUMN, UUID_FROM_BYTES_COLUMN, UUID_AS_BYTES_COLUMN);
+  }
+
+  @Override
+  public Schema createSchema() {
+    return new Schema.SchemaBuilder().setSchemaName(getTableName())
+        .addSingleValueDimension(ID_COLUMN, FieldSpec.DataType.INT)
+        .addSingleValueDimension(UUID_FROM_STRING_COLUMN, FieldSpec.DataType.UUID)
+        .addSingleValueDimension(UUID_FROM_BYTES_COLUMN, FieldSpec.DataType.UUID)
+        .addSingleValueDimension(UUID_AS_BYTES_COLUMN, FieldSpec.DataType.BYTES)
+        .addDateTimeField(TIME_COLUMN, FieldSpec.DataType.LONG, "1:MILLISECONDS:EPOCH", "1:MILLISECONDS")
+        .build();
+  }
+
+  @Override
+  public List<File> createAvroFiles()
+      throws Exception {
+    org.apache.avro.Schema avroSchema = org.apache.avro.Schema.createRecord("uuidRecord", null, null, false);
+    avroSchema.setFields(List.of(
+        new Field(ID_COLUMN, create(Type.INT), null, null),
+        new Field(UUID_FROM_STRING_COLUMN, create(Type.STRING), null, null),
+        new Field(UUID_FROM_BYTES_COLUMN, create(Type.BYTES), null, null),
+        new Field(UUID_AS_BYTES_COLUMN, create(Type.BYTES), null, null),
+        new Field(TIME_COLUMN, create(Type.LONG), null, null)));
+
+    try (AvroFilesAndWriters avroFilesAndWriters = createAvroFilesAndWriters(avroSchema)) {
+      List<DataFileWriter<GenericData.Record>> writers = avroFilesAndWriters.getWriters();
+      for (int i = 0; i < UUID_VALUES.size(); i++) {
+        String uuidInputValue = UUID_INPUT_VALUES.get(i);
+        byte[] uuidBytes = UuidUtils.toBytes(uuidInputValue);
+        GenericData.Record record = new GenericData.Record(avroSchema);
+        record.put(ID_COLUMN, i);
+        record.put(UUID_FROM_STRING_COLUMN, uuidInputValue);
+        record.put(UUID_FROM_BYTES_COLUMN, ByteBuffer.wrap(uuidBytes));
+        record.put(UUID_AS_BYTES_COLUMN, ByteBuffer.wrap(uuidBytes));
+        record.put(TIME_COLUMN, BASE_TIMESTAMP_MILLIS + i);
+        writers.get(0).append(record);
+      }
+      return avroFilesAndWriters.getAvroFiles();
+    }
+  }
+
+  @Test(dataProvider = "useBothQueryEngines")
+  public void testSelectAndPredicateQueries(boolean useMultiStageQueryEngine)
+      throws Exception {
+    JsonNode rows = postRows(useMultiStageQueryEngine, String.format(
+        "SELECT %s, %s, %s, %s FROM %s ORDER BY %s", ID_COLUMN, UUID_FROM_STRING_COLUMN, UUID_FROM_BYTES_COLUMN,
+        UUID_AS_BYTES_COLUMN, getTableName(), ID_COLUMN));
+
+    assertEquals(rows.size(), UUID_VALUES.size());
+    for (int i = 0; i < UUID_VALUES.size(); i++) {
+      assertEquals(rows.get(i).get(0).asInt(), i);
+      assertEquals(rows.get(i).get(1).asText(), UUID_VALUES.get(i));
+      assertEquals(rows.get(i).get(2).asText(), UUID_VALUES.get(i));
+      assertEquals(rows.get(i).get(3).asText(), uuidHex(UUID_VALUES.get(i)));
+    }
+
+    rows = postRows(useMultiStageQueryEngine, String.format(
+        "SELECT %s FROM %s WHERE %s = CAST('%s' AS UUID) ORDER BY %s", ID_COLUMN, getTableName(),
+        UUID_FROM_STRING_COLUMN, UUID_INPUT_VALUES.get(1).toUpperCase(), ID_COLUMN));
+    assertIdRows(rows, 1, 4);
+
+    rows = postRows(useMultiStageQueryEngine, String.format(
+        "SELECT %s FROM %s WHERE %s IN (CAST('%s' AS UUID), CAST('%s' AS UUID)) ORDER BY %s", ID_COLUMN,
+        getTableName(), UUID_FROM_BYTES_COLUMN, DISTINCT_UUID_VALUES.get(0).toUpperCase(), DISTINCT_UUID_VALUES.get(2),
+        ID_COLUMN));
+    assertIdRows(rows, 0, 2, 3);
+
+    rows = postRows(useMultiStageQueryEngine, String.format(
+        "SELECT %s FROM %s WHERE %s = TO_UUID('%s') ORDER BY %s", ID_COLUMN, getTableName(), UUID_FROM_STRING_COLUMN,
+        DISTINCT_UUID_VALUES.get(3).toUpperCase(), ID_COLUMN));
+    assertIdRows(rows, 5);
+
+    rows = postRows(useMultiStageQueryEngine, String.format(
+        "SELECT %s FROM %s WHERE %s = UUID_TO_BYTES(CAST('%s' AS UUID)) ORDER BY %s", ID_COLUMN, getTableName(),
+        UUID_AS_BYTES_COLUMN, DISTINCT_UUID_VALUES.get(1), ID_COLUMN));
+    assertIdRows(rows, 1, 4);
+
+    rows = postRows(useMultiStageQueryEngine, String.format(
+        "SELECT %s FROM %s WHERE CAST(%s AS UUID) = TO_UUID('%s') ORDER BY %s", ID_COLUMN, getTableName(),
+        UUID_AS_BYTES_COLUMN, DISTINCT_UUID_VALUES.get(2).toUpperCase(), ID_COLUMN));
+    assertIdRows(rows, 3);
+
+    rows = postRows(useMultiStageQueryEngine, String.format(
+        "SELECT %s FROM %s WHERE %s NOT IN (CAST('%s' AS UUID), CAST('%s' AS UUID)) ORDER BY %s", ID_COLUMN,
+        getTableName(), UUID_FROM_STRING_COLUMN, DISTINCT_UUID_VALUES.get(0), DISTINCT_UUID_VALUES.get(3), ID_COLUMN));
+    assertIdRows(rows, 1, 3, 4);
+  }
+
+  @Test(dataProvider = "useBothQueryEngines")
+  public void testUuidFunctionsAndCaseQueries(boolean useMultiStageQueryEngine)
+      throws Exception {
+    JsonNode rows = postRows(useMultiStageQueryEngine, String.format(
+        "SELECT UUID_TO_STRING(TO_UUID(UUID_TO_STRING(%s))), UUID_TO_STRING(TO_UUID(%s)), "
+            + "UUID_TO_STRING(BYTES_TO_UUID(%s)), UUID_TO_BYTES(%s), "
+            + "IS_UUID(UUID_TO_STRING(%s)), IS_UUID(%s), IS_UUID('not-a-uuid') "
+            + "FROM %s ORDER BY %s", UUID_FROM_STRING_COLUMN, UUID_AS_BYTES_COLUMN, UUID_FROM_BYTES_COLUMN,
+        UUID_FROM_BYTES_COLUMN, UUID_FROM_STRING_COLUMN, UUID_AS_BYTES_COLUMN, getTableName(), ID_COLUMN));
+
+    assertEquals(rows.size(), UUID_VALUES.size());
+    for (int i = 0; i < UUID_VALUES.size(); i++) {
+      assertEquals(rows.get(i).get(0).asText(), UUID_VALUES.get(i));
+      assertEquals(rows.get(i).get(1).asText(), UUID_VALUES.get(i));
+      assertEquals(rows.get(i).get(2).asText(), UUID_VALUES.get(i));
+      assertEquals(rows.get(i).get(3).asText(), uuidHex(UUID_VALUES.get(i)));
+      assertEquals(rows.get(i).get(4).asBoolean(), true);
+      assertEquals(rows.get(i).get(5).asBoolean(), true);
+      assertEquals(rows.get(i).get(6).asBoolean(), false);
+    }
+
+    rows = postRows(useMultiStageQueryEngine, String.format(
+        "SELECT CAST('%s' AS UUID) FROM %s ORDER BY %s LIMIT 1", DISTINCT_UUID_VALUES.get(0).toUpperCase(),
+        getTableName(), ID_COLUMN));
+    assertEquals(rows.size(), 1);
+    assertEquals(rows.get(0).get(0).asText(), DISTINCT_UUID_VALUES.get(0));
+
+    rows = postRows(useMultiStageQueryEngine, String.format(
+        "SELECT CASE WHEN %s < 2 THEN CAST('%s' AS UUID) ELSE BYTES_TO_UUID(%s) END "
+            + "FROM %s ORDER BY %s", ID_COLUMN, DISTINCT_UUID_VALUES.get(3).toUpperCase(), UUID_AS_BYTES_COLUMN,
+        getTableName(), ID_COLUMN));
+    assertEquals(rows.size(), UUID_VALUES.size());
+    assertEquals(rows.get(0).get(0).asText(), DISTINCT_UUID_VALUES.get(3));
+    assertEquals(rows.get(1).get(0).asText(), DISTINCT_UUID_VALUES.get(3));
+    for (int i = 2; i < UUID_VALUES.size(); i++) {
+      assertEquals(rows.get(i).get(0).asText(), UUID_VALUES.get(i));
+    }
+  }
+
+  @Test(dataProvider = "useBothQueryEngines")
+  public void testGroupByDistinctOrderByAndParity(boolean useMultiStageQueryEngine)
+      throws Exception {
+    JsonNode rows = postRows(useMultiStageQueryEngine, String.format(
+        "SELECT %s, COUNT(*) FROM %s GROUP BY %s ORDER BY %s", UUID_FROM_STRING_COLUMN, getTableName(),
+        UUID_FROM_STRING_COLUMN, UUID_FROM_STRING_COLUMN));
+    assertGroupedCounts(rows);
+
+    JsonNode rawRows = postRows(useMultiStageQueryEngine, String.format(
+        "SELECT %s, COUNT(*) FROM %s GROUP BY %s ORDER BY %s", UUID_FROM_BYTES_COLUMN, getTableName(),
+        UUID_FROM_BYTES_COLUMN, UUID_FROM_BYTES_COLUMN));
+    assertEquals(rawRows, rows);
+
+    rows = postRows(useMultiStageQueryEngine, String.format(
+        "SELECT DISTINCT BYTES_TO_UUID(%s) FROM %s ORDER BY BYTES_TO_UUID(%s)", UUID_AS_BYTES_COLUMN, getTableName(),
+        UUID_AS_BYTES_COLUMN));
+    assertDistinctRows(rows);
+
+    JsonNode dictRows = postRows(useMultiStageQueryEngine, String.format(
+        "SELECT %s, %s FROM %s ORDER BY %s, %s", UUID_FROM_STRING_COLUMN, ID_COLUMN, getTableName(),
+        UUID_FROM_STRING_COLUMN, ID_COLUMN));
+    JsonNode rawOrderRows = postRows(useMultiStageQueryEngine, String.format(
+        "SELECT %s, %s FROM %s ORDER BY %s, %s", UUID_FROM_BYTES_COLUMN, ID_COLUMN, getTableName(),
+        UUID_FROM_BYTES_COLUMN, ID_COLUMN));
+    assertEquals(rawOrderRows, dictRows);
+
+    for (int i = 0; i < SORTED_UUID_IDS.size(); i++) {
+      int expectedId = SORTED_UUID_IDS.get(i);
+      assertEquals(dictRows.get(i).get(0).asText(), UUID_VALUES.get(expectedId));
+      assertEquals(dictRows.get(i).get(1).asInt(), expectedId);
+    }
+  }
+
+  @Test
+  public void testSseMseParity()
+      throws Exception {
+    List<String> queries = List.of(
+        String.format("SELECT %s, UUID_TO_STRING(BYTES_TO_UUID(%s)) AS uuidText FROM %s ORDER BY %s",
+            UUID_FROM_STRING_COLUMN, UUID_AS_BYTES_COLUMN, getTableName(), ID_COLUMN),
+        String.format("SELECT COUNT(*) AS cnt FROM %s WHERE %s = TO_UUID('%s')", getTableName(),
+            UUID_FROM_STRING_COLUMN, DISTINCT_UUID_VALUES.get(1).toUpperCase()),
+        String.format("SELECT BYTES_TO_UUID(%s) AS uuidValue, COUNT(*) AS cnt FROM %s "
+                + "GROUP BY BYTES_TO_UUID(%s) ORDER BY uuidValue",
+            UUID_AS_BYTES_COLUMN, getTableName(), UUID_AS_BYTES_COLUMN));
+
+    for (String query : queries) {
+      JsonNode sseResult = postResultTable(false, query);
+      JsonNode mseResult = postResultTable(true, query);
+      assertEquals(mseResult, sseResult, query);
+    }
+  }
+
+  @Test(dataProvider = "useV2QueryEngine")
+  public void testUuidEqualityJoinWithExpressionKey(boolean useMultiStageQueryEngine)
+      throws Exception {
+    JsonNode rows = postRows(useMultiStageQueryEngine, String.format(
+        "SELECT a.%s, b.%s, a.%s "
+            + "FROM (SELECT %s, %s FROM %s WHERE %s < 5) a "
+            + "JOIN (SELECT %s, %s, %s FROM %s WHERE %s > 0) b "
+            + "ON a.%s = BYTES_TO_UUID(UUID_TO_BYTES(b.%s)) "
+            + "WHERE a.%s < b.%s "
+            + "ORDER BY a.%s, b.%s",
+        ID_COLUMN, ID_COLUMN, UUID_FROM_STRING_COLUMN, ID_COLUMN, UUID_FROM_STRING_COLUMN, getTableName(), ID_COLUMN,
+        ID_COLUMN, UUID_FROM_BYTES_COLUMN, UUID_AS_BYTES_COLUMN, getTableName(), ID_COLUMN, UUID_FROM_STRING_COLUMN,
+        UUID_FROM_BYTES_COLUMN, ID_COLUMN, ID_COLUMN, ID_COLUMN, ID_COLUMN));
+
+    assertEquals(rows.size(), 2);
+    assertEquals(rows.get(0).get(0).asInt(), 0);
+    assertEquals(rows.get(0).get(1).asInt(), 2);
+    assertEquals(rows.get(0).get(2).asText(), DISTINCT_UUID_VALUES.get(0));
+    assertEquals(rows.get(1).get(0).asInt(), 1);
+    assertEquals(rows.get(1).get(1).asInt(), 4);
+    assertEquals(rows.get(1).get(2).asText(), DISTINCT_UUID_VALUES.get(1));
+  }
+
+  private JsonNode postRows(boolean useMultiStageQueryEngine, String query)
+      throws Exception {
+    return postResultTable(useMultiStageQueryEngine, query).get("rows");
+  }
+
+  private JsonNode postResultTable(boolean useMultiStageQueryEngine, String query)
+      throws Exception {
+    setUseMultiStageQueryEngine(useMultiStageQueryEngine);
+    JsonNode response = postQuery(query);
+    assertNoExceptions(response);
+    return response.get("resultTable");
+  }
+
+  private static void assertGroupedCounts(JsonNode rows) {
+    assertEquals(rows.size(), DISTINCT_UUID_VALUES.size());
+    assertEquals(rows.get(0).get(0).asText(), DISTINCT_UUID_VALUES.get(0));
+    assertEquals(rows.get(0).get(1).asInt(), 2);
+    assertEquals(rows.get(1).get(0).asText(), DISTINCT_UUID_VALUES.get(1));
+    assertEquals(rows.get(1).get(1).asInt(), 2);
+    assertEquals(rows.get(2).get(0).asText(), DISTINCT_UUID_VALUES.get(2));
+    assertEquals(rows.get(2).get(1).asInt(), 1);
+    assertEquals(rows.get(3).get(0).asText(), DISTINCT_UUID_VALUES.get(3));
+    assertEquals(rows.get(3).get(1).asInt(), 1);
+  }
+
+  private static void assertDistinctRows(JsonNode rows) {
+    assertEquals(rows.size(), DISTINCT_UUID_VALUES.size());
+    for (int i = 0; i < DISTINCT_UUID_VALUES.size(); i++) {
+      assertEquals(rows.get(i).get(0).asText(), DISTINCT_UUID_VALUES.get(i));
+    }
+  }
+
+  private static void assertIdRows(JsonNode rows, int... expectedIds) {
+    assertEquals(rows.size(), expectedIds.length);
+    for (int i = 0; i < expectedIds.length; i++) {
+      assertEquals(rows.get(i).get(0).asInt(), expectedIds[i]);
+    }
+  }
+
+  private static String uuidHex(String uuidValue) {
+    return BytesUtils.toHexString(UuidUtils.toBytes(uuidValue));
+  }
+
+  private static void assertNoExceptions(JsonNode response) {
+    assertEquals(response.get("exceptions").size(), 0, response.toPrettyString());
+  }
+}

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/UuidUpsertRealtimeTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/UuidUpsertRealtimeTest.java
@@ -1,0 +1,336 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.integration.tests.custom;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.avro.Schema.Field;
+import org.apache.avro.Schema.Type;
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.generic.GenericData;
+import org.apache.pinot.integration.tests.ClusterTest.AvroFileSchemaKafkaAvroMessageDecoder;
+import org.apache.pinot.spi.config.table.ColumnPartitionConfig;
+import org.apache.pinot.spi.config.table.ReplicaGroupStrategyConfig;
+import org.apache.pinot.spi.config.table.RoutingConfig;
+import org.apache.pinot.spi.config.table.SegmentPartitionConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.config.table.UpsertConfig;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.util.TestUtils;
+import org.testng.annotations.Test;
+
+import static org.apache.avro.Schema.create;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+/**
+ * Realtime upsert coverage for UUID primary keys.
+ *
+ * <p>This test uses a single Kafka partition because mixed-case UUID spellings normalize only after Pinot ingests the
+ * row. Keeping the stream single-partitioned ensures logically equivalent UUID keys remain colocated before that
+ * canonicalization step.
+ */
+@Test(suiteName = "CustomClusterIntegrationTest")
+public class UuidUpsertRealtimeTest extends CustomDataQueryClusterIntegrationTest {
+  private static final long DEDUPLICATED_RECORDS_READY_TIMEOUT_MS = 120_000L;
+  private static final String TABLE_NAME = "UuidUpsertRealtimeTest";
+  private static final String UUID_PK_COLUMN = "uuidPk";
+  private static final String PAYLOAD_COLUMN = "payload";
+  private static final String TIME_COLUMN = "ts";
+  private static final List<String> UUID_INPUT_VALUES = List.of(
+      "550E8400-E29B-41D4-A716-446655440000",
+      "550E8400-E29B-41D4-A716-446655440001",
+      "550e8400-e29b-41d4-a716-446655440000",
+      "550e8400-e29b-41d4-a716-446655440002",
+      "550e8400-e29b-41d4-a716-446655440001");
+  private static final List<String> PAYLOAD_VALUES = List.of("alpha-v1", "beta-v1", "alpha-v2", "gamma-v1",
+      "beta-v2");
+  private static final List<String> EXPECTED_UUID_VALUES = List.of(
+      "550e8400-e29b-41d4-a716-446655440000",
+      "550e8400-e29b-41d4-a716-446655440001",
+      "550e8400-e29b-41d4-a716-446655440002");
+  private static final List<String> EXPECTED_PAYLOAD_VALUES = List.of("alpha-v2", "beta-v2", "gamma-v1");
+  private static final String COUNT_QUERY = String.format("SELECT COUNT(*) FROM %s", TABLE_NAME);
+  private static final String RAW_COUNT_QUERY =
+      String.format("SELECT COUNT(*) FROM %s OPTION(skipUpsert=true)", TABLE_NAME);
+  private static final String ORDERED_ROWS_QUERY =
+      String.format("SELECT %s, %s FROM %s ORDER BY %s", UUID_PK_COLUMN, PAYLOAD_COLUMN, TABLE_NAME, UUID_PK_COLUMN);
+  private static final String FILTER_QUERY = String.format("SELECT %s FROM %s WHERE %s = TO_UUID('%s')",
+      PAYLOAD_COLUMN, TABLE_NAME, UUID_PK_COLUMN, UUID_INPUT_VALUES.get(0));
+  private static final int TOTAL_RAW_RECORDS = UUID_INPUT_VALUES.size();
+  private static final long BASE_TIMESTAMP_MILLIS = 1_700_100_000_000L;
+
+  @Override
+  public String getTableName() {
+    return TABLE_NAME;
+  }
+
+  @Override
+  public boolean isRealtimeTable() {
+    return true;
+  }
+
+  @Override
+  public String getTimeColumnName() {
+    return TIME_COLUMN;
+  }
+
+  @Override
+  protected UpsertConfig getUpsertConfig() {
+    return new UpsertConfig(UpsertConfig.Mode.FULL);
+  }
+
+  @Override
+  protected RoutingConfig getRoutingConfig() {
+    return new RoutingConfig(null, null, RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE, false);
+  }
+
+  @Override
+  protected long getCountStarResult() {
+    return EXPECTED_UUID_VALUES.size();
+  }
+
+  @Override
+  protected int getNumKafkaPartitions() {
+    return 1;
+  }
+
+  @Override
+  public int getNumAvroFiles() {
+    return 1;
+  }
+
+  @Override
+  protected int getRealtimeSegmentFlushSize() {
+    return 2;
+  }
+
+  @Override
+  protected TableConfig createRealtimeTableConfig(File sampleAvroFile) {
+    AvroFileSchemaKafkaAvroMessageDecoder._avroFile = sampleAvroFile;
+    SegmentPartitionConfig segmentPartitionConfig = new SegmentPartitionConfig(
+        Map.of(UUID_PK_COLUMN, new ColumnPartitionConfig("Murmur", getNumKafkaPartitions())));
+    return getTableConfigBuilder(TableType.REALTIME)
+        .setSegmentPartitionConfig(segmentPartitionConfig)
+        .setReplicaGroupStrategyConfig(new ReplicaGroupStrategyConfig(UUID_PK_COLUMN, 1))
+        .build();
+  }
+
+  @Override
+  protected void waitForAllDocsLoaded(long timeoutMs)
+      throws Exception {
+    TestUtils.waitForCondition(aVoid -> {
+      try {
+        return queryCountStarWithoutUpsert() == TOTAL_RAW_RECORDS;
+      } catch (Exception e) {
+        return null;
+      }
+    }, 100L, timeoutMs, "Failed to load raw UUID upsert records");
+  }
+
+  @Override
+  public Schema createSchema() {
+    return new Schema.SchemaBuilder().setSchemaName(getTableName())
+        .addSingleValueDimension(UUID_PK_COLUMN, FieldSpec.DataType.UUID)
+        .addSingleValueDimension(PAYLOAD_COLUMN, FieldSpec.DataType.STRING)
+        .addDateTimeField(TIME_COLUMN, FieldSpec.DataType.LONG, "1:MILLISECONDS:EPOCH", "1:MILLISECONDS")
+        .setPrimaryKeyColumns(List.of(UUID_PK_COLUMN))
+        .build();
+  }
+
+  @Override
+  public List<File> createAvroFiles()
+      throws Exception {
+    org.apache.avro.Schema avroSchema = org.apache.avro.Schema.createRecord("uuidUpsertRecord", null, null, false);
+    avroSchema.setFields(List.of(
+        new Field(UUID_PK_COLUMN, create(Type.STRING), null, null),
+        new Field(PAYLOAD_COLUMN, create(Type.STRING), null, null),
+        new Field(TIME_COLUMN, create(Type.LONG), null, null)));
+
+    try (AvroFilesAndWriters avroFilesAndWriters = createAvroFilesAndWriters(avroSchema)) {
+      List<DataFileWriter<GenericData.Record>> writers = avroFilesAndWriters.getWriters();
+      for (int i = 0; i < UUID_INPUT_VALUES.size(); i++) {
+        GenericData.Record record = new GenericData.Record(avroSchema);
+        record.put(UUID_PK_COLUMN, UUID_INPUT_VALUES.get(i));
+        record.put(PAYLOAD_COLUMN, PAYLOAD_VALUES.get(i));
+        record.put(TIME_COLUMN, BASE_TIMESTAMP_MILLIS + i);
+        writers.get(0).append(record);
+      }
+      return avroFilesAndWriters.getAvroFiles();
+    }
+  }
+
+  @Test(dataProvider = "useBothQueryEngines")
+  public void testUuidPrimaryKeyUpsertDedup(boolean useMultiStageQueryEngine)
+      throws Exception {
+    setUseMultiStageQueryEngine(useMultiStageQueryEngine);
+    UuidQueryResults queryResults = waitForExpectedQueryResults(DEDUPLICATED_RECORDS_READY_TIMEOUT_MS);
+
+    assertExpectedCountResponse(queryResults._countResponse, EXPECTED_UUID_VALUES.size());
+    assertExpectedCountResponse(queryResults._rawCountResponse, TOTAL_RAW_RECORDS);
+    assertExpectedOrderedRowsResponse(queryResults._orderedRowsResponse);
+    assertExpectedFilterResponse(queryResults._filterResponse);
+  }
+
+  private static void assertNoExceptions(JsonNode response) {
+    assertEquals(getExceptionCount(response), 0, response.toPrettyString());
+  }
+
+  private void assertExpectedCountResponse(JsonNode response, long expectedCount) {
+    assertNoExceptions(response);
+    JsonNode firstRowFirstColumn = getFirstRowFirstColumn(response);
+    assertNotNull(firstRowFirstColumn, response.toPrettyString());
+    assertEquals(firstRowFirstColumn.asLong(), expectedCount);
+  }
+
+  private void assertExpectedOrderedRowsResponse(JsonNode response) {
+    assertNoExceptions(response);
+    JsonNode rows = getRows(response);
+    assertNotNull(rows, response.toPrettyString());
+    assertEquals(rows.size(), EXPECTED_UUID_VALUES.size());
+    for (int i = 0; i < EXPECTED_UUID_VALUES.size(); i++) {
+      assertEquals(rows.get(i).get(0).asText(), EXPECTED_UUID_VALUES.get(i));
+      assertEquals(rows.get(i).get(1).asText(), EXPECTED_PAYLOAD_VALUES.get(i));
+    }
+  }
+
+  private void assertExpectedFilterResponse(JsonNode response) {
+    assertNoExceptions(response);
+    JsonNode firstRowFirstColumn = getFirstRowFirstColumn(response);
+    assertNotNull(firstRowFirstColumn, response.toPrettyString());
+    assertEquals(firstRowFirstColumn.asText(), "alpha-v2");
+  }
+
+  private UuidQueryResults waitForExpectedQueryResults(long timeoutMs)
+      throws Exception {
+    AtomicReference<UuidQueryResults> queryResultsRef = new AtomicReference<>();
+    TestUtils.waitForCondition(aVoid -> {
+      try {
+        UuidQueryResults queryResults = fetchQueryResults();
+        if (matchesExpectedQueryResults(queryResults)) {
+          queryResultsRef.set(queryResults);
+          return true;
+        }
+        return false;
+      } catch (Exception e) {
+        return null;
+      }
+    }, 100L, timeoutMs, "Failed to observe expected UUID upsert query results");
+    return queryResultsRef.get();
+  }
+
+  private UuidQueryResults fetchQueryResults()
+      throws Exception {
+    return new UuidQueryResults(postQuery(COUNT_QUERY), postQuery(RAW_COUNT_QUERY), postQuery(ORDERED_ROWS_QUERY),
+        postQuery(FILTER_QUERY));
+  }
+
+  private boolean matchesExpectedQueryResults(UuidQueryResults queryResults) {
+    return hasExpectedCount(queryResults._countResponse, EXPECTED_UUID_VALUES.size())
+        && hasExpectedCount(queryResults._rawCountResponse, TOTAL_RAW_RECORDS)
+        && hasExpectedOrderedRows(queryResults._orderedRowsResponse)
+        && hasExpectedFilterValue(queryResults._filterResponse, "alpha-v2");
+  }
+
+  private boolean hasExpectedCount(JsonNode response, long expectedCount) {
+    JsonNode firstRowFirstColumn = getFirstRowFirstColumn(response);
+    return hasNoExceptions(response) && firstRowFirstColumn != null
+        && firstRowFirstColumn.asLong(Long.MIN_VALUE) == expectedCount;
+  }
+
+  private boolean hasExpectedOrderedRows(JsonNode response) {
+    if (!hasNoExceptions(response)) {
+      return false;
+    }
+    JsonNode rows = getRows(response);
+    if (rows == null) {
+      return false;
+    }
+    if (rows.size() != EXPECTED_UUID_VALUES.size()) {
+      return false;
+    }
+    for (int i = 0; i < EXPECTED_UUID_VALUES.size(); i++) {
+      JsonNode row = rows.get(i);
+      if (row == null || row.size() < 2 || !EXPECTED_UUID_VALUES.get(i).equals(row.get(0).asText())
+          || !EXPECTED_PAYLOAD_VALUES.get(i).equals(row.get(1).asText())) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  private boolean hasExpectedFilterValue(JsonNode response, String expectedValue) {
+    JsonNode firstRowFirstColumn = getFirstRowFirstColumn(response);
+    return hasNoExceptions(response) && firstRowFirstColumn != null
+        && expectedValue.equals(firstRowFirstColumn.asText());
+  }
+
+  private static boolean hasNoExceptions(JsonNode response) {
+    return getExceptionCount(response) == 0;
+  }
+
+  private static int getExceptionCount(JsonNode response) {
+    JsonNode exceptions = response.get("exceptions");
+    return exceptions != null ? exceptions.size() : 0;
+  }
+
+  private static JsonNode getRows(JsonNode response) {
+    JsonNode resultTable = response.get("resultTable");
+    if (resultTable == null) {
+      return null;
+    }
+    return resultTable.get("rows");
+  }
+
+  private static JsonNode getFirstRowFirstColumn(JsonNode response) {
+    JsonNode rows = getRows(response);
+    if (rows == null || rows.isEmpty()) {
+      return null;
+    }
+    JsonNode firstRow = rows.get(0);
+    if (firstRow == null || firstRow.isEmpty()) {
+      return null;
+    }
+    return firstRow.get(0);
+  }
+
+  private long queryCountStarWithoutUpsert() {
+    return getPinotConnection().execute(RAW_COUNT_QUERY).getResultSet(0).getLong(0);
+  }
+
+  private static final class UuidQueryResults {
+    private final JsonNode _countResponse;
+    private final JsonNode _rawCountResponse;
+    private final JsonNode _orderedRowsResponse;
+    private final JsonNode _filterResponse;
+
+    private UuidQueryResults(JsonNode countResponse, JsonNode rawCountResponse, JsonNode orderedRowsResponse,
+        JsonNode filterResponse) {
+      _countResponse = countResponse;
+      _rawCountResponse = rawCountResponse;
+      _orderedRowsResponse = orderedRowsResponse;
+      _filterResponse = filterResponse;
+    }
+  }
+}

--- a/pinot-perf/pom.xml
+++ b/pinot-perf/pom.xml
@@ -51,6 +51,10 @@
     </dependency>
     <dependency>
       <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-query-runtime</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-kafka-3.0</artifactId>
       <scope>runtime</scope>
     </dependency>

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkUuidGroupingAndLookup.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkUuidGroupingAndLookup.java
@@ -1,0 +1,276 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.perf;
+
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import org.apache.pinot.query.runtime.operator.groupby.OneObjectKeyGroupIdGenerator;
+import org.apache.pinot.query.runtime.operator.groupby.OneUuidKeyGroupIdGenerator;
+import org.apache.pinot.query.runtime.operator.join.ObjectLookupTable;
+import org.apache.pinot.query.runtime.operator.join.UuidLookupTable;
+import org.apache.pinot.spi.utils.ByteArray;
+import org.apache.pinot.spi.utils.UuidUtils;
+import org.apache.pinot.spi.utils.UuidUtils.UuidKey;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+
+/**
+ * Benchmarks UUID grouping and lookup hot paths using Pinot's current {@link ByteArray}-based representation versus a
+ * two-long UUID key representation and {@link UUID}.
+ *
+ * <p>The benchmark is intentionally engine-adjacent:
+ * <ul>
+ *   <li>V1 grouping uses the same {@code Object2IntOpenHashMap<ByteArray>} shape as no-dictionary UUID group-by</li>
+ *   <li>V2 grouping uses {@link OneUuidKeyGroupIdGenerator}</li>
+ *   <li>Lookup uses {@link UuidLookupTable}, which is the UUID-specific path used by MSE hash join</li>
+ * </ul>
+ */
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@Fork(1)
+@Warmup(iterations = 3, time = 5)
+@Measurement(iterations = 5, time = 5)
+@State(Scope.Benchmark)
+public class BenchmarkUuidGroupingAndLookup {
+  private static final long RANDOM_SEED = 677_280_899_123L;
+
+  @Param({"262144"})
+  public int _numRows;
+
+  @Param({"65536"})
+  public int _cardinality;
+
+  @Param({"8192"})
+  public int _numProbes;
+
+  private byte[][] _rowUuidBytes;
+  private ByteArray[] _rowByteArrays;
+  private UuidKey[] _rowUuidKeys;
+  private UUID[] _rowJavaUuids;
+  private ByteArray[] _distinctByteArrays;
+  private UuidKey[] _distinctUuidKeys;
+  private UUID[] _distinctJavaUuids;
+  private Object[][] _distinctByteArrayRows;
+  private Object[][] _distinctJavaUuidRows;
+  private ByteArray[] _probeByteArrays;
+  private UUID[] _probeJavaUuids;
+
+  @Setup
+  public void setUp() {
+    Random random = new Random(RANDOM_SEED);
+
+    byte[][] distinctUuidBytes = new byte[_cardinality][];
+    _distinctByteArrays = new ByteArray[_cardinality];
+    _distinctUuidKeys = new UuidKey[_cardinality];
+    _distinctJavaUuids = new UUID[_cardinality];
+    _distinctByteArrayRows = new Object[_cardinality][];
+    _distinctJavaUuidRows = new Object[_cardinality][];
+
+    for (int i = 0; i < _cardinality; i++) {
+      UUID uuid = new UUID(random.nextLong(), random.nextLong());
+      byte[] uuidBytes = UuidUtils.toBytes(uuid);
+
+      distinctUuidBytes[i] = uuidBytes;
+      _distinctByteArrays[i] = new ByteArray(uuidBytes);
+      _distinctUuidKeys[i] = UuidKey.fromLongs(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits());
+      _distinctJavaUuids[i] = uuid;
+      _distinctByteArrayRows[i] = new Object[]{i};
+      _distinctJavaUuidRows[i] = new Object[]{i};
+    }
+
+    _rowUuidBytes = new byte[_numRows][];
+    _rowByteArrays = new ByteArray[_numRows];
+    _rowUuidKeys = new UuidKey[_numRows];
+    _rowJavaUuids = new UUID[_numRows];
+
+    for (int i = 0; i < _numRows; i++) {
+      int dictId = random.nextInt(_cardinality);
+      _rowUuidBytes[i] = distinctUuidBytes[dictId];
+      _rowByteArrays[i] = _distinctByteArrays[dictId];
+      _rowUuidKeys[i] = _distinctUuidKeys[dictId];
+      _rowJavaUuids[i] = _distinctJavaUuids[dictId];
+    }
+
+    _probeByteArrays = new ByteArray[_numProbes];
+    _probeJavaUuids = new UUID[_numProbes];
+    for (int i = 0; i < _numProbes; i++) {
+      int dictId = random.nextInt(_cardinality);
+      _probeByteArrays[i] = _distinctByteArrays[dictId];
+      _probeJavaUuids[i] = _distinctJavaUuids[dictId];
+    }
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  public int v1CurrentByteArrayGrouping() {
+    Object2IntOpenHashMap<ByteArray> groupIdMap = new Object2IntOpenHashMap<>(_cardinality);
+    groupIdMap.defaultReturnValue(-1);
+
+    int checksum = 0;
+    for (int i = 0; i < _numRows; i++) {
+      checksum += getOrCreateGroupId(groupIdMap, new ByteArray(_rowUuidBytes[i]));
+    }
+    return checksum + groupIdMap.size();
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  public int v1UuidKeyGrouping() {
+    Object2IntOpenHashMap<UuidKey> groupIdMap = new Object2IntOpenHashMap<>(_cardinality);
+    groupIdMap.defaultReturnValue(-1);
+
+    int checksum = 0;
+    for (int i = 0; i < _numRows; i++) {
+      checksum += getOrCreateGroupId(groupIdMap, _rowUuidKeys[i]);
+    }
+    return checksum + groupIdMap.size();
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  public int v1JavaUuidGrouping() {
+    Object2IntOpenHashMap<UUID> groupIdMap = new Object2IntOpenHashMap<>(_cardinality);
+    groupIdMap.defaultReturnValue(-1);
+
+    int checksum = 0;
+    for (int i = 0; i < _numRows; i++) {
+      checksum += getOrCreateGroupId(groupIdMap, _rowJavaUuids[i]);
+    }
+    return checksum + groupIdMap.size();
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  public int v2CurrentByteArrayGroupIdGenerator() {
+    OneObjectKeyGroupIdGenerator groupIdGenerator = new OneObjectKeyGroupIdGenerator(_cardinality, _cardinality);
+
+    int checksum = 0;
+    for (ByteArray rowByteArray : _rowByteArrays) {
+      checksum += groupIdGenerator.getGroupId(rowByteArray);
+    }
+    return checksum + groupIdGenerator.getNumGroups();
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  public int v2UuidKeyGroupIdGenerator() {
+    OneUuidKeyGroupIdGenerator groupIdGenerator = new OneUuidKeyGroupIdGenerator(_cardinality, _cardinality);
+
+    int checksum = 0;
+    for (UuidKey rowUuidKey : _rowUuidKeys) {
+      checksum += groupIdGenerator.getGroupId(rowUuidKey);
+    }
+    return checksum + groupIdGenerator.getNumGroups();
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  public int v2JavaUuidGroupIdGenerator() {
+    OneObjectKeyGroupIdGenerator groupIdGenerator = new OneObjectKeyGroupIdGenerator(_cardinality, _cardinality);
+
+    int checksum = 0;
+    for (UUID rowJavaUuid : _rowJavaUuids) {
+      checksum += groupIdGenerator.getGroupId(rowJavaUuid);
+    }
+    return checksum + groupIdGenerator.getNumGroups();
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  public int currentObjectLookupTableBuildAndProbe() {
+    ObjectLookupTable lookupTable = new ObjectLookupTable();
+    for (int i = 0; i < _cardinality; i++) {
+      lookupTable.addRow(_distinctByteArrays[i], _distinctByteArrayRows[i]);
+    }
+    lookupTable.finish();
+
+    int checksum = lookupTable.size();
+    for (ByteArray probeByteArray : _probeByteArrays) {
+      Object[] row = (Object[]) lookupTable.lookup(probeByteArray);
+      if (row != null) {
+        checksum += (int) row[0];
+      }
+    }
+    return checksum;
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  public int uuidLookupTableBuildAndProbe() {
+    UuidLookupTable lookupTable = new UuidLookupTable();
+    for (int i = 0; i < _cardinality; i++) {
+      lookupTable.addRow(_distinctByteArrays[i], _distinctByteArrayRows[i]);
+    }
+    lookupTable.finish();
+
+    int checksum = lookupTable.size();
+    for (ByteArray probeByteArray : _probeByteArrays) {
+      Object[] row = (Object[]) lookupTable.lookup(probeByteArray);
+      if (row != null) {
+        checksum += (int) row[0];
+      }
+    }
+    return checksum;
+  }
+
+  @Benchmark
+  @BenchmarkMode(Mode.AverageTime)
+  public int javaUuidObjectLookupTableBuildAndProbe() {
+    ObjectLookupTable lookupTable = new ObjectLookupTable();
+    for (int i = 0; i < _cardinality; i++) {
+      lookupTable.addRow(_distinctJavaUuids[i], _distinctJavaUuidRows[i]);
+    }
+    lookupTable.finish();
+
+    int checksum = lookupTable.size();
+    for (UUID probeJavaUuid : _probeJavaUuids) {
+      Object[] row = (Object[]) lookupTable.lookup(probeJavaUuid);
+      if (row != null) {
+        checksum += (int) row[0];
+      }
+    }
+    return checksum;
+  }
+
+  private <T> int getOrCreateGroupId(Object2IntOpenHashMap<T> groupIdMap, T key) {
+    int numGroups = groupIdMap.size();
+    if (numGroups < _cardinality) {
+      return groupIdMap.computeIfAbsent(key, ignored -> numGroups);
+    }
+    return groupIdMap.getInt(key);
+  }
+
+  public static void main(String[] args)
+      throws Exception {
+    new Runner(new OptionsBuilder().include(BenchmarkUuidGroupingAndLookup.class.getSimpleName()).build()).run();
+  }
+}

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkUuidQueryExecution.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkUuidQueryExecution.java
@@ -1,0 +1,363 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.perf;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.common.response.broker.BrokerResponseNative;
+import org.apache.pinot.queries.BaseQueriesTest;
+import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
+import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
+import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.utils.BytesUtils;
+import org.apache.pinot.spi.utils.UuidUtils;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Measurement;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Param;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Warmup;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+
+/**
+ * Compares query execution performance for UUID values stored in three representations:
+ * <ul>
+ *   <li><b>STRING</b> — canonical RFC 4122 form, e.g. {@code "550e8400-e29b-41d4-a716-446655440000"} (36-char string
+ *   key in group-by)</li>
+ *   <li><b>BYTES</b> — raw 16-byte binary; group-by key is a {@code ByteArray} (heap allocation per row)</li>
+ *   <li><b>UUID</b> — native {@code DataType.UUID}; group-by key is a {@code UuidKey} (two {@code long} fields,
+ *   no heap allocation)</li>
+ * </ul>
+ * Each representation is tested with both raw (no-dictionary) and dictionary-encoded columns. The benchmarked
+ * operations are GROUP BY, COUNT(DISTINCT), and equality-filter COUNT(*).
+ *
+ * <p>Run with:
+ * <pre>
+ *   ./mvnw package -DskipTests -pl pinot-perf -am -Ppinot-fastdev
+ *   java -jar pinot-perf/target/benchmarks.jar BenchmarkUuidQueryExecution
+ * </pre>
+ */
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@Fork(1)
+@Warmup(iterations = 3, time = 3)
+@Measurement(iterations = 5, time = 3)
+@State(Scope.Benchmark)
+public class BenchmarkUuidQueryExecution extends BaseQueriesTest {
+  private static final File INDEX_DIR =
+      new File(FileUtils.getTempDirectory(), "BenchmarkUuidQueryExecution");
+  private static final String TABLE_NAME = "uuidBenchTable";
+  private static final String SEGMENT_NAME = "uuidBenchSegment";
+
+  // STRING columns: UUID in canonical "8-4-4-4-12" dash-separated form
+  private static final String STR_UUID_RAW = "str_uuid_raw";
+  private static final String STR_UUID_DICT = "str_uuid_dict";
+  // BYTES columns: UUID as raw 16-byte binary; group-by uses ByteArray
+  private static final String BYTES_UUID_RAW = "bytes_uuid_raw";
+  private static final String BYTES_UUID_DICT = "bytes_uuid_dict";
+  // UUID columns: native DataType.UUID; group-by uses UuidKey (two longs)
+  private static final String UUID_RAW = "uuid_raw";
+  private static final String UUID_DICT = "uuid_dict";
+  // Two-LONG columns: UUID split into MSB + LSB; GROUP BY both simultaneously
+  private static final String LONG_MSB_RAW = "long_msb_raw";
+  private static final String LONG_LSB_RAW = "long_lsb_raw";
+  private static final String LONG_MSB_DICT = "long_msb_dict";
+  private static final String LONG_LSB_DICT = "long_lsb_dict";
+
+  private static final TableConfig TABLE_CONFIG = new TableConfigBuilder(TableType.OFFLINE)
+      .setTableName(TABLE_NAME)
+      .setNoDictionaryColumns(List.of(STR_UUID_RAW, BYTES_UUID_RAW, UUID_RAW, LONG_MSB_RAW, LONG_LSB_RAW))
+      .build();
+
+  private static final Schema SCHEMA = new Schema.SchemaBuilder()
+      .addSingleValueDimension(STR_UUID_RAW, FieldSpec.DataType.STRING)
+      .addSingleValueDimension(STR_UUID_DICT, FieldSpec.DataType.STRING)
+      .addSingleValueDimension(BYTES_UUID_RAW, FieldSpec.DataType.BYTES)
+      .addSingleValueDimension(BYTES_UUID_DICT, FieldSpec.DataType.BYTES)
+      .addSingleValueDimension(UUID_RAW, FieldSpec.DataType.UUID)
+      .addSingleValueDimension(UUID_DICT, FieldSpec.DataType.UUID)
+      .addSingleValueDimension(LONG_MSB_RAW, FieldSpec.DataType.LONG)
+      .addSingleValueDimension(LONG_LSB_RAW, FieldSpec.DataType.LONG)
+      .addSingleValueDimension(LONG_MSB_DICT, FieldSpec.DataType.LONG)
+      .addSingleValueDimension(LONG_LSB_DICT, FieldSpec.DataType.LONG)
+      .build();
+
+  /** Total rows in the segment. */
+  @Param("500000")
+  private int _numRows;
+
+  /** Number of distinct UUID values. Controls group-by cardinality. */
+  @Param("1000")
+  private int _numUniqueUuids;
+
+  private IndexSegment _indexSegment;
+  private List<IndexSegment> _indexSegments;
+
+  /** UUID string used in equality-filter benchmarks (RFC 4122 form). */
+  private String _filterUuidString;
+  /** Same UUID as hex (no dashes) for BYTES column equality filter. */
+  private String _filterBytesHex;
+  /** MSB of the filter UUID, for two-long filter benchmarks. */
+  private long _filterMsb;
+  /** LSB of the filter UUID, for two-long filter benchmarks. */
+  private long _filterLsb;
+
+  @Setup
+  public void setUp()
+      throws Exception {
+    FileUtils.deleteQuietly(INDEX_DIR);
+    INDEX_DIR.mkdirs();
+
+    Random random = new Random(42L);
+
+    // Pre-generate the UUID value pool
+    String[] uuidStrings = new String[_numUniqueUuids];
+    byte[][] uuidBytesArr = new byte[_numUniqueUuids][];
+    long[] msbArr = new long[_numUniqueUuids];
+    long[] lsbArr = new long[_numUniqueUuids];
+    for (int i = 0; i < _numUniqueUuids; i++) {
+      UUID uuid = new UUID(random.nextLong(), random.nextLong());
+      uuidStrings[i] = uuid.toString();
+      uuidBytesArr[i] = UuidUtils.toBytes(uuid);
+      msbArr[i] = uuid.getMostSignificantBits();
+      lsbArr[i] = uuid.getLeastSignificantBits();
+    }
+    _filterUuidString = uuidStrings[0];
+    _filterBytesHex = BytesUtils.toHexString(uuidBytesArr[0]);
+    _filterMsb = msbArr[0];
+    _filterLsb = lsbArr[0];
+
+    // Build rows with uniform distribution over the UUID pool
+    List<GenericRow> rows = new ArrayList<>(_numRows);
+    for (int i = 0; i < _numRows; i++) {
+      int idx = i % _numUniqueUuids;
+      GenericRow row = new GenericRow();
+      row.putValue(STR_UUID_RAW, uuidStrings[idx]);
+      row.putValue(STR_UUID_DICT, uuidStrings[idx]);
+      row.putValue(BYTES_UUID_RAW, uuidBytesArr[idx]);
+      row.putValue(BYTES_UUID_DICT, uuidBytesArr[idx]);
+      row.putValue(UUID_RAW, uuidBytesArr[idx]);
+      row.putValue(UUID_DICT, uuidBytesArr[idx]);
+      row.putValue(LONG_MSB_RAW, msbArr[idx]);
+      row.putValue(LONG_LSB_RAW, lsbArr[idx]);
+      row.putValue(LONG_MSB_DICT, msbArr[idx]);
+      row.putValue(LONG_LSB_DICT, lsbArr[idx]);
+      rows.add(row);
+    }
+
+    SegmentGeneratorConfig config = new SegmentGeneratorConfig(TABLE_CONFIG, SCHEMA);
+    config.setOutDir(INDEX_DIR.getPath());
+    config.setTableName(TABLE_NAME);
+    config.setSegmentName(SEGMENT_NAME);
+
+    SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+    driver.init(config, new GenericRowRecordReader(rows));
+    driver.build();
+
+    IndexLoadingConfig loadingConfig = new IndexLoadingConfig(TABLE_CONFIG, SCHEMA);
+    _indexSegment = ImmutableSegmentLoader.load(new File(INDEX_DIR, SEGMENT_NAME), loadingConfig);
+    _indexSegments = List.of(_indexSegment);
+  }
+
+  @TearDown
+  public void tearDown() {
+    _indexSegment.destroy();
+    FileUtils.deleteQuietly(INDEX_DIR);
+  }
+
+  // ---- GROUP BY --------------------------------------------------------
+
+  @Benchmark
+  public BrokerResponseNative groupByStrUuidRaw() {
+    return getBrokerResponse(
+        "SELECT " + STR_UUID_RAW + ", COUNT(*) FROM " + TABLE_NAME + " GROUP BY " + STR_UUID_RAW);
+  }
+
+  @Benchmark
+  public BrokerResponseNative groupByStrUuidDict() {
+    return getBrokerResponse(
+        "SELECT " + STR_UUID_DICT + ", COUNT(*) FROM " + TABLE_NAME + " GROUP BY " + STR_UUID_DICT);
+  }
+
+  @Benchmark
+  public BrokerResponseNative groupByBytesUuidRaw() {
+    return getBrokerResponse(
+        "SELECT " + BYTES_UUID_RAW + ", COUNT(*) FROM " + TABLE_NAME + " GROUP BY " + BYTES_UUID_RAW);
+  }
+
+  @Benchmark
+  public BrokerResponseNative groupByBytesUuidDict() {
+    return getBrokerResponse(
+        "SELECT " + BYTES_UUID_DICT + ", COUNT(*) FROM " + TABLE_NAME + " GROUP BY " + BYTES_UUID_DICT);
+  }
+
+  @Benchmark
+  public BrokerResponseNative groupByNativeUuidRaw() {
+    return getBrokerResponse(
+        "SELECT " + UUID_RAW + ", COUNT(*) FROM " + TABLE_NAME + " GROUP BY " + UUID_RAW);
+  }
+
+  @Benchmark
+  public BrokerResponseNative groupByNativeUuidDict() {
+    return getBrokerResponse(
+        "SELECT " + UUID_DICT + ", COUNT(*) FROM " + TABLE_NAME + " GROUP BY " + UUID_DICT);
+  }
+
+  @Benchmark
+  public BrokerResponseNative groupByTwoLongRaw() {
+    return getBrokerResponse(
+        "SELECT " + LONG_MSB_RAW + ", " + LONG_LSB_RAW + ", COUNT(*) FROM " + TABLE_NAME
+            + " GROUP BY " + LONG_MSB_RAW + ", " + LONG_LSB_RAW);
+  }
+
+  @Benchmark
+  public BrokerResponseNative groupByTwoLongDict() {
+    return getBrokerResponse(
+        "SELECT " + LONG_MSB_DICT + ", " + LONG_LSB_DICT + ", COUNT(*) FROM " + TABLE_NAME
+            + " GROUP BY " + LONG_MSB_DICT + ", " + LONG_LSB_DICT);
+  }
+
+  // ---- COUNT(DISTINCT) ------------------------------------------------
+
+  @Benchmark
+  public BrokerResponseNative countDistinctStrUuidRaw() {
+    return getBrokerResponse("SELECT COUNT(DISTINCT " + STR_UUID_RAW + ") FROM " + TABLE_NAME);
+  }
+
+  @Benchmark
+  public BrokerResponseNative countDistinctStrUuidDict() {
+    return getBrokerResponse("SELECT COUNT(DISTINCT " + STR_UUID_DICT + ") FROM " + TABLE_NAME);
+  }
+
+  @Benchmark
+  public BrokerResponseNative countDistinctBytesUuidRaw() {
+    return getBrokerResponse("SELECT COUNT(DISTINCT " + BYTES_UUID_RAW + ") FROM " + TABLE_NAME);
+  }
+
+  @Benchmark
+  public BrokerResponseNative countDistinctBytesUuidDict() {
+    return getBrokerResponse("SELECT COUNT(DISTINCT " + BYTES_UUID_DICT + ") FROM " + TABLE_NAME);
+  }
+
+  @Benchmark
+  public BrokerResponseNative countDistinctNativeUuidRaw() {
+    return getBrokerResponse("SELECT COUNT(DISTINCT " + UUID_RAW + ") FROM " + TABLE_NAME);
+  }
+
+  @Benchmark
+  public BrokerResponseNative countDistinctNativeUuidDict() {
+    return getBrokerResponse("SELECT COUNT(DISTINCT " + UUID_DICT + ") FROM " + TABLE_NAME);
+  }
+
+  // ---- Equality filter (full scan) ------------------------------------
+  // For BYTES, the literal is a lowercase hex string (no dashes).
+  // For STRING and UUID, the literal is the RFC 4122 dash-separated string.
+
+  @Benchmark
+  public BrokerResponseNative filterStrUuidRaw() {
+    return getBrokerResponse(
+        "SELECT COUNT(*) FROM " + TABLE_NAME + " WHERE " + STR_UUID_RAW + " = '" + _filterUuidString + "'");
+  }
+
+  @Benchmark
+  public BrokerResponseNative filterStrUuidDict() {
+    return getBrokerResponse(
+        "SELECT COUNT(*) FROM " + TABLE_NAME + " WHERE " + STR_UUID_DICT + " = '" + _filterUuidString + "'");
+  }
+
+  @Benchmark
+  public BrokerResponseNative filterBytesUuidRaw() {
+    return getBrokerResponse(
+        "SELECT COUNT(*) FROM " + TABLE_NAME + " WHERE " + BYTES_UUID_RAW + " = '" + _filterBytesHex + "'");
+  }
+
+  @Benchmark
+  public BrokerResponseNative filterBytesUuidDict() {
+    return getBrokerResponse(
+        "SELECT COUNT(*) FROM " + TABLE_NAME + " WHERE " + BYTES_UUID_DICT + " = '" + _filterBytesHex + "'");
+  }
+
+  @Benchmark
+  public BrokerResponseNative filterNativeUuidRaw() {
+    return getBrokerResponse(
+        "SELECT COUNT(*) FROM " + TABLE_NAME + " WHERE " + UUID_RAW + " = '" + _filterUuidString + "'");
+  }
+
+  @Benchmark
+  public BrokerResponseNative filterNativeUuidDict() {
+    return getBrokerResponse(
+        "SELECT COUNT(*) FROM " + TABLE_NAME + " WHERE " + UUID_DICT + " = '" + _filterUuidString + "'");
+  }
+
+  @Benchmark
+  public BrokerResponseNative filterTwoLongRaw() {
+    return getBrokerResponse(
+        "SELECT COUNT(*) FROM " + TABLE_NAME + " WHERE " + LONG_MSB_RAW + " = " + _filterMsb
+            + " AND " + LONG_LSB_RAW + " = " + _filterLsb);
+  }
+
+  @Benchmark
+  public BrokerResponseNative filterTwoLongDict() {
+    return getBrokerResponse(
+        "SELECT COUNT(*) FROM " + TABLE_NAME + " WHERE " + LONG_MSB_DICT + " = " + _filterMsb
+            + " AND " + LONG_LSB_DICT + " = " + _filterLsb);
+  }
+
+  @Override
+  protected String getFilter() {
+    return null;
+  }
+
+  @Override
+  protected IndexSegment getIndexSegment() {
+    return _indexSegment;
+  }
+
+  @Override
+  protected List<IndexSegment> getIndexSegments() {
+    return _indexSegments;
+  }
+
+  public static void main(String[] args)
+      throws Exception {
+    new Runner(new OptionsBuilder().include(BenchmarkUuidQueryExecution.class.getSimpleName()).build()).run();
+  }
+}

--- a/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroIngestionSchemaValidator.java
+++ b/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroIngestionSchemaValidator.java
@@ -139,7 +139,7 @@ public class AvroIngestionSchemaValidator implements IngestionSchemaValidator {
         if (fieldSpec.getDataType() != dataTypeForSVColumn) {
           _dataTypeMismatch.addMismatchReason(String
               .format("The Pinot column: (%s: %s) doesn't match with the column (%s: %s) in input %s schema.",
-                  columnName, fieldSpec.getDataType().name(), avroColumnName, avroColumnType.name(),
+                  columnName, fieldSpec.getDataType().name(), avroColumnName, dataTypeForSVColumn.name(),
                   getInputSchemaType()));
         }
       } else {

--- a/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroSchemaUtil.java
+++ b/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroSchemaUtil.java
@@ -98,6 +98,17 @@ public class AvroSchemaUtil {
   }
 
   /**
+   * Returns the Pinot data type associated with the given Avro schema, including logical types.
+   */
+  public static DataType valueOf(Schema schema) {
+    LogicalType logicalType = LogicalTypes.fromSchemaIgnoreInvalid(schema);
+    if (logicalType != null && UUID.equals(logicalType.getName()) && schema.getType() == Schema.Type.STRING) {
+      return DataType.UUID;
+    }
+    return valueOf(schema.getType());
+  }
+
+  /**
    * @return if the given avro type is a primitive type.
    */
   public static boolean isPrimitiveType(Schema.Type avroType) {
@@ -118,7 +129,8 @@ public class AvroSchemaUtil {
   public static ObjectNode toAvroSchemaJsonObject(FieldSpec fieldSpec) {
     ObjectNode jsonSchema = JsonUtils.newObjectNode();
     jsonSchema.put("name", fieldSpec.getName());
-    switch (fieldSpec.getDataType().getStoredType()) {
+    DataType dataType = fieldSpec.getDataType();
+    switch (dataType.getStoredType()) {
       case INT:
         jsonSchema.set("type", convertStringsToJsonArray("null", "int"));
         return jsonSchema;
@@ -136,7 +148,14 @@ public class AvroSchemaUtil {
         jsonSchema.set("type", convertStringsToJsonArray("null", "string"));
         return jsonSchema;
       case BYTES:
-        jsonSchema.set("type", convertStringsToJsonArray("null", "bytes"));
+        if (dataType == DataType.UUID) {
+          ObjectNode uuidType = JsonUtils.newObjectNode();
+          uuidType.put("type", "string");
+          uuidType.put("logicalType", UUID);
+          jsonSchema.set("type", convertToJsonArray("null", uuidType));
+        } else {
+          jsonSchema.set("type", convertStringsToJsonArray("null", "bytes"));
+        }
         return jsonSchema;
       default:
         throw new UnsupportedOperationException();
@@ -148,6 +167,13 @@ public class AvroSchemaUtil {
     for (String string : strings) {
       jsonArray.add(string);
     }
+    return jsonArray;
+  }
+
+  private static ArrayNode convertToJsonArray(String string, ObjectNode objectNode) {
+    ArrayNode jsonArray = JsonUtils.newArrayNode();
+    jsonArray.add(string);
+    jsonArray.add(objectNode);
     return jsonArray;
   }
 

--- a/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroUtils.java
+++ b/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroUtils.java
@@ -28,6 +28,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.zip.GZIPInputStream;
 import javax.annotation.Nullable;
 import org.apache.avro.Conversions;
+import org.apache.avro.LogicalTypes;
 import org.apache.avro.Schema.Field;
 import org.apache.avro.SchemaBuilder;
 import org.apache.avro.file.DataFileStream;
@@ -55,10 +56,10 @@ public class AvroUtils {
     GENERIC_DATA.addLogicalTypeConversion(new Conversions.BigDecimalConversion());
     // Decimal with scale and precision. Deserialized as BigDecimal, serialized as bytes.
     GENERIC_DATA.addLogicalTypeConversion(new Conversions.DecimalConversion());
-    // TODO: Other interesting standard conversions we may want to add. First we need to make sure that we support
-    //  the corresponding data types in Pinot (ie can we read UUIDs or Instant?).
     // UUID is deserialized as java.util.UUID, serialized as string.
-    //GENERIC_DATA.addLogicalTypeConversion(new Conversions.UUIDConversion());
+    GENERIC_DATA.addLogicalTypeConversion(new Conversions.UUIDConversion());
+    // TODO: Other interesting standard conversions we may want to add. First we need to make sure that we support
+    //  the corresponding data types in Pinot (ie can we read Instant?).
     // Instant is deserialized as java.time.Instant, serialized as long (epoch millis).
     //GENERIC_DATA.addLogicalTypeConversion(new TimeConversions.TimestampMillisConversion());
   }
@@ -177,6 +178,14 @@ public class AvroUtils {
     SchemaBuilder.FieldAssembler<org.apache.avro.Schema> fieldAssembler = SchemaBuilder.record("record").fields();
 
     for (FieldSpec fieldSpec : pinotSchema.getAllFieldSpecs()) {
+      if (fieldSpec.getDataType() == DataType.UUID) {
+        Preconditions.checkState(fieldSpec.isSingleValueField(),
+            "UUID data type only supports single-value fields: %s", fieldSpec.getName());
+        org.apache.avro.Schema uuidSchema = LogicalTypes.uuid().addToSchema(org.apache.avro.Schema.create(
+            org.apache.avro.Schema.Type.STRING));
+        fieldAssembler = fieldAssembler.name(fieldSpec.getName()).type(uuidSchema).noDefault();
+        continue;
+      }
       DataType storedType = fieldSpec.getDataType().getStoredType();
       if (fieldSpec.isSingleValueField()) {
         switch (storedType) {
@@ -262,11 +271,10 @@ public class AvroUtils {
   public static DataType extractFieldDataType(Field field) {
     try {
       org.apache.avro.Schema fieldSchema = extractSupportedSchema(field.schema());
-      org.apache.avro.Schema.Type fieldType = fieldSchema.getType();
-      if (fieldType == org.apache.avro.Schema.Type.ARRAY) {
-        return AvroSchemaUtil.valueOf(extractSupportedSchema(fieldSchema.getElementType()).getType());
+      if (fieldSchema.getType() == org.apache.avro.Schema.Type.ARRAY) {
+        return AvroSchemaUtil.valueOf(extractSupportedSchema(fieldSchema.getElementType()));
       } else {
-        return AvroSchemaUtil.valueOf(fieldType);
+        return AvroSchemaUtil.valueOf(fieldSchema);
       }
     } catch (Exception e) {
       throw new RuntimeException("Caught exception while extracting data type from field: " + field.name(), e);
@@ -342,15 +350,18 @@ public class AvroUtils {
               timeUnit, collectionNotUnnestedToJson);
         } else if (collectionNotUnnestedToJson == ComplexTypeConfig.CollectionNotUnnestedToJson.NON_PRIMITIVE
             && AvroSchemaUtil.isPrimitiveType(elementType.getType())) {
-          addFieldToPinotSchema(pinotSchema, AvroSchemaUtil.valueOf(elementType.getType()), path, false, fieldTypeMap,
-              timeUnit);
+          DataType elementDataType = AvroSchemaUtil.valueOf(elementType);
+          Preconditions.checkState(elementDataType != DataType.UUID,
+              "Avro ARRAY<uuid> cannot be mapped to Pinot UUID because UUID data type only supports single-value "
+                  + "fields: %s", path);
+          addFieldToPinotSchema(pinotSchema, elementDataType, path, false, fieldTypeMap, timeUnit);
         } else if (shallConvertToJson(collectionNotUnnestedToJson, elementType)) {
           addFieldToPinotSchema(pinotSchema, DataType.STRING, path, true, fieldTypeMap, timeUnit);
         }
         // do not include the node for other cases
         break;
       default:
-        DataType dataType = AvroSchemaUtil.valueOf(fieldType);
+        DataType dataType = AvroSchemaUtil.valueOf(fieldSchema);
         addFieldToPinotSchema(pinotSchema, dataType, path, true, fieldTypeMap, timeUnit);
         break;
     }

--- a/pinot-plugins/pinot-input-format/pinot-avro-base/src/test/java/org/apache/pinot/plugin/inputformat/avro/AvroSchemaUtilTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-avro-base/src/test/java/org/apache/pinot/plugin/inputformat/avro/AvroSchemaUtilTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.plugin.inputformat.avro;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
@@ -38,6 +39,8 @@ import org.apache.avro.generic.GenericDatumReader;
 import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.util.Utf8;
+import org.apache.pinot.spi.data.DimensionFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec;
 import org.joda.time.chrono.ISOChronology;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -144,6 +147,18 @@ public class AvroSchemaUtilTest {
     // Read the Avro file and convert its records to include logical types.
     GenericRecord convertedRecord = readAndConvertRecord(avroFile, schema);
     validateComplexLogicalTypeRecordData(convertedRecord);
+  }
+
+  @Test
+  public void testToAvroSchemaJsonObjectForUuid() {
+    FieldSpec fieldSpec = new DimensionFieldSpec("uuidCol", FieldSpec.DataType.UUID, true);
+
+    JsonNode jsonNode = AvroSchemaUtil.toAvroSchemaJsonObject(fieldSpec);
+
+    Assert.assertEquals(jsonNode.get("name").asText(), "uuidCol");
+    Assert.assertEquals(jsonNode.get("type").get(0).asText(), "null");
+    Assert.assertEquals(jsonNode.get("type").get(1).get("type").asText(), "string");
+    Assert.assertEquals(jsonNode.get("type").get(1).get("logicalType").asText(), "uuid");
   }
 
   private void validateComplexLogicalTypeRecordData(GenericRecord convertedRecord) {

--- a/pinot-plugins/pinot-input-format/pinot-avro-base/src/test/java/org/apache/pinot/plugin/inputformat/avro/AvroUtilsTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-avro-base/src/test/java/org/apache/pinot/plugin/inputformat/avro/AvroUtilsTest.java
@@ -22,15 +22,19 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import org.apache.avro.LogicalTypes;
 import org.apache.pinot.spi.config.table.ingestion.ComplexTypeConfig;
+import org.apache.pinot.spi.data.DimensionFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.FieldSpec.FieldType;
 import org.apache.pinot.spi.data.Schema;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 import org.testng.collections.Lists;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 
 public class AvroUtilsTest {
@@ -130,5 +134,55 @@ public class AvroUtilsTest {
             .addSingleValueDimension("d1", DataType.STRING).addMetric("m1", DataType.INT)
             .addDateTime("hoursSinceEpoch", DataType.LONG, "EPOCH|HOURS", "1:HOURS").build();
     assertEquals(inferredPinotSchema, expectedSchema);
+  }
+
+  @Test
+  public void testGetPinotSchemaFromAvroSchemaWithUuidLogicalType() {
+    org.apache.avro.Schema avroSchema = org.apache.avro.Schema.createRecord("uuidRecord", null, null, false);
+    org.apache.avro.Schema uuidSchema =
+        LogicalTypes.uuid().addToSchema(org.apache.avro.Schema.create(org.apache.avro.Schema.Type.STRING));
+    avroSchema.setFields(Lists.newArrayList(
+        new org.apache.avro.Schema.Field("uuidCol", uuidSchema, null, null)
+    ));
+
+    Schema inferredPinotSchema = AvroUtils.getPinotSchemaFromAvroSchema(avroSchema, null, null);
+
+    Schema expectedSchema =
+        new Schema.SchemaBuilder().addSingleValueDimension("uuidCol", DataType.UUID).build();
+    assertEquals(inferredPinotSchema, expectedSchema);
+  }
+
+  @Test
+  public void testGetAvroSchemaFromPinotSchemaWithUuidLogicalType() {
+    Schema pinotSchema = new Schema.SchemaBuilder().addSingleValueDimension("uuidCol", DataType.UUID).build();
+
+    org.apache.avro.Schema avroSchema = AvroUtils.getAvroSchemaFromPinotSchema(pinotSchema);
+    org.apache.avro.Schema fieldSchema = avroSchema.getField("uuidCol").schema();
+
+    assertEquals(fieldSchema.getType(), org.apache.avro.Schema.Type.STRING);
+    assertEquals(fieldSchema.getLogicalType().getName(), "uuid");
+  }
+
+  @Test
+  public void testGetPinotSchemaFromAvroSchemaRejectsUuidArray() {
+    org.apache.avro.Schema uuidSchema =
+        LogicalTypes.uuid().addToSchema(org.apache.avro.Schema.create(org.apache.avro.Schema.Type.STRING));
+    org.apache.avro.Schema avroSchema = org.apache.avro.SchemaBuilder.record("uuidArrayRecord").fields()
+        .name("uuidArray").type().array().items(uuidSchema).noDefault().endRecord();
+
+    IllegalStateException exception = Assert.expectThrows(IllegalStateException.class,
+        () -> AvroUtils.getPinotSchemaFromAvroSchemaWithComplexTypeHandling(avroSchema, null, null,
+            new ArrayList<>(), ".", ComplexTypeConfig.CollectionNotUnnestedToJson.NON_PRIMITIVE));
+    assertTrue(exception.getMessage().contains("ARRAY<uuid>"));
+  }
+
+  @Test
+  public void testGetAvroSchemaFromPinotSchemaRejectsMvUuid() {
+    Schema pinotSchema = new Schema();
+    pinotSchema.addField(new DimensionFieldSpec("uuidMv", DataType.UUID, false));
+
+    IllegalStateException exception =
+        Assert.expectThrows(IllegalStateException.class, () -> AvroUtils.getAvroSchemaFromPinotSchema(pinotSchema));
+    assertTrue(exception.getMessage().contains("single-value"));
   }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/parser/CalciteRexExpressionParser.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/parser/CalciteRexExpressionParser.java
@@ -31,6 +31,7 @@ import org.apache.pinot.common.utils.request.RequestUtils;
 import org.apache.pinot.query.planner.logical.RexExpression;
 import org.apache.pinot.spi.utils.BooleanUtils;
 import org.apache.pinot.spi.utils.ByteArray;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.apache.pinot.sql.parsers.ParserUtils;
 
 
@@ -124,7 +125,13 @@ public class CalciteRexExpressionParser {
     if (rexNode instanceof RexExpression.InputRef) {
       return inputRefToIdentifier((RexExpression.InputRef) rexNode, selectList);
     } else if (rexNode instanceof RexExpression.Literal) {
-      return RequestUtils.getLiteralExpression(toLiteral((RexExpression.Literal) rexNode));
+      RexExpression.Literal literal = (RexExpression.Literal) rexNode;
+      if (literal.getDataType() == ColumnDataType.UUID) {
+        return RequestUtils.getFunctionExpression("cast",
+            RequestUtils.getLiteralExpression(UuidUtils.toString((ByteArray) literal.getValue())),
+            RequestUtils.getLiteralExpression("UUID"));
+      }
+      return RequestUtils.getLiteralExpression(toLiteral(literal));
     } else {
       assert rexNode instanceof RexExpression.FunctionCall;
       return compileFunctionExpression((RexExpression.FunctionCall) rexNode, selectList);
@@ -146,6 +153,8 @@ public class CalciteRexExpressionParser {
     ColumnDataType dataType = literal.getDataType();
     if (dataType == ColumnDataType.BOOLEAN) {
       value = BooleanUtils.isTrueInternalValue(value);
+    } else if (dataType == ColumnDataType.UUID) {
+      value = UuidUtils.toString((ByteArray) value);
     } else if (dataType == ColumnDataType.BYTES) {
       value = ((ByteArray) value).getBytes();
     }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RelToPlanNodeConverter.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RelToPlanNodeConverter.java
@@ -966,6 +966,11 @@ public final class RelToPlanNodeConverter {
       case CHAR:
       case VARCHAR:
         return isArray ? ColumnDataType.STRING_ARRAY : ColumnDataType.STRING;
+      case UUID:
+        if (isArray) {
+          throw new IllegalArgumentException("UUID arrays are not supported: " + relDataType);
+        }
+        return ColumnDataType.UUID;
       case BINARY:
       case VARBINARY:
         return isArray ? ColumnDataType.BYTES_ARRAY : ColumnDataType.BYTES;

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RexExpressionUtils.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RexExpressionUtils.java
@@ -26,6 +26,7 @@ import java.util.ArrayList;
 import java.util.Calendar;
 import java.util.List;
 import java.util.Set;
+import java.util.UUID;
 import javax.annotation.Nullable;
 import org.apache.calcite.avatica.util.ByteString;
 import org.apache.calcite.plan.RelOptCluster;
@@ -51,6 +52,7 @@ import org.apache.calcite.util.TimestampString;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.spi.utils.BooleanUtils;
 import org.apache.pinot.spi.utils.ByteArray;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -148,6 +150,9 @@ public class RexExpressionUtils {
         ByteString byteString = new ByteString(bytes);
         return rexBuilder.makeBinaryLiteral(byteString);
       }
+      case UUID:
+        assert value != null;
+        return rexBuilder.makeUuidLiteral(UuidUtils.toUUID((ByteArray) value));
       case BOOLEAN_ARRAY:
       case BYTES_ARRAY:
       case DOUBLE_ARRAY:
@@ -272,6 +277,19 @@ public class RexExpressionUtils {
         break;
       case BYTES:
         value = new ByteArray(((ByteString) value).getBytes());
+        break;
+      case UUID:
+        if (value instanceof UUID) {
+          value = new ByteArray(UuidUtils.toBytes((UUID) value));
+        } else if (value instanceof ByteString) {
+          value = new ByteArray(UuidUtils.toBytes(((ByteString) value).getBytes()));
+        } else if (value instanceof NlsString) {
+          value = new ByteArray(UuidUtils.toBytes(((NlsString) value).getValue()));
+        } else if (value instanceof String) {
+          value = new ByteArray(UuidUtils.toBytes((String) value));
+        } else {
+          throw new IllegalStateException("Unsupported value type for UUID: " + value.getClass().getName());
+        }
         break;
       default:
         throw new IllegalStateException("Unsupported ColumnDataType: " + dataType);

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/PRelToPlanNodeConverter.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/v2/PRelToPlanNodeConverter.java
@@ -323,6 +323,11 @@ public class PRelToPlanNodeConverter {
       case CHAR:
       case VARCHAR:
         return isArray ? ColumnDataType.STRING_ARRAY : ColumnDataType.STRING;
+      case UUID:
+        if (isArray) {
+          throw new IllegalArgumentException("UUID arrays are not supported: " + relDataType);
+        }
+        return ColumnDataType.UUID;
       case BINARY:
       case VARBINARY:
         return isArray ? ColumnDataType.BYTES_ARRAY : ColumnDataType.BYTES;

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/serde/ProtoExpressionToRexExpression.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/serde/ProtoExpressionToRexExpression.java
@@ -163,6 +163,8 @@ public class ProtoExpressionToRexExpression {
         return ColumnDataType.JSON;
       case BYTES:
         return ColumnDataType.BYTES;
+      case UUID:
+        return ColumnDataType.UUID;
       case INT_ARRAY:
         return ColumnDataType.INT_ARRAY;
       case LONG_ARRAY:

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/serde/RexExpressionToProtoExpression.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/serde/RexExpressionToProtoExpression.java
@@ -152,6 +152,8 @@ public class RexExpressionToProtoExpression {
         return Expressions.ColumnDataType.JSON;
       case BYTES:
         return Expressions.ColumnDataType.BYTES;
+      case UUID:
+        return Expressions.ColumnDataType.UUID;
       case MAP:
         return Expressions.ColumnDataType.MAP;
       case INT_ARRAY:

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/type/TypeFactory.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/type/TypeFactory.java
@@ -102,6 +102,8 @@ public class TypeFactory extends JavaTypeFactoryImpl {
       case STRING:
       case JSON:
         return SqlTypeName.VARCHAR;
+      case UUID:
+        return SqlTypeName.UUID;
       case BYTES:
         return SqlTypeName.VARBINARY;
       case BIG_DECIMAL:

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/parser/CalciteRexExpressionParserTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/parser/CalciteRexExpressionParserTest.java
@@ -1,0 +1,53 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.parser;
+
+import java.util.List;
+import org.apache.pinot.common.request.Expression;
+import org.apache.pinot.common.request.Function;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+import org.apache.pinot.query.planner.logical.RexExpression;
+import org.apache.pinot.spi.utils.ByteArray;
+import org.apache.pinot.spi.utils.UuidUtils;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+
+
+public class CalciteRexExpressionParserTest {
+  private static final String UUID_VALUE = "550e8400-e29b-41d4-a716-446655440000";
+
+  @Test
+  public void testToExpressionPreservesUuidLiteralAsCast() {
+    RexExpression.Literal uuidLiteral =
+        new RexExpression.Literal(ColumnDataType.UUID, new ByteArray(UuidUtils.toBytes(UUID_VALUE)));
+
+    Expression expression = CalciteRexExpressionParser.toExpression(uuidLiteral, List.of());
+
+    assertNull(expression.getLiteral());
+    Function function = expression.getFunctionCall();
+    assertNotNull(function);
+    assertEquals(function.getOperator(), "cast");
+    assertEquals(function.getOperandsSize(), 2);
+    assertEquals(function.getOperands().get(0).getLiteral().getStringValue(), UUID_VALUE);
+    assertEquals(function.getOperands().get(1).getLiteral().getStringValue(), "UUID");
+  }
+}

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/planner/logical/RelToPlanNodeConverterTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/planner/logical/RelToPlanNodeConverterTest.java
@@ -50,6 +50,7 @@ import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.pinot.calcite.rel.logical.PinotLogicalEnrichedJoin;
 import org.apache.pinot.calcite.rel.rules.PinotEnrichedJoinRule;
 import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.query.planner.physical.v2.PRelToPlanNodeConverter;
 import org.apache.pinot.query.planner.plannode.EnrichedJoinNode;
 import org.apache.pinot.query.planner.plannode.FilterNode;
 import org.apache.pinot.query.planner.plannode.PlanNode;
@@ -126,6 +127,13 @@ public class RelToPlanNodeConverterTest {
   }
 
   @Test
+  public void testConvertToColumnDataTypeForUUID() {
+    RelDataType uuidType = new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.UUID);
+    Assert.assertEquals(RelToPlanNodeConverter.convertToColumnDataType(uuidType), DataSchema.ColumnDataType.UUID);
+    Assert.assertEquals(PRelToPlanNodeConverter.convertToColumnDataType(uuidType), DataSchema.ColumnDataType.UUID);
+  }
+
+  @Test
   public void testConvertToColumnDataTypeForArray() {
     Assert.assertEquals(RelToPlanNodeConverter.convertToColumnDataType(
             new ArraySqlType(new ObjectSqlType(SqlTypeName.BOOLEAN, SqlIdentifier.STAR, true, null, null), true)),
@@ -160,6 +168,20 @@ public class RelToPlanNodeConverterTest {
     Assert.assertEquals(RelToPlanNodeConverter.convertToColumnDataType(
             new ArraySqlType(new ObjectSqlType(SqlTypeName.VARBINARY, SqlIdentifier.STAR, true, null, null), true)),
         DataSchema.ColumnDataType.BYTES_ARRAY);
+  }
+
+  @Test
+  public void testConvertToColumnDataTypeForUUIDArrayRejected() {
+    RelDataType uuidArrayType =
+        new ArraySqlType(new BasicSqlType(RelDataTypeSystem.DEFAULT, SqlTypeName.UUID), true);
+
+    IllegalArgumentException logicalException = Assert.expectThrows(IllegalArgumentException.class,
+        () -> RelToPlanNodeConverter.convertToColumnDataType(uuidArrayType));
+    Assert.assertTrue(logicalException.getMessage().contains("UUID arrays are not supported"));
+
+    IllegalArgumentException physicalException = Assert.expectThrows(IllegalArgumentException.class,
+        () -> PRelToPlanNodeConverter.convertToColumnDataType(uuidArrayType));
+    Assert.assertTrue(physicalException.getMessage().contains("UUID arrays are not supported"));
   }
 
   @Test

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/planner/serde/RexExpressionSerDeTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/planner/serde/RexExpressionSerDeTest.java
@@ -26,6 +26,7 @@ import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.query.planner.logical.RexExpression;
 import org.apache.pinot.spi.utils.BooleanUtils;
 import org.apache.pinot.spi.utils.ByteArray;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
@@ -35,10 +36,12 @@ public class RexExpressionSerDeTest {
   private static final List<ColumnDataType> SUPPORTED_DATE_TYPES =
       List.of(ColumnDataType.INT, ColumnDataType.LONG, ColumnDataType.FLOAT, ColumnDataType.DOUBLE,
           ColumnDataType.BIG_DECIMAL, ColumnDataType.BOOLEAN, ColumnDataType.TIMESTAMP, ColumnDataType.STRING,
-          ColumnDataType.BYTES, ColumnDataType.INT_ARRAY, ColumnDataType.LONG_ARRAY, ColumnDataType.FLOAT_ARRAY,
+          ColumnDataType.UUID, ColumnDataType.BYTES, ColumnDataType.INT_ARRAY, ColumnDataType.LONG_ARRAY,
+          ColumnDataType.FLOAT_ARRAY,
           ColumnDataType.DOUBLE_ARRAY, ColumnDataType.BOOLEAN_ARRAY, ColumnDataType.TIMESTAMP_ARRAY,
           ColumnDataType.STRING_ARRAY, ColumnDataType.UNKNOWN);
   private static final Random RANDOM = new Random();
+  private static final String UUID_VALUE = "550e8400-e29b-41d4-a716-446655440000";
 
   @Test
   public void testNullLiteral() {
@@ -93,6 +96,11 @@ public class RexExpressionSerDeTest {
     byte[] bytes = new byte[RANDOM.nextInt(10)];
     RANDOM.nextBytes(bytes);
     verifyLiteralSerDe(new RexExpression.Literal(ColumnDataType.BYTES, new ByteArray(bytes)));
+  }
+
+  @Test
+  public void testUuidLiteral() {
+    verifyLiteralSerDe(new RexExpression.Literal(ColumnDataType.UUID, new ByteArray(UuidUtils.toBytes(UUID_VALUE))));
   }
 
   @Test

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/type/TypeFactoryTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/type/TypeFactoryTest.java
@@ -77,6 +77,10 @@ public class TypeFactoryTest {
           basicType = TYPE_FACTORY.createSqlType(SqlTypeName.VARCHAR);
           break;
         }
+        case UUID: {
+          basicType = TYPE_FACTORY.createSqlType(SqlTypeName.UUID);
+          break;
+        }
         case BYTES: {
           basicType = TYPE_FACTORY.createSqlType(SqlTypeName.VARBINARY);
           break;
@@ -152,6 +156,9 @@ public class TypeFactoryTest {
 
   @Test(dataProvider = "relDataTypeConversion")
   public void testArrayTypes(FieldSpec.DataType dataType, RelDataType arrayType, boolean columnNullMode) {
+    if (dataType == FieldSpec.DataType.UUID) {
+      return;
+    }
     TypeFactory typeFactory = new TypeFactory();
     Schema testSchema = new Schema.SchemaBuilder()
         .addMultiValueDimension("col", dataType)
@@ -170,6 +177,9 @@ public class TypeFactoryTest {
 
   @Test(dataProvider = "relDataTypeConversion")
   public void testNullableArrayTypes(FieldSpec.DataType dataType, RelDataType arrayType, boolean columnNullMode) {
+    if (dataType == FieldSpec.DataType.UUID) {
+      return;
+    }
     TypeFactory typeFactory = new TypeFactory();
     Schema testSchema = new Schema.SchemaBuilder()
         .addDimensionField("col", dataType, field -> {
@@ -191,6 +201,9 @@ public class TypeFactoryTest {
 
   @Test(dataProvider = "relDataTypeConversion")
   public void testNotNullableArrayTypes(FieldSpec.DataType dataType, RelDataType arrayType, boolean columnNullMode) {
+    if (dataType == FieldSpec.DataType.UUID) {
+      return;
+    }
     TypeFactory typeFactory = new TypeFactory();
     Schema testSchema = new Schema.SchemaBuilder()
         .addDimensionField("col", dataType, field -> {
@@ -216,6 +229,7 @@ public class TypeFactoryTest {
         .addSingleValueDimension("FLOAT_COL", FieldSpec.DataType.FLOAT)
         .addSingleValueDimension("DOUBLE_COL", FieldSpec.DataType.DOUBLE)
         .addSingleValueDimension("STRING_COL", FieldSpec.DataType.STRING)
+        .addSingleValueDimension("UUID_COL", FieldSpec.DataType.UUID)
         .addSingleValueDimension("BYTES_COL", FieldSpec.DataType.BYTES)
         .addSingleValueDimension("JSON_COL", FieldSpec.DataType.JSON)
         .addMultiValueDimension("INT_ARRAY_COL", FieldSpec.DataType.INT)
@@ -254,6 +268,9 @@ public class TypeFactoryTest {
           Assert.assertEquals(field.getType(),
               TYPE_FACTORY.createTypeWithCharsetAndCollation(new BasicSqlType(TypeSystem.INSTANCE, SqlTypeName.VARCHAR),
                   StandardCharsets.UTF_8, SqlCollation.IMPLICIT));
+          break;
+        case "UUID_COL":
+          Assert.assertEquals(field.getType(), new BasicSqlType(TypeSystem.INSTANCE, SqlTypeName.UUID));
           break;
         case "BYTES_COL":
           Assert.assertEquals(field.getType(), new BasicSqlType(TypeSystem.INSTANCE, SqlTypeName.VARBINARY));

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/function/BytesToUuidUdf.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/function/BytesToUuidUdf.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.function;
+
+import com.google.auto.service.AutoService;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import org.apache.pinot.common.function.scalar.uuid.UuidConversionFunctions;
+import org.apache.pinot.core.udf.Udf;
+import org.apache.pinot.core.udf.UdfExample;
+import org.apache.pinot.core.udf.UdfSignature;
+
+
+@AutoService(Udf.class)
+public class BytesToUuidUdf extends Udf.FromAnnotatedMethod {
+  public BytesToUuidUdf()
+      throws NoSuchMethodException {
+    super(UuidConversionFunctions.class.getMethod("bytesToUuid", byte[].class));
+  }
+
+  @Override
+  public String getDescription() {
+    return "Converts a 16-byte BYTES value into a canonical lowercase UUID string rendered as Pinot UUID.";
+  }
+
+  @Override
+  public Map<UdfSignature, Set<UdfExample>> getExamples() {
+    return Collections.emptyMap();
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/function/IsUuidUdf.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/function/IsUuidUdf.java
@@ -1,0 +1,60 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.function;
+
+import com.google.auto.service.AutoService;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import org.apache.pinot.common.function.PinotScalarFunction;
+import org.apache.pinot.common.function.scalar.uuid.IsUuidScalarFunction;
+import org.apache.pinot.core.udf.Udf;
+import org.apache.pinot.core.udf.UdfExample;
+import org.apache.pinot.core.udf.UdfSignature;
+
+
+@AutoService(Udf.class)
+public class IsUuidUdf extends Udf {
+  private static final IsUuidScalarFunction SCALAR_FUNCTION = new IsUuidScalarFunction();
+
+  @Override
+  public String getMainName() {
+    return SCALAR_FUNCTION.getName();
+  }
+
+  @Override
+  public Set<String> getAllNames() {
+    return SCALAR_FUNCTION.getNames();
+  }
+
+  @Override
+  public String getDescription() {
+    return "Returns true when the input is a valid RFC 4122 UUID string or a 16-byte BYTES value.";
+  }
+
+  @Override
+  public Map<UdfSignature, Set<UdfExample>> getExamples() {
+    return Collections.emptyMap();
+  }
+
+  @Override
+  public PinotScalarFunction getScalarFunction() {
+    return SCALAR_FUNCTION;
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/function/ToUuidUdf.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/function/ToUuidUdf.java
@@ -1,0 +1,60 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.function;
+
+import com.google.auto.service.AutoService;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import org.apache.pinot.common.function.PinotScalarFunction;
+import org.apache.pinot.common.function.scalar.uuid.ToUuidScalarFunction;
+import org.apache.pinot.core.udf.Udf;
+import org.apache.pinot.core.udf.UdfExample;
+import org.apache.pinot.core.udf.UdfSignature;
+
+
+@AutoService(Udf.class)
+public class ToUuidUdf extends Udf {
+  private static final ToUuidScalarFunction SCALAR_FUNCTION = new ToUuidScalarFunction();
+
+  @Override
+  public String getMainName() {
+    return SCALAR_FUNCTION.getName();
+  }
+
+  @Override
+  public Set<String> getAllNames() {
+    return SCALAR_FUNCTION.getNames();
+  }
+
+  @Override
+  public String getDescription() {
+    return "Converts a canonical UUID string or a 16-byte BYTES value into Pinot's logical UUID type.";
+  }
+
+  @Override
+  public Map<UdfSignature, Set<UdfExample>> getExamples() {
+    return Collections.emptyMap();
+  }
+
+  @Override
+  public PinotScalarFunction getScalarFunction() {
+    return SCALAR_FUNCTION;
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/function/UuidToBytesUdf.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/function/UuidToBytesUdf.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.function;
+
+import com.google.auto.service.AutoService;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import org.apache.pinot.common.function.scalar.uuid.UuidConversionFunctions;
+import org.apache.pinot.core.udf.Udf;
+import org.apache.pinot.core.udf.UdfExample;
+import org.apache.pinot.core.udf.UdfSignature;
+
+
+@AutoService(Udf.class)
+public class UuidToBytesUdf extends Udf.FromAnnotatedMethod {
+  public UuidToBytesUdf()
+      throws NoSuchMethodException {
+    super(UuidConversionFunctions.class.getMethod("uuidToBytes", java.util.UUID.class));
+  }
+
+  @Override
+  public String getDescription() {
+    return "Converts a UUID value to its canonical 16-byte representation.";
+  }
+
+  @Override
+  public Map<UdfSignature, Set<UdfExample>> getExamples() {
+    return Collections.emptyMap();
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/function/UuidToStringUdf.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/function/UuidToStringUdf.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.function;
+
+import com.google.auto.service.AutoService;
+import java.util.Collections;
+import java.util.Map;
+import java.util.Set;
+import org.apache.pinot.common.function.scalar.uuid.UuidConversionFunctions;
+import org.apache.pinot.core.udf.Udf;
+import org.apache.pinot.core.udf.UdfExample;
+import org.apache.pinot.core.udf.UdfSignature;
+
+
+@AutoService(Udf.class)
+public class UuidToStringUdf extends Udf.FromAnnotatedMethod {
+  public UuidToStringUdf()
+      throws NoSuchMethodException {
+    super(UuidConversionFunctions.class.getMethod("uuidToString", java.util.UUID.class));
+  }
+
+  @Override
+  public String getDescription() {
+    return "Converts a UUID value to its canonical lowercase RFC 4122 string representation.";
+  }
+
+  @Override
+  public Map<UdfSignature, Set<UdfExample>> getExamples() {
+    return Collections.emptyMap();
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.calcite.rel.core.JoinRelType;
 import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.data.table.Key;
 import org.apache.pinot.query.planner.partitioning.KeySelector;
 import org.apache.pinot.query.planner.partitioning.KeySelectorFactory;
@@ -38,6 +39,7 @@ import org.apache.pinot.query.runtime.operator.join.IntLookupTable;
 import org.apache.pinot.query.runtime.operator.join.LongLookupTable;
 import org.apache.pinot.query.runtime.operator.join.LookupTable;
 import org.apache.pinot.query.runtime.operator.join.ObjectLookupTable;
+import org.apache.pinot.query.runtime.operator.join.UuidLookupTable;
 import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
 
 
@@ -97,7 +99,11 @@ public class HashJoinOperator extends BaseJoinOperator {
     if (joinKeys.size() > 1) {
       return new ObjectLookupTable();
     }
-    switch (schema.getColumnDataType(joinKeys.get(0)).getStoredType()) {
+    ColumnDataType columnDataType = schema.getColumnDataType(joinKeys.get(0));
+    if (columnDataType == ColumnDataType.UUID) {
+      return new UuidLookupTable();
+    }
+    switch (columnDataType.getStoredType()) {
       case INT:
         return new IntLookupTable();
       case LONG:
@@ -207,7 +213,8 @@ public class HashJoinOperator extends BaseJoinOperator {
       if (handleNullKey(key, leftRow, rows)) {
         continue;
       }
-      Object[] rightRow = (Object[]) _rightTable.lookup(key);
+      Object normalizedKey = _rightTable.normalizeKey(key);
+      Object[] rightRow = (Object[]) _rightTable.lookup(normalizedKey);
       if (rightRow == null) {
         handleUnmatchedLeftRow(leftRow, rows);
       } else {
@@ -220,7 +227,7 @@ public class HashJoinOperator extends BaseJoinOperator {
           checkTerminationAndSampleUsagePeriodically(rows.size(), BUILD_JOINED_ROWS_SCOPE);
           rows.add(resultRowView.toArray());
           if (_matchedRightRows != null) {
-            _matchedRightRows.put(key, BIT_SET_PLACEHOLDER);
+            _matchedRightRows.put(normalizedKey, BIT_SET_PLACEHOLDER);
           }
         } else {
           handleUnmatchedLeftRow(leftRow, rows);
@@ -242,7 +249,8 @@ public class HashJoinOperator extends BaseJoinOperator {
       if (handleNullKey(key, leftRow, rows)) {
         continue;
       }
-      List<Object[]> rightRows = (List<Object[]>) _rightTable.lookup(key);
+      Object normalizedKey = _rightTable.normalizeKey(key);
+      List<Object[]> rightRows = (List<Object[]>) _rightTable.lookup(normalizedKey);
       if (rightRows == null) {
         handleUnmatchedLeftRow(leftRow, rows);
       } else {
@@ -260,7 +268,7 @@ public class HashJoinOperator extends BaseJoinOperator {
             rows.add(resultRowView.toArray());
             hasMatchForLeftRow = true;
             if (_matchedRightRows != null) {
-              _matchedRightRows.computeIfAbsent(key, k -> new BitSet(numRightRows)).set(i);
+              _matchedRightRows.computeIfAbsent(normalizedKey, k -> new BitSet(numRightRows)).set(i);
             }
           }
         }
@@ -293,7 +301,7 @@ public class HashJoinOperator extends BaseJoinOperator {
 
     for (Object[] leftRow : leftRows) {
       Object key = _leftKeySelector.getKey(leftRow);
-      if (_rightTable.containsKey(key)) {
+      if (_rightTable.containsKey(_rightTable.normalizeKey(key))) {
         checkTerminationAndSampleUsagePeriodically(rows.size(), BUILD_JOINED_ROWS_SCOPE);
         rows.add(leftRow);
       }
@@ -309,7 +317,7 @@ public class HashJoinOperator extends BaseJoinOperator {
 
     for (Object[] leftRow : leftRows) {
       Object key = _leftKeySelector.getKey(leftRow);
-      if (!_rightTable.containsKey(key)) {
+      if (!_rightTable.containsKey(_rightTable.normalizeKey(key))) {
         checkTerminationAndSampleUsagePeriodically(rows.size(), BUILD_JOINED_ROWS_SCOPE);
         rows.add(leftRow);
       }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/groupby/GroupIdGeneratorFactory.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/groupby/GroupIdGeneratorFactory.java
@@ -38,6 +38,8 @@ public class GroupIdGeneratorFactory {
           return new OneFloatKeyGroupIdGenerator(numGroupsLimit, initialCapacity);
         case DOUBLE:
           return new OneDoubleKeyGroupIdGenerator(numGroupsLimit, initialCapacity);
+        case UUID:
+          return new OneUuidKeyGroupIdGenerator(numGroupsLimit, initialCapacity);
         default:
           return new OneObjectKeyGroupIdGenerator(numGroupsLimit, initialCapacity);
       }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/groupby/OneUuidKeyGroupIdGenerator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/groupby/OneUuidKeyGroupIdGenerator.java
@@ -1,0 +1,77 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.operator.groupby;
+
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+import it.unimi.dsi.fastutil.objects.ObjectIterator;
+import java.util.Iterator;
+import java.util.function.ToIntFunction;
+import org.apache.pinot.spi.utils.UuidUtils.UuidKey;
+
+
+public class OneUuidKeyGroupIdGenerator implements GroupIdGenerator {
+  private final Object2IntOpenHashMap<Object> _groupIdMap;
+  private final int _numGroupsLimit;
+  private final ToIntFunction<Object> _groupIdGenerator;
+
+  public OneUuidKeyGroupIdGenerator(int numGroupsLimit, int initialCapacity) {
+    _groupIdMap = new Object2IntOpenHashMap<>(initialCapacity);
+    _groupIdMap.defaultReturnValue(INVALID_ID);
+    _numGroupsLimit = numGroupsLimit;
+    _groupIdGenerator = ignored -> _groupIdMap.size();
+  }
+
+  @Override
+  public int getGroupId(Object key) {
+    Object normalizedKey = key != null ? UuidKey.fromObject(key) : null;
+    if (_groupIdMap.size() < _numGroupsLimit) {
+      return _groupIdMap.computeIfAbsent(normalizedKey, _groupIdGenerator);
+    } else {
+      return _groupIdMap.getInt(normalizedKey);
+    }
+  }
+
+  @Override
+  public int getNumGroups() {
+    return _groupIdMap.size();
+  }
+
+  @Override
+  public Iterator<GroupKey> getGroupKeyIterator(int numColumns) {
+    return new Iterator<GroupKey>() {
+      final ObjectIterator<Object2IntOpenHashMap.Entry<Object>> _entryIterator =
+          _groupIdMap.object2IntEntrySet().fastIterator();
+
+      @Override
+      public boolean hasNext() {
+        return _entryIterator.hasNext();
+      }
+
+      @Override
+      public GroupKey next() {
+        Object2IntMap.Entry<Object> entry = _entryIterator.next();
+        Object[] row = new Object[numColumns];
+        Object key = entry.getKey();
+        row[0] = key != null ? ((UuidKey) key).toByteArray() : null;
+        return new GroupKey(entry.getIntValue(), row);
+      }
+    };
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/LookupTable.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/LookupTable.java
@@ -61,6 +61,14 @@ public abstract class LookupTable {
    */
   public abstract void finish();
 
+  /**
+   * Normalizes a join key into the internal lookup-table key shape.
+   */
+  @Nullable
+  public Object normalizeKey(@Nullable Object key) {
+    return key;
+  }
+
   protected static void convertValueToList(Map.Entry<?, Object> entry) {
     Object value = entry.getValue();
     if (value instanceof Object[]) {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/UuidLookupTable.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/join/UuidLookupTable.java
@@ -1,0 +1,82 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.operator.join;
+
+import com.google.common.collect.Maps;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.apache.pinot.spi.utils.UuidUtils.UuidKey;
+
+
+/**
+ * Lookup table optimized for Pinot's logical UUID type.
+ */
+@SuppressWarnings("unchecked")
+public class UuidLookupTable extends LookupTable {
+  private final Map<Object, Object> _lookupTable = Maps.newHashMapWithExpectedSize(INITIAL_CAPACITY);
+
+  @Override
+  public void addRow(@Nullable Object key, Object[] row) {
+    Object normalizedKey = normalizeKey(key);
+    if (normalizedKey == null) {
+      return;
+    }
+    _lookupTable.compute(normalizedKey, (k, v) -> computeNewValue(row, v));
+  }
+
+  @Override
+  public void finish() {
+    if (!_keysUnique) {
+      for (Map.Entry<Object, Object> entry : _lookupTable.entrySet()) {
+        convertValueToList(entry);
+      }
+    }
+  }
+
+  @Nullable
+  @Override
+  public Object normalizeKey(@Nullable Object key) {
+    return key != null ? UuidKey.fromObject(key) : null;
+  }
+
+  @Override
+  public boolean containsKey(@Nullable Object key) {
+    Object normalizedKey = normalizeKey(key);
+    return normalizedKey != null && _lookupTable.containsKey(normalizedKey);
+  }
+
+  @Nullable
+  @Override
+  public Object lookup(@Nullable Object key) {
+    Object normalizedKey = normalizeKey(key);
+    return normalizedKey != null ? _lookupTable.get(normalizedKey) : null;
+  }
+
+  @SuppressWarnings("rawtypes")
+  @Override
+  public Set<Map.Entry<Object, Object>> entrySet() {
+    return _lookupTable.entrySet();
+  }
+
+  @Override
+  public int size() {
+    return _lookupTable.size();
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestUtils.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestUtils.java
@@ -60,6 +60,7 @@ import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.utils.ByteArray;
 import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.sql.FilterKind;
 import org.apache.pinot.sql.parsers.rewriter.NonAggregationGroupByToDistinctQueryRewriter;
@@ -412,7 +413,11 @@ public class ServerPlanRequestUtils {
         }
         Arrays.sort(arrBytes);
         for (int rowIdx = 0; rowIdx < numRows; rowIdx++) {
-          expressions.add(RequestUtils.getLiteralExpression(arrBytes[rowIdx].getBytes()));
+          if (columnDataType == DataSchema.ColumnDataType.UUID) {
+            expressions.add(RequestUtils.getLiteralExpression(UuidUtils.toString(arrBytes[rowIdx])));
+          } else {
+            expressions.add(RequestUtils.getLiteralExpression(arrBytes[rowIdx].getBytes()));
+          }
         }
         break;
       default:

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/HashJoinOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/HashJoinOperatorTest.java
@@ -32,6 +32,8 @@ import org.apache.pinot.query.routing.VirtualServerAddress;
 import org.apache.pinot.query.runtime.blocks.ErrorMseBlock;
 import org.apache.pinot.query.runtime.blocks.MseBlock;
 import org.apache.pinot.spi.exception.QueryErrorCode;
+import org.apache.pinot.spi.utils.ByteArray;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.testng.annotations.AfterMethod;
@@ -47,6 +49,9 @@ import static org.testng.internal.junit.ArrayAsserts.assertArrayEquals;
 
 
 public class HashJoinOperatorTest {
+  private static final ByteArray UUID_A = uuid("550e8400-e29b-41d4-a716-446655440000");
+  private static final ByteArray UUID_B = uuid("550e8400-e29b-41d4-a716-446655440001");
+  private static final ByteArray UUID_C = uuid("550e8400-e29b-41d4-a716-446655440002");
   private AutoCloseable _mocks;
   private MultiStageOperator _leftInput;
   private MultiStageOperator _rightInput;
@@ -55,6 +60,8 @@ public class HashJoinOperatorTest {
 
   private static final DataSchema DEFAULT_CHILD_SCHEMA = new DataSchema(new String[]{"int_col", "string_col"},
       new ColumnDataType[] {ColumnDataType.INT, ColumnDataType.STRING});
+  private static final DataSchema UUID_CHILD_SCHEMA = new DataSchema(new String[]{"uuid_col", "int_col"},
+      new ColumnDataType[] {ColumnDataType.UUID, ColumnDataType.INT});
   @BeforeMethod
   public void setUp() {
     _mocks = openMocks(this);
@@ -112,6 +119,34 @@ public class HashJoinOperatorTest {
         OperatorTestUtil.getStatMap(HashJoinOperator.StatKey.class, operator.calculateStats());
     assertEquals(statMap.getLong(HashJoinOperator.StatKey.MAX_ROWS_IN_JOIN), 3,
         "Max rows in join should equal right table size");
+  }
+
+  @Test
+  public void shouldHandleRightJoinOnUuid() {
+    _leftInput = new BlockListMultiStageOperator.Builder(UUID_CHILD_SCHEMA)
+        .addRow(UUID_A, 1)
+        .addRow(UUID_B, 2)
+        .buildWithEos();
+    _rightInput = new BlockListMultiStageOperator.Builder(UUID_CHILD_SCHEMA)
+        .addRow(UUID_B, 20)
+        .addRow(UUID_B, 21)
+        .addRow(UUID_C, 30)
+        .buildWithEos();
+    DataSchema resultSchema = new DataSchema(new String[]{"uuid_col1", "int_col1", "uuid_col2", "int_col2"},
+        new ColumnDataType[]{ColumnDataType.UUID, ColumnDataType.INT, ColumnDataType.UUID, ColumnDataType.INT});
+
+    HashJoinOperator operator = getOperator(UUID_CHILD_SCHEMA, resultSchema, JoinRelType.RIGHT, List.of(0), List.of(0),
+        List.of(), PlanNode.NodeHint.EMPTY);
+
+    List<Object[]> resultRows1 = ((MseBlock.Data) operator.nextBlock()).asRowHeap().getRows();
+    assertEquals(resultRows1.size(), 2);
+    assertTrue(containsRow(resultRows1, new Object[]{UUID_B, 2, UUID_B, 20}));
+    assertTrue(containsRow(resultRows1, new Object[]{UUID_B, 2, UUID_B, 21}));
+
+    List<Object[]> resultRows2 = ((MseBlock.Data) operator.nextBlock()).asRowHeap().getRows();
+    assertEquals(resultRows2.size(), 1);
+    assertTrue(containsRow(resultRows2, new Object[]{null, null, UUID_C, 30}));
+    assertTrue(operator.nextBlock().isSuccess());
   }
 
   @Test
@@ -568,6 +603,10 @@ public class HashJoinOperatorTest {
       }
     }
     return false;
+  }
+
+  private static ByteArray uuid(String value) {
+    return new ByteArray(UuidUtils.toBytes(value));
   }
 
 

--- a/pinot-segment-local/pom.xml
+++ b/pinot-segment-local/pom.xml
@@ -111,6 +111,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-avro-base</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-csv</artifactId>
       <scope>test</scope>
     </dependency>

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
@@ -122,6 +122,7 @@ import org.apache.pinot.spi.utils.BooleanUtils;
 import org.apache.pinot.spi.utils.ByteArray;
 import org.apache.pinot.spi.utils.FixedIntArray;
 import org.apache.pinot.spi.utils.MapUtils;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.roaringbitmap.BatchIterator;
 import org.roaringbitmap.buffer.MutableRoaringBitmap;
@@ -588,7 +589,7 @@ public class MutableSegmentImpl implements MutableSegment {
     // So to continue aggregating metrics for such cases, we will create dictionary even
     // if the column is part of noDictionary set from table config
     if (fieldSpec instanceof DimensionFieldSpec && isAggregateMetricsEnabled() && (dataType == STRING
-        || dataType == BYTES)) {
+        || dataType.getStoredType() == BYTES)) {
       _logger.info("Aggregate metrics is enabled. Will create dictionary in consuming segment for column {} of type {}",
           column, dataType);
       return false;
@@ -769,7 +770,7 @@ public class MutableSegmentImpl implements MutableSegment {
   }
 
   private DedupRecordInfo getDedupRecordInfo(GenericRow row) {
-    PrimaryKey primaryKey = row.getPrimaryKey(_schema.getPrimaryKeyColumns());
+    PrimaryKey primaryKey = getPrimaryKey(row);
     // it is okay not having dedup time column if metadata ttl is not enabled
     if (_dedupTimeColumn == null) {
       return new DedupRecordInfo(primaryKey);
@@ -779,16 +780,37 @@ public class MutableSegmentImpl implements MutableSegment {
   }
 
   private RecordInfo getRecordInfo(GenericRow row, int docId) {
-    PrimaryKey primaryKey = row.getPrimaryKey(_schema.getPrimaryKeyColumns());
+    PrimaryKey primaryKey = getPrimaryKey(row);
     Comparable comparisonValue = getComparisonValue(row);
     boolean deleteRecord = _deleteRecordColumn != null && BooleanUtils.toBoolean(row.getValue(_deleteRecordColumn));
     return new RecordInfo(primaryKey, docId, comparisonValue, deleteRecord);
   }
 
+  private PrimaryKey getPrimaryKey(GenericRow row) {
+    List<String> primaryKeyColumns = _schema.getPrimaryKeyColumns();
+    int numPrimaryKeyColumns = primaryKeyColumns.size();
+    Object[] values = new Object[numPrimaryKeyColumns];
+    for (int i = 0; i < numPrimaryKeyColumns; i++) {
+      String primaryKeyColumn = primaryKeyColumns.get(i);
+      Object value = row.getValue(primaryKeyColumn);
+      DataType dataType = _schema.getFieldSpecFor(primaryKeyColumn).getDataType();
+      values[i] = normalizePrimaryKeyValue(value, dataType);
+    }
+    return new PrimaryKey(values);
+  }
+
+  private Object normalizePrimaryKeyValue(@Nullable Object value, DataType dataType) {
+    if (dataType == DataType.UUID) {
+      return new ByteArray(UuidUtils.toBytes(value));
+    }
+    return value instanceof byte[] ? new ByteArray((byte[]) value) : value;
+  }
+
   private Comparable getComparisonValue(GenericRow row) {
     int numComparisonColumns = _upsertComparisonColumns.size();
     if (numComparisonColumns == 1) {
-      return (Comparable) row.getValue(_upsertComparisonColumns.get(0));
+      String comparisonColumn = _upsertComparisonColumns.get(0);
+      return toComparableValue(row.getValue(comparisonColumn), _schema.getFieldSpecFor(comparisonColumn).getDataType());
     }
 
     Comparable[] comparisonValues = new Comparable[numComparisonColumns];
@@ -807,9 +829,8 @@ public class MutableSegmentImpl implements MutableSegment {
         comparableIndex = i;
 
         Object comparisonValue = row.getValue(columnName);
-        Preconditions.checkState(comparisonValue instanceof Comparable,
-            "Upsert comparison column: %s must be comparable", columnName);
-        comparisonValues[i] = (Comparable) comparisonValue;
+        comparisonValues[i] =
+            toComparableValue(comparisonValue, _schema.getFieldSpecFor(columnName).getDataType(), columnName);
       }
     }
     Preconditions.checkState(comparableIndex != -1, "Documents must have exactly 1 non-null comparison column value");
@@ -956,14 +977,7 @@ public class MutableSegmentImpl implements MutableSegment {
           // Update min/max value from raw value
           // NOTE: Skip updating min/max value for aggregated metrics because the value will change over time.
           if (!isAggregateMetricsEnabled() || fieldSpec.getFieldType() != FieldSpec.FieldType.METRIC) {
-            Comparable comparable;
-            if (dataType == BYTES) {
-              comparable = new ByteArray((byte[]) value);
-            } else if (dataType == MAP) {
-              comparable = new ByteArray(MapUtils.serializeMap((Map) value));
-            } else {
-              comparable = (Comparable) value;
-            }
+            Comparable comparable = toComparableValue(value, dataType, column);
             if (indexContainer._minValue == null) {
               indexContainer._minValue = comparable;
               indexContainer._maxValue = comparable;
@@ -1014,6 +1028,21 @@ public class MutableSegmentImpl implements MutableSegment {
       _multiColumnTextIndex.add(_multiColumnValues);
       Collections.fill(_multiColumnValues, null);
     }
+  }
+
+  private Comparable toComparableValue(Object value, DataType dataType) {
+    return toComparableValue(value, dataType, null);
+  }
+
+  private Comparable toComparableValue(Object value, DataType dataType, @Nullable String columnName) {
+    if (dataType == MAP) {
+      return new ByteArray(MapUtils.serializeMap((Map) value));
+    }
+    if (dataType.getStoredType() == BYTES) {
+      return new ByteArray((byte[]) value);
+    }
+    Preconditions.checkState(value instanceof Comparable, "Column: %s must be comparable", columnName);
+    return (Comparable) value;
   }
 
   private void updateIndexCapacityThresholdBreached(MutableIndex mutableIndex, IndexType indexType, String column) {
@@ -1430,7 +1459,8 @@ public class MutableSegmentImpl implements MutableSegment {
       docIds[i] = i;
     }
 
-    DataType storedType = indexContainer._fieldSpec.getDataType().getStoredType();
+    DataType dataType = indexContainer._fieldSpec.getDataType();
+    DataType storedType = dataType.getStoredType();
     switch (storedType) {
       case INT:
         IntArrays.quickSort(docIds, (d1, d2) -> Integer.compare(forwardIndex.getInt(d1), forwardIndex.getInt(d2)));
@@ -1452,8 +1482,13 @@ public class MutableSegmentImpl implements MutableSegment {
         IntArrays.quickSort(docIds, (d1, d2) -> forwardIndex.getString(d1).compareTo(forwardIndex.getString(d2)));
         break;
       case BYTES:
-        IntArrays.quickSort(docIds,
-            (d1, d2) -> ByteArray.compare(forwardIndex.getBytes(d1), forwardIndex.getBytes(d2)));
+        if (dataType == DataType.UUID) {
+          IntArrays.quickSort(docIds,
+              (d1, d2) -> UuidUtils.compare(forwardIndex.getBytes(d1), forwardIndex.getBytes(d2)));
+        } else {
+          IntArrays.quickSort(docIds,
+              (d1, d2) -> ByteArray.compare(forwardIndex.getBytes(d1), forwardIndex.getBytes(d2)));
+        }
         break;
       default:
         throw new UnsupportedOperationException(

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/converter/stats/MutableNoDictColumnStatistics.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/converter/stats/MutableNoDictColumnStatistics.java
@@ -33,6 +33,7 @@ import org.apache.pinot.segment.spi.partition.PartitionFunction;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.ByteArray;
+import org.apache.pinot.spi.utils.UuidUtils;
 
 import static org.apache.pinot.segment.spi.Constants.UNKNOWN_CARDINALITY;
 
@@ -114,7 +115,8 @@ public class MutableNoDictColumnStatistics implements ColumnStatistics, CLPStats
     int numDocs = _dataSourceMetadata.getNumDocs();
 
     // Verify that values are non-decreasing when iterated in the given order
-    DataType valueType = getValueType();
+    DataType valueType = _forwardIndex.getStoredType();
+    boolean useUuidComparison = _dataSourceMetadata.getFieldSpec().getDataType() == DataType.UUID;
     if (_sortedDocIds != null) {
       switch (valueType) {
         case INT: {
@@ -187,7 +189,7 @@ public class MutableNoDictColumnStatistics implements ColumnStatistics, CLPStats
           byte[] prev = _forwardIndex.getBytes(_sortedDocIds[0]);
           for (int i = 1; i < numDocs; i++) {
             byte[] curr = _forwardIndex.getBytes(_sortedDocIds[i]);
-            if (ByteArray.compare(curr, prev) < 0) {
+            if ((useUuidComparison ? UuidUtils.compare(curr, prev) : ByteArray.compare(curr, prev)) < 0) {
               return false;
             }
             prev = curr;
@@ -269,7 +271,7 @@ public class MutableNoDictColumnStatistics implements ColumnStatistics, CLPStats
           byte[] prev = _forwardIndex.getBytes(0);
           for (int i = 1; i < numDocs; i++) {
             byte[] curr = _forwardIndex.getBytes(i);
-            if (ByteArray.compare(curr, prev) < 0) {
+            if ((useUuidComparison ? UuidUtils.compare(curr, prev) : ByteArray.compare(curr, prev)) < 0) {
               return false;
             }
             prev = curr;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/dictionary/MutableDictionaryFactory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/dictionary/MutableDictionaryFactory.java
@@ -27,12 +27,12 @@ public class MutableDictionaryFactory {
   private MutableDictionaryFactory() {
   }
 
-  public static MutableDictionary getMutableDictionary(DataType dataType, boolean isOffHeapAllocation,
+  public static MutableDictionary getMutableDictionary(DataType valueType, boolean isOffHeapAllocation,
       PinotDataBufferMemoryManager memoryManager, int avgLength, int cardinality, String allocationContext) {
     if (isOffHeapAllocation) {
       // OnHeap allocation
       int maxOverflowSize = cardinality / 10;
-      switch (dataType) {
+      switch (valueType) {
         case INT:
           return new IntOffHeapMutableDictionary(cardinality, maxOverflowSize, memoryManager, allocationContext);
         case LONG:
@@ -55,7 +55,7 @@ public class MutableDictionaryFactory {
       }
     } else {
       // OnHeap allocation
-      switch (dataType) {
+      switch (valueType) {
         case INT:
           return new IntOnHeapMutableDictionary();
         case LONG:

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/BaseSegmentCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/BaseSegmentCreator.java
@@ -44,6 +44,7 @@ import org.apache.pinot.common.metrics.ServerMeter;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.utils.FileUtils;
 import org.apache.pinot.segment.local.io.util.PinotDataBitSet;
+import org.apache.pinot.segment.local.segment.creator.impl.inv.RawValueBitmapInvertedIndexCreator;
 import org.apache.pinot.segment.local.segment.creator.impl.nullvalue.NullValueVectorCreator;
 import org.apache.pinot.segment.local.segment.index.converter.SegmentFormatConverterFactory;
 import org.apache.pinot.segment.local.segment.index.dictionary.DictionaryIndexPlugin;
@@ -166,7 +167,7 @@ public abstract class BaseSegmentCreator implements SegmentCreator {
 
     boolean dictEnabledColumn = createDictionaryForColumn(columnStatistics, _config, fieldSpec);
     if (originalConfig.getConfig(StandardIndexes.inverted()).isEnabled()) {
-      Preconditions.checkState(dictEnabledColumn,
+      Preconditions.checkState(dictEnabledColumn || supportsRawValueInvertedIndex(fieldSpec),
           "Cannot create inverted index for raw index column: %s", columnName);
     }
     IndexCreationContext.Common context = getIndexCreationContext(fieldSpec, dictEnabledColumn);
@@ -255,6 +256,10 @@ public abstract class BaseSegmentCreator implements SegmentCreator {
       if (index.getIndexBuildLifecycle() != IndexType.BuildLifecycle.DURING_SEGMENT_CREATION) {
         continue;
       }
+      if (index == StandardIndexes.inverted() && !dictEnabledColumn && supportsRawValueInvertedIndex(fieldSpec)) {
+        creatorsByIndex.put(index, new RawValueBitmapInvertedIndexCreator(context));
+        continue;
+      }
       tryCreateIndexCreator(creatorsByIndex, index, context, config);
     }
 
@@ -270,6 +275,10 @@ public abstract class BaseSegmentCreator implements SegmentCreator {
       }
     }
     return new ArrayList<>(creatorsByIndex.values());
+  }
+
+  private boolean supportsRawValueInvertedIndex(FieldSpec fieldSpec) {
+    return fieldSpec.isSingleValueField() && fieldSpec.getDataType() == FieldSpec.DataType.UUID;
   }
 
   private NullValueVectorCreator getNullValueCreator(FieldSpec fieldSpec) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/RawValueBitmapInvertedIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/RawValueBitmapInvertedIndexCreator.java
@@ -33,9 +33,8 @@ import org.apache.pinot.segment.spi.V1Constants;
 import org.apache.pinot.segment.spi.creator.IndexCreationContext;
 import org.apache.pinot.segment.spi.index.creator.RawValueBasedInvertedIndexCreator;
 import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
-import org.apache.pinot.spi.data.DimensionFieldSpec;
-import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.utils.ByteArray;
 import org.roaringbitmap.buffer.MutableRoaringBitmap;
 
 /**
@@ -161,7 +160,7 @@ public class RawValueBitmapInvertedIndexCreator implements RawValueBasedInverted
   public void add(byte[] value) {
     if (value != null) {
       _maxLength = Math.max(_maxLength, value.length);
-      addValue(value);
+      addValue(new ByteArray(value));
     }
   }
 
@@ -172,17 +171,99 @@ public class RawValueBitmapInvertedIndexCreator implements RawValueBasedInverted
         _maxLength = Math.max(_maxLength, values[i].length);
       }
     }
-    addValues(values, length);
+    ByteArray[] wrappedValues = new ByteArray[length];
+    for (int i = 0; i < length; i++) {
+      wrappedValues[i] = values[i] != null ? new ByteArray(values[i]) : null;
+    }
+    addValues(wrappedValues, length);
   }
 
   @Override
   public void add(Object value, int dictId)
       throws IOException {
+    if (value == null) {
+      _nextDocId++;
+      return;
+    }
+    switch (_dataType.getStoredType()) {
+      case INT:
+        add((Integer) value);
+        break;
+      case LONG:
+        add((Long) value);
+        break;
+      case FLOAT:
+        add((Float) value);
+        break;
+      case DOUBLE:
+        add((Double) value);
+        break;
+      case STRING:
+        add((String) value);
+        break;
+      case BYTES:
+        if (value instanceof ByteArray) {
+          add(((ByteArray) value).getBytes());
+        } else {
+          add((byte[]) value);
+        }
+        break;
+      default:
+        throw new IllegalStateException("Unsupported data type for raw inverted index: " + _dataType);
+    }
   }
 
   @Override
   public void add(Object[] values, @Nullable int[] dictIds)
       throws IOException {
+    switch (_dataType.getStoredType()) {
+      case INT:
+        int[] intValues = new int[values.length];
+        for (int i = 0; i < values.length; i++) {
+          intValues[i] = (Integer) values[i];
+        }
+        add(intValues, values.length);
+        break;
+      case LONG:
+        long[] longValues = new long[values.length];
+        for (int i = 0; i < values.length; i++) {
+          longValues[i] = (Long) values[i];
+        }
+        add(longValues, values.length);
+        break;
+      case FLOAT:
+        float[] floatValues = new float[values.length];
+        for (int i = 0; i < values.length; i++) {
+          floatValues[i] = (Float) values[i];
+        }
+        add(floatValues, values.length);
+        break;
+      case DOUBLE:
+        double[] doubleValues = new double[values.length];
+        for (int i = 0; i < values.length; i++) {
+          doubleValues[i] = (Double) values[i];
+        }
+        add(doubleValues, values.length);
+        break;
+      case STRING:
+        String[] stringValues = new String[values.length];
+        for (int i = 0; i < values.length; i++) {
+          stringValues[i] = (String) values[i];
+        }
+        add(stringValues, values.length);
+        break;
+      case BYTES:
+        byte[][] bytesValues = new byte[values.length][];
+        for (int i = 0; i < values.length; i++) {
+          Object value = values[i];
+          bytesValues[i] = value == null ? null
+              : value instanceof ByteArray ? ((ByteArray) value).getBytes() : (byte[]) value;
+        }
+        add(bytesValues, values.length);
+        break;
+      default:
+        throw new IllegalStateException("Unsupported data type for raw inverted index: " + _dataType);
+    }
   }
 
   private void addValue(Object value) {
@@ -208,108 +289,117 @@ public class RawValueBitmapInvertedIndexCreator implements RawValueBasedInverted
       return;
     }
 
-    // Create dictionary from unique values
-    boolean useVarLengthDictionary = _dataType == DataType.STRING;
-    FieldSpec fieldSpec = new DimensionFieldSpec(_columnName, _dataType, true);
-    _dictionaryCreator = new SegmentDictionaryCreator(fieldSpec, new File(_indexFile.getParent()),
-        useVarLengthDictionary);
+    File temporaryDictionaryFile = File.createTempFile(_columnName + ".raw-inv-dict-", ".tmp",
+        _indexFile.getParentFile());
+    try {
+      // Create dictionary from unique values.
+      // This dictionary is only embedded inside the raw-value bitmap index and must not be persisted as a segment
+      // dictionary file, otherwise later reloads will mis-detect the column as dictionary-encoded.
+      boolean useVarLengthDictionary = _dataType.getStoredType() == DataType.STRING;
+      _dictionaryCreator =
+          new SegmentDictionaryCreator(_columnName, _dataType.getStoredType(), temporaryDictionaryFile,
+              useVarLengthDictionary);
 
-    // Convert values to type-specific array
-    Object[] rawValues = _valueToDocIds.keySet().toArray();
-    int numValues = rawValues.length;
-    Object typedValues;
-    switch (_dataType.getStoredType()) {
-      case INT:
-        int[] intValues = new int[numValues];
-        for (int i = 0; i < numValues; i++) {
-          intValues[i] = (Integer) rawValues[i];
-        }
-        typedValues = intValues;
-        break;
-      case LONG:
-        long[] longValues = new long[numValues];
-        for (int i = 0; i < numValues; i++) {
-          longValues[i] = (Long) rawValues[i];
-        }
-        typedValues = longValues;
-        break;
-      case FLOAT:
-        float[] floatValues = new float[numValues];
-        for (int i = 0; i < numValues; i++) {
-          floatValues[i] = (Float) rawValues[i];
-        }
-        typedValues = floatValues;
-        break;
-      case DOUBLE:
-        double[] doubleValues = new double[numValues];
-        for (int i = 0; i < numValues; i++) {
-          doubleValues[i] = (Double) rawValues[i];
-        }
-        typedValues = doubleValues;
-        break;
-      case STRING:
-        String[] stringValues = new String[numValues];
-        for (int i = 0; i < numValues; i++) {
-          stringValues[i] = (String) rawValues[i];
-        }
-        typedValues = stringValues;
-        break;
-      case BYTES:
-        byte[][] bytesValues = new byte[numValues][];
-        for (int i = 0; i < numValues; i++) {
-          bytesValues[i] = (byte[]) rawValues[i];
-        }
-        typedValues = bytesValues;
-        break;
-      default:
-        throw new IllegalStateException("Unsupported data type: " + _dataType);
-    }
-    _dictionaryCreator.build(typedValues);
+      // Convert values to type-specific array
+      Object[] rawValues = _valueToDocIds.keySet().toArray();
+      int numValues = rawValues.length;
+      Object typedValues;
+      switch (_dataType.getStoredType()) {
+        case INT:
+          int[] intValues = new int[numValues];
+          for (int i = 0; i < numValues; i++) {
+            intValues[i] = (Integer) rawValues[i];
+          }
+          typedValues = intValues;
+          break;
+        case LONG:
+          long[] longValues = new long[numValues];
+          for (int i = 0; i < numValues; i++) {
+            longValues[i] = (Long) rawValues[i];
+          }
+          typedValues = longValues;
+          break;
+        case FLOAT:
+          float[] floatValues = new float[numValues];
+          for (int i = 0; i < numValues; i++) {
+            floatValues[i] = (Float) rawValues[i];
+          }
+          typedValues = floatValues;
+          break;
+        case DOUBLE:
+          double[] doubleValues = new double[numValues];
+          for (int i = 0; i < numValues; i++) {
+            doubleValues[i] = (Double) rawValues[i];
+          }
+          typedValues = doubleValues;
+          break;
+        case STRING:
+          String[] stringValues = new String[numValues];
+          for (int i = 0; i < numValues; i++) {
+            stringValues[i] = (String) rawValues[i];
+          }
+          typedValues = stringValues;
+          break;
+        case BYTES:
+          ByteArray[] bytesValues = new ByteArray[numValues];
+          for (int i = 0; i < numValues; i++) {
+            bytesValues[i] = (ByteArray) rawValues[i];
+          }
+          typedValues = bytesValues;
+          break;
+        default:
+          throw new IllegalStateException("Unsupported data type: " + _dataType);
+      }
+      _dictionaryCreator.build(typedValues);
 
-    // Write header placeholder
-    ByteBuffer headerBuffer = ByteBuffer.allocate(HEADER_LENGTH).order(ByteOrder.BIG_ENDIAN);
-    headerBuffer.putInt(VERSION);
-    headerBuffer.putInt(numValues);
-    headerBuffer.putInt(_maxLength);
-    headerBuffer.putLong(0L); // dictionaryOffset placeholder
-    headerBuffer.putLong(0L); // dictionaryLength placeholder
-    headerBuffer.putLong(0L); // invertedIndexOffset placeholder
-    headerBuffer.putLong(0L); // invertedIndexLength placeholder
-    try (FileOutputStream outputStream = new FileOutputStream(_indexFile)) {
-      outputStream.write(headerBuffer.array());
-    }
+      // Write header placeholder
+      ByteBuffer headerBuffer = ByteBuffer.allocate(HEADER_LENGTH).order(ByteOrder.BIG_ENDIAN);
+      headerBuffer.putInt(VERSION);
+      headerBuffer.putInt(numValues);
+      headerBuffer.putInt(_maxLength);
+      headerBuffer.putLong(0L); // dictionaryOffset placeholder
+      headerBuffer.putLong(0L); // dictionaryLength placeholder
+      headerBuffer.putLong(0L); // invertedIndexOffset placeholder
+      headerBuffer.putLong(0L); // invertedIndexLength placeholder
+      try (FileOutputStream outputStream = new FileOutputStream(_indexFile)) {
+        outputStream.write(headerBuffer.array());
+      }
 
-    // Write dictionary
-    long dictionaryOffset = HEADER_LENGTH;
-    File dictionaryFile = _dictionaryCreator.getDictionaryFile();
-    long dictionaryLength = dictionaryFile.length();
-    FileUtils.writeByteArrayToFile(_indexFile, FileUtils.readFileToByteArray(dictionaryFile), true);
+      // Write dictionary
+      long dictionaryOffset = HEADER_LENGTH;
+      File dictionaryFile = _dictionaryCreator.getDictionaryFile();
+      long dictionaryLength = dictionaryFile.length();
+      FileUtils.writeByteArrayToFile(_indexFile, FileUtils.readFileToByteArray(dictionaryFile), true);
 
-    // Write inverted index
-    long invertedIndexOffset = dictionaryOffset + dictionaryLength;
-    try (FileChannel channel = new RandomAccessFile(_indexFile, "rw").getChannel()) {
-      channel.position(invertedIndexOffset);
-      try (BitmapInvertedIndexWriter writer = new BitmapInvertedIndexWriter(channel, numValues, false)) {
-        for (Object value : rawValues) {
-          writer.add(_valueToDocIds.get(value).toRoaringBitmap());
+      // Write inverted index
+      long invertedIndexOffset = dictionaryOffset + dictionaryLength;
+      try (FileChannel channel = new RandomAccessFile(_indexFile, "rw").getChannel()) {
+        channel.position(invertedIndexOffset);
+        try (BitmapInvertedIndexWriter writer = new BitmapInvertedIndexWriter(channel, numValues, false)) {
+          for (Object value : rawValues) {
+            writer.add(_valueToDocIds.get(value).toRoaringBitmap());
+          }
         }
       }
-    }
-    long invertedIndexLength = _indexFile.length() - invertedIndexOffset;
+      long invertedIndexLength = _indexFile.length() - invertedIndexOffset;
 
-    // Update header with actual offsets and lengths
-    try (PinotDataBuffer buffer = PinotDataBuffer.mapFile(_indexFile, false, 0, HEADER_LENGTH, ByteOrder.BIG_ENDIAN,
-        getClass().getSimpleName())) {
-      buffer.putInt(0, VERSION);
-      buffer.putInt(4, numValues);
-      buffer.putInt(8, _maxLength);
-      buffer.putLong(12, dictionaryOffset);
-      buffer.putLong(20, dictionaryLength);
-      buffer.putLong(28, invertedIndexOffset);
-      buffer.putLong(36, invertedIndexLength);
-    }
+      // Update header with actual offsets and lengths
+      try (PinotDataBuffer buffer =
+          PinotDataBuffer.mapFile(_indexFile, false, 0, HEADER_LENGTH, ByteOrder.BIG_ENDIAN,
+              getClass().getSimpleName())) {
+        buffer.putInt(0, VERSION);
+        buffer.putInt(4, numValues);
+        buffer.putInt(8, _maxLength);
+        buffer.putLong(12, dictionaryOffset);
+        buffer.putLong(20, dictionaryLength);
+        buffer.putLong(28, invertedIndexOffset);
+        buffer.putLong(36, invertedIndexLength);
+      }
 
-    _isClosed = true;
+      _isClosed = true;
+    } finally {
+      FileUtils.deleteQuietly(temporaryDictionaryFile);
+    }
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/column/DefaultNullValueVirtualColumnProvider.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/column/DefaultNullValueVirtualColumnProvider.java
@@ -70,6 +70,7 @@ public class DefaultNullValueVirtualColumnProvider implements VirtualColumnProvi
       case STRING:
         return new ConstantValueStringDictionary((String) fieldSpec.getDefaultNullValue());
       case BYTES:
+      case UUID:
         return new ConstantValueBytesDictionary((byte[]) fieldSpec.getDefaultNullValue());
       default:
         throw new IllegalStateException();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/columnminmaxvalue/ColumnMinMaxValueGenerator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/columnminmaxvalue/ColumnMinMaxValueGenerator.java
@@ -46,6 +46,7 @@ import org.apache.pinot.segment.spi.utils.SegmentMetadataUtils;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.utils.ByteArray;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -349,13 +350,16 @@ public class ColumnMinMaxValueGenerator {
         case BYTES: {
           byte[] min = null;
           byte[] max = null;
+          boolean useUuidComparison = dataType == DataType.UUID;
           if (isSingleValue) {
             for (int docId = 0; docId < numDocs; docId++) {
               byte[] value = rawIndexReader.getBytes(docId, readerContext);
-              if (min == null || ByteArray.compare(value, min) > 0) {
+              if (min == null || (useUuidComparison ? UuidUtils.compare(value, min) : ByteArray.compare(value, min))
+                  > 0) {
                 min = value;
               }
-              if (max == null || ByteArray.compare(value, max) < 0) {
+              if (max == null || (useUuidComparison ? UuidUtils.compare(value, max) : ByteArray.compare(value, max))
+                  < 0) {
                 max = value;
               }
             }
@@ -363,10 +367,12 @@ public class ColumnMinMaxValueGenerator {
             for (int docId = 0; docId < numDocs; docId++) {
               byte[][] values = rawIndexReader.getBytesMV(docId, readerContext);
               for (byte[] value : values) {
-                if (min == null || ByteArray.compare(value, min) > 0) {
+                if (min == null || (useUuidComparison ? UuidUtils.compare(value, min)
+                    : ByteArray.compare(value, min)) > 0) {
                   min = value;
                 }
-                if (max == null || ByteArray.compare(value, max) < 0) {
+                if (max == null || (useUuidComparison ? UuidUtils.compare(value, max)
+                    : ByteArray.compare(value, max)) < 0) {
                   max = value;
                 }
               }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/BytesDictionary.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/BytesDictionary.java
@@ -30,7 +30,6 @@ import org.apache.pinot.spi.utils.BytesUtils;
  * Extension of {@link BaseImmutableDictionary} that implements immutable dictionary for byte[] type.
  */
 public class BytesDictionary extends BaseImmutableDictionary {
-
   public BytesDictionary(PinotDataBuffer dataBuffer, int length, int numBytesPerValue) {
     super(dataBuffer, length, numBytesPerValue);
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/RawValueBitmapInvertedIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/RawValueBitmapInvertedIndexReader.java
@@ -23,6 +23,7 @@ import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.segment.spi.index.reader.InvertedIndexReader;
 import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.utils.ByteArray;
 import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
 import org.roaringbitmap.buffer.MutableRoaringBitmap;
 
@@ -143,6 +144,14 @@ public class RawValueBitmapInvertedIndexReader implements InvertedIndexReader<Im
    */
   public ImmutableRoaringBitmap getDocIdsForString(String value) {
     int dictId = _dictionary.indexOf(value);
+    return dictId >= 0 ? getDocIds(dictId) : new MutableRoaringBitmap();
+  }
+
+  /**
+   * Returns the document IDs for the given raw BYTES value.
+   */
+  public ImmutableRoaringBitmap getDocIdsForBytes(byte[] value) {
+    int dictId = _dictionary.indexOf(new ByteArray(value));
     return dictId >= 0 ? getDocIds(dictId) : new MutableRoaringBitmap();
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/readers/PinotSegmentColumnReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/readers/PinotSegmentColumnReader.java
@@ -32,6 +32,7 @@ import org.apache.pinot.segment.spi.index.reader.ForwardIndexReaderContext;
 import org.apache.pinot.segment.spi.index.reader.NullValueVectorReader;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.ByteArray;
+import org.apache.pinot.spi.utils.UuidUtils;
 
 
 @SuppressWarnings({"rawtypes", "unchecked"})
@@ -42,6 +43,7 @@ public class PinotSegmentColumnReader implements Closeable {
   private final NullValueVectorReader _nullValueVectorReader;
   private final int[] _dictIdBuffer;
   private final DataType _valueType;
+  private final DataType _logicalValueType;
 
   public PinotSegmentColumnReader(IndexSegment indexSegment, String column) {
     DataSource dataSource = indexSegment.getDataSource(column);
@@ -51,6 +53,7 @@ public class PinotSegmentColumnReader implements Closeable {
     _dictionary = dataSource.getDictionary();
     _nullValueVectorReader = dataSource.getNullValueVector();
     _valueType = _dictionary != null ? _dictionary.getValueType() : _forwardIndexReader.getStoredType();
+    _logicalValueType = dataSource.getDataSourceMetadata().getFieldSpec().getDataType();
     if (_forwardIndexReader.isSingleValue()) {
       _dictIdBuffer = null;
     } else {
@@ -67,6 +70,7 @@ public class PinotSegmentColumnReader implements Closeable {
     _dictionary = dictionary;
     _nullValueVectorReader = nullValueVectorReader;
     _valueType = _dictionary != null ? _dictionary.getValueType() : _forwardIndexReader.getStoredType();
+    _logicalValueType = _valueType;
     if (_forwardIndexReader.isSingleValue()) {
       _dictIdBuffer = null;
     } else {
@@ -579,8 +583,11 @@ public class PinotSegmentColumnReader implements Closeable {
         return _forwardIndexReader.getString(docId1, _forwardIndexReaderContext)
             .compareTo(_forwardIndexReader.getString(docId2, _forwardIndexReaderContext));
       case BYTES:
-        return ByteArray.compare(_forwardIndexReader.getBytes(docId1, _forwardIndexReaderContext),
-            _forwardIndexReader.getBytes(docId2, _forwardIndexReaderContext));
+        return _logicalValueType == DataType.UUID
+            ? UuidUtils.compare(_forwardIndexReader.getBytes(docId1, _forwardIndexReaderContext),
+                _forwardIndexReader.getBytes(docId2, _forwardIndexReaderContext))
+            : ByteArray.compare(_forwardIndexReader.getBytes(docId1, _forwardIndexReaderContext),
+                _forwardIndexReader.getBytes(docId2, _forwardIndexReaderContext));
       default:
         throw new IllegalStateException("Unsupported SV no-dictionary column type for comparison: " + _valueType);
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/HashUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/HashUtils.java
@@ -23,13 +23,13 @@ import com.dynatrace.hash4j.hashing.Hasher128;
 import com.google.common.hash.Hashing;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.util.UUID;
 import net.jpountz.xxhash.XXHashFactory;
 import org.apache.pinot.spi.config.table.HashFunction;
 import org.apache.pinot.spi.data.readers.PrimaryKey;
 import org.apache.pinot.spi.utils.ByteArray;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.PinotMd5Mode;
+import org.apache.pinot.spi.utils.UuidUtils;
 
 
 public class HashUtils {
@@ -56,14 +56,11 @@ public class HashUtils {
       if (value == null) {
         throw new IllegalArgumentException("Found null value in primary key");
       }
-      UUID uuid;
       try {
-        uuid = UUID.fromString(value.toString());
-      } catch (Throwable t) {
+        byteBuffer.put(UuidUtils.toBytes(value));
+      } catch (RuntimeException e) {
         return primaryKey.asBytes();
       }
-      byteBuffer.putLong(uuid.getMostSignificantBits());
-      byteBuffer.putLong(uuid.getLeastSignificantBits());
     }
     return result;
   }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplUuidPrimaryKeyTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplUuidPrimaryKeyTest.java
@@ -1,0 +1,89 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.indexsegment.mutable;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.List;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.data.readers.PrimaryKey;
+import org.apache.pinot.spi.utils.ByteArray;
+import org.apache.pinot.spi.utils.UuidUtils;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+
+/**
+ * Regression tests for UUID primary-key normalization during realtime upsert ingestion.
+ */
+public class MutableSegmentImplUuidPrimaryKeyTest {
+  private static final String UUID_PK_COLUMN = "uuidPk";
+  private static final String VALUE_COLUMN = "payload";
+  private static final String TIME_COLUMN = "ts";
+  private static final String UUID_VALUE = "550e8400-e29b-41d4-a716-446655440000";
+
+  private static final Schema SCHEMA = new Schema.SchemaBuilder()
+      .addSingleValueDimension(UUID_PK_COLUMN, FieldSpec.DataType.UUID)
+      .addSingleValueDimension(VALUE_COLUMN, FieldSpec.DataType.STRING)
+      .addDateTimeField(TIME_COLUMN, FieldSpec.DataType.LONG, "1:MILLISECONDS:EPOCH", "1:MILLISECONDS")
+      .setPrimaryKeyColumns(List.of(UUID_PK_COLUMN))
+      .build();
+
+  private MutableSegmentImpl _segment;
+
+  @AfterMethod
+  public void tearDown() {
+    if (_segment != null) {
+      _segment.destroy();
+      _segment = null;
+    }
+  }
+
+  @Test
+  public void testUpsertPrimaryKeyNormalizesMixedCaseUuidStrings()
+      throws ReflectiveOperationException {
+    _segment = MutableSegmentImplTestUtils.createMutableSegmentImpl(SCHEMA, false, TIME_COLUMN, null, null);
+
+    PrimaryKey firstPrimaryKey = getPrimaryKey(createRow(UUID_VALUE.toUpperCase(), 1L));
+    PrimaryKey secondPrimaryKey = getPrimaryKey(createRow(UUID_VALUE, 2L));
+    assertEquals(firstPrimaryKey, secondPrimaryKey);
+    assertTrue(firstPrimaryKey.getValues()[0] instanceof ByteArray);
+    assertEquals(firstPrimaryKey.getValues()[0], new ByteArray(UuidUtils.toBytes(UUID_VALUE)));
+  }
+
+  private GenericRow createRow(String uuidValue, long timestamp) {
+    GenericRow row = new GenericRow();
+    row.putValue(UUID_PK_COLUMN, uuidValue);
+    row.putValue(VALUE_COLUMN, "payload-" + timestamp);
+    row.putValue(TIME_COLUMN, timestamp);
+    return row;
+  }
+
+  private PrimaryKey getPrimaryKey(GenericRow row)
+      throws NoSuchMethodException, InvocationTargetException, IllegalAccessException {
+    Method getPrimaryKeyMethod = MutableSegmentImpl.class.getDeclaredMethod("getPrimaryKey", GenericRow.class);
+    getPrimaryKeyMethod.setAccessible(true);
+    return (PrimaryKey) getPrimaryKeyMethod.invoke(_segment, row);
+  }
+}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/column/DefaultNullValueVirtualColumnProviderTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/column/DefaultNullValueVirtualColumnProviderTest.java
@@ -31,6 +31,7 @@ import org.apache.pinot.spi.data.DimensionFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.ByteArray;
+import org.apache.pinot.spi.utils.BytesUtils;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
@@ -45,6 +46,7 @@ public class DefaultNullValueVirtualColumnProviderTest {
   private static final FieldSpec SV_STRING_WITH_DEFAULT =
       new DimensionFieldSpec("svStringColumn", DataType.STRING, true, "default");
   private static final FieldSpec SV_BYTES = new DimensionFieldSpec("svBytesColumn", DataType.BYTES, true);
+  private static final FieldSpec SV_UUID = new DimensionFieldSpec("svUuidColumn", DataType.UUID, true);
   private static final FieldSpec MV_INT = new DimensionFieldSpec("mvIntColumn", DataType.INT, false);
   private static final FieldSpec MV_LONG = new DimensionFieldSpec("mvLongColumn", DataType.LONG, false);
   private static final FieldSpec MV_FLOAT = new DimensionFieldSpec("mvFloatColumn", DataType.FLOAT, false);
@@ -87,6 +89,11 @@ public class DefaultNullValueVirtualColumnProviderTest {
         new ColumnMetadataImpl.Builder().setFieldSpec(SV_BYTES).setTotalDocs(1).setCardinality(1).setSorted(true)
             .setHasDictionary(true).setMinValue(new ByteArray((byte[]) SV_BYTES.getDefaultNullValue()))
             .setMaxValue(new ByteArray((byte[]) SV_BYTES.getDefaultNullValue())).build());
+
+    assertEquals(new DefaultNullValueVirtualColumnProvider().buildMetadata(new VirtualColumnContext(SV_UUID, 1)),
+        new ColumnMetadataImpl.Builder().setFieldSpec(SV_UUID).setTotalDocs(1).setCardinality(1).setSorted(true)
+            .setHasDictionary(true).setMinValue(new ByteArray((byte[]) SV_UUID.getDefaultNullValue()))
+            .setMaxValue(new ByteArray((byte[]) SV_UUID.getDefaultNullValue())).build());
 
     assertEquals(new DefaultNullValueVirtualColumnProvider().buildMetadata(new VirtualColumnContext(MV_INT, 1)),
         new ColumnMetadataImpl.Builder().setFieldSpec(MV_INT).setTotalDocs(1).setCardinality(1).setSorted(false)
@@ -145,6 +152,14 @@ public class DefaultNullValueVirtualColumnProviderTest {
     dictionary = new DefaultNullValueVirtualColumnProvider().buildDictionary(virtualColumnContext);
     assertEquals(dictionary.getClass(), ConstantValueBytesDictionary.class);
     assertEquals(dictionary.getBytesValue(0), new byte[0]);
+
+    virtualColumnContext = new VirtualColumnContext(SV_UUID, 1);
+    dictionary = new DefaultNullValueVirtualColumnProvider().buildDictionary(virtualColumnContext);
+    assertEquals(dictionary.getClass(), ConstantValueBytesDictionary.class);
+    byte[] uuidDefaultNullValue = (byte[]) SV_UUID.getDefaultNullValue();
+    assertEquals(dictionary.getBytesValue(0), uuidDefaultNullValue);
+    assertEquals(dictionary.getStringValue(0), BytesUtils.toHexString(uuidDefaultNullValue));
+    assertEquals(dictionary.indexOf(BytesUtils.toHexString(uuidDefaultNullValue)), 0);
 
     virtualColumnContext = new VirtualColumnContext(MV_INT, 1);
     dictionary = new DefaultNullValueVirtualColumnProvider().buildDictionary(virtualColumnContext);

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/BloomFilterCreatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/BloomFilterCreatorTest.java
@@ -29,6 +29,7 @@ import org.apache.pinot.segment.spi.index.reader.BloomFilterReader;
 import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
 import org.apache.pinot.spi.config.table.BloomFilterConfig;
 import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.apache.pinot.util.TestUtils;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
@@ -72,6 +73,33 @@ public class BloomFilterCreatorTest implements PinotBuffersAfterMethodCheckRule 
         Assert.assertFalse(onHeapBloomFilter.mightContain(Integer.toString(i)));
         Assert.assertFalse(offHeapBloomFilter.mightContain(Integer.toString(i)));
       }
+    }
+  }
+
+  @Test
+  public void testUuidBloomFilterCreatorWithBytesValues()
+      throws Exception {
+    int cardinality = 100;
+    String columnName = "uuidColumn";
+    String uuid0 = "550e8400-e29b-41d4-a716-446655440000";
+    String uuid1 = "550e8400-e29b-41d4-a716-446655440001";
+    try (BloomFilterCreator bloomFilterCreator = new OnHeapGuavaBloomFilterCreator(TEMP_DIR, columnName, cardinality,
+        new BloomFilterConfig(BloomFilterConfig.DEFAULT_FPP, 0, false), FieldSpec.DataType.UUID)) {
+      bloomFilterCreator.add(UuidUtils.toBytes(uuid0), -1);
+      bloomFilterCreator.add(UuidUtils.toBytes(uuid1), -1);
+      bloomFilterCreator.seal();
+    }
+
+    File bloomFilterFile = new File(TEMP_DIR, columnName + V1Constants.Indexes.BLOOM_FILTER_FILE_EXTENSION);
+    try (PinotDataBuffer dataBuffer = PinotDataBuffer.mapReadOnlyBigEndianFile(bloomFilterFile);
+        BloomFilterReader onHeapBloomFilter = BloomFilterReaderFactory.getBloomFilterReader(dataBuffer, true);
+        BloomFilterReader offHeapBloomFilter = BloomFilterReaderFactory.getBloomFilterReader(dataBuffer, false)) {
+      Assert.assertTrue(onHeapBloomFilter.mightContain(uuid0));
+      Assert.assertTrue(onHeapBloomFilter.mightContain(uuid1));
+      Assert.assertFalse(onHeapBloomFilter.mightContain("550e8400-e29b-41d4-a716-4466554400ff"));
+      Assert.assertTrue(offHeapBloomFilter.mightContain(uuid0));
+      Assert.assertTrue(offHeapBloomFilter.mightContain(uuid1));
+      Assert.assertFalse(offHeapBloomFilter.mightContain("550e8400-e29b-41d4-a716-4466554400ff"));
     }
   }
 

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/inv/RawValueBitmapInvertedIndexTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/inv/RawValueBitmapInvertedIndexTest.java
@@ -32,10 +32,12 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.pinot.segment.local.segment.creator.impl.inv.RawValueBitmapInvertedIndexCreator;
+import org.apache.pinot.segment.local.segment.index.dictionary.DictionaryIndexType;
 import org.apache.pinot.segment.local.segment.index.readers.RawValueBitmapInvertedIndexReader;
 import org.apache.pinot.segment.spi.V1Constants;
 import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
@@ -79,6 +81,10 @@ public class RawValueBitmapInvertedIndexTest {
       case STRING:
         return IntStream.range(0, NUM_VALUES)
             .mapToObj(i -> "value_" + RANDOM.nextInt(100000))
+            .collect(Collectors.toList());
+      case UUID:
+        return IntStream.range(0, NUM_VALUES)
+            .mapToObj(i -> String.format("550e8400-e29b-41d4-a716-%012x", i))
             .collect(Collectors.toList());
       default:
         throw new IllegalStateException("Unsupported data type: " + dataType);
@@ -126,6 +132,12 @@ public class RawValueBitmapInvertedIndexTest {
           stringValues[i] = (String) values[i];
         }
         return new Object[]{stringValues, values.length};
+      case UUID:
+        byte[][] uuidValues = new byte[values.length][];
+        for (int i = 0; i < values.length; i++) {
+          uuidValues[i] = UuidUtils.toBytes((String) values[i]);
+        }
+        return new Object[]{uuidValues, values.length};
       default:
         throw new IllegalStateException("Unsupported data type: " + dataType);
     }
@@ -163,6 +175,9 @@ public class RawValueBitmapInvertedIndexTest {
           case STRING:
             creator.add((String) value);
             break;
+          case UUID:
+            creator.add(UuidUtils.toBytes((String) value));
+            break;
           default:
             throw new IllegalStateException("Unsupported data type: " + dataType);
         }
@@ -177,7 +192,7 @@ public class RawValueBitmapInvertedIndexTest {
           new RawValueBitmapInvertedIndexReader(dataBuffer, dataType)) {
         // Test all values
         for (Object value : values) {
-          ImmutableRoaringBitmap actualBitmap = getBitmap(reader, value);
+          ImmutableRoaringBitmap actualBitmap = getBitmap(reader, value, dataType);
           Set<Integer> expectedDocIds = valueToDocIds.getOrDefault(value, Collections.emptySet());
 
           // Convert bitmap to docIds for comparison
@@ -189,9 +204,37 @@ public class RawValueBitmapInvertedIndexTest {
 
         // Test non-existent values
         Object nonExistentValue = getNonExistentValue(dataType);
-        ImmutableRoaringBitmap bitmap = getBitmap(reader, nonExistentValue);
+        ImmutableRoaringBitmap bitmap = getBitmap(reader, nonExistentValue, dataType);
         Assert.assertTrue(bitmap.isEmpty(), "Bitmap should be empty for non-existent value");
       }
+    }
+  }
+
+  @Test
+  public void testUuidSingleValueInvertedIndexViaGenericApi()
+      throws IOException {
+    File indexDir = Files.createTempDirectory("inverted-index").toFile();
+    indexDir.deleteOnExit();
+    File indexFile = new File(indexDir, "col" + V1Constants.Indexes.BITMAP_INVERTED_INDEX_FILE_EXTENSION);
+    indexFile.deleteOnExit();
+    String uuid = "550e8400-e29b-41d4-a716-446655440000";
+    byte[] uuidBytes = UuidUtils.toBytes(uuid);
+
+    try (RawValueBitmapInvertedIndexCreator creator =
+        new RawValueBitmapInvertedIndexCreator(DataType.UUID, "col", indexDir)) {
+      creator.add(uuidBytes, -1);
+    }
+
+    Assert.assertFalse(new File(indexDir, "col" + DictionaryIndexType.getFileExtension()).exists(),
+        "Raw-value inverted index creation should not leave a segment dictionary file behind");
+
+    try (PinotDataBuffer dataBuffer = PinotDataBuffer.mapFile(indexFile, true, 0,
+        indexFile.length(), ByteOrder.BIG_ENDIAN, "");
+        RawValueBitmapInvertedIndexReader reader = new RawValueBitmapInvertedIndexReader(dataBuffer, DataType.UUID)) {
+      ImmutableRoaringBitmap bitmap = reader.getDocIdsForBytes(uuidBytes);
+      Set<Integer> actualDocIds = new HashSet<>();
+      bitmap.forEach((int docId) -> actualDocIds.add(docId));
+      Assert.assertEquals(actualDocIds, Set.of(0));
     }
   }
 
@@ -228,6 +271,9 @@ public class RawValueBitmapInvertedIndexTest {
           case STRING:
             creator.add((String[]) typedArray[0], (int) typedArray[1]);
             break;
+          case UUID:
+            creator.add((byte[][]) typedArray[0], (int) typedArray[1]);
+            break;
           default:
             throw new IllegalStateException("Unsupported data type: " + dataType);
         }
@@ -246,7 +292,7 @@ public class RawValueBitmapInvertedIndexTest {
           new RawValueBitmapInvertedIndexReader(dataBuffer, dataType)) {
         // Test all values
         for (Object value : values) {
-          ImmutableRoaringBitmap actualBitmap = getBitmap(reader, value);
+          ImmutableRoaringBitmap actualBitmap = getBitmap(reader, value, dataType);
           Set<Integer> expectedDocIds = valueToDocIds.getOrDefault(value, Collections.emptySet());
 
           // Convert bitmap to docIds for comparison
@@ -260,26 +306,28 @@ public class RawValueBitmapInvertedIndexTest {
 
         // Test non-existent values
         Object nonExistentValue = getNonExistentValue(dataType);
-        ImmutableRoaringBitmap bitmap = getBitmap(reader, nonExistentValue);
+        ImmutableRoaringBitmap bitmap = getBitmap(reader, nonExistentValue, dataType);
         Assert.assertTrue(bitmap.isEmpty(), "Bitmap should be empty for non-existent value");
       }
     }
   }
 
-  private ImmutableRoaringBitmap getBitmap(RawValueBitmapInvertedIndexReader reader, Object value) {
-    switch (value.getClass().getSimpleName()) {
-      case "Integer":
+  private ImmutableRoaringBitmap getBitmap(RawValueBitmapInvertedIndexReader reader, Object value, DataType dataType) {
+    switch (dataType) {
+      case INT:
         return reader.getDocIdsForInt((Integer) value);
-      case "Long":
+      case LONG:
         return reader.getDocIdsForLong((Long) value);
-      case "Float":
+      case FLOAT:
         return reader.getDocIdsForFloat((Float) value);
-      case "Double":
+      case DOUBLE:
         return reader.getDocIdsForDouble((Double) value);
-      case "String":
+      case STRING:
         return reader.getDocIdsForString((String) value);
+      case UUID:
+        return reader.getDocIdsForBytes(UuidUtils.toBytes((String) value));
       default:
-        throw new IllegalStateException("Unsupported value type: " + value.getClass());
+        throw new IllegalStateException("Unsupported data type: " + dataType);
     }
   }
 
@@ -295,6 +343,8 @@ public class RawValueBitmapInvertedIndexTest {
         return Double.MAX_VALUE;
       case STRING:
         return "non_existent_value";
+      case UUID:
+        return "550e8400-e29b-41d4-a716-ffffffffffff";
       default:
         throw new IllegalStateException("Unsupported data type: " + dataType);
     }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/HashUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/HashUtilsTest.java
@@ -21,9 +21,11 @@ package org.apache.pinot.segment.local.utils;
 import java.util.UUID;
 import org.apache.pinot.spi.config.table.HashFunction;
 import org.apache.pinot.spi.data.readers.PrimaryKey;
+import org.apache.pinot.spi.utils.ByteArray;
 import org.apache.pinot.spi.utils.BytesUtils;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.PinotMd5Mode;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.*;
@@ -47,6 +49,7 @@ public class HashUtilsTest {
     // Test happy cases: when all UUID values are valid
     testHashUUID(new UUID[]{UUID.randomUUID()});
     testHashUUID(new UUID[]{UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID()});
+    testHashUUIDNormalizedPrimaryKeyValues();
 
     // Test failure scenario when there's a non-null invalid uuid value
     PrimaryKey invalidUUIDs = new PrimaryKey(new String[]{"some-random-string"});
@@ -62,6 +65,19 @@ public class HashUtilsTest {
     } catch (IllegalArgumentException e) {
       assertTrue(e.getMessage().contains("Found null value"));
     }
+  }
+
+  @Test
+  public void testHashUUIDNormalizedPrimaryKeyValues() {
+    UUID firstUuid = UUID.randomUUID();
+    UUID secondUuid = UUID.randomUUID();
+
+    byte[] expectedHash = HashUtils.hashUUID(new PrimaryKey(new Object[]{firstUuid, secondUuid}));
+    assertEquals(HashUtils.hashUUID(new PrimaryKey(
+        new Object[]{new ByteArray(UuidUtils.toBytes(firstUuid)), new ByteArray(UuidUtils.toBytes(secondUuid))})),
+        expectedHash);
+    assertEquals(HashUtils.hashUUID(
+        new PrimaryKey(new Object[]{UuidUtils.toBytes(firstUuid), UuidUtils.toBytes(secondUuid)})), expectedHash);
   }
 
   @Test

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/creator/BloomFilterCreator.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/creator/BloomFilterCreator.java
@@ -23,6 +23,7 @@ import javax.annotation.Nullable;
 import org.apache.pinot.segment.spi.index.IndexCreator;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.utils.BytesUtils;
+import org.apache.pinot.spi.utils.UuidUtils;
 
 
 public interface BloomFilterCreator extends IndexCreator {
@@ -33,6 +34,8 @@ public interface BloomFilterCreator extends IndexCreator {
   default void add(Object value, int dictId) {
     if (getDataType() == FieldSpec.DataType.BYTES) {
       add(BytesUtils.toHexString((byte[]) value));
+    } else if (getDataType() == FieldSpec.DataType.UUID) {
+      add(UuidUtils.toString((byte[]) value));
     } else {
       add(value.toString());
     }
@@ -43,6 +46,10 @@ public interface BloomFilterCreator extends IndexCreator {
     if (getDataType() == FieldSpec.DataType.BYTES) {
       for (Object value : values) {
         add(BytesUtils.toHexString((byte[]) value));
+      }
+    } else if (getDataType() == FieldSpec.DataType.UUID) {
+      for (Object value : values) {
+        add(UuidUtils.toString((byte[]) value));
       }
     } else {
       for (Object value : values) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/FieldSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/FieldSpec.java
@@ -36,6 +36,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
 import javax.annotation.Nullable;
 import org.apache.pinot.spi.utils.BooleanUtils;
 import org.apache.pinot.spi.utils.ByteArray;
@@ -43,6 +44,7 @@ import org.apache.pinot.spi.utils.BytesUtils;
 import org.apache.pinot.spi.utils.EqualityUtils;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.TimestampUtils;
+import org.apache.pinot.spi.utils.UuidUtils;
 
 
 /**
@@ -84,6 +86,7 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
   public static final String DEFAULT_DIMENSION_NULL_VALUE_OF_STRING = "null";
   public static final String DEFAULT_DIMENSION_NULL_VALUE_OF_JSON = "null";
   public static final byte[] DEFAULT_DIMENSION_NULL_VALUE_OF_BYTES = new byte[0];
+  public static final byte[] DEFAULT_DIMENSION_NULL_VALUE_OF_UUID = UuidUtils.nullUuidBytes();
   public static final BigDecimal DEFAULT_DIMENSION_NULL_VALUE_OF_BIG_DECIMAL = BigDecimal.ZERO;
 
   public static final Integer DEFAULT_METRIC_NULL_VALUE_OF_INT = 0;
@@ -360,11 +363,15 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
   }
 
   public Object getDefaultNullValue() {
+    if (_dataType == DataType.UUID && _defaultNullValue instanceof byte[]) {
+      byte[] uuidDefaultNullValue = (byte[]) _defaultNullValue;
+      return Arrays.copyOf(uuidDefaultNullValue, uuidDefaultNullValue.length);
+    }
     return _defaultNullValue;
   }
 
   public String getDefaultNullValueString() {
-    return getStringValue(_defaultNullValue);
+    return _dataType != null ? _dataType.toString(_defaultNullValue) : getStringValue(_defaultNullValue);
   }
 
   /// Returns the [String] representation of the given object.
@@ -406,11 +413,22 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
   @JsonIgnore
   public void setDefaultNullValue(@Nullable Object defaultNullValue) {
     if (defaultNullValue != null) {
-      _stringDefaultNullValue = getStringValue(defaultNullValue);
+      if (defaultNullValue instanceof String) {
+        _stringDefaultNullValue = (String) defaultNullValue;
+      } else {
+        _stringDefaultNullValue = getStringDefaultNullValue(defaultNullValue);
+      }
     }
     if (_dataType != null) {
       _defaultNullValue = getDefaultNullValue(getFieldType(), _dataType, _stringDefaultNullValue);
     }
+  }
+
+  private String getStringDefaultNullValue(Object defaultNullValue) {
+    if (_dataType == DataType.UUID) {
+      return _dataType.toString(defaultNullValue);
+    }
+    return getStringValue(defaultNullValue);
   }
 
   public static Object getDefaultNullValue(FieldType fieldType, DataType dataType,
@@ -460,6 +478,8 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
               return DEFAULT_DIMENSION_NULL_VALUE_OF_JSON;
             case BYTES:
               return DEFAULT_DIMENSION_NULL_VALUE_OF_BYTES;
+            case UUID:
+              return UuidUtils.nullUuidBytes();
             case BIG_DECIMAL:
               return DEFAULT_DIMENSION_NULL_VALUE_OF_BIG_DECIMAL;
             default:
@@ -594,6 +614,9 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
         case BYTES:
           jsonNode.put(key, BytesUtils.toHexString((byte[]) _defaultNullValue));
           break;
+        case UUID:
+          jsonNode.put(key, UuidUtils.toString((byte[]) _defaultNullValue));
+          break;
         case MAP:
         case LIST:
           jsonNode.set(key, JsonUtils.objectToJsonNode(_defaultNullValue));
@@ -670,6 +693,7 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
     STRING(false, true),
     JSON(STRING, false, false),
     BYTES(false, false),
+    UUID(BYTES, UuidUtils.UUID_NUM_BYTES, false, true),
     STRUCT(false, false),
     MAP(false, false),
     LIST(false, false),
@@ -690,6 +714,13 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
     DataType(DataType storedType, boolean numeric, boolean sortable) {
       _storedType = storedType;
       _size = storedType._size;
+      _sortable = sortable;
+      _numeric = numeric;
+    }
+
+    DataType(DataType storedType, int size, boolean numeric, boolean sortable) {
+      _storedType = storedType;
+      _size = size;
       _sortable = sortable;
       _numeric = numeric;
     }
@@ -745,7 +776,7 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
     }
 
     /**
-     * Converts the given string value to the data type. Returns byte[] for BYTES.
+     * Converts the given string value to the data type. Returns byte[] for BYTES and UUID.
      */
     public Object convert(String value) {
       try {
@@ -767,6 +798,8 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
           case STRING:
           case JSON:
             return value;
+          case UUID:
+            return UuidUtils.toBytes(value);
           case BYTES:
             return BytesUtils.toBytes(value);
           case MAP:
@@ -777,16 +810,23 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
             throw new IllegalStateException();
         }
       } catch (Exception e) {
-        throw new IllegalArgumentException("Cannot convert value: '" + value + "' to type: " + this);
+        throw new IllegalArgumentException(
+            "Cannot convert value: '" + value + "' to type: " + this + " (" + e.getMessage() + ")", e);
       }
     }
 
     public boolean equals(Object value1, Object value2) {
-      return this == BYTES ? Arrays.equals((byte[]) value1, (byte[]) value2) : value1.equals(value2);
+      if (this == UUID) {
+        return UuidUtils.equals(toBytesValue(value1), toBytesValue(value2));
+      }
+      return this == BYTES ? Arrays.equals(toBytesValue(value1), toBytesValue(value2)) : value1.equals(value2);
     }
 
     public int hashCode(Object value) {
-      return this == BYTES ? Arrays.hashCode((byte[]) value) : value.hashCode();
+      if (this == UUID) {
+        return UuidUtils.hashCode(toBytesValue(value));
+      }
+      return this == BYTES ? Arrays.hashCode(toBytesValue(value)) : value.hashCode();
     }
 
     /**
@@ -816,7 +856,9 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
         case JSON:
           return ((String) value1).compareTo((String) value2);
         case BYTES:
-          return ByteArray.compare((byte[]) value1, (byte[]) value2);
+          return ByteArray.compare(toBytesValue(value1), toBytesValue(value2));
+        case UUID:
+          return UuidUtils.compare(toBytesValue(value1), toBytesValue(value2));
         case MAP:
         case LIST:
           throw new UnsupportedOperationException("Cannot compare complex data types: " + this);
@@ -826,14 +868,20 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
     }
 
     /**
-     * Converts the given value of the data type to string.The input value for BYTES type should be byte[].
+     * Converts the given value of the data type to string. The input value for BYTES/UUID should be byte[].
      */
     public String toString(Object value) {
       if (this == BIG_DECIMAL) {
         return ((BigDecimal) value).toPlainString();
       }
+      if (this == UUID) {
+        if (value instanceof UUID) {
+          return UuidUtils.toString((UUID) value);
+        }
+        return UuidUtils.toString(toBytesValue(value));
+      }
       if (this == BYTES) {
-        return BytesUtils.toHexString((byte[]) value);
+        return BytesUtils.toHexString(toBytesValue(value));
       }
       if (this == MAP || this == LIST) {
         try {
@@ -846,7 +894,7 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
     }
 
     /**
-     * Converts the given string value to the data type. Returns ByteArray for BYTES.
+     * Converts the given string value to the data type. Returns ByteArray for BYTES and UUID.
      */
     public Comparable convertInternal(String value) {
       try {
@@ -868,6 +916,8 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
           case STRING:
           case JSON:
             return value;
+          case UUID:
+            return new ByteArray(UuidUtils.toBytes(value));
           case BYTES:
             return BytesUtils.toByteArray(value);
           case MAP:
@@ -877,8 +927,25 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
             throw new IllegalStateException();
         }
       } catch (Exception e) {
-        throw new IllegalArgumentException("Cannot convert value: '" + value + "' to type: " + this);
+        throw new IllegalArgumentException(
+            "Cannot convert value: '" + value + "' to type: " + this + " (" + e.getMessage() + ")", e);
       }
+    }
+
+    private byte[] toBytesValue(Object value) {
+      if (value instanceof byte[]) {
+        return (byte[]) value;
+      }
+      if (value instanceof ByteArray) {
+        return ((ByteArray) value).getBytes();
+      }
+      if (value instanceof UUID) {
+        return UuidUtils.toBytes((UUID) value);
+      }
+      if (value instanceof String && this == UUID) {
+        return UuidUtils.toBytes((String) value);
+      }
+      throw new IllegalArgumentException("Unsupported value for " + this + ": " + value);
     }
 
     /**

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
@@ -132,6 +132,7 @@ public final class Schema implements Serializable {
           case TIMESTAMP:
           case STRING:
           case JSON:
+          case UUID:
           case BYTES:
             break;
           default:
@@ -609,20 +610,32 @@ public final class Schema implements Serializable {
    * Validates a pinot schema.
    * <p>The following validations are performed:
    * <ul>
-   *   <li>For dimension, time, date time fields, support {@link DataType}: INT, LONG, FLOAT, DOUBLE, BOOLEAN,
-   *   TIMESTAMP, STRING, BYTES</li>
-   *   <li>For metric fields, support {@link DataType}: INT, LONG, FLOAT, DOUBLE, BYTES</li>
+   *   <li>For dimension, time, date time fields, support {@link DataType}: INT, LONG, FLOAT, DOUBLE, BIG_DECIMAL,
+   *   BOOLEAN, TIMESTAMP, STRING, JSON, UUID, BYTES</li>
+   *   <li>For metric fields, support {@link DataType}: INT, LONG, FLOAT, DOUBLE, BIG_DECIMAL, BYTES</li>
+   *   <li>BIG_DECIMAL and UUID fields only support single-value columns</li>
    * </ul>
    */
   public void validate() {
     for (FieldSpec fieldSpec : _fieldSpecMap.values()) {
-      FieldType fieldType = fieldSpec.getFieldType();
-      DataType dataType = fieldSpec.getDataType();
       String fieldName = fieldSpec.getName();
       try {
-        validate(fieldType, dataType);
+        validate(fieldSpec);
       } catch (IllegalStateException e) {
         throw new IllegalStateException(e.getMessage() + ": " + fieldName);
+      }
+    }
+  }
+
+  public static void validate(FieldSpec fieldSpec) {
+    DataType dataType = fieldSpec.getDataType();
+    validate(fieldSpec.getFieldType(), dataType);
+    if (!fieldSpec.isSingleValueField()) {
+      if (dataType == DataType.BIG_DECIMAL) {
+        throw new IllegalStateException("BIG_DECIMAL data type only supports single-value fields");
+      }
+      if (dataType == DataType.UUID) {
+        throw new IllegalStateException("UUID data type only supports single-value fields");
       }
     }
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -2167,6 +2167,8 @@ public class CommonConstants {
     public static final String STRING = "";
     public static final byte[] BYTES = new byte[0];
     public static final ByteArray INTERNAL_BYTES = new ByteArray(BYTES);
+    public static final byte[] UUID_BYTES = UuidUtils.nullUuidBytes();
+    public static final ByteArray INTERNAL_UUID_BYTES = new ByteArray(UUID_BYTES);
     public static final int[] INT_ARRAY = new int[0];
     public static final long[] LONG_ARRAY = new long[0];
     public static final float[] FLOAT_ARRAY = new float[0];

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/UuidUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/UuidUtils.java
@@ -1,0 +1,443 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.utils;
+
+import java.util.Arrays;
+import java.util.UUID;
+
+
+/**
+ * Utilities for Pinot's logical UUID type.
+ *
+ * <p>UUID values are externally represented as canonical lowercase RFC 4122 strings and internally represented as
+ * fixed-width 16-byte values.
+ */
+public final class UuidUtils {
+  public static final int UUID_NUM_BYTES = 16;
+  private static final byte[] NULL_UUID_BYTES = new byte[UUID_NUM_BYTES];
+
+  private UuidUtils() {
+  }
+
+  public static byte[] nullUuidBytes() {
+    return Arrays.copyOf(NULL_UUID_BYTES, UUID_NUM_BYTES);
+  }
+
+  @Deprecated
+  public static byte[] nilUuidBytes() {
+    return nullUuidBytes();
+  }
+
+  public static byte[] toBytes(long mostSignificantBits, long leastSignificantBits) {
+    byte[] uuidBytes = new byte[UUID_NUM_BYTES];
+    writeLong(uuidBytes, 0, mostSignificantBits);
+    writeLong(uuidBytes, Long.BYTES, leastSignificantBits);
+    return uuidBytes;
+  }
+
+  public static byte[] toBytes(UUID uuid) {
+    validateNotNull(uuid, "UUID bytes");
+    return toBytes(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits());
+  }
+
+  public static byte[] toBytes(String uuidString) {
+    UUID uuid;
+    try {
+      uuid = UUID.fromString(uuidString);
+    } catch (Exception e) {
+      throw new IllegalArgumentException("Invalid UUID value: '" + uuidString + "'", e);
+    }
+    String canonical = uuid.toString();
+    if (!canonical.equalsIgnoreCase(uuidString)) {
+      throw new IllegalArgumentException(
+          "Invalid UUID value: '" + uuidString + "'. Expected RFC 4122 format: " + canonical);
+    }
+    return toBytes(uuid);
+  }
+
+  public static byte[] toBytes(byte[] uuidBytes) {
+    validateNotNull(uuidBytes, "UUID bytes");
+    validateLength(uuidBytes);
+    return Arrays.copyOf(uuidBytes, uuidBytes.length);
+  }
+
+  public static byte[] toBytes(ByteArray uuidBytes) {
+    validateNotNull(uuidBytes, "UUID bytes");
+    return toBytes(uuidBytes.getBytes());
+  }
+
+  public static byte[] toBytes(Object value) {
+    validateNotNull(value, "UUID bytes");
+    if (value instanceof UUID) {
+      return toBytes((UUID) value);
+    }
+    if (value instanceof byte[]) {
+      return toBytes((byte[]) value);
+    }
+    if (value instanceof ByteArray) {
+      return toBytes((ByteArray) value);
+    }
+    if (value instanceof CharSequence) {
+      return toBytes(value.toString());
+    }
+    throw new IllegalArgumentException(
+        "Cannot convert value: '" + value + "' to UUID bytes, unsupported type: " + value.getClass());
+  }
+
+  public static UUID toUUID(byte[] uuidBytes) {
+    validateNotNull(uuidBytes, "UUID");
+    validateLength(uuidBytes);
+    return toUUID(getMostSignificantBitsInternal(uuidBytes), getLeastSignificantBitsInternal(uuidBytes));
+  }
+
+  public static UUID toUUID(ByteArray uuidBytes) {
+    validateNotNull(uuidBytes, "UUID");
+    return toUUID(uuidBytes.getBytes());
+  }
+
+  public static UUID toUUID(String uuidString) {
+    return toUUID(toBytes(uuidString));
+  }
+
+  public static UUID toUUID(long mostSignificantBits, long leastSignificantBits) {
+    return new UUID(mostSignificantBits, leastSignificantBits);
+  }
+
+  public static UUID toUUID(Object value) {
+    validateNotNull(value, "UUID");
+    if (value instanceof UUID) {
+      return (UUID) value;
+    }
+    if (value instanceof byte[]) {
+      return toUUID((byte[]) value);
+    }
+    if (value instanceof ByteArray) {
+      return toUUID((ByteArray) value);
+    }
+    if (value instanceof CharSequence) {
+      return toUUID(value.toString());
+    }
+    throw new IllegalArgumentException(
+        "Cannot convert value: '" + value + "' to UUID, unsupported type: " + value.getClass());
+  }
+
+  public static String toString(byte[] uuidBytes) {
+    return toUUID(uuidBytes).toString();
+  }
+
+  public static String toString(ByteArray uuidBytes) {
+    return toString(uuidBytes.getBytes());
+  }
+
+  public static String toString(UUID uuid) {
+    return uuid.toString();
+  }
+
+  public static String toString(long mostSignificantBits, long leastSignificantBits) {
+    return toUUID(mostSignificantBits, leastSignificantBits).toString();
+  }
+
+  /**
+   * Immutable UUID key optimized for Pinot execution hot paths.
+   *
+   * <p>The key stores UUID values as two primitive longs to avoid repeated {@code ByteArray} allocation and
+   * byte-by-byte equality/hashing while preserving Pinot's canonical 16-byte representation at the edges.
+   */
+  public static final class UuidKey implements Comparable<UuidKey> {
+    private final long _mostSignificantBits;
+    private final long _leastSignificantBits;
+    private final int _hashCode;
+
+    private UuidKey(long mostSignificantBits, long leastSignificantBits) {
+      _mostSignificantBits = mostSignificantBits;
+      _leastSignificantBits = leastSignificantBits;
+      _hashCode = UuidUtils.hashCode(mostSignificantBits, leastSignificantBits);
+    }
+
+    public static UuidKey fromLongs(long mostSignificantBits, long leastSignificantBits) {
+      return new UuidKey(mostSignificantBits, leastSignificantBits);
+    }
+
+    public static UuidKey fromBytes(byte[] uuidBytes) {
+      validateNotNull(uuidBytes, "UUID");
+      validateLength(uuidBytes);
+      return fromLongs(getMostSignificantBitsInternal(uuidBytes), getLeastSignificantBitsInternal(uuidBytes));
+    }
+
+    public static UuidKey fromByteArray(ByteArray uuidBytes) {
+      validateNotNull(uuidBytes, "UUID");
+      return fromBytes(uuidBytes.getBytes());
+    }
+
+    public static UuidKey fromUUID(UUID uuid) {
+      validateNotNull(uuid, "UUID");
+      return fromLongs(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits());
+    }
+
+    public static UuidKey fromObject(Object value) {
+      validateNotNull(value, "UUID");
+      if (value instanceof UuidKey) {
+        return (UuidKey) value;
+      }
+      if (value instanceof UUID) {
+        return fromUUID((UUID) value);
+      }
+      if (value instanceof byte[]) {
+        return fromBytes((byte[]) value);
+      }
+      if (value instanceof ByteArray) {
+        return fromByteArray((ByteArray) value);
+      }
+      if (value instanceof CharSequence) {
+        return fromUUID(UuidUtils.toUUID(value.toString()));
+      }
+      throw new IllegalArgumentException(
+          "Cannot convert value: '" + value + "' to UUID key, unsupported type: " + value.getClass());
+    }
+
+    public long getMostSignificantBits() {
+      return _mostSignificantBits;
+    }
+
+    public long getLeastSignificantBits() {
+      return _leastSignificantBits;
+    }
+
+    public byte[] toBytes() {
+      return UuidUtils.toBytes(_mostSignificantBits, _leastSignificantBits);
+    }
+
+    public ByteArray toByteArray() {
+      return new ByteArray(toBytes());
+    }
+
+    public UUID toUUID() {
+      return UuidUtils.toUUID(_mostSignificantBits, _leastSignificantBits);
+    }
+
+    @Override
+    public int compareTo(UuidKey other) {
+      return UuidUtils.compare(_mostSignificantBits, _leastSignificantBits, other._mostSignificantBits,
+          other._leastSignificantBits);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+      if (this == other) {
+        return true;
+      }
+      if (!(other instanceof UuidKey)) {
+        return false;
+      }
+      UuidKey otherUuidKey = (UuidKey) other;
+      return UuidUtils.equals(_mostSignificantBits, _leastSignificantBits, otherUuidKey._mostSignificantBits,
+          otherUuidKey._leastSignificantBits);
+    }
+
+    @Override
+    public int hashCode() {
+      return _hashCode;
+    }
+
+    @Override
+    public String toString() {
+      return toUUID().toString();
+    }
+  }
+
+  public static long getMostSignificantBits(byte[] uuidBytes) {
+    validateNotNull(uuidBytes, "UUID");
+    validateLength(uuidBytes);
+    return getMostSignificantBitsInternal(uuidBytes);
+  }
+
+  public static long getLeastSignificantBits(byte[] uuidBytes) {
+    validateNotNull(uuidBytes, "UUID");
+    validateLength(uuidBytes);
+    return getLeastSignificantBitsInternal(uuidBytes);
+  }
+
+  public static boolean equals(byte[] left, byte[] right) {
+    if (left == right) {
+      return true;
+    }
+    validateNotNull(left, "UUID bytes");
+    validateNotNull(right, "UUID bytes");
+    validateLength(left);
+    validateLength(right);
+    return getMostSignificantBitsInternal(left) == getMostSignificantBitsInternal(right)
+        && getLeastSignificantBitsInternal(left) == getLeastSignificantBitsInternal(right);
+  }
+
+  public static boolean equals(ByteArray left, ByteArray right) {
+    if (left == right) {
+      return true;
+    }
+    validateNotNull(left, "UUID bytes");
+    validateNotNull(right, "UUID bytes");
+    return equals(left.getBytes(), right.getBytes());
+  }
+
+  public static boolean equals(long leftMostSignificantBits, long leftLeastSignificantBits,
+      long rightMostSignificantBits, long rightLeastSignificantBits) {
+    return leftMostSignificantBits == rightMostSignificantBits && leftLeastSignificantBits == rightLeastSignificantBits;
+  }
+
+  public static int hashCode(byte[] uuidBytes) {
+    validateNotNull(uuidBytes, "UUID");
+    validateLength(uuidBytes);
+    return hashCode(getMostSignificantBitsInternal(uuidBytes), getLeastSignificantBitsInternal(uuidBytes));
+  }
+
+  public static int hashCode(ByteArray uuidBytes) {
+    validateNotNull(uuidBytes, "UUID");
+    return hashCode(uuidBytes.getBytes());
+  }
+
+  public static int hashCode(long mostSignificantBits, long leastSignificantBits) {
+    return updateHash(updateHash(1, mostSignificantBits), leastSignificantBits);
+  }
+
+  public static int compare(byte[] left, byte[] right) {
+    if (left == right) {
+      return 0;
+    }
+    validateNotNull(left, "UUID bytes");
+    validateNotNull(right, "UUID bytes");
+    validateLength(left);
+    validateLength(right);
+    return compare(getMostSignificantBitsInternal(left), getLeastSignificantBitsInternal(left),
+        getMostSignificantBitsInternal(right), getLeastSignificantBitsInternal(right));
+  }
+
+  public static int compare(ByteArray left, ByteArray right) {
+    if (left == right) {
+      return 0;
+    }
+    validateNotNull(left, "UUID bytes");
+    validateNotNull(right, "UUID bytes");
+    return compare(left.getBytes(), right.getBytes());
+  }
+
+  public static int compare(long leftMostSignificantBits, long leftLeastSignificantBits, long rightMostSignificantBits,
+      long rightLeastSignificantBits) {
+    int mostSignificantBitsComparison = Long.compareUnsigned(leftMostSignificantBits, rightMostSignificantBits);
+    if (mostSignificantBitsComparison != 0) {
+      return mostSignificantBitsComparison;
+    }
+    return Long.compareUnsigned(leftLeastSignificantBits, rightLeastSignificantBits);
+  }
+
+  public static boolean isUuid(String uuidString) {
+    if (uuidString == null) {
+      return false;
+    }
+    try {
+      toBytes(uuidString);
+      return true;
+    } catch (IllegalArgumentException e) {
+      return false;
+    }
+  }
+
+  public static boolean isUuid(byte[] uuidBytes) {
+    if (uuidBytes == null) {
+      return false;
+    }
+    try {
+      validateLength(uuidBytes);
+      return true;
+    } catch (IllegalArgumentException e) {
+      return false;
+    }
+  }
+
+  public static boolean isUuid(ByteArray uuidBytes) {
+    return uuidBytes != null && isUuid(uuidBytes.getBytes());
+  }
+
+  public static boolean isUuid(Object value) {
+    if (value == null) {
+      return false;
+    }
+    if (value instanceof UUID) {
+      return true;
+    }
+    if (value instanceof byte[]) {
+      return isUuid((byte[]) value);
+    }
+    if (value instanceof ByteArray) {
+      return isUuid((ByteArray) value);
+    }
+    if (value instanceof CharSequence) {
+      return isUuid(value.toString());
+    }
+    return false;
+  }
+
+  private static void validateLength(byte[] uuidBytes) {
+    if (uuidBytes.length != UUID_NUM_BYTES) {
+      throw new IllegalArgumentException(
+          "Invalid UUID byte length: " + uuidBytes.length + ", expected: " + UUID_NUM_BYTES);
+    }
+  }
+
+  private static long getMostSignificantBitsInternal(byte[] uuidBytes) {
+    return readLong(uuidBytes, 0);
+  }
+
+  private static long getLeastSignificantBitsInternal(byte[] uuidBytes) {
+    return readLong(uuidBytes, Long.BYTES);
+  }
+
+  private static int updateHash(int hashCode, long value) {
+    for (int shift = Long.SIZE - Byte.SIZE; shift >= 0; shift -= Byte.SIZE) {
+      hashCode = 31 * hashCode + (byte) (value >>> shift);
+    }
+    return hashCode;
+  }
+
+  private static long readLong(byte[] bytes, int offset) {
+    return ((long) bytes[offset] & 0xFF) << 56
+        | ((long) bytes[offset + 1] & 0xFF) << 48
+        | ((long) bytes[offset + 2] & 0xFF) << 40
+        | ((long) bytes[offset + 3] & 0xFF) << 32
+        | ((long) bytes[offset + 4] & 0xFF) << 24
+        | ((long) bytes[offset + 5] & 0xFF) << 16
+        | ((long) bytes[offset + 6] & 0xFF) << 8
+        | (long) bytes[offset + 7] & 0xFF;
+  }
+
+  private static void writeLong(byte[] bytes, int offset, long value) {
+    bytes[offset] = (byte) (value >>> 56);
+    bytes[offset + 1] = (byte) (value >>> 48);
+    bytes[offset + 2] = (byte) (value >>> 40);
+    bytes[offset + 3] = (byte) (value >>> 32);
+    bytes[offset + 4] = (byte) (value >>> 24);
+    bytes[offset + 5] = (byte) (value >>> 16);
+    bytes[offset + 6] = (byte) (value >>> 8);
+    bytes[offset + 7] = (byte) value;
+  }
+
+  private static void validateNotNull(Object value, String targetType) {
+    if (value == null) {
+      throw new IllegalArgumentException("Cannot convert null value to " + targetType);
+    }
+  }
+}

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/data/FieldSpecTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/data/FieldSpecTest.java
@@ -28,7 +28,9 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
+import org.apache.pinot.spi.utils.ByteArray;
 import org.apache.pinot.spi.utils.JsonUtils;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -44,6 +46,8 @@ public class FieldSpecTest {
   private static final long RANDOM_SEED = System.currentTimeMillis();
   private static final Random RANDOM = new Random(RANDOM_SEED);
   private static final String ERROR_MESSAGE = "Random seed is: " + RANDOM_SEED;
+  private static final String UUID_VALUE = "550e8400-e29b-41d4-a716-446655440000";
+  private static final String LARGER_UUID_VALUE = "550e8400-e29b-41d4-a716-446655440001";
 
   /**
    * Test all {@link FieldSpec.DataType}.
@@ -60,6 +64,7 @@ public class FieldSpecTest {
     Assert.assertEquals(STRING.getStoredType(), STRING);
     Assert.assertEquals(JSON.getStoredType(), STRING);
     Assert.assertEquals(BYTES.getStoredType(), BYTES);
+    Assert.assertEquals(UUID.getStoredType(), BYTES);
 
     Assert.assertEquals(INT.size(), Integer.BYTES);
     Assert.assertEquals(LONG.size(), Long.BYTES);
@@ -67,6 +72,7 @@ public class FieldSpecTest {
     Assert.assertEquals(DOUBLE.size(), Double.BYTES);
     Assert.assertEquals(BOOLEAN.size(), Integer.BYTES);
     Assert.assertEquals(TIMESTAMP.size(), Long.BYTES);
+    Assert.assertEquals(UUID.size(), UuidUtils.UUID_NUM_BYTES);
   }
 
   /**
@@ -175,6 +181,11 @@ public class FieldSpecTest {
     Assert.assertEquals(fieldSpec1.hashCode(), fieldSpec2.hashCode());
     Assert.assertEquals(fieldSpec1.getDefaultNullValue(), BigDecimal.ZERO);
 
+    // Single-value BigDecimal type dimension field with numeric default null value.
+    fieldSpec1 = new DimensionFieldSpec("bigDecimalDimension", BIG_DECIMAL, true, -1);
+    Assert.assertEquals(fieldSpec1.getDefaultNullValue(), new BigDecimal("-1"));
+    Assert.assertEquals(fieldSpec1.getDefaultNullValueString(), "-1");
+
     // Metric field with default null value for byte column.
     fieldSpec1 = new MetricFieldSpec();
     fieldSpec1.setName("byteMetric");
@@ -185,6 +196,58 @@ public class FieldSpecTest {
     Assert.assertEquals(fieldSpec1.toJsonObject(), fieldSpec2.toJsonObject());
     Assert.assertEquals(fieldSpec1.hashCode(), fieldSpec2.hashCode());
     Assert.assertEquals(fieldSpec1.getDefaultNullValue(), fieldSpec2.getDefaultNullValue());
+
+    // Single-value uuid type dimension field with default null value.
+    fieldSpec1 = new DimensionFieldSpec();
+    fieldSpec1.setName("uuidDimension");
+    fieldSpec1.setDataType(UUID);
+    fieldSpec1.setDefaultNullValue(UUID_VALUE);
+    fieldSpec2 = new DimensionFieldSpec("uuidDimension", UUID, true, UUID_VALUE);
+    Assert.assertEquals(fieldSpec1, fieldSpec2);
+    Assert.assertEquals(fieldSpec1.toJsonObject(), fieldSpec2.toJsonObject());
+    Assert.assertEquals(fieldSpec1.hashCode(), fieldSpec2.hashCode());
+    assertThat((byte[]) fieldSpec1.getDefaultNullValue()).isEqualTo(UuidUtils.toBytes(UUID_VALUE));
+    Assert.assertEquals(fieldSpec1.getDefaultNullValueString(), UUID_VALUE);
+
+    FieldSpec uuidBytesFieldSpec =
+        new DimensionFieldSpec("uuidBytesDimension", UUID, true, UuidUtils.toBytes(UUID_VALUE));
+    assertThat((byte[]) uuidBytesFieldSpec.getDefaultNullValue()).isEqualTo(UuidUtils.toBytes(UUID_VALUE));
+    Assert.assertEquals(uuidBytesFieldSpec.getDefaultNullValueString(), UUID_VALUE);
+
+    FieldSpec defaultUuidFieldSpec = new DimensionFieldSpec("defaultUuidDimension", UUID, true);
+    byte[] firstDefaultNullValue = (byte[]) defaultUuidFieldSpec.getDefaultNullValue();
+    byte[] secondDefaultNullValue = (byte[]) defaultUuidFieldSpec.getDefaultNullValue();
+    assertThat(firstDefaultNullValue).isEqualTo(UuidUtils.nullUuidBytes());
+    assertThat(secondDefaultNullValue).isEqualTo(UuidUtils.nullUuidBytes());
+    Assert.assertNotSame(firstDefaultNullValue, secondDefaultNullValue);
+    Assert.assertEquals(defaultUuidFieldSpec.getDefaultNullValueString(), "00000000-0000-0000-0000-000000000000");
+  }
+
+  @Test
+  public void testUUIDConversions() {
+    byte[] uuidBytes = UuidUtils.toBytes(UUID_VALUE);
+    byte[] largerUuidBytes = UuidUtils.toBytes(LARGER_UUID_VALUE);
+    String mixedCaseUuidValue = UUID_VALUE.toUpperCase();
+    ByteArray uuidInternal = new ByteArray(uuidBytes);
+
+    assertThat((byte[]) UUID.convert(UUID_VALUE)).isEqualTo(uuidBytes);
+    assertThat((byte[]) UUID.convert(mixedCaseUuidValue)).isEqualTo(uuidBytes);
+    Assert.assertEquals(UUID.convertInternal(UUID_VALUE), uuidInternal);
+    Assert.assertEquals(UUID.convertInternal(mixedCaseUuidValue), uuidInternal);
+    Assert.assertEquals(UUID.toString(uuidBytes), UUID_VALUE);
+    Assert.assertEquals(UUID.toString(uuidInternal), UUID_VALUE);
+    Assert.assertTrue(UUID.equals(uuidBytes, uuidInternal));
+    Assert.assertEquals(UUID.hashCode(uuidBytes), uuidInternal.hashCode());
+    Assert.assertEquals(UUID.compare(uuidBytes, uuidInternal), 0);
+    Assert.assertTrue(UUID.compare(uuidBytes, largerUuidBytes) < 0);
+    Assert.assertTrue(UUID.compare(largerUuidBytes, uuidBytes) > 0);
+  }
+
+  @Test
+  public void testInvalidUUIDConversion() {
+    IllegalArgumentException exception = Assert.expectThrows(IllegalArgumentException.class,
+        () -> UUID.convert("not-a-uuid"));
+    assertThat(exception).hasMessageContaining("Invalid UUID");
   }
 
   /**

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/data/SchemaTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/data/SchemaTest.java
@@ -30,6 +30,7 @@ import org.apache.pinot.spi.data.TimeGranularitySpec.TimeFormat;
 import org.apache.pinot.spi.utils.BytesUtils;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.JsonUtils;
+import org.apache.pinot.spi.utils.UuidUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
@@ -42,6 +43,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SuppressWarnings("deprecation")
 public class SchemaTest {
   public static final Logger LOGGER = LoggerFactory.getLogger(SchemaTest.class);
+  private static final String UUID_VALUE = "550e8400-e29b-41d4-a716-446655440000";
 
   @Test
   public void testValidation() {
@@ -54,6 +56,10 @@ public class SchemaTest {
 
     schemaToValidate = new Schema();
     schemaToValidate.addField(new DimensionFieldSpec("d", FieldSpec.DataType.STRING, true));
+    schemaToValidate.validate();
+
+    schemaToValidate = new Schema();
+    schemaToValidate.addField(new DimensionFieldSpec("uuid", FieldSpec.DataType.UUID, true));
     schemaToValidate.validate();
 
     schemaToValidate = new Schema();
@@ -98,6 +104,24 @@ public class SchemaTest {
     schemaToValidate = new Schema();
     schemaToValidate.addField(new MetricFieldSpec("m", FieldSpec.DataType.BIG_DECIMAL, BigDecimal.ZERO));
     schemaToValidate.validate();
+  }
+
+  @Test
+  public void testUUIDValidationRejectsMV() {
+    Schema schema = new Schema();
+    schema.addField(new DimensionFieldSpec("uuidMv", FieldSpec.DataType.UUID, false));
+
+    IllegalStateException exception = Assert.expectThrows(IllegalStateException.class, schema::validate);
+    assertThat(exception).hasMessageContaining("single-value fields");
+  }
+
+  @Test
+  public void testBigDecimalValidationRejectsMV() {
+    Schema schema = new Schema();
+    schema.addField(new DimensionFieldSpec("bdMv", FieldSpec.DataType.BIG_DECIMAL, false));
+
+    IllegalStateException exception = Assert.expectThrows(IllegalStateException.class, schema::validate);
+    assertThat(exception).hasMessageContaining("single-value fields");
   }
 
   @Test
@@ -354,6 +378,23 @@ public class SchemaTest {
     Assert.assertEquals(actualSchema.getFieldSpecFor("emptyDefault").getDefaultNullValue(), expectedEmptyDefault);
     Assert.assertEquals(actualSchema.getFieldSpecFor("nonEmptyDefault").getDefaultNullValue(), expectedNonEmptyDefault);
 
+    Assert.assertEquals(actualSchema, expectedSchema);
+    Assert.assertEquals(actualSchema.hashCode(), expectedSchema.hashCode());
+  }
+
+  @Test
+  public void testUUIDType()
+      throws Exception {
+    Schema expectedSchema = new Schema();
+    byte[] expectedDefault = UuidUtils.toBytes(UUID_VALUE);
+
+    expectedSchema.setSchemaName("test");
+    expectedSchema.addField(new DimensionFieldSpec("uuidDefault", FieldSpec.DataType.UUID, true, UUID_VALUE));
+
+    String jsonSchema = expectedSchema.toSingleLineJsonString();
+    Schema actualSchema = Schema.fromString(jsonSchema);
+
+    assertThat((byte[]) actualSchema.getFieldSpecFor("uuidDefault").getDefaultNullValue()).isEqualTo(expectedDefault);
     Assert.assertEquals(actualSchema, expectedSchema);
     Assert.assertEquals(actualSchema.hashCode(), expectedSchema.hashCode());
   }

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/utils/UuidUtilsTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/utils/UuidUtilsTest.java
@@ -1,0 +1,184 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.utils;
+
+import java.util.Arrays;
+import java.util.UUID;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+
+/**
+ * Tests for {@link UuidUtils}.
+ */
+public class UuidUtilsTest {
+  private static final String UUID_VALUE = "550e8400-e29b-41d4-a716-446655440000";
+
+  @DataProvider(name = "invalidUuidStrings")
+  public Object[][] invalidUuidStrings() {
+    return new Object[][]{
+        {"550e8400-e29b-41d4-a716-44665544000"},
+        {"550e8400-e29b-41d4-a716-4466554400000"},
+        {"550e8400-e29b-41d4-a716-44665544000g"},
+        {"550e8400e29b41d4a716446655440000"},
+        {""}
+    };
+  }
+
+  @DataProvider(name = "invalidUuidBytes")
+  public Object[][] invalidUuidBytes() {
+    return new Object[][]{
+        {new byte[15]},
+        {new byte[17]}
+    };
+  }
+
+  @Test
+  public void testMixedCaseUuidStringRoundTrips() {
+    String mixedCaseUuid = "550E8400-E29B-41D4-A716-446655440000";
+    byte[] bytes = UuidUtils.toBytes(mixedCaseUuid);
+
+    assertEquals(UuidUtils.toString(bytes), UUID_VALUE);
+    assertEquals(UuidUtils.toUUID(mixedCaseUuid), UUID.fromString(UUID_VALUE));
+  }
+
+  @Test
+  public void testCharSequenceRoundTrips() {
+    CharSequence mixedCaseUuid = new StringBuilder("550E8400-E29B-41D4-A716-446655440000");
+
+    assertEquals(UuidUtils.toBytes(mixedCaseUuid), UuidUtils.toBytes(UUID_VALUE));
+    assertEquals(UuidUtils.toUUID(mixedCaseUuid), UUID.fromString(UUID_VALUE));
+    assertTrue(UuidUtils.isUuid(mixedCaseUuid));
+  }
+
+  @Test(dataProvider = "invalidUuidStrings")
+  public void testRejectsInvalidUuidStrings(String invalidUuid) {
+    Assert.expectThrows(IllegalArgumentException.class, () -> UuidUtils.toBytes(invalidUuid));
+    Assert.expectThrows(IllegalArgumentException.class, () -> UuidUtils.toUUID(invalidUuid));
+    assertFalse(UuidUtils.isUuid(invalidUuid));
+  }
+
+  @Test(dataProvider = "invalidUuidBytes")
+  public void testRejectsInvalidUuidBytes(byte[] invalidBytes) {
+    Assert.expectThrows(IllegalArgumentException.class, () -> UuidUtils.toBytes(invalidBytes));
+    Assert.expectThrows(IllegalArgumentException.class, () -> UuidUtils.toUUID(invalidBytes));
+    assertFalse(UuidUtils.isUuid(invalidBytes));
+  }
+
+  @Test
+  public void testIsUuidAcceptsValidStringAndBytes() {
+    byte[] uuidBytes = UuidUtils.toBytes(UUID_VALUE);
+
+    assertTrue(UuidUtils.isUuid(UUID_VALUE));
+    assertTrue(UuidUtils.isUuid(uuidBytes));
+    assertTrue(UuidUtils.isUuid(new ByteArray(uuidBytes)));
+  }
+
+  @Test
+  public void testIsUuidRejectsNull() {
+    assertFalse(UuidUtils.isUuid((String) null));
+    assertFalse(UuidUtils.isUuid((byte[]) null));
+    assertFalse(UuidUtils.isUuid((Object) null));
+  }
+
+  @Test
+  public void testToBytesRejectsNull() {
+    IllegalArgumentException exception =
+        Assert.expectThrows(IllegalArgumentException.class, () -> UuidUtils.toBytes((Object) null));
+    assertEquals(exception.getMessage(), "Cannot convert null value to UUID bytes");
+    exception = Assert.expectThrows(IllegalArgumentException.class, () -> UuidUtils.toBytes((ByteArray) null));
+    assertEquals(exception.getMessage(), "Cannot convert null value to UUID bytes");
+  }
+
+  @Test
+  public void testToUuidRejectsNull() {
+    IllegalArgumentException exception =
+        Assert.expectThrows(IllegalArgumentException.class, () -> UuidUtils.toUUID((Object) null));
+    assertEquals(exception.getMessage(), "Cannot convert null value to UUID");
+    exception = Assert.expectThrows(IllegalArgumentException.class, () -> UuidUtils.toUUID((ByteArray) null));
+    assertEquals(exception.getMessage(), "Cannot convert null value to UUID");
+  }
+
+  @Test
+  public void testNullUuidBytesReturnsDefensiveCopy() {
+    byte[] first = UuidUtils.nullUuidBytes();
+    byte[] second = UuidUtils.nullUuidBytes();
+
+    first[0] = 1;
+    assertEquals(second, new byte[UuidUtils.UUID_NUM_BYTES]);
+    assertEquals(UuidUtils.nilUuidBytes(), new byte[UuidUtils.UUID_NUM_BYTES]);
+  }
+
+  @Test
+  public void testComparePreservesUnsignedByteOrdering() {
+    byte[] larger = UuidUtils.toBytes("80000000-0000-0000-0000-000000000000");
+    byte[] smaller = UuidUtils.toBytes("7fffffff-ffff-ffff-ffff-ffffffffffff");
+
+    assertTrue(ByteArray.compare(larger, smaller) > 0);
+    assertEquals(UuidUtils.compare(larger, smaller), ByteArray.compare(larger, smaller));
+    assertEquals(UuidUtils.compare(smaller, larger), ByteArray.compare(smaller, larger));
+  }
+
+  @Test
+  public void testUuidEqualityHashAndBitExtraction() {
+    UUID uuid = UUID.fromString(UUID_VALUE);
+    byte[] uuidBytes = UuidUtils.toBytes(uuid);
+
+    assertEquals(UuidUtils.getMostSignificantBits(uuidBytes), uuid.getMostSignificantBits());
+    assertEquals(UuidUtils.getLeastSignificantBits(uuidBytes), uuid.getLeastSignificantBits());
+    assertTrue(UuidUtils.equals(uuidBytes, Arrays.copyOf(uuidBytes, uuidBytes.length)));
+    assertTrue(UuidUtils.equals(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits(),
+        uuid.getMostSignificantBits(), uuid.getLeastSignificantBits()));
+    assertEquals(UuidUtils.hashCode(uuidBytes), new ByteArray(uuidBytes).hashCode());
+    assertEquals(UuidUtils.hashCode(uuid.getMostSignificantBits(), uuid.getLeastSignificantBits()),
+        new ByteArray(uuidBytes).hashCode());
+  }
+
+  @Test
+  public void testUuidKeyNormalizesRepresentations() {
+    UUID uuid = UUID.fromString(UUID_VALUE);
+    byte[] uuidBytes = UuidUtils.toBytes(uuid);
+    UuidUtils.UuidKey uuidKeyFromBytes = UuidUtils.UuidKey.fromBytes(uuidBytes);
+    UuidUtils.UuidKey uuidKeyFromObject = UuidUtils.UuidKey.fromObject(new ByteArray(uuidBytes));
+
+    assertEquals(uuidKeyFromBytes, UuidUtils.UuidKey.fromUUID(uuid));
+    assertEquals(uuidKeyFromBytes, uuidKeyFromObject);
+    assertEquals(uuidKeyFromBytes.hashCode(), UuidUtils.hashCode(uuidBytes));
+    assertEquals(uuidKeyFromBytes.toByteArray(), new ByteArray(uuidBytes));
+    assertEquals(uuidKeyFromBytes.toString(), UUID_VALUE);
+  }
+
+  @Test
+  public void testLongPairHelpersRoundTrip() {
+    UUID uuid = UUID.fromString(UUID_VALUE);
+    long mostSignificantBits = uuid.getMostSignificantBits();
+    long leastSignificantBits = uuid.getLeastSignificantBits();
+
+    assertEquals(UuidUtils.toBytes(mostSignificantBits, leastSignificantBits), UuidUtils.toBytes(uuid));
+    assertEquals(UuidUtils.toUUID(mostSignificantBits, leastSignificantBits), uuid);
+    assertEquals(UuidUtils.toString(mostSignificantBits, leastSignificantBits), UUID_VALUE);
+    assertEquals(UuidUtils.UuidKey.fromLongs(mostSignificantBits, leastSignificantBits), UuidUtils.UuidKey.fromUUID(
+        uuid));
+  }
+}


### PR DESCRIPTION
## Summary

- In `ServerPlanRequestUtils`, the `BYTES` branch of the IN-predicate builder iterates sorted `ByteArray` values and emits raw-bytes literals via `getLiteralExpression(bytes[])`.
- For UUID columns (stored internally as 16-byte BYTES), this sends raw bytes to the broker, but the broker plan represents UUID values as canonical RFC 4122 string literals. The mismatch causes incorrect query results when filtering a UUID column through the gRPC / multi-stage query engine path.
- Fix: detect `ColumnDataType.UUID` and call `UuidUtils.toString()` to emit the canonical UUID string literal.

**Depends on:** #18140 (adds `FieldSpec.DataType.UUID`, `DataSchema.ColumnDataType.UUID`, and `UuidUtils`)

## Changes

- `ServerPlanRequestUtils.java` — 6-line fix in the BYTES branch of the IN-predicate builder

## Test plan

- [ ] Covered by `UuidTypeTest` and `UuidTypeRealtimeTest` integration tests added in #18140, which exercise UUID equality and IN predicates through the MSQE path

🤖 Generated with [Claude Code](https://claude.com/claude-code)