### PR TITLE
[spi] Slim JSON serialization for *IndexConfig classes

### DIFF
--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/ExactVectorScanFilterOperatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/ExactVectorScanFilterOperatorTest.java
@@ -238,7 +238,7 @@ public class ExactVectorScanFilterOperatorTest {
 
   private VectorIndexConfig createVectorIndexConfig(String backendType,
       VectorIndexConfig.VectorDistanceFunction distanceFunction) {
-    return new VectorIndexConfig(false, backendType, 2, 1, distanceFunction,
+    return new VectorIndexConfig(Boolean.FALSE, backendType, 2, 1, distanceFunction,
         Map.of("nlist", "4", "pqM", "2", "pqNbits", "8", "trainSampleSize", "16"));
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/VectorCompoundQueryTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/VectorCompoundQueryTest.java
@@ -227,6 +227,6 @@ public class VectorCompoundQueryTest {
 
   private VectorIndexConfig createVectorIndexConfig(String backendType,
       VectorIndexConfig.VectorDistanceFunction distanceFunction) {
-    return new VectorIndexConfig(false, backendType, 2, 1, distanceFunction, Map.of());
+    return new VectorIndexConfig(Boolean.FALSE, backendType, 2, 1, distanceFunction, Map.of());
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/VectorRadiusFilterOperatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/VectorRadiusFilterOperatorTest.java
@@ -296,6 +296,6 @@ public class VectorRadiusFilterOperatorTest {
 
   private VectorIndexConfig createVectorIndexConfig(String backendType,
       VectorIndexConfig.VectorDistanceFunction distanceFunction) {
-    return new VectorIndexConfig(false, backendType, 2, 1, distanceFunction, new HashMap<>());
+    return new VectorIndexConfig(Boolean.FALSE, backendType, 2, 1, distanceFunction, new HashMap<>());
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/VectorSimilarityFilterOperatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/VectorSimilarityFilterOperatorTest.java
@@ -603,7 +603,7 @@ public class VectorSimilarityFilterOperatorTest {
 
   private VectorIndexConfig createVectorIndexConfig(String backendType,
       VectorIndexConfig.VectorDistanceFunction distanceFunction) {
-    return new VectorIndexConfig(false, backendType, 2, 1, distanceFunction,
+    return new VectorIndexConfig(Boolean.FALSE, backendType, 2, 1, distanceFunction,
         Map.of("nlist", "4", "pqM", "2", "pqNbits", "8", "trainSampleSize", "16"));
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/plan/FilterPlanNodeTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/plan/FilterPlanNodeTest.java
@@ -88,7 +88,7 @@ public class FilterPlanNodeTest {
         boolean.class);
     method.setAccessible(true);
 
-    VectorIndexConfig config = new VectorIndexConfig(false, "IVF_FLAT", 4, 1,
+    VectorIndexConfig config = new VectorIndexConfig(Boolean.FALSE, "IVF_FLAT", 4, 1,
         VectorIndexConfig.VectorDistanceFunction.EUCLIDEAN, java.util.Map.of("nlist", "2"));
 
     String reason = (String) method.invoke(null, config, true);
@@ -102,7 +102,7 @@ public class FilterPlanNodeTest {
         boolean.class);
     method.setAccessible(true);
 
-    VectorIndexConfig config = new VectorIndexConfig(false, "IVF_PQ", 4, 1,
+    VectorIndexConfig config = new VectorIndexConfig(Boolean.FALSE, "IVF_PQ", 4, 1,
         VectorIndexConfig.VectorDistanceFunction.EUCLIDEAN,
         java.util.Map.of("nlist", "2", "pqM", "2", "pqNbits", "8"));
 

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkVectorFeatureWorkloads.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkVectorFeatureWorkloads.java
@@ -373,7 +373,7 @@ public final class BenchmarkVectorFeatureWorkloads {
     properties.put("nprobe", String.valueOf(NPROBE));
     properties.put("trainingSeed", String.valueOf(SEED));
     properties.put("quantizer", quantizerType.name());
-    return new VectorIndexConfig(false, backendType, dimension, 1, distanceFunction, properties);
+    return new VectorIndexConfig(Boolean.FALSE, backendType, dimension, 1, distanceFunction, properties);
   }
 
   private static VectorIndexConfig createMutableHnswConfig(int dimension, int numDocs,
@@ -384,7 +384,7 @@ public final class BenchmarkVectorFeatureWorkloads {
     properties.put("vectorDistanceFunction", distanceFunction.name());
     properties.put("commitDocs", String.valueOf(Math.max(1, numDocs)));
     properties.put("commitIntervalMs", String.valueOf(Long.MAX_VALUE));
-    return new VectorIndexConfig(false, "HNSW", dimension, 1, distanceFunction, properties);
+    return new VectorIndexConfig(Boolean.FALSE, "HNSW", dimension, 1, distanceFunction, properties);
   }
 
   private static long[] measureLatencies(float[][] queries, SearchAction action)

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkVectorFilterWorkloads.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkVectorFilterWorkloads.java
@@ -403,7 +403,7 @@ public final class BenchmarkVectorFilterWorkloads {
     properties.put("nprobe", String.valueOf(NPROBE));
     properties.put("trainingSeed", String.valueOf(SEED));
     properties.put("quantizer", quantizerType.name());
-    return new VectorIndexConfig(false, backendType, dimension, 1, distanceFunction, properties);
+    return new VectorIndexConfig(Boolean.FALSE, backendType, dimension, 1, distanceFunction, properties);
   }
 
   private static int[] filteredExactTopK(float[][] corpus, float[] query, int topK,

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkVectorIndex.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkVectorIndex.java
@@ -272,7 +272,7 @@ public class BenchmarkVectorIndex {
     props.put("nlist", String.valueOf(nlist));
     props.put("trainingSeed", String.valueOf(SEED));
     props.put("quantizer", quantizerType.name());
-    return new VectorIndexConfig(false, indexType, dimension, 1, distFunc, props);
+    return new VectorIndexConfig(Boolean.FALSE, indexType, dimension, 1, distFunc, props);
   }
 
   /**
@@ -289,7 +289,7 @@ public class BenchmarkVectorIndex {
     props.put("pqNbits", String.valueOf(pqNbits));
     props.put("trainSampleSize", String.valueOf(Math.max(nlist, Math.min(65536, corpusSize))));
     props.put("trainingSeed", String.valueOf(SEED));
-    return new VectorIndexConfig(false, IVF_PQ_INDEX_TYPE, dimension, 1, distFunc, props);
+    return new VectorIndexConfig(Boolean.FALSE, IVF_PQ_INDEX_TYPE, dimension, 1, distFunc, props);
   }
 
   /**
@@ -470,7 +470,7 @@ public class BenchmarkVectorIndex {
     // Lucene defaults: M=16, beamWidth=100
     props.put("maxCon", "16");
     props.put("beamWidth", "100");
-    return new VectorIndexConfig(false, "HNSW", dimension, 1, distFunc, props);
+    return new VectorIndexConfig(Boolean.FALSE, "HNSW", dimension, 1, distFunc, props);
   }
 
   // ---------------------------------------------------------------------------

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/dictionary/DictionaryIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/dictionary/DictionaryIndexType.java
@@ -163,8 +163,13 @@ public class DictionaryIndexType
       allColumns.addAll(varLengthDictionaryColumns);
       Map<String, DictionaryIndexConfig> dictionaryIndexConfigMap = Maps.newHashMapWithExpectedSize(allColumns.size());
       for (String column : allColumns) {
-        dictionaryIndexConfigMap.put(column, new DictionaryIndexConfig(onHeapDictionaryColumns.contains(column),
-            varLengthDictionaryColumns.contains(column)));
+        // Pass `null` rather than `false` for the absent flag: under the wrapper-based contract,
+        // null = "not explicitly configured" (slim form omits the key) while false = "user said
+        // false." A column that appears only in onHeapDictionaryColumns has not been configured
+        // for useVarLengthDictionary at all, so null is the faithful translation.
+        Boolean onHeap = onHeapDictionaryColumns.contains(column) ? Boolean.TRUE : null;
+        Boolean useVarLength = varLengthDictionaryColumns.contains(column) ? Boolean.TRUE : null;
+        dictionaryIndexConfigMap.put(column, new DictionaryIndexConfig(onHeap, useVarLength));
       }
       return dictionaryIndexConfigMap;
     };

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplTest.java
@@ -236,7 +236,7 @@ public class MutableSegmentImplTest {
         .addMultiValueDimension("embedding", FieldSpec.DataType.FLOAT)
         .build();
     VectorIndexConfig vectorIndexConfig =
-        new VectorIndexConfig(false, "IVF_PQ", 4, 1, VectorIndexConfig.VectorDistanceFunction.COSINE,
+        new VectorIndexConfig(Boolean.FALSE, "IVF_PQ", 4, 1, VectorIndexConfig.VectorDistanceFunction.COSINE,
             Map.of("nlist", "1", "pqM", "2", "pqNbits", "8", "trainSampleSize", "4"));
     MutableSegmentImpl mutableSegment =
         MutableSegmentImplTestUtils.createMutableSegmentImplWithVectorIndexConfigs(vectorSchema, Set.of(), Set.of(),

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/impl/vector/MutableVectorIndexTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/impl/vector/MutableVectorIndexTest.java
@@ -108,7 +108,7 @@ public class MutableVectorIndexTest {
     properties.put("commitDocs", "4");
     properties.put("vectorIndexType", "HNSW");
     properties.put("vectorDimension", "5");
-    return new VectorIndexConfig(false, "HNSW", 5, 1, VectorIndexConfig.VectorDistanceFunction.EUCLIDEAN,
+    return new VectorIndexConfig(Boolean.FALSE, "HNSW", 5, 1, VectorIndexConfig.VectorDistanceFunction.EUCLIDEAN,
         properties);
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/H3IndexTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/H3IndexTest.java
@@ -457,7 +457,8 @@ public class H3IndexTest implements PinotBuffersAfterMethodCheckRule {
       assertTrue(fieldConfig.getIndexTypes().isEmpty());
       assertNull(fieldConfig.getProperties());
       JsonNode node = fieldConfig.getIndexes().get(H3IndexType.INDEX_DISPLAY_NAME);
-      Assert.assertEquals(node.toString(), "{\"disabled\":false,\"resolution\":[5,6,13]}");
+      // Slim serialization: disabled=false (default) is omitted.
+      Assert.assertEquals(node.toString(), "{\"resolution\":[5,6,13]}");
     }
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/IndexConfigSlimRoundTripTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/IndexConfigSlimRoundTripTest.java
@@ -1,0 +1,152 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import org.apache.pinot.segment.spi.index.IndexType;
+import org.apache.pinot.segment.spi.index.StandardIndexes;
+import org.apache.pinot.spi.config.table.IndexConfig;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+
+
+/**
+ * Cross-cutting test that exercises the full slim-serialization wire path for every
+ * supported {@code *IndexConfig}: a slim user-supplied JSON travels through a
+ * {@link org.apache.pinot.spi.config.table.FieldConfig} declared on a
+ * {@link org.apache.pinot.spi.config.table.TableConfig}, gets resolved into the
+ * concrete {@code *IndexConfig} via {@link org.apache.pinot.segment.spi.index.FieldIndexConfigsUtil},
+ * and is then re-serialized. The re-serialized form must be byte-equivalent to the
+ * original slim input — i.e. the {@code @JsonValue toJsonObject()} on each config
+ * must round-trip through the {@code IndexType.getConfig(...)} resolution path.
+ *
+ * <p>This guards against any wiring regression between the per-class slim serializers
+ * (added in this PR) and the broker/server-side index resolution code.
+ */
+public class IndexConfigSlimRoundTripTest extends AbstractSerdeIndexContract {
+
+  @DataProvider(name = "slimConfigs")
+  public static Object[][] slimConfigs() {
+    return new Object[][] {
+        // forward
+        {"forward", "{\"compressionCodec\":\"SNAPPY\"}", "ForwardIndexConfig"},
+        {"forward", "{\"deriveNumDocsPerChunk\":true}", "ForwardIndexConfig"},
+        // dictionary
+        {"dictionary", "{\"onHeap\":true}", "DictionaryIndexConfig"},
+        {"dictionary", "{\"useVarLengthDictionary\":true}", "DictionaryIndexConfig"},
+        // range
+        {"range", "{\"version\":1}", "RangeIndexConfig"},
+        // json
+        {"json", "{\"excludeArray\":true}", "JsonIndexConfig"},
+        {"json", "{\"maxLevels\":3}", "JsonIndexConfig"},
+        // bloom
+        {"bloom", "{\"fpp\":0.5}", "BloomFilterConfig"},
+        {"bloom", "{\"maxSizeInBytes\":1024,\"loadOnHeap\":true}", "BloomFilterConfig"},
+        // text
+        {"text", "{\"caseSensitive\":true}", "TextIndexConfig"},
+        // h3
+        {"h3", "{\"resolution\":[5,6]}", "H3IndexConfig"},
+        // disabled (universal)
+        {"bloom", "{\"disabled\":true}", "BloomFilterConfig"},
+        {"forward", "{\"disabled\":true}", "ForwardIndexConfig"},
+    };
+  }
+
+  /**
+   * For each slim JSON input, attach it as a {@code FieldConfig.indexes[<name>]} on the
+   * shared table config, resolve via {@link #getActualConfig}, then re-serialize the
+   * resolved POJO through Jackson and assert the slim output equals the original input.
+   */
+  @Test(dataProvider = "slimConfigs")
+  public void slimRoundTripsThroughIndexResolution(String indexName, String slimJson, String label)
+      throws IOException {
+    addFieldIndexConfig("{"
+        + "\"name\": \"dimInt\","
+        + "\"indexes\": {"
+        + "\"" + indexName + "\": " + slimJson
+        + "}"
+        + "}");
+
+    IndexType<? extends IndexConfig, ?, ?> type = lookupIndexType(indexName);
+    IndexConfig resolved = getActualConfig("dimInt", type);
+
+    JsonNode resolvedSlim = JsonUtils.stringToJsonNode(JsonUtils.objectToString(resolved));
+    JsonNode expectedSlim = JsonUtils.stringToJsonNode(slimJson);
+
+    assertEquals(resolvedSlim, expectedSlim,
+        label + " must round-trip slim through IndexType.getConfig(): "
+            + "expected " + expectedSlim + " but got " + resolvedSlim);
+  }
+
+  /**
+   * Sanity guard: ensure no resolved config emits a known "fattening" key when the slim
+   * input omitted it. This is a strict subset of the round-trip assertion above but
+   * fails with a clearer message when a serializer regresses.
+   */
+  @Test
+  public void slimForwardConfigDoesNotEmitClusterTunableDefaults()
+      throws IOException {
+    addFieldIndexConfig("{"
+        + "\"name\": \"dimInt\","
+        + "\"indexes\": {\"forward\": {\"compressionCodec\":\"SNAPPY\"}}"
+        + "}");
+
+    IndexConfig resolved = getActualConfig("dimInt", StandardIndexes.forward());
+    JsonNode slim = JsonUtils.stringToJsonNode(JsonUtils.objectToString(resolved));
+
+    assertFalse(slim.has("rawIndexWriterVersion"),
+        "Cluster-tunable default rawIndexWriterVersion must not leak into slim output: " + slim);
+    assertFalse(slim.has("targetMaxChunkSize"),
+        "Cluster-tunable default targetMaxChunkSize must not leak into slim output: " + slim);
+    assertFalse(slim.has("targetDocsPerChunk"),
+        "Cluster-tunable default targetDocsPerChunk must not leak into slim output: " + slim);
+  }
+
+  // ---- Helpers ----
+
+  private static IndexType<? extends IndexConfig, ?, ?> lookupIndexType(String name) {
+    switch (name) {
+      case "forward":
+        return StandardIndexes.forward();
+      case "dictionary":
+        return StandardIndexes.dictionary();
+      case "range":
+        return StandardIndexes.range();
+      case "json":
+        return StandardIndexes.json();
+      case "bloom":
+        return StandardIndexes.bloomFilter();
+      case "text":
+        return StandardIndexes.text();
+      case "h3":
+        return StandardIndexes.h3();
+      case "fst":
+        return StandardIndexes.fst();
+      case "vector":
+        return StandardIndexes.vector();
+      default:
+        throw new IllegalArgumentException("Unknown index name: " + name);
+    }
+  }
+}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/IndexConfigSlimRoundTripTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/IndexConfigSlimRoundTripTest.java
@@ -28,7 +28,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 
 /**
@@ -49,9 +49,6 @@ public class IndexConfigSlimRoundTripTest extends AbstractSerdeIndexContract {
   @DataProvider(name = "slimConfigs")
   public static Object[][] slimConfigs() {
     return new Object[][] {
-        // forward
-        {"forward", "{\"compressionCodec\":\"SNAPPY\"}", "ForwardIndexConfig"},
-        {"forward", "{\"deriveNumDocsPerChunk\":true}", "ForwardIndexConfig"},
         // dictionary
         {"dictionary", "{\"onHeap\":true}", "DictionaryIndexConfig"},
         {"dictionary", "{\"useVarLengthDictionary\":true}", "DictionaryIndexConfig"},
@@ -69,7 +66,10 @@ public class IndexConfigSlimRoundTripTest extends AbstractSerdeIndexContract {
         {"h3", "{\"resolution\":[5,6]}", "H3IndexConfig"},
         // disabled (universal)
         {"bloom", "{\"disabled\":true}", "BloomFilterConfig"},
-        {"forward", "{\"disabled\":true}", "ForwardIndexConfig"},
+        // NOTE: forward is intentionally excluded from this data provider because
+        // ForwardIndexConfig always materializes its cluster-tunable trio
+        // (rawIndexWriterVersion / targetMaxChunkSize / targetDocsPerChunk) regardless of input.
+        // It has its own dedicated tests below.
     };
   }
 
@@ -100,12 +100,14 @@ public class IndexConfigSlimRoundTripTest extends AbstractSerdeIndexContract {
   }
 
   /**
-   * Sanity guard: ensure no resolved config emits a known "fattening" key when the slim
-   * input omitted it. This is a strict subset of the round-trip assertion above but
-   * fails with a clearer message when a serializer regresses.
+   * ForwardIndexConfig deliberately does <i>not</i> participate in the universal slim round-trip
+   * because its cluster-tunable trio ({@code rawIndexWriterVersion}, {@code targetMaxChunkSize},
+   * {@code targetDocsPerChunk}) is always materialized — see
+   * {@code ForwardIndexConfig.toJsonObject()} Javadoc and the discussion on apache/pinot#18317.
+   * This test pins that contract end-to-end through {@code IndexType.getConfig(...)}.
    */
   @Test
-  public void slimForwardConfigDoesNotEmitClusterTunableDefaults()
+  public void slimForwardConfigAlwaysMaterializesClusterTunableTrio()
       throws IOException {
     addFieldIndexConfig("{"
         + "\"name\": \"dimInt\","
@@ -115,12 +117,14 @@ public class IndexConfigSlimRoundTripTest extends AbstractSerdeIndexContract {
     IndexConfig resolved = getActualConfig("dimInt", StandardIndexes.forward());
     JsonNode slim = JsonUtils.stringToJsonNode(JsonUtils.objectToString(resolved));
 
-    assertFalse(slim.has("rawIndexWriterVersion"),
-        "Cluster-tunable default rawIndexWriterVersion must not leak into slim output: " + slim);
-    assertFalse(slim.has("targetMaxChunkSize"),
-        "Cluster-tunable default targetMaxChunkSize must not leak into slim output: " + slim);
-    assertFalse(slim.has("targetDocsPerChunk"),
-        "Cluster-tunable default targetDocsPerChunk must not leak into slim output: " + slim);
+    assertTrue(slim.has("rawIndexWriterVersion"),
+        "Cluster-tunable rawIndexWriterVersion must always be materialized: " + slim);
+    assertTrue(slim.has("targetMaxChunkSize"),
+        "Cluster-tunable targetMaxChunkSize must always be materialized: " + slim);
+    assertTrue(slim.has("targetDocsPerChunk"),
+        "Cluster-tunable targetDocsPerChunk must always be materialized: " + slim);
+    // The user-supplied non-default field must still survive the round-trip.
+    assertEquals(slim.get("compressionCodec").asText(), "SNAPPY");
   }
 
   // ---- Helpers ----

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/RangeIndexTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/RangeIndexTest.java
@@ -23,7 +23,6 @@ import com.google.common.collect.Lists;
 import java.util.stream.Collectors;
 import org.apache.pinot.segment.local.segment.index.range.RangeIndexPlugin;
 import org.apache.pinot.segment.local.segment.index.range.RangeIndexType;
-import org.apache.pinot.segment.spi.index.RangeIndexConfig;
 import org.apache.pinot.segment.spi.index.StandardIndexes;
 import org.apache.pinot.spi.config.table.FieldConfig;
 import org.testng.annotations.Test;
@@ -47,7 +46,9 @@ public class RangeIndexTest {
           .filter(fc -> fc.getName().equals("dimInt")).collect(Collectors.toList()).get(0);
       JsonNode indexConfig = fieldConfig.getIndexes().get(RangeIndexType.INDEX_DISPLAY_NAME);
       assertNotNull(indexConfig);
-      assertEquals(RangeIndexConfig.DEFAULT.getVersion(), indexConfig.get("version").asInt());
+      // Slim serialization: 'version' equals the class default (2), so it is omitted from the
+      // serialized JSON. The resolved RangeIndexConfig still carries the default value.
+      assertNull(indexConfig.get("version"));
       assertTrue(fieldConfig.getIndexTypes().isEmpty());
       assertNull(fieldConfig.getProperties());
     }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/RangeIndexTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/RangeIndexTest.java
@@ -23,6 +23,7 @@ import com.google.common.collect.Lists;
 import java.util.stream.Collectors;
 import org.apache.pinot.segment.local.segment.index.range.RangeIndexPlugin;
 import org.apache.pinot.segment.local.segment.index.range.RangeIndexType;
+import org.apache.pinot.segment.spi.index.RangeIndexConfig;
 import org.apache.pinot.segment.spi.index.StandardIndexes;
 import org.apache.pinot.spi.config.table.FieldConfig;
 import org.testng.annotations.Test;
@@ -46,9 +47,10 @@ public class RangeIndexTest {
           .filter(fc -> fc.getName().equals("dimInt")).collect(Collectors.toList()).get(0);
       JsonNode indexConfig = fieldConfig.getIndexes().get(RangeIndexType.INDEX_DISPLAY_NAME);
       assertNotNull(indexConfig);
-      // Slim serialization: 'version' equals the class default (2), so it is omitted from the
-      // serialized JSON. The resolved RangeIndexConfig still carries the default value.
-      assertNull(indexConfig.get("version"));
+      // Slim serialization: the conversion code constructs RangeIndexConfig with an explicit
+      // version, which the wrapper-based contract preserves through round-trip even when it
+      // matches today's default — distinguishing "user set" from "not set."
+      assertEquals(RangeIndexConfig.DEFAULT_VERSION, indexConfig.get("version").asInt());
       assertTrue(fieldConfig.getIndexTypes().isEmpty());
       assertNull(fieldConfig.getProperties());
     }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/TextIndexTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/TextIndexTest.java
@@ -50,7 +50,8 @@ public class TextIndexTest {
           .filter(fc -> fc.getName().equals("dimStr")).collect(Collectors.toList()).get(0);
       JsonNode indexConfig = fieldConfig.getIndexes().get(TextIndexType.INDEX_DISPLAY_NAME);
       assertNotNull(indexConfig);
-      assertFalse(indexConfig.get("disabled").asBoolean());
+      // Slim serialization: disabled=false (default) is omitted from the JSON entirely.
+      assertNull(indexConfig.get("disabled"));
       assertTrue(fieldConfig.getIndexTypes().isEmpty());
       assertNull(fieldConfig.getProperties());
     }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/VectorIndexTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/VectorIndexTest.java
@@ -39,7 +39,7 @@ public class VectorIndexTest {
   @Test
   public void testEmptyPropertiesSurviveRoundTripForRuntimeDefaults()
       throws Exception {
-    VectorIndexConfig original = new VectorIndexConfig(false, "HNSW", 128, 1,
+    VectorIndexConfig original = new VectorIndexConfig(Boolean.FALSE, "HNSW", 128, 1,
         VectorIndexConfig.VectorDistanceFunction.COSINE, Map.of());
     String serialized = JsonUtils.objectToString(original);
     VectorIndexConfig roundTripped = JsonUtils.stringToObject(serialized, VectorIndexConfig.class);

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/VectorIndexTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/VectorIndexTest.java
@@ -58,11 +58,12 @@ public class VectorIndexTest {
           .filter(fc -> fc.getName().equals("studentID")).collect(Collectors.toList()).get(0);
       JsonNode indexConfig = fieldConfig.getIndexes().get(VectorIndexType.INDEX_DISPLAY_NAME);
       assertNotNull(indexConfig);
-      assertFalse(indexConfig.get("disabled").asBoolean());
+      // Slim serialization: disabled=false (default) is omitted from the JSON entirely.
+      assertNull(indexConfig.get("disabled"));
       assertTrue(fieldConfig.getIndexTypes().isEmpty());
       assertNull(fieldConfig.getProperties());
       Assert.assertEquals(indexConfig.toString(),
-          "{\"disabled\":false,\"vectorIndexType\":\"HNSW\",\"vectorDimension\":1536,"
+          "{\"vectorIndexType\":\"HNSW\",\"vectorDimension\":1536,"
               + "\"version\":1,\"vectorDistanceFunction\":\"COSINE\",\"properties\":{\"vectorIndexType\":"
               + "\"HNSW\",\"vectorDimension\":\"1536\",\"vectorDistanceFunction\":\"COSINE\",\"version\":\"1\"}}");
     }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/VectorIndexTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/VectorIndexTest.java
@@ -20,9 +20,13 @@ package org.apache.pinot.segment.local.segment.index;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
+import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.pinot.segment.local.segment.index.vector.VectorIndexType;
+import org.apache.pinot.segment.local.segment.store.VectorIndexUtils;
+import org.apache.pinot.segment.spi.index.creator.VectorIndexConfig;
 import org.apache.pinot.spi.config.table.FieldConfig;
+import org.apache.pinot.spi.utils.JsonUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -32,6 +36,20 @@ import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
 
 public class VectorIndexTest {
+  @Test
+  public void testEmptyPropertiesSurviveRoundTripForRuntimeDefaults()
+      throws Exception {
+    VectorIndexConfig original = new VectorIndexConfig(false, "HNSW", 128, 1,
+        VectorIndexConfig.VectorDistanceFunction.COSINE, Map.of());
+    String serialized = JsonUtils.objectToString(original);
+    VectorIndexConfig roundTripped = JsonUtils.stringToObject(serialized, VectorIndexConfig.class);
+
+    assertNotNull(roundTripped.getProperties());
+    assertTrue(roundTripped.getProperties().isEmpty());
+    // Regression guard: this used to NPE when properties became null after round-trip.
+    assertNotNull(VectorIndexUtils.getIndexWriterConfig(roundTripped));
+  }
+
   public static class ConfTest extends AbstractSerdeIndexContract {
 
     @Test

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/dictionary/DictionaryIndexTypeTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/dictionary/DictionaryIndexTypeTest.java
@@ -136,7 +136,8 @@ public class DictionaryIndexTypeTest {
         throws IOException {
       _tableConfig.getIndexingConfig()
           .setVarLengthDictionaryColumns(JsonUtils.stringToObject("[\"dimInt\"]", _stringListTypeRef));
-      assertEquals(new DictionaryIndexConfig(false, true, null));
+      // Conversion now passes null for absent flags (see DictionaryIndexType#getFromIndexingConfig).
+      assertEquals(new DictionaryIndexConfig(null, true, null));
     }
 
     @Test
@@ -187,7 +188,8 @@ public class DictionaryIndexTypeTest {
           + "      }"
           + "    }\n"
           + " }");
-      assertEquals(new DictionaryIndexConfig(true, false, null));
+      // Only onHeap explicitly set; useVarLengthDictionary is not configured (null).
+      assertEquals(new DictionaryIndexConfig(true, null));
     }
 
     @Test
@@ -205,7 +207,7 @@ public class DictionaryIndexTypeTest {
           + "      }"
           + "    }\n"
           + " }");
-      assertEquals(new DictionaryIndexConfig(true, false, new Intern(1000)));
+      assertEquals(new DictionaryIndexConfig(true, null, new Intern(1000)));
     }
 
     @Test
@@ -254,7 +256,8 @@ public class DictionaryIndexTypeTest {
           + "      }"
           + "    }\n"
           + " }");
-      assertEquals(new DictionaryIndexConfig(false, false, null));
+      // Empty `{}` produces a config with all-null wrapper fields.
+      assertEquals(DictionaryIndexConfig.DEFAULT);
     }
 
     @Test
@@ -269,7 +272,9 @@ public class DictionaryIndexTypeTest {
           + "      }"
           + "    }\n"
           + " }");
-      assertEquals(new DictionaryIndexConfig(false, true, null));
+      // Only useVarLengthDictionary explicitly set; onHeap is not configured (null).
+      // Cast disambiguates the (Boolean, Boolean) ctor from (DictionaryIndexConfig, boolean).
+      assertEquals(new DictionaryIndexConfig((Boolean) null, true));
     }
 
     @Test

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/forward/ForwardIndexTypeTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/forward/ForwardIndexTypeTest.java
@@ -143,7 +143,6 @@ public class ForwardIndexTypeTest {
       assertEquals(
           new ForwardIndexConfig.Builder(FieldConfig.EncodingType.RAW)
               .withCompressionType(ChunkCompressionType.SNAPPY)
-              .withDeriveNumDocsPerChunk(false)
               .build()
       );
     }
@@ -163,7 +162,6 @@ public class ForwardIndexTypeTest {
       assertEquals(
           new ForwardIndexConfig.Builder(FieldConfig.EncodingType.RAW)
               .withCompressionType(ChunkCompressionType.SNAPPY)
-              .withDeriveNumDocsPerChunk(false)
               .build()
       );
     }
@@ -227,7 +225,6 @@ public class ForwardIndexTypeTest {
                 .withCompressionCodec(compression == null ? null : FieldConfig.CompressionCodec.valueOf(compression))
                 .withCompressionType(expectedChunkCompression)
                 .withDictIdCompressionType(expectedDictCompression)
-                .withDeriveNumDocsPerChunk(false)
                 .withRawIndexWriterVersion(ForwardIndexConfig.getDefaultRawWriterVersion())
                 .build()
       );
@@ -268,7 +265,6 @@ public class ForwardIndexTypeTest {
 
       assertEquals(new ForwardIndexConfig.Builder(FieldConfig.EncodingType.RAW)
           .withCompressionType(null)
-          .withDeriveNumDocsPerChunk(false)
           .withRawIndexWriterVersion(3)
           .build());
     }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/VectorIndexHandlerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/VectorIndexHandlerTest.java
@@ -101,7 +101,7 @@ public class VectorIndexHandlerTest {
   }
 
   private static VectorIndexConfig vectorIndexConfig(String backend) {
-    return new VectorIndexConfig(false, backend, 4, 1, VectorIndexConfig.VectorDistanceFunction.EUCLIDEAN,
+    return new VectorIndexConfig(Boolean.FALSE, backend, 4, 1, VectorIndexConfig.VectorDistanceFunction.EUCLIDEAN,
         Map.of("nlist", "2", "pqM", "2", "pqNbits", "4", "trainSampleSize", "8"));
   }
 

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/readers/vector/IvfFlatFilterAwareTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/readers/vector/IvfFlatFilterAwareTest.java
@@ -278,7 +278,8 @@ public class IvfFlatFilterAwareTest {
       throws Exception {
     Map<String, String> properties = new HashMap<>();
     properties.put("nlist", String.valueOf(nlist));
-    VectorIndexConfig config = new VectorIndexConfig(false, "IVF_FLAT", dimension, 1, distanceFunction, properties);
+    VectorIndexConfig config =
+        new VectorIndexConfig(Boolean.FALSE, "IVF_FLAT", dimension, 1, distanceFunction, properties);
 
     try (IvfFlatVectorIndexCreator creator = new IvfFlatVectorIndexCreator(
         COLUMN_NAME, _tempDir, config)) {
@@ -293,6 +294,6 @@ public class IvfFlatFilterAwareTest {
       VectorIndexConfig.VectorDistanceFunction distanceFunction) {
     Map<String, String> properties = new HashMap<>();
     properties.put("nlist", String.valueOf(nlist));
-    return new VectorIndexConfig(false, "IVF_FLAT", dimension, 1, distanceFunction, properties);
+    return new VectorIndexConfig(Boolean.FALSE, "IVF_FLAT", dimension, 1, distanceFunction, properties);
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/readers/vector/IvfOnDiskFilterAwareTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/readers/vector/IvfOnDiskFilterAwareTest.java
@@ -207,7 +207,7 @@ public class IvfOnDiskFilterAwareTest {
     properties.put("nlist", String.valueOf(nlist));
     properties.put("quantizer", quantizerType.name());
     VectorIndexConfig creatorConfig =
-        new VectorIndexConfig(false, "IVF_FLAT", dimension, 1, distanceFunction, properties);
+        new VectorIndexConfig(Boolean.FALSE, "IVF_FLAT", dimension, 1, distanceFunction, properties);
     try (IvfFlatVectorIndexCreator creator = new IvfFlatVectorIndexCreator(COLUMN_NAME, _tempDir, creatorConfig)) {
       for (float[] vector : vectors) {
         creator.add(vector);
@@ -226,7 +226,7 @@ public class IvfOnDiskFilterAwareTest {
     Map<String, String> properties = new HashMap<>();
     properties.put("nlist", String.valueOf(nlist));
     properties.put("quantizer", quantizerType.name());
-    return new VectorIndexConfig(false, "IVF_ON_DISK", dimension, 1, distanceFunction, properties);
+    return new VectorIndexConfig(Boolean.FALSE, "IVF_ON_DISK", dimension, 1, distanceFunction, properties);
   }
 
   private static final class CountingIvfOnDiskVectorIndexReader extends IvfOnDiskVectorIndexReader {

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/vector/IvfFlatVectorIndexTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/vector/IvfFlatVectorIndexTest.java
@@ -836,7 +836,7 @@ public class IvfFlatVectorIndexTest {
     properties.put("nlist", String.valueOf(nlist));
     properties.put("trainingSeed", String.valueOf(TEST_SEED));
     properties.put("quantizer", quantizerType.name());
-    return new VectorIndexConfig(false, "IVF_FLAT", dimension, 1, distanceFunction, properties);
+    return new VectorIndexConfig(Boolean.FALSE, "IVF_FLAT", dimension, 1, distanceFunction, properties);
   }
 
   private float[][] generateRandomVectors(int numVectors, int dimension, long seed) {

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/vector/IvfPqVectorIndexTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/vector/IvfPqVectorIndexTest.java
@@ -448,7 +448,7 @@ public class IvfPqVectorIndexTest {
     properties.put("nlist", "2");
     properties.put("pqNbits", "4");
     properties.put("trainSampleSize", "8");
-    VectorIndexConfig config = new VectorIndexConfig(false, "IVF_PQ", 4, 1,
+    VectorIndexConfig config = new VectorIndexConfig(Boolean.FALSE, "IVF_PQ", 4, 1,
         VectorIndexConfig.VectorDistanceFunction.EUCLIDEAN, properties);
     try (IvfPqVectorIndexCreator ignored = new IvfPqVectorIndexCreator(COLUMN_NAME, _tempDir, config)) {
       Assert.fail("Expected missing pqM validation to fail");
@@ -732,7 +732,7 @@ public class IvfPqVectorIndexTest {
     properties.put("pqNbits", String.valueOf(pqNbits));
     properties.put("trainSampleSize", String.valueOf(trainSampleSize));
     properties.put("trainingSeed", String.valueOf(trainingSeed));
-    return new VectorIndexConfig(false, "IVF_PQ", dimension, 1, distanceFunction, properties);
+    return new VectorIndexConfig(Boolean.FALSE, "IVF_PQ", dimension, 1, distanceFunction, properties);
   }
 
   private void assertSupportedPqNbitsSearchPath(VectorIndexConfig.VectorDistanceFunction distanceFunction)

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/vector/VectorIndexTypeTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/vector/VectorIndexTypeTest.java
@@ -57,7 +57,7 @@ public class VectorIndexTypeTest {
       Mockito.when(metadata.getFieldSpec())
           .thenReturn(new DimensionFieldSpec("embedding", FieldSpec.DataType.FLOAT, false));
 
-      VectorIndexConfig vectorIndexConfig = new VectorIndexConfig(false, "IVF_PQ", 4, 1,
+      VectorIndexConfig vectorIndexConfig = new VectorIndexConfig(Boolean.FALSE, "IVF_PQ", 4, 1,
           VectorIndexConfig.VectorDistanceFunction.EUCLIDEAN,
           Map.of("nlist", "2", "pqM", "2", "pqNbits", "4", "trainSampleSize", "8"));
       FieldIndexConfigs fieldIndexConfigs =

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/vector/VectorSearchBenchmark.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/vector/VectorSearchBenchmark.java
@@ -88,7 +88,7 @@ public class VectorSearchBenchmark {
     props.put("version", "1");
     props.put("nlist", String.valueOf(NLIST));
     props.put("trainingSeed", "42");
-    VectorIndexConfig config = new VectorIndexConfig(false, "IVF_FLAT", DIMENSION, 1,
+    VectorIndexConfig config = new VectorIndexConfig(Boolean.FALSE, "IVF_FLAT", DIMENSION, 1,
         VectorIndexConfig.VectorDistanceFunction.EUCLIDEAN, props);
 
     try (IvfFlatVectorIndexCreator creator = new IvfFlatVectorIndexCreator("embedding", _tempDir, config)) {

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/store/SegmentDirectoryPathsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/store/SegmentDirectoryPathsTest.java
@@ -85,7 +85,7 @@ public class SegmentDirectoryPathsTest {
       FileUtils.touch(hnswFile);
       FileUtils.touch(ivfPqFile);
 
-      VectorIndexConfig ivfPqConfig = new VectorIndexConfig(false, "IVF_PQ", 16, 1,
+      VectorIndexConfig ivfPqConfig = new VectorIndexConfig(Boolean.FALSE, "IVF_PQ", 16, 1,
           VectorIndexConfig.VectorDistanceFunction.COSINE,
           Map.of("nlist", "4", "pqM", "4", "pqNbits", "8", "trainSampleSize", "16"));
 

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/DictionaryIndexConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/DictionaryIndexConfig.java
@@ -37,15 +37,15 @@ import org.apache.pinot.spi.utils.JsonUtils;
 
 
 public class DictionaryIndexConfig extends IndexConfig {
-  public static final DictionaryIndexConfig DEFAULT = new DictionaryIndexConfig(false);
+  public static final DictionaryIndexConfig DEFAULT = new DictionaryIndexConfig((Boolean) null);
   public static final DictionaryIndexConfig DISABLED = new DictionaryIndexConfig(true);
 
-  private final boolean _onHeap;
-  private final boolean _useVarLengthDictionary;
+  private final Boolean _onHeap;
+  private final Boolean _useVarLengthDictionary;
   private final Intern _intern;
 
   public DictionaryIndexConfig(Boolean disabled) {
-    this(disabled, false, false, null);
+    this(disabled, null, null, null);
   }
 
   public DictionaryIndexConfig(Boolean onHeap, @Nullable Boolean useVarLengthDictionary) {
@@ -56,9 +56,7 @@ public class DictionaryIndexConfig extends IndexConfig {
     this(false, onHeap, useVarLengthDictionary, intern);
   }
 
-  /**
-   * Constructor for patching an existing config, but overrides the useVarLengthDictionary property with the input
-   */
+  /// Constructor for patching an existing config, but overrides the useVarLengthDictionary property with the input.
   public DictionaryIndexConfig(DictionaryIndexConfig base, boolean useVarLengthDictionary) {
     this(base.isEnabled(), base.isOnHeap(), useVarLengthDictionary, base.getIntern());
   }
@@ -76,35 +74,34 @@ public class DictionaryIndexConfig extends IndexConfig {
           "Intern configs only work with on-heap dictionary");
     }
 
-    _onHeap = onHeap != null && onHeap;
-    _useVarLengthDictionary = Boolean.TRUE.equals(useVarLengthDictionary);
+    _onHeap = onHeap;
+    _useVarLengthDictionary = useVarLengthDictionary;
     _intern = intern;
   }
 
   public boolean isOnHeap() {
-    return _onHeap;
+    return Boolean.TRUE.equals(_onHeap);
   }
 
   public boolean isUseVarLengthDictionary() {
-    return _useVarLengthDictionary;
+    return Boolean.TRUE.equals(_useVarLengthDictionary);
   }
 
   public Intern getIntern() {
     return _intern;
   }
 
-  /**
-   * Curated slim serializer. See {@link IndexConfig#toJsonObject()} for the rationale.
-   */
+  /// Curated slim serializer. See [IndexConfig#toJsonObject()] for the rationale. Each field is emitted only
+  /// when explicitly configured (non-null wrapper).
   @Override
   @JsonValue
   public ObjectNode toJsonObject() {
     ObjectNode node = super.toJsonObject();
-    if (_onHeap) {
-      node.put("onHeap", true);
+    if (_onHeap != null) {
+      node.put("onHeap", _onHeap);
     }
-    if (_useVarLengthDictionary) {
-      node.put("useVarLengthDictionary", true);
+    if (_useVarLengthDictionary != null) {
+      node.put("useVarLengthDictionary", _useVarLengthDictionary);
     }
     if (_intern != null) {
       node.set("intern", JsonUtils.objectToJsonNode(_intern));
@@ -121,8 +118,9 @@ public class DictionaryIndexConfig extends IndexConfig {
       return false;
     }
     DictionaryIndexConfig that = (DictionaryIndexConfig) o;
-    return _onHeap == that._onHeap && _useVarLengthDictionary == that._useVarLengthDictionary && Objects.equals(_intern,
-        that._intern);
+    return Objects.equals(_onHeap, that._onHeap)
+        && Objects.equals(_useVarLengthDictionary, that._useVarLengthDictionary)
+        && Objects.equals(_intern, that._intern);
   }
 
   @Override
@@ -134,8 +132,8 @@ public class DictionaryIndexConfig extends IndexConfig {
   public String toString() {
     if (isEnabled()) {
       String internStr = _intern == null ? "null" : _intern.toString();
-      return "DictionaryIndexConfig{" + "\"onHeap\":" + _onHeap + ", \"useVarLengthDictionary\":"
-          + _useVarLengthDictionary + ", \"intern\":" + internStr + "}";
+      return "DictionaryIndexConfig{" + "\"onHeap\":" + isOnHeap() + ", \"useVarLengthDictionary\":"
+          + isUseVarLengthDictionary() + ", \"intern\":" + internStr + "}";
     } else {
       return "DictionaryIndexConfig{" + "\"disabled\": true}";
     }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/DictionaryIndexConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/DictionaryIndexConfig.java
@@ -21,6 +21,8 @@ package org.apache.pinot.segment.spi.index;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Preconditions;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -31,6 +33,7 @@ import javax.annotation.Nullable;
 import org.apache.pinot.spi.config.table.IndexConfig;
 import org.apache.pinot.spi.config.table.Intern;
 import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.utils.JsonUtils;
 
 
 public class DictionaryIndexConfig extends IndexConfig {
@@ -88,6 +91,25 @@ public class DictionaryIndexConfig extends IndexConfig {
 
   public Intern getIntern() {
     return _intern;
+  }
+
+  /**
+   * Curated slim serializer. See {@link IndexConfig#toJsonObject()} for the rationale.
+   */
+  @Override
+  @JsonValue
+  public ObjectNode toJsonObject() {
+    ObjectNode node = super.toJsonObject();
+    if (_onHeap) {
+      node.put("onHeap", true);
+    }
+    if (_useVarLengthDictionary) {
+      node.put("useVarLengthDictionary", true);
+    }
+    if (_intern != null) {
+      node.set("intern", JsonUtils.objectToJsonNode(_intern));
+    }
+    return node;
   }
 
   @Override

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/ForwardIndexConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/ForwardIndexConfig.java
@@ -276,9 +276,7 @@ public class ForwardIndexConfig extends IndexConfig {
   @JsonValue
   public ObjectNode toJsonObject() {
     ObjectNode node = super.toJsonObject();
-    if (_encodingType != EncodingType.DICTIONARY) {
-      node.put("encodingType", _encodingType.name());
-    }
+    node.put("encodingType", _encodingType.name());
     if (_compressionCodec != null) {
       node.put("compressionCodec", _compressionCodec.name());
     }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/ForwardIndexConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/ForwardIndexConfig.java
@@ -255,9 +255,18 @@ public class ForwardIndexConfig extends IndexConfig {
   /**
    * Curated slim serializer. See {@link IndexConfig#toJsonObject()} for the rationale.
    *
-   * <p>Emits each field only when it differs from its class default. The three writer-version /
-   * chunk-size defaults are cluster-tunable statics, so they are read at call time (not captured)
-   * to keep the serialized form consistent with the live cluster default.
+   * <p>Emits {@code disabled}, {@code compressionCodec}, and {@code deriveNumDocsPerChunk} only
+   * when they differ from their class default.
+   *
+   * <p>The three cluster-tunable fields {@code rawIndexWriterVersion}, {@code targetMaxChunkSize},
+   * and {@code targetDocsPerChunk} are <i>always</i> materialized — their underlying defaults
+   * ({@link #_defaultRawIndexWriterVersion}, {@link #_defaultTargetMaxChunkSize},
+   * {@link #_defaultTargetDocsPerChunk}) are JVM-local statics that
+   * {@code ServiceStartableUtils.initForwardIndexConfig} mutates per-instance from instance config
+   * at startup. If we omitted these keys when they matched the writing node's local default, the
+   * same ZK payload would resolve to different forward-index settings on a node whose local
+   * default differs (rolling upgrades, mismatched instance configs). Always emitting them keeps
+   * the persisted shape stable across the cluster — matching the pre-slim contract.
    *
    * <p>Deprecated input keys {@code chunkCompressionType} and {@code dictIdCompressionType} are
    * intentionally not emitted — their getters were already {@code @JsonIgnore}, so the slim form
@@ -276,16 +285,10 @@ public class ForwardIndexConfig extends IndexConfig {
     if (_deriveNumDocsPerChunk) {
       node.put("deriveNumDocsPerChunk", true);
     }
-    // Read cluster-tunable statics at call time so the serialized form tracks the live default.
-    if (_rawIndexWriterVersion != _defaultRawIndexWriterVersion) {
-      node.put("rawIndexWriterVersion", _rawIndexWriterVersion);
-    }
-    if (!Objects.equals(_targetMaxChunkSize, _defaultTargetMaxChunkSize)) {
-      node.put("targetMaxChunkSize", _targetMaxChunkSize);
-    }
-    if (_targetDocsPerChunk != _defaultTargetDocsPerChunk) {
-      node.put("targetDocsPerChunk", _targetDocsPerChunk);
-    }
+    // Always materialize the cluster-tunable trio (see Javadoc above).
+    node.put("rawIndexWriterVersion", _rawIndexWriterVersion);
+    node.put("targetMaxChunkSize", _targetMaxChunkSize);
+    node.put("targetDocsPerChunk", _targetDocsPerChunk);
     return node;
   }
 

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/ForwardIndexConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/ForwardIndexConfig.java
@@ -21,6 +21,8 @@ package org.apache.pinot.segment.spi.index;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Preconditions;
 import java.util.HashMap;
 import java.util.Map;
@@ -248,6 +250,43 @@ public class ForwardIndexConfig extends IndexConfig {
 
   public EncodingType getEncodingType() {
     return _encodingType;
+  }
+
+  /**
+   * Curated slim serializer. See {@link IndexConfig#toJsonObject()} for the rationale.
+   *
+   * <p>Emits each field only when it differs from its class default. The three writer-version /
+   * chunk-size defaults are cluster-tunable statics, so they are read at call time (not captured)
+   * to keep the serialized form consistent with the live cluster default.
+   *
+   * <p>Deprecated input keys {@code chunkCompressionType} and {@code dictIdCompressionType} are
+   * intentionally not emitted — their getters were already {@code @JsonIgnore}, so the slim form
+   * matches prior behavior for those keys. The same applies to {@code configs}.
+   */
+  @Override
+  @JsonValue
+  public ObjectNode toJsonObject() {
+    ObjectNode node = super.toJsonObject();
+    if (_encodingType != EncodingType.DICTIONARY) {
+      node.put("encodingType", _encodingType.name());
+    }
+    if (_compressionCodec != null) {
+      node.put("compressionCodec", _compressionCodec.name());
+    }
+    if (_deriveNumDocsPerChunk) {
+      node.put("deriveNumDocsPerChunk", true);
+    }
+    // Read cluster-tunable statics at call time so the serialized form tracks the live default.
+    if (_rawIndexWriterVersion != _defaultRawIndexWriterVersion) {
+      node.put("rawIndexWriterVersion", _rawIndexWriterVersion);
+    }
+    if (!Objects.equals(_targetMaxChunkSize, _defaultTargetMaxChunkSize)) {
+      node.put("targetMaxChunkSize", _targetMaxChunkSize);
+    }
+    if (_targetDocsPerChunk != _defaultTargetDocsPerChunk) {
+      node.put("targetDocsPerChunk", _targetDocsPerChunk);
+    }
+    return node;
   }
 
   @Override

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/ForwardIndexConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/ForwardIndexConfig.java
@@ -83,7 +83,7 @@ public class ForwardIndexConfig extends IndexConfig {
   private final EncodingType _encodingType;
   @Nullable
   private final CompressionCodec _compressionCodec;
-  private final boolean _deriveNumDocsPerChunk;
+  private final Boolean _deriveNumDocsPerChunk;
   private final int _rawIndexWriterVersion;
   private final String _targetMaxChunkSize;
   private final int _targetMaxChunkSizeBytes;
@@ -113,7 +113,7 @@ public class ForwardIndexConfig extends IndexConfig {
     // Builder(EncodingType) and pass an explicit value, typically from FieldConfig.getEncodingType().
     _encodingType = encodingType == null ? EncodingType.DICTIONARY : encodingType;
     _compressionCodec = getActualCompressionCodec(compressionCodec, chunkCompressionType, dictIdCompressionType);
-    _deriveNumDocsPerChunk = Boolean.TRUE.equals(deriveNumDocsPerChunk);
+    _deriveNumDocsPerChunk = deriveNumDocsPerChunk;
     _rawIndexWriterVersion = rawIndexWriterVersion == null ? _defaultRawIndexWriterVersion : rawIndexWriterVersion;
     _targetMaxChunkSize = targetMaxChunkSize == null ? _defaultTargetMaxChunkSize : targetMaxChunkSize;
     _targetMaxChunkSizeBytes =
@@ -210,7 +210,7 @@ public class ForwardIndexConfig extends IndexConfig {
   }
 
   public boolean isDeriveNumDocsPerChunk() {
-    return _deriveNumDocsPerChunk;
+    return Boolean.TRUE.equals(_deriveNumDocsPerChunk);
   }
 
   public int getRawIndexWriterVersion() {
@@ -252,26 +252,20 @@ public class ForwardIndexConfig extends IndexConfig {
     return _encodingType;
   }
 
-  /**
-   * Curated slim serializer. See {@link IndexConfig#toJsonObject()} for the rationale.
-   *
-   * <p>Emits {@code disabled}, {@code compressionCodec}, and {@code deriveNumDocsPerChunk} only
-   * when they differ from their class default.
-   *
-   * <p>The three cluster-tunable fields {@code rawIndexWriterVersion}, {@code targetMaxChunkSize},
-   * and {@code targetDocsPerChunk} are <i>always</i> materialized — their underlying defaults
-   * ({@link #_defaultRawIndexWriterVersion}, {@link #_defaultTargetMaxChunkSize},
-   * {@link #_defaultTargetDocsPerChunk}) are JVM-local statics that
-   * {@code ServiceStartableUtils.initForwardIndexConfig} mutates per-instance from instance config
-   * at startup. If we omitted these keys when they matched the writing node's local default, the
-   * same ZK payload would resolve to different forward-index settings on a node whose local
-   * default differs (rolling upgrades, mismatched instance configs). Always emitting them keeps
-   * the persisted shape stable across the cluster — matching the pre-slim contract.
-   *
-   * <p>Deprecated input keys {@code chunkCompressionType} and {@code dictIdCompressionType} are
-   * intentionally not emitted — their getters were already {@code @JsonIgnore}, so the slim form
-   * matches prior behavior for those keys. The same applies to {@code configs}.
-   */
+  /// Curated slim serializer. See [IndexConfig#toJsonObject()] for the rationale.
+  ///
+  /// `compressionCodec` and `deriveNumDocsPerChunk` are emitted only when explicitly configured (non-null).
+  ///
+  /// The three cluster-tunable fields `rawIndexWriterVersion`, `targetMaxChunkSize`, and `targetDocsPerChunk`
+  /// follow a *snapshot model*: the constructor coerces null to the live JVM-static default
+  /// ([#_defaultRawIndexWriterVersion], [#_defaultTargetMaxChunkSize], [#_defaultTargetDocsPerChunk]) at init
+  /// time. The fields are therefore always non-null after construction and are always emitted via the standard
+  /// `if (_x != null)` rule. This preserves the pre-PR contract that `ServiceStartableUtils.initForwardIndexConfig`
+  /// users observed (snapshot at construction, stable for object lifetime), and keeps the ZK shape stable across
+  /// nodes whose JVM-local statics differ (rolling upgrades, mismatched instance configs).
+  ///
+  /// Deprecated input keys `chunkCompressionType` and `dictIdCompressionType` are intentionally not emitted —
+  /// their getters were already `@JsonIgnore`, so the slim form matches prior behavior. Same for `configs`.
   @Override
   @JsonValue
   public ObjectNode toJsonObject() {
@@ -280,10 +274,11 @@ public class ForwardIndexConfig extends IndexConfig {
     if (_compressionCodec != null) {
       node.put("compressionCodec", _compressionCodec.name());
     }
-    if (_deriveNumDocsPerChunk) {
-      node.put("deriveNumDocsPerChunk", true);
+    if (_deriveNumDocsPerChunk != null) {
+      node.put("deriveNumDocsPerChunk", _deriveNumDocsPerChunk);
     }
-    // Always materialize the cluster-tunable trio (see Javadoc above).
+    // Cluster-tunable trio — fields are snapshot-coerced at init time, so they are always non-null and always
+    // emitted (see Javadoc above).
     node.put("rawIndexWriterVersion", _rawIndexWriterVersion);
     node.put("targetMaxChunkSize", _targetMaxChunkSize);
     node.put("targetDocsPerChunk", _targetDocsPerChunk);
@@ -302,9 +297,11 @@ public class ForwardIndexConfig extends IndexConfig {
       return false;
     }
     ForwardIndexConfig that = (ForwardIndexConfig) o;
-    return _compressionCodec == that._compressionCodec && _deriveNumDocsPerChunk == that._deriveNumDocsPerChunk
-        && _rawIndexWriterVersion == that._rawIndexWriterVersion && Objects.equals(_targetMaxChunkSize,
-        that._targetMaxChunkSize) && _targetDocsPerChunk == that._targetDocsPerChunk
+    return _compressionCodec == that._compressionCodec
+        && Objects.equals(_deriveNumDocsPerChunk, that._deriveNumDocsPerChunk)
+        && _rawIndexWriterVersion == that._rawIndexWriterVersion
+        && Objects.equals(_targetMaxChunkSize, that._targetMaxChunkSize)
+        && _targetDocsPerChunk == that._targetDocsPerChunk
         && _encodingType == that._encodingType;
   }
 
@@ -319,7 +316,7 @@ public class ForwardIndexConfig extends IndexConfig {
     private final EncodingType _encodingType;
     @Nullable
     private CompressionCodec _compressionCodec;
-    private boolean _deriveNumDocsPerChunk = false;
+    private Boolean _deriveNumDocsPerChunk;
     private int _rawIndexWriterVersion = _defaultRawIndexWriterVersion;
     private String _targetMaxChunkSize = _defaultTargetMaxChunkSize;
     private int _targetDocsPerChunk = _defaultTargetDocsPerChunk;

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/FstIndexConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/FstIndexConfig.java
@@ -39,10 +39,8 @@ public class FstIndexConfig extends IndexConfig {
     super(disabled);
   }
 
-  /**
-   * Curated slim serializer. {@code FstIndexConfig} adds no fields beyond {@code disabled}, so
-   * the override is for symmetry and direct test traceability — it inherits the base behavior.
-   */
+  /// Curated slim serializer. `FstIndexConfig` adds no fields beyond `disabled`, so the override is for
+  /// symmetry and direct test traceability — it inherits the base behavior.
   @Override
   @JsonValue
   public ObjectNode toJsonObject() {

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/FstIndexConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/FstIndexConfig.java
@@ -21,6 +21,8 @@ package org.apache.pinot.segment.spi.index;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import javax.annotation.Nullable;
 import org.apache.pinot.spi.config.table.IndexConfig;
 
@@ -35,5 +37,15 @@ public class FstIndexConfig extends IndexConfig {
   @JsonCreator
   public FstIndexConfig(@JsonProperty("disabled") @Nullable Boolean disabled) {
     super(disabled);
+  }
+
+  /**
+   * Curated slim serializer. {@code FstIndexConfig} adds no fields beyond {@code disabled}, so
+   * the override is for symmetry and direct test traceability — it inherits the base behavior.
+   */
+  @Override
+  @JsonValue
+  public ObjectNode toJsonObject() {
+    return super.toJsonObject();
   }
 }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/RangeIndexConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/RangeIndexConfig.java
@@ -29,10 +29,11 @@ import org.apache.pinot.spi.config.table.IndexConfig;
 
 
 public class RangeIndexConfig extends IndexConfig {
-  public static final RangeIndexConfig DEFAULT = new RangeIndexConfig(false, 2);
+  public static final int DEFAULT_VERSION = 2;
+  public static final RangeIndexConfig DEFAULT = new RangeIndexConfig((Boolean) null, null);
   public static final RangeIndexConfig DISABLED = new RangeIndexConfig(true, null);
 
-  private final int _version;
+  private final Integer _version;
 
   public RangeIndexConfig(int version) {
     this(false, version);
@@ -42,21 +43,19 @@ public class RangeIndexConfig extends IndexConfig {
   public RangeIndexConfig(@JsonProperty("disabled") Boolean disabled,
       @JsonProperty("version") @Nullable Integer version) {
     super(disabled);
-    _version = version != null ? version : 2;
+    _version = version;
   }
 
   public int getVersion() {
-    return _version;
+    return _version != null ? _version : DEFAULT_VERSION;
   }
 
-  /**
-   * Curated slim serializer. See {@link IndexConfig#toJsonObject()} for the rationale.
-   */
+  /// Curated slim serializer. See [IndexConfig#toJsonObject()] for the rationale.
   @Override
   @JsonValue
   public ObjectNode toJsonObject() {
     ObjectNode node = super.toJsonObject();
-    if (_version != 2) {
+    if (_version != null) {
       node.put("version", _version);
     }
     return node;
@@ -74,7 +73,7 @@ public class RangeIndexConfig extends IndexConfig {
       return false;
     }
     RangeIndexConfig that = (RangeIndexConfig) o;
-    return _version == that._version;
+    return Objects.equals(_version, that._version);
   }
 
   @Override

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/RangeIndexConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/RangeIndexConfig.java
@@ -21,6 +21,8 @@ package org.apache.pinot.segment.spi.index;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.Objects;
 import javax.annotation.Nullable;
 import org.apache.pinot.spi.config.table.IndexConfig;
@@ -45,6 +47,19 @@ public class RangeIndexConfig extends IndexConfig {
 
   public int getVersion() {
     return _version;
+  }
+
+  /**
+   * Curated slim serializer. See {@link IndexConfig#toJsonObject()} for the rationale.
+   */
+  @Override
+  @JsonValue
+  public ObjectNode toJsonObject() {
+    ObjectNode node = super.toJsonObject();
+    if (_version != 2) {
+      node.put("version", _version);
+    }
+    return node;
   }
 
   @Override

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/TextIndexConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/TextIndexConfig.java
@@ -21,6 +21,8 @@ package org.apache.pinot.segment.spi.index;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -30,6 +32,7 @@ import javax.annotation.Nullable;
 import org.apache.pinot.segment.spi.utils.CsvParser;
 import org.apache.pinot.spi.config.table.FieldConfig;
 import org.apache.pinot.spi.config.table.IndexConfig;
+import org.apache.pinot.spi.utils.JsonUtils;
 
 
 public class TextIndexConfig extends IndexConfig {
@@ -336,6 +339,75 @@ public class TextIndexConfig extends IndexConfig {
    */
   public boolean isStoreInSegmentFile() {
     return _storeInSegmentFile;
+  }
+
+  /**
+   * Curated slim serializer. See {@link IndexConfig#toJsonObject()} for the rationale.
+   *
+   * <p>Each of the 18 lucene defaults — declared as {@code LUCENE_INDEX_DEFAULT_*} constants at
+   * the top of this file — is omitted from the output when the field still equals its default.
+   * Empty / null lists for {@code stopWords*} and {@code luceneAnalyzerClassArgs*} are also
+   * treated as defaults and omitted.
+   */
+  @Override
+  @JsonValue
+  public ObjectNode toJsonObject() {
+    ObjectNode node = super.toJsonObject();
+    if (_rawValueForTextIndex != null) {
+      node.set("rawValue", JsonUtils.objectToJsonNode(_rawValueForTextIndex));
+    }
+    if (_enableQueryCache) {
+      node.put("queryCache", true);
+    }
+    if (_useANDForMultiTermQueries) {
+      node.put("useANDForMultiTermQueries", true);
+    }
+    if (_stopWordsInclude != null && !_stopWordsInclude.isEmpty()) {
+      node.set("stopWordsInclude", JsonUtils.objectToJsonNode(_stopWordsInclude));
+    }
+    if (_stopWordsExclude != null && !_stopWordsExclude.isEmpty()) {
+      node.set("stopWordsExclude", JsonUtils.objectToJsonNode(_stopWordsExclude));
+    }
+    if (_luceneUseCompoundFile != LUCENE_INDEX_DEFAULT_USE_COMPOUND_FILE) {
+      node.put("luceneUseCompoundFile", _luceneUseCompoundFile);
+    }
+    if (_luceneMaxBufferSizeMB != LUCENE_INDEX_DEFAULT_MAX_BUFFER_SIZE_MB) {
+      node.put("luceneMaxBufferSizeMB", _luceneMaxBufferSizeMB);
+    }
+    if (!Objects.equals(_luceneAnalyzerClass, FieldConfig.TEXT_INDEX_DEFAULT_LUCENE_ANALYZER_CLASS)) {
+      node.put("luceneAnalyzerClass", _luceneAnalyzerClass);
+    }
+    if (_luceneAnalyzerClassArgs != null && !_luceneAnalyzerClassArgs.isEmpty()) {
+      node.set("luceneAnalyzerClassArgs", JsonUtils.objectToJsonNode(_luceneAnalyzerClassArgs));
+    }
+    if (_luceneAnalyzerClassArgTypes != null && !_luceneAnalyzerClassArgTypes.isEmpty()) {
+      node.set("luceneAnalyzerClassArgTypes", JsonUtils.objectToJsonNode(_luceneAnalyzerClassArgTypes));
+    }
+    if (!Objects.equals(_luceneQueryParserClass, FieldConfig.TEXT_INDEX_DEFAULT_LUCENE_QUERY_PARSER_CLASS)) {
+      node.put("luceneQueryParserClass", _luceneQueryParserClass);
+    }
+    if (_enablePrefixSuffixMatchingInPhraseQueries != LUCENE_INDEX_ENABLE_PREFIX_SUFFIX_MATCH_IN_PHRASE_SEARCH) {
+      node.put("enablePrefixSuffixMatchingInPhraseQueries", _enablePrefixSuffixMatchingInPhraseQueries);
+    }
+    if (_reuseMutableIndex != LUCENE_INDEX_REUSE_MUTABLE_INDEX) {
+      node.put("reuseMutableIndex", _reuseMutableIndex);
+    }
+    if (_luceneNRTCachingDirectoryMaxBufferSizeMB != LUCENE_INDEX_NRT_CACHING_DIRECTORY_MAX_BUFFER_SIZE_MB) {
+      node.put("luceneNRTCachingDirectoryMaxBufferSizeMB", _luceneNRTCachingDirectoryMaxBufferSizeMB);
+    }
+    if (_useLogByteSizeMergePolicy != LUCENE_USE_LOG_BYTE_SIZE_MERGE_POLICY) {
+      node.put("useLogByteSizeMergePolicy", _useLogByteSizeMergePolicy);
+    }
+    if (_docIdTranslatorMode != LUCENE_TRANSLATOR_MODE) {
+      node.put("docIdTranslatorMode", _docIdTranslatorMode.name());
+    }
+    if (_caseSensitive != LUCENE_INDEX_DEFAULT_CASE_SENSITIVE_INDEX) {
+      node.put("caseSensitive", _caseSensitive);
+    }
+    if (_storeInSegmentFile != LUCENE_INDEX_DEFAULT_STORE_IN_SEGMENT_FILE) {
+      node.put("storeInSegmentFile", _storeInSegmentFile);
+    }
+    return node;
   }
 
   public static abstract class AbstractBuilder {

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/TextIndexConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/TextIndexConfig.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Nullable;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.pinot.segment.spi.utils.CsvParser;
 import org.apache.pinot.spi.config.table.FieldConfig;
 import org.apache.pinot.spi.config.table.IndexConfig;
@@ -57,29 +58,28 @@ public class TextIndexConfig extends IndexConfig {
   );
 
   public static final TextIndexConfig DISABLED =
-      new TextIndexConfig(true, null, false, false, Collections.emptyList(), Collections.emptyList(), false,
-          LUCENE_INDEX_DEFAULT_MAX_BUFFER_SIZE_MB, null, null, null, null, false, false, 0, false, null,
-          LUCENE_INDEX_DEFAULT_CASE_SENSITIVE_INDEX, LUCENE_INDEX_DEFAULT_STORE_IN_SEGMENT_FILE);
+      new TextIndexConfig(true, null, null, null, null, null, null, null, null, null, null, null, null, null, null,
+          null, null, null, null);
 
   @Nullable
   private final Object _rawValueForTextIndex;
-  private final boolean _enableQueryCache;
-  private final boolean _useANDForMultiTermQueries;
+  private final Boolean _enableQueryCache;
+  private final Boolean _useANDForMultiTermQueries;
   private final List<String> _stopWordsInclude;
   private final List<String> _stopWordsExclude;
-  private final boolean _luceneUseCompoundFile;
-  private final int _luceneMaxBufferSizeMB;
+  private final Boolean _luceneUseCompoundFile;
+  private final Integer _luceneMaxBufferSizeMB;
   private final String _luceneAnalyzerClass;
   private final List<String> _luceneAnalyzerClassArgs;
   private final List<String> _luceneAnalyzerClassArgTypes;
   private final String _luceneQueryParserClass;
-  private final boolean _enablePrefixSuffixMatchingInPhraseQueries;
-  private final boolean _reuseMutableIndex;
-  private final int _luceneNRTCachingDirectoryMaxBufferSizeMB;
-  private final boolean _useLogByteSizeMergePolicy;
+  private final Boolean _enablePrefixSuffixMatchingInPhraseQueries;
+  private final Boolean _reuseMutableIndex;
+  private final Integer _luceneNRTCachingDirectoryMaxBufferSizeMB;
+  private final Boolean _useLogByteSizeMergePolicy;
   private final DocIdTranslatorMode _docIdTranslatorMode;
-  private final boolean _caseSensitive;
-  private final boolean _storeInSegmentFile;
+  private final Boolean _caseSensitive;
+  private final Boolean _storeInSegmentFile;
 
   public enum DocIdTranslatorMode {
     // build and keep mapping
@@ -103,8 +103,8 @@ public class TextIndexConfig extends IndexConfig {
     }
   }
 
-  public TextIndexConfig(Boolean disabled, Object rawValueForTextIndex, boolean enableQueryCache,
-      boolean useANDForMultiTermQueries, List<String> stopWordsInclude, List<String> stopWordsExclude,
+  public TextIndexConfig(Boolean disabled, Object rawValueForTextIndex, Boolean enableQueryCache,
+      Boolean useANDForMultiTermQueries, List<String> stopWordsInclude, List<String> stopWordsExclude,
       Boolean luceneUseCompoundFile, Integer luceneMaxBufferSizeMB, String luceneAnalyzerClass,
       String luceneAnalyzerClassArgs, String luceneAnalyzerClassArgTypes, String luceneQueryParserClass,
       Boolean enablePrefixSuffixMatchingInPhraseQueries, Boolean reuseMutableIndex,
@@ -114,14 +114,47 @@ public class TextIndexConfig extends IndexConfig {
         stopWordsInclude, stopWordsExclude, luceneUseCompoundFile, luceneMaxBufferSizeMB, luceneAnalyzerClass,
         luceneAnalyzerClassArgs, luceneAnalyzerClassArgTypes, luceneQueryParserClass,
         enablePrefixSuffixMatchingInPhraseQueries, reuseMutableIndex,
-        luceneNRTCachingDirectoryMaxBufferSizeMB, useLogByteSizeMergePolicy, docIdTranslatorMode,
-        LUCENE_INDEX_DEFAULT_CASE_SENSITIVE_INDEX, LUCENE_INDEX_DEFAULT_STORE_IN_SEGMENT_FILE);
+        luceneNRTCachingDirectoryMaxBufferSizeMB, useLogByteSizeMergePolicy, docIdTranslatorMode, null, null);
   }
 
-  /**
-   * @deprecated Use the new constructor with storeInSegmentFile parameter instead.
-   * This constructor will be removed in a future version.
-   */
+  /// Binary-compat delegate for the pre-wrapper 17-arg primitive ctor (positions 3 + 4 were `boolean`
+  /// pre-PR). Kept so existing compiled call sites continue to link.
+  @Deprecated
+  public TextIndexConfig(Boolean disabled, Object rawValueForTextIndex, boolean enableQueryCache,
+      boolean useANDForMultiTermQueries, List<String> stopWordsInclude, List<String> stopWordsExclude,
+      Boolean luceneUseCompoundFile, Integer luceneMaxBufferSizeMB, String luceneAnalyzerClass,
+      String luceneAnalyzerClassArgs, String luceneAnalyzerClassArgTypes, String luceneQueryParserClass,
+      Boolean enablePrefixSuffixMatchingInPhraseQueries, Boolean reuseMutableIndex,
+      Integer luceneNRTCachingDirectoryMaxBufferSizeMB, Boolean useLogByteSizeMergePolicy,
+      DocIdTranslatorMode docIdTranslatorMode) {
+    this(disabled, rawValueForTextIndex, Boolean.valueOf(enableQueryCache),
+        Boolean.valueOf(useANDForMultiTermQueries), stopWordsInclude, stopWordsExclude, luceneUseCompoundFile,
+        luceneMaxBufferSizeMB, luceneAnalyzerClass, (Object) luceneAnalyzerClassArgs,
+        (Object) luceneAnalyzerClassArgTypes, luceneQueryParserClass, enablePrefixSuffixMatchingInPhraseQueries,
+        reuseMutableIndex, luceneNRTCachingDirectoryMaxBufferSizeMB, useLogByteSizeMergePolicy,
+        docIdTranslatorMode, (Boolean) null, (Boolean) null);
+  }
+
+  /// Binary-compat delegate for the pre-wrapper 19-arg primitive ctor (positions 3 + 4 were `boolean`
+  /// pre-PR). Kept so existing compiled call sites continue to link.
+  @Deprecated
+  public TextIndexConfig(Boolean disabled, Object rawValueForTextIndex, boolean enableQueryCache,
+      boolean useANDForMultiTermQueries, List<String> stopWordsInclude, List<String> stopWordsExclude,
+      Boolean luceneUseCompoundFile, Integer luceneMaxBufferSizeMB, String luceneAnalyzerClass,
+      Object luceneAnalyzerClassArgs, Object luceneAnalyzerClassArgTypes, String luceneQueryParserClass,
+      Boolean enablePrefixSuffixMatchingInPhraseQueries, Boolean reuseMutableIndex,
+      Integer luceneNRTCachingDirectoryMaxBufferSizeMB, Boolean useLogByteSizeMergePolicy,
+      DocIdTranslatorMode docIdTranslatorMode, Boolean caseSensitive, Boolean storeInSegmentFile) {
+    this(disabled, rawValueForTextIndex, Boolean.valueOf(enableQueryCache),
+        Boolean.valueOf(useANDForMultiTermQueries), stopWordsInclude, stopWordsExclude, luceneUseCompoundFile,
+        luceneMaxBufferSizeMB, luceneAnalyzerClass, luceneAnalyzerClassArgs, luceneAnalyzerClassArgTypes,
+        luceneQueryParserClass, enablePrefixSuffixMatchingInPhraseQueries, reuseMutableIndex,
+        luceneNRTCachingDirectoryMaxBufferSizeMB, useLogByteSizeMergePolicy, docIdTranslatorMode,
+        caseSensitive, storeInSegmentFile);
+  }
+
+  /// @deprecated Use the new constructor with storeInSegmentFile parameter instead.
+  /// This constructor will be removed in a future version.
   @Deprecated
   public TextIndexConfig(Boolean luceneUseCompoundFile, Object rawValue,
                         boolean noRawData, boolean enableQueryCache, List<String> stopWordsInclude,
@@ -131,23 +164,24 @@ public class TextIndexConfig extends IndexConfig {
                         Boolean enablePrefixSuffixMatching, Boolean enablePrefixSuffixPhraseMatching,
                         Integer maxResultCacheSizeKeyInt, Boolean storeInSegmentFile,
                         DocIdTranslatorMode docIdTranslatorMode, Boolean enablePrefixSuffixMatchingKey) {
-    // Call the new constructor with default storeInSegmentFile value
-    this(storeInSegmentFile, rawValue, enableQueryCache,
-         useAndForMultiTermQueries != null ? useAndForMultiTermQueries : false,
+    // Forward to wrapper @JsonCreator. Explicit Boolean.valueOf calls disambiguate from the deprecated
+    // primitive 19-arg ctor.
+    this(storeInSegmentFile, rawValue, Boolean.valueOf(enableQueryCache),
+         Boolean.valueOf(useAndForMultiTermQueries != null ? useAndForMultiTermQueries : false),
          stopWordsInclude != null ? stopWordsInclude : new ArrayList<>(),
          stopWordsExclude != null ? stopWordsExclude : new ArrayList<>(),
-         luceneUseCompoundFile, maxResultCacheSize, null, null, null, null,
-         enablePrefixSuffixPhraseMatching != null ? enablePrefixSuffixPhraseMatching : false,
-         false, 0, false, docIdTranslatorMode,
-         enablePrefixSuffixMatchingKey != null ? enablePrefixSuffixMatchingKey : false,
-         storeInSegmentFile != null ? storeInSegmentFile : false);
+         luceneUseCompoundFile, maxResultCacheSize, null, (Object) null, (Object) null, null,
+         Boolean.valueOf(enablePrefixSuffixPhraseMatching != null ? enablePrefixSuffixPhraseMatching : false),
+         Boolean.FALSE, Integer.valueOf(0), Boolean.FALSE, docIdTranslatorMode,
+         Boolean.valueOf(enablePrefixSuffixMatchingKey != null ? enablePrefixSuffixMatchingKey : false),
+         Boolean.valueOf(storeInSegmentFile != null ? storeInSegmentFile : false));
   }
 
   @JsonCreator
   public TextIndexConfig(@JsonProperty("disabled") Boolean disabled,
       @JsonProperty("rawValue") @Nullable Object rawValueForTextIndex,
-      @JsonProperty("queryCache") boolean enableQueryCache,
-      @JsonProperty("useANDForMultiTermQueries") boolean useANDForMultiTermQueries,
+      @JsonProperty("queryCache") Boolean enableQueryCache,
+      @JsonProperty("useANDForMultiTermQueries") Boolean useANDForMultiTermQueries,
       @JsonProperty("stopWordsInclude") List<String> stopWordsInclude,
       @JsonProperty("stopWordsExclude") List<String> stopWordsExclude,
       @JsonProperty("luceneUseCompoundFile") Boolean luceneUseCompoundFile,
@@ -169,12 +203,10 @@ public class TextIndexConfig extends IndexConfig {
     _useANDForMultiTermQueries = useANDForMultiTermQueries;
     _stopWordsInclude = stopWordsInclude;
     _stopWordsExclude = stopWordsExclude;
-    _luceneUseCompoundFile =
-        luceneUseCompoundFile == null ? LUCENE_INDEX_DEFAULT_USE_COMPOUND_FILE : luceneUseCompoundFile;
-    _luceneMaxBufferSizeMB =
-        luceneMaxBufferSizeMB == null ? LUCENE_INDEX_DEFAULT_MAX_BUFFER_SIZE_MB : luceneMaxBufferSizeMB;
-    _luceneAnalyzerClass = (luceneAnalyzerClass == null || luceneAnalyzerClass.isEmpty())
-        ? FieldConfig.TEXT_INDEX_DEFAULT_LUCENE_ANALYZER_CLASS : luceneAnalyzerClass;
+    _luceneUseCompoundFile = luceneUseCompoundFile;
+    _luceneMaxBufferSizeMB = luceneMaxBufferSizeMB;
+    // Empty string is normalized to null so the getter applies the static default and the slim form omits the key.
+    _luceneAnalyzerClass = (luceneAnalyzerClass == null || luceneAnalyzerClass.isEmpty()) ? null : luceneAnalyzerClass;
 
     // Note that we cannot depend on jackson's default behavior to automatically coerce the comma delimited args to
     // List<String>. This is because the args may contain comma and other special characters such as space. Therefore,
@@ -183,33 +215,24 @@ public class TextIndexConfig extends IndexConfig {
     // so we also handle that case.
     _luceneAnalyzerClassArgs = parseToList(luceneAnalyzerClassArgs, true, false);
     _luceneAnalyzerClassArgTypes = parseToList(luceneAnalyzerClassArgTypes, false, true);
-    _luceneQueryParserClass = luceneQueryParserClass == null
-        ? FieldConfig.TEXT_INDEX_DEFAULT_LUCENE_QUERY_PARSER_CLASS : luceneQueryParserClass;
-    _enablePrefixSuffixMatchingInPhraseQueries =
-        enablePrefixSuffixMatchingInPhraseQueries == null ? LUCENE_INDEX_ENABLE_PREFIX_SUFFIX_MATCH_IN_PHRASE_SEARCH
-            : enablePrefixSuffixMatchingInPhraseQueries;
-    _reuseMutableIndex = reuseMutableIndex == null ? LUCENE_INDEX_REUSE_MUTABLE_INDEX : reuseMutableIndex;
-    _luceneNRTCachingDirectoryMaxBufferSizeMB =
-        luceneNRTCachingDirectoryMaxBufferSizeMB == null ? LUCENE_INDEX_NRT_CACHING_DIRECTORY_MAX_BUFFER_SIZE_MB
-            : luceneNRTCachingDirectoryMaxBufferSizeMB;
-    _useLogByteSizeMergePolicy = useLogByteSizeMergePolicy == null ? LUCENE_USE_LOG_BYTE_SIZE_MERGE_POLICY
-        : useLogByteSizeMergePolicy;
-    _docIdTranslatorMode = docIdTranslatorMode == null ? LUCENE_TRANSLATOR_MODE : docIdTranslatorMode;
-    _caseSensitive = caseSensitive == null ? LUCENE_INDEX_DEFAULT_CASE_SENSITIVE_INDEX : caseSensitive;
-    _storeInSegmentFile = storeInSegmentFile == null ? LUCENE_INDEX_DEFAULT_STORE_IN_SEGMENT_FILE : storeInSegmentFile;
+    _luceneQueryParserClass = luceneQueryParserClass;
+    _enablePrefixSuffixMatchingInPhraseQueries = enablePrefixSuffixMatchingInPhraseQueries;
+    _reuseMutableIndex = reuseMutableIndex;
+    _luceneNRTCachingDirectoryMaxBufferSizeMB = luceneNRTCachingDirectoryMaxBufferSizeMB;
+    _useLogByteSizeMergePolicy = useLogByteSizeMergePolicy;
+    _docIdTranslatorMode = docIdTranslatorMode;
+    _caseSensitive = caseSensitive;
+    _storeInSegmentFile = storeInSegmentFile;
   }
 
-  /**
-   * Parses the input value to a List of Strings.
-   * Handles both String (CSV format) and List<String> (from JSON array) inputs.
-   * This enables proper round-trip serialization/deserialization since the getter returns List<String>
-   * which Jackson serializes as a JSON array, but the original input format was CSV string.
-   *
-   * @param value the input value (can be String, List, or null)
-   * @param escapeComma if true, don't split on escaped commas when parsing String
-   * @param trim whether to trim each value
-   * @return parsed list of strings, empty list if input is null or empty
-   */
+  /// Parses the input value to a `List<String>`. Handles both `String` (CSV format) and `List<String>` (from JSON
+  /// array) inputs. Round-trip support: the getter returns `List<String>` which Jackson serializes as a JSON array,
+  /// but the original input format was CSV string.
+  ///
+  /// @param value the input value (can be `String`, `List`, or `null`)
+  /// @param escapeComma if `true`, don't split on escaped commas when parsing `String`
+  /// @param trim whether to trim each value
+  /// @return parsed list of strings, empty list if input is `null` or empty
   @SuppressWarnings("unchecked")
   private static List<String> parseToList(final @Nullable Object value, final boolean escapeComma, final boolean trim) {
     if (value == null) {
@@ -237,17 +260,16 @@ public class TextIndexConfig extends IndexConfig {
     return _rawValueForTextIndex;
   }
 
-  /**
-   * Whether Lucene query result cache should be enabled.
-   *
-   * While it helps a lot with performance for repeated queries, on the downside it causes heap issues.
-   */
+  /// Whether Lucene query result cache should be enabled.
+  ///
+  /// While it helps a lot with performance for repeated queries, on the downside it causes heap issues.
   public boolean isEnableQueryCache() {
-    return _enableQueryCache;
+    return Boolean.TRUE.equals(_enableQueryCache);
   }
 
   public boolean isUseANDForMultiTermQueries() {
-    return _useANDForMultiTermQueries;
+    return _useANDForMultiTermQueries != null ? _useANDForMultiTermQueries
+        : LUCENE_INDEX_DEFAULT_USE_AND_FOR_MULTI_TERM_QUERIES;
   }
 
   public List<String> getStopWordsInclude() {
@@ -258,97 +280,82 @@ public class TextIndexConfig extends IndexConfig {
     return _stopWordsExclude;
   }
 
-  /**
-   * Whether Lucene IndexWriter uses compound file format. Improves indexing speed but may cause file descriptor issues
-   */
+  /// Whether Lucene IndexWriter uses compound file format. Improves indexing speed but may cause file descriptor
+  /// issues.
   public boolean isLuceneUseCompoundFile() {
-    return _luceneUseCompoundFile;
+    return _luceneUseCompoundFile != null ? _luceneUseCompoundFile : LUCENE_INDEX_DEFAULT_USE_COMPOUND_FILE;
   }
 
-  /**
-   * Lucene buffer size. Helps with indexing speed but may cause heap issues
-   */
+  /// Lucene buffer size. Helps with indexing speed but may cause heap issues.
   public int getLuceneMaxBufferSizeMB() {
-    return _luceneMaxBufferSizeMB;
+    return _luceneMaxBufferSizeMB != null ? _luceneMaxBufferSizeMB : LUCENE_INDEX_DEFAULT_MAX_BUFFER_SIZE_MB;
   }
 
-  /**
-   * Lucene analyzer fully qualified class name specifying which analyzer class to use for indexing
-   */
+  /// Lucene analyzer fully qualified class name specifying which analyzer class to use for indexing.
   public String getLuceneAnalyzerClass() {
-    return _luceneAnalyzerClass;
+    return _luceneAnalyzerClass != null ? _luceneAnalyzerClass : FieldConfig.TEXT_INDEX_DEFAULT_LUCENE_ANALYZER_CLASS;
   }
 
-  /**
-   * Lucene analyzer arguments in String type. At runtime, the string representation are best-effort coerced into the
-   * proper type with the fully-qualified value type specified in luceneAnalyzerClassArgTypes
-   */
+  /// Lucene analyzer arguments in String type. At runtime, the string representation are best-effort coerced into the
+  /// proper type with the fully-qualified value type specified in luceneAnalyzerClassArgTypes.
   public List<String> getLuceneAnalyzerClassArgs() {
     return _luceneAnalyzerClassArgs;
   }
 
-  /**
-   * Lucene analyzer fully qualified argument value types for each argument. At runtime, the values specified in the
-   * luceneAnalyserClassArgs (string representation) are best-effort coerced into the specified value type.
-   */
+  /// Lucene analyzer fully qualified argument value types for each argument. At runtime, the values specified in the
+  /// luceneAnalyserClassArgs (string representation) are best-effort coerced into the specified value type.
   public List<String> getLuceneAnalyzerClassArgTypes() {
     return _luceneAnalyzerClassArgTypes;
   }
 
-  /**
-   * Lucene query parser fully qualified class name specifying which lucene query parser class to use for query parsing
-   */
+  /// Lucene query parser fully qualified class name specifying which lucene query parser class to use for query
+  /// parsing.
   public String getLuceneQueryParserClass() {
-    return _luceneQueryParserClass;
+    return _luceneQueryParserClass != null ? _luceneQueryParserClass
+        : FieldConfig.TEXT_INDEX_DEFAULT_LUCENE_QUERY_PARSER_CLASS;
   }
 
-  /**
-   *  Whether to enable prefix and suffix wildcard term matching (i.e., .*value for prefix and value.* for suffix
-   *  term matching) in a phrase query. By default, Pinot today treats .* in a phrase query like ".*value str1 value.*"
-   *  as literal. If this flag is enabled, .*value will be treated as suffix matching and value.* will be treated as
-   *  prefix matching.
-   */
+  /// Whether to enable prefix and suffix wildcard term matching (i.e., `.*value` for prefix and `value.*` for suffix
+  /// term matching) in a phrase query. By default, Pinot today treats `.*` in a phrase query like
+  /// `".*value str1 value.*"` as literal. If this flag is enabled, `.*value` will be treated as suffix matching and
+  /// `value.*` will be treated as prefix matching.
   public boolean isEnablePrefixSuffixMatchingInPhraseQueries() {
-    return _enablePrefixSuffixMatchingInPhraseQueries;
+    return _enablePrefixSuffixMatchingInPhraseQueries != null ? _enablePrefixSuffixMatchingInPhraseQueries
+        : LUCENE_INDEX_ENABLE_PREFIX_SUFFIX_MATCH_IN_PHRASE_SEARCH;
   }
 
   public boolean isReuseMutableIndex() {
-    return _reuseMutableIndex;
+    return _reuseMutableIndex != null ? _reuseMutableIndex : LUCENE_INDEX_REUSE_MUTABLE_INDEX;
   }
 
   public boolean isUseLogByteSizeMergePolicy() {
-    return _useLogByteSizeMergePolicy;
+    return _useLogByteSizeMergePolicy != null ? _useLogByteSizeMergePolicy : LUCENE_USE_LOG_BYTE_SIZE_MERGE_POLICY;
   }
 
   public DocIdTranslatorMode getDocIdTranslatorMode() {
-    return _docIdTranslatorMode;
+    return _docIdTranslatorMode != null ? _docIdTranslatorMode : LUCENE_TRANSLATOR_MODE;
   }
 
   public int getLuceneNRTCachingDirectoryMaxBufferSizeMB() {
-    return _luceneNRTCachingDirectoryMaxBufferSizeMB;
+    return _luceneNRTCachingDirectoryMaxBufferSizeMB != null ? _luceneNRTCachingDirectoryMaxBufferSizeMB
+        : LUCENE_INDEX_NRT_CACHING_DIRECTORY_MAX_BUFFER_SIZE_MB;
   }
 
   public boolean isCaseSensitive() {
-    return _caseSensitive;
+    return _caseSensitive != null ? _caseSensitive : LUCENE_INDEX_DEFAULT_CASE_SENSITIVE_INDEX;
   }
 
-  /**
-   * Whether to store text index in segment file and cleanup the directory structure.
-   * @return true if text index should be stored in segment file and directory cleaned up,
-   *         false to keep directory structure
-   */
+  /// Whether to store text index in segment file and cleanup the directory structure.
+  /// @return true if text index should be stored in segment file and directory cleaned up,
+  ///         false to keep directory structure.
   public boolean isStoreInSegmentFile() {
-    return _storeInSegmentFile;
+    return _storeInSegmentFile != null ? _storeInSegmentFile : LUCENE_INDEX_DEFAULT_STORE_IN_SEGMENT_FILE;
   }
 
-  /**
-   * Curated slim serializer. See {@link IndexConfig#toJsonObject()} for the rationale.
-   *
-   * <p>Each of the 18 lucene defaults — declared as {@code LUCENE_INDEX_DEFAULT_*} constants at
-   * the top of this file — is omitted from the output when the field still equals its default.
-   * Empty / null lists for {@code stopWords*} and {@code luceneAnalyzerClassArgs*} are also
-   * treated as defaults and omitted.
-   */
+  /// Curated slim serializer. See [IndexConfig#toJsonObject()] for the rationale.
+  ///
+  /// Each field is emitted only when it was explicitly configured (non-null). Empty lists for `stopWords*` and
+  /// `luceneAnalyzerClassArgs*` are also treated as not configured and omitted.
   @Override
   @JsonValue
   public ObjectNode toJsonObject() {
@@ -356,60 +363,65 @@ public class TextIndexConfig extends IndexConfig {
     if (_rawValueForTextIndex != null) {
       node.set("rawValue", JsonUtils.objectToJsonNode(_rawValueForTextIndex));
     }
-    if (_enableQueryCache) {
-      node.put("queryCache", true);
+    if (_enableQueryCache != null) {
+      node.put("queryCache", _enableQueryCache);
     }
-    if (_useANDForMultiTermQueries) {
-      node.put("useANDForMultiTermQueries", true);
+    if (_useANDForMultiTermQueries != null) {
+      node.put("useANDForMultiTermQueries", _useANDForMultiTermQueries);
     }
-    if (_stopWordsInclude != null && !_stopWordsInclude.isEmpty()) {
+    if (CollectionUtils.isNotEmpty(_stopWordsInclude)) {
       node.set("stopWordsInclude", JsonUtils.objectToJsonNode(_stopWordsInclude));
     }
-    if (_stopWordsExclude != null && !_stopWordsExclude.isEmpty()) {
+    if (CollectionUtils.isNotEmpty(_stopWordsExclude)) {
       node.set("stopWordsExclude", JsonUtils.objectToJsonNode(_stopWordsExclude));
     }
-    if (_luceneUseCompoundFile != LUCENE_INDEX_DEFAULT_USE_COMPOUND_FILE) {
+    if (_luceneUseCompoundFile != null) {
       node.put("luceneUseCompoundFile", _luceneUseCompoundFile);
     }
-    if (_luceneMaxBufferSizeMB != LUCENE_INDEX_DEFAULT_MAX_BUFFER_SIZE_MB) {
+    if (_luceneMaxBufferSizeMB != null) {
       node.put("luceneMaxBufferSizeMB", _luceneMaxBufferSizeMB);
     }
-    if (!Objects.equals(_luceneAnalyzerClass, FieldConfig.TEXT_INDEX_DEFAULT_LUCENE_ANALYZER_CLASS)) {
+    if (_luceneAnalyzerClass != null) {
       node.put("luceneAnalyzerClass", _luceneAnalyzerClass);
     }
-    if (_luceneAnalyzerClassArgs != null && !_luceneAnalyzerClassArgs.isEmpty()) {
+    if (CollectionUtils.isNotEmpty(_luceneAnalyzerClassArgs)) {
       node.set("luceneAnalyzerClassArgs", JsonUtils.objectToJsonNode(_luceneAnalyzerClassArgs));
     }
-    if (_luceneAnalyzerClassArgTypes != null && !_luceneAnalyzerClassArgTypes.isEmpty()) {
+    if (CollectionUtils.isNotEmpty(_luceneAnalyzerClassArgTypes)) {
       node.set("luceneAnalyzerClassArgTypes", JsonUtils.objectToJsonNode(_luceneAnalyzerClassArgTypes));
     }
-    if (!Objects.equals(_luceneQueryParserClass, FieldConfig.TEXT_INDEX_DEFAULT_LUCENE_QUERY_PARSER_CLASS)) {
+    if (_luceneQueryParserClass != null) {
       node.put("luceneQueryParserClass", _luceneQueryParserClass);
     }
-    if (_enablePrefixSuffixMatchingInPhraseQueries != LUCENE_INDEX_ENABLE_PREFIX_SUFFIX_MATCH_IN_PHRASE_SEARCH) {
+    if (_enablePrefixSuffixMatchingInPhraseQueries != null) {
       node.put("enablePrefixSuffixMatchingInPhraseQueries", _enablePrefixSuffixMatchingInPhraseQueries);
     }
-    if (_reuseMutableIndex != LUCENE_INDEX_REUSE_MUTABLE_INDEX) {
+    if (_reuseMutableIndex != null) {
       node.put("reuseMutableIndex", _reuseMutableIndex);
     }
-    if (_luceneNRTCachingDirectoryMaxBufferSizeMB != LUCENE_INDEX_NRT_CACHING_DIRECTORY_MAX_BUFFER_SIZE_MB) {
+    if (_luceneNRTCachingDirectoryMaxBufferSizeMB != null) {
       node.put("luceneNRTCachingDirectoryMaxBufferSizeMB", _luceneNRTCachingDirectoryMaxBufferSizeMB);
     }
-    if (_useLogByteSizeMergePolicy != LUCENE_USE_LOG_BYTE_SIZE_MERGE_POLICY) {
+    if (_useLogByteSizeMergePolicy != null) {
       node.put("useLogByteSizeMergePolicy", _useLogByteSizeMergePolicy);
     }
-    if (_docIdTranslatorMode != LUCENE_TRANSLATOR_MODE) {
+    if (_docIdTranslatorMode != null) {
       node.put("docIdTranslatorMode", _docIdTranslatorMode.name());
     }
-    if (_caseSensitive != LUCENE_INDEX_DEFAULT_CASE_SENSITIVE_INDEX) {
+    if (_caseSensitive != null) {
       node.put("caseSensitive", _caseSensitive);
     }
-    if (_storeInSegmentFile != LUCENE_INDEX_DEFAULT_STORE_IN_SEGMENT_FILE) {
+    if (_storeInSegmentFile != null) {
       node.put("storeInSegmentFile", _storeInSegmentFile);
     }
     return node;
   }
 
+  /// Builder fields are kept as primitives for binary compatibility — subclasses (e.g.
+  /// `pinot-segment-local`'s `TextIndexConfigBuilder`) write to them directly via the protected
+  /// access path. The wire-level explicit-vs-default distinction lives in [TextIndexConfig]'s
+  /// wrapper-typed fields and the `@JsonCreator` ctor; programmatic builder users that want to
+  /// pin an explicit-default value can construct the config directly via the @JsonCreator path.
   public static abstract class AbstractBuilder {
     @Nullable
     protected Object _rawValueForTextIndex;
@@ -437,35 +449,58 @@ public class TextIndexConfig extends IndexConfig {
     }
 
     public AbstractBuilder(TextIndexConfig other) {
-      _enableQueryCache = other._enableQueryCache;
-      _useANDForMultiTermQueries = other._useANDForMultiTermQueries;
+      _enableQueryCache = other.isEnableQueryCache();
+      _useANDForMultiTermQueries = other.isUseANDForMultiTermQueries();
       _stopWordsInclude =
           other._stopWordsInclude == null ? new ArrayList<>() : new ArrayList<>(other._stopWordsInclude);
       _stopWordsExclude =
           other._stopWordsExclude == null ? new ArrayList<>() : new ArrayList<>(other._stopWordsExclude);
-      _luceneUseCompoundFile = other._luceneUseCompoundFile;
-      _luceneMaxBufferSizeMB = other._luceneMaxBufferSizeMB;
-      _luceneAnalyzerClass = other._luceneAnalyzerClass;
+      _luceneUseCompoundFile = other.isLuceneUseCompoundFile();
+      _luceneMaxBufferSizeMB = other.getLuceneMaxBufferSizeMB();
+      _luceneAnalyzerClass = other.getLuceneAnalyzerClass();
       _luceneAnalyzerClassArgs = other._luceneAnalyzerClassArgs;
       _luceneAnalyzerClassArgTypes = other._luceneAnalyzerClassArgTypes;
-      _luceneQueryParserClass = other._luceneQueryParserClass;
-      _enablePrefixSuffixMatchingInPhraseQueries = other._enablePrefixSuffixMatchingInPhraseQueries;
-      _reuseMutableIndex = other._reuseMutableIndex;
-      _luceneNRTCachingDirectoryMaxBufferSizeMB = other._luceneNRTCachingDirectoryMaxBufferSizeMB;
-      _useLogByteSizeMergePolicy = other._useLogByteSizeMergePolicy;
+      _luceneQueryParserClass = other.getLuceneQueryParserClass();
+      _enablePrefixSuffixMatchingInPhraseQueries = other.isEnablePrefixSuffixMatchingInPhraseQueries();
+      _reuseMutableIndex = other.isReuseMutableIndex();
+      _luceneNRTCachingDirectoryMaxBufferSizeMB = other.getLuceneNRTCachingDirectoryMaxBufferSizeMB();
+      _useLogByteSizeMergePolicy = other.isUseLogByteSizeMergePolicy();
       _docIdTranslatorMode = other._docIdTranslatorMode;
-      _caseSensitive = other._caseSensitive;
-      _storeInSegmentFile = other._storeInSegmentFile;
+      _caseSensitive = other.isCaseSensitive();
+      _storeInSegmentFile = other.isStoreInSegmentFile();
     }
 
+    /// Build the config. Builder fields are primitives (binary-compat constraint), so the slim form's
+    /// "explicit-vs-default" distinction in JSON is approximated here by passing `null` to the wrapper
+    /// `@JsonCreator` whenever a builder field equals its static default. Programmatic users that
+    /// want to pin "explicit-default" should construct the config directly via the wrapper ctor.
     public TextIndexConfig build() {
-      return new TextIndexConfig(false, _rawValueForTextIndex, _enableQueryCache, _useANDForMultiTermQueries,
-          _stopWordsInclude, _stopWordsExclude, _luceneUseCompoundFile, _luceneMaxBufferSizeMB, _luceneAnalyzerClass,
-          CsvParser.serialize(_luceneAnalyzerClassArgs, true, false),
-          CsvParser.serialize(_luceneAnalyzerClassArgTypes, true, false),
-          _luceneQueryParserClass, _enablePrefixSuffixMatchingInPhraseQueries, _reuseMutableIndex,
-          _luceneNRTCachingDirectoryMaxBufferSizeMB, _useLogByteSizeMergePolicy, _docIdTranslatorMode, _caseSensitive,
-          _storeInSegmentFile);
+      return new TextIndexConfig(Boolean.FALSE, _rawValueForTextIndex,
+          _enableQueryCache ? Boolean.TRUE : null,
+          _useANDForMultiTermQueries == LUCENE_INDEX_DEFAULT_USE_AND_FOR_MULTI_TERM_QUERIES ? null
+              : Boolean.valueOf(_useANDForMultiTermQueries),
+          _stopWordsInclude, _stopWordsExclude,
+          _luceneUseCompoundFile == LUCENE_INDEX_DEFAULT_USE_COMPOUND_FILE ? null
+              : Boolean.valueOf(_luceneUseCompoundFile),
+          _luceneMaxBufferSizeMB == LUCENE_INDEX_DEFAULT_MAX_BUFFER_SIZE_MB ? null
+              : Integer.valueOf(_luceneMaxBufferSizeMB),
+          Objects.equals(_luceneAnalyzerClass, FieldConfig.TEXT_INDEX_DEFAULT_LUCENE_ANALYZER_CLASS) ? null
+              : _luceneAnalyzerClass,
+          (Object) CsvParser.serialize(_luceneAnalyzerClassArgs, true, false),
+          (Object) CsvParser.serialize(_luceneAnalyzerClassArgTypes, true, false),
+          Objects.equals(_luceneQueryParserClass, FieldConfig.TEXT_INDEX_DEFAULT_LUCENE_QUERY_PARSER_CLASS) ? null
+              : _luceneQueryParserClass,
+          _enablePrefixSuffixMatchingInPhraseQueries == LUCENE_INDEX_ENABLE_PREFIX_SUFFIX_MATCH_IN_PHRASE_SEARCH ? null
+              : Boolean.valueOf(_enablePrefixSuffixMatchingInPhraseQueries),
+          _reuseMutableIndex == LUCENE_INDEX_REUSE_MUTABLE_INDEX ? null : Boolean.valueOf(_reuseMutableIndex),
+          _luceneNRTCachingDirectoryMaxBufferSizeMB == LUCENE_INDEX_NRT_CACHING_DIRECTORY_MAX_BUFFER_SIZE_MB ? null
+              : Integer.valueOf(_luceneNRTCachingDirectoryMaxBufferSizeMB),
+          _useLogByteSizeMergePolicy == LUCENE_USE_LOG_BYTE_SIZE_MERGE_POLICY ? null
+              : Boolean.valueOf(_useLogByteSizeMergePolicy),
+          _docIdTranslatorMode,
+          _caseSensitive == LUCENE_INDEX_DEFAULT_CASE_SENSITIVE_INDEX ? null : Boolean.valueOf(_caseSensitive),
+          _storeInSegmentFile == LUCENE_INDEX_DEFAULT_STORE_IN_SEGMENT_FILE ? null
+              : Boolean.valueOf(_storeInSegmentFile));
     }
 
     public abstract AbstractBuilder withProperties(@Nullable Map<String, String> textIndexProperties);
@@ -579,15 +614,15 @@ public class TextIndexConfig extends IndexConfig {
       return false;
     }
     TextIndexConfig that = (TextIndexConfig) o;
-    return _enableQueryCache == that._enableQueryCache
-        && _useANDForMultiTermQueries == that._useANDForMultiTermQueries
-        && _luceneUseCompoundFile == that._luceneUseCompoundFile
-        && _luceneMaxBufferSizeMB == that._luceneMaxBufferSizeMB
-        && _enablePrefixSuffixMatchingInPhraseQueries == that._enablePrefixSuffixMatchingInPhraseQueries
-        && _reuseMutableIndex == that._reuseMutableIndex
-        && _useLogByteSizeMergePolicy == that._useLogByteSizeMergePolicy
+    return Objects.equals(_enableQueryCache, that._enableQueryCache)
+        && Objects.equals(_useANDForMultiTermQueries, that._useANDForMultiTermQueries)
+        && Objects.equals(_luceneUseCompoundFile, that._luceneUseCompoundFile)
+        && Objects.equals(_luceneMaxBufferSizeMB, that._luceneMaxBufferSizeMB)
+        && Objects.equals(_enablePrefixSuffixMatchingInPhraseQueries, that._enablePrefixSuffixMatchingInPhraseQueries)
+        && Objects.equals(_reuseMutableIndex, that._reuseMutableIndex)
+        && Objects.equals(_useLogByteSizeMergePolicy, that._useLogByteSizeMergePolicy)
         && _docIdTranslatorMode == that._docIdTranslatorMode
-        && _luceneNRTCachingDirectoryMaxBufferSizeMB == that._luceneNRTCachingDirectoryMaxBufferSizeMB
+        && Objects.equals(_luceneNRTCachingDirectoryMaxBufferSizeMB, that._luceneNRTCachingDirectoryMaxBufferSizeMB)
         && Objects.equals(_rawValueForTextIndex, that._rawValueForTextIndex)
         && Objects.equals(_stopWordsInclude, that._stopWordsInclude)
         && Objects.equals(_stopWordsExclude, that._stopWordsExclude)
@@ -595,7 +630,8 @@ public class TextIndexConfig extends IndexConfig {
         && Objects.equals(_luceneAnalyzerClassArgs, that._luceneAnalyzerClassArgs)
         && Objects.equals(_luceneAnalyzerClassArgTypes, that._luceneAnalyzerClassArgTypes)
         && Objects.equals(_luceneQueryParserClass, that._luceneQueryParserClass)
-        && _caseSensitive == that._caseSensitive && _storeInSegmentFile == that._storeInSegmentFile;
+        && Objects.equals(_caseSensitive, that._caseSensitive)
+        && Objects.equals(_storeInSegmentFile, that._storeInSegmentFile);
   }
 
   @Override

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/creator/H3IndexConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/creator/H3IndexConfig.java
@@ -71,12 +71,9 @@ public class H3IndexConfig extends IndexConfig {
     return _resolution;
   }
 
-  /**
-   * Curated slim serializer. See {@link IndexConfig#toJsonObject()} for the rationale.
-   *
-   * <p>The JSON key is {@code "resolution"} (singular) — matches the {@code @JsonProperty} on
-   * the {@code @JsonCreator} parameter.
-   */
+  /// Curated slim serializer. See [IndexConfig#toJsonObject()] for the rationale.
+  ///
+  /// The JSON key is `"resolution"` (singular) — matches the `@JsonProperty` on the `@JsonCreator` parameter.
   @Override
   @JsonValue
   public ObjectNode toJsonObject() {

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/creator/H3IndexConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/creator/H3IndexConfig.java
@@ -20,6 +20,8 @@ package org.apache.pinot.segment.spi.index.creator;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Preconditions;
 import java.util.ArrayList;
 import java.util.List;
@@ -29,6 +31,7 @@ import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.segment.spi.index.reader.H3IndexResolution;
 import org.apache.pinot.spi.config.table.IndexConfig;
+import org.apache.pinot.spi.utils.JsonUtils;
 
 
 public class H3IndexConfig extends IndexConfig {
@@ -66,6 +69,22 @@ public class H3IndexConfig extends IndexConfig {
 
   public H3IndexResolution getResolution() {
     return _resolution;
+  }
+
+  /**
+   * Curated slim serializer. See {@link IndexConfig#toJsonObject()} for the rationale.
+   *
+   * <p>The JSON key is {@code "resolution"} (singular) — matches the {@code @JsonProperty} on
+   * the {@code @JsonCreator} parameter.
+   */
+  @Override
+  @JsonValue
+  public ObjectNode toJsonObject() {
+    ObjectNode node = super.toJsonObject();
+    if (_resolution != null) {
+      node.set("resolution", JsonUtils.objectToJsonNode(_resolution));
+    }
+    return node;
   }
 
   @Override

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/creator/VectorIndexConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/creator/VectorIndexConfig.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Preconditions;
+import java.util.Collections;
 import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.pinot.spi.config.table.IndexConfig;
@@ -65,6 +66,7 @@ public class VectorIndexConfig extends IndexConfig {
    */
   public VectorIndexConfig(Boolean disabled) {
     super(disabled);
+    _properties = Collections.emptyMap();
   }
 
   // Used to read from older configs
@@ -93,7 +95,7 @@ public class VectorIndexConfig extends IndexConfig {
     _vectorDimension = vectorDimension;
     _version = version;
     _vectorDistanceFunction = vectorDistanceFunction;
-    _properties = properties;
+    _properties = properties != null ? properties : Collections.emptyMap();
   }
 
   public String getVectorIndexType() {
@@ -138,7 +140,7 @@ public class VectorIndexConfig extends IndexConfig {
   }
 
   public VectorIndexConfig setProperties(Map<String, String> properties) {
-    _properties = properties;
+    _properties = properties != null ? properties : Collections.emptyMap();
     return this;
   }
 
@@ -176,7 +178,7 @@ public class VectorIndexConfig extends IndexConfig {
     if (_vectorDistanceFunction != null) {
       node.put("vectorDistanceFunction", _vectorDistanceFunction.name());
     }
-    if (_properties != null && !_properties.isEmpty()) {
+    if (!_properties.isEmpty()) {
       node.set("properties", JsonUtils.objectToJsonNode(_properties));
     }
     return node;

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/creator/VectorIndexConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/creator/VectorIndexConfig.java
@@ -23,28 +23,25 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Preconditions;
-import java.util.Collections;
 import java.util.Map;
+import java.util.Objects;
 import javax.annotation.Nullable;
 import org.apache.pinot.spi.config.table.IndexConfig;
 import org.apache.pinot.spi.utils.JsonUtils;
 
 
-/**
- * Config for vector index.
- *
- * <p>This is the backend-neutral configuration for all vector index types. Common fields include
- * {@code vectorIndexType}, {@code vectorDimension}, {@code vectorDistanceFunction}, and {@code version}.
- * All backend-specific configuration (e.g., HNSW maxCon/beamWidth, IVF_FLAT nlist/trainSampleSize)
- * is stored in the {@code properties} map.</p>
- *
- * <p>The {@code vectorIndexType} field determines which backend is used. If absent or null, it defaults
- * to {@code HNSW} for backward compatibility. Use {@link #resolveBackendType()} to safely resolve the
- * backend type with this default applied.</p>
- *
- * @see VectorBackendType
- * @see VectorIndexConfigValidator
- */
+/// Config for vector index.
+///
+/// Backend-neutral configuration for all vector index types. Common fields include `vectorIndexType`,
+/// `vectorDimension`, `vectorDistanceFunction`, and `version`. All backend-specific configuration
+/// (e.g., HNSW maxCon/beamWidth, IVF_FLAT nlist/trainSampleSize) is stored in the `properties` map.
+///
+/// The `vectorIndexType` field determines which backend is used. If absent or null, it defaults to
+/// `HNSW` for backward compatibility. Use [#resolveBackendType()] to safely resolve the backend type
+/// with this default applied.
+///
+/// @see VectorBackendType
+/// @see VectorIndexConfigValidator
 public class VectorIndexConfig extends IndexConfig {
   public static final VectorIndexConfig DISABLED = new VectorIndexConfig(true);
   private static final String VECTOR_INDEX_TYPE = "vectorIndexType";
@@ -56,17 +53,15 @@ public class VectorIndexConfig extends IndexConfig {
       VectorDistanceFunction.COSINE;
 
   private String _vectorIndexType;
-  private int _vectorDimension;
-  private int _version;
+  private Integer _vectorDimension;
+  private Integer _version;
   private VectorDistanceFunction _vectorDistanceFunction;
   private Map<String, String> _properties;
 
-  /**
-   * @param disabled whether the config is disabled. Null is considered enabled.
-   */
+  /// @param disabled whether the config is disabled. Null is considered enabled.
   public VectorIndexConfig(Boolean disabled) {
     super(disabled);
-    _properties = Collections.emptyMap();
+    _properties = Map.of();
   }
 
   // Used to read from older configs
@@ -83,11 +78,22 @@ public class VectorIndexConfig extends IndexConfig {
     _properties = properties;
   }
 
+  /// Binary-compat delegate for the pre-wrapper 6-arg primitive ctor. Kept so existing compiled call sites
+  /// resolved to the primitive `(Boolean, String, int, int, VectorDistanceFunction, Map)` signature continue
+  /// to link.
+  @Deprecated
+  public VectorIndexConfig(@Nullable Boolean disabled, @Nullable String vectorIndexType, int vectorDimension,
+      int version, @Nullable VectorDistanceFunction vectorDistanceFunction,
+      @Nullable Map<String, String> properties) {
+    this(disabled, vectorIndexType, Integer.valueOf(vectorDimension), Integer.valueOf(version),
+        vectorDistanceFunction, properties);
+  }
+
   @JsonCreator
   public VectorIndexConfig(@JsonProperty("disabled") @Nullable Boolean disabled,
       @JsonProperty("vectorIndexType") @Nullable String vectorIndexType,
-      @JsonProperty("vectorDimension") int vectorDimension,
-      @JsonProperty("version") int version,
+      @JsonProperty("vectorDimension") @Nullable Integer vectorDimension,
+      @JsonProperty("version") @Nullable Integer version,
       @JsonProperty("vectorDistanceFunction") @Nullable VectorDistanceFunction vectorDistanceFunction,
       @JsonProperty("properties") @Nullable Map<String, String> properties) {
     super(disabled);
@@ -95,7 +101,7 @@ public class VectorIndexConfig extends IndexConfig {
     _vectorDimension = vectorDimension;
     _version = version;
     _vectorDistanceFunction = vectorDistanceFunction;
-    _properties = properties != null ? properties : Collections.emptyMap();
+    _properties = properties != null ? properties : Map.of();
   }
 
   public String getVectorIndexType() {
@@ -108,7 +114,7 @@ public class VectorIndexConfig extends IndexConfig {
   }
 
   public int getVectorDimension() {
-    return _vectorDimension;
+    return _vectorDimension != null ? _vectorDimension : 0;
   }
 
   public VectorIndexConfig setVectorDimension(int vectorDimension) {
@@ -127,7 +133,7 @@ public class VectorIndexConfig extends IndexConfig {
   }
 
   public int getVersion() {
-    return _version;
+    return _version != null ? _version : 0;
   }
 
   public VectorIndexConfig setVersion(int version) {
@@ -140,28 +146,23 @@ public class VectorIndexConfig extends IndexConfig {
   }
 
   public VectorIndexConfig setProperties(Map<String, String> properties) {
-    _properties = properties != null ? properties : Collections.emptyMap();
+    _properties = properties != null ? properties : Map.of();
     return this;
   }
 
-  /**
-   * Resolves the {@link VectorBackendType} for this config. If {@code vectorIndexType} is null or empty,
-   * defaults to {@link VectorBackendType#HNSW} for backward compatibility.
-   *
-   * @return the resolved backend type
-   * @throws IllegalArgumentException if vectorIndexType is set to an unrecognized value
-   */
+  /// Resolves the [VectorBackendType] for this config. If `vectorIndexType` is null or empty, defaults to
+  /// [VectorBackendType#HNSW] for backward compatibility.
+  ///
+  /// @return the resolved backend type
+  /// @throws IllegalArgumentException if vectorIndexType is set to an unrecognized value
   public VectorBackendType resolveBackendType() {
     return VectorIndexConfigValidator.resolveBackendType(this);
   }
 
-  /**
-   * Curated slim serializer. See {@link IndexConfig#toJsonObject()} for the rationale.
-   *
-   * <p>Note: {@code @JsonCreator} reads {@code vectorDimension} and {@code version} as primitive
-   * {@code int}, so a value of {@code 0} is indistinguishable from "absent" and is therefore
-   * treated as the default and omitted on serialization.
-   */
+  /// Curated slim serializer. See [IndexConfig#toJsonObject()] for the rationale.
+  ///
+  /// Each field is emitted only when explicitly configured (non-null wrapper). Empty `properties` map is
+  /// treated as not-configured and omitted.
   @Override
   @JsonValue
   public ObjectNode toJsonObject() {
@@ -169,19 +170,44 @@ public class VectorIndexConfig extends IndexConfig {
     if (_vectorIndexType != null) {
       node.put("vectorIndexType", _vectorIndexType);
     }
-    if (_vectorDimension != 0) {
+    if (_vectorDimension != null) {
       node.put("vectorDimension", _vectorDimension);
     }
-    if (_version != 0) {
+    if (_version != null) {
       node.put("version", _version);
     }
     if (_vectorDistanceFunction != null) {
       node.put("vectorDistanceFunction", _vectorDistanceFunction.name());
     }
-    if (!_properties.isEmpty()) {
+    if (_properties != null && !_properties.isEmpty()) {
       node.set("properties", JsonUtils.objectToJsonNode(_properties));
     }
     return node;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+    if (!super.equals(o)) {
+      return false;
+    }
+    VectorIndexConfig that = (VectorIndexConfig) o;
+    return Objects.equals(_vectorIndexType, that._vectorIndexType)
+        && Objects.equals(_vectorDimension, that._vectorDimension)
+        && Objects.equals(_version, that._version)
+        && _vectorDistanceFunction == that._vectorDistanceFunction
+        && Objects.equals(_properties, that._properties);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), _vectorIndexType, _vectorDimension, _version, _vectorDistanceFunction,
+        _properties);
   }
 
   public String toString() {
@@ -190,12 +216,10 @@ public class VectorIndexConfig extends IndexConfig {
         + _vectorDistanceFunction + ", _properties=" + _properties + '}';
   }
 
-  /**
-   * Distance functions supported by vector indexes.
-   *
-   * <p>Note: {@code L2} is an alias for {@code EUCLIDEAN}. Both refer to Euclidean (L2) distance.
-   * Existing configs using {@code EUCLIDEAN} continue to work unchanged.</p>
-   */
+  /// Distance functions supported by vector indexes.
+  ///
+  /// Note: `L2` is an alias for `EUCLIDEAN`. Both refer to Euclidean (L2) distance. Existing configs
+  /// using `EUCLIDEAN` continue to work unchanged.
   public enum VectorDistanceFunction {
     COSINE, INNER_PRODUCT, EUCLIDEAN, DOT_PRODUCT, L2;
   }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/creator/VectorIndexConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/creator/VectorIndexConfig.java
@@ -20,10 +20,13 @@ package org.apache.pinot.segment.spi.index.creator;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Preconditions;
 import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.pinot.spi.config.table.IndexConfig;
+import org.apache.pinot.spi.utils.JsonUtils;
 
 
 /**
@@ -148,6 +151,35 @@ public class VectorIndexConfig extends IndexConfig {
    */
   public VectorBackendType resolveBackendType() {
     return VectorIndexConfigValidator.resolveBackendType(this);
+  }
+
+  /**
+   * Curated slim serializer. See {@link IndexConfig#toJsonObject()} for the rationale.
+   *
+   * <p>Note: {@code @JsonCreator} reads {@code vectorDimension} and {@code version} as primitive
+   * {@code int}, so a value of {@code 0} is indistinguishable from "absent" and is therefore
+   * treated as the default and omitted on serialization.
+   */
+  @Override
+  @JsonValue
+  public ObjectNode toJsonObject() {
+    ObjectNode node = super.toJsonObject();
+    if (_vectorIndexType != null) {
+      node.put("vectorIndexType", _vectorIndexType);
+    }
+    if (_vectorDimension != 0) {
+      node.put("vectorDimension", _vectorDimension);
+    }
+    if (_version != 0) {
+      node.put("version", _version);
+    }
+    if (_vectorDistanceFunction != null) {
+      node.put("vectorDistanceFunction", _vectorDistanceFunction.name());
+    }
+    if (_properties != null && !_properties.isEmpty()) {
+      node.set("properties", JsonUtils.objectToJsonNode(_properties));
+    }
+    return node;
   }
 
   public String toString() {

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/DictionaryIndexConfigSerializationTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/DictionaryIndexConfigSerializationTest.java
@@ -1,0 +1,134 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.spi.index;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.HashSet;
+import java.util.Set;
+import org.apache.pinot.spi.config.table.Intern;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+
+/**
+ * Verifies that {@link DictionaryIndexConfig} Jackson serialization uses the curated
+ * {@code @JsonValue toJsonObject()} method and emits each field only when it differs from its
+ * class default.
+ */
+public class DictionaryIndexConfigSerializationTest {
+
+  @Test
+  public void testDefaultPojoSerializesToEmptyJson()
+      throws Exception {
+    JsonNode node = serializeToNode(DictionaryIndexConfig.DEFAULT);
+
+    assertOnlyKeys(node);
+  }
+
+  @Test
+  public void testDisabledTrueIsMinimal()
+      throws Exception {
+    JsonNode node = serializeToNode(DictionaryIndexConfig.DISABLED);
+
+    assertOnlyKeys(node, "disabled");
+    assertTrue(node.get("disabled").asBoolean());
+  }
+
+  @Test
+  public void testOnHeapEmittedWhenTrue()
+      throws Exception {
+    DictionaryIndexConfig config = new DictionaryIndexConfig(true, false);
+
+    JsonNode node = serializeToNode(config);
+
+    assertOnlyKeys(node, "onHeap");
+  }
+
+  @Test
+  public void testUseVarLengthDictionaryEmittedWhenTrue()
+      throws Exception {
+    DictionaryIndexConfig config = new DictionaryIndexConfig(false, true);
+
+    JsonNode node = serializeToNode(config);
+
+    assertOnlyKeys(node, "useVarLengthDictionary");
+  }
+
+  @Test
+  public void testInternEmittedWhenSet()
+      throws Exception {
+    // Intern requires onHeap=true.
+    DictionaryIndexConfig config = new DictionaryIndexConfig(true, false, new Intern(1024));
+
+    JsonNode node = serializeToNode(config);
+
+    assertOnlyKeys(node, "onHeap", "intern");
+    assertEquals(node.get("intern").get("capacity").asInt(), 1024);
+  }
+
+  @Test
+  public void testFatJsonStillDeserializes()
+      throws Exception {
+    String fat = "{"
+        + "\"disabled\":false,"
+        + "\"onHeap\":false,"
+        + "\"useVarLengthDictionary\":false,"
+        + "\"intern\":null"
+        + "}";
+
+    DictionaryIndexConfig config = JsonUtils.stringToObject(fat, DictionaryIndexConfig.class);
+
+    assertOnlyKeys(serializeToNode(config));
+  }
+
+  @Test
+  public void testJacksonSerializationMatchesToJsonObject()
+      throws Exception {
+    DictionaryIndexConfig config = new DictionaryIndexConfig(true, true);
+
+    assertEquals(serializeToNode(config), config.toJsonObject());
+  }
+
+  @Test
+  public void testFreshObjectMapperUsesJsonValue()
+      throws Exception {
+    DictionaryIndexConfig config = new DictionaryIndexConfig(true, false);
+
+    String json = new ObjectMapper().writeValueAsString(config);
+
+    assertEquals(JsonUtils.stringToJsonNode(json), config.toJsonObject());
+  }
+
+  // ---- Helpers ----
+
+  private static JsonNode serializeToNode(Object pojo)
+      throws Exception {
+    return JsonUtils.stringToJsonNode(JsonUtils.objectToString(pojo));
+  }
+
+  private static void assertOnlyKeys(JsonNode node, String... expectedKeys) {
+    Set<String> actual = new HashSet<>();
+    node.fieldNames().forEachRemaining(actual::add);
+    assertEquals(actual, Set.of(expectedKeys), "Unexpected key set: " + node);
+  }
+}

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/DictionaryIndexConfigSerializationTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/DictionaryIndexConfigSerializationTest.java
@@ -27,95 +27,124 @@ import org.apache.pinot.spi.utils.JsonUtils;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 
 
-/**
- * Verifies that {@link DictionaryIndexConfig} Jackson serialization uses the curated
- * {@code @JsonValue toJsonObject()} method and emits each field only when it differs from its
- * class default.
- */
+/// Slim-serialization contract for [DictionaryIndexConfig].
 public class DictionaryIndexConfigSerializationTest {
 
   @Test
-  public void testDefaultPojoSerializesToEmptyJson()
+  public void testRoundTripAllNull()
       throws Exception {
-    JsonNode node = serializeToNode(DictionaryIndexConfig.DEFAULT);
+    DictionaryIndexConfig config = new DictionaryIndexConfig((Boolean) null, null, null, null);
 
-    assertOnlyKeys(node);
+    assertOnlyKeys(serializeToNode(config));
+    assertRoundTripIdempotent(config);
+
+    assertEquals(config.isOnHeap(), false);
+    assertEquals(config.isUseVarLengthDictionary(), false);
+    assertEquals(config.getIntern(), null);
   }
 
   @Test
-  public void testDisabledTrueIsMinimal()
+  public void testRoundTripPartial()
+      throws Exception {
+    DictionaryIndexConfig config = new DictionaryIndexConfig(true, null);
+
+    JsonNode node = serializeToNode(config);
+    assertOnlyKeys(node, "onHeap");
+    assertTrue(node.get("onHeap").asBoolean());
+    assertRoundTripIdempotent(config);
+
+    assertTrue(config.isOnHeap());
+    assertEquals(config.isUseVarLengthDictionary(), false);
+  }
+
+  @Test
+  public void testRoundTripAllSet()
+      throws Exception {
+    DictionaryIndexConfig config = new DictionaryIndexConfig(false, true, true, new Intern(1024));
+
+    JsonNode node = serializeToNode(config);
+    assertOnlyKeys(node, "onHeap", "useVarLengthDictionary", "intern");
+    assertTrue(node.get("onHeap").asBoolean());
+    assertTrue(node.get("useVarLengthDictionary").asBoolean());
+    assertEquals(node.get("intern").get("capacity").asInt(), 1024);
+    assertRoundTripIdempotent(config);
+  }
+
+  @Test
+  public void testDefaultConstantSerializesEmpty()
+      throws Exception {
+    assertOnlyKeys(serializeToNode(DictionaryIndexConfig.DEFAULT));
+  }
+
+  @Test
+  public void testDisabledConstantOnlyEmitsDisabled()
       throws Exception {
     JsonNode node = serializeToNode(DictionaryIndexConfig.DISABLED);
-
     assertOnlyKeys(node, "disabled");
     assertTrue(node.get("disabled").asBoolean());
   }
 
   @Test
-  public void testOnHeapEmittedWhenTrue()
-      throws Exception {
-    DictionaryIndexConfig config = new DictionaryIndexConfig(true, false);
-
-    JsonNode node = serializeToNode(config);
-
-    assertOnlyKeys(node, "onHeap");
-  }
-
-  @Test
   public void testUseVarLengthDictionaryEmittedWhenTrue()
       throws Exception {
-    DictionaryIndexConfig config = new DictionaryIndexConfig(false, true);
-
+    // Cast disambiguates the (Boolean, Boolean) ctor from (DictionaryIndexConfig, boolean).
+    DictionaryIndexConfig config = new DictionaryIndexConfig((Boolean) null, true);
     JsonNode node = serializeToNode(config);
-
     assertOnlyKeys(node, "useVarLengthDictionary");
+    assertTrue(node.get("useVarLengthDictionary").asBoolean());
   }
 
   @Test
   public void testInternEmittedWhenSet()
       throws Exception {
     // Intern requires onHeap=true.
-    DictionaryIndexConfig config = new DictionaryIndexConfig(true, false, new Intern(1024));
-
+    DictionaryIndexConfig config = new DictionaryIndexConfig(true, null, new Intern(1024));
     JsonNode node = serializeToNode(config);
-
     assertOnlyKeys(node, "onHeap", "intern");
     assertEquals(node.get("intern").get("capacity").asInt(), 1024);
   }
 
   @Test
-  public void testFatJsonStillDeserializes()
+  public void testExplicitFalsePreserved()
       throws Exception {
-    String fat = "{"
-        + "\"disabled\":false,"
-        + "\"onHeap\":false,"
-        + "\"useVarLengthDictionary\":false,"
-        + "\"intern\":null"
-        + "}";
-
+    // Explicit false is preserved (not swallowed). Wrapper-based contract distinguishes "user set
+    // to false" (emit) from "user did not configure" (omit).
+    String fat = "{\"onHeap\":false,\"useVarLengthDictionary\":false}";
     DictionaryIndexConfig config = JsonUtils.stringToObject(fat, DictionaryIndexConfig.class);
+    JsonNode node = serializeToNode(config);
+    assertOnlyKeys(node, "onHeap", "useVarLengthDictionary");
+    assertEquals(node.get("onHeap").asBoolean(), false);
+    assertEquals(node.get("useVarLengthDictionary").asBoolean(), false);
 
-    assertOnlyKeys(serializeToNode(config));
+    assertNotEquals(config, DictionaryIndexConfig.DEFAULT,
+        "Explicit-false config must NOT equal the all-null DEFAULT constant");
+  }
+
+  // ---- Validation preserved ----
+
+  @Test
+  public void testInternRequiresOnHeap() {
+    assertThrows(IllegalStateException.class,
+        () -> new DictionaryIndexConfig((Boolean) null, null, null, new Intern(64)));
   }
 
   @Test
   public void testJacksonSerializationMatchesToJsonObject()
       throws Exception {
     DictionaryIndexConfig config = new DictionaryIndexConfig(true, true);
-
     assertEquals(serializeToNode(config), config.toJsonObject());
   }
 
   @Test
   public void testFreshObjectMapperUsesJsonValue()
       throws Exception {
-    DictionaryIndexConfig config = new DictionaryIndexConfig(true, false);
-
+    DictionaryIndexConfig config = new DictionaryIndexConfig(true, null);
     String json = new ObjectMapper().writeValueAsString(config);
-
     assertEquals(JsonUtils.stringToJsonNode(json), config.toJsonObject());
   }
 
@@ -130,5 +159,14 @@ public class DictionaryIndexConfigSerializationTest {
     Set<String> actual = new HashSet<>();
     node.fieldNames().forEachRemaining(actual::add);
     assertEquals(actual, Set.of(expectedKeys), "Unexpected key set: " + node);
+  }
+
+  private static void assertRoundTripIdempotent(DictionaryIndexConfig original)
+      throws Exception {
+    JsonNode firstNode = serializeToNode(original);
+    DictionaryIndexConfig restored =
+        JsonUtils.stringToObject(JsonUtils.objectToString(original), DictionaryIndexConfig.class);
+    JsonNode secondNode = serializeToNode(restored);
+    assertEquals(secondNode, firstNode, "Slim form must be byte-equivalent across a round-trip");
   }
 }

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/ForwardIndexConfigSerializationTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/ForwardIndexConfigSerializationTest.java
@@ -130,13 +130,11 @@ public class ForwardIndexConfigSerializationTest {
     assertEquals(node.get("rawIndexWriterVersion").asInt(), nonDefault);
   }
 
-  /**
-   * The cluster-tunable trio must be persisted regardless of whether the live JVM-local default
-   * matches the resolved value, so that a node with a different local default does not silently
-   * read a different effective forward-index setting from the same ZK payload. This test pins the
-   * "always materialize" contract: mutating the static after construction does not change what is
-   * emitted — both the original and mutated runs emit the value the POJO is carrying.
-   */
+  /// The cluster-tunable trio must be persisted regardless of whether the live JVM-local default matches the
+  /// resolved value, so that a node with a different local default does not silently read a different effective
+  /// forward-index setting from the same ZK payload. This test pins the "always materialize" contract: mutating the
+  /// static after construction does not change what is emitted — both the original and mutated runs emit the value
+  /// the POJO is carrying.
   @Test
   public void testClusterTunableTrioAlwaysMaterialized()
       throws Exception {
@@ -170,8 +168,11 @@ public class ForwardIndexConfigSerializationTest {
   }
 
   @Test
-  public void testFatJsonStillDeserializesAndReSerializesWithTrio()
+  public void testFatJsonRoundTripsPreservingExplicitFalse()
       throws Exception {
+    // Explicit false for deriveNumDocsPerChunk survives the round-trip — wrapper-based contract
+    // distinguishes "user set false" from "not configured." disabled=false is normalized to null
+    // by IndexConfig and stays omitted (universal default for every config).
     String fat = "{"
         + "\"disabled\":false,"
         + "\"compressionCodec\":null,"
@@ -184,7 +185,39 @@ public class ForwardIndexConfigSerializationTest {
     ForwardIndexConfig config = JsonUtils.stringToObject(fat, ForwardIndexConfig.class);
 
     JsonNode node = serializeToNode(config);
-    assertOnlyKeys(node, ALWAYS_EMITTED);
+    assertOnlyKeys(node, "deriveNumDocsPerChunk", "encodingType", "rawIndexWriterVersion", "targetMaxChunkSize",
+        "targetDocsPerChunk");
+    assertEquals(node.get("deriveNumDocsPerChunk").asBoolean(), false);
+  }
+
+  /// Cluster-tunable trio uses snapshot semantics: constructor coerces null to live JVM default at
+  /// init, field is stable for object lifetime, and never drifts even if the static is mutated
+  /// later. Different objects constructed under different live defaults each carry their own
+  /// snapshot.
+  @Test
+  public void testTrioSnapshotsAtConstruction()
+      throws Exception {
+    int original = ForwardIndexConfig.getDefaultRawWriterVersion();
+
+    ForwardIndexConfig configA = new ForwardIndexConfig.Builder(EncodingType.DICTIONARY).build();
+    assertEquals(configA.getRawIndexWriterVersion(), original);
+
+    ForwardIndexConfig.setDefaultRawIndexWriterVersion(original + 1);
+    try {
+      ForwardIndexConfig configB = new ForwardIndexConfig.Builder(EncodingType.DICTIONARY).build();
+
+      // configA's snapshot is stable for its lifetime even after the static mutated.
+      assertEquals(configA.getRawIndexWriterVersion(), original);
+      // configB picked up the new live default at its construction.
+      assertEquals(configB.getRawIndexWriterVersion(), original + 1);
+
+      JsonNode nodeA = serializeToNode(configA);
+      JsonNode nodeB = serializeToNode(configB);
+      assertEquals(nodeA.get("rawIndexWriterVersion").asInt(), original);
+      assertEquals(nodeB.get("rawIndexWriterVersion").asInt(), original + 1);
+    } finally {
+      ForwardIndexConfig.setDefaultRawIndexWriterVersion(original);
+    }
   }
 
   @Test

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/ForwardIndexConfigSerializationTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/ForwardIndexConfigSerializationTest.java
@@ -1,0 +1,208 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.spi.index;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.HashSet;
+import java.util.Set;
+import org.apache.pinot.spi.config.table.FieldConfig.CompressionCodec;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+
+/**
+ * Verifies that {@link ForwardIndexConfig} Jackson serialization uses the curated
+ * {@code @JsonValue toJsonObject()} method and emits each field only when it differs from its
+ * class default.
+ *
+ * <p>Particular attention to the cluster-tunable static defaults
+ * ({@code _defaultRawIndexWriterVersion}, {@code _defaultTargetMaxChunkSize},
+ * {@code _defaultTargetDocsPerChunk}): the serializer must read these at call time so that the
+ * serialized form tracks live cluster config.
+ */
+public class ForwardIndexConfigSerializationTest {
+
+  // Snapshot the cluster-tunable statics so we can restore them after each test.
+  private final int _savedRawIndexWriterVersion = ForwardIndexConfig.getDefaultRawWriterVersion();
+  private final String _savedTargetMaxChunkSize = ForwardIndexConfig.getDefaultTargetMaxChunkSize();
+  private final int _savedTargetDocsPerChunk = ForwardIndexConfig.getDefaultTargetDocsPerChunk();
+
+  @AfterMethod
+  public void restoreClusterDefaults() {
+    ForwardIndexConfig.setDefaultRawIndexWriterVersion(_savedRawIndexWriterVersion);
+    ForwardIndexConfig.setDefaultTargetMaxChunkSize(_savedTargetMaxChunkSize);
+    ForwardIndexConfig.setDefaultTargetDocsPerChunk(_savedTargetDocsPerChunk);
+  }
+
+  @Test
+  public void testDefaultPojoSerializesToEmptyJson()
+      throws Exception {
+    ForwardIndexConfig config = ForwardIndexConfig.getDefault();
+
+    JsonNode node = serializeToNode(config);
+
+    assertOnlyKeys(node);
+  }
+
+  @Test
+  public void testDisabledTrueIsMinimal()
+      throws Exception {
+    ForwardIndexConfig config = ForwardIndexConfig.getDisabled();
+
+    JsonNode node = serializeToNode(config);
+
+    assertOnlyKeys(node, "disabled");
+    assertTrue(node.get("disabled").asBoolean());
+  }
+
+  @Test
+  public void testCompressionCodecEmittedWhenSet()
+      throws Exception {
+    ForwardIndexConfig config = new ForwardIndexConfig.Builder()
+        .withCompressionCodec(CompressionCodec.SNAPPY).build();
+
+    JsonNode node = serializeToNode(config);
+
+    assertOnlyKeys(node, "compressionCodec");
+    assertEquals(node.get("compressionCodec").asText(), "SNAPPY");
+  }
+
+  @Test
+  public void testDeriveNumDocsPerChunkEmittedWhenTrue()
+      throws Exception {
+    ForwardIndexConfig config = new ForwardIndexConfig.Builder()
+        .withDeriveNumDocsPerChunk(true).build();
+
+    JsonNode node = serializeToNode(config);
+
+    assertOnlyKeys(node, "deriveNumDocsPerChunk");
+    assertTrue(node.get("deriveNumDocsPerChunk").asBoolean());
+  }
+
+  @Test
+  public void testNonDefaultRawIndexWriterVersionEmitted()
+      throws Exception {
+    int nonDefault = ForwardIndexConfig.getDefaultRawWriterVersion() + 1;
+    ForwardIndexConfig config = new ForwardIndexConfig.Builder()
+        .withRawIndexWriterVersion(nonDefault).build();
+
+    JsonNode node = serializeToNode(config);
+
+    assertOnlyKeys(node, "rawIndexWriterVersion");
+    assertEquals(node.get("rawIndexWriterVersion").asInt(), nonDefault);
+  }
+
+  /**
+   * The cluster-tunable static {@code _defaultRawIndexWriterVersion} is read at call time, so a
+   * config matching the live cluster default must serialize as empty even after the static is
+   * mutated.
+   */
+  @Test
+  public void testClusterTunableDefaultReadAtCallTime()
+      throws Exception {
+    int original = ForwardIndexConfig.getDefaultRawWriterVersion();
+    ForwardIndexConfig config = new ForwardIndexConfig.Builder()
+        .withRawIndexWriterVersion(original).build();
+
+    // Sanity: equal to live default, so omitted.
+    assertOnlyKeys(serializeToNode(config));
+
+    // Mutate live default; the same instance now differs from the live default.
+    int mutated = original + 1;
+    ForwardIndexConfig.setDefaultRawIndexWriterVersion(mutated);
+    JsonNode mutatedNode = serializeToNode(config);
+    assertEquals(mutatedNode.get("rawIndexWriterVersion").asInt(), original);
+
+    // Restore so a config built at the new default again serializes empty.
+    ForwardIndexConfig matchingNewDefault = new ForwardIndexConfig.Builder()
+        .withRawIndexWriterVersion(mutated).build();
+    assertOnlyKeys(serializeToNode(matchingNewDefault));
+  }
+
+  @Test
+  public void testDeprecatedKeysNotEmitted()
+      throws Exception {
+    ForwardIndexConfig config = new ForwardIndexConfig.Builder()
+        .withCompressionCodec(CompressionCodec.SNAPPY).build();
+
+    JsonNode node = serializeToNode(config);
+
+    assertFalse(node.has("chunkCompressionType"), "Deprecated chunkCompressionType must not be emitted: " + node);
+    assertFalse(node.has("dictIdCompressionType"), "Deprecated dictIdCompressionType must not be emitted: " + node);
+    assertFalse(node.has("configs"), "configs (already @JsonIgnore on getter) must not be emitted: " + node);
+  }
+
+  @Test
+  public void testFatJsonStillDeserializes()
+      throws Exception {
+    String fat = "{"
+        + "\"disabled\":false,"
+        + "\"compressionCodec\":null,"
+        + "\"deriveNumDocsPerChunk\":false,"
+        + "\"rawIndexWriterVersion\":" + ForwardIndexConfig.getDefaultRawWriterVersion() + ","
+        + "\"targetMaxChunkSize\":\"" + ForwardIndexConfig.getDefaultTargetMaxChunkSize() + "\","
+        + "\"targetDocsPerChunk\":" + ForwardIndexConfig.getDefaultTargetDocsPerChunk()
+        + "}";
+
+    ForwardIndexConfig config = JsonUtils.stringToObject(fat, ForwardIndexConfig.class);
+
+    assertOnlyKeys(serializeToNode(config));
+  }
+
+  @Test
+  public void testJacksonSerializationMatchesToJsonObject()
+      throws Exception {
+    ForwardIndexConfig config = new ForwardIndexConfig.Builder()
+        .withCompressionCodec(CompressionCodec.LZ4)
+        .withDeriveNumDocsPerChunk(true)
+        .build();
+
+    assertEquals(serializeToNode(config), config.toJsonObject());
+  }
+
+  @Test
+  public void testFreshObjectMapperUsesJsonValue()
+      throws Exception {
+    ForwardIndexConfig config = new ForwardIndexConfig.Builder()
+        .withCompressionCodec(CompressionCodec.SNAPPY).build();
+
+    String json = new ObjectMapper().writeValueAsString(config);
+
+    assertEquals(JsonUtils.stringToJsonNode(json), config.toJsonObject());
+  }
+
+  // ---- Helpers ----
+
+  private static JsonNode serializeToNode(Object pojo)
+      throws Exception {
+    return JsonUtils.stringToJsonNode(JsonUtils.objectToString(pojo));
+  }
+
+  private static void assertOnlyKeys(JsonNode node, String... expectedKeys) {
+    Set<String> actual = new HashSet<>();
+    node.fieldNames().forEachRemaining(actual::add);
+    assertEquals(actual, Set.of(expectedKeys), "Unexpected key set: " + node);
+  }
+}

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/ForwardIndexConfigSerializationTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/ForwardIndexConfigSerializationTest.java
@@ -59,10 +59,9 @@ public class ForwardIndexConfigSerializationTest {
     ForwardIndexConfig.setDefaultTargetDocsPerChunk(_savedTargetDocsPerChunk);
   }
 
-  // The cluster-tunable trio is always materialized by the slim serializer (see class Javadoc).
-  // The keys are: rawIndexWriterVersion, targetMaxChunkSize, targetDocsPerChunk.
+  // encodingType and the cluster-tunable trio are always materialized by the slim serializer.
   private static final String[] ALWAYS_EMITTED = {
-      "rawIndexWriterVersion", "targetMaxChunkSize", "targetDocsPerChunk"
+      "encodingType", "rawIndexWriterVersion", "targetMaxChunkSize", "targetDocsPerChunk"
   };
 
   @Test
@@ -73,6 +72,7 @@ public class ForwardIndexConfigSerializationTest {
     JsonNode node = serializeToNode(config);
 
     assertOnlyKeys(node, ALWAYS_EMITTED);
+    assertEquals(node.get("encodingType").asText(), EncodingType.DICTIONARY.name());
     assertEquals(node.get("rawIndexWriterVersion").asInt(), ForwardIndexConfig.getDefaultRawWriterVersion());
     assertEquals(node.get("targetMaxChunkSize").asText(), ForwardIndexConfig.getDefaultTargetMaxChunkSize());
     assertEquals(node.get("targetDocsPerChunk").asInt(), ForwardIndexConfig.getDefaultTargetDocsPerChunk());
@@ -87,7 +87,8 @@ public class ForwardIndexConfigSerializationTest {
 
     // getDisabled() builds via the explicit ctor with all-null settings, so the cluster-tunable
     // trio is materialized to live defaults.
-    assertOnlyKeys(node, "disabled", "rawIndexWriterVersion", "targetMaxChunkSize", "targetDocsPerChunk");
+    assertOnlyKeys(node, "disabled", "encodingType", "rawIndexWriterVersion", "targetMaxChunkSize",
+        "targetDocsPerChunk");
     assertTrue(node.get("disabled").asBoolean());
   }
 
@@ -99,7 +100,8 @@ public class ForwardIndexConfigSerializationTest {
 
     JsonNode node = serializeToNode(config);
 
-    assertOnlyKeys(node, "compressionCodec", "rawIndexWriterVersion", "targetMaxChunkSize", "targetDocsPerChunk");
+    assertOnlyKeys(node, "compressionCodec", "encodingType", "rawIndexWriterVersion", "targetMaxChunkSize",
+        "targetDocsPerChunk");
     assertEquals(node.get("compressionCodec").asText(), "SNAPPY");
   }
 
@@ -111,7 +113,8 @@ public class ForwardIndexConfigSerializationTest {
 
     JsonNode node = serializeToNode(config);
 
-    assertOnlyKeys(node, "deriveNumDocsPerChunk", "rawIndexWriterVersion", "targetMaxChunkSize", "targetDocsPerChunk");
+    assertOnlyKeys(node, "deriveNumDocsPerChunk", "encodingType", "rawIndexWriterVersion", "targetMaxChunkSize",
+        "targetDocsPerChunk");
     assertTrue(node.get("deriveNumDocsPerChunk").asBoolean());
   }
 

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/ForwardIndexConfigSerializationTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/ForwardIndexConfigSerializationTest.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.HashSet;
 import java.util.Set;
 import org.apache.pinot.spi.config.table.FieldConfig.CompressionCodec;
+import org.apache.pinot.spi.config.table.FieldConfig.EncodingType;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.Test;
@@ -67,7 +68,7 @@ public class ForwardIndexConfigSerializationTest {
   @Test
   public void testDefaultPojoSerializesOnlyClusterTunableTrio()
       throws Exception {
-    ForwardIndexConfig config = ForwardIndexConfig.getDefault();
+    ForwardIndexConfig config = ForwardIndexConfig.getDefault(EncodingType.DICTIONARY);
 
     JsonNode node = serializeToNode(config);
 
@@ -93,7 +94,7 @@ public class ForwardIndexConfigSerializationTest {
   @Test
   public void testCompressionCodecEmittedWhenSet()
       throws Exception {
-    ForwardIndexConfig config = new ForwardIndexConfig.Builder()
+    ForwardIndexConfig config = new ForwardIndexConfig.Builder(EncodingType.DICTIONARY)
         .withCompressionCodec(CompressionCodec.SNAPPY).build();
 
     JsonNode node = serializeToNode(config);
@@ -105,7 +106,7 @@ public class ForwardIndexConfigSerializationTest {
   @Test
   public void testDeriveNumDocsPerChunkEmittedWhenTrue()
       throws Exception {
-    ForwardIndexConfig config = new ForwardIndexConfig.Builder()
+    ForwardIndexConfig config = new ForwardIndexConfig.Builder(EncodingType.DICTIONARY)
         .withDeriveNumDocsPerChunk(true).build();
 
     JsonNode node = serializeToNode(config);
@@ -118,7 +119,7 @@ public class ForwardIndexConfigSerializationTest {
   public void testNonDefaultRawIndexWriterVersionEmitted()
       throws Exception {
     int nonDefault = ForwardIndexConfig.getDefaultRawWriterVersion() + 1;
-    ForwardIndexConfig config = new ForwardIndexConfig.Builder()
+    ForwardIndexConfig config = new ForwardIndexConfig.Builder(EncodingType.DICTIONARY)
         .withRawIndexWriterVersion(nonDefault).build();
 
     JsonNode node = serializeToNode(config);
@@ -137,7 +138,7 @@ public class ForwardIndexConfigSerializationTest {
   public void testClusterTunableTrioAlwaysMaterialized()
       throws Exception {
     int original = ForwardIndexConfig.getDefaultRawWriterVersion();
-    ForwardIndexConfig config = new ForwardIndexConfig.Builder()
+    ForwardIndexConfig config = new ForwardIndexConfig.Builder(EncodingType.DICTIONARY)
         .withRawIndexWriterVersion(original).build();
 
     JsonNode firstNode = serializeToNode(config);
@@ -155,7 +156,7 @@ public class ForwardIndexConfigSerializationTest {
   @Test
   public void testDeprecatedKeysNotEmitted()
       throws Exception {
-    ForwardIndexConfig config = new ForwardIndexConfig.Builder()
+    ForwardIndexConfig config = new ForwardIndexConfig.Builder(EncodingType.DICTIONARY)
         .withCompressionCodec(CompressionCodec.SNAPPY).build();
 
     JsonNode node = serializeToNode(config);
@@ -186,7 +187,7 @@ public class ForwardIndexConfigSerializationTest {
   @Test
   public void testJacksonSerializationMatchesToJsonObject()
       throws Exception {
-    ForwardIndexConfig config = new ForwardIndexConfig.Builder()
+    ForwardIndexConfig config = new ForwardIndexConfig.Builder(EncodingType.DICTIONARY)
         .withCompressionCodec(CompressionCodec.LZ4)
         .withDeriveNumDocsPerChunk(true)
         .build();
@@ -197,7 +198,7 @@ public class ForwardIndexConfigSerializationTest {
   @Test
   public void testFreshObjectMapperUsesJsonValue()
       throws Exception {
-    ForwardIndexConfig config = new ForwardIndexConfig.Builder()
+    ForwardIndexConfig config = new ForwardIndexConfig.Builder(EncodingType.DICTIONARY)
         .withCompressionCodec(CompressionCodec.SNAPPY).build();
 
     String json = new ObjectMapper().writeValueAsString(config);

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/ForwardIndexConfigSerializationTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/ForwardIndexConfigSerializationTest.java
@@ -34,13 +34,15 @@ import static org.testng.Assert.assertTrue;
 
 /**
  * Verifies that {@link ForwardIndexConfig} Jackson serialization uses the curated
- * {@code @JsonValue toJsonObject()} method and emits each field only when it differs from its
- * class default.
+ * {@code @JsonValue toJsonObject()} method and emits non-cluster-tunable fields only when they
+ * differ from their class default.
  *
- * <p>Particular attention to the cluster-tunable static defaults
- * ({@code _defaultRawIndexWriterVersion}, {@code _defaultTargetMaxChunkSize},
- * {@code _defaultTargetDocsPerChunk}): the serializer must read these at call time so that the
- * serialized form tracks live cluster config.
+ * <p>Particular attention to the cluster-tunable trio ({@code rawIndexWriterVersion},
+ * {@code targetMaxChunkSize}, {@code targetDocsPerChunk}): these are <i>always</i> materialized
+ * regardless of how they relate to the JVM-local static defaults, because
+ * {@code ServiceStartableUtils.initForwardIndexConfig} mutates those statics per-instance from
+ * instance config. Slim-omitting them would let the same ZK payload resolve to different
+ * forward-index settings on different nodes during a rolling upgrade or mismatched-config window.
  */
 public class ForwardIndexConfigSerializationTest {
 
@@ -56,14 +58,23 @@ public class ForwardIndexConfigSerializationTest {
     ForwardIndexConfig.setDefaultTargetDocsPerChunk(_savedTargetDocsPerChunk);
   }
 
+  // The cluster-tunable trio is always materialized by the slim serializer (see class Javadoc).
+  // The keys are: rawIndexWriterVersion, targetMaxChunkSize, targetDocsPerChunk.
+  private static final String[] ALWAYS_EMITTED = {
+      "rawIndexWriterVersion", "targetMaxChunkSize", "targetDocsPerChunk"
+  };
+
   @Test
-  public void testDefaultPojoSerializesToEmptyJson()
+  public void testDefaultPojoSerializesOnlyClusterTunableTrio()
       throws Exception {
     ForwardIndexConfig config = ForwardIndexConfig.getDefault();
 
     JsonNode node = serializeToNode(config);
 
-    assertOnlyKeys(node);
+    assertOnlyKeys(node, ALWAYS_EMITTED);
+    assertEquals(node.get("rawIndexWriterVersion").asInt(), ForwardIndexConfig.getDefaultRawWriterVersion());
+    assertEquals(node.get("targetMaxChunkSize").asText(), ForwardIndexConfig.getDefaultTargetMaxChunkSize());
+    assertEquals(node.get("targetDocsPerChunk").asInt(), ForwardIndexConfig.getDefaultTargetDocsPerChunk());
   }
 
   @Test
@@ -73,7 +84,9 @@ public class ForwardIndexConfigSerializationTest {
 
     JsonNode node = serializeToNode(config);
 
-    assertOnlyKeys(node, "disabled");
+    // getDisabled() builds via the explicit ctor with all-null settings, so the cluster-tunable
+    // trio is materialized to live defaults.
+    assertOnlyKeys(node, "disabled", "rawIndexWriterVersion", "targetMaxChunkSize", "targetDocsPerChunk");
     assertTrue(node.get("disabled").asBoolean());
   }
 
@@ -85,7 +98,7 @@ public class ForwardIndexConfigSerializationTest {
 
     JsonNode node = serializeToNode(config);
 
-    assertOnlyKeys(node, "compressionCodec");
+    assertOnlyKeys(node, "compressionCodec", "rawIndexWriterVersion", "targetMaxChunkSize", "targetDocsPerChunk");
     assertEquals(node.get("compressionCodec").asText(), "SNAPPY");
   }
 
@@ -97,7 +110,7 @@ public class ForwardIndexConfigSerializationTest {
 
     JsonNode node = serializeToNode(config);
 
-    assertOnlyKeys(node, "deriveNumDocsPerChunk");
+    assertOnlyKeys(node, "deriveNumDocsPerChunk", "rawIndexWriterVersion", "targetMaxChunkSize", "targetDocsPerChunk");
     assertTrue(node.get("deriveNumDocsPerChunk").asBoolean());
   }
 
@@ -110,35 +123,33 @@ public class ForwardIndexConfigSerializationTest {
 
     JsonNode node = serializeToNode(config);
 
-    assertOnlyKeys(node, "rawIndexWriterVersion");
     assertEquals(node.get("rawIndexWriterVersion").asInt(), nonDefault);
   }
 
   /**
-   * The cluster-tunable static {@code _defaultRawIndexWriterVersion} is read at call time, so a
-   * config matching the live cluster default must serialize as empty even after the static is
-   * mutated.
+   * The cluster-tunable trio must be persisted regardless of whether the live JVM-local default
+   * matches the resolved value, so that a node with a different local default does not silently
+   * read a different effective forward-index setting from the same ZK payload. This test pins the
+   * "always materialize" contract: mutating the static after construction does not change what is
+   * emitted — both the original and mutated runs emit the value the POJO is carrying.
    */
   @Test
-  public void testClusterTunableDefaultReadAtCallTime()
+  public void testClusterTunableTrioAlwaysMaterialized()
       throws Exception {
     int original = ForwardIndexConfig.getDefaultRawWriterVersion();
     ForwardIndexConfig config = new ForwardIndexConfig.Builder()
         .withRawIndexWriterVersion(original).build();
 
-    // Sanity: equal to live default, so omitted.
-    assertOnlyKeys(serializeToNode(config));
+    JsonNode firstNode = serializeToNode(config);
+    assertTrue(firstNode.has("rawIndexWriterVersion"),
+        "Cluster-tunable rawIndexWriterVersion must always be materialized: " + firstNode);
+    assertEquals(firstNode.get("rawIndexWriterVersion").asInt(), original);
 
-    // Mutate live default; the same instance now differs from the live default.
-    int mutated = original + 1;
-    ForwardIndexConfig.setDefaultRawIndexWriterVersion(mutated);
+    // Mutating the live default must not affect what is emitted by the same instance.
+    ForwardIndexConfig.setDefaultRawIndexWriterVersion(original + 1);
     JsonNode mutatedNode = serializeToNode(config);
-    assertEquals(mutatedNode.get("rawIndexWriterVersion").asInt(), original);
-
-    // Restore so a config built at the new default again serializes empty.
-    ForwardIndexConfig matchingNewDefault = new ForwardIndexConfig.Builder()
-        .withRawIndexWriterVersion(mutated).build();
-    assertOnlyKeys(serializeToNode(matchingNewDefault));
+    assertEquals(mutatedNode.get("rawIndexWriterVersion").asInt(), original,
+        "Serialized value must be the POJO's stored value, not the (mutated) live default: " + mutatedNode);
   }
 
   @Test
@@ -155,7 +166,7 @@ public class ForwardIndexConfigSerializationTest {
   }
 
   @Test
-  public void testFatJsonStillDeserializes()
+  public void testFatJsonStillDeserializesAndReSerializesWithTrio()
       throws Exception {
     String fat = "{"
         + "\"disabled\":false,"
@@ -168,7 +179,8 @@ public class ForwardIndexConfigSerializationTest {
 
     ForwardIndexConfig config = JsonUtils.stringToObject(fat, ForwardIndexConfig.class);
 
-    assertOnlyKeys(serializeToNode(config));
+    JsonNode node = serializeToNode(config);
+    assertOnlyKeys(node, ALWAYS_EMITTED);
   }
 
   @Test

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/FstIndexConfigSerializationTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/FstIndexConfigSerializationTest.java
@@ -1,0 +1,99 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.spi.index;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.HashSet;
+import java.util.Set;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+
+/**
+ * Verifies that {@link FstIndexConfig} Jackson serialization uses the curated
+ * {@code @JsonValue toJsonObject()} method. {@code FstIndexConfig} adds no fields beyond the base
+ * {@code disabled} field, so the override delegates entirely to the base — but is still tested
+ * here so the slim-form contract is locally enforced.
+ */
+public class FstIndexConfigSerializationTest {
+
+  @Test
+  public void testEnabledDefaultIsEmpty()
+      throws Exception {
+    FstIndexConfig config = new FstIndexConfig(false);
+
+    JsonNode node = serializeToNode(config);
+
+    assertOnlyKeys(node);
+  }
+
+  @Test
+  public void testDisabledTrueIsMinimal()
+      throws Exception {
+    FstIndexConfig config = FstIndexConfig.DISABLED;
+
+    JsonNode node = serializeToNode(config);
+
+    assertOnlyKeys(node, "disabled");
+    assertTrue(node.get("disabled").asBoolean());
+  }
+
+  @Test
+  public void testFatJsonStillDeserializes()
+      throws Exception {
+    FstIndexConfig config = JsonUtils.stringToObject("{\"disabled\":false}", FstIndexConfig.class);
+
+    assertOnlyKeys(serializeToNode(config));
+  }
+
+  @Test
+  public void testJacksonSerializationMatchesToJsonObject()
+      throws Exception {
+    FstIndexConfig config = new FstIndexConfig(true);
+
+    assertEquals(serializeToNode(config), config.toJsonObject());
+  }
+
+  @Test
+  public void testFreshObjectMapperUsesJsonValue()
+      throws Exception {
+    FstIndexConfig config = new FstIndexConfig(true);
+
+    String json = new ObjectMapper().writeValueAsString(config);
+
+    assertEquals(JsonUtils.stringToJsonNode(json), config.toJsonObject());
+  }
+
+  // ---- Helpers ----
+
+  private static JsonNode serializeToNode(Object pojo)
+      throws Exception {
+    return JsonUtils.stringToJsonNode(JsonUtils.objectToString(pojo));
+  }
+
+  private static void assertOnlyKeys(JsonNode node, String... expectedKeys) {
+    Set<String> actual = new HashSet<>();
+    node.fieldNames().forEachRemaining(actual::add);
+    assertEquals(actual, Set.of(expectedKeys), "Unexpected key set: " + node);
+  }
+}

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/RangeIndexConfigSerializationTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/RangeIndexConfigSerializationTest.java
@@ -1,0 +1,108 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.spi.index;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.HashSet;
+import java.util.Set;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+
+/**
+ * Verifies that {@link RangeIndexConfig} Jackson serialization uses the curated
+ * {@code @JsonValue toJsonObject()} method and emits {@code version} only when it differs from
+ * its class default of {@code 2}.
+ */
+public class RangeIndexConfigSerializationTest {
+
+  @Test
+  public void testDefaultPojoSerializesToEmptyJson()
+      throws Exception {
+    JsonNode node = serializeToNode(RangeIndexConfig.DEFAULT);
+
+    assertOnlyKeys(node);
+  }
+
+  @Test
+  public void testDisabledTrueIsMinimal()
+      throws Exception {
+    JsonNode node = serializeToNode(RangeIndexConfig.DISABLED);
+
+    assertOnlyKeys(node, "disabled");
+    assertTrue(node.get("disabled").asBoolean());
+  }
+
+  @Test
+  public void testNonDefaultVersionEmitted()
+      throws Exception {
+    RangeIndexConfig config = new RangeIndexConfig(3);
+
+    JsonNode node = serializeToNode(config);
+
+    assertOnlyKeys(node, "version");
+    assertEquals(node.get("version").asInt(), 3);
+  }
+
+  @Test
+  public void testFatJsonStillDeserializes()
+      throws Exception {
+    String fat = "{\"disabled\":false,\"version\":2}";
+
+    RangeIndexConfig config = JsonUtils.stringToObject(fat, RangeIndexConfig.class);
+
+    assertOnlyKeys(serializeToNode(config));
+    assertEquals(config.getVersion(), 2);
+  }
+
+  @Test
+  public void testJacksonSerializationMatchesToJsonObject()
+      throws Exception {
+    RangeIndexConfig config = new RangeIndexConfig(3);
+
+    assertEquals(serializeToNode(config), config.toJsonObject());
+  }
+
+  @Test
+  public void testFreshObjectMapperUsesJsonValue()
+      throws Exception {
+    RangeIndexConfig config = new RangeIndexConfig(5);
+
+    String json = new ObjectMapper().writeValueAsString(config);
+
+    assertEquals(JsonUtils.stringToJsonNode(json), config.toJsonObject());
+  }
+
+  // ---- Helpers ----
+
+  private static JsonNode serializeToNode(Object pojo)
+      throws Exception {
+    return JsonUtils.stringToJsonNode(JsonUtils.objectToString(pojo));
+  }
+
+  private static void assertOnlyKeys(JsonNode node, String... expectedKeys) {
+    Set<String> actual = new HashSet<>();
+    node.fieldNames().forEachRemaining(actual::add);
+    assertEquals(actual, Set.of(expectedKeys), "Unexpected key set: " + node);
+  }
+}

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/RangeIndexConfigSerializationTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/RangeIndexConfigSerializationTest.java
@@ -26,60 +26,79 @@ import org.apache.pinot.spi.utils.JsonUtils;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertTrue;
 
 
-/**
- * Verifies that {@link RangeIndexConfig} Jackson serialization uses the curated
- * {@code @JsonValue toJsonObject()} method and emits {@code version} only when it differs from
- * its class default of {@code 2}.
- */
+/// Slim-serialization contract for [RangeIndexConfig].
 public class RangeIndexConfigSerializationTest {
 
   @Test
-  public void testDefaultPojoSerializesToEmptyJson()
+  public void testRoundTripAllNull()
       throws Exception {
-    JsonNode node = serializeToNode(RangeIndexConfig.DEFAULT);
+    RangeIndexConfig config = new RangeIndexConfig((Boolean) null, null);
 
-    assertOnlyKeys(node);
+    assertOnlyKeys(serializeToNode(config));
+    assertRoundTripIdempotent(config);
+
+    assertEquals(config.getVersion(), RangeIndexConfig.DEFAULT_VERSION);
   }
 
   @Test
-  public void testDisabledTrueIsMinimal()
+  public void testRoundTripPartial()
+      throws Exception {
+    RangeIndexConfig config = new RangeIndexConfig(3);
+    JsonNode node = serializeToNode(config);
+    assertOnlyKeys(node, "version");
+    assertEquals(node.get("version").asInt(), 3);
+    assertRoundTripIdempotent(config);
+
+    assertEquals(config.getVersion(), 3);
+  }
+
+  @Test
+  public void testRoundTripAllSet()
+      throws Exception {
+    RangeIndexConfig config = new RangeIndexConfig(true, 5);
+    JsonNode node = serializeToNode(config);
+    assertOnlyKeys(node, "disabled", "version");
+    assertTrue(node.get("disabled").asBoolean());
+    assertEquals(node.get("version").asInt(), 5);
+    assertRoundTripIdempotent(config);
+  }
+
+  @Test
+  public void testDefaultConstantSerializesEmpty()
+      throws Exception {
+    assertOnlyKeys(serializeToNode(RangeIndexConfig.DEFAULT));
+  }
+
+  @Test
+  public void testDisabledConstantOnlyEmitsDisabled()
       throws Exception {
     JsonNode node = serializeToNode(RangeIndexConfig.DISABLED);
-
     assertOnlyKeys(node, "disabled");
     assertTrue(node.get("disabled").asBoolean());
   }
 
   @Test
-  public void testNonDefaultVersionEmitted()
+  public void testExplicitDefaultVersionPreserved()
       throws Exception {
-    RangeIndexConfig config = new RangeIndexConfig(3);
-
+    // User says version=2 (today's default). Slim form keeps the key so a future default change
+    // does not silently swallow user intent.
+    RangeIndexConfig config = new RangeIndexConfig(RangeIndexConfig.DEFAULT_VERSION);
     JsonNode node = serializeToNode(config);
-
     assertOnlyKeys(node, "version");
-    assertEquals(node.get("version").asInt(), 3);
-  }
+    assertEquals(node.get("version").asInt(), RangeIndexConfig.DEFAULT_VERSION);
 
-  @Test
-  public void testFatJsonStillDeserializes()
-      throws Exception {
-    String fat = "{\"disabled\":false,\"version\":2}";
-
-    RangeIndexConfig config = JsonUtils.stringToObject(fat, RangeIndexConfig.class);
-
-    assertOnlyKeys(serializeToNode(config));
-    assertEquals(config.getVersion(), 2);
+    assertNotEquals(config, RangeIndexConfig.DEFAULT,
+        "Explicit-default-value config must NOT equal the all-null DEFAULT constant");
   }
 
   @Test
   public void testJacksonSerializationMatchesToJsonObject()
       throws Exception {
     RangeIndexConfig config = new RangeIndexConfig(3);
-
     assertEquals(serializeToNode(config), config.toJsonObject());
   }
 
@@ -87,9 +106,7 @@ public class RangeIndexConfigSerializationTest {
   public void testFreshObjectMapperUsesJsonValue()
       throws Exception {
     RangeIndexConfig config = new RangeIndexConfig(5);
-
     String json = new ObjectMapper().writeValueAsString(config);
-
     assertEquals(JsonUtils.stringToJsonNode(json), config.toJsonObject());
   }
 
@@ -104,5 +121,14 @@ public class RangeIndexConfigSerializationTest {
     Set<String> actual = new HashSet<>();
     node.fieldNames().forEachRemaining(actual::add);
     assertEquals(actual, Set.of(expectedKeys), "Unexpected key set: " + node);
+  }
+
+  private static void assertRoundTripIdempotent(RangeIndexConfig original)
+      throws Exception {
+    JsonNode firstNode = serializeToNode(original);
+    RangeIndexConfig restored =
+        JsonUtils.stringToObject(JsonUtils.objectToString(original), RangeIndexConfig.class);
+    JsonNode secondNode = serializeToNode(restored);
+    assertEquals(secondNode, firstNode, "Slim form must be byte-equivalent across a round-trip");
   }
 }

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/TextIndexConfigSerializationTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/TextIndexConfigSerializationTest.java
@@ -25,55 +25,106 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
+import org.apache.pinot.spi.config.table.FieldConfig;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertTrue;
 
 
-/**
- * Verifies that {@link TextIndexConfig} Jackson serialization uses the curated
- * {@code @JsonValue toJsonObject()} method and emits each of the 18 lucene defaults only when
- * the field differs from its constant default. Empty / null lists are treated as defaults.
- *
- * <p>This module ({@code pinot-segment-spi}) does not contain a concrete builder, so the test
- * uses an in-line anonymous subclass of {@link TextIndexConfig.AbstractBuilder}.
- */
+/// Slim-serialization contract for [TextIndexConfig].
 public class TextIndexConfigSerializationTest {
 
   @Test
-  public void testDefaultBuiltConfigSerializesToEmptyJson()
+  public void testRoundTripAllNull()
       throws Exception {
     TextIndexConfig config = newBuilder().build();
 
-    JsonNode node = serializeToNode(config);
+    assertOnlyKeys(serializeToNode(config));
+    assertRoundTripIdempotent(config);
 
-    assertOnlyKeys(node);
+    // Getters fall back to documented defaults.
+    assertEquals(config.isEnableQueryCache(), false);
+    assertEquals(config.isUseANDForMultiTermQueries(), false);
+    assertEquals(config.isLuceneUseCompoundFile(), true);
+    assertEquals(config.getLuceneMaxBufferSizeMB(), 500);
+    assertEquals(config.getLuceneAnalyzerClass(), FieldConfig.TEXT_INDEX_DEFAULT_LUCENE_ANALYZER_CLASS);
+    assertEquals(config.getLuceneQueryParserClass(), FieldConfig.TEXT_INDEX_DEFAULT_LUCENE_QUERY_PARSER_CLASS);
+    assertEquals(config.isEnablePrefixSuffixMatchingInPhraseQueries(), false);
+    assertEquals(config.isReuseMutableIndex(), false);
+    assertEquals(config.getLuceneNRTCachingDirectoryMaxBufferSizeMB(), 0);
+    assertEquals(config.isUseLogByteSizeMergePolicy(), false);
+    assertEquals(config.isCaseSensitive(), false);
+    assertEquals(config.isStoreInSegmentFile(), false);
   }
 
   @Test
-  public void testDisabledTrueIsMinimal()
+  public void testRoundTripPartial()
       throws Exception {
-    // TextIndexConfig.DISABLED is constructed with luceneUseCompoundFile=false (vs. default true),
-    // so the slim form correctly carries that one extra field beyond "disabled". This documents
-    // an intentional quirk of the DISABLED constant rather than a serializer bug.
-    JsonNode node = serializeToNode(TextIndexConfig.DISABLED);
-
-    assertOnlyKeys(node, "disabled", "luceneUseCompoundFile");
-    assertTrue(node.get("disabled").asBoolean());
-    assertTrue(!node.get("luceneUseCompoundFile").asBoolean());
-  }
-
-  @Test
-  public void testNonDefaultLuceneMaxBufferSizeMBEmitted()
-      throws Exception {
-    TextIndexConfig config = newBuilder().withLuceneMaxBufferSizeMB(1024).build();
+    TextIndexConfig config = newBuilder().withLuceneMaxBufferSizeMB(1024).withCaseSensitive(true).build();
 
     JsonNode node = serializeToNode(config);
-
-    assertOnlyKeys(node, "luceneMaxBufferSizeMB");
+    assertOnlyKeys(node, "luceneMaxBufferSizeMB", "caseSensitive");
     assertEquals(node.get("luceneMaxBufferSizeMB").asInt(), 1024);
+    assertTrue(node.get("caseSensitive").asBoolean());
+    assertRoundTripIdempotent(config);
+
+    assertEquals(config.getLuceneMaxBufferSizeMB(), 1024);
+    assertTrue(config.isCaseSensitive());
+    assertEquals(config.isLuceneUseCompoundFile(), true); // default applied
+  }
+
+  @Test
+  public void testRoundTripAllSet()
+      throws Exception {
+    TextIndexConfig config = newBuilder()
+        .withUseANDForMultiTermQueries(true)
+        .withStopWordsInclude(List.of("the", "a"))
+        .withStopWordsExclude(List.of("is"))
+        .withLuceneUseCompoundFile(false)
+        .withLuceneMaxBufferSizeMB(800)
+        .withLuceneAnalyzerClass("org.example.MyAnalyzer")
+        .withLuceneAnalyzerClassArgs(List.of("foo"))
+        .withLuceneAnalyzerClassArgTypes(List.of("java.lang.String"))
+        .withLuceneQueryParserClass("org.example.MyParser")
+        .withEnablePrefixSuffixMatchingInPhraseQueries(true)
+        .withReuseMutableIndex(true)
+        .withLuceneNRTCachingDirectoryMaxBufferSizeMB(64)
+        .withUseLogByteSizeMergePolicy(true)
+        .withDocIdTranslatorMode("Default")
+        .withCaseSensitive(true)
+        .withStoreInSegmentFile(true)
+        .build();
+    // queryCache is not exposed via the Builder; flip it via copy-constructor pattern.
+
+    JsonNode node = serializeToNode(config);
+    assertTrue(node.has("useANDForMultiTermQueries"));
+    assertTrue(node.has("stopWordsInclude"));
+    assertTrue(node.has("stopWordsExclude"));
+    assertTrue(node.has("luceneUseCompoundFile"));
+    assertTrue(node.has("luceneMaxBufferSizeMB"));
+    assertTrue(node.has("luceneAnalyzerClass"));
+    assertTrue(node.has("luceneAnalyzerClassArgs"));
+    assertTrue(node.has("luceneAnalyzerClassArgTypes"));
+    assertTrue(node.has("luceneQueryParserClass"));
+    assertTrue(node.has("enablePrefixSuffixMatchingInPhraseQueries"));
+    assertTrue(node.has("reuseMutableIndex"));
+    assertTrue(node.has("luceneNRTCachingDirectoryMaxBufferSizeMB"));
+    assertTrue(node.has("useLogByteSizeMergePolicy"));
+    assertTrue(node.has("docIdTranslatorMode"));
+    assertTrue(node.has("caseSensitive"));
+    assertTrue(node.has("storeInSegmentFile"));
+    assertRoundTripIdempotent(config);
+  }
+
+  @Test
+  public void testDisabledConstantOnlyEmitsDisabled()
+      throws Exception {
+    JsonNode node = serializeToNode(TextIndexConfig.DISABLED);
+    assertOnlyKeys(node, "disabled");
+    assertTrue(node.get("disabled").asBoolean());
   }
 
   @Test
@@ -89,33 +140,23 @@ public class TextIndexConfigSerializationTest {
   }
 
   @Test
-  public void testCaseSensitiveAndStoreInSegmentFileEmittedWhenNonDefault()
+  public void testExplicitDefaultPreserved()
       throws Exception {
-    TextIndexConfig config = newBuilder()
-        .withCaseSensitive(true)
-        .withStoreInSegmentFile(true)
-        .build();
-
+    // Build via the wrapper @JsonCreator directly (the Builder path uses primitive fields for binary
+    // compat and therefore can't preserve explicit-default). User explicitly sets
+    // luceneUseCompoundFile=true (today's default). Slim form keeps the key so a future default
+    // change does not silently swallow user intent.
+    TextIndexConfig config = new TextIndexConfig(Boolean.FALSE, null, null, null, null, null,
+        Boolean.TRUE, null, null, (Object) null, (Object) null, null, null, null, null, null, null,
+        null, null);
     JsonNode node = serializeToNode(config);
+    assertOnlyKeys(node, "luceneUseCompoundFile");
+    assertEquals(node.get("luceneUseCompoundFile").asBoolean(), true);
 
-    assertOnlyKeys(node, "caseSensitive", "storeInSegmentFile");
-  }
-
-  @Test
-  public void testFatJsonStillDeserializes()
-      throws Exception {
-    String fat = "{"
-        + "\"disabled\":false,"
-        + "\"luceneUseCompoundFile\":true,"
-        + "\"luceneMaxBufferSizeMB\":500,"
-        + "\"reuseMutableIndex\":false,"
-        + "\"caseSensitive\":false,"
-        + "\"storeInSegmentFile\":false"
-        + "}";
-
-    TextIndexConfig config = JsonUtils.stringToObject(fat, TextIndexConfig.class);
-
-    assertOnlyKeys(serializeToNode(config));
+    TextIndexConfig nullConfig = new TextIndexConfig(Boolean.FALSE, null, null, null, null, null, null, null, null,
+        (Object) null, (Object) null, null, null, null, null, null, null, null, null);
+    assertNotEquals(config, nullConfig,
+        "Explicit-default-value config must NOT equal the all-null ctor output");
   }
 
   @Test
@@ -125,7 +166,6 @@ public class TextIndexConfigSerializationTest {
         .withLuceneMaxBufferSizeMB(800)
         .withCaseSensitive(true)
         .build();
-
     assertEquals(serializeToNode(config), config.toJsonObject());
   }
 
@@ -133,18 +173,13 @@ public class TextIndexConfigSerializationTest {
   public void testFreshObjectMapperUsesJsonValue()
       throws Exception {
     TextIndexConfig config = newBuilder().withCaseSensitive(true).build();
-
     String json = new ObjectMapper().writeValueAsString(config);
-
     assertEquals(JsonUtils.stringToJsonNode(json), config.toJsonObject());
   }
 
   // ---- Helpers ----
 
-  /**
-   * Builds a concrete subclass of the abstract builder that no-ops {@code withProperties()}.
-   * Tests do not exercise the property-bag path; they target the explicit fluent setters.
-   */
+  /// Anonymous concrete builder for tests; this module has no production builder subclass.
   private static TextIndexConfig.AbstractBuilder newBuilder() {
     return new TextIndexConfig.AbstractBuilder() {
       @Override
@@ -163,5 +198,14 @@ public class TextIndexConfigSerializationTest {
     Set<String> actual = new HashSet<>();
     node.fieldNames().forEachRemaining(actual::add);
     assertEquals(actual, Set.of(expectedKeys), "Unexpected key set: " + node);
+  }
+
+  private static void assertRoundTripIdempotent(TextIndexConfig original)
+      throws Exception {
+    JsonNode firstNode = serializeToNode(original);
+    TextIndexConfig restored =
+        JsonUtils.stringToObject(JsonUtils.objectToString(original), TextIndexConfig.class);
+    JsonNode secondNode = serializeToNode(restored);
+    assertEquals(secondNode, firstNode, "Slim form must be byte-equivalent across a round-trip");
   }
 }

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/TextIndexConfigSerializationTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/TextIndexConfigSerializationTest.java
@@ -1,0 +1,167 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.spi.index;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+
+/**
+ * Verifies that {@link TextIndexConfig} Jackson serialization uses the curated
+ * {@code @JsonValue toJsonObject()} method and emits each of the 18 lucene defaults only when
+ * the field differs from its constant default. Empty / null lists are treated as defaults.
+ *
+ * <p>This module ({@code pinot-segment-spi}) does not contain a concrete builder, so the test
+ * uses an in-line anonymous subclass of {@link TextIndexConfig.AbstractBuilder}.
+ */
+public class TextIndexConfigSerializationTest {
+
+  @Test
+  public void testDefaultBuiltConfigSerializesToEmptyJson()
+      throws Exception {
+    TextIndexConfig config = newBuilder().build();
+
+    JsonNode node = serializeToNode(config);
+
+    assertOnlyKeys(node);
+  }
+
+  @Test
+  public void testDisabledTrueIsMinimal()
+      throws Exception {
+    // TextIndexConfig.DISABLED is constructed with luceneUseCompoundFile=false (vs. default true),
+    // so the slim form correctly carries that one extra field beyond "disabled". This documents
+    // an intentional quirk of the DISABLED constant rather than a serializer bug.
+    JsonNode node = serializeToNode(TextIndexConfig.DISABLED);
+
+    assertOnlyKeys(node, "disabled", "luceneUseCompoundFile");
+    assertTrue(node.get("disabled").asBoolean());
+    assertTrue(!node.get("luceneUseCompoundFile").asBoolean());
+  }
+
+  @Test
+  public void testNonDefaultLuceneMaxBufferSizeMBEmitted()
+      throws Exception {
+    TextIndexConfig config = newBuilder().withLuceneMaxBufferSizeMB(1024).build();
+
+    JsonNode node = serializeToNode(config);
+
+    assertOnlyKeys(node, "luceneMaxBufferSizeMB");
+    assertEquals(node.get("luceneMaxBufferSizeMB").asInt(), 1024);
+  }
+
+  @Test
+  public void testStopWordsIncludeEmittedOnlyWhenNonEmpty()
+      throws Exception {
+    TextIndexConfig empty = newBuilder().withStopWordsInclude(List.of()).build();
+    assertOnlyKeys(serializeToNode(empty));
+
+    TextIndexConfig populated = newBuilder().withStopWordsInclude(List.of("the", "a")).build();
+    JsonNode node = serializeToNode(populated);
+    assertOnlyKeys(node, "stopWordsInclude");
+    assertEquals(node.get("stopWordsInclude").size(), 2);
+  }
+
+  @Test
+  public void testCaseSensitiveAndStoreInSegmentFileEmittedWhenNonDefault()
+      throws Exception {
+    TextIndexConfig config = newBuilder()
+        .withCaseSensitive(true)
+        .withStoreInSegmentFile(true)
+        .build();
+
+    JsonNode node = serializeToNode(config);
+
+    assertOnlyKeys(node, "caseSensitive", "storeInSegmentFile");
+  }
+
+  @Test
+  public void testFatJsonStillDeserializes()
+      throws Exception {
+    String fat = "{"
+        + "\"disabled\":false,"
+        + "\"luceneUseCompoundFile\":true,"
+        + "\"luceneMaxBufferSizeMB\":500,"
+        + "\"reuseMutableIndex\":false,"
+        + "\"caseSensitive\":false,"
+        + "\"storeInSegmentFile\":false"
+        + "}";
+
+    TextIndexConfig config = JsonUtils.stringToObject(fat, TextIndexConfig.class);
+
+    assertOnlyKeys(serializeToNode(config));
+  }
+
+  @Test
+  public void testJacksonSerializationMatchesToJsonObject()
+      throws Exception {
+    TextIndexConfig config = newBuilder()
+        .withLuceneMaxBufferSizeMB(800)
+        .withCaseSensitive(true)
+        .build();
+
+    assertEquals(serializeToNode(config), config.toJsonObject());
+  }
+
+  @Test
+  public void testFreshObjectMapperUsesJsonValue()
+      throws Exception {
+    TextIndexConfig config = newBuilder().withCaseSensitive(true).build();
+
+    String json = new ObjectMapper().writeValueAsString(config);
+
+    assertEquals(JsonUtils.stringToJsonNode(json), config.toJsonObject());
+  }
+
+  // ---- Helpers ----
+
+  /**
+   * Builds a concrete subclass of the abstract builder that no-ops {@code withProperties()}.
+   * Tests do not exercise the property-bag path; they target the explicit fluent setters.
+   */
+  private static TextIndexConfig.AbstractBuilder newBuilder() {
+    return new TextIndexConfig.AbstractBuilder() {
+      @Override
+      public TextIndexConfig.AbstractBuilder withProperties(@Nullable Map<String, String> textIndexProperties) {
+        return this;
+      }
+    };
+  }
+
+  private static JsonNode serializeToNode(Object pojo)
+      throws Exception {
+    return JsonUtils.stringToJsonNode(JsonUtils.objectToString(pojo));
+  }
+
+  private static void assertOnlyKeys(JsonNode node, String... expectedKeys) {
+    Set<String> actual = new HashSet<>();
+    node.fieldNames().forEachRemaining(actual::add);
+    assertEquals(actual, Set.of(expectedKeys), "Unexpected key set: " + node);
+  }
+}

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/TextIndexConfigTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/TextIndexConfigTest.java
@@ -210,14 +210,16 @@ public class TextIndexConfigTest {
     assertTrue(originalConfig.getLuceneAnalyzerClassArgs().isEmpty());
     assertTrue(originalConfig.getLuceneAnalyzerClassArgTypes().isEmpty());
 
-    // Serialize to JSON - this produces the problematic format with empty arrays
+    // Serialize to JSON. Under slim serialization, empty list defaults are omitted entirely,
+    // which is strictly safer than the pre-existing "[]" output that previously triggered the
+    // "Cannot deserialize String from Array" bug. The round-trip below still verifies semantic
+    // equivalence; we just no longer assert on the legacy "[]" wire shape.
     final String serialized = JsonUtils.objectToString(originalConfig);
 
-    // Verify serialized JSON contains the array format that was causing the bug
-    assertTrue(serialized.contains("\"luceneAnalyzerClassArgs\":[]"),
-        "Serialized JSON should contain luceneAnalyzerClassArgs as empty array");
-    assertTrue(serialized.contains("\"luceneAnalyzerClassArgTypes\":[]"),
-        "Serialized JSON should contain luceneAnalyzerClassArgTypes as empty array");
+    assertFalse(serialized.contains("\"luceneAnalyzerClassArgs\":[]"),
+        "Slim serialization must omit empty luceneAnalyzerClassArgs, not emit '[]': " + serialized);
+    assertFalse(serialized.contains("\"luceneAnalyzerClassArgTypes\":[]"),
+        "Slim serialization must omit empty luceneAnalyzerClassArgTypes, not emit '[]': " + serialized);
 
     // Deserialize back
     final TextIndexConfig deserializedConfig = JsonUtils.stringToObject(serialized, TextIndexConfig.class);

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/VectorConfigTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/VectorConfigTest.java
@@ -138,7 +138,9 @@ public class VectorConfigTest {
       throws JsonProcessingException {
     VectorIndexConfig initialConf = new VectorIndexConfig(false);
 
-    String serialized = "{\"disabled\":false,\"vectorDimension\":0,\"version\":0}";
+    // Slim form omits dim/version when not configured. The "{}" round-trip is the canonical
+    // shape; explicit zero values would survive as Integer.valueOf(0) and break field equality.
+    String serialized = "{}";
     VectorIndexConfig vectorIndexConfig = JsonUtils.stringToObject(serialized, VectorIndexConfig.class);
 
     Assert.assertEquals(vectorIndexConfig, initialConf, "Unexpected configuration after reading " + serialized);

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/VectorConfigTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/VectorConfigTest.java
@@ -42,7 +42,7 @@ public class VectorConfigTest {
     assertFalse(config.isDisabled(), "Unexpected disabled");
     assertNull(config.getVectorIndexType(), "Unexpected vectorIndexType");
     assertNull(config.getVectorDistanceFunction(), "Unexpected vectorDistanceFunction");
-    assertNull(config.getProperties(), "unexpected properties");
+    assertTrue(config.getProperties().isEmpty(), "unexpected properties");
     assertEquals(config.getVectorDimension(), 0);
     assertEquals(config.getVersion(), 0);
   }
@@ -56,7 +56,7 @@ public class VectorConfigTest {
     assertFalse(config.isDisabled(), "Unexpected disabled");
     assertNull(config.getVectorIndexType(), "Unexpected vectorIndexType");
     assertNull(config.getVectorDistanceFunction(), "Unexpected vectorDistanceFunction");
-    assertNull(config.getProperties(), "unexpected properties");
+    assertTrue(config.getProperties().isEmpty(), "unexpected properties");
     assertEquals(config.getVectorDimension(), 0);
     assertEquals(config.getVersion(), 0);
   }
@@ -70,7 +70,7 @@ public class VectorConfigTest {
     assertFalse(config.isDisabled(), "Unexpected disabled");
     assertNull(config.getVectorIndexType(), "Unexpected vectorIndexType");
     assertNull(config.getVectorDistanceFunction(), "Unexpected vectorDistanceFunction");
-    assertNull(config.getProperties(), "unexpected properties");
+    assertTrue(config.getProperties().isEmpty(), "unexpected properties");
     assertEquals(config.getVectorDimension(), 0);
     assertEquals(config.getVersion(), 0);
   }
@@ -84,7 +84,7 @@ public class VectorConfigTest {
     assertTrue(config.isDisabled(), "Unexpected disabled");
     assertNull(config.getVectorIndexType(), "Unexpected vectorIndexType");
     assertNull(config.getVectorDistanceFunction(), "Unexpected vectorDistanceFunction");
-    assertNull(config.getProperties(), "unexpected properties");
+    assertTrue(config.getProperties().isEmpty(), "unexpected properties");
     assertEquals(config.getVectorDimension(), 0);
     assertEquals(config.getVersion(), 0);
   }

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/VectorConfigTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/VectorConfigTest.java
@@ -126,7 +126,8 @@ public class VectorConfigTest {
     VectorIndexConfig initialConf = new VectorIndexConfig(false);
 
     String confAsJson = JsonUtils.objectToString(initialConf);
-    Assert.assertEquals(confAsJson, "{\"disabled\":false,\"vectorDimension\":0,\"version\":0}");
+    // Slim serialization: disabled=false and primitive int defaults (0) are omitted.
+    Assert.assertEquals(confAsJson, "{}");
 
     VectorIndexConfig readConf = JsonUtils.stringToObject(confAsJson, VectorIndexConfig.class);
     Assert.assertEquals(readConf, initialConf, "Unexpected configuration after serialization and deserialization");

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/column/ColumnIndexContainerTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/column/ColumnIndexContainerTest.java
@@ -69,7 +69,7 @@ public class ColumnIndexContainerTest {
   }
 
   private static VectorIndexConfig createVectorConfig(String backend) {
-    return new VectorIndexConfig(false, backend, 8, 1, VectorIndexConfig.VectorDistanceFunction.COSINE,
+    return new VectorIndexConfig(Boolean.FALSE, backend, 8, 1, VectorIndexConfig.VectorDistanceFunction.COSINE,
         Map.of("vectorIndexType", backend));
   }
 

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/creator/H3IndexConfigSerializationTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/creator/H3IndexConfigSerializationTest.java
@@ -1,0 +1,115 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.spi.index.creator;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.apache.pinot.segment.spi.index.reader.H3IndexResolution;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+
+/**
+ * Verifies that {@link H3IndexConfig} Jackson serialization uses the curated
+ * {@code @JsonValue toJsonObject()} method. The JSON key is {@code "resolution"} (singular),
+ * matching the {@code @JsonProperty} on the {@code @JsonCreator} parameter.
+ */
+public class H3IndexConfigSerializationTest {
+
+  @Test
+  public void testDisabledIsMinimal()
+      throws Exception {
+    JsonNode node = serializeToNode(H3IndexConfig.DISABLED);
+
+    assertOnlyKeys(node, "disabled");
+    assertTrue(node.get("disabled").asBoolean());
+  }
+
+  @Test
+  public void testResolutionEmittedWhenSet()
+      throws Exception {
+    H3IndexConfig config = new H3IndexConfig(new H3IndexResolution(List.of(5, 6)));
+
+    JsonNode node = serializeToNode(config);
+
+    assertOnlyKeys(node, "resolution");
+    // Resolution serializes as an int list via H3IndexResolution.ToIntListConverted.
+    assertEquals(node.get("resolution").size(), 2);
+  }
+
+  @Test
+  public void testJsonKeyIsSingularResolution()
+      throws Exception {
+    H3IndexConfig config = new H3IndexConfig(new H3IndexResolution(List.of(7)));
+
+    JsonNode node = serializeToNode(config);
+
+    assertTrue(node.has("resolution"));
+    assertTrue(!node.has("resolutions"), "Key must be singular 'resolution': " + node);
+  }
+
+  @Test
+  public void testFatJsonStillDeserializes()
+      throws Exception {
+    String fat = "{\"disabled\":false,\"resolution\":[5,6,7]}";
+
+    H3IndexConfig config = JsonUtils.stringToObject(fat, H3IndexConfig.class);
+
+    JsonNode node = serializeToNode(config);
+    assertOnlyKeys(node, "resolution");
+    assertEquals(node.get("resolution").size(), 3);
+  }
+
+  @Test
+  public void testJacksonSerializationMatchesToJsonObject()
+      throws Exception {
+    H3IndexConfig config = new H3IndexConfig(new H3IndexResolution(List.of(5)));
+
+    assertEquals(serializeToNode(config), config.toJsonObject());
+  }
+
+  @Test
+  public void testFreshObjectMapperUsesJsonValue()
+      throws Exception {
+    H3IndexConfig config = new H3IndexConfig(new H3IndexResolution(List.of(5)));
+
+    String json = new ObjectMapper().writeValueAsString(config);
+
+    assertEquals(JsonUtils.stringToJsonNode(json), config.toJsonObject());
+  }
+
+  // ---- Helpers ----
+
+  private static JsonNode serializeToNode(Object pojo)
+      throws Exception {
+    return JsonUtils.stringToJsonNode(JsonUtils.objectToString(pojo));
+  }
+
+  private static void assertOnlyKeys(JsonNode node, String... expectedKeys) {
+    Set<String> actual = new HashSet<>();
+    node.fieldNames().forEachRemaining(actual::add);
+    assertEquals(actual, Set.of(expectedKeys), "Unexpected key set: " + node);
+  }
+}

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/creator/H3IndexConfigTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/creator/H3IndexConfigTest.java
@@ -91,7 +91,8 @@ public class H3IndexConfigTest {
     H3IndexConfig initialConf = new H3IndexConfig(new H3IndexResolution(Lists.newArrayList(5, 6, 13)));
 
     String confAsJson = JsonUtils.objectToString(initialConf);
-    Assert.assertEquals(confAsJson, "{\"disabled\":false,\"resolution\":[5,6,13]}");
+    // Slim serialization: disabled=false (the default) is omitted; only non-default fields are emitted.
+    Assert.assertEquals(confAsJson, "{\"resolution\":[5,6,13]}");
 
     H3IndexConfig readConf = JsonUtils.stringToObject(confAsJson, H3IndexConfig.class);
     Assert.assertEquals(readConf, initialConf, "Unexpected configuration after serialization and deserialization");

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/creator/VectorIndexConfigSerializationTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/creator/VectorIndexConfigSerializationTest.java
@@ -27,74 +27,103 @@ import org.apache.pinot.spi.utils.JsonUtils;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
 
-/**
- * Verifies that {@link VectorIndexConfig} Jackson serialization uses the curated
- * {@code @JsonValue toJsonObject()} method and emits each field only when it differs from its
- * class default.
- *
- * <p>{@code vectorDimension} and {@code version} are primitive {@code int} in the
- * {@code @JsonCreator}, so a value of {@code 0} is indistinguishable from absent and is
- * intentionally omitted from the slim form.
- */
+/// Slim-serialization contract for [VectorIndexConfig].
 public class VectorIndexConfigSerializationTest {
 
   @Test
-  public void testEnabledDefaultIsEmpty()
+  public void testRoundTripAllNull()
       throws Exception {
-    VectorIndexConfig config = new VectorIndexConfig(false);
+    VectorIndexConfig config = new VectorIndexConfig(null, null, null, null, null, null);
 
     JsonNode node = serializeToNode(config);
-
     assertOnlyKeys(node);
+    assertRoundTripIdempotent(config);
+
+    assertEquals(config.getVectorIndexType(), null);
+    assertEquals(config.getVectorDimension(), 0);
+    assertEquals(config.getVersion(), 0);
+    assertEquals(config.getVectorDistanceFunction(), null);
+    assertNotNull(config.getProperties());
+    assertTrue(config.getProperties().isEmpty());
   }
 
   @Test
-  public void testDisabledTrueIsMinimal()
+  public void testRoundTripPartial()
       throws Exception {
-    JsonNode node = serializeToNode(VectorIndexConfig.DISABLED);
-
-    assertOnlyKeys(node, "disabled");
-    assertTrue(node.get("disabled").asBoolean());
-  }
-
-  @Test
-  public void testZeroDimensionAndVersionOmitted()
-      throws Exception {
-    // vectorDimension=0 and version=0 are treated as defaults (primitive int absent).
-    VectorIndexConfig config = new VectorIndexConfig(false, null, 0, 0, null, null);
+    VectorIndexConfig config = new VectorIndexConfig(null, "HNSW", 768, null, null, null);
 
     JsonNode node = serializeToNode(config);
+    assertOnlyKeys(node, "vectorIndexType", "vectorDimension");
+    assertEquals(node.get("vectorIndexType").asText(), "HNSW");
+    assertEquals(node.get("vectorDimension").asInt(), 768);
+    assertRoundTripIdempotent(config);
 
-    assertOnlyKeys(node);
+    assertEquals(config.getVectorIndexType(), "HNSW");
+    assertEquals(config.getVectorDimension(), 768);
+    assertEquals(config.getVersion(), 0);
   }
 
   @Test
-  public void testFullySpecifiedConfigEmitsAllFields()
+  public void testRoundTripAllSet()
       throws Exception {
-    VectorIndexConfig config = new VectorIndexConfig(false, "HNSW", 768, 1,
+    VectorIndexConfig config = new VectorIndexConfig(Boolean.FALSE, "HNSW", 768, 1,
         VectorIndexConfig.VectorDistanceFunction.COSINE, Map.of("maxCon", "16"));
 
     JsonNode node = serializeToNode(config);
-
     assertOnlyKeys(node, "vectorIndexType", "vectorDimension", "version", "vectorDistanceFunction", "properties");
     assertEquals(node.get("vectorIndexType").asText(), "HNSW");
     assertEquals(node.get("vectorDimension").asInt(), 768);
     assertEquals(node.get("version").asInt(), 1);
     assertEquals(node.get("vectorDistanceFunction").asText(), "COSINE");
     assertEquals(node.get("properties").get("maxCon").asText(), "16");
+    assertRoundTripIdempotent(config);
+
+    assertEquals(config.getVectorIndexType(), "HNSW");
+    assertEquals(config.getVectorDimension(), 768);
+    assertEquals(config.getVersion(), 1);
+    assertEquals(config.getVectorDistanceFunction(), VectorIndexConfig.VectorDistanceFunction.COSINE);
+  }
+
+  @Test
+  public void testEnabledDefaultIsEmpty()
+      throws Exception {
+    VectorIndexConfig config = new VectorIndexConfig(false);
+    assertOnlyKeys(serializeToNode(config));
+  }
+
+  @Test
+  public void testDisabledTrueIsMinimal()
+      throws Exception {
+    JsonNode node = serializeToNode(VectorIndexConfig.DISABLED);
+    assertOnlyKeys(node, "disabled");
+    assertTrue(node.get("disabled").asBoolean());
+  }
+
+  @Test
+  public void testExplicitDefaultPreserved()
+      throws Exception {
+    // User explicitly says vectorDimension=0 (matches "absent" sentinel) — wrapper preserves the
+    // explicit Integer.valueOf(0). Slim form keeps the key so a future default change cannot
+    // silently swallow the user's intent.
+    VectorIndexConfig config = new VectorIndexConfig(null, null, 0, null, null, null);
+    JsonNode node = serializeToNode(config);
+    assertOnlyKeys(node, "vectorDimension");
+    assertEquals(node.get("vectorDimension").asInt(), 0);
+
+    assertNotEquals(config, new VectorIndexConfig(false),
+        "Explicit-zero config must NOT equal the all-null no-arg constructor");
   }
 
   @Test
   public void testEmptyPropertiesMapOmitted()
       throws Exception {
-    VectorIndexConfig config = new VectorIndexConfig(false, null, 0, 0, null, Map.of());
-
+    VectorIndexConfig config = new VectorIndexConfig(null, null, null, null, null, Map.of());
     JsonNode node = serializeToNode(config);
-
     assertOnlyKeys(node);
     assertNotNull(config.getProperties());
     assertTrue(config.getProperties().isEmpty());
@@ -115,37 +144,17 @@ public class VectorIndexConfigSerializationTest {
   }
 
   @Test
-  public void testFatJsonStillDeserializes()
-      throws Exception {
-    String fat = "{"
-        + "\"disabled\":false,"
-        + "\"vectorIndexType\":null,"
-        + "\"vectorDimension\":0,"
-        + "\"version\":0,"
-        + "\"vectorDistanceFunction\":null,"
-        + "\"properties\":null"
-        + "}";
-
-    VectorIndexConfig config = JsonUtils.stringToObject(fat, VectorIndexConfig.class);
-
-    assertOnlyKeys(serializeToNode(config));
-  }
-
-  @Test
   public void testJacksonSerializationMatchesToJsonObject()
       throws Exception {
-    VectorIndexConfig config = new VectorIndexConfig(false, "HNSW", 256, 1, null, null);
-
+    VectorIndexConfig config = new VectorIndexConfig(Boolean.FALSE, "HNSW", 256, 1, null, null);
     assertEquals(serializeToNode(config), config.toJsonObject());
   }
 
   @Test
   public void testFreshObjectMapperUsesJsonValue()
       throws Exception {
-    VectorIndexConfig config = new VectorIndexConfig(false, "HNSW", 128, 1, null, null);
-
+    VectorIndexConfig config = new VectorIndexConfig(Boolean.FALSE, "HNSW", 128, 1, null, null);
     String json = new ObjectMapper().writeValueAsString(config);
-
     assertEquals(JsonUtils.stringToJsonNode(json), config.toJsonObject());
   }
 
@@ -160,5 +169,14 @@ public class VectorIndexConfigSerializationTest {
     Set<String> actual = new HashSet<>();
     node.fieldNames().forEachRemaining(actual::add);
     assertEquals(actual, Set.of(expectedKeys), "Unexpected key set: " + node);
+  }
+
+  private static void assertRoundTripIdempotent(VectorIndexConfig original)
+      throws Exception {
+    JsonNode firstNode = serializeToNode(original);
+    VectorIndexConfig restored =
+        JsonUtils.stringToObject(JsonUtils.objectToString(original), VectorIndexConfig.class);
+    JsonNode secondNode = serializeToNode(restored);
+    assertEquals(secondNode, firstNode, "Slim form must be byte-equivalent across a round-trip");
   }
 }

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/creator/VectorIndexConfigSerializationTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/creator/VectorIndexConfigSerializationTest.java
@@ -1,0 +1,147 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.spi.index.creator;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+
+/**
+ * Verifies that {@link VectorIndexConfig} Jackson serialization uses the curated
+ * {@code @JsonValue toJsonObject()} method and emits each field only when it differs from its
+ * class default.
+ *
+ * <p>{@code vectorDimension} and {@code version} are primitive {@code int} in the
+ * {@code @JsonCreator}, so a value of {@code 0} is indistinguishable from absent and is
+ * intentionally omitted from the slim form.
+ */
+public class VectorIndexConfigSerializationTest {
+
+  @Test
+  public void testEnabledDefaultIsEmpty()
+      throws Exception {
+    VectorIndexConfig config = new VectorIndexConfig(false);
+
+    JsonNode node = serializeToNode(config);
+
+    assertOnlyKeys(node);
+  }
+
+  @Test
+  public void testDisabledTrueIsMinimal()
+      throws Exception {
+    JsonNode node = serializeToNode(VectorIndexConfig.DISABLED);
+
+    assertOnlyKeys(node, "disabled");
+    assertTrue(node.get("disabled").asBoolean());
+  }
+
+  @Test
+  public void testZeroDimensionAndVersionOmitted()
+      throws Exception {
+    // vectorDimension=0 and version=0 are treated as defaults (primitive int absent).
+    VectorIndexConfig config = new VectorIndexConfig(false, null, 0, 0, null, null);
+
+    JsonNode node = serializeToNode(config);
+
+    assertOnlyKeys(node);
+  }
+
+  @Test
+  public void testFullySpecifiedConfigEmitsAllFields()
+      throws Exception {
+    VectorIndexConfig config = new VectorIndexConfig(false, "HNSW", 768, 1,
+        VectorIndexConfig.VectorDistanceFunction.COSINE, Map.of("maxCon", "16"));
+
+    JsonNode node = serializeToNode(config);
+
+    assertOnlyKeys(node, "vectorIndexType", "vectorDimension", "version", "vectorDistanceFunction", "properties");
+    assertEquals(node.get("vectorIndexType").asText(), "HNSW");
+    assertEquals(node.get("vectorDimension").asInt(), 768);
+    assertEquals(node.get("version").asInt(), 1);
+    assertEquals(node.get("vectorDistanceFunction").asText(), "COSINE");
+    assertEquals(node.get("properties").get("maxCon").asText(), "16");
+  }
+
+  @Test
+  public void testEmptyPropertiesMapOmitted()
+      throws Exception {
+    VectorIndexConfig config = new VectorIndexConfig(false, null, 0, 0, null, Map.of());
+
+    JsonNode node = serializeToNode(config);
+
+    assertOnlyKeys(node);
+  }
+
+  @Test
+  public void testFatJsonStillDeserializes()
+      throws Exception {
+    String fat = "{"
+        + "\"disabled\":false,"
+        + "\"vectorIndexType\":null,"
+        + "\"vectorDimension\":0,"
+        + "\"version\":0,"
+        + "\"vectorDistanceFunction\":null,"
+        + "\"properties\":null"
+        + "}";
+
+    VectorIndexConfig config = JsonUtils.stringToObject(fat, VectorIndexConfig.class);
+
+    assertOnlyKeys(serializeToNode(config));
+  }
+
+  @Test
+  public void testJacksonSerializationMatchesToJsonObject()
+      throws Exception {
+    VectorIndexConfig config = new VectorIndexConfig(false, "HNSW", 256, 1, null, null);
+
+    assertEquals(serializeToNode(config), config.toJsonObject());
+  }
+
+  @Test
+  public void testFreshObjectMapperUsesJsonValue()
+      throws Exception {
+    VectorIndexConfig config = new VectorIndexConfig(false, "HNSW", 128, 1, null, null);
+
+    String json = new ObjectMapper().writeValueAsString(config);
+
+    assertEquals(JsonUtils.stringToJsonNode(json), config.toJsonObject());
+  }
+
+  // ---- Helpers ----
+
+  private static JsonNode serializeToNode(Object pojo)
+      throws Exception {
+    return JsonUtils.stringToJsonNode(JsonUtils.objectToString(pojo));
+  }
+
+  private static void assertOnlyKeys(JsonNode node, String... expectedKeys) {
+    Set<String> actual = new HashSet<>();
+    node.fieldNames().forEachRemaining(actual::add);
+    assertEquals(actual, Set.of(expectedKeys), "Unexpected key set: " + node);
+  }
+}

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/creator/VectorIndexConfigSerializationTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/creator/VectorIndexConfigSerializationTest.java
@@ -27,6 +27,7 @@ import org.apache.pinot.spi.utils.JsonUtils;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
 
@@ -95,6 +96,22 @@ public class VectorIndexConfigSerializationTest {
     JsonNode node = serializeToNode(config);
 
     assertOnlyKeys(node);
+    assertNotNull(config.getProperties());
+    assertTrue(config.getProperties().isEmpty());
+  }
+
+  @Test
+  public void testPropertiesNullAndEmptyMapRoundTripToNonNull()
+      throws Exception {
+    VectorIndexConfig fromNull = JsonUtils.stringToObject("{\"properties\":null}", VectorIndexConfig.class);
+    assertNotNull(fromNull.getProperties());
+    assertTrue(fromNull.getProperties().isEmpty());
+    assertOnlyKeys(serializeToNode(fromNull));
+
+    VectorIndexConfig fromEmpty = JsonUtils.stringToObject("{\"properties\":{}}", VectorIndexConfig.class);
+    assertNotNull(fromEmpty.getProperties());
+    assertTrue(fromEmpty.getProperties().isEmpty());
+    assertOnlyKeys(serializeToNode(fromEmpty));
   }
 
   @Test

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/creator/VectorIndexConfigValidatorTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/creator/VectorIndexConfigValidatorTest.java
@@ -53,7 +53,7 @@ public class VectorIndexConfigValidatorTest {
 
   @Test
   public void testBackwardCompatEmptyVectorIndexTypeDefaultsToHnsw() {
-    VectorIndexConfig config = new VectorIndexConfig(false, "", 768, 1,
+    VectorIndexConfig config = new VectorIndexConfig(Boolean.FALSE, "", 768, 1,
         VectorIndexConfig.VectorDistanceFunction.COSINE, null);
     assertEquals(VectorIndexConfigValidator.resolveBackendType(config), VectorBackendType.HNSW);
   }
@@ -110,7 +110,7 @@ public class VectorIndexConfigValidatorTest {
   @Test
   public void testValidHnswConfigMinimal() {
     // Minimal config: only required fields
-    VectorIndexConfig config = new VectorIndexConfig(false, "HNSW", 768, 1,
+    VectorIndexConfig config = new VectorIndexConfig(Boolean.FALSE, "HNSW", 768, 1,
         VectorIndexConfig.VectorDistanceFunction.COSINE, null);
     VectorIndexConfigValidator.validate(config);
   }
@@ -150,7 +150,7 @@ public class VectorIndexConfigValidatorTest {
 
   @Test
   public void testValidIvfFlatConfigMinimal() {
-    VectorIndexConfig config = new VectorIndexConfig(false, "IVF_FLAT", 768, 1,
+    VectorIndexConfig config = new VectorIndexConfig(Boolean.FALSE, "IVF_FLAT", 768, 1,
         VectorIndexConfig.VectorDistanceFunction.COSINE, null);
     VectorIndexConfigValidator.validate(config);
   }
@@ -371,7 +371,7 @@ public class VectorIndexConfigValidatorTest {
   @Test(expectedExceptions = IllegalArgumentException.class,
       expectedExceptionsMessageRegExp = ".*vectorDimension must be a positive integer.*")
   public void testRejectZeroDimension() {
-    VectorIndexConfig config = new VectorIndexConfig(false, "HNSW", 0, 1,
+    VectorIndexConfig config = new VectorIndexConfig(Boolean.FALSE, "HNSW", 0, 1,
         VectorIndexConfig.VectorDistanceFunction.COSINE, null);
     VectorIndexConfigValidator.validate(config);
   }
@@ -379,7 +379,7 @@ public class VectorIndexConfigValidatorTest {
   @Test(expectedExceptions = IllegalArgumentException.class,
       expectedExceptionsMessageRegExp = ".*vectorDimension must be a positive integer.*")
   public void testRejectNegativeDimension() {
-    VectorIndexConfig config = new VectorIndexConfig(false, "HNSW", -5, 1,
+    VectorIndexConfig config = new VectorIndexConfig(Boolean.FALSE, "HNSW", -5, 1,
         VectorIndexConfig.VectorDistanceFunction.COSINE, null);
     VectorIndexConfigValidator.validate(config);
   }
@@ -387,7 +387,7 @@ public class VectorIndexConfigValidatorTest {
   @Test(expectedExceptions = IllegalArgumentException.class,
       expectedExceptionsMessageRegExp = ".*vectorDistanceFunction is required.*")
   public void testRejectNullDistanceFunction() {
-    VectorIndexConfig config = new VectorIndexConfig(false, "HNSW", 768, 1, null, null);
+    VectorIndexConfig config = new VectorIndexConfig(Boolean.FALSE, "HNSW", 768, 1, null, null);
     VectorIndexConfigValidator.validate(config);
   }
 
@@ -516,21 +516,21 @@ public class VectorIndexConfigValidatorTest {
   @Test
   public void testAllDistanceFunctions() {
     for (VectorIndexConfig.VectorDistanceFunction df : VectorIndexConfig.VectorDistanceFunction.values()) {
-      VectorIndexConfig config = new VectorIndexConfig(false, "HNSW", 768, 1, df, null);
+      VectorIndexConfig config = new VectorIndexConfig(Boolean.FALSE, "HNSW", 768, 1, df, null);
       VectorIndexConfigValidator.validate(config);
     }
   }
 
   @Test
   public void testL2DistanceFunctionForIvfFlat() {
-    VectorIndexConfig config = new VectorIndexConfig(false, "IVF_FLAT", 768, 1,
+    VectorIndexConfig config = new VectorIndexConfig(Boolean.FALSE, "IVF_FLAT", 768, 1,
         VectorIndexConfig.VectorDistanceFunction.L2, null);
     VectorIndexConfigValidator.validate(config);
   }
 
   @Test
   public void testL2DistanceFunctionForIvfPq() {
-    VectorIndexConfig config = new VectorIndexConfig(false, "IVF_PQ", 768, 1,
+    VectorIndexConfig config = new VectorIndexConfig(Boolean.FALSE, "IVF_PQ", 768, 1,
         VectorIndexConfig.VectorDistanceFunction.L2,
         Map.of("nlist", "128", "pqM", "32", "pqNbits", "8", "trainSampleSize", "10000"));
     VectorIndexConfigValidator.validate(config);
@@ -553,43 +553,43 @@ public class VectorIndexConfigValidatorTest {
 
   @Test
   public void testResolveBackendTypeExplicitHnsw() {
-    VectorIndexConfig config = new VectorIndexConfig(false, "HNSW", 768, 1,
+    VectorIndexConfig config = new VectorIndexConfig(Boolean.FALSE, "HNSW", 768, 1,
         VectorIndexConfig.VectorDistanceFunction.COSINE, null);
     assertEquals(config.resolveBackendType(), VectorBackendType.HNSW);
   }
 
   @Test
   public void testResolveBackendTypeExplicitIvfFlat() {
-    VectorIndexConfig config = new VectorIndexConfig(false, "IVF_FLAT", 768, 1,
+    VectorIndexConfig config = new VectorIndexConfig(Boolean.FALSE, "IVF_FLAT", 768, 1,
         VectorIndexConfig.VectorDistanceFunction.COSINE, null);
     assertEquals(config.resolveBackendType(), VectorBackendType.IVF_FLAT);
   }
 
   @Test
   public void testResolveBackendTypeExplicitIvfPq() {
-    VectorIndexConfig config = new VectorIndexConfig(false, "IVF_PQ", 768, 1,
+    VectorIndexConfig config = new VectorIndexConfig(Boolean.FALSE, "IVF_PQ", 768, 1,
         VectorIndexConfig.VectorDistanceFunction.COSINE, null);
     assertEquals(config.resolveBackendType(), VectorBackendType.IVF_PQ);
   }
 
   @Test
   public void testResolveBackendTypeCaseInsensitive() {
-    VectorIndexConfig config = new VectorIndexConfig(false, "hnsw", 768, 1,
+    VectorIndexConfig config = new VectorIndexConfig(Boolean.FALSE, "hnsw", 768, 1,
         VectorIndexConfig.VectorDistanceFunction.COSINE, null);
     assertEquals(config.resolveBackendType(), VectorBackendType.HNSW);
 
-    VectorIndexConfig config2 = new VectorIndexConfig(false, "ivf_flat", 768, 1,
+    VectorIndexConfig config2 = new VectorIndexConfig(Boolean.FALSE, "ivf_flat", 768, 1,
         VectorIndexConfig.VectorDistanceFunction.COSINE, null);
     assertEquals(config2.resolveBackendType(), VectorBackendType.IVF_FLAT);
 
-    VectorIndexConfig config3 = new VectorIndexConfig(false, "ivf_pq", 768, 1,
+    VectorIndexConfig config3 = new VectorIndexConfig(Boolean.FALSE, "ivf_pq", 768, 1,
         VectorIndexConfig.VectorDistanceFunction.COSINE, null);
     assertEquals(config3.resolveBackendType(), VectorBackendType.IVF_PQ);
   }
 
   @Test
   public void testResolveBackendTypeNullDefaultsToHnsw() {
-    VectorIndexConfig config = new VectorIndexConfig(false, null, 768, 1,
+    VectorIndexConfig config = new VectorIndexConfig(Boolean.FALSE, null, 768, 1,
         VectorIndexConfig.VectorDistanceFunction.COSINE, null);
     assertEquals(config.resolveBackendType(), VectorBackendType.HNSW);
   }
@@ -597,7 +597,7 @@ public class VectorIndexConfigValidatorTest {
   @Test(expectedExceptions = IllegalArgumentException.class,
       expectedExceptionsMessageRegExp = ".*Unknown vector backend type.*FAISS.*")
   public void testResolveBackendTypeUnknown() {
-    VectorIndexConfig config = new VectorIndexConfig(false, "FAISS", 768, 1,
+    VectorIndexConfig config = new VectorIndexConfig(Boolean.FALSE, "FAISS", 768, 1,
         VectorIndexConfig.VectorDistanceFunction.COSINE, null);
     config.resolveBackendType();
   }
@@ -748,7 +748,7 @@ public class VectorIndexConfigValidatorTest {
     assert trainSampleSize >= nlist : "trainSampleSize must be >= nlist";
 
     // Verify the defaults pass validation
-    VectorIndexConfig config = new VectorIndexConfig(false, "IVF_PQ", 128, 1,
+    VectorIndexConfig config = new VectorIndexConfig(Boolean.FALSE, "IVF_PQ", 128, 1,
         VectorIndexConfig.VectorDistanceFunction.EUCLIDEAN, defaults);
     VectorIndexConfigValidator.validate(config);
   }
@@ -760,7 +760,7 @@ public class VectorIndexConfigValidatorTest {
     assert 512 % pqM == 0 : "pqM must evenly divide dimension=512";
     assert pqM <= 64 : "pqM should be <= dim/8 for dim=512";
 
-    VectorIndexConfig config = new VectorIndexConfig(false, "IVF_PQ", 512, 1,
+    VectorIndexConfig config = new VectorIndexConfig(Boolean.FALSE, "IVF_PQ", 512, 1,
         VectorIndexConfig.VectorDistanceFunction.COSINE, defaults);
     VectorIndexConfigValidator.validate(config);
   }
@@ -773,7 +773,7 @@ public class VectorIndexConfigValidatorTest {
     assert 7 % pqM == 0 : "pqM must evenly divide dimension=7";
     assertEquals(pqM, 1, "For prime dimension=7, pqM should fall back to 1");
 
-    VectorIndexConfig config = new VectorIndexConfig(false, "IVF_PQ", 7, 1,
+    VectorIndexConfig config = new VectorIndexConfig(Boolean.FALSE, "IVF_PQ", 7, 1,
         VectorIndexConfig.VectorDistanceFunction.EUCLIDEAN, defaults);
     VectorIndexConfigValidator.validate(config);
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/BloomFilterConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/BloomFilterConfig.java
@@ -28,63 +28,68 @@ import java.util.Objects;
 
 public class BloomFilterConfig extends IndexConfig {
   public static final double DEFAULT_FPP = 0.05;
-  public static final BloomFilterConfig DEFAULT = new BloomFilterConfig(BloomFilterConfig.DEFAULT_FPP, 0, false);
-  public static final BloomFilterConfig DISABLED = new BloomFilterConfig(true, BloomFilterConfig.DEFAULT_FPP, 0,
-      false);
+  public static final BloomFilterConfig DEFAULT = new BloomFilterConfig(null, null, null, null);
+  public static final BloomFilterConfig DISABLED = new BloomFilterConfig(true, null, null, null);
 
-  private final double _fpp;
-  private final int _maxSizeInBytes;
-  private final boolean _loadOnHeap;
+  private final Double _fpp;
+  private final Integer _maxSizeInBytes;
+  private final Boolean _loadOnHeap;
 
   public BloomFilterConfig(double fpp, int maxSizeInBytes, boolean loadOnHeap) {
-    this(false, fpp, maxSizeInBytes, loadOnHeap);
+    // Forward to the wrapper @JsonCreator. Boolean.FALSE for arg0 disambiguates from the deprecated
+    // primitive overload below (which would otherwise tie on overload resolution).
+    this(Boolean.FALSE, Double.valueOf(fpp), Integer.valueOf(maxSizeInBytes), Boolean.valueOf(loadOnHeap));
+  }
+
+  /// Binary-compat delegate for the pre-wrapper `(Boolean, double, int, boolean)` ctor. Kept so existing
+  /// compiled call sites resolved to the primitive signature continue to link. Prefer the wrapper-typed
+  /// `@JsonCreator` ctor below for new code.
+  @Deprecated
+  public BloomFilterConfig(Boolean disabled, double fpp, int maxSizeInBytes, boolean loadOnHeap) {
+    this(disabled, Double.valueOf(fpp), Integer.valueOf(maxSizeInBytes), Boolean.valueOf(loadOnHeap));
   }
 
   @JsonCreator
-  public BloomFilterConfig(@JsonProperty("disabled") Boolean disabled, @JsonProperty(value = "fpp") double fpp,
-      @JsonProperty(value = "maxSizeInBytes") int maxSizeInBytes,
-      @JsonProperty(value = "loadOnHeap") boolean loadOnHeap) {
+  public BloomFilterConfig(@JsonProperty("disabled") Boolean disabled, @JsonProperty(value = "fpp") Double fpp,
+      @JsonProperty(value = "maxSizeInBytes") Integer maxSizeInBytes,
+      @JsonProperty(value = "loadOnHeap") Boolean loadOnHeap) {
     super(disabled);
-    if (fpp != 0.0) {
+    if (fpp != null && fpp != 0.0) {
       Preconditions.checkArgument(fpp > 0.0 && fpp < 1.0, "Invalid fpp (false positive probability): %s", fpp);
-      _fpp = fpp;
-    } else {
-      _fpp = DEFAULT_FPP;
     }
+    _fpp = fpp;
     _maxSizeInBytes = maxSizeInBytes;
     _loadOnHeap = loadOnHeap;
   }
 
   public double getFpp() {
-    return _fpp;
+    return _fpp != null && _fpp != 0.0 ? _fpp : DEFAULT_FPP;
   }
 
   public int getMaxSizeInBytes() {
-    return _maxSizeInBytes;
+    return _maxSizeInBytes != null ? _maxSizeInBytes : 0;
   }
 
   public boolean isLoadOnHeap() {
-    return _loadOnHeap;
+    return Boolean.TRUE.equals(_loadOnHeap);
   }
 
-  /**
-   * Curated slim serializer. See {@link IndexConfig#toJsonObject()} for the rationale.
-   *
-   * <p>Note: the constructor coerces {@code fpp == 0.0} to {@link #DEFAULT_FPP}, so the only
-   * sane slim form for the default {@code fpp} is omitting the key entirely.
-   */
+  /// Curated slim serializer. See [IndexConfig#toJsonObject()] for the rationale.
+  ///
+  /// Each field is emitted only when it was explicitly configured (non-null). Sentinel `fpp == 0.0` is also
+  /// emitted as-is — the runtime getter still resolves to [#DEFAULT_FPP] for that legacy sentinel.
   @Override
   @JsonValue
   public ObjectNode toJsonObject() {
     ObjectNode node = super.toJsonObject();
-    if (Double.compare(_fpp, DEFAULT_FPP) != 0) {
+    if (_fpp != null) {
       node.put("fpp", _fpp);
     }
-    if (_maxSizeInBytes != 0) {
+    if (_maxSizeInBytes != null) {
       node.put("maxSizeInBytes", _maxSizeInBytes);
     }
-    if (_loadOnHeap) {
-      node.put("loadOnHeap", true);
+    if (_loadOnHeap != null) {
+      node.put("loadOnHeap", _loadOnHeap);
     }
     return node;
   }
@@ -101,12 +106,12 @@ public class BloomFilterConfig extends IndexConfig {
       return false;
     }
     BloomFilterConfig that = (BloomFilterConfig) o;
-    return Double.compare(that._fpp, _fpp) == 0 && _maxSizeInBytes == that._maxSizeInBytes
-        && _loadOnHeap == that._loadOnHeap && isEnabled() == that.isEnabled();
+    return Objects.equals(_fpp, that._fpp) && Objects.equals(_maxSizeInBytes, that._maxSizeInBytes)
+        && Objects.equals(_loadOnHeap, that._loadOnHeap);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(super.hashCode(), _fpp, _maxSizeInBytes, _loadOnHeap, isEnabled());
+    return Objects.hash(super.hashCode(), _fpp, _maxSizeInBytes, _loadOnHeap);
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/BloomFilterConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/BloomFilterConfig.java
@@ -20,6 +20,8 @@ package org.apache.pinot.spi.config.table;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Preconditions;
 import java.util.Objects;
 
@@ -63,6 +65,28 @@ public class BloomFilterConfig extends IndexConfig {
 
   public boolean isLoadOnHeap() {
     return _loadOnHeap;
+  }
+
+  /**
+   * Curated slim serializer. See {@link IndexConfig#toJsonObject()} for the rationale.
+   *
+   * <p>Note: the constructor coerces {@code fpp == 0.0} to {@link #DEFAULT_FPP}, so the only
+   * sane slim form for the default {@code fpp} is omitting the key entirely.
+   */
+  @Override
+  @JsonValue
+  public ObjectNode toJsonObject() {
+    ObjectNode node = super.toJsonObject();
+    if (Double.compare(_fpp, DEFAULT_FPP) != 0) {
+      node.put("fpp", _fpp);
+    }
+    if (_maxSizeInBytes != 0) {
+      node.put("maxSizeInBytes", _maxSizeInBytes);
+    }
+    if (_loadOnHeap) {
+      node.put("loadOnHeap", true);
+    }
+    return node;
   }
 
   @Override

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/IndexConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/IndexConfig.java
@@ -21,8 +21,11 @@ package org.apache.pinot.spi.config.table;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.Objects;
 import org.apache.pinot.spi.config.BaseJsonConfig;
+import org.apache.pinot.spi.utils.JsonUtils;
 
 
 /**
@@ -52,6 +55,25 @@ public class IndexConfig extends BaseJsonConfig {
   @JsonIgnore
   public boolean isEnabled() {
     return !_disabled;
+  }
+
+  /**
+   * Curated Jackson serializer. Annotated with {@link JsonValue} so Jackson skips default bean
+   * introspection and uses this method as the sole source of truth, emitting only fields whose
+   * value differs from the class default. Subclasses override and call {@code super.toJsonObject()}
+   * first to inherit the {@code disabled} key handling.
+   *
+   * <p>This mirrors the slim-serialization pattern introduced for {@code Schema} and
+   * {@code TableConfigs} in apache/pinot#17558 and ensures user-supplied slim index configs do not
+   * get fattened with defaults on the first round-trip through any Pinot {@code ObjectMapper}.
+   */
+  @JsonValue
+  public ObjectNode toJsonObject() {
+    ObjectNode node = JsonUtils.newObjectNode();
+    if (_disabled) {
+      node.put("disabled", true);
+    }
+    return node;
   }
 
   @Override

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/IndexConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/IndexConfig.java
@@ -28,49 +28,43 @@ import org.apache.pinot.spi.config.BaseJsonConfig;
 import org.apache.pinot.spi.utils.JsonUtils;
 
 
-/**
- * This is the base class used to configure indexes.
- *
- * The common logic between all indexes is that they can be enabled or disabled.
- *
- * Indexes that do not require extra configuration can directly use this class.
- */
+/// Base class for index configs.
+///
+/// Common logic across all indexes: each can be enabled or disabled. Indexes with no extra
+/// configuration can use this class directly.
 public class IndexConfig extends BaseJsonConfig {
-  public static final IndexConfig ENABLED = new IndexConfig(false);
+  public static final IndexConfig ENABLED = new IndexConfig((Boolean) null);
   public static final IndexConfig DISABLED = new IndexConfig(true);
-  private final boolean _disabled;
+  private final Boolean _disabled;
 
-  /**
-   * @param disabled whether the config is disabled. Null is considered enabled.
-   */
+  /// @param disabled whether the config is disabled. `null` and `false` both mean enabled — explicit `false` is
+  /// normalized to `null` so the slim form omits the key (every index defaults to enabled and that default is
+  /// extremely unlikely to flip).
   @JsonCreator
   public IndexConfig(@JsonProperty("disabled") Boolean disabled) {
-    _disabled = Boolean.TRUE.equals(disabled);
+    _disabled = Boolean.TRUE.equals(disabled) ? Boolean.TRUE : null;
   }
 
   public boolean isDisabled() {
-    return _disabled;
+    return Boolean.TRUE.equals(_disabled);
   }
 
   @JsonIgnore
   public boolean isEnabled() {
-    return !_disabled;
+    return !isDisabled();
   }
 
-  /**
-   * Curated Jackson serializer. Annotated with {@link JsonValue} so Jackson skips default bean
-   * introspection and uses this method as the sole source of truth, emitting only fields whose
-   * value differs from the class default. Subclasses override and call {@code super.toJsonObject()}
-   * first to inherit the {@code disabled} key handling.
-   *
-   * <p>This mirrors the slim-serialization pattern introduced for {@code Schema} and
-   * {@code TableConfigs} in apache/pinot#17558 and ensures user-supplied slim index configs do not
-   * get fattened with defaults on the first round-trip through any Pinot {@code ObjectMapper}.
-   */
+  /// Curated Jackson serializer. Annotated with [JsonValue] so Jackson skips default bean introspection and uses
+  /// this method as the sole source of truth, emitting only fields that were explicitly configured (non-null).
+  /// Subclasses override and call `super.toJsonObject()` first to inherit the `disabled` key handling.
+  ///
+  /// This mirrors the slim-serialization pattern introduced for `Schema` and `TableConfigs` in apache/pinot#17558
+  /// and ensures user-supplied slim index configs do not get fattened with defaults on the first round-trip
+  /// through any Pinot `ObjectMapper`.
   @JsonValue
   public ObjectNode toJsonObject() {
     ObjectNode node = JsonUtils.newObjectNode();
-    if (_disabled) {
+    if (Boolean.TRUE.equals(_disabled)) {
       node.put("disabled", true);
     }
     return node;
@@ -85,7 +79,7 @@ public class IndexConfig extends BaseJsonConfig {
       return false;
     }
     IndexConfig that = (IndexConfig) o;
-    return _disabled == that._disabled;
+    return Objects.equals(_disabled, that._disabled);
   }
 
   @Override

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/JsonIndexConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/JsonIndexConfig.java
@@ -29,50 +29,46 @@ import javax.annotation.Nullable;
 import org.apache.pinot.spi.utils.JsonUtils;
 
 
-/**
- * Configs related to the JSON index:
- * - maxLevels: Max levels to flatten the json object (array is also counted as one level), non-positive value means
- *              unlimited
- * - excludeArray: Whether to exclude array when flattening the object
- * - disableCrossArrayUnnest: Whether to not unnest multiple arrays (unique combination of all elements)
- * - includePaths: Only include the given paths, e.g. "$.a.b", "$.a.c[*]" (mutual exclusive with excludePaths). Paths
- *                 under the included paths will be included, e.g. "$.a.b.c" will be included when "$.a.b" is configured
- *                 to be included.
- * - excludePaths: Exclude the given paths, e.g. "$.a.b", "$.a.c[*]" (mutual exclusive with includePaths). Paths under
- *                 the excluded paths will also be excluded, e.g. "$.a.b.c" will be excluded when "$.a.b" is configured
- *                 to be excluded.
- * - excludeFields: Exclude the given fields, e.g. "b", "c", even if it is under the included paths.
- * - indexPaths: Index the given paths, e.g. "*.*", "a.**". Paths matches the indexed paths will be indexed.
- *               This config could work together with other configs, e.g. includePaths, excludePaths, maxLevels but
- *               usually does not have to because it should be flexible enough to config any scenarios. By default, it
- *               is working as "**" this is to allow everything.
- *               Check {@link org.apache.pinot.spi.utils.JsonSchemaTreeNode} for more details.
- * - maxValueLength: Exclude field values which are longer than this length. A value of "0" disables this filter.
- *                   Excluded values will be replaced with JsonUtils.SKIPPED_VALUE_REPLACEMENT.
- * - skipInvalidJson: If the raw data is not a valid json string, then replace with {"":SKIPPED_VALUE_REPLACEMENT}
- *                    and continue indexing on following Json records.
- */
+/// Configs related to the JSON index:
+///
+/// - `maxLevels`: Max levels to flatten the json object (array is also counted as one level); non-positive value
+///   means unlimited.
+/// - `excludeArray`: Whether to exclude array when flattening the object.
+/// - `disableCrossArrayUnnest`: Whether to not unnest multiple arrays (unique combination of all elements).
+/// - `includePaths`: Only include the given paths, e.g. `"$.a.b"`, `"$.a.c[*]"` (mutually exclusive with
+///   `excludePaths`). Paths under the included paths will be included, e.g. `"$.a.b.c"` will be included when
+///   `"$.a.b"` is configured to be included.
+/// - `excludePaths`: Exclude the given paths, e.g. `"$.a.b"`, `"$.a.c[*]"` (mutually exclusive with `includePaths`).
+///   Paths under the excluded paths will also be excluded, e.g. `"$.a.b.c"` will be excluded when `"$.a.b"` is
+///   configured to be excluded.
+/// - `excludeFields`: Exclude the given fields, e.g. `"b"`, `"c"`, even if it is under the included paths.
+/// - `indexPaths`: Index the given paths, e.g. `"*.*"`, `"a.**"`. Paths matching the indexed paths will be indexed.
+///   This config could work together with other configs (e.g. `includePaths`, `excludePaths`, `maxLevels`) but usually
+///   does not have to because it should be flexible enough to config any scenarios. By default it works as `"**"`
+///   to allow everything. Check [org.apache.pinot.spi.utils.JsonSchemaTreeNode] for more details.
+/// - `maxValueLength`: Exclude field values which are longer than this length. A value of `0` disables this filter.
+///   Excluded values will be replaced with `JsonUtils.SKIPPED_VALUE_REPLACEMENT`.
+/// - `skipInvalidJson`: If the raw data is not a valid json string, replace with `{"":SKIPPED_VALUE_REPLACEMENT}`
+///   and continue indexing on following Json records.
 public class JsonIndexConfig extends IndexConfig {
   public static final JsonIndexConfig DEFAULT = new JsonIndexConfig();
   public static final JsonIndexConfig DISABLED = new JsonIndexConfig(true);
 
-  private int _maxLevels = -1;
-  private boolean _excludeArray = false;
-  private boolean _disableCrossArrayUnnest = false;
+  private Integer _maxLevels;
+  private Boolean _excludeArray;
+  private Boolean _disableCrossArrayUnnest;
   private Set<String> _includePaths;
   private Set<String> _excludePaths;
   private Set<String> _excludeFields;
   private Set<String> _indexPaths;
-  private int _maxValueLength = 0;
-  private boolean _skipInvalidJson = false;
+  private Integer _maxValueLength;
+  private Boolean _skipInvalidJson;
 
-  /**
-   * Max on-heap bytes size of the mutable JSON index. An underestimate, as this excludes the posting lists.
-   */
+  /// Max on-heap bytes size of the mutable JSON index. An underestimate, as this excludes the posting lists.
   private Long _maxBytesSize;
 
   public JsonIndexConfig() {
-    super(false);
+    super(null);
   }
 
   public JsonIndexConfig(Boolean disabled) {
@@ -80,15 +76,15 @@ public class JsonIndexConfig extends IndexConfig {
   }
 
   @JsonCreator
-  public JsonIndexConfig(@JsonProperty("disabled") Boolean disabled, @JsonProperty("maxLevels") int maxLevels,
-      @JsonProperty("excludeArray") boolean excludeArray,
-      @JsonProperty("disableCrossArrayUnnest") boolean disableCrossArrayUnnest,
+  public JsonIndexConfig(@JsonProperty("disabled") Boolean disabled, @JsonProperty("maxLevels") Integer maxLevels,
+      @JsonProperty("excludeArray") Boolean excludeArray,
+      @JsonProperty("disableCrossArrayUnnest") Boolean disableCrossArrayUnnest,
       @JsonProperty("includePaths") @Nullable Set<String> includePaths,
       @JsonProperty("excludePaths") @Nullable Set<String> excludePaths,
       @JsonProperty("excludeFields") @Nullable Set<String> excludeFields,
       @JsonProperty("indexPaths") @Nullable Set<String> indexPaths,
-      @JsonProperty("maxValueLength") int maxValueLength,
-      @JsonProperty("skipInvalidJson") boolean skipInvalidJson,
+      @JsonProperty("maxValueLength") Integer maxValueLength,
+      @JsonProperty("skipInvalidJson") Boolean skipInvalidJson,
       @JsonProperty("maxBytesSize") @Nullable Long maxBytesSize) {
     super(disabled);
     _maxLevels = maxLevels;
@@ -107,11 +103,23 @@ public class JsonIndexConfig extends IndexConfig {
       @Nullable Set<String> includePaths, @Nullable Set<String> excludePaths, @Nullable Set<String> excludeFields,
       @Nullable Set<String> indexPaths, int maxValueLength, boolean skipInvalidJson) {
     this(disabled, maxLevels, excludeArray, disableCrossArrayUnnest, includePaths, excludePaths, excludeFields,
-        indexPaths, maxValueLength, skipInvalidJson, null);
+        indexPaths, maxValueLength, skipInvalidJson, (Long) null);
+  }
+
+  /// Binary-compat delegate for the pre-wrapper 11-arg primitive ctor. Kept so existing compiled call sites
+  /// resolved to the primitive signature continue to link. Prefer the wrapper-typed `@JsonCreator` ctor for
+  /// new code.
+  @Deprecated
+  public JsonIndexConfig(Boolean disabled, int maxLevels, boolean excludeArray, boolean disableCrossArrayUnnest,
+      @Nullable Set<String> includePaths, @Nullable Set<String> excludePaths, @Nullable Set<String> excludeFields,
+      @Nullable Set<String> indexPaths, int maxValueLength, boolean skipInvalidJson, @Nullable Long maxBytesSize) {
+    this(disabled, Integer.valueOf(maxLevels), Boolean.valueOf(excludeArray), Boolean.valueOf(disableCrossArrayUnnest),
+        includePaths, excludePaths, excludeFields, indexPaths, Integer.valueOf(maxValueLength),
+        Boolean.valueOf(skipInvalidJson), maxBytesSize);
   }
 
   public int getMaxLevels() {
-    return _maxLevels;
+    return _maxLevels != null ? _maxLevels : -1;
   }
 
   public void setMaxLevels(int maxLevels) {
@@ -119,7 +127,7 @@ public class JsonIndexConfig extends IndexConfig {
   }
 
   public boolean isExcludeArray() {
-    return _excludeArray;
+    return Boolean.TRUE.equals(_excludeArray);
   }
 
   public void setExcludeArray(boolean excludeArray) {
@@ -127,7 +135,7 @@ public class JsonIndexConfig extends IndexConfig {
   }
 
   public boolean isDisableCrossArrayUnnest() {
-    return _disableCrossArrayUnnest;
+    return Boolean.TRUE.equals(_disableCrossArrayUnnest);
   }
 
   public void setDisableCrossArrayUnnest(boolean disableCrossArrayUnnest) {
@@ -176,7 +184,7 @@ public class JsonIndexConfig extends IndexConfig {
   }
 
   public int getMaxValueLength() {
-    return _maxValueLength;
+    return _maxValueLength != null ? _maxValueLength : 0;
   }
 
   public void setMaxValueLength(int maxValueLength) {
@@ -184,7 +192,7 @@ public class JsonIndexConfig extends IndexConfig {
   }
 
   public boolean getSkipInvalidJson() {
-    return _skipInvalidJson;
+    return Boolean.TRUE.equals(_skipInvalidJson);
   }
 
   public void setSkipInvalidJson(boolean skipInvalidJson) {
@@ -200,24 +208,20 @@ public class JsonIndexConfig extends IndexConfig {
     _maxBytesSize = maxBytesSize;
   }
 
-  /**
-   * Curated slim serializer. See {@link IndexConfig#toJsonObject()} for the rationale.
-   */
+  /// Curated slim serializer. See [IndexConfig#toJsonObject()] for the rationale. Each field is emitted
+  /// only when explicitly configured (non-null wrapper).
   @Override
   @JsonValue
   public ObjectNode toJsonObject() {
     ObjectNode node = super.toJsonObject();
-    // Both -1 (no-arg ctor field default) and 0 (@JsonCreator primitive default) are functionally
-    // equivalent — JsonUtils.flatten() only consults maxLevels when > 0. Treat both as default
-    // and omit, which keeps the slim form idempotent under round-trip.
-    if (_maxLevels > 0) {
+    if (_maxLevels != null) {
       node.put("maxLevels", _maxLevels);
     }
-    if (_excludeArray) {
-      node.put("excludeArray", true);
+    if (_excludeArray != null) {
+      node.put("excludeArray", _excludeArray);
     }
-    if (_disableCrossArrayUnnest) {
-      node.put("disableCrossArrayUnnest", true);
+    if (_disableCrossArrayUnnest != null) {
+      node.put("disableCrossArrayUnnest", _disableCrossArrayUnnest);
     }
     if (_includePaths != null) {
       node.set("includePaths", JsonUtils.objectToJsonNode(_includePaths));
@@ -231,11 +235,11 @@ public class JsonIndexConfig extends IndexConfig {
     if (_indexPaths != null) {
       node.set("indexPaths", JsonUtils.objectToJsonNode(_indexPaths));
     }
-    if (_maxValueLength != 0) {
+    if (_maxValueLength != null) {
       node.put("maxValueLength", _maxValueLength);
     }
-    if (_skipInvalidJson) {
-      node.put("skipInvalidJson", true);
+    if (_skipInvalidJson != null) {
+      node.put("skipInvalidJson", _skipInvalidJson);
     }
     if (_maxBytesSize != null) {
       node.put("maxBytesSize", _maxBytesSize);
@@ -255,16 +259,21 @@ public class JsonIndexConfig extends IndexConfig {
       return false;
     }
     JsonIndexConfig config = (JsonIndexConfig) o;
-    return _maxLevels == config._maxLevels && _excludeArray == config._excludeArray
-        && _disableCrossArrayUnnest == config._disableCrossArrayUnnest && Objects.equals(_includePaths,
-        config._includePaths) && Objects.equals(_excludePaths, config._excludePaths) && Objects.equals(_excludeFields,
-        config._excludeFields) && _maxValueLength == config._maxValueLength
-        && _skipInvalidJson == config._skipInvalidJson;
+    return Objects.equals(_maxLevels, config._maxLevels)
+        && Objects.equals(_excludeArray, config._excludeArray)
+        && Objects.equals(_disableCrossArrayUnnest, config._disableCrossArrayUnnest)
+        && Objects.equals(_includePaths, config._includePaths)
+        && Objects.equals(_excludePaths, config._excludePaths)
+        && Objects.equals(_excludeFields, config._excludeFields)
+        && Objects.equals(_indexPaths, config._indexPaths)
+        && Objects.equals(_maxValueLength, config._maxValueLength)
+        && Objects.equals(_skipInvalidJson, config._skipInvalidJson)
+        && Objects.equals(_maxBytesSize, config._maxBytesSize);
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(super.hashCode(), _maxLevels, _excludeArray, _disableCrossArrayUnnest, _includePaths,
-        _excludePaths, _excludeFields, _maxValueLength, _skipInvalidJson);
+        _excludePaths, _excludeFields, _indexPaths, _maxValueLength, _skipInvalidJson, _maxBytesSize);
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/JsonIndexConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/JsonIndexConfig.java
@@ -20,10 +20,13 @@ package org.apache.pinot.spi.config.table;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Preconditions;
 import java.util.Objects;
 import java.util.Set;
 import javax.annotation.Nullable;
+import org.apache.pinot.spi.utils.JsonUtils;
 
 
 /**
@@ -195,6 +198,49 @@ public class JsonIndexConfig extends IndexConfig {
 
   public void setMaxBytesSize(@Nullable Long maxBytesSize) {
     _maxBytesSize = maxBytesSize;
+  }
+
+  /**
+   * Curated slim serializer. See {@link IndexConfig#toJsonObject()} for the rationale.
+   */
+  @Override
+  @JsonValue
+  public ObjectNode toJsonObject() {
+    ObjectNode node = super.toJsonObject();
+    // Both -1 (no-arg ctor field default) and 0 (@JsonCreator primitive default) are functionally
+    // equivalent — JsonUtils.flatten() only consults maxLevels when > 0. Treat both as default
+    // and omit, which keeps the slim form idempotent under round-trip.
+    if (_maxLevels > 0) {
+      node.put("maxLevels", _maxLevels);
+    }
+    if (_excludeArray) {
+      node.put("excludeArray", true);
+    }
+    if (_disableCrossArrayUnnest) {
+      node.put("disableCrossArrayUnnest", true);
+    }
+    if (_includePaths != null) {
+      node.set("includePaths", JsonUtils.objectToJsonNode(_includePaths));
+    }
+    if (_excludePaths != null) {
+      node.set("excludePaths", JsonUtils.objectToJsonNode(_excludePaths));
+    }
+    if (_excludeFields != null) {
+      node.set("excludeFields", JsonUtils.objectToJsonNode(_excludeFields));
+    }
+    if (_indexPaths != null) {
+      node.set("indexPaths", JsonUtils.objectToJsonNode(_indexPaths));
+    }
+    if (_maxValueLength != 0) {
+      node.put("maxValueLength", _maxValueLength);
+    }
+    if (_skipInvalidJson) {
+      node.put("skipInvalidJson", true);
+    }
+    if (_maxBytesSize != null) {
+      node.put("maxBytesSize", _maxBytesSize);
+    }
+    return node;
   }
 
   @Override

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/MultiColumnTextIndexConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/MultiColumnTextIndexConfig.java
@@ -20,10 +20,13 @@ package org.apache.pinot.spi.config.table;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.pinot.spi.config.BaseJsonConfig;
+import org.apache.pinot.spi.utils.JsonUtils;
 
 
 /** Index configuration for single text index containing multiple columns.
@@ -66,5 +69,23 @@ public class MultiColumnTextIndexConfig extends BaseJsonConfig {
   @Nullable
   public Map<String, Map<String, String>> getPerColumnProperties() {
     return _perColumnProperties;
+  }
+
+  /**
+   * Curated slim serializer. Standalone (not inheriting from {@link IndexConfig}) — this class
+   * extends {@link BaseJsonConfig} directly and has no {@code disabled} field. {@code columns}
+   * is required and is always emitted; the optional maps are emitted only when non-null.
+   */
+  @JsonValue
+  public ObjectNode toJsonObject() {
+    ObjectNode node = JsonUtils.newObjectNode();
+    node.set("columns", JsonUtils.objectToJsonNode(_columns));
+    if (_properties != null) {
+      node.set("properties", JsonUtils.objectToJsonNode(_properties));
+    }
+    if (_perColumnProperties != null) {
+      node.set("perColumnProperties", JsonUtils.objectToJsonNode(_perColumnProperties));
+    }
+    return node;
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/StarTreeIndexConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/StarTreeIndexConfig.java
@@ -20,11 +20,14 @@ package org.apache.pinot.spi.config.table;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Preconditions;
 import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.pinot.spi.config.BaseJsonConfig;
+import org.apache.pinot.spi.utils.JsonUtils;
 
 
 public class StarTreeIndexConfig extends BaseJsonConfig {
@@ -80,5 +83,31 @@ public class StarTreeIndexConfig extends BaseJsonConfig {
 
   public int getMaxLeafRecords() {
     return _maxLeafRecords;
+  }
+
+  /**
+   * Curated slim serializer. Standalone (not inheriting from {@link IndexConfig}) — this class
+   * extends {@link BaseJsonConfig} directly and has no {@code disabled} field. The constructor
+   * coerces empty optional lists to {@code null}, so the optional list fields are emitted only
+   * when non-null. {@code maxLeafRecords} is a primitive {@code int}; "absent" and {@code 0}
+   * collapse, so {@code 0} is treated as the default and omitted.
+   */
+  @JsonValue
+  public ObjectNode toJsonObject() {
+    ObjectNode node = JsonUtils.newObjectNode();
+    node.set("dimensionsSplitOrder", JsonUtils.objectToJsonNode(_dimensionsSplitOrder));
+    if (_skipStarNodeCreationForDimensions != null) {
+      node.set("skipStarNodeCreationForDimensions", JsonUtils.objectToJsonNode(_skipStarNodeCreationForDimensions));
+    }
+    if (_functionColumnPairs != null) {
+      node.set("functionColumnPairs", JsonUtils.objectToJsonNode(_functionColumnPairs));
+    }
+    if (_aggregationConfigs != null) {
+      node.set("aggregationConfigs", JsonUtils.objectToJsonNode(_aggregationConfigs));
+    }
+    if (_maxLeafRecords != 0) {
+      node.put("maxLeafRecords", _maxLeafRecords);
+    }
+    return node;
   }
 }

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/config/table/BloomFilterConfigSerializationTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/config/table/BloomFilterConfigSerializationTest.java
@@ -1,0 +1,158 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.config.table;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.HashSet;
+import java.util.Set;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+
+/**
+ * Verifies that {@link BloomFilterConfig} Jackson serialization uses the curated
+ * {@code @JsonValue toJsonObject()} method and emits each field only when it differs from its
+ * class default.
+ *
+ * <p>Calls out the {@code fpp == 0.0 → DEFAULT_FPP} ctor coercion: an explicit {@code 0.0} input
+ * is indistinguishable from "absent", so the only sane slim form for the default fpp is omission.
+ */
+public class BloomFilterConfigSerializationTest {
+
+  @Test
+  public void testDefaultPojoSerializesToEmptyJson()
+      throws Exception {
+    BloomFilterConfig config = BloomFilterConfig.DEFAULT;
+
+    JsonNode node = serializeToNode(config);
+
+    assertOnlyKeys(node);
+  }
+
+  @Test
+  public void testDisabledTrueIsMinimal()
+      throws Exception {
+    BloomFilterConfig config = BloomFilterConfig.DISABLED;
+
+    JsonNode node = serializeToNode(config);
+
+    assertOnlyKeys(node, "disabled");
+    assertTrue(node.get("disabled").asBoolean());
+  }
+
+  @Test
+  public void testNonDefaultFppEmitted()
+      throws Exception {
+    BloomFilterConfig config = new BloomFilterConfig(0.01, 0, false);
+
+    JsonNode node = serializeToNode(config);
+
+    assertOnlyKeys(node, "fpp");
+    assertEquals(node.get("fpp").asDouble(), 0.01);
+  }
+
+  @Test
+  public void testNonDefaultMaxSizeAndLoadOnHeapEmitted()
+      throws Exception {
+    BloomFilterConfig config = new BloomFilterConfig(BloomFilterConfig.DEFAULT_FPP, 1024, true);
+
+    JsonNode node = serializeToNode(config);
+
+    assertOnlyKeys(node, "maxSizeInBytes", "loadOnHeap");
+    assertEquals(node.get("maxSizeInBytes").asInt(), 1024);
+    assertTrue(node.get("loadOnHeap").asBoolean());
+  }
+
+  /**
+   * Documents the ctor coercion: {@code fpp == 0.0} → {@code DEFAULT_FPP}, so the slim output
+   * after a fat-input parse omits {@code fpp}, and the round-tripped POJO matches the default.
+   */
+  @Test
+  public void testFppZeroInputCoercedToDefaultAndOmittedOnSerialization()
+      throws Exception {
+    String fat = "{\"fpp\":0.0,\"maxSizeInBytes\":0,\"loadOnHeap\":false}";
+
+    BloomFilterConfig config = JsonUtils.stringToObject(fat, BloomFilterConfig.class);
+
+    assertEquals(config.getFpp(), BloomFilterConfig.DEFAULT_FPP);
+    assertOnlyKeys(serializeToNode(config));
+  }
+
+  @Test
+  public void testFatJsonStillDeserializes()
+      throws Exception {
+    // Pre-fix output explicitly carried the default fpp, so verify it round-trips back to slim.
+    String fat = "{\"disabled\":false,\"fpp\":0.05,\"maxSizeInBytes\":0,\"loadOnHeap\":false}";
+
+    BloomFilterConfig config = JsonUtils.stringToObject(fat, BloomFilterConfig.class);
+
+    assertOnlyKeys(serializeToNode(config));
+    assertEquals(config, BloomFilterConfig.DEFAULT);
+  }
+
+  @Test
+  public void testJacksonSerializationMatchesToJsonObject()
+      throws Exception {
+    BloomFilterConfig config = new BloomFilterConfig(0.02, 2048, true);
+
+    assertEquals(serializeToNode(config), config.toJsonObject());
+  }
+
+  @Test
+  public void testFreshObjectMapperUsesJsonValue()
+      throws Exception {
+    BloomFilterConfig config = new BloomFilterConfig(0.02, 0, false);
+
+    String json = new ObjectMapper().writeValueAsString(config);
+
+    assertEquals(JsonUtils.stringToJsonNode(json), config.toJsonObject());
+  }
+
+  @Test
+  public void testEqualPojosProduceIdenticalJson()
+      throws Exception {
+    BloomFilterConfig a = new BloomFilterConfig(0.01, 100, true);
+    BloomFilterConfig b = new BloomFilterConfig(0.01, 100, true);
+
+    assertEquals(a, b);
+    assertEquals(serializeToNode(a), serializeToNode(b));
+  }
+
+  // ---- Helpers ----
+
+  private static JsonNode serializeToNode(Object pojo)
+      throws Exception {
+    return JsonUtils.stringToJsonNode(JsonUtils.objectToString(pojo));
+  }
+
+  private static void assertOnlyKeys(JsonNode node, String... expectedKeys) {
+    Set<String> actual = new HashSet<>();
+    node.fieldNames().forEachRemaining(actual::add);
+    assertEquals(actual, Set.of(expectedKeys), "Unexpected key set: " + node);
+    // Defensive: ensure the resulting node doesn't accidentally carry stale "disabled" defaults.
+    if (!actual.contains("disabled")) {
+      assertFalse(node.has("disabled"));
+    }
+  }
+}

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/config/table/BloomFilterConfigSerializationTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/config/table/BloomFilterConfigSerializationTest.java
@@ -26,120 +26,144 @@ import org.apache.pinot.spi.utils.JsonUtils;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 
 
-/**
- * Verifies that {@link BloomFilterConfig} Jackson serialization uses the curated
- * {@code @JsonValue toJsonObject()} method and emits each field only when it differs from its
- * class default.
- *
- * <p>Calls out the {@code fpp == 0.0 → DEFAULT_FPP} ctor coercion: an explicit {@code 0.0} input
- * is indistinguishable from "absent", so the only sane slim form for the default fpp is omission.
- */
+/// Slim-serialization contract for [BloomFilterConfig] under the wrapper-typed contract:
+/// fields are stored raw (null = not configured), runtime getters apply defaults, the slim form
+/// emits only fields that were explicitly configured.
 public class BloomFilterConfigSerializationTest {
 
+  // ---- Round-trip matrix ----
+
   @Test
-  public void testDefaultPojoSerializesToEmptyJson()
+  public void testRoundTripAllNull()
       throws Exception {
-    BloomFilterConfig config = BloomFilterConfig.DEFAULT;
+    BloomFilterConfig config = new BloomFilterConfig(null, null, null, null);
 
     JsonNode node = serializeToNode(config);
-
     assertOnlyKeys(node);
+    assertRoundTripIdempotent(config);
+
+    // Getters fall back to documented defaults.
+    assertEquals(config.getFpp(), BloomFilterConfig.DEFAULT_FPP);
+    assertEquals(config.getMaxSizeInBytes(), 0);
+    assertEquals(config.isLoadOnHeap(), false);
   }
 
   @Test
-  public void testDisabledTrueIsMinimal()
+  public void testRoundTripPartial()
       throws Exception {
-    BloomFilterConfig config = BloomFilterConfig.DISABLED;
+    BloomFilterConfig config = new BloomFilterConfig(null, 0.01, null, null);
 
     JsonNode node = serializeToNode(config);
-
-    assertOnlyKeys(node, "disabled");
-    assertTrue(node.get("disabled").asBoolean());
-  }
-
-  @Test
-  public void testNonDefaultFppEmitted()
-      throws Exception {
-    BloomFilterConfig config = new BloomFilterConfig(0.01, 0, false);
-
-    JsonNode node = serializeToNode(config);
-
     assertOnlyKeys(node, "fpp");
     assertEquals(node.get("fpp").asDouble(), 0.01);
+    assertRoundTripIdempotent(config);
+
+    // Explicit field returns its value; null fields fall back.
+    assertEquals(config.getFpp(), 0.01);
+    assertEquals(config.getMaxSizeInBytes(), 0);
+    assertEquals(config.isLoadOnHeap(), false);
   }
 
   @Test
-  public void testNonDefaultMaxSizeAndLoadOnHeapEmitted()
+  public void testRoundTripAllSet()
       throws Exception {
-    BloomFilterConfig config = new BloomFilterConfig(BloomFilterConfig.DEFAULT_FPP, 1024, true);
+    BloomFilterConfig config = new BloomFilterConfig(null, 0.02, 2048, true);
 
     JsonNode node = serializeToNode(config);
-
-    assertOnlyKeys(node, "maxSizeInBytes", "loadOnHeap");
-    assertEquals(node.get("maxSizeInBytes").asInt(), 1024);
+    assertOnlyKeys(node, "fpp", "maxSizeInBytes", "loadOnHeap");
+    assertEquals(node.get("fpp").asDouble(), 0.02);
+    assertEquals(node.get("maxSizeInBytes").asInt(), 2048);
     assertTrue(node.get("loadOnHeap").asBoolean());
+    assertRoundTripIdempotent(config);
+
+    assertEquals(config.getFpp(), 0.02);
+    assertEquals(config.getMaxSizeInBytes(), 2048);
+    assertEquals(config.isLoadOnHeap(), true);
   }
 
-  /**
-   * Documents the ctor coercion: {@code fpp == 0.0} → {@code DEFAULT_FPP}, so the slim output
-   * after a fat-input parse omits {@code fpp}, and the round-tripped POJO matches the default.
-   */
+  // ---- Constants ----
+
   @Test
-  public void testFppZeroInputCoercedToDefaultAndOmittedOnSerialization()
+  public void testDefaultConstantSerializesEmpty()
       throws Exception {
-    String fat = "{\"fpp\":0.0,\"maxSizeInBytes\":0,\"loadOnHeap\":false}";
+    assertOnlyKeys(serializeToNode(BloomFilterConfig.DEFAULT));
+    assertRoundTripIdempotent(BloomFilterConfig.DEFAULT);
+  }
 
-    BloomFilterConfig config = JsonUtils.stringToObject(fat, BloomFilterConfig.class);
+  @Test
+  public void testDisabledConstantOnlyEmitsDisabled()
+      throws Exception {
+    JsonNode node = serializeToNode(BloomFilterConfig.DISABLED);
+    assertOnlyKeys(node, "disabled");
+    assertTrue(node.get("disabled").asBoolean());
+    assertRoundTripIdempotent(BloomFilterConfig.DISABLED);
+  }
 
+  // ---- The load-bearing distinction ----
+
+  @Test
+  public void testExplicitDefaultValueIsPreserved()
+      throws Exception {
+    // User sets fpp explicitly to today's default (0.05). Slim form keeps the key so a future
+    // default change does not silently swallow the user's intent.
+    BloomFilterConfig config = new BloomFilterConfig(null, BloomFilterConfig.DEFAULT_FPP, null, null);
+
+    JsonNode node = serializeToNode(config);
+    assertOnlyKeys(node, "fpp");
+    assertEquals(node.get("fpp").asDouble(), BloomFilterConfig.DEFAULT_FPP);
+
+    assertNotEquals(config, BloomFilterConfig.DEFAULT,
+        "Explicit-default-value config must not equal the all-null DEFAULT constant");
+  }
+
+  @Test
+  public void testFppZeroInputPreservedAsExplicit()
+      throws Exception {
+    // The historical sentinel `fpp == 0.0` was previously coerced to DEFAULT_FPP. With wrappers we
+    // keep the raw input so the slim form preserves it; the runtime getter still returns
+    // DEFAULT_FPP for the sentinel.
+    BloomFilterConfig config = JsonUtils.stringToObject("{\"fpp\":0.0}", BloomFilterConfig.class);
     assertEquals(config.getFpp(), BloomFilterConfig.DEFAULT_FPP);
-    assertOnlyKeys(serializeToNode(config));
+    assertOnlyKeys(serializeToNode(config), "fpp");
+  }
+
+  // ---- Validation preserved ----
+
+  @Test
+  public void testFppValidationRejectsOutOfRange() {
+    assertThrows(IllegalArgumentException.class,
+        () -> new BloomFilterConfig(null, 2.0, null, null));
+    assertThrows(IllegalArgumentException.class,
+        () -> new BloomFilterConfig(null, -0.5, null, null));
   }
 
   @Test
-  public void testFatJsonStillDeserializes()
-      throws Exception {
-    // Pre-fix output explicitly carried the default fpp, so verify it round-trips back to slim.
-    String fat = "{\"disabled\":false,\"fpp\":0.05,\"maxSizeInBytes\":0,\"loadOnHeap\":false}";
-
-    BloomFilterConfig config = JsonUtils.stringToObject(fat, BloomFilterConfig.class);
-
-    assertOnlyKeys(serializeToNode(config));
-    assertEquals(config, BloomFilterConfig.DEFAULT);
+  public void testFppNullSkipsValidation() {
+    // null bypasses validation — required so absent JSON keys don't throw.
+    new BloomFilterConfig(null, null, null, null);
   }
+
+  // ---- Helpers ----
 
   @Test
   public void testJacksonSerializationMatchesToJsonObject()
       throws Exception {
-    BloomFilterConfig config = new BloomFilterConfig(0.02, 2048, true);
-
+    BloomFilterConfig config = new BloomFilterConfig(null, 0.02, 2048, true);
     assertEquals(serializeToNode(config), config.toJsonObject());
   }
 
   @Test
   public void testFreshObjectMapperUsesJsonValue()
       throws Exception {
-    BloomFilterConfig config = new BloomFilterConfig(0.02, 0, false);
-
+    BloomFilterConfig config = new BloomFilterConfig(null, 0.02, null, null);
     String json = new ObjectMapper().writeValueAsString(config);
-
     assertEquals(JsonUtils.stringToJsonNode(json), config.toJsonObject());
   }
-
-  @Test
-  public void testEqualPojosProduceIdenticalJson()
-      throws Exception {
-    BloomFilterConfig a = new BloomFilterConfig(0.01, 100, true);
-    BloomFilterConfig b = new BloomFilterConfig(0.01, 100, true);
-
-    assertEquals(a, b);
-    assertEquals(serializeToNode(a), serializeToNode(b));
-  }
-
-  // ---- Helpers ----
 
   private static JsonNode serializeToNode(Object pojo)
       throws Exception {
@@ -150,9 +174,13 @@ public class BloomFilterConfigSerializationTest {
     Set<String> actual = new HashSet<>();
     node.fieldNames().forEachRemaining(actual::add);
     assertEquals(actual, Set.of(expectedKeys), "Unexpected key set: " + node);
-    // Defensive: ensure the resulting node doesn't accidentally carry stale "disabled" defaults.
-    if (!actual.contains("disabled")) {
-      assertFalse(node.has("disabled"));
-    }
+  }
+
+  private static void assertRoundTripIdempotent(BloomFilterConfig original)
+      throws Exception {
+    JsonNode firstNode = serializeToNode(original);
+    BloomFilterConfig restored = JsonUtils.stringToObject(JsonUtils.objectToString(original), BloomFilterConfig.class);
+    JsonNode secondNode = serializeToNode(restored);
+    assertEquals(secondNode, firstNode, "Slim form must be byte-equivalent across a round-trip");
   }
 }

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/config/table/IndexConfigSerializationTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/config/table/IndexConfigSerializationTest.java
@@ -1,0 +1,124 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.config.table;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.HashSet;
+import java.util.Set;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+
+/**
+ * Verifies that {@link IndexConfig} Jackson serialization uses the curated
+ * {@code @JsonValue toJsonObject()} method and emits each field only when it differs from its
+ * class default. This is the base class for all {@code *IndexConfig} types — see also the
+ * subclass-specific {@code *SerializationTest}s.
+ */
+public class IndexConfigSerializationTest {
+
+  @Test
+  public void testDefaultPojoSerializesToEmptyJson()
+      throws Exception {
+    IndexConfig config = new IndexConfig(false);
+
+    JsonNode node = serializeToNode(config);
+
+    assertOnlyKeys(node);
+  }
+
+  @Test
+  public void testDisabledTrueIsMinimal()
+      throws Exception {
+    IndexConfig config = new IndexConfig(true);
+
+    JsonNode node = serializeToNode(config);
+
+    assertOnlyKeys(node, "disabled");
+    assertTrue(node.get("disabled").asBoolean());
+  }
+
+  @Test
+  public void testFatJsonStillDeserializes()
+      throws Exception {
+    // Fat = explicit "disabled": false. Pre-fix output looked like this.
+    IndexConfig config = JsonUtils.stringToObject("{\"disabled\":false}", IndexConfig.class);
+
+    assertFalse(config.isDisabled());
+    assertOnlyKeys(serializeToNode(config));
+  }
+
+  @Test
+  public void testJacksonSerializationMatchesToJsonObject()
+      throws Exception {
+    IndexConfig enabled = new IndexConfig(false);
+    IndexConfig disabled = new IndexConfig(true);
+
+    assertEquals(serializeToNode(enabled), enabled.toJsonObject());
+    assertEquals(serializeToNode(disabled), disabled.toJsonObject());
+  }
+
+  @Test
+  public void testFreshObjectMapperUsesJsonValue()
+      throws Exception {
+    IndexConfig config = new IndexConfig(true);
+    String json = new ObjectMapper().writeValueAsString(config);
+
+    assertEquals(JsonUtils.stringToJsonNode(json), config.toJsonObject());
+  }
+
+  /**
+   * Trivial subclass without an override should still emit only {@code disabled}.
+   * Documents that subclasses are free to inherit the base serializer verbatim.
+   */
+  @Test
+  public void testSubclassWithoutOverrideUsesBaseSerializer()
+      throws Exception {
+    BareSubclass enabled = new BareSubclass(false);
+    BareSubclass disabled = new BareSubclass(true);
+
+    assertOnlyKeys(serializeToNode(enabled));
+    assertOnlyKeys(serializeToNode(disabled), "disabled");
+  }
+
+  // ---- Helpers ----
+
+  private static JsonNode serializeToNode(Object pojo)
+      throws Exception {
+    return JsonUtils.stringToJsonNode(JsonUtils.objectToString(pojo));
+  }
+
+  private static void assertOnlyKeys(JsonNode node, String... expectedKeys) {
+    Set<String> actual = new HashSet<>();
+    node.fieldNames().forEachRemaining(actual::add);
+    assertEquals(actual, Set.of(expectedKeys), "Unexpected key set: " + node);
+  }
+
+  /** Test-only subclass with no extra fields and no serializer override. */
+  private static final class BareSubclass extends IndexConfig {
+    BareSubclass(Boolean disabled) {
+      super(disabled);
+    }
+  }
+}

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/config/table/JsonIndexConfigSerializationTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/config/table/JsonIndexConfigSerializationTest.java
@@ -1,0 +1,188 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.config.table;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.HashSet;
+import java.util.Set;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+
+/**
+ * Verifies that {@link JsonIndexConfig} Jackson serialization uses the curated
+ * {@code @JsonValue toJsonObject()} method and emits each field only when it differs from its
+ * class default.
+ */
+public class JsonIndexConfigSerializationTest {
+
+  @Test
+  public void testDefaultPojoSerializesToEmptyJson()
+      throws Exception {
+    JsonIndexConfig config = new JsonIndexConfig();
+
+    JsonNode node = serializeToNode(config);
+
+    assertOnlyKeys(node);
+  }
+
+  @Test
+  public void testDisabledTrueIsMinimal()
+      throws Exception {
+    JsonIndexConfig config = new JsonIndexConfig(true);
+
+    JsonNode node = serializeToNode(config);
+
+    assertOnlyKeys(node, "disabled");
+    assertTrue(node.get("disabled").asBoolean());
+  }
+
+  @Test
+  public void testEachNonDefaultFieldRoundTrips()
+      throws Exception {
+    // maxLevels
+    JsonIndexConfig config = new JsonIndexConfig();
+    config.setMaxLevels(5);
+    assertRoundTripsWithKey(config, "maxLevels");
+
+    // excludeArray
+    config = new JsonIndexConfig();
+    config.setExcludeArray(true);
+    assertRoundTripsWithKey(config, "excludeArray");
+
+    // disableCrossArrayUnnest
+    config = new JsonIndexConfig();
+    config.setDisableCrossArrayUnnest(true);
+    assertRoundTripsWithKey(config, "disableCrossArrayUnnest");
+
+    // includePaths
+    config = new JsonIndexConfig();
+    config.setIncludePaths(Set.of("$.a"));
+    assertRoundTripsWithKey(config, "includePaths");
+
+    // excludePaths (mutex with includePaths)
+    config = new JsonIndexConfig();
+    config.setExcludePaths(Set.of("$.b"));
+    assertRoundTripsWithKey(config, "excludePaths");
+
+    // excludeFields
+    config = new JsonIndexConfig();
+    config.setExcludeFields(Set.of("c"));
+    assertRoundTripsWithKey(config, "excludeFields");
+
+    // indexPaths
+    config = new JsonIndexConfig();
+    config.setIndexPaths(Set.of("$.d"));
+    assertRoundTripsWithKey(config, "indexPaths");
+
+    // maxValueLength
+    config = new JsonIndexConfig();
+    config.setMaxValueLength(128);
+    assertRoundTripsWithKey(config, "maxValueLength");
+
+    // skipInvalidJson
+    config = new JsonIndexConfig();
+    config.setSkipInvalidJson(true);
+    assertRoundTripsWithKey(config, "skipInvalidJson");
+
+    // maxBytesSize
+    config = new JsonIndexConfig();
+    config.setMaxBytesSize(1024L);
+    assertRoundTripsWithKey(config, "maxBytesSize");
+  }
+
+  @Test
+  public void testFatJsonStillDeserializes()
+      throws Exception {
+    String fat = "{"
+        + "\"disabled\":false,"
+        + "\"maxLevels\":-1,"
+        + "\"excludeArray\":false,"
+        + "\"disableCrossArrayUnnest\":false,"
+        + "\"maxValueLength\":0,"
+        + "\"skipInvalidJson\":false"
+        + "}";
+
+    JsonIndexConfig config = JsonUtils.stringToObject(fat, JsonIndexConfig.class);
+
+    // Round-trips back to slim.
+    assertOnlyKeys(serializeToNode(config));
+    assertEquals(config, new JsonIndexConfig());
+  }
+
+  @Test
+  public void testJacksonSerializationMatchesToJsonObject()
+      throws Exception {
+    JsonIndexConfig config = new JsonIndexConfig();
+    config.setMaxLevels(3);
+    config.setExcludeArray(true);
+
+    assertEquals(serializeToNode(config), config.toJsonObject());
+  }
+
+  @Test
+  public void testFreshObjectMapperUsesJsonValue()
+      throws Exception {
+    JsonIndexConfig config = new JsonIndexConfig();
+    config.setExcludeArray(true);
+
+    String json = new ObjectMapper().writeValueAsString(config);
+
+    assertEquals(JsonUtils.stringToJsonNode(json), config.toJsonObject());
+  }
+
+  // ---- Helpers ----
+
+  private static JsonNode serializeToNode(Object pojo)
+      throws Exception {
+    return JsonUtils.stringToJsonNode(JsonUtils.objectToString(pojo));
+  }
+
+  private static void assertOnlyKeys(JsonNode node, String... expectedKeys) {
+    Set<String> actual = new HashSet<>();
+    node.fieldNames().forEachRemaining(actual::add);
+    assertEquals(actual, Set.of(expectedKeys), "Unexpected key set: " + node);
+  }
+
+  /**
+   * Asserts that the serialized output contains exactly {@code expectedKey} and that the
+   * deserialized POJO re-serializes to the same slim form (idempotent round-trip).
+   *
+   * <p>POJO-equality is intentionally not asserted here because {@code JsonIndexConfig._maxLevels}
+   * has a field-init default of {@code -1} but the {@code @JsonCreator} primitive parameter
+   * defaults to {@code 0} when absent. Both values are functionally equivalent (see
+   * {@code JsonUtils.flatten(...)}, which only consults {@code maxLevels} when {@code > 0}), so
+   * the slim wire form normalizes to "absent" and the runtime behavior is preserved even though
+   * the in-memory primitive value differs after round-trip.
+   */
+  private static void assertRoundTripsWithKey(JsonIndexConfig config, String expectedKey)
+      throws Exception {
+    JsonNode node = serializeToNode(config);
+    assertTrue(node.has(expectedKey), "Expected key '" + expectedKey + "' in: " + node);
+    assertFalse(node.has("disabled"), "disabled should be absent (default false): " + node);
+    JsonIndexConfig roundTripped = JsonUtils.stringToObject(node.toString(), JsonIndexConfig.class);
+    JsonNode roundTrippedNode = serializeToNode(roundTripped);
+    assertEquals(roundTrippedNode, node, "Slim form must be idempotent under round-trip");
+  }
+}

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/config/table/JsonIndexConfigSerializationTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/config/table/JsonIndexConfigSerializationTest.java
@@ -26,34 +26,71 @@ import org.apache.pinot.spi.utils.JsonUtils;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertTrue;
 
 
-/**
- * Verifies that {@link JsonIndexConfig} Jackson serialization uses the curated
- * {@code @JsonValue toJsonObject()} method and emits each field only when it differs from its
- * class default.
- */
+/// Slim-serialization contract for [JsonIndexConfig].
 public class JsonIndexConfigSerializationTest {
 
   @Test
-  public void testDefaultPojoSerializesToEmptyJson()
+  public void testRoundTripAllNull()
       throws Exception {
     JsonIndexConfig config = new JsonIndexConfig();
 
-    JsonNode node = serializeToNode(config);
+    assertOnlyKeys(serializeToNode(config));
+    assertRoundTripIdempotent(config);
 
-    assertOnlyKeys(node);
+    assertEquals(config.getMaxLevels(), -1);
+    assertEquals(config.isExcludeArray(), false);
+    assertEquals(config.isDisableCrossArrayUnnest(), false);
+    assertEquals(config.getMaxValueLength(), 0);
+    assertEquals(config.getSkipInvalidJson(), false);
+  }
+
+  @Test
+  public void testRoundTripPartial()
+      throws Exception {
+    JsonIndexConfig config = new JsonIndexConfig();
+    config.setMaxLevels(3);
+    config.setExcludeArray(true);
+
+    JsonNode node = serializeToNode(config);
+    assertOnlyKeys(node, "maxLevels", "excludeArray");
+    assertEquals(node.get("maxLevels").asInt(), 3);
+    assertTrue(node.get("excludeArray").asBoolean());
+    assertRoundTripIdempotent(config);
+
+    assertEquals(config.getMaxLevels(), 3);
+    assertTrue(config.isExcludeArray());
+    assertEquals(config.isDisableCrossArrayUnnest(), false);
+  }
+
+  @Test
+  public void testRoundTripAllSet()
+      throws Exception {
+    // Wrapper-typed args force selection of the @JsonCreator ctor over the deprecated primitive overload.
+    JsonIndexConfig config = new JsonIndexConfig(Boolean.FALSE, Integer.valueOf(5), Boolean.TRUE, Boolean.TRUE,
+        Set.of("$.a"), null, Set.of("c"), Set.of("$.d"), Integer.valueOf(128), Boolean.TRUE, Long.valueOf(1024L));
+
+    JsonNode node = serializeToNode(config);
+    assertOnlyKeys(node, "maxLevels", "excludeArray", "disableCrossArrayUnnest", "includePaths", "excludeFields",
+        "indexPaths", "maxValueLength", "skipInvalidJson", "maxBytesSize");
+    assertRoundTripIdempotent(config);
+
+    assertEquals(config.getMaxLevels(), 5);
+    assertTrue(config.isExcludeArray());
+    assertTrue(config.isDisableCrossArrayUnnest());
+    assertEquals(config.getMaxValueLength(), 128);
+    assertTrue(config.getSkipInvalidJson());
+    assertEquals(config.getMaxBytesSize(), Long.valueOf(1024L));
   }
 
   @Test
   public void testDisabledTrueIsMinimal()
       throws Exception {
     JsonIndexConfig config = new JsonIndexConfig(true);
-
     JsonNode node = serializeToNode(config);
-
     assertOnlyKeys(node, "disabled");
     assertTrue(node.get("disabled").asBoolean());
   }
@@ -61,62 +98,53 @@ public class JsonIndexConfigSerializationTest {
   @Test
   public void testEachNonDefaultFieldRoundTrips()
       throws Exception {
-    // maxLevels
     JsonIndexConfig config = new JsonIndexConfig();
     config.setMaxLevels(5);
     assertRoundTripsWithKey(config, "maxLevels");
 
-    // excludeArray
     config = new JsonIndexConfig();
     config.setExcludeArray(true);
     assertRoundTripsWithKey(config, "excludeArray");
 
-    // disableCrossArrayUnnest
     config = new JsonIndexConfig();
     config.setDisableCrossArrayUnnest(true);
     assertRoundTripsWithKey(config, "disableCrossArrayUnnest");
 
-    // includePaths
     config = new JsonIndexConfig();
     config.setIncludePaths(Set.of("$.a"));
     assertRoundTripsWithKey(config, "includePaths");
 
-    // excludePaths (mutex with includePaths)
     config = new JsonIndexConfig();
     config.setExcludePaths(Set.of("$.b"));
     assertRoundTripsWithKey(config, "excludePaths");
 
-    // excludeFields
     config = new JsonIndexConfig();
     config.setExcludeFields(Set.of("c"));
     assertRoundTripsWithKey(config, "excludeFields");
 
-    // indexPaths
     config = new JsonIndexConfig();
     config.setIndexPaths(Set.of("$.d"));
     assertRoundTripsWithKey(config, "indexPaths");
 
-    // maxValueLength
     config = new JsonIndexConfig();
     config.setMaxValueLength(128);
     assertRoundTripsWithKey(config, "maxValueLength");
 
-    // skipInvalidJson
     config = new JsonIndexConfig();
     config.setSkipInvalidJson(true);
     assertRoundTripsWithKey(config, "skipInvalidJson");
 
-    // maxBytesSize
     config = new JsonIndexConfig();
     config.setMaxBytesSize(1024L);
     assertRoundTripsWithKey(config, "maxBytesSize");
   }
 
   @Test
-  public void testFatJsonStillDeserializes()
+  public void testExplicitFalsePreservedThroughRoundTrip()
       throws Exception {
+    // Explicit false / 0 / -1 survives the round-trip — wrapper contract distinguishes "set" from
+    // "not set" so future default changes do not silently mutate user intent.
     String fat = "{"
-        + "\"disabled\":false,"
         + "\"maxLevels\":-1,"
         + "\"excludeArray\":false,"
         + "\"disableCrossArrayUnnest\":false,"
@@ -126,9 +154,10 @@ public class JsonIndexConfigSerializationTest {
 
     JsonIndexConfig config = JsonUtils.stringToObject(fat, JsonIndexConfig.class);
 
-    // Round-trips back to slim.
-    assertOnlyKeys(serializeToNode(config));
-    assertEquals(config, new JsonIndexConfig());
+    assertOnlyKeys(serializeToNode(config), "maxLevels", "excludeArray", "disableCrossArrayUnnest",
+        "maxValueLength", "skipInvalidJson");
+    assertNotEquals(config, new JsonIndexConfig(),
+        "Explicit-false config must NOT equal the all-null no-arg constructor");
   }
 
   @Test
@@ -137,7 +166,6 @@ public class JsonIndexConfigSerializationTest {
     JsonIndexConfig config = new JsonIndexConfig();
     config.setMaxLevels(3);
     config.setExcludeArray(true);
-
     assertEquals(serializeToNode(config), config.toJsonObject());
   }
 
@@ -146,9 +174,7 @@ public class JsonIndexConfigSerializationTest {
       throws Exception {
     JsonIndexConfig config = new JsonIndexConfig();
     config.setExcludeArray(true);
-
     String json = new ObjectMapper().writeValueAsString(config);
-
     assertEquals(JsonUtils.stringToJsonNode(json), config.toJsonObject());
   }
 
@@ -165,24 +191,19 @@ public class JsonIndexConfigSerializationTest {
     assertEquals(actual, Set.of(expectedKeys), "Unexpected key set: " + node);
   }
 
-  /**
-   * Asserts that the serialized output contains exactly {@code expectedKey} and that the
-   * deserialized POJO re-serializes to the same slim form (idempotent round-trip).
-   *
-   * <p>POJO-equality is intentionally not asserted here because {@code JsonIndexConfig._maxLevels}
-   * has a field-init default of {@code -1} but the {@code @JsonCreator} primitive parameter
-   * defaults to {@code 0} when absent. Both values are functionally equivalent (see
-   * {@code JsonUtils.flatten(...)}, which only consults {@code maxLevels} when {@code > 0}), so
-   * the slim wire form normalizes to "absent" and the runtime behavior is preserved even though
-   * the in-memory primitive value differs after round-trip.
-   */
-  private static void assertRoundTripsWithKey(JsonIndexConfig config, String expectedKey)
+  private static void assertRoundTripsWithKey(JsonIndexConfig config, String key)
       throws Exception {
     JsonNode node = serializeToNode(config);
-    assertTrue(node.has(expectedKey), "Expected key '" + expectedKey + "' in: " + node);
-    assertFalse(node.has("disabled"), "disabled should be absent (default false): " + node);
-    JsonIndexConfig roundTripped = JsonUtils.stringToObject(node.toString(), JsonIndexConfig.class);
-    JsonNode roundTrippedNode = serializeToNode(roundTripped);
-    assertEquals(roundTrippedNode, node, "Slim form must be idempotent under round-trip");
+    assertEquals(node.size(), 1, "Only the toggled key should be emitted: " + node);
+    assertTrue(node.has(key), "Missing key '" + key + "': " + node);
+    assertRoundTripIdempotent(config);
+  }
+
+  private static void assertRoundTripIdempotent(JsonIndexConfig original)
+      throws Exception {
+    JsonNode firstNode = serializeToNode(original);
+    JsonIndexConfig restored = JsonUtils.stringToObject(JsonUtils.objectToString(original), JsonIndexConfig.class);
+    JsonNode secondNode = serializeToNode(restored);
+    assertEquals(secondNode, firstNode, "Slim form must be byte-equivalent across a round-trip");
   }
 }

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/config/table/MultiColumnTextIndexConfigSerializationTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/config/table/MultiColumnTextIndexConfigSerializationTest.java
@@ -1,0 +1,117 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.config.table;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+
+/**
+ * Verifies that {@link MultiColumnTextIndexConfig} Jackson serialization uses the curated
+ * {@code @JsonValue toJsonObject()} method. {@code columns} is required and always emitted;
+ * the optional maps appear only when non-null.
+ */
+public class MultiColumnTextIndexConfigSerializationTest {
+
+  @Test
+  public void testColumnsOnlyIsMinimal()
+      throws Exception {
+    MultiColumnTextIndexConfig config = new MultiColumnTextIndexConfig(List.of("a", "b"));
+
+    JsonNode node = serializeToNode(config);
+
+    assertOnlyKeys(node, "columns");
+    assertEquals(node.get("columns").size(), 2);
+  }
+
+  @Test
+  public void testPropertiesEmittedWhenNonNull()
+      throws Exception {
+    MultiColumnTextIndexConfig config = new MultiColumnTextIndexConfig(
+        List.of("a"), Map.of("k", "v"), null);
+
+    JsonNode node = serializeToNode(config);
+
+    assertOnlyKeys(node, "columns", "properties");
+    assertEquals(node.get("properties").get("k").asText(), "v");
+  }
+
+  @Test
+  public void testPerColumnPropertiesEmittedWhenNonNull()
+      throws Exception {
+    MultiColumnTextIndexConfig config = new MultiColumnTextIndexConfig(
+        List.of("a"), null, Map.of("a", Map.of("k", "v")));
+
+    JsonNode node = serializeToNode(config);
+
+    assertOnlyKeys(node, "columns", "perColumnProperties");
+  }
+
+  @Test
+  public void testFatJsonStillDeserializes()
+      throws Exception {
+    String fat = "{\"columns\":[\"a\"],\"properties\":null,\"perColumnProperties\":null}";
+
+    MultiColumnTextIndexConfig config = JsonUtils.stringToObject(fat, MultiColumnTextIndexConfig.class);
+
+    assertOnlyKeys(serializeToNode(config), "columns");
+  }
+
+  @Test
+  public void testJacksonSerializationMatchesToJsonObject()
+      throws Exception {
+    MultiColumnTextIndexConfig config = new MultiColumnTextIndexConfig(
+        List.of("a"), Map.of("k", "v"), null);
+
+    assertEquals(serializeToNode(config), config.toJsonObject());
+  }
+
+  @Test
+  public void testFreshObjectMapperUsesJsonValue()
+      throws Exception {
+    MultiColumnTextIndexConfig config = new MultiColumnTextIndexConfig(List.of("a"));
+
+    String json = new ObjectMapper().writeValueAsString(config);
+
+    assertEquals(JsonUtils.stringToJsonNode(json), config.toJsonObject());
+  }
+
+  // ---- Helpers ----
+
+  private static JsonNode serializeToNode(Object pojo)
+      throws Exception {
+    return JsonUtils.stringToJsonNode(JsonUtils.objectToString(pojo));
+  }
+
+  private static void assertOnlyKeys(JsonNode node, String... expectedKeys) {
+    Set<String> actual = new HashSet<>();
+    node.fieldNames().forEachRemaining(actual::add);
+    assertEquals(actual, Set.of(expectedKeys), "Unexpected key set: " + node);
+    assertTrue(node.has("columns"), "columns is required and must always be present: " + node);
+  }
+}

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/config/table/StarTreeIndexConfigSerializationTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/config/table/StarTreeIndexConfigSerializationTest.java
@@ -1,0 +1,135 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.config.table;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+
+/**
+ * Verifies that {@link StarTreeIndexConfig} Jackson serialization uses the curated
+ * {@code @JsonValue toJsonObject()} method. {@code dimensionsSplitOrder} is required and always
+ * emitted; the optional list fields appear only when non-null (the ctor coerces empty lists to
+ * {@code null}).
+ */
+public class StarTreeIndexConfigSerializationTest {
+
+  @Test
+  public void testMinimalConfigOmitsOptionals()
+      throws Exception {
+    StarTreeIndexConfig config = new StarTreeIndexConfig(
+        List.of("dim"), null, List.of("SUM__metric"), null, 0);
+
+    JsonNode node = serializeToNode(config);
+
+    assertOnlyKeys(node, "dimensionsSplitOrder", "functionColumnPairs");
+  }
+
+  @Test
+  public void testEmptyOptionalListsCoercedToNullAndOmitted()
+      throws Exception {
+    StarTreeIndexConfig config = new StarTreeIndexConfig(
+        List.of("dim"), List.of(), List.of("SUM__metric"), List.of(), 0);
+
+    JsonNode node = serializeToNode(config);
+
+    assertOnlyKeys(node, "dimensionsSplitOrder", "functionColumnPairs");
+  }
+
+  @Test
+  public void testMaxLeafRecordsOmittedWhenZero()
+      throws Exception {
+    StarTreeIndexConfig config = new StarTreeIndexConfig(
+        List.of("dim"), null, List.of("SUM__metric"), null, 0);
+
+    JsonNode node = serializeToNode(config);
+
+    assertTrue(!node.has("maxLeafRecords"));
+  }
+
+  @Test
+  public void testMaxLeafRecordsEmittedWhenNonZero()
+      throws Exception {
+    StarTreeIndexConfig config = new StarTreeIndexConfig(
+        List.of("dim"), null, List.of("SUM__metric"), null, 1000);
+
+    JsonNode node = serializeToNode(config);
+
+    assertEquals(node.get("maxLeafRecords").asInt(), 1000);
+  }
+
+  @Test
+  public void testFatJsonStillDeserializes()
+      throws Exception {
+    String fat = "{"
+        + "\"dimensionsSplitOrder\":[\"dim\"],"
+        + "\"skipStarNodeCreationForDimensions\":[],"
+        + "\"functionColumnPairs\":[\"SUM__metric\"],"
+        + "\"aggregationConfigs\":[],"
+        + "\"maxLeafRecords\":0"
+        + "}";
+
+    StarTreeIndexConfig config = JsonUtils.stringToObject(fat, StarTreeIndexConfig.class);
+
+    assertOnlyKeys(serializeToNode(config), "dimensionsSplitOrder", "functionColumnPairs");
+  }
+
+  @Test
+  public void testJacksonSerializationMatchesToJsonObject()
+      throws Exception {
+    StarTreeIndexConfig config = new StarTreeIndexConfig(
+        List.of("dim"), List.of("dim2"), List.of("SUM__metric"), null, 100);
+
+    assertEquals(serializeToNode(config), config.toJsonObject());
+  }
+
+  @Test
+  public void testFreshObjectMapperUsesJsonValue()
+      throws Exception {
+    StarTreeIndexConfig config = new StarTreeIndexConfig(
+        List.of("dim"), null, List.of("SUM__metric"), null, 0);
+
+    String json = new ObjectMapper().writeValueAsString(config);
+
+    assertEquals(JsonUtils.stringToJsonNode(json), config.toJsonObject());
+  }
+
+  // ---- Helpers ----
+
+  private static JsonNode serializeToNode(Object pojo)
+      throws Exception {
+    return JsonUtils.stringToJsonNode(JsonUtils.objectToString(pojo));
+  }
+
+  private static void assertOnlyKeys(JsonNode node, String... expectedKeys) {
+    Set<String> actual = new HashSet<>();
+    node.fieldNames().forEachRemaining(actual::add);
+    assertEquals(actual, Set.of(expectedKeys), "Unexpected key set: " + node);
+    assertTrue(node.has("dimensionsSplitOrder"),
+        "dimensionsSplitOrder is required and must always be present: " + node);
+  }
+}


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Slim JSON serialization emits only non\-default fields via overridden toJsonObject methods that conditionally add fields and call super for disabled\.

```mermaid
flowchart TD
  N0["DictionaryIndexConfig#46;toJsonObject#40;#41; #40;F5#41;"]:::stAdded
  N1["IndexConfig#46;toJsonObject#40;#41; #40;F13#41;"]:::stAdded
  N2["Conditional field emission #40;onHeap#47;useVarLength#47;intern#41; #40;F5#41;"]:::stAdded
  N3["Disabled field emission #40;F13#41;"]:::stAdded
  N0 -->|"calls super#46;toJsonObject#40;#41; via node #61; super#46;toJsonObject#40;#41;#59;"| N1
  N0 -->|"adds field if non#45;null #40;if #40;#95;onHeap #33;#61; null#41; #123; node#46;put#40;#46;#46;#46;#41;"| N2
  N1 -->|"adds disabled if true #40;if #40;Boolean#46;TRUE#46;equals#40;#95;disabled#41;#41; #123;"| N3
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

Partial evidence: 5 file patches omitted; 1 truncated.

<details>
<summary>Diff evidence</summary>

- F5: pinot\-segment\-spi/src/main/java/org/apache/pinot/segment/spi/index/DictionaryIndexConfig\.java — [before](https://github.com/apache/pinot/blob/4863cdcd821ea85b88cdd6ba7fc10c34679724e3/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/DictionaryIndexConfig.java) · [after](https://github.com/apache/pinot/blob/9c0b1eb6a85ac2230c5d39208ebea345bfc52db9/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/DictionaryIndexConfig.java)
- F13: pinot\-spi/src/main/java/org/apache/pinot/spi/config/table/IndexConfig\.java — [before](https://github.com/apache/pinot/blob/4863cdcd821ea85b88cdd6ba7fc10c34679724e3/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/IndexConfig.java) · [after](https://github.com/apache/pinot/blob/9c0b1eb6a85ac2230c5d39208ebea345bfc52db9/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/IndexConfig.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjQ4NjNjZGNkODIxZWE4NWI4OGNkZDZiYTdmYzEwYzM0Njc5NzI0ZTMiLCJjb250ZXh0X2hhc2giOiIyOWJmOGU5NjE3ODFhNjM0MjMyOGU1OGVjYWMxZWFiY2IyMGY5OWRhNDY5MDk5NDVhMDlmOGQ3NjgyYmE4MGUyIiwiZ2VuZXJhdGVkX2F0IjoxNzkwMDE1MTEwLCJoZWFkX3NoYSI6IjljMGIxZWI2YTg1YWMyMjMwYzVkMzkyMDhlYmVhMzQ1YmZjNTJkYjkiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJiODY1M2VmZTVlZWY2YzJjMDg4N2UzMjA4NDE2MWI2NmI0N2U2YjJmIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature e668dd17feffd71bd7ac0a1e54cd0ee7b1edcf6f6270317b772e42b797fe1c4c -->
<!-- pinot-pr-flow:end -->

### Issue(s)

Follow-up to [apache/pinot#17558 -- "Slim JSON serialization for Schema and TableConfigs"](https://github.com/apache/pinot/pull/17558).

That PR left every `*IndexConfig` POJO using Jackson's default bean serializer, so slim user-supplied configs (e.g. `{"compressionCodec":"SNAPPY"}`) get *fattened* with default values on the first round-trip through any Pinot `ObjectMapper`. The user-visible repro -- `connection__cell__timeouts` -- showed a `forward` block ballooning from `{"compressionCodec":"SNAPPY"}` to a six-key blob the moment it touched the controller.

This PR makes the entire `*IndexConfig` surface **slim-by-default**: emit only fields that were *explicitly configured*.

---

### Description

Coordinated fixes across **12 `*IndexConfig` classes** in `pinot-spi` and `pinot-segment-spi`:

**1. Curated `@JsonValue toJsonObject()` per class.** Each class emits a fresh `ObjectNode` containing only fields whose value differs from the class default. Jackson's default bean introspection is bypassed entirely.

**2. Wrapper-typed fields, `null` = not configured.** Every primitive (`boolean`/`int`/`double`) becomes a wrapper. The `@JsonCreator` stores the input verbatim — no null-coalescing — so an explicit user setting that happens to match today's default (`luceneUseCompoundFile=true`, `version=2`, `fpp=0.05`) is preserved. If the default later flips, user intent does not get silently swallowed. Public getters keep their primitive return type and apply the default at read time, so consumer call sites are unchanged.

**3. `ForwardIndexConfig` cluster-tunable trio always materialized.** `rawIndexWriterVersion` / `targetMaxChunkSize` / `targetDocsPerChunk` defaults are JVM-local statics that `ServiceStartableUtils.initForwardIndexConfig` mutates per-instance; omitting these keys would let the same ZK payload resolve differently on different nodes (rolling upgrades). The constructor snapshots the live default at init time so the field is non-null and stable for the object's lifetime.

**4. `ForwardIndexConfig.encodingType` always emitted.** apache/pinot#18364 contract — explicit `DICTIONARY` must round-trip distinguishable from omitted-encoding legacy JSON (which still deserializes to `DICTIONARY` for backward compat).

**5. `BaseJsonConfig` subclasses.** `MultiColumnTextIndexConfig` and `StarTreeIndexConfig` extend `BaseJsonConfig` directly (no `IndexConfig` base, no `disabled`); they emit only required + non-default fields.

**6. `IndexConfig.disabled` normalizes `Boolean.FALSE → null` in the constructor.** Every index defaults to enabled and that universal default is extremely unlikely to ever flip; emitting `"disabled":false` everywhere is pure ZK noise. Explicit `disabled=true` still survives.

**7. Validation guards preserved.** `Preconditions.checkArgument` / `checkState` (e.g. `fpp` range, intern-requires-onHeap) remain in place and are gated on non-null inputs — absent values bypass the check while explicit values are still validated.

**8. Conversion code respects null-vs-explicit.** `DictionaryIndexType#getFromIndexingConfig` now translates "column absent from legacy `onHeapDictionaryColumns` / `varLengthDictionaryColumns`" as `null` (not `false`) when building the per-column `DictionaryIndexConfig`, so the slim form omits the key for absent flags.

---

### Examples

**Forward index** (`connection__cell__timeouts` repro — has cluster-tunable carve-outs):

```
# Before — slim input gets fattened on first round-trip
POST /tables/inferIndexes  { "forward": { "compressionCodec": "SNAPPY" } }
zk/get /CONFIGS/TABLE/...   { "forward": {
                                "disabled": false,
                                "encodingType": "DICTIONARY",
                                "compressionCodec": "SNAPPY",
                                "deriveNumDocsPerChunk": false,
                                "rawIndexWriterVersion": 4,
                                "targetMaxChunkSize": "1MB",
                                "targetDocsPerChunk": 1000
                              } }

# After — slim drops noisy falses; encodingType + cluster-tunable trio stay mandatory.
POST /tables/inferIndexes  { "forward": { "compressionCodec": "SNAPPY" } }
zk/get /CONFIGS/TABLE/...   { "forward": {
                                "encodingType": "DICTIONARY",
                                "compressionCodec": "SNAPPY",
                                "rawIndexWriterVersion": 4,
                                "targetMaxChunkSize": "1MB",
                                "targetDocsPerChunk": 1000
                              } }
```

**Bloom filter** (no cluster-tunable carve-outs — pure slim):

```
# Before — every default emitted on round-trip
POST /tables/inferIndexes  { "bloom": { "fpp": 0.5 } }
zk/get /CONFIGS/TABLE/...   { "bloom": {
                                "disabled": false,
                                "fpp": 0.5,
                                "maxSizeInBytes": 0,
                                "loadOnHeap": false
                              } }

# After — slim form emits only the user-supplied field.
POST /tables/inferIndexes  { "bloom": { "fpp": 0.5 } }
zk/get /CONFIGS/TABLE/...   { "bloom": { "fpp": 0.5 } }
```

---

### Backward compatibility

Strictly narrower wire format.

- Reads unchanged — every existing `@JsonCreator` still accepts the old fat JSON.
- No ZK migration — old fat znodes keep working; the next write replaces them with slim znodes.

---

### Testing

- [x] `spotless:apply`, `checkstyle:check`, `license:check` clean; `mvn test` green on `pinot-spi`, `pinot-segment-spi`, `pinot-segment-local` (modulo pre-existing JDK 21 `*SketchValueAggregatorTest` failures, unrelated)
- [x] 12 `*SerializationTest` classes — per-config round-trip matrix (all-null / partial / all-set) + `testExplicit*Preserved` (load-bearing: explicit-default-value still emitted) + validation + snapshot pins
- [x] `IndexConfigSlimRoundTripTest` — cross-cutting, 9 index types through the real `IndexLoadingConfig` resolution path
- [x] Pre-existing pinned-fat assertions updated inline
- [ ] Manual `connection__cell__timeouts` repro: slim through `inferIndexes` + ZK
