### PR TITLE
Deduplicate ExpressionTransformer and CustomFunctionEnricher function evaluation

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ExpressionTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ExpressionTransformer.java
@@ -52,7 +52,7 @@ import org.slf4j.LoggerFactory;
  */
 public class ExpressionTransformer implements RecordTransformer {
   private static final Logger LOGGER = LoggerFactory.getLogger(ExpressionTransformer.class);
-  
+
   @VisibleForTesting
   final LinkedHashMap<String, FunctionEvaluator> _expressionEvaluators = new LinkedHashMap<>();
   /// Tracks columns whose transform functions were implicitly derived from MAP field specs (e.g. `mapField__KEYS`,

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ExpressionTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ExpressionTransformer.java
@@ -20,14 +20,12 @@ package org.apache.pinot.segment.local.recordtransformer;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import javax.annotation.Nullable;
 import org.apache.pinot.common.evaluator.FunctionEvaluatorFactory;
 import org.apache.pinot.common.utils.ThrottledLogger;
 import org.apache.pinot.segment.local.utils.SchemaUtils;
@@ -44,14 +42,17 @@ import org.slf4j.LoggerFactory;
 
 
 /**
- * The {@code ExpressionTransformer} class will evaluate the function expressions.
+ * {@link RecordTransformer} that evaluates ingestion transform functions from table config and field specs.
+ * <p>Per-row evaluation logic is shared with the enricher pipeline via
+ * {@link IngestionFunctionEvaluation#applyExpressionTransformations};
+ * see {@link org.apache.pinot.segment.local.recordtransformer.enricher.function.CustomFunctionEnricher} for the
+ * enricher-specific configuration and {@link IngestionFunctionEvaluation#applyEnricherEvaluations} semantics.
  * <p>NOTE: should put this before the {@link DataTypeTransformer}. After this, transformed column can be treated as
  * regular column for other record transformers.
- * TODO: Merge this and CustomFunctionEnricher
  */
 public class ExpressionTransformer implements RecordTransformer {
   private static final Logger LOGGER = LoggerFactory.getLogger(ExpressionTransformer.class);
-
+  
   @VisibleForTesting
   final LinkedHashMap<String, FunctionEvaluator> _expressionEvaluators = new LinkedHashMap<>();
   /// Tracks columns whose transform functions were implicitly derived from MAP field specs (e.g. `mapField__KEYS`,
@@ -177,43 +178,8 @@ public class ExpressionTransformer implements RecordTransformer {
 
   @Override
   public void transform(GenericRow record) {
-    for (Map.Entry<String, FunctionEvaluator> entry : _expressionEvaluators.entrySet()) {
-      String column = entry.getKey();
-      FunctionEvaluator transformFunctionEvaluator = entry.getValue();
-      Object existingValue = record.getValue(column);
-      boolean shouldApplyTransform = _overwriteExistingValues || existingValue == null || record.isNullValue(column);
-      if (shouldApplyTransform) {
-        try {
-          // Apply transformation when overwriting is enabled or when the current value is null.
-          // NOTE: column value might already exist for OFFLINE data. For backward compatibility, we may override
-          // nested fields like arrays, collections, or maps since they were not included in the record
-          // transformation before.
-          Object transformedValue = transformFunctionEvaluator.evaluate(record);
-          applyTransformedValue(record, column, transformedValue);
-        } catch (Exception e) {
-          if (!_continueOnError) {
-            throw new RuntimeException("Caught exception while evaluation transform function for column: " + column, e);
-          }
-          _throttledLogger.warn("Caught exception while evaluation transform function for column: " + column, e);
-          record.markIncomplete();
-        }
-      } else if (existingValue.getClass().isArray() || existingValue instanceof Collection
-          || existingValue instanceof Map) {
-        try {
-          Object transformedValue = transformFunctionEvaluator.evaluate(record);
-          if (transformedValue == null && _implicitMapTransformColumns.contains(column)) {
-            continue;
-          }
-          // For backward compatibility, The only exception here is that we will override nested field like array,
-          // collection or map since they were not included in the record transformation before.
-          if (!isTypeCompatible(existingValue, transformedValue)) {
-            applyTransformedValue(record, column, transformedValue);
-          }
-        } catch (Exception e) {
-          LOGGER.debug("Caught exception while evaluation transform function for column: {}", column, e);
-        }
-      }
-    }
+    IngestionFunctionEvaluation.applyExpressionTransformations(record, _expressionEvaluators, _continueOnError,
+        _overwriteExistingValues, _implicitMapTransformColumns, _throttledLogger);
   }
 
   private static boolean isImplicitMapTransform(FieldSpec fieldSpec) {
@@ -223,31 +189,5 @@ public class ExpressionTransformer implements RecordTransformer {
     String fieldName = fieldSpec.getName();
     return fieldName.endsWith(SchemaUtils.MAP_KEY_COLUMN_SUFFIX)
         || fieldName.endsWith(SchemaUtils.MAP_VALUE_COLUMN_SUFFIX);
-  }
-
-  private void applyTransformedValue(GenericRow record, String column, @Nullable Object transformedValue) {
-    if (transformedValue != null) {
-      record.removeNullValueField(column);
-      record.putValue(column, transformedValue);
-    } else {
-      record.removeValue(column);
-      record.addNullValueField(column);
-    }
-  }
-
-  private boolean isTypeCompatible(Object existingValue, @Nullable Object transformedValue) {
-    if (transformedValue == null || existingValue == null) {
-      return transformedValue == existingValue;
-    }
-    if (transformedValue.getClass() == existingValue.getClass()) {
-      return true;
-    }
-    if (transformedValue instanceof Collection && existingValue instanceof Collection) {
-      return true;
-    }
-    if (transformedValue instanceof Map && existingValue instanceof Map) {
-      return true;
-    }
-    return transformedValue.getClass().isArray() && existingValue.getClass().isArray();
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ExpressionTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ExpressionTransformer.java
@@ -44,9 +44,9 @@ import org.slf4j.LoggerFactory;
 /**
  * {@link RecordTransformer} that evaluates ingestion transform functions from table config and field specs.
  * <p>Per-row evaluation logic is shared with the enricher pipeline via
- * {@link IngestionFunctionEvaluation#applyExpressionTransformations};
- * see {@link org.apache.pinot.segment.local.recordtransformer.enricher.function.CustomFunctionEnricher} for the
- * enricher-specific configuration and {@link IngestionFunctionEvaluation#applyEnricherEvaluations} semantics.
+ * {@link IngestionFunctionEvaluation#applyFunctionEvaluations} and {@link IngestionFunctionEvaluation.Policy};
+ * see {@link org.apache.pinot.segment.local.recordtransformer.enricher.function.CustomFunctionEnricher} for
+ * enricher-specific configuration (JSON {@code fieldToFunctionMap}).
  * <p>NOTE: should put this before the {@link DataTypeTransformer}. After this, transformed column can be treated as
  * regular column for other record transformers.
  */
@@ -178,8 +178,9 @@ public class ExpressionTransformer implements RecordTransformer {
 
   @Override
   public void transform(GenericRow record) {
-    IngestionFunctionEvaluation.applyExpressionTransformations(record, _expressionEvaluators, _continueOnError,
-        _overwriteExistingValues, _implicitMapTransformColumns, _throttledLogger);
+    IngestionFunctionEvaluation.applyFunctionEvaluations(record, _expressionEvaluators,
+        IngestionFunctionEvaluation.Policy.expressionTransformation(_continueOnError, _overwriteExistingValues,
+            _implicitMapTransformColumns, _throttledLogger));
   }
 
   private static boolean isImplicitMapTransform(FieldSpec fieldSpec) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/IngestionFunctionEvaluation.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/IngestionFunctionEvaluation.java
@@ -48,10 +48,12 @@ public final class IngestionFunctionEvaluation {
   }
 
   /**
-   * Enricher: each target field is set to {@code evaluate(record)} (map iteration order; segment-local evaluators).
+   * Enricher: each target field is set to {@code evaluate(record)} (map iteration order; same {@link FunctionEvaluator}
+   * type as {@link org.apache.pinot.segment.local.recordtransformer.enricher.function.CustomFunctionEnricher} and
+   * {@link org.apache.pinot.segment.local.recordtransformer.ExpressionTransformer}).
    */
   public static void applyEnricherEvaluations(GenericRow record,
-      Map<String, org.apache.pinot.segment.local.function.FunctionEvaluator> fieldToFunctionEvaluator) {
+      Map<String, FunctionEvaluator> fieldToFunctionEvaluator) {
     fieldToFunctionEvaluator.forEach(
         (field, evaluator) -> record.putValue(field, evaluator.evaluate(record)));
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/IngestionFunctionEvaluation.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/IngestionFunctionEvaluation.java
@@ -20,6 +20,7 @@ package org.apache.pinot.segment.local.recordtransformer;
 
 import java.util.Collection;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.utils.ThrottledLogger;
@@ -29,17 +30,15 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Shared evaluation of function expressions during ingestion. Two call sites exist for historical reasons:
+ * Shared per-row application of {@link FunctionEvaluator}s during ingestion. A single entry point,
+ * {@link #applyFunctionEvaluations}, iterates evaluators; {@link Policy} selects semantics for each pipeline:
  * <ul>
- *   <li>{@link ExpressionTransformer} &mdash; {@link org.apache.pinot.spi.recordtransformer.RecordTransformer} chain.
- *   Table/schema {@link org.apache.pinot.spi.config.table.ingestion.TransformConfig}s, topological order,
- *   null / overwrite / implicit MAP rules, and {@code continueOnError} (see
- *   {@link #applyExpressionTransformations})</li>
- *   <li>{@link org.apache.pinot.segment.local.recordtransformer.enricher.function.CustomFunctionEnricher} &mdash;
- *   {@link org.apache.pinot.spi.recordtransformer.enricher.RecordEnricher} with JSON
- *   {@code fieldToFunctionMap}; see {@link #applyEnricherEvaluations}.</li>
+ *   <li>{@link Policy#enricher()} &mdash; used by
+ *   {@link org.apache.pinot.segment.local.recordtransformer.enricher.function.CustomFunctionEnricher}: always
+ *   {@code putValue(column, evaluate(record))} in map order (exceptions propagate).</li>
+ *   <li>{@link Policy#expressionTransformation} &mdash; used by {@link ExpressionTransformer}: null / overwrite /
+ *   implicit MAP rules and {@code continueOnError} as in table/schema-driven transforms.</li>
  * </ul>
- * Configuration, ordering, and pipeline wiring stay in the respective classes.
  */
 public final class IngestionFunctionEvaluation {
   private static final Logger LOGGER = LoggerFactory.getLogger(IngestionFunctionEvaluation.class);
@@ -48,45 +47,74 @@ public final class IngestionFunctionEvaluation {
   }
 
   /**
-   * Enricher: each target field is set to {@code evaluate(record)} (map iteration order; same {@link FunctionEvaluator}
-   * type as {@link org.apache.pinot.segment.local.recordtransformer.enricher.function.CustomFunctionEnricher} and
-   * {@link org.apache.pinot.segment.local.recordtransformer.ExpressionTransformer}).
+   * How each {@code (column, evaluator)} pair is applied to the row. Only one policy is active per call.
    */
-  public static void applyEnricherEvaluations(GenericRow record,
-      Map<String, FunctionEvaluator> fieldToFunctionEvaluator) {
-    fieldToFunctionEvaluator.forEach(
-        (field, evaluator) -> record.putValue(field, evaluator.evaluate(record)));
+  public static final class Policy {
+    private final boolean _enricherOverwrite;
+    private final boolean _continueOnError;
+    private final boolean _overwriteExistingValues;
+    private final Set<String> _implicitMapTransformColumns;
+    private final ThrottledLogger _throttledLogger;
+
+    private Policy(boolean enricherOverwrite, boolean continueOnError, boolean overwriteExistingValues,
+        Set<String> implicitMapTransformColumns, ThrottledLogger throttledLogger) {
+      _enricherOverwrite = enricherOverwrite;
+      _continueOnError = continueOnError;
+      _overwriteExistingValues = overwriteExistingValues;
+      _implicitMapTransformColumns = implicitMapTransformColumns;
+      _throttledLogger = throttledLogger;
+    }
+
+    /**
+     * JSON {@code fieldToFunctionMap} enricher: every field is overwritten with {@code evaluate(record)}.
+     */
+    public static Policy enricher() {
+      return new Policy(true, false, false, Set.of(), null);
+    }
+
+    /**
+     * Table/schema-driven {@link ExpressionTransformer} transforms (including post-upsert overrides).
+     */
+    public static Policy expressionTransformation(boolean continueOnError, boolean overwriteExistingValues,
+        Set<String> implicitMapTransformColumns, ThrottledLogger throttledLogger) {
+      return new Policy(false, continueOnError, overwriteExistingValues, implicitMapTransformColumns,
+          Objects.requireNonNull(throttledLogger, "throttledLogger"));
+    }
   }
 
   /**
-   * {@link ExpressionTransformer#transform} semantics: SPI {@link FunctionEvaluator} map, post-upsert overwrite flag,
-   * and implicit MAP-derived column handling.
+   * Single loop over {@code evaluators}: behavior is determined by {@code policy} (enricher vs. expression transform).
    */
-  public static void applyExpressionTransformations(GenericRow record,
-      Map<String, FunctionEvaluator> expressionEvaluators, boolean continueOnError, boolean overwriteExistingValues,
-      Set<String> implicitMapTransformColumns, ThrottledLogger throttledLogger) {
-    for (Map.Entry<String, FunctionEvaluator> entry : expressionEvaluators.entrySet()) {
+  public static void applyFunctionEvaluations(GenericRow record, Map<String, FunctionEvaluator> evaluators,
+      Policy policy) {
+    for (Map.Entry<String, FunctionEvaluator> entry : evaluators.entrySet()) {
       String column = entry.getKey();
       FunctionEvaluator transformFunctionEvaluator = entry.getValue();
+
+      if (policy._enricherOverwrite) {
+        record.putValue(column, transformFunctionEvaluator.evaluate(record));
+        continue;
+      }
+
       Object existingValue = record.getValue(column);
       boolean shouldApplyTransform =
-          overwriteExistingValues || existingValue == null || record.isNullValue(column);
+          policy._overwriteExistingValues || existingValue == null || record.isNullValue(column);
       if (shouldApplyTransform) {
         try {
           Object transformedValue = transformFunctionEvaluator.evaluate(record);
           applyTransformedValue(record, column, transformedValue);
         } catch (Exception e) {
-          if (!continueOnError) {
+          if (!policy._continueOnError) {
             throw new RuntimeException("Caught exception while evaluation transform function for column: " + column, e);
           }
-          throttledLogger.warn("Caught exception while evaluation transform function for column: " + column, e);
+          policy._throttledLogger.warn("Caught exception while evaluation transform function for column: " + column, e);
           record.markIncomplete();
         }
       } else if (existingValue.getClass().isArray() || existingValue instanceof Collection
           || existingValue instanceof Map) {
         try {
           Object transformedValue = transformFunctionEvaluator.evaluate(record);
-          if (transformedValue == null && implicitMapTransformColumns.contains(column)) {
+          if (transformedValue == null && policy._implicitMapTransformColumns.contains(column)) {
             continue;
           }
           if (!isTypeCompatible(existingValue, transformedValue)) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/IngestionFunctionEvaluation.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/IngestionFunctionEvaluation.java
@@ -1,0 +1,125 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.recordtransformer;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.apache.pinot.common.utils.ThrottledLogger;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.function.FunctionEvaluator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Shared evaluation of function expressions during ingestion. Two call sites exist for historical reasons:
+ * <ul>
+ *   <li>{@link ExpressionTransformer} &mdash; {@link org.apache.pinot.spi.recordtransformer.RecordTransformer} chain.
+ *   Table/schema {@link org.apache.pinot.spi.config.table.ingestion.TransformConfig}s, topological order,
+ *   null / overwrite / implicit MAP rules, and {@code continueOnError} (see
+ *   {@link #applyExpressionTransformations})</li>
+ *   <li>{@link org.apache.pinot.segment.local.recordtransformer.enricher.function.CustomFunctionEnricher} &mdash;
+ *   {@link org.apache.pinot.spi.recordtransformer.enricher.RecordEnricher} with JSON
+ *   {@code fieldToFunctionMap}; see {@link #applyEnricherEvaluations}.</li>
+ * </ul>
+ * Configuration, ordering, and pipeline wiring stay in the respective classes.
+ */
+public final class IngestionFunctionEvaluation {
+  private static final Logger LOGGER = LoggerFactory.getLogger(IngestionFunctionEvaluation.class);
+
+  private IngestionFunctionEvaluation() {
+  }
+
+  /**
+   * Enricher: each target field is set to {@code evaluate(record)} (map iteration order; segment-local evaluators).
+   */
+  public static void applyEnricherEvaluations(GenericRow record,
+      Map<String, org.apache.pinot.segment.local.function.FunctionEvaluator> fieldToFunctionEvaluator) {
+    fieldToFunctionEvaluator.forEach(
+        (field, evaluator) -> record.putValue(field, evaluator.evaluate(record)));
+  }
+
+  /**
+   * {@link ExpressionTransformer#transform} semantics: SPI {@link FunctionEvaluator} map, post-upsert overwrite flag,
+   * and implicit MAP-derived column handling.
+   */
+  public static void applyExpressionTransformations(GenericRow record,
+      Map<String, FunctionEvaluator> expressionEvaluators, boolean continueOnError, boolean overwriteExistingValues,
+      Set<String> implicitMapTransformColumns, ThrottledLogger throttledLogger) {
+    for (Map.Entry<String, FunctionEvaluator> entry : expressionEvaluators.entrySet()) {
+      String column = entry.getKey();
+      FunctionEvaluator transformFunctionEvaluator = entry.getValue();
+      Object existingValue = record.getValue(column);
+      boolean shouldApplyTransform =
+          overwriteExistingValues || existingValue == null || record.isNullValue(column);
+      if (shouldApplyTransform) {
+        try {
+          Object transformedValue = transformFunctionEvaluator.evaluate(record);
+          applyTransformedValue(record, column, transformedValue);
+        } catch (Exception e) {
+          if (!continueOnError) {
+            throw new RuntimeException("Caught exception while evaluation transform function for column: " + column, e);
+          }
+          throttledLogger.warn("Caught exception while evaluation transform function for column: " + column, e);
+          record.markIncomplete();
+        }
+      } else if (existingValue.getClass().isArray() || existingValue instanceof Collection
+          || existingValue instanceof Map) {
+        try {
+          Object transformedValue = transformFunctionEvaluator.evaluate(record);
+          if (transformedValue == null && implicitMapTransformColumns.contains(column)) {
+            continue;
+          }
+          if (!isTypeCompatible(existingValue, transformedValue)) {
+            applyTransformedValue(record, column, transformedValue);
+          }
+        } catch (Exception e) {
+          LOGGER.debug("Caught exception while evaluation transform function for column: {}", column, e);
+        }
+      }
+    }
+  }
+
+  private static void applyTransformedValue(GenericRow record, String column, @Nullable Object transformedValue) {
+    if (transformedValue != null) {
+      record.removeNullValueField(column);
+      record.putValue(column, transformedValue);
+    } else {
+      record.removeValue(column);
+      record.addNullValueField(column);
+    }
+  }
+
+  private static boolean isTypeCompatible(Object existingValue, @Nullable Object transformedValue) {
+    if (transformedValue == null || existingValue == null) {
+      return transformedValue == existingValue;
+    }
+    if (transformedValue.getClass() == existingValue.getClass()) {
+      return true;
+    }
+    if (transformedValue instanceof Collection && existingValue instanceof Collection) {
+      return true;
+    }
+    if (transformedValue instanceof Map && existingValue instanceof Map) {
+      return true;
+    }
+    return transformedValue.getClass().isArray() && existingValue.getClass().isArray();
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/enricher/function/CustomFunctionEnricher.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/enricher/function/CustomFunctionEnricher.java
@@ -35,7 +35,8 @@ import org.apache.pinot.spi.utils.JsonUtils;
 
 /**
  * {@link RecordEnricher} that applies a JSON {@code fieldToFunctionMap} of transform expressions. Evaluation is
- * delegated to {@link IngestionFunctionEvaluation#applyEnricherEvaluations}; for table/schema-driven transforms and
+ * delegated to {@link IngestionFunctionEvaluation#applyFunctionEvaluations} with
+ * {@link IngestionFunctionEvaluation.Policy#enricher()}; for table/schema-driven transforms and
  * dependency ordering, see {@link org.apache.pinot.segment.local.recordtransformer.ExpressionTransformer}.
  */
 public class CustomFunctionEnricher implements RecordEnricher {
@@ -63,6 +64,7 @@ public class CustomFunctionEnricher implements RecordEnricher {
 
   @Override
   public void enrich(GenericRow record) {
-    IngestionFunctionEvaluation.applyEnricherEvaluations(record, _fieldToFunctionEvaluator);
+    IngestionFunctionEvaluation.applyFunctionEvaluations(record, _fieldToFunctionEvaluator,
+        IngestionFunctionEvaluation.Policy.enricher());
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/enricher/function/CustomFunctionEnricher.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/enricher/function/CustomFunctionEnricher.java
@@ -26,6 +26,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.pinot.common.evaluator.FunctionEvaluatorFactory;
+import org.apache.pinot.segment.local.recordtransformer.IngestionFunctionEvaluation;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.function.FunctionEvaluator;
 import org.apache.pinot.spi.recordtransformer.enricher.RecordEnricher;
@@ -33,8 +34,9 @@ import org.apache.pinot.spi.utils.JsonUtils;
 
 
 /**
- * Enriches the record with custom functions.
- * TODO: Merge this and ExpressionTransformer
+ * {@link RecordEnricher} that applies a JSON {@code fieldToFunctionMap} of transform expressions. Evaluation is
+ * delegated to {@link IngestionFunctionEvaluation#applyEnricherEvaluations}; for table/schema-driven transforms and
+ * dependency ordering, see {@link org.apache.pinot.segment.local.recordtransformer.ExpressionTransformer}.
  */
 public class CustomFunctionEnricher implements RecordEnricher {
   private final LinkedHashMap<String, FunctionEvaluator> _fieldToFunctionEvaluator;
@@ -61,8 +63,6 @@ public class CustomFunctionEnricher implements RecordEnricher {
 
   @Override
   public void enrich(GenericRow record) {
-    _fieldToFunctionEvaluator.forEach((field, evaluator) -> {
-      record.putValue(field, evaluator.evaluate(record));
-    });
+    IngestionFunctionEvaluation.applyEnricherEvaluations(record, _fieldToFunctionEvaluator);
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/IngestionFunctionEvaluationTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/IngestionFunctionEvaluationTest.java
@@ -44,7 +44,7 @@ public class IngestionFunctionEvaluationTest {
   @Test
   public void testApplyEnricherEvaluationsAlwaysOverwrites() {
     FunctionEvaluator evaluator = mock(FunctionEvaluator.class);
-    when(evaluator.evaluate(any())).thenReturn("enriched");
+    when(evaluator.evaluate(any(GenericRow.class))).thenReturn("enriched");
     LinkedHashMap<String, FunctionEvaluator> map = new LinkedHashMap<>();
     map.put("out", evaluator);
     GenericRow record = new GenericRow();
@@ -57,7 +57,7 @@ public class IngestionFunctionEvaluationTest {
   @Test
   public void testApplyExpressionTransformationsFillsWhenColumnNull() {
     FunctionEvaluator evaluator = mock(FunctionEvaluator.class);
-    when(evaluator.evaluate(any())).thenReturn(99L);
+    when(evaluator.evaluate(any(GenericRow.class))).thenReturn(99L);
     LinkedHashMap<String, FunctionEvaluator> map = new LinkedHashMap<>();
     map.put("c", evaluator);
     GenericRow record = new GenericRow();
@@ -85,7 +85,8 @@ public class IngestionFunctionEvaluationTest {
   @Test
   public void testApplyExpressionTransformationsContinueOnErrorMarksIncomplete() {
     FunctionEvaluator evaluator = mock(FunctionEvaluator.class);
-    when(evaluator.evaluate(any())).thenThrow(new RuntimeException("eval failed"));
+    when(evaluator.evaluate(any(GenericRow.class)))
+        .thenThrow(new RuntimeException("eval failed"));
     LinkedHashMap<String, FunctionEvaluator> map = new LinkedHashMap<>();
     map.put("c", evaluator);
     GenericRow record = new GenericRow();

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/IngestionFunctionEvaluationTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/IngestionFunctionEvaluationTest.java
@@ -1,0 +1,98 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.recordtransformer;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import org.apache.pinot.common.utils.ThrottledLogger;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.function.FunctionEvaluator;
+import org.testng.annotations.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+
+/**
+ * Parity tests for {@link IngestionFunctionEvaluation} (shared by {@link ExpressionTransformer} and
+ * {@link org.apache.pinot.segment.local.recordtransformer.enricher.function.CustomFunctionEnricher}).
+ */
+public class IngestionFunctionEvaluationTest {
+
+  @Test
+  public void testApplyEnricherEvaluationsAlwaysOverwrites() {
+    org.apache.pinot.segment.local.function.FunctionEvaluator evaluator =
+        mock(org.apache.pinot.segment.local.function.FunctionEvaluator.class);
+    when(evaluator.evaluate(any())).thenReturn("enriched");
+    LinkedHashMap<String, org.apache.pinot.segment.local.function.FunctionEvaluator> map = new LinkedHashMap<>();
+    map.put("out", evaluator);
+    GenericRow record = new GenericRow();
+    record.putValue("out", "stale");
+    IngestionFunctionEvaluation.applyEnricherEvaluations(record, map);
+    assertEquals(record.getValue("out"), "enriched");
+    verify(evaluator).evaluate(record);
+  }
+
+  @Test
+  public void testApplyExpressionTransformationsFillsWhenColumnNull() {
+    FunctionEvaluator evaluator = mock(FunctionEvaluator.class);
+    when(evaluator.evaluate(any())).thenReturn(99L);
+    LinkedHashMap<String, FunctionEvaluator> map = new LinkedHashMap<>();
+    map.put("c", evaluator);
+    GenericRow record = new GenericRow();
+    assertNull(record.getValue("c"));
+    ThrottledLogger throttledLogger = mock(ThrottledLogger.class);
+    IngestionFunctionEvaluation.applyExpressionTransformations(record, map, false, false,
+        Collections.emptySet(), throttledLogger);
+    assertEquals(record.getValue("c"), 99L);
+  }
+
+  @Test
+  public void testApplyExpressionTransformationsSkipsWhenPrimitivePresent() {
+    FunctionEvaluator evaluator = mock(FunctionEvaluator.class);
+    LinkedHashMap<String, FunctionEvaluator> map = new LinkedHashMap<>();
+    map.put("c", evaluator);
+    GenericRow record = new GenericRow();
+    record.putValue("c", 1);
+    ThrottledLogger throttledLogger = mock(ThrottledLogger.class);
+    IngestionFunctionEvaluation.applyExpressionTransformations(record, map, false, false,
+        Collections.emptySet(), throttledLogger);
+    assertEquals(record.getValue("c"), 1);
+    verifyNoInteractions(evaluator);
+  }
+
+  @Test
+  public void testApplyExpressionTransformationsContinueOnErrorMarksIncomplete() {
+    FunctionEvaluator evaluator = mock(FunctionEvaluator.class);
+    when(evaluator.evaluate(any())).thenThrow(new RuntimeException("eval failed"));
+    LinkedHashMap<String, FunctionEvaluator> map = new LinkedHashMap<>();
+    map.put("c", evaluator);
+    GenericRow record = new GenericRow();
+    ThrottledLogger throttledLogger = mock(ThrottledLogger.class);
+    IngestionFunctionEvaluation.applyExpressionTransformations(record, map, true, false,
+        Collections.emptySet(), throttledLogger);
+    assertTrue(record.isIncomplete());
+  }
+}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/IngestionFunctionEvaluationTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/IngestionFunctionEvaluationTest.java
@@ -43,10 +43,9 @@ public class IngestionFunctionEvaluationTest {
 
   @Test
   public void testApplyEnricherEvaluationsAlwaysOverwrites() {
-    org.apache.pinot.segment.local.function.FunctionEvaluator evaluator =
-        mock(org.apache.pinot.segment.local.function.FunctionEvaluator.class);
+    FunctionEvaluator evaluator = mock(FunctionEvaluator.class);
     when(evaluator.evaluate(any())).thenReturn("enriched");
-    LinkedHashMap<String, org.apache.pinot.segment.local.function.FunctionEvaluator> map = new LinkedHashMap<>();
+    LinkedHashMap<String, FunctionEvaluator> map = new LinkedHashMap<>();
     map.put("out", evaluator);
     GenericRow record = new GenericRow();
     record.putValue("out", "stale");

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/IngestionFunctionEvaluationTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/IngestionFunctionEvaluationTest.java
@@ -49,7 +49,7 @@ public class IngestionFunctionEvaluationTest {
     map.put("out", evaluator);
     GenericRow record = new GenericRow();
     record.putValue("out", "stale");
-    IngestionFunctionEvaluation.applyEnricherEvaluations(record, map);
+    IngestionFunctionEvaluation.applyFunctionEvaluations(record, map, IngestionFunctionEvaluation.Policy.enricher());
     assertEquals(record.getValue("out"), "enriched");
     verify(evaluator).evaluate(record);
   }
@@ -63,8 +63,9 @@ public class IngestionFunctionEvaluationTest {
     GenericRow record = new GenericRow();
     assertNull(record.getValue("c"));
     ThrottledLogger throttledLogger = mock(ThrottledLogger.class);
-    IngestionFunctionEvaluation.applyExpressionTransformations(record, map, false, false,
-        Collections.emptySet(), throttledLogger);
+    IngestionFunctionEvaluation.applyFunctionEvaluations(record, map,
+        IngestionFunctionEvaluation.Policy.expressionTransformation(false, false, Collections.emptySet(),
+            throttledLogger));
     assertEquals(record.getValue("c"), 99L);
   }
 
@@ -76,8 +77,9 @@ public class IngestionFunctionEvaluationTest {
     GenericRow record = new GenericRow();
     record.putValue("c", 1);
     ThrottledLogger throttledLogger = mock(ThrottledLogger.class);
-    IngestionFunctionEvaluation.applyExpressionTransformations(record, map, false, false,
-        Collections.emptySet(), throttledLogger);
+    IngestionFunctionEvaluation.applyFunctionEvaluations(record, map,
+        IngestionFunctionEvaluation.Policy.expressionTransformation(false, false, Collections.emptySet(),
+            throttledLogger));
     assertEquals(record.getValue("c"), 1);
     verifyNoInteractions(evaluator);
   }
@@ -91,8 +93,9 @@ public class IngestionFunctionEvaluationTest {
     map.put("c", evaluator);
     GenericRow record = new GenericRow();
     ThrottledLogger throttledLogger = mock(ThrottledLogger.class);
-    IngestionFunctionEvaluation.applyExpressionTransformations(record, map, true, false,
-        Collections.emptySet(), throttledLogger);
+    IngestionFunctionEvaluation.applyFunctionEvaluations(record, map,
+        IngestionFunctionEvaluation.Policy.expressionTransformation(true, false, Collections.emptySet(),
+            throttledLogger));
     assertTrue(record.isIncomplete());
   }
 }


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Both transformers delegate per\-row function evaluation to a shared helper, eliminating duplicate logic\.

```mermaid
flowchart TD
  N0["ExpressionTransformer#46;transform #40;F1#41;"]:::stModified
  N1["CustomFunctionEnricher#46;enrich #40;F3#41;"]:::stModified
  N2["IngestionFunctionEvaluation#46;applyFunctionEvaluations #40;F2#41;"]:::stAdded
  N3["applyTransformedValue #40;F2#41;"]:::stAdded
  N4["isTypeCompatible #40;F2#41;"]:::stAdded
  N5["record#46;putValue #40;F2#41;"]:::stAdded
  N6["record#46;markIncomplete #40;F2#41;"]:::stAdded
  N0 -->|"calls"| N2
  N1 -->|"calls"| N2
  N2 -->|"calls"| N3
  N2 -->|"calls"| N4
  N2 -->|"calls"| N5
  N2 -->|"calls"| N6
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-segment\-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ExpressionTransformer\.java — [before](https://github.com/apache/pinot/blob/ab9ac391fa16b731eb2e1498bb13cdaaf65e92da/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ExpressionTransformer.java) · [after](https://github.com/apache/pinot/blob/cf995e75f24076d7fbe891d135083aa95f2b7be1/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/ExpressionTransformer.java)
- F2: pinot\-segment\-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/IngestionFunctionEvaluation\.java — [after](https://github.com/apache/pinot/blob/cf995e75f24076d7fbe891d135083aa95f2b7be1/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/IngestionFunctionEvaluation.java)
- F3: pinot\-segment\-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/enricher/function/CustomFunctionEnricher\.java — [before](https://github.com/apache/pinot/blob/ab9ac391fa16b731eb2e1498bb13cdaaf65e92da/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/enricher/function/CustomFunctionEnricher.java) · [after](https://github.com/apache/pinot/blob/cf995e75f24076d7fbe891d135083aa95f2b7be1/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/enricher/function/CustomFunctionEnricher.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImFiOWFjMzkxZmExNmI3MzFlYjJlMTQ5OGJiMTNjZGFhZjY1ZTkyZGEiLCJjb250ZXh0X2hhc2giOiIxMmViZTkzMjlkOWU5MzliMjQ0NmYwYzM1YzU4NmQ3YzJjOTYxODc1NjBmYmFlNGNlNzgzNTRjODMyNzJlNDE3IiwiZ2VuZXJhdGVkX2F0IjoxNzg5NjE1OTMyLCJoZWFkX3NoYSI6ImNmOTk1ZTc1ZjI0MDc2ZDdmYmU4OTFkMTM1MDgzYWE5NWYyYjdiZTEiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJhYjlhYzM5MWZhMTZiNzMxZWIyZTE0OThiYjEzY2RhYWY2NWU5MmRhIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature a9bf7c991eacabde83c1fefe28dd801bca840d9d4da1a2a149f9fa162813d9e2 -->
<!-- pinot-pr-flow:end -->

Fixes #18216

## Motivation
`ExpressionTransformer` and `CustomFunctionEnricher` both apply transform-style `FunctionEvaluators` to a `GenericRow`. Duplicating per-column evaluation and write behavior in two places makes drift and subtle bugs more likely.

## What changed
- Introduced `IngestionFunctionEvaluation` as the single place for per-row evaluator application.
-- One loop: `applyFunctionEvaluations(record, evaluators, policy)` iterates the Map<String, FunctionEvaluator> once; behavior is selected by IngestionFunctionEvaluation.Policy:
-- `Policy.expressionTransformation(...)` — same semantics as before for the record-transformer chain: null / overwrite / implicit MAP-derived columns, collection-or-map backward-compat path, continueOnError with throttled warning and incomplete row marking, and applyTransformedValue null handling.
-- `Policy.enricher()` — JSON enricher path: always putValue(column, evaluate(record)) in map order (exceptions propagate), matching prior CustomFunctionEnricher behavior.
- `ExpressionTransformer`: transform delegates to `applyFunctionEvaluations` with `Policy.expressionTransformation`; constructor, topological ordering, and implicit-MAP discovery are unchanged.
- `CustomFunctionEnricher`: enrich delegates to `applyFunctionEvaluations` with `Policy.enricher()`; Javadoc links to the shared helper and ExpressionTransformer for table/schema-driven transforms.

## Testing
Added `IngestionFunctionEvaluationTest` to cover unit tests