### PR TITLE
Honor deletedSegmentsRetentionPeriod for REFRESH tables in segment lineage cleanup

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/retention/RetentionManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/retention/RetentionManager.java
@@ -492,9 +492,12 @@ public class RetentionManager extends ControllerPeriodicTask<Void> {
     if (TableNameBuilder.isRealtimeTableResource(tableNameWithType)) {
       segmentsToDelete.removeAll(_pinotHelixResourceManager.getLastLLCCompletedSegments(tableNameWithType));
     }
-    // Delete segments based on the segment lineage
+    // Delete segments based on the segment lineage.
+    // Pass deletedSegmentsRetentionPeriod from table config so REFRESH tables (which are skipped by
+    // manageRetentionForTable) can honour per-table staging retention, including "0d" for immediate deletion.
     if (!segmentsToDelete.isEmpty()) {
-      _pinotHelixResourceManager.deleteSegments(tableNameWithType, segmentsToDelete);
+      String retentionPeriod = tableConfig.getValidationConfig().getDeletedSegmentsRetentionPeriod();
+      _pinotHelixResourceManager.deleteSegments(tableNameWithType, segmentsToDelete, retentionPeriod);
       LOGGER.info("Finished cleaning up segment lineage for table: {} in {}ms, deleted segments: {}",
           tableNameWithType, (System.currentTimeMillis() - cleanupStartTime), segmentsToDelete);
     }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/retention/SegmentLineageCleanupTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/retention/SegmentLineageCleanupTest.java
@@ -45,6 +45,7 @@ import org.testng.annotations.Test;
 
 import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 
 
 public class SegmentLineageCleanupTest {
@@ -184,6 +185,22 @@ public class SegmentLineageCleanupTest {
     _retentionManager.processTable(REFRESH_OFFLINE_TABLE_NAME);
     assertEquals(getNumSegments(REFRESH_OFFLINE_TABLE_NAME), 6);
     assertEquals(_resourceManager.getSegmentsFor(REFRESH_OFFLINE_TABLE_NAME, true).size(), 3);
+
+    // Validate the case when the lineage entry state is 'COMPLETED' — old segments should be deleted.
+    // Timestamp must be older than REPLACED_SEGMENTS_RETENTION_IN_MILLIS (1 day) for REFRESH tables.
+    SegmentLineage completedLineage = new SegmentLineage(REFRESH_OFFLINE_TABLE_NAME);
+    completedLineage.addLineageEntry("0", new LineageEntry(Arrays.asList("segment1_0", "segment1_1", "segment1_2"),
+        Arrays.asList("segment2_0", "segment2_1", "segment2_2"),
+        LineageEntryState.COMPLETED, System.currentTimeMillis() - TimeUnit.DAYS.toMillis(2)));
+    SegmentLineageAccessHelper.writeSegmentLineage(_resourceManager.getPropertyStore(), completedLineage, -1);
+    _retentionManager.processTable(REFRESH_OFFLINE_TABLE_NAME);
+
+    TestUtils.waitForCondition(aVoid -> getNumSegments(REFRESH_OFFLINE_TABLE_NAME) == 3, 60_000L,
+        "Failed to delete old segments for REFRESH table after COMPLETED lineage entry");
+    List<String> remaining = getSegments(REFRESH_OFFLINE_TABLE_NAME);
+    for (String seg : Arrays.asList("segment1_0", "segment1_1", "segment1_2")) {
+      assertFalse(remaining.contains(seg));
+    }
   }
 
   @AfterClass


### PR DESCRIPTION
## Problem

REFRESH (non-APPEND) offline tables have their superseded segments deleted via `manageSegmentLineageCleanupForTable`. This method called `deleteSegments(tableNameWithType, segmentsToDelete)` — the no-arg overload that ignores `deletedSegmentsRetentionPeriod` from the table config and always falls back to the cluster-level default (7 days).

`manageRetentionForTable` (which does read per-table retention config) exits early for REFRESH tables:
```java
if (tableConfig.getTableType() == TableType.OFFLINE && !"APPEND".equalsIgnoreCase(segmentPushType)) {
    return; // REFRESH tables skip this entirely
}
```

So even if an operator sets `deletedSegmentsRetentionPeriod: "0d"` on a REFRESH table, the staging retention is silently ignored — segments always sit in `Deleted_Segments/` for the full cluster default before permanent deletion.

## Fix

Pass the table's `deletedSegmentsRetentionPeriod` to `deleteSegments` in `manageSegmentLineageCleanupForTable`:

```java
// before
_pinotHelixResourceManager.deleteSegments(tableNameWithType, segmentsToDelete);

// after
String retentionPeriod = tableConfig.getValidationConfig().getDeletedSegmentsRetentionPeriod();
_pinotHelixResourceManager.deleteSegments(tableNameWithType, segmentsToDelete, retentionPeriod);
```

When `deletedSegmentsRetentionPeriod` is null (not configured), the existing `deleteSegments(String, List, String)` overload falls through to re-read the table config and then the cluster default — identical behavior to before.

## Usage

To enable immediate deletion of superseded segments for a REFRESH table:
```json
"segmentsConfig": {
  "deletedSegmentsRetentionPeriod": "0d"
}
```

## Backward Compatibility

No behavior change for tables that do not set `deletedSegmentsRetentionPeriod`. APPEND and realtime tables are unaffected.