### PR TITLE
Allow invertedIndexDistinctCostRatio=0

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
@@ -184,10 +184,11 @@ public class QueryOptionsUtils {
   /**
    * Returns the cost ratio for the inverted-index-based distinct heuristic, or null if not set.
    * The inverted index path is chosen when dictionaryCardinality * costRatio <= filteredDocCount.
+   * A cost ratio of 0 forces the inverted index path for any non-empty filter result.
    */
   @Nullable
   public static Double getInvertedIndexDistinctCostRatio(Map<String, String> queryOptions) {
-    return checkedParseDoublePositive(QueryOptionKey.INVERTED_INDEX_DISTINCT_COST_RATIO,
+    return checkedParseDoubleNonNegative(QueryOptionKey.INVERTED_INDEX_DISTINCT_COST_RATIO,
         queryOptions.get(QueryOptionKey.INVERTED_INDEX_DISTINCT_COST_RATIO));
   }
 
@@ -617,6 +618,25 @@ public class QueryOptionsUtils {
     if (!Double.isFinite(value) || value <= 0) {
       throw new IllegalArgumentException(
           String.format("%s must be a positive number, got: %s", optionName, optionValue));
+    }
+    return value;
+  }
+
+  @Nullable
+  private static Double checkedParseDoubleNonNegative(String optionName, @Nullable String optionValue) {
+    if (optionValue == null) {
+      return null;
+    }
+    double value;
+    try {
+      value = Double.parseDouble(optionValue.trim());
+    } catch (NumberFormatException nfe) {
+      throw new IllegalArgumentException(
+          String.format("%s must be a non-negative number, got: %s", optionName, optionValue));
+    }
+    if (!Double.isFinite(value) || value < 0) {
+      throw new IllegalArgumentException(
+          String.format("%s must be a non-negative number, got: %s", optionName, optionValue));
     }
     return value;
   }

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/config/QueryOptionsUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/config/QueryOptionsUtilsTest.java
@@ -262,6 +262,8 @@ public class QueryOptionsUtilsTest {
   @Test
   public void testInvertedIndexDistinctCostRatioValid() {
     assertEquals(QueryOptionsUtils.getInvertedIndexDistinctCostRatio(
+        Map.of(INVERTED_INDEX_DISTINCT_COST_RATIO, "0")), Double.valueOf(0));
+    assertEquals(QueryOptionsUtils.getInvertedIndexDistinctCostRatio(
         Map.of(INVERTED_INDEX_DISTINCT_COST_RATIO, "2.5")), Double.valueOf(2.5));
     assertEquals(QueryOptionsUtils.getInvertedIndexDistinctCostRatio(
         Map.of(INVERTED_INDEX_DISTINCT_COST_RATIO, " 3.5 ")), Double.valueOf(3.5));
@@ -270,13 +272,13 @@ public class QueryOptionsUtilsTest {
 
   @Test
   public void testInvertedIndexDistinctCostRatioRejectsNonFiniteValues() {
-    for (String value : new String[]{"NaN", "Infinity", "-Infinity", "0", "-1"}) {
+    for (String value : new String[]{"NaN", "Infinity", "-Infinity", "-1", "invalid"}) {
       try {
         QueryOptionsUtils.getInvertedIndexDistinctCostRatio(Map.of(INVERTED_INDEX_DISTINCT_COST_RATIO, value));
         fail();
       } catch (IllegalArgumentException e) {
         assertEquals(e.getMessage(),
-            INVERTED_INDEX_DISTINCT_COST_RATIO + " must be a positive number, got: " + value);
+            INVERTED_INDEX_DISTINCT_COST_RATIO + " must be a non-negative number, got: " + value);
       }
     }
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/InvertedIndexDistinctOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/InvertedIndexDistinctOperator.java
@@ -85,7 +85,8 @@ import org.roaringbitmap.buffer.MutableRoaringBitmap;
  * </ul>
  *
  * <p>Enabled via the {@code useIndexBasedDistinctOperator} query option. The cost ratio can be tuned
- * via the {@code invertedIndexDistinctCostRatio} query option.
+ * via the {@code invertedIndexDistinctCostRatio} query option; setting it to 0 forces the inverted index path
+ * for non-empty filter results.
  */
 public class InvertedIndexDistinctOperator extends BaseOperator<DistinctResultsBlock> {
   private static final String EXPLAIN_NAME = "DISTINCT_INVERTED_INDEX";
@@ -173,7 +174,8 @@ public class InvertedIndexDistinctOperator extends BaseOperator<DistinctResultsB
    *   <li>dictCard &gt; 10K: costRatio=6  — inverted index wins when filteredDocs &ge; ~6x dictCard</li>
    * </ul>
    *
-   * <p>Can be overridden at query time via the query option {@code invertedIndexDistinctCostRatio}.
+   * <p>Can be overridden at query time via the query option {@code invertedIndexDistinctCostRatio}. Setting it
+   * to 0 forces the inverted index path for non-empty filter results.
    */
   static final NavigableMap<Integer, Double> DEFAULT_COST_RATIO_BY_CARDINALITY;
 
@@ -190,11 +192,14 @@ public class InvertedIndexDistinctOperator extends BaseOperator<DistinctResultsB
   }
 
   private boolean shouldUseBitmapInvertedIndex(int filteredDocCount) {
-    int dictionaryCardinality = _dictionary.length();
     if (filteredDocCount == 0) {
       return false;
     }
     Double costRatioOverride = QueryOptionsUtils.getInvertedIndexDistinctCostRatio(_queryContext.getQueryOptions());
+    if (costRatioOverride != null && costRatioOverride == 0.0) {
+      return true;
+    }
+    int dictionaryCardinality = _dictionary.length();
     double costRatio = costRatioOverride != null ? costRatioOverride : getDefaultCostRatio(dictionaryCardinality);
     return (double) dictionaryCardinality * costRatio <= filteredDocCount;
   }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InvertedIndexDistinctOperatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InvertedIndexDistinctOperatorTest.java
@@ -420,6 +420,11 @@ public class InvertedIndexDistinctOperatorTest extends BaseQueriesTest {
         "SELECT DISTINCT intColumn FROM testTable WHERE intColumn = 0 "
             + OPT + ", invertedIndexDistinctCostRatio=2)")));
 
+    // costRatio=0: force inverted index for non-empty filters
+    assertTrue(usedInvertedIndex(runDistinct(
+        "SELECT DISTINCT intColumn FROM testTable WHERE intColumn = 0 "
+            + OPT + ", invertedIndexDistinctCostRatio=0)")));
+
     // Default costRatio=30: 100*30=3000 <= 10K → inverted
     assertTrue(usedInvertedIndex(runDistinct(
         "SELECT DISTINCT intColumn FROM testTable WHERE intColumn >= 0 " + OPT + ")")));


### PR DESCRIPTION
## Summary

- Allow `invertedIndexDistinctCostRatio=0` as a valid query option value.
- Treat `0` as the documented way to force the bitmap inverted-index distinct path for non-empty filter results.
- Add parser coverage and query-path coverage for the zero-ratio behavior.

## User Manual

For single-column `DISTINCT` queries on dictionary-encoded columns with an inverted index, enable the index-based distinct operator and set `invertedIndexDistinctCostRatio=0` to force the inverted-index path whenever the filter matches at least one document.

```sql
SELECT DISTINCT intColumn
FROM testTable
WHERE intColumn = 0
OPTION(
  useIndexBasedDistinctOperator=true,
  invertedIndexDistinctCostRatio=0
)
```

A value of `0` means `dictionaryCardinality * costRatio <= filteredDocCount` is true for any non-empty filter result. Empty filter results still short-circuit to an empty result block. Positive values keep the existing cost-based behavior.

## Why

The option was previously parsed as strictly positive, so users could not configure the cost ratio to `0` even though the operator heuristic naturally supports that value as an always-use-inverted-index setting.

## Tests

- `./mvnw -pl pinot-common -Dtest=QueryOptionsUtilsTest test`
- `./mvnw -pl pinot-core -am -Dtest=InvertedIndexDistinctOperatorTest,InvertedIndexDistinctOperatorUnitTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw spotless:apply -pl pinot-common,pinot-core`
- `./mvnw checkstyle:check -pl pinot-common,pinot-core`
- `./mvnw license:format -pl pinot-common,pinot-core`
- `./mvnw license:check -pl pinot-common,pinot-core`
