### PR TITLE
Relax partial-upsert strategy update validation

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -1287,8 +1287,10 @@ public final class TableConfigUtils {
   /**
    * Validates that critical upsert configuration fields are not changed during table config update.
    * Checks: mode, hashFunction, comparisonColumns, timeColumn (when no comparison columns),
-   * deleteRecordColumn, dropOutOfOrderRecord, outOfOrderRecordColumn,
-   * partialUpsertStrategies, defaultPartialUpsertStrategy.
+   * deleteRecordColumn, dropOutOfOrderRecord, outOfOrderRecordColumn.
+   *
+   * <p>Partial-upsert strategy maps and the default partial-upsert strategy are intentionally
+   * not validated here — they may be added, removed, or changed on existing tables.
    *
    * @param newConfig the new table config being applied
    * @param existingConfig the existing table config
@@ -1346,19 +1348,6 @@ public final class TableConfigUtils {
           newUpsertConfig.getOutOfOrderRecordColumn())) {
         violations.add(String.format("upsertConfig.outOfOrderRecordColumn (%s -> %s)",
             existingUpsertConfig.getOutOfOrderRecordColumn(), newUpsertConfig.getOutOfOrderRecordColumn()));
-      }
-      if (existingUpsertConfig.getMode() == UpsertConfig.Mode.PARTIAL) {
-        if (!Objects.equals(existingUpsertConfig.getPartialUpsertStrategies(),
-            newUpsertConfig.getPartialUpsertStrategies())) {
-          violations.add(String.format("upsertConfig.partialUpsertStrategies (%s -> %s)",
-              existingUpsertConfig.getPartialUpsertStrategies(), newUpsertConfig.getPartialUpsertStrategies()));
-        }
-        if (existingUpsertConfig.getDefaultPartialUpsertStrategy()
-            != newUpsertConfig.getDefaultPartialUpsertStrategy()) {
-          violations.add(String.format("upsertConfig.defaultPartialUpsertStrategy (%s -> %s)",
-              existingUpsertConfig.getDefaultPartialUpsertStrategy(),
-              newUpsertConfig.getDefaultPartialUpsertStrategy()));
-        }
       }
     }
   }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -4107,4 +4107,40 @@ public class TableConfigUtilsTest {
       assertTrue(e.getMessage().contains("out-of-order record column"));
     }
   }
+
+  @Test
+  public void testValidateBackwardCompatibilityAllowsPartialUpsertStrategyChanges() {
+    // Build two PARTIAL upsert table configs that differ only in partialUpsertStrategies and
+    // defaultPartialUpsertStrategy. The relaxed validator must accept all of:
+    //   - adding a strategy for a new column
+    //   - changing a strategy on an existing column
+    //   - removing a strategy on an existing column
+    //   - changing the defaultPartialUpsertStrategy
+    Map<String, UpsertConfig.Strategy> existingStrategies = new HashMap<>();
+    existingStrategies.put("col_a", UpsertConfig.Strategy.INCREMENT);
+    existingStrategies.put("col_b", UpsertConfig.Strategy.MAX);
+    UpsertConfig existingUpsertConfig = new UpsertConfig(UpsertConfig.Mode.PARTIAL);
+    existingUpsertConfig.setPartialUpsertStrategies(existingStrategies);
+    existingUpsertConfig.setDefaultPartialUpsertStrategy(UpsertConfig.Strategy.OVERWRITE);
+
+    Map<String, UpsertConfig.Strategy> newStrategies = new HashMap<>();
+    // col_a: INCREMENT → MAX (mutation)
+    newStrategies.put("col_a", UpsertConfig.Strategy.MAX);
+    // col_b: removed
+    // col_c: new
+    newStrategies.put("col_c", UpsertConfig.Strategy.UNION);
+    UpsertConfig newUpsertConfig = new UpsertConfig(UpsertConfig.Mode.PARTIAL);
+    newUpsertConfig.setPartialUpsertStrategies(newStrategies);
+    // default: OVERWRITE → APPEND (default change)
+    newUpsertConfig.setDefaultPartialUpsertStrategy(UpsertConfig.Strategy.APPEND);
+
+    TableConfig existingConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
+        .setTimeColumnName(TIME_COLUMN).setUpsertConfig(existingUpsertConfig).build();
+    TableConfig newConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
+        .setTimeColumnName(TIME_COLUMN).setUpsertConfig(newUpsertConfig).build();
+
+    List<String> violations = TableConfigUtils.validateBackwardCompatibility(newConfig, existingConfig);
+    assertTrue(violations.isEmpty(),
+        "Expected no violations for partial-upsert strategy and default-strategy changes, but got: " + violations);
+  }
 }


### PR DESCRIPTION
## Summary

Allows operators to add, remove, or change `partialUpsertStrategies` (and `defaultPartialUpsertStrategy`) on an existing partial-upsert table via `PUT /tables/{tableName}`. Previously, any change to either field was rejected by `validateBackwardCompatibility`, forcing a full table rebuild for updation.

## Motivation

Partial-upsert strategy changes currently require a server restart to take effect. During a rolling restart, replicas may diverge and apply different strategy versions while consuming the same data, causing segment-level divergence across replicas. Users can typically resolve this by resetting and rebuilding the latest consuming segments after the rollout.
A common schema evolution workflow is adding a new column with a partial-upsert strategy (e.g. INCREMENT, MAX, UNION). The current validator rejects such changes even though the strategy only impacts future merges and does not affect existing persisted values. So added this change to remove the validation on partial upsert strategies altogether.

## Behavior after this change
- Switch-forward semantics: existing merged values are retained verbatim; the new strategy applies only to merges performed after a consuming server reloads its `PartialUpsertHandler`. Restart consumers (or trigger handler reconstruction) to make the new strategy effective uniformly. If row-value drift is observed during the rollout window, run a segment RESET to re-derive correct values from common segment's data.

## Tests

Added `TableConfigUtilsTest#testValidateBackwardCompatibilityAllowsPartialUpsertStrategyChanges` covering all four cases in one update: add, remove, mutate, and default-strategy change.