### PR TITLE
Add POST /query/sql/validateSyntax broker endpoint

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotClientRequest.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotClientRequest.java
@@ -246,6 +246,43 @@ public class PinotClientRequest {
     }
   }
 
+  @POST
+  @Produces(MediaType.APPLICATION_JSON)
+  @Path("query/sql/validateSyntax")
+  @ApiOperation(value = "Validate the syntax of a SQL query without executing it",
+      notes = "Parses the query using Pinot's Calcite-based SQL parser. No table metadata or "
+          + "schema validation is performed, and the query is not executed. Supports both "
+          + "single-stage and multi-stage queries. Returns HTTP 200 in both the valid and invalid "
+          + "cases; clients should inspect the `valid` field of the response body.")
+  @ApiResponses(value = {
+      @ApiResponse(code = 200, message = "Syntax validation result"),
+      @ApiResponse(code = 400, message = "Bad Request"),
+      @ApiResponse(code = 500, message = "Internal Server Error")
+  })
+  @ManualAuthorization
+  public Response validateSqlSyntax(String query,
+      @Context org.glassfish.grizzly.http.server.Request requestContext,
+      @Context HttpHeaders httpHeaders) {
+    try {
+      JsonNode requestJson = JsonUtils.stringToJsonNode(query);
+      if (!requestJson.has(Request.SQL)) {
+        return Response.status(Response.Status.BAD_REQUEST)
+            .entity("{\"error\": \"Payload is missing the query string field 'sql'\"}")
+            .build();
+      }
+      return Response.ok(validateSqlSyntax((ObjectNode) requestJson)).build();
+    } catch (WebApplicationException wae) {
+      _brokerMetrics.addMeteredGlobalValue(BrokerMeter.WEB_APPLICATION_EXCEPTIONS, 1L);
+      throw wae;
+    } catch (Exception e) {
+      LOGGER.error("Caught exception while validating SQL syntax for POST request", e);
+      _brokerMetrics.addMeteredGlobalValue(BrokerMeter.UNCAUGHT_POST_EXCEPTIONS, 1L);
+      return Response.status(Response.Status.INTERNAL_SERVER_ERROR)
+          .entity("{\"error\": \"" + e.getMessage() + "\"}")
+          .build();
+    }
+  }
+
   @GET
   @ManagedAsync
   @Produces(MediaType.APPLICATION_JSON)
@@ -616,6 +653,17 @@ public class PinotClientRequest {
         }
       default:
         return new BrokerResponseNative(QueryErrorCode.SQL_PARSING, "Unsupported SQL type - " + sqlType);
+    }
+  }
+
+  @VisibleForTesting
+  SqlSyntaxValidationResponse validateSqlSyntax(ObjectNode sqlRequestJson) {
+    try {
+      SqlNodeAndOptions sqlNodeAndOptions =
+          RequestUtils.parseQuery(sqlRequestJson.get(Request.SQL).asText(), sqlRequestJson);
+      return SqlSyntaxValidationResponse.valid(sqlNodeAndOptions.getSqlType().name());
+    } catch (Exception e) {
+      return SqlSyntaxValidationResponse.invalid(e.getMessage());
     }
   }
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/SqlSyntaxValidationResponse.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/SqlSyntaxValidationResponse.java
@@ -1,0 +1,61 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.api.resources;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+
+
+/**
+ * Response for the {@code POST /query/sql/validateSyntax} broker endpoint. Reports whether a SQL
+ * query was accepted by Pinot's Calcite-based parser, along with an error message when parsing
+ * failed.
+ */
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class SqlSyntaxValidationResponse {
+
+  private final boolean _valid;
+  private final String _sqlType;
+  private final String _errorMessage;
+
+  public SqlSyntaxValidationResponse(boolean valid, String sqlType, String errorMessage) {
+    _valid = valid;
+    _sqlType = sqlType;
+    _errorMessage = errorMessage;
+  }
+
+  public static SqlSyntaxValidationResponse valid(String sqlType) {
+    return new SqlSyntaxValidationResponse(true, sqlType, null);
+  }
+
+  public static SqlSyntaxValidationResponse invalid(String errorMessage) {
+    return new SqlSyntaxValidationResponse(false, null, errorMessage);
+  }
+
+  public boolean isValid() {
+    return _valid;
+  }
+
+  public String getSqlType() {
+    return _sqlType;
+  }
+
+  public String getErrorMessage() {
+    return _errorMessage;
+  }
+}

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/api/resources/PinotClientRequestTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/api/resources/PinotClientRequestTest.java
@@ -281,6 +281,65 @@ public class PinotClientRequestTest {
   }
 
   @Test
+  public void testValidateSqlSyntaxSingleStage() throws Exception {
+    Request request = mock(Request.class);
+    when(request.getRequestURL()).thenReturn(new StringBuilder());
+
+    String requestJson = "{\"sql\": \"SELECT * FROM myTable WHERE id > 10\"}";
+    Response response = _pinotClientRequest.validateSqlSyntax(requestJson, request, null);
+
+    assertEquals(response.getStatus(), Response.Status.OK.getStatusCode());
+    SqlSyntaxValidationResponse body = (SqlSyntaxValidationResponse) response.getEntity();
+    Assert.assertTrue(body.isValid(), "Valid single-stage query should parse successfully");
+    assertEquals(body.getSqlType(), "DQL");
+    Assert.assertNull(body.getErrorMessage());
+  }
+
+  @Test
+  public void testValidateSqlSyntaxMultiStage() throws Exception {
+    Request request = mock(Request.class);
+    when(request.getRequestURL()).thenReturn(new StringBuilder());
+
+    String requestJson = "{\"sql\": \"SET useMultistageEngine=true; \\n"
+        + "SELECT * FROM t1 LEFT JOIN t2 ON t1.id = t2.id WHERE t1.col1 > 100\"}";
+    Response response = _pinotClientRequest.validateSqlSyntax(requestJson, request, null);
+
+    assertEquals(response.getStatus(), Response.Status.OK.getStatusCode());
+    SqlSyntaxValidationResponse body = (SqlSyntaxValidationResponse) response.getEntity();
+    Assert.assertTrue(body.isValid(), "Valid multi-stage query should parse successfully");
+    assertEquals(body.getSqlType(), "DQL");
+    Assert.assertNull(body.getErrorMessage());
+  }
+
+  @Test
+  public void testValidateSqlSyntaxWithInvalidSql() throws Exception {
+    Request request = mock(Request.class);
+    when(request.getRequestURL()).thenReturn(new StringBuilder());
+
+    String requestJson = "{\"sql\": \"SELECT FROM WHERE\"}";
+    Response response = _pinotClientRequest.validateSqlSyntax(requestJson, request, null);
+
+    assertEquals(response.getStatus(), Response.Status.OK.getStatusCode(),
+        "Invalid SQL should still return HTTP 200 with valid=false in body");
+    SqlSyntaxValidationResponse body = (SqlSyntaxValidationResponse) response.getEntity();
+    assertFalse(body.isValid(), "Unparseable query should report valid=false");
+    Assert.assertNull(body.getSqlType());
+    Assert.assertNotNull(body.getErrorMessage(), "Failed validation should include an error message");
+  }
+
+  @Test
+  public void testValidateSqlSyntaxMissingSqlField() throws Exception {
+    Request request = mock(Request.class);
+    when(request.getRequestURL()).thenReturn(new StringBuilder());
+
+    String requestJson = "{\"notSql\": \"SELECT * FROM myTable\"}";
+    Response response = _pinotClientRequest.validateSqlSyntax(requestJson, request, null);
+
+    assertEquals(response.getStatus(), Response.Status.BAD_REQUEST.getStatusCode(),
+        "Payload missing the 'sql' field should return BAD_REQUEST");
+  }
+
+  @Test
   public void testQueryResponseSizeMetric()
       throws Exception {
     // Create a broker response with some result data


### PR DESCRIPTION
## Summary

Adds a lightweight, parse-only syntax validation endpoint to the broker, as proposed in #17615.

The new `POST /query/sql/validateSyntax` endpoint runs the query through Pinot's Calcite-based SQL parser (`RequestUtils.parseQuery`) without consulting table metadata, performing semantic validation, or executing the query. It supports both single-stage and multi-stage queries and all `PinotSqlType` values (DQL/DML/DDL/DCL).

## Motivation

Per #17615: Calcite upgrades occasionally introduce new reserved keywords that cause parse failures against previously-valid queries (see #16295 for a prior incident). This endpoint lets operators replay a corpus of queries against a canary broker to detect parser regressions *before* rolling a new Calcite version into production, without needing any table setup, schema, or query execution.

There are related endpoints, but none solve this use case:
- `POST /query/sql/queryFingerprint` (broker) — parses but also generates a fingerprint, and only accepts DQL.
- `POST /validateMultiStageQuery` (controller) — does more than parsing and is multi-stage-only.

## Contract

Request:
```json
POST /query/sql/validateSyntax
{"sql": "SELECT * FROM t WHERE id > 10"}
```

Response (valid):
```json
200 OK
{"valid": true, "sqlType": "DQL"}
```

Response (invalid syntax):
```json
200 OK
{"valid": false, "errorMessage": "..."}
```

Response (missing `sql` field):
```json
400 Bad Request
{"error": "Payload is missing the query string field 'sql'"}
```

Design note: both valid and invalid parse outcomes return HTTP 200 with the result in the body. This keeps clients from having to distinguish transport errors from parse errors when replaying query corpuses at scale. 4xx/5xx are reserved for malformed requests and uncaught server errors.

## Changes

- `pinot-broker/.../PinotClientRequest.java` — new endpoint method and private `validateSqlSyntax(ObjectNode)` helper.
- `pinot-broker/.../SqlSyntaxValidationResponse.java` — new response POJO with `valid` / `sqlType` / `errorMessage` fields.
- `pinot-broker/.../PinotClientRequestTest.java` — tests for single-stage valid, multi-stage valid, invalid syntax, and missing `sql` field.

## Test plan

- [x] Unit tests for single-stage valid query (returns DQL, no error)
- [x] Unit tests for multi-stage valid query (`SET useMultistageEngine=true; ...`)
- [x] Unit tests for invalid SQL (`SELECT FROM WHERE`) — 200 OK with `valid=false` and error message
- [x] Unit tests for missing `sql` field — 400 Bad Request
- [ ] Manual smoke test against a running broker (reviewer discretion)

Closes #17615