### PR TITLE
Support role-specific accounting config prefixes for broker and server

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
@@ -393,9 +393,10 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
             CommonConstants.Broker.DEFAULT_THREAD_ALLOCATED_BYTES_MEASUREMENT));
     // Initialize workload budget manager and thread resource usage accountant. Workload budget manager must be
     // initialized first because it might be used by the accountant.
-    PinotConfiguration schedulerConfig = _brokerConf.subset(CommonConstants.PINOT_QUERY_SCHEDULER_PREFIX);
-    WorkloadBudgetManager.set(createWorkloadBudgetManager(schedulerConfig));
-    _threadAccountant = ThreadAccountantUtils.createAccountant(schedulerConfig, _instanceId,
+    PinotConfiguration accountingConfig = ThreadAccountantUtils.extractAccountingConfig(_brokerConf,
+        org.apache.pinot.spi.config.instance.InstanceType.BROKER);
+    WorkloadBudgetManager.set(createWorkloadBudgetManager(accountingConfig));
+    _threadAccountant = ThreadAccountantUtils.createAccountant(accountingConfig, _instanceId,
         org.apache.pinot.spi.config.instance.InstanceType.BROKER);
     _threadAccountant.startWatcherTask();
     PinotClusterConfigChangeListener threadAccountantListener = _threadAccountant.getClusterConfigChangeListener();

--- a/pinot-core/src/main/java/org/apache/pinot/core/accounting/HeapUsagePublishingAccountantFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/accounting/HeapUsagePublishingAccountantFactory.java
@@ -33,7 +33,7 @@ import org.apache.pinot.spi.accounting.TrackingScope;
 import org.apache.pinot.spi.config.instance.InstanceType;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.query.QueryThreadContext;
-import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.CommonConstants.Accounting;
 import org.apache.pinot.spi.utils.ResourceUsageUtils;
 
 
@@ -44,8 +44,8 @@ public class HeapUsagePublishingAccountantFactory implements ThreadAccountantFac
 
   @Override
   public ThreadAccountant init(PinotConfiguration config, String instanceId, InstanceType instanceType) {
-    int period = config.getProperty(CommonConstants.Accounting.CONFIG_OF_HEAP_USAGE_PUBLISHING_PERIOD_MS,
-        CommonConstants.Accounting.DEFAULT_HEAP_USAGE_PUBLISH_PERIOD);
+    int period = config.getProperty(Accounting.Keys.HEAP_USAGE_PUBLISHING_PERIOD_MS,
+        Accounting.DEFAULT_HEAP_USAGE_PUBLISH_PERIOD);
     return new HeapUsagePublishingAccountant(period);
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/accounting/PerQueryCPUMemAccountantFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/accounting/PerQueryCPUMemAccountantFactory.java
@@ -30,7 +30,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Collectors;
 import org.apache.pinot.common.metrics.AbstractMetrics;
 import org.apache.pinot.common.metrics.BrokerGauge;
 import org.apache.pinot.common.metrics.BrokerMeter;
@@ -41,6 +40,7 @@ import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.spi.accounting.QueryResourceTracker;
 import org.apache.pinot.spi.accounting.ThreadAccountant;
 import org.apache.pinot.spi.accounting.ThreadAccountantFactory;
+import org.apache.pinot.spi.accounting.ThreadAccountantUtils;
 import org.apache.pinot.spi.accounting.ThreadResourceUsageProvider;
 import org.apache.pinot.spi.accounting.TrackingScope;
 import org.apache.pinot.spi.config.instance.InstanceType;
@@ -50,7 +50,6 @@ import org.apache.pinot.spi.exception.QueryErrorCode;
 import org.apache.pinot.spi.metrics.PinotMetricUtils;
 import org.apache.pinot.spi.query.QueryExecutionContext;
 import org.apache.pinot.spi.query.QueryThreadContext;
-import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.CommonConstants.Accounting;
 import org.apache.pinot.spi.utils.ResourceUsageUtils;
 import org.slf4j.Logger;
@@ -118,14 +117,14 @@ public class PerQueryCPUMemAccountantFactory implements ThreadAccountantFactory 
       LOGGER.info("Initializing PerQueryCPUMemResourceUsageAccountant");
       _instanceId = instanceId;
       _instanceType = instanceType;
-      boolean cpuSamplingEnabled = config.getProperty(Accounting.CONFIG_OF_ENABLE_THREAD_CPU_SAMPLING,
-          Accounting.DEFAULT_ENABLE_THREAD_CPU_SAMPLING);
+      boolean cpuSamplingEnabled =
+          config.getProperty(Accounting.Keys.ENABLE_THREAD_CPU_SAMPLING, Accounting.DEFAULT_ENABLE_THREAD_CPU_SAMPLING);
       if (cpuSamplingEnabled && !ThreadResourceUsageProvider.isThreadCpuTimeMeasurementEnabled()) {
         LOGGER.warn("Thread CPU time measurement is not enabled in the JVM, disabling CPU sampling");
         cpuSamplingEnabled = false;
       }
       _cpuSamplingEnabled = cpuSamplingEnabled;
-      boolean memorySamplingEnabled = config.getProperty(Accounting.CONFIG_OF_ENABLE_THREAD_MEMORY_SAMPLING,
+      boolean memorySamplingEnabled = config.getProperty(Accounting.Keys.ENABLE_THREAD_MEMORY_SAMPLING,
           Accounting.DEFAULT_ENABLE_THREAD_MEMORY_SAMPLING);
       if (memorySamplingEnabled && !ThreadResourceUsageProvider.isThreadMemoryMeasurementEnabled()) {
         LOGGER.warn("Thread memory measurement is not enabled in the JVM, disabling memory sampling");
@@ -367,27 +366,15 @@ public class PerQueryCPUMemAccountantFactory implements ThreadAccountantFactory 
 
       @Override
       public synchronized void onChange(Set<String> changedConfigs, Map<String, String> clusterConfigs) {
-        // Filter configs that have CommonConstants.PREFIX_SCHEDULER_PREFIX
-        Set<String> filteredChangedConfigs = changedConfigs.stream()
-            .filter(config -> config.startsWith(CommonConstants.PINOT_QUERY_SCHEDULER_PREFIX))
-            .map(config -> config.replace(CommonConstants.PINOT_QUERY_SCHEDULER_PREFIX + ".", ""))
-            .collect(Collectors.toSet());
-
-        if (filteredChangedConfigs.isEmpty()) {
+        ThreadAccountantUtils.AccountingConfigChange change =
+            ThreadAccountantUtils.filterAccountingConfigChange(changedConfigs, clusterConfigs, _instanceType);
+        if (change.isEmpty()) {
           LOGGER.debug("No relevant configs changed, skipping update for QueryMonitorConfig.");
           return;
         }
-
-        Map<String, String> filteredClusterConfigs = clusterConfigs.entrySet()
-            .stream()
-            .filter(entry -> entry.getKey().startsWith(CommonConstants.PINOT_QUERY_SCHEDULER_PREFIX))
-            .collect(Collectors.toMap(
-                entry -> entry.getKey().replace(CommonConstants.PINOT_QUERY_SCHEDULER_PREFIX + ".", ""),
-                Map.Entry::getValue));
-
         QueryMonitorConfig oldConfig = _queryMonitorConfig.get();
         QueryMonitorConfig newConfig =
-            new QueryMonitorConfig(oldConfig, filteredChangedConfigs, filteredClusterConfigs);
+            new QueryMonitorConfig(oldConfig, change.getChangedConfigs(), change.getClusterConfigs());
         _queryMonitorConfig.set(newConfig);
         logQueryMonitorConfig(newConfig);
       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/accounting/QueryMonitorConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/accounting/QueryMonitorConfig.java
@@ -21,7 +21,7 @@ package org.apache.pinot.core.accounting;
 import java.util.Map;
 import java.util.Set;
 import org.apache.pinot.spi.env.PinotConfiguration;
-import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.CommonConstants.Accounting;
 
 
 public class QueryMonitorConfig {
@@ -75,246 +75,172 @@ public class QueryMonitorConfig {
   public QueryMonitorConfig(PinotConfiguration config, long maxHeapSize) {
     _maxHeapSize = maxHeapSize;
 
-    _minMemoryFootprintForKill = (long) (maxHeapSize * config.getProperty(
-        CommonConstants.Accounting.CONFIG_OF_MIN_MEMORY_FOOTPRINT_TO_KILL_RATIO,
-        CommonConstants.Accounting.DEFAULT_MEMORY_FOOTPRINT_TO_KILL_RATIO));
+    _minMemoryFootprintForKill =
+        (long) (maxHeapSize * config.getProperty(Accounting.Keys.MIN_MEMORY_FOOTPRINT_TO_KILL_RATIO,
+            Accounting.DEFAULT_MEMORY_FOOTPRINT_TO_KILL_RATIO));
 
-    _panicLevel =
-        (long) (maxHeapSize * config.getProperty(CommonConstants.Accounting.CONFIG_OF_PANIC_LEVEL_HEAP_USAGE_RATIO,
-            CommonConstants.Accounting.DEFAULT_PANIC_LEVEL_HEAP_USAGE_RATIO));
+    _panicLevel = (long) (maxHeapSize * config.getProperty(Accounting.Keys.PANIC_LEVEL_HEAP_USAGE_RATIO,
+        Accounting.DEFAULT_PANIC_LEVEL_HEAP_USAGE_RATIO));
 
     // kill the most expensive query if heap usage exceeds this
-    _criticalLevel =
-        (long) (maxHeapSize * config.getProperty(CommonConstants.Accounting.CONFIG_OF_CRITICAL_LEVEL_HEAP_USAGE_RATIO,
-            CommonConstants.Accounting.DEFAULT_CRITICAL_LEVEL_HEAP_USAGE_RATIO));
+    _criticalLevel = (long) (maxHeapSize * config.getProperty(Accounting.Keys.CRITICAL_LEVEL_HEAP_USAGE_RATIO,
+        Accounting.DEFAULT_CRITICAL_LEVEL_HEAP_USAGE_RATIO));
 
-    _alarmingLevel =
-        (long) (maxHeapSize * config.getProperty(CommonConstants.Accounting.CONFIG_OF_ALARMING_LEVEL_HEAP_USAGE_RATIO,
-            CommonConstants.Accounting.DEFAULT_ALARMING_LEVEL_HEAP_USAGE_RATIO));
+    _alarmingLevel = (long) (maxHeapSize * config.getProperty(Accounting.Keys.ALARMING_LEVEL_HEAP_USAGE_RATIO,
+        Accounting.DEFAULT_ALARMING_LEVEL_HEAP_USAGE_RATIO));
 
-    _normalSleepTime = config.getProperty(CommonConstants.Accounting.CONFIG_OF_SLEEP_TIME_MS,
-        CommonConstants.Accounting.DEFAULT_SLEEP_TIME_MS);
+    _normalSleepTime = config.getProperty(Accounting.Keys.SLEEP_TIME_MS, Accounting.DEFAULT_SLEEP_TIME_MS);
 
-    _alarmingSleepTimeDenominator = config.getProperty(CommonConstants.Accounting.CONFIG_OF_SLEEP_TIME_DENOMINATOR,
-        CommonConstants.Accounting.DEFAULT_SLEEP_TIME_DENOMINATOR);
+    _alarmingSleepTimeDenominator =
+        config.getProperty(Accounting.Keys.SLEEP_TIME_DENOMINATOR, Accounting.DEFAULT_SLEEP_TIME_DENOMINATOR);
 
     _alarmingSleepTime = _normalSleepTime / _alarmingSleepTimeDenominator;
 
-    _oomKillQueryEnabled = config.getProperty(CommonConstants.Accounting.CONFIG_OF_OOM_PROTECTION_KILLING_QUERY,
-        CommonConstants.Accounting.DEFAULT_ENABLE_OOM_PROTECTION_KILLING_QUERY);
+    _oomKillQueryEnabled = config.getProperty(Accounting.Keys.OOM_PROTECTION_KILLING_QUERY,
+        Accounting.DEFAULT_ENABLE_OOM_PROTECTION_KILLING_QUERY);
 
-    _publishHeapUsageMetric = config.getProperty(CommonConstants.Accounting.CONFIG_OF_PUBLISHING_JVM_USAGE,
-        CommonConstants.Accounting.DEFAULT_PUBLISHING_JVM_USAGE);
+    _publishHeapUsageMetric =
+        config.getProperty(Accounting.Keys.PUBLISHING_JVM_USAGE, Accounting.DEFAULT_PUBLISHING_JVM_USAGE);
 
-    _cpuTimeBasedKillingEnabled =
-        config.getProperty(CommonConstants.Accounting.CONFIG_OF_CPU_TIME_BASED_KILLING_ENABLED,
-            CommonConstants.Accounting.DEFAULT_CPU_TIME_BASED_KILLING_ENABLED);
+    _cpuTimeBasedKillingEnabled = config.getProperty(Accounting.Keys.CPU_TIME_BASED_KILLING_ENABLED,
+        Accounting.DEFAULT_CPU_TIME_BASED_KILLING_ENABLED);
 
-    _cpuTimeBasedKillingThresholdNs =
-        config.getProperty(CommonConstants.Accounting.CONFIG_OF_CPU_TIME_BASED_KILLING_THRESHOLD_MS,
-            CommonConstants.Accounting.DEFAULT_CPU_TIME_BASED_KILLING_THRESHOLD_MS) * 1000_000L;
+    _cpuTimeBasedKillingThresholdNs = config.getProperty(Accounting.Keys.CPU_TIME_BASED_KILLING_THRESHOLD_MS,
+        Accounting.DEFAULT_CPU_TIME_BASED_KILLING_THRESHOLD_MS) * 1000_000L;
 
-    _queryKilledMetricEnabled = config.getProperty(CommonConstants.Accounting.CONFIG_OF_QUERY_KILLED_METRIC_ENABLED,
-        CommonConstants.Accounting.DEFAULT_QUERY_KILLED_METRIC_ENABLED);
+    _queryKilledMetricEnabled =
+        config.getProperty(Accounting.Keys.QUERY_KILLED_METRIC_ENABLED, Accounting.DEFAULT_QUERY_KILLED_METRIC_ENABLED);
 
-    _oomPreQueryKillPauseDurationMs = config.getProperty(
-        CommonConstants.Accounting.CONFIG_OF_OOM_PRE_QUERY_KILL_PAUSE_DURATION_MS,
-        CommonConstants.Accounting.DEFAULT_OOM_PRE_QUERY_KILL_PAUSE_DURATION_MS);
+    _oomPreQueryKillPauseDurationMs = config.getProperty(Accounting.Keys.OOM_PRE_QUERY_KILL_PAUSE_DURATION_MS,
+        Accounting.DEFAULT_OOM_PRE_QUERY_KILL_PAUSE_DURATION_MS);
 
-    _oomPanicPreQueryKillPauseEnabled = config.getProperty(
-        CommonConstants.Accounting.CONFIG_OF_OOM_PANIC_ALLOW_PRE_QUERY_KILL_PAUSE,
-        CommonConstants.Accounting.DEFAULT_OOM_PANIC_PRE_QUERY_KILL_PAUSE_ENABLED);
+    _oomPanicPreQueryKillPauseEnabled = config.getProperty(Accounting.Keys.OOM_PANIC_ALLOW_PRE_QUERY_KILL_PAUSE,
+        Accounting.DEFAULT_OOM_PANIC_PRE_QUERY_KILL_PAUSE_ENABLED);
 
-    _workloadSleepTimeMs = config.getProperty(CommonConstants.Accounting.CONFIG_OF_WORKLOAD_SLEEP_TIME_MS,
-        CommonConstants.Accounting.DEFAULT_WORKLOAD_SLEEP_TIME_MS);
+    _workloadSleepTimeMs =
+        config.getProperty(Accounting.Keys.WORKLOAD_SLEEP_TIME_MS, Accounting.DEFAULT_WORKLOAD_SLEEP_TIME_MS);
 
-    _workloadCostEnforcementEnabled =
-        config.getProperty(CommonConstants.Accounting.CONFIG_OF_WORKLOAD_ENABLE_COST_ENFORCEMENT,
-            CommonConstants.Accounting.DEFAULT_WORKLOAD_ENABLE_COST_ENFORCEMENT);
+    _workloadCostEnforcementEnabled = config.getProperty(Accounting.Keys.WORKLOAD_ENABLE_COST_ENFORCEMENT,
+        Accounting.DEFAULT_WORKLOAD_ENABLE_COST_ENFORCEMENT);
   }
 
   QueryMonitorConfig(QueryMonitorConfig oldConfig, Set<String> changedConfigs, Map<String, String> clusterConfigs) {
     _maxHeapSize = oldConfig._maxHeapSize;
 
-    if (changedConfigs.contains(CommonConstants.Accounting.CONFIG_OF_MIN_MEMORY_FOOTPRINT_TO_KILL_RATIO)) {
-      if (clusterConfigs == null || !clusterConfigs.containsKey(
-          CommonConstants.Accounting.CONFIG_OF_MIN_MEMORY_FOOTPRINT_TO_KILL_RATIO)) {
-        _minMemoryFootprintForKill =
-            (long) (_maxHeapSize * CommonConstants.Accounting.DEFAULT_MEMORY_FOOTPRINT_TO_KILL_RATIO);
-      } else {
-        _minMemoryFootprintForKill = (long) (_maxHeapSize * Double.parseDouble(
-            clusterConfigs.get(CommonConstants.Accounting.CONFIG_OF_MIN_MEMORY_FOOTPRINT_TO_KILL_RATIO)));
-      }
+    if (changedConfigs.contains(Accounting.Keys.MIN_MEMORY_FOOTPRINT_TO_KILL_RATIO)) {
+      String str = clusterConfigs.get(Accounting.Keys.MIN_MEMORY_FOOTPRINT_TO_KILL_RATIO);
+      double value = str != null ? Double.parseDouble(str) : Accounting.DEFAULT_MEMORY_FOOTPRINT_TO_KILL_RATIO;
+      _minMemoryFootprintForKill = (long) (_maxHeapSize * value);
     } else {
       _minMemoryFootprintForKill = oldConfig._minMemoryFootprintForKill;
     }
 
-    if (changedConfigs.contains(CommonConstants.Accounting.CONFIG_OF_PANIC_LEVEL_HEAP_USAGE_RATIO)) {
-      if (clusterConfigs == null || !clusterConfigs.containsKey(
-          CommonConstants.Accounting.CONFIG_OF_PANIC_LEVEL_HEAP_USAGE_RATIO)) {
-        _panicLevel = (long) (_maxHeapSize * CommonConstants.Accounting.DEFAULT_PANIC_LEVEL_HEAP_USAGE_RATIO);
-      } else {
-        _panicLevel = (long) (_maxHeapSize * Double.parseDouble(
-            clusterConfigs.get(CommonConstants.Accounting.CONFIG_OF_PANIC_LEVEL_HEAP_USAGE_RATIO)));
-      }
+    if (changedConfigs.contains(Accounting.Keys.PANIC_LEVEL_HEAP_USAGE_RATIO)) {
+      String str = clusterConfigs.get(Accounting.Keys.PANIC_LEVEL_HEAP_USAGE_RATIO);
+      double value = str != null ? Double.parseDouble(str) : Accounting.DEFAULT_PANIC_LEVEL_HEAP_USAGE_RATIO;
+      _panicLevel = (long) (_maxHeapSize * value);
     } else {
       _panicLevel = oldConfig._panicLevel;
     }
 
-    if (changedConfigs.contains(CommonConstants.Accounting.CONFIG_OF_CRITICAL_LEVEL_HEAP_USAGE_RATIO)) {
-      if (clusterConfigs == null || !clusterConfigs.containsKey(
-          CommonConstants.Accounting.CONFIG_OF_CRITICAL_LEVEL_HEAP_USAGE_RATIO)) {
-        _criticalLevel = (long) (_maxHeapSize * CommonConstants.Accounting.DEFAULT_CRITICAL_LEVEL_HEAP_USAGE_RATIO);
-      } else {
-        _criticalLevel = (long) (_maxHeapSize * Double.parseDouble(
-            clusterConfigs.get(CommonConstants.Accounting.CONFIG_OF_CRITICAL_LEVEL_HEAP_USAGE_RATIO)));
-      }
+    if (changedConfigs.contains(Accounting.Keys.CRITICAL_LEVEL_HEAP_USAGE_RATIO)) {
+      String str = clusterConfigs.get(Accounting.Keys.CRITICAL_LEVEL_HEAP_USAGE_RATIO);
+      double value = str != null ? Double.parseDouble(str) : Accounting.DEFAULT_CRITICAL_LEVEL_HEAP_USAGE_RATIO;
+      _criticalLevel = (long) (_maxHeapSize * value);
     } else {
       _criticalLevel = oldConfig._criticalLevel;
     }
 
-    if (changedConfigs.contains(CommonConstants.Accounting.CONFIG_OF_ALARMING_LEVEL_HEAP_USAGE_RATIO)) {
-      if (clusterConfigs == null || !clusterConfigs.containsKey(
-          CommonConstants.Accounting.CONFIG_OF_ALARMING_LEVEL_HEAP_USAGE_RATIO)) {
-        _alarmingLevel = (long) (_maxHeapSize * CommonConstants.Accounting.DEFAULT_ALARMING_LEVEL_HEAP_USAGE_RATIO);
-      } else {
-        _alarmingLevel = (long) (_maxHeapSize * Double.parseDouble(
-            clusterConfigs.get(CommonConstants.Accounting.CONFIG_OF_ALARMING_LEVEL_HEAP_USAGE_RATIO)));
-      }
+    if (changedConfigs.contains(Accounting.Keys.ALARMING_LEVEL_HEAP_USAGE_RATIO)) {
+      String str = clusterConfigs.get(Accounting.Keys.ALARMING_LEVEL_HEAP_USAGE_RATIO);
+      double value = str != null ? Double.parseDouble(str) : Accounting.DEFAULT_ALARMING_LEVEL_HEAP_USAGE_RATIO;
+      _alarmingLevel = (long) (_maxHeapSize * value);
     } else {
       _alarmingLevel = oldConfig._alarmingLevel;
     }
 
-    if (changedConfigs.contains(CommonConstants.Accounting.CONFIG_OF_SLEEP_TIME_MS)) {
-      if (clusterConfigs == null || !clusterConfigs.containsKey(CommonConstants.Accounting.CONFIG_OF_SLEEP_TIME_MS)) {
-        _normalSleepTime = CommonConstants.Accounting.DEFAULT_SLEEP_TIME_MS;
-      } else {
-        _normalSleepTime = Integer.parseInt(clusterConfigs.get(CommonConstants.Accounting.CONFIG_OF_SLEEP_TIME_MS));
-      }
+    if (changedConfigs.contains(Accounting.Keys.SLEEP_TIME_MS)) {
+      String str = clusterConfigs.get(Accounting.Keys.SLEEP_TIME_MS);
+      _normalSleepTime = str != null ? Integer.parseInt(str) : Accounting.DEFAULT_SLEEP_TIME_MS;
     } else {
       _normalSleepTime = oldConfig._normalSleepTime;
     }
 
-    if (changedConfigs.contains(CommonConstants.Accounting.CONFIG_OF_SLEEP_TIME_DENOMINATOR)) {
-      if (clusterConfigs == null || !clusterConfigs.containsKey(
-          CommonConstants.Accounting.CONFIG_OF_SLEEP_TIME_DENOMINATOR)) {
-        _alarmingSleepTimeDenominator = CommonConstants.Accounting.DEFAULT_SLEEP_TIME_DENOMINATOR;
-      } else {
-        _alarmingSleepTimeDenominator =
-            Integer.parseInt(clusterConfigs.get(CommonConstants.Accounting.CONFIG_OF_SLEEP_TIME_DENOMINATOR));
-      }
+    if (changedConfigs.contains(Accounting.Keys.SLEEP_TIME_DENOMINATOR)) {
+      String str = clusterConfigs.get(Accounting.Keys.SLEEP_TIME_DENOMINATOR);
+      _alarmingSleepTimeDenominator = str != null ? Integer.parseInt(str) : Accounting.DEFAULT_SLEEP_TIME_DENOMINATOR;
     } else {
       _alarmingSleepTimeDenominator = oldConfig._alarmingSleepTimeDenominator;
     }
 
     _alarmingSleepTime = _normalSleepTime / _alarmingSleepTimeDenominator;
 
-    if (changedConfigs.contains(CommonConstants.Accounting.CONFIG_OF_OOM_PROTECTION_KILLING_QUERY)) {
-      if (clusterConfigs == null || !clusterConfigs.containsKey(
-          CommonConstants.Accounting.CONFIG_OF_OOM_PROTECTION_KILLING_QUERY)) {
-        _oomKillQueryEnabled = CommonConstants.Accounting.DEFAULT_ENABLE_OOM_PROTECTION_KILLING_QUERY;
-      } else {
-        _oomKillQueryEnabled =
-            Boolean.parseBoolean(clusterConfigs.get(CommonConstants.Accounting.CONFIG_OF_OOM_PROTECTION_KILLING_QUERY));
-      }
+    if (changedConfigs.contains(Accounting.Keys.OOM_PROTECTION_KILLING_QUERY)) {
+      String str = clusterConfigs.get(Accounting.Keys.OOM_PROTECTION_KILLING_QUERY);
+      _oomKillQueryEnabled =
+          str != null ? Boolean.parseBoolean(str) : Accounting.DEFAULT_ENABLE_OOM_PROTECTION_KILLING_QUERY;
     } else {
       _oomKillQueryEnabled = oldConfig._oomKillQueryEnabled;
     }
 
-    if (changedConfigs.contains(CommonConstants.Accounting.CONFIG_OF_PUBLISHING_JVM_USAGE)) {
-      if (clusterConfigs == null || !clusterConfigs.containsKey(
-          CommonConstants.Accounting.CONFIG_OF_PUBLISHING_JVM_USAGE)) {
-        _publishHeapUsageMetric = CommonConstants.Accounting.DEFAULT_PUBLISHING_JVM_USAGE;
-      } else {
-        _publishHeapUsageMetric =
-            Boolean.parseBoolean(clusterConfigs.get(CommonConstants.Accounting.CONFIG_OF_PUBLISHING_JVM_USAGE));
-      }
+    if (changedConfigs.contains(Accounting.Keys.PUBLISHING_JVM_USAGE)) {
+      String str = clusterConfigs.get(Accounting.Keys.PUBLISHING_JVM_USAGE);
+      _publishHeapUsageMetric = str != null ? Boolean.parseBoolean(str) : Accounting.DEFAULT_PUBLISHING_JVM_USAGE;
     } else {
       _publishHeapUsageMetric = oldConfig._publishHeapUsageMetric;
     }
 
-    if (changedConfigs.contains(CommonConstants.Accounting.CONFIG_OF_CPU_TIME_BASED_KILLING_ENABLED)) {
-      if (clusterConfigs == null || !clusterConfigs.containsKey(
-          CommonConstants.Accounting.CONFIG_OF_CPU_TIME_BASED_KILLING_ENABLED)) {
-        _cpuTimeBasedKillingEnabled = CommonConstants.Accounting.DEFAULT_CPU_TIME_BASED_KILLING_ENABLED;
-      } else {
-        _cpuTimeBasedKillingEnabled = Boolean.parseBoolean(
-            clusterConfigs.get(CommonConstants.Accounting.CONFIG_OF_CPU_TIME_BASED_KILLING_ENABLED));
-      }
+    if (changedConfigs.contains(Accounting.Keys.CPU_TIME_BASED_KILLING_ENABLED)) {
+      String str = clusterConfigs.get(Accounting.Keys.CPU_TIME_BASED_KILLING_ENABLED);
+      _cpuTimeBasedKillingEnabled =
+          str != null ? Boolean.parseBoolean(str) : Accounting.DEFAULT_CPU_TIME_BASED_KILLING_ENABLED;
     } else {
       _cpuTimeBasedKillingEnabled = oldConfig._cpuTimeBasedKillingEnabled;
     }
 
-    if (changedConfigs.contains(CommonConstants.Accounting.CONFIG_OF_CPU_TIME_BASED_KILLING_THRESHOLD_MS)) {
-      if (clusterConfigs == null || !clusterConfigs.containsKey(
-          CommonConstants.Accounting.CONFIG_OF_CPU_TIME_BASED_KILLING_THRESHOLD_MS)) {
-        _cpuTimeBasedKillingThresholdNs =
-            CommonConstants.Accounting.DEFAULT_CPU_TIME_BASED_KILLING_THRESHOLD_MS * 1000_000L;
-      } else {
-        _cpuTimeBasedKillingThresholdNs =
-            Long.parseLong(clusterConfigs.get(CommonConstants.Accounting.CONFIG_OF_CPU_TIME_BASED_KILLING_THRESHOLD_MS))
-                * 1000_000L;
-      }
+    if (changedConfigs.contains(Accounting.Keys.CPU_TIME_BASED_KILLING_THRESHOLD_MS)) {
+      String str = clusterConfigs.get(Accounting.Keys.CPU_TIME_BASED_KILLING_THRESHOLD_MS);
+      long valueMs = str != null ? Long.parseLong(str) : Accounting.DEFAULT_CPU_TIME_BASED_KILLING_THRESHOLD_MS;
+      _cpuTimeBasedKillingThresholdNs = valueMs * 1000_000L;
     } else {
       _cpuTimeBasedKillingThresholdNs = oldConfig._cpuTimeBasedKillingThresholdNs;
     }
 
-    if (changedConfigs.contains(CommonConstants.Accounting.CONFIG_OF_QUERY_KILLED_METRIC_ENABLED)) {
-      if (clusterConfigs == null || !clusterConfigs.containsKey(
-          CommonConstants.Accounting.CONFIG_OF_QUERY_KILLED_METRIC_ENABLED)) {
-        _queryKilledMetricEnabled = CommonConstants.Accounting.DEFAULT_QUERY_KILLED_METRIC_ENABLED;
-      } else {
-        _queryKilledMetricEnabled =
-            Boolean.parseBoolean(clusterConfigs.get(CommonConstants.Accounting.CONFIG_OF_QUERY_KILLED_METRIC_ENABLED));
-      }
+    if (changedConfigs.contains(Accounting.Keys.QUERY_KILLED_METRIC_ENABLED)) {
+      String str = clusterConfigs.get(Accounting.Keys.QUERY_KILLED_METRIC_ENABLED);
+      _queryKilledMetricEnabled =
+          str != null ? Boolean.parseBoolean(str) : Accounting.DEFAULT_QUERY_KILLED_METRIC_ENABLED;
     } else {
       _queryKilledMetricEnabled = oldConfig._queryKilledMetricEnabled;
     }
 
-    if (changedConfigs.contains(CommonConstants.Accounting.CONFIG_OF_OOM_PRE_QUERY_KILL_PAUSE_DURATION_MS)) {
-      if (clusterConfigs == null || !clusterConfigs.containsKey(
-          CommonConstants.Accounting.CONFIG_OF_OOM_PRE_QUERY_KILL_PAUSE_DURATION_MS)) {
-        _oomPreQueryKillPauseDurationMs = CommonConstants.Accounting.DEFAULT_OOM_PRE_QUERY_KILL_PAUSE_DURATION_MS;
-      } else {
-        _oomPreQueryKillPauseDurationMs = Long.parseLong(
-            clusterConfigs.get(CommonConstants.Accounting.CONFIG_OF_OOM_PRE_QUERY_KILL_PAUSE_DURATION_MS));
-      }
+    if (changedConfigs.contains(Accounting.Keys.OOM_PRE_QUERY_KILL_PAUSE_DURATION_MS)) {
+      String str = clusterConfigs.get(Accounting.Keys.OOM_PRE_QUERY_KILL_PAUSE_DURATION_MS);
+      _oomPreQueryKillPauseDurationMs =
+          str != null ? Long.parseLong(str) : Accounting.DEFAULT_OOM_PRE_QUERY_KILL_PAUSE_DURATION_MS;
     } else {
       _oomPreQueryKillPauseDurationMs = oldConfig._oomPreQueryKillPauseDurationMs;
     }
 
-    if (changedConfigs.contains(CommonConstants.Accounting.CONFIG_OF_OOM_PANIC_ALLOW_PRE_QUERY_KILL_PAUSE)) {
-      if (clusterConfigs == null || !clusterConfigs.containsKey(
-          CommonConstants.Accounting.CONFIG_OF_OOM_PANIC_ALLOW_PRE_QUERY_KILL_PAUSE)) {
-        _oomPanicPreQueryKillPauseEnabled = CommonConstants.Accounting.DEFAULT_OOM_PANIC_PRE_QUERY_KILL_PAUSE_ENABLED;
-      } else {
-        _oomPanicPreQueryKillPauseEnabled = Boolean.parseBoolean(
-            clusterConfigs.get(CommonConstants.Accounting.CONFIG_OF_OOM_PANIC_ALLOW_PRE_QUERY_KILL_PAUSE));
-      }
+    if (changedConfigs.contains(Accounting.Keys.OOM_PANIC_ALLOW_PRE_QUERY_KILL_PAUSE)) {
+      String str = clusterConfigs.get(Accounting.Keys.OOM_PANIC_ALLOW_PRE_QUERY_KILL_PAUSE);
+      _oomPanicPreQueryKillPauseEnabled =
+          str != null ? Boolean.parseBoolean(str) : Accounting.DEFAULT_OOM_PANIC_PRE_QUERY_KILL_PAUSE_ENABLED;
     } else {
       _oomPanicPreQueryKillPauseEnabled = oldConfig._oomPanicPreQueryKillPauseEnabled;
     }
 
-    if (changedConfigs.contains(CommonConstants.Accounting.CONFIG_OF_WORKLOAD_SLEEP_TIME_MS)) {
-      if (clusterConfigs == null || !clusterConfigs.containsKey(
-          CommonConstants.Accounting.CONFIG_OF_WORKLOAD_SLEEP_TIME_MS)) {
-        _workloadSleepTimeMs = CommonConstants.Accounting.DEFAULT_WORKLOAD_SLEEP_TIME_MS;
-      } else {
-        _workloadSleepTimeMs =
-            Integer.parseInt(clusterConfigs.get(CommonConstants.Accounting.CONFIG_OF_WORKLOAD_SLEEP_TIME_MS));
-      }
+    if (changedConfigs.contains(Accounting.Keys.WORKLOAD_SLEEP_TIME_MS)) {
+      String str = clusterConfigs.get(Accounting.Keys.WORKLOAD_SLEEP_TIME_MS);
+      _workloadSleepTimeMs = str != null ? Integer.parseInt(str) : Accounting.DEFAULT_WORKLOAD_SLEEP_TIME_MS;
     } else {
       _workloadSleepTimeMs = oldConfig._workloadSleepTimeMs;
     }
 
-    if (changedConfigs.contains(CommonConstants.Accounting.CONFIG_OF_WORKLOAD_ENABLE_COST_ENFORCEMENT)) {
-      if (clusterConfigs == null || !clusterConfigs.containsKey(
-          CommonConstants.Accounting.CONFIG_OF_WORKLOAD_ENABLE_COST_ENFORCEMENT)) {
-        _workloadCostEnforcementEnabled = CommonConstants.Accounting.DEFAULT_WORKLOAD_ENABLE_COST_ENFORCEMENT;
-      } else {
-        _workloadCostEnforcementEnabled = Boolean.parseBoolean(
-            clusterConfigs.get(CommonConstants.Accounting.CONFIG_OF_WORKLOAD_ENABLE_COST_ENFORCEMENT));
-      }
+    if (changedConfigs.contains(Accounting.Keys.WORKLOAD_ENABLE_COST_ENFORCEMENT)) {
+      String str = clusterConfigs.get(Accounting.Keys.WORKLOAD_ENABLE_COST_ENFORCEMENT);
+      _workloadCostEnforcementEnabled =
+          str != null ? Boolean.parseBoolean(str) : Accounting.DEFAULT_WORKLOAD_ENABLE_COST_ENFORCEMENT;
     } else {
       _workloadCostEnforcementEnabled = oldConfig._workloadCostEnforcementEnabled;
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/accounting/ResourceUsageAccountantFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/accounting/ResourceUsageAccountantFactory.java
@@ -26,10 +26,10 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicReference;
-import java.util.stream.Collectors;
 import org.apache.pinot.spi.accounting.QueryResourceTracker;
 import org.apache.pinot.spi.accounting.ThreadAccountant;
 import org.apache.pinot.spi.accounting.ThreadAccountantFactory;
+import org.apache.pinot.spi.accounting.ThreadAccountantUtils;
 import org.apache.pinot.spi.accounting.ThreadResourceTracker;
 import org.apache.pinot.spi.accounting.ThreadResourceUsageProvider;
 import org.apache.pinot.spi.accounting.TrackingScope;
@@ -39,7 +39,7 @@ import org.apache.pinot.spi.config.provider.PinotClusterConfigChangeListener;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.query.QueryExecutionContext;
 import org.apache.pinot.spi.query.QueryThreadContext;
-import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.CommonConstants.Accounting;
 import org.apache.pinot.spi.utils.ResourceUsageUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -83,22 +83,21 @@ public class ResourceUsageAccountantFactory implements ThreadAccountantFactory {
 
     public ResourceUsageAccountant(PinotConfiguration config, String instanceId, InstanceType instanceType) {
       LOGGER.info("Initializing ResourceUsageAccountant");
-      boolean cpuSamplingEnabled = config.getProperty(CommonConstants.Accounting.CONFIG_OF_ENABLE_THREAD_CPU_SAMPLING,
-          CommonConstants.Accounting.DEFAULT_ENABLE_THREAD_CPU_SAMPLING);
+      boolean cpuSamplingEnabled =
+          config.getProperty(Accounting.Keys.ENABLE_THREAD_CPU_SAMPLING, Accounting.DEFAULT_ENABLE_THREAD_CPU_SAMPLING);
       if (cpuSamplingEnabled && !ThreadResourceUsageProvider.isThreadCpuTimeMeasurementEnabled()) {
         LOGGER.warn("Thread CPU time measurement is not enabled in the JVM, disabling CPU sampling");
         cpuSamplingEnabled = false;
       }
       _cpuSamplingEnabled = cpuSamplingEnabled;
-      boolean memorySamplingEnabled =
-          config.getProperty(CommonConstants.Accounting.CONFIG_OF_ENABLE_THREAD_MEMORY_SAMPLING,
-              CommonConstants.Accounting.DEFAULT_ENABLE_THREAD_MEMORY_SAMPLING);
+      boolean memorySamplingEnabled = config.getProperty(Accounting.Keys.ENABLE_THREAD_MEMORY_SAMPLING,
+          Accounting.DEFAULT_ENABLE_THREAD_MEMORY_SAMPLING);
       if (memorySamplingEnabled && !ThreadResourceUsageProvider.isThreadMemoryMeasurementEnabled()) {
         LOGGER.warn("Thread memory measurement is not enabled in the JVM, disabling memory sampling");
         memorySamplingEnabled = false;
       }
       _memorySamplingEnabled = memorySamplingEnabled;
-      _watcherTask = new WatcherTask(config);
+      _watcherTask = new WatcherTask(config, instanceType);
       _queryResourceAggregator =
           new QueryResourceAggregator(instanceId, instanceType, cpuSamplingEnabled, memorySamplingEnabled,
               _watcherTask._queryMonitorConfig);
@@ -206,11 +205,13 @@ public class ResourceUsageAccountantFactory implements ThreadAccountantFactory {
 
     private class WatcherTask implements Runnable, PinotClusterConfigChangeListener {
       final AtomicReference<QueryMonitorConfig> _queryMonitorConfig = new AtomicReference<>();
+      final InstanceType _instanceType;
 
       long _nextQueryAggregateTimeMs;
       long _nextWorkloadAggregateTimeMs;
 
-      WatcherTask(PinotConfiguration config) {
+      WatcherTask(PinotConfiguration config, InstanceType instanceType) {
+        _instanceType = instanceType;
         QueryMonitorConfig queryMonitorConfig = new QueryMonitorConfig(config, ResourceUsageUtils.getMaxHeapSize());
         _queryMonitorConfig.set(queryMonitorConfig);
         logQueryMonitorConfig(queryMonitorConfig);
@@ -296,29 +297,16 @@ public class ResourceUsageAccountantFactory implements ThreadAccountantFactory {
       }
 
       @Override
-      public synchronized void onChange(Set<String> changedConfigs,
-          Map<String, String> clusterConfigs) {        // Filter configs that have CommonConstants
-        // .PREFIX_SCHEDULER_PREFIX
-        Set<String> filteredChangedConfigs = changedConfigs.stream()
-            .filter(config -> config.startsWith(CommonConstants.PINOT_QUERY_SCHEDULER_PREFIX))
-            .map(config -> config.replace(CommonConstants.PINOT_QUERY_SCHEDULER_PREFIX + ".", ""))
-            .collect(Collectors.toSet());
-
-        if (filteredChangedConfigs.isEmpty()) {
+      public synchronized void onChange(Set<String> changedConfigs, Map<String, String> clusterConfigs) {
+        ThreadAccountantUtils.AccountingConfigChange change =
+            ThreadAccountantUtils.filterAccountingConfigChange(changedConfigs, clusterConfigs, _instanceType);
+        if (change.isEmpty()) {
           LOGGER.debug("No relevant configs changed, skipping update for QueryMonitorConfig.");
           return;
         }
-
-        Map<String, String> filteredClusterConfigs = clusterConfigs.entrySet()
-            .stream()
-            .filter(entry -> entry.getKey().startsWith(CommonConstants.PINOT_QUERY_SCHEDULER_PREFIX))
-            .collect(Collectors.toMap(
-                entry -> entry.getKey().replace(CommonConstants.PINOT_QUERY_SCHEDULER_PREFIX + ".", ""),
-                Map.Entry::getValue));
-
         QueryMonitorConfig oldConfig = getQueryMonitorConfig();
         QueryMonitorConfig newConfig =
-            new QueryMonitorConfig(oldConfig, filteredChangedConfigs, filteredClusterConfigs);
+            new QueryMonitorConfig(oldConfig, change.getChangedConfigs(), change.getClusterConfigs());
         _queryMonitorConfig.set(newConfig);
         logQueryMonitorConfig(newConfig);
       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/WorkloadScheduler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/WorkloadScheduler.java
@@ -31,7 +31,6 @@ import org.apache.pinot.core.query.scheduler.resources.UnboundedResourceManager;
 import org.apache.pinot.spi.accounting.ThreadAccountant;
 import org.apache.pinot.spi.accounting.WorkloadBudgetManager;
 import org.apache.pinot.spi.env.PinotConfiguration;
-import org.apache.pinot.spi.utils.CommonConstants.Accounting;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,14 +50,11 @@ public class WorkloadScheduler extends QueryScheduler {
   private static final Logger LOGGER = LoggerFactory.getLogger(WorkloadScheduler.class);
 
   private final WorkloadBudgetManager _workloadBudgetManager;
-  private final String _secondaryWorkloadName;
 
   public WorkloadScheduler(PinotConfiguration config, String instanceId, QueryExecutor queryExecutor,
       ThreadAccountant threadAccountant, LongAccumulator latestQueryTime) {
     super(config, instanceId, queryExecutor, threadAccountant, latestQueryTime, new UnboundedResourceManager(config));
     _workloadBudgetManager = WorkloadBudgetManager.get();
-    _secondaryWorkloadName =
-        config.getProperty(Accounting.CONFIG_OF_SECONDARY_WORKLOAD_NAME, Accounting.DEFAULT_SECONDARY_WORKLOAD_NAME);
   }
 
   @Override
@@ -76,7 +72,7 @@ public class WorkloadScheduler extends QueryScheduler {
     // This is for backward compatibility, where we want to honor the isSecondary query option to use the secondary
     // workload budget.
     String workloadName = isSecondary
-        ? _secondaryWorkloadName
+        ? _workloadBudgetManager.getSecondaryWorkloadName()
         : QueryOptionsUtils.getWorkloadName(queryRequest.getQueryContext().getQueryOptions());
     if (!_workloadBudgetManager.canAdmitQuery(workloadName)) {
       // TODO: Explore queuing the query instead of rejecting it.

--- a/pinot-core/src/test/java/org/apache/pinot/core/accounting/QueryMonitorConfigTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/accounting/QueryMonitorConfigTest.java
@@ -24,7 +24,6 @@ import java.util.Set;
 import org.apache.pinot.core.accounting.PerQueryCPUMemAccountantFactory.PerQueryCPUMemResourceUsageAccountant;
 import org.apache.pinot.spi.config.instance.InstanceType;
 import org.apache.pinot.spi.env.PinotConfiguration;
-import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.CommonConstants.Accounting;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -48,40 +47,36 @@ public class QueryMonitorConfigTest {
   private static final boolean EXPECTED_IS_QUERY_KILLED_METRIC_ENABLED = true;
   private static final Map<String, String> CLUSTER_CONFIGS = new HashMap<>();
 
-  private static String getFullyQualifiedConfigName(String config) {
-    return CommonConstants.PINOT_QUERY_SCHEDULER_PREFIX + "." + config;
-  }
-
   private static final long EXPECTED_OOM_PAUSE_TIMEOUT_MS = 2000;
   private static final boolean EXPECTED_OOM_PAUSE_ON_PANIC_ENABLED = true;
 
   @BeforeClass
   public void setUp() {
-    CLUSTER_CONFIGS.put(getFullyQualifiedConfigName(Accounting.CONFIG_OF_OOM_PROTECTION_KILLING_QUERY),
+    CLUSTER_CONFIGS.put(Accounting.COMMON_PREFIX + "." + Accounting.Keys.OOM_PROTECTION_KILLING_QUERY,
         Boolean.toString(EXPECTED_OOM_KILL_QUERY_ENABLED));
-    CLUSTER_CONFIGS.put(getFullyQualifiedConfigName(Accounting.CONFIG_OF_PUBLISHING_JVM_USAGE),
+    CLUSTER_CONFIGS.put(Accounting.COMMON_PREFIX + "." + Accounting.Keys.PUBLISHING_JVM_USAGE,
         Boolean.toString(EXPECTED_PUBLISH_HEAP_USAGE_METRIC));
-    CLUSTER_CONFIGS.put(getFullyQualifiedConfigName(Accounting.CONFIG_OF_CPU_TIME_BASED_KILLING_ENABLED),
+    CLUSTER_CONFIGS.put(Accounting.COMMON_PREFIX + "." + Accounting.Keys.CPU_TIME_BASED_KILLING_ENABLED,
         Boolean.toString(EXPECTED_IS_CPU_TIME_BASED_KILLING_ENABLED));
-    CLUSTER_CONFIGS.put(getFullyQualifiedConfigName(Accounting.CONFIG_OF_CPU_TIME_BASED_KILLING_THRESHOLD_MS),
+    CLUSTER_CONFIGS.put(Accounting.COMMON_PREFIX + "." + Accounting.Keys.CPU_TIME_BASED_KILLING_THRESHOLD_MS,
         Long.toString(EXPECTED_CPU_TIME_BASED_KILLING_THRESHOLD_NS));
-    CLUSTER_CONFIGS.put(getFullyQualifiedConfigName(Accounting.CONFIG_OF_PANIC_LEVEL_HEAP_USAGE_RATIO),
+    CLUSTER_CONFIGS.put(Accounting.COMMON_PREFIX + "." + Accounting.Keys.PANIC_LEVEL_HEAP_USAGE_RATIO,
         Double.toString(EXPECTED_PANIC_LEVEL));
-    CLUSTER_CONFIGS.put(getFullyQualifiedConfigName(Accounting.CONFIG_OF_CRITICAL_LEVEL_HEAP_USAGE_RATIO),
+    CLUSTER_CONFIGS.put(Accounting.COMMON_PREFIX + "." + Accounting.Keys.CRITICAL_LEVEL_HEAP_USAGE_RATIO,
         Double.toString(EXPECTED_CRITICAL_LEVEL));
-    CLUSTER_CONFIGS.put(getFullyQualifiedConfigName(Accounting.CONFIG_OF_ALARMING_LEVEL_HEAP_USAGE_RATIO),
+    CLUSTER_CONFIGS.put(Accounting.COMMON_PREFIX + "." + Accounting.Keys.ALARMING_LEVEL_HEAP_USAGE_RATIO,
         Double.toString(EXPECTED_ALARMING_LEVEL));
-    CLUSTER_CONFIGS.put(getFullyQualifiedConfigName(Accounting.CONFIG_OF_SLEEP_TIME_MS),
+    CLUSTER_CONFIGS.put(Accounting.COMMON_PREFIX + "." + Accounting.Keys.SLEEP_TIME_MS,
         Integer.toString(EXPECTED_NORMAL_SLEEP_TIME));
-    CLUSTER_CONFIGS.put(getFullyQualifiedConfigName(Accounting.CONFIG_OF_SLEEP_TIME_DENOMINATOR),
+    CLUSTER_CONFIGS.put(Accounting.COMMON_PREFIX + "." + Accounting.Keys.SLEEP_TIME_DENOMINATOR,
         Integer.toString(EXPECTED_ALARMING_SLEEP_TIME_DENOMINATOR));
-    CLUSTER_CONFIGS.put(getFullyQualifiedConfigName(Accounting.CONFIG_OF_MIN_MEMORY_FOOTPRINT_TO_KILL_RATIO),
+    CLUSTER_CONFIGS.put(Accounting.COMMON_PREFIX + "." + Accounting.Keys.MIN_MEMORY_FOOTPRINT_TO_KILL_RATIO,
         Double.toString(EXPECTED_MIN_MEMORY_FOOTPRINT_FOR_KILL));
-    CLUSTER_CONFIGS.put(getFullyQualifiedConfigName(Accounting.CONFIG_OF_QUERY_KILLED_METRIC_ENABLED),
+    CLUSTER_CONFIGS.put(Accounting.COMMON_PREFIX + "." + Accounting.Keys.QUERY_KILLED_METRIC_ENABLED,
         Boolean.toString(EXPECTED_IS_QUERY_KILLED_METRIC_ENABLED));
-    CLUSTER_CONFIGS.put(getFullyQualifiedConfigName(Accounting.CONFIG_OF_OOM_PRE_QUERY_KILL_PAUSE_DURATION_MS),
+    CLUSTER_CONFIGS.put(Accounting.COMMON_PREFIX + "." + Accounting.Keys.OOM_PRE_QUERY_KILL_PAUSE_DURATION_MS,
         Long.toString(EXPECTED_OOM_PAUSE_TIMEOUT_MS));
-    CLUSTER_CONFIGS.put(getFullyQualifiedConfigName(Accounting.CONFIG_OF_OOM_PANIC_ALLOW_PRE_QUERY_KILL_PAUSE),
+    CLUSTER_CONFIGS.put(Accounting.COMMON_PREFIX + "." + Accounting.Keys.OOM_PANIC_ALLOW_PRE_QUERY_KILL_PAUSE,
         Boolean.toString(EXPECTED_OOM_PAUSE_ON_PANIC_ENABLED));
   }
 
@@ -92,7 +87,7 @@ public class QueryMonitorConfigTest {
 
     assertFalse(accountant.getQueryMonitorConfig().isOomKillQueryEnabled());
     accountant.getWatcherTask()
-        .onChange(Set.of(getFullyQualifiedConfigName(Accounting.CONFIG_OF_OOM_PROTECTION_KILLING_QUERY)),
+        .onChange(Set.of(Accounting.COMMON_PREFIX + "." + Accounting.Keys.OOM_PROTECTION_KILLING_QUERY),
             CLUSTER_CONFIGS);
     assertTrue(accountant.getQueryMonitorConfig().isOomKillQueryEnabled());
   }
@@ -104,7 +99,7 @@ public class QueryMonitorConfigTest {
 
     assertFalse(accountant.getQueryMonitorConfig().isPublishHeapUsageMetric());
     accountant.getWatcherTask()
-        .onChange(Set.of(getFullyQualifiedConfigName(Accounting.CONFIG_OF_PUBLISHING_JVM_USAGE)), CLUSTER_CONFIGS);
+        .onChange(Set.of(Accounting.COMMON_PREFIX + "." + Accounting.Keys.PUBLISHING_JVM_USAGE), CLUSTER_CONFIGS);
     assertTrue(accountant.getQueryMonitorConfig().isPublishHeapUsageMetric());
   }
 
@@ -115,7 +110,7 @@ public class QueryMonitorConfigTest {
 
     assertFalse(accountant.getQueryMonitorConfig().isCpuTimeBasedKillingEnabled());
     accountant.getWatcherTask()
-        .onChange(Set.of(getFullyQualifiedConfigName(Accounting.CONFIG_OF_CPU_TIME_BASED_KILLING_ENABLED)),
+        .onChange(Set.of(Accounting.COMMON_PREFIX + "." + Accounting.Keys.CPU_TIME_BASED_KILLING_ENABLED),
             CLUSTER_CONFIGS);
     assertTrue(accountant.getQueryMonitorConfig().isCpuTimeBasedKillingEnabled());
   }
@@ -128,7 +123,7 @@ public class QueryMonitorConfigTest {
     assertEquals(accountant.getQueryMonitorConfig().getCpuTimeBasedKillingThresholdNs(),
         Accounting.DEFAULT_CPU_TIME_BASED_KILLING_THRESHOLD_MS * 1000_000L);
     accountant.getWatcherTask()
-        .onChange(Set.of(getFullyQualifiedConfigName(Accounting.CONFIG_OF_CPU_TIME_BASED_KILLING_THRESHOLD_MS)),
+        .onChange(Set.of(Accounting.COMMON_PREFIX + "." + Accounting.Keys.CPU_TIME_BASED_KILLING_THRESHOLD_MS),
             CLUSTER_CONFIGS);
     assertEquals(accountant.getQueryMonitorConfig().getCpuTimeBasedKillingThresholdNs(),
         EXPECTED_CPU_TIME_BASED_KILLING_THRESHOLD_NS * 1000_000L);
@@ -142,7 +137,7 @@ public class QueryMonitorConfigTest {
     assertEquals(accountant.getQueryMonitorConfig().getPanicLevel(),
         Accounting.DEFAULT_PANIC_LEVEL_HEAP_USAGE_RATIO * accountant.getQueryMonitorConfig().getMaxHeapSize());
     accountant.getWatcherTask()
-        .onChange(Set.of(getFullyQualifiedConfigName(Accounting.CONFIG_OF_PANIC_LEVEL_HEAP_USAGE_RATIO)),
+        .onChange(Set.of(Accounting.COMMON_PREFIX + "." + Accounting.Keys.PANIC_LEVEL_HEAP_USAGE_RATIO),
             CLUSTER_CONFIGS);
     assertEquals(accountant.getQueryMonitorConfig().getPanicLevel(),
         EXPECTED_PANIC_LEVEL * accountant.getQueryMonitorConfig().getMaxHeapSize());
@@ -156,7 +151,7 @@ public class QueryMonitorConfigTest {
     assertEquals(accountant.getQueryMonitorConfig().getCriticalLevel(),
         Accounting.DEFAULT_CRITICAL_LEVEL_HEAP_USAGE_RATIO * accountant.getQueryMonitorConfig().getMaxHeapSize());
     accountant.getWatcherTask()
-        .onChange(Set.of(getFullyQualifiedConfigName(Accounting.CONFIG_OF_CRITICAL_LEVEL_HEAP_USAGE_RATIO)),
+        .onChange(Set.of(Accounting.COMMON_PREFIX + "." + Accounting.Keys.CRITICAL_LEVEL_HEAP_USAGE_RATIO),
             CLUSTER_CONFIGS);
     assertEquals(accountant.getQueryMonitorConfig().getCriticalLevel(),
         EXPECTED_CRITICAL_LEVEL * accountant.getQueryMonitorConfig().getMaxHeapSize());
@@ -170,7 +165,7 @@ public class QueryMonitorConfigTest {
     assertEquals(accountant.getQueryMonitorConfig().getAlarmingLevel(),
         Accounting.DEFAULT_ALARMING_LEVEL_HEAP_USAGE_RATIO * accountant.getQueryMonitorConfig().getMaxHeapSize());
     accountant.getWatcherTask()
-        .onChange(Set.of(getFullyQualifiedConfigName(Accounting.CONFIG_OF_ALARMING_LEVEL_HEAP_USAGE_RATIO)),
+        .onChange(Set.of(Accounting.COMMON_PREFIX + "." + Accounting.Keys.ALARMING_LEVEL_HEAP_USAGE_RATIO),
             CLUSTER_CONFIGS);
     assertEquals(accountant.getQueryMonitorConfig().getAlarmingLevel(),
         EXPECTED_ALARMING_LEVEL * accountant.getQueryMonitorConfig().getMaxHeapSize());
@@ -183,7 +178,7 @@ public class QueryMonitorConfigTest {
 
     assertEquals(accountant.getQueryMonitorConfig().getNormalSleepTime(), Accounting.DEFAULT_SLEEP_TIME_MS);
     accountant.getWatcherTask()
-        .onChange(Set.of(getFullyQualifiedConfigName(Accounting.CONFIG_OF_SLEEP_TIME_MS)), CLUSTER_CONFIGS);
+        .onChange(Set.of(Accounting.COMMON_PREFIX + "." + Accounting.Keys.SLEEP_TIME_MS), CLUSTER_CONFIGS);
     assertEquals(accountant.getQueryMonitorConfig().getNormalSleepTime(), EXPECTED_NORMAL_SLEEP_TIME);
   }
 
@@ -195,7 +190,7 @@ public class QueryMonitorConfigTest {
     assertEquals(accountant.getQueryMonitorConfig().getAlarmingSleepTime(),
         accountant.getQueryMonitorConfig().getNormalSleepTime() / Accounting.DEFAULT_SLEEP_TIME_DENOMINATOR);
     accountant.getWatcherTask()
-        .onChange(Set.of(getFullyQualifiedConfigName(Accounting.CONFIG_OF_SLEEP_TIME_DENOMINATOR)), CLUSTER_CONFIGS);
+        .onChange(Set.of(Accounting.COMMON_PREFIX + "." + Accounting.Keys.SLEEP_TIME_DENOMINATOR), CLUSTER_CONFIGS);
     assertEquals(accountant.getQueryMonitorConfig().getAlarmingSleepTime(),
         accountant.getQueryMonitorConfig().getNormalSleepTime() / EXPECTED_ALARMING_SLEEP_TIME_DENOMINATOR);
   }
@@ -209,7 +204,7 @@ public class QueryMonitorConfigTest {
         (long) (Accounting.DEFAULT_MEMORY_FOOTPRINT_TO_KILL_RATIO * accountant.getQueryMonitorConfig()
             .getMaxHeapSize()));
     accountant.getWatcherTask()
-        .onChange(Set.of(getFullyQualifiedConfigName(Accounting.CONFIG_OF_MIN_MEMORY_FOOTPRINT_TO_KILL_RATIO)),
+        .onChange(Set.of(Accounting.COMMON_PREFIX + "." + Accounting.Keys.MIN_MEMORY_FOOTPRINT_TO_KILL_RATIO),
             CLUSTER_CONFIGS);
     assertEquals(accountant.getQueryMonitorConfig().getMinMemoryFootprintForKill(),
         (long) (EXPECTED_MIN_MEMORY_FOOTPRINT_FOR_KILL * accountant.getQueryMonitorConfig().getMaxHeapSize()));
@@ -222,7 +217,7 @@ public class QueryMonitorConfigTest {
 
     assertFalse(accountant.getQueryMonitorConfig().isQueryKilledMetricEnabled());
     accountant.getWatcherTask()
-        .onChange(Set.of(getFullyQualifiedConfigName(Accounting.CONFIG_OF_QUERY_KILLED_METRIC_ENABLED)),
+        .onChange(Set.of(Accounting.COMMON_PREFIX + "." + Accounting.Keys.QUERY_KILLED_METRIC_ENABLED),
             CLUSTER_CONFIGS);
     assertTrue(accountant.getQueryMonitorConfig().isQueryKilledMetricEnabled());
   }
@@ -235,8 +230,7 @@ public class QueryMonitorConfigTest {
     assertEquals(accountant.getQueryMonitorConfig().getOomPreQueryKillPauseDurationMs(),
         Accounting.DEFAULT_OOM_PRE_QUERY_KILL_PAUSE_DURATION_MS);
     accountant.getWatcherTask()
-        .onChange(
-            Set.of(getFullyQualifiedConfigName(Accounting.CONFIG_OF_OOM_PRE_QUERY_KILL_PAUSE_DURATION_MS)),
+        .onChange(Set.of(Accounting.COMMON_PREFIX + "." + Accounting.Keys.OOM_PRE_QUERY_KILL_PAUSE_DURATION_MS),
             CLUSTER_CONFIGS);
     assertEquals(accountant.getQueryMonitorConfig().getOomPreQueryKillPauseDurationMs(), EXPECTED_OOM_PAUSE_TIMEOUT_MS);
   }
@@ -248,9 +242,173 @@ public class QueryMonitorConfigTest {
 
     assertFalse(accountant.getQueryMonitorConfig().isOomPanicPreQueryKillPauseEnabled());
     accountant.getWatcherTask()
-        .onChange(
-            Set.of(getFullyQualifiedConfigName(Accounting.CONFIG_OF_OOM_PANIC_ALLOW_PRE_QUERY_KILL_PAUSE)),
+        .onChange(Set.of(Accounting.COMMON_PREFIX + "." + Accounting.Keys.OOM_PANIC_ALLOW_PRE_QUERY_KILL_PAUSE),
             CLUSTER_CONFIGS);
     assertTrue(accountant.getQueryMonitorConfig().isOomPanicPreQueryKillPauseEnabled());
+  }
+
+  /// Verifies the role-specific prefix takes precedence over {@link Accounting#COMMON_PREFIX} on a server accountant,
+  /// and that the broker-specific prefix is ignored.
+  @Test
+  void testServerPrefixOverridesCommonAndIgnoresBrokerPrefix() {
+    PerQueryCPUMemResourceUsageAccountant accountant =
+        new PerQueryCPUMemResourceUsageAccountant(new PinotConfiguration(), "test", InstanceType.SERVER);
+    assertFalse(accountant.getQueryMonitorConfig().isOomKillQueryEnabled());
+
+    String commonKey = Accounting.COMMON_PREFIX + "." + Accounting.Keys.OOM_PROTECTION_KILLING_QUERY;
+    String brokerKey = Accounting.BROKER_PREFIX + "." + Accounting.Keys.OOM_PROTECTION_KILLING_QUERY;
+    String serverKey = Accounting.SERVER_PREFIX + "." + Accounting.Keys.OOM_PROTECTION_KILLING_QUERY;
+
+    // Common says false, broker says false, server says true. The server accountant should pick the server value.
+    Map<String, String> clusterConfigs = Map.of(commonKey, "false", brokerKey, "false", serverKey, "true");
+    accountant.getWatcherTask().onChange(Set.of(commonKey, brokerKey, serverKey), clusterConfigs);
+    assertTrue(accountant.getQueryMonitorConfig().isOomKillQueryEnabled(),
+        "Server-specific prefix value should override the common prefix value");
+  }
+
+  /// Same as above but asserts the broker accountant picks up {@link Accounting#BROKER_PREFIX} and ignores
+  /// {@link Accounting#SERVER_PREFIX}.
+  @Test
+  void testBrokerPrefixOverridesCommonAndIgnoresServerPrefix() {
+    PerQueryCPUMemResourceUsageAccountant accountant =
+        new PerQueryCPUMemResourceUsageAccountant(new PinotConfiguration(), "test", InstanceType.BROKER);
+    assertFalse(accountant.getQueryMonitorConfig().isOomKillQueryEnabled());
+
+    String commonKey = Accounting.COMMON_PREFIX + "." + Accounting.Keys.OOM_PROTECTION_KILLING_QUERY;
+    String brokerKey = Accounting.BROKER_PREFIX + "." + Accounting.Keys.OOM_PROTECTION_KILLING_QUERY;
+    String serverKey = Accounting.SERVER_PREFIX + "." + Accounting.Keys.OOM_PROTECTION_KILLING_QUERY;
+
+    Map<String, String> clusterConfigs = Map.of(commonKey, "false", brokerKey, "true", serverKey, "false");
+    accountant.getWatcherTask().onChange(Set.of(commonKey, brokerKey, serverKey), clusterConfigs);
+    assertTrue(accountant.getQueryMonitorConfig().isOomKillQueryEnabled(),
+        "Broker-specific prefix value should override the common prefix value");
+  }
+
+  /// Common config added to cluster: the accountant should pick up the new value.
+  @Test
+  void testCommonConfigAdded() {
+    PerQueryCPUMemResourceUsageAccountant accountant =
+        new PerQueryCPUMemResourceUsageAccountant(new PinotConfiguration(), "test", InstanceType.SERVER);
+    assertFalse(accountant.getQueryMonitorConfig().isOomKillQueryEnabled());
+
+    String commonKey = Accounting.COMMON_PREFIX + "." + Accounting.Keys.OOM_PROTECTION_KILLING_QUERY;
+    accountant.getWatcherTask().onChange(Set.of(commonKey), Map.of(commonKey, "true"));
+    assertTrue(accountant.getQueryMonitorConfig().isOomKillQueryEnabled());
+  }
+
+  /// Common config value changed: the accountant should reflect the new value.
+  @Test
+  void testCommonConfigChanged() {
+    PerQueryCPUMemResourceUsageAccountant accountant =
+        new PerQueryCPUMemResourceUsageAccountant(new PinotConfiguration(), "test", InstanceType.SERVER);
+    String commonKey = Accounting.COMMON_PREFIX + "." + Accounting.Keys.OOM_PROTECTION_KILLING_QUERY;
+    accountant.getWatcherTask().onChange(Set.of(commonKey), Map.of(commonKey, "true"));
+    assertTrue(accountant.getQueryMonitorConfig().isOomKillQueryEnabled());
+
+    accountant.getWatcherTask().onChange(Set.of(commonKey), Map.of(commonKey, "false"));
+    assertFalse(accountant.getQueryMonitorConfig().isOomKillQueryEnabled());
+  }
+
+  /// Common config removed from cluster: key is in changedConfigs but absent from clusterConfigs; the accountant should
+  /// revert to the default value.
+  @Test
+  void testCommonConfigRemovedRevertsToDefault() {
+    PerQueryCPUMemResourceUsageAccountant accountant =
+        new PerQueryCPUMemResourceUsageAccountant(new PinotConfiguration(), "test", InstanceType.SERVER);
+    String commonKey = Accounting.COMMON_PREFIX + "." + Accounting.Keys.OOM_PROTECTION_KILLING_QUERY;
+    accountant.getWatcherTask().onChange(Set.of(commonKey), Map.of(commonKey, "true"));
+    assertTrue(accountant.getQueryMonitorConfig().isOomKillQueryEnabled());
+
+    accountant.getWatcherTask().onChange(Set.of(commonKey), Map.of());
+    assertFalse(accountant.getQueryMonitorConfig().isOomKillQueryEnabled(),
+        "Removed common config should revert to the default value");
+  }
+
+  /// Role-specific config added on top of an existing common value: role value wins.
+  @Test
+  void testServerConfigAddedOverridesCommon() {
+    PerQueryCPUMemResourceUsageAccountant accountant =
+        new PerQueryCPUMemResourceUsageAccountant(new PinotConfiguration(), "test", InstanceType.SERVER);
+    String commonKey = Accounting.COMMON_PREFIX + "." + Accounting.Keys.OOM_PROTECTION_KILLING_QUERY;
+    String serverKey = Accounting.SERVER_PREFIX + "." + Accounting.Keys.OOM_PROTECTION_KILLING_QUERY;
+
+    accountant.getWatcherTask().onChange(Set.of(commonKey), Map.of(commonKey, "true"));
+    assertTrue(accountant.getQueryMonitorConfig().isOomKillQueryEnabled());
+
+    accountant.getWatcherTask().onChange(Set.of(serverKey), Map.of(commonKey, "true", serverKey, "false"));
+    assertFalse(accountant.getQueryMonitorConfig().isOomKillQueryEnabled(),
+        "Added server-specific value should override the common value");
+  }
+
+  /// Role-specific config value changed.
+  @Test
+  void testServerConfigChanged() {
+    PerQueryCPUMemResourceUsageAccountant accountant =
+        new PerQueryCPUMemResourceUsageAccountant(new PinotConfiguration(), "test", InstanceType.SERVER);
+    String serverKey = Accounting.SERVER_PREFIX + "." + Accounting.Keys.OOM_PROTECTION_KILLING_QUERY;
+
+    accountant.getWatcherTask().onChange(Set.of(serverKey), Map.of(serverKey, "true"));
+    assertTrue(accountant.getQueryMonitorConfig().isOomKillQueryEnabled());
+
+    accountant.getWatcherTask().onChange(Set.of(serverKey), Map.of(serverKey, "false"));
+    assertFalse(accountant.getQueryMonitorConfig().isOomKillQueryEnabled());
+  }
+
+  /// Role-specific config removed while the common value is still present: the accountant falls back to the common
+  /// value.
+  @Test
+  void testServerConfigRemovedFallsBackToCommon() {
+    PerQueryCPUMemResourceUsageAccountant accountant =
+        new PerQueryCPUMemResourceUsageAccountant(new PinotConfiguration(), "test", InstanceType.SERVER);
+    String commonKey = Accounting.COMMON_PREFIX + "." + Accounting.Keys.OOM_PROTECTION_KILLING_QUERY;
+    String serverKey = Accounting.SERVER_PREFIX + "." + Accounting.Keys.OOM_PROTECTION_KILLING_QUERY;
+
+    accountant.getWatcherTask().onChange(Set.of(commonKey, serverKey), Map.of(commonKey, "true", serverKey, "false"));
+    assertFalse(accountant.getQueryMonitorConfig().isOomKillQueryEnabled());
+
+    // Remove server-specific: changedConfigs has serverKey but clusterConfigs only has commonKey.
+    accountant.getWatcherTask().onChange(Set.of(serverKey), Map.of(commonKey, "true"));
+    assertTrue(accountant.getQueryMonitorConfig().isOomKillQueryEnabled(),
+        "Removed server-specific config should fall back to the common value");
+  }
+
+  /// Changing the common config does not override the role-specific value while the role-specific value is set.
+  @Test
+  void testChangingCommonDoesNotOverrideServer() {
+    PerQueryCPUMemResourceUsageAccountant accountant =
+        new PerQueryCPUMemResourceUsageAccountant(new PinotConfiguration(), "test", InstanceType.SERVER);
+    String commonKey = Accounting.COMMON_PREFIX + "." + Accounting.Keys.OOM_PROTECTION_KILLING_QUERY;
+    String serverKey = Accounting.SERVER_PREFIX + "." + Accounting.Keys.OOM_PROTECTION_KILLING_QUERY;
+
+    // Start with server=true -> enabled=true.
+    accountant.getWatcherTask().onChange(Set.of(serverKey), Map.of(serverKey, "true"));
+    assertTrue(accountant.getQueryMonitorConfig().isOomKillQueryEnabled());
+
+    // Add conflicting common=false. Server still wins; common value is ignored.
+    accountant.getWatcherTask().onChange(Set.of(commonKey), Map.of(serverKey, "true", commonKey, "false"));
+    assertTrue(accountant.getQueryMonitorConfig().isOomKillQueryEnabled(),
+        "Adding a conflicting common value should not override the role-specific value");
+
+    // Flip common back and forth; server value should continue to dominate.
+    accountant.getWatcherTask().onChange(Set.of(commonKey), Map.of(serverKey, "true", commonKey, "true"));
+    assertTrue(accountant.getQueryMonitorConfig().isOomKillQueryEnabled());
+    accountant.getWatcherTask().onChange(Set.of(commonKey), Map.of(serverKey, "true", commonKey, "false"));
+    assertTrue(accountant.getQueryMonitorConfig().isOomKillQueryEnabled(),
+        "Subsequent common changes should not override the role-specific value");
+  }
+
+  /// Role-specific config removed with no common value set: the accountant reverts to the default.
+  @Test
+  void testServerConfigRemovedRevertsToDefault() {
+    PerQueryCPUMemResourceUsageAccountant accountant =
+        new PerQueryCPUMemResourceUsageAccountant(new PinotConfiguration(), "test", InstanceType.SERVER);
+    String serverKey = Accounting.SERVER_PREFIX + "." + Accounting.Keys.OOM_PROTECTION_KILLING_QUERY;
+
+    accountant.getWatcherTask().onChange(Set.of(serverKey), Map.of(serverKey, "true"));
+    assertTrue(accountant.getQueryMonitorConfig().isOomKillQueryEnabled());
+
+    accountant.getWatcherTask().onChange(Set.of(serverKey), Map.of());
+    assertFalse(accountant.getQueryMonitorConfig().isOomKillQueryEnabled(),
+        "Removed server-specific config without a common fallback should revert to the default");
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/accounting/QueryResourceAggregatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/accounting/QueryResourceAggregatorTest.java
@@ -22,7 +22,7 @@ import java.util.Collections;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.pinot.spi.config.instance.InstanceType;
 import org.apache.pinot.spi.env.PinotConfiguration;
-import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.CommonConstants.Accounting;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
@@ -45,17 +45,15 @@ public class QueryResourceAggregatorTest {
   /// also set to 0 so that the aggregator always hits panic level instead.
   private QueryResourceAggregator createAggregator(long oomPauseTimeoutMs, boolean pauseOnPanic) {
     PinotConfiguration config = new PinotConfiguration();
-    config.setProperty(CommonConstants.Accounting.CONFIG_OF_OOM_PRE_QUERY_KILL_PAUSE_DURATION_MS, oomPauseTimeoutMs);
-    config.setProperty(CommonConstants.Accounting.CONFIG_OF_CRITICAL_LEVEL_HEAP_USAGE_RATIO, TEST_CRITICAL_RATIO);
-    config.setProperty(CommonConstants.Accounting.CONFIG_OF_PANIC_LEVEL_HEAP_USAGE_RATIO,
-        pauseOnPanic ? 0f : TEST_PANIC_RATIO);
-    config.setProperty(CommonConstants.Accounting.CONFIG_OF_OOM_PROTECTION_KILLING_QUERY, true);
-    config.setProperty(CommonConstants.Accounting.CONFIG_OF_ALARMING_LEVEL_HEAP_USAGE_RATIO, 0f);
-    config.setProperty(CommonConstants.Accounting.CONFIG_OF_OOM_PANIC_ALLOW_PRE_QUERY_KILL_PAUSE, pauseOnPanic);
+    config.setProperty(Accounting.Keys.OOM_PRE_QUERY_KILL_PAUSE_DURATION_MS, oomPauseTimeoutMs);
+    config.setProperty(Accounting.Keys.CRITICAL_LEVEL_HEAP_USAGE_RATIO, TEST_CRITICAL_RATIO);
+    config.setProperty(Accounting.Keys.PANIC_LEVEL_HEAP_USAGE_RATIO, pauseOnPanic ? 0f : TEST_PANIC_RATIO);
+    config.setProperty(Accounting.Keys.OOM_PROTECTION_KILLING_QUERY, true);
+    config.setProperty(Accounting.Keys.ALARMING_LEVEL_HEAP_USAGE_RATIO, 0f);
+    config.setProperty(Accounting.Keys.OOM_PANIC_ALLOW_PRE_QUERY_KILL_PAUSE, pauseOnPanic);
 
     long maxHeapSize = org.apache.pinot.spi.utils.ResourceUsageUtils.getMaxHeapSize();
-    AtomicReference<QueryMonitorConfig> configRef =
-        new AtomicReference<>(new QueryMonitorConfig(config, maxHeapSize));
+    AtomicReference<QueryMonitorConfig> configRef = new AtomicReference<>(new QueryMonitorConfig(config, maxHeapSize));
 
     return new QueryResourceAggregator("test-instance", InstanceType.SERVER, false, true, configRef);
   }
@@ -63,7 +61,7 @@ public class QueryResourceAggregatorTest {
   @Test
   public void testConfigReadsOomPauseTimeout() {
     PinotConfiguration config = new PinotConfiguration();
-    config.setProperty(CommonConstants.Accounting.CONFIG_OF_OOM_PRE_QUERY_KILL_PAUSE_DURATION_MS, 2000L);
+    config.setProperty(Accounting.Keys.OOM_PRE_QUERY_KILL_PAUSE_DURATION_MS, 2000L);
 
     long maxHeapSize = org.apache.pinot.spi.utils.ResourceUsageUtils.getMaxHeapSize();
     QueryMonitorConfig qmc = new QueryMonitorConfig(config, maxHeapSize);
@@ -129,8 +127,7 @@ public class QueryResourceAggregatorTest {
 
     assertTrue(elapsed >= 150,
         "waitIfPaused should have blocked until signaled (~200ms), but only blocked for " + elapsed + "ms");
-    assertTrue(elapsed < 2000,
-        "waitIfPaused should have unblocked promptly after signal, but took " + elapsed + "ms");
+    assertTrue(elapsed < 2000, "waitIfPaused should have unblocked promptly after signal, but took " + elapsed + "ms");
   }
 
   @Test
@@ -159,8 +156,7 @@ public class QueryResourceAggregatorTest {
     aggregator.preAggregate(Collections.emptyList());
     aggregator.postAggregate();
 
-    assertFalse(aggregator.isPauseActive(),
-        "Should not re-pause when already at critical level");
+    assertFalse(aggregator.isPauseActive(), "Should not re-pause when already at critical level");
   }
 
   @Test
@@ -183,16 +179,15 @@ public class QueryResourceAggregatorTest {
   public void testNoPanicPauseWhenDisabled() {
     // Create aggregator that hits panic but with pauseOnPanic=false
     PinotConfiguration config = new PinotConfiguration();
-    config.setProperty(CommonConstants.Accounting.CONFIG_OF_OOM_PRE_QUERY_KILL_PAUSE_DURATION_MS, 5000L);
-    config.setProperty(CommonConstants.Accounting.CONFIG_OF_CRITICAL_LEVEL_HEAP_USAGE_RATIO, 0f);
-    config.setProperty(CommonConstants.Accounting.CONFIG_OF_PANIC_LEVEL_HEAP_USAGE_RATIO, 0f);
-    config.setProperty(CommonConstants.Accounting.CONFIG_OF_OOM_PROTECTION_KILLING_QUERY, true);
-    config.setProperty(CommonConstants.Accounting.CONFIG_OF_ALARMING_LEVEL_HEAP_USAGE_RATIO, 0f);
-    config.setProperty(CommonConstants.Accounting.CONFIG_OF_OOM_PANIC_ALLOW_PRE_QUERY_KILL_PAUSE, false);
+    config.setProperty(Accounting.Keys.OOM_PRE_QUERY_KILL_PAUSE_DURATION_MS, 5000L);
+    config.setProperty(Accounting.Keys.CRITICAL_LEVEL_HEAP_USAGE_RATIO, 0f);
+    config.setProperty(Accounting.Keys.PANIC_LEVEL_HEAP_USAGE_RATIO, 0f);
+    config.setProperty(Accounting.Keys.OOM_PROTECTION_KILLING_QUERY, true);
+    config.setProperty(Accounting.Keys.ALARMING_LEVEL_HEAP_USAGE_RATIO, 0f);
+    config.setProperty(Accounting.Keys.OOM_PANIC_ALLOW_PRE_QUERY_KILL_PAUSE, false);
 
     long maxHeapSize = org.apache.pinot.spi.utils.ResourceUsageUtils.getMaxHeapSize();
-    AtomicReference<QueryMonitorConfig> configRef =
-        new AtomicReference<>(new QueryMonitorConfig(config, maxHeapSize));
+    AtomicReference<QueryMonitorConfig> configRef = new AtomicReference<>(new QueryMonitorConfig(config, maxHeapSize));
     QueryResourceAggregator aggregator =
         new QueryResourceAggregator("test-instance", InstanceType.SERVER, false, true, configRef);
 
@@ -215,9 +210,7 @@ public class QueryResourceAggregatorTest {
 
     // Second cycle: Panic → Panic, should NOT re-pause
     aggregator.preAggregate(Collections.emptyList());
-    assertEquals(aggregator.getPreviousTriggeringLevel(),
-        QueryResourceAggregator.TriggeringLevel.HeapMemoryPanic);
-    assertFalse(aggregator.isPauseActive(),
-        "Should not re-pause on Panic→Panic transition");
+    assertEquals(aggregator.getPreviousTriggeringLevel(), QueryResourceAggregator.TriggeringLevel.HeapMemoryPanic);
+    assertFalse(aggregator.isPauseActive(), "Should not re-pause on Panic→Panic transition");
   }
 }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/CpuBasedBrokerQueryKillingIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/CpuBasedBrokerQueryKillingIntegrationTest.java
@@ -26,7 +26,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.apache.pinot.core.accounting.ResourceUsageAccountantFactory;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.exception.QueryErrorCode;
-import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.CommonConstants.Accounting;
 import org.testng.annotations.Test;
 
@@ -41,13 +40,13 @@ public class CpuBasedBrokerQueryKillingIntegrationTest extends BaseQueryKillingI
   protected void overrideBrokerConf(PinotConfiguration brokerConf) {
     super.overrideBrokerConf(brokerConf);
 
-    String prefix = CommonConstants.PINOT_QUERY_SCHEDULER_PREFIX + ".";
-    brokerConf.setProperty(prefix + Accounting.CONFIG_OF_FACTORY_NAME, ResourceUsageAccountantFactory.class.getName());
-    brokerConf.setProperty(prefix + Accounting.CONFIG_OF_ENABLE_THREAD_CPU_SAMPLING, true);
-    brokerConf.setProperty(prefix + Accounting.CONFIG_OF_CPU_TIME_BASED_KILLING_ENABLED, true);
-    brokerConf.setProperty(prefix + Accounting.CONFIG_OF_CPU_TIME_BASED_KILLING_THRESHOLD_MS, 500);
-    brokerConf.setProperty(prefix + Accounting.CONFIG_OF_CRITICAL_LEVEL_HEAP_USAGE_RATIO, 1.1f);
-    brokerConf.setProperty(prefix + Accounting.CONFIG_OF_PANIC_LEVEL_HEAP_USAGE_RATIO, 1.1f);
+    String prefix = Accounting.BROKER_PREFIX + ".";
+    brokerConf.setProperty(prefix + Accounting.Keys.FACTORY_NAME, ResourceUsageAccountantFactory.class.getName());
+    brokerConf.setProperty(prefix + Accounting.Keys.ENABLE_THREAD_CPU_SAMPLING, true);
+    brokerConf.setProperty(prefix + Accounting.Keys.CPU_TIME_BASED_KILLING_ENABLED, true);
+    brokerConf.setProperty(prefix + Accounting.Keys.CPU_TIME_BASED_KILLING_THRESHOLD_MS, 500);
+    brokerConf.setProperty(prefix + Accounting.Keys.CRITICAL_LEVEL_HEAP_USAGE_RATIO, 1.1f);
+    brokerConf.setProperty(prefix + Accounting.Keys.PANIC_LEVEL_HEAP_USAGE_RATIO, 1.1f);
   }
 
   @Test

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/CpuBasedServerQueryKillingIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/CpuBasedServerQueryKillingIntegrationTest.java
@@ -26,7 +26,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.apache.pinot.core.accounting.ResourceUsageAccountantFactory;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.exception.QueryErrorCode;
-import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.CommonConstants.Accounting;
 import org.testng.annotations.Test;
 
@@ -41,13 +40,13 @@ public class CpuBasedServerQueryKillingIntegrationTest extends BaseQueryKillingI
   protected void overrideServerConf(PinotConfiguration serverConf) {
     super.overrideServerConf(serverConf);
 
-    String prefix = CommonConstants.PINOT_QUERY_SCHEDULER_PREFIX + ".";
-    serverConf.setProperty(prefix + Accounting.CONFIG_OF_FACTORY_NAME, ResourceUsageAccountantFactory.class.getName());
-    serverConf.setProperty(prefix + Accounting.CONFIG_OF_ENABLE_THREAD_CPU_SAMPLING, true);
-    serverConf.setProperty(prefix + Accounting.CONFIG_OF_CPU_TIME_BASED_KILLING_ENABLED, true);
-    serverConf.setProperty(prefix + Accounting.CONFIG_OF_CPU_TIME_BASED_KILLING_THRESHOLD_MS, 500);
-    serverConf.setProperty(prefix + Accounting.CONFIG_OF_CRITICAL_LEVEL_HEAP_USAGE_RATIO, 1.1f);
-    serverConf.setProperty(prefix + Accounting.CONFIG_OF_PANIC_LEVEL_HEAP_USAGE_RATIO, 1.1f);
+    String prefix = Accounting.SERVER_PREFIX + ".";
+    serverConf.setProperty(prefix + Accounting.Keys.FACTORY_NAME, ResourceUsageAccountantFactory.class.getName());
+    serverConf.setProperty(prefix + Accounting.Keys.ENABLE_THREAD_CPU_SAMPLING, true);
+    serverConf.setProperty(prefix + Accounting.Keys.CPU_TIME_BASED_KILLING_ENABLED, true);
+    serverConf.setProperty(prefix + Accounting.Keys.CPU_TIME_BASED_KILLING_THRESHOLD_MS, 500);
+    serverConf.setProperty(prefix + Accounting.Keys.CRITICAL_LEVEL_HEAP_USAGE_RATIO, 1.1f);
+    serverConf.setProperty(prefix + Accounting.Keys.PANIC_LEVEL_HEAP_USAGE_RATIO, 1.1f);
   }
 
   @Test(dataProvider = "expensiveQueries")

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MemoryBasedServerQueryKillingIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MemoryBasedServerQueryKillingIntegrationTest.java
@@ -26,7 +26,6 @@ import java.util.concurrent.atomic.AtomicReference;
 import org.apache.pinot.core.accounting.ResourceUsageAccountantFactory;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.exception.QueryErrorCode;
-import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.CommonConstants.Accounting;
 import org.testng.annotations.Test;
 
@@ -41,12 +40,12 @@ public class MemoryBasedServerQueryKillingIntegrationTest extends BaseQueryKilli
   protected void overrideServerConf(PinotConfiguration serverConf) {
     super.overrideServerConf(serverConf);
 
-    String prefix = CommonConstants.PINOT_QUERY_SCHEDULER_PREFIX + ".";
-    serverConf.setProperty(prefix + Accounting.CONFIG_OF_FACTORY_NAME, ResourceUsageAccountantFactory.class.getName());
-    serverConf.setProperty(prefix + Accounting.CONFIG_OF_ENABLE_THREAD_MEMORY_SAMPLING, true);
-    serverConf.setProperty(prefix + Accounting.CONFIG_OF_OOM_PROTECTION_KILLING_QUERY, true);
-    serverConf.setProperty(prefix + Accounting.CONFIG_OF_ALARMING_LEVEL_HEAP_USAGE_RATIO, 0f);
-    serverConf.setProperty(prefix + Accounting.CONFIG_OF_CRITICAL_LEVEL_HEAP_USAGE_RATIO, 0.15f);
+    String prefix = Accounting.SERVER_PREFIX + ".";
+    serverConf.setProperty(prefix + Accounting.Keys.FACTORY_NAME, ResourceUsageAccountantFactory.class.getName());
+    serverConf.setProperty(prefix + Accounting.Keys.ENABLE_THREAD_MEMORY_SAMPLING, true);
+    serverConf.setProperty(prefix + Accounting.Keys.OOM_PROTECTION_KILLING_QUERY, true);
+    serverConf.setProperty(prefix + Accounting.Keys.ALARMING_LEVEL_HEAP_USAGE_RATIO, 0f);
+    serverConf.setProperty(prefix + Accounting.Keys.CRITICAL_LEVEL_HEAP_USAGE_RATIO, 0.15f);
   }
 
   @Test(dataProvider = "expensiveQueries")

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiNodesOfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiNodesOfflineClusterIntegrationTest.java
@@ -29,7 +29,7 @@ import org.apache.pinot.core.accounting.ResourceUsageAccountantFactory;
 import org.apache.pinot.server.starter.helix.BaseServerStarter;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.exception.QueryErrorCode;
-import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.CommonConstants.Accounting;
 import org.apache.pinot.spi.utils.CommonConstants.Broker;
 import org.apache.pinot.spi.utils.CommonConstants.Broker.FailureDetector;
 import org.apache.pinot.spi.utils.CommonConstants.Helix;
@@ -79,11 +79,10 @@ public class MultiNodesOfflineClusterIntegrationTest extends OfflineClusterInteg
     // Enable thread CPU/memory tracking but not killing queries
     brokerConf.setProperty(Broker.CONFIG_OF_ENABLE_THREAD_CPU_TIME_MEASUREMENT, true);
     brokerConf.setProperty(Broker.CONFIG_OF_ENABLE_THREAD_ALLOCATED_BYTES_MEASUREMENT, true);
-    String prefix = CommonConstants.PINOT_QUERY_SCHEDULER_PREFIX + ".";
-    brokerConf.setProperty(prefix + CommonConstants.Accounting.CONFIG_OF_FACTORY_NAME,
-        ResourceUsageAccountantFactory.class.getName());
-    brokerConf.setProperty(prefix + CommonConstants.Accounting.CONFIG_OF_ENABLE_THREAD_CPU_SAMPLING, true);
-    brokerConf.setProperty(prefix + CommonConstants.Accounting.CONFIG_OF_ENABLE_THREAD_MEMORY_SAMPLING, true);
+    String prefix = Accounting.BROKER_PREFIX + ".";
+    brokerConf.setProperty(prefix + Accounting.Keys.FACTORY_NAME, ResourceUsageAccountantFactory.class.getName());
+    brokerConf.setProperty(prefix + Accounting.Keys.ENABLE_THREAD_CPU_SAMPLING, true);
+    brokerConf.setProperty(prefix + Accounting.Keys.ENABLE_THREAD_MEMORY_SAMPLING, true);
   }
 
   @Override
@@ -93,11 +92,10 @@ public class MultiNodesOfflineClusterIntegrationTest extends OfflineClusterInteg
     // Enable thread CPU/memory tracking but not killing queries
     serverConf.setProperty(Server.CONFIG_OF_ENABLE_THREAD_CPU_TIME_MEASUREMENT, true);
     serverConf.setProperty(Server.CONFIG_OF_ENABLE_THREAD_ALLOCATED_BYTES_MEASUREMENT, true);
-    String prefix = CommonConstants.PINOT_QUERY_SCHEDULER_PREFIX + ".";
-    serverConf.setProperty(prefix + CommonConstants.Accounting.CONFIG_OF_FACTORY_NAME,
-        ResourceUsageAccountantFactory.class.getName());
-    serverConf.setProperty(prefix + CommonConstants.Accounting.CONFIG_OF_ENABLE_THREAD_CPU_SAMPLING, true);
-    serverConf.setProperty(prefix + CommonConstants.Accounting.CONFIG_OF_ENABLE_THREAD_MEMORY_SAMPLING, true);
+    String prefix = Accounting.SERVER_PREFIX + ".";
+    serverConf.setProperty(prefix + Accounting.Keys.FACTORY_NAME, ResourceUsageAccountantFactory.class.getName());
+    serverConf.setProperty(prefix + Accounting.Keys.ENABLE_THREAD_CPU_SAMPLING, true);
+    serverConf.setProperty(prefix + Accounting.Keys.ENABLE_THREAD_MEMORY_SAMPLING, true);
   }
 
   @Test

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineGRPCServerIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineGRPCServerIntegrationTest.java
@@ -109,10 +109,10 @@ public class OfflineGRPCServerIntegrationTest extends BaseClusterIntegrationTest
     // Enable thread CPU/memory tracking but not killing queries
     brokerConf.setProperty(Broker.CONFIG_OF_ENABLE_THREAD_CPU_TIME_MEASUREMENT, true);
     brokerConf.setProperty(Broker.CONFIG_OF_ENABLE_THREAD_ALLOCATED_BYTES_MEASUREMENT, true);
-    String prefix = CommonConstants.PINOT_QUERY_SCHEDULER_PREFIX + ".";
-    brokerConf.setProperty(prefix + Accounting.CONFIG_OF_FACTORY_NAME, ResourceUsageAccountantFactory.class.getName());
-    brokerConf.setProperty(prefix + Accounting.CONFIG_OF_ENABLE_THREAD_CPU_SAMPLING, true);
-    brokerConf.setProperty(prefix + Accounting.CONFIG_OF_ENABLE_THREAD_MEMORY_SAMPLING, true);
+    String prefix = Accounting.BROKER_PREFIX + ".";
+    brokerConf.setProperty(prefix + Accounting.Keys.FACTORY_NAME, ResourceUsageAccountantFactory.class.getName());
+    brokerConf.setProperty(prefix + Accounting.Keys.ENABLE_THREAD_CPU_SAMPLING, true);
+    brokerConf.setProperty(prefix + Accounting.Keys.ENABLE_THREAD_MEMORY_SAMPLING, true);
   }
 
   @Override
@@ -122,10 +122,10 @@ public class OfflineGRPCServerIntegrationTest extends BaseClusterIntegrationTest
     // Enable thread CPU/memory tracking but not killing queries
     serverConf.setProperty(CommonConstants.Server.CONFIG_OF_ENABLE_THREAD_CPU_TIME_MEASUREMENT, true);
     serverConf.setProperty(CommonConstants.Server.CONFIG_OF_ENABLE_THREAD_ALLOCATED_BYTES_MEASUREMENT, true);
-    String prefix = CommonConstants.PINOT_QUERY_SCHEDULER_PREFIX + ".";
-    serverConf.setProperty(prefix + Accounting.CONFIG_OF_FACTORY_NAME, ResourceUsageAccountantFactory.class.getName());
-    serverConf.setProperty(prefix + Accounting.CONFIG_OF_ENABLE_THREAD_CPU_SAMPLING, true);
-    serverConf.setProperty(prefix + Accounting.CONFIG_OF_ENABLE_THREAD_MEMORY_SAMPLING, true);
+    String prefix = Accounting.SERVER_PREFIX + ".";
+    serverConf.setProperty(prefix + Accounting.Keys.FACTORY_NAME, ResourceUsageAccountantFactory.class.getName());
+    serverConf.setProperty(prefix + Accounting.Keys.ENABLE_THREAD_CPU_SAMPLING, true);
+    serverConf.setProperty(prefix + Accounting.Keys.ENABLE_THREAD_MEMORY_SAMPLING, true);
   }
 
   public ServerGrpcQueryClient getGrpcQueryClient() {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/QueryWorkloadIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/QueryWorkloadIntegrationTest.java
@@ -42,6 +42,7 @@ import org.apache.pinot.spi.config.workload.QueryWorkloadConfig;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.CommonConstants.Accounting;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.util.TestUtils;
 import org.testng.annotations.AfterClass;
@@ -51,14 +52,14 @@ import org.testng.annotations.Test;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 
+
 public class QueryWorkloadIntegrationTest extends BaseClusterIntegrationTest {
   private static final int NUM_OFFLINE_SEGMENTS = 8;
   private static final int NUM_REALTIME_SEGMENTS = 6;
 
   @Override
   protected void overrideBrokerConf(PinotConfiguration configuration) {
-    configuration.setProperty(CommonConstants.PINOT_QUERY_SCHEDULER_PREFIX + "."
-        + CommonConstants.Accounting.CONFIG_OF_WORKLOAD_ENABLE_COST_COLLECTION, true);
+    configuration.setProperty(Accounting.BROKER_PREFIX + "." + Accounting.Keys.WORKLOAD_ENABLE_COST_COLLECTION, true);
     try {
       configuration.setProperty(CommonConstants.MultiStageQueryRunner.KEY_OF_QUERY_RUNNER_PORT,
           org.apache.pinot.spi.utils.NetUtils.findOpenPort());
@@ -69,8 +70,7 @@ public class QueryWorkloadIntegrationTest extends BaseClusterIntegrationTest {
 
   @Override
   protected void overrideServerConf(PinotConfiguration configuration) {
-    configuration.setProperty(CommonConstants.PINOT_QUERY_SCHEDULER_PREFIX + "."
-        + CommonConstants.Accounting.CONFIG_OF_WORKLOAD_ENABLE_COST_COLLECTION, true);
+    configuration.setProperty(Accounting.SERVER_PREFIX + "." + Accounting.Keys.WORKLOAD_ENABLE_COST_COLLECTION, true);
   }
 
   @BeforeClass
@@ -141,7 +141,8 @@ public class QueryWorkloadIntegrationTest extends BaseClusterIntegrationTest {
 
   // TODO: Expand tests to cover more scenarios for workload enforcement
   @Test
-  public void testQueryWorkloadConfig() throws Exception {
+  public void testQueryWorkloadConfig()
+      throws Exception {
     EnforcementProfile enforcementProfile = new EnforcementProfile(1000, 1000);
     PropagationEntity entity = new PropagationEntity(DEFAULT_TABLE_NAME + "_OFFLINE", 1000L, 1000L, null);
     PropagationScheme propagationScheme = new PropagationScheme(PropagationScheme.Type.TABLE, List.of(entity));
@@ -176,8 +177,8 @@ public class QueryWorkloadIntegrationTest extends BaseClusterIntegrationTest {
   /**
    * Test QueryWorkloadResource endpoints on a specific server instance for a specific workload
    */
-  private void testServerQueryWorkloadEndpoints(String serverInstance, String workloadName,
-                                                long expectedCpuBudgetNs, long expectedMemoryBudgetBytes)
+  private void testServerQueryWorkloadEndpoints(String serverInstance, String workloadName, long expectedCpuBudgetNs,
+      long expectedMemoryBudgetBytes)
       throws Exception {
     // Extract host from server instance name (format: Server_hostname_port)
     String[] parts = serverInstance.split("_");
@@ -202,7 +203,8 @@ public class QueryWorkloadIntegrationTest extends BaseClusterIntegrationTest {
   /**
    * Get the definitive list of server instances that serve a specific table
    */
-  private Set<String> getServerInstancesForTable(String tableName) throws Exception {
+  private Set<String> getServerInstancesForTable(String tableName)
+      throws Exception {
     // Use the controller API to get server instances for the specific table
     String response = getOrCreateAdminClient().getTableClient().getTableInstances(tableName, "server");
 
@@ -228,10 +230,8 @@ public class QueryWorkloadIntegrationTest extends BaseClusterIntegrationTest {
     constraints.add("constraints1");
     InstanceConstraintConfig instanceConstraintConfig = new InstanceConstraintConfig(constraints);
     InstanceReplicaGroupPartitionConfig instanceReplicaGroupPartitionConfig =
-        new InstanceReplicaGroupPartitionConfig(true, 1, 1,
-            1, 1, 1, minimizeDataMovement,
-            null);
-    return new InstanceAssignmentConfig(instanceTagPoolConfig,
-        instanceConstraintConfig, instanceReplicaGroupPartitionConfig, null, minimizeDataMovement);
+        new InstanceReplicaGroupPartitionConfig(true, 1, 1, 1, 1, 1, minimizeDataMovement, null);
+    return new InstanceAssignmentConfig(instanceTagPoolConfig, instanceConstraintConfig,
+        instanceReplicaGroupPartitionConfig, null, minimizeDataMovement);
   }
 }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/WindowResourceAccountingTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/WindowResourceAccountingTest.java
@@ -38,7 +38,6 @@ import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.query.QueryExecutionContext;
 import org.apache.pinot.spi.query.QueryThreadContext;
-import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.CommonConstants.Accounting;
 import org.apache.pinot.spi.utils.CommonConstants.Broker;
 import org.apache.pinot.spi.utils.CommonConstants.Server;
@@ -96,20 +95,20 @@ public class WindowResourceAccountingTest extends BaseClusterIntegrationTest {
   protected void overrideBrokerConf(PinotConfiguration brokerConf) {
     brokerConf.setProperty(Broker.CONFIG_OF_ENABLE_THREAD_ALLOCATED_BYTES_MEASUREMENT, true);
 
-    String prefix = CommonConstants.PINOT_QUERY_SCHEDULER_PREFIX + ".";
-    brokerConf.setProperty(prefix + Accounting.CONFIG_OF_FACTORY_NAME, TestAccountantFactory.class.getName());
-    brokerConf.setProperty(prefix + Accounting.CONFIG_OF_ENABLE_THREAD_MEMORY_SAMPLING, true);
-    brokerConf.setProperty(prefix + Accounting.CONFIG_OF_OOM_PROTECTION_KILLING_QUERY, true);
+    String prefix = Accounting.BROKER_PREFIX + ".";
+    brokerConf.setProperty(prefix + Accounting.Keys.FACTORY_NAME, TestAccountantFactory.class.getName());
+    brokerConf.setProperty(prefix + Accounting.Keys.ENABLE_THREAD_MEMORY_SAMPLING, true);
+    brokerConf.setProperty(prefix + Accounting.Keys.OOM_PROTECTION_KILLING_QUERY, true);
   }
 
   @Override
   protected void overrideServerConf(PinotConfiguration serverConf) {
     serverConf.setProperty(Server.CONFIG_OF_ENABLE_THREAD_ALLOCATED_BYTES_MEASUREMENT, true);
 
-    String prefix = CommonConstants.PINOT_QUERY_SCHEDULER_PREFIX + ".";
-    serverConf.setProperty(prefix + Accounting.CONFIG_OF_FACTORY_NAME, TestAccountantFactory.class.getName());
-    serverConf.setProperty(prefix + Accounting.CONFIG_OF_ENABLE_THREAD_MEMORY_SAMPLING, true);
-    serverConf.setProperty(prefix + Accounting.CONFIG_OF_ENABLE_THREAD_CPU_SAMPLING, false);
+    String prefix = Accounting.SERVER_PREFIX + ".";
+    serverConf.setProperty(prefix + Accounting.Keys.FACTORY_NAME, TestAccountantFactory.class.getName());
+    serverConf.setProperty(prefix + Accounting.Keys.ENABLE_THREAD_MEMORY_SAMPLING, true);
+    serverConf.setProperty(prefix + Accounting.Keys.ENABLE_THREAD_CPU_SAMPLING, false);
   }
 
   @BeforeClass

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkWorkloadBudgetManager.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkWorkloadBudgetManager.java
@@ -21,7 +21,7 @@ package org.apache.pinot.perf;
 import java.util.concurrent.TimeUnit;
 import org.apache.pinot.spi.accounting.WorkloadBudgetManager;
 import org.apache.pinot.spi.env.PinotConfiguration;
-import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.CommonConstants.Accounting;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Level;
@@ -60,8 +60,8 @@ public class BenchmarkWorkloadBudgetManager {
     @Setup(Level.Iteration)
     public void setup() {
       PinotConfiguration config = new PinotConfiguration();
-      config.setProperty(CommonConstants.Accounting.CONFIG_OF_WORKLOAD_ENABLE_COST_COLLECTION, true);
-      config.setProperty(CommonConstants.Accounting.CONFIG_OF_WORKLOAD_ENFORCEMENT_WINDOW_MS, Long.MAX_VALUE);
+      config.setProperty(Accounting.Keys.WORKLOAD_ENABLE_COST_COLLECTION, true);
+      config.setProperty(Accounting.Keys.WORKLOAD_ENFORCEMENT_WINDOW_MS, Long.MAX_VALUE);
 
       _manager = new WorkloadBudgetManager(config);
       _manager.addOrUpdateWorkload(WORKLOAD, Long.MAX_VALUE, Long.MAX_VALUE);

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
@@ -752,9 +752,10 @@ public abstract class BaseServerStarter implements ServiceStartable {
             Server.DEFAULT_THREAD_ALLOCATED_BYTES_MEASUREMENT));
     // Initialize workload budget manager and thread accountant. Workload budget manager must be initialized first
     // because it might be used by the accountant.
-    PinotConfiguration schedulerConfig = _serverConf.subset(CommonConstants.PINOT_QUERY_SCHEDULER_PREFIX);
-    WorkloadBudgetManager.set(createWorkloadBudgetManager(schedulerConfig));
-    _threadAccountant = ThreadAccountantUtils.createAccountant(schedulerConfig, _instanceId,
+    PinotConfiguration accountingConfig = ThreadAccountantUtils.extractAccountingConfig(_serverConf,
+        org.apache.pinot.spi.config.instance.InstanceType.SERVER);
+    WorkloadBudgetManager.set(createWorkloadBudgetManager(accountingConfig));
+    _threadAccountant = ThreadAccountantUtils.createAccountant(accountingConfig, _instanceId,
         org.apache.pinot.spi.config.instance.InstanceType.SERVER);
 
     SendStatsPredicate sendStatsPredicate = SendStatsPredicate.create(_serverConf, _helixManager);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/accounting/ThreadAccountantUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/accounting/ThreadAccountantUtils.java
@@ -19,8 +19,11 @@
 package org.apache.pinot.spi.accounting;
 
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.apache.pinot.spi.config.instance.InstanceType;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.query.QueryThreadContext;
@@ -35,11 +38,101 @@ public class ThreadAccountantUtils {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(ThreadAccountantUtils.class);
 
+  /// Extracts the accounting config subset for the given instance type, merging the legacy shared prefix
+  /// [Accounting#COMMON_PREFIX] with the role-specific prefix
+  /// ([Accounting#BROKER_PREFIX] / [Accounting#SERVER_PREFIX]).
+  /// Role-specific values win on conflict.
+  /// Keys in the returned config are stripped of the accounting prefix (e.g. `oom.enable.killing.query`) and are
+  /// expected to match [Accounting.Keys].
+  /// Only BROKER and SERVER instance types are supported.
+  public static PinotConfiguration extractAccountingConfig(PinotConfiguration fullConfig, InstanceType instanceType) {
+    PinotConfiguration legacy = fullConfig.subset(Accounting.COMMON_PREFIX);
+    PinotConfiguration override = fullConfig.subset(getRoleAccountingPrefix(instanceType));
+    if (override.isEmpty()) {
+      return legacy;
+    }
+    Map<String, Object> merged = new HashMap<>(legacy.toMap());
+    merged.putAll(override.toMap());
+    return new PinotConfiguration(merged);
+  }
+
+  /// Returns the role-specific accounting config prefix (no trailing dot).
+  /// Only BROKER and SERVER are supported; any other instance type throws [IllegalStateException].
+  public static String getRoleAccountingPrefix(InstanceType instanceType) {
+    switch (instanceType) {
+      case BROKER:
+        return Accounting.BROKER_PREFIX;
+      case SERVER:
+        return Accounting.SERVER_PREFIX;
+      default:
+        throw new IllegalStateException("Unsupported instance type for query accounting config: " + instanceType);
+    }
+  }
+
+  /// Filtered and normalized cluster config change payload used by accounting listeners. Keys are stripped to the
+  /// accounting-local form (e.g. `oom.enable.killing.query`, matching [Accounting.Keys]). Values from the role-specific
+  /// prefix take precedence over values from the legacy shared prefix.
+  public static class AccountingConfigChange {
+    private final Set<String> _changedConfigs;
+    private final Map<String, String> _clusterConfigs;
+
+    public AccountingConfigChange(Set<String> changedConfigs, Map<String, String> clusterConfigs) {
+      _changedConfigs = changedConfigs;
+      _clusterConfigs = clusterConfigs;
+    }
+
+    public Set<String> getChangedConfigs() {
+      return _changedConfigs;
+    }
+
+    public Map<String, String> getClusterConfigs() {
+      return _clusterConfigs;
+    }
+
+    public boolean isEmpty() {
+      return _changedConfigs.isEmpty();
+    }
+  }
+
+  /// Filters and normalizes a cluster config change event for the accountant listener of the given instance type.
+  /// Accepts keys under both the legacy [Accounting#COMMON_PREFIX] and the role-specific prefix
+  /// ([Accounting#BROKER_PREFIX] / [Accounting#SERVER_PREFIX]); role-specific values win on conflict.
+  public static AccountingConfigChange filterAccountingConfigChange(Set<String> changedConfigs,
+      Map<String, String> clusterConfigs, InstanceType instanceType) {
+    String legacyPrefixDot = Accounting.COMMON_PREFIX + ".";
+    String rolePrefixDot = getRoleAccountingPrefix(instanceType) + ".";
+
+    Set<String> filteredChanged = new HashSet<>();
+    for (String key : changedConfigs) {
+      if (key.startsWith(legacyPrefixDot)) {
+        filteredChanged.add(key.substring(legacyPrefixDot.length()));
+      } else if (key.startsWith(rolePrefixDot)) {
+        filteredChanged.add(key.substring(rolePrefixDot.length()));
+      }
+    }
+
+    Map<String, String> filteredClusterConfigs = new HashMap<>();
+    // Legacy values first, then role-specific values overwrite on conflict.
+    for (Map.Entry<String, String> entry : clusterConfigs.entrySet()) {
+      String key = entry.getKey();
+      if (key.startsWith(legacyPrefixDot)) {
+        filteredClusterConfigs.put(key.substring(legacyPrefixDot.length()), entry.getValue());
+      }
+    }
+    for (Map.Entry<String, String> entry : clusterConfigs.entrySet()) {
+      String key = entry.getKey();
+      if (key.startsWith(rolePrefixDot)) {
+        filteredClusterConfigs.put(key.substring(rolePrefixDot.length()), entry.getValue());
+      }
+    }
+    return new AccountingConfigChange(filteredChanged, filteredClusterConfigs);
+  }
+
   /// Creates a thread accountant based on the factory class name in the config. If no factory class name is specified,
   /// or if any exception is thrown while loading the factory class, returns a no-op accountant.
   public static ThreadAccountant createAccountant(PinotConfiguration config, String instanceId,
       InstanceType instanceType) {
-    String factoryName = config.getProperty(Accounting.CONFIG_OF_FACTORY_NAME);
+    String factoryName = config.getProperty(Accounting.Keys.FACTORY_NAME);
     if (factoryName != null) {
       LOGGER.info("Initializing ThreadAccountant with factory: {}", factoryName);
       try {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/accounting/WorkloadBudgetManager.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/accounting/WorkloadBudgetManager.java
@@ -25,7 +25,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.pinot.spi.env.PinotConfiguration;
-import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.CommonConstants.Accounting;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,25 +44,32 @@ public class WorkloadBudgetManager {
     return _instance;
   }
 
+  private final String _secondaryWorkloadName;
   private long _enforcementWindowMs;
   private ConcurrentHashMap<String, Budget> _workloadBudgets;
   private final ScheduledExecutorService _resetScheduler = Executors.newSingleThreadScheduledExecutor();
   private volatile boolean _enabled;
 
-  public WorkloadBudgetManager(PinotConfiguration config) {
-    _enabled = config.getProperty(CommonConstants.Accounting.CONFIG_OF_WORKLOAD_ENABLE_COST_COLLECTION,
-        CommonConstants.Accounting.DEFAULT_WORKLOAD_ENABLE_COST_COLLECTION);
+  public WorkloadBudgetManager(PinotConfiguration accountingConfig) {
+    _secondaryWorkloadName = accountingConfig.getProperty(Accounting.Keys.SECONDARY_WORKLOAD_NAME,
+        Accounting.DEFAULT_SECONDARY_WORKLOAD_NAME);
+    _enabled = accountingConfig.getProperty(Accounting.Keys.WORKLOAD_ENABLE_COST_COLLECTION,
+        Accounting.DEFAULT_WORKLOAD_ENABLE_COST_COLLECTION);
     // Return an object even if disabled. All functionalities of this class will be noops.
     if (!_enabled) {
       LOGGER.info("WorkloadBudgetManager is disabled. Creating a no-op instance.");
       return;
     }
     _workloadBudgets = new ConcurrentHashMap<>();
-    _enforcementWindowMs = config.getProperty(CommonConstants.Accounting.CONFIG_OF_WORKLOAD_ENFORCEMENT_WINDOW_MS,
-        CommonConstants.Accounting.DEFAULT_WORKLOAD_ENFORCEMENT_WINDOW_MS);
-    initSecondaryWorkloadBudget(config);
+    _enforcementWindowMs = accountingConfig.getProperty(Accounting.Keys.WORKLOAD_ENFORCEMENT_WINDOW_MS,
+        Accounting.DEFAULT_WORKLOAD_ENFORCEMENT_WINDOW_MS);
+    initSecondaryWorkloadBudget(accountingConfig);
     startBudgetResetTask();
     LOGGER.info("WorkloadBudgetManager initialized with enforcement window: {}ms", _enforcementWindowMs);
+  }
+
+  public String getSecondaryWorkloadName() {
+    return _secondaryWorkloadName;
   }
 
   public boolean isEnabled() {
@@ -74,18 +81,13 @@ public class WorkloadBudgetManager {
    * This is fixed budget allocated during host startup and used across all secondary queries.
    */
   private void initSecondaryWorkloadBudget(PinotConfiguration config) {
-    double secondaryCpuPercentage = config.getProperty(
-        CommonConstants.Accounting.CONFIG_OF_SECONDARY_WORKLOAD_CPU_PERCENTAGE,
-        CommonConstants.Accounting.DEFAULT_SECONDARY_WORKLOAD_CPU_PERCENTAGE);
+    double secondaryCpuPercentage = config.getProperty(Accounting.Keys.SECONDARY_WORKLOAD_CPU_PERCENTAGE,
+        Accounting.DEFAULT_SECONDARY_WORKLOAD_CPU_PERCENTAGE);
 
     // Don't create a secondary workload if cpu percentage is non-zero.
     if (secondaryCpuPercentage <= 0.0) {
       return;
     }
-
-    String secondaryWorkloadName = config.getProperty(
-        CommonConstants.Accounting.CONFIG_OF_SECONDARY_WORKLOAD_NAME,
-        CommonConstants.Accounting.DEFAULT_SECONDARY_WORKLOAD_NAME);
 
     // The Secondary CPU budget is based on the CPU percentage allocated for secondary workload.
     // The memory budget is set to Long.MAX_VALUE for now, since we do not have a specific memory budget for
@@ -96,7 +98,7 @@ public class WorkloadBudgetManager {
     long totalCpuCapacityNs = _enforcementWindowMs * 1_000_000L * availableProcessors;
     long secondaryCpuBudget = (long) (secondaryCpuPercentage * totalCpuCapacityNs);
     // TODO: Add memory budget for secondary workload queries
-    addOrUpdateWorkload(secondaryWorkloadName, secondaryCpuBudget, Long.MAX_VALUE);
+    addOrUpdateWorkload(_secondaryWorkloadName, secondaryCpuBudget, Long.MAX_VALUE);
   }
 
   public void shutdown() {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -1710,114 +1710,152 @@ public class CommonConstants {
     public static final String NUM_CONSUMING_SEGMENTS_YET_TO_BE_COMMITTED = "numberOfSegmentsYetToBeCommitted";
   }
 
-  // prefix for scheduler related features, e.g. query accountant
+  // Prefix for query scheduler related features
   public static final String PINOT_QUERY_SCHEDULER_PREFIX = "pinot.query.scheduler";
 
   public static class Accounting {
-    public static final String CONFIG_OF_FACTORY_NAME = "accounting.factory.name";
+    /// Shared prefix for accounting configs. Values under this prefix applies to both brokers and servers.
+    public static final String COMMON_PREFIX = "pinot.query.scheduler.accounting";
+    /// Broker-specific accounting config prefix. Values under this prefix override values under [#COMMON_PREFIX] on the
+    /// broker.
+    public static final String BROKER_PREFIX = "pinot.broker.query.accounting";
+    /// Server-specific accounting config prefix. Values under this prefix override values under [#COMMON_PREFIX] on the
+    /// server.
+    public static final String SERVER_PREFIX = "pinot.server.query.accounting";
 
-    public static final String CONFIG_OF_ENABLE_THREAD_CPU_SAMPLING = "accounting.enable.thread.cpu.sampling";
-    public static final Boolean DEFAULT_ENABLE_THREAD_CPU_SAMPLING = false;
+    /// Config keys within the accounting scope (i.e. the suffix after one of [#COMMON_PREFIX], [#BROKER_PREFIX], or
+    /// [#SERVER_PREFIX]). Use these when reading from a config subsetted to the accounting scope.
+    public static class Keys {
+      public static final String FACTORY_NAME = "factory.name";
+      public static final String ENABLE_THREAD_CPU_SAMPLING = "enable.thread.cpu.sampling";
+      public static final String ENABLE_THREAD_MEMORY_SAMPLING = "enable.thread.memory.sampling";
+      public static final String OOM_PROTECTION_KILLING_QUERY = "oom.enable.killing.query";
+      public static final String PUBLISHING_JVM_USAGE = "publishing.jvm.heap.usage";
+      public static final String CPU_TIME_BASED_KILLING_ENABLED = "cpu.time.based.killing.enabled";
+      public static final String CPU_TIME_BASED_KILLING_THRESHOLD_MS = "cpu.time.based.killing.threshold.ms";
+      public static final String PANIC_LEVEL_HEAP_USAGE_RATIO = "oom.panic.heap.usage.ratio";
+      public static final String CRITICAL_LEVEL_HEAP_USAGE_RATIO = "oom.critical.heap.usage.ratio";
+      public static final String ALARMING_LEVEL_HEAP_USAGE_RATIO = "oom.alarming.usage.ratio";
+      public static final String HEAP_USAGE_PUBLISHING_PERIOD_MS = "heap.usage.publishing.period.ms";
+      public static final String SLEEP_TIME_MS = "sleep.ms";
+      public static final String SLEEP_TIME_DENOMINATOR = "sleep.time.denominator";
+      public static final String MIN_MEMORY_FOOTPRINT_TO_KILL_RATIO = "min.memory.footprint.to.kill.ratio";
+      public static final String QUERY_KILLED_METRIC_ENABLED = "query.killed.metric.enabled";
+      public static final String OOM_PRE_QUERY_KILL_PAUSE_DURATION_MS = "oom.pre.query.kill.pause.duration.ms";
+      public static final String OOM_PANIC_ALLOW_PRE_QUERY_KILL_PAUSE = "oom.panic.allow.pre.query.kill.pause";
 
-    public static final String CONFIG_OF_ENABLE_THREAD_MEMORY_SAMPLING = "accounting.enable.thread.memory.sampling";
-    public static final Boolean DEFAULT_ENABLE_THREAD_MEMORY_SAMPLING = false;
+      /// QUERY WORKLOAD ISOLATION Configs
+      ///
+      /// This is a set of configs to enable query workload isolation. Queries are classified into workload based on the
+      /// QueryOption - WORKLOAD_NAME. The CPU and Memory cost for a workload are set globally in ZK. The CPU and memory
+      /// costs are for a certain time duration, called "enforcementWindow". The workload cost is split into smaller
+      /// cost for each instance involved in executing queries of the workload.
+      ///
+      /// At each instance (broker,server), there are two parts to workload isolation:
+      /// 1. Workload Cost Collection
+      /// 2. Workload Cost Enforcement
+      ///
+      /// Workload Cost collection happens at various stages of query execution. On server, the resource costs
+      /// associated with pruning, planning and execution are collected. On broker, the resource costs associated with
+      /// compilation & reduce are collected. WorkloadBudgetManager maintains the budget and usage for each workload in
+      /// the instance.
+      ///
+      /// Workload Enforcement enforces the budget for a workload if the resource usages are exceeded. The queries in
+      /// the workload are killed until the enforcementWindow is refreshed.
+      ///
+      /// More details in the [Design Doc](https://tinyurl.com/2p9vuzbd)
+      ///
+      /// Pre-req configs for enabling Query Workload Isolation:
+      ///  - CommonConstants.Accounting.Keys.FACTORY_NAME = ResourceUsageAccountantFactory
+      ///  - CommonConstants.Accounting.Keys.ENABLE_THREAD_CPU_SAMPLING = true
+      ///  - CommonConstants.Accounting.Keys.ENABLE_THREAD_MEMORY_SAMPLING = true
+      ///  - CommonConstants.Accounting.Keys.ENABLE_THREAD_SAMPLING_MSE = true
+      ///  - Instance Config: enableThreadCpuTimeMeasurement = true
+      ///  - Instance Config: enableThreadAllocatedBytesMeasurement = true
+      public static final String WORKLOAD_ENABLE_COST_COLLECTION = "workload.enable.cost.collection";
+      public static final String WORKLOAD_ENABLE_COST_ENFORCEMENT = "workload.enable.cost.enforcement";
+      public static final String WORKLOAD_ENFORCEMENT_WINDOW_MS = "workload.enforcement.window.ms";
+      public static final String WORKLOAD_SLEEP_TIME_MS = "workload.sleep.time.ms";
+      public static final String SECONDARY_WORKLOAD_NAME = "secondary.workload.name";
+      public static final String SECONDARY_WORKLOAD_CPU_PERCENTAGE = "secondary.workload.cpu.percentage";
+    }
 
-    public static final String CONFIG_OF_OOM_PROTECTION_KILLING_QUERY = "accounting.oom.enable.killing.query";
+    public static final boolean DEFAULT_ENABLE_THREAD_CPU_SAMPLING = false;
+    public static final boolean DEFAULT_ENABLE_THREAD_MEMORY_SAMPLING = false;
     public static final boolean DEFAULT_ENABLE_OOM_PROTECTION_KILLING_QUERY = false;
-
-    public static final String CONFIG_OF_PUBLISHING_JVM_USAGE = "accounting.publishing.jvm.heap.usage";
     public static final boolean DEFAULT_PUBLISHING_JVM_USAGE = false;
-
-    public static final String CONFIG_OF_CPU_TIME_BASED_KILLING_ENABLED = "accounting.cpu.time.based.killing.enabled";
     public static final boolean DEFAULT_CPU_TIME_BASED_KILLING_ENABLED = false;
+    public static final int DEFAULT_CPU_TIME_BASED_KILLING_THRESHOLD_MS = 30_000;
+    public static final float DEFAULT_PANIC_LEVEL_HEAP_USAGE_RATIO = 0.99f;
+    public static final float DEFAULT_CRITICAL_LEVEL_HEAP_USAGE_RATIO = 0.96f;
+    public static final float DEFAULT_ALARMING_LEVEL_HEAP_USAGE_RATIO = 0.75f;
+    public static final int DEFAULT_HEAP_USAGE_PUBLISH_PERIOD = 5000;
+    public static final int DEFAULT_SLEEP_TIME_MS = 30;
+    public static final int DEFAULT_SLEEP_TIME_DENOMINATOR = 3;
+    public static final double DEFAULT_MEMORY_FOOTPRINT_TO_KILL_RATIO = 0.025;
+    public static final boolean DEFAULT_QUERY_KILLED_METRIC_ENABLED = false;
+    public static final long DEFAULT_OOM_PRE_QUERY_KILL_PAUSE_DURATION_MS = -1;
+    public static final boolean DEFAULT_OOM_PANIC_PRE_QUERY_KILL_PAUSE_ENABLED = false;
+    public static final boolean DEFAULT_WORKLOAD_ENABLE_COST_COLLECTION = false;
+    public static final boolean DEFAULT_WORKLOAD_ENABLE_COST_ENFORCEMENT = false;
+    public static final long DEFAULT_WORKLOAD_ENFORCEMENT_WINDOW_MS = 60_000L;
+    public static final int DEFAULT_WORKLOAD_SLEEP_TIME_MS = 100;
+    public static final String DEFAULT_WORKLOAD_NAME = "default";
+    public static final String DEFAULT_SECONDARY_WORKLOAD_NAME = "defaultSecondary";
+    public static final double DEFAULT_SECONDARY_WORKLOAD_CPU_PERCENTAGE = 0.0;
 
+    @Deprecated(since = "1.6.0", forRemoval = true)
+    public static final String CONFIG_OF_FACTORY_NAME = "accounting.factory.name";
+    @Deprecated(since = "1.6.0", forRemoval = true)
+    public static final String CONFIG_OF_ENABLE_THREAD_CPU_SAMPLING = "accounting.enable.thread.cpu.sampling";
+    @Deprecated(since = "1.6.0", forRemoval = true)
+    public static final String CONFIG_OF_ENABLE_THREAD_MEMORY_SAMPLING = "accounting.enable.thread.memory.sampling";
+    @Deprecated(since = "1.6.0", forRemoval = true)
+    public static final String CONFIG_OF_OOM_PROTECTION_KILLING_QUERY = "accounting.oom.enable.killing.query";
+    @Deprecated(since = "1.6.0", forRemoval = true)
+    public static final String CONFIG_OF_PUBLISHING_JVM_USAGE = "accounting.publishing.jvm.heap.usage";
+    @Deprecated(since = "1.6.0", forRemoval = true)
+    public static final String CONFIG_OF_CPU_TIME_BASED_KILLING_ENABLED = "accounting.cpu.time.based.killing.enabled";
+    @Deprecated(since = "1.6.0", forRemoval = true)
     public static final String CONFIG_OF_CPU_TIME_BASED_KILLING_THRESHOLD_MS =
         "accounting.cpu.time.based.killing.threshold.ms";
-    public static final int DEFAULT_CPU_TIME_BASED_KILLING_THRESHOLD_MS = 30_000;
-
+    @Deprecated(since = "1.6.0", forRemoval = true)
     public static final String CONFIG_OF_PANIC_LEVEL_HEAP_USAGE_RATIO = "accounting.oom.panic.heap.usage.ratio";
-    public static final float DEFAULT_PANIC_LEVEL_HEAP_USAGE_RATIO = 0.99f;
-
+    @Deprecated(since = "1.6.0", forRemoval = true)
     public static final String CONFIG_OF_CRITICAL_LEVEL_HEAP_USAGE_RATIO = "accounting.oom.critical.heap.usage.ratio";
-    public static final float DEFAULT_CRITICAL_LEVEL_HEAP_USAGE_RATIO = 0.96f;
-
+    @Deprecated(since = "1.6.0", forRemoval = true)
     public static final String CONFIG_OF_ALARMING_LEVEL_HEAP_USAGE_RATIO = "accounting.oom.alarming.usage.ratio";
-    public static final float DEFAULT_ALARMING_LEVEL_HEAP_USAGE_RATIO = 0.75f;
-
+    @Deprecated(since = "1.6.0", forRemoval = true)
     public static final String CONFIG_OF_HEAP_USAGE_PUBLISHING_PERIOD_MS = "accounting.heap.usage.publishing.period.ms";
-    public static final int DEFAULT_HEAP_USAGE_PUBLISH_PERIOD = 5000;
-
+    @Deprecated(since = "1.6.0", forRemoval = true)
     public static final String CONFIG_OF_SLEEP_TIME_MS = "accounting.sleep.ms";
-    public static final int DEFAULT_SLEEP_TIME_MS = 30;
-
+    @Deprecated(since = "1.6.0", forRemoval = true)
     public static final String CONFIG_OF_SLEEP_TIME_DENOMINATOR = "accounting.sleep.time.denominator";
-    public static final int DEFAULT_SLEEP_TIME_DENOMINATOR = 3;
-
+    @Deprecated(since = "1.6.0", forRemoval = true)
     public static final String CONFIG_OF_MIN_MEMORY_FOOTPRINT_TO_KILL_RATIO =
         "accounting.min.memory.footprint.to.kill.ratio";
-    public static final double DEFAULT_MEMORY_FOOTPRINT_TO_KILL_RATIO = 0.025;
-
+    @Deprecated(since = "1.6.0", forRemoval = true)
     public static final String CONFIG_OF_QUERY_KILLED_METRIC_ENABLED = "accounting.query.killed.metric.enabled";
-    public static final boolean DEFAULT_QUERY_KILLED_METRIC_ENABLED = false;
-
+    @Deprecated(since = "1.6.0", forRemoval = true)
     public static final String CONFIG_OF_OOM_PRE_QUERY_KILL_PAUSE_DURATION_MS =
         "accounting.oom.pre.query.kill.pause.duration.ms";
-    public static final long DEFAULT_OOM_PRE_QUERY_KILL_PAUSE_DURATION_MS = -1;
-
+    @Deprecated(since = "1.6.0", forRemoval = true)
     public static final String CONFIG_OF_OOM_PANIC_ALLOW_PRE_QUERY_KILL_PAUSE =
         "accounting.oom.panic.allow.pre.query.kill.pause";
-    public static final boolean DEFAULT_OOM_PANIC_PRE_QUERY_KILL_PAUSE_ENABLED = false;
-
-    /**
-     * QUERY WORKLOAD ISOLATION Configs
-     *
-     * This is a set of configs to enable query workload isolation. Queries are classified into workload based on the
-     * QueryOption - WORKLOAD_NAME. The CPU and Memory cost for a workload are set globally in ZK. The CPU and memory
-     * costs are for a certain time duration, called "enforcementWindow". The workload cost is split into smaller cost
-     * for each instance involved in executing queries of the workload.
-     *
-     *
-     * At each instance (broker,server), there are two parts to workload isolation:
-     * 1. Workload Cost Collection
-     * 2. Workload Cost Enforcement
-     *
-     *
-     * Workload Cost collection happens at various stages of query execution. On server, the resource costs associated
-     * with pruning, planning and execution are collected. On broker, the resource costs associated with compilation &
-     * reduce are collected. WorkloadBudgetManager maintains the budget and usage for each workload in the instance.
-     * Workload Enforcement enforces the budget for a workload if the resource usages are exceeded. The queries in the
-     * workload are killed until the enforcementWindow is refreshed.
-     *
-     * More details in https://tinyurl.com/2p9vuzbd
-     *
-     * Pre-req configs for enabling Query Workload Isolation:
-     *  - CommonConstants.Accounting.CONFIG_OF_FACTORY_NAME  = ResourceUsageAccountantFactory
-     *  - CommonConstants.Accounting.CONFIG_OF_ENABLE_THREAD_CPU_SAMPLING = true
-     *  - CommonConstants.Accounting.CONFIG_OF_ENABLE_THREAD_MEMORY_SAMPLING = true
-     *  - CommonConstants.Accounting.CONFIG_OF_ENABLE_THREAD_SAMPLING_MSE = true
-     *  - Instance Config: enableThreadCpuTimeMeasurement = true
-     *  - Instance Config: enableThreadAllocatedBytesMeasurement = true
-     */
-
+    @Deprecated(since = "1.6.0", forRemoval = true)
     public static final String CONFIG_OF_WORKLOAD_ENABLE_COST_COLLECTION = "accounting.workload.enable.cost.collection";
-    public static final boolean DEFAULT_WORKLOAD_ENABLE_COST_COLLECTION = false;
-
+    @Deprecated(since = "1.6.0", forRemoval = true)
     public static final String CONFIG_OF_WORKLOAD_ENABLE_COST_ENFORCEMENT =
         "accounting.workload.enable.cost.enforcement";
-    public static final boolean DEFAULT_WORKLOAD_ENABLE_COST_ENFORCEMENT = false;
-
+    @Deprecated(since = "1.6.0", forRemoval = true)
     public static final String CONFIG_OF_WORKLOAD_ENFORCEMENT_WINDOW_MS = "accounting.workload.enforcement.window.ms";
-    public static final long DEFAULT_WORKLOAD_ENFORCEMENT_WINDOW_MS = 60_000L;
-
+    @Deprecated(since = "1.6.0", forRemoval = true)
     public static final String CONFIG_OF_WORKLOAD_SLEEP_TIME_MS = "accounting.workload.sleep.time.ms";
-    public static final int DEFAULT_WORKLOAD_SLEEP_TIME_MS = 100;
-
-    public static final String DEFAULT_WORKLOAD_NAME = "default";
+    @Deprecated(since = "1.6.0", forRemoval = true)
     public static final String CONFIG_OF_SECONDARY_WORKLOAD_NAME = "accounting.secondary.workload.name";
-    public static final String DEFAULT_SECONDARY_WORKLOAD_NAME = "defaultSecondary";
+    @Deprecated(since = "1.6.0", forRemoval = true)
     public static final String CONFIG_OF_SECONDARY_WORKLOAD_CPU_PERCENTAGE =
         "accounting.secondary.workload.cpu.percentage";
-    public static final double DEFAULT_SECONDARY_WORKLOAD_CPU_PERCENTAGE = 0.0;
   }
 
   public static class ExecutorService {

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/accounting/WorkloadBudgetManagerTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/accounting/WorkloadBudgetManagerTest.java
@@ -22,7 +22,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.apache.pinot.spi.env.PinotConfiguration;
-import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.CommonConstants.Accounting;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -38,8 +38,8 @@ public class WorkloadBudgetManagerTest {
   @BeforeClass
   void setup() {
     _config = new PinotConfiguration();
-    _config.setProperty(CommonConstants.Accounting.CONFIG_OF_WORKLOAD_ENABLE_COST_COLLECTION, true);
-    _config.setProperty(CommonConstants.Accounting.CONFIG_OF_WORKLOAD_ENFORCEMENT_WINDOW_MS, _enforcementWindowMs);
+    _config.setProperty(Accounting.Keys.WORKLOAD_ENABLE_COST_COLLECTION, true);
+    _config.setProperty(Accounting.Keys.WORKLOAD_ENFORCEMENT_WINDOW_MS, _enforcementWindowMs);
   }
 
   @Test

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/utils/PinotConfigUtils.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/utils/PinotConfigUtils.java
@@ -32,9 +32,10 @@ import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.ControllerConf.ControllerPeriodicTasksConf;
-import org.apache.pinot.core.accounting.PerQueryCPUMemAccountantFactory;
+import org.apache.pinot.core.accounting.ResourceUsageAccountantFactory;
 import org.apache.pinot.spi.env.CommonsConfigurationUtils;
 import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.CommonConstants.Accounting;
 import org.apache.pinot.spi.utils.NetUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -228,18 +229,12 @@ public class PinotConfigUtils {
     configOverrides.put(CommonConstants.Server.CONFIG_OF_ENABLE_THREAD_ALLOCATED_BYTES_MEASUREMENT, true);
     configOverrides.put(CommonConstants.Broker.CONFIG_OF_ENABLE_THREAD_CPU_TIME_MEASUREMENT, true);
     configOverrides.put(CommonConstants.Broker.CONFIG_OF_ENABLE_THREAD_ALLOCATED_BYTES_MEASUREMENT, true);
-    configOverrides.put(CommonConstants.Accounting.CONFIG_OF_ENABLE_THREAD_CPU_SAMPLING, true);
-    configOverrides.put(CommonConstants.Accounting.CONFIG_OF_ENABLE_THREAD_MEMORY_SAMPLING, true);
 
-    configOverrides.put(
-        CommonConstants.PINOT_QUERY_SCHEDULER_PREFIX + "." + CommonConstants.Accounting.CONFIG_OF_FACTORY_NAME,
-        PerQueryCPUMemAccountantFactory.class.getCanonicalName());
-    configOverrides.put(CommonConstants.PINOT_QUERY_SCHEDULER_PREFIX + "."
-        + CommonConstants.Accounting.CONFIG_OF_ENABLE_THREAD_MEMORY_SAMPLING, true);
-    configOverrides.put(CommonConstants.PINOT_QUERY_SCHEDULER_PREFIX + "."
-        + CommonConstants.Accounting.CONFIG_OF_ENABLE_THREAD_CPU_SAMPLING, false);
-    configOverrides.put(CommonConstants.PINOT_QUERY_SCHEDULER_PREFIX + "."
-        + CommonConstants.Accounting.CONFIG_OF_OOM_PROTECTION_KILLING_QUERY, true);
+    String prefix = Accounting.COMMON_PREFIX + ".";
+    configOverrides.put(prefix + Accounting.Keys.FACTORY_NAME, ResourceUsageAccountantFactory.class.getName());
+    configOverrides.put(prefix + Accounting.Keys.ENABLE_THREAD_MEMORY_SAMPLING, true);
+    configOverrides.put(prefix + Accounting.Keys.ENABLE_THREAD_CPU_SAMPLING, false);
+    configOverrides.put(prefix + Accounting.Keys.OOM_PROTECTION_KILLING_QUERY, true);
     return configOverrides;
   }
 

--- a/pinot-tools/src/test/java/org/apache/pinot/tools/utils/PinotConfigUtilsTest.java
+++ b/pinot-tools/src/test/java/org/apache/pinot/tools/utils/PinotConfigUtilsTest.java
@@ -27,7 +27,6 @@ import java.util.Map;
 import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.controller.ControllerConf;
-import org.apache.pinot.spi.utils.CommonConstants;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
@@ -74,34 +73,6 @@ public class PinotConfigUtilsTest {
       throws SocketException, UnknownHostException {
     PinotConfigUtils.generateControllerConf(
         "localhost:2181", "", "localhost", "9000", "/tmp/pinot", ControllerConf.ControllerMode.DUAL, true);
-  }
-
-  @Test
-  public void testGenerateMinionConf()
-      throws SocketException, UnknownHostException {
-    String clusterName = "testCluster";
-    String zkAddress = "localhost:2181";
-    String minionHost = "localhost";
-    int minionPort = 9000;
-
-    Map<String, Object> config = PinotConfigUtils.generateMinionConf(clusterName, zkAddress, minionHost, minionPort);
-
-    assertEquals(config.get(CommonConstants.Helix.CONFIG_OF_CLUSTER_NAME), clusterName);
-    assertEquals(config.get(CommonConstants.Helix.CONFIG_OF_ZOOKEEPR_SERVER), zkAddress);
-    assertEquals(config.get(CommonConstants.Helix.KEY_OF_MINION_HOST), minionHost);
-    assertEquals(config.get(CommonConstants.Helix.KEY_OF_MINION_PORT), minionPort);
-  }
-
-  @Test
-  public void testGetResourceTrackingConf() {
-    Map<String, Object> config = PinotConfigUtils.getResourceTrackingConf();
-
-    assertTrue((Boolean) config.get(CommonConstants.Server.CONFIG_OF_ENABLE_THREAD_CPU_TIME_MEASUREMENT));
-    assertTrue((Boolean) config.get(CommonConstants.Server.CONFIG_OF_ENABLE_THREAD_ALLOCATED_BYTES_MEASUREMENT));
-    assertTrue((Boolean) config.get(CommonConstants.Broker.CONFIG_OF_ENABLE_THREAD_CPU_TIME_MEASUREMENT));
-    assertTrue((Boolean) config.get(CommonConstants.Broker.CONFIG_OF_ENABLE_THREAD_ALLOCATED_BYTES_MEASUREMENT));
-    assertTrue((Boolean) config.get(CommonConstants.Accounting.CONFIG_OF_ENABLE_THREAD_CPU_SAMPLING));
-    assertTrue((Boolean) config.get(CommonConstants.Accounting.CONFIG_OF_ENABLE_THREAD_MEMORY_SAMPLING));
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Adds `pinot.broker.query.accounting.*` and `pinot.server.query.accounting.*` config prefixes so broker and server can be tuned independently.
- The legacy `pinot.query.scheduler.accounting.*` prefix continues to work for backward compatibility. Role-specific values override the legacy value on the matching role.
- Introduces `CommonConstants.Accounting.Keys`, a nested class that holds accounting-scope keys stripped of the `accounting.` prefix, to keep internal reads decoupled from the full cluster key.
- All existing `CommonConstants.Accounting.CONFIG_OF_*` constants are marked `@Deprecated(since = "1.6.0", forRemoval = true)`; internal callers migrated to `Accounting.Keys.*`.
- New helpers in `ThreadAccountantUtils`: `extractAccountingConfig` (merges the three prefixes for startup) and `filterAccountingConfigChange` (for the cluster-config listener). Both normalize to bare `Keys.*`.

## Example configs
```
# Legacy (still supported)
pinot.query.scheduler.accounting.oom.enable.killing.query=true

# New role-specific — override for broker only
pinot.broker.query.accounting.oom.enable.killing.query=false

# New role-specific — override for server only
pinot.server.query.accounting.oom.enable.killing.query=false
```

## Suggested labels
- `feature`
- `release-notes` (new configuration options, deprecation of `CONFIG_OF_*` constants)

## Test plan
- [x] `QueryMonitorConfigTest` covers the new common/role-specific lifecycle (added, changed, removed) and role-precedence scenarios.
- [x] `QueryResourceAggregatorTest` migrated to the new `Keys.*`.
- [x] Existing integration tests (`CpuBasedBrokerQueryKillingIntegrationTest`, `CpuBasedServerQueryKillingIntegrationTest`, `MemoryBasedServerQueryKillingIntegrationTest`, `MultiNodesOfflineClusterIntegrationTest`, `OfflineGRPCServerIntegrationTest`, `QueryWorkloadIntegrationTest`, `WindowResourceAccountingTest`) exercise the new prefixes end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)