### PR TITLE
Fix Parquet boolean value preservation

### DIFF
--- a/pinot-plugins/pinot-input-format/pinot-parquet/src/main/java/org/apache/pinot/plugin/inputformat/parquet/ParquetAvroRecordExtractor.java
+++ b/pinot-plugins/pinot-input-format/pinot-parquet/src/main/java/org/apache/pinot/plugin/inputformat/parquet/ParquetAvroRecordExtractor.java
@@ -46,6 +46,14 @@ public class ParquetAvroRecordExtractor extends AvroRecordExtractor {
     return handleDeprecatedTypes(convert(value), field);
   }
 
+  @Override
+  protected Object convertSingleValue(Object value) {
+    if (value instanceof Boolean) {
+      return value;
+    }
+    return super.convertSingleValue(value);
+  }
+
   Object handleDeprecatedTypes(Object value, Schema.Field field) {
     Schema.Type avroColumnType = field.schema().getType();
     if (avroColumnType == Schema.Type.UNION) {

--- a/pinot-plugins/pinot-input-format/pinot-parquet/src/main/java/org/apache/pinot/plugin/inputformat/parquet/ParquetNativeRecordExtractor.java
+++ b/pinot-plugins/pinot-input-format/pinot-parquet/src/main/java/org/apache/pinot/plugin/inputformat/parquet/ParquetNativeRecordExtractor.java
@@ -135,7 +135,7 @@ public class ParquetNativeRecordExtractor extends BaseRecordExtractor<Group> {
         case DOUBLE:
           return from.getDouble(fieldIndex, index);
         case BOOLEAN:
-          return from.getValueToString(fieldIndex, index);
+          return from.getBoolean(fieldIndex, index);
         case INT96:
           Binary int96 = from.getInt96(fieldIndex, index);
           return convertInt96ToLong(int96.getBytes());
@@ -173,6 +173,14 @@ public class ParquetNativeRecordExtractor extends BaseRecordExtractor<Group> {
     ByteBuffer buf = ByteBuffer.wrap(int96Bytes).order(ByteOrder.LITTLE_ENDIAN);
     return (buf.getInt(8) - JULIAN_DAY_NUMBER_FOR_UNIX_EPOCH) * DateTimeConstants.MILLIS_PER_DAY
         + buf.getLong(0) / NANOS_PER_MILLISECOND;
+  }
+
+  @Override
+  protected Object convertSingleValue(Object value) {
+    if (value instanceof Boolean) {
+      return value;
+    }
+    return super.convertSingleValue(value);
   }
 
   public Object[] extractList(Group group) {

--- a/pinot-plugins/pinot-input-format/pinot-parquet/src/test/java/org/apache/pinot/plugin/inputformat/parquet/ParquetCollectionAndEquivalenceTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-parquet/src/test/java/org/apache/pinot/plugin/inputformat/parquet/ParquetCollectionAndEquivalenceTest.java
@@ -425,7 +425,7 @@ public class ParquetCollectionAndEquivalenceTest {
     assertEquals(row.getValue("longField"), 1234567890123L);
     assertEquals(row.getValue("floatField"), 1.5F);
     assertEquals(row.getValue("doubleField"), 2.25D);
-    assertEquals(row.getValue("boolField"), "true");
+    assertEquals(row.getValue("boolField"), Boolean.TRUE);
     assertEquals(row.getValue("stringField"), "hello parquet");
     assertEquals(row.getValue("decimalField"), new BigDecimal("123.45"));
     assertEquals(row.getValue("dateField"), 19723);

--- a/pinot-plugins/pinot-input-format/pinot-parquet/src/test/java/org/apache/pinot/plugin/inputformat/parquet/ParquetRecordReaderTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-parquet/src/test/java/org/apache/pinot/plugin/inputformat/parquet/ParquetRecordReaderTest.java
@@ -28,7 +28,13 @@ import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.hadoop.fs.Path;
+import org.apache.parquet.example.data.Group;
+import org.apache.parquet.example.data.simple.SimpleGroupFactory;
 import org.apache.parquet.hadoop.ParquetWriter;
+import org.apache.parquet.hadoop.example.ExampleParquetWriter;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.apache.parquet.schema.MessageType;
+import org.apache.parquet.schema.MessageTypeParser;
 import org.apache.pinot.plugin.inputformat.avro.AvroUtils;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.readers.AbstractRecordReaderTest;
@@ -123,6 +129,17 @@ public class ParquetRecordReaderTest extends AbstractRecordReaderTest {
   }
 
   @Test
+  public void testBooleanValuesPreserved()
+      throws IOException {
+    try (ParquetRecordReader recordReader = new ParquetRecordReader()) {
+      assertBooleanValues(recordReader, writeNativeBooleanParquetFile(), false);
+    }
+    try (ParquetRecordReader recordReader = new ParquetRecordReader()) {
+      assertBooleanValues(recordReader, writeAvroBooleanParquetFile(), true);
+    }
+  }
+
+  @Test
   public void testComparison()
       throws IOException {
     testComparison(_dataFile, SAMPLE_RECORDS_SIZE);
@@ -173,5 +190,56 @@ public class ParquetRecordReaderTest extends AbstractRecordReaderTest {
     Assert.assertFalse(nativeRecordReader.hasNext());
     Assert.assertEquals(recordsRead, totalRecords,
         "Message read from ParquetRecordReader doesn't match the expected number.");
+  }
+
+  private File writeNativeBooleanParquetFile()
+      throws IOException {
+    File outputFile = new File(_tempDir, "boolean-native-" + System.nanoTime() + ".parquet");
+    Path outputPath = new Path(outputFile.getAbsolutePath());
+    MessageType schema = MessageTypeParser.parseMessageType("message BooleanExample {"
+        + "required boolean bool_true;"
+        + "required boolean bool_false;"
+        + "}");
+    try (ParquetWriter<Group> writer = ExampleParquetWriter.builder(outputPath)
+        .withType(schema)
+        .withCompressionCodec(CompressionCodecName.SNAPPY)
+        .build()) {
+      Group group = new SimpleGroupFactory(schema).newGroup();
+      group.append("bool_true", true);
+      group.append("bool_false", false);
+      writer.write(group);
+    }
+    return outputFile;
+  }
+
+  private File writeAvroBooleanParquetFile()
+      throws IOException {
+    File outputFile = new File(_tempDir, "boolean-avro-" + System.nanoTime() + ".parquet");
+    Schema schema = new Schema.Parser().parse("{"
+        + "\"type\":\"record\","
+        + "\"name\":\"BooleanExample\","
+        + "\"fields\":["
+        + "{\"name\":\"bool_true\",\"type\":\"boolean\"},"
+        + "{\"name\":\"bool_false\",\"type\":\"boolean\"}"
+        + "]}");
+    GenericRecord record = new GenericData.Record(schema);
+    record.put("bool_true", true);
+    record.put("bool_false", false);
+    try (ParquetWriter<GenericRecord> writer = ParquetTestUtils.getParquetAvroWriter(
+        new Path(outputFile.getAbsolutePath()), schema)) {
+      writer.write(record);
+    }
+    return outputFile;
+  }
+
+  private void assertBooleanValues(ParquetRecordReader recordReader, File dataFile, boolean useAvroParquetRecordReader)
+      throws IOException {
+    recordReader.init(dataFile, null, null);
+    Assert.assertEquals(recordReader.useAvroParquetRecordReader(), useAvroParquetRecordReader);
+    Assert.assertTrue(recordReader.hasNext());
+    GenericRow row = recordReader.next();
+    Assert.assertEquals(row.getValue("bool_true"), Boolean.TRUE);
+    Assert.assertEquals(row.getValue("bool_false"), Boolean.FALSE);
+    Assert.assertFalse(recordReader.hasNext());
   }
 }


### PR DESCRIPTION
## Summary
- Preserve Parquet `BOOLEAN` values as Java `Boolean` objects in both native and Avro-backed Parquet reader paths.
- Add regression coverage that writes native Parquet and Avro Parquet boolean columns, then verifies `ParquetRecordReader` returns `Boolean.TRUE` and `Boolean.FALSE`.

## How to reproduce the issue
- Read a Parquet file containing a `BOOLEAN` column through `ParquetRecordReader`.
- Before this fix, boolean values were returned as string values such as `"true"` and `"false"` instead of Boolean values.

## Root cause
- The native Parquet extractor read `BOOLEAN` values with `Group#getValueToString()`.
- The shared single-value conversion path also stringified `Boolean` values because booleans are not numeric or byte arrays.

## Validation
- `./mvnw -pl pinot-plugins/pinot-input-format/pinot-parquet -Dtest=ParquetRecordReaderTest#testBooleanValuesPreserved test`
- `./mvnw -pl pinot-plugins/pinot-input-format/pinot-parquet -Dtest=ParquetRecordReaderTest test`
- `./mvnw spotless:apply -pl pinot-plugins/pinot-input-format/pinot-parquet`
- `./mvnw checkstyle:check -pl pinot-plugins/pinot-input-format/pinot-parquet`
- `./mvnw license:format -pl pinot-plugins/pinot-input-format/pinot-parquet`
- `./mvnw license:check -pl pinot-plugins/pinot-input-format/pinot-parquet`
- `git diff --check`