### PR TITLE
[UI] Fix rebalance jobs table: show correct start time and populate finished at

### DIFF
--- a/pinot-controller/src/main/resources/app/components/Homepage/Operations/RebalanceServerStatusOp.tsx
+++ b/pinot-controller/src/main/resources/app/components/Homepage/Operations/RebalanceServerStatusOp.tsx
@@ -181,12 +181,19 @@ export const RebalanceServerStatusOp = (
                             }}
                             data={{
                                 records: rebalanceServerJobs.map(rebalanceServerJob => {
-                                    const progressStats = JSON.parse(rebalanceServerJob.REBALANCE_PROGRESS_STATS);
+                                    const progressStats = JSON.parse(rebalanceServerJob.REBALANCE_PROGRESS_STATS || '{}');
+                                    // Prefer the rebalance-reported start time; fall back to the job submission time.
+                                    const startTimeMs = progressStats.startTimeMs || +rebalanceServerJob.submissionTimeMs;
+                                    // timeToFinishInSeconds is only populated once the rebalance completes.
+                                    const timeToFinishInSeconds = progressStats.timeToFinishInSeconds || 0;
                                     return [
                                         rebalanceServerJob.jobId,
                                         rebalanceServerJob.tableName,
                                         progressStats.status,
-                                        formatTimeInTimezone(+rebalanceServerJob.submissionTimeMs + (JSON.parse(rebalanceServerJob?.REBALANCE_PROGRESS_STATS || '{}').timeToFinishInSeconds * 1000))
+                                        formatTimeInTimezone(startTimeMs),
+                                        timeToFinishInSeconds > 0
+                                            ? formatTimeInTimezone(startTimeMs + timeToFinishInSeconds * 1000)
+                                            : '-'
                                     ];
                                 }),
                                 columns: ['Job id', 'Table name', 'Status', 'Started at', 'Finished at']


### PR DESCRIPTION
## Summary

The Rebalance Servers Status dialog (Tenant Details → Rebalance Servers Status) declared 5 column headers (`Job id, Table name, Status, Started at, Finished at`) but each row only emitted 4 cells. As a result:

- The computed finish time (`submissionTimeMs + timeToFinishInSeconds * 1000`) was rendered under the **Started at** header.
- The **Finished at** column was always blank.
- For in-progress jobs (`timeToFinishInSeconds == 0`) the "Started at" column collapsed to `submissionTimeMs`, which can differ from the authoritative `startTimeMs` reported by the controller — and didn't match what the job-detail response showed after clicking.

### Fix

In `RebalanceServerStatusOp.tsx`:

- Parse `REBALANCE_PROGRESS_STATS` once per row with a `|| '{}'` guard.
- Use `progressStats.startTimeMs` for **Started at**, falling back to `submissionTimeMs` only when the rebalance hasn't recorded one yet (backend default `0L`).
- Render **Finished at** as `startTimeMs + timeToFinishInSeconds * 1000` only when `timeToFinishInSeconds > 0`; otherwise `-`.

The row now produces 5 cells, matching the 5 column headers.

Note: the related title/button mismatch (`Rebalance Table Status` vs `Rebalance Servers Status`) was already fixed in #16545.

Fixes #15939

## Test plan

- [ ] Open Tenant Details → Rebalance Servers Status while a rebalance is in progress and verify **Started at** matches `startTimeMs` in the detail view (not `submissionTimeMs`).
- [ ] Verify two concurrent in-progress jobs show their individual start times (not identical).
- [ ] Verify **Finished at** is blank (`-`) for in-progress jobs and populated after the job completes.
- [ ] Verify refresh does not change the displayed start time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)