### PR TITLE
fix(tls): tighten transient SSL factory renewal retry log message in RenewableTlsUtils

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/tls/RenewableTlsUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/tls/RenewableTlsUtils.java
@@ -302,7 +302,7 @@ public class RenewableTlsUtils {
                   + "truststore {}) on file", baseSslFactory, keyStorePath, trustStorePath);
               return true;
             } catch (Exception e) {
-              LOGGER.warn(
+              LOGGER.info(
                   "reloadSslFactory :: Encountered issues when renewing SSLFactory "
                   + "{} (built from key store {} and "
                   + "truststore {}), retrying if attempts remain", baseSslFactory, keyStorePath, trustStorePath, e);

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/tls/RenewableTlsUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/tls/RenewableTlsUtils.java
@@ -302,10 +302,10 @@ public class RenewableTlsUtils {
                   + "truststore {}) on file", baseSslFactory, keyStorePath, trustStorePath);
               return true;
             } catch (Exception e) {
-              LOGGER.info(
+              LOGGER.warn(
                   "reloadSslFactory :: Encountered issues when renewing SSLFactory "
                   + "{} (built from key store {} and "
-                  + "truststore {}) on ", baseSslFactory, keyStorePath, trustStorePath, e);
+                  + "truststore {}), retrying if attempts remain", baseSslFactory, keyStorePath, trustStorePath, e);
               return false;
             }
           });

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/tls/RenewableTlsUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/tls/RenewableTlsUtils.java
@@ -286,10 +286,10 @@ public class RenewableTlsUtils {
                   + "truststore {}) on file", baseSslFactory, keyStorePath, trustStorePath);
               return true;
             } catch (Exception e) {
-              LOGGER.info(
+              LOGGER.warn(
                   "reloadSslFactory :: Encountered issues when renewing SSLFactory "
                   + "{} (built from key store {} and "
-                  + "truststore {}) on ", baseSslFactory, keyStorePath, trustStorePath, e);
+                  + "truststore {}), retrying if attempts remain", baseSslFactory, keyStorePath, trustStorePath, e);
               return false;
             }
           });

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/tls/RenewableTlsUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/tls/RenewableTlsUtils.java
@@ -286,7 +286,7 @@ public class RenewableTlsUtils {
                   + "truststore {}) on file", baseSslFactory, keyStorePath, trustStorePath);
               return true;
             } catch (Exception e) {
-              LOGGER.warn(
+              LOGGER.info(
                   "reloadSslFactory :: Encountered issues when renewing SSLFactory "
                   + "{} (built from key store {} and "
                   + "truststore {}), retrying if attempts remain", baseSslFactory, keyStorePath, trustStorePath, e);


### PR DESCRIPTION
Tightens the per-attempt log message in the retry catch block of
`RenewableTlsUtils.reloadSslFactory`. The old text ended with a
truncated-looking `"... truststore {}) on "`. The new wording
(`"retrying if attempts remain"`) stays accurate even on the final
retry, so it does not contradict the `LOGGER.error` that fires right
after when all attempts are exhausted.
The log level is intentionally kept at `INFO`. As raised in review
(thanks @yashmayya), this catch block fires on every healthy cert
rotation — attempt 1 fails while the second file is still being
written, attempt 2 succeeds — so promoting it to `WARN` would spam
WARN dashboards on every normal rotation. The outer `LOGGER.error`
already surfaces the "all attempts exhausted" case at the correct
severity.
### Diff
\`\`\`java
} catch (Exception e) {
  LOGGER.info(
      "reloadSslFactory :: Encountered issues when renewing SSLFactory "
      + "{} (built from key store {} and "
-     + "truststore {}) on "seSslFactory, keyStorePath, trustStorePath, e);
+     + "truststore {}), retrying if attempts remain",
+     baseSslFactory, keyStorePath, trustStorePath, e);
  return false;
}
\`\`\`
### Scope
Single file: \`pinot-common/src/main/java/org/apache/pinot/common/utils/tls/RenewableTlsUtils.java\`.
No behavior change, no config / SPI / wire-format change.
### Testing
Existing \`RenewableTlsUtilsTest\` still passes (this catch block isn't
currently covered by a test, so no test changes needed). Manually
verified the new message renders correctly when an exception is
thrown — the SLF4J trailing \`Throwable\` argument still produces the
full stack trace.
### Release note
none (log-message-only change)
Related to #18402 (the level change originally proposed there was
intentionally dropped after review discussion; only the truncated
message text is fixed here).
