### PR TITLE
Fix flaky MergeRollupMinionClusterIntegrationTest gauge assertions

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MergeRollupMinionClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MergeRollupMinionClusterIntegrationTest.java
@@ -464,8 +464,7 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
     // Check total tasks
     assertEquals(numTasks, 5);
 
-    assertTrue(MetricValueUtils.gaugeExists(_controllerStarter.getControllerMetrics(),
-        "mergeRollupTaskDelayInNumBuckets.myTable1_OFFLINE.100days"));
+    waitForGaugesToExist("mergeRollupTaskDelayInNumBuckets.myTable1_OFFLINE.100days");
     // Drop the table
     dropOfflineTable(SINGLE_LEVEL_CONCAT_TEST_TABLE);
 
@@ -582,8 +581,7 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
     // Check total tasks
     assertEquals(numTasks, 5);
 
-    assertTrue(MetricValueUtils.gaugeExists(_controllerStarter.getControllerMetrics(),
-        "mergeRollupTaskDelayInNumBuckets.myTable4_OFFLINE.100days"));
+    waitForGaugesToExist("mergeRollupTaskDelayInNumBuckets.myTable4_OFFLINE.100days");
 
     // Drop the table
     dropOfflineTable(SINGLE_LEVEL_CONCAT_METADATA_TEST_TABLE);
@@ -706,8 +704,7 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
     // Check total tasks
     assertEquals(numTasks, 3);
 
-    assertTrue(MetricValueUtils.gaugeExists(_controllerStarter.getControllerMetrics(),
-        "mergeRollupTaskDelayInNumBuckets.myTable2_OFFLINE.150days"));
+    waitForGaugesToExist("mergeRollupTaskDelayInNumBuckets.myTable2_OFFLINE.150days");
   }
 
   /**
@@ -853,10 +850,8 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
     // Check total tasks
     assertEquals(numTasks, 8);
 
-    assertTrue(MetricValueUtils.gaugeExists(_controllerStarter.getControllerMetrics(),
-        "mergeRollupTaskDelayInNumBuckets.myTable3_OFFLINE.45days"));
-    assertTrue(MetricValueUtils.gaugeExists(_controllerStarter.getControllerMetrics(),
-        "mergeRollupTaskDelayInNumBuckets.myTable3_OFFLINE.90days"));
+    waitForGaugesToExist("mergeRollupTaskDelayInNumBuckets.myTable3_OFFLINE.45days",
+        "mergeRollupTaskDelayInNumBuckets.myTable3_OFFLINE.90days");
   }
 
   protected void verifyTableDelete(String tableNameWithType) {
@@ -909,6 +904,31 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
       return MetricValueUtils.getGaugeValue(controllerMetrics, metric100Days) == expected100Days
           && MetricValueUtils.getGaugeValue(controllerMetrics, metric200Days) == expected200Days;
     }, TIMEOUT_IN_MS, "Timeout while waiting for expected num buckets to process metrics on " + tableNameWithType);
+  }
+
+  /**
+   * Poll until all of the named gauges exist on the controller. Used here for
+   * {@code mergeRollupTaskDelayInNumBuckets.*} after each test's scheduling loop completes.
+   *
+   * <p>Those gauges are (re)registered by {@link PinotTaskManager#scheduleTasks} via
+   * {@code MergeRollupTaskGenerator.createOrUpdateDelayMetrics}. They are removed by
+   * {@code resetDelayMetrics} when a {@code scheduleTasks} call observes no eligible segments for the
+   * table — which can happen transiently if a {@code scheduleTasks} call (e.g. the per-iteration
+   * {@code RealtimeToOfflineSegmentsTask} probe inside the for-loop body) lands while the previous
+   * merge task's segment-lineage commit is still in flight. Polling here mirrors
+   * {@link #waitForExpectedNumBucketsToProcess} so the post-loop assertion does not flake on the same
+   * race window.
+   */
+  private void waitForGaugesToExist(String... metricNames) {
+    TestUtils.waitForCondition(aVoid -> {
+      ControllerMetrics controllerMetrics = _controllerStarter.getControllerMetrics();
+      for (String metricName : metricNames) {
+        if (!MetricValueUtils.gaugeExists(controllerMetrics, metricName)) {
+          return false;
+        }
+      }
+      return true;
+    }, TIMEOUT_IN_MS, "Timeout while waiting for gauges to exist: " + String.join(", ", metricNames));
   }
 
   // The use case is similar as the one defined in offline table
@@ -1010,8 +1030,7 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
     // Check total tasks
     assertEquals(numTasks, 5);
 
-    assertTrue(MetricValueUtils.gaugeExists(_controllerStarter.getControllerMetrics(),
-        "mergeRollupTaskDelayInNumBuckets.myTable5_REALTIME.100days"));
+    waitForGaugesToExist("mergeRollupTaskDelayInNumBuckets.myTable5_REALTIME.100days");
 
     // Drop the table
     dropRealtimeTable(tableName);


### PR DESCRIPTION
## Summary

Extends the polling pattern introduced in #18253 (for `mergeRollupTaskNumBucketsToProcess`) to the remaining five `mergeRollupTaskDelayInNumBuckets.*` `gaugeExists` checks in the same test class.

## Root cause

The gauge is registered by `MergeRollupTaskGenerator.createOrUpdateDelayMetrics` and removed by `resetDelayMetrics` when a `scheduleTasks` call observes no eligible segments for the table. Each per-iteration body's

```java
assertNull(_taskManager.scheduleTasks(context).get(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE));
```

probe triggers an extra synchronized `scheduleTasks` that can race with the previous merge task's segment-lineage commit — transiently reaching the `resetDelayMetrics` branch and removing the gauge. The post-loop `assertTrue(MetricValueUtils.gaugeExists(...))` then flakes on the same window that #18253 addressed for the processAll-mode test.

## Fix

Added a `waitForGaugesToExist(String...)` helper that polls via `TestUtils.waitForCondition` with the existing `TIMEOUT_IN_MS`, mirroring `waitForExpectedNumBucketsToProcess` introduced in #18253. Replaced the `assertTrue(gaugeExists(...))` calls in:

- `testOfflineTableSingleLevelConcat`
- `testOfflineTableSingleLevelConcatWithMetadataPush`
- `testOfflineTableSingleLevelRollup`
- `testOfflineTableMultiLevelConcat` (polls `45days` + `90days` atomically)
- `testRealtimeTableSingleLevelConcat`

## Test plan

- [x] `./mvnw test-compile -pl pinot-integration-tests -am` passes.
- [x] `./mvnw spotless:apply checkstyle:check license:format license:check -pl pinot-integration-tests` clean.
- [ ] CI runs `MergeRollupMinionClusterIntegrationTest` successfully across multiple runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)