### PR TITLE
Add post-GC heap and executor queue depth gauges to controller metrics

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
@@ -37,6 +37,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import javax.inject.Singleton;
 import javax.net.ssl.SSLContext;
@@ -163,6 +164,7 @@ import org.apache.pinot.spi.utils.ConsumingSegmentConsistencyModeListener;
 import org.apache.pinot.spi.utils.InstanceTypeUtils;
 import org.apache.pinot.spi.utils.NetUtils;
 import org.apache.pinot.spi.utils.PinotMd5Mode;
+import org.apache.pinot.spi.utils.ResourceUsageUtils;
 import org.apache.pinot.sql.parsers.rewriter.QueryRewriterFactory;
 import org.glassfish.hk2.utilities.binding.AbstractBinder;
 import org.slf4j.Logger;
@@ -898,6 +900,13 @@ public abstract class BaseControllerStarter implements ServiceStartable {
         Integer.getInteger(ZkSystemPropertyKeys.JUTE_MAXBUFFER, 0xfffff));
     ControllerMetrics.register(_controllerMetrics);
     _validationMetrics = new ValidationMetrics(_metricsRegistry);
+
+    _controllerMetrics.setOrUpdateGauge("jvmHeapUsedAfterGc", ResourceUsageUtils::getHeapUsedAfterGc);
+    if (_executorService instanceof ThreadPoolExecutor) {
+      ThreadPoolExecutor tpe = (ThreadPoolExecutor) _executorService;
+      _controllerMetrics.setOrUpdateGauge("asyncExecutorQueueDepth", () -> (long) tpe.getQueue().size());
+      _controllerMetrics.setOrUpdateGauge("asyncExecutorActiveThreads", () -> (long) tpe.getActiveCount());
+    }
   }
 
   private void initPinotFSFactory() {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/ResourceUsageUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/ResourceUsageUtils.java
@@ -20,7 +20,9 @@ package org.apache.pinot.spi.utils;
 
 import java.lang.management.ManagementFactory;
 import java.lang.management.MemoryMXBean;
+import java.lang.management.MemoryPoolMXBean;
 import java.lang.management.MemoryUsage;
+import java.util.List;
 
 
 public class ResourceUsageUtils {
@@ -39,5 +41,22 @@ public class ResourceUsageUtils {
 
   public static long getUsedHeapSize() {
     return MEMORY_MX_BEAN.getHeapMemoryUsage().getUsed();
+  }
+
+  /**
+   * Returns heap bytes used immediately after the last GC, summed across all memory pools.
+   * More stable than {@link #getUsedHeapSize()} because it excludes short-lived objects allocated
+   * since the last collection.
+   */
+  public static long getHeapUsedAfterGc() {
+    long total = 0;
+    List<MemoryPoolMXBean> pools = ManagementFactory.getMemoryPoolMXBeans();
+    for (MemoryPoolMXBean pool : pools) {
+      MemoryUsage collectionUsage = pool.getCollectionUsage();
+      if (collectionUsage != null && collectionUsage.getUsed() >= 0) {
+        total += collectionUsage.getUsed();
+      }
+    }
+    return total;
   }
 }


### PR DESCRIPTION
- Add ResourceUsageUtils.getHeapUsedAfterGc() which sums collectionUsage across all JVM memory pools to give a stable, post-GC heap reading
- Register jvmHeapUsedAfterGc gauge in BaseControllerStarter on startup
- Register asyncExecutorQueueDepth and asyncExecutorActiveThreads gauges when the controller executor is a fixed ThreadPoolExecutor, providing visibility into queue backpressure