### PR TITLE
Allow dynamic toggling of adaptive routing metrics export

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
@@ -697,6 +697,7 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
         System.currentTimeMillis() - startTimeMs, TimeUnit.MILLISECONDS);
 
     _clusterConfigChangeHandler.registerClusterConfigChangeListener(ContinuousJfrStarter.INSTANCE);
+    _clusterConfigChangeHandler.registerClusterConfigChangeListener(_serverRoutingStatsManager);
 
     NettyInspector.registerMetrics(_brokerMetrics);
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsManager.java
@@ -46,10 +46,16 @@ import org.slf4j.LoggerFactory;
 
 
 /**
+ * {@code ServerRoutingStatsManager} manages the query routing stats for each server and used by the Adaptive
+ * Server Selection feature (when enabled). The stats are maintained at the broker and are updated when a query is
+ * submitted to a server and when a server responds after processing a query.
  *
- *  {@code ServerRoutingStatsManager} manages the query routing stats for each server and used by the Adaptive
- *  Server Selection feature (when enabled). The stats are maintained at the broker and are updated when a query is
- *  submitted to a server and when a server responds after processing a query.
+ * <p>Thread safety: {@code onChange} is invoked on the Helix config-change callback thread.
+ * {@code exportStatsAsMetrics} runs on the single-threaded {@code _periodicTaskExecutor}.
+ * {@code _enableStatsMetricExport} and {@code _statsMetricExportIntervalMs} are {@code volatile} so
+ * writes from the Helix callback thread are immediately visible to the export thread. All other config
+ * fields ({@code _alpha}, {@code _autoDecayWindowMs}, etc.) are written once during {@code init()}
+ * before any executor threads start, so no additional synchronization is needed for those.
  */
 public class ServerRoutingStatsManager implements PinotClusterConfigChangeListener {
   private static final Logger LOGGER = LoggerFactory.getLogger(ServerRoutingStatsManager.class);
@@ -72,8 +78,8 @@ public class ServerRoutingStatsManager implements PinotClusterConfigChangeListen
   private double _avgInitializationVal;
   private int _hybridScoreExponent;
   private int _hybridScoreQueueFloor;
-  private boolean _enableStatsMetricExport;
-  private long _statsMetricExportIntervalMs;
+  private volatile boolean _enableStatsMetricExport;
+  private volatile long _statsMetricExportIntervalMs;
   private volatile ScheduledFuture<?> _metricExportFuture;
 
   public ServerRoutingStatsManager(PinotConfiguration pinotConfig, BrokerMetrics brokerMetrics) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsManager.java
@@ -23,10 +23,12 @@ import com.google.common.base.Preconditions;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
@@ -34,6 +36,7 @@ import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pinot.common.metrics.BrokerGauge;
 import org.apache.pinot.common.metrics.BrokerMetrics;
+import org.apache.pinot.spi.config.provider.PinotClusterConfigChangeListener;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.query.QueryExecutionContext.QueryType;
 import org.apache.pinot.spi.query.QueryThreadContext;
@@ -48,7 +51,7 @@ import org.slf4j.LoggerFactory;
  *  Server Selection feature (when enabled). The stats are maintained at the broker and are updated when a query is
  *  submitted to a server and when a server responds after processing a query.
  */
-public class ServerRoutingStatsManager {
+public class ServerRoutingStatsManager implements PinotClusterConfigChangeListener {
   private static final Logger LOGGER = LoggerFactory.getLogger(ServerRoutingStatsManager.class);
 
   private final PinotConfiguration _config;
@@ -70,6 +73,8 @@ public class ServerRoutingStatsManager {
   private int _hybridScoreExponent;
   private int _hybridScoreQueueFloor;
   private boolean _enableStatsMetricExport;
+  private long _statsMetricExportIntervalMs;
+  private volatile ScheduledFuture<?> _metricExportFuture;
 
   public ServerRoutingStatsManager(PinotConfiguration pinotConfig, BrokerMetrics brokerMetrics) {
     _config = pinotConfig;
@@ -112,12 +117,42 @@ public class ServerRoutingStatsManager {
 
     _enableStatsMetricExport = _config.getProperty(AdaptiveServerSelector.CONFIG_OF_ENABLE_STATS_METRIC_EXPORT,
         AdaptiveServerSelector.DEFAULT_ENABLE_STATS_METRIC_EXPORT);
-    if (_enableStatsMetricExport) {
-      long intervalMs = _config.getProperty(AdaptiveServerSelector.CONFIG_OF_STATS_METRIC_EXPORT_INTERVAL_MS,
-          AdaptiveServerSelector.DEFAULT_STATS_METRIC_EXPORT_INTERVAL_MS);
-      _periodicTaskExecutor.scheduleAtFixedRate(this::exportStatsAsMetrics, intervalMs, intervalMs,
-          TimeUnit.MILLISECONDS);
-      LOGGER.info("Adaptive server routing stats metric export enabled with interval {}ms.", intervalMs);
+    _statsMetricExportIntervalMs = _config.getProperty(AdaptiveServerSelector.CONFIG_OF_STATS_METRIC_EXPORT_INTERVAL_MS,
+        AdaptiveServerSelector.DEFAULT_STATS_METRIC_EXPORT_INTERVAL_MS);
+    _metricExportFuture = _periodicTaskExecutor.scheduleAtFixedRate(this::exportStatsAsMetrics,
+        _statsMetricExportIntervalMs, _statsMetricExportIntervalMs, TimeUnit.MILLISECONDS);
+    LOGGER.info("Adaptive server routing stats metric export scheduled with interval {}ms (enabled={}).",
+        _statsMetricExportIntervalMs, _enableStatsMetricExport);
+  }
+
+  @Override
+  public void onChange(Set<String> changedConfigs, Map<String, String> clusterConfigs) {
+    if (changedConfigs.contains(AdaptiveServerSelector.CONFIG_OF_ENABLE_STATS_METRIC_EXPORT)) {
+      String value = clusterConfigs.get(AdaptiveServerSelector.CONFIG_OF_ENABLE_STATS_METRIC_EXPORT);
+      if (value != null) {
+        _enableStatsMetricExport = Boolean.parseBoolean(value);
+      } else {
+        // Key was removed from cluster config — fall back to the static broker config value.
+        _enableStatsMetricExport = _config.getProperty(AdaptiveServerSelector.CONFIG_OF_ENABLE_STATS_METRIC_EXPORT,
+            AdaptiveServerSelector.DEFAULT_ENABLE_STATS_METRIC_EXPORT);
+      }
+      LOGGER.info("Updated enableStatsMetricExport to {} from cluster config.", _enableStatsMetricExport);
+      if (!_enableStatsMetricExport) {
+        removeAllServerStatsGauges();
+      }
+    }
+    if (changedConfigs.contains(AdaptiveServerSelector.CONFIG_OF_STATS_METRIC_EXPORT_INTERVAL_MS)) {
+      String value = clusterConfigs.get(AdaptiveServerSelector.CONFIG_OF_STATS_METRIC_EXPORT_INTERVAL_MS);
+      long newIntervalMs = value != null ? Long.parseLong(value)
+          : _config.getProperty(AdaptiveServerSelector.CONFIG_OF_STATS_METRIC_EXPORT_INTERVAL_MS,
+              AdaptiveServerSelector.DEFAULT_STATS_METRIC_EXPORT_INTERVAL_MS);
+      if (newIntervalMs != _statsMetricExportIntervalMs) {
+        _statsMetricExportIntervalMs = newIntervalMs;
+        _metricExportFuture.cancel(false);
+        _metricExportFuture = _periodicTaskExecutor.scheduleAtFixedRate(this::exportStatsAsMetrics,
+            newIntervalMs, newIntervalMs, TimeUnit.MILLISECONDS);
+        LOGGER.info("Rescheduled adaptive server routing stats metric export with new interval {}ms.", newIntervalMs);
+      }
     }
   }
 
@@ -441,12 +476,28 @@ public class ServerRoutingStatsManager {
     }
   }
 
+  private void removeAllServerStatsGauges() {
+    if (_serverQueryStatsMap == null) {
+      return;
+    }
+    for (String serverInstanceId : _serverQueryStatsMap.keySet()) {
+      String serverTag = "server." + serverInstanceId;
+      _brokerMetrics.removeGauge(BrokerGauge.ADAPTIVE_SERVER_NUM_IN_FLIGHT_REQUESTS.getGaugeName() + "." + serverTag);
+      _brokerMetrics.removeGauge(BrokerGauge.ADAPTIVE_SERVER_LATENCY_EMA.getGaugeName() + "." + serverTag);
+      _brokerMetrics.removeGauge(BrokerGauge.ADAPTIVE_SERVER_HYBRID_SCORE.getGaugeName() + "." + serverTag);
+    }
+    LOGGER.info("Removed adaptive server routing stats gauges for {} servers.", _serverQueryStatsMap.size());
+  }
+
   private void recordQueueSizeMetrics() {
     int queueSize = getQueueSize();
     _brokerMetrics.setValueOfGlobalGauge(BrokerGauge.ROUTING_STATS_MANAGER_QUEUE_SIZE, queueSize);
   }
 
   private void exportStatsAsMetrics() {
+    if (!_enableStatsMetricExport) {
+      return;
+    }
     try {
       exportStatsForMap(_serverQueryStatsMap, "server.",
           BrokerGauge.ADAPTIVE_SERVER_NUM_IN_FLIGHT_REQUESTS,

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsManager.java
@@ -19,6 +19,7 @@
 
 package org.apache.pinot.core.transport.server.routing.stats;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import java.util.ArrayList;
 import java.util.List;
@@ -149,9 +150,24 @@ public class ServerRoutingStatsManager implements PinotClusterConfigChangeListen
     }
     if (changedConfigs.contains(AdaptiveServerSelector.CONFIG_OF_STATS_METRIC_EXPORT_INTERVAL_MS)) {
       String value = clusterConfigs.get(AdaptiveServerSelector.CONFIG_OF_STATS_METRIC_EXPORT_INTERVAL_MS);
-      long newIntervalMs = value != null ? Long.parseLong(value)
-          : _config.getProperty(AdaptiveServerSelector.CONFIG_OF_STATS_METRIC_EXPORT_INTERVAL_MS,
-              AdaptiveServerSelector.DEFAULT_STATS_METRIC_EXPORT_INTERVAL_MS);
+      long newIntervalMs;
+      if (value != null) {
+        try {
+          newIntervalMs = Long.parseLong(value);
+        } catch (NumberFormatException e) {
+          LOGGER.warn("Invalid value '{}' for config '{}'; ignoring interval change", value,
+              AdaptiveServerSelector.CONFIG_OF_STATS_METRIC_EXPORT_INTERVAL_MS);
+          return;
+        }
+        if (newIntervalMs <= 0) {
+          LOGGER.warn("Non-positive value {} for config '{}'; ignoring interval change", newIntervalMs,
+              AdaptiveServerSelector.CONFIG_OF_STATS_METRIC_EXPORT_INTERVAL_MS);
+          return;
+        }
+      } else {
+        newIntervalMs = _config.getProperty(AdaptiveServerSelector.CONFIG_OF_STATS_METRIC_EXPORT_INTERVAL_MS,
+            AdaptiveServerSelector.DEFAULT_STATS_METRIC_EXPORT_INTERVAL_MS);
+      }
       if (newIntervalMs != _statsMetricExportIntervalMs) {
         _statsMetricExportIntervalMs = newIntervalMs;
         _metricExportFuture.cancel(false);
@@ -164,6 +180,11 @@ public class ServerRoutingStatsManager implements PinotClusterConfigChangeListen
 
   public boolean isEnabled() {
     return _isEnabled;
+  }
+
+  @VisibleForTesting
+  public long getStatsMetricExportIntervalMs() {
+    return _statsMetricExportIntervalMs;
   }
 
   public void shutDown() {

--- a/pinot-core/src/test/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsManagerTest.java
@@ -541,6 +541,54 @@ public class ServerRoutingStatsManagerTest {
   }
 
   @Test
+  public void testStatsMetricExportIntervalDynamicUpdateIgnoresBadValues() {
+    Map<String, Object> properties = new HashMap<>();
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_ENABLE_STATS_COLLECTION, true);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_EWMA_ALPHA, 1.0);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_AUTODECAY_WINDOW_MS, -1);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_WARMUP_DURATION_MS, 0);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_AVG_INITIALIZATION_VAL, 0.0);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_HYBRID_SCORE_EXPONENT, 3);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_ENABLE_STATS_METRIC_EXPORT, true);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_STATS_METRIC_EXPORT_INTERVAL_MS, 100000L);
+    ServerRoutingStatsManager manager = new ServerRoutingStatsManager(new PinotConfiguration(properties),
+        _brokerMetrics);
+    manager.init();
+
+    long intervalBefore = manager.getStatsMetricExportIntervalMs();
+
+    // Non-numeric value: must be silently ignored without throwing.
+    manager.onChange(
+        Set.of(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_STATS_METRIC_EXPORT_INTERVAL_MS),
+        Map.of(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_STATS_METRIC_EXPORT_INTERVAL_MS, "abc"));
+    assertEquals(manager.getStatsMetricExportIntervalMs(), intervalBefore,
+        "Interval must not change on non-numeric config value");
+
+    // Zero: must be silently ignored.
+    manager.onChange(
+        Set.of(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_STATS_METRIC_EXPORT_INTERVAL_MS),
+        Map.of(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_STATS_METRIC_EXPORT_INTERVAL_MS, "0"));
+    assertEquals(manager.getStatsMetricExportIntervalMs(), intervalBefore,
+        "Interval must not change on zero config value");
+
+    // Negative value: must be silently ignored.
+    manager.onChange(
+        Set.of(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_STATS_METRIC_EXPORT_INTERVAL_MS),
+        Map.of(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_STATS_METRIC_EXPORT_INTERVAL_MS, "-1"));
+    assertEquals(manager.getStatsMetricExportIntervalMs(), intervalBefore,
+        "Interval must not change on negative config value");
+
+    // Key removed from cluster config — must fall back to the static broker config value (100000L).
+    manager.onChange(
+        Set.of(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_STATS_METRIC_EXPORT_INTERVAL_MS),
+        Collections.emptyMap());
+    assertEquals(manager.getStatsMetricExportIntervalMs(), 100000L,
+        "Interval must revert to static config when cluster key is removed");
+
+    manager.shutDown();
+  }
+
+  @Test
   public void testMseAndSseStatsIsolation() {
     Map<String, Object> properties = new HashMap<>();
     properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_ENABLE_STATS_COLLECTION, true);

--- a/pinot-core/src/test/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsManagerTest.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pinot.common.metrics.BrokerGauge;
 import org.apache.pinot.common.metrics.BrokerMetrics;
@@ -454,6 +455,89 @@ public class ServerRoutingStatsManagerTest {
     double fastScore = managerMultiServer.fetchHybridScoreForServer("fastServer");
     double slowScore = managerMultiServer.fetchHybridScoreForServer("slowServer");
     assertTrue(fastScore < slowScore, "Idle servers should be ranked by latency");
+  }
+
+  @Test
+  public void testStatsMetricExportDynamicToggle() throws InterruptedException {
+    Map<String, Object> properties = new HashMap<>();
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_ENABLE_STATS_COLLECTION, true);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_EWMA_ALPHA, 1.0);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_AUTODECAY_WINDOW_MS, -1);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_WARMUP_DURATION_MS, 0);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_AVG_INITIALIZATION_VAL, 0.0);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_HYBRID_SCORE_EXPONENT, 3);
+    // Start with metric export disabled.
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_ENABLE_STATS_METRIC_EXPORT, false);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_STATS_METRIC_EXPORT_INTERVAL_MS, 50L);
+    ServerRoutingStatsManager manager = new ServerRoutingStatsManager(new PinotConfiguration(properties),
+        _brokerMetrics);
+    manager.init();
+
+    int requestId = 0;
+    manager.recordStatsForQuerySubmission(requestId++, "dynamicToggleServer");
+    waitForStatsUpdate(manager, requestId);
+    manager.recordStatsUponResponseArrival(requestId++, "dynamicToggleServer", 100);
+    waitForStatsUpdate(manager, requestId);
+
+    String numInFlightKey = BrokerGauge.ADAPTIVE_SERVER_NUM_IN_FLIGHT_REQUESTS.getGaugeName() + "."
+        + "server.dynamicToggleServer";
+
+    // Confirm no metrics while disabled.
+    Thread.sleep(200);
+    assertNull(_brokerMetrics.getGaugeValue(numInFlightKey));
+
+    // Enable via cluster config change and verify metrics are now exported.
+    manager.onChange(
+        Set.of(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_ENABLE_STATS_METRIC_EXPORT),
+        Map.of(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_ENABLE_STATS_METRIC_EXPORT, "true"));
+
+    TestUtils.waitForCondition(aVoid -> _brokerMetrics.getGaugeValue(numInFlightKey) != null,
+        50L, 5000, "Timed out waiting for metrics after dynamic enable");
+
+    // Disable again and verify the gauges are removed from the registry.
+    manager.onChange(
+        Set.of(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_ENABLE_STATS_METRIC_EXPORT),
+        Map.of(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_ENABLE_STATS_METRIC_EXPORT, "false"));
+
+    assertNull(_brokerMetrics.getGaugeValue(numInFlightKey));
+  }
+
+  @Test
+  public void testStatsMetricExportIntervalDynamicUpdate() throws InterruptedException {
+    Map<String, Object> properties = new HashMap<>();
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_ENABLE_STATS_COLLECTION, true);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_EWMA_ALPHA, 1.0);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_AUTODECAY_WINDOW_MS, -1);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_WARMUP_DURATION_MS, 0);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_AVG_INITIALIZATION_VAL, 0.0);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_HYBRID_SCORE_EXPONENT, 3);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_ENABLE_STATS_METRIC_EXPORT, true);
+    // Start with a very long interval so the task won't fire during the test.
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_STATS_METRIC_EXPORT_INTERVAL_MS, 100000L);
+    ServerRoutingStatsManager manager = new ServerRoutingStatsManager(new PinotConfiguration(properties),
+        _brokerMetrics);
+    manager.init();
+
+    int requestId = 0;
+    manager.recordStatsForQuerySubmission(requestId++, "intervalUpdateServer");
+    waitForStatsUpdate(manager, requestId);
+    manager.recordStatsUponResponseArrival(requestId++, "intervalUpdateServer", 100);
+    waitForStatsUpdate(manager, requestId);
+
+    String numInFlightKey = BrokerGauge.ADAPTIVE_SERVER_NUM_IN_FLIGHT_REQUESTS.getGaugeName()
+        + ".server.intervalUpdateServer";
+
+    // No export yet — interval is too long.
+    Thread.sleep(200);
+    assertNull(_brokerMetrics.getGaugeValue(numInFlightKey));
+
+    // Shorten the interval via cluster config change and verify metrics are now exported.
+    manager.onChange(
+        Set.of(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_STATS_METRIC_EXPORT_INTERVAL_MS),
+        Map.of(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_STATS_METRIC_EXPORT_INTERVAL_MS, "50"));
+
+    TestUtils.waitForCondition(aVoid -> _brokerMetrics.getGaugeValue(numInFlightKey) != null,
+        50L, 5000, "Timed out waiting for metrics after interval update");
   }
 
   @Test


### PR DESCRIPTION
https://github.com/apache/pinot/pull/18134 adds metrics for adaptive routing stats.

We may want to toggle whether or not stats are exported as metrics without needing to rolling restart the brokers. 

ServerRoutingStatsManager now implements PinotClusterConfigChangeListener. The periodic export task is always scheduled when stats collection is enabled; the enable.stats.metric.export flag is checked inside the task and can be updated at runtime via the Helix cluster config (PUT /cluster/configs) without a broker restart.

We also allow updating the metrics export frequency at runtime.

If the metric interval set to a bad value at startup, it'll block the cluster from starting. But if a bad value is set dynamically, if we don't validate it, it could stop us from reaching later listeners. 

### Testing
Deployed to an internal Stripe cluster. 

`ssh`ed onto one of the controllers and ran
```
curl -X POST localhost:9000/cluster/configs -H "Content-Type: application/json" -d '{"pinot.broker.adaptive.server.selector.enable.stats.metric.export": "false"}'
# wait a bit
curl -X POST localhost:9000/cluster/configs -H "Content-Type: application/json" -d '{"pinot.broker.adaptive.server.selector.enable.stats.metric.export": "true"}'
# wait a bit more
curl -X POST localhost:9000/cluster/configs -H "Content-Type: application/json" -d '{"pinot.broker.adaptive.server.selector.enable.stats.metric.export": "false"}'
```

Saw the metrics start/stop as expected. 