### PR TITLE
Make lineage retention periods configurable via table config

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/lineage/DefaultLineageManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/lineage/DefaultLineageManager.java
@@ -77,10 +77,10 @@ public class DefaultLineageManager implements LineageManager {
     String tableNameWithType = tableConfig.getTableName();
     long lineageCleanupRetentionMs = getRetentionMsFromConfig(
         tableConfig.getValidationConfig().getLineageEntryCleanupRetentionPeriod(),
-        LINEAGE_ENTRY_CLEANUP_RETENTION_IN_MILLIS, tableNameWithType);
+        LINEAGE_ENTRY_CLEANUP_RETENTION_IN_MILLIS, tableNameWithType, "lineageEntryCleanupRetentionPeriod");
     long replacedSegmentsRetentionMs = getRetentionMsFromConfig(
         tableConfig.getValidationConfig().getReplacedSegmentsRetentionPeriod(),
-        REPLACED_SEGMENTS_RETENTION_IN_MILLIS, tableNameWithType);
+        REPLACED_SEGMENTS_RETENTION_IN_MILLIS, tableNameWithType, "replacedSegmentsRetentionPeriod");
     Set<String> segmentsForTable = new HashSet<>(allSegments);
     Iterator<LineageEntry> lineageEntryIterator = lineage.getLineageEntries().values().iterator();
     while (lineageEntryIterator.hasNext()) {
@@ -122,12 +122,14 @@ public class DefaultLineageManager implements LineageManager {
   /**
    * Helper function to decide whether we should delete segmentsFrom (replaced segments) given a lineage entry.
    *
-   * The replaced segments are safe to delete if the following conditions are all satisfied
-   * 1) Table is "APPEND"
-   * 2) It has been more than 24 hours since the lineage entry became "COMPLETED" state.
+   * The replaced segments are safe to delete if either:
+   * 1) The table is not "REFRESH" (e.g. "APPEND"), in which case they are deleted immediately, or
+   * 2) The lineage entry has been in "COMPLETED" state for longer than {@code replacedSegmentsRetentionMs}
+   *    (configurable via {@code replacedSegmentsRetentionPeriod} in table config, defaulting to 1 day).
    *
    * @param tableConfig a table config
    * @param lineageEntry lineage entry
+   * @param replacedSegmentsRetentionMs configured retention in ms for replaced segments
    * @return True if we can safely delete the replaced segments. False otherwise.
    */
   private boolean shouldDeleteReplacedSegments(TableConfig tableConfig, LineageEntry lineageEntry,
@@ -141,18 +143,19 @@ public class DefaultLineageManager implements LineageManager {
     return lineageEntry.getTimestamp() < (System.currentTimeMillis() - replacedSegmentsRetentionMs);
   }
 
-  private static long getRetentionMsFromConfig(@Nullable String period, long defaultMs, String tableNameWithType) {
+  private static long getRetentionMsFromConfig(@Nullable String period, long defaultMs, String tableNameWithType,
+      String configFieldName) {
     if (!StringUtils.isEmpty(period)) {
       try {
         long ms = TimeUtils.convertPeriodToMillis(period);
-        if (ms == 0) {
-          LOGGER.warn("Retention period '{}' resolves to 0ms for table: {}: replaced/zombie segments will be deleted "
-              + "immediately with no rollback window", period, tableNameWithType);
+        if (ms <= 0) {
+          LOGGER.warn("Retention period '{}' for config field '{}' resolves to {}ms for table: {}: cleanup will run "
+              + "immediately with no rollback window", period, configFieldName, ms, tableNameWithType);
         }
         return ms;
       } catch (Exception e) {
-        LOGGER.warn("Unable to parse retention period: {} for table: {}, using default: {}ms", period,
-            tableNameWithType, defaultMs);
+        LOGGER.warn("Unable to parse retention period '{}' for config field '{}' on table: {}, using default: {}ms",
+            period, configFieldName, tableNameWithType, defaultMs);
       }
     }
     return defaultMs;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/lineage/DefaultLineageManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/lineage/DefaultLineageManager.java
@@ -140,6 +140,8 @@ public class DefaultLineageManager implements LineageManager {
     if (!batchSegmentIngestionType.equalsIgnoreCase("REFRESH")) {
       return true;
     }
+    // Strict < means a 0ms retention won't delete on the exact same millisecond; this is intentional to
+    // avoid edge-case races and is consistent with the existing behavior for non-zero retention values.
     return lineageEntry.getTimestamp() < (System.currentTimeMillis() - replacedSegmentsRetentionMs);
   }
 
@@ -149,7 +151,7 @@ public class DefaultLineageManager implements LineageManager {
       try {
         long ms = TimeUtils.convertPeriodToMillis(period);
         if (ms <= 0) {
-          LOGGER.warn("Retention period '{}' for config field '{}' resolves to {}ms for table: {}: cleanup will run "
+          LOGGER.debug("Retention period '{}' for config field '{}' resolves to {}ms for table: {}: cleanup will run "
               + "immediately with no rollback window", period, configFieldName, ms, tableNameWithType);
         }
         return ms;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/lineage/DefaultLineageManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/lineage/DefaultLineageManager.java
@@ -24,15 +24,21 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.lineage.LineageEntry;
 import org.apache.pinot.common.lineage.LineageEntryState;
 import org.apache.pinot.common.lineage.SegmentLineage;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.utils.IngestionConfigUtils;
+import org.apache.pinot.spi.utils.TimeUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public class DefaultLineageManager implements LineageManager {
+  private static final Logger LOGGER = LoggerFactory.getLogger(DefaultLineageManager.class);
   private static final long REPLACED_SEGMENTS_RETENTION_IN_MILLIS = TimeUnit.DAYS.toMillis(1L); // 1 day
   private static final long LINEAGE_ENTRY_CLEANUP_RETENTION_IN_MILLIS = TimeUnit.DAYS.toMillis(1L); // 1 day
 
@@ -68,6 +74,13 @@ public class DefaultLineageManager implements LineageManager {
     // 1. The original segments can be deleted once the merged segments are successfully uploaded
     // 2. The zombie lineage entry & merged segments should be deleted if the segment replacement failed in
     //    the middle
+    String tableNameWithType = tableConfig.getTableName();
+    long lineageCleanupRetentionMs = getRetentionMsFromConfig(
+        tableConfig.getValidationConfig().getLineageEntryCleanupRetentionPeriod(),
+        LINEAGE_ENTRY_CLEANUP_RETENTION_IN_MILLIS, tableNameWithType);
+    long replacedSegmentsRetentionMs = getRetentionMsFromConfig(
+        tableConfig.getValidationConfig().getReplacedSegmentsRetentionPeriod(),
+        REPLACED_SEGMENTS_RETENTION_IN_MILLIS, tableNameWithType);
     Set<String> segmentsForTable = new HashSet<>(allSegments);
     Iterator<LineageEntry> lineageEntryIterator = lineage.getLineageEntries().values().iterator();
     while (lineageEntryIterator.hasNext()) {
@@ -81,13 +94,13 @@ public class DefaultLineageManager implements LineageManager {
         } else {
           // If the lineage state is 'COMPLETED' and we already preserved the original segments for the required
           // retention, it is safe to delete all segments from 'segmentsFrom'
-          if (shouldDeleteReplacedSegments(tableConfig, lineageEntry)) {
+          if (shouldDeleteReplacedSegments(tableConfig, lineageEntry, replacedSegmentsRetentionMs)) {
             segmentsToDelete.addAll(sourceSegments);
           }
         }
       } else if (lineageEntry.getState() == LineageEntryState.REVERTED || (
           lineageEntry.getState() == LineageEntryState.IN_PROGRESS && lineageEntry.getTimestamp()
-              < System.currentTimeMillis() - LINEAGE_ENTRY_CLEANUP_RETENTION_IN_MILLIS)) {
+              < System.currentTimeMillis() - lineageCleanupRetentionMs)) {
         // If the lineage state is 'IN_PROGRESS' or 'REVERTED', we need to clean up the zombie lineage
         // entry and its segments
         Set<String> destinationSegments = new HashSet<>(lineageEntry.getSegmentsTo());
@@ -117,14 +130,31 @@ public class DefaultLineageManager implements LineageManager {
    * @param lineageEntry lineage entry
    * @return True if we can safely delete the replaced segments. False otherwise.
    */
-  private boolean shouldDeleteReplacedSegments(TableConfig tableConfig, LineageEntry lineageEntry) {
-    // TODO: Currently, we preserve the replaced segments for 1 day for REFRESH tables only. Once we support
+  private boolean shouldDeleteReplacedSegments(TableConfig tableConfig, LineageEntry lineageEntry,
+      long replacedSegmentsRetentionMs) {
+    // TODO: Currently, we preserve the replaced segments for REFRESH tables only. Once we support
     // data rollback for APPEND tables, we should remove this check.
     String batchSegmentIngestionType = IngestionConfigUtils.getBatchSegmentIngestionType(tableConfig);
-    if (!batchSegmentIngestionType.equalsIgnoreCase("REFRESH")
-        || lineageEntry.getTimestamp() < System.currentTimeMillis() - REPLACED_SEGMENTS_RETENTION_IN_MILLIS) {
+    if (!batchSegmentIngestionType.equalsIgnoreCase("REFRESH")) {
       return true;
     }
-    return false;
+    return lineageEntry.getTimestamp() < (System.currentTimeMillis() - replacedSegmentsRetentionMs);
+  }
+
+  private static long getRetentionMsFromConfig(@Nullable String period, long defaultMs, String tableNameWithType) {
+    if (!StringUtils.isEmpty(period)) {
+      try {
+        long ms = TimeUtils.convertPeriodToMillis(period);
+        if (ms == 0) {
+          LOGGER.warn("Retention period '{}' resolves to 0ms for table: {}: replaced/zombie segments will be deleted "
+              + "immediately with no rollback window", period, tableNameWithType);
+        }
+        return ms;
+      } catch (Exception e) {
+        LOGGER.warn("Unable to parse retention period: {} for table: {}, using default: {}ms", period,
+            tableNameWithType, defaultMs);
+      }
+    }
+    return defaultMs;
   }
 }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/lineage/DefaultLineageManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/lineage/DefaultLineageManagerTest.java
@@ -239,4 +239,47 @@ public class DefaultLineageManagerTest {
     assertTrue(segmentsToDelete.contains("dst1"),
         "Destination segment must be deleted immediately when lineageEntryCleanupRetentionPeriod is 0d");
   }
+
+  // ---------------------------------------------------------------------------
+  // Unparseable retention period falls back to 1-day default
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void testUnparseableReplacedRetentionFallsBackToDefault() {
+    // An invalid period string should fall back to the 1-day default, so a recently-completed entry must NOT delete
+    TableConfig tableConfig = refreshTableBuilder().setReplacedSegmentsRetentionPeriod("foo").build();
+
+    String entryId = UUID.randomUUID().toString();
+    long recentTimestamp = System.currentTimeMillis();
+    SegmentLineage lineage = new SegmentLineage("testTable_OFFLINE");
+    lineage.addLineageEntry(entryId,
+        new LineageEntry(Arrays.asList("src1"), Arrays.asList("dst1"), LineageEntryState.COMPLETED, recentTimestamp));
+
+    List<String> segmentsToDelete = new ArrayList<>();
+    _lineageManager.updateLineageForRetention(tableConfig, lineage, Arrays.asList("src1", "dst1"), segmentsToDelete,
+        new HashSet<>());
+
+    assertFalse(segmentsToDelete.contains("src1"),
+        "Unparseable replacedSegmentsRetentionPeriod must fall back to 1-day default");
+  }
+
+  @Test
+  public void testUnparseableLineageCleanupRetentionFallsBackToDefault() {
+    // An invalid period string should fall back to the 1-day default, so a recent IN_PROGRESS entry must NOT delete
+    TableConfig tableConfig = refreshTableBuilder().setLineageEntryCleanupRetentionPeriod("notaperiod").build();
+
+    String entryId = UUID.randomUUID().toString();
+    long recentTimestamp = System.currentTimeMillis();
+    SegmentLineage lineage = new SegmentLineage("testTable_OFFLINE");
+    lineage.addLineageEntry(entryId,
+        new LineageEntry(Collections.emptyList(), Arrays.asList("dst1"), LineageEntryState.IN_PROGRESS,
+            recentTimestamp));
+
+    List<String> segmentsToDelete = new ArrayList<>();
+    _lineageManager.updateLineageForRetention(tableConfig, lineage, Arrays.asList("dst1"), segmentsToDelete,
+        new HashSet<>());
+
+    assertFalse(segmentsToDelete.contains("dst1"),
+        "Unparseable lineageEntryCleanupRetentionPeriod must fall back to 1-day default");
+  }
 }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/lineage/DefaultLineageManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/lineage/DefaultLineageManagerTest.java
@@ -1,0 +1,242 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core.lineage;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.UUID;
+import org.apache.pinot.common.lineage.LineageEntry;
+import org.apache.pinot.common.lineage.LineageEntryState;
+import org.apache.pinot.common.lineage.SegmentLineage;
+import org.apache.pinot.controller.ControllerConf;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.config.table.ingestion.BatchIngestionConfig;
+import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.mockito.Mockito;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+
+public class DefaultLineageManagerTest {
+  private DefaultLineageManager _lineageManager;
+
+  @BeforeMethod
+  public void setUp() {
+    _lineageManager = new DefaultLineageManager(Mockito.mock(ControllerConf.class));
+  }
+
+  private TableConfigBuilder refreshTableBuilder() {
+    IngestionConfig ingestionConfig = new IngestionConfig();
+    ingestionConfig.setBatchIngestionConfig(new BatchIngestionConfig(null, "REFRESH", "DAILY", false));
+    return new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable_OFFLINE")
+        .setIngestionConfig(ingestionConfig);
+  }
+
+  private TableConfigBuilder appendTableBuilder() {
+    IngestionConfig ingestionConfig = new IngestionConfig();
+    ingestionConfig.setBatchIngestionConfig(new BatchIngestionConfig(null, "APPEND", "DAILY", false));
+    return new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable_OFFLINE")
+        .setIngestionConfig(ingestionConfig);
+  }
+
+  // ---------------------------------------------------------------------------
+  // JSON round-trip: verify field names deserialize correctly
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void testNewFieldsRoundTripSerialization()
+      throws Exception {
+    TableConfig original = refreshTableBuilder()
+        .setReplacedSegmentsRetentionPeriod("2d")
+        .setLineageEntryCleanupRetentionPeriod("12h")
+        .build();
+
+    String json = JsonUtils.objectToString(original);
+    TableConfig deserialized = JsonUtils.stringToObject(json, TableConfig.class);
+
+    assertEquals(deserialized.getValidationConfig().getReplacedSegmentsRetentionPeriod(), "2d");
+    assertEquals(deserialized.getValidationConfig().getLineageEntryCleanupRetentionPeriod(), "12h");
+  }
+
+  @Test
+  public void testNewFieldsDefaultToNullWhenAbsent()
+      throws Exception {
+    TableConfig original = refreshTableBuilder().build();
+
+    String json = JsonUtils.objectToString(original);
+    TableConfig deserialized = JsonUtils.stringToObject(json, TableConfig.class);
+
+    assertNull(deserialized.getValidationConfig().getReplacedSegmentsRetentionPeriod());
+    assertNull(deserialized.getValidationConfig().getLineageEntryCleanupRetentionPeriod());
+  }
+
+  // ---------------------------------------------------------------------------
+  // shouldDeleteReplacedSegments / COMPLETED lineage
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void testRefreshTableDefaultRetentionDoesNotDeleteRecentlyCompletedLineage() {
+    // REFRESH table with default 1-day retention: lineage just completed → segments must NOT be deleted
+    TableConfig tableConfig = refreshTableBuilder().build();
+
+    String entryId = UUID.randomUUID().toString();
+    long recentTimestamp = System.currentTimeMillis();
+    SegmentLineage lineage = new SegmentLineage("testTable_OFFLINE");
+    lineage.addLineageEntry(entryId,
+        new LineageEntry(Arrays.asList("src1"), Arrays.asList("dst1"), LineageEntryState.COMPLETED, recentTimestamp));
+
+    List<String> segmentsToDelete = new ArrayList<>();
+    _lineageManager.updateLineageForRetention(tableConfig, lineage, Arrays.asList("src1", "dst1"), segmentsToDelete,
+        new HashSet<>());
+
+    assertFalse(segmentsToDelete.contains("src1"),
+        "Source segment must not be deleted within the default 1-day replaced-segments retention");
+  }
+
+  @Test
+  public void testRefreshTableDefaultRetentionDeletesOldCompletedLineage() {
+    // REFRESH table with default 1-day retention: lineage completed >1 day ago → segments MUST be deleted
+    TableConfig tableConfig = refreshTableBuilder().build();
+
+    String entryId = UUID.randomUUID().toString();
+    long oldTimestamp = System.currentTimeMillis() - 2 * 24 * 60 * 60 * 1000L; // 2 days ago
+    SegmentLineage lineage = new SegmentLineage("testTable_OFFLINE");
+    lineage.addLineageEntry(entryId,
+        new LineageEntry(Arrays.asList("src1"), Arrays.asList("dst1"), LineageEntryState.COMPLETED, oldTimestamp));
+
+    List<String> segmentsToDelete = new ArrayList<>();
+    _lineageManager.updateLineageForRetention(tableConfig, lineage, Arrays.asList("src1", "dst1"), segmentsToDelete,
+        new HashSet<>());
+
+    assertTrue(segmentsToDelete.contains("src1"),
+        "Source segment must be deleted after the default 1-day replaced-segments retention has elapsed");
+  }
+
+  @Test
+  public void testRefreshTableZeroRetentionDeletesImmediately() {
+    // REFRESH table with replacedSegmentsRetentionPeriod="0d" → delete immediately after COMPLETED
+    TableConfig tableConfig = refreshTableBuilder().setReplacedSegmentsRetentionPeriod("0d").build();
+
+    String entryId = UUID.randomUUID().toString();
+    long recentTimestamp = System.currentTimeMillis() - 1; // 1ms in the past to satisfy strict < with 0 retention
+    SegmentLineage lineage = new SegmentLineage("testTable_OFFLINE");
+    lineage.addLineageEntry(entryId,
+        new LineageEntry(Arrays.asList("src1"), Arrays.asList("dst1"), LineageEntryState.COMPLETED, recentTimestamp));
+
+    List<String> segmentsToDelete = new ArrayList<>();
+    _lineageManager.updateLineageForRetention(tableConfig, lineage, Arrays.asList("src1", "dst1"), segmentsToDelete,
+        new HashSet<>());
+
+    assertTrue(segmentsToDelete.contains("src1"),
+        "Source segment must be deleted immediately when replacedSegmentsRetentionPeriod is 0d");
+  }
+
+  @Test
+  public void testAppendTableAlwaysDeletesRegardlessOfRetentionConfig() {
+    // APPEND table: source segments are always eligible for deletion regardless of retention setting
+    TableConfig tableConfig = appendTableBuilder().setReplacedSegmentsRetentionPeriod("7d").build();
+
+    String entryId = UUID.randomUUID().toString();
+    long recentTimestamp = System.currentTimeMillis();
+    SegmentLineage lineage = new SegmentLineage("testTable_OFFLINE");
+    lineage.addLineageEntry(entryId,
+        new LineageEntry(Arrays.asList("src1"), Arrays.asList("dst1"), LineageEntryState.COMPLETED, recentTimestamp));
+
+    List<String> segmentsToDelete = new ArrayList<>();
+    _lineageManager.updateLineageForRetention(tableConfig, lineage, Arrays.asList("src1", "dst1"), segmentsToDelete,
+        new HashSet<>());
+
+    assertTrue(segmentsToDelete.contains("src1"),
+        "APPEND table source segments must always be eligible for deletion");
+  }
+
+  // ---------------------------------------------------------------------------
+  // lineageEntryCleanupRetentionPeriod / IN_PROGRESS lineage
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void testDefaultRetentionDoesNotCleanupRecentInProgressLineage() {
+    // Default 1-day cleanup retention: IN_PROGRESS entry created recently → must NOT be cleaned up
+    TableConfig tableConfig = refreshTableBuilder().build();
+
+    String entryId = UUID.randomUUID().toString();
+    long recentTimestamp = System.currentTimeMillis();
+    SegmentLineage lineage = new SegmentLineage("testTable_OFFLINE");
+    lineage.addLineageEntry(entryId,
+        new LineageEntry(Collections.emptyList(), Arrays.asList("dst1"), LineageEntryState.IN_PROGRESS,
+            recentTimestamp));
+
+    List<String> segmentsToDelete = new ArrayList<>();
+    _lineageManager.updateLineageForRetention(tableConfig, lineage, Arrays.asList("dst1"), segmentsToDelete,
+        new HashSet<>());
+
+    assertFalse(segmentsToDelete.contains("dst1"),
+        "Destination segment must not be deleted for a recent IN_PROGRESS lineage entry with default retention");
+  }
+
+  @Test
+  public void testDefaultRetentionCleansUpOldInProgressLineage() {
+    // Default 1-day cleanup retention: IN_PROGRESS entry >1 day old → destination segments MUST be deleted
+    TableConfig tableConfig = refreshTableBuilder().build();
+
+    String entryId = UUID.randomUUID().toString();
+    long oldTimestamp = System.currentTimeMillis() - 2 * 24 * 60 * 60 * 1000L; // 2 days ago
+    SegmentLineage lineage = new SegmentLineage("testTable_OFFLINE");
+    lineage.addLineageEntry(entryId,
+        new LineageEntry(Collections.emptyList(), Arrays.asList("dst1"), LineageEntryState.IN_PROGRESS, oldTimestamp));
+
+    List<String> segmentsToDelete = new ArrayList<>();
+    _lineageManager.updateLineageForRetention(tableConfig, lineage, Arrays.asList("dst1"), segmentsToDelete,
+        new HashSet<>());
+
+    assertTrue(segmentsToDelete.contains("dst1"),
+        "Destination segment must be deleted for an old IN_PROGRESS lineage entry with default retention");
+  }
+
+  @Test
+  public void testZeroLineageCleanupRetentionCleansUpImmediately() {
+    // lineageEntryCleanupRetentionPeriod="0d" → IN_PROGRESS entry created just before now is cleaned up
+    TableConfig tableConfig = refreshTableBuilder().setLineageEntryCleanupRetentionPeriod("0d").build();
+
+    String entryId = UUID.randomUUID().toString();
+    long recentTimestamp = System.currentTimeMillis() - 1; // 1ms in the past to satisfy strict < with 0 retention
+    SegmentLineage lineage = new SegmentLineage("testTable_OFFLINE");
+    lineage.addLineageEntry(entryId,
+        new LineageEntry(Collections.emptyList(), Arrays.asList("dst1"), LineageEntryState.IN_PROGRESS,
+            recentTimestamp));
+
+    List<String> segmentsToDelete = new ArrayList<>();
+    _lineageManager.updateLineageForRetention(tableConfig, lineage, Arrays.asList("dst1"), segmentsToDelete,
+        new HashSet<>());
+
+    assertTrue(segmentsToDelete.contains("dst1"),
+        "Destination segment must be deleted immediately when lineageEntryCleanupRetentionPeriod is 0d");
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/SegmentsValidationAndRetentionConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/SegmentsValidationAndRetentionConfig.java
@@ -31,6 +31,8 @@ public class SegmentsValidationAndRetentionConfig extends BaseJsonConfig {
   private String _retentionTimeUnit;
   private String _retentionTimeValue;
   private String _deletedSegmentsRetentionPeriod;
+  private String _replacedSegmentsRetentionPeriod;
+  private String _lineageEntryCleanupRetentionPeriod;
   @Deprecated
   private String _segmentPushFrequency; // DO NOT REMOVE, this is used in internal segment generation management
   @Deprecated
@@ -110,6 +112,38 @@ public class SegmentsValidationAndRetentionConfig extends BaseJsonConfig {
 
   public void setDeletedSegmentsRetentionPeriod(String deletedSegmentsRetentionPeriod) {
     _deletedSegmentsRetentionPeriod = deletedSegmentsRetentionPeriod;
+  }
+
+  /**
+   * Returns the retention period for segments replaced by a REFRESH ingestion job. When a lineage entry transitions
+   * to COMPLETED state, source segments are preserved for this duration before being scheduled for deletion,
+   * providing a rollback window. If null or unparseable, defaults to 1 day.
+   *
+   * <p>Accepts a human-readable period string (e.g. {@code "7d"}, {@code "12h"}) as understood by
+   * {@code TimeUtils.convertPeriodToMillis}. Setting this value too low (e.g. {@code "0d"}) eliminates the rollback
+   * window; source segments will be deleted on the next retention pass after the lineage is COMPLETED.
+   */
+  public String getReplacedSegmentsRetentionPeriod() {
+    return _replacedSegmentsRetentionPeriod;
+  }
+
+  public void setReplacedSegmentsRetentionPeriod(String replacedSegmentsRetentionPeriod) {
+    _replacedSegmentsRetentionPeriod = replacedSegmentsRetentionPeriod;
+  }
+
+  /**
+   * Returns the retention period before stale IN_PROGRESS or REVERTED lineage entries and their destination segments
+   * are cleaned up. If null or unparseable, defaults to 1 day.
+   *
+   * <p>Accepts a human-readable period string (e.g. {@code "7d"}, {@code "12h"}) as understood by
+   * {@code TimeUtils.convertPeriodToMillis}.
+   */
+  public String getLineageEntryCleanupRetentionPeriod() {
+    return _lineageEntryCleanupRetentionPeriod;
+  }
+
+  public void setLineageEntryCleanupRetentionPeriod(String lineageEntryCleanupRetentionPeriod) {
+    _lineageEntryCleanupRetentionPeriod = lineageEntryCleanupRetentionPeriod;
   }
 
   /**

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/SegmentsValidationAndRetentionConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/SegmentsValidationAndRetentionConfig.java
@@ -115,10 +115,12 @@ public class SegmentsValidationAndRetentionConfig extends BaseJsonConfig {
   }
 
   /**
-   * Returns the retention period for segments replaced by a REFRESH ingestion job. When a lineage entry transitions
-   * to COMPLETED state, source segments are preserved for this duration before being scheduled for deletion,
-   * providing a rollback window. Consumers of this config (e.g. the lineage manager) treat a null or unparseable
-   * value as a 1 day default.
+   * Returns the retention period for segments replaced by a REFRESH ingestion job. Only applies to tables with
+   * REFRESH ingestion type; for APPEND tables this setting is ignored and replaced segments are deleted immediately.
+   *
+   * <p>When a lineage entry transitions to COMPLETED state, source segments are preserved for this duration before
+   * being scheduled for deletion, providing a rollback window. Consumers of this config (e.g. the lineage manager)
+   * treat a null or unparseable value as a 1 day default.
    *
    * <p>Accepts a human-readable period string (e.g. {@code "7d"}, {@code "12h"}) as understood by
    * {@code TimeUtils.convertPeriodToMillis}. Setting this value too low (e.g. {@code "0d"}) eliminates the rollback

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/SegmentsValidationAndRetentionConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/SegmentsValidationAndRetentionConfig.java
@@ -117,7 +117,8 @@ public class SegmentsValidationAndRetentionConfig extends BaseJsonConfig {
   /**
    * Returns the retention period for segments replaced by a REFRESH ingestion job. When a lineage entry transitions
    * to COMPLETED state, source segments are preserved for this duration before being scheduled for deletion,
-   * providing a rollback window. If null or unparseable, defaults to 1 day.
+   * providing a rollback window. Consumers of this config (e.g. the lineage manager) treat a null or unparseable
+   * value as a 1 day default.
    *
    * <p>Accepts a human-readable period string (e.g. {@code "7d"}, {@code "12h"}) as understood by
    * {@code TimeUtils.convertPeriodToMillis}. Setting this value too low (e.g. {@code "0d"}) eliminates the rollback
@@ -133,7 +134,8 @@ public class SegmentsValidationAndRetentionConfig extends BaseJsonConfig {
 
   /**
    * Returns the retention period before stale IN_PROGRESS or REVERTED lineage entries and their destination segments
-   * are cleaned up. If null or unparseable, defaults to 1 day.
+   * are cleaned up. Consumers of this config (e.g. the lineage manager) treat a null or unparseable value as a
+   * 1 day default.
    *
    * <p>Accepts a human-readable period string (e.g. {@code "7d"}, {@code "12h"}) as understood by
    * {@code TimeUtils.convertPeriodToMillis}.

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/TableConfigBuilder.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/TableConfigBuilder.java
@@ -74,6 +74,8 @@ public class TableConfigBuilder {
   private String _retentionTimeUnit;
   private String _retentionTimeValue;
   private String _deletedSegmentsRetentionPeriod = DEFAULT_DELETED_SEGMENTS_RETENTION_PERIOD;
+  private String _replacedSegmentsRetentionPeriod;
+  private String _lineageEntryCleanupRetentionPeriod;
   @Deprecated
   private String _segmentPushFrequency;
 
@@ -204,6 +206,16 @@ public class TableConfigBuilder {
 
   public TableConfigBuilder setDeletedSegmentsRetentionPeriod(String deletedSegmentsRetentionPeriod) {
     _deletedSegmentsRetentionPeriod = deletedSegmentsRetentionPeriod;
+    return this;
+  }
+
+  public TableConfigBuilder setReplacedSegmentsRetentionPeriod(String replacedSegmentsRetentionPeriod) {
+    _replacedSegmentsRetentionPeriod = replacedSegmentsRetentionPeriod;
+    return this;
+  }
+
+  public TableConfigBuilder setLineageEntryCleanupRetentionPeriod(String lineageEntryCleanupRetentionPeriod) {
+    _lineageEntryCleanupRetentionPeriod = lineageEntryCleanupRetentionPeriod;
     return this;
   }
 
@@ -510,6 +522,8 @@ public class TableConfigBuilder {
     validationConfig.setRetentionTimeUnit(_retentionTimeUnit);
     validationConfig.setRetentionTimeValue(_retentionTimeValue);
     validationConfig.setDeletedSegmentsRetentionPeriod(_deletedSegmentsRetentionPeriod);
+    validationConfig.setReplacedSegmentsRetentionPeriod(_replacedSegmentsRetentionPeriod);
+    validationConfig.setLineageEntryCleanupRetentionPeriod(_lineageEntryCleanupRetentionPeriod);
     validationConfig.setSegmentPushFrequency(_segmentPushFrequency);
     validationConfig.setSegmentPushType(_segmentPushType);
     validationConfig.setSegmentAssignmentStrategy(_segmentAssignmentStrategy);


### PR DESCRIPTION
## Summary

Currently, `DefaultLineageManager` has two hardcoded 1-day wait periods that prevent rapid segment cleanup in the lineage path:
1. REFRESH table source segments are kept for 1 day after lineage is `COMPLETED` before being scheduled for deletion.
2. Stale `IN_PROGRESS`/`REVERTED` lineage entries are not cleaned up until they are 1 day old.

Combined with the default 7-day deep-store tombstone (`deletedSegmentsRetentionPeriod`), segments can linger in deep store for **up to 8 days** with defaults. This is particularly painful for use cases that frequently swap (REFRESH) tables, causing significant storage pressure.

### Changes
- Adds two new optional period-string fields to `SegmentsValidationAndRetentionConfig` (same format as the existing `deletedSegmentsRetentionPeriod`, e.g. `"1d"`, `"12h"`, `"0d"`):
  - **`replacedSegmentsRetentionPeriod`**: controls how long REFRESH source segments are preserved after lineage is `COMPLETED` before being scheduled for deletion (default: `1d`). Only applies to REFRESH ingestion; APPEND tables ignore this setting.
  - **`lineageEntryCleanupRetentionPeriod`**: controls how long stale `IN_PROGRESS`/`REVERTED` lineage entries wait before cleanup (default: `1d`)
- Both fields default to the existing 1-day constants when unset — **no behaviour change for existing tables**.
- A DEBUG log is emitted when either value resolves to `<= 0ms` (immediate deletion, no rollback window) — kept at DEBUG to avoid log spam since operators deliberately opt in.
- Unparseable values fall back to the 1-day default with a WARN log (consistent with existing `deletedSegmentsRetentionPeriod` behavior).
- Log messages include both the table name and config field name for easier debugging.
- Both retention values are parsed once per retention pass (not per lineage entry).
- Corresponding fluent builder methods added to `TableConfigBuilder`.
- No upfront validation added — consistent with the existing `deletedSegmentsRetentionPeriod` field which also relies on parse-with-warn-and-fallback at use-time.

### Example usage — immediate cleanup for a high-frequency REFRESH table
```json
{
  "segmentsConfig": {
    "replacedSegmentsRetentionPeriod": "0d",
    "lineageEntryCleanupRetentionPeriod": "0d",
    "deletedSegmentsRetentionPeriod": "0d"
  }
}
```

## Test plan
- [x] New unit test class `DefaultLineageManagerTest` (11 tests) covering:
  - JSON round-trip serialization of both new fields
  - Default 1-day behaviour preserved when fields are unset
  - `"0d"` causes immediate deletion for both REFRESH replaced segments and stale IN_PROGRESS lineage entries
  - APPEND tables are unaffected by `replacedSegmentsRetentionPeriod`
  - Unparseable period strings (e.g. `"foo"`) fall back to 1-day default for both fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)