### PR TITLE
Close cached PinotDataBuffer in FilePerIndexDirectory.removeIndex() to stop mmap/heap buffer leaks

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/FilePerIndexDirectory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/FilePerIndexDirectory.java
@@ -22,6 +22,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import java.io.File;
 import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.nio.ByteOrder;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -99,8 +100,16 @@ class FilePerIndexDirectory extends ColumnIndexDirectory {
 
   @Override
   public void removeIndex(String columnName, IndexType<?, ?, ?> indexType) {
-    // TODO: this leaks the removed data buffer (it's not going to be freed in close() method)
-    _indexBuffers.remove(new IndexKey(columnName, indexType));
+    IndexKey key = new IndexKey(columnName, indexType);
+    PinotDataBuffer removed = _indexBuffers.remove(key);
+    if (removed != null) {
+      try {
+        removed.close();
+      } catch (IOException e) {
+        throw new UncheckedIOException(
+            "Failed to close buffer for column " + columnName + ", index " + indexType.getId(), e);
+      }
+    }
     if (indexType == StandardIndexes.text()) {
       TextIndexUtils.cleanupTextIndex(_segmentDirectory, columnName);
     } else if (indexType == StandardIndexes.vector()) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/FilePerIndexDirectory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/FilePerIndexDirectory.java
@@ -22,7 +22,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import java.io.File;
 import java.io.IOException;
-import java.io.UncheckedIOException;
 import java.nio.ByteOrder;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -37,9 +36,13 @@ import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
 import org.apache.pinot.segment.spi.store.ColumnIndexDirectory;
 import org.apache.pinot.spi.utils.ReadMode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 class FilePerIndexDirectory extends ColumnIndexDirectory {
+  private static final Logger LOGGER = LoggerFactory.getLogger(FilePerIndexDirectory.class);
+
   private final File _segmentDirectory;
   private SegmentMetadataImpl _segmentMetadata;
   private final ReadMode _readMode;
@@ -106,8 +109,7 @@ class FilePerIndexDirectory extends ColumnIndexDirectory {
       try {
         removed.close();
       } catch (IOException e) {
-        throw new UncheckedIOException(
-            "Failed to close buffer for column " + columnName + ", index " + indexType.getId(), e);
+        LOGGER.error("Failed to close buffer for column {}, index {}", columnName, indexType.getId(), e);
       }
     }
     if (indexType == StandardIndexes.text()) {

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/store/FilePerIndexDirectoryTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/store/FilePerIndexDirectoryTest.java
@@ -163,14 +163,25 @@ public class FilePerIndexDirectoryTest implements PinotBuffersAfterMethodCheckRu
   @Test
   public void testRemoveIndex()
       throws IOException {
-    try (FilePerIndexDirectory fpi = new FilePerIndexDirectory(TEMP_DIR, _segmentMetadata, ReadMode.mmap);
-        //buff needs closing because removeIndex() doesn't do it.
-        PinotDataBuffer buff = fpi.newBuffer("col1", StandardIndexes.forward(), 1024)) {
+    try (FilePerIndexDirectory fpi = new FilePerIndexDirectory(TEMP_DIR, _segmentMetadata, ReadMode.mmap)) {
+      fpi.newBuffer("col1", StandardIndexes.forward(), 1024);
       fpi.newBuffer("col2", StandardIndexes.dictionary(), 100);
       assertTrue(fpi.getFileFor("col1", StandardIndexes.forward()).exists());
       assertTrue(fpi.getFileFor("col2", StandardIndexes.dictionary()).exists());
       fpi.removeIndex("col1", StandardIndexes.forward());
       assertFalse(fpi.getFileFor("col1", StandardIndexes.forward()).exists());
+    }
+  }
+
+  @Test
+  public void testRemoveIndexClosesReadBuffer()
+      throws IOException {
+    try (FilePerIndexDirectory fpi = new FilePerIndexDirectory(TEMP_DIR, _segmentMetadata, ReadMode.mmap)) {
+      fpi.newBuffer("toRemove", StandardIndexes.dictionary(), 16);
+    }
+    try (FilePerIndexDirectory fpi = new FilePerIndexDirectory(TEMP_DIR, _segmentMetadata, ReadMode.mmap)) {
+      fpi.getBuffer("toRemove", StandardIndexes.dictionary());
+      fpi.removeIndex("toRemove", StandardIndexes.dictionary());
     }
   }
 


### PR DESCRIPTION
## Problem
`removeIndex()` dropped entries from` _indexBuffers` but did not close the associated `PinotDataBuffer`. Those buffers are no longer reached by `close()`, so mmap (and other) mappings could stay alive until GC/finalize behavior, which is incorrect and can leak file descriptors and native memory.

## Change
On removal, take the buffer out of the map, call `close()` on it, then run the existing cleanup (text index, vector index, or per-file delete). I/O errors while closing are surfaced as error logs.

## Tests
- Simplify `testRemoveIndex` so it relies on `removeIndex()` to release the forward buffer.
- Add `testRemoveIndexClosesReadBuffer` to cover the getBuffer (read) path with the class-level `PinotBuffersAfterMethodCheckRule` leak check.

## Scope note
Text- and vector-specific cleanup still runs after the buffer is released, so we do not keep stale mapped buffers over directory deletes.

Fixes #18218