### PR TITLE
Annotation-driven deprecated table config validation on create + update

### DIFF
--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/admin/README.md
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/admin/README.md
@@ -147,6 +147,94 @@ String status = tableClient.getTableStatus("myTable");
 String rebalanceResult = tableClient.rebalanceTable("myTable", true, "default", 1);
 ```
 
+### Creating Tables With Modern Config Fields
+
+Table create and update endpoints surface deprecated table-config properties via a `deprecationWarnings` field on
+the success response. The validator is in soft-launch mode: requests with deprecated keys succeed (HTTP 200) and the
+controller logs a warning. A future release will promote older deprecations to a `400 BAD_REQUEST` rejection, so
+clients should treat any value in `deprecationWarnings` as a migration TODO and update their payloads accordingly.
+
+Common migrations:
+
+- `segmentsConfig.segmentPushType` -> `ingestionConfig.batchIngestionConfig.segmentIngestionType`
+- `segmentsConfig.segmentPushFrequency` -> `ingestionConfig.batchIngestionConfig.segmentIngestionFrequency`
+- `tableIndexConfig.streamConfigs` -> `ingestionConfig.streamIngestionConfig.streamConfigMaps`
+- `fieldConfigList[].indexType` -> `fieldConfigList[].indexTypes`
+
+### Wire-shape changes (rolling upgrade)
+
+The same migration touches the controller's REST response shape. Several deprecated fields are no longer emitted
+when at their Java default. Old clients reading `GET /tables/{name}` or `GET /tableConfigs/{name}` MUST tolerate
+the absent fields:
+
+- `fieldConfigList[].indexType` is preserved in the response shape for back-compat, but the controller emits a
+  `deprecationWarnings` entry pointing callers to `indexTypes` instead.
+- The following boolean getters are now annotated with `@JsonInclude(NON_DEFAULT)`; the field disappears from the
+  response when the value is `false` (the type default): `upsertConfig.enableSnapshot`, `dedupConfig.enablePreload`,
+  `indexingConfig.createInvertedIndexDuringSegmentGeneration`,
+  `instanceAssignmentConfigMap.*.replicaGroupPartitionConfig.minimizeDataMovement`.
+
+The new `deprecationWarnings` field on `ConfigSuccessResponse` and `CopyTableResponse` is annotated with
+`@JsonInclude(NON_EMPTY)` and the response classes carry `@JsonIgnoreProperties(ignoreUnknown = true)`, so:
+
+- New clients reading old controllers: succeed (no `deprecationWarnings`, treated as empty).
+- Old clients reading new controllers: succeed (unknown field is ignored).
+
+Rolling-upgrade label: this PR changes wire shape (field elision and new optional field) but no field name or
+type is changed; existing clients that parse leniently round-trip cleanly. Strict-parsing clients should set
+`FAIL_ON_UNKNOWN_PROPERTIES=false` or upgrade in lockstep with the controller.
+
+Sample REALTIME table config for create:
+
+```json
+{
+  "tableName": "events",
+  "tableType": "REALTIME",
+  "segmentsConfig": {
+    "timeColumnName": "ts",
+    "replication": "1"
+  },
+  "tenants": {
+    "broker": "DefaultTenant",
+    "server": "DefaultTenant"
+  },
+  "tableIndexConfig": {
+    "loadMode": "MMAP"
+  },
+  "fieldConfigList": [
+    {
+      "name": "userId",
+      "encodingType": "DICTIONARY",
+      "indexTypes": [
+        "INVERTED"
+      ]
+    }
+  ],
+  "ingestionConfig": {
+    "batchIngestionConfig": {
+      "segmentIngestionType": "APPEND",
+      "segmentIngestionFrequency": "DAILY"
+    },
+    "streamIngestionConfig": {
+      "streamConfigMaps": [
+        {
+          "streamType": "kafka",
+          "stream.kafka.topic.name": "events",
+          "stream.kafka.consumer.type": "lowlevel",
+          "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.inputformat.json.JSONMessageDecoder"
+        }
+      ]
+    }
+  },
+  "metadata": {}
+}
+```
+
+A create or update request that includes deprecated fields succeeds (HTTP 200) with a populated
+`deprecationWarnings` array on the response body. Each entry names the offending JSON path and the replacement
+field to use. The response shape is identical for the `/tables/.../validate` and `/tableConfigs/.../validate`
+endpoints, so the same parser can surface warnings from any of them.
+
 ### Schema Operations
 
 ```java

--- a/pinot-common/src/main/java/org/apache/pinot/common/exception/TableConfigVersionConflictException.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/exception/TableConfigVersionConflictException.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.exception;
+
+/// Thrown by table-config update paths when the version-checked CAS write to ZooKeeper fails because a
+/// concurrent writer updated the znode between the pre-read (used for diffing / deprecation validation) and the
+/// subsequent write. Callers SHOULD surface this as HTTP 409 CONFLICT and instruct the client to re-read and
+/// retry — the failure is recoverable and is NOT the same as a transient ZK availability error.
+///
+/// **Unchecked** so adding the version-checked CAS path does not break the binary contract of pre-existing
+/// public methods (`PinotHelixResourceManager.setExistingTableConfig(TableConfig, int [, boolean])`). External
+/// callers that already swallow `RuntimeException` from the CAS-failure path continue to work; new callers that
+/// want 409 semantics can catch this specific subclass.
+public class TableConfigVersionConflictException extends RuntimeException {
+
+  public TableConfigVersionConflictException(String message) {
+    super(message);
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider.java
@@ -481,6 +481,27 @@ public class ZKMetadataProvider {
         AccessOption.PERSISTENT), replaceVariables, applyDecorator);
   }
 
+  /// Returns the raw [ZNRecord] for a stored table config without deserializing it. Use this when callers need the
+  /// byte-faithful view of what was last written to ZK (e.g. update-time deprecation diffing). Returns null when
+  /// the table does not exist.
+  @Nullable
+  public static ZNRecord getTableConfigZNRecord(ZkHelixPropertyStore<ZNRecord> propertyStore,
+      String tableNameWithType) {
+    return propertyStore.get(constructPropertyStorePathForResourceConfig(tableNameWithType), null,
+        AccessOption.PERSISTENT);
+  }
+
+  /// Same as [#getTableConfigZNRecord(ZkHelixPropertyStore, String)] but also populates the supplied [Stat] with the
+  /// stat of the read znode. Callers use the stat's version for a version-checked CAS on the subsequent write
+  /// (e.g. the deprecation-validator update path needs the version of the znode it diffed against to ensure no
+  /// concurrent writer slipped a deprecated key in between the diff read and the update write).
+  @Nullable
+  public static ZNRecord getTableConfigZNRecord(ZkHelixPropertyStore<ZNRecord> propertyStore,
+      String tableNameWithType, Stat stat) {
+    return propertyStore.get(constructPropertyStorePathForResourceConfig(tableNameWithType), stat,
+        AccessOption.PERSISTENT);
+  }
+
   @Nullable
   public static ImmutablePair<TableConfig, Stat> getTableConfigWithStat(ZkHelixPropertyStore<ZNRecord> propertyStore,
       String tableNameWithType) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider.java
@@ -480,6 +480,27 @@ public class ZKMetadataProvider {
         AccessOption.PERSISTENT), replaceVariables, applyDecorator);
   }
 
+  /// Returns the raw [ZNRecord] for a stored table config without deserializing it. Use this when callers need the
+  /// byte-faithful view of what was last written to ZK (e.g. update-time deprecation diffing). Returns null when
+  /// the table does not exist.
+  @Nullable
+  public static ZNRecord getTableConfigZNRecord(ZkHelixPropertyStore<ZNRecord> propertyStore,
+      String tableNameWithType) {
+    return propertyStore.get(constructPropertyStorePathForResourceConfig(tableNameWithType), null,
+        AccessOption.PERSISTENT);
+  }
+
+  /// Same as [#getTableConfigZNRecord(ZkHelixPropertyStore, String)] but also populates the supplied [Stat] with the
+  /// stat of the read znode. Callers use the stat's version for a version-checked CAS on the subsequent write
+  /// (e.g. the deprecation-validator update path needs the version of the znode it diffed against to ensure no
+  /// concurrent writer slipped a deprecated key in between the diff read and the update write).
+  @Nullable
+  public static ZNRecord getTableConfigZNRecord(ZkHelixPropertyStore<ZNRecord> propertyStore,
+      String tableNameWithType, Stat stat) {
+    return propertyStore.get(constructPropertyStorePathForResourceConfig(tableNameWithType), stat,
+        AccessOption.PERSISTENT);
+  }
+
   @Nullable
   public static ImmutablePair<TableConfig, Stat> getTableConfigWithStat(ZkHelixPropertyStore<ZNRecord> propertyStore,
       String tableNameWithType) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/DeprecatedTableConfigValidationUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/DeprecatedTableConfigValidationUtils.java
@@ -1,0 +1,723 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.utils.config;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.apache.pinot.common.version.PinotVersion;
+import org.apache.pinot.spi.config.BaseJsonConfig;
+import org.apache.pinot.spi.config.DeprecatedConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/// Validates raw table-config JSON for deprecated properties on create and update paths.
+///
+/// Rules are derived at class-load time from [DeprecatedConfig] annotations on getters reachable from [TableConfig].
+/// The current soft-launch policy reports every parseable annotation `since` value as [Severity#WARNING] so existing
+/// callers continue to work while seeing migration guidance. Only an unparseable annotation `since` value classifies
+/// as [Severity#ERROR], since that case is a code-side bug rather than user-supplied data.
+///
+/// The validator operates on raw JSON rather than the deserialized [TableConfig] so it can detect explicitly
+/// provided deprecated keys even when they carry default or false-y values that Jackson would otherwise elide.
+public final class DeprecatedTableConfigValidationUtils {
+  private DeprecatedTableConfigValidationUtils() {
+  }
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(DeprecatedTableConfigValidationUtils.class);
+  private static final String WILDCARD = "*";
+  private static final String FIELD_CONFIG_INDEX_TYPES_KEY = "indexTypes";
+  private static final List<String> FIELD_CONFIG_INDEX_TYPE_PATH =
+      List.of(TableConfig.FIELD_CONFIG_LIST_KEY, WILDCARD, "indexType");
+  /// Lazy holder. The list of rules is computed exactly once on first reference; classifySeverity calls
+  /// currentMajorMinor() directly so there is no source-order dependency between two interdependent constants.
+  private static final class Rules {
+    private static final List<DeprecatedConfigRule> ALL = discoverRules();
+  }
+
+  /// Test-only override of the rule list used by [#validate]. When set, [#activeRules] returns this list instead
+  /// of [Rules#ALL]; tests use this to inject a synthetic ERROR-severity rule and exercise the throw branch of
+  /// [#validateOnCreate] / [#validateOnUpdate] end-to-end through the REST surface without flipping
+  /// [#SOFT_LAUNCH_WARNING_ONLY]. Tests MUST clear the override (via [#clearRulesOverrideForTesting]) in a
+  /// `finally` block so a failing test does not poison subsequent tests' behaviour.
+  private static volatile List<DeprecatedConfigRule> _rulesOverrideForTesting;
+
+  @VisibleForTesting
+  public static void setRulesOverrideForTesting(List<DeprecatedConfigRule> rules) {
+    _rulesOverrideForTesting = rules;
+  }
+
+  @VisibleForTesting
+  public static void clearRulesOverrideForTesting() {
+    _rulesOverrideForTesting = null;
+  }
+
+  private static List<DeprecatedConfigRule> activeRules() {
+    List<DeprecatedConfigRule> override = _rulesOverrideForTesting;
+    return override != null ? override : Rules.ALL;
+  }
+
+  public enum Severity {
+    WARNING, ERROR
+  }
+
+  /// Result of validating a table-config JSON, exposing errors and warnings separately so callers can decide
+  /// whether to reject the request or surface non-fatal warnings to the user.
+  public static final class Result {
+    private final List<String> _errors;
+    private final List<String> _warnings;
+
+    private Result(List<String> errors, List<String> warnings) {
+      _errors = List.copyOf(errors);
+      _warnings = List.copyOf(warnings);
+    }
+
+    public List<String> getErrors() {
+      return _errors;
+    }
+
+    public List<String> getWarnings() {
+      return _warnings;
+    }
+
+    public boolean hasErrors() {
+      return !_errors.isEmpty();
+    }
+
+    public boolean hasWarnings() {
+      return !_warnings.isEmpty();
+    }
+  }
+
+  /// Validates a table-config JSON document. When `oldTableConfigJson` is non-null, only paths whose value newly
+  /// appears in `newTableConfigJson` or whose value differs from the corresponding path in `oldTableConfigJson` are
+  /// reported, so re-submitting an unchanged legacy field on an update is a no-op. When `oldTableConfigJson` is null
+  /// (creation path), every present deprecated path is reported.
+  ///
+  /// The `rootPathPrefix` argument controls the path string surfaced in deprecation warnings. It must mirror the
+  /// shape of the user-submitted JSON so the emitted path can be located back in the request body:
+  /// - `/tables/...` endpoints submit a single TableConfig whose root IS the bean, so pass `null` (no prefix).
+  /// - `/tableConfigs/...` endpoints submit `{"offline": {...}, "realtime": {...}}`, so pass `"offline"` /
+  ///   `"realtime"` when iterating each sub-section so warnings read e.g.
+  ///   `realtime.segmentsConfig.replicasPerPartition`.
+  ///
+  /// @param newTableConfigJson the incoming table config to validate; must not be `null`
+  /// @param oldTableConfigJson the currently-stored table config to diff against, or `null` for create paths
+  /// @param rootPathPrefix optional prefix for emitted paths, matching the user-submitted JSON structure
+  public static Result validate(JsonNode newTableConfigJson, @Nullable JsonNode oldTableConfigJson,
+      @Nullable String rootPathPrefix) {
+    return validateWithRules(newTableConfigJson, oldTableConfigJson, rootPathPrefix, activeRules());
+  }
+
+  /// Test seam for [#validate]. Allows unit tests to drive a synthetic rule list end-to-end, e.g. to verify
+  /// that an ERROR-severity rule trips [#validateOnCreate]'s throw branch without needing to flip the
+  /// [#SOFT_LAUNCH_WARNING_ONLY] feature gate.
+  static Result validateWithRules(JsonNode newTableConfigJson, @Nullable JsonNode oldTableConfigJson,
+      @Nullable String rootPathPrefix, List<DeprecatedConfigRule> rules) {
+    Objects.requireNonNull(newTableConfigJson, "newTableConfigJson");
+    List<String> errors = new ArrayList<>();
+    List<String> warnings = new ArrayList<>();
+    String prefix = rootPathPrefix == null ? "" : rootPathPrefix;
+    for (DeprecatedConfigRule rule : rules) {
+      rule.collect(newTableConfigJson, oldTableConfigJson, prefix, errors, warnings);
+    }
+    return new Result(errors, warnings);
+  }
+
+  /// Test seam exposing the throw-on-errors decision branch in [#validateOnCreate]. Tests assemble a
+  /// synthetic [Result] (e.g. via [#validateWithRules] with a single ERROR-severity rule) and pass it here.
+  /// Production callers should always invoke [#validateOnCreate] which constructs the Result via [#validate].
+  static List<String> throwIfErrorsOnCreate(Result result) {
+    if (result.hasErrors()) {
+      throw new IllegalArgumentException("Deprecated table config properties are not allowed on table creation: "
+          + String.join("; ", result.getErrors()));
+    }
+    if (result.hasWarnings()) {
+      LOGGER.warn("Deprecated table config properties on creation: {}", String.join("; ", result.getWarnings()));
+    }
+    return result.getWarnings();
+  }
+
+  /// Validates a freshly-submitted table config (no prior stored value). On any error the method throws
+  /// [IllegalArgumentException]; warnings are returned so the caller can surface them in the response.
+  public static List<String> validateOnCreate(JsonNode newTableConfigJson, @Nullable String rootPathPrefix) {
+    return throwIfErrorsOnCreate(validate(newTableConfigJson, null, rootPathPrefix));
+  }
+
+  /// Validates an updated table config against its currently-stored counterpart. Only newly-introduced or
+  /// value-changed deprecated paths are reported, so legacy values that were already present do not block updates.
+  /// On any error the method throws [IllegalArgumentException]; warnings are returned for the caller to surface.
+  ///
+  /// Callers must ensure the table exists before invoking this method; pass the stored config JSON (never `null`)
+  /// for `oldTableConfigJson`. For paths where no stored counterpart exists, use [#validateOnCreate] instead.
+  public static List<String> validateOnUpdate(JsonNode newTableConfigJson, JsonNode oldTableConfigJson,
+      @Nullable String rootPathPrefix) {
+    Objects.requireNonNull(oldTableConfigJson, "oldTableConfigJson; use validateOnCreate for create paths");
+    Result result = validate(newTableConfigJson, oldTableConfigJson, rootPathPrefix);
+    if (result.hasErrors()) {
+      throw new IllegalArgumentException("Newly introduced deprecated table config properties are not allowed: "
+          + String.join("; ", result.getErrors()));
+    }
+    if (result.hasWarnings()) {
+      LOGGER.warn("Newly introduced deprecated table config properties on update: {}",
+          String.join("; ", result.getWarnings()));
+    }
+    return result.getWarnings();
+  }
+
+  static List<DeprecatedConfigRule> rulesForTesting() {
+    return Collections.unmodifiableList(Rules.ALL);
+  }
+
+  /// Eagerly initialise the lazy `Rules.ALL` holder so the first user-facing REST request after controller
+  /// startup doesn't pay the reflective discovery cost. Returns the rule count for the caller to log. Fails
+  /// loudly: if the discovery walk throws (e.g., duplicate `@JsonProperty` across two annotated getters on the
+  /// same bean), the `ExceptionInInitializerError` surfaces at startup rather than on every REST endpoint.
+  public static int warmUp() {
+    return Rules.ALL.size();
+  }
+
+  /// Test seam to construct synthetic [DeprecatedConfigRule] instances. The constructor is package-private so
+  /// production code cannot fabricate rules outside the reflective discovery walk; tests use this to inject
+  /// synthetic ERROR-severity rules into [#setRulesOverrideForTesting] for end-to-end coverage of the throw
+  /// branch in [#validateOnCreate]. Path segments use `*` as a wildcard for array elements and map values.
+  @VisibleForTesting
+  public static DeprecatedConfigRule makeRuleForTesting(List<String> pathSegments, String replacement, String since,
+      Severity severity) {
+    return new DeprecatedConfigRule(List.copyOf(pathSegments), replacement, since, severity, Object.class, null);
+  }
+
+  private static List<DeprecatedConfigRule> discoverRules() {
+    List<DeprecatedConfigRule> rules = new ArrayList<>();
+    walk(TableConfig.class, new ArrayList<>(), new HashSet<>(), rules);
+    return Collections.unmodifiableList(rules);
+  }
+
+  /// Safety cap on path depth to fail loudly if a future SPI change introduces a cycle that the visiting set
+  /// alone can't break (e.g. a Map<String, NestedBean> recursion through wildcards).
+  private static final int MAX_WALK_DEPTH = 32;
+
+  private static void walk(Type type, List<String> currentPath, Set<Class<?>> visiting,
+      List<DeprecatedConfigRule> rules) {
+    Preconditions.checkState(currentPath.size() < MAX_WALK_DEPTH,
+        "Pathological depth in @DeprecatedConfig discovery walk (path=%s); check for a cycle in TableConfig nested "
+            + "beans", currentPath);
+    Class<?> rawClass = rawClass(type);
+    if (rawClass == null) {
+      return;
+    }
+    if (Map.class.isAssignableFrom(rawClass)) {
+      Type valueType = typeArg(type, 1);
+      if (valueType != null) {
+        currentPath.add(WILDCARD);
+        walk(valueType, currentPath, visiting, rules);
+        currentPath.remove(currentPath.size() - 1);
+      }
+      return;
+    }
+    if (Collection.class.isAssignableFrom(rawClass)) {
+      Type elemType = typeArg(type, 0);
+      if (elemType != null) {
+        currentPath.add(WILDCARD);
+        walk(elemType, currentPath, visiting, rules);
+        currentPath.remove(currentPath.size() - 1);
+      }
+      return;
+    }
+    if (rawClass.isArray()) {
+      currentPath.add(WILDCARD);
+      walk(rawClass.getComponentType(), currentPath, visiting, rules);
+      currentPath.remove(currentPath.size() - 1);
+      return;
+    }
+    if (!isConfigBean(rawClass) || !visiting.add(rawClass)) {
+      return;
+    }
+    /// Detect duplicate JSON property names on the same bean — e.g. both a `@JsonProperty("foo")` getter and a
+    /// bare `getFoo()`. `Class.getMethods()` returns methods in unspecified order, so a collision would let
+    /// either rule win non-deterministically and silently disable validation for the loser. Fail loud at
+    /// class-load time instead.
+    Set<String> seenProperties = new HashSet<>();
+    try {
+      for (Method method : rawClass.getMethods()) {
+        if (!isJsonAccessor(method)) {
+          continue;
+        }
+        String propertyName = jsonPropertyName(method);
+        if (propertyName == null) {
+          continue;
+        }
+        Preconditions.checkState(seenProperties.add(propertyName),
+            "Duplicate JSON property name '%s' on bean %s — both a @JsonProperty-annotated getter and a bare "
+                + "getter map to the same name. Pick one or rename the @JsonProperty value so the deprecation "
+                + "discovery walk is deterministic.", propertyName, rawClass.getName());
+        currentPath.add(propertyName);
+        DeprecatedConfig anno = method.getAnnotation(DeprecatedConfig.class);
+        if (anno != null) {
+          rules.add(new DeprecatedConfigRule(List.copyOf(currentPath), anno.replacement(), anno.since(),
+              classifySeverity(anno.since()), rawClass, method));
+        }
+        walk(method.getGenericReturnType(), currentPath, visiting, rules);
+        currentPath.remove(currentPath.size() - 1);
+      }
+    } finally {
+      visiting.remove(rawClass);
+    }
+  }
+
+  private static boolean isConfigBean(Class<?> rawClass) {
+    return BaseJsonConfig.class.isAssignableFrom(rawClass) && rawClass != BaseJsonConfig.class;
+  }
+
+  /// **`@JsonIgnore` getters are intentionally NOT filtered out.** The validator's job is to detect deprecated
+  /// JSON *input* keys (which are still accepted by the bean's `@JsonCreator` / setters even when the matching
+  /// output getter is `@JsonIgnore`-d). For example, `FieldConfig.getIndexType()` is `@JsonIgnore` because we no
+  /// longer want it to round-trip back into JSON, but the constructor still accepts an `indexType` argument so
+  /// legacy configs continue to parse. Filtering by `@JsonIgnore` here would silently disable the rule for that
+  /// legacy input — exactly the case the validator exists to flag.
+  ///
+  /// Implicit contract for future `@DeprecatedConfig` annotations on `@JsonIgnore` getters: the bean MUST accept
+  /// the corresponding JSON property name via a `@JsonCreator` parameter or setter for the rule to fire on
+  /// real-world input. There is no build-time assertion of this invariant yet; if you add such an annotation,
+  /// also add a test exercising a real JSON input that uses the deprecated key.
+  private static boolean isJsonAccessor(Method method) {
+    if (method.getParameterCount() != 0 || method.getDeclaringClass() == Object.class
+        || Modifier.isStatic(method.getModifiers())) {
+      return false;
+    }
+    Class<?> returnType = method.getReturnType();
+    if (returnType == void.class) {
+      return false;
+    }
+    String name = method.getName();
+    if (name.startsWith("get") && name.length() > 3) {
+      return true;
+    }
+    return name.startsWith("is") && name.length() > 2 && (returnType == boolean.class || returnType == Boolean.class);
+  }
+
+  @Nullable
+  private static String jsonPropertyName(Method method) {
+    JsonProperty jsonProperty = method.getAnnotation(JsonProperty.class);
+    if (jsonProperty != null && !jsonProperty.value().isEmpty()) {
+      return jsonProperty.value();
+    }
+    String name = method.getName();
+    String stripped;
+    if (name.startsWith("get")) {
+      stripped = name.substring(3);
+    } else if (name.startsWith("is")) {
+      stripped = name.substring(2);
+    } else {
+      return null;
+    }
+    if (stripped.isEmpty()) {
+      return null;
+    }
+    return Character.toLowerCase(stripped.charAt(0)) + stripped.substring(1);
+  }
+
+  @Nullable
+  private static Class<?> rawClass(Type type) {
+    if (type instanceof Class<?>) {
+      return (Class<?>) type;
+    }
+    if (type instanceof ParameterizedType) {
+      Type rawType = ((ParameterizedType) type).getRawType();
+      if (rawType instanceof Class<?>) {
+        return (Class<?>) rawType;
+      }
+    }
+    return null;
+  }
+
+  @Nullable
+  private static Type typeArg(Type type, int index) {
+    if (type instanceof ParameterizedType) {
+      Type[] args = ((ParameterizedType) type).getActualTypeArguments();
+      if (index < args.length) {
+        return args[index];
+      }
+    }
+    return null;
+  }
+
+  @Nullable
+  private static String currentMajorMinor() {
+    String version = PinotVersion.VERSION;
+    if (version == null || PinotVersion.UNKNOWN.equals(version)) {
+      return null;
+    }
+    return majorMinor(version);
+  }
+
+  /// Returns the `major.minor` prefix of a version string, stripping any pre-release qualifier (e.g. `-SNAPSHOT`)
+  /// and ignoring the patch component. Returns `null` if the input does not parse.
+  @Nullable
+  static String majorMinor(@Nullable String version) {
+    if (version == null) {
+      return null;
+    }
+    String trimmed = version.trim();
+    int qualifierIdx = trimmed.indexOf('-');
+    if (qualifierIdx >= 0) {
+      trimmed = trimmed.substring(0, qualifierIdx);
+    }
+    String[] parts = trimmed.split("\\.");
+    if (parts.length < 2) {
+      return null;
+    }
+    if (!isNumeric(parts[0]) || !isNumeric(parts[1])) {
+      return null;
+    }
+    return parts[0] + "." + parts[1];
+  }
+
+  private static boolean isNumeric(String s) {
+    if (s.isEmpty()) {
+      return false;
+    }
+    for (int i = 0; i < s.length(); i++) {
+      if (!Character.isDigit(s.charAt(i))) {
+        return false;
+      }
+    }
+    return true;
+  }
+
+  /// Decides the severity for a violation based on the annotation's `since` value. The current Pinot release's
+  /// deprecations are warnings (one-release grace period); older deprecations escalate to errors.
+  ///
+  /// Feature gate: while `true`, every parseable `@DeprecatedConfig.since` classifies as a WARNING regardless of
+  /// the running Pinot version. Flip to `false` (and supply real comparison logic in [#classifySeverity]) to
+  /// promote older deprecations to ERROR after the codebase has migrated off them. Grep-able sentinel so the
+  /// follow-up promotion PR is a single-keyword change rather than a behavioural drift.
+  ///
+  /// PROMOTION PRE-CONDITIONS — the follow-up PR that flips this MUST first verify:
+  /// 1. **Done in this PR**: every update path uses a version-checked CAS (PinotTableRestletResource and
+  ///    TableConfigsRestletResource both thread the ZK znode version from the diff read through to
+  ///    `PinotHelixResourceManager.updateTableConfig(tableConfig, expectedVersion, force)`). A concurrent writer
+  ///    that lands between the diff read and the write bumps the version, the CAS fails, and the update is
+  ///    rejected — preventing a deprecated key from slipping past the diff.
+  /// 2. A concurrency regression test that exercises the read→write window with a stubbed ZK observer.
+  /// 3. A test seam (e.g. injected currentMajorMinor or a non-final flag) that exercises this method's
+  ///    older-than-current → ERROR branch end-to-end.
+  /// 4. A REST integration test that exercises the validator's ERROR-path end-to-end (currently exercised only
+  ///    via unit tests of [#throwIfErrorsOnCreate]).
+  ///
+  /// SUNSET TARGET: the flip is intended for the release AFTER 1.6.0 (i.e. ≥1.7.0). Until promotion lands, this
+  /// validator runs as a logging shim: it adds no behavioural change versus the pre-existing `@Deprecated` IDE
+  /// warning, but it surfaces deprecated keys in REST responses where operators can observe them centrally. If
+  /// the promotion PR has not landed by the 1.7.0 release cut, re-evaluate whether the validator should stay on
+  /// (and continue collecting deprecation telemetry) or be gated behind a controller config flag.
+  static final boolean SOFT_LAUNCH_WARNING_ONLY = true;
+
+  /// Classifies the soft-launch severity for a deprecated property. Under the [#SOFT_LAUNCH_WARNING_ONLY] policy
+  /// the only outcome that is ever ERROR is "the annotation's `since` string is unparseable" — a code-side bug,
+  /// not a user-supplied data problem. Every other case (including the version-unknown environment fallback) is
+  /// reported as WARNING.
+  static Severity classifySeverity(String since) {
+    return classifySeverity(since, currentMajorMinor());
+  }
+
+  /// Test seam for [#classifySeverity(String)] that takes the current major.minor version explicitly so the
+  /// version-unknown fallback branch can be unit-tested without manipulating the classloader-scoped
+  /// `pinot-version.properties` resource.
+  ///
+  /// Note: the `currentMajorMinor` parameter is currently unused at production runtime because
+  /// [#SOFT_LAUNCH_WARNING_ONLY] forces every parseable `since` to WARNING. It is preserved for the follow-up
+  /// promotion PR which will compare against the running version to decide ERROR vs WARNING.
+  static Severity classifySeverity(String since, @Nullable String currentMajorMinor) {
+    String sinceMajorMinor = majorMinor(since);
+    if (sinceMajorMinor == null) {
+      return Severity.ERROR;
+    }
+    return Severity.WARNING;
+  }
+
+  /// Returns true when the JSON value matches the Java zero-value for its type (`false` for booleans, `0` for
+  /// numerics, empty for strings/arrays/objects, and explicit JSON `null`). This is an approximation of
+  /// Jackson's `@JsonInclude(NON_DEFAULT)` semantics: the real Jackson behaviour consults the bean's actual
+  /// initialised default by instantiating it, but every deprecated getter currently annotated with
+  /// `@DeprecatedConfig` uses a type-zero default. A regression test in
+  /// `DeprecatedTableConfigValidationUtilsTest#testEveryAnnotatedGetterHasJavaZeroDefault` walks every
+  /// discovered rule's leaf bean+getter and asserts the Java default value is treated as default here, so a
+  /// future contributor who annotates a non-zero-default getter fails at test time rather than silently
+  /// suppressing diffs at runtime.
+  ///
+  /// Numeric types are compared via integer paths where possible to avoid the `double`-coercion edge cases
+  /// (lossy conversion for `BigDecimal`/`BigInteger`, IEEE-754 `-0.0 == 0.0d`, etc.). Today no annotated getter
+  /// returns a floating-point or arbitrary-precision type, but the dispatch is robust enough to extend to those
+  /// cases in the future.
+  static boolean isJacksonDefault(@Nullable JsonNode node) {
+    if (node == null || node.isMissingNode() || node.isNull()) {
+      return true;
+    }
+    if (node.isBoolean()) {
+      return !node.booleanValue();
+    }
+    if (node.isShort() || node.isInt() || node.isLong()) {
+      return node.longValue() == 0L;
+    }
+    if (node.isBigInteger()) {
+      return BigInteger.ZERO.equals(node.bigIntegerValue());
+    }
+    if (node.isBigDecimal()) {
+      return BigDecimal.ZERO.compareTo(node.decimalValue()) == 0;
+    }
+    if (node.isFloatingPointNumber()) {
+      /// Use Double.compare so -0.0 is treated as non-default (it differs from the Java zero-value of 0.0d).
+      return Double.compare(node.doubleValue(), 0.0d) == 0;
+    }
+    if (node.isTextual()) {
+      /// Every currently-annotated String-returning getter has a Java field default of null (asserted by
+      /// DeprecatedTableConfigValidationUtilsTest#testEveryAnnotatedGetterHasJavaZeroDefault). The explicit-null
+      /// case is already handled above, so any textual node here is a real user-supplied value. NOTE: this is NOT
+      /// a faithful reimplementation of Jackson @JsonInclude(NON_DEFAULT) — a String field that defaults to "" in
+      /// its bean would be elided by Jackson and would arrive as a missing node, never reaching this branch. If a
+      /// future @DeprecatedConfig is added on a String getter whose owning field defaults to "", revisit this
+      /// branch and the no-arg-default-instance test that backs it.
+      return false;
+    }
+    if (node.isArray() || node.isObject()) {
+      return node.isEmpty();
+    }
+    /// BinaryNode / POJONode never arise from text JSON parsed by Jackson; treat as non-default conservatively.
+    return false;
+  }
+
+  public static final class DeprecatedConfigRule {
+    private final List<String> _pathSegments;
+    private final String _replacement;
+    private final String _since;
+    private final Severity _severity;
+    private final Class<?> _leafOwner;
+    private final Method _leafGetter;
+
+    DeprecatedConfigRule(List<String> pathSegments, String replacement, String since, Severity severity,
+        Class<?> leafOwner, Method leafGetter) {
+      _pathSegments = pathSegments;
+      _replacement = replacement;
+      _since = since;
+      _severity = severity;
+      _leafOwner = leafOwner;
+      _leafGetter = leafGetter;
+    }
+
+    List<String> pathSegments() {
+      return _pathSegments;
+    }
+
+    Severity severity() {
+      return _severity;
+    }
+
+    /// Returns the raw `since` string from the source `@DeprecatedConfig`. Exposed for tests so they can lock
+    /// the build-time invariant that every annotated `since` parses to a non-null version (see
+    /// `testEveryRuleHasParseableSince`); a typo here would resolve to `Severity.ERROR` and turn every REST
+    /// PUT/POST that touches this path into a 400 the moment the soft-launch flag flips.
+    String since() {
+      return _since;
+    }
+
+    /// Returns the bean class that declares the leaf annotated getter. Exposed for tests so they can verify the
+    /// default-value invariant assumed by [#isJacksonDefault].
+    Class<?> leafOwner() {
+      return _leafOwner;
+    }
+
+    /// Returns the leaf annotated getter. Exposed for tests so they can read the Java default value from a
+    /// no-arg-constructed bean and assert it is treated as default by [#isJacksonDefault].
+    Method leafGetter() {
+      return _leafGetter;
+    }
+
+    void collect(JsonNode newRoot, @Nullable JsonNode oldRoot, String pathPrefix, List<String> errors,
+        List<String> warnings) {
+      List<MatchedPath> matches = new ArrayList<>();
+      collectMatches(newRoot, oldRoot, null, 0, pathPrefix, matches);
+      for (MatchedPath match : matches) {
+        if (oldRoot != null) {
+          /// Update path. Silently drop matches that are unchanged from the stored config, OR that are absent in
+          /// the stored config but whose new value is the type's Java default. The default-skip handles the case
+          /// where many deprecated getters carry @JsonInclude(NON_DEFAULT): a previous create with
+          /// `enableSnapshot: false` is stripped at ZK write time, so on PUT the diff would otherwise see `false`
+          /// as "newly introduced" and reject an unchanged config. Crucially, the default-skip applies ONLY when
+          /// the stored config did not contain the path — a deliberate flip of an existing non-default value back
+          /// to the default (e.g. `true` → `false`) is still reported, matching validateOnUpdate's contract that
+          /// value-changed deprecated paths must be flagged.
+          if (match._oldValue != null) {
+            if (Objects.equals(match._newValue, match._oldValue)) {
+              continue;
+            }
+          } else if (isModernFieldConfigIndexTypeEquivalent(match)
+              || DeprecatedTableConfigValidationUtils.isJacksonDefault(match._newValue)) {
+            continue;
+          }
+        }
+        String message = "'" + match._path + "' is deprecated since " + _since + ". " + _replacement;
+        if (_severity == Severity.ERROR) {
+          errors.add(message);
+        } else {
+          warnings.add(message);
+        }
+      }
+    }
+
+    private boolean isModernFieldConfigIndexTypeEquivalent(MatchedPath match) {
+      if (!_pathSegments.equals(FIELD_CONFIG_INDEX_TYPE_PATH) || match._oldParent == null
+          || !match._oldParent.isObject()) {
+        return false;
+      }
+      JsonNode oldIndexTypes = match._oldParent.get(FIELD_CONFIG_INDEX_TYPES_KEY);
+      return oldIndexTypes != null && oldIndexTypes.isArray() && oldIndexTypes.size() == 1
+          && Objects.equals(oldIndexTypes.get(0), match._newValue);
+    }
+
+    private void collectMatches(@Nullable JsonNode newNode, @Nullable JsonNode oldNode,
+        @Nullable JsonNode oldParentNode, int idx, String currentPath, List<MatchedPath> matches) {
+      if (newNode == null || newNode.isMissingNode()) {
+        return;
+      }
+      if (idx == _pathSegments.size()) {
+        matches.add(new MatchedPath(currentPath, newNode, oldNode, oldParentNode));
+        return;
+      }
+      String segment = _pathSegments.get(idx);
+      if (WILDCARD.equals(segment)) {
+        if (newNode.isArray()) {
+          for (int i = 0; i < newNode.size(); i++) {
+            JsonNode newElem = newNode.get(i);
+            /// Find the matching old element by a stable identity key so that reordering an array between two PUTs
+            /// does not surface unchanged legacy values as "newly introduced" — see C5.2 / validateOnUpdate
+            /// contract. The lookup prefers the `name` field (used by FieldConfig, TierConfig, etc.); falls back to
+            /// positional alignment only when neither side has a usable identity key.
+            JsonNode oldElem = findMatchingOldElement(newElem, oldNode, i);
+            collectMatches(newElem, oldElem, oldNode, idx + 1, currentPath + "[" + i + "]", matches);
+          }
+        } else if (newNode.isObject()) {
+          newNode.fieldNames().forEachRemaining(field -> {
+            JsonNode oldChild = (oldNode != null && oldNode.isObject()) ? oldNode.get(field) : null;
+            collectMatches(newNode.get(field), oldChild, oldNode, idx + 1, append(currentPath, field), matches);
+          });
+        }
+        return;
+      }
+      if (newNode.has(segment)) {
+        JsonNode oldChild = (oldNode != null && oldNode.isObject()) ? oldNode.get(segment) : null;
+        collectMatches(newNode.get(segment), oldChild, oldNode, idx + 1, append(currentPath, segment), matches);
+      }
+    }
+
+    @Nullable
+    private static JsonNode findMatchingOldElement(JsonNode newElem, @Nullable JsonNode oldNode, int positionalIdx) {
+      if (oldNode == null || !oldNode.isArray()) {
+        return null;
+      }
+      /// Identity-key match policy: `name` is the stable key for FieldConfig and TierConfig (the Pinot
+      /// table-config beans that ship as wildcard-element types under TableConfig today). To avoid a
+      /// positional-fallback footgun where a malformed legacy element without a `name` could spuriously align
+      /// with a different-shaped old element at the same index, require either:
+      /// - BOTH sides carry a textual `name` (match by name; null if no equal-name candidate exists), OR
+      /// - NEITHER side carries a textual `name` (positional fallback for genuinely non-keyed arrays).
+      /// Mixed shapes (one side has `name`, the other doesn't) return null so the new element is treated as
+      /// newly-introduced rather than incorrectly aligned with a positional sibling.
+      boolean newHasName = hasTextualName(newElem);
+      boolean anyOldHasName = false;
+      for (int i = 0; i < oldNode.size(); i++) {
+        if (hasTextualName(oldNode.get(i))) {
+          anyOldHasName = true;
+          break;
+        }
+      }
+      if (newHasName != anyOldHasName) {
+        /// Asymmetric: don't pretend the position-aligned sibling is the same element.
+        return null;
+      }
+      if (newHasName) {
+        String key = newElem.get("name").asText();
+        JsonNode firstMatch = null;
+        int matches = 0;
+        for (int i = 0; i < oldNode.size(); i++) {
+          JsonNode candidate = oldNode.get(i);
+          if (hasTextualName(candidate) && key.equals(candidate.get("name").asText())) {
+            if (firstMatch == null) {
+              firstMatch = candidate;
+            }
+            matches++;
+          }
+        }
+        if (matches > 1) {
+          /// Stored array carries duplicate `name` keys — Pinot does not enforce uniqueness at the JSON layer,
+          /// so this is legal but rare. First-name-wins alignment would silently misalign later duplicates with
+          /// their first sibling. Log so the corruption is visible; fall back to first match to preserve the
+          /// historical behaviour.
+          LOGGER.warn("Stored deprecated-config array contains {} elements with duplicate name='{}'; deprecation "
+              + "diff aligns against the first match. Resolve duplicates in the stored ZK record to silence this "
+              + "warning.", matches, key);
+        }
+        /// firstMatch is null if newElem has a name but no old element matches → treat as newly introduced.
+        return firstMatch;
+      }
+      return positionalIdx < oldNode.size() ? oldNode.get(positionalIdx) : null;
+    }
+
+    private static boolean hasTextualName(@Nullable JsonNode node) {
+      return node != null && node.isObject() && node.hasNonNull("name") && node.get("name").isTextual();
+    }
+
+    private static String append(String currentPath, String segment) {
+      return currentPath.isEmpty() ? segment : currentPath + "." + segment;
+    }
+  }
+
+  private static final class MatchedPath {
+    final String _path;
+    final JsonNode _newValue;
+    @Nullable
+    final JsonNode _oldValue;
+    @Nullable
+    final JsonNode _oldParent;
+
+    MatchedPath(String path, JsonNode newValue, @Nullable JsonNode oldValue, @Nullable JsonNode oldParent) {
+      _path = path;
+      _newValue = newValue;
+      _oldValue = oldValue;
+      _oldParent = oldParent;
+    }
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/TableConfigSerDeUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/TableConfigSerDeUtils.java
@@ -20,11 +20,15 @@ package org.apache.pinot.common.utils.config;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Preconditions;
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.pinot.spi.config.table.DedupConfig;
@@ -48,10 +52,14 @@ import org.apache.pinot.spi.config.table.assignment.SegmentAssignmentConfig;
 import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.apache.pinot.spi.config.table.sampler.TableSamplerConfig;
 import org.apache.pinot.spi.utils.JsonUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /// Util class for serializing and deserializing [TableConfig] to and from [ZNRecord].
 public class TableConfigSerDeUtils {
+  private static final Logger LOGGER = LoggerFactory.getLogger(TableConfigSerDeUtils.class);
+
   private TableConfigSerDeUtils() {
   }
 
@@ -296,5 +304,71 @@ public class TableConfigSerDeUtils {
     ZNRecord znRecord = new ZNRecord(tableConfig.getTableName());
     znRecord.setSimpleFields(simpleFields);
     return znRecord;
+  }
+
+  /// Reconstructs the table-config JSON tree from a stored [ZNRecord], preserving every key originally written to
+  /// ZK. Unlike `TableConfig.toJsonNode()`, this method does not round-trip through the Java bean and therefore
+  /// does not strip fields that the bean's getters mark with `@JsonIgnore` or `@JsonInclude(NON_DEFAULT)`. It is
+  /// intended for code paths (e.g. update-time deprecation diffing) that need to compare an incoming request
+  /// against the exact bytes that were stored.
+  ///
+  /// JSON parsing is restricted to values whose first non-whitespace character is `{` or `[` (objects/arrays).
+  /// Other values are kept as raw text nodes so that a stored simple field like a tableName `"123"` is not
+  /// coerced by Jackson's lenient parser into a numeric node.
+  ///
+  /// @param znRecord the raw ZNRecord read from the property store
+  /// @return a JsonNode equivalent to what the user originally PUT/POST-ed for the table, or `null` if the input is
+  /// `null`
+  @Nullable
+  public static JsonNode toRawJsonNode(@Nullable ZNRecord znRecord) {
+    if (znRecord == null) {
+      return null;
+    }
+    ObjectNode root = JsonNodeFactory.instance.objectNode();
+    Map<String, String> simpleFields = znRecord.getSimpleFields();
+    for (Map.Entry<String, String> entry : simpleFields.entrySet()) {
+      String key = entry.getKey();
+      String value = entry.getValue();
+      if (value == null) {
+        /// ZNRecord simpleFields is a regular HashMap that permits null values. Preserve the null in the JSON tree
+        /// (NullNode) so a downstream diff sees the original ZK state byte-faithfully.
+        root.putNull(key);
+        continue;
+      }
+      if (looksLikeJsonContainer(value)) {
+        try {
+          root.set(key, JsonUtils.stringToJsonNode(value));
+          continue;
+        } catch (IOException e) {
+          /// Malformed JSON container under a key that we expected to be parseable. Operators need to know — the
+          /// downstream diff will treat the value as a text node instead of a structured object, which can
+          /// produce spurious "path newly introduced" warnings on update. WARN-log so the corruption is visible
+          /// (the table is still usable since fromZNRecord owns the deserialization path; this only affects the
+          /// raw-JSON view used by the deprecation validator).
+          LOGGER.warn("Stored simpleField {} on znode {} starts with '{}'/'[' but failed to parse as JSON: {}. "
+                  + "Falling back to a text-node representation; downstream diffs may treat the path as newly "
+                  + "introduced.", key, znRecord.getId(), e.getMessage());
+        }
+      }
+      root.put(key, value);
+    }
+    if (!root.has(TableConfig.TABLE_NAME_KEY)) {
+      root.put(TableConfig.TABLE_NAME_KEY, znRecord.getId());
+    }
+    return root;
+  }
+
+  /// Returns true if the value's first non-whitespace character is `{` or `[`, indicating a JSON object/array
+  /// payload. Restricts JSON parsing in [#toRawJsonNode] so that simple textual fields whose contents happen to
+  /// look like JSON primitives (`"true"`, `"null"`, `"123"`, etc.) are kept as text nodes rather than coerced.
+  private static boolean looksLikeJsonContainer(String value) {
+    for (int i = 0; i < value.length(); i++) {
+      char c = value.charAt(i);
+      if (Character.isWhitespace(c)) {
+        continue;
+      }
+      return c == '{' || c == '[';
+    }
+    return false;
   }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/config/DeprecatedTableConfigValidationUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/config/DeprecatedTableConfigValidationUtilsTest.java
@@ -1,0 +1,647 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.utils.config;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.apache.pinot.common.utils.config.DeprecatedTableConfigValidationUtils.DeprecatedConfigRule;
+import org.apache.pinot.common.utils.config.DeprecatedTableConfigValidationUtils.Result;
+import org.apache.pinot.common.utils.config.DeprecatedTableConfigValidationUtils.Severity;
+import org.apache.pinot.spi.config.BaseJsonConfig;
+import org.apache.pinot.spi.config.DeprecatedConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+public class DeprecatedTableConfigValidationUtilsTest {
+
+  @Test
+  public void testReportsDeprecatedConfigsOnCreateAsWarnings()
+      throws Exception {
+    /// Soft-launch policy: every parseable @DeprecatedConfig annotation is reported as a WARNING on create so
+    /// legacy callers (TableConfigBuilder setters, integration test bases, downstream automations) keep working.
+    /// A follow-up PR can promote to ERROR after the codebase migrates off these paths.
+    JsonNode tableConfigJson = JsonUtils.stringToJsonNode("{"
+        + "\"segmentsConfig\":{\"replicasPerPartition\":\"APPEND\",\"minimizeDataMovement\":false},"
+        + "\"fieldConfigList\":[{\"name\":\"c1\",\"indexType\":\"INVERTED\"}],"
+        + "\"instanceAssignmentConfigMap\":{\"CONSUMING\":{\"replicaGroupPartitionConfig\":"
+        + "{\"minimizeDataMovement\":false}}}}");
+
+    List<String> warnings =
+        DeprecatedTableConfigValidationUtils.validateOnCreate(tableConfigJson, "realtime");
+    assertTrue(warnings.stream().anyMatch(w -> w.contains("realtime.segmentsConfig.replicasPerPartition")), warnings
+        .toString());
+    assertTrue(warnings.stream().anyMatch(w -> w.contains("realtime.segmentsConfig.minimizeDataMovement")), warnings
+        .toString());
+    assertTrue(warnings.stream().anyMatch(w -> w.contains("realtime.fieldConfigList[0].indexType")), warnings
+        .toString());
+    assertTrue(warnings.stream().anyMatch(w -> w.contains(
+            "realtime.instanceAssignmentConfigMap.CONSUMING.replicaGroupPartitionConfig.minimizeDataMovement")),
+        warnings.toString());
+  }
+
+  @Test
+  public void testCurrentVersionDeprecationIsWarningNotError()
+      throws Exception {
+    /// tableIndexConfig.createInvertedIndexDuringSegmentGeneration is annotated with since=1.6.0, matching the
+    /// current Pinot release line. It is reported as a warning (matches the soft-launch policy where every
+    /// parseable `since` classifies as a warning).
+    JsonNode tableConfigJson = JsonUtils.stringToJsonNode(
+        "{\"tableIndexConfig\":{\"createInvertedIndexDuringSegmentGeneration\":false}}");
+
+    List<String> warnings = DeprecatedTableConfigValidationUtils.validateOnCreate(tableConfigJson, null);
+    assertTrue(warnings.stream().anyMatch(
+            w -> w.contains("tableIndexConfig.createInvertedIndexDuringSegmentGeneration")),
+        "expected warning for current-version deprecation, got: " + warnings);
+  }
+
+  @Test
+  public void testAllowsModernConfigsOnCreate()
+      throws Exception {
+    JsonNode tableConfigJson = JsonUtils.stringToJsonNode("{"
+        + "\"segmentsConfig\":{\"replication\":\"1\"},"
+        + "\"fieldConfigList\":[{\"name\":\"c1\",\"indexTypes\":[\"INVERTED\"]}],"
+        + "\"ingestionConfig\":{\"batchIngestionConfig\":{\"segmentIngestionType\":\"APPEND\"},"
+        + "\"streamIngestionConfig\":{\"streamConfigMaps\":[{\"streamType\":\"kafka\"}]}}}");
+
+    DeprecatedTableConfigValidationUtils.validateOnCreate(tableConfigJson, null);
+  }
+
+  @Test
+  public void testUpdateAllowsUnchangedLegacyDeprecatedValue()
+      throws Exception {
+    /// Legacy config is already stored with replicasPerPartition=APPEND. Re-submitting the same value must NOT trigger
+    /// an error: the diff sees the value as unchanged.
+    JsonNode oldJson = JsonUtils.stringToJsonNode("{\"segmentsConfig\":{\"replicasPerPartition\":\"APPEND\"}}");
+    JsonNode newJson = JsonUtils.stringToJsonNode("{\"segmentsConfig\":{\"replicasPerPartition\":\"APPEND\"}}");
+
+    Result result = DeprecatedTableConfigValidationUtils.validate(newJson, oldJson, null);
+    assertFalse(result.hasErrors(), "errors=" + result.getErrors());
+    assertFalse(result.hasWarnings(), "warnings=" + result.getWarnings());
+  }
+
+  @Test
+  public void testUpdateReportsValueChangeOnDeprecatedFieldAsWarning()
+      throws Exception {
+    /// Legacy config had replicasPerPartition=APPEND. The update changes it to REFRESH — the diff treats this as
+    /// a new write to a deprecated key and reports a warning under the soft-launch policy.
+    JsonNode oldJson = JsonUtils.stringToJsonNode("{\"segmentsConfig\":{\"replicasPerPartition\":\"APPEND\"}}");
+    JsonNode newJson = JsonUtils.stringToJsonNode("{\"segmentsConfig\":{\"replicasPerPartition\":\"REFRESH\"}}");
+
+    Result result = DeprecatedTableConfigValidationUtils.validate(newJson, oldJson, null);
+    assertTrue(result.hasWarnings(), "expected warning on changed deprecated value");
+    assertTrue(result.getWarnings().get(0).contains("segmentsConfig.replicasPerPartition"),
+        result.getWarnings().toString());
+  }
+
+  @Test
+  public void testUpdateAllowsReSubmittedDefaultValueWhenAbsentFromStored()
+      throws Exception {
+    /// Many deprecated booleans carry @JsonInclude(NON_DEFAULT). A previous create with `enableSnapshot: false`
+    /// (the type default) is stripped at ZK write time, so the stored config has no `enableSnapshot` key. On PUT,
+    /// the diff sees the path as missing in the stored config but present in the new submission with the type
+    /// default — the validator must treat this as a no-op so users can re-submit cached configs unchanged.
+    JsonNode oldJson = JsonUtils.stringToJsonNode("{\"upsertConfig\":{}}");
+    JsonNode newJson = JsonUtils.stringToJsonNode("{\"upsertConfig\":{\"enableSnapshot\":false}}");
+
+    Result result = DeprecatedTableConfigValidationUtils.validate(newJson, oldJson, null);
+    assertFalse(result.hasErrors(), "errors=" + result.getErrors());
+    assertFalse(result.hasWarnings(), "warnings=" + result.getWarnings());
+  }
+
+  @Test
+  public void testUpdateAllowsLegacyIndexTypeWhenStoredAsSingletonIndexTypes()
+      throws Exception {
+    /// Even when stored configs were written before `@DeprecatedConfig` shipped (so the legacy `indexType` key is
+    /// absent and only the singleton `indexTypes` array survives in ZK), re-submitting the same legacy payload on
+    /// update must remain idempotent. The validator's `isModernFieldConfigIndexTypeEquivalent` shortcut handles
+    /// this old-stored / new-input shape mismatch.
+    JsonNode oldJson =
+        JsonUtils.stringToJsonNode("{\"fieldConfigList\":[{\"name\":\"c1\",\"indexTypes\":[\"INVERTED\"]}]}");
+    JsonNode newJson =
+        JsonUtils.stringToJsonNode("{\"fieldConfigList\":[{\"name\":\"c1\",\"indexType\":\"INVERTED\"}]}");
+
+    Result result = DeprecatedTableConfigValidationUtils.validate(newJson, oldJson, null);
+    assertFalse(result.hasErrors(), "errors=" + result.getErrors());
+    assertFalse(result.hasWarnings(), "warnings=" + result.getWarnings());
+  }
+
+  @Test
+  public void testUpdateReportsLegacyIndexTypeWhenStoredIndexTypesAreNotEquivalent()
+      throws Exception {
+    /// The compatibility shortcut only applies to a singleton `indexTypes` value that exactly matches `indexType`.
+    /// Multi-index stored configs cannot be represented by legacy `indexType`, so the deprecated write is reported.
+    JsonNode oldJson = JsonUtils.stringToJsonNode(
+        "{\"fieldConfigList\":[{\"name\":\"c1\",\"indexTypes\":[\"INVERTED\",\"RANGE\"]}]}");
+    JsonNode newJson =
+        JsonUtils.stringToJsonNode("{\"fieldConfigList\":[{\"name\":\"c1\",\"indexType\":\"INVERTED\"}]}");
+
+    Result result = DeprecatedTableConfigValidationUtils.validate(newJson, oldJson, null);
+    assertTrue(result.hasWarnings(), "expected warning on non-equivalent legacy indexType");
+    assertTrue(result.getWarnings().get(0).contains("fieldConfigList[0].indexType"),
+        result.getWarnings().toString());
+  }
+
+  @Test
+  public void testUpdateTreatsExplicitJsonNullStoredValueAsPresent()
+      throws Exception {
+    /// The stored JSON has an explicit `null` value for a deprecated path. The new submission flips it to a
+    /// non-default `true`. Both differ, so the diff must report it (the default-skip applies only when the path
+    /// was *absent* in the stored config, not when it was present-but-null).
+    JsonNode oldJson = JsonUtils.stringToJsonNode("{\"upsertConfig\":{\"enableSnapshot\":null}}");
+    JsonNode newJson = JsonUtils.stringToJsonNode("{\"upsertConfig\":{\"enableSnapshot\":true}}");
+
+    Result result = DeprecatedTableConfigValidationUtils.validate(newJson, oldJson, null);
+    assertTrue(result.hasWarnings(), "expected warning on flip from null to true");
+    assertTrue(result.getWarnings().get(0).contains("upsertConfig.enableSnapshot"),
+        result.getWarnings().toString());
+  }
+
+  @Test
+  public void testUpdateReportsDeliberateFlipFromNonDefaultToDefaultAsWarning()
+      throws Exception {
+    /// The default-skip optimisation must not silently swallow a deliberate value flip on an existing field.
+    /// Stored config has `enableSnapshot: true`; user submits `enableSnapshot: false` — this is a value change on
+    /// a deprecated path and is reported as a warning under the soft-launch policy.
+    JsonNode oldJson = JsonUtils.stringToJsonNode("{\"upsertConfig\":{\"enableSnapshot\":true}}");
+    JsonNode newJson = JsonUtils.stringToJsonNode("{\"upsertConfig\":{\"enableSnapshot\":false}}");
+
+    Result result = DeprecatedTableConfigValidationUtils.validate(newJson, oldJson, null);
+    assertTrue(result.hasWarnings(), "expected warning on deliberate flip true → false");
+    assertTrue(result.getWarnings().get(0).contains("upsertConfig.enableSnapshot"),
+        result.getWarnings().toString());
+  }
+
+  @Test
+  public void testUpdateReportsEmptyStringValueForNullDefaultField()
+      throws Exception {
+    /// String-returning deprecated getters initialise to null (the Java default), not "". A user submitting
+    /// "replicasPerPartition":"" on update — when the stored config lacks the key — is supplying a real value that
+    /// Jackson would NOT elide under NON_DEFAULT, and is flagged as a warning. Locks the textual branch of
+    /// isJacksonDefault returning false (rather than treating empty string as default).
+    JsonNode oldJson = JsonUtils.stringToJsonNode("{\"segmentsConfig\":{\"replication\":\"1\"}}");
+    JsonNode newJson = JsonUtils.stringToJsonNode(
+        "{\"segmentsConfig\":{\"replication\":\"1\",\"replicasPerPartition\":\"\"}}");
+
+    Result result = DeprecatedTableConfigValidationUtils.validate(newJson, oldJson, null);
+    assertTrue(result.hasWarnings(), "expected warning on empty-string value for deprecated path");
+    assertTrue(result.getWarnings().get(0).contains("segmentsConfig.replicasPerPartition"),
+        result.getWarnings().toString());
+  }
+
+  @Test
+  public void testUpdateReportsNewlyIntroducedDeprecatedField()
+      throws Exception {
+    /// Legacy config did not contain the deprecated field. Adding it on update fires a warning under the
+    /// soft-launch policy (parseable since classifies as warning).
+    JsonNode oldJson = JsonUtils.stringToJsonNode("{\"segmentsConfig\":{\"replication\":\"1\"}}");
+    JsonNode newJson = JsonUtils.stringToJsonNode(
+        "{\"segmentsConfig\":{\"replication\":\"1\",\"replicasPerPartition\":\"APPEND\"}}");
+
+    Result result = DeprecatedTableConfigValidationUtils.validate(newJson, oldJson, null);
+    assertTrue(result.hasWarnings());
+    assertTrue(result.getWarnings().get(0).contains("segmentsConfig.replicasPerPartition"));
+  }
+
+  @Test
+  public void testMajorMinorParsing() {
+    assertEquals(DeprecatedTableConfigValidationUtils.majorMinor("1.6.0"), "1.6");
+    assertEquals(DeprecatedTableConfigValidationUtils.majorMinor("1.6.0-SNAPSHOT"), "1.6");
+    assertEquals(DeprecatedTableConfigValidationUtils.majorMinor("1.6"), "1.6");
+    assertEquals(DeprecatedTableConfigValidationUtils.majorMinor("12.345.6"), "12.345");
+    assertNull(DeprecatedTableConfigValidationUtils.majorMinor(null));
+    assertNull(DeprecatedTableConfigValidationUtils.majorMinor("garbage"));
+    assertNull(DeprecatedTableConfigValidationUtils.majorMinor("1"));
+  }
+
+  @Test
+  public void testSeverityClassification() {
+    /// An unparseable annotation `since` reflects a code-side bug and classifies as ERROR.
+    assertEquals(DeprecatedTableConfigValidationUtils.classifySeverity("garbage"), Severity.ERROR);
+    assertEquals(DeprecatedTableConfigValidationUtils.classifySeverity(""), Severity.ERROR);
+    assertEquals(DeprecatedTableConfigValidationUtils.classifySeverity("1"), Severity.ERROR);
+  }
+
+  @Test
+  public void testSeverityIsWarningForAllParseableSinceUnderSoftLaunch() {
+    /// Soft-launch policy: every parseable `since` returns WARNING, regardless of the running Pinot version, so
+    /// existing callers that already use deprecated keys keep working. ERROR is reserved for unparseable values
+    /// (which reflect a code-side annotation bug, not user-supplied data).
+    assertEquals(DeprecatedTableConfigValidationUtils.classifySeverity("1.6.0", null), Severity.WARNING);
+    assertEquals(DeprecatedTableConfigValidationUtils.classifySeverity("1.5.0", null), Severity.WARNING);
+    assertEquals(DeprecatedTableConfigValidationUtils.classifySeverity("0.3.0", null), Severity.WARNING);
+    assertEquals(DeprecatedTableConfigValidationUtils.classifySeverity("1.6.0", "1.6"), Severity.WARNING);
+    assertEquals(DeprecatedTableConfigValidationUtils.classifySeverity("1.5.0", "1.6"), Severity.WARNING);
+    assertEquals(DeprecatedTableConfigValidationUtils.classifySeverity("0.3.0", "1.6"), Severity.WARNING);
+    assertEquals(DeprecatedTableConfigValidationUtils.classifySeverity("garbage", null), Severity.ERROR);
+    assertEquals(DeprecatedTableConfigValidationUtils.classifySeverity("garbage", "1.6"), Severity.ERROR);
+  }
+
+  /// Locks in the contract assumed by [DeprecatedTableConfigValidationUtils#isJacksonDefault]: every getter
+  /// annotated with [DeprecatedConfig @DeprecatedConfig] must be on a bean whose
+  /// no-arg-constructed default value for that getter is a Java zero-value (`false`, `0`, `null`, empty string,
+  /// empty collection). If a future contributor adds the annotation on a getter whose bean default is non-zero
+  /// (e.g. an int defaulting to `1`), this test fails at compile/test time rather than silently suppressing
+  /// deprecation diffs at runtime.
+  @Test
+  public void testEveryAnnotatedGetterHasJavaZeroDefault()
+      throws Exception {
+    for (DeprecatedConfigRule rule : DeprecatedTableConfigValidationUtils.rulesForTesting()) {
+      Class<?> owner = rule.leafOwner();
+      Method getter = rule.leafGetter();
+      Object defaultInstance = instantiateForDefaultLookup(owner);
+      Object value = getter.invoke(defaultInstance);
+      JsonNode jsonValue = JsonUtils.objectToJsonNode(value);
+      assertTrue(DeprecatedTableConfigValidationUtils.isJacksonDefault(jsonValue),
+          "Java default for " + owner.getSimpleName() + "#" + getter.getName() + " (path=" + rule.pathSegments()
+              + ") is " + value + " (JSON=" + jsonValue + "), which isJacksonDefault treats as non-default. "
+              + "Either change the field's Java default to the type-zero value, OR teach isJacksonDefault to "
+              + "consult the bean's actual default via reflection.");
+    }
+  }
+
+  /// Beans whose declared constructor reflection-with-placeholder-args is known to produce the same Java field
+  /// defaults that Jackson would observe. New beans that hit the third fallback must be added here explicitly
+  /// (after a human confirms the reflective ctor preserves the bean's default field state) — otherwise the
+  /// test fails loud, so a future `@DeprecatedConfig` on a non-zero-default getter cannot silently slip past.
+  private static final Set<String> ALLOW_REFLECTIVE_CTOR_FALLBACK = Set.of(
+      "org.apache.pinot.spi.config.table.FieldConfig",
+      "org.apache.pinot.spi.config.table.assignment.InstanceReplicaGroupPartitionConfig");
+
+  /// Returns a default-state instance of `owner` suitable for reading the Java zero-value of each declared field.
+  /// Strategy: (1) prefer a no-arg constructor; (2) fall back to Jackson deserialization of `"{}"`; (3) for an
+  /// allowlisted bean (see [#ALLOW_REFLECTIVE_CTOR_FALLBACK]), invoke the smallest declared constructor with
+  /// `null` for reference params and zero/placeholder for primitives. Falling through to (3) for an unlisted
+  /// bean throws so a new `@DeprecatedConfig` on a non-zero-default getter cannot silently skip the contract.
+  private static Object instantiateForDefaultLookup(Class<?> owner)
+      throws Exception {
+    try {
+      return owner.getDeclaredConstructor().newInstance();
+    } catch (NoSuchMethodException ignored) {
+      /// No no-arg constructor; fall through.
+    }
+    try {
+      return JsonUtils.stringToObject("{}", owner);
+    } catch (Exception ignored) {
+      /// @JsonCreator requires fields that aren't in "{}". Try reflective construction with null/zero defaults.
+    }
+    if (!ALLOW_REFLECTIVE_CTOR_FALLBACK.contains(owner.getName())) {
+      throw new AssertionError("Bean " + owner.getName() + " requires reflective-ctor fallback to instantiate "
+          + "for @DeprecatedConfig default-value lookup, but is not in ALLOW_REFLECTIVE_CTOR_FALLBACK. "
+          + "Confirm by hand that the bean's reflective-zero-arg ctor produces the same field defaults that "
+          + "Jackson would deserialize, then add the FQN to the allowlist.");
+    }
+    Constructor<?>[] ctors = owner.getDeclaredConstructors();
+    /// Sort by parameter count ascending — prefer the smallest viable constructor.
+    Arrays.sort(ctors, Comparator.comparingInt(Constructor::getParameterCount));
+    Exception lastFailure = null;
+    for (Constructor<?> ctor : ctors) {
+      Object[] args = new Object[ctor.getParameterCount()];
+      Class<?>[] paramTypes = ctor.getParameterTypes();
+      for (int i = 0; i < args.length; i++) {
+        args[i] = primitiveZeroOrPlaceholder(paramTypes[i]);
+      }
+      try {
+        ctor.setAccessible(true);
+        return ctor.newInstance(args);
+      } catch (Exception e) {
+        lastFailure = e;
+      }
+    }
+    throw new AssertionError("Cannot instantiate " + owner.getName() + " for default-value lookup", lastFailure);
+  }
+
+  @Nullable
+  private static Object primitiveZeroOrPlaceholder(Class<?> type) {
+    /// String params may carry Preconditions.checkArgument(name != null) — supply the empty string rather than null
+    /// or a non-default sentinel. Using "" means the test fails only when a real String getter has a non-default
+    /// default; a "_test"-like sentinel would surface as a confusing "got `_test`, expected default" failure for
+    /// any future String getter even when the bean's real default is also non-empty.
+    if (type == String.class) {
+      return "";
+    }
+    if (!type.isPrimitive()) {
+      return null;
+    }
+    if (type == boolean.class) {
+      return false;
+    }
+    if (type == char.class) {
+      return '\0';
+    }
+    if (type == byte.class) {
+      return (byte) 0;
+    }
+    if (type == short.class) {
+      return (short) 0;
+    }
+    if (type == int.class) {
+      return 0;
+    }
+    if (type == long.class) {
+      return 0L;
+    }
+    if (type == float.class) {
+      return 0f;
+    }
+    if (type == double.class) {
+      return 0d;
+    }
+    throw new IllegalStateException("Unknown primitive type: " + type);
+  }
+
+  /// Locks the rule-list cache. The discovery walk is intentionally one-shot at class-init (lazy holder
+  /// pattern); if a future refactor accidentally re-runs `discoverRules()` on every `validate(...)` call, this
+  /// test fails fast. We check that the underlying backing list is the same JVM-identity instance, not just
+  /// equal — the unmodifiable wrapper returned by `rulesForTesting()` rewraps each call, so we compare via
+  /// the rule pointers it contains instead.
+  @Test
+  public void testRulesListIsCachedAcrossCalls() {
+    List<DeprecatedConfigRule> first = DeprecatedTableConfigValidationUtils.rulesForTesting();
+    List<DeprecatedConfigRule> second = DeprecatedTableConfigValidationUtils.rulesForTesting();
+    assertEquals(first.size(), second.size());
+    for (int i = 0; i < first.size(); i++) {
+      assertTrue(first.get(i) == second.get(i),
+          "rulesForTesting() should return cached rule instances; rule " + i + " differs across calls. "
+              + "Check that Rules.ALL is still a static final and that no refactor moved discoverRules() to a "
+              + "per-request path.");
+    }
+  }
+
+  /// Eagerly forces the static `Rules.ALL` discovery walk at test time so a duplicate JsonProperty annotation
+  /// or other discovery-walk bug surfaces as a JUnit failure instead of as an `ExceptionInInitializerError`
+  /// that takes down every controller endpoint after deployment. Today, `rulesForTesting()` is the only way to
+  /// trigger the lazy-holder load, so any test class that touches the validator already serves this purpose;
+  /// this test makes the intent explicit and adds a friendly failure message pointing at the likely cause.
+  @Test
+  public void testDiscoveryWalkDoesNotThrowAtClassLoad() {
+    try {
+      DeprecatedTableConfigValidationUtils.rulesForTesting();
+    } catch (Throwable t) {
+      throw new AssertionError(
+          "DeprecatedTableConfigValidationUtils discovery walk failed at class load. The lazy holder (Rules.ALL) "
+              + "throws ExceptionInInitializerError on every subsequent reference, so a controller deploying with "
+              + "this build would 500 on every table CREATE/UPDATE/VALIDATE/TUNE/COPY endpoint. Likely causes: a "
+              + "duplicate JsonProperty name across two @DeprecatedConfig getters on the same bean, an annotation "
+              + "with an unparseable since=\"...\" value, or a nested bean cycle exceeding MAX_WALK_DEPTH. Root "
+              + "cause:",
+          t);
+    }
+  }
+
+  /// Locks the soft-launch flag at its initial value so the flip cannot land without an intentional, reviewable
+  /// edit. The PR that flips this constant MUST first land the items enumerated in [#SOFT_LAUNCH_WARNING_ONLY]'s
+  /// Javadoc — version-checked CAS on the update path, a concurrency regression test, an injected-version test
+  /// seam, and an integration test of the ERROR-path. Once those are in place, edit BOTH `SOFT_LAUNCH_WARNING_ONLY`
+  /// and this test in the same commit so the test continues to lock the post-flip value.
+  ///
+  /// Promotion pre-conditions coverage map (cross-references for future maintainers):
+  /// 1. Version-checked CAS — implemented in `PinotHelixResourceManager.setExistingTableConfig(...)`. Threaded
+  ///    through `PinotTableRestletResource.updateTableConfig` and `TableConfigsRestletResource.updateConfig`.
+  /// 2. Concurrency regression test —
+  ///    `PinotHelixResourceManagerStatelessTest#testUpdateTableConfigCasConflictThrowsConflictException`.
+  ///    Exercises the T1-read / T2-write / T1-CAS-fail interleaving end-to-end.
+  /// 3. Version-injection seam — see `classifySeverity(String, String)` overload in
+  ///    `DeprecatedTableConfigValidationUtils`; tests pass an injected `currentMajorMinor` to exercise the
+  ///    older-than-current → ERROR branch.
+  /// 4. ERROR-path REST integration test —
+  ///    `PinotTableRestletResourceTest#testErrorSeverityRuleRejectsCreateAs400`. Uses the `@VisibleForTesting`
+  ///    rule-override seam to inject a synthetic ERROR rule and asserts 400.
+  @Test
+  public void testSoftLaunchFlagDefaultsToWarningOnly() {
+    assertTrue(DeprecatedTableConfigValidationUtils.SOFT_LAUNCH_WARNING_ONLY,
+        "SOFT_LAUNCH_WARNING_ONLY must remain true until the four promotion pre-conditions in its Javadoc are met. "
+            + "Edit this test in the same commit that flips the flag, and ensure the promotion PR also adds: "
+            + "(1) version-checked CAS on PinotTableRestletResource and TableConfigsRestletResource update paths, "
+            + "(2) a concurrency regression test that exercises the read→write window, "
+            + "(3) a test seam for the older-than-current → ERROR branch in classifySeverity, "
+            + "(4) an integration test that exercises the validator's ERROR-path end-to-end through the REST stack.");
+  }
+
+  /// Locks the build-time invariant that every `@DeprecatedConfig.since` value is parseable. Without this guard
+  /// a typo like `@DeprecatedConfig(since = "")` would classify as ERROR (Severity.ERROR is the unparseable-
+  /// since fallback in `classifySeverity`). Today, under `SOFT_LAUNCH_WARNING_ONLY = true`, an ERROR fires the
+  /// throw branch in `validateOnCreate`/`validateOnUpdate` → 400 from the REST endpoints. When the soft-launch
+  /// flag flips, a since-typo on any annotation becomes a permanent production outage for every PUT/POST that
+  /// touches that path. Fail at class-load instead.
+  @Test
+  public void testEveryRuleHasParseableSince() {
+    for (DeprecatedConfigRule rule : DeprecatedTableConfigValidationUtils.rulesForTesting()) {
+      assertEquals(rule.severity(), Severity.WARNING,
+          "Rule at " + rule.pathSegments() + " has @DeprecatedConfig(since=\"" + rule.since() + "\") that the "
+              + "soft-launch classifier resolved to " + rule.severity() + ". Under SOFT_LAUNCH_WARNING_ONLY=true "
+              + "this means `since` is unparseable. Use MAJOR.MINOR or MAJOR.MINOR.PATCH form (e.g. \"1.6.0\").");
+    }
+  }
+
+  /// Locks the dual-annotation invariant: every getter annotated with `@DeprecatedConfig` (the validator metadata)
+  /// must also carry `@Deprecated` (the JDK marker that surfaces IDE/compiler warnings). Without this guard a
+  /// future contributor can add a `@DeprecatedConfig` annotation without `@Deprecated`, so callers continue to
+  /// use the field without the IDE warning that should signal a migration.
+  @Test
+  public void testEveryAnnotatedGetterAlsoCarriesJdkDeprecated() {
+    for (DeprecatedConfigRule rule : DeprecatedTableConfigValidationUtils.rulesForTesting()) {
+      Method getter = rule.leafGetter();
+      assertTrue(getter.isAnnotationPresent(Deprecated.class),
+          "Getter " + rule.leafOwner().getSimpleName() + "#" + getter.getName()
+              + " has @DeprecatedConfig but lacks @Deprecated. Both annotations are required: @DeprecatedConfig"
+              + " for the runtime validator, @Deprecated for the IDE/compiler warning.");
+    }
+  }
+
+  /// Locks the BaseJsonConfig invariant relied on by [DeprecatedTableConfigValidationUtils#isConfigBean]. The
+  /// reflective discovery walk only descends into classes that extend `BaseJsonConfig`. If a future SPI bean
+  /// reachable from `TableConfig` (via a getter return type, a Map value type, or a Collection element type)
+  /// were to NOT extend `BaseJsonConfig`, any `@DeprecatedConfig` annotation on its getters would be silently
+  /// invisible to the validator. This test re-walks the TableConfig graph and asserts every nested bean type
+  /// is a `BaseJsonConfig` descendant — failing loudly the moment the invariant breaks.
+  @Test
+  public void testEveryNestedConfigBeanExtendsBaseJsonConfig() {
+    Set<Class<?>> visited = new HashSet<>();
+    List<String> offenders = new ArrayList<>();
+    walkConfigBeans(TableConfig.class, visited, offenders);
+    assertTrue(offenders.isEmpty(),
+        "Found getter return types reachable from TableConfig whose declaring class is NOT a BaseJsonConfig "
+            + "descendant. The validator's reflective walk will silently skip @DeprecatedConfig annotations on "
+            + "these classes. Offenders:\n  " + String.join("\n  ", offenders));
+  }
+
+  private static void walkConfigBeans(Class<?> type, Set<Class<?>> visited, List<String> out) {
+    if (type == null || type.isPrimitive() || type == Object.class || !visited.add(type)) {
+      return;
+    }
+    if (type.getName().startsWith("java.") || type.getName().startsWith("javax.")
+        || type.getName().startsWith("com.fasterxml.jackson.")) {
+      return;
+    }
+    for (Method method : type.getMethods()) {
+      if (method.getParameterCount() != 0 || method.getDeclaringClass() == Object.class
+          || Modifier.isStatic(method.getModifiers())
+          || method.getReturnType() == void.class) {
+        continue;
+      }
+      String name = method.getName();
+      if (!name.startsWith("get") && !(name.startsWith("is") && (method.getReturnType() == boolean.class
+          || method.getReturnType() == Boolean.class))) {
+        continue;
+      }
+      Class<?> ret = method.getReturnType();
+      if (BaseJsonConfig.class.isAssignableFrom(ret)
+          && ret != BaseJsonConfig.class) {
+        walkConfigBeans(ret, visited, out);
+      } else if (ret.getPackageName().startsWith("org.apache.pinot")
+          && !BaseJsonConfig.class.isAssignableFrom(ret)
+          && !ret.isEnum() && !ret.isInterface() && !ret.isAnnotation() && !ret.isPrimitive()
+          && method.getAnnotation(DeprecatedConfig.class) != null) {
+        /// The getter is annotated with @DeprecatedConfig but its return type is a Pinot type that is NOT a
+        /// BaseJsonConfig descendant — this is the silent-skip risk the test guards against.
+        out.add(type.getSimpleName() + "#" + name + "() returns " + ret.getName()
+            + " (not a BaseJsonConfig descendant)");
+      }
+    }
+  }
+
+  @Test
+  public void testRulesDiscoveredFromAnnotations() {
+    /// Sanity check that the annotation walk picks up the expected paths from TableConfig.
+    boolean foundIndexType = DeprecatedTableConfigValidationUtils.rulesForTesting().stream()
+        .anyMatch(rule -> rule.pathSegments().equals(List.of("fieldConfigList", "*", "indexType")));
+    assertTrue(foundIndexType, "expected fieldConfigList[*].indexType rule");
+
+    boolean foundNestedMinimize = DeprecatedTableConfigValidationUtils.rulesForTesting().stream()
+        .anyMatch(rule -> rule.pathSegments().equals(List.of(
+            "instanceAssignmentConfigMap", "*", "replicaGroupPartitionConfig", "minimizeDataMovement")));
+    assertTrue(foundNestedMinimize, "expected nested map-wildcard rule");
+
+    boolean foundStreamConfigs = DeprecatedTableConfigValidationUtils.rulesForTesting().stream()
+        .anyMatch(rule -> rule.pathSegments().equals(List.of("tableIndexConfig", "streamConfigs")));
+    assertTrue(foundStreamConfigs, "expected tableIndexConfig.streamConfigs rule");
+
+    boolean foundSegmentPushType = DeprecatedTableConfigValidationUtils.rulesForTesting().stream()
+        .anyMatch(rule -> rule.pathSegments().equals(List.of("segmentsConfig", "segmentPushType")));
+    assertTrue(foundSegmentPushType, "expected segmentsConfig.segmentPushType rule");
+
+    boolean foundSegmentPushFrequency = DeprecatedTableConfigValidationUtils.rulesForTesting().stream()
+        .anyMatch(rule -> rule.pathSegments().equals(List.of("segmentsConfig", "segmentPushFrequency")));
+    assertTrue(foundSegmentPushFrequency, "expected segmentsConfig.segmentPushFrequency rule");
+  }
+
+  /// Provides every rule discovered by the annotation walk so the parameterized test below covers the full set
+  /// 1:1. If a new {@link DeprecatedConfig @DeprecatedConfig} is added on a getter, this
+  /// test automatically exercises it without needing a new test case.
+  @DataProvider(name = "allRules")
+  public Object[][] allRules() {
+    List<DeprecatedConfigRule> rules = DeprecatedTableConfigValidationUtils.rulesForTesting();
+    Object[][] data = new Object[rules.size()][];
+    for (int i = 0; i < rules.size(); i++) {
+      data[i] = new Object[] {rules.get(i)};
+    }
+    return data;
+  }
+
+  @Test(dataProvider = "allRules")
+  public void testEveryRuleFiresOnSyntheticInputAsArrayWildcard(DeprecatedConfigRule rule)
+      throws Exception {
+    runEveryRuleCase(rule, /* arrayWildcard */ true);
+  }
+
+  @Test(dataProvider = "allRules")
+  public void testEveryRuleFiresOnSyntheticInputAsMapWildcard(DeprecatedConfigRule rule)
+      throws Exception {
+    runEveryRuleCase(rule, /* arrayWildcard */ false);
+  }
+
+  /// Builds a JSON tree containing the deprecated path and asserts the rule fires. The {@code arrayWildcard} flag
+  /// controls how `*` segments are realised: as `[ {...} ]` (array branch) or `{"x":...}` (object branch). Running
+  /// both shapes ensures `collectMatches` is exercised on both wildcard branches for every rule.
+  private static void runEveryRuleCase(DeprecatedConfigRule rule, boolean arrayWildcard)
+      throws Exception {
+    String synthetic = synthesizeJsonForPath(rule.pathSegments(), arrayWildcard);
+    String expectedPath = expectedPathInMessage(rule.pathSegments(), arrayWildcard);
+
+    Result result = DeprecatedTableConfigValidationUtils.validate(JsonUtils.stringToJsonNode(synthetic), null, null);
+    if (rule.severity() == Severity.ERROR) {
+      assertTrue(result.getErrors().stream().anyMatch(m -> m.contains(expectedPath)),
+          "expected error containing '" + expectedPath + "', got errors=" + result.getErrors() + ", warnings="
+              + result.getWarnings());
+    } else {
+      assertTrue(result.getWarnings().stream().anyMatch(m -> m.contains(expectedPath)),
+          "expected warning containing '" + expectedPath + "', got warnings=" + result.getWarnings() + ", errors="
+              + result.getErrors());
+    }
+  }
+
+  private static String synthesizeJsonForPath(List<String> path, boolean arrayWildcard) {
+    StringBuilder open = new StringBuilder();
+    StringBuilder close = new StringBuilder();
+    for (String segment : path.subList(0, path.size() - 1)) {
+      if ("*".equals(segment)) {
+        if (arrayWildcard) {
+          open.append("[");
+          close.insert(0, "]");
+        } else {
+          open.append("{\"x\":");
+          close.insert(0, "}");
+        }
+      } else {
+        open.append("{\"").append(segment).append("\":");
+        close.insert(0, "}");
+      }
+    }
+    String leaf = path.get(path.size() - 1);
+    if ("*".equals(leaf)) {
+      open.append(arrayWildcard ? "[\"v\"]" : "{\"x\":\"v\"}");
+    } else {
+      open.append("{\"").append(leaf).append("\":\"v\"}");
+    }
+    return open.append(close).toString();
+  }
+
+  private static String expectedPathInMessage(List<String> path, boolean arrayWildcard) {
+    StringBuilder sb = new StringBuilder();
+    for (String segment : path) {
+      if ("*".equals(segment) && arrayWildcard) {
+        /// The walker emits `[<index>]` (no preceding `.`) for array entries.
+        sb.append("[0]");
+      } else {
+        String key = "*".equals(segment) ? "x" : segment;
+        if (sb.length() > 0) {
+          sb.append('.');
+        }
+        sb.append(key);
+      }
+    }
+    return sb.toString();
+  }
+}

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigSerDeUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigSerDeUtilsTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.common.utils.config;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.Lists;
 import java.io.IOException;
@@ -25,6 +26,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.pinot.common.tier.TierFactory;
 import org.apache.pinot.spi.config.table.CompletionConfig;
 import org.apache.pinot.spi.config.table.DedupConfig;
@@ -608,5 +610,81 @@ public class TableConfigSerDeUtilsTest {
     assertEquals(dedupConfig.getHashFunction(), HashFunction.MD5);
     assertEquals(dedupConfig.getMetadataTTL(), 10);
     assertEquals(dedupConfig.getDedupTimeColumn(), "dedupTimeColumn");
+  }
+
+  /// Confirms that `toRawJsonNode` preserves keys that are stripped by the deserialize/re-serialize round-trip
+  /// (e.g. `@JsonIgnore` or `@JsonInclude(NON_DEFAULT)` getters). The deprecation diff in
+  /// `DeprecatedTableConfigValidationUtils` relies on this.
+  @Test
+  public void testToRawJsonNodePreservesStrippedKeys() {
+    ZNRecord znRecord = new ZNRecord("myTable_OFFLINE");
+    znRecord.setSimpleField(TableConfig.TABLE_NAME_KEY, "myTable_OFFLINE");
+    znRecord.setSimpleField(TableConfig.TABLE_TYPE_KEY, "OFFLINE");
+    /// The fieldConfigList stored in ZK carries the legacy 'indexType' key alongside the modern 'indexTypes'.
+    znRecord.setSimpleField(TableConfig.FIELD_CONFIG_LIST_KEY,
+        "[{\"name\":\"c1\",\"indexType\":\"INVERTED\",\"indexTypes\":[\"INVERTED\"]}]");
+
+    JsonNode raw = TableConfigSerDeUtils.toRawJsonNode(znRecord);
+    assertNotNull(raw);
+    JsonNode legacy = raw.get(TableConfig.FIELD_CONFIG_LIST_KEY);
+    assertNotNull(legacy);
+    assertTrue(legacy.isArray());
+    assertEquals(legacy.get(0).get("indexType").asText(), "INVERTED");
+  }
+
+  @Test
+  public void testToRawJsonNodeHandlesNull() {
+    assertNull(TableConfigSerDeUtils.toRawJsonNode(null));
+  }
+
+  /// `ZNRecord.getSimpleFields()` is a regular `HashMap<String, String>` that permits null values. The deprecation
+  /// diff path on `PinotTableRestletResource.updateTableConfig` reads the stored ZNRecord through this method, so
+  /// a null simpleField value must not NPE inside `looksLikeJsonContainer`.
+  @Test
+  public void testToRawJsonNodeHandlesNullSimpleFieldValue() {
+    ZNRecord znRecord = new ZNRecord("myTable_OFFLINE");
+    znRecord.setSimpleField(TableConfig.TABLE_NAME_KEY, "myTable_OFFLINE");
+    znRecord.getSimpleFields().put("someLegacyField", null);
+    JsonNode raw = TableConfigSerDeUtils.toRawJsonNode(znRecord);
+    assertNotNull(raw);
+    assertTrue(raw.has("someLegacyField"));
+    assertTrue(raw.get("someLegacyField").isNull());
+  }
+
+  /// A stored simpleField whose value looks like a JSON container (`{...}` / `[...]`) but is malformed must not
+  /// take down the read — falls back to a text node and emits a WARN log so operators see the corruption.
+  /// Downstream diffs will treat the path as text rather than structured, which is the documented contract.
+  @Test
+  public void testToRawJsonNodeFallsBackToTextOnMalformedJsonContainer() {
+    ZNRecord znRecord = new ZNRecord("myTable_OFFLINE");
+    znRecord.setSimpleField(TableConfig.TABLE_NAME_KEY, "myTable_OFFLINE");
+    znRecord.setSimpleField(TableConfig.INDEXING_CONFIG_KEY, "{\"unclosed\": ");
+    JsonNode raw = TableConfigSerDeUtils.toRawJsonNode(znRecord);
+    assertNotNull(raw);
+    JsonNode indexingNode = raw.get(TableConfig.INDEXING_CONFIG_KEY);
+    assertNotNull(indexingNode);
+    assertTrue(indexingNode.isTextual(),
+        "Malformed JSON container must fall back to a text node so downstream code does not NPE");
+    assertEquals(indexingNode.asText(), "{\"unclosed\": ");
+  }
+
+  /// Primitive-shaped simpleField values that happen to look like JSON primitives (`"123"`, `"true"`, `"null"`)
+  /// MUST be preserved as text — the heuristic-sniff in `looksLikeJsonContainer` only triggers on `{`/`[` first
+  /// chars, so these values bypass the JSON-parse path entirely.
+  @Test
+  public void testToRawJsonNodePreservesTextValuesThatLookLikeJsonPrimitives() {
+    ZNRecord znRecord = new ZNRecord("myTable_OFFLINE");
+    znRecord.setSimpleField(TableConfig.TABLE_NAME_KEY, "myTable_OFFLINE");
+    znRecord.setSimpleField("intLikeKey", "123");
+    znRecord.setSimpleField("boolLikeKey", "true");
+    znRecord.setSimpleField("nullLikeKey", "null");
+    JsonNode raw = TableConfigSerDeUtils.toRawJsonNode(znRecord);
+    assertNotNull(raw);
+    assertEquals(raw.get("intLikeKey").asText(), "123");
+    assertTrue(raw.get("intLikeKey").isTextual(), "JSON-like primitive must stay text, not be coerced to IntNode");
+    assertEquals(raw.get("boolLikeKey").asText(), "true");
+    assertTrue(raw.get("boolLikeKey").isTextual());
+    assertEquals(raw.get("nullLikeKey").asText(), "null");
+    assertTrue(raw.get("nullLikeKey").isTextual());
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
@@ -83,6 +83,7 @@ import org.apache.pinot.common.minion.TaskManagerStatusCache;
 import org.apache.pinot.common.utils.PinotAppConfigs;
 import org.apache.pinot.common.utils.ServiceStartableUtils;
 import org.apache.pinot.common.utils.ServiceStatus;
+import org.apache.pinot.common.utils.config.DeprecatedTableConfigValidationUtils;
 import org.apache.pinot.common.utils.fetcher.SegmentFetcherFactory;
 import org.apache.pinot.common.utils.grpc.ServerGrpcQueryClient;
 import org.apache.pinot.common.utils.helix.HelixHelper;
@@ -566,6 +567,14 @@ public abstract class BaseControllerStarter implements ServiceStartable {
       SslContext serverSslContext = GrpcQueryServer.buildGrpcSslContext(tlsDefaults);
       controllerContext.setServerGrpcSslContext(serverSslContext);
     }
+
+    /// Warm up the deprecation-validator lazy holder so the first REST request after startup doesn't pay the
+    /// reflection cost (Class.getMethods() over every nested TableConfig bean). The cost is small (~13 rules in
+    /// the current SPI) but happens on a user-facing latency path otherwise. Failure here is fatal-loud: an
+    /// ExceptionInInitializerError would otherwise surface on every subsequent table-config REST endpoint, so
+    /// catching it at startup gives operators an actionable signal instead of a cluster-wide 500 cascade.
+    int discoveredRuleCount = DeprecatedTableConfigValidationUtils.warmUp();
+    LOGGER.info("Deprecation validator initialised with {} rules.", discoveredRuleCount);
 
     // Set up Pinot cluster in Helix if needed
     HelixSetupUtils.setupPinotCluster(_helixClusterName, _helixZkURL, _isUpdateStateModel, _config);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/ConfigSuccessResponse.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/ConfigSuccessResponse.java
@@ -18,17 +18,51 @@
  */
 package org.apache.pinot.controller.api.resources;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import java.util.List;
 import java.util.Map;
 
+/// Field order is fixed via [JsonPropertyOrder] so the wire shape is deterministic across Jackson versions.
+/// `unrecognizedProperties` comes first to match the pre-deprecationWarnings response layout that existing
+/// clients and integration tests assert byte-exactly.
+///
+/// `@JsonIgnoreProperties(ignoreUnknown = true)` so future controller versions can add wire fields without
+/// breaking strict-parsing older clients (rolling-upgrade direction: old client + new controller). Locked by
+/// `testStrictParserToleratesUnknownFutureField`.
+@JsonIgnoreProperties(ignoreUnknown = true)
+@JsonPropertyOrder({"unrecognizedProperties", "deprecationWarnings", "status"})
 public final class ConfigSuccessResponse extends SuccessResponse {
   private final Map<String, Object> _unrecognizedProperties;
+  private final List<String> _deprecationWarnings;
 
   public ConfigSuccessResponse(String status, Map<String, Object> unrecognizedProperties) {
+    this(status, unrecognizedProperties, List.of());
+  }
+
+  /// Annotated with `@JsonCreator` so Jackson can deserialize this DTO without depending on the `-parameters`
+  /// compiler flag. Downstream clients (admin SDK, integration tests, tooling) deserialize controller
+  /// responses; pinning the constructor to named JSON properties keeps that contract explicit.
+  @JsonCreator
+  public ConfigSuccessResponse(@JsonProperty("status") String status,
+      @JsonProperty("unrecognizedProperties") Map<String, Object> unrecognizedProperties,
+      @JsonProperty("deprecationWarnings") List<String> deprecationWarnings) {
     super(status);
-    _unrecognizedProperties = unrecognizedProperties;
+    _unrecognizedProperties = unrecognizedProperties == null ? Map.of() : unrecognizedProperties;
+    _deprecationWarnings = deprecationWarnings == null ? List.of() : deprecationWarnings;
   }
 
   public Map<String, Object> getUnrecognizedProperties() {
     return _unrecognizedProperties;
+  }
+
+  /// `@JsonInclude(NON_EMPTY)` is on the getter so the empty-list case is elided from the response. Older clients
+  /// that strict-parse this DTO continue to see the original (pre-deprecationWarnings) shape when no warnings fire.
+  @JsonInclude(JsonInclude.Include.NON_EMPTY)
+  public List<String> getDeprecationWarnings() {
+    return _deprecationWarnings;
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/CopyTableResponse.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/CopyTableResponse.java
@@ -22,6 +22,7 @@ package org.apache.pinot.controller.api.resources;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.pinot.controller.helix.core.WatermarkInductionResult;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -44,16 +45,30 @@ public class CopyTableResponse {
   @JsonProperty("watermarkInductionResult")
   private WatermarkInductionResult _watermarkInductionResult;
 
+  @JsonProperty("deprecationWarnings")
+  @JsonInclude(JsonInclude.Include.NON_EMPTY)
+  private List<String> _deprecationWarnings;
+
+  /// `status` and `msg` are `@Nullable` here to match the historical wire contract: the class is
+  /// `@JsonInclude(NON_NULL)`, so both fields have always been omittable from the JSON, and existing setters allow
+  /// either to be null. Older deserializers (admin SDK, integration tests) must continue to parse responses that
+  /// elide one or both fields.
   @JsonCreator
-  public CopyTableResponse(@JsonProperty("status") String status, @JsonProperty("msg") String msg,
-      @JsonProperty("schema") @Nullable Schema schema,
+  public CopyTableResponse(@JsonProperty("status") @Nullable String status,
+      @JsonProperty("msg") @Nullable String msg, @JsonProperty("schema") @Nullable Schema schema,
       @JsonProperty("realtimeTableConfig") @Nullable TableConfig tableConfig,
       @JsonProperty("watermarkInductionResult") @Nullable WatermarkInductionResult watermarkInductionResult) {
+    this(status, msg, schema, tableConfig, watermarkInductionResult, null);
+  }
+
+  public CopyTableResponse(String status, String msg, @Nullable Schema schema, @Nullable TableConfig tableConfig,
+      @Nullable WatermarkInductionResult watermarkInductionResult, @Nullable List<String> deprecationWarnings) {
     _status = status;
     _msg = msg;
     _schema = schema;
     _tableConfig = tableConfig;
     _watermarkInductionResult = watermarkInductionResult;
+    _deprecationWarnings = deprecationWarnings == null ? List.of() : deprecationWarnings;
   }
 
   public String getMsg() {
@@ -95,5 +110,11 @@ public class CopyTableResponse {
   public void setWatermarkInductionResult(
       WatermarkInductionResult watermarkInductionResult) {
     _watermarkInductionResult = watermarkInductionResult;
+  }
+
+  /// Read-only: callers must populate deprecation warnings via the all-args constructor. No setter is exposed so
+  /// the field cannot drift after the response is constructed by the REST handler.
+  public List<String> getDeprecationWarnings() {
+    return _deprecationWarnings;
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -78,6 +78,7 @@ import org.apache.pinot.common.exception.InvalidConfigException;
 import org.apache.pinot.common.exception.RebalanceInProgressException;
 import org.apache.pinot.common.exception.SchemaNotFoundException;
 import org.apache.pinot.common.exception.TableConfigBackwardIncompatibleException;
+import org.apache.pinot.common.exception.TableConfigVersionConflictException;
 import org.apache.pinot.common.exception.TableNotFoundException;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.metrics.ControllerMeter;
@@ -92,6 +93,8 @@ import org.apache.pinot.common.restlet.resources.ValidDocIdsType;
 import org.apache.pinot.common.utils.DatabaseUtils;
 import org.apache.pinot.common.utils.LogicalTableConfigUtils;
 import org.apache.pinot.common.utils.SimpleHttpResponse;
+import org.apache.pinot.common.utils.config.DeprecatedTableConfigValidationUtils;
+import org.apache.pinot.common.utils.config.TableConfigSerDeUtils;
 import org.apache.pinot.common.utils.helix.HelixHelper;
 import org.apache.pinot.common.utils.http.HttpClient;
 import org.apache.pinot.controller.ControllerConf;
@@ -227,6 +230,7 @@ public class PinotTableRestletResource {
     TableConfig tableConfig;
     String tableNameWithType;
     Schema schema;
+    List<String> deprecationWarnings;
     try {
       tableConfigAndUnrecognizedProperties =
           JsonUtils.stringToObjectAndUnrecognizedProperties(tableConfigStr, TableConfig.class);
@@ -248,6 +252,8 @@ public class PinotTableRestletResource {
       schema = _pinotHelixResourceManager.getTableSchema(tableNameWithType);
       Preconditions.checkState(schema != null, "Failed to find schema for table: %s", tableNameWithType);
 
+      deprecationWarnings = DeprecatedTableConfigValidationUtils.validateOnCreate(
+          JsonUtils.stringToJsonNode(tableConfigStr), null);
       TableConfigTunerUtils.applyTunerConfigs(_pinotHelixResourceManager, tableConfig, schema, Map.of());
 
       TableConfigValidationUtils.validateTableConfig(
@@ -267,7 +273,7 @@ public class PinotTableRestletResource {
       // the validation manager)
       LOGGER.info("Successfully added table: {} with config: {}", tableNameWithType, tableConfig);
       return new ConfigSuccessResponse("Table " + tableNameWithType + " successfully added",
-          tableConfigAndUnrecognizedProperties.getRight());
+          tableConfigAndUnrecognizedProperties.getRight(), deprecationWarnings);
     } catch (Exception e) {
       _controllerMetrics.addMeteredGlobalValue(ControllerMeter.CONTROLLER_TABLE_ADD_ERROR, 1L);
       if (e instanceof InvalidTableConfigException) {
@@ -337,6 +343,7 @@ public class PinotTableRestletResource {
       boolean hasOffline = tableConfigNode.has(TableType.OFFLINE.name());
       boolean hasRealtime = tableConfigNode.has(TableType.REALTIME.name());
       TableConfig realtimeTableConfig;
+      List<String> copyDeprecationWarnings;
       try {
         if (hasOffline && !hasRealtime) {
           throw new IllegalStateException("pure offline table copy not supported yet");
@@ -344,6 +351,8 @@ public class PinotTableRestletResource {
 
         ObjectNode realtimeTableConfigNode = (ObjectNode) tableConfigNode.get(TableType.REALTIME.name());
         tweakRealtimeTableConfig(realtimeTableConfigNode, copyTablePayload);
+        copyDeprecationWarnings =
+            DeprecatedTableConfigValidationUtils.validateOnCreate(realtimeTableConfigNode, null);
         realtimeTableConfig = JsonUtils.jsonNodeToObject(realtimeTableConfigNode, TableConfig.class);
         if (realtimeTableConfig.getUpsertConfig() != null) {
           throw new IllegalStateException("upsert table copy not supported");
@@ -358,7 +367,8 @@ public class PinotTableRestletResource {
       LOGGER.info("[copyTable] Successfully fetched and tweaked table config for table: {}", tableName);
 
       if (dryRun) {
-        return new CopyTableResponse("success", "Dry run", schema, realtimeTableConfig, watermarkInductionResult);
+        return new CopyTableResponse("success", "Dry run", schema, realtimeTableConfig, watermarkInductionResult,
+            copyDeprecationWarnings);
       }
 
       List<StreamConfig> streamConfigs = IngestionConfigUtils.getStreamConfigs(realtimeTableConfig);
@@ -369,10 +379,11 @@ public class PinotTableRestletResource {
       // Add the table with designated starting kafka offset and segment sequence number to create consuming segments
       _pinotHelixResourceManager.addTable(realtimeTableConfig, streamMetadataList);
       LOGGER.info("[copyTable] Successfully added table config: {} with designated high watermark", tableName);
-      CopyTableResponse response = new CopyTableResponse("success", "Table copied successfully", null, null, null);
+      CopyTableResponse response = new CopyTableResponse("success", "Table copied successfully", null, null, null,
+          copyDeprecationWarnings);
       if (hasOffline) {
         response = new CopyTableResponse("warn", "detect offline too; it will only copy real-time segments",
-            null, null, null);
+            null, null, null, copyDeprecationWarnings);
       }
       if (verbose) {
         response.setSchema(schema);
@@ -770,12 +781,17 @@ public class PinotTableRestletResource {
       throws Exception {
     Pair<TableConfig, Map<String, Object>> tableConfigAndUnrecognizedProperties;
     TableConfig tableConfig;
+    JsonNode newTableConfigJson;
     String tableNameWithType;
     Schema schema;
+    List<String> deprecationWarnings = List.of();
     try {
       tableConfigAndUnrecognizedProperties =
           JsonUtils.stringToObjectAndUnrecognizedProperties(tableConfigString, TableConfig.class);
       tableConfig = tableConfigAndUnrecognizedProperties.getLeft();
+      /// Capture the raw JsonNode view alongside the typed view so the deprecation diff below does not re-parse
+      /// the same input.
+      newTableConfigJson = JsonUtils.stringToJsonNode(tableConfigString);
       tableNameWithType = DatabaseUtils.translateTableName(tableConfig.getTableName(), headers);
       tableConfig.setTableName(tableNameWithType);
       String tableNameFromPath = DatabaseUtils.translateTableName(
@@ -796,12 +812,55 @@ public class PinotTableRestletResource {
       throw new ControllerApplicationException(LOGGER, msg, Response.Status.BAD_REQUEST, e);
     }
 
+    /// Existence check runs before the deprecation diff so a PUT to a missing table reports 404 rather than a
+    /// misleading 400 about deprecated keys.
+    if (!_pinotHelixResourceManager.hasTable(tableNameWithType)) {
+      throw new ControllerApplicationException(LOGGER, "Table " + tableNameWithType + " does not exist",
+          Response.Status.NOT_FOUND);
+    }
+
+    /// Deprecation diff is computed against the byte-faithful stored ZNRecord. Runs outside the BAD_REQUEST catch so
+    /// ZK transient failures propagate as 5xx rather than masquerading as client-side validation errors. The read
+    /// also captures the ZK znode version, which is threaded through to updateTableConfig so the subsequent write is
+    /// a version-checked CAS: a concurrent writer that landed between this read and the write will bump the version
+    /// and the CAS fails — preventing a deprecated key from slipping past the diff via a racing update on the same
+    /// table.
+    int expectedVersion;
     try {
-      if (!_pinotHelixResourceManager.hasTable(tableNameWithType)) {
-        throw new ControllerApplicationException(LOGGER, "Table " + tableNameWithType + " does not exist",
+      Stat stat = new Stat();
+      ZNRecord storedRecord = ZKMetadataProvider.getTableConfigZNRecord(
+          _pinotHelixResourceManager.getPropertyStore(), tableNameWithType, stat);
+      if (storedRecord == null) {
+        /// Race: hasTable() above returned true, but the znode was deleted before this read. Surface a 404 so
+        /// the caller learns the table is gone rather than seeing an opaque 5xx from a NullPointerException
+        /// inside validateOnUpdate's @NonNull oldTableConfigJson check.
+        throw new ControllerApplicationException(LOGGER,
+            "Table " + tableNameWithType + " was deleted concurrently with this update",
             Response.Status.NOT_FOUND);
       }
-      _pinotHelixResourceManager.updateTableConfig(tableConfig, force);
+      expectedVersion = stat.getVersion();
+      JsonNode oldTableConfigJson = TableConfigSerDeUtils.toRawJsonNode(storedRecord);
+      deprecationWarnings = DeprecatedTableConfigValidationUtils.validateOnUpdate(
+          newTableConfigJson, oldTableConfigJson, null);
+    } catch (ControllerApplicationException e) {
+      throw e;
+    } catch (IllegalArgumentException e) {
+      String msg = String.format("Invalid table config: %s with error: %s", tableName, e.getMessage());
+      throw new ControllerApplicationException(LOGGER, msg, Response.Status.BAD_REQUEST, e);
+    } catch (RuntimeException e) {
+      _controllerMetrics.addMeteredGlobalValue(ControllerMeter.CONTROLLER_TABLE_UPDATE_ERROR, 1L);
+      LOGGER.warn("Failed to compute deprecation diff for update of table: {}", tableNameWithType, e);
+      throw e;
+    }
+
+    try {
+      _pinotHelixResourceManager.updateTableConfig(tableConfig, expectedVersion, force);
+    } catch (TableConfigVersionConflictException e) {
+      /// CAS lost: a concurrent writer landed between our deprecation-diff read and this write. Return 409 so the
+      /// client can re-read and retry rather than burning a 5xx error metric.
+      throw new ControllerApplicationException(LOGGER,
+          String.format("Conflict updating %s: %s. Re-read the current config and retry.", tableName, e.getMessage()),
+          Response.Status.CONFLICT, e);
     } catch (TableConfigBackwardIncompatibleException e) {
       String errStr = String.format("Failed to update configuration for %s due to: %s", tableName, e.getMessage());
       _controllerMetrics.addMeteredGlobalValue(ControllerMeter.CONTROLLER_TABLE_UPDATE_ERROR, 1L);
@@ -816,7 +875,7 @@ public class PinotTableRestletResource {
     }
     LOGGER.info("Successfully updated table: {} with new config: {}", tableNameWithType, tableConfig);
     return new ConfigSuccessResponse("Table config updated for " + tableName,
-        tableConfigAndUnrecognizedProperties.getRight());
+        tableConfigAndUnrecognizedProperties.getRight(), deprecationWarnings);
   }
 
   @POST
@@ -831,12 +890,14 @@ public class PinotTableRestletResource {
       @QueryParam("validationTypesToSkip") @Nullable String typesToSkip, @Context HttpHeaders httpHeaders,
       @Context Request request) {
     Pair<TableConfig, Map<String, Object>> tableConfigAndUnrecognizedProperties;
+    JsonNode tableConfigJson;
     try {
       tableConfigAndUnrecognizedProperties =
           JsonUtils.stringToObjectAndUnrecognizedProperties(tableConfigStr, TableConfig.class);
+      tableConfigJson = JsonUtils.stringToJsonNode(tableConfigStr);
     } catch (IOException e) {
-      String msg = String.format("Invalid table config json string: %s. Reason: %s", tableConfigStr, e.getMessage());
-      throw new ControllerApplicationException(LOGGER, msg, Response.Status.BAD_REQUEST, e);
+      throw new ControllerApplicationException(LOGGER, "Invalid table config json string. " + e.getMessage(),
+          Response.Status.BAD_REQUEST, e);
     }
     TableConfig tableConfig = tableConfigAndUnrecognizedProperties.getLeft();
     String tableNameWithType = DatabaseUtils.translateTableName(tableConfig.getTableName(), httpHeaders);
@@ -845,10 +906,34 @@ public class PinotTableRestletResource {
     // validate permission
     ResourceUtils.checkPermissionAndAccess(tableNameWithType, request, httpHeaders,
         AccessType.READ, Actions.Table.VALIDATE_TABLE_CONFIGS, _accessControlFactory, LOGGER);
+    JsonNode oldTableConfigJson;
+    try {
+      oldTableConfigJson = TableConfigSerDeUtils.toRawJsonNode(
+          ZKMetadataProvider.getTableConfigZNRecord(_pinotHelixResourceManager.getPropertyStore(),
+              tableNameWithType));
+    } catch (RuntimeException e) {
+      LOGGER.warn("Failed to read stored config for validate of table: {}", tableNameWithType, e);
+      throw e;
+    }
+    List<String> deprecationWarnings;
+    try {
+      if (oldTableConfigJson == null) {
+        deprecationWarnings = DeprecatedTableConfigValidationUtils.validateOnCreate(tableConfigJson, null);
+      } else {
+        deprecationWarnings = DeprecatedTableConfigValidationUtils.validateOnUpdate(tableConfigJson,
+            oldTableConfigJson, null);
+      }
+    } catch (IllegalArgumentException e) {
+      String msg = String.format("Invalid table config: %s. %s", tableNameWithType, e.getMessage());
+      throw new ControllerApplicationException(LOGGER, msg, Response.Status.BAD_REQUEST, e);
+    }
 
     ObjectNode validationResponse = validateConfig(tableConfig, typesToSkip);
     validationResponse.set("unrecognizedProperties",
         JsonUtils.objectToJsonNode(tableConfigAndUnrecognizedProperties.getRight()));
+    if (!deprecationWarnings.isEmpty()) {
+      validationResponse.set("deprecationWarnings", JsonUtils.objectToJsonNode(deprecationWarnings));
+    }
     return validationResponse;
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -78,6 +78,7 @@ import org.apache.pinot.common.exception.InvalidConfigException;
 import org.apache.pinot.common.exception.RebalanceInProgressException;
 import org.apache.pinot.common.exception.SchemaNotFoundException;
 import org.apache.pinot.common.exception.TableConfigBackwardIncompatibleException;
+import org.apache.pinot.common.exception.TableConfigVersionConflictException;
 import org.apache.pinot.common.exception.TableNotFoundException;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.metrics.ControllerMeter;
@@ -92,6 +93,8 @@ import org.apache.pinot.common.restlet.resources.ValidDocIdsType;
 import org.apache.pinot.common.utils.DatabaseUtils;
 import org.apache.pinot.common.utils.LogicalTableConfigUtils;
 import org.apache.pinot.common.utils.SimpleHttpResponse;
+import org.apache.pinot.common.utils.config.DeprecatedTableConfigValidationUtils;
+import org.apache.pinot.common.utils.config.TableConfigSerDeUtils;
 import org.apache.pinot.common.utils.helix.HelixHelper;
 import org.apache.pinot.common.utils.http.HttpClient;
 import org.apache.pinot.controller.ControllerConf;
@@ -226,6 +229,7 @@ public class PinotTableRestletResource {
     TableConfig tableConfig;
     String tableNameWithType;
     Schema schema;
+    List<String> deprecationWarnings;
     try {
       tableConfigAndUnrecognizedProperties =
           JsonUtils.stringToObjectAndUnrecognizedProperties(tableConfigStr, TableConfig.class);
@@ -247,6 +251,8 @@ public class PinotTableRestletResource {
       schema = _pinotHelixResourceManager.getTableSchema(tableNameWithType);
       Preconditions.checkState(schema != null, "Failed to find schema for table: %s", tableNameWithType);
 
+      deprecationWarnings = DeprecatedTableConfigValidationUtils.validateOnCreate(
+          JsonUtils.stringToJsonNode(tableConfigStr), null);
       TableConfigTunerUtils.applyTunerConfigs(_pinotHelixResourceManager, tableConfig, schema, Map.of());
 
       TableConfigValidationUtils.validateTableConfig(
@@ -266,7 +272,7 @@ public class PinotTableRestletResource {
       // the validation manager)
       LOGGER.info("Successfully added table: {} with config: {}", tableNameWithType, tableConfig);
       return new ConfigSuccessResponse("Table " + tableNameWithType + " successfully added",
-          tableConfigAndUnrecognizedProperties.getRight());
+          tableConfigAndUnrecognizedProperties.getRight(), deprecationWarnings);
     } catch (Exception e) {
       _controllerMetrics.addMeteredGlobalValue(ControllerMeter.CONTROLLER_TABLE_ADD_ERROR, 1L);
       if (e instanceof InvalidTableConfigException) {
@@ -336,6 +342,7 @@ public class PinotTableRestletResource {
       boolean hasOffline = tableConfigNode.has(TableType.OFFLINE.name());
       boolean hasRealtime = tableConfigNode.has(TableType.REALTIME.name());
       TableConfig realtimeTableConfig;
+      List<String> copyDeprecationWarnings;
       try {
         if (hasOffline && !hasRealtime) {
           throw new IllegalStateException("pure offline table copy not supported yet");
@@ -343,6 +350,8 @@ public class PinotTableRestletResource {
 
         ObjectNode realtimeTableConfigNode = (ObjectNode) tableConfigNode.get(TableType.REALTIME.name());
         tweakRealtimeTableConfig(realtimeTableConfigNode, copyTablePayload);
+        copyDeprecationWarnings =
+            DeprecatedTableConfigValidationUtils.validateOnCreate(realtimeTableConfigNode, null);
         realtimeTableConfig = JsonUtils.jsonNodeToObject(realtimeTableConfigNode, TableConfig.class);
         if (realtimeTableConfig.getUpsertConfig() != null) {
           throw new IllegalStateException("upsert table copy not supported");
@@ -357,7 +366,8 @@ public class PinotTableRestletResource {
       LOGGER.info("[copyTable] Successfully fetched and tweaked table config for table: {}", tableName);
 
       if (dryRun) {
-        return new CopyTableResponse("success", "Dry run", schema, realtimeTableConfig, watermarkInductionResult);
+        return new CopyTableResponse("success", "Dry run", schema, realtimeTableConfig, watermarkInductionResult,
+            copyDeprecationWarnings);
       }
 
       List<StreamConfig> streamConfigs = IngestionConfigUtils.getStreamConfigs(realtimeTableConfig);
@@ -368,10 +378,11 @@ public class PinotTableRestletResource {
       // Add the table with designated starting kafka offset and segment sequence number to create consuming segments
       _pinotHelixResourceManager.addTable(realtimeTableConfig, streamMetadataList);
       LOGGER.info("[copyTable] Successfully added table config: {} with designated high watermark", tableName);
-      CopyTableResponse response = new CopyTableResponse("success", "Table copied successfully", null, null, null);
+      CopyTableResponse response = new CopyTableResponse("success", "Table copied successfully", null, null, null,
+          copyDeprecationWarnings);
       if (hasOffline) {
         response = new CopyTableResponse("warn", "detect offline too; it will only copy real-time segments",
-            null, null, null);
+            null, null, null, copyDeprecationWarnings);
       }
       if (verbose) {
         response.setSchema(schema);
@@ -777,12 +788,17 @@ public class PinotTableRestletResource {
       throws Exception {
     Pair<TableConfig, Map<String, Object>> tableConfigAndUnrecognizedProperties;
     TableConfig tableConfig;
+    JsonNode newTableConfigJson;
     String tableNameWithType;
     Schema schema;
+    List<String> deprecationWarnings = List.of();
     try {
       tableConfigAndUnrecognizedProperties =
           JsonUtils.stringToObjectAndUnrecognizedProperties(tableConfigString, TableConfig.class);
       tableConfig = tableConfigAndUnrecognizedProperties.getLeft();
+      /// Capture the raw JsonNode view alongside the typed view so the deprecation diff below does not re-parse
+      /// the same input.
+      newTableConfigJson = JsonUtils.stringToJsonNode(tableConfigString);
       tableNameWithType = DatabaseUtils.translateTableName(tableConfig.getTableName(), headers);
       tableConfig.setTableName(tableNameWithType);
       String tableNameFromPath = DatabaseUtils.translateTableName(
@@ -803,12 +819,55 @@ public class PinotTableRestletResource {
       throw new ControllerApplicationException(LOGGER, msg, Response.Status.BAD_REQUEST, e);
     }
 
+    /// Existence check runs before the deprecation diff so a PUT to a missing table reports 404 rather than a
+    /// misleading 400 about deprecated keys.
+    if (!_pinotHelixResourceManager.hasTable(tableNameWithType)) {
+      throw new ControllerApplicationException(LOGGER, "Table " + tableNameWithType + " does not exist",
+          Response.Status.NOT_FOUND);
+    }
+
+    /// Deprecation diff is computed against the byte-faithful stored ZNRecord. Runs outside the BAD_REQUEST catch so
+    /// ZK transient failures propagate as 5xx rather than masquerading as client-side validation errors. The read
+    /// also captures the ZK znode version, which is threaded through to updateTableConfig so the subsequent write is
+    /// a version-checked CAS: a concurrent writer that landed between this read and the write will bump the version
+    /// and the CAS fails — preventing a deprecated key from slipping past the diff via a racing update on the same
+    /// table.
+    int expectedVersion;
     try {
-      if (!_pinotHelixResourceManager.hasTable(tableNameWithType)) {
-        throw new ControllerApplicationException(LOGGER, "Table " + tableNameWithType + " does not exist",
+      Stat stat = new Stat();
+      ZNRecord storedRecord = ZKMetadataProvider.getTableConfigZNRecord(
+          _pinotHelixResourceManager.getPropertyStore(), tableNameWithType, stat);
+      if (storedRecord == null) {
+        /// Race: hasTable() above returned true, but the znode was deleted before this read. Surface a 404 so
+        /// the caller learns the table is gone rather than seeing an opaque 5xx from a NullPointerException
+        /// inside validateOnUpdate's @NonNull oldTableConfigJson check.
+        throw new ControllerApplicationException(LOGGER,
+            "Table " + tableNameWithType + " was deleted concurrently with this update",
             Response.Status.NOT_FOUND);
       }
-      _pinotHelixResourceManager.updateTableConfig(tableConfig, force);
+      expectedVersion = stat.getVersion();
+      JsonNode oldTableConfigJson = TableConfigSerDeUtils.toRawJsonNode(storedRecord);
+      deprecationWarnings = DeprecatedTableConfigValidationUtils.validateOnUpdate(
+          newTableConfigJson, oldTableConfigJson, null);
+    } catch (ControllerApplicationException e) {
+      throw e;
+    } catch (IllegalArgumentException e) {
+      String msg = String.format("Invalid table config: %s with error: %s", tableName, e.getMessage());
+      throw new ControllerApplicationException(LOGGER, msg, Response.Status.BAD_REQUEST, e);
+    } catch (RuntimeException e) {
+      _controllerMetrics.addMeteredGlobalValue(ControllerMeter.CONTROLLER_TABLE_UPDATE_ERROR, 1L);
+      LOGGER.warn("Failed to compute deprecation diff for update of table: {}", tableNameWithType, e);
+      throw e;
+    }
+
+    try {
+      _pinotHelixResourceManager.updateTableConfig(tableConfig, expectedVersion, force);
+    } catch (TableConfigVersionConflictException e) {
+      /// CAS lost: a concurrent writer landed between our deprecation-diff read and this write. Return 409 so the
+      /// client can re-read and retry rather than burning a 5xx error metric.
+      throw new ControllerApplicationException(LOGGER,
+          String.format("Conflict updating %s: %s. Re-read the current config and retry.", tableName, e.getMessage()),
+          Response.Status.CONFLICT, e);
     } catch (TableConfigBackwardIncompatibleException e) {
       String errStr = String.format("Failed to update configuration for %s due to: %s", tableName, e.getMessage());
       _controllerMetrics.addMeteredGlobalValue(ControllerMeter.CONTROLLER_TABLE_UPDATE_ERROR, 1L);
@@ -823,7 +882,7 @@ public class PinotTableRestletResource {
     }
     LOGGER.info("Successfully updated table: {} with new config: {}", tableNameWithType, tableConfig);
     return new ConfigSuccessResponse("Table config updated for " + tableName,
-        tableConfigAndUnrecognizedProperties.getRight());
+        tableConfigAndUnrecognizedProperties.getRight(), deprecationWarnings);
   }
 
   @POST
@@ -838,12 +897,14 @@ public class PinotTableRestletResource {
       @QueryParam("validationTypesToSkip") @Nullable String typesToSkip, @Context HttpHeaders httpHeaders,
       @Context Request request) {
     Pair<TableConfig, Map<String, Object>> tableConfigAndUnrecognizedProperties;
+    JsonNode tableConfigJson;
     try {
       tableConfigAndUnrecognizedProperties =
           JsonUtils.stringToObjectAndUnrecognizedProperties(tableConfigStr, TableConfig.class);
+      tableConfigJson = JsonUtils.stringToJsonNode(tableConfigStr);
     } catch (IOException e) {
-      String msg = String.format("Invalid table config json string: %s. Reason: %s", tableConfigStr, e.getMessage());
-      throw new ControllerApplicationException(LOGGER, msg, Response.Status.BAD_REQUEST, e);
+      throw new ControllerApplicationException(LOGGER, "Invalid table config json string. " + e.getMessage(),
+          Response.Status.BAD_REQUEST, e);
     }
     TableConfig tableConfig = tableConfigAndUnrecognizedProperties.getLeft();
     String tableNameWithType = DatabaseUtils.translateTableName(tableConfig.getTableName(), httpHeaders);
@@ -852,10 +913,34 @@ public class PinotTableRestletResource {
     // validate permission
     ResourceUtils.checkPermissionAndAccess(tableNameWithType, request, httpHeaders,
         AccessType.READ, Actions.Table.VALIDATE_TABLE_CONFIGS, _accessControlFactory, LOGGER);
+    JsonNode oldTableConfigJson;
+    try {
+      oldTableConfigJson = TableConfigSerDeUtils.toRawJsonNode(
+          ZKMetadataProvider.getTableConfigZNRecord(_pinotHelixResourceManager.getPropertyStore(),
+              tableNameWithType));
+    } catch (RuntimeException e) {
+      LOGGER.warn("Failed to read stored config for validate of table: {}", tableNameWithType, e);
+      throw e;
+    }
+    List<String> deprecationWarnings;
+    try {
+      if (oldTableConfigJson == null) {
+        deprecationWarnings = DeprecatedTableConfigValidationUtils.validateOnCreate(tableConfigJson, null);
+      } else {
+        deprecationWarnings = DeprecatedTableConfigValidationUtils.validateOnUpdate(tableConfigJson,
+            oldTableConfigJson, null);
+      }
+    } catch (IllegalArgumentException e) {
+      String msg = String.format("Invalid table config: %s. %s", tableNameWithType, e.getMessage());
+      throw new ControllerApplicationException(LOGGER, msg, Response.Status.BAD_REQUEST, e);
+    }
 
     ObjectNode validationResponse = validateConfig(tableConfig, typesToSkip);
     validationResponse.set("unrecognizedProperties",
         JsonUtils.objectToJsonNode(tableConfigAndUnrecognizedProperties.getRight()));
+    if (!deprecationWarnings.isEmpty()) {
+      validationResponse.set("deprecationWarnings", JsonUtils.objectToJsonNode(deprecationWarnings));
+    }
     return validationResponse;
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableConfigsRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableConfigsRestletResource.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.controller.api.resources;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.base.Preconditions;
@@ -29,6 +30,7 @@ import io.swagger.annotations.Authorization;
 import io.swagger.annotations.SecurityDefinition;
 import io.swagger.annotations.SwaggerDefinition;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -50,12 +52,16 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.pinot.common.exception.TableConfigBackwardIncompatibleException;
+import org.apache.pinot.common.exception.TableConfigVersionConflictException;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.metrics.ControllerMeter;
 import org.apache.pinot.common.metrics.ControllerMetrics;
 import org.apache.pinot.common.utils.DatabaseUtils;
 import org.apache.pinot.common.utils.LogicalTableConfigUtils;
+import org.apache.pinot.common.utils.config.DeprecatedTableConfigValidationUtils;
+import org.apache.pinot.common.utils.config.TableConfigSerDeUtils;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.api.access.AccessControl;
 import org.apache.pinot.controller.api.access.AccessControlFactory;
@@ -79,10 +85,12 @@ import org.apache.pinot.segment.local.utils.TableConfigUtils;
 import org.apache.pinot.spi.config.TableConfigs;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableConfigValidatorRegistry;
+import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.LogicalTableConfig;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+import org.apache.zookeeper.data.Stat;
 import org.glassfish.grizzly.http.server.Request;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -200,7 +208,7 @@ public class TableConfigsRestletResource {
       tableConfigsAndUnrecognizedProps =
           JsonUtils.stringToObjectAndUnrecognizedProperties(tableConfigsStr, TableConfigs.class);
     } catch (Exception e) {
-      throw new ControllerApplicationException(LOGGER, String.format("Invalid TableConfigs. %s", e.getMessage()),
+      throw new ControllerApplicationException(LOGGER, "Invalid TableConfigs. " + e.getMessage(),
           Response.Status.BAD_REQUEST, e);
     }
     TableConfigs tableConfigs = tableConfigsAndUnrecognizedProps.getLeft();
@@ -213,22 +221,38 @@ public class TableConfigsRestletResource {
           Response.Status.BAD_REQUEST);
     }
 
-    validateConfig(tableConfigs, databaseName, typesToSkip);
-    tableConfigs.setTableName(rawTableName);
+    /// Permission check runs BEFORE validateNoDeprecatedConfigs (which reads stored configs from ZK on update-mode
+    /// paths). Mirrors the /tableConfigs/validate ordering and prevents an unauthenticated caller from probing
+    /// stored config contents via the deprecation-diff response shape.
+    String endpointUrl = request.getRequestURL().toString();
+    AccessControl accessControl = _accessControlFactory.create();
+    AccessControlUtils.validatePermission(rawTableName, AccessType.CREATE, httpHeaders, endpointUrl, accessControl);
+    if (!accessControl.hasAccess(httpHeaders, TargetType.TABLE, rawTableName, Actions.Table.CREATE_TABLE)) {
+      throw new ControllerApplicationException(LOGGER, "Permission denied", Response.Status.FORBIDDEN);
+    }
+
+    List<String> deprecationWarnings;
+    try {
+      deprecationWarnings = validateNoDeprecatedConfigs(tableConfigs, JsonUtils.stringToJsonNode(tableConfigsStr),
+          databaseName)._warnings;
+      validateConfig(tableConfigs, databaseName, typesToSkip);
+      tableConfigs.setTableName(rawTableName);
+    } catch (ControllerApplicationException e) {
+      throw e;
+    } catch (IOException | IllegalArgumentException | IllegalStateException e) {
+      throw new ControllerApplicationException(LOGGER, "Invalid TableConfigs. " + e.getMessage(),
+          Response.Status.BAD_REQUEST, e);
+    } catch (RuntimeException e) {
+      _controllerMetrics.addMeteredGlobalValue(ControllerMeter.CONTROLLER_TABLE_ADD_ERROR, 1L);
+      LOGGER.warn("Failed to validate TableConfigs for create of table: {}", rawTableName, e);
+      throw e;
+    }
 
     TableConfig offlineTableConfig = tableConfigs.getOffline();
     TableConfig realtimeTableConfig = tableConfigs.getRealtime();
     Schema schema = tableConfigs.getSchema();
 
     try {
-      // validate permission
-      String endpointUrl = request.getRequestURL().toString();
-      AccessControl accessControl = _accessControlFactory.create();
-      AccessControlUtils.validatePermission(rawTableName, AccessType.CREATE, httpHeaders, endpointUrl,
-          accessControl);
-      if (!accessControl.hasAccess(httpHeaders, TargetType.TABLE, rawTableName, Actions.Table.CREATE_TABLE)) {
-        throw new ControllerApplicationException(LOGGER, "Permission denied", Response.Status.FORBIDDEN);
-      }
 
       if (offlineTableConfig != null) {
         applyTuning(offlineTableConfig, schema);
@@ -263,7 +287,7 @@ public class TableConfigsRestletResource {
       }
 
       return new ConfigSuccessResponse("TableConfigs " + rawTableName + " successfully added",
-          tableConfigsAndUnrecognizedProps.getRight());
+          tableConfigsAndUnrecognizedProps.getRight(), deprecationWarnings);
     } catch (Exception e) {
       _controllerMetrics.addMeteredGlobalValue(ControllerMeter.CONTROLLER_TABLE_ADD_ERROR, 1L);
       if (e instanceof InvalidTableConfigException) {
@@ -343,6 +367,9 @@ public class TableConfigsRestletResource {
   ///
   /// The option to skip table config validation (validationTypesToSkip) and force update the table schema
   /// (forceTableSchemaUpdate) are provided for testing purposes and should be used with caution.
+  ///
+  /// This endpoint performs sequential schema, offline-config, and realtime-config writes without rollback. A 409
+  /// can therefore mean a partial update; clients must re-read all three resources before retrying.
   @PUT
   @Path("/tableConfigs/{tableName}")
   @Authorize(targetType = TargetType.TABLE, paramName = "tableName", action = Actions.Table.UPDATE_TABLE_CONFIGS)
@@ -364,25 +391,39 @@ public class TableConfigsRestletResource {
     tableName = DatabaseUtils.translateTableName(tableName, databaseName);
     Pair<TableConfigs, Map<String, Object>> tableConfigsAndUnrecognizedProps;
     TableConfigs tableConfigs;
-    try {
-      tableConfigsAndUnrecognizedProps =
-          JsonUtils.stringToObjectAndUnrecognizedProperties(tableConfigsStr, TableConfigs.class);
-      tableConfigs = tableConfigsAndUnrecognizedProps.getLeft();
-      validateConfig(tableConfigs, databaseName, typesToSkip);
-      Preconditions.checkState(
-          DatabaseUtils.translateTableName(tableConfigs.getTableName(), databaseName).equals(tableName),
-          "'tableName' in TableConfigs: %s must match provided tableName: %s", tableConfigs.getTableName(), tableName);
-      tableConfigs.setTableName(tableName);
-    } catch (Exception e) {
-      throw new ControllerApplicationException(LOGGER, String.format("Invalid TableConfigs: %s. Reason: %s", tableName,
-          e.getMessage()), Response.Status.BAD_REQUEST, e);
-    }
+    DeprecationValidationResult deprecationResult;
 
+    /// Existence check runs before deprecation validation so a PUT to a missing TableConfigs reports the actual
+    /// problem (table does not exist) instead of a misleading "deprecated property" 400 from create-mode fallback.
     if (!_pinotHelixResourceManager.hasOfflineTable(tableName) && !_pinotHelixResourceManager.hasRealtimeTable(
         tableName)) {
       throw new ControllerApplicationException(LOGGER,
           String.format("TableConfigs: %s does not exist. Use POST to create it first.", tableName),
           Response.Status.BAD_REQUEST);
+    }
+
+    try {
+      tableConfigsAndUnrecognizedProps =
+          JsonUtils.stringToObjectAndUnrecognizedProperties(tableConfigsStr, TableConfigs.class);
+      tableConfigs = tableConfigsAndUnrecognizedProps.getLeft();
+      deprecationResult = validateNoDeprecatedConfigs(tableConfigs, JsonUtils.stringToJsonNode(tableConfigsStr),
+          databaseName);
+      validateConfig(tableConfigs, databaseName, typesToSkip);
+      Preconditions.checkState(
+          DatabaseUtils.translateTableName(tableConfigs.getTableName(), databaseName).equals(tableName),
+          "'tableName' in TableConfigs: %s must match provided tableName: %s", tableConfigs.getTableName(), tableName);
+      tableConfigs.setTableName(tableName);
+    } catch (ControllerApplicationException e) {
+      throw e;
+    } catch (IOException | IllegalArgumentException | IllegalStateException e) {
+      /// Narrowed to client-input exception types so transient ZK / Helix errors propagate as 5xx instead of being
+      /// mis-reported as 400.
+      throw new ControllerApplicationException(LOGGER, "Invalid TableConfigs: " + tableName + ". " + e.getMessage(),
+          Response.Status.BAD_REQUEST, e);
+    } catch (RuntimeException e) {
+      _controllerMetrics.addMeteredGlobalValue(ControllerMeter.CONTROLLER_TABLE_UPDATE_ERROR, 1L);
+      LOGGER.warn("Failed to validate TableConfigs for update of table: {}", tableName, e);
+      throw e;
     }
 
     TableConfig offlineTableConfig = tableConfigs.getOffline();
@@ -396,7 +437,11 @@ public class TableConfigsRestletResource {
       if (offlineTableConfig != null) {
         applyTuning(offlineTableConfig, schema);
         if (_pinotHelixResourceManager.hasOfflineTable(tableName)) {
-          _pinotHelixResourceManager.updateTableConfig(offlineTableConfig, forceTableSchemaUpdate);
+          /// Version-checked CAS: a concurrent writer that landed between the deprecation-diff read and this write
+          /// bumps the znode version, so the CAS fails and we return 5xx — preventing a deprecated key from
+          /// slipping past the diff via a racing update on the same sub-config.
+          _pinotHelixResourceManager.updateTableConfig(offlineTableConfig,
+              deprecationResult._offlineExpectedVersion, forceTableSchemaUpdate);
           LOGGER.info("Updated offline table config: {}", tableName);
         } else {
           _pinotHelixResourceManager.addTable(offlineTableConfig);
@@ -406,13 +451,21 @@ public class TableConfigsRestletResource {
       if (realtimeTableConfig != null) {
         applyTuning(realtimeTableConfig, schema);
         if (_pinotHelixResourceManager.hasRealtimeTable(tableName)) {
-          _pinotHelixResourceManager.updateTableConfig(realtimeTableConfig, forceTableSchemaUpdate);
+          _pinotHelixResourceManager.updateTableConfig(realtimeTableConfig,
+              deprecationResult._realtimeExpectedVersion, forceTableSchemaUpdate);
           LOGGER.info("Updated realtime table config: {}", tableName);
         } else {
           _pinotHelixResourceManager.addTable(realtimeTableConfig);
           LOGGER.info("Created realtime table config: {}", tableName);
         }
       }
+    } catch (TableConfigVersionConflictException e) {
+      /// CAS lost on at least one sub-config (offline or realtime). Note: the offline write may have already
+      /// landed before the realtime CAS failed — TableConfigs PUT writes each sub-type sequentially. The 409
+      /// response signals that the caller should re-read both sub-configs and retry the full transaction.
+      throw new ControllerApplicationException(LOGGER,
+          String.format("Conflict updating TableConfigs for %s: %s. Re-read both sub-configs and retry.", tableName,
+              e.getMessage()), Response.Status.CONFLICT, e);
     } catch (TableConfigBackwardIncompatibleException e) {
       _controllerMetrics.addMeteredGlobalValue(ControllerMeter.CONTROLLER_TABLE_UPDATE_ERROR, 1L);
       throw new ControllerApplicationException(LOGGER,
@@ -429,7 +482,7 @@ public class TableConfigsRestletResource {
     }
 
     return new ConfigSuccessResponse("TableConfigs updated for " + tableName,
-        tableConfigsAndUnrecognizedProps.getRight());
+        tableConfigsAndUnrecognizedProps.getRight(), deprecationResult._warnings);
   }
 
   /// Validates the [TableConfigs] as provided in the tableConfigsStr json, by validating the schema,
@@ -444,11 +497,13 @@ public class TableConfigsRestletResource {
           + "(ALL|TASK|UPSERT|TENANT|MINION_INSTANCES)")
       @QueryParam("validationTypesToSkip") @Nullable String typesToSkip, @Context HttpHeaders httpHeaders,
       @Context Request request) {
-    Pair<TableConfigs, Map<String, Object>> tableConfigsAndUnrecognizedProps =
+    TableConfigsValidationResult result =
         parseAndValidateTableConfigs(tableConfigsStr, typesToSkip, httpHeaders, request);
-    TableConfigs tableConfigs = tableConfigsAndUnrecognizedProps.getLeft();
-    ObjectNode response = JsonUtils.objectToJsonNode(tableConfigs).deepCopy();
-    response.set("unrecognizedProperties", JsonUtils.objectToJsonNode(tableConfigsAndUnrecognizedProps.getRight()));
+    ObjectNode response = JsonUtils.objectToJsonNode(result._tableConfigs).deepCopy();
+    response.set("unrecognizedProperties", JsonUtils.objectToJsonNode(result._unrecognizedProps));
+    if (!result._deprecationWarnings.isEmpty()) {
+      response.set("deprecationWarnings", JsonUtils.objectToJsonNode(result._deprecationWarnings));
+    }
     return response.toString();
   }
 
@@ -466,9 +521,9 @@ public class TableConfigsRestletResource {
           + "(ALL|TASK|UPSERT|TENANT|MINION_INSTANCES)")
       @QueryParam("validationTypesToSkip") @Nullable String typesToSkip, @Context HttpHeaders httpHeaders,
       @Context Request request) {
-    Pair<TableConfigs, Map<String, Object>> tableConfigsAndUnrecognizedProps =
+    TableConfigsValidationResult result =
         parseAndValidateTableConfigs(tableConfigsStr, typesToSkip, httpHeaders, request);
-    TableConfigs tableConfigs = tableConfigsAndUnrecognizedProps.getLeft();
+    TableConfigs tableConfigs = result._tableConfigs;
     Schema schema = tableConfigs.getSchema();
     if (tableConfigs.getOffline() != null) {
       applyTuning(tableConfigs.getOffline(), schema);
@@ -477,26 +532,28 @@ public class TableConfigsRestletResource {
       applyTuning(tableConfigs.getRealtime(), schema);
     }
     ObjectNode response = JsonUtils.objectToJsonNode(tableConfigs).deepCopy();
-    response.set("unrecognizedProperties", JsonUtils.objectToJsonNode(tableConfigsAndUnrecognizedProps.getRight()));
+    response.set("unrecognizedProperties", JsonUtils.objectToJsonNode(result._unrecognizedProps));
+    if (!result._deprecationWarnings.isEmpty()) {
+      response.set("deprecationWarnings", JsonUtils.objectToJsonNode(result._deprecationWarnings));
+    }
     return response.toString();
   }
 
-  private Pair<TableConfigs, Map<String, Object>> parseAndValidateTableConfigs(String tableConfigsStr,
+  private TableConfigsValidationResult parseAndValidateTableConfigs(String tableConfigsStr,
       @Nullable String typesToSkip, HttpHeaders httpHeaders, Request request) {
     Pair<TableConfigs, Map<String, Object>> tableConfigsAndUnrecognizedProps;
+    JsonNode tableConfigsJson;
     try {
       tableConfigsAndUnrecognizedProps =
           JsonUtils.stringToObjectAndUnrecognizedProperties(tableConfigsStr, TableConfigs.class);
+      tableConfigsJson = JsonUtils.stringToJsonNode(tableConfigsStr);
     } catch (IOException e) {
-      throw new ControllerApplicationException(LOGGER,
-          String.format("Invalid TableConfigs json string: %s. Reason: %s", tableConfigsStr, e.getMessage()),
+      throw new ControllerApplicationException(LOGGER, "Invalid TableConfigs json string. " + e.getMessage(),
           Response.Status.BAD_REQUEST, e);
     }
     String databaseName = DatabaseUtils.extractDatabaseFromHttpHeaders(httpHeaders);
     TableConfigs tableConfigs = tableConfigsAndUnrecognizedProps.getLeft();
-    validateConfig(tableConfigs, databaseName, typesToSkip);
     String rawTableName = DatabaseUtils.translateTableName(tableConfigs.getTableName(), databaseName);
-    tableConfigs.setTableName(rawTableName);
 
     // Cluster-aware validations are exclusive to the validate/tune pre-flight endpoints so that users get fail-fast
     // feedback on tenant/minion issues without re-running them in the create/update paths (which already perform the
@@ -519,14 +576,52 @@ public class TableConfigsRestletResource {
           String.format("Invalid TableConfigs: %s. %s", rawTableName, e.getMessage()), Response.Status.BAD_REQUEST, e);
     }
 
-    // validate permission
+    /// Validate permission BEFORE running validateNoDeprecatedConfigs (which reads stored configs from ZK).
+    /// Mirrors PinotTableRestletResource.checkTableConfig and prevents an unauthenticated caller from probing
+    /// table existence via the deprecation-diff response shape.
+    /// setTableName is deferred until AFTER validateConfig because it has the side effect of overwriting the
+    /// schema name (TableConfigs.setTableName calls _schema.setSchemaName), which would mask the schema-mismatch
+    /// check inside validateConfig.
     String endpointUrl = request.getRequestURL().toString();
     AccessControl accessControl = _accessControlFactory.create();
     AccessControlUtils.validatePermission(rawTableName, AccessType.READ, httpHeaders, endpointUrl, accessControl);
     if (!accessControl.hasAccess(httpHeaders, TargetType.TABLE, rawTableName, Actions.Table.VALIDATE_TABLE_CONFIGS)) {
       throw new ControllerApplicationException(LOGGER, "Permission denied", Response.Status.FORBIDDEN);
     }
-    return tableConfigsAndUnrecognizedProps;
+
+    List<String> deprecationWarnings;
+    try {
+      deprecationWarnings = validateNoDeprecatedConfigs(tableConfigs, tableConfigsJson, databaseName)._warnings;
+      validateConfig(tableConfigs, databaseName, typesToSkip);
+      tableConfigs.setTableName(rawTableName);
+    } catch (ControllerApplicationException e) {
+      /// Preserve the upstream status (e.g. 500 from validateConfig); don't downgrade to 400.
+      throw e;
+    } catch (IllegalArgumentException | IllegalStateException e) {
+      throw new ControllerApplicationException(LOGGER, "Invalid TableConfigs. " + e.getMessage(),
+          Response.Status.BAD_REQUEST, e);
+    } catch (RuntimeException e) {
+      LOGGER.warn("Failed to validate TableConfigs for: {}", tableConfigs.getTableName(), e);
+      throw e;
+    }
+    return new TableConfigsValidationResult(tableConfigs, tableConfigsAndUnrecognizedProps.getRight(),
+        deprecationWarnings);
+  }
+
+  /// Carries the parsed [TableConfigs], the map of unrecognized JSON properties, and the list of deprecation
+  /// warnings out of [#parseAndValidateTableConfigs] so the calling REST methods (`/validate`, `/tune`) can
+  /// surface the same set of fields on their response without duplicating the parsing pipeline.
+  private static final class TableConfigsValidationResult {
+    final TableConfigs _tableConfigs;
+    final Map<String, Object> _unrecognizedProps;
+    final List<String> _deprecationWarnings;
+
+    TableConfigsValidationResult(TableConfigs tableConfigs, Map<String, Object> unrecognizedProps,
+        List<String> deprecationWarnings) {
+      _tableConfigs = tableConfigs;
+      _unrecognizedProps = unrecognizedProps;
+      _deprecationWarnings = deprecationWarnings;
+    }
   }
 
   private void validateClusterAwareConfig(TableConfig tableConfig, Set<TableConfigUtils.ValidationType> skipTypes) {
@@ -596,5 +691,97 @@ public class TableConfigsRestletResource {
       throw new ControllerApplicationException(LOGGER,
           String.format("Invalid TableConfigs: %s. %s", rawTableName, e.getMessage()), Response.Status.BAD_REQUEST, e);
     }
+  }
+
+  /// Validates the offline and realtime sub-configs for deprecated properties. For each sub-type, if a stored
+  /// table config already exists for `rawTableName` the validation runs in update mode (diffing against the
+  /// stored config), otherwise it runs in create mode. Aggregated warnings from all sub-types are returned along
+  /// with the ZK znode versions observed at diff time so callers can issue a version-checked CAS on the
+  /// subsequent write.
+  private DeprecationValidationResult validateNoDeprecatedConfigs(TableConfigs tableConfigs,
+      JsonNode tableConfigsJson, String database) {
+    /// All call sites verify tableName non-null before reaching here; assert the invariant so a future refactor
+    /// that moves the call earlier fails loudly instead of silently skipping the deprecation pass.
+    Preconditions.checkState(tableConfigs.getTableName() != null,
+        "tableName must be set before deprecation validation");
+    String rawTableName = DatabaseUtils.translateTableName(tableConfigs.getTableName(), database);
+    List<String> warnings = new ArrayList<>();
+    int offlineExpectedVersion = -1;
+    int realtimeExpectedVersion = -1;
+    JsonNode offlineTableConfigJson = subConfigJson(tableConfigsJson, TableType.OFFLINE);
+    if (offlineTableConfigJson != null) {
+      ReadStoredConfigResult read =
+          readStoredTableConfigJsonWithVersion(TableNameBuilder.OFFLINE.tableNameWithType(rawTableName));
+      offlineExpectedVersion = read._version;
+      String prefix = TableType.OFFLINE.name().toLowerCase();
+      if (read._json == null) {
+        warnings.addAll(DeprecatedTableConfigValidationUtils.validateOnCreate(offlineTableConfigJson, prefix));
+      } else {
+        warnings.addAll(DeprecatedTableConfigValidationUtils.validateOnUpdate(offlineTableConfigJson, read._json,
+            prefix));
+      }
+    }
+    JsonNode realtimeTableConfigJson = subConfigJson(tableConfigsJson, TableType.REALTIME);
+    if (realtimeTableConfigJson != null) {
+      ReadStoredConfigResult read =
+          readStoredTableConfigJsonWithVersion(TableNameBuilder.REALTIME.tableNameWithType(rawTableName));
+      realtimeExpectedVersion = read._version;
+      String prefix = TableType.REALTIME.name().toLowerCase();
+      if (read._json == null) {
+        warnings.addAll(DeprecatedTableConfigValidationUtils.validateOnCreate(realtimeTableConfigJson, prefix));
+      } else {
+        warnings.addAll(DeprecatedTableConfigValidationUtils.validateOnUpdate(realtimeTableConfigJson, read._json,
+            prefix));
+      }
+    }
+    return new DeprecationValidationResult(warnings, offlineExpectedVersion, realtimeExpectedVersion);
+  }
+
+  /// Read result paired with the ZK znode version observed at read time. Used to thread the CAS expected-version
+  /// through to the subsequent `updateTableConfig` write.
+  private static final class ReadStoredConfigResult {
+    @Nullable
+    final JsonNode _json;
+    final int _version;
+
+    ReadStoredConfigResult(@Nullable JsonNode json, int version) {
+      _json = json;
+      _version = version;
+    }
+  }
+
+  /// Aggregated deprecation-diff result. Carries the per-sub-type ZK znode versions so the subsequent
+  /// `updateTableConfig` call can issue a version-checked CAS. A `-1` version means the sub-type did not exist at
+  /// diff time (create path), so no version check is required.
+  static final class DeprecationValidationResult {
+    final List<String> _warnings;
+    final int _offlineExpectedVersion;
+    final int _realtimeExpectedVersion;
+
+    DeprecationValidationResult(List<String> warnings, int offlineExpectedVersion, int realtimeExpectedVersion) {
+      _warnings = warnings;
+      _offlineExpectedVersion = offlineExpectedVersion;
+      _realtimeExpectedVersion = realtimeExpectedVersion;
+    }
+  }
+
+  private ReadStoredConfigResult readStoredTableConfigJsonWithVersion(String tableNameWithType) {
+    Stat stat = new Stat();
+    ZNRecord stored = ZKMetadataProvider.getTableConfigZNRecord(_pinotHelixResourceManager.getPropertyStore(),
+        tableNameWithType, stat);
+    return new ReadStoredConfigResult(TableConfigSerDeUtils.toRawJsonNode(stored),
+        stored == null ? -1 : stat.getVersion());
+  }
+
+  @Nullable
+  private static JsonNode subConfigJson(JsonNode tableConfigsJson, TableType type) {
+    /// Mirror what Jackson populates on the deserialized POJO: TableConfigs uses @JsonProperty("offline") /
+    /// @JsonProperty("realtime"), so any uppercase variant in the raw user JSON is already silently ignored at
+    /// deserialization time. We use the same lowercase-only lookup here so the deprecation pass agrees with what
+    /// ends up in the stored config. The Jackson-ignores-uppercase invariant is locked at the SPI layer by
+    /// TableConfigsSerializationTest#testUppercaseOfflineRealtimeKeysAreIgnoredByJackson — if Jackson is ever
+    /// configured to ACCEPT_CASE_INSENSITIVE_PROPERTIES, that SPI test fails first, surfacing the regression
+    /// before any request reaches this code path.
+    return tableConfigsJson.get(type.name().toLowerCase());
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -61,6 +61,7 @@ import javax.ws.rs.NotFoundException;
 import javax.ws.rs.core.Response;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.helix.AccessOption;
 import org.apache.helix.ClusterMessagingService;
@@ -100,6 +101,7 @@ import org.apache.pinot.common.exception.SchemaAlreadyExistsException;
 import org.apache.pinot.common.exception.SchemaBackwardIncompatibleException;
 import org.apache.pinot.common.exception.SchemaNotFoundException;
 import org.apache.pinot.common.exception.TableConfigBackwardIncompatibleException;
+import org.apache.pinot.common.exception.TableConfigVersionConflictException;
 import org.apache.pinot.common.exception.TableNotFoundException;
 import org.apache.pinot.common.lineage.LineageEntry;
 import org.apache.pinot.common.lineage.LineageEntryState;
@@ -2355,9 +2357,27 @@ public class PinotHelixResourceManager {
   /// @throws TableConfigBackwardIncompatibleException if config changes are backward incompatible and force is false
   public void updateTableConfig(TableConfig tableConfig, boolean force)
       throws IOException, TableConfigBackwardIncompatibleException {
+    updateTableConfig(tableConfig, -1, force);
+  }
+
+  /// Validate the table config and update it with a version-checked CAS write. Callers that pre-read the stored
+  /// config (e.g. the deprecation-validator diff path) can pass the version they observed so a concurrent write
+  /// fails the CAS rather than silently overwriting the other writer's changes.
+  ///
+  /// @param tableConfig the table config to update
+  /// @param expectedVersion the expected ZK znode version, or -1 to skip the version check
+  /// @param force if true, allows upsert/dedup config changes with a warning
+  /// @throws IOException if validation fails
+  /// @throws TableConfigBackwardIncompatibleException if config changes are backward incompatible and force is false
+  /// @throws TableConfigVersionConflictException (unchecked) if expectedVersion is set and a concurrent writer
+  ///         bumped or deleted the znode between the caller's read and this write. Callers SHOULD surface this
+  ///         as HTTP 409 CONFLICT so the client can re-read and retry. Unchecked to preserve the prior binary
+  ///         contract of `updateTableConfig(TableConfig, boolean)` for external callers.
+  public void updateTableConfig(TableConfig tableConfig, int expectedVersion, boolean force)
+      throws IOException, TableConfigBackwardIncompatibleException {
     validateTableTenantConfig(tableConfig);
     validateTableTaskMinionInstanceTagConfig(tableConfig);
-    setExistingTableConfig(tableConfig, -1, force);
+    setExistingTableConfig(tableConfig, expectedVersion, force);
   }
 
   /// Sets the given table config into zookeeper bypassing validations in updateTableConfig
@@ -2470,10 +2490,48 @@ public class PinotHelixResourceManager {
   /// @param expectedVersion the expected version (-1 to ignore version check)
   /// @param force if true, allows upsert/dedup config changes with a warning
   /// @throws TableConfigBackwardIncompatibleException if config changes are backward incompatible and force is false
+  /// @throws TableConfigVersionConflictException if expectedVersion is set (non-negative) and the CAS write fails
+  ///     because a concurrent writer bumped the znode version or deleted the znode. This unchecked exception lets
+  ///     REST callers surface HTTP 409 without changing the existing method signature.
   public void setExistingTableConfig(TableConfig tableConfig, int expectedVersion, boolean force)
       throws TableConfigBackwardIncompatibleException {
     String tableNameWithType = tableConfig.getTableName();
-    TableConfig existingTableConfig = getTableConfig(tableNameWithType);
+    /// In CAS mode (expectedVersion >= 0) the pre-flight read serves two purposes:
+    ///   (1) Optimisation: short-circuit to TableConfigVersionConflictException when this read already shows the
+    ///       znode is past expectedVersion. The atomicity-essential CAS happens at ZKMetadataProvider.setTableConfig
+    ///       below — a concurrent writer landing between this read and that write will still be caught by the
+    ///       write-time CAS. The early throw avoids running back-compat validation against a snapshot we already
+    ///       know is doomed to fail the CAS, and gives the caller a precise 409 rather than a misleading 400.
+    ///   (2) Single-snapshot consistency: feed the SAME (existingConfig, statV) snapshot into the back-compat
+    ///       validation that follows. Doing two independent reads (one here for the version, one via
+    ///       getTableConfig() below) opened a window where back-compat ran against a fresher snapshot than the
+    ///       caller's expectedVersion intent. Reusing the pair keeps a single TableConfig instance driving both
+    ///       decisions on the in-method evaluation; the write-time CAS remains the only atomicity boundary.
+    /// In non-CAS mode (expectedVersion == -1) the legacy `getTableConfig(tableNameWithType)` path is retained
+    /// for back-compat with existing callers (PinotDdlRestletResource, RealtimeOffsetAutoResetKafkaHandler, etc.)
+    /// that do not pre-read a version.
+    TableConfig existingTableConfig;
+    if (expectedVersion >= 0) {
+      ImmutablePair<TableConfig, Stat> withStat =
+          ZKMetadataProvider.getTableConfigWithStat(_propertyStore, tableNameWithType);
+      if (withStat == null) {
+        /// Concurrent-delete race: caller pre-read the znode at version `expectedVersion`, then a concurrent
+        /// deleter removed it before we got here. Distinguish from a regular version-mismatch so the message
+        /// says "deleted" rather than "modified". This avoids the controller silently re-creating the table at
+        /// expectedVersion (Lazarus pattern) when the operator's intent was to delete it.
+        throw new TableConfigVersionConflictException(
+            "Table config for " + tableNameWithType + " was deleted concurrently (expected version "
+                + expectedVersion + "); re-create the table explicitly or abort the update");
+      }
+      if (withStat.getRight().getVersion() != expectedVersion) {
+        throw new TableConfigVersionConflictException(
+            "Table config for " + tableNameWithType + " was modified by a concurrent writer (expected version "
+                + expectedVersion + ", current " + withStat.getRight().getVersion() + ")");
+      }
+      existingTableConfig = withStat.getLeft();
+    } else {
+      existingTableConfig = getTableConfig(tableNameWithType);
+    }
     if (existingTableConfig != null) {
       List<String> violations = TableConfigUtils.validateBackwardCompatibility(tableConfig, existingTableConfig);
       if (!violations.isEmpty()) {
@@ -2492,6 +2550,14 @@ public class PinotHelixResourceManager {
     }
 
     if (!ZKMetadataProvider.setTableConfig(_propertyStore, tableConfig, expectedVersion)) {
+      /// Disambiguate CAS-conflict (concurrent writer bumped the znode version) from a generic ZK failure so
+      /// callers can return HTTP 409 with retry guidance instead of a 500. expectedVersion < 0 means "no version
+      /// check requested" — any failure in that mode is treated as a generic ZK error.
+      if (expectedVersion >= 0) {
+        throw new TableConfigVersionConflictException(
+            "Table config for " + tableNameWithType + " was modified by a concurrent writer (expected version "
+                + expectedVersion + ")");
+      }
       throw new RuntimeException(
           "Failed to update table config in Zookeeper for table: " + tableNameWithType + " with" + " expected version: "
               + expectedVersion);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -61,6 +61,7 @@ import javax.ws.rs.NotFoundException;
 import javax.ws.rs.core.Response;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.tuple.ImmutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.helix.AccessOption;
 import org.apache.helix.ClusterMessagingService;
@@ -99,6 +100,7 @@ import org.apache.pinot.common.exception.SchemaAlreadyExistsException;
 import org.apache.pinot.common.exception.SchemaBackwardIncompatibleException;
 import org.apache.pinot.common.exception.SchemaNotFoundException;
 import org.apache.pinot.common.exception.TableConfigBackwardIncompatibleException;
+import org.apache.pinot.common.exception.TableConfigVersionConflictException;
 import org.apache.pinot.common.exception.TableNotFoundException;
 import org.apache.pinot.common.lineage.LineageEntry;
 import org.apache.pinot.common.lineage.LineageEntryState;
@@ -2341,9 +2343,27 @@ public class PinotHelixResourceManager {
   /// @throws TableConfigBackwardIncompatibleException if config changes are backward incompatible and force is false
   public void updateTableConfig(TableConfig tableConfig, boolean force)
       throws IOException, TableConfigBackwardIncompatibleException {
+    updateTableConfig(tableConfig, -1, force);
+  }
+
+  /// Validate the table config and update it with a version-checked CAS write. Callers that pre-read the stored
+  /// config (e.g. the deprecation-validator diff path) can pass the version they observed so a concurrent write
+  /// fails the CAS rather than silently overwriting the other writer's changes.
+  ///
+  /// @param tableConfig the table config to update
+  /// @param expectedVersion the expected ZK znode version, or -1 to skip the version check
+  /// @param force if true, allows upsert/dedup config changes with a warning
+  /// @throws IOException if validation fails
+  /// @throws TableConfigBackwardIncompatibleException if config changes are backward incompatible and force is false
+  /// @throws TableConfigVersionConflictException (unchecked) if expectedVersion is set and a concurrent writer
+  ///         bumped or deleted the znode between the caller's read and this write. Callers SHOULD surface this
+  ///         as HTTP 409 CONFLICT so the client can re-read and retry. Unchecked to preserve the prior binary
+  ///         contract of `updateTableConfig(TableConfig, boolean)` for external callers.
+  public void updateTableConfig(TableConfig tableConfig, int expectedVersion, boolean force)
+      throws IOException, TableConfigBackwardIncompatibleException {
     validateTableTenantConfig(tableConfig);
     validateTableTaskMinionInstanceTagConfig(tableConfig);
-    setExistingTableConfig(tableConfig, -1, force);
+    setExistingTableConfig(tableConfig, expectedVersion, force);
   }
 
   /// Sets the given table config into zookeeper bypassing validations in updateTableConfig
@@ -2456,10 +2476,48 @@ public class PinotHelixResourceManager {
   /// @param expectedVersion the expected version (-1 to ignore version check)
   /// @param force if true, allows upsert/dedup config changes with a warning
   /// @throws TableConfigBackwardIncompatibleException if config changes are backward incompatible and force is false
+  /// @throws TableConfigVersionConflictException if expectedVersion is set (non-negative) and the CAS write fails
+  ///     because a concurrent writer bumped the znode version or deleted the znode. This unchecked exception lets
+  ///     REST callers surface HTTP 409 without changing the existing method signature.
   public void setExistingTableConfig(TableConfig tableConfig, int expectedVersion, boolean force)
       throws TableConfigBackwardIncompatibleException {
     String tableNameWithType = tableConfig.getTableName();
-    TableConfig existingTableConfig = getTableConfig(tableNameWithType);
+    /// In CAS mode (expectedVersion >= 0) the pre-flight read serves two purposes:
+    ///   (1) Optimisation: short-circuit to TableConfigVersionConflictException when this read already shows the
+    ///       znode is past expectedVersion. The atomicity-essential CAS happens at ZKMetadataProvider.setTableConfig
+    ///       below — a concurrent writer landing between this read and that write will still be caught by the
+    ///       write-time CAS. The early throw avoids running back-compat validation against a snapshot we already
+    ///       know is doomed to fail the CAS, and gives the caller a precise 409 rather than a misleading 400.
+    ///   (2) Single-snapshot consistency: feed the SAME (existingConfig, statV) snapshot into the back-compat
+    ///       validation that follows. Doing two independent reads (one here for the version, one via
+    ///       getTableConfig() below) opened a window where back-compat ran against a fresher snapshot than the
+    ///       caller's expectedVersion intent. Reusing the pair keeps a single TableConfig instance driving both
+    ///       decisions on the in-method evaluation; the write-time CAS remains the only atomicity boundary.
+    /// In non-CAS mode (expectedVersion == -1) the legacy `getTableConfig(tableNameWithType)` path is retained
+    /// for back-compat with existing callers (PinotDdlRestletResource, RealtimeOffsetAutoResetKafkaHandler, etc.)
+    /// that do not pre-read a version.
+    TableConfig existingTableConfig;
+    if (expectedVersion >= 0) {
+      ImmutablePair<TableConfig, Stat> withStat =
+          ZKMetadataProvider.getTableConfigWithStat(_propertyStore, tableNameWithType);
+      if (withStat == null) {
+        /// Concurrent-delete race: caller pre-read the znode at version `expectedVersion`, then a concurrent
+        /// deleter removed it before we got here. Distinguish from a regular version-mismatch so the message
+        /// says "deleted" rather than "modified". This avoids the controller silently re-creating the table at
+        /// expectedVersion (Lazarus pattern) when the operator's intent was to delete it.
+        throw new TableConfigVersionConflictException(
+            "Table config for " + tableNameWithType + " was deleted concurrently (expected version "
+                + expectedVersion + "); re-create the table explicitly or abort the update");
+      }
+      if (withStat.getRight().getVersion() != expectedVersion) {
+        throw new TableConfigVersionConflictException(
+            "Table config for " + tableNameWithType + " was modified by a concurrent writer (expected version "
+                + expectedVersion + ", current " + withStat.getRight().getVersion() + ")");
+      }
+      existingTableConfig = withStat.getLeft();
+    } else {
+      existingTableConfig = getTableConfig(tableNameWithType);
+    }
     if (existingTableConfig != null) {
       List<String> violations = TableConfigUtils.validateBackwardCompatibility(tableConfig, existingTableConfig);
       if (!violations.isEmpty()) {
@@ -2478,6 +2536,14 @@ public class PinotHelixResourceManager {
     }
 
     if (!ZKMetadataProvider.setTableConfig(_propertyStore, tableConfig, expectedVersion)) {
+      /// Disambiguate CAS-conflict (concurrent writer bumped the znode version) from a generic ZK failure so
+      /// callers can return HTTP 409 with retry guidance instead of a 500. expectedVersion < 0 means "no version
+      /// check requested" — any failure in that mode is treated as a generic ZK error.
+      if (expectedVersion >= 0) {
+        throw new TableConfigVersionConflictException(
+            "Table config for " + tableNameWithType + " was modified by a concurrent writer (expected version "
+                + expectedVersion + ")");
+      }
       throw new RuntimeException(
           "Failed to update table config in Zookeeper for table: " + tableNameWithType + " with" + " expected version: "
               + expectedVersion);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotTableRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotTableRestletResourceTest.java
@@ -31,14 +31,19 @@ import java.util.Set;
 import javax.annotation.Nullable;
 import javax.ws.rs.core.Response;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.helix.task.TaskState;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.pinot.client.admin.LogicalTableAdminClient;
 import org.apache.pinot.client.admin.PinotAdminClient;
 import org.apache.pinot.client.admin.PinotAdminException;
 import org.apache.pinot.client.admin.TableAdminClient;
 import org.apache.pinot.client.admin.TaskAdminClient;
 import org.apache.pinot.client.admin.ZookeeperAdminClient;
+import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.restlet.resources.RebalanceResult;
+import org.apache.pinot.common.utils.config.DeprecatedTableConfigValidationUtils;
+import org.apache.pinot.common.utils.config.TableConfigSerDeUtils;
 import org.apache.pinot.controller.helix.ControllerTest;
 import org.apache.pinot.controller.helix.core.minion.ClusterInfoAccessor;
 import org.apache.pinot.controller.helix.core.minion.PinotHelixTaskResourceManager;
@@ -69,6 +74,7 @@ import org.apache.pinot.spi.utils.StringUtil;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.util.TestUtils;
+import org.apache.zookeeper.data.Stat;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
@@ -90,6 +96,14 @@ import static org.testng.Assert.fail;
 public class PinotTableRestletResourceTest extends ControllerTest {
   private static final String OFFLINE_TABLE_NAME = "testOfflineTable";
   private static final String REALTIME_TABLE_NAME = "testRealtimeTable";
+  private static final String STREAM_CONFIGS_DEPRECATION_WARNING =
+      "'tableIndexConfig.streamConfigs' is deprecated since 0.7.1. Use "
+          + "'ingestionConfig.streamIngestionConfig.streamConfigMaps' instead.";
+  /// TableConfigBuilder defaults _segmentPushType to "APPEND" (preserved for programmatic-caller back-compat),
+  /// so every realtime config built via the builder also emits this deprecation warning.
+  private static final String SEGMENT_PUSH_TYPE_DEPRECATION_WARNING =
+      "'segmentsConfig.segmentPushType' is deprecated since 0.8.0. Use "
+          + "'ingestionConfig.batchIngestionConfig.segmentIngestionType' instead.";
   private final TableConfigBuilder _offlineBuilder = getOfflineTableBuilder(OFFLINE_TABLE_NAME);
   private final TableConfigBuilder _realtimeBuilder = getRealtimeTableBuilder(REALTIME_TABLE_NAME);
 
@@ -132,6 +146,39 @@ public class PinotTableRestletResourceTest extends ControllerTest {
     } catch (Exception e) {
       throw unwrapAsIOException(e);
     }
+  }
+
+  /// Asserts that a successful realtime-table create response carries both the segmentPushType and streamConfigs
+  /// deprecation warnings, the expected status, and no unrecognized properties. The deprecation warnings are
+  /// compared as a SET because the discovery walk order is `Class.getMethods()`-dependent and not guaranteed
+  /// stable across JVM versions or future TableConfig refactors.
+  private static void assertSuccessfulRealtimeTableCreationResponse(String actualJson, String tableNameWithType) {
+    assertSuccessfulTableCreationResponse(actualJson, tableNameWithType,
+        Set.of(SEGMENT_PUSH_TYPE_DEPRECATION_WARNING, STREAM_CONFIGS_DEPRECATION_WARNING));
+  }
+
+  private static void assertSuccessfulOfflineTableCreationResponse(String actualJson, String tableNameWithType) {
+    assertSuccessfulTableCreationResponse(actualJson, tableNameWithType,
+        Set.of(SEGMENT_PUSH_TYPE_DEPRECATION_WARNING));
+  }
+
+  private static void assertSuccessfulTableCreationResponse(String actualJson, String tableNameWithType,
+      Set<String> expectedWarnings) {
+    JsonNode parsed;
+    try {
+      parsed = JsonUtils.stringToJsonNode(actualJson);
+    } catch (IOException e) {
+      throw new AssertionError("response is not valid JSON: " + actualJson, e);
+    }
+    assertEquals(parsed.path("status").asText(), "Table " + tableNameWithType + " successfully added",
+        "unexpected status in " + actualJson);
+    assertTrue(parsed.path("unrecognizedProperties").isObject()
+            && parsed.path("unrecognizedProperties").isEmpty(),
+        "expected empty unrecognizedProperties in " + actualJson);
+    Set<String> actualWarnings = new java.util.HashSet<>();
+    parsed.path("deprecationWarnings").forEach(n -> actualWarnings.add(n.asText()));
+    assertEquals(actualWarnings, expectedWarnings,
+        "deprecationWarnings set mismatch in " + actualJson);
   }
 
   private String updateTable(String tableName, String tableConfigJson)
@@ -355,6 +402,93 @@ public class PinotTableRestletResourceTest extends ControllerTest {
   }
 
   @Test
+  public void testReportsDeprecatedConfigOnCreateAndOnUpdateAsWarning()
+      throws Exception {
+    /// Soft-launch policy: deprecated keys are reported via the deprecationWarnings field on the success
+    /// response, not rejected with a 400.
+    TableConfig offlineTableConfig = _offlineBuilder.setTableName(OFFLINE_TABLE_NAME).build();
+    ObjectNode createTableJson = (ObjectNode) JsonUtils.stringToJsonNode(offlineTableConfig.toJsonString());
+    createTableJson.withObject("segmentsConfig").put("replicasPerPartition", "APPEND");
+
+    JsonNode createResponse = JsonUtils.stringToJsonNode(createTable(createTableJson.toString()));
+    JsonNode createWarnings = createResponse.path("deprecationWarnings");
+    assertTrue(createWarnings.isArray() && createWarnings.size() > 0,
+        "expected deprecationWarnings on create response: " + createResponse);
+    assertTrue(createWarnings.toString().contains("segmentsConfig.replicasPerPartition"),
+        createWarnings.toString());
+
+    /// Update that introduces a previously-absent deprecated property: also reported as a warning.
+    String rawTableName = "deprecated_update_table";
+    DEFAULT_INSTANCE.addDummySchema(rawTableName);
+    TableConfig existingTableConfig = getOfflineTableBuilder(rawTableName).build();
+    createTable(existingTableConfig.toJsonString());
+
+    ObjectNode updateTableJson = (ObjectNode) JsonUtils.stringToJsonNode(existingTableConfig.toJsonString());
+    updateTableJson.withObject("segmentsConfig").put("replicasPerPartition", "APPEND");
+    JsonNode updateResponse = JsonUtils.stringToJsonNode(
+        updateTable(existingTableConfig.getTableName(), updateTableJson.toString()));
+    JsonNode updateWarnings = updateResponse.path("deprecationWarnings");
+    assertTrue(updateWarnings.isArray() && updateWarnings.size() > 0,
+        "expected deprecationWarnings on update response: " + updateResponse);
+    assertTrue(updateWarnings.toString().contains("segmentsConfig.replicasPerPartition"),
+        updateWarnings.toString());
+  }
+
+  @Test
+  public void testUpdateMissingTableReports404NotDeprecationError()
+      throws Exception {
+    /// PUT to a missing table whose body contains a deprecated key must report 404 (table does not exist) rather
+    /// than a misleading 400 about a deprecated property — the existence check runs before the deprecation diff.
+    String rawTableName = "missing_update_with_legacy_key";
+    DEFAULT_INSTANCE.addDummySchema(rawTableName);
+    TableConfig tableConfig = getOfflineTableBuilder(rawTableName).build();
+    ObjectNode updateTableJson = (ObjectNode) JsonUtils.stringToJsonNode(tableConfig.toJsonString());
+    updateTableJson.withObject("segmentsConfig").put("replicasPerPartition", "APPEND");
+    IOException e = expectThrows(IOException.class,
+        () -> updateTable(tableConfig.getTableName(), updateTableJson.toString()));
+    String message = e.getMessage() != null ? e.getMessage() : "";
+    /// The admin client wraps the server response into the IOException message. Parse the embedded JSON body and
+    /// assert structurally on the `code` field rather than grepping multiple substring formats.
+    int braceStart = message.indexOf('{');
+    int braceEnd = message.lastIndexOf('}');
+    assertTrue(braceStart >= 0 && braceEnd > braceStart, "Expected JSON body embedded in error, got: " + message);
+    JsonNode errorBody = JsonUtils.stringToJsonNode(message.substring(braceStart, braceEnd + 1));
+    assertEquals(errorBody.path("code").asInt(), 404,
+        "Expected 404 status code on missing-table PUT, got body: " + errorBody);
+    assertTrue(errorBody.path("error").asText().contains("does not exist"),
+        "Expected 'does not exist' to take precedence over deprecation, got: " + errorBody);
+    assertTrue(!errorBody.path("error").asText().contains("Newly introduced deprecated"),
+        "404 must take precedence over deprecation diff, got: " + errorBody);
+  }
+
+  @Test
+  /// Intentionally exercises re-submission of a deprecated key stored by an older Pinot version.
+  @SuppressWarnings("deprecation")
+  public void testUpdateAllowsUnchangedLegacyDeprecatedConfig()
+      throws Exception {
+    /// Simulate a table whose stored config already contains a deprecated property (e.g. created on an older
+    /// version). On update, re-submitting the same legacy value must NOT trigger validation; only newly introduced
+    /// or value-changed deprecated paths are flagged.
+    String rawTableName = "deprecated_legacy_table";
+    DEFAULT_INSTANCE.addDummySchema(rawTableName);
+    TableConfig existingTableConfig = getOfflineTableBuilder(rawTableName).build();
+    createTable(existingTableConfig.toJsonString());
+
+    /// Inject a deprecated value directly into ZK to mimic a pre-existing legacy config.
+    String tableNameWithType = TableNameBuilder.OFFLINE.tableNameWithType(rawTableName);
+    TableConfig stored = DEFAULT_INSTANCE.getHelixResourceManager().getTableConfig(tableNameWithType);
+    stored.getValidationConfig().setReplicasPerPartition("3");
+    DEFAULT_INSTANCE.getHelixResourceManager().setExistingTableConfig(stored);
+
+    /// Re-submit the same legacy value. The diff against the stored config means this is treated as unchanged and
+    /// should pass.
+    ObjectNode updateTableJson = (ObjectNode) JsonUtils.stringToJsonNode(stored.toJsonString());
+    JsonNode response = JsonUtils.stringToJsonNode(
+        updateTable(existingTableConfig.getTableName(), updateTableJson.toString()));
+    assertEquals(response.get("status").asText(), "Table config updated for " + existingTableConfig.getTableName());
+  }
+
+  @Test
   public void testTableCronSchedule()
       throws IOException {
     String rawTableName = "test_table_cron_schedule";
@@ -377,8 +511,7 @@ public class PinotTableRestletResourceTest extends ControllerTest {
             Map.of(PinotTaskManager.SCHEDULE_KEY, "0 */10 * ? * * *")))).build();
     try {
       String response = createTable(tableConfig.toJsonString());
-      assertEquals(response,
-          "{\"unrecognizedProperties\":{},\"status\":\"Table test_table_cron_schedule_OFFLINE successfully added\"}");
+      assertSuccessfulOfflineTableCreationResponse(response, "test_table_cron_schedule_OFFLINE");
     } catch (IOException e) {
       // Expected 400 Bad Request
       fail("This is a valid table config with cron schedule");
@@ -724,8 +857,7 @@ public class PinotTableRestletResourceTest extends ControllerTest {
     DEFAULT_INSTANCE.addDummySchema("table0");
     TableConfig realtimeTableConfig = _realtimeBuilder.setTableName("table0").build();
     String creationResponse = createTable(realtimeTableConfig.toJsonString());
-    assertEquals(creationResponse,
-        "{\"unrecognizedProperties\":{},\"status\":\"Table table0_REALTIME successfully added\"}");
+    assertSuccessfulRealtimeTableCreationResponse(creationResponse, "table0_REALTIME");
 
     // Delete realtime table using REALTIME suffix.
     String deleteResponse = sendDeleteRequest(
@@ -735,8 +867,7 @@ public class PinotTableRestletResourceTest extends ControllerTest {
     // Case 2: Create an offline table and delete it directly w/o using query param.
     TableConfig offlineTableConfig = _offlineBuilder.setTableName("table0").build();
     creationResponse = createTable(offlineTableConfig.toJsonString());
-    assertEquals(creationResponse,
-        "{\"unrecognizedProperties\":{},\"status\":\"Table table0_OFFLINE successfully added\"}");
+    assertSuccessfulOfflineTableCreationResponse(creationResponse, "table0_OFFLINE");
 
     // Delete offline table using OFFLINE suffix.
     deleteResponse =
@@ -747,13 +878,11 @@ public class PinotTableRestletResourceTest extends ControllerTest {
     DEFAULT_INSTANCE.addDummySchema("table1");
     TableConfig rtConfig1 = _realtimeBuilder.setTableName("table1").build();
     creationResponse = createTable(rtConfig1.toJsonString());
-    assertEquals(creationResponse,
-        "{\"unrecognizedProperties\":{},\"status\":\"Table table1_REALTIME successfully added\"}");
+    assertSuccessfulRealtimeTableCreationResponse(creationResponse, "table1_REALTIME");
 
     TableConfig offlineConfig1 = _offlineBuilder.setTableName("table1").build();
     creationResponse = createTable(offlineConfig1.toJsonString());
-    assertEquals(creationResponse,
-        "{\"unrecognizedProperties\":{},\"status\":\"Table table1_OFFLINE successfully added\"}");
+    assertSuccessfulOfflineTableCreationResponse(creationResponse, "table1_OFFLINE");
 
     deleteResponse =
         sendDeleteRequest(StringUtil.join("/", DEFAULT_INSTANCE.getControllerBaseApiUrl(), "tables", "table1"));
@@ -763,13 +892,11 @@ public class PinotTableRestletResourceTest extends ControllerTest {
     DEFAULT_INSTANCE.addDummySchema("table2");
     TableConfig rtConfig2 = _realtimeBuilder.setTableName("table2").build();
     creationResponse = createTable(rtConfig2.toJsonString());
-    assertEquals(creationResponse,
-        "{\"unrecognizedProperties\":{},\"status\":\"Table table2_REALTIME successfully added\"}");
+    assertSuccessfulRealtimeTableCreationResponse(creationResponse, "table2_REALTIME");
 
     TableConfig offlineConfig2 = _offlineBuilder.setTableName("table2").build();
     creationResponse = createTable(offlineConfig2.toJsonString());
-    assertEquals(creationResponse,
-        "{\"unrecognizedProperties\":{},\"status\":\"Table table2_OFFLINE successfully added\"}");
+    assertSuccessfulOfflineTableCreationResponse(creationResponse, "table2_OFFLINE");
 
     // The conflict between param type and table name suffix causes no table being deleted.
     try {
@@ -801,13 +928,11 @@ public class PinotTableRestletResourceTest extends ControllerTest {
     DEFAULT_INSTANCE.addDummySchema("table3");
     TableConfig rtConfig3 = _realtimeBuilder.setTableName("table3").build();
     creationResponse = createTable(rtConfig3.toJsonString());
-    assertEquals(creationResponse,
-        "{\"unrecognizedProperties\":{},\"status\":\"Table table3_REALTIME successfully added\"}");
+    assertSuccessfulRealtimeTableCreationResponse(creationResponse, "table3_REALTIME");
 
     TableConfig offlineConfig3 = _offlineBuilder.setTableName("table3").build();
     creationResponse = createTable(offlineConfig3.toJsonString());
-    assertEquals(creationResponse,
-        "{\"unrecognizedProperties\":{},\"status\":\"Table table3_OFFLINE successfully added\"}");
+    assertSuccessfulOfflineTableCreationResponse(creationResponse, "table3_OFFLINE");
 
     deleteResponse = deleteTable("table3_REALTIME", "realtime");
     assertEquals(deleteResponse, "{\"status\":\"Tables: [table3_REALTIME] deleted\"}");
@@ -871,14 +996,12 @@ public class PinotTableRestletResourceTest extends ControllerTest {
     DEFAULT_INSTANCE.addDummySchema(tableName);
     TableConfig realtimeTableConfig = _realtimeBuilder.setTableName(tableName).build();
     String creationResponse = createTable(realtimeTableConfig.toJsonString());
-    assertEquals(creationResponse,
-        "{\"unrecognizedProperties\":{},\"status\":\"Table testTable_REALTIME successfully added\"}");
+    assertSuccessfulRealtimeTableCreationResponse(creationResponse, "testTable_REALTIME");
 
     // Create a valid OFFLINE table
     TableConfig offlineTableConfig = _offlineBuilder.setTableName(tableName).build();
     creationResponse = createTable(offlineTableConfig.toJsonString());
-    assertEquals(creationResponse,
-        "{\"unrecognizedProperties\":{},\"status\":\"Table testTable_OFFLINE successfully added\"}");
+    assertSuccessfulOfflineTableCreationResponse(creationResponse, "testTable_OFFLINE");
 
     // Case 1: Check table state with specifying tableType as realtime should return 1 [enabled]
     String realtimeStateResponse = sendGetRequest(
@@ -962,9 +1085,15 @@ public class PinotTableRestletResourceTest extends ControllerTest {
     ((ObjectNode) jsonNode).put("illegalKey2", internalObj);
 
     String creationResponse = createTable(jsonNode.toString());
-    assertEquals(creationResponse,
-        "{\"unrecognizedProperties\":{\"/illegalKey1\":1,\"/illegalKey2/illegalKey3\":2},\"status\":\"Table "
-            + "valid_table_name_extra_props_REALTIME successfully added\"}");
+    JsonNode parsedCreate = JsonUtils.stringToJsonNode(creationResponse);
+    assertEquals(parsedCreate.path("status").asText(),
+        "Table valid_table_name_extra_props_REALTIME successfully added");
+    assertEquals(parsedCreate.path("unrecognizedProperties").get("/illegalKey1").asInt(), 1);
+    assertEquals(parsedCreate.path("unrecognizedProperties").get("/illegalKey2/illegalKey3").asInt(), 2);
+    Set<String> creationWarnings = new java.util.HashSet<>();
+    parsedCreate.path("deprecationWarnings").forEach(n -> creationWarnings.add(n.asText()));
+    assertEquals(creationWarnings,
+        Set.of(SEGMENT_PUSH_TYPE_DEPRECATION_WARNING, STREAM_CONFIGS_DEPRECATION_WARNING));
 
     // update table with unrecognizedProperties
     String updateResponse =
@@ -1088,8 +1217,7 @@ public class PinotTableRestletResourceTest extends ControllerTest {
     DEFAULT_INSTANCE.addDummySchema(tableName);
     TableConfig offlineTableConfig = _offlineBuilder.setTableName(tableName).build();
     String creationResponse = createTable(offlineTableConfig.toJsonString());
-    assertEquals(creationResponse,
-        "{\"unrecognizedProperties\":{},\"status\":\"Table testTable_OFFLINE successfully added\"}");
+    assertSuccessfulOfflineTableCreationResponse(creationResponse, "testTable_OFFLINE");
 
     // create logical table with above physical table
     String logicalTableName = "testTable_LOGICAL";
@@ -1194,7 +1322,7 @@ public class PinotTableRestletResourceTest extends ControllerTest {
     constraints.add("constraints1");
     InstanceConstraintConfig instanceConstraintConfig = new InstanceConstraintConfig(constraints);
     InstanceReplicaGroupPartitionConfig instanceReplicaGroupPartitionConfig =
-        new InstanceReplicaGroupPartitionConfig(true, 1, numReplicaGroups, numInstancesPerReplicaGroup, 1, 1, true,
+        new InstanceReplicaGroupPartitionConfig(true, 1, numReplicaGroups, numInstancesPerReplicaGroup, 1, 1, false,
             null);
     return new InstanceAssignmentConfig(instanceTagPoolConfig, instanceConstraintConfig,
         instanceReplicaGroupPartitionConfig,
@@ -1214,8 +1342,7 @@ public class PinotTableRestletResourceTest extends ControllerTest {
 
     String tableNameWithType = offlineTableConfig.getTableName();
     String creationResponse = createTable(offlineTableConfig.toJsonString());
-    assertEquals(creationResponse,
-        "{\"unrecognizedProperties\":{},\"status\":\"Table " + tableNameWithType + " successfully added\"}");
+    assertSuccessfulOfflineTableCreationResponse(creationResponse, tableNameWithType);
 
     String idealStatePath = "/ControllerTest/IDEALSTATES/" + tableNameWithType;
     zookeeperClient().delete(idealStatePath);
@@ -1246,8 +1373,7 @@ public class PinotTableRestletResourceTest extends ControllerTest {
 
     // Should succeed when no dangling tasks exist
     String creationResponse = createTable(offlineTableConfig.toJsonString());
-    assertEquals(creationResponse,
-        "{\"unrecognizedProperties\":{},\"status\":\"Table testTableTasksValidation_OFFLINE successfully added\"}");
+    assertSuccessfulOfflineTableCreationResponse(creationResponse, "testTableTasksValidation_OFFLINE");
 
     // Clean up
     deleteTable(tableName);
@@ -1312,8 +1438,7 @@ public class PinotTableRestletResourceTest extends ControllerTest {
 
     // Should succeed when task config is null
     String creationResponse = createTable(offlineTableConfig.toJsonString());
-    assertEquals(creationResponse, "{\"unrecognizedProperties\":{},"
-        + "\"status\":\"Table testTableTasksValidationNullConfig_OFFLINE successfully added\"}");
+    assertSuccessfulOfflineTableCreationResponse(creationResponse, "testTableTasksValidationNullConfig_OFFLINE");
 
     // Clean up
     deleteTable(tableName);
@@ -1467,8 +1592,125 @@ public class PinotTableRestletResourceTest extends ControllerTest {
   @AfterMethod
   public void cleanUp()
       throws IOException {
+    /// Defensive: clear any deprecation-validator rule override that an ERROR-path test may have set. The
+    /// override is a static volatile field consumed by every REST request through the validator; a test that
+    /// fails between setRulesOverrideForTesting and clearRulesOverrideForTesting would otherwise poison every
+    /// subsequent test in this class (and any other test class running in the same JVM). The owning tests
+    /// already wrap their override in a try/finally; this is belt-and-braces.
+    DeprecatedTableConfigValidationUtils.clearRulesOverrideForTesting();
     // Delete all tables after each test
     DEFAULT_INSTANCE.cleanup();
+  }
+
+  /// End-to-end REST coverage of the validator's ERROR-path. Under SOFT_LAUNCH_WARNING_ONLY, no in-tree
+  /// annotation can produce an ERROR severity (every parseable `since` resolves to WARNING; unparseable values
+  /// are locked out by `testEveryRuleHasParseableSince`). To exercise the throw branch through the real Jersey
+  /// stack, this test injects a synthetic ERROR-severity rule via
+  /// `DeprecatedTableConfigValidationUtils.setRulesOverrideForTesting`, POSTs a table whose JSON triggers the
+  /// rule, and asserts the REST surface returns 400 with the deprecation error message. Documented as
+  /// pre-condition #4 in `DeprecatedTableConfigValidationUtils.SOFT_LAUNCH_WARNING_ONLY` Javadoc.
+  @Test
+  public void testErrorSeverityRuleRejectsCreateAs400()
+      throws Exception {
+    String tableName = "errorSeverityRuleTable";
+    DEFAULT_INSTANCE.addDummySchema(tableName);
+    /// Synthetic ERROR rule that fires on the literal path "ingestionConfig.batchIngestionConfig.batchType" — a
+    /// location no current @DeprecatedConfig annotation owns, so this override does not collide with the real
+    /// rule set.
+    DeprecatedTableConfigValidationUtils.setRulesOverrideForTesting(java.util.List.of(
+        DeprecatedTableConfigValidationUtils.makeRuleForTesting(
+            java.util.List.of("ingestionConfig", "batchIngestionConfig", "batchType"),
+            "Synthetic ERROR rule for end-to-end test coverage of validateOnCreate's throw branch.",
+            "0.1.0", DeprecatedTableConfigValidationUtils.Severity.ERROR)));
+    try {
+      ObjectNode tableConfigJson = (ObjectNode) JsonUtils.objectToJsonNode(
+          _offlineBuilder.setTableName(tableName).build());
+      ObjectNode ingestionConfig = JsonUtils.newObjectNode();
+      ObjectNode batchIngestionConfig = JsonUtils.newObjectNode();
+      batchIngestionConfig.put("batchType", "s3");
+      ingestionConfig.set("batchIngestionConfig", batchIngestionConfig);
+      tableConfigJson.set("ingestionConfig", ingestionConfig);
+
+      try {
+        createTable(tableConfigJson.toString());
+        fail("Expected HTTP 400 BAD_REQUEST when synthetic ERROR rule fires on create");
+      } catch (IOException e) {
+        assertTrue(e.getMessage().contains("400") || e.getMessage().contains("Bad Request"),
+            "Expected 400-class response; got: " + e.getMessage());
+        assertTrue(e.getMessage().contains("batchIngestionConfig.batchType"),
+            "Error message should name the offending path; got: " + e.getMessage());
+      }
+    } finally {
+      DeprecatedTableConfigValidationUtils.clearRulesOverrideForTesting();
+    }
+  }
+
+  /// Post-flip rehearsal: simulates `SOFT_LAUNCH_WARNING_ONLY=false` semantics end-to-end using a synthetic ERROR
+  /// rule. Verifies the two non-obvious post-flip cases that operators must rely on at promotion time:
+  /// 1. A PUT that re-submits an UNCHANGED legacy value on an existing table must succeed (the diff sees no
+  ///    change, so the ERROR severity does not fire). Without this, every PUT to every existing table that
+  ///    holds a legacy field becomes un-acceptable the moment the flag flips.
+  /// 2. A PUT that INTRODUCES a deprecated field on an existing table must be rejected as 400 (the diff sees a
+  ///    new write to a deprecated path).
+  @Test
+  public void testErrorSeverityRuleAllowsUnchangedLegacyValueOnUpdate()
+      throws Exception {
+    String tableName = "errorPathUpdateRehearsalTable";
+    DEFAULT_INSTANCE.addDummySchema(tableName);
+    String tableNameWithType = TableNameBuilder.OFFLINE.tableNameWithType(tableName);
+
+    /// Phase 1: create the table with a non-deprecated config. No ERROR rule active yet — passes cleanly.
+    String creationResponse = createTable(_offlineBuilder.setTableName(tableName).build().toJsonString());
+    assertSuccessfulOfflineTableCreationResponse(creationResponse, tableNameWithType);
+
+    /// Phase 2: stamp a "legacy" field into the stored ZNRecord directly so the diff sees a value the validator
+    /// will subsequently flag as ERROR. We use ingestionConfig.batchIngestionConfig.batchType because no real
+    /// annotation owns it (collision-free with the in-tree rule set).
+    ZkHelixPropertyStore<ZNRecord> propertyStore =
+        DEFAULT_INSTANCE.getControllerStarter().getHelixResourceManager().getPropertyStore();
+    Stat stat = new Stat();
+    ZNRecord storedRecord = ZKMetadataProvider.getTableConfigZNRecord(propertyStore, tableNameWithType, stat);
+    assertNotNull(storedRecord, "stored ZNRecord must exist after create");
+    JsonNode currentTableJson = TableConfigSerDeUtils.toRawJsonNode(storedRecord);
+    ObjectNode stampedTableJson = (ObjectNode) currentTableJson.deepCopy();
+    ObjectNode stampedIngestion = JsonUtils.newObjectNode();
+    ObjectNode stampedBatch = JsonUtils.newObjectNode();
+    stampedBatch.put("batchType", "s3");
+    stampedIngestion.set("batchIngestionConfig", stampedBatch);
+    stampedTableJson.set("ingestionConfig", stampedIngestion);
+    /// Round-trip through TableConfig to refresh the stored ZNRecord with the new path.
+    org.apache.pinot.spi.config.table.TableConfig stampedTableConfig = JsonUtils.jsonNodeToObject(stampedTableJson,
+        org.apache.pinot.spi.config.table.TableConfig.class);
+    DEFAULT_INSTANCE.getControllerStarter().getHelixResourceManager()
+        .setExistingTableConfig(stampedTableConfig);
+
+    DeprecatedTableConfigValidationUtils.setRulesOverrideForTesting(java.util.List.of(
+        DeprecatedTableConfigValidationUtils.makeRuleForTesting(
+            java.util.List.of("ingestionConfig", "batchIngestionConfig", "batchType"),
+            "Synthetic ERROR rule for post-flip rehearsal.", "0.1.0",
+            DeprecatedTableConfigValidationUtils.Severity.ERROR)));
+    try {
+      /// Case 1: PUT the same body the stored config already holds. The diff sees no change → no ERROR fired,
+      /// even under post-flip ERROR severity. This is the operability guarantee the promotion PR depends on.
+      String unchangedResubmit = updateTable(tableName, stampedTableConfig.toJsonString());
+      assertTrue(unchangedResubmit.contains("updated"),
+          "Unchanged re-submission of legacy field must succeed under ERROR severity. Got: " + unchangedResubmit);
+
+      /// Case 2: PUT a body that INTRODUCES a different value at the same deprecated path. The diff sees a value
+      /// change → ERROR fires → 400.
+      ObjectNode changedJson = (ObjectNode) JsonUtils.objectToJsonNode(stampedTableConfig);
+      ((ObjectNode) ((ObjectNode) changedJson.get("ingestionConfig")).get("batchIngestionConfig"))
+          .put("batchType", "hdfs");
+      try {
+        updateTable(tableName, changedJson.toString());
+        fail("Expected HTTP 400 when changing a value at an ERROR-classified deprecated path");
+      } catch (IOException e) {
+        assertTrue(e.getMessage().contains("400") || e.getMessage().contains("Bad Request"),
+            "Expected 400-class response on changed value; got: " + e.getMessage());
+      }
+    } finally {
+      DeprecatedTableConfigValidationUtils.clearRulesOverrideForTesting();
+    }
   }
 
   @AfterClass

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotTableRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotTableRestletResourceTest.java
@@ -31,14 +31,19 @@ import java.util.Set;
 import javax.annotation.Nullable;
 import javax.ws.rs.core.Response;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.helix.task.TaskState;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.pinot.client.admin.LogicalTableAdminClient;
 import org.apache.pinot.client.admin.PinotAdminClient;
 import org.apache.pinot.client.admin.PinotAdminException;
 import org.apache.pinot.client.admin.TableAdminClient;
 import org.apache.pinot.client.admin.TaskAdminClient;
 import org.apache.pinot.client.admin.ZookeeperAdminClient;
+import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.restlet.resources.RebalanceResult;
+import org.apache.pinot.common.utils.config.DeprecatedTableConfigValidationUtils;
+import org.apache.pinot.common.utils.config.TableConfigSerDeUtils;
 import org.apache.pinot.controller.helix.ControllerTest;
 import org.apache.pinot.controller.helix.core.minion.ClusterInfoAccessor;
 import org.apache.pinot.controller.helix.core.minion.PinotHelixTaskResourceManager;
@@ -69,6 +74,7 @@ import org.apache.pinot.spi.utils.StringUtil;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.util.TestUtils;
+import org.apache.zookeeper.data.Stat;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
@@ -90,6 +96,14 @@ import static org.testng.Assert.fail;
 public class PinotTableRestletResourceTest extends ControllerTest {
   private static final String OFFLINE_TABLE_NAME = "testOfflineTable";
   private static final String REALTIME_TABLE_NAME = "testRealtimeTable";
+  private static final String STREAM_CONFIGS_DEPRECATION_WARNING =
+      "'tableIndexConfig.streamConfigs' is deprecated since 0.7.1. Use "
+          + "'ingestionConfig.streamIngestionConfig.streamConfigMaps' instead.";
+  /// TableConfigBuilder defaults _segmentPushType to "APPEND" (preserved for programmatic-caller back-compat),
+  /// so every realtime config built via the builder also emits this deprecation warning.
+  private static final String SEGMENT_PUSH_TYPE_DEPRECATION_WARNING =
+      "'segmentsConfig.segmentPushType' is deprecated since 0.8.0. Use "
+          + "'ingestionConfig.batchIngestionConfig.segmentIngestionType' instead.";
   private final TableConfigBuilder _offlineBuilder = getOfflineTableBuilder(OFFLINE_TABLE_NAME);
   private final TableConfigBuilder _realtimeBuilder = getRealtimeTableBuilder(REALTIME_TABLE_NAME);
 
@@ -132,6 +146,39 @@ public class PinotTableRestletResourceTest extends ControllerTest {
     } catch (Exception e) {
       throw unwrapAsIOException(e);
     }
+  }
+
+  /// Asserts that a successful realtime-table create response carries both the segmentPushType and streamConfigs
+  /// deprecation warnings, the expected status, and no unrecognized properties. The deprecation warnings are
+  /// compared as a SET because the discovery walk order is `Class.getMethods()`-dependent and not guaranteed
+  /// stable across JVM versions or future TableConfig refactors.
+  private static void assertSuccessfulRealtimeTableCreationResponse(String actualJson, String tableNameWithType) {
+    assertSuccessfulTableCreationResponse(actualJson, tableNameWithType,
+        Set.of(SEGMENT_PUSH_TYPE_DEPRECATION_WARNING, STREAM_CONFIGS_DEPRECATION_WARNING));
+  }
+
+  private static void assertSuccessfulOfflineTableCreationResponse(String actualJson, String tableNameWithType) {
+    assertSuccessfulTableCreationResponse(actualJson, tableNameWithType,
+        Set.of(SEGMENT_PUSH_TYPE_DEPRECATION_WARNING));
+  }
+
+  private static void assertSuccessfulTableCreationResponse(String actualJson, String tableNameWithType,
+      Set<String> expectedWarnings) {
+    JsonNode parsed;
+    try {
+      parsed = JsonUtils.stringToJsonNode(actualJson);
+    } catch (IOException e) {
+      throw new AssertionError("response is not valid JSON: " + actualJson, e);
+    }
+    assertEquals(parsed.path("status").asText(), "Table " + tableNameWithType + " successfully added",
+        "unexpected status in " + actualJson);
+    assertTrue(parsed.path("unrecognizedProperties").isObject()
+            && parsed.path("unrecognizedProperties").isEmpty(),
+        "expected empty unrecognizedProperties in " + actualJson);
+    Set<String> actualWarnings = new java.util.HashSet<>();
+    parsed.path("deprecationWarnings").forEach(n -> actualWarnings.add(n.asText()));
+    assertEquals(actualWarnings, expectedWarnings,
+        "deprecationWarnings set mismatch in " + actualJson);
   }
 
   private String updateTable(String tableName, String tableConfigJson)
@@ -355,6 +402,93 @@ public class PinotTableRestletResourceTest extends ControllerTest {
   }
 
   @Test
+  public void testReportsDeprecatedConfigOnCreateAndOnUpdateAsWarning()
+      throws Exception {
+    /// Soft-launch policy: deprecated keys are reported via the deprecationWarnings field on the success
+    /// response, not rejected with a 400.
+    TableConfig offlineTableConfig = _offlineBuilder.setTableName(OFFLINE_TABLE_NAME).build();
+    ObjectNode createTableJson = (ObjectNode) JsonUtils.stringToJsonNode(offlineTableConfig.toJsonString());
+    createTableJson.withObject("segmentsConfig").put("replicasPerPartition", "APPEND");
+
+    JsonNode createResponse = JsonUtils.stringToJsonNode(createTable(createTableJson.toString()));
+    JsonNode createWarnings = createResponse.path("deprecationWarnings");
+    assertTrue(createWarnings.isArray() && createWarnings.size() > 0,
+        "expected deprecationWarnings on create response: " + createResponse);
+    assertTrue(createWarnings.toString().contains("segmentsConfig.replicasPerPartition"),
+        createWarnings.toString());
+
+    /// Update that introduces a previously-absent deprecated property: also reported as a warning.
+    String rawTableName = "deprecated_update_table";
+    DEFAULT_INSTANCE.addDummySchema(rawTableName);
+    TableConfig existingTableConfig = getOfflineTableBuilder(rawTableName).build();
+    createTable(existingTableConfig.toJsonString());
+
+    ObjectNode updateTableJson = (ObjectNode) JsonUtils.stringToJsonNode(existingTableConfig.toJsonString());
+    updateTableJson.withObject("segmentsConfig").put("replicasPerPartition", "APPEND");
+    JsonNode updateResponse = JsonUtils.stringToJsonNode(
+        updateTable(existingTableConfig.getTableName(), updateTableJson.toString()));
+    JsonNode updateWarnings = updateResponse.path("deprecationWarnings");
+    assertTrue(updateWarnings.isArray() && updateWarnings.size() > 0,
+        "expected deprecationWarnings on update response: " + updateResponse);
+    assertTrue(updateWarnings.toString().contains("segmentsConfig.replicasPerPartition"),
+        updateWarnings.toString());
+  }
+
+  @Test
+  public void testUpdateMissingTableReports404NotDeprecationError()
+      throws Exception {
+    /// PUT to a missing table whose body contains a deprecated key must report 404 (table does not exist) rather
+    /// than a misleading 400 about a deprecated property — the existence check runs before the deprecation diff.
+    String rawTableName = "missing_update_with_legacy_key";
+    DEFAULT_INSTANCE.addDummySchema(rawTableName);
+    TableConfig tableConfig = getOfflineTableBuilder(rawTableName).build();
+    ObjectNode updateTableJson = (ObjectNode) JsonUtils.stringToJsonNode(tableConfig.toJsonString());
+    updateTableJson.withObject("segmentsConfig").put("replicasPerPartition", "APPEND");
+    IOException e = expectThrows(IOException.class,
+        () -> updateTable(tableConfig.getTableName(), updateTableJson.toString()));
+    String message = e.getMessage() != null ? e.getMessage() : "";
+    /// The admin client wraps the server response into the IOException message. Parse the embedded JSON body and
+    /// assert structurally on the `code` field rather than grepping multiple substring formats.
+    int braceStart = message.indexOf('{');
+    int braceEnd = message.lastIndexOf('}');
+    assertTrue(braceStart >= 0 && braceEnd > braceStart, "Expected JSON body embedded in error, got: " + message);
+    JsonNode errorBody = JsonUtils.stringToJsonNode(message.substring(braceStart, braceEnd + 1));
+    assertEquals(errorBody.path("code").asInt(), 404,
+        "Expected 404 status code on missing-table PUT, got body: " + errorBody);
+    assertTrue(errorBody.path("error").asText().contains("does not exist"),
+        "Expected 'does not exist' to take precedence over deprecation, got: " + errorBody);
+    assertTrue(!errorBody.path("error").asText().contains("Newly introduced deprecated"),
+        "404 must take precedence over deprecation diff, got: " + errorBody);
+  }
+
+  @Test
+  /// Intentionally exercises re-submission of a deprecated key stored by an older Pinot version.
+  @SuppressWarnings("deprecation")
+  public void testUpdateAllowsUnchangedLegacyDeprecatedConfig()
+      throws Exception {
+    /// Simulate a table whose stored config already contains a deprecated property (e.g. created on an older
+    /// version). On update, re-submitting the same legacy value must NOT trigger validation; only newly introduced
+    /// or value-changed deprecated paths are flagged.
+    String rawTableName = "deprecated_legacy_table";
+    DEFAULT_INSTANCE.addDummySchema(rawTableName);
+    TableConfig existingTableConfig = getOfflineTableBuilder(rawTableName).build();
+    createTable(existingTableConfig.toJsonString());
+
+    /// Inject a deprecated value directly into ZK to mimic a pre-existing legacy config.
+    String tableNameWithType = TableNameBuilder.OFFLINE.tableNameWithType(rawTableName);
+    TableConfig stored = DEFAULT_INSTANCE.getHelixResourceManager().getTableConfig(tableNameWithType);
+    stored.getValidationConfig().setReplicasPerPartition("3");
+    DEFAULT_INSTANCE.getHelixResourceManager().setExistingTableConfig(stored);
+
+    /// Re-submit the same legacy value. The diff against the stored config means this is treated as unchanged and
+    /// should pass.
+    ObjectNode updateTableJson = (ObjectNode) JsonUtils.stringToJsonNode(stored.toJsonString());
+    JsonNode response = JsonUtils.stringToJsonNode(
+        updateTable(existingTableConfig.getTableName(), updateTableJson.toString()));
+    assertEquals(response.get("status").asText(), "Table config updated for " + existingTableConfig.getTableName());
+  }
+
+  @Test
   public void testTableCronSchedule()
       throws IOException {
     String rawTableName = "test_table_cron_schedule";
@@ -377,8 +511,7 @@ public class PinotTableRestletResourceTest extends ControllerTest {
             Map.of(PinotTaskManager.SCHEDULE_KEY, "0 */10 * ? * * *")))).build();
     try {
       String response = createTable(tableConfig.toJsonString());
-      assertEquals(response,
-          "{\"unrecognizedProperties\":{},\"status\":\"Table test_table_cron_schedule_OFFLINE successfully added\"}");
+      assertSuccessfulOfflineTableCreationResponse(response, "test_table_cron_schedule_OFFLINE");
     } catch (IOException e) {
       // Expected 400 Bad Request
       fail("This is a valid table config with cron schedule");
@@ -725,8 +858,7 @@ public class PinotTableRestletResourceTest extends ControllerTest {
     DEFAULT_INSTANCE.addDummySchema("table0");
     TableConfig realtimeTableConfig = _realtimeBuilder.setTableName("table0").build();
     String creationResponse = createTable(realtimeTableConfig.toJsonString());
-    assertEquals(creationResponse,
-        "{\"unrecognizedProperties\":{},\"status\":\"Table table0_REALTIME successfully added\"}");
+    assertSuccessfulRealtimeTableCreationResponse(creationResponse, "table0_REALTIME");
 
     // Delete realtime table using REALTIME suffix.
     String deleteResponse = sendDeleteRequest(
@@ -736,8 +868,7 @@ public class PinotTableRestletResourceTest extends ControllerTest {
     // Case 2: Create an offline table and delete it directly w/o using query param.
     TableConfig offlineTableConfig = _offlineBuilder.setTableName("table0").build();
     creationResponse = createTable(offlineTableConfig.toJsonString());
-    assertEquals(creationResponse,
-        "{\"unrecognizedProperties\":{},\"status\":\"Table table0_OFFLINE successfully added\"}");
+    assertSuccessfulOfflineTableCreationResponse(creationResponse, "table0_OFFLINE");
 
     // Delete offline table using OFFLINE suffix.
     deleteResponse =
@@ -748,13 +879,11 @@ public class PinotTableRestletResourceTest extends ControllerTest {
     DEFAULT_INSTANCE.addDummySchema("table1");
     TableConfig rtConfig1 = _realtimeBuilder.setTableName("table1").build();
     creationResponse = createTable(rtConfig1.toJsonString());
-    assertEquals(creationResponse,
-        "{\"unrecognizedProperties\":{},\"status\":\"Table table1_REALTIME successfully added\"}");
+    assertSuccessfulRealtimeTableCreationResponse(creationResponse, "table1_REALTIME");
 
     TableConfig offlineConfig1 = _offlineBuilder.setTableName("table1").build();
     creationResponse = createTable(offlineConfig1.toJsonString());
-    assertEquals(creationResponse,
-        "{\"unrecognizedProperties\":{},\"status\":\"Table table1_OFFLINE successfully added\"}");
+    assertSuccessfulOfflineTableCreationResponse(creationResponse, "table1_OFFLINE");
 
     deleteResponse =
         sendDeleteRequest(StringUtil.join("/", DEFAULT_INSTANCE.getControllerBaseApiUrl(), "tables", "table1"));
@@ -764,13 +893,11 @@ public class PinotTableRestletResourceTest extends ControllerTest {
     DEFAULT_INSTANCE.addDummySchema("table2");
     TableConfig rtConfig2 = _realtimeBuilder.setTableName("table2").build();
     creationResponse = createTable(rtConfig2.toJsonString());
-    assertEquals(creationResponse,
-        "{\"unrecognizedProperties\":{},\"status\":\"Table table2_REALTIME successfully added\"}");
+    assertSuccessfulRealtimeTableCreationResponse(creationResponse, "table2_REALTIME");
 
     TableConfig offlineConfig2 = _offlineBuilder.setTableName("table2").build();
     creationResponse = createTable(offlineConfig2.toJsonString());
-    assertEquals(creationResponse,
-        "{\"unrecognizedProperties\":{},\"status\":\"Table table2_OFFLINE successfully added\"}");
+    assertSuccessfulOfflineTableCreationResponse(creationResponse, "table2_OFFLINE");
 
     // The conflict between param type and table name suffix causes no table being deleted.
     try {
@@ -802,13 +929,11 @@ public class PinotTableRestletResourceTest extends ControllerTest {
     DEFAULT_INSTANCE.addDummySchema("table3");
     TableConfig rtConfig3 = _realtimeBuilder.setTableName("table3").build();
     creationResponse = createTable(rtConfig3.toJsonString());
-    assertEquals(creationResponse,
-        "{\"unrecognizedProperties\":{},\"status\":\"Table table3_REALTIME successfully added\"}");
+    assertSuccessfulRealtimeTableCreationResponse(creationResponse, "table3_REALTIME");
 
     TableConfig offlineConfig3 = _offlineBuilder.setTableName("table3").build();
     creationResponse = createTable(offlineConfig3.toJsonString());
-    assertEquals(creationResponse,
-        "{\"unrecognizedProperties\":{},\"status\":\"Table table3_OFFLINE successfully added\"}");
+    assertSuccessfulOfflineTableCreationResponse(creationResponse, "table3_OFFLINE");
 
     deleteResponse = deleteTable("table3_REALTIME", "realtime");
     assertEquals(deleteResponse, "{\"status\":\"Tables: [table3_REALTIME] deleted\"}");
@@ -872,14 +997,12 @@ public class PinotTableRestletResourceTest extends ControllerTest {
     DEFAULT_INSTANCE.addDummySchema(tableName);
     TableConfig realtimeTableConfig = _realtimeBuilder.setTableName(tableName).build();
     String creationResponse = createTable(realtimeTableConfig.toJsonString());
-    assertEquals(creationResponse,
-        "{\"unrecognizedProperties\":{},\"status\":\"Table testTable_REALTIME successfully added\"}");
+    assertSuccessfulRealtimeTableCreationResponse(creationResponse, "testTable_REALTIME");
 
     // Create a valid OFFLINE table
     TableConfig offlineTableConfig = _offlineBuilder.setTableName(tableName).build();
     creationResponse = createTable(offlineTableConfig.toJsonString());
-    assertEquals(creationResponse,
-        "{\"unrecognizedProperties\":{},\"status\":\"Table testTable_OFFLINE successfully added\"}");
+    assertSuccessfulOfflineTableCreationResponse(creationResponse, "testTable_OFFLINE");
 
     // Case 1: Check table state with specifying tableType as realtime should return 1 [enabled]
     String realtimeStateResponse = sendGetRequest(
@@ -963,9 +1086,15 @@ public class PinotTableRestletResourceTest extends ControllerTest {
     ((ObjectNode) jsonNode).put("illegalKey2", internalObj);
 
     String creationResponse = createTable(jsonNode.toString());
-    assertEquals(creationResponse,
-        "{\"unrecognizedProperties\":{\"/illegalKey1\":1,\"/illegalKey2/illegalKey3\":2},\"status\":\"Table "
-            + "valid_table_name_extra_props_REALTIME successfully added\"}");
+    JsonNode parsedCreate = JsonUtils.stringToJsonNode(creationResponse);
+    assertEquals(parsedCreate.path("status").asText(),
+        "Table valid_table_name_extra_props_REALTIME successfully added");
+    assertEquals(parsedCreate.path("unrecognizedProperties").get("/illegalKey1").asInt(), 1);
+    assertEquals(parsedCreate.path("unrecognizedProperties").get("/illegalKey2/illegalKey3").asInt(), 2);
+    Set<String> creationWarnings = new java.util.HashSet<>();
+    parsedCreate.path("deprecationWarnings").forEach(n -> creationWarnings.add(n.asText()));
+    assertEquals(creationWarnings,
+        Set.of(SEGMENT_PUSH_TYPE_DEPRECATION_WARNING, STREAM_CONFIGS_DEPRECATION_WARNING));
 
     // update table with unrecognizedProperties
     String updateResponse =
@@ -1089,8 +1218,7 @@ public class PinotTableRestletResourceTest extends ControllerTest {
     DEFAULT_INSTANCE.addDummySchema(tableName);
     TableConfig offlineTableConfig = _offlineBuilder.setTableName(tableName).build();
     String creationResponse = createTable(offlineTableConfig.toJsonString());
-    assertEquals(creationResponse,
-        "{\"unrecognizedProperties\":{},\"status\":\"Table testTable_OFFLINE successfully added\"}");
+    assertSuccessfulOfflineTableCreationResponse(creationResponse, "testTable_OFFLINE");
 
     // create logical table with above physical table
     String logicalTableName = "testTable_LOGICAL";
@@ -1195,7 +1323,7 @@ public class PinotTableRestletResourceTest extends ControllerTest {
     constraints.add("constraints1");
     InstanceConstraintConfig instanceConstraintConfig = new InstanceConstraintConfig(constraints);
     InstanceReplicaGroupPartitionConfig instanceReplicaGroupPartitionConfig =
-        new InstanceReplicaGroupPartitionConfig(true, 1, numReplicaGroups, numInstancesPerReplicaGroup, 1, 1, true,
+        new InstanceReplicaGroupPartitionConfig(true, 1, numReplicaGroups, numInstancesPerReplicaGroup, 1, 1, false,
             null);
     return new InstanceAssignmentConfig(instanceTagPoolConfig, instanceConstraintConfig,
         instanceReplicaGroupPartitionConfig,
@@ -1215,8 +1343,7 @@ public class PinotTableRestletResourceTest extends ControllerTest {
 
     String tableNameWithType = offlineTableConfig.getTableName();
     String creationResponse = createTable(offlineTableConfig.toJsonString());
-    assertEquals(creationResponse,
-        "{\"unrecognizedProperties\":{},\"status\":\"Table " + tableNameWithType + " successfully added\"}");
+    assertSuccessfulOfflineTableCreationResponse(creationResponse, tableNameWithType);
 
     String idealStatePath = "/ControllerTest/IDEALSTATES/" + tableNameWithType;
     zookeeperClient().delete(idealStatePath);
@@ -1247,8 +1374,7 @@ public class PinotTableRestletResourceTest extends ControllerTest {
 
     // Should succeed when no dangling tasks exist
     String creationResponse = createTable(offlineTableConfig.toJsonString());
-    assertEquals(creationResponse,
-        "{\"unrecognizedProperties\":{},\"status\":\"Table testTableTasksValidation_OFFLINE successfully added\"}");
+    assertSuccessfulOfflineTableCreationResponse(creationResponse, "testTableTasksValidation_OFFLINE");
 
     // Clean up
     deleteTable(tableName);
@@ -1313,8 +1439,7 @@ public class PinotTableRestletResourceTest extends ControllerTest {
 
     // Should succeed when task config is null
     String creationResponse = createTable(offlineTableConfig.toJsonString());
-    assertEquals(creationResponse, "{\"unrecognizedProperties\":{},"
-        + "\"status\":\"Table testTableTasksValidationNullConfig_OFFLINE successfully added\"}");
+    assertSuccessfulOfflineTableCreationResponse(creationResponse, "testTableTasksValidationNullConfig_OFFLINE");
 
     // Clean up
     deleteTable(tableName);
@@ -1468,8 +1593,125 @@ public class PinotTableRestletResourceTest extends ControllerTest {
   @AfterMethod
   public void cleanUp()
       throws IOException {
+    /// Defensive: clear any deprecation-validator rule override that an ERROR-path test may have set. The
+    /// override is a static volatile field consumed by every REST request through the validator; a test that
+    /// fails between setRulesOverrideForTesting and clearRulesOverrideForTesting would otherwise poison every
+    /// subsequent test in this class (and any other test class running in the same JVM). The owning tests
+    /// already wrap their override in a try/finally; this is belt-and-braces.
+    DeprecatedTableConfigValidationUtils.clearRulesOverrideForTesting();
     // Delete all tables after each test
     DEFAULT_INSTANCE.cleanup();
+  }
+
+  /// End-to-end REST coverage of the validator's ERROR-path. Under SOFT_LAUNCH_WARNING_ONLY, no in-tree
+  /// annotation can produce an ERROR severity (every parseable `since` resolves to WARNING; unparseable values
+  /// are locked out by `testEveryRuleHasParseableSince`). To exercise the throw branch through the real Jersey
+  /// stack, this test injects a synthetic ERROR-severity rule via
+  /// `DeprecatedTableConfigValidationUtils.setRulesOverrideForTesting`, POSTs a table whose JSON triggers the
+  /// rule, and asserts the REST surface returns 400 with the deprecation error message. Documented as
+  /// pre-condition #4 in `DeprecatedTableConfigValidationUtils.SOFT_LAUNCH_WARNING_ONLY` Javadoc.
+  @Test
+  public void testErrorSeverityRuleRejectsCreateAs400()
+      throws Exception {
+    String tableName = "errorSeverityRuleTable";
+    DEFAULT_INSTANCE.addDummySchema(tableName);
+    /// Synthetic ERROR rule that fires on the literal path "ingestionConfig.batchIngestionConfig.batchType" — a
+    /// location no current @DeprecatedConfig annotation owns, so this override does not collide with the real
+    /// rule set.
+    DeprecatedTableConfigValidationUtils.setRulesOverrideForTesting(java.util.List.of(
+        DeprecatedTableConfigValidationUtils.makeRuleForTesting(
+            java.util.List.of("ingestionConfig", "batchIngestionConfig", "batchType"),
+            "Synthetic ERROR rule for end-to-end test coverage of validateOnCreate's throw branch.",
+            "0.1.0", DeprecatedTableConfigValidationUtils.Severity.ERROR)));
+    try {
+      ObjectNode tableConfigJson = (ObjectNode) JsonUtils.objectToJsonNode(
+          _offlineBuilder.setTableName(tableName).build());
+      ObjectNode ingestionConfig = JsonUtils.newObjectNode();
+      ObjectNode batchIngestionConfig = JsonUtils.newObjectNode();
+      batchIngestionConfig.put("batchType", "s3");
+      ingestionConfig.set("batchIngestionConfig", batchIngestionConfig);
+      tableConfigJson.set("ingestionConfig", ingestionConfig);
+
+      try {
+        createTable(tableConfigJson.toString());
+        fail("Expected HTTP 400 BAD_REQUEST when synthetic ERROR rule fires on create");
+      } catch (IOException e) {
+        assertTrue(e.getMessage().contains("400") || e.getMessage().contains("Bad Request"),
+            "Expected 400-class response; got: " + e.getMessage());
+        assertTrue(e.getMessage().contains("batchIngestionConfig.batchType"),
+            "Error message should name the offending path; got: " + e.getMessage());
+      }
+    } finally {
+      DeprecatedTableConfigValidationUtils.clearRulesOverrideForTesting();
+    }
+  }
+
+  /// Post-flip rehearsal: simulates `SOFT_LAUNCH_WARNING_ONLY=false` semantics end-to-end using a synthetic ERROR
+  /// rule. Verifies the two non-obvious post-flip cases that operators must rely on at promotion time:
+  /// 1. A PUT that re-submits an UNCHANGED legacy value on an existing table must succeed (the diff sees no
+  ///    change, so the ERROR severity does not fire). Without this, every PUT to every existing table that
+  ///    holds a legacy field becomes un-acceptable the moment the flag flips.
+  /// 2. A PUT that INTRODUCES a deprecated field on an existing table must be rejected as 400 (the diff sees a
+  ///    new write to a deprecated path).
+  @Test
+  public void testErrorSeverityRuleAllowsUnchangedLegacyValueOnUpdate()
+      throws Exception {
+    String tableName = "errorPathUpdateRehearsalTable";
+    DEFAULT_INSTANCE.addDummySchema(tableName);
+    String tableNameWithType = TableNameBuilder.OFFLINE.tableNameWithType(tableName);
+
+    /// Phase 1: create the table with a non-deprecated config. No ERROR rule active yet — passes cleanly.
+    String creationResponse = createTable(_offlineBuilder.setTableName(tableName).build().toJsonString());
+    assertSuccessfulOfflineTableCreationResponse(creationResponse, tableNameWithType);
+
+    /// Phase 2: stamp a "legacy" field into the stored ZNRecord directly so the diff sees a value the validator
+    /// will subsequently flag as ERROR. We use ingestionConfig.batchIngestionConfig.batchType because no real
+    /// annotation owns it (collision-free with the in-tree rule set).
+    ZkHelixPropertyStore<ZNRecord> propertyStore =
+        DEFAULT_INSTANCE.getControllerStarter().getHelixResourceManager().getPropertyStore();
+    Stat stat = new Stat();
+    ZNRecord storedRecord = ZKMetadataProvider.getTableConfigZNRecord(propertyStore, tableNameWithType, stat);
+    assertNotNull(storedRecord, "stored ZNRecord must exist after create");
+    JsonNode currentTableJson = TableConfigSerDeUtils.toRawJsonNode(storedRecord);
+    ObjectNode stampedTableJson = (ObjectNode) currentTableJson.deepCopy();
+    ObjectNode stampedIngestion = JsonUtils.newObjectNode();
+    ObjectNode stampedBatch = JsonUtils.newObjectNode();
+    stampedBatch.put("batchType", "s3");
+    stampedIngestion.set("batchIngestionConfig", stampedBatch);
+    stampedTableJson.set("ingestionConfig", stampedIngestion);
+    /// Round-trip through TableConfig to refresh the stored ZNRecord with the new path.
+    org.apache.pinot.spi.config.table.TableConfig stampedTableConfig = JsonUtils.jsonNodeToObject(stampedTableJson,
+        org.apache.pinot.spi.config.table.TableConfig.class);
+    DEFAULT_INSTANCE.getControllerStarter().getHelixResourceManager()
+        .setExistingTableConfig(stampedTableConfig);
+
+    DeprecatedTableConfigValidationUtils.setRulesOverrideForTesting(java.util.List.of(
+        DeprecatedTableConfigValidationUtils.makeRuleForTesting(
+            java.util.List.of("ingestionConfig", "batchIngestionConfig", "batchType"),
+            "Synthetic ERROR rule for post-flip rehearsal.", "0.1.0",
+            DeprecatedTableConfigValidationUtils.Severity.ERROR)));
+    try {
+      /// Case 1: PUT the same body the stored config already holds. The diff sees no change → no ERROR fired,
+      /// even under post-flip ERROR severity. This is the operability guarantee the promotion PR depends on.
+      String unchangedResubmit = updateTable(tableName, stampedTableConfig.toJsonString());
+      assertTrue(unchangedResubmit.contains("updated"),
+          "Unchanged re-submission of legacy field must succeed under ERROR severity. Got: " + unchangedResubmit);
+
+      /// Case 2: PUT a body that INTRODUCES a different value at the same deprecated path. The diff sees a value
+      /// change → ERROR fires → 400.
+      ObjectNode changedJson = (ObjectNode) JsonUtils.objectToJsonNode(stampedTableConfig);
+      ((ObjectNode) ((ObjectNode) changedJson.get("ingestionConfig")).get("batchIngestionConfig"))
+          .put("batchType", "hdfs");
+      try {
+        updateTable(tableName, changedJson.toString());
+        fail("Expected HTTP 400 when changing a value at an ERROR-classified deprecated path");
+      } catch (IOException e) {
+        assertTrue(e.getMessage().contains("400") || e.getMessage().contains("Bad Request"),
+            "Expected 400-class response on changed value; got: " + e.getMessage());
+      }
+    } finally {
+      DeprecatedTableConfigValidationUtils.clearRulesOverrideForTesting();
+    }
   }
 
   @AfterClass

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/TableConfigsRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/TableConfigsRestletResourceTest.java
@@ -392,6 +392,71 @@ public class TableConfigsRestletResourceTest extends ControllerTest {
   }
 
   @Test
+  public void testCreateConfigReportsDeprecatedTablePropertiesAsWarning()
+      throws Exception {
+    PinotAdminClient adminClient = getOrCreateAdminClient();
+    String tableName = "testDeprecatedCreate";
+    TableConfigs tableConfigs =
+        new TableConfigs(tableName, createDummySchema(tableName), createOfflineTableConfig(tableName),
+            createRealtimeTableConfig(tableName));
+    ObjectNode tableConfigsJson = (ObjectNode) JsonUtils.stringToJsonNode(tableConfigs.toPrettyJsonString());
+    ((ObjectNode) tableConfigsJson.get(TableType.REALTIME.name().toLowerCase()).get("segmentsConfig"))
+        .put("replicasPerPartition", "3");
+
+    try {
+      String response =
+          adminClient.getTableClient().createTableConfigs(tableConfigsJson.toPrettyString(), null, null);
+      Assert.assertTrue(response.contains("realtime.segmentsConfig.replicasPerPartition"),
+          "Expected deprecation warning in response: " + response);
+    } finally {
+      adminClient.getTableClient().deleteTableConfigs(tableName, null);
+    }
+  }
+
+  @Test
+  public void testUpdateConfigReportsNewlyIntroducedDeprecatedPropertyAsWarning()
+      throws Exception {
+    PinotAdminClient adminClient = getOrCreateAdminClient();
+    String tableName = "testDeprecatedUpdateNew";
+    TableConfigs tableConfigs =
+        new TableConfigs(tableName, createDummySchema(tableName), createOfflineTableConfig(tableName),
+            createRealtimeTableConfig(tableName));
+    adminClient.getTableClient().createTableConfigs(tableConfigs.toPrettyJsonString(), null, null);
+    try {
+      ObjectNode tableConfigsJson = (ObjectNode) JsonUtils.stringToJsonNode(tableConfigs.toPrettyJsonString());
+      ((ObjectNode) tableConfigsJson.get(TableType.REALTIME.name().toLowerCase()).get("segmentsConfig"))
+          .put("replicasPerPartition", "3");
+      String response = adminClient.getTableClient()
+          .updateTableConfigs(tableName, tableConfigsJson.toPrettyString(), null, false, false);
+      Assert.assertTrue(response.contains("realtime.segmentsConfig.replicasPerPartition"),
+          "Expected deprecation warning in update response: " + response);
+    } finally {
+      adminClient.getTableClient().deleteTableConfigs(tableName, null);
+    }
+  }
+
+  @Test
+  public void testUpdateMissingTableConfigsReportsNotExistsNotDeprecation()
+      throws Exception {
+    PinotAdminClient adminClient = getOrCreateAdminClient();
+    String tableName = "testMissingUpdate";
+    TableConfigs tableConfigs =
+        new TableConfigs(tableName, createDummySchema(tableName), createOfflineTableConfig(tableName),
+            createRealtimeTableConfig(tableName));
+    ObjectNode tableConfigsJson = (ObjectNode) JsonUtils.stringToJsonNode(tableConfigs.toPrettyJsonString());
+    ((ObjectNode) tableConfigsJson.get(TableType.REALTIME.name().toLowerCase()).get("segmentsConfig"))
+        .put("replicasPerPartition", "3");
+    try {
+      adminClient.getTableClient()
+          .updateTableConfigs(tableName, tableConfigsJson.toPrettyString(), null, false, false);
+      fail("Update of a non-existent TableConfigs should have failed");
+    } catch (Exception e) {
+      Assert.assertTrue(e.getMessage().contains("does not exist"),
+          "Expected 'does not exist' error to take precedence over deprecation, but got: " + e.getMessage());
+    }
+  }
+
+  @Test
   public void testListConfigs()
       throws Exception {
     PinotAdminClient adminClient = getOrCreateAdminClient();
@@ -760,15 +825,19 @@ public class TableConfigsRestletResourceTest extends ControllerTest {
 
     // Create
     response = adminClient.getTableClient().createTableConfigs(tableConfigsJson.toPrettyString(), null, null);
-    Assert.assertEquals(response, "{\"unrecognizedProperties\":{\"/illegalKey1\":1},\"status\":\"TableConfigs "
-        + "testUnrecognized1 successfully added\"}");
+    JsonNode createJson = JsonUtils.stringToJsonNode(response);
+    Assert.assertTrue(createJson.path("unrecognizedProperties").has("/illegalKey1"),
+        "expected unrecognizedProperties./illegalKey1 in: " + response);
+    Assert.assertEquals(createJson.path("status").asText(), "TableConfigs testUnrecognized1 successfully added");
 
     // Update
     response =
         adminClient.getTableClient().updateTableConfigs(tableName, tableConfigsJson.toPrettyString(), null, false,
             false);
-    Assert.assertEquals(response,
-        "{\"unrecognizedProperties\":{\"/illegalKey1\":1},\"status\":\"TableConfigs updated for testUnrecognized1\"}");
+    JsonNode updateJson = JsonUtils.stringToJsonNode(response);
+    Assert.assertTrue(updateJson.path("unrecognizedProperties").has("/illegalKey1"),
+        "expected unrecognizedProperties./illegalKey1 in: " + response);
+    Assert.assertEquals(updateJson.path("status").asText(), "TableConfigs updated for testUnrecognized1");
     // Delete
     adminClient.getTableClient().deleteTableConfigs(tableName, null);
   }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/ConfigSuccessResponseTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/ConfigSuccessResponseTest.java
@@ -1,0 +1,105 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.api.resources;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+
+/// Round-trip tests for the wire format of [ConfigSuccessResponse]. The DTO gained a `deprecationWarnings` field
+/// that must (a) be elided from the JSON when empty so older clients that strict-parse the response continue to
+/// see the original shape, and (b) appear when non-empty so callers can surface controller-side warnings.
+public class ConfigSuccessResponseTest {
+
+  @Test
+  public void testEmptyDeprecationWarningsAreOmittedFromJson() {
+    /// The new `deprecationWarnings` field carries `@JsonInclude(NON_EMPTY)` on its getter so existing clients
+    /// (including older Java client versions that strict-parse this DTO) keep observing the same JSON shape when no
+    /// warnings fire.
+    ConfigSuccessResponse response = new ConfigSuccessResponse("ok", Map.of());
+    JsonNode json = JsonUtils.objectToJsonNode(response);
+    assertFalse(json.has("deprecationWarnings"), "expected deprecationWarnings to be elided when empty: " + json);
+  }
+
+  @Test
+  public void testNonEmptyDeprecationWarningsAppearInJson() {
+    ConfigSuccessResponse response = new ConfigSuccessResponse("ok", Map.of(),
+        List.of("'segmentsConfig.segmentPushType' is deprecated since 0.8.0. Use 'ingestionConfig...' instead."));
+    JsonNode json = JsonUtils.objectToJsonNode(response);
+    assertTrue(json.has("deprecationWarnings"));
+    assertEquals(json.get("deprecationWarnings").size(), 1);
+  }
+
+  @Test
+  public void testNullCollectionsNormalisedToEmpty() {
+    ConfigSuccessResponse response = new ConfigSuccessResponse("ok", null, null);
+    assertTrue(response.getUnrecognizedProperties().isEmpty());
+    assertTrue(response.getDeprecationWarnings().isEmpty());
+  }
+
+  /// Locks the Jackson deserialization contract that downstream clients (admin SDK, integration tests, tooling)
+  /// rely on. Without `@JsonCreator`, Jackson silently falls back to the `-parameters` compiler flag for argument
+  /// names; this test fails if that fallback breaks.
+  @Test
+  public void testJsonRoundTripPreservesAllFields()
+      throws Exception {
+    ConfigSuccessResponse original = new ConfigSuccessResponse("ok", Map.of("unrecognised", "value"),
+        List.of("warning-one", "warning-two"));
+    String json = JsonUtils.objectToString(original);
+    ConfigSuccessResponse parsed = JsonUtils.stringToObject(json, ConfigSuccessResponse.class);
+    assertEquals(parsed.getStatus(), "ok");
+    assertEquals(parsed.getUnrecognizedProperties(), Map.of("unrecognised", "value"));
+    assertEquals(parsed.getDeprecationWarnings(), List.of("warning-one", "warning-two"));
+  }
+
+  /// Older controller payloads (pre-deprecationWarnings) omit the `deprecationWarnings` field entirely. Newer
+  /// clients must accept that shape — this is the rolling-upgrade direction: new client + old controller.
+  @Test
+  public void testParsingResponseWithoutDeprecationWarningsField()
+      throws Exception {
+    String json = "{\"status\":\"ok\",\"unrecognizedProperties\":{}}";
+    ConfigSuccessResponse parsed = JsonUtils.stringToObject(json, ConfigSuccessResponse.class);
+    assertEquals(parsed.getStatus(), "ok");
+    assertTrue(parsed.getDeprecationWarnings().isEmpty());
+  }
+
+  /// Future controller versions may add new wire fields. Strict-parsing older clients (with
+  /// FAIL_ON_UNKNOWN_PROPERTIES=true) must still parse the response — this is the rolling-upgrade direction:
+  /// old client + new controller emitting fields the client does not yet know about. Locked here so a future
+  /// refactor that removes `@JsonIgnoreProperties(ignoreUnknown=true)` from ConfigSuccessResponse fails this
+  /// test before it ships.
+  @Test
+  public void testStrictParserToleratesUnknownFutureField()
+      throws Exception {
+    String json = "{\"status\":\"ok\",\"unrecognizedProperties\":{},\"deprecationWarnings\":[\"w1\"],"
+        + "\"futureField\":\"some value the old client does not know about\"}";
+    com.fasterxml.jackson.databind.ObjectMapper strict = new com.fasterxml.jackson.databind.ObjectMapper()
+        .configure(com.fasterxml.jackson.databind.DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, true);
+    ConfigSuccessResponse parsed = strict.readValue(json, ConfigSuccessResponse.class);
+    assertEquals(parsed.getStatus(), "ok");
+    assertEquals(parsed.getDeprecationWarnings(), List.of("w1"));
+  }
+}

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerStatelessTest.java
@@ -41,6 +41,7 @@ import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.model.MasterSlaveSMD;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.pinot.common.exception.InvalidConfigException;
+import org.apache.pinot.common.exception.TableConfigVersionConflictException;
 import org.apache.pinot.common.exception.TableNotFoundException;
 import org.apache.pinot.common.lineage.LineageEntryState;
 import org.apache.pinot.common.lineage.SegmentLineage;
@@ -1912,5 +1913,56 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
 
     _helixResourceManager.deleteRealtimeTable(rawTableName);
     deleteSchema(rawTableName);
+  }
+
+  /// Concurrency regression test for the version-checked CAS plumbing on table-config update. Simulates the
+  /// TOCTOU window between the deprecation-validator's diff read and the subsequent write: T1 reads version `v`,
+  /// T2 commits a write that bumps the znode to `v+1`, T1 then attempts a CAS write at version `v`. The CAS must
+  /// fail with [TableConfigVersionConflictException] — preventing T1 from silently overwriting T2's changes
+  /// (which would let a deprecated key slip past T1's diff). Documented as pre-condition #2 in
+  /// [DeprecatedTableConfigValidationUtils.SOFT_LAUNCH_WARNING_ONLY]'s Javadoc.
+  @Test
+  public void testUpdateTableConfigCasConflictThrowsConflictException()
+      throws Exception {
+    String rawTableName = "casConflictTable";
+    addDummySchema(rawTableName);
+    TableConfig initialConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(rawTableName)
+        .setBrokerTenant(BROKER_TENANT_NAME).setServerTenant(SERVER_TENANT_NAME).build();
+    _helixResourceManager.addTable(initialConfig);
+
+    try {
+      String tableNameWithType = TableNameBuilder.OFFLINE.tableNameWithType(rawTableName);
+      /// T1 reads the current znode version.
+      Stat statAtRead = new Stat();
+      ZNRecord storedAtRead = ZKMetadataProvider.getTableConfigZNRecord(_helixResourceManager.getPropertyStore(),
+          tableNameWithType, statAtRead);
+      assertNotNull(storedAtRead);
+      int t1ExpectedVersion = statAtRead.getVersion();
+
+      /// T2 commits an unrelated update that bumps the znode version.
+      TableConfig t2Config = new TableConfigBuilder(TableType.OFFLINE).setTableName(rawTableName)
+          .setBrokerTenant(BROKER_TENANT_NAME).setServerTenant(SERVER_TENANT_NAME).setNumReplicas(2).build();
+      _helixResourceManager.updateTableConfig(t2Config);
+
+      /// T1 attempts its write at the stale version. The CAS must fail with TableConfigVersionConflictException
+      /// rather than silently overwriting T2's commit or returning a generic 5xx.
+      TableConfig t1Config = new TableConfigBuilder(TableType.OFFLINE).setTableName(rawTableName)
+          .setBrokerTenant(BROKER_TENANT_NAME).setServerTenant(SERVER_TENANT_NAME).setNumReplicas(3).build();
+      try {
+        _helixResourceManager.updateTableConfig(t1Config, t1ExpectedVersion, false);
+        fail("Expected TableConfigVersionConflictException for CAS write at stale version " + t1ExpectedVersion);
+      } catch (TableConfigVersionConflictException expected) {
+        assertTrue(expected.getMessage().contains(tableNameWithType),
+            "Conflict message should name the table: " + expected.getMessage());
+      }
+
+      /// T2's commit survives — verify by reading back the numReplicas.
+      TableConfig finalConfig = _helixResourceManager.getTableConfig(tableNameWithType);
+      assertEquals(finalConfig.getReplication(), 2,
+          "T2's commit must survive the failed T1 CAS attempt; finalConfig should reflect T2 not T1");
+    } finally {
+      _helixResourceManager.deleteOfflineTable(rawTableName);
+      deleteSchema(rawTableName);
+    }
   }
 }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerStatelessTest.java
@@ -41,6 +41,7 @@ import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.model.MasterSlaveSMD;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.pinot.common.exception.InvalidConfigException;
+import org.apache.pinot.common.exception.TableConfigVersionConflictException;
 import org.apache.pinot.common.exception.TableNotFoundException;
 import org.apache.pinot.common.lineage.LineageEntryState;
 import org.apache.pinot.common.lineage.SegmentLineage;
@@ -91,6 +92,7 @@ import org.apache.pinot.spi.utils.CommonConstants.Server;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.util.TestUtils;
+import org.apache.zookeeper.data.Stat;
 import org.joda.time.DateTimeZone;
 import org.joda.time.format.DateTimeFormatter;
 import org.joda.time.format.DateTimeFormatterBuilder;
@@ -1866,5 +1868,56 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
 
     _helixResourceManager.deleteRealtimeTable(rawTableName);
     deleteSchema(rawTableName);
+  }
+
+  /// Concurrency regression test for the version-checked CAS plumbing on table-config update. Simulates the
+  /// TOCTOU window between the deprecation-validator's diff read and the subsequent write: T1 reads version `v`,
+  /// T2 commits a write that bumps the znode to `v+1`, T1 then attempts a CAS write at version `v`. The CAS must
+  /// fail with [TableConfigVersionConflictException] — preventing T1 from silently overwriting T2's changes
+  /// (which would let a deprecated key slip past T1's diff). Documented as pre-condition #2 in
+  /// [DeprecatedTableConfigValidationUtils.SOFT_LAUNCH_WARNING_ONLY]'s Javadoc.
+  @Test
+  public void testUpdateTableConfigCasConflictThrowsConflictException()
+      throws Exception {
+    String rawTableName = "casConflictTable";
+    addDummySchema(rawTableName);
+    TableConfig initialConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(rawTableName)
+        .setBrokerTenant(BROKER_TENANT_NAME).setServerTenant(SERVER_TENANT_NAME).build();
+    _helixResourceManager.addTable(initialConfig);
+
+    try {
+      String tableNameWithType = TableNameBuilder.OFFLINE.tableNameWithType(rawTableName);
+      /// T1 reads the current znode version.
+      Stat statAtRead = new Stat();
+      ZNRecord storedAtRead = ZKMetadataProvider.getTableConfigZNRecord(_helixResourceManager.getPropertyStore(),
+          tableNameWithType, statAtRead);
+      assertNotNull(storedAtRead);
+      int t1ExpectedVersion = statAtRead.getVersion();
+
+      /// T2 commits an unrelated update that bumps the znode version.
+      TableConfig t2Config = new TableConfigBuilder(TableType.OFFLINE).setTableName(rawTableName)
+          .setBrokerTenant(BROKER_TENANT_NAME).setServerTenant(SERVER_TENANT_NAME).setNumReplicas(2).build();
+      _helixResourceManager.updateTableConfig(t2Config);
+
+      /// T1 attempts its write at the stale version. The CAS must fail with TableConfigVersionConflictException
+      /// rather than silently overwriting T2's commit or returning a generic 5xx.
+      TableConfig t1Config = new TableConfigBuilder(TableType.OFFLINE).setTableName(rawTableName)
+          .setBrokerTenant(BROKER_TENANT_NAME).setServerTenant(SERVER_TENANT_NAME).setNumReplicas(3).build();
+      try {
+        _helixResourceManager.updateTableConfig(t1Config, t1ExpectedVersion, false);
+        fail("Expected TableConfigVersionConflictException for CAS write at stale version " + t1ExpectedVersion);
+      } catch (TableConfigVersionConflictException expected) {
+        assertTrue(expected.getMessage().contains(tableNameWithType),
+            "Conflict message should name the table: " + expected.getMessage());
+      }
+
+      /// T2's commit survives — verify by reading back the numReplicas.
+      TableConfig finalConfig = _helixResourceManager.getTableConfig(tableNameWithType);
+      assertEquals(finalConfig.getReplication(), 2,
+          "T2's commit must survive the failed T1 CAS attempt; finalConfig should reflect T2 not T1");
+    } finally {
+      _helixResourceManager.deleteOfflineTable(rawTableName);
+      deleteSchema(rawTableName);
+    }
   }
 }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerClusterStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerClusterStatelessTest.java
@@ -56,6 +56,8 @@ import org.apache.pinot.spi.config.table.assignment.InstanceAssignmentConfig;
 import org.apache.pinot.spi.config.table.assignment.InstancePartitionsType;
 import org.apache.pinot.spi.config.table.assignment.InstanceReplicaGroupPartitionConfig;
 import org.apache.pinot.spi.config.table.assignment.InstanceTagPoolConfig;
+import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
+import org.apache.pinot.spi.config.table.ingestion.StreamIngestionConfig;
 import org.apache.pinot.spi.config.tenant.Tenant;
 import org.apache.pinot.spi.config.tenant.TenantRole;
 import org.apache.pinot.spi.stream.LongMsgOffset;
@@ -707,11 +709,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
       preChecker.init(_helixResourceManager, executorService, 1);
       TableRebalancer tableRebalancer =
           new TableRebalancer(_helixManager, null, null, preChecker, _tableSizeReader, null);
-      TableConfig tableConfig =
-          new TableConfigBuilder(TableType.REALTIME).setTableName(RAW_TABLE_NAME)
-              .setNumReplicas(1)
-              .setStreamConfigs(FakeStreamConfigUtils.getDefaultLowLevelStreamConfigs().getStreamConfigsMap())
-              .build();
+      TableConfig tableConfig = getRealtimeTableConfigBuilder(RAW_TABLE_NAME).setNumReplicas(1).build();
       // Create the table
       addDummySchema(RAW_TABLE_NAME);
       _helixResourceManager.addTable(tableConfig);
@@ -884,7 +882,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
         new InstanceTagPoolConfig(TagNameUtils.getRealtimeTagForTenant(null), false, 0, null), null,
         replicaGroupPartitionConfig,
         InstanceAssignmentConfig.PartitionSelector.IMPLICIT_REALTIME_TABLE_PARTITION_SELECTOR.name(), true);
-    TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(RAW_TABLE_NAME)
+    TableConfig tableConfig = getRealtimeTableConfigBuilder(RAW_TABLE_NAME)
         .setNumReplicas(numReplicas)
         .setRoutingConfig(
             new RoutingConfig(null, null, RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE, false))
@@ -987,9 +985,8 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
 
     // "Repartition" and add two new partitions
     int newNumPartitions = 20;
-    tableConfig.getIndexingConfig()
-        .setStreamConfigs(
-            FakeStreamConfigUtils.getDefaultLowLevelStreamConfigs(newNumPartitions).getStreamConfigsMap());
+    setStreamIngestionConfig(tableConfig,
+        FakeStreamConfigUtils.getDefaultLowLevelStreamConfigs(newNumPartitions).getStreamConfigsMap());
     _helixResourceManager.updateTableConfig(tableConfig);
 
     // Add segments for the new partitions
@@ -1060,6 +1057,24 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
       numSegmentsMoved += newInstanceStateMap.size() - commonInstances.size();
     }
     return numSegmentsMoved;
+  }
+
+  private static TableConfigBuilder getRealtimeTableConfigBuilder(String tableName) {
+    return new TableConfigBuilder(TableType.REALTIME).setTableName(tableName)
+        .setTimeColumnName("timeColumn")
+        .setTimeType("DAYS")
+        .setRetentionTimeUnit("DAYS")
+        .setRetentionTimeValue("5")
+        .setStreamConfigs(FakeStreamConfigUtils.getDefaultLowLevelStreamConfigs().getStreamConfigsMap());
+  }
+
+  private static void setStreamIngestionConfig(TableConfig tableConfig, Map<String, String> streamConfigs) {
+    IngestionConfig ingestionConfig = tableConfig.getIngestionConfig();
+    if (ingestionConfig == null) {
+      ingestionConfig = new IngestionConfig();
+      tableConfig.setIngestionConfig(ingestionConfig);
+    }
+    ingestionConfig.setStreamIngestionConfig(new StreamIngestionConfig(List.of(streamConfigs)));
   }
 
   @Test
@@ -1232,11 +1247,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     preChecker.init(_helixResourceManager, executorService, 0.5);
     TableRebalancer tableRebalancer =
         new TableRebalancer(_helixManager, null, null, preChecker, _tableSizeReader, null);
-    TableConfig tableConfig =
-        new TableConfigBuilder(TableType.REALTIME).setTableName(RAW_TABLE_NAME)
-            .setNumReplicas(2)
-            .setStreamConfigs(FakeStreamConfigUtils.getDefaultLowLevelStreamConfigs().getStreamConfigsMap())
-            .build();
+    TableConfig tableConfig = getRealtimeTableConfigBuilder(RAW_TABLE_NAME).setNumReplicas(2).build();
 
     // Create the table
     addDummySchema(RAW_TABLE_NAME);
@@ -1292,8 +1303,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(preCheckerResult.getMessage(), "updateTargetTier should be enabled when tier configs are present");
 
     // trigger downtime warning
-    TableConfig newTableConfig =
-        new TableConfigBuilder(TableType.REALTIME).setTableName(RAW_TABLE_NAME).setNumReplicas(3).build();
+    TableConfig newTableConfig = getRealtimeTableConfigBuilder(RAW_TABLE_NAME).setNumReplicas(3).build();
 
     rebalanceConfig.setBootstrap(false);
     rebalanceConfig.setBestEfforts(false);
@@ -1308,7 +1318,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
         "Number of replicas (3) is greater than 1, downtime is not recommended.");
 
     // no downtime warning with 1 replica
-    newTableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(RAW_TABLE_NAME).setNumReplicas(1).build();
+    newTableConfig = getRealtimeTableConfigBuilder(RAW_TABLE_NAME).setNumReplicas(1).build();
 
     rebalanceConfig.setDowntime(true);
     rebalanceResult = tableRebalancer.rebalance(newTableConfig, rebalanceConfig, null);
@@ -1329,7 +1339,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
         "Replication of the table is 1, which is not recommended for peer-download enabled tables as it may "
             + "cause data loss during rebalance");
 
-    newTableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(RAW_TABLE_NAME).setNumReplicas(3).build();
+    newTableConfig = getRealtimeTableConfigBuilder(RAW_TABLE_NAME).setNumReplicas(3).build();
     newTableConfig.getValidationConfig().setPeerSegmentDownloadScheme("https");
 
     rebalanceResult = tableRebalancer.rebalance(newTableConfig, rebalanceConfig, null);
@@ -1378,7 +1388,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     addFakeServerInstanceToAutoJoinHelixCluster(instanceId, true);
 
     // change num replicas from 3 to 4
-    newTableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(RAW_TABLE_NAME).setNumReplicas(4).build();
+    newTableConfig = getRealtimeTableConfigBuilder(RAW_TABLE_NAME).setNumReplicas(4).build();
 
     // now the new server (the 4th server) should expect to be added all the existing segments (including consuming)
     rebalanceResult = tableRebalancer.rebalance(newTableConfig, rebalanceConfig, null);
@@ -2174,11 +2184,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     ConsumingSegmentInfoReader mockConsumingSegmentInfoReader = Mockito.mock(ConsumingSegmentInfoReader.class);
     TableRebalancer tableRebalancerOriginal =
         new TableRebalancer(_helixManager, null, null, null, _tableSizeReader, null);
-    TableConfig tableConfig =
-        new TableConfigBuilder(TableType.REALTIME).setTableName(RAW_TABLE_NAME)
-            .setNumReplicas(numReplica)
-            .setStreamConfigs(FakeStreamConfigUtils.getDefaultLowLevelStreamConfigs().getStreamConfigsMap())
-            .build();
+    TableConfig tableConfig = getRealtimeTableConfigBuilder(RAW_TABLE_NAME).setNumReplicas(numReplica).build();
 
     // Create the table
     addDummySchema(RAW_TABLE_NAME);
@@ -2285,11 +2291,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
 
     TableRebalancer tableRebalancerOriginal =
         new TableRebalancer(_helixManager, null, null, null, _tableSizeReader, null);
-    TableConfig tableConfig =
-        new TableConfigBuilder(TableType.REALTIME).setTableName(RAW_TABLE_NAME)
-            .setNumReplicas(numReplica)
-            .setStreamConfigs(FakeStreamConfigUtils.getDefaultLowLevelStreamConfigs().getStreamConfigsMap())
-            .build();
+    TableConfig tableConfig = getRealtimeTableConfigBuilder(RAW_TABLE_NAME).setNumReplicas(numReplica).build();
 
     // Create the table
     addDummySchema(RAW_TABLE_NAME);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerClusterStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerClusterStatelessTest.java
@@ -56,6 +56,8 @@ import org.apache.pinot.spi.config.table.assignment.InstanceAssignmentConfig;
 import org.apache.pinot.spi.config.table.assignment.InstancePartitionsType;
 import org.apache.pinot.spi.config.table.assignment.InstanceReplicaGroupPartitionConfig;
 import org.apache.pinot.spi.config.table.assignment.InstanceTagPoolConfig;
+import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
+import org.apache.pinot.spi.config.table.ingestion.StreamIngestionConfig;
 import org.apache.pinot.spi.config.tenant.Tenant;
 import org.apache.pinot.spi.config.tenant.TenantRole;
 import org.apache.pinot.spi.stream.LongMsgOffset;
@@ -694,11 +696,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
       preChecker.init(_helixResourceManager, executorService, 1);
       TableRebalancer tableRebalancer =
           new TableRebalancer(_helixManager, null, null, preChecker, _tableSizeReader, null);
-      TableConfig tableConfig =
-          new TableConfigBuilder(TableType.REALTIME).setTableName(RAW_TABLE_NAME)
-              .setNumReplicas(1)
-              .setStreamConfigs(FakeStreamConfigUtils.getDefaultLowLevelStreamConfigs().getStreamConfigsMap())
-              .build();
+      TableConfig tableConfig = getRealtimeTableConfigBuilder(RAW_TABLE_NAME).setNumReplicas(1).build();
       // Create the table
       addDummySchema(RAW_TABLE_NAME);
       _helixResourceManager.addTable(tableConfig);
@@ -871,7 +869,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
         new InstanceTagPoolConfig(TagNameUtils.getRealtimeTagForTenant(null), false, 0, null), null,
         replicaGroupPartitionConfig,
         InstanceAssignmentConfig.PartitionSelector.IMPLICIT_REALTIME_TABLE_PARTITION_SELECTOR.name(), true);
-    TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(RAW_TABLE_NAME)
+    TableConfig tableConfig = getRealtimeTableConfigBuilder(RAW_TABLE_NAME)
         .setNumReplicas(numReplicas)
         .setRoutingConfig(
             new RoutingConfig(null, null, RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE, false))
@@ -974,9 +972,8 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
 
     // "Repartition" and add two new partitions
     int newNumPartitions = 20;
-    tableConfig.getIndexingConfig()
-        .setStreamConfigs(
-            FakeStreamConfigUtils.getDefaultLowLevelStreamConfigs(newNumPartitions).getStreamConfigsMap());
+    setStreamIngestionConfig(tableConfig,
+        FakeStreamConfigUtils.getDefaultLowLevelStreamConfigs(newNumPartitions).getStreamConfigsMap());
     _helixResourceManager.updateTableConfig(tableConfig);
 
     // Add segments for the new partitions
@@ -1047,6 +1044,24 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
       numSegmentsMoved += newInstanceStateMap.size() - commonInstances.size();
     }
     return numSegmentsMoved;
+  }
+
+  private static TableConfigBuilder getRealtimeTableConfigBuilder(String tableName) {
+    return new TableConfigBuilder(TableType.REALTIME).setTableName(tableName)
+        .setTimeColumnName("timeColumn")
+        .setTimeType("DAYS")
+        .setRetentionTimeUnit("DAYS")
+        .setRetentionTimeValue("5")
+        .setStreamConfigs(FakeStreamConfigUtils.getDefaultLowLevelStreamConfigs().getStreamConfigsMap());
+  }
+
+  private static void setStreamIngestionConfig(TableConfig tableConfig, Map<String, String> streamConfigs) {
+    IngestionConfig ingestionConfig = tableConfig.getIngestionConfig();
+    if (ingestionConfig == null) {
+      ingestionConfig = new IngestionConfig();
+      tableConfig.setIngestionConfig(ingestionConfig);
+    }
+    ingestionConfig.setStreamIngestionConfig(new StreamIngestionConfig(List.of(streamConfigs)));
   }
 
   @Test
@@ -1226,11 +1241,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     preChecker.init(_helixResourceManager, executorService, 0.5);
     TableRebalancer tableRebalancer =
         new TableRebalancer(_helixManager, null, null, preChecker, _tableSizeReader, null);
-    TableConfig tableConfig =
-        new TableConfigBuilder(TableType.REALTIME).setTableName(RAW_TABLE_NAME)
-            .setNumReplicas(2)
-            .setStreamConfigs(FakeStreamConfigUtils.getDefaultLowLevelStreamConfigs().getStreamConfigsMap())
-            .build();
+    TableConfig tableConfig = getRealtimeTableConfigBuilder(RAW_TABLE_NAME).setNumReplicas(2).build();
 
     // Create the table
     addDummySchema(RAW_TABLE_NAME);
@@ -1286,8 +1297,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     assertEquals(preCheckerResult.getMessage(), "updateTargetTier should be enabled when tier configs are present");
 
     // trigger downtime warning
-    TableConfig newTableConfig =
-        new TableConfigBuilder(TableType.REALTIME).setTableName(RAW_TABLE_NAME).setNumReplicas(3).build();
+    TableConfig newTableConfig = getRealtimeTableConfigBuilder(RAW_TABLE_NAME).setNumReplicas(3).build();
 
     rebalanceConfig.setBootstrap(false);
     rebalanceConfig.setBestEfforts(false);
@@ -1302,7 +1312,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
         "Number of replicas (3) is greater than 1, downtime is not recommended.");
 
     // no downtime warning with 1 replica
-    newTableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(RAW_TABLE_NAME).setNumReplicas(1).build();
+    newTableConfig = getRealtimeTableConfigBuilder(RAW_TABLE_NAME).setNumReplicas(1).build();
 
     rebalanceConfig.setDowntime(true);
     rebalanceResult = tableRebalancer.rebalance(newTableConfig, rebalanceConfig, null);
@@ -1334,7 +1344,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
         "Replication of the table is 1, which is not recommended for peer-download enabled tables as it may "
             + "cause data loss during rebalance");
 
-    newTableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(RAW_TABLE_NAME).setNumReplicas(3).build();
+    newTableConfig = getRealtimeTableConfigBuilder(RAW_TABLE_NAME).setNumReplicas(3).build();
     newTableConfig.getValidationConfig().setPeerSegmentDownloadScheme("https");
 
     rebalanceResult = tableRebalancer.rebalance(newTableConfig, rebalanceConfig, null);
@@ -1383,7 +1393,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     addFakeServerInstanceToAutoJoinHelixCluster(instanceId, true);
 
     // change num replicas from 3 to 4
-    newTableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(RAW_TABLE_NAME).setNumReplicas(4).build();
+    newTableConfig = getRealtimeTableConfigBuilder(RAW_TABLE_NAME).setNumReplicas(4).build();
 
     // now the new server (the 4th server) should expect to be added all the existing segments (including consuming)
     rebalanceResult = tableRebalancer.rebalance(newTableConfig, rebalanceConfig, null);
@@ -2179,11 +2189,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     ConsumingSegmentInfoReader mockConsumingSegmentInfoReader = Mockito.mock(ConsumingSegmentInfoReader.class);
     TableRebalancer tableRebalancerOriginal =
         new TableRebalancer(_helixManager, null, null, null, _tableSizeReader, null);
-    TableConfig tableConfig =
-        new TableConfigBuilder(TableType.REALTIME).setTableName(RAW_TABLE_NAME)
-            .setNumReplicas(numReplica)
-            .setStreamConfigs(FakeStreamConfigUtils.getDefaultLowLevelStreamConfigs().getStreamConfigsMap())
-            .build();
+    TableConfig tableConfig = getRealtimeTableConfigBuilder(RAW_TABLE_NAME).setNumReplicas(numReplica).build();
 
     // Create the table
     addDummySchema(RAW_TABLE_NAME);
@@ -2290,11 +2296,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
 
     TableRebalancer tableRebalancerOriginal =
         new TableRebalancer(_helixManager, null, null, null, _tableSizeReader, null);
-    TableConfig tableConfig =
-        new TableConfigBuilder(TableType.REALTIME).setTableName(RAW_TABLE_NAME)
-            .setNumReplicas(numReplica)
-            .setStreamConfigs(FakeStreamConfigUtils.getDefaultLowLevelStreamConfigs().getStreamConfigsMap())
-            .build();
+    TableConfig tableConfig = getRealtimeTableConfigBuilder(RAW_TABLE_NAME).setNumReplicas(numReplica).build();
 
     // Create the table
     addDummySchema(RAW_TABLE_NAME);

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManagerTest.java
@@ -71,6 +71,7 @@ import org.apache.pinot.spi.stream.PermanentConsumerException;
 import org.apache.pinot.spi.stream.StreamConfigProperties;
 import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
 import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.IngestionConfigUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
@@ -192,11 +193,11 @@ public class RealtimeSegmentDataManagerTest {
       tableConfig.setUpsertConfig(null);
     }
     if (maxRows != null) {
-      tableConfig.getIndexingConfig().getStreamConfigs()
+      IngestionConfigUtils.getFirstStreamConfigMap(tableConfig)
           .put(StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_ROWS, maxRows);
     }
     if (maxDuration != null) {
-      tableConfig.getIndexingConfig().getStreamConfigs()
+      IngestionConfigUtils.getFirstStreamConfigMap(tableConfig)
           .put(StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_TIME, maxDuration);
     }
     if (tableConfig.getIngestionConfig() == null) {
@@ -358,7 +359,7 @@ public class RealtimeSegmentDataManagerTest {
   public void testCommitAfterCatchupWithPeriodOffset()
       throws Exception {
     TableConfig tableConfig = createTableConfig();
-    tableConfig.getIndexingConfig().getStreamConfigs().put(
+    IngestionConfigUtils.getFirstStreamConfigMap(tableConfig).put(
         StreamConfigProperties.constructStreamProperty(StreamConfigProperties.STREAM_CONSUMER_OFFSET_CRITERIA,
             "fakeStream"), "2d");
     FakeRealtimeSegmentDataManager segmentDataManager =
@@ -405,7 +406,7 @@ public class RealtimeSegmentDataManagerTest {
   public void testCommitAfterCatchupWithTimestampOffset()
       throws Exception {
     TableConfig tableConfig = createTableConfig();
-    tableConfig.getIndexingConfig().getStreamConfigs().put(
+    IngestionConfigUtils.getFirstStreamConfigMap(tableConfig).put(
         StreamConfigProperties.constructStreamProperty(StreamConfigProperties.STREAM_CONSUMER_OFFSET_CRITERIA,
             "fakeStream"), Instant.now().toString());
     FakeRealtimeSegmentDataManager segmentDataManager =

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BasePauselessRealtimeIngestionTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BasePauselessRealtimeIngestionTest.java
@@ -40,6 +40,7 @@ import org.apache.pinot.spi.config.table.ingestion.StreamIngestionConfig;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.IngestionConfigUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.util.TestUtils;
 import org.slf4j.Logger;
@@ -146,7 +147,7 @@ public abstract class BasePauselessRealtimeIngestionTest extends BaseClusterInte
 
     IngestionConfig ingestionConfig = new IngestionConfig();
     ingestionConfig.setStreamIngestionConfig(
-        new StreamIngestionConfig(List.of(tableConfig.getIndexingConfig().getStreamConfigs())));
+        new StreamIngestionConfig(List.of(IngestionConfigUtils.getFirstStreamConfigMap(tableConfig))));
     ingestionConfig.getStreamIngestionConfig().setPauselessConsumptionEnabled(true);
     tableConfig.getIndexingConfig().setStreamConfigs(null);
     tableConfig.setIngestionConfig(ingestionConfig);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BasePauselessRealtimeIngestionTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BasePauselessRealtimeIngestionTest.java
@@ -42,6 +42,7 @@ import org.apache.pinot.spi.config.table.ingestion.StreamIngestionConfig;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.IngestionConfigUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.util.TestUtils;
 import org.slf4j.Logger;
@@ -146,7 +147,7 @@ public abstract class BasePauselessRealtimeIngestionTest extends BaseClusterInte
 
     IngestionConfig ingestionConfig = new IngestionConfig();
     ingestionConfig.setStreamIngestionConfig(
-        new StreamIngestionConfig(List.of(tableConfig.getIndexingConfig().getStreamConfigs())));
+        new StreamIngestionConfig(List.of(IngestionConfigUtils.getFirstStreamConfigMap(tableConfig))));
     ingestionConfig.getStreamIngestionConfig().setPauselessConsumptionEnabled(true);
     tableConfig.getIndexingConfig().setStreamConfigs(null);
     tableConfig.setIngestionConfig(ingestionConfig);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/logicaltable/LogicalTableWithTwoRealtimeTableIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/logicaltable/LogicalTableWithTwoRealtimeTableIntegrationTest.java
@@ -42,6 +42,7 @@ import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.apache.pinot.spi.config.table.ingestion.StreamIngestionConfig;
 import org.apache.pinot.spi.exception.QueryErrorCode;
+import org.apache.pinot.spi.utils.IngestionConfigUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.util.TestUtils;
 import org.testng.Assert;
@@ -171,7 +172,7 @@ public class LogicalTableWithTwoRealtimeTableIntegrationTest extends BaseLogical
     String tableName = REALTIME_TABLE_NAMES.get(tableIndex);
     Integer partitionId = REALTIME_TABLE_PARTITIONS.get(tableName);
     tableConfig.setTableName(tableName);
-    Map<String, String> streamConfigs = new HashMap<>(tableConfig.getIndexingConfig().getStreamConfigs());
+    Map<String, String> streamConfigs = new HashMap<>(IngestionConfigUtils.getFirstStreamConfigMap(tableConfig));
     streamConfigs.put("stream.kafka.partition.ids", String.valueOf(partitionId));
 
     tableConfig.getIndexingConfig().setStreamConfigs(null);

--- a/pinot-integration-tests/src/test/resources/chaos-monkey-create-table.json
+++ b/pinot-integration-tests/src/test/resources/chaos-monkey-create-table.json
@@ -2,8 +2,12 @@
   "tableName": "myTable",
   "tableType": "OFFLINE",
   "segmentsConfig": {
-    "segmentPushType": "APPEND",
     "replication": "3"
+  },
+  "segmentAssignmentConfigMap": {
+    "OFFLINE": {
+      "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy"
+    }
   },
   "tenants": {
   },
@@ -12,6 +16,11 @@
   },
   "metadata": {
     "customConfigs": {
+    }
+  },
+  "ingestionConfig": {
+    "batchIngestionConfig": {
+      "segmentIngestionType": "APPEND"
     }
   }
 }

--- a/pinot-integration-tests/src/test/resources/dimDayOfWeek_config.json
+++ b/pinot-integration-tests/src/test/resources/dimDayOfWeek_config.json
@@ -3,7 +3,6 @@
   "tableType": "OFFLINE",
   "isDimTable": true,
   "segmentsConfig": {
-    "segmentPushType": "REFRESH",
     "replication": "1"
   },
   "tenants": {
@@ -13,6 +12,11 @@
   },
   "metadata": {
     "customConfigs": {
+    }
+  },
+  "ingestionConfig": {
+    "batchIngestionConfig": {
+      "segmentIngestionType": "REFRESH"
     }
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -3843,11 +3843,10 @@ public class TableConfigUtilsTest {
     String expectedPushType = "APPEND";
 
     Map<String, String> expectedStreamConfigsMap = getTestStreamConfigs();
-    TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
-        .setSegmentPushFrequency(expectedPushFrequency)
-        .setSegmentPushType(expectedPushType)
-        .setStreamConfigs(expectedStreamConfigsMap)
-        .build();
+    TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).build();
+    tableConfig.getValidationConfig().setSegmentPushFrequency(expectedPushFrequency);
+    tableConfig.getValidationConfig().setSegmentPushType(expectedPushType);
+    tableConfig.getIndexingConfig().setStreamConfigs(expectedStreamConfigsMap);
 
     // Before conversion, the ingestion config should be null.
     assertNull(tableConfig.getIngestionConfig());

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -3884,11 +3884,10 @@ public class TableConfigUtilsTest {
     String expectedPushType = "APPEND";
 
     Map<String, String> expectedStreamConfigsMap = getTestStreamConfigs();
-    TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
-        .setSegmentPushFrequency(expectedPushFrequency)
-        .setSegmentPushType(expectedPushType)
-        .setStreamConfigs(expectedStreamConfigsMap)
-        .build();
+    TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).build();
+    tableConfig.getValidationConfig().setSegmentPushFrequency(expectedPushFrequency);
+    tableConfig.getValidationConfig().setSegmentPushType(expectedPushType);
+    tableConfig.getIndexingConfig().setStreamConfigs(expectedStreamConfigsMap);
 
     // Before conversion, the ingestion config should be null.
     assertNull(tableConfig.getIngestionConfig());

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/DeprecatedConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/DeprecatedConfig.java
@@ -1,0 +1,67 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.config;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+
+/// Marks a config getter as a deprecated JSON property in `TableConfig` (or any nested config bean).
+///
+/// **Metadata-only**: this annotation has no runtime effect on serialization or deserialization. It is consumed by
+/// the controller's `DeprecatedTableConfigValidationUtils` to gate creation and update of table configs.
+///
+/// **Current behaviour (soft-launch)**: every parseable `since` value classifies the violation as a **warning**.
+/// Warnings are surfaced in the REST response's `deprecationWarnings` field but never block the request. The only
+/// outcome that becomes an **error** today is an unparseable `since` string — that is treated as a code-side
+/// annotation bug and is locked out at build time by the controller's `testEveryRuleHasParseableSince`.
+///
+/// **Future behaviour (after the soft-launch flag flips)**: severity will be derived by comparing `since()`
+/// against the running Pinot version — properties deprecated in the current major.minor release stay as warnings,
+/// while properties deprecated in any earlier release escalate to errors that reject the REST request with HTTP
+/// 400 BAD_REQUEST. The flip is gated on four documented promotion pre-conditions (see
+/// `DeprecatedTableConfigValidationUtils.SOFT_LAUNCH_WARNING_ONLY`'s Javadoc).
+///
+/// Place this annotation on the Jackson-visible getter (the one that drives JSON property naming) so the discovery
+/// walk picks up the correct serialized name.
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface DeprecatedConfig {
+
+  /// Human-readable replacement guidance, surfaced verbatim in the user-facing error/warning. Should describe what
+  /// the user should set instead, e.g. `"Use 'segmentsConfig.replication' instead."`.
+  String replacement();
+
+  /// The Pinot release in which this property was deprecated, e.g. `"1.6.0"`. Today (under the soft-launch
+  /// policy) every parseable value classifies as **warning** regardless of running version. After the
+  /// soft-launch flag flips, the value will be compared against the running version to decide warning vs error.
+  ///
+  /// Format: `MAJOR.MINOR` or `MAJOR.MINOR.PATCH` with an optional `-SNAPSHOT` qualifier; only the leading
+  /// major.minor pair is compared.
+  ///
+  /// **Strict format**: unparseable values are classified as `ERROR` by the controller's reflective validator —
+  /// a code-side bug, not a user-supplied input issue. Even under the soft-launch policy, an unparseable `since`
+  /// fires the throw branch in `validateOnCreate`/`validateOnUpdate` and the REST endpoint returns 400 BAD_REQUEST,
+  /// breaking every PUT/POST that touches the affected table-config path. The controller test
+  /// `testEveryRuleHasParseableSince` locks this at build time for in-tree annotations; external annotators
+  /// should ensure their own coverage exists.
+  String since();
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/DedupConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/DedupConfig.java
@@ -18,11 +18,13 @@
  */
 package org.apache.pinot.spi.config.table;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.google.common.base.Preconditions;
 import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.pinot.spi.config.BaseJsonConfig;
+import org.apache.pinot.spi.config.DeprecatedConfig;
 import org.apache.pinot.spi.utils.Enablement;
 
 
@@ -165,6 +167,8 @@ public class DedupConfig extends BaseJsonConfig {
   }
 
   @Deprecated
+  @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+  @DeprecatedConfig(replacement = "Use 'dedupConfig.preload' instead.", since = "1.4.0")
   public boolean isEnablePreload() {
     return _enablePreload;
   }
@@ -178,6 +182,10 @@ public class DedupConfig extends BaseJsonConfig {
   }
 
   @Deprecated
+  @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+  @DeprecatedConfig(
+      replacement = "Use 'ingestionConfig.streamIngestionConfig.parallelSegmentConsumptionPolicy' instead.",
+      since = "1.4.0")
   public boolean isAllowDedupConsumptionDuringCommit() {
     return _allowDedupConsumptionDuringCommit;
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FieldConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FieldConfig.java
@@ -28,6 +28,7 @@ import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.pinot.spi.config.BaseJsonConfig;
+import org.apache.pinot.spi.config.DeprecatedConfig;
 
 
 public class FieldConfig extends BaseJsonConfig {
@@ -194,8 +195,14 @@ public class FieldConfig extends BaseJsonConfig {
     return _encodingType;
   }
 
+  /// `@JsonIgnore` is intentionally NOT applied here. Stripping `indexType` from the serialised view would
+  /// break the deprecation diff on update: a user resubmitting the same body with `indexType: "INVERTED"` would
+  /// see it as "newly introduced" because the round-tripped stored bean would only carry `indexTypes`. Keeping
+  /// the field in the wire shape preserves the pre-`@DeprecatedConfig` behaviour for back-compat callers; the
+  /// soft-launch warning is still emitted on every input that uses the deprecated form.
   @Nullable
   @Deprecated
+  @DeprecatedConfig(replacement = "Use 'fieldConfigList[].indexTypes' instead.", since = "0.9.0")
   public IndexType getIndexType() {
     return !_indexTypes.isEmpty() ? _indexTypes.get(0) : null;
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/IndexingConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/IndexingConfig.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.spi.config.table;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.JsonNode;
 import java.util.HashSet;
 import java.util.List;
@@ -26,6 +27,7 @@ import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.pinot.spi.config.BaseJsonConfig;
+import org.apache.pinot.spi.config.DeprecatedConfig;
 
 
 public class IndexingConfig extends BaseJsonConfig {
@@ -133,6 +135,8 @@ public class IndexingConfig extends BaseJsonConfig {
     _rangeIndexVersion = rangeIndexVersion;
   }
 
+  @Deprecated
+  @DeprecatedConfig(replacement = "Use 'tableIndexConfig.jsonIndexConfigs' instead.", since = "0.12.0")
   public List<String> getJsonIndexColumns() {
     return _jsonIndexColumns;
   }
@@ -158,6 +162,8 @@ public class IndexingConfig extends BaseJsonConfig {
   }
 
   @Deprecated
+  @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+  @DeprecatedConfig(replacement = "Remove this field; it is ignored.", since = "1.6.0")
   public boolean isCreateInvertedIndexDuringSegmentGeneration() {
     return _createInvertedIndexDuringSegmentGeneration;
   }
@@ -206,6 +212,9 @@ public class IndexingConfig extends BaseJsonConfig {
   /// @deprecated Use `List<Map<String, String>> streamConfigs` from
   /// [org.apache.pinot.spi.config.table.ingestion.IngestionConfig#getStreamIngestionConfig()]
   @Nullable
+  @Deprecated
+  @DeprecatedConfig(replacement = "Use 'ingestionConfig.streamIngestionConfig.streamConfigMaps' instead.",
+      since = "0.7.1")
   public Map<String, String> getStreamConfigs() {
     return _streamConfigs;
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/RoutingConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/RoutingConfig.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.pinot.spi.config.BaseJsonConfig;
+import org.apache.pinot.spi.config.DeprecatedConfig;
 
 
 public class RoutingConfig extends BaseJsonConfig {
@@ -55,6 +56,9 @@ public class RoutingConfig extends BaseJsonConfig {
   }
 
   @Nullable
+  @Deprecated
+  @DeprecatedConfig(replacement = "Use 'routing.segmentPrunerTypes' and 'routing.instanceSelectorType' instead.",
+      since = "0.3.0")
   public String getRoutingTableBuilderName() {
     return _routingTableBuilderName;
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/SegmentsValidationAndRetentionConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/SegmentsValidationAndRetentionConfig.java
@@ -18,8 +18,10 @@
  */
 package org.apache.pinot.spi.config.table;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import java.util.concurrent.TimeUnit;
 import org.apache.pinot.spi.config.BaseJsonConfig;
+import org.apache.pinot.spi.config.DeprecatedConfig;
 import org.apache.pinot.spi.utils.TimeUtils;
 
 
@@ -131,6 +133,8 @@ public class SegmentsValidationAndRetentionConfig extends BaseJsonConfig {
   /// @deprecated Use `segmentIngestionFrequency` from
   ///     [org.apache.pinot.spi.config.table.ingestion.IngestionConfig#getBatchIngestionConfig()]
   @Deprecated
+  @DeprecatedConfig(replacement = "Use 'ingestionConfig.batchIngestionConfig.segmentIngestionFrequency' instead.",
+      since = "0.8.0")
   public String getSegmentPushFrequency() {
     return _segmentPushFrequency;
   }
@@ -143,6 +147,8 @@ public class SegmentsValidationAndRetentionConfig extends BaseJsonConfig {
   /// @deprecated Use `segmentIngestionType` from
   ///     [org.apache.pinot.spi.config.table.ingestion.IngestionConfig#getBatchIngestionConfig()]
   @Deprecated
+  @DeprecatedConfig(replacement = "Use 'ingestionConfig.batchIngestionConfig.segmentIngestionType' instead.",
+      since = "0.8.0")
   public String getSegmentPushType() {
     return _segmentPushType;
   }
@@ -166,6 +172,7 @@ public class SegmentsValidationAndRetentionConfig extends BaseJsonConfig {
   ///
   /// Will be deleted in future version of Pinot
   @Deprecated
+  @DeprecatedConfig(replacement = "Use 'segmentsConfig.replication' instead.", since = "1.1.0")
   public String getReplicasPerPartition() {
     return _replicasPerPartition;
   }
@@ -180,6 +187,7 @@ public class SegmentsValidationAndRetentionConfig extends BaseJsonConfig {
 
   /// @deprecated Use [org.apache.pinot.spi.config.table.assignment.InstanceAssignmentConfig] instead.
   @Deprecated
+  @DeprecatedConfig(replacement = "Use 'segmentAssignmentConfigMap' instead.", since = "1.3.0")
   public ReplicaGroupStrategyConfig getReplicaGroupStrategyConfig() {
     return _replicaGroupStrategyConfig;
   }
@@ -215,6 +223,8 @@ public class SegmentsValidationAndRetentionConfig extends BaseJsonConfig {
 
   /// @deprecated Use [org.apache.pinot.spi.config.table.assignment.InstanceAssignmentConfig] instead
   @Deprecated
+  @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+  @DeprecatedConfig(replacement = "Use 'instanceAssignmentConfigMap' instead.", since = "1.3.0")
   public boolean isMinimizeDataMovement() {
     return _minimizeDataMovement;
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/UpsertConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/UpsertConfig.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.spi.config.table;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import com.google.common.base.Preconditions;
 import java.util.List;
@@ -26,6 +27,7 @@ import javax.annotation.Nullable;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.spi.config.BaseJsonConfig;
+import org.apache.pinot.spi.config.DeprecatedConfig;
 import org.apache.pinot.spi.config.table.ingestion.TransformConfig;
 import org.apache.pinot.spi.utils.Enablement;
 
@@ -353,6 +355,8 @@ public class UpsertConfig extends BaseJsonConfig {
   }
 
   @Deprecated
+  @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+  @DeprecatedConfig(replacement = "Use 'upsertConfig.snapshot' instead.", since = "1.4.0")
   public boolean isEnableSnapshot() {
     return _enableSnapshot;
   }
@@ -366,6 +370,8 @@ public class UpsertConfig extends BaseJsonConfig {
   }
 
   @Deprecated
+  @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+  @DeprecatedConfig(replacement = "Use 'upsertConfig.preload' instead.", since = "1.4.0")
   public boolean isEnablePreload() {
     return _enablePreload;
   }
@@ -379,6 +385,10 @@ public class UpsertConfig extends BaseJsonConfig {
   }
 
   @Deprecated
+  @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+  @DeprecatedConfig(
+      replacement = "Use 'ingestionConfig.streamIngestionConfig.parallelSegmentConsumptionPolicy' instead.",
+      since = "1.4.0")
   public boolean isAllowPartialUpsertConsumptionDuringCommit() {
     return _allowPartialUpsertConsumptionDuringCommit;
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/assignment/InstanceReplicaGroupPartitionConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/assignment/InstanceReplicaGroupPartitionConfig.java
@@ -19,10 +19,12 @@
 package org.apache.pinot.spi.config.table.assignment;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyDescription;
 import javax.annotation.Nullable;
 import org.apache.pinot.spi.config.BaseJsonConfig;
+import org.apache.pinot.spi.config.DeprecatedConfig;
 
 
 public class InstanceReplicaGroupPartitionConfig extends BaseJsonConfig {
@@ -102,6 +104,9 @@ public class InstanceReplicaGroupPartitionConfig extends BaseJsonConfig {
     return _numInstancesPerPartition;
   }
 
+  @JsonInclude(JsonInclude.Include.NON_DEFAULT)
+  @Deprecated
+  @DeprecatedConfig(replacement = "Remove this field; it will be removed in a future release.", since = "1.1.0")
   public boolean isMinimizeDataMovement() {
     return _minimizeDataMovement;
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/TableConfigBuilder.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/TableConfigBuilder.java
@@ -54,8 +54,8 @@ import org.apache.pinot.spi.config.table.sampler.TableSamplerConfig;
 
 
 public class TableConfigBuilder {
-  private static final String DEFAULT_SEGMENT_PUSH_TYPE = "APPEND";
   private static final String REFRESH_SEGMENT_PUSH_TYPE = "REFRESH";
+  private static final String APPEND_SEGMENT_PUSH_TYPE = "APPEND";
   private static final String DEFAULT_DELETED_SEGMENTS_RETENTION_PERIOD = "7d";
   private static final String DEFAULT_NUM_REPLICAS = "1";
   private static final String MMAP_LOAD_MODE = "MMAP";
@@ -79,9 +79,12 @@ public class TableConfigBuilder {
   @Deprecated
   private String _segmentPushFrequency;
 
-  // TODO: Remove 'DEFAULT_SEGMENT_PUSH_TYPE' in the future major release.
   @Deprecated
-  private String _segmentPushType = DEFAULT_SEGMENT_PUSH_TYPE;
+  /// Historical default preserved so existing programmatic callers that depend on segmentsConfig.segmentPushType
+  /// being "APPEND" when not explicitly set continue to work. The new @DeprecatedConfig soft-launch surfaces
+  /// this as a warning on create/update, signalling migration to ingestionConfig.batchIngestionConfig
+  /// .segmentIngestionType. TODO: drop the default once the soft-launch flag flips and callers have migrated.
+  private String _segmentPushType = APPEND_SEGMENT_PUSH_TYPE;
   private String _peerSegmentDownloadScheme;
   @Deprecated
   private ReplicaGroupStrategyConfig _replicaGroupStrategyConfig;
@@ -123,7 +126,7 @@ public class TableConfigBuilder {
 
   /// @deprecated This flag is ignored. Keep it for backward compatibility during upgrade (especially for JSON ser/de).
   @Deprecated
-  private boolean _createInvertedIndexDuringSegmentGeneration;
+  private Boolean _createInvertedIndexDuringSegmentGeneration;
 
   private TableCustomConfig _customConfig;
   private QuotaConfig _quotaConfig;
@@ -217,16 +220,18 @@ public class TableConfigBuilder {
   }
 
   /// @deprecated Use `segmentIngestionType` from [IngestionConfig#getBatchIngestionConfig()]
+  @Deprecated
   public TableConfigBuilder setSegmentPushType(String segmentPushType) {
     if (REFRESH_SEGMENT_PUSH_TYPE.equalsIgnoreCase(segmentPushType)) {
       _segmentPushType = REFRESH_SEGMENT_PUSH_TYPE;
     } else {
-      _segmentPushType = DEFAULT_SEGMENT_PUSH_TYPE;
+      _segmentPushType = APPEND_SEGMENT_PUSH_TYPE;
     }
     return this;
   }
 
   /// @deprecated Use `segmentIngestionFrequency` from [IngestionConfig#getBatchIngestionConfig()]
+  @Deprecated
   public TableConfigBuilder setSegmentPushFrequency(String segmentPushFrequency) {
     _segmentPushFrequency = segmentPushFrequency;
     return this;
@@ -370,6 +375,8 @@ public class TableConfigBuilder {
     return this;
   }
 
+  /// @deprecated Use `streamConfigMaps` from [IngestionConfig#getStreamIngestionConfig()]
+  @Deprecated
   public TableConfigBuilder setStreamConfigs(Map<String, String> streamConfigs) {
     Preconditions.checkState(_tableType == TableType.REALTIME);
     _streamConfigs = streamConfigs;
@@ -508,6 +515,8 @@ public class TableConfigBuilder {
     return this;
   }
 
+  /// Preserves deprecated fields when explicitly requested so legacy programmatic callers retain their wire shape.
+  @SuppressWarnings("deprecation")
   public TableConfig build() {
     // Validation config
     SegmentsValidationAndRetentionConfig validationConfig = new SegmentsValidationAndRetentionConfig();
@@ -537,7 +546,9 @@ public class TableConfigBuilder {
       indexingConfig.setSortedColumn(List.of(_sortedColumn));
     }
     indexingConfig.setInvertedIndexColumns(_invertedIndexColumns);
-    indexingConfig.setCreateInvertedIndexDuringSegmentGeneration(_createInvertedIndexDuringSegmentGeneration);
+    if (_createInvertedIndexDuringSegmentGeneration != null) {
+      indexingConfig.setCreateInvertedIndexDuringSegmentGeneration(_createInvertedIndexDuringSegmentGeneration);
+    }
     indexingConfig.setNoDictionaryColumns(_noDictionaryColumns);
     indexingConfig.setOnHeapDictionaryColumns(_onHeapDictionaryColumns);
     indexingConfig.setBloomFilterColumns(_bloomFilterColumns);

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/config/TableConfigsSerializationTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/config/TableConfigsSerializationTest.java
@@ -271,4 +271,23 @@ public class TableConfigsSerializationTest {
     Assert.assertFalse(jsonNode.has("offline"), "offline should not be present when null");
     Assert.assertTrue(jsonNode.has("realtime"));
   }
+
+  /// Locks the invariant relied upon by `TableConfigsRestletResource.subConfigJson` — uppercase `OFFLINE` /
+  /// `REALTIME` keys in the user-submitted JSON are silently dropped by Jackson at deserialization time because
+  /// the constructor parameters are annotated `@JsonProperty("offline")` / `@JsonProperty("realtime")`. The
+  /// deprecation pass therefore needs only to look up the lowercase keys.
+  @Test
+  public void testUppercaseOfflineRealtimeKeysAreIgnoredByJackson()
+      throws Exception {
+    final String jsonWithUppercaseKeys = "{"
+        + "\"tableName\":\"" + TEST_TABLE_NAME + "\","
+        + "\"schema\":" + createTestSchema().toSingleLineJsonString() + ","
+        + "\"OFFLINE\":{},"
+        + "\"REALTIME\":{}"
+        + "}";
+
+    final TableConfigs parsed = JsonUtils.stringToObject(jsonWithUppercaseKeys, TableConfigs.class);
+    Assert.assertNull(parsed.getOffline(), "uppercase OFFLINE key must not populate the offline sub-config");
+    Assert.assertNull(parsed.getRealtime(), "uppercase REALTIME key must not populate the realtime sub-config");
+  }
 }

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/utils/builder/TableConfigBuilderTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/utils/builder/TableConfigBuilderTest.java
@@ -19,8 +19,18 @@
 
 package org.apache.pinot.spi.utils.builder;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.spi.config.table.DedupConfig;
+import org.apache.pinot.spi.config.table.FieldConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.config.table.UpsertConfig;
+import org.apache.pinot.spi.config.table.assignment.InstanceAssignmentConfig;
+import org.apache.pinot.spi.config.table.assignment.InstanceReplicaGroupPartitionConfig;
+import org.apache.pinot.spi.config.table.assignment.InstanceTagPoolConfig;
+import org.apache.pinot.spi.utils.JsonUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -39,5 +49,48 @@ public class TableConfigBuilderTest {
         .setSkipSegmentPreprocess(true).build();
     Assert.assertTrue(tableconfig.getIndexingConfig().isSkipSegmentPreprocess(),
         "skipSegmentPreprocess will be true");
+  }
+
+  @Test
+  public void testBuildOmitsDefaultDeprecatedFieldsFromSerializedJson()
+      throws Exception {
+    TableConfig offlineTableConfig = new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName(TABLE_NAME)
+        .setTimeColumnName(TIME_COLUMN)
+        .setFieldConfigList(List.of(new FieldConfig("c1", FieldConfig.EncodingType.DICTIONARY,
+            List.of(FieldConfig.IndexType.INVERTED), null, null)))
+        .build();
+    JsonNode offlineJson = JsonUtils.stringToJsonNode(offlineTableConfig.toJsonString());
+    Assert.assertFalse(offlineJson.path("segmentsConfig").has("minimizeDataMovement"));
+    Assert.assertFalse(offlineJson.path("tableIndexConfig").has("createInvertedIndexDuringSegmentGeneration"));
+    /// `fieldConfigList[].indexType` is intentionally emitted in the wire shape: stripping it via @JsonIgnore
+    /// broke the deprecation diff on update (round-trip dropped `indexType`, then resubmits looked like "newly
+    /// introduced"). The soft-launch warning still flags the deprecated input; the field stays on the wire.
+    Assert.assertTrue(offlineJson.path("fieldConfigList").get(0).has("indexType"));
+
+    TableConfig upsertTableConfig = new TableConfigBuilder(TableType.REALTIME)
+        .setTableName(TABLE_NAME)
+        .setTimeColumnName(TIME_COLUMN)
+        .setUpsertConfig(new UpsertConfig())
+        .build();
+    JsonNode upsertJson = JsonUtils.stringToJsonNode(upsertTableConfig.toJsonString());
+    Assert.assertFalse(upsertJson.path("upsertConfig").has("enableSnapshot"));
+    Assert.assertFalse(upsertJson.path("upsertConfig").has("enablePreload"));
+    Assert.assertFalse(upsertJson.path("upsertConfig").has("allowPartialUpsertConsumptionDuringCommit"));
+
+    InstanceAssignmentConfig instanceAssignmentConfig = new InstanceAssignmentConfig(
+        new InstanceTagPoolConfig("testTenant", false, 0, null), null,
+        new InstanceReplicaGroupPartitionConfig(false, 0, 0, 0, 0, 0, false, null), null, false);
+    TableConfig dedupTableConfig = new TableConfigBuilder(TableType.REALTIME)
+        .setTableName(TABLE_NAME)
+        .setTimeColumnName(TIME_COLUMN)
+        .setDedupConfig(new DedupConfig())
+        .setInstanceAssignmentConfigMap(Map.of("CONSUMING", instanceAssignmentConfig))
+        .build();
+    JsonNode dedupJson = JsonUtils.stringToJsonNode(dedupTableConfig.toJsonString());
+    Assert.assertFalse(dedupJson.path("dedupConfig").has("enablePreload"));
+    Assert.assertFalse(dedupJson.path("dedupConfig").has("allowDedupConsumptionDuringCommit"));
+    Assert.assertFalse(dedupJson.path("instanceAssignmentConfigMap").path("CONSUMING")
+        .path("replicaGroupPartitionConfig").has("minimizeDataMovement"));
   }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/BootstrapTableTool.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/BootstrapTableTool.java
@@ -274,6 +274,9 @@ public class BootstrapTableTool {
       throws Exception {
     final List<Map<String, String>> batchConfigsMaps =
         tableConfig.getIngestionConfig().getBatchIngestionConfig().getBatchConfigMaps();
+    if (batchConfigsMaps == null) {
+      return;
+    }
     for (Map<String, String> batchConfigsMap : batchConfigsMaps) {
       String inputDirURI = batchConfigsMap.get(BatchConfigProperties.INPUT_DIR_URI);
       if (!new File(inputDirURI).exists()) {

--- a/pinot-tools/src/main/resources/conf/sample_offline_table_config.json
+++ b/pinot-tools/src/main/resources/conf/sample_offline_table_config.json
@@ -6,7 +6,6 @@
     "timeType": "DAYS",
     "retentionTimeUnit": "DAYS",
     "retentionTimeValue": "365",
-    "segmentPushType": "APPEND",
     "replication": "3"
   },
   "tenants": {
@@ -21,7 +20,11 @@
     ]
   },
   "metadata": {
-    "customConfigs": {
+    "customConfigs": {}
+  },
+  "ingestionConfig": {
+    "batchIngestionConfig": {
+      "segmentIngestionType": "APPEND"
     }
   }
 }

--- a/pinot-tools/src/main/resources/conf/sample_realtime_table_config.json
+++ b/pinot-tools/src/main/resources/conf/sample_realtime_table_config.json
@@ -6,9 +6,7 @@
     "timeType": "DAYS",
     "retentionTimeUnit": "DAYS",
     "retentionTimeValue": "5",
-    "segmentPushType": "APPEND",
-    "replication": "3",
-    "replicasPerPartition": "1"
+    "replication": "3"
   },
   "tenants": {
     "broker": "brokerOne",
@@ -19,21 +17,26 @@
     "invertedIndexColumns": [
       "column1",
       "column2"
-    ],
-    "streamConfigs": {
-      "streamType": "kafka",
-      "stream.kafka.topic.name": "kafkaTopicName",
-      "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.stream.kafka.KafkaAvroMessageDecoder",
-      "stream.kafka.decoder.prop.schema.registry.rest.url": "http://localhost:2222/schemaRegistry",
-      "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka30.KafkaConsumerFactory",
-      "stream.kafka.consumer.prop.auto.offset.reset": "largest",
-      "stream.kafka.broker.list": "localhost:19092",
-      "realtime.segment.flush.threshold.time": "12h",
-      "realtime.segment.flush.threshold.size": "100000"
+    ]
+  },
+  "ingestionConfig": {
+    "streamIngestionConfig": {
+      "streamConfigMaps": [
+        {
+          "streamType": "kafka",
+          "stream.kafka.topic.name": "kafkaTopicName",
+          "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.stream.kafka.KafkaAvroMessageDecoder",
+          "stream.kafka.decoder.prop.schema.registry.rest.url": "http://localhost:2222/schemaRegistry",
+          "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka30.KafkaConsumerFactory",
+          "stream.kafka.consumer.prop.auto.offset.reset": "largest",
+          "stream.kafka.broker.list": "localhost:19092",
+          "realtime.segment.flush.threshold.time": "12h",
+          "realtime.segment.flush.threshold.size": "100000"
+        }
+      ]
     }
   },
   "metadata": {
-    "customConfigs": {
-    }
+    "customConfigs": {}
   }
 }

--- a/pinot-tools/src/main/resources/examples/batch/airlineStats/airlineStats_offline_table_config.json
+++ b/pinot-tools/src/main/resources/examples/batch/airlineStats/airlineStats_offline_table_config.json
@@ -4,7 +4,6 @@
   "segmentsConfig": {
     "timeColumnName": "DaysSinceEpoch",
     "timeType": "DAYS",
-    "segmentPushType": "APPEND",
     "replication": "1"
   },
   "tenants": {},
@@ -117,6 +116,9 @@
     }
   ],
   "ingestionConfig": {
+    "batchIngestionConfig": {
+      "segmentIngestionType": "APPEND"
+    },
     "transformConfigs": [
       {
         "columnName": "ts",

--- a/pinot-tools/src/main/resources/examples/batch/baseballStats/baseballStats_offline_table_config.json
+++ b/pinot-tools/src/main/resources/examples/batch/baseballStats/baseballStats_offline_table_config.json
@@ -2,11 +2,9 @@
   "tableName": "baseballStats",
   "tableType": "OFFLINE",
   "segmentsConfig": {
-    "segmentPushType": "APPEND",
     "replication": "1"
   },
-  "tenants": {
-  },
+  "tenants": {},
   "tableIndexConfig": {
     "loadMode": "HEAP",
     "invertedIndexColumns": [
@@ -15,7 +13,11 @@
     ]
   },
   "metadata": {
-    "customConfigs": {
+    "customConfigs": {}
+  },
+  "ingestionConfig": {
+    "batchIngestionConfig": {
+      "segmentIngestionType": "APPEND"
     }
   }
 }

--- a/pinot-tools/src/main/resources/examples/batch/clickstreamFunnel/clickstreamFunnel_offline_table_config.json
+++ b/pinot-tools/src/main/resources/examples/batch/clickstreamFunnel/clickstreamFunnel_offline_table_config.json
@@ -2,13 +2,11 @@
   "tableName": "clickstreamFunnel",
   "tableType": "OFFLINE",
   "segmentsConfig": {
-    "segmentPushType": "APPEND",
     "timeColumnName": "ts",
     "retentionTimeUnit": "DAYS",
     "retentionTimeValue": "30",
     "replication": "1",
-    "deletedSegmentsRetentionPeriod": "7d",
-    "minimizeDataMovement": false
+    "deletedSegmentsRetentionPeriod": "7d"
   },
   "tenants": {
     "broker": "DefaultTenant",
@@ -16,7 +14,6 @@
   },
   "tableIndexConfig": {
     "loadMode": "MMAP",
-    "createInvertedIndexDuringSegmentGeneration": true,
     "rangeIndexVersion": 2,
     "aggregateMetrics": false,
     "nullHandlingEnabled": true,
@@ -37,6 +34,9 @@
   },
   "metadata": {},
   "ingestionConfig": {
+    "batchIngestionConfig": {
+      "segmentIngestionType": "APPEND"
+    },
     "transformConfigs": [],
     "continueOnError": true,
     "rowTimeValueCheck": true,

--- a/pinot-tools/src/main/resources/examples/batch/dimBaseballTeams/dimBaseballTeams_offline_table_config.json
+++ b/pinot-tools/src/main/resources/examples/batch/dimBaseballTeams/dimBaseballTeams_offline_table_config.json
@@ -3,7 +3,6 @@
   "tableType": "OFFLINE",
   "isDimTable": true,
   "segmentsConfig": {
-    "segmentPushType": "REFRESH",
     "replication": "1"
   },
   "tenants": {
@@ -13,6 +12,11 @@
   },
   "metadata": {
     "customConfigs": {
+    }
+  },
+  "ingestionConfig": {
+    "batchIngestionConfig": {
+      "segmentIngestionType": "REFRESH"
     }
   }
 }

--- a/pinot-tools/src/main/resources/examples/batch/fineFoodReviews/fineFoodReviews_offline_table_config.json
+++ b/pinot-tools/src/main/resources/examples/batch/fineFoodReviews/fineFoodReviews_offline_table_config.json
@@ -2,28 +2,37 @@
   "tableName": "fineFoodReviews",
   "tableType": "OFFLINE",
   "segmentsConfig": {
-    "segmentPushType": "APPEND",
     "replication": "1"
   },
-  "tenants": {
-  },
+  "tenants": {},
   "tableIndexConfig": {
     "loadMode": "MMAP",
-    "noDictionaryColumns": ["Text"],
-    "invertedIndexColumns": [
+    "noDictionaryColumns": [
+      "Text"
     ],
+    "invertedIndexColumns": [],
     "multiColumnTextIndexConfig": {
-      "columns": ["UserId", "ProductId", "Summary"]
+      "columns": [
+        "UserId",
+        "ProductId",
+        "Summary"
+      ]
+    }
+  },
+  "ingestionConfig": {
+    "batchIngestionConfig": {
+      "segmentIngestionType": "APPEND"
     }
   },
   "metadata": {
-    "customConfigs": {
-    }
+    "customConfigs": {}
   },
   "fieldConfigList": [
     {
       "encodingType": "RAW",
-      "indexType": "VECTOR",
+      "indexTypes": [
+        "VECTOR"
+      ],
       "name": "embedding",
       "properties": {
         "vectorIndexType": "HNSW",

--- a/pinot-tools/src/main/resources/examples/batch/githubComplexTypeEvents/githubComplexTypeEvents_offline_table_config.json
+++ b/pinot-tools/src/main/resources/examples/batch/githubComplexTypeEvents/githubComplexTypeEvents_offline_table_config.json
@@ -4,7 +4,6 @@
   "tenants": {
   },
   "segmentsConfig": {
-    "segmentPushType": "REFRESH",
     "replication": "1",
     "timeColumnName": "created_at_timestamp"
   },
@@ -24,6 +23,9 @@
     }
   ],
   "ingestionConfig": {
+    "batchIngestionConfig": {
+      "segmentIngestionType": "REFRESH"
+    },
     "transformConfigs": [
       {
         "columnName": "created_at_timestamp",

--- a/pinot-tools/src/main/resources/examples/batch/githubEvents/githubEvents_offline_table_config.json
+++ b/pinot-tools/src/main/resources/examples/batch/githubEvents/githubEvents_offline_table_config.json
@@ -4,7 +4,6 @@
   "tenants": {
   },
   "segmentsConfig": {
-    "segmentPushType": "REFRESH",
     "replication": "1",
     "timeColumnName": "created_at_timestamp"
   },
@@ -15,13 +14,16 @@
       "repo",
       "payload"
     ],
-    "jsonIndexColumns": [
-      "actor",
-      "repo",
-      "payload"
-    ]
+    "jsonIndexConfigs": {
+      "actor": {},
+      "repo": {},
+      "payload": {}
+    }
   },
   "ingestionConfig": {
+    "batchIngestionConfig": {
+      "segmentIngestionType": "REFRESH"
+    },
     "transformConfigs": [
       {
         "columnName": "created_at_timestamp",

--- a/pinot-tools/src/main/resources/examples/batch/starbucksStores/starbucksStores_offline_table_config.json
+++ b/pinot-tools/src/main/resources/examples/batch/starbucksStores/starbucksStores_offline_table_config.json
@@ -4,16 +4,16 @@
   "segmentsConfig": {
     "retentionTimeUnit": "DAYS",
     "retentionTimeValue": "1",
-    "segmentPushType": "APPEND",
     "replication": "1"
   },
-  "tenants": {
-  },
+  "tenants": {},
   "fieldConfigList": [
     {
       "name": "location_st_point",
       "encodingType": "RAW",
-      "indexType": "H3",
+      "indexTypes": [
+        "H3"
+      ],
       "properties": {
         "resolutions": "5"
       }
@@ -25,8 +25,12 @@
       "location_st_point"
     ]
   },
-  "metadata": {
-    "customConfigs": {
+  "ingestionConfig": {
+    "batchIngestionConfig": {
+      "segmentIngestionType": "APPEND"
     }
+  },
+  "metadata": {
+    "customConfigs": {}
   }
 }

--- a/pinot-tools/src/main/resources/examples/batch/testUnnest/testUnnest_offline_table_config.json
+++ b/pinot-tools/src/main/resources/examples/batch/testUnnest/testUnnest_offline_table_config.json
@@ -3,11 +3,9 @@
   "tableType": "OFFLINE",
   "segmentsConfig": {
     "deletedSegmentsRetentionPeriod": "0d",
-    "segmentPushType": "APPEND",
     "timeColumnName": "event_time",
     "retentionTimeUnit": "DAYS",
     "retentionTimeValue": "180",
-    "minimizeDataMovement": false,
     "replication": "1"
   },
   "tenants": {
@@ -24,7 +22,6 @@
     "optimizeDictionaryType": false,
     "enableDynamicStarTreeCreation": false,
     "columnMajorSegmentBuilderEnabled": true,
-    "createInvertedIndexDuringSegmentGeneration": true,
     "optimizeDictionaryForMetrics": false,
     "noDictionarySizeRatioThreshold": 0,
     "loadMode": "MMAP",
@@ -38,6 +35,9 @@
   },
   "metadata": {},
   "ingestionConfig": {
+    "batchIngestionConfig": {
+      "segmentIngestionType": "APPEND"
+    },
     "transformConfigs": [],
     "enrichmentConfigs": [
       {

--- a/pinot-tools/src/main/resources/examples/minions/batch/baseballStats/baseballStats_offline_table_config.json
+++ b/pinot-tools/src/main/resources/examples/minions/batch/baseballStats/baseballStats_offline_table_config.json
@@ -2,11 +2,9 @@
   "tableName": "baseballStats",
   "tableType": "OFFLINE",
   "segmentsConfig": {
-    "segmentPushType": "APPEND",
     "replication": "1"
   },
-  "tenants": {
-  },
+  "tenants": {},
   "tableIndexConfig": {
     "loadMode": "HEAP",
     "invertedIndexColumns": [
@@ -15,8 +13,7 @@
     ]
   },
   "metadata": {
-    "customConfigs": {
-    }
+    "customConfigs": {}
   },
   "ingestionConfig": {
     "batchIngestionConfig": {
@@ -35,8 +32,7 @@
   },
   "task": {
     "taskTypeConfigsMap": {
-      "SegmentGenerationAndPushTask": {
-      }
+      "SegmentGenerationAndPushTask": {}
     }
   }
 }

--- a/pinot-tools/src/main/resources/examples/stream/dailySales/dailySales_realtime_table_config.json
+++ b/pinot-tools/src/main/resources/examples/stream/dailySales/dailySales_realtime_table_config.json
@@ -2,14 +2,12 @@
   "tableName": "dailySales",
   "tableType": "REALTIME",
   "segmentsConfig": {
-    "segmentPushType": "APPEND",
     "timeColumnName": "daysSinceEpoch",
     "retentionTimeUnit": "DAYS",
     "retentionTimeValue": "50000",
     "replication": "1"
   },
-  "tenants": {
-  },
+  "tenants": {},
   "tableIndexConfig": {
     "loadMode": "MMAP",
     "noDictionaryColumns": [
@@ -50,7 +48,6 @@
     ]
   },
   "metadata": {
-    "customConfigs": {
-    }
+    "customConfigs": {}
   }
 }

--- a/pinot-tools/src/main/resources/examples/stream/fineFoodReviews/fineFoodReviews_realtime_table_config.json
+++ b/pinot-tools/src/main/resources/examples/stream/fineFoodReviews/fineFoodReviews_realtime_table_config.json
@@ -2,19 +2,23 @@
   "tableName": "fineFoodReviews",
   "tableType": "REALTIME",
   "segmentsConfig": {
-    "segmentPushType": "APPEND",
     "timeColumnName": "ts",
     "retentionTimeUnit": "DAYS",
     "retentionTimeValue": "5",
     "replication": "1"
   },
-  "tenants": {
-  },
+  "tenants": {},
   "tableIndexConfig": {
     "loadMode": "MMAP",
-    "noDictionaryColumns": ["Text"],
+    "noDictionaryColumns": [
+      "Text"
+    ],
     "multiColumnTextIndexConfig": {
-      "columns": ["UserId", "ProductId", "Summary"]
+      "columns": [
+        "UserId",
+        "ProductId",
+        "Summary"
+      ]
     }
   },
   "routing": {
@@ -45,13 +49,14 @@
     ]
   },
   "metadata": {
-    "customConfigs": {
-    }
+    "customConfigs": {}
   },
   "fieldConfigList": [
     {
       "encodingType": "RAW",
-      "indexType": "VECTOR",
+      "indexTypes": [
+        "VECTOR"
+      ],
       "name": "embedding",
       "properties": {
         "vectorIndexType": "HNSW",

--- a/pinot-tools/src/main/resources/examples/stream/fineFoodReviews_part_0/fineFoodReviews_part_0_realtime_table_config.json
+++ b/pinot-tools/src/main/resources/examples/stream/fineFoodReviews_part_0/fineFoodReviews_part_0_realtime_table_config.json
@@ -2,19 +2,23 @@
   "tableName": "fineFoodReviews_part_0",
   "tableType": "REALTIME",
   "segmentsConfig": {
-    "segmentPushType": "APPEND",
     "timeColumnName": "ts",
     "retentionTimeUnit": "DAYS",
     "retentionTimeValue": "5",
     "replication": "1"
   },
-  "tenants": {
-  },
+  "tenants": {},
   "tableIndexConfig": {
     "loadMode": "MMAP",
-    "noDictionaryColumns": ["Text"],
+    "noDictionaryColumns": [
+      "Text"
+    ],
     "multiColumnTextIndexConfig": {
-      "columns": ["UserId", "ProductId", "Summary"]
+      "columns": [
+        "UserId",
+        "ProductId",
+        "Summary"
+      ]
     }
   },
   "routing": {
@@ -46,13 +50,14 @@
     ]
   },
   "metadata": {
-    "customConfigs": {
-    }
+    "customConfigs": {}
   },
   "fieldConfigList": [
     {
       "encodingType": "RAW",
-      "indexType": "VECTOR",
+      "indexTypes": [
+        "VECTOR"
+      ],
       "name": "embedding",
       "properties": {
         "vectorIndexType": "HNSW",

--- a/pinot-tools/src/main/resources/examples/stream/fineFoodReviews_part_1/fineFoodReviews_part_1_realtime_table_config.json
+++ b/pinot-tools/src/main/resources/examples/stream/fineFoodReviews_part_1/fineFoodReviews_part_1_realtime_table_config.json
@@ -2,19 +2,23 @@
   "tableName": "fineFoodReviews_part_1",
   "tableType": "REALTIME",
   "segmentsConfig": {
-    "segmentPushType": "APPEND",
     "timeColumnName": "ts",
     "retentionTimeUnit": "DAYS",
     "retentionTimeValue": "5",
     "replication": "1"
   },
-  "tenants": {
-  },
+  "tenants": {},
   "tableIndexConfig": {
     "loadMode": "MMAP",
-    "noDictionaryColumns": ["Text"],
+    "noDictionaryColumns": [
+      "Text"
+    ],
     "multiColumnTextIndexConfig": {
-      "columns": ["UserId", "ProductId", "Summary"]
+      "columns": [
+        "UserId",
+        "ProductId",
+        "Summary"
+      ]
     }
   },
   "routing": {
@@ -46,13 +50,14 @@
     ]
   },
   "metadata": {
-    "customConfigs": {
-    }
+    "customConfigs": {}
   },
   "fieldConfigList": [
     {
       "encodingType": "RAW",
-      "indexType": "VECTOR",
+      "indexTypes": [
+        "VECTOR"
+      ],
       "name": "embedding",
       "properties": {
         "vectorIndexType": "HNSW",

--- a/pinot-tools/src/main/resources/examples/stream/meetupRsvpJson/meetupRsvpJson_realtime_table_config.json
+++ b/pinot-tools/src/main/resources/examples/stream/meetupRsvpJson/meetupRsvpJson_realtime_table_config.json
@@ -15,12 +15,12 @@
       "member_json",
       "venue_json"
     ],
-    "jsonIndexColumns": [
-      "event_json",
-      "group_json",
-      "member_json",
-      "venue_json"
-    ]
+    "jsonIndexConfigs": {
+      "event_json": {},
+      "group_json": {},
+      "member_json": {},
+      "venue_json": {}
+    }
   },
   "ingestionConfig": {
     "streamIngestionConfig": {

--- a/pinot-tools/src/main/resources/examples/stream/upsertJsonMeetupRsvp/upsertJsonMeetupRsvp_realtime_table_config.json
+++ b/pinot-tools/src/main/resources/examples/stream/upsertJsonMeetupRsvp/upsertJsonMeetupRsvp_realtime_table_config.json
@@ -15,12 +15,12 @@
       "member_json",
       "venue_json"
     ],
-    "jsonIndexColumns": [
-      "event_json",
-      "group_json",
-      "member_json",
-      "venue_json"
-    ],
+    "jsonIndexConfigs": {
+      "event_json": {},
+      "group_json": {},
+      "member_json": {},
+      "venue_json": {}
+    },
     "columnPartitionMap": {
       "rsvp_id": {
         "functionName": "Hashcode",

--- a/pinot-tools/src/main/resources/examples/stream/upsertMeetupRsvp/upsertMeetupRsvp_realtime_table_config.json
+++ b/pinot-tools/src/main/resources/examples/stream/upsertMeetupRsvp/upsertMeetupRsvp_realtime_table_config.json
@@ -55,14 +55,16 @@
   },
   "upsertConfig": {
     "mode": "FULL",
-    "enableSnapshot": true,
-    "enablePreload": true
+    "snapshot": "ENABLE",
+    "preload": "ENABLE"
   },
   "fieldConfigList": [
     {
       "name": "location",
       "encodingType": "RAW",
-      "indexType": "H3",
+      "indexTypes": [
+        "H3"
+      ],
       "properties": {
         "resolutions": "5"
       }

--- a/pinot-tools/src/main/resources/examples/stream/upsertPartialMeetupRsvp/upsertPartialMeetupRsvp_realtime_table_config.json
+++ b/pinot-tools/src/main/resources/examples/stream/upsertPartialMeetupRsvp/upsertPartialMeetupRsvp_realtime_table_config.json
@@ -64,7 +64,9 @@
     {
       "name": "location",
       "encodingType": "RAW",
-      "indexType": "H3",
+      "indexTypes": [
+        "H3"
+      ],
       "properties": {
         "resolutions": "5"
       }


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Annotation\-driven deprecated table config validation for create/update with version\-aware severity and raw\-JSON diffing

```mermaid
flowchart TD
  N0["Discover deprecated config rules #40;F4#44; F8#41;"]:::stAdded
  N1["Classify rule severity #40;WARNING#47;ERROR#41; #40;F4#41;"]:::stAdded
  N2["Validate table config on create #40;F4#41;"]:::stAdded
  N3["Validate table config on update #40;diff against stored#41; #40;F4#41;"]:::stAdded
  N4["Extract raw JSON from ZK for update validation #40;F5#44; F3#41;"]:::stModified
  N5["Perform version#45;checked CAS update #40;F7#44; F2#41;"]:::stModified
  N6["Handle validation result #40;warnings#47;errors#41; #40;F20#44; F21#44; F4#41;"]:::stModified
  N7["REST endpoint#58; Create table #40;POST #47;tables#47;#123;name#125;#41; #40;F22#41;"]:::stModified
  N8["REST endpoint#58; Update table #40;PUT #47;tables#47;#123;name#125;#41; #40;F22#41;"]:::stModified
  N9["REST endpoint#58; Validate table config #40;F22#44; F23#41;"]:::stModified
  N0 -->|"feeds rules to"| N1
  N1 -->|"classifies rules for"| N2
  N1 -->|"classifies rules for"| N3
  N7 -->|"triggers"| N2
  N8 -->|"triggers raw JSON extraction for"| N4
  N4 -->|"provides stored JSON to"| N3
  N3 -->|"triggers version#45;checked update after"| N5
  N2 -->|"sends validation result to"| N6
  N3 -->|"sends validation result to"| N6
  N6 -->|"adds warnings to response #47; throws error for"| N7
  N6 -->|"adds warnings to response #47; throws error for"| N8
  N9 -->|"uses create mode when table doesn#39;t exist"| N2
  N9 -->|"uses update mode when table exists"| N3
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

Partial evidence: 30 file patches omitted; 4 truncated.

<details>
<summary>Diff evidence</summary>

- F2: pinot\-common/src/main/java/org/apache/pinot/common/exception/TableConfigVersionConflictException\.java — [after](https://github.com/apache/pinot/blob/b4dd805dc3811b8d7a878f89e54b41e95c56d170/pinot-common/src/main/java/org/apache/pinot/common/exception/TableConfigVersionConflictException.java)
- F3: pinot\-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider\.java — [before](https://github.com/apache/pinot/blob/e6787e178645fd3c5a887e2aba7e0de8343cd524/pinot-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider.java) · [after](https://github.com/apache/pinot/blob/b4dd805dc3811b8d7a878f89e54b41e95c56d170/pinot-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider.java)
- F4: pinot\-common/src/main/java/org/apache/pinot/common/utils/config/DeprecatedTableConfigValidationUtils\.java — [after](https://github.com/apache/pinot/blob/b4dd805dc3811b8d7a878f89e54b41e95c56d170/pinot-common/src/main/java/org/apache/pinot/common/utils/config/DeprecatedTableConfigValidationUtils.java)
- F5: pinot\-common/src/main/java/org/apache/pinot/common/utils/config/TableConfigSerDeUtils\.java — [before](https://github.com/apache/pinot/blob/e6787e178645fd3c5a887e2aba7e0de8343cd524/pinot-common/src/main/java/org/apache/pinot/common/utils/config/TableConfigSerDeUtils.java) · [after](https://github.com/apache/pinot/blob/b4dd805dc3811b8d7a878f89e54b41e95c56d170/pinot-common/src/main/java/org/apache/pinot/common/utils/config/TableConfigSerDeUtils.java)
- F7: pinot\-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager\.java — [before](https://github.com/apache/pinot/blob/e6787e178645fd3c5a887e2aba7e0de8343cd524/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java) · [after](https://github.com/apache/pinot/blob/b4dd805dc3811b8d7a878f89e54b41e95c56d170/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java)
- F8: pinot\-spi/src/main/java/org/apache/pinot/spi/config/DeprecatedConfig\.java — [after](https://github.com/apache/pinot/blob/b4dd805dc3811b8d7a878f89e54b41e95c56d170/pinot-spi/src/main/java/org/apache/pinot/spi/config/DeprecatedConfig.java)
- F20: pinot\-controller/src/main/java/org/apache/pinot/controller/api/resources/ConfigSuccessResponse\.java — [before](https://github.com/apache/pinot/blob/e6787e178645fd3c5a887e2aba7e0de8343cd524/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/ConfigSuccessResponse.java) · [after](https://github.com/apache/pinot/blob/b4dd805dc3811b8d7a878f89e54b41e95c56d170/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/ConfigSuccessResponse.java)
- F21: pinot\-controller/src/main/java/org/apache/pinot/controller/api/resources/CopyTableResponse\.java — [before](https://github.com/apache/pinot/blob/e6787e178645fd3c5a887e2aba7e0de8343cd524/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/CopyTableResponse.java) · [after](https://github.com/apache/pinot/blob/b4dd805dc3811b8d7a878f89e54b41e95c56d170/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/CopyTableResponse.java)
- F22: pinot\-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource\.java — [before](https://github.com/apache/pinot/blob/e6787e178645fd3c5a887e2aba7e0de8343cd524/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java) · [after](https://github.com/apache/pinot/blob/b4dd805dc3811b8d7a878f89e54b41e95c56d170/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java)
- F23: pinot\-controller/src/main/java/org/apache/pinot/controller/api/resources/TableConfigsRestletResource\.java — [before](https://github.com/apache/pinot/blob/e6787e178645fd3c5a887e2aba7e0de8343cd524/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableConfigsRestletResource.java) · [after](https://github.com/apache/pinot/blob/b4dd805dc3811b8d7a878f89e54b41e95c56d170/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableConfigsRestletResource.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImU2Nzg3ZTE3ODY0NWZkM2M1YTg4N2UyYWJhN2UwZGU4MzQzY2Q1MjQiLCJjb250ZXh0X2hhc2giOiI5M2I3NmYxZTY3YjFlODQ1YjA1NTkxMjc4MmY5ZDUwODJmOTdjYjU3MTM3MmM2MGM2ZTEyMTQ2M2I5ODA4YTk0IiwiZ2VuZXJhdGVkX2F0IjoxNzg5NzI0MTE2LCJoZWFkX3NoYSI6ImI0ZGQ4MDVkYzM4MTFiOGQ3YTg3OGY4OWU1NGI0MWU5NWM1NmQxNzAiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJlNjc4N2UxNzg2NDVmZDNjNWE4ODdlMmFiYTdlMGRlODM0M2NkNTI0IiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 78653c3a86155d33f689e650fc115ef29c2395fe2f69249eacf12ce4b767368d -->
<!-- pinot-pr-flow:end -->

## Summary

Reject explicit use of deprecated table-config keys on **both create and update**, driven by a single source of truth on the SPI getters instead of a hand-maintained rule list.

- New `@DeprecatedConfig(replacement, since)` annotation in `pinot-spi`. Placed on the deprecated getter; `since` is the Pinot release the field was first marked `@Deprecated`.
- `DeprecatedTableConfigValidationUtils` discovers rules at class-load via a Jackson-aware reflection walk over `TableConfig` (recursing into nested `BaseJsonConfig` types, `Collection<X>`, `Map<?,V>`, honoring `@JsonProperty` renames). The hand-maintained list is gone.
- Severity is **version-aware**: a rule whose `since.major.minor` equals the running `PinotVersion.major.minor` is reported as a **warning** (one-release grace period). Older rules are **errors** that block the request. Unknown current version → safe default of error.
- Update paths (PUT `/tables/{name}`, PUT `/tableConfigs/{name}`, validate POSTs against existing tables) diff the incoming JSON against the **byte-faithful stored ZNRecord JSON** (new helper `TableConfigSerDeUtils.toRawJsonNode` + `ZKMetadataProvider.getTableConfigZNRecord`) — *not* against `existingConfig.toJsonNode()`, which would silently strip `@JsonIgnore`-d / `@JsonInclude(NON_DEFAULT)` deprecated keys and turn every legacy PUT into a false positive. Re-submitting an unchanged legacy value is a no-op; only **newly introduced or value-changed** deprecated paths fire.
- Warnings surface via a new optional `deprecationWarnings: List<String>` field on `ConfigSuccessResponse` and the validate endpoint JSON. Errors continue to throw `400`.

## Deprecated table-config keys covered

Sorted from earliest deprecation to latest. On the current `1.6.0-SNAPSHOT` release line, everything older than `1.6` is an error; `1.6.0` deprecations are warnings (one-release grace period).

| Since | JSON path | Replacement | Severity on 1.6 |
|---|---|---|---|
| **0.3.0** | `routing.routingTableBuilderName` | Use `routing.segmentPrunerTypes` and `routing.instanceSelectorType` | error |
| **0.7.1** | `tableIndexConfig.streamConfigs` | Use `ingestionConfig.streamIngestionConfig.streamConfigMaps` | error |
| **0.8.0** | `segmentsConfig.segmentPushFrequency` | Use `ingestionConfig.batchIngestionConfig.segmentIngestionFrequency` | error |
| **0.8.0** | `segmentsConfig.segmentPushType` | Use `ingestionConfig.batchIngestionConfig.segmentIngestionType` | error |
| **0.9.0** | `fieldConfigList[*].indexType` | Use `fieldConfigList[].indexTypes` | error |
| **0.12.0** | `tableIndexConfig.jsonIndexColumns` | Use `tableIndexConfig.jsonIndexConfigs` | error |
| **1.1.0** | `segmentsConfig.replicasPerPartition` | Use `segmentsConfig.replication` | error |
| **1.1.0** | `instanceAssignmentConfigMap[*].replicaGroupPartitionConfig.minimizeDataMovement` | Remove this field; it will be removed in a future release | error |
| **1.3.0** | `segmentsConfig.replicaGroupStrategyConfig` | Use `segmentAssignmentConfigMap` | error |
| **1.3.0** | `segmentsConfig.minimizeDataMovement` | Use `instanceAssignmentConfigMap` | error |
| **1.4.0** | `upsertConfig.enableSnapshot` | Use `upsertConfig.snapshot` | error |
| **1.4.0** | `upsertConfig.enablePreload` | Use `upsertConfig.preload` | error |
| **1.4.0** | `upsertConfig.allowPartialUpsertConsumptionDuringCommit` | Use `ingestionConfig.streamIngestionConfig.parallelSegmentConsumptionPolicy` | error |
| **1.4.0** | `dedupConfig.enablePreload` | Use `dedupConfig.preload` | error |
| **1.4.0** | `dedupConfig.allowDedupConsumptionDuringCommit` | Use `ingestionConfig.streamIngestionConfig.parallelSegmentConsumptionPolicy` | error |
| **1.6.0** | `tableIndexConfig.createInvertedIndexDuringSegmentGeneration` | Remove this field; it is ignored | **warning** |

`since` was determined per field by walking `git log` / `git tag --contains` against the upstream apache/pinot history to find the first release tag that ships the `@Deprecated` annotation (or the original `@deprecated` Javadoc when that came first).

## Behavior

- **Create** (POST): every present rule fires. Errors → `400`; warnings → server WARN log + `deprecationWarnings` field.
- **Update** (PUT): diff against the raw stored ZK JSON. Only paths newly added or whose value changed fire. Legacy values that were already on the table and re-submitted unchanged pass silently.
- **Validate** (POST): runs in create mode if the table doesn't yet exist, update mode otherwise. Returns warnings in the response body.
- **Builder-generated payloads**: `TableConfigBuilder.build()` now converts the deprecated `_segmentPushType` / `_segmentPushFrequency` setters into modern `ingestionConfig.batchIngestionConfig.segmentIngestionType/Frequency`, so existing tests and tools that use the builder produce create payloads that pass validation.

## Testing

- `./mvnw -pl pinot-spi,pinot-common,pinot-controller -am -Dtest='DeprecatedTableConfigValidationUtilsTest+TableConfigSerDeUtilsTest+TableConfigBuilderTest+PinotTableRestletResourceTest#testRejectsDeprecatedConfigOnCreateAndOnUpdateWhenNewlyIntroduced+PinotTableRestletResourceTest#testUpdateAllowsUnchangedLegacyDeprecatedConfig+TableConfigsRestletResourceTest' test`
- `./mvnw -pl pinot-spi,pinot-common,pinot-controller spotless:apply checkstyle:check license:check`

Coverage includes: annotation discovery walk against `TableConfig`, diff filtering on update, version-based severity classification, raw-JSON preservation across `@JsonIgnore`/`@JsonInclude(NON_DEFAULT)` getters, and round-trip rejection/acceptance through the controller REST endpoints.