### PR TITLE
Use Boolean and List for ORCRecordReader boolean and list columns

### DIFF
--- a/pinot-plugins/pinot-input-format/pinot-orc/src/main/java/org/apache/pinot/plugin/inputformat/orc/ORCRecordExtractor.java
+++ b/pinot-plugins/pinot-input-format/pinot-orc/src/main/java/org/apache/pinot/plugin/inputformat/orc/ORCRecordExtractor.java
@@ -21,6 +21,7 @@ package org.apache.pinot.plugin.inputformat.orc;
 import com.google.common.collect.Maps;
 import java.sql.Timestamp;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -59,7 +60,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 /// - `BINARY` → `byte[]`
 /// - `DATE` → [LocalDate] via [LocalDate#ofEpochDay] (TZ-independent, calendar-date semantics)
 /// - `TIMESTAMP` / `TIMESTAMP_INSTANT` → [Timestamp] preserving full sub-second nanos from [TimestampColumnVector]
-/// - `LIST<X>` → `Object[]` (null elements preserved; empty list surfaces as empty `Object[]`)
+/// - `LIST<X>` → `List<Object>` (null elements preserved; empty list surfaces as an empty list)
 /// - `MAP<K, V>` → `Map<Object, Object>`
 /// - `STRUCT<...>` → `Map<String, Object>`
 /// - any nullable column with `isNull[rowId]` set → `null`
@@ -140,9 +141,9 @@ public class ORCRecordExtractor extends BaseRecordExtractor<ORCRecordExtractor.R
         ListColumnVector listColumnVector = (ListColumnVector) columnVector;
         int offset = (int) listColumnVector.offsets[rowId];
         int length = (int) listColumnVector.lengths[rowId];
-        Object[] values = new Object[length];
+        List<Object> values = new ArrayList<>(length);
         for (int j = 0; j < length; j++) {
-          values[j] = extractValue(field, listColumnVector.child, childType, offset + j);
+          values.add(extractValue(field, listColumnVector.child, childType, offset + j));
         }
         return values;
       }
@@ -191,7 +192,8 @@ public class ORCRecordExtractor extends BaseRecordExtractor<ORCRecordExtractor.R
       TypeDescription.Category category) {
     switch (category) {
       case BOOLEAN:
-        return ((LongColumnVector) columnVector).vector[rowId] == 1;
+        // ORC booleans are stored in a LongColumnVector as 0 / 1.
+        return Boolean.valueOf(((LongColumnVector) columnVector).vector[rowId] != 0);
       case BYTE:
       case SHORT:
       case INT:

--- a/pinot-plugins/pinot-input-format/pinot-orc/src/test/java/org/apache/pinot/plugin/inputformat/orc/ORCRecordExtractorTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-orc/src/test/java/org/apache/pinot/plugin/inputformat/orc/ORCRecordExtractorTest.java
@@ -21,6 +21,8 @@ package org.apache.pinot.plugin.inputformat.orc;
 import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Consumer;
 import org.apache.hadoop.hive.common.type.HiveDecimal;
@@ -167,9 +169,10 @@ public class ORCRecordExtractorTest {
 
   // === Complex types ===
 
-  @Test
-  public void testListOfIntsExtractedAsArray() {
-    Object[] result = (Object[]) extract("array<int>", batch -> {
+   @Test
+   public void testListOfIntsExtractedAsList() {
+    @SuppressWarnings("unchecked")
+    List<Object> result = (List<Object>) extract("array<int>", batch -> {
       ListColumnVector list = (ListColumnVector) batch.cols[0];
       LongColumnVector child = (LongColumnVector) list.child;
       child.ensureSize(3, false);
@@ -179,13 +182,14 @@ public class ORCRecordExtractorTest {
       child.vector[1] = 20;
       child.vector[2] = 30;
     });
-    assertEquals(result, new Object[]{10, 20, 30});
+    assertEquals(result, List.of(10, 20, 30));
   }
 
   @Test
   public void testListPreservesNullElements() {
-    // The contract requires multi-value shape preservation: null elements stay null in `Object[]`.
-    Object[] result = (Object[]) extract("array<int>", batch -> {
+    // Null elements stay null in the returned list (`List.of` cannot express this).
+    @SuppressWarnings("unchecked")
+    List<Object> result = (List<Object>) extract("array<int>", batch -> {
       ListColumnVector list = (ListColumnVector) batch.cols[0];
       LongColumnVector child = (LongColumnVector) list.child;
       child.ensureSize(3, false);
@@ -196,18 +200,18 @@ public class ORCRecordExtractorTest {
       child.vector[0] = 10;
       child.vector[2] = 30;
     });
-    assertEquals(result, new Object[]{10, null, 30});
+    assertEquals(result, Arrays.asList(10, null, 30));
   }
 
   @Test
-  public void testEmptyListExtractedAsEmptyArray() {
-    // The contract requires shape preservation: an empty list surfaces as an empty `Object[]`, not `null`.
-    Object[] result = (Object[]) extract("array<int>", batch -> {
+  public void testEmptyListExtractedAsEmptyList() {
+    @SuppressWarnings("unchecked")
+    List<Object> result = (List<Object>) extract("array<int>", batch -> {
       ListColumnVector list = (ListColumnVector) batch.cols[0];
       list.offsets[0] = 0;
       list.lengths[0] = 0;
     });
-    assertEquals(result, new Object[]{});
+    assertEquals(result, List.of());
   }
 
   @Test

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
@@ -117,6 +117,7 @@ import org.apache.pinot.spi.data.MetricFieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.PrimaryKey;
+import org.apache.pinot.spi.data.readers.RecordReaderUtils;
 import org.apache.pinot.spi.stream.StreamMessageMetadata;
 import org.apache.pinot.spi.utils.BooleanUtils;
 import org.apache.pinot.spi.utils.ByteArray;
@@ -831,7 +832,7 @@ public class MutableSegmentImpl implements MutableSegment {
         continue;
       }
 
-      Object[] values = (Object[]) row.getValue(entry.getKey());
+      Object[] values = RecordReaderUtils.toObjectArray(row.getValue(entry.getKey()));
       // Note that max chunk capacity is derived from "FixedByteMVMutableForwardIndex._maxNumberOfMultiValuesPerRow"
       // which is set to "1000" in "ForwardIndexType.MAX_MULTI_VALUES_PER_ROW". If the number of values in the
       // multi-value entry that we are attempting to ingest is greater than the maximum accepted value, we throw an
@@ -859,7 +860,7 @@ public class MutableSegmentImpl implements MutableSegment {
         if (indexContainer._fieldSpec.isSingleValueField()) {
           indexContainer._dictId = dictionary.index(value);
         } else {
-          indexContainer._dictIds = dictionary.index((Object[]) value);
+          indexContainer._dictIds = dictionary.index(RecordReaderUtils.toObjectArray(value));
         }
 
         // Update min/max value from dictionary
@@ -989,7 +990,7 @@ public class MutableSegmentImpl implements MutableSegment {
 
         int[] dictIds = indexContainer._dictIds;
         indexContainer._valuesInfo.updateVarByteMVMaxRowLengthInBytes(value, dataType.getStoredType());
-        Object[] values = (Object[]) value;
+        Object[] values = RecordReaderUtils.toObjectArray(value);
         for (Map.Entry<IndexType, MutableIndex> indexEntry : indexContainer._mutableIndexes.entrySet()) {
           try {
             MutableIndex mutableIndex = indexEntry.getValue();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/SpecialValueTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/SpecialValueTransformer.java
@@ -19,11 +19,13 @@
 package org.apache.pinot.segment.local.recordtransformer;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import org.apache.pinot.segment.local.utils.SpecialValueTransformerUtils;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.data.readers.RecordReaderUtils;
 import org.apache.pinot.spi.recordtransformer.RecordTransformer;
 
 
@@ -78,6 +80,10 @@ public class SpecialValueTransformer implements RecordTransformer {
         if (transformedValues != value) {
           record.putValue(column, transformedValues);
         }
+      } else if (value instanceof List) {
+        Object[] values = RecordReaderUtils.toObjectArray(value);
+        Object[] transformedValues = SpecialValueTransformerUtils.transformValues(values);
+        record.putValue(column, transformedValues);
       } else if (value != null) {
         // Single-valued column.
         Object transformedValue = SpecialValueTransformerUtils.transformValue(value);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -30,6 +30,7 @@ import org.apache.pinot.segment.spi.index.IndexCreator;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.readers.ColumnReader;
 import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.data.readers.RecordReaderUtils;
 import org.roaringbitmap.RoaringBitmap;
 
 
@@ -60,7 +61,7 @@ public class SegmentColumnarIndexCreator extends BaseSegmentCreator {
         if (fieldSpec.isSingleValueField()) {
           indexSingleValueRow(dictionaryCreator, columnValueToIndex, creatorsByIndex);
         } else {
-          indexMultiValueRow(dictionaryCreator, (Object[]) columnValueToIndex, creatorsByIndex);
+          indexMultiValueRow(dictionaryCreator, RecordReaderUtils.toObjectArray(columnValueToIndex), creatorsByIndex);
         }
       } catch (JsonParseException jpe) {
         throw new ColumnJsonParserException(columnName, jpe);
@@ -172,7 +173,8 @@ public class SegmentColumnarIndexCreator extends BaseSegmentCreator {
         if (fieldSpec.isSingleValueField()) {
           indexSingleValueRow(dictionaryCreator, reuseColumnValueToIndex, creatorsByIndex);
         } else {
-          indexMultiValueRow(dictionaryCreator, (Object[]) reuseColumnValueToIndex, creatorsByIndex);
+          indexMultiValueRow(dictionaryCreator, RecordReaderUtils.toObjectArray(reuseColumnValueToIndex),
+              creatorsByIndex);
         }
       } catch (JsonParseException jpe) {
         throw new ColumnJsonParserException(columnName, jpe);
@@ -197,7 +199,7 @@ public class SegmentColumnarIndexCreator extends BaseSegmentCreator {
     if (fieldSpec.isSingleValueField()) {
       indexSingleValueRow(dictionaryCreator, columnValueToIndex, creatorsByIndex);
     } else {
-      indexMultiValueRow(dictionaryCreator, (Object[]) columnValueToIndex, creatorsByIndex);
+      indexMultiValueRow(dictionaryCreator, RecordReaderUtils.toObjectArray(columnValueToIndex), creatorsByIndex);
     }
 
     if (nullVec != null) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/SegmentPreIndexStatsCollectorImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/SegmentPreIndexStatsCollectorImpl.java
@@ -20,6 +20,7 @@ package org.apache.pinot.segment.local.segment.creator.impl.stats;
 
 import com.google.common.collect.Maps;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 import org.apache.pinot.segment.spi.creator.ColumnStatistics;
 import org.apache.pinot.segment.spi.creator.SegmentPreIndexStatsCollector;
@@ -29,6 +30,7 @@ import org.apache.pinot.segment.spi.index.FieldIndexConfigsUtil;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.data.readers.RecordReaderUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -85,10 +87,16 @@ public class SegmentPreIndexStatsCollectorImpl implements SegmentPreIndexStatsCo
 
   @Override
   public void collectRow(GenericRow row) {
+    Schema schema = _statsCollectorConfig.getSchema();
     for (Map.Entry<String, ColumnStatistics> entry : _columnStatisticsMap.entrySet()) {
       String column = entry.getKey();
       ColumnStatistics columnStatistics = entry.getValue();
-      ((AbstractColumnStatisticsCollector) columnStatistics).collect(row.getValue(column));
+      Object value = row.getValue(column);
+      FieldSpec fieldSpec = schema.getFieldSpecFor(column);
+      if (!fieldSpec.isSingleValueField() && value instanceof List) {
+        value = RecordReaderUtils.toObjectArray(value);
+      }
+      ((AbstractColumnStatisticsCollector) columnStatistics).collect(value);
     }
     _totalDocCount++;
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/RecordReaderUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/RecordReaderUtils.java
@@ -29,6 +29,7 @@ import java.io.RandomAccessFile;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
+import java.util.List;
 import java.util.zip.GZIPInputStream;
 
 
@@ -87,5 +88,20 @@ public class RecordReaderUtils {
       magic = raf.read() & 0xff | ((raf.read() << 8) & 0xff00);
     }
     return magic == GZIPInputStream.GZIP_MAGIC;
+  }
+
+  /**
+   * Normalizes a multi-value column read from a {@link RecordReader} to {@code Object[]}. Most readers already
+   * return {@code Object[]}; some (e.g. ORC {@code LIST}) return a {@link List}.
+   */
+  public static Object[] toObjectArray(Object multiValue) {
+    if (multiValue instanceof Object[]) {
+      return (Object[]) multiValue;
+    }
+    if (multiValue instanceof List) {
+      return ((List<?>) multiValue).toArray();
+    }
+    throw new IllegalArgumentException(
+        "Multi-value column must be Object[] or List, got: " + multiValue.getClass().getName());
   }
 }

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/data/readers/AbstractRecordReaderTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/data/readers/AbstractRecordReaderTest.java
@@ -123,9 +123,11 @@ public abstract class AbstractRecordReaderTest {
         if (fieldSpec.isSingleValueField()) {
           assertValueEquals(actualRecord.getValue(fieldSpecName), expectedRecord.get(fieldSpecName));
         } else {
-          Object[] actualRecords = (Object[]) actualRecord.getValue(fieldSpecName);
-          List expectedRecords = (List) expectedRecord.get(fieldSpecName);
+          List<?> expectedRecords = (List<?>) expectedRecord.get(fieldSpecName);
           if (expectedRecords != null) {
+            Object actualMv = actualRecord.getValue(fieldSpecName);
+            Assert.assertNotNull(actualMv, "Multi-value column " + fieldSpecName + " is null but expected non-null");
+            Object[] actualRecords = RecordReaderUtils.toObjectArray(actualMv);
             Assert.assertEquals(actualRecords.length, expectedRecords.size());
             for (int j = 0; j < actualRecords.length; j++) {
               assertValueEquals(actualRecords[j], expectedRecords.get(j));


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

ORC extractor yields Boolean/List; downstream code converts List to Object\[\] via RecordReaderUtils

```mermaid
flowchart TD
  N0["ORCRecordExtractor returns Boolean#47;List #40;F1#41;"]:::stModified
  N1["MutableSegmentImpl processes MV #40;F2#41;"]:::stModified
  N2["SpecialValueTransformer handles List #40;F3#41;"]:::stModified
  N3["SegmentColumnarIndexCreator indexes MV #40;F4#41;"]:::stModified
  N4["SegmentPreIndexStatsCollector processes MV #40;F5#41;"]:::stModified
  N5["RecordReaderUtils#46;toObjectArray normalizes #40;F6#41;"]:::stModified
  N0 -->|"value used"| N1
  N0 -->|"value used"| N2
  N0 -->|"value used"| N3
  N0 -->|"value used"| N4
  N1 -->|"calls toObjectArray"| N5
  N2 -->|"calls toObjectArray"| N5
  N3 -->|"calls toObjectArray"| N5
  N4 -->|"calls toObjectArray"| N5
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-plugins/pinot\-input\-format/pinot\-orc/src/main/java/org/apache/pinot/plugin/inputformat/orc/ORCRecordExtractor\.java — [before](https://github.com/apache/pinot/blob/a4bef7bc7c31dda01773e9255deb6f9145d6e303/pinot-plugins/pinot-input-format/pinot-orc/src/main/java/org/apache/pinot/plugin/inputformat/orc/ORCRecordExtractor.java) · [after](https://github.com/apache/pinot/blob/bc30d8c5bc13ec38e705bfd8cc8d1c216610c8a3/pinot-plugins/pinot-input-format/pinot-orc/src/main/java/org/apache/pinot/plugin/inputformat/orc/ORCRecordExtractor.java)
- F2: pinot\-segment\-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl\.java — [before](https://github.com/apache/pinot/blob/a4bef7bc7c31dda01773e9255deb6f9145d6e303/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java) · [after](https://github.com/apache/pinot/blob/bc30d8c5bc13ec38e705bfd8cc8d1c216610c8a3/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java)
- F3: pinot\-segment\-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/SpecialValueTransformer\.java — [before](https://github.com/apache/pinot/blob/a4bef7bc7c31dda01773e9255deb6f9145d6e303/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/SpecialValueTransformer.java) · [after](https://github.com/apache/pinot/blob/bc30d8c5bc13ec38e705bfd8cc8d1c216610c8a3/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/SpecialValueTransformer.java)
- F4: pinot\-segment\-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator\.java — [before](https://github.com/apache/pinot/blob/a4bef7bc7c31dda01773e9255deb6f9145d6e303/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java) · [after](https://github.com/apache/pinot/blob/bc30d8c5bc13ec38e705bfd8cc8d1c216610c8a3/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java)
- F5: pinot\-segment\-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/SegmentPreIndexStatsCollectorImpl\.java — [before](https://github.com/apache/pinot/blob/a4bef7bc7c31dda01773e9255deb6f9145d6e303/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/SegmentPreIndexStatsCollectorImpl.java) · [after](https://github.com/apache/pinot/blob/bc30d8c5bc13ec38e705bfd8cc8d1c216610c8a3/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/SegmentPreIndexStatsCollectorImpl.java)
- F6: pinot\-spi/src/main/java/org/apache/pinot/spi/data/readers/RecordReaderUtils\.java — [before](https://github.com/apache/pinot/blob/a4bef7bc7c31dda01773e9255deb6f9145d6e303/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/RecordReaderUtils.java) · [after](https://github.com/apache/pinot/blob/bc30d8c5bc13ec38e705bfd8cc8d1c216610c8a3/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/RecordReaderUtils.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImE0YmVmN2JjN2MzMWRkYTAxNzczZTkyNTVkZWI2ZjkxNDVkNmUzMDMiLCJjb250ZXh0X2hhc2giOiI1ZWI5NDM0NmQ1YmI5YjI0YjFmMGQ2MGYyZDAxMWVjNDA0ZmY4M2MxNGM1NzMxNDMxZmEwNGY3NGJlNDEzNzgwIiwiZ2VuZXJhdGVkX2F0IjoxNzkwMDcxMTcwLCJoZWFkX3NoYSI6ImJjMzBkOGM1YmMxM2VjMzhlNzA1YmZkOGNjOGQxYzIxNjYxMGM4YTMiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJiODhmNjJmNWIwOWQ3NmMwM2UxOWFiYjQ3ZTYyOTE3YjM1Y2VmYTVmIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 241f36af89832c034d252e26429320fa047dc5735408b7b4d308e170aef4d1b6 -->
<!-- pinot-pr-flow:end -->

Fixed #18222

### Summary
ORC rows are built by `ORCRecordExtractor` (the reader only reads the file and calls the extractor). This change makes common types match what users expect:
- Boolean columns are exposed as Boolean, not as a string.
- List / array columns are exposed as List, not as Object[]. Empty lists stay as empty lists; null entries inside a list are still null.

Segment building and tests already assumed multi-value fields as `Object[]` in many places. Those paths now accept `List `as well (via `RecordReaderUtils.toObjectArray` and small updates in stats collection and special-value handling), so ORC ingestion keeps working.

### Test Plan
Unit tests are updated so the exact Java types for boolean and list extraction are checked, including empty lists and null list elements.