### PR TITLE
minor(cleanup): fix 'occurence'/'seperate' typos in comments and javadocs

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
@@ -254,7 +254,7 @@ public class StringFunctions {
 
   /**
    * @see StringUtils#ordinalIndexOf(CharSequence, CharSequence, int)
-   * Return the Nth occurence of a substring within the String
+   * Return the Nth occurrence of a substring within the String
    * @param input
    * @param find substring to find
    * @param instance Integer denoting the instance no.
@@ -267,7 +267,7 @@ public class StringFunctions {
 
   /**
    * @see StringUtils#indexOf(CharSequence, CharSequence)
-   * Return the 1st occurence of a substring within the String
+   * Return the 1st occurrence of a substring within the String
    * @param input
    * @param find substring to find
    * @return start index of the 1st instance of substring in main string
@@ -279,7 +279,7 @@ public class StringFunctions {
 
   /**
    * @see StringUtils#lastIndexOf(CharSequence, CharSequence)
-   * Return the last occurence of a substring within the String
+   * Return the last occurrence of a substring within the String
    * @param input
    * @param find substring to find
    * @return start index of the last instance of substring in main string
@@ -291,7 +291,7 @@ public class StringFunctions {
 
   /**
    * @see StringUtils#lastIndexOf(CharSequence, CharSequence, int)
-   * Return the Nth occurence of a substring in string starting from the end of the string.
+   * Return the Nth occurrence of a substring in string starting from the end of the string.
    * @param input
    * @param find substring to find
    * @param instance Integer denoting the instance no.

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/regexp/RegexpReplaceConstFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/regexp/RegexpReplaceConstFunctions.java
@@ -98,7 +98,7 @@ public class RegexpReplaceConstFunctions {
 
   /**
    * See #regexpReplace(String, String, String, int, int, String). Matches against entire inputStr and replaces all
-   * occurences. Match is performed in case-sensitive mode.
+   * occurrences. Match is performed in case-sensitive mode.
    *
    * @param inputStr      Input string to apply the regexpReplace
    * @param matchStr      Regexp or string to match against inputStr

--- a/pinot-core/src/test/resources/conf/pinot-broker.properties
+++ b/pinot-core/src/test/resources/conf/pinot-broker.properties
@@ -20,7 +20,7 @@
 pinot.broker.routing.tableName=testTable
 # Number of nodes constituting a replica-set. A replica-set has 0-(n-1) nodes where n is the below config value.
 pinot.broker.routing.testTable.numNodesPerReplica=1
-# Comma seperated list of servers for node 0 in the replica-set.
+# Comma separated list of servers for node 0 in the replica-set.
 #pinot.broker.routing.testTable.serversForNode.0=localhost:9099
 # default servers
 pinot.broker.routing.testTable.serversForNode.default=localhost:9099

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java
@@ -467,7 +467,7 @@ public class MultiStageEngineIntegrationTest extends BaseClusterIntegrationTestS
     result = response.get("resultTable").get("rows").get(0).get(0).asText();
     assertEquals(result, "hsomething, something, something and wise");
 
-    // Test occurence
+    // Test occurrence
     sqlQuery = "SELECT regexpReplace('healthy, wealthy, stealthy and wise','\\w+thy', 'something', 0, 2)";
     response = postQuery(sqlQuery);
     result = response.get("resultTable").get("rows").get(0).get(0).asText();
@@ -584,7 +584,7 @@ public class MultiStageEngineIntegrationTest extends BaseClusterIntegrationTestS
     result = response.get("resultTable").get("rows").get(0).get(0).asText();
     assertEquals(result, "hsomething, something, something and wise");
 
-    // Test occurence
+    // Test occurrence
     sqlQuery = "SELECT regexpReplaceVar('healthy, wealthy, stealthy and wise','\\w+thy', 'something', 0, 2)";
     response = postQuery(sqlQuery);
     result = response.get("resultTable").get("rows").get(0).get(0).asText();

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -871,7 +871,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     result = response.get("resultTable").get("rows").get(0).get(0).asText();
     assertEquals(result, "hsomething, something, something and wise");
 
-    // Test occurence
+    // Test occurrence
     sqlQuery = "SELECT regexpReplace('healthy, wealthy, stealthy and wise','\\w+thy', 'something', 0, 2)";
     response = postQuery(sqlQuery);
     result = response.get("resultTable").get("rows").get(0).get(0).asText();
@@ -989,7 +989,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     result = response.get("resultTable").get("rows").get(0).get(0).asText();
     assertEquals(result, "hsomething, something, something and wise");
 
-    // Test occurence
+    // Test occurrence
     sqlQuery = "SELECT regexpReplaceVar('healthy, wealthy, stealthy and wise','\\w+thy', 'something', 0, 2)";
     response = postQuery(sqlQuery);
     result = response.get("resultTable").get("rows").get(0).get(0).asText();

--- a/pinot-server/src/test/resources/conf/pinot-broker.properties
+++ b/pinot-server/src/test/resources/conf/pinot-broker.properties
@@ -20,7 +20,7 @@
 pinot.broker.routing.tableName=testTable
 # Number of nodes constituting a replica-set. A replica-set has 0-(n-1) nodes where n is the below config value.
 pinot.broker.routing.testTable.numNodesPerReplica=1
-# Comma seperated list of servers for node 0 in the replica-set.
+# Comma separated list of servers for node 0 in the replica-set.
 #pinot.broker.routing.testTable.serversForNode.0=localhost:9099
 # default servers
 pinot.broker.routing.testTable.serversForNode.default=localhost:9099


### PR DESCRIPTION
Fixes #18226. This is a targeted, behavior-neutral sweep of the low-risk typos called out in the issue scope ("Fix obvious typos and grammar issues in code comments and Javadocs. Keep the sweep low-risk and behavior-neutral.").

### Scope of this PR
- `occurence` -> `occurrence` in javadoc and line comments only. Left all **parameter names** (`int occurence`, `@param occurence`) untouched because those are part of the scalar function's public surface and renaming them would be a user-visible change.
- `seperate` -> `separate` in config-file comments only. Left the test method names `testStartSeperately` / `testStartSeperatelyWithStreamingUntar` untouched so build filters and historical test-report links aren't invalidated.

### Files changed
- `pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java` -- Javadoc for four `strpos`-style overloads ("Return the Nth occurrence of a substring...").
- `pinot-common/src/main/java/org/apache/pinot/common/function/scalar/regexp/RegexpReplaceConstFunctions.java` -- Javadoc "all occurrences. Match is performed in case-sensitive mode."
- `pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java` -- two `// Test occurrence` comments.
- `pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java` -- two `// Test occurrence` comments.
- `pinot-core/src/test/resources/conf/pinot-broker.properties` -- `# Comma separated list of servers...`.
- `pinot-server/src/test/resources/conf/pinot-broker.properties` -- same comment.

### Deliberately out of scope
- The `supproted` typo originally quoted from `RefreshSegmentTaskExecutor.java` is no longer in that file on master (already fixed at some point since the issue was filed), so nothing to do there.
- Stale TODO / FIXME wording clean-ups require per-site engineering judgement and were left for a follow-up sweep.
- `successfull` still has around 30 hits but many are embedded in log keys, downstream-parsed status strings, and compressor enum names where a rename isn't comment-only; skipping for safety.
- Parameter names (`occurence` in public SQL-reachable function signatures) are deliberately untouched to stay behavior-neutral.

### Verification
- No code paths changed; only comment and property-file comment text.
- Labels from the PR template that apply: `cleanup`, `code-style`, `testing` (two test files touched for comment text only).
