### PR TITLE
Fix Pinot base Maven download URL

### DIFF
--- a/docker/images/pinot-base/pinot-base-build/amazoncorretto.dockerfile
+++ b/docker/images/pinot-base/pinot-base-build/amazoncorretto.dockerfile
@@ -69,13 +69,18 @@ ENV LANG=C.UTF-8
 ENV JAVA_HOME=/usr/lib/jvm/java-${JAVA_VERSION}-amazon-corretto
 
 # install maven
+ARG MAVEN_VERSION=3.9.14
 RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
-  && echo "Downloading Maven for $(uname -m) architecture..." \
-  && wget https://dlcdn.apache.org/maven/maven-3/3.9.14/binaries/apache-maven-3.9.14-bin.tar.gz -P /tmp \
-  && tar -xzf /tmp/apache-maven-*.tar.gz -C /usr/share/maven --strip-components=1 \
-  && rm -f /tmp/apache-maven-*.tar.gz \
+  && echo "Downloading Maven ${MAVEN_VERSION} for $(uname -m) architecture..." \
+  && wget https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz -O /tmp/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && wget https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz.sha512 -O /tmp/apache-maven-${MAVEN_VERSION}-bin.tar.gz.sha512 \
+  && echo "$(cat /tmp/apache-maven-${MAVEN_VERSION}-bin.tar.gz.sha512)  /tmp/apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
+  && tar -xzf /tmp/apache-maven-${MAVEN_VERSION}-bin.tar.gz -C /usr/share/maven --strip-components=1 \
+  && rm -f /tmp/apache-maven-${MAVEN_VERSION}-bin.tar.gz* \
   && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn \
-  && mvn --version
+  && mvn --version | tee /tmp/maven-version \
+  && grep -F "Apache Maven ${MAVEN_VERSION}" /tmp/maven-version \
+  && rm -f /tmp/maven-version
 ENV MAVEN_HOME=/usr/share/maven
 ENV MAVEN_CONFIG=/opt/.m2
 

--- a/docker/images/pinot-base/pinot-base-build/ms-openjdk.dockerfile
+++ b/docker/images/pinot-base/pinot-base-build/ms-openjdk.dockerfile
@@ -42,13 +42,18 @@ RUN apt-get update && \
   rm -rf /var/lib/apt/lists/*
 
 # install maven
+ARG MAVEN_VERSION=3.9.14
 RUN mkdir -p /usr/share/maven /usr/share/maven/ref \
-  && echo "Downloading Maven for $(uname -m) architecture..." \
-  && wget https://dlcdn.apache.org/maven/maven-3/3.9.14/binaries/apache-maven-3.9.14-bin.tar.gz -P /tmp \
-  && tar -xzf /tmp/apache-maven-*.tar.gz -C /usr/share/maven --strip-components=1 \
-  && rm -f /tmp/apache-maven-*.tar.gz \
+  && echo "Downloading Maven ${MAVEN_VERSION} for $(uname -m) architecture..." \
+  && wget https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz -O /tmp/apache-maven-${MAVEN_VERSION}-bin.tar.gz \
+  && wget https://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz.sha512 -O /tmp/apache-maven-${MAVEN_VERSION}-bin.tar.gz.sha512 \
+  && echo "$(cat /tmp/apache-maven-${MAVEN_VERSION}-bin.tar.gz.sha512)  /tmp/apache-maven-${MAVEN_VERSION}-bin.tar.gz" | sha512sum -c - \
+  && tar -xzf /tmp/apache-maven-${MAVEN_VERSION}-bin.tar.gz -C /usr/share/maven --strip-components=1 \
+  && rm -f /tmp/apache-maven-${MAVEN_VERSION}-bin.tar.gz* \
   && ln -s /usr/share/maven/bin/mvn /usr/bin/mvn \
-  && mvn --version
+  && mvn --version | tee /tmp/maven-version \
+  && grep -F "Apache Maven ${MAVEN_VERSION}" /tmp/maven-version \
+  && rm -f /tmp/maven-version
 ENV MAVEN_HOME=/usr/share/maven
 ENV MAVEN_CONFIG=/opt/.m2
 


### PR DESCRIPTION
### Summary
- Switch Pinot base build Dockerfiles to fetch pinned Maven 3.9.14 from archive.apache.org instead of dlcdn.apache.org.
- Verify the Maven tarball with the published .sha512 before extracting it.

### Motivation
The manual Pinot base image workflow failed in https://github.com/apache/pinot/actions/runs/25101349275 because dlcdn.apache.org now serves Maven 3.9.15 and returns 404 for the pinned 3.9.14 tarball. The Apache archive URL is stable for pinned release artifacts.

### Validation
- gh run view 25101349275 --repo apache/pinot --job 73551104834 --log
- curl -I https://archive.apache.org/dist/maven/maven-3/3.9.14/binaries/apache-maven-3.9.14-bin.tar.gz
- Local download + .sha512 check + extract + mvn --version
- git diff --check

Docker build smoke test was not run because the local Docker daemon is not running.

User manual / sample table config or queries: not applicable for this Docker base image CI fix.