### PR TITLE
Support partial metadata based aggregation when some projection aggregations are not metadata compatible

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/AggregationOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/AggregationOperator.java
@@ -40,7 +40,7 @@ import org.apache.pinot.spi.query.QueryScanCostContext;
 /// The `AggregationOperator` class implements keyless aggregation query on a single segment in V1/SSQE.
 @SuppressWarnings("rawtypes")
 public class AggregationOperator extends BaseOperator<AggregationResultsBlock> {
-  private static final String EXPLAIN_NAME = "AGGREGATE";
+  public static final String EXPLAIN_NAME = "AGGREGATE";
 
   private final QueryContext _queryContext;
   private final AggregationFunction[] _aggregationFunctions;
@@ -55,6 +55,15 @@ public class AggregationOperator extends BaseOperator<AggregationResultsBlock> {
     this(queryContext, aggregationInfo, numTotalDocs, null);
   }
 
+  /**
+   * Constructs an aggregation operator with optional pre-aggregated results. Each non-null entry in
+   * {@code preAggregatedResults} is a result already resolved from the column dictionary/metadata (see
+   * {@link AggregationFunctionUtils#getAggregationResult}); the corresponding function is skipped during the scan and
+   * its pre-aggregated value is used directly. A {@code null} array (or a {@code null} entry) means the function is
+   * computed by scanning the segment.
+   *
+   * @param preAggregatedResults per-function pre-aggregated results, or {@code null} if none are pre-aggregated
+   */
   public AggregationOperator(QueryContext queryContext, AggregationInfo aggregationInfo, long numTotalDocs,
       Object[] preAggregatedResults) {
     _queryContext = queryContext;
@@ -70,6 +79,7 @@ public class AggregationOperator extends BaseOperator<AggregationResultsBlock> {
     // Perform aggregation on all the transform blocks
     AggregationExecutor aggregationExecutor;
     if (_useStarTree) {
+      // StarTreeAggregationExecutor doesn't support pre-aggregated results.
       aggregationExecutor = new StarTreeAggregationExecutor(_aggregationFunctions);
     } else {
       aggregationExecutor = new DefaultAggregationExecutor(_aggregationFunctions, _preAggregatedResults);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/AggregationOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/AggregationOperator.java
@@ -21,7 +21,9 @@ package org.apache.pinot.core.operator.query;
 import com.google.common.base.CaseFormat;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import org.apache.pinot.core.operator.BaseOperator;
 import org.apache.pinot.core.operator.BaseProjectOperator;
 import org.apache.pinot.core.operator.ExecutionStatistics;
@@ -31,16 +33,18 @@ import org.apache.pinot.core.operator.blocks.results.AggregationResultsBlock;
 import org.apache.pinot.core.query.aggregation.AggregationExecutor;
 import org.apache.pinot.core.query.aggregation.DefaultAggregationExecutor;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
+import org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils.AggregationInfo;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.startree.executor.StarTreeAggregationExecutor;
+import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.spi.query.QueryScanCostContext;
 
 
 /// The `AggregationOperator` class implements keyless aggregation query on a single segment in V1/SSQE.
 @SuppressWarnings("rawtypes")
 public class AggregationOperator extends BaseOperator<AggregationResultsBlock> {
-  public static final String EXPLAIN_NAME = "AGGREGATE";
+  private static final String EXPLAIN_NAME = "AGGREGATE";
 
   private final QueryContext _queryContext;
   private final AggregationFunction[] _aggregationFunctions;
@@ -49,29 +53,41 @@ public class AggregationOperator extends BaseOperator<AggregationResultsBlock> {
   private final long _numTotalDocs;
 
   private int _numDocsScanned = 0;
-  protected final Object[] _preAggregatedResults;
+
+  // Marks the functions that can be resolved from the column dictionary/metadata without scanning the segment. The
+  // aligned dataSources array holds the argument data source of each such function (a null entry is only valid for
+  // COUNT). Resolution is deferred to execution time (see getNextBlock) to keep query planning cheap. Both are null
+  // when no function is metadata-resolvable, in which case every function is computed by scanning.
+  @Nullable
+  private final boolean[] _metadataResolvable;
+  @Nullable
+  private final DataSource[] _dataSources;
 
   public AggregationOperator(QueryContext queryContext, AggregationInfo aggregationInfo, long numTotalDocs) {
-    this(queryContext, aggregationInfo, numTotalDocs, null);
+    this(queryContext, aggregationInfo, numTotalDocs, null, null);
   }
 
   /**
-   * Constructs an aggregation operator with optional pre-aggregated results. Each non-null entry in
-   * {@code preAggregatedResults} is a result already resolved from the column dictionary/metadata (see
-   * {@link AggregationFunctionUtils#getAggregationResult}); the corresponding function is skipped during the scan and
-   * its pre-aggregated value is used directly. A {@code null} array (or a {@code null} entry) means the function is
-   * computed by scanning the segment.
+   * Constructs an aggregation operator that optionally resolves some functions from the column dictionary/metadata
+   * instead of scanning the segment. For each function flagged in {@code metadataResolvable}, the result is resolved
+   * from the aligned {@code dataSources} entry (via {@link AggregationFunctionUtils#getAggregationResult}) at execution
+   * time and the function is skipped during the scan; all other functions are computed by scanning the segment.
+   * Passing {@code null} for both means every function is computed by scanning.
    *
-   * @param preAggregatedResults per-function pre-aggregated results, or {@code null} if none are pre-aggregated
+   * @param metadataResolvable per-function flags (aligned by function index) marking the functions to resolve from
+   *     dictionary/metadata, or {@code null} if none are resolvable
+   * @param dataSources per-function argument data sources aligned by function index (a {@code null} entry is only
+   *     valid for {@code COUNT}), or {@code null} if none are resolvable
    */
   public AggregationOperator(QueryContext queryContext, AggregationInfo aggregationInfo, long numTotalDocs,
-      Object[] preAggregatedResults) {
+      @Nullable boolean[] metadataResolvable, @Nullable DataSource[] dataSources) {
     _queryContext = queryContext;
     _aggregationFunctions = queryContext.getAggregationFunctions();
     _projectOperator = aggregationInfo.getProjectOperator();
     _useStarTree = aggregationInfo.isUseStarTree();
     _numTotalDocs = numTotalDocs;
-    _preAggregatedResults = preAggregatedResults;
+    _metadataResolvable = metadataResolvable;
+    _dataSources = dataSources;
   }
 
   @Override
@@ -82,7 +98,7 @@ public class AggregationOperator extends BaseOperator<AggregationResultsBlock> {
       // StarTreeAggregationExecutor doesn't support pre-aggregated results.
       aggregationExecutor = new StarTreeAggregationExecutor(_aggregationFunctions);
     } else {
-      aggregationExecutor = new DefaultAggregationExecutor(_aggregationFunctions, _preAggregatedResults);
+      aggregationExecutor = new DefaultAggregationExecutor(_aggregationFunctions, resolveMetadataBasedResults());
     }
     ValueBlock valueBlock;
     while ((valueBlock = _projectOperator.nextBlock()) != null) {
@@ -98,6 +114,28 @@ public class AggregationOperator extends BaseOperator<AggregationResultsBlock> {
 
     // Build intermediate result block based on aggregation result from the executor
     return new AggregationResultsBlock(_aggregationFunctions, aggregationExecutor.getResult(), _queryContext);
+  }
+
+  /**
+   * Returns {@code null} when no function is metadata-resolvable, in which case all functions are computed by scanning.
+   * Each returned non-null entry is consumed by {@link DefaultAggregationExecutor}, which skips the scan for that
+   * function and emits the resolved value directly.
+   */
+  @Nullable
+  private Object[] resolveMetadataBasedResults() {
+    if (_metadataResolvable == null) {
+      return null;
+    }
+
+    Objects.requireNonNull(_dataSources);
+    Object[] preAggregatedResults = new Object[_aggregationFunctions.length];
+    for (int i = 0; i < _aggregationFunctions.length; i++) {
+      if (_metadataResolvable[i]) {
+        preAggregatedResults[i] = AggregationFunctionUtils.getAggregationResult(_aggregationFunctions[i],
+            _dataSources[i], (int) _numTotalDocs, EXPLAIN_NAME);
+      }
+    }
+    return preAggregatedResults;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/AggregationOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/AggregationOperator.java
@@ -49,13 +49,20 @@ public class AggregationOperator extends BaseOperator<AggregationResultsBlock> {
   private final long _numTotalDocs;
 
   private int _numDocsScanned = 0;
+  protected final Object[] _preAggregatedResults;
 
   public AggregationOperator(QueryContext queryContext, AggregationInfo aggregationInfo, long numTotalDocs) {
+    this(queryContext, aggregationInfo, numTotalDocs, null);
+  }
+
+  public AggregationOperator(QueryContext queryContext, AggregationInfo aggregationInfo, long numTotalDocs,
+      Object[] preAggregatedResults) {
     _queryContext = queryContext;
     _aggregationFunctions = queryContext.getAggregationFunctions();
     _projectOperator = aggregationInfo.getProjectOperator();
     _useStarTree = aggregationInfo.isUseStarTree();
     _numTotalDocs = numTotalDocs;
+    _preAggregatedResults = preAggregatedResults;
   }
 
   @Override
@@ -65,7 +72,7 @@ public class AggregationOperator extends BaseOperator<AggregationResultsBlock> {
     if (_useStarTree) {
       aggregationExecutor = new StarTreeAggregationExecutor(_aggregationFunctions);
     } else {
-      aggregationExecutor = new DefaultAggregationExecutor(_aggregationFunctions);
+      aggregationExecutor = new DefaultAggregationExecutor(_aggregationFunctions, _preAggregatedResults);
     }
     ValueBlock valueBlock;
     while ((valueBlock = _projectOperator.nextBlock()) != null) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/AggregationOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/AggregationOperator.java
@@ -50,43 +50,41 @@ public class AggregationOperator extends BaseOperator<AggregationResultsBlock> {
   private final AggregationFunction[] _aggregationFunctions;
   private final BaseProjectOperator<?> _projectOperator;
   private final boolean _useStarTree;
-  private final long _numTotalDocs;
+  private final int _numTotalDocs;
 
   private int _numDocsScanned = 0;
 
   // Marks the functions that can be resolved from the column dictionary/metadata without scanning the segment. The
   // aligned dataSources array holds the argument data source of each such function (a null entry is only valid for
   // COUNT). Resolution is deferred to execution time (see getNextBlock) to keep query planning cheap. Both are null
-  // when no function is metadata-resolvable, in which case every function is computed by scanning.
+  // when no function is resolvable without scanning, in which case every function is computed by scanning.
   @Nullable
-  private final boolean[] _metadataResolvable;
+  private final boolean[] _nonScanResolvable;
   @Nullable
   private final DataSource[] _dataSources;
 
-  public AggregationOperator(QueryContext queryContext, AggregationInfo aggregationInfo, long numTotalDocs) {
+  public AggregationOperator(QueryContext queryContext, AggregationInfo aggregationInfo, int numTotalDocs) {
     this(queryContext, aggregationInfo, numTotalDocs, null, null);
   }
 
-  /**
-   * Constructs an aggregation operator that optionally resolves some functions from the column dictionary/metadata
-   * instead of scanning the segment. For each function flagged in {@code metadataResolvable}, the result is resolved
-   * from the aligned {@code dataSources} entry (via {@link AggregationFunctionUtils#getAggregationResult}) at execution
-   * time and the function is skipped during the scan; all other functions are computed by scanning the segment.
-   * Passing {@code null} for both means every function is computed by scanning.
-   *
-   * @param metadataResolvable per-function flags (aligned by function index) marking the functions to resolve from
-   *     dictionary/metadata, or {@code null} if none are resolvable
-   * @param dataSources per-function argument data sources aligned by function index (a {@code null} entry is only
-   *     valid for {@code COUNT}), or {@code null} if none are resolvable
-   */
-  public AggregationOperator(QueryContext queryContext, AggregationInfo aggregationInfo, long numTotalDocs,
-      @Nullable boolean[] metadataResolvable, @Nullable DataSource[] dataSources) {
+  /// Constructs an aggregation operator that optionally resolves some functions from the column dictionary/metadata
+  /// instead of scanning the segment. For each function flagged in {@code nonScanResolvable}, the result is resolved
+  /// from the aligned {@code dataSources} entry (via {@link AggregationFunctionUtils#getAggregationResult}) at
+  /// execution time and the function is skipped during the scan; all other functions are computed by scanning the
+  /// segment. Passing {@code null} for both means every function is computed by scanning.
+  ///
+  /// @param nonScanResolvable per-function flags (aligned by function index) marking the functions to resolve from
+  ///     dictionary/metadata, or {@code null} if none are resolvable
+  /// @param dataSources per-function argument data sources aligned by function index (a {@code null} entry is only
+  ///     valid for {@code COUNT}), or {@code null} if none are resolvable
+  public AggregationOperator(QueryContext queryContext, AggregationInfo aggregationInfo, int numTotalDocs,
+      @Nullable boolean[] nonScanResolvable, @Nullable DataSource[] dataSources) {
     _queryContext = queryContext;
     _aggregationFunctions = queryContext.getAggregationFunctions();
     _projectOperator = aggregationInfo.getProjectOperator();
     _useStarTree = aggregationInfo.isUseStarTree();
     _numTotalDocs = numTotalDocs;
-    _metadataResolvable = metadataResolvable;
+    _nonScanResolvable = nonScanResolvable;
     _dataSources = dataSources;
   }
 
@@ -95,10 +93,10 @@ public class AggregationOperator extends BaseOperator<AggregationResultsBlock> {
     // Perform aggregation on all the transform blocks
     AggregationExecutor aggregationExecutor;
     if (_useStarTree) {
-      // StarTreeAggregationExecutor doesn't support pre-aggregated results.
+      // StarTreeAggregationExecutor doesn't support non-scan results.
       aggregationExecutor = new StarTreeAggregationExecutor(_aggregationFunctions);
     } else {
-      aggregationExecutor = new DefaultAggregationExecutor(_aggregationFunctions, resolveMetadataBasedResults());
+      aggregationExecutor = new DefaultAggregationExecutor(_aggregationFunctions, resolveNonScanResults());
     }
     ValueBlock valueBlock;
     while ((valueBlock = _projectOperator.nextBlock()) != null) {
@@ -116,26 +114,24 @@ public class AggregationOperator extends BaseOperator<AggregationResultsBlock> {
     return new AggregationResultsBlock(_aggregationFunctions, aggregationExecutor.getResult(), _queryContext);
   }
 
-  /**
-   * Returns {@code null} when no function is metadata-resolvable, in which case all functions are computed by scanning.
-   * Each returned non-null entry is consumed by {@link DefaultAggregationExecutor}, which skips the scan for that
-   * function and emits the resolved value directly.
-   */
+  /// Returns {@code null} when no function is resolvable without scanning, in which case all functions are computed by
+  /// scanning. Each returned non-null entry is consumed by {@link DefaultAggregationExecutor}, which skips the scan for
+  /// that function and emits the resolved value directly.
   @Nullable
-  private Object[] resolveMetadataBasedResults() {
-    if (_metadataResolvable == null) {
+  private Object[] resolveNonScanResults() {
+    if (_nonScanResolvable == null) {
       return null;
     }
 
     Objects.requireNonNull(_dataSources);
-    Object[] preAggregatedResults = new Object[_aggregationFunctions.length];
+    Object[] nonScanResults = new Object[_aggregationFunctions.length];
     for (int i = 0; i < _aggregationFunctions.length; i++) {
-      if (_metadataResolvable[i]) {
-        preAggregatedResults[i] = AggregationFunctionUtils.getAggregationResult(_aggregationFunctions[i],
-            _dataSources[i], (int) _numTotalDocs, EXPLAIN_NAME);
+      if (_nonScanResolvable[i]) {
+        nonScanResults[i] = AggregationFunctionUtils.getAggregationResult(_aggregationFunctions[i],
+            _dataSources[i], _numTotalDocs, EXPLAIN_NAME);
       }
     }
-    return preAggregatedResults;
+    return nonScanResults;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/NonScanBasedAggregationOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/NonScanBasedAggregationOperator.java
@@ -45,7 +45,7 @@ import org.apache.pinot.segment.spi.datasource.DataSource;
 /// is no dictionary.
 @SuppressWarnings("rawtypes")
 public class NonScanBasedAggregationOperator extends BaseOperator<AggregationResultsBlock> {
-  public static final String EXPLAIN_NAME = "AGGREGATE_NO_SCAN";
+  private static final String EXPLAIN_NAME = "AGGREGATE_NO_SCAN";
 
   private final QueryContext _queryContext;
   private final AggregationFunction[] _aggregationFunctions;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/NonScanBasedAggregationOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/NonScanBasedAggregationOperator.java
@@ -18,43 +18,16 @@
  */
 package org.apache.pinot.core.operator.query;
 
-import com.clearspring.analytics.stream.cardinality.HyperLogLog;
-import com.clearspring.analytics.stream.cardinality.HyperLogLogPlus;
-import com.dynatrace.hash4j.distinctcount.UltraLogLog;
-import com.google.common.base.Preconditions;
-import it.unimi.dsi.fastutil.doubles.DoubleOpenHashSet;
-import it.unimi.dsi.fastutil.floats.FloatOpenHashSet;
-import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
-import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
-import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
-import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
-import java.util.Set;
-import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.operator.BaseOperator;
 import org.apache.pinot.core.operator.ExecutionStatistics;
 import org.apache.pinot.core.operator.blocks.results.AggregationResultsBlock;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
-import org.apache.pinot.core.query.aggregation.function.DistinctCountHLLAggregationFunction;
-import org.apache.pinot.core.query.aggregation.function.DistinctCountHLLPlusAggregationFunction;
-import org.apache.pinot.core.query.aggregation.function.DistinctCountOffHeapAggregationFunction;
-import org.apache.pinot.core.query.aggregation.function.DistinctCountRawHLLAggregationFunction;
-import org.apache.pinot.core.query.aggregation.function.DistinctCountRawHLLPlusAggregationFunction;
-import org.apache.pinot.core.query.aggregation.function.DistinctCountSmartHLLAggregationFunction;
-import org.apache.pinot.core.query.aggregation.function.DistinctCountSmartHLLPlusAggregationFunction;
-import org.apache.pinot.core.query.aggregation.function.DistinctCountSmartULLAggregationFunction;
-import org.apache.pinot.core.query.aggregation.function.DistinctCountULLAggregationFunction;
+import org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils;
 import org.apache.pinot.core.query.request.context.QueryContext;
-import org.apache.pinot.segment.local.customobject.MinMaxRangePair;
-import org.apache.pinot.segment.local.utils.UltraLogLogUtils;
 import org.apache.pinot.segment.spi.datasource.DataSource;
-import org.apache.pinot.segment.spi.index.reader.Dictionary;
-import org.apache.pinot.spi.data.FieldSpec.DataType;
-import org.apache.pinot.spi.query.QueryThreadContext;
-import org.apache.pinot.spi.utils.ByteArray;
 
 
 /// Aggregation operator that utilizes dictionary or column metadata for serving aggregation queries to avoid scanning.
@@ -72,7 +45,7 @@ import org.apache.pinot.spi.utils.ByteArray;
 /// is no dictionary.
 @SuppressWarnings("rawtypes")
 public class NonScanBasedAggregationOperator extends BaseOperator<AggregationResultsBlock> {
-  private static final String EXPLAIN_NAME = "AGGREGATE_NO_SCAN";
+  public static final String EXPLAIN_NAME = "AGGREGATE_NO_SCAN";
 
   private final QueryContext _queryContext;
   private final AggregationFunction[] _aggregationFunctions;
@@ -93,332 +66,13 @@ public class NonScanBasedAggregationOperator extends BaseOperator<AggregationRes
       AggregationFunction aggregationFunction = _aggregationFunctions[i];
       // note that dataSource will be null for COUNT, sp do not interact with it until it's known this isn't a COUNT
       DataSource dataSource = _dataSources[i];
-      Object result;
-      switch (aggregationFunction.getType()) {
-        case COUNT:
-          result = (long) _numTotalDocs;
-          break;
-        case MIN:
-        case MINMV:
-          result = getMinValueNumeric(dataSource);
-          break;
-        case MINLONG:
-          result = getMinValueLong(dataSource);
-          break;
-        case MINSTRING:
-          assert dataSource.getDictionary() != null;
-          result = dataSource.getDictionary().getMinVal();
-          break;
-        case MAX:
-        case MAXMV:
-          result = getMaxValueNumeric(dataSource);
-          break;
-        case MAXLONG:
-          result = getMaxValueLong(dataSource);
-          break;
-        case MAXSTRING:
-          assert dataSource.getDictionary() != null;
-          result = dataSource.getDictionary().getMaxVal();
-          break;
-        case MINMAXRANGE:
-        case MINMAXRANGEMV:
-          result = new MinMaxRangePair(getMinValueNumeric(dataSource), getMaxValueNumeric(dataSource));
-          break;
-        case DISTINCTCOUNT:
-        case DISTINCTSUM:
-        case DISTINCTAVG:
-        case DISTINCTCOUNTMV:
-        case DISTINCTSUMMV:
-        case DISTINCTAVGMV:
-          result = getDistinctValueSet(Objects.requireNonNull(dataSource.getDictionary()));
-          break;
-        case DISTINCTCOUNTOFFHEAP:
-          result = ((DistinctCountOffHeapAggregationFunction) aggregationFunction).extractAggregationResult(
-              Objects.requireNonNull(dataSource.getDictionary()));
-          break;
-        case DISTINCTCOUNTHLL:
-        case DISTINCTCOUNTHLLMV:
-          result = getDistinctCountHLLResult(Objects.requireNonNull(dataSource.getDictionary()),
-              (DistinctCountHLLAggregationFunction) aggregationFunction);
-          break;
-        case DISTINCTCOUNTRAWHLL:
-        case DISTINCTCOUNTRAWHLLMV:
-          result = getDistinctCountHLLResult(Objects.requireNonNull(dataSource.getDictionary()),
-              ((DistinctCountRawHLLAggregationFunction) aggregationFunction).getDistinctCountHLLAggregationFunction());
-          break;
-        case DISTINCTCOUNTHLLPLUS:
-        case DISTINCTCOUNTHLLPLUSMV:
-          result = getDistinctCountHLLPlusResult(Objects.requireNonNull(dataSource.getDictionary()),
-              (DistinctCountHLLPlusAggregationFunction) aggregationFunction);
-          break;
-        case DISTINCTCOUNTRAWHLLPLUS:
-        case DISTINCTCOUNTRAWHLLPLUSMV:
-          result = getDistinctCountHLLPlusResult(Objects.requireNonNull(dataSource.getDictionary()),
-              ((DistinctCountRawHLLPlusAggregationFunction) aggregationFunction)
-                  .getDistinctCountHLLPlusAggregationFunction());
-          break;
-        case SEGMENTPARTITIONEDDISTINCTCOUNT:
-          result = (long) Objects.requireNonNull(dataSource.getDictionary()).length();
-          break;
-        case DISTINCTCOUNTSMARTHLL:
-          result = getDistinctCountSmartHLLResult(Objects.requireNonNull(dataSource.getDictionary()),
-              (DistinctCountSmartHLLAggregationFunction) aggregationFunction);
-          break;
-        case DISTINCTCOUNTSMARTHLLPLUS:
-          result = getDistinctCountSmartHLLPlusResult(Objects.requireNonNull(dataSource.getDictionary()),
-              (DistinctCountSmartHLLPlusAggregationFunction) aggregationFunction);
-          break;
-        case DISTINCTCOUNTULL:
-          result = getDistinctCountULLResult(Objects.requireNonNull(dataSource.getDictionary()),
-              (DistinctCountULLAggregationFunction) aggregationFunction);
-          break;
-        case DISTINCTCOUNTSMARTULL:
-          result = getDistinctCountSmartULLResult(Objects.requireNonNull(dataSource.getDictionary()),
-              (DistinctCountSmartULLAggregationFunction) aggregationFunction);
-          break;
-        case DISTINCTCOUNTRAWULL:
-          result = getDistinctCountULLResult(Objects.requireNonNull(dataSource.getDictionary()),
-              (DistinctCountULLAggregationFunction) aggregationFunction);
-          break;
-        default:
-          throw new IllegalStateException(
-              "Non-scan based aggregation operator does not support function type: " + aggregationFunction.getType());
-      }
+      Object result = AggregationFunctionUtils.getAggregationResult(aggregationFunction, dataSource,
+          _numTotalDocs, EXPLAIN_NAME);
       aggregationResults.add(result);
     }
 
     // Build intermediate result block based on aggregation result from the executor.
     return new AggregationResultsBlock(_aggregationFunctions, aggregationResults, _queryContext);
-  }
-
-  private static Double getMinValueNumeric(DataSource dataSource) {
-    Dictionary dictionary = dataSource.getDictionary();
-    if (dictionary != null) {
-      return toDouble(dictionary.getMinVal());
-    }
-    return toDouble(dataSource.getDataSourceMetadata().getMinValue());
-  }
-
-  private static Long getMinValueLong(DataSource dataSource) {
-    DataType dataType = dataSource.getDataSourceMetadata().getDataType().getStoredType();
-    Preconditions.checkArgument(
-        dataType == DataType.LONG || dataType == DataType.INT,
-        "MINLONG aggregation function can only be applied to columns of integer types");
-    Dictionary dictionary = dataSource.getDictionary();
-    if (dictionary != null) {
-      return ((Number) dictionary.getMinVal()).longValue();
-    }
-    return ((Number) dataSource.getDataSourceMetadata().getMinValue()).longValue();
-  }
-
-  private static Double getMaxValueNumeric(DataSource dataSource) {
-    Dictionary dictionary = dataSource.getDictionary();
-    if (dictionary != null) {
-      return toDouble(dictionary.getMaxVal());
-    }
-    return toDouble(dataSource.getDataSourceMetadata().getMaxValue());
-  }
-
-  private static Long getMaxValueLong(DataSource dataSource) {
-    DataType dataType = dataSource.getDataSourceMetadata().getDataType().getStoredType();
-    Preconditions.checkArgument(
-        dataType == DataType.LONG || dataType == DataType.INT,
-        "MAXLONG aggregation function can only be applied to columns of integer types");
-    Dictionary dictionary = dataSource.getDictionary();
-    if (dictionary != null) {
-      return ((Number) dictionary.getMaxVal()).longValue();
-    }
-    return ((Number) dataSource.getDataSourceMetadata().getMaxValue()).longValue();
-  }
-
-  private static Double toDouble(Comparable<?> value) {
-    if (value instanceof Double) {
-      return (Double) value;
-    } else if (value instanceof Number) {
-      return ((Number) value).doubleValue();
-    } else {
-      return Double.parseDouble(value.toString());
-    }
-  }
-
-  private static Set getDistinctValueSet(Dictionary dictionary) {
-    int dictionarySize = dictionary.length();
-    switch (dictionary.getValueType()) {
-      case INT:
-        IntOpenHashSet intSet = new IntOpenHashSet(dictionarySize);
-        for (int dictId = 0; dictId < dictionarySize; dictId++) {
-          QueryThreadContext.checkTerminationAndSampleUsagePeriodically(dictId, EXPLAIN_NAME);
-          intSet.add(dictionary.getIntValue(dictId));
-        }
-        return intSet;
-      case LONG:
-        LongOpenHashSet longSet = new LongOpenHashSet(dictionarySize);
-        for (int dictId = 0; dictId < dictionarySize; dictId++) {
-          QueryThreadContext.checkTerminationAndSampleUsagePeriodically(dictId, EXPLAIN_NAME);
-          longSet.add(dictionary.getLongValue(dictId));
-        }
-        return longSet;
-      case FLOAT:
-        FloatOpenHashSet floatSet = new FloatOpenHashSet(dictionarySize);
-        for (int dictId = 0; dictId < dictionarySize; dictId++) {
-          QueryThreadContext.checkTerminationAndSampleUsagePeriodically(dictId, EXPLAIN_NAME);
-          floatSet.add(dictionary.getFloatValue(dictId));
-        }
-        return floatSet;
-      case DOUBLE:
-        DoubleOpenHashSet doubleSet = new DoubleOpenHashSet(dictionarySize);
-        for (int dictId = 0; dictId < dictionarySize; dictId++) {
-          QueryThreadContext.checkTerminationAndSampleUsagePeriodically(dictId, EXPLAIN_NAME);
-          doubleSet.add(dictionary.getDoubleValue(dictId));
-        }
-        return doubleSet;
-      case BIG_DECIMAL:
-        ObjectOpenHashSet<BigDecimal> bigDecimalSet = new ObjectOpenHashSet<>(dictionarySize);
-        for (int dictId = 0; dictId < dictionarySize; dictId++) {
-          QueryThreadContext.checkTerminationAndSampleUsagePeriodically(dictId, EXPLAIN_NAME);
-          bigDecimalSet.add(dictionary.getBigDecimalValue(dictId));
-        }
-        return bigDecimalSet;
-      case STRING:
-        ObjectOpenHashSet<String> stringSet = new ObjectOpenHashSet<>(dictionarySize);
-        for (int dictId = 0; dictId < dictionarySize; dictId++) {
-          QueryThreadContext.checkTerminationAndSampleUsagePeriodically(dictId, EXPLAIN_NAME);
-          stringSet.add(dictionary.getStringValue(dictId));
-        }
-        return stringSet;
-      case BYTES:
-        ObjectOpenHashSet<ByteArray> bytesSet = new ObjectOpenHashSet<>(dictionarySize);
-        for (int dictId = 0; dictId < dictionarySize; dictId++) {
-          QueryThreadContext.checkTerminationAndSampleUsagePeriodically(dictId, EXPLAIN_NAME);
-          bytesSet.add(new ByteArray(dictionary.getBytesValue(dictId)));
-        }
-        return bytesSet;
-      default:
-        throw new IllegalStateException();
-    }
-  }
-
-  private static HyperLogLog getDistinctValueHLL(Dictionary dictionary, int log2m) {
-    HyperLogLog hll = new HyperLogLog(log2m);
-    int length = dictionary.length();
-    for (int i = 0; i < length; i++) {
-      QueryThreadContext.checkTerminationAndSampleUsagePeriodically(i, EXPLAIN_NAME);
-      hll.offer(dictionary.get(i));
-    }
-    return hll;
-  }
-
-  private static UltraLogLog getDistinctValueULL(Dictionary dictionary, int p) {
-    UltraLogLog ull = UltraLogLog.create(p);
-    int length = dictionary.length();
-    for (int i = 0; i < length; i++) {
-      QueryThreadContext.checkTerminationAndSampleUsagePeriodically(i, EXPLAIN_NAME);
-      Object value = dictionary.get(i);
-      UltraLogLogUtils.hashObject(value).ifPresent(ull::add);
-    }
-    return ull;
-  }
-
-  private static HyperLogLogPlus getDistinctValueHLLPlus(Dictionary dictionary, int p, int sp) {
-    HyperLogLogPlus hllPlus = new HyperLogLogPlus(p, sp);
-    int length = dictionary.length();
-    for (int i = 0; i < length; i++) {
-      QueryThreadContext.checkTerminationAndSampleUsagePeriodically(i, EXPLAIN_NAME);
-      hllPlus.offer(dictionary.get(i));
-    }
-    return hllPlus;
-  }
-
-  private static HyperLogLog getDistinctCountHLLResult(Dictionary dictionary,
-      DistinctCountHLLAggregationFunction function) {
-    if (dictionary.getValueType() == DataType.BYTES) {
-      // Treat BYTES value as serialized HyperLogLog
-      try {
-        QueryThreadContext.checkTerminationAndSampleUsage(EXPLAIN_NAME);
-        HyperLogLog hll = ObjectSerDeUtils.HYPER_LOG_LOG_SER_DE.deserialize(dictionary.getBytesValue(0));
-        int length = dictionary.length();
-        for (int i = 1; i < length; i++) {
-          QueryThreadContext.checkTerminationAndSampleUsagePeriodically(i, EXPLAIN_NAME);
-          hll.addAll(ObjectSerDeUtils.HYPER_LOG_LOG_SER_DE.deserialize(dictionary.getBytesValue(i)));
-        }
-        return hll;
-      } catch (Exception e) {
-        throw new RuntimeException("Caught exception while merging HyperLogLogs", e);
-      }
-    } else {
-      return getDistinctValueHLL(dictionary, function.getLog2m());
-    }
-  }
-
-  private static HyperLogLogPlus getDistinctCountHLLPlusResult(Dictionary dictionary,
-      DistinctCountHLLPlusAggregationFunction function) {
-    if (dictionary.getValueType() == DataType.BYTES) {
-      // Treat BYTES value as serialized HyperLogLogPlus
-      try {
-        QueryThreadContext.checkTerminationAndSampleUsage(EXPLAIN_NAME);
-        HyperLogLogPlus hllplus = ObjectSerDeUtils.HYPER_LOG_LOG_PLUS_SER_DE.deserialize(dictionary.getBytesValue(0));
-        int length = dictionary.length();
-        for (int i = 1; i < length; i++) {
-          QueryThreadContext.checkTerminationAndSampleUsagePeriodically(i, EXPLAIN_NAME);
-          hllplus.addAll(ObjectSerDeUtils.HYPER_LOG_LOG_PLUS_SER_DE.deserialize(dictionary.getBytesValue(i)));
-        }
-        return hllplus;
-      } catch (Exception e) {
-        throw new RuntimeException("Caught exception while merging HyperLogLogPluses", e);
-      }
-    } else {
-      return getDistinctValueHLLPlus(dictionary, function.getP(), function.getSp());
-    }
-  }
-
-  private static Object getDistinctCountSmartHLLResult(Dictionary dictionary,
-      DistinctCountSmartHLLAggregationFunction function) {
-    if (dictionary.length() > function.getThreshold()) {
-      // Store values into a HLL when the dictionary size exceeds the conversion threshold
-      return getDistinctValueHLL(dictionary, function.getLog2m());
-    } else {
-      return getDistinctValueSet(dictionary);
-    }
-  }
-
-  private static Object getDistinctCountSmartHLLPlusResult(Dictionary dictionary,
-      DistinctCountSmartHLLPlusAggregationFunction function) {
-    if (dictionary.length() > function.getThreshold()) {
-      // Store values into a HLLPlus when the dictionary size exceeds the conversion threshold
-      return getDistinctValueHLLPlus(dictionary, function.getP(), function.getSp());
-    } else {
-      return getDistinctValueSet(dictionary);
-    }
-  }
-
-  private static UltraLogLog getDistinctCountULLResult(Dictionary dictionary,
-      DistinctCountULLAggregationFunction function) {
-    if (dictionary.getValueType() == DataType.BYTES) {
-      // Treat BYTES value as serialized UltraLogLog and merge
-      try {
-        QueryThreadContext.checkTerminationAndSampleUsage(EXPLAIN_NAME);
-        UltraLogLog ull = ObjectSerDeUtils.ULTRA_LOG_LOG_OBJECT_SER_DE.deserialize(dictionary.getBytesValue(0));
-        int length = dictionary.length();
-        for (int i = 1; i < length; i++) {
-          QueryThreadContext.checkTerminationAndSampleUsagePeriodically(i, EXPLAIN_NAME);
-          ull.add(ObjectSerDeUtils.ULTRA_LOG_LOG_OBJECT_SER_DE.deserialize(dictionary.getBytesValue(i)));
-        }
-        return ull;
-      } catch (Exception e) {
-        throw new RuntimeException("Caught exception while merging UltraLogLogs", e);
-      }
-    } else {
-      return getDistinctValueULL(dictionary, function.getP());
-    }
-  }
-
-  private static Object getDistinctCountSmartULLResult(Dictionary dictionary,
-      DistinctCountSmartULLAggregationFunction function) {
-    if (dictionary.length() > function.getThreshold()) {
-      return getDistinctValueULL(dictionary, function.getP());
-    } else {
-      return getDistinctValueSet(dictionary);
-    }
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode.java
@@ -138,10 +138,17 @@ public class AggregationPlanNode implements PlanNode {
           return new NonScanBasedAggregationOperator(_queryContext, dataSources, numTotalDocs);
         }
         if (numResolved > 0) {
-          // some functions can be resolved from dictionary/metadata; the rest fall back to scan-based
-          // execution in the AggregationOperator.
+          // Some functions are resolved from dictionary/metadata; the rest are scanned by the AggregationOperator.
+          // Project only the scanned functions' columns so a column that is resolved by metadata is not counted as
+          // scanned (keeps it out of numEntriesScannedPostFilter).
+          AggregationFunction[] scannedFunctions = new AggregationFunction[aggregationFunctions.length - numResolved];
+          for (int i = 0, j = 0; i < aggregationFunctions.length; i++) {
+            if (!metadataResolvable[i]) {
+              scannedFunctions[j++] = aggregationFunctions[i];
+            }
+          }
           aggregationInfo = AggregationFunctionUtils.buildAggregationInfoWithoutStarTree(_segmentContext, _queryContext,
-              aggregationFunctions, filterOperator);
+              aggregationFunctions, scannedFunctions, filterOperator);
           return new AggregationOperator(_queryContext, aggregationInfo, numTotalDocs, metadataResolvable, dataSources);
         }
       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode.java
@@ -121,13 +121,13 @@ public class AggregationPlanNode implements PlanNode {
       // and reused for both the fully non-scan path (all functions resolvable) and
       // the partial path (some functions resolvable).
       if (filterOperator.isResultMatchingAll()) {
-        boolean[] metadataResolvable = new boolean[aggregationFunctions.length];
+        boolean[] nonScanResolvable = new boolean[aggregationFunctions.length];
         DataSource[] dataSources = new DataSource[aggregationFunctions.length];
         int numResolved = 0;
         for (int i = 0; i < aggregationFunctions.length; i++) {
           DataSource dataSource = getDataSourceForAggregationFunction(aggregationFunctions[i]);
           if (isFitForNonScanBasedPlan(aggregationFunctions[i], dataSource)) {
-            metadataResolvable[i] = true;
+            nonScanResolvable[i] = true;
             dataSources[i] = dataSource;
             numResolved++;
           }
@@ -143,13 +143,13 @@ public class AggregationPlanNode implements PlanNode {
           // scanned (keeps it out of numEntriesScannedPostFilter).
           AggregationFunction[] scannedFunctions = new AggregationFunction[aggregationFunctions.length - numResolved];
           for (int i = 0, j = 0; i < aggregationFunctions.length; i++) {
-            if (!metadataResolvable[i]) {
+            if (!nonScanResolvable[i]) {
               scannedFunctions[j++] = aggregationFunctions[i];
             }
           }
           aggregationInfo = AggregationFunctionUtils.buildAggregationInfoWithoutStarTree(_segmentContext, _queryContext,
               aggregationFunctions, scannedFunctions, filterOperator);
-          return new AggregationOperator(_queryContext, aggregationInfo, numTotalDocs, metadataResolvable, dataSources);
+          return new AggregationOperator(_queryContext, aggregationInfo, numTotalDocs, nonScanResolvable, dataSources);
         }
       }
 
@@ -195,15 +195,13 @@ public class AggregationPlanNode implements PlanNode {
     return false;
   }
 
-  /**
-   * Returns {@code true} if the given aggregation function can be resolved from the column dictionary or metadata
-   * (without scanning the segment), {@code false} otherwise. {@code COUNT} is always eligible. Functions whose result
-   * is derived numerically from the column min/max (e.g. MIN, MAX, MINMAXRANGE) are only eligible for numeric columns,
-   * since non-numeric columns (e.g. BYTES) store min/max as raw values that cannot be parsed as numbers.
-   *
-   * @param aggregationFunction aggregation function to test
-   * @param dataSource the function argument's data source (see {@link #getDataSourceForAggregationFunction})
-   */
+  /// Returns {@code true} if the given aggregation function can be resolved from the column dictionary or metadata
+  /// (without scanning the segment), {@code false} otherwise. {@code COUNT} is always eligible. Functions whose result
+  /// is derived numerically from the column min/max (e.g. MIN, MAX, MINMAXRANGE) are only eligible for numeric columns,
+  /// since non-numeric columns (e.g. BYTES) store min/max as raw values that cannot be parsed as numbers.
+  ///
+  /// @param aggregationFunction aggregation function to test
+  /// @param dataSource the function argument's data source (see {@link #getDataSourceForAggregationFunction})
   private boolean isFitForNonScanBasedPlan(AggregationFunction<?, ?> aggregationFunction,
       @Nullable DataSource dataSource) {
     AggregationFunctionType functionType = aggregationFunction.getType();
@@ -212,7 +210,7 @@ public class AggregationPlanNode implements PlanNode {
     }
 
     if (dataSource == null) {
-      // Aggregation function does not have a single identifier argument (e.g. COUNT(*) or COUNT(1)),
+      // Aggregation function does not have a single identifier argument (e.g. SUM(1)),
       // so it cannot be resolved from metadata
       return false;
     }
@@ -239,14 +237,12 @@ public class AggregationPlanNode implements PlanNode {
         && filterOperator.canOptimizeCount();
   }
 
-  /**
-   * Returns the data source for the given aggregation function's argument, or {@code null} if the function has no
-   * argument (e.g. {@code COUNT(*)}) or its argument is not a single column identifier (e.g. {@code COUNT(1)} or a
-   * transform expression), in which case it cannot be resolved from dictionary/metadata.
-   *
-   * @param aggregationFunction aggregation function whose argument data source is resolved
-   * @return the argument's data source, or {@code null} if it has no single identifier argument
-   */
+  /// Returns the data source for the given aggregation function's argument, or {@code null} if the function has no
+  /// argument (e.g. {@code COUNT(*)}) or its argument is not a single column identifier (e.g. {@code COUNT(1)} or a
+  /// transform expression), in which case it cannot be resolved from dictionary/metadata.
+  ///
+  /// @param aggregationFunction aggregation function whose argument data source is resolved
+  /// @return the argument's data source, or {@code null} if it has no single identifier argument
   @Nullable
   private DataSource getDataSourceForAggregationFunction(AggregationFunction<?, ?> aggregationFunction) {
     List<ExpressionContext> inputExpressions = aggregationFunction.getInputExpressions();

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode.java
@@ -242,9 +242,9 @@ public class AggregationPlanNode implements PlanNode {
    */
   @Nullable
   private DataSource getDataSourceForAggregationFunction(AggregationFunction<?, ?> aggregationFunction) {
-    List<?> inputExpressions = aggregationFunction.getInputExpressions();
+    List<ExpressionContext> inputExpressions = aggregationFunction.getInputExpressions();
     if (!inputExpressions.isEmpty()) {
-      ExpressionContext argument = aggregationFunction.getInputExpressions().get(0);
+      ExpressionContext argument = inputExpressions.get(0);
       if (argument.getType() != ExpressionContext.Type.IDENTIFIER) {
         return null;
       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode.java
@@ -116,42 +116,33 @@ public class AggregationPlanNode implements PlanNode {
 
     boolean hasNullValues = _queryContext.isNullHandlingEnabled() && hasNullValues(aggregationFunctions);
     if (!hasNullValues) {
-      // Priority 2: Check if non-scan based aggregation is feasible
-      if (filterOperator.isResultMatchingAll() && isFitForNonScanBasedPlan()) {
-        DataSource[] dataSources = new DataSource[aggregationFunctions.length];
-        for (int i = 0; i < aggregationFunctions.length; i++) {
-          dataSources[i] = getDataSourceForAggregationFunction(aggregationFunctions[i]);
-          List<?> inputExpressions = aggregationFunctions[i].getInputExpressions();
-          if (!inputExpressions.isEmpty()) {
-            String column = ((ExpressionContext) inputExpressions.get(0)).getIdentifier();
-            dataSources[i] = _indexSegment.getDataSource(column, _queryContext.getSchema());
-          }
-        }
-        return new NonScanBasedAggregationOperator(_queryContext, dataSources, numTotalDocs);
-      }
-
+      // when the filter matches all documents, resolve as many functions as possible from the column
+      // dictionary/metadata without scanning the segment. Eligibility is evaluated once per function here
+      // and reused for both the fully non-scan path (all functions resolvable) and
+      // the partial path (some functions resolvable).
       if (filterOperator.isResultMatchingAll()) {
-        boolean anyResolved = false;
-        Object[] preAggregatedResults = new Object[aggregationFunctions.length];
+        boolean[] metadataResolvable = new boolean[aggregationFunctions.length];
+        DataSource[] dataSources = new DataSource[aggregationFunctions.length];
+        int numResolved = 0;
         for (int i = 0; i < aggregationFunctions.length; i++) {
-          // Only resolve functions that can be answered from dictionary/metadata; the rest fall back to scan-based
-          // execution in the AggregationOperator below. getAggregationResult() throws for unsupported function types,
-          // so it must not be called for functions that are not metadata compatible (e.g. MODE, SUM, AVG).
-          if (!isFitForNonScanBasedPlan(aggregationFunctions[i])) {
-            continue;
-          }
-
           DataSource dataSource = getDataSourceForAggregationFunction(aggregationFunctions[i]);
-          preAggregatedResults[i] = AggregationFunctionUtils.getAggregationResult(aggregationFunctions[i],
-              dataSource, numTotalDocs, AggregationOperator.EXPLAIN_NAME);
-          anyResolved = true;
+          if (isFitForNonScanBasedPlan(aggregationFunctions[i], dataSource)) {
+            metadataResolvable[i] = true;
+            dataSources[i] = dataSource;
+            numResolved++;
+          }
         }
 
-        if (anyResolved) {
-          // build aggregation info for all functions (including those that cannot be resolved from metadata)
+        if (numResolved == aggregationFunctions.length) {
+          // Priority 2: all functions can be resolved from dictionary/metadata -> fully non-scan based execution
+          return new NonScanBasedAggregationOperator(_queryContext, dataSources, numTotalDocs);
+        }
+        if (numResolved > 0) {
+          // some functions can be resolved from dictionary/metadata; the rest fall back to scan-based
+          // execution in the AggregationOperator.
           aggregationInfo = AggregationFunctionUtils.buildAggregationInfoWithoutStarTree(_segmentContext, _queryContext,
               aggregationFunctions, filterOperator);
-          return new AggregationOperator(_queryContext, aggregationInfo, numTotalDocs, preAggregatedResults);
+          return new AggregationOperator(_queryContext, aggregationInfo, numTotalDocs, metadataResolvable, dataSources);
         }
       }
 
@@ -197,32 +188,22 @@ public class AggregationPlanNode implements PlanNode {
     return false;
   }
 
-  /// Returns `true` if the given aggregations can be solved with dictionary or column metadata, `false`
-  /// otherwise.
-  private boolean isFitForNonScanBasedPlan() {
-    AggregationFunction[] aggregationFunctions = _queryContext.getAggregationFunctions();
-    assert aggregationFunctions != null;
-    for (AggregationFunction<?, ?> aggregationFunction : aggregationFunctions) {
-      if (!isFitForNonScanBasedPlan(aggregationFunction)) {
-        return false;
-      }
-    }
-    return true;
-  }
-
   /**
    * Returns {@code true} if the given aggregation function can be resolved from the column dictionary or metadata
    * (without scanning the segment), {@code false} otherwise. {@code COUNT} is always eligible. Functions whose result
    * is derived numerically from the column min/max (e.g. MIN, MAX, MINMAXRANGE) are only eligible for numeric columns,
    * since non-numeric columns (e.g. BYTES) store min/max as raw values that cannot be parsed as numbers.
+   *
+   * @param aggregationFunction aggregation function to test
+   * @param dataSource the function argument's data source (see {@link #getDataSourceForAggregationFunction})
    */
-  private boolean isFitForNonScanBasedPlan(AggregationFunction<?, ?> aggregationFunction) {
+  private boolean isFitForNonScanBasedPlan(AggregationFunction<?, ?> aggregationFunction,
+      @Nullable DataSource dataSource) {
     AggregationFunctionType functionType = aggregationFunction.getType();
     if (functionType == COUNT) {
       return true;
     }
 
-    DataSource dataSource = getDataSourceForAggregationFunction(aggregationFunction);
     if (dataSource == null) {
       // Aggregation function does not have a single identifier argument (e.g. COUNT(*) or COUNT(1)),
       // so it cannot be resolved from metadata

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode.java
@@ -109,17 +109,38 @@ public class AggregationPlanNode implements PlanNode {
 
     boolean hasNullValues = _queryContext.isNullHandlingEnabled() && hasNullValues(aggregationFunctions);
     if (!hasNullValues) {
+      DataSource[] dataSources = new DataSource[aggregationFunctions.length];
+      for (int i = 0; i < aggregationFunctions.length; i++) {
+        List<?> inputExpressions = aggregationFunctions[i].getInputExpressions();
+        if (!inputExpressions.isEmpty()) {
+          String column = ((ExpressionContext) inputExpressions.get(0)).getIdentifier();
+          dataSources[i] = _indexSegment.getDataSource(column, _queryContext.getSchema());
+        }
+      }
+
       // Priority 2: Check if non-scan based aggregation is feasible
       if (filterOperator.isResultMatchingAll() && isFitForNonScanBasedPlan()) {
-        DataSource[] dataSources = new DataSource[aggregationFunctions.length];
+        return new NonScanBasedAggregationOperator(_queryContext, dataSources, numTotalDocs);
+      }
+
+      if (filterOperator.isResultMatchingAll()) {
+        boolean anyResolved = false;
+        Object[] preAggregatedResults = new Object[aggregationFunctions.length];
         for (int i = 0; i < aggregationFunctions.length; i++) {
-          List<?> inputExpressions = aggregationFunctions[i].getInputExpressions();
-          if (!inputExpressions.isEmpty()) {
-            String column = ((ExpressionContext) inputExpressions.get(0)).getIdentifier();
-            dataSources[i] = _indexSegment.getDataSource(column, _queryContext.getSchema());
+          Object resolved = AggregationFunctionUtils.getAggregationResult(aggregationFunctions[i],
+              dataSources[i], numTotalDocs, NonScanBasedAggregationOperator.EXPLAIN_NAME);
+          if (resolved != null) {
+            preAggregatedResults[i] = resolved;
+            anyResolved = true;
           }
         }
-        return new NonScanBasedAggregationOperator(_queryContext, dataSources, numTotalDocs);
+
+        if (anyResolved) {
+          // build aggregation info for all functions (including those that cannot be resolved from metadata)
+          aggregationInfo = AggregationFunctionUtils.buildAggregationInfoWithoutStarTree(_segmentContext, _queryContext,
+              aggregationFunctions, filterOperator);
+          return new AggregationOperator(_queryContext, aggregationInfo, numTotalDocs, preAggregatedResults);
+        }
       }
 
       // Priority 3: Check if fast filtered count can be used

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode.java
@@ -20,6 +20,7 @@ package org.apache.pinot.core.plan;
 
 import java.util.EnumSet;
 import java.util.List;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.operator.blocks.results.AggregationResultsBlock;
@@ -59,6 +60,12 @@ public class AggregationPlanNode implements PlanNode {
   // https://github.com/apache/pinot/pull/16983)
   private static final EnumSet<AggregationFunctionType> METADATA_BASED_FUNCTIONS =
       EnumSet.of(COUNT, MIN, MINMV, MINLONG, MAX, MAXMV, MAXLONG, MINMAXRANGE, MINMAXRANGEMV);
+
+  // MIN/MAX/MINMAXRANGE derive their result numerically from the column min/max, so they can only be resolved from
+  // metadata/dictionary for numeric columns. Non-numeric columns (e.g. BYTES) store min/max as raw values that cannot
+  // be parsed as numbers.
+  private static final EnumSet<AggregationFunctionType> NUMERIC_METADATA_FUNCTIONS =
+      EnumSet.of(MIN, MINMV, MINLONG, MAX, MAXMV, MAXLONG, MINMAXRANGE, MINMAXRANGEMV);
 
   private final IndexSegment _indexSegment;
   private final SegmentContext _segmentContext;
@@ -109,17 +116,17 @@ public class AggregationPlanNode implements PlanNode {
 
     boolean hasNullValues = _queryContext.isNullHandlingEnabled() && hasNullValues(aggregationFunctions);
     if (!hasNullValues) {
-      DataSource[] dataSources = new DataSource[aggregationFunctions.length];
-      for (int i = 0; i < aggregationFunctions.length; i++) {
-        List<?> inputExpressions = aggregationFunctions[i].getInputExpressions();
-        if (!inputExpressions.isEmpty()) {
-          String column = ((ExpressionContext) inputExpressions.get(0)).getIdentifier();
-          dataSources[i] = _indexSegment.getDataSource(column, _queryContext.getSchema());
-        }
-      }
-
       // Priority 2: Check if non-scan based aggregation is feasible
       if (filterOperator.isResultMatchingAll() && isFitForNonScanBasedPlan()) {
+        DataSource[] dataSources = new DataSource[aggregationFunctions.length];
+        for (int i = 0; i < aggregationFunctions.length; i++) {
+          dataSources[i] = getDataSourceForAggregationFunction(aggregationFunctions[i]);
+          List<?> inputExpressions = aggregationFunctions[i].getInputExpressions();
+          if (!inputExpressions.isEmpty()) {
+            String column = ((ExpressionContext) inputExpressions.get(0)).getIdentifier();
+            dataSources[i] = _indexSegment.getDataSource(column, _queryContext.getSchema());
+          }
+        }
         return new NonScanBasedAggregationOperator(_queryContext, dataSources, numTotalDocs);
       }
 
@@ -127,12 +134,17 @@ public class AggregationPlanNode implements PlanNode {
         boolean anyResolved = false;
         Object[] preAggregatedResults = new Object[aggregationFunctions.length];
         for (int i = 0; i < aggregationFunctions.length; i++) {
-          Object resolved = AggregationFunctionUtils.getAggregationResult(aggregationFunctions[i],
-              dataSources[i], numTotalDocs, NonScanBasedAggregationOperator.EXPLAIN_NAME);
-          if (resolved != null) {
-            preAggregatedResults[i] = resolved;
-            anyResolved = true;
+          // Only resolve functions that can be answered from dictionary/metadata; the rest fall back to scan-based
+          // execution in the AggregationOperator below. getAggregationResult() throws for unsupported function types,
+          // so it must not be called for functions that are not metadata compatible (e.g. MODE, SUM, AVG).
+          if (!isFitForNonScanBasedPlan(aggregationFunctions[i])) {
+            continue;
           }
+
+          DataSource dataSource = getDataSourceForAggregationFunction(aggregationFunctions[i]);
+          preAggregatedResults[i] = AggregationFunctionUtils.getAggregationResult(aggregationFunctions[i],
+              dataSource, numTotalDocs, AggregationOperator.EXPLAIN_NAME);
+          anyResolved = true;
         }
 
         if (anyResolved) {
@@ -191,33 +203,73 @@ public class AggregationPlanNode implements PlanNode {
     AggregationFunction[] aggregationFunctions = _queryContext.getAggregationFunctions();
     assert aggregationFunctions != null;
     for (AggregationFunction<?, ?> aggregationFunction : aggregationFunctions) {
-      if (aggregationFunction.getType() == COUNT) {
-        continue;
-      }
-      ExpressionContext argument = aggregationFunction.getInputExpressions().get(0);
-      if (argument.getType() != ExpressionContext.Type.IDENTIFIER) {
+      if (!isFitForNonScanBasedPlan(aggregationFunction)) {
         return false;
       }
-      DataSource dataSource = _indexSegment.getDataSource(argument.getIdentifier(), _queryContext.getSchema());
-      if (DICTIONARY_BASED_FUNCTIONS.contains(aggregationFunction.getType())) {
-        if (dataSource.getDictionary() != null) {
-          continue;
-        }
-      }
-      if (METADATA_BASED_FUNCTIONS.contains(aggregationFunction.getType())) {
-        if (dataSource.getDataSourceMetadata().getMaxValue() != null
-            && dataSource.getDataSourceMetadata().getMinValue() != null) {
-          continue;
-        }
-      }
-      return false;
     }
     return true;
+  }
+
+  /**
+   * Returns {@code true} if the given aggregation function can be resolved from the column dictionary or metadata
+   * (without scanning the segment), {@code false} otherwise. {@code COUNT} is always eligible. Functions whose result
+   * is derived numerically from the column min/max (e.g. MIN, MAX, MINMAXRANGE) are only eligible for numeric columns,
+   * since non-numeric columns (e.g. BYTES) store min/max as raw values that cannot be parsed as numbers.
+   */
+  private boolean isFitForNonScanBasedPlan(AggregationFunction<?, ?> aggregationFunction) {
+    AggregationFunctionType functionType = aggregationFunction.getType();
+    if (functionType == COUNT) {
+      return true;
+    }
+
+    DataSource dataSource = getDataSourceForAggregationFunction(aggregationFunction);
+    if (dataSource == null) {
+      // Aggregation function does not have a single identifier argument (e.g. COUNT(*) or COUNT(1)),
+      // so it cannot be resolved from metadata
+      return false;
+    }
+
+    // MIN/MAX/MINMAXRANGE derive their result numerically from the column min/max, which is only valid for numeric
+    // columns. Non-numeric columns (e.g. BYTES) store min/max as raw values that cannot be parsed as numbers.
+    if (NUMERIC_METADATA_FUNCTIONS.contains(functionType)
+        && !dataSource.getDataSourceMetadata().getDataType().getStoredType().isNumeric()) {
+      return false;
+    }
+
+    if (dataSource.getDictionary() != null && DICTIONARY_BASED_FUNCTIONS.contains(functionType)) {
+      return true;
+    }
+
+    return METADATA_BASED_FUNCTIONS.contains(functionType)
+        && dataSource.getDataSourceMetadata().getMaxValue() != null
+        && dataSource.getDataSourceMetadata().getMinValue() != null;
   }
 
   private static boolean canOptimizeFilteredCount(BaseFilterOperator filterOperator,
       AggregationFunction[] aggregationFunctions) {
     return (aggregationFunctions.length == 1 && aggregationFunctions[0].getType() == COUNT)
         && filterOperator.canOptimizeCount();
+  }
+
+  /**
+   * Returns the data source for the given aggregation function's argument, or {@code null} if the function has no
+   * argument (e.g. {@code COUNT(*)}) or its argument is not a single column identifier (e.g. {@code COUNT(1)} or a
+   * transform expression), in which case it cannot be resolved from dictionary/metadata.
+   *
+   * @param aggregationFunction aggregation function whose argument data source is resolved
+   * @return the argument's data source, or {@code null} if it has no single identifier argument
+   */
+  @Nullable
+  private DataSource getDataSourceForAggregationFunction(AggregationFunction<?, ?> aggregationFunction) {
+    List<?> inputExpressions = aggregationFunction.getInputExpressions();
+    if (!inputExpressions.isEmpty()) {
+      ExpressionContext argument = aggregationFunction.getInputExpressions().get(0);
+      if (argument.getType() != ExpressionContext.Type.IDENTIFIER) {
+        return null;
+      }
+      return _indexSegment.getDataSource(argument.getIdentifier(), _queryContext.getSchema());
+    }
+
+    return null;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/DefaultAggregationExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/DefaultAggregationExecutor.java
@@ -29,8 +29,10 @@ import org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils
 public class DefaultAggregationExecutor implements AggregationExecutor {
   protected final AggregationFunction[] _aggregationFunctions;
   protected final AggregationResultHolder[] _aggregationResultHolders;
+  protected final Object[] _preAggregatedResults;
 
-  public DefaultAggregationExecutor(AggregationFunction[] aggregationFunctions) {
+  public DefaultAggregationExecutor(AggregationFunction[] aggregationFunctions, Object[] preAggregatedResults) {
+    _preAggregatedResults = preAggregatedResults;
     _aggregationFunctions = aggregationFunctions;
     int numAggregationFunctions = aggregationFunctions.length;
     _aggregationResultHolders = new AggregationResultHolder[numAggregationFunctions];
@@ -39,11 +41,18 @@ public class DefaultAggregationExecutor implements AggregationExecutor {
     }
   }
 
+  public DefaultAggregationExecutor(AggregationFunction[] aggregationFunctions) {
+    this(aggregationFunctions, null);
+  }
+
   @Override
   public void aggregate(ValueBlock valueBlock) {
     int numAggregationFunctions = _aggregationFunctions.length;
     int length = valueBlock.getNumDocs();
     for (int i = 0; i < numAggregationFunctions; i++) {
+      if (_preAggregatedResults != null && _preAggregatedResults[i] != null) {
+        continue; // skip — already resolved from metadata
+      }
       AggregationFunction aggregationFunction = _aggregationFunctions[i];
       aggregationFunction.aggregate(length, _aggregationResultHolders[i],
           AggregationFunctionUtils.getBlockValSetMap(aggregationFunction, valueBlock));
@@ -55,7 +64,11 @@ public class DefaultAggregationExecutor implements AggregationExecutor {
     int numFunctions = _aggregationFunctions.length;
     List<Object> aggregationResults = new ArrayList<>(numFunctions);
     for (int i = 0; i < numFunctions; i++) {
-      aggregationResults.add(_aggregationFunctions[i].extractAggregationResult(_aggregationResultHolders[i]));
+      if (_preAggregatedResults != null && _preAggregatedResults[i] != null) {
+        aggregationResults.add(_preAggregatedResults[i]);
+      } else {
+        aggregationResults.add(_aggregationFunctions[i].extractAggregationResult(_aggregationResultHolders[i]));
+      }
     }
     return aggregationResults;
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/DefaultAggregationExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/DefaultAggregationExecutor.java
@@ -31,6 +31,14 @@ public class DefaultAggregationExecutor implements AggregationExecutor {
   protected final AggregationResultHolder[] _aggregationResultHolders;
   protected final Object[] _preAggregatedResults;
 
+  /**
+   * Creates an executor that skips functions with a pre-aggregated result. For each index {@code i} where
+   * {@code preAggregatedResults[i]} is non-null, the function is not aggregated over the scanned blocks and the
+   * pre-aggregated value is emitted directly in the results. A {@code null} array disables this behavior and all
+   * functions are computed by scanning.
+   *
+   * @param preAggregatedResults per-function pre-aggregated results, or {@code null} if none are pre-aggregated
+   */
   public DefaultAggregationExecutor(AggregationFunction[] aggregationFunctions, Object[] preAggregatedResults) {
     _preAggregatedResults = preAggregatedResults;
     _aggregationFunctions = aggregationFunctions;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/DefaultAggregationExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/DefaultAggregationExecutor.java
@@ -20,6 +20,7 @@ package org.apache.pinot.core.query.aggregation;
 
 import java.util.ArrayList;
 import java.util.List;
+import javax.annotation.Nullable;
 import org.apache.pinot.core.operator.blocks.ValueBlock;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils;
@@ -29,18 +30,19 @@ import org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils
 public class DefaultAggregationExecutor implements AggregationExecutor {
   protected final AggregationFunction[] _aggregationFunctions;
   protected final AggregationResultHolder[] _aggregationResultHolders;
-  protected final Object[] _preAggregatedResults;
+  @Nullable
+  protected final Object[] _nonScanResults;
 
-  /**
-   * Creates an executor that skips functions with a pre-aggregated result. For each index {@code i} where
-   * {@code preAggregatedResults[i]} is non-null, the function is not aggregated over the scanned blocks and the
-   * pre-aggregated value is emitted directly in the results. A {@code null} array disables this behavior and all
-   * functions are computed by scanning.
-   *
-   * @param preAggregatedResults per-function pre-aggregated results, or {@code null} if none are pre-aggregated
-   */
-  public DefaultAggregationExecutor(AggregationFunction[] aggregationFunctions, Object[] preAggregatedResults) {
-    _preAggregatedResults = preAggregatedResults;
+  /// Creates an executor that skips functions with a non-scan result (resolved from the column dictionary or
+  /// metadata). For each index {@code i} where {@code nonScanResults[i]} is non-null, the function is not aggregated
+  /// over the scanned blocks and the resolved value is emitted directly in the results. A {@code null} array disables
+  /// this behavior and all functions are computed by scanning.
+  ///
+  /// @param nonScanResults per-function results resolved without scanning (from the column dictionary or metadata),
+  ///     or {@code null} if none are resolved
+  public DefaultAggregationExecutor(AggregationFunction[] aggregationFunctions,
+      @Nullable Object[] nonScanResults) {
+    _nonScanResults = nonScanResults;
     _aggregationFunctions = aggregationFunctions;
     int numAggregationFunctions = aggregationFunctions.length;
     _aggregationResultHolders = new AggregationResultHolder[numAggregationFunctions];
@@ -58,8 +60,8 @@ public class DefaultAggregationExecutor implements AggregationExecutor {
     int numAggregationFunctions = _aggregationFunctions.length;
     int length = valueBlock.getNumDocs();
     for (int i = 0; i < numAggregationFunctions; i++) {
-      if (_preAggregatedResults != null && _preAggregatedResults[i] != null) {
-        continue; // skip — already resolved from metadata
+      if (_nonScanResults != null && _nonScanResults[i] != null) {
+        continue; // skip — already resolved without scanning (dictionary/metadata)
       }
       AggregationFunction aggregationFunction = _aggregationFunctions[i];
       aggregationFunction.aggregate(length, _aggregationResultHolders[i],
@@ -72,8 +74,8 @@ public class DefaultAggregationExecutor implements AggregationExecutor {
     int numFunctions = _aggregationFunctions.length;
     List<Object> aggregationResults = new ArrayList<>(numFunctions);
     for (int i = 0; i < numFunctions; i++) {
-      if (_preAggregatedResults != null && _preAggregatedResults[i] != null) {
-        aggregationResults.add(_preAggregatedResults[i]);
+      if (_nonScanResults != null && _nonScanResults[i] != null) {
+        aggregationResults.add(_nonScanResults[i]);
       } else {
         aggregationResults.add(_aggregationFunctions[i].extractAggregationResult(_aggregationResultHolders[i]));
       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
@@ -497,20 +497,35 @@ public class AggregationFunctionUtils {
   }
 
   /**
-   * Gets the aggregation result without scanning the segment.
-   * This is used for non-scan based aggregation operator.
-   * @param aggregationFunction
-   * @param dataSource
-   * @param numTotalDocs
-   * @return
+   * Resolves the result of the given aggregation function from the column dictionary or metadata, without scanning the
+   * segment. This is used by the non-scan based aggregation operator and by the partial metadata-based path in
+   * {@link org.apache.pinot.core.plan.AggregationPlanNode} to pre-aggregate metadata-eligible functions.
+   * <p>
+   * {@code COUNT} is resolved directly from {@code numTotalDocs}. Every other supported function reads its result from
+   * the column dictionary or metadata and therefore requires a non-null {@code dataSource}. Callers must only invoke
+   * this method for functions that are metadata/dictionary eligible (as determined by the fitness check in
+   * {@link org.apache.pinot.core.plan.AggregationPlanNode}); unsupported function types cause an
+   * {@link IllegalStateException}.
+   *
+   * @param aggregationFunction aggregation function to resolve
+   * @param dataSource data source of the function argument; may be {@code null} only for {@code COUNT}
+   * @param numTotalDocs total number of documents in the segment, used to resolve {@code COUNT}
+   * @param explainPlanName explain-plan name used for periodic query termination checks
+   * @return the pre-aggregated result for the function
+   * @throws IllegalStateException if the function type cannot be resolved from dictionary or metadata
    */
-  public static Object getAggregationResult(AggregationFunction aggregationFunction, DataSource dataSource,
-      int numTotalDocs, String explainName) {
+  public static Object getAggregationResult(AggregationFunction aggregationFunction, @Nullable DataSource dataSource,
+      int numTotalDocs, String explainPlanName) {
+    AggregationFunctionType functionType = aggregationFunction.getType();
+    if (functionType == AggregationFunctionType.COUNT) {
+      return (long) numTotalDocs;
+    }
+    // Every other supported function resolves its result from the column dictionary or metadata, all of which require
+    // a non-null data source.
+    Objects.requireNonNull(dataSource, "DataSource is null for aggregation function: " + functionType);
+
     Object result;
-    switch (aggregationFunction.getType()) {
-      case COUNT:
-        result = (long) numTotalDocs;
-        break;
+    switch (functionType) {
       case MIN:
       case MINMV:
         result = getMinValueNumeric(dataSource);
@@ -543,7 +558,7 @@ public class AggregationFunctionUtils {
       case DISTINCTCOUNTMV:
       case DISTINCTSUMMV:
       case DISTINCTAVGMV:
-        result = getDistinctValueSet(Objects.requireNonNull(dataSource.getDictionary()), explainName);
+        result = getDistinctValueSet(Objects.requireNonNull(dataSource.getDictionary()), explainPlanName);
         break;
       case DISTINCTCOUNTOFFHEAP:
         result = ((DistinctCountOffHeapAggregationFunction) aggregationFunction).extractAggregationResult(
@@ -552,51 +567,51 @@ public class AggregationFunctionUtils {
       case DISTINCTCOUNTHLL:
       case DISTINCTCOUNTHLLMV:
         result = getDistinctCountHLLResult(Objects.requireNonNull(dataSource.getDictionary()),
-            (DistinctCountHLLAggregationFunction) aggregationFunction, explainName);
+            (DistinctCountHLLAggregationFunction) aggregationFunction, explainPlanName);
         break;
       case DISTINCTCOUNTRAWHLL:
       case DISTINCTCOUNTRAWHLLMV:
         result = getDistinctCountHLLResult(Objects.requireNonNull(dataSource.getDictionary()),
             ((DistinctCountRawHLLAggregationFunction) aggregationFunction).getDistinctCountHLLAggregationFunction(),
-            explainName);
+            explainPlanName);
         break;
       case DISTINCTCOUNTHLLPLUS:
       case DISTINCTCOUNTHLLPLUSMV:
         result = getDistinctCountHLLPlusResult(Objects.requireNonNull(dataSource.getDictionary()),
-            (DistinctCountHLLPlusAggregationFunction) aggregationFunction, explainName);
+            (DistinctCountHLLPlusAggregationFunction) aggregationFunction, explainPlanName);
         break;
       case DISTINCTCOUNTRAWHLLPLUS:
       case DISTINCTCOUNTRAWHLLPLUSMV:
         result = getDistinctCountHLLPlusResult(Objects.requireNonNull(dataSource.getDictionary()),
             ((DistinctCountRawHLLPlusAggregationFunction) aggregationFunction)
-                .getDistinctCountHLLPlusAggregationFunction(), explainName);
+                .getDistinctCountHLLPlusAggregationFunction(), explainPlanName);
         break;
       case SEGMENTPARTITIONEDDISTINCTCOUNT:
         result = (long) Objects.requireNonNull(dataSource.getDictionary()).length();
         break;
       case DISTINCTCOUNTSMARTHLL:
         result = getDistinctCountSmartHLLResult(Objects.requireNonNull(dataSource.getDictionary()),
-            (DistinctCountSmartHLLAggregationFunction) aggregationFunction, explainName);
+            (DistinctCountSmartHLLAggregationFunction) aggregationFunction, explainPlanName);
         break;
       case DISTINCTCOUNTSMARTHLLPLUS:
         result = getDistinctCountSmartHLLPlusResult(Objects.requireNonNull(dataSource.getDictionary()),
-            (DistinctCountSmartHLLPlusAggregationFunction) aggregationFunction, explainName);
+            (DistinctCountSmartHLLPlusAggregationFunction) aggregationFunction, explainPlanName);
         break;
       case DISTINCTCOUNTULL:
         result = getDistinctCountULLResult(Objects.requireNonNull(dataSource.getDictionary()),
-            (DistinctCountULLAggregationFunction) aggregationFunction, explainName);
+            (DistinctCountULLAggregationFunction) aggregationFunction, explainPlanName);
         break;
       case DISTINCTCOUNTSMARTULL:
         result = getDistinctCountSmartULLResult(Objects.requireNonNull(dataSource.getDictionary()),
-            (DistinctCountSmartULLAggregationFunction) aggregationFunction, explainName);
+            (DistinctCountSmartULLAggregationFunction) aggregationFunction, explainPlanName);
         break;
       case DISTINCTCOUNTRAWULL:
         result = getDistinctCountULLResult(Objects.requireNonNull(dataSource.getDictionary()),
-            (DistinctCountULLAggregationFunction) aggregationFunction, explainName);
+            (DistinctCountULLAggregationFunction) aggregationFunction, explainPlanName);
         break;
       default:
         throw new IllegalStateException(
-            "Non-scan based aggregation operator does not support function type: " + aggregationFunction.getType());
+            "Non-scan based aggregation operator does not support function type: " + functionType);
     }
 
     return result;
@@ -652,55 +667,55 @@ public class AggregationFunctionUtils {
     }
   }
 
-  private static Set getDistinctValueSet(Dictionary dictionary, String explainName) {
+  private static Set getDistinctValueSet(Dictionary dictionary, String explainPlanName) {
     int dictionarySize = dictionary.length();
     switch (dictionary.getValueType()) {
       case INT:
         IntOpenHashSet intSet = new IntOpenHashSet(dictionarySize);
         for (int dictId = 0; dictId < dictionarySize; dictId++) {
-          QueryThreadContext.checkTerminationAndSampleUsagePeriodically(dictId, explainName);
+          QueryThreadContext.checkTerminationAndSampleUsagePeriodically(dictId, explainPlanName);
           intSet.add(dictionary.getIntValue(dictId));
         }
         return intSet;
       case LONG:
         LongOpenHashSet longSet = new LongOpenHashSet(dictionarySize);
         for (int dictId = 0; dictId < dictionarySize; dictId++) {
-          QueryThreadContext.checkTerminationAndSampleUsagePeriodically(dictId, explainName);
+          QueryThreadContext.checkTerminationAndSampleUsagePeriodically(dictId, explainPlanName);
           longSet.add(dictionary.getLongValue(dictId));
         }
         return longSet;
       case FLOAT:
         FloatOpenHashSet floatSet = new FloatOpenHashSet(dictionarySize);
         for (int dictId = 0; dictId < dictionarySize; dictId++) {
-          QueryThreadContext.checkTerminationAndSampleUsagePeriodically(dictId, explainName);
+          QueryThreadContext.checkTerminationAndSampleUsagePeriodically(dictId, explainPlanName);
           floatSet.add(dictionary.getFloatValue(dictId));
         }
         return floatSet;
       case DOUBLE:
         DoubleOpenHashSet doubleSet = new DoubleOpenHashSet(dictionarySize);
         for (int dictId = 0; dictId < dictionarySize; dictId++) {
-          QueryThreadContext.checkTerminationAndSampleUsagePeriodically(dictId, explainName);
+          QueryThreadContext.checkTerminationAndSampleUsagePeriodically(dictId, explainPlanName);
           doubleSet.add(dictionary.getDoubleValue(dictId));
         }
         return doubleSet;
       case BIG_DECIMAL:
         ObjectOpenHashSet<BigDecimal> bigDecimalSet = new ObjectOpenHashSet<>(dictionarySize);
         for (int dictId = 0; dictId < dictionarySize; dictId++) {
-          QueryThreadContext.checkTerminationAndSampleUsagePeriodically(dictId, explainName);
+          QueryThreadContext.checkTerminationAndSampleUsagePeriodically(dictId, explainPlanName);
           bigDecimalSet.add(dictionary.getBigDecimalValue(dictId));
         }
         return bigDecimalSet;
       case STRING:
         ObjectOpenHashSet<String> stringSet = new ObjectOpenHashSet<>(dictionarySize);
         for (int dictId = 0; dictId < dictionarySize; dictId++) {
-          QueryThreadContext.checkTerminationAndSampleUsagePeriodically(dictId, explainName);
+          QueryThreadContext.checkTerminationAndSampleUsagePeriodically(dictId, explainPlanName);
           stringSet.add(dictionary.getStringValue(dictId));
         }
         return stringSet;
       case BYTES:
         ObjectOpenHashSet<ByteArray> bytesSet = new ObjectOpenHashSet<>(dictionarySize);
         for (int dictId = 0; dictId < dictionarySize; dictId++) {
-          QueryThreadContext.checkTerminationAndSampleUsagePeriodically(dictId, explainName);
+          QueryThreadContext.checkTerminationAndSampleUsagePeriodically(dictId, explainPlanName);
           bytesSet.add(new ByteArray(dictionary.getBytesValue(dictId)));
         }
         return bytesSet;
@@ -709,47 +724,47 @@ public class AggregationFunctionUtils {
     }
   }
 
-  private static HyperLogLog getDistinctValueHLL(Dictionary dictionary, int log2m, String explainName) {
+  private static HyperLogLog getDistinctValueHLL(Dictionary dictionary, int log2m, String explainPlanName) {
     HyperLogLog hll = new HyperLogLog(log2m);
     int length = dictionary.length();
     for (int i = 0; i < length; i++) {
-      QueryThreadContext.checkTerminationAndSampleUsagePeriodically(i, explainName);
+      QueryThreadContext.checkTerminationAndSampleUsagePeriodically(i, explainPlanName);
       hll.offer(dictionary.get(i));
     }
     return hll;
   }
 
-  private static UltraLogLog getDistinctValueULL(Dictionary dictionary, int p, String explainName) {
+  private static UltraLogLog getDistinctValueULL(Dictionary dictionary, int p, String explainPlanName) {
     UltraLogLog ull = UltraLogLog.create(p);
     int length = dictionary.length();
     for (int i = 0; i < length; i++) {
-      QueryThreadContext.checkTerminationAndSampleUsagePeriodically(i, explainName);
+      QueryThreadContext.checkTerminationAndSampleUsagePeriodically(i, explainPlanName);
       Object value = dictionary.get(i);
       UltraLogLogUtils.hashObject(value).ifPresent(ull::add);
     }
     return ull;
   }
 
-  private static HyperLogLogPlus getDistinctValueHLLPlus(Dictionary dictionary, int p, int sp, String explainName) {
+  private static HyperLogLogPlus getDistinctValueHLLPlus(Dictionary dictionary, int p, int sp, String explainPlanName) {
     HyperLogLogPlus hllPlus = new HyperLogLogPlus(p, sp);
     int length = dictionary.length();
     for (int i = 0; i < length; i++) {
-      QueryThreadContext.checkTerminationAndSampleUsagePeriodically(i, explainName);
+      QueryThreadContext.checkTerminationAndSampleUsagePeriodically(i, explainPlanName);
       hllPlus.offer(dictionary.get(i));
     }
     return hllPlus;
   }
 
   private static HyperLogLog getDistinctCountHLLResult(Dictionary dictionary,
-      DistinctCountHLLAggregationFunction function, String explainName) {
+      DistinctCountHLLAggregationFunction function, String explainPlanName) {
     if (dictionary.getValueType() == FieldSpec.DataType.BYTES) {
       // Treat BYTES value as serialized HyperLogLog
       try {
-        QueryThreadContext.checkTerminationAndSampleUsage(explainName);
+        QueryThreadContext.checkTerminationAndSampleUsage(explainPlanName);
         HyperLogLog hll = ObjectSerDeUtils.HYPER_LOG_LOG_SER_DE.deserialize(dictionary.getBytesValue(0));
         int length = dictionary.length();
         for (int i = 1; i < length; i++) {
-          QueryThreadContext.checkTerminationAndSampleUsagePeriodically(i, explainName);
+          QueryThreadContext.checkTerminationAndSampleUsagePeriodically(i, explainPlanName);
           hll.addAll(ObjectSerDeUtils.HYPER_LOG_LOG_SER_DE.deserialize(dictionary.getBytesValue(i)));
         }
         return hll;
@@ -757,20 +772,20 @@ public class AggregationFunctionUtils {
         throw new RuntimeException("Caught exception while merging HyperLogLogs", e);
       }
     } else {
-      return getDistinctValueHLL(dictionary, function.getLog2m(), explainName);
+      return getDistinctValueHLL(dictionary, function.getLog2m(), explainPlanName);
     }
   }
 
   private static HyperLogLogPlus getDistinctCountHLLPlusResult(Dictionary dictionary,
-      DistinctCountHLLPlusAggregationFunction function, String explainName) {
+      DistinctCountHLLPlusAggregationFunction function, String explainPlanName) {
     if (dictionary.getValueType() == FieldSpec.DataType.BYTES) {
       // Treat BYTES value as serialized HyperLogLogPlus
       try {
-        QueryThreadContext.checkTerminationAndSampleUsage(explainName);
+        QueryThreadContext.checkTerminationAndSampleUsage(explainPlanName);
         HyperLogLogPlus hllplus = ObjectSerDeUtils.HYPER_LOG_LOG_PLUS_SER_DE.deserialize(dictionary.getBytesValue(0));
         int length = dictionary.length();
         for (int i = 1; i < length; i++) {
-          QueryThreadContext.checkTerminationAndSampleUsagePeriodically(i, explainName);
+          QueryThreadContext.checkTerminationAndSampleUsagePeriodically(i, explainPlanName);
           hllplus.addAll(ObjectSerDeUtils.HYPER_LOG_LOG_PLUS_SER_DE.deserialize(dictionary.getBytesValue(i)));
         }
         return hllplus;
@@ -778,7 +793,7 @@ public class AggregationFunctionUtils {
         throw new RuntimeException("Caught exception while merging HyperLogLogPluses", e);
       }
     } else {
-      return getDistinctValueHLLPlus(dictionary, function.getP(), function.getSp(), explainName);
+      return getDistinctValueHLLPlus(dictionary, function.getP(), function.getSp(), explainPlanName);
     }
   }
 
@@ -793,25 +808,25 @@ public class AggregationFunctionUtils {
   }
 
   private static Object getDistinctCountSmartHLLPlusResult(Dictionary dictionary,
-      DistinctCountSmartHLLPlusAggregationFunction function, String explainName) {
+      DistinctCountSmartHLLPlusAggregationFunction function, String explainPlanName) {
     if (dictionary.length() > function.getThreshold()) {
       // Store values into a HLLPlus when the dictionary size exceeds the conversion threshold
-      return getDistinctValueHLLPlus(dictionary, function.getP(), function.getSp(), explainName);
+      return getDistinctValueHLLPlus(dictionary, function.getP(), function.getSp(), explainPlanName);
     } else {
-      return getDistinctValueSet(dictionary, explainName);
+      return getDistinctValueSet(dictionary, explainPlanName);
     }
   }
 
   private static UltraLogLog getDistinctCountULLResult(Dictionary dictionary,
-      DistinctCountULLAggregationFunction function, String explainName) {
+      DistinctCountULLAggregationFunction function, String explainPlanName) {
     if (dictionary.getValueType() == FieldSpec.DataType.BYTES) {
       // Treat BYTES value as serialized UltraLogLog and merge
       try {
-        QueryThreadContext.checkTerminationAndSampleUsage(explainName);
+        QueryThreadContext.checkTerminationAndSampleUsage(explainPlanName);
         UltraLogLog ull = ObjectSerDeUtils.ULTRA_LOG_LOG_OBJECT_SER_DE.deserialize(dictionary.getBytesValue(0));
         int length = dictionary.length();
         for (int i = 1; i < length; i++) {
-          QueryThreadContext.checkTerminationAndSampleUsagePeriodically(i, explainName);
+          QueryThreadContext.checkTerminationAndSampleUsagePeriodically(i, explainPlanName);
           ull.add(ObjectSerDeUtils.ULTRA_LOG_LOG_OBJECT_SER_DE.deserialize(dictionary.getBytesValue(i)));
         }
         return ull;
@@ -819,16 +834,17 @@ public class AggregationFunctionUtils {
         throw new RuntimeException("Caught exception while merging UltraLogLogs", e);
       }
     } else {
-      return getDistinctValueULL(dictionary, function.getP(), explainName);
+      return getDistinctValueULL(dictionary, function.getP(), explainPlanName);
     }
   }
 
+  @Nullable
   private static Object getDistinctCountSmartULLResult(Dictionary dictionary,
-      DistinctCountSmartULLAggregationFunction function, String explainName) {
+      DistinctCountSmartULLAggregationFunction function, String explainPlanName) {
     if (dictionary.length() > function.getThreshold()) {
-      return getDistinctValueULL(dictionary, function.getP(), explainName);
+      return getDistinctValueULL(dictionary, function.getP(), explainPlanName);
     } else {
-      return getDistinctValueSet(dictionary, explainName);
+      return getDistinctValueSet(dictionary, explainPlanName);
     }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
@@ -499,7 +499,7 @@ public class AggregationFunctionUtils {
   /**
    * Resolves the result of the given aggregation function from the column dictionary or metadata, without scanning the
    * segment. This is used by the non-scan based aggregation operator and by the partial metadata-based path in
-   * {@link org.apache.pinot.core.plan.AggregationPlanNode} to pre-aggregate metadata-eligible functions.
+   * {@link org.apache.pinot.core.operator.query.AggregationOperator} to resolve metadata-eligible functions.
    * <p>
    * {@code COUNT} is resolved directly from {@code numTotalDocs}. Every other supported function reads its result from
    * the column dictionary or metadata and therefore requires a non-null {@code dataSource}. Callers must only invoke

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
@@ -380,12 +380,10 @@ public class AggregationFunctionUtils {
     return new AggregationInfo(aggregationFunctions, projectOperator, false);
   }
 
-  /**
-   * Builds {@link AggregationInfo} for aggregations without using star-tree index, projecting only the columns
-   * required by {@code projectionFunctions} (a subset of {@code allFunctions}). The partial metadata path passes just
-   * the scanned functions here so that columns used solely by metadata-resolved functions are excluded from the scan,
-   * while {@link AggregationInfo} still carries the full function set. For a full scan the two arrays are identical.
-   */
+  /// Builds {@link AggregationInfo} for aggregations without using star-tree index, projecting only the columns
+  /// required by {@code projectionFunctions} (a subset of {@code allFunctions}). The partial metadata path passes just
+  /// the scanned functions here so that columns used solely by metadata-resolved functions are excluded from the scan,
+  /// while {@link AggregationInfo} still carries the full function set. For a full scan the two arrays are identical.
   public static AggregationInfo buildAggregationInfoWithoutStarTree(SegmentContext segmentContext,
       QueryContext queryContext, AggregationFunction[] allFunctions, AggregationFunction[] projectionFunctions,
       BaseFilterOperator filterOperator) {
@@ -397,9 +395,8 @@ public class AggregationFunctionUtils {
     return new AggregationInfo(allFunctions, projectOperator, false);
   }
 
-  /**
-   * Builds swim-lanes (list of {@link AggregationInfo}) for filtered aggregations.
-   */
+
+  /// Builds swim-lanes (list of {@link AggregationInfo}) for filtered aggregations.
   public static List<AggregationInfo> buildFilteredAggregationInfos(SegmentContext segmentContext,
       QueryContext queryContext) {
     assert queryContext.getAggregationFunctions() != null && queryContext.getFilteredAggregationFunctions() != null;
@@ -515,24 +512,22 @@ public class AggregationFunctionUtils {
     return columnName;
   }
 
-  /**
-   * Resolves the result of the given aggregation function from the column dictionary or metadata, without scanning the
-   * segment. This is used by the non-scan based aggregation operator and by the partial metadata-based path in
-   * {@link org.apache.pinot.core.operator.query.AggregationOperator} to resolve metadata-eligible functions.
-   * <p>
-   * {@code COUNT} is resolved directly from {@code numTotalDocs}. Every other supported function reads its result from
-   * the column dictionary or metadata and therefore requires a non-null {@code dataSource}. Callers must only invoke
-   * this method for functions that are metadata/dictionary eligible (as determined by the fitness check in
-   * {@link org.apache.pinot.core.plan.AggregationPlanNode}); unsupported function types cause an
-   * {@link IllegalStateException}.
-   *
-   * @param aggregationFunction aggregation function to resolve
-   * @param dataSource data source of the function argument; may be {@code null} only for {@code COUNT}
-   * @param numTotalDocs total number of documents in the segment, used to resolve {@code COUNT}
-   * @param explainPlanName explain-plan name used for periodic query termination checks
-   * @return the pre-aggregated result for the function
-   * @throws IllegalStateException if the function type cannot be resolved from dictionary or metadata
-   */
+  /// Resolves the result of the given aggregation function from the column dictionary or metadata, without scanning the
+  /// segment. This is used by the non-scan based aggregation operator and by the partial metadata-based path in
+  /// {@link org.apache.pinot.core.operator.query.AggregationOperator} to resolve metadata-eligible functions.
+  /// <p>
+  /// {@code COUNT} is resolved directly from {@code numTotalDocs}. Every other supported function reads its result from
+  /// the column dictionary or metadata and therefore requires a non-null {@code dataSource}. Callers must only invoke
+  /// this method for functions that are metadata/dictionary eligible (as determined by the fitness check in
+  /// {@link org.apache.pinot.core.plan.AggregationPlanNode}); unsupported function types cause an
+  /// {@link IllegalStateException}.
+  ///
+  /// @param aggregationFunction aggregation function to resolve
+  /// @param dataSource data source of the function argument; may be {@code null} only for {@code COUNT}
+  /// @param numTotalDocs total number of documents in the segment, used to resolve {@code COUNT}
+  /// @param explainPlanName explain-plan name used for periodic query termination checks
+  /// @return the result resolved from dictionary/metadata for the function
+  /// @throws IllegalStateException if the function type cannot be resolved from dictionary or metadata
   public static Object getAggregationResult(AggregationFunction aggregationFunction, @Nullable DataSource dataSource,
       int numTotalDocs, String explainPlanName) {
     AggregationFunctionType functionType = aggregationFunction.getType();
@@ -857,7 +852,6 @@ public class AggregationFunctionUtils {
     }
   }
 
-  @Nullable
   private static Object getDistinctCountSmartULLResult(Dictionary dictionary,
       DistinctCountSmartULLAggregationFunction function, String explainPlanName) {
     if (dictionary.length() > function.getThreshold()) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
@@ -18,11 +18,20 @@
  */
 package org.apache.pinot.core.query.aggregation.function;
 
+import com.clearspring.analytics.stream.cardinality.HyperLogLog;
+import com.clearspring.analytics.stream.cardinality.HyperLogLogPlus;
+import com.dynatrace.hash4j.distinctcount.UltraLogLog;
+import com.google.common.base.Preconditions;
 import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
+import it.unimi.dsi.fastutil.doubles.DoubleOpenHashSet;
 import it.unimi.dsi.fastutil.floats.FloatArrayList;
+import it.unimi.dsi.fastutil.floats.FloatOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
 import it.unimi.dsi.fastutil.longs.LongArrayList;
+import it.unimi.dsi.fastutil.longs.LongOpenHashSet;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import it.unimi.dsi.fastutil.objects.ObjectOpenHashSet;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.sql.Timestamp;
@@ -31,6 +40,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.tuple.Pair;
@@ -42,6 +52,7 @@ import org.apache.pinot.common.request.context.predicate.Predicate;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.common.utils.config.QueryOptionsUtils;
 import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.common.datatable.DataTableBuilder;
 import org.apache.pinot.core.operator.BaseProjectOperator;
 import org.apache.pinot.core.operator.blocks.ValueBlock;
@@ -53,15 +64,22 @@ import org.apache.pinot.core.plan.FilterPlanNode;
 import org.apache.pinot.core.plan.ProjectPlanNode;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.startree.StarTreeUtils;
+import org.apache.pinot.segment.local.customobject.MinMaxRangePair;
+import org.apache.pinot.segment.local.utils.UltraLogLogUtils;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.segment.spi.SegmentContext;
+import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.segment.spi.index.startree.AggregationFunctionColumnPair;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.query.QueryThreadContext;
 import org.apache.pinot.spi.utils.ByteArray;
 
 
 /// The `AggregationFunctionUtils` class provides utility methods for aggregation function.
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class AggregationFunctionUtils {
+
   private AggregationFunctionUtils() {
   }
 
@@ -476,5 +494,341 @@ public class AggregationFunctionUtils {
       columnName += " FILTER(WHERE " + filter + ")";
     }
     return columnName;
+  }
+
+  /**
+   * Gets the aggregation result without scanning the segment.
+   * This is used for non-scan based aggregation operator.
+   * @param aggregationFunction
+   * @param dataSource
+   * @param numTotalDocs
+   * @return
+   */
+  public static Object getAggregationResult(AggregationFunction aggregationFunction, DataSource dataSource,
+      int numTotalDocs, String explainName) {
+    Object result;
+    switch (aggregationFunction.getType()) {
+      case COUNT:
+        result = (long) numTotalDocs;
+        break;
+      case MIN:
+      case MINMV:
+        result = getMinValueNumeric(dataSource);
+        break;
+      case MINLONG:
+        result = getMinValueLong(dataSource);
+        break;
+      case MINSTRING:
+        assert dataSource.getDictionary() != null;
+        result = dataSource.getDictionary().getMinVal();
+        break;
+      case MAX:
+      case MAXMV:
+        result = getMaxValueNumeric(dataSource);
+        break;
+      case MAXLONG:
+        result = getMaxValueLong(dataSource);
+        break;
+      case MAXSTRING:
+        assert dataSource.getDictionary() != null;
+        result = dataSource.getDictionary().getMaxVal();
+        break;
+      case MINMAXRANGE:
+      case MINMAXRANGEMV:
+        result = new MinMaxRangePair(getMinValueNumeric(dataSource), getMaxValueNumeric(dataSource));
+        break;
+      case DISTINCTCOUNT:
+      case DISTINCTSUM:
+      case DISTINCTAVG:
+      case DISTINCTCOUNTMV:
+      case DISTINCTSUMMV:
+      case DISTINCTAVGMV:
+        result = getDistinctValueSet(Objects.requireNonNull(dataSource.getDictionary()), explainName);
+        break;
+      case DISTINCTCOUNTOFFHEAP:
+        result = ((DistinctCountOffHeapAggregationFunction) aggregationFunction).extractAggregationResult(
+            Objects.requireNonNull(dataSource.getDictionary()));
+        break;
+      case DISTINCTCOUNTHLL:
+      case DISTINCTCOUNTHLLMV:
+        result = getDistinctCountHLLResult(Objects.requireNonNull(dataSource.getDictionary()),
+            (DistinctCountHLLAggregationFunction) aggregationFunction, explainName);
+        break;
+      case DISTINCTCOUNTRAWHLL:
+      case DISTINCTCOUNTRAWHLLMV:
+        result = getDistinctCountHLLResult(Objects.requireNonNull(dataSource.getDictionary()),
+            ((DistinctCountRawHLLAggregationFunction) aggregationFunction).getDistinctCountHLLAggregationFunction(),
+            explainName);
+        break;
+      case DISTINCTCOUNTHLLPLUS:
+      case DISTINCTCOUNTHLLPLUSMV:
+        result = getDistinctCountHLLPlusResult(Objects.requireNonNull(dataSource.getDictionary()),
+            (DistinctCountHLLPlusAggregationFunction) aggregationFunction, explainName);
+        break;
+      case DISTINCTCOUNTRAWHLLPLUS:
+      case DISTINCTCOUNTRAWHLLPLUSMV:
+        result = getDistinctCountHLLPlusResult(Objects.requireNonNull(dataSource.getDictionary()),
+            ((DistinctCountRawHLLPlusAggregationFunction) aggregationFunction)
+                .getDistinctCountHLLPlusAggregationFunction(), explainName);
+        break;
+      case SEGMENTPARTITIONEDDISTINCTCOUNT:
+        result = (long) Objects.requireNonNull(dataSource.getDictionary()).length();
+        break;
+      case DISTINCTCOUNTSMARTHLL:
+        result = getDistinctCountSmartHLLResult(Objects.requireNonNull(dataSource.getDictionary()),
+            (DistinctCountSmartHLLAggregationFunction) aggregationFunction, explainName);
+        break;
+      case DISTINCTCOUNTSMARTHLLPLUS:
+        result = getDistinctCountSmartHLLPlusResult(Objects.requireNonNull(dataSource.getDictionary()),
+            (DistinctCountSmartHLLPlusAggregationFunction) aggregationFunction, explainName);
+        break;
+      case DISTINCTCOUNTULL:
+        result = getDistinctCountULLResult(Objects.requireNonNull(dataSource.getDictionary()),
+            (DistinctCountULLAggregationFunction) aggregationFunction, explainName);
+        break;
+      case DISTINCTCOUNTSMARTULL:
+        result = getDistinctCountSmartULLResult(Objects.requireNonNull(dataSource.getDictionary()),
+            (DistinctCountSmartULLAggregationFunction) aggregationFunction, explainName);
+        break;
+      case DISTINCTCOUNTRAWULL:
+        result = getDistinctCountULLResult(Objects.requireNonNull(dataSource.getDictionary()),
+            (DistinctCountULLAggregationFunction) aggregationFunction, explainName);
+        break;
+      default:
+        throw new IllegalStateException(
+            "Non-scan based aggregation operator does not support function type: " + aggregationFunction.getType());
+    }
+
+    return result;
+  }
+
+  private static Double getMinValueNumeric(DataSource dataSource) {
+    Dictionary dictionary = dataSource.getDictionary();
+    if (dictionary != null) {
+      return toDouble(dictionary.getMinVal());
+    }
+    return toDouble(dataSource.getDataSourceMetadata().getMinValue());
+  }
+
+  private static Long getMinValueLong(DataSource dataSource) {
+    FieldSpec.DataType dataType = dataSource.getDataSourceMetadata().getDataType().getStoredType();
+    Preconditions.checkArgument(
+        dataType == FieldSpec.DataType.LONG || dataType == FieldSpec.DataType.INT,
+        "MINLONG aggregation function can only be applied to columns of integer types");
+    Dictionary dictionary = dataSource.getDictionary();
+    if (dictionary != null) {
+      return ((Number) dictionary.getMinVal()).longValue();
+    }
+    return ((Number) dataSource.getDataSourceMetadata().getMinValue()).longValue();
+  }
+
+  private static Double getMaxValueNumeric(DataSource dataSource) {
+    Dictionary dictionary = dataSource.getDictionary();
+    if (dictionary != null) {
+      return toDouble(dictionary.getMaxVal());
+    }
+    return toDouble(dataSource.getDataSourceMetadata().getMaxValue());
+  }
+
+  private static Long getMaxValueLong(DataSource dataSource) {
+    FieldSpec.DataType dataType = dataSource.getDataSourceMetadata().getDataType().getStoredType();
+    Preconditions.checkArgument(
+        dataType == FieldSpec.DataType.LONG || dataType == FieldSpec.DataType.INT,
+        "MAXLONG aggregation function can only be applied to columns of integer types");
+    Dictionary dictionary = dataSource.getDictionary();
+    if (dictionary != null) {
+      return ((Number) dictionary.getMaxVal()).longValue();
+    }
+    return ((Number) dataSource.getDataSourceMetadata().getMaxValue()).longValue();
+  }
+
+  private static Double toDouble(Comparable<?> value) {
+    if (value instanceof Double) {
+      return (Double) value;
+    } else if (value instanceof Number) {
+      return ((Number) value).doubleValue();
+    } else {
+      return Double.parseDouble(value.toString());
+    }
+  }
+
+  private static Set getDistinctValueSet(Dictionary dictionary, String explainName) {
+    int dictionarySize = dictionary.length();
+    switch (dictionary.getValueType()) {
+      case INT:
+        IntOpenHashSet intSet = new IntOpenHashSet(dictionarySize);
+        for (int dictId = 0; dictId < dictionarySize; dictId++) {
+          QueryThreadContext.checkTerminationAndSampleUsagePeriodically(dictId, explainName);
+          intSet.add(dictionary.getIntValue(dictId));
+        }
+        return intSet;
+      case LONG:
+        LongOpenHashSet longSet = new LongOpenHashSet(dictionarySize);
+        for (int dictId = 0; dictId < dictionarySize; dictId++) {
+          QueryThreadContext.checkTerminationAndSampleUsagePeriodically(dictId, explainName);
+          longSet.add(dictionary.getLongValue(dictId));
+        }
+        return longSet;
+      case FLOAT:
+        FloatOpenHashSet floatSet = new FloatOpenHashSet(dictionarySize);
+        for (int dictId = 0; dictId < dictionarySize; dictId++) {
+          QueryThreadContext.checkTerminationAndSampleUsagePeriodically(dictId, explainName);
+          floatSet.add(dictionary.getFloatValue(dictId));
+        }
+        return floatSet;
+      case DOUBLE:
+        DoubleOpenHashSet doubleSet = new DoubleOpenHashSet(dictionarySize);
+        for (int dictId = 0; dictId < dictionarySize; dictId++) {
+          QueryThreadContext.checkTerminationAndSampleUsagePeriodically(dictId, explainName);
+          doubleSet.add(dictionary.getDoubleValue(dictId));
+        }
+        return doubleSet;
+      case BIG_DECIMAL:
+        ObjectOpenHashSet<BigDecimal> bigDecimalSet = new ObjectOpenHashSet<>(dictionarySize);
+        for (int dictId = 0; dictId < dictionarySize; dictId++) {
+          QueryThreadContext.checkTerminationAndSampleUsagePeriodically(dictId, explainName);
+          bigDecimalSet.add(dictionary.getBigDecimalValue(dictId));
+        }
+        return bigDecimalSet;
+      case STRING:
+        ObjectOpenHashSet<String> stringSet = new ObjectOpenHashSet<>(dictionarySize);
+        for (int dictId = 0; dictId < dictionarySize; dictId++) {
+          QueryThreadContext.checkTerminationAndSampleUsagePeriodically(dictId, explainName);
+          stringSet.add(dictionary.getStringValue(dictId));
+        }
+        return stringSet;
+      case BYTES:
+        ObjectOpenHashSet<ByteArray> bytesSet = new ObjectOpenHashSet<>(dictionarySize);
+        for (int dictId = 0; dictId < dictionarySize; dictId++) {
+          QueryThreadContext.checkTerminationAndSampleUsagePeriodically(dictId, explainName);
+          bytesSet.add(new ByteArray(dictionary.getBytesValue(dictId)));
+        }
+        return bytesSet;
+      default:
+        throw new IllegalStateException();
+    }
+  }
+
+  private static HyperLogLog getDistinctValueHLL(Dictionary dictionary, int log2m, String explainName) {
+    HyperLogLog hll = new HyperLogLog(log2m);
+    int length = dictionary.length();
+    for (int i = 0; i < length; i++) {
+      QueryThreadContext.checkTerminationAndSampleUsagePeriodically(i, explainName);
+      hll.offer(dictionary.get(i));
+    }
+    return hll;
+  }
+
+  private static UltraLogLog getDistinctValueULL(Dictionary dictionary, int p, String explainName) {
+    UltraLogLog ull = UltraLogLog.create(p);
+    int length = dictionary.length();
+    for (int i = 0; i < length; i++) {
+      QueryThreadContext.checkTerminationAndSampleUsagePeriodically(i, explainName);
+      Object value = dictionary.get(i);
+      UltraLogLogUtils.hashObject(value).ifPresent(ull::add);
+    }
+    return ull;
+  }
+
+  private static HyperLogLogPlus getDistinctValueHLLPlus(Dictionary dictionary, int p, int sp, String explainName) {
+    HyperLogLogPlus hllPlus = new HyperLogLogPlus(p, sp);
+    int length = dictionary.length();
+    for (int i = 0; i < length; i++) {
+      QueryThreadContext.checkTerminationAndSampleUsagePeriodically(i, explainName);
+      hllPlus.offer(dictionary.get(i));
+    }
+    return hllPlus;
+  }
+
+  private static HyperLogLog getDistinctCountHLLResult(Dictionary dictionary,
+      DistinctCountHLLAggregationFunction function, String explainName) {
+    if (dictionary.getValueType() == FieldSpec.DataType.BYTES) {
+      // Treat BYTES value as serialized HyperLogLog
+      try {
+        QueryThreadContext.checkTerminationAndSampleUsage(explainName);
+        HyperLogLog hll = ObjectSerDeUtils.HYPER_LOG_LOG_SER_DE.deserialize(dictionary.getBytesValue(0));
+        int length = dictionary.length();
+        for (int i = 1; i < length; i++) {
+          QueryThreadContext.checkTerminationAndSampleUsagePeriodically(i, explainName);
+          hll.addAll(ObjectSerDeUtils.HYPER_LOG_LOG_SER_DE.deserialize(dictionary.getBytesValue(i)));
+        }
+        return hll;
+      } catch (Exception e) {
+        throw new RuntimeException("Caught exception while merging HyperLogLogs", e);
+      }
+    } else {
+      return getDistinctValueHLL(dictionary, function.getLog2m(), explainName);
+    }
+  }
+
+  private static HyperLogLogPlus getDistinctCountHLLPlusResult(Dictionary dictionary,
+      DistinctCountHLLPlusAggregationFunction function, String explainName) {
+    if (dictionary.getValueType() == FieldSpec.DataType.BYTES) {
+      // Treat BYTES value as serialized HyperLogLogPlus
+      try {
+        QueryThreadContext.checkTerminationAndSampleUsage(explainName);
+        HyperLogLogPlus hllplus = ObjectSerDeUtils.HYPER_LOG_LOG_PLUS_SER_DE.deserialize(dictionary.getBytesValue(0));
+        int length = dictionary.length();
+        for (int i = 1; i < length; i++) {
+          QueryThreadContext.checkTerminationAndSampleUsagePeriodically(i, explainName);
+          hllplus.addAll(ObjectSerDeUtils.HYPER_LOG_LOG_PLUS_SER_DE.deserialize(dictionary.getBytesValue(i)));
+        }
+        return hllplus;
+      } catch (Exception e) {
+        throw new RuntimeException("Caught exception while merging HyperLogLogPluses", e);
+      }
+    } else {
+      return getDistinctValueHLLPlus(dictionary, function.getP(), function.getSp(), explainName);
+    }
+  }
+
+  private static Object getDistinctCountSmartHLLResult(Dictionary dictionary,
+      DistinctCountSmartHLLAggregationFunction function, String explainPlanName) {
+    if (dictionary.length() > function.getThreshold()) {
+      // Store values into a HLL when the dictionary size exceeds the conversion threshold
+      return getDistinctValueHLL(dictionary, function.getLog2m(), explainPlanName);
+    } else {
+      return getDistinctValueSet(dictionary, explainPlanName);
+    }
+  }
+
+  private static Object getDistinctCountSmartHLLPlusResult(Dictionary dictionary,
+      DistinctCountSmartHLLPlusAggregationFunction function, String explainName) {
+    if (dictionary.length() > function.getThreshold()) {
+      // Store values into a HLLPlus when the dictionary size exceeds the conversion threshold
+      return getDistinctValueHLLPlus(dictionary, function.getP(), function.getSp(), explainName);
+    } else {
+      return getDistinctValueSet(dictionary, explainName);
+    }
+  }
+
+  private static UltraLogLog getDistinctCountULLResult(Dictionary dictionary,
+      DistinctCountULLAggregationFunction function, String explainName) {
+    if (dictionary.getValueType() == FieldSpec.DataType.BYTES) {
+      // Treat BYTES value as serialized UltraLogLog and merge
+      try {
+        QueryThreadContext.checkTerminationAndSampleUsage(explainName);
+        UltraLogLog ull = ObjectSerDeUtils.ULTRA_LOG_LOG_OBJECT_SER_DE.deserialize(dictionary.getBytesValue(0));
+        int length = dictionary.length();
+        for (int i = 1; i < length; i++) {
+          QueryThreadContext.checkTerminationAndSampleUsagePeriodically(i, explainName);
+          ull.add(ObjectSerDeUtils.ULTRA_LOG_LOG_OBJECT_SER_DE.deserialize(dictionary.getBytesValue(i)));
+        }
+        return ull;
+      } catch (Exception e) {
+        throw new RuntimeException("Caught exception while merging UltraLogLogs", e);
+      }
+    } else {
+      return getDistinctValueULL(dictionary, function.getP(), explainName);
+    }
+  }
+
+  private static Object getDistinctCountSmartULLResult(Dictionary dictionary,
+      DistinctCountSmartULLAggregationFunction function, String explainName) {
+    if (dictionary.length() > function.getThreshold()) {
+      return getDistinctValueULL(dictionary, function.getP(), explainName);
+    } else {
+      return getDistinctValueSet(dictionary, explainName);
+    }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
@@ -380,7 +380,26 @@ public class AggregationFunctionUtils {
     return new AggregationInfo(aggregationFunctions, projectOperator, false);
   }
 
-  /// Builds swim-lanes (list of [AggregationInfo]) for filtered aggregations.
+  /**
+   * Builds {@link AggregationInfo} for aggregations without using star-tree index, projecting only the columns
+   * required by {@code projectionFunctions} (a subset of {@code allFunctions}). The partial metadata path passes just
+   * the scanned functions here so that columns used solely by metadata-resolved functions are excluded from the scan,
+   * while {@link AggregationInfo} still carries the full function set. For a full scan the two arrays are identical.
+   */
+  public static AggregationInfo buildAggregationInfoWithoutStarTree(SegmentContext segmentContext,
+      QueryContext queryContext, AggregationFunction[] allFunctions, AggregationFunction[] projectionFunctions,
+      BaseFilterOperator filterOperator) {
+    Set<ExpressionContext> expressionsToTransform =
+        collectExpressionsToTransform(projectionFunctions, queryContext.getGroupByExpressions());
+    BaseProjectOperator<?> projectOperator =
+        new ProjectPlanNode(segmentContext, queryContext, expressionsToTransform, DocIdSetPlanNode.MAX_DOC_PER_CALL,
+            filterOperator).run();
+    return new AggregationInfo(allFunctions, projectOperator, false);
+  }
+
+  /**
+   * Builds swim-lanes (list of {@link AggregationInfo}) for filtered aggregations.
+   */
   public static List<AggregationInfo> buildFilteredAggregationInfos(SegmentContext segmentContext,
       QueryContext queryContext) {
     assert queryContext.getAggregationFunctions() != null && queryContext.getFilteredAggregationFunctions() != null;

--- a/pinot-core/src/main/java/org/apache/pinot/core/startree/executor/StarTreeAggregationExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/startree/executor/StarTreeAggregationExecutor.java
@@ -33,7 +33,10 @@ import org.apache.pinot.segment.spi.index.startree.AggregationFunctionColumnPair
 public class StarTreeAggregationExecutor extends DefaultAggregationExecutor {
   private final AggregationFunctionColumnPair[] _aggregationFunctionColumnPairs;
 
+
   public StarTreeAggregationExecutor(AggregationFunction[] aggregationFunctions) {
+    // StarTreeAggregationExecutor doesn't support pre-aggregated results.
+    // So, we don't need to pass pre-aggregated results to the super class.
     super(aggregationFunctions);
 
     int numAggregationFunctions = aggregationFunctions.length;

--- a/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/MetadataAndDictionaryAggregationPlanMakerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/MetadataAndDictionaryAggregationPlanMakerTest.java
@@ -27,6 +27,8 @@ import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.core.common.Operator;
+import org.apache.pinot.core.operator.BaseProjectOperator;
+import org.apache.pinot.core.operator.ExecutionStatistics;
 import org.apache.pinot.core.operator.blocks.results.AggregationResultsBlock;
 import org.apache.pinot.core.operator.query.AggregationOperator;
 import org.apache.pinot.core.operator.query.FastFilteredCountOperator;
@@ -360,6 +362,93 @@ public class MetadataAndDictionaryAggregationPlanMakerTest {
       assertTrue(exception.getMessage().contains("Cannot compute " + function + " for non-numeric type: BYTES"),
           exception.getMessage());
     }
+  }
+
+  /**
+   * Verifies that a column aggregation resolved by metadata is excluded from the scan projection,
+   * so the partial path only reads the columns needed by the scanned aggregations. The reduced projection is also
+   * reflected in numEntriesScannedPostFilter (20 docs * 1 column instead of 40).
+   */
+  @Test
+  public void testResolvedOnlyColumnExcludedFromProjection() {
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContext(
+        "select max(metricCol), sum(intCol) from " + PREDICTABLE_TABLE_NAME);
+    Operator<?> operator =
+        PLAN_MAKER.makeSegmentPlanNode(new SegmentContext(_predictableSegment), queryContext).run();
+    assertTrue(operator instanceof AggregationOperator);
+
+    BaseProjectOperator<?> projectOperator = ((AggregationOperator) operator).getChildOperators().get(0);
+    // Only intCol (used by the scanned sum) is projected; metricCol (used solely by the resolved max) is excluded.
+    assertEquals(projectOperator.getNumColumnsProjected(), 1);
+    assertTrue(projectOperator.getSourceColumnContextMap().containsKey("intCol"));
+    assertFalse(projectOperator.getSourceColumnContextMap().containsKey("metricCol"));
+
+    AggregationResultsBlock resultsBlock = (AggregationResultsBlock) operator.nextBlock();
+    List<Object> results = resultsBlock.getResults();
+    assertNotNull(results);
+    // max(metricCol) is resolved from the dictionary; sum(intCol) is scanned.
+    // intCol = i + 10 for i = 1..10 over the two row copies, so sum(intCol) = 2 * (11 + 12 + ... + 20) = 310.
+    assertEquals(((Number) results.get(0)).doubleValue(), 10.0);
+    assertEquals(((Number) results.get(1)).doubleValue(), 310.0);
+
+    // All 20 docs are still scanned for the unresolved sum(intCol).
+    assertEquals(operator.getExecutionStatistics().getNumDocsScanned(), 20);
+    // With metricCol excluded, only 1 column is projected, so entries scanned post-filter is 20 docs * 1 column = 20
+    // (it would be 40 if the resolved-only metricCol were still projected).
+    assertEquals(operator.getExecutionStatistics().getNumEntriesScannedPostFilter(), 20);
+  }
+
+  /**
+   * Verifies numDocsScanned and numEntriesScannedPostFilter across the three routing paths: partial metadata
+   * resolution, fully metadata-resolvable (non-scan), and full scan over multiple aggregations.
+   */
+  @Test(dataProvider = "scanCostStatistics")
+  public void testScanCostStatistics(String description, String query, Class<?> expectedOperatorClass,
+      long expectedNumDocsScanned, long expectedNumEntriesScannedPostFilter) {
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContext(query);
+    Operator<?> operator =
+        PLAN_MAKER.makeSegmentPlanNode(new SegmentContext(_predictableSegment), queryContext).run();
+    assertTrue(expectedOperatorClass.isInstance(operator), description);
+    // Drain the blocks so scan operators accumulate their document counts (harmless for the non-scan operator, whose
+    // statistics are constant).
+    operator.nextBlock();
+    ExecutionStatistics stats = operator.getExecutionStatistics();
+    assertEquals(stats.getNumDocsScanned(), expectedNumDocsScanned, description);
+    assertEquals(stats.getNumEntriesScannedPostFilter(), expectedNumEntriesScannedPostFilter, description);
+  }
+
+  @DataProvider(name = "scanCostStatistics")
+  public Object[][] scanCostStatistics() {
+    return new Object[][]{
+        // Partial metadata resolution: max(metricCol) is resolved from the dictionary and only sum(intCol) is
+        // scanned, so a single column is projected -> 20 docs * 1 column = 20 entries scanned post-filter.
+        {
+            "partial metadata resolution",
+            "select max(metricCol), sum(intCol) from " + PREDICTABLE_TABLE_NAME,
+            AggregationOperator.class,
+            20L,
+            20L
+        },
+        // Fully metadata-resolvable: max + min on the numeric dictionary column are both resolved, so the non-scan
+        // operator is used and nothing is scanned post-filter. numDocsScanned is reported as numTotalDocs (20) for
+        // backward compatibility even though no rows are actually scanned.
+        {
+            "fully metadata-resolvable",
+            "select max(metricCol), min(metricCol) from " + PREDICTABLE_TABLE_NAME,
+            NonScanBasedAggregationOperator.class,
+            20L,
+            0L
+        },
+        // Full scan over multiple aggregations: neither sum is resolvable, so both columns are scanned for all 20
+        // docs -> 20 docs * 2 columns = 40 entries scanned post-filter.
+        {
+            "full scan multiple aggregations",
+            "select sum(metricCol), sum(intCol) from " + PREDICTABLE_TABLE_NAME,
+            AggregationOperator.class,
+            20L,
+            40L
+        }
+    };
   }
 
   @DataProvider(name = "testPlanMakerDataProvider")

--- a/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/MetadataAndDictionaryAggregationPlanMakerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/MetadataAndDictionaryAggregationPlanMakerTest.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.metrics.ServerMetrics;
@@ -38,6 +39,7 @@ import org.apache.pinot.segment.local.data.manager.TableDataManager;
 import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentImpl;
 import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
 import org.apache.pinot.segment.local.upsert.ConcurrentMapPartitionUpsertMetadataManager;
 import org.apache.pinot.segment.local.upsert.UpsertContext;
 import org.apache.pinot.segment.local.upsert.UpsertUtils;
@@ -55,6 +57,8 @@ import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.TimeGranularitySpec;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.exception.BadQueryRequestException;
 import org.apache.pinot.spi.utils.ReadMode;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.annotations.AfterClass;
@@ -71,19 +75,27 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
 
 
 public class MetadataAndDictionaryAggregationPlanMakerTest {
   private static final String AVRO_DATA = "data" + File.separator + "test_data-sv.avro";
   private static final String SEGMENT_NAME = "testTable_201711219_20171120";
+  // A small segment with fully predictable data so aggregation results can be asserted exactly. It holds the 10 rows
+  // metricCol = i, intCol = i + 10, bytesCol = new byte[]{(byte) i} for i = 1..10, with every row duplicated (20 rows
+  // total).
+  private static final String PREDICTABLE_TABLE_NAME = "predictableTable";
+  private static final String PREDICTABLE_SEGMENT_NAME = "predictableTable_segment";
   private static final File INDEX_DIR =
       new File(FileUtils.getTempDirectory(), "MetadataAndDictionaryAggregationPlanMakerTest");
   private static final InstancePlanMakerImplV2 PLAN_MAKER = new InstancePlanMakerImplV2();
 
   private IndexSegment _indexSegment;
   private IndexSegment _upsertIndexSegment;
+  private IndexSegment _predictableSegment;
 
   @BeforeTest
   public void buildSegment()
@@ -130,6 +142,45 @@ public class MetadataAndDictionaryAggregationPlanMakerTest {
     SegmentIndexCreationDriver driver = new SegmentIndexCreationDriverImpl();
     driver.init(segmentGeneratorConfig);
     driver.build();
+
+    buildPredictableSegment();
+  }
+
+  /**
+   * Builds a segment with fully predictable data so that aggregation results can be asserted exactly. It contains the
+   * 10 rows where row {@code i} (for {@code i = 1..10}) has {@code metricCol = i}, {@code intCol = i + 10} and
+   * {@code bytesCol = new byte[]{(byte) i}}, and every row is duplicated (20 rows total).
+   */
+  private void buildPredictableSegment()
+      throws Exception {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName(PREDICTABLE_TABLE_NAME)
+        .addMetric("metricCol", FieldSpec.DataType.INT)
+        .addMetric("intCol", FieldSpec.DataType.INT)
+        .addSingleValueDimension("bytesCol", FieldSpec.DataType.BYTES)
+        .build();
+    TableConfig tableConfig =
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(PREDICTABLE_TABLE_NAME).build();
+
+    List<GenericRow> records = new ArrayList<>(20);
+    // Add each row twice.
+    for (int n = 0; n < 2; n++) {
+      for (int i = 1; i <= 10; i++) {
+        GenericRow record = new GenericRow();
+        record.putValue("metricCol", i);
+        record.putValue("intCol", i + 10);
+        record.putValue("bytesCol", new byte[]{(byte) i});
+        records.add(record);
+      }
+    }
+
+    SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(tableConfig, schema);
+    segmentGeneratorConfig.setTableName(PREDICTABLE_TABLE_NAME);
+    segmentGeneratorConfig.setSegmentName(PREDICTABLE_SEGMENT_NAME);
+    segmentGeneratorConfig.setOutDir(INDEX_DIR.getAbsolutePath());
+
+    SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+    driver.init(segmentGeneratorConfig, new GenericRowRecordReader(records));
+    driver.build();
   }
 
   @BeforeClass
@@ -138,6 +189,7 @@ public class MetadataAndDictionaryAggregationPlanMakerTest {
     ServerMetrics.register(mock(ServerMetrics.class));
     _indexSegment = ImmutableSegmentLoader.load(new File(INDEX_DIR, SEGMENT_NAME), ReadMode.heap);
     _upsertIndexSegment = ImmutableSegmentLoader.load(new File(INDEX_DIR, SEGMENT_NAME), ReadMode.heap);
+    _predictableSegment = ImmutableSegmentLoader.load(new File(INDEX_DIR, PREDICTABLE_SEGMENT_NAME), ReadMode.heap);
     TableDataManager tableDataManager = mock(TableDataManager.class);
     when(tableDataManager.getTableDataDir()).thenReturn(INDEX_DIR);
     UpsertContext upsertContext = new UpsertContext.Builder()
@@ -158,6 +210,7 @@ public class MetadataAndDictionaryAggregationPlanMakerTest {
     _indexSegment.destroy();
     _upsertIndexSegment.offload();
     _upsertIndexSegment.destroy();
+    _predictableSegment.destroy();
   }
 
   @AfterTest
@@ -185,23 +238,24 @@ public class MetadataAndDictionaryAggregationPlanMakerTest {
    * functions were metadata eligible; a mixed query would have scanned every function.
    * <p>
    * To prove the eligible function is actually served from metadata (and not scanned), the column dictionary is
-   * overridden to report a bogus max value that does not exist in the data. The query result equals the bogus value
-   * only if the metadata path is taken; a scan would return the true max.
+   * overridden to report a bogus max value that does not exist in the data. MAX equals the bogus value only if the
+   * metadata path is taken (a scan would return the true max of 10), while SUM equals the true scanned sum of
+   * {@code metricCol} ((1 + 2 + ... + 10) over the two row copies = 110).
    */
   @Test
   public void testPartialMetadataBasedAggregationServesEligibleFromMetadata() {
     int bogusMax = 999_999_999;
-    QueryContext queryContext =
-        QueryContextConverterUtils.getQueryContext("select max(daysSinceEpoch), sum(column1) from testTable");
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContext(
+        "select max(metricCol), sum(metricCol) from " + PREDICTABLE_TABLE_NAME);
 
-    // Override only daysSinceEpoch's dictionary max value; everything else delegates to the real segment.
-    DataSource realDataSource = _indexSegment.getDataSource("daysSinceEpoch", queryContext.getSchema());
+    // Override only metricCol's dictionary max value; everything else delegates to the real segment.
+    DataSource realDataSource = _predictableSegment.getDataSource("metricCol", queryContext.getSchema());
     Dictionary dictionaryWithBogusMax = mock(Dictionary.class, delegatesTo(realDataSource.getDictionary()));
     doReturn(bogusMax).when(dictionaryWithBogusMax).getMaxVal();
     DataSource dataSourceWithBogusMax = mock(DataSource.class, delegatesTo(realDataSource));
     doReturn(dictionaryWithBogusMax).when(dataSourceWithBogusMax).getDictionary();
-    IndexSegment segment = mock(IndexSegment.class, delegatesTo(_indexSegment));
-    doReturn(dataSourceWithBogusMax).when(segment).getDataSource(eq("daysSinceEpoch"), any());
+    IndexSegment segment = mock(IndexSegment.class, delegatesTo(_predictableSegment));
+    doReturn(dataSourceWithBogusMax).when(segment).getDataSource(eq("metricCol"), any());
 
     Operator<?> operator = PLAN_MAKER.makeSegmentPlanNode(new SegmentContext(segment), queryContext).run();
     // A mixed query must use the (partial) AggregationOperator, not the fully non-scan based operator.
@@ -212,6 +266,100 @@ public class MetadataAndDictionaryAggregationPlanMakerTest {
     assertNotNull(results);
     // MAX is served from the (overridden) dictionary metadata, so the bogus value proves the metadata path was used.
     assertEquals(((Number) results.get(0)).doubleValue(), (double) bogusMax);
+    // SUM is scanned, so the result is the true sum of metricCol: (1 + 2 + ... + 10) over the two row copies = 110.
+    assertEquals(((Number) results.get(1)).doubleValue(), 110.0);
+  }
+
+  /**
+   * {@code distinctcount} over a dictionary-encoded column is resolved entirely from the dictionary (its cardinality is
+   * the number of distinct values), so it must plan to the fully non-scan {@link NonScanBasedAggregationOperator}
+   * without a mock. {@code metricCol} holds the 10 distinct values 1..10 across 20 (duplicated) rows, so the distinct
+   * count is 10 even though the segment has 20 docs.
+   */
+  @Test
+  public void testDistinctCountResolvedFromDictionary() {
+    // Sanity check that the fixture actually has duplicate rows, so distinct count < total docs is a meaningful result.
+    assertEquals(_predictableSegment.getSegmentMetadata().getTotalDocs(), 20);
+
+    QueryContext queryContext =
+        QueryContextConverterUtils.getQueryContext("select distinctcount(metricCol) from " + PREDICTABLE_TABLE_NAME);
+
+    Operator<?> operator =
+        PLAN_MAKER.makeSegmentPlanNode(new SegmentContext(_predictableSegment), queryContext).run();
+    // The column is dictionary-encoded, so DISTINCTCOUNT is resolved from the dictionary without scanning the segment.
+    assertTrue(operator instanceof NonScanBasedAggregationOperator);
+
+    AggregationResultsBlock resultsBlock = (AggregationResultsBlock) operator.nextBlock();
+    List<Object> results = resultsBlock.getResults();
+    assertNotNull(results);
+    // The intermediate result is the set of distinct dictionary values: metricCol has 10 distinct values (1..10),
+    // fewer than the 20 total docs, proving DISTINCTCOUNT counts distinct values rather than rows.
+    assertEquals(((Set<?>) results.get(0)).size(), 10);
+  }
+
+  /**
+   * Tests for aggregations that cannot be resolved from dictionary/metadata and must therefore fall back to
+   * the scan-based {@link AggregationOperator}, still returning the correct scanned result:
+   * <ul>
+   *   <li>a single non-resolvable aggregation with no filter ({@code sum(metricCol)}): the partial metadata path
+   *   evaluates eligibility per function, and when none is resolvable it must fall back to a full scan rather than
+   *   emitting a (partial) non-scan operator with zero resolved functions;</li>
+   *   <li>an aggregation over an expression argument ({@code max(add(metricCol, intCol))}): the argument is not a plain
+   *   column reference, so it cannot be resolved from dictionary/metadata.</li>
+   * </ul>
+   */
+  @Test(dataProvider = "nonResolvableScanQueries")
+  public void testNonResolvableAggregationFallsToScan(String description, String query, double expectedResult) {
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContext(query);
+
+    Operator<?> operator =
+        PLAN_MAKER.makeSegmentPlanNode(new SegmentContext(_predictableSegment), queryContext).run();
+    assertTrue(operator instanceof AggregationOperator, description);
+
+    AggregationResultsBlock resultsBlock = (AggregationResultsBlock) operator.nextBlock();
+    List<Object> results = resultsBlock.getResults();
+    assertNotNull(results, description);
+    assertEquals(((Number) results.get(0)).doubleValue(), expectedResult, description);
+  }
+
+  @DataProvider(name = "nonResolvableScanQueries")
+  public Object[][] nonResolvableScanQueries() {
+    return new Object[][]{
+        // SUM is not resolvable from metadata and is scanned: (1 + 2 + ... + 10) over the two row copies = 110.
+        {"single non-resolvable aggregation", "select sum(metricCol) from " + PREDICTABLE_TABLE_NAME, 110.0},
+        // add(metricCol, intCol) = i + (i + 10) is an expression argument, so it is scanned; max over i = 1..10 is 30.
+        {"aggregation over expression argument",
+            "select max(add(metricCol, intCol)) from " + PREDICTABLE_TABLE_NAME, 30.0}
+    };
+  }
+
+  /**
+   * MIN/MAX derive their result numerically from the column min/max, which is only valid for numeric columns.
+   * For a non-numeric (BYTES) column the dictionary stores raw values that cannot be
+   * parsed as numbers, so {@code max(bytesCol)} and {@code min(bytesCol)} must fall back to the scan-based
+   * {@link AggregationOperator} rather than being (wrongly) resolved from the dictionary by a
+   * {@link NonScanBasedAggregationOperator}. The scan path in turn throws a
+   * {@link BadQueryRequestException} for non-numeric aggregation.
+   */
+  @Test
+  public void testMinMaxOnNonNumericColumnFallsToScan() {
+    assertNotNull(_predictableSegment.getDataSourceNullable("bytesCol").getDictionary());
+
+    for (String function : List.of("max", "min")) {
+      String query = "select " + function + "(bytesCol) from " + PREDICTABLE_TABLE_NAME;
+      QueryContext queryContext = QueryContextConverterUtils.getQueryContext(query);
+      Operator<?> operator =
+          PLAN_MAKER.makeSegmentPlanNode(new SegmentContext(_predictableSegment), queryContext).run();
+      // MIN/MAX on a non-numeric column must fall back to the scan-based AggregationOperator, not the metadata path.
+      assertTrue(operator instanceof AggregationOperator, query);
+      assertFalse(operator instanceof NonScanBasedAggregationOperator, query);
+
+      // Running the scan path proves it still executes and correctly rejects the non-numeric aggregation rather than
+      // producing a wrong result.
+      BadQueryRequestException exception = expectThrows(BadQueryRequestException.class, operator::nextBlock);
+      assertTrue(exception.getMessage().contains("Cannot compute " + function + " for non-numeric type: BYTES"),
+          exception.getMessage());
+    }
   }
 
   @DataProvider(name = "testPlanMakerDataProvider")
@@ -266,6 +414,9 @@ public class MetadataAndDictionaryAggregationPlanMakerTest {
     // Aggregation
     entries.add(new Object[]{
         "select sum(column1) from testTable", AggregationOperator.class, AggregationOperator.class
+    });
+    entries.add(new Object[]{
+        "select count(*), sum(column1) from testTable", AggregationOperator.class, AggregationOperator.class
     });
     // Aggregation group-by
     entries.add(new Object[]{

--- a/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/MetadataAndDictionaryAggregationPlanMakerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/MetadataAndDictionaryAggregationPlanMakerTest.java
@@ -26,6 +26,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.core.common.Operator;
+import org.apache.pinot.core.operator.blocks.results.AggregationResultsBlock;
 import org.apache.pinot.core.operator.query.AggregationOperator;
 import org.apache.pinot.core.operator.query.FastFilteredCountOperator;
 import org.apache.pinot.core.operator.query.GroupByOperator;
@@ -44,7 +45,9 @@ import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.SegmentContext;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
 import org.apache.pinot.segment.spi.creator.SegmentIndexCreationDriver;
+import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.segment.spi.index.mutable.ThreadSafeMutableRoaringBitmap;
+import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
@@ -61,8 +64,13 @@ import org.testng.annotations.BeforeTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import static org.mockito.AdditionalAnswers.delegatesTo;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
@@ -168,6 +176,42 @@ public class MetadataAndDictionaryAggregationPlanMakerTest {
     segmentContext.setDocIdsSnapshot(UpsertUtils.getQueryableDocIdsSnapshotFromSegment(_upsertIndexSegment));
     Operator<?> upsertOperator = PLAN_MAKER.makeSegmentPlanNode(segmentContext, queryContext).run();
     assertTrue(upsertOperatorClass.isInstance(upsertOperator));
+  }
+
+  /**
+   * Verifies the partial metadata-based aggregation path. When a query mixes a metadata-eligible function (MAX) with a
+   * non-eligible one (SUM), the plan uses an {@link AggregationOperator} that pre-aggregates the eligible function from
+   * metadata while scanning the rest. Before this feature, a non-scan based operator was used only when <em>all</em>
+   * functions were metadata eligible; a mixed query would have scanned every function.
+   * <p>
+   * To prove the eligible function is actually served from metadata (and not scanned), the column dictionary is
+   * overridden to report a bogus max value that does not exist in the data. The query result equals the bogus value
+   * only if the metadata path is taken; a scan would return the true max.
+   */
+  @Test
+  public void testPartialMetadataBasedAggregationServesEligibleFromMetadata() {
+    int bogusMax = 999_999_999;
+    QueryContext queryContext =
+        QueryContextConverterUtils.getQueryContext("select max(daysSinceEpoch), sum(column1) from testTable");
+
+    // Override only daysSinceEpoch's dictionary max value; everything else delegates to the real segment.
+    DataSource realDataSource = _indexSegment.getDataSource("daysSinceEpoch", queryContext.getSchema());
+    Dictionary dictionaryWithBogusMax = mock(Dictionary.class, delegatesTo(realDataSource.getDictionary()));
+    doReturn(bogusMax).when(dictionaryWithBogusMax).getMaxVal();
+    DataSource dataSourceWithBogusMax = mock(DataSource.class, delegatesTo(realDataSource));
+    doReturn(dictionaryWithBogusMax).when(dataSourceWithBogusMax).getDictionary();
+    IndexSegment segment = mock(IndexSegment.class, delegatesTo(_indexSegment));
+    doReturn(dataSourceWithBogusMax).when(segment).getDataSource(eq("daysSinceEpoch"), any());
+
+    Operator<?> operator = PLAN_MAKER.makeSegmentPlanNode(new SegmentContext(segment), queryContext).run();
+    // A mixed query must use the (partial) AggregationOperator, not the fully non-scan based operator.
+    assertTrue(operator instanceof AggregationOperator);
+
+    AggregationResultsBlock resultsBlock = (AggregationResultsBlock) operator.nextBlock();
+    List<Object> results = resultsBlock.getResults();
+    assertNotNull(results);
+    // MAX is served from the (overridden) dictionary metadata, so the bogus value proves the metadata path was used.
+    assertEquals(((Number) results.get(0)).doubleValue(), (double) bogusMax);
   }
 
   @DataProvider(name = "testPlanMakerDataProvider")

--- a/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/MetadataAndDictionaryAggregationPlanMakerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/MetadataAndDictionaryAggregationPlanMakerTest.java
@@ -148,11 +148,9 @@ public class MetadataAndDictionaryAggregationPlanMakerTest {
     buildPredictableSegment();
   }
 
-  /**
-   * Builds a segment with fully predictable data so that aggregation results can be asserted exactly. It contains the
-   * 10 rows where row {@code i} (for {@code i = 1..10}) has {@code metricCol = i}, {@code intCol = i + 10} and
-   * {@code bytesCol = new byte[]{(byte) i}}, and every row is duplicated (20 rows total).
-   */
+  /// Builds a segment with fully predictable data so that aggregation results can be asserted exactly. It contains the
+  /// 10 rows where row {@code i} (for {@code i = 1..10}) has {@code metricCol = i}, {@code intCol = i + 10} and
+  /// {@code bytesCol = new byte[]{(byte) i}}, and every row is duplicated (20 rows total).
   private void buildPredictableSegment()
       throws Exception {
     Schema schema = new Schema.SchemaBuilder().setSchemaName(PREDICTABLE_TABLE_NAME)
@@ -233,17 +231,15 @@ public class MetadataAndDictionaryAggregationPlanMakerTest {
     assertTrue(upsertOperatorClass.isInstance(upsertOperator));
   }
 
-  /**
-   * Verifies the partial metadata-based aggregation path. When a query mixes a metadata-eligible function (MAX) with a
-   * non-eligible one (SUM), the plan uses an {@link AggregationOperator} that pre-aggregates the eligible function from
-   * metadata while scanning the rest. Before this feature, a non-scan based operator was used only when <em>all</em>
-   * functions were metadata eligible; a mixed query would have scanned every function.
-   * <p>
-   * To prove the eligible function is actually served from metadata (and not scanned), the column dictionary is
-   * overridden to report a bogus max value that does not exist in the data. MAX equals the bogus value only if the
-   * metadata path is taken (a scan would return the true max of 10), while SUM equals the true scanned sum of
-   * {@code metricCol} ((1 + 2 + ... + 10) over the two row copies = 110).
-   */
+  /// Verifies the partial metadata-based aggregation path. When a query mixes a metadata-eligible function (MAX) with a
+  /// non-eligible one (SUM), the plan uses an {@link AggregationOperator} that pre-aggregates the eligible function
+  /// from metadata while scanning the rest. Before this feature, a non-scan based operator was used only when _all_
+  /// functions were metadata eligible; a mixed query would have scanned every function.
+  ///
+  /// To prove the eligible function is actually served from metadata (and not scanned), the column dictionary is
+  /// overridden to report a bogus max value that does not exist in the data. MAX equals the bogus value only if the
+  /// metadata path is taken (a scan would return the true max of 10), while SUM equals the true scanned sum of
+  /// {@code metricCol} ((1 + 2 + ... + 10) over the two row copies = 110).
   @Test
   public void testPartialMetadataBasedAggregationServesEligibleFromMetadata() {
     int bogusMax = 999_999_999;
@@ -272,12 +268,10 @@ public class MetadataAndDictionaryAggregationPlanMakerTest {
     assertEquals(((Number) results.get(1)).doubleValue(), 110.0);
   }
 
-  /**
-   * {@code distinctcount} over a dictionary-encoded column is resolved entirely from the dictionary (its cardinality is
-   * the number of distinct values), so it must plan to the fully non-scan {@link NonScanBasedAggregationOperator}
-   * without a mock. {@code metricCol} holds the 10 distinct values 1..10 across 20 (duplicated) rows, so the distinct
-   * count is 10 even though the segment has 20 docs.
-   */
+  /// {@code distinctcount} over a dictionary-encoded column is resolved entirely from the dictionary (its cardinality
+  /// is the number of distinct values), so it must plan to the fully non-scan {@link NonScanBasedAggregationOperator}
+  /// without a mock. {@code metricCol} holds the 10 distinct values 1..10 across 20 (duplicated) rows, so the distinct
+  /// count is 10 even though the segment has 20 docs.
   @Test
   public void testDistinctCountResolvedFromDictionary() {
     // Sanity check that the fixture actually has duplicate rows, so distinct count < total docs is a meaningful result.
@@ -299,17 +293,14 @@ public class MetadataAndDictionaryAggregationPlanMakerTest {
     assertEquals(((Set<?>) results.get(0)).size(), 10);
   }
 
-  /**
-   * Tests for aggregations that cannot be resolved from dictionary/metadata and must therefore fall back to
-   * the scan-based {@link AggregationOperator}, still returning the correct scanned result:
-   * <ul>
-   *   <li>a single non-resolvable aggregation with no filter ({@code sum(metricCol)}): the partial metadata path
-   *   evaluates eligibility per function, and when none is resolvable it must fall back to a full scan rather than
-   *   emitting a (partial) non-scan operator with zero resolved functions;</li>
-   *   <li>an aggregation over an expression argument ({@code max(add(metricCol, intCol))}): the argument is not a plain
-   *   column reference, so it cannot be resolved from dictionary/metadata.</li>
-   * </ul>
-   */
+  /// Tests for aggregations that cannot be resolved from dictionary/metadata and must therefore fall back to
+  /// the scan-based {@link AggregationOperator}, still returning the correct scanned result:
+  ///
+  /// - a single non-resolvable aggregation with no filter ({@code sum(metricCol)}): the partial metadata path
+  ///   evaluates eligibility per function, and when none is resolvable it must fall back to a full scan rather than
+  ///   emitting a (partial) non-scan operator with zero resolved functions;
+  /// - an aggregation over an expression argument ({@code max(add(metricCol, intCol))}): the argument is not a plain
+  ///   column reference, so it cannot be resolved from dictionary/metadata.
   @Test(dataProvider = "nonResolvableScanQueries")
   public void testNonResolvableAggregationFallsToScan(String description, String query, double expectedResult) {
     QueryContext queryContext = QueryContextConverterUtils.getQueryContext(query);
@@ -335,14 +326,12 @@ public class MetadataAndDictionaryAggregationPlanMakerTest {
     };
   }
 
-  /**
-   * MIN/MAX derive their result numerically from the column min/max, which is only valid for numeric columns.
-   * For a non-numeric (BYTES) column the dictionary stores raw values that cannot be
-   * parsed as numbers, so {@code max(bytesCol)} and {@code min(bytesCol)} must fall back to the scan-based
-   * {@link AggregationOperator} rather than being (wrongly) resolved from the dictionary by a
-   * {@link NonScanBasedAggregationOperator}. The scan path in turn throws a
-   * {@link BadQueryRequestException} for non-numeric aggregation.
-   */
+  /// MIN/MAX derive their result numerically from the column min/max, which is only valid for numeric columns.
+  /// For a non-numeric (BYTES) column the dictionary stores raw values that cannot be
+  /// parsed as numbers, so {@code max(bytesCol)} and {@code min(bytesCol)} must fall back to the scan-based
+  /// {@link AggregationOperator} rather than being (wrongly) resolved from the dictionary by a
+  /// {@link NonScanBasedAggregationOperator}. The scan path in turn throws a
+  /// {@link BadQueryRequestException} for non-numeric aggregation.
   @Test
   public void testMinMaxOnNonNumericColumnFallsToScan() {
     assertNotNull(_predictableSegment.getDataSourceNullable("bytesCol").getDictionary());
@@ -364,11 +353,9 @@ public class MetadataAndDictionaryAggregationPlanMakerTest {
     }
   }
 
-  /**
-   * Verifies that a column aggregation resolved by metadata is excluded from the scan projection,
-   * so the partial path only reads the columns needed by the scanned aggregations. The reduced projection is also
-   * reflected in numEntriesScannedPostFilter (20 docs * 1 column instead of 40).
-   */
+  /// Verifies that a column aggregation resolved by metadata is excluded from the scan projection,
+  /// so the partial path only reads the columns needed by the scanned aggregations. The reduced projection is also
+  /// reflected in numEntriesScannedPostFilter (20 docs * 1 column instead of 40).
   @Test
   public void testResolvedOnlyColumnExcludedFromProjection() {
     QueryContext queryContext = QueryContextConverterUtils.getQueryContext(
@@ -398,10 +385,8 @@ public class MetadataAndDictionaryAggregationPlanMakerTest {
     assertEquals(operator.getExecutionStatistics().getNumEntriesScannedPostFilter(), 20);
   }
 
-  /**
-   * Verifies numDocsScanned and numEntriesScannedPostFilter across the three routing paths: partial metadata
-   * resolution, fully metadata-resolvable (non-scan), and full scan over multiple aggregations.
-   */
+  /// Verifies numDocsScanned and numEntriesScannedPostFilter across the three routing paths: partial metadata
+  /// resolution, fully metadata-resolvable (non-scan), and full scan over multiple aggregations.
   @Test(dataProvider = "scanCostStatistics")
   public void testScanCostStatistics(String description, String query, Class<?> expectedOperatorClass,
       long expectedNumDocsScanned, long expectedNumEntriesScannedPostFilter) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/DefaultAggregationExecutorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/DefaultAggregationExecutorTest.java
@@ -114,6 +114,59 @@ public class DefaultAggregationExecutorTest {
   /// Asserts that the aggregation results returned by the executor are as expected.
   @Test
   void testAggregation() {
+    TransformBlock transformBlock = nextTransformBlock();
+    AggregationFunction[] aggregationFunctions = _queryContext.getAggregationFunctions();
+    assert aggregationFunctions != null;
+    AggregationExecutor aggregationExecutor = new DefaultAggregationExecutor(aggregationFunctions);
+    aggregationExecutor.aggregate(transformBlock);
+    List<Object> result = aggregationExecutor.getResult();
+    for (int i = 0; i < result.size(); i++) {
+      double actual = (double) result.get(i);
+      double expected = computeAggregation(AGGREGATION_FUNCTIONS[i], _inputData[i]);
+      Assert.assertEquals(actual, expected,
+          "Aggregation mis-match for function " + AGGREGATION_FUNCTIONS[i] + ", Expected: " + expected + " Actual: "
+              + actual);
+    }
+  }
+
+  /**
+   * Verifies that functions with a pre-aggregated result are not re-computed by scanning: the injected value is
+   * returned as-is, while functions with a {@code null} pre-aggregated entry are still computed from the scanned block.
+   */
+  @Test
+  void testPreAggregatedResultsSkipScan() {
+    TransformBlock transformBlock = nextTransformBlock();
+    AggregationFunction[] aggregationFunctions = _queryContext.getAggregationFunctions();
+    assert aggregationFunctions != null;
+
+    // Pre-aggregate only the first function (index 0 -> SUM); the rest fall back to scan-based execution.
+    Object[] preAggregatedResults = new Object[aggregationFunctions.length];
+    double injectedSum = 12345.0;
+    preAggregatedResults[0] = injectedSum;
+
+    AggregationExecutor aggregationExecutor =
+        new DefaultAggregationExecutor(aggregationFunctions, preAggregatedResults);
+    aggregationExecutor.aggregate(transformBlock);
+    List<Object> result = aggregationExecutor.getResult();
+
+    // Index 0 returns the injected pre-aggregated value untouched (not the scanned SUM).
+    Assert.assertEquals((double) result.get(0), injectedSum,
+        "Pre-aggregated function should return the injected value, not a scanned result");
+
+    // Remaining functions are still computed by scanning the segment.
+    for (int i = 1; i < result.size(); i++) {
+      double actual = (double) result.get(i);
+      double expected = computeAggregation(AGGREGATION_FUNCTIONS[i], _inputData[i]);
+      Assert.assertEquals(actual, expected,
+          "Aggregation mis-match for function " + AGGREGATION_FUNCTIONS[i] + ", Expected: " + expected + " Actual: "
+              + actual);
+    }
+  }
+
+  /**
+   * Builds a transform block over all physical columns of the test segment with a match-all filter.
+   */
+  private TransformBlock nextTransformBlock() {
     Map<String, DataSource> dataSourceMap = new HashMap<>();
     List<ExpressionContext> expressions = new ArrayList<>();
     for (String column : _indexSegment.getPhysicalColumnNames()) {
@@ -127,19 +180,7 @@ public class DefaultAggregationExecutorTest {
     ProjectionOperator projectionOperator =
         new ProjectionOperator(dataSourceMap, docIdSetOperator, new QueryContext.Builder().build());
     TransformOperator transformOperator = new TransformOperator(_queryContext, projectionOperator, expressions);
-    TransformBlock transformBlock = transformOperator.nextBlock();
-    AggregationFunction[] aggregationFunctions = _queryContext.getAggregationFunctions();
-    assert aggregationFunctions != null;
-    AggregationExecutor aggregationExecutor = new DefaultAggregationExecutor(aggregationFunctions);
-    aggregationExecutor.aggregate(transformBlock);
-    List<Object> result = aggregationExecutor.getResult();
-    for (int i = 0; i < result.size(); i++) {
-      double actual = (double) result.get(i);
-      double expected = computeAggregation(AGGREGATION_FUNCTIONS[i], _inputData[i]);
-      Assert.assertEquals(actual, expected,
-          "Aggregation mis-match for function " + AGGREGATION_FUNCTIONS[i] + ", Expected: " + expected + " Actual: "
-              + actual);
-    }
+    return transformOperator.nextBlock();
   }
 
   /// Helper method to setup the index segment on which to perform aggregation tests.

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/DefaultAggregationExecutorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/DefaultAggregationExecutorTest.java
@@ -129,32 +129,37 @@ public class DefaultAggregationExecutorTest {
     }
   }
 
-  /**
-   * Verifies that functions with a pre-aggregated result are not re-computed by scanning: the injected value is
-   * returned as-is, while functions with a {@code null} pre-aggregated entry are still computed from the scanned block.
-   */
+  /// Verifies that functions with a non-scan result are not re-computed by scanning: the injected value is
+  /// returned as-is, while functions with a {@code null} non-scan entry are still computed from the scanned
+  /// block.
   @Test
-  void testPreAggregatedResultsSkipScan() {
+  void testNonScanResultsSkipScan() {
     TransformBlock transformBlock = nextTransformBlock();
     AggregationFunction[] aggregationFunctions = _queryContext.getAggregationFunctions();
     assert aggregationFunctions != null;
 
-    // Pre-aggregate only the first function (index 0 -> SUM); the rest fall back to scan-based execution.
-    Object[] preAggregatedResults = new Object[aggregationFunctions.length];
-    double injectedSum = 12345.0;
-    preAggregatedResults[0] = injectedSum;
+    // Resolve only the second function (index 1 -> MAX) without scanning; the rest fall back to scan-based execution.
+    int nonScanIndex = 1;
+    Object[] nonScanResults = new Object[aggregationFunctions.length];
+    // inject a Double sentinel that cannot occur in the data (all values
+    // are non-negative), proving the injected value is returned untouched rather than recomputed by scanning.
+    double injectedMax = -1.0;
+    nonScanResults[nonScanIndex] = injectedMax;
 
     AggregationExecutor aggregationExecutor =
-        new DefaultAggregationExecutor(aggregationFunctions, preAggregatedResults);
+        new DefaultAggregationExecutor(aggregationFunctions, nonScanResults);
     aggregationExecutor.aggregate(transformBlock);
     List<Object> result = aggregationExecutor.getResult();
 
-    // Index 0 returns the injected pre-aggregated value untouched (not the scanned SUM).
-    Assert.assertEquals((double) result.get(0), injectedSum,
-        "Pre-aggregated function should return the injected value, not a scanned result");
+    // The non-scan function returns the injected value untouched (not a scanned MAX).
+    Assert.assertEquals(result.get(nonScanIndex), injectedMax,
+        "Non-scan function should return the injected value, not a scanned result");
 
     // Remaining functions are still computed by scanning the segment.
-    for (int i = 1; i < result.size(); i++) {
+    for (int i = 0; i < result.size(); i++) {
+      if (i == nonScanIndex) {
+        continue;
+      }
       double actual = (double) result.get(i);
       double expected = computeAggregation(AGGREGATION_FUNCTIONS[i], _inputData[i]);
       Assert.assertEquals(actual, expected,
@@ -163,9 +168,7 @@ public class DefaultAggregationExecutorTest {
     }
   }
 
-  /**
-   * Builds a transform block over all physical columns of the test segment with a match-all filter.
-   */
+  /// Builds a transform block over all physical columns of the test segment with a match-all filter.
   private TransformBlock nextTransformBlock() {
     Map<String, DataSource> dataSourceMap = new HashMap<>();
     List<ExpressionContext> expressions = new ArrayList<>();

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtilsTest.java
@@ -80,7 +80,7 @@ public class AggregationFunctionUtilsTest {
   public void testNonCountWithNullDataSourceThrows() {
     // Every non-COUNT function reads from the column dictionary/metadata and therefore requires a non-null data source.
     assertThrows(NullPointerException.class,
-        () -> AggregationFunctionUtils.getAggregationResult(mockFunction(AggregationFunctionType.MIN), null, 100,
+          () -> AggregationFunctionUtils.getAggregationResult(mockFunction(AggregationFunctionType.MIN), null, 100,
             "TEST"));
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtilsTest.java
@@ -1,0 +1,86 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.aggregation.function;
+
+import org.apache.pinot.segment.spi.AggregationFunctionType;
+import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.segment.spi.index.reader.Dictionary;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
+
+
+/**
+ * Unit test for {@link AggregationFunctionUtils#getAggregationResult}, the metadata/dictionary based aggregation
+ * result resolver used by the non-scan based and partial metadata based aggregation paths.
+ */
+@SuppressWarnings("rawtypes")
+public class AggregationFunctionUtilsTest {
+
+  private static AggregationFunction mockFunction(AggregationFunctionType type) {
+    AggregationFunction aggregationFunction = mock(AggregationFunction.class);
+    when(aggregationFunction.getType()).thenReturn(type);
+    return aggregationFunction;
+  }
+
+  @Test
+  public void testCountResolvedFromNumTotalDocs() {
+    AggregationFunction countFunction = mockFunction(AggregationFunctionType.COUNT);
+    // COUNT is resolved directly from numTotalDocs and must not touch the (possibly null) data source.
+    Object result = AggregationFunctionUtils.getAggregationResult(countFunction, null, 42, "TEST");
+    assertEquals(result, 42L);
+  }
+
+  @Test
+  public void testMinAndMaxResolvedFromDictionary() {
+    Dictionary dictionary = mock(Dictionary.class);
+    when(dictionary.getMinVal()).thenReturn(5);
+    when(dictionary.getMaxVal()).thenReturn(10);
+    DataSource dataSource = mock(DataSource.class);
+    when(dataSource.getDictionary()).thenReturn(dictionary);
+
+    Object minResult = AggregationFunctionUtils.getAggregationResult(mockFunction(AggregationFunctionType.MIN),
+        dataSource, 100, "TEST");
+    assertEquals(minResult, 5.0);
+
+    Object maxResult = AggregationFunctionUtils.getAggregationResult(mockFunction(AggregationFunctionType.MAX),
+        dataSource, 100, "TEST");
+    assertEquals(maxResult, 10.0);
+  }
+
+  @Test
+  public void testUnsupportedFunctionThrows() {
+    // MODE cannot be resolved from dictionary/metadata; the resolver must reject it rather than return a wrong result.
+    DataSource dataSource = mock(DataSource.class);
+    assertThrows(IllegalStateException.class,
+        () -> AggregationFunctionUtils.getAggregationResult(mockFunction(AggregationFunctionType.MODE), dataSource, 100,
+            "TEST"));
+  }
+
+  @Test
+  public void testNonCountWithNullDataSourceThrows() {
+    // Every non-COUNT function reads from the column dictionary/metadata and therefore requires a non-null data source.
+    assertThrows(NullPointerException.class,
+        () -> AggregationFunctionUtils.getAggregationResult(mockFunction(AggregationFunctionType.MIN), null, 100,
+            "TEST"));
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtilsTest.java
@@ -72,8 +72,8 @@ public class AggregationFunctionUtilsTest {
     // MODE cannot be resolved from dictionary/metadata; the resolver must reject it rather than return a wrong result.
     DataSource dataSource = mock(DataSource.class);
     assertThrows(IllegalStateException.class,
-        () -> AggregationFunctionUtils.getAggregationResult(mockFunction(AggregationFunctionType.MODE), dataSource, 100,
-            "TEST"));
+        () -> AggregationFunctionUtils.getAggregationResult(mockFunction(AggregationFunctionType.MODE), dataSource,
+            100, "TEST"));
   }
 
   @Test

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtilsTest.java
@@ -29,10 +29,8 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertThrows;
 
 
-/**
- * Unit test for {@link AggregationFunctionUtils#getAggregationResult}, the metadata/dictionary based aggregation
- * result resolver used by the non-scan based and partial metadata based aggregation paths.
- */
+/// Unit test for {@link AggregationFunctionUtils#getAggregationResult}, the metadata/dictionary based aggregation
+/// result resolver used by the non-scan based and partial metadata based aggregation paths.
 @SuppressWarnings("rawtypes")
 public class AggregationFunctionUtilsTest {
 

--- a/pinot-core/src/test/java/org/apache/pinot/queries/ExplainPlanQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/ExplainPlanQueriesTest.java
@@ -1811,7 +1811,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     });
     result3.add(
         new Object[]{"AGGREGATE(aggregations:count(*), max(noIndexCol1), sum(noIndexCol2), avg(noIndexCol2))", 3, 2});
-    result3.add(new Object[]{"PROJECT(noIndexCol2, noIndexCol1)", 4, 3});
+    result3.add(new Object[]{"PROJECT(noIndexCol2)", 4, 3});
     result3.add(new Object[]{"DOC_ID_SET", 5, 4});
     result3.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 6, 5});
     check(query3, new ResultTable(DATA_SCHEMA, result3));
@@ -1924,7 +1924,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     });
     result3.add(
         new Object[]{"AGGREGATE(aggregations:count(*), max(noIndexCol1), sum(noIndexCol2), avg(noIndexCol2))", 3, 2});
-    result3.add(new Object[]{"PROJECT(noIndexCol2, noIndexCol1)", 4, 3});
+    result3.add(new Object[]{"PROJECT(noIndexCol2)", 4, 3});
     result3.add(new Object[]{"DOC_ID_SET", 5, 4});
     result3.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 6, 5});
     check(query3, new ResultTable(DATA_SCHEMA, result3));

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InnerSegmentAggregationMultiValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InnerSegmentAggregationMultiValueQueriesTest.java
@@ -47,7 +47,7 @@ public class InnerSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
     AggregationOperator aggregationOperator = getOperator(AGGREGATION_QUERY);
     AggregationResultsBlock resultsBlock = aggregationOperator.nextBlock();
     QueriesTestUtils.testInnerSegmentExecutionStatistics(aggregationOperator.getExecutionStatistics(), 100000L, 0L,
-        400000L, 100000L);
+        200000L, 100000L);
     QueriesTestUtils.testInnerSegmentAggregationResult(resultsBlock.getResults(), 100000L, 100991525475000L, 2147434110,
         1182655, 83439903673981L, 100000L);
 

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InnerSegmentAggregationMultiValueRawQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InnerSegmentAggregationMultiValueRawQueriesTest.java
@@ -47,7 +47,7 @@ public class InnerSegmentAggregationMultiValueRawQueriesTest extends BaseMultiVa
     AggregationOperator aggregationOperator = getOperator(AGGREGATION_QUERY);
     AggregationResultsBlock resultsBlock = aggregationOperator.nextBlock();
     QueriesTestUtils.testInnerSegmentExecutionStatistics(aggregationOperator.getExecutionStatistics(), 100000L, 0L,
-        400000L, 100000L);
+        200000L, 100000L);
     QueriesTestUtils.testInnerSegmentAggregationResult(resultsBlock.getResults(), 100000L, 100991525475000L, 2147434110,
         1182655, 83439903673981L, 100000L);
 

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InnerSegmentAggregationSingleValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InnerSegmentAggregationSingleValueQueriesTest.java
@@ -46,7 +46,7 @@ public class InnerSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
     AggregationOperator aggregationOperator = getOperator(AGGREGATION_QUERY);
     AggregationResultsBlock resultsBlock = aggregationOperator.nextBlock();
     QueriesTestUtils.testInnerSegmentExecutionStatistics(aggregationOperator.getExecutionStatistics(), 30000L, 0L,
-        120000L, 30000L);
+        60000L, 30000L);
     QueriesTestUtils.testInnerSegmentAggregationResult(resultsBlock.getResults(), 30000L, 32317185437847L, 2147419555,
         1689277, 28175373944314L, 30000L);
 


### PR DESCRIPTION
Metadata-based aggregation is currently applied only when all projection aggregation functions are metadata-compatible.

If even one aggregation function in the projection is not metadata-based, the query engine falls back to scan-based execution for all aggregations, including those that could have been computed using metadata.
* Metadata-compatible aggregations (e.g., COUNT, MIN, MAX)
* Non-metadata-compatible aggregations (e.g., SUM, DISTINCT, or others)

This results in missed optimization opportunities and unnecessary full segment scans.
Eg: 
```
SELECT COUNT(*), MAX(col1), SUM(col2)
FROM my_table;
```

This PR adds partial metadata based aggregations for aggregation plan node only.

Pending:
- Unit tests