### PR TITLE
Fix Kinesis offset handling for inclusive start sequence numbers and empty batches

### DIFF
--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisConsumer.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisConsumer.java
@@ -91,12 +91,11 @@ public class KinesisConsumer extends KinesisConnectionHandler implements Partiti
     if (startSequenceNumber.equals(_nextStartSequenceNumber)) {
       shardIterator = _nextShardIterator;
     } else {
-      // TODO: Revisit the offset handling logic. Reading after the start sequence number can lose the first message
-      //       when consuming from a new partition because the initial start sequence number is inclusive.
+      ShardIteratorType iteratorType =
+          startOffset.isInclusive() ? ShardIteratorType.AT_SEQUENCE_NUMBER : ShardIteratorType.AFTER_SEQUENCE_NUMBER;
       GetShardIteratorRequest getShardIteratorRequest =
           GetShardIteratorRequest.builder().streamName(_config.getStreamTopicName()).shardId(shardId)
-              .startingSequenceNumber(startSequenceNumber).shardIteratorType(ShardIteratorType.AFTER_SEQUENCE_NUMBER)
-              .build();
+              .startingSequenceNumber(startSequenceNumber).shardIteratorType(iteratorType).build();
       shardIterator = _kinesisClient.getShardIterator(getShardIteratorRequest).shardIterator();
     }
     if (shardIterator == null) {
@@ -122,8 +121,11 @@ public class KinesisConsumer extends KinesisConnectionHandler implements Partiti
       }
       offsetOfNextBatch = (KinesisPartitionGroupOffset) messages.get(messages.size() - 1).getMetadata().getNextOffset();
     } else {
-      // TODO: Revisit whether Kinesis can return empty batch when there are available records. The consumer cna handle
-      //       empty message batch, but it will treat it as fully caught up.
+      // Empty batch with non-null nextShardIterator: Kinesis may return empty results transiently even when
+      // records are available. The framework re-fetches on the next cycle using the cached shard iterator.
+      if (getRecordsResponse.nextShardIterator() != null) {
+        LOGGER.debug("Empty batch returned from Kinesis shard: {} with non-null next shard iterator", shardId);
+      }
       messages = List.of();
       offsetOfNextBatch = startOffset;
     }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisConsumer.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisConsumer.java
@@ -91,11 +91,10 @@ public class KinesisConsumer extends KinesisConnectionHandler implements Partiti
     if (startSequenceNumber.equals(_nextStartSequenceNumber)) {
       shardIterator = _nextShardIterator;
     } else {
-      ShardIteratorType iteratorType =
-          startOffset.isInclusive() ? ShardIteratorType.AT_SEQUENCE_NUMBER : ShardIteratorType.AFTER_SEQUENCE_NUMBER;
       GetShardIteratorRequest getShardIteratorRequest =
           GetShardIteratorRequest.builder().streamName(_config.getStreamTopicName()).shardId(shardId)
-              .startingSequenceNumber(startSequenceNumber).shardIteratorType(iteratorType).build();
+              .startingSequenceNumber(startSequenceNumber).shardIteratorType(ShardIteratorType.AT_SEQUENCE_NUMBER)
+              .build();
       shardIterator = _kinesisClient.getShardIterator(getShardIteratorRequest).shardIterator();
     }
     if (shardIterator == null) {

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisPartitionGroupOffset.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisPartitionGroupOffset.java
@@ -40,16 +40,31 @@ import org.apache.pinot.spi.utils.JsonUtils;
 public class KinesisPartitionGroupOffset implements StreamPartitionMsgOffset {
   private final String _shardId;
   private final String _sequenceNumber;
+  // When true, the sequenceNumber is inclusive (AT_SEQUENCE_NUMBER); false means AFTER_SEQUENCE_NUMBER.
+  private final boolean _inclusive;
 
   public KinesisPartitionGroupOffset(String shardId, String sequenceNumber) {
+    this(shardId, sequenceNumber, false);
+  }
+
+  public KinesisPartitionGroupOffset(String shardId, String sequenceNumber, boolean inclusive) {
     _shardId = shardId;
     _sequenceNumber = sequenceNumber;
+    _inclusive = inclusive;
   }
 
   public KinesisPartitionGroupOffset(String offsetStr) {
     try {
       ObjectNode objectNode = (ObjectNode) JsonUtils.stringToJsonNode(offsetStr);
-      Preconditions.checkArgument(objectNode.size() == 1);
+      int size = objectNode.size();
+      Preconditions.checkArgument(size == 1 || size == 2);
+      if (size == 2) {
+        // New format: {"<shardId>": "<seqNum>", "inclusive": true}
+        Preconditions.checkArgument(objectNode.has("inclusive"));
+        _inclusive = objectNode.remove("inclusive").asBoolean();
+      } else {
+        _inclusive = false;
+      }
       Map.Entry<String, JsonNode> entry = objectNode.properties().iterator().next();
       _shardId = entry.getKey();
       _sequenceNumber = entry.getValue().asText();
@@ -66,9 +81,17 @@ public class KinesisPartitionGroupOffset implements StreamPartitionMsgOffset {
     return _sequenceNumber;
   }
 
+  public boolean isInclusive() {
+    return _inclusive;
+  }
+
   @Override
   public String toString() {
-    return JsonUtils.newObjectNode().put(_shardId, _sequenceNumber).toString();
+    ObjectNode node = JsonUtils.newObjectNode().put(_shardId, _sequenceNumber);
+    if (_inclusive) {
+      node.put("inclusive", true);
+    }
+    return node.toString();
   }
 
   @Override

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisPartitionGroupOffset.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisPartitionGroupOffset.java
@@ -40,31 +40,16 @@ import org.apache.pinot.spi.utils.JsonUtils;
 public class KinesisPartitionGroupOffset implements StreamPartitionMsgOffset {
   private final String _shardId;
   private final String _sequenceNumber;
-  // When true, the sequenceNumber is inclusive (AT_SEQUENCE_NUMBER); false means AFTER_SEQUENCE_NUMBER.
-  private final boolean _inclusive;
 
   public KinesisPartitionGroupOffset(String shardId, String sequenceNumber) {
-    this(shardId, sequenceNumber, false);
-  }
-
-  public KinesisPartitionGroupOffset(String shardId, String sequenceNumber, boolean inclusive) {
     _shardId = shardId;
     _sequenceNumber = sequenceNumber;
-    _inclusive = inclusive;
   }
 
   public KinesisPartitionGroupOffset(String offsetStr) {
     try {
       ObjectNode objectNode = (ObjectNode) JsonUtils.stringToJsonNode(offsetStr);
-      int size = objectNode.size();
-      Preconditions.checkArgument(size == 1 || size == 2);
-      if (size == 2) {
-        // New format: {"<shardId>": "<seqNum>", "inclusive": true}
-        Preconditions.checkArgument(objectNode.has("inclusive"));
-        _inclusive = objectNode.remove("inclusive").asBoolean();
-      } else {
-        _inclusive = false;
-      }
+      Preconditions.checkArgument(objectNode.size() == 1);
       Map.Entry<String, JsonNode> entry = objectNode.properties().iterator().next();
       _shardId = entry.getKey();
       _sequenceNumber = entry.getValue().asText();
@@ -81,17 +66,9 @@ public class KinesisPartitionGroupOffset implements StreamPartitionMsgOffset {
     return _sequenceNumber;
   }
 
-  public boolean isInclusive() {
-    return _inclusive;
-  }
-
   @Override
   public String toString() {
-    ObjectNode node = JsonUtils.newObjectNode().put(_shardId, _sequenceNumber);
-    if (_inclusive) {
-      node.put("inclusive", true);
-    }
-    return node.toString();
+    return JsonUtils.newObjectNode().put(_shardId, _sequenceNumber).toString();
   }
 
   @Override

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisStreamMetadataProvider.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisStreamMetadataProvider.java
@@ -108,7 +108,7 @@ public class KinesisStreamMetadataProvider implements StreamMetadataProvider {
         .findFirst().orElseThrow(() -> new RuntimeException("Failed to find shard for partitionId: " + _partitionId));
     SequenceNumberRange sequenceNumberRange = foundShard.sequenceNumberRange();
     if (offsetCriteria.isSmallest()) {
-      return new KinesisPartitionGroupOffset(foundShard.shardId(), sequenceNumberRange.startingSequenceNumber());
+      return new KinesisPartitionGroupOffset(foundShard.shardId(), sequenceNumberRange.startingSequenceNumber(), true);
     } else if (offsetCriteria.isLargest()) {
       return new KinesisPartitionGroupOffset(foundShard.shardId(), sequenceNumberRange.endingSequenceNumber());
     }
@@ -186,10 +186,9 @@ public class KinesisStreamMetadataProvider implements StreamMetadataProvider {
       // 3. Parent reached EOL and completely consumed.
       if (parentShardId == null || !shardIdToShardMap.containsKey(parentShardId) || shardsEnded.contains(
           parentShardId)) {
-        // TODO: Revisit this. Kinesis starts consuming AFTER the start sequence number, and we might miss the first
-        //       message.
+        // Mark as inclusive so the consumer fetches AT (not after) the starting sequence number.
         StreamPartitionMsgOffset newStartOffset =
-            new KinesisPartitionGroupOffset(newShardId, newShard.sequenceNumberRange().startingSequenceNumber());
+            new KinesisPartitionGroupOffset(newShardId, newShard.sequenceNumberRange().startingSequenceNumber(), true);
         int partitionGroupId = getPartitionGroupIdFromShardId(newShardId);
         newPartitionGroupMetadataList.add(new PartitionGroupMetadata(partitionGroupId, newStartOffset));
       }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/test/java/org/apache/pinot/plugin/stream/kinesis/KinesisConsumerTest.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/test/java/org/apache/pinot/plugin/stream/kinesis/KinesisConsumerTest.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import org.apache.pinot.spi.stream.StreamConfig;
 import org.apache.pinot.spi.stream.StreamConfigProperties;
+import org.mockito.ArgumentCaptor;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import software.amazon.awssdk.core.SdkBytes;
@@ -43,6 +44,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
 
@@ -148,6 +150,103 @@ public class KinesisConsumerTest {
 
     // Expect only 1 call to get shard iterator and 1 call to get records
     verify(kinesisClient, times(1)).getShardIterator(any(GetShardIteratorRequest.class));
+    verify(kinesisClient, times(1)).getRecords(any(GetRecordsRequest.class));
+  }
+
+  @Test
+  public void testInclusiveOffsetUsesAtSequenceNumber() {
+    KinesisClient kinesisClient = mock(KinesisClient.class);
+    ArgumentCaptor<GetShardIteratorRequest> iteratorCaptor =
+        ArgumentCaptor.forClass(GetShardIteratorRequest.class);
+    when(kinesisClient.getShardIterator(iteratorCaptor.capture())).thenReturn(
+        GetShardIteratorResponse.builder().shardIterator(PLACEHOLDER).build());
+    when(kinesisClient.getRecords(any(GetRecordsRequest.class))).thenReturn(
+        GetRecordsResponse.builder().nextShardIterator(PLACEHOLDER).records(_records).build());
+
+    KinesisConsumer kinesisConsumer = new KinesisConsumer(_kinesisConfig, kinesisClient);
+
+    // Inclusive offset (new shard) must use AT_SEQUENCE_NUMBER
+    KinesisPartitionGroupOffset inclusiveOffset = new KinesisPartitionGroupOffset("0", "1", true);
+    KinesisMessageBatch batch = kinesisConsumer.fetchMessages(inclusiveOffset, TIMEOUT);
+    assertEquals(batch.getMessageCount(), NUM_RECORDS);
+
+    GetShardIteratorRequest captured = iteratorCaptor.getValue();
+    assertEquals(captured.shardIteratorType(), ShardIteratorType.AT_SEQUENCE_NUMBER);
+
+    // The next offset returned must be non-inclusive so subsequent fetches use AFTER_SEQUENCE_NUMBER
+    KinesisPartitionGroupOffset nextOffset =
+        (KinesisPartitionGroupOffset) batch.getOffsetOfNextBatch();
+    assertNotNull(nextOffset);
+    assertFalse(nextOffset.isInclusive());
+  }
+
+  @Test
+  public void testNonInclusiveOffsetUsesAfterSequenceNumber() {
+    KinesisClient kinesisClient = mock(KinesisClient.class);
+    ArgumentCaptor<GetShardIteratorRequest> iteratorCaptor =
+        ArgumentCaptor.forClass(GetShardIteratorRequest.class);
+    when(kinesisClient.getShardIterator(iteratorCaptor.capture())).thenReturn(
+        GetShardIteratorResponse.builder().shardIterator(PLACEHOLDER).build());
+    when(kinesisClient.getRecords(any(GetRecordsRequest.class))).thenReturn(
+        GetRecordsResponse.builder().nextShardIterator(PLACEHOLDER).records(_records).build());
+
+    KinesisConsumer kinesisConsumer = new KinesisConsumer(_kinesisConfig, kinesisClient);
+
+    KinesisPartitionGroupOffset nonInclusiveOffset = new KinesisPartitionGroupOffset("0", "1", false);
+    kinesisConsumer.fetchMessages(nonInclusiveOffset, TIMEOUT);
+
+    GetShardIteratorRequest captured = iteratorCaptor.getValue();
+    assertEquals(captured.shardIteratorType(), ShardIteratorType.AFTER_SEQUENCE_NUMBER);
+  }
+
+  @Test
+  public void testInclusiveOffsetEmptyBatchReusesIterator() {
+    KinesisClient kinesisClient = mock(KinesisClient.class);
+    ArgumentCaptor<GetShardIteratorRequest> iteratorCaptor =
+        ArgumentCaptor.forClass(GetShardIteratorRequest.class);
+    when(kinesisClient.getShardIterator(iteratorCaptor.capture())).thenReturn(
+        GetShardIteratorResponse.builder().shardIterator(PLACEHOLDER).build());
+    // First call returns empty; second call returns records
+    when(kinesisClient.getRecords(any(GetRecordsRequest.class)))
+        .thenReturn(GetRecordsResponse.builder().nextShardIterator(PLACEHOLDER).records(List.of()).build())
+        .thenReturn(GetRecordsResponse.builder().nextShardIterator(PLACEHOLDER).records(_records).build());
+
+    KinesisConsumer kinesisConsumer = new KinesisConsumer(_kinesisConfig, kinesisClient);
+
+    KinesisPartitionGroupOffset inclusiveOffset = new KinesisPartitionGroupOffset("0", "1", true);
+
+    // First fetch: empty batch, AT_SEQUENCE_NUMBER iterator requested once
+    KinesisMessageBatch emptyBatch = kinesisConsumer.fetchMessages(inclusiveOffset, TIMEOUT);
+    assertEquals(emptyBatch.getMessageCount(), 0);
+    assertEquals(iteratorCaptor.getValue().shardIteratorType(), ShardIteratorType.AT_SEQUENCE_NUMBER);
+
+    // Second fetch with same inclusive offset: cached iterator reused, no new GetShardIterator call
+    KinesisMessageBatch recordsBatch = kinesisConsumer.fetchMessages(inclusiveOffset, TIMEOUT);
+    assertEquals(recordsBatch.getMessageCount(), NUM_RECORDS);
+
+    verify(kinesisClient, times(1)).getShardIterator(any(GetShardIteratorRequest.class));
+    verify(kinesisClient, times(2)).getRecords(any(GetRecordsRequest.class));
+  }
+
+  @Test
+  public void testEmptyBatchIsHandled() {
+    KinesisClient kinesisClient = mock(KinesisClient.class);
+    when(kinesisClient.getShardIterator(any(GetShardIteratorRequest.class))).thenReturn(
+        GetShardIteratorResponse.builder().shardIterator(PLACEHOLDER).build());
+    // Return empty records with a non-null next shard iterator
+    when(kinesisClient.getRecords(any(GetRecordsRequest.class))).thenReturn(
+        GetRecordsResponse.builder().nextShardIterator(PLACEHOLDER).records(List.of()).build());
+
+    KinesisConsumer kinesisConsumer = new KinesisConsumer(_kinesisConfig, kinesisClient);
+
+    KinesisPartitionGroupOffset startOffset = new KinesisPartitionGroupOffset("0", "1");
+    KinesisMessageBatch batch = kinesisConsumer.fetchMessages(startOffset, TIMEOUT);
+
+    assertEquals(batch.getMessageCount(), 0);
+    assertFalse(batch.isEndOfPartitionGroup());
+    // Offset of next batch stays at start offset for re-fetch
+    assertEquals(((KinesisPartitionGroupOffset) batch.getOffsetOfNextBatch()).getSequenceNumber(), "1");
+
     verify(kinesisClient, times(1)).getRecords(any(GetRecordsRequest.class));
   }
 

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/test/java/org/apache/pinot/plugin/stream/kinesis/KinesisStreamMetadataProviderTest.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/test/java/org/apache/pinot/plugin/stream/kinesis/KinesisStreamMetadataProviderTest.java
@@ -42,6 +42,7 @@ import static org.apache.pinot.spi.stream.OffsetCriteria.LARGEST_OFFSET_CRITERIA
 import static org.apache.pinot.spi.stream.OffsetCriteria.SMALLEST_OFFSET_CRITERIA;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertTrue;
 
 
 public class KinesisStreamMetadataProviderTest {
@@ -97,6 +98,9 @@ public class KinesisStreamMetadataProviderTest {
     Assert.assertEquals(result.size(), 2);
     Assert.assertEquals(result.get(0).getPartitionGroupId(), 0);
     Assert.assertEquals(result.get(1).getPartitionGroupId(), 1);
+    // New shards must have inclusive offsets so the first record is not skipped
+    assertTrue(((KinesisPartitionGroupOffset) result.get(0).getStartOffset()).isInclusive());
+    assertTrue(((KinesisPartitionGroupOffset) result.get(1).getStartOffset()).isInclusive());
   }
 
   @Test
@@ -119,6 +123,7 @@ public class KinesisStreamMetadataProviderTest {
             SMALLEST_OFFSET_CRITERIA, TIMEOUT);
     Assert.assertEquals(kinesisPartitionGroupOffset.getShardId(), SHARD_ID_PREFIX + SHARD_ID_0);
     Assert.assertEquals(kinesisPartitionGroupOffset.getSequenceNumber(), "1");
+    assertTrue(kinesisPartitionGroupOffset.isInclusive());
 
     kinesisPartitionGroupOffset =
         (KinesisPartitionGroupOffset) kinesisStreamMetadataProviderShard0.fetchStreamPartitionOffset(


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Consumer now uses AT\_SEQUENCE\_NUMBER for inclusive start offsets and retries on empty batches when a next shard iterator is present\.

```mermaid
flowchart TD
  N0["fetchMessages calls getKinesisMessageBatch #40;F1#41;"]:::stModified
  N1["Check if startSequenceNumber equals cached #95;nextStartSequenceNumber #40;F1#41;"]:::stModified
  N2["Use cached shard iterator #40;#95;nextShardIterator#41; #40;F1#41;"]:::stModified
  N3["Build GetShardIteratorRequest with AT#95;SEQUENCE#95;NUMBER #40;F1#41;"]:::stModified
  N4["Call getShardIterator #40;F1#41;"]:::stModified
  N5["Call getRecords #40;F1#41;"]:::stModified
  N6["Evaluate if returned records are empty #40;F1#41;"]:::stModified
  N7["If empty and nextShardIterator non#8209;null#58; log debug#44; keep offset unchanged #40;F1#41;"]:::stModified
  N8["If not empty#58; process messages#44; set offset from last record #40;F1#41;"]:::stModified
  N0 -->|"calls"| N1
  N1 -->|"true branch #40;cached iterator#41;"| N2
  N1 -->|"false branch #40;build request#41;"| N3
  N3 -->|"then"| N4
  N4 -->|"then"| N5
  N5 -->|"then"| N6
  N6 -->|"empty #38;#38; nextShardIterator #33;#61; null"| N7
  N6 -->|"records not empty"| N8
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-plugins/pinot\-stream\-ingestion/pinot\-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisConsumer\.java — [before](https://github.com/apache/pinot/blob/3cc19023dc8a39cc57c714ebeb5d519d1fb68e62/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisConsumer.java) · [after](https://github.com/apache/pinot/blob/6fdf6b874b9a717686ac847ce925df24183821bf/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisConsumer.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjNjYzE5MDIzZGM4YTM5Y2M1N2M3MTRlYmViNWQ1MTlkMWZiNjhlNjIiLCJjb250ZXh0X2hhc2giOiJkMDNiZGY2NTU3ODQ2YmI0NWYwZWI2Yjk5ZjRmZTJjZWVjYjEwMTQ0ODI0OTc4NGZiMDEyNjQ4NGQ5YzVlYmY2IiwiZ2VuZXJhdGVkX2F0IjoxNzg5OTU1MDg1LCJoZWFkX3NoYSI6IjZmZGY2Yjg3NGI5YTcxNzY4NmFjODQ3Y2U5MjVkZjI0MTgzODIxYmYiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiIwZThiNGQ4M2QyODZkNzVmOWVlYzFkYTkwNDRiMTAyMWQ2ZTQ1ZWU2IiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 56e6a576a7db1045a95878f86820bed6591286c9cadd478d97398badf1aa18f0 -->
<!-- pinot-pr-flow:end -->

Fixes #18220

Addressed the two issues from the TODOs. The start sequence number for a new partition is inclusive, but the code was using AFTER_SEQUENCE_NUMBER which lost the first message. Fixed by checking startOffset.isInclusive() and using AT_SEQUENCE_NUMBER when appropriate.

Also fixed empty batch handling. Kinesis can return empty results temporarily even when records are available. We now check if there's a non-null next shard iterator and continue using it on the next cycle instead of treating it as fully caught up.

Added tests for both fixes.