### PR TITLE
Fix memory leak in UpsertViewManager SNAPSHOT mode on segment untrack

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/UpsertViewManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/UpsertViewManager.java
@@ -294,8 +294,15 @@ public class UpsertViewManager {
     _trackedSegmentsLock.writeLock().lock();
     try {
       _trackedSegments.remove(segment);
-      // No need to eagerly refresh the upsert view for SNAPSHOT mode when untracking a segment, as the untracked
-      // segment won't be used by any new queries, thus it can be removed when next refresh happens later.
+      _updatedSegmentsSinceLastRefresh.remove(segment);
+      // Eagerly evict destroyed segment from the snapshot view to avoid retaining its bitmap indefinitely on idle
+      // SNAPSHOT tables. Swap in a new map without the segment to preserve the lock-free volatile read guarantee.
+      Map<IndexSegment, MutableRoaringBitmap> current = _segmentQueryableDocIdsMap;
+      if (current != null && current.containsKey(segment)) {
+        Map<IndexSegment, MutableRoaringBitmap> updated = new HashMap<>(current);
+        updated.remove(segment);
+        _segmentQueryableDocIdsMap = updated;
+      }
     } finally {
       _trackedSegmentsLock.writeLock().unlock();
     }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/UpsertViewManagerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/UpsertViewManagerTest.java
@@ -20,6 +20,7 @@ package org.apache.pinot.segment.local.upsert;
 
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.Map;
 import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.MutableSegment;
 import org.apache.pinot.segment.spi.SegmentContext;
@@ -31,6 +32,7 @@ import org.testng.annotations.Test;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
@@ -58,5 +60,49 @@ public class UpsertViewManagerTest {
     segCtx1 = new SegmentContext(seg1);
     mgr.setSegmentContexts(Collections.singletonList(segCtx1), new HashMap<>());
     assertNull(segCtx1.getQueryableDocIdsSnapshot());
+  }
+
+  @Test
+  public void testUntrackEvictsFromSnapshotView() {
+    UpsertContext context = mock(UpsertContext.class);
+    when(context.getUpsertViewRefreshIntervalMs()).thenReturn(0L);
+    UpsertViewManager mgr = new UpsertViewManager(UpsertConfig.ConsistencyMode.SNAPSHOT, context);
+
+    // Set up two segments with queryable doc ids
+    IndexSegment seg1 = mock(MutableSegment.class);
+    when(seg1.getSegmentName()).thenReturn("seg1");
+    ThreadSafeMutableRoaringBitmap bitmap1 = new ThreadSafeMutableRoaringBitmap();
+    bitmap1.add(1);
+    bitmap1.add(3);
+    when(seg1.getQueryableDocIds()).thenReturn(bitmap1);
+    when(seg1.getValidDocIds()).thenReturn(bitmap1);
+
+    IndexSegment seg2 = mock(MutableSegment.class);
+    when(seg2.getSegmentName()).thenReturn("seg2");
+    ThreadSafeMutableRoaringBitmap bitmap2 = new ThreadSafeMutableRoaringBitmap();
+    bitmap2.add(2);
+    bitmap2.add(4);
+    when(seg2.getQueryableDocIds()).thenReturn(bitmap2);
+    when(seg2.getValidDocIds()).thenReturn(bitmap2);
+
+    // Track both segments — this triggers a refresh that populates _segmentQueryableDocIdsMap
+    mgr.trackSegment(seg1);
+    mgr.trackSegment(seg2);
+    Map<IndexSegment, MutableRoaringBitmap> viewMap = mgr.getSegmentQueryableDocIdsMap();
+    assertEquals(viewMap.size(), 2);
+    assertTrue(viewMap.containsKey(seg1));
+    assertTrue(viewMap.containsKey(seg2));
+
+    // Mark seg1 as updated to verify _updatedSegmentsSinceLastRefresh cleanup
+    mgr.getUpdatedSegmentsSinceLastRefresh().add(seg1);
+
+    // Untrack seg1 — should eagerly evict from snapshot view map and updated set
+    mgr.untrackSegment(seg1);
+    assertFalse(mgr.getTrackedSegments().contains(seg1));
+    assertFalse(mgr.getUpdatedSegmentsSinceLastRefresh().contains(seg1));
+    Map<IndexSegment, MutableRoaringBitmap> updatedMap = mgr.getSegmentQueryableDocIdsMap();
+    assertEquals(updatedMap.size(), 1);
+    assertFalse(updatedMap.containsKey(seg1));
+    assertTrue(updatedMap.containsKey(seg2));
   }
 }


### PR DESCRIPTION
## Summary

When a segment is destroyed and untracked via `untrackSegment()`, it was only removed from `_trackedSegments`. The segment reference and its cloned bitmap remained in `_segmentQueryableDocIdsMap` and `_updatedSegmentsSinceLastRefresh` until the next refresh happened. On idle SNAPSHOT tables (no upserts, no queries arriving), the next refresh never occurs, meaning destroyed segments and their cloned bitmaps are retained indefinitely as strong references in the `HashMap`.

### Root cause

The original code had a comment: *"No need to eagerly refresh the upsert view for SNAPSHOT mode when untracking a segment, as the untracked segment won't be used by any new queries, thus it can be removed when next refresh happens later."*

This is correct for active tables — the next upsert or query triggers a refresh that rebuilds the map from `_trackedSegments`, naturally dropping the destroyed segment. However, for idle SNAPSHOT tables, no such refresh ever comes, creating an unbounded memory leak proportional to the number of segments destroyed without intervening traffic.

### Fix

In `untrackSegment()`:
1. Remove the segment from `_updatedSegmentsSinceLastRefresh` immediately.
2. Eagerly evict the segment from `_segmentQueryableDocIdsMap` using a copy-on-write map swap — this preserves the lock-free volatile read guarantee that SNAPSHOT mode query threads rely on.

Both operations happen under the existing `_trackedSegmentsLock` write lock, so no additional synchronization is needed.

### Files changed

- `UpsertViewManager.java` — eager eviction in `untrackSegment()`
- `UpsertViewManagerTest.java` — new test `testUntrackEvictsFromSnapshotView` that tracks two segments in SNAPSHOT mode, triggers a refresh to populate the view map, untracks one, and verifies it is immediately evicted from both `_segmentQueryableDocIdsMap` and `_updatedSegmentsSinceLastRefresh`

## Test plan

- [x] `UpsertViewManagerTest#testTrackUntrackSegments` — existing test still passes (SYNC mode behavior unchanged)
- [x] `UpsertViewManagerTest#testUntrackEvictsFromSnapshotView` — new test verifying eager eviction in SNAPSHOT mode
- [ ] Verify no regression on active SNAPSHOT upsert tables (the refresh path in `doBatchRefreshUpsertView` is unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)