### PR TITLE
Multi-stage leaf routing: optional segments, unavailable metadata, and empty partitions

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/DispatchablePlanContext.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/DispatchablePlanContext.java
@@ -156,6 +156,10 @@ public class DispatchablePlanContext {
           dispatchablePlanMetadata.getWorkerIdToMailboxesMap();
       Preconditions.checkArgument(workerIdToSegmentsMap == null || workerIdToTableNameSegmentsMap == null,
           "Both workerIdToSegmentsMap and workerIdToTableNameSegmentsMap cannot be set at the same time");
+      Map<Integer, Map<String, List<String>>> workerIdToOptionalSegmentsMap =
+          dispatchablePlanMetadata.getWorkerIdToOptionalSegmentsMap();
+      Map<Integer, Map<String, List<String>>> workerIdToOptionalTableSegmentsMap =
+          dispatchablePlanMetadata.getWorkerIdToOptionalTableSegmentsMap();
       Map<QueryServerInstance, List<Integer>> serverInstanceToWorkerIdsMap = new HashMap<>();
       WorkerMetadata[] workerMetadataArray = new WorkerMetadata[workerIdToServerInstanceMap.size()];
       for (Map.Entry<Integer, QueryServerInstance> serverEntry : workerIdToServerInstanceMap.entrySet()) {
@@ -165,9 +169,21 @@ public class DispatchablePlanContext {
         WorkerMetadata workerMetadata = new WorkerMetadata(workerId, workerIdToMailboxesMap.get(workerId));
         if (workerIdToSegmentsMap != null) {
           workerMetadata.setTableSegmentsMap(workerIdToSegmentsMap.get(workerId));
+          if (workerIdToOptionalSegmentsMap != null) {
+            Map<String, List<String>> optionalForWorker = workerIdToOptionalSegmentsMap.get(workerId);
+            if (optionalForWorker != null && !optionalForWorker.isEmpty()) {
+              workerMetadata.setOptionalTableSegmentsMap(optionalForWorker);
+            }
+          }
         }
         if (workerIdToTableNameSegmentsMap != null) {
           workerMetadata.setLogicalTableSegmentsMap(workerIdToTableNameSegmentsMap.get(workerId));
+          if (workerIdToOptionalTableSegmentsMap != null) {
+            Map<String, List<String>> optionalLogical = workerIdToOptionalTableSegmentsMap.get(workerId);
+            if (optionalLogical != null && !optionalLogical.isEmpty()) {
+              workerMetadata.setOptionalTableSegmentsMap(optionalLogical);
+            }
+          }
         }
         workerMetadataArray[workerId] = workerMetadata;
       }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/DispatchablePlanMetadata.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/DispatchablePlanMetadata.java
@@ -71,6 +71,9 @@ public class DispatchablePlanMetadata implements Serializable {
   // Available for leaf stage only
   // Map from workerId -> {tableType -> segments}
   private Map<Integer, Map<String, List<String>>> _workerIdToSegmentsMap;
+  // Map from workerId -> {tableType -> optional segments}, parallel to _workerIdToSegmentsMap when present
+  @Nullable
+  private Map<Integer, Map<String, List<String>>> _workerIdToOptionalSegmentsMap;
   // Map from tableType -> segments, available when 'is_replicated' hint is set to true
   private Map<String, List<String>> _replicatedSegments;
   private TimeBoundaryInfo _timeBoundaryInfo;
@@ -85,6 +88,8 @@ public class DispatchablePlanMetadata implements Serializable {
    * Map from workerId -> {physicalTableName -> segments} is required for logical tables.
    */
   private Map<Integer, Map<String, List<String>>> _workerIdToTableSegmentsMap;
+  @Nullable
+  private Map<Integer, Map<String, List<String>>> _workerIdToOptionalTableSegmentsMap;
   private LogicalTableRouteInfo _logicalTableRouteInfo;
 
   public List<String> getScannedTables() {
@@ -123,6 +128,16 @@ public class DispatchablePlanMetadata implements Serializable {
 
   public void setWorkerIdToSegmentsMap(Map<Integer, Map<String, List<String>>> workerIdToSegmentsMap) {
     _workerIdToSegmentsMap = workerIdToSegmentsMap;
+  }
+
+  @Nullable
+  public Map<Integer, Map<String, List<String>>> getWorkerIdToOptionalSegmentsMap() {
+    return _workerIdToOptionalSegmentsMap;
+  }
+
+  public void setWorkerIdToOptionalSegmentsMap(
+      @Nullable Map<Integer, Map<String, List<String>>> workerIdToOptionalSegmentsMap) {
+    _workerIdToOptionalSegmentsMap = workerIdToOptionalSegmentsMap;
   }
 
   @Nullable
@@ -203,5 +218,15 @@ public class DispatchablePlanMetadata implements Serializable {
   public void setWorkerIdToTableSegmentsMap(
       Map<Integer, Map<String, List<String>>> workerIdToTableSegmentsMap) {
     _workerIdToTableSegmentsMap = workerIdToTableSegmentsMap;
+  }
+
+  @Nullable
+  public Map<Integer, Map<String, List<String>>> getWorkerIdToOptionalTableSegmentsMap() {
+    return _workerIdToOptionalTableSegmentsMap;
+  }
+
+  public void setWorkerIdToOptionalTableSegmentsMap(
+      @Nullable Map<Integer, Map<String, List<String>>> workerIdToOptionalTableSegmentsMap) {
+    _workerIdToOptionalTableSegmentsMap = workerIdToOptionalTableSegmentsMap;
   }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerManager.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerManager.java
@@ -328,6 +328,7 @@ public class WorkerManager {
         }
         childMetadata.setWorkerIdToServerInstanceMap(childWorkerIdToServerInstanceMap);
         childMetadata.setWorkerIdToSegmentsMap(childWorkerIdToSegmentsMap);
+        attachReplicatedLeafOptionalSegments(childMetadata, context, childWorkerIdToServerInstanceMap);
       }
     }
 
@@ -530,8 +531,9 @@ public class WorkerManager {
     Preconditions.checkState(!routingTableMap.isEmpty(), "Unable to find routing entries for table: %s", tableName);
 
     // acquire time boundary info if it is a hybrid table.
+    TimeBoundaryInfo timeBoundaryInfo = null;
     if (routingTableMap.size() > 1) {
-      TimeBoundaryInfo timeBoundaryInfo = _routingManager.getTimeBoundaryInfo(
+      timeBoundaryInfo = _routingManager.getTimeBoundaryInfo(
           TableNameBuilder.OFFLINE.tableNameWithType(TableNameBuilder.extractRawTableName(tableName)));
       if (timeBoundaryInfo != null) {
         metadata.setTimeBoundaryInfo(timeBoundaryInfo);
@@ -543,6 +545,7 @@ public class WorkerManager {
 
     // extract all the instances associated to each table type
     Map<ServerInstance, Map<String, List<String>>> serverInstanceToSegmentsMap = new HashMap<>();
+    Map<ServerInstance, Map<String, List<String>>> serverInstanceToOptionalSegmentsMap = new HashMap<>();
     for (Map.Entry<String, RoutingTable> routingEntry : routingTableMap.entrySet()) {
       String tableType = routingEntry.getKey();
       RoutingTable routingTable = routingEntry.getValue();
@@ -551,9 +554,13 @@ public class WorkerManager {
       for (Map.Entry<ServerInstance, SegmentsToQuery> serverEntry : segmentsMap.entrySet()) {
         Map<String, List<String>> tableTypeToSegmentListMap =
             serverInstanceToSegmentsMap.computeIfAbsent(serverEntry.getKey(), k -> new HashMap<>());
-        // TODO: support optional segments for multi-stage engine.
         Preconditions.checkState(tableTypeToSegmentListMap.put(tableType, serverEntry.getValue().getSegments()) == null,
             "Entry for server {} and table type: {} already exist!", serverEntry.getKey(), tableType);
+        List<String> optionalSegments = serverEntry.getValue().getOptionalSegments();
+        if (CollectionUtils.isNotEmpty(optionalSegments)) {
+          serverInstanceToOptionalSegmentsMap.computeIfAbsent(serverEntry.getKey(), k -> new HashMap<>())
+              .put(tableType, new ArrayList<>(optionalSegments));
+        }
       }
 
       // attach unavailable segments to metadata
@@ -571,10 +578,17 @@ public class WorkerManager {
         new ArrayList<>(serverInstanceToSegmentsMap.entrySet());
     sortedServerInstanceToSegmentsMap.sort(Comparator.comparing(entry -> entry.getKey().getInstanceId()));
 
+    if (sortedServerInstanceToSegmentsMap.isEmpty()) {
+      assignNonPartitionedLeafWorkersWhenNoServersHaveSegments(metadata, tableName, routingTableMap, context,
+          timeBoundaryInfo);
+      return;
+    }
+
     // Assign 1 worker per server
     int numWorkers = sortedServerInstanceToSegmentsMap.size();
     Map<Integer, QueryServerInstance> workerIdToServerInstanceMap = Maps.newHashMapWithExpectedSize(numWorkers);
     Map<Integer, Map<String, List<String>>> workerIdToSegmentsMap = Maps.newHashMapWithExpectedSize(numWorkers);
+    Map<Integer, Map<String, List<String>>> workerIdToOptionalSegmentsMap = Maps.newHashMapWithExpectedSize(numWorkers);
 
     for (int workerId = 0; workerId < numWorkers; workerId++) {
       Map.Entry<ServerInstance, Map<String, List<String>>> serverEntry =
@@ -584,10 +598,52 @@ public class WorkerManager {
 
       workerIdToServerInstanceMap.put(workerId, server);
       workerIdToSegmentsMap.put(workerId, segmentsMap);
+      Map<String, List<String>> optionalForServer = serverInstanceToOptionalSegmentsMap.get(serverEntry.getKey());
+      if (MapUtils.isNotEmpty(optionalForServer)) {
+        workerIdToOptionalSegmentsMap.put(workerId, optionalForServer);
+      }
     }
 
     metadata.setWorkerIdToServerInstanceMap(workerIdToServerInstanceMap);
     metadata.setWorkerIdToSegmentsMap(workerIdToSegmentsMap);
+    if (!workerIdToOptionalSegmentsMap.isEmpty()) {
+      metadata.setWorkerIdToOptionalSegmentsMap(workerIdToOptionalSegmentsMap);
+    }
+  }
+
+  /**
+   * When routing returns no server-to-segment entries (e.g. empty table), still assign a leaf worker on a routable
+   * server with empty segment lists so the multi-stage leaf can return an empty v1 result.
+   */
+  private void assignNonPartitionedLeafWorkersWhenNoServersHaveSegments(DispatchablePlanMetadata metadata,
+      String tableName, Map<String, RoutingTable> routingTableMap, DispatchablePlanContext context,
+      @Nullable TimeBoundaryInfo timeBoundaryInfo) {
+    Map<String, ServerInstance> routableServers = _routingManager.getRoutableServerInstanceMap();
+    if (routableServers.isEmpty()) {
+      LOGGER.error("[RequestId: {}] No routable server for empty routing on table: {}", context.getRequestId(),
+          tableName);
+      throw new IllegalStateException("No routable server for empty routing on table: " + tableName);
+    }
+    List<String> sortedInstanceIds = new ArrayList<>(routableServers.keySet());
+    Collections.sort(sortedInstanceIds);
+    ServerInstance serverInstance = routableServers.get(sortedInstanceIds.get(0));
+    Map<String, List<String>> emptySegmentsMap = new HashMap<>();
+    for (String tableType : routingTableMap.keySet()) {
+      emptySegmentsMap.put(tableType, List.of());
+    }
+    if (emptySegmentsMap.isEmpty()) {
+      TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableName);
+      if (tableType != null) {
+        emptySegmentsMap.put(tableType.name(), List.of());
+      } else if (timeBoundaryInfo != null) {
+        emptySegmentsMap.put(TableType.OFFLINE.name(), List.of());
+        emptySegmentsMap.put(TableType.REALTIME.name(), List.of());
+      } else {
+        emptySegmentsMap.put(TableType.OFFLINE.name(), List.of());
+      }
+    }
+    metadata.setWorkerIdToServerInstanceMap(Map.of(0, new QueryServerInstance(serverInstance)));
+    metadata.setWorkerIdToSegmentsMap(Map.of(0, emptySegmentsMap));
   }
 
   /**
@@ -726,13 +782,20 @@ public class WorkerManager {
       }
     }
 
-    // TODO: Support unavailable segments and optional segments for replicated leaf stage
+    Map<String, RoutingTable> routingTableMap =
+        getRoutingTable(tableName, context.getRequestId(), context.getPlannerContext().getOptions());
+    for (Map.Entry<String, RoutingTable> routingEntry : routingTableMap.entrySet()) {
+      RoutingTable routingTable = routingEntry.getValue();
+      if (!routingTable.getUnavailableSegments().isEmpty()) {
+        metadata.addUnavailableSegments(tableName, routingTable.getUnavailableSegments());
+      }
+    }
+
     metadata.setReplicatedSegments(segmentsMap);
   }
 
   /**
    * Returns the segments for the given table, keyed by table type.
-   * TODO: It doesn't handle unavailable segments.
    */
   private Map<String, List<String>> getSegments(String tableName, Map<String, String> queryOptions) {
     String samplerName = MapUtils.isNotEmpty(queryOptions) ? QueryOptionsUtils.getTableSampler(queryOptions) : null;
@@ -796,20 +859,38 @@ public class WorkerManager {
     tableRouteProvider.calculateRoutes(logicalTableRouteInfo, _routingManager, offlineBrokerRequest,
         realtimeBrokerRequest, context.getRequestId());
 
+    if (logicalTableRouteInfo.getOfflineTables() != null) {
+      for (TableRouteInfo physicalTableRoute : logicalTableRouteInfo.getOfflineTables()) {
+        List<String> unavailable = physicalTableRoute.getUnavailableSegments();
+        if (CollectionUtils.isNotEmpty(unavailable)) {
+          metadata.addUnavailableSegments(physicalTableRoute.getOfflineTableName(), unavailable);
+        }
+      }
+    }
+    if (logicalTableRouteInfo.getRealtimeTables() != null) {
+      for (TableRouteInfo physicalTableRoute : logicalTableRouteInfo.getRealtimeTables()) {
+        List<String> unavailable = physicalTableRoute.getUnavailableSegments();
+        if (CollectionUtils.isNotEmpty(unavailable)) {
+          metadata.addUnavailableSegments(physicalTableRoute.getRealtimeTableName(), unavailable);
+        }
+      }
+    }
+
     assignTableSegmentsToWorkers(logicalTableRouteInfo, metadata);
   }
 
   private static void assignTableSegmentsToWorkers(LogicalTableRouteInfo logicalTableRouteInfo,
       DispatchablePlanMetadata metadata) {
-    Map<ServerInstance, Map<String, List<String>>> serverInstanceToLogicalSegmentsMap =
-        new HashMap<>();
+    Map<ServerInstance, Map<String, List<String>>> serverInstanceToLogicalSegmentsMap = new HashMap<>();
+    Map<ServerInstance, Map<String, List<String>>> serverInstanceToOptionalLogicalSegmentsMap = new HashMap<>();
 
     if (logicalTableRouteInfo.getOfflineTables() != null) {
       for (TableRouteInfo physicalTableRoute : logicalTableRouteInfo.getOfflineTables()) {
         // Routing table maybe null if no routing table is found OR there are no segments.
         if (physicalTableRoute.getOfflineRoutingTable() != null) {
           transferToServerInstanceLogicalSegmentsMap(physicalTableRoute.getOfflineTableName(),
-              physicalTableRoute.getOfflineRoutingTable(), serverInstanceToLogicalSegmentsMap);
+              physicalTableRoute.getOfflineRoutingTable(), serverInstanceToLogicalSegmentsMap,
+              serverInstanceToOptionalLogicalSegmentsMap);
         }
       }
     }
@@ -819,7 +900,8 @@ public class WorkerManager {
         // Routing table maybe null if no routing table is found OR there are no segments.
         if (physicalTableRoute.getRealtimeRoutingTable() != null) {
           transferToServerInstanceLogicalSegmentsMap(physicalTableRoute.getRealtimeTableName(),
-              physicalTableRoute.getRealtimeRoutingTable(), serverInstanceToLogicalSegmentsMap);
+              physicalTableRoute.getRealtimeRoutingTable(), serverInstanceToLogicalSegmentsMap,
+              serverInstanceToOptionalLogicalSegmentsMap);
         }
       }
     }
@@ -836,6 +918,8 @@ public class WorkerManager {
     Map<Integer, QueryServerInstance> workerIdToServerInstanceMap = Maps.newHashMapWithExpectedSize(numWorkers);
     Map<Integer, Map<String, List<String>>> workerIdToLogicalTableSegmentsMap =
         Maps.newHashMapWithExpectedSize(numWorkers);
+    Map<Integer, Map<String, List<String>>> workerIdToOptionalLogicalTableSegmentsMap =
+        Maps.newHashMapWithExpectedSize(numWorkers);
 
     for (int workerId = 0; workerId < numWorkers; workerId++) {
       Map.Entry<ServerInstance, Map<String, List<String>>> serverEntry =
@@ -845,22 +929,35 @@ public class WorkerManager {
 
       workerIdToServerInstanceMap.put(workerId, server);
       workerIdToLogicalTableSegmentsMap.put(workerId, segmentsMap);
+      Map<String, List<String>> optionalForServer =
+          serverInstanceToOptionalLogicalSegmentsMap.get(serverEntry.getKey());
+      if (MapUtils.isNotEmpty(optionalForServer)) {
+        workerIdToOptionalLogicalTableSegmentsMap.put(workerId, optionalForServer);
+      }
     }
 
     metadata.setWorkerIdToServerInstanceMap(workerIdToServerInstanceMap);
     metadata.setWorkerIdToTableSegmentsMap(workerIdToLogicalTableSegmentsMap);
+    if (!workerIdToOptionalLogicalTableSegmentsMap.isEmpty()) {
+      metadata.setWorkerIdToOptionalTableSegmentsMap(workerIdToOptionalLogicalTableSegmentsMap);
+    }
   }
 
   private static void transferToServerInstanceLogicalSegmentsMap(String physicalTableName,
       Map<ServerInstance, SegmentsToQuery> segmentsMap,
-      Map<ServerInstance, Map<String, List<String>>> serverInstanceToLogicalSegmentsMap) {
+      Map<ServerInstance, Map<String, List<String>>> serverInstanceToLogicalSegmentsMap,
+      Map<ServerInstance, Map<String, List<String>>> serverInstanceToOptionalLogicalSegmentsMap) {
     for (Map.Entry<ServerInstance, SegmentsToQuery> serverEntry : segmentsMap.entrySet()) {
       Map<String, List<String>> tableNameToSegmentsMap =
           serverInstanceToLogicalSegmentsMap.computeIfAbsent(serverEntry.getKey(), k -> new HashMap<>());
-      // TODO: support optional segments for multi-stage engine.
       Preconditions.checkState(
           tableNameToSegmentsMap.put(physicalTableName, serverEntry.getValue().getSegments()) == null,
           "Entry for server {} and physical table: {} already exist!", serverEntry.getKey(), physicalTableName);
+      List<String> optionalSegments = serverEntry.getValue().getOptionalSegments();
+      if (CollectionUtils.isNotEmpty(optionalSegments)) {
+        serverInstanceToOptionalLogicalSegmentsMap.computeIfAbsent(serverEntry.getKey(), k -> new HashMap<>())
+            .put(physicalTableName, new ArrayList<>(optionalSegments));
+      }
     }
   }
 
@@ -895,10 +992,12 @@ public class WorkerManager {
     Map<Integer, Map<String, List<String>>> workerIdToSegmentsMap = new HashMap<>();
     if (numPartitionsPerWorker == 1) {
       assignOnePartitionPerWorker(tableName, context.getRequestId(), partitionInfoMap,
-          _routingManager.getEnabledServerInstanceMap(), workedIdToServerInstanceMap, workerIdToSegmentsMap);
+          _routingManager.getEnabledServerInstanceMap(), workedIdToServerInstanceMap, workerIdToSegmentsMap,
+          metadata, partitionTableInfo);
     } else {
       assignMultiplePartitionsPerWorker(tableName, context.getRequestId(), numPartitionsPerWorker, partitionInfoMap,
-          _routingManager.getEnabledServerInstanceMap(), workedIdToServerInstanceMap, workerIdToSegmentsMap);
+          _routingManager.getEnabledServerInstanceMap(), workedIdToServerInstanceMap, workerIdToSegmentsMap,
+          metadata, partitionTableInfo);
     }
     metadata.setWorkerIdToServerInstanceMap(workedIdToServerInstanceMap);
     metadata.setWorkerIdToSegmentsMap(workerIdToSegmentsMap);
@@ -910,15 +1009,22 @@ public class WorkerManager {
   private void assignOnePartitionPerWorker(String tableName, long requestId, PartitionInfo[] partitionInfoMap,
       Map<String, ServerInstance> enabledServerInstanceMap,
       Map<Integer, QueryServerInstance> workedIdToServerInstanceMap,
-      Map<Integer, Map<String, List<String>>> workerIdToSegmentsMap) {
+      Map<Integer, Map<String, List<String>>> workerIdToSegmentsMap, DispatchablePlanMetadata metadata,
+      PartitionTableInfo partitionTableInfo) {
     int numPartitions = partitionInfoMap.length;
     int workerId = 0;
     for (int i = 0; i < numPartitions; i++) {
       PartitionInfo partitionInfo = partitionInfoMap[i];
-      // TODO: Currently we don't support the case when a partition doesn't contain any segment. The reason is that
-      //       the leaf stage won't be able to directly return empty response.
-      Preconditions.checkState(partitionInfo != null, "Failed to find any segment for table: %s, partition: %s",
-          tableName, i);
+      if (partitionInfo == null) {
+        ServerInstance serverInstance =
+            pickDeterministicEnabledServer(enabledServerInstanceMap, requestId + i);
+        Preconditions.checkState(serverInstance != null,
+            "No enabled server available for empty partition on table: %s, partition: %s", tableName, i);
+        workedIdToServerInstanceMap.put(workerId, new QueryServerInstance(serverInstance));
+        workerIdToSegmentsMap.put(workerId, emptyPartitionLeafSegmentsMap(metadata, partitionTableInfo));
+        workerId++;
+        continue;
+      }
       // NOTE: Pick worker based on the request id so that the same worker is picked across different table scan when
       //       the segments for the same partition is colocated
       ServerInstance serverInstance =
@@ -940,7 +1046,8 @@ public class WorkerManager {
   private void assignMultiplePartitionsPerWorker(String tableName, long requestId, int numPartitionsPerWorker,
       PartitionInfo[] partitionInfoMap, Map<String, ServerInstance> enabledServerInstanceMap,
       Map<Integer, QueryServerInstance> workedIdToServerInstanceMap,
-      Map<Integer, Map<String, List<String>>> workerIdToSegmentsMap) {
+      Map<Integer, Map<String, List<String>>> workerIdToSegmentsMap, DispatchablePlanMetadata metadata,
+      PartitionTableInfo partitionTableInfo) {
     int numPartitions = partitionInfoMap.length;
     assert numPartitions % numPartitionsPerWorker == 0;
     int numWorkers = numPartitions / numPartitionsPerWorker;
@@ -974,11 +1081,17 @@ public class WorkerManager {
           }
         }
       }
-      // TODO: Currently we don't support the case when all partitions for a worker don't contain any segment. The
-      //       reason is that the leaf stage won't be able to directly return empty response.
-      Preconditions.checkState(fullyReplicatedServers != null,
-          "Failed to find any segment for table: %s, worker: %s, partitions per worker: %s", tableName, i,
-          numPartitionsPerWorker);
+      if (fullyReplicatedServers == null) {
+        ServerInstance serverInstance =
+            pickDeterministicEnabledServer(enabledServerInstanceMap, requestId++);
+        Preconditions.checkState(serverInstance != null,
+            "No enabled server for empty partition group on table: %s, worker: %s, partitions per worker: %s",
+            tableName, i, numPartitionsPerWorker);
+        workedIdToServerInstanceMap.put(workerId, new QueryServerInstance(serverInstance));
+        workerIdToSegmentsMap.put(workerId, emptyPartitionLeafSegmentsMap(metadata, partitionTableInfo));
+        workerId++;
+        continue;
+      }
       // NOTE: Pick worker based on the request id so that the same worker is picked across different table scan when
       //       the segments for the same partition is colocated
       ServerInstance serverInstance = pickEnabledServer(fullyReplicatedServers, enabledServerInstanceMap, requestId++);
@@ -1186,6 +1299,79 @@ public class WorkerManager {
       _offlineSegments = offlineSegments;
       _realtimeSegments = realtimeSegments;
     }
+  }
+
+  private void attachReplicatedLeafOptionalSegments(DispatchablePlanMetadata childMetadata,
+      DispatchablePlanContext context, Map<Integer, QueryServerInstance> childWorkerIdToServerInstanceMap) {
+    List<String> scannedTables = childMetadata.getScannedTables();
+    if (scannedTables.isEmpty()) {
+      return;
+    }
+    String tableName = scannedTables.get(0);
+    Map<String, RoutingTable> routingTableMap =
+        getRoutingTable(tableName, context.getRequestId(), context.getPlannerContext().getOptions());
+    if (routingTableMap.size() > 1 && childMetadata.getTimeBoundaryInfo() == null) {
+      routingTableMap = new HashMap<>(routingTableMap);
+      routingTableMap.remove(TableType.OFFLINE.name());
+    }
+    Map<String, Map<String, List<String>>> optionalByInstanceId = new HashMap<>();
+    for (Map.Entry<String, RoutingTable> e : routingTableMap.entrySet()) {
+      String tableType = e.getKey();
+      Map<ServerInstance, SegmentsToQuery> sm = e.getValue().getServerInstanceToSegmentsMap();
+      for (Map.Entry<ServerInstance, SegmentsToQuery> se : sm.entrySet()) {
+        List<String> opt = se.getValue().getOptionalSegments();
+        if (CollectionUtils.isEmpty(opt)) {
+          continue;
+        }
+        optionalByInstanceId.computeIfAbsent(se.getKey().getInstanceId(), x -> new HashMap<>())
+            .put(tableType, new ArrayList<>(opt));
+      }
+    }
+    if (optionalByInstanceId.isEmpty()) {
+      return;
+    }
+    Map<Integer, Map<String, List<String>>> workerIdToOptional = new HashMap<>();
+    for (Map.Entry<Integer, QueryServerInstance> we : childWorkerIdToServerInstanceMap.entrySet()) {
+      Map<String, List<String>> opt = optionalByInstanceId.get(we.getValue().getInstanceId());
+      if (MapUtils.isNotEmpty(opt)) {
+        workerIdToOptional.put(we.getKey(), opt);
+      }
+    }
+    if (!workerIdToOptional.isEmpty()) {
+      childMetadata.setWorkerIdToOptionalSegmentsMap(workerIdToOptional);
+    }
+  }
+
+  private static Map<String, List<String>> emptyPartitionLeafSegmentsMap(DispatchablePlanMetadata metadata,
+      PartitionTableInfo partitionTableInfo) {
+    String scannedTable = metadata.getScannedTables().get(0);
+    if (partitionTableInfo._timeBoundaryInfo != null || metadata.getTimeBoundaryInfo() != null) {
+      return Map.of(TableType.OFFLINE.name(), List.of(), TableType.REALTIME.name(), List.of());
+    }
+    TableType tableType = TableNameBuilder.getTableTypeFromTableName(scannedTable);
+    if (tableType != null) {
+      return Map.of(tableType.name(), List.of());
+    }
+    return Map.of(TableType.OFFLINE.name(), List.of());
+  }
+
+  @Nullable
+  private static ServerInstance pickDeterministicEnabledServer(
+      Map<String, ServerInstance> enabledServerInstanceMap, long salt) {
+    if (enabledServerInstanceMap.isEmpty()) {
+      return null;
+    }
+    List<String> instanceIds = new ArrayList<>(enabledServerInstanceMap.keySet());
+    Collections.sort(instanceIds);
+    int n = instanceIds.size();
+    int start = (int) ((salt & Long.MAX_VALUE) % n);
+    for (int i = 0; i < n; i++) {
+      ServerInstance instance = enabledServerInstanceMap.get(instanceIds.get((start + i) % n));
+      if (instance != null) {
+        return instance;
+      }
+    }
+    return null;
   }
 
   /**

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerMetadata.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerMetadata.java
@@ -44,6 +44,7 @@ import org.apache.pinot.spi.utils.JsonUtils;
 public class WorkerMetadata {
   public static final String TABLE_SEGMENTS_MAP_KEY = "tableSegmentsMap";
   public static final String LOGICAL_TABLE_SEGMENTS_MAP_KEY = "logicalTableSegmentsMap";
+  public static final String OPTIONAL_TABLE_SEGMENTS_MAP_KEY = "optionalTableSegmentsMap";
 
   private final int _workerId;
   private final Map<Integer, MailboxInfos> _mailboxInfosMap;
@@ -96,6 +97,21 @@ public class WorkerMetadata {
   public boolean isLeafStageWorker() {
     return _customProperties.containsKey(TABLE_SEGMENTS_MAP_KEY)
         || _customProperties.containsKey(LOGICAL_TABLE_SEGMENTS_MAP_KEY);
+  }
+
+  @Nullable
+  public Map<String, List<String>> getOptionalTableSegmentsMap() {
+    return deserializeStringSegmentListMap(OPTIONAL_TABLE_SEGMENTS_MAP_KEY);
+  }
+
+  public void setOptionalTableSegmentsMap(Map<String, List<String>> optionalTableSegmentsMap) {
+    String json;
+    try {
+      json = JsonUtils.objectToString(optionalTableSegmentsMap);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException("Unable to serialize optional table segments map: " + optionalTableSegmentsMap, e);
+    }
+    _customProperties.put(OPTIONAL_TABLE_SEGMENTS_MAP_KEY, json);
   }
 
   public void setTableSegmentsMap(Map<String, List<String>> tableSegmentsMap) {

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/routing/WorkerManagerTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/routing/WorkerManagerTest.java
@@ -43,6 +43,7 @@ import org.apache.pinot.query.QueryEnvironment;
 import org.apache.pinot.query.planner.physical.DispatchablePlanFragment;
 import org.apache.pinot.query.planner.physical.DispatchableSubPlan;
 import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.utils.CommonConstants;
@@ -426,6 +427,58 @@ public class WorkerManagerTest {
       }
     }
     assertTrue(anyT1Server, "Expected at least one T1 server to be used");
+  }
+
+  @Test
+  public void testNonPartitionedLeafPropagatesOptionalSegmentsToWorkerMetadata() {
+    Schema schema = getSchemaBuilder("optTable").build();
+    ServerInstance server = getServerInstance("localhost", 1);
+    Map<String, ServerInstance> serverInstanceMap = Map.of(server.getInstanceId(), server);
+    List<String> optionalSegments = List.of("optionalSeg1");
+    RoutingTable routingTable = new RoutingTable(
+        Map.of(server, new SegmentsToQuery(List.of("requiredSeg1"), optionalSegments)), List.of(), 0);
+    CapturingRoutingManager routingManager = new CapturingRoutingManager(serverInstanceMap,
+        Map.of("optTable_OFFLINE", routingTable));
+
+    Map<String, String> tableNameMap = new HashMap<>();
+    tableNameMap.put("optTable_OFFLINE", "optTable_OFFLINE");
+    tableNameMap.put("optTable", "optTable");
+
+    TableCache tableCache = mock(TableCache.class);
+    when(tableCache.getTableNameMap()).thenReturn(tableNameMap);
+    when(tableCache.getActualTableName(anyString())).thenAnswer(inv -> tableNameMap.get(inv.getArgument(0)));
+    when(tableCache.getSchema(anyString())).thenReturn(schema);
+    when(tableCache.getTableConfig("optTable_OFFLINE")).thenReturn(mock(TableConfig.class));
+
+    WorkerManager workerManager = new WorkerManager("Broker_localhost", "localhost", 3, routingManager);
+    QueryEnvironment queryEnvironment = new QueryEnvironment(CommonConstants.DEFAULT_DATABASE, tableCache,
+        workerManager);
+
+    try (QueryEnvironment.CompiledQuery compiledQuery = queryEnvironment.compile("SELECT * FROM optTable")) {
+      DispatchableSubPlan plan = compiledQuery.planQuery(0).getQueryPlan();
+      assertNotNull(plan);
+      boolean foundOptional = false;
+      for (DispatchablePlanFragment fragment : plan.getQueryStageMap().values()) {
+        List<WorkerMetadata> workers = fragment.getWorkerMetadataList();
+        if (workers == null) {
+          continue;
+        }
+        for (WorkerMetadata worker : workers) {
+          if (!worker.isLeafStageWorker()) {
+            continue;
+          }
+          Map<String, List<String>> optionalMap = worker.getOptionalTableSegmentsMap();
+          if (optionalMap != null && optionalSegments.equals(optionalMap.get(TableType.OFFLINE.name()))) {
+            foundOptional = true;
+            break;
+          }
+        }
+        if (foundOptional) {
+          break;
+        }
+      }
+      assertTrue(foundOptional, "Leaf worker metadata should include optional segments from routing");
+    }
   }
 
   /**

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafOperator.java
@@ -527,7 +527,7 @@ public class LeafOperator extends MultiStageOperator {
       //       Propagate empty-but-typed non-selection results (e.g. zero-row aggregation) so pruned leaves still
       //       contribute schema upstream. For selection, require at least one row: an empty SelectionResultsBlock
       //       from the instance response is skipped so a mismatched block schema does not emit a spurious zero-row
-      //       data block before EOS (LeafOperatorTest#shouldNotErrorOutWhenIncorrectDataSchemaProvidedWithEmptyRowsSelection).
+      //       data block before EOS.
       BaseResultsBlock resultsBlock = instanceResponseBlock.getResultsBlock();
       boolean shouldAdd = resultsBlock != null && (resultsBlock.getNumRows() > 0
           || (resultsBlock.getDataSchema() != null && !(resultsBlock instanceof SelectionResultsBlock)));

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafOperator.java
@@ -524,9 +524,10 @@ public class LeafOperator extends MultiStageOperator {
       }
     } else {
       // NOTE: Instance response block might contain data (not metadata only) when all the segments are pruned.
-      //       Add the results block if it contains data.
+      //       Also propagate empty-but-typed results (e.g. zero-row selection) so partitioned or empty-segment leaves
+      //       contribute the correct schema upstream.
       BaseResultsBlock resultsBlock = instanceResponseBlock.getResultsBlock();
-      if (resultsBlock != null && resultsBlock.getNumRows() > 0) {
+      if (resultsBlock != null && (resultsBlock.getNumRows() > 0 || resultsBlock.getDataSchema() != null)) {
         try {
           addResultsBlock(resultsBlock);
         } catch (InterruptedException e) {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafOperator.java
@@ -524,10 +524,14 @@ public class LeafOperator extends MultiStageOperator {
       }
     } else {
       // NOTE: Instance response block might contain data (not metadata only) when all the segments are pruned.
-      //       Also propagate empty-but-typed results (e.g. zero-row selection) so partitioned or empty-segment leaves
-      //       contribute the correct schema upstream.
+      //       Propagate empty-but-typed non-selection results (e.g. zero-row aggregation) so pruned leaves still
+      //       contribute schema upstream. For selection, require at least one row: an empty SelectionResultsBlock
+      //       from the instance response is skipped so a mismatched block schema does not emit a spurious zero-row
+      //       data block before EOS (LeafOperatorTest#shouldNotErrorOutWhenIncorrectDataSchemaProvidedWithEmptyRowsSelection).
       BaseResultsBlock resultsBlock = instanceResponseBlock.getResultsBlock();
-      if (resultsBlock != null && (resultsBlock.getNumRows() > 0 || resultsBlock.getDataSchema() != null)) {
+      boolean shouldAdd = resultsBlock != null && (resultsBlock.getNumRows() > 0
+          || (resultsBlock.getDataSchema() != null && !(resultsBlock instanceof SelectionResultsBlock)));
+      if (shouldAdd) {
         try {
           addResultsBlock(resultsBlock);
         } catch (InterruptedException e) {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestUtils.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestUtils.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.function.BiConsumer;
 import javax.annotation.Nullable;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pinot.common.metrics.ServerMetrics;
@@ -162,12 +163,15 @@ public class ServerPlanRequestUtils {
     String rawTableName = TableNameBuilder.extractRawTableName(stageMetadata.getTableName());
     Map<String, List<String>> tableSegmentsMap = executionContext.getWorkerMetadata().getTableSegmentsMap();
     assert tableSegmentsMap != null;
+    Map<String, List<String>> optionalSegmentsMap =
+        executionContext.getWorkerMetadata().getOptionalTableSegmentsMap();
     TimeBoundaryInfo timeBoundary = stageMetadata.getTimeBoundary();
     int numRequests = tableSegmentsMap.size();
     if (numRequests == 1) {
       Map.Entry<String, List<String>> entry = tableSegmentsMap.entrySet().iterator().next();
       String tableType = entry.getKey();
       List<String> segments = entry.getValue();
+      List<String> optionalSegments = optionalListOrNull(optionalSegmentsMap, tableType);
       if (tableType.equals(TableType.OFFLINE.name())) {
         String offlineTableName = TableNameBuilder.forType(TableType.OFFLINE).tableNameWithType(rawTableName);
         TableDataManager tableDataManager = instanceDataManager.getTableDataManager(offlineTableName);
@@ -176,7 +180,7 @@ public class ServerPlanRequestUtils {
         Pair<TableConfig, Schema> tableConfigAndSchema = tableDataManager.getCachedTableConfigAndSchema();
         return List.of(compileInstanceRequest(executionContext, pinotQuery, timeBoundary, TableType.OFFLINE,
             tableDataManager.getTableName(), tableConfigAndSchema.getLeft(), tableConfigAndSchema.getRight(), segments,
-            null));
+            optionalSegments, null));
       } else {
         assert tableType.equals(TableType.REALTIME.name());
         String realtimeTableName = TableNameBuilder.forType(TableType.REALTIME).tableNameWithType(rawTableName);
@@ -186,13 +190,15 @@ public class ServerPlanRequestUtils {
         Pair<TableConfig, Schema> tableConfigAndSchema = tableDataManager.getCachedTableConfigAndSchema();
         return List.of(compileInstanceRequest(executionContext, pinotQuery, timeBoundary, TableType.REALTIME,
             tableDataManager.getTableName(), tableConfigAndSchema.getLeft(), tableConfigAndSchema.getRight(), segments,
-            null));
+            optionalSegments, null));
       }
     } else {
       assert numRequests == 2;
       List<String> offlineSegments = tableSegmentsMap.get(TableType.OFFLINE.name());
       List<String> realtimeSegments = tableSegmentsMap.get(TableType.REALTIME.name());
       assert offlineSegments != null && realtimeSegments != null;
+      List<String> offlineOptional = optionalListOrNull(optionalSegmentsMap, TableType.OFFLINE.name());
+      List<String> realtimeOptional = optionalListOrNull(optionalSegmentsMap, TableType.REALTIME.name());
       String offlineTableName = TableNameBuilder.forType(TableType.OFFLINE).tableNameWithType(rawTableName);
       TableDataManager offlineTableDataManager = instanceDataManager.getTableDataManager(offlineTableName);
       Preconditions.checkState(offlineTableDataManager != null, "Failed to find data manager for table: %s",
@@ -208,11 +214,21 @@ public class ServerPlanRequestUtils {
       return List.of(
           compileInstanceRequest(executionContext, new PinotQuery(pinotQuery), timeBoundary, TableType.OFFLINE,
               offlineTableDataManager.getTableName(), offlineTableConfigAndSchema.getLeft(),
-              offlineTableConfigAndSchema.getRight(), offlineSegments, null),
+              offlineTableConfigAndSchema.getRight(), offlineSegments, offlineOptional, null),
           compileInstanceRequest(executionContext, pinotQuery, timeBoundary, TableType.REALTIME,
               realtimeTableDataManager.getTableName(), realtimeTableConfigAndSchema.getLeft(),
-              realtimeTableConfigAndSchema.getRight(), realtimeSegments, null));
+              realtimeTableConfigAndSchema.getRight(), realtimeSegments, realtimeOptional, null));
     }
+  }
+
+  @Nullable
+  private static List<String> optionalListOrNull(@Nullable Map<String, List<String>> optionalSegmentsMap,
+      String tableTypeKey) {
+    if (optionalSegmentsMap == null) {
+      return null;
+    }
+    List<String> list = optionalSegmentsMap.get(tableTypeKey);
+    return CollectionUtils.isEmpty(list) ? null : list;
   }
 
   /**
@@ -221,7 +237,7 @@ public class ServerPlanRequestUtils {
   private static InstanceRequest compileInstanceRequest(OpChainExecutionContext executionContext, PinotQuery pinotQuery,
       @Nullable TimeBoundaryInfo timeBoundaryInfo, TableType tableType,
       String tableNameWithType, TableConfig tableConfig, Schema schema, @Nullable List<String> segmentList,
-      @Nullable List<TableSegmentsInfo> tableRouteInfoList) {
+      @Nullable List<String> optionalSegmentList, @Nullable List<TableSegmentsInfo> tableRouteInfoList) {
     Preconditions.checkArgument(segmentList == null || tableRouteInfoList == null,
         "Either segmentList OR tableRouteInfoList should be set");
 
@@ -265,6 +281,9 @@ public class ServerPlanRequestUtils {
       instanceRequest.setSearchSegments(segmentList);
     } else {
       instanceRequest.setTableSegmentsInfoList(tableRouteInfoList);
+    }
+    if (CollectionUtils.isNotEmpty(optionalSegmentList)) {
+      instanceRequest.setOptionalSegments(optionalSegmentList);
     }
     instanceRequest.setQuery(brokerRequest);
 
@@ -432,6 +451,8 @@ public class ServerPlanRequestUtils {
 
     Map<String, List<String>> logicalTableSegmentsMap =
         executionContext.getWorkerMetadata().getLogicalTableSegmentsMap();
+    Map<String, List<String>> optionalLogicalTableSegmentsMap =
+        executionContext.getWorkerMetadata().getOptionalTableSegmentsMap();
     List<TableSegmentsInfo> offlineTableRouteInfoList = new ArrayList<>();
     List<TableSegmentsInfo> realtimeTableRouteInfoList = new ArrayList<>();
 
@@ -442,6 +463,12 @@ public class ServerPlanRequestUtils {
       TableSegmentsInfo tableSegmentsInfo = new TableSegmentsInfo();
       tableSegmentsInfo.setTableName(physicalTableName);
       tableSegmentsInfo.setSegments(entry.getValue());
+      if (optionalLogicalTableSegmentsMap != null) {
+        List<String> optionalSegments = optionalLogicalTableSegmentsMap.get(physicalTableName);
+        if (CollectionUtils.isNotEmpty(optionalSegments)) {
+          tableSegmentsInfo.setOptionalSegments(new ArrayList<>(optionalSegments));
+        }
+      }
       if (tableType == TableType.REALTIME) {
         realtimeTableRouteInfoList.add(tableSegmentsInfo);
       } else {
@@ -461,14 +488,14 @@ public class ServerPlanRequestUtils {
         return List.of(
             compileInstanceRequest(executionContext, pinotQuery, timeBoundaryInfo, TableType.OFFLINE, offlineTableName,
                 logicalTableContext.getRefOfflineTableConfig(), logicalTableContext.getLogicalTableSchema(), null,
-                routeInfoList));
+                null, routeInfoList));
       } else {
         Preconditions.checkNotNull(logicalTableContext.getRefRealtimeTableConfig());
         String realtimeTableName = TableNameBuilder.forType(TableType.REALTIME).tableNameWithType(logicalTableName);
         return List.of(
             compileInstanceRequest(executionContext, pinotQuery, timeBoundaryInfo, TableType.REALTIME,
                 realtimeTableName, logicalTableContext.getRefRealtimeTableConfig(),
-                logicalTableContext.getLogicalTableSchema(), null, routeInfoList));
+                logicalTableContext.getLogicalTableSchema(), null, null, routeInfoList));
       }
     } else {
       Preconditions.checkNotNull(logicalTableContext.getRefOfflineTableConfig());
@@ -480,10 +507,10 @@ public class ServerPlanRequestUtils {
       return List.of(
           compileInstanceRequest(executionContext, offlinePinotQuery, timeBoundaryInfo, TableType.OFFLINE,
               offlineTableName, logicalTableContext.getRefOfflineTableConfig(),
-              logicalTableContext.getLogicalTableSchema(), null, offlineTableRouteInfoList),
+              logicalTableContext.getLogicalTableSchema(), null, null, offlineTableRouteInfoList),
           compileInstanceRequest(executionContext, realtimePinotQuery, timeBoundaryInfo, TableType.REALTIME,
               realtimeTableName, logicalTableContext.getRefRealtimeTableConfig(),
-              logicalTableContext.getLogicalTableSchema(), null, realtimeTableRouteInfoList));
+              logicalTableContext.getLogicalTableSchema(), null, null, realtimeTableRouteInfoList));
     }
   }
 }


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Flow of optional segments from routing to instance request in multi\-stage leaf planning\.

```mermaid
flowchart TD
  N0["Extract optional segments per server instance #40;F3#41;"]:::stAdded
  N1["Build worker#45;optional segments map and set in metadata #40;F3#41;"]:::stAdded
  N2["Retrieve optional segments from metadata and set in worker metadata #40;F1#41;"]:::stAdded
  N3["Get optional segments from worker metadata and set in instance request #40;F6#41;"]:::stAdded
  N0 -->|"per#45;server#45;instance optional segments map used to build#45;work"| N1
  N1 -->|"metadata#39;s workerIdToOptionalSegmentsMap read by context"| N2
  N2 -->|"worker metadata#39;s optional table segments map read by req"| N3
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-query\-planner/src/main/java/org/apache/pinot/query/planner/physical/DispatchablePlanContext\.java — [before](https://github.com/apache/pinot/blob/a4bef7bc7c31dda01773e9255deb6f9145d6e303/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/DispatchablePlanContext.java) · [after](https://github.com/apache/pinot/blob/b46a4edeb9760b1f08cae6127be992582081ceb2/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/DispatchablePlanContext.java)
- F3: pinot\-query\-planner/src/main/java/org/apache/pinot/query/routing/WorkerManager\.java — [before](https://github.com/apache/pinot/blob/a4bef7bc7c31dda01773e9255deb6f9145d6e303/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerManager.java) · [after](https://github.com/apache/pinot/blob/b46a4edeb9760b1f08cae6127be992582081ceb2/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerManager.java)
- F6: pinot\-query\-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestUtils\.java — [before](https://github.com/apache/pinot/blob/a4bef7bc7c31dda01773e9255deb6f9145d6e303/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestUtils.java) · [after](https://github.com/apache/pinot/blob/b46a4edeb9760b1f08cae6127be992582081ceb2/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestUtils.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImE0YmVmN2JjN2MzMWRkYTAxNzczZTkyNTVkZWI2ZjkxNDVkNmUzMDMiLCJjb250ZXh0X2hhc2giOiIzOWIzN2MyNTcyMWQwNjQ1OGRjOTUyYzQ0NWI1MmU2YmFhMDAwZWNhM2Y2ZmIzMDc2YzZkYzBkNzAzN2Q2NGI5IiwiZ2VuZXJhdGVkX2F0IjoxNzkwMDUxNjg5LCJoZWFkX3NoYSI6ImI0NmE0ZWRlYjk3NjBiMWYwOGNhZTYxMjdiZTk5MjU4MjA4MWNlYjIiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJiODhmNjJmNWIwOWQ3NmMwM2UxOWFiYjQ3ZTYyOTE3YjM1Y2VmYTVmIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature e485a656f631334fe54e4dbe00ab680677efbd21b905626f2f2bf6b9002d7531 -->
<!-- pinot-pr-flow:end -->

Fixes #18223

### Summary 
Multi-stage query planning used to ignore or mishandle a few real-world routing situations: optional segments (segments the broker may still send so servers can decide what to do), unavailable segments (known missing pieces of the table), partitions with no data, and workers that end up with no segments at all. 

### What changed 
The planner now carries optional segments per worker, records unavailable segments in metadata when routing provides them, and handles empty partitions and empty routing by assigning a worker with empty segment lists instead of failing. Dispatch sends optional segments on leaf requests, and the leaf operator forwards empty results that still have a schema so later stages stay consistent.

### Test Plan
Added unit tests