### PR TITLE
Add support for polymorphic scalar functions in ingestion-time transform functions

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/evaluator/FunctionEvaluatorFactory.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/evaluator/FunctionEvaluatorFactory.java
@@ -20,6 +20,7 @@ package org.apache.pinot.common.evaluator;
 
 import javax.annotation.Nullable;
 import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.TimeFieldSpec;
 import org.apache.pinot.spi.data.TimeGranularitySpec;
 import org.apache.pinot.spi.function.FunctionEvaluator;
@@ -36,20 +37,24 @@ public class FunctionEvaluatorFactory {
   private FunctionEvaluatorFactory() {
   }
 
+  @Nullable
+  public static FunctionEvaluator getExpressionEvaluator(FieldSpec fieldSpec) {
+    return getExpressionEvaluator(fieldSpec, null);
+  }
+
   /**
-   * Creates the {@link FunctionEvaluator} for the given field spec
+   * Creates the {@link FunctionEvaluator} for the given field spec with an optional schema for type-aware function
+   * resolution.
    *
    * 1. If transform expression is defined, use it to create the appropriate {@link FunctionEvaluator}
    * 2. For TIME column, if conversion is needed, {@link TimeSpecFunctionEvaluator} for backward compatible handling
-   * of time spec. This
-   * is needed until we migrate to {@link org.apache.pinot.spi.data.DateTimeFieldSpec}
+   * of time spec. This is needed until we migrate to {@link org.apache.pinot.spi.data.DateTimeFieldSpec}
    * 3. For columns ending with __KEYS or __VALUES (used for interpreting Map column in Avro), create default groovy
-   * functions for
-   * handing the Map
+   * functions for handling the Map
    * 4. Return null, if none of the above
    */
   @Nullable
-  public static FunctionEvaluator getExpressionEvaluator(FieldSpec fieldSpec) {
+  public static FunctionEvaluator getExpressionEvaluator(FieldSpec fieldSpec, @Nullable Schema schema) {
     FunctionEvaluator functionEvaluator = null;
 
     String columnName = fieldSpec.getName();
@@ -61,7 +66,7 @@ public class FunctionEvaluatorFactory {
 
       // if transform function expression present, use it to generate function evaluator
       try {
-        functionEvaluator = getExpressionEvaluator(transformExpression);
+        functionEvaluator = getExpressionEvaluator(transformExpression, schema);
       } catch (Exception e) {
         throw new IllegalStateException(
             "Caught exception while constructing expression evaluator for transform expression: " + transformExpression
@@ -88,22 +93,30 @@ public class FunctionEvaluatorFactory {
       // for backward compatible handling of Map type (currently only in Avro)
       String sourceMapName = columnName.substring(0, columnName.length() - MAP_KEY_COLUMN_SUFFIX.length());
       String defaultMapKeysTransformExpression = getDefaultMapKeysTransformExpression(sourceMapName);
-      functionEvaluator = getExpressionEvaluator(defaultMapKeysTransformExpression);
+      functionEvaluator = getExpressionEvaluator(defaultMapKeysTransformExpression, schema);
     } else if (columnName.endsWith(MAP_VALUE_COLUMN_SUFFIX)) {
       // for backward compatible handling of Map type in avro (currently only in Avro)
       String sourceMapName =
           columnName.substring(0, columnName.length() - MAP_VALUE_COLUMN_SUFFIX.length());
       String defaultMapValuesTransformExpression = getDefaultMapValuesTransformExpression(sourceMapName);
-      functionEvaluator = getExpressionEvaluator(defaultMapValuesTransformExpression);
+      functionEvaluator = getExpressionEvaluator(defaultMapValuesTransformExpression, schema);
     }
     return functionEvaluator;
   }
 
   public static FunctionEvaluator getExpressionEvaluator(String transformExpression) {
+    return getExpressionEvaluator(transformExpression, null);
+  }
+
+  /**
+   * Creates a {@link FunctionEvaluator} for the given transform expression with an optional schema for type-aware
+   * function resolution.
+   */
+  public static FunctionEvaluator getExpressionEvaluator(String transformExpression, @Nullable Schema schema) {
     if (isGroovyExpression(transformExpression)) {
       return new GroovyFunctionEvaluator(transformExpression);
     } else {
-      return new InbuiltFunctionEvaluator(transformExpression);
+      return new InbuiltFunctionEvaluator(transformExpression, schema);
     }
   }
 

--- a/pinot-common/src/main/java/org/apache/pinot/common/evaluator/InbuiltFunctionEvaluator.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/evaluator/InbuiltFunctionEvaluator.java
@@ -19,16 +19,23 @@
 package org.apache.pinot.common.evaluator;
 
 import com.google.common.base.Preconditions;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.function.FunctionInfo;
 import org.apache.pinot.common.function.FunctionInvoker;
 import org.apache.pinot.common.function.FunctionRegistry;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.FunctionContext;
+import org.apache.pinot.common.request.context.LiteralContext;
 import org.apache.pinot.common.request.context.RequestContextUtils;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.function.FunctionEvaluator;
 
@@ -50,18 +57,29 @@ public class InbuiltFunctionEvaluator implements FunctionEvaluator {
   private final String _functionExpression;
 
   public InbuiltFunctionEvaluator(String functionExpression) {
-    _functionExpression = functionExpression;
-    _arguments = new ArrayList<>();
-    _rootNode = planExecution(RequestContextUtils.getExpression(functionExpression));
+    this(functionExpression, null);
   }
 
-  private ExecutableNode planExecution(ExpressionContext expression) {
+  /**
+   * Creates an evaluator with an optional schema for type-aware function resolution. When the schema is provided,
+   * polymorphic scalar functions (e.g. comparison operators) are resolved using argument data types, selecting
+   * type-specific implementations (e.g. {@code stringEquals} instead of {@code doubleEqualsWithTolerance}).
+   */
+  public InbuiltFunctionEvaluator(String functionExpression, @Nullable Schema schema) {
+    _functionExpression = functionExpression;
+    _arguments = new ArrayList<>();
+    _rootNode = planExecution(RequestContextUtils.getExpression(functionExpression), schema);
+  }
+
+  private ExecutableNode planExecution(ExpressionContext expression, @Nullable Schema schema) {
     switch (expression.getType()) {
       case LITERAL:
-        return new ConstantExecutionNode(expression.getLiteral().getValue());
+        LiteralContext literal = expression.getLiteral();
+        return new ConstantExecutionNode(literal.getValue(), resolveLiteralType(literal));
       case IDENTIFIER:
         String columnName = expression.getIdentifier();
-        ColumnExecutionNode columnExecutionNode = new ColumnExecutionNode(columnName, _arguments.size());
+        ColumnExecutionNode columnExecutionNode =
+            new ColumnExecutionNode(columnName, _arguments.size(), resolveColumnType(columnName, schema));
         _arguments.add(columnName);
         return columnExecutionNode;
       case FUNCTION:
@@ -70,7 +88,7 @@ public class InbuiltFunctionEvaluator implements FunctionEvaluator {
         int numArguments = arguments.size();
         ExecutableNode[] childNodes = new ExecutableNode[numArguments];
         for (int i = 0; i < numArguments; i++) {
-          childNodes[i] = planExecution(arguments.get(i));
+          childNodes[i] = planExecution(arguments.get(i), schema);
         }
         String functionName = function.getFunctionName();
         String canonicalName = FunctionRegistry.canonicalize(functionName);
@@ -85,25 +103,102 @@ public class InbuiltFunctionEvaluator implements FunctionEvaluator {
           case "arrayvalueconstructor":
             Object[] values = new Object[numArguments];
             int i = 0;
-            for (ExpressionContext literal : arguments) {
-              values[i++] = literal.getLiteral().getValue();
+            for (ExpressionContext lit : arguments) {
+              values[i++] = lit.getLiteral().getValue();
             }
             return new ArrayConstantExecutionNode(values);
           default:
-            FunctionInfo functionInfo = FunctionRegistry.lookupFunctionInfo(canonicalName, numArguments);
-            if (functionInfo == null) {
-              if (FunctionRegistry.contains(canonicalName)) {
-                throw new IllegalStateException(
-                    String.format("Unsupported function: %s with %d arguments", functionName, numArguments));
-              } else {
-                throw new IllegalStateException(String.format("Unsupported function: %s", functionName));
-              }
-            }
+            FunctionInfo functionInfo = resolveFunction(canonicalName, functionName, childNodes, numArguments);
             return new FunctionExecutionNode(functionInfo, childNodes);
         }
       default:
         throw new IllegalStateException();
     }
+  }
+
+  /**
+   * Resolves a scalar function, preferring polymorphic (type-aware) lookup when argument types are available,
+   * and falling back to arity-based lookup otherwise.
+   */
+  private FunctionInfo resolveFunction(String canonicalName, String functionName, ExecutableNode[] childNodes,
+      int numArguments) {
+    // Try polymorphic lookup when all argument types are known
+    ColumnDataType[] argumentTypes = new ColumnDataType[numArguments];
+    boolean allTypesKnown = true;
+    for (int i = 0; i < numArguments; i++) {
+      argumentTypes[i] = childNodes[i].getResultType();
+      if (argumentTypes[i] == null) {
+        allTypesKnown = false;
+        break;
+      }
+    }
+    if (allTypesKnown) {
+      FunctionInfo functionInfo = FunctionRegistry.lookupFunctionInfo(canonicalName, argumentTypes);
+      if (functionInfo != null) {
+        return functionInfo;
+      }
+    }
+    // Fall back to arity-based lookup
+    FunctionInfo functionInfo = FunctionRegistry.lookupFunctionInfo(canonicalName, numArguments);
+    if (functionInfo == null) {
+      if (FunctionRegistry.contains(canonicalName)) {
+        throw new IllegalStateException(
+            String.format("Unsupported function: %s with %d arguments", functionName, numArguments));
+      } else {
+        throw new IllegalStateException(String.format("Unsupported function: %s", functionName));
+      }
+    }
+    return functionInfo;
+  }
+
+  @Nullable
+  private static ColumnDataType resolveColumnType(String columnName, @Nullable Schema schema) {
+    if (schema == null) {
+      return null;
+    }
+    FieldSpec fieldSpec = schema.getFieldSpecFor(columnName);
+    if (fieldSpec == null) {
+      return null;
+    }
+    return ColumnDataType.fromDataType(fieldSpec.getDataType(), fieldSpec.isSingleValueField());
+  }
+
+  @Nullable
+  static ColumnDataType resolveLiteralType(LiteralContext literal) {
+    DataType type = literal.getType();
+    if (type == DataType.UNKNOWN) {
+      return null;
+    }
+    return ColumnDataType.fromDataType(type, literal.isSingleValue());
+  }
+
+  @Nullable
+  static ColumnDataType resolveReturnType(Class<?> clazz) {
+    if (clazz == boolean.class || clazz == Boolean.class) {
+      return ColumnDataType.BOOLEAN;
+    }
+    if (clazz == int.class || clazz == Integer.class) {
+      return ColumnDataType.INT;
+    }
+    if (clazz == long.class || clazz == Long.class) {
+      return ColumnDataType.LONG;
+    }
+    if (clazz == float.class || clazz == Float.class) {
+      return ColumnDataType.FLOAT;
+    }
+    if (clazz == double.class || clazz == Double.class) {
+      return ColumnDataType.DOUBLE;
+    }
+    if (clazz == String.class) {
+      return ColumnDataType.STRING;
+    }
+    if (clazz == BigDecimal.class) {
+      return ColumnDataType.BIG_DECIMAL;
+    }
+    if (clazz == byte[].class) {
+      return ColumnDataType.BYTES;
+    }
+    return null;
   }
 
   @Override
@@ -131,6 +226,13 @@ public class InbuiltFunctionEvaluator implements FunctionEvaluator {
     Object execute(GenericRow row);
 
     Object execute(Object[] values);
+
+    /**
+     * Returns the result data type of this node, or {@code null} if the type cannot be determined. Used during
+     * planning to enable polymorphic (type-aware) function resolution.
+     */
+    @Nullable
+    ColumnDataType getResultType();
   }
 
   private static class NotExecutionNode implements ExecutableNode {
@@ -158,6 +260,12 @@ public class InbuiltFunctionEvaluator implements FunctionEvaluator {
       } else {
         return !res;
       }
+    }
+
+    @Nullable
+    @Override
+    public ColumnDataType getResultType() {
+      return ColumnDataType.BOOLEAN;
     }
   }
 
@@ -203,6 +311,12 @@ public class InbuiltFunctionEvaluator implements FunctionEvaluator {
 
       return hasNull ? null : false;
     }
+
+    @Nullable
+    @Override
+    public ColumnDataType getResultType() {
+      return ColumnDataType.BOOLEAN;
+    }
   }
 
   private static class AndExecutionNode implements ExecutableNode {
@@ -247,6 +361,12 @@ public class InbuiltFunctionEvaluator implements FunctionEvaluator {
 
       return hasNull ? null : true;
     }
+
+    @Nullable
+    @Override
+    public ColumnDataType getResultType() {
+      return ColumnDataType.BOOLEAN;
+    }
   }
 
   private static class FunctionExecutionNode implements ExecutableNode {
@@ -254,12 +374,15 @@ public class InbuiltFunctionEvaluator implements FunctionEvaluator {
     final FunctionInfo _functionInfo;
     final ExecutableNode[] _argumentNodes;
     final Object[] _arguments;
+    @Nullable
+    final ColumnDataType _resultType;
 
     FunctionExecutionNode(FunctionInfo functionInfo, ExecutableNode[] argumentNodes) {
       _functionInvoker = new FunctionInvoker(functionInfo);
       _functionInfo = functionInfo;
       _argumentNodes = argumentNodes;
       _arguments = new Object[_argumentNodes.length];
+      _resultType = resolveReturnType(functionInfo.getMethod().getReturnType());
     }
 
     @Override
@@ -314,6 +437,12 @@ public class InbuiltFunctionEvaluator implements FunctionEvaluator {
       }
     }
 
+    @Nullable
+    @Override
+    public ColumnDataType getResultType() {
+      return _resultType;
+    }
+
     @Override
     public String toString() {
       return _functionInvoker.getMethod().getName() + '(' + StringUtils.join(_argumentNodes, ',') + ')';
@@ -322,9 +451,12 @@ public class InbuiltFunctionEvaluator implements FunctionEvaluator {
 
   private static class ConstantExecutionNode implements ExecutableNode {
     final Object _value;
+    @Nullable
+    final ColumnDataType _resultType;
 
-    ConstantExecutionNode(Object value) {
+    ConstantExecutionNode(Object value, @Nullable ColumnDataType resultType) {
       _value = value;
+      _resultType = resultType;
     }
 
     @Override
@@ -335,6 +467,12 @@ public class InbuiltFunctionEvaluator implements FunctionEvaluator {
     @Override
     public Object execute(Object[] values) {
       return _value;
+    }
+
+    @Nullable
+    @Override
+    public ColumnDataType getResultType() {
+      return _resultType;
     }
 
     @Override
@@ -360,6 +498,12 @@ public class InbuiltFunctionEvaluator implements FunctionEvaluator {
       return _value;
     }
 
+    @Nullable
+    @Override
+    public ColumnDataType getResultType() {
+      return null;
+    }
+
     @Override
     public String toString() {
       return String.format("'%s'", Arrays.toString(_value));
@@ -369,10 +513,13 @@ public class InbuiltFunctionEvaluator implements FunctionEvaluator {
   private static class ColumnExecutionNode implements ExecutableNode {
     final String _column;
     final int _id;
+    @Nullable
+    final ColumnDataType _resultType;
 
-    ColumnExecutionNode(String column, int id) {
+    ColumnExecutionNode(String column, int id, @Nullable ColumnDataType resultType) {
       _column = column;
       _id = id;
+      _resultType = resultType;
     }
 
     @Override
@@ -383,6 +530,12 @@ public class InbuiltFunctionEvaluator implements FunctionEvaluator {
     @Override
     public Object execute(Object[] values) {
       return values[_id];
+    }
+
+    @Nullable
+    @Override
+    public ColumnDataType getResultType() {
+      return _resultType;
     }
 
     @Override

--- a/pinot-common/src/main/java/org/apache/pinot/common/evaluator/InbuiltFunctionEvaluator.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/evaluator/InbuiltFunctionEvaluator.java
@@ -106,7 +106,7 @@ public class InbuiltFunctionEvaluator implements FunctionEvaluator {
             for (ExpressionContext lit : arguments) {
               values[i++] = lit.getLiteral().getValue();
             }
-            return new ArrayConstantExecutionNode(values);
+            return new ArrayConstantExecutionNode(values, resolveArrayLiteralType(arguments));
           default:
             FunctionInfo functionInfo = resolveFunction(canonicalName, functionName, childNodes, numArguments);
             return new FunctionExecutionNode(functionInfo, childNodes);
@@ -170,6 +170,44 @@ public class InbuiltFunctionEvaluator implements FunctionEvaluator {
       return null;
     }
     return ColumnDataType.fromDataType(type, literal.isSingleValue());
+  }
+
+  /**
+   * Infers the {@link ColumnDataType} of an ARRAY[...] literal by unifying the element types. Returns {@code null}
+   * when the type cannot be determined — mixed element types, non-literal arguments, nested arrays, all-null or empty
+   * arrays, or element types that do not have an array variant (e.g. BIG_DECIMAL, JSON, MAP).
+   */
+  @Nullable
+  static ColumnDataType resolveArrayLiteralType(List<ExpressionContext> arguments) {
+    DataType elementType = null;
+    for (ExpressionContext arg : arguments) {
+      if (arg.getType() != ExpressionContext.Type.LITERAL) {
+        return null;
+      }
+      LiteralContext lit = arg.getLiteral();
+      if (!lit.isSingleValue()) {
+        return null;
+      }
+      DataType type = lit.getType();
+      if (type == DataType.UNKNOWN) {
+        // Null literal — skip for inference and let non-null siblings determine the element type.
+        continue;
+      }
+      if (elementType == null) {
+        elementType = type;
+      } else if (elementType != type) {
+        return null;
+      }
+    }
+    if (elementType == null) {
+      return null;
+    }
+    try {
+      return ColumnDataType.fromDataType(elementType, false);
+    } catch (IllegalStateException e) {
+      // The element type has no multi-valued variant (e.g. BIG_DECIMAL, JSON, MAP).
+      return null;
+    }
   }
 
   @Nullable
@@ -483,9 +521,12 @@ public class InbuiltFunctionEvaluator implements FunctionEvaluator {
 
   private static class ArrayConstantExecutionNode implements ExecutableNode {
     final Object[] _value;
+    @Nullable
+    final ColumnDataType _resultType;
 
-    ArrayConstantExecutionNode(Object[] value) {
+    ArrayConstantExecutionNode(Object[] value, @Nullable ColumnDataType resultType) {
       _value = value;
+      _resultType = resultType;
     }
 
     @Override
@@ -501,7 +542,7 @@ public class InbuiltFunctionEvaluator implements FunctionEvaluator {
     @Nullable
     @Override
     public ColumnDataType getResultType() {
-      return null;
+      return _resultType;
     }
 
     @Override

--- a/pinot-common/src/test/java/org/apache/pinot/common/evaluator/InbuiltFunctionEvaluatorTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/evaluator/InbuiltFunctionEvaluatorTest.java
@@ -21,6 +21,8 @@ package org.apache.pinot.common.evaluator;
 import java.util.Collections;
 import org.apache.pinot.common.function.FunctionUtils;
 import org.apache.pinot.common.utils.PinotDataType;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
@@ -252,5 +254,303 @@ public class InbuiltFunctionEvaluatorTest {
     longRow.putValue("value", 1L << 40);
     longRow.putValue("shift", 40);
     assertEquals(new InbuiltFunctionEvaluator("bitExtract(value, shift)").evaluate(longRow), 1);
+  }
+
+  // ---- Tests for polymorphic function dispatch with schema ----
+
+  /**
+   * The original reported bug: CASE WHEN stringCol = 'literal' THEN ... ELSE ... END
+   * Without schema, this resolves to doubleEqualsWithTolerance and fails on strings.
+   * With schema, it should resolve to stringEquals.
+   */
+  @Test
+  public void testStringEqualsWithSchema() {
+    Schema schema = new Schema.SchemaBuilder()
+        .addSingleValueDimension("lastName", FieldSpec.DataType.STRING)
+        .build();
+    String expression = "CASE WHEN lastName = 'Brown' THEN 'Brown1' ELSE lastName END";
+    InbuiltFunctionEvaluator evaluator = new InbuiltFunctionEvaluator(expression, schema);
+
+    GenericRow row = new GenericRow();
+    row.putValue("lastName", "Martinez");
+    // Without the fix, this would throw: "For input string: Martinez" trying to convert to double
+    assertEquals(evaluator.evaluate(row), "Martinez");
+
+    row.putValue("lastName", "Brown");
+    assertEquals(evaluator.evaluate(row), "Brown1");
+  }
+
+  /**
+   * Test that int equality works correctly with schema (should use intEquals, not doubleEqualsWithTolerance).
+   */
+  @Test
+  public void testIntEqualsWithSchema() {
+    Schema schema = new Schema.SchemaBuilder()
+        .addSingleValueDimension("status", FieldSpec.DataType.INT)
+        .build();
+    String expression = "CASE WHEN status = 1 THEN 'active' ELSE 'inactive' END";
+    InbuiltFunctionEvaluator evaluator = new InbuiltFunctionEvaluator(expression, schema);
+
+    GenericRow row = new GenericRow();
+    row.putValue("status", 1);
+    assertEquals(evaluator.evaluate(row), "active");
+
+    row.putValue("status", 0);
+    assertEquals(evaluator.evaluate(row), "inactive");
+  }
+
+  /**
+   * Test that string not-equals works correctly with schema.
+   */
+  @Test
+  public void testStringNotEqualsWithSchema() {
+    Schema schema = new Schema.SchemaBuilder()
+        .addSingleValueDimension("city", FieldSpec.DataType.STRING)
+        .build();
+    String expression = "CASE WHEN city != 'NYC' THEN 'other' ELSE 'nyc' END";
+    InbuiltFunctionEvaluator evaluator = new InbuiltFunctionEvaluator(expression, schema);
+
+    GenericRow row = new GenericRow();
+    row.putValue("city", "NYC");
+    assertEquals(evaluator.evaluate(row), "nyc");
+
+    row.putValue("city", "Boston");
+    assertEquals(evaluator.evaluate(row), "other");
+  }
+
+  /**
+   * Test string greater-than comparison with schema.
+   */
+  @Test
+  public void testStringGreaterThanWithSchema() {
+    Schema schema = new Schema.SchemaBuilder()
+        .addSingleValueDimension("name", FieldSpec.DataType.STRING)
+        .build();
+    String expression = "CASE WHEN name > 'M' THEN 'after_M' ELSE 'before_M' END";
+    InbuiltFunctionEvaluator evaluator = new InbuiltFunctionEvaluator(expression, schema);
+
+    GenericRow row = new GenericRow();
+    row.putValue("name", "Zebra");
+    assertEquals(evaluator.evaluate(row), "after_M");
+
+    row.putValue("name", "Alpha");
+    assertEquals(evaluator.evaluate(row), "before_M");
+  }
+
+  /**
+   * Test string less-than-or-equal comparison with schema.
+   */
+  @Test
+  public void testStringLessThanOrEqualWithSchema() {
+    Schema schema = new Schema.SchemaBuilder()
+        .addSingleValueDimension("grade", FieldSpec.DataType.STRING)
+        .build();
+    String expression = "CASE WHEN grade <= 'C' THEN 'pass' ELSE 'fail' END";
+    InbuiltFunctionEvaluator evaluator = new InbuiltFunctionEvaluator(expression, schema);
+
+    GenericRow row = new GenericRow();
+    row.putValue("grade", "B");
+    assertEquals(evaluator.evaluate(row), "pass");
+
+    row.putValue("grade", "D");
+    assertEquals(evaluator.evaluate(row), "fail");
+  }
+
+  /**
+   * Test nested function whose return type is int: strcmp returns int, so equals resolves to intEquals.
+   */
+  @Test
+  public void testNestedIntReturningFunctionInComparison() {
+    Schema schema = new Schema.SchemaBuilder()
+        .addSingleValueDimension("name", FieldSpec.DataType.STRING)
+        .build();
+    String expression = "CASE WHEN strcmp(name, 'Brown') = 0 THEN 'match' ELSE 'no_match' END";
+    InbuiltFunctionEvaluator evaluator = new InbuiltFunctionEvaluator(expression, schema);
+
+    GenericRow row = new GenericRow();
+    row.putValue("name", "Brown");
+    assertEquals(evaluator.evaluate(row), "match");
+
+    row.putValue("name", "Smith");
+    assertEquals(evaluator.evaluate(row), "no_match");
+  }
+
+  /**
+   * Test nested function whose return type is String: upper returns String, so equals resolves to stringEquals.
+   * This is the key nested-function case for the original bug — the return type of the inner function must
+   * propagate through the execution tree so that the outer comparison uses the correct type-specific method.
+   */
+  @Test
+  public void testNestedStringReturningFunctionInComparison() {
+    Schema schema = new Schema.SchemaBuilder()
+        .addSingleValueDimension("name", FieldSpec.DataType.STRING)
+        .build();
+    String expression = "CASE WHEN upper(name) = 'BROWN' THEN 'match' ELSE 'no_match' END";
+    InbuiltFunctionEvaluator evaluator = new InbuiltFunctionEvaluator(expression, schema);
+
+    GenericRow row = new GenericRow();
+    row.putValue("name", "Brown");
+    assertEquals(evaluator.evaluate(row), "match");
+
+    row.putValue("name", "Smith");
+    assertEquals(evaluator.evaluate(row), "no_match");
+  }
+
+  /**
+   * Test deeply nested functions: reverse(upper(name)) = 'NWORB'.
+   * The return type must propagate through multiple levels of nesting.
+   */
+  @Test
+  public void testDeeplyNestedFunctionInComparison() {
+    Schema schema = new Schema.SchemaBuilder()
+        .addSingleValueDimension("name", FieldSpec.DataType.STRING)
+        .build();
+    String expression = "CASE WHEN reverse(upper(name)) = 'NWORB' THEN 'match' ELSE 'no_match' END";
+    InbuiltFunctionEvaluator evaluator = new InbuiltFunctionEvaluator(expression, schema);
+
+    GenericRow row = new GenericRow();
+    row.putValue("name", "Brown");
+    assertEquals(evaluator.evaluate(row), "match");
+
+    row.putValue("name", "Smith");
+    assertEquals(evaluator.evaluate(row), "no_match");
+  }
+
+  /**
+   * Test that a nested CASE WHEN whose result is used in a comparison falls back gracefully.
+   * caseWhen returns Object, so its result type is null — the outer equals falls back to arity-based lookup.
+   * This means the outer comparison uses doubleEqualsWithTolerance, which will fail for string values.
+   * This is a known limitation: Object-returning functions (caseWhen, coalesce, etc.) cannot propagate
+   * type information since their return type depends on runtime values, not static analysis.
+   */
+  @Test
+  public void testNestedCaseWhenInComparisonFallsBackToArityLookup() {
+    Schema schema = new Schema.SchemaBuilder()
+        .addSingleValueDimension("a", FieldSpec.DataType.INT)
+        .addSingleValueDimension("b", FieldSpec.DataType.INT)
+        .build();
+    // Inner CASE WHEN returns Object → outer = uses arity-based lookup → doubleEqualsWithTolerance.
+    // This works for numeric types since FunctionInvoker converts int to double.
+    String expression = "CASE WHEN (CASE WHEN a = 1 THEN b ELSE 0 END) = 42 THEN 'match' ELSE 'no_match' END";
+    InbuiltFunctionEvaluator evaluator = new InbuiltFunctionEvaluator(expression, schema);
+
+    GenericRow row = new GenericRow();
+    row.putValue("a", 1);
+    row.putValue("b", 42);
+    assertEquals(evaluator.evaluate(row), "match");
+
+    row.putValue("a", 1);
+    row.putValue("b", 99);
+    assertEquals(evaluator.evaluate(row), "no_match");
+  }
+
+  /**
+   * Test that the schema-aware evaluator handles null values correctly.
+   */
+  @Test
+  public void testStringEqualsWithNullValueAndSchema() {
+    Schema schema = new Schema.SchemaBuilder()
+        .addSingleValueDimension("city", FieldSpec.DataType.STRING)
+        .build();
+    String expression = "CASE WHEN city = 'NYC' THEN 'match' ELSE 'no_match' END";
+    InbuiltFunctionEvaluator evaluator = new InbuiltFunctionEvaluator(expression, schema);
+
+    GenericRow row = new GenericRow();
+    row.putValue("city", null);
+    // equals is null-intolerant, so equals(null, 'NYC') returns null, and caseWhen treats null as not-true
+    assertEquals(evaluator.evaluate(row), "no_match");
+  }
+
+  /**
+   * Test column-to-column string comparison (both columns from schema).
+   */
+  @Test
+  public void testColumnToColumnStringComparisonWithSchema() {
+    Schema schema = new Schema.SchemaBuilder()
+        .addSingleValueDimension("firstName", FieldSpec.DataType.STRING)
+        .addSingleValueDimension("lastName", FieldSpec.DataType.STRING)
+        .build();
+    String expression = "CASE WHEN firstName = lastName THEN 'same' ELSE 'different' END";
+    InbuiltFunctionEvaluator evaluator = new InbuiltFunctionEvaluator(expression, schema);
+
+    GenericRow row = new GenericRow();
+    row.putValue("firstName", "Lee");
+    row.putValue("lastName", "Lee");
+    assertEquals(evaluator.evaluate(row), "same");
+
+    row.putValue("firstName", "John");
+    row.putValue("lastName", "Doe");
+    assertEquals(evaluator.evaluate(row), "different");
+  }
+
+  /**
+   * Test that long equality uses the correct type-specific method.
+   */
+  @Test
+  public void testLongEqualsWithSchema() {
+    Schema schema = new Schema.SchemaBuilder()
+        .addSingleValueDimension("eventTime", FieldSpec.DataType.LONG)
+        .build();
+    String expression = "CASE WHEN eventTime = 1000000 THEN 'match' ELSE 'no_match' END";
+    InbuiltFunctionEvaluator evaluator = new InbuiltFunctionEvaluator(expression, schema);
+
+    GenericRow row = new GenericRow();
+    row.putValue("eventTime", 1000000L);
+    assertEquals(evaluator.evaluate(row), "match");
+
+    row.putValue("eventTime", 999999L);
+    assertEquals(evaluator.evaluate(row), "no_match");
+  }
+
+  /**
+   * Test that non-polymorphic functions still work when schema is provided (regression check).
+   */
+  @Test
+  public void testNonPolymorphicFunctionWithSchema() {
+    Schema schema = new Schema.SchemaBuilder()
+        .addSingleValueDimension("testColumn", FieldSpec.DataType.STRING)
+        .build();
+    String expression = "reverse(testColumn)";
+    InbuiltFunctionEvaluator evaluator = new InbuiltFunctionEvaluator(expression, schema);
+    assertEquals(evaluator.getArguments(), Collections.singletonList("testColumn"));
+
+    GenericRow row = new GenericRow();
+    row.putValue("testColumn", "hello");
+    assertEquals(evaluator.evaluate(row), "olleh");
+  }
+
+  /**
+   * Test backward compatibility: the no-schema constructor still works (arity-based lookup).
+   * For numeric types, doubleEqualsWithTolerance is fine.
+   */
+  @Test
+  public void testBackwardCompatibilityWithoutSchema() {
+    String expression = "CASE WHEN status = 1 THEN 'active' ELSE 'inactive' END";
+    // No schema - falls back to arity-based lookup (doubleEqualsWithTolerance)
+    InbuiltFunctionEvaluator evaluator = new InbuiltFunctionEvaluator(expression);
+
+    GenericRow row = new GenericRow();
+    row.putValue("status", 1);
+    assertEquals(evaluator.evaluate(row), "active");
+
+    row.putValue("status", 0);
+    assertEquals(evaluator.evaluate(row), "inactive");
+  }
+
+  /**
+   * Test that a column not in the schema (e.g., intermediate derived column) falls back gracefully.
+   */
+  @Test
+  public void testColumnNotInSchemaFallsBackToArityLookup() {
+    Schema schema = new Schema.SchemaBuilder()
+        .addSingleValueDimension("knownCol", FieldSpec.DataType.STRING)
+        .build();
+    // 'unknownCol' is not in the schema — should still work via arity fallback for numeric values
+    String expression = "CASE WHEN unknownCol = 1 THEN 'yes' ELSE 'no' END";
+    InbuiltFunctionEvaluator evaluator = new InbuiltFunctionEvaluator(expression, schema);
+
+    GenericRow row = new GenericRow();
+    row.putValue("unknownCol", 1);
+    assertEquals(evaluator.evaluate(row), "yes");
   }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/common/evaluator/InbuiltFunctionEvaluatorTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/evaluator/InbuiltFunctionEvaluatorTest.java
@@ -538,6 +538,43 @@ public class InbuiltFunctionEvaluatorTest {
   }
 
   /**
+   * Array literals (ARRAY[...]) propagate their inferred element type so comparisons with multi-valued columns
+   * dispatch to the typed array overloads (e.g. {@code stringArrayEquals}) instead of falling back to
+   * {@code doubleEqualsWithTolerance}, which would throw or misbehave on non-numeric arrays.
+   */
+  @Test
+  public void testStringArrayLiteralEqualityWithSchema() {
+    Schema schema = new Schema.SchemaBuilder()
+        .addMultiValueDimension("tags", FieldSpec.DataType.STRING)
+        .build();
+    String expression = "CASE WHEN tags = ARRAY['a', 'b'] THEN 'match' ELSE 'no_match' END";
+    InbuiltFunctionEvaluator evaluator = new InbuiltFunctionEvaluator(expression, schema);
+
+    GenericRow row = new GenericRow();
+    row.putValue("tags", new String[]{"a", "b"});
+    assertEquals(evaluator.evaluate(row), "match");
+
+    row.putValue("tags", new String[]{"a", "c"});
+    assertEquals(evaluator.evaluate(row), "no_match");
+  }
+
+  /**
+   * Mixed-type array literals cannot be unified to a single element type, so polymorphic dispatch falls back
+   * to arity-based lookup. Ensures the mixed-type case doesn't throw and the existing behavior is preserved.
+   */
+  @Test
+  public void testMixedTypeArrayLiteralFallsBackToArityLookup() {
+    Schema schema = new Schema.SchemaBuilder()
+        .addMultiValueDimension("nums", FieldSpec.DataType.INT)
+        .build();
+    // ARRAY[1, 'a'] has mixed INT/STRING — type can't be inferred, so we fall back to arity-based lookup.
+    // The check itself is just that planning doesn't blow up; runtime behavior is preserved.
+    String expression = "CASE WHEN nums = ARRAY[1, 'a'] THEN 'match' ELSE 'no_match' END";
+    // Constructing the evaluator is the real assertion — it must not throw during planning.
+    new InbuiltFunctionEvaluator(expression, schema);
+  }
+
+  /**
    * Test that a column not in the schema (e.g., intermediate derived column) falls back gracefully.
    */
   @Test

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/function/FunctionEvaluatorFactory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/function/FunctionEvaluatorFactory.java
@@ -20,6 +20,7 @@ package org.apache.pinot.segment.local.function;
 
 import javax.annotation.Nullable;
 import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.function.FunctionEvaluator;
 
 
@@ -44,8 +45,18 @@ public class FunctionEvaluatorFactory {
     return org.apache.pinot.common.evaluator.FunctionEvaluatorFactory.getExpressionEvaluator(fieldSpec);
   }
 
+  @Nullable
+  public static FunctionEvaluator getExpressionEvaluator(FieldSpec fieldSpec, @Nullable Schema schema) {
+    return org.apache.pinot.common.evaluator.FunctionEvaluatorFactory.getExpressionEvaluator(fieldSpec, schema);
+  }
+
   public static FunctionEvaluator getExpressionEvaluator(String transformExpression) {
     return org.apache.pinot.common.evaluator.FunctionEvaluatorFactory.getExpressionEvaluator(transformExpression);
+  }
+
+  public static FunctionEvaluator getExpressionEvaluator(String transformExpression, @Nullable Schema schema) {
+    return org.apache.pinot.common.evaluator.FunctionEvaluatorFactory.getExpressionEvaluator(transformExpression,
+        schema);
   }
 
   public static boolean isGroovyExpression(String transformExpression) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/function/InbuiltFunctionEvaluator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/function/InbuiltFunctionEvaluator.java
@@ -18,6 +18,10 @@
  */
 package org.apache.pinot.segment.local.function;
 
+import javax.annotation.Nullable;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.function.FunctionEvaluator;
+
 
 /**
  * Deprecated forwarding wrapper for the legacy inbuilt evaluator type name.
@@ -34,5 +38,9 @@ public class InbuiltFunctionEvaluator extends org.apache.pinot.common.evaluator.
     implements FunctionEvaluator {
   public InbuiltFunctionEvaluator(String functionExpression) {
     super(functionExpression);
+  }
+
+  public InbuiltFunctionEvaluator(String functionExpression, @Nullable Schema schema) {
+    super(functionExpression, schema);
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ExpressionTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ExpressionTransformer.java
@@ -75,7 +75,7 @@ public class ExpressionTransformer implements RecordTransformer {
     if (transformConfigs != null) {
       for (TransformConfig transformConfig : transformConfigs) {
         FunctionEvaluator previous = expressionEvaluators.put(transformConfig.getColumnName(),
-            FunctionEvaluatorFactory.getExpressionEvaluator(transformConfig.getTransformFunction()));
+            FunctionEvaluatorFactory.getExpressionEvaluator(transformConfig.getTransformFunction(), schema));
         Preconditions.checkState(previous == null,
             "Cannot set more than one transform function on column: %s.", transformConfig.getColumnName());
       }
@@ -83,7 +83,7 @@ public class ExpressionTransformer implements RecordTransformer {
     for (FieldSpec fieldSpec : schema.getAllFieldSpecs()) {
       String fieldName = fieldSpec.getName();
       if (!fieldSpec.isVirtualColumn() && !expressionEvaluators.containsKey(fieldName)) {
-        FunctionEvaluator functionEvaluator = FunctionEvaluatorFactory.getExpressionEvaluator(fieldSpec);
+        FunctionEvaluator functionEvaluator = FunctionEvaluatorFactory.getExpressionEvaluator(fieldSpec, schema);
         if (functionEvaluator != null) {
           expressionEvaluators.put(fieldName, functionEvaluator);
           if (isImplicitMapTransform(fieldSpec)) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/FilterTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/FilterTransformer.java
@@ -20,10 +20,12 @@ package org.apache.pinot.segment.local.recordtransformer;
 
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.evaluator.FunctionEvaluatorFactory;
 import org.apache.pinot.common.utils.ThrottledLogger;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
+import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.function.FunctionEvaluator;
 import org.apache.pinot.spi.recordtransformer.RecordTransformer;
@@ -46,13 +48,18 @@ public class FilterTransformer implements RecordTransformer {
   private long _numRecordsFiltered;
 
   public FilterTransformer(TableConfig tableConfig) {
+    this(tableConfig, null);
+  }
+
+  public FilterTransformer(TableConfig tableConfig, @Nullable Schema schema) {
     IngestionConfig ingestionConfig = tableConfig.getIngestionConfig();
     if (ingestionConfig != null && ingestionConfig.getFilterConfig() != null) {
       _filterFunction = ingestionConfig.getFilterConfig().getFilterFunction();
     } else {
       _filterFunction = null;
     }
-    _evaluator = _filterFunction != null ? FunctionEvaluatorFactory.getExpressionEvaluator(_filterFunction) : null;
+    _evaluator = _filterFunction != null ? FunctionEvaluatorFactory.getExpressionEvaluator(_filterFunction, schema)
+        : null;
     _continueOnError = ingestionConfig != null && ingestionConfig.isContinueOnError();
     _throttledLogger = new ThrottledLogger(LOGGER, ingestionConfig);
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/RecordTransformerUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/RecordTransformerUtils.java
@@ -77,7 +77,7 @@ public class RecordTransformerUtils {
     addRecordEnricherTransformers(tableConfig, transformers, false);
     addIfNotNoOp(transformers, new ExpressionTransformer(tableConfig, schema));
     if (!skipFilterTransformer) {
-      addIfNotNoOp(transformers, new FilterTransformer(tableConfig));
+      addIfNotNoOp(transformers, new FilterTransformer(tableConfig, schema));
     }
     addIfNotNoOp(transformers, SchemaConformingTransformer.create(tableConfig, schema));
     addIfNotNoOp(transformers, new DataTypeTransformer(tableConfig, schema));

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/ExpressionTransformerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/ExpressionTransformerTest.java
@@ -444,10 +444,12 @@ public class ExpressionTransformerTest {
             .build();
     ExpressionTransformer expressionTransformer = new ExpressionTransformer(tableConfig, pinotSchema);
     // Valid case: x is int, y is int
+    // The result type depends on whether PlusScalarFunction resolves polymorphically (long) or via arity fallback
+    // (double). Both are correct — the DataTypeTransformer coerces to the target column type downstream.
     GenericRow genericRow = new GenericRow();
     genericRow.putValue("x", 10);
     expressionTransformer.transform(genericRow);
-    Assert.assertEquals(genericRow.getValue("y"), 20.0);
+    Assert.assertEquals(((Number) genericRow.getValue("y")).longValue(), 20L);
     // Invalid case: x is string, y is int
     genericRow = new GenericRow();
     genericRow.putValue("x", "abcd");
@@ -475,10 +477,12 @@ public class ExpressionTransformerTest {
             .build();
     ExpressionTransformer expressionTransformer = new ExpressionTransformer(tableConfig, pinotSchema);
     // Valid case: x is int, y is int
+    // The result type depends on whether PlusScalarFunction resolves polymorphically (long) or via arity fallback
+    // (double). Both are correct — the DataTypeTransformer coerces to the target column type downstream.
     GenericRow genericRow = new GenericRow();
     genericRow.putValue("x", 10);
     expressionTransformer.transform(genericRow);
-    Assert.assertEquals(genericRow.getValue("y"), 20.0);
+    Assert.assertEquals(((Number) genericRow.getValue("y")).longValue(), 20L);
     // Invalid case: x is string, y is int
     genericRow = new GenericRow();
     genericRow.putValue("x", "abcd");
@@ -546,5 +550,41 @@ public class ExpressionTransformerTest {
     Object transformedValue = row.getValue("columnArray");
     Assert.assertTrue(transformedValue.getClass().isArray());
     Assert.assertEquals(Arrays.asList((Object[]) transformedValue), Arrays.asList("a", "b", "c"));
+  }
+
+  /**
+   * Tests that string equality in CASE WHEN transform expressions works correctly during ingestion.
+   * This is the end-to-end test for the polymorphic function resolution fix: previously, the '=' operator
+   * in transform functions always resolved to doubleEqualsWithTolerance, which failed on string columns.
+   */
+  @Test
+  public void testCaseWhenStringEqualityTransform() {
+    Schema schema = new Schema.SchemaBuilder()
+        .addSingleValueDimension("shippingCompanyCode", FieldSpec.DataType.STRING)
+        .addSingleValueDimension("mappedCode", FieldSpec.DataType.STRING)
+        .build();
+
+    IngestionConfig ingestionConfig = new IngestionConfig();
+    ingestionConfig.setTransformConfigs(Collections.singletonList(
+        new TransformConfig("mappedCode",
+            "CASE WHEN shippingCompanyCode = 'COUPANG' THEN 'COUPANG1' ELSE shippingCompanyCode END")));
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName("testCaseWhenStringEquality")
+        .setIngestionConfig(ingestionConfig)
+        .build();
+
+    ExpressionTransformer expressionTransformer = new ExpressionTransformer(tableConfig, schema);
+
+    // Test matching case
+    GenericRow row = new GenericRow();
+    row.putValue("shippingCompanyCode", "COUPANG");
+    expressionTransformer.transform(row);
+    Assert.assertEquals(row.getValue("mappedCode"), "COUPANG1");
+
+    // Test non-matching case
+    row = new GenericRow();
+    row.putValue("shippingCompanyCode", "FEDEX");
+    expressionTransformer.transform(row);
+    Assert.assertEquals(row.getValue("mappedCode"), "FEDEX");
   }
 }


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Thread schema from transformers to function evaluator for type\-aware polymorphic dispatch

```mermaid
flowchart TD
  N0["Transformer calls factory with schema #40;F5#44; F6#44; F7#41;"]:::stModified
  N1["Factory creates evaluator with schema #40;F1#44; F2#41;"]:::stModified
  N2["Evaluator plans execution #40;with schema#41; #40;F2#41;"]:::stModified
  N3["resolveFunction#58; polymorphic lookup if types known #40;F2#41;"]:::stModified
  N4["Create function node with result type #40;F2#41;"]:::stModified
  N0 -->|"pass schema"| N1
  N1 -->|"create evaluator"| N2
  N2 -->|"resolve function node"| N3
  N3 -->|"create function execution node"| N4
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-common/src/main/java/org/apache/pinot/common/evaluator/FunctionEvaluatorFactory\.java — [before](https://github.com/apache/pinot/blob/dc78809d480550ad04a361381dbbe3f5a3746a5d/pinot-common/src/main/java/org/apache/pinot/common/evaluator/FunctionEvaluatorFactory.java) · [after](https://github.com/apache/pinot/blob/5c3d1b157e8cb61b8cfb05c55b4195808a6fe4bd/pinot-common/src/main/java/org/apache/pinot/common/evaluator/FunctionEvaluatorFactory.java)
- F2: pinot\-common/src/main/java/org/apache/pinot/common/evaluator/InbuiltFunctionEvaluator\.java — [before](https://github.com/apache/pinot/blob/dc78809d480550ad04a361381dbbe3f5a3746a5d/pinot-common/src/main/java/org/apache/pinot/common/evaluator/InbuiltFunctionEvaluator.java) · [after](https://github.com/apache/pinot/blob/5c3d1b157e8cb61b8cfb05c55b4195808a6fe4bd/pinot-common/src/main/java/org/apache/pinot/common/evaluator/InbuiltFunctionEvaluator.java)
- F5: pinot\-segment\-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ExpressionTransformer\.java — [before](https://github.com/apache/pinot/blob/dc78809d480550ad04a361381dbbe3f5a3746a5d/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ExpressionTransformer.java) · [after](https://github.com/apache/pinot/blob/5c3d1b157e8cb61b8cfb05c55b4195808a6fe4bd/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ExpressionTransformer.java)
- F6: pinot\-segment\-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/FilterTransformer\.java — [before](https://github.com/apache/pinot/blob/dc78809d480550ad04a361381dbbe3f5a3746a5d/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/FilterTransformer.java) · [after](https://github.com/apache/pinot/blob/5c3d1b157e8cb61b8cfb05c55b4195808a6fe4bd/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/FilterTransformer.java)
- F7: pinot\-segment\-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/RecordTransformerUtils\.java — [before](https://github.com/apache/pinot/blob/dc78809d480550ad04a361381dbbe3f5a3746a5d/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/RecordTransformerUtils.java) · [after](https://github.com/apache/pinot/blob/5c3d1b157e8cb61b8cfb05c55b4195808a6fe4bd/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/RecordTransformerUtils.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImRjNzg4MDlkNDgwNTUwYWQwNGEzNjEzODFkYmJlM2Y1YTM3NDZhNWQiLCJjb250ZXh0X2hhc2giOiJiYjhhYjUwZDJmZDFiNWJhNGE0NmExNzYzYjQ0NzA4YzRlYWMwYzEyOGE3ZmU2NmRkOGZmOTY5Nzg4NmY4MmI0IiwiZ2VuZXJhdGVkX2F0IjoxNzg4OTkyMDU3LCJoZWFkX3NoYSI6IjVjM2QxYjE1N2U4Y2I2MWI4Y2ZiMDVjNTViNDE5NTgwOGE2ZmU0YmQiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJkYzc4ODA5ZDQ4MDU1MGFkMDRhMzYxMzgxZGJiZTNmNWEzNzQ2YTVkIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 11a9b6c21e0356aaa12a9c677696723e15eb6a1a445cb02f59388bc6270e8181 -->
<!-- pinot-pr-flow:end -->



  - Fix ingestion-time transform functions failing on string comparisons with = operator (e.g. CASE WHEN col = 'literal' THEN ...)
  - Root cause: `InbuiltFunctionEvaluator` used arity-based function lookup which always resolved equals to `doubleEqualsWithTolerance`, even for string columns                                                                                                                                                                                  
  - Add optional `Schema` parameter to `InbuiltFunctionEvaluator` for type-aware polymorphic function resolution                                                                                                                                                                                                                                  
  - Each `ExecutableNode` now exposes a result `ColumnDataType` derived from schema (columns), literal type (constants), or Java return type (functions)                                                                                                                                                                                          
  - When all argument types are known, use `FunctionRegistry.lookupFunctionInfo(name, ColumnDataType[])` for correct dispatch; fall back to arity-based lookup otherwise                                                                                                                                                                        
  - Thread schema through `FunctionEvaluatorFactory` and `ExpressionTransformer`/`FilterTransformer` to `InbuiltFunctionEvaluator`                                                                                                                                                                                                                    
  - Fixes all polymorphic operators during ingestion: =, !=, >, <, >=, <=, +, -, *                                                                                                                                                                                                                                                            
  - Backward compatible: all existing no-schema callers unchanged via constructor/method overloads                                                                                                                                                                                                                                            
  - Known limitation: functions returning `Object` (e.g. `caseWhen`, `coalesce`) cannot propagate type info to outer expressions
