### PR TITLE
Columnar map 2 query

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/MapFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/MapFilterOperator.java
@@ -32,12 +32,18 @@ import org.apache.pinot.common.request.context.predicate.Predicate;
 import org.apache.pinot.core.common.BlockDocIdSet;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.operator.ExplainAttributeBuilder;
+import org.apache.pinot.core.operator.filter.predicate.PredicateEvaluator;
+import org.apache.pinot.core.operator.filter.predicate.PredicateEvaluatorProvider;
 import org.apache.pinot.core.query.request.context.QueryContext;
+import org.apache.pinot.segment.local.segment.index.columnarmap.ColumnarMapDataSource;
 import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.segment.spi.datasource.MapDataSource;
 import org.apache.pinot.segment.spi.index.IndexService;
 import org.apache.pinot.segment.spi.index.IndexType;
+import org.apache.pinot.segment.spi.index.reader.ColumnarMapIndexReader;
 import org.apache.pinot.segment.spi.index.reader.JsonIndexReader;
+import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
 
 
 /**
@@ -49,6 +55,8 @@ public class MapFilterOperator extends BaseFilterOperator {
   private static final String EXPLAIN_NAME = "FILTER_MAP";
 
   private final JsonMatchFilterOperator _jsonMatchOperator;
+  private final BaseFilterOperator _perKeyInvertedIndexOperator;
+  private final BitmapBasedFilterOperator _presenceBitmapOperator;
   private final ExpressionFilterOperator _expressionFilterOperator;
   private final String _columnName;
   private final String _keyName;
@@ -68,6 +76,7 @@ public class MapFilterOperator extends BaseFilterOperator {
     _columnName = arguments.get(0).getIdentifier();
     _keyName = arguments.get(1).getLiteral().getStringValue();
 
+    // Strategy 1: Try JSON index on the parent MAP column
     JsonIndexReader jsonIndex = null;
     if (canUseJsonIndex(_predicate.getType())) {
       DataSource dataSource = indexSegment.getDataSourceNullable(_columnName);
@@ -83,14 +92,52 @@ public class MapFilterOperator extends BaseFilterOperator {
         }
       }
     }
+
     if (jsonIndex != null) {
       FilterContext filterContext = createFilterContext();
       _jsonMatchOperator = new JsonMatchFilterOperator(jsonIndex, filterContext, numDocs);
+      _perKeyInvertedIndexOperator = null;
+      _presenceBitmapOperator = null;
       _expressionFilterOperator = null;
-    } else {
-      _jsonMatchOperator = null;
-      _expressionFilterOperator = new ExpressionFilterOperator(indexSegment, queryContext, predicate, numDocs);
+      return;
     }
+
+    // Strategy 2: Try per-key inverted index from MapDataSource (COLUMNAR_MAP)
+    _jsonMatchOperator = null;
+    DataSource dataSource = indexSegment.getDataSourceNullable(_columnName);
+    if (dataSource instanceof MapDataSource && canUseJsonIndex(_predicate.getType())) {
+      MapDataSource mapDS = (MapDataSource) dataSource;
+      DataSource keyDS = mapDS.getKeyDataSource(_keyName);
+      if (keyDS != null && keyDS.getInvertedIndex() != null) {
+        PredicateEvaluator predicateEvaluator =
+            PredicateEvaluatorProvider.getPredicateEvaluator(predicate, keyDS, queryContext);
+        _perKeyInvertedIndexOperator =
+            FilterOperatorUtils.getLeafFilterOperator(queryContext, predicateEvaluator, keyDS, numDocs);
+        _presenceBitmapOperator = null;
+        _expressionFilterOperator = null;
+        return;
+      }
+    }
+
+    // Strategy 2b: IS_NULL / IS_NOT_NULL via presence bitmap (O(1) bitmap lookup)
+    _perKeyInvertedIndexOperator = null;
+    Predicate.Type predType = _predicate.getType();
+    if (predType == Predicate.Type.IS_NOT_NULL || predType == Predicate.Type.IS_NULL) {
+      if (dataSource instanceof ColumnarMapDataSource) {
+        ColumnarMapDataSource columnarDS = (ColumnarMapDataSource) dataSource;
+        ColumnarMapIndexReader reader = columnarDS.getColumnarMapIndexReader();
+        ImmutableRoaringBitmap presenceBitmap = reader.getPresenceBitmap(_keyName);
+        // IS_NOT_NULL: docs IN the presence bitmap; IS_NULL: docs NOT in bitmap (inverted)
+        boolean inverted = (predType == Predicate.Type.IS_NULL);
+        _presenceBitmapOperator = new BitmapBasedFilterOperator(presenceBitmap, inverted, numDocs);
+        _expressionFilterOperator = null;
+        return;
+      }
+    }
+
+    // Strategy 3: Full scan fallback via ExpressionFilterOperator
+    _presenceBitmapOperator = null;
+    _expressionFilterOperator = new ExpressionFilterOperator(indexSegment, queryContext, predicate, numDocs);
   }
 
   /**
@@ -127,6 +174,10 @@ public class MapFilterOperator extends BaseFilterOperator {
   protected BlockDocIdSet getTrues() {
     if (_jsonMatchOperator != null) {
       return _jsonMatchOperator.getTrues();
+    } else if (_perKeyInvertedIndexOperator != null) {
+      return _perKeyInvertedIndexOperator.getTrues();
+    } else if (_presenceBitmapOperator != null) {
+      return _presenceBitmapOperator.getTrues();
     } else {
       return _expressionFilterOperator.getTrues();
     }
@@ -136,6 +187,10 @@ public class MapFilterOperator extends BaseFilterOperator {
   public boolean canOptimizeCount() {
     if (_jsonMatchOperator != null) {
       return _jsonMatchOperator.canOptimizeCount();
+    } else if (_perKeyInvertedIndexOperator != null) {
+      return _perKeyInvertedIndexOperator.canOptimizeCount();
+    } else if (_presenceBitmapOperator != null) {
+      return _presenceBitmapOperator.canOptimizeCount();
     } else {
       return _expressionFilterOperator.canOptimizeCount();
     }
@@ -145,6 +200,10 @@ public class MapFilterOperator extends BaseFilterOperator {
   public int getNumMatchingDocs() {
     if (_jsonMatchOperator != null) {
       return _jsonMatchOperator.getNumMatchingDocs();
+    } else if (_perKeyInvertedIndexOperator != null) {
+      return _perKeyInvertedIndexOperator.getNumMatchingDocs();
+    } else if (_presenceBitmapOperator != null) {
+      return _presenceBitmapOperator.getNumMatchingDocs();
     } else {
       return _expressionFilterOperator.getNumMatchingDocs();
     }
@@ -154,6 +213,10 @@ public class MapFilterOperator extends BaseFilterOperator {
   public boolean canProduceBitmaps() {
     if (_jsonMatchOperator != null) {
       return _jsonMatchOperator.canProduceBitmaps();
+    } else if (_perKeyInvertedIndexOperator != null) {
+      return _perKeyInvertedIndexOperator.canProduceBitmaps();
+    } else if (_presenceBitmapOperator != null) {
+      return _presenceBitmapOperator.canProduceBitmaps();
     } else {
       return _expressionFilterOperator.canProduceBitmaps();
     }
@@ -163,6 +226,10 @@ public class MapFilterOperator extends BaseFilterOperator {
   public BitmapCollection getBitmaps() {
     if (_jsonMatchOperator != null) {
       return _jsonMatchOperator.getBitmaps();
+    } else if (_perKeyInvertedIndexOperator != null) {
+      return _perKeyInvertedIndexOperator.getBitmaps();
+    } else if (_presenceBitmapOperator != null) {
+      return _presenceBitmapOperator.getBitmaps();
     } else {
       return _expressionFilterOperator.getBitmaps();
     }
@@ -182,6 +249,10 @@ public class MapFilterOperator extends BaseFilterOperator {
 
     if (_jsonMatchOperator != null) {
       stringBuilder.append(",delegateTo:json_match");
+    } else if (_perKeyInvertedIndexOperator != null) {
+      stringBuilder.append(",delegateTo:per_key_inverted_index");
+    } else if (_presenceBitmapOperator != null) {
+      stringBuilder.append(",delegateTo:presence_bitmap");
     } else {
       stringBuilder.append(",delegateTo:expression_filter");
     }
@@ -205,6 +276,10 @@ public class MapFilterOperator extends BaseFilterOperator {
 
     if (_jsonMatchOperator != null) {
       attributeBuilder.putString("delegateTo", "json_match");
+    } else if (_perKeyInvertedIndexOperator != null) {
+      attributeBuilder.putString("delegateTo", "per_key_inverted_index");
+    } else if (_presenceBitmapOperator != null) {
+      attributeBuilder.putString("delegateTo", "presence_bitmap");
     } else {
       attributeBuilder.putString("delegateTo", "expression_filter");
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ItemTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ItemTransformFunction.java
@@ -21,13 +21,17 @@ package org.apache.pinot.core.operator.transform.function;
 import com.google.common.base.Preconditions;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.pinot.core.operator.ColumnContext;
 import org.apache.pinot.core.operator.blocks.ValueBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
 import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.segment.spi.datasource.MapDataSource;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
+import org.apache.pinot.segment.spi.index.reader.NullValueVectorReader;
 import org.apache.pinot.spi.data.FieldSpec;
+import org.roaringbitmap.RoaringBitmap;
+import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
 
 
 /**
@@ -42,6 +46,8 @@ public class ItemTransformFunction extends BaseTransformFunction {
   TransformFunction _keyValue;
   Dictionary _keyDictionary;
   private TransformResultMetadata _resultMetadata;
+  @Nullable
+  private ImmutableRoaringBitmap _keyNullBitmap;
 
   @Override
   public void init(List<TransformFunction> arguments, Map<String, ColumnContext> columnContextMap) {
@@ -82,6 +88,9 @@ public class ItemTransformFunction extends BaseTransformFunction {
       _resultMetadata =
           new TransformResultMetadata(keyType, keyDS.getDataSourceMetadata().isSingleValue(),
               _keyDictionary != null);
+      // Capture per-key null bitmap for null-aware item() evaluation
+      NullValueVectorReader nullReader = keyDS.getNullValueVector();
+      _keyNullBitmap = nullReader != null ? nullReader.getNullBitmap() : null;
     } else {
       throw new RuntimeException("The left operand for a MAP ITEM operation must resolve to a Map Data Source");
     }
@@ -90,6 +99,14 @@ public class ItemTransformFunction extends BaseTransformFunction {
   @Override
   public String getName() {
     return FUNCTION_NAME;
+  }
+
+  /**
+   * Returns the key path for this item expression: [columnName, keyName].
+   * Used by TransformBlock to bypass the transform function and resolve the MAP key directly.
+   */
+  public String[] getKeyPath() {
+    return _keyPath;
   }
 
   @Override
@@ -126,5 +143,31 @@ public class ItemTransformFunction extends BaseTransformFunction {
   @Override
   public String[] transformToStringValuesSV(ValueBlock valueBlock) {
     return valueBlock.getBlockValueSet(_keyPath).getStringValuesSV();
+  }
+
+  @Nullable
+  @Override
+  public RoaringBitmap getNullBitmap(ValueBlock valueBlock) {
+    // Skip when the query did not enable null handling — matches the convention used by
+    // BaseTransformFunction subclasses that emit nulls only under the explicit query flag.
+    // Without this gate, COLUMNAR_MAP queries would surface IS NULL semantics on tables that
+    // never opted in.
+    if (!_nullHandlingEnabled || _keyNullBitmap == null || _keyNullBitmap.isEmpty()) {
+      return null;
+    }
+    int[] docIds = valueBlock.getDocIds();
+    int numDocs = valueBlock.getNumDocs();
+    // Block-overlap shortcut: if the segment-level null bitmap doesn't intersect the docId
+    // range covered by this block, allocate nothing. Cheap when most blocks have no nulls.
+    if (numDocs > 0 && !_keyNullBitmap.intersects(docIds[0], (long) docIds[numDocs - 1] + 1)) {
+      return null;
+    }
+    RoaringBitmap blockNullBitmap = new RoaringBitmap();
+    for (int i = 0; i < numDocs; i++) {
+      if (_keyNullBitmap.contains(docIds[i])) {
+        blockNullBitmap.add(i);
+      }
+    }
+    return blockNullBitmap.isEmpty() ? null : blockNullBitmap;
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/ColumnarMapBenchmarkTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/ColumnarMapBenchmarkTest.java
@@ -1,0 +1,581 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.queries;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.common.response.broker.BrokerResponseNative;
+import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
+import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
+import org.apache.pinot.spi.config.table.FieldConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.ComplexFieldSpec;
+import org.apache.pinot.spi.data.DimensionFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.apache.pinot.spi.utils.ReadMode;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+/**
+ * Micro-benchmark comparing COLUMNAR_MAP (two-tier) vs flattened columns.
+ * Ingests 5M synthetic docs into two segments and compares query latency and storage cost.
+ *
+ * <p>Disabled by default — run manually:
+ * <pre>
+ *   mvn test -pl pinot-core -Dtest=ColumnarMapBenchmarkTest -DenableBenchmark=true
+ * </pre>
+ */
+public class ColumnarMapBenchmarkTest extends BaseQueriesTest {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ColumnarMapBenchmarkTest.class);
+
+  private static final int NUM_SEGMENTS = 10;
+  private static final int DOCS_PER_SEGMENT = 2_000_000;
+  private static final int WARMUP_RUNS = 5;
+  private static final int MEASURED_RUNS = 5;
+
+  private static final String MAP_TABLE = "benchmark_columnar_map";
+  private static final String FLAT_TABLE = "benchmark_flattened";
+  private static final File INDEX_DIR = new File(FileUtils.getTempDirectory(), "ColumnarMapBenchmark");
+  private static final File CACHE_DIR = new File(System.getProperty("user.home"), ".pinot-benchmark-cache");
+
+  // Map key definitions: name → fill rate
+  private static final String[] KEY_NAMES = {
+      "tenancy", "country", "device_os", "event_type", "session_id",
+      "discount_code", "referral", "error_code", "debug_trace", "experiment_id"
+  };
+  private static final double[] FILL_RATES = {
+      1.0, 1.0, 0.95, 0.80, 0.60,
+      0.30, 0.15, 0.05, 0.02, 0.01
+  };
+
+  // Value pools for each key
+  private static final String[][] VALUE_POOLS = {
+      {"uber/production", "uber/testing", "uber_eats", "uber_freight", "uber_connect"},
+      generateCountries(),
+      {"ios", "android", "web", "unknown"},
+      {"page_view", "click", "purchase", "signup", "logout", "search", "add_to_cart", "checkout",
+          "payment", "refund", "review", "share", "bookmark", "notify", "subscribe",
+          "unsubscribe", "report", "upload", "download", "export"},
+      null, // session_id generated dynamically (high cardinality)
+      generateCodes("SAVE", 100),
+      {"google", "facebook", "twitter", "email", "instagram", "tiktok", "youtube", "reddit",
+          "linkedin", "snapchat", "pinterest", "whatsapp", "telegram", "discord", "slack",
+          "organic", "direct", "affiliate", "partner", "other",
+          "blog", "podcast", "newsletter", "press", "event",
+          "referral_program", "word_of_mouth", "app_store", "play_store", "sms"},
+      {"E001", "E002", "E003", "E004", "E005", "E006", "E007", "E008", "E009", "E010"},
+      null, // debug_trace generated dynamically (high cardinality)
+      generateCodes("exp-", 50)
+  };
+
+  // Inverted index keys (must match between MAP and flattened)
+  private static final Set<String> INVERTED_INDEX_KEYS = Set.of("tenancy", "country");
+
+  private final List<IndexSegment> _mapSegments = new ArrayList<>();
+  private final List<IndexSegment> _flatSegments = new ArrayList<>();
+  private List<IndexSegment> _activeSegments;  // toggled per query
+  private long _mapSegmentSize;
+  private long _flatSegmentSize;
+  private final List<BenchmarkResult> _results = new ArrayList<>();
+
+  @Override
+  protected String getFilter() {
+    return "";
+  }
+
+  @Override
+  protected IndexSegment getIndexSegment() {
+    return _activeSegments.get(0);
+  }
+
+  @Override
+  protected List<IndexSegment> getIndexSegments() {
+    return _activeSegments;
+  }
+
+  @BeforeClass
+  public void setUp()
+      throws Exception {
+    if (!"true".equals(System.getProperty("enableBenchmark"))) {
+      LOGGER.info("Benchmark disabled. Set -DenableBenchmark=true to run.");
+      return;
+    }
+
+    FileUtils.deleteDirectory(INDEX_DIR);
+    INDEX_DIR.mkdirs();
+    CACHE_DIR.mkdirs();
+
+    int totalDocs = NUM_SEGMENTS * DOCS_PER_SEGMENT;
+    LOGGER.info("Setting up {} segments × {} docs = {} total docs...", NUM_SEGMENTS, DOCS_PER_SEGMENT, totalDocs);
+
+    // Create or reuse cached template segments (one MAP + one Flat with DOCS_PER_SEGMENT docs)
+    String cacheKey = "docs_" + DOCS_PER_SEGMENT;
+    File cachedMapTemplate = new File(CACHE_DIR, "mapTemplate_" + cacheKey);
+    File cachedFlatTemplate = new File(CACHE_DIR, "flatTemplate_" + cacheKey);
+
+    if (!cachedMapTemplate.exists() || !cachedFlatTemplate.exists()) {
+      LOGGER.info("Cache miss — creating template segments with {} docs...", DOCS_PER_SEGMENT);
+      File tempBuildDir = new File(CACHE_DIR, "build_tmp");
+      FileUtils.deleteDirectory(tempBuildDir);
+      tempBuildDir.mkdirs();
+
+      List<GenericRow> rows = generateRows(0);
+      createMapSegment(rows, "mapTemplate_" + cacheKey, tempBuildDir);
+      createFlattenedSegment(rows, "flatTemplate_" + cacheKey, tempBuildDir);
+      rows.clear();
+
+      // Move to cache
+      File builtMap = new File(tempBuildDir, "mapTemplate_" + cacheKey);
+      File builtFlat = new File(tempBuildDir, "flatTemplate_" + cacheKey);
+      if (cachedMapTemplate.exists()) {
+        FileUtils.deleteDirectory(cachedMapTemplate);
+      }
+      if (cachedFlatTemplate.exists()) {
+        FileUtils.deleteDirectory(cachedFlatTemplate);
+      }
+      FileUtils.moveDirectory(builtMap, cachedMapTemplate);
+      FileUtils.moveDirectory(builtFlat, cachedFlatTemplate);
+      FileUtils.deleteDirectory(tempBuildDir);
+      LOGGER.info("Template segments cached to {}", CACHE_DIR);
+    } else {
+      LOGGER.info("Cache hit — reusing template segments from {}", CACHE_DIR);
+    }
+
+    // Copy template segments N times and load them
+    _mapSegmentSize = 0;
+    _flatSegmentSize = 0;
+
+    for (int seg = 0; seg < NUM_SEGMENTS; seg++) {
+      String mapSegName = "mapSegment_" + seg;
+      String flatSegName = "flatSegment_" + seg;
+      File mapDir = new File(INDEX_DIR, mapSegName);
+      File flatDir = new File(INDEX_DIR, flatSegName);
+
+      FileUtils.copyDirectory(cachedMapTemplate, mapDir);
+      FileUtils.copyDirectory(cachedFlatTemplate, flatDir);
+
+      _mapSegments.add(ImmutableSegmentLoader.load(mapDir, ReadMode.mmap));
+      _flatSegments.add(ImmutableSegmentLoader.load(flatDir, ReadMode.mmap));
+      _mapSegmentSize += FileUtils.sizeOfDirectory(mapDir);
+      _flatSegmentSize += FileUtils.sizeOfDirectory(flatDir);
+    }
+
+    LOGGER.info("All {} segments loaded. MAP total: {} bytes ({} B/doc), Flat total: {} bytes ({} B/doc)",
+        NUM_SEGMENTS, _mapSegmentSize, _mapSegmentSize / totalDocs,
+        _flatSegmentSize, _flatSegmentSize / totalDocs);
+  }
+
+  @Test(enabled = false,
+      description = "Manual benchmark — run with -Dtest=ColumnarMapBenchmarkTest -DenableBenchmark=true and "
+          + "the @Test-method-level enabled flag flipped to true")
+  public void testBenchmark()
+      throws Exception {
+    if (_mapSegments.isEmpty()) {
+      LOGGER.info("Skipping benchmark (not enabled). Set -DenableBenchmark=true to run.");
+      return;
+    }
+
+    // Q1: Full-scan COUNT with filter (dense key, inverted index)
+    benchmark("Q1: COUNT + filter (dense)",
+        "SELECT count(*) FROM " + MAP_TABLE + " WHERE props['country'] = 'US'",
+        "SELECT count(*) FROM " + FLAT_TABLE + " WHERE props__country = 'US'");
+
+    // Q2: SUM aggregation (full scan, dense key)
+    benchmark("Q2: SUM (full scan)",
+        "SELECT sum(amount) FROM " + MAP_TABLE + " WHERE props['tenancy'] = 'uber/production'",
+        "SELECT sum(amount) FROM " + FLAT_TABLE + " WHERE props__tenancy = 'uber/production'");
+
+    // Q3: COUNT aggregation on dense key (full scan, no group by — just touch the column)
+    benchmark("Q3: COUNT DISTINCT (dense)",
+        "SELECT count(distinct props['country']) FROM " + MAP_TABLE,
+        "SELECT count(distinct props__country) FROM " + FLAT_TABLE);
+
+    // Q4: GROUP BY single dense key (full scan)
+    benchmark("Q4: GROUP BY 1 key",
+        "SELECT props['country'], count(*) FROM " + MAP_TABLE + " GROUP BY props['country']",
+        "SELECT props__country, count(*) FROM " + FLAT_TABLE + " GROUP BY props__country");
+
+    // Q5: GROUP BY two dense keys (full scan)
+    benchmark("Q5: GROUP BY 2 keys",
+        "SELECT props['country'], props['tenancy'], count(*) FROM " + MAP_TABLE
+            + " GROUP BY props['country'], props['tenancy']",
+        "SELECT props__country, props__tenancy, count(*) FROM " + FLAT_TABLE
+            + " GROUP BY props__country, props__tenancy");
+
+    // Q6: Filtered GROUP BY (inverted index filter + GROUP BY on different key)
+    benchmark("Q6: Filtered GROUP BY",
+        "SELECT props['country'], count(*) FROM " + MAP_TABLE
+            + " WHERE props['tenancy'] = 'uber/production' GROUP BY props['country']",
+        "SELECT props__country, count(*) FROM " + FLAT_TABLE
+            + " WHERE props__tenancy = 'uber/production' GROUP BY props__country");
+
+    // Q7: DISTINCT count on dense key (full scan)
+    benchmark("Q7: DISTINCT COUNT",
+        "SELECT distinctcount(props['country']) FROM " + MAP_TABLE,
+        "SELECT distinctcount(props__country) FROM " + FLAT_TABLE);
+
+    // Q8: Multi-filter AND (two dense keys with inverted indexes)
+    benchmark("Q8: AND filter (2 keys)",
+        "SELECT count(*) FROM " + MAP_TABLE
+            + " WHERE props['country'] = 'US' AND props['tenancy'] = 'uber/production'",
+        "SELECT count(*) FROM " + FLAT_TABLE
+            + " WHERE props__country = 'US' AND props__tenancy = 'uber/production'");
+
+    // Write report
+    writeReport();
+  }
+
+  @AfterClass
+  public void tearDown()
+      throws Exception {
+    for (IndexSegment seg : _mapSegments) {
+      seg.destroy();
+    }
+    for (IndexSegment seg : _flatSegments) {
+      seg.destroy();
+    }
+    FileUtils.deleteDirectory(INDEX_DIR);
+  }
+
+  // ---- Data Generation ----
+
+  private List<GenericRow> generateRows(int segmentIndex) {
+    Random rng = new Random(42 + segmentIndex);  // deterministic per segment
+    List<GenericRow> rows = new ArrayList<>(DOCS_PER_SEGMENT);
+    for (int i = 0; i < DOCS_PER_SEGMENT; i++) {
+      GenericRow row = new GenericRow();
+      row.putValue("userId", "user_" + (rng.nextInt(500_000)));
+      row.putValue("timestamp", System.currentTimeMillis() - rng.nextInt(86400_000));
+      row.putValue("amount", Math.round(rng.nextDouble() * 100.0) / 100.0 * 10.0);  // ~1000 distinct values
+
+      Map<String, Object> props = new HashMap<>();
+      for (int k = 0; k < KEY_NAMES.length; k++) {
+        if (rng.nextDouble() < FILL_RATES[k]) {
+          String value;
+          if (VALUE_POOLS[k] != null) {
+            value = VALUE_POOLS[k][rng.nextInt(VALUE_POOLS[k].length)];
+          } else if (KEY_NAMES[k].equals("session_id")) {
+            value = "sess_" + rng.nextInt(10_000);  // cap cardinality
+          } else {
+            // debug_trace: high cardinality
+            value = Long.toHexString(rng.nextLong());
+          }
+          props.put(KEY_NAMES[k], value);
+        }
+      }
+      row.putValue("props", props);
+      rows.add(row);
+    }
+    return rows;
+  }
+
+  private void createMapSegment(List<GenericRow> rows, String mapSegmentName)
+      throws Exception {
+    createMapSegment(rows, mapSegmentName, INDEX_DIR);
+  }
+
+  private void createMapSegment(List<GenericRow> rows, String mapSegmentName, File outDir)
+      throws Exception {
+    Schema schema = new Schema.SchemaBuilder()
+        .setSchemaName(MAP_TABLE)
+        .addSingleValueDimension("userId", FieldSpec.DataType.STRING)
+        .addSingleValueDimension("timestamp", FieldSpec.DataType.LONG)
+        .addMetric("amount", FieldSpec.DataType.DOUBLE)
+        .addField(new ComplexFieldSpec("props", FieldSpec.DataType.MAP, true,
+            Map.of("key", new DimensionFieldSpec("key", FieldSpec.DataType.STRING, true),
+                "value", new DimensionFieldSpec("value", FieldSpec.DataType.STRING, true))))
+        .build();
+
+    ObjectNode columnarMapNode = JsonUtils.newObjectNode();
+    columnarMapNode.put("enabled", true);
+    columnarMapNode.put("maxKeys", 1000);
+    columnarMapNode.put("enableInvertedIndexForAll", false);
+    columnarMapNode.put("denseKeyThreshold", 0.5);
+    columnarMapNode.set("invertedIndexKeys",
+        JsonUtils.newObjectNode().arrayNode().add("tenancy").add("country"));
+    ObjectNode indexesNode = JsonUtils.newObjectNode();
+    indexesNode.set("columnar_map", columnarMapNode);
+    FieldConfig propsFieldConfig = new FieldConfig.Builder("props")
+        .withIndexes(indexesNode)
+        .withProperties(Map.of(
+            "denseKeyThreshold", "0.5",
+            "invertedIndexKeys", "tenancy,country"
+        ))
+        .build();
+
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName(MAP_TABLE)
+        .setFieldConfigList(List.of(propsFieldConfig))
+        .build();
+
+    buildSegment(schema, tableConfig, mapSegmentName, rows, outDir);
+  }
+
+  private void createFlattenedSegment(List<GenericRow> rows, String flatSegmentName)
+      throws Exception {
+    createFlattenedSegment(rows, flatSegmentName, INDEX_DIR);
+  }
+
+  private void createFlattenedSegment(List<GenericRow> rows, String flatSegmentName, File outDir)
+      throws Exception {
+    Schema.SchemaBuilder sb = new Schema.SchemaBuilder()
+        .setSchemaName(FLAT_TABLE)
+        .addSingleValueDimension("userId", FieldSpec.DataType.STRING)
+        .addSingleValueDimension("timestamp", FieldSpec.DataType.LONG)
+        .addMetric("amount", FieldSpec.DataType.DOUBLE);
+    for (String key : KEY_NAMES) {
+      sb.addSingleValueDimension("props__" + key, FieldSpec.DataType.STRING);
+    }
+    Schema schema = sb.build();
+
+    // Inverted index on matching keys
+    List<String> invertedCols = new ArrayList<>();
+    for (String key : INVERTED_INDEX_KEYS) {
+      invertedCols.add("props__" + key);
+    }
+
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName(FLAT_TABLE)
+        .setInvertedIndexColumns(invertedCols)
+        .build();
+
+    // Convert rows: extract map keys into top-level columns
+    List<GenericRow> flatRows = new ArrayList<>(rows.size());
+    for (GenericRow row : rows) {
+      GenericRow flatRow = new GenericRow();
+      flatRow.putValue("userId", row.getValue("userId"));
+      flatRow.putValue("timestamp", row.getValue("timestamp"));
+      flatRow.putValue("amount", row.getValue("amount"));
+
+      @SuppressWarnings("unchecked")
+      Map<String, Object> props = (Map<String, Object>) row.getValue("props");
+      for (String key : KEY_NAMES) {
+        Object val = props != null ? props.get(key) : null;
+        flatRow.putValue("props__" + key, val != null ? val : "");
+      }
+      flatRows.add(flatRow);
+    }
+
+    buildSegment(schema, tableConfig, flatSegmentName, flatRows, outDir);
+  }
+
+  private void buildSegment(Schema schema, TableConfig tableConfig, String segmentName,
+      List<GenericRow> rows)
+      throws Exception {
+    buildSegment(schema, tableConfig, segmentName, rows, INDEX_DIR);
+  }
+
+  private void buildSegment(Schema schema, TableConfig tableConfig, String segmentName,
+      List<GenericRow> rows, File outDir)
+      throws Exception {
+    SegmentGeneratorConfig config = new SegmentGeneratorConfig(tableConfig, schema);
+    config.setOutDir(outDir.getAbsolutePath());
+    config.setTableName(schema.getSchemaName());
+    config.setSegmentName(segmentName);
+
+    SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+    driver.init(config, new GenericRowRecordReader(rows));
+    driver.build();
+  }
+
+  // ---- Benchmarking ----
+
+  private void benchmark(String label, String mapQuery, String flatQuery) {
+    LOGGER.info("Benchmarking: {}", label);
+
+    // Warmup + measure on MAP segments
+    _activeSegments = _mapSegments;
+    long[] mapTimes = runQuery(mapQuery, WARMUP_RUNS, MEASURED_RUNS);
+
+    // Warmup + measure on Flattened segments
+    _activeSegments = _flatSegments;
+    long[] flatTimes = runQuery(flatQuery, WARMUP_RUNS, MEASURED_RUNS);
+
+    long mapMedian = median(mapTimes);
+    long flatMedian = median(flatTimes);
+    double ratio = flatMedian > 0 ? (double) mapMedian / flatMedian : 0;
+
+    LOGGER.info("  MAP: {}ms (median), Flat: {}ms (median), Ratio: {}",
+        mapMedian, flatMedian, String.format("%.2fx", ratio));
+
+    _results.add(new BenchmarkResult(label, mapTimes, flatTimes));
+  }
+
+  private long[] runQuery(String query, int warmup, int measured) {
+    // Warmup
+    for (int i = 0; i < warmup; i++) {
+      try {
+        BrokerResponseNative response = getBrokerResponse(query);
+        if (response.getExceptionsSize() > 0) {
+          LOGGER.warn("Query exception during warmup: {}", response.getExceptions());
+        }
+      } catch (Exception e) {
+        LOGGER.warn("Warmup query failed: {}", e.getMessage());
+      }
+    }
+
+    // Measured runs
+    long[] times = new long[measured];
+    for (int i = 0; i < measured; i++) {
+      long start = System.nanoTime();
+      try {
+        getBrokerResponse(query);
+      } catch (Exception e) {
+        LOGGER.warn("Measured query failed: {}", e.getMessage());
+      }
+      times[i] = (System.nanoTime() - start) / 1_000_000;  // convert to ms
+    }
+    return times;
+  }
+
+  private static long median(long[] values) {
+    long[] sorted = values.clone();
+    Arrays.sort(sorted);
+    return sorted[sorted.length / 2];
+  }
+
+  // ---- Report Generation ----
+
+  private void writeReport()
+      throws IOException {
+    File reportFile = new File(INDEX_DIR.getParentFile(), "benchmark-results-columnar-map-vs-flattened.md");
+    try (PrintWriter pw = new PrintWriter(new FileWriter(reportFile))) {
+      pw.println("# COLUMNAR_MAP vs Flattened Benchmark Results");
+      pw.println();
+      int totalDocs = NUM_SEGMENTS * DOCS_PER_SEGMENT;
+      pw.printf("**Date:** %s%n", Instant.now());
+      pw.printf("**Segments:** %d × %,d docs = **%,d total docs**%n", NUM_SEGMENTS, DOCS_PER_SEGMENT, totalDocs);
+      pw.printf("**Warmup:** %d runs, **Measured:** %d runs%n", WARMUP_RUNS, MEASURED_RUNS);
+      pw.printf("**Dense keys (>50%% fill):** tenancy, country, device_os, event_type, session_id%n");
+      pw.printf("**Sparse keys (<50%% fill):** discount_code, referral, error_code, debug_trace, experiment_id%n");
+      pw.println();
+
+      // Storage
+      pw.println("## Storage");
+      pw.println();
+      pw.println("| Table | Total Size | Bytes/Doc |");
+      pw.println("|---|---|---|");
+      pw.printf("| COLUMNAR_MAP | %.1f MB | %.1f |%n",
+          _mapSegmentSize / (1024.0 * 1024.0), (double) _mapSegmentSize / totalDocs);
+      pw.printf("| Flattened | %.1f MB | %.1f |%n",
+          _flatSegmentSize / (1024.0 * 1024.0), (double) _flatSegmentSize / totalDocs);
+      pw.printf("| **Ratio** | **%.2fx** | |%n",
+          (double) _mapSegmentSize / _flatSegmentSize);
+      pw.println();
+
+      // Query Latency
+      pw.println("## Query Latency (median of " + MEASURED_RUNS + " runs, ms)");
+      pw.println();
+      pw.println("| Query | MAP (ms) | Flat (ms) | Ratio | MAP range | Flat range |");
+      pw.println("|---|---|---|---|---|---|");
+      for (BenchmarkResult r : _results) {
+        long mapMedian = median(r._mapTimes);
+        long flatMedian = median(r._flatTimes);
+        double ratio = flatMedian > 0 ? (double) mapMedian / flatMedian : 0;
+        pw.printf("| %s | %d | %d | %.2fx | %d-%d | %d-%d |%n",
+            r._label, mapMedian, flatMedian, ratio,
+            min(r._mapTimes), max(r._mapTimes),
+            min(r._flatTimes), max(r._flatTimes));
+      }
+      pw.println();
+
+      // Raw data
+      pw.println("## Raw Data (all runs, ms)");
+      pw.println();
+      for (BenchmarkResult r : _results) {
+        pw.printf("**%s**%n", r._label);
+        pw.printf("- MAP: %s%n", Arrays.toString(r._mapTimes));
+        pw.printf("- Flat: %s%n%n", Arrays.toString(r._flatTimes));
+      }
+    }
+    LOGGER.info("Report written to: {}", reportFile.getAbsolutePath());
+  }
+
+  private static long min(long[] values) {
+    long m = Long.MAX_VALUE;
+    for (long v : values) {
+      m = Math.min(m, v);
+    }
+    return m;
+  }
+
+  private static long max(long[] values) {
+    long m = Long.MIN_VALUE;
+    for (long v : values) {
+      m = Math.max(m, v);
+    }
+    return m;
+  }
+
+  // ---- Helpers ----
+
+  private static String[] generateCountries() {
+    return new String[]{
+        "US", "MX", "BR", "CA", "GB", "FR", "DE", "ES", "IT", "NL",
+        "AU", "JP", "KR", "IN", "ID", "TH", "VN", "PH", "MY", "SG",
+        "AE", "SA", "EG", "ZA", "NG", "KE", "GH", "CO", "AR", "CL",
+        "PE", "EC", "VE", "UY", "PY", "BO", "CR", "PA", "DO", "GT",
+        "HN", "SV", "NI", "CU", "JM", "TT", "BZ", "HT", "PR", "BB"
+    };
+  }
+
+  private static String[] generateCodes(String prefix, int count) {
+    String[] codes = new String[count];
+    for (int i = 0; i < count; i++) {
+      codes[i] = prefix + String.format("%03d", i + 1);
+    }
+    return codes;
+  }
+
+  private static class BenchmarkResult {
+    final String _label;
+    final long[] _mapTimes;
+    final long[] _flatTimes;
+
+    BenchmarkResult(String label, long[] mapTimes, long[] flatTimes) {
+      _label = label;
+      _mapTimes = mapTimes;
+      _flatTimes = flatTimes;
+    }
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/BaseSegmentCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/BaseSegmentCreator.java
@@ -331,9 +331,18 @@ public abstract class BaseSegmentCreator implements SegmentCreator {
   private <C extends IndexConfig> void tryCreateIndexCreator(Map<IndexType<?, ?, ?>, IndexCreator> creatorsByIndex,
       IndexType<C, ?, ?> index, IndexCreationContext.Common context, FieldIndexConfigs fieldIndexConfigs)
       throws Exception {
+    // Skip forward index for MAP columns that have columnar map index enabled
+    if (index == StandardIndexes.forward()
+        && context.getFieldSpec().getDataType() == FieldSpec.DataType.MAP
+        && fieldIndexConfigs.getConfig(StandardIndexes.columnarMap()).isEnabled()) {
+      return;
+    }
     C config = fieldIndexConfigs.getConfig(index);
     if (config.isEnabled()) {
-      creatorsByIndex.put(index, index.createIndexCreator(context, config));
+      IndexCreator creator = index.createIndexCreator(context, config);
+      if (creator != null) {
+        creatorsByIndex.put(index, creator);
+      }
     }
   }
 
@@ -420,6 +429,7 @@ public abstract class BaseSegmentCreator implements SegmentCreator {
     properties.setProperty(METRICS, _config.getMetrics());
     properties.setProperty(DATETIME_COLUMNS, _config.getDateTimeColumnNames());
     properties.setProperty(COMPLEX_COLUMNS, _config.getComplexColumnNames());
+    properties.setProperty(COLUMNAR_MAP_COLUMNS, _config.getColumnarMapColumnNames());
     String timeColumnName = _config.getTimeColumnName();
     properties.setProperty(TIME_COLUMN_NAME, timeColumnName);
     properties.setProperty(SEGMENT_TOTAL_DOCS, String.valueOf(_totalDocs));
@@ -602,6 +612,29 @@ public abstract class BaseSegmentCreator implements SegmentCreator {
       DateTimeFieldSpec dateTimeFieldSpec = (DateTimeFieldSpec) fieldSpec;
       properties.setProperty(getKeyFor(column, DATETIME_FORMAT), dateTimeFieldSpec.getFormat());
       properties.setProperty(getKeyFor(column, DATETIME_GRANULARITY), dateTimeFieldSpec.getGranularity());
+    }
+
+    // MAP field with sparse map index: persist key-type declarations so they survive segment reload.
+    // Each key name and its type are stored as separate properties to avoid comma-delimiter
+    // issues in PropertiesConfiguration multi-value parsing.
+    if (dataType == DataType.MAP && fieldSpec instanceof ComplexFieldSpec) {
+      ComplexFieldSpec complexSpec = (ComplexFieldSpec) fieldSpec;
+      ComplexFieldSpec.MapFieldSpec mapFieldSpec = ComplexFieldSpec.toMapFieldSpec(complexSpec);
+      Map<String, DataType> keyTypes = mapFieldSpec.getKeyTypes();
+      if (keyTypes != null && !keyTypes.isEmpty()) {
+        properties.setProperty(getKeyFor(column, COLUMNAR_MAP_KEY_NAMES),
+            new ArrayList<>(keyTypes.keySet()));
+        for (Map.Entry<String, DataType> entry : keyTypes.entrySet()) {
+          properties.setProperty(
+              getKeyFor(column, COLUMNAR_MAP_KEY_TYPE_PREFIX + "." + entry.getKey()),
+              entry.getValue().name());
+        }
+      }
+      DataType defaultValueType = mapFieldSpec.getDefaultValueType();
+      if (defaultValueType != null) {
+        properties.setProperty(getKeyFor(column, COLUMNAR_MAP_DEFAULT_VALUE_TYPE),
+            defaultValueType.name());
+      }
     }
 
     if (fieldType != FieldType.COMPLEX) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/ColumnarMapColumnPreIndexStatsCollector.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/ColumnarMapColumnPreIndexStatsCollector.java
@@ -1,0 +1,79 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.creator.impl.stats;
+
+import org.apache.pinot.segment.spi.creator.StatsCollectorConfig;
+
+
+/**
+ * Statistics collector for MAP columns with sparse map index.
+ *
+ * <p>Unlike regular columns, MAP columns with sparse map index store all per-key data in the ColumnarMapIndex itself.
+ * This collector only tracks document count; no min/max/cardinality/dictionary is needed.
+ */
+public class ColumnarMapColumnPreIndexStatsCollector extends AbstractColumnStatisticsCollector {
+
+  private boolean _sealed = false;
+
+  public ColumnarMapColumnPreIndexStatsCollector(String column, StatsCollectorConfig statsCollectorConfig) {
+    super(column, statsCollectorConfig);
+    _sorted = false;
+  }
+
+  @Override
+  public void collect(Object entry) {
+    assert !_sealed;
+    _totalNumberOfEntries++;
+  }
+
+  @Override
+  public Comparable getMinValue() {
+    return null;
+  }
+
+  @Override
+  public Comparable getMaxValue() {
+    return null;
+  }
+
+  @Override
+  public Object getUniqueValuesSet() {
+    return null;
+  }
+
+  @Override
+  public int getCardinality() {
+    return 0;
+  }
+
+  @Override
+  public int getLengthOfLongestElement() {
+    return 0;
+  }
+
+  @Override
+  public int getLengthOfShortestElement() {
+    return 0;
+  }
+
+  @Override
+  public void seal() {
+    _sealed = true;
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/StatsCollectorUtil.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/StatsCollectorUtil.java
@@ -44,7 +44,7 @@ public final class StatsCollectorUtil {
       FieldIndexConfigs indexConfig, StatsCollectorConfig statsCollectorConfig) {
     boolean dictionaryEnabled = indexConfig.getConfig(StandardIndexes.dictionary()).isEnabled();
     if (!dictionaryEnabled) {
-      // MAP collector is optimised for no-dictionary collection
+      // MAP collectors are optimised for no-dictionary collection
       if (!fieldSpec.getDataType().getStoredType().equals(FieldSpec.DataType.MAP)) {
         if (ClusterConfigForTable.useOptimizedNoDictCollector(statsCollectorConfig.getTableConfig())) {
           return new NoDictColumnStatisticsCollector(columnName, statsCollectorConfig);
@@ -67,6 +67,9 @@ public final class StatsCollectorUtil {
       case BYTES:
         return new BytesColumnPreIndexStatsCollector(columnName, statsCollectorConfig);
       case MAP:
+        if (indexConfig.getConfig(StandardIndexes.columnarMap()).isEnabled()) {
+          return new ColumnarMapColumnPreIndexStatsCollector(columnName, statsCollectorConfig);
+        }
         return new MapColumnPreIndexStatsCollector(columnName, statsCollectorConfig);
       default:
         throw new IllegalStateException("Unsupported data type: " + fieldSpec.getDataType());

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/columnarmap/ColumnarMapDataSource.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/columnarmap/ColumnarMapDataSource.java
@@ -1,0 +1,671 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.columnarmap;
+
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import javax.annotation.Nullable;
+import org.apache.pinot.segment.local.io.util.FixedBitIntReaderWriter;
+import org.apache.pinot.segment.local.segment.index.datasource.BaseDataSource;
+import org.apache.pinot.segment.local.segment.index.map.NullDataSource;
+import org.apache.pinot.segment.local.segment.index.readers.forward.FixedBitSVForwardIndexReaderV2;
+import org.apache.pinot.segment.spi.ColumnMetadata;
+import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.segment.spi.datasource.DataSourceMetadata;
+import org.apache.pinot.segment.spi.datasource.MapDataSource;
+import org.apache.pinot.segment.spi.index.StandardIndexes;
+import org.apache.pinot.segment.spi.index.column.ColumnIndexContainer;
+import org.apache.pinot.segment.spi.index.mutable.MutableDictionary;
+import org.apache.pinot.segment.spi.index.mutable.MutableForwardIndex;
+import org.apache.pinot.segment.spi.index.reader.ColumnarMapIndexReader;
+import org.apache.pinot.segment.spi.index.reader.ForwardIndexReader;
+import org.apache.pinot.segment.spi.index.reader.ForwardIndexReaderContext;
+import org.apache.pinot.segment.spi.index.reader.NullValueVectorReader;
+import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
+import org.apache.pinot.segment.spi.partition.PartitionFunction;
+import org.apache.pinot.spi.data.ComplexFieldSpec;
+import org.apache.pinot.spi.data.DimensionFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
+import org.roaringbitmap.buffer.MutableRoaringBitmap;
+
+
+/**
+ * Data source for MAP columns with sparse map index. Wraps a {@link ColumnarMapIndexReader} and exposes it for
+ * query access.
+ *
+ * <p>Implements {@link MapDataSource} so that {@code metrics['key']} expressions handled by
+ * {@code ItemTransformFunction} can resolve per-key {@link DataSource} instances via
+ * {@link #getKeyDataSource(String)}.  Each per-key data source wraps a
+ * {@link ColumnarMapKeyForwardIndexReader} that delegates typed reads directly to the underlying
+ * {@link ColumnarMapIndexReader}.
+ */
+public class ColumnarMapDataSource extends BaseDataSource implements MapDataSource {
+
+  private final ColumnarMapIndexReader _columnarMapIndexReader;
+  private final Map<String, DataSource> _keyDataSourceCache = new ConcurrentHashMap<>();
+
+  /**
+   * Constructs a ColumnarMapDataSource for an immutable segment.
+   */
+  public ColumnarMapDataSource(ColumnMetadata columnMetadata, ColumnarMapIndexReader columnarMapIndexReader) {
+    super(new ColumnarMapDataSourceMetadata(columnMetadata),
+        buildContainerWithForwardIndex(columnarMapIndexReader));
+    _columnarMapIndexReader = columnarMapIndexReader;
+  }
+
+  /**
+   * Constructs a ColumnarMapDataSource for a mutable (real-time) segment.
+   */
+  public ColumnarMapDataSource(FieldSpec fieldSpec, int numDocs, ColumnarMapIndexReader columnarMapIndexReader) {
+    super(new MutableColumnarMapDataSourceMetadata(fieldSpec, numDocs),
+        buildContainerWithForwardIndex(columnarMapIndexReader));
+    _columnarMapIndexReader = columnarMapIndexReader;
+  }
+
+  private static ColumnIndexContainer buildContainerWithForwardIndex(ColumnarMapIndexReader reader) {
+    return new ColumnIndexContainer.FromMap.Builder()
+        .with(StandardIndexes.forward(), new ColumnarMapForwardIndexReader(reader))
+        .build();
+  }
+
+  /**
+   * Returns the ColumnarMapIndexReader for this column.
+   */
+  public ColumnarMapIndexReader getColumnarMapIndexReader() {
+    return _columnarMapIndexReader;
+  }
+
+  // ---- MapDataSource implementation ----
+
+  /**
+   * MAP columns with sparse map index use per-key typed storage rather than the homogeneous
+   * {@link ComplexFieldSpec.MapFieldSpec}. Returns {@code null} because the types are incompatible.
+   */
+  @Nullable
+  @Override
+  public ComplexFieldSpec.MapFieldSpec getFieldSpec() {
+    return null;
+  }
+
+  /**
+   * Returns a per-key {@link DataSource} whose forward index delegates to this column's
+   * {@link ColumnarMapIndexReader} for the requested key.
+   *
+   * <p>For an unknown key (not present in this segment's index), returns a
+   * {@link NullDataSource} that yields the type's default value for every doc. Matches the
+   * contract of {@link org.apache.pinot.segment.local.segment.index.map.BaseMapDataSource}
+   * so callers (e.g. {@code ProjectionBlock}, {@code ItemTransformFunction}) never need a
+   * null guard.
+   */
+  @Override
+  public DataSource getKeyDataSource(String key) {
+    DataSource cached = _keyDataSourceCache.get(key);
+    if (cached != null) {
+      return cached;
+    }
+    DataSource ds = buildKeyDataSource(key);
+    if (ds == null) {
+      ds = new NullDataSource(key);
+    }
+    DataSource existing = _keyDataSourceCache.putIfAbsent(key, ds);
+    return existing != null ? existing : ds;
+  }
+
+  @Override
+  public Map<String, DataSource> getKeyDataSources() {
+    Map<String, DataSource> result = new HashMap<>();
+    for (String key : _columnarMapIndexReader.getKeys()) {
+      result.put(key, getKeyDataSource(key));
+    }
+    return result;
+  }
+
+  @Override
+  public DataSourceMetadata getKeyDataSourceMetadata(String key) {
+    throw new UnsupportedOperationException("getKeyDataSourceMetadata not supported for MAP with sparse map index");
+  }
+
+  @Override
+  public ColumnIndexContainer getKeyIndexContainer(String key) {
+    throw new UnsupportedOperationException("getKeyIndexContainer not supported for MAP with sparse map index");
+  }
+
+  private DataSource buildKeyDataSource(String key) {
+    FieldSpec.DataType keyType = _columnarMapIndexReader.getKeyValueType(key);
+
+    // Check if this is a sparse key (type is known from SPMX metadata but no per-key data)
+    if (keyType == null) {
+      return null;
+    }
+
+    // Mutable segment: use per-key FixedByteSVMutableForwardIndex directly (O(1) lock-free reads)
+    if (_columnarMapIndexReader instanceof MutableColumnarMapIndexImpl) {
+      return buildMutableKeyDataSource(key, keyType, (MutableColumnarMapIndexImpl) _columnarMapIndexReader);
+    }
+
+    if (_columnarMapIndexReader instanceof ImmutableColumnarMapIndexReader) {
+      ImmutableColumnarMapIndexReader immutableReader = (ImmutableColumnarMapIndexReader) _columnarMapIndexReader;
+      byte tierFlag = immutableReader.getTierFlag(key);
+
+      if (tierFlag == ImmutableColumnarMapIndexReader.TIER_SPARSE) {
+        // Sparse key: build DataSource backed by sidecar JSON blob reader
+        return buildSparseKeyDataSource(key, keyType, immutableReader);
+      }
+    }
+
+    // Dense key (immutable): standard path
+    DimensionFieldSpec keyFieldSpec = new DimensionFieldSpec(key, keyType, true);
+
+    // Try to use pre-built dictionary and dictId reader from immutable reader
+    ColumnarMapKeyDictionary keyDictionary = null;
+    FixedBitIntReaderWriter dictIdReader = null;
+    if (_columnarMapIndexReader instanceof ImmutableColumnarMapIndexReader) {
+      ImmutableColumnarMapIndexReader immutableReader = (ImmutableColumnarMapIndexReader) _columnarMapIndexReader;
+      keyDictionary = immutableReader.getKeyDictionary(key);
+      dictIdReader = immutableReader.getDictIdReader(key);
+    }
+
+    // Fallback: build dictionary from inverted index if pre-built not available
+    if (keyDictionary == null) {
+      String[] distinctValues = _columnarMapIndexReader.getDistinctValuesForKey(key);
+      if (distinctValues != null) {
+        String defaultValue = ColumnarMapKeyDictionary.getDefaultValueString(keyType);
+        distinctValues = mergeDefaultValue(distinctValues, defaultValue, keyType);
+        keyDictionary = new ColumnarMapKeyDictionary(keyType, distinctValues);
+      }
+    }
+
+    // Determine if this is a dense key (direct docId access, no rank())
+    boolean isDense = false;
+    if (_columnarMapIndexReader instanceof ImmutableColumnarMapIndexReader) {
+      isDense = ((ImmutableColumnarMapIndexReader) _columnarMapIndexReader).getTierFlag(key)
+          == ImmutableColumnarMapIndexReader.TIER_DENSE;
+    }
+
+    // For dense dictionary-encoded keys, use FixedBitSVForwardIndexReaderV2 (V2 reader)
+    // which has SIMD-optimized read32() for contiguous docIds — same fast path as regular columns.
+    ForwardIndexReader<?> keyReader;
+    if (isDense && keyDictionary != null && _columnarMapIndexReader instanceof ImmutableColumnarMapIndexReader) {
+      ImmutableColumnarMapIndexReader immutableReader = (ImmutableColumnarMapIndexReader) _columnarMapIndexReader;
+      PinotDataBuffer dictIdFwdBuffer = immutableReader.getDictIdFwdBuffer(key);
+      int numBitsPerDictId = immutableReader.getNumBitsPerDictId(key);
+      if (dictIdFwdBuffer != null && numBitsPerDictId > 0) {
+        int numDocs = getDataSourceMetadata().getNumDocs();
+        keyReader = new FixedBitSVForwardIndexReaderV2(dictIdFwdBuffer, numDocs, numBitsPerDictId);
+      } else {
+        keyReader = new ColumnarMapKeyForwardIndexReader(_columnarMapIndexReader, key, keyType, keyDictionary,
+            dictIdReader, _columnarMapIndexReader.getPresenceBitmap(key), isDense);
+      }
+    } else {
+      keyReader = new ColumnarMapKeyForwardIndexReader(_columnarMapIndexReader, key, keyType, keyDictionary,
+          dictIdReader, _columnarMapIndexReader.getPresenceBitmap(key), isDense);
+    }
+
+    ColumnIndexContainer.FromMap.Builder containerBuilder =
+        new ColumnIndexContainer.FromMap.Builder().with(StandardIndexes.forward(), keyReader);
+    if (keyDictionary != null) {
+      containerBuilder.with(StandardIndexes.dictionary(), keyDictionary);
+    }
+    // Add per-key inverted index if available (enables fast filter path in MapFilterOperator)
+    if (_columnarMapIndexReader instanceof ImmutableColumnarMapIndexReader) {
+      ImmutableColumnarMapIndexReader immutableReader = (ImmutableColumnarMapIndexReader) _columnarMapIndexReader;
+      if (immutableReader.hasInvertedIndex(key) && keyDictionary != null) {
+        containerBuilder.with(StandardIndexes.inverted(),
+            new ColumnarMapKeyInvertedIndexReader(immutableReader, key, keyDictionary));
+      }
+      // Add null value vector for dense keys (docs where key is absent)
+      ImmutableRoaringBitmap nullBitmap = immutableReader.getNullBitmap(key);
+      if (nullBitmap != null) {
+        containerBuilder.with(StandardIndexes.nullValueVector(), bitmapNullValueVector(nullBitmap));
+      }
+    }
+    ColumnIndexContainer keyContainer = containerBuilder.build();
+
+    int numDocs = getDataSourceMetadata().getNumDocs();
+    int cardinality = keyDictionary != null ? keyDictionary.length() : 0;
+    return new BaseDataSource(new KeyDataSourceMetadata(keyFieldSpec, numDocs, cardinality), keyContainer) {
+    };
+  }
+
+  @Nullable
+  private DataSource buildMutableKeyDataSource(String key, FieldSpec.DataType keyType,
+      MutableColumnarMapIndexImpl mutableReader) {
+    MutableForwardIndex fwdIndex = mutableReader.getPerKeyForwardIndex(key);
+    if (fwdIndex == null) {
+      // Key has a known type but was never ingested — lazily initialize storage so it's queryable
+      // (all docs will read default values from the zeroed forward index)
+      mutableReader.ensureKeyStorage(key);
+      fwdIndex = mutableReader.getPerKeyForwardIndex(key);
+      if (fwdIndex == null) {
+        return null;
+      }
+    }
+
+    DimensionFieldSpec keyFieldSpec = new DimensionFieldSpec(key, keyType, true);
+    int numDocs = getDataSourceMetadata().getNumDocs();
+
+    ColumnIndexContainer.FromMap.Builder containerBuilder =
+        new ColumnIndexContainer.FromMap.Builder().with(StandardIndexes.forward(), fwdIndex);
+
+    int cardinality = 0;
+    if (mutableReader.isDictionaryEncodedKey(key)) {
+      MutableDictionary dict = mutableReader.getPerKeyDictionary(key);
+      if (dict != null) {
+        containerBuilder.with(StandardIndexes.dictionary(), dict);
+        cardinality = dict.length();
+      }
+      // Wire dictId-based inverted index for InvertedIndexFilterOperator
+      ColumnarMapRealtimeInvertedIndex invertedIndex = mutableReader.getPerKeyInvertedIndex(key);
+      if (invertedIndex != null) {
+        containerBuilder.with(StandardIndexes.inverted(), invertedIndex);
+      }
+    }
+
+    // Add null value vector for mutable keys (complement of presence bitmap)
+    ImmutableRoaringBitmap presenceBitmap = mutableReader.getPresenceBitmap(key);
+    if (presenceBitmap != null) {
+      int mutableNumDocs = numDocs;
+      MutableRoaringBitmap nullBitmap = new MutableRoaringBitmap();
+      nullBitmap.add(0L, (long) mutableNumDocs);
+      nullBitmap.andNot(presenceBitmap);
+      containerBuilder.with(StandardIndexes.nullValueVector(),
+          bitmapNullValueVector(nullBitmap.toImmutableRoaringBitmap()));
+    }
+
+    ColumnIndexContainer keyContainer = containerBuilder.build();
+    return new BaseDataSource(new KeyDataSourceMetadata(keyFieldSpec, numDocs, cardinality), keyContainer) {
+    };
+  }
+
+  /**
+   * Builds a DataSource for a sparse-tier key backed by the sidecar JSON blob reader.
+   * The forward index reader extracts the key's value from each doc's JSON blob.
+   */
+  private DataSource buildSparseKeyDataSource(String key, FieldSpec.DataType keyType,
+      ImmutableColumnarMapIndexReader immutableReader) {
+    DimensionFieldSpec keyFieldSpec = new DimensionFieldSpec(key, keyType, true);
+    int numDocs = getDataSourceMetadata().getNumDocs();
+
+    // Create a ForwardIndexReader that reads from the sidecar JSON blob
+    // TODO(A11, columnar-map-todos.md): extract this anonymous class to a top-level
+    // ColumnarMapSparseKeyForwardIndexReader so the per-doc JSON parse logic is unit-testable
+    // and the perf fix (cache parsed map per docId in ForwardIndexReaderContext, or stream the
+    // JSON token-by-token) can land independently.
+    ForwardIndexReader<ForwardIndexReaderContext> sparseReader = new ForwardIndexReader<ForwardIndexReaderContext>() {
+      @Override
+      public boolean isDictionaryEncoded() {
+        return false;
+      }
+
+      @Override
+      public boolean isSingleValue() {
+        return true;
+      }
+
+      @Override
+      public FieldSpec.DataType getStoredType() {
+        return keyType.getStoredType();
+      }
+
+      @Override
+      public String getString(int docId, ForwardIndexReaderContext context) {
+        String json = immutableReader.getSparseJsonBlob(docId);
+        if (json == null) {
+          return ColumnarMapKeyDictionary.getDefaultValueString(keyType);
+        }
+        Map<String, Object> map;
+        try {
+          @SuppressWarnings("unchecked")
+          Map<String, Object> parsed = org.apache.pinot.spi.utils.JsonUtils.stringToObject(json, Map.class);
+          map = parsed;
+        } catch (Exception e) {
+          throw new RuntimeException("Failed to parse sparse map sidecar JSON for column='" + getColumnName()
+              + "' key='" + key + "' docId=" + docId, e);
+        }
+        Object val = map.get(key);
+        return val != null ? String.valueOf(val) : ColumnarMapKeyDictionary.getDefaultValueString(keyType);
+      }
+
+      @Override
+      public int getInt(int docId, ForwardIndexReaderContext context) {
+        String val = getString(docId, context);
+        if (val.isEmpty()) {
+          return 0;
+        }
+        try {
+          return Integer.parseInt(val);
+        } catch (NumberFormatException e) {
+          throw new RuntimeException("Sparse map value not parseable as INT for column='" + getColumnName()
+              + "' key='" + key + "' docId=" + docId + " value='" + val + "'", e);
+        }
+      }
+
+      @Override
+      public long getLong(int docId, ForwardIndexReaderContext context) {
+        String val = getString(docId, context);
+        if (val.isEmpty()) {
+          return 0L;
+        }
+        try {
+          return Long.parseLong(val);
+        } catch (NumberFormatException e) {
+          throw new RuntimeException("Sparse map value not parseable as LONG for column='" + getColumnName()
+              + "' key='" + key + "' docId=" + docId + " value='" + val + "'", e);
+        }
+      }
+
+      @Override
+      public float getFloat(int docId, ForwardIndexReaderContext context) {
+        String val = getString(docId, context);
+        if (val.isEmpty()) {
+          return 0.0f;
+        }
+        try {
+          return Float.parseFloat(val);
+        } catch (NumberFormatException e) {
+          throw new RuntimeException("Sparse map value not parseable as FLOAT for column='" + getColumnName()
+              + "' key='" + key + "' docId=" + docId + " value='" + val + "'", e);
+        }
+      }
+
+      @Override
+      public double getDouble(int docId, ForwardIndexReaderContext context) {
+        String val = getString(docId, context);
+        if (val.isEmpty()) {
+          return 0.0;
+        }
+        try {
+          return Double.parseDouble(val);
+        } catch (NumberFormatException e) {
+          throw new RuntimeException("Sparse map value not parseable as DOUBLE for column='" + getColumnName()
+              + "' key='" + key + "' docId=" + docId + " value='" + val + "'", e);
+        }
+      }
+
+      @Override
+      public void close() {
+      }
+    };
+
+    ColumnIndexContainer keyContainer = new ColumnIndexContainer.FromMap.Builder()
+        .with(StandardIndexes.forward(), sparseReader)
+        .build();
+
+    return new BaseDataSource(new KeyDataSourceMetadata(keyFieldSpec, numDocs, 0), keyContainer) {
+    };
+  }
+
+  private static String[] mergeDefaultValue(String[] sortedValues, String defaultValue,
+      FieldSpec.DataType keyType) {
+    Comparator<String> cmp = ColumnarMapKeyDictionary.getComparator(keyType);
+    int insertionPoint = cmp != null
+        ? java.util.Arrays.binarySearch(sortedValues, defaultValue, cmp)
+        : java.util.Arrays.binarySearch(sortedValues, defaultValue);
+    if (insertionPoint >= 0) {
+      // Default value already in the array
+      return sortedValues;
+    }
+    // Insert at the correct position to maintain sorted order
+    int pos = -(insertionPoint + 1);
+    String[] merged = new String[sortedValues.length + 1];
+    System.arraycopy(sortedValues, 0, merged, 0, pos);
+    merged[pos] = defaultValue;
+    System.arraycopy(sortedValues, pos, merged, pos + 1, sortedValues.length - pos);
+    return merged;
+  }
+
+  // ---- Per-key DataSourceMetadata ----
+
+  private static class KeyDataSourceMetadata implements DataSourceMetadata {
+    private final FieldSpec _keyFieldSpec;
+    private final int _numDocs;
+    private final int _cardinality;
+
+    KeyDataSourceMetadata(FieldSpec keyFieldSpec, int numDocs, int cardinality) {
+      _keyFieldSpec = keyFieldSpec;
+      _numDocs = numDocs;
+      _cardinality = cardinality;
+    }
+
+    @Override
+    public FieldSpec getFieldSpec() {
+      return _keyFieldSpec;
+    }
+
+    @Override
+    public boolean isSorted() {
+      return false;
+    }
+
+    @Override
+    public int getNumDocs() {
+      return _numDocs;
+    }
+
+    @Override
+    public int getNumValues() {
+      return _numDocs;
+    }
+
+    @Override
+    public int getMaxNumValuesPerMVEntry() {
+      return -1;
+    }
+
+    @Nullable
+    @Override
+    public Comparable getMinValue() {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public Comparable getMaxValue() {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public PartitionFunction getPartitionFunction() {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public Set<Integer> getPartitions() {
+      return null;
+    }
+
+    @Override
+    public int getCardinality() {
+      return _cardinality;
+    }
+
+    @Override
+    public int getMaxRowLengthInBytes() {
+      return 0;
+    }
+  }
+
+  // ---- Metadata for immutable segments ----
+
+  private static class ColumnarMapDataSourceMetadata implements DataSourceMetadata {
+    private final FieldSpec _fieldSpec;
+    private final int _numDocs;
+    private final int _numValues;
+    private final PartitionFunction _partitionFunction;
+    private final Set<Integer> _partitions;
+
+    ColumnarMapDataSourceMetadata(ColumnMetadata columnMetadata) {
+      _fieldSpec = columnMetadata.getFieldSpec();
+      _numDocs = columnMetadata.getTotalDocs();
+      _numValues = columnMetadata.getTotalNumberOfEntries();
+      _partitionFunction = columnMetadata.getPartitionFunction();
+      _partitions = columnMetadata.getPartitions();
+    }
+
+    @Override
+    public FieldSpec getFieldSpec() {
+      return _fieldSpec;
+    }
+
+    @Override
+    public boolean isSorted() {
+      return false;
+    }
+
+    @Override
+    public int getNumDocs() {
+      return _numDocs;
+    }
+
+    @Override
+    public int getNumValues() {
+      return _numValues;
+    }
+
+    @Override
+    public int getMaxNumValuesPerMVEntry() {
+      return -1;
+    }
+
+    @Nullable
+    @Override
+    public Comparable getMinValue() {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public Comparable getMaxValue() {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public PartitionFunction getPartitionFunction() {
+      return _partitionFunction;
+    }
+
+    @Nullable
+    @Override
+    public Set<Integer> getPartitions() {
+      return _partitions;
+    }
+
+    @Override
+    public int getCardinality() {
+      return 0;
+    }
+
+    @Override
+    public int getMaxRowLengthInBytes() {
+      return 0;
+    }
+  }
+
+  // ---- Metadata for mutable (real-time) segments ----
+
+  private static class MutableColumnarMapDataSourceMetadata implements DataSourceMetadata {
+    private final FieldSpec _fieldSpec;
+    private final int _numDocs;
+
+    MutableColumnarMapDataSourceMetadata(FieldSpec fieldSpec, int numDocs) {
+      _fieldSpec = fieldSpec;
+      _numDocs = numDocs;
+    }
+
+    @Override
+    public FieldSpec getFieldSpec() {
+      return _fieldSpec;
+    }
+
+    @Override
+    public boolean isSorted() {
+      return false;
+    }
+
+    @Override
+    public int getNumDocs() {
+      return _numDocs;
+    }
+
+    @Override
+    public int getNumValues() {
+      return _numDocs;
+    }
+
+    @Override
+    public int getMaxNumValuesPerMVEntry() {
+      return -1;
+    }
+
+    @Nullable
+    @Override
+    public Comparable getMinValue() {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public Comparable getMaxValue() {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public PartitionFunction getPartitionFunction() {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public Set<Integer> getPartitions() {
+      return null;
+    }
+
+    @Override
+    public int getCardinality() {
+      return 0;
+    }
+
+    @Override
+    public int getMaxRowLengthInBytes() {
+      return 0;
+    }
+  }
+
+  private static NullValueVectorReader bitmapNullValueVector(ImmutableRoaringBitmap nullBitmap) {
+    return new NullValueVectorReader() {
+      @Override
+      public boolean isNull(int docId) {
+        return nullBitmap.contains(docId);
+      }
+
+      @Override
+      public ImmutableRoaringBitmap getNullBitmap() {
+        return nullBitmap;
+      }
+    };
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/columnarmap/ColumnarMapForwardIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/columnarmap/ColumnarMapForwardIndexReader.java
@@ -1,0 +1,78 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.columnarmap;
+
+import java.io.IOException;
+import java.util.Map;
+import org.apache.pinot.segment.spi.index.reader.ColumnarMapIndexReader;
+import org.apache.pinot.segment.spi.index.reader.ForwardIndexReader;
+import org.apache.pinot.segment.spi.index.reader.ForwardIndexReaderContext;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+
+
+/**
+ * A {@link ForwardIndexReader} for the parent MAP column (with sparse map index) that delegates to
+ * {@link ColumnarMapIndexReader#getMap(int)}.
+ *
+ * <p>This reader exposes the reconstructed {@code Map<String, Object>} for each document,
+ * allowing downstream consumers ({@code PinotSegmentColumnReader}, {@code PinotSegmentRecordReader},
+ * {@code RealtimeSegmentStatsContainer}) to read MAP columns with sparse map index through the standard forward
+ * index API without any special-casing.
+ *
+ * <p>Only {@link #getMap(int, ForwardIndexReaderContext)} is implemented; other typed accessors
+ * ({@code getInt}, {@code getString}, etc.) throw {@code UnsupportedOperationException} via the
+ * default interface methods.
+ *
+ * <p>Lifecycle: this reader does NOT own the underlying {@link ColumnarMapIndexReader}—closing this
+ * reader is a no-op. The owning {@link ColumnarMapDataSource} is responsible for closing the reader.
+ */
+public class ColumnarMapForwardIndexReader implements ForwardIndexReader<ForwardIndexReaderContext> {
+
+  private final ColumnarMapIndexReader _columnarMapIndexReader;
+
+  public ColumnarMapForwardIndexReader(ColumnarMapIndexReader columnarMapIndexReader) {
+    _columnarMapIndexReader = columnarMapIndexReader;
+  }
+
+  @Override
+  public boolean isDictionaryEncoded() {
+    return false;
+  }
+
+  @Override
+  public boolean isSingleValue() {
+    return true;
+  }
+
+  @Override
+  public DataType getStoredType() {
+    return DataType.MAP;
+  }
+
+  @Override
+  public Map<String, Object> getMap(int docId, ForwardIndexReaderContext context) {
+    return _columnarMapIndexReader.getMap(docId);
+  }
+
+  @Override
+  public void close()
+      throws IOException {
+    // no-op: the underlying reader is owned by ColumnarMapDataSource
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/columnarmap/ColumnarMapIndexHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/columnarmap/ColumnarMapIndexHandler.java
@@ -1,0 +1,114 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.columnarmap;
+
+import java.io.File;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.apache.pinot.segment.local.segment.index.loader.BaseIndexHandler;
+import org.apache.pinot.segment.spi.index.FieldIndexConfigs;
+import org.apache.pinot.segment.spi.index.FieldIndexConfigsUtil;
+import org.apache.pinot.segment.spi.index.StandardIndexes;
+import org.apache.pinot.segment.spi.store.SegmentDirectory;
+import org.apache.pinot.spi.config.table.ColumnarMapIndexConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.data.Schema;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Handles loading, adding and removing ColumnarMap indexes during segment reload.
+ *
+ * <p>Note: ColumnarMap indexes are created during segment ingestion only. This handler manages
+ * removal of the index when the table config disables it. Creating a new ColumnarMap index
+ * from an existing segment is not supported (requires re-ingestion).
+ *
+ * <p>Segment merge: when segments are merged (e.g., via the Minion merge task), the sparse map
+ * index is rebuilt from scratch by re-ingesting all documents through
+ * {@link OnHeapColumnarMapIndexCreator}. The resulting merged index contains the union of all
+ * keys observed across the merged segments, subject to the {@code maxKeys} limit configured
+ * for the merged segment. No explicit merge handler is needed; the creator handles key-set
+ * union naturally as documents are added in sequence.
+ */
+public class ColumnarMapIndexHandler extends BaseIndexHandler {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ColumnarMapIndexHandler.class);
+
+  private final Map<String, ColumnarMapIndexConfig> _columnarMapIndexConfigs;
+
+  public ColumnarMapIndexHandler(SegmentDirectory segmentDirectory, Map<String, FieldIndexConfigs> fieldIndexConfigs,
+      TableConfig tableConfig, Schema schema) {
+    super(segmentDirectory, fieldIndexConfigs, tableConfig, schema);
+    _columnarMapIndexConfigs =
+        FieldIndexConfigsUtil.enableConfigByColumn(StandardIndexes.columnarMap(), _fieldIndexConfigs);
+  }
+
+  @Override
+  public boolean needUpdateIndices(SegmentDirectory.Reader segmentReader) {
+    String segmentName = _segmentDirectory.getSegmentMetadata().getName();
+    Set<String> columnsToAddIdx = new HashSet<>(_columnarMapIndexConfigs.keySet());
+    Set<String> existingColumns =
+        segmentReader.toSegmentDirectory().getColumnsWithIndex(StandardIndexes.columnarMap());
+    for (String column : existingColumns) {
+      if (!columnsToAddIdx.contains(column)) {
+        LOGGER.info("Need to remove existing ColumnarMap index from segment: {}, column: {}", segmentName, column);
+        return true;
+      }
+    }
+    return false;
+  }
+
+  @Override
+  public void updateIndices(SegmentDirectory.Writer segmentWriter)
+      throws Exception {
+    String segmentName = _segmentDirectory.getSegmentMetadata().getName();
+    Set<String> columnsToAddIdx = new HashSet<>(_columnarMapIndexConfigs.keySet());
+    Set<String> existingColumns =
+        segmentWriter.toSegmentDirectory().getColumnsWithIndex(StandardIndexes.columnarMap());
+    for (String column : existingColumns) {
+      if (!columnsToAddIdx.contains(column)) {
+        LOGGER.info("Removing existing ColumnarMap index from segment: {}, column: {}", segmentName, column);
+        segmentWriter.removeIndex(column, StandardIndexes.columnarMap());
+        // Also remove sparse sidecar file if it exists
+        File indexDir = _segmentDirectory.getSegmentMetadata().getIndexDir();
+        if (indexDir != null) {
+          File sidecarFile = new File(indexDir,
+              column + OnHeapColumnarMapIndexCreator.SPARSE_SIDECAR_EXTENSION);
+          if (sidecarFile.exists() && sidecarFile.delete()) {
+            LOGGER.info("Removed sparse sidecar file for column: {}", column);
+          }
+        }
+        LOGGER.info("Removed ColumnarMap index from segment: {}, column: {}", segmentName, column);
+      }
+    }
+    for (String column : columnsToAddIdx) {
+      if (!existingColumns.contains(column)) {
+        LOGGER.warn(
+            "Cannot add ColumnarMap index to existing segment: {}, column: {}. Re-ingest the segment to create the "
+                + "ColumnarMap index.", segmentName, column);
+      }
+    }
+  }
+
+  @Override
+  public void postUpdateIndicesCleanup(SegmentDirectory.Writer segmentWriter) {
+    // No temporary forward index to clean up for ColumnarMap indexes.
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/columnarmap/ColumnarMapIndexPlugin.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/columnarmap/ColumnarMapIndexPlugin.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.columnarmap;
+
+import com.google.auto.service.AutoService;
+import org.apache.pinot.segment.spi.index.IndexPlugin;
+
+
+/** Registers {@link ColumnarMapIndexType} via AutoService for SPI discovery. */
+@AutoService(IndexPlugin.class)
+public class ColumnarMapIndexPlugin implements IndexPlugin<ColumnarMapIndexType> {
+  public static final ColumnarMapIndexType INSTANCE = new ColumnarMapIndexType();
+
+  @Override
+  public ColumnarMapIndexType getIndexType() {
+    return INSTANCE;
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/columnarmap/ColumnarMapIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/columnarmap/ColumnarMapIndexType.java
@@ -1,0 +1,147 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.columnarmap;
+
+import com.google.common.base.Preconditions;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.apache.pinot.segment.spi.ColumnMetadata;
+import org.apache.pinot.segment.spi.V1Constants;
+import org.apache.pinot.segment.spi.creator.IndexCreationContext;
+import org.apache.pinot.segment.spi.index.AbstractIndexType;
+import org.apache.pinot.segment.spi.index.ColumnConfigDeserializer;
+import org.apache.pinot.segment.spi.index.FieldIndexConfigs;
+import org.apache.pinot.segment.spi.index.IndexConfigDeserializer;
+import org.apache.pinot.segment.spi.index.IndexHandler;
+import org.apache.pinot.segment.spi.index.IndexReaderConstraintException;
+import org.apache.pinot.segment.spi.index.IndexReaderFactory;
+import org.apache.pinot.segment.spi.index.IndexType;
+import org.apache.pinot.segment.spi.index.StandardIndexes;
+import org.apache.pinot.segment.spi.index.creator.ColumnarMapIndexCreator;
+import org.apache.pinot.segment.spi.index.mutable.MutableIndex;
+import org.apache.pinot.segment.spi.index.mutable.provider.MutableIndexContext;
+import org.apache.pinot.segment.spi.index.reader.ColumnarMapIndexReader;
+import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
+import org.apache.pinot.segment.spi.store.SegmentDirectory;
+import org.apache.pinot.spi.config.table.ColumnarMapIndexConfig;
+import org.apache.pinot.spi.config.table.FieldConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+
+
+/**
+ * Index type for MAP columns with sparse map index. Provides per-key columnar storage with presence bitmaps,
+ * typed forward indexes, and optional inverted indexes for fast value-based filtering.
+ */
+public class ColumnarMapIndexType
+    extends AbstractIndexType<ColumnarMapIndexConfig, ColumnarMapIndexReader, ColumnarMapIndexCreator> {
+  public static final String INDEX_DISPLAY_NAME = "columnar_map";
+  private static final List<String> EXTENSIONS =
+      Collections.singletonList(V1Constants.Indexes.COLUMNAR_MAP_INDEX_FILE_EXTENSION);
+
+  protected ColumnarMapIndexType() {
+    super(StandardIndexes.COLUMNAR_MAP_ID);
+  }
+
+  @Override
+  public Class<ColumnarMapIndexConfig> getIndexConfigClass() {
+    return ColumnarMapIndexConfig.class;
+  }
+
+  @Override
+  public ColumnarMapIndexConfig getDefaultConfig() {
+    return ColumnarMapIndexConfig.DISABLED;
+  }
+
+  @Override
+  protected ColumnConfigDeserializer<ColumnarMapIndexConfig> createDeserializerForLegacyConfigs() {
+    return IndexConfigDeserializer.fromIndexTypes(FieldConfig.IndexType.COLUMNAR_MAP,
+        (tableConfig, fieldConfig) -> ColumnarMapIndexConfig.fromProperties(fieldConfig.getProperties()));
+  }
+
+  @Override
+  public void validate(FieldIndexConfigs indexConfigs, FieldSpec fieldSpec, TableConfig tableConfig) {
+    ColumnarMapIndexConfig config = indexConfigs.getConfig(this);
+    if (config.isEnabled()) {
+      String column = fieldSpec.getName();
+      Preconditions.checkState(fieldSpec.isSingleValueField(),
+          "Cannot create ColumnarMap index on multi-value column: %s", column);
+      Preconditions.checkState(fieldSpec.getDataType() == FieldSpec.DataType.MAP,
+          "ColumnarMap index can only be created on MAP columns, got: %s for column: %s",
+          fieldSpec.getDataType(), column);
+    }
+  }
+
+  @Override
+  public String getPrettyName() {
+    return INDEX_DISPLAY_NAME;
+  }
+
+  @Override
+  public ColumnarMapIndexCreator createIndexCreator(IndexCreationContext context, ColumnarMapIndexConfig indexConfig)
+      throws IOException {
+    return new OnHeapColumnarMapIndexCreator(context, indexConfig);
+  }
+
+  @Override
+  protected IndexReaderFactory<ColumnarMapIndexReader> createReaderFactory() {
+    return new IndexReaderFactory.Default<ColumnarMapIndexConfig, ColumnarMapIndexReader>() {
+      @Override
+      protected IndexType<ColumnarMapIndexConfig, ColumnarMapIndexReader, ?> getIndexType() {
+        return ColumnarMapIndexType.this;
+      }
+
+      @Override
+      protected ColumnarMapIndexReader createIndexReader(PinotDataBuffer dataBuffer, ColumnMetadata metadata,
+          ColumnarMapIndexConfig indexConfig)
+          throws IOException, IndexReaderConstraintException {
+        return new ImmutableColumnarMapIndexReader(dataBuffer, metadata);
+      }
+    };
+  }
+
+  @Override
+  public List<String> getFileExtensions(@Nullable ColumnMetadata columnMetadata) {
+    return EXTENSIONS;
+  }
+
+  @Override
+  public IndexHandler createIndexHandler(SegmentDirectory segmentDirectory, Map<String, FieldIndexConfigs> configsByCol,
+      Schema schema, TableConfig tableConfig) {
+    return new ColumnarMapIndexHandler(segmentDirectory, configsByCol, tableConfig, schema);
+  }
+
+  @Nullable
+  @Override
+  public MutableIndex createMutableIndex(MutableIndexContext context, ColumnarMapIndexConfig config) {
+    if (!config.isEnabled()) {
+      return null;
+    }
+    if (context.getFieldSpec().getDataType() != FieldSpec.DataType.MAP) {
+      return null;
+    }
+    // TODO: Implement MutableColumnarMapIndexImpl in PR 2 (query layer).
+    //  Until then, REALTIME tables with COLUMNAR_MAP will fail at segment creation.
+    throw new UnsupportedOperationException("Mutable COLUMNAR_MAP index not available in this build");
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/columnarmap/ColumnarMapIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/columnarmap/ColumnarMapIndexType.java
@@ -140,8 +140,6 @@ public class ColumnarMapIndexType
     if (context.getFieldSpec().getDataType() != FieldSpec.DataType.MAP) {
       return null;
     }
-    // TODO: Implement MutableColumnarMapIndexImpl in PR 2 (query layer).
-    //  Until then, REALTIME tables with COLUMNAR_MAP will fail at segment creation.
-    throw new UnsupportedOperationException("Mutable COLUMNAR_MAP index not available in this build");
+    return new MutableColumnarMapIndexImpl(context, config);
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/columnarmap/ColumnarMapKeyDictionary.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/columnarmap/ColumnarMapKeyDictionary.java
@@ -1,0 +1,336 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.columnarmap;
+
+import com.google.common.base.Preconditions;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.ints.IntSet;
+import it.unimi.dsi.fastutil.ints.IntSets;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.util.Arrays;
+import java.util.Comparator;
+import org.apache.pinot.common.request.context.predicate.RangePredicate;
+import org.apache.pinot.segment.spi.index.reader.Dictionary;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.utils.ByteArray;
+import org.apache.pinot.spi.utils.BytesUtils;
+
+
+/**
+ * In-memory {@link Dictionary} implementation backed by sorted distinct values extracted from the
+ * columnar map value dictionary section. Enables dictionary-based GROUP BY for columnar map key columns.
+ *
+ * <p>All values are stored as sorted strings regardless of the key's declared type, with typed
+ * parsing on demand (e.g. {@code Integer.parseInt} in {@link #getIntValue}). This string-based
+ * approach was chosen because:
+ * <ul>
+ *   <li>SQL predicates arrive as strings ({@code WHERE metrics['clicks'] = '42'}) — even with
+ *       native typed arrays, the predicate string would need parsing for binary search</li>
+ *   <li>Dictionary value reads only happen when materializing final results (small result set);
+ *       the hot path for GROUP BY is {@code readDictIds()} on the bit-packed forward index</li>
+ *   <li>A single code path for all types keeps the writer, reader, and dictionary simple —
+ *       typed arrays would mean 4+ code paths with more surface area for bugs</li>
+ * </ul>
+ *
+ * <p>TODO: If profiling shows dictionary value access is a bottleneck, switch to native typed
+ * arrays (int[], long[], double[], String[]) for zero-parse forward lookups and type-aware
+ * binary search for indexOf. This would require corresponding changes in
+ * {@link OnHeapColumnarMapIndexCreator#buildValueDictionarySection} (write fixed-width values)
+ * and {@link ImmutableColumnarMapIndexReader} (read into typed arrays).
+ *
+ * <p>The reverse map provides O(1) string-to-dictId lookup. Since the source values come from a
+ * sorted inverted index (TreeMap or sorted binary scan), the dictionary is always sorted.
+ *
+ * <p>Thread safety: this class is immutable after construction and safe for concurrent reads.
+ */
+public class ColumnarMapKeyDictionary implements Dictionary {
+
+  private final DataType _valueType;
+  private final String[] _sortedValues;
+  private final Object2IntOpenHashMap<String> _valueToIdMap;
+
+  public ColumnarMapKeyDictionary(DataType valueType, String[] sortedDistinctValues) {
+    _valueType = valueType;
+    _sortedValues = sortedDistinctValues;
+    _valueToIdMap = new Object2IntOpenHashMap<>(sortedDistinctValues.length);
+    _valueToIdMap.defaultReturnValue(NULL_VALUE_INDEX);
+    for (int i = 0; i < sortedDistinctValues.length; i++) {
+      _valueToIdMap.put(sortedDistinctValues[i], i);
+    }
+  }
+
+  @Override
+  public boolean isSorted() {
+    return true;
+  }
+
+  @Override
+  public DataType getValueType() {
+    return _valueType;
+  }
+
+  @Override
+  public int length() {
+    return _sortedValues.length;
+  }
+
+  @Override
+  public int indexOf(String stringValue) {
+    return _valueToIdMap.getInt(stringValue);
+  }
+
+  @Override
+  public int indexOf(int intValue) {
+    return indexOf(String.valueOf(intValue));
+  }
+
+  @Override
+  public int indexOf(long longValue) {
+    return indexOf(String.valueOf(longValue));
+  }
+
+  @Override
+  public int indexOf(float floatValue) {
+    return indexOf(String.valueOf(floatValue));
+  }
+
+  @Override
+  public int indexOf(double doubleValue) {
+    return indexOf(String.valueOf(doubleValue));
+  }
+
+  @Override
+  public int indexOf(BigDecimal bigDecimalValue) {
+    return indexOf(bigDecimalValue.toPlainString());
+  }
+
+  @Override
+  public int indexOf(ByteArray bytesValue) {
+    return indexOf(bytesValue.toHexString());
+  }
+
+  @Override
+  public int insertionIndexOf(String stringValue) {
+    int index = _valueToIdMap.getInt(stringValue);
+    if (index != NULL_VALUE_INDEX) {
+      return index;
+    }
+    Comparator<String> cmp = getComparator(_valueType);
+    if (cmp != null) {
+      return Arrays.binarySearch(_sortedValues, stringValue, cmp);
+    }
+    return Arrays.binarySearch(_sortedValues, stringValue);
+  }
+
+  @Override
+  public IntSet getDictIdsInRange(String lower, String upper, boolean includeLower, boolean includeUpper) {
+    int numValues = _sortedValues.length;
+    if (numValues == 0) {
+      return IntSets.EMPTY_SET;
+    }
+
+    // Determine the start index (inclusive) using binary search on the sorted array.
+    int startIndex;
+    if (lower.equals(RangePredicate.UNBOUNDED)) {
+      startIndex = 0;
+    } else {
+      int idx = binarySearch(lower);
+      if (idx >= 0) {
+        // Exact match found
+        startIndex = includeLower ? idx : idx + 1;
+      } else {
+        // Not found: insertion point is -(idx + 1), the first element greater than lower
+        startIndex = -(idx + 1);
+      }
+    }
+
+    // Determine the end index (exclusive) using binary search on the sorted array.
+    int endIndex;
+    if (upper.equals(RangePredicate.UNBOUNDED)) {
+      endIndex = numValues;
+    } else {
+      int idx = binarySearch(upper);
+      if (idx >= 0) {
+        // Exact match found
+        endIndex = includeUpper ? idx + 1 : idx;
+      } else {
+        // Not found: insertion point is the first element greater than upper
+        endIndex = -(idx + 1);
+      }
+    }
+
+    int count = endIndex - startIndex;
+    if (count <= 0) {
+      return IntSets.EMPTY_SET;
+    }
+    IntSet dictIds = new IntOpenHashSet(count);
+    for (int i = startIndex; i < endIndex; i++) {
+      dictIds.add(i);
+    }
+    return dictIds;
+  }
+
+  /// Performs a binary search on the sorted values array using the type-appropriate comparator.
+  private int binarySearch(String value) {
+    Comparator<String> cmp = getComparator(_valueType);
+    if (cmp != null) {
+      return Arrays.binarySearch(_sortedValues, value, cmp);
+    }
+    return Arrays.binarySearch(_sortedValues, value);
+  }
+
+  @Override
+  public int compare(int dictId1, int dictId2) {
+    return Integer.compare(dictId1, dictId2);
+  }
+
+  @Override
+  public Comparable getMinVal() {
+    if (_sortedValues.length == 0) {
+      return null;
+    }
+    return parseValue(_sortedValues[0]);
+  }
+
+  @Override
+  public Comparable getMaxVal() {
+    if (_sortedValues.length == 0) {
+      return null;
+    }
+    return parseValue(_sortedValues[_sortedValues.length - 1]);
+  }
+
+  @Override
+  public Object getSortedValues() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public Object get(int dictId) {
+    checkDictId(dictId);
+    return parseValue(_sortedValues[dictId]);
+  }
+
+  @Override
+  public int getIntValue(int dictId) {
+    checkDictId(dictId);
+    return Integer.parseInt(_sortedValues[dictId]);
+  }
+
+  @Override
+  public long getLongValue(int dictId) {
+    checkDictId(dictId);
+    return Long.parseLong(_sortedValues[dictId]);
+  }
+
+  @Override
+  public float getFloatValue(int dictId) {
+    checkDictId(dictId);
+    return Float.parseFloat(_sortedValues[dictId]);
+  }
+
+  @Override
+  public double getDoubleValue(int dictId) {
+    checkDictId(dictId);
+    return Double.parseDouble(_sortedValues[dictId]);
+  }
+
+  @Override
+  public BigDecimal getBigDecimalValue(int dictId) {
+    checkDictId(dictId);
+    return new BigDecimal(_sortedValues[dictId]);
+  }
+
+  @Override
+  public String getStringValue(int dictId) {
+    checkDictId(dictId);
+    return _sortedValues[dictId];
+  }
+
+  @Override
+  public byte[] getBytesValue(int dictId) {
+    checkDictId(dictId);
+    return BytesUtils.toBytes(_sortedValues[dictId]);
+  }
+
+  private void checkDictId(int dictId) {
+    Preconditions.checkArgument(dictId >= 0 && dictId < _sortedValues.length,
+        "Invalid dictId: %s, dictionary size: %s", dictId, _sortedValues.length);
+  }
+
+  @Override
+  public void close()
+      throws IOException {
+    // no-op: in-memory dictionary
+  }
+
+  private Comparable parseValue(String stringValue) {
+    switch (_valueType) {
+      case INT:
+        return Integer.parseInt(stringValue);
+      case LONG:
+        return Long.parseLong(stringValue);
+      case FLOAT:
+        return Float.parseFloat(stringValue);
+      case DOUBLE:
+        return Double.parseDouble(stringValue);
+      default:
+        return stringValue;
+    }
+  }
+
+  /**
+   * Returns the string representation of the default (null-substitute) value for the given type.
+   * INT/LONG default to "0", FLOAT/DOUBLE to "0.0", and STRING/BYTES to "".
+   */
+  static String getDefaultValueString(DataType dataType) {
+    switch (dataType) {
+      case INT:
+        return "0";
+      case LONG:
+        return "0";
+      case FLOAT:
+        return "0.0";
+      case DOUBLE:
+        return "0.0";
+      default:
+        return "";
+    }
+  }
+
+  /**
+   * Returns a numeric comparator for the given type, or null for STRING/BYTES (lexicographic).
+   */
+  static Comparator<String> getComparator(DataType valueType) {
+    switch (valueType) {
+      case INT:
+        return Comparator.comparingInt(Integer::parseInt);
+      case LONG:
+        return Comparator.comparingLong(Long::parseLong);
+      case FLOAT:
+        return (a, b) -> Float.compare(Float.parseFloat(a), Float.parseFloat(b));
+      case DOUBLE:
+        return Comparator.comparingDouble(Double::parseDouble);
+      default:
+        return null;
+    }
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/columnarmap/ColumnarMapKeyForwardIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/columnarmap/ColumnarMapKeyForwardIndexReader.java
@@ -1,0 +1,223 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.columnarmap;
+
+import java.io.IOException;
+import javax.annotation.Nullable;
+import org.apache.pinot.segment.local.io.util.FixedBitIntReaderWriter;
+import org.apache.pinot.segment.spi.index.reader.ColumnarMapIndexReader;
+import org.apache.pinot.segment.spi.index.reader.ForwardIndexReader;
+import org.apache.pinot.segment.spi.index.reader.ForwardIndexReaderContext;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.roaringbitmap.PeekableIntIterator;
+import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
+
+
+/**
+ * A per-key {@link ForwardIndexReader} backed by a {@link ColumnarMapIndexReader}.
+ *
+ * <p>Each instance is bound to a single key within a MAP column. Reads for document IDs
+ * that do not contain the key return the type-appropriate zero/empty default value; the caller can
+ * combine this with the presence bitmap ({@link ColumnarMapIndexReader#getPresenceBitmap}) when null
+ * semantics are required.
+ *
+ * <p>When a {@link ColumnarMapKeyDictionary} is provided, this reader supports dictionary-encoded
+ * access via {@link #readDictIds}, enabling dictionary-based GROUP BY operations.
+ *
+ * <p>No context is needed because the {@link ColumnarMapIndexReader} implementations maintain their
+ * own internal state; {@link #createContext()} therefore returns {@code null}.
+ *
+ * <p>Lifecycle: this reader does NOT own the underlying {@link ColumnarMapIndexReader}—closing this
+ * reader is a no-op. The owning {@link ColumnarMapDataSource} is responsible for closing the reader.
+ */
+public class ColumnarMapKeyForwardIndexReader implements ForwardIndexReader<ForwardIndexReaderContext> {
+
+  private final ColumnarMapIndexReader _columnarMapIndexReader;
+  private final String _key;
+  private final DataType _storedType;
+  @Nullable
+  private final ColumnarMapKeyDictionary _dictionary;
+  @Nullable
+  private final FixedBitIntReaderWriter _dictIdReader;
+  private final ImmutableRoaringBitmap _presenceBitmap;
+  private final int _defaultDictId;
+  private final boolean _isDense;
+
+  public ColumnarMapKeyForwardIndexReader(ColumnarMapIndexReader columnarMapIndexReader, String key,
+      DataType storedType) {
+    this(columnarMapIndexReader, key, storedType, null, null, null, false);
+  }
+
+  public ColumnarMapKeyForwardIndexReader(ColumnarMapIndexReader columnarMapIndexReader, String key,
+      DataType storedType, @Nullable ColumnarMapKeyDictionary dictionary) {
+    this(columnarMapIndexReader, key, storedType, dictionary, null, null, false);
+  }
+
+  public ColumnarMapKeyForwardIndexReader(ColumnarMapIndexReader columnarMapIndexReader, String key,
+      DataType storedType, @Nullable ColumnarMapKeyDictionary dictionary,
+      @Nullable FixedBitIntReaderWriter dictIdReader) {
+    this(columnarMapIndexReader, key, storedType, dictionary, dictIdReader, null, false);
+  }
+
+  public ColumnarMapKeyForwardIndexReader(ColumnarMapIndexReader columnarMapIndexReader, String key,
+      DataType storedType, @Nullable ColumnarMapKeyDictionary dictionary,
+      @Nullable FixedBitIntReaderWriter dictIdReader,
+      @Nullable ImmutableRoaringBitmap presenceBitmap) {
+    this(columnarMapIndexReader, key, storedType, dictionary, dictIdReader, presenceBitmap, false);
+  }
+
+  public ColumnarMapKeyForwardIndexReader(ColumnarMapIndexReader columnarMapIndexReader, String key,
+      DataType storedType, @Nullable ColumnarMapKeyDictionary dictionary,
+      @Nullable FixedBitIntReaderWriter dictIdReader,
+      @Nullable ImmutableRoaringBitmap presenceBitmap, boolean isDense) {
+    _columnarMapIndexReader = columnarMapIndexReader;
+    _key = key;
+    _storedType = storedType;
+    _dictionary = dictionary;
+    _dictIdReader = dictIdReader;
+    _presenceBitmap = presenceBitmap != null ? presenceBitmap : ImmutableRoaringBitmap.bitmapOf();
+    _isDense = isDense;
+    if (dictionary != null) {
+      String defaultValueStr = ColumnarMapKeyDictionary.getDefaultValueString(storedType);
+      _defaultDictId = dictionary.indexOf(defaultValueStr);
+    } else {
+      _defaultDictId = 0;
+    }
+  }
+
+  @Override
+  public boolean isDictionaryEncoded() {
+    return _dictionary != null;
+  }
+
+  @Override
+  public boolean isSingleValue() {
+    return true;
+  }
+
+  @Override
+  public DataType getStoredType() {
+    return _storedType;
+  }
+
+  /**
+   * Batch-reads dictionary IDs for a sorted array of document IDs.
+   *
+   * <p>When a sparse dictId forward index is available, this method uses a co-iteration
+   * strategy instead of per-document {@code rank()} calls. A single {@code rankLong()} seeds
+   * the ordinal for the first docId in the batch, then a {@link PeekableIntIterator} walks
+   * the presence bitmap forward alongside the sorted docIds. This reduces per-block cost
+   * from O(blockSize × numContainers) to O(numContainers + blockSize).
+   *
+   * <p>Absent docs return {@code _defaultDictId} — the dictId of the type's default value
+   * (0 for INT/LONG, 0.0 for FLOAT/DOUBLE, "" for STRING). This matches Pinot's standard
+   * nullable column behavior where nulls are indistinguishable from the default value when
+   * null handling is not enabled.
+   *
+   * <p><b>Contract:</b> {@code docIds} must be in ascending order (always true for Pinot
+   * query blocks).
+   */
+  @Override
+  public void readDictIds(int[] docIds, int length, int[] dictIdBuffer, ForwardIndexReaderContext context) {
+    if (_dictionary == null) {
+      throw new UnsupportedOperationException("Dictionary not available for key: " + _key);
+    }
+    if (_dictIdReader != null) {
+      if (_isDense) {
+        // Dense key: direct docId access (full forward index with numDocs entries)
+        // Use batch read when docIds are contiguous (common in full-scan GROUP BY)
+        if (length > 1 && docIds[length - 1] - docIds[0] == length - 1) {
+          _dictIdReader.readInt(docIds[0], length, dictIdBuffer);
+        } else {
+          for (int i = 0; i < length; i++) {
+            dictIdBuffer[i] = _dictIdReader.readInt(docIds[i]);
+          }
+        }
+        return;
+      }
+      // Sparse key: co-iterate sorted docIds with presence bitmap iterator.
+      // Seed ordinal with one rankLong() call for the first docId, then walk forward.
+      int firstDocId = docIds[0];
+      PeekableIntIterator iter = _presenceBitmap.getIntIterator();
+      iter.advanceIfNeeded(firstDocId);
+      int ordinal = (firstDocId == 0) ? 0 : (int) _presenceBitmap.rankLong(firstDocId - 1);
+
+      for (int i = 0; i < length; i++) {
+        int docId = docIds[i];
+        while (iter.hasNext() && iter.peekNext() < docId) {
+          iter.next();
+          ordinal++;
+        }
+        if (iter.hasNext() && iter.peekNext() == docId) {
+          dictIdBuffer[i] = _dictIdReader.readInt(ordinal);
+          iter.next();
+          ordinal++;
+        } else {
+          dictIdBuffer[i] = _defaultDictId;
+        }
+      }
+    } else {
+      // Slow path: getString + indexOf for mutable segments
+      for (int i = 0; i < length; i++) {
+        String rawValue = _columnarMapIndexReader.getString(docIds[i], _key);
+        if (rawValue == null || rawValue.isEmpty()) {
+          dictIdBuffer[i] = _defaultDictId;
+        } else {
+          dictIdBuffer[i] = _dictionary.indexOf(rawValue);
+        }
+      }
+    }
+  }
+
+  @Override
+  public int getInt(int docId, ForwardIndexReaderContext context) {
+    return _columnarMapIndexReader.getInt(docId, _key);
+  }
+
+  @Override
+  public long getLong(int docId, ForwardIndexReaderContext context) {
+    return _columnarMapIndexReader.getLong(docId, _key);
+  }
+
+  @Override
+  public float getFloat(int docId, ForwardIndexReaderContext context) {
+    return _columnarMapIndexReader.getFloat(docId, _key);
+  }
+
+  @Override
+  public double getDouble(int docId, ForwardIndexReaderContext context) {
+    return _columnarMapIndexReader.getDouble(docId, _key);
+  }
+
+  @Override
+  public String getString(int docId, ForwardIndexReaderContext context) {
+    return _columnarMapIndexReader.getString(docId, _key);
+  }
+
+  @Override
+  public byte[] getBytes(int docId, ForwardIndexReaderContext context) {
+    return _columnarMapIndexReader.getBytes(docId, _key);
+  }
+
+  @Override
+  public void close()
+      throws IOException {
+    // no-op: the underlying reader is owned by ColumnarMapDataSource
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/columnarmap/ColumnarMapKeyInvertedIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/columnarmap/ColumnarMapKeyInvertedIndexReader.java
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.columnarmap;
+
+import java.io.IOException;
+import org.apache.pinot.segment.spi.index.reader.InvertedIndexReader;
+import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
+
+
+/**
+ * Adapts the per-key inverted index from {@link ImmutableColumnarMapIndexReader} into the
+ * standard {@link InvertedIndexReader} interface expected by {@code InvertedIndexFilterOperator}.
+ *
+ * <p>Maps dictId → value string (via dictionary) → docId bitmap (via getDocsWithKeyValue).
+ */
+public class ColumnarMapKeyInvertedIndexReader implements InvertedIndexReader<ImmutableRoaringBitmap> {
+
+  private final ImmutableColumnarMapIndexReader _reader;
+  private final String _key;
+  private final ColumnarMapKeyDictionary _dictionary;
+
+  public ColumnarMapKeyInvertedIndexReader(ImmutableColumnarMapIndexReader reader, String key,
+      ColumnarMapKeyDictionary dictionary) {
+    _reader = reader;
+    _key = key;
+    _dictionary = dictionary;
+  }
+
+  @Override
+  public ImmutableRoaringBitmap getDocIds(int dictId) {
+    String value = _dictionary.getStringValue(dictId);
+    ImmutableRoaringBitmap bitmap = _reader.getDocsWithKeyValue(_key, value);
+    return bitmap != null ? bitmap : ImmutableRoaringBitmap.bitmapOf();
+  }
+
+  @Override
+  public void close()
+      throws IOException {
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/columnarmap/ColumnarMapRealtimeInvertedIndex.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/columnarmap/ColumnarMapRealtimeInvertedIndex.java
@@ -1,0 +1,92 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.columnarmap;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import org.apache.pinot.segment.spi.index.mutable.ThreadSafeMutableRoaringBitmap;
+import org.apache.pinot.segment.spi.index.reader.InvertedIndexReader;
+import org.roaringbitmap.buffer.MutableRoaringBitmap;
+
+
+/**
+ * DictId-based inverted index for mutable MAP keys. Similar to
+ * {@link org.apache.pinot.segment.local.realtime.impl.invertedindex.RealtimeInvertedIndex}
+ * but handles non-sequential dictId insertion (gaps). This is needed because MAP keys
+ * pre-index a default value at dictId 0 in the dictionary, but documents may never
+ * explicitly contain that default value, causing a gap when the first real value gets
+ * dictId 1.
+ *
+ * <p>Thread-safe for single writer, multiple readers. Per-bitmap mutations are protected
+ * by {@link ThreadSafeMutableRoaringBitmap}; the list resize path is protected by the
+ * write lock. {@link #getDocIds(int)} returns a synchronized clone, so readers can iterate
+ * the result safely while the writer continues to mutate the underlying bitmap.
+ */
+public class ColumnarMapRealtimeInvertedIndex implements InvertedIndexReader<MutableRoaringBitmap> {
+  private final List<ThreadSafeMutableRoaringBitmap> _bitmaps = new ArrayList<>();
+  private final ReentrantReadWriteLock.ReadLock _readLock;
+  private final ReentrantReadWriteLock.WriteLock _writeLock;
+
+  public ColumnarMapRealtimeInvertedIndex() {
+    ReentrantReadWriteLock readWriteLock = new ReentrantReadWriteLock();
+    _readLock = readWriteLock.readLock();
+    _writeLock = readWriteLock.writeLock();
+  }
+
+  public void add(int dictId, int docId) {
+    if (_bitmaps.size() > dictId) {
+      // Common case: bitmap for this dictId already exists. ThreadSafeMutableRoaringBitmap.add
+      // is internally synchronized; no list mutation, so no list lock needed.
+      _bitmaps.get(dictId).add(docId);
+      return;
+    }
+    // Need to grow the list. Take the write lock — readers may be iterating the list.
+    _writeLock.lock();
+    try {
+      while (_bitmaps.size() <= dictId) {
+        _bitmaps.add(new ThreadSafeMutableRoaringBitmap());
+      }
+      _bitmaps.get(dictId).add(docId);
+    } finally {
+      _writeLock.unlock();
+    }
+  }
+
+  @Override
+  public MutableRoaringBitmap getDocIds(int dictId) {
+    ThreadSafeMutableRoaringBitmap bitmap;
+    _readLock.lock();
+    try {
+      if (_bitmaps.size() <= dictId) {
+        return new MutableRoaringBitmap();
+      }
+      bitmap = _bitmaps.get(dictId);
+    } finally {
+      _readLock.unlock();
+    }
+    // Returns a synchronized clone — safe for the caller to iterate concurrently with new
+    // add() calls from the writer thread.
+    return bitmap.getMutableRoaringBitmap();
+  }
+
+  @Override
+  public void close() {
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/columnarmap/ImmutableColumnarMapIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/columnarmap/ImmutableColumnarMapIndexReader.java
@@ -57,7 +57,14 @@ import org.slf4j.LoggerFactory;
  *   <li>Key metadata (70 bytes/key, big-endian): tierFlag(byte), storedTypeOrdinal(byte),
  *       numDocs(int), nullBitmapOffset(long), nullBitmapLen(long), fwdOffset(long),
  *       fwdLen(long), invOffset(long), invLen(long), dictIdFwdOffset(long),
- *       dictIdFwdLen(long)</li>
+ *       dictIdFwdLen(long).
+ *       <br>Slot semantic depends on tierFlag:
+ *       <br>- TIER_DENSE: nullBitmapOffset/Len point to a Roaring bitmap of ABSENT docs.
+ *           Presence is derived as the complement at load time.
+ *       <br>- TIER_SPARSE: nullBitmapOffset/Len point to a Roaring bitmap of PRESENT docs
+ *           (presence bitmap reused into the same slot). fwd/inv/dictIdFwd slots are 0;
+ *           values live in the JSON sidecar. nullBitmapLen == 0 indicates a legacy segment
+ *           written before sparse presence was tracked.</li>
  *   <li>Per-key data: null bitmap (RLE-optimized Roaring) + forward index + optional
  *       inverted index + optional dictId forward index</li>
  *   <li>Value dictionary: per-key sorted distinct values for dictionary-encoded keys</li>
@@ -223,8 +230,19 @@ public class ImmutableColumnarMapIndexReader implements ColumnarMapIndexReader {
         // Build presence bitmap as complement of null bitmap (for backward compat with query layer)
         _presenceBitmaps[i] = ImmutableRoaringBitmap.flip(_nullBitmaps[i], 0L, (long) _numDocs);
       } else if (_tierFlags[i] == TIER_SPARSE) {
-        // Sparse key: no per-key data in SPMX
-        _presenceBitmaps[i] = ImmutableRoaringBitmap.bitmapOf();
+        // Sparse key: per-key data in SPMX is just a presence bitmap (docs where key is PRESENT).
+        // The same metadata slot used as nullBitmapOffset/Len for dense keys is reused here for
+        // presenceOffset/Len. nullBitmapLen == 0 indicates a legacy segment without sparse
+        // presence — fall back to empty (preserving the pre-fix broken behavior, no worse than
+        // before). New segments always populate this for sparse keys, so IS NULL / IS NOT NULL
+        // queries return correct results.
+        if (nullBitmapLen > 0) {
+          byte[] bitmapBytes = new byte[(int) nullBitmapLen];
+          dataBuffer.copyTo(_perKeyDataSectionOffset + nullBitmapOffset, bitmapBytes, 0, bitmapBytes.length);
+          _presenceBitmaps[i] = new ImmutableRoaringBitmap(ByteBuffer.wrap(bitmapBytes));
+        } else {
+          _presenceBitmaps[i] = ImmutableRoaringBitmap.bitmapOf();
+        }
         _nullBitmaps[i] = null;
       }
     }
@@ -666,8 +684,11 @@ public class ImmutableColumnarMapIndexReader implements ColumnarMapIndexReader {
 
   @Override
   public DataSource getKeyDataSource(String key) {
-    // Implemented in ColumnarMapDataSource (Task 15)
-    return null;
+    // Per-key DataSource construction lives in ColumnarMapDataSource (handles dense/sparse
+    // tier dispatch + per-key forward/inverted index wrapping). The reader-level SPI method
+    // is intentionally not implemented; calling it directly bypasses the data source layer
+    // and would skip the sparse-key fall-back to NullDataSource.
+    throw new UnsupportedOperationException("Use ColumnarMapDataSource.getKeyDataSource() instead");
   }
 
   /// Returns a FixedBitIntReaderWriter for reading bit-packed dictIds for the given key,

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/columnarmap/ImmutableColumnarMapIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/columnarmap/ImmutableColumnarMapIndexReader.java
@@ -1,0 +1,798 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.columnarmap;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.apache.pinot.segment.local.io.util.FixedBitIntReaderWriter;
+import org.apache.pinot.segment.local.io.util.PinotDataBitSet;
+import org.apache.pinot.segment.spi.ColumnMetadata;
+import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.segment.spi.index.reader.ColumnarMapIndexReader;
+import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
+import org.apache.pinot.spi.data.ComplexFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Memory-mapped immutable reader for the ColumnarMap index.
+ * Provides O(1) typed key lookup via presence bitmap rank operations.
+ *
+ * <p>Binary format (written by {@link OnHeapColumnarMapIndexCreator}):
+ * <ul>
+ *   <li>Header (56 bytes): magic(int), version(int), numKeys(int), numDocs(int),
+ *       numDenseKeys(int), numSparseKeys(int), keyDictOffset(long),
+ *       keyMetaOffset(long), perKeyDataOffset(long), valueDictOffset(long)</li>
+ *   <li>Key dictionary: numKeys(int), per key: keyLen(int) + keyBytes</li>
+ *   <li>Key metadata (70 bytes/key, big-endian): tierFlag(byte), storedTypeOrdinal(byte),
+ *       numDocs(int), nullBitmapOffset(long), nullBitmapLen(long), fwdOffset(long),
+ *       fwdLen(long), invOffset(long), invLen(long), dictIdFwdOffset(long),
+ *       dictIdFwdLen(long)</li>
+ *   <li>Per-key data: null bitmap (RLE-optimized Roaring) + forward index + optional
+ *       inverted index + optional dictId forward index</li>
+ *   <li>Value dictionary: per-key sorted distinct values for dictionary-encoded keys</li>
+ * </ul>
+ * <p>Null-means-absent policy: keys with null values are not recorded during ingestion.
+ * A key absent from the presence bitmap is indistinguishable from a key explicitly set to null.
+ */
+public class ImmutableColumnarMapIndexReader implements ColumnarMapIndexReader {
+
+  private static final int MAGIC = 0x53504D58;   // "SPMX"
+  private static final int CURRENT_VERSION = 3;
+  private static final int HEADER_SIZE = 56;
+  private static final int KEY_METADATA_ENTRY_SIZE = 70;
+
+  public static final byte TIER_DENSE = OnHeapColumnarMapIndexCreator.TIER_DENSE;
+  public static final byte TIER_SPARSE = OnHeapColumnarMapIndexCreator.TIER_SPARSE;
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(ImmutableColumnarMapIndexReader.class);
+
+  private final PinotDataBuffer _dataBuffer;
+  private final int _numDocs;
+  private final int _numKeys;
+
+  // per-key data (indexed by keyId)
+  private final String[] _keys;
+  private final Map<String, Integer> _keyToId;
+  private final DataType[] _keyStoredTypes;
+  private final int[] _numDocsPerKey;
+  private final byte[] _tierFlags;
+  private final ImmutableRoaringBitmap[] _nullBitmaps;   // null bitmap for dense keys (absent docs)
+  private final ImmutableRoaringBitmap[] _presenceBitmaps; // kept for backward compat with query layer
+
+  // offsets/lengths within _dataBuffer for forward and inverted indexes
+  private final long _perKeyDataSectionOffset;
+  private final long[] _fwdOffsets;
+  private final long[] _fwdLengths;
+  private final long[] _invOffsets;
+  private final long[] _invLengths;
+  private final long[] _dictIdFwdOffsets;
+  private final long[] _dictIdFwdLengths;
+
+  // value dictionary section
+  private final long _valueDictionarySectionOffset;
+  private final Map<String, ColumnarMapKeyDictionary> _keyDictionaries;
+
+  // Pre-built dictId readers for keys with dictionary encoding (indexed by keyId)
+  private final FixedBitIntReaderWriter[] _dictIdReaders;
+
+  // Cached inverted index entry offsets per keyId (avoids O(numUnique) scan per query)
+  private final long[][] _invEntryOffsets;
+
+  // Sparse sidecar data (loaded separately via loadSparseSidecar())
+  private byte[] _sparseData;
+  private int[] _sparseOffsets;  // numDocs+1 entries
+
+  // Default value type for keys not found in SPMX metadata (from schema's ComplexFieldSpec)
+  @Nullable
+  private final DataType _defaultValueType;
+  private int _numSparseKeys;
+
+  public ImmutableColumnarMapIndexReader(PinotDataBuffer dataBuffer, ColumnMetadata metadata)
+      throws IOException {
+    _dataBuffer = dataBuffer;
+
+    // Extract defaultValueType from schema's ComplexFieldSpec if available
+    if (metadata != null) {
+      FieldSpec fieldSpec = metadata.getFieldSpec();
+      if (fieldSpec instanceof ComplexFieldSpec) {
+        _defaultValueType = ((ComplexFieldSpec) fieldSpec).getDefaultValueType();
+      } else {
+        _defaultValueType = null;
+      }
+    } else {
+      _defaultValueType = null;
+    }
+
+    // ---- Parse Header (BIG_ENDIAN throughout) ----
+    byte[] headerBytes = new byte[HEADER_SIZE];
+    dataBuffer.copyTo(0, headerBytes, 0, HEADER_SIZE);
+    ByteBuffer headerBuf = ByteBuffer.wrap(headerBytes).order(ByteOrder.BIG_ENDIAN);
+    int magic = headerBuf.getInt();
+    if (magic != MAGIC) {
+      throw new IOException(
+          String.format("Invalid ColumnarMap index: expected magic 0x%08X but got 0x%08X", MAGIC, magic));
+    }
+    int version = headerBuf.getInt();
+    if (version != CURRENT_VERSION) {
+      throw new IOException(
+          String.format("SPMX version %d not supported (expected %d). Re-ingest segment to upgrade.",
+              version, CURRENT_VERSION));
+    }
+    _numKeys = headerBuf.getInt();
+    _numDocs = headerBuf.getInt();
+    int numDenseKeys = headerBuf.getInt();
+    int numSparseKeys = headerBuf.getInt();
+    long keyDictOffset = headerBuf.getLong();
+    long keyMetaOffset = headerBuf.getLong();
+    _perKeyDataSectionOffset = headerBuf.getLong();
+    _valueDictionarySectionOffset = headerBuf.getLong();
+    _numSparseKeys = numSparseKeys;
+
+    // ---- Parse Key Dictionary (big-endian) ----
+    _keys = new String[_numKeys];
+    _keyToId = new HashMap<>(_numKeys * 2);
+    long dictPos = keyDictOffset;
+    int dictNumKeys = _dataBuffer.getInt(dictPos);
+    if (dictNumKeys != _numKeys) {
+      throw new IOException("Key dictionary count mismatch: header=" + _numKeys + ", dict=" + dictNumKeys);
+    }
+    dictPos += 4;
+    for (int i = 0; i < _numKeys; i++) {
+      int keyLen = _dataBuffer.getInt(dictPos);
+      dictPos += 4;
+      byte[] keyBytes = new byte[keyLen];
+      dataBuffer.copyTo(dictPos, keyBytes, 0, keyLen);
+      _keys[i] = new String(keyBytes, StandardCharsets.UTF_8);
+      _keyToId.put(_keys[i], i);
+      dictPos += keyLen;
+    }
+
+    // ---- Parse Key Metadata (BIG_ENDIAN, 70 bytes per key) ----
+    _keyStoredTypes = new DataType[_numKeys];
+    _numDocsPerKey = new int[_numKeys];
+    _tierFlags = new byte[_numKeys];
+    _nullBitmaps = new ImmutableRoaringBitmap[_numKeys];
+    _presenceBitmaps = new ImmutableRoaringBitmap[_numKeys];
+    _fwdOffsets = new long[_numKeys];
+    _fwdLengths = new long[_numKeys];
+    _invOffsets = new long[_numKeys];
+    _invLengths = new long[_numKeys];
+    _dictIdFwdOffsets = new long[_numKeys];
+    _dictIdFwdLengths = new long[_numKeys];
+
+    byte[] metaBlock = new byte[_numKeys * KEY_METADATA_ENTRY_SIZE];
+    dataBuffer.copyTo(keyMetaOffset, metaBlock, 0, metaBlock.length);
+    ByteBuffer metaBuf = ByteBuffer.wrap(metaBlock).order(ByteOrder.BIG_ENDIAN);
+    DataType[] allTypes = DataType.values();
+
+    for (int i = 0; i < _numKeys; i++) {
+      _tierFlags[i] = metaBuf.get();
+      int storedTypeOrdinal = metaBuf.get() & 0xFF;
+      if (storedTypeOrdinal >= allTypes.length) {
+        throw new IOException(
+            "Invalid ColumnarMap index: unknown DataType ordinal " + storedTypeOrdinal
+                + " for key index " + i + " (max=" + (allTypes.length - 1) + ")");
+      }
+      _keyStoredTypes[i] = allTypes[storedTypeOrdinal];
+      _numDocsPerKey[i] = metaBuf.getInt();
+      long nullBitmapOffset = metaBuf.getLong();
+      long nullBitmapLen = metaBuf.getLong();
+      _fwdOffsets[i] = metaBuf.getLong();
+      _fwdLengths[i] = metaBuf.getLong();
+      _invOffsets[i] = metaBuf.getLong();
+      _invLengths[i] = metaBuf.getLong();
+      _dictIdFwdOffsets[i] = metaBuf.getLong();
+      _dictIdFwdLengths[i] = metaBuf.getLong();
+
+      if (_tierFlags[i] == TIER_DENSE && nullBitmapLen > 0) {
+        // Dense key: load null bitmap (docs where key is absent)
+        byte[] bitmapBytes = new byte[(int) nullBitmapLen];
+        dataBuffer.copyTo(_perKeyDataSectionOffset + nullBitmapOffset, bitmapBytes, 0, bitmapBytes.length);
+        _nullBitmaps[i] = new ImmutableRoaringBitmap(ByteBuffer.wrap(bitmapBytes));
+        // Build presence bitmap as complement of null bitmap (for backward compat with query layer)
+        _presenceBitmaps[i] = ImmutableRoaringBitmap.flip(_nullBitmaps[i], 0L, (long) _numDocs);
+      } else if (_tierFlags[i] == TIER_SPARSE) {
+        // Sparse key: no per-key data in SPMX
+        _presenceBitmaps[i] = ImmutableRoaringBitmap.bitmapOf();
+        _nullBitmaps[i] = null;
+      }
+    }
+
+    // ---- Parse Value Dictionary Section ----
+    _keyDictionaries = new HashMap<>();
+    if (_valueDictionarySectionOffset > 0) {
+      long pos = _valueDictionarySectionOffset;
+      for (int i = 0; i < _numKeys; i++) {
+        if (_dictIdFwdLengths[i] == 0 && _invLengths[i] == 0) {
+          continue;
+        }
+        int numDistinctValues = dataBuffer.getInt(pos);
+        pos += 4;
+
+        // skip numBitsPerValue (recomputed from dictionary size when needed)
+        pos += 4;
+
+        String[] values = new String[numDistinctValues];
+        for (int v = 0; v < numDistinctValues; v++) {
+          int vLen = dataBuffer.getInt(pos);
+          pos += 4;
+          byte[] vBytes = new byte[vLen];
+          dataBuffer.copyTo(pos, vBytes, 0, vLen);
+          values[v] = new String(vBytes, StandardCharsets.UTF_8);
+          pos += vLen;
+        }
+        _keyDictionaries.put(_keys[i], new ColumnarMapKeyDictionary(_keyStoredTypes[i], values));
+      }
+    }
+
+    // Pre-build dictId readers for all keys with dictId forward index.
+    // Dense keys: full forward index with _numDocs entries (direct docId access).
+    // Sparse keys: no forward index in SPMX (handled by JSON column).
+    _dictIdReaders = new FixedBitIntReaderWriter[_numKeys];
+    for (int i = 0; i < _numKeys; i++) {
+      if (_dictIdFwdLengths[i] > 0) {
+        ColumnarMapKeyDictionary dict = _keyDictionaries.get(_keys[i]);
+        if (dict != null) {
+          int numBitsPerValue = PinotDataBitSet.getNumBitsPerValue(Math.max(dict.length() - 1, 0));
+          long offset = _perKeyDataSectionOffset + _dictIdFwdOffsets[i];
+          PinotDataBuffer slice = _dataBuffer.view(offset, offset + _dictIdFwdLengths[i]);
+          // Dense keys have _numDocs entries (full forward index)
+          int numEntries = (_tierFlags[i] == TIER_DENSE) ? _numDocs : _numDocsPerKey[i];
+          _dictIdReaders[i] = new FixedBitIntReaderWriter(slice, numEntries, numBitsPerValue);
+        }
+      }
+    }
+
+    // Pre-build inverted index entry offset tables for keys with inverted indexes.
+    // This avoids rebuilding the O(numUnique) offset table on every getDocsWithKeyValue() call.
+    _invEntryOffsets = new long[_numKeys][];
+    for (int i = 0; i < _numKeys; i++) {
+      if (_invLengths[i] > 0) {
+        long invBase = _perKeyDataSectionOffset + _invOffsets[i];
+        int numUnique = _dataBuffer.getInt(invBase);
+        long[] offsets = new long[numUnique];
+        long pos = invBase + 4;
+        for (int j = 0; j < numUnique; j++) {
+          offsets[j] = pos;
+          int vLen = _dataBuffer.getInt(pos);
+          pos += 4 + vLen;
+          int bLen = _dataBuffer.getInt(pos);
+          pos += 4 + bLen;
+        }
+        _invEntryOffsets[i] = offsets;
+      }
+    }
+  }
+
+  /**
+   * Loads the sparse sidecar file containing JSON blobs for sparse-tier keys.
+   * Must be called after construction if the segment has sparse keys.
+   *
+   * @param sidecarFile the .columnarmap.sparse file
+   */
+  public void loadSparseSidecar(File sidecarFile)
+      throws IOException {
+    if (!sidecarFile.exists()) {
+      if (_numSparseKeys > 0) {
+        LOGGER.warn("Sparse sidecar file not found at {} but SPMX header reports {} sparse keys. "
+            + "Sparse key values will return defaults.", sidecarFile.getAbsolutePath(), _numSparseKeys);
+      }
+      return;
+    }
+    byte[] fileBytes = java.nio.file.Files.readAllBytes(sidecarFile.toPath());
+    ByteBuffer buf = ByteBuffer.wrap(fileBytes).order(ByteOrder.BIG_ENDIAN);
+    int magic = buf.getInt();
+    if (magic != OnHeapColumnarMapIndexCreator.SPARSE_SIDECAR_MAGIC) {
+      throw new IOException(String.format(
+          "Invalid sparse sidecar magic: expected 0x%08X but got 0x%08X",
+          OnHeapColumnarMapIndexCreator.SPARSE_SIDECAR_MAGIC, magic));
+    }
+    int numDocs = buf.getInt();
+    _sparseOffsets = new int[numDocs + 1];
+    for (int i = 0; i <= numDocs; i++) {
+      _sparseOffsets[i] = buf.getInt();
+    }
+    int dataSize = _sparseOffsets[numDocs];
+    _sparseData = new byte[dataSize];
+    buf.get(_sparseData);
+  }
+
+  /**
+   * Returns the raw JSON blob string for sparse keys at the given docId,
+   * or null if no sparse keys exist for this doc.
+   */
+  @Nullable
+  public String getSparseJsonBlob(int docId) {
+    if (_sparseData == null || _sparseOffsets == null) {
+      return null;
+    }
+    int start = _sparseOffsets[docId];
+    int end = _sparseOffsets[docId + 1];
+    if (start == end) {
+      return null;
+    }
+    return new String(_sparseData, start, end - start, StandardCharsets.UTF_8);
+  }
+
+  /**
+   * Parses the sparse JSON blob at the given docId and returns a map of key-value pairs.
+   * Returns empty map if no sparse keys exist for this doc.
+   */
+  public Map<String, Object> getSparseMap(int docId) {
+    String json = getSparseJsonBlob(docId);
+    if (json == null) {
+      return Collections.emptyMap();
+    }
+    try {
+      @SuppressWarnings("unchecked")
+      Map<String, Object> result = JsonUtils.stringToObject(json, Map.class);
+      return result;
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to parse sparse JSON blob for docId " + docId, e);
+    }
+  }
+
+  @Override
+  public Set<String> getKeys() {
+    Set<String> keys = new HashSet<>(_numKeys * 2);
+    for (String key : _keys) {
+      keys.add(key);
+    }
+    return keys;
+  }
+
+  /**
+   * Returns the tier flag for the given key: TIER_DENSE or TIER_SPARSE.
+   * Returns 0 if the key is not found.
+   */
+  public byte getTierFlag(String key) {
+    Integer keyId = _keyToId.get(key);
+    return keyId != null ? _tierFlags[keyId] : 0;
+  }
+
+  /**
+   * Returns the null bitmap for a dense key (docs where the key is absent).
+   * Returns null if the key is not found or is sparse.
+   */
+  @Nullable
+  public ImmutableRoaringBitmap getNullBitmap(String key) {
+    Integer keyId = _keyToId.get(key);
+    return keyId != null ? _nullBitmaps[keyId] : null;
+  }
+
+  @Nullable
+  @Override
+  public DataType getKeyValueType(String key) {
+    Integer keyId = _keyToId.get(key);
+    if (keyId != null) {
+      return _keyStoredTypes[keyId];
+    }
+    // Key not found in this segment's SPMX — fall back to schema's defaultValueType.
+    // This avoids NPE in buildKeyDataSource() when querying keys that exist in other segments
+    // but not this one (MAP keys are discovered dynamically during ingestion).
+    return _defaultValueType;
+  }
+
+  @Override
+  public int getNumDocsWithKey(String key) {
+    Integer keyId = _keyToId.get(key);
+    return keyId != null ? _numDocsPerKey[keyId] : 0;
+  }
+
+  @Override
+  public ImmutableRoaringBitmap getPresenceBitmap(String key) {
+    Integer keyId = _keyToId.get(key);
+    return keyId != null ? _presenceBitmaps[keyId] : ImmutableRoaringBitmap.bitmapOf();
+  }
+
+  @Override
+  public int getInt(int docId, String key) {
+    Integer keyId = _keyToId.get(key);
+    if (keyId == null || _tierFlags[keyId] == TIER_SPARSE) {
+      return 0;
+    }
+    // Dense key: direct docId access (no rank())
+    if (_nullBitmaps[keyId] != null && _nullBitmaps[keyId].contains(docId)) {
+      return 0;
+    }
+    if (_dictIdReaders[keyId] != null) {
+      int dictId = _dictIdReaders[keyId].readInt(docId);
+      return _keyDictionaries.get(_keys[keyId]).getIntValue(dictId);
+    }
+    long bufOffset = _perKeyDataSectionOffset + _fwdOffsets[keyId] + (long) docId * Integer.BYTES;
+    return _dataBuffer.getInt(bufOffset);
+  }
+
+  @Override
+  public long getLong(int docId, String key) {
+    Integer keyId = _keyToId.get(key);
+    if (keyId == null || _tierFlags[keyId] == TIER_SPARSE) {
+      return 0L;
+    }
+    if (_nullBitmaps[keyId] != null && _nullBitmaps[keyId].contains(docId)) {
+      return 0L;
+    }
+    if (_dictIdReaders[keyId] != null) {
+      int dictId = _dictIdReaders[keyId].readInt(docId);
+      return _keyDictionaries.get(_keys[keyId]).getLongValue(dictId);
+    }
+    long bufOffset = _perKeyDataSectionOffset + _fwdOffsets[keyId] + (long) docId * Long.BYTES;
+    return _dataBuffer.getLong(bufOffset);
+  }
+
+  @Override
+  public float getFloat(int docId, String key) {
+    Integer keyId = _keyToId.get(key);
+    if (keyId == null || _tierFlags[keyId] == TIER_SPARSE) {
+      return 0.0f;
+    }
+    if (_nullBitmaps[keyId] != null && _nullBitmaps[keyId].contains(docId)) {
+      return 0.0f;
+    }
+    if (_dictIdReaders[keyId] != null) {
+      int dictId = _dictIdReaders[keyId].readInt(docId);
+      return _keyDictionaries.get(_keys[keyId]).getFloatValue(dictId);
+    }
+    long bufOffset = _perKeyDataSectionOffset + _fwdOffsets[keyId] + (long) docId * Float.BYTES;
+    return _dataBuffer.getFloat(bufOffset);
+  }
+
+  @Override
+  public double getDouble(int docId, String key) {
+    Integer keyId = _keyToId.get(key);
+    if (keyId == null || _tierFlags[keyId] == TIER_SPARSE) {
+      return 0.0;
+    }
+    if (_nullBitmaps[keyId] != null && _nullBitmaps[keyId].contains(docId)) {
+      return 0.0;
+    }
+    if (_dictIdReaders[keyId] != null) {
+      int dictId = _dictIdReaders[keyId].readInt(docId);
+      return _keyDictionaries.get(_keys[keyId]).getDoubleValue(dictId);
+    }
+    long bufOffset = _perKeyDataSectionOffset + _fwdOffsets[keyId] + (long) docId * Double.BYTES;
+    return _dataBuffer.getDouble(bufOffset);
+  }
+
+  @Override
+  public String getString(int docId, String key) {
+    Integer keyId = _keyToId.get(key);
+    if (keyId == null || _tierFlags[keyId] == TIER_SPARSE) {
+      return "";
+    }
+    if (_nullBitmaps[keyId] != null && _nullBitmaps[keyId].contains(docId)) {
+      return "";
+    }
+    if (_dictIdReaders[keyId] != null) {
+      int dictId = _dictIdReaders[keyId].readInt(docId);
+      return _keyDictionaries.get(_keys[keyId]).getStringValue(dictId);
+    }
+    return readStringAtOrdinal(keyId, docId);
+  }
+
+  @Override
+  public byte[] getBytes(int docId, String key) {
+    Integer keyId = _keyToId.get(key);
+    if (keyId == null || _tierFlags[keyId] == TIER_SPARSE) {
+      return new byte[0];
+    }
+    if (_nullBitmaps[keyId] != null && _nullBitmaps[keyId].contains(docId)) {
+      return new byte[0];
+    }
+    if (_dictIdReaders[keyId] != null) {
+      int dictId = _dictIdReaders[keyId].readInt(docId);
+      return _keyDictionaries.get(_keys[keyId]).getBytesValue(dictId);
+    }
+    return readBytesAtOrdinal(keyId, docId);
+  }
+
+  private String readStringAtOrdinal(int keyId, int ordinal) {
+    byte[] raw = readBytesAtOrdinal(keyId, ordinal);
+    return new String(raw, StandardCharsets.UTF_8);
+  }
+
+  /**
+   * Reads variable-length bytes from the STRING/BYTES forward index at the given ordinal.
+   * Format: numValues(int), offsets(int[numValues+1]), data(bytes)
+   */
+  private byte[] readBytesAtOrdinal(int keyId, int ordinal) {
+    // Header: numValues(4 bytes), then offsets array ((numValues+1)*4 bytes), then data
+    long fwdBase = _perKeyDataSectionOffset + _fwdOffsets[keyId];
+    byte[] numValBytes = new byte[4];
+    _dataBuffer.copyTo(fwdBase, numValBytes, 0, 4);
+    int numValues = ByteBuffer.wrap(numValBytes).order(ByteOrder.BIG_ENDIAN).getInt();
+    // Dense keys have numDocs entries, sparse would have numDocsPerKey
+    int expectedCount = (_tierFlags[keyId] == TIER_DENSE) ? _numDocs : _numDocsPerKey[keyId];
+    if (numValues != expectedCount) {
+      throw new IllegalStateException(
+          "ColumnarMap forward index corrupt for key '" + _keys[keyId]
+              + "': numValues=" + numValues + " but expected=" + expectedCount);
+    }
+
+    // Read the two offsets for this ordinal: offsets[ordinal] and offsets[ordinal+1]
+    long offsetBase = fwdBase + 4 + (long) ordinal * Integer.BYTES;
+    byte[] offsetBytes = new byte[8];
+    _dataBuffer.copyTo(offsetBase, offsetBytes, 0, 8);
+    ByteBuffer ob = ByteBuffer.wrap(offsetBytes).order(ByteOrder.BIG_ENDIAN);
+    int startOffset = ob.getInt();
+    int endOffset = ob.getInt();
+
+    int dataLen = endOffset - startOffset;
+    if (dataLen <= 0) {
+      return new byte[0];
+    }
+
+    // Data starts after the offsets array: fwdBase + 4 (numValues) + (numValues+1)*4 (offsets)
+    long dataBase = fwdBase + 4 + (long) (numValues + 1) * Integer.BYTES;
+    byte[] result = new byte[dataLen];
+    _dataBuffer.copyTo(dataBase + startOffset, result, 0, dataLen);
+    return result;
+  }
+
+  @Nullable
+  @Override
+  public ImmutableRoaringBitmap getDocsWithKeyValue(String key, Object value) {
+    Integer keyId = _keyToId.get(key);
+    if (keyId == null || _invLengths[keyId] == 0) {
+      return null;
+    }
+    String valueStr = _keyStoredTypes[keyId].toString(value);
+
+    // Fast O(1) negative check: if the in-memory value dictionary is loaded and does not
+    // contain the value, we can return null immediately without any I/O.
+    ColumnarMapKeyDictionary dict = _keyDictionaries.get(key);
+    if (dict != null && dict.indexOf(valueStr) < 0) {
+      return null;
+    }
+
+    // Scan the inverted index entries using binary search on the sorted values.
+    // Format: numUnique(int), then per entry: valueLen(int), valueBytes, bitmapLen(int), bitmapBytes.
+    // Values are sorted (lexicographic for STRING, numeric order for numeric types via TreeMap),
+    // so we first load all entry offsets, then binary search by value.
+    byte[] valueBytes = valueStr.getBytes(StandardCharsets.UTF_8);
+    long[] entryOffsets = _invEntryOffsets[keyId];
+    if (entryOffsets == null) {
+      return null;
+    }
+    int numUnique = entryOffsets.length;
+
+    // Binary search over the sorted inverted index entries.
+    // The inverted index uses a TreeMap which sorts lexicographically for all types.
+    int lo = 0;
+    int hi = numUnique - 1;
+    while (lo <= hi) {
+      int mid = (lo + hi) >>> 1;
+      long entryPos = entryOffsets[mid];
+      int vLen = _dataBuffer.getInt(entryPos);
+      entryPos += 4;
+      byte[] vBytes = new byte[vLen];
+      _dataBuffer.copyTo(entryPos, vBytes, 0, vLen);
+      entryPos += vLen;
+
+      int cmp = compareBytes(vBytes, valueBytes);
+      if (cmp < 0) {
+        lo = mid + 1;
+      } else if (cmp > 0) {
+        hi = mid - 1;
+      } else {
+        // Found the matching value; read the bitmap
+        int bLen = _dataBuffer.getInt(entryPos);
+        entryPos += 4;
+        byte[] bitmapBytes = new byte[bLen];
+        _dataBuffer.copyTo(entryPos, bitmapBytes, 0, bLen);
+        return new ImmutableRoaringBitmap(ByteBuffer.wrap(bitmapBytes));
+      }
+    }
+    return null;
+  }
+
+  /// Lexicographic comparison of two byte arrays, equivalent to comparing the UTF-8 strings.
+  private static int compareBytes(byte[] a, byte[] b) {
+    int len = Math.min(a.length, b.length);
+    for (int i = 0; i < len; i++) {
+      int diff = (a[i] & 0xFF) - (b[i] & 0xFF);
+      if (diff != 0) {
+        return diff;
+      }
+    }
+    return a.length - b.length;
+  }
+
+  @Override
+  public boolean hasInvertedIndex(String key) {
+    Integer keyId = _keyToId.get(key);
+    return keyId != null && _invLengths[keyId] > 0;
+  }
+
+  @Override
+  @Nullable
+  public String[] getDistinctValuesForKey(String key) {
+    Integer keyId = _keyToId.get(key);
+    if (keyId == null || _invLengths[keyId] == 0) {
+      return null;
+    }
+
+    long invBase = _perKeyDataSectionOffset + _invOffsets[keyId];
+    int numUnique = _dataBuffer.getInt(invBase);
+
+    String[] distinctValues = new String[numUnique];
+    long pos = invBase + 4;
+    for (int i = 0; i < numUnique; i++) {
+      int vLen = _dataBuffer.getInt(pos);
+      pos += 4;
+
+      byte[] vBytes = new byte[vLen];
+      _dataBuffer.copyTo(pos, vBytes, 0, vLen);
+      distinctValues[i] = new String(vBytes, StandardCharsets.UTF_8);
+      pos += vLen;
+
+      // Skip bitmap: read bLen and advance past bitmap bytes
+      int bLen = _dataBuffer.getInt(pos);
+      pos += 4 + bLen;
+    }
+    return distinctValues;
+  }
+
+  @Override
+  public DataSource getKeyDataSource(String key) {
+    // Implemented in ColumnarMapDataSource (Task 15)
+    return null;
+  }
+
+  /// Returns a FixedBitIntReaderWriter for reading bit-packed dictIds for the given key,
+  /// or null if no dictId forward index is available.
+  @Nullable
+  public FixedBitIntReaderWriter getDictIdReader(String key) {
+    Integer keyId = _keyToId.get(key);
+    return keyId != null ? _dictIdReaders[keyId] : null;
+  }
+
+  /// Returns the cached ColumnarMapKeyDictionary for the given key, or null if not available.
+  @Nullable
+  public ColumnarMapKeyDictionary getKeyDictionary(String key) {
+    return _keyDictionaries.get(key);
+  }
+
+  /**
+   * Returns a PinotDataBuffer view over the dictId forward index for the given dense key,
+   * suitable for creating a FixedBitSVForwardIndexReaderV2. Returns null if the key is not
+   * found or has no dictId forward index.
+   */
+  @Nullable
+  public PinotDataBuffer getDictIdFwdBuffer(String key) {
+    Integer keyId = _keyToId.get(key);
+    if (keyId == null || _dictIdFwdLengths[keyId] == 0) {
+      return null;
+    }
+    long offset = _perKeyDataSectionOffset + _dictIdFwdOffsets[keyId];
+    return _dataBuffer.view(offset, offset + _dictIdFwdLengths[keyId]);
+  }
+
+  /**
+   * Returns the number of bits per dictId value for the given key's dictionary,
+   * or 0 if the key has no dictionary.
+   */
+  public int getNumBitsPerDictId(String key) {
+    ColumnarMapKeyDictionary dict = _keyDictionaries.get(key);
+    if (dict == null) {
+      return 0;
+    }
+    return PinotDataBitSet.getNumBitsPerValue(Math.max(dict.length() - 1, 0));
+  }
+
+  /// Returns the total number of documents in this index.
+  public int getNumDocs() {
+    return _numDocs;
+  }
+
+  /**
+   * Returns the value for the given (docId, keyId) pair without any HashMap lookup.
+   * The keyId must be valid and the caller must have already confirmed the doc is present
+   * via the presence bitmap. The ordinal (rank - 1) is computed here.
+   */
+  private Object getValueByKeyId(int docId, int keyId) {
+    // For dense keys: docId IS the index into the full forward index (no rank() needed)
+    // For sparse keys: this method should not be called (handled by JSON column)
+    if (_dictIdReaders[keyId] != null) {
+      int dictId = _dictIdReaders[keyId].readInt(docId);
+      ColumnarMapKeyDictionary dict = _keyDictionaries.get(_keys[keyId]);
+      switch (_keyStoredTypes[keyId]) {
+        case INT:
+          return dict.getIntValue(dictId);
+        case LONG:
+          return dict.getLongValue(dictId);
+        case FLOAT:
+          return dict.getFloatValue(dictId);
+        case DOUBLE:
+          return dict.getDoubleValue(dictId);
+        case BYTES:
+          return dict.getBytesValue(dictId);
+        default:
+          return dict.getStringValue(dictId);
+      }
+    }
+    // Raw forward index path — direct docId access
+    switch (_keyStoredTypes[keyId]) {
+      case INT: {
+        long bufOffset = _perKeyDataSectionOffset + _fwdOffsets[keyId] + (long) docId * Integer.BYTES;
+        return _dataBuffer.getInt(bufOffset);
+      }
+      case LONG: {
+        long bufOffset = _perKeyDataSectionOffset + _fwdOffsets[keyId] + (long) docId * Long.BYTES;
+        return _dataBuffer.getLong(bufOffset);
+      }
+      case FLOAT: {
+        long bufOffset = _perKeyDataSectionOffset + _fwdOffsets[keyId] + (long) docId * Float.BYTES;
+        return _dataBuffer.getFloat(bufOffset);
+      }
+      case DOUBLE: {
+        long bufOffset = _perKeyDataSectionOffset + _fwdOffsets[keyId] + (long) docId * Double.BYTES;
+        return _dataBuffer.getDouble(bufOffset);
+      }
+      case BYTES:
+        return readBytesAtOrdinal(keyId, docId);
+      default:
+        return readStringAtOrdinal(keyId, docId);
+    }
+  }
+
+  @Override
+  public Map<String, Object> getMap(int docId) {
+    Map<String, Object> result = new HashMap<>();
+    // Dense keys from SPMX
+    for (int i = 0; i < _numKeys; i++) {
+      if (_tierFlags[i] == TIER_SPARSE) {
+        continue;
+      }
+      if (_nullBitmaps[i] != null && _nullBitmaps[i].contains(docId)) {
+        continue;
+      }
+      result.put(_keys[i], getValueByKeyId(docId, i));
+    }
+    // Sparse keys from sidecar
+    Map<String, Object> sparseMap = getSparseMap(docId);
+    result.putAll(sparseMap);
+    return result;
+  }
+
+  @Override
+  public void close()
+      throws IOException {
+    for (FixedBitIntReaderWriter reader : _dictIdReaders) {
+      if (reader != null) {
+        reader.close();
+      }
+    }
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/columnarmap/MutableColumnarMapIndexImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/columnarmap/MutableColumnarMapIndexImpl.java
@@ -1,0 +1,600 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.columnarmap;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
+import javax.annotation.Nullable;
+import org.apache.pinot.segment.local.realtime.impl.dictionary.MutableDictionaryFactory;
+import org.apache.pinot.segment.local.realtime.impl.forward.FixedByteSVMutableForwardIndex;
+import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.segment.spi.index.mutable.MutableDictionary;
+import org.apache.pinot.segment.spi.index.mutable.MutableForwardIndex;
+import org.apache.pinot.segment.spi.index.mutable.MutableIndex;
+import org.apache.pinot.segment.spi.index.mutable.provider.MutableIndexContext;
+import org.apache.pinot.segment.spi.index.reader.ColumnarMapIndexReader;
+import org.apache.pinot.segment.spi.memory.PinotDataBufferMemoryManager;
+import org.apache.pinot.spi.config.table.ColumnarMapIndexConfig;
+import org.apache.pinot.spi.data.ComplexFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
+import org.roaringbitmap.buffer.MutableRoaringBitmap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * In-memory mutable ColumnarMap index for real-time segments.
+ * Implements both {@link MutableIndex} (for segment indexing) and
+ * {@link ColumnarMapIndexReader} (for query access during real-time serving).
+ *
+ * <p>Each MAP key gets a dense per-key forward index ({@link FixedByteSVMutableForwardIndex})
+ * indexed by docId, providing O(1) lock-free reads. For dictionary-encoded keys, a
+ * {@link MutableDictionary} maps values to dictIds stored in the forward index. For raw
+ * (noDictionary) keys, typed values are stored directly.
+ *
+ * <p>Thread-safe: writes use a {@link ReentrantReadWriteLock}. Forward index reads are lock-free
+ * via the {@link java.util.concurrent.CopyOnWriteArrayList} pattern inside
+ * {@link FixedByteSVMutableForwardIndex}.
+ */
+public class MutableColumnarMapIndexImpl implements MutableIndex, ColumnarMapIndexReader {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(MutableColumnarMapIndexImpl.class);
+  private static final int NUM_ROWS_PER_CHUNK = 1024;
+
+  private final Map<String, DataType> _keyTypes;
+  private final DataType _defaultValueType;
+  private final ColumnarMapIndexConfig _config;
+  private final int _maxKeys;
+  private final String _columnName;
+  private final PinotDataBufferMemoryManager _memoryManager;
+
+  // per-key presence bitmaps (mutable for writes)
+  private final Map<String, MutableRoaringBitmap> _presenceBitmaps = new HashMap<>();
+  // per-key dense forward indexes indexed by docId (lock-free reads)
+  private final ConcurrentHashMap<String, MutableForwardIndex> _perKeyForwardIndexes = new ConcurrentHashMap<>();
+  // per-key mutable dictionaries for dictionary-encoded keys
+  private final ConcurrentHashMap<String, MutableDictionary> _perKeyDictionaries = new ConcurrentHashMap<>();
+  // per-key dictId-based inverted indexes for dictionary-encoded keys (used by InvertedIndexFilterOperator)
+  private final ConcurrentHashMap<String, ColumnarMapRealtimeInvertedIndex> _perKeyInvertedIndexes =
+      new ConcurrentHashMap<>();
+  // tracks which keys are dictionary-encoded
+  private final ConcurrentHashMap<String, Boolean> _isDictEncoded = new ConcurrentHashMap<>();
+  // optional inverted index: key -> value-string -> docId bitmap
+  private final Map<String, TreeMap<String, MutableRoaringBitmap>> _invertedIndexes = new HashMap<>();
+
+  private final ReentrantReadWriteLock _lock = new ReentrantReadWriteLock();
+  private int _distinctKeyCount;
+  private int _droppedKeyCount;
+
+  public MutableColumnarMapIndexImpl(MutableIndexContext context, ColumnarMapIndexConfig config) {
+    this(context, config, null, null);
+  }
+
+  public MutableColumnarMapIndexImpl(MutableIndexContext context, ColumnarMapIndexConfig config,
+      @Nullable Map<String, DataType> explicitKeyTypes,
+      @Nullable DataType explicitDefaultValueType) {
+    FieldSpec fieldSpec = context.getFieldSpec();
+    Map<String, DataType> keyTypes = explicitKeyTypes;
+    DataType defaultType = explicitDefaultValueType;
+    if (keyTypes == null && fieldSpec instanceof ComplexFieldSpec) {
+      ComplexFieldSpec.MapFieldSpec mapFieldSpec = ComplexFieldSpec.toMapFieldSpec((ComplexFieldSpec) fieldSpec);
+      keyTypes = mapFieldSpec.getKeyTypes();
+      defaultType = mapFieldSpec.getDefaultValueType();
+    }
+    _keyTypes = keyTypes != null ? new HashMap<>(keyTypes) : new HashMap<>();
+    _defaultValueType = defaultType != null ? defaultType : DataType.STRING;
+    _config = config;
+    _maxKeys = config.getMaxKeys();
+    _columnName = context.getFieldSpec().getName();
+    _memoryManager = context.getMemoryManager();
+  }
+
+  // ---- MutableIndex methods ----
+
+  @Override
+  public void add(Object value, int dictId, int docId) {
+    if (!(value instanceof Map)) {
+      return;
+    }
+    @SuppressWarnings("unchecked")
+    Map<String, Object> columnarMap = (Map<String, Object>) value;
+    _lock.writeLock().lock();
+    try {
+      for (Map.Entry<String, Object> entry : columnarMap.entrySet()) {
+        String key = entry.getKey();
+        Object rawValue = entry.getValue();
+        if (rawValue == null) {
+          continue;
+        }
+        if (!_presenceBitmaps.containsKey(key) && _distinctKeyCount >= _maxKeys) {
+          _droppedKeyCount++;
+          if (_droppedKeyCount == 1 || _droppedKeyCount % 1000 == 0) {
+            LOGGER.warn(
+                "MutableColumnarMapIndex for column '{}' reached maxKeys limit ({}). Key '{}' dropped. "
+                    + "Total drops: {}.",
+                _columnName, _maxKeys, key, _droppedKeyCount);
+          }
+          continue;
+        }
+        DataType valueType = _keyTypes.getOrDefault(key, _defaultValueType);
+        DataType storedType = valueType.getStoredType();
+        if (!_presenceBitmaps.containsKey(key)) {
+          _presenceBitmaps.put(key, new MutableRoaringBitmap());
+          initPerKeyStorage(key, storedType);
+          if (_config.shouldEnableInvertedIndexForKey(key)) {
+            _invertedIndexes.put(key, new TreeMap<>());
+          }
+          _distinctKeyCount++;
+        }
+        Object coerced;
+        try {
+          coerced = coerceValue(rawValue, valueType);
+        } catch (ClassCastException | NumberFormatException e) {
+          LOGGER.warn(
+              "MutableColumnarMapIndex for column '{}': failed to coerce value '{}' (type {}) to {} for key '{}'"
+                  + " in docId {}. Skipping key for this document.",
+              _columnName, rawValue, rawValue.getClass().getSimpleName(), valueType, key, docId, e);
+          continue;
+        }
+        _presenceBitmaps.get(key).add(docId);
+        writeValueToForwardIndex(key, docId, coerced, storedType);
+        if (_config.shouldEnableInvertedIndexForKey(key)) {
+          String valueStr = valueType.toString(coerced);
+          _invertedIndexes.get(key).computeIfAbsent(valueStr, k -> new MutableRoaringBitmap()).add(docId);
+        }
+      }
+    } finally {
+      _lock.writeLock().unlock();
+    }
+  }
+
+  private void initPerKeyStorage(String key, DataType storedType) {
+    boolean useDictionary = _config.shouldUseDictionaryForKey(key);
+    _isDictEncoded.put(key, useDictionary);
+
+    String allocationContext = _columnName + "." + key;
+    if (useDictionary) {
+      // Dictionary-encoded: forward index stores INT dictIds
+      MutableDictionary dict = MutableDictionaryFactory.getMutableDictionary(
+          storedType, false, _memoryManager, 0, 0, allocationContext + ".dict");
+      // Pre-index default value at dictId 0 so zeroed forward index slots map to the correct default
+      dict.index(getDefaultValue(storedType));
+      _perKeyDictionaries.put(key, dict);
+      _perKeyForwardIndexes.put(key,
+          new FixedByteSVMutableForwardIndex(true, DataType.INT, NUM_ROWS_PER_CHUNK, _memoryManager,
+              allocationContext + ".fwd"));
+      // DictId-based inverted index for InvertedIndexFilterOperator.
+      // Use ColumnarMapRealtimeInvertedIndex which handles non-sequential dictIds (gap-safe),
+      // since the default value is pre-indexed at dictId 0 in the dictionary but may never
+      // appear in actual documents.
+      ColumnarMapRealtimeInvertedIndex invertedIndex = new ColumnarMapRealtimeInvertedIndex();
+      _perKeyInvertedIndexes.put(key, invertedIndex);
+    } else {
+      // Raw: forward index stores typed values directly
+      _perKeyForwardIndexes.put(key,
+          new FixedByteSVMutableForwardIndex(false, storedType, NUM_ROWS_PER_CHUNK, _memoryManager,
+              allocationContext + ".fwd"));
+    }
+  }
+
+  private void writeValueToForwardIndex(String key, int docId, Object coerced, DataType storedType) {
+    MutableForwardIndex fwdIndex = _perKeyForwardIndexes.get(key);
+    if (_isDictEncoded.get(key)) {
+      MutableDictionary dict = _perKeyDictionaries.get(key);
+      int valueDictId = dict.index(coerced);
+      fwdIndex.setDictId(docId, valueDictId);
+      ColumnarMapRealtimeInvertedIndex invertedIndex = _perKeyInvertedIndexes.get(key);
+      if (invertedIndex != null) {
+        invertedIndex.add(valueDictId, docId);
+      }
+    } else {
+      switch (storedType) {
+        case INT:
+          fwdIndex.setInt(docId, (Integer) coerced);
+          break;
+        case LONG:
+          fwdIndex.setLong(docId, (Long) coerced);
+          break;
+        case FLOAT:
+          fwdIndex.setFloat(docId, (Float) coerced);
+          break;
+        case DOUBLE:
+          fwdIndex.setDouble(docId, (Double) coerced);
+          break;
+        case STRING:
+          fwdIndex.setString(docId, (String) coerced);
+          break;
+        case BYTES:
+          fwdIndex.setBytes(docId, (byte[]) coerced);
+          break;
+        default:
+          fwdIndex.setString(docId, coerced.toString());
+          break;
+      }
+    }
+  }
+
+  private static Object getDefaultValue(DataType storedType) {
+    switch (storedType) {
+      case INT:
+        return 0;
+      case LONG:
+        return 0L;
+      case FLOAT:
+        return 0.0f;
+      case DOUBLE:
+        return 0.0;
+      case STRING:
+        return "";
+      case BYTES:
+        return new byte[0];
+      default:
+        return "";
+    }
+  }
+
+  /// Coerces a raw value to the target stored type.
+  private Object coerceValue(Object value, DataType dataType) {
+    DataType storedType = dataType.getStoredType();
+    switch (storedType) {
+      case INT:
+        if (value instanceof Boolean) {
+          return (Boolean) value ? 1 : 0;
+        }
+        if (value instanceof Number) {
+          return ((Number) value).intValue();
+        }
+        return Integer.parseInt(value.toString().trim());
+      case LONG:
+        if (value instanceof Number) {
+          return ((Number) value).longValue();
+        }
+        return Long.parseLong(value.toString().trim());
+      case FLOAT:
+        if (value instanceof Number) {
+          return ((Number) value).floatValue();
+        }
+        return Float.parseFloat(value.toString().trim());
+      case DOUBLE:
+        if (value instanceof Number) {
+          return ((Number) value).doubleValue();
+        }
+        return Double.parseDouble(value.toString().trim());
+      case STRING:
+        return value.toString();
+      case BYTES:
+        return value instanceof byte[] ? value : value.toString().getBytes(StandardCharsets.UTF_8);
+      default:
+        return value.toString();
+    }
+  }
+
+  // ---- ColumnarMapIndexReader methods ----
+
+  @Override
+  public Set<String> getKeys() {
+    _lock.readLock().lock();
+    try {
+      return new HashSet<>(_presenceBitmaps.keySet());
+    } finally {
+      _lock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public DataType getKeyValueType(String key) {
+    DataType type = _keyTypes.get(key);
+    return type != null ? type : _defaultValueType;
+  }
+
+  @Override
+  public void add(Object[] values, @Nullable int[] dictIds, int docId) {
+    if (values != null && values.length > 0) {
+      add(values[0], dictIds != null ? dictIds[0] : -1, docId);
+    }
+  }
+
+  @Override
+  public int getNumDocsWithKey(String key) {
+    _lock.readLock().lock();
+    try {
+      MutableRoaringBitmap bitmap = _presenceBitmaps.get(key);
+      return bitmap != null ? (int) bitmap.getLongCardinality() : 0;
+    } finally {
+      _lock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public ImmutableRoaringBitmap getPresenceBitmap(String key) {
+    _lock.readLock().lock();
+    try {
+      MutableRoaringBitmap bitmap = _presenceBitmaps.get(key);
+      return bitmap != null ? bitmap.clone().toImmutableRoaringBitmap() : ImmutableRoaringBitmap.bitmapOf();
+    } finally {
+      _lock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public int getInt(int docId, String key) {
+    MutableForwardIndex fwdIndex = _perKeyForwardIndexes.get(key);
+    if (fwdIndex == null) {
+      return 0;
+    }
+    if (Boolean.TRUE.equals(_isDictEncoded.get(key))) {
+      int dictId = fwdIndex.getDictId(docId);
+      MutableDictionary dict = _perKeyDictionaries.get(key);
+      return dict.getIntValue(dictId);
+    }
+    return fwdIndex.getInt(docId);
+  }
+
+  @Override
+  public long getLong(int docId, String key) {
+    MutableForwardIndex fwdIndex = _perKeyForwardIndexes.get(key);
+    if (fwdIndex == null) {
+      return 0L;
+    }
+    if (Boolean.TRUE.equals(_isDictEncoded.get(key))) {
+      int dictId = fwdIndex.getDictId(docId);
+      MutableDictionary dict = _perKeyDictionaries.get(key);
+      return dict.getLongValue(dictId);
+    }
+    return fwdIndex.getLong(docId);
+  }
+
+  @Override
+  public float getFloat(int docId, String key) {
+    MutableForwardIndex fwdIndex = _perKeyForwardIndexes.get(key);
+    if (fwdIndex == null) {
+      return 0.0f;
+    }
+    if (Boolean.TRUE.equals(_isDictEncoded.get(key))) {
+      int dictId = fwdIndex.getDictId(docId);
+      MutableDictionary dict = _perKeyDictionaries.get(key);
+      return dict.getFloatValue(dictId);
+    }
+    return fwdIndex.getFloat(docId);
+  }
+
+  @Override
+  public double getDouble(int docId, String key) {
+    MutableForwardIndex fwdIndex = _perKeyForwardIndexes.get(key);
+    if (fwdIndex == null) {
+      return 0.0;
+    }
+    if (Boolean.TRUE.equals(_isDictEncoded.get(key))) {
+      int dictId = fwdIndex.getDictId(docId);
+      MutableDictionary dict = _perKeyDictionaries.get(key);
+      return dict.getDoubleValue(dictId);
+    }
+    return fwdIndex.getDouble(docId);
+  }
+
+  @Override
+  public String getString(int docId, String key) {
+    MutableForwardIndex fwdIndex = _perKeyForwardIndexes.get(key);
+    if (fwdIndex == null) {
+      return "";
+    }
+    if (Boolean.TRUE.equals(_isDictEncoded.get(key))) {
+      int dictId = fwdIndex.getDictId(docId);
+      MutableDictionary dict = _perKeyDictionaries.get(key);
+      return dict.getStringValue(dictId);
+    }
+    return fwdIndex.getString(docId);
+  }
+
+  @Override
+  public byte[] getBytes(int docId, String key) {
+    MutableForwardIndex fwdIndex = _perKeyForwardIndexes.get(key);
+    if (fwdIndex == null) {
+      return new byte[0];
+    }
+    if (Boolean.TRUE.equals(_isDictEncoded.get(key))) {
+      int dictId = fwdIndex.getDictId(docId);
+      MutableDictionary dict = _perKeyDictionaries.get(key);
+      return dict.getBytesValue(dictId);
+    }
+    return fwdIndex.getBytes(docId);
+  }
+
+  @Nullable
+  @Override
+  public ImmutableRoaringBitmap getDocsWithKeyValue(String key, Object value) {
+    if (!_config.shouldEnableInvertedIndexForKey(key)) {
+      return null;
+    }
+    _lock.readLock().lock();
+    try {
+      TreeMap<String, MutableRoaringBitmap> inv = _invertedIndexes.get(key);
+      if (inv == null) {
+        return null;
+      }
+      DataType type = _keyTypes.getOrDefault(key, _defaultValueType);
+      String valueStr = type.toString(value);
+      MutableRoaringBitmap bitmap = inv.get(valueStr);
+      return bitmap != null ? bitmap.clone().toImmutableRoaringBitmap() : ImmutableRoaringBitmap.bitmapOf();
+    } finally {
+      _lock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public boolean hasInvertedIndex(String key) {
+    _lock.readLock().lock();
+    try {
+      TreeMap<String, MutableRoaringBitmap> inv = _invertedIndexes.get(key);
+      return inv != null && !inv.isEmpty();
+    } finally {
+      _lock.readLock().unlock();
+    }
+  }
+
+  @Nullable
+  @Override
+  public String[] getDistinctValuesForKey(String key) {
+    _lock.readLock().lock();
+    try {
+      TreeMap<String, MutableRoaringBitmap> inv = _invertedIndexes.get(key);
+      return inv != null ? inv.keySet().toArray(new String[0]) : null;
+    } finally {
+      _lock.readLock().unlock();
+    }
+  }
+
+  @Override
+  public DataSource getKeyDataSource(String key) {
+    // Per-key DataSource construction lives in ColumnarMapDataSource. Calling this method
+    // directly bypasses the data source layer and would skip the unknown-key fall-back to
+    // NullDataSource that callers rely on.
+    throw new UnsupportedOperationException("Use ColumnarMapDataSource.getKeyDataSource() instead");
+  }
+
+  @Override
+  public Map<String, Object> getMap(int docId) {
+    _lock.readLock().lock();
+    try {
+      Map<String, Object> result = new HashMap<>();
+      for (Map.Entry<String, MutableRoaringBitmap> entry : _presenceBitmaps.entrySet()) {
+        String key = entry.getKey();
+        MutableRoaringBitmap bitmap = entry.getValue();
+        if (!bitmap.contains(docId)) {
+          continue;
+        }
+        DataType valueType = _keyTypes.getOrDefault(key, _defaultValueType);
+        DataType storedType = valueType.getStoredType();
+        MutableForwardIndex fwdIndex = _perKeyForwardIndexes.get(key);
+        if (fwdIndex == null) {
+          continue;
+        }
+        if (Boolean.TRUE.equals(_isDictEncoded.get(key))) {
+          int dictId = fwdIndex.getDictId(docId);
+          MutableDictionary dict = _perKeyDictionaries.get(key);
+          result.put(key, getTypedValueFromDict(dict, dictId, storedType));
+        } else {
+          result.put(key, getTypedValueFromFwdIndex(fwdIndex, docId, storedType));
+        }
+      }
+      return result;
+    } finally {
+      _lock.readLock().unlock();
+    }
+  }
+
+  private static Object getTypedValueFromDict(MutableDictionary dict, int dictId, DataType storedType) {
+    switch (storedType) {
+      case INT:
+        return dict.getIntValue(dictId);
+      case LONG:
+        return dict.getLongValue(dictId);
+      case FLOAT:
+        return dict.getFloatValue(dictId);
+      case DOUBLE:
+        return dict.getDoubleValue(dictId);
+      case STRING:
+        return dict.getStringValue(dictId);
+      case BYTES:
+        return dict.getBytesValue(dictId);
+      default:
+        return dict.getStringValue(dictId);
+    }
+  }
+
+  private static Object getTypedValueFromFwdIndex(MutableForwardIndex fwdIndex, int docId, DataType storedType) {
+    switch (storedType) {
+      case INT:
+        return fwdIndex.getInt(docId);
+      case LONG:
+        return fwdIndex.getLong(docId);
+      case FLOAT:
+        return fwdIndex.getFloat(docId);
+      case DOUBLE:
+        return fwdIndex.getDouble(docId);
+      case STRING:
+        return fwdIndex.getString(docId);
+      case BYTES:
+        return fwdIndex.getBytes(docId);
+      default:
+        return fwdIndex.getString(docId);
+    }
+  }
+
+  // ---- Accessors for ColumnarMapDataSource ----
+
+  /// Ensures per-key storage exists for the given key, even if no documents have been ingested
+  /// with this key yet. Called by {@link ColumnarMapDataSource} when a query references a key
+  /// that has a known type but was never ingested. The forward index will return default values
+  /// for all docIds.
+  public void ensureKeyStorage(String key) {
+    if (_perKeyForwardIndexes.containsKey(key)) {
+      return;
+    }
+    DataType valueType = _keyTypes.getOrDefault(key, _defaultValueType);
+    DataType storedType = valueType.getStoredType();
+    _lock.writeLock().lock();
+    try {
+      if (!_perKeyForwardIndexes.containsKey(key)) {
+        initPerKeyStorage(key, storedType);
+      }
+    } finally {
+      _lock.writeLock().unlock();
+    }
+  }
+
+  @Nullable
+  public MutableForwardIndex getPerKeyForwardIndex(String key) {
+    return _perKeyForwardIndexes.get(key);
+  }
+
+  @Nullable
+  public MutableDictionary getPerKeyDictionary(String key) {
+    return _perKeyDictionaries.get(key);
+  }
+
+  public boolean isDictionaryEncodedKey(String key) {
+    return Boolean.TRUE.equals(_isDictEncoded.get(key));
+  }
+
+  @Nullable
+  public ColumnarMapRealtimeInvertedIndex getPerKeyInvertedIndex(String key) {
+    return _perKeyInvertedIndexes.get(key);
+  }
+
+  @Override
+  public void close()
+      throws IOException {
+    for (MutableForwardIndex fwdIndex : _perKeyForwardIndexes.values()) {
+      fwdIndex.close();
+    }
+    for (MutableDictionary dict : _perKeyDictionaries.values()) {
+      dict.close();
+    }
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/columnarmap/OnHeapColumnarMapIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/columnarmap/OnHeapColumnarMapIndexCreator.java
@@ -493,12 +493,26 @@ public class OnHeapColumnarMapIndexCreator implements ColumnarMapIndexCreator {
         byte tierFlag = isDense ? TIER_DENSE : TIER_SPARSE;
 
         if (!isDense) {
-          // Sparse key: no per-key data in SPMX, all offsets/lengths are 0
+          // Sparse key: write only a presence bitmap into SPMX (values live in the JSON sidecar).
+          // The presence bitmap is required for IS NULL / IS NOT NULL correctness — without it
+          // MapFilterOperator's Strategy 2b path returns empty for sparse keys.
+          // Reuses the dense "nullBitmapOffset/Len" slots: for sparse keys these slots point to
+          // a presence bitmap (docs WHERE the key IS PRESENT). The reader branches on tierFlag
+          // to interpret the slot correctly.
+          RoaringBitmap presenceCopy = presence.clone();
+          presenceCopy.runOptimize();
+          byte[] presenceBytes = RoaringBitmapUtils.serialize(presenceCopy);
+          long presenceOffset = currentOffset;
+          dos.write(presenceBytes);
+          currentOffset += presenceBytes.length;
+
           int entryOffset = i * KEY_METADATA_ENTRY_SIZE;
           keyMetadataSection[entryOffset] = tierFlag;
           keyMetadataSection[entryOffset + 1] = (byte) storedType.ordinal();
           writeInt(keyMetadataSection, entryOffset + 2, values.size());
-          // All 4 offset/length pairs are 0 (already zeroed by array initialization)
+          writeLong(keyMetadataSection, entryOffset + 6, presenceOffset);
+          writeLong(keyMetadataSection, entryOffset + 14, presenceBytes.length);
+          // Forward, inverted, and dictId-fwd offset/length pairs remain 0 for sparse keys.
           continue;
         }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/columnarmap/OnHeapColumnarMapIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/columnarmap/OnHeapColumnarMapIndexCreator.java
@@ -1,0 +1,926 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.columnarmap;
+
+import com.google.common.base.Preconditions;
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.TreeMap;
+import javax.annotation.Nullable;
+import org.apache.pinot.common.utils.RoaringBitmapUtils;
+import org.apache.pinot.segment.local.io.util.PinotDataBitSet;
+import org.apache.pinot.segment.spi.V1Constants;
+import org.apache.pinot.segment.spi.creator.IndexCreationContext;
+import org.apache.pinot.segment.spi.index.creator.ColumnarMapIndexCreator;
+import org.apache.pinot.spi.config.table.ColumnarMapIndexConfig;
+import org.apache.pinot.spi.data.ComplexFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.roaringbitmap.RoaringBitmap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * On-heap implementation of {@link ColumnarMapIndexCreator} for immutable (offline) segments.
+ * Accumulates per-document sparse maps in memory and writes a binary index file on seal.
+ * Uses more heap memory but avoids disk I/O during indexing.
+ */
+public class OnHeapColumnarMapIndexCreator implements ColumnarMapIndexCreator {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(OnHeapColumnarMapIndexCreator.class);
+
+  private static final int MAGIC = 0x53504D58;   // "SPMX"
+  private static final int VERSION = 3;
+  private static final int HEADER_SIZE = 56;
+  private static final int KEY_METADATA_ENTRY_SIZE = 70;
+
+  public static final byte TIER_DENSE = 0x01;
+  public static final byte TIER_SPARSE = 0x02;
+
+  private final File _indexDir;
+  private final String _columnName;
+  private final Map<String, DataType> _keyTypes;
+  private final DataType _defaultValueType;
+  private final ColumnarMapIndexConfig _config;
+  private final Set<String> _indexedKeys;
+  private final int _maxKeys;
+  private final Set<String> _configDenseKeys;
+  private final double _denseKeyThreshold;
+
+  private static final double NO_DICTIONARY_SIZE_RATIO_THRESHOLD = 0.85;
+
+  private final Map<String, RoaringBitmap> _presenceBitmaps = new HashMap<>();
+  private final Map<String, List<Object>> _values = new HashMap<>();
+  private final Map<String, Set<String>> _distinctValuesPerKey = new HashMap<>();
+  private final Map<String, Long> _totalRawBytesPerKey = new HashMap<>();
+  private int _numDocs;
+  private int _distinctKeyCount;
+  private final Set<String> _droppedKeys = new HashSet<>();
+  private Set<String> _resolvedDenseKeys;  // computed at seal() time
+
+  public OnHeapColumnarMapIndexCreator(IndexCreationContext context, ColumnarMapIndexConfig config)
+      throws IOException {
+    this(context.getIndexDir(), context.getFieldSpec().getName(),
+        context.getFieldSpec(), config);
+  }
+
+  public OnHeapColumnarMapIndexCreator(File indexDir, String columnName, FieldSpec fieldSpec,
+      ColumnarMapIndexConfig config)
+      throws IOException {
+    this(indexDir, columnName, fieldSpec, config, null, null);
+  }
+
+  public OnHeapColumnarMapIndexCreator(File indexDir, String columnName, FieldSpec fieldSpec,
+      ColumnarMapIndexConfig config,
+      @Nullable Map<String, FieldSpec.DataType> explicitKeyTypes,
+      @Nullable FieldSpec.DataType explicitDefaultValueType)
+      throws IOException {
+    _indexDir = indexDir;
+    _columnName = columnName;
+    _config = config;
+    _indexedKeys = config.getIndexedKeys();
+    _maxKeys = config.getMaxKeys();
+    _configDenseKeys = config.getDenseKeys();
+    _denseKeyThreshold = config.getDenseKeyThreshold();
+
+    Map<String, FieldSpec.DataType> keyTypes = explicitKeyTypes;
+    FieldSpec.DataType defaultType = explicitDefaultValueType;
+    if (keyTypes == null && fieldSpec instanceof ComplexFieldSpec) {
+      ComplexFieldSpec.MapFieldSpec mapSpec = ComplexFieldSpec.toMapFieldSpec((ComplexFieldSpec) fieldSpec);
+      keyTypes = mapSpec.getKeyTypes();
+      defaultType = mapSpec.getDefaultValueType();
+    }
+    _keyTypes = keyTypes != null ? new HashMap<>(keyTypes) : new HashMap<>();
+    _defaultValueType = defaultType != null ? defaultType : FieldSpec.DataType.STRING;
+  }
+
+  @Override
+  public void add(Map<String, Object> columnarMap)
+      throws IOException {
+    if (columnarMap != null && !columnarMap.isEmpty()) {
+      for (Map.Entry<String, Object> entry : columnarMap.entrySet()) {
+        String key = entry.getKey();
+        if (_indexedKeys != null && !_indexedKeys.contains(key)) {
+          continue;
+        }
+        Object rawValue = entry.getValue();
+        if (rawValue == null) {
+          // Null values are treated as absent: the key is not recorded for this document.
+          // There is no distinction between "key absent" and "key present with null value".
+          continue;
+        }
+        if (!_presenceBitmaps.containsKey(key) && _distinctKeyCount >= _maxKeys) {
+          if (_droppedKeys.add(key)) {
+            LOGGER.warn(
+                "ColumnarMap index for column '{}' reached maxKeys limit ({}). Dropping key '{}'. "
+                    + "Total distinct dropped keys so far: {}.",
+                _columnName, _maxKeys, key, _droppedKeys.size());
+          }
+          continue;
+        }
+        DataType valueType = _keyTypes.getOrDefault(key, _defaultValueType);
+        if (!_presenceBitmaps.containsKey(key)) {
+          _presenceBitmaps.put(key, new RoaringBitmap());
+          _values.put(key, new ArrayList<>());
+          _distinctKeyCount++;
+        }
+        _presenceBitmaps.get(key).add(_numDocs);
+        Object coerced;
+        try {
+          coerced = coerceValue(rawValue, valueType);
+        } catch (ClassCastException | NumberFormatException e) {
+          LOGGER.warn(
+              "OnHeapColumnarMapIndexCreator for column '{}': failed to coerce value '{}' (type {}) to {} for key '{}'."
+                  + " Skipping key for this document.",
+              _columnName, rawValue, rawValue.getClass().getSimpleName(), valueType, key, e);
+          _presenceBitmaps.get(key).remove(_numDocs);
+          continue;
+        }
+        _values.get(key).add(coerced);
+
+        // Track per-key stats for dictionary optimization decision
+        DataType storedType = valueType.getStoredType();
+        String stringRep = storedType.toString(coerced);
+        _distinctValuesPerKey.computeIfAbsent(key, k -> new HashSet<>()).add(stringRep);
+        if (storedType == DataType.STRING || storedType == DataType.BYTES) {
+          byte[] rawBytes;
+          if (storedType == DataType.BYTES) {
+            rawBytes = (byte[]) coerced;
+          } else {
+            rawBytes = ((String) coerced).getBytes(StandardCharsets.UTF_8);
+          }
+          _totalRawBytesPerKey.merge(key, (long) rawBytes.length, Long::sum);
+        }
+      }
+    }
+    _numDocs++;
+  }
+
+  @Override
+  public void add(Object value, int dictId)
+      throws IOException {
+    if (!(value instanceof Map)) {
+      return;
+    }
+    @SuppressWarnings("unchecked")
+    Map<String, Object> columnarMap = (Map<String, Object>) value;
+    add(columnarMap);
+  }
+
+  @Override
+  public void add(Object[] values, @Nullable int[] dictIds)
+      throws IOException {
+    throw new UnsupportedOperationException("MAP with sparse map index is single-value only");
+  }
+
+  private Object coerceValue(Object value, DataType dataType) {
+    if (value == null) {
+      return coerceValueForType(dataType, null);
+    }
+    DataType storedType = dataType.getStoredType();
+    switch (storedType) {
+      case INT:
+        if (value instanceof Boolean) {
+          return (Boolean) value ? 1 : 0;
+        }
+        if (value instanceof Number) {
+          return ((Number) value).intValue();
+        }
+        return Integer.parseInt(value.toString().trim());
+      case LONG:
+        if (value instanceof Number) {
+          return ((Number) value).longValue();
+        }
+        return Long.parseLong(value.toString().trim());
+      case FLOAT:
+        if (value instanceof Number) {
+          return ((Number) value).floatValue();
+        }
+        return Float.parseFloat(value.toString().trim());
+      case DOUBLE:
+        if (value instanceof Number) {
+          return ((Number) value).doubleValue();
+        }
+        return Double.parseDouble(value.toString().trim());
+      case STRING:
+        return value.toString();
+      case BYTES:
+        if (value instanceof byte[]) {
+          return value;
+        }
+        return value.toString().getBytes(StandardCharsets.UTF_8);
+      default:
+        return value.toString();
+    }
+  }
+
+  private Object coerceValueForType(DataType dataType, Object nullValue) {
+    DataType storedType = dataType.getStoredType();
+    switch (storedType) {
+      case INT:
+        return nullValue != null ? ((Number) nullValue).intValue() : 0;
+      case LONG:
+        return nullValue != null ? ((Number) nullValue).longValue() : 0L;
+      case FLOAT:
+        return nullValue != null ? ((Number) nullValue).floatValue() : 0.0f;
+      case DOUBLE:
+        return nullValue != null ? ((Number) nullValue).doubleValue() : 0.0;
+      case STRING:
+        return nullValue != null ? nullValue.toString() : "";
+      case BYTES:
+        return nullValue instanceof byte[] ? nullValue : new byte[0];
+      default:
+        return "";
+    }
+  }
+
+  /**
+   * Decides whether to use dictionary encoding for a sparse map key.
+   * Mirrors the logic in DictionaryIndexType.canSafelyCreateDictionaryWithinThreshold.
+   * Returns true if dictionary+dictIdFwd is more compact than raw forward index.
+   */
+  private boolean shouldUseDictionary(String key, DataType storedType, int numDocsForKey) {
+    // Keys with inverted index always get dictionary (inverted index requires it)
+    if (_config.shouldEnableInvertedIndexForKey(key)) {
+      return true;
+    }
+
+    // Explicit override: noDictionaryKeys forces raw encoding
+    if (!_config.shouldUseDictionaryForKey(key)) {
+      return false;
+    }
+
+    Set<String> distinctValues = _distinctValuesPerKey.get(key);
+    if (distinctValues == null || distinctValues.isEmpty()) {
+      return false;
+    }
+
+    // Cardinality is just the distinct values (no default value in sparse dictId forward index)
+    int cardinality = distinctValues.size();
+    if (cardinality == 0) {
+      return false;
+    }
+
+    int numBitsPerValue = PinotDataBitSet.getNumBitsPerValue(Math.max(cardinality - 1, 0));
+    // Sparse dictId forward index: only stores entries for docs that have the key,
+    // same as the raw forward index. Both cover numDocsForKey entries.
+    long dictIdFwdSize = ((long) numDocsForKey * numBitsPerValue + Byte.SIZE - 1) / Byte.SIZE;
+
+    long rawSize;
+    long dictSize;
+
+    switch (storedType) {
+      case INT:
+        rawSize = (long) numDocsForKey * Integer.BYTES;
+        dictSize = (long) cardinality * Integer.BYTES;
+        break;
+      case LONG:
+        rawSize = (long) numDocsForKey * Long.BYTES;
+        dictSize = (long) cardinality * Long.BYTES;
+        break;
+      case FLOAT:
+        rawSize = (long) numDocsForKey * Float.BYTES;
+        dictSize = (long) cardinality * Float.BYTES;
+        break;
+      case DOUBLE:
+        rawSize = (long) numDocsForKey * Double.BYTES;
+        dictSize = (long) cardinality * Double.BYTES;
+        break;
+      case STRING:
+      case BYTES: {
+        // Raw size: numValues(int) + offsets[numDocsForKey+1](int[]) + totalRawBytes
+        long totalRawBytes = _totalRawBytesPerKey.getOrDefault(key, 0L);
+        rawSize = Integer.BYTES + (long) (numDocsForKey + 1) * Integer.BYTES + totalRawBytes;
+        // Dict size: sum of (int + bytes) per distinct value in the value dictionary section
+        dictSize = 0;
+        for (String v : distinctValues) {
+          dictSize += Integer.BYTES + v.getBytes(StandardCharsets.UTF_8).length;
+        }
+        break;
+      }
+      default:
+        return true;
+    }
+
+    // If raw is cheaper than dict+dictIdFwd (within threshold), use raw
+    double ratio = (double) rawSize / (dictSize + dictIdFwdSize);
+    return ratio > NO_DICTIONARY_SIZE_RATIO_THRESHOLD;
+  }
+
+  @Override
+  public void seal()
+      throws IOException {
+    List<String> sortedKeys = new ArrayList<>(_presenceBitmaps.keySet());
+    Collections.sort(sortedKeys);
+    int numKeys = sortedKeys.size();
+
+    // Compute tier assignment: a key is dense if fillRate > threshold OR in configDenseKeys
+    _resolvedDenseKeys = new HashSet<>(_configDenseKeys);
+    for (String key : sortedKeys) {
+      int numDocsForKey = _presenceBitmaps.get(key).getCardinality();
+      double fillRate = _numDocs > 0 ? (double) numDocsForKey / _numDocs : 0;
+      if (fillRate > _denseKeyThreshold) {
+        _resolvedDenseKeys.add(key);
+      }
+    }
+
+    int numDenseKeys = 0;
+    int numSparseKeys = 0;
+    for (String key : sortedKeys) {
+      if (_resolvedDenseKeys.contains(key)) {
+        numDenseKeys++;
+      } else {
+        numSparseKeys++;
+      }
+    }
+
+    byte[] keyDictionarySection = buildKeyDictionarySection(sortedKeys);
+    byte[] keyMetadataSection = new byte[numKeys * KEY_METADATA_ENTRY_SIZE];
+    Map<String, TreeMap<String, RoaringBitmap>> cachedValueToDocIds = new HashMap<>();
+    byte[] perKeyDataSection = buildPerKeyDataSection(sortedKeys, keyMetadataSection, cachedValueToDocIds);
+    byte[] valueDictionarySection = buildValueDictionarySection(sortedKeys, cachedValueToDocIds);
+
+    long keyDictionaryOffset = HEADER_SIZE;
+    long keyMetadataOffset = keyDictionaryOffset + keyDictionarySection.length;
+    long perKeyDataOffset = keyMetadataOffset + keyMetadataSection.length;
+    long valueDictionaryOffset = perKeyDataOffset + perKeyDataSection.length;
+
+    File indexFile = new File(_indexDir, _columnName + V1Constants.Indexes.COLUMNAR_MAP_INDEX_FILE_EXTENSION);
+    try (FileOutputStream fos = new FileOutputStream(indexFile);
+        DataOutputStream dos = new DataOutputStream(fos)) {
+      writeHeader(dos, numKeys, numDenseKeys, numSparseKeys,
+          keyDictionaryOffset, keyMetadataOffset, perKeyDataOffset, valueDictionaryOffset);
+      dos.write(keyDictionarySection);
+      dos.write(keyMetadataSection);
+      dos.write(perKeyDataSection);
+      dos.write(valueDictionarySection);
+    }
+
+    // Write sparse sidecar file if there are any sparse keys
+    if (numSparseKeys > 0) {
+      writeSparseKeySidecar(sortedKeys);
+    }
+  }
+
+  /**
+   * Writes a sidecar file containing JSON blobs for sparse keys.
+   * Format: MAGIC(int) + numDocs(int) + offsets(int[numDocs+1]) + json_data(bytes)
+   * Each doc's JSON blob contains only its sparse-tier key-value pairs as a JSON object.
+   * Docs with no sparse keys have offset[i] == offset[i+1] (zero-length entry).
+   */
+  public static final int SPARSE_SIDECAR_MAGIC = 0x534D5350;  // "SMSP"
+  public static final String SPARSE_SIDECAR_EXTENSION = ".columnarmap.sparse";
+
+  private void writeSparseKeySidecar(List<String> sortedKeys)
+      throws IOException {
+    // Collect sparse keys (sorted)
+    List<String> sparseKeys = new ArrayList<>();
+    for (String key : sortedKeys) {
+      if (!_resolvedDenseKeys.contains(key)) {
+        sparseKeys.add(key);
+      }
+    }
+
+    // Build JSON blobs per doc
+    ByteArrayOutputStream dataBaos = new ByteArrayOutputStream();
+    int[] offsets = new int[_numDocs + 1];
+    int dataOffset = 0;
+
+    for (int docId = 0; docId < _numDocs; docId++) {
+      offsets[docId] = dataOffset;
+      Map<String, Object> sparseEntries = new LinkedHashMap<>();
+      for (String key : sparseKeys) {
+        RoaringBitmap presence = _presenceBitmaps.get(key);
+        if (presence != null && presence.contains(docId)) {
+          int ordinal = presence.rank(docId) - 1;
+          Object value = _values.get(key).get(ordinal);
+          sparseEntries.put(key, value);
+        }
+      }
+      if (!sparseEntries.isEmpty()) {
+        byte[] jsonBytes = serializeSparseEntries(sparseEntries).getBytes(StandardCharsets.UTF_8);
+        dataBaos.write(jsonBytes);
+        dataOffset += jsonBytes.length;
+      }
+    }
+    offsets[_numDocs] = dataOffset;
+
+    // Write sidecar file
+    File sidecarFile = new File(_indexDir, _columnName + SPARSE_SIDECAR_EXTENSION);
+    try (FileOutputStream fos = new FileOutputStream(sidecarFile);
+        DataOutputStream dos = new DataOutputStream(fos)) {
+      dos.writeInt(SPARSE_SIDECAR_MAGIC);
+      dos.writeInt(_numDocs);
+      for (int offset : offsets) {
+        dos.writeInt(offset);
+      }
+      dos.write(dataBaos.toByteArray());
+    }
+  }
+
+  /**
+   * Serializes sparse key entries as a JSON object string using Jackson.
+   */
+  private String serializeSparseEntries(Map<String, Object> entries) {
+    try {
+      return JsonUtils.objectToString(entries);
+    } catch (IOException e) {
+      throw new RuntimeException("Failed to serialize sparse entries", e);
+    }
+  }
+
+  private byte[] buildKeyDictionarySection(List<String> sortedKeys)
+      throws IOException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    try (DataOutputStream dos = new DataOutputStream(baos)) {
+      dos.writeInt(sortedKeys.size());
+      for (String key : sortedKeys) {
+        byte[] keyBytes = key.getBytes(StandardCharsets.UTF_8);
+        dos.writeInt(keyBytes.length);
+        dos.write(keyBytes);
+      }
+    }
+    return baos.toByteArray();
+  }
+
+  private byte[] buildPerKeyDataSection(List<String> sortedKeys, byte[] keyMetadataSection,
+      Map<String, TreeMap<String, RoaringBitmap>> cachedValueToDocIds)
+      throws IOException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    try (DataOutputStream dos = new DataOutputStream(baos)) {
+      long currentOffset = 0;
+
+      for (int i = 0; i < sortedKeys.size(); i++) {
+        String key = sortedKeys.get(i);
+        RoaringBitmap presence = _presenceBitmaps.get(key);
+        List<Object> values = _values.get(key);
+        DataType dataType = _keyTypes.getOrDefault(key, _defaultValueType);
+        DataType storedType = dataType.getStoredType();
+
+        boolean isDense = _resolvedDenseKeys.contains(key);
+        byte tierFlag = isDense ? TIER_DENSE : TIER_SPARSE;
+
+        if (!isDense) {
+          // Sparse key: no per-key data in SPMX, all offsets/lengths are 0
+          int entryOffset = i * KEY_METADATA_ENTRY_SIZE;
+          keyMetadataSection[entryOffset] = tierFlag;
+          keyMetadataSection[entryOffset + 1] = (byte) storedType.ordinal();
+          writeInt(keyMetadataSection, entryOffset + 2, values.size());
+          // All 4 offset/length pairs are 0 (already zeroed by array initialization)
+          continue;
+        }
+
+        // Dense key: write null bitmap + full forward index (numDocs entries)
+
+        // 1. Build and write null bitmap (docs where key is ABSENT)
+        RoaringBitmap nullBitmap = new RoaringBitmap();
+        for (int docId = 0; docId < _numDocs; docId++) {
+          if (!presence.contains(docId)) {
+            nullBitmap.add(docId);
+          }
+        }
+        nullBitmap.runOptimize();
+        byte[] nullBitmapBytes = RoaringBitmapUtils.serialize(nullBitmap);
+        long nullBitmapOffset = currentOffset;
+        dos.write(nullBitmapBytes);
+        currentOffset += nullBitmapBytes.length;
+
+        boolean useDictionary = shouldUseDictionary(key, storedType, values.size());
+        boolean enableInverted = _config.shouldEnableInvertedIndexForKey(key);
+
+        // 2. Write forward index: either raw OR dictId, never both
+        long forwardOffset = 0;
+        long forwardLength = 0;
+        long dictIdFwdOffset = 0;
+        long dictIdFwdLength = 0;
+
+        TreeMap<String, RoaringBitmap> valueToDocIds = null;
+
+        if (useDictionary) {
+          // Dictionary-encoded path: build valueToDocIds and FULL dictId forward index
+          valueToDocIds = buildValueToDocIds(presence, values, storedType);
+          cachedValueToDocIds.put(key, valueToDocIds);
+
+          byte[] dictIdFwdBytes = buildFullDictIdForwardIndex(valueToDocIds, storedType, presence, values);
+          dictIdFwdOffset = currentOffset;
+          dictIdFwdLength = dictIdFwdBytes.length;
+          dos.write(dictIdFwdBytes);
+          currentOffset += dictIdFwdBytes.length;
+        } else {
+          // Raw forward index path — full (numDocs entries, defaults for absent)
+          byte[] forwardBytes = buildFullRawForwardIndex(values, storedType, presence);
+          forwardOffset = currentOffset;
+          forwardLength = forwardBytes.length;
+          dos.write(forwardBytes);
+          currentOffset += forwardBytes.length;
+        }
+
+        // 3. Inverted index (independent of dictionary decision)
+        long invertedOffset = 0;
+        long invertedLength = 0;
+        if (enableInverted) {
+          if (valueToDocIds == null) {
+            valueToDocIds = buildValueToDocIds(presence, values, storedType);
+            cachedValueToDocIds.put(key, valueToDocIds);
+          }
+          byte[] invertedBytes = serializeInvertedIndex(valueToDocIds);
+          invertedOffset = currentOffset;
+          invertedLength = invertedBytes.length;
+          dos.write(invertedBytes);
+          currentOffset += invertedBytes.length;
+        }
+
+        // Write key metadata entry (70 bytes)
+        int entryOffset = i * KEY_METADATA_ENTRY_SIZE;
+        keyMetadataSection[entryOffset] = tierFlag;
+        keyMetadataSection[entryOffset + 1] = (byte) storedType.ordinal();
+        writeInt(keyMetadataSection, entryOffset + 2, values.size());
+        writeLong(keyMetadataSection, entryOffset + 6, nullBitmapOffset);
+        writeLong(keyMetadataSection, entryOffset + 14, nullBitmapBytes.length);
+        writeLong(keyMetadataSection, entryOffset + 22, forwardOffset);
+        writeLong(keyMetadataSection, entryOffset + 30, forwardLength);
+        writeLong(keyMetadataSection, entryOffset + 38, invertedOffset);
+        writeLong(keyMetadataSection, entryOffset + 46, invertedLength);
+        writeLong(keyMetadataSection, entryOffset + 54, dictIdFwdOffset);
+        writeLong(keyMetadataSection, entryOffset + 62, dictIdFwdLength);
+      }
+    }
+    return baos.toByteArray();
+  }
+
+  private static void writeInt(byte[] buf, int offset, int value) {
+    buf[offset] = (byte) (value >> 24);
+    buf[offset + 1] = (byte) (value >> 16);
+    buf[offset + 2] = (byte) (value >> 8);
+    buf[offset + 3] = (byte) (value);
+  }
+
+  private static void writeLong(byte[] buf, int offset, long value) {
+    for (int i = 0; i < 8; i++) {
+      buf[offset + i] = (byte) (value >> ((7 - i) * 8));
+    }
+  }
+
+  private byte[] buildForwardIndex(List<Object> values, DataType storedType)
+      throws IOException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    try (DataOutputStream dos = new DataOutputStream(baos)) {
+      writeForwardIndex(dos, values, storedType);
+    }
+    return baos.toByteArray();
+  }
+
+  private void writeForwardIndex(DataOutputStream dos, List<Object> values, DataType storedType)
+      throws IOException {
+    switch (storedType) {
+      case INT:
+        for (Object v : values) {
+          dos.writeInt((Integer) v);
+        }
+        break;
+      case LONG:
+        for (Object v : values) {
+          dos.writeLong((Long) v);
+        }
+        break;
+      case FLOAT:
+        for (Object v : values) {
+          dos.writeFloat((Float) v);
+        }
+        break;
+      case DOUBLE:
+        for (Object v : values) {
+          dos.writeDouble((Double) v);
+        }
+        break;
+      case STRING: {
+        int numValues = values.size();
+        dos.writeInt(numValues);
+        ByteArrayOutputStream dataBaos = new ByteArrayOutputStream();
+        int[] offsets = new int[numValues + 1];
+        int offset = 0;
+        for (int i = 0; i < numValues; i++) {
+          offsets[i] = offset;
+          byte[] b = ((String) values.get(i)).getBytes(StandardCharsets.UTF_8);
+          dataBaos.write(b);
+          offset += b.length;
+        }
+        offsets[numValues] = offset;
+        for (int o : offsets) {
+          dos.writeInt(o);
+        }
+        dos.write(dataBaos.toByteArray());
+        break;
+      }
+      case BYTES: {
+        int numValues = values.size();
+        dos.writeInt(numValues);
+        ByteArrayOutputStream dataBaos = new ByteArrayOutputStream();
+        int[] offsets = new int[numValues + 1];
+        int offset = 0;
+        for (int i = 0; i < numValues; i++) {
+          offsets[i] = offset;
+          byte[] b = (byte[]) values.get(i);
+          dataBaos.write(b);
+          offset += b.length;
+        }
+        offsets[numValues] = offset;
+        for (int o : offsets) {
+          dos.writeInt(o);
+        }
+        dos.write(dataBaos.toByteArray());
+        break;
+      }
+      default:
+        throw new IllegalStateException("Unsupported stored type for forward index: " + storedType);
+    }
+  }
+
+  private TreeMap<String, RoaringBitmap> buildValueToDocIds(RoaringBitmap presence, List<Object> values,
+      DataType storedType) {
+    TreeMap<String, RoaringBitmap> valueToDocIds = new TreeMap<>();
+    int ordinal = 0;
+    for (int docId : presence) {
+      Object value = values.get(ordinal);
+      String keyRep = storedType.toString(value);
+      valueToDocIds.computeIfAbsent(keyRep, k -> new RoaringBitmap()).add(docId);
+      ordinal++;
+    }
+    return valueToDocIds;
+  }
+
+  private byte[] serializeInvertedIndex(TreeMap<String, RoaringBitmap> valueToDocIds)
+      throws IOException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    try (DataOutputStream dos = new DataOutputStream(baos)) {
+      dos.writeInt(valueToDocIds.size());
+      for (Map.Entry<String, RoaringBitmap> entry : valueToDocIds.entrySet()) {
+        byte[] valueBytes = entry.getKey().getBytes(StandardCharsets.UTF_8);
+        dos.writeInt(valueBytes.length);
+        dos.write(valueBytes);
+        byte[] bitmapBytes = RoaringBitmapUtils.serialize(entry.getValue());
+        dos.writeInt(bitmapBytes.length);
+        dos.write(bitmapBytes);
+      }
+    }
+    return baos.toByteArray();
+  }
+
+  /// Builds a FULL bit-packed dictId forward index for dense keys (numDocs entries).
+  /// Absent docs get the default value's dictId (dictId 0).
+  private byte[] buildFullDictIdForwardIndex(TreeMap<String, RoaringBitmap> valueToDocIds,
+      DataType storedType, RoaringBitmap presence, List<Object> valueList)
+      throws IOException {
+    // Ensure the default value is in the dictionary
+    String defaultValue = ColumnarMapKeyDictionary.getDefaultValueString(storedType);
+    valueToDocIds.putIfAbsent(defaultValue, new RoaringBitmap());
+
+    String[] distinctValues = valueToDocIds.keySet().toArray(new String[0]);
+    sortValues(distinctValues, storedType);
+
+    // Build value → dictId mapping
+    Map<String, Integer> valueToDictId = new HashMap<>();
+    for (int i = 0; i < distinctValues.length; i++) {
+      valueToDictId.put(distinctValues[i], i);
+    }
+
+    int defaultDictId = valueToDictId.getOrDefault(defaultValue, 0);
+    int numBitsPerValue = PinotDataBitSet.getNumBitsPerValue(Math.max(distinctValues.length - 1, 0));
+
+    // Build FULL dictId array: one entry per segment doc (numDocs entries)
+    int[] dictIdArray = new int[_numDocs];
+    int ordinal = 0;
+    for (int docId = 0; docId < _numDocs; docId++) {
+      if (presence.contains(docId)) {
+        Object value = valueList.get(ordinal);
+        String strValue = storedType.toString(value);
+        Integer dictId = valueToDictId.get(strValue);
+        dictIdArray[docId] = dictId != null ? dictId : defaultDictId;
+        ordinal++;
+      } else {
+        dictIdArray[docId] = defaultDictId;
+      }
+    }
+
+    // Write bit-packed
+    long bufferSize = ((long) _numDocs * numBitsPerValue + Byte.SIZE - 1) / Byte.SIZE;
+    Preconditions.checkState(bufferSize <= Integer.MAX_VALUE,
+        "DictId forward index too large for column '%s': %s bytes", _columnName, bufferSize);
+    byte[] buffer = new byte[(int) bufferSize];
+    writeBitPacked(buffer, dictIdArray, _numDocs, numBitsPerValue);
+    return buffer;
+  }
+
+  /// Builds a FULL raw forward index for dense keys (numDocs entries).
+  /// Absent docs get the type's default value.
+  private byte[] buildFullRawForwardIndex(List<Object> values, DataType storedType, RoaringBitmap presence)
+      throws IOException {
+    // Build full list with defaults for absent docs
+    List<Object> fullValues = new ArrayList<>(_numDocs);
+    int ordinal = 0;
+    for (int docId = 0; docId < _numDocs; docId++) {
+      if (presence.contains(docId)) {
+        fullValues.add(values.get(ordinal));
+        ordinal++;
+      } else {
+        fullValues.add(getDefaultValue(storedType));
+      }
+    }
+    return buildForwardIndex(fullValues, storedType);
+  }
+
+  private static Object getDefaultValue(DataType storedType) {
+    switch (storedType) {
+      case INT:
+        return 0;
+      case LONG:
+        return 0L;
+      case FLOAT:
+        return 0.0f;
+      case DOUBLE:
+        return 0.0;
+      case STRING:
+        return "";
+      case BYTES:
+        return new byte[0];
+      default:
+        return "";
+    }
+  }
+
+  /// Builds a sparse bit-packed dictId forward index for only the docs that have the key.
+  /// Uses presence bitmap rank to map docId → ordinal, same as the raw forward index.
+  /// This preserves the space benefit of columnar_map by not wasting space on absent docs.
+  private byte[] buildDictIdForwardIndex(TreeMap<String, RoaringBitmap> valueToDocIds,
+      DataType storedType, RoaringBitmap presence, List<Object> valueList)
+      throws IOException {
+    // Ensure the default value is in the dictionary so absent docs can map to it at query time.
+    // This matches Pinot's standard nullable column behavior where nulls get the default value's dictId.
+    String defaultValue = ColumnarMapKeyDictionary.getDefaultValueString(storedType);
+    valueToDocIds.putIfAbsent(defaultValue, new RoaringBitmap());
+
+    String[] distinctValues = valueToDocIds.keySet().toArray(new String[0]);
+    sortValues(distinctValues, storedType);
+
+    // Build value → dictId mapping
+    Map<String, Integer> valueToDictId = new HashMap<>();
+    for (int i = 0; i < distinctValues.length; i++) {
+      valueToDictId.put(distinctValues[i], i);
+    }
+
+    int numDocsForKey = (int) presence.getCardinality();
+    int numBitsPerValue = PinotDataBitSet.getNumBitsPerValue(Math.max(distinctValues.length - 1, 0));
+
+    // Build sparse dictId array: one entry per doc that has the key, in bitmap iteration order.
+    // Use ordinal-indexed _values list for O(N) instead of brute-force O(N*K).
+    int[] dictIdArray = new int[numDocsForKey];
+    for (int ordinal = 0; ordinal < numDocsForKey; ordinal++) {
+      Object value = valueList.get(ordinal);
+      String strValue = storedType.toString(value);
+      Integer dictId = valueToDictId.get(strValue);
+      dictIdArray[ordinal] = dictId != null ? dictId : 0;
+    }
+
+    // Write bit-packed
+    long bufferSize = ((long) numDocsForKey * numBitsPerValue + Byte.SIZE - 1) / Byte.SIZE;
+    Preconditions.checkState(bufferSize <= Integer.MAX_VALUE,
+        "DictId forward index too large for column '%s': %s bytes", _columnName, bufferSize);
+    byte[] buffer = new byte[(int) bufferSize];
+    writeBitPacked(buffer, dictIdArray, numDocsForKey, numBitsPerValue);
+    return buffer;
+  }
+
+  /// Writes bit-packed integers into a byte array (big-endian bit order).
+  private static void writeBitPacked(byte[] buffer, int[] values, int numValues, int numBitsPerValue) {
+    long bitOffset = 0;
+    for (int i = 0; i < numValues; i++) {
+      int value = values[i];
+      for (int bit = numBitsPerValue - 1; bit >= 0; bit--) {
+        if (((value >> bit) & 1) == 1) {
+          int byteIndex = (int) (bitOffset / 8);
+          int bitIndex = (int) (7 - (bitOffset % 8));
+          buffer[byteIndex] |= (1 << bitIndex);
+        }
+        bitOffset++;
+      }
+    }
+  }
+
+  /**
+   * Sorts string-encoded dictionary values using the type-appropriate comparator.
+   * Numeric types (INT, LONG, FLOAT, DOUBLE) are sorted by parsed numeric value;
+   * STRING and BYTES types are sorted lexicographically.
+   * This must match the comparator used by {@link ColumnarMapKeyDictionary} to ensure
+   * dictId assignment, binary search, and range lookups are consistent.
+   */
+  private static void sortValues(String[] values, DataType storedType) {
+    Comparator<String> cmp = ColumnarMapKeyDictionary.getComparator(storedType);
+    if (cmp != null) {
+      Arrays.sort(values, cmp);
+    } else {
+      Arrays.sort(values);
+    }
+  }
+
+  /// Builds the value dictionary section written after all per-key data.
+  /// For each key with dictionary encoding: numDistinctValues(int), numBitsPerValue(int),
+  /// then [valueLen(int) + valueBytes] × numDistinctValues.
+  private byte[] buildValueDictionarySection(List<String> sortedKeys,
+      Map<String, TreeMap<String, RoaringBitmap>> cachedValueToDocIds)
+      throws IOException {
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    DataOutputStream dos = new DataOutputStream(baos);
+
+    for (String key : sortedKeys) {
+      // Write value dictionary for all keys that have cached valueToDocIds
+      // (includes both dictionary-encoded keys and inverted-index keys)
+      if (!cachedValueToDocIds.containsKey(key)) {
+        continue;
+      }
+
+      DataType dataType = _keyTypes.getOrDefault(key, _defaultValueType);
+      DataType storedType = dataType.getStoredType();
+
+      TreeMap<String, RoaringBitmap> valueToDocIds = cachedValueToDocIds.get(key);
+
+      // Use only the actual distinct values (no default value needed for sparse dictId forward index)
+      String[] allValues = valueToDocIds != null ? valueToDocIds.keySet().toArray(new String[0]) : new String[0];
+
+      // Sort numerically for numeric types, lexicographically for strings
+      sortValues(allValues, storedType);
+
+      int numBitsPerValue = PinotDataBitSet.getNumBitsPerValue(Math.max(allValues.length - 1, 0));
+      dos.writeInt(allValues.length);
+      dos.writeInt(numBitsPerValue);
+      for (String v : allValues) {
+        byte[] vBytes = v.getBytes(StandardCharsets.UTF_8);
+        dos.writeInt(vBytes.length);
+        dos.write(vBytes);
+      }
+    }
+    return baos.toByteArray();
+  }
+
+  private void writeHeader(DataOutputStream dos, int numKeys, int numDenseKeys, int numSparseKeys,
+      long keyDictOffset, long keyMetaOffset, long perKeyOffset, long valueDictOffset)
+      throws IOException {
+    dos.writeInt(MAGIC);
+    dos.writeInt(VERSION);
+    dos.writeInt(numKeys);
+    dos.writeInt(_numDocs);
+    dos.writeInt(numDenseKeys);
+    dos.writeInt(numSparseKeys);
+    dos.writeLong(keyDictOffset);
+    dos.writeLong(keyMetaOffset);
+    dos.writeLong(perKeyOffset);
+    dos.writeLong(valueDictOffset);
+    // Header is exactly 56 bytes: 6 ints (24B) + 4 longs (32B) = 56B, no padding
+  }
+
+  @Override
+  public void close()
+      throws IOException {
+  }
+
+  /**
+   * Returns the set of keys resolved as dense after seal().
+   * A key is dense if its fill rate exceeds the threshold OR it's in the configured denseKeys.
+   * Returns null if seal() has not been called yet.
+   */
+  @Nullable
+  public Set<String> getResolvedDenseKeys() {
+    return _resolvedDenseKeys;
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/columnminmaxvalue/ColumnMinMaxValueGenerator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/columnminmaxvalue/ColumnMinMaxValueGenerator.java
@@ -135,17 +135,19 @@ public class ColumnMinMaxValueGenerator {
   }
 
   private boolean needAddColumnMinMaxValueForColumn(String columnName) {
-    return needAddColumnMinMaxValueForColumn(_segmentMetadata.getColumnMetadataFor(columnName));
-  }
-
-  private boolean needAddColumnMinMaxValueForColumn(ColumnMetadata columnMetadata) {
+    ColumnMetadata columnMetadata = _segmentMetadata.getColumnMetadataFor(columnName);
+    // Only skip min/max for MAP columns that have a columnar map index
+    if (columnMetadata.getFieldSpec().getDataType() == FieldSpec.DataType.MAP
+        && _segmentWriter.hasIndexFor(columnName, StandardIndexes.columnarMap())) {
+      return false;
+    }
     return columnMetadata.getMinValue() == null && columnMetadata.getMaxValue() == null
         && !columnMetadata.isMinMaxValueInvalid();
   }
 
   private void addColumnMinMaxValueForColumn(String columnName) {
     ColumnMetadata columnMetadata = _segmentMetadata.getColumnMetadataFor(columnName);
-    if (!needAddColumnMinMaxValueForColumn(columnMetadata)) {
+    if (!needAddColumnMinMaxValueForColumn(columnName)) {
       return;
     }
     try {

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/columnarmap/ColumnarMapIndexEndToEndTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/columnarmap/ColumnarMapIndexEndToEndTest.java
@@ -1,0 +1,386 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.columnarmap;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.segment.spi.V1Constants;
+import org.apache.pinot.segment.spi.index.reader.ColumnarMapIndexReader;
+import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
+import org.apache.pinot.spi.config.table.ColumnarMapIndexConfig;
+import org.apache.pinot.spi.data.ComplexFieldSpec;
+import org.apache.pinot.spi.data.DimensionFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+
+/**
+ * End-to-end test for COLUMNAR_MAP index creation, sealing, and reading.
+ * Validates the complete lifecycle: creating a COLUMNAR_MAP index with OnHeapColumnarMapIndexCreator,
+ * writing to disk, and reading back via ImmutableColumnarMapIndexReader.
+ */
+public class ColumnarMapIndexEndToEndTest {
+
+  private static final File INDEX_DIR = new File(FileUtils.getTempDirectory(), "ColumnarMapIndexEndToEndTest");
+  private static final String COLUMN = "userMetrics";
+
+  private static ComplexFieldSpec buildMapFieldSpec(String columnName) {
+    Map<String, FieldSpec> childFieldSpecs = Map.of(
+        "key", new DimensionFieldSpec("key", FieldSpec.DataType.STRING, true),
+        "value", new DimensionFieldSpec("value", FieldSpec.DataType.STRING, true)
+    );
+    return new ComplexFieldSpec(columnName, FieldSpec.DataType.MAP, true, childFieldSpecs);
+  }
+
+  @BeforeMethod
+  public void setUp()
+      throws IOException {
+    FileUtils.forceMkdir(INDEX_DIR);
+  }
+
+  @AfterMethod
+  public void tearDown()
+      throws IOException {
+    FileUtils.deleteDirectory(INDEX_DIR);
+  }
+
+  /**
+   * Tests a realistic scenario: multiple users with sparse feature maps.
+   * Each user has a subset of possible features, with typed values.
+   * Validates full map reconstruction, presence bitmaps, and inverted index lookups.
+   */
+  @Test
+  public void testUserMetricsScenario()
+      throws IOException {
+    Map<String, FieldSpec.DataType> keyTypes = new HashMap<>();
+    keyTypes.put("clicks", FieldSpec.DataType.LONG);
+    keyTypes.put("spend", FieldSpec.DataType.DOUBLE);
+    keyTypes.put("country", FieldSpec.DataType.STRING);
+
+    ComplexFieldSpec fieldSpec = buildMapFieldSpec(COLUMN);
+
+    ColumnarMapIndexConfig config = new ColumnarMapIndexConfig(true, null, true, null, null, 100, null, 0.0);
+
+    // Build test data: 6 documents, sparse keys
+    @SuppressWarnings("unchecked")
+    Map<String, Object>[] docs = new Map[]{
+        Map.of("clicks", 100L, "spend", 5.50, "country", "US"),  // doc 0: all 3 keys
+        Map.of("clicks", 200L, "country", "CA"),                  // doc 1: no spend
+        Map.of("spend", 12.75, "country", "UK"),                  // doc 2: no clicks
+        Map.of("country", "US"),                                  // doc 3: country only
+        new HashMap<>(),                                           // doc 4: empty map
+        Map.of("clicks", 100L, "spend", 5.50, "country", "US")   // doc 5: duplicate of doc 0
+    };
+
+    File indexFile = new File(INDEX_DIR, COLUMN + V1Constants.Indexes.COLUMNAR_MAP_INDEX_FILE_EXTENSION);
+    try (OnHeapColumnarMapIndexCreator creator =
+        new OnHeapColumnarMapIndexCreator(INDEX_DIR, COLUMN, fieldSpec, config,
+            keyTypes, FieldSpec.DataType.STRING)) {
+      for (Map<String, Object> doc : docs) {
+        creator.add(doc);
+      }
+      creator.seal();
+    }
+    assertTrue(indexFile.exists());
+
+    try (PinotDataBuffer buffer = PinotDataBuffer.mapReadOnlyBigEndianFile(indexFile);
+        ColumnarMapIndexReader reader = new ImmutableColumnarMapIndexReader(buffer, null)) {
+
+      // Verify known keys exist
+      assertTrue(reader.getKeys().contains("clicks"));
+      assertTrue(reader.getKeys().contains("spend"));
+      assertTrue(reader.getKeys().contains("country"));
+
+      // Verify key types
+      assertEquals(reader.getKeyValueType("clicks"), FieldSpec.DataType.LONG);
+      assertEquals(reader.getKeyValueType("spend"), FieldSpec.DataType.DOUBLE);
+      assertEquals(reader.getKeyValueType("country"), FieldSpec.DataType.STRING);
+
+      // Verify doc counts
+      assertEquals(reader.getNumDocsWithKey("clicks"), 3);  // docs 0, 1, 5
+      assertEquals(reader.getNumDocsWithKey("spend"), 3);   // docs 0, 2, 5
+      assertEquals(reader.getNumDocsWithKey("country"), 5); // docs 0, 1, 2, 3, 5
+
+      // Verify presence bitmaps
+      ImmutableRoaringBitmap clicksBitmap = reader.getPresenceBitmap("clicks");
+      assertTrue(clicksBitmap.contains(0));
+      assertTrue(clicksBitmap.contains(1));
+      assertFalse(clicksBitmap.contains(2));
+      assertFalse(clicksBitmap.contains(3));
+      assertFalse(clicksBitmap.contains(4));
+      assertTrue(clicksBitmap.contains(5));
+
+      ImmutableRoaringBitmap spendBitmap = reader.getPresenceBitmap("spend");
+      assertTrue(spendBitmap.contains(0));
+      assertFalse(spendBitmap.contains(1));
+      assertTrue(spendBitmap.contains(2));
+      assertFalse(spendBitmap.contains(3));
+      assertFalse(spendBitmap.contains(4));
+      assertTrue(spendBitmap.contains(5));
+
+      // Verify typed value access
+      assertEquals(reader.getLong(0, "clicks"), 100L);
+      assertEquals(reader.getLong(1, "clicks"), 200L);
+      assertEquals(reader.getLong(5, "clicks"), 100L);
+
+      assertEquals(reader.getDouble(0, "spend"), 5.50, 0.001);
+      assertEquals(reader.getDouble(2, "spend"), 12.75, 0.001);
+
+      assertEquals(reader.getString(0, "country"), "US");
+      assertEquals(reader.getString(1, "country"), "CA");
+      assertEquals(reader.getString(2, "country"), "UK");
+      assertEquals(reader.getString(3, "country"), "US");
+
+      // Verify inverted index: docs with country = "US"
+      ImmutableRoaringBitmap usDocs = reader.getDocsWithKeyValue("country", "US");
+      assertNotNull(usDocs);
+      assertTrue(usDocs.contains(0));
+      assertFalse(usDocs.contains(1));
+      assertFalse(usDocs.contains(2));
+      assertTrue(usDocs.contains(3));
+      assertFalse(usDocs.contains(4));
+      assertTrue(usDocs.contains(5));
+
+      // Verify inverted index: docs with clicks = 100
+      ImmutableRoaringBitmap clicks100 = reader.getDocsWithKeyValue("clicks", "100");
+      assertNotNull(clicks100);
+      assertTrue(clicks100.contains(0));
+      assertFalse(clicks100.contains(1)); // has 200 clicks, not 100
+      assertTrue(clicks100.contains(5));
+
+      // Non-existent value in inverted index
+      assertNull(reader.getDocsWithKeyValue("country", "AU"));
+
+      // Full map reconstruction
+      Map<String, Object> doc0Map = reader.getMap(0);
+      assertEquals(((Number) doc0Map.get("clicks")).longValue(), 100L);
+      assertEquals(((Number) doc0Map.get("spend")).doubleValue(), 5.50, 0.001);
+      assertEquals(doc0Map.get("country"), "US");
+
+      Map<String, Object> doc4Map = reader.getMap(4);
+      assertTrue(doc4Map.isEmpty(), "Empty document should produce empty map");
+
+      Map<String, Object> doc3Map = reader.getMap(3);
+      assertEquals(doc3Map.size(), 1);
+      assertEquals(doc3Map.get("country"), "US");
+    }
+  }
+
+  /**
+   * Tests index with default value type fallback for undeclared keys.
+   * Validates that undeclared keys are stored as the defaultValueType.
+   */
+  @Test
+  public void testUndeclaredKeyUsesDefaultType()
+      throws IOException {
+    Map<String, FieldSpec.DataType> keyTypes = new HashMap<>();
+    keyTypes.put("score", FieldSpec.DataType.FLOAT);
+
+    ComplexFieldSpec fieldSpec = buildMapFieldSpec(COLUMN);
+
+    ColumnarMapIndexConfig config = new ColumnarMapIndexConfig(true, null, false, null, null, 100, null, 0.0);
+
+    @SuppressWarnings("unchecked")
+    Map<String, Object>[] docs = new Map[]{
+        Map.of("score", 9.5f, "tag", "vip"),
+        Map.of("score", 7.0f, "tag", "standard", "region", "west")
+    };
+
+    File indexFile = new File(INDEX_DIR, COLUMN + V1Constants.Indexes.COLUMNAR_MAP_INDEX_FILE_EXTENSION);
+    try (OnHeapColumnarMapIndexCreator creator =
+        new OnHeapColumnarMapIndexCreator(INDEX_DIR, COLUMN, fieldSpec, config,
+            keyTypes, FieldSpec.DataType.STRING)) {
+      for (Map<String, Object> doc : docs) {
+        creator.add(doc);
+      }
+      creator.seal();
+    }
+
+    try (PinotDataBuffer buffer = PinotDataBuffer.mapReadOnlyBigEndianFile(indexFile);
+        ColumnarMapIndexReader reader = new ImmutableColumnarMapIndexReader(buffer, null)) {
+
+      // score is declared as FLOAT
+      assertEquals(reader.getKeyValueType("score"), FieldSpec.DataType.FLOAT);
+      assertEquals(reader.getFloat(0, "score"), 9.5f, 0.001f);
+      assertEquals(reader.getFloat(1, "score"), 7.0f, 0.001f);
+
+      // tag is undeclared, stored as STRING (defaultValueType)
+      assertEquals(reader.getKeyValueType("tag"), FieldSpec.DataType.STRING);
+      assertEquals(reader.getString(0, "tag"), "vip");
+      assertEquals(reader.getString(1, "tag"), "standard");
+
+      // region appears only in doc 1
+      assertEquals(reader.getNumDocsWithKey("region"), 1);
+      assertEquals(reader.getString(1, "region"), "west");
+    }
+  }
+
+  /**
+   * Tests round-trip from MutableColumnarMapIndex to immutable index file.
+   * Creates data via mutable index, then serializes and reads back.
+   */
+  @Test
+  public void testMutableToImmutableRoundTrip()
+      throws IOException {
+    Map<String, FieldSpec.DataType> keyTypes = new HashMap<>();
+    keyTypes.put("value", FieldSpec.DataType.INT);
+
+    ComplexFieldSpec fieldSpec = buildMapFieldSpec(COLUMN);
+
+    ColumnarMapIndexConfig config = new ColumnarMapIndexConfig(true, null, true, null, null, 100, null, 0.0);
+    org.apache.pinot.segment.spi.index.mutable.provider.MutableIndexContext context =
+        new org.apache.pinot.segment.spi.index.mutable.provider.MutableIndexContext(
+            fieldSpec, -1, false, "testSegment",
+            new org.apache.pinot.segment.local.io.writer.impl.DirectMemoryManager("mutableMapE2ETest"),
+            100, false, 100, 1000, 1, null);
+
+    // Step 1: Add to mutable index
+    MutableColumnarMapIndexImpl mutableIdx = new MutableColumnarMapIndexImpl(context, config,
+        keyTypes, FieldSpec.DataType.STRING);
+    mutableIdx.add(Map.of("value", 10), -1, 0);
+    mutableIdx.add(Map.of("value", 20, "label", "alpha"), -1, 1);
+    mutableIdx.add(Map.of("label", "beta"), -1, 2);
+    mutableIdx.add(Map.of("value", 10), -1, 3);
+
+    // Verify mutable reads
+    assertEquals(mutableIdx.getInt(0, "value"), 10);
+    assertEquals(mutableIdx.getInt(1, "value"), 20);
+    assertEquals(mutableIdx.getInt(3, "value"), 10);
+    assertEquals(mutableIdx.getString(1, "label"), "alpha");
+    assertEquals(mutableIdx.getString(2, "label"), "beta");
+
+    // Step 2: Persist to immutable index using OnHeapColumnarMapIndexCreator
+    File indexFile = new File(INDEX_DIR, COLUMN + V1Constants.Indexes.COLUMNAR_MAP_INDEX_FILE_EXTENSION);
+    List<Map<String, Object>> allDocs = List.of(
+        Map.of("value", 10),
+        Map.of("value", 20, "label", "alpha"),
+        Map.of("label", "beta"),
+        Map.of("value", 10)
+    );
+
+    try (OnHeapColumnarMapIndexCreator creator =
+        new OnHeapColumnarMapIndexCreator(INDEX_DIR, COLUMN, fieldSpec, config,
+            keyTypes, FieldSpec.DataType.STRING)) {
+      for (Map<String, Object> doc : allDocs) {
+        creator.add(doc);
+      }
+      creator.seal();
+    }
+
+    // Step 3: Read back immutable index and verify matches mutable
+    try (PinotDataBuffer buffer = PinotDataBuffer.mapReadOnlyBigEndianFile(indexFile);
+        ColumnarMapIndexReader immutableReader = new ImmutableColumnarMapIndexReader(buffer, null)) {
+
+      assertEquals(immutableReader.getInt(0, "value"), 10);
+      assertEquals(immutableReader.getInt(1, "value"), 20);
+      assertEquals(immutableReader.getInt(3, "value"), 10);
+      assertEquals(immutableReader.getString(1, "label"), "alpha");
+      assertEquals(immutableReader.getString(2, "label"), "beta");
+
+      ImmutableRoaringBitmap value10Docs = immutableReader.getDocsWithKeyValue("value", "10");
+      assertNotNull(value10Docs);
+      assertTrue(value10Docs.contains(0));
+      assertFalse(value10Docs.contains(1));
+      assertFalse(value10Docs.contains(2));
+      assertTrue(value10Docs.contains(3));
+    }
+
+    mutableIdx.close();
+  }
+
+  @Test
+  public void testKeyUnionAcrossSegments() throws Exception {
+    // Simulate merging two segments by re-ingesting both sets of docs
+    // through a single OnHeapColumnarMapIndexCreator.
+    //
+    // Segment A docs: keys {price, quantity}
+    // Segment B docs: keys {color, quantity}   <- "quantity" overlaps
+    // Merged result: keys {price, quantity, color}, 5 docs total
+
+    String colName = "merge_test_col";
+    Map<String, FieldSpec.DataType> keyTypes = new HashMap<>();
+    keyTypes.put("price", FieldSpec.DataType.INT);
+    keyTypes.put("quantity", FieldSpec.DataType.INT);
+    ComplexFieldSpec fieldSpec = buildMapFieldSpec(colName);
+    ColumnarMapIndexConfig config = new ColumnarMapIndexConfig(true, null, false, null, null, 10, null, 0.0);
+    OnHeapColumnarMapIndexCreator creator =
+        new OnHeapColumnarMapIndexCreator(INDEX_DIR, colName, fieldSpec, config,
+            keyTypes, FieldSpec.DataType.STRING);
+
+    // "Segment A" docs: 0, 1 — have price and quantity
+    creator.add(Map.of("price", 10, "quantity", 5));   // doc 0
+    creator.add(Map.of("price", 20, "quantity", 8));   // doc 1
+
+    // "Segment B" docs: 2, 3, 4 — have color and quantity
+    creator.add(Map.of("color", "red", "quantity", 3));  // doc 2
+    creator.add(Map.of("color", "blue", "quantity", 7));  // doc 3
+    creator.add(Map.of("color", "green", "quantity", 2));  // doc 4
+
+    creator.seal();
+    creator.close();
+
+    File indexFile = new File(INDEX_DIR, colName + V1Constants.Indexes.COLUMNAR_MAP_INDEX_FILE_EXTENSION);
+    PinotDataBuffer buf = PinotDataBuffer.mapReadOnlyBigEndianFile(indexFile);
+    ImmutableColumnarMapIndexReader reader = new ImmutableColumnarMapIndexReader(buf, null);
+
+    // Union of keys across both "segments"
+    assertEquals(reader.getKeys().size(), 3);
+    assertTrue(reader.getKeys().contains("price"));
+    assertTrue(reader.getKeys().contains("quantity"));
+    assertTrue(reader.getKeys().contains("color"));
+
+    // "price" present only in docs 0 and 1 (segment A); absent from segment B docs
+    assertTrue(reader.getPresenceBitmap("price").contains(0));
+    assertTrue(reader.getPresenceBitmap("price").contains(1));
+    assertFalse(reader.getPresenceBitmap("price").contains(2));
+    assertFalse(reader.getPresenceBitmap("price").contains(3));
+    assertFalse(reader.getPresenceBitmap("price").contains(4));
+    assertEquals(reader.getPresenceBitmap("price").getCardinality(), 2);
+
+    // "color" present only in docs 2, 3, 4 (segment B); absent from segment A docs
+    assertFalse(reader.getPresenceBitmap("color").contains(0));
+    assertFalse(reader.getPresenceBitmap("color").contains(1));
+    assertTrue(reader.getPresenceBitmap("color").contains(2));
+    assertTrue(reader.getPresenceBitmap("color").contains(3));
+    assertTrue(reader.getPresenceBitmap("color").contains(4));
+    assertEquals(reader.getPresenceBitmap("color").getCardinality(), 3);
+
+    // "quantity" present in all 5 docs (both segments)
+    assertTrue(reader.getPresenceBitmap("quantity").contains(0));
+    assertTrue(reader.getPresenceBitmap("quantity").contains(4));
+    assertEquals(reader.getPresenceBitmap("quantity").getCardinality(), 5);
+
+    // Spot-check values to confirm no corruption during merge re-ingestion
+    assertEquals(reader.getInt(0, "price"), 10);
+    assertEquals(reader.getInt(1, "price"), 20);
+    assertEquals(reader.getString(2, "color"), "red");
+    assertEquals(reader.getString(4, "color"), "green");
+
+    buf.close();
+  }
+}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/columnarmap/ColumnarMapSegmentCreationTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/columnarmap/ColumnarMapSegmentCreationTest.java
@@ -1,0 +1,195 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.columnarmap;
+
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
+import org.apache.pinot.segment.spi.index.StandardIndexes;
+import org.apache.pinot.spi.config.table.FieldConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.ComplexFieldSpec;
+import org.apache.pinot.spi.data.DimensionFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.data.readers.RecordReader;
+import org.apache.pinot.spi.data.readers.RecordReaderConfig;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+
+/**
+ * Tests full segment creation pipeline for MAP columns with sparse map index.
+ * Verifies that OnHeapColumnarMapIndexCreator is properly invoked and produces an index file.
+ */
+public class ColumnarMapSegmentCreationTest {
+
+  private static final File SEGMENT_DIR = new File(FileUtils.getTempDirectory(), "ColumnarMapSegmentCreationTest");
+  private static final String TABLE_NAME = "userMetrics";
+
+  @BeforeMethod
+  public void setUp()
+      throws Exception {
+    FileUtils.forceMkdir(SEGMENT_DIR);
+  }
+
+  @AfterMethod
+  public void tearDown()
+      throws Exception {
+    FileUtils.deleteDirectory(SEGMENT_DIR);
+  }
+
+  @Test
+  public void testColumnarMapIndexCreatedInSegment()
+      throws Exception {
+    // Build schema with a MAP column
+    Map<String, FieldSpec.DataType> keyTypes = new HashMap<>();
+    keyTypes.put("clicks", FieldSpec.DataType.LONG);
+    keyTypes.put("spend", FieldSpec.DataType.DOUBLE);
+
+    Map<String, FieldSpec> childFieldSpecs = Map.of(
+        "key", new DimensionFieldSpec("key", FieldSpec.DataType.STRING, true),
+        "value", new DimensionFieldSpec("value", FieldSpec.DataType.STRING, true)
+    );
+    ComplexFieldSpec metricsSpec = new ComplexFieldSpec("metrics", FieldSpec.DataType.MAP, true, childFieldSpecs);
+
+    Schema schema = new Schema.SchemaBuilder()
+        .setSchemaName(TABLE_NAME)
+        .addField(new DimensionFieldSpec("userId", FieldSpec.DataType.STRING, true))
+        .addField(metricsSpec)
+        .build();
+
+    // Build table config with columnar_map index in fieldConfigList
+    ObjectNode columnarMapNode = JsonUtils.newObjectNode();
+    columnarMapNode.put("enabled", true);
+    columnarMapNode.put("enableInvertedIndexForAll", false);
+    columnarMapNode.put("maxKeys", 100);
+    ObjectNode indexesNode = JsonUtils.newObjectNode();
+    indexesNode.set("columnar_map", columnarMapNode);
+    FieldConfig metricsFieldConfig = new FieldConfig.Builder("metrics")
+        .withIndexes(indexesNode)
+        .build();
+
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName(TABLE_NAME)
+        .setFieldConfigList(List.of(metricsFieldConfig))
+        .build();
+
+    // Build test rows
+    List<Map<String, Object>> rows = new ArrayList<>();
+    rows.add(buildRow("user1", Map.of("clicks", 100L, "spend", 5.5)));
+    rows.add(buildRow("user2", Map.of("clicks", 200L)));
+    rows.add(buildRow("user3", Map.of("spend", 12.75)));
+    rows.add(buildRow("user4", new HashMap<>()));
+
+    // Create segment generator config
+    SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(tableConfig, schema);
+    segmentGeneratorConfig.setTableName(TABLE_NAME);
+    segmentGeneratorConfig.setSegmentName(TABLE_NAME + "_0");
+    segmentGeneratorConfig.setOutDir(SEGMENT_DIR.getAbsolutePath());
+
+    // Create segment with test reader
+    SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+    driver.init(segmentGeneratorConfig, new TestRecordReader(rows));
+    driver.build();
+
+    // Verify the segment was created
+    File segmentDir = new File(SEGMENT_DIR, TABLE_NAME + "_0");
+    assertTrue(segmentDir.exists(), "Segment directory should exist: " + segmentDir);
+
+    // Verify the sparse map index file exists in the V3 segment
+    File v3Dir = new File(segmentDir, "v3");
+    assertTrue(v3Dir.exists(), "V3 directory should exist: " + v3Dir);
+
+    File indexMap = new File(v3Dir, "index_map");
+    assertTrue(indexMap.exists(), "index_map should exist");
+
+    String indexMapContent = org.apache.commons.io.FileUtils.readFileToString(indexMap,
+        java.nio.charset.StandardCharsets.UTF_8);
+
+    // The sparse map index should be present in the index_map
+    assertTrue(indexMapContent.contains("metrics." + StandardIndexes.COLUMNAR_MAP_ID),
+        "index_map should contain metrics columnar_map_index entry but got:\n" + indexMapContent);
+  }
+
+  private Map<String, Object> buildRow(String userId, Map<String, Object> metrics) {
+    Map<String, Object> row = new HashMap<>();
+    row.put("userId", userId);
+    row.put("metrics", metrics);
+    return row;
+  }
+
+  /**
+   * Simple in-memory record reader for testing.
+   */
+  private static class TestRecordReader implements RecordReader {
+    private final List<Map<String, Object>> _rows;
+    private int _index = 0;
+
+    TestRecordReader(List<Map<String, Object>> rows) {
+      _rows = rows;
+    }
+
+    @Override
+    public void init(File dataFile, Set<String> fieldsToRead, RecordReaderConfig recordReaderConfig)
+        throws IOException {
+    }
+
+    @Override
+    public boolean hasNext() {
+      return _index < _rows.size();
+    }
+
+    @Override
+    public GenericRow next(GenericRow reuse)
+        throws IOException {
+      Map<String, Object> rowData = _rows.get(_index++);
+      reuse.clear();
+      for (Map.Entry<String, Object> entry : rowData.entrySet()) {
+        reuse.putValue(entry.getKey(), entry.getValue());
+      }
+      return reuse;
+    }
+
+    @Override
+    public void rewind()
+        throws IOException {
+      _index = 0;
+    }
+
+    @Override
+    public void close() {
+    }
+  }
+}

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/V1Constants.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/V1Constants.java
@@ -46,6 +46,7 @@ public class V1Constants {
     public static final String BITMAP_INVERTED_INDEX_FILE_EXTENSION = ".bitmap.inv";
     public static final String BITMAP_RANGE_INDEX_FILE_EXTENSION = ".bitmap.range";
     public static final String JSON_INDEX_FILE_EXTENSION = ".json.idx";
+    public static final String COLUMNAR_MAP_INDEX_FILE_EXTENSION = ".columnarmap.idx";
     /** @deprecated Legacy native text index file extension kept only for cleanup and migration logic. */
     @Deprecated
     public static final String DEPRECATED_NATIVE_TEXT_INDEX_FILE_EXTENSION = ".nativetext.idx";
@@ -98,6 +99,7 @@ public class V1Constants {
       public static final String SEGMENT_TOTAL_DOCS = "segment.total.docs";
       public static final String SEGMENT_PADDING_CHARACTER = "segment.padding.character";
       public static final String COMPLEX_COLUMNS = "segment.complex.column.names";
+      public static final String COLUMNAR_MAP_COLUMNS = "segment.columnarmap.column.names";
 
       public static final String CUSTOM_SUBSET = "custom";
 
@@ -132,6 +134,9 @@ public class V1Constants {
       public static final String DATETIME_FORMAT = "datetimeFormat";
       public static final String DATETIME_GRANULARITY = "datetimeGranularity";
       public static final String COMPLEX_CHILD_FIELD_NAMES = "complexChildFieldNames";
+      public static final String COLUMNAR_MAP_KEY_NAMES = "columnarMapKeyNames";
+      public static final String COLUMNAR_MAP_KEY_TYPE_PREFIX = "columnarMapKeyType";
+      public static final String COLUMNAR_MAP_DEFAULT_VALUE_TYPE = "columnarMapDefaultValueType";
 
       public static final String COLUMN_PROPS_KEY_PREFIX = "column.";
       public static final String SCHEMA_MAX_LENGTH = "schemaMaxLength";

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/SegmentGeneratorConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/SegmentGeneratorConfig.java
@@ -36,6 +36,7 @@ import org.apache.pinot.segment.spi.creator.name.SimpleSegmentNameGenerator;
 import org.apache.pinot.segment.spi.creator.name.UploadedRealtimeSegmentNameGenerator;
 import org.apache.pinot.segment.spi.index.FieldIndexConfigs;
 import org.apache.pinot.segment.spi.index.FieldIndexConfigsUtil;
+import org.apache.pinot.segment.spi.index.StandardIndexes;
 import org.apache.pinot.spi.config.instance.InstanceType;
 import org.apache.pinot.spi.config.table.FieldConfig;
 import org.apache.pinot.spi.config.table.IndexingConfig;
@@ -528,6 +529,23 @@ public class SegmentGeneratorConfig implements Serializable {
 
   public List<String> getComplexColumnNames() {
     return getQualifyingFields(FieldType.COMPLEX, true);
+  }
+
+  public List<String> getColumnarMapColumnNames() {
+    List<String> fields = new ArrayList<>();
+    for (FieldSpec fieldSpec : getSchema().getAllFieldSpecs()) {
+      if (fieldSpec.isVirtualColumn()) {
+        continue;
+      }
+      if (fieldSpec.getDataType() == FieldSpec.DataType.MAP) {
+        FieldIndexConfigs indexConfigs = _indexConfigsByColName.get(fieldSpec.getName());
+        if (indexConfigs != null && indexConfigs.getConfig(StandardIndexes.columnarMap()).isEnabled()) {
+          fields.add(fieldSpec.getName());
+        }
+      }
+    }
+    Collections.sort(fields);
+    return fields;
   }
 
   public void setSegmentPartitionConfig(SegmentPartitionConfig segmentPartitionConfig) {

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/StandardIndexes.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/StandardIndexes.java
@@ -20,6 +20,7 @@
 package org.apache.pinot.segment.spi.index;
 
 import org.apache.pinot.segment.spi.index.creator.BloomFilterCreator;
+import org.apache.pinot.segment.spi.index.creator.ColumnarMapIndexCreator;
 import org.apache.pinot.segment.spi.index.creator.CombinedInvertedIndexCreator;
 import org.apache.pinot.segment.spi.index.creator.DictionaryBasedInvertedIndexCreator;
 import org.apache.pinot.segment.spi.index.creator.FSTIndexCreator;
@@ -31,6 +32,7 @@ import org.apache.pinot.segment.spi.index.creator.TextIndexCreator;
 import org.apache.pinot.segment.spi.index.creator.VectorIndexConfig;
 import org.apache.pinot.segment.spi.index.creator.VectorIndexCreator;
 import org.apache.pinot.segment.spi.index.reader.BloomFilterReader;
+import org.apache.pinot.segment.spi.index.reader.ColumnarMapIndexReader;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.segment.spi.index.reader.ForwardIndexReader;
 import org.apache.pinot.segment.spi.index.reader.H3IndexReader;
@@ -41,6 +43,7 @@ import org.apache.pinot.segment.spi.index.reader.RangeIndexReader;
 import org.apache.pinot.segment.spi.index.reader.TextIndexReader;
 import org.apache.pinot.segment.spi.index.reader.VectorIndexReader;
 import org.apache.pinot.spi.config.table.BloomFilterConfig;
+import org.apache.pinot.spi.config.table.ColumnarMapIndexConfig;
 import org.apache.pinot.spi.config.table.IndexConfig;
 import org.apache.pinot.spi.config.table.JsonIndexConfig;
 
@@ -79,6 +82,7 @@ public class StandardIndexes {
   public static final String TEXT_ID = "text_index";
   public static final String H3_ID = "h3_index";
   public static final String VECTOR_ID = "vector_index";
+  public static final String COLUMNAR_MAP_ID = "columnar_map_index";
 
   private StandardIndexes() {
   }
@@ -141,5 +145,11 @@ public class StandardIndexes {
   public static IndexType<VectorIndexConfig, VectorIndexReader, VectorIndexCreator> vector() {
     return (IndexType<VectorIndexConfig, VectorIndexReader, VectorIndexCreator>)
         IndexService.getInstance().get(VECTOR_ID);
+  }
+
+  @SuppressWarnings("unchecked")
+  public static IndexType<ColumnarMapIndexConfig, ColumnarMapIndexReader, ColumnarMapIndexCreator> columnarMap() {
+    return (IndexType<ColumnarMapIndexConfig, ColumnarMapIndexReader, ColumnarMapIndexCreator>)
+        IndexService.getInstance().get(COLUMNAR_MAP_ID);
   }
 }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/creator/ColumnarMapIndexCreator.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/creator/ColumnarMapIndexCreator.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.spi.index.creator;
+
+import java.io.IOException;
+import java.util.Map;
+import org.apache.pinot.segment.spi.index.IndexCreator;
+
+
+/**
+ * Creator for the ColumnarMap index. Accepts a Map per document during segment creation and
+ * decomposes it into per-key columnar storage (presence bitmaps, typed forward indexes,
+ * optional inverted indexes) on seal().
+ */
+public interface ColumnarMapIndexCreator extends IndexCreator {
+
+  /**
+   * Adds a document's sparse map data. The map may be null or empty if the document has no keys.
+   * Keys in the map that match declared key types are stored with typed per-key forward indexes.
+   * Undeclared keys are stored using the default value type (STRING if not configured).
+   */
+  void add(Map<String, Object> columnarMap)
+      throws IOException;
+
+  /**
+   * Finalizes the index, writing per-key presence bitmaps, typed forward indexes, and optional
+   * inverted indexes to the index file.
+   */
+  @Override
+  void seal()
+      throws IOException;
+}

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/metadata/ColumnMetadataImpl.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/metadata/ColumnMetadataImpl.java
@@ -381,6 +381,27 @@ public class ColumnMetadataImpl implements ColumnMetadata {
               generateFieldSpec(ComplexFieldSpec.getFullChildName(column, childField), config));
         }
         fieldSpec = new ComplexFieldSpec(fieldName, dataType, true, childFieldSpecs);
+        // Restore keyTypes and defaultValueType from segment metadata for MAP columns
+        if (dataType == DataType.MAP) {
+          List<String> keyNames = config.getList(String.class,
+              Column.getKeyFor(column, Column.COLUMNAR_MAP_KEY_NAMES), null);
+          if (keyNames != null && !keyNames.isEmpty()) {
+            Map<String, DataType> keyTypes = new HashMap<>();
+            for (String keyName : keyNames) {
+              String typeStr = config.getString(
+                  Column.getKeyFor(column, Column.COLUMNAR_MAP_KEY_TYPE_PREFIX + "." + keyName), null);
+              if (typeStr != null) {
+                keyTypes.put(keyName, DataType.valueOf(typeStr));
+              }
+            }
+            ((ComplexFieldSpec) fieldSpec).setKeyTypes(keyTypes);
+          }
+          String defaultTypeStr = config.getString(
+              Column.getKeyFor(column, Column.COLUMNAR_MAP_DEFAULT_VALUE_TYPE), null);
+          if (defaultTypeStr != null) {
+            ((ComplexFieldSpec) fieldSpec).setDefaultValueType(DataType.valueOf(defaultTypeStr));
+          }
+        }
         break;
       default:
         throw new IllegalStateException("Unsupported field type: " + fieldType);

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/metadata/SegmentMetadataImpl.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/metadata/SegmentMetadataImpl.java
@@ -236,6 +236,7 @@ public class SegmentMetadataImpl implements SegmentMetadata {
     addPhysicalColumns(segmentMetadata.getList(Segment.TIME_COLUMN_NAME), physicalColumns);
     addPhysicalColumns(segmentMetadata.getList(Segment.DATETIME_COLUMNS), physicalColumns);
     addPhysicalColumns(segmentMetadata.getList(Segment.COMPLEX_COLUMNS), physicalColumns);
+    addPhysicalColumns(segmentMetadata.getList(Segment.COLUMNAR_MAP_COLUMNS), physicalColumns);
 
     // Set the table name (for backward compatibility)
     String tableName = segmentMetadata.getString(Segment.TABLE_NAME);

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/ColumnarMapIndexReader.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/ColumnarMapIndexReader.java
@@ -1,0 +1,110 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.spi.index.reader;
+
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.segment.spi.index.IndexReader;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
+
+
+/**
+ * Reader for the ColumnarMap index. Provides O(1) typed key lookup per document via presence bitmap
+ * rank operations. Each key has its own presence bitmap and typed forward index, allowing direct
+ * typed reads without full map deserialization.
+ */
+public interface ColumnarMapIndexReader extends IndexReader {
+
+  /**
+   * Returns the set of all indexed key names.
+   */
+  Set<String> getKeys();
+
+  /**
+   * Returns the value DataType for the given key, or null if the key is not indexed.
+   */
+  @Nullable
+  DataType getKeyValueType(String key);
+
+  /**
+   * Returns the number of documents that have the given key (i.e., the size of the presence bitmap).
+   */
+  int getNumDocsWithKey(String key);
+
+  /**
+   * Returns the presence bitmap for the given key. A document is present in this bitmap if and
+   * only if it has a non-null value for the key. This bitmap is the inverted null bitmap.
+   */
+  ImmutableRoaringBitmap getPresenceBitmap(String key);
+
+  // Typed value access -- O(1) per doc via presence bitmap rank
+  // Returns the default value (0, 0L, 0.0f, 0.0, "", new byte[0]) if the doc does not have the key.
+
+  int getInt(int docId, String key);
+
+  long getLong(int docId, String key);
+
+  float getFloat(int docId, String key);
+
+  double getDouble(int docId, String key);
+
+  String getString(int docId, String key);
+
+  byte[] getBytes(int docId, String key);
+
+  /**
+   * Returns a bitmap of docIds that have the given key-value pair.
+   * Only available if per-key inverted index is enabled (enableInvertedIndexForAll=true or key in invertedIndexKeys).
+   * Returns null if inverted index is not available for this key.
+   */
+  @Nullable
+  ImmutableRoaringBitmap getDocsWithKeyValue(String key, Object value);
+
+  /**
+   * Returns a DataSource for the given key, suitable for use with ItemTransformFunction and
+   * MapFilterOperator. The DataSource provides typed single-value access backed by the per-key
+   * forward index.
+   */
+  DataSource getKeyDataSource(String key);
+
+  /**
+   * Reconstructs the full map for a document from per-key data. Used for SELECT sparse_col queries
+   * and data table transport to the broker.
+   */
+  Map<String, Object> getMap(int docId);
+
+  /**
+   * Returns whether the given key has an inverted index available.
+   */
+  default boolean hasInvertedIndex(String key) {
+    return false;
+  }
+
+  /**
+   * Returns the sorted distinct values for the given key from the inverted index, or null if no
+   * inverted index is available. Used to build a dictionary for dictionary-based GROUP BY.
+   */
+  @Nullable
+  default String[] getDistinctValuesForKey(String key) {
+    return null;
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ColumnarMapIndexConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ColumnarMapIndexConfig.java
@@ -1,0 +1,218 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.config.table;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+
+
+/**
+ * Configuration for the ColumnarMap index on a MAP column.
+ * Controls which keys are indexed per-key in columnar storage and whether
+ * per-key inverted indexes are enabled for fast value-based filtering.
+ *
+ * <p>Inverted index control:
+ * <ul>
+ *   <li>{@code enableInvertedIndexForAll: true} — inverted index on ALL keys
+ *       ({@code invertedIndexKeys} is ignored)</li>
+ *   <li>{@code enableInvertedIndexForAll: false} + {@code invertedIndexKeys: [...]} —
+ *       only the listed keys get inverted indexes</li>
+ *   <li>{@code enableInvertedIndexForAll: false} + no {@code invertedIndexKeys} —
+ *       no inverted indexes</li>
+ * </ul>
+ */
+public class ColumnarMapIndexConfig extends IndexConfig {
+  public static final ColumnarMapIndexConfig DISABLED = new ColumnarMapIndexConfig(false);
+  public static final ColumnarMapIndexConfig DEFAULT = new ColumnarMapIndexConfig(true);
+
+  public static final double DEFAULT_DENSE_KEY_THRESHOLD = 0.5;
+
+  private final Set<String> _indexedKeys;
+  private final boolean _enableInvertedIndexForAll;
+  private final Set<String> _invertedIndexKeys;
+  private final Set<String> _noDictionaryKeys;
+  private final int _maxKeys;
+  private final Set<String> _denseKeys;
+  private final double _denseKeyThreshold;
+
+  /**
+   * Creates a ColumnarMapIndexConfig from FieldConfig properties map.
+   * Reads the COLUMNAR_MAP_INDEX_* property constants from {@link FieldConfig}.
+   */
+  public static ColumnarMapIndexConfig fromProperties(@Nullable Map<String, String> properties) {
+    if (properties == null || properties.isEmpty()) {
+      return DEFAULT;
+    }
+    int maxKeys = Integer.parseInt(
+        properties.getOrDefault(FieldConfig.COLUMNAR_MAP_INDEX_MAX_KEYS, "1000"));
+    Set<String> invertedIndexKeys = parseCommaSeparated(
+        properties.get(FieldConfig.COLUMNAR_MAP_INDEX_INVERTED_INDEX_KEYS));
+    Set<String> noDictionaryKeys = parseCommaSeparated(
+        properties.get(FieldConfig.COLUMNAR_MAP_INDEX_NO_DICTIONARY_KEYS));
+    boolean enableInvertedForAll = Boolean.parseBoolean(
+        properties.getOrDefault(FieldConfig.COLUMNAR_MAP_INDEX_ENABLE_INVERTED_FOR_ALL, "false"));
+    Set<String> denseKeys = parseCommaSeparated(
+        properties.get(FieldConfig.COLUMNAR_MAP_INDEX_DENSE_KEYS));
+    double denseKeyThreshold = Double.parseDouble(
+        properties.getOrDefault(FieldConfig.COLUMNAR_MAP_INDEX_DENSE_KEY_THRESHOLD,
+            String.valueOf(DEFAULT_DENSE_KEY_THRESHOLD)));
+    return new ColumnarMapIndexConfig(true, null, enableInvertedForAll, invertedIndexKeys, noDictionaryKeys, maxKeys,
+        denseKeys, denseKeyThreshold);
+  }
+
+  @Nullable
+  private static Set<String> parseCommaSeparated(@Nullable String value) {
+    if (value == null || value.trim().isEmpty()) {
+      return null;
+    }
+    Set<String> result = new HashSet<>();
+    for (String part : value.split(FieldConfig.COLUMNAR_MAP_INDEX_KEY_SEPARATOR)) {
+      String trimmed = part.trim();
+      if (!trimmed.isEmpty()) {
+        result.add(trimmed);
+      }
+    }
+    return result.isEmpty() ? null : result;
+  }
+
+  public ColumnarMapIndexConfig(boolean enabled) {
+    this(enabled, null, false, null, null, 1000, null, DEFAULT_DENSE_KEY_THRESHOLD);
+  }
+
+  public ColumnarMapIndexConfig(boolean enabled, @Nullable Set<String> indexedKeys,
+      boolean enableInvertedIndexForAll, @Nullable Set<String> invertedIndexKeys, int maxKeys) {
+    this(enabled, indexedKeys, enableInvertedIndexForAll, invertedIndexKeys, null, maxKeys,
+        null, DEFAULT_DENSE_KEY_THRESHOLD);
+  }
+
+  public ColumnarMapIndexConfig(boolean enabled, @Nullable Set<String> indexedKeys,
+      boolean enableInvertedIndexForAll, @Nullable Set<String> invertedIndexKeys,
+      @Nullable Set<String> noDictionaryKeys, int maxKeys) {
+    this(enabled, indexedKeys, enableInvertedIndexForAll, invertedIndexKeys, noDictionaryKeys, maxKeys,
+        null, DEFAULT_DENSE_KEY_THRESHOLD);
+  }
+
+  @JsonCreator
+  public ColumnarMapIndexConfig(
+      @JsonProperty("enabled") boolean enabled,
+      @JsonProperty("indexedKeys") @Nullable Set<String> indexedKeys,
+      @JsonProperty("enableInvertedIndexForAll") boolean enableInvertedIndexForAll,
+      @JsonProperty("invertedIndexKeys") @Nullable Set<String> invertedIndexKeys,
+      @JsonProperty("noDictionaryKeys") @Nullable Set<String> noDictionaryKeys,
+      @JsonProperty("maxKeys") int maxKeys,
+      @JsonProperty("denseKeys") @Nullable Set<String> denseKeys,
+      @JsonProperty("denseKeyThreshold") double denseKeyThreshold) {
+    super(!enabled);
+    _indexedKeys = indexedKeys;
+    _enableInvertedIndexForAll = enableInvertedIndexForAll;
+    _invertedIndexKeys = invertedIndexKeys;
+    _noDictionaryKeys = noDictionaryKeys;
+    _maxKeys = maxKeys > 0 ? maxKeys : 1000;
+    _denseKeys = denseKeys;
+    _denseKeyThreshold = denseKeyThreshold >= 0 ? denseKeyThreshold : DEFAULT_DENSE_KEY_THRESHOLD;
+  }
+
+  /**
+   * Returns the set of keys to index, or null if all keys should be indexed.
+   */
+  @Nullable
+  public Set<String> getIndexedKeys() {
+    return _indexedKeys;
+  }
+
+  /**
+   * Returns true if inverted indexes should be created for ALL keys.
+   */
+  public boolean isEnableInvertedIndexForAll() {
+    return _enableInvertedIndexForAll;
+  }
+
+  /**
+   * Returns the set of keys that should have inverted indexes, or null if not specified.
+   * Only consulted when {@link #isEnableInvertedIndexForAll()} is false.
+   */
+  @Nullable
+  public Set<String> getInvertedIndexKeys() {
+    return _invertedIndexKeys;
+  }
+
+  /**
+   * Returns true if an inverted index should be created for the given key.
+   * Returns true if {@code enableInvertedIndexForAll} is set, or if the key
+   * is in the {@code invertedIndexKeys} set.
+   */
+  public boolean shouldEnableInvertedIndexForKey(String key) {
+    return _enableInvertedIndexForAll
+        || (_invertedIndexKeys != null && _invertedIndexKeys.contains(key));
+  }
+
+  /**
+   * Returns the set of keys that should always use raw encoding (no dictionary),
+   * or null if not specified (all keys eligible for dictionary encoding).
+   */
+  @Nullable
+  public Set<String> getNoDictionaryKeys() {
+    return _noDictionaryKeys;
+  }
+
+  /**
+   * Returns true if dictionary encoding is allowed for the given key.
+   * Returns false if the key is in the {@code noDictionaryKeys} set.
+   */
+  public boolean shouldUseDictionaryForKey(String key) {
+    return _noDictionaryKeys == null || !_noDictionaryKeys.contains(key);
+  }
+
+  /**
+   * Returns the maximum number of distinct keys allowed. Keys beyond this cap fall back to
+   * the forward index blob. Default is 1000.
+   */
+  public int getMaxKeys() {
+    return _maxKeys;
+  }
+
+  /**
+   * Returns the set of keys that are always stored as dense (full forward index),
+   * regardless of fill rate. Returns empty set if not specified.
+   */
+  public Set<String> getDenseKeys() {
+    return _denseKeys != null ? _denseKeys : Set.of();
+  }
+
+  /**
+   * Returns the fill-rate threshold for automatic dense tier assignment.
+   * Keys present in more than {@code denseKeyThreshold * numDocs} documents are
+   * automatically promoted to dense tier. Default is 0.5 (50%).
+   */
+  public double getDenseKeyThreshold() {
+    return _denseKeyThreshold;
+  }
+
+  /**
+   * Returns true if the given key is explicitly declared as dense via config.
+   * Note: keys may also be auto-promoted to dense based on fill rate at segment creation time.
+   */
+  public boolean isDenseKey(String key) {
+    return _denseKeys != null && _denseKeys.contains(key);
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FieldConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FieldConfig.java
@@ -65,6 +65,15 @@ public class FieldConfig extends BaseJsonConfig {
   // Config to disable forward index
   public static final String FORWARD_INDEX_DISABLED = "forwardIndexDisabled";
   public static final String DEFAULT_FORWARD_INDEX_DISABLED = Boolean.FALSE.toString();
+
+  // Config for COLUMNAR_MAP index (columnar per-key storage for MAP columns)
+  public static final String COLUMNAR_MAP_INDEX_MAX_KEYS = "maxKeys";
+  public static final String COLUMNAR_MAP_INDEX_INVERTED_INDEX_KEYS = "invertedIndexKeys";
+  public static final String COLUMNAR_MAP_INDEX_NO_DICTIONARY_KEYS = "noDictionaryKeys";
+  public static final String COLUMNAR_MAP_INDEX_ENABLE_INVERTED_FOR_ALL = "enableInvertedIndexForAll";
+  public static final String COLUMNAR_MAP_INDEX_DENSE_KEYS = "denseKeys";
+  public static final String COLUMNAR_MAP_INDEX_DENSE_KEY_THRESHOLD = "denseKeyThreshold";
+  public static final String COLUMNAR_MAP_INDEX_KEY_SEPARATOR = ",";
   public static final String TEXT_INDEX_ENABLE_PREFIX_SUFFIX_PHRASE_QUERIES =
       "enablePrefixSuffixMatchingInPhraseQueries";
   public static final String TEXT_INDEX_LUCENE_REUSE_MUTABLE_INDEX = "reuseMutableIndex";
@@ -128,7 +137,7 @@ public class FieldConfig extends BaseJsonConfig {
   // If null, there won't be any index
   // NOTE: TIMESTAMP is ignored. In order to create TIMESTAMP index, configure 'timestampConfig' instead.
   public enum IndexType {
-    INVERTED, SORTED, TEXT, FST, IFST, H3, JSON, TIMESTAMP, VECTOR, RANGE
+    INVERTED, SORTED, TEXT, FST, IFST, H3, JSON, TIMESTAMP, VECTOR, RANGE, COLUMNAR_MAP
   }
 
   public enum CompressionCodec {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/ComplexFieldSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/ComplexFieldSpec.java
@@ -20,10 +20,13 @@ package org.apache.pinot.spi.data;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Preconditions;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
+import javax.annotation.Nullable;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.StringUtil;
 
@@ -52,11 +55,14 @@ import org.apache.pinot.spi.utils.StringUtil;
  * to model the hierarchy
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
+@JsonTypeName("COMPLEX")
 public final class ComplexFieldSpec extends FieldSpec {
   public static final String KEY_FIELD = "key";
   public static final String VALUE_FIELD = "value";
 
   private final Map<String, FieldSpec> _childFieldSpecs;
+  private Map<String, DataType> _keyTypes;
+  private DataType _defaultValueType;
 
   // Default constructor required by JSON de-serializer
   public ComplexFieldSpec() {
@@ -68,7 +74,7 @@ public final class ComplexFieldSpec extends FieldSpec {
       Map<String, FieldSpec> childFieldSpecs) {
     super(name, dataType, isSingleValueField);
     Preconditions.checkArgument(dataType == DataType.STRUCT || dataType == DataType.MAP || dataType == DataType.LIST);
-    _childFieldSpecs = childFieldSpecs;
+    _childFieldSpecs = new HashMap<>(childFieldSpecs);
   }
 
   public static String[] getColumnPath(String column) {
@@ -76,11 +82,40 @@ public final class ComplexFieldSpec extends FieldSpec {
   }
 
   public FieldSpec getChildFieldSpec(String child) {
-    return _childFieldSpecs.get(child);
+    return getChildFieldSpecs().get(child);
   }
 
+  public void addChildFieldSpec(String child, FieldSpec fieldSpec) {
+    _childFieldSpecs.put(child, fieldSpec);
+  }
+
+  @JsonIgnore
   public Map<String, FieldSpec> getChildFieldSpecs() {
+    if (_childFieldSpecs.isEmpty() && _dataType == DataType.MAP) {
+      Map<String, FieldSpec> defaults = new HashMap<>();
+      defaults.put(KEY_FIELD, new DimensionFieldSpec(KEY_FIELD, DataType.STRING, true));
+      defaults.put(VALUE_FIELD, new DimensionFieldSpec(VALUE_FIELD, DataType.STRING, true));
+      return defaults;
+    }
     return _childFieldSpecs;
+  }
+
+  @Nullable
+  public Map<String, DataType> getKeyTypes() {
+    return _keyTypes;
+  }
+
+  public void setKeyTypes(@Nullable Map<String, DataType> keyTypes) {
+    _keyTypes = keyTypes;
+  }
+
+  @Nullable
+  public DataType getDefaultValueType() {
+    return _defaultValueType;
+  }
+
+  public void setDefaultValueType(@Nullable DataType defaultValueType) {
+    _defaultValueType = defaultValueType;
   }
 
   @JsonIgnore
@@ -99,15 +134,30 @@ public final class ComplexFieldSpec extends FieldSpec {
     private final String _fieldName;
     private final FieldSpec _keyFieldSpec;
     private final FieldSpec _valueFieldSpec;
+    private final Map<String, FieldSpec.DataType> _keyTypes;
+    private final FieldSpec.DataType _defaultValueType;
 
     private MapFieldSpec(ComplexFieldSpec complexFieldSpec) {
-      Preconditions.checkState(complexFieldSpec.getChildFieldSpecs().containsKey(KEY_FIELD),
-          "Missing 'key' in the 'childFieldSpec'");
-      Preconditions.checkState(complexFieldSpec.getChildFieldSpecs().containsKey(VALUE_FIELD),
-          "Missing 'value' in the 'childFieldSpec'");
-      _keyFieldSpec = complexFieldSpec.getChildFieldSpec(KEY_FIELD);
-      _valueFieldSpec = complexFieldSpec.getChildFieldSpec(VALUE_FIELD);
+      this(complexFieldSpec, null, null);
+    }
+
+    private MapFieldSpec(ComplexFieldSpec complexFieldSpec,
+        @Nullable Map<String, FieldSpec.DataType> keyTypes,
+        @Nullable FieldSpec.DataType defaultValueType) {
+      Map<String, FieldSpec> children = complexFieldSpec.getChildFieldSpecs();
+      if (children.containsKey(KEY_FIELD)) {
+        _keyFieldSpec = complexFieldSpec.getChildFieldSpec(KEY_FIELD);
+      } else {
+        _keyFieldSpec = new DimensionFieldSpec(KEY_FIELD, DataType.STRING, true);
+      }
+      if (children.containsKey(VALUE_FIELD)) {
+        _valueFieldSpec = complexFieldSpec.getChildFieldSpec(VALUE_FIELD);
+      } else {
+        _valueFieldSpec = new DimensionFieldSpec(VALUE_FIELD, DataType.STRING, true);
+      }
       _fieldName = complexFieldSpec.getName();
+      _keyTypes = keyTypes != null ? keyTypes : complexFieldSpec.getKeyTypes();
+      _defaultValueType = defaultValueType != null ? defaultValueType : complexFieldSpec.getDefaultValueType();
     }
 
     public String getFieldName() {
@@ -121,10 +171,30 @@ public final class ComplexFieldSpec extends FieldSpec {
     public FieldSpec getValueFieldSpec() {
       return _valueFieldSpec;
     }
+
+    @Nullable
+    public Map<String, FieldSpec.DataType> getKeyTypes() {
+      return _keyTypes;
+    }
+
+    @Nullable
+    public FieldSpec.DataType getDefaultValueType() {
+      return _defaultValueType;
+    }
+
+    public FieldSpec.DataType getEffectiveDefaultValueType() {
+      return _defaultValueType != null ? _defaultValueType : FieldSpec.DataType.STRING;
+    }
   }
 
   public static MapFieldSpec toMapFieldSpec(ComplexFieldSpec complexFieldSpec) {
     return new MapFieldSpec(complexFieldSpec);
+  }
+
+  public static MapFieldSpec toMapFieldSpec(ComplexFieldSpec complexFieldSpec,
+      @Nullable Map<String, FieldSpec.DataType> keyTypes,
+      @Nullable FieldSpec.DataType defaultValueType) {
+    return new MapFieldSpec(complexFieldSpec, keyTypes, defaultValueType);
   }
 
   public static ComplexFieldSpec fromMapFieldSpec(MapFieldSpec mapFieldSpec) {
@@ -141,13 +211,43 @@ public final class ComplexFieldSpec extends FieldSpec {
     return StringUtil.join("$$", columns);
   }
 
+  @Override
+  public boolean equals(Object o) {
+    if (!super.equals(o)) {
+      return false;
+    }
+    ComplexFieldSpec that = (ComplexFieldSpec) o;
+    return Objects.equals(_keyTypes, that._keyTypes)
+        && Objects.equals(_defaultValueType, that._defaultValueType);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = super.hashCode();
+    result = 31 * result + Objects.hashCode(_keyTypes);
+    result = 31 * result + Objects.hashCode(_defaultValueType);
+    return result;
+  }
+
   public ObjectNode toJsonObject() {
     ObjectNode jsonObject = super.toJsonObject();
-    ObjectNode childFieldSpecsNode = JsonUtils.newObjectNode();
-    for (Map.Entry<String, FieldSpec> entry : _childFieldSpecs.entrySet()) {
-      childFieldSpecsNode.put(entry.getKey(), entry.getValue().toJsonObject());
+    if (!_childFieldSpecs.isEmpty()) {
+      ObjectNode childFieldSpecsNode = JsonUtils.newObjectNode();
+      for (Map.Entry<String, FieldSpec> entry : _childFieldSpecs.entrySet()) {
+        childFieldSpecsNode.put(entry.getKey(), entry.getValue().toJsonObject());
+      }
+      jsonObject.put("childFieldSpecs", childFieldSpecsNode);
     }
-    jsonObject.put("childFieldSpecs", childFieldSpecsNode);
+    if (_keyTypes != null && !_keyTypes.isEmpty()) {
+      ObjectNode keyTypesNode = JsonUtils.newObjectNode();
+      for (Map.Entry<String, DataType> entry : _keyTypes.entrySet()) {
+        keyTypesNode.put(entry.getKey(), entry.getValue().name());
+      }
+      jsonObject.set("keyTypes", keyTypesNode);
+    }
+    if (_defaultValueType != null) {
+      jsonObject.put("defaultValueType", _defaultValueType.name());
+    }
     return jsonObject;
   }
 }

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/config/table/ColumnarMapIndexConfigTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/config/table/ColumnarMapIndexConfigTest.java
@@ -1,0 +1,110 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.config.table;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+
+/** Tests for {@link ColumnarMapIndexConfig} deserialization, defaults, and property round-trips. */
+public class ColumnarMapIndexConfigTest {
+
+  @Test
+  public void testDenseKeysFromProperties() {
+    Map<String, String> props = new HashMap<>();
+    props.put("denseKeys", "country,tenancy,device_os");
+    props.put("denseKeyThreshold", "0.3");
+    props.put("maxKeys", "500");
+
+    ColumnarMapIndexConfig config = ColumnarMapIndexConfig.fromProperties(props);
+
+    assertEquals(config.getDenseKeys(), Set.of("country", "tenancy", "device_os"));
+    assertEquals(config.getDenseKeyThreshold(), 0.3, 0.001);
+    assertEquals(config.getMaxKeys(), 500);
+  }
+
+  @Test
+  public void testDenseKeysDefaults() {
+    ColumnarMapIndexConfig config = ColumnarMapIndexConfig.fromProperties(Map.of());
+
+    assertTrue(config.getDenseKeys().isEmpty());
+    assertEquals(config.getDenseKeyThreshold(), 0.5, 0.001);
+  }
+
+  @Test
+  public void testIsDenseKey() {
+    Map<String, String> props = new HashMap<>();
+    props.put("denseKeys", "country,tenancy");
+
+    ColumnarMapIndexConfig config = ColumnarMapIndexConfig.fromProperties(props);
+
+    assertTrue(config.isDenseKey("country"));
+    assertTrue(config.isDenseKey("tenancy"));
+    assertFalse(config.isDenseKey("rare_flag"));
+  }
+
+  @Test
+  public void testDenseKeysWithInvertedIndex() {
+    Map<String, String> props = new HashMap<>();
+    props.put("denseKeys", "country");
+    props.put("invertedIndexKeys", "country,status");
+    props.put("denseKeyThreshold", "0.8");
+
+    ColumnarMapIndexConfig config = ColumnarMapIndexConfig.fromProperties(props);
+
+    assertTrue(config.isDenseKey("country"));
+    assertFalse(config.isDenseKey("status"));
+    assertTrue(config.shouldEnableInvertedIndexForKey("country"));
+    assertTrue(config.shouldEnableInvertedIndexForKey("status"));
+    assertFalse(config.shouldEnableInvertedIndexForKey("unknown"));
+    assertEquals(config.getDenseKeyThreshold(), 0.8, 0.001);
+  }
+
+  @Test
+  public void testDefaultConstructorDenseKeyDefaults() {
+    ColumnarMapIndexConfig config = new ColumnarMapIndexConfig(true);
+
+    assertTrue(config.getDenseKeys().isEmpty());
+    assertEquals(config.getDenseKeyThreshold(), 0.5, 0.001);
+    assertFalse(config.isDenseKey("anything"));
+  }
+
+  @Test
+  public void testNullPropertiesReturnDefault() {
+    ColumnarMapIndexConfig config = ColumnarMapIndexConfig.fromProperties(null);
+
+    assertTrue(config.getDenseKeys().isEmpty());
+    assertEquals(config.getDenseKeyThreshold(), 0.5, 0.001);
+  }
+
+  @Test
+  public void testDenseKeyThresholdZeroMakesAllDense() {
+    Map<String, String> props = new HashMap<>();
+    props.put("denseKeyThreshold", "0.0");
+
+    ColumnarMapIndexConfig config = ColumnarMapIndexConfig.fromProperties(props);
+
+    // Threshold of 0 means any key with >0% fill rate is auto-dense
+    assertEquals(config.getDenseKeyThreshold(), 0.0, 0.001);
+  }
+}

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/data/ColumnarMapDataTypeTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/data/ColumnarMapDataTypeTest.java
@@ -1,0 +1,250 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.data;
+
+import java.util.Map;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+
+/**
+ * Unit tests for MAP DataType and Schema integration using ComplexFieldSpec.
+ */
+public class ColumnarMapDataTypeTest {
+
+  @Test
+  public void testMapDataTypeProperties() {
+    FieldSpec.DataType dt = FieldSpec.DataType.MAP;
+    assertEquals(dt.getStoredType(), FieldSpec.DataType.MAP);
+    assertFalse(dt.isFixedWidth());
+    assertFalse(dt.isNumeric());
+  }
+
+  @Test
+  public void testSchemaValidationAcceptsMapField() {
+    Schema schema = new Schema();
+    Map<String, FieldSpec> childFieldSpecs = Map.of(
+        "key", new DimensionFieldSpec("key", FieldSpec.DataType.STRING, true),
+        "value", new DimensionFieldSpec("value", FieldSpec.DataType.STRING, true)
+    );
+    ComplexFieldSpec spec = new ComplexFieldSpec("features", FieldSpec.DataType.MAP, true, childFieldSpecs);
+    schema.addField(spec);
+    schema.validate();
+    assertNotNull(schema.getFieldSpecFor("features"));
+    assertEquals(schema.getFieldSpecFor("features").getDataType(), FieldSpec.DataType.MAP);
+    assertEquals(schema.getFieldSpecFor("features").getFieldType(), FieldSpec.FieldType.COMPLEX);
+  }
+
+  @Test
+  public void testSchemaMultipleMapColumns() {
+    Schema schema = new Schema();
+
+    Map<String, FieldSpec> childFieldSpecs = Map.of(
+        "key", new DimensionFieldSpec("key", FieldSpec.DataType.STRING, true),
+        "value", new DimensionFieldSpec("value", FieldSpec.DataType.STRING, true)
+    );
+    ComplexFieldSpec features = new ComplexFieldSpec("features", FieldSpec.DataType.MAP, true, childFieldSpecs);
+    schema.addField(features);
+
+    ComplexFieldSpec labels = new ComplexFieldSpec("labels", FieldSpec.DataType.MAP, true, childFieldSpecs);
+    schema.addField(labels);
+
+    schema.addField(new DimensionFieldSpec("userId", FieldSpec.DataType.STRING, true));
+    schema.validate();
+    assertNotNull(schema.getFieldSpecFor("features"));
+    assertNotNull(schema.getFieldSpecFor("labels"));
+    assertEquals(schema.getFieldSpecFor("features").getDataType(), FieldSpec.DataType.MAP);
+    assertEquals(schema.getFieldSpecFor("features").getFieldType(), FieldSpec.FieldType.COMPLEX);
+  }
+
+  @Test
+  public void testComplexFieldSpecIsSingleValue() {
+    Map<String, FieldSpec> childFieldSpecs = Map.of(
+        "key", new DimensionFieldSpec("key", FieldSpec.DataType.STRING, true),
+        "value", new DimensionFieldSpec("value", FieldSpec.DataType.STRING, true)
+    );
+    ComplexFieldSpec spec = new ComplexFieldSpec("col", FieldSpec.DataType.MAP, true, childFieldSpecs);
+    assertTrue(spec.isSingleValueField());
+  }
+
+  @Test
+  public void testSchemaRoundTripPreservesMapField()
+      throws Exception {
+    Schema original = new Schema();
+    original.setSchemaName("roundTripSchema");
+    Map<String, FieldSpec> childFieldSpecs = Map.of(
+        "key", new DimensionFieldSpec("key", FieldSpec.DataType.STRING, true),
+        "value", new DimensionFieldSpec("value", FieldSpec.DataType.STRING, true)
+    );
+    ComplexFieldSpec spec = new ComplexFieldSpec("metrics", FieldSpec.DataType.MAP, true, childFieldSpecs);
+    original.addField(spec);
+
+    String jsonStr = original.toJsonObject().toString();
+    Schema reloaded = Schema.fromString(jsonStr);
+
+    reloaded.validate();
+    FieldSpec reloadedSpec = reloaded.getFieldSpecFor("metrics");
+    assertNotNull(reloadedSpec);
+    assertEquals(reloadedSpec.getDataType(), FieldSpec.DataType.MAP);
+    assertEquals(reloadedSpec.getFieldType(), FieldSpec.FieldType.COMPLEX);
+  }
+
+  // ---- Tests for ComplexFieldSpec.equals() including keyTypes and defaultValueType ----
+
+  @Test
+  public void testComplexFieldSpecEqualsDiffersOnKeyTypes() {
+    Map<String, FieldSpec> children = Map.of(
+        "key", new DimensionFieldSpec("key", FieldSpec.DataType.STRING, true),
+        "value", new DimensionFieldSpec("value", FieldSpec.DataType.STRING, true)
+    );
+    ComplexFieldSpec spec1 = new ComplexFieldSpec("col", FieldSpec.DataType.MAP, true, children);
+    ComplexFieldSpec spec2 = new ComplexFieldSpec("col", FieldSpec.DataType.MAP, true, children);
+
+    // Without keyTypes, they should be equal
+    assertEquals(spec1, spec2);
+
+    // Set keyTypes on spec1 only
+    spec1.setKeyTypes(Map.of("k1", FieldSpec.DataType.INT));
+    assertNotEquals(spec1, spec2, "ComplexFieldSpecs with different keyTypes must not be equal");
+  }
+
+  @Test
+  public void testComplexFieldSpecEqualsDiffersOnDefaultValueType() {
+    Map<String, FieldSpec> children = Map.of(
+        "key", new DimensionFieldSpec("key", FieldSpec.DataType.STRING, true),
+        "value", new DimensionFieldSpec("value", FieldSpec.DataType.STRING, true)
+    );
+    ComplexFieldSpec spec1 = new ComplexFieldSpec("col", FieldSpec.DataType.MAP, true, children);
+    ComplexFieldSpec spec2 = new ComplexFieldSpec("col", FieldSpec.DataType.MAP, true, children);
+
+    spec1.setDefaultValueType(FieldSpec.DataType.STRING);
+    assertNotEquals(spec1, spec2, "ComplexFieldSpecs with different defaultValueType must not be equal");
+  }
+
+  @Test
+  public void testComplexFieldSpecEqualsMatchingKeyTypesAreEqual() {
+    Map<String, FieldSpec> children = Map.of(
+        "key", new DimensionFieldSpec("key", FieldSpec.DataType.STRING, true),
+        "value", new DimensionFieldSpec("value", FieldSpec.DataType.STRING, true)
+    );
+    ComplexFieldSpec spec1 = new ComplexFieldSpec("col", FieldSpec.DataType.MAP, true, children);
+    ComplexFieldSpec spec2 = new ComplexFieldSpec("col", FieldSpec.DataType.MAP, true, children);
+
+    Map<String, FieldSpec.DataType> keyTypes = Map.of("k1", FieldSpec.DataType.INT, "k2", FieldSpec.DataType.STRING);
+    spec1.setKeyTypes(keyTypes);
+    spec2.setKeyTypes(keyTypes);
+    spec1.setDefaultValueType(FieldSpec.DataType.STRING);
+    spec2.setDefaultValueType(FieldSpec.DataType.STRING);
+
+    assertEquals(spec1, spec2);
+    assertEquals(spec1.hashCode(), spec2.hashCode());
+  }
+
+  @Test
+  public void testSchemaEqualsDetectsKeyTypesChange() {
+    Schema schema1 = new Schema();
+    schema1.setSchemaName("test");
+    ComplexFieldSpec spec1 = new ComplexFieldSpec("col", FieldSpec.DataType.MAP, true, Map.of());
+    schema1.addField(spec1);
+
+    Schema schema2 = new Schema();
+    schema2.setSchemaName("test");
+    ComplexFieldSpec spec2 = new ComplexFieldSpec("col", FieldSpec.DataType.MAP, true, Map.of());
+    spec2.setKeyTypes(Map.of("tenant", FieldSpec.DataType.STRING));
+    schema2.addField(spec2);
+
+    assertNotEquals(schema1, schema2, "Schema.equals must detect keyTypes difference");
+  }
+
+  // ---- Test for fieldType: COMPLEX deserialization without explicit fieldType ----
+
+  @Test
+  public void testSchemaDeserializationWithoutFieldTypePreservesKeyTypes()
+      throws Exception {
+    // Simulate user-provided schema JSON without "fieldType": "COMPLEX"
+    String schemaJson = "{"
+        + "\"schemaName\": \"testSchema\","
+        + "\"complexFieldSpecs\": [{"
+        + "  \"name\": \"metadata\","
+        + "  \"dataType\": \"MAP\","
+        + "  \"keyTypes\": {\"tenant\": \"STRING\", \"count\": \"INT\"},"
+        + "  \"defaultValueType\": \"STRING\""
+        + "}]"
+        + "}";
+
+    Schema schema = Schema.fromString(schemaJson);
+    FieldSpec fieldSpec = schema.getFieldSpecFor("metadata");
+    assertNotNull(fieldSpec, "metadata field should be deserialized");
+    assertTrue(fieldSpec instanceof ComplexFieldSpec, "Should be ComplexFieldSpec");
+
+    ComplexFieldSpec complexSpec = (ComplexFieldSpec) fieldSpec;
+    assertNotNull(complexSpec.getKeyTypes(), "keyTypes should be preserved");
+    assertEquals(complexSpec.getKeyTypes().size(), 2);
+    assertEquals(complexSpec.getKeyTypes().get("tenant"), FieldSpec.DataType.STRING);
+    assertEquals(complexSpec.getKeyTypes().get("count"), FieldSpec.DataType.INT);
+    assertEquals(complexSpec.getDefaultValueType(), FieldSpec.DataType.STRING);
+  }
+
+  @Test
+  public void testSchemaDeserializationWithFieldTypePreservesKeyTypes()
+      throws Exception {
+    // Schema JSON with "fieldType": "COMPLEX" — the standard path
+    String schemaJson = "{"
+        + "\"schemaName\": \"testSchema\","
+        + "\"complexFieldSpecs\": [{"
+        + "  \"name\": \"metadata\","
+        + "  \"dataType\": \"MAP\","
+        + "  \"fieldType\": \"COMPLEX\","
+        + "  \"keyTypes\": {\"tenant\": \"STRING\"},"
+        + "  \"defaultValueType\": \"STRING\""
+        + "}]"
+        + "}";
+
+    Schema schema = Schema.fromString(schemaJson);
+    ComplexFieldSpec complexSpec = (ComplexFieldSpec) schema.getFieldSpecFor("metadata");
+    assertNotNull(complexSpec.getKeyTypes());
+    assertEquals(complexSpec.getKeyTypes().get("tenant"), FieldSpec.DataType.STRING);
+    assertEquals(complexSpec.getDefaultValueType(), FieldSpec.DataType.STRING);
+  }
+
+  @Test
+  public void testSchemaRoundTripPreservesKeyTypes()
+      throws Exception {
+    // Build schema programmatically with keyTypes
+    Schema original = new Schema();
+    original.setSchemaName("roundTripKeyTypes");
+    ComplexFieldSpec spec = new ComplexFieldSpec("metrics", FieldSpec.DataType.MAP, true, Map.of());
+    spec.setKeyTypes(Map.of("tenant", FieldSpec.DataType.STRING, "count", FieldSpec.DataType.INT));
+    spec.setDefaultValueType(FieldSpec.DataType.STRING);
+    original.addField(spec);
+
+    // Serialize and deserialize
+    String json = original.toPrettyJsonString();
+    Schema reloaded = Schema.fromString(json);
+
+    ComplexFieldSpec reloadedSpec = (ComplexFieldSpec) reloaded.getFieldSpecFor("metrics");
+    assertNotNull(reloadedSpec);
+    assertEquals(reloadedSpec.getKeyTypes(), spec.getKeyTypes());
+    assertEquals(reloadedSpec.getDefaultValueType(), FieldSpec.DataType.STRING);
+
+    // Schema.equals should confirm they're equal
+    assertEquals(original, reloaded);
+  }
+}


### PR DESCRIPTION
### Summary
 
This is **PR 2 of 3** introducing the columnar MAP query layer on top of the storage layer landed in #17896. This PR makes COLUMNAR_MAP columns actually queryable — adding the per-key DataSource, mutable consuming-segment index, filter-operator delegation strategies, and null-aware item() evaluation.
 
### Stack
 
- **PR 1 (#17896):** Storage layer — SPI, index format, segment creation, immutable read path
- **PR 2 (this):** Query layer — DataSource, mutable segments, filter operators, item() null-handling
- **PR 3:** Comprehensive `ColumnarMapIndexTest` (46 unit tests covering both storage and query paths, including regression tests for the CRITICAL fixes in this PR — see "Notes for reviewers" below)
 
### Motivation
 
PR 1 added the binary format and immutable read path for COLUMNAR_MAP, but no query path was wired up — `MapFilterOperator` would fall through to the slow `ExpressionFilterOperator` (per-doc `Map<String, Object>` materialization), `ItemTransformFunction` had no per-key null bitmap, and consuming (real-time) segments would fail at segment creation because `createMutableIndex` threw `UnsupportedOperationException`. This PR closes those gaps and delivers the actual query speedups the columnar storage was designed to enable.
 

### What's in this PR
 
#### Query data source (`pinot-segment-local`)
 
`ColumnarMapDataSource` implements `MapDataSource` and routes `getKeyDataSource(key)` to one of four paths:
- **Dense immutable** — wraps `ColumnarMapKeyForwardIndexReader` + per-key dictionary + per-key inverted index
- **Sparse immutable** — wraps a per-key reader backed by the JSON sidecar
- **Mutable** — wraps the per-key `FixedByteSVMutableForwardIndex` directly (O(1) lock-free)
- **Unknown key** — returns `NullDataSource(key)` to match `BaseMapDataSource` (callers like `ProjectionBlock` and `ItemTransformFunction` never see null)
 
Supporting classes: `ColumnarMapForwardIndexReader` (column-level wrapper), `ColumnarMapRealtimeInvertedIndex` (mutable per-dictId inverted index, thread-safe via `ThreadSafeMutableRoaringBitmap`), `MutableColumnarMapIndexImpl` (consuming-segment columnar map implementing `ColumnarMapIndexReader`).
 
#### Filter operator delegation (`pinot-core`)
 
`MapFilterOperator` selects between four strategies:
1. JSON index match (existing) — when a JsonIndexReader exists on the column
2. **Per-key inverted index (new)** — when a `MapDataSource` exposes a per-key inverted index for the requested key
3. **Presence-bitmap fast path (new)** — for `IS NULL` / `IS NOT NULL` on COLUMNAR_MAP, via `BitmapBasedFilterOperator` over the per-key presence bitmap
4. Expression filter (existing fallback)
 
`explainAttributes` now emits `delegateTo:per_key_inverted_index` and `delegateTo:presence_bitmap` (was previously misreported as `expression_filter`).
 
#### `ItemTransformFunction` null-aware reads (`pinot-core`)
 
Captures the per-key null bitmap from `keyDS.getNullValueVector()` and projects it to block-local docIds in `getNullBitmap`. Gated on the query's `nullHandlingEnabled` flag; short-circuits when the segment-level null bitmap doesn't intersect the block's docId range. Adds `getKeyPath()` for direct key resolution by `TransformBlock`/`ProjectionBlock`.
 
#### Storage format addition
 
`OnHeapColumnarMapIndexCreator` now writes a per-sparse-key presence bitmap (run-optimized) into the SPMX layout, reusing the dense-tier `nullBitmapOffset/Len` slot per `tierFlag`. Without this, IS NULL / IS NOT NULL on sparse keys returned wrong results. Format version unchanged (still SPMX v3); legacy v3 segments without the new bytes (`nullBitmapLen == 0`) preserve the prior empty-bitmap behavior.
 
#### Wire-up + SPI hardening
 
- `ColumnarMapIndexType.createMutableIndex` returns `new MutableColumnarMapIndexImpl(...)` instead of throwing
- `ColumnarMapIndexReader.getKeyDataSource(String)` throws `UnsupportedOperationException` on both reader implementations — callers must go through `ColumnarMapDataSource` so the unknown-key fall-back stays consistent
- Sparse-tier reader now throws `RuntimeException` with `column`/`key`/`docId`/`value` context on JSON parse and numeric parse failures (was previously silent)
 

 
### How to use
 
Schema and table-config setup is unchanged from PR 1 (#17896). Once both PRs are landed, queries against COLUMNAR_MAP columns work transparently:
 
```sql
-- EQ filter on a dense key — uses per-key inverted index
SELECT count(*) FROM events WHERE metrics['country'] = 'US'
 
-- IS NOT NULL on a sparse key — uses presence bitmap (new)
SELECT count(*) FROM events WHERE metrics['rare_flag'] IS NOT NULL
 
-- Projection of multiple keys
SELECT user_id, metrics['clicks'], metrics['spend'] FROM events WHERE metrics['country'] = 'US'
 
-- GROUP BY on a MAP key
SELECT metrics['country'], count(*) FROM events GROUP BY metrics['country'] ORDER BY count(*) DESC
```
 
EXPLAIN PLAN VERBOSE will show `delegateTo:per_key_inverted_index` for fast-path EQ predicates and `delegateTo:presence_bitmap` for IS NULL / IS NOT NULL on sparse keys.
  
### Test plan
 
- `ColumnarMapIndexEndToEndTest` — 4 tests (mutable→immutable round-trip, undeclared-key default type, user-metrics scenario, cross-segment merge)
- `ColumnarMapFilterOperatorTest` — 7 tests (IS_NULL / IS_NOT_NULL / NOT_EQ / NOT_IN against absent and partially-present keys)
- `ColumnarMapSegmentCreationTest` — 1 test (segment build pipeline)
- `ColumnarMapBenchmarkTest` — disabled (`@Test(enabled = false)`); manual perf benchmark, run with `-DenableBenchmark=true` and the annotation flipped
- All 12 in-PR tests pass
- 46 additional tests in follow up test PR cover storage + query + concurrency in depth
- Deployed this code in a test cluster to collect the query performance and storage improvements. 
 