### PR TITLE
Fix old-to-new format conversion crash when RAW encoding overlaps noDictionaryColumns

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/dictionary/DictionaryIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/dictionary/DictionaryIndexType.java
@@ -415,6 +415,7 @@ public class DictionaryIndexType
     for (FieldConfig fieldConfig : fieldConfigList) {
       // skip further computation of field configs which already has RAW encodingType
       if (fieldConfig.getEncodingType() == FieldConfig.EncodingType.RAW) {
+        noDictionaryColumns.remove(fieldConfig.getName());
         continue;
       }
       // ensure encodingType is RAW on noDictionaryColumns

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/dictionary/DictionaryIndexTypeTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/dictionary/DictionaryIndexTypeTest.java
@@ -314,6 +314,149 @@ public class DictionaryIndexTypeTest {
       postConversionAsserts();
     }
 
+    @Test
+    public void oldToNewConfConversionWithRawEncodingAndNoDictionaryColumns()
+        throws IOException {
+      addFieldIndexConfig("{"
+          + "\"name\": \"dimInt\","
+          + "\"encodingType\": \"RAW\","
+          + "\"indexes\": {"
+          + "  \"forward\": {"
+          + "    \"compressionCodec\": \"ZSTANDARD\""
+          + "  }"
+          + "}"
+          + "}");
+      _tableConfig.getIndexingConfig().setNoDictionaryColumns(
+          JsonUtils.stringToObject("[\"dimInt\"]", _stringListTypeRef));
+
+      convertToUpdatedFormat();
+
+      final FieldConfig fieldConfig = getFieldConfigByColumn("dimInt");
+      Assert.assertEquals(fieldConfig.getEncodingType(), FieldConfig.EncodingType.RAW);
+      assertNotNull(fieldConfig.getIndexes());
+      assertTrue(fieldConfig.getIndexes().isObject());
+      assertNotNull(fieldConfig.getIndexes().get("forward"));
+
+      final long dimIntCount = _tableConfig.getFieldConfigList().stream()
+          .filter(fc -> fc.getName().equals("dimInt"))
+          .count();
+      Assert.assertEquals(dimIntCount, 1L);
+      postConversionAsserts();
+    }
+
+    @Test
+    public void oldToNewConfConversionWithRawEncodingAndNoDictionaryColumnsMultipleCols()
+        throws IOException {
+      addFieldIndexConfig("{"
+          + "\"name\": \"dimInt\","
+          + "\"encodingType\": \"RAW\","
+          + "\"indexes\": {"
+          + "  \"forward\": {\"compressionCodec\": \"ZSTANDARD\"}"
+          + "}"
+          + "}");
+      addFieldIndexConfig("{"
+          + "\"name\": \"dimStr\","
+          + "\"encodingType\": \"RAW\","
+          + "\"indexes\": {"
+          + "  \"forward\": {\"compressionCodec\": \"LZ4\"}"
+          + "}"
+          + "}");
+      _tableConfig.getIndexingConfig().setNoDictionaryColumns(
+          JsonUtils.stringToObject("[\"dimInt\", \"dimStr\"]", _stringListTypeRef));
+
+      convertToUpdatedFormat();
+
+      final FieldConfig dimInt = getFieldConfigByColumn("dimInt");
+      final FieldConfig dimStr = getFieldConfigByColumn("dimStr");
+      Assert.assertEquals(dimInt.getEncodingType(), FieldConfig.EncodingType.RAW);
+      Assert.assertEquals(dimStr.getEncodingType(), FieldConfig.EncodingType.RAW);
+      assertNotNull(dimInt.getIndexes().get("forward"));
+      assertNotNull(dimStr.getIndexes().get("forward"));
+
+      for (final String col : new String[]{"dimInt", "dimStr"}) {
+        final long count = _tableConfig.getFieldConfigList().stream()
+            .filter(fc -> fc.getName().equals(col))
+            .count();
+        Assert.assertEquals(count, 1L, "Duplicate FieldConfig for " + col);
+      }
+      postConversionAsserts();
+    }
+
+    @Test
+    public void oldToNewConfConversionWithRawEncodingNoDictionaryColumnsPartialOverlap()
+        throws IOException {
+      addFieldIndexConfig("{"
+          + "\"name\": \"dimInt\","
+          + "\"encodingType\": \"RAW\","
+          + "\"indexes\": {"
+          + "  \"forward\": {\"compressionCodec\": \"ZSTANDARD\"}"
+          + "}"
+          + "}");
+      _tableConfig.getIndexingConfig().setNoDictionaryColumns(
+          JsonUtils.stringToObject("[\"dimInt\", \"dimStr\"]", _stringListTypeRef));
+
+      convertToUpdatedFormat();
+
+      final FieldConfig dimInt = getFieldConfigByColumn("dimInt");
+      Assert.assertEquals(dimInt.getEncodingType(), FieldConfig.EncodingType.RAW);
+      assertNotNull(dimInt.getIndexes().get("forward"));
+
+      final FieldConfig dimStr = getFieldConfigByColumn("dimStr");
+      Assert.assertEquals(dimStr.getEncodingType(), FieldConfig.EncodingType.RAW);
+
+      for (final String col : new String[]{"dimInt", "dimStr"}) {
+        final long count = _tableConfig.getFieldConfigList().stream()
+            .filter(fc -> fc.getName().equals(col))
+            .count();
+        Assert.assertEquals(count, 1L, "Duplicate FieldConfig for " + col);
+      }
+      postConversionAsserts();
+    }
+
+    @Test
+    public void oldToNewConfConversionWithRawEncodingNoDictionaryColumnsAndNoIndexes()
+        throws IOException {
+      addFieldIndexConfig("{"
+          + "\"name\": \"dimInt\","
+          + "\"encodingType\": \"RAW\""
+          + "}");
+      _tableConfig.getIndexingConfig().setNoDictionaryColumns(
+          JsonUtils.stringToObject("[\"dimInt\"]", _stringListTypeRef));
+
+      convertToUpdatedFormat();
+
+      final FieldConfig fieldConfig = getFieldConfigByColumn("dimInt");
+      Assert.assertEquals(fieldConfig.getEncodingType(), FieldConfig.EncodingType.RAW);
+
+      final long count = _tableConfig.getFieldConfigList().stream()
+          .filter(fc -> fc.getName().equals("dimInt"))
+          .count();
+      Assert.assertEquals(count, 1L);
+      postConversionAsserts();
+    }
+
+    @Test
+    public void oldToNewConfConversionWithNonRawEncodingAndNoDictionaryColumns()
+        throws IOException {
+      addFieldIndexConfig("{"
+          + "\"name\": \"dimInt\","
+          + "\"encodingType\": \"DICTIONARY\""
+          + "}");
+      _tableConfig.getIndexingConfig().setNoDictionaryColumns(
+          JsonUtils.stringToObject("[\"dimInt\"]", _stringListTypeRef));
+
+      convertToUpdatedFormat();
+
+      final FieldConfig fieldConfig = getFieldConfigByColumn("dimInt");
+      Assert.assertEquals(fieldConfig.getEncodingType(), FieldConfig.EncodingType.RAW);
+
+      final long count = _tableConfig.getFieldConfigList().stream()
+          .filter(fc -> fc.getName().equals("dimInt"))
+          .count();
+      Assert.assertEquals(count, 1L);
+      postConversionAsserts();
+    }
+
     private FieldConfig getFieldConfigByColumn(String column) {
       assertNotNull(_tableConfig.getFieldConfigList());
       assertFalse(_tableConfig.getFieldConfigList().isEmpty());


### PR DESCRIPTION
## Issue(s)

`DictionaryIndexType.handleIndexSpecificCleanup` has a bug where the early `continue` on `encodingType == RAW` skips `noDictionaryColumns.remove()`. This leaves the column in `noDictionaryColumns`, causing the final loop to create a duplicate bare `FieldConfig` entry. When the next index type's `convertToNewFormat` runs, `Collectors.toMap` encounters two entries for the same column name and throws `IllegalStateException: Duplicate key`.

This is a redundant but valid configuration (both `encodingType: RAW` and `noDictionaryColumns` declare "no dictionary") that passes `validate-config` without issues.

### Impact on `inferIndexes` API

The `inferIndexes` API (StarTree's `POST /tables/inferIndexes`) calls `TableConfigUtils.createTableConfigFromOldFormat` to normalize old-format index configs into the new `fieldConfigList` format. This method loops over all registered index types and calls `indexType.convertToNewFormat()` on each one sequentially. The call chain is:

1. `TableIndexesService.prepareTableConfig` → `TableConfigUtils.createTableConfigFromOldFormat`
2. → loops over all index types, calling `indexType.convertToNewFormat(clone, schema)` for each
3. → `DictionaryIndexType.convertToNewFormat` runs first and calls `handleIndexSpecificCleanup` at the end
4. → the bug in `handleIndexSpecificCleanup` creates a duplicate `FieldConfig` entry in `fieldConfigList`
5. → the next index type (e.g., InvertedIndexType) calls `convertToNewFormat`, which starts with `Collectors.toMap(FieldConfig::getName, ...)` on the now-corrupted `fieldConfigList`
6. → `IllegalStateException: Duplicate key col_66e7a6c7`

This blocks the `inferIndexes` API for any table that has this RAW + noDictionaryColumns overlap in its config.

### Example

Input table config (minimized):
```json
{
  "tableIndexConfig": {
    "noDictionaryColumns": ["col_X"]
  },
  "fieldConfigList": [
    { "name": "col_X", "encodingType": "RAW", "indexes": { "forward": { "compressionCodec": "ZSTANDARD" } } }
  ]
}
```

**Before fix** — `handleIndexSpecificCleanup` processes the loop:

1. Sees `col_X` with `encodingType: RAW` → hits `continue`, skips `noDictionaryColumns.remove("col_X")`
2. `col_X` stays in `noDictionaryColumns`
3. Final loop creates a bare `FieldConfig` for every remaining entry in `noDictionaryColumns`

Result after cleanup:
```json
{
  "tableIndexConfig": {
    "noDictionaryColumns": null,
    "noDictionaryConfig": null
  },
  "fieldConfigList": [
    { "name": "col_X", "encodingType": "RAW", "indexes": { "forward": { "compressionCodec": "ZSTANDARD" } } },
    { "name": "col_X", "encodingType": "RAW", "indexes": null }
  ]
}
```
→ Two entries for `col_X`. Next index type's `convertToNewFormat` calls `Collectors.toMap(FieldConfig::getName, ...)` → crashes: `Duplicate key col_X`

**After fix** — `handleIndexSpecificCleanup` processes the loop:

1. Sees `col_X` with `encodingType: RAW` → calls `noDictionaryColumns.remove("col_X")`, then `continue`
2. `col_X` is no longer in `noDictionaryColumns`
3. Final loop has nothing left to process

Result after cleanup:
```json
{
  "tableIndexConfig": {
    "noDictionaryColumns": null,
    "noDictionaryConfig": null
  },
  "fieldConfigList": [
    { "name": "col_X", "encodingType": "RAW", "indexes": { "forward": { "compressionCodec": "ZSTANDARD" } } }
  ]
}
```
→ Single entry for `col_X`. Conversion proceeds successfully.

## Root Cause

In `DictionaryIndexType.handleIndexSpecificCleanup` (line 425):

```java
if (fieldConfig.getEncodingType() == FieldConfig.EncodingType.RAW) {
    continue; // skips noDictionaryColumns.remove() on line 429
}
```

The column stays in `noDictionaryColumns` and the final loop (lines 457-461) creates a second `FieldConfig(name=col, encodingType=RAW, indexes=null)`. The next index type's `AbstractIndexType.convertToNewFormat` then fails at:

```java
fieldConfigList.stream().collect(Collectors.toMap(FieldConfig::getName, Function.identity()));
// IllegalStateException: Duplicate key col_66e7a6c7
```

## Fix

Add `noDictionaryColumns.remove(fieldConfig.getName())` before the `continue`:

```java
if (fieldConfig.getEncodingType() == FieldConfig.EncodingType.RAW) {
    noDictionaryColumns.remove(fieldConfig.getName());
    continue;
}
```

## Test Plan

Added 6 new tests in `DictionaryIndexTypeTest.ConfTest` covering: exact production crash scenario (RAW + noDictionaryColumns with forward index), multiple columns, partial overlap, bare FieldConfig without indexes, and regression for non-RAW encoding. All 28 tests pass.

---