### PR TITLE
Add method createSegmentOnlineOfflineStateModelFactory in BaseServerStarter

### DIFF
--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
@@ -776,7 +776,8 @@ public abstract class BaseServerStarter implements ServiceStartable {
     _clusterConfigChangeHandler.registerClusterConfigChangeListener(serverRateLimitConfigChangeListener);
 
     initSegmentFetcher(_serverConf);
-    StateModelFactory<?> stateModelFactory = createSegmentOnlineOfflineStateModelFactory(instanceDataManager);
+    StateModelFactory<?> stateModelFactory =
+        createSegmentOnlineOfflineStateModelFactory(instanceDataManager, _transitionThreadPoolManager);
     _helixManager.getStateMachineEngine()
         .registerStateModelFactory(SegmentOnlineOfflineStateModelFactory.getStateModelName(), stateModelFactory);
     // Start the data manager as a pre-connect callback so that it starts after connecting to the ZK in order to access
@@ -1265,13 +1266,11 @@ public abstract class BaseServerStarter implements ServiceStartable {
 
   /**
    * Creates the {@link SegmentOnlineOfflineStateModelFactory} used to handle Helix state transitions for segments.
-   * The {@link StateTransitionThreadPoolManager} should be initialized by
-   * {@link BaseServerStarter#initTransitionThreadPoolManager()} before this method is called.
    * Subclasses can override to return a custom factory.
    */
   protected SegmentOnlineOfflineStateModelFactory createSegmentOnlineOfflineStateModelFactory(
-      InstanceDataManager instanceDataManager) {
-    return new SegmentOnlineOfflineStateModelFactory(_instanceId, instanceDataManager, _transitionThreadPoolManager);
+      InstanceDataManager instanceDataManager, StateTransitionThreadPoolManager transitionThreadPoolManager) {
+    return new SegmentOnlineOfflineStateModelFactory(instanceDataManager, transitionThreadPoolManager);
   }
 
   private void refreshMessageCount() {

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
@@ -776,8 +776,7 @@ public abstract class BaseServerStarter implements ServiceStartable {
     _clusterConfigChangeHandler.registerClusterConfigChangeListener(serverRateLimitConfigChangeListener);
 
     initSegmentFetcher(_serverConf);
-    StateModelFactory<?> stateModelFactory =
-        new SegmentOnlineOfflineStateModelFactory(_instanceId, instanceDataManager, _transitionThreadPoolManager);
+    StateModelFactory<?> stateModelFactory = createSegmentOnlineOfflineStateModelFactory(instanceDataManager);
     _helixManager.getStateMachineEngine()
         .registerStateModelFactory(SegmentOnlineOfflineStateModelFactory.getStateModelName(), stateModelFactory);
     // Start the data manager as a pre-connect callback so that it starts after connecting to the ZK in order to access
@@ -1262,6 +1261,17 @@ public abstract class BaseServerStarter implements ServiceStartable {
   protected SegmentMessageHandlerFactory createSegmentMessageHandlerFactory(InstanceDataManager instanceDataManager,
       ServerMetrics serverMetrics) {
     return new SegmentMessageHandlerFactory(instanceDataManager, serverMetrics);
+  }
+
+  /**
+   * Creates the {@link SegmentOnlineOfflineStateModelFactory} used to handle Helix state transitions for segments.
+   * The {@link StateTransitionThreadPoolManager} should be initialized by
+   * {@link BaseServerStarter#initTransitionThreadPoolManager()} before this method is called.
+   * Subclasses can override to return a custom factory.
+   */
+  protected SegmentOnlineOfflineStateModelFactory createSegmentOnlineOfflineStateModelFactory(
+      InstanceDataManager instanceDataManager) {
+    return new SegmentOnlineOfflineStateModelFactory(_instanceId, instanceDataManager, _transitionThreadPoolManager);
   }
 
   private void refreshMessageCount() {

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/SegmentOnlineOfflineStateModelFactory.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/SegmentOnlineOfflineStateModelFactory.java
@@ -47,9 +47,9 @@ public class SegmentOnlineOfflineStateModelFactory extends StateModelFactory<Sta
   @Nullable
   protected final StateTransitionThreadPoolManager _stateTransitionThreadPoolManager;
 
-  public SegmentOnlineOfflineStateModelFactory(String instanceId, InstanceDataManager instanceDataManager,
+  public SegmentOnlineOfflineStateModelFactory(InstanceDataManager instanceDataManager,
       @Nullable StateTransitionThreadPoolManager stateTransitionThreadPoolManager) {
-    _instanceId = instanceId;
+    _instanceId = instanceDataManager.getInstanceId();
     _instanceDataManager = instanceDataManager;
     _stateTransitionThreadPoolManager = stateTransitionThreadPoolManager;
   }

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/SegmentOnlineOfflineStateModelFactory.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/SegmentOnlineOfflineStateModelFactory.java
@@ -40,12 +40,12 @@ import org.slf4j.LoggerFactory;
  */
 public class SegmentOnlineOfflineStateModelFactory extends StateModelFactory<StateModel> {
 
-  private final String _instanceId;
-  private final InstanceDataManager _instanceDataManager;
+  protected final String _instanceId;
+  protected final InstanceDataManager _instanceDataManager;
   /** Provides custom thread pools for executing Helix state transition messages. If this is null, all state
    * transition message will be executed using the default shared thread pool by Helix */
   @Nullable
-  private final StateTransitionThreadPoolManager _stateTransitionThreadPoolManager;
+  protected final StateTransitionThreadPoolManager _stateTransitionThreadPoolManager;
 
   public SegmentOnlineOfflineStateModelFactory(String instanceId, InstanceDataManager instanceDataManager,
       @Nullable StateTransitionThreadPoolManager stateTransitionThreadPoolManager) {


### PR DESCRIPTION
## Description
Similar to https://github.com/apache/pinot/pull/18298, making this change allows overriding with customized state model factory

## Changes
1. Add a new method `createSegmentOnlineOfflineStateModelFactory` in  `BaseServerStarter` to provide `SegmentOnlineOfflineStateModelFactory` and register.
2. Change the private variables in `SegmentOnlineOfflineStateModelFactory` to protected