### PR TITLE
Canonicalize map serialization and preserve primitive types in record extractors

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/PinotDataType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/PinotDataType.java
@@ -820,38 +820,36 @@ public enum PinotDataType {
 
   MAP {
     @Override
+    public String toString(Object value) {
+      //noinspection unchecked
+      return MapUtils.toString((Map<String, Object>) value);
+    }
+
+    @Override
+    public String toJson(Object value) {
+      //noinspection unchecked
+      return MapUtils.toString((Map<String, Object>) value);
+    }
+
+    @Override
+    public byte[] toBytes(Object value) {
+      //noinspection unchecked
+      return MapUtils.serializeMap((Map<String, Object>) value);
+    }
+
+    @Override
     public Object convert(Object value, PinotDataType sourceType) {
       switch (sourceType) {
         case STRING:
-          try {
-            return JsonUtils.stringToObject(value.toString(), Map.class);
-          } catch (Exception e) {
-            throw new RuntimeException("Unable to convert String to Map. Input value: " + value, e);
-          }
+          return MapUtils.fromString(value.toString());
         case BYTES:
           return MapUtils.deserializeMap((byte[]) value);
-        case OBJECT:
         case MAP:
-          if (value instanceof Map) {
-            return value;
-          } else {
-            throw new UnsupportedOperationException(String.format("Cannot convert '%s' (Class of value: '%s') to MAP",
-                sourceType, value.getClass()));
-          }
+          return value;
         default:
           throw new UnsupportedOperationException(String.format("Cannot convert '%s' (Class of value: '%s') to MAP",
               sourceType, value.getClass()));
       }
-    }
-
-    @SuppressWarnings("unchecked")
-    @Override
-    public byte[] toBytes(Object value) {
-      if (!(value instanceof Map)) {
-        throw new UnsupportedOperationException("Cannot convert non-Map value to BYTES for MAP type: "
-            + (value == null ? "null" : value.getClass()));
-      }
-      return MapUtils.serializeMap((Map<String, Object>) value);
     }
   },
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/datablock/DataBlockBuilder.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/datablock/DataBlockBuilder.java
@@ -621,7 +621,7 @@ public class DataBlockBuilder {
   private static void setColumn(ByteBuffer fixedSize, PagedPinotOutputStream varSize, Map value)
       throws IOException {
     writeVarOffsetInFixed(fixedSize, varSize);
-    byte[] bytes = MapUtils.serializeMap(value);
+    byte[] bytes = MapUtils.serializeMap(value, false);
     fixedSize.putInt(bytes.length);
     varSize.write(bytes);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/datatable/BaseDataTableBuilder.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/datatable/BaseDataTableBuilder.java
@@ -107,7 +107,7 @@ public abstract class BaseDataTableBuilder implements DataTableBuilder {
     if (value == null) {
       _currentRowDataByteBuffer.putInt(0);
     } else {
-      byte[] bytes = MapUtils.serializeMap(value);
+      byte[] bytes = MapUtils.serializeMap(value, false);
       _currentRowDataByteBuffer.putInt(bytes.length);
       _variableSizeDataByteArrayOutputStream.write(bytes);
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/genericrow/GenericRowSerializer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/genericrow/GenericRowSerializer.java
@@ -31,8 +31,7 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.utils.BigDecimalUtils;
 import org.apache.pinot.spi.utils.MapUtils;
-
-import static java.nio.charset.StandardCharsets.UTF_8;
+import org.apache.pinot.spi.utils.Utf8Utils;
 
 
 /**
@@ -105,7 +104,7 @@ public class GenericRowSerializer {
             _objectBytes[i] = bigDecimalBytes;
             break;
           case STRING:
-            byte[] stringBytes = ((String) value).getBytes(UTF_8);
+            byte[] stringBytes = Utf8Utils.encode((String) value);
             numBytes += Integer.BYTES + stringBytes.length;
             _objectBytes[i] = stringBytes;
             break;
@@ -113,8 +112,8 @@ public class GenericRowSerializer {
             numBytes += Integer.BYTES + ((byte[]) value).length;
             break;
           case MAP:
-            Map<String, Object> map = (Map<String, Object>) value;
-            byte[] mapBytes = MapUtils.serializeMap(map);
+            //noinspection unchecked
+            byte[] mapBytes = MapUtils.serializeMap((Map<String, Object>) value, false);
             numBytes += Integer.BYTES + mapBytes.length;
             _objectBytes[i] = mapBytes;
             break;
@@ -143,7 +142,7 @@ public class GenericRowSerializer {
             numBytes += Integer.BYTES * numValues;
             byte[][] stringBytesArray = new byte[numValues][];
             for (int j = 0; j < numValues; j++) {
-              byte[] stringBytes = ((String) multiValue[j]).getBytes(UTF_8);
+              byte[] stringBytes = Utf8Utils.encode((String) multiValue[j]);
               numBytes += stringBytes.length;
               stringBytesArray[j] = stringBytes;
             }

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/processing/framework/BaseSegmentProcessorFrameworkTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/processing/framework/BaseSegmentProcessorFrameworkTest.java
@@ -59,12 +59,14 @@ import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.RecordReader;
 import org.apache.pinot.spi.utils.ReadMode;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
-import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 
 /**
@@ -269,13 +271,11 @@ public abstract class BaseSegmentProcessorFrameworkTest {
     // Pick the column created from complex type
     ColumnMetadata campaignInner2Metadata = segmentMetadata.getColumnMetadataFor("campaign.inner1.inner2");
     // Verify we see a specific value parsed from the complexType
-    Assert.assertEquals(campaignInner2Metadata.getMinValue().compareTo("inner2v"), 0);
+    assertEquals(campaignInner2Metadata.getMinValue(), "inner2v");
     ColumnMetadata campaignMetadata = segmentMetadata.getColumnMetadataFor("campaign");
-    Assert.assertEquals(
-        campaignMetadata.getMinValue().compareTo("{\"inner1\":{\"inner2\":\"inner2v\"},\"inner\":\"innerv\"}"), 0);
-
+    assertEquals(campaignMetadata.getMinValue(), "{\"inner\":\"innerv\",\"inner1\":{\"inner2\":\"inner2v\"}}");
     ColumnMetadata listMetadata = segmentMetadata.getColumnMetadataFor("targetusers.user");
-    Assert.assertEquals(listMetadata.getMinValue().compareTo("barfoo"), 0);
+    assertEquals(listMetadata.getMinValue(), "barfoo");
   }
 
   @Test

--- a/pinot-core/src/test/java/org/apache/pinot/queries/JsonIngestionFromAvroQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/JsonIngestionFromAvroQueriesTest.java
@@ -53,12 +53,12 @@ import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
-import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static org.apache.avro.Schema.*;
+import static org.testng.Assert.assertEquals;
 
 
 /**
@@ -167,9 +167,9 @@ public class JsonIngestionFromAvroQueriesTest extends BaseQueriesTest {
       throws IOException {
     INDEX_DIR.mkdir();
     Schema avroSchema = createRecord("eventsRecord", null, null, false);
-    Schema enumSchema = createEnum("direction", null, null, Arrays.asList("UP", "DOWN", "LEFT", "RIGHT"));
+    Schema enumSchema = createEnum("direction", null, null, List.of("UP", "DOWN", "LEFT", "RIGHT"));
     Schema fixedSchema = createFixed("fixed", null, null, 4);
-    List<Field> fields = Arrays.asList(
+    List<Field> fields = List.of(
         new Field(INT_COLUMN, createUnion(Lists.newArrayList(create(Type.INT), create(Type.NULL))), null, null),
         new Field(STRING_COLUMN, createUnion(Lists.newArrayList(create(Type.STRING), create(Type.NULL))), null, null),
         new Field(JSON_COLUMN_1,
@@ -187,51 +187,107 @@ public class JsonIngestionFromAvroQueriesTest extends BaseQueriesTest {
     avroSchema.setFields(fields);
     List<GenericRow> inputRecords = new ArrayList<>();
     // Insert ARRAY
-    inputRecords.add(
-        createTableRecord(1, "daffy duck", Arrays.asList("this", "is", "a", "test"), createEnumField(enumSchema, "UP"),
-            createFixedField(fixedSchema, 1), new byte[] {0, 0, 0, 1}, Arrays.asList(
-                new GenericRecordBuilder(createJson5RecordSchema())
-                    .set("timestamp", 1719390721)
-                    .set("data", createMapField(new Pair[]{Pair.of("a", "1"), Pair.of("b", "2")})).build())));
+    inputRecords.add(createTableRecord(
+        1,
+        "daffy duck",
+        List.of("this", "is", "a", "test"),
+        createEnumField(enumSchema, "UP"),
+        createFixedField(fixedSchema, 1),
+        new byte[]{0, 0, 0, 1},
+        List.of(new GenericRecordBuilder(createJson5RecordSchema())
+            .set("timestamp", 1719390721)
+            .set("data", createMapField(new Pair[]{Pair.of("a", "1"), Pair.of("b", "2")}))
+            .build()
+        )
+    ));
 
-    // Insert MAP
-    inputRecords.add(
-        createTableRecord(2, "mickey mouse", createMapField(new Pair[]{Pair.of("a", "1"), Pair.of("b", "2")}),
-            createEnumField(enumSchema, "DOWN"), createFixedField(fixedSchema, 2), new byte[] {0, 0, 0, 2},
-            Arrays.asList(new GenericRecordBuilder(createJson5RecordSchema()).set("timestamp", 1719390722)
-                    .set("data", createMapField(new Pair[]{Pair.of("a", "2"), Pair.of("b", "4")})).build())));
+    // Insert MAP, keys should be sorted
+    inputRecords.add(createTableRecord(
+        2,
+        "mickey mouse",
+        createMapField(new Pair[]{Pair.of("b", "2"), Pair.of("a", "1")}),
+        createEnumField(enumSchema, "DOWN"),
+        createFixedField(fixedSchema, 2),
+        new byte[]{0, 0, 0, 2},
+        List.of(new GenericRecordBuilder(createJson5RecordSchema())
+            .set("timestamp", 1719390722)
+            .set("data", createMapField(new Pair[]{Pair.of("a", "2"), Pair.of("b", "4")}))
+            .build()
+        )
+    ));
 
-    inputRecords.add(
-        createTableRecord(3, "donald duck", createMapField(new Pair[]{Pair.of("a", "1"), Pair.of("b", "2")}),
-            createEnumField(enumSchema, "UP"), createFixedField(fixedSchema, 3), new byte[] {0, 0, 0, 3}, Arrays.asList(
-                new GenericRecordBuilder(createJson5RecordSchema()).set("timestamp", 1719390723)
-                    .set("data", createMapField(new Pair[]{Pair.of("a", "3"), Pair.of("b", "6")})).build())));
+    inputRecords.add(createTableRecord(
+        3,
+        "donald duck",
+        createMapField(new Pair[]{Pair.of("a", "1"), Pair.of("b", "2")}),
+        createEnumField(enumSchema, "UP"),
+        createFixedField(fixedSchema, 3),
+        new byte[]{0, 0, 0, 3},
+        List.of(new GenericRecordBuilder(createJson5RecordSchema())
+            .set("timestamp", 1719390723)
+            .set("data", createMapField(new Pair[]{Pair.of("a", "3"), Pair.of("b", "6")}))
+            .build()
+        )
+    ));
 
-    inputRecords.add(
-        createTableRecord(4, "scrooge mcduck", createMapField(new Pair[]{Pair.of("a", "1"), Pair.of("b", "2")}),
-            createEnumField(enumSchema, "LEFT"), createFixedField(fixedSchema, 4), new byte[] {0, 0, 0, 4},
-            Arrays.asList(new GenericRecordBuilder(createJson5RecordSchema()).set("timestamp", 1719390724)
-                    .set("data", createMapField(new Pair[]{Pair.of("a", "4"), Pair.of("b", "8")})).build())));
+    inputRecords.add(createTableRecord(
+        4,
+        "scrooge mcduck",
+        createMapField(new Pair[]{Pair.of("a", "1"), Pair.of("b", "2")}),
+        createEnumField(enumSchema, "LEFT"),
+        createFixedField(fixedSchema, 4),
+        new byte[]{0, 0, 0, 4},
+        List.of(new GenericRecordBuilder(createJson5RecordSchema())
+            .set("timestamp", 1719390724)
+            .set("data", createMapField(new Pair[]{Pair.of("a", "4"), Pair.of("b", "8")}))
+            .build()
+        )
+    ));
 
-    // insert RECORD
-    inputRecords.add(createTableRecord(5, "minney mouse", createRecordField("id", 1, "name", "minney"),
-        createEnumField(enumSchema, "RIGHT"), createFixedField(fixedSchema, 5), new byte[] {0, 0, 0, 5}, Arrays.asList(
-            new GenericRecordBuilder(createJson5RecordSchema()).set("timestamp", 1719390725)
-                .set("data", createMapField(new Pair[]{Pair.of("a", "5"), Pair.of("b", "10")})).build())));
+    // Insert MAP, keys should be sorted
+    inputRecords.add(createTableRecord(
+        5,
+        "minney mouse",
+        createRecordField("id", 1, "name", "minney"),
+        createEnumField(enumSchema, "RIGHT"),
+        createFixedField(fixedSchema, 5),
+        new byte[]{0, 0, 0, 5},
+        List.of(new GenericRecordBuilder(createJson5RecordSchema())
+            .set("timestamp", 1719390725)
+            .set("data", createMapField(new Pair[]{Pair.of("a", "5"), Pair.of("b", "10")}))
+            .build()
+        )
+    ));
 
     // Insert simple Java String (gets converted into JSON value)
-    inputRecords.add(
-        createTableRecord(6, "pluto", "test", createEnumField(enumSchema, "DOWN"), createFixedField(fixedSchema, 6),
-            new byte[] {0, 0, 0, 6}, Arrays.asList(
-                new GenericRecordBuilder(createJson5RecordSchema()).set("timestamp", 1719390726)
-                    .set("data", createMapField(new Pair[]{Pair.of("a", "6"), Pair.of("b", "12")})).build())));
+    inputRecords.add(createTableRecord(
+        6,
+        "pluto",
+        "test",
+        createEnumField(enumSchema, "DOWN"),
+        createFixedField(fixedSchema, 6),
+        new byte[]{0, 0, 0, 6},
+        List.of(new GenericRecordBuilder(createJson5RecordSchema())
+            .set("timestamp", 1719390726)
+            .set("data", createMapField(new Pair[]{Pair.of("a", "6"), Pair.of("b", "12")}))
+            .build()
+        )
+    ));
 
-    // Insert JSON string (gets converted into JSON document)
-    inputRecords.add(
-        createTableRecord(7, "scooby doo", "{\"name\":\"scooby\",\"id\":7}", createEnumField(enumSchema, "UP"),
-            createFixedField(fixedSchema, 7), new byte[] {0, 0, 0, 7}, Arrays.asList(
-                new GenericRecordBuilder(createJson5RecordSchema()).set("timestamp", 1719390727)
-                    .set("data", createMapField(new Pair[]{Pair.of("a", "7"), Pair.of("b", "14")})).build())));
+    // Insert JSON string (gets converted into canonical JSON)
+    inputRecords.add(createTableRecord(
+        7,
+        "scooby doo",
+        "{\"name\":  \"scooby\",   \"id\":7}",
+        createEnumField(enumSchema, "UP"),
+        createFixedField(fixedSchema, 7),
+        new byte[]{0, 0, 0, 7},
+        List.of(new GenericRecordBuilder(createJson5RecordSchema())
+            .set("timestamp", 1719390727)
+            .set("data", createMapField(new Pair[]{Pair.of("a", "7"), Pair.of("b", "14")}))
+            .build()
+        )
+    ));
 
     try (DataFileWriter<GenericData.Record> fileWriter = new DataFileWriter<>(new GenericDatumWriter<>(avroSchema))) {
       fileWriter.create(avroSchema, AVRO_DATA_FILE);
@@ -275,45 +331,49 @@ public class JsonIngestionFromAvroQueriesTest extends BaseQueriesTest {
   @Test
   public void testSimpleSelectOnJsonColumn() {
     Operator<SelectionResultsBlock> operator =
-        getOperator("select intColumn, stringColumn, jsonColumn1, jsonColumn2 FROM " + "testTable limit 100");
+        getOperator("select intColumn, stringColumn, jsonColumn1, jsonColumn2 FROM testTable limit 100");
     SelectionResultsBlock block = operator.nextBlock();
     Collection<Object[]> rows = block.getRows();
-    Assert.assertEquals(block.getDataSchema().getColumnDataType(0), DataSchema.ColumnDataType.INT);
-    Assert.assertEquals(block.getDataSchema().getColumnDataType(1), DataSchema.ColumnDataType.STRING);
-    Assert.assertEquals(block.getDataSchema().getColumnDataType(2), DataSchema.ColumnDataType.JSON);
+    assertEquals(block.getDataSchema().getColumnDataType(0), DataSchema.ColumnDataType.INT);
+    assertEquals(block.getDataSchema().getColumnDataType(1), DataSchema.ColumnDataType.STRING);
+    assertEquals(block.getDataSchema().getColumnDataType(2), DataSchema.ColumnDataType.JSON);
 
-    List<String> expecteds = Arrays.asList("[1, daffy duck, [\"this\",\"is\",\"a\",\"test\"], \"UP\"]",
-        "[2, mickey mouse, {\"a\":\"1\",\"b\":\"2\"}, \"DOWN\"]", "[3, donald duck, {\"a\":\"1\",\"b\":\"2\"}, \"UP\"]",
+    List<String> expecteds = List.of(
+        "[1, daffy duck, [\"this\",\"is\",\"a\",\"test\"], \"UP\"]",
+        "[2, mickey mouse, {\"a\":\"1\",\"b\":\"2\"}, \"DOWN\"]",
+        "[3, donald duck, {\"a\":\"1\",\"b\":\"2\"}, \"UP\"]",
         "[4, scrooge mcduck, {\"a\":\"1\",\"b\":\"2\"}, \"LEFT\"]",
-        "[5, minney mouse, {\"name\":\"minney\",\"id\":1}, \"RIGHT\"]", "[6, pluto, \"test\", \"DOWN\"]",
-        "[7, scooby doo, {\"name\":\"scooby\",\"id\":7}, \"UP\"]");
+        "[5, minney mouse, {\"id\":1,\"name\":\"minney\"}, \"RIGHT\"]",
+        "[6, pluto, \"test\", \"DOWN\"]",
+        "[7, scooby doo, {\"name\":\"scooby\",\"id\":7}, \"UP\"]"
+    );
 
     int index = 0;
     Iterator<Object[]> iterator = rows.iterator();
     while (iterator.hasNext()) {
       Object[] row = iterator.next();
-      Assert.assertEquals(Arrays.toString(row), expecteds.get(index++));
+      assertEquals(Arrays.toString(row), expecteds.get(index++));
     }
   }
 
   /** Verify simple path expression query on ingested Avro file. */
   @Test
   public void testJsonPathSelectOnJsonColumn() {
-    Operator<SelectionResultsBlock> operator = getOperator(
-        "select intColumn, json_extract_scalar(jsonColumn1, '$.name', " + "'STRING', 'null') FROM testTable");
+    Operator<SelectionResultsBlock> operator =
+        getOperator("select intColumn, json_extract_scalar(jsonColumn1, '$.name', 'STRING', 'null') FROM testTable");
     SelectionResultsBlock block = operator.nextBlock();
     Collection<Object[]> rows = block.getRows();
-    Assert.assertEquals(block.getDataSchema().getColumnDataType(0), DataSchema.ColumnDataType.INT);
-    Assert.assertEquals(block.getDataSchema().getColumnDataType(1), DataSchema.ColumnDataType.STRING);
+    assertEquals(block.getDataSchema().getColumnDataType(0), DataSchema.ColumnDataType.INT);
+    assertEquals(block.getDataSchema().getColumnDataType(1), DataSchema.ColumnDataType.STRING);
 
     List<String> expecteds =
-        Arrays.asList("[1, null]", "[2, null]", "[3, null]", "[4, null]", "[5, minney]", "[6, null]", "[7, scooby]");
+        List.of("[1, null]", "[2, null]", "[3, null]", "[4, null]", "[5, minney]", "[6, null]", "[7, scooby]");
     int index = 0;
 
     Iterator<Object[]> iterator = rows.iterator();
     while (iterator.hasNext()) {
       Object[] row = iterator.next();
-      Assert.assertEquals(Arrays.toString(row), expecteds.get(index++));
+      assertEquals(Arrays.toString(row), expecteds.get(index++));
     }
   }
 
@@ -321,19 +381,19 @@ public class JsonIngestionFromAvroQueriesTest extends BaseQueriesTest {
   @Test
   public void testStringValueSelectOnJsonColumn() {
     Operator<SelectionResultsBlock> operator = getOperator(
-        "SELECT json_extract_scalar(jsonColumn1, '$', 'STRING') FROM "
-            + "testTable WHERE JSON_MATCH(jsonColumn1, '\"$\" = ''test''')");
+        "SELECT json_extract_scalar(jsonColumn1, '$', 'STRING') FROM testTable"
+            + " WHERE JSON_MATCH(jsonColumn1, '\"$\" = ''test''')");
     SelectionResultsBlock block = operator.nextBlock();
     Collection<Object[]> rows = block.getRows();
-    Assert.assertEquals(block.getDataSchema().getColumnDataType(0), DataSchema.ColumnDataType.STRING);
+    assertEquals(block.getDataSchema().getColumnDataType(0), DataSchema.ColumnDataType.STRING);
 
-    List<String> expecteds = Arrays.asList("[test]");
+    List<String> expecteds = List.of("[test]");
     int index = 0;
 
     Iterator<Object[]> iterator = rows.iterator();
     while (iterator.hasNext()) {
       Object[] row = iterator.next();
-      Assert.assertEquals(Arrays.toString(row), expecteds.get(index++));
+      assertEquals(Arrays.toString(row), expecteds.get(index++));
     }
   }
 
@@ -355,22 +415,23 @@ public class JsonIngestionFromAvroQueriesTest extends BaseQueriesTest {
         "select jsonColumn5 FROM testTable");
     SelectionResultsBlock block = operator.nextBlock();
     Collection<Object[]> rows = block.getRows();
-    Assert.assertEquals(block.getDataSchema().getColumnDataType(0), DataSchema.ColumnDataType.JSON);
+    assertEquals(block.getDataSchema().getColumnDataType(0), DataSchema.ColumnDataType.JSON);
 
-    List<String> expecteds = Arrays.asList(
+    List<String> expecteds = List.of(
         "[[{\"data\":{\"a\":\"1\",\"b\":\"2\"},\"timestamp\":1719390721}]]",
         "[[{\"data\":{\"a\":\"2\",\"b\":\"4\"},\"timestamp\":1719390722}]]",
         "[[{\"data\":{\"a\":\"3\",\"b\":\"6\"},\"timestamp\":1719390723}]]",
         "[[{\"data\":{\"a\":\"4\",\"b\":\"8\"},\"timestamp\":1719390724}]]",
         "[[{\"data\":{\"a\":\"5\",\"b\":\"10\"},\"timestamp\":1719390725}]]",
         "[[{\"data\":{\"a\":\"6\",\"b\":\"12\"},\"timestamp\":1719390726}]]",
-        "[[{\"data\":{\"a\":\"7\",\"b\":\"14\"},\"timestamp\":1719390727}]]");
+        "[[{\"data\":{\"a\":\"7\",\"b\":\"14\"},\"timestamp\":1719390727}]]"
+    );
 
     int index = 0;
     Iterator<Object[]> iterator = rows.iterator();
     while (iterator.hasNext()) {
       Object[] row = iterator.next();
-      Assert.assertEquals(Arrays.toString(row), expecteds.get(index++));
+      assertEquals(Arrays.toString(row), expecteds.get(index++));
     }
   }
 
@@ -378,16 +439,16 @@ public class JsonIngestionFromAvroQueriesTest extends BaseQueriesTest {
     Operator<SelectionResultsBlock> operator = getOperator(query);
     SelectionResultsBlock block = operator.nextBlock();
     Collection<Object[]> rows = block.getRows();
-    Assert.assertEquals(block.getDataSchema().getColumnDataType(0), DataSchema.ColumnDataType.JSON);
+    assertEquals(block.getDataSchema().getColumnDataType(0), DataSchema.ColumnDataType.JSON);
 
     List<String> expecteds = IntStream.range(1, 8)
-        .mapToObj(i -> new byte[] {0, 0, 0, (byte) i})
+        .mapToObj(i -> new byte[]{0, 0, 0, (byte) i})
         .map(byteArray -> "[\"" + StringFunctions.toBase64(byteArray) + "\"]")
         .collect(Collectors.toList());
 
     int index = 0;
     for (Object[] row : rows) {
-      Assert.assertEquals(Arrays.toString(row), expecteds.get(index++));
+      assertEquals(Arrays.toString(row), expecteds.get(index++));
     }
   }
 

--- a/pinot-plugins/pinot-input-format/pinot-avro-base/src/test/java/org/apache/pinot/plugin/inputformat/avro/AvroRecordExtractorTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-avro-base/src/test/java/org/apache/pinot/plugin/inputformat/avro/AvroRecordExtractorTest.java
@@ -237,6 +237,36 @@ public class AvroRecordExtractorTest extends AbstractRecordExtractorTest {
     Assert.assertEquals(genericRow.getValue(timestampMicrosColName).getClass().getSimpleName(), "Timestamp");
   }
 
+  /// Verify that avro primitive types come back as their native Java boxed types — Boolean stays Boolean (was
+  /// previously stringified by `convertSingleValue`).
+  @Test
+  public void testPrimitiveTypePreservation() {
+    Schema avroSchema = createRecord("PrimitiveRecord", null, null, false);
+    avroSchema.setFields(Lists.newArrayList(
+        new Schema.Field("boolField", create(Type.BOOLEAN), null, null),
+        new Schema.Field("intField", create(Type.INT), null, null),
+        new Schema.Field("longField", create(Type.LONG), null, null),
+        new Schema.Field("floatField", create(Type.FLOAT), null, null),
+        new Schema.Field("doubleField", create(Type.DOUBLE), null, null)));
+    GenericRecord genericRecord = new GenericData.Record(avroSchema);
+    genericRecord.put("boolField", true);
+    genericRecord.put("intField", 42);
+    genericRecord.put("longField", 42L);
+    genericRecord.put("floatField", 1.5f);
+    genericRecord.put("doubleField", 1.5);
+
+    AvroRecordExtractor extractor = new AvroRecordExtractor();
+    extractor.init(null, null);
+    GenericRow row = new GenericRow();
+    extractor.extract(genericRecord, row);
+
+    Assert.assertSame(row.getValue("boolField").getClass(), Boolean.class, "avro boolean → Boolean");
+    Assert.assertSame(row.getValue("intField").getClass(), Integer.class, "avro int → Integer");
+    Assert.assertSame(row.getValue("longField").getClass(), Long.class, "avro long → Long");
+    Assert.assertSame(row.getValue("floatField").getClass(), Float.class, "avro float → Float");
+    Assert.assertSame(row.getValue("doubleField").getClass(), Double.class, "avro double → Double");
+  }
+
   @Test
   public void testReusedByteBuffer() {
     byte[] content = new byte[100];

--- a/pinot-plugins/pinot-input-format/pinot-clp-log/src/main/java/org/apache/pinot/plugin/inputformat/clplog/CLPLogRecordExtractor.java
+++ b/pinot-plugins/pinot-input-format/pinot-clp-log/src/main/java/org/apache/pinot/plugin/inputformat/clplog/CLPLogRecordExtractor.java
@@ -175,17 +175,6 @@ public class CLPLogRecordExtractor extends BaseRecordExtractor<Map<String, Objec
   }
 
   /**
-   * In addition to the basic conversion, we also needs to retain the type info of Boolean input.
-   */
-  @Override
-  protected Object convertSingleValue(Object value) {
-    if (value instanceof Boolean) {
-      return value;
-    }
-    return super.convertSingleValue(value);
-  }
-
-  /**
    * Encodes a field with CLP
    * <p></p>
    * Given a field "x", this will output three fields: "x_logtype", "x_dictionaryVars", "x_encodedVars"

--- a/pinot-plugins/pinot-input-format/pinot-clp-log/src/test/java/org/apache/pinot/plugin/inputformat/clplog/CLPLogRecordExtractorTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-clp-log/src/test/java/org/apache/pinot/plugin/inputformat/clplog/CLPLogRecordExtractorTest.java
@@ -36,6 +36,7 @@ import static org.apache.pinot.plugin.inputformat.clplog.CLPLogRecordExtractorCo
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
 import static org.testng.Assert.fail;
 
 
@@ -147,6 +148,15 @@ public class CLPLogRecordExtractorTest {
     assertEquals(row.getValue(_LEVEL_FIELD_NAME), _LEVEL_FIELD_VALUE);
     assertEquals(row.getValue(_MESSAGE_1_FIELD_NAME), _MESSAGE_1_FIELD_VALUE);
     assertEquals(row.getValue(_MESSAGE_2_FIELD_NAME), _MESSAGE_2_FIELD_VALUE);
+  }
+
+  /// Verify that primitive types pass through `convertSingleValue` as their native Java boxed types — Boolean stays
+  /// Boolean (was previously stringified), int stays Integer.
+  @Test
+  public void testPrimitiveTypePreservation() {
+    GenericRow row = extract(new HashMap<>(), null);
+    assertSame(row.getValue(_BOOLEAN_FIELD_NAME).getClass(), Boolean.class, "boolean → Boolean");
+    assertSame(row.getValue(_TIMESTAMP_FIELD_NAME).getClass(), Integer.class, "int → Integer");
   }
 
   @Test

--- a/pinot-plugins/pinot-input-format/pinot-csv/src/test/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordExtractorTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-csv/src/test/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordExtractorTest.java
@@ -105,6 +105,33 @@ public class CSVRecordExtractorTest extends AbstractRecordExtractorTest {
     }
   }
 
+  /// CSV is fundamentally untyped — every cell is a String regardless of how it could be interpreted. This locks in
+  /// that behavior: numeric and boolean-looking cells must come out as String, not parsed into Integer/Boolean.
+  @Test
+  public void testPrimitiveTypePreservation()
+      throws IOException {
+    File typeFile = new File(_tempDir, "types.csv");
+    try (BufferedWriter w = new BufferedWriter(new FileWriter(typeFile))) {
+      w.write("boolField,intField,doubleField,stringField\n");
+      w.write("true,42,1.5,hello");
+    }
+    CSVRecordReader reader = new CSVRecordReader();
+    HashSet<String> fields = new HashSet<>();
+    fields.add("boolField");
+    fields.add("intField");
+    fields.add("doubleField");
+    fields.add("stringField");
+    reader.init(typeFile, fields, new CSVRecordReaderConfig());
+    GenericRow row = new GenericRow();
+    reader.next(row);
+    reader.close();
+
+    Assert.assertSame(row.getValue("boolField").getClass(), String.class, "CSV cells stay String — no bool parsing");
+    Assert.assertSame(row.getValue("intField").getClass(), String.class, "CSV cells stay String — no int parsing");
+    Assert.assertSame(row.getValue("doubleField").getClass(), String.class, "CSV cells stay String — no num parsing");
+    Assert.assertSame(row.getValue("stringField").getClass(), String.class);
+  }
+
   @Test
   public void testRemovingSurroundingSpaces() throws IOException {
     CSVRecordReaderConfig csvRecordReaderConfig = new CSVRecordReaderConfig();

--- a/pinot-plugins/pinot-input-format/pinot-json/src/test/java/org/apache/pinot/plugin/inputformat/json/JSONRecordExtractorTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-json/src/test/java/org/apache/pinot/plugin/inputformat/json/JSONRecordExtractorTest.java
@@ -29,8 +29,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.pinot.spi.data.readers.AbstractRecordExtractorTest;
+import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.RecordReader;
 import org.apache.pinot.spi.utils.JsonUtils;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertSame;
 
 
 /**
@@ -197,5 +201,33 @@ public class JSONRecordExtractorTest extends AbstractRecordExtractorTest {
     record.put(MAP_2_FIELD, map6);
 
     return record;
+  }
+
+  /// Verify that JSON primitive types come back as their native Java boxed types — Boolean stays Boolean (was
+  /// previously stringified by `convertSingleValue`).
+  @Test
+  public void testPrimitiveTypePreservation()
+      throws IOException {
+    File typeFile = new File(_tempDir, "types.json");
+    try (FileWriter writer = new FileWriter(typeFile)) {
+      ObjectNode node = JsonUtils.newObjectNode();
+      node.put("boolField", true);
+      node.put("intField", 42);
+      node.put("longField", 1234567890123L);
+      node.put("doubleField", 1.5);
+      node.put("stringField", "hello");
+      writer.write(node.toString());
+    }
+    JSONRecordReader reader = new JSONRecordReader();
+    reader.init(typeFile, null, null);
+    GenericRow row = new GenericRow();
+    reader.next(row);
+    reader.close();
+
+    assertSame(row.getValue("boolField").getClass(), Boolean.class, "JSON bool → Boolean");
+    assertSame(row.getValue("intField").getClass(), Integer.class, "JSON int → Integer");
+    assertSame(row.getValue("longField").getClass(), Long.class, "JSON long → Long");
+    assertSame(row.getValue("doubleField").getClass(), Double.class, "JSON double → Double");
+    assertSame(row.getValue("stringField").getClass(), String.class, "JSON string → String");
   }
 }

--- a/pinot-plugins/pinot-input-format/pinot-orc/src/test/java/org/apache/pinot/plugin/inputformat/orc/ORCRecordExtractorTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-orc/src/test/java/org/apache/pinot/plugin/inputformat/orc/ORCRecordExtractorTest.java
@@ -44,9 +44,12 @@ import org.apache.orc.OrcFile;
 import org.apache.orc.TypeDescription;
 import org.apache.orc.Writer;
 import org.apache.pinot.spi.data.readers.AbstractRecordExtractorTest;
+import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.RecordReader;
+import org.testng.annotations.Test;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.testng.Assert.assertSame;
 
 
 /**
@@ -359,5 +362,45 @@ public class ORCRecordExtractorTest extends AbstractRecordExtractorTest {
     struct.put(fieldName2, value2);
     struct.put(fieldName3, value3);
     return struct;
+  }
+
+  /// Locks in the ORC reader's primitive type contract: BOOLEAN comes back as String "true"/"false" (TODO in
+  /// ORCRecordReader.java tracks aligning with the Boolean-preserving contract); BYTE / SHORT / INT all collapse to
+  /// Integer; LONG stays Long; FLOAT stays Float; DOUBLE stays Double. If anyone changes ORCRecordReader to
+  /// preserve Boolean directly, this test will catch and require updating.
+  @Test
+  public void testPrimitiveTypePreservation()
+      throws IOException {
+    File typeFile = new File(_tempDir, "types.orc");
+    TypeDescription schema = TypeDescription.fromString(
+        "struct<boolField:boolean,byteField:tinyint,shortField:smallint,intField:int,longField:bigint,"
+            + "floatField:float,doubleField:double,stringField:string>");
+    VectorizedRowBatch batch = schema.createRowBatch(1);
+    ((LongColumnVector) batch.cols[0]).vector[0] = 1; // true
+    ((LongColumnVector) batch.cols[1]).vector[0] = 7;
+    ((LongColumnVector) batch.cols[2]).vector[0] = 42;
+    ((LongColumnVector) batch.cols[3]).vector[0] = 1234;
+    ((LongColumnVector) batch.cols[4]).vector[0] = 1234567890123L;
+    ((DoubleColumnVector) batch.cols[5]).vector[0] = 1.5;
+    ((DoubleColumnVector) batch.cols[6]).vector[0] = 2.5;
+    ((BytesColumnVector) batch.cols[7]).setVal(0, "hello".getBytes(UTF_8));
+    batch.size = 1;
+    try (Writer writer = OrcFile.createWriter(new Path(typeFile.getAbsolutePath()),
+        OrcFile.writerOptions(new Configuration()).setSchema(schema).overwrite(true))) {
+      writer.addRowBatch(batch);
+    }
+
+    try (ORCRecordReader reader = new ORCRecordReader()) {
+      reader.init(typeFile, null, null);
+      GenericRow row = reader.next();
+      assertSame(row.getValue("boolField").getClass(), String.class, "ORC BOOLEAN currently surfaces as String");
+      assertSame(row.getValue("byteField").getClass(), Integer.class, "ORC TINYINT collapses to Integer");
+      assertSame(row.getValue("shortField").getClass(), Integer.class, "ORC SMALLINT collapses to Integer");
+      assertSame(row.getValue("intField").getClass(), Integer.class, "ORC INT → Integer");
+      assertSame(row.getValue("longField").getClass(), Long.class, "ORC BIGINT → Long");
+      assertSame(row.getValue("floatField").getClass(), Float.class, "ORC FLOAT → Float");
+      assertSame(row.getValue("doubleField").getClass(), Double.class, "ORC DOUBLE → Double");
+      assertSame(row.getValue("stringField").getClass(), String.class, "ORC STRING → String");
+    }
   }
 }

--- a/pinot-plugins/pinot-input-format/pinot-parquet/src/main/java/org/apache/pinot/plugin/inputformat/parquet/ParquetNativeRecordExtractor.java
+++ b/pinot-plugins/pinot-input-format/pinot-parquet/src/main/java/org/apache/pinot/plugin/inputformat/parquet/ParquetNativeRecordExtractor.java
@@ -114,6 +114,8 @@ public class ParquetNativeRecordExtractor extends BaseRecordExtractor<Group> {
     if (fieldType.isPrimitive()) {
       PrimitiveType.PrimitiveTypeName primitiveTypeName = fieldType.asPrimitiveType().getPrimitiveTypeName();
       switch (primitiveTypeName) {
+        case BOOLEAN:
+          return from.getBoolean(fieldIndex, index);
         case INT32:
           int intValue = from.getInteger(fieldIndex, index);
           if (logicalTypeAnnotation instanceof LogicalTypeAnnotation.DecimalLogicalTypeAnnotation) {
@@ -130,15 +132,13 @@ public class ParquetNativeRecordExtractor extends BaseRecordExtractor<Group> {
             return BigDecimal.valueOf(longValue, decimalLogicalTypeAnnotation.getScale());
           }
           return longValue;
+        case INT96:
+          Binary int96 = from.getInt96(fieldIndex, index);
+          return convertInt96ToLong(int96.getBytes());
         case FLOAT:
           return from.getFloat(fieldIndex, index);
         case DOUBLE:
           return from.getDouble(fieldIndex, index);
-        case BOOLEAN:
-          return from.getValueToString(fieldIndex, index);
-        case INT96:
-          Binary int96 = from.getInt96(fieldIndex, index);
-          return convertInt96ToLong(int96.getBytes());
         case BINARY:
         case FIXED_LEN_BYTE_ARRAY:
           if (logicalTypeAnnotation instanceof LogicalTypeAnnotation.DecimalLogicalTypeAnnotation) {

--- a/pinot-plugins/pinot-input-format/pinot-parquet/src/test/java/org/apache/pinot/plugin/inputformat/parquet/ParquetCollectionAndEquivalenceTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-parquet/src/test/java/org/apache/pinot/plugin/inputformat/parquet/ParquetCollectionAndEquivalenceTest.java
@@ -425,7 +425,7 @@ public class ParquetCollectionAndEquivalenceTest {
     assertEquals(row.getValue("longField"), 1234567890123L);
     assertEquals(row.getValue("floatField"), 1.5F);
     assertEquals(row.getValue("doubleField"), 2.25D);
-    assertEquals(row.getValue("boolField"), "true");
+    assertEquals(row.getValue("boolField"), true);
     assertEquals(row.getValue("stringField"), "hello parquet");
     assertEquals(row.getValue("decimalField"), new BigDecimal("123.45"));
     assertEquals(row.getValue("dateField"), 19723);

--- a/pinot-plugins/pinot-input-format/pinot-protobuf/src/main/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufRecordExtractor.java
+++ b/pinot-plugins/pinot-input-format/pinot-protobuf/src/main/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufRecordExtractor.java
@@ -235,10 +235,11 @@ public class ProtoBufRecordExtractor extends BaseRecordExtractor<Message> {
   @Override
   protected Object convertSingleValue(Object value) {
     Object fieldValue = ((ProtoBufFieldInfo) value).getFieldValue();
+    if (fieldValue instanceof Number || fieldValue instanceof Boolean) {
+      return fieldValue;
+    }
     if (fieldValue instanceof ByteString) {
       return ((ByteString) fieldValue).toByteArray();
-    } else if (fieldValue instanceof Number) {
-      return fieldValue;
     }
     return fieldValue.toString();
   }

--- a/pinot-plugins/pinot-input-format/pinot-protobuf/src/main/java/org/apache/pinot/plugin/inputformat/protobuf/codegen/MessageCodeGen.java
+++ b/pinot-plugins/pinot-input-format/pinot-protobuf/src/main/java/org/apache/pinot/plugin/inputformat/protobuf/codegen/MessageCodeGen.java
@@ -160,22 +160,15 @@ public class MessageCodeGen {
     }
 
     for (Descriptors.FieldDescriptor desc : descriptorsToDerive) {
-      Descriptors.FieldDescriptor.Type type = desc.getType();
+      Descriptors.FieldDescriptor.JavaType javaType = desc.getJavaType();
       String fieldNameInCode = ProtobufInternalUtils.underScoreToCamelCase(desc.getName(), true);
-      switch (type) {
-        case STRING:
-        case INT32:
-        case INT64:
-        case UINT64:
-        case FIXED64:
-        case FIXED32:
-        case UINT32:
-        case SFIXED32:
-        case SFIXED64:
-        case SINT32:
-        case SINT64:
-        case DOUBLE:
+      switch (javaType) {
+        case BOOLEAN:
+        case INT:
+        case LONG:
         case FLOAT:
+        case DOUBLE:
+        case STRING:
           /* Generate code for scalar field extraction
            Example: If field has presence
             if (msg.hasEmail()) {
@@ -190,33 +183,7 @@ public class MessageCodeGen {
           */
           code.append(codeForScalarFieldExtraction(desc, fieldNameInCode, indent));
           break;
-        case BOOL:
-          /* Generate code for boolean field extraction
-           Example: If field has presence
-             if (msg.hasIsRegistered()) {
-               msgMap.put("is_registered", String.valueOf(msg.getIsRegistered()));
-             }
-           OR if no presence:
-             msgMap.put("is_registered", String.valueOf(msg.getIsRegistered()));
-           OR if repeated:
-             List<Object> list1 = new ArrayList<>();
-             for (String row: msg.getIsRegisteredList()) {
-               list3.add(String.valueOf(row));
-             }
-             if (!list1.isEmpty()) {
-                msgMap.put("is_registered", list1.toArray());
-             }
-          */
-          code.append(codeForComplexFieldExtraction(
-              desc,
-              fieldNameInCode,
-              "String",
-              indent,
-              ++varNum,
-              "String.valueOf",
-              ""));
-          break;
-        case BYTES:
+        case BYTE_STRING:
           /* Generate code for bytes field extraction
             Example: If field has presence
               if (msg.hasEmail()) {
@@ -273,7 +240,7 @@ public class MessageCodeGen {
           if (desc.isMapField()) {
             // Generated code for Map extraction. The key for the map is always a scalar object in Protobuf.
             Descriptors.FieldDescriptor valueDescriptor = desc.getMessageType().findFieldByName("value");
-            if (valueDescriptor.getType() == Descriptors.FieldDescriptor.Type.MESSAGE) {
+            if (valueDescriptor.getJavaType() == Descriptors.FieldDescriptor.JavaType.MESSAGE) {
               /* Generate code for map field extraction if the value type is a message
               Example: If field has presence
                 if (msg.hasComplexMap()) {
@@ -315,8 +282,8 @@ public class MessageCodeGen {
           }
           break;
         default:
-          LOGGER.error(String.format("Protobuf type %s is not supported by pinot yet. Skipping this field %s",
-              type, desc.getName()));
+          LOGGER.error("Protobuf JavaType {} is not supported by pinot yet. Skipping this field {}", javaType,
+              desc.getName());
           break;
       }
     }

--- a/pinot-plugins/pinot-input-format/pinot-protobuf/src/test/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufCodeGenMessageDecoderTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-protobuf/src/test/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufCodeGenMessageDecoderTest.java
@@ -182,8 +182,8 @@ public class ProtoBufCodeGenMessageDecoderTest {
         new Object[] {BYTES_FIELD, ByteString.copyFrom(new byte[] {0, 1, 2, 3}), new byte[] {0, 1, 2, 3}},
         new Object[] {NULLABLE_BYTES_FIELD, ByteString.copyFrom(new byte[] {0, 1, 2, 3}), new byte[] {0, 1, 2, 3}},
 
-        new Object[] {BOOL_FIELD, true, "true"},
-        new Object[] {NULLABLE_BOOL_FIELD, true, "true"}
+        new Object[] {BOOL_FIELD, true, true},
+        new Object[] {NULLABLE_BOOL_FIELD, true, true}
     };
   }
 
@@ -237,8 +237,8 @@ public class ProtoBufCodeGenMessageDecoderTest {
         new Object[] {BYTES_FIELD, ByteString.EMPTY, new byte[] {}},
         new Object[] {NULLABLE_BYTES_FIELD, ByteString.EMPTY, new byte[] {}},
 
-        new Object[] {BOOL_FIELD, false, "false"},
-        new Object[] {NULLABLE_BOOL_FIELD, false, "false"}
+        new Object[] {BOOL_FIELD, false, false},
+        new Object[] {NULLABLE_BOOL_FIELD, false, false}
     };
   }
 
@@ -280,7 +280,7 @@ public class ProtoBufCodeGenMessageDecoderTest {
         new Object[] {BYTES_FIELD, new byte[] {}},
         new Object[] {NULLABLE_BYTES_FIELD, null},
 
-        new Object[] {BOOL_FIELD, "false"},
+        new Object[] {BOOL_FIELD, false},
         new Object[] {NULLABLE_BOOL_FIELD, null}
     };
   }
@@ -320,7 +320,7 @@ public class ProtoBufCodeGenMessageDecoderTest {
         new Object[] {BYTES_FIELD, new byte[] {}},
         new Object[] {NULLABLE_BYTES_FIELD, null},
 
-        new Object[] {BOOL_FIELD, "false"},
+        new Object[] {BOOL_FIELD, false},
         new Object[] {NULLABLE_BOOL_FIELD, null}
     };
   }

--- a/pinot-plugins/pinot-input-format/pinot-protobuf/src/test/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufRecordExtractorCachingTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-protobuf/src/test/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufRecordExtractorCachingTest.java
@@ -266,8 +266,7 @@ public class ProtoBufRecordExtractorCachingTest {
     assertEquals(row.getValue(LONG_FIELD), 100L);
     assertEquals(row.getValue(DOUBLE_FIELD), 1.1);
     assertEquals(row.getValue(FLOAT_FIELD), 2.2f);
-    // Note: convertSingleValue converts booleans to strings via toString()
-    assertEquals(row.getValue(BOOL_FIELD), "true");
+    assertEquals(row.getValue(BOOL_FIELD), true);
     assertNotNull(row.getValue(BYTES_FIELD)); // ByteString converted to byte[]
     assertEquals(row.getValue(ENUM_FIELD), "GAMMA");
 
@@ -352,7 +351,7 @@ public class ProtoBufRecordExtractorCachingTest {
     record.put(LONG_FIELD, (long) intValue * 10);
     record.put(DOUBLE_FIELD, intValue * 1.1);
     record.put(FLOAT_FIELD, intValue * 0.5f);
-    record.put(BOOL_FIELD, String.valueOf(intValue % 2 == 0));
+    record.put(BOOL_FIELD, intValue % 2 == 0);
     record.put(BYTES_FIELD, ("bytes_" + intValue).getBytes(UTF_8));
     record.put(REPEATED_STRINGS, Arrays.asList("a", "b", "c"));
     record.put(NESTED_MESSAGE, getNestedMap(NESTED_STRING_FIELD, "nested_" + intValue, NESTED_INT_FIELD, intValue));

--- a/pinot-plugins/pinot-input-format/pinot-protobuf/src/test/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufRecordExtractorLowLevelTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-protobuf/src/test/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufRecordExtractorLowLevelTest.java
@@ -113,8 +113,8 @@ public class ProtoBufRecordExtractorLowLevelTest {
         new Object[] {BYTES_FIELD, ByteString.copyFrom(new byte[] {0, 1, 2, 3}), new byte[] {0, 1, 2, 3}},
         new Object[] {NULLABLE_BYTES_FIELD, ByteString.copyFrom(new byte[] {0, 1, 2, 3}), new byte[] {0, 1, 2, 3}},
 
-        new Object[] {BOOL_FIELD, true, "true"},
-        new Object[] {NULLABLE_BOOL_FIELD, true, "true"}
+        new Object[] {BOOL_FIELD, true, true},
+        new Object[] {NULLABLE_BOOL_FIELD, true, true}
     };
   }
 
@@ -166,8 +166,8 @@ public class ProtoBufRecordExtractorLowLevelTest {
         new Object[] {BYTES_FIELD, ByteString.EMPTY, new byte[] {}},
         new Object[] {NULLABLE_BYTES_FIELD, ByteString.EMPTY, new byte[] {}},
 
-        new Object[] {BOOL_FIELD, false, "false"},
-        new Object[] {NULLABLE_BOOL_FIELD, false, "false"}
+        new Object[] {BOOL_FIELD, false, false},
+        new Object[] {NULLABLE_BOOL_FIELD, false, false}
     };
   }
 
@@ -206,7 +206,7 @@ public class ProtoBufRecordExtractorLowLevelTest {
         new Object[] {BYTES_FIELD, new byte[] {}},
         new Object[] {NULLABLE_BYTES_FIELD, null},
 
-        new Object[] {BOOL_FIELD, "false"},
+        new Object[] {BOOL_FIELD, false},
         new Object[] {NULLABLE_BOOL_FIELD, null}
     };
   }
@@ -243,7 +243,7 @@ public class ProtoBufRecordExtractorLowLevelTest {
         new Object[] {BYTES_FIELD, new byte[] {}},
         new Object[] {NULLABLE_BYTES_FIELD, null},
 
-        new Object[] {BOOL_FIELD, "false"},
+        new Object[] {BOOL_FIELD, false},
         new Object[] {NULLABLE_BOOL_FIELD, null}
     };
   }

--- a/pinot-plugins/pinot-input-format/pinot-protobuf/src/test/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufRecordExtractorTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-protobuf/src/test/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufRecordExtractorTest.java
@@ -31,9 +31,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.pinot.spi.data.readers.AbstractRecordExtractorTest;
+import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.RecordReader;
+import org.testng.annotations.Test;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.testng.Assert.assertSame;
 
 
 /**
@@ -73,6 +76,23 @@ public class ProtoBufRecordExtractorTest extends AbstractRecordExtractorTest {
     return Arrays.asList(createExplicitOptionalDefaultRecord(), createOptionalDefaultRecordWithNulls());
   }
 
+  /// Verify that protobuf primitive types come back as their native Java boxed types — Boolean stays Boolean, ints stay
+  /// Integer, etc. — rather than being stringified by `convertSingleValue`.
+  @Test
+  public void testPrimitiveTypePreservation()
+      throws IOException {
+    try (RecordReader reader = createRecordReader(_sourceFieldNames)) {
+      GenericRow row = new GenericRow();
+      reader.next(row);
+      assertSame(row.getValue(BOOL_FIELD).getClass(), Boolean.class, "proto bool → Boolean");
+      assertSame(row.getValue(INT_FIELD).getClass(), Integer.class, "proto int32 → Integer");
+      assertSame(row.getValue(LONG_FIELD).getClass(), Long.class, "proto int64 → Long");
+      assertSame(row.getValue(FLOAT_FIELD).getClass(), Float.class, "proto float → Float");
+      assertSame(row.getValue(DOUBLE_FIELD).getClass(), Double.class, "proto double → Double");
+      assertSame(row.getValue(BYTES_FIELD).getClass(), byte[].class, "proto bytes → byte[]");
+    }
+  }
+
   @Override
   protected Set<String> getSourceFields() {
     return Sets.newHashSet(STRING_FIELD, INT_FIELD, LONG_FIELD, DOUBLE_FIELD, FLOAT_FIELD, BOOL_FIELD, BYTES_FIELD,
@@ -105,7 +125,7 @@ public class ProtoBufRecordExtractorTest extends AbstractRecordExtractorTest {
       messageBuilder.setLongField((Long) inputRecord.get(LONG_FIELD));
       messageBuilder.setDoubleField((Double) inputRecord.get(DOUBLE_FIELD));
       messageBuilder.setFloatField((Float) inputRecord.get(FLOAT_FIELD));
-      messageBuilder.setBoolField(Boolean.parseBoolean((String) inputRecord.get(BOOL_FIELD)));
+      messageBuilder.setBoolField((Boolean) inputRecord.get(BOOL_FIELD));
       messageBuilder.setBytesField(ByteString.copyFrom((byte[]) inputRecord.get(BYTES_FIELD)));
 
       if (inputRecord.get(NULLABLE_STRING_FIELD) != null) {
@@ -124,7 +144,7 @@ public class ProtoBufRecordExtractorTest extends AbstractRecordExtractorTest {
         messageBuilder.setNullableFloatField((Float) inputRecord.get(NULLABLE_FLOAT_FIELD));
       }
       if (inputRecord.get(NULLABLE_BOOL_FIELD) != null) {
-        messageBuilder.setNullableBoolField(Boolean.parseBoolean((String) inputRecord.get(NULLABLE_BOOL_FIELD)));
+        messageBuilder.setNullableBoolField((Boolean) inputRecord.get(NULLABLE_BOOL_FIELD));
       }
       if (inputRecord.get(NULLABLE_BYTES_FIELD) != null) {
         messageBuilder.setNullableBytesField(ByteString.copyFrom((byte[]) inputRecord.get(NULLABLE_BYTES_FIELD)));
@@ -170,7 +190,7 @@ public class ProtoBufRecordExtractorTest extends AbstractRecordExtractorTest {
     record.put(LONG_FIELD, 100L);
     record.put(DOUBLE_FIELD, 1.1);
     record.put(FLOAT_FIELD, 2.2f);
-    record.put(BOOL_FIELD, "true");
+    record.put(BOOL_FIELD, true);
     record.put(BYTES_FIELD, "hello world!".getBytes(UTF_8));
     // These optional fields are explicitly set to proto defaults and expect
     // to see these values preserved (not treated as null).
@@ -179,7 +199,7 @@ public class ProtoBufRecordExtractorTest extends AbstractRecordExtractorTest {
     record.put(NULLABLE_LONG_FIELD, 0L);
     record.put(NULLABLE_DOUBLE_FIELD, 0.0);
     record.put(NULLABLE_FLOAT_FIELD, 0.0f);
-    record.put(NULLABLE_BOOL_FIELD, "false");
+    record.put(NULLABLE_BOOL_FIELD, false);
     record.put(NULLABLE_BYTES_FIELD, "".getBytes(UTF_8));
     record.put(REPEATED_STRINGS, Arrays.asList("aaa", "bbb", "ccc"));
     record.put(NESTED_MESSAGE, getNestedMap(NESTED_STRING_FIELD, "ice cream", NESTED_INT_FIELD, 9));
@@ -204,7 +224,7 @@ public class ProtoBufRecordExtractorTest extends AbstractRecordExtractorTest {
     record.put(LONG_FIELD, 200L);
     record.put(DOUBLE_FIELD, 3.3);
     record.put(FLOAT_FIELD, 4.4f);
-    record.put(BOOL_FIELD, "true");
+    record.put(BOOL_FIELD, true);
     record.put(BYTES_FIELD, "goodbye world!".getBytes(UTF_8));
     record.put(NULLABLE_STRING_FIELD, null);
     record.put(NULLABLE_INT_FIELD, null);

--- a/pinot-plugins/pinot-input-format/pinot-protobuf/src/test/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufRecordReaderTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-protobuf/src/test/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufRecordReaderTest.java
@@ -35,15 +35,12 @@ import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.AbstractRecordReaderTest;
 import org.apache.pinot.spi.data.readers.RecordReader;
 import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Test;
 
 
 public class ProtoBufRecordReaderTest extends AbstractRecordReaderTest {
   private final static Random RANDOM = new Random(System.currentTimeMillis());
   private static final String PROTO_DATA = "_test_sample_proto_data.data";
   private static final String DESCRIPTOR_FILE = "sample.desc";
-  private File _dataFile;
-  private RecordReader _recordReader;
   private final static int SAMPLE_RECORDS_SIZE = 10000;
 
   @Override
@@ -109,16 +106,6 @@ public class ProtoBufRecordReaderTest extends AbstractRecordReaderTest {
     _primaryKeys = generatePrimaryKeys(_records, getPrimaryKeyColumns());
     // Write generated random records to file
     writeRecordsToFile(_records);
-    // Create and init RecordReader
-    _recordReader = createRecordReader();
-  }
-
-  @Test
-  public void testRecordReader()
-      throws Exception {
-    checkValue(_recordReader, _records, _primaryKeys);
-    _recordReader.rewind();
-    checkValue(_recordReader, _records, _primaryKeys);
   }
 
   @Override
@@ -135,15 +122,16 @@ public class ProtoBufRecordReaderTest extends AbstractRecordReaderTest {
       throws Exception {
     List<Sample.SampleRecord> lists = new ArrayList<>();
     for (Map<String, Object> record : recordsToWrite) {
-      Sample.SampleRecord sampleRecord =
-          Sample.SampleRecord.newBuilder().setEmail((String) record.get("email")).setName((String) record.get("name"))
-              .setId((Integer) record.get("id")).addAllFriends((List<String>) record.get("friends")).build();
-
+      Sample.SampleRecord sampleRecord = Sample.SampleRecord.newBuilder()
+          .setEmail((String) record.get("email"))
+          .setName((String) record.get("name"))
+          .setId((Integer) record.get("id"))
+          .addAllFriends((List<String>) record.get("friends"))
+          .build();
       lists.add(sampleRecord);
     }
 
-    _dataFile = getSampleDataPath();
-    try (FileOutputStream output = new FileOutputStream(_dataFile, true)) {
+    try (FileOutputStream output = new FileOutputStream(getSampleDataPath(), true)) {
       for (Sample.SampleRecord record : lists) {
         record.writeDelimitedTo(output);
       }

--- a/pinot-plugins/pinot-input-format/pinot-protobuf/src/test/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufTestDataGenerator.java
+++ b/pinot-plugins/pinot-input-format/pinot-protobuf/src/test/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufTestDataGenerator.java
@@ -74,7 +74,7 @@ public class ProtoBufTestDataGenerator {
     messageBuilder.setLongField((Long) inputRecord.get(LONG_FIELD));
     messageBuilder.setDoubleField((Double) inputRecord.get(DOUBLE_FIELD));
     messageBuilder.setFloatField((Float) inputRecord.get(FLOAT_FIELD));
-    messageBuilder.setBoolField(Boolean.parseBoolean((String) inputRecord.get(BOOL_FIELD)));
+    messageBuilder.setBoolField((Boolean) inputRecord.get(BOOL_FIELD));
     messageBuilder.setBytesField(ByteString.copyFrom((byte[]) inputRecord.get(BYTES_FIELD)));
     messageBuilder.addAllRepeatedStrings((List) inputRecord.get(REPEATED_STRINGS));
     messageBuilder.setNestedMessage(createNestedMessage((Map<String, Object>) inputRecord.get(NESTED_MESSAGE)));
@@ -108,7 +108,7 @@ public class ProtoBufTestDataGenerator {
     record.put(LONG_FIELD, 100L);
     record.put(DOUBLE_FIELD, 1.1);
     record.put(FLOAT_FIELD, 2.2f);
-    record.put(BOOL_FIELD, "true");
+    record.put(BOOL_FIELD, true);
     record.put(BYTES_FIELD, "hello world!".getBytes(UTF_8));
     record.put(REPEATED_STRINGS, Arrays.asList("aaa", "bbb", "ccc"));
     record.put(NESTED_MESSAGE, getNestedMap(NESTED_STRING_FIELD, "ice cream", NESTED_INT_FIELD, 9));

--- a/pinot-plugins/pinot-input-format/pinot-protobuf/src/test/resources/codegen_output/complex_type_all_method.txt
+++ b/pinot-plugins/pinot-input-format/pinot-protobuf/src/test/resources/codegen_output/complex_type_all_method.txt
@@ -5,23 +5,23 @@
     msgMap.put("long_field", msg.getLongField());
     msgMap.put("double_field", msg.getDoubleField());
     msgMap.put("float_field", msg.getFloatField());
-    msgMap.put("bool_field", String.valueOf(msg.getBoolField()));
+    msgMap.put("bool_field", msg.getBoolField());
     msgMap.put("bytes_field", msg.getBytesField().toByteArray());
     if (msg.hasNestedMessage()) {
       msgMap.put("nested_message", decodeorg_apache_pinot_plugin_inputformat_protobuf_ComplexTypes_TestMessage_NestedMessageMessage(msg.getNestedMessage()));
     }
-    List<Object> list6 = new ArrayList<>();
+    List<Object> list5 = new ArrayList<>();
     for (org.apache.pinot.plugin.inputformat.protobuf.ComplexTypes.TestMessage.NestedMessage row: msg.getRepeatedNestedMessagesList()) {
-      list6.add(decodeorg_apache_pinot_plugin_inputformat_protobuf_ComplexTypes_TestMessage_NestedMessageMessage(row));
+      list5.add(decodeorg_apache_pinot_plugin_inputformat_protobuf_ComplexTypes_TestMessage_NestedMessageMessage(row));
     }
-    if (!list6.isEmpty()) {
-      msgMap.put("repeated_nested_messages", list6.toArray());
+    if (!list5.isEmpty()) {
+      msgMap.put("repeated_nested_messages", list5.toArray());
     }
-    Map<Object, Map<String, Object>> map6 = new HashMap<>();
+    Map<Object, Map<String, Object>> map5 = new HashMap<>();
     for (Map.Entry<String, Map<String,org.apache.pinot.plugin.inputformat.protobuf.ComplexTypes.TestMessage.NestedMessage>> entry: msg.getComplexMapMap().entrySet()) {
-      map6.put(entry.getKey(), decodeorg_apache_pinot_plugin_inputformat_protobuf_ComplexTypes_TestMessage_NestedMessageMessage( (org.apache.pinot.plugin.inputformat.protobuf.ComplexTypes.TestMessage.NestedMessage) entry.getValue()));
+      map5.put(entry.getKey(), decodeorg_apache_pinot_plugin_inputformat_protobuf_ComplexTypes_TestMessage_NestedMessageMessage( (org.apache.pinot.plugin.inputformat.protobuf.ComplexTypes.TestMessage.NestedMessage) entry.getValue()));
     }
-    msgMap.put("complex_map", map6);
+    msgMap.put("complex_map", map5);
     msgMap.put("simple_map", msg.getSimpleMapMap());
     msgMap.put("enum_field", msg.getEnumField().name());
     if (msg.hasNullableStringField()) {
@@ -40,7 +40,7 @@
       msgMap.put("nullable_float_field", msg.getNullableFloatField());
     }
     if (msg.hasNullableBoolField()) {
-      msgMap.put("nullable_bool_field", String.valueOf(msg.getNullableBoolField()));
+      msgMap.put("nullable_bool_field", msg.getNullableBoolField());
     }
     if (msg.hasNullableBytesField()) {
       msgMap.put("nullable_bytes_field", msg.getNullableBytesField().toByteArray());
@@ -60,26 +60,22 @@
     if (msg.getRepeatedFloatsCount() > 0) {
       msgMap.put("repeated_floats", msg.getRepeatedFloatsList().toArray());
     }
-    List<Object> list10 = new ArrayList<>();
-    for (String row: msg.getRepeatedBoolsList()) {
-      list10.add(String.valueOf(row));
+    if (msg.getRepeatedBoolsCount() > 0) {
+      msgMap.put("repeated_bools", msg.getRepeatedBoolsList().toArray());
     }
-    if (!list10.isEmpty()) {
-      msgMap.put("repeated_bools", list10.toArray());
-    }
-    List<Object> list11 = new ArrayList<>();
+    List<Object> list8 = new ArrayList<>();
     for (com.google.protobuf.ByteString row: msg.getRepeatedBytesList()) {
-      list11.add(row.toByteArray());
+      list8.add(row.toByteArray());
     }
-    if (!list11.isEmpty()) {
-      msgMap.put("repeated_bytes", list11.toArray());
+    if (!list8.isEmpty()) {
+      msgMap.put("repeated_bytes", list8.toArray());
     }
-    List<Object> list12 = new ArrayList<>();
+    List<Object> list9 = new ArrayList<>();
     for (org.apache.pinot.plugin.inputformat.protobuf.ComplexTypes.TestMessage.TestEnum row: msg.getRepeatedEnumsList()) {
-      list12.add(row.name());
+      list9.add(row.name());
     }
-    if (!list12.isEmpty()) {
-      msgMap.put("repeated_enums", list12.toArray());
+    if (!list9.isEmpty()) {
+      msgMap.put("repeated_enums", list9.toArray());
     }
     return msgMap;
   }

--- a/pinot-plugins/pinot-input-format/pinot-protobuf/src/test/resources/codegen_output/complex_types_record_extractor.txt
+++ b/pinot-plugins/pinot-input-format/pinot-protobuf/src/test/resources/codegen_output/complex_types_record_extractor.txt
@@ -45,23 +45,23 @@ public class ProtobufRecorderMessageExtractor {
     msgMap.put("long_field", msg.getLongField());
     msgMap.put("double_field", msg.getDoubleField());
     msgMap.put("float_field", msg.getFloatField());
-    msgMap.put("bool_field", String.valueOf(msg.getBoolField()));
+    msgMap.put("bool_field", msg.getBoolField());
     msgMap.put("bytes_field", msg.getBytesField().toByteArray());
     if (msg.hasNestedMessage()) {
       msgMap.put("nested_message", decodeorg_apache_pinot_plugin_inputformat_protobuf_ComplexTypes_TestMessage_NestedMessageMessage(msg.getNestedMessage()));
     }
-    List<Object> list6 = new ArrayList<>();
+    List<Object> list5 = new ArrayList<>();
     for (org.apache.pinot.plugin.inputformat.protobuf.ComplexTypes.TestMessage.NestedMessage row: msg.getRepeatedNestedMessagesList()) {
-      list6.add(decodeorg_apache_pinot_plugin_inputformat_protobuf_ComplexTypes_TestMessage_NestedMessageMessage(row));
+      list5.add(decodeorg_apache_pinot_plugin_inputformat_protobuf_ComplexTypes_TestMessage_NestedMessageMessage(row));
     }
-    if (!list6.isEmpty()) {
-      msgMap.put("repeated_nested_messages", list6.toArray());
+    if (!list5.isEmpty()) {
+      msgMap.put("repeated_nested_messages", list5.toArray());
     }
-    Map<Object, Map<String, Object>> map6 = new HashMap<>();
+    Map<Object, Map<String, Object>> map5 = new HashMap<>();
     for (Map.Entry<String, Map<String,org.apache.pinot.plugin.inputformat.protobuf.ComplexTypes.TestMessage.NestedMessage>> entry: msg.getComplexMapMap().entrySet()) {
-      map6.put(entry.getKey(), decodeorg_apache_pinot_plugin_inputformat_protobuf_ComplexTypes_TestMessage_NestedMessageMessage( (org.apache.pinot.plugin.inputformat.protobuf.ComplexTypes.TestMessage.NestedMessage) entry.getValue()));
+      map5.put(entry.getKey(), decodeorg_apache_pinot_plugin_inputformat_protobuf_ComplexTypes_TestMessage_NestedMessageMessage( (org.apache.pinot.plugin.inputformat.protobuf.ComplexTypes.TestMessage.NestedMessage) entry.getValue()));
     }
-    msgMap.put("complex_map", map6);
+    msgMap.put("complex_map", map5);
     msgMap.put("simple_map", msg.getSimpleMapMap());
     msgMap.put("enum_field", msg.getEnumField().name());
     if (msg.hasNullableStringField()) {
@@ -80,7 +80,7 @@ public class ProtobufRecorderMessageExtractor {
       msgMap.put("nullable_float_field", msg.getNullableFloatField());
     }
     if (msg.hasNullableBoolField()) {
-      msgMap.put("nullable_bool_field", String.valueOf(msg.getNullableBoolField()));
+      msgMap.put("nullable_bool_field", msg.getNullableBoolField());
     }
     if (msg.hasNullableBytesField()) {
       msgMap.put("nullable_bytes_field", msg.getNullableBytesField().toByteArray());
@@ -100,26 +100,22 @@ public class ProtobufRecorderMessageExtractor {
     if (msg.getRepeatedFloatsCount() > 0) {
       msgMap.put("repeated_floats", msg.getRepeatedFloatsList().toArray());
     }
-    List<Object> list10 = new ArrayList<>();
-    for (String row: msg.getRepeatedBoolsList()) {
-      list10.add(String.valueOf(row));
+    if (msg.getRepeatedBoolsCount() > 0) {
+      msgMap.put("repeated_bools", msg.getRepeatedBoolsList().toArray());
     }
-    if (!list10.isEmpty()) {
-      msgMap.put("repeated_bools", list10.toArray());
-    }
-    List<Object> list11 = new ArrayList<>();
+    List<Object> list8 = new ArrayList<>();
     for (com.google.protobuf.ByteString row: msg.getRepeatedBytesList()) {
-      list11.add(row.toByteArray());
+      list8.add(row.toByteArray());
     }
-    if (!list11.isEmpty()) {
-      msgMap.put("repeated_bytes", list11.toArray());
+    if (!list8.isEmpty()) {
+      msgMap.put("repeated_bytes", list8.toArray());
     }
-    List<Object> list12 = new ArrayList<>();
+    List<Object> list9 = new ArrayList<>();
     for (org.apache.pinot.plugin.inputformat.protobuf.ComplexTypes.TestMessage.TestEnum row: msg.getRepeatedEnumsList()) {
-      list12.add(row.name());
+      list9.add(row.name());
     }
-    if (!list12.isEmpty()) {
-      msgMap.put("repeated_enums", list12.toArray());
+    if (!list9.isEmpty()) {
+      msgMap.put("repeated_enums", list9.toArray());
     }
     return msgMap;
   }

--- a/pinot-plugins/pinot-input-format/pinot-protobuf/src/test/resources/codegen_output/composite_types_record_extractor.txt
+++ b/pinot-plugins/pinot-input-format/pinot-protobuf/src/test/resources/codegen_output/composite_types_record_extractor.txt
@@ -45,23 +45,23 @@ public class ProtobufRecorderMessageExtractor {
     msgMap.put("long_field", msg.getLongField());
     msgMap.put("double_field", msg.getDoubleField());
     msgMap.put("float_field", msg.getFloatField());
-    msgMap.put("bool_field", String.valueOf(msg.getBoolField()));
+    msgMap.put("bool_field", msg.getBoolField());
     msgMap.put("bytes_field", msg.getBytesField().toByteArray());
     if (msg.hasNestedMessage()) {
       msgMap.put("nested_message", decodeorg_apache_pinot_plugin_inputformat_protobuf_ComplexTypes_TestMessage_NestedMessageMessage(msg.getNestedMessage()));
     }
-    List<Object> list6 = new ArrayList<>();
+    List<Object> list5 = new ArrayList<>();
     for (org.apache.pinot.plugin.inputformat.protobuf.ComplexTypes.TestMessage.NestedMessage row: msg.getRepeatedNestedMessagesList()) {
-      list6.add(decodeorg_apache_pinot_plugin_inputformat_protobuf_ComplexTypes_TestMessage_NestedMessageMessage(row));
+      list5.add(decodeorg_apache_pinot_plugin_inputformat_protobuf_ComplexTypes_TestMessage_NestedMessageMessage(row));
     }
-    if (!list6.isEmpty()) {
-      msgMap.put("repeated_nested_messages", list6.toArray());
+    if (!list5.isEmpty()) {
+      msgMap.put("repeated_nested_messages", list5.toArray());
     }
-    Map<Object, Map<String, Object>> map6 = new HashMap<>();
+    Map<Object, Map<String, Object>> map5 = new HashMap<>();
     for (Map.Entry<String, Map<String,org.apache.pinot.plugin.inputformat.protobuf.ComplexTypes.TestMessage.NestedMessage>> entry: msg.getComplexMapMap().entrySet()) {
-      map6.put(entry.getKey(), decodeorg_apache_pinot_plugin_inputformat_protobuf_ComplexTypes_TestMessage_NestedMessageMessage( (org.apache.pinot.plugin.inputformat.protobuf.ComplexTypes.TestMessage.NestedMessage) entry.getValue()));
+      map5.put(entry.getKey(), decodeorg_apache_pinot_plugin_inputformat_protobuf_ComplexTypes_TestMessage_NestedMessageMessage( (org.apache.pinot.plugin.inputformat.protobuf.ComplexTypes.TestMessage.NestedMessage) entry.getValue()));
     }
-    msgMap.put("complex_map", map6);
+    msgMap.put("complex_map", map5);
     msgMap.put("simple_map", msg.getSimpleMapMap());
     msgMap.put("enum_field", msg.getEnumField().name());
     if (msg.hasNullableStringField()) {
@@ -80,7 +80,7 @@ public class ProtobufRecorderMessageExtractor {
       msgMap.put("nullable_float_field", msg.getNullableFloatField());
     }
     if (msg.hasNullableBoolField()) {
-      msgMap.put("nullable_bool_field", String.valueOf(msg.getNullableBoolField()));
+      msgMap.put("nullable_bool_field", msg.getNullableBoolField());
     }
     if (msg.hasNullableBytesField()) {
       msgMap.put("nullable_bytes_field", msg.getNullableBytesField().toByteArray());
@@ -100,26 +100,22 @@ public class ProtobufRecorderMessageExtractor {
     if (msg.getRepeatedFloatsCount() > 0) {
       msgMap.put("repeated_floats", msg.getRepeatedFloatsList().toArray());
     }
-    List<Object> list10 = new ArrayList<>();
-    for (String row: msg.getRepeatedBoolsList()) {
-      list10.add(String.valueOf(row));
+    if (msg.getRepeatedBoolsCount() > 0) {
+      msgMap.put("repeated_bools", msg.getRepeatedBoolsList().toArray());
     }
-    if (!list10.isEmpty()) {
-      msgMap.put("repeated_bools", list10.toArray());
-    }
-    List<Object> list11 = new ArrayList<>();
+    List<Object> list8 = new ArrayList<>();
     for (com.google.protobuf.ByteString row: msg.getRepeatedBytesList()) {
-      list11.add(row.toByteArray());
+      list8.add(row.toByteArray());
     }
-    if (!list11.isEmpty()) {
-      msgMap.put("repeated_bytes", list11.toArray());
+    if (!list8.isEmpty()) {
+      msgMap.put("repeated_bytes", list8.toArray());
     }
-    List<Object> list12 = new ArrayList<>();
+    List<Object> list9 = new ArrayList<>();
     for (org.apache.pinot.plugin.inputformat.protobuf.ComplexTypes.TestMessage.TestEnum row: msg.getRepeatedEnumsList()) {
-      list12.add(row.name());
+      list9.add(row.name());
     }
-    if (!list12.isEmpty()) {
-      msgMap.put("repeated_enums", list12.toArray());
+    if (!list9.isEmpty()) {
+      msgMap.put("repeated_enums", list9.toArray());
     }
     return msgMap;
   }

--- a/pinot-plugins/pinot-input-format/pinot-thrift/src/test/java/org/apache/pinot/plugin/inputformat/thrift/ThriftRecordExtractorTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-thrift/src/test/java/org/apache/pinot/plugin/inputformat/thrift/ThriftRecordExtractorTest.java
@@ -30,10 +30,14 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.pinot.spi.data.readers.AbstractRecordExtractorTest;
+import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.RecordReader;
 import org.apache.thrift.TException;
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.apache.thrift.transport.TIOStreamTransport;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertSame;
 
 
 /**
@@ -61,6 +65,21 @@ public class ThriftRecordExtractorTest extends AbstractRecordExtractorTest {
   @Override
   protected List<Map<String, Object>> getInputRecords() {
     return Arrays.asList(createRecord1(), createRecord2());
+  }
+
+  /// Verify that thrift primitive types come back as their native Java boxed types — Boolean stays Boolean, ints stay
+  /// Integer, etc. — rather than being stringified by `convertSingleValue`.
+  @Test
+  public void testPrimitiveTypePreservation()
+      throws IOException {
+    try (RecordReader reader = createRecordReader(_sourceFieldNames)) {
+      GenericRow row = new GenericRow();
+      reader.next(row);
+      assertSame(row.getValue(BOOL_FIELD).getClass(), Boolean.class, "thrift bool → Boolean");
+      assertSame(row.getValue(INT_FIELD).getClass(), Integer.class, "thrift i32 → Integer");
+      assertSame(row.getValue(LONG_FIELD).getClass(), Long.class, "thrift i64 → Long");
+      assertSame(row.getValue(DOUBLE_FIELD).getClass(), Double.class, "thrift double → Double");
+    }
   }
 
   @Override
@@ -113,7 +132,7 @@ public class ThriftRecordExtractorTest extends AbstractRecordExtractorTest {
       }
 
       thriftRecord.setComplexListField(nestedTypeList);
-      thriftRecord.setBooleanField(Boolean.valueOf((String) inputRecord.get(BOOL_FIELD)));
+      thriftRecord.setBooleanField((Boolean) inputRecord.get(BOOL_FIELD));
       thriftRecord.setDoubleField((Double) inputRecord.get(DOUBLE_FIELD));
       thriftRecord.setStringField((String) inputRecord.get(STRING_FIELD));
       thriftRecord.setEnumField(TestEnum.valueOf((String) inputRecord.get(ENUM_FIELD)));
@@ -145,7 +164,7 @@ public class ThriftRecordExtractorTest extends AbstractRecordExtractorTest {
     record.put(INT_FIELD, 10);
     record.put(LONG_FIELD, 1000L);
     record.put(DOUBLE_FIELD, 1.0);
-    record.put(BOOL_FIELD, "false");
+    record.put(BOOL_FIELD, false);
     record.put(ENUM_FIELD, TestEnum.DELTA.toString());
     record.put(NESTED_STRUCT_FIELD, createNestedMap(NESTED_STRING_FIELD, "ice cream", NESTED_INT_FIELD, 5));
     record.put(SIMPLE_LIST, Arrays.asList("aaa", "bbb", "ccc"));
@@ -165,7 +184,7 @@ public class ThriftRecordExtractorTest extends AbstractRecordExtractorTest {
     record.put(INT_FIELD, 20);
     record.put(LONG_FIELD, 2000L);
     record.put(DOUBLE_FIELD, 2.0);
-    record.put(BOOL_FIELD, "false");
+    record.put(BOOL_FIELD, false);
     record.put(ENUM_FIELD, TestEnum.GAMMA.toString());
     record.put(NESTED_STRUCT_FIELD, createNestedMap(NESTED_STRING_FIELD, "ice cream", NESTED_INT_FIELD, 5));
     record.put(SIMPLE_LIST, Arrays.asList("aaa", "bbb", "ccc"));

--- a/pinot-plugins/pinot-input-format/pinot-thrift/src/test/java/org/apache/pinot/plugin/inputformat/thrift/ThriftRecordReaderTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-thrift/src/test/java/org/apache/pinot/plugin/inputformat/thrift/ThriftRecordReaderTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.plugin.inputformat.thrift;
 
-import com.google.common.collect.Sets;
 import java.io.File;
 import java.io.FileWriter;
 import java.nio.charset.Charset;
@@ -30,13 +29,17 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.AbstractRecordReaderTest;
+import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.RecordReader;
 import org.apache.thrift.TSerializer;
 import org.apache.thrift.protocol.TBinaryProtocol;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertSame;
 
 
 /**
@@ -67,20 +70,16 @@ public class ThriftRecordReaderTest extends AbstractRecordReaderTest {
     _primaryKeys = generatePrimaryKeys(_records, getPrimaryKeyColumns());
     // Write generated random records to file
     writeRecordsToFile(_records);
-    // Create and init RecordReader
-    _recordReader = createRecordReader();
   }
 
   protected static List<Map<String, Object>> generateRandomRecords(Schema pinotSchema) {
     // TODO: instead of hardcoding some rows, change this to work with the AbstractRecordReader's random value generator
     List<Map<String, Object>> records = new ArrayList<>();
     Map<String, Object> record1 = new HashMap<>();
-    record1.put("active", "true");
+    record1.put("active", true);
     record1.put("created_at", 1515541280L);
     record1.put("id", 1);
-    List<Integer> groups1 = new ArrayList<>();
-    groups1.add(1);
-    groups1.add(4);
+    List<Short> groups1 = List.of((short) 1, (short) 4);
     record1.put("groups", groups1);
     Map<String, Long> mapValues1 = new HashMap<>();
     mapValues1.put("name1", 1L);
@@ -91,12 +90,10 @@ public class ThriftRecordReaderTest extends AbstractRecordReaderTest {
     records.add(record1);
 
     Map<String, Object> record2 = new HashMap<>();
-    record2.put("active", "false");
+    record2.put("active", false);
     record2.put("created_at", 1515541290L);
     record2.put("id", 1);
-    List<Integer> groups2 = new ArrayList<>();
-    groups2.add(2);
-    groups2.add(3);
+    List<Short> groups2 = List.of((short) 2, (short) 3);
     record2.put("groups", groups2);
     records.add(record2);
 
@@ -105,17 +102,19 @@ public class ThriftRecordReaderTest extends AbstractRecordReaderTest {
 
   @Override
   protected org.apache.pinot.spi.data.Schema getPinotSchema() {
-    return new Schema.SchemaBuilder().setSchemaName("ThriftSampleData")
-        .addSingleValueDimension("id", FieldSpec.DataType.INT)
-        .addSingleValueDimension("name", FieldSpec.DataType.STRING)
-        .addSingleValueDimension("created_at", FieldSpec.DataType.LONG)
-        .addSingleValueDimension("active", FieldSpec.DataType.BOOLEAN)
-        .addMultiValueDimension("groups", FieldSpec.DataType.INT)
-        .addMultiValueDimension("set_values", FieldSpec.DataType.STRING).build();
+    return new Schema.SchemaBuilder()
+        .setSchemaName("ThriftSampleData")
+        .addSingleValueDimension("id", DataType.INT)
+        .addSingleValueDimension("name", DataType.STRING)
+        .addSingleValueDimension("created_at", DataType.LONG)
+        .addSingleValueDimension("active", DataType.BOOLEAN)
+        .addMultiValueDimension("groups", DataType.INT)
+        .addMultiValueDimension("set_values", DataType.STRING)
+        .build();
   }
 
   private Set<String> getSourceFields() {
-    return Sets.newHashSet("id", "name", "created_at", "active", "groups", "set_values");
+    return Set.of("id", "name", "created_at", "active", "groups", "set_values");
   }
 
   @Override
@@ -132,18 +131,14 @@ public class ThriftRecordReaderTest extends AbstractRecordReaderTest {
     List<ThriftSampleData> dataList = new ArrayList<>(recordsToWrite.size());
     for (Map<String, Object> record : recordsToWrite) {
       ThriftSampleData data = new ThriftSampleData();
-      data.setActive(Boolean.parseBoolean(record.get("active").toString()));
+      data.setActive((Boolean) record.get("active"));
       data.setCreated_at(Math.abs(((Long) record.get("created_at")).longValue()));
       int i = Math.abs(((Integer) record.get("id")).intValue());
       data.setId(i);
       data.setName((String) record.get("name"));
-      List<Integer> groupsList = (List<Integer>) record.get("groups");
+      List<Short> groupsList = (List<Short>) record.get("groups");
       if (groupsList != null) {
-        List<Short> groupsResult = new ArrayList<>(groupsList.size());
-        for (Integer num : groupsList) {
-          groupsResult.add(num.shortValue());
-        }
-        data.setGroups(groupsResult);
+        data.setGroups(groupsList);
       }
       List<String> setValuesList = (List<String>) record.get("set_values");
       if (setValuesList != null) {
@@ -157,15 +152,31 @@ public class ThriftRecordReaderTest extends AbstractRecordReaderTest {
     }
 
     TSerializer binarySerializer = new TSerializer(new TBinaryProtocol.Factory());
-    FileWriter writer = new FileWriter(_dataFile);
-    for (ThriftSampleData d : dataList) {
-      IOUtils.write(binarySerializer.serialize(d), writer, Charset.defaultCharset());
+    try (FileWriter writer = new FileWriter(_dataFile)) {
+      for (ThriftSampleData d : dataList) {
+        IOUtils.write(binarySerializer.serialize(d), writer, Charset.defaultCharset());
+      }
     }
-    writer.close();
   }
 
   @Override
   protected String getDataFileName() {
     return THRIFT_DATA;
+  }
+
+  /// Verify that thrift primitive types are preserved end-to-end through the reader — `bool` stays `Boolean`,
+  /// `i16` (multi-value) stays `Short[]`, `i32` stays `Integer`, `i64` stays `Long`. No silent stringification or
+  /// auto-promotion to wider types.
+  @Test
+  public void testPrimitiveTypePreservation()
+      throws Exception {
+    try (RecordReader reader = createRecordReader()) {
+      GenericRow row = reader.next();
+      assertSame(row.getValue("active").getClass(), Boolean.class, "thrift bool → Boolean");
+      assertSame(row.getValue("id").getClass(), Integer.class, "thrift i32 → Integer");
+      assertSame(row.getValue("created_at").getClass(), Long.class, "thrift i64 → Long");
+      Object[] groups = (Object[]) row.getValue("groups");
+      assertSame(groups[0].getClass(), Short.class, "thrift i16 elements stay Short — not promoted to Integer");
+    }
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/MapColumnPreIndexStatsCollector.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/MapColumnPreIndexStatsCollector.java
@@ -93,7 +93,7 @@ public class MapColumnPreIndexStatsCollector extends AbstractColumnStatisticsCol
     if (entry instanceof Map) {
       //noinspection unchecked
       Map<String, Object> mapValue = (Map<String, Object>) entry;
-      int length = MapUtils.serializeMap(mapValue).length;
+      int length = MapUtils.serializedSize(mapValue);
       _minLength = Math.min(_minLength, length);
       _maxLength = Math.max(_maxLength, length);
 

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/impl/stats/MapColumnPreIndexStatsCollectorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/impl/stats/MapColumnPreIndexStatsCollectorTest.java
@@ -35,6 +35,7 @@ import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.utils.ByteArray;
+import org.apache.pinot.spi.utils.MapUtils;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.annotations.Test;
 
@@ -258,7 +259,7 @@ public class MapColumnPreIndexStatsCollectorTest {
     r1.put("kLong", 7L);
     r1.put("kFloat", 1.5f);
     r1.put("kDouble", 2.25d);
-    r1.put("kBigDec", new java.math.BigDecimal("10.01"));
+    r1.put("kBigDec", new BigDecimal("10.01"));
     r1.put("kNull", null); // ignored
 
     Map<String, Object> r2 = new HashMap<>();
@@ -267,13 +268,13 @@ public class MapColumnPreIndexStatsCollectorTest {
     r2.put("kLong", 2L);
     r2.put("kFloat", 1.5f);
     r2.put("kDouble", 0.75d);
-    r2.put("kBigDec", new java.math.BigDecimal("10.01"));
+    r2.put("kBigDec", new BigDecimal("10.01"));
 
     Map<String, Object> r3 = new HashMap<>();
     r3.put("kStr", "alpha");
     r3.put("kInt", 3);
     r3.put("kFloat", 3.5f);
-    r3.put("kBigDec", new java.math.BigDecimal("5.25"));
+    r3.put("kBigDec", new BigDecimal("5.25"));
 
     StatsCollectorConfig cfg = newConfig(false);
     MapColumnPreIndexStatsCollector col = new MapColumnPreIndexStatsCollector("col", cfg);
@@ -297,9 +298,9 @@ public class MapColumnPreIndexStatsCollectorTest {
     assertEquals(keys, new String[]{"kBigDec", "kDouble", "kFloat", "kInt", "kLong", "kStr"});
 
     // Row length metrics
-    int l1 = org.apache.pinot.spi.utils.MapUtils.serializeMap(r1).length;
-    int l2 = org.apache.pinot.spi.utils.MapUtils.serializeMap(r2).length;
-    int l3 = org.apache.pinot.spi.utils.MapUtils.serializeMap(r3).length;
+    int l1 = MapUtils.serializedSize(r1);
+    int l2 = MapUtils.serializedSize(r2);
+    int l3 = MapUtils.serializedSize(r3);
     int expectedMin = Math.min(l1, Math.min(l2, l3));
     int expectedMax = Math.max(l1, Math.max(l2, l3));
     assertEquals(col.getLengthOfShortestElement(), expectedMin);
@@ -339,8 +340,8 @@ public class MapColumnPreIndexStatsCollectorTest {
     AbstractColumnStatisticsCollector sDec = col.getKeyStatistics("kBigDec2");
     assertNotNull(sDec);
     assertTrue(sDec instanceof BigDecimalColumnPreIndexStatsCollector);
-    assertEquals(sDec.getMaxValue(), new java.math.BigDecimal("4.56"));
-    assertEquals(sDec.getMinValue(), new java.math.BigDecimal("1.23"));
+    assertEquals(sDec.getMaxValue(), new BigDecimal("4.56"));
+    assertEquals(sDec.getMinValue(), new BigDecimal("1.23"));
 
     // JSON serialization branch for String collector
     AbstractColumnStatisticsCollector sObj = col.getKeyStatistics("kObj");

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/BaseRecordExtractor.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/BaseRecordExtractor.java
@@ -163,6 +163,9 @@ public abstract class BaseRecordExtractor<T> implements RecordExtractor<T> {
    * a different conversion for its single values.
    */
   protected Object convertSingleValue(Object value) {
+    if (value instanceof Number || value instanceof Boolean || value instanceof byte[]) {
+      return value;
+    }
     if (value instanceof ByteBuffer) {
       // NOTE: ByteBuffer might be reused in some record reader implementation. Make a slice to ensure nothing is
       //       modified in the original buffer
@@ -170,12 +173,6 @@ public abstract class BaseRecordExtractor<T> implements RecordExtractor<T> {
       byte[] bytesValue = new byte[slice.limit()];
       slice.get(bytesValue);
       return bytesValue;
-    }
-    if (value instanceof Number || value instanceof byte[]) {
-      if (value instanceof Short) {
-        return Integer.valueOf(value.toString());
-      }
-      return value;
     }
     return value.toString();
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/MapUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/MapUtils.java
@@ -19,60 +19,98 @@
 package org.apache.pinot.spi.utils;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Maps;
 import java.io.IOException;
+import java.io.OutputStream;
 import java.nio.ByteBuffer;
-import java.util.HashMap;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Map;
+import java.util.Map.Entry;
+import java.util.SortedMap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static java.nio.charset.StandardCharsets.UTF_8;
 
-
+/// Utilities for Pinot's `MAP` column representation.
+///
+/// Write paths come in two flavors:
+/// - `sortByKey = true` (default) — entries are sorted by key and nested maps are also key-sorted via
+///   [SerializationFeature#ORDER_MAP_ENTRIES_BY_KEYS]. Output is canonical: a pure function of the logical map.
+/// - `sortByKey = false` — entries written in the input map's iteration order with no nested key sort. Faster, but
+///   bytes are not a pure function of the logical map.
+///
+/// Read paths are identical regardless of how the input was written.
 public class MapUtils {
-
-  private static final Logger LOGGER = LoggerFactory.getLogger(MapUtils.class);
-
-  private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
-
   private MapUtils() {
   }
 
-  public static byte[] serializeMap(Map<String, Object> map) {
-    int size = map.size();
+  private static final Logger LOGGER = LoggerFactory.getLogger(MapUtils.class);
+  private static final ObjectMapper SORTED_MAPPER =
+      new ObjectMapper().configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
+  private static final ObjectMapper UNSORTED_MAPPER = new ObjectMapper();
+  private static final TypeReference<Map<String, Object>> MAP_TYPE_REFERENCE = new TypeReference<>() {
+  };
 
-    // Directly return the size (0) for empty map
+  /// Serializes a map into a length-prefixed binary frame: `[size][keyLen][keyBytes][valueLen][valueBytes]...`.
+  /// Entries are sorted by key before writing for canonical output.
+  public static byte[] serializeMap(Map<String, Object> map) {
+    return serializeMap(map, true);
+  }
+
+  /// Variant of [#serializeMap(Map)] that lets the caller skip the per-entry key sort when canonical output is not
+  /// required. `sortByKey = false` writes entries in the input map's iteration order and skips the per-value
+  /// nested-map key sort — faster, but the bytes are no longer a pure function of the logical map.
+  public static byte[] serializeMap(Map<String, Object> map, boolean sortByKey) {
+    int size = map.size();
     if (size == 0) {
       return new byte[Integer.BYTES];
     }
+    ObjectMapper mapper = sortByKey ? SORTED_MAPPER : UNSORTED_MAPPER;
 
-    // Besides the value bytes, we store: size, length for each key, length for each value
+    // Sorted path on a non-SortedMap: copy entries to a sortable array. Otherwise iterate the entrySet directly to
+    // avoid the array allocation (`SortedMap.entrySet()` is already sorted; the unsorted path doesn't care).
+    Collection<Entry<String, Object>> entries;
+    if (sortByKey && !(map instanceof SortedMap)) {
+      //noinspection unchecked
+      Entry<String, Object>[] sorted = map.entrySet().toArray(new Entry[0]);
+      Arrays.sort(sorted, Entry.comparingByKey());
+      entries = Arrays.asList(sorted);
+    } else {
+      entries = map.entrySet();
+    }
+
+    // First pass: serialize values and accumulate the total buffer size (4-byte map size + per-entry 4-byte key/value
+    // lengths plus key/value bytes).
     long bufferSize = (1 + 2 * (long) size) * Integer.BYTES;
     byte[][] keyBytesArray = new byte[size][];
     byte[][] valueBytesArray = new byte[size][];
-
     int index = 0;
-    for (Map.Entry<String, Object> entry : map.entrySet()) {
-      byte[] keyBytes = entry.getKey().getBytes(UTF_8);
-      bufferSize += keyBytes.length;
+    for (Entry<String, Object> entry : entries) {
+      byte[] keyBytes = Utf8Utils.encode(entry.getKey());
       keyBytesArray[index] = keyBytes;
-
-      byte[] valueBytes = null;
+      bufferSize += keyBytes.length;
+      byte[] valueBytes;
       try {
-        valueBytes = OBJECT_MAPPER.writeValueAsBytes(entry.getValue());
+        valueBytes = mapper.writeValueAsBytes(entry.getValue());
       } catch (JsonProcessingException e) {
         throw new RuntimeException(e);
       }
+      valueBytesArray[index] = valueBytes;
       bufferSize += valueBytes.length;
-      valueBytesArray[index++] = valueBytes;
+      index++;
     }
     Preconditions.checkState(bufferSize <= Integer.MAX_VALUE, "Buffer size exceeds 2GB");
+
+    // Second pass: emit into a single pre-sized buffer.
     byte[] bytes = new byte[(int) bufferSize];
     ByteBuffer byteBuffer = ByteBuffer.wrap(bytes);
     byteBuffer.putInt(size);
-    for (int i = 0; i < index; i++) {
+    for (int i = 0; i < size; i++) {
       byte[] keyBytes = keyBytesArray[i];
       byteBuffer.putInt(keyBytes.length);
       byteBuffer.put(keyBytes);
@@ -83,61 +121,91 @@ public class MapUtils {
     return bytes;
   }
 
+  /// Returns the byte size that [#serializeMap] would produce for the given map. Sort order does not affect the size.
+  /// Streams each value through Jackson into a counting sink so no per-value `byte[]` is allocated — Jackson's
+  /// per-thread `BufferRecycler` provides the encoding buffer.
+  public static int serializedSize(Map<String, Object> map) {
+    int size = map.size();
+    if (size == 0) {
+      return Integer.BYTES;
+    }
+    long bufferSize = (1 + 2 * (long) size) * Integer.BYTES;
+    CountingOutputStream sink = new CountingOutputStream();
+    for (Entry<String, Object> entry : map.entrySet()) {
+      bufferSize += Utf8Utils.encodedLength(entry.getKey());
+      try {
+        UNSORTED_MAPPER.writeValue(sink, entry.getValue());
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
+    bufferSize += sink._count;
+    Preconditions.checkState(bufferSize <= Integer.MAX_VALUE, "Buffer size exceeds 2GB");
+    return (int) bufferSize;
+  }
+
+  /// Discards bytes and counts them. Used by [#serializedSize] to measure JSON output without allocating a buffer.
+  private static final class CountingOutputStream extends OutputStream {
+    private long _count;
+
+    @Override
+    public void write(int b) {
+      _count++;
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) {
+      _count += len;
+    }
+  }
+
   public static Map<String, Object> deserializeMap(byte[] bytes) {
     return deserializeMap(ByteBuffer.wrap(bytes));
   }
 
   public static Map<String, Object> deserializeMap(ByteBuffer byteBuffer) {
-    Preconditions.checkNotNull(byteBuffer, "ByteBuffer cannot be null");
-
     int size = byteBuffer.getInt();
-    Preconditions.checkState(size >= 0, "Size of the map cannot be negative");
-
     if (size == 0) {
-      return Map.of(); // Return empty map if size is zero
+      return Map.of();
     }
-
-    // Check that remaining bytes are sufficient to read key and value lengths and data
-    Preconditions.checkState(byteBuffer.remaining() >= size * 2 * Integer.BYTES,
-        "Insufficient bytes in buffer to read all keys and values");
-
-    Map<String, Object> map = new HashMap<>(size);
+    Map<String, Object> map = Maps.newHashMapWithExpectedSize(size);
     for (int i = 0; i < size; i++) {
-      Preconditions.checkState(byteBuffer.remaining() >= Integer.BYTES,
-          "Insufficient bytes in buffer to read key length");
-      int keyLength = byteBuffer.getInt();
-      Preconditions.checkState(keyLength >= 0, "Key length cannot be negative");
-      Preconditions.checkState(byteBuffer.remaining() >= keyLength,
-          "Insufficient bytes in buffer to read key");
-
-      byte[] keyBytes = new byte[keyLength];
-      byteBuffer.get(keyBytes);
-      String key = new String(keyBytes, UTF_8);
-
-      Preconditions.checkState(byteBuffer.remaining() >= Integer.BYTES,
-          "Insufficient bytes in buffer to read value length");
-      int valueLength = byteBuffer.getInt();
-      Preconditions.checkState(valueLength >= 0, "Value length cannot be negative");
-      Preconditions.checkState(byteBuffer.remaining() >= valueLength,
-          "Insufficient bytes in buffer to read value");
-
-      byte[] valueBytes = new byte[valueLength];
-      byteBuffer.get(valueBytes);
-      Object value = null;
-
+      String key = Utf8Utils.decode(readLengthPrefixed(byteBuffer));
+      byte[] valueBytes = readLengthPrefixed(byteBuffer);
       try {
-        value = OBJECT_MAPPER.readValue(valueBytes, Object.class);
+        Object value = UNSORTED_MAPPER.readValue(valueBytes, Object.class);
+        map.put(key, value);
       } catch (IOException e) {
         LOGGER.error("Caught exception while deserializing value for key: {}", key, e);
       }
-      map.put(key, value);
     }
     return map;
   }
 
+  private static byte[] readLengthPrefixed(ByteBuffer byteBuffer) {
+    int length = byteBuffer.getInt();
+    byte[] bytes = new byte[length];
+    byteBuffer.get(bytes);
+    return bytes;
+  }
+
   public static String toString(Map<String, Object> map) {
+    return toString(map, true);
+  }
+
+  /// `sortByKey = false` skips key sorting (top-level and nested) for faster serialization when canonical output is
+  /// not required.
+  public static String toString(Map<String, Object> map, boolean sortByKey) {
     try {
-      return OBJECT_MAPPER.writeValueAsString(map);
+      return (sortByKey ? SORTED_MAPPER : UNSORTED_MAPPER).writeValueAsString(map);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public static Map<String, Object> fromString(String json) {
+    try {
+      return UNSORTED_MAPPER.readValue(json, MAP_TYPE_REFERENCE);
     } catch (JsonProcessingException e) {
       throw new RuntimeException(e);
     }

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/data/readers/AbstractRecordReaderTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/data/readers/AbstractRecordReaderTest.java
@@ -53,7 +53,6 @@ public abstract class AbstractRecordReaderTest {
   protected List<Object[]> _primaryKeys;
   protected org.apache.pinot.spi.data.Schema _pinotSchema;
   protected Set<String> _sourceFields;
-  protected RecordReader _recordReader;
 
   protected static List<Map<String, Object>> generateRandomRecords(Schema pinotSchema) {
     List<Map<String, Object>> records = new ArrayList<>();
@@ -207,8 +206,6 @@ public abstract class AbstractRecordReaderTest {
     _primaryKeys = generatePrimaryKeys(_records, getPrimaryKeyColumns());
     // Write generated random records to file
     writeRecordsToFile(_records);
-    // Create and init RecordReader
-    _recordReader = createRecordReader();
   }
 
   @AfterClass
@@ -220,9 +217,11 @@ public abstract class AbstractRecordReaderTest {
   @Test
   public void testRecordReader()
       throws Exception {
-    checkValue(_recordReader, _records, _primaryKeys);
-    _recordReader.rewind();
-    checkValue(_recordReader, _records, _primaryKeys);
+    try (RecordReader recordReader = createRecordReader()) {
+      checkValue(recordReader, _records, _primaryKeys);
+      recordReader.rewind();
+      checkValue(recordReader, _records, _primaryKeys);
+    }
   }
 
   @Test

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/data/readers/BaseRecordExtractorTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/data/readers/BaseRecordExtractorTest.java
@@ -1,0 +1,163 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.data.readers;
+
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.nio.ByteBuffer;
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+
+/**
+ * Locks in {@link BaseRecordExtractor#convertSingleValue} type-preservation contract:
+ * <ul>
+ *   <li>Numbers (Byte, Short, Integer, Long, Float, Double, BigDecimal, BigInteger) are returned as-is — Short is
+ *       NOT promoted to Integer.</li>
+ *   <li>Boolean is returned as-is — NOT converted to "true"/"false" String.</li>
+ *   <li>byte[] is returned as-is.</li>
+ *   <li>ByteBuffer is materialized into byte[].</li>
+ *   <li>Everything else falls back to {@code toString()}.</li>
+ * </ul>
+ */
+public class BaseRecordExtractorTest {
+  private static final TestExtractor EXTRACTOR = new TestExtractor();
+
+  @Test
+  void testBytePreserved() {
+    Object result = EXTRACTOR.convertSingleValue((byte) 42);
+    assertSame(result.getClass(), Byte.class, "Byte must remain Byte");
+    assertEquals(result, (byte) 42);
+  }
+
+  @Test
+  void testShortPreserved() {
+    Object result = EXTRACTOR.convertSingleValue((short) 42);
+    assertSame(result.getClass(), Short.class, "Short must remain Short — not promoted to Integer");
+    assertEquals(result, (short) 42);
+  }
+
+  @Test
+  void testIntegerPreserved() {
+    Object result = EXTRACTOR.convertSingleValue(42);
+    assertSame(result.getClass(), Integer.class);
+    assertEquals(result, 42);
+  }
+
+  @Test
+  void testLongPreserved() {
+    Object result = EXTRACTOR.convertSingleValue(42L);
+    assertSame(result.getClass(), Long.class);
+    assertEquals(result, 42L);
+  }
+
+  @Test
+  void testFloatPreserved() {
+    Object result = EXTRACTOR.convertSingleValue(1.5f);
+    assertSame(result.getClass(), Float.class);
+    assertEquals(result, 1.5f);
+  }
+
+  @Test
+  void testDoublePreserved() {
+    Object result = EXTRACTOR.convertSingleValue(1.5);
+    assertSame(result.getClass(), Double.class);
+    assertEquals(result, 1.5);
+  }
+
+  @Test
+  void testBigDecimalPreserved() {
+    BigDecimal value = new BigDecimal("123.45");
+    Object result = EXTRACTOR.convertSingleValue(value);
+    assertSame(result, value, "BigDecimal must be returned as-is, not stringified");
+  }
+
+  @Test
+  void testBigIntegerPreserved() {
+    BigInteger value = new BigInteger("12345678901234567890");
+    Object result = EXTRACTOR.convertSingleValue(value);
+    assertSame(result, value, "BigInteger must be returned as-is, not stringified");
+  }
+
+  @Test
+  void testBooleanPreserved() {
+    Object trueResult = EXTRACTOR.convertSingleValue(true);
+    assertSame(trueResult.getClass(), Boolean.class, "Boolean must remain Boolean — not converted to String");
+    assertEquals(trueResult, true);
+
+    Object falseResult = EXTRACTOR.convertSingleValue(false);
+    assertSame(falseResult.getClass(), Boolean.class);
+    assertEquals(falseResult, false);
+  }
+
+  @Test
+  void testByteArrayPreserved() {
+    byte[] bytes = {1, 2, 3};
+    Object result = EXTRACTOR.convertSingleValue(bytes);
+    assertSame(result, bytes, "byte[] must be returned as-is (same reference)");
+  }
+
+  @Test
+  void testByteBufferConvertedToByteArray() {
+    ByteBuffer buf = ByteBuffer.wrap(new byte[]{1, 2, 3});
+    Object result = EXTRACTOR.convertSingleValue(buf);
+    assertEquals(result, new byte[]{1, 2, 3}, "ByteBuffer must be materialized into byte[]");
+    assertSame(result.getClass(), byte[].class);
+  }
+
+  @Test
+  void testByteBufferSliceDoesNotMutateOriginal() {
+    // Position the buffer to verify the slice — extractor must read the remaining bytes only and not consume
+    // the original buffer.
+    ByteBuffer buf = ByteBuffer.wrap(new byte[]{0, 1, 2, 3, 4});
+    buf.position(2);
+    byte[] result = (byte[]) EXTRACTOR.convertSingleValue(buf);
+    assertEquals(result, new byte[]{2, 3, 4});
+    assertEquals(buf.position(), 2, "Original buffer position must not be advanced");
+  }
+
+  @Test
+  void testStringPreserved() {
+    Object result = EXTRACTOR.convertSingleValue("hello");
+    assertSame(result.getClass(), String.class);
+    assertEquals(result, "hello");
+  }
+
+  @Test
+  void testNonStandardObjectFallsBackToToString() {
+    Object result = EXTRACTOR.convertSingleValue(new StringBuilder("hello"));
+    assertSame(result.getClass(), String.class, "Unknown types fall back to toString()");
+    assertEquals(result, "hello");
+  }
+
+  /// Minimal concrete subclass to exercise the protected {@code convertSingleValue}.
+  private static final class TestExtractor extends BaseRecordExtractor<Object> {
+    @Override
+    public void init(@Nullable Set<String> fields, RecordExtractorConfig recordExtractorConfig) {
+    }
+
+    @Override
+    public GenericRow extract(Object from, GenericRow to) {
+      return to;
+    }
+  }
+}

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/utils/MapUtilsTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/utils/MapUtilsTest.java
@@ -18,30 +18,33 @@
  */
 package org.apache.pinot.spi.utils;
 
+import java.nio.BufferUnderflowException;
 import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.*;
 
 
 public class MapUtilsTest {
+
   @Test
   void testSerializeAndDeserializeEmptyMap() {
-    // Test for empty map
     Map<String, Object> emptyMap = Map.of();
     byte[] serialized = MapUtils.serializeMap(emptyMap);
     Map<String, Object> deserialized = MapUtils.deserializeMap(serialized);
 
     assertNotNull(serialized, "Serialized byte array should not be null");
-    assertEquals(4, serialized.length, "Serialized empty map should only have 4 bytes for size integer");
+    assertEquals(serialized.length, 4, "Serialized empty map should only have 4 bytes for size integer");
     assertNotNull(deserialized, "Deserialized map should not be null");
     assertTrue(deserialized.isEmpty(), "Deserialized map should be empty");
   }
 
   @Test
   void testSerializeAndDeserializeMapWithVariousDataTypes() {
-    // Test map with various data types
     Map<String, Object> map = new HashMap<>();
     map.put("string", "value");
     map.put("int", 123);
@@ -53,17 +56,16 @@ public class MapUtilsTest {
     Map<String, Object> deserialized = MapUtils.deserializeMap(serialized);
 
     assertNotNull(deserialized, "Deserialized map should not be null");
-    assertEquals(map.size(), deserialized.size(), "Deserialized map should have the same size as the original");
-    assertEquals(map.get("string"), deserialized.get("string"), "String value should match");
-    assertEquals(map.get("int"), deserialized.get("int"), "Integer value should match");
-    assertEquals(map.get("double"), deserialized.get("double"), "Double value should match");
-    assertEquals(map.get("boolean"), deserialized.get("boolean"), "Boolean value should match");
+    assertEquals(deserialized.size(), map.size(), "Deserialized map should have the same size as the original");
+    assertEquals(deserialized.get("string"), map.get("string"), "String value should match");
+    assertEquals(deserialized.get("int"), map.get("int"), "Integer value should match");
+    assertEquals(deserialized.get("double"), map.get("double"), "Double value should match");
+    assertEquals(deserialized.get("boolean"), map.get("boolean"), "Boolean value should match");
     assertNull(deserialized.get("nullValue"), "Null value should be preserved");
   }
 
   @Test
   void testSerializeAndDeserializeWithSpecialCharacters() {
-    // Test map with special characters
     Map<String, Object> map = new HashMap<>();
     map.put("specialChars", "çöğüşÇÖĞÜŞéÉ");
 
@@ -71,12 +73,109 @@ public class MapUtilsTest {
     Map<String, Object> deserialized = MapUtils.deserializeMap(serialized);
 
     assertNotNull(deserialized, "Deserialized map should not be null");
-    assertEquals(map.get("specialChars"), deserialized.get("specialChars"), "Special character value should match");
+    assertEquals(deserialized.get("specialChars"), map.get("specialChars"), "Special character value should match");
+  }
+
+  @Test
+  void testSerializeSortedIsDeterministic() {
+    // Same logical content in different insertion orders must produce identical canonical bytes.
+    Map<String, Object> map1 = new LinkedHashMap<>();
+    map1.put("a", 1);
+    map1.put("b", 2);
+    map1.put("c", 3);
+
+    Map<String, Object> map2 = new LinkedHashMap<>();
+    map2.put("c", 3);
+    map2.put("a", 1);
+    map2.put("b", 2);
+
+    assertEquals(MapUtils.serializeMap(map1), MapUtils.serializeMap(map2),
+        "Sorted serialization should be deterministic regardless of input iteration order");
+  }
+
+  @Test
+  void testSerializeUnsortedPreservesIterationOrder() {
+    // sortByKey=false should write entries in the input map's iteration order.
+    Map<String, Object> map = new LinkedHashMap<>();
+    map.put("z", 1);
+    map.put("a", 2);
+    map.put("m", 3);
+
+    byte[] sorted = MapUtils.serializeMap(map, true);
+    byte[] unsorted = MapUtils.serializeMap(map, false);
+
+    assertNotEquals(sorted, unsorted,
+        "Sorted and unsorted serialization should differ for non-alphabetical insertion order");
+    assertEquals(MapUtils.deserializeMap(sorted), map, "Sorted bytes should round-trip");
+    assertEquals(MapUtils.deserializeMap(unsorted), map, "Unsorted bytes should round-trip");
+  }
+
+  @Test
+  void testSerializeSortedMapShortCircuitsSort() {
+    // SortedMap is already in sorted order, so no resort is needed; bytes must still match the canonical form.
+    Map<String, Object> treeMap = new TreeMap<>();
+    treeMap.put("c", 3);
+    treeMap.put("a", 1);
+    treeMap.put("b", 2);
+    Map<String, Object> hashMap = new HashMap<>(treeMap);
+
+    assertEquals(MapUtils.serializeMap(treeMap), MapUtils.serializeMap(hashMap),
+        "TreeMap and HashMap with the same content should produce identical canonical bytes");
+  }
+
+  @Test
+  void testSerializeNestedMapsAreCanonical() {
+    // Nested maps inside values must also be key-sorted in canonical mode (ORDER_MAP_ENTRIES_BY_KEYS).
+    Map<String, Object> nested1 = new LinkedHashMap<>();
+    nested1.put("z", 1);
+    nested1.put("a", 2);
+
+    Map<String, Object> nested2 = new LinkedHashMap<>();
+    nested2.put("a", 2);
+    nested2.put("z", 1);
+
+    Map<String, Object> outer1 = new HashMap<>();
+    outer1.put("nested", nested1);
+    Map<String, Object> outer2 = new HashMap<>();
+    outer2.put("nested", nested2);
+
+    assertEquals(MapUtils.serializeMap(outer1), MapUtils.serializeMap(outer2),
+        "Nested-map canonicalization should produce identical bytes");
+  }
+
+  @Test
+  void testSerializedSizeMatchesSerializedBytes() {
+    Map<String, Object> map = new HashMap<>();
+    map.put("string", "value");
+    map.put("int", 123);
+    map.put("double", 4.5);
+    map.put("boolean", true);
+    map.put("nested", Map.of("a", 1, "b", 2));
+    map.put("list", List.of("x", "y", "z"));
+
+    int reportedSize = MapUtils.serializedSize(map);
+    byte[] actualBytes = MapUtils.serializeMap(map);
+
+    assertEquals(reportedSize, actualBytes.length, "serializedSize should match serializeMap(...).length");
+  }
+
+  @Test
+  void testSerializedSizeEmpty() {
+    assertEquals(MapUtils.serializedSize(Map.of()), 4, "Empty map should report 4 bytes (size header only)");
+  }
+
+  @Test
+  void testSerializedSizeWithSpecialCharacters() {
+    // UTF-8 multi-byte chars must be counted correctly on both key and value sides.
+    Map<String, Object> map = new HashMap<>();
+    map.put("çöğüş", "ÇÖĞÜŞéÉ");
+
+    assertEquals(MapUtils.serializedSize(map), MapUtils.serializeMap(map).length,
+        "serializedSize should match for maps containing UTF-8 multi-byte characters");
   }
 
   @Test
   void testToString() {
-    // Test the toString method
     Map<String, Object> map = new HashMap<>();
     map.put("key1", "value1");
     map.put("key2", 123);
@@ -89,17 +188,67 @@ public class MapUtilsTest {
   }
 
   @Test
-  void testDeserializeInvalidData() {
-    // Test deserialization of invalid data
-    byte[] invalidData = new byte[]{0, 1, 2, 3};
+  void testToStringSortedByDefault() {
+    // Default toString must produce canonical (key-sorted) JSON.
+    Map<String, Object> map = new LinkedHashMap<>();
+    map.put("z", 1);
+    map.put("a", 2);
 
-    try {
-      MapUtils.deserializeMap(invalidData);
-    } catch (IllegalStateException e) {
-      assertTrue(e.getMessage().contains("Insufficient bytes in buffer to read all keys and values"),
-          "Exception message should contain the correct error message");
-      return;
-    }
-    fail("Should have thrown an exception");
+    assertEquals(MapUtils.toString(map), "{\"a\":2,\"z\":1}", "Default toString should be key-sorted");
+  }
+
+  @Test
+  void testToStringSortedAndUnsorted() {
+    Map<String, Object> map = new LinkedHashMap<>();
+    map.put("z", 1);
+    map.put("a", 2);
+
+    assertEquals(MapUtils.toString(map, true), "{\"a\":2,\"z\":1}", "sortByKey=true should produce sorted JSON");
+    assertEquals(MapUtils.toString(map, false), "{\"z\":1,\"a\":2}",
+        "sortByKey=false should preserve insertion order");
+  }
+
+  @Test
+  void testToStringNestedMapsAreSortedInCanonicalMode() {
+    Map<String, Object> nested = new LinkedHashMap<>();
+    nested.put("z", 1);
+    nested.put("a", 2);
+    Map<String, Object> outer = new LinkedHashMap<>();
+    outer.put("inner", nested);
+
+    assertEquals(MapUtils.toString(outer, true), "{\"inner\":{\"a\":2,\"z\":1}}",
+        "Canonical toString should sort nested map keys too");
+    assertEquals(MapUtils.toString(outer, false), "{\"inner\":{\"z\":1,\"a\":2}}",
+        "Non-canonical toString should preserve nested map iteration order");
+  }
+
+  @Test
+  void testFromStringRoundTrip() {
+    Map<String, Object> original = new HashMap<>();
+    original.put("string", "value");
+    original.put("int", 123);
+    original.put("double", 4.5);
+    original.put("boolean", true);
+    original.put("nullValue", null);
+    original.put("list", List.of(1, 2, 3));
+    original.put("nested", Map.of("a", 1, "b", 2));
+
+    String json = MapUtils.toString(original);
+    Map<String, Object> roundTripped = MapUtils.fromString(json);
+
+    assertEquals(roundTripped, original, "fromString(toString) should preserve all values");
+  }
+
+  @Test
+  void testFromStringEmpty() {
+    Map<String, Object> result = MapUtils.fromString("{}");
+    assertNotNull(result, "fromString of empty object should return non-null map");
+    assertTrue(result.isEmpty(), "fromString of empty object should return empty map");
+  }
+
+  @Test(expectedExceptions = BufferUnderflowException.class)
+  void testDeserializeInvalidData() {
+    // First 4 bytes parse as size = 66051, which the loop then tries to read past end-of-buffer.
+    MapUtils.deserializeMap(new byte[]{0, 1, 2, 3});
   }
 }


### PR DESCRIPTION
## Summary
Two related correctness improvements to ingestion/serialization plumbing.

### MapUtils — canonical output by default
- `serializeMap` and `toString` now produce key-sorted, deterministic output. Nested maps inside values are also key-sorted via `SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS`, so the bytes/JSON are a pure function of the logical map regardless of the input `Map` implementation's iteration order. Existing fast path is exposed via `sortByKey = false` overloads for performance-sensitive callers.
- `PinotDataType.MAP` overrides `toString` / `toJson` / `toBytes` to delegate to the canonical `MapUtils` path, so map columns now serialize byte-deterministically end-to-end. The STRING source case in `convert` also routes through `MapUtils.fromString` for round-trip symmetry.
- Add `serializedSize(Map)` that streams values through Jackson into a counting `OutputStream` (no per-value `byte[]` allocation), and a `fromString` JSON-to-map helper.

### BaseRecordExtractor — preserve primitive types
- `convertSingleValue` now preserves `Boolean`, `Number`, and `byte[]` as-is. Removes the silent `Short` → `Integer` promotion and the `Boolean` → `"true"/"false"` stringification that previous callers had to work around.
- `ParquetNativeRecordExtractor` returns `Boolean` for the BOOLEAN primitive (was a String via `getValueToString`).
- `CLPLogRecordExtractor` drops its now-redundant Boolean-preserving override; `ProtoBufRecordExtractor` aligns its override with the new base contract.

### Tests
- Each record extractor / reader test gains an explicit `testPrimitiveTypePreservation` that asserts the actual `getClass()` returned per format — locking in the per-format type contract (e.g., proto bool → Boolean, thrift i16 → Short, ORC currently still BOOLEAN → String per the existing TODO).
- New `BaseRecordExtractorTest` covers `convertSingleValue` at the unit level.
- Tests that previously fed Booleans/Shorts as Strings (`ProtoBufRecordExtractorTest`, `ThriftRecordExtractorTest`, `ThriftRecordReaderTest`, `ProtoBufRecordExtractorCachingTest`, `ProtoBufTestDataGenerator`, `ParquetCollectionAndEquivalenceTest`) now use native types end-to-end.
