### PR TITLE
Fix literal-only stages being scheduled on wrong tenant servers

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerManager.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerManager.java
@@ -112,19 +112,34 @@ public class WorkerManager {
     DispatchablePlanMetadata metadata = context.getDispatchablePlanMetadataMap().get(0);
     metadata.setWorkerIdToServerInstanceMap(
         Collections.singletonMap(0, new QueryServerInstance(_instanceId, _hostName, _port, _port)));
+
+    // Two-pass assignment: leaf stages must be assigned first so that the candidate server information
+    // (_nonLookupTables or _leafServerInstances) is fully populated before intermediate stages use it.
+    // Without this, literal-only stages (e.g. UNION ALL of constants) that are traversed before any table scan
+    // would see an empty candidate set and fall back to all enabled servers across all tenants.
     for (PlanFragment child : rootFragment.getChildren()) {
-      assignWorkersToNonRootFragment(child, context);
+      assignWorkersToNonRootFragment(child, context, true);
+    }
+    for (PlanFragment child : rootFragment.getChildren()) {
+      assignWorkersToNonRootFragment(child, context, false);
     }
   }
 
-  private void assignWorkersToNonRootFragment(PlanFragment fragment, DispatchablePlanContext context) {
+  /// Post-order traversal that assigns workers to either leaf or intermediate fragments.
+  /// @param leafOnly when true, only leaf fragments are assigned; when false, only intermediate fragments are assigned
+  private void assignWorkersToNonRootFragment(PlanFragment fragment, DispatchablePlanContext context,
+      boolean leafOnly) {
     List<PlanFragment> children = fragment.getChildren();
     for (PlanFragment child : children) {
-      assignWorkersToNonRootFragment(child, context);
+      assignWorkersToNonRootFragment(child, context, leafOnly);
     }
     Map<Integer, DispatchablePlanMetadata> metadataMap = context.getDispatchablePlanMetadataMap();
     DispatchablePlanMetadata metadata = metadataMap.get(fragment.getFragmentId());
-    if (isLeafPlan(metadata)) {
+    boolean isLeaf = isLeafPlan(metadata);
+    if (leafOnly != isLeaf) {
+      return;
+    }
+    if (isLeaf) {
       // TODO: Revisit this logic and see if we can generalize this
       // For LOOKUP join, join is leaf stage because there is no exchange added to the right side of the join. When we
       // find a single local exchange child in the leaf stage, assign workers based on the local exchange child.

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/routing/WorkerManagerTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/routing/WorkerManagerTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.query.routing;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -31,11 +32,13 @@ import org.apache.pinot.common.config.provider.TableCache;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.core.routing.RoutingManager;
 import org.apache.pinot.core.routing.RoutingTable;
+import org.apache.pinot.core.routing.SegmentsToQuery;
 import org.apache.pinot.core.routing.TablePartitionInfo;
 import org.apache.pinot.core.routing.TablePartitionReplicatedServersInfo;
 import org.apache.pinot.core.routing.timeboundary.TimeBoundaryInfo;
 import org.apache.pinot.core.transport.ServerInstance;
 import org.apache.pinot.query.QueryEnvironment;
+import org.apache.pinot.query.planner.physical.DispatchablePlanFragment;
 import org.apache.pinot.query.planner.physical.DispatchableSubPlan;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
@@ -45,7 +48,9 @@ import org.testng.annotations.Test;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
 
 
 /**
@@ -121,6 +126,177 @@ public class WorkerManagerTest {
     @SuppressWarnings("deprecation")
     DispatchableSubPlan dispatchableSubPlan = queryEnvironment.planQuery(query);
     assertNotNull(dispatchableSubPlan);
+  }
+
+  /**
+   * Tests that literal-only stages (e.g. UNION ALL of constant values) are assigned to the same
+   * servers as the table-scanning stages, not to all enabled servers across all tenants.
+   *
+   * <p>Simulates two server tenants: T1 (serves the queried table) and T2 (unrelated). Before the fix,
+   * literal-only stages processed before leaf stages would see an empty candidate set and fall back to
+   * all enabled servers, potentially landing on T2 servers.
+   */
+  @Test
+  public void testLiteralOnlyStagesUseTableServers() {
+    Schema tableSchema = getSchemaBuilder("testTable").build();
+
+    // T1 servers: serve the queried table
+    ServerInstance t1Server1 = getServerInstance("t1-host1", 1);
+    ServerInstance t1Server2 = getServerInstance("t1-host2", 2);
+
+    // T2 servers: unrelated tenant, should NOT be used
+    ServerInstance t2Server1 = getServerInstance("t2-host1", 3);
+    ServerInstance t2Server2 = getServerInstance("t2-host2", 4);
+
+    // All enabled servers (both tenants)
+    Map<String, ServerInstance> allEnabledServers = new HashMap<>();
+    allEnabledServers.put(t1Server1.getInstanceId(), t1Server1);
+    allEnabledServers.put(t1Server2.getInstanceId(), t1Server2);
+    allEnabledServers.put(t2Server1.getInstanceId(), t2Server1);
+    allEnabledServers.put(t2Server2.getInstanceId(), t2Server2);
+
+    // Only T1 servers serve the table
+    Set<String> t1ServerIds = Set.of(t1Server1.getInstanceId(), t1Server2.getInstanceId());
+    Set<String> t2ServerIds = Set.of(t2Server1.getInstanceId(), t2Server2.getInstanceId());
+
+    // Routing table: T1 servers have segments for testTable
+    Map<ServerInstance, SegmentsToQuery> serverSegmentsMap = new HashMap<>();
+    serverSegmentsMap.put(t1Server1, new SegmentsToQuery(List.of("seg1", "seg2"), List.of()));
+    serverSegmentsMap.put(t1Server2, new SegmentsToQuery(List.of("seg3", "seg4"), List.of()));
+    RoutingTable routingTable = new RoutingTable(serverSegmentsMap, List.of(), 0);
+
+    RoutingManager routingManager = new MultiTenantRoutingManager(allEnabledServers, t1ServerIds, routingTable);
+
+    Map<String, String> tableNameMap = new HashMap<>();
+    tableNameMap.put("testTable_OFFLINE", "testTable_OFFLINE");
+    tableNameMap.put("testTable", "testTable");
+
+    TableCache tableCache = mock(TableCache.class);
+    when(tableCache.getTableNameMap()).thenReturn(tableNameMap);
+    when(tableCache.getActualTableName(anyString())).thenAnswer(inv -> tableNameMap.get(inv.getArgument(0)));
+    when(tableCache.getSchema(anyString())).thenReturn(tableSchema);
+    when(tableCache.getTableConfig("testTable_OFFLINE"))
+        .thenReturn(mock(org.apache.pinot.spi.config.table.TableConfig.class));
+
+    WorkerManager workerManager = new WorkerManager("Broker_localhost", "localhost", 5, routingManager);
+    QueryEnvironment queryEnvironment = new QueryEnvironment(CommonConstants.DEFAULT_DATABASE, tableCache,
+        workerManager);
+
+    // Query with UNION ALL of literals joined with a table scan. The literal stages (from the subquery)
+    // are in a subtree that is traversed before the table scan in post-order.
+    String query = "SELECT * FROM ("
+        + "  SELECT 1 AS id, 'a' AS val"
+        + "  UNION ALL"
+        + "  SELECT 2 AS id, 'b' AS val"
+        + "  UNION ALL"
+        + "  SELECT 3 AS id, 'c' AS val"
+        + ") AS literals"
+        + " JOIN testTable ON testTable.col1 = literals.val";
+
+    @SuppressWarnings("deprecation")
+    DispatchableSubPlan plan = queryEnvironment.planQuery(query);
+    assertNotNull(plan);
+
+    // Verify: no stage should be assigned to T2 servers
+    Set<String> allAssignedServerIds = new HashSet<>();
+    for (Map.Entry<Integer, DispatchablePlanFragment> entry : plan.getQueryStageMap().entrySet()) {
+      int stageId = entry.getKey();
+      if (stageId == 0) {
+        continue; // skip broker root stage
+      }
+      for (QueryServerInstance server : entry.getValue().getServerInstances()) {
+        allAssignedServerIds.add(server.getInstanceId());
+      }
+    }
+
+    assertFalse(allAssignedServerIds.isEmpty(), "Expected at least one server assignment");
+    for (String serverId : allAssignedServerIds) {
+      assertFalse(t2ServerIds.contains(serverId),
+          "Literal-only stage was incorrectly assigned to T2 server: " + serverId);
+    }
+    // At least one T1 server should be used (for the table scan)
+    boolean anyT1Server = false;
+    for (String serverId : allAssignedServerIds) {
+      if (t1ServerIds.contains(serverId)) {
+        anyT1Server = true;
+        break;
+      }
+    }
+    assertTrue(anyT1Server, "Expected at least one T1 server to be used");
+  }
+
+  /**
+   * A RoutingManager that simulates two tenants of servers, where only one tenant serves the queried
+   * tables. {@code getEnabledServerInstanceMap()} returns all servers across both tenants, while
+   * {@code getServingInstances()} returns only the tenant's servers.
+   */
+  private static class MultiTenantRoutingManager implements RoutingManager {
+    private final Map<String, ServerInstance> _allEnabledServers;
+    private final Set<String> _servingInstanceIds;
+    private final RoutingTable _routingTable;
+
+    MultiTenantRoutingManager(Map<String, ServerInstance> allEnabledServers, Set<String> servingInstanceIds,
+        RoutingTable routingTable) {
+      _allEnabledServers = allEnabledServers;
+      _servingInstanceIds = servingInstanceIds;
+      _routingTable = routingTable;
+    }
+
+    @Override
+    public Map<String, ServerInstance> getEnabledServerInstanceMap() {
+      return _allEnabledServers;
+    }
+
+    @Nullable
+    @Override
+    public RoutingTable getRoutingTable(BrokerRequest brokerRequest, long requestId) {
+      return _routingTable;
+    }
+
+    @Nullable
+    @Override
+    public RoutingTable getRoutingTable(BrokerRequest brokerRequest, String tableNameWithType, long requestId) {
+      return _routingTable;
+    }
+
+    @Nullable
+    @Override
+    public List<String> getSegments(BrokerRequest brokerRequest) {
+      return new ArrayList<>(_routingTable.getServerInstanceToSegmentsMap().values().iterator().next().getSegments());
+    }
+
+    @Override
+    public boolean routingExists(String tableNameWithType) {
+      return true;
+    }
+
+    @Nullable
+    @Override
+    public TimeBoundaryInfo getTimeBoundaryInfo(String offlineTableName) {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public TablePartitionInfo getTablePartitionInfo(String tableNameWithType) {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public TablePartitionReplicatedServersInfo getTablePartitionReplicatedServersInfo(String tableNameWithType) {
+      return null;
+    }
+
+    @Override
+    public Set<String> getServingInstances(String tableNameWithType) {
+      return _servingInstanceIds;
+    }
+
+    @Override
+    public boolean isTableDisabled(String tableNameWithType) {
+      return false;
+    }
   }
 
   /**


### PR DESCRIPTION
Literal-only stages (e.g. UNION ALL of constant values) were assigned to all enabled servers across all tenants because the single post-order traversal processed them before leaf stages had populated the candidate server information. Use two-pass worker assignment: leaf stages first (populates _nonLookupTables / _leafServerInstances), then intermediate stages (which now see correct tenant-scoped candidates).

Made-with: Cursor
