### PR TITLE
Add scalar functions: math, IP address, and string utilities

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/ArithmeticFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/ArithmeticFunctions.java
@@ -211,4 +211,52 @@ public class ArithmeticFunctions {
     // Skip the heading 0s in the long value
     return Long.reverseBytes(a);
   }
+
+  /** Returns the cube root of the given value. */
+  @ScalarFunction
+  public static double cbrt(double a) {
+    return Math.cbrt(a);
+  }
+
+  /** Returns 2 raised to the power of the given value. */
+  @ScalarFunction
+  public static double exp2(double a) {
+    return Math.pow(2, a);
+  }
+
+  /** Returns 10 raised to the power of the given value. */
+  @ScalarFunction
+  public static double exp10(double a) {
+    return Math.pow(10, a);
+  }
+
+  /** Returns log(1 + x), computed in a way that is accurate even when x is close to zero. */
+  @ScalarFunction
+  public static double log1p(double a) {
+    return Math.log1p(a);
+  }
+
+  /** Returns the sigmoid (logistic) function: 1 / (1 + e^(-x)). */
+  @ScalarFunction
+  public static double sigmoid(double a) {
+    return 1.0 / (1.0 + Math.exp(-a));
+  }
+
+  /** Returns the mathematical constant pi (π). */
+  @ScalarFunction
+  public static double pi() {
+    return Math.PI;
+  }
+
+  /** Returns Euler's number (e), the base of the natural logarithm. */
+  @ScalarFunction(names = {"e", "euler"})
+  public static double e() {
+    return Math.E;
+  }
+
+  /** Returns the number of set bits (popcount) in the binary representation of the given long value. */
+  @ScalarFunction
+  public static int bitCount(long a) {
+    return Long.bitCount(a);
+  }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/IpAddressFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/IpAddressFunctions.java
@@ -23,19 +23,15 @@ import inet.ipaddr.AddressStringException;
 import inet.ipaddr.IPAddress;
 import inet.ipaddr.IPAddressString;
 import inet.ipaddr.PrefixLenException;
+import inet.ipaddr.ipv4.IPv4Address;
+import inet.ipaddr.ipv6.IPv6Address;
 import org.apache.pinot.spi.annotations.ScalarFunction;
 
 
 /**
- * Inbuilt IP related transform functions
+ * Scalar functions for IP address manipulation.
  *
- * Functions added:
- * isSubnetOf(String ipPrefix, String ipAddress) --> boolean
- *
- * Functions to add:
- * ipPrefix(String ipAddress, int prefixBits) -> String ipPrefix
- * ipSubnetMin(String ipPrefix) -> String ipMin
- * ipSubnetMax(String ipPrefix) -> String ipMax
+ * <p>All functions are stateless and thread-safe.
  */
 public class IpAddressFunctions {
 
@@ -128,5 +124,131 @@ public class IpAddressFunctions {
   public static String ipSubnetMax(String ipPrefix) {
     IPAddress prefix = getPrefix(ipPrefix);
     return prefix.getUpper().withoutPrefixLength().toCanonicalString();
+  }
+
+  /**
+   * Returns true if the input string is a valid IPv4 address (not a CIDR prefix).
+   *
+   * @param ipString the string to validate
+   * @return true if the string is a valid IPv4 address without a prefix length
+   */
+  @ScalarFunction
+  public static boolean isIPv4String(String ipString) {
+    if (ipString.isEmpty()) {
+      return false;
+    }
+    IPAddressString addr = new IPAddressString(ipString);
+    return addr.isValid() && addr.isIPv4() && !addr.isPrefixed();
+  }
+
+  /**
+   * Returns true if the input string is a valid IPv6 address (not a CIDR prefix).
+   *
+   * @param ipString the string to validate
+   * @return true if the string is a valid IPv6 address without a prefix length
+   */
+  @ScalarFunction
+  public static boolean isIPv6String(String ipString) {
+    if (ipString.isEmpty()) {
+      return false;
+    }
+    IPAddressString addr = new IPAddressString(ipString);
+    return addr.isValid() && addr.isIPv6() && !addr.isPrefixed();
+  }
+
+  /**
+   * Converts an IPv4 address string to its unsigned 32-bit integer representation as a long.
+   *
+   * @param ipString IPv4 address string (e.g., "192.168.1.1")
+   * @return unsigned 32-bit integer value (e.g., 3232235777)
+   * @throws IllegalArgumentException if the string is not a valid IPv4 address
+   */
+  @ScalarFunction
+  public static long ipv4ToLong(String ipString) {
+    IPAddress addr = getAddress(ipString);
+    if (!addr.isIPv4()) {
+      throw new IllegalArgumentException("Not an IPv4 address: " + ipString);
+    }
+    return Integer.toUnsignedLong(addr.toIPv4().intValue());
+  }
+
+  /**
+   * Converts an unsigned 32-bit integer (as long) to an IPv4 address string.
+   *
+   * @param value unsigned 32-bit integer value (0 to 4294967295)
+   * @return IPv4 address string in dotted-decimal notation
+   * @throws IllegalArgumentException if the value is outside the valid IPv4 range
+   */
+  @ScalarFunction
+  public static String longToIpv4(long value) {
+    if (value < 0 || value > 0xFFFFFFFFL) {
+      throw new IllegalArgumentException("Value out of IPv4 range: " + value);
+    }
+    return new IPv4Address((int) value).toCanonicalString();
+  }
+
+  /**
+   * Converts an IPv6 address string to its 16-byte representation.
+   *
+   * @param ipString IPv6 address string (e.g., "2001:db8::1")
+   * @return 16-byte array containing the IPv6 address
+   * @throws IllegalArgumentException if the string is not a valid IPv6 address
+   */
+  @ScalarFunction
+  public static byte[] ipv6ToBytes(String ipString) {
+    IPAddress addr = getAddress(ipString);
+    if (!addr.isIPv6()) {
+      throw new IllegalArgumentException("Not an IPv6 address: " + ipString);
+    }
+    return addr.toIPv6().getBytes();
+  }
+
+  /**
+   * Converts a 16-byte array to an IPv6 address string in canonical form.
+   *
+   * @param bytes 16-byte array containing the IPv6 address
+   * @return IPv6 address string in canonical form (e.g., "2001:db8::1")
+   * @throws IllegalArgumentException if the array is not exactly 16 bytes
+   */
+  @ScalarFunction
+  public static String bytesToIpv6(byte[] bytes) {
+    if (bytes.length != 16) {
+      throw new IllegalArgumentException("IPv6 address requires exactly 16 bytes, got " + bytes.length);
+    }
+    return new IPv6Address(bytes).toCanonicalString();
+  }
+
+  /**
+   * Maps an IPv4 address to its IPv4-mapped IPv6 representation.
+   *
+   * @param ipString IPv4 address string (e.g., "192.168.1.1")
+   * @return IPv4-mapped IPv6 address string (e.g., "::ffff:c0a8:101")
+   * @throws IllegalArgumentException if the string is not a valid IPv4 address
+   */
+  @ScalarFunction
+  public static String ipv4ToIpv6(String ipString) {
+    IPAddress addr = getAddress(ipString);
+    if (!addr.isIPv4()) {
+      throw new IllegalArgumentException("Not an IPv4 address: " + ipString);
+    }
+    return addr.toIPv4().toIPv6().toCanonicalString();
+  }
+
+  /**
+   * Returns the min and max addresses of an IPv4 CIDR range as a two-element string array.
+   *
+   * @param cidr IPv4 CIDR string (e.g., "192.168.1.0/24")
+   * @return two-element array [min, max] (e.g., ["192.168.1.0", "192.168.1.255"])
+   * @throws IllegalArgumentException if the CIDR is invalid or not IPv4
+   */
+  @ScalarFunction
+  public static String[] ipv4CIDRToRange(String cidr) {
+    IPAddress prefix = getPrefix(cidr);
+    if (!prefix.isIPv4()) {
+      throw new IllegalArgumentException("Not an IPv4 CIDR: " + cidr);
+    }
+    String min = prefix.getLower().withoutPrefixLength().toCanonicalString();
+    String max = prefix.getUpper().withoutPrefixLength().toCanonicalString();
+    return new String[]{min, max};
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
@@ -945,4 +945,113 @@ public class StringFunctions {
     }
     return matches;
   }
+
+  /**
+   * Returns the ASCII code of the first character, or 0 for an empty string.
+   * Matches SQL standard behavior (MySQL, PostgreSQL, Trino).
+   *
+   * @param input the input string
+   * @return ASCII value of the first character, or 0 if the string is empty
+   */
+  @ScalarFunction
+  public static int ascii(String input) {
+    return input.isEmpty() ? 0 : (int) input.charAt(0);
+  }
+
+  /**
+   * Returns a string consisting of {@code n} space characters.
+   *
+   * @param n the number of spaces
+   * @return a string of n spaces, or empty string if n is non-positive
+   */
+  @ScalarFunction
+  public static String space(int n) {
+    if (n <= 0) {
+      return "";
+    }
+    return StringUtils.repeat(' ', n);
+  }
+
+  /**
+   * Returns the substring before (positive count) or after (negative count) the Nth delimiter occurrence.
+   *
+   * <p>MySQL-compatible semantics: {@code substringIndex("a.b.c.d", ".", 2)} returns {@code "a.b"}.
+   * Negative count counts from the right: {@code substringIndex("a.b.c.d", ".", -2)} returns {@code "c.d"}.
+   *
+   * @param input the input string
+   * @param delimiter the delimiter to search for
+   * @param count occurrence count (positive = from left, negative = from right)
+   * @return the substring, or the entire input if the delimiter does not occur enough times
+   */
+  @ScalarFunction(names = {"substringIndex", "substring_index"})
+  public static String substringIndex(String input, String delimiter, int count) {
+    if (count == 0 || delimiter.isEmpty()) {
+      return "";
+    }
+    if (count > 0) {
+      int idx = StringUtils.ordinalIndexOf(input, delimiter, count);
+      return idx == -1 ? input : input.substring(0, idx);
+    } else {
+      int idx = StringUtils.lastOrdinalIndexOf(input, delimiter, -count);
+      return idx == -1 ? input : input.substring(idx + delimiter.length());
+    }
+  }
+
+  /**
+   * Returns the first line of the input string (up to the first line terminator).
+   * Handles Unix ({@code \n}), Windows ({@code \r\n}), and old Mac ({@code \r}) line endings.
+   *
+   * @param input the input string
+   * @return the first line, without the line terminator
+   */
+  @ScalarFunction
+  public static String firstLine(String input) {
+    int idxN = input.indexOf('\n');
+    int idxR = input.indexOf('\r');
+    if (idxN == -1 && idxR == -1) {
+      return input;
+    }
+    int idx = (idxN == -1) ? idxR : (idxR == -1) ? idxN : Math.min(idxN, idxR);
+    return input.substring(0, idx);
+  }
+
+  /**
+   * Returns true if the string starts with the given prefix, ignoring case differences.
+   *
+   * @param input the input string
+   * @param prefix the prefix to check
+   * @return true if the input starts with the prefix (case-insensitive)
+   */
+  @ScalarFunction
+  public static boolean startsWithCaseInsensitive(String input, String prefix) {
+    return Strings.CI.startsWith(input, prefix);
+  }
+
+  /**
+   * Returns true if the string ends with the given suffix, ignoring case differences.
+   *
+   * @param input the input string
+   * @param suffix the suffix to check
+   * @return true if the input ends with the suffix (case-insensitive)
+   */
+  @ScalarFunction
+  public static boolean endsWithCaseInsensitive(String input, String suffix) {
+    return Strings.CI.endsWith(input, suffix);
+  }
+
+  /**
+   * Returns true if all characters in the string are valid ASCII (values 0–127).
+   *
+   * @param input the input string
+   * @return true if every character is in the ASCII range
+   */
+  @ScalarFunction
+  public static boolean isValidASCII(String input) {
+    for (int i = 0; i < input.length(); i++) {
+      if (input.charAt(i) > 127) {
+        return false;
+      }
+    }
+    return true;
+  }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/common/function/scalar/ArithmeticFunctionsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/function/scalar/ArithmeticFunctionsTest.java
@@ -1,0 +1,117 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.function.scalar;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+
+/**
+ * Tests for non-polymorphic arithmetic scalar functions in {@link ArithmeticFunctions}.
+ */
+public class ArithmeticFunctionsTest {
+
+  private static final double DELTA = 1e-10;
+
+  @Test
+  public void testCbrt() {
+    assertEquals(ArithmeticFunctions.cbrt(27.0), 3.0, DELTA);
+    assertEquals(ArithmeticFunctions.cbrt(-8.0), -2.0, DELTA);
+    assertEquals(ArithmeticFunctions.cbrt(0.0), 0.0, DELTA);
+    assertEquals(ArithmeticFunctions.cbrt(1.0), 1.0, DELTA);
+    assertTrue(Double.isNaN(ArithmeticFunctions.cbrt(Double.NaN)));
+    assertEquals(ArithmeticFunctions.cbrt(Double.POSITIVE_INFINITY), Double.POSITIVE_INFINITY);
+    assertEquals(ArithmeticFunctions.cbrt(Double.NEGATIVE_INFINITY), Double.NEGATIVE_INFINITY);
+  }
+
+  @Test
+  public void testExp2() {
+    assertEquals(ArithmeticFunctions.exp2(0.0), 1.0, DELTA);
+    assertEquals(ArithmeticFunctions.exp2(1.0), 2.0, DELTA);
+    assertEquals(ArithmeticFunctions.exp2(3.0), 8.0, DELTA);
+    assertEquals(ArithmeticFunctions.exp2(10.0), 1024.0, DELTA);
+    assertEquals(ArithmeticFunctions.exp2(-1.0), 0.5, DELTA);
+    assertTrue(Double.isNaN(ArithmeticFunctions.exp2(Double.NaN)));
+    assertEquals(ArithmeticFunctions.exp2(Double.POSITIVE_INFINITY), Double.POSITIVE_INFINITY);
+    assertEquals(ArithmeticFunctions.exp2(Double.NEGATIVE_INFINITY), 0.0, DELTA);
+  }
+
+  @Test
+  public void testExp10() {
+    assertEquals(ArithmeticFunctions.exp10(0.0), 1.0, DELTA);
+    assertEquals(ArithmeticFunctions.exp10(1.0), 10.0, DELTA);
+    assertEquals(ArithmeticFunctions.exp10(2.0), 100.0, DELTA);
+    assertEquals(ArithmeticFunctions.exp10(3.0), 1000.0, DELTA);
+    assertEquals(ArithmeticFunctions.exp10(-1.0), 0.1, DELTA);
+    assertTrue(Double.isNaN(ArithmeticFunctions.exp10(Double.NaN)));
+    assertEquals(ArithmeticFunctions.exp10(Double.POSITIVE_INFINITY), Double.POSITIVE_INFINITY);
+    assertEquals(ArithmeticFunctions.exp10(Double.NEGATIVE_INFINITY), 0.0, DELTA);
+  }
+
+  @Test
+  public void testLog1p() {
+    assertEquals(ArithmeticFunctions.log1p(0.0), 0.0, DELTA);
+    assertEquals(ArithmeticFunctions.log1p(Math.E - 1), 1.0, DELTA);
+    assertEquals(ArithmeticFunctions.log1p(-1.0), Double.NEGATIVE_INFINITY);
+    assertTrue(Double.isNaN(ArithmeticFunctions.log1p(-2.0)));
+    assertTrue(Double.isNaN(ArithmeticFunctions.log1p(Double.NaN)));
+    assertEquals(ArithmeticFunctions.log1p(Double.POSITIVE_INFINITY), Double.POSITIVE_INFINITY);
+    // Verify numerical stability for small values
+    double smallValue = 1e-15;
+    assertEquals(ArithmeticFunctions.log1p(smallValue), smallValue, smallValue * 1e-5);
+  }
+
+  @Test
+  public void testSigmoid() {
+    assertEquals(ArithmeticFunctions.sigmoid(0.0), 0.5, DELTA);
+    assertTrue(ArithmeticFunctions.sigmoid(100.0) > 0.999);
+    assertTrue(ArithmeticFunctions.sigmoid(-100.0) < 0.001);
+    assertEquals(ArithmeticFunctions.sigmoid(Double.POSITIVE_INFINITY), 1.0, DELTA);
+    assertEquals(ArithmeticFunctions.sigmoid(Double.NEGATIVE_INFINITY), 0.0, DELTA);
+    assertTrue(Double.isNaN(ArithmeticFunctions.sigmoid(Double.NaN)));
+    // Symmetry: sigmoid(x) + sigmoid(-x) == 1
+    assertEquals(ArithmeticFunctions.sigmoid(2.0) + ArithmeticFunctions.sigmoid(-2.0), 1.0, DELTA);
+  }
+
+  @Test
+  public void testPi() {
+    assertEquals(ArithmeticFunctions.pi(), Math.PI, DELTA);
+  }
+
+  @Test
+  public void testE() {
+    assertEquals(ArithmeticFunctions.e(), Math.E, DELTA);
+  }
+
+  @Test
+  public void testBitCount() {
+    assertEquals(ArithmeticFunctions.bitCount(0L), 0);
+    assertEquals(ArithmeticFunctions.bitCount(1L), 1);
+    assertEquals(ArithmeticFunctions.bitCount(7L), 3);
+    assertEquals(ArithmeticFunctions.bitCount(255L), 8);
+    assertEquals(ArithmeticFunctions.bitCount(-1L), 64);
+    assertEquals(ArithmeticFunctions.bitCount(Long.MIN_VALUE), 1);
+    assertEquals(ArithmeticFunctions.bitCount(Long.MAX_VALUE), 63);
+    // int values promoted to long
+    assertEquals(ArithmeticFunctions.bitCount((long) Integer.MAX_VALUE), 31);
+    assertEquals(ArithmeticFunctions.bitCount((long) Integer.MIN_VALUE), 33);
+  }
+}

--- a/pinot-common/src/test/java/org/apache/pinot/common/function/scalar/IpAddressFunctionsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/function/scalar/IpAddressFunctionsTest.java
@@ -284,4 +284,155 @@ public class IpAddressFunctionsTest {
     String docPrefix = IpAddressFunctions.ipPrefix("2001:db8::1", 32);
     assertEquals(docPrefix, "2001:db8::/32");
   }
+
+  // ==================== Tests for isIPv4String ====================
+
+  @Test
+  public void testIsIPv4String() {
+    assertTrue(IpAddressFunctions.isIPv4String("192.168.1.1"));
+    assertTrue(IpAddressFunctions.isIPv4String("0.0.0.0"));
+    assertTrue(IpAddressFunctions.isIPv4String("255.255.255.255"));
+    assertTrue(IpAddressFunctions.isIPv4String("10.0.0.1"));
+
+    assertFalse(IpAddressFunctions.isIPv4String("2001:db8::1"));
+    assertFalse(IpAddressFunctions.isIPv4String("::1"));
+    assertFalse(IpAddressFunctions.isIPv4String("not-an-ip"));
+    assertFalse(IpAddressFunctions.isIPv4String(""));
+    assertFalse(IpAddressFunctions.isIPv4String("999.999.999.999"));
+    assertFalse(IpAddressFunctions.isIPv4String("192.168.1.1/24"));
+  }
+
+  // ==================== Tests for isIPv6String ====================
+
+  @Test
+  public void testIsIPv6String() {
+    assertTrue(IpAddressFunctions.isIPv6String("2001:db8::1"));
+    assertTrue(IpAddressFunctions.isIPv6String("::1"));
+    assertTrue(IpAddressFunctions.isIPv6String("fe80::1"));
+    assertTrue(IpAddressFunctions.isIPv6String("::"));
+
+    assertFalse(IpAddressFunctions.isIPv6String("192.168.1.1"));
+    assertFalse(IpAddressFunctions.isIPv6String("not-an-ip"));
+    assertFalse(IpAddressFunctions.isIPv6String(""));
+    assertFalse(IpAddressFunctions.isIPv6String("2001:db8::1/64"));
+  }
+
+  // ==================== Tests for ipv4ToLong ====================
+
+  @Test
+  public void testIpv4ToLong() {
+    assertEquals(IpAddressFunctions.ipv4ToLong("0.0.0.0"), 0L);
+    assertEquals(IpAddressFunctions.ipv4ToLong("0.0.0.1"), 1L);
+    assertEquals(IpAddressFunctions.ipv4ToLong("0.0.1.0"), 256L);
+    assertEquals(IpAddressFunctions.ipv4ToLong("192.168.1.1"), 3232235777L);
+    assertEquals(IpAddressFunctions.ipv4ToLong("255.255.255.255"), 4294967295L);
+    assertEquals(IpAddressFunctions.ipv4ToLong("10.0.0.1"), 167772161L);
+  }
+
+  @Test
+  public void testIpv4ToLongInvalid() {
+    assertThrows(IllegalArgumentException.class, () -> IpAddressFunctions.ipv4ToLong("2001:db8::1"));
+    assertThrows(IllegalArgumentException.class, () -> IpAddressFunctions.ipv4ToLong("not-an-ip"));
+  }
+
+  // ==================== Tests for longToIpv4 ====================
+
+  @Test
+  public void testLongToIpv4() {
+    assertEquals(IpAddressFunctions.longToIpv4(0L), "0.0.0.0");
+    assertEquals(IpAddressFunctions.longToIpv4(1L), "0.0.0.1");
+    assertEquals(IpAddressFunctions.longToIpv4(256L), "0.0.1.0");
+    assertEquals(IpAddressFunctions.longToIpv4(3232235777L), "192.168.1.1");
+    assertEquals(IpAddressFunctions.longToIpv4(4294967295L), "255.255.255.255");
+  }
+
+  @Test
+  public void testLongToIpv4Invalid() {
+    assertThrows(IllegalArgumentException.class, () -> IpAddressFunctions.longToIpv4(-1L));
+    assertThrows(IllegalArgumentException.class, () -> IpAddressFunctions.longToIpv4(4294967296L));
+  }
+
+  @Test
+  public void testIpv4RoundTrip() {
+    String[] addresses = {"0.0.0.0", "192.168.1.1", "10.20.30.40", "255.255.255.255", "127.0.0.1"};
+    for (String addr : addresses) {
+      assertEquals(IpAddressFunctions.longToIpv4(IpAddressFunctions.ipv4ToLong(addr)), addr);
+    }
+  }
+
+  // ==================== Tests for ipv6ToBytes / bytesToIpv6 ====================
+
+  @Test
+  public void testIpv6ToBytes() {
+    byte[] bytes = IpAddressFunctions.ipv6ToBytes("::1");
+    assertEquals(bytes.length, 16);
+    assertEquals(bytes[15], 1);
+    for (int i = 0; i < 15; i++) {
+      assertEquals(bytes[i], 0);
+    }
+  }
+
+  @Test
+  public void testIpv6ToBytesInvalid() {
+    assertThrows(IllegalArgumentException.class, () -> IpAddressFunctions.ipv6ToBytes("192.168.1.1"));
+    assertThrows(IllegalArgumentException.class, () -> IpAddressFunctions.ipv6ToBytes("not-an-ip"));
+  }
+
+  @Test
+  public void testBytesToIpv6() {
+    byte[] loopback = new byte[16];
+    loopback[15] = 1;
+    assertEquals(IpAddressFunctions.bytesToIpv6(loopback), "::1");
+  }
+
+  @Test
+  public void testBytesToIpv6Invalid() {
+    assertThrows(IllegalArgumentException.class, () -> IpAddressFunctions.bytesToIpv6(new byte[4]));
+    assertThrows(IllegalArgumentException.class, () -> IpAddressFunctions.bytesToIpv6(new byte[15]));
+  }
+
+  @Test
+  public void testIpv6RoundTrip() {
+    String[] addresses = {"::1", "2001:db8::1", "fe80::1", "::"};
+    for (String addr : addresses) {
+      assertEquals(IpAddressFunctions.bytesToIpv6(IpAddressFunctions.ipv6ToBytes(addr)), addr);
+    }
+  }
+
+  // ==================== Tests for ipv4ToIpv6 ====================
+
+  @Test
+  public void testIpv4ToIpv6() {
+    assertEquals(IpAddressFunctions.ipv4ToIpv6("192.168.1.1"), "::ffff:c0a8:101");
+  }
+
+  @Test
+  public void testIpv4ToIpv6Invalid() {
+    assertThrows(IllegalArgumentException.class, () -> IpAddressFunctions.ipv4ToIpv6("2001:db8::1"));
+  }
+
+  // ==================== Tests for ipv4CIDRToRange ====================
+
+  @Test
+  public void testIpv4CIDRToRange() {
+    String[] range = IpAddressFunctions.ipv4CIDRToRange("192.168.1.0/24");
+    assertEquals(range[0], "192.168.1.0");
+    assertEquals(range[1], "192.168.1.255");
+
+    range = IpAddressFunctions.ipv4CIDRToRange("10.0.0.0/8");
+    assertEquals(range[0], "10.0.0.0");
+    assertEquals(range[1], "10.255.255.255");
+
+    range = IpAddressFunctions.ipv4CIDRToRange("192.168.1.1/32");
+    assertEquals(range[0], "192.168.1.1");
+    assertEquals(range[1], "192.168.1.1");
+  }
+
+  @Test
+  public void testIpv4CIDRToRangeInvalid() {
+    // Not a prefix
+    assertThrows(IllegalArgumentException.class, () -> IpAddressFunctions.ipv4CIDRToRange("192.168.1.0"));
+    // IPv6 CIDR rejected
+    assertThrows(IllegalArgumentException.class, () -> IpAddressFunctions.ipv4CIDRToRange("2001:db8::/32"));
+  }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/common/function/scalar/StringFunctionsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/function/scalar/StringFunctionsTest.java
@@ -24,7 +24,9 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 
 public class StringFunctionsTest {
@@ -394,5 +396,109 @@ public class StringFunctionsTest {
 
     assertEquals(StringFunctions.encodeUrl(
         "https://localhost:8080/hello?a=b"), "https%3A%2F%2Flocalhost%3A8080%2Fhello%3Fa%3Db");
+  }
+
+  // ==================== Tests for ascii ====================
+
+  @Test
+  public void testAscii() {
+    assertEquals(StringFunctions.ascii("A"), 65);
+    assertEquals(StringFunctions.ascii("a"), 97);
+    assertEquals(StringFunctions.ascii("0"), 48);
+    assertEquals(StringFunctions.ascii("hello"), 104);
+    assertEquals(StringFunctions.ascii(" "), 32);
+    assertEquals(StringFunctions.ascii(""), 0);
+  }
+
+  // ==================== Tests for space ====================
+
+  @Test
+  public void testSpace() {
+    assertEquals(StringFunctions.space(0), "");
+    assertEquals(StringFunctions.space(1), " ");
+    assertEquals(StringFunctions.space(5), "     ");
+    assertEquals(StringFunctions.space(-1), "");
+  }
+
+  // ==================== Tests for substringIndex ====================
+
+  @Test
+  public void testSubstringIndex() {
+    // Positive count — substring before nth delimiter
+    assertEquals(StringFunctions.substringIndex("a.b.c.d", ".", 1), "a");
+    assertEquals(StringFunctions.substringIndex("a.b.c.d", ".", 2), "a.b");
+    assertEquals(StringFunctions.substringIndex("a.b.c.d", ".", 3), "a.b.c");
+    assertEquals(StringFunctions.substringIndex("a.b.c.d", ".", 10), "a.b.c.d");
+
+    // Negative count — substring after nth delimiter from right
+    assertEquals(StringFunctions.substringIndex("a.b.c.d", ".", -1), "d");
+    assertEquals(StringFunctions.substringIndex("a.b.c.d", ".", -2), "c.d");
+    assertEquals(StringFunctions.substringIndex("a.b.c.d", ".", -3), "b.c.d");
+    assertEquals(StringFunctions.substringIndex("a.b.c.d", ".", -10), "a.b.c.d");
+
+    // Zero count
+    assertEquals(StringFunctions.substringIndex("a.b.c", ".", 0), "");
+
+    // Empty delimiter
+    assertEquals(StringFunctions.substringIndex("a.b.c", "", 1), "");
+
+    // No delimiter found
+    assertEquals(StringFunctions.substringIndex("abc", ".", 1), "abc");
+    assertEquals(StringFunctions.substringIndex("abc", ".", -1), "abc");
+
+    // Multi-char delimiter
+    assertEquals(StringFunctions.substringIndex("a::b::c", "::", 1), "a");
+    assertEquals(StringFunctions.substringIndex("a::b::c", "::", -1), "c");
+  }
+
+  // ==================== Tests for firstLine ====================
+
+  @Test
+  public void testFirstLine() {
+    assertEquals(StringFunctions.firstLine("hello\nworld"), "hello");
+    assertEquals(StringFunctions.firstLine("single line"), "single line");
+    assertEquals(StringFunctions.firstLine(""), "");
+    assertEquals(StringFunctions.firstLine("\nstart"), "");
+    assertEquals(StringFunctions.firstLine("line1\nline2\nline3"), "line1");
+    // Windows line endings
+    assertEquals(StringFunctions.firstLine("hello\r\nworld"), "hello");
+    // Old Mac line endings
+    assertEquals(StringFunctions.firstLine("hello\rworld"), "hello");
+    // Mixed
+    assertEquals(StringFunctions.firstLine("first\r\nsecond\nthird"), "first");
+  }
+
+  // ==================== Tests for startsWithCaseInsensitive ====================
+
+  @Test
+  public void testStartsWithCaseInsensitive() {
+    assertTrue(StringFunctions.startsWithCaseInsensitive("Hello World", "hello"));
+    assertTrue(StringFunctions.startsWithCaseInsensitive("Hello World", "HELLO"));
+    assertTrue(StringFunctions.startsWithCaseInsensitive("Hello World", "Hello"));
+    assertTrue(StringFunctions.startsWithCaseInsensitive("Hello World", ""));
+    assertFalse(StringFunctions.startsWithCaseInsensitive("Hello World", "world"));
+  }
+
+  // ==================== Tests for endsWithCaseInsensitive ====================
+
+  @Test
+  public void testEndsWithCaseInsensitive() {
+    assertTrue(StringFunctions.endsWithCaseInsensitive("Hello World", "world"));
+    assertTrue(StringFunctions.endsWithCaseInsensitive("Hello World", "WORLD"));
+    assertTrue(StringFunctions.endsWithCaseInsensitive("Hello World", "World"));
+    assertTrue(StringFunctions.endsWithCaseInsensitive("Hello World", ""));
+    assertFalse(StringFunctions.endsWithCaseInsensitive("Hello World", "hello"));
+  }
+
+  // ==================== Tests for isValidASCII ====================
+
+  @Test
+  public void testIsValidASCII() {
+    assertTrue(StringFunctions.isValidASCII("hello"));
+    assertTrue(StringFunctions.isValidASCII("Hello World 123!@#"));
+    assertTrue(StringFunctions.isValidASCII(""));
+    assertFalse(StringFunctions.isValidASCII("héllo"));
+    assertFalse(StringFunctions.isValidASCII("日本語"));
+    assertFalse(StringFunctions.isValidASCII("café"));
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/ScalarTransformFunctionWrapperTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/ScalarTransformFunctionWrapperTest.java
@@ -30,6 +30,8 @@ import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.Strings;
 import org.apache.pinot.common.function.scalar.ArithmeticFunctions;
+import org.apache.pinot.common.function.scalar.IpAddressFunctions;
+import org.apache.pinot.common.function.scalar.StringFunctions;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.RequestContextUtils;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
@@ -1208,5 +1210,364 @@ public class ScalarTransformFunctionWrapperTest extends BaseTransformFunctionTes
       }
     }
     testTransformFunctionWithNull(transformFunction, expectedValues, bitmap);
+  }
+
+  @Test
+  public void testCbrtTransformFunction() {
+    ExpressionContext expression =
+        RequestContextUtils.getExpression(String.format("cbrt(%s)", DOUBLE_SV_COLUMN));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
+    assertEquals(transformFunction.getName(), "cbrt");
+    double[] expectedValues = new double[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = Math.cbrt(_doubleSVValues[i]);
+    }
+    testTransformFunction(transformFunction, expectedValues);
+  }
+
+  @Test
+  public void testExp2TransformFunction() {
+    ExpressionContext expression =
+        RequestContextUtils.getExpression(String.format("exp2(%s)", DOUBLE_SV_COLUMN));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
+    assertEquals(transformFunction.getName(), "exp2");
+    double[] expectedValues = new double[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = Math.pow(2, _doubleSVValues[i]);
+    }
+    testTransformFunction(transformFunction, expectedValues);
+  }
+
+  @Test
+  public void testExp10TransformFunction() {
+    ExpressionContext expression =
+        RequestContextUtils.getExpression(String.format("exp10(%s)", DOUBLE_SV_COLUMN));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
+    assertEquals(transformFunction.getName(), "exp10");
+    double[] expectedValues = new double[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = Math.pow(10, _doubleSVValues[i]);
+    }
+    testTransformFunction(transformFunction, expectedValues);
+  }
+
+  @Test
+  public void testLog1pTransformFunction() {
+    ExpressionContext expression =
+        RequestContextUtils.getExpression(String.format("log1p(%s)", DOUBLE_SV_COLUMN));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
+    assertEquals(transformFunction.getName(), "log1p");
+    double[] expectedValues = new double[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = Math.log1p(_doubleSVValues[i]);
+    }
+    testTransformFunction(transformFunction, expectedValues);
+  }
+
+  @Test
+  public void testSigmoidTransformFunction() {
+    ExpressionContext expression =
+        RequestContextUtils.getExpression(String.format("sigmoid(%s)", DOUBLE_SV_COLUMN));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
+    assertEquals(transformFunction.getName(), "sigmoid");
+    double[] expectedValues = new double[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = 1.0 / (1.0 + Math.exp(-_doubleSVValues[i]));
+    }
+    testTransformFunction(transformFunction, expectedValues);
+  }
+
+  @Test
+  public void testPiTransformFunction() {
+    ExpressionContext expression = RequestContextUtils.getExpression("pi()");
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
+    assertEquals(transformFunction.getName(), "pi");
+    double[] expectedValues = new double[NUM_ROWS];
+    Arrays.fill(expectedValues, Math.PI);
+    testTransformFunction(transformFunction, expectedValues);
+  }
+
+  @Test
+  public void testETransformFunction() {
+    ExpressionContext expression = RequestContextUtils.getExpression("e()");
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
+    assertEquals(transformFunction.getName(), "e");
+    double[] expectedValues = new double[NUM_ROWS];
+    Arrays.fill(expectedValues, Math.E);
+    testTransformFunction(transformFunction, expectedValues);
+  }
+
+  @Test
+  public void testBitCountTransformFunction() {
+    ExpressionContext expression =
+        RequestContextUtils.getExpression(String.format("bitCount(%s)", LONG_SV_COLUMN));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
+    assertEquals(transformFunction.getName(), "bitCount");
+    int[] expectedValues = new int[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = Long.bitCount(_longSVValues[i]);
+    }
+    testTransformFunction(transformFunction, expectedValues);
+  }
+
+  // --- IP Address Functions ---
+
+  @Test
+  public void testIsIPv4StringTransformFunction() {
+    ExpressionContext expression = RequestContextUtils.getExpression("isIPv4String('192.168.1.1')");
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
+    assertEquals(transformFunction.getName(), "isIPv4String");
+    int[] expectedValues = new int[NUM_ROWS];
+    Arrays.fill(expectedValues, 1);
+    testTransformFunction(transformFunction, expectedValues);
+
+    expression = RequestContextUtils.getExpression("isIPv4String('::1')");
+    transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    int[] expectedFalse = new int[NUM_ROWS];
+    Arrays.fill(expectedFalse, 0);
+    testTransformFunction(transformFunction, expectedFalse);
+  }
+
+  @Test
+  public void testIsIPv6StringTransformFunction() {
+    ExpressionContext expression = RequestContextUtils.getExpression("isIPv6String('::1')");
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
+    assertEquals(transformFunction.getName(), "isIPv6String");
+    int[] expectedValues = new int[NUM_ROWS];
+    Arrays.fill(expectedValues, 1);
+    testTransformFunction(transformFunction, expectedValues);
+
+    expression = RequestContextUtils.getExpression("isIPv6String('192.168.1.1')");
+    transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    int[] expectedFalse = new int[NUM_ROWS];
+    Arrays.fill(expectedFalse, 0);
+    testTransformFunction(transformFunction, expectedFalse);
+  }
+
+  @Test
+  public void testIpv4ToLongTransformFunction() {
+    ExpressionContext expression = RequestContextUtils.getExpression("ipv4ToLong('192.168.1.1')");
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
+    assertEquals(transformFunction.getName(), "ipv4ToLong");
+    long[] expectedValues = new long[NUM_ROWS];
+    Arrays.fill(expectedValues, IpAddressFunctions.ipv4ToLong("192.168.1.1"));
+    testTransformFunction(transformFunction, expectedValues);
+  }
+
+  @Test
+  public void testLongToIpv4TransformFunction() {
+    long ipLong = IpAddressFunctions.ipv4ToLong("10.0.0.1");
+    ExpressionContext expression =
+        RequestContextUtils.getExpression(String.format("longToIpv4(%d)", ipLong));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
+    assertEquals(transformFunction.getName(), "longToIpv4");
+    String[] expectedValues = new String[NUM_ROWS];
+    Arrays.fill(expectedValues, "10.0.0.1");
+    testTransformFunction(transformFunction, expectedValues);
+  }
+
+  @Test
+  public void testIpv4ToIpv6TransformFunction() {
+    ExpressionContext expression = RequestContextUtils.getExpression("ipv4ToIpv6('192.168.1.1')");
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
+    assertEquals(transformFunction.getName(), "ipv4ToIpv6");
+    String[] expectedValues = new String[NUM_ROWS];
+    Arrays.fill(expectedValues, IpAddressFunctions.ipv4ToIpv6("192.168.1.1"));
+    testTransformFunction(transformFunction, expectedValues);
+  }
+
+  @Test
+  public void testIpPrefixTransformFunction() {
+    ExpressionContext expression =
+        RequestContextUtils.getExpression("ipPrefix('192.168.1.100', 24)");
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
+    assertEquals(transformFunction.getName(), "ipPrefix");
+    String[] expectedValues = new String[NUM_ROWS];
+    Arrays.fill(expectedValues, IpAddressFunctions.ipPrefix("192.168.1.100", 24));
+    testTransformFunction(transformFunction, expectedValues);
+  }
+
+  @Test
+  public void testIsSubnetOfTransformFunction() {
+    ExpressionContext expression =
+        RequestContextUtils.getExpression("isSubnetOf('192.168.1.0/24', '192.168.1.100')");
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
+    assertEquals(transformFunction.getName(), "isSubnetOf");
+    int[] expectedValues = new int[NUM_ROWS];
+    Arrays.fill(expectedValues, 1);
+    testTransformFunction(transformFunction, expectedValues);
+  }
+
+  @Test
+  public void testIpSubnetMinTransformFunction() {
+    ExpressionContext expression =
+        RequestContextUtils.getExpression("ipSubnetMin('10.1.2.0/24')");
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
+    assertEquals(transformFunction.getName(), "ipSubnetMin");
+    String[] expectedValues = new String[NUM_ROWS];
+    Arrays.fill(expectedValues, IpAddressFunctions.ipSubnetMin("10.1.2.0/24"));
+    testTransformFunction(transformFunction, expectedValues);
+  }
+
+  @Test
+  public void testIpSubnetMaxTransformFunction() {
+    ExpressionContext expression =
+        RequestContextUtils.getExpression("ipSubnetMax('10.1.2.0/24')");
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
+    assertEquals(transformFunction.getName(), "ipSubnetMax");
+    String[] expectedValues = new String[NUM_ROWS];
+    Arrays.fill(expectedValues, IpAddressFunctions.ipSubnetMax("10.1.2.0/24"));
+    testTransformFunction(transformFunction, expectedValues);
+  }
+
+  @Test
+  public void testIpv6ToBytesTransformFunction() {
+    ExpressionContext expression = RequestContextUtils.getExpression("ipv6ToBytes('2001:db8::1')");
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
+    assertEquals(transformFunction.getName(), "ipv6ToBytes");
+    byte[][] expectedValues = new byte[NUM_ROWS][];
+    Arrays.fill(expectedValues, IpAddressFunctions.ipv6ToBytes("2001:db8::1"));
+    testTransformFunction(transformFunction, expectedValues);
+  }
+
+  @Test
+  public void testBytesToIpv6TransformFunction() {
+    ExpressionContext expression =
+        RequestContextUtils.getExpression("bytesToIpv6(ipv6ToBytes('2001:db8::1'))");
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
+    assertEquals(transformFunction.getName(), "bytesToIpv6");
+    String[] expectedValues = new String[NUM_ROWS];
+    Arrays.fill(expectedValues, "2001:db8::1");
+    testTransformFunction(transformFunction, expectedValues);
+  }
+
+  @Test
+  public void testIpv4CIDRToRangeTransformFunction() {
+    ExpressionContext expression =
+        RequestContextUtils.getExpression("ipv4CIDRToRange('192.168.1.0/24')");
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
+    assertEquals(transformFunction.getName(), "ipv4CIDRToRange");
+    String[][] expectedValues = new String[NUM_ROWS][];
+    Arrays.fill(expectedValues, new String[]{"192.168.1.0", "192.168.1.255"});
+    testTransformFunctionMV(transformFunction, expectedValues);
+  }
+
+  // --- String Functions ---
+
+  @Test
+  public void testAsciiTransformFunction() {
+    ExpressionContext expression =
+        RequestContextUtils.getExpression(String.format("ascii(%s)", STRING_ALPHANUM_SV_COLUMN));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
+    assertEquals(transformFunction.getName(), "ascii");
+    int[] expectedValues = new int[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = StringFunctions.ascii(_stringAlphaNumericSVValues[i]);
+    }
+    testTransformFunction(transformFunction, expectedValues);
+  }
+
+  @Test
+  public void testSpaceTransformFunction() {
+    ExpressionContext expression = RequestContextUtils.getExpression("space(5)");
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
+    assertEquals(transformFunction.getName(), "space");
+    String[] expectedValues = new String[NUM_ROWS];
+    Arrays.fill(expectedValues, "     ");
+    testTransformFunction(transformFunction, expectedValues);
+  }
+
+  @Test
+  public void testSubstringIndexTransformFunction() {
+    ExpressionContext expression = RequestContextUtils.getExpression(
+        String.format("substringIndex(%s, 'a', 1)", STRING_ALPHANUM_SV_COLUMN));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
+    assertEquals(transformFunction.getName(), "substringIndex");
+    String[] expectedValues = new String[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = StringFunctions.substringIndex(_stringAlphaNumericSVValues[i], "a", 1);
+    }
+    testTransformFunction(transformFunction, expectedValues);
+  }
+
+  @Test
+  public void testFirstLineTransformFunction() {
+    ExpressionContext expression =
+        RequestContextUtils.getExpression(String.format("firstLine(%s)", STRING_ALPHANUM_SV_COLUMN));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
+    assertEquals(transformFunction.getName(), "firstLine");
+    String[] expectedValues = new String[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = StringFunctions.firstLine(_stringAlphaNumericSVValues[i]);
+    }
+    testTransformFunction(transformFunction, expectedValues);
+  }
+
+  @Test
+  public void testStartsWithCaseInsensitiveTransformFunction() {
+    ExpressionContext expression = RequestContextUtils.getExpression(
+        String.format("startsWithCaseInsensitive(%s, 'A')", STRING_ALPHANUM_SV_COLUMN));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
+    assertEquals(transformFunction.getName(), "startsWithCaseInsensitive");
+    int[] expectedValues = new int[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = StringFunctions.startsWithCaseInsensitive(
+          _stringAlphaNumericSVValues[i], "A") ? 1 : 0;
+    }
+    testTransformFunction(transformFunction, expectedValues);
+  }
+
+  @Test
+  public void testEndsWithCaseInsensitiveTransformFunction() {
+    ExpressionContext expression = RequestContextUtils.getExpression(
+        String.format("endsWithCaseInsensitive(%s, 'Z')", STRING_ALPHANUM_SV_COLUMN));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
+    assertEquals(transformFunction.getName(), "endsWithCaseInsensitive");
+    int[] expectedValues = new int[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = StringFunctions.endsWithCaseInsensitive(
+          _stringAlphaNumericSVValues[i], "Z") ? 1 : 0;
+    }
+    testTransformFunction(transformFunction, expectedValues);
+  }
+
+  @Test
+  public void testIsValidASCIITransformFunction() {
+    ExpressionContext expression =
+        RequestContextUtils.getExpression(String.format("isValidASCII(%s)", STRING_ALPHANUM_SV_COLUMN));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    assertTrue(transformFunction instanceof ScalarTransformFunctionWrapper);
+    assertEquals(transformFunction.getName(), "isValidASCII");
+    int[] expectedValues = new int[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      expectedValues[i] = StringFunctions.isValidASCII(_stringAlphaNumericSVValues[i]) ? 1 : 0;
+    }
+    testTransformFunction(transformFunction, expectedValues);
   }
 }


### PR DESCRIPTION
## Summary

Adds 23 new `@ScalarFunction` methods. No new dependencies — all implementations use libraries already on the classpath. All functions are stateless, thread-safe, and auto-registered via `FunctionRegistry`.

| Category | Function | Description |
|---|---|---|
| **Math** | `cbrt(x)` | Cube root |
| | `exp2(x)` | 2^x (convenience over `power(2,x)`) |
| | `exp10(x)` | 10^x (convenience over `power(10,x)`) |
| | `log1p(x)` | Numerically stable log(1+x) |
| | `sigmoid(x)` | Logistic function 1/(1+e^-x) |
| | `pi()` | Returns π |
| | `e()` / `euler()` | Returns Euler's number |
| | `bitCount(x)` | Popcount (set bits) |
| **IP** | `isIPv4String(s)` | Validate IPv4 address |
| | `isIPv6String(s)` | Validate IPv6 address |
| | `ipv4ToLong(s)` | IPv4 → integer |
| | `longToIpv4(x)` | Integer → IPv4 |
| | `ipv6ToBytes(s)` | IPv6 → 16 bytes |
| | `bytesToIpv6(b)` | 16 bytes → IPv6 |
| | `ipv4ToIpv6(s)` | IPv4 → IPv4-mapped IPv6 |
| | `ipv4CIDRToRange(s)` | CIDR → [min, max] range |
| **String** | `ascii(s)` | ASCII code of first char |
| | `space(n)` | N spaces (convenience over `repeat(' ',n)`) |
| | `substringIndex(s,d,n)` | Everything before/after Nth delimiter |
| | `firstLine(s)` | Text before first newline |
| | `startsWithCaseInsensitive(s,p)` | Case-insensitive prefix check |
| | `endsWithCaseInsensitive(s,p)` | Case-insensitive suffix check |
| | `isValidASCII(s)` | All chars are ASCII |

## Test plan
- [ ] 56 unit tests across `ArithmeticFunctionsTest` (new), `IpAddressFunctionsTest`, `StringFunctionsTest` — edge cases include NaN, Infinity, boundary values, round-trip conversions, invalid inputs
- [ ] 27 transform tests in `ScalarTransformFunctionWrapperTest` — verifies each function works end-to-end through `ScalarTransformFunctionWrapper` with segment data
- [ ] All tests passing, zero compiler deprecation warnings in changed files
- [ ] Spotless, checkstyle, and license checks pass

## Documentation
Documentation updates to pinot-docs will follow once this PR is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)