### PR TITLE
[bugfix] Clear realtime inverted index bitmaps on close

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
@@ -1336,6 +1336,7 @@ public class MutableSegmentImpl implements MutableSegment {
     for (IndexContainer indexContainer : _indexContainerMap.values()) {
       indexContainer.close();
     }
+    _indexContainerMap.clear();
 
     if (_multiColumnTextIndex != null) {
       try {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/RealtimeInvertedIndex.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/RealtimeInvertedIndex.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.segment.local.realtime.impl.invertedindex;
 
 import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.apache.pinot.segment.spi.index.mutable.MutableInvertedIndex;
 import org.apache.pinot.segment.spi.index.mutable.ThreadSafeMutableRoaringBitmap;
@@ -31,7 +30,7 @@ import org.roaringbitmap.buffer.MutableRoaringBitmap;
  * <p>This class is thread-safe for single writer multiple readers.
  */
 public class RealtimeInvertedIndex implements MutableInvertedIndex {
-  private final List<ThreadSafeMutableRoaringBitmap> _bitmaps = new ArrayList<>();
+  private final ArrayList<ThreadSafeMutableRoaringBitmap> _bitmaps = new ArrayList<>();
   private final ReentrantReadWriteLock.ReadLock _readLock;
   private final ReentrantReadWriteLock.WriteLock _writeLock;
 
@@ -82,5 +81,12 @@ public class RealtimeInvertedIndex implements MutableInvertedIndex {
 
   @Override
   public void close() {
+    try {
+      _writeLock.lock();
+      _bitmaps.clear();
+      _bitmaps.trimToSize();
+    } finally {
+      _writeLock.unlock();
+    }
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/RealtimeInvertedIndex.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/RealtimeInvertedIndex.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.segment.local.realtime.impl.invertedindex;
 
 import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.apache.pinot.segment.spi.index.mutable.MutableInvertedIndex;
 import org.apache.pinot.segment.spi.index.mutable.ThreadSafeMutableRoaringBitmap;
@@ -30,7 +31,7 @@ import org.roaringbitmap.buffer.MutableRoaringBitmap;
  * <p>This class is thread-safe for single writer multiple readers.
  */
 public class RealtimeInvertedIndex implements MutableInvertedIndex {
-  private final ArrayList<ThreadSafeMutableRoaringBitmap> _bitmaps = new ArrayList<>();
+  private final List<ThreadSafeMutableRoaringBitmap> _bitmaps = new ArrayList<>();
   private final ReentrantReadWriteLock.ReadLock _readLock;
   private final ReentrantReadWriteLock.WriteLock _writeLock;
 
@@ -84,7 +85,6 @@ public class RealtimeInvertedIndex implements MutableInvertedIndex {
     try {
       _writeLock.lock();
       _bitmaps.clear();
-      _bitmaps.trimToSize();
     } finally {
       _writeLock.unlock();
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/RealtimeInvertedIndex.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/RealtimeInvertedIndex.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.segment.local.realtime.impl.invertedindex;
 
 import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.apache.pinot.segment.spi.index.mutable.MutableInvertedIndex;
 import org.apache.pinot.segment.spi.index.mutable.ThreadSafeMutableRoaringBitmap;
@@ -31,7 +30,7 @@ import org.roaringbitmap.buffer.MutableRoaringBitmap;
  * <p>This class is thread-safe for single writer multiple readers.
  */
 public class RealtimeInvertedIndex implements MutableInvertedIndex {
-  private final List<ThreadSafeMutableRoaringBitmap> _bitmaps = new ArrayList<>();
+  private final ArrayList<ThreadSafeMutableRoaringBitmap> _bitmaps = new ArrayList<>();
   private final ReentrantReadWriteLock.ReadLock _readLock;
   private final ReentrantReadWriteLock.WriteLock _writeLock;
 
@@ -85,6 +84,7 @@ public class RealtimeInvertedIndex implements MutableInvertedIndex {
     try {
       _writeLock.lock();
       _bitmaps.clear();
+      _bitmaps.trimToSize();
     } finally {
       _writeLock.unlock();
     }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplTest.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.segment.local.indexsegment.mutable;
 
 import java.io.File;
+import java.lang.reflect.Field;
 import java.net.URL;
 import java.util.Map;
 import java.util.Set;
@@ -248,6 +249,28 @@ public class MutableSegmentImplTest {
       assertEquals(dataSource.getVectorIndexConfig(), vectorIndexConfig);
     } finally {
       mutableSegment.destroy();
+    }
+  }
+
+  @Test
+  public void testDestroyClearsIndexContainerMap()
+      throws ReflectiveOperationException {
+    MutableSegmentImpl freshSegment = MutableSegmentImplTestUtils.createMutableSegmentImpl(_schema);
+    boolean destroyed = false;
+    try {
+      Field indexContainerMapField = MutableSegmentImpl.class.getDeclaredField("_indexContainerMap");
+      indexContainerMapField.setAccessible(true);
+      Map<?, ?> indexContainerMap = (Map<?, ?>) indexContainerMapField.get(freshSegment);
+      Assert.assertFalse(indexContainerMap.isEmpty());
+
+      freshSegment.destroy();
+      destroyed = true;
+
+      Assert.assertTrue(indexContainerMap.isEmpty());
+    } finally {
+      if (!destroyed) {
+        freshSegment.destroy();
+      }
     }
   }
 

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/RealtimeInvertedIndexReaderTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/RealtimeInvertedIndexReaderTest.java
@@ -18,9 +18,12 @@
  */
 package org.apache.pinot.segment.local.realtime.impl.invertedindex;
 
+import java.lang.reflect.Field;
+import java.util.List;
 import org.roaringbitmap.buffer.MutableRoaringBitmap;
 import org.testng.annotations.Test;
 
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
@@ -102,5 +105,23 @@ public class RealtimeInvertedIndexReaderTest {
     assertFalse(docIds.contains(0));
     assertFalse(docIds.contains(1));
     assertTrue(docIds.contains(2));
+  }
+
+  @Test
+  public void testCloseClearsBitmaps()
+      throws ReflectiveOperationException {
+    RealtimeInvertedIndex realtimeInvertedIndex = new RealtimeInvertedIndex();
+    realtimeInvertedIndex.add(0, 0);
+    realtimeInvertedIndex.add(1, 1);
+
+    realtimeInvertedIndex.close();
+
+    assertTrue(realtimeInvertedIndex.getDocIds(0).isEmpty());
+    assertTrue(realtimeInvertedIndex.getDocIds(1).isEmpty());
+
+    Field bitmapsField = RealtimeInvertedIndex.class.getDeclaredField("_bitmaps");
+    bitmapsField.setAccessible(true);
+    List<?> bitmaps = (List<?>) bitmapsField.get(realtimeInvertedIndex);
+    assertEquals(bitmaps.size(), 0);
   }
 }


### PR DESCRIPTION
## Summary
- make `RealtimeInvertedIndex.close()` actively clear and trim in-memory bitmap state
- add a regression test that verifies `close()` empties the bitmaps and returns empty results afterward

## Root cause
`MutableSegmentImpl.destroy()` already walks mutable indexes and calls `close()`, but `RealtimeInvertedIndex.close()` was a no-op. After a consuming segment was persisted and replaced, any lingering wrapper or data-source reference could still retain the in-memory posting lists because the index never dropped its bitmap references.

## Reproduction
1. Create a consuming segment with a dictionary-encoded column and realtime inverted index enabled.
2. Index rows so the mutable inverted index allocates posting lists.
3. Persist and replace the segment, then let the mutable segment destroy path run.
4. Inspect the heap and follow a stale `indexContainer` or `DataSource` wrapper: the `RealtimeInvertedIndex` still retains its `_bitmaps` list because `close()` does not release anything.

## Impact
This makes realtime inverted-index cleanup deterministic once the mutable segment destroy path runs, reducing retained heap after realtime segment replacement.

## Validation
- `./mvnw spotless:apply -pl pinot-segment-local`
- `./mvnw -pl pinot-segment-local -Dtest=RealtimeInvertedIndexReaderTest test`
- `./mvnw checkstyle:check -pl pinot-segment-local`
- `./mvnw license:format -pl pinot-segment-local`
- `./mvnw license:check -pl pinot-segment-local`
