### PR TITLE
style: fix low-risk comment typos and duplicated words

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/minion/RealtimeToOfflineSegmentsTaskMetadata.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/minion/RealtimeToOfflineSegmentsTaskMetadata.java
@@ -35,7 +35,7 @@ import org.apache.helix.zookeeper.datamodel.ZNRecord;
  *
  * PinotTaskExecutor:
  * The same watermark is used by the <code>RealtimeToOfflineSegmentsTaskExecutor</code>, to:
- * - Verify that is is running the latest task scheduled by the task generator
+ * - Verify that it is running the latest task scheduled by the task generator
  * - Update the watermark as the end of the window that it executed for
  */
 public class RealtimeToOfflineSegmentsTaskMetadata extends BaseTaskMetadata {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/BlockingSegmentCompletionFSM.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/BlockingSegmentCompletionFSM.java
@@ -41,7 +41,7 @@ import org.slf4j.LoggerFactory;
 /**
  * This class implements the FSM on the controller side for each completing segment.
  *
- * An FSM is is created when we first hear about a segment (typically through the segmentConsumed message).
+ * An FSM is created when we first hear about a segment (typically through the segmentConsumed message).
  * When an FSM is created, it may have one of two start states (HOLDING, or COMMITTED), depending on the
  * constructor used.
  *

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/realtime/provisioning/MemoryEstimator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/realtime/provisioning/MemoryEstimator.java
@@ -456,7 +456,7 @@ public class MemoryEstimator {
   }
 
   /**
-   * This class is used in Memory Estimator to generate segment based on the the given characteristics of data
+   * This class is used in Memory Estimator to generate segment based on the given characteristics of data
    */
   public static class SegmentGenerator {
     private static final Logger LOGGER = LoggerFactory.getLogger(SegmentGenerator.class);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/rules/utils/QueryInvertedSortedIndexRecommender.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/rules/utils/QueryInvertedSortedIndexRecommender.java
@@ -207,7 +207,7 @@ public class QueryInvertedSortedIndexRecommender {
       // Pick the top N candidates whose nESI saved are > ratio * top_nESI_saved. Forming a list of candidates.
       // However only one of these candidates will be counted towards the global recommendation, this is called
       // exclusive candidates
-      // This is to ensure the the per-query near-optimal recommendations not be overshadowed by the optimal
+      // This is to ensure the per-query near-optimal recommendations not be overshadowed by the optimal
       // recommendations
       // Which will make the global recommendation optimal
       if (totalNESIWithIdxSorted.isEmpty()) { // If no applicable PredicateParseResult

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/groupby/DoubleGroupByResultHolderTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/groupby/DoubleGroupByResultHolderTest.java
@@ -68,7 +68,7 @@ public class DoubleGroupByResultHolderTest {
 
   /**
    * This test is for the GroupByResultHolder.EnsureCapacity api.
-   * - Fills the the result holder with a set of values.
+   * - Fills the result holder with a set of values.
    * - Calls ensureCapacity to expand the result holder size.
    * - Checks that the expanded unfilled portion of the result holder contains {@ref #DEFAULT_VALUE}
    * - Fills the rest of the resultHolder, and ensures all values are returned as expected.

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/refreshsegment/RefreshSegmentTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/refreshsegment/RefreshSegmentTaskExecutor.java
@@ -66,7 +66,7 @@ public class RefreshSegmentTaskExecutor extends BaseSingleSegmentConversionExecu
     _eventObserver.notifyProgress(pinotTaskConfig, "Refreshing segment: " + indexDir);
 
     // We set _taskStartTime before fetching the tableConfig. Task Generation relies on tableConfig/Schema updates
-    // happening after the last processed time. So we explicity use the timestamp before fetching tableConfig as the
+    // happening after the last processed time. So we explicitly use the timestamp before fetching tableConfig as the
     // processedTime.
     _taskStartTime = System.currentTimeMillis();
     Map<String, String> configs = pinotTaskConfig.getConfigs();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/dictionary/BaseOffHeapMutableDictionary.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/dictionary/BaseOffHeapMutableDictionary.java
@@ -130,7 +130,7 @@ import org.slf4j.LoggerFactory;
  * NOT safe for a multiple writer scenario.
  *
  * TODO
- * - It may be useful to implement a way to stop adding new items when the the number of buffers reaches a certain
+ * - It may be useful to implement a way to stop adding new items when the number of buffers reaches a certain
  *   threshold. In this case, we could close the realtime segment, and start a new one with bigger buffers.
  */
 public abstract class BaseOffHeapMutableDictionary implements MutableDictionary {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ComplexTypeTransformer.java
@@ -74,7 +74,7 @@ import org.slf4j.LoggerFactory;
  *
  * </p>
  * The unnesting rule will flatten all the collections provided, which are the paths navigating to the collections. For
- * the same example above. If the the collectionToUnnest is provided as "t1.array", then the rule will unnest the
+ * the same example above. If the collectionToUnnest is provided as "t1.array", then the rule will unnest the
  * previous output to:
  *
  * <pre>


### PR DESCRIPTION
## Summary

Per #18226, sweep a few low-risk comment and Javadoc typos across existing Java files. Comments onlym no code changes, no parameter-name renames, no behavior change.

## What changed

- `RefreshSegmentTaskExecutor` — `explicity` → `explicitly` (the file called out in the issue body).
- `DoubleGroupByResultHolderTest`, `MemoryEstimator`, `QueryInvertedSortedIndexRecommender`, `BaseOffHeapMutableDictionary`, `ComplexTypeTransformer` — duplicated `the the` reduced to `the`.
- `RealtimeToOfflineSegmentsTaskMetadata` — `Verify that is is running` → `Verify that it is running`.
- `BlockingSegmentCompletionFSM` — `An FSM is is created` → `An FSM is created`.

## Scope note

I deliberately left parameter-name typos (for example `occurence` on the `RegexpReplaceVar` scalar functions) out of this PR. Those appear in public-facing Javadoc (`@param occurence`) tied to the parameter names themselves, so renaming them could be confused with an API change even though the parameter names do not affect the SQL function signature. Happy to do a follow-up PR for those once you confirm the direction.

Refs #18226
