### PR TITLE
Fix comment typos and stale wording

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -1016,7 +1016,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
                 TimeUnit.MILLISECONDS.toSeconds(now() - initialConsumptionEnd));
       }
       // There is a race condition that the destroy() method can be called which ends up calling stop on the consumer.
-      // The destroy() method does not wait for the thread to terminate (and reasonably so, we dont want to wait
+      // The destroy() method does not wait for the thread to terminate (and reasonably so, we don't want to wait
       // forever).
       // Since the _shouldStop variable is set to true only in stop() method, we know that the metric will be destroyed,
       // so it is ok not to mark it non-consuming, as the main thread will clean up this metric in destroy() method

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PurgeMinionClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PurgeMinionClusterIntegrationTest.java
@@ -203,7 +203,7 @@ public class PurgeMinionClusterIntegrationTest extends BaseClusterIntegrationTes
   public void testFirstRunPurge()
       throws Exception {
     // Expected purge task generation :
-    // 1. No previous purge run so all segment should be processed and purge metadata sould be added to the segments
+    // 1. No previous purge run so all segment should be processed and purge metadata should be added to the segments
     // 2. Check that we cannot run on same time two purge generation ensuring running segment will be skipped
     // 3. Check segment ZK metadata to ensure purge time is updated into the metadata
     // 4. Check after the first run of the purge if we rerun a purge task generation no task should be scheduled

--- a/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotRuleUtils.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/calcite/rel/rules/PinotRuleUtils.java
@@ -100,7 +100,7 @@ public class PinotRuleUtils {
    * <ul>
    *   <li>`RelNode` that are single-in, single-out are possible (Project/Filter/)</li>
    *   <li>`Join` can be stacked on top if we only consider SEMI-JOIN</li>
-   *   <li>`Window` should be allowed but we dont have impl for Window on leaf, so not yet included.</li>
+   *   <li>`Window` should be allowed but we don't have impl for Window on leaf, so not yet included.</li>
    *   <li>`Sort` should be allowed but we need to reorder Sort and Join first, so not yet included.</li>
    * </ul>
    */

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/tablestate/TableStateUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/tablestate/TableStateUtils.java
@@ -76,12 +76,12 @@ public class TableStateUtils {
   }
 
   /**
-   * Checks if all segments for the given @param tableNameWithType were succesfully loaded
+   * Checks if all segments for the given @param tableNameWithType were successfully loaded
    * This function will get all segments in IDEALSTATE and CURRENTSTATE for the given table,
    * and then check if all ONLINE segments in IDEALSTATE match with CURRENTSTATE.
    * @param helixManager helix manager for the server instance
    * @param tableNameWithType table name for which segment state is to be checked
-   * @return true if all segments for the given table are succesfully loaded. False otherwise
+   * @return true if all segments for the given table are successfully loaded. False otherwise
    */
   public static boolean isAllSegmentsLoaded(HelixManager helixManager, String tableNameWithType) {
     List<String> onlineSegments =


### PR DESCRIPTION
Good day

This PR addresses the issue https://github.com/apache/pinot/issues/18226 by sweeping low-risk comment typos and stale wording in cleanup TODOs.

## Changes (behavior-neutral, comment-only)

1. **pinot-segment-local/TableStateUtils.java**: Fixed 2 occurrences of `succesfully` → `successfully` in Javadoc.
2. **pinot-integration-tests/PurgeMinionClusterIntegrationTest.java**: Fixed `sould` → `should` in a test comment.
3. **pinot-query-planner/PinotRuleUtils.java**: Fixed `dont` → `don't` in a code comment.
4. **pinot-core/RealtimeSegmentDataManager.java**: Fixed `dont` → `don't` in a comment.

## Rationale

- All changes are limited to comments/Javadoc only — no code behavior changes.
- Typos fixed are common misspellings that reduce code readability.
- PR is kept small to ensure quality review.

Thank you for your attention. If there are any issues or suggestions, please leave a comment and I will address them promptly.

Warmly, Jah-yee