### PR TITLE
Fix flaky integration tests: prevent MSE port collisions on rapid server starts

### DIFF
--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
@@ -76,6 +76,7 @@ import org.apache.pinot.spi.stream.StreamMessageDecoder;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.CommonConstants.Broker;
 import org.apache.pinot.spi.utils.CommonConstants.Helix;
+import org.apache.pinot.spi.utils.CommonConstants.MultiStageQueryRunner;
 import org.apache.pinot.spi.utils.CommonConstants.Server;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.NetUtils;
@@ -265,12 +266,20 @@ public abstract class ClusterTest extends ControllerTest {
     serverConf.setProperty(Helix.KEY_OF_SERVER_NETTY_PORT, serverNettyPort);
     int serverGrpcPort = NetUtils.findOpenPort(serverNettyPort + 1);
     serverConf.setProperty(Server.CONFIG_OF_GRPC_PORT, serverGrpcPort);
+    // Assign the multi-stage query engine ports explicitly using the incremental findOpenPort pattern so that
+    // rapid back-to-back server starts in the same JVM don't collide on OS-ephemeral ports. Otherwise
+    // BaseServerStarter.init() falls back to NetUtils.findOpenPort() which probes and releases a ServerSocket(0)
+    // before the gRPC server binds, opening a window where the same port can be handed to a later caller.
+    int queryServerPort = NetUtils.findOpenPort(serverGrpcPort + 1);
+    serverConf.setProperty(MultiStageQueryRunner.KEY_OF_QUERY_SERVER_PORT, queryServerPort);
+    int queryRunnerPort = NetUtils.findOpenPort(queryServerPort + 1);
+    serverConf.setProperty(MultiStageQueryRunner.KEY_OF_QUERY_RUNNER_PORT, queryRunnerPort);
     if (_serverAdminApiPort == 0) {
       _serverAdminApiPort = serverAdminApiPort;
       _serverNettyPort = serverNettyPort;
       _serverGrpcPort = serverGrpcPort;
     }
-    _nextServerPort = serverGrpcPort + 1;
+    _nextServerPort = queryRunnerPort + 1;
 
     // Thread time measurement is disabled by default, enable it in integration tests.
     // TODO: this can be removed when we eventually enable thread time measurement by default.


### PR DESCRIPTION
## Summary
- `ClusterTest.getServerConf()` did not set the multi-stage query engine's `pinot.query.server.port` and `pinot.query.runner.port`, so `BaseServerStarter.init()` fell back to `NetUtils.findOpenPort()` (ephemeral `ServerSocket(0)` probe that is closed before the gRPC server actually binds).
- Rapid back-to-back `startOneServer(...)` calls in the same JVM can be handed the same OS-ephemeral port, causing the later server to fail to bind with `Address already in use`. This manifested as a flake in `TableRebalanceIntegrationTest.testForceCommit` which starts 4 servers in sequence:
  ```
  java.io.IOException: Failed to bind to address 0.0.0.0/0.0.0.0:32953
    at io.grpc.netty.shaded.io.grpc.netty.NettyServer.start(NettyServer.java:341)
    ...
    at org.apache.pinot.query.service.server.QueryServer.start(QueryServer.java:186)
    at org.apache.pinot.server.worker.WorkerQueryServer.start(WorkerQueryServer.java:89)
  ```
- Fix: assign both MSE ports explicitly using the same incremental `findOpenPort(base)` chain already used for the admin/netty/grpc ports, and carry the cursor forward via `_nextServerPort` so subsequent `getServerConf` / `overrideServerConf` calls stay monotonic.

## Test plan
- [ ] `./mvnw -pl pinot-integration-test-base -am test-compile` passes
- [ ] `./mvnw spotless:apply checkstyle:check license:check -pl pinot-integration-test-base` passes
- [ ] `./mvnw -pl pinot-integration-tests -am -Dtest=TableRebalanceIntegrationTest#testForceCommit -Dsurefire.failIfNoSpecifiedTests=false test` passes consistently across repeated runs
- [ ] CI green for the broader integration-test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)