### PR TITLE
[Testing] Add unit tests to verify Prometheus JMX template regexp patterns

### DIFF
--- a/pinot-common/src/test/java/org/apache/pinot/common/metrics/prometheus/PrometheusTemplateRegexpTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/metrics/prometheus/PrometheusTemplateRegexpTest.java
@@ -77,13 +77,13 @@ public class PrometheusTemplateRegexpTest {
   // ---- Broker patterns ----
 
   /**
-   * broker.yml: meters/timers scoped to tableNameWithType.
+   * broker.yml rule 0: meters/timers scoped to tableNameWithType.
    * e.g. pinot.broker.myTable_REALTIME.queries
    */
   @Test
-  public void testBrokerTableWithTypeMeterPattern() {
-    String pattern = "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, "
-        + "name=\"?pinot\\.(\\w+)\\.((\\w+)\\.)?(\\w+)_(OFFLINE|REALTIME)\\.(\\w+)\"?><>(\\w+)";
+  public void testBrokerTableWithTypeMeterPattern()
+      throws Exception {
+    String pattern = loadPattern("broker.yml", 0);
     Matcher m = Pattern.compile(pattern).matcher(
         "\"org.apache.pinot.common.metrics\"<type=\"BrokerMetrics\", "
             + "name=\"pinot.broker.myTable_REALTIME.queries\"><>Count");
@@ -96,13 +96,13 @@ public class PrometheusTemplateRegexpTest {
   }
 
   /**
-   * broker.yml: meters/timers scoped to tableNameWithType with database prefix.
+   * broker.yml rule 0: meters/timers scoped to tableNameWithType with database prefix.
    * e.g. pinot.broker.myDb.myTable_OFFLINE.queries
    */
   @Test
-  public void testBrokerTableWithTypeMeterPatternWithDatabase() {
-    String pattern = "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, "
-        + "name=\"?pinot\\.(\\w+)\\.((\\w+)\\.)?(\\w+)_(OFFLINE|REALTIME)\\.(\\w+)\"?><>(\\w+)";
+  public void testBrokerTableWithTypeMeterPatternWithDatabase()
+      throws Exception {
+    String pattern = loadPattern("broker.yml", 0);
     Matcher m = Pattern.compile(pattern).matcher(
         "\"org.apache.pinot.common.metrics\"<type=\"BrokerMetrics\", "
             + "name=\"pinot.broker.myDb.myTable_OFFLINE.queries\"><>Count");
@@ -116,13 +116,13 @@ public class PrometheusTemplateRegexpTest {
   }
 
   /**
-   * broker.yml: meters/timers scoped to rawTableName.
+   * broker.yml rule 3: meters/timers scoped to rawTableName.
    * e.g. pinot.broker.myTable.queries
    */
   @Test
-  public void testBrokerRawTableNameMeterPattern() {
-    String pattern = "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, "
-        + "name=\"?pinot\\.(\\w+)\\.((\\w+)\\.)?(\\w+)\\.(\\w+)\"?><>(\\w+)";
+  public void testBrokerRawTableNameMeterPattern()
+      throws Exception {
+    String pattern = loadPattern("broker.yml", 3);
     Matcher m = Pattern.compile(pattern).matcher(
         "\"org.apache.pinot.common.metrics\"<type=\"BrokerMetrics\", "
             + "name=\"pinot.broker.myTable.queries\"><>Count");
@@ -134,13 +134,13 @@ public class PrometheusTemplateRegexpTest {
   }
 
   /**
-   * broker.yml: global gauge/meter/timer (no table scope).
+   * broker.yml rule 5: global gauge/meter/timer (no table scope).
    * e.g. pinot.broker.totalDocuments
    */
   @Test
-  public void testBrokerGlobalMeterPattern() {
-    String pattern = "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, "
-        + "name=\"?pinot\\.broker\\.(\\w+)\"?><>(\\w+)";
+  public void testBrokerGlobalMeterPattern()
+      throws Exception {
+    String pattern = loadPattern("broker.yml", 5);
     Matcher m = Pattern.compile(pattern).matcher(
         "\"org.apache.pinot.common.metrics\"<type=\"BrokerMetrics\", "
             + "name=\"pinot.broker.totalDocuments\"><>Value");
@@ -152,13 +152,13 @@ public class PrometheusTemplateRegexpTest {
   // ---- Server patterns ----
 
   /**
-   * server.yml: meters/timers scoped to tableNameWithType.
+   * server.yml rule 7: meters/timers scoped to tableNameWithType.
    * e.g. pinot.server.myTable_OFFLINE.segmentUploadFailure
    */
   @Test
-  public void testServerTableWithTypeMeterPattern() {
-    String pattern = "\"org\\.apache\\.pinot\\.common\\.metrics\"<type=\"ServerMetrics\", "
-        + "name=\"pinot\\.server\\.((\\w+)\\.)?(\\w+)_(OFFLINE|REALTIME)\\.(\\w+)\"><>(\\w+)";
+  public void testServerTableWithTypeMeterPattern()
+      throws Exception {
+    String pattern = loadPattern("server.yml", 7);
     Matcher m = Pattern.compile(pattern).matcher(
         "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", "
             + "name=\"pinot.server.myTable_OFFLINE.segmentUploadFailure\"><>Count");
@@ -170,13 +170,13 @@ public class PrometheusTemplateRegexpTest {
   }
 
   /**
-   * server.yml: gauge scoped to tableNameWithType with partition.
+   * server.yml rule 2: gauge scoped to tableNameWithType with partition.
    * e.g. pinot.server.queries.myTable_REALTIME.3
    */
   @Test
-  public void testServerTableWithTypeAndPartitionGaugePattern() {
-    String pattern = "\"org\\.apache\\.pinot\\.common\\.metrics\"<type=\"ServerMetrics\", "
-        + "name=\"pinot\\.server\\.(\\w+)\\.(([^.]+)\\.)?([^.]*)_(OFFLINE|REALTIME)\\.(\\w+)\"><>(\\w+)";
+  public void testServerTableWithTypeAndPartitionGaugePattern()
+      throws Exception {
+    String pattern = loadPattern("server.yml", 2);
     Matcher m = Pattern.compile(pattern).matcher(
         "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", "
             + "name=\"pinot.server.queries.myTable_REALTIME.3\"><>Value");
@@ -191,16 +191,13 @@ public class PrometheusTemplateRegexpTest {
   // ---- Controller patterns ----
 
   /**
-   * controller.yml: minion task-type gauge.
+   * controller.yml rule 2: minion task-type gauge.
    * e.g. pinot.controller.numMinionTasksInProgress.SegmentGenerationAndPush
    */
   @Test
-  public void testControllerTaskTypeGaugePattern() {
-    String pattern = "\"org\\.apache\\.pinot\\.common\\.metrics\"<type=\"ControllerMetrics\", "
-        + "name=\"pinot\\.controller\\.(numMinionTasksInProgress|numMinionSubtasksRunning|"
-        + "numMinionSubtasksWaiting|numMinionSubtasksError|numMinionSubtasksUnknown|"
-        + "numMinionSubtasksDropped|numMinionSubtasksTimedOut|numMinionSubtasksAborted|"
-        + "percentMinionSubtasksInQueue|percentMinionSubtasksInError|tasksTrackedForTaskType)\\.(\\w+)\"><>(\\w+)";
+  public void testControllerTaskTypeGaugePattern()
+      throws Exception {
+    String pattern = loadPattern("controller.yml", 2);
     Matcher m = Pattern.compile(pattern).matcher(
         "\"org.apache.pinot.common.metrics\"<type=\"ControllerMetrics\", "
             + "name=\"pinot.controller.numMinionTasksInProgress.SegmentGenerationAndPush\"><>Value");
@@ -211,13 +208,13 @@ public class PrometheusTemplateRegexpTest {
   }
 
   /**
-   * controller.yml: meters/timers scoped to tableNameWithType.
+   * controller.yml rule 10: meters/timers scoped to tableNameWithType.
    * e.g. pinot.controller.myTable_OFFLINE.segmentUploadFailure
    */
   @Test
-  public void testControllerTableWithTypeMeterPattern() {
-    String pattern = "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, "
-        + "name=\"?pinot\\.(\\w+)\\.((\\w+)\\.)?(\\w+)_(OFFLINE|REALTIME)\\.(\\w+)\"?><>(\\w+)";
+  public void testControllerTableWithTypeMeterPattern()
+      throws Exception {
+    String pattern = loadPattern("controller.yml", 10);
     Matcher m = Pattern.compile(pattern).matcher(
         "\"org.apache.pinot.common.metrics\"<type=\"ControllerMetrics\", "
             + "name=\"pinot.controller.myTable_OFFLINE.segmentUploadFailure\"><>Count");
@@ -232,13 +229,13 @@ public class PrometheusTemplateRegexpTest {
   // ---- Minion patterns ----
 
   /**
-   * minion.yml: meters/timers scoped to tableNameWithType and taskType.
+   * minion.yml rule 0: meters/timers scoped to tableNameWithType and taskType.
    * e.g. pinot.minion.myTable_REALTIME.SegmentGenerationAndPush.segmentUploadFailure
    */
   @Test
-  public void testMinionTableWithTypeAndTaskTypeMeterPattern() {
-    String pattern = "\"org\\.apache\\.pinot\\.common\\.metrics\"<type=\"MinionMetrics\", "
-        + "name=\"pinot\\.minion\\.(([^.]+)\\.)?([^.]*)_(OFFLINE|REALTIME)\\.(\\w+)\\.(\\w+)\"><>(\\w+)";
+  public void testMinionTableWithTypeAndTaskTypeMeterPattern()
+      throws Exception {
+    String pattern = loadPattern("minion.yml", 0);
     Matcher m = Pattern.compile(pattern).matcher(
         "\"org.apache.pinot.common.metrics\"<type=\"MinionMetrics\", "
             + "name=\"pinot.minion.myTable_REALTIME.SegmentGenerationAndPush.segmentUploadFailure\"><>Count");
@@ -251,13 +248,13 @@ public class PrometheusTemplateRegexpTest {
   }
 
   /**
-   * minion.yml: meters/timers accepting either rawTableName or tableNameWithType.
+   * minion.yml rule 1: meters/timers accepting either rawTableName or tableNameWithType.
    * e.g. pinot.minion.myTable.queries
    */
   @Test
-  public void testMinionTableOrIdScopedMeterPattern() {
-    String pattern = "\"org\\.apache\\.pinot\\.common\\.metrics\"<type=\"MinionMetrics\", "
-        + "name=\"pinot\\.minion\\.(\\w+)\\.(\\w+)\"><>(\\w+)";
+  public void testMinionTableOrIdScopedMeterPattern()
+      throws Exception {
+    String pattern = loadPattern("minion.yml", 1);
     Matcher m = Pattern.compile(pattern).matcher(
         "\"org.apache.pinot.common.metrics\"<type=\"MinionMetrics\", "
             + "name=\"pinot.minion.myTable.numberOfSegmentsQueued\"><>Value");
@@ -265,6 +262,19 @@ public class PrometheusTemplateRegexpTest {
     Assert.assertEquals(m.group(1), "myTable");
     Assert.assertEquals(m.group(2), "numberOfSegmentsQueued");
     Assert.assertEquals(m.group(3), "Value");
+  }
+
+  /**
+   * Returns the pattern string at the given index from the named config file.
+   * Only rules that contain a {@code pattern} field are counted.
+   */
+  private String loadPattern(String configFile, int ruleIndex)
+      throws Exception {
+    List<String> patterns = extractPatterns(CONFIG_BASE_PATH + "/" + configFile);
+    Assert.assertTrue(ruleIndex < patterns.size(),
+        "Rule index " + ruleIndex + " out of bounds for " + configFile
+            + " (has " + patterns.size() + " pattern rules)");
+    return patterns.get(ruleIndex);
   }
 
   @SuppressWarnings("unchecked")

--- a/pinot-common/src/test/java/org/apache/pinot/common/metrics/prometheus/PrometheusTemplateRegexpTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/metrics/prometheus/PrometheusTemplateRegexpTest.java
@@ -77,13 +77,13 @@ public class PrometheusTemplateRegexpTest {
   // ---- Broker patterns ----
 
   /**
-   * broker.yml rule 0: meters/timers scoped to tableNameWithType.
+   * broker.yml: meters/timers scoped to tableNameWithType.
    * e.g. pinot.broker.myTable_REALTIME.queries
    */
   @Test
   public void testBrokerTableWithTypeMeterPattern()
       throws Exception {
-    String pattern = loadPattern("broker.yml", 0);
+    String pattern = loadPatternByName("broker.yml", "pinot_$1_$6_$7");
     Matcher m = Pattern.compile(pattern).matcher(
         "\"org.apache.pinot.common.metrics\"<type=\"BrokerMetrics\", "
             + "name=\"pinot.broker.myTable_REALTIME.queries\"><>Count");
@@ -96,13 +96,13 @@ public class PrometheusTemplateRegexpTest {
   }
 
   /**
-   * broker.yml rule 0: meters/timers scoped to tableNameWithType with database prefix.
+   * broker.yml: meters/timers scoped to tableNameWithType with database prefix.
    * e.g. pinot.broker.myDb.myTable_OFFLINE.queries
    */
   @Test
   public void testBrokerTableWithTypeMeterPatternWithDatabase()
       throws Exception {
-    String pattern = loadPattern("broker.yml", 0);
+    String pattern = loadPatternByName("broker.yml", "pinot_$1_$6_$7");
     Matcher m = Pattern.compile(pattern).matcher(
         "\"org.apache.pinot.common.metrics\"<type=\"BrokerMetrics\", "
             + "name=\"pinot.broker.myDb.myTable_OFFLINE.queries\"><>Count");
@@ -116,13 +116,13 @@ public class PrometheusTemplateRegexpTest {
   }
 
   /**
-   * broker.yml rule 3: meters/timers scoped to rawTableName.
+   * broker.yml: meters/timers scoped to rawTableName.
    * e.g. pinot.broker.myTable.queries
    */
   @Test
   public void testBrokerRawTableNameMeterPattern()
       throws Exception {
-    String pattern = loadPattern("broker.yml", 3);
+    String pattern = loadPatternByName("broker.yml", "pinot_$1_$5_$6");
     Matcher m = Pattern.compile(pattern).matcher(
         "\"org.apache.pinot.common.metrics\"<type=\"BrokerMetrics\", "
             + "name=\"pinot.broker.myTable.queries\"><>Count");
@@ -134,13 +134,13 @@ public class PrometheusTemplateRegexpTest {
   }
 
   /**
-   * broker.yml rule 5: global gauge/meter/timer (no table scope).
+   * broker.yml: global gauge/meter/timer (no table scope).
    * e.g. pinot.broker.totalDocuments
    */
   @Test
   public void testBrokerGlobalMeterPattern()
       throws Exception {
-    String pattern = loadPattern("broker.yml", 5);
+    String pattern = loadPatternByName("broker.yml", "pinot_broker_$1_$2");
     Matcher m = Pattern.compile(pattern).matcher(
         "\"org.apache.pinot.common.metrics\"<type=\"BrokerMetrics\", "
             + "name=\"pinot.broker.totalDocuments\"><>Value");
@@ -152,13 +152,13 @@ public class PrometheusTemplateRegexpTest {
   // ---- Server patterns ----
 
   /**
-   * server.yml rule 7: meters/timers scoped to tableNameWithType.
+   * server.yml: meters/timers scoped to tableNameWithType.
    * e.g. pinot.server.myTable_OFFLINE.segmentUploadFailure
    */
   @Test
   public void testServerTableWithTypeMeterPattern()
       throws Exception {
-    String pattern = loadPattern("server.yml", 7);
+    String pattern = loadPatternByName("server.yml", "pinot_server_$5_$6");
     Matcher m = Pattern.compile(pattern).matcher(
         "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", "
             + "name=\"pinot.server.myTable_OFFLINE.segmentUploadFailure\"><>Count");
@@ -170,13 +170,13 @@ public class PrometheusTemplateRegexpTest {
   }
 
   /**
-   * server.yml rule 2: gauge scoped to tableNameWithType with partition.
+   * server.yml: gauge scoped to tableNameWithType with partition.
    * e.g. pinot.server.queries.myTable_REALTIME.3
    */
   @Test
   public void testServerTableWithTypeAndPartitionGaugePattern()
       throws Exception {
-    String pattern = loadPattern("server.yml", 2);
+    String pattern = loadPatternByName("server.yml", "pinot_server_$1_$7");
     Matcher m = Pattern.compile(pattern).matcher(
         "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", "
             + "name=\"pinot.server.queries.myTable_REALTIME.3\"><>Value");
@@ -191,13 +191,13 @@ public class PrometheusTemplateRegexpTest {
   // ---- Controller patterns ----
 
   /**
-   * controller.yml rule 2: minion task-type gauge.
+   * controller.yml: minion task-type gauge.
    * e.g. pinot.controller.numMinionTasksInProgress.SegmentGenerationAndPush
    */
   @Test
   public void testControllerTaskTypeGaugePattern()
       throws Exception {
-    String pattern = loadPattern("controller.yml", 2);
+    String pattern = loadPatternByName("controller.yml", "pinot_controller_$1_$3");
     Matcher m = Pattern.compile(pattern).matcher(
         "\"org.apache.pinot.common.metrics\"<type=\"ControllerMetrics\", "
             + "name=\"pinot.controller.numMinionTasksInProgress.SegmentGenerationAndPush\"><>Value");
@@ -208,13 +208,13 @@ public class PrometheusTemplateRegexpTest {
   }
 
   /**
-   * controller.yml rule 10: meters/timers scoped to tableNameWithType.
+   * controller.yml: meters/timers scoped to tableNameWithType.
    * e.g. pinot.controller.myTable_OFFLINE.segmentUploadFailure
    */
   @Test
   public void testControllerTableWithTypeMeterPattern()
       throws Exception {
-    String pattern = loadPattern("controller.yml", 10);
+    String pattern = loadPatternByName("controller.yml", "pinot_$1_$6_$7");
     Matcher m = Pattern.compile(pattern).matcher(
         "\"org.apache.pinot.common.metrics\"<type=\"ControllerMetrics\", "
             + "name=\"pinot.controller.myTable_OFFLINE.segmentUploadFailure\"><>Count");
@@ -229,13 +229,13 @@ public class PrometheusTemplateRegexpTest {
   // ---- Minion patterns ----
 
   /**
-   * minion.yml rule 0: meters/timers scoped to tableNameWithType and taskType.
+   * minion.yml: meters/timers scoped to tableNameWithType and taskType.
    * e.g. pinot.minion.myTable_REALTIME.SegmentGenerationAndPush.segmentUploadFailure
    */
   @Test
   public void testMinionTableWithTypeAndTaskTypeMeterPattern()
       throws Exception {
-    String pattern = loadPattern("minion.yml", 0);
+    String pattern = loadPatternByName("minion.yml", "pinot_minion_$6_$7");
     Matcher m = Pattern.compile(pattern).matcher(
         "\"org.apache.pinot.common.metrics\"<type=\"MinionMetrics\", "
             + "name=\"pinot.minion.myTable_REALTIME.SegmentGenerationAndPush.segmentUploadFailure\"><>Count");
@@ -248,13 +248,13 @@ public class PrometheusTemplateRegexpTest {
   }
 
   /**
-   * minion.yml rule 1: meters/timers accepting either rawTableName or tableNameWithType.
+   * minion.yml: meters/timers accepting either rawTableName or tableNameWithType.
    * e.g. pinot.minion.myTable.queries
    */
   @Test
   public void testMinionTableOrIdScopedMeterPattern()
       throws Exception {
-    String pattern = loadPattern("minion.yml", 1);
+    String pattern = loadPatternByName("minion.yml", "pinot_minion_$2_$3");
     Matcher m = Pattern.compile(pattern).matcher(
         "\"org.apache.pinot.common.metrics\"<type=\"MinionMetrics\", "
             + "name=\"pinot.minion.myTable.numberOfSegmentsQueued\"><>Value");
@@ -265,16 +265,25 @@ public class PrometheusTemplateRegexpTest {
   }
 
   /**
-   * Returns the pattern string at the given index from the named config file.
-   * Only rules that contain a {@code pattern} field are counted.
+   * Returns the pattern string for the rule whose {@code name} field equals {@code ruleName}.
+   * Keying off the rule name survives YAML rule reorderings — inserting or moving a rule in
+   * the config file will not silently shift the index and cause this test to assert against
+   * the wrong pattern.
    */
-  private String loadPattern(String configFile, int ruleIndex)
+  @SuppressWarnings("unchecked")
+  private String loadPatternByName(String configFile, String ruleName)
       throws Exception {
-    List<String> patterns = extractPatterns(CONFIG_BASE_PATH + "/" + configFile);
-    Assert.assertTrue(ruleIndex < patterns.size(),
-        "Rule index " + ruleIndex + " out of bounds for " + configFile
-            + " (has " + patterns.size() + " pattern rules)");
-    return patterns.get(ruleIndex);
+    Yaml yaml = new Yaml();
+    try (FileReader reader = new FileReader(CONFIG_BASE_PATH + "/" + configFile)) {
+      Map<String, Object> config = yaml.load(reader);
+      List<Map<String, Object>> rules = (List<Map<String, Object>>) config.get("rules");
+      return rules.stream()
+          .filter(rule -> ruleName.equals(rule.get("name")))
+          .map(rule -> (String) rule.get("pattern"))
+          .findFirst()
+          .orElseThrow(() -> new IllegalArgumentException(
+              "No rule with name '" + ruleName + "' found in " + configFile));
+    }
   }
 
   @SuppressWarnings("unchecked")

--- a/pinot-common/src/test/java/org/apache/pinot/common/metrics/prometheus/PrometheusTemplateRegexpTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/metrics/prometheus/PrometheusTemplateRegexpTest.java
@@ -1,0 +1,283 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.metrics.prometheus;
+
+import java.io.FileReader;
+import java.util.List;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+import java.util.stream.Collectors;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+import org.yaml.snakeyaml.Yaml;
+
+
+/**
+ * Verifies that the Prometheus JMX template regexp patterns defined in the docker config YAML files
+ * are valid Java regexps and match expected JMX metric name strings with correct capture groups.
+ *
+ * Config files under test: docker/images/pinot/etc/jmx_prometheus_javaagent/configs/
+ *
+ * @see <a href="https://github.com/apache/pinot/issues/13588">Issue #13588</a>
+ */
+public class PrometheusTemplateRegexpTest {
+
+  private static final String CONFIG_BASE_PATH =
+      "../docker/images/pinot/etc/jmx_prometheus_javaagent/configs";
+
+  @DataProvider(name = "configFiles")
+  public Object[][] configFiles() {
+    return new Object[][]{
+        {"broker.yml"},
+        {"server.yml"},
+        {"controller.yml"},
+        {"minion.yml"},
+        {"pinot.yml"}
+    };
+  }
+
+  /**
+   * Verifies every pattern in each YAML config file compiles as a valid Java regexp.
+   */
+  @Test(dataProvider = "configFiles")
+  public void testAllPatternsAreValidRegexp(String configFile)
+      throws Exception {
+    List<String> patterns = extractPatterns(CONFIG_BASE_PATH + "/" + configFile);
+    Assert.assertFalse(patterns.isEmpty(),
+        "Expected at least one rule pattern in " + configFile);
+    for (String patternStr : patterns) {
+      try {
+        Pattern.compile(patternStr);
+      } catch (PatternSyntaxException e) {
+        Assert.fail(
+            "Invalid regexp in " + configFile + ": [" + patternStr + "] - " + e.getDescription());
+      }
+    }
+  }
+
+  // ---- Broker patterns ----
+
+  /**
+   * broker.yml: meters/timers scoped to tableNameWithType.
+   * e.g. pinot.broker.myTable_REALTIME.queries
+   */
+  @Test
+  public void testBrokerTableWithTypeMeterPattern() {
+    String pattern = "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, "
+        + "name=\"?pinot\\.(\\w+)\\.((\\w+)\\.)?(\\w+)_(OFFLINE|REALTIME)\\.(\\w+)\"?><>(\\w+)";
+    Matcher m = Pattern.compile(pattern).matcher(
+        "\"org.apache.pinot.common.metrics\"<type=\"BrokerMetrics\", "
+            + "name=\"pinot.broker.myTable_REALTIME.queries\"><>Count");
+    Assert.assertTrue(m.matches(), "Pattern should match broker table-scoped meter");
+    Assert.assertEquals(m.group(1), "broker");
+    Assert.assertEquals(m.group(4), "myTable");
+    Assert.assertEquals(m.group(5), "REALTIME");
+    Assert.assertEquals(m.group(6), "queries");
+    Assert.assertEquals(m.group(7), "Count");
+  }
+
+  /**
+   * broker.yml: meters/timers scoped to tableNameWithType with database prefix.
+   * e.g. pinot.broker.myDb.myTable_OFFLINE.queries
+   */
+  @Test
+  public void testBrokerTableWithTypeMeterPatternWithDatabase() {
+    String pattern = "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, "
+        + "name=\"?pinot\\.(\\w+)\\.((\\w+)\\.)?(\\w+)_(OFFLINE|REALTIME)\\.(\\w+)\"?><>(\\w+)";
+    Matcher m = Pattern.compile(pattern).matcher(
+        "\"org.apache.pinot.common.metrics\"<type=\"BrokerMetrics\", "
+            + "name=\"pinot.broker.myDb.myTable_OFFLINE.queries\"><>Count");
+    Assert.assertTrue(m.matches(), "Pattern should match broker table-scoped meter with database prefix");
+    Assert.assertEquals(m.group(1), "broker");
+    Assert.assertEquals(m.group(3), "myDb");
+    Assert.assertEquals(m.group(4), "myTable");
+    Assert.assertEquals(m.group(5), "OFFLINE");
+    Assert.assertEquals(m.group(6), "queries");
+    Assert.assertEquals(m.group(7), "Count");
+  }
+
+  /**
+   * broker.yml: meters/timers scoped to rawTableName.
+   * e.g. pinot.broker.myTable.queries
+   */
+  @Test
+  public void testBrokerRawTableNameMeterPattern() {
+    String pattern = "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, "
+        + "name=\"?pinot\\.(\\w+)\\.((\\w+)\\.)?(\\w+)\\.(\\w+)\"?><>(\\w+)";
+    Matcher m = Pattern.compile(pattern).matcher(
+        "\"org.apache.pinot.common.metrics\"<type=\"BrokerMetrics\", "
+            + "name=\"pinot.broker.myTable.queries\"><>Count");
+    Assert.assertTrue(m.matches(), "Pattern should match broker raw-table-name meter");
+    Assert.assertEquals(m.group(1), "broker");
+    Assert.assertEquals(m.group(4), "myTable");
+    Assert.assertEquals(m.group(5), "queries");
+    Assert.assertEquals(m.group(6), "Count");
+  }
+
+  /**
+   * broker.yml: global gauge/meter/timer (no table scope).
+   * e.g. pinot.broker.totalDocuments
+   */
+  @Test
+  public void testBrokerGlobalMeterPattern() {
+    String pattern = "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, "
+        + "name=\"?pinot\\.broker\\.(\\w+)\"?><>(\\w+)";
+    Matcher m = Pattern.compile(pattern).matcher(
+        "\"org.apache.pinot.common.metrics\"<type=\"BrokerMetrics\", "
+            + "name=\"pinot.broker.totalDocuments\"><>Value");
+    Assert.assertTrue(m.matches(), "Pattern should match global broker gauge");
+    Assert.assertEquals(m.group(1), "totalDocuments");
+    Assert.assertEquals(m.group(2), "Value");
+  }
+
+  // ---- Server patterns ----
+
+  /**
+   * server.yml: meters/timers scoped to tableNameWithType.
+   * e.g. pinot.server.myTable_OFFLINE.segmentUploadFailure
+   */
+  @Test
+  public void testServerTableWithTypeMeterPattern() {
+    String pattern = "\"org\\.apache\\.pinot\\.common\\.metrics\"<type=\"ServerMetrics\", "
+        + "name=\"pinot\\.server\\.((\\w+)\\.)?(\\w+)_(OFFLINE|REALTIME)\\.(\\w+)\"><>(\\w+)";
+    Matcher m = Pattern.compile(pattern).matcher(
+        "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", "
+            + "name=\"pinot.server.myTable_OFFLINE.segmentUploadFailure\"><>Count");
+    Assert.assertTrue(m.matches(), "Pattern should match server table-scoped meter");
+    Assert.assertEquals(m.group(3), "myTable");
+    Assert.assertEquals(m.group(4), "OFFLINE");
+    Assert.assertEquals(m.group(5), "segmentUploadFailure");
+    Assert.assertEquals(m.group(6), "Count");
+  }
+
+  /**
+   * server.yml: gauge scoped to tableNameWithType with partition.
+   * e.g. pinot.server.queries.myTable_REALTIME.3
+   */
+  @Test
+  public void testServerTableWithTypeAndPartitionGaugePattern() {
+    String pattern = "\"org\\.apache\\.pinot\\.common\\.metrics\"<type=\"ServerMetrics\", "
+        + "name=\"pinot\\.server\\.(\\w+)\\.(([^.]+)\\.)?([^.]*)_(OFFLINE|REALTIME)\\.(\\w+)\"><>(\\w+)";
+    Matcher m = Pattern.compile(pattern).matcher(
+        "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", "
+            + "name=\"pinot.server.queries.myTable_REALTIME.3\"><>Value");
+    Assert.assertTrue(m.matches(), "Pattern should match server table-scoped gauge with partition");
+    Assert.assertEquals(m.group(1), "queries");
+    Assert.assertEquals(m.group(4), "myTable");
+    Assert.assertEquals(m.group(5), "REALTIME");
+    Assert.assertEquals(m.group(6), "3");
+    Assert.assertEquals(m.group(7), "Value");
+  }
+
+  // ---- Controller patterns ----
+
+  /**
+   * controller.yml: minion task-type gauge.
+   * e.g. pinot.controller.numMinionTasksInProgress.SegmentGenerationAndPush
+   */
+  @Test
+  public void testControllerTaskTypeGaugePattern() {
+    String pattern = "\"org\\.apache\\.pinot\\.common\\.metrics\"<type=\"ControllerMetrics\", "
+        + "name=\"pinot\\.controller\\.(numMinionTasksInProgress|numMinionSubtasksRunning|"
+        + "numMinionSubtasksWaiting|numMinionSubtasksError|numMinionSubtasksUnknown|"
+        + "numMinionSubtasksDropped|numMinionSubtasksTimedOut|numMinionSubtasksAborted|"
+        + "percentMinionSubtasksInQueue|percentMinionSubtasksInError|tasksTrackedForTaskType)\\.(\\w+)\"><>(\\w+)";
+    Matcher m = Pattern.compile(pattern).matcher(
+        "\"org.apache.pinot.common.metrics\"<type=\"ControllerMetrics\", "
+            + "name=\"pinot.controller.numMinionTasksInProgress.SegmentGenerationAndPush\"><>Value");
+    Assert.assertTrue(m.matches(), "Pattern should match controller task-type gauge");
+    Assert.assertEquals(m.group(1), "numMinionTasksInProgress");
+    Assert.assertEquals(m.group(2), "SegmentGenerationAndPush");
+    Assert.assertEquals(m.group(3), "Value");
+  }
+
+  /**
+   * controller.yml: meters/timers scoped to tableNameWithType.
+   * e.g. pinot.controller.myTable_OFFLINE.segmentUploadFailure
+   */
+  @Test
+  public void testControllerTableWithTypeMeterPattern() {
+    String pattern = "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, "
+        + "name=\"?pinot\\.(\\w+)\\.((\\w+)\\.)?(\\w+)_(OFFLINE|REALTIME)\\.(\\w+)\"?><>(\\w+)";
+    Matcher m = Pattern.compile(pattern).matcher(
+        "\"org.apache.pinot.common.metrics\"<type=\"ControllerMetrics\", "
+            + "name=\"pinot.controller.myTable_OFFLINE.segmentUploadFailure\"><>Count");
+    Assert.assertTrue(m.matches(), "Pattern should match controller table-scoped meter");
+    Assert.assertEquals(m.group(1), "controller");
+    Assert.assertEquals(m.group(4), "myTable");
+    Assert.assertEquals(m.group(5), "OFFLINE");
+    Assert.assertEquals(m.group(6), "segmentUploadFailure");
+    Assert.assertEquals(m.group(7), "Count");
+  }
+
+  // ---- Minion patterns ----
+
+  /**
+   * minion.yml: meters/timers scoped to tableNameWithType and taskType.
+   * e.g. pinot.minion.myTable_REALTIME.SegmentGenerationAndPush.segmentUploadFailure
+   */
+  @Test
+  public void testMinionTableWithTypeAndTaskTypeMeterPattern() {
+    String pattern = "\"org\\.apache\\.pinot\\.common\\.metrics\"<type=\"MinionMetrics\", "
+        + "name=\"pinot\\.minion\\.(([^.]+)\\.)?([^.]*)_(OFFLINE|REALTIME)\\.(\\w+)\\.(\\w+)\"><>(\\w+)";
+    Matcher m = Pattern.compile(pattern).matcher(
+        "\"org.apache.pinot.common.metrics\"<type=\"MinionMetrics\", "
+            + "name=\"pinot.minion.myTable_REALTIME.SegmentGenerationAndPush.segmentUploadFailure\"><>Count");
+    Assert.assertTrue(m.matches(), "Pattern should match minion table + taskType scoped meter");
+    Assert.assertEquals(m.group(3), "myTable");
+    Assert.assertEquals(m.group(4), "REALTIME");
+    Assert.assertEquals(m.group(5), "SegmentGenerationAndPush");
+    Assert.assertEquals(m.group(6), "segmentUploadFailure");
+    Assert.assertEquals(m.group(7), "Count");
+  }
+
+  /**
+   * minion.yml: meters/timers accepting either rawTableName or tableNameWithType.
+   * e.g. pinot.minion.myTable.queries
+   */
+  @Test
+  public void testMinionTableOrIdScopedMeterPattern() {
+    String pattern = "\"org\\.apache\\.pinot\\.common\\.metrics\"<type=\"MinionMetrics\", "
+        + "name=\"pinot\\.minion\\.(\\w+)\\.(\\w+)\"><>(\\w+)";
+    Matcher m = Pattern.compile(pattern).matcher(
+        "\"org.apache.pinot.common.metrics\"<type=\"MinionMetrics\", "
+            + "name=\"pinot.minion.myTable.numberOfSegmentsQueued\"><>Value");
+    Assert.assertTrue(m.matches(), "Pattern should match minion table/id scoped meter");
+    Assert.assertEquals(m.group(1), "myTable");
+    Assert.assertEquals(m.group(2), "numberOfSegmentsQueued");
+    Assert.assertEquals(m.group(3), "Value");
+  }
+
+  @SuppressWarnings("unchecked")
+  private List<String> extractPatterns(String filePath)
+      throws Exception {
+    Yaml yaml = new Yaml();
+    try (FileReader reader = new FileReader(filePath)) {
+      Map<String, Object> config = yaml.load(reader);
+      List<Map<String, Object>> rules = (List<Map<String, Object>>) config.get("rules");
+      return rules.stream()
+          .filter(rule -> rule.containsKey("pattern"))
+          .map(rule -> (String) rule.get("pattern"))
+          .collect(Collectors.toList());
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Closes #13588

Adds `PrometheusTemplateRegexpTest` to validate the regexp patterns defined in the JMX exporter YAML config files under `docker/images/pinot/etc/jmx_prometheus_javaagent/configs/`.

**What the tests cover:**
- **Parameterized validity check**: verifies all patterns in `broker.yml`, `server.yml`, `controller.yml`, `minion.yml`, and `pinot.yml` compile as valid Java regexps — catches syntax errors introduced when editing these files
- **Targeted correctness tests** for key patterns across all four components, verifying that expected JMX metric name strings match and that capture groups produce correct label values (`table`, `tableType`, `database`, `taskType`, measurement type)

**Test cases included:**
| Component | Pattern | JMX sample |
|---|---|---|
| Broker | meter scoped to tableNameWithType | `pinot.broker.myTable_REALTIME.queries` |
| Broker | meter scoped to tableNameWithType + database prefix | `pinot.broker.myDb.myTable_OFFLINE.queries` |
| Broker | meter scoped to rawTableName | `pinot.broker.myTable.queries` |
| Broker | global gauge | `pinot.broker.totalDocuments` |
| Server | meter scoped to tableNameWithType | `pinot.server.myTable_OFFLINE.segmentUploadFailure` |
| Server | gauge scoped to tableNameWithType + partition | `pinot.server.queries.myTable_REALTIME.3` |
| Controller | task-type gauge | `pinot.controller.numMinionTasksInProgress.SegmentGenerationAndPush` |
| Controller | meter scoped to tableNameWithType | `pinot.controller.myTable_OFFLINE.segmentUploadFailure` |
| Minion | meter scoped to tableNameWithType + taskType | `pinot.minion.myTable_REALTIME.SegmentGenerationAndPush.segmentUploadFailure` |
| Minion | meter scoped to table/id | `pinot.minion.myTable.numberOfSegmentsQueued` |

## Test plan

- [x] `mvn -pl pinot-common test -Dtest=PrometheusTemplateRegexpTest` passes locally
- [x] Parameterized test covers all 5 YAML files

