### PR TITLE
Fix nightly Superset Docker publish flow

### DIFF
--- a/.github/workflows/nightly-build-multi-arch-superset-docker-image.yml
+++ b/.github/workflows/nightly-build-multi-arch-superset-docker-image.yml
@@ -19,6 +19,7 @@
 name: Nightly Multi Arch Superset Pinot Docker Image Build and Publish
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: "0 0 * * *" # run at 0 AM UTC
 
@@ -43,6 +44,7 @@ jobs:
     runs-on: ${{ matrix.runner }}
     needs: generate-superset-info
     strategy:
+      fail-fast: false
       matrix:
         arch: ["amd64", "arm64"]
         include:
@@ -58,31 +60,16 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
       - uses: actions/checkout@v6
       - name: Build and push
         env:
+          DOCKER_FILE_BASE_DIR: docker/images/pinot-superset
           DOCKER_IMAGE_NAME: apachepinot/pinot-superset
           SUPERSET_IMAGE_TAG: "master-py310${{ matrix.superset_suffix }}"
           TAGS: "${{ needs.generate-superset-info.outputs.tags }}"
-          ARCH: ${{ matrix.arch }}
-        run: |
-          cd docker/images/pinot-superset
-
-          DOCKER_BUILD_TAGS=""
-          for tag in $(echo ${TAGS} | tr "," " "); do
-            DOCKER_BUILD_TAGS+=" --tag ${DOCKER_IMAGE_NAME}:${tag}-${ARCH} "
-          done
-
-          docker buildx build \
-            --no-cache \
-            --platform=linux/${ARCH} \
-            --file Dockerfile \
-            --build-arg SUPERSET_IMAGE_TAG=${SUPERSET_IMAGE_TAG} \
-            ${DOCKER_BUILD_TAGS} \
-            --push \
-            .
+          BUILD_PLATFORM: linux/${{ matrix.arch }}
+          TAG_SUFFIX: "-${{ matrix.arch }}"
+        run: .github/workflows/scripts/docker/.superset_docker_image_build_and_push.sh
   create-superset-manifest:
     name: Create Superset Multi-Arch Manifest
     runs-on: ubuntu-24.04
@@ -93,15 +80,10 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - uses: actions/checkout@v6
       - name: Create and push manifests
         env:
           DOCKER_IMAGE_NAME: apachepinot/pinot-superset
           TAGS: "${{ needs.generate-superset-info.outputs.tags }}"
-        run: |
-          for tag in $(echo ${TAGS} | tr "," " "); do
-            echo "Creating manifest for ${DOCKER_IMAGE_NAME}:${tag}"
-            docker manifest create ${DOCKER_IMAGE_NAME}:${tag} \
-              --amend ${DOCKER_IMAGE_NAME}:${tag}-amd64 \
-              --amend ${DOCKER_IMAGE_NAME}:${tag}-arm64
-            docker manifest push ${DOCKER_IMAGE_NAME}:${tag}
-          done
+          BUILD_PLATFORM: linux/amd64,linux/arm64
+        run: .github/workflows/scripts/docker/.superset_multi_arch_docker_image_manifest_package.sh

--- a/.github/workflows/scripts/docker/.superset_docker_image_build_and_push.sh
+++ b/.github/workflows/scripts/docker/.superset_docker_image_build_and_push.sh
@@ -18,8 +18,14 @@
 # under the License.
 #
 
+set -e
+
 if [ -z "${DOCKER_IMAGE_NAME}" ]; then
   DOCKER_IMAGE_NAME="apachepinot/pinot-superset"
+fi
+if [ -z "${DOCKER_FILE_BASE_DIR}" ]; then
+  echo "DOCKER_FILE_BASE_DIR is required" >&2
+  exit 1
 fi
 if [ -z "${SUPERSET_IMAGE_TAG}" ]; then
   SUPERSET_IMAGE_TAG="latest"
@@ -27,33 +33,40 @@ fi
 if [ -z "${BUILD_PLATFORM}" ]; then
   BUILD_PLATFORM="linux/amd64"
 fi
+if [ -z "${TAG_SUFFIX}" ]; then
+  TAG_SUFFIX=""
+fi
 
-DATE=`date +%Y%m%d`
-docker pull apache/superset:${SUPERSET_IMAGE_TAG}
-COMMIT_ID=`docker images apache/superset:${SUPERSET_IMAGE_TAG} --format "{{.ID}}"`
+DATE=$(date +%Y%m%d)
+docker pull "apache/superset:${SUPERSET_IMAGE_TAG}"
+COMMIT_ID=$(docker images "apache/superset:${SUPERSET_IMAGE_TAG}" --format "{{.ID}}")
 
 tags=()
 if [ -z "${TAGS}" ]; then
   tags=("${COMMIT_ID}-${DATE}")
   tags+=("latest")
 else
-  declare -a tags=($(echo ${TAGS} | tr "," " "))
+  declare -a tags=($(echo "${TAGS}" | tr "," " "))
 fi
 
 DOCKER_BUILD_TAGS=""
 for tag in "${tags[@]}"
 do
-  echo "Plan to build and push docker images for: ${DOCKER_IMAGE_NAME}:${tag}"
-  DOCKER_BUILD_TAGS+=" --tag ${DOCKER_IMAGE_NAME}:${tag} "
+  echo "Plan to build and push docker images for: ${DOCKER_IMAGE_NAME}:${tag}${TAG_SUFFIX}"
+  DOCKER_BUILD_TAGS+=" --tag ${DOCKER_IMAGE_NAME}:${tag}${TAG_SUFFIX} "
 done
 
-cd ${DOCKER_FILE_BASE_DIR}
+cd "${DOCKER_FILE_BASE_DIR}"
 
 docker build \
     --no-cache \
-    --platform=${BUILD_PLATFORM} \
+    --platform="${BUILD_PLATFORM}" \
     --file Dockerfile \
-    --build-arg SUPERSET_IMAGE_TAG=${SUPERSET_IMAGE_TAG} \
+    --build-arg "SUPERSET_IMAGE_TAG=${SUPERSET_IMAGE_TAG}" \
     ${DOCKER_BUILD_TAGS} \
-    --push \
     .
+
+for tag in "${tags[@]}"
+do
+  docker push "${DOCKER_IMAGE_NAME}:${tag}${TAG_SUFFIX}"
+done

--- a/.github/workflows/scripts/docker/.superset_multi_arch_docker_image_manifest_package.sh
+++ b/.github/workflows/scripts/docker/.superset_multi_arch_docker_image_manifest_package.sh
@@ -1,0 +1,51 @@
+#!/bin/bash -x
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+set -e
+
+if [ -z "${DOCKER_IMAGE_NAME}" ]; then
+  DOCKER_IMAGE_NAME="apachepinot/pinot-superset"
+fi
+if [ -z "${TAGS}" ]; then
+  echo "TAGS is required" >&2
+  exit 1
+fi
+if [ -z "${BUILD_PLATFORM}" ]; then
+  BUILD_PLATFORM="linux/arm64,linux/amd64"
+fi
+
+declare -a tags=($(echo "${TAGS}" | tr "," " "))
+declare -a platforms=($(echo "${BUILD_PLATFORM}" | tr "," " "))
+
+for tag in "${tags[@]}"; do
+  DOCKER_AMEND_TAGS_CMD=""
+  for platform in "${platforms[@]}"; do
+    arch="${platform##*/}"
+    DOCKER_AMEND_TAGS_CMD+=" --amend ${DOCKER_IMAGE_NAME}:${tag}-${arch} "
+  done
+
+  echo "Creating manifest for ${DOCKER_IMAGE_NAME}:${tag}"
+  docker manifest create \
+    "${DOCKER_IMAGE_NAME}:${tag}" \
+    ${DOCKER_AMEND_TAGS_CMD}
+
+  docker manifest push \
+    "${DOCKER_IMAGE_NAME}:${tag}"
+done


### PR DESCRIPTION
## Summary
- Switch the nightly Superset image workflow to the same explicit docker build + docker push pattern used by the successful nightly Pinot image workflow.
- Move Superset multi-arch manifest creation into a checked-in helper script.
- Add workflow_dispatch and keep both architecture jobs running with fail-fast disabled.

## Root Cause
The scheduled Superset workflow authenticated to DockerHub successfully, but docker buildx build --push failed while fetching a DockerHub token for apachepinot/pinot-superset with `401 Unauthorized: access token has insufficient scopes`. The nightly Pinot publish workflow with the same DockerHub secrets succeeds by building locally and pushing tags explicitly with docker push.

## User Manual
Operators can manually rerun `Nightly Multi Arch Superset Pinot Docker Image Build and Publish` from the Actions UI. The workflow publishes architecture-specific tags such as `<tag>-amd64` and `<tag>-arm64`, then publishes the multi-arch manifest tag `<tag>`.

## Sample Table Config / Queries
Not applicable. This change only affects the Docker image publishing workflow and does not change Pinot table configuration or query behavior.

## Validation
- `bash -n .github/workflows/scripts/docker/.superset_docker_image_build_and_push.sh`
- `bash -n .github/workflows/scripts/docker/.superset_multi_arch_docker_image_manifest_package.sh`
- `ruby -e 'require "yaml"; YAML.load_file(ARGV[0]); puts "yaml ok"' .github/workflows/nightly-build-multi-arch-superset-docker-image.yml`\n- `git diff --cached --check`