### PR TITLE
fix(segment): close removed PinotDataBuffer in FilePerIndexDirectory

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/FilePerIndexDirectory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/FilePerIndexDirectory.java
@@ -36,9 +36,13 @@ import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
 import org.apache.pinot.segment.spi.store.ColumnIndexDirectory;
 import org.apache.pinot.spi.utils.ReadMode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 class FilePerIndexDirectory extends ColumnIndexDirectory {
+  private static final Logger LOGGER = LoggerFactory.getLogger(FilePerIndexDirectory.class);
+
   private final File _segmentDirectory;
   private SegmentMetadataImpl _segmentMetadata;
   private final ReadMode _readMode;
@@ -99,8 +103,15 @@ class FilePerIndexDirectory extends ColumnIndexDirectory {
 
   @Override
   public void removeIndex(String columnName, IndexType<?, ?, ?> indexType) {
-    // TODO: this leaks the removed data buffer (it's not going to be freed in close() method)
-    _indexBuffers.remove(new IndexKey(columnName, indexType));
+    PinotDataBuffer removedBuffer = _indexBuffers.remove(new IndexKey(columnName, indexType));
+    if (removedBuffer != null) {
+      try {
+        removedBuffer.close();
+      } catch (Exception e) {
+        LOGGER.warn("Failed to close removed buffer for column: {}, indexType: {}",
+            columnName, indexType, e);
+      }
+    }
     if (indexType == StandardIndexes.text()) {
       TextIndexUtils.cleanupTextIndex(_segmentDirectory, columnName);
     } else if (indexType == StandardIndexes.vector()) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/FilePerIndexDirectory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/FilePerIndexDirectory.java
@@ -103,13 +103,18 @@ class FilePerIndexDirectory extends ColumnIndexDirectory {
 
   @Override
   public void removeIndex(String columnName, IndexType<?, ?, ?> indexType) {
-    PinotDataBuffer removedBuffer = _indexBuffers.remove(new IndexKey(columnName, indexType));
-    if (removedBuffer != null) {
+    IndexKey key = new IndexKey(columnName, indexType);
+    // Fetch the buffer without removing it from the map first; the mapping is removed only after close() succeeds.
+    // If close() throws, the entry stays in _indexBuffers so a subsequent directory close() can attempt to release
+    // it on a best-effort basis (this class is not thread-safe; callers must serialize access).
+    PinotDataBuffer buffer = _indexBuffers.get(key);
+    if (buffer != null) {
       try {
-        removedBuffer.close();
+        buffer.close();
+        _indexBuffers.remove(key);
       } catch (Exception e) {
-        LOGGER.warn("Failed to close removed buffer for column: {}, indexType: {}",
-            columnName, indexType, e);
+        throw new RuntimeException(
+            String.format("Failed to close index buffer for column: %s, indexType: %s", columnName, indexType), e);
       }
     }
     if (indexType == StandardIndexes.text()) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/FilePerIndexDirectory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/FilePerIndexDirectory.java
@@ -36,13 +36,9 @@ import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
 import org.apache.pinot.segment.spi.store.ColumnIndexDirectory;
 import org.apache.pinot.spi.utils.ReadMode;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 class FilePerIndexDirectory extends ColumnIndexDirectory {
-  private static final Logger LOGGER = LoggerFactory.getLogger(FilePerIndexDirectory.class);
-
   private final File _segmentDirectory;
   private SegmentMetadataImpl _segmentMetadata;
   private final ReadMode _readMode;


### PR DESCRIPTION

`FilePerIndexDirectory.removeIndex()` was dropping the buffer entry
from the cache map without calling `close()` on it. For mmap-backed
buffers (the default for offline segments), this means the kernel
mapping leaks for the lifetime of the JVM — the on-disk file does
get deleted, but the address-space mapping stays until the process
exits (or the `Cleaner` happens to fire, which we shouldn't rely on
for deterministic cleanup).

`removeIndex()` is hit during segment reloads, minion-driven segment
conversions, and the various `*IndexHandler` drop/replace flows, so on
long-running servers that churn through reloads this shows up as the
classic.

The class itself had a `// TODO` flagging this, so this PR just
finishes it.

### Scope
Single file: pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/FilePerIndexDirectory.java
~10 lines changed

No public API change, no behavior change for callers and removeIndex still returns void. It still cleans up the on-disk files exactly the same way, just additionally closes the cached buffer.

### Testing
Existing FilePerIndexDirectoryTest still passes.
Manually verified the flow: with the fix, the PinotDataBuffer.close() on the removed entry is invoked once; without the fix it never was.

### Fixes #18404

### Release note
none (memory leak fix, no user-visible behavior change)

