### PR TITLE
Promote validator registry reset() to public lifecycle API and invoke from controller stop

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
@@ -146,7 +146,9 @@ import org.apache.pinot.core.transport.grpc.GrpcQueryServer;
 import org.apache.pinot.core.util.ListenerConfigUtil;
 import org.apache.pinot.core.util.trace.ContinuousJfrStarter;
 import org.apache.pinot.segment.local.utils.TableConfigUtils;
+import org.apache.pinot.spi.config.instance.InstanceConfigValidatorRegistry;
 import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableConfigValidatorRegistry;
 import org.apache.pinot.spi.crypt.PinotCrypterFactory;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.env.PinotConfiguration;
@@ -1118,6 +1120,11 @@ public abstract class BaseControllerStarter implements ServiceStartable {
     ServiceStatus.removeServiceStatusCallback(_helixParticipantInstanceId);
     LOGGER.info("Shutdown Controller Metrics Registry");
     _metricsRegistry.shutdown();
+    // Clear validator registries so in-process restart (e.g. integration tests reusing one JVM) does not leak
+    // validators that hold references to the now-disconnected HelixAdmin/HelixManager.
+    LOGGER.info("Clearing config validator registries");
+    TableConfigValidatorRegistry.reset();
+    InstanceConfigValidatorRegistry.reset();
     LOGGER.info("Finish shutting down Pinot controller for {}", _helixParticipantInstanceId);
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/instance/InstanceConfigValidatorRegistry.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/instance/InstanceConfigValidatorRegistry.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.spi.config.instance;
 
-import com.google.common.annotations.VisibleForTesting;
 import java.util.concurrent.CopyOnWriteArrayList;
 import org.apache.pinot.spi.exception.ConfigValidationException;
 
@@ -27,6 +26,14 @@ import org.apache.pinot.spi.exception.ConfigValidationException;
  * Registry for {@link InstanceConfigValidator} implementations.
  * Supports multiple validators invoked in registration order; the first rejection short-circuits with an error.
  * When no validators are registered, {@link #validate} is a no-op.
+ *
+ * <p><b>Lifecycle:</b> {@code BaseControllerStarter#stop()} invokes {@link #reset()} automatically, so
+ * subclasses do <b>not</b> need to call it themselves. Validators registered against controller-owned state
+ * (e.g. {@code HelixAdmin}, {@code HelixManager}, ZK client references) become stale once the controller
+ * stops; the automatic {@code reset()} in {@code stop()} ensures they are removed before any subsequent
+ * {@code start()} registers replacements. This matters for in-process restart scenarios such as integration
+ * tests that reuse a single JVM across multiple controller lifecycles — without it, the next config-mutation
+ * request would fail when a stale validator dereferences its torn-down dependencies.</p>
  */
 public class InstanceConfigValidatorRegistry {
   private InstanceConfigValidatorRegistry() {
@@ -57,7 +64,26 @@ public class InstanceConfigValidatorRegistry {
     }
   }
 
-  @VisibleForTesting
+  /**
+   * Removes a previously registered validator. No-op if the validator is not registered. Removes only the
+   * first matching reference if the same validator was registered multiple times.
+   *
+   * @param validator The validator instance to remove
+   * @return {@code true} if a validator was removed, {@code false} otherwise
+   */
+  public static boolean unregister(InstanceConfigValidator validator) {
+    return VALIDATORS.remove(validator);
+  }
+
+  /**
+   * Removes all registered validators. Intended to be called from a service's shutdown/stop hook when the
+   * validators it registered are about to become stale (e.g. they hold references to soon-to-be-disconnected
+   * Helix clients).
+   *
+   * <p>In production this is rarely needed since service shutdown coincides with JVM shutdown. It is essential
+   * for in-process restart scenarios such as integration tests that reuse a single JVM across multiple
+   * controller lifecycles.</p>
+   */
   public static void reset() {
     VALIDATORS.clear();
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableConfigValidatorRegistry.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableConfigValidatorRegistry.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.spi.config.table;
 
-import com.google.common.annotations.VisibleForTesting;
 import java.util.concurrent.CopyOnWriteArrayList;
 import javax.annotation.Nullable;
 import org.apache.pinot.spi.data.Schema;
@@ -29,6 +28,14 @@ import org.apache.pinot.spi.exception.ConfigValidationException;
  * Registry for {@link TableConfigValidator} implementations.
  * Supports multiple validators invoked in registration order; the first rejection short-circuits with an error.
  * When no validators are registered, {@link #validate} is a no-op.
+ *
+ * <p><b>Lifecycle:</b> {@code BaseControllerStarter#stop()} invokes {@link #reset()} automatically, so
+ * subclasses do <b>not</b> need to call it themselves. Validators registered against controller-owned state
+ * (e.g. {@code HelixAdmin}, {@code HelixManager}, ZK client references) become stale once the controller
+ * stops; the automatic {@code reset()} in {@code stop()} ensures they are removed before any subsequent
+ * {@code start()} registers replacements. This matters for in-process restart scenarios such as integration
+ * tests that reuse a single JVM across multiple controller lifecycles — without it, the next config-mutation
+ * request would fail when a stale validator dereferences its torn-down dependencies.</p>
  */
 public class TableConfigValidatorRegistry {
   private TableConfigValidatorRegistry() {
@@ -60,7 +67,26 @@ public class TableConfigValidatorRegistry {
     }
   }
 
-  @VisibleForTesting
+  /**
+   * Removes a previously registered validator. No-op if the validator is not registered. Removes only the
+   * first matching reference if the same validator was registered multiple times.
+   *
+   * @param validator The validator instance to remove
+   * @return {@code true} if a validator was removed, {@code false} otherwise
+   */
+  public static boolean unregister(TableConfigValidator validator) {
+    return VALIDATORS.remove(validator);
+  }
+
+  /**
+   * Removes all registered validators. Intended to be called from a service's shutdown/stop hook when the
+   * validators it registered are about to become stale (e.g. they hold references to soon-to-be-disconnected
+   * Helix clients).
+   *
+   * <p>In production this is rarely needed since service shutdown coincides with JVM shutdown. It is essential
+   * for in-process restart scenarios such as integration tests that reuse a single JVM across multiple
+   * controller lifecycles.</p>
+   */
   public static void reset() {
     VALIDATORS.clear();
   }


### PR DESCRIPTION
## Summary

- Promote `reset()` on `TableConfigValidatorRegistry` and `InstanceConfigValidatorRegistry` from a `@VisibleForTesting` helper to a public lifecycle API. Added `unregister(validator)` on both registries for API completeness.
- Invoke `TableConfigValidatorRegistry.reset()` and `InstanceConfigValidatorRegistry.reset()` from `BaseControllerStarter.stop()` so cleanup is automatic for any subclass that registered validators.
- Class Javadoc on both registries now documents the lifecycle contract.

## Motivation

The validator SPI added in #18167 holds validators in static `CopyOnWriteArrayList`s. In production this is invisible (controller restart = JVM restart). In integration tests that restart the controller in-process — e.g. `ControllerTest.restartController()` — each `start()` registers a new validator, but the previous validator stays in the static list and retains references to a now-disconnected `HelixAdmin`. After N restarts, the oldest stale validator throws when the next config-mutation request iterates it, and the write is rejected with HTTP 400.

The fix is additive:
- The SPI gains two new public methods; no existing signatures change.
- Production behavior is unchanged: `stop()` previously coincided with JVM exit, which already cleared the static registry. Invoking `reset()` explicitly only affects in-process restart scenarios (integration tests, downstream distributions that restart controllers without JVM restart).

## Test plan

- [x] `./mvnw -pl pinot-spi -am test -Dtest='TableConfigValidatorRegistryTest,InstanceConfigValidatorRegistryTest'`
- [x] `./mvnw -pl pinot-spi spotless:apply checkstyle:check license:format license:check`
- [x] `./mvnw -pl pinot-controller compile`
- [x] `./mvnw -pl pinot-controller spotless:apply checkstyle:check license:format license:check`
- [ ] CI green