### PR TITLE
Add IGNORE NULLS support for LEAD and LAG window functions

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/NullHandlingIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/NullHandlingIntegrationTest.java
@@ -369,21 +369,56 @@ public class NullHandlingIntegrationTest extends BaseClusterIntegrationTestSet
     // Window functions are only supported in the multi-stage query engine
     setUseMultiStageQueryEngine(true);
     String sqlQuery =
-        "SELECT salary, LAST_VALUE(salary) IGNORE NULLS OVER (ORDER BY DaysSinceEpoch) AS gapfilledSalary from "
-            + "mytable";
+        "SELECT salary, "
+            + "LAST_VALUE(salary) IGNORE NULLS OVER (ORDER BY DaysSinceEpoch) AS gapfilledSalary, "
+            + "LAG(salary) IGNORE NULLS OVER (ORDER BY DaysSinceEpoch) AS prevSalary, "
+            + "LEAD(salary) IGNORE NULLS OVER (ORDER BY DaysSinceEpoch) AS nextSalary "
+            + "FROM mytable";
     JsonNode response = postQuery(sqlQuery);
     assertNoError(response);
-
-    // Check if the LAST_VALUE window function with IGNORE NULLS has effectively gap-filled the salary values
-    Integer lastSalary = null;
     JsonNode rows = response.get("resultTable").get("rows");
-    for (int i = 0; i < rows.size(); i++) {
+    int numRows = rows.size();
+    // The rows are returned in the shared window ORDER BY (DaysSinceEpoch) order, so scanning them in iteration order
+    // reproduces each window function's per-row result even when DaysSinceEpoch has ties (both the window computation
+    // and the verification below see the same row sequence).
+
+    // LAST_VALUE(salary) IGNORE NULLS gap-fills each row with the most recent non-null salary (including itself).
+    Integer lastSalary = null;
+    for (int i = 0; i < numRows; i++) {
       JsonNode row = rows.get(i);
       if (!row.get(0).isNull()) {
         lastSalary = row.get(0).asInt();
-        assertEquals(row.get(1).asInt(), lastSalary);
+        assertEquals(row.get(1).asInt(), (int) lastSalary);
       } else {
         assertEquals(row.get(1).numberValue(), lastSalary);
+      }
+    }
+
+    // LAG(salary) IGNORE NULLS returns the closest preceding non-null salary, or null before the first non-null one.
+    Integer prevNonNullSalary = null;
+    for (int i = 0; i < numRows; i++) {
+      JsonNode row = rows.get(i);
+      if (prevNonNullSalary == null) {
+        assertTrue(row.get(2).isNull());
+      } else {
+        assertEquals(row.get(2).asInt(), (int) prevNonNullSalary);
+      }
+      if (!row.get(0).isNull()) {
+        prevNonNullSalary = row.get(0).asInt();
+      }
+    }
+
+    // LEAD(salary) IGNORE NULLS returns the closest following non-null salary, or null after the last non-null one.
+    Integer nextNonNullSalary = null;
+    for (int i = numRows - 1; i >= 0; i--) {
+      JsonNode row = rows.get(i);
+      if (nextNonNullSalary == null) {
+        assertTrue(row.get(3).isNull());
+      } else {
+        assertEquals(row.get(3).asInt(), (int) nextNonNullSalary);
+      }
+      if (!row.get(0).isNull()) {
+        nextNonNullSalary = row.get(0).asInt();
       }
     }
   }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/sql/fun/PinotOperatorTable.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/sql/fun/PinotOperatorTable.java
@@ -38,7 +38,6 @@ import org.apache.calcite.sql.SqlOperatorTable;
 import org.apache.calcite.sql.SqlPostfixOperator;
 import org.apache.calcite.sql.SqlSplittableAggFunction;
 import org.apache.calcite.sql.SqlSyntax;
-import org.apache.calcite.sql.fun.SqlLeadLagAggFunction;
 import org.apache.calcite.sql.fun.SqlMonotonicBinaryOperator;
 import org.apache.calcite.sql.fun.SqlNtileAggFunction;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
@@ -214,10 +213,8 @@ public class PinotOperatorTable implements SqlOperatorTable {
       // WINDOW Functions (non-aggregate)
       SqlStdOperatorTable.LAST_VALUE,
       SqlStdOperatorTable.FIRST_VALUE,
-      // TODO: Replace these with SqlStdOperatorTable.LEAD and SqlStdOperatorTable.LAG when the function implementations
-      // are updated to support the IGNORE NULLS option.
-      PinotLeadWindowFunction.INSTANCE,
-      PinotLagWindowFunction.INSTANCE,
+      SqlStdOperatorTable.LEAD,
+      SqlStdOperatorTable.LAG,
 
       // SPECIAL OPERATORS
       SqlStdOperatorTable.IGNORE_NULLS,
@@ -446,32 +443,6 @@ public class PinotOperatorTable implements SqlOperatorTable {
   @Override
   public List<SqlOperator> getOperatorList() {
     return _operatorList;
-  }
-
-  private static class PinotLeadWindowFunction extends SqlLeadLagAggFunction {
-    static final SqlOperator INSTANCE = new PinotLeadWindowFunction();
-
-    public PinotLeadWindowFunction() {
-      super(SqlKind.LEAD);
-    }
-
-    @Override
-    public boolean allowsNullTreatment() {
-      return false;
-    }
-  }
-
-  private static class PinotLagWindowFunction extends SqlLeadLagAggFunction {
-    static final SqlOperator INSTANCE = new PinotLagWindowFunction();
-
-    public PinotLagWindowFunction() {
-      super(SqlKind.LAG);
-    }
-
-    @Override
-    public boolean allowsNullTreatment() {
-      return false;
-    }
   }
 
   private static final class PinotNtileWindowFunction extends SqlNtileAggFunction {

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/sql/fun/PinotOperatorTable.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/sql/fun/PinotOperatorTable.java
@@ -39,7 +39,6 @@ import org.apache.calcite.sql.SqlOperatorTable;
 import org.apache.calcite.sql.SqlPostfixOperator;
 import org.apache.calcite.sql.SqlSplittableAggFunction;
 import org.apache.calcite.sql.SqlSyntax;
-import org.apache.calcite.sql.fun.SqlLeadLagAggFunction;
 import org.apache.calcite.sql.fun.SqlMonotonicBinaryOperator;
 import org.apache.calcite.sql.fun.SqlNtileAggFunction;
 import org.apache.calcite.sql.fun.SqlStdOperatorTable;
@@ -217,10 +216,8 @@ public class PinotOperatorTable implements SqlOperatorTable {
       // WINDOW Functions (non-aggregate)
       SqlStdOperatorTable.LAST_VALUE,
       SqlStdOperatorTable.FIRST_VALUE,
-      // TODO: Replace these with SqlStdOperatorTable.LEAD and SqlStdOperatorTable.LAG when the function implementations
-      // are updated to support the IGNORE NULLS option.
-      PinotLeadWindowFunction.INSTANCE,
-      PinotLagWindowFunction.INSTANCE,
+      SqlStdOperatorTable.LEAD,
+      SqlStdOperatorTable.LAG,
 
       // SPECIAL OPERATORS
       SqlStdOperatorTable.IGNORE_NULLS,
@@ -485,32 +482,6 @@ public class PinotOperatorTable implements SqlOperatorTable {
   @Override
   public List<SqlOperator> getOperatorList() {
     return _operatorList;
-  }
-
-  private static class PinotLeadWindowFunction extends SqlLeadLagAggFunction {
-    static final SqlOperator INSTANCE = new PinotLeadWindowFunction();
-
-    public PinotLeadWindowFunction() {
-      super(SqlKind.LEAD);
-    }
-
-    @Override
-    public boolean allowsNullTreatment() {
-      return false;
-    }
-  }
-
-  private static class PinotLagWindowFunction extends SqlLeadLagAggFunction {
-    static final SqlOperator INSTANCE = new PinotLagWindowFunction();
-
-    public PinotLagWindowFunction() {
-      super(SqlKind.LAG);
-    }
-
-    @Override
-    public boolean allowsNullTreatment() {
-      return false;
-    }
   }
 
   private static final class PinotNtileWindowFunction extends SqlNtileAggFunction {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/WindowFunction.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/WindowFunction.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.query.runtime.operator.window;
 
 import java.util.List;
+import javax.annotation.Nullable;
 import org.apache.calcite.rel.RelFieldCollation;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.query.planner.logical.RexExpression;
@@ -63,6 +64,7 @@ public abstract class WindowFunction extends AggregationUtils.Accumulator {
    */
   public abstract List<Object> processRows(List<Object[]> rows);
 
+  @Nullable
   protected Object extractValueFromRow(Object[] row) {
     return _inputRef == -1 ? _literal : (row == null ? null : row[_inputRef]);
   }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/WindowFunction.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/WindowFunction.java
@@ -20,6 +20,7 @@ package org.apache.pinot.query.runtime.operator.window;
 
 import java.util.List;
 import java.util.Objects;
+import javax.annotation.Nullable;
 import org.apache.calcite.rel.RelFieldCollation;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.query.planner.logical.RexExpression;
@@ -65,6 +66,7 @@ public abstract class WindowFunction extends AggregationUtils.Accumulator {
    */
   public abstract List<Object> processRows(List<Object[]> rows);
 
+  @Nullable
   protected Object extractValueFromRow(Object[] row) {
     return _inputRef == -1 ? _literal : (row == null ? null : row[_inputRef]);
   }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/value/LagValueWindowFunction.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/value/LagValueWindowFunction.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.query.runtime.operator.window.value;
 
 import com.google.common.base.Preconditions;
+import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.calcite.rel.RelFieldCollation;
@@ -28,9 +29,10 @@ import org.apache.pinot.query.planner.logical.RexExpression;
 import org.apache.pinot.query.runtime.operator.window.WindowFrame;
 
 
-/**
- * The LAG window function doesn't allow custom window frames (and this is enforced by Calcite).
- */
+/// Window function that returns the value of a column from a preceding row within the partition.
+/// Supports an optional offset (default 1), an optional default value for when no row exists at
+/// that offset, and IGNORE NULLS mode which skips null values when scanning backward.
+/// Custom window frames are not allowed (enforced by Calcite).
 public class LagValueWindowFunction extends ValueWindowFunction {
   private final int _offset;
   private final Object _defaultValue;
@@ -75,6 +77,9 @@ public class LagValueWindowFunction extends ValueWindowFunction {
 
   @Override
   public List<Object> processRows(List<Object[]> rows) {
+    if (_ignoreNulls) {
+      return processRowsIgnoreNulls(rows);
+    }
     int numRows = rows.size();
     Object[] result = new Object[numRows];
     if (_defaultValue != null) {
@@ -85,6 +90,30 @@ public class LagValueWindowFunction extends ValueWindowFunction {
     }
     for (int i = _offset; i < numRows; i++) {
       result[i] = extractValueFromRow(rows.get(i - _offset));
+    }
+    return Arrays.asList(result);
+  }
+
+  /**
+   * LAG with IGNORE NULLS: for each row, find the offset-th non-null value scanning backward.
+   * Uses a bounded deque of size {@code _offset} for O(N) time and O(offset) memory.
+   * Scans left-to-right, maintaining a sliding window of preceding non-null values. The oldest
+   * element in the deque (peekFirst) is always the offset-th non-null value behind the current
+   * row.
+   */
+  private List<Object> processRowsIgnoreNulls(List<Object[]> rows) {
+    int numRows = rows.size();
+    Object[] result = new Object[numRows];
+    ArrayDeque<Object> window = new ArrayDeque<>(_offset);
+    for (int i = 0; i < numRows; i++) {
+      result[i] = (window.size() == _offset) ? window.peekFirst() : _defaultValue;
+      Object val = extractValueFromRow(rows.get(i));
+      if (val != null) {
+        window.addLast(val);
+        if (window.size() > _offset) {
+          window.pollFirst();
+        }
+      }
     }
     return Arrays.asList(result);
   }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/value/LagValueWindowFunction.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/value/LagValueWindowFunction.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.query.runtime.operator.window.value;
 
-import com.google.common.base.Preconditions;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.calcite.rel.RelFieldCollation;
@@ -28,51 +27,23 @@ import org.apache.pinot.query.runtime.operator.window.WindowFrame;
 
 
 /**
- * The LAG window function doesn't allow custom window frames (and this is enforced by Calcite).
+ * Window function that returns the value of a column from a preceding row within the partition. Supports an optional
+ * offset (default 1), an optional default value for when no row exists at that offset, and IGNORE NULLS mode which
+ * skips null values when scanning backward. Custom window frames are not allowed (enforced by Calcite).
  */
-public class LagValueWindowFunction extends ValueWindowFunction {
-  private final int _offset;
-  private final Object _defaultValue;
+public class LagValueWindowFunction extends OffsetValueWindowFunction {
 
   public LagValueWindowFunction(RexExpression.FunctionCall aggCall, DataSchema inputSchema,
       List<RelFieldCollation> collations, WindowFrame windowFrame) {
     super(aggCall, inputSchema, collations, windowFrame);
-    int offset = 1;
-    Object defaultValue = null;
-    List<RexExpression> operands = aggCall.getFunctionOperands();
-    int numOperands = operands.size();
-    Preconditions.checkArgument(numOperands > 0, "LAG function requires at least one operand");
-    if (numOperands > 1) {
-      RexExpression secondOperand = operands.get(1);
-      Preconditions.checkArgument(secondOperand instanceof RexExpression.Literal,
-          "Second operand (offset) of LAG function must be a literal");
-      Object offsetValue = ((RexExpression.Literal) secondOperand).getValue();
-      if (offsetValue instanceof Number) {
-        offset = ((Number) offsetValue).intValue();
-      }
-    }
-    if (numOperands == 3) {
-      RexExpression thirdOperand = operands.get(2);
-      Preconditions.checkArgument(thirdOperand instanceof RexExpression.Literal,
-          "Third operand (default value) of LAG function must be a literal");
-      RexExpression.Literal defaultValueLiteral = (RexExpression.Literal) thirdOperand;
-      defaultValue = defaultValueLiteral.getValue();
-      if (defaultValue != null) {
-        DataSchema.ColumnDataType srcDataType = defaultValueLiteral.getDataType();
-        DataSchema.ColumnDataType destDataType = getDataType();
-        if (srcDataType != destDataType) {
-          // Convert the default value to the same data type as the input column
-          // (e.g. convert INT to LONG, FLOAT to DOUBLE, etc.
-          defaultValue = destDataType.toPinotDataType().convert(defaultValue, srcDataType.toPinotDataType());
-        }
-      }
-    }
-    _offset = offset;
-    _defaultValue = defaultValue;
   }
 
   @Override
   public List<Object> processRows(List<Object[]> rows) {
+    if (_ignoreNulls && _offset > 0) {
+      // Iterate front-to-back so the sliding window holds the preceding non-null values.
+      return processRowsIgnoreNulls(rows, true);
+    }
     int numRows = rows.size();
     Object[] result = new Object[numRows];
     if (_defaultValue != null) {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/value/LeadValueWindowFunction.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/value/LeadValueWindowFunction.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.query.runtime.operator.window.value;
 
-import com.google.common.base.Preconditions;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.calcite.rel.RelFieldCollation;
@@ -28,51 +27,23 @@ import org.apache.pinot.query.runtime.operator.window.WindowFrame;
 
 
 /**
- * The LAG window function doesn't allow custom window frames (and this is enforced by Calcite).
+ * Window function that returns the value of a column from a subsequent row within the partition. Supports an optional
+ * offset (default 1), an optional default value for when no row exists at that offset, and IGNORE NULLS mode which
+ * skips null values when scanning forward. Custom window frames are not allowed (enforced by Calcite).
  */
-public class LeadValueWindowFunction extends ValueWindowFunction {
-
-  private final int _offset;
-  private final Object _defaultValue;
+public class LeadValueWindowFunction extends OffsetValueWindowFunction {
 
   public LeadValueWindowFunction(RexExpression.FunctionCall aggCall, DataSchema inputSchema,
       List<RelFieldCollation> collations, WindowFrame windowFrame) {
     super(aggCall, inputSchema, collations, windowFrame);
-    int offset = 1;
-    Object defaultValue = null;
-    List<RexExpression> operands = aggCall.getFunctionOperands();
-    int numOperands = operands.size();
-    if (numOperands > 1) {
-      RexExpression secondOperand = operands.get(1);
-      Preconditions.checkArgument(secondOperand instanceof RexExpression.Literal,
-          "Second operand (offset) of LEAD function must be a literal");
-      Object offsetValue = ((RexExpression.Literal) secondOperand).getValue();
-      if (offsetValue instanceof Number) {
-        offset = ((Number) offsetValue).intValue();
-      }
-    }
-    if (numOperands == 3) {
-      RexExpression thirdOperand = operands.get(2);
-      Preconditions.checkArgument(thirdOperand instanceof RexExpression.Literal,
-          "Third operand (default value) of LEAD function must be a literal");
-      RexExpression.Literal defaultValueLiteral = (RexExpression.Literal) thirdOperand;
-      defaultValue = defaultValueLiteral.getValue();
-      if (defaultValue != null) {
-        DataSchema.ColumnDataType srcDataType = defaultValueLiteral.getDataType();
-        DataSchema.ColumnDataType destDataType = inputSchema.getColumnDataType(0);
-        if (srcDataType != destDataType) {
-          // Convert the default value to the same data type as the input column
-          // (e.g. convert INT to LONG, FLOAT to DOUBLE, etc.
-          defaultValue = destDataType.toPinotDataType().convert(defaultValue, srcDataType.toPinotDataType());
-        }
-      }
-    }
-    _offset = offset;
-    _defaultValue = defaultValue;
   }
 
   @Override
   public List<Object> processRows(List<Object[]> rows) {
+    if (_ignoreNulls && _offset > 0) {
+      // Iterate back-to-front so the sliding window holds the upcoming non-null values.
+      return processRowsIgnoreNulls(rows, false);
+    }
     int numRows = rows.size();
     Object[] result = new Object[numRows];
     for (int i = 0; i < numRows - _offset; i++) {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/value/LeadValueWindowFunction.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/value/LeadValueWindowFunction.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.query.runtime.operator.window.value;
 
 import com.google.common.base.Preconditions;
+import java.util.ArrayDeque;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.calcite.rel.RelFieldCollation;
@@ -28,9 +29,10 @@ import org.apache.pinot.query.planner.logical.RexExpression;
 import org.apache.pinot.query.runtime.operator.window.WindowFrame;
 
 
-/**
- * The LAG window function doesn't allow custom window frames (and this is enforced by Calcite).
- */
+/// Window function that returns the value of a column from a subsequent row within the partition.
+/// Supports an optional offset (default 1), an optional default value for when no row exists at
+/// that offset, and IGNORE NULLS mode which skips null values when scanning forward.
+/// Custom window frames are not allowed (enforced by Calcite).
 public class LeadValueWindowFunction extends ValueWindowFunction {
 
   private final int _offset;
@@ -75,6 +77,9 @@ public class LeadValueWindowFunction extends ValueWindowFunction {
 
   @Override
   public List<Object> processRows(List<Object[]> rows) {
+    if (_ignoreNulls) {
+      return processRowsIgnoreNulls(rows);
+    }
     int numRows = rows.size();
     Object[] result = new Object[numRows];
     for (int i = 0; i < numRows - _offset; i++) {
@@ -85,6 +90,30 @@ public class LeadValueWindowFunction extends ValueWindowFunction {
       // only down to 0.
       int fillFrom = Math.max(numRows - _offset, 0);
       Arrays.fill(result, fillFrom, numRows, _defaultValue);
+    }
+    return Arrays.asList(result);
+  }
+
+  /**
+   * LEAD with IGNORE NULLS: for each row, find the offset-th non-null value scanning forward.
+   * Uses a bounded deque of size {@code _offset} for O(N) time and O(offset) memory.
+   * Scans right-to-left, maintaining a sliding window of upcoming non-null values. The oldest
+   * element in the deque (peekFirst) is always the offset-th non-null value ahead of the current
+   * row.
+   */
+  private List<Object> processRowsIgnoreNulls(List<Object[]> rows) {
+    int numRows = rows.size();
+    Object[] result = new Object[numRows];
+    ArrayDeque<Object> window = new ArrayDeque<>(_offset);
+    for (int i = numRows - 1; i >= 0; i--) {
+      result[i] = (window.size() == _offset) ? window.peekFirst() : _defaultValue;
+      Object val = extractValueFromRow(rows.get(i));
+      if (val != null) {
+        window.addLast(val);
+        if (window.size() > _offset) {
+          window.pollFirst();
+        }
+      }
     }
     return Arrays.asList(result);
   }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/value/OffsetValueWindowFunction.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/window/value/OffsetValueWindowFunction.java
@@ -1,0 +1,121 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.operator.window.value;
+
+import com.google.common.base.Preconditions;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.List;
+import javax.annotation.Nullable;
+import org.apache.calcite.rel.RelFieldCollation;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.query.planner.logical.RexExpression;
+import org.apache.pinot.query.runtime.operator.window.WindowFrame;
+
+
+/**
+ * Base class for the offset-based value window functions {@code LAG} and {@code LEAD}. Both return the value of the
+ * function's argument from a row at a fixed offset (default 1) before ({@code LAG}) or after ({@code LEAD}) the current
+ * row within the partition, support an optional default value emitted when no such row exists, and support the
+ * {@code IGNORE NULLS} option which skips null values when counting the offset.
+ *
+ * <p>Custom window frames are not allowed for these functions (enforced by Calcite).
+ *
+ * <p>Instances are not thread-safe. The multi-stage window operator creates one instance per operator and invokes it
+ * from at most one thread at a time (never concurrently), so no synchronization is required.
+ */
+public abstract class OffsetValueWindowFunction extends ValueWindowFunction {
+  protected final int _offset;
+  @Nullable
+  protected final Object _defaultValue;
+
+  public OffsetValueWindowFunction(RexExpression.FunctionCall aggCall, DataSchema inputSchema,
+      List<RelFieldCollation> collations, WindowFrame windowFrame) {
+    super(aggCall, inputSchema, collations, windowFrame);
+    String functionName = aggCall.getFunctionName();
+    List<RexExpression> operands = aggCall.getFunctionOperands();
+    int numOperands = operands.size();
+    Preconditions.checkArgument(numOperands > 0, "%s function requires at least one operand", functionName);
+    int offset = 1;
+    if (numOperands > 1) {
+      RexExpression secondOperand = operands.get(1);
+      Preconditions.checkArgument(secondOperand instanceof RexExpression.Literal,
+          "Second operand (offset) of %s function must be a literal", functionName);
+      Object offsetValue = ((RexExpression.Literal) secondOperand).getValue();
+      if (offsetValue instanceof Number) {
+        offset = ((Number) offsetValue).intValue();
+      }
+    }
+    Object defaultValue = null;
+    if (numOperands == 3) {
+      RexExpression thirdOperand = operands.get(2);
+      Preconditions.checkArgument(thirdOperand instanceof RexExpression.Literal,
+          "Third operand (default value) of %s function must be a literal", functionName);
+      RexExpression.Literal defaultValueLiteral = (RexExpression.Literal) thirdOperand;
+      defaultValue = defaultValueLiteral.getValue();
+      if (defaultValue != null) {
+        DataSchema.ColumnDataType srcDataType = defaultValueLiteral.getDataType();
+        // Coerce the default value to the type of the function's value argument (getDataType()) so it matches the type
+        // of the values returned for the non-default rows. Note this is the argument's type, not necessarily the first
+        // input column's type.
+        DataSchema.ColumnDataType destDataType = getDataType();
+        if (srcDataType != destDataType) {
+          defaultValue = destDataType.toPinotDataType().convert(defaultValue, srcDataType.toPinotDataType());
+        }
+      }
+    }
+    _offset = offset;
+    _defaultValue = defaultValue;
+  }
+
+  /**
+   * Shared {@code IGNORE NULLS} implementation for {@code LAG}/{@code LEAD}. Walks the partition in the given direction
+   * maintaining a bounded sliding window of the {@code _offset} most-recently-seen non-null values; when the window is
+   * full, its oldest element ({@code peekFirst()}) is the offset-th non-null value in the scan direction relative to
+   * the current row. Until {@code _offset} non-null values have been seen, the default value is emitted.
+   *
+   * <p>Runs in O(numRows) time and O(min(_offset, numRows)) memory. Requires {@code _offset >= 1}; the degenerate
+   * {@code _offset <= 0} case (which has no null-skipping semantics) must be routed through the RESPECT NULLS path by
+   * the caller.
+   *
+   * @param rows the rows of a single partition, in partition/collation order
+   * @param iterateForward {@code true} to iterate front-to-back (used by {@code LAG}, which looks at preceding rows);
+   *                       {@code false} to iterate back-to-front (used by {@code LEAD}, which looks at following rows)
+   */
+  protected List<Object> processRowsIgnoreNulls(List<Object[]> rows, boolean iterateForward) {
+    int numRows = rows.size();
+    Object[] result = new Object[numRows];
+    // Cap the initial capacity at the number of rows so a pathologically large offset literal can't force a huge eager
+    // allocation (the deque never holds more than min(_offset, numRows) elements). The +1 leaves room for the transient
+    // (_offset + 1)-th element that is added before being polled, avoiding a resize in the common case.
+    ArrayDeque<Object> window = new ArrayDeque<>(Math.min(_offset, numRows) + 1);
+    for (int k = 0; k < numRows; k++) {
+      int i = iterateForward ? k : numRows - 1 - k;
+      result[i] = window.size() == _offset ? window.peekFirst() : _defaultValue;
+      Object value = extractValueFromRow(rows.get(i));
+      if (value != null) {
+        window.addLast(value);
+        if (window.size() > _offset) {
+          window.pollFirst();
+        }
+      }
+    }
+    return Arrays.asList(result);
+  }
+}

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/WindowAggregateOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/WindowAggregateOperatorTest.java
@@ -705,6 +705,302 @@ public class WindowAggregateOperatorTest {
     assertTrue(operator.nextBlock().isSuccess(), "Second block is EOS (done processing)");
   }
 
+  @Test
+  public void testLeadIgnoreNullsWithDefaultOffset() {
+    // Given: LEAD(value) IGNORE NULLS - should find next non-null value
+    DataSchema inputSchema = new DataSchema(new String[]{"group", "value"}, new ColumnDataType[]{INT, INT});
+    MultiStageOperator input = new BlockListMultiStageOperator.Builder(inputSchema)
+        .addRow(1, null)
+        .addRow(1, null)
+        .addRow(1, 10)
+        .addRow(1, 20)
+        .addRow(1, null)
+        .addRow(2, 10)
+        .addRow(2, null)
+        .addRow(2, 20)
+        .addRow(3, null)
+        .addRow(3, null)
+        .buildWithEos();
+    DataSchema resultSchema =
+        new DataSchema(new String[]{"group", "value", "lead"}, new ColumnDataType[]{INT, INT, INT});
+    List<Integer> keys = List.of(0);
+    List<RelFieldCollation> collations =
+        List.of(new RelFieldCollation(1, RelFieldCollation.Direction.ASCENDING, RelFieldCollation.NullDirection.LAST));
+    List<RexExpression.FunctionCall> aggCalls = List.of(
+        new RexExpression.FunctionCall(ColumnDataType.INT, SqlKind.LEAD.name(),
+            List.of(new RexExpression.InputRef(1)), false, true));
+    WindowAggregateOperator operator =
+        getOperator(inputSchema, resultSchema, keys, collations, aggCalls, WindowNode.WindowFrameType.RANGE,
+            Integer.MIN_VALUE, 0, input);
+
+    // When:
+    List<Object[]> resultRows = ((MseBlock.Data) operator.nextBlock()).asRowHeap().getRows();
+
+    // Then:
+    verifyResultRows(resultRows, keys, Map.of(
+        1, List.of(
+            new Object[]{1, null, 10},
+            new Object[]{1, null, 10},
+            new Object[]{1, 10, 20},
+            new Object[]{1, 20, null},
+            new Object[]{1, null, null}),
+        2, List.of(
+            new Object[]{2, 10, 20},
+            new Object[]{2, null, 20},
+            new Object[]{2, 20, null}),
+        3, List.of(
+            new Object[]{3, null, null},
+            new Object[]{3, null, null})
+    ));
+    assertTrue(operator.nextBlock().isSuccess(), "Second block is EOS (done processing)");
+  }
+
+  @Test
+  public void testLeadIgnoreNullsWithOffset() {
+    // Given: LEAD(value, 2) IGNORE NULLS - should find 2nd non-null value ahead
+    DataSchema inputSchema = new DataSchema(new String[]{"group", "value"}, new ColumnDataType[]{INT, INT});
+    MultiStageOperator input = new BlockListMultiStageOperator.Builder(inputSchema)
+        .addRow(1, 10)
+        .addRow(1, null)
+        .addRow(1, 20)
+        .addRow(1, null)
+        .addRow(1, 30)
+        .addRow(1, null)
+        .buildWithEos();
+    DataSchema resultSchema =
+        new DataSchema(new String[]{"group", "value", "lead"}, new ColumnDataType[]{INT, INT, INT});
+    List<Integer> keys = List.of(0);
+    List<RelFieldCollation> collations =
+        List.of(new RelFieldCollation(1, RelFieldCollation.Direction.ASCENDING, RelFieldCollation.NullDirection.LAST));
+    List<RexExpression.FunctionCall> aggCalls = List.of(
+        new RexExpression.FunctionCall(ColumnDataType.INT, SqlKind.LEAD.name(),
+            List.of(new RexExpression.InputRef(1), new RexExpression.Literal(ColumnDataType.INT, 2)), false, true));
+    WindowAggregateOperator operator =
+        getOperator(inputSchema, resultSchema, keys, collations, aggCalls, WindowNode.WindowFrameType.RANGE,
+            Integer.MIN_VALUE, 0, input);
+
+    // When:
+    List<Object[]> resultRows = ((MseBlock.Data) operator.nextBlock()).asRowHeap().getRows();
+
+    // Then:
+    verifyResultRows(resultRows, keys, Map.of(
+        1, List.of(
+            new Object[]{1, 10, 30},
+            new Object[]{1, null, 30},
+            new Object[]{1, 20, null},
+            new Object[]{1, null, null},
+            new Object[]{1, 30, null},
+            new Object[]{1, null, null})
+    ));
+    assertTrue(operator.nextBlock().isSuccess(), "Second block is EOS (done processing)");
+  }
+
+  @Test
+  public void testLeadIgnoreNullsWithOffsetAndDefault() {
+    // Given: LEAD(value, 2, 99) IGNORE NULLS - 2nd non-null value ahead, or 99 if not enough non-nulls
+    DataSchema inputSchema = new DataSchema(new String[]{"group", "value"}, new ColumnDataType[]{INT, INT});
+    MultiStageOperator input = new BlockListMultiStageOperator.Builder(inputSchema)
+        .addRow(1, 10)
+        .addRow(1, null)
+        .addRow(1, 20)
+        .addRow(1, null)
+        .addRow(1, 30)
+        .addRow(1, null)
+        .buildWithEos();
+    DataSchema resultSchema =
+        new DataSchema(new String[]{"group", "value", "lead"}, new ColumnDataType[]{INT, INT, INT});
+    List<Integer> keys = List.of(0);
+    List<RelFieldCollation> collations =
+        List.of(new RelFieldCollation(1, RelFieldCollation.Direction.ASCENDING, RelFieldCollation.NullDirection.LAST));
+    List<RexExpression.FunctionCall> aggCalls = List.of(
+        new RexExpression.FunctionCall(ColumnDataType.INT, SqlKind.LEAD.name(),
+            List.of(new RexExpression.InputRef(1), new RexExpression.Literal(ColumnDataType.INT, 2),
+                new RexExpression.Literal(ColumnDataType.INT, 99)), false, true));
+    WindowAggregateOperator operator =
+        getOperator(inputSchema, resultSchema, keys, collations, aggCalls, WindowNode.WindowFrameType.RANGE,
+            Integer.MIN_VALUE, 0, input);
+
+    // When:
+    List<Object[]> resultRows = ((MseBlock.Data) operator.nextBlock()).asRowHeap().getRows();
+
+    // Then:
+    verifyResultRows(resultRows, keys, Map.of(
+        1, List.of(
+            new Object[]{1, 10, 30},
+            new Object[]{1, null, 30},
+            new Object[]{1, 20, 99},
+            new Object[]{1, null, 99},
+            new Object[]{1, 30, 99},
+            new Object[]{1, null, 99})
+    ));
+    assertTrue(operator.nextBlock().isSuccess(), "Second block is EOS (done processing)");
+  }
+
+  @Test
+  public void testLagIgnoreNullsWithDefaultOffset() {
+    // Given: LAG(value) IGNORE NULLS - should find previous non-null value
+    DataSchema inputSchema = new DataSchema(new String[]{"group", "value"}, new ColumnDataType[]{INT, INT});
+    MultiStageOperator input = new BlockListMultiStageOperator.Builder(inputSchema)
+        .addRow(1, null)
+        .addRow(1, null)
+        .addRow(1, 10)
+        .addRow(1, 20)
+        .addRow(1, null)
+        .addRow(2, 10)
+        .addRow(2, null)
+        .addRow(2, 20)
+        .addRow(3, null)
+        .addRow(3, null)
+        .buildWithEos();
+    DataSchema resultSchema =
+        new DataSchema(new String[]{"group", "value", "lag"}, new ColumnDataType[]{INT, INT, INT});
+    List<Integer> keys = List.of(0);
+    List<RelFieldCollation> collations =
+        List.of(new RelFieldCollation(1, RelFieldCollation.Direction.ASCENDING, RelFieldCollation.NullDirection.LAST));
+    List<RexExpression.FunctionCall> aggCalls = List.of(
+        new RexExpression.FunctionCall(ColumnDataType.INT, SqlKind.LAG.name(),
+            List.of(new RexExpression.InputRef(1)), false, true));
+    WindowAggregateOperator operator =
+        getOperator(inputSchema, resultSchema, keys, collations, aggCalls, WindowNode.WindowFrameType.RANGE,
+            Integer.MIN_VALUE, 0, input);
+
+    // When:
+    List<Object[]> resultRows = ((MseBlock.Data) operator.nextBlock()).asRowHeap().getRows();
+
+    // Then:
+    verifyResultRows(resultRows, keys, Map.of(
+        1, List.of(
+            new Object[]{1, null, null},
+            new Object[]{1, null, null},
+            new Object[]{1, 10, null},
+            new Object[]{1, 20, 10},
+            new Object[]{1, null, 20}),
+        2, List.of(
+            new Object[]{2, 10, null},
+            new Object[]{2, null, 10},
+            new Object[]{2, 20, 10}),
+        3, List.of(
+            new Object[]{3, null, null},
+            new Object[]{3, null, null})
+    ));
+    assertTrue(operator.nextBlock().isSuccess(), "Second block is EOS (done processing)");
+  }
+
+  @Test
+  public void testLagIgnoreNullsWithOffset() {
+    // Given: LAG(value, 2) IGNORE NULLS - should find 2nd non-null value behind
+    DataSchema inputSchema = new DataSchema(new String[]{"group", "value"}, new ColumnDataType[]{INT, INT});
+    MultiStageOperator input = new BlockListMultiStageOperator.Builder(inputSchema)
+        .addRow(1, 10)
+        .addRow(1, null)
+        .addRow(1, 20)
+        .addRow(1, null)
+        .addRow(1, 30)
+        .addRow(1, null)
+        .buildWithEos();
+    DataSchema resultSchema =
+        new DataSchema(new String[]{"group", "value", "lag"}, new ColumnDataType[]{INT, INT, INT});
+    List<Integer> keys = List.of(0);
+    List<RelFieldCollation> collations =
+        List.of(new RelFieldCollation(1, RelFieldCollation.Direction.ASCENDING, RelFieldCollation.NullDirection.LAST));
+    List<RexExpression.FunctionCall> aggCalls = List.of(
+        new RexExpression.FunctionCall(ColumnDataType.INT, SqlKind.LAG.name(),
+            List.of(new RexExpression.InputRef(1), new RexExpression.Literal(ColumnDataType.INT, 2)), false, true));
+    WindowAggregateOperator operator =
+        getOperator(inputSchema, resultSchema, keys, collations, aggCalls, WindowNode.WindowFrameType.RANGE,
+            Integer.MIN_VALUE, 0, input);
+
+    // When:
+    List<Object[]> resultRows = ((MseBlock.Data) operator.nextBlock()).asRowHeap().getRows();
+
+    // Then:
+    verifyResultRows(resultRows, keys, Map.of(
+        1, List.of(
+            new Object[]{1, 10, null},
+            new Object[]{1, null, null},
+            new Object[]{1, 20, null},
+            new Object[]{1, null, 10},
+            new Object[]{1, 30, 10},
+            new Object[]{1, null, 20})
+    ));
+    assertTrue(operator.nextBlock().isSuccess(), "Second block is EOS (done processing)");
+  }
+
+  @Test
+  public void testLagIgnoreNullsWithOffsetAndDefault() {
+    // Given: LAG(value, 2, 99) IGNORE NULLS - 2nd non-null value behind, or 99 if not enough non-nulls
+    DataSchema inputSchema = new DataSchema(new String[]{"group", "value"}, new ColumnDataType[]{INT, INT});
+    MultiStageOperator input = new BlockListMultiStageOperator.Builder(inputSchema)
+        .addRow(1, 10)
+        .addRow(1, null)
+        .addRow(1, 20)
+        .addRow(1, null)
+        .addRow(1, 30)
+        .addRow(1, null)
+        .buildWithEos();
+    DataSchema resultSchema =
+        new DataSchema(new String[]{"group", "value", "lag"}, new ColumnDataType[]{INT, INT, INT});
+    List<Integer> keys = List.of(0);
+    List<RelFieldCollation> collations =
+        List.of(new RelFieldCollation(1, RelFieldCollation.Direction.ASCENDING, RelFieldCollation.NullDirection.LAST));
+    List<RexExpression.FunctionCall> aggCalls = List.of(
+        new RexExpression.FunctionCall(ColumnDataType.INT, SqlKind.LAG.name(),
+            List.of(new RexExpression.InputRef(1), new RexExpression.Literal(ColumnDataType.INT, 2),
+                new RexExpression.Literal(ColumnDataType.INT, 99)), false, true));
+    WindowAggregateOperator operator =
+        getOperator(inputSchema, resultSchema, keys, collations, aggCalls, WindowNode.WindowFrameType.RANGE,
+            Integer.MIN_VALUE, 0, input);
+
+    // When:
+    List<Object[]> resultRows = ((MseBlock.Data) operator.nextBlock()).asRowHeap().getRows();
+
+    // Then:
+    verifyResultRows(resultRows, keys, Map.of(
+        1, List.of(
+            new Object[]{1, 10, 99},
+            new Object[]{1, null, 99},
+            new Object[]{1, 20, 99},
+            new Object[]{1, null, 10},
+            new Object[]{1, 30, 10},
+            new Object[]{1, null, 20})
+    ));
+    assertTrue(operator.nextBlock().isSuccess(), "Second block is EOS (done processing)");
+  }
+
+  @Test
+  public void testLeadIgnoreNullsAllNulls() {
+    // Given: LEAD(value) IGNORE NULLS where all values are null
+    DataSchema inputSchema = new DataSchema(new String[]{"group", "value"}, new ColumnDataType[]{INT, INT});
+    MultiStageOperator input = new BlockListMultiStageOperator.Builder(inputSchema)
+        .addRow(1, null)
+        .addRow(1, null)
+        .addRow(1, null)
+        .buildWithEos();
+    DataSchema resultSchema =
+        new DataSchema(new String[]{"group", "value", "lead"}, new ColumnDataType[]{INT, INT, INT});
+    List<Integer> keys = List.of(0);
+    List<RelFieldCollation> collations =
+        List.of(new RelFieldCollation(1, RelFieldCollation.Direction.ASCENDING, RelFieldCollation.NullDirection.LAST));
+    List<RexExpression.FunctionCall> aggCalls = List.of(
+        new RexExpression.FunctionCall(ColumnDataType.INT, SqlKind.LEAD.name(),
+            List.of(new RexExpression.InputRef(1)), false, true));
+    WindowAggregateOperator operator =
+        getOperator(inputSchema, resultSchema, keys, collations, aggCalls, WindowNode.WindowFrameType.RANGE,
+            Integer.MIN_VALUE, 0, input);
+
+    // When:
+    List<Object[]> resultRows = ((MseBlock.Data) operator.nextBlock()).asRowHeap().getRows();
+
+    // Then:
+    verifyResultRows(resultRows, keys, Map.of(
+        1, List.of(
+            new Object[]{1, null, null},
+            new Object[]{1, null, null},
+            new Object[]{1, null, null})
+    ));
+    assertTrue(operator.nextBlock().isSuccess(), "Second block is EOS (done processing)");
+  }
+
   @Test(dataProvider = "windowFrameTypes")
   public void testSumWithUnboundedPrecedingLowerAndUnboundedFollowingUpper(WindowNode.WindowFrameType frameType) {
     // Given:

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/WindowAggregateOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/WindowAggregateOperatorTest.java
@@ -706,6 +706,454 @@ public class WindowAggregateOperatorTest {
     assertTrue(operator.nextBlock().isSuccess(), "Second block is EOS (done processing)");
   }
 
+  @Test
+  public void testLeadIgnoreNullsWithDefaultOffset() {
+    // Given: LEAD(value) IGNORE NULLS - should find next non-null value
+    DataSchema inputSchema = new DataSchema(new String[]{"group", "value"}, new ColumnDataType[]{INT, INT});
+    MultiStageOperator input = new BlockListMultiStageOperator.Builder(inputSchema)
+        .addRow(1, null)
+        .addRow(1, null)
+        .addRow(1, 10)
+        .addRow(1, 20)
+        .addRow(1, null)
+        .addRow(2, 10)
+        .addRow(2, null)
+        .addRow(2, 20)
+        .addRow(3, null)
+        .addRow(3, null)
+        .buildWithEos();
+    DataSchema resultSchema =
+        new DataSchema(new String[]{"group", "value", "lead"}, new ColumnDataType[]{INT, INT, INT});
+    List<Integer> keys = List.of(0);
+    List<RelFieldCollation> collations =
+        List.of(new RelFieldCollation(1, RelFieldCollation.Direction.ASCENDING, RelFieldCollation.NullDirection.LAST));
+    List<RexExpression.FunctionCall> aggCalls = List.of(
+        new RexExpression.FunctionCall(ColumnDataType.INT, SqlKind.LEAD.name(),
+            List.of(new RexExpression.InputRef(1)), false, true));
+    WindowAggregateOperator operator =
+        getOperator(inputSchema, resultSchema, keys, collations, aggCalls, WindowNode.WindowFrameType.RANGE,
+            Integer.MIN_VALUE, 0, input);
+
+    // When:
+    List<Object[]> resultRows = ((MseBlock.Data) operator.nextBlock()).asRowHeap().getRows();
+
+    // Then:
+    verifyResultRows(resultRows, keys, Map.of(
+        1, List.of(
+            new Object[]{1, null, 10},
+            new Object[]{1, null, 10},
+            new Object[]{1, 10, 20},
+            new Object[]{1, 20, null},
+            new Object[]{1, null, null}),
+        2, List.of(
+            new Object[]{2, 10, 20},
+            new Object[]{2, null, 20},
+            new Object[]{2, 20, null}),
+        3, List.of(
+            new Object[]{3, null, null},
+            new Object[]{3, null, null})
+    ));
+    assertTrue(operator.nextBlock().isSuccess(), "Second block is EOS (done processing)");
+  }
+
+  @Test
+  public void testLeadIgnoreNullsWithOffset() {
+    // Given: LEAD(value, 2) IGNORE NULLS - should find 2nd non-null value ahead
+    DataSchema inputSchema = new DataSchema(new String[]{"group", "value"}, new ColumnDataType[]{INT, INT});
+    MultiStageOperator input = new BlockListMultiStageOperator.Builder(inputSchema)
+        .addRow(1, 10)
+        .addRow(1, null)
+        .addRow(1, 20)
+        .addRow(1, null)
+        .addRow(1, 30)
+        .addRow(1, null)
+        .buildWithEos();
+    DataSchema resultSchema =
+        new DataSchema(new String[]{"group", "value", "lead"}, new ColumnDataType[]{INT, INT, INT});
+    List<Integer> keys = List.of(0);
+    List<RelFieldCollation> collations =
+        List.of(new RelFieldCollation(1, RelFieldCollation.Direction.ASCENDING, RelFieldCollation.NullDirection.LAST));
+    List<RexExpression.FunctionCall> aggCalls = List.of(
+        new RexExpression.FunctionCall(ColumnDataType.INT, SqlKind.LEAD.name(),
+            List.of(new RexExpression.InputRef(1), new RexExpression.Literal(ColumnDataType.INT, 2)), false, true));
+    WindowAggregateOperator operator =
+        getOperator(inputSchema, resultSchema, keys, collations, aggCalls, WindowNode.WindowFrameType.RANGE,
+            Integer.MIN_VALUE, 0, input);
+
+    // When:
+    List<Object[]> resultRows = ((MseBlock.Data) operator.nextBlock()).asRowHeap().getRows();
+
+    // Then:
+    verifyResultRows(resultRows, keys, Map.of(
+        1, List.of(
+            new Object[]{1, 10, 30},
+            new Object[]{1, null, 30},
+            new Object[]{1, 20, null},
+            new Object[]{1, null, null},
+            new Object[]{1, 30, null},
+            new Object[]{1, null, null})
+    ));
+    assertTrue(operator.nextBlock().isSuccess(), "Second block is EOS (done processing)");
+  }
+
+  @Test
+  public void testLeadIgnoreNullsWithOffsetAndDefault() {
+    // Given: LEAD(value, 2, 99) IGNORE NULLS - 2nd non-null value ahead, or 99 if not enough non-nulls
+    DataSchema inputSchema = new DataSchema(new String[]{"group", "value"}, new ColumnDataType[]{INT, INT});
+    MultiStageOperator input = new BlockListMultiStageOperator.Builder(inputSchema)
+        .addRow(1, 10)
+        .addRow(1, null)
+        .addRow(1, 20)
+        .addRow(1, null)
+        .addRow(1, 30)
+        .addRow(1, null)
+        .buildWithEos();
+    DataSchema resultSchema =
+        new DataSchema(new String[]{"group", "value", "lead"}, new ColumnDataType[]{INT, INT, INT});
+    List<Integer> keys = List.of(0);
+    List<RelFieldCollation> collations =
+        List.of(new RelFieldCollation(1, RelFieldCollation.Direction.ASCENDING, RelFieldCollation.NullDirection.LAST));
+    List<RexExpression.FunctionCall> aggCalls = List.of(
+        new RexExpression.FunctionCall(ColumnDataType.INT, SqlKind.LEAD.name(),
+            List.of(new RexExpression.InputRef(1), new RexExpression.Literal(ColumnDataType.INT, 2),
+                new RexExpression.Literal(ColumnDataType.INT, 99)), false, true));
+    WindowAggregateOperator operator =
+        getOperator(inputSchema, resultSchema, keys, collations, aggCalls, WindowNode.WindowFrameType.RANGE,
+            Integer.MIN_VALUE, 0, input);
+
+    // When:
+    List<Object[]> resultRows = ((MseBlock.Data) operator.nextBlock()).asRowHeap().getRows();
+
+    // Then:
+    verifyResultRows(resultRows, keys, Map.of(
+        1, List.of(
+            new Object[]{1, 10, 30},
+            new Object[]{1, null, 30},
+            new Object[]{1, 20, 99},
+            new Object[]{1, null, 99},
+            new Object[]{1, 30, 99},
+            new Object[]{1, null, 99})
+    ));
+    assertTrue(operator.nextBlock().isSuccess(), "Second block is EOS (done processing)");
+  }
+
+  @Test
+  public void testLagIgnoreNullsWithDefaultOffset() {
+    // Given: LAG(value) IGNORE NULLS - should find previous non-null value
+    DataSchema inputSchema = new DataSchema(new String[]{"group", "value"}, new ColumnDataType[]{INT, INT});
+    MultiStageOperator input = new BlockListMultiStageOperator.Builder(inputSchema)
+        .addRow(1, null)
+        .addRow(1, null)
+        .addRow(1, 10)
+        .addRow(1, 20)
+        .addRow(1, null)
+        .addRow(2, 10)
+        .addRow(2, null)
+        .addRow(2, 20)
+        .addRow(3, null)
+        .addRow(3, null)
+        .buildWithEos();
+    DataSchema resultSchema =
+        new DataSchema(new String[]{"group", "value", "lag"}, new ColumnDataType[]{INT, INT, INT});
+    List<Integer> keys = List.of(0);
+    List<RelFieldCollation> collations =
+        List.of(new RelFieldCollation(1, RelFieldCollation.Direction.ASCENDING, RelFieldCollation.NullDirection.LAST));
+    List<RexExpression.FunctionCall> aggCalls = List.of(
+        new RexExpression.FunctionCall(ColumnDataType.INT, SqlKind.LAG.name(),
+            List.of(new RexExpression.InputRef(1)), false, true));
+    WindowAggregateOperator operator =
+        getOperator(inputSchema, resultSchema, keys, collations, aggCalls, WindowNode.WindowFrameType.RANGE,
+            Integer.MIN_VALUE, 0, input);
+
+    // When:
+    List<Object[]> resultRows = ((MseBlock.Data) operator.nextBlock()).asRowHeap().getRows();
+
+    // Then:
+    verifyResultRows(resultRows, keys, Map.of(
+        1, List.of(
+            new Object[]{1, null, null},
+            new Object[]{1, null, null},
+            new Object[]{1, 10, null},
+            new Object[]{1, 20, 10},
+            new Object[]{1, null, 20}),
+        2, List.of(
+            new Object[]{2, 10, null},
+            new Object[]{2, null, 10},
+            new Object[]{2, 20, 10}),
+        3, List.of(
+            new Object[]{3, null, null},
+            new Object[]{3, null, null})
+    ));
+    assertTrue(operator.nextBlock().isSuccess(), "Second block is EOS (done processing)");
+  }
+
+  @Test
+  public void testLagIgnoreNullsWithOffset() {
+    // Given: LAG(value, 2) IGNORE NULLS - should find 2nd non-null value behind
+    DataSchema inputSchema = new DataSchema(new String[]{"group", "value"}, new ColumnDataType[]{INT, INT});
+    MultiStageOperator input = new BlockListMultiStageOperator.Builder(inputSchema)
+        .addRow(1, 10)
+        .addRow(1, null)
+        .addRow(1, 20)
+        .addRow(1, null)
+        .addRow(1, 30)
+        .addRow(1, null)
+        .buildWithEos();
+    DataSchema resultSchema =
+        new DataSchema(new String[]{"group", "value", "lag"}, new ColumnDataType[]{INT, INT, INT});
+    List<Integer> keys = List.of(0);
+    List<RelFieldCollation> collations =
+        List.of(new RelFieldCollation(1, RelFieldCollation.Direction.ASCENDING, RelFieldCollation.NullDirection.LAST));
+    List<RexExpression.FunctionCall> aggCalls = List.of(
+        new RexExpression.FunctionCall(ColumnDataType.INT, SqlKind.LAG.name(),
+            List.of(new RexExpression.InputRef(1), new RexExpression.Literal(ColumnDataType.INT, 2)), false, true));
+    WindowAggregateOperator operator =
+        getOperator(inputSchema, resultSchema, keys, collations, aggCalls, WindowNode.WindowFrameType.RANGE,
+            Integer.MIN_VALUE, 0, input);
+
+    // When:
+    List<Object[]> resultRows = ((MseBlock.Data) operator.nextBlock()).asRowHeap().getRows();
+
+    // Then:
+    verifyResultRows(resultRows, keys, Map.of(
+        1, List.of(
+            new Object[]{1, 10, null},
+            new Object[]{1, null, null},
+            new Object[]{1, 20, null},
+            new Object[]{1, null, 10},
+            new Object[]{1, 30, 10},
+            new Object[]{1, null, 20})
+    ));
+    assertTrue(operator.nextBlock().isSuccess(), "Second block is EOS (done processing)");
+  }
+
+  @Test
+  public void testLagIgnoreNullsWithOffsetAndDefault() {
+    // Given: LAG(value, 2, 99) IGNORE NULLS - 2nd non-null value behind, or 99 if not enough non-nulls
+    DataSchema inputSchema = new DataSchema(new String[]{"group", "value"}, new ColumnDataType[]{INT, INT});
+    MultiStageOperator input = new BlockListMultiStageOperator.Builder(inputSchema)
+        .addRow(1, 10)
+        .addRow(1, null)
+        .addRow(1, 20)
+        .addRow(1, null)
+        .addRow(1, 30)
+        .addRow(1, null)
+        .buildWithEos();
+    DataSchema resultSchema =
+        new DataSchema(new String[]{"group", "value", "lag"}, new ColumnDataType[]{INT, INT, INT});
+    List<Integer> keys = List.of(0);
+    List<RelFieldCollation> collations =
+        List.of(new RelFieldCollation(1, RelFieldCollation.Direction.ASCENDING, RelFieldCollation.NullDirection.LAST));
+    List<RexExpression.FunctionCall> aggCalls = List.of(
+        new RexExpression.FunctionCall(ColumnDataType.INT, SqlKind.LAG.name(),
+            List.of(new RexExpression.InputRef(1), new RexExpression.Literal(ColumnDataType.INT, 2),
+                new RexExpression.Literal(ColumnDataType.INT, 99)), false, true));
+    WindowAggregateOperator operator =
+        getOperator(inputSchema, resultSchema, keys, collations, aggCalls, WindowNode.WindowFrameType.RANGE,
+            Integer.MIN_VALUE, 0, input);
+
+    // When:
+    List<Object[]> resultRows = ((MseBlock.Data) operator.nextBlock()).asRowHeap().getRows();
+
+    // Then:
+    verifyResultRows(resultRows, keys, Map.of(
+        1, List.of(
+            new Object[]{1, 10, 99},
+            new Object[]{1, null, 99},
+            new Object[]{1, 20, 99},
+            new Object[]{1, null, 10},
+            new Object[]{1, 30, 10},
+            new Object[]{1, null, 20})
+    ));
+    assertTrue(operator.nextBlock().isSuccess(), "Second block is EOS (done processing)");
+  }
+
+  @Test
+  public void testLeadIgnoreNullsAllNulls() {
+    // Given: LEAD(value) IGNORE NULLS where all values are null
+    DataSchema inputSchema = new DataSchema(new String[]{"group", "value"}, new ColumnDataType[]{INT, INT});
+    MultiStageOperator input = new BlockListMultiStageOperator.Builder(inputSchema)
+        .addRow(1, null)
+        .addRow(1, null)
+        .addRow(1, null)
+        .buildWithEos();
+    DataSchema resultSchema =
+        new DataSchema(new String[]{"group", "value", "lead"}, new ColumnDataType[]{INT, INT, INT});
+    List<Integer> keys = List.of(0);
+    List<RelFieldCollation> collations =
+        List.of(new RelFieldCollation(1, RelFieldCollation.Direction.ASCENDING, RelFieldCollation.NullDirection.LAST));
+    List<RexExpression.FunctionCall> aggCalls = List.of(
+        new RexExpression.FunctionCall(ColumnDataType.INT, SqlKind.LEAD.name(),
+            List.of(new RexExpression.InputRef(1)), false, true));
+    WindowAggregateOperator operator =
+        getOperator(inputSchema, resultSchema, keys, collations, aggCalls, WindowNode.WindowFrameType.RANGE,
+            Integer.MIN_VALUE, 0, input);
+
+    // When:
+    List<Object[]> resultRows = ((MseBlock.Data) operator.nextBlock()).asRowHeap().getRows();
+
+    // Then:
+    verifyResultRows(resultRows, keys, Map.of(
+        1, List.of(
+            new Object[]{1, null, null},
+            new Object[]{1, null, null},
+            new Object[]{1, null, null})
+    ));
+    assertTrue(operator.nextBlock().isSuccess(), "Second block is EOS (done processing)");
+  }
+
+  @Test
+  public void testLeadIgnoreNullsStringValueWithDefault() {
+    // Given: LEAD(value, 2, '99') IGNORE NULLS over a STRING value column. The value argument is column 1 while the
+    // partition/group column (column 0) is INT, so this also verifies the default value is coerced to the argument's
+    // type (STRING) rather than to the first input column's type (INT).
+    DataSchema inputSchema = new DataSchema(new String[]{"group", "value"}, new ColumnDataType[]{INT, STRING});
+    MultiStageOperator input = new BlockListMultiStageOperator.Builder(inputSchema)
+        .addRow(1, "a")
+        .addRow(1, null)
+        .addRow(1, "b")
+        .addRow(1, null)
+        .addRow(1, "c")
+        .addRow(1, null)
+        .buildWithEos();
+    DataSchema resultSchema =
+        new DataSchema(new String[]{"group", "value", "lead"}, new ColumnDataType[]{INT, STRING, STRING});
+    List<Integer> keys = List.of(0);
+    List<RelFieldCollation> collations =
+        List.of(new RelFieldCollation(1, RelFieldCollation.Direction.ASCENDING, RelFieldCollation.NullDirection.LAST));
+    List<RexExpression.FunctionCall> aggCalls = List.of(
+        new RexExpression.FunctionCall(ColumnDataType.STRING, SqlKind.LEAD.name(),
+            List.of(new RexExpression.InputRef(1), new RexExpression.Literal(ColumnDataType.INT, 2),
+                new RexExpression.Literal(ColumnDataType.STRING, "99")), false, true));
+    WindowAggregateOperator operator =
+        getOperator(inputSchema, resultSchema, keys, collations, aggCalls, WindowNode.WindowFrameType.RANGE,
+            Integer.MIN_VALUE, 0, input);
+
+    // When:
+    List<Object[]> resultRows = ((MseBlock.Data) operator.nextBlock()).asRowHeap().getRows();
+
+    // Then: the default is emitted as the STRING "99" (not coerced to an INT), matching the value column type.
+    verifyResultRows(resultRows, keys, Map.of(
+        1, List.of(
+            new Object[]{1, "a", "c"},
+            new Object[]{1, null, "c"},
+            new Object[]{1, "b", "99"},
+            new Object[]{1, null, "99"},
+            new Object[]{1, "c", "99"},
+            new Object[]{1, null, "99"})
+    ));
+    assertTrue(operator.nextBlock().isSuccess(), "Second block is EOS (done processing)");
+  }
+
+  @Test
+  public void testLagIgnoreNullsDoubleValue() {
+    // Given: LAG(value) IGNORE NULLS over a DOUBLE value column - previous non-null value.
+    DataSchema inputSchema = new DataSchema(new String[]{"group", "value"}, new ColumnDataType[]{INT, DOUBLE});
+    MultiStageOperator input = new BlockListMultiStageOperator.Builder(inputSchema)
+        .addRow(1, null)
+        .addRow(1, null)
+        .addRow(1, 10.5)
+        .addRow(1, 20.5)
+        .addRow(1, null)
+        .buildWithEos();
+    DataSchema resultSchema =
+        new DataSchema(new String[]{"group", "value", "lag"}, new ColumnDataType[]{INT, DOUBLE, DOUBLE});
+    List<Integer> keys = List.of(0);
+    List<RelFieldCollation> collations =
+        List.of(new RelFieldCollation(1, RelFieldCollation.Direction.ASCENDING, RelFieldCollation.NullDirection.LAST));
+    List<RexExpression.FunctionCall> aggCalls = List.of(
+        new RexExpression.FunctionCall(ColumnDataType.DOUBLE, SqlKind.LAG.name(),
+            List.of(new RexExpression.InputRef(1)), false, true));
+    WindowAggregateOperator operator =
+        getOperator(inputSchema, resultSchema, keys, collations, aggCalls, WindowNode.WindowFrameType.RANGE,
+            Integer.MIN_VALUE, 0, input);
+
+    // When:
+    List<Object[]> resultRows = ((MseBlock.Data) operator.nextBlock()).asRowHeap().getRows();
+
+    // Then:
+    verifyResultRows(resultRows, keys, Map.of(
+        1, List.of(
+            new Object[]{1, null, null},
+            new Object[]{1, null, null},
+            new Object[]{1, 10.5, null},
+            new Object[]{1, 20.5, 10.5},
+            new Object[]{1, null, 20.5})
+    ));
+    assertTrue(operator.nextBlock().isSuccess(), "Second block is EOS (done processing)");
+  }
+
+  @Test
+  public void testLagIgnoreNullsZeroOffset() {
+    // Given: LAG(value, 0) IGNORE NULLS. Offset 0 has no null-skipping semantics (there is no preceding row to skip
+    // to), so it must return the current row's value - including nulls - exactly like RESPECT NULLS, rather than
+    // treating every row as having "not enough" non-null predecessors and emitting the (absent) default.
+    DataSchema inputSchema = new DataSchema(new String[]{"group", "value"}, new ColumnDataType[]{INT, INT});
+    MultiStageOperator input = new BlockListMultiStageOperator.Builder(inputSchema)
+        .addRow(1, 10)
+        .addRow(1, null)
+        .addRow(1, 20)
+        .buildWithEos();
+    DataSchema resultSchema =
+        new DataSchema(new String[]{"group", "value", "lag"}, new ColumnDataType[]{INT, INT, INT});
+    List<Integer> keys = List.of(0);
+    List<RelFieldCollation> collations =
+        List.of(new RelFieldCollation(1, RelFieldCollation.Direction.ASCENDING, RelFieldCollation.NullDirection.LAST));
+    List<RexExpression.FunctionCall> aggCalls = List.of(
+        new RexExpression.FunctionCall(ColumnDataType.INT, SqlKind.LAG.name(),
+            List.of(new RexExpression.InputRef(1), new RexExpression.Literal(ColumnDataType.INT, 0)), false, true));
+    WindowAggregateOperator operator =
+        getOperator(inputSchema, resultSchema, keys, collations, aggCalls, WindowNode.WindowFrameType.RANGE,
+            Integer.MIN_VALUE, 0, input);
+
+    // When:
+    List<Object[]> resultRows = ((MseBlock.Data) operator.nextBlock()).asRowHeap().getRows();
+
+    // Then: each row's LAG is its own value (the current row).
+    verifyResultRows(resultRows, keys, Map.of(
+        1, List.of(
+            new Object[]{1, 10, 10},
+            new Object[]{1, null, null},
+            new Object[]{1, 20, 20})
+    ));
+    assertTrue(operator.nextBlock().isSuccess(), "Second block is EOS (done processing)");
+  }
+
+  @Test
+  public void testLeadIgnoreNullsZeroOffset() {
+    // Given: LEAD(value, 0) IGNORE NULLS. As with LAG, offset 0 has no null-skipping semantics, so it must return the
+    // current row's value (including nulls), matching RESPECT NULLS, rather than emitting the (absent) default.
+    DataSchema inputSchema = new DataSchema(new String[]{"group", "value"}, new ColumnDataType[]{INT, INT});
+    MultiStageOperator input = new BlockListMultiStageOperator.Builder(inputSchema)
+        .addRow(1, 10)
+        .addRow(1, null)
+        .addRow(1, 20)
+        .buildWithEos();
+    DataSchema resultSchema =
+        new DataSchema(new String[]{"group", "value", "lead"}, new ColumnDataType[]{INT, INT, INT});
+    List<Integer> keys = List.of(0);
+    List<RelFieldCollation> collations =
+        List.of(new RelFieldCollation(1, RelFieldCollation.Direction.ASCENDING, RelFieldCollation.NullDirection.LAST));
+    List<RexExpression.FunctionCall> aggCalls = List.of(
+        new RexExpression.FunctionCall(ColumnDataType.INT, SqlKind.LEAD.name(),
+            List.of(new RexExpression.InputRef(1), new RexExpression.Literal(ColumnDataType.INT, 0)), false, true));
+    WindowAggregateOperator operator =
+        getOperator(inputSchema, resultSchema, keys, collations, aggCalls, WindowNode.WindowFrameType.RANGE,
+            Integer.MIN_VALUE, 0, input);
+
+    // When:
+    List<Object[]> resultRows = ((MseBlock.Data) operator.nextBlock()).asRowHeap().getRows();
+
+    // Then: each row's LEAD is its own value (the current row).
+    verifyResultRows(resultRows, keys, Map.of(
+        1, List.of(
+            new Object[]{1, 10, 10},
+            new Object[]{1, null, null},
+            new Object[]{1, 20, 20})
+    ));
+    assertTrue(operator.nextBlock().isSuccess(), "Second block is EOS (done processing)");
+  }
+
   @Test(dataProvider = "windowFrameTypes")
   public void testSumWithUnboundedPrecedingLowerAndUnboundedFollowingUpper(WindowNode.WindowFrameType frameType) {
     // Given:

--- a/pinot-query-runtime/src/test/resources/queries/WindowFunctions.json
+++ b/pinot-query-runtime/src/test/resources/queries/WindowFunctions.json
@@ -5720,6 +5720,116 @@
         ]
       },
       {
+        "description": "LEAD with IGNORE NULLS and default offset",
+        "sql": "SELECT string_col, double_col, nullable_int_col, LEAD(nullable_int_col) IGNORE NULLS OVER(PARTITION BY string_col ORDER BY double_col) FROM {tbl} ORDER BY string_col",
+        "outputs": [
+          ["a", 42.0, 4, 5],
+          ["a", 50.5, null, 5],
+          ["a", 75.0, 5, 1],
+          ["a", 300.0, 1, null],
+          ["a", 400.0, null, null],
+          ["b", 1.0, 1, null],
+          ["b", 100.0, null, null],
+          ["c", 1.01, 7, 6],
+          ["c", 1.5, 6, 3],
+          ["c", 100.0, 3, null],
+          ["c", 400.0, null, null],
+          ["d", 42.0, null, null],
+          ["e", 42.0, null, 2],
+          ["e", 50.5, 2, null],
+          ["g", 100.0, 10, null],
+          ["h", -1.53, null, null]
+        ]
+      },
+      {
+        "description": "LAG with IGNORE NULLS and default offset",
+        "sql": "SELECT string_col, double_col, nullable_int_col, LAG(nullable_int_col) IGNORE NULLS OVER(PARTITION BY string_col ORDER BY double_col) FROM {tbl} ORDER BY string_col",
+        "outputs": [
+          ["a", 42.0, 4, null],
+          ["a", 50.5, null, 4],
+          ["a", 75.0, 5, 4],
+          ["a", 300.0, 1, 5],
+          ["a", 400.0, null, 1],
+          ["b", 1.0, 1, null],
+          ["b", 100.0, null, 1],
+          ["c", 1.01, 7, null],
+          ["c", 1.5, 6, 7],
+          ["c", 100.0, 3, 6],
+          ["c", 400.0, null, 3],
+          ["d", 42.0, null, null],
+          ["e", 42.0, null, null],
+          ["e", 50.5, 2, null],
+          ["g", 100.0, 10, null],
+          ["h", -1.53, null, null]
+        ]
+      },
+      {
+        "description": "LEAD with IGNORE NULLS, offset 2, and default value 0",
+        "sql": "SELECT string_col, double_col, nullable_int_col, LEAD(nullable_int_col, 2, 0) IGNORE NULLS OVER(PARTITION BY string_col ORDER BY double_col) FROM {tbl} ORDER BY string_col",
+        "outputs": [
+          ["a", 42.0, 4, 1],
+          ["a", 50.5, null, 1],
+          ["a", 75.0, 5, 0],
+          ["a", 300.0, 1, 0],
+          ["a", 400.0, null, 0],
+          ["b", 1.0, 1, 0],
+          ["b", 100.0, null, 0],
+          ["c", 1.01, 7, 3],
+          ["c", 1.5, 6, 0],
+          ["c", 100.0, 3, 0],
+          ["c", 400.0, null, 0],
+          ["d", 42.0, null, 0],
+          ["e", 42.0, null, 0],
+          ["e", 50.5, 2, 0],
+          ["g", 100.0, 10, 0],
+          ["h", -1.53, null, 0]
+        ]
+      },
+      {
+        "description": "LAG with IGNORE NULLS, offset 2, and default value -1",
+        "sql": "SELECT string_col, double_col, nullable_int_col, LAG(nullable_int_col, 2, -1) IGNORE NULLS OVER(PARTITION BY string_col ORDER BY double_col) FROM {tbl} ORDER BY string_col",
+        "outputs": [
+          ["a", 42.0, 4, -1],
+          ["a", 50.5, null, -1],
+          ["a", 75.0, 5, -1],
+          ["a", 300.0, 1, 4],
+          ["a", 400.0, null, 5],
+          ["b", 1.0, 1, -1],
+          ["b", 100.0, null, -1],
+          ["c", 1.01, 7, -1],
+          ["c", 1.5, 6, -1],
+          ["c", 100.0, 3, 7],
+          ["c", 400.0, null, 6],
+          ["d", 42.0, null, -1],
+          ["e", 42.0, null, -1],
+          ["e", 50.5, 2, -1],
+          ["g", 100.0, 10, -1],
+          ["h", -1.53, null, -1]
+        ]
+      },
+      {
+        "description": "LEAD with RESPECT NULLS (explicit, same as default behavior)",
+        "sql": "SELECT string_col, double_col, nullable_int_col, LEAD(nullable_int_col) RESPECT NULLS OVER(PARTITION BY string_col ORDER BY double_col) FROM {tbl} ORDER BY string_col",
+        "outputs": [
+          ["a", 42.0, 4, null],
+          ["a", 50.5, null, 5],
+          ["a", 75.0, 5, 1],
+          ["a", 300.0, 1, null],
+          ["a", 400.0, null, null],
+          ["b", 1.0, 1, null],
+          ["b", 100.0, null, null],
+          ["c", 1.01, 7, 6],
+          ["c", 1.5, 6, 3],
+          ["c", 100.0, 3, null],
+          ["c", 400.0, null, null],
+          ["d", 42.0, null, null],
+          ["e", 42.0, null, 2],
+          ["e", 50.5, 2, null],
+          ["g", 100.0, 10, null],
+          ["h", -1.53, null, null]
+        ]
+      },
+      {
         "description": "NTILE with 2 buckets",
         "sql": "SELECT string_col, int_col, NTILE(2) OVER(PARTITION BY string_col ORDER BY int_col) FROM {tbl} ORDER BY string_col, int_col",
         "outputs": [

--- a/pinot-query-runtime/src/test/resources/queries/WindowFunctions.json
+++ b/pinot-query-runtime/src/test/resources/queries/WindowFunctions.json
@@ -5474,6 +5474,116 @@
         ]
       },
       {
+        "description": "LEAD with IGNORE NULLS and default offset",
+        "sql": "SELECT string_col, double_col, nullable_int_col, LEAD(nullable_int_col) IGNORE NULLS OVER(PARTITION BY string_col ORDER BY double_col) FROM {tbl} ORDER BY string_col",
+        "outputs": [
+          ["a", 42.0, 4, 5],
+          ["a", 50.5, null, 5],
+          ["a", 75.0, 5, 1],
+          ["a", 300.0, 1, null],
+          ["a", 400.0, null, null],
+          ["b", 1.0, 1, null],
+          ["b", 100.0, null, null],
+          ["c", 1.01, 7, 6],
+          ["c", 1.5, 6, 3],
+          ["c", 100.0, 3, null],
+          ["c", 400.0, null, null],
+          ["d", 42.0, null, null],
+          ["e", 42.0, null, 2],
+          ["e", 50.5, 2, null],
+          ["g", 100.0, 10, null],
+          ["h", -1.53, null, null]
+        ]
+      },
+      {
+        "description": "LAG with IGNORE NULLS and default offset",
+        "sql": "SELECT string_col, double_col, nullable_int_col, LAG(nullable_int_col) IGNORE NULLS OVER(PARTITION BY string_col ORDER BY double_col) FROM {tbl} ORDER BY string_col",
+        "outputs": [
+          ["a", 42.0, 4, null],
+          ["a", 50.5, null, 4],
+          ["a", 75.0, 5, 4],
+          ["a", 300.0, 1, 5],
+          ["a", 400.0, null, 1],
+          ["b", 1.0, 1, null],
+          ["b", 100.0, null, 1],
+          ["c", 1.01, 7, null],
+          ["c", 1.5, 6, 7],
+          ["c", 100.0, 3, 6],
+          ["c", 400.0, null, 3],
+          ["d", 42.0, null, null],
+          ["e", 42.0, null, null],
+          ["e", 50.5, 2, null],
+          ["g", 100.0, 10, null],
+          ["h", -1.53, null, null]
+        ]
+      },
+      {
+        "description": "LEAD with IGNORE NULLS, offset 2, and default value 0",
+        "sql": "SELECT string_col, double_col, nullable_int_col, LEAD(nullable_int_col, 2, 0) IGNORE NULLS OVER(PARTITION BY string_col ORDER BY double_col) FROM {tbl} ORDER BY string_col",
+        "outputs": [
+          ["a", 42.0, 4, 1],
+          ["a", 50.5, null, 1],
+          ["a", 75.0, 5, 0],
+          ["a", 300.0, 1, 0],
+          ["a", 400.0, null, 0],
+          ["b", 1.0, 1, 0],
+          ["b", 100.0, null, 0],
+          ["c", 1.01, 7, 3],
+          ["c", 1.5, 6, 0],
+          ["c", 100.0, 3, 0],
+          ["c", 400.0, null, 0],
+          ["d", 42.0, null, 0],
+          ["e", 42.0, null, 0],
+          ["e", 50.5, 2, 0],
+          ["g", 100.0, 10, 0],
+          ["h", -1.53, null, 0]
+        ]
+      },
+      {
+        "description": "LAG with IGNORE NULLS, offset 2, and default value -1",
+        "sql": "SELECT string_col, double_col, nullable_int_col, LAG(nullable_int_col, 2, -1) IGNORE NULLS OVER(PARTITION BY string_col ORDER BY double_col) FROM {tbl} ORDER BY string_col",
+        "outputs": [
+          ["a", 42.0, 4, -1],
+          ["a", 50.5, null, -1],
+          ["a", 75.0, 5, -1],
+          ["a", 300.0, 1, 4],
+          ["a", 400.0, null, 5],
+          ["b", 1.0, 1, -1],
+          ["b", 100.0, null, -1],
+          ["c", 1.01, 7, -1],
+          ["c", 1.5, 6, -1],
+          ["c", 100.0, 3, 7],
+          ["c", 400.0, null, 6],
+          ["d", 42.0, null, -1],
+          ["e", 42.0, null, -1],
+          ["e", 50.5, 2, -1],
+          ["g", 100.0, 10, -1],
+          ["h", -1.53, null, -1]
+        ]
+      },
+      {
+        "description": "LEAD with RESPECT NULLS (explicit, same as default behavior)",
+        "sql": "SELECT string_col, double_col, nullable_int_col, LEAD(nullable_int_col) RESPECT NULLS OVER(PARTITION BY string_col ORDER BY double_col) FROM {tbl} ORDER BY string_col",
+        "outputs": [
+          ["a", 42.0, 4, null],
+          ["a", 50.5, null, 5],
+          ["a", 75.0, 5, 1],
+          ["a", 300.0, 1, null],
+          ["a", 400.0, null, null],
+          ["b", 1.0, 1, null],
+          ["b", 100.0, null, null],
+          ["c", 1.01, 7, 6],
+          ["c", 1.5, 6, 3],
+          ["c", 100.0, 3, null],
+          ["c", 400.0, null, null],
+          ["d", 42.0, null, null],
+          ["e", 42.0, null, 2],
+          ["e", 50.5, 2, null],
+          ["g", 100.0, 10, null],
+          ["h", -1.53, null, null]
+        ]
+      },
+      {
         "description": "NTILE with 2 buckets",
         "sql": "SELECT string_col, int_col, NTILE(2) OVER(PARTITION BY string_col ORDER BY int_col) FROM {tbl} ORDER BY string_col, int_col",
         "outputs": [


### PR DESCRIPTION
- Replace custom `PinotLeadWindowFunction` / `PinotLagWindowFunction` (which blocked `IGNORE NULLS` at the Calcite level) with standard `SqlStdOperatorTable.LEAD` / `SqlStdOperatorTable.LAG`
- Add `processRowsIgnoreNulls()` to `LeadValueWindowFunction` and `LagValueWindowFunction` using a bounded `ArrayDeque` for O(N) time and O(offset) memory
- LEAD scans right-to-left and LAG scans left-to-right, each maintaining a sliding window of the last `offset` non-null values
- Support all three operand forms: `LEAD/LAG(col)`, `LEAD/LAG(col, offset)`, and `LEAD/LAG(col, offset, default)`
- Add 7 unit tests covering default offset, custom offset, offset with default value, all-nulls edge case, and multiple partitions
- Add 5 resource-based query tests including LEAD/LAG IGNORE NULLS with various configurations and an explicit RESPECT NULLS regression guard
- Add `@Nullable` annotation to `WindowFunction.extractValueFromRow()`
- Fix pre-existing Javadoc typo in `LeadValueWindowFunction` ("LAG" → "LEAD")