### PR TITLE
[bugfix] fix memory leak

### DIFF
--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/BrokerCache.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/BrokerCache.java
@@ -129,7 +129,13 @@ public class BrokerCache {
         .setConnectTimeout(Duration.ofMillis(connectTimeoutMs))
         .setHandshakeTimeout(handshakeTimeoutMs)
         .setUserAgent(ConnectionUtils.getUserAgentVersionFromClassPath("ua_broker_cache", appId))
-        .setEnabledProtocols(tlsProtocols.getEnabledProtocols().toArray(new String[0]));
+        .setEnabledProtocols(tlsProtocols.getEnabledProtocols().toArray(new String[0]))
+        // Reuse a JVM-wide Netty I/O thread pool and timer across all BrokerCache instances so
+        // that the periodic broker refresh does not multiply Netty threads by the number of
+        // client connections. AHC will not shut these down on close() because they are externally
+        // supplied (see ChannelManager#allowReleaseEventLoopGroup / AHC#allowStopNettyTimer).
+        .setEventLoopGroup(PinotClientNettyResources.eventLoopGroup())
+        .setNettyTimer(PinotClientNettyResources.timer());
 
     _client = Dsl.asyncHttpClient(builder.build());
     ControllerRequestURLBuilder controllerRequestURLBuilder =

--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/PinotClientNettyResources.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/PinotClientNettyResources.java
@@ -1,0 +1,82 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.client;
+
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.util.HashedWheelTimer;
+import io.netty.util.Timer;
+import io.netty.util.concurrent.DefaultThreadFactory;
+
+
+/**
+ * Process-wide shared Netty resources for Pinot client {@code AsyncHttpClient} instances.
+ *
+ * <p>Every {@code AsyncHttpClient} built inside the Pinot client (one per {@link BrokerCache},
+ * per query transport, and per controller transport) owns, by default, its own
+ * {@link io.netty.channel.EventLoopGroup} and {@link io.netty.util.HashedWheelTimer}. When many
+ * client connections are kept alive simultaneously (for example behind a JDBC connection pool
+ * such as HikariCP), this multiplies the number of Netty I/O and timer threads by the number of
+ * pooled connections. The combination of AHC's default pooled-connection idle timeout (60s) and
+ * the broker cache refresh interval (5 minutes) additionally causes new TCP connections to be
+ * opened on every refresh, which lazily spawns fresh {@code NioEventLoop} threads up to each
+ * group's {@code 2 * availableProcessors()} cap.
+ *
+ * <p>AsyncHttpClient natively supports injecting an externally managed {@code EventLoopGroup}
+ * and {@code Timer} via
+ * {@link org.asynchttpclient.DefaultAsyncHttpClientConfig.Builder#setEventLoopGroup(EventLoopGroup)}
+ * and {@link org.asynchttpclient.DefaultAsyncHttpClientConfig.Builder#setNettyTimer(Timer)}; when
+ * either is supplied externally, AHC will not shut it down on {@code close()} (see
+ * {@code ChannelManager#allowReleaseEventLoopGroup} and
+ * {@code DefaultAsyncHttpClient#allowStopNettyTimer}). This class exposes such shared instances
+ * so that Pinot client AHCs can reuse a single I/O thread pool and a single timer across the
+ * JVM regardless of how many {@code AsyncHttpClient} instances are created.
+ *
+ * <p>The underlying threads are daemon threads; no explicit shutdown is required and they will
+ * not block JVM exit.
+ */
+public final class PinotClientNettyResources {
+
+  private PinotClientNettyResources() {
+  }
+
+  private static final class Holder {
+    private static final EventLoopGroup EVENT_LOOP_GROUP =
+        new NioEventLoopGroup(0, new DefaultThreadFactory("pinot-client-nio", true));
+    private static final Timer TIMER =
+        new HashedWheelTimer(new DefaultThreadFactory("pinot-client-timer", true));
+  }
+
+  /**
+   * Returns the JVM-wide shared {@link EventLoopGroup} for Pinot client {@code AsyncHttpClient}
+   * instances. The group uses daemon threads and the Netty default size of
+   * {@code 2 * availableProcessors()}.
+   */
+  public static EventLoopGroup eventLoopGroup() {
+    return Holder.EVENT_LOOP_GROUP;
+  }
+
+  /**
+   * Returns the JVM-wide shared {@link Timer} for Pinot client {@code AsyncHttpClient} instances.
+   * The timer uses a daemon thread.
+   */
+  public static Timer timer() {
+    return Holder.TIMER;
+  }
+}


### PR DESCRIPTION
## Background

We packaged a new `pinot-jdbc-driver` based on Pinot 1.5.0 and rolled it out to production services that use `PinotDriver` behind a HikariCP connection pool — a standard, high-throughput JDBC integration pattern.
Shortly after the upgrade, those services began reporting `OutOfMemoryError` in production. The OOMs were not query-related and could not be reproduced with ad-hoc single-connection usage; they correlated strictly with the use of a connection pool and the amount of wall-clock time the service had been running.


**Screenshot 1 — Production OOM stack trace from the affected service:**
<img width="920" height="614" alt="image" src="https://github.com/user-attachments/assets/2ab338b0-7c68-4991-8c58-d0e21d0e0f73" />

**Screenshot 2 — Reproduction showing thread count growing by 20 every 5
minutes under HikariCP (pool size = 20):**
<img width="1613" height="427" alt="image" src="https://github.com/user-attachments/assets/705d87ea-cce1-4721-8efb-52eb62289b27" />

**Screenshot 3 — Same reproduction after this fix; thread count stays flat
across multiple refresh cycles:**
<img width="1615" height="418" alt="image" src="https://github.com/user-attachments/assets/69b2a60a-21e4-4950-9802-1badbbdc9d7d" />


## Problem
Each `BrokerCache` instance creates its own `AsyncHttpClient`, which in turn creates its own private `NioEventLoopGroup` (sized `2 * availableProcessors()`) and `HashedWheelTimer` thread. When the Pinot Java / JDBC client is used behind a connection pool (e.g. HikariCP) with N pooled connections, there are N `BrokerCache` instances, and therefore N independent Netty thread pools for a task that is fundamentally shared: periodically refreshing the broker-to-table mapping from the controller.
Two behaviors compound the cost:
1. `BrokerCacheUpdaterPeriodic` refreshes every 5 minutes by default. Between refreshes the pooled HTTP connection sits idle for ~5 minutes, well beyond AHC's default `pooledConnectionIdleTimeout` of 60s, so the connection pool cleaner closes the TCP connection every cycle.
2. The next refresh opens a brand-new TCP connection, which Netty binds to the next `NioEventLoop` slot via round-robin. If that slot's worker thread has not been lazily spawned yet, it is spawned now. This means the NIO thread count grows by roughly +1 per `BrokerCache` per refresh interval, until each private `NioEventLoopGroup` reaches its `2 * NPROC` cap.
With N pooled JDBC connections on an M-core host, `BrokerCache` alone can contribute up to `N * 2 * M` Netty NIO threads plus `N` `HashedWheelTimer` threads, growing observably over time.

## Root cause
Each `BrokerCache` owns a private Netty I/O thread pool for a workload that is effectively homogeneous across all instances (GET `/brokers/tables` from the controller). The per-instance ownership model is the source of the amplification; the instances do not need private thread pools to remain correct.

## Fix
Introduce `PinotClientNettyResources`, a small holder that exposes a single JVM-wide daemon `NioEventLoopGroup` and a single JVM-wide daemon `HashedWheelTimer`. `BrokerCache` now injects both into its AHC builder via `setEventLoopGroup(...)` and `setNettyTimer(...)`.
AsyncHttpClient natively supports this sharing pattern: when either resource is supplied externally, AHC does not shut it down on `close()` (`ChannelManager#allowReleaseEventLoopGroup` and `DefaultAsyncHttpClient#allowStopNettyTimer` are both set to `false` in that case). Each `BrokerCache` still owns its own `AsyncHttpClient`, connection pool, SSL context, timeouts, and headers — only the low-level Netty I/O threads and timer thread are shared.
After this change, the total NIO thread count contributed by `BrokerCache` refreshes is bounded by `2 * availableProcessors()` globally, independent of the number of pooled `PinotConnection` / `Connection` instances. All shared threads are daemon, so they do not block JVM exit.

## Scope of change
- New class: `pinot-clients/pinot-java-client/.../PinotClientNettyResources.java`
- Modified: `pinot-clients/pinot-java-client/.../BrokerCache.java` — two extra builder calls (`setEventLoopGroup`, `setNettyTimer`) on the existing AHC configuration.
No public API changes. No changes to `JsonAsyncHttpPinotClientTransport`, `PinotControllerTransport`, `ControllerBasedBrokerSelector`, `PinotDriver`, or `ConnectionFactory`. Behavior of direct Java-client users of `BrokerCache` is unchanged other than the reduced thread footprint.

## Why this is safe
- **Thread safety**: `NioEventLoopGroup` and `HashedWheelTimer` are thread-safe and explicitly designed to be shared across clients; this is the standard pattern documented by both Netty and AsyncHttpClient.
- **Per-instance configuration preserved**: SSL context, read/connect/handshake timeouts, user agent, enabled TLS protocols, and request headers are all still scoped to each `BrokerCache`'s own `AsyncHttpClient` and its own connection pool.
- **No lifecycle regression**: AHC will not shut down externally-supplied Netty resources, so `BrokerCache.close()` continues to close its own AHC cleanly without affecting other `BrokerCache` instances.
- **JVM exit**: the shared threads are daemon, so they do not hold the JVM alive.
## Impact on QPS and controller load
No change. Each `BrokerCache` still issues the same number of requests at the same cadence against the same controller endpoint. Sharing I/O threads can only reduce context-switch overhead, never add to it.

## Testing
- Manual reproduction with HikariCP + `PinotDriver`, pool size N, on an M-core host: before this change the NIO thread count grows by N every `brokerUpdateFreqInMillis`; after this change it is bounded by `2 * M` regardless of N (see Screenshot 3 above).
- Existing `BrokerCache` / `BrokerCacheUpdaterPeriodic` unit tests continue to pass; behavior of the constructor and `updateBrokerData()` is unchanged from the caller's perspective.
## Follow-ups (not in this PR)
- Daemonize `BrokerCacheUpdaterPeriodic`'s `ScheduledExecutorService` thread.
- Add a bounded timeout to the blocking `Future#get()` call in `BrokerCache#getTableToBrokersData()`.
- Optionally apply the same sharing to `JsonAsyncHttpPinotClientTransport` and `PinotControllerTransport`.