### PR TITLE
[refactor] Centralize batch ingestion job spec constants into SegmentGenerationJobUtils

### DIFF
--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/main/java/org/apache/pinot/plugin/ingestion/batch/common/SegmentGenerationJobUtils.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/main/java/org/apache/pinot/plugin/ingestion/batch/common/SegmentGenerationJobUtils.java
@@ -47,6 +47,13 @@ public class SegmentGenerationJobUtils implements Serializable {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(SegmentGenerationJobUtils.class);
 
+  // Key used to pass the serialized SegmentGenerationJobSpec through a distributed job framework
+  public static final String SEGMENT_GENERATION_JOB_SPEC = "segmentGenerationJobSpec";
+
+  // Field names in the executionFrameworkSpec/extraConfigs section shared across ingestion frameworks
+  public static final String DEPENDENCY_JAR_DIR = "dependencyJarDir";
+  public static final String STAGING_DIR = "stagingDir";
+
   /**
    * Always use local directory sequence id unless explicitly config: "use.global.directory.sequence.id".
    *

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/src/main/java/org/apache/pinot/plugin/ingestion/batch/hadoop/HadoopSegmentGenerationJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/src/main/java/org/apache/pinot/plugin/ingestion/batch/hadoop/HadoopSegmentGenerationJobRunner.java
@@ -67,13 +67,10 @@ import static org.apache.pinot.spi.plugin.PluginManager.PLUGINS_INCLUDE_PROPERTY
 public class HadoopSegmentGenerationJobRunner extends Configured implements IngestionJobRunner, Serializable {
   private static final Logger LOGGER = LoggerFactory.getLogger(HadoopSegmentGenerationJobRunner.class);
 
-  public static final String SEGMENT_GENERATION_JOB_SPEC = "segmentGenerationJobSpec";
+  // Kept for backward compatibility; callers should prefer SegmentGenerationJobUtils.SEGMENT_GENERATION_JOB_SPEC
+  public static final String SEGMENT_GENERATION_JOB_SPEC = SegmentGenerationJobUtils.SEGMENT_GENERATION_JOB_SPEC;
 
-  // Field names in job spec's executionFrameworkSpec/extraConfigs section
-  private static final String DEPS_JAR_DIR_FIELD = "dependencyJarDir";
-  private static final String STAGING_DIR_FIELD = "stagingDir";
-
-  // Sub-dirs under directory specified by STAGING_DIR_FIELD
+  // Sub-dirs under the staging directory
   private static final String SEGMENT_TAR_SUBDIR_NAME = "segmentTar";
   private static final String DEPS_JAR_SUBDIR_NAME = "dependencyJars";
 
@@ -156,7 +153,8 @@ public class HadoopSegmentGenerationJobRunner extends Configured implements Inge
     outputDirFS.mkdir(outputDirURI);
 
     //Get staging directory for temporary output pinot segments
-    String stagingDir = _spec.getExecutionFrameworkSpec().getExtraConfigs().get(STAGING_DIR_FIELD);
+    String stagingDir =
+        _spec.getExecutionFrameworkSpec().getExtraConfigs().get(SegmentGenerationJobUtils.STAGING_DIR);
     Preconditions.checkNotNull(stagingDir, "Please set config: stagingDir under 'executionFrameworkSpec.extraConfigs'");
     URI stagingDirURI = URI.create(stagingDir);
     if (stagingDirURI.getScheme() == null) {
@@ -247,7 +245,8 @@ public class HadoopSegmentGenerationJobRunner extends Configured implements Inge
       packPluginsToDistributedCache(job, outputDirFS, stagingDirURI);
 
       // Add dependency jars, if we're provided with a directory containing these.
-      String dependencyJarsSrcDir = _spec.getExecutionFrameworkSpec().getExtraConfigs().get(DEPS_JAR_DIR_FIELD);
+      String dependencyJarsSrcDir =
+          _spec.getExecutionFrameworkSpec().getExtraConfigs().get(SegmentGenerationJobUtils.DEPENDENCY_JAR_DIR);
       if (dependencyJarsSrcDir != null) {
         Path dependencyJarsDestPath = new Path(stagingDirURI.toString(), DEPS_JAR_SUBDIR_NAME);
         addJarsToDistributedCache(job, new File(dependencyJarsSrcDir), outputDirFS, dependencyJarsDestPath.toUri(),

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark3/SparkSegmentGenerationJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark3/SparkSegmentGenerationJobRunner.java
@@ -67,8 +67,6 @@ import static org.apache.pinot.spi.plugin.PluginManager.PLUGINS_INCLUDE_PROPERTY
 public class SparkSegmentGenerationJobRunner implements IngestionJobRunner, Serializable {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(SparkSegmentGenerationJobRunner.class);
-  private static final String DEPS_JAR_DIR = "dependencyJarDir";
-  private static final String STAGING_DIR = "stagingDir";
 
   private SegmentGenerationJobSpec _spec;
 
@@ -155,7 +153,8 @@ public class SparkSegmentGenerationJobRunner implements IngestionJobRunner, Seri
     outputDirFS.mkdir(outputDirURI);
 
     //Get staging directory for temporary output pinot segments
-    String stagingDir = _spec.getExecutionFrameworkSpec().getExtraConfigs().get(STAGING_DIR);
+    String stagingDir =
+        _spec.getExecutionFrameworkSpec().getExtraConfigs().get(SegmentGenerationJobUtils.STAGING_DIR);
     URI stagingDirURI = null;
     if (stagingDir != null) {
       stagingDirURI = URI.create(stagingDir);
@@ -178,9 +177,10 @@ public class SparkSegmentGenerationJobRunner implements IngestionJobRunner, Seri
       packPluginsToDistributedCache(sparkContext);
 
       // Add dependency jars
-      if (_spec.getExecutionFrameworkSpec().getExtraConfigs().containsKey(DEPS_JAR_DIR)) {
+      if (_spec.getExecutionFrameworkSpec().getExtraConfigs()
+          .containsKey(SegmentGenerationJobUtils.DEPENDENCY_JAR_DIR)) {
         addDepsJarToDistributedCache(sparkContext,
-            _spec.getExecutionFrameworkSpec().getExtraConfigs().get(DEPS_JAR_DIR));
+            _spec.getExecutionFrameworkSpec().getExtraConfigs().get(SegmentGenerationJobUtils.DEPENDENCY_JAR_DIR));
       }
 
       List<String> pathAndIdxList = new ArrayList<>();


### PR DESCRIPTION
## Description
Centralizes duplicated string constants (`SEGMENT_GENERATION_JOB_SPEC`, `DEPENDENCY_JAR_DIR`, `STAGING_DIR`) from `HadoopSegmentGenerationJobRunner` and `SparkSegmentGenerationJobRunner` into the shared `SegmentGenerationJobUtils` class in `pinot-batch-ingestion-common`.

These three config-key strings were independently declared as private literals in each runner. Because they must stay in sync (they reference the same `executionFrameworkSpec.extraConfigs` keys), having separate copies creates a risk of silent drift if one runner is updated but the other is not.

## Changes Made
- **`SegmentGenerationJobUtils.java`** -- added three `public static final String` constants: `SEGMENT_GENERATION_JOB_SPEC`, `DEPENDENCY_JAR_DIR`, and `STAGING_DIR`.
- **`HadoopSegmentGenerationJobRunner.java`** -- removed the private `DEPS_JAR_DIR_FIELD` and `STAGING_DIR_FIELD` literals; replaced all usages with `SegmentGenerationJobUtils.DEPENDENCY_JAR_DIR` and `SegmentGenerationJobUtils.STAGING_DIR`. The existing **public** `SEGMENT_GENERATION_JOB_SPEC` field is preserved as a delegating alias (`= SegmentGenerationJobUtils.SEGMENT_GENERATION_JOB_SPEC`) so that any external callers continue to compile without changes.
- **`SparkSegmentGenerationJobRunner.java`** -- removed the private `DEPS_JAR_DIR` and `STAGING_DIR` literals; replaced all usages with the shared constants from `SegmentGenerationJobUtils`.

## Backward Compatibility
- `HadoopSegmentGenerationJobRunner.SEGMENT_GENERATION_JOB_SPEC` remains a public field with the same value, so downstream code that references it is unaffected.
- No config key values were changed -- only where the string literals are defined.

## Testing Done
- [x] Verified the project compiles (`mvn install -DskipTests` on the affected modules)
- [x] Existing unit tests for `pinot-batch-ingestion-hadoop` and `pinot-batch-ingestion-spark-3` continue to pass
- [x] Manual inspection confirms all usages now reference the centralized constants

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No new warnings introduced
- [x] Backward compatible -- no API/config changes