### PR TITLE
Add round robin segment assignment strategy

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/SegmentAssignmentUtils.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/SegmentAssignmentUtils.java
@@ -133,13 +133,20 @@ public class SegmentAssignmentUtils {
     }
 
     // Mirror the assignment to all replica-groups
+    return getOneInstanceFromEachReplicaGroup(instancePartitions, partitionId, instanceIdWithLeastSegmentsAssigned);
+  }
+
+  public static List<String> getOneInstanceFromEachReplicaGroup(InstancePartitions instancePartitions,
+      int partitionId, int instanceId) {
     int numReplicaGroups = instancePartitions.getNumReplicaGroups();
-    List<String> instancesAssigned = new ArrayList<>(numReplicaGroups);
+    int numInstancesPerReplicaGroup = instancePartitions.getInstances(partitionId, 0).size();
+    instanceId %= numInstancesPerReplicaGroup;
+    List<String> instances = new ArrayList<>(numReplicaGroups);
     for (int replicaGroupId = 0; replicaGroupId < numReplicaGroups; replicaGroupId++) {
-      instancesAssigned.add(
-          instancePartitions.getInstances(partitionId, replicaGroupId).get(instanceIdWithLeastSegmentsAssigned));
+      List<String> instancesInReplicaGroup = instancePartitions.getInstances(partitionId, replicaGroupId);
+      instances.add(instancesInReplicaGroup.get(instanceId));
     }
-    return instancesAssigned;
+    return instances;
   }
 
   /// Rebalances the table with non-replica-group based segment assignment strategy by uniformly spraying segment

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/BalancedNumSegmentAssignmentStrategy.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/BalancedNumSegmentAssignmentStrategy.java
@@ -39,7 +39,7 @@ import org.slf4j.LoggerFactory;
 public class BalancedNumSegmentAssignmentStrategy implements SegmentAssignmentStrategy {
   private static final Logger LOGGER = LoggerFactory.getLogger(BalancedNumSegmentAssignmentStrategy.class);
 
-  private int _replication;
+  protected int _replication;
 
   @Override
   public void init(HelixManager helixManager, TableConfig tableConfig) {
@@ -66,7 +66,7 @@ public class BalancedNumSegmentAssignmentStrategy implements SegmentAssignmentSt
     return SegmentAssignmentUtils.rebalanceNonReplicaGroupBasedTable(currentAssignment, instances, _replication);
   }
 
-  private void validateSegmentAssignmentStrategy(InstancePartitions instancePartitions) {
+  protected void validateSegmentAssignmentStrategy(InstancePartitions instancePartitions) {
     int numReplicaGroups = instancePartitions.getNumReplicaGroups();
     int numPartitions = instancePartitions.getNumPartitions();
     // Non-replica-group based assignment should have numReplicaGroups and numPartitions = 1

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/BalancedNumSegmentAssignmentStrategy.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/BalancedNumSegmentAssignmentStrategy.java
@@ -46,7 +46,7 @@ public class BalancedNumSegmentAssignmentStrategy implements SegmentAssignmentSt
     SegmentsValidationAndRetentionConfig validationAndRetentionConfig = tableConfig.getValidationConfig();
     Preconditions.checkState(validationAndRetentionConfig != null, "segmentsConfig is null");
     _replication = tableConfig.getReplication();
-    LOGGER.info("Initialized BalancedNumSegmentAssignmentStrategy for table: {} with replication: {}",
+    LOGGER.info("Initialized {} for table: {} with replication: {}", this.getClass().getSimpleName(),
         tableConfig.getTableName(), _replication);
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/ReplicaGroupSegmentAssignmentStrategy.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/ReplicaGroupSegmentAssignmentStrategy.java
@@ -54,11 +54,13 @@ class ReplicaGroupSegmentAssignmentStrategy implements SegmentAssignmentStrategy
     _replication = tableConfig.getReplication();
     _partitionColumn = TableConfigUtils.getPartitionColumn(tableConfig);
     if (_partitionColumn == null) {
-      LOGGER.info("Initialized ReplicaGroupSegmentAssignmentStrategy "
-          + "with replication: {} without partition column for table: {} ", _replication, _tableName);
+      LOGGER.info("Initialized {} "
+              + "with replication: {} without partition column for table: {} ", this.getClass().getSimpleName(),
+          _replication, _tableName);
     } else {
-      LOGGER.info("Initialized ReplicaGroupSegmentAssignmentStrategy "
-          + "with replication: {} and partition column: {} for table: {}", _replication, _partitionColumn, _tableName);
+      LOGGER.info("Initialized {} "
+              + "with replication: {} and partition column: {} for table: {}", this.getClass().getSimpleName(),
+          _replication, _partitionColumn, _tableName);
     }
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/ReplicaGroupSegmentAssignmentStrategy.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/ReplicaGroupSegmentAssignmentStrategy.java
@@ -37,7 +37,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
-class ReplicaGroupSegmentAssignmentStrategy implements SegmentAssignmentStrategy {
+public class ReplicaGroupSegmentAssignmentStrategy implements SegmentAssignmentStrategy {
   private static final Logger LOGGER = LoggerFactory.getLogger(ReplicaGroupSegmentAssignmentStrategy.class);
 
   protected HelixManager _helixManager;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/ReplicaGroupSegmentAssignmentStrategy.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/ReplicaGroupSegmentAssignmentStrategy.java
@@ -40,10 +40,10 @@ import org.slf4j.LoggerFactory;
 class ReplicaGroupSegmentAssignmentStrategy implements SegmentAssignmentStrategy {
   private static final Logger LOGGER = LoggerFactory.getLogger(ReplicaGroupSegmentAssignmentStrategy.class);
 
-  private HelixManager _helixManager;
-  private String _tableName;
-  private String _partitionColumn;
-  private int _replication;
+  protected HelixManager _helixManager;
+  protected String _tableName;
+  protected String _partitionColumn;
+  protected int _replication;
 
   @Override
   public void init(HelixManager helixManager, TableConfig tableConfig) {
@@ -64,6 +64,7 @@ class ReplicaGroupSegmentAssignmentStrategy implements SegmentAssignmentStrategy
 
   /**
    * Assigns the segment for the replica-group based segment assignment strategy and returns the assigned instances.
+   * Assign to the instance with the least number of segments for each replica-group.
    */
   @Override
   public List<String> assignSegment(String segmentName, Map<String, Map<String, String>> currentAssignment,
@@ -128,7 +129,7 @@ class ReplicaGroupSegmentAssignmentStrategy implements SegmentAssignmentStrategy
    * mismatch can happen when table is not configured correctly (table replication and numReplicaGroups does not match
    * or replication changed without reassigning instances).
    */
-  private static void checkReplication(InstancePartitions instancePartitions, int replication, String tableName) {
+  protected static void checkReplication(InstancePartitions instancePartitions, int replication, String tableName) {
     int numReplicaGroups = instancePartitions.getNumReplicaGroups();
     if (numReplicaGroups != replication) {
       LOGGER.warn(

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/RoundRobinReplicaGroupSegmentAssignmentStrategy.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/RoundRobinReplicaGroupSegmentAssignmentStrategy.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.ConcurrentHashMap;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pinot.common.assignment.InstancePartitions;
 import org.apache.pinot.common.utils.SegmentUtils;
 import org.apache.pinot.controller.helix.core.assignment.segment.SegmentAssignmentUtils;
@@ -32,21 +33,27 @@ import org.apache.pinot.controller.helix.core.assignment.segment.SegmentAssignme
  * It can be used in the same scenarios as {@link ReplicaGroupSegmentAssignmentStrategy}, except the new segment will
  * not be assigned to the instance with the least number of segments, but instead assigned to the next instance in a
  * round-robin fashion within each replica-group. Rebalance with this strategy is identical to
- * {@link ReplicaGroupSegmentAssignmentStrategy}
+ * {@link ReplicaGroupSegmentAssignmentStrategy}.
  *
- * When the number of instances in each replica group increases, this is useful when we don't care about the existing
- * segments as they might be removed later by the retention, or there are significantly unbalanced demands on newer
- * segments. This strategy works better than {@link ReplicaGroupSegmentAssignmentStrategy} since it might need a
- * bootstrap rebalance in this case
+ * <p>When the number of instances in each replica group increases, this is useful when we don't care about the
+ * existing segments as they might be removed later by retention, or there are significantly unbalanced demands on
+ * newer segments. This strategy works better than {@link ReplicaGroupSegmentAssignmentStrategy} since that strategy
+ * may require a bootstrap rebalance in this case.
  *
- * The round-robin counter is maintained per table and stored in memory, and does not sync across controller instances,
- * which means the segment assignment may not be strictly round-robin after controller restarts, and when there are
- * multiple controllers assigning new segments.
+ * <p>The round-robin counter is maintained per table and partition in memory and does not sync across controller
+ * instances, which means segment assignment may not be strictly round-robin after controller restarts or when
+ * multiple controllers assign segments concurrently.
+ *
  */
-class RoundRobinReplicaGroupSegmentAssignmentStrategy extends ReplicaGroupSegmentAssignmentStrategy {
-  private static final Map<String, Integer> TABLE_ROUND_ROBIN_COUNTER = new ConcurrentHashMap<>();
+public class RoundRobinReplicaGroupSegmentAssignmentStrategy extends ReplicaGroupSegmentAssignmentStrategy {
+  private static final Map<Pair<String, Integer>, Integer> TABLE_ROUND_ROBIN_COUNTER = new ConcurrentHashMap<>();
   private static final Random RANDOM = new Random();
 
+  /**
+   * Assign the segment to the replica groups of its partition. The instance in each replica group is picked in a
+   * round-robin manner, and the counter increases regardless whether the segment is actually added to the ideal
+   * state or not.
+   */
   @Override
   public List<String> assignSegment(String segmentName, Map<String, Map<String, String>> currentAssignment,
       InstancePartitions instancePartitions) {
@@ -62,7 +69,7 @@ class RoundRobinReplicaGroupSegmentAssignmentStrategy extends ReplicaGroupSegmen
     }
     int numInstancesPerReplicaGroup = instancePartitions.getInstances(partitionId, 0).size();
 
-    String counterKey = _tableName + "_" + partitionId;
+    Pair<String, Integer> counterKey = Pair.of(_tableName, partitionId);
     int instanceId = TABLE_ROUND_ROBIN_COUNTER.compute(counterKey,
         (key, value) -> value == null ? RANDOM.nextInt(numInstancesPerReplicaGroup)
             : (value + 1) % numInstancesPerReplicaGroup);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/RoundRobinReplicaGroupSegmentAssignmentStrategy.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/RoundRobinReplicaGroupSegmentAssignmentStrategy.java
@@ -1,0 +1,71 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core.assignment.segment.strategy;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.pinot.common.assignment.InstancePartitions;
+import org.apache.pinot.common.utils.SegmentUtils;
+import org.apache.pinot.controller.helix.core.assignment.segment.SegmentAssignmentUtils;
+
+
+/**
+ * Segment assignment strategy class where segments are assigned in a round-robin fashion across available instances.
+ * It can be used in the same scenarios as {@link ReplicaGroupSegmentAssignmentStrategy}, except the new segment will
+ * not be assigned to the instance with the least number of segments, but instead assigned to the next instance in a
+ * round-robin fashion within each replica-group. Rebalance with this strategy is identical to
+ * {@link ReplicaGroupSegmentAssignmentStrategy}
+ *
+ * When the number of instances in each replica group increases, this is useful when we don't care about the existing
+ * segments as they might be removed later by the retention, or there are significantly unbalanced demands on newer
+ * segments. This strategy works better than {@link ReplicaGroupSegmentAssignmentStrategy} since it might need a
+ * bootstrap rebalance in this case
+ *
+ * The round-robin counter is maintained per table and stored in memory, and does not sync across controller instances,
+ * which means the segment assignment may not be strictly round-robin after controller restarts, and when there are
+ * multiple controllers assigning new segments.
+ */
+class RoundRobinReplicaGroupSegmentAssignmentStrategy extends ReplicaGroupSegmentAssignmentStrategy {
+  private static final Map<String, Integer> TABLE_ROUND_ROBIN_COUNTER = new ConcurrentHashMap<>();
+  private static final Random RANDOM = new Random();
+
+  @Override
+  public List<String> assignSegment(String segmentName, Map<String, Map<String, String>> currentAssignment,
+      InstancePartitions instancePartitions) {
+    checkReplication(instancePartitions, _replication, _tableName);
+    int numPartitions = instancePartitions.getNumPartitions();
+    int partitionId;
+    if (numPartitions == 1) {
+      partitionId = 0;
+    } else {
+      partitionId =
+          SegmentUtils.getSegmentPartitionIdOrDefault(segmentName, _tableName, _helixManager, _partitionColumn)
+              % numPartitions;
+    }
+    int numInstancesPerReplicaGroup = instancePartitions.getInstances(partitionId, 0).size();
+
+    String counterKey = _tableName + "_" + partitionId;
+    int instanceId = TABLE_ROUND_ROBIN_COUNTER.compute(counterKey,
+        (key, value) -> value == null ? RANDOM.nextInt(numInstancesPerReplicaGroup)
+            : (value + 1) % numInstancesPerReplicaGroup);
+    return SegmentAssignmentUtils.getOneInstanceFromEachReplicaGroup(instancePartitions, partitionId, instanceId);
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/RoundRobinSegmentAssignmentStrategy.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/RoundRobinSegmentAssignmentStrategy.java
@@ -65,7 +65,7 @@ public class RoundRobinSegmentAssignmentStrategy extends BalancedNumSegmentAssig
     int instanceId = TABLE_ROUND_ROBIN_COUNTER.compute(_tableName,
         (key, value) -> value == null ? RANDOM.nextInt(instances.size()) : (value + _replication) % instances.size());
     for (int i = 0; i < _replication; i++) {
-      assignedInstances.add(instances.get((instanceId - i) % instances.size()));
+      assignedInstances.add(instances.get((instanceId - i + instances.size()) % instances.size()));
     }
     return assignedInstances;
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/RoundRobinSegmentAssignmentStrategy.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/RoundRobinSegmentAssignmentStrategy.java
@@ -62,10 +62,10 @@ public class RoundRobinSegmentAssignmentStrategy extends BalancedNumSegmentAssig
     List<String> instances =
         SegmentAssignmentUtils.getInstancesForNonReplicaGroupBasedAssignment(instancePartitions, _replication);
     List<String> assignedInstances = new ArrayList<>();
+    int instanceId = TABLE_ROUND_ROBIN_COUNTER.compute(_tableName,
+        (key, value) -> value == null ? RANDOM.nextInt(instances.size()) : (value + _replication) % instances.size());
     for (int i = 0; i < _replication; i++) {
-      int instanceId = TABLE_ROUND_ROBIN_COUNTER.compute(_tableName,
-          (key, value) -> value == null ? RANDOM.nextInt(instances.size()) : (value + 1) % instances.size());
-      assignedInstances.add(instances.get(instanceId));
+      assignedInstances.add(instances.get((instanceId - i) % instances.size()));
     }
     return assignedInstances;
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/RoundRobinSegmentAssignmentStrategy.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/RoundRobinSegmentAssignmentStrategy.java
@@ -1,0 +1,72 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core.assignment.segment.strategy;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.concurrent.ConcurrentHashMap;
+import org.apache.helix.HelixManager;
+import org.apache.pinot.common.assignment.InstancePartitions;
+import org.apache.pinot.controller.helix.core.assignment.segment.SegmentAssignmentUtils;
+import org.apache.pinot.spi.config.table.TableConfig;
+
+
+/**
+ * Segment assignment strategy class where segments are assigned in a round-robin fashion across available instances.
+ * It can be used in the same scenarios as {@link BalancedNumSegmentAssignmentStrategy}, except the new segment will
+ * not be assigned to the instance with the least number of segments, but instead assigned to the next instance in a
+ * round-robin fashion. Rebalance with this strategy is identical to {@link BalancedNumSegmentAssignmentStrategy}
+ *
+ * When the number of instances increases, this is useful when we don't care about the existing
+ * segments as they might be removed later by the retention, or there are significantly unbalanced demands on newer
+ * segments. This strategy works better than {@link BalancedNumSegmentAssignmentStrategy} since it might need a
+ * bootstrap rebalance in this case
+ *
+ * The round-robin counter is maintained per table and stored in memory, and does not sync across controller instances,
+ * which means the segment assignment may not be strictly round-robin after controller restarts, and when there are
+ * multiple controllers assigning new segments.
+ */
+public class RoundRobinSegmentAssignmentStrategy extends BalancedNumSegmentAssignmentStrategy {
+  private static final Map<String, Integer> TABLE_ROUND_ROBIN_COUNTER = new ConcurrentHashMap<>();
+  private static final Random RANDOM = new Random();
+  private String _tableName;
+
+  @Override
+  public void init(HelixManager helixManager, TableConfig tableConfig) {
+    super.init(helixManager, tableConfig);
+    _tableName = tableConfig.getTableName();
+  }
+
+  @Override
+  public List<String> assignSegment(String segmentName, Map<String, Map<String, String>> currentAssignment,
+      InstancePartitions instancePartitions) {
+    validateSegmentAssignmentStrategy(instancePartitions);
+    List<String> instances =
+        SegmentAssignmentUtils.getInstancesForNonReplicaGroupBasedAssignment(instancePartitions, _replication);
+    List<String> assignedInstances = new ArrayList<>();
+    for (int i = 0; i < _replication; i++) {
+      int instanceId = TABLE_ROUND_ROBIN_COUNTER.compute(_tableName,
+          (key, value) -> value == null ? RANDOM.nextInt(instances.size()) : (value + 1) % instances.size());
+      assignedInstances.add(instances.get(instanceId));
+    }
+    return assignedInstances;
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/RoundRobinSegmentAssignmentStrategy.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/RoundRobinSegmentAssignmentStrategy.java
@@ -33,16 +33,17 @@ import org.apache.pinot.spi.config.table.TableConfig;
  * Segment assignment strategy class where segments are assigned in a round-robin fashion across available instances.
  * It can be used in the same scenarios as {@link BalancedNumSegmentAssignmentStrategy}, except the new segment will
  * not be assigned to the instance with the least number of segments, but instead assigned to the next instance in a
- * round-robin fashion. Rebalance with this strategy is identical to {@link BalancedNumSegmentAssignmentStrategy}
+ * round-robin fashion. Rebalance with this strategy is identical to {@link BalancedNumSegmentAssignmentStrategy}.
  *
- * When the number of instances increases, this is useful when we don't care about the existing
- * segments as they might be removed later by the retention, or there are significantly unbalanced demands on newer
- * segments. This strategy works better than {@link BalancedNumSegmentAssignmentStrategy} since it might need a
- * bootstrap rebalance in this case
+ * <p>When the number of instances increases, this is useful when we don't care about the existing segments as they
+ * might be removed later by retention, or there are significantly unbalanced demands on newer segments. This strategy
+ * works better than {@link BalancedNumSegmentAssignmentStrategy} since that strategy may require a bootstrap rebalance
+ * in this case. Note that bootstrap rebalances with this strategy are non-deterministic in ordering because the
+ * round-robin counter is not persisted.
  *
- * The round-robin counter is maintained per table and stored in memory, and does not sync across controller instances,
- * which means the segment assignment may not be strictly round-robin after controller restarts, and when there are
- * multiple controllers assigning new segments.
+ * <p>The round-robin counter is maintained per table in memory and does not sync across controller instances, which
+ * means segment assignment may not be strictly round-robin after controller restarts or when multiple controllers
+ * assign segments concurrently.
  */
 public class RoundRobinSegmentAssignmentStrategy extends BalancedNumSegmentAssignmentStrategy {
   private static final Map<String, Integer> TABLE_ROUND_ROBIN_COUNTER = new ConcurrentHashMap<>();
@@ -55,6 +56,10 @@ public class RoundRobinSegmentAssignmentStrategy extends BalancedNumSegmentAssig
     _tableName = tableConfig.getTableName();
   }
 
+  /**
+   * Assign the segment to the next n_replica instances from the current round-robin counter, and the counter increases
+   * regardless whether the segment is actually added to the ideal state or not.
+   */
   @Override
   public List<String> assignSegment(String segmentName, Map<String, Map<String, String>> currentAssignment,
       InstancePartitions instancePartitions) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/SegmentAssignmentStrategyFactory.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/SegmentAssignmentStrategyFactory.java
@@ -86,6 +86,12 @@ public class SegmentAssignmentStrategyFactory {
     } else {
       // Set segment assignment strategy depending on strategy set in table config
       switch (assignmentStrategy) {
+        case AssignmentStrategy.ROUND_ROBIN_SEGMENT_ASSIGNMENT_STRATEGY:
+          segmentAssignmentStrategy = new RoundRobinSegmentAssignmentStrategy();
+          break;
+        case AssignmentStrategy.ROUND_ROBIN_REPLICA_GROUP_SEGMENT_ASSIGNMENT_STRATEGY:
+          segmentAssignmentStrategy = new RoundRobinReplicaGroupSegmentAssignmentStrategy();
+          break;
         case AssignmentStrategy.REPLICA_GROUP_SEGMENT_ASSIGNMENT_STRATEGY:
           segmentAssignmentStrategy = new ReplicaGroupSegmentAssignmentStrategy();
           break;

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/RoundRobinReplicaGroupSegmentAssignmentStrategyTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/RoundRobinReplicaGroupSegmentAssignmentStrategyTest.java
@@ -1,0 +1,247 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core.assignment.segment.strategy;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import org.apache.helix.HelixManager;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.pinot.common.assignment.InstancePartitions;
+import org.apache.pinot.common.metadata.ZKMetadataProvider;
+import org.apache.pinot.common.metadata.segment.SegmentPartitionMetadata;
+import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
+import org.apache.pinot.controller.helix.core.assignment.segment.OfflineSegmentAssignment;
+import org.apache.pinot.controller.helix.core.assignment.segment.SegmentAssignment;
+import org.apache.pinot.controller.helix.core.assignment.segment.SegmentAssignmentFactory;
+import org.apache.pinot.controller.helix.core.assignment.segment.SegmentAssignmentTestUtils;
+import org.apache.pinot.controller.helix.core.assignment.segment.SegmentAssignmentUtils;
+import org.apache.pinot.segment.spi.partition.metadata.ColumnPartitionMetadata;
+import org.apache.pinot.spi.config.table.ReplicaGroupStrategyConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.config.table.assignment.InstancePartitionsType;
+import org.apache.pinot.spi.config.table.assignment.SegmentAssignmentConfig;
+import org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.SegmentStateModel;
+import org.apache.pinot.spi.utils.CommonConstants.Segment.AssignmentStrategy;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+
+@SuppressWarnings("unchecked")
+public class RoundRobinReplicaGroupSegmentAssignmentStrategyTest {
+  private static final int NUM_REPLICAS = 3;
+  private static final String SEGMENT_NAME_PREFIX = "segment_";
+  private static final int NUM_SEGMENTS = 12;
+  private static final List<String> SEGMENTS =
+      SegmentAssignmentTestUtils.getNameList(SEGMENT_NAME_PREFIX, NUM_SEGMENTS);
+  private static final String INSTANCE_NAME_PREFIX = "instance_";
+  private static final int NUM_INSTANCES = 18;
+  private static final List<String> INSTANCES =
+      SegmentAssignmentTestUtils.getNameList(INSTANCE_NAME_PREFIX, NUM_INSTANCES);
+  // Use unique table names to avoid counter interference with other test classes
+  private static final String RAW_TABLE_NAME_WITHOUT_PARTITION = "rrReplicaGroupTableWithoutPartition";
+  private static final String INSTANCE_PARTITIONS_NAME_WITHOUT_PARTITION =
+      InstancePartitionsType.OFFLINE.getInstancePartitionsName(RAW_TABLE_NAME_WITHOUT_PARTITION);
+  private static final String RAW_TABLE_NAME_WITH_PARTITION = "rrReplicaGroupTableWithPartition";
+  private static final String OFFLINE_TABLE_NAME_WITH_PARTITION =
+      TableNameBuilder.OFFLINE.tableNameWithType(RAW_TABLE_NAME_WITH_PARTITION);
+  private static final String INSTANCE_PARTITIONS_NAME_WITH_PARTITION =
+      InstancePartitionsType.OFFLINE.getInstancePartitionsName(RAW_TABLE_NAME_WITH_PARTITION);
+  private static final String PARTITION_COLUMN = "partitionColumn";
+  private static final int NUM_PARTITIONS = 3;
+
+  private SegmentAssignment _segmentAssignmentWithoutPartition;
+  private InstancePartitions _instancePartitionsWithoutPartition;
+  private Map<InstancePartitionsType, InstancePartitions> _instancePartitionsMapWithoutPartition;
+  private SegmentAssignment _segmentAssignmentWithPartition;
+  private InstancePartitions _instancePartitionsWithPartition;
+  private Map<InstancePartitionsType, InstancePartitions> _instancePartitionsMapWithPartition;
+
+  @BeforeClass
+  public void setUp() {
+    TableConfig tableConfigWithoutPartitions =
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME_WITHOUT_PARTITION)
+            .setNumReplicas(NUM_REPLICAS)
+            .setSegmentAssignmentConfigMap(Collections.singletonMap(InstancePartitionsType.OFFLINE.toString(),
+                new SegmentAssignmentConfig(
+                    AssignmentStrategy.ROUND_ROBIN_REPLICA_GROUP_SEGMENT_ASSIGNMENT_STRATEGY))).build();
+    _segmentAssignmentWithoutPartition =
+        SegmentAssignmentFactory.getSegmentAssignment(null, tableConfigWithoutPartitions, null);
+
+    // {
+    //   0_0=[instance_0, instance_1, instance_2, instance_3, instance_4, instance_5],
+    //   0_1=[instance_6, instance_7, instance_8, instance_9, instance_10, instance_11],
+    //   0_2=[instance_12, instance_13, instance_14, instance_15, instance_16, instance_17]
+    // }
+    _instancePartitionsWithoutPartition = new InstancePartitions(INSTANCE_PARTITIONS_NAME_WITHOUT_PARTITION);
+    int numInstancesPerReplicaGroup = NUM_INSTANCES / NUM_REPLICAS;
+    int instanceIdToAdd = 0;
+    for (int replicaGroupId = 0; replicaGroupId < NUM_REPLICAS; replicaGroupId++) {
+      List<String> instancesForReplicaGroup = new ArrayList<>(numInstancesPerReplicaGroup);
+      for (int i = 0; i < numInstancesPerReplicaGroup; i++) {
+        instancesForReplicaGroup.add(INSTANCES.get(instanceIdToAdd++));
+      }
+      _instancePartitionsWithoutPartition.setInstances(0, replicaGroupId, instancesForReplicaGroup);
+    }
+    _instancePartitionsMapWithoutPartition =
+        Collections.singletonMap(InstancePartitionsType.OFFLINE, _instancePartitionsWithoutPartition);
+
+    // Mock HelixManager for partition metadata
+    ZkHelixPropertyStore<ZNRecord> propertyStoreWithPartitions = mock(ZkHelixPropertyStore.class);
+    List<ZNRecord> segmentZKMetadataZNRecords = new ArrayList<>(NUM_SEGMENTS);
+    for (int segmentId = 0; segmentId < NUM_SEGMENTS; segmentId++) {
+      String segmentName = SEGMENTS.get(segmentId);
+      SegmentZKMetadata segmentZKMetadata = new SegmentZKMetadata(segmentName);
+      int partitionId = segmentId % NUM_PARTITIONS;
+      segmentZKMetadata.setPartitionMetadata(new SegmentPartitionMetadata(Collections.singletonMap(PARTITION_COLUMN,
+          new ColumnPartitionMetadata(null, NUM_PARTITIONS, Collections.singleton(partitionId), null))));
+      ZNRecord segmentZKMetadataZNRecord = segmentZKMetadata.toZNRecord();
+      when(propertyStoreWithPartitions.get(
+          eq(ZKMetadataProvider.constructPropertyStorePathForSegment(OFFLINE_TABLE_NAME_WITH_PARTITION, segmentName)),
+          any(), anyInt())).thenReturn(segmentZKMetadataZNRecord);
+      segmentZKMetadataZNRecords.add(segmentZKMetadataZNRecord);
+    }
+    when(propertyStoreWithPartitions
+        .getChildren(eq(ZKMetadataProvider.constructPropertyStorePathForResource(OFFLINE_TABLE_NAME_WITH_PARTITION)),
+            any(), anyInt(), anyInt(), anyInt())).thenReturn(segmentZKMetadataZNRecords);
+    HelixManager helixManagerWithPartitions = mock(HelixManager.class);
+    when(helixManagerWithPartitions.getHelixPropertyStore()).thenReturn(propertyStoreWithPartitions);
+
+    int numInstancesPerPartition = numInstancesPerReplicaGroup / NUM_PARTITIONS;
+    ReplicaGroupStrategyConfig replicaGroupStrategyConfig =
+        new ReplicaGroupStrategyConfig(PARTITION_COLUMN, numInstancesPerPartition);
+    TableConfig tableConfigWithPartitions =
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME_WITH_PARTITION)
+            .setNumReplicas(NUM_REPLICAS)
+            .setReplicaGroupStrategyConfig(replicaGroupStrategyConfig)
+            .setSegmentAssignmentConfigMap(Collections.singletonMap(InstancePartitionsType.OFFLINE.toString(),
+                new SegmentAssignmentConfig(
+                    AssignmentStrategy.ROUND_ROBIN_REPLICA_GROUP_SEGMENT_ASSIGNMENT_STRATEGY))).build();
+    _segmentAssignmentWithPartition =
+        SegmentAssignmentFactory.getSegmentAssignment(helixManagerWithPartitions, tableConfigWithPartitions, null);
+
+    // {
+    //   0_0=[instance_0, instance_1], 1_0=[instance_2, instance_3], 2_0=[instance_4, instance_5],
+    //   0_1=[instance_6, instance_7], 1_1=[instance_8, instance_9], 2_1=[instance_10, instance_11],
+    //   0_2=[instance_12, instance_13], 1_2=[instance_14, instance_15], 2_2=[instance_16, instance_17]
+    // }
+    _instancePartitionsWithPartition = new InstancePartitions(INSTANCE_PARTITIONS_NAME_WITH_PARTITION);
+    instanceIdToAdd = 0;
+    for (int replicaGroupId = 0; replicaGroupId < NUM_REPLICAS; replicaGroupId++) {
+      for (int partitionId = 0; partitionId < NUM_PARTITIONS; partitionId++) {
+        List<String> instancesForPartition = new ArrayList<>(numInstancesPerPartition);
+        for (int i = 0; i < numInstancesPerPartition; i++) {
+          instancesForPartition.add(INSTANCES.get(instanceIdToAdd++));
+        }
+        _instancePartitionsWithPartition.setInstances(partitionId, replicaGroupId, instancesForPartition);
+      }
+    }
+    _instancePartitionsMapWithPartition =
+        Collections.singletonMap(InstancePartitionsType.OFFLINE, _instancePartitionsWithPartition);
+  }
+
+  @Test
+  public void testFactory() {
+    assertTrue(_segmentAssignmentWithoutPartition instanceof OfflineSegmentAssignment);
+    assertTrue(_segmentAssignmentWithPartition instanceof OfflineSegmentAssignment);
+  }
+
+  @Test
+  public void testAssignSegmentWithoutPartition() {
+    int numInstancesPerReplicaGroup = NUM_INSTANCES / NUM_REPLICAS; // 6
+    Map<String, Map<String, String>> currentAssignment = new TreeMap<>();
+
+    // The counter initializes to a random value; derive the starting instanceId from the first result.
+    List<String> firstInstances = _segmentAssignmentWithoutPartition
+        .assignSegment(SEGMENTS.get(0), currentAssignment, _instancePartitionsMapWithoutPartition);
+    assertEquals(firstInstances.size(), NUM_REPLICAS);
+    // The counter advances once per segment. Each replica group contributes the instance at the same instanceId.
+    int startIdx = _instancePartitionsWithoutPartition.getInstances(0, 0).indexOf(firstInstances.get(0));
+    for (int rgId = 0; rgId < NUM_REPLICAS; rgId++) {
+      assertEquals(firstInstances.get(rgId),
+          _instancePartitionsWithoutPartition.getInstances(0, rgId).get(startIdx));
+    }
+    currentAssignment.put(SEGMENTS.get(0),
+        SegmentAssignmentUtils.getInstanceStateMap(firstInstances, SegmentStateModel.ONLINE));
+
+    // Each subsequent segment advances the instanceId by 1 within the replica group.
+    for (int segId = 1; segId < NUM_SEGMENTS; segId++) {
+      int expectedIdx = (startIdx + segId) % numInstancesPerReplicaGroup;
+      List<String> instances = _segmentAssignmentWithoutPartition
+          .assignSegment(SEGMENTS.get(segId), currentAssignment, _instancePartitionsMapWithoutPartition);
+      assertEquals(instances.size(), NUM_REPLICAS);
+      for (int rgId = 0; rgId < NUM_REPLICAS; rgId++) {
+        assertEquals(instances.get(rgId),
+            _instancePartitionsWithoutPartition.getInstances(0, rgId).get(expectedIdx));
+      }
+      currentAssignment.put(SEGMENTS.get(segId),
+          SegmentAssignmentUtils.getInstanceStateMap(instances, SegmentStateModel.ONLINE));
+    }
+  }
+
+  @Test
+  public void testAssignSegmentWithPartition() {
+    int numInstancesPerReplicaGroup = NUM_INSTANCES / NUM_REPLICAS; // 6
+    int numInstancesPerPartition = numInstancesPerReplicaGroup / NUM_PARTITIONS; // 2
+    Map<String, Map<String, String>> currentAssignment = new TreeMap<>();
+
+    // Each partition has its own independent counter, so track start and assignment count per partition.
+    int[] partitionStartIdx = new int[NUM_PARTITIONS];
+    Arrays.fill(partitionStartIdx, -1);
+    int[] partitionAssignmentCount = new int[NUM_PARTITIONS];
+
+    for (int segId = 0; segId < NUM_SEGMENTS; segId++) {
+      int partitionId = segId % NUM_PARTITIONS;
+      List<String> instances = _segmentAssignmentWithPartition
+          .assignSegment(SEGMENTS.get(segId), currentAssignment, _instancePartitionsMapWithPartition);
+      assertEquals(instances.size(), NUM_REPLICAS);
+
+      if (partitionStartIdx[partitionId] == -1) {
+        // First segment for this partition — observe the random starting index.
+        partitionStartIdx[partitionId] =
+            _instancePartitionsWithPartition.getInstances(partitionId, 0).indexOf(instances.get(0));
+      }
+      int expectedIdx =
+          (partitionStartIdx[partitionId] + partitionAssignmentCount[partitionId]) % numInstancesPerPartition;
+      partitionAssignmentCount[partitionId]++;
+
+      for (int rgId = 0; rgId < NUM_REPLICAS; rgId++) {
+        assertEquals(instances.get(rgId),
+            _instancePartitionsWithPartition.getInstances(partitionId, rgId).get(expectedIdx));
+      }
+      currentAssignment.put(SEGMENTS.get(segId),
+          SegmentAssignmentUtils.getInstanceStateMap(instances, SegmentStateModel.ONLINE));
+    }
+  }
+}

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/RoundRobinSegmentAssignmentStrategyTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/RoundRobinSegmentAssignmentStrategyTest.java
@@ -112,4 +112,32 @@ public class RoundRobinSegmentAssignmentStrategyTest {
           SegmentAssignmentUtils.getInstanceStateMap(instances, SegmentStateModel.ONLINE));
     }
   }
+
+  @Test
+  public void testAssignSegmentWithChangedInstanceCount() {
+    Map<String, Map<String, String>> currentAssignment = new TreeMap<>();
+
+    // Assign one segment to observe the current counter position
+    List<String> firstInstances =
+        _segmentAssignment.assignSegment("changeTest_0", currentAssignment, _instancePartitionsMap);
+    int prevInstanceId = INSTANCES.indexOf(firstInstances.get(0));
+
+    // Switch to a new instance list with a different count (7 instead of 10)
+    int newNumInstances = 7;
+    List<String> newInstances = SegmentAssignmentTestUtils.getNameList(INSTANCE_NAME_PREFIX, newNumInstances);
+    InstancePartitions newInstancePartitions = new InstancePartitions(INSTANCE_PARTITIONS_NAME);
+    newInstancePartitions.setInstances(0, 0, newInstances);
+    Map<InstancePartitionsType, InstancePartitions> newInstancePartitionsMap =
+        Collections.singletonMap(InstancePartitionsType.OFFLINE, newInstancePartitions);
+
+    // Counter after the first assignment is prevInstanceId. Next compute advances by NUM_REPLICAS modulo the new size.
+    int expectedStartIdx = (prevInstanceId + NUM_REPLICAS) % newNumInstances;
+    List<String> secondInstances =
+        _segmentAssignment.assignSegment("changeTest_1", currentAssignment, newInstancePartitionsMap);
+    assertEquals(secondInstances.size(), NUM_REPLICAS);
+    for (int r = 0; r < NUM_REPLICAS; r++) {
+      assertEquals(secondInstances.get(r),
+          newInstances.get((expectedStartIdx - r + newNumInstances) % newNumInstances));
+    }
+  }
 }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/RoundRobinSegmentAssignmentStrategyTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/RoundRobinSegmentAssignmentStrategyTest.java
@@ -93,7 +93,7 @@ public class RoundRobinSegmentAssignmentStrategyTest {
     // Counter advances once per replica, so replicas within each segment occupy consecutive instance slots.
     int startIdx = INSTANCES.indexOf(firstInstances.get(0));
     for (int r = 0; r < NUM_REPLICAS; r++) {
-      assertEquals(firstInstances.get(r), INSTANCES.get((startIdx + r) % NUM_INSTANCES));
+      assertEquals(firstInstances.get(r), INSTANCES.get((startIdx - r + NUM_INSTANCES) % NUM_INSTANCES));
     }
     currentAssignment.put(SEGMENTS.get(0),
         SegmentAssignmentUtils.getInstanceStateMap(firstInstances, SegmentStateModel.ONLINE));
@@ -105,7 +105,7 @@ public class RoundRobinSegmentAssignmentStrategyTest {
           _segmentAssignment.assignSegment(SEGMENTS.get(segId), currentAssignment, _instancePartitionsMap);
       assertEquals(instances.size(), NUM_REPLICAS);
       for (int r = 0; r < NUM_REPLICAS; r++) {
-        assertEquals(instances.get(r), INSTANCES.get((nextIdx + r) % NUM_INSTANCES));
+        assertEquals(instances.get(r), INSTANCES.get((nextIdx - r + NUM_INSTANCES) % NUM_INSTANCES));
       }
       nextIdx = (nextIdx + NUM_REPLICAS) % NUM_INSTANCES;
       currentAssignment.put(SEGMENTS.get(segId),

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/RoundRobinSegmentAssignmentStrategyTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/RoundRobinSegmentAssignmentStrategyTest.java
@@ -1,0 +1,115 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core.assignment.segment.strategy;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import org.apache.pinot.common.assignment.InstancePartitions;
+import org.apache.pinot.controller.helix.core.assignment.segment.OfflineSegmentAssignment;
+import org.apache.pinot.controller.helix.core.assignment.segment.SegmentAssignment;
+import org.apache.pinot.controller.helix.core.assignment.segment.SegmentAssignmentFactory;
+import org.apache.pinot.controller.helix.core.assignment.segment.SegmentAssignmentTestUtils;
+import org.apache.pinot.controller.helix.core.assignment.segment.SegmentAssignmentUtils;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.config.table.assignment.InstancePartitionsType;
+import org.apache.pinot.spi.config.table.assignment.SegmentAssignmentConfig;
+import org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.SegmentStateModel;
+import org.apache.pinot.spi.utils.CommonConstants.Segment.AssignmentStrategy;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+
+public class RoundRobinSegmentAssignmentStrategyTest {
+  private static final int NUM_REPLICAS = 3;
+  private static final String SEGMENT_NAME_PREFIX = "segment_";
+  private static final int NUM_SEGMENTS = 100;
+  private static final List<String> SEGMENTS =
+      SegmentAssignmentTestUtils.getNameList(SEGMENT_NAME_PREFIX, NUM_SEGMENTS);
+  private static final String INSTANCE_NAME_PREFIX = "instance_";
+  private static final int NUM_INSTANCES = 10;
+  private static final List<String> INSTANCES =
+      SegmentAssignmentTestUtils.getNameList(INSTANCE_NAME_PREFIX, NUM_INSTANCES);
+  // Use a unique table name to avoid counter interference with other test classes
+  private static final String RAW_TABLE_NAME = "roundRobinAssignmentTable";
+  private static final String INSTANCE_PARTITIONS_NAME =
+      InstancePartitionsType.OFFLINE.getInstancePartitionsName(RAW_TABLE_NAME);
+
+  private SegmentAssignment _segmentAssignment;
+  private Map<InstancePartitionsType, InstancePartitions> _instancePartitionsMap;
+
+  @BeforeClass
+  public void setUp() {
+    TableConfig tableConfig =
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).setNumReplicas(NUM_REPLICAS)
+            .setSegmentAssignmentConfigMap(Collections.singletonMap(InstancePartitionsType.OFFLINE.toString(),
+                new SegmentAssignmentConfig(AssignmentStrategy.ROUND_ROBIN_SEGMENT_ASSIGNMENT_STRATEGY))).build();
+    _segmentAssignment = SegmentAssignmentFactory.getSegmentAssignment(null, tableConfig, null);
+
+    // {
+    //   0_0=[instance_0, instance_1, instance_2, instance_3, instance_4, instance_5, instance_6, instance_7,
+    //   instance_8, instance_9]
+    // }
+    InstancePartitions instancePartitions = new InstancePartitions(INSTANCE_PARTITIONS_NAME);
+    instancePartitions.setInstances(0, 0, INSTANCES);
+    _instancePartitionsMap = Collections.singletonMap(InstancePartitionsType.OFFLINE, instancePartitions);
+  }
+
+  @Test
+  public void testFactory() {
+    assertTrue(_segmentAssignment instanceof OfflineSegmentAssignment);
+  }
+
+  @Test
+  public void testAssignSegment() {
+    Map<String, Map<String, String>> currentAssignment = new TreeMap<>();
+
+    // The counter initializes to a random starting value, so derive the start from the first observed result.
+    List<String> firstInstances =
+        _segmentAssignment.assignSegment(SEGMENTS.get(0), currentAssignment, _instancePartitionsMap);
+    assertEquals(firstInstances.size(), NUM_REPLICAS);
+    // Counter advances once per replica, so replicas within each segment occupy consecutive instance slots.
+    int startIdx = INSTANCES.indexOf(firstInstances.get(0));
+    for (int r = 0; r < NUM_REPLICAS; r++) {
+      assertEquals(firstInstances.get(r), INSTANCES.get((startIdx + r) % NUM_INSTANCES));
+    }
+    currentAssignment.put(SEGMENTS.get(0),
+        SegmentAssignmentUtils.getInstanceStateMap(firstInstances, SegmentStateModel.ONLINE));
+
+    // Each subsequent segment begins exactly where the previous segment's last replica left off.
+    int nextIdx = (startIdx + NUM_REPLICAS) % NUM_INSTANCES;
+    for (int segId = 1; segId < NUM_SEGMENTS; segId++) {
+      List<String> instances =
+          _segmentAssignment.assignSegment(SEGMENTS.get(segId), currentAssignment, _instancePartitionsMap);
+      assertEquals(instances.size(), NUM_REPLICAS);
+      for (int r = 0; r < NUM_REPLICAS; r++) {
+        assertEquals(instances.get(r), INSTANCES.get((nextIdx + r) % NUM_INSTANCES));
+      }
+      nextIdx = (nextIdx + NUM_REPLICAS) % NUM_INSTANCES;
+      currentAssignment.put(SEGMENTS.get(segId),
+          SegmentAssignmentUtils.getInstanceStateMap(instances, SegmentStateModel.ONLINE));
+    }
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -1954,7 +1954,9 @@ public class CommonConstants {
 
     public static class AssignmentStrategy {
       public static final String BALANCE_NUM_SEGMENT_ASSIGNMENT_STRATEGY = "balanced";
+      public static final String ROUND_ROBIN_SEGMENT_ASSIGNMENT_STRATEGY = "roundrobin";
       public static final String REPLICA_GROUP_SEGMENT_ASSIGNMENT_STRATEGY = "replicagroup";
+      public static final String ROUND_ROBIN_REPLICA_GROUP_SEGMENT_ASSIGNMENT_STRATEGY = "roundrobinreplicagroup";
       public static final String DIM_TABLE_SEGMENT_ASSIGNMENT_STRATEGY = "allservers";
     }
 


### PR DESCRIPTION
## Description
Sometimes when we add instances, the current segment assignment strategies fail to distribute the new segments in a desired balanced way. Generally, all new segments will go to the new instances since they have the least instances, and the current `BalancedNumSegmentAssignmentStrategy` and `ReplicaGroupSegmentAssignmentStrategy` both assign new segments to the instances with the least segments.

This creates a potential skew if new segments are in a higher demand, where new instances instantly become hotspot. Solution will be a bootstrap rebalance, which can be expensive. In such a case, we don't care about the existing segments and we just need the newly added segments to be evenly distributed.

The newly added round-robin based segment assignment strategies would have a better fit for these cases. Notice that these two new strategies didn't introduce new behavior of rebalancing segments, only provides new strategies to new segment assignment (the `assignSegment()` interface, not `reassignSegments()`)

## Change
### New class `RoundRobinSegmentAssignmentStrategy`
This inherits from `BalancedNumSegmentAssignmentStrategy`, and override the `assignSegment(String segmentName, Map<String, Map<String, String>> currentAssignment,  InstancePartitions instancePartitions)` method.

While assigning new segments, instead of picking the instance that has the least segments across all matched instances, it picks the next `n_replica` instances in a round-robin manner.

Any table that uses `BalancedNumSegmentAssignmentStrategy` can switch to `RoundRobinSegmentAssignmentStrategy`. A non-bootstrap rebalance using this strategy will have the same outcome as using `BalancedNumSegmentAssignmentStrategy`


### New class `RoundRobinReplicaGroupSegmentAssignmentStrategy`
This inherits from `ReplicaGroupSegmentAssignmentStrategy`, and override the `assignSegment(String segmentName, Map<String, Map<String, String>> currentAssignment,  InstancePartitions instancePartitions)` method.

While assigning new segments, instead of picking the instance that has the least segments within each replica group, it picks the next instance in a round-robin manner.

Any table that uses `ReplicaGroupSegmentAssignmentStrategy` can switch to `RoundRobinReplicaGroupSegmentAssignmentStrategy`. A non-bootstrap rebalance using this strategy will have the same outcome as using `ReplicaGroupSegmentAssignmentStrategy`

## Limitation

The round-robin counter states are not shared among controller instances, all counter states are in-memory. That means the round-robin is not strictly enforced when multiple controller instances are to assign segments to the same table (this includes controller instance restarts). The initial value of the round-robin counter is randomly picked to best reduce the skew if we have multiple controller instances.

This is acceptable since the skewness (`max_n_assigned - min_n_assigned <= n_controller_instances`) is much smaller than the number of segments. There's no need to do extra engineering to ensure the strict round-robin.

## Configuration

In table config:
```json
{
    ...
    "segmentAssignmentConfigMap": {
        "OFFLINE": {
            "segmentAssignmentStrategy": "roundRobin"
        }
    }
}
```

or 

```json
{
    ...
    "segmentAssignmentConfigMap": {
        "OFFLINE": {
            "segmentAssignmentStrategy": "roundRobinReplicaGroup"
        }
    }
}
```