### PR TITLE
Fix typos and improve comments in RefreshSegmentTaskExecutor

### DIFF
--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/refreshsegment/RefreshSegmentTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/refreshsegment/RefreshSegmentTaskExecutor.java
@@ -66,8 +66,7 @@ public class RefreshSegmentTaskExecutor extends BaseSingleSegmentConversionExecu
     _eventObserver.notifyProgress(pinotTaskConfig, "Refreshing segment: " + indexDir);
 
     // We set _taskStartTime before fetching the tableConfig. Task Generation relies on tableConfig/Schema updates
-    // happening after the last processed time. So we explicity use the timestamp before fetching tableConfig as the
-    // processedTime.
+    // happening after the last processed time. So we explicitly use the timestamp before fetching tableConfig as the processed time.
     _taskStartTime = System.currentTimeMillis();
     Map<String, String> configs = pinotTaskConfig.getConfigs();
     String tableNameWithType = configs.get(MinionConstants.TABLE_NAME_KEY);
@@ -121,12 +120,12 @@ public class RefreshSegmentTaskExecutor extends BaseSingleSegmentConversionExecu
         // Column exists in segment.
         if (dataTypeInSegment != dataTypeInSchema) {
           // Check if we need to update the data-type. DataType change is dependent on segmentGeneration code converting
-          // the object to the destination datatype. If the existing data is the column is not compatible with the
+          // the object to the destination datatype. If the existing data in the column is not compatible with the
           // destination data-type, the refresh task will fail.
           refreshColumnSet.add(column);
         }
 
-        // TODO: Maybe we can support singleValue to multi-value conversions are supproted and vice-versa.
+        // TODO: Maybe we can support singleValue to multi-value conversions and vice-versa.
       } else {
         refreshColumnSet.add(column);
       }


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Comment improvements in RefreshSegmentTaskExecutor\.convert with no functional change\.

```mermaid
flowchart TD
  N0["convert method #40;comments updated#41; #40;F1#41;"]:::stModified
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-plugins/pinot\-minion\-tasks/pinot\-minion\-builtin\-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/refreshsegment/RefreshSegmentTaskExecutor\.java — [before](https://github.com/apache/pinot/blob/3cc19023dc8a39cc57c714ebeb5d519d1fb68e62/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/refreshsegment/RefreshSegmentTaskExecutor.java) · [after](https://github.com/apache/pinot/blob/60bec82b3918af0b961a06423749669b5c4fe307/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/refreshsegment/RefreshSegmentTaskExecutor.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjNjYzE5MDIzZGM4YTM5Y2M1N2M3MTRlYmViNWQ1MTlkMWZiNjhlNjIiLCJjb250ZXh0X2hhc2giOiJlZWYzOTExOGE5ZTRhZDg2Mzc0YTJmYzlmN2NiNmRmNDdhYzhlZWI4N2RiYmU5MDBiYWM2M2MxYjQwNTg0NDRlIiwiZ2VuZXJhdGVkX2F0IjoxNzg5NDc4MDI1LCJoZWFkX3NoYSI6IjYwYmVjODJiMzkxOGFmMGI5NjFhMDY0MjM3NDk2NjliNWM0ZmUzMDciLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiIzY2MxOTAyM2RjOGEzOWNjNTdjNzE0ZWJlYjVkNTE5ZDFmYjY4ZTYyIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature e90aec61eb03b3632c261975e524ddafde18f23af399809b22621b9307eac9c7 -->
<!-- pinot-pr-flow:end -->

- Fixed typos in comments (e.g., "explicity" → "explicitly")
- Improved grammar and clarity in inline comments
- No functional changes (behavior-neutral)