### PR TITLE
[codex] Upgrade Flink connector to Flink 2.2.0 for Java 21

### DIFF
--- a/pinot-connectors/pinot-flink-connector/README.md
+++ b/pinot-connectors/pinot-flink-connector/README.md
@@ -28,7 +28,7 @@ including the upsert tables. You can read more about the motivation and design i
 // Set up flink env and data source
 StreamExecutionEnvironment execEnv = StreamExecutionEnvironment.getExecutionEnvironment();
 execEnv.setParallelism(2); // optional
-DataStream<Row> srcDs = execEnv.fromData(data, TEST_TYPE_INFO)
+DataStream<Row> srcDs = execEnv.fromData(data, TEST_TYPE_INFO);
 
 // Create a PinotAdminClient to fetch Pinot schema and table config
 String controllerUrl = "http://localhost:9000";
@@ -60,7 +60,7 @@ execEnv.execute();
 // Set up flink env and data source
 StreamExecutionEnvironment execEnv = StreamExecutionEnvironment.getExecutionEnvironment();
 execEnv.setParallelism(2); // mandatory for upsert tables
-DataStream<Row> srcDs = execEnv.fromData(data, TEST_TYPE_INFO)
+DataStream<Row> srcDs = execEnv.fromData(data, TEST_TYPE_INFO);
 
 // Create a PinotAdminClient to fetch Pinot schema and table config
 String controllerUrl = "http://localhost:9000";

--- a/pinot-connectors/pinot-flink-connector/README.md
+++ b/pinot-connectors/pinot-flink-connector/README.md
@@ -28,7 +28,7 @@ including the upsert tables. You can read more about the motivation and design i
 // Set up flink env and data source
 StreamExecutionEnvironment execEnv = StreamExecutionEnvironment.getExecutionEnvironment();
 execEnv.setParallelism(2); // optional
-DataStream<Row> srcDs = execEnv.fromCollection(data).returns(TEST_TYPE_INFO)
+DataStream<Row> srcDs = execEnv.fromData(data, TEST_TYPE_INFO)
 
 // Create a PinotAdminClient to fetch Pinot schema and table config
 String controllerUrl = "http://localhost:9000";
@@ -49,7 +49,7 @@ try (PinotAdminClient client = new PinotAdminClient(controllerAddress, propertie
   TableConfig tableConfig =
       client.getTableClient().getTableConfigObjectForType("starbucksStores", TableType.OFFLINE);
   // create Flink Pinot Sink
-  srcDs.addSink(new PinotSinkFunction<>(new PinotRowRecordConverter(TEST_TYPE_INFO), tableConfig, schema,
+  srcDs.sinkTo(new PinotSink<>(new PinotRowRecordConverter(TEST_TYPE_INFO), tableConfig, schema,
       controllerUrl));
 }
 execEnv.execute();
@@ -60,7 +60,7 @@ execEnv.execute();
 // Set up flink env and data source
 StreamExecutionEnvironment execEnv = StreamExecutionEnvironment.getExecutionEnvironment();
 execEnv.setParallelism(2); // mandatory for upsert tables
-DataStream<Row> srcDs = execEnv.fromCollection(data).returns(TEST_TYPE_INFO)
+DataStream<Row> srcDs = execEnv.fromData(data, TEST_TYPE_INFO)
 
 // Create a PinotAdminClient to fetch Pinot schema and table config
 String controllerUrl = "http://localhost:9000";
@@ -83,7 +83,7 @@ try (PinotAdminClient client = new PinotAdminClient(controllerAddress, propertie
 
   // create Flink Pinot Sink (partition it same as the realtime stream(e.g. kafka) in case of upsert tables)
   srcDs.partitionCustom((Partitioner<Integer>) (key, partitions) -> key % partitions, r -> (Integer) r.getField("primaryKey"))
-      .addSink(new PinotSinkFunction<>(new PinotRowRecordConverter(TEST_TYPE_INFO), tableConfig, schema,
+      .sinkTo(new PinotSink<>(new PinotRowRecordConverter(TEST_TYPE_INFO), tableConfig, schema,
           controllerUrl));
 }
 execEnv.execute();

--- a/pinot-connectors/pinot-flink-connector/pom.xml
+++ b/pinot-connectors/pinot-flink-connector/pom.xml
@@ -61,11 +61,6 @@
         </exclusion>
       </exclusions>
     </dependency>
-    <dependency>
-      <groupId>org.apache.flink</groupId>
-      <artifactId>flink-java</artifactId>
-    </dependency>
-
     <!-- Test Dependencies -->
     <dependency>
       <groupId>org.apache.pinot</groupId>

--- a/pinot-connectors/pinot-flink-connector/src/main/java/org/apache/pinot/connector/flink/FlinkQuickStart.java
+++ b/pinot-connectors/pinot-flink-connector/src/main/java/org/apache/pinot/connector/flink/FlinkQuickStart.java
@@ -35,7 +35,7 @@ import org.apache.flink.types.Row;
 import org.apache.pinot.client.admin.PinotAdminClient;
 import org.apache.pinot.client.admin.PinotAdminTransport;
 import org.apache.pinot.connector.flink.common.FlinkRowGenericRowConverter;
-import org.apache.pinot.connector.flink.sink.PinotSinkFunction;
+import org.apache.pinot.connector.flink.sink.PinotSink;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.Schema;
@@ -78,7 +78,7 @@ public final class FlinkQuickStart {
     List<Row> data = loadData();
     StreamExecutionEnvironment execEnv = StreamExecutionEnvironment.getExecutionEnvironment();
     execEnv.setParallelism(2);
-    DataStream<Row> srcDs = execEnv.fromCollection(data).returns(TEST_TYPE_INFO).keyBy(r -> r.getField(0));
+    DataStream<Row> srcDs = execEnv.fromData(data, TEST_TYPE_INFO).keyBy(r -> r.getField(0));
 
     URI controllerUri = URI.create(DEFAULT_CONTROLLER_URL);
     String controllerAddress = controllerUri.getAuthority();
@@ -94,9 +94,8 @@ public final class FlinkQuickStart {
       Schema schema = client.getSchemaClient().getSchemaObject("starbucksStores");
       TableConfig tableConfig =
           client.getTableClient().getTableConfigObjectForType("starbucksStores", TableType.OFFLINE);
-      srcDs.addSink(
-          new PinotSinkFunction<>(new FlinkRowGenericRowConverter(TEST_TYPE_INFO), tableConfig, schema,
-              DEFAULT_CONTROLLER_URL));
+      srcDs.sinkTo(new PinotSink<>(new FlinkRowGenericRowConverter(TEST_TYPE_INFO), tableConfig, schema,
+          DEFAULT_CONTROLLER_URL));
     }
     execEnv.execute();
   }

--- a/pinot-connectors/pinot-flink-connector/src/main/java/org/apache/pinot/connector/flink/sink/PinotSink.java
+++ b/pinot-connectors/pinot-flink-connector/src/main/java/org/apache/pinot/connector/flink/sink/PinotSink.java
@@ -1,0 +1,336 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.connector.flink.sink;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
+import org.apache.flink.api.connector.sink2.Sink;
+import org.apache.flink.api.connector.sink2.SinkWriter;
+import org.apache.flink.api.connector.sink2.WriterInitContext;
+import org.apache.pinot.connector.flink.common.PinotGenericRowConverter;
+import org.apache.pinot.plugin.segmentuploader.SegmentUploaderDefault;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.ingestion.BatchIngestionConfig;
+import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.ingestion.batch.BatchConfigProperties;
+import org.apache.pinot.spi.ingestion.segment.uploader.SegmentUploader;
+import org.apache.pinot.spi.ingestion.segment.writer.SegmentWriter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * A Flink 2.x {@link Sink} that converts stream records into Pinot segments and uploads them to Pinot.
+ *
+ * <p>The sink is stateless and provides at-least-once semantics by draining in-flight uploads whenever Flink asks the
+ * writer to flush.
+ *
+ * @param <T> type of record supported by the sink
+ */
+@SuppressWarnings("NullAway")
+public class PinotSink<T> implements Sink<T> {
+  public static final long DEFAULT_SEGMENT_FLUSH_MAX_NUM_RECORDS = 500000;
+  public static final int DEFAULT_EXECUTOR_POOL_SIZE = 5;
+  public static final long DEFAULT_EXECUTOR_SHUTDOWN_WAIT_MS = 3000;
+  public static final String DEFAULT_OUTPUT_DIR_URI = "/tmp/pinotoutput";
+
+  private static final long serialVersionUID = 1L;
+  private static final Logger LOG = LoggerFactory.getLogger(PinotSink.class);
+
+  private final long _segmentFlushMaxNumRecords;
+  private final int _executorPoolSize;
+  private final PinotGenericRowConverter<T> _recordConverter;
+  private final TableConfig _tableConfig;
+  private final Schema _schema;
+  @Nullable private final String _segmentNamePrefix;
+  @Nullable private final Long _segmentUploadTimeMs;
+
+  public PinotSink(PinotGenericRowConverter<T> recordConverter, TableConfig tableConfig, Schema schema) {
+    this(recordConverter, tableConfig, schema, DEFAULT_SEGMENT_FLUSH_MAX_NUM_RECORDS, DEFAULT_EXECUTOR_POOL_SIZE);
+  }
+
+  /**
+   * Creates a sink using a table config fetched from the controller and injects the upload settings required by the
+   * Flink connector.
+   */
+  public PinotSink(PinotGenericRowConverter<T> recordConverter, TableConfig tableConfig, Schema schema,
+      String controllerBaseUrl) {
+    this(recordConverter, prepareTableConfigForSink(tableConfig, controllerBaseUrl), schema,
+        DEFAULT_SEGMENT_FLUSH_MAX_NUM_RECORDS, DEFAULT_EXECUTOR_POOL_SIZE);
+  }
+
+  public PinotSink(PinotGenericRowConverter<T> recordConverter, TableConfig tableConfig, Schema schema,
+      long segmentFlushMaxNumRecords, int executorPoolSize) {
+    this(recordConverter, tableConfig, schema, segmentFlushMaxNumRecords, executorPoolSize, null, null);
+  }
+
+  public PinotSink(PinotGenericRowConverter<T> recordConverter, TableConfig tableConfig, Schema schema,
+      long segmentFlushMaxNumRecords, int executorPoolSize, @Nullable String segmentNamePrefix,
+      @Nullable Long segmentUploadTimeMs) {
+    _recordConverter = recordConverter;
+    _tableConfig = tableConfig;
+    _schema = schema;
+    _segmentFlushMaxNumRecords = segmentFlushMaxNumRecords;
+    _executorPoolSize = executorPoolSize;
+    _segmentNamePrefix = segmentNamePrefix;
+    _segmentUploadTimeMs = segmentUploadTimeMs;
+  }
+
+  /**
+   * Applies the connector-specific batch-ingestion defaults needed for segment generation and upload.
+   */
+  static TableConfig prepareTableConfigForSink(TableConfig tableConfig, String controllerBaseUrl) {
+    Map<String, String> requiredBatchConfig = new HashMap<>();
+    requiredBatchConfig.put(BatchConfigProperties.PUSH_CONTROLLER_URI, controllerBaseUrl);
+    requiredBatchConfig.put(BatchConfigProperties.OUTPUT_DIR_URI, DEFAULT_OUTPUT_DIR_URI);
+
+    IngestionConfig ingestionConfig = tableConfig.getIngestionConfig();
+    if (ingestionConfig == null) {
+      ingestionConfig = new IngestionConfig();
+      ingestionConfig.setBatchIngestionConfig(
+          new BatchIngestionConfig(Collections.singletonList(requiredBatchConfig), "APPEND", "HOURLY"));
+      tableConfig.setIngestionConfig(ingestionConfig);
+      return tableConfig;
+    }
+
+    BatchIngestionConfig batchIngestionConfig = ingestionConfig.getBatchIngestionConfig();
+    if (batchIngestionConfig == null) {
+      ingestionConfig.setBatchIngestionConfig(
+          new BatchIngestionConfig(Collections.singletonList(requiredBatchConfig), "APPEND", "HOURLY"));
+      return tableConfig;
+    }
+
+    List<Map<String, String>> batchConfigMaps = batchIngestionConfig.getBatchConfigMaps();
+    if (batchConfigMaps == null || batchConfigMaps.isEmpty()) {
+      batchIngestionConfig.setBatchConfigMaps(Collections.singletonList(requiredBatchConfig));
+    } else if (batchConfigMaps.size() > 1) {
+      throw new IllegalStateException(String.format(
+          "Flink connector requires exactly 1 batchConfigMap for table %s, got %d", tableConfig.getTableName(),
+          batchConfigMaps.size()));
+    } else {
+      Map<String, String> mergedBatchConfig = new HashMap<>(batchConfigMaps.get(0));
+      mergedBatchConfig.putAll(requiredBatchConfig);
+      batchIngestionConfig.setBatchConfigMaps(Collections.singletonList(mergedBatchConfig));
+    }
+    return tableConfig;
+  }
+
+  @Override
+  public SinkWriter<T> createWriter(WriterInitContext context)
+      throws IOException {
+    return new PinotSinkWriter(context);
+  }
+
+  /**
+   * Writer implementation used by the Flink runtime inside each sink subtask.
+   *
+   * <p>This writer is not thread-safe; Flink invokes it from a single task thread while uploads are dispatched to a
+   * bounded background pool.
+   */
+  private final class PinotSinkWriter implements SinkWriter<T> {
+    private final SegmentWriter _segmentWriter;
+    private final SegmentUploader _segmentUploader;
+    private final ExecutorService _executor;
+    private final List<Future<?>> _pendingUploads = new ArrayList<>();
+    private long _segmentNumRecord;
+
+    private PinotSinkWriter(WriterInitContext context)
+        throws IOException {
+      _executor = Executors.newFixedThreadPool(_executorPoolSize);
+
+      SegmentWriter segmentWriter = null;
+      SegmentUploader segmentUploader = null;
+      try {
+        int subtaskIndex = context.getTaskInfo().getIndexOfThisSubtask();
+        segmentWriter =
+            new FlinkSegmentWriter(subtaskIndex, context.metricGroup(), _segmentNamePrefix, _segmentUploadTimeMs);
+        segmentWriter.init(_tableConfig, _schema);
+        segmentUploader = new SegmentUploaderDefault();
+        segmentUploader.init(_tableConfig);
+        _segmentWriter = segmentWriter;
+        _segmentUploader = segmentUploader;
+        LOG.info("Open Pinot sink with the table {}", _tableConfig.toJsonString());
+      } catch (Exception e) {
+        shutdownExecutorNow();
+        closeQuietly(segmentWriter);
+        throw new IOException("Failed to initialize Pinot sink writer", e);
+      }
+    }
+
+    @Override
+    public void write(T element, Context context)
+        throws IOException, InterruptedException {
+      checkCompletedUploads();
+      try {
+        _segmentWriter.collect(_recordConverter.convertToRow(element));
+      } catch (Exception e) {
+        throw new IOException("Failed to write record to Pinot segment buffer", e);
+      }
+      _segmentNumRecord++;
+      if (_segmentNumRecord >= _segmentFlushMaxNumRecords) {
+        flushBufferAsync();
+      }
+    }
+
+    @Override
+    public void flush(boolean endOfInput)
+        throws IOException, InterruptedException {
+      if (_segmentNumRecord > 0) {
+        flushBufferAsync();
+      }
+      waitForPendingUploads();
+    }
+
+    @Override
+    public void close()
+        throws Exception {
+      Exception failure = null;
+      LOG.info("Closing Pinot sink");
+      try {
+        flush(true);
+      } catch (Exception e) {
+        failure = e;
+      } finally {
+        try {
+          shutdownExecutor();
+        } catch (InterruptedException e) {
+          if (failure == null) {
+            failure = e;
+          } else {
+            failure.addSuppressed(e);
+          }
+        }
+        try {
+          _segmentWriter.close();
+        } catch (Exception e) {
+          if (failure == null) {
+            failure = e;
+          } else {
+            failure.addSuppressed(e);
+          }
+        }
+      }
+
+      if (failure != null) {
+        throw failure;
+      }
+    }
+
+    private void flushBufferAsync()
+        throws IOException {
+      final URI segmentURI;
+      try {
+        segmentURI = _segmentWriter.flush();
+      } catch (Exception e) {
+        throw new IOException("Failed to flush Pinot segment buffer", e);
+      }
+
+      long recordsInSegment = _segmentNumRecord;
+      _segmentNumRecord = 0;
+      LOG.info("Pinot segment writer flushed with {} records to {}", recordsInSegment, segmentURI);
+      _pendingUploads.add(_executor.submit(() -> {
+        try {
+          _segmentUploader.uploadSegment(segmentURI, null);
+        } catch (Exception e) {
+          throw new RuntimeException("Failed to upload Pinot segment", e);
+        }
+        LOG.info("Pinot segment uploaded to {}", segmentURI);
+      }));
+    }
+
+    private void checkCompletedUploads()
+        throws IOException, InterruptedException {
+      Iterator<Future<?>> iterator = _pendingUploads.iterator();
+      while (iterator.hasNext()) {
+        Future<?> pendingUpload = iterator.next();
+        if (pendingUpload.isDone()) {
+          awaitUpload(pendingUpload);
+          iterator.remove();
+        }
+      }
+    }
+
+    private void waitForPendingUploads()
+        throws IOException, InterruptedException {
+      for (Future<?> pendingUpload : _pendingUploads) {
+        awaitUpload(pendingUpload);
+      }
+      _pendingUploads.clear();
+    }
+
+    private void awaitUpload(Future<?> pendingUpload)
+        throws IOException, InterruptedException {
+      try {
+        pendingUpload.get();
+      } catch (ExecutionException e) {
+        Throwable cause = unwrapExecutionFailure(e.getCause());
+        if (cause instanceof IOException) {
+          throw (IOException) cause;
+        }
+        if (cause instanceof InterruptedException) {
+          Thread.currentThread().interrupt();
+          throw (InterruptedException) cause;
+        }
+        throw new IOException("Failed to upload Pinot segment", cause);
+      }
+    }
+
+    private Throwable unwrapExecutionFailure(Throwable throwable) {
+      if (throwable instanceof RuntimeException && throwable.getCause() != null) {
+        return throwable.getCause();
+      }
+      return throwable;
+    }
+
+    private void shutdownExecutor()
+        throws InterruptedException {
+      _executor.shutdown();
+      if (!_executor.awaitTermination(DEFAULT_EXECUTOR_SHUTDOWN_WAIT_MS, TimeUnit.MILLISECONDS)) {
+        _executor.shutdownNow();
+      }
+    }
+
+    private void shutdownExecutorNow() {
+      _executor.shutdownNow();
+    }
+
+    private void closeQuietly(@Nullable SegmentWriter closeable) {
+      if (closeable != null) {
+        try {
+          closeable.close();
+        } catch (Exception e) {
+          LOG.warn("Failed to close Pinot segment writer during cleanup", e);
+        }
+      }
+    }
+  }
+}

--- a/pinot-connectors/pinot-flink-connector/src/main/java/org/apache/pinot/connector/flink/sink/PinotSink.java
+++ b/pinot-connectors/pinot-flink-connector/src/main/java/org/apache/pinot/connector/flink/sink/PinotSink.java
@@ -218,11 +218,13 @@ public class PinotSink<T> implements Sink<T> {
       try {
         flush(true);
       } catch (Exception e) {
+        restoreInterruptFlag(e);
         failure = e;
       } finally {
         try {
           shutdownExecutor();
         } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
           if (failure == null) {
             failure = e;
           } else {
@@ -321,6 +323,12 @@ public class PinotSink<T> implements Sink<T> {
 
     private void shutdownExecutorNow() {
       _executor.shutdownNow();
+    }
+
+    private void restoreInterruptFlag(Exception exception) {
+      if (exception instanceof InterruptedException) {
+        Thread.currentThread().interrupt();
+      }
     }
 
     private void closeQuietly(@Nullable SegmentWriter closeable) {

--- a/pinot-connectors/pinot-flink-connector/src/main/java/org/apache/pinot/connector/flink/sink/PinotSinkFunction.java
+++ b/pinot-connectors/pinot-flink-connector/src/main/java/org/apache/pinot/connector/flink/sink/PinotSinkFunction.java
@@ -35,6 +35,12 @@ import org.apache.pinot.spi.data.Schema;
 @Deprecated
 public class PinotSinkFunction<T> extends PinotSink<T> {
   private static final long serialVersionUID = 1L;
+  @Deprecated
+  public static final String DEFAULT_OUTPUT_DIR_URI = PinotSink.DEFAULT_OUTPUT_DIR_URI;
+  @Deprecated
+  public static final long DEFAULT_SEGMENT_FLUSH_MAX_NUM_RECORDS = PinotSink.DEFAULT_SEGMENT_FLUSH_MAX_NUM_RECORDS;
+  @Deprecated
+  public static final int DEFAULT_EXECUTOR_POOL_SIZE = PinotSink.DEFAULT_EXECUTOR_POOL_SIZE;
 
   public PinotSinkFunction(PinotGenericRowConverter<T> recordConverter, TableConfig tableConfig, Schema schema) {
     super(recordConverter, tableConfig, schema);

--- a/pinot-connectors/pinot-flink-connector/src/main/java/org/apache/pinot/connector/flink/sink/PinotSinkFunction.java
+++ b/pinot-connectors/pinot-flink-connector/src/main/java/org/apache/pinot/connector/flink/sink/PinotSinkFunction.java
@@ -18,209 +18,46 @@
  */
 package org.apache.pinot.connector.flink.sink;
 
-import java.net.URI;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
-import org.apache.flink.configuration.Configuration;
-import org.apache.flink.runtime.state.FunctionInitializationContext;
-import org.apache.flink.runtime.state.FunctionSnapshotContext;
-import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
-import org.apache.flink.streaming.api.functions.sink.RichSinkFunction;
 import org.apache.pinot.connector.flink.common.PinotGenericRowConverter;
-import org.apache.pinot.plugin.segmentuploader.SegmentUploaderDefault;
 import org.apache.pinot.spi.config.table.TableConfig;
-import org.apache.pinot.spi.config.table.ingestion.BatchIngestionConfig;
-import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.apache.pinot.spi.data.Schema;
-import org.apache.pinot.spi.ingestion.batch.BatchConfigProperties;
-import org.apache.pinot.spi.ingestion.segment.uploader.SegmentUploader;
-import org.apache.pinot.spi.ingestion.segment.writer.SegmentWriter;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 /**
- * The sink function for Pinot.
+ * Backward-compatible shim for code that still constructs the old sink class name.
  *
- * @param <T> type of record supported
+ * <p>Flink 2.x removed the legacy {@code SinkFunction} API. Use {@link PinotSink} together with
+ * {@code DataStream#sinkTo(Sink)} for new code.
+ *
+ * @param <T> type of record supported by the sink
  */
-@SuppressWarnings("NullAway")
-public class PinotSinkFunction<T> extends RichSinkFunction<T> implements CheckpointedFunction {
-
-  public static final long DEFAULT_SEGMENT_FLUSH_MAX_NUM_RECORDS = 500000;
-  public static final int DEFAULT_EXECUTOR_POOL_SIZE = 5;
-  public static final long DEFAULT_EXECUTOR_SHUTDOWN_WAIT_MS = 3000;
-  public static final String DEFAULT_OUTPUT_DIR_URI = "/tmp/pinotoutput";
-
+@Deprecated
+public class PinotSinkFunction<T> extends PinotSink<T> {
   private static final long serialVersionUID = 1L;
-  private static final Logger LOG = LoggerFactory.getLogger(PinotSinkFunction.class);
-
-  private final long _segmentFlushMaxNumRecords;
-  private final int _executorPoolSize;
-
-  private final PinotGenericRowConverter<T> _recordConverter;
-
-  private final TableConfig _tableConfig;
-  private final Schema _schema;
-
-  @Nullable private final String _segmentNamePrefix;
-
-  // Used to set upload time in segment name, if not provided, current time is used
-  @Nullable private final Long _segmentUploadTimeMs;
-
-  private transient SegmentWriter _segmentWriter;
-  private transient SegmentUploader _segmentUploader;
-  private transient ExecutorService _executor;
-  private transient long _segmentNumRecord;
 
   public PinotSinkFunction(PinotGenericRowConverter<T> recordConverter, TableConfig tableConfig, Schema schema) {
-    this(recordConverter, tableConfig, schema, DEFAULT_SEGMENT_FLUSH_MAX_NUM_RECORDS, DEFAULT_EXECUTOR_POOL_SIZE);
+    super(recordConverter, tableConfig, schema);
   }
 
-  /**
-   * Creates a sink using a table config fetched from the controller and injects the upload settings required by the
-   * Flink connector.
-   */
   public PinotSinkFunction(PinotGenericRowConverter<T> recordConverter, TableConfig tableConfig, Schema schema,
       String controllerBaseUrl) {
-    this(recordConverter, prepareTableConfigForSink(tableConfig, controllerBaseUrl), schema,
-        DEFAULT_SEGMENT_FLUSH_MAX_NUM_RECORDS, DEFAULT_EXECUTOR_POOL_SIZE);
+    super(recordConverter, tableConfig, schema, controllerBaseUrl);
   }
 
   public PinotSinkFunction(PinotGenericRowConverter<T> recordConverter, TableConfig tableConfig, Schema schema,
       long segmentFlushMaxNumRecords, int executorPoolSize) {
-    this(recordConverter, tableConfig, schema, segmentFlushMaxNumRecords, executorPoolSize, null, null);
+    super(recordConverter, tableConfig, schema, segmentFlushMaxNumRecords, executorPoolSize);
   }
 
   public PinotSinkFunction(PinotGenericRowConverter<T> recordConverter, TableConfig tableConfig, Schema schema,
       long segmentFlushMaxNumRecords, int executorPoolSize, @Nullable String segmentNamePrefix,
       @Nullable Long segmentUploadTimeMs) {
-    _recordConverter = recordConverter;
-    _tableConfig = tableConfig;
-    _schema = schema;
-    _segmentFlushMaxNumRecords = segmentFlushMaxNumRecords;
-    _executorPoolSize = executorPoolSize;
-    _segmentNamePrefix = segmentNamePrefix;
-    _segmentUploadTimeMs = segmentUploadTimeMs;
+    super(recordConverter, tableConfig, schema, segmentFlushMaxNumRecords, executorPoolSize, segmentNamePrefix,
+        segmentUploadTimeMs);
   }
 
-  /**
-   * Applies the connector-specific batch-ingestion defaults needed for segment generation and upload.
-   */
   static TableConfig prepareTableConfigForSink(TableConfig tableConfig, String controllerBaseUrl) {
-    Map<String, String> requiredBatchConfig = new HashMap<>();
-    requiredBatchConfig.put(BatchConfigProperties.PUSH_CONTROLLER_URI, controllerBaseUrl);
-    requiredBatchConfig.put(BatchConfigProperties.OUTPUT_DIR_URI, DEFAULT_OUTPUT_DIR_URI);
-
-    IngestionConfig ingestionConfig = tableConfig.getIngestionConfig();
-    if (ingestionConfig == null) {
-      ingestionConfig = new IngestionConfig();
-      ingestionConfig.setBatchIngestionConfig(
-          new BatchIngestionConfig(Collections.singletonList(requiredBatchConfig), "APPEND", "HOURLY"));
-      tableConfig.setIngestionConfig(ingestionConfig);
-      return tableConfig;
-    }
-
-    BatchIngestionConfig batchIngestionConfig = ingestionConfig.getBatchIngestionConfig();
-    if (batchIngestionConfig == null) {
-      ingestionConfig.setBatchIngestionConfig(
-          new BatchIngestionConfig(Collections.singletonList(requiredBatchConfig), "APPEND", "HOURLY"));
-      return tableConfig;
-    }
-
-    List<Map<String, String>> batchConfigMaps = batchIngestionConfig.getBatchConfigMaps();
-    if (batchConfigMaps == null || batchConfigMaps.isEmpty()) {
-      batchIngestionConfig.setBatchConfigMaps(Collections.singletonList(requiredBatchConfig));
-    } else if (batchConfigMaps.size() > 1) {
-      throw new IllegalStateException(String.format(
-          "Flink connector requires exactly 1 batchConfigMap for table %s, got %d", tableConfig.getTableName(),
-          batchConfigMaps.size()));
-    } else {
-      Map<String, String> mergedBatchConfig = new HashMap<>(batchConfigMaps.get(0));
-      mergedBatchConfig.putAll(requiredBatchConfig);
-      batchIngestionConfig.setBatchConfigMaps(Collections.singletonList(mergedBatchConfig));
-    }
-    return tableConfig;
-  }
-
-  @Override
-  public void open(Configuration parameters)
-      throws Exception {
-    int indexOfSubtask = this.getRuntimeContext().getIndexOfThisSubtask();
-    _segmentWriter = new FlinkSegmentWriter(indexOfSubtask, getRuntimeContext().getMetricGroup(), _segmentNamePrefix,
-        _segmentUploadTimeMs);
-    _segmentWriter.init(_tableConfig, _schema);
-    _segmentUploader = new SegmentUploaderDefault();
-    _segmentUploader.init(_tableConfig);
-    _segmentNumRecord = 0;
-    _executor = Executors.newFixedThreadPool(_executorPoolSize);
-    LOG.info("Open Pinot Sink with the table {}", _tableConfig.toJsonString());
-  }
-
-  @Override
-  public void close()
-      throws Exception {
-    LOG.info("Closing Pinot Sink");
-    try {
-      if (_segmentNumRecord > 0) {
-        flush();
-      }
-    } catch (Exception e) {
-      LOG.error("Error when closing Pinot sink", e);
-    }
-    _executor.shutdown();
-    try {
-      if (!_executor.awaitTermination(DEFAULT_EXECUTOR_SHUTDOWN_WAIT_MS, TimeUnit.MILLISECONDS)) {
-        _executor.shutdownNow();
-      }
-    } catch (InterruptedException e) {
-      _executor.shutdownNow();
-    } finally {
-      _segmentWriter.close();
-    }
-  }
-
-  @Override
-  public void invoke(T value, Context context)
-      throws Exception {
-    _segmentWriter.collect(_recordConverter.convertToRow(value));
-    _segmentNumRecord++;
-    if (_segmentNumRecord >= _segmentFlushMaxNumRecords) {
-      flush();
-    }
-  }
-
-  @Override
-  public void snapshotState(FunctionSnapshotContext functionSnapshotContext)
-      throws Exception {
-    throw new UnsupportedOperationException("snapshotState is invoked in Pinot sink");
-  }
-
-  @Override
-  public void initializeState(FunctionInitializationContext functionInitializationContext)
-      throws Exception {
-    // no initialization needed
-    // ...
-  }
-
-  private void flush()
-      throws Exception {
-    URI segmentURI = _segmentWriter.flush();
-    LOG.info("Pinot segment writer flushed with {} records to {}", _segmentNumRecord, segmentURI);
-    _segmentNumRecord = 0;
-    _executor.submit(() -> {
-      try {
-        _segmentUploader.uploadSegment(segmentURI, null);
-      } catch (Exception e) {
-        throw new RuntimeException("Failed to upload pinot segment", e);
-      }
-      LOG.info("Pinot segment uploaded to {}", segmentURI);
-    });
+    return PinotSink.prepareTableConfigForSink(tableConfig, controllerBaseUrl);
   }
 }

--- a/pinot-connectors/pinot-flink-connector/src/test/java/org/apache/pinot/connector/flink/sink/PinotSinkIntegrationTest.java
+++ b/pinot-connectors/pinot-flink-connector/src/test/java/org/apache/pinot/connector/flink/sink/PinotSinkIntegrationTest.java
@@ -114,8 +114,8 @@ public class PinotSinkIntegrationTest extends BaseClusterIntegrationTest {
     // Single-thread write
     StreamExecutionEnvironment execEnv = StreamExecutionEnvironment.getExecutionEnvironment();
     execEnv.setParallelism(1);
-    DataStream<Row> srcDs = execEnv.fromCollection(_data).returns(_typeInfo);
-    srcDs.addSink(new PinotSinkFunction<>(new FlinkRowGenericRowConverter(_typeInfo), _tableConfig, _schema));
+    DataStream<Row> srcDs = execEnv.fromData(_data, _typeInfo);
+    srcDs.sinkTo(new PinotSink<>(new FlinkRowGenericRowConverter(_typeInfo), _tableConfig, _schema));
     execEnv.execute();
     verifySegments(1, 6);
 
@@ -124,8 +124,8 @@ public class PinotSinkIntegrationTest extends BaseClusterIntegrationTest {
     // Parallel write
     execEnv = StreamExecutionEnvironment.getExecutionEnvironment();
     execEnv.setParallelism(2);
-    srcDs = execEnv.fromCollection(_data).returns(_typeInfo).keyBy(r -> r.getField(0));
-    srcDs.addSink(new PinotSinkFunction<>(new FlinkRowGenericRowConverter(_typeInfo), _tableConfig, _schema));
+    srcDs = execEnv.fromData(_data, _typeInfo).keyBy(r -> r.getField(0));
+    srcDs.sinkTo(new PinotSink<>(new FlinkRowGenericRowConverter(_typeInfo), _tableConfig, _schema));
     execEnv.execute();
     verifySegments(2, 6);
   }

--- a/pinot-connectors/pinot-flink-connector/src/test/java/org/apache/pinot/connector/flink/sink/PinotSinkUpsertTableIntegrationTest.java
+++ b/pinot-connectors/pinot-flink-connector/src/test/java/org/apache/pinot/connector/flink/sink/PinotSinkUpsertTableIntegrationTest.java
@@ -130,9 +130,9 @@ public class PinotSinkUpsertTableIntegrationTest extends BaseClusterIntegrationT
 
     // Single-thread write
     execEnv.setParallelism(1);
-    DataStream<Row> srcDs = execEnv.fromCollection(_data).returns(_typeInfo);
-    srcDs.addSink(new PinotSinkFunction<>(new FlinkRowGenericRowConverter(_typeInfo), _tableConfig, _schema,
-        PinotSinkFunction.DEFAULT_SEGMENT_FLUSH_MAX_NUM_RECORDS, PinotSinkFunction.DEFAULT_EXECUTOR_POOL_SIZE, "batch",
+    DataStream<Row> srcDs = execEnv.fromData(_data, _typeInfo);
+    srcDs.sinkTo(new PinotSink<>(new FlinkRowGenericRowConverter(_typeInfo), _tableConfig, _schema,
+        PinotSink.DEFAULT_SEGMENT_FLUSH_MAX_NUM_RECORDS, PinotSink.DEFAULT_EXECUTOR_POOL_SIZE, "batch",
         1724045185L));
     execEnv.execute();
     // 1 uploaded, 2 realtime in progress segment
@@ -142,19 +142,19 @@ public class PinotSinkUpsertTableIntegrationTest extends BaseClusterIntegrationT
     execEnv = StreamExecutionEnvironment.getExecutionEnvironment();
     execEnv.setParallelism(2);
 
-    srcDs = execEnv.fromCollection(_data).returns(_typeInfo)
+    srcDs = execEnv.fromData(_data, _typeInfo)
         .partitionCustom((Partitioner<Integer>) (key, partitions) -> key % partitions, r -> (Integer) r.getField(0));
-    srcDs.addSink(new PinotSinkFunction<>(new FlinkRowGenericRowConverter(_typeInfo), _tableConfig, _schema,
-        PinotSinkFunction.DEFAULT_SEGMENT_FLUSH_MAX_NUM_RECORDS, PinotSinkFunction.DEFAULT_EXECUTOR_POOL_SIZE, "batch",
+    srcDs.sinkTo(new PinotSink<>(new FlinkRowGenericRowConverter(_typeInfo), _tableConfig, _schema,
+        PinotSink.DEFAULT_SEGMENT_FLUSH_MAX_NUM_RECORDS, PinotSink.DEFAULT_EXECUTOR_POOL_SIZE, "batch",
         1724045186L));
     execEnv.execute();
     verifySegments(5, 8);
 
     // Generate next sequence segments in partitioned segments
-    srcDs = execEnv.fromCollection(_data).returns(_typeInfo)
+    srcDs = execEnv.fromData(_data, _typeInfo)
         .partitionCustom((Partitioner<Integer>) (key, partitions) -> key % partitions, r -> (Integer) r.getField(0));
-    srcDs.addSink(new PinotSinkFunction<>(new FlinkRowGenericRowConverter(_typeInfo), _tableConfig, _schema, 1,
-        PinotSinkFunction.DEFAULT_EXECUTOR_POOL_SIZE, "batch", 1724045187L));
+    srcDs.sinkTo(new PinotSink<>(new FlinkRowGenericRowConverter(_typeInfo), _tableConfig, _schema, 1,
+        PinotSink.DEFAULT_EXECUTOR_POOL_SIZE, "batch", 1724045187L));
     execEnv.execute();
     verifySegments(9, 12);
     verifyContainsSegments(Arrays.asList("batch__mytable__0__1724045187__0", "batch__mytable__0__1724045187__1",

--- a/pom.xml
+++ b/pom.xml
@@ -217,7 +217,7 @@
     <kafka4.version>4.2.0</kafka4.version>
     <confluent.version>8.2.0</confluent.version>
     <pulsar.version>4.0.9</pulsar.version>
-    <flink.version>1.20.3</flink.version>
+    <flink.version>2.2.0</flink.version>
 
     <!-- Apache Commons Libraries -->
     <commons-lang3.version>3.20.0</commons-lang3.version>
@@ -1854,11 +1854,6 @@
       <dependency>
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-streaming-java</artifactId>
-        <version>${flink.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.flink</groupId>
-        <artifactId>flink-java</artifactId>
         <version>${flink.version}</version>
       </dependency>
 


### PR DESCRIPTION
## Summary

- upgrade `pinot-flink-connector` from Flink `1.20.3` to `2.2.0` to align with the Flink 2.x line used for Java 21 support
- replace the removed legacy `SinkFunction`-based connector implementation with a Flink 2 `Sink`/`SinkWriter` implementation
- update connector examples and integration tests to use `DataStream.sinkTo(new PinotSink<>(...))` and `fromData(...)`

## Root Cause

Flink 2.x removes the legacy `SourceFunction`/`SinkFunction` APIs entirely. Pinots Flink connector still extended `RichSinkFunction`, so simply bumping the Flink dependency was not enough: the connector no longer compiled or ran on the supported Flink 2.x line needed for Java 21 environments.

## How To Reproduce

1. Check out Pinot on `master` before this change.
2. Try to build the Flink connector against a Flink 2.x version, for example by setting `flink.version=2.2.0`.
3. Observe that the connector fails because it depends on the removed legacy sink API and still uses deprecated collection source patterns.

## What Changed

- add a new `PinotSink` implementation backed by Flinks `Sink`/`SinkWriter` API
- keep `PinotSinkFunction` as a deprecated compatibility shim for constructor migration
- remove the obsolete `flink-java` dependency, which is no longer published in Flink 2.x
- update the quick start, README, and integration tests to use Flink 2-style APIs

## Validation

- `./mvnw -U -pl pinot-connectors/pinot-flink-connector -DskipTests -Dcheckstyle.skip=true -Denforcer.skip=true test-compile`
- `./mvnw -U -pl pinot-connectors/pinot-flink-connector -Dcheckstyle.skip=true -Denforcer.skip=true test`
- `./mvnw spotless:apply -pl pinot-connectors/pinot-flink-connector`
- `./mvnw checkstyle:check -pl pinot-connectors/pinot-flink-connector`
- `./mvnw license:format -pl pinot-connectors/pinot-flink-connector`
- `./mvnw license:check -pl pinot-connectors/pinot-flink-connector`
