### PR TITLE
Propagate task configuration to remote index buffers for improved configuration resolution

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/SingleFileIndexDirectory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/SingleFileIndexDirectory.java
@@ -49,7 +49,10 @@ import org.apache.pinot.segment.spi.memory.EmptyIndexBuffer;
 import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
 import org.apache.pinot.segment.spi.store.ColumnIndexDirectory;
 import org.apache.pinot.segment.spi.store.ColumnIndexUtils;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableTaskConfig;
 import org.apache.pinot.spi.env.CommonsConfigurationUtils;
+import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.ReadMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -81,6 +84,8 @@ class SingleFileIndexDirectory extends ColumnIndexDirectory {
   // This breaks the abstraction with PinotDataBuffer....a workaround for
   // now till PinotDataBuffer can support large buffers again
   private static final int MAX_ALLOCATION_SIZE = 2000 * 1024 * 1024;
+
+  private static final String TASK_CONFIG_JSON_PROPERTY = "task.config.json";
 
   private final File _segmentDirectory;
   private final SegmentDirectoryLoaderContext _segmentDirectoryLoaderContext;
@@ -340,11 +345,46 @@ class SingleFileIndexDirectory extends ColumnIndexDirectory {
       properties.putAll(_segmentDirectoryLoaderContext.getSegmentCustomConfigs());
     }
 
+    // Propagate the table's task config (serialized as JSON) to remote/empty index buffers so that
+    // downstream readers backed by external storage can resolve any configuration they require
+    // (e.g. credentials, regions, endpoints) from the ingestion task config rather than relying
+    // solely on ambient environment defaults, which may be incomplete or unavailable in this context.
+    String taskConfigJson = serializeTaskConfigToJsonFromContext();
+    if (taskConfigJson != null) {
+      properties.setProperty(TASK_CONFIG_JSON_PROPERTY, taskConfigJson);
+    }
+
     // Create empty buffers for all zero-size entries
     for (IndexEntry entry : zeroSizeEntries) {
       entry._buffer = new EmptyIndexBuffer(properties,
           _segmentMetadata.getName(),
           _segmentMetadata.getTableName());
+    }
+  }
+
+  @Nullable
+  private String serializeTaskConfigToJsonFromContext() {
+    if (_segmentDirectoryLoaderContext == null) {
+      return null;
+    }
+    TableConfig tableConfig = _segmentDirectoryLoaderContext.getTableConfig();
+    if (tableConfig == null) {
+      return null;
+    }
+    TableTaskConfig taskConfig = tableConfig.getTaskConfig();
+    if (taskConfig == null) {
+      return null;
+    }
+    Map<String, Map<String, String>> taskTypeConfigsMap = taskConfig.getTaskTypeConfigsMap();
+    if (taskTypeConfigsMap == null || taskTypeConfigsMap.isEmpty()) {
+      return null;
+    }
+    try {
+      return JsonUtils.objectToString(taskTypeConfigsMap);
+    } catch (Exception e) {
+      LOGGER.warn("Failed to serialize task config to JSON for segment: {}",
+          _segmentMetadata.getName(), e);
+      return null;
     }
   }
 


### PR DESCRIPTION
## Description

During segment preprocessing for tables that use remote/external-storage-backed columns (i.e. zero-size index entries that resolve lazily through `EmptyIndexBuffer`), `SingleFileIndexDirectory.createRemoteBuffers()` was only propagating `SegmentCustomConfigs` (sourced from ZK segment custom metadata) into the `EmptyIndexBuffer` properties. The table's ingestion task config — which is already available on `SegmentDirectoryLoaderContext` via `getTableConfig().getTaskConfig()` — was never surfaced to the downstream readers.

This leaves readers backed by external storage with no way to discover the configuration they require (e.g. credentials, regions, endpoints) other than falling back to ambient environment defaults, which are often incomplete or unavailable in the preprocessing path.

## Changes

- In `SingleFileIndexDirectory.createRemoteBuffers()`, serialize the table's `TableTaskConfig#getTaskTypeConfigsMap()` to JSON via `JsonUtils` and inject it into the `EmptyIndexBuffer` properties under the key `task.config.json`.
- Add a helper `serializeTaskConfigToJsonFromContext()` that is fully null-safe: it returns `null` (and the property is not set) when the loader context, table config, task config, or task-type map is missing/empty. Serialization failures are logged at WARN and do not break segment load.

With this change, any downstream reader that consumes `EmptyIndexBuffer` properties can now resolve its required configuration from the ingestion task config, making preprocessing behavior consistent with the runtime query path.

## Scope / Compatibility

- Single-file change under `pinot-segment-local`; no public API or on-disk format changes.
- Behavior is additive: the new property is only set when a task config is actually present on the table. Existing callers and tables without a task config see no change.
- No new dependencies.

## Testing

- `./mvnw spotless:apply -pl pinot-segment-spi,pinot-segment-local` — clean.
- `./mvnw checkstyle:check -pl pinot-segment-spi,pinot-segment-local` — passes.
- `./mvnw license:format -pl pinot-segment-spi,pinot-segment-local` / `license:check` — pass.
- Compiles under `./mvnw install -pl pinot-segment-spi,pinot-segment-local -am -DskipTests`.

## Release Notes

Propagate the table's ingestion task config (serialized as JSON under the `task.config.json` property) through `EmptyIndexBuffer` properties created by `SingleFileIndexDirectory.createRemoteBuffers()`, so that remote/external-storage-backed index readers can resolve their configuration (credentials, regions, endpoints, etc.) during segment preprocessing instead of relying solely on ambient environment defaults.