### PR TITLE
Default Stats Send Mode SAFE -> ALWAYS

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/SendStatsPredicate.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/SendStatsPredicate.java
@@ -80,7 +80,6 @@ public abstract class SendStatsPredicate implements InstanceConfigChangeListener
   public enum Mode {
     /// Sends stats only if all the cluster participants use the same known version.
     // ALWAYS is strictly better than SAFE if all servers are already on versions >= 1.4
-    @Deprecated
     SAFE {
       @Override
       public SendStatsPredicate create(HelixManager helixManager) {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/SendStatsPredicate.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/SendStatsPredicate.java
@@ -79,6 +79,8 @@ public abstract class SendStatsPredicate implements InstanceConfigChangeListener
 
   public enum Mode {
     /// Sends stats only if all the cluster participants use the same known version.
+    // ALWAYS is strictly better than SAFE if all servers are already on versions >= 1.4
+    @Deprecated
     SAFE {
       @Override
       public SendStatsPredicate create(HelixManager helixManager) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -2151,7 +2151,7 @@ public class CommonConstants {
     /// continues without children stats. But if a query involves servers in versions 1.3.0 and 1.4.0, the one
     /// running 1.3.0 may fail, which breaks backward compatibility.
     public static final String KEY_OF_SEND_STATS_MODE = "pinot.query.mse.stats.mode";
-    public static final String DEFAULT_SEND_STATS_MODE = "SAFE";
+    public static final String DEFAULT_SEND_STATS_MODE = "ALWAYS";
 
     /// Used to indicate whether MSE pipeline breaker stats should be included in the queryStats field.
     /// This flag was introduced in 1.5.0. Before 1.5.0, MSE pipeline breaker stats were not kept. Starting from 1.5.0,

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -2142,14 +2142,6 @@ public class CommonConstants {
     /// - "SAFE": MSE will only send stats if all instances in the cluster are running 1.4.0 or later.
     /// - "ALWAYS": MSE will always send stats, regardless of the version of the instances in the cluster.
     /// - "NEVER": MSE will never send stats.
-    ///
-    /// The reason for this flag that versions 1.3.0 and lower have two undesired behaviors:
-    /// 1. Some queries using intersection generate incorrect stats
-    /// 2. When stats from other nodes are sent but are different from expected, the query fails.
-    ///
-    /// In 1.4.0 the first issue is solved and instead of failing when unexpected stats are received, the query
-    /// continues without children stats. But if a query involves servers in versions 1.3.0 and 1.4.0, the one
-    /// running 1.3.0 may fail, which breaks backward compatibility.
     public static final String KEY_OF_SEND_STATS_MODE = "pinot.query.mse.stats.mode";
     public static final String DEFAULT_SEND_STATS_MODE = "ALWAYS";
 


### PR DESCRIPTION
### Summary 
- Pinot 1.5 is out
- Pinot clusters should not be upgraded more than one minor version at a time, as in they should not go from < 1.4 -> > 1.4 and must upgrade through 1.4 first
- ALWAYS is strictly better than SAFE unless involving servers < 1.4 

### Improvements
This will further mitigate https://github.com/apache/pinot/issues/15890 which was only partially mitigated in https://github.com/apache/pinot/pull/15895#issuecomment-2914011383 where there is still the risk of ZK instability risk for big clusters where operators haven't come across this setting.

### Detailed Explanation
AI powered summary [here](https://gist.github.com/satwik-pachigolla/c7f4e670be9f15cbf2f77cd71edebe63).

In short,
```
ALWAYS with no break: All queries optimized > SAFE (no stats)
ALWAYS with break: Average(optimized, slow) > SAFE (no stats)
So yes, ALWAYS is strictly better than SAFE in 1.4.0+ even during a rolling upgrade!
```

### Compatability

- **Unsafe** to upgrade from pinot servers with versions < 1.4 (this commit is on 1.5), doing so may lead to query errors during the upgrade
- Safe to upgrade from pinot servers with version >= 1.4
- This only changes the default, avoiding affecting any explicit configurations. 