### PR TITLE
Fix code quality issues: raw types, printStackTrace, System.out, and empty catch blocks

### DIFF
--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/utils/DriverUtils.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/utils/DriverUtils.java
@@ -276,6 +276,7 @@ public class DriverUtils {
           return numVal;
         }
       } catch (NumberFormatException e) {
+        // Not a Long, try the next format
       }
 
       try {
@@ -284,6 +285,7 @@ public class DriverUtils {
           return numVal;
         }
       } catch (NumberFormatException e) {
+        // Not a Double, try the next format
       }
 
       Boolean boolVal = Boolean.valueOf(str.toLowerCase());

--- a/pinot-common/src/main/java/org/apache/pinot/common/helix/ExtraInstanceConfig.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/helix/ExtraInstanceConfig.java
@@ -65,7 +65,8 @@ public class ExtraInstanceConfig {
           protocol = CommonConstants.HTTP_PROTOCOL;
           port = _proxy.getPort();
         }
-      } catch (Exception ignored) {
+      } catch (Exception e) {
+        // Failed to parse port as integer, URL will not be constructed
       }
     }
     if (port != null) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/helix/ExtraInstanceConfig.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/helix/ExtraInstanceConfig.java
@@ -65,7 +65,7 @@ public class ExtraInstanceConfig {
           protocol = CommonConstants.HTTP_PROTOCOL;
           port = _proxy.getPort();
         }
-      } catch (Exception e) {
+      } catch (Exception ex) {
         // Failed to parse port as integer, URL will not be constructed
       }
     }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
@@ -890,7 +890,8 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
             if (lock != null) {
               acquiredTaskLocks.put(tableName, lock);
             }
-          } catch (RuntimeException ignore) {
+          } catch (RuntimeException e) {
+            LOGGER.warn("Failed to acquire task lock for task type: {} on table: {}", taskType, tableName, e);
           }
         }
 

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/src/main/java/org/apache/pinot/plugin/ingestion/batch/hadoop/HadoopSegmentGenerationJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/src/main/java/org/apache/pinot/plugin/ingestion/batch/hadoop/HadoopSegmentGenerationJobRunner.java
@@ -333,7 +333,7 @@ public class HadoopSegmentGenerationJobRunner extends Configured implements Inge
       return;
     }
 
-    ArrayList<File> validPluginDirectories = new ArrayList();
+    ArrayList<File> validPluginDirectories = new ArrayList<>();
 
     for (String pluginsDirPath : pluginDirectories) {
       File pluginsDir = new File(pluginsDirPath);

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark3/SparkSegmentGenerationJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark3/SparkSegmentGenerationJobRunner.java
@@ -366,7 +366,7 @@ public class SparkSegmentGenerationJobRunner implements IngestionJobRunner, Seri
       return;
     }
 
-    ArrayList<File> validPluginDirectories = new ArrayList();
+    ArrayList<File> validPluginDirectories = new ArrayList<>();
 
     for (String pluginsDirPath : pluginDirectories) {
       File pluginsDir = new File(pluginsDirPath);

--- a/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3Config.java
+++ b/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3Config.java
@@ -212,7 +212,8 @@ public class S3Config {
     try {
       // try format like '1hr20s'
       return Duration.ofMillis(TimeUtils.convertPeriodToMillis(durStr));
-    } catch (Exception ignore) {
+    } catch (Exception e) {
+      // Not a period format, try ISO-8601 duration format
     }
     try {
       // try format like 'PT1H20S'

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/RealtimeSegmentStatsHistory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/RealtimeSegmentStatsHistory.java
@@ -100,7 +100,7 @@ public class RealtimeSegmentStatsHistory implements Serializable {
     // numRowsIndexed can be <= numRowsConsumed when aggregateMetrics is true.
     private int _numSeconds;        // Number of seconds taken to consume them
     private long _memUsedBytes;          // Memory used for consumption (bytes)
-    private Map<String, ColumnStats> _colNameToStats = new HashMap();
+    private Map<String, ColumnStats> _colNameToStats = new HashMap<>();
 
     public int getNumRowsConsumed() {
       return _numRowsConsumed;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/OffHeapStarTree.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/OffHeapStarTree.java
@@ -28,6 +28,8 @@ import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.segment.spi.index.startree.StarTree;
 import org.apache.pinot.segment.spi.index.startree.StarTreeNode;
 import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -36,6 +38,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * The {@code OffHeapStarTree} class implements the star-tree using off-heap memory.
  */
 public class OffHeapStarTree implements StarTree {
+  private static final Logger LOGGER = LoggerFactory.getLogger(OffHeapStarTree.class);
   public static final long MAGIC_MARKER = 0xBADDA55B00DAD00DL;
   public static final int VERSION = 1;
 
@@ -128,7 +131,7 @@ public class OffHeapStarTree implements StarTree {
         .add("startDocId", node.getStartDocId()).add("endDocId", node.getEndDocId())
         .add("aggregatedDocId", node.getAggregatedDocId()).add("numChildren", node.getNumChildren()).toString();
     stringBuilder.append(formattedOutput);
-    System.out.println(stringBuilder.toString());
+    LOGGER.debug("{}", stringBuilder);
 
     if (!node.isLeaf()) {
       Iterator<OffHeapStarTreeNode> childrenIterator = node.getChildrenIterator();

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/memory/PinotDataBuffer.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/memory/PinotDataBuffer.java
@@ -346,7 +346,7 @@ public abstract class PinotDataBuffer implements DataBuffer {
       try {
         buffer.close();
       } catch (IOException e) {
-        e.printStackTrace();
+        LOGGER.error("Failed to close PinotDataBuffer", e);
       }
     }
     BUFFER_CONTEXT_MAP.clear();

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/ByteArray.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/ByteArray.java
@@ -175,7 +175,8 @@ public class ByteArray implements Comparable<ByteArray>, Serializable {
             rightToIndex);
       } catch (ArrayIndexOutOfBoundsException outOfBounds) {
         throw outOfBounds;
-      } catch (Throwable ignore) {
+      } catch (Throwable t) {
+        LOGGER.debug("MethodHandle invocation for Arrays.compareUnsigned failed, falling back to manual comparison", t);
       }
     }
     return compareFallback(left, leftFromIndex, leftToIndex, right, rightFromIndex, rightToIndex);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/TimestampUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/TimestampUtils.java
@@ -85,6 +85,7 @@ public class TimestampUtils {
     try {
       return new Timestamp(Long.parseLong(timestampString));
     } catch (Exception e) {
+      // Try the next format
     }
     try {
       return Timestamp.from(ZonedDateTime.parse(timestampString, UNIVERSAL_DATE_TIME_FORMATTER).toInstant());


### PR DESCRIPTION
## Summary
- Replace raw type `new HashMap()` / `new ArrayList()` with diamond operator in `RealtimeSegmentStatsHistory`, `SparkSegmentGenerationJobRunner`, and `HadoopSegmentGenerationJobRunner`
- Replace `e.printStackTrace()` with `LOGGER.error()` in `PinotDataBuffer.closeOpenBuffers()`
- Replace `System.out.println` with `LOGGER.debug()` in `OffHeapStarTree.printTreeHelper()` (added slf4j Logger)
- Add `LOGGER.warn()` to silent catch block in `PinotTaskManager` during task lock acquisition
- Add `LOGGER.debug()` to silent catch block in `ByteArray` for MethodHandle fallback
- Add descriptive comments to catch blocks in `DriverUtils`, `TimestampUtils`, `ExtraInstanceConfig`, and `S3Config`

## Test plan
- [ ] Verify `spotless:apply` and `checkstyle:check` pass on all affected modules
- [ ] Verify no behavioral changes — all fixes are logging/comment-only or type inference (diamond operator)
- [ ] CI green