### PR TITLE
Fix flaky PinotTaskManagerDistributedLockingTest cron race

### DIFF
--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManagerDistributedLockingTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManagerDistributedLockingTest.java
@@ -778,11 +778,17 @@ public class PinotTaskManagerDistributedLockingTest extends ControllerTest {
   }
 
   /**
-   * Helper to create a single test table
+   * Helper to create a single test table.
+   * <p>
+   * The cron schedule is intentionally set to a one-time fire date in the year 2099 so that the Quartz cron scheduler
+   * (enabled via {@code PINOT_TASK_MANAGER_SCHEDULER_ENABLED}) never fires during the test. Tests in this class
+   * assert on exact {@link ControllableTaskGenerator#getTaskGenerationCount()} values driven by explicit
+   * {@code createTask} / {@code scheduleTasks} calls, and a spurious cron firing at a :00 minute boundary would
+   * produce an extra {@code generateTasks} invocation and make the test flaky.
    */
   private void createSingleTestTable(String rawTableName) throws Exception {
     Map<String, Map<String, String>> taskTypeConfigsMap = new HashMap<>();
-    taskTypeConfigsMap.put(TEST_TASK_TYPE, Map.of("schedule", "0 */10 * ? * * *"));
+    taskTypeConfigsMap.put(TEST_TASK_TYPE, Map.of("schedule", "0 0 0 1 1 ? 2099"));
 
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE)
         .setTableName(rawTableName)


### PR DESCRIPTION
## Summary

Fixes flaky `PinotTaskManagerDistributedLockingTest.testForceReleaseLockDuringTaskExecution` (and siblings) that intermittently observed an extra `generateTasks` invocation:

```
java.lang.AssertionError: Both createTask calls should have generated tasks
expected [2] but found [3]
```

## Root cause

The shared `createSingleTestTable` helper configured every test table with cron `"0 */10 * ? * * *"` — fires every 10 minutes at the `:00` second boundary. Each test in this class enables `PINOT_TASK_MANAGER_SCHEDULER_ENABLED=true`, which starts the Quartz scheduler and registers that cron. If the test window happened to straddle a `:00/:10/:20/...` wall-clock boundary, Quartz would fire `CronJobScheduleJob` → `PinotTaskManager.scheduleTasks(...)` → `PinotTaskGenerator.generateTasks(...)`, bumping `ControllableTaskGenerator._taskGenerationCount` beyond what the test's explicit `createTask` / `scheduleTasks` calls produced.

The tests assert exact counts (e.g. `assertEquals(slowGenerator.getTaskGenerationCount(), 2, ...)`), so even a single spurious cron firing breaks them.

## Fix

Change the helper's cron to `"0 0 0 1 1 ? 2099"` — a valid Quartz expression that fires once at midnight on Jan 1, 2099, i.e. effectively never during a test run. Added a Javadoc comment on `createSingleTestTable` explaining why the schedule is deliberately far-future so a future reader doesn't "correct" it and reintroduce the flakiness.

This removes the nondeterminism at the source rather than masking it with retries or loosened assertions. No product code changes.

## Test plan

- [x] `./mvnw -pl pinot-controller -am -Dtest='PinotTaskManagerDistributedLockingTest#testForceReleaseLockDuringTaskExecution' test` — passes
- [x] `./mvnw -pl pinot-controller -am -Dtest='PinotTaskManagerDistributedLockingTest' test` — all 6 tests pass
- [x] `./mvnw spotless:apply checkstyle:check license:check -pl pinot-controller` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)