### PR TITLE
Add configurable queue size offset to adaptive routing hybrid score

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/adaptiveserverselector/HybridSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/adaptiveserverselector/HybridSelector.java
@@ -37,8 +37,10 @@ import org.apache.pinot.core.transport.server.routing.stats.ServerRoutingStatsMa
  * https://www.usenix.org/system/files/conference/nsdi15/nsdi15-paper-suresh.pdf
  *
  * The Hybrid score for each server is calculated as follows. The server with the lowest Hybrid score is picked.
- *       HybridScore = Math.pow(A+B, N) * C
+ *       HybridScore = Math.pow(O+A+B, N) * C
  * N -> Configurable exponent with default value of 3.
+ * O -> Configurable queue size offset with default value of 0. Setting O=1 matches the original paper formulation and
+ *      prevents the score from collapsing to 0 when all servers are idle, ensuring latency is still used for routing.
  */
 public class HybridSelector implements AdaptiveServerSelector {
   private final ServerRoutingStatsManager _serverRoutingStatsManager;

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/adaptiveserverselector/HybridSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/adaptiveserverselector/HybridSelector.java
@@ -39,7 +39,7 @@ import org.apache.pinot.core.transport.server.routing.stats.ServerRoutingStatsMa
  * The Hybrid score for each server is calculated as follows. The server with the lowest Hybrid score is picked.
  *       HybridScore = Math.pow(F+A+B, N) * C
  * N -> Configurable exponent with default value of 3.
- * F -> Configurable queue size floor with default value of 0. Setting O=1 matches the original paper formulation and
+ * F -> Configurable queue size floor with default value of 0. Setting F=1 matches the original paper formulation and
  *      prevents the score from collapsing to 0 when all servers are idle, ensuring latency is still used for routing.
  */
 public class HybridSelector implements AdaptiveServerSelector {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/adaptiveserverselector/HybridSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/adaptiveserverselector/HybridSelector.java
@@ -37,9 +37,9 @@ import org.apache.pinot.core.transport.server.routing.stats.ServerRoutingStatsMa
  * https://www.usenix.org/system/files/conference/nsdi15/nsdi15-paper-suresh.pdf
  *
  * The Hybrid score for each server is calculated as follows. The server with the lowest Hybrid score is picked.
- *       HybridScore = Math.pow(O+A+B, N) * C
+ *       HybridScore = Math.pow(F+A+B, N) * C
  * N -> Configurable exponent with default value of 3.
- * O -> Configurable queue size offset with default value of 0. Setting O=1 matches the original paper formulation and
+ * F -> Configurable queue size floor with default value of 0. Setting O=1 matches the original paper formulation and
  *      prevents the score from collapsing to 0 when all servers are idle, ensuring latency is still used for routing.
  */
 public class HybridSelector implements AdaptiveServerSelector {

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsEntry.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsEntry.java
@@ -44,8 +44,11 @@ public class ServerRoutingStatsEntry {
   // Hybrid score exponent.
   private final int _hybridScoreExponent;
 
+  // Hybrid score queue size offset (added to A+B before exponentiation to avoid score collapsing to 0 when idle).
+  private final int _hybridScoreQueueSizeOffset;
+
   public ServerRoutingStatsEntry(String serverInstanceId, double alphaEMA, long autoDecayWindowMsEMA,
-      long warmupDurationMsEMA, double avgInitializationValEMA, int scoreExponent,
+      long warmupDurationMsEMA, double avgInitializationValEMA, int scoreExponent, int queueSizeOffset,
       ScheduledExecutorService periodicTaskExecutor) {
     _serverInstanceId = serverInstanceId;
     _serverLock = new ReentrantReadWriteLock();
@@ -58,6 +61,7 @@ public class ServerRoutingStatsEntry {
             periodicTaskExecutor);
 
     _hybridScoreExponent = scoreExponent;
+    _hybridScoreQueueSizeOffset = queueSizeOffset;
   }
 
   @JsonIgnore
@@ -84,7 +88,7 @@ public class ServerRoutingStatsEntry {
 
   @JsonProperty("hybridScore")
   public double computeHybridScore() {
-    double estimatedQSize = _numInFlightRequests + _inFlighRequestsEMA.getAverage();
+    double estimatedQSize = _hybridScoreQueueSizeOffset + _numInFlightRequests + _inFlighRequestsEMA.getAverage();
     return Math.pow(estimatedQSize, _hybridScoreExponent) * _latencyMsEMA.getAverage();
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsEntry.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsEntry.java
@@ -20,6 +20,7 @@ package org.apache.pinot.core.transport.server.routing.stats;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Preconditions;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.apache.pinot.common.utils.ExponentialMovingAverage;

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsEntry.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsEntry.java
@@ -61,6 +61,7 @@ public class ServerRoutingStatsEntry {
             periodicTaskExecutor);
 
     _hybridScoreExponent = scoreExponent;
+    Preconditions.checkArgument(queueSizeOffset >= 0, "queueSizeOffset must be non-negative, got: %s", queueSizeOffset);
     _hybridScoreQueueSizeOffset = queueSizeOffset;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsEntry.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsEntry.java
@@ -45,11 +45,11 @@ public class ServerRoutingStatsEntry {
   // Hybrid score exponent.
   private final int _hybridScoreExponent;
 
-  // Hybrid score queue size offset (added to A+B before exponentiation to avoid score collapsing to 0 when idle).
-  private final int _hybridScoreQueueSizeOffset;
+  // Hybrid score queue size floor (added to A+B before exponentiation to avoid score collapsing to 0 when idle).
+  private final int _hybridScoreQueueFloor;
 
   public ServerRoutingStatsEntry(String serverInstanceId, double alphaEMA, long autoDecayWindowMsEMA,
-      long warmupDurationMsEMA, double avgInitializationValEMA, int scoreExponent, int queueSizeOffset,
+      long warmupDurationMsEMA, double avgInitializationValEMA, int scoreExponent, int queueFloor,
       ScheduledExecutorService periodicTaskExecutor) {
     _serverInstanceId = serverInstanceId;
     _serverLock = new ReentrantReadWriteLock();
@@ -62,8 +62,8 @@ public class ServerRoutingStatsEntry {
             periodicTaskExecutor);
 
     _hybridScoreExponent = scoreExponent;
-    Preconditions.checkArgument(queueSizeOffset >= 0, "queueSizeOffset must be non-negative, got: %s", queueSizeOffset);
-    _hybridScoreQueueSizeOffset = queueSizeOffset;
+    Preconditions.checkArgument(queueFloor >= 0, "queueFloor must be non-negative, got: %s", queueFloor);
+    _hybridScoreQueueFloor = queueFloor;
   }
 
   @JsonIgnore
@@ -90,7 +90,7 @@ public class ServerRoutingStatsEntry {
 
   @JsonProperty("hybridScore")
   public double computeHybridScore() {
-    double estimatedQSize = _hybridScoreQueueSizeOffset + _numInFlightRequests + _inFlighRequestsEMA.getAverage();
+    double estimatedQSize = _hybridScoreQueueFloor + _numInFlightRequests + _inFlighRequestsEMA.getAverage();
     return Math.pow(estimatedQSize, _hybridScoreExponent) * _latencyMsEMA.getAverage();
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsManager.java
@@ -64,6 +64,7 @@ public class ServerRoutingStatsManager {
   private long _warmupDurationMs;
   private double _avgInitializationVal;
   private int _hybridScoreExponent;
+  private int _hybridScoreQueueSizeOffset;
   private boolean _enableStatsMetricExport;
 
   public ServerRoutingStatsManager(PinotConfiguration pinotConfig, BrokerMetrics brokerMetrics) {
@@ -91,6 +92,8 @@ public class ServerRoutingStatsManager {
         AdaptiveServerSelector.DEFAULT_AVG_INITIALIZATION_VAL);
     _hybridScoreExponent = _config.getProperty(AdaptiveServerSelector.CONFIG_OF_HYBRID_SCORE_EXPONENT,
         AdaptiveServerSelector.DEFAULT_HYBRID_SCORE_EXPONENT);
+    _hybridScoreQueueSizeOffset = _config.getProperty(AdaptiveServerSelector.CONFIG_OF_HYBRID_SCORE_QUEUE_SIZE_OFFSET,
+        AdaptiveServerSelector.DEFAULT_HYBRID_SCORE_QUEUE_SIZE_OFFSET);
 
     int threadPoolSize = _config.getProperty(AdaptiveServerSelector.CONFIG_OF_STATS_MANAGER_THREADPOOL_SIZE,
         AdaptiveServerSelector.DEFAULT_STATS_MANAGER_THREADPOOL_SIZE);
@@ -167,7 +170,7 @@ public class ServerRoutingStatsManager {
   private void updateStatsAfterQuerySubmission(String serverInstanceId) {
     ServerRoutingStatsEntry stats = _serverQueryStatsMap.computeIfAbsent(serverInstanceId,
         k -> new ServerRoutingStatsEntry(serverInstanceId, _alpha, _autoDecayWindowMs, _warmupDurationMs,
-            _avgInitializationVal, _hybridScoreExponent, _periodicTaskExecutor));
+            _avgInitializationVal, _hybridScoreExponent, _hybridScoreQueueSizeOffset, _periodicTaskExecutor));
 
     try {
       stats.getServerWriteLock().lock();
@@ -197,7 +200,7 @@ public class ServerRoutingStatsManager {
   private void updateStatsUponResponseArrival(String serverInstanceId, long latencyMs) {
     ServerRoutingStatsEntry stats = _serverQueryStatsMap.computeIfAbsent(serverInstanceId,
         k -> new ServerRoutingStatsEntry(serverInstanceId, _alpha, _autoDecayWindowMs, _warmupDurationMs,
-            _avgInitializationVal, _hybridScoreExponent, _periodicTaskExecutor));
+            _avgInitializationVal, _hybridScoreExponent, _hybridScoreQueueSizeOffset, _periodicTaskExecutor));
 
     try {
       stats.getServerWriteLock().lock();

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsManager.java
@@ -64,7 +64,7 @@ public class ServerRoutingStatsManager {
   private long _warmupDurationMs;
   private double _avgInitializationVal;
   private int _hybridScoreExponent;
-  private int _hybridScoreQueueSizeOffset;
+  private int _hybridScoreQueueFloor;
   private boolean _enableStatsMetricExport;
 
   public ServerRoutingStatsManager(PinotConfiguration pinotConfig, BrokerMetrics brokerMetrics) {
@@ -92,7 +92,7 @@ public class ServerRoutingStatsManager {
         AdaptiveServerSelector.DEFAULT_AVG_INITIALIZATION_VAL);
     _hybridScoreExponent = _config.getProperty(AdaptiveServerSelector.CONFIG_OF_HYBRID_SCORE_EXPONENT,
         AdaptiveServerSelector.DEFAULT_HYBRID_SCORE_EXPONENT);
-    _hybridScoreQueueSizeOffset = _config.getProperty(AdaptiveServerSelector.CONFIG_OF_HYBRID_SCORE_QUEUE_FLOOR,
+    _hybridScoreQueueFloor = _config.getProperty(AdaptiveServerSelector.CONFIG_OF_HYBRID_SCORE_QUEUE_FLOOR,
         AdaptiveServerSelector.DEFAULT_HYBRID_SCORE_QUEUE_FLOOR);
 
     int threadPoolSize = _config.getProperty(AdaptiveServerSelector.CONFIG_OF_STATS_MANAGER_THREADPOOL_SIZE,
@@ -170,7 +170,7 @@ public class ServerRoutingStatsManager {
   private void updateStatsAfterQuerySubmission(String serverInstanceId) {
     ServerRoutingStatsEntry stats = _serverQueryStatsMap.computeIfAbsent(serverInstanceId,
         k -> new ServerRoutingStatsEntry(serverInstanceId, _alpha, _autoDecayWindowMs, _warmupDurationMs,
-            _avgInitializationVal, _hybridScoreExponent, _hybridScoreQueueSizeOffset, _periodicTaskExecutor));
+            _avgInitializationVal, _hybridScoreExponent, _hybridScoreQueueFloor, _periodicTaskExecutor));
 
     try {
       stats.getServerWriteLock().lock();
@@ -200,7 +200,7 @@ public class ServerRoutingStatsManager {
   private void updateStatsUponResponseArrival(String serverInstanceId, long latencyMs) {
     ServerRoutingStatsEntry stats = _serverQueryStatsMap.computeIfAbsent(serverInstanceId,
         k -> new ServerRoutingStatsEntry(serverInstanceId, _alpha, _autoDecayWindowMs, _warmupDurationMs,
-            _avgInitializationVal, _hybridScoreExponent, _hybridScoreQueueSizeOffset, _periodicTaskExecutor));
+            _avgInitializationVal, _hybridScoreExponent, _hybridScoreQueueFloor, _periodicTaskExecutor));
 
     try {
       stats.getServerWriteLock().lock();

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsManager.java
@@ -92,8 +92,8 @@ public class ServerRoutingStatsManager {
         AdaptiveServerSelector.DEFAULT_AVG_INITIALIZATION_VAL);
     _hybridScoreExponent = _config.getProperty(AdaptiveServerSelector.CONFIG_OF_HYBRID_SCORE_EXPONENT,
         AdaptiveServerSelector.DEFAULT_HYBRID_SCORE_EXPONENT);
-    _hybridScoreQueueSizeOffset = _config.getProperty(AdaptiveServerSelector.CONFIG_OF_HYBRID_SCORE_QUEUE_FLOOR,
-        AdaptiveServerSelector.DEFAULT_HYBRID_SCORE_QUEUE_FLOOR);
+    _hybridScoreQueueSizeOffset = _config.getProperty(AdaptiveServerSelector.CONFIG_OF_HYBRID_SCORE_QUEUE_SIZE_OFFSET,
+        AdaptiveServerSelector.DEFAULT_HYBRID_SCORE_QUEUE_SIZE_OFFSET);
 
     int threadPoolSize = _config.getProperty(AdaptiveServerSelector.CONFIG_OF_STATS_MANAGER_THREADPOOL_SIZE,
         AdaptiveServerSelector.DEFAULT_STATS_MANAGER_THREADPOOL_SIZE);

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsManager.java
@@ -92,8 +92,8 @@ public class ServerRoutingStatsManager {
         AdaptiveServerSelector.DEFAULT_AVG_INITIALIZATION_VAL);
     _hybridScoreExponent = _config.getProperty(AdaptiveServerSelector.CONFIG_OF_HYBRID_SCORE_EXPONENT,
         AdaptiveServerSelector.DEFAULT_HYBRID_SCORE_EXPONENT);
-    _hybridScoreQueueSizeOffset = _config.getProperty(AdaptiveServerSelector.CONFIG_OF_HYBRID_SCORE_QUEUE_SIZE_OFFSET,
-        AdaptiveServerSelector.DEFAULT_HYBRID_SCORE_QUEUE_SIZE_OFFSET);
+    _hybridScoreQueueSizeOffset = _config.getProperty(AdaptiveServerSelector.CONFIG_OF_HYBRID_SCORE_QUEUE_FLOOR,
+        AdaptiveServerSelector.DEFAULT_HYBRID_SCORE_QUEUE_FLOOR);
 
     int threadPoolSize = _config.getProperty(AdaptiveServerSelector.CONFIG_OF_STATS_MANAGER_THREADPOOL_SIZE,
         AdaptiveServerSelector.DEFAULT_STATS_MANAGER_THREADPOOL_SIZE);

--- a/pinot-core/src/test/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsManagerTest.java
@@ -388,6 +388,45 @@ public class ServerRoutingStatsManagerTest {
     assertNull(_brokerMetrics.getGaugeValue(numInFlightKey));
   }
 
+  @Test
+  public void testHybridScoreWithQueueSizeOffset() {
+    // With offset=1 the formula is Math.pow(1+A+B, N)*C instead of Math.pow(A+B, N)*C.
+    // This prevents the score from collapsing to 0 when all servers are idle so that latency
+    // still drives routing decisions in low-traffic conditions.
+    Map<String, Object> properties = new HashMap<>();
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_ENABLE_STATS_COLLECTION, true);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_EWMA_ALPHA, 1.0);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_AUTODECAY_WINDOW_MS, -1);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_WARMUP_DURATION_MS, 0);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_AVG_INITIALIZATION_VAL, 0.0);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_HYBRID_SCORE_EXPONENT, 3);
+
+    // offset=0 (default): after 1 submit + 1 response at latency=10,
+    // numInFlight=0, inFlightEMA=1, latencyEMA=10 -> (0+1)^3 * 10 = 10.
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_HYBRID_SCORE_QUEUE_SIZE_OFFSET, 0);
+    ServerRoutingStatsManager managerNoOffset =
+        new ServerRoutingStatsManager(new PinotConfiguration(properties), _brokerMetrics);
+    managerNoOffset.init();
+    int requestId = 0;
+    managerNoOffset.recordStatsForQuerySubmission(requestId++, "offsetServer");
+    waitForStatsUpdate(managerNoOffset, requestId);
+    managerNoOffset.recordStatsUponResponseArrival(requestId++, "offsetServer", 10);
+    waitForStatsUpdate(managerNoOffset, requestId);
+    assertEquals(managerNoOffset.fetchHybridScoreForServer("offsetServer"), 10.0);
+
+    // offset=1: same sequence -> (1+0+1)^3 * 10 = 80.
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_HYBRID_SCORE_QUEUE_SIZE_OFFSET, 1);
+    ServerRoutingStatsManager managerWithOffset =
+        new ServerRoutingStatsManager(new PinotConfiguration(properties), _brokerMetrics);
+    managerWithOffset.init();
+    requestId = 0;
+    managerWithOffset.recordStatsForQuerySubmission(requestId++, "offsetServer");
+    waitForStatsUpdate(managerWithOffset, requestId);
+    managerWithOffset.recordStatsUponResponseArrival(requestId++, "offsetServer", 10);
+    waitForStatsUpdate(managerWithOffset, requestId);
+    assertEquals(managerWithOffset.fetchHybridScoreForServer("offsetServer"), 80.0);
+  }
+
   private void assertStatsNullForInstance(ServerRoutingStatsManager manager, String instanceId) {
     Integer numInFlightReq = manager.fetchNumInFlightRequestsForServer(instanceId);
     assertNull(numInFlightReq);

--- a/pinot-core/src/test/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsManagerTest.java
@@ -403,7 +403,7 @@ public class ServerRoutingStatsManagerTest {
 
     // offset=0 (default): after 1 submit + 1 response at latency=10,
     // numInFlight=0, inFlightEMA=1, latencyEMA=10 -> (0+1)^3 * 10 = 10.
-    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_HYBRID_SCORE_QUEUE_FLOOR, 0);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_HYBRID_SCORE_QUEUE_SIZE_OFFSET, 0);
     ServerRoutingStatsManager managerNoOffset =
         new ServerRoutingStatsManager(new PinotConfiguration(properties), _brokerMetrics);
     managerNoOffset.init();
@@ -415,7 +415,7 @@ public class ServerRoutingStatsManagerTest {
     assertEquals(managerNoOffset.fetchHybridScoreForServer("offsetServer"), 10.0);
 
     // offset=1: same sequence -> (1+0+1)^3 * 10 = 80.
-    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_HYBRID_SCORE_QUEUE_FLOOR, 1);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_HYBRID_SCORE_QUEUE_SIZE_OFFSET, 1);
     ServerRoutingStatsManager managerWithOffset =
         new ServerRoutingStatsManager(new PinotConfiguration(properties), _brokerMetrics);
     managerWithOffset.init();
@@ -433,7 +433,7 @@ public class ServerRoutingStatsManagerTest {
     // When autodecay is enabled, inFlightEMA eventually decays to 0 during idle periods; at that
     // point offset=0 collapses all scores to (0+0+0)^3 * latency = 0, destroying latency ordering,
     // while offset=1 keeps score = 1^3 * latency = latency and preserves the ranking.
-    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_HYBRID_SCORE_QUEUE_FLOOR, 1);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_HYBRID_SCORE_QUEUE_SIZE_OFFSET, 1);
     ServerRoutingStatsManager managerMultiServer =
         new ServerRoutingStatsManager(new PinotConfiguration(properties), _brokerMetrics);
     managerMultiServer.init();

--- a/pinot-core/src/test/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsManagerTest.java
@@ -389,8 +389,8 @@ public class ServerRoutingStatsManagerTest {
   }
 
   @Test
-  public void testHybridScoreWithQueueSizeOffset() {
-    // With offset=1 the formula is Math.pow(1+A+B, N)*C instead of Math.pow(A+B, N)*C.
+  public void testHybridScoreWithQueueFloor() {
+    // With floor=1 the formula is Math.pow(1+A+B, N)*C instead of Math.pow(A+B, N)*C.
     // This prevents the score from collapsing to 0 when all servers are idle so that latency
     // still drives routing decisions in low-traffic conditions.
     Map<String, Object> properties = new HashMap<>();
@@ -401,38 +401,38 @@ public class ServerRoutingStatsManagerTest {
     properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_AVG_INITIALIZATION_VAL, 0.0);
     properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_HYBRID_SCORE_EXPONENT, 3);
 
-    // offset=0 (default): after 1 submit + 1 response at latency=10,
+    // floor=0 (default): after 1 submit + 1 response at latency=10,
     // numInFlight=0, inFlightEMA=1, latencyEMA=10 -> (0+1)^3 * 10 = 10.
     properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_HYBRID_SCORE_QUEUE_FLOOR, 0);
-    ServerRoutingStatsManager managerNoOffset =
+    ServerRoutingStatsManager managerNoFloor =
         new ServerRoutingStatsManager(new PinotConfiguration(properties), _brokerMetrics);
-    managerNoOffset.init();
+    managerNoFloor.init();
     int requestId = 0;
-    managerNoOffset.recordStatsForQuerySubmission(requestId++, "offsetServer");
-    waitForStatsUpdate(managerNoOffset, requestId);
-    managerNoOffset.recordStatsUponResponseArrival(requestId++, "offsetServer", 10);
-    waitForStatsUpdate(managerNoOffset, requestId);
-    assertEquals(managerNoOffset.fetchHybridScoreForServer("offsetServer"), 10.0);
+    managerNoFloor.recordStatsForQuerySubmission(requestId++, "floorServer");
+    waitForStatsUpdate(managerNoFloor, requestId);
+    managerNoFloor.recordStatsUponResponseArrival(requestId++, "floorServer", 10);
+    waitForStatsUpdate(managerNoFloor, requestId);
+    assertEquals(managerNoFloor.fetchHybridScoreForServer("floorServer"), 10.0);
 
-    // offset=1: same sequence -> (1+0+1)^3 * 10 = 80.
+    // floor=1: same sequence -> (1+0+1)^3 * 10 = 80.
     properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_HYBRID_SCORE_QUEUE_FLOOR, 1);
-    ServerRoutingStatsManager managerWithOffset =
+    ServerRoutingStatsManager managerWithFloor =
         new ServerRoutingStatsManager(new PinotConfiguration(properties), _brokerMetrics);
-    managerWithOffset.init();
+    managerWithFloor.init();
     requestId = 0;
-    managerWithOffset.recordStatsForQuerySubmission(requestId++, "offsetServer");
-    waitForStatsUpdate(managerWithOffset, requestId);
-    managerWithOffset.recordStatsUponResponseArrival(requestId++, "offsetServer", 10);
-    waitForStatsUpdate(managerWithOffset, requestId);
-    assertEquals(managerWithOffset.fetchHybridScoreForServer("offsetServer"), 80.0);
+    managerWithFloor.recordStatsForQuerySubmission(requestId++, "floorServer");
+    waitForStatsUpdate(managerWithFloor, requestId);
+    managerWithFloor.recordStatsUponResponseArrival(requestId++, "floorServer", 10);
+    waitForStatsUpdate(managerWithFloor, requestId);
+    assertEquals(managerWithFloor.fetchHybridScoreForServer("floorServer"), 80.0);
 
     // Multiple idle servers (numInFlight=0 after queries complete) should be ranked by latency.
     // In this config (autodecay disabled, alpha=1) inFlightEMA freezes at 1 after the first
-    // submission, so with offset=1: score = (1+0+1)^3 * latency = 8 * latency.
+    // submission, so with floor=1: score = (1+0+1)^3 * latency = 8 * latency.
     // The server with lower observed latency gets a lower score and is therefore preferred.
     // When autodecay is enabled, inFlightEMA eventually decays to 0 during idle periods; at that
-    // point offset=0 collapses all scores to (0+0+0)^3 * latency = 0, destroying latency ordering,
-    // while offset=1 keeps score = 1^3 * latency = latency and preserves the ranking.
+    // point floor=0 collapses all scores to (0+0+0)^3 * latency = 0, destroying latency ordering,
+    // while floor=1 keeps score = 1^3 * latency = latency and preserves the ranking.
     properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_HYBRID_SCORE_QUEUE_FLOOR, 1);
     ServerRoutingStatsManager managerMultiServer =
         new ServerRoutingStatsManager(new PinotConfiguration(properties), _brokerMetrics);

--- a/pinot-core/src/test/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsManagerTest.java
@@ -403,7 +403,7 @@ public class ServerRoutingStatsManagerTest {
 
     // offset=0 (default): after 1 submit + 1 response at latency=10,
     // numInFlight=0, inFlightEMA=1, latencyEMA=10 -> (0+1)^3 * 10 = 10.
-    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_HYBRID_SCORE_QUEUE_SIZE_OFFSET, 0);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_HYBRID_SCORE_QUEUE_FLOOR, 0);
     ServerRoutingStatsManager managerNoOffset =
         new ServerRoutingStatsManager(new PinotConfiguration(properties), _brokerMetrics);
     managerNoOffset.init();
@@ -415,7 +415,7 @@ public class ServerRoutingStatsManagerTest {
     assertEquals(managerNoOffset.fetchHybridScoreForServer("offsetServer"), 10.0);
 
     // offset=1: same sequence -> (1+0+1)^3 * 10 = 80.
-    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_HYBRID_SCORE_QUEUE_SIZE_OFFSET, 1);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_HYBRID_SCORE_QUEUE_FLOOR, 1);
     ServerRoutingStatsManager managerWithOffset =
         new ServerRoutingStatsManager(new PinotConfiguration(properties), _brokerMetrics);
     managerWithOffset.init();
@@ -433,7 +433,7 @@ public class ServerRoutingStatsManagerTest {
     // When autodecay is enabled, inFlightEMA eventually decays to 0 during idle periods; at that
     // point offset=0 collapses all scores to (0+0+0)^3 * latency = 0, destroying latency ordering,
     // while offset=1 keeps score = 1^3 * latency = latency and preserves the ranking.
-    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_HYBRID_SCORE_QUEUE_SIZE_OFFSET, 1);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_HYBRID_SCORE_QUEUE_FLOOR, 1);
     ServerRoutingStatsManager managerMultiServer =
         new ServerRoutingStatsManager(new PinotConfiguration(properties), _brokerMetrics);
     managerMultiServer.init();

--- a/pinot-core/src/test/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsManagerTest.java
@@ -403,7 +403,7 @@ public class ServerRoutingStatsManagerTest {
 
     // offset=0 (default): after 1 submit + 1 response at latency=10,
     // numInFlight=0, inFlightEMA=1, latencyEMA=10 -> (0+1)^3 * 10 = 10.
-    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_HYBRID_SCORE_QUEUE_SIZE_OFFSET, 0);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_HYBRID_SCORE_QUEUE_FLOOR, 0);
     ServerRoutingStatsManager managerNoOffset =
         new ServerRoutingStatsManager(new PinotConfiguration(properties), _brokerMetrics);
     managerNoOffset.init();
@@ -415,7 +415,7 @@ public class ServerRoutingStatsManagerTest {
     assertEquals(managerNoOffset.fetchHybridScoreForServer("offsetServer"), 10.0);
 
     // offset=1: same sequence -> (1+0+1)^3 * 10 = 80.
-    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_HYBRID_SCORE_QUEUE_SIZE_OFFSET, 1);
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_HYBRID_SCORE_QUEUE_FLOOR, 1);
     ServerRoutingStatsManager managerWithOffset =
         new ServerRoutingStatsManager(new PinotConfiguration(properties), _brokerMetrics);
     managerWithOffset.init();
@@ -425,6 +425,34 @@ public class ServerRoutingStatsManagerTest {
     managerWithOffset.recordStatsUponResponseArrival(requestId++, "offsetServer", 10);
     waitForStatsUpdate(managerWithOffset, requestId);
     assertEquals(managerWithOffset.fetchHybridScoreForServer("offsetServer"), 80.0);
+
+    // Multiple idle servers (numInFlight=0 after queries complete) should be ranked by latency.
+    // In this config (autodecay disabled, alpha=1) inFlightEMA freezes at 1 after the first
+    // submission, so with offset=1: score = (1+0+1)^3 * latency = 8 * latency.
+    // The server with lower observed latency gets a lower score and is therefore preferred.
+    // When autodecay is enabled, inFlightEMA eventually decays to 0 during idle periods; at that
+    // point offset=0 collapses all scores to (0+0+0)^3 * latency = 0, destroying latency ordering,
+    // while offset=1 keeps score = 1^3 * latency = latency and preserves the ranking.
+    properties.put(CommonConstants.Broker.AdaptiveServerSelector.CONFIG_OF_HYBRID_SCORE_QUEUE_FLOOR, 1);
+    ServerRoutingStatsManager managerMultiServer =
+        new ServerRoutingStatsManager(new PinotConfiguration(properties), _brokerMetrics);
+    managerMultiServer.init();
+    requestId = 0;
+
+    managerMultiServer.recordStatsForQuerySubmission(requestId++, "fastServer");
+    waitForStatsUpdate(managerMultiServer, requestId);
+    managerMultiServer.recordStatsUponResponseArrival(requestId++, "fastServer", 5);
+    waitForStatsUpdate(managerMultiServer, requestId);
+
+    managerMultiServer.recordStatsForQuerySubmission(requestId++, "slowServer");
+    waitForStatsUpdate(managerMultiServer, requestId);
+    managerMultiServer.recordStatsUponResponseArrival(requestId++, "slowServer", 20);
+    waitForStatsUpdate(managerMultiServer, requestId);
+
+    // Both servers are now idle (numInFlight=0). The fast server should rank better (lower score).
+    double fastScore = managerMultiServer.fetchHybridScoreForServer("fastServer");
+    double slowScore = managerMultiServer.fetchHybridScoreForServer("slowServer");
+    assertTrue(fastScore < slowScore, "Idle servers should be ranked by latency");
   }
 
   private void assertStatsNullForInstance(ServerRoutingStatsManager manager, String instanceId) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -1134,9 +1134,9 @@ public class CommonConstants {
       // Parameters related to Hybrid score.
       public static final String CONFIG_OF_HYBRID_SCORE_EXPONENT = CONFIG_PREFIX + ".hybrid.score.exponent";
       public static final int DEFAULT_HYBRID_SCORE_EXPONENT = 3;
-      public static final String CONFIG_OF_HYBRID_SCORE_QUEUE_FLOOR =
+      public static final String CONFIG_OF_HYBRID_SCORE_QUEUE_SIZE_OFFSET =
           CONFIG_PREFIX + ".hybrid.score.queue.size.offset";
-      public static final int DEFAULT_HYBRID_SCORE_QUEUE_FLOOR = 0;
+      public static final int DEFAULT_HYBRID_SCORE_QUEUE_SIZE_OFFSET = 0;
 
       // Threadpool size of ServerRoutingStatsManager. This controls the number of threads available to update routing
       // stats for servers upon query submission and response arrival.

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -1135,7 +1135,7 @@ public class CommonConstants {
       public static final String CONFIG_OF_HYBRID_SCORE_EXPONENT = CONFIG_PREFIX + ".hybrid.score.exponent";
       public static final int DEFAULT_HYBRID_SCORE_EXPONENT = 3;
       public static final String CONFIG_OF_HYBRID_SCORE_QUEUE_FLOOR =
-          CONFIG_PREFIX + ".hybrid.score.queue.size.offset";
+          CONFIG_PREFIX + ".hybrid.score.queue.size.floor";
       public static final int DEFAULT_HYBRID_SCORE_QUEUE_FLOOR = 0;
 
       // Threadpool size of ServerRoutingStatsManager. This controls the number of threads available to update routing

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -1134,9 +1134,9 @@ public class CommonConstants {
       // Parameters related to Hybrid score.
       public static final String CONFIG_OF_HYBRID_SCORE_EXPONENT = CONFIG_PREFIX + ".hybrid.score.exponent";
       public static final int DEFAULT_HYBRID_SCORE_EXPONENT = 3;
-      public static final String CONFIG_OF_HYBRID_SCORE_QUEUE_SIZE_OFFSET =
+      public static final String CONFIG_OF_HYBRID_SCORE_QUEUE_FLOOR =
           CONFIG_PREFIX + ".hybrid.score.queue.size.offset";
-      public static final int DEFAULT_HYBRID_SCORE_QUEUE_SIZE_OFFSET = 0;
+      public static final int DEFAULT_HYBRID_SCORE_QUEUE_FLOOR = 0;
 
       // Threadpool size of ServerRoutingStatsManager. This controls the number of threads available to update routing
       // stats for servers upon query submission and response arrival.

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -1134,6 +1134,9 @@ public class CommonConstants {
       // Parameters related to Hybrid score.
       public static final String CONFIG_OF_HYBRID_SCORE_EXPONENT = CONFIG_PREFIX + ".hybrid.score.exponent";
       public static final int DEFAULT_HYBRID_SCORE_EXPONENT = 3;
+      public static final String CONFIG_OF_HYBRID_SCORE_QUEUE_SIZE_OFFSET =
+          CONFIG_PREFIX + ".hybrid.score.queue.size.offset";
+      public static final int DEFAULT_HYBRID_SCORE_QUEUE_SIZE_OFFSET = 0;
 
       // Threadpool size of ServerRoutingStatsManager. This controls the number of threads available to update routing
       // stats for servers upon query submission and response arrival.


### PR DESCRIPTION
Adaptive routing uses the following formula to score
```
JsonProperty("hybridScore")
public double computeHybridScore() {
  double estimatedQSize = _numInFlightRequests + _inFlighRequestsEMA.getAverage();
  return Math.pow(estimatedQSize, _hybridScoreExponent) * _latencyMsEMA.getAverage();
}
```
`EMA` = exponentially weighted moving average.

This term is pretty unstable if the number of inflight requests is low (e.g. Stripe's test cluster often has 0 inflight requests, even at 80 RPS). I was thinking that this formula might be better as (1 + A + B)^3 * C , so the server latency is always accounted for in the score.

Looking at the [paper](https://www.usenix.org/system/files/conference/nsdi15/nsdi15-paper-suresh.pdf) that was the original source for the formula, their "queue-size estimation" included a +1 term. It seems like it was a bug in the original adaptive routing implementation. This +1 term was also mentioned in the [original feature design doc](https://docs.google.com/document/d/1w8YVpKIj0S62NvwDpf1HgruwxJYJ6ODuKQLjGXupH8w/edit?tab=t.0#heading=h.1us4z2nuog6s). 

To avoid causing any behavioural regressions for existing users of adaptive routing, instead of just adding a `+1` to the formula, we should add a parameter defaulting to 0.

On high concurrency clusters, this should have marginal impact. (if num_inflight_requests ~= 100, now it would be 101). On low concurrency clusters, we should have more meaningful scores. This way, multiple idle servers would still have a score ~= their latency, instead of all having a score of 0.

We tested on an internal cluster and saw the adaptive routing scores stabilize on our low concurrency test cluster. 