### PR TITLE
Fix flaky TableRebalancePauselessIntegrationTest across parameterized runs

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/TableRebalancePauselessIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/TableRebalancePauselessIntegrationTest.java
@@ -39,6 +39,11 @@ import static org.testng.Assert.*;
 
 public class TableRebalancePauselessIntegrationTest extends BasePauselessRealtimeIngestionTest {
   private final static int FORCE_COMMIT_REBALANCE_TIMEOUT_MS = 600_000;
+  // startOneServer() does not register the starter in _serverStarters, so its size doesn't advance across parameterized
+  // invocations. Track our own counter so each invocation gets a unique serverId range, and therefore unique on-disk
+  // data dirs (TEMP_SERVER_DIR/dataDir-<serverId>); otherwise leftover state from a prior invocation pushes segment
+  // transitions into ERROR and rebalance hangs.
+  private int _nextExtraServerId = 1;
 
   @Override
   protected String getFailurePoint() {
@@ -115,7 +120,8 @@ public class TableRebalancePauselessIntegrationTest extends BasePauselessRealtim
     final String tenantA = tableConfig.getTenantConfig().getServer();
     final String tenantB = tenantA + "_new";
 
-    final int baseServerIndex = _serverStarters.size();
+    final int baseServerIndex = _nextExtraServerId;
+    _nextExtraServerId += 4;
     BaseServerStarter serverStarter0 = startOneServer(baseServerIndex);
     BaseServerStarter serverStarter1 = startOneServer(baseServerIndex + 1);
     createServerTenant(tenantA, 0, 2);


### PR DESCRIPTION
## Description

Follow-up to #18138, which fixed one source of flakiness in `TableRebalancePauselessIntegrationTest.testForceCommit` (server-0 directory collision between `setUp()` and the test). The test still fails on master (e.g. https://github.com/apache/pinot/actions/runs/24765845607/job/72459803573).

### Root cause

#18138 derived the unique serverId base from `_serverStarters.size()`:

```java
final int baseServerIndex = _serverStarters.size();
BaseServerStarter serverStarter0 = startOneServer(baseServerIndex);
...
```

However, `ClusterTest.startOneServer(int)` does **not** add the started server to `_serverStarters` — only `startServers(int)` does. Since `setUp()` calls `startServer()` once, `_serverStarters.size()` stays at `1` for the lifetime of the test class, including across both parameterized invocations of `testForceCommit`.

Both invocations therefore start servers with serverId `1, 2, 3, 4`. `getServerConf(serverId)` keys the on-disk data dirs by serverId:

```
TEMP_SERVER_DIR/dataDir-<serverId>
TEMP_SERVER_DIR/segmentTar-<serverId>
```

So the second invocation reuses the same directories as the first — leftover segment files / RocksDB state cause segment transitions to fail, partitions land in `ERROR`, and the rebalance never converges (600s timeout). This shows up as `MessageGenerationPhase ... Unable to find a next state ... from:ERROR to:ONLINE` in the controller log.

### Fix

Track an explicit `_nextExtraServerId` counter that advances by 4 per invocation, so each invocation gets a unique serverId range and unique data dirs.

## Test plan

- [x] `./mvnw -pl pinot-integration-tests -am -Dtest=TableRebalancePauselessIntegrationTest -Dsurefire.failIfNoSpecifiedTests=false test` passes locally — both parameterized invocations of `testForceCommit` complete cleanly.