### PR TITLE
allow configuring max headers for grizzly

### DIFF
--- a/pinot-controller/src/test/java/org/apache/pinot/controller/util/ListenerConfigUtilTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/util/ListenerConfigUtilTest.java
@@ -75,6 +75,43 @@ public class ListenerConfigUtilTest {
     Assert.assertEquals(9, listenerConfigs.get(0).getThreadPoolConfig().getMaxPoolSize());
   }
 
+  @Test
+  public void testMaxHttpHeaderConfig() {
+    // Test broker
+    PinotConfiguration brokerConf = new PinotConfiguration();
+    brokerConf.setProperty("pinot.broker.client.queryPort", "8099");
+
+    List<ListenerConfig> listenerConfigs = ListenerConfigUtil.buildBrokerConfigs(brokerConf);
+    Assert.assertEquals(listenerConfigs.size(), 1);
+    Assert.assertEquals(-1, listenerConfigs.get(0).getMaxHttpHeaderSize());
+    Assert.assertEquals(-1, listenerConfigs.get(0).getMaxRequestHeaders());
+
+    brokerConf.setProperty("pinot.broker.http.server.max.http.header.size", 16384);
+    brokerConf.setProperty("pinot.broker.http.server.max.request.headers", 200);
+
+    listenerConfigs = ListenerConfigUtil.buildBrokerConfigs(brokerConf);
+    Assert.assertEquals(listenerConfigs.size(), 1);
+    Assert.assertEquals(16384, listenerConfigs.get(0).getMaxHttpHeaderSize());
+    Assert.assertEquals(200, listenerConfigs.get(0).getMaxRequestHeaders());
+
+    // Test controller
+    ControllerConf controllerConf = new ControllerConf();
+    controllerConf.setProperty("controller.port", "9000");
+
+    listenerConfigs = ListenerConfigUtil.buildControllerConfigs(controllerConf);
+    Assert.assertEquals(listenerConfigs.size(), 1);
+    Assert.assertEquals(-1, listenerConfigs.get(0).getMaxHttpHeaderSize());
+    Assert.assertEquals(-1, listenerConfigs.get(0).getMaxRequestHeaders());
+
+    controllerConf.setProperty("pinot.controller.http.server.max.http.header.size", 32768);
+    controllerConf.setProperty("pinot.controller.http.server.max.request.headers", 150);
+
+    listenerConfigs = ListenerConfigUtil.buildControllerConfigs(controllerConf);
+    Assert.assertEquals(listenerConfigs.size(), 1);
+    Assert.assertEquals(32768, listenerConfigs.get(0).getMaxHttpHeaderSize());
+    Assert.assertEquals(150, listenerConfigs.get(0).getMaxRequestHeaders());
+  }
+
   /**
    * Asserts that enabling https generates the existing legacy listener as well as the another one configured with
    * TLS settings.

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/ListenerConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/ListenerConfig.java
@@ -32,15 +32,24 @@ public class ListenerConfig {
   private final String _protocol;
   private final TlsConfig _tlsConfig;
   private final HttpServerThreadPoolConfig _threadPoolConfig;
+  private final int _maxHttpHeaderSize;
+  private final int _maxRequestHeaders;
 
   public ListenerConfig(String name, String host, int port, String protocol, TlsConfig tlsConfig,
       HttpServerThreadPoolConfig threadPoolConfig) {
+    this(name, host, port, protocol, tlsConfig, threadPoolConfig, -1, -1);
+  }
+
+  public ListenerConfig(String name, String host, int port, String protocol, TlsConfig tlsConfig,
+      HttpServerThreadPoolConfig threadPoolConfig, int maxHttpHeaderSize, int maxRequestHeaders) {
     _name = name;
     _host = host;
     _port = port;
     _protocol = protocol;
     _tlsConfig = tlsConfig;
     _threadPoolConfig = threadPoolConfig;
+    _maxHttpHeaderSize = maxHttpHeaderSize;
+    _maxRequestHeaders = maxRequestHeaders;
   }
 
   public String getName() {
@@ -65,5 +74,13 @@ public class ListenerConfig {
 
   public HttpServerThreadPoolConfig getThreadPoolConfig() {
     return _threadPoolConfig;
+  }
+
+  public int getMaxHttpHeaderSize() {
+    return _maxHttpHeaderSize;
+  }
+
+  public int getMaxRequestHeaders() {
+    return _maxRequestHeaders;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/ListenerConfigUtil.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/ListenerConfigUtil.java
@@ -64,6 +64,8 @@ public final class ListenerConfigUtil {
   private static final String DEFAULT_HOST = "0.0.0.0";
   private static final String DOT_ACCESS_PROTOCOLS = ".access.protocols";
   private static final String DOT_ACCESS_THREAD_POOL = ".http.server.thread.pool";
+  private static final String DOT_MAX_HTTP_HEADER_SIZE = ".http.server.max.http.header.size";
+  private static final String DOT_MAX_REQUEST_HEADERS = ".http.server.max.request.headers";
 
   private ListenerConfigUtil() {
     // left blank
@@ -101,7 +103,8 @@ public final class ListenerConfigUtil {
     if (portString != null) {
       listeners.add(new ListenerConfig(CommonConstants.HTTP_PROTOCOL, DEFAULT_HOST, Integer.parseInt(portString),
           CommonConstants.HTTP_PROTOCOL, new TlsConfig(), buildServerThreadPoolConfig(controllerConf,
-          "pinot.controller")));
+          "pinot.controller"), getMaxHttpHeaderSize(controllerConf, "pinot.controller"),
+          getMaxRequestHeaders(controllerConf, "pinot.controller")));
     }
 
     TlsConfig tlsDefaults = TlsUtils.extractTlsConfig(controllerConf, "controller.tls");
@@ -118,7 +121,8 @@ public final class ListenerConfigUtil {
     String queryPortString = brokerConf.getProperty(CommonConstants.Helix.KEY_OF_BROKER_QUERY_PORT);
     if (queryPortString != null) {
       listeners.add(new ListenerConfig(CommonConstants.HTTP_PROTOCOL, DEFAULT_HOST, Integer.parseInt(queryPortString),
-          CommonConstants.HTTP_PROTOCOL, new TlsConfig(), buildServerThreadPoolConfig(brokerConf, "pinot.broker")));
+          CommonConstants.HTTP_PROTOCOL, new TlsConfig(), buildServerThreadPoolConfig(brokerConf, "pinot.broker"),
+          getMaxHttpHeaderSize(brokerConf, "pinot.broker"), getMaxRequestHeaders(brokerConf, "pinot.broker")));
     }
 
     TlsConfig tlsDefaults = TlsUtils.extractTlsConfig(brokerConf, CommonConstants.Broker.BROKER_TLS_PREFIX);
@@ -129,7 +133,8 @@ public final class ListenerConfigUtil {
     if (listeners.isEmpty()) {
       listeners.add(new ListenerConfig(CommonConstants.HTTP_PROTOCOL, DEFAULT_HOST,
           CommonConstants.Helix.DEFAULT_BROKER_QUERY_PORT, CommonConstants.HTTP_PROTOCOL, new TlsConfig(),
-          buildServerThreadPoolConfig(brokerConf, "pinot.broker")));
+          buildServerThreadPoolConfig(brokerConf, "pinot.broker"),
+          getMaxHttpHeaderSize(brokerConf, "pinot.broker"), getMaxRequestHeaders(brokerConf, "pinot.broker")));
     }
 
     return listeners;
@@ -142,7 +147,8 @@ public final class ListenerConfigUtil {
     if (adminApiPortString != null) {
       listeners.add(
           new ListenerConfig(CommonConstants.HTTP_PROTOCOL, DEFAULT_HOST, Integer.parseInt(adminApiPortString),
-              CommonConstants.HTTP_PROTOCOL, new TlsConfig(), buildServerThreadPoolConfig(serverConf, "pinot.server")));
+              CommonConstants.HTTP_PROTOCOL, new TlsConfig(), buildServerThreadPoolConfig(serverConf, "pinot.server"),
+              getMaxHttpHeaderSize(serverConf, "pinot.server"), getMaxRequestHeaders(serverConf, "pinot.server")));
     }
 
     TlsConfig tlsDefaults = TlsUtils.extractTlsConfig(serverConf, CommonConstants.Server.SERVER_TLS_PREFIX);
@@ -153,7 +159,8 @@ public final class ListenerConfigUtil {
     if (listeners.isEmpty()) {
       listeners.add(
           new ListenerConfig(CommonConstants.HTTP_PROTOCOL, DEFAULT_HOST, CommonConstants.Server.DEFAULT_ADMIN_API_PORT,
-              CommonConstants.HTTP_PROTOCOL, new TlsConfig(), buildServerThreadPoolConfig(serverConf, "pinot.server")));
+              CommonConstants.HTTP_PROTOCOL, new TlsConfig(), buildServerThreadPoolConfig(serverConf, "pinot.server"),
+              getMaxHttpHeaderSize(serverConf, "pinot.server"), getMaxRequestHeaders(serverConf, "pinot.server")));
     }
 
     return listeners;
@@ -165,7 +172,8 @@ public final class ListenerConfigUtil {
     String portString = minionConf.getProperty(CommonConstants.Helix.KEY_OF_MINION_PORT);
     if (portString != null) {
       listeners.add(new ListenerConfig(CommonConstants.HTTP_PROTOCOL, DEFAULT_HOST, Integer.parseInt(portString),
-          CommonConstants.HTTP_PROTOCOL, new TlsConfig(), buildServerThreadPoolConfig(minionConf, "pinot.minion")));
+          CommonConstants.HTTP_PROTOCOL, new TlsConfig(), buildServerThreadPoolConfig(minionConf, "pinot.minion"),
+          getMaxHttpHeaderSize(minionConf, "pinot.minion"), getMaxRequestHeaders(minionConf, "pinot.minion")));
     }
 
     TlsConfig tlsDefaults = TlsUtils.extractTlsConfig(minionConf, CommonConstants.Minion.MINION_TLS_PREFIX);
@@ -175,7 +183,8 @@ public final class ListenerConfigUtil {
     if (listeners.isEmpty()) {
       listeners.add(
           new ListenerConfig(CommonConstants.HTTP_PROTOCOL, DEFAULT_HOST, CommonConstants.Minion.DEFAULT_HELIX_PORT,
-              CommonConstants.HTTP_PROTOCOL, new TlsConfig(), buildServerThreadPoolConfig(minionConf, "pinot.minion")));
+              CommonConstants.HTTP_PROTOCOL, new TlsConfig(), buildServerThreadPoolConfig(minionConf, "pinot.minion"),
+              getMaxHttpHeaderSize(minionConf, "pinot.minion"), getMaxRequestHeaders(minionConf, "pinot.minion")));
     }
 
     return listeners;
@@ -189,7 +198,8 @@ public final class ListenerConfigUtil {
         getPort(config.getProperty(protocolNamespace + ".port")),
         getProtocol(config.getProperty(protocolNamespace + ".protocol"), name),
         TlsUtils.extractTlsConfig(config, protocolNamespace + ".tls", tlsConfig),
-        buildServerThreadPoolConfig(config, namespace));
+        buildServerThreadPoolConfig(config, namespace),
+        getMaxHttpHeaderSize(config, namespace), getMaxRequestHeaders(config, namespace));
   }
 
   private static String getHost(String configuredHost) {
@@ -242,6 +252,13 @@ public final class ListenerConfigUtil {
         .setCorePoolSize(listenerConfig.getThreadPoolConfig().getCorePoolSize())
         .setMaxPoolSize(listenerConfig.getThreadPoolConfig().getMaxPoolSize());
 
+    if (listenerConfig.getMaxHttpHeaderSize() > 0) {
+      listener.setMaxHttpHeaderSize(listenerConfig.getMaxHttpHeaderSize());
+    }
+    if (listenerConfig.getMaxRequestHeaders() > 0) {
+      listener.setMaxRequestHeaders(listenerConfig.getMaxRequestHeaders());
+    }
+
     if (CommonConstants.HTTPS_PROTOCOL.equals(listenerConfig.getProtocol())) {
       listener.setSecure(true);
       listener.setSSLEngineConfig(buildSSLEngineConfigurator(listenerConfig.getTlsConfig()));
@@ -285,6 +302,14 @@ public final class ListenerConfigUtil {
       threadPoolConfig.setMaxPoolSize(maxPoolSize);
     }
     return threadPoolConfig;
+  }
+
+  private static int getMaxHttpHeaderSize(PinotConfiguration config, String namespace) {
+    return config.getProperty(namespace + DOT_MAX_HTTP_HEADER_SIZE, -1);
+  }
+
+  private static int getMaxRequestHeaders(PinotConfiguration config, String namespace) {
+    return config.getProperty(namespace + DOT_MAX_REQUEST_HEADERS, -1);
   }
 
   public static String toString(Collection<? extends ListenerConfig> listenerConfigs) {


### PR DESCRIPTION
This is a small feature addition to allow configuring max request header size and count in Pinot's HTTP server. We recently ran into an issue where requests fail with HTTP 400 and an empty body when exceeding the default limits.

This is tested with unit tests. The default behavior is to leave these unset. We also deployed this into a QA cluster and confirmed requests succeeded with increased header limits.
