### PR TITLE
Include MSE inflight_requests in adaptive query stats

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
@@ -495,7 +495,6 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
       multiStageBrokerRequestHandler =
           new MultiStageBrokerRequestHandler(_brokerConf, brokerId, requestIdGenerator, _routingManager,
               _accessControlFactory, _queryQuotaManager, _tableCache, _multiStageQueryThrottler, _failureDetector,
-<<<<<<< HEAD
               _threadAccountant, multiClusterRoutingContext, workerManager, multiClusterWorkerManager,
               _serverRoutingStatsManager);
       MultiStageBrokerRequestHandler finalHandler = multiStageBrokerRequestHandler;

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
@@ -495,7 +495,9 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
       multiStageBrokerRequestHandler =
           new MultiStageBrokerRequestHandler(_brokerConf, brokerId, requestIdGenerator, _routingManager,
               _accessControlFactory, _queryQuotaManager, _tableCache, _multiStageQueryThrottler, _failureDetector,
-              _threadAccountant, multiClusterRoutingContext, workerManager, multiClusterWorkerManager);
+<<<<<<< HEAD
+              _threadAccountant, multiClusterRoutingContext, workerManager, multiClusterWorkerManager,
+              _serverRoutingStatsManager);
       MultiStageBrokerRequestHandler finalHandler = multiStageBrokerRequestHandler;
       _routingManager.setServerReenableCallback(
           serverInstance -> finalHandler.getQueryDispatcher().resetClientConnectionBackoff(serverInstance));

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -74,6 +74,7 @@ import org.apache.pinot.common.utils.tls.TlsUtils;
 import org.apache.pinot.core.routing.MultiClusterRoutingContext;
 import org.apache.pinot.core.routing.RoutingManager;
 import org.apache.pinot.core.transport.ServerInstance;
+import org.apache.pinot.core.transport.server.routing.stats.ServerRoutingStatsManager;
 import org.apache.pinot.query.ImmutableQueryEnvironment;
 import org.apache.pinot.query.QueryEnvironment;
 import org.apache.pinot.query.mailbox.MailboxService;
@@ -132,6 +133,8 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
   private final WorkerManager _workerManager;
   private final WorkerManager _multiClusterWorkerManager;
   private final QueryDispatcher _queryDispatcher;
+  @Nullable
+  private final ServerRoutingStatsManager _serverRoutingStatsManager;
   private final boolean _explainAskingServerDefault;
   private final MultiStageQueryThrottler _queryThrottler;
   private final ExecutorService _queryCompileExecutor;
@@ -149,9 +152,11 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
       AccessControlFactory accessControlFactory, QueryQuotaManager queryQuotaManager, TableCache tableCache,
       MultiStageQueryThrottler queryThrottler, FailureDetector failureDetector, ThreadAccountant threadAccountant,
       MultiClusterRoutingContext multiClusterRoutingContext,
-      WorkerManager workerManager, WorkerManager multiClusterWorkerManager) {
+      WorkerManager workerManager, WorkerManager multiClusterWorkerManager,
+      @Nullable ServerRoutingStatsManager statsManager) {
     super(config, brokerId, requestIdGenerator, routingManager, accessControlFactory, queryQuotaManager, tableCache,
         threadAccountant, multiClusterRoutingContext);
+    _serverRoutingStatsManager = statsManager;
     String hostname = config.getProperty(CommonConstants.MultiStageQueryRunner.KEY_OF_QUERY_RUNNER_HOSTNAME);
     int port = Integer.parseInt(config.getProperty(CommonConstants.MultiStageQueryRunner.KEY_OF_QUERY_RUNNER_PORT));
 
@@ -643,7 +648,7 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
       QueryDispatcher.QueryResult queryResults;
       try {
         queryResults = _queryDispatcher.submitAndReduce(requestContext, dispatchableSubPlan, timer.getRemainingTimeMs(),
-            query.getOptions());
+            query.getOptions(), _serverRoutingStatsManager);
       } catch (QueryException e) {
         throw e;
       } catch (Throwable t) {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
@@ -63,6 +63,7 @@ import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.common.utils.grpc.ServerGrpcQueryClient;
 import org.apache.pinot.core.instance.context.BrokerContext;
 import org.apache.pinot.core.transport.ServerInstance;
+import org.apache.pinot.core.transport.server.routing.stats.ServerRoutingStatsManager;
 import org.apache.pinot.core.util.DataBlockExtractUtils;
 import org.apache.pinot.core.util.trace.TracedThreadFactory;
 import org.apache.pinot.query.mailbox.MailboxService;
@@ -150,10 +151,40 @@ public class QueryDispatcher {
   public QueryResult submitAndReduce(RequestContext context, DispatchableSubPlan dispatchableSubPlan, long timeoutMs,
       Map<String, String> queryOptions)
       throws Exception {
+    return submitAndReduce(context, dispatchableSubPlan, timeoutMs, queryOptions, null);
+  }
+
+  /// Same as {@link #submitAndReduce(RequestContext, DispatchableSubPlan, long, Map)} but records per-server
+  /// in-flight request statistics into {@code statsManager} for use by the adaptive query router.
+  /// When {@code statsManager} is non-null:
+  /// <ul>
+  ///   <li>Each leaf server is registered as having one more in-flight request via
+  ///       {@link ServerRoutingStatsManager#recordStatsForQuerySubmission} after the fan-out begins.</li>
+  ///   <li>After the full fan-out completes (or fails), each server is decremented via
+  ///       {@link ServerRoutingStatsManager#recordStatsUponResponseArrival} with {@code latency = -1}
+  ///       (no latency is recorded at this stage).</li>
+  /// </ul>
+  /// TODO: Replace the coarse end-of-fanout decrement with per-sender arrival once per-sender EOS
+  ///       interception is in place, and record real leaf-stage latency at that point.
+  public QueryResult submitAndReduce(RequestContext context, DispatchableSubPlan dispatchableSubPlan, long timeoutMs,
+      Map<String, String> queryOptions, @Nullable ServerRoutingStatsManager statsManager)
+      throws Exception {
     long requestId = context.getRequestId();
     Set<QueryServerInstance> servers = new HashSet<>();
+    // Tracks servers where recordStatsForQuerySubmission was actually called, so the finally block only
+    // decrements servers that were incremented — guarding against a partial failure in submit().
+    Set<QueryServerInstance> incrementedServers = new HashSet<>();
     try {
       submit(requestId, dispatchableSubPlan, timeoutMs, servers, queryOptions);
+      // The SSE engine increments before `submit`, but here we increment after because `submit` populates
+      // the list of servers. Getting the list of servers before calling `submit` would expose
+      // implementation details of `submit`.
+      if (statsManager != null) {
+        for (QueryServerInstance server : servers) {
+          statsManager.recordStatsForQuerySubmission(requestId, server.getInstanceId());
+          incrementedServers.add(server);
+        }
+      }
       QueryResult result = runReducer(dispatchableSubPlan, queryOptions, _mailboxService);
       if (result.getProcessingException() != null) {
         cancel(requestId);
@@ -166,6 +197,11 @@ public class QueryDispatcher {
       cancel(requestId);
       throw e;
     } finally {
+      if (statsManager != null) {
+        for (QueryServerInstance server : incrementedServers) {
+          statsManager.recordStatsUponResponseArrival(requestId, server.getInstanceId(), -1);
+        }
+      }
       if (isQueryCancellationEnabled()) {
         _serversByQuery.remove(requestId);
       }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/dispatch/QueryDispatcherTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/dispatch/QueryDispatcherTest.java
@@ -243,9 +243,20 @@ public class QueryDispatcherTest extends QueryTestSet {
     }
     Assert.assertFalse(expectedInstanceIds.isEmpty());
 
+    // Spy the dispatcher and stub submit() to populate the server set without real gRPC dispatch.
+    // This isolates the stats-recording logic from gRPC test infrastructure.
+    QueryDispatcher spyDispatcher = Mockito.spy(_queryDispatcher);
+    Mockito.doAnswer(inv -> {
+      Set<QueryServerInstance> serversOut = inv.getArgument(3);
+      for (DispatchablePlanFragment fragment : plan.getQueryStagesWithoutRoot()) {
+        serversOut.addAll(fragment.getServerInstanceToWorkerIdMap().keySet());
+      }
+      return null;
+    }).when(spyDispatcher).submit(Mockito.anyLong(), Mockito.any(), Mockito.anyLong(), Mockito.any(), Mockito.any());
+
     try (QueryThreadContext ignore = QueryThreadContext.openForMseTest()) {
-      _queryDispatcher.submitAndReduce(context, plan, 10_000L, Map.of(), statsManager);
-    } catch (NullPointerException e) {
+      spyDispatcher.submitAndReduce(context, plan, 10_000L, Map.of(), statsManager);
+    } catch (Exception e) {
       // expected: reduce phase fails with mocked MailboxService
     }
 
@@ -256,7 +267,7 @@ public class QueryDispatcherTest extends QueryTestSet {
   }
 
   @Test
-  public void testStatsManagerArrivalRecordedEvenWhenDispatchFails()
+  public void testStatsManagerNotRecordedWhenDispatchFails()
       throws Exception {
     ServerRoutingStatsManager statsManager = Mockito.mock(ServerRoutingStatsManager.class);
     QueryServer failingServer = _queryServerMap.values().iterator().next();
@@ -278,9 +289,8 @@ public class QueryDispatcherTest extends QueryTestSet {
       // dispatch failed — expected
     }
 
-    // Inflight must be decremented even when dispatch fails
-    Mockito.verify(statsManager, Mockito.atLeastOnce())
-        .recordStatsUponResponseArrival(Mockito.eq(requestId), Mockito.anyString(), Mockito.eq(-1L));
+    // Stats are only recorded after submit() succeeds; when dispatch fails, no stats interactions occur
+    Mockito.verifyNoInteractions(statsManager);
     Mockito.reset(failingServer);
   }
 }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/dispatch/QueryDispatcherTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/dispatch/QueryDispatcherTest.java
@@ -31,11 +31,14 @@ import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.pinot.common.failuredetector.FailureDetector;
 import org.apache.pinot.common.proto.Worker;
+import org.apache.pinot.core.transport.server.routing.stats.ServerRoutingStatsManager;
 import org.apache.pinot.query.QueryEnvironment;
 import org.apache.pinot.query.QueryEnvironmentTestBase;
 import org.apache.pinot.query.QueryTestSet;
 import org.apache.pinot.query.mailbox.MailboxService;
+import org.apache.pinot.query.planner.physical.DispatchablePlanFragment;
 import org.apache.pinot.query.planner.physical.DispatchableSubPlan;
+import org.apache.pinot.query.routing.QueryServerInstance;
 import org.apache.pinot.query.runtime.QueryRunner;
 import org.apache.pinot.query.service.server.QueryServer;
 import org.apache.pinot.query.testutils.QueryTestUtils;
@@ -220,5 +223,64 @@ public class QueryDispatcherTest extends QueryTestSet {
     try (QueryThreadContext ignore = QueryThreadContext.openForMseTest()) {
       _queryDispatcher.submit(REQUEST_ID_GEN.getAndIncrement(), dispatchableSubPlan, 0L, new HashSet<>(), Map.of());
     }
+  }
+
+  @Test
+  public void testStatsManagerRecordsSubmissionAndArrivalForDispatchedServers()
+      throws Exception {
+    ServerRoutingStatsManager statsManager = Mockito.mock(ServerRoutingStatsManager.class);
+    String sql = "SELECT * FROM a";
+    long requestId = REQUEST_ID_GEN.getAndIncrement();
+    RequestContext context = new DefaultRequestContext();
+    context.setRequestId(requestId);
+    DispatchableSubPlan plan = _queryEnvironment.planQuery(sql);
+
+    Set<String> expectedInstanceIds = new HashSet<>();
+    for (DispatchablePlanFragment fragment : plan.getQueryStagesWithoutRoot()) {
+      for (QueryServerInstance server : fragment.getServerInstanceToWorkerIdMap().keySet()) {
+        expectedInstanceIds.add(server.getInstanceId());
+      }
+    }
+    Assert.assertFalse(expectedInstanceIds.isEmpty());
+
+    try (QueryThreadContext ignore = QueryThreadContext.openForMseTest()) {
+      _queryDispatcher.submitAndReduce(context, plan, 10_000L, Map.of(), statsManager);
+    } catch (NullPointerException e) {
+      // expected: reduce phase fails with mocked MailboxService
+    }
+
+    for (String instanceId : expectedInstanceIds) {
+      Mockito.verify(statsManager).recordStatsForQuerySubmission(requestId, instanceId);
+      Mockito.verify(statsManager).recordStatsUponResponseArrival(requestId, instanceId, -1L);
+    }
+  }
+
+  @Test
+  public void testStatsManagerArrivalRecordedEvenWhenDispatchFails()
+      throws Exception {
+    ServerRoutingStatsManager statsManager = Mockito.mock(ServerRoutingStatsManager.class);
+    QueryServer failingServer = _queryServerMap.values().iterator().next();
+    Mockito.doAnswer(inv -> {
+      StreamObserver<Worker.QueryResponse> obs = inv.getArgument(1);
+      obs.onError(new RuntimeException("simulated failure"));
+      return null;
+    }).when(failingServer).submit(Mockito.any(), Mockito.any());
+
+    String sql = "SELECT * FROM a WHERE col1 = 'foo'";
+    long requestId = REQUEST_ID_GEN.getAndIncrement();
+    RequestContext context = new DefaultRequestContext();
+    context.setRequestId(requestId);
+    DispatchableSubPlan plan = _queryEnvironment.planQuery(sql);
+
+    try (QueryThreadContext ignore = QueryThreadContext.openForMseTest()) {
+      _queryDispatcher.submitAndReduce(context, plan, 10_000L, Map.of(), statsManager);
+    } catch (Exception e) {
+      // dispatch failed — expected
+    }
+
+    // Inflight must be decremented even when dispatch fails
+    Mockito.verify(statsManager, Mockito.atLeastOnce())
+        .recordStatsUponResponseArrival(Mockito.eq(requestId), Mockito.anyString(), Mockito.eq(-1L));
+    Mockito.reset(failingServer);
   }
 }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/dispatch/QueryDispatcherTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/dispatch/QueryDispatcherTest.java
@@ -267,8 +267,17 @@ public class QueryDispatcherTest extends QueryTestSet {
   }
 
   @Test
-  public void testStatsManagerNotRecordedWhenDispatchFails()
-      throws Exception {
+  public void testNoStatsRecordedWhenDispatchFails() throws Exception {
+    // Stub submit() to throw before recordStatsForQuerySubmission runs. The finally block must
+    // make zero interactions with statsManager — guarding against a decrement without a prior
+    // increment in ServerRoutingStatsManager's in-flight tracking.
+    // Using doThrow on submit() directly is deterministic; relying on gRPC obs.onError() timing
+    // is not (error delivery order varies with channel warmup state).
+    QueryDispatcher spyDispatcher = Mockito.spy(_queryDispatcher);
+    Mockito.doThrow(new RuntimeException("simulated failure"))
+        .when(spyDispatcher)
+        .submit(Mockito.anyLong(), Mockito.any(), Mockito.anyLong(), Mockito.any(), Mockito.any());
+
     ServerRoutingStatsManager statsManager = Mockito.mock(ServerRoutingStatsManager.class);
     QueryServer failingServer = _queryServerMap.values().iterator().next();
     Mockito.doAnswer(inv -> {
@@ -283,11 +292,12 @@ public class QueryDispatcherTest extends QueryTestSet {
     context.setRequestId(requestId);
     DispatchableSubPlan plan = _queryEnvironment.planQuery(sql);
 
-    try (QueryThreadContext ignore = QueryThreadContext.openForMseTest()) {
-      _queryDispatcher.submitAndReduce(context, plan, 10_000L, Map.of(), statsManager);
-    } catch (Exception e) {
-      // dispatch failed — expected
-    }
+    RuntimeException thrown = Assert.expectThrows(RuntimeException.class, () -> {
+      try (QueryThreadContext ignore = QueryThreadContext.openForMseTest()) {
+        spyDispatcher.submitAndReduce(context, plan, 10_000L, Map.of(), statsManager);
+      }
+    });
+    Assert.assertEquals(thrown.getMessage(), "simulated failure");
 
     // Stats are only recorded after submit() succeeds; when dispatch fails, no stats interactions occur
     Mockito.verifyNoInteractions(statsManager);


### PR DESCRIPTION
Records per-server in-flight request counts for MSE queries so that `NumInFlightReqSelector` and `HybridSelector` can start to factor in MSE load.

- `MultiStageBrokerRequestHandler`: accept optional `ServerRoutingStatsManager` via new constructor overload; pass through to `QueryDispatcher`
- `BaseBrokerStarter`: pass `_serverRoutingStatsManager` to the handler
- `QueryDispatcher.submitAndReduce`: when `statsManager` is present, call `recordStatsForQuerySubmission` for each dispatched server after `submit()`, and decrement inflight for all servers in the finally block via `recordStatsUponResponseArrival(..., -1)`

Latency (`recordStatsUponResponseArrival` with real values) and per-sender arrival granularity are left to a follow-up PR once per-sender EOS interception is in place (see TODO in submitAndReduce). Supplying `-1` for latency will [ignore the latency value](https://github.com/apache/pinot/blob/master/pinot-core/src/main/java/org/apache/pinot/core/transport/server/routing/stats/ServerRoutingStatsManager.java#L205-L207). 

Submit could fail part way through so we never get to the incrementing. To handle this, we either have to:
* split up calculating the server list from the actual dispatch.
* send the stats manager (or a hook) into the dispatch
* **be okay with sometimes under-reporting the number of inflight ops for a few servers.** This approach is the simplest. Under-reporting is unlikely to result in a systemic bias towards a set of servers, and the stats are only used for adaptive routing.
