### PR TITLE
Skip table size aggregation for disabled and null-IdealState tables in SegmentStatusChecker

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java
@@ -123,7 +123,12 @@ public class SegmentStatusChecker extends ControllerPeriodicTask<SegmentStatusCh
       TableConfig tableConfig = _pinotHelixResourceManager.getTableConfig(tableNameWithType);
       updateTableConfigMetrics(tableNameWithType, tableConfig, context);
       updateSegmentMetrics(tableNameWithType, tableConfig, context);
-      updateTableSizeMetrics(tableNameWithType);
+      // Skip table size aggregation for disabled tables. Servers do not load segments for disabled tables, so the
+      // /table/{name}/size scatter-gather would otherwise return 404 from every server and flood controller logs
+      // with ERROR-level entries. updateSegmentMetrics has already populated context._disabledTables.
+      if (!context._disabledTables.contains(tableNameWithType)) {
+        updateTableSizeMetrics(tableNameWithType);
+      }
     } catch (Exception e) {
       LOGGER.error("Caught exception while updating segment status for table {}", tableNameWithType, e);
       // Remove the metric for this table

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java
@@ -123,10 +123,13 @@ public class SegmentStatusChecker extends ControllerPeriodicTask<SegmentStatusCh
       TableConfig tableConfig = _pinotHelixResourceManager.getTableConfig(tableNameWithType);
       updateTableConfigMetrics(tableNameWithType, tableConfig, context);
       updateSegmentMetrics(tableNameWithType, tableConfig, context);
-      // Skip table size aggregation for disabled tables. Servers do not load segments for disabled tables, so the
-      // /table/{name}/size scatter-gather would otherwise return 404 from every server and flood controller logs
-      // with ERROR-level entries. updateSegmentMetrics has already populated context._disabledTables.
-      if (!context._disabledTables.contains(tableNameWithType)) {
+      // Skip the /table/{name}/size scatter-gather when the table can't return useful size data. Two cases:
+      //   - Disabled table: servers do not load segments, every server responds 404, controller logs flood with
+      //     ERROR entries (issue #14279).
+      //   - Null IdealState: no servers known to query; getServerToSegmentsMap throws IllegalStateException
+      //     which propagates to the outer catch as an ERROR + stack trace per table per cycle.
+      // updateSegmentMetrics populates context._tablesToSkipSizeAggregation in both branches.
+      if (!context._tablesToSkipSizeAggregation.contains(tableNameWithType)) {
         updateTableSizeMetrics(tableNameWithType);
       }
     } catch (Exception e) {
@@ -280,6 +283,7 @@ public class SegmentStatusChecker extends ControllerPeriodicTask<SegmentStatusCh
     if (idealState == null) {
       LOGGER.warn("Table {} has null ideal state. Skipping segment status checks", tableNameWithType);
       removeMetricsForTable(tableNameWithType);
+      context._tablesToSkipSizeAggregation.add(tableNameWithType);
       return;
     }
 
@@ -289,6 +293,7 @@ public class SegmentStatusChecker extends ControllerPeriodicTask<SegmentStatusCh
       }
       removeMetricsForTable(tableNameWithType);
       context._disabledTables.add(tableNameWithType);
+      context._tablesToSkipSizeAggregation.add(tableNameWithType);
       return;
     }
 
@@ -599,6 +604,9 @@ public class SegmentStatusChecker extends ControllerPeriodicTask<SegmentStatusCh
     private final Map<String, Integer> _tierBackendTableCountMap = new HashMap<>();
     private final Set<String> _processedTables = new HashSet<>();
     private final Set<String> _disabledTables = new HashSet<>();
+    // Superset of _disabledTables: tables for which updateTableSizeMetrics should be skipped because
+    // /table/{name}/size cannot return useful data (disabled tables, or tables with null IdealState).
+    private final Set<String> _tablesToSkipSizeAggregation = new HashSet<>();
     private final Set<String> _pausedTables = new HashSet<>();
   }
 }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/SegmentStatusCheckerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/SegmentStatusCheckerTest.java
@@ -718,6 +718,22 @@ public class SegmentStatusCheckerTest {
   }
 
   @Test
+  public void nullIdealStateTest()
+      throws Exception {
+    PinotHelixResourceManager resourceManager = mock(PinotHelixResourceManager.class);
+    when(resourceManager.getAllTables()).thenReturn(List.of(OFFLINE_TABLE_NAME));
+    when(resourceManager.getTableIdealState(OFFLINE_TABLE_NAME)).thenReturn(null);
+
+    TableSizeReader tableSizeReader = runSegmentStatusChecker(resourceManager, 0);
+    // Tables with null IdealState should not trigger the size scatter-gather either: getServerToSegmentsMap throws
+    // IllegalStateException when IdealState is missing, which would propagate to processTable's outer catch as an
+    // ERROR + stack trace per table per cycle.
+    verify(tableSizeReader, never()).getTableSizeDetails(anyString(), anyInt(), anyBoolean());
+    // Disabled-table count should not be inflated by null-IdealState entries.
+    assertEquals(MetricValueUtils.getGlobalGaugeValue(_controllerMetrics, ControllerGauge.DISABLED_TABLE_COUNT), 0);
+  }
+
+  @Test
   public void noSegmentTest() {
     noSegmentTest(0);
     noSegmentTest(5);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/SegmentStatusCheckerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/SegmentStatusCheckerTest.java
@@ -60,10 +60,13 @@ import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.testng.annotations.Test;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
@@ -147,7 +150,8 @@ public class SegmentStatusCheckerTest {
     return segmentZKMetadata;
   }
 
-  private void runSegmentStatusChecker(PinotHelixResourceManager resourceManager, int waitForPushTimeInSeconds) {
+  private TableSizeReader runSegmentStatusChecker(PinotHelixResourceManager resourceManager,
+      int waitForPushTimeInSeconds) {
     LeadControllerManager leadControllerManager = mock(LeadControllerManager.class);
     when(leadControllerManager.isLeaderForTable(anyString())).thenReturn(true);
     ControllerConf controllerConf = mock(ControllerConf.class);
@@ -158,6 +162,7 @@ public class SegmentStatusCheckerTest {
             tableSizeReader);
     segmentStatusChecker.start();
     segmentStatusChecker.run();
+    return tableSizeReader;
   }
 
   private void verifyControllerMetrics(String tableNameWithType, int expectedReplicationFromConfig,
@@ -689,7 +694,8 @@ public class SegmentStatusCheckerTest {
   }
 
   @Test
-  public void disabledTableTest() {
+  public void disabledTableTest()
+      throws Exception {
     IdealState idealState = new IdealState(OFFLINE_TABLE_NAME);
     // disable table in idealstate
     idealState.enable(false);
@@ -703,9 +709,12 @@ public class SegmentStatusCheckerTest {
     when(resourceManager.getAllTables()).thenReturn(List.of(OFFLINE_TABLE_NAME));
     when(resourceManager.getTableIdealState(OFFLINE_TABLE_NAME)).thenReturn(idealState);
 
-    runSegmentStatusChecker(resourceManager, 0);
+    TableSizeReader tableSizeReader = runSegmentStatusChecker(resourceManager, 0);
     assertEquals(MetricValueUtils.getGlobalGaugeValue(_controllerMetrics, ControllerGauge.DISABLED_TABLE_COUNT), 1);
     verifyControllerMetricsNotExist();
+    // Disabled tables should not trigger the size scatter-gather: servers do not load segments for disabled tables,
+    // so calling /table/{name}/size would return 404 from every server and flood logs (issue #14279).
+    verify(tableSizeReader, never()).getTableSizeDetails(anyString(), anyInt(), anyBoolean());
   }
 
   @Test


### PR DESCRIPTION
## Problem

Per #14279, the controller floods ERROR logs whenever table state is refreshed: one entry per server, per disabled table, per refresh cycle.

```
ERROR [CompletionServiceHelper] Server: Server_pinot-server-0... returned error: 404, reason: Not Found for uri: http://pinot-server-0...:8097/table/<table>_OFFLINE/size
ERROR [CompletionServiceHelper] Server: Server_pinot-server-1... returned error: 404, reason: Not Found for uri: http://pinot-server-1...:8097/table/<table>_OFFLINE/size
```

Monitors wired to controller ERROR logs trip on this. As noted in the issue, the root problem is Pinot issuing a size read for a table that cannot answer it.

## Fix

`SegmentStatusChecker.processTable` ran `updateTableSizeMetrics` unconditionally, which scatter-gathers `/table/{name}/size` to every server. Two table states cannot return useful size data and generate the noise:

- Disabled table: servers do not load its segments, so every server responds 404.
- Null IdealState: `getServerToSegmentsMap` throws `IllegalStateException`, which lands in `processTable`'s outer catch as an ERROR plus stack trace, once per table per cycle.

`updateSegmentMetrics` already returns early for both. It now records them in a new `_tablesToSkipSizeAggregation` set, and `processTable` skips the size scatter-gather for any table in that set. The set is populated during the pass that already runs, so the guard adds no extra ZK lookup or controller round-trip. `_disabledTables` stays separate so the `DISABLED_TABLE_COUNT` gauge is not inflated by null-IdealState entries.

## Testing

`./mvnw -pl pinot-controller -am -Dtest=SegmentStatusCheckerTest test`

- `disabledTableTest`: extended with `verify(tableSizeReader, never()).getTableSizeDetails(...)` to lock in the skip.
- `nullIdealStateTest`: new; asserts the same skip and that `DISABLED_TABLE_COUNT` stays 0.

Both fail if the guard is removed. `spotless:apply`, `checkstyle:check`, and `license:check` are clean.

Fixes #14279
