### PR TITLE
Remove deprecated field segmentAssignmentStrategy in SegmentsValidationAndRetentionConfig

### DIFF
--- a/compatibility-verifier/multi-stage-query-engine-test-suite/config/feature-test-1.json
+++ b/compatibility-verifier/multi-stage-query-engine-test-suite/config/feature-test-1.json
@@ -19,7 +19,6 @@
     "replication": "1",
     "retentionTimeUnit": "",
     "retentionTimeValue": "",
-    "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
     "segmentPushFrequency": "daily",
     "segmentPushType": "REFRESH",
     "timeColumnName": "HoursSinceEpoch",

--- a/compatibility-verifier/multi-stage-query-engine-test-suite/config/feature-test-2-realtime.json
+++ b/compatibility-verifier/multi-stage-query-engine-test-suite/config/feature-test-2-realtime.json
@@ -20,7 +20,6 @@
     "replication": "1",
     "retentionTimeUnit": "",
     "retentionTimeValue": "",
-    "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
     "segmentPushFrequency": "daily",
     "segmentPushType": "APPEND",
     "timeColumnName": "HoursSinceEpoch",

--- a/compatibility-verifier/sample-test-suite/config/feature-test-1.json
+++ b/compatibility-verifier/sample-test-suite/config/feature-test-1.json
@@ -19,7 +19,6 @@
     "replication": "1",
     "retentionTimeUnit": "",
     "retentionTimeValue": "",
-    "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
     "segmentPushFrequency": "daily",
     "segmentPushType": "REFRESH",
     "timeColumnName": "HoursSinceEpoch",

--- a/compatibility-verifier/sample-test-suite/config/feature-test-2-realtime.json
+++ b/compatibility-verifier/sample-test-suite/config/feature-test-2-realtime.json
@@ -20,7 +20,6 @@
     "replication": "1",
     "retentionTimeUnit": "",
     "retentionTimeValue": "",
-    "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
     "segmentPushFrequency": "daily",
     "segmentPushType": "APPEND",
     "timeColumnName": "HoursSinceEpoch",

--- a/compatibility-verifier/sample-test-suite/config/feature-test-3-realtime.json
+++ b/compatibility-verifier/sample-test-suite/config/feature-test-3-realtime.json
@@ -42,7 +42,6 @@
     "replication": "1",
     "retentionTimeUnit": "",
     "retentionTimeValue": "",
-    "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
     "segmentPushFrequency": "daily",
     "segmentPushType": "APPEND",
     "timeColumnName": "HoursSinceEpoch",

--- a/docker/images/pinot/examples/docker/table-configs/airlineStats_realtime_table_config.json
+++ b/docker/images/pinot/examples/docker/table-configs/airlineStats_realtime_table_config.json
@@ -7,7 +7,6 @@
     "retentionTimeUnit": "DAYS",
     "retentionTimeValue": "5",
     "segmentPushType": "APPEND",
-    "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
     "replication": "1",
     "replicasPerPartition": "1"
   },

--- a/docker/images/pinot/examples/docker/table-configs/meetupRsvp_realtime_table_config.json
+++ b/docker/images/pinot/examples/docker/table-configs/meetupRsvp_realtime_table_config.json
@@ -5,7 +5,6 @@
     "timeColumnName": "mtime",
     "timeType": "MILLISECONDS",
     "segmentPushType": "APPEND",
-    "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
     "replication": "1",
     "replicasPerPartition": "1"
   },

--- a/helm/pinot/pinot-realtime-quickstart.yml
+++ b/helm/pinot/pinot-realtime-quickstart.yml
@@ -33,7 +33,6 @@ data:
         "retentionTimeUnit": "DAYS",
         "retentionTimeValue": "3650",
         "segmentPushType": "APPEND",
-        "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
         "replication": "1",
         "replicasPerPartition": "1"
       },
@@ -68,7 +67,6 @@ data:
         "retentionTimeUnit": "DAYS",
         "retentionTimeValue": "3650",
         "segmentPushType": "APPEND",
-        "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
         "replication": "1",
         "replicasPerPartition": "1"
       },

--- a/pinot-common/src/main/java/org/apache/pinot/common/assignment/InstanceAssignmentConfigUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/assignment/InstanceAssignmentConfigUtils.java
@@ -31,6 +31,7 @@ import org.apache.pinot.spi.config.table.assignment.InstanceAssignmentConfig;
 import org.apache.pinot.spi.config.table.assignment.InstancePartitionsType;
 import org.apache.pinot.spi.config.table.assignment.InstanceReplicaGroupPartitionConfig;
 import org.apache.pinot.spi.config.table.assignment.InstanceTagPoolConfig;
+import org.apache.pinot.spi.config.table.assignment.SegmentAssignmentConfig;
 import org.apache.pinot.spi.utils.CommonConstants.Segment.AssignmentStrategy;
 
 
@@ -65,10 +66,17 @@ public class InstanceAssignmentConfigUtils {
       // Allow OFFLINE instance assignment if the offline table has it configured or (for backward-compatibility) is
       // using replica-group segment assignment
       case OFFLINE:
+        Map<String, SegmentAssignmentConfig> segmentAssignmentConfigMap = tableConfig.getSegmentAssignmentConfigMap();
+        boolean isSetReplicaGroupAssignmentStrategy = false;
+        if (segmentAssignmentConfigMap != null
+            && segmentAssignmentConfigMap.get(instancePartitionsType.toString()) != null) {
+          isSetReplicaGroupAssignmentStrategy =
+              AssignmentStrategy.REPLICA_GROUP_SEGMENT_ASSIGNMENT_STRATEGY.equalsIgnoreCase(
+                  segmentAssignmentConfigMap.get(instancePartitionsType.toString()).getAssignmentStrategy());
+        }
         return tableType == TableType.OFFLINE && ((instanceAssignmentConfigMap != null
             && instanceAssignmentConfigMap.get(InstancePartitionsType.OFFLINE.toString()) != null)
-            || AssignmentStrategy.REPLICA_GROUP_SEGMENT_ASSIGNMENT_STRATEGY
-            .equalsIgnoreCase(tableConfig.getValidationConfig().getSegmentAssignmentStrategy()));
+            || isSetReplicaGroupAssignmentStrategy);
       // Allow CONSUMING/COMPLETED instance assignment if the real-time table has it configured
       case CONSUMING:
       case COMPLETED:

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigSerDeUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigSerDeUtilsTest.java
@@ -48,6 +48,7 @@ import org.apache.pinot.spi.config.table.assignment.InstanceConstraintConfig;
 import org.apache.pinot.spi.config.table.assignment.InstancePartitionsType;
 import org.apache.pinot.spi.config.table.assignment.InstanceReplicaGroupPartitionConfig;
 import org.apache.pinot.spi.config.table.assignment.InstanceTagPoolConfig;
+import org.apache.pinot.spi.config.table.assignment.SegmentAssignmentConfig;
 import org.apache.pinot.spi.config.table.ingestion.AggregationConfig;
 import org.apache.pinot.spi.config.table.ingestion.BatchIngestionConfig;
 import org.apache.pinot.spi.config.table.ingestion.ComplexTypeConfig;
@@ -146,7 +147,9 @@ public class TableConfigSerDeUtilsTest {
     {
       // With SegmentAssignmentStrategyConfig
       ReplicaGroupStrategyConfig replicaGroupStrategyConfig = new ReplicaGroupStrategyConfig("memberId", 5);
-      TableConfig tableConfig = tableConfigBuilder.setSegmentAssignmentStrategy("ReplicaGroupSegmentAssignmentStrategy")
+      TableConfig tableConfig = tableConfigBuilder.setSegmentAssignmentConfigMap(
+              Collections.singletonMap(InstancePartitionsType.OFFLINE.toString(),
+                  new SegmentAssignmentConfig("ReplicaGroupSegmentAssignmentStrategy")))
           .setReplicaGroupStrategyConfig(replicaGroupStrategyConfig)
           .build();
 
@@ -439,7 +442,12 @@ public class TableConfigSerDeUtilsTest {
 
   private void checkSegmentAssignmentStrategyConfig(TableConfig tableConfig) {
     SegmentsValidationAndRetentionConfig validationConfig = tableConfig.getValidationConfig();
-    assertEquals(validationConfig.getSegmentAssignmentStrategy(), "ReplicaGroupSegmentAssignmentStrategy");
+    Map<String, SegmentAssignmentConfig> segmentAssignmentConfigMap = tableConfig.getSegmentAssignmentConfigMap();
+    assertNotNull(segmentAssignmentConfigMap);
+    SegmentAssignmentConfig segmentAssignmentConfig =
+        segmentAssignmentConfigMap.get(InstancePartitionsType.OFFLINE.toString());
+    assertNotNull(segmentAssignmentConfig);
+    assertEquals(segmentAssignmentConfig.getAssignmentStrategy(), "ReplicaGroupSegmentAssignmentStrategy");
     ReplicaGroupStrategyConfig replicaGroupStrategyConfig = validationConfig.getReplicaGroupStrategyConfig();
     assertNotNull(replicaGroupStrategyConfig);
     assertEquals(replicaGroupStrategyConfig.getPartitionColumn(), "memberId");

--- a/pinot-connectors/pinot-flink-connector/src/test/resources/fixtures/pinotTableConfigLowLevel.json
+++ b/pinot-connectors/pinot-flink-connector/src/test/resources/fixtures/pinotTableConfigLowLevel.json
@@ -8,7 +8,6 @@
     "segmentPushType" : "APPEND",
     "replication" : "2",
     "timeColumnName" : "timestamp",
-    "segmentAssignmentStrategy" : "BalanceNumSegmentAssignmentStrategy",
     "replicaGroupStrategyConfig" : null,
     "hllConfig" : null,
     "replicasPerPartition" : 2,

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotFileUploadTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotFileUploadTest.java
@@ -45,7 +45,7 @@ public class PinotFileUploadTest {
     TEST_INSTANCE.addDummySchema(TABLE_NAME);
     // Adding table
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-        .setSegmentAssignmentStrategy("RandomAssignmentStrategy").setNumReplicas(2).build();
+        .setNumReplicas(2).build();
     TEST_INSTANCE.getHelixResourceManager().addTable(tableConfig);
   }
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/instance/InstanceAssignmentTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/instance/InstanceAssignmentTest.java
@@ -47,6 +47,7 @@ import org.apache.pinot.spi.config.table.assignment.InstanceConstraintConfig;
 import org.apache.pinot.spi.config.table.assignment.InstancePartitionsType;
 import org.apache.pinot.spi.config.table.assignment.InstanceReplicaGroupPartitionConfig;
 import org.apache.pinot.spi.config.table.assignment.InstanceTagPoolConfig;
+import org.apache.pinot.spi.config.table.assignment.SegmentAssignmentConfig;
 import org.apache.pinot.spi.stream.StreamMetadataProvider;
 import org.apache.pinot.spi.utils.CommonConstants.Segment.AssignmentStrategy;
 import org.apache.pinot.spi.utils.Enablement;
@@ -75,7 +76,8 @@ public class InstanceAssignmentTest {
     TableConfig tableConfig =
         new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).setServerTenant(TENANT_NAME)
             .setNumReplicas(numReplicas)
-            .setSegmentAssignmentStrategy(AssignmentStrategy.REPLICA_GROUP_SEGMENT_ASSIGNMENT_STRATEGY).build();
+            .setSegmentAssignmentConfigMap(Collections.singletonMap(InstancePartitionsType.OFFLINE.toString(),
+                new SegmentAssignmentConfig(AssignmentStrategy.REPLICA_GROUP_SEGMENT_ASSIGNMENT_STRATEGY))).build();
     int numInstancesPerPartition = 2;
     tableConfig.getValidationConfig()
         .setReplicaGroupStrategyConfig(new ReplicaGroupStrategyConfig(null, numInstancesPerPartition));

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/RealtimeReplicaGroupSegmentAssignmentTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/RealtimeReplicaGroupSegmentAssignmentTest.java
@@ -35,6 +35,7 @@ import org.apache.pinot.spi.config.table.ReplicaGroupStrategyConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.assignment.InstancePartitionsType;
+import org.apache.pinot.spi.config.table.assignment.SegmentAssignmentConfig;
 import org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.SegmentStateModel;
 import org.apache.pinot.spi.utils.CommonConstants.Segment.AssignmentStrategy;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
@@ -86,7 +87,8 @@ public class RealtimeReplicaGroupSegmentAssignmentTest {
     TableConfig tableConfig =
         new TableConfigBuilder(TableType.REALTIME).setTableName(RAW_TABLE_NAME).setNumReplicas(NUM_REPLICAS)
             .setStreamConfigs(streamConfigs)
-            .setSegmentAssignmentStrategy(AssignmentStrategy.REPLICA_GROUP_SEGMENT_ASSIGNMENT_STRATEGY)
+            .setSegmentAssignmentConfigMap(Collections.singletonMap(InstancePartitionsType.COMPLETED.toString(),
+                new SegmentAssignmentConfig(AssignmentStrategy.REPLICA_GROUP_SEGMENT_ASSIGNMENT_STRATEGY)))
             .setReplicaGroupStrategyConfig(new ReplicaGroupStrategyConfig(PARTITION_COLUMN, 1)).build();
     _segmentAssignment = SegmentAssignmentFactory.getSegmentAssignment(createHelixManager(), tableConfig, null);
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/StrictRealtimeSegmentAssignmentTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/StrictRealtimeSegmentAssignmentTest.java
@@ -46,6 +46,7 @@ import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.UpsertConfig;
 import org.apache.pinot.spi.config.table.assignment.InstancePartitionsType;
+import org.apache.pinot.spi.config.table.assignment.SegmentAssignmentConfig;
 import org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.SegmentStateModel;
 import org.apache.pinot.spi.utils.CommonConstants.Segment.AssignmentStrategy;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
@@ -135,7 +136,8 @@ public class StrictRealtimeSegmentAssignmentTest {
     TableConfigBuilder builder = new TableConfigBuilder(TableType.REALTIME).setTableName(RAW_TABLE_NAME)
         .setNumReplicas(NUM_REPLICAS)
         .setStreamConfigs(FakeStreamConfigUtils.getDefaultLowLevelStreamConfigs().getStreamConfigsMap())
-        .setSegmentAssignmentStrategy(AssignmentStrategy.REPLICA_GROUP_SEGMENT_ASSIGNMENT_STRATEGY)
+        .setSegmentAssignmentConfigMap(Collections.singletonMap(InstancePartitionsType.COMPLETED.toString(),
+            new SegmentAssignmentConfig(AssignmentStrategy.REPLICA_GROUP_SEGMENT_ASSIGNMENT_STRATEGY)))
         .setReplicaGroupStrategyConfig(new ReplicaGroupStrategyConfig(PARTITION_COLUMN, 1));
     TableConfig tableConfig;
     if ("upsert".equalsIgnoreCase(tableType)) {

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/ReplicaGroupSegmentAssignmentStrategyTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/ReplicaGroupSegmentAssignmentStrategyTest.java
@@ -42,6 +42,7 @@ import org.apache.pinot.spi.config.table.ReplicaGroupStrategyConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.assignment.InstancePartitionsType;
+import org.apache.pinot.spi.config.table.assignment.SegmentAssignmentConfig;
 import org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.SegmentStateModel;
 import org.apache.pinot.spi.utils.CommonConstants.Segment.AssignmentStrategy;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
@@ -90,7 +91,8 @@ public class ReplicaGroupSegmentAssignmentStrategyTest {
     TableConfig tableConfigWithoutPartitions =
         new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME_WITHOUT_PARTITION)
             .setNumReplicas(NUM_REPLICAS)
-            .setSegmentAssignmentStrategy(AssignmentStrategy.REPLICA_GROUP_SEGMENT_ASSIGNMENT_STRATEGY).build();
+            .setSegmentAssignmentConfigMap(Collections.singletonMap(InstancePartitionsType.OFFLINE.toString(),
+                new SegmentAssignmentConfig(AssignmentStrategy.REPLICA_GROUP_SEGMENT_ASSIGNMENT_STRATEGY))).build();
     _segmentAssignmentWithoutPartition =
         SegmentAssignmentFactory.getSegmentAssignment(null, tableConfigWithoutPartitions, null);
 
@@ -140,7 +142,8 @@ public class ReplicaGroupSegmentAssignmentStrategyTest {
     TableConfig tableConfigWithPartitions =
         new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME_WITH_PARTITION)
             .setNumReplicas(NUM_REPLICAS)
-            .setSegmentAssignmentStrategy(AssignmentStrategy.REPLICA_GROUP_SEGMENT_ASSIGNMENT_STRATEGY)
+            .setSegmentAssignmentConfigMap(Collections.singletonMap(InstancePartitionsType.OFFLINE.toString(),
+                new SegmentAssignmentConfig(AssignmentStrategy.REPLICA_GROUP_SEGMENT_ASSIGNMENT_STRATEGY)))
             .setReplicaGroupStrategyConfig(replicaGroupStrategyConfig).build();
     _segmentAssignmentWithPartition =
         SegmentAssignmentFactory.getSegmentAssignment(helixManagerWithPartitions, tableConfigWithPartitions, null);
@@ -398,7 +401,8 @@ public class ReplicaGroupSegmentAssignmentStrategyTest {
         new ReplicaGroupStrategyConfig(PARTITION_COLUMN, numInstancesPerPartition);
     TableConfig tableConfigWithPartitions =
         new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME_WITH_PARTITION).setNumReplicas(1)
-            .setSegmentAssignmentStrategy(AssignmentStrategy.REPLICA_GROUP_SEGMENT_ASSIGNMENT_STRATEGY).build();
+            .setSegmentAssignmentConfigMap(Collections.singletonMap(InstancePartitionsType.OFFLINE.toString(),
+                new SegmentAssignmentConfig(AssignmentStrategy.REPLICA_GROUP_SEGMENT_ASSIGNMENT_STRATEGY))).build();
     tableConfigWithPartitions.getValidationConfig().setReplicaGroupStrategyConfig(replicaGroupStrategyConfig);
     SegmentAssignment segmentAssignment =
         SegmentAssignmentFactory.getSegmentAssignment(helixManager, tableConfigWithPartitions, null);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/SegmentAssignmentStrategyFactoryTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/SegmentAssignmentStrategyFactoryTest.java
@@ -119,8 +119,11 @@ public class SegmentAssignmentStrategyFactoryTest {
     int numInstancesPerPartition = numInstancesPerReplicaGroup / NUM_REPLICAS;
     ReplicaGroupStrategyConfig replicaGroupStrategyConfig =
         new ReplicaGroupStrategyConfig(PARTITION_COLUMN, numInstancesPerPartition);
+    Map<String, SegmentAssignmentConfig> segmentAssignmentConfigMap = new HashMap<>();
+    segmentAssignmentConfigMap.put(InstancePartitionsType.OFFLINE.toString(),
+        new SegmentAssignmentConfig("ReplicaGroup"));
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME_WITH_PARTITION)
-        .setNumReplicas(NUM_REPLICAS).setSegmentAssignmentStrategy("ReplicaGroup")
+        .setNumReplicas(NUM_REPLICAS).setSegmentAssignmentConfigMap(segmentAssignmentConfigMap)
         .setReplicaGroupStrategyConfig(replicaGroupStrategyConfig).build();
 
     // {

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/workload/PropagationUtilsTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/workload/PropagationUtilsTest.java
@@ -194,7 +194,6 @@ public class PropagationUtilsTest {
     public TableConfig createTableConfig(String tableName, String serverTag, String brokerTenant, TableType type) {
         return new TableConfigBuilder(type)
             .setTableName(tableName)
-            .setSegmentAssignmentStrategy("BalanceNumSegmentAssignmentStrategy")
             .setNumReplicas(1)
             .setBrokerTenant(brokerTenant)
             .setServerTenant(serverTag)

--- a/pinot-controller/src/test/resources/memory_estimation/table-config-for-upsert.json
+++ b/pinot-controller/src/test/resources/memory_estimation/table-config-for-upsert.json
@@ -13,7 +13,6 @@
     "replication": "3",
     "retentionTimeUnit": "DAYS",
     "retentionTimeValue": "5",
-    "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
     "segmentPushFrequency": "daily",
     "segmentPushType": "APPEND",
     "timeColumnName": "colTime",

--- a/pinot-controller/src/test/resources/memory_estimation/table-config.json
+++ b/pinot-controller/src/test/resources/memory_estimation/table-config.json
@@ -9,7 +9,6 @@
     "replication": "3",
     "retentionTimeUnit": "DAYS",
     "retentionTimeValue": "5",
-    "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
     "segmentPushFrequency": "daily",
     "segmentPushType": "APPEND",
     "timeColumnName": "colTime",

--- a/pinot-core/src/test/resources/data/test_crc_complex_table.json
+++ b/pinot-core/src/test/resources/data/test_crc_complex_table.json
@@ -77,7 +77,6 @@
   "routing": {},
   "segmentsConfig": {
     "timeColumn": "eventTime",
-    "replication": 1,
-    "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy"
+    "replication": 1
   }
 }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java
@@ -1994,7 +1994,6 @@ public class MultiStageEngineIntegrationTest extends BaseClusterIntegrationTestS
         .setRetentionTimeUnit("DAYS")
         .setRetentionTimeValue("5000")
         .setDeletedSegmentsRetentionPeriod("7d")
-        .setSegmentAssignmentStrategy("BalanceNumSegmentAssignmentStrategy")
         .setNumReplicas(1)
         .setSegmentPushType("APPEND")
         .setBrokerTenant("DefaultTenant")

--- a/pinot-integration-tests/src/test/resources/chaos-monkey-create-table.json
+++ b/pinot-integration-tests/src/test/resources/chaos-monkey-create-table.json
@@ -3,7 +3,6 @@
   "tableType": "OFFLINE",
   "segmentsConfig": {
     "segmentPushType": "APPEND",
-    "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
     "replication": "3"
   },
   "tenants": {

--- a/pinot-integration-tests/src/test/resources/simpleMeetup_realtime_table_config.json
+++ b/pinot-integration-tests/src/test/resources/simpleMeetup_realtime_table_config.json
@@ -5,7 +5,6 @@
     "timeColumnName": "mtime",
     "timeType": "MILLISECONDS",
     "segmentPushType": "APPEND",
-    "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
     "replicasPerPartition": "1",
     "replicaGroupStrategyConfig": {
       "partitionColumn": "event_id",

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -82,6 +82,7 @@ import org.apache.pinot.spi.config.table.TimestampConfig;
 import org.apache.pinot.spi.config.table.UpsertConfig;
 import org.apache.pinot.spi.config.table.assignment.InstanceAssignmentConfig;
 import org.apache.pinot.spi.config.table.assignment.InstancePartitionsType;
+import org.apache.pinot.spi.config.table.assignment.SegmentAssignmentConfig;
 import org.apache.pinot.spi.config.table.ingestion.AggregationConfig;
 import org.apache.pinot.spi.config.table.ingestion.BatchIngestionConfig;
 import org.apache.pinot.spi.config.table.ingestion.ComplexTypeConfig;
@@ -179,6 +180,7 @@ public final class TableConfigUtils {
     }
 
     validateValidationConfig(tableConfig, schema);
+    validateSegmentAssignmentConfig(tableConfig);
     validateIngestionConfig(tableConfig, schema);
     if (tableConfig.getTableType() == TableType.REALTIME) {
       validateStreamConfigMaps(tableConfig);
@@ -372,16 +374,6 @@ public final class TableConfigUtils {
           "Dimension table must be of OFFLINE table type.");
       Preconditions.checkState(CollectionUtils.isNotEmpty(schema.getPrimaryKeyColumns()),
           "Dimension table must have primary key[s]");
-
-      String segmentAssignmentStrategy = validationConfig.getSegmentAssignmentStrategy();
-      if (segmentAssignmentStrategy != null
-          && !segmentAssignmentStrategy.equalsIgnoreCase(AssignmentStrategy.DIM_TABLE_SEGMENT_ASSIGNMENT_STRATEGY)) {
-        throw new IllegalStateException(
-            String.format("Dimension table: %s can only use '%s' segment assignment strategy, found: %s",
-              tableConfig.getTableName(),
-              CommonConstants.Segment.AssignmentStrategy.DIM_TABLE_SEGMENT_ASSIGNMENT_STRATEGY,
-              segmentAssignmentStrategy));
-      }
     }
 
     String peerSegmentDownloadScheme = validationConfig.getPeerSegmentDownloadScheme();
@@ -397,6 +389,29 @@ public final class TableConfigUtils {
     }
 
     validateRetentionConfig(tableConfig);
+  }
+
+  private static void validateSegmentAssignmentConfig(TableConfig tableConfig) {
+    Map<String, SegmentAssignmentConfig> segmentAssignmentConfigMap = tableConfig.getSegmentAssignmentConfigMap();
+    if (segmentAssignmentConfigMap == null) {
+      return;
+    }
+    if (tableConfig.isDimTable()) {
+      SegmentAssignmentConfig segmentAssignmentConfig =
+          segmentAssignmentConfigMap.get(InstancePartitionsType.OFFLINE.toString());
+      if (segmentAssignmentConfig == null) {
+        return;
+      }
+      String segmentAssignmentStrategy = segmentAssignmentConfig.getAssignmentStrategy();
+      if (segmentAssignmentStrategy != null
+          && !segmentAssignmentStrategy.equalsIgnoreCase(AssignmentStrategy.DIM_TABLE_SEGMENT_ASSIGNMENT_STRATEGY)) {
+        throw new IllegalStateException(
+            String.format("Dimension table: %s can only use '%s' segment assignment strategy, found: %s",
+                tableConfig.getTableName(),
+                CommonConstants.Segment.AssignmentStrategy.DIM_TABLE_SEGMENT_ASSIGNMENT_STRATEGY,
+                segmentAssignmentStrategy));
+      }
+    }
   }
 
   private static boolean isValidPeerDownloadScheme(String peerSegmentDownloadScheme) {

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -57,6 +57,7 @@ import org.apache.pinot.spi.config.table.assignment.InstanceAssignmentConfig;
 import org.apache.pinot.spi.config.table.assignment.InstancePartitionsType;
 import org.apache.pinot.spi.config.table.assignment.InstanceReplicaGroupPartitionConfig;
 import org.apache.pinot.spi.config.table.assignment.InstanceTagPoolConfig;
+import org.apache.pinot.spi.config.table.assignment.SegmentAssignmentConfig;
 import org.apache.pinot.spi.config.table.ingestion.AggregationConfig;
 import org.apache.pinot.spi.config.table.ingestion.BatchIngestionConfig;
 import org.apache.pinot.spi.config.table.ingestion.ComplexTypeConfig;
@@ -290,14 +291,16 @@ public class TableConfigUtilsTest {
     // Valid: allservers strategy using constant
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setIsDimTable(true)
-        .setSegmentAssignmentStrategy(AssignmentStrategy.DIM_TABLE_SEGMENT_ASSIGNMENT_STRATEGY)
+        .setSegmentAssignmentConfigMap(Collections.singletonMap(InstancePartitionsType.OFFLINE.toString(),
+            new SegmentAssignmentConfig(AssignmentStrategy.DIM_TABLE_SEGMENT_ASSIGNMENT_STRATEGY)))
         .build();
     TableConfigUtils.validate(tableConfig, schema);
 
     // Invalid: other strategy
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setIsDimTable(true)
-        .setSegmentAssignmentStrategy("replicaGroup")
+        .setSegmentAssignmentConfigMap(Collections.singletonMap(InstancePartitionsType.OFFLINE.toString(),
+            new SegmentAssignmentConfig("replicaGroup")))
         .build();
     try {
       TableConfigUtils.validate(tableConfig, schema);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/SegmentsValidationAndRetentionConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/SegmentsValidationAndRetentionConfig.java
@@ -43,8 +43,6 @@ public class SegmentsValidationAndRetentionConfig extends BaseJsonConfig {
   private String _timeColumnName;
   private TimeUnit _timeType;
   @Deprecated  // Use SegmentAssignmentConfig instead
-  private String _segmentAssignmentStrategy;
-  @Deprecated  // Use SegmentAssignmentConfig instead
   private ReplicaGroupStrategyConfig _replicaGroupStrategyConfig;
   private CompletionConfig _completionConfig;
   private String _crypterClassName;
@@ -58,19 +56,6 @@ public class SegmentsValidationAndRetentionConfig extends BaseJsonConfig {
   private String _untrackedSegmentsDeletionBatchSize;
   private String _untrackedSegmentsRetentionTimeUnit;
   private String _untrackedSegmentsRetentionTimeValue;
-
-  /**
-   * @deprecated Use {@link InstanceAssignmentConfig} instead
-   */
-  @Deprecated
-  public String getSegmentAssignmentStrategy() {
-    return _segmentAssignmentStrategy;
-  }
-
-  @Deprecated
-  public void setSegmentAssignmentStrategy(String segmentAssignmentStrategy) {
-    _segmentAssignmentStrategy = segmentAssignmentStrategy;
-  }
 
   public String getTimeColumnName() {
     return _timeColumnName;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/TableConfigBuilder.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/TableConfigBuilder.java
@@ -82,8 +82,6 @@ public class TableConfigBuilder {
   // TODO: Remove 'DEFAULT_SEGMENT_PUSH_TYPE' in the future major release.
   @Deprecated
   private String _segmentPushType = DEFAULT_SEGMENT_PUSH_TYPE;
-  @Deprecated
-  private String _segmentAssignmentStrategy;
   private String _peerSegmentDownloadScheme;
   @Deprecated
   private ReplicaGroupStrategyConfig _replicaGroupStrategyConfig;
@@ -236,11 +234,6 @@ public class TableConfigBuilder {
    */
   public TableConfigBuilder setSegmentPushFrequency(String segmentPushFrequency) {
     _segmentPushFrequency = segmentPushFrequency;
-    return this;
-  }
-
-  public TableConfigBuilder setSegmentAssignmentStrategy(String segmentAssignmentStrategy) {
-    _segmentAssignmentStrategy = segmentAssignmentStrategy;
     return this;
   }
 
@@ -526,7 +519,6 @@ public class TableConfigBuilder {
     validationConfig.setLineageEntryCleanupRetentionPeriod(_lineageEntryCleanupRetentionPeriod);
     validationConfig.setSegmentPushFrequency(_segmentPushFrequency);
     validationConfig.setSegmentPushType(_segmentPushType);
-    validationConfig.setSegmentAssignmentStrategy(_segmentAssignmentStrategy);
     validationConfig.setReplicaGroupStrategyConfig(_replicaGroupStrategyConfig);
     validationConfig.setCompletionConfig(_completionConfig);
     validationConfig.setReplication(_numReplicas);

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/perf/PerfBenchmarkDriver.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/perf/PerfBenchmarkDriver.java
@@ -93,7 +93,6 @@ public class PerfBenchmarkDriver {
 
   // TODO: read from configuration.
   private final int _numReplicas = 1;
-  private final String _segmentAssignmentStrategy = "BalanceNumSegmentAssignmentStrategy";
   private final String _brokerTenantName = "DefaultTenant";
   private final String _serverTenantName = "DefaultTenant";
 
@@ -345,7 +344,7 @@ public class PerfBenchmarkDriver {
   public void configureTable(String tableName, List<String> invertedIndexColumns, List<String> bloomFilterColumns)
       throws Exception {
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(tableName)
-        .setSegmentAssignmentStrategy(_segmentAssignmentStrategy).setNumReplicas(_numReplicas)
+        .setNumReplicas(_numReplicas)
         .setBrokerTenant(_brokerTenantName).setServerTenant(_serverTenantName).setLoadMode(_loadMode)
         .setSegmentVersion(_segmentFormatVersion).setInvertedIndexColumns(invertedIndexColumns)
         .setBloomFilterColumns(bloomFilterColumns).build();

--- a/pinot-tools/src/main/resources/conf/sample_offline_table_config.json
+++ b/pinot-tools/src/main/resources/conf/sample_offline_table_config.json
@@ -7,7 +7,6 @@
     "retentionTimeUnit": "DAYS",
     "retentionTimeValue": "365",
     "segmentPushType": "APPEND",
-    "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
     "replication": "3"
   },
   "tenants": {

--- a/pinot-tools/src/main/resources/conf/sample_realtime_table_config.json
+++ b/pinot-tools/src/main/resources/conf/sample_realtime_table_config.json
@@ -7,7 +7,6 @@
     "retentionTimeUnit": "DAYS",
     "retentionTimeValue": "5",
     "segmentPushType": "APPEND",
-    "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
     "replication": "3",
     "replicasPerPartition": "1"
   },

--- a/pinot-tools/src/main/resources/examples/batch/airlineStats/airlineStats_offline_table_config.json
+++ b/pinot-tools/src/main/resources/examples/batch/airlineStats/airlineStats_offline_table_config.json
@@ -5,7 +5,6 @@
     "timeColumnName": "DaysSinceEpoch",
     "timeType": "DAYS",
     "segmentPushType": "APPEND",
-    "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
     "replication": "1"
   },
   "tenants": {},

--- a/pinot-tools/src/main/resources/examples/batch/baseballStats/baseballStats_offline_table_config.json
+++ b/pinot-tools/src/main/resources/examples/batch/baseballStats/baseballStats_offline_table_config.json
@@ -3,7 +3,6 @@
   "tableType": "OFFLINE",
   "segmentsConfig": {
     "segmentPushType": "APPEND",
-    "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
     "replication": "1"
   },
   "tenants": {

--- a/pinot-tools/src/main/resources/examples/batch/fineFoodReviews/fineFoodReviews_offline_table_config.json
+++ b/pinot-tools/src/main/resources/examples/batch/fineFoodReviews/fineFoodReviews_offline_table_config.json
@@ -3,7 +3,6 @@
   "tableType": "OFFLINE",
   "segmentsConfig": {
     "segmentPushType": "APPEND",
-    "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
     "replication": "1"
   },
   "tenants": {

--- a/pinot-tools/src/main/resources/examples/batch/orders/ordersAPAC/ordersAPAC_offline_table_config.json
+++ b/pinot-tools/src/main/resources/examples/batch/orders/ordersAPAC/ordersAPAC_offline_table_config.json
@@ -3,7 +3,6 @@
   "tableType": "OFFLINE",
   "segmentsConfig": {
     "segmentPushType": "APPEND",
-    "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
     "replication": "1"
   },
   "tenants": {

--- a/pinot-tools/src/main/resources/examples/batch/orders/ordersEU/ordersEU_offline_table_config.json
+++ b/pinot-tools/src/main/resources/examples/batch/orders/ordersEU/ordersEU_offline_table_config.json
@@ -3,7 +3,6 @@
   "tableType": "OFFLINE",
   "segmentsConfig": {
     "segmentPushType": "APPEND",
-    "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
     "replication": "1"
   },
   "tenants": {

--- a/pinot-tools/src/main/resources/examples/batch/orders/ordersUS/ordersUS_offline_table_config.json
+++ b/pinot-tools/src/main/resources/examples/batch/orders/ordersUS/ordersUS_offline_table_config.json
@@ -3,7 +3,6 @@
   "tableType": "OFFLINE",
   "segmentsConfig": {
     "segmentPushType": "APPEND",
-    "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
     "replication": "1"
   },
   "tenants": {

--- a/pinot-tools/src/main/resources/examples/batch/starbucksStores/starbucksStores_offline_table_config.json
+++ b/pinot-tools/src/main/resources/examples/batch/starbucksStores/starbucksStores_offline_table_config.json
@@ -5,7 +5,6 @@
     "retentionTimeUnit": "DAYS",
     "retentionTimeValue": "1",
     "segmentPushType": "APPEND",
-    "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
     "replication": "1"
   },
   "tenants": {

--- a/pinot-tools/src/main/resources/examples/minions/batch/airlineStats/airlineStats_offline_table_config.json
+++ b/pinot-tools/src/main/resources/examples/minions/batch/airlineStats/airlineStats_offline_table_config.json
@@ -5,7 +5,6 @@
     "timeColumnName": "DaysSinceEpoch",
     "timeType": "DAYS",
     "segmentPushType": "APPEND",
-    "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
     "replication": "1"
   },
   "tenants": {},

--- a/pinot-tools/src/main/resources/examples/minions/batch/baseballStats/baseballStats_offline_table_config.json
+++ b/pinot-tools/src/main/resources/examples/minions/batch/baseballStats/baseballStats_offline_table_config.json
@@ -3,7 +3,6 @@
   "tableType": "OFFLINE",
   "segmentsConfig": {
     "segmentPushType": "APPEND",
-    "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
     "replication": "1"
   },
   "tenants": {

--- a/pinot-tools/src/main/resources/examples/minions/stream/githubEvents/githubEvents_offline_table_config.json
+++ b/pinot-tools/src/main/resources/examples/minions/stream/githubEvents/githubEvents_offline_table_config.json
@@ -4,7 +4,6 @@
   "segmentsConfig": {
     "timeColumnName": "created_at_timestamp",
     "segmentPushType": "APPEND",
-    "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
     "replication": "1"
   },
   "tenants": {

--- a/pinot-tools/src/main/resources/examples/minions/stream/githubEvents/githubEvents_realtime_table_config.json
+++ b/pinot-tools/src/main/resources/examples/minions/stream/githubEvents/githubEvents_realtime_table_config.json
@@ -4,7 +4,6 @@
   "segmentsConfig": {
     "timeColumnName": "created_at_timestamp",
     "segmentPushType": "APPEND",
-    "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
     "replication": "1",
     "replicasPerPartition": "1"
   },

--- a/pinot-tools/src/main/resources/examples/stream/airlineStats/docker/airlineStats_realtime_table_config.json
+++ b/pinot-tools/src/main/resources/examples/stream/airlineStats/docker/airlineStats_realtime_table_config.json
@@ -7,7 +7,6 @@
     "retentionTimeUnit": "DAYS",
     "retentionTimeValue": "5",
     "segmentPushType": "APPEND",
-    "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
     "replication": "1",
     "replicasPerPartition": "1"
   },

--- a/pinot-tools/src/main/resources/examples/stream/dailySales/dailySales_realtime_table_config.json
+++ b/pinot-tools/src/main/resources/examples/stream/dailySales/dailySales_realtime_table_config.json
@@ -3,7 +3,6 @@
   "tableType": "REALTIME",
   "segmentsConfig": {
     "segmentPushType": "APPEND",
-    "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
     "timeColumnName": "daysSinceEpoch",
     "retentionTimeUnit": "DAYS",
     "retentionTimeValue": "50000",

--- a/pinot-tools/src/main/resources/examples/stream/fineFoodReviews/fineFoodReviews_realtime_table_config.json
+++ b/pinot-tools/src/main/resources/examples/stream/fineFoodReviews/fineFoodReviews_realtime_table_config.json
@@ -3,7 +3,6 @@
   "tableType": "REALTIME",
   "segmentsConfig": {
     "segmentPushType": "APPEND",
-    "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
     "timeColumnName": "ts",
     "retentionTimeUnit": "DAYS",
     "retentionTimeValue": "5",

--- a/pinot-tools/src/main/resources/examples/stream/fineFoodReviews_part_0/fineFoodReviews_part_0_realtime_table_config.json
+++ b/pinot-tools/src/main/resources/examples/stream/fineFoodReviews_part_0/fineFoodReviews_part_0_realtime_table_config.json
@@ -3,7 +3,6 @@
   "tableType": "REALTIME",
   "segmentsConfig": {
     "segmentPushType": "APPEND",
-    "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
     "timeColumnName": "ts",
     "retentionTimeUnit": "DAYS",
     "retentionTimeValue": "5",

--- a/pinot-tools/src/main/resources/examples/stream/fineFoodReviews_part_1/fineFoodReviews_part_1_realtime_table_config.json
+++ b/pinot-tools/src/main/resources/examples/stream/fineFoodReviews_part_1/fineFoodReviews_part_1_realtime_table_config.json
@@ -3,7 +3,6 @@
   "tableType": "REALTIME",
   "segmentsConfig": {
     "segmentPushType": "APPEND",
-    "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
     "timeColumnName": "ts",
     "retentionTimeUnit": "DAYS",
     "retentionTimeValue": "5",


### PR DESCRIPTION
## Description
This field has been marked deprecated since https://github.com/apache/pinot/pull/11869, and has not been used in pinot code effectively.

## Backward Incompatibility
For any downstream usage of this deprecated field `segmentAssignmentStrategy` in `segmentConfig`, please read from `segmentAssignmentConfigMap` from first level field from table config instead. Related issue: https://github.com/apache/pinot/issues/13659 