### PR TITLE
[codex] Fix Superset nightly manifest publishing

### DIFF
--- a/.github/workflows/nightly-build-multi-arch-superset-docker-image.yml
+++ b/.github/workflows/nightly-build-multi-arch-superset-docker-image.yml
@@ -75,9 +75,12 @@ jobs:
             DOCKER_BUILD_TAGS+=" --tag ${DOCKER_IMAGE_NAME}:${tag}-${ARCH} "
           done
 
+          # Keep arch staging tags as image manifests; default BuildKit
+          # provenance turns them into OCI indexes with attestation entries.
           docker buildx build \
             --no-cache \
             --platform=linux/${ARCH} \
+            --provenance=false \
             --file Dockerfile \
             --build-arg SUPERSET_IMAGE_TAG=${SUPERSET_IMAGE_TAG} \
             ${DOCKER_BUILD_TAGS} \
@@ -93,15 +96,18 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
       - name: Create and push manifests
         env:
           DOCKER_IMAGE_NAME: apachepinot/pinot-superset
           TAGS: "${{ needs.generate-superset-info.outputs.tags }}"
         run: |
-          for tag in $(echo ${TAGS} | tr "," " "); do
-            echo "Creating manifest for ${DOCKER_IMAGE_NAME}:${tag}"
-            docker manifest create ${DOCKER_IMAGE_NAME}:${tag} \
-              --amend ${DOCKER_IMAGE_NAME}:${tag}-amd64 \
-              --amend ${DOCKER_IMAGE_NAME}:${tag}-arm64
-            docker manifest push ${DOCKER_IMAGE_NAME}:${tag}
+          for tag in $(echo "${TAGS}" | tr "," " "); do
+            image="${DOCKER_IMAGE_NAME}:${tag}"
+            echo "Creating manifest for ${image}"
+            docker buildx imagetools create \
+              --tag "${image}" \
+              "${image}-amd64" \
+              "${image}-arm64"
           done


### PR DESCRIPTION
## Summary
- disable default BuildKit provenance on Superset per-arch staging images so they stay single-platform image manifests
- switch the final Superset manifest publish step from `docker manifest create/push` to `docker buildx imagetools create`
- set up Buildx in the manifest job before using `imagetools`

## Root Cause
The 2026-04-30 scheduled Superset image build failed in `Create Superset Multi-Arch Manifest` because Buildx published the `*-amd64` and `*-arm64` staging tags as OCI indexes with attestation manifests. `docker manifest create` rejects those sources with `is a manifest list`.

Failed job: https://github.com/apache/pinot/actions/runs/25140956516/job/73726719386

## Validation
- `git diff HEAD^ --check`
- parsed `.github/workflows/nightly-build-multi-arch-superset-docker-image.yml` as YAML
- `bash -n` on both edited workflow shell blocks
- locally repaired the failed Docker Hub tags using digest refs and verified `apachepinot/pinot-superset:5fc90d5da9e9-20260430` and `apachepinot/pinot-superset:latest` now resolve to `linux/amd64` and `linux/arm64` manifests

## Notes
User manual, sample table config, and sample queries are not applicable because this only changes the GitHub Actions Docker publish workflow.
