### PR TITLE
Fix false-positive "column deleted" stale check for timestamp-index derived columns

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -116,6 +116,7 @@ import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.ConsumingSegmentConsistencyModeListener;
+import org.apache.pinot.spi.utils.TimestampIndexUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -1630,6 +1631,20 @@ public abstract class BaseTableDataManager implements TableDataManager {
 
       // Column is deleted
       if (fieldSpecInSchema == null) {
+        // Timestamp-index derived columns ($col$GRANULARITY) are materialized in the segment when the timestamp
+        // index is configured, but are not present in the table schema as first-class columns. If the timestamp
+        // index is later removed from the table config, applyTimestampIndex no longer injects the derived column
+        // into the IndexLoadingConfig schema, causing a false "column deleted" stale verdict. These columns are
+        // managed by the timestamp index staleness check (via "column added" when re-enabling) and by
+        // SegmentPreProcessor at reload time, so skipping them here is safe.
+        // We only skip when the base column is still present in the schema; if the base column was also removed,
+        // the column is not a timestamp-derived orphan and must still trigger "column deleted".
+        if (TimestampIndexUtils.isValidColumnWithGranularity(columnName)) {
+          String baseColumn = columnName.substring(1, columnName.indexOf('$', 1));
+          if (schema.getFieldSpecFor(baseColumn) != null) {
+            continue;
+          }
+        }
         LOGGER.debug("tableNameWithType: {}, columnName: {}, segmentName: {}, change: column deleted",
             tableNameWithType, columnName, segmentName);
         return new StaleSegment(segmentName, true, "column deleted: " + columnName);

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerNeedRefreshTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerNeedRefreshTest.java
@@ -43,6 +43,8 @@ import org.apache.pinot.spi.config.table.StarTreeAggregationConfig;
 import org.apache.pinot.spi.config.table.StarTreeIndexConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.config.table.TimestampConfig;
+import org.apache.pinot.spi.config.table.TimestampIndexGranularity;
 import org.apache.pinot.spi.data.DimensionFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.MetricFieldSpec;
@@ -859,5 +861,136 @@ public class BaseTableDataManagerNeedRefreshTest {
     assertTrue(
         BASE_TABLE_DATA_MANAGER.isSegmentStale(new IndexLoadingConfig(newTableConfig, SCHEMA), segmentDataManager)
             .isStale());
+  }
+
+  @Test
+  void testTimestampIndexNoChange()
+      throws Exception {
+    // Segment built with a DAY timestamp index; table config still has the same timestamp index → not stale.
+    FieldConfig fieldConfig = new FieldConfig.Builder(MS_SINCE_EPOCH_COLUMN_NAME)
+        .withTimestampConfig(new TimestampConfig(List.of(TimestampIndexGranularity.DAY)))
+        .build();
+    TableConfig tableConfig = getTableConfigBuilder().setFieldConfigList(List.of(fieldConfig)).build();
+    // Use a fresh schema per test: applyTimestampIndex mutates the schema object in-place, so sharing the
+    // static SCHEMA across timestamp tests causes cross-test contamination.
+    IndexLoadingConfig indexLoadingConfig = new IndexLoadingConfig(tableConfig, getSchema());
+    ImmutableSegmentDataManager segmentDataManager =
+        createImmutableSegmentDataManager(indexLoadingConfig, _testName, generateRows());
+
+    assertFalse(BASE_TABLE_DATA_MANAGER.isSegmentStale(indexLoadingConfig, segmentDataManager).isStale());
+  }
+
+  @Test
+  void testTimestampIndexAdded()
+      throws Exception {
+    // Segment built without a timestamp index; table config adds a DAY timestamp index → stale ("column added").
+    FieldConfig fieldConfig = new FieldConfig.Builder(MS_SINCE_EPOCH_COLUMN_NAME)
+        .withTimestampConfig(new TimestampConfig(List.of(TimestampIndexGranularity.DAY)))
+        .build();
+    TableConfig tableConfigWithTimestampIndex =
+        getTableConfigBuilder().setFieldConfigList(List.of(fieldConfig)).build();
+    IndexLoadingConfig indexLoadingConfigWithTimestampIndex =
+        new IndexLoadingConfig(tableConfigWithTimestampIndex, getSchema());
+
+    // Segment was created without the timestamp index.
+    StaleSegment response =
+        BASE_TABLE_DATA_MANAGER.isSegmentStale(indexLoadingConfigWithTimestampIndex, IMMUTABLE_SEGMENT_DATA_MANAGER);
+    assertTrue(response.isStale());
+    assertEquals(response.getReason(), "column added");
+  }
+
+  @Test
+  void testTimestampIndexRemoved()
+      throws Exception {
+    // Segment built with a DAY timestamp index; table config no longer has the timestamp index → not stale.
+    // This tests the fix: the derived $col$DAY column in the segment must not be flagged as "column deleted".
+    FieldConfig fieldConfig = new FieldConfig.Builder(MS_SINCE_EPOCH_COLUMN_NAME)
+        .withTimestampConfig(new TimestampConfig(List.of(TimestampIndexGranularity.DAY)))
+        .build();
+    TableConfig tableConfigWithTimestampIndex =
+        getTableConfigBuilder().setFieldConfigList(List.of(fieldConfig)).build();
+    IndexLoadingConfig indexLoadingConfigWithTimestampIndex =
+        new IndexLoadingConfig(tableConfigWithTimestampIndex, getSchema());
+    ImmutableSegmentDataManager segmentDataManager =
+        createImmutableSegmentDataManager(indexLoadingConfigWithTimestampIndex, _testName, generateRows());
+
+    // Evaluate staleness against a fresh config with no timestamp index.
+    IndexLoadingConfig indexLoadingConfigNoTimestamp = new IndexLoadingConfig(getTableConfigBuilder().build(),
+        getSchema());
+    assertFalse(BASE_TABLE_DATA_MANAGER.isSegmentStale(indexLoadingConfigNoTimestamp, segmentDataManager).isStale());
+  }
+
+  @Test
+  void testTimestampIndexGranularityAdded()
+      throws Exception {
+    // Segment built with a DAY timestamp index; table config adds a WEEK granularity → stale ("column added").
+    FieldConfig fieldConfigDay = new FieldConfig.Builder(MS_SINCE_EPOCH_COLUMN_NAME)
+        .withTimestampConfig(new TimestampConfig(List.of(TimestampIndexGranularity.DAY)))
+        .build();
+    TableConfig tableConfigDay = getTableConfigBuilder().setFieldConfigList(List.of(fieldConfigDay)).build();
+    IndexLoadingConfig indexLoadingConfigDay = new IndexLoadingConfig(tableConfigDay, getSchema());
+    ImmutableSegmentDataManager segmentDataManager =
+        createImmutableSegmentDataManager(indexLoadingConfigDay, _testName, generateRows());
+
+    FieldConfig fieldConfigDayAndWeek = new FieldConfig.Builder(MS_SINCE_EPOCH_COLUMN_NAME)
+        .withTimestampConfig(
+            new TimestampConfig(List.of(TimestampIndexGranularity.DAY, TimestampIndexGranularity.WEEK)))
+        .build();
+    TableConfig tableConfigDayAndWeek =
+        getTableConfigBuilder().setFieldConfigList(List.of(fieldConfigDayAndWeek)).build();
+    IndexLoadingConfig indexLoadingConfigDayAndWeek = new IndexLoadingConfig(tableConfigDayAndWeek, getSchema());
+
+    StaleSegment response = BASE_TABLE_DATA_MANAGER.isSegmentStale(indexLoadingConfigDayAndWeek, segmentDataManager);
+    assertTrue(response.isStale());
+    assertEquals(response.getReason(), "column added");
+  }
+
+  @Test
+  void testTimestampIndexGranularityRemoved()
+      throws Exception {
+    // Segment built with DAY + WEEK timestamp index; table config drops WEEK → not stale.
+    // The orphaned $col$WEEK column in the segment must not be flagged as "column deleted".
+    FieldConfig fieldConfigDayAndWeek = new FieldConfig.Builder(MS_SINCE_EPOCH_COLUMN_NAME)
+        .withTimestampConfig(
+            new TimestampConfig(List.of(TimestampIndexGranularity.DAY, TimestampIndexGranularity.WEEK)))
+        .build();
+    TableConfig tableConfigDayAndWeek =
+        getTableConfigBuilder().setFieldConfigList(List.of(fieldConfigDayAndWeek)).build();
+    IndexLoadingConfig indexLoadingConfigDayAndWeek = new IndexLoadingConfig(tableConfigDayAndWeek, getSchema());
+    ImmutableSegmentDataManager segmentDataManager =
+        createImmutableSegmentDataManager(indexLoadingConfigDayAndWeek, _testName, generateRows());
+
+    FieldConfig fieldConfigDay = new FieldConfig.Builder(MS_SINCE_EPOCH_COLUMN_NAME)
+        .withTimestampConfig(new TimestampConfig(List.of(TimestampIndexGranularity.DAY)))
+        .build();
+    TableConfig tableConfigDay = getTableConfigBuilder().setFieldConfigList(List.of(fieldConfigDay)).build();
+    IndexLoadingConfig indexLoadingConfigDay = new IndexLoadingConfig(tableConfigDay, getSchema());
+
+    assertFalse(BASE_TABLE_DATA_MANAGER.isSegmentStale(indexLoadingConfigDay, segmentDataManager).isStale());
+  }
+
+  @Test
+  void testUserDefinedColumnWithGranularityPatternDeleted()
+      throws Exception {
+    // A user-defined column whose name matches $col$GRANULARITY must still trigger "column deleted" when
+    // both the column and its apparent base column are absent from the new schema.
+    // The skip guard only fires when the base column is still in the schema (timestamp-derived orphan case);
+    // when the base column is also gone, the skip must not activate.
+    String baseColumnName = "customBase";
+    String granularityLookingColumn = "$customBase$DAY";
+    Schema schemaWithBothColumns = getSchema();
+    schemaWithBothColumns.addField(new DimensionFieldSpec(baseColumnName, FieldSpec.DataType.STRING, true));
+    schemaWithBothColumns.addField(new DimensionFieldSpec(granularityLookingColumn, FieldSpec.DataType.STRING, true));
+    IndexLoadingConfig indexLoadingConfig = new IndexLoadingConfig(getTableConfigBuilder().build(),
+        schemaWithBothColumns);
+    ImmutableSegmentDataManager segmentDataManager =
+        createImmutableSegmentDataManager(indexLoadingConfig, _testName, generateRows());
+
+    // New schema has neither the derived column nor its base column.
+    // The skip guard must not activate, so "column deleted" fires for the $-prefixed column (alphabetically first).
+    StaleSegment response = BASE_TABLE_DATA_MANAGER.isSegmentStale(
+        new IndexLoadingConfig(getTableConfigBuilder().build(), getSchema()), segmentDataManager);
+    assertTrue(response.isStale());
+    assertEquals(response.getReason(), "column deleted: " + granularityLookingColumn);
   }
 }


### PR DESCRIPTION
## Summary

- Timestamp-index derived columns (`$col$GRANULARITY`) are materialized as physical segment columns when a `TimestampConfig` is active, but are not present in the user-facing schema. When the timestamp index is later removed from the table config, `applyTimestampIndex` no longer injects the derived column into the `IndexLoadingConfig` schema, causing `isSegmentStale` to fire `"column deleted: $col$GRANULARITY"` and trigger an unnecessary segment reload.
- The fix skips the "column deleted" verdict for `$col$GRANULARITY` columns when the **base column is still in the schema** (confirming this is a timestamp-derived orphan, not a genuine user-schema deletion). If the base column is also absent the guard does not activate, so user-defined columns whose names happen to match the pattern are still correctly caught.
- Six tests added: no-change, index added (stale), index removed (not stale), granularity added (stale), granularity removed (not stale), and a boundary test for a user-defined `$col$GRANULARITY`-named column that is genuinely deleted.

## Root cause

`FieldSpec.isVirtualColumn()` returns `true` only when `_virtualColumnProvider` is set — a `transformFunction` alone does not make a column virtual. So `$col$DAY` added by `applyTimestampIndex` lands in `schema.getPhysicalColumnNames()`, and the segment also stores it as a physical column (with `isAutoGenerated=false`). When the `TimestampConfig` is removed, the schema no longer contains the derived column but the segment still does, triggering the false stale verdict.

## Test plan

- [x] `BaseTableDataManagerNeedRefreshTest` — all 43 tests pass (`./mvnw -pl pinot-core -am -Dtest=BaseTableDataManagerNeedRefreshTest -Dsurefire.failIfNoSpecifiedTests=false test`)
- [x] `spotless:apply`, `license:format`, `checkstyle:check`, `license:check` all pass on `pinot-core`

🤖 Generated with [Claude Code](https://claude.com/claude-code)