### PR TITLE
Fix AIOOBE in MapColumnPreIndexStatsCollector when all map rows are empty

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/MapColumnPreIndexStatsCollector.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/MapColumnPreIndexStatsCollector.java
@@ -23,6 +23,7 @@ import it.unimi.dsi.fastutil.objects.Object2ObjectOpenHashMap;
 import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.utils.PinotDataType;
 import org.apache.pinot.segment.spi.creator.StatsCollectorConfig;
 import org.apache.pinot.segment.spi.index.FieldIndexConfigs;
@@ -206,26 +207,29 @@ public class MapColumnPreIndexStatsCollector extends AbstractColumnStatisticsCol
     }
   }
 
+  @Nullable
   @Override
   public String getMinValue() {
     if (_sealed) {
-      return _sortedKeys[0];
+      return _sortedKeys.length > 0 ? _sortedKeys[0] : null;
     }
     throw new IllegalStateException("you must seal the collector first before asking for min value");
   }
 
+  @Nullable
   @Override
   public String getMaxValue() {
     if (_sealed) {
-      return _sortedKeys[_sortedKeys.length - 1];
+      return _sortedKeys.length > 0 ? _sortedKeys[_sortedKeys.length - 1] : null;
     }
     throw new IllegalStateException("you must seal the collector first before asking for max value");
   }
 
+  @Nullable
   @Override
   public String[] getUniqueValuesSet() {
     if (_sealed) {
-      return _sortedKeys;
+      return _sortedKeys.length > 0 ? _sortedKeys : null;
     }
     throw new IllegalStateException("you must seal the collector first before asking for unique values set");
   }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/impl/stats/MapColumnPreIndexStatsCollectorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/impl/stats/MapColumnPreIndexStatsCollectorTest.java
@@ -502,6 +502,53 @@ public class MapColumnPreIndexStatsCollectorTest {
   }
 
   @Test
+  public void testAllEmptyMaps() {
+    StatsCollectorConfig cfg = newConfig(false);
+    MapColumnPreIndexStatsCollector col = new MapColumnPreIndexStatsCollector("col", cfg);
+
+    // Collect multiple rows with empty maps
+    col.collect(new HashMap<>());
+    col.collect(new HashMap<>());
+    col.collect(new HashMap<>());
+    col.seal();
+
+    // Should not throw AIOOBE; should return null for min/max/uniqueValuesSet
+    assertNull(col.getMinValue());
+    assertNull(col.getMaxValue());
+    assertNull(col.getUniqueValuesSet());
+    assertEquals(col.getCardinality(), 0);
+    assertEquals(col.getTotalNumberOfEntries(), 3);
+    // Serialized empty map is Integer.BYTES (4) bytes
+    assertEquals(col.getLengthOfShortestElement(), Integer.BYTES);
+    assertEquals(col.getLengthOfLongestElement(), Integer.BYTES);
+    assertEquals(col.getMaxRowLengthInBytes(), Integer.BYTES);
+    assertTrue(col.getAllKeyFrequencies().isEmpty());
+  }
+
+  @Test
+  public void testMixOfEmptyAndNonEmptyMaps() {
+    StatsCollectorConfig cfg = newConfig(false);
+    MapColumnPreIndexStatsCollector col = new MapColumnPreIndexStatsCollector("col", cfg);
+
+    col.collect(new HashMap<>());
+    col.collect(Map.of("k1", "v1"));
+    col.collect(new HashMap<>());
+    col.seal();
+
+    assertEquals(col.getMinValue(), "k1");
+    assertEquals(col.getMaxValue(), "k1");
+    assertNotNull(col.getUniqueValuesSet());
+    assertEquals(col.getUniqueValuesSet(), new String[]{"k1"});
+    assertEquals(col.getCardinality(), 1);
+    assertEquals(col.getTotalNumberOfEntries(), 3);
+
+    // Key appeared in 1 of 3 rows, so seal() inserted one default null value (2 total)
+    AbstractColumnStatisticsCollector k1Stats = col.getKeyStatistics("k1");
+    assertNotNull(k1Stats);
+    assertEquals(k1Stats.getTotalNumberOfEntries(), 2);
+  }
+
+  @Test
   public void testNoDictCreatesNoDictChildCollectors() {
     StatsCollectorConfig cfgNoDict = newConfig(true);
     MapColumnPreIndexStatsCollector col = new MapColumnPreIndexStatsCollector("col", cfgNoDict);


### PR DESCRIPTION
## Summary
- Fixes `ArrayIndexOutOfBoundsException` in `MapColumnPreIndexStatsCollector` during segment build when a MAP column has all rows containing empty maps (`{}`).
- When all map entries are empty, no keys are collected, so `_sortedKeys` is a zero-length array after `seal()`. `getMinValue()` / `getMaxValue()` then crash accessing index 0 / length-1 of the empty array.
- The fix returns `null` from `getMinValue()`, `getMaxValue()`, and `getUniqueValuesSet()` when `_sortedKeys` is empty, consistent with the `@Nullable` contract on the `ColumnStatistics` interface and the `EmptyColumnStatistics` implementation.

## Test plan
- [x] Added `testAllEmptyMaps` — verifies 3 rows of `{}` no longer throw AIOOBE; min/max/unique return null, cardinality is 0.
- [x] Added `testMixOfEmptyAndNonEmptyMaps` — verifies a mix of empty and non-empty maps produces correct stats.
- [x] All existing `MapColumnPreIndexStatsCollectorTest` tests continue to pass (20/20).