### PR TITLE
Add IndexType SPI methods to declare per-index dictionary contract

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/bloom/BloomIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/bloom/BloomIndexType.java
@@ -121,6 +121,19 @@ public class BloomIndexType extends AbstractIndexType<BloomFilterConfig, BloomFi
   }
 
   @Override
+  public boolean requiresDictionary(FieldSpec fieldSpec, BloomFilterConfig indexConfig) {
+    // Bloom filters are computed by hashing column values directly, so the index does not need a dictionary.
+    return false;
+  }
+
+  @Override
+  public boolean shouldInvalidateOnDictionaryChange(FieldSpec fieldSpec, BloomFilterConfig indexConfig) {
+    // The on-disk bloom filter content is independent of dictionary presence (values are hashed, not dict IDs),
+    // so enabling/disabling the dictionary does not require rebuilding it.
+    return false;
+  }
+
+  @Override
   public List<String> getFileExtensions(@Nullable ColumnMetadata columnMetadata) {
     return EXTENSIONS;
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/dictionary/DictionaryIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/dictionary/DictionaryIndexType.java
@@ -353,6 +353,18 @@ public class DictionaryIndexType
     return IndexHandler.NoOp.INSTANCE;
   }
 
+  @Override
+  public boolean requiresDictionary(FieldSpec fieldSpec, DictionaryIndexConfig indexConfig) {
+    // The dictionary index is the dictionary itself; the question of whether it requires a dictionary is moot.
+    return false;
+  }
+
+  @Override
+  public boolean shouldInvalidateOnDictionaryChange(FieldSpec fieldSpec, DictionaryIndexConfig indexConfig) {
+    // Enable/disable of the dictionary IS the change being driven; the dictionary handler owns its own rebuild.
+    return false;
+  }
+
   public static String getFileExtension() {
     return V1Constants.Dict.FILE_EXTENSION;
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/forward/ForwardIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/forward/ForwardIndexType.java
@@ -231,6 +231,20 @@ public class ForwardIndexType extends AbstractIndexType<ForwardIndexConfig, Forw
   }
 
   @Override
+  public boolean requiresDictionary(FieldSpec fieldSpec, ForwardIndexConfig indexConfig) {
+    // Forward index supports both DICT and RAW encodings; it does not require a dictionary to function.
+    return false;
+  }
+
+  @Override
+  public boolean shouldInvalidateOnDictionaryChange(FieldSpec fieldSpec, ForwardIndexConfig indexConfig) {
+    // The forward index encoding is reconciled with FieldConfig.encodingType independently of dictionary state
+    // (apache/pinot#18364), so adding or removing a dictionary alone does not change the on-disk forward index
+    // layout — the existing forward index can be reused.
+    return false;
+  }
+
+  @Override
   protected IndexReaderFactory<ForwardIndexReader> createReaderFactory() {
     return ForwardIndexReaderFactory.getInstance();
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/fst/FstIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/fst/FstIndexType.java
@@ -126,6 +126,19 @@ public class FstIndexType extends AbstractIndexType<FstIndexConfig, TextIndexRea
   }
 
   @Override
+  public boolean requiresDictionary(FieldSpec fieldSpec, FstIndexConfig indexConfig) {
+    // FST is built over the column's sorted dictionary entries; without a dictionary it cannot be created or read.
+    return true;
+  }
+
+  @Override
+  public boolean shouldInvalidateOnDictionaryChange(FieldSpec fieldSpec, FstIndexConfig indexConfig) {
+    // FST exists only when a dictionary exists; enabling/disabling the dictionary changes whether the FST file
+    // must exist at all and is built from a different value set.
+    return true;
+  }
+
+  @Override
   public List<String> getFileExtensions(@Nullable ColumnMetadata columnMetadata) {
     return EXTENSIONS;
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/fst/IFSTIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/fst/IFSTIndexType.java
@@ -122,6 +122,19 @@ public class IFSTIndexType extends AbstractIndexType<FstIndexConfig, TextIndexRe
   }
 
   @Override
+  public boolean requiresDictionary(FieldSpec fieldSpec, FstIndexConfig indexConfig) {
+    // IFST is built over the column's sorted dictionary entries; without a dictionary it cannot be created or read.
+    return true;
+  }
+
+  @Override
+  public boolean shouldInvalidateOnDictionaryChange(FieldSpec fieldSpec, FstIndexConfig indexConfig) {
+    // IFST exists only when a dictionary exists; enabling/disabling the dictionary changes whether the IFST file
+    // must exist at all and is built from a different value set.
+    return true;
+  }
+
+  @Override
   public List<String> getFileExtensions(@Nullable ColumnMetadata columnMetadata) {
     return EXTENSIONS;
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/h3/H3IndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/h3/H3IndexType.java
@@ -126,6 +126,18 @@ public class H3IndexType extends AbstractIndexType<H3IndexConfig, H3IndexReader,
   }
 
   @Override
+  public boolean requiresDictionary(FieldSpec fieldSpec, H3IndexConfig indexConfig) {
+    // H3 index is built directly from geospatial values; it does not depend on a dictionary.
+    return false;
+  }
+
+  @Override
+  public boolean shouldInvalidateOnDictionaryChange(FieldSpec fieldSpec, H3IndexConfig indexConfig) {
+    // H3 cell IDs are derived from geometry values, independent of dictionary representation.
+    return false;
+  }
+
+  @Override
   public List<String> getFileExtensions(@Nullable ColumnMetadata columnMetadata) {
     return EXTENSIONS;
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/inverted/InvertedIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/inverted/InvertedIndexType.java
@@ -149,6 +149,22 @@ public class InvertedIndexType
     return new InvertedIndexHandler(segmentDirectory, configsByCol, tableConfig, schema);
   }
 
+  @Override
+  public boolean requiresDictionary(FieldSpec fieldSpec, IndexConfig indexConfig) {
+    // Inverted index posting lists are keyed by dictionary IDs. Note: a separate raw-value bitmap inverted index
+    // currently exists for SV no-dictionary columns (RawValueBitmapInvertedIndexCreator); under the upcoming
+    // shared-dictionary contract (apache/pinot#17269) that path is removed and any enabled inverted index requires
+    // a dictionary, so we declare the dependency unconditionally here.
+    return true;
+  }
+
+  @Override
+  public boolean shouldInvalidateOnDictionaryChange(FieldSpec fieldSpec, IndexConfig indexConfig) {
+    // Inverted index references dictionary IDs; enabling/disabling the dictionary changes whether the index can
+    // exist at all and (for shared-dict columns) the format on disk.
+    return true;
+  }
+
   public static class ReaderFactory implements IndexReaderFactory<InvertedIndexReader> {
     public static final ReaderFactory INSTANCE = new ReaderFactory();
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/json/JsonIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/json/JsonIndexType.java
@@ -141,6 +141,18 @@ public class JsonIndexType extends AbstractIndexType<JsonIndexConfig, JsonIndexR
     return new JsonIndexHandler(segmentDirectory, configsByCol, tableConfig, schema);
   }
 
+  @Override
+  public boolean requiresDictionary(FieldSpec fieldSpec, JsonIndexConfig indexConfig) {
+    // JSON index is built directly from the raw JSON column values; it does not depend on a dictionary.
+    return false;
+  }
+
+  @Override
+  public boolean shouldInvalidateOnDictionaryChange(FieldSpec fieldSpec, JsonIndexConfig indexConfig) {
+    // JSON index payload is derived from raw JSON values, independent of dictionary representation.
+    return false;
+  }
+
   private static class ReaderFactory extends IndexReaderFactory.Default<JsonIndexConfig, JsonIndexReader> {
     public static final ReaderFactory INSTANCE = new ReaderFactory();
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/nullvalue/NullValueIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/nullvalue/NullValueIndexType.java
@@ -118,6 +118,18 @@ public class NullValueIndexType extends AbstractIndexType<IndexConfig, NullValue
   }
 
   @Override
+  public boolean requiresDictionary(FieldSpec fieldSpec, IndexConfig indexConfig) {
+    // The null value vector is a bitmap of doc IDs whose value is null; no dictionary involvement.
+    return false;
+  }
+
+  @Override
+  public boolean shouldInvalidateOnDictionaryChange(FieldSpec fieldSpec, IndexConfig indexConfig) {
+    // The null value vector is keyed by doc ID and independent of the column's value representation.
+    return false;
+  }
+
+  @Override
   public List<String> getFileExtensions(@Nullable ColumnMetadata columnMetadata) {
     return EXTENSIONS;
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/range/RangeIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/range/RangeIndexType.java
@@ -160,6 +160,19 @@ public class RangeIndexType
     return new RangeIndexHandler(segmentDirectory, configsByCol, tableConfig, schema);
   }
 
+  @Override
+  public boolean requiresDictionary(FieldSpec fieldSpec, RangeIndexConfig indexConfig) {
+    // Range index supports both dict-encoded (range over dict IDs) and raw (range over values) columns.
+    return false;
+  }
+
+  @Override
+  public boolean shouldInvalidateOnDictionaryChange(FieldSpec fieldSpec, RangeIndexConfig indexConfig) {
+    // The on-disk format differs: dict-encoded ranges use dict IDs while raw ranges use raw values. Transitioning
+    // between the two states requires rebuilding the index against the new domain.
+    return true;
+  }
+
   private static class ReaderFactory extends IndexReaderFactory.Default<RangeIndexConfig, RangeIndexReader> {
 
     public static final ReaderFactory INSTANCE = new ReaderFactory();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/text/TextIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/text/TextIndexType.java
@@ -120,6 +120,18 @@ public class TextIndexType extends AbstractIndexType<TextIndexConfig, TextIndexR
   }
 
   @Override
+  public boolean requiresDictionary(FieldSpec fieldSpec, TextIndexConfig indexConfig) {
+    // Lucene text index is built directly from raw text values.
+    return false;
+  }
+
+  @Override
+  public boolean shouldInvalidateOnDictionaryChange(FieldSpec fieldSpec, TextIndexConfig indexConfig) {
+    // Lucene text index payload is derived from raw text values, independent of dictionary representation.
+    return false;
+  }
+
+  @Override
   public List<String> getFileExtensions(@Nullable ColumnMetadata columnMetadata) {
     return EXTENSIONS;
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/vector/VectorIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/vector/VectorIndexType.java
@@ -161,6 +161,18 @@ public class VectorIndexType extends AbstractIndexType<VectorIndexConfig, Vector
   }
 
   @Override
+  public boolean requiresDictionary(FieldSpec fieldSpec, VectorIndexConfig indexConfig) {
+    // Vector index is built directly from vector values; it does not depend on a dictionary.
+    return false;
+  }
+
+  @Override
+  public boolean shouldInvalidateOnDictionaryChange(FieldSpec fieldSpec, VectorIndexConfig indexConfig) {
+    // Vector index payload is derived from raw vector values, independent of dictionary representation.
+    return false;
+  }
+
+  @Override
   public List<String> getFileExtensions(@Nullable ColumnMetadata columnMetadata) {
     // NOTE: IVF_ON_DISK intentionally reuses the IVF_FLAT file extension since it reads the
     // same on-disk format via FileChannel rather than memory-mapped I/O.

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/range/RangeIndexTypeTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/range/RangeIndexTypeTest.java
@@ -1,0 +1,94 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.range;
+
+import java.util.Set;
+import org.apache.pinot.segment.spi.index.DictionaryIndexConfig;
+import org.apache.pinot.segment.spi.index.FieldIndexConfigs;
+import org.apache.pinot.segment.spi.index.IndexType;
+import org.apache.pinot.segment.spi.index.RangeIndexConfig;
+import org.apache.pinot.segment.spi.index.StandardIndexes;
+import org.apache.pinot.spi.data.DimensionFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+
+public class RangeIndexTypeTest {
+
+  /// Range index encodes values differently depending on whether the column is dictionary-encoded (range over
+  /// dictionary IDs) or raw (range over the raw values), so the existing on-disk range index becomes invalid the
+  /// moment the dictionary is added or removed for the column. The
+  /// [IndexType#shouldInvalidateOnDictionaryChange] contract must surface this so the segment-reload path knows to
+  /// drop and rebuild the range index.
+  @Test
+  public void rangeIndexMustBeInvalidatedWhenDictionaryStateChanges() {
+    FieldSpec fieldSpec = new DimensionFieldSpec("col", FieldSpec.DataType.INT, true);
+    assertTrue(StandardIndexes.range().shouldInvalidateOnDictionaryChange(fieldSpec, RangeIndexConfig.DEFAULT),
+        "Range index on-disk format depends on dictionary presence and must be rebuilt on dictionary change");
+  }
+
+  @Test
+  public void disabledRangeIndexIsNotInvalidatedByHelper() {
+    FieldSpec fieldSpec = new DimensionFieldSpec("col", FieldSpec.DataType.INT, true);
+    FieldIndexConfigs configs = new FieldIndexConfigs.Builder()
+        .add(StandardIndexes.range(), RangeIndexConfig.DISABLED)
+        .build();
+    Set<IndexType<?, ?, ?>> toRebuild =
+        DictionaryIndexConfig.getIndexTypesToInvalidateOnDictionaryChange(fieldSpec, configs);
+    assertFalse(toRebuild.contains(StandardIndexes.range()),
+        "A disabled range index must not appear in the rebuild list");
+  }
+
+  /**
+   * End-to-end shape of the user-visible scenario:
+   *
+   * <ol>
+   *   <li>A column starts with a raw forward index and a raw range index (no dictionary).</li>
+   *   <li>The user enables a dictionary on that column.</li>
+   *   <li>On segment reload, the dictionary handler builds the new dictionary, and the loader consults
+   *       {@link DictionaryIndexConfig#getIndexTypesToInvalidateOnDictionaryChange} to find every index whose
+   *       on-disk payload has been invalidated by the dictionary state change. The range index must be in that
+   *       set so it is dropped and rebuilt against the new dictionary IDs.</li>
+   * </ol>
+   *
+   * This test asserts step (3): the rebuild list, computed from the post-change config (range still enabled,
+   * dictionary now enabled), includes the range index.
+   */
+  @Test
+  public void rangeIndexIsScheduledForRebuildAfterDictionaryEnable() {
+    FieldSpec fieldSpec = new DimensionFieldSpec("col", FieldSpec.DataType.INT, true);
+
+    // Post-change config: range index enabled, dictionary now enabled too. The forward-index encoding is
+    // intentionally not part of this contract — encoding reconciliation is owned by ForwardIndexConfig and
+    // FieldIndexConfigsUtil; the rebuild-on-dictionary-change signal is what this test exercises.
+    FieldIndexConfigs configs = new FieldIndexConfigs.Builder()
+        .add(StandardIndexes.range(), RangeIndexConfig.DEFAULT)
+        .add(StandardIndexes.dictionary(), new DictionaryIndexConfig(false, false))
+        .build();
+
+    Set<IndexType<?, ?, ?>> toRebuild =
+        DictionaryIndexConfig.getIndexTypesToInvalidateOnDictionaryChange(fieldSpec, configs);
+
+    assertTrue(toRebuild.contains(StandardIndexes.range()),
+        "Range index must be marked for rebuild after a dictionary is added to the column");
+  }
+}

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/DictionaryIndexConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/DictionaryIndexConfig.java
@@ -22,10 +22,15 @@ package org.apache.pinot.segment.spi.index;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Objects;
+import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.pinot.spi.config.table.IndexConfig;
 import org.apache.pinot.spi.config.table.Intern;
+import org.apache.pinot.spi.data.FieldSpec;
 
 
 public class DictionaryIndexConfig extends IndexConfig {
@@ -112,5 +117,98 @@ public class DictionaryIndexConfig extends IndexConfig {
     } else {
       return "DictionaryIndexConfig{" + "\"disabled\": true}";
     }
+  }
+
+  /// Returns `true` if a dictionary must be created for the given column based on the configured indexes.
+  /// Iterates over the index types registered in the global [IndexService] singleton; tests that need to exercise a
+  /// custom set of index types should call [#requiresDictionary(FieldSpec, FieldIndexConfigs, Iterable)] directly.
+  ///
+  /// Used at segment creation and segment reload time to decide whether a shared standalone dictionary must be
+  /// materialized for a column whose forward index is RAW-encoded but which carries an enabled secondary index that
+  /// needs dictionary IDs (for example `inverted`, `fst`, `ifst`).
+  public static boolean requiresDictionary(FieldSpec fieldSpec, FieldIndexConfigs fieldIndexConfigs) {
+    return requiresDictionary(fieldSpec, fieldIndexConfigs, IndexService.getInstance().getAllIndexes());
+  }
+
+  /// Test/plugin-friendly variant: returns `true` if any of the supplied `indexTypes` requires a dictionary for the
+  /// column. Decoupled from [IndexService#getInstance()] so callers can pass a controlled set of index types.
+  public static boolean requiresDictionary(FieldSpec fieldSpec, FieldIndexConfigs fieldIndexConfigs,
+      Iterable<IndexType<?, ?, ?>> indexTypes) {
+    for (IndexType<?, ?, ?> indexType : indexTypes) {
+      if (StandardIndexes.DICTIONARY_ID.equals(indexType.getId())) {
+        continue;
+      }
+      if (requiresDictionaryBy(indexType, fieldSpec, fieldIndexConfigs)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static <C extends IndexConfig> boolean requiresDictionaryBy(IndexType<C, ?, ?> indexType,
+      FieldSpec fieldSpec, FieldIndexConfigs fieldIndexConfigs) {
+    C config = fieldIndexConfigs.getConfig(indexType);
+    if (config == null || config.isDisabled()) {
+      return false;
+    }
+    return indexType.requiresDictionary(fieldSpec, config);
+  }
+
+  /// Returns the list of index types that require a dictionary for the given column based on the configured
+  /// indexes. See [#requiresDictionary(FieldSpec, FieldIndexConfigs)] for the singleton-vs-injected discussion.
+  public static List<IndexType<?, ?, ?>> getIndexTypesWithDictionaryRequired(FieldSpec fieldSpec,
+      FieldIndexConfigs fieldIndexConfigs) {
+    return getIndexTypesWithDictionaryRequired(fieldSpec, fieldIndexConfigs,
+        IndexService.getInstance().getAllIndexes());
+  }
+
+  /// Test/plugin-friendly variant: returns the list of index types from the supplied iterable that require a
+  /// dictionary for the column.
+  public static List<IndexType<?, ?, ?>> getIndexTypesWithDictionaryRequired(FieldSpec fieldSpec,
+      FieldIndexConfigs fieldIndexConfigs, Iterable<IndexType<?, ?, ?>> indexTypes) {
+    List<IndexType<?, ?, ?>> result = new ArrayList<>();
+    for (IndexType<?, ?, ?> indexType : indexTypes) {
+      if (StandardIndexes.DICTIONARY_ID.equals(indexType.getId())) {
+        continue;
+      }
+      if (requiresDictionaryBy(indexType, fieldSpec, fieldIndexConfigs)) {
+        result.add(indexType);
+      }
+    }
+    return result;
+  }
+
+  /// Returns the set of index types whose existing on-disk index must be invalidated (deleted and rebuilt) when the
+  /// dictionary for the column is added or removed across a segment reload. Each candidate index type is queried
+  /// via [IndexType#shouldInvalidateOnDictionaryChange(FieldSpec, IndexConfig)].
+  ///
+  /// The returned set is the per-column work-list for the dictionary-change rebuild pass: each contained index
+  /// type's existing payload is no longer trustworthy under the new dictionary state and must be regenerated.
+  public static Set<IndexType<?, ?, ?>> getIndexTypesToInvalidateOnDictionaryChange(FieldSpec fieldSpec,
+      FieldIndexConfigs fieldIndexConfigs) {
+    return getIndexTypesToInvalidateOnDictionaryChange(fieldSpec, fieldIndexConfigs,
+        IndexService.getInstance().getAllIndexes());
+  }
+
+  /// Test/plugin-friendly variant of
+  /// [#getIndexTypesToInvalidateOnDictionaryChange(FieldSpec, FieldIndexConfigs)].
+  public static Set<IndexType<?, ?, ?>> getIndexTypesToInvalidateOnDictionaryChange(FieldSpec fieldSpec,
+      FieldIndexConfigs fieldIndexConfigs, Iterable<IndexType<?, ?, ?>> indexTypes) {
+    Set<IndexType<?, ?, ?>> result = new HashSet<>();
+    for (IndexType<?, ?, ?> indexType : indexTypes) {
+      if (shouldInvalidateOnDictionaryChange(indexType, fieldSpec, fieldIndexConfigs)) {
+        result.add(indexType);
+      }
+    }
+    return result;
+  }
+
+  private static <C extends IndexConfig> boolean shouldInvalidateOnDictionaryChange(IndexType<C, ?, ?> indexType,
+      FieldSpec fieldSpec, FieldIndexConfigs fieldIndexConfigs) {
+    C config = fieldIndexConfigs.getConfig(indexType);
+    if (config == null || config.isDisabled()) {
+      return false;
+    }
+    return indexType.shouldInvalidateOnDictionaryChange(fieldSpec, config);
   }
 }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/IndexType.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/IndexType.java
@@ -33,11 +33,19 @@ import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 
 
-/**
- * @param <C> the class that represents how this object is configured.
- * @param <IR> the {@link IndexReader} subclass that should be used to read indexes of this type.
- * @param <IC> the {@link IndexCreator} subclass that should be used to create indexes of this type.
- */
+/// @param <C> the class that represents how this object is configured.
+/// @param <IR> the [IndexReader] subclass that should be used to read indexes of this type.
+/// @param <IC> the [IndexCreator] subclass that should be used to create indexes of this type.
+///
+/// ## Backward compatibility
+///
+/// [#requiresDictionary(FieldSpec, IndexConfig)] and
+/// [#shouldInvalidateOnDictionaryChange(FieldSpec, IndexConfig)] are declared *abstract* rather than `default` on
+/// purpose: every `IndexType` implementation must explicitly declare its dictionary contract. **This is a
+/// binary-incompatible change.** External plugins compiled against an older version of this SPI will fail to load
+/// (or fail to compile) until they implement both methods. Plugin authors upgrading across this change should
+/// consult the Javadoc on each method and pick a value consistent with whether their on-disk index references
+/// dictionary IDs.
 public interface IndexType<C extends IndexConfig, IR extends IndexReader, IC extends IndexCreator> {
   /**
    * Returns the {@link BuildLifecycle} for this index type. This is used to determine when the index should be built.
@@ -118,6 +126,66 @@ public interface IndexType<C extends IndexConfig, IR extends IndexReader, IC ext
   // TODO: Consider passing in IndexLoadingConfig
   IndexHandler createIndexHandler(SegmentDirectory segmentDirectory, Map<String, FieldIndexConfigs> configsByCol,
       Schema schema, TableConfig tableConfig);
+
+  /// Declares whether the on-disk representation of this index *references dictionary IDs* for the given column,
+  /// meaning the index cannot be built or read without a dictionary being present.
+  ///
+  /// This is consulted at segment-creation and segment-reload time to decide whether a shared dictionary must be
+  /// materialized for a column whose forward index is RAW-encoded but which carries an enabled secondary index that
+  /// needs dictionary IDs (for example `inverted`, `fst`, `ifst`). When any enabled index on the column returns
+  /// `true`, the loader auto-creates a shared standalone dictionary for the column even if the user did not
+  /// explicitly request one.
+  ///
+  /// Implementation guidance:
+  ///
+  ///   - Return `true` only when the on-disk representation of this index references dictionary IDs (e.g. inverted
+  ///     posting lists keyed by dict ID, FST/IFST built over the sorted dictionary).
+  ///   - Return `false` when the index is computed directly from raw column values (e.g. bloom over hashed values,
+  ///     json/text over the raw payload, vector/h3 over the geometry).
+  ///   - This must be a pure function of `fieldSpec` and `indexConfig`; it is called during config validation and
+  ///     segment creation, not against a live segment. Implementations should NOT short-circuit on
+  ///     `indexConfig.isDisabled()` — the caller filters out disabled configs.
+  ///
+  /// This method is intentionally abstract so that every [IndexType] implementation must explicitly declare its
+  /// dictionary dependency. New index types must opt in by considering the contract above.
+  ///
+  /// @param fieldSpec the column's field spec
+  /// @param indexConfig the per-column config for this specific index type
+  boolean requiresDictionary(FieldSpec fieldSpec, C indexConfig);
+
+  /// Declares whether the on-disk representation of this index depends on whether a dictionary exists for the
+  /// column. If `true`, an existing on-disk index of this type must be deleted and rebuilt when the dictionary for
+  /// the column is added or removed across a segment reload.
+  ///
+  /// Used by segment reload (e.g. `SegmentPreProcessor` / per-index handlers) to decide whether a stale index file
+  /// can be reused or must be dropped and rebuilt after a dictionary enable/disable transition. This covers exactly
+  /// the presence/absence change of the dictionary:
+  ///
+  ///   - dictionary previously absent → now enabled (column gained a dictionary), or
+  ///   - dictionary previously present → now disabled (column lost its dictionary).
+  ///
+  /// It does *not* cover changes to dictionary *configuration* while the dictionary remains enabled (heap mode,
+  /// capacity, etc.) — those are handled by the per-index [IndexHandler#needUpdateIndices] hook.
+  ///
+  /// Implementation guidance:
+  ///
+  ///   - Return `true` when the index's on-disk format differs depending on dictionary presence — i.e.
+  ///     enabling/disabling the dictionary would silently leave a wrong-result index on disk if not rebuilt
+  ///     (inverted, fst/ifst, range).
+  ///   - Return `false` when the index is computed from raw column values and is therefore identical regardless of
+  ///     dictionary presence (bloom, json, text, vector, h3, null-value, forward index — encoding is reconciled
+  ///     with FieldConfig.encodingType independently of dictionary state).
+  ///   - The dictionary index type itself returns `false` — the dictionary *is* what is changing; its own rebuild
+  ///     is driven by the dictionary handler, not by this hook.
+  ///   - This must be a pure function of `fieldSpec` and `indexConfig`. Implementations should NOT short-circuit
+  ///     on `indexConfig.isDisabled()` — the caller filters out disabled configs.
+  ///
+  /// This method is intentionally abstract so that every [IndexType] implementation must explicitly declare its
+  /// rebuild requirement. New index types must opt in by considering the contract above.
+  ///
+  /// @param fieldSpec the column's field spec
+  /// @param indexConfig the per-column config for this specific index type
+  boolean shouldInvalidateOnDictionaryChange(FieldSpec fieldSpec, C indexConfig);
 
   /**
    * This method is used to perform in place conversion of provided {@link TableConfig} to newer format

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/DictionaryIndexConfigTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/DictionaryIndexConfigTest.java
@@ -19,13 +19,39 @@
 package org.apache.pinot.segment.spi.index;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.apache.pinot.segment.spi.ColumnMetadata;
+import org.apache.pinot.segment.spi.creator.IndexCreationContext;
+import org.apache.pinot.segment.spi.store.SegmentDirectory;
+import org.apache.pinot.spi.config.table.IndexConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.utils.JsonUtils;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.*;
 
 
 public class DictionaryIndexConfigTest {
+
+  private IndexService _originalIndexService;
+
+  @BeforeMethod
+  public void setUp() {
+    _originalIndexService = IndexService.getInstance();
+  }
+
+  @AfterMethod
+  public void tearDown() {
+    IndexService.setInstance(_originalIndexService);
+  }
 
   @Test
   public void withEmptyConf()
@@ -83,5 +109,210 @@ public class DictionaryIndexConfigTest {
     assertFalse(config.isDisabled(), "Unexpected disabled");
     assertTrue(config.isOnHeap(), "Unexpected onHeap");
     assertTrue(config.isUseVarLengthDictionary(), "Unexpected useVarLengthDictionary");
+  }
+
+  @Test
+  public void isDictionaryRequiredReturnsTrueWhenAnyEnabledIndexNeedsDictionary() {
+    StubIndexType<?> dictDependent = StubIndexType.dictionaryDependent("needs-dict");
+    StubIndexType<?> independent = StubIndexType.independent("no-dict");
+    installIndexService(dictDependent, independent);
+
+    FieldSpec fieldSpec = new DimensionFieldSpec("col", FieldSpec.DataType.STRING, true);
+    FieldIndexConfigs configs = new FieldIndexConfigs.Builder()
+        .addUnsafe(dictDependent, IndexConfig.ENABLED)
+        .addUnsafe(independent, IndexConfig.ENABLED)
+        .build();
+
+    assertTrue(DictionaryIndexConfig.requiresDictionary(fieldSpec, configs));
+  }
+
+  @Test
+  public void isDictionaryRequiredReturnsFalseWhenDictionaryDependentIndexIsDisabled() {
+    StubIndexType<?> dictDependent = StubIndexType.dictionaryDependent("needs-dict");
+    StubIndexType<?> independent = StubIndexType.independent("no-dict");
+    installIndexService(dictDependent, independent);
+
+    FieldSpec fieldSpec = new DimensionFieldSpec("col", FieldSpec.DataType.STRING, true);
+    // dictDependent left at default (disabled), independent enabled
+    FieldIndexConfigs configs = new FieldIndexConfigs.Builder()
+        .addUnsafe(independent, IndexConfig.ENABLED)
+        .build();
+
+    assertFalse(DictionaryIndexConfig.requiresDictionary(fieldSpec, configs));
+  }
+
+  @Test
+  public void isDictionaryRequiredReturnsFalseWhenAllIndexesAreIndependent() {
+    StubIndexType<?> a = StubIndexType.independent("a");
+    StubIndexType<?> b = StubIndexType.independent("b");
+    installIndexService(a, b);
+
+    FieldSpec fieldSpec = new DimensionFieldSpec("col", FieldSpec.DataType.STRING, true);
+    FieldIndexConfigs configs = new FieldIndexConfigs.Builder()
+        .addUnsafe(a, IndexConfig.ENABLED)
+        .addUnsafe(b, IndexConfig.ENABLED)
+        .build();
+
+    assertFalse(DictionaryIndexConfig.requiresDictionary(fieldSpec, configs));
+  }
+
+  @Test
+  public void getIndexTypesToInvalidateReturnsOnlyIndexesThatDeclareInvalidation() {
+    StubIndexType<?> rebuilds = StubIndexType.rebuildOnDictionaryChange("rebuilds");
+    StubIndexType<?> independent = StubIndexType.independent("independent");
+    StubIndexType<?> rebuildsButDisabled = StubIndexType.rebuildOnDictionaryChange("rebuilds-disabled");
+    installIndexService(rebuilds, independent, rebuildsButDisabled);
+
+    FieldSpec fieldSpec = new DimensionFieldSpec("col", FieldSpec.DataType.STRING, true);
+    FieldIndexConfigs configs = new FieldIndexConfigs.Builder()
+        .addUnsafe(rebuilds, IndexConfig.ENABLED)
+        .addUnsafe(independent, IndexConfig.ENABLED)
+        // rebuildsButDisabled left at default (disabled)
+        .build();
+
+    Set<IndexType<?, ?, ?>> result =
+        DictionaryIndexConfig.getIndexTypesToInvalidateOnDictionaryChange(fieldSpec, configs);
+
+    assertEquals(result, Set.of(rebuilds));
+  }
+
+  @Test
+  public void getIndexTypesToInvalidateReturnsEmptyWhenNothingDeclaresInvalidation() {
+    StubIndexType<?> a = StubIndexType.independent("a");
+    StubIndexType<?> b = StubIndexType.independent("b");
+    installIndexService(a, b);
+
+    FieldSpec fieldSpec = new DimensionFieldSpec("col", FieldSpec.DataType.STRING, true);
+    FieldIndexConfigs configs = new FieldIndexConfigs.Builder()
+        .addUnsafe(a, IndexConfig.ENABLED)
+        .addUnsafe(b, IndexConfig.ENABLED)
+        .build();
+
+    assertTrue(DictionaryIndexConfig.getIndexTypesToInvalidateOnDictionaryChange(fieldSpec, configs).isEmpty());
+  }
+
+  private static void installIndexService(StubIndexType<?>... types) {
+    Set<IndexPlugin<?>> plugins = new HashSet<>();
+    int priority = 0;
+    for (StubIndexType<?> type : types) {
+      plugins.add(new StubIndexPlugin<>(type, priority++));
+    }
+    IndexService.setInstance(new IndexService(plugins));
+  }
+
+  private static final class DimensionFieldSpec extends FieldSpec {
+    DimensionFieldSpec(String name, DataType dataType, boolean singleValue) {
+      super(name, dataType, singleValue);
+    }
+
+    @Override
+    public FieldType getFieldType() {
+      return FieldType.DIMENSION;
+    }
+  }
+
+  private static final class StubIndexPlugin<T extends StubIndexType<?>> implements IndexPlugin<T> {
+    private final T _type;
+    private final int _priority;
+
+    StubIndexPlugin(T type, int priority) {
+      _type = type;
+      _priority = priority;
+    }
+
+    @Override
+    public T getIndexType() {
+      return _type;
+    }
+
+    @Override
+    public int getPriority() {
+      return _priority;
+    }
+  }
+
+  /**
+   * Minimal {@link IndexType} stub used to drive the {@link DictionaryIndexConfig} static helpers under a controlled
+   * {@link IndexService}. All segment-creation/read entry points throw — the helpers only consult the two new
+   * dictionary-related methods plus {@link #getId()}.
+   */
+  private static final class StubIndexType<C extends IndexConfig> implements IndexType<IndexConfig, IndexReader,
+      IndexCreator> {
+    private final String _id;
+    private final boolean _requiresDictionary;
+    private final boolean _invalidateOnDictionaryChange;
+
+    static StubIndexType<?> dictionaryDependent(String id) {
+      return new StubIndexType<>(id, true, true);
+    }
+
+    static StubIndexType<?> independent(String id) {
+      return new StubIndexType<>(id, false, false);
+    }
+
+    static StubIndexType<?> rebuildOnDictionaryChange(String id) {
+      return new StubIndexType<>(id, false, true);
+    }
+
+    private StubIndexType(String id, boolean requiresDictionary, boolean invalidateOnDictionaryChange) {
+      _id = id;
+      _requiresDictionary = requiresDictionary;
+      _invalidateOnDictionaryChange = invalidateOnDictionaryChange;
+    }
+
+    @Override
+    public String getId() {
+      return _id;
+    }
+
+    @Override
+    public Class<IndexConfig> getIndexConfigClass() {
+      return IndexConfig.class;
+    }
+
+    @Override
+    public IndexConfig getDefaultConfig() {
+      return IndexConfig.DISABLED;
+    }
+
+    @Override
+    public Map<String, IndexConfig> getConfig(TableConfig tableConfig, Schema schema) {
+      return Map.of();
+    }
+
+    @Override
+    public IndexCreator createIndexCreator(IndexCreationContext context, IndexConfig indexConfig) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public IndexReaderFactory<IndexReader> getReaderFactory() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<String> getFileExtensions(@Nullable ColumnMetadata columnMetadata) {
+      return List.of();
+    }
+
+    @Override
+    public IndexHandler createIndexHandler(SegmentDirectory segmentDirectory,
+        Map<String, FieldIndexConfigs> configsByCol, Schema schema, TableConfig tableConfig) {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean requiresDictionary(FieldSpec fieldSpec, IndexConfig indexConfig) {
+      return _requiresDictionary;
+    }
+
+    @Override
+    public boolean shouldInvalidateOnDictionaryChange(FieldSpec fieldSpec, IndexConfig indexConfig) {
+      return _invalidateOnDictionaryChange;
+    }
+
+    @Override
+    public void convertToNewFormat(TableConfig tableConfig, Schema schema) {
+    }
   }
 }

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/IndexServiceTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/IndexServiceTest.java
@@ -28,6 +28,7 @@ import org.apache.pinot.segment.spi.creator.IndexCreationContext;
 import org.apache.pinot.segment.spi.store.SegmentDirectory;
 import org.apache.pinot.spi.config.table.IndexConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.testng.annotations.Test;
 
@@ -124,6 +125,16 @@ public class IndexServiceTest {
     public IndexHandler createIndexHandler(SegmentDirectory segmentDirectory,
         Map<String, FieldIndexConfigs> configsByCol, Schema schema, TableConfig tableConfig) {
       throw new UnsupportedOperationException(IndexType.class.getName() + " should not be created");
+    }
+
+    @Override
+    public boolean requiresDictionary(FieldSpec fieldSpec, IndexConfig indexConfig) {
+      return false;
+    }
+
+    @Override
+    public boolean shouldInvalidateOnDictionaryChange(FieldSpec fieldSpec, IndexConfig indexConfig) {
+      return false;
     }
 
     @Override


### PR DESCRIPTION
## Summary

Adds two abstract methods to the `IndexType<C, IR, IC>` SPI so every index type must explicitly declare its per-column dictionary contract:

- **`requiresDictionary(FieldSpec, C)`** — does this index's on-disk representation reference dictionary IDs (i.e. cannot be built or read without a dictionary on the column)?
- **`invalidateAfterDictionaryChange(FieldSpec, C)`** — must the existing on-disk index be deleted and rebuilt when the dictionary for the column transitions between *enabled* and *disabled* across a segment reload?

This is groundwork for the shared-dictionary feature (apache/pinot#17269): when a column has an enabled secondary index that needs dictionary IDs (`inverted`, `fst`, `ifst`) but the user configured a RAW forward index, the loader can use these hooks to (a) auto-materialize a shared standalone dictionary, and (b) invalidate stale per-index files on dictionary state changes.

This PR is scoped to the SPI surface plus the `DictionaryIndexConfig` consumer helpers; the encoding signal (`ForwardIndexConfig.Encoding`, `ColumnMetadata.getForwardIndexEncoding`, etc.) lands separately in apache/pinot#18364, and `BaseSegmentCreator` / `SegmentPreProcessor` wiring is in #17269.

## Why abstract instead of `default`

Both methods are abstract on purpose — every implementation must explicitly think about and declare its dictionary contract. **This is a binary-incompatible change** for any third-party `IndexType` plugin compiled against an older SPI; this is documented in the `IndexType` Javadoc and called out here for plugin maintainers.

## Per-implementation values

| Index | `requiresDictionary` | `invalidateAfterDictionaryChange` | Reason |
|---|---|---|---|
| Inverted, FST, IFST | `true` | `true` | Reference dictionary IDs / built from sorted dictionary entries. |
| Range | `false` | `true` | Works on dict IDs or raw values; on-disk format differs. |
| Forward | `false` | `false` | Forward-index encoding is reconciled with `FieldConfig.encodingType` independently of dictionary state (apache/pinot#18364), so adding/removing a dictionary alone does not change the forward-index payload. |
| Bloom, JSON, Text, Vector, H3, NullValue | `false` | `false` | Built from raw column values, dictionary-independent. |
| Dictionary | `false` | `false` | Self-managed by the dictionary handler. |

> Note for `InvertedIndexType.requiresDictionary`: returned unconditionally `true`. Pinot currently has a raw-value bitmap inverted index that does not need a dictionary. Under the post-#17269 contract that path is removed and any enabled inverted index requires a dictionary, so the SPI declares the dependency unconditionally now. This is documented in the override comment.

## Wiring

Two static helper families on `DictionaryIndexConfig` are the primary consumers and iterate `IndexService.getInstance().getAllIndexes()`:

- `isDictionaryRequired(FieldSpec, FieldIndexConfigs)` plus an `Iterable<IndexType>` test/plugin overload.
- `getIndexTypesWithDictionaryRequired(FieldSpec, FieldIndexConfigs)` plus an `Iterable<IndexType>` overload — returns the list of index types whose `requiresDictionary` is true; primary consumer at segment-creation / reload.
- `getIndexTypesToInvalidateOnDictionaryChange(FieldSpec, FieldIndexConfigs)` plus an `Iterable<IndexType>` overload — returns the set of index types whose existing on-disk payload must be dropped and rebuilt across a dictionary enable/disable.

Both helpers centrally filter out disabled configs (`config.isDisabled()`) and skip the `dictionary` index type by id; implementations should not short-circuit on disabled themselves.

`BaseSegmentCreator` and `SegmentPreProcessor` wiring (the actual auto-materialization and invalidation behavior) is in #17269.

## Test plan

- [x] `DictionaryIndexConfigTest` — 5 new tests using a controlled `IndexService` with stub `IndexType`s exercise both helpers (true/false/empty/disabled cases).
- [x] `IndexServiceTest.TestIndexType` updated to implement the new abstract methods.
- [x] Full `pinot-segment-spi` test suite green.
- [x] `mvn test-compile` green across the entire pinot tree.
- [x] Pre-commit (spotless / checkstyle / license) clean on `pinot-segment-spi` and `pinot-segment-local`.

## Backward compatibility

External `IndexType` plugins compiled against the previous SPI will fail to load (`AbstractMethodError`) until they implement both methods. Plugin maintainers should consult the Javadoc on each method and pick values consistent with whether their on-disk index references dictionary IDs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)