### PR TITLE
Restrict nightly Docker build workflows to apache/pinot

### DIFF
--- a/.github/workflows/nightly-build-all-pinot-docker-image.yml
+++ b/.github/workflows/nightly-build-all-pinot-docker-image.yml
@@ -25,6 +25,7 @@ on:
 
 jobs:
   generate-build-info:
+    if: github.repository == 'apache/pinot'
     name: Generate Build Info
     runs-on: ubuntu-24.04
     outputs:

--- a/.github/workflows/nightly-build-multi-arch-superset-docker-image.yml
+++ b/.github/workflows/nightly-build-multi-arch-superset-docker-image.yml
@@ -24,6 +24,7 @@ on:
 
 jobs:
   generate-superset-info:
+    if: github.repository == 'apache/pinot'
     name: Generate Superset Build Info
     runs-on: ubuntu-24.04
     outputs:


### PR DESCRIPTION
## Summary

- The two nightly Docker build workflows (`nightly-build-all-pinot-docker-image.yml` and `nightly-build-multi-arch-superset-docker-image.yml`) are scheduled via cron and would otherwise fire on every forked repository, wasting Actions minutes and producing failures (forks lack the DockerHub secrets).
- Add `if: github.repository == 'apache/pinot'` to the entry-point job in each workflow. Downstream jobs chain via `needs:` and skip automatically.
- This matches the pattern already used by `close_stale_issues.yml` and `pinot_vuln_check.yml`.

## Test plan

- [ ] Verify the workflows show as skipped on forked repositories at the next scheduled run.
- [ ] Verify the workflows continue to run normally on `apache/pinot`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)