### PR TITLE
Fix noisy logs in QueryDispatcher

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
@@ -343,7 +343,7 @@ public class QueryDispatcher {
     // TODO: Cancel all dispatched requests if one of the dispatch errors out or deadline is breached.
     while (!deadline.isExpired() && numSuccessCalls < numServers) {
       AsyncResponse<E> resp =
-          dispatchCallbacks.poll(deadline.timeRemaining(TimeUnit.MILLISECONDS), TimeUnit.MILLISECONDS);
+          dispatchCallbacks.poll(Math.max(1, deadline.timeRemaining(TimeUnit.MILLISECONDS)), TimeUnit.MILLISECONDS);
       if (resp != null) {
         if (resp.getThrowable() != null) {
           // If it's a connectivity issue between the broker and the server, mark the server as unhealthy to prevent


### PR DESCRIPTION
- In `QueryDispatcher.processResults`, `dispatchCallbacks.poll(deadline.timeRemaining(MS), MS)` could be called with 0 when the deadline has sub-millisecond time remaining (rounded down from nanos) but `isExpired()` is still false. This caused poll to return null immediately, log `"No response from server for query"`, and spin the loop until the deadline flipped to expired.
- This fix clamps the poll timeout to at least 1ms via `Math.max(1, deadline.timeRemaining(MS))` so the final iteration blocks long enough for the deadline to actually expire (or a response to arrive), avoiding the busy loop and noisy logs.