### PR TITLE
Order Parquet map keys deterministically

### DIFF
--- a/pinot-plugins/pinot-input-format/pinot-parquet/src/main/java/org/apache/pinot/plugin/inputformat/parquet/ParquetAvroRecordExtractor.java
+++ b/pinot-plugins/pinot-input-format/pinot-parquet/src/main/java/org/apache/pinot/plugin/inputformat/parquet/ParquetAvroRecordExtractor.java
@@ -18,9 +18,15 @@
  */
 package org.apache.pinot.plugin.inputformat.parquet;
 
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
 import org.apache.pinot.plugin.inputformat.avro.AvroRecordExtractor;
 import org.apache.pinot.spi.data.readers.RecordExtractorConfig;
 
@@ -44,6 +50,39 @@ public class ParquetAvroRecordExtractor extends AvroRecordExtractor {
   @Override
   protected Object transformValue(Object value, Schema.Field field) {
     return handleDeprecatedTypes(convert(value), field);
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  protected Map<Object, Object> convertMap(Object value) {
+    Map<Object, Object> map = (Map<Object, Object>) value;
+    List<Map.Entry<Object, Object>> entries = new ArrayList<>(map.entrySet());
+    entries.removeIf(entry -> entry.getKey() == null);
+    entries.sort(Comparator.comparing(entry -> String.valueOf(convertSingleValue(entry.getKey()))));
+
+    Map<Object, Object> convertedMap = new LinkedHashMap<>(entries.size());
+    for (Map.Entry<Object, Object> entry : entries) {
+      Object mapValue = entry.getValue();
+      Object convertedMapValue = mapValue != null ? convert(mapValue) : null;
+      convertedMap.put(convertSingleValue(entry.getKey()), convertedMapValue);
+    }
+    return convertedMap;
+  }
+
+  @Override
+  protected Map<Object, Object> convertRecord(Object value) {
+    GenericRecord record = (GenericRecord) value;
+    List<Schema.Field> fields = new ArrayList<>(record.getSchema().getFields());
+    fields.sort(Comparator.comparing(Schema.Field::name));
+
+    Map<Object, Object> convertedMap = new LinkedHashMap<>(fields.size());
+    for (Schema.Field field : fields) {
+      String fieldName = field.name();
+      Object fieldValue = record.get(fieldName);
+      Object convertedValue = fieldValue != null ? transformValue(fieldValue, field) : null;
+      convertedMap.put(fieldName, convertedValue);
+    }
+    return convertedMap;
   }
 
   Object handleDeprecatedTypes(Object value, Schema.Field field) {

--- a/pinot-plugins/pinot-input-format/pinot-parquet/src/main/java/org/apache/pinot/plugin/inputformat/parquet/ParquetNativeRecordExtractor.java
+++ b/pinot-plugins/pinot-input-format/pinot-parquet/src/main/java/org/apache/pinot/plugin/inputformat/parquet/ParquetNativeRecordExtractor.java
@@ -18,14 +18,17 @@
  */
 package org.apache.pinot.plugin.inputformat.parquet;
 
-import com.google.common.collect.Maps;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
 import javax.annotation.Nullable;
 import org.apache.parquet.example.data.Group;
 import org.apache.parquet.io.api.Binary;
@@ -215,7 +218,7 @@ public class ParquetNativeRecordExtractor extends BaseRecordExtractor<Group> {
     // Plain Parquet group (no LIST/MAP annotation) — surfaces as a Map keyed by child field name. Reached for
     // nested struct fields and for groups read with the legacy/un-annotated branch.
     int numValues = group.getType().getFieldCount();
-    Map<String, Object> map = Maps.newHashMapWithExpectedSize(numValues);
+    Map<String, Object> map = new TreeMap<>();
     for (int i = 0; i < numValues; i++) {
       map.put(group.getType().getType(i).getName(), extractValue(group, i));
     }
@@ -234,10 +237,8 @@ public class ParquetNativeRecordExtractor extends BaseRecordExtractor<Group> {
     // The repeated wrapper name (`key_value` / `map`) and field order vary across writers, so we resolve the
     // key/value field indices from the schema once and reuse them for every entry.
     //
-    // NOTE: Parquet does NOT guarantee that MAP entries are returned in any particular order on read — neither
-    // sorted nor in insertion order. Writers, page boundaries, and dictionary encodings can all reorder entries.
-    // If you need a stable order, write the data as a LIST of STRUCT<key, value> instead of using the native MAP
-    // logical type. We therefore use a plain HashMap here and make no ordering promise to downstream consumers.
+    // Parquet does NOT guarantee that MAP entries are returned in any particular order on read, so sort by key before
+    // returning the map. Downstream ingestion transforms often iterate map entries while serializing or flattening.
     int numValues = group.getFieldRepetitionCount(0);
     if (numValues == 0) {
       return Map.of();
@@ -245,7 +246,7 @@ public class ParquetNativeRecordExtractor extends BaseRecordExtractor<Group> {
     GroupType keyValueType = group.getType().getType(0).asGroupType();
     int keyIndex = keyValueType.getFieldIndex("key");
     int valueIndex = keyValueType.getFieldIndex("value");
-    Map<String, Object> map = Maps.newHashMapWithExpectedSize(numValues);
+    Map<String, Object> map = new TreeMap<>();
     for (int i = 0; i < numValues; i++) {
       Group keyValueGroup = group.getGroup(0, i);
       Object key = extractValue(keyValueGroup, keyIndex);
@@ -253,6 +254,23 @@ public class ParquetNativeRecordExtractor extends BaseRecordExtractor<Group> {
       map.put(key.toString(), value);
     }
     return map;
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  protected Map<Object, Object> convertMap(Object value) {
+    Map<Object, Object> map = (Map<Object, Object>) value;
+    List<Map.Entry<Object, Object>> entries = new ArrayList<>(map.entrySet());
+    entries.removeIf(entry -> entry.getKey() == null);
+    entries.sort(Comparator.comparing(entry -> String.valueOf(convertSingleValue(entry.getKey()))));
+
+    Map<Object, Object> convertedMap = new LinkedHashMap<>(entries.size());
+    for (Map.Entry<Object, Object> entry : entries) {
+      Object mapValue = entry.getValue();
+      Object convertedMapValue = mapValue != null ? convert(mapValue) : null;
+      convertedMap.put(convertSingleValue(entry.getKey()), convertedMapValue);
+    }
+    return convertedMap;
   }
 
   private boolean isStandardListWrapper(Type repeatedField, String parentListName) {

--- a/pinot-plugins/pinot-input-format/pinot-parquet/src/test/java/org/apache/pinot/plugin/inputformat/parquet/ParquetCollectionAndEquivalenceTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-parquet/src/test/java/org/apache/pinot/plugin/inputformat/parquet/ParquetCollectionAndEquivalenceTest.java
@@ -26,6 +26,7 @@ import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -286,6 +287,62 @@ public class ParquetCollectionAndEquivalenceTest {
     }
   }
 
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testParquetAvroMapKeysAreSorted()
+      throws IOException {
+    Schema avroSchema = new Schema.Parser().parse(String.join("\n",
+        "{",
+        "  \"type\": \"record\",",
+        "  \"name\": \"AvroMapOrdering\",",
+        "  \"namespace\": \"com.example\",",
+        "  \"fields\": [",
+        "    {\"name\": \"properties\", \"type\": {\"type\": \"map\", \"values\": \"string\"}},",
+        "    {\"name\": \"nested\", \"type\": {",
+        "      \"type\": \"record\",",
+        "      \"name\": \"Nested\",",
+        "      \"fields\": [",
+        "        {\"name\": \"b\", \"type\": \"string\"},",
+        "        {\"name\": \"a\", \"type\": \"string\"}",
+        "      ]",
+        "    }}",
+        "  ]",
+        "}"));
+    FileUtils.forceMkdir(_tempDir);
+    File dataFile = new File(_tempDir, "avro-map-ordering.parquet");
+    FileUtils.deleteQuietly(dataFile);
+
+    GenericRecord row = new GenericData.Record(avroSchema);
+    Map<String, String> properties = new LinkedHashMap<>();
+    properties.put("z", "last");
+    properties.put("a", "first");
+    properties.put("m", "middle");
+    row.put("properties", properties);
+    GenericRecord nested = new GenericData.Record(avroSchema.getField("nested").schema());
+    nested.put("b", "bee");
+    nested.put("a", "aye");
+    row.put("nested", nested);
+
+    try (ParquetWriter<GenericRecord> writer = ParquetTestUtils.getParquetAvroWriter(
+        new Path(dataFile.getAbsolutePath()), avroSchema)) {
+      writer.write(row);
+    }
+    try (ParquetRecordReader recordReader = new ParquetRecordReader()) {
+      recordReader.init(dataFile, null, null);
+      assertTrue(recordReader.useAvroParquetRecordReader());
+      assertTrue(recordReader.hasNext());
+      GenericRow out = recordReader.next();
+      Map<String, Object> propertiesOut = (Map<String, Object>) out.getValue("properties");
+      assertKeyOrder(propertiesOut, "a", "m", "z");
+      assertEquals(propertiesOut, Map.of("a", "first", "m", "middle", "z", "last"));
+
+      Map<String, Object> nestedOut = (Map<String, Object>) out.getValue("nested");
+      assertKeyOrder(nestedOut, "a", "b");
+      assertEquals(nestedOut, Map.of("a", "aye", "b", "bee"));
+      assertFalse(recordReader.hasNext());
+    }
+  }
+
   /**
    * Cross-checks every existing Parquet test resource through both readers and asserts the two produce the
    * same Pinot rows. Locks in that any encoding subtlety in the fixtures (LIST/MAP variants, INT96, decimals,
@@ -354,8 +411,8 @@ public class ParquetCollectionAndEquivalenceTest {
       topLevelTags.addGroup("list").append("element", "top-a");
       topLevelTags.addGroup("list").append("element", "top-b");
       Group topLevelProperties = group.addGroup("topLevelProperties");
-      topLevelProperties.addGroup("key_value").append("key", "top-key-a").append("value", "top-value-a");
       topLevelProperties.addGroup("key_value").append("key", "top-key-b").append("value", "top-value-b");
+      topLevelProperties.addGroup("key_value").append("key", "top-key-a").append("value", "top-value-a");
       group.addGroup("emptyProperties");
       Group metadata = group.addGroup("metadata");
       metadata.append("element", "real-element-field");
@@ -371,8 +428,8 @@ public class ParquetCollectionAndEquivalenceTest {
       metadata.addGroup("tagStructs").addGroup("list").addGroup("element").append("element", "inner-a");
       metadata.getGroup("tagStructs", 0).addGroup("list").addGroup("element").append("element", "inner-b");
       Group properties = metadata.addGroup("properties");
-      properties.addGroup("key_value").append("key", "key-a").append("value", "value-a");
       properties.addGroup("key_value").append("key", "key-b").append("value", "value-b");
+      properties.addGroup("key_value").append("key", "key-a").append("value", "value-a");
       writer.write(group);
     }
     return dataFile;
@@ -384,14 +441,18 @@ public class ParquetCollectionAndEquivalenceTest {
     assertTrue(recordReader.hasNext());
     GenericRow row = recordReader.next();
     assertEquals(Arrays.asList((Object[]) row.getValue("topLevelTags")), Arrays.asList("top-a", "top-b"));
-    assertEquals(row.getValue("topLevelProperties"), Map.of("top-key-a", "top-value-a", "top-key-b", "top-value-b"));
+    Map<String, Object> topLevelProperties = (Map<String, Object>) row.getValue("topLevelProperties");
+    assertKeyOrder(topLevelProperties, "top-key-a", "top-key-b");
+    assertEquals(topLevelProperties, Map.of("top-key-a", "top-value-a", "top-key-b", "top-value-b"));
     assertEquals(row.getValue("emptyProperties"), Map.of());
 
     Map<String, Object> metadata = (Map<String, Object>) row.getValue("metadata");
     assertEquals(metadata.get("element"), "real-element-field");
     assertEquals(Arrays.asList((Object[]) metadata.get("tags")), Arrays.asList("abc", "xyz"));
     assertEquals(Arrays.asList((Object[]) metadata.get("nullableTags")), Arrays.asList(null, "nonnull"));
-    assertEquals(metadata.get("properties"), Map.of("key-a", "value-a", "key-b", "value-b"));
+    Map<String, Object> properties = (Map<String, Object>) metadata.get("properties");
+    assertKeyOrder(properties, "key-a", "key-b");
+    assertEquals(properties, Map.of("key-a", "value-a", "key-b", "value-b"));
 
     // Per the Parquet LogicalTypes spec backward-compat rules, a single-field repeated wrapper whose name is
     // NOT `array` or `<list>_tuple` is a wrapper — its inner field is the element regardless of the inner
@@ -494,6 +555,10 @@ public class ParquetCollectionAndEquivalenceTest {
       reader.close();
     }
     return rows;
+  }
+
+  private static void assertKeyOrder(Map<?, ?> map, String... expectedKeys) {
+    assertEquals(new ArrayList<>(map.keySet()), Arrays.asList(expectedKeys));
   }
 
   /**


### PR DESCRIPTION
## Summary
- Sort Parquet MAP keys before returning map values from the native reader.
- Preserve sorted map iteration order during Parquet Avro-backed conversion.
- Add regression coverage for deterministic key order in native and Avro-backed Parquet paths.

## Why
Parquet MAP entries are not guaranteed to be read back in a stable order. Later ingestion processing can iterate those maps while flattening or serializing, which makes deterministic map-key order useful for reproducible downstream behavior.

## How to reproduce the issue
1. Write a Parquet file with MAP entries in non-sorted order, for example keys `z`, `a`, `m`.
2. Read the file through Pinot Parquet readers.
3. Iterate the returned map keys during a downstream transform or serialization step.
4. The old implementation rebuilt maps with hash-based iteration order, so consumers could not rely on deterministic key traversal.

## Validation
- `./mvnw -pl pinot-plugins/pinot-input-format/pinot-parquet -Dtest=ParquetCollectionAndEquivalenceTest test`
- `./mvnw -pl pinot-plugins/pinot-input-format/pinot-parquet test`
- `./mvnw spotless:apply -pl pinot-plugins/pinot-input-format/pinot-parquet`
- `./mvnw checkstyle:check -pl pinot-plugins/pinot-input-format/pinot-parquet`
- `./mvnw license:format -pl pinot-plugins/pinot-input-format/pinot-parquet`
- `./mvnw license:check -pl pinot-plugins/pinot-input-format/pinot-parquet`
