### PR TITLE
MSE resilience to silently unreachable servers

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -172,11 +172,11 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
         CommonConstants.MultiStageQueryRunner.DEFAULT_OF_CANCEL_TIMEOUT_MS);
     Duration cancelTimeout = Duration.ofMillis(cancelMillis);
     int dispatchKeepAliveTimeSeconds = config.getProperty(
-        CommonConstants.MultiStageQueryRunner.KEY_OF_DISPATCH_CHANNEL_KEEP_ALIVE_TIME_SECONDS,
-        CommonConstants.MultiStageQueryRunner.DEFAULT_OF_DISPATCH_CHANNEL_KEEP_ALIVE_TIME_SECONDS);
+        CommonConstants.MultiStageQueryRunner.KEY_OF_DISPATCH_CHANNEL_KEEP_ALIVE_TIME_MS,
+        CommonConstants.MultiStageQueryRunner.DEFAULT_OF_DISPATCH_CHANNEL_KEEP_ALIVE_TIME_MS);
     int dispatchKeepAliveTimeoutSeconds = config.getProperty(
-        CommonConstants.MultiStageQueryRunner.KEY_OF_DISPATCH_CHANNEL_KEEP_ALIVE_TIMEOUT_SECONDS,
-        CommonConstants.MultiStageQueryRunner.DEFAULT_OF_DISPATCH_CHANNEL_KEEP_ALIVE_TIMEOUT_SECONDS);
+        CommonConstants.MultiStageQueryRunner.KEY_OF_DISPATCH_CHANNEL_KEEP_ALIVE_TIMEOUT_MS,
+        CommonConstants.MultiStageQueryRunner.DEFAULT_OF_DISPATCH_CHANNEL_KEEP_ALIVE_TIMEOUT_MS);
     boolean dispatchKeepAliveWithoutCalls = config.getProperty(
         CommonConstants.MultiStageQueryRunner.KEY_OF_DISPATCH_CHANNEL_KEEP_ALIVE_WITHOUT_CALLS,
         CommonConstants.MultiStageQueryRunner.DEFAULT_OF_DISPATCH_CHANNEL_KEEP_ALIVE_WITHOUT_CALLS);

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -171,9 +171,19 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
         CommonConstants.MultiStageQueryRunner.KEY_OF_CANCEL_TIMEOUT_MS,
         CommonConstants.MultiStageQueryRunner.DEFAULT_OF_CANCEL_TIMEOUT_MS);
     Duration cancelTimeout = Duration.ofMillis(cancelMillis);
+    int dispatchKeepAliveTimeSeconds = config.getProperty(
+        CommonConstants.MultiStageQueryRunner.KEY_OF_DISPATCH_CHANNEL_KEEP_ALIVE_TIME_SECONDS,
+        CommonConstants.MultiStageQueryRunner.DEFAULT_OF_DISPATCH_CHANNEL_KEEP_ALIVE_TIME_SECONDS);
+    int dispatchKeepAliveTimeoutSeconds = config.getProperty(
+        CommonConstants.MultiStageQueryRunner.KEY_OF_DISPATCH_CHANNEL_KEEP_ALIVE_TIMEOUT_SECONDS,
+        CommonConstants.MultiStageQueryRunner.DEFAULT_OF_DISPATCH_CHANNEL_KEEP_ALIVE_TIMEOUT_SECONDS);
+    boolean dispatchKeepAliveWithoutCalls = config.getProperty(
+        CommonConstants.MultiStageQueryRunner.KEY_OF_DISPATCH_CHANNEL_KEEP_ALIVE_WITHOUT_CALLS,
+        CommonConstants.MultiStageQueryRunner.DEFAULT_OF_DISPATCH_CHANNEL_KEEP_ALIVE_WITHOUT_CALLS);
     _queryDispatcher =
         new QueryDispatcher(new MailboxService(hostname, port, InstanceType.BROKER, config, tlsConfig), failureDetector,
-            tlsConfig, isQueryCancellationEnabled(), cancelTimeout);
+            tlsConfig, isQueryCancellationEnabled(), cancelTimeout, dispatchKeepAliveTimeSeconds,
+            dispatchKeepAliveTimeoutSeconds, dispatchKeepAliveWithoutCalls);
     LOGGER.info("Initialized MultiStageBrokerRequestHandler on host: {}, port: {} with broker id: {}, timeout: {}ms, "
             + "query log max length: {}, query log max rate: {}, query cancellation enabled: {}", hostname, port,
         _brokerId, _brokerTimeoutMs, _queryLogger.getMaxQueryLengthToLog(), _queryLogger.getLogRateLimit(),

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -171,10 +171,10 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
         CommonConstants.MultiStageQueryRunner.KEY_OF_CANCEL_TIMEOUT_MS,
         CommonConstants.MultiStageQueryRunner.DEFAULT_OF_CANCEL_TIMEOUT_MS);
     Duration cancelTimeout = Duration.ofMillis(cancelMillis);
-    int dispatchKeepAliveTimeSeconds = config.getProperty(
+    int dispatchKeepAliveTimeMs = config.getProperty(
         CommonConstants.MultiStageQueryRunner.KEY_OF_DISPATCH_CHANNEL_KEEP_ALIVE_TIME_MS,
         CommonConstants.MultiStageQueryRunner.DEFAULT_OF_DISPATCH_CHANNEL_KEEP_ALIVE_TIME_MS);
-    int dispatchKeepAliveTimeoutSeconds = config.getProperty(
+    int dispatchKeepAliveTimeoutMs = config.getProperty(
         CommonConstants.MultiStageQueryRunner.KEY_OF_DISPATCH_CHANNEL_KEEP_ALIVE_TIMEOUT_MS,
         CommonConstants.MultiStageQueryRunner.DEFAULT_OF_DISPATCH_CHANNEL_KEEP_ALIVE_TIMEOUT_MS);
     boolean dispatchKeepAliveWithoutCalls = config.getProperty(
@@ -182,8 +182,8 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
         CommonConstants.MultiStageQueryRunner.DEFAULT_OF_DISPATCH_CHANNEL_KEEP_ALIVE_WITHOUT_CALLS);
     _queryDispatcher =
         new QueryDispatcher(new MailboxService(hostname, port, InstanceType.BROKER, config, tlsConfig), failureDetector,
-            tlsConfig, isQueryCancellationEnabled(), cancelTimeout, dispatchKeepAliveTimeSeconds,
-            dispatchKeepAliveTimeoutSeconds, dispatchKeepAliveWithoutCalls);
+            tlsConfig, isQueryCancellationEnabled(), cancelTimeout, dispatchKeepAliveTimeMs,
+            dispatchKeepAliveTimeoutMs, dispatchKeepAliveWithoutCalls);
     LOGGER.info("Initialized MultiStageBrokerRequestHandler on host: {}, port: {} with broker id: {}, timeout: {}ms, "
             + "query log max length: {}, query log max rate: {}, query cancellation enabled: {}", hostname, port,
         _brokerId, _brokerTimeoutMs, _queryLogger.getMaxQueryLengthToLog(), _queryLogger.getLogRateLimit(),

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/manager/BaseBrokerRoutingManager.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/manager/BaseBrokerRoutingManager.java
@@ -40,6 +40,7 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Consumer;
 import javax.annotation.Nullable;
+import javax.annotation.concurrent.GuardedBy;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
@@ -162,10 +163,10 @@ public abstract class BaseBrokerRoutingManager implements RoutingManager, Cluste
 
   private Set<String> _routableServers;
 
-  // Snapshot of {@code _enabledServerInstanceMap} restricted to {@code _routableServers} (enabled minus excluded).
-  // Maintained in lockstep with {@code _routableServers} under {@code _globalLock.writeLock()}. Callers that select
-  // workers outside of per-table instance selection (MSE intermediate-stage worker picking) read this snapshot so
-  // that FailureDetector-driven exclusions are honored.
+  /// Snapshot of `_enabledServerInstanceMap` restricted to `_routableServers` (enabled minus excluded). Maintained in
+  /// lockstep with `_routableServers` under `_globalLock.writeLock()`. Callers that select workers outside of
+  /// per-table instance selection (MSE intermediate-stage worker picking) read this snapshot so that
+  /// FailureDetector-driven exclusions are honored.
   private volatile Map<String, ServerInstance> _routableServerInstanceMap = Collections.emptyMap();
 
   // Process assignment change timestamp. Used to check if buildRouting needs to be re-run for a given table to avoid
@@ -1186,8 +1187,11 @@ public abstract class BaseBrokerRoutingManager implements RoutingManager, Cluste
     return _routableServerInstanceMap;
   }
 
-  // Must be called under {@code _globalLock.writeLock()} whenever {@code _routableServers} is reassigned.
+  /// Must be called under `_globalLock.writeLock()` whenever `_routableServers` is reassigned.
+  @GuardedBy("_globalLock.writeLock()")
   private Map<String, ServerInstance> buildRoutableServerInstanceMap() {
+    assert ((ReentrantReadWriteLock) _globalLock).isWriteLockedByCurrentThread()
+        : "buildRoutableServerInstanceMap must be called under _globalLock.writeLock()";
     Set<String> routableServers = _routableServers;
     if (routableServers == null || routableServers.isEmpty()) {
       return Collections.emptyMap();

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/manager/BaseBrokerRoutingManager.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/manager/BaseBrokerRoutingManager.java
@@ -143,8 +143,8 @@ public abstract class BaseBrokerRoutingManager implements RoutingManager, Cluste
   private Consumer<ServerInstance> _serverReenableCallback;
 
   // Global read-write lock for protecting the global data structures such as _enabledServerInstanceMap,
-  // _excludedServers, and _routableServers. Write lock must be held if any of these are modified, read lock must be
-  // held otherwise
+  // _excludedServers, and _routableServerInstanceMap. Write lock must be held if any of these are modified, read lock
+  // must be held otherwise
   private final ReadWriteLock _globalLock = new ReentrantReadWriteLock(true);
 
   // Per-table locks to allow concurrent routing builds across different tables while serializing per-table operations
@@ -161,11 +161,10 @@ public abstract class BaseBrokerRoutingManager implements RoutingManager, Cluste
   private String _instanceConfigsPath;
   protected ZkHelixPropertyStore<ZNRecord> _propertyStore;
 
-  private Set<String> _routableServers;
-
-  /// Snapshot of `_enabledServerInstanceMap` restricted to `_routableServers` (enabled minus excluded). Maintained in
-  /// lockstep with `_routableServers` under `_globalLock.writeLock()`. Callers that select workers outside of
-  /// per-table instance selection (MSE intermediate-stage worker picking) read this snapshot so that
+  /// Snapshot of `_enabledServerInstanceMap` restricted to enabled-minus-excluded servers. Replaced atomically under
+  /// `_globalLock.writeLock()` whenever routing membership changes. Serves as the single source of truth for routable
+  /// servers: its `keySet()` is passed to `InstanceSelector` for per-table selection, and callers that pick workers
+  /// outside of per-table instance selection (MSE intermediate-stage worker picking) read the map directly so that
   /// FailureDetector-driven exclusions are honored.
   private volatile Map<String, ServerInstance> _routableServerInstanceMap = Collections.emptyMap();
 
@@ -448,8 +447,7 @@ public abstract class BaseBrokerRoutingManager implements RoutingManager, Cluste
         }
       }
     }
-    _routableServers = enabledServers;
-    _routableServerInstanceMap = buildRoutableServerInstanceMap();
+    _routableServerInstanceMap = buildRoutableServerInstanceMap(enabledServers);
     long calculateChangedServersEndTimeMs = System.currentTimeMillis();
 
     // Early terminate if there is no changed servers
@@ -468,7 +466,7 @@ public abstract class BaseBrokerRoutingManager implements RoutingManager, Cluste
       try {
         Object tableLock = getRoutingTableBuildLock(tableNameWithType);
         synchronized (tableLock) {
-          routingEntry.onInstancesChange(_routableServers, changedServers);
+          routingEntry.onInstancesChange(_routableServerInstanceMap.keySet(), changedServers);
         }
       } catch (Exception e) {
         LOGGER.error("Caught unexpected exception while updating routing entry on instances change for table: {}",
@@ -529,24 +527,23 @@ public abstract class BaseBrokerRoutingManager implements RoutingManager, Cluste
       LOGGER.info("Server: {} is already excluded from routing, skipping updating the routing", instanceId);
       return;
     }
-    if (!_routableServers.contains(instanceId)) {
+    if (!_routableServerInstanceMap.containsKey(instanceId)) {
       LOGGER.info("Server: {} is not enabled, skipping updating the routing", instanceId);
       return;
     }
 
     // Update routing entry for all tables
     long startTimeMs = System.currentTimeMillis();
-    Set<String> routableServers = new HashSet<>(_routableServers);
-    routableServers.remove(instanceId);
-    _routableServers = routableServers;
-    _routableServerInstanceMap = buildRoutableServerInstanceMap();
+    Map<String, ServerInstance> routableServerInstanceMap = new HashMap<>(_routableServerInstanceMap);
+    routableServerInstanceMap.remove(instanceId);
+    _routableServerInstanceMap = routableServerInstanceMap;
     List<String> changedServers = Collections.singletonList(instanceId);
     for (RoutingEntry routingEntry : _routingEntryMap.values()) {
       String tableNameWithType = routingEntry.getTableNameWithType();
       try {
         Object tableLock = getRoutingTableBuildLock(tableNameWithType);
         synchronized (tableLock) {
-          routingEntry.onInstancesChange(_routableServers, changedServers);
+          routingEntry.onInstancesChange(_routableServerInstanceMap.keySet(), changedServers);
         }
       } catch (Exception e) {
         LOGGER.error("Caught unexpected exception while updating routing entry when excluding server: {} for table: {}",
@@ -582,17 +579,20 @@ public abstract class BaseBrokerRoutingManager implements RoutingManager, Cluste
 
     // Update routing entry for all tables
     long startTimeMs = System.currentTimeMillis();
-    Set<String> routableServers = new HashSet<>(_routableServers);
-    routableServers.add(instanceId);
-    _routableServers = routableServers;
-    _routableServerInstanceMap = buildRoutableServerInstanceMap();
+    // The containsKey check above was performed under the write lock, so the get here must return non-null
+    ServerInstance serverInstance = _enabledServerInstanceMap.get(instanceId);
+    Preconditions.checkState(serverInstance != null,
+        "Enabled server instance map missing entry for server: %s", instanceId);
+    Map<String, ServerInstance> routableServerInstanceMap = new HashMap<>(_routableServerInstanceMap);
+    routableServerInstanceMap.put(instanceId, serverInstance);
+    _routableServerInstanceMap = routableServerInstanceMap;
     List<String> changedServers = Collections.singletonList(instanceId);
     for (RoutingEntry routingEntry : _routingEntryMap.values()) {
       String tableNameWithType = routingEntry.getTableNameWithType();
       try {
         Object tableLock = getRoutingTableBuildLock(tableNameWithType);
         synchronized (tableLock) {
-          routingEntry.onInstancesChange(_routableServers, changedServers);
+          routingEntry.onInstancesChange(_routableServerInstanceMap.keySet(), changedServers);
         }
       } catch (Exception e) {
         LOGGER.error("Caught unexpected exception while updating routing entry when including server: {} for table: {}",
@@ -747,8 +747,8 @@ public abstract class BaseBrokerRoutingManager implements RoutingManager, Cluste
           AdaptiveServerSelectorFactory.getAdaptiveServerSelector(_serverRoutingStatsManager, _pinotConfig);
       InstanceSelector instanceSelector =
           InstanceSelectorFactory.getInstanceSelector(tableConfig, _propertyStore, _brokerMetrics,
-              adaptiveServerSelector, _pinotConfig, _routableServers, _enabledServerInstanceMap, idealState,
-              externalView, preSelectedOnlineSegments);
+              adaptiveServerSelector, _pinotConfig, _routableServerInstanceMap.keySet(), _enabledServerInstanceMap,
+              idealState, externalView, preSelectedOnlineSegments);
 
       // Add time boundary manager if both offline and real-time part exist for a hybrid table
       TimeBoundaryManager timeBoundaryManager = null;
@@ -858,8 +858,8 @@ public abstract class BaseBrokerRoutingManager implements RoutingManager, Cluste
             samplerSegmentSelector.init(idealState, externalView, samplerPreSelectedOnlineSegments);
             InstanceSelector samplerInstanceSelector =
                 InstanceSelectorFactory.getInstanceSelector(tableConfig, _propertyStore, _brokerMetrics,
-                    adaptiveServerSelector, _pinotConfig, _routableServers, _enabledServerInstanceMap,
-                    idealState, externalView, samplerPreSelectedOnlineSegments);
+                    adaptiveServerSelector, _pinotConfig, _routableServerInstanceMap.keySet(),
+                    _enabledServerInstanceMap, idealState, externalView, samplerPreSelectedOnlineSegments);
             configuredSamplerInfos.put(normalizedSamplerName,
                 new SamplerInfo(sampler, samplerSegmentSelector, samplerInstanceSelector));
           } catch (Exception e) {
@@ -1187,13 +1187,13 @@ public abstract class BaseBrokerRoutingManager implements RoutingManager, Cluste
     return _routableServerInstanceMap;
   }
 
-  /// Must be called under `_globalLock.writeLock()` whenever `_routableServers` is reassigned.
+  /// Must be called under `_globalLock.writeLock()` when rebuilding `_routableServerInstanceMap` from a freshly
+  /// computed set of routable server IDs.
   @GuardedBy("_globalLock.writeLock()")
-  private Map<String, ServerInstance> buildRoutableServerInstanceMap() {
+  private Map<String, ServerInstance> buildRoutableServerInstanceMap(Set<String> routableServers) {
     assert ((ReentrantReadWriteLock) _globalLock).isWriteLockedByCurrentThread()
         : "buildRoutableServerInstanceMap must be called under _globalLock.writeLock()";
-    Set<String> routableServers = _routableServers;
-    if (routableServers == null || routableServers.isEmpty()) {
+    if (routableServers.isEmpty()) {
       return Collections.emptyMap();
     }
     Map<String, ServerInstance> map = Maps.newHashMapWithExpectedSize(routableServers.size());

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/manager/BaseBrokerRoutingManager.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/manager/BaseBrokerRoutingManager.java
@@ -162,6 +162,12 @@ public abstract class BaseBrokerRoutingManager implements RoutingManager, Cluste
 
   private Set<String> _routableServers;
 
+  // Snapshot of {@code _enabledServerInstanceMap} restricted to {@code _routableServers} (enabled minus excluded).
+  // Maintained in lockstep with {@code _routableServers} under {@code _globalLock.writeLock()}. Callers that select
+  // workers outside of per-table instance selection (MSE intermediate-stage worker picking) read this snapshot so
+  // that FailureDetector-driven exclusions are honored.
+  private volatile Map<String, ServerInstance> _routableServerInstanceMap = Collections.emptyMap();
+
   // Process assignment change timestamp. Used to check if buildRouting needs to be re-run for a given table to avoid
   // race conditions with processSegmentAssignmentChange()
   private long _processAssignmentChangeSnapshotTimestampMs;
@@ -442,6 +448,7 @@ public abstract class BaseBrokerRoutingManager implements RoutingManager, Cluste
       }
     }
     _routableServers = enabledServers;
+    _routableServerInstanceMap = buildRoutableServerInstanceMap();
     long calculateChangedServersEndTimeMs = System.currentTimeMillis();
 
     // Early terminate if there is no changed servers
@@ -531,6 +538,7 @@ public abstract class BaseBrokerRoutingManager implements RoutingManager, Cluste
     Set<String> routableServers = new HashSet<>(_routableServers);
     routableServers.remove(instanceId);
     _routableServers = routableServers;
+    _routableServerInstanceMap = buildRoutableServerInstanceMap();
     List<String> changedServers = Collections.singletonList(instanceId);
     for (RoutingEntry routingEntry : _routingEntryMap.values()) {
       String tableNameWithType = routingEntry.getTableNameWithType();
@@ -576,6 +584,7 @@ public abstract class BaseBrokerRoutingManager implements RoutingManager, Cluste
     Set<String> routableServers = new HashSet<>(_routableServers);
     routableServers.add(instanceId);
     _routableServers = routableServers;
+    _routableServerInstanceMap = buildRoutableServerInstanceMap();
     List<String> changedServers = Collections.singletonList(instanceId);
     for (RoutingEntry routingEntry : _routingEntryMap.values()) {
       String tableNameWithType = routingEntry.getTableNameWithType();
@@ -1170,6 +1179,27 @@ public abstract class BaseBrokerRoutingManager implements RoutingManager, Cluste
   @Override
   public Map<String, ServerInstance> getEnabledServerInstanceMap() {
     return _enabledServerInstanceMap;
+  }
+
+  @Override
+  public Map<String, ServerInstance> getRoutableServerInstanceMap() {
+    return _routableServerInstanceMap;
+  }
+
+  // Must be called under {@code _globalLock.writeLock()} whenever {@code _routableServers} is reassigned.
+  private Map<String, ServerInstance> buildRoutableServerInstanceMap() {
+    Set<String> routableServers = _routableServers;
+    if (routableServers == null || routableServers.isEmpty()) {
+      return Collections.emptyMap();
+    }
+    Map<String, ServerInstance> map = Maps.newHashMapWithExpectedSize(routableServers.size());
+    for (String instanceId : routableServers) {
+      ServerInstance instance = _enabledServerInstanceMap.get(instanceId);
+      if (instance != null) {
+        map.put(instanceId, instance);
+      }
+    }
+    return map;
   }
 
   private String getIdealStatePath(String tableNameWithType) {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/manager/MultiClusterRoutingManager.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/manager/MultiClusterRoutingManager.java
@@ -161,6 +161,15 @@ public class MultiClusterRoutingManager implements RoutingManager {
   }
 
   @Override
+  public Map<String, ServerInstance> getRoutableServerInstanceMap() {
+    Map<String, ServerInstance> combined = new HashMap<>(_localClusterRoutingManager.getRoutableServerInstanceMap());
+    for (BaseBrokerRoutingManager remoteCluster : _remoteClusterRoutingManagers) {
+      combined.putAll(remoteCluster.getRoutableServerInstanceMap());
+    }
+    return combined;
+  }
+
+  @Override
   public TablePartitionInfo getTablePartitionInfo(String tableNameWithType) {
     return findFirst(mgr -> mgr.getTablePartitionInfo(tableNameWithType), tableNameWithType);
   }

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/manager/BrokerRoutingManagerConcurrencyTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/manager/BrokerRoutingManagerConcurrencyTest.java
@@ -119,7 +119,7 @@ public class BrokerRoutingManagerConcurrencyTest extends ControllerTest {
     // Create and upload test table configs and schemas to ZooKeeper
     setupTestTablesInZooKeeper();
 
-    // Trigger instance config processing to populate _routableServers
+    // Trigger instance config processing to populate _routableServerInstanceMap
     triggerInstanceConfigProcessing();
   }
 
@@ -166,7 +166,7 @@ public class BrokerRoutingManagerConcurrencyTest extends ControllerTest {
 
   private void triggerInstanceConfigProcessing() {
     // Trigger BrokerRoutingManager to process instance config changes
-    // This will populate _routableServers which is needed for buildRouting to work
+    // This will populate _routableServerInstanceMap which is needed for buildRouting to work
     try {
       _routingManager.processClusterChange(ChangeType.INSTANCE_CONFIG);
     } catch (Exception e) {

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/manager/BrokerRoutingManagerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/manager/BrokerRoutingManagerTest.java
@@ -262,6 +262,34 @@ public class BrokerRoutingManagerTest {
     routingEntries.put(tableNameWithType, routingEntry);
   }
 
+  @Test
+  public void testRoutableServerInstanceMapReflectsExclusion() {
+    // Enable server
+    List<ZNRecord> instanceConfigs = Collections.singletonList(createEnabledServerZNRecord(SERVER_INSTANCE_ID));
+    when(_zkDataAccessor.getChildren(eq(INSTANCE_CONFIGS_PATH), any(), eq(AccessOption.PERSISTENT), anyInt(), anyInt()))
+        .thenReturn(instanceConfigs);
+    _routingManager.processClusterChange(ChangeType.INSTANCE_CONFIG);
+
+    // Server is present in both the enabled and routable maps initially.
+    assertTrue(_routingManager.getEnabledServerInstanceMap().containsKey(SERVER_INSTANCE_ID));
+    assertTrue(_routingManager.getRoutableServerInstanceMap().containsKey(SERVER_INSTANCE_ID));
+
+    // Exclude the server (simulating FailureDetector marking it unhealthy).
+    _routingManager.excludeServerFromRouting(SERVER_INSTANCE_ID);
+
+    // Routable map no longer contains the server, but enabled map still does.
+    // This is the contract MSE WorkerManager relies on for intermediate-stage worker selection.
+    assertTrue(_routingManager.getEnabledServerInstanceMap().containsKey(SERVER_INSTANCE_ID));
+    assertTrue(!_routingManager.getRoutableServerInstanceMap().containsKey(SERVER_INSTANCE_ID));
+
+    // Re-include the server.
+    _routingManager.includeServerToRouting(SERVER_INSTANCE_ID);
+
+    // Routable map contains the server again.
+    assertTrue(_routingManager.getEnabledServerInstanceMap().containsKey(SERVER_INSTANCE_ID));
+    assertTrue(_routingManager.getRoutableServerInstanceMap().containsKey(SERVER_INSTANCE_ID));
+  }
+
   /**
    * Creates a ZNRecord representing an enabled server instance.
    */

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/manager/BrokerRoutingManagerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/manager/BrokerRoutingManagerTest.java
@@ -61,6 +61,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertSame;
 import static org.testng.Assert.assertTrue;
 
@@ -280,7 +281,7 @@ public class BrokerRoutingManagerTest {
     // Routable map no longer contains the server, but enabled map still does.
     // This is the contract MSE WorkerManager relies on for intermediate-stage worker selection.
     assertTrue(_routingManager.getEnabledServerInstanceMap().containsKey(SERVER_INSTANCE_ID));
-    assertTrue(!_routingManager.getRoutableServerInstanceMap().containsKey(SERVER_INSTANCE_ID));
+    assertFalse(_routingManager.getRoutableServerInstanceMap().containsKey(SERVER_INSTANCE_ID));
 
     // Re-include the server.
     _routingManager.includeServerToRouting(SERVER_INSTANCE_ID);

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/manager/MultiClusterRoutingManagerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/manager/MultiClusterRoutingManagerTest.java
@@ -264,6 +264,28 @@ public class MultiClusterRoutingManagerTest {
     assertTrue(result.containsKey("server2"));
   }
 
+  @Test
+  public void testGetRoutableServerInstanceMapCombinesAll() {
+    ServerInstance server1 = createMockServerInstance("server1");
+    ServerInstance server2 = createMockServerInstance("server2");
+
+    Map<String, ServerInstance> localRoutable = new HashMap<>();
+    localRoutable.put("server1", server1);
+
+    Map<String, ServerInstance> remoteRoutable = new HashMap<>();
+    remoteRoutable.put("server2", server2);
+
+    when(_localClusterRoutingManager.getRoutableServerInstanceMap()).thenReturn(localRoutable);
+    when(_remoteClusterRoutingManager1.getRoutableServerInstanceMap()).thenReturn(remoteRoutable);
+    when(_remoteClusterRoutingManager2.getRoutableServerInstanceMap()).thenReturn(new HashMap<>());
+
+    Map<String, ServerInstance> result = _multiClusterRoutingManager.getRoutableServerInstanceMap();
+
+    assertEquals(result.size(), 2);
+    assertTrue(result.containsKey("server1"));
+    assertTrue(result.containsKey("server2"));
+  }
+
   // Helper methods
 
   private BrokerRequest createMockBrokerRequest(String tableName) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/routing/RoutingManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/routing/RoutingManager.java
@@ -49,6 +49,19 @@ public interface RoutingManager {
   Map<String, ServerInstance> getEnabledServerInstanceMap();
 
   /**
+   * Get all routable server instances in the cluster -- enabled servers that have not been excluded from routing by
+   * the broker (e.g. by the FailureDetector). Callers that pick workers without going through per-table instance
+   * selection (such as MSE intermediate stage worker selection) should prefer this over
+   * {@link #getEnabledServerInstanceMap()} so that FailureDetector exclusions are honored.
+   *
+   * <p>The default implementation delegates to {@link #getEnabledServerInstanceMap()} for backward compatibility with
+   * implementations that do not track exclusions separately.
+   */
+  default Map<String, ServerInstance> getRoutableServerInstanceMap() {
+    return getEnabledServerInstanceMap();
+  }
+
+  /**
    * Returns whether the given table is enabled
    * @param tableNameWithType Table name with type
    * @return Whether the given table is enabled

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerManager.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerManager.java
@@ -226,10 +226,11 @@ public class WorkerManager {
     DispatchablePlanMetadata metadata = metadataMap.get(fragment.getFragmentId());
 
     if (context.getTableNames().isEmpty()) {
-      // For constant expression query (no table is accessed), assign it to a random enabled server.
+      // For constant expression query (no table is accessed), assign it to a random routable server so we don't pick
+      // a server that's been excluded from routing by the FailureDetector.
       // TODO: Consider short-circuiting it and directly calculating the result on broker.
 
-      Collection<ServerInstance> serverInstances = _routingManager.getEnabledServerInstanceMap().values();
+      Collection<ServerInstance> serverInstances = _routingManager.getRoutableServerInstanceMap().values();
       int numServers = serverInstances.size();
       if (numServers == 0) {
         LOGGER.error("[RequestId: {}] No server instance found for constant expression query", context.getRequestId());
@@ -381,12 +382,13 @@ public class WorkerManager {
     if (context.isUseLeafServerForIntermediateStage()) {
       Set<QueryServerInstance> leafServerInstances = context.getLeafServerInstances();
       if (leafServerInstances.isEmpty()) {
-        // Fall back to use all enabled servers if no leaf server is found (e.g., when querying an empty table).
+        // Fall back to use all routable servers if no leaf server is found (e.g., when querying an empty table).
+        // Routable excludes servers removed from routing by the FailureDetector.
         LOGGER.warn("[RequestId: {}] No leaf server found with useLeafServerForIntermediateStage enabled, "
-            + "falling back to all enabled servers", context.getRequestId());
-        Map<String, ServerInstance> enabledServerInstanceMap = _routingManager.getEnabledServerInstanceMap();
-        candidateServers = new ArrayList<>(enabledServerInstanceMap.size());
-        for (ServerInstance serverInstance : enabledServerInstanceMap.values()) {
+            + "falling back to all routable servers", context.getRequestId());
+        Map<String, ServerInstance> routableServerInstanceMap = _routingManager.getRoutableServerInstanceMap();
+        candidateServers = new ArrayList<>(routableServerInstanceMap.size());
+        for (ServerInstance serverInstance : routableServerInstanceMap.values()) {
           candidateServers.add(new QueryServerInstance(serverInstance));
         }
         if (candidateServers.isEmpty()) {
@@ -426,21 +428,24 @@ public class WorkerManager {
         }
       }
     }
-    Map<String, ServerInstance> enabledServerInstanceMap = _routingManager.getEnabledServerInstanceMap();
+    // Use the routable server map so that FailureDetector-excluded servers are filtered out from both the fallback and
+    // the per-table lookup paths. The {@code servers} set is already filtered via per-table InstanceSelector, but the
+    // routable map narrows the fallback path too.
+    Map<String, ServerInstance> routableServerInstanceMap = _routingManager.getRoutableServerInstanceMap();
     List<QueryServerInstance> candidateServers;
     if (servers.isEmpty()) {
-      // Fall back to use all enabled servers if no server is found for the tables.
+      // Fall back to use all routable servers if no server is found for the tables.
       // TODO: Revisit if we should throw an exception instead.
       LOGGER.warn("[RequestId: {}] No server instance found for intermediate stage for tables: {}, "
-          + "falling back to all enabled servers", context.getRequestId(), nonLookupTables);
-      candidateServers = new ArrayList<>(enabledServerInstanceMap.size());
-      for (ServerInstance serverInstance : enabledServerInstanceMap.values()) {
+          + "falling back to all routable servers", context.getRequestId(), nonLookupTables);
+      candidateServers = new ArrayList<>(routableServerInstanceMap.size());
+      for (ServerInstance serverInstance : routableServerInstanceMap.values()) {
         candidateServers.add(new QueryServerInstance(serverInstance));
       }
     } else {
       candidateServers = new ArrayList<>(servers.size());
       for (String server : servers) {
-        ServerInstance serverInstance = enabledServerInstanceMap.get(server);
+        ServerInstance serverInstance = routableServerInstanceMap.get(server);
         if (serverInstance != null) {
           candidateServers.add(new QueryServerInstance(serverInstance));
         }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/DispatchClient.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/DispatchClient.java
@@ -77,43 +77,43 @@ class DispatchClient {
     // Enable gRPC keep-alive when configured so that a silently unreachable peer transitions the channel out of READY,
     // which lets the broker's FailureDetector exclude it from routing.
     if (keepAliveConfig.isEnabled()) {
-      channelBuilder.keepAliveTime(keepAliveConfig.getTimeSeconds(), TimeUnit.SECONDS)
-          .keepAliveTimeout(keepAliveConfig.getTimeoutSeconds(), TimeUnit.SECONDS)
+      channelBuilder.keepAliveTime(keepAliveConfig.getTimeMs(), TimeUnit.MILLISECONDS)
+          .keepAliveTimeout(keepAliveConfig.getTimeoutMs(), TimeUnit.MILLISECONDS)
           .keepAliveWithoutCalls(keepAliveConfig.isWithoutCalls());
     }
     _channel = channelBuilder.build();
     _dispatchStub = PinotQueryWorkerGrpc.newStub(_channel);
   }
 
-  /// Immutable gRPC keep-alive configuration for broker dispatch channels. Keep-alive is disabled when
-  /// `timeSeconds` is not positive, matching the convention in [org.apache.pinot.common.config.GrpcConfig].
+  /// Immutable gRPC keep-alive configuration for broker dispatch channels. Keep-alive is disabled when `timeMs` is not
+  /// positive.
   static final class KeepAliveConfig {
-    static final KeepAliveConfig DISABLED = new KeepAliveConfig(-1, 30, false);
+    static final KeepAliveConfig DISABLED = new KeepAliveConfig(-1, 30_000, false);
 
-    private final int _timeSeconds;
-    private final int _timeoutSeconds;
+    private final int _timeMs;
+    private final int _timeoutMs;
     private final boolean _withoutCalls;
 
-    KeepAliveConfig(int timeSeconds, int timeoutSeconds, boolean withoutCalls) {
-      if (timeSeconds > 0) {
-        Preconditions.checkArgument(timeoutSeconds > 0,
-            "keepAliveTimeoutSeconds must be positive when keep-alive is enabled, got: %s", timeoutSeconds);
+    KeepAliveConfig(int timeMs, int timeoutMs, boolean withoutCalls) {
+      if (timeMs > 0) {
+        Preconditions.checkArgument(timeoutMs > 0,
+            "keepAliveTimeoutMs must be positive when keep-alive is enabled, got: %s", timeoutMs);
       }
-      _timeSeconds = timeSeconds;
-      _timeoutSeconds = timeoutSeconds;
+      _timeMs = timeMs;
+      _timeoutMs = timeoutMs;
       _withoutCalls = withoutCalls;
     }
 
     boolean isEnabled() {
-      return _timeSeconds > 0;
+      return _timeMs > 0;
     }
 
-    int getTimeSeconds() {
-      return _timeSeconds;
+    int getTimeMs() {
+      return _timeMs;
     }
 
-    int getTimeoutSeconds() {
-      return _timeoutSeconds;
+    int getTimeoutMs() {
+      return _timeoutMs;
     }
 
     boolean isWithoutCalls() {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/DispatchClient.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/DispatchClient.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.query.service.dispatch;
 
+import com.google.common.base.Preconditions;
 import io.grpc.Deadline;
 import io.grpc.ManagedChannel;
 import io.grpc.netty.shaded.io.grpc.netty.NettyChannelBuilder;
@@ -26,6 +27,7 @@ import io.grpc.netty.shaded.io.netty.channel.ChannelOption;
 import io.grpc.netty.shaded.io.netty.handler.ssl.SslContext;
 import io.grpc.stub.StreamObserver;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.config.TlsConfig;
@@ -53,25 +55,70 @@ class DispatchClient {
   private final PinotQueryWorkerGrpc.PinotQueryWorkerStub _dispatchStub;
 
   public DispatchClient(String host, int port, @Nullable TlsConfig tlsConfig) {
-    this(host, port, tlsConfig, null);
+    this(host, port, tlsConfig, null, KeepAliveConfig.DISABLED);
   }
 
   public DispatchClient(String host, int port, @Nullable TlsConfig tlsConfig, @Nullable SslContext sslContext) {
+    this(host, port, tlsConfig, sslContext, KeepAliveConfig.DISABLED);
+  }
+
+  DispatchClient(String host, int port, @Nullable TlsConfig tlsConfig, @Nullable SslContext sslContext,
+      KeepAliveConfig keepAliveConfig) {
     // Always use NettyChannelBuilder to allow setting Netty-specific channel options like the buffer allocator.
     // This ensures we can explicitly configure direct (off-heap) buffers for better performance.
+    NettyChannelBuilder channelBuilder = NettyChannelBuilder.forAddress(host, port)
+        .withOption(ChannelOption.ALLOCATOR, BUF_ALLOCATOR);
     if (tlsConfig == null) {
-      _channel = NettyChannelBuilder.forAddress(host, port)
-          .usePlaintext()
-          .withOption(ChannelOption.ALLOCATOR, BUF_ALLOCATOR)
-          .build();
+      channelBuilder.usePlaintext();
     } else {
       SslContext contextToUse = sslContext != null ? sslContext : ServerGrpcQueryClient.buildSslContext(tlsConfig);
-      _channel = NettyChannelBuilder.forAddress(host, port)
-          .sslContext(contextToUse)
-          .withOption(ChannelOption.ALLOCATOR, BUF_ALLOCATOR)
-          .build();
+      channelBuilder.sslContext(contextToUse);
     }
+    // Enable gRPC keep-alive when configured so that a silently unreachable peer transitions the channel out of READY,
+    // which lets the broker's FailureDetector exclude it from routing.
+    if (keepAliveConfig.isEnabled()) {
+      channelBuilder.keepAliveTime(keepAliveConfig.getTimeSeconds(), TimeUnit.SECONDS)
+          .keepAliveTimeout(keepAliveConfig.getTimeoutSeconds(), TimeUnit.SECONDS)
+          .keepAliveWithoutCalls(keepAliveConfig.isWithoutCalls());
+    }
+    _channel = channelBuilder.build();
     _dispatchStub = PinotQueryWorkerGrpc.newStub(_channel);
+  }
+
+  /// Immutable gRPC keep-alive configuration for broker dispatch channels. Keep-alive is disabled when
+  /// {@code timeSeconds} is not positive, matching the convention in {@link org.apache.pinot.common.config.GrpcConfig}.
+  static final class KeepAliveConfig {
+    static final KeepAliveConfig DISABLED = new KeepAliveConfig(-1, 30, false);
+
+    private final int _timeSeconds;
+    private final int _timeoutSeconds;
+    private final boolean _withoutCalls;
+
+    KeepAliveConfig(int timeSeconds, int timeoutSeconds, boolean withoutCalls) {
+      if (timeSeconds > 0) {
+        Preconditions.checkArgument(timeoutSeconds > 0,
+            "keepAliveTimeoutSeconds must be positive when keep-alive is enabled, got: %s", timeoutSeconds);
+      }
+      _timeSeconds = timeSeconds;
+      _timeoutSeconds = timeoutSeconds;
+      _withoutCalls = withoutCalls;
+    }
+
+    boolean isEnabled() {
+      return _timeSeconds > 0;
+    }
+
+    int getTimeSeconds() {
+      return _timeSeconds;
+    }
+
+    int getTimeoutSeconds() {
+      return _timeoutSeconds;
+    }
+
+    boolean isWithoutCalls() {
+      return _withoutCalls;
+    }
   }
 
   public ManagedChannel getChannel() {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/DispatchClient.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/DispatchClient.java
@@ -86,7 +86,7 @@ class DispatchClient {
   }
 
   /// Immutable gRPC keep-alive configuration for broker dispatch channels. Keep-alive is disabled when
-  /// {@code timeSeconds} is not positive, matching the convention in {@link org.apache.pinot.common.config.GrpcConfig}.
+  /// `timeSeconds` is not positive, matching the convention in [org.apache.pinot.common.config.GrpcConfig].
   static final class KeepAliveConfig {
     static final KeepAliveConfig DISABLED = new KeepAliveConfig(-1, 30, false);
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
@@ -113,6 +113,7 @@ public class QueryDispatcher {
   private final TlsConfig _tlsConfig;
   @Nullable
   private final SslContext _clientGrpcSslContext;
+  private final DispatchClient.KeepAliveConfig _keepAliveConfig;
   // maps broker-generated query id to the set of servers that the query was dispatched to
   private final Map<Long, Set<QueryServerInstance>> _serversByQuery;
   private final FailureDetector _failureDetector;
@@ -120,12 +121,28 @@ public class QueryDispatcher {
 
   public QueryDispatcher(MailboxService mailboxService, FailureDetector failureDetector, @Nullable TlsConfig tlsConfig,
       boolean enableCancellation, Duration cancelTimeout) {
+    this(mailboxService, failureDetector, tlsConfig, enableCancellation, cancelTimeout,
+        DispatchClient.KeepAliveConfig.DISABLED);
+  }
+
+  /// Overload that accepts gRPC keep-alive settings for broker dispatch channels. A non-positive
+  /// {@code keepAliveTimeSeconds} disables keep-alive.
+  public QueryDispatcher(MailboxService mailboxService, FailureDetector failureDetector, @Nullable TlsConfig tlsConfig,
+      boolean enableCancellation, Duration cancelTimeout, int keepAliveTimeSeconds, int keepAliveTimeoutSeconds,
+      boolean keepAliveWithoutCalls) {
+    this(mailboxService, failureDetector, tlsConfig, enableCancellation, cancelTimeout,
+        new DispatchClient.KeepAliveConfig(keepAliveTimeSeconds, keepAliveTimeoutSeconds, keepAliveWithoutCalls));
+  }
+
+  private QueryDispatcher(MailboxService mailboxService, FailureDetector failureDetector, @Nullable TlsConfig tlsConfig,
+      boolean enableCancellation, Duration cancelTimeout, DispatchClient.KeepAliveConfig keepAliveConfig) {
     _cancelTimeout = cancelTimeout;
     _mailboxService = mailboxService;
     _executorService = Executors.newFixedThreadPool(2 * Runtime.getRuntime().availableProcessors(),
         new TracedThreadFactory(Thread.NORM_PRIORITY, false, PINOT_BROKER_QUERY_DISPATCHER_FORMAT));
     _tlsConfig = tlsConfig;
     _clientGrpcSslContext = initClientSslContext(tlsConfig);
+    _keepAliveConfig = keepAliveConfig;
     _failureDetector = failureDetector;
 
     if (enableCancellation) {
@@ -522,7 +539,7 @@ public class QueryDispatcher {
     String hostname = queryServerInstance.getHostname();
     int port = queryServerInstance.getQueryServicePort();
     return _dispatchClientMap.computeIfAbsent(toHostnamePortKey(hostname, port),
-        k -> new DispatchClient(hostname, port, _tlsConfig, _clientGrpcSslContext));
+        k -> new DispatchClient(hostname, port, _tlsConfig, _clientGrpcSslContext, _keepAliveConfig));
   }
 
   /**

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
@@ -125,13 +125,13 @@ public class QueryDispatcher {
         DispatchClient.KeepAliveConfig.DISABLED);
   }
 
-  /// Overload that accepts gRPC keep-alive settings for broker dispatch channels. A non-positive
-  /// {@code keepAliveTimeSeconds} disables keep-alive.
+  /// Overload that accepts gRPC keep-alive settings for broker dispatch channels. A non-positive `keepAliveTimeMs`
+  /// disables keep-alive.
   public QueryDispatcher(MailboxService mailboxService, FailureDetector failureDetector, @Nullable TlsConfig tlsConfig,
-      boolean enableCancellation, Duration cancelTimeout, int keepAliveTimeSeconds, int keepAliveTimeoutSeconds,
+      boolean enableCancellation, Duration cancelTimeout, int keepAliveTimeMs, int keepAliveTimeoutMs,
       boolean keepAliveWithoutCalls) {
     this(mailboxService, failureDetector, tlsConfig, enableCancellation, cancelTimeout,
-        new DispatchClient.KeepAliveConfig(keepAliveTimeSeconds, keepAliveTimeoutSeconds, keepAliveWithoutCalls));
+        new DispatchClient.KeepAliveConfig(keepAliveTimeMs, keepAliveTimeoutMs, keepAliveWithoutCalls));
   }
 
   private QueryDispatcher(MailboxService mailboxService, FailureDetector failureDetector, @Nullable TlsConfig tlsConfig,

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -2203,6 +2203,28 @@ public class CommonConstants {
     /// TODO: This is used by the broker. Consider renaming it.
     public static final String KEY_OF_CANCEL_TIMEOUT_MS = "pinot.server.query.cancel.timeout.ms";
     public static final long DEFAULT_OF_CANCEL_TIMEOUT_MS = 1000;
+
+    /// gRPC keep-alive time for broker dispatch channels, in seconds. Values &gt; 0 enable keep-alive pings so that a
+    /// silently unreachable server (e.g. kernel-dead node, one-way network partition) transitions the dispatch channel
+    /// out of `READY`, which in turn lets the broker's FailureDetector exclude it from routing.
+    ///
+    /// Defaults are chosen to be safe against Netty's default gRPC server enforcement
+    /// (`permitKeepAliveTime` = 5 minutes, `permitKeepAliveWithoutCalls` = false); operators may tune these down for
+    /// faster silent-peer detection once the server side has been configured to permit a higher ping rate.
+    public static final String KEY_OF_DISPATCH_CHANNEL_KEEP_ALIVE_TIME_SECONDS =
+        "pinot.query.multistage.dispatch.channel.keep.alive.time.seconds";
+    public static final int DEFAULT_OF_DISPATCH_CHANNEL_KEEP_ALIVE_TIME_SECONDS = 300;
+
+    /// gRPC keep-alive timeout for broker dispatch channels, in seconds. Only applies when keep-alive is enabled.
+    public static final String KEY_OF_DISPATCH_CHANNEL_KEEP_ALIVE_TIMEOUT_SECONDS =
+        "pinot.query.multistage.dispatch.channel.keep.alive.timeout.seconds";
+    public static final int DEFAULT_OF_DISPATCH_CHANNEL_KEEP_ALIVE_TIMEOUT_SECONDS = 30;
+
+    /// Whether to send gRPC keep-alive pings on dispatch channels even when there are no active calls. Default is
+    /// `false` because Netty's default gRPC server rejects pings-without-calls with `GOAWAY (ENHANCE_YOUR_CALM)`.
+    public static final String KEY_OF_DISPATCH_CHANNEL_KEEP_ALIVE_WITHOUT_CALLS =
+        "pinot.query.multistage.dispatch.channel.keep.alive.without.calls";
+    public static final boolean DEFAULT_OF_DISPATCH_CHANNEL_KEEP_ALIVE_WITHOUT_CALLS = false;
   }
 
   public static class NullValuePlaceHolder {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -2204,21 +2204,21 @@ public class CommonConstants {
     public static final String KEY_OF_CANCEL_TIMEOUT_MS = "pinot.server.query.cancel.timeout.ms";
     public static final long DEFAULT_OF_CANCEL_TIMEOUT_MS = 1000;
 
-    /// gRPC keep-alive time for broker dispatch channels, in seconds. Values &gt; 0 enable keep-alive pings so that a
-    /// silently unreachable server (e.g. kernel-dead node, one-way network partition) transitions the dispatch channel
-    /// out of `READY`, which in turn lets the broker's FailureDetector exclude it from routing.
+    /// gRPC keep-alive time for broker dispatch channels, in milliseconds. Values &gt; 0 enable keep-alive pings so
+    /// that a silently unreachable server (e.g. kernel-dead node, one-way network partition) transitions the dispatch
+    /// channel out of `READY`, which in turn lets the broker's FailureDetector exclude it from routing.
     ///
     /// Defaults are chosen to be safe against Netty's default gRPC server enforcement
     /// (`permitKeepAliveTime` = 5 minutes, `permitKeepAliveWithoutCalls` = false); operators may tune these down for
     /// faster silent-peer detection once the server side has been configured to permit a higher ping rate.
-    public static final String KEY_OF_DISPATCH_CHANNEL_KEEP_ALIVE_TIME_SECONDS =
-        "pinot.query.multistage.dispatch.channel.keep.alive.time.seconds";
-    public static final int DEFAULT_OF_DISPATCH_CHANNEL_KEEP_ALIVE_TIME_SECONDS = 300;
+    public static final String KEY_OF_DISPATCH_CHANNEL_KEEP_ALIVE_TIME_MS =
+        "pinot.query.multistage.dispatch.channel.keep.alive.time.ms";
+    public static final int DEFAULT_OF_DISPATCH_CHANNEL_KEEP_ALIVE_TIME_MS = 300_000;
 
-    /// gRPC keep-alive timeout for broker dispatch channels, in seconds. Only applies when keep-alive is enabled.
-    public static final String KEY_OF_DISPATCH_CHANNEL_KEEP_ALIVE_TIMEOUT_SECONDS =
-        "pinot.query.multistage.dispatch.channel.keep.alive.timeout.seconds";
-    public static final int DEFAULT_OF_DISPATCH_CHANNEL_KEEP_ALIVE_TIMEOUT_SECONDS = 30;
+    /// gRPC keep-alive timeout for broker dispatch channels, in milliseconds. Only applies when keep-alive is enabled.
+    public static final String KEY_OF_DISPATCH_CHANNEL_KEEP_ALIVE_TIMEOUT_MS =
+        "pinot.query.multistage.dispatch.channel.keep.alive.timeout.ms";
+    public static final int DEFAULT_OF_DISPATCH_CHANNEL_KEEP_ALIVE_TIMEOUT_MS = 30_000;
 
     /// Whether to send gRPC keep-alive pings on dispatch channels even when there are no active calls. Default is
     /// `false` because Netty's default gRPC server rejects pings-without-calls with `GOAWAY (ENHANCE_YOUR_CALM)`.


### PR DESCRIPTION
- **Problem:** Observed in prod — a server node became kernel-dead (kubelet dead, pod stuck terminating). The broker's MSE dispatch gRPC channel stayed `READY` (no keep-alive configured), `FailureDetector` never fired, and `WorkerManager` kept picking the dead server as an intermediate-stage worker on unrelated queries, causing cluster-wide MSE failures for ~1h38m until the node came back. SSE queries were mostly unaffected because per-table `InstanceSelector` already filters by `_routableServers`.
- **Fix 1 — gRPC keep-alive on broker dispatch channels:** plumb keep-alive through `DispatchClient` → `QueryDispatcher` → `MultiStageBrokerRequestHandler` via three new configs (`pinot.query.multistage.dispatch.channel.keep.alive.{time.seconds,timeout.seconds,without.calls}`). Activates the dormant ``channel.getState() != READY → markServerUnhealthy`` gate in `QueryDispatcher#processResults` so a silently unreachable peer transitions the channel out of `READY` and gets excluded from routing.
- **Fix 2 — MSE routing honors FailureDetector exclusions:** add `RoutingManager#getRoutableServerInstanceMap()` (default method delegates to `getEnabledServerInstanceMap()`). `BaseBrokerRoutingManager` maintains a `volatile` snapshot of ``enabled ∩ _routableServers``, rebuilt in lockstep with `_routableServers` under `_globalLock.writeLock()` (O(1) reads, zero per-call allocation). `MultiClusterRoutingManager` overrides with its existing aggregation pattern. `WorkerManager` switches three direct-read call sites — constant-expression query, `useLeafServerForIntermediateStage` fallback, and `getCandidateServersPerTables` — to the new accessor so excluded servers are filtered from intermediate-stage worker selection. Leaf-stage partition paths unchanged since they already flow through per-table `InstanceSelector`.
- **Why both fixes:** Fix 1 alone wouldn't reach every MSE code path because three `WorkerManager` paths read `_enabledServerInstanceMap` directly, which is never affected by exclusions. Fix 2 alone wouldn't help in Helix-blind failure modes (zombie JVM with healthy ZK session, broker↔server partition with ZK intact) because Helix never updates `ExternalView` / `LiveInstance` in those scenarios. Together they cover the full failure surface.
- **Defaults:** Keep-alive is **on by default** with conservative values tuned for Netty's default server-side permits — `keepAliveTime=300s` (matches `permitKeepAliveTime=5min`), `keepAliveTimeout=30s`, `keepAliveWithoutCalls=false` (Netty default forbids pings without calls). This catches persistent / long-running dispatches without risking `GOAWAY(ENHANCE_YOUR_CALM)`. Operators can tune down (e.g. 30s / 10s / true) for per-query detection after configuring server-side `permitKeepAliveTime` and `permitKeepAliveWithoutCalls`. Rationale documented in `CommonConstants.MultiStageQueryRunner`.
- **Backward compatibility:** `RoutingManager#getRoutableServerInstanceMap()` has a default implementation delegating to `getEnabledServerInstanceMap()`, so all existing implementations (including test mocks and `MockRoutingManagerFactory`) work unchanged. Existing `QueryDispatcher` and `DispatchClient` constructors preserved.
- **Tests:** Added regression tests in `BrokerRoutingManagerTest` (asserts `getRoutableServerInstanceMap()` excludes the server after `excludeServerFromRouting()` and reappears after `includeServerToRouting()`) and `MultiClusterRoutingManagerTest` (asserts routable-map aggregation across clusters). Full suite status on affected modules: `BrokerRoutingManagerTest` 5/5, `MultiClusterRoutingManagerTest` 13/13, `WorkerManagerTest` 2/2, `QueryDispatcherTest` 69/69. Spotless / Checkstyle / license all clean.