### PR TITLE
Split reload and refresh executor wrappers in BaseTableDataManager

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -142,6 +142,12 @@ public abstract class BaseTableDataManager implements TableDataManager {
   protected File _resourceTmpDir;
   protected Logger _logger;
   protected SegmentReloadSemaphore _segmentReloadSemaphore;
+  /**
+   * @deprecated Use {@link #_segmentReloadExecutor} or {@link #_segmentRefreshExecutor} instead. Kept for binary
+   * compatibility with downstream extensions; refers to the shared underlying executor pool.
+   */
+  @Deprecated
+  protected ExecutorService _segmentReloadRefreshExecutor;
   protected ExecutorService _segmentReloadExecutor;
   protected ExecutorService _segmentRefreshExecutor;
   @Nullable
@@ -189,6 +195,7 @@ public abstract class BaseTableDataManager implements TableDataManager {
     _propertyStore = helixManager.getHelixPropertyStore();
     _segmentLocks = segmentLocks;
     _segmentReloadSemaphore = segmentReloadSemaphore;
+    _segmentReloadRefreshExecutor = segmentReloadRefreshExecutor;
     // These two executors are using the same underlying thread pool, only that they're wrapped with different decorator
     _segmentReloadExecutor = new SegmentOperationsExecutorService(segmentReloadRefreshExecutor,
         SegmentOperationsTaskType.RELOAD, tableConfig.getTableName());

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -142,7 +142,8 @@ public abstract class BaseTableDataManager implements TableDataManager {
   protected File _resourceTmpDir;
   protected Logger _logger;
   protected SegmentReloadSemaphore _segmentReloadSemaphore;
-  protected ExecutorService _segmentReloadRefreshExecutor;
+  protected ExecutorService _segmentReloadExecutor;
+  protected ExecutorService _segmentRefreshExecutor;
   @Nullable
   protected ExecutorService _segmentPreloadExecutor;
   protected AuthProvider _authProvider;
@@ -188,8 +189,10 @@ public abstract class BaseTableDataManager implements TableDataManager {
     _propertyStore = helixManager.getHelixPropertyStore();
     _segmentLocks = segmentLocks;
     _segmentReloadSemaphore = segmentReloadSemaphore;
-    _segmentReloadRefreshExecutor = new SegmentOperationsExecutorService(segmentReloadRefreshExecutor,
-        SegmentOperationsTaskType.REFRESH_OR_RELOAD, tableConfig.getTableName());
+    _segmentReloadExecutor = new SegmentOperationsExecutorService(segmentReloadRefreshExecutor,
+        SegmentOperationsTaskType.RELOAD, tableConfig.getTableName());
+    _segmentRefreshExecutor = new SegmentOperationsExecutorService(segmentReloadRefreshExecutor,
+        SegmentOperationsTaskType.REFRESH, tableConfig.getTableName());
     _segmentPreloadExecutor = segmentPreloadExecutor != null
         ? new SegmentOperationsExecutorService(segmentPreloadExecutor, SegmentOperationsTaskType.PRELOAD,
         tableConfig.getTableName())
@@ -498,7 +501,7 @@ public abstract class BaseTableDataManager implements TableDataManager {
       return;
     }
     _logger.info("Enqueuing segment: {} to be replaced", segmentName);
-    _segmentReloadRefreshExecutor.submit(() -> {
+    _segmentRefreshExecutor.submit(() -> {
       try {
         replaceSegmentInternal(segmentName);
       } catch (Exception e) {
@@ -948,7 +951,7 @@ public abstract class BaseTableDataManager implements TableDataManager {
           _reloadJobStatusCache.recordFailure(reloadJobId, segmentName, t);
         }
       }
-    }, _segmentReloadRefreshExecutor)).toArray(CompletableFuture[]::new)).get();
+    }, _segmentReloadExecutor)).toArray(CompletableFuture[]::new)).get();
     if (sampleException.get() != null) {
       throw new RuntimeException(
           String.format("Failed to reload %d/%d segments: %s in table: %s", failedSegments.size(),

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -189,6 +189,7 @@ public abstract class BaseTableDataManager implements TableDataManager {
     _propertyStore = helixManager.getHelixPropertyStore();
     _segmentLocks = segmentLocks;
     _segmentReloadSemaphore = segmentReloadSemaphore;
+    // These two executors are using the same underlying thread pool, only that they're wrapped with different decorator
     _segmentReloadExecutor = new SegmentOperationsExecutorService(segmentReloadRefreshExecutor,
         SegmentOperationsTaskType.RELOAD, tableConfig.getTableName());
     _segmentRefreshExecutor = new SegmentOperationsExecutorService(segmentReloadRefreshExecutor,

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/SegmentOperationsTaskType.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/SegmentOperationsTaskType.java
@@ -32,6 +32,13 @@ public class SegmentOperationsTaskType {
       new SegmentOperationsTaskType("REFRESH");
   public static final SegmentOperationsTaskType RELOAD =
       new SegmentOperationsTaskType("RELOAD");
+  /**
+   * @deprecated Use {@link #REFRESH} or {@link #RELOAD} instead. Segment refresh and reload operations are now
+   * tracked as separate task types for independent throttling.
+   */
+  @Deprecated
+  public static final SegmentOperationsTaskType REFRESH_OR_RELOAD =
+      new SegmentOperationsTaskType("REFRESH_OR_RELOAD");
   public static final SegmentOperationsTaskType PRELOAD =
       new SegmentOperationsTaskType("PRELOAD");
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/SegmentOperationsTaskType.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/SegmentOperationsTaskType.java
@@ -28,8 +28,10 @@ package org.apache.pinot.core.data.manager;
 public class SegmentOperationsTaskType {
   public static final SegmentOperationsTaskType CONSUMER =
       new SegmentOperationsTaskType("CONSUMER");
-  public static final SegmentOperationsTaskType REFRESH_OR_RELOAD =
-      new SegmentOperationsTaskType("REFRESH_OR_RELOAD");
+  public static final SegmentOperationsTaskType REFRESH =
+      new SegmentOperationsTaskType("REFRESH");
+  public static final SegmentOperationsTaskType RELOAD =
+      new SegmentOperationsTaskType("RELOAD");
   public static final SegmentOperationsTaskType PRELOAD =
       new SegmentOperationsTaskType("PRELOAD");
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerEnqueueSegmentToReplaceTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerEnqueueSegmentToReplaceTest.java
@@ -236,7 +236,7 @@ public class BaseTableDataManagerEnqueueSegmentToReplaceTest {
     }).when(spyExecutor).submit(any(Runnable.class));
 
     // Replace the executor in the table data manager
-    _tableDataManager._segmentReloadRefreshExecutor = spyExecutor;
+    _tableDataManager._segmentRefreshExecutor = spyExecutor;
 
     // Test the method
     _tableDataManager.replaceSegment(SEGMENT_NAME);
@@ -262,7 +262,7 @@ public class BaseTableDataManagerEnqueueSegmentToReplaceTest {
   @Test
   public void testExecutorUsage() throws Exception {
     ExecutorService mockExecutor = mock(ExecutorService.class);
-    _tableDataManager._segmentReloadRefreshExecutor = mockExecutor;
+    _tableDataManager._segmentRefreshExecutor = mockExecutor;
 
     // Test the method
     _tableDataManager.replaceSegment(SEGMENT_NAME);


### PR DESCRIPTION
## Description
Reload and refresh now use separately-wrapped ExecutorService fields backed by the same underlying thread pool. Separation lets subclasses decorate one path without affecting the other, also refresh tasks and reload tasks now labeled with distinct `SegmentOperationTaskType` for any down stream application that makes decision based on the task type.

## Changes
- Add `SegmentOperationsTaskType.RELOAD` and `SegmentOperationsTaskType.REFRESH` (split from the combined REFRESH_OR_RELOAD).
- Route refresh submissions through `_segmentRefreshExecutor` and reload submissions through `_segmentReloadExecutor`.
