### PR TITLE
Add validation to ensure segment assignment strategy is either null or allservers for dimension tables

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -348,7 +348,7 @@ public final class TableConfigUtils {
    *
    * 2. For OFFLINE table
    * - checks for valid field spec for timeColumnName in schema, if timeColumnName and schema are non-null
-   * - for Dimension tables checks the primary key requirement and incompatible segment assignment strategies 
+   * - for Dimension tables checks the primary key requirement and incompatible segment assignment strategies
    *
    * 3. Checks peerDownloadSchema
    * 4. Checks time column existence if null handling for time column is enabled
@@ -373,12 +373,13 @@ public final class TableConfigUtils {
           "Dimension table must have primary key[s]");
       // Check for incompatible segment assignment strategies
       String segmentAssignmentStrategy = validationConfig.getSegmentAssignmentStrategy();
-      if (segmentAssignmentStrategy != null &&
-          AssignmentStrategy.REPLICA_GROUP_SEGMENT_ASSIGNMENT_STRATEGY.equalsIgnoreCase(segmentAssignmentStrategy)) {
+      if (segmentAssignmentStrategy != null
+          && AssignmentStrategy.REPLICA_GROUP_SEGMENT_ASSIGNMENT_STRATEGY.equalsIgnoreCase(segmentAssignmentStrategy)) {
         throw new IllegalStateException(
             "Dimension table '" + tableConfig.getTableName() + "' has segmentAssignmentStrategy: 'replicagroup', "
             + "but dimension tables automatically use 'allservers' strategy and replica group configurations "
-            + "have no meaning for dimension tables. Remove segmentAssignmentStrategy from dimension table configuration.");
+            + "have no meaning for dimension tables. Remove segmentAssignmentStrategy from dimension table "
+            + "configuration.");
       }
     }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -348,7 +348,7 @@ public final class TableConfigUtils {
    *
    * 2. For OFFLINE table
    * - checks for valid field spec for timeColumnName in schema, if timeColumnName and schema are non-null
-   * - for Dimension tables checks the primary key requirement
+   * - for Dimension tables checks the primary key requirement and incompatible segment assignment strategies 
    *
    * 3. Checks peerDownloadSchema
    * 4. Checks time column existence if null handling for time column is enabled
@@ -371,6 +371,15 @@ public final class TableConfigUtils {
           "Dimension table must be of OFFLINE table type.");
       Preconditions.checkState(CollectionUtils.isNotEmpty(schema.getPrimaryKeyColumns()),
           "Dimension table must have primary key[s]");
+      // Check for incompatible segment assignment strategies
+      String segmentAssignmentStrategy = validationConfig.getSegmentAssignmentStrategy();
+      if (segmentAssignmentStrategy != null &&
+          AssignmentStrategy.REPLICA_GROUP_SEGMENT_ASSIGNMENT_STRATEGY.equalsIgnoreCase(segmentAssignmentStrategy)) {
+        throw new IllegalStateException(
+            "Dimension table '" + tableConfig.getTableName() + "' has segmentAssignmentStrategy: 'replicagroup', "
+            + "but dimension tables automatically use 'allservers' strategy and replica group configurations "
+            + "have no meaning for dimension tables. Remove segmentAssignmentStrategy from dimension table configuration.");
+      }
     }
 
     String peerSegmentDownloadScheme = validationConfig.getPeerSegmentDownloadScheme();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -374,7 +374,7 @@ public final class TableConfigUtils {
       // Check for incompatible segment assignment strategies
       String segmentAssignmentStrategy = validationConfig.getSegmentAssignmentStrategy();
       if (segmentAssignmentStrategy != null
-          && AssignmentStrategy.REPLICA_GROUP_SEGMENT_ASSIGNMENT_STRATEGY.equalsIgnoreCase(segmentAssignmentStrategy)) {
+          && CommonConstants.Segment.AssignmentStrategy.REPLICA_GROUP_SEGMENT_ASSIGNMENT_STRATEGY.equalsIgnoreCase(segmentAssignmentStrategy)) {
         throw new IllegalStateException(
             "Dimension table '" + tableConfig.getTableName() + "' has segmentAssignmentStrategy: 'replicagroup', "
             + "but dimension tables automatically use 'allservers' strategy and replica group configurations "

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -372,15 +372,15 @@ public final class TableConfigUtils {
           "Dimension table must be of OFFLINE table type.");
       Preconditions.checkState(CollectionUtils.isNotEmpty(schema.getPrimaryKeyColumns()),
           "Dimension table must have primary key[s]");
-      // Check for incompatible segment assignment strategies
+
       String segmentAssignmentStrategy = validationConfig.getSegmentAssignmentStrategy();
       if (segmentAssignmentStrategy != null
-          && AssignmentStrategy.REPLICA_GROUP_SEGMENT_ASSIGNMENT_STRATEGY.equalsIgnoreCase(segmentAssignmentStrategy)) {
+          && !segmentAssignmentStrategy.equalsIgnoreCase(AssignmentStrategy.DIM_TABLE_SEGMENT_ASSIGNMENT_STRATEGY)) {
         throw new IllegalStateException(
-            "Dimension table '" + tableConfig.getTableName()
-              + "' has segmentAssignmentStrategy: 'replicagroup', but dimension tables automatically "
-              + "use 'allservers' strategy and replica group configurations have no meaning for "
-              + "dimension tables. Remove segmentAssignmentStrategy from dimension table configuration.");
+            String.format("Dimension table: %s can only use '%s' segment assignment strategy, found: %s",
+              tableConfig.getTableName(),
+              CommonConstants.Segment.AssignmentStrategy.DIM_TABLE_SEGMENT_ASSIGNMENT_STRATEGY,
+              segmentAssignmentStrategy));
       }
     }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -374,12 +374,14 @@ public final class TableConfigUtils {
       // Check for incompatible segment assignment strategies
       String segmentAssignmentStrategy = validationConfig.getSegmentAssignmentStrategy();
       if (segmentAssignmentStrategy != null
-          && CommonConstants.Segment.AssignmentStrategy.REPLICA_GROUP_SEGMENT_ASSIGNMENT_STRATEGY.equalsIgnoreCase(segmentAssignmentStrategy)) {
+          && CommonConstants.Segment.AssignmentStrategy
+          .REPLICA_GROUP_SEGMENT_ASSIGNMENT_STRATEGY
+          .equalsIgnoreCase(segmentAssignmentStrategy)) {
         throw new IllegalStateException(
-            "Dimension table '" + tableConfig.getTableName() + "' has segmentAssignmentStrategy: 'replicagroup', "
-            + "but dimension tables automatically use 'allservers' strategy and replica group configurations "
-            + "have no meaning for dimension tables. Remove segmentAssignmentStrategy from dimension table "
-            + "configuration.");
+            "Dimension table '" + tableConfig.getTableName()
+              + "' has segmentAssignmentStrategy: 'replicagroup', but dimension tables automatically "
+              + "use 'allservers' strategy and replica group configurations have no meaning for "
+              + "dimension tables. Remove segmentAssignmentStrategy from dimension table configuration.");
       }
     }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -102,6 +102,7 @@ import org.apache.pinot.spi.recordtransformer.enricher.RecordEnricherValidationC
 import org.apache.pinot.spi.stream.StreamConfig;
 import org.apache.pinot.spi.stream.StreamConfigProperties;
 import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.CommonConstants.Segment.AssignmentStrategy;
 import org.apache.pinot.spi.utils.DataSizeUtils;
 import org.apache.pinot.spi.utils.Enablement;
 import org.apache.pinot.spi.utils.IngestionConfigUtils;
@@ -114,7 +115,6 @@ import org.slf4j.LoggerFactory;
 import static org.apache.pinot.segment.spi.AggregationFunctionType.DISTINCTCOUNTHLL;
 import static org.apache.pinot.segment.spi.AggregationFunctionType.DISTINCTCOUNTHLLPLUS;
 import static org.apache.pinot.segment.spi.AggregationFunctionType.SUMPRECISION;
-import static org.apache.pinot.spi.utils.CommonConstants.Segment.AssignmentStrategy.REPLICA_GROUP_SEGMENT_ASSIGNMENT_STRATEGY;
 
 
 /**
@@ -375,7 +375,7 @@ public final class TableConfigUtils {
       // Check for incompatible segment assignment strategies
       String segmentAssignmentStrategy = validationConfig.getSegmentAssignmentStrategy();
       if (segmentAssignmentStrategy != null
-          && REPLICA_GROUP_SEGMENT_ASSIGNMENT_STRATEGY.equalsIgnoreCase(segmentAssignmentStrategy)) {
+          && AssignmentStrategy.REPLICA_GROUP_SEGMENT_ASSIGNMENT_STRATEGY.equalsIgnoreCase(segmentAssignmentStrategy)) {
         throw new IllegalStateException(
             "Dimension table '" + tableConfig.getTableName()
               + "' has segmentAssignmentStrategy: 'replicagroup', but dimension tables automatically "

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -114,6 +114,7 @@ import org.slf4j.LoggerFactory;
 import static org.apache.pinot.segment.spi.AggregationFunctionType.DISTINCTCOUNTHLL;
 import static org.apache.pinot.segment.spi.AggregationFunctionType.DISTINCTCOUNTHLLPLUS;
 import static org.apache.pinot.segment.spi.AggregationFunctionType.SUMPRECISION;
+import static org.apache.pinot.spi.utils.CommonConstants.Segment.AssignmentStrategy.REPLICA_GROUP_SEGMENT_ASSIGNMENT_STRATEGY;
 
 
 /**
@@ -374,9 +375,7 @@ public final class TableConfigUtils {
       // Check for incompatible segment assignment strategies
       String segmentAssignmentStrategy = validationConfig.getSegmentAssignmentStrategy();
       if (segmentAssignmentStrategy != null
-          && CommonConstants.Segment.AssignmentStrategy
-          .REPLICA_GROUP_SEGMENT_ASSIGNMENT_STRATEGY
-          .equalsIgnoreCase(segmentAssignmentStrategy)) {
+          && REPLICA_GROUP_SEGMENT_ASSIGNMENT_STRATEGY.equalsIgnoreCase(segmentAssignmentStrategy)) {
         throw new IllegalStateException(
             "Dimension table '" + tableConfig.getTableName()
               + "' has segmentAssignmentStrategy: 'replicagroup', but dimension tables automatically "

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -283,7 +283,9 @@ public class TableConfigUtilsTest {
     // Dimension table with replica group strategy should fail
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setIsDimTable(true)
-        .setSegmentAssignmentStrategy(CommonConstants.Segment.AssignmentStrategy.REPLICA_GROUP_SEGMENT_ASSIGNMENT_STRATEGY)
+        .setSegmentAssignmentStrategy(
+          CommonConstants.Segment.AssignmentStrategy
+            .REPLICA_GROUP_SEGMENT_ASSIGNMENT_STRATEGY)
         .build();
 
     try {

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -303,8 +303,8 @@ public class TableConfigUtilsTest {
       TableConfigUtils.validate(tableConfig, schema);
       fail("Should fail with invalid segment assignment strategy for dimension table");
     } catch (IllegalStateException e) {
-      assertTrue(e.getMessage().contains("can only use '" +
-          AssignmentStrategy.DIM_TABLE_SEGMENT_ASSIGNMENT_STRATEGY + "' segment assignment strategy"));
+      assertTrue(e.getMessage().contains("can only use '"
+          + AssignmentStrategy.DIM_TABLE_SEGMENT_ASSIGNMENT_STRATEGY + "' segment assignment strategy"));
     }
 }
 

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -283,7 +283,7 @@ public class TableConfigUtilsTest {
     // Dimension table with replica group strategy should fail
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setIsDimTable(true)
-        .setSegmentAssignmentStrategy(AssignmentStrategy.REPLICA_GROUP_SEGMENT_ASSIGNMENT_STRATEGY)
+        .setSegmentAssignmentStrategy(CommonConstants.Segment.AssignmentStrategy.REPLICA_GROUP_SEGMENT_ASSIGNMENT_STRATEGY)
         .build();
 
     try {

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -274,6 +274,34 @@ public class TableConfigUtilsTest {
   }
 
   @Test
+  public void validateDimensionTableWithReplicaGroupStrategy() {
+    Schema schema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
+        .addSingleValueDimension("myCol", FieldSpec.DataType.STRING)
+        .setPrimaryKeyColumns(Lists.newArrayList("myCol"))
+        .build();
+
+    // Dimension table with replica group strategy should fail
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME) 
+        .setIsDimTable(true)
+        .setSegmentAssignmentStrategy(AssignmentStrategy.REPLICA_GROUP_SEGMENT_ASSIGNMENT_STRATEGY)
+        .build();
+
+    try {
+      TableConfigUtils.validate(tableConfig, schema);
+      fail("Should fail for dimension table with replica group strategy");
+    } catch (IllegalStateException e) {
+      assertTrue(e.getMessage().contains("has segmentAssignmentStrategy: 'replicagroup'"));
+      assertTrue(e.getMessage().contains("dimension tables automatically use 'allservers' strategy"));
+    }
+
+    // Valid dimension table without segment assignment strategy should pass
+    TableConfig validTableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
+        .setIsDimTable(true)
+        .build();
+    TableConfigUtils.validate(validTableConfig, schema);
+}
+
+  @Test
   public void validateIngestionConfig() {
     Schema schema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).build();
     // null ingestion config

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -275,31 +275,37 @@ public class TableConfigUtilsTest {
   }
 
   @Test
-  public void validateDimensionTableWithReplicaGroupStrategy() {
+  public void validateDimensionTableSegmentAssignmentStrategy() {
     Schema schema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
         .addSingleValueDimension("myCol", FieldSpec.DataType.STRING)
         .setPrimaryKeyColumns(Lists.newArrayList("myCol"))
         .build();
 
-    // Dimension table with replica group strategy should fail
+    // Valid: null segment assignment strategy
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setIsDimTable(true)
-        .setSegmentAssignmentStrategy(AssignmentStrategy.REPLICA_GROUP_SEGMENT_ASSIGNMENT_STRATEGY)
         .build();
+    TableConfigUtils.validate(tableConfig, schema);
 
+    // Valid: allservers strategy using constant
+    tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
+        .setIsDimTable(true)
+        .setSegmentAssignmentStrategy(AssignmentStrategy.DIM_TABLE_SEGMENT_ASSIGNMENT_STRATEGY)
+        .build();
+    TableConfigUtils.validate(tableConfig, schema);
+
+    // Invalid: other strategy
+    tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
+        .setIsDimTable(true)
+        .setSegmentAssignmentStrategy("replicaGroup")
+        .build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
-      fail("Should fail for dimension table with replica group strategy");
+      fail("Should fail with invalid segment assignment strategy for dimension table");
     } catch (IllegalStateException e) {
-      assertTrue(e.getMessage().contains("has segmentAssignmentStrategy: 'replicagroup'"));
-      assertTrue(e.getMessage().contains("dimension tables automatically use 'allservers' strategy"));
+      assertTrue(e.getMessage().contains("can only use '" +
+          AssignmentStrategy.DIM_TABLE_SEGMENT_ASSIGNMENT_STRATEGY + "' segment assignment strategy"));
     }
-
-    // Valid dimension table without segment assignment strategy should pass
-    TableConfig validTableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-        .setIsDimTable(true)
-        .build();
-    TableConfigUtils.validate(validTableConfig, schema);
 }
 
   @Test

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -86,6 +86,7 @@ import org.mockito.Mockito;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import static org.apache.pinot.spi.utils.CommonConstants.Segment.AssignmentStrategy.REPLICA_GROUP_SEGMENT_ASSIGNMENT_STRATEGY;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.*;
 
@@ -283,9 +284,7 @@ public class TableConfigUtilsTest {
     // Dimension table with replica group strategy should fail
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setIsDimTable(true)
-        .setSegmentAssignmentStrategy(
-          CommonConstants.Segment.AssignmentStrategy
-            .REPLICA_GROUP_SEGMENT_ASSIGNMENT_STRATEGY)
+        .setSegmentAssignmentStrategy(REPLICA_GROUP_SEGMENT_ASSIGNMENT_STRATEGY)
         .build();
 
     try {

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -78,6 +78,7 @@ import org.apache.pinot.spi.stream.StreamConsumerFactory;
 import org.apache.pinot.spi.stream.StreamMessageDecoder;
 import org.apache.pinot.spi.stream.StreamMetadataProvider;
 import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.CommonConstants.Segment.AssignmentStrategy;
 import org.apache.pinot.spi.utils.Enablement;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.PinotMd5Mode;
@@ -86,7 +87,6 @@ import org.mockito.Mockito;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import static org.apache.pinot.spi.utils.CommonConstants.Segment.AssignmentStrategy.REPLICA_GROUP_SEGMENT_ASSIGNMENT_STRATEGY;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.*;
 
@@ -284,7 +284,7 @@ public class TableConfigUtilsTest {
     // Dimension table with replica group strategy should fail
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setIsDimTable(true)
-        .setSegmentAssignmentStrategy(REPLICA_GROUP_SEGMENT_ASSIGNMENT_STRATEGY)
+        .setSegmentAssignmentStrategy(AssignmentStrategy.REPLICA_GROUP_SEGMENT_ASSIGNMENT_STRATEGY)
         .build();
 
     try {

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -281,7 +281,7 @@ public class TableConfigUtilsTest {
         .build();
 
     // Dimension table with replica group strategy should fail
-    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME) 
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setIsDimTable(true)
         .setSegmentAssignmentStrategy(AssignmentStrategy.REPLICA_GROUP_SEGMENT_ASSIGNMENT_STRATEGY)
         .build();


### PR DESCRIPTION
Fixes #18345

Added validation to catch incorrect segment assignment strategy early and provide clear error messages.

The fix is backward incompatible:

✅ Valid dimension tables (without `segmentAssignmentStrategy` or set as `allservers`) continue to work unchanged
❌ Invalid dimension tables (with strategy other than `allservers`) will fail this validation
🔄 The fix provides clearer error messages for the same failing configurations