### PR TITLE
Relax Segment Operation Throttler Permit limitation to zero

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SegmentOperationsThrottler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SegmentOperationsThrottler.java
@@ -31,7 +31,10 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Base class for segment operation throttlers, contains the common logic for the semaphore and handling the pre and
- * post query serving values. The semaphore cannot be null and must contain > 0 total permits
+ * post query serving values. The semaphore cannot be null and must contain >= 0 total permits. A value of 0 acts as
+ * a kill switch that blocks all {@link #acquire()} callers until permits are restored via
+ * {@link #updatePermits(int, int)} or {@link #startServingQueries()}; negative values are rejected as
+ * misconfiguration.
  */
 public class SegmentOperationsThrottler {
 
@@ -39,8 +42,9 @@ public class SegmentOperationsThrottler {
   protected ServerMetrics _serverMetrics;
   protected AdjustableSemaphore _semaphore;
   /**
-   * _maxConcurrency and _maxConcurrencyBeforeServingQueries must be > 0. To effectively disable throttling, this can
-   * be set to a very high value
+   * _maxConcurrency and _maxConcurrencyBeforeServingQueries must be >= 0. To effectively disable throttling, set
+   * to a very high value. To halt all operations (kill switch), set to 0; blocked acquirers park until permits are
+   * restored.
    */
   protected int _maxConcurrency;
   protected int _maxConcurrencyBeforeServingQueries;
@@ -95,9 +99,10 @@ public class SegmentOperationsThrottler {
             + "maxConcurrencyBeforeServingQueries: {}, isServingQueries: {}",
         throttlerName, maxConcurrency, maxConcurrencyBeforeServingQueries,
         isServingQueries);
-    Preconditions.checkArgument(maxConcurrency > 0, "Max parallelism must be > 0, but found to be: " + maxConcurrency);
-    Preconditions.checkArgument(maxConcurrencyBeforeServingQueries > 0,
-        "Max parallelism before serving queries must be > 0, but found to be: " + maxConcurrencyBeforeServingQueries);
+    Preconditions.checkArgument(maxConcurrency >= 0,
+        "Max parallelism must be >= 0, but found to be: " + maxConcurrency);
+    Preconditions.checkArgument(maxConcurrencyBeforeServingQueries >= 0,
+        "Max parallelism before serving queries must be >= 0, but found to be: " + maxConcurrencyBeforeServingQueries);
 
     _maxConcurrency = maxConcurrency;
     _maxConcurrencyBeforeServingQueries = maxConcurrencyBeforeServingQueries;
@@ -173,9 +178,9 @@ public class SegmentOperationsThrottler {
    * @param maxConcurrencyBeforeServingQueries new max concurrency before serving queries value
    */
   public synchronized void updatePermits(int maxConcurrency, int maxConcurrencyBeforeServingQueries) {
-    Preconditions.checkArgument(maxConcurrency > 0, "Max concurrency must be > 0, but found: " + maxConcurrency);
-    Preconditions.checkArgument(maxConcurrencyBeforeServingQueries > 0,
-        "Max concurrency before serving queries must be > 0, but found: " + maxConcurrencyBeforeServingQueries);
+    Preconditions.checkArgument(maxConcurrency >= 0, "Max concurrency must be >= 0, but found: " + maxConcurrency);
+    Preconditions.checkArgument(maxConcurrencyBeforeServingQueries >= 0,
+        "Max concurrency before serving queries must be >= 0, but found: " + maxConcurrencyBeforeServingQueries);
 
     LOGGER.info("Throttler {}: Updating permits - maxConcurrency: {} -> {}, "
         + "maxConcurrencyBeforeServingQueries: {} -> {}",

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SegmentOperationsThrottlerSet.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SegmentOperationsThrottlerSet.java
@@ -155,23 +155,28 @@ public class SegmentOperationsThrottlerSet implements PinotClusterConfigChangeLi
       return;
     }
 
-    // Parse maxConcurrency
+    // Parse maxConcurrency. 0 is a valid kill-switch value; negative values are treated as misconfiguration.
     int maxConcurrency = parseConfigValue(clusterConfigs, maxConcurrencyConfigKey, maxConcurrencyDefault);
-    if (maxConcurrency <= 0) {
+    if (maxConcurrency < 0) {
       return;
     }
 
-    // Parse maxConcurrencyBeforeServingQueries
+    // Parse maxConcurrencyBeforeServingQueries. Same handling as maxConcurrency.
     int maxConcurrencyBeforeServingQueries =
         parseConfigValue(clusterConfigs, maxConcurrencyBeforeServingQueriesConfigKey,
             maxConcurrencyBeforeServingQueriesDefault);
-    if (maxConcurrencyBeforeServingQueries <= 0) {
+    if (maxConcurrencyBeforeServingQueries < 0) {
       return;
     }
 
     // Update throttler
     LOGGER.info("Updating {} throttler with maxConcurrency: {}, maxConcurrencyBeforeServingQueries: {}",
         throttlerName, maxConcurrency, maxConcurrencyBeforeServingQueries);
+    if (maxConcurrency == 0 || maxConcurrencyBeforeServingQueries == 0) {
+      LOGGER.warn("Throttler {} configured with 0 permits (maxConcurrency: {}, maxConcurrencyBeforeServingQueries: "
+              + "{}) — all operations will block until value is raised",
+          throttlerName, maxConcurrency, maxConcurrencyBeforeServingQueries);
+    }
     throttler.updatePermits(maxConcurrency, maxConcurrencyBeforeServingQueries);
   }
 

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/SegmentOperationsThrottlerSetTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/SegmentOperationsThrottlerSetTest.java
@@ -20,7 +20,6 @@ package org.apache.pinot.segment.local.utils;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.pinot.common.metrics.ServerGauge;
@@ -224,19 +223,16 @@ public class SegmentOperationsThrottlerSetTest {
   }
 
   @Test(timeOut = 10_000)
-  public void testZeroPermitsBlocksAcquireUntilPermitsRestored()
+  public void testZeroPermitsUnblocksWhenPermitsRestored()
       throws Exception {
     SegmentOperationsThrottler t = new SegmentOperationsThrottler(0, 0, true);
     Assert.assertEquals(t.totalPermits(), 0);
     Assert.assertEquals(t.availablePermits(), 0);
 
-    // Spawn a thread that calls acquire() and parks because permits == 0.
-    CountDownLatch acquired = new CountDownLatch(1);
     AtomicReference<Throwable> failure = new AtomicReference<>();
     Thread acquirer = new Thread(() -> {
       try {
         t.acquire();
-        acquired.countDown();
       } catch (Throwable th) {
         failure.set(th);
       }
@@ -244,22 +240,10 @@ public class SegmentOperationsThrottlerSetTest {
     acquirer.setDaemon(true);
     acquirer.start();
 
-    // Wait until the acquirer is parked inside acquire(). availablePermits() goes to -1 once it
-    // has decremented but not yet been granted a permit (AdjustableSemaphore behavior), so poll
-    // for that condition.
-    long deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
-    while (acquirer.getState() != Thread.State.WAITING && System.nanoTime() < deadlineNanos) {
-      Thread.sleep(10);
-    }
-    Assert.assertEquals(acquirer.getState(), Thread.State.WAITING,
-        "acquirer thread should be parked when permits == 0");
-    Assert.assertFalse(acquired.await(100, TimeUnit.MILLISECONDS),
-        "acquire() must not return while permits == 0");
-
     // Restore permits — the parked acquirer should be released.
     t.updatePermits(1, 1);
-    Assert.assertTrue(acquired.await(5, TimeUnit.SECONDS),
-        "acquire() should complete once permits are restored");
+    acquirer.join(TimeUnit.SECONDS.toMillis(5));
+    Assert.assertFalse(acquirer.isAlive(), "acquire() should complete once permits are restored");
     Assert.assertNull(failure.get(), "acquirer thread should not throw");
 
     // The released acquirer holds the one permit, so available is now 0 with total 1.

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/SegmentOperationsThrottlerSetTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/SegmentOperationsThrottlerSetTest.java
@@ -20,6 +20,9 @@ package org.apache.pinot.segment.local.utils;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import org.apache.pinot.common.metrics.ServerGauge;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.spi.metrics.PinotMetricUtils;
@@ -195,15 +198,76 @@ public class SegmentOperationsThrottlerSetTest {
 
   @Test
   public void testThrowExceptionOnSettingInvalidConfigValues() {
-    // All invalid constructor args should throw IllegalArgumentException regardless of isServingQueries
+    // Negative constructor args should throw IllegalArgumentException regardless of isServingQueries.
     Assert.assertThrows(IllegalArgumentException.class, () -> new SegmentOperationsThrottler(-1, 4, true));
-    Assert.assertThrows(IllegalArgumentException.class, () -> new SegmentOperationsThrottler(0, 4, true));
     Assert.assertThrows(IllegalArgumentException.class, () -> new SegmentOperationsThrottler(1, -4, true));
-    Assert.assertThrows(IllegalArgumentException.class, () -> new SegmentOperationsThrottler(1, 0, true));
     Assert.assertThrows(IllegalArgumentException.class, () -> new SegmentOperationsThrottler(-1, 4, false));
-    Assert.assertThrows(IllegalArgumentException.class, () -> new SegmentOperationsThrottler(0, 4, false));
     Assert.assertThrows(IllegalArgumentException.class, () -> new SegmentOperationsThrottler(1, -4, false));
-    Assert.assertThrows(IllegalArgumentException.class, () -> new SegmentOperationsThrottler(1, 0, false));
+  }
+
+  @Test
+  public void testZeroPermitsKillSwitch()
+      throws Exception {
+    SegmentOperationsThrottler t = new SegmentOperationsThrottler(0, 0, true);
+    Assert.assertEquals(t.totalPermits(), 0);
+    Assert.assertEquals(t.availablePermits(), 0);
+
+    // Updating to a positive value lifts the kill switch.
+    t.updatePermits(2, 2);
+    Assert.assertEquals(t.totalPermits(), 2);
+    Assert.assertEquals(t.availablePermits(), 2);
+
+    // Setting back to 0 restores the kill switch without throwing.
+    t.updatePermits(0, 0);
+    Assert.assertEquals(t.totalPermits(), 0);
+    Assert.assertEquals(t.availablePermits(), 0);
+  }
+
+  @Test(timeOut = 10_000)
+  public void testZeroPermitsBlocksAcquireUntilPermitsRestored()
+      throws Exception {
+    SegmentOperationsThrottler t = new SegmentOperationsThrottler(0, 0, true);
+    Assert.assertEquals(t.totalPermits(), 0);
+    Assert.assertEquals(t.availablePermits(), 0);
+
+    // Spawn a thread that calls acquire() and parks because permits == 0.
+    CountDownLatch acquired = new CountDownLatch(1);
+    AtomicReference<Throwable> failure = new AtomicReference<>();
+    Thread acquirer = new Thread(() -> {
+      try {
+        t.acquire();
+        acquired.countDown();
+      } catch (Throwable th) {
+        failure.set(th);
+      }
+    }, "kill-switch-acquirer");
+    acquirer.setDaemon(true);
+    acquirer.start();
+
+    // Wait until the acquirer is parked inside acquire(). availablePermits() goes to -1 once it
+    // has decremented but not yet been granted a permit (AdjustableSemaphore behavior), so poll
+    // for that condition.
+    long deadlineNanos = System.nanoTime() + TimeUnit.SECONDS.toNanos(5);
+    while (acquirer.getState() != Thread.State.WAITING && System.nanoTime() < deadlineNanos) {
+      Thread.sleep(10);
+    }
+    Assert.assertEquals(acquirer.getState(), Thread.State.WAITING,
+        "acquirer thread should be parked when permits == 0");
+    Assert.assertFalse(acquired.await(100, TimeUnit.MILLISECONDS),
+        "acquire() must not return while permits == 0");
+
+    // Restore permits — the parked acquirer should be released.
+    t.updatePermits(1, 1);
+    Assert.assertTrue(acquired.await(5, TimeUnit.SECONDS),
+        "acquire() should complete once permits are restored");
+    Assert.assertNull(failure.get(), "acquirer thread should not throw");
+
+    // The released acquirer holds the one permit, so available is now 0 with total 1.
+    Assert.assertEquals(t.totalPermits(), 1);
+    Assert.assertEquals(t.availablePermits(), 0);
+
+    t.release();
+    Assert.assertEquals(t.availablePermits(), 1);
   }
 
   @Test
@@ -259,7 +323,7 @@ public class SegmentOperationsThrottlerSetTest {
       Assert.assertEquals(countGaugeValue, 0);
 
       // Change the value of cluster config for max segment operation parallelism to be a negative value.
-      // If config is <= 0, this is an invalid configuration change. The throttler should not be updated.
+      // Negative values are invalid and the throttler should not be updated. (0 is valid as a kill switch.)
       Map<String, String> updatedClusterConfigs = new HashMap<>();
       updatedClusterConfigs.put(PARALLELISM_KEYS[i], "-1");
       sot.onChange(updatedClusterConfigs.keySet(), updatedClusterConfigs);


### PR DESCRIPTION
## Description

Currently we disallow users to set throttler permit to zero (e.g. `pinot.server.max.segment.preprocess.parallelism=0`). Relaxing this limitation so that these throttlers can be used as kill switches functionally, to disable certain segment operations.