### PR TITLE
SegmentZKMetadata: round-trip customMap in toJsonString/fromJsonString

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metadata/segment/SegmentZKMetadata.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metadata/segment/SegmentZKMetadata.java
@@ -39,6 +39,7 @@ public class SegmentZKMetadata implements ZKMetadata {
   private static final Logger LOGGER = LoggerFactory.getLogger(SegmentZKMetadata.class);
   private static final String SEGMENT_NAME_KEY = "segmentName";
   private static final String SIMPLE_FIELDS_KEY = "simpleFields";
+  private static final String CUSTOM_MAP_KEY = "customMap";
   private static final String NULL = "null";
 
   private final ZNRecord _znRecord;
@@ -418,6 +419,10 @@ public class SegmentZKMetadata implements ZKMetadata {
     ObjectNode objectNode = JsonUtils.newObjectNode();
     objectNode.put(SEGMENT_NAME_KEY, getSegmentName());
     objectNode.set(SIMPLE_FIELDS_KEY, JsonUtils.objectToJsonNode(_simpleFields));
+    Map<String, String> customMap = getCustomMap();
+    if (MapUtils.isNotEmpty(customMap)) {
+      objectNode.set(CUSTOM_MAP_KEY, JsonUtils.objectToJsonNode(customMap));
+    }
     return objectNode.toString();
   }
 
@@ -430,6 +435,12 @@ public class SegmentZKMetadata implements ZKMetadata {
     });
     ZNRecord znRecord = new ZNRecord(segmentName);
     znRecord.setSimpleFields(simpleFields);
+    JsonNode customMapJsonNode = jsonNode.get(CUSTOM_MAP_KEY);
+    if (customMapJsonNode != null && !customMapJsonNode.isNull()) {
+      Map<String, String> customMap = JsonUtils.jsonNodeToObject(customMapJsonNode, new TypeReference<>() {
+      });
+      znRecord.setMapField(Segment.CUSTOM_MAP, customMap);
+    }
     return new SegmentZKMetadata(znRecord);
   }
 

--- a/pinot-common/src/test/java/org/apache/pinot/common/metadata/SegmentZKMetadataTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/metadata/SegmentZKMetadataTest.java
@@ -39,7 +39,8 @@ import static org.testng.Assert.assertEquals;
 public class SegmentZKMetadataTest {
 
   @Test
-  public void realtimeSegmentZKMetadataConversionTest() {
+  public void realtimeSegmentZKMetadataConversionTest()
+      throws IOException {
 
     ZNRecord inProgressZnRecord = getTestInProgressRealtimeSegmentZNRecord();
     ZNRecord doneZnRecord = getTestDoneRealtimeSegmentZNRecord();
@@ -65,10 +66,18 @@ public class SegmentZKMetadataTest {
         new SegmentZKMetadata(inProgressSegmentMetadata.toZNRecord()).hashCode());
     assertEquals(doneSegmentMetadata, new SegmentZKMetadata(doneSegmentMetadata.toZNRecord()));
     assertEquals(doneSegmentMetadata.hashCode(), new SegmentZKMetadata(doneSegmentMetadata.toZNRecord()).hashCode());
+
+    // toJsonString / fromJsonString round-trip. These records have no customMap, so the JSON
+    // must omit the customMap key and the round-tripped instance must equal the original.
+    assertEquals(SegmentZKMetadata.fromJsonString(inProgressSegmentMetadata.toJsonString()), inProgressSegmentMetadata);
+    assertEquals(SegmentZKMetadata.fromJsonString(doneSegmentMetadata.toJsonString()), doneSegmentMetadata);
+    Assert.assertFalse(inProgressSegmentMetadata.toJsonString().contains("\"customMap\""));
+    Assert.assertFalse(doneSegmentMetadata.toJsonString().contains("\"customMap\""));
   }
 
   @Test
-  public void offlineSegmentZKMetadataConvertionTest() {
+  public void offlineSegmentZKMetadataConvertionTest()
+      throws IOException {
     ZNRecord offlineZNRecord = getTestOfflineSegmentZNRecord();
     SegmentZKMetadata offlineSegmentMetadata = getTestOfflineSegmentZKMetadata();
     Assert.assertTrue(MetadataUtils.comparisonZNRecords(offlineZNRecord, offlineSegmentMetadata.toZNRecord()));
@@ -79,6 +88,25 @@ public class SegmentZKMetadataTest {
     assertEquals(offlineSegmentMetadata, new SegmentZKMetadata(offlineSegmentMetadata.toZNRecord()));
     assertEquals(offlineSegmentMetadata.hashCode(),
         new SegmentZKMetadata(offlineSegmentMetadata.toZNRecord()).hashCode());
+
+    // toJsonString / fromJsonString round-trip with a populated customMap. The round-tripped
+    // instance must equal the original (which compares both simpleFields and customMap via
+    // SegmentZKMetadata#equals -> toMap).
+    SegmentZKMetadata roundTripped = SegmentZKMetadata.fromJsonString(offlineSegmentMetadata.toJsonString());
+    assertEquals(roundTripped, offlineSegmentMetadata);
+    assertEquals(roundTripped.getCustomMap(), offlineSegmentMetadata.getCustomMap());
+  }
+
+  @Test
+  public void fromJsonStringIsBackwardCompatibleWithoutCustomMap()
+      throws IOException {
+    // Legacy JSON (pre-customMap) must still parse and yield a SegmentZKMetadata whose customMap
+    // is null.
+    String legacyJson = "{\"segmentName\":\"legacy\",\"simpleFields\":{\"segment.crc\":\"42\"}}";
+    SegmentZKMetadata parsed = SegmentZKMetadata.fromJsonString(legacyJson);
+    assertEquals(parsed.getSegmentName(), "legacy");
+    assertEquals(parsed.getCrc(), 42L);
+    Assert.assertNull(parsed.getCustomMap());
   }
 
   @Test

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -56,6 +56,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import org.apache.commons.collections4.CollectionUtils;
+import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.helix.AccessOption;
 import org.apache.helix.ClusterMessagingService;
@@ -2357,6 +2358,19 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
           uploadedMetadata.getCrc());
       currentMetadata.setCrc(uploadedMetadata.getCrc());
       currentMetadata.setDataCrc(uploadedMetadata.getDataCrc());
+    }
+    // Merge the custom map from the server into the current metadata. The server merges segment-file customMap entries
+    // into the existing ZK customMap; without this merge those entries would be dropped when we persist
+    // currentMetadata. Additive merge matches the server-side convention of preserving existing keys.
+    Map<String, String> uploadedCustomMap = uploadedMetadata.getCustomMap();
+    if (MapUtils.isNotEmpty(uploadedCustomMap)) {
+      Map<String, String> mergedCustomMap = currentMetadata.getCustomMap();
+      if (mergedCustomMap == null) {
+        mergedCustomMap = new HashMap<>(uploadedCustomMap);
+      } else {
+        mergedCustomMap.putAll(uploadedCustomMap);
+      }
+      currentMetadata.setCustomMap(mergedCustomMap);
     }
     moveSegmentAndSetDownloadUrl(rawTableName, segmentName, uploadedMetadata.getDownloadUrl(), pinotFS,
         currentMetadata);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
@@ -1776,10 +1776,21 @@ public class PinotLLCRealtimeSegmentManagerTest {
     // its final location. This is the expected segment location.
     String expectedSegmentLocation =
         segmentManager.createSegmentPath(RAW_TABLE_NAME, segmentsZKMetadata.get(0).getSegmentName()).toString();
+    // Pre-populate the current ZK metadata with a controller-side customMap entry to verify that the controller's
+    // additive merge preserves existing keys when the server response is propagated.
+    Map<String, String> existingCustomMap = new HashMap<>();
+    existingCustomMap.put("controllerKey", "controllerValue");
+    segmentsZKMetadata.get(0).setCustomMap(existingCustomMap);
+
     SegmentZKMetadata segmentZKMetadataCopy =
         new SegmentZKMetadata(new ZNRecord(segmentsZKMetadata.get(0).toZNRecord()));
 
     segmentZKMetadataCopy.setDownloadUrl(tempSegmentFileLocation.getPath());
+    // Simulate the server-side merge of segment-file customMap entries into the uploaded ZK metadata. The controller
+    // must propagate these entries to the persisted ZK metadata.
+    Map<String, String> uploadedCustomMap = new HashMap<>();
+    uploadedCustomMap.put("segmentFileKey", "segmentFileValue");
+    segmentZKMetadataCopy.setCustomMap(uploadedCustomMap);
     when(segmentManager._mockedFileUploadDownloadClient.uploadLLCToSegmentStoreWithZKMetadata(
         serverUploadRequestUrl0)).thenReturn(segmentZKMetadataCopy);
 
@@ -1833,6 +1844,11 @@ public class PinotLLCRealtimeSegmentManagerTest {
         expectedSegmentLocation);
     assertFalse(tempSegmentFileLocation.exists(),
         "Deep-store retry task should move the file from temp location to permanent location");
+    Map<String, String> persistedCustomMap =
+        segmentManager.getSegmentZKMetadata(REALTIME_TABLE_NAME, segmentNames.get(0), null).getCustomMap();
+    assertNotNull(persistedCustomMap);
+    assertEquals(persistedCustomMap.get("segmentFileKey"), "segmentFileValue");
+    assertEquals(persistedCustomMap.get("controllerKey"), "controllerValue");
 
     assertEquals(segmentManager.getSegmentZKMetadata(REALTIME_TABLE_NAME, segmentNames.get(1), null).getDownloadUrl(),
         METADATA_URI_FOR_PEER_DOWNLOAD);


### PR DESCRIPTION
## Summary

- `SegmentZKMetadata.toJsonString()` previously serialized only `simpleFields` and dropped `customMap`. Add an optional `customMap` JSON key (omitted when null/empty) so the JSON form is a lossless representation of the underlying ZNRecord.
- `SegmentZKMetadata.fromJsonString(...)` reads the `customMap` key when present. Backward-compat read is preserved: legacy JSON without the key still parses and yields a record whose `customMap` is null.
- Tests fold the new round-trip assertion into the existing realtime + offline tests (the offline test already populated a `customMap`) and add a focused backward-compat test for legacy JSON.

## Test plan
- [x] `./mvnw -pl pinot-common -am -Dtest=SegmentZKMetadataTest test` passes (4/4).
- [x] `./mvnw -pl pinot-common spotless:apply / license:format / checkstyle:check / license:check` clean.