### PR TITLE
Support range syntax in stream.kafka.partition.ids config

### DIFF
--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-base/src/main/java/org/apache/pinot/plugin/stream/kafka/KafkaPartitionSubsetUtils.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-base/src/main/java/org/apache/pinot/plugin/stream/kafka/KafkaPartitionSubsetUtils.java
@@ -34,6 +34,8 @@ import org.apache.commons.lang3.StringUtils;
  */
 public final class KafkaPartitionSubsetUtils {
 
+  static final int MAX_TOTAL_PARTITION_IDS = 10_000;
+
   private KafkaPartitionSubsetUtils() {
   }
 
@@ -49,11 +51,15 @@ public final class KafkaPartitionSubsetUtils {
    * Duplicate IDs in the config are silently removed; this ensures stable ordering and prevents
    * duplicate processing of the same partition.
    *
+   * <p>The total number of unique partition IDs must not exceed {@link #MAX_TOTAL_PARTITION_IDS}
+   * (currently 10,000). This guard prevents accidental OOM from typos or overly broad ranges.
+   *
    * @param streamConfigMap table stream config map (e.g. from
    *                        {@link org.apache.pinot.spi.stream.StreamConfig#getStreamConfigsMap()})
    * @return Sorted list of unique partition IDs when stream.kafka.partition.ids is set and non-empty;
    *         null when not set or blank
-   * @throws IllegalArgumentException if the value contains invalid entries
+   * @throws IllegalArgumentException if the value contains invalid entries or exceeds
+   *         {@link #MAX_TOTAL_PARTITION_IDS}
    */
   @Nullable
   public static List<Integer> getPartitionIdsFromConfig(Map<String, String> streamConfigMap) {
@@ -75,6 +81,11 @@ public final class KafkaPartitionSubsetUtils {
       } else {
         parseSingleId(trimmed, key, value, idSet);
       }
+      if (idSet.size() > MAX_TOTAL_PARTITION_IDS) {
+        throw new IllegalArgumentException(
+            "Invalid " + key + " value: total partition count " + idSet.size()
+                + " exceeds maximum allowed " + MAX_TOTAL_PARTITION_IDS + ", got '" + value + "'");
+      }
     }
     if (idSet.isEmpty()) {
       return null;
@@ -89,12 +100,14 @@ public final class KafkaPartitionSubsetUtils {
       int partitionId = Integer.parseInt(trimmed);
       if (partitionId < 0) {
         throw new IllegalArgumentException(
-            "Invalid " + key + " value: partition IDs must be non-negative, got '" + originalValue + "'");
+            "Invalid " + key + " value: partition ID must be non-negative in '" + trimmed + "', got '"
+                + originalValue + "'");
       }
       idSet.add(partitionId);
     } catch (NumberFormatException e) {
       throw new IllegalArgumentException(
-          "Invalid " + key + " value: expected integers or ranges, got '" + originalValue + "'", e);
+          "Invalid " + key + " value: expected integer or range in '" + trimmed + "', got '" + originalValue + "'",
+          e);
     }
   }
 
@@ -120,8 +133,14 @@ public final class KafkaPartitionSubsetUtils {
       throw new IllegalArgumentException(
           "Invalid " + key + " value: range start must be <= end in '" + trimmed + "', got '" + originalValue + "'");
     }
-    for (int i = start; i <= end; i++) {
-      idSet.add(i);
+    long rangeSize = (long) end - start + 1;
+    if (idSet.size() + rangeSize > MAX_TOTAL_PARTITION_IDS) {
+      throw new IllegalArgumentException(
+          "Invalid " + key + " value: total partition count exceeds maximum allowed " + MAX_TOTAL_PARTITION_IDS
+              + ", got '" + originalValue + "'");
+    }
+    for (long i = start; i <= end; i++) {
+      idSet.add((int) i);
     }
   }
 }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-base/src/main/java/org/apache/pinot/plugin/stream/kafka/KafkaPartitionSubsetUtils.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-base/src/main/java/org/apache/pinot/plugin/stream/kafka/KafkaPartitionSubsetUtils.java
@@ -38,7 +38,13 @@ public final class KafkaPartitionSubsetUtils {
   }
 
   /**
-   * Reads the optional comma-separated partition ID list from the stream config map.
+   * Reads the optional partition ID specification from the stream config map.
+   * Supports three formats, which can be mixed in a single value:
+   * <ul>
+   *   <li>Individual IDs: {@code "0,2,5"}</li>
+   *   <li>Inclusive ranges (both start and end are included): {@code "0-399"}</li>
+   *   <li>Mixed: {@code "0-99,200,300-399"}</li>
+   * </ul>
    * Returns a sorted, deduplicated list for stable ordering when used for partition group metadata.
    * Duplicate IDs in the config are silently removed; this ensures stable ordering and prevents
    * duplicate processing of the same partition.
@@ -47,7 +53,7 @@ public final class KafkaPartitionSubsetUtils {
    *                        {@link org.apache.pinot.spi.stream.StreamConfig#getStreamConfigsMap()})
    * @return Sorted list of unique partition IDs when stream.kafka.partition.ids is set and non-empty;
    *         null when not set or blank
-   * @throws IllegalArgumentException if the value contains invalid (non-integer) entries
+   * @throws IllegalArgumentException if the value contains invalid entries
    */
   @Nullable
   public static List<Integer> getPartitionIdsFromConfig(Map<String, String> streamConfigMap) {
@@ -63,16 +69,11 @@ public final class KafkaPartitionSubsetUtils {
       if (trimmed.isEmpty()) {
         continue;
       }
-      try {
-        int partitionId = Integer.parseInt(trimmed);
-        if (partitionId < 0) {
-          throw new IllegalArgumentException("Invalid " + key
-              + " value: partition IDs must be non-negative, got '" + value + "'");
-        }
-        idSet.add(partitionId);
-      } catch (NumberFormatException e) {
-        throw new IllegalArgumentException(
-            "Invalid " + key + " value: expected comma-separated integers, got '" + value + "'", e);
+      int hyphenIndex = trimmed.indexOf('-', 1);
+      if (hyphenIndex > 0) {
+        parseRange(trimmed, hyphenIndex, key, value, idSet);
+      } else {
+        parseSingleId(trimmed, key, value, idSet);
       }
     }
     if (idSet.isEmpty()) {
@@ -81,5 +82,46 @@ public final class KafkaPartitionSubsetUtils {
     List<Integer> ids = new ArrayList<>(idSet);
     Collections.sort(ids);
     return ids;
+  }
+
+  private static void parseSingleId(String trimmed, String key, String originalValue, Set<Integer> idSet) {
+    try {
+      int partitionId = Integer.parseInt(trimmed);
+      if (partitionId < 0) {
+        throw new IllegalArgumentException(
+            "Invalid " + key + " value: partition IDs must be non-negative, got '" + originalValue + "'");
+      }
+      idSet.add(partitionId);
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException(
+          "Invalid " + key + " value: expected integers or ranges, got '" + originalValue + "'", e);
+    }
+  }
+
+  // Parses an inclusive range token like "0-399" (both start and end are included).
+  private static void parseRange(String trimmed, int hyphenIndex, String key, String originalValue,
+      Set<Integer> idSet) {
+    String startStr = trimmed.substring(0, hyphenIndex).trim();
+    String endStr = trimmed.substring(hyphenIndex + 1).trim();
+    int start;
+    int end;
+    try {
+      start = Integer.parseInt(startStr);
+      end = Integer.parseInt(endStr);
+    } catch (NumberFormatException e) {
+      throw new IllegalArgumentException(
+          "Invalid " + key + " value: invalid range '" + trimmed + "', got '" + originalValue + "'", e);
+    }
+    if (start < 0 || end < 0) {
+      throw new IllegalArgumentException(
+          "Invalid " + key + " value: partition IDs must be non-negative, got '" + originalValue + "'");
+    }
+    if (start > end) {
+      throw new IllegalArgumentException(
+          "Invalid " + key + " value: range start must be <= end in '" + trimmed + "', got '" + originalValue + "'");
+    }
+    for (int i = start; i <= end; i++) {
+      idSet.add(i);
+    }
   }
 }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-base/src/main/java/org/apache/pinot/plugin/stream/kafka/KafkaStreamConfigProperties.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-base/src/main/java/org/apache/pinot/plugin/stream/kafka/KafkaStreamConfigProperties.java
@@ -70,7 +70,8 @@ public class KafkaStreamConfigProperties {
   public static final String KAFKA_CONSUMER_PROP_PREFIX = "kafka.consumer.prop";
 
   /**
-   * Optional comma-separated list of Kafka partition IDs to consume (e.g. "0,2,5").
+   * Optional comma-separated list of Kafka partition IDs or inclusive ranges to consume
+   * (e.g. "0,2,5" or "0-399" or "0-99,200,300-399").
    * When set, only these partitions are used for the table; when absent, all topic partitions are consumed.
    */
   public static final String PARTITION_IDS = "kafka.partition.ids";

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-base/src/main/java/org/apache/pinot/plugin/stream/kafka/KafkaStreamConfigProperties.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-base/src/main/java/org/apache/pinot/plugin/stream/kafka/KafkaStreamConfigProperties.java
@@ -73,6 +73,7 @@ public class KafkaStreamConfigProperties {
    * Optional comma-separated list of Kafka partition IDs or inclusive ranges to consume
    * (e.g. "0,2,5" or "0-399" or "0-99,200,300-399").
    * When set, only these partitions are used for the table; when absent, all topic partitions are consumed.
+   * The total number of unique partition IDs must not exceed 10,000.
    */
   public static final String PARTITION_IDS = "kafka.partition.ids";
 }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-base/src/test/java/org/apache/pinot/plugin/stream/kafka/KafkaPartitionSubsetUtilsTest.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-base/src/test/java/org/apache/pinot/plugin/stream/kafka/KafkaPartitionSubsetUtilsTest.java
@@ -198,4 +198,73 @@ public class KafkaPartitionSubsetUtilsTest {
         "0,1,-5,2");
     KafkaPartitionSubsetUtils.getPartitionIdsFromConfig(config);
   }
+
+  @Test
+  public void testRangeMixedWithIndividualIds() {
+    Map<String, String> config = new HashMap<>();
+    config.put(KafkaStreamConfigProperties.constructStreamProperty(KafkaStreamConfigProperties.PARTITION_IDS),
+        "0-4,50,100-104");
+    List<Integer> result = KafkaPartitionSubsetUtils.getPartitionIdsFromConfig(config);
+    Assert.assertNotNull(result);
+    Assert.assertEquals(result, List.of(0, 1, 2, 3, 4, 50, 100, 101, 102, 103, 104));
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testRangeStartGreaterThanEnd() {
+    Map<String, String> config = new HashMap<>();
+    config.put(KafkaStreamConfigProperties.constructStreamProperty(KafkaStreamConfigProperties.PARTITION_IDS),
+        "10-5");
+    KafkaPartitionSubsetUtils.getPartitionIdsFromConfig(config);
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testRangeEmptyEnd() {
+    Map<String, String> config = new HashMap<>();
+    config.put(KafkaStreamConfigProperties.constructStreamProperty(KafkaStreamConfigProperties.PARTITION_IDS),
+        "5-");
+    KafkaPartitionSubsetUtils.getPartitionIdsFromConfig(config);
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testNegativePartitionStillFailsWithRangeSyntax() {
+    Map<String, String> config = new HashMap<>();
+    config.put(KafkaStreamConfigProperties.constructStreamProperty(KafkaStreamConfigProperties.PARTITION_IDS),
+        "-1,0,1");
+    KafkaPartitionSubsetUtils.getPartitionIdsFromConfig(config);
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testRangeNonNumeric() {
+    Map<String, String> config = new HashMap<>();
+    config.put(KafkaStreamConfigProperties.constructStreamProperty(KafkaStreamConfigProperties.PARTITION_IDS),
+        "abc-def");
+    KafkaPartitionSubsetUtils.getPartitionIdsFromConfig(config);
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testRangeNegativeStart() {
+    Map<String, String> config = new HashMap<>();
+    config.put(KafkaStreamConfigProperties.constructStreamProperty(KafkaStreamConfigProperties.PARTITION_IDS),
+        "-1-5");
+    KafkaPartitionSubsetUtils.getPartitionIdsFromConfig(config);
+  }
+
+  @Test
+  public void testSingleElementRange() {
+    Map<String, String> config = new HashMap<>();
+    config.put(KafkaStreamConfigProperties.constructStreamProperty(KafkaStreamConfigProperties.PARTITION_IDS), "5-5");
+    List<Integer> result = KafkaPartitionSubsetUtils.getPartitionIdsFromConfig(config);
+    Assert.assertNotNull(result);
+    Assert.assertEquals(result, List.of(5));
+  }
+
+  @Test
+  public void testOverlappingRangesAreDeduplicated() {
+    Map<String, String> config = new HashMap<>();
+    config.put(KafkaStreamConfigProperties.constructStreamProperty(KafkaStreamConfigProperties.PARTITION_IDS),
+        "0-5,3-8");
+    List<Integer> result = KafkaPartitionSubsetUtils.getPartitionIdsFromConfig(config);
+    Assert.assertNotNull(result);
+    Assert.assertEquals(result, List.of(0, 1, 2, 3, 4, 5, 6, 7, 8));
+  }
 }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-base/src/test/java/org/apache/pinot/plugin/stream/kafka/KafkaPartitionSubsetUtilsTest.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-base/src/test/java/org/apache/pinot/plugin/stream/kafka/KafkaPartitionSubsetUtilsTest.java
@@ -226,7 +226,7 @@ public class KafkaPartitionSubsetUtilsTest {
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class)
-  public void testNegativePartitionStillFailsWithRangeSyntax() {
+  public void testNegativePartitionIdNotMisreadAsRange() {
     Map<String, String> config = new HashMap<>();
     config.put(KafkaStreamConfigProperties.constructStreamProperty(KafkaStreamConfigProperties.PARTITION_IDS),
         "-1,0,1");
@@ -266,5 +266,46 @@ public class KafkaPartitionSubsetUtilsTest {
     List<Integer> result = KafkaPartitionSubsetUtils.getPartitionIdsFromConfig(config);
     Assert.assertNotNull(result);
     Assert.assertEquals(result, List.of(0, 1, 2, 3, 4, 5, 6, 7, 8));
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testSingleRangeExceedsTotalMax() {
+    Map<String, String> config = new HashMap<>();
+    config.put(KafkaStreamConfigProperties.constructStreamProperty(KafkaStreamConfigProperties.PARTITION_IDS),
+        "0-" + KafkaPartitionSubsetUtils.MAX_TOTAL_PARTITION_IDS);
+    KafkaPartitionSubsetUtils.getPartitionIdsFromConfig(config);
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testMultipleRangesExceedTotalMax() {
+    Map<String, String> config = new HashMap<>();
+    config.put(KafkaStreamConfigProperties.constructStreamProperty(KafkaStreamConfigProperties.PARTITION_IDS),
+        "0-5999,6000-11999");
+    KafkaPartitionSubsetUtils.getPartitionIdsFromConfig(config);
+  }
+
+  @Test
+  public void testExactlyMaxPartitionIdsAccepted() {
+    Map<String, String> config = new HashMap<>();
+    config.put(KafkaStreamConfigProperties.constructStreamProperty(KafkaStreamConfigProperties.PARTITION_IDS),
+        "0-" + (KafkaPartitionSubsetUtils.MAX_TOTAL_PARTITION_IDS - 1));
+    List<Integer> result = KafkaPartitionSubsetUtils.getPartitionIdsFromConfig(config);
+    Assert.assertNotNull(result);
+    Assert.assertEquals(result.size(), KafkaPartitionSubsetUtils.MAX_TOTAL_PARTITION_IDS);
+  }
+
+  @Test(expectedExceptions = IllegalArgumentException.class)
+  public void testIndividualIdsExceedTotalMax() {
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i <= KafkaPartitionSubsetUtils.MAX_TOTAL_PARTITION_IDS; i++) {
+      if (i > 0) {
+        sb.append(',');
+      }
+      sb.append(i);
+    }
+    Map<String, String> config = new HashMap<>();
+    config.put(KafkaStreamConfigProperties.constructStreamProperty(KafkaStreamConfigProperties.PARTITION_IDS),
+        sb.toString());
+    KafkaPartitionSubsetUtils.getPartitionIdsFromConfig(config);
   }
 }


### PR DESCRIPTION
## Summary

- Add inclusive range notation (e.g. `"0-399"`) to the `stream.kafka.partition.ids` config parser, in addition to existing comma-separated individual IDs
- Supports mixed format: `"0-99,200,300-399"` — practical for high-partition-count topics (e.g. 1600 partitions) in logical table setups
- Fully backward compatible — all previously valid values produce identical results; no caller changes required

## Design

The parser detects range tokens by finding a hyphen at position > 0 (`indexOf('-', 1)`). This cleanly distinguishes ranges from negative numbers since partition IDs are always non-negative:

| Input | Detection | Result |
|---|---|---|
| `"0-399"` | hyphen at index 1 → range | Expands to [0..399] inclusive |
| `"-1"` | no hyphen found (indexOf returns -1) → single int | Fails non-negative check |
| `"0-99,200,300-399"` | mix of ranges and singles | Union, sorted, deduplicated |

Ranges are **inclusive** of both start and end values.

### Safety guards

- **Total partition ID cap**: Maximum of 10,000 unique partition IDs (`MAX_TOTAL_PARTITION_IDS`). Checked after every token in the parsing loop — applies equally to ranges and individual IDs.
- **Pre-expansion check in ranges**: Before iterating a range, validates `idSet.size() + rangeSize` won't exceed the cap. Fails fast without allocating.
- **Integer overflow protection**: Uses `long` arithmetic for range size calculation and `long` loop counter to prevent wrap-around when partition IDs approach `Integer.MAX_VALUE`.

## Changes

- `KafkaPartitionSubsetUtils.java` — refactored parsing loop into `parseSingleId()` and `parseRange()` helpers; added range expansion with validation (non-negative, start ≤ end, total cap); uses `long` loop counter to prevent overflow
- `KafkaStreamConfigProperties.java` — updated Javadoc on `PARTITION_IDS` constant to document range support and 10K limit
- `KafkaPartitionSubsetUtilsTest.java` — added 12 test methods covering: mixed ranges + IDs, inverted range, empty end, negative IDs, non-numeric range, negative start, single-element range, overlapping range dedup, exact boundary acceptance (10K), single range overflow, multiple range overflow, individual ID overflow

## Test plan

- [x] All 31 unit tests pass (`KafkaPartitionSubsetUtilsTest`)
- [x] Spotless, checkstyle, and license checks pass
- [ ] Existing integration tests (`KafkaPartitionSubsetChaosIntegrationTest`, `LogicalTableWithTwoRealtimeTableIntegrationTest`) pass in CI
- [ ] No changes to `pinot-kafka-3.0` or `pinot-kafka-4.0` modules needed — they consume the shared `pinot-kafka-base` parser unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)