### PR TITLE
Update compatibility CI to release 1.5.0

### DIFF
--- a/.github/workflows/pinot_tests.yml
+++ b/.github/workflows/pinot_tests.yml
@@ -380,7 +380,7 @@ jobs:
       matrix:
         test_suite: [ "compatibility-verifier/sample-test-suite" ]
         old_commit: [
-          "release-1.4.0", "master"
+          "release-1.5.0", "master"
         ]
     name: Pinot Compatibility Regression Testing against ${{ matrix.old_commit }} on ${{ matrix.test_suite }}
     steps:
@@ -438,7 +438,7 @@ jobs:
       matrix:
         test_suite: [ "compatibility-verifier/multi-stage-query-engine-test-suite" ]
         old_commit: [
-          "release-1.4.0", "master"
+          "release-1.5.0", "master"
         ]
     name: Pinot Multi-Stage Query Engine Compatibility Regression Testing against ${{ matrix.old_commit }} on ${{ matrix.test_suite }}
     steps:


### PR DESCRIPTION
## Summary
- Update the GitHub Actions compatibility verifier matrices from `release-1.4.0` to `release-1.5.0`.
- Keep both the standard and multi-stage compatibility jobs aligned with the latest release branch covered by CI.

## Why
- The compatibility regression jobs in `.github/workflows/pinot_tests.yml` were still pinned to `release-1.4.0`.
- Moving them to `release-1.5.0` keeps CI exercising compatibility against the current release line.

## How to reproduce
1. Open `.github/workflows/pinot_tests.yml` before this change.
2. Inspect the `compatibility-verifier` and `multi-stage-compatibility-verifier` job matrices.
3. Observe that both `old_commit` lists reference `release-1.4.0` instead of `release-1.5.0`.

## Validation
- Parsed `.github/workflows/pinot_tests.yml` with Ruby `YAML.load_file`.
- Ran `git diff --check upstream/master...HEAD`.