### PR TITLE
Deprecate padding character check in ColumnMetadataImpl

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/BaseSegmentCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/BaseSegmentCreator.java
@@ -413,6 +413,7 @@ public abstract class BaseSegmentCreator implements SegmentCreator {
     PropertiesConfiguration properties = CommonsConfigurationUtils.fromFile(metadataFile);
 
     properties.setProperty(SEGMENT_CREATOR_VERSION, _config.getCreatorVersion());
+    // TODO: Remove it after 1.6 release
     properties.setProperty(SEGMENT_PADDING_CHARACTER, String.valueOf(V1Constants.Str.DEFAULT_STRING_PAD_CHAR));
     properties.setProperty(SEGMENT_NAME, _segmentName);
     properties.setProperty(TABLE_NAME, _config.getTableName());

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/ColumnMetadataTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/ColumnMetadataTest.java
@@ -35,7 +35,6 @@ import org.apache.pinot.segment.local.segment.creator.impl.BaseSegmentCreator;
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentCreationDriverFactory;
 import org.apache.pinot.segment.spi.ColumnMetadata;
 import org.apache.pinot.segment.spi.SegmentMetadata;
-import org.apache.pinot.segment.spi.V1Constants;
 import org.apache.pinot.segment.spi.creator.ColumnStatistics;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
 import org.apache.pinot.segment.spi.creator.SegmentIndexCreationDriver;
@@ -63,7 +62,6 @@ import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import static org.apache.pinot.segment.spi.V1Constants.MetadataKeys.Segment.SEGMENT_PADDING_CHARACTER;
 import static org.mockito.Mockito.mock;
 import static org.testng.Assert.*;
 
@@ -282,7 +280,6 @@ public class ColumnMetadataTest {
         Map.of("key", new DimensionFieldSpec("key", DataType.STRING, true), "value",
             new DimensionFieldSpec("value", DataType.INT, true)));
     PropertiesConfiguration config = new PropertiesConfiguration();
-    config.setProperty(SEGMENT_PADDING_CHARACTER, String.valueOf(V1Constants.Str.DEFAULT_STRING_PAD_CHAR));
     BaseSegmentCreator.addColumnMetadataInfo(config, "intMap", mock(ColumnStatistics.class), 1, intMapFieldSpec, false,
         -1, false);
     ColumnMetadataImpl intMapColumnMetadata = ColumnMetadataImpl.fromPropertiesConfiguration("intMap", config);

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/V1Constants.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/V1Constants.java
@@ -96,10 +96,13 @@ public class V1Constants {
       public static final String SEGMENT_END_TIME = "segment.end.time";
       public static final String DATETIME_COLUMNS = "segment.datetime.column.names";
       public static final String SEGMENT_TOTAL_DOCS = "segment.total.docs";
-      public static final String SEGMENT_PADDING_CHARACTER = "segment.padding.character";
       public static final String COMPLEX_COLUMNS = "segment.complex.column.names";
 
       public static final String CUSTOM_SUBSET = "custom";
+
+      // TODO: Remove it after 1.6 release
+      @Deprecated
+      public static final String SEGMENT_PADDING_CHARACTER = "segment.padding.character";
 
       public static class Realtime {
         public static final String START_OFFSET = "segment.realtime.startOffset";

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/metadata/ColumnMetadataImpl.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/metadata/ColumnMetadataImpl.java
@@ -20,7 +20,6 @@ package org.apache.pinot.segment.spi.index.metadata;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
 import it.unimi.dsi.fastutil.longs.LongArrayList;
 import java.math.BigDecimal;
 import java.util.HashMap;
@@ -33,9 +32,7 @@ import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 import org.apache.commons.configuration2.Configuration;
 import org.apache.commons.configuration2.PropertiesConfiguration;
-import org.apache.commons.text.StringEscapeUtils;
 import org.apache.pinot.segment.spi.ColumnMetadata;
-import org.apache.pinot.segment.spi.V1Constants;
 import org.apache.pinot.segment.spi.V1Constants.MetadataKeys.Column;
 import org.apache.pinot.segment.spi.V1Constants.MetadataKeys.Segment;
 import org.apache.pinot.segment.spi.index.IndexService;
@@ -298,10 +295,6 @@ public class ColumnMetadataImpl implements ColumnMetadata {
       }
       builder.setMinMaxValueInvalid(config.getBoolean(Column.getKeyFor(column, Column.MIN_MAX_VALUE_INVALID), false));
     }
-    // Only support zero padding
-    String padding = config.getString(Segment.SEGMENT_PADDING_CHARACTER, null);
-    Preconditions.checkState(String.valueOf(V1Constants.Str.DEFAULT_STRING_PAD_CHAR)
-        .equals(StringEscapeUtils.unescapeJava(padding)), "Got non-zero string padding: %s", padding);
 
     String partitionFunctionName = config.getString(Column.getKeyFor(column, Column.PARTITION_FUNCTION), null);
     if (partitionFunctionName != null) {


### PR DESCRIPTION
## Summary
- Remove the runtime `Preconditions.checkState` that validates the padding character on segment load in `ColumnMetadataImpl`, since only the default zero padding character has ever been used
- Deprecate the `SEGMENT_PADDING_CHARACTER` constant in `V1Constants` for removal after the 1.6 release
- The segment creator still writes the padding character property for backward compatibility with older servers during rolling upgrades

## Test plan
- [x] Existing unit tests in `ColumnMetadataTest` pass (updated to remove padding character setup)
- [x] Segments created by older versions (which include the padding character metadata) continue to load without error
- [x] Segments created by new version still include the padding character metadata for backward compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)