### PR TITLE
Move caching Null Bitmap to NullValueVectorReaderImpl's contructor

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/NullValueVectorReaderImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/NullValueVectorReaderImpl.java
@@ -26,7 +26,6 @@ import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
 public class NullValueVectorReaderImpl implements NullValueVectorReader {
 
   // Cached bitmap to avoid re-deserializing from the underlying buffer on every call.
-  // ImmutableRoaringBitmap is thread-safe once constructed, so a volatile field is sufficient.
   private final ImmutableRoaringBitmap _nullBitmap;
 
   public NullValueVectorReaderImpl(PinotDataBuffer dataBuffer) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/NullValueVectorReaderImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/NullValueVectorReaderImpl.java
@@ -25,13 +25,12 @@ import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
 
 public class NullValueVectorReaderImpl implements NullValueVectorReader {
 
-  private final PinotDataBuffer _dataBuffer;
   // Cached bitmap to avoid re-deserializing from the underlying buffer on every call.
   // ImmutableRoaringBitmap is thread-safe once constructed, so a volatile field is sufficient.
-  private volatile ImmutableRoaringBitmap _nullBitmap;
+  private final ImmutableRoaringBitmap _nullBitmap;
 
   public NullValueVectorReaderImpl(PinotDataBuffer dataBuffer) {
-    _dataBuffer = dataBuffer;
+    _nullBitmap = new ImmutableRoaringBitmap(dataBuffer.toDirectByteBuffer(0, (int) dataBuffer.size()));
   }
 
   public boolean isNull(int docId) {
@@ -40,11 +39,6 @@ public class NullValueVectorReaderImpl implements NullValueVectorReader {
 
   @Override
   public ImmutableRoaringBitmap getNullBitmap() {
-    ImmutableRoaringBitmap nullBitmap = _nullBitmap;
-    if (nullBitmap == null) {
-      nullBitmap = new ImmutableRoaringBitmap(_dataBuffer.toDirectByteBuffer(0, (int) _dataBuffer.size()));
-      _nullBitmap = nullBitmap;
-    }
-    return nullBitmap;
+    return _nullBitmap;
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/readers/NullValueVectorReaderImplTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/readers/NullValueVectorReaderImplTest.java
@@ -62,19 +62,6 @@ public class NullValueVectorReaderImplTest implements PinotBuffersAfterMethodChe
     }
   }
 
-  @Test
-  public void testNullBitmapIsCached()
-      throws IOException {
-    File nullValueFile = new File(TEMP_DIR, TEMP_DIR.list()[0]);
-    try (PinotDataBuffer buffer = PinotDataBuffer.loadBigEndianFile(nullValueFile)) {
-      NullValueVectorReaderImpl reader = new NullValueVectorReaderImpl(buffer);
-      // Repeated calls to getNullBitmap() must return the same instance, not reconstruct it
-      org.roaringbitmap.buffer.ImmutableRoaringBitmap first = reader.getNullBitmap();
-      org.roaringbitmap.buffer.ImmutableRoaringBitmap second = reader.getNullBitmap();
-      Assert.assertSame(first, second, "getNullBitmap() should return the cached instance on repeated calls");
-    }
-  }
-
   @AfterClass
   public void tearDown()
       throws Exception {


### PR DESCRIPTION
cache null bitmap as index reader creation time rather than query time.