### PR TITLE
Add scalar functions: PostgreSQL-compliance math, string, trig, and IP utilities

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/ArithmeticFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/ArithmeticFunctions.java
@@ -259,4 +259,65 @@ public class ArithmeticFunctions {
   public static int bitCount(long a) {
     return Long.bitCount(a);
   }
+
+  // Precomputed factorials for 0! through 20! (21! overflows long).
+  private static final long[] FACTORIALS = new long[21];
+
+  static {
+    FACTORIALS[0] = 1;
+    for (int i = 1; i < FACTORIALS.length; i++) {
+      FACTORIALS[i] = FACTORIALS[i - 1] * i;
+    }
+  }
+
+  /**
+   * Returns the factorial of the given non-negative integer.
+   *
+   * @param n non-negative integer (0 to 20)
+   * @return n! as a long
+   * @throws IllegalArgumentException if n is negative or greater than 20
+   */
+  @ScalarFunction
+  public static long factorial(long n) {
+    if (n < 0 || n > 20) {
+      throw new IllegalArgumentException("factorial argument must be between 0 and 20, got " + n);
+    }
+    return FACTORIALS[(int) n];
+  }
+
+  /**
+   * Returns the bucket number for a value in a histogram with the given bounds and number of buckets.
+   *
+   * <p>SQL standard semantics: returns 0 if value < lo, numBuckets + 1 if value >= hi,
+   * otherwise a bucket in the range [1, numBuckets].
+   *
+   * @param value the value to bucket
+   * @param lo lower bound of the histogram (inclusive)
+   * @param hi upper bound of the histogram (exclusive)
+   * @param numBuckets number of equal-width buckets
+   * @return bucket number (0 to numBuckets + 1)
+   * @throws IllegalArgumentException if lo >= hi or numBuckets <= 0
+   */
+  @ScalarFunction(names = {"widthBucket", "width_bucket"})
+  public static int widthBucket(double value, double lo, double hi, int numBuckets) {
+    if (Double.isNaN(value) || Double.isNaN(lo) || Double.isNaN(hi)) {
+      throw new IllegalArgumentException("widthBucket does not accept NaN values");
+    }
+    if (Double.isInfinite(lo) || Double.isInfinite(hi)) {
+      throw new IllegalArgumentException("widthBucket bounds must be finite");
+    }
+    if (lo >= hi) {
+      throw new IllegalArgumentException("lo must be less than hi: lo=" + lo + ", hi=" + hi);
+    }
+    if (numBuckets <= 0) {
+      throw new IllegalArgumentException("numBuckets must be positive, got " + numBuckets);
+    }
+    if (value < lo) {
+      return 0;
+    }
+    if (value >= hi) {
+      return numBuckets + 1;
+    }
+    return (int) ((value - lo) / (hi - lo) * numBuckets) + 1;
+  }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/IpAddressFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/IpAddressFunctions.java
@@ -251,4 +251,86 @@ public class IpAddressFunctions {
     String max = prefix.getUpper().withoutPrefixLength().toCanonicalString();
     return new String[]{min, max};
   }
+
+  /**
+   * Returns the IP version family: 4 for IPv4, 6 for IPv6.
+   *
+   * @param ipString IP address string (e.g., "192.168.1.1" or "2001:db8::1")
+   * @return 4 or 6
+   * @throws IllegalArgumentException if the string is not a valid IP address
+   */
+  @ScalarFunction(names = {"ipFamily", "ip_family"})
+  public static int ipFamily(String ipString) {
+    IPAddress addr = getAddress(ipString);
+    return addr.isIPv4() ? 4 : 6;
+  }
+
+  /**
+   * Extracts the prefix length (mask length) from a CIDR notation string.
+   *
+   * @param cidr CIDR string (e.g., "192.168.1.0/24" or "2001:db8::/32")
+   * @return the prefix length (e.g., 24)
+   * @throws IllegalArgumentException if the input is not a valid CIDR prefix
+   */
+  @ScalarFunction(names = {"ipMaskLen", "ip_mask_len"})
+  public static int ipMaskLen(String cidr) {
+    IPAddress prefix = getPrefix(cidr);
+    return prefix.getNetworkPrefixLength();
+  }
+
+  /**
+   * Builds a network or host mask for the given prefix.
+   *
+   * @param prefix the validated CIDR prefix
+   * @param invert false for network mask (1s in network portion), true for host mask (1s in host portion)
+   * @return mask as an IP address string
+   */
+  private static String buildMask(IPAddress prefix, boolean invert) {
+    int prefixLen = prefix.getNetworkPrefixLength();
+    int bitCount = prefix.getBitCount();
+    byte[] maskBytes = new byte[bitCount / 8];
+    int fullBytes = prefixLen / 8;
+    int remainingBits = prefixLen % 8;
+    // Build network mask: 1s for network portion, 0s for host portion
+    for (int i = 0; i < fullBytes; i++) {
+      maskBytes[i] = (byte) 0xFF;
+    }
+    if (remainingBits > 0 && fullBytes < maskBytes.length) {
+      maskBytes[fullBytes] = (byte) (0xFF << (8 - remainingBits));
+    }
+    // Invert for host mask
+    if (invert) {
+      for (int i = 0; i < maskBytes.length; i++) {
+        maskBytes[i] = (byte) ~maskBytes[i];
+      }
+    }
+    if (prefix.isIPv4()) {
+      return new IPv4Address(maskBytes).toCanonicalString();
+    }
+    return new IPv6Address(maskBytes).toCanonicalString();
+  }
+
+  /**
+   * Returns the network mask for a CIDR prefix as an IP address string.
+   *
+   * @param cidr CIDR string (e.g., "192.168.1.0/24")
+   * @return network mask string (e.g., "255.255.255.0")
+   * @throws IllegalArgumentException if the input is not a valid CIDR prefix
+   */
+  @ScalarFunction(names = {"ipNetmask", "ip_netmask"})
+  public static String ipNetmask(String cidr) {
+    return buildMask(getPrefix(cidr), false);
+  }
+
+  /**
+   * Returns the host mask (inverse of network mask) for a CIDR prefix as an IP address string.
+   *
+   * @param cidr CIDR string (e.g., "192.168.1.0/24")
+   * @return host mask string (e.g., "0.0.0.255")
+   * @throws IllegalArgumentException if the input is not a valid CIDR prefix
+   */
+  @ScalarFunction(names = {"ipHostmask", "ip_hostmask"})
+  public static String ipHostmask(String cidr) {
+    return buildMask(getPrefix(cidr), true);
+  }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
@@ -25,6 +25,8 @@ import java.nio.charset.StandardCharsets;
 import java.text.Normalizer;
 import java.util.Base64;
 import java.util.UUID;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import javax.annotation.Nullable;
 import org.apache.commons.codec.language.Soundex;
 import org.apache.commons.lang3.StringUtils;
@@ -1053,5 +1055,76 @@ public class StringFunctions {
       }
     }
     return true;
+  }
+
+  /**
+   * Returns the number of bytes in the UTF-8 representation of the string.
+   *
+   * @param input the input string
+   * @return byte length of the UTF-8 encoded string
+   */
+  @ScalarFunction(names = {"octetLength", "octet_length"})
+  public static int octetLength(String input) {
+    return input.getBytes(StandardCharsets.UTF_8).length;
+  }
+
+  /**
+   * Returns the number of bits in the UTF-8 representation of the string.
+   *
+   * @param input the input string
+   * @return bit length of the UTF-8 encoded string
+   */
+  @ScalarFunction(names = {"bitLength", "bit_length"})
+  public static int bitLength(String input) {
+    return octetLength(input) * 8;
+  }
+
+  /**
+   * Returns the number of Unicode codepoints in the string.
+   * Unlike {@link #length(String)}, this correctly counts supplementary characters (e.g., emoji) as one.
+   *
+   * @param input the input string
+   * @return number of Unicode codepoints
+   */
+  @ScalarFunction(names = {"charLength", "char_length", "characterLength", "character_length"})
+  public static int charLength(String input) {
+    return input.codePointCount(0, input.length());
+  }
+
+  /**
+   * Returns the number of non-overlapping matches of a regular expression pattern in the string.
+   *
+   * <p>Note: the pattern is compiled on every invocation. For constant-pattern queries, consider
+   * adding a {@code RegexpCountConstFunctions} variant in the {@code regexp/} package.
+   *
+   * @param input the input string
+   * @param regexp the regular expression pattern
+   * @return count of non-overlapping matches
+   */
+  @ScalarFunction(names = {"regexpCount", "regexp_count"})
+  public static int regexpCount(String input, String regexp) {
+    Matcher matcher = Pattern.compile(regexp).matcher(input);
+    int count = 0;
+    while (matcher.find()) {
+      count++;
+    }
+    return count;
+  }
+
+  /**
+   * Returns the first substring that matches the regular expression, or null if no match is found.
+   *
+   * <p>Note: the pattern is compiled on every invocation. For constant-pattern queries, consider
+   * adding a {@code RegexpSubstrConstFunctions} variant in the {@code regexp/} package.
+   *
+   * @param input the input string
+   * @param regexp the regular expression pattern
+   * @return the first matching substring, or null if no match
+   */
+  @Nullable
+  @ScalarFunction(names = {"regexpSubstr", "regexp_substr"})
+  public static String regexpSubstr(String input, String regexp) {
+    Matcher matcher = Pattern.compile(regexp).matcher(input);
+    return matcher.find() ? matcher.group() : null;
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/TrigonometricFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/TrigonometricFunctions.java
@@ -88,4 +88,26 @@ public class TrigonometricFunctions {
   public static double radians(double a) {
     return Math.toRadians(a);
   }
+
+  /** Returns the inverse hyperbolic sine of the given value. */
+  @ScalarFunction
+  public static double asinh(double a) {
+    // Use sign-separated formula to avoid -Inf + Inf cancellation for large negative values.
+    if (a >= 0) {
+      return Math.log(a + Math.sqrt(a * a + 1));
+    }
+    return -Math.log(-a + Math.sqrt(a * a + 1));
+  }
+
+  /** Returns the inverse hyperbolic cosine of the given value. Domain: a >= 1. */
+  @ScalarFunction
+  public static double acosh(double a) {
+    return Math.log(a + Math.sqrt(a * a - 1));
+  }
+
+  /** Returns the inverse hyperbolic tangent of the given value. Domain: -1 < a < 1. */
+  @ScalarFunction
+  public static double atanh(double a) {
+    return 0.5 * Math.log((1 + a) / (1 - a));
+  }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/common/function/scalar/ArithmeticFunctionsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/function/scalar/ArithmeticFunctionsTest.java
@@ -21,6 +21,7 @@ package org.apache.pinot.common.function.scalar;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 
 
@@ -113,5 +114,69 @@ public class ArithmeticFunctionsTest {
     // int values promoted to long
     assertEquals(ArithmeticFunctions.bitCount((long) Integer.MAX_VALUE), 31);
     assertEquals(ArithmeticFunctions.bitCount((long) Integer.MIN_VALUE), 33);
+  }
+
+  @Test
+  public void testFactorial() {
+    assertEquals(ArithmeticFunctions.factorial(0), 1L);
+    assertEquals(ArithmeticFunctions.factorial(1), 1L);
+    assertEquals(ArithmeticFunctions.factorial(2), 2L);
+    assertEquals(ArithmeticFunctions.factorial(5), 120L);
+    assertEquals(ArithmeticFunctions.factorial(10), 3628800L);
+    assertEquals(ArithmeticFunctions.factorial(20), 2432902008176640000L);
+  }
+
+  @Test
+  public void testFactorialInvalid() {
+    assertThrows(IllegalArgumentException.class, () -> ArithmeticFunctions.factorial(-1));
+    assertThrows(IllegalArgumentException.class, () -> ArithmeticFunctions.factorial(21));
+  }
+
+  @Test
+  public void testWidthBucket() {
+    // Values within range
+    assertEquals(ArithmeticFunctions.widthBucket(5.0, 0.0, 10.0, 5), 3);
+    assertEquals(ArithmeticFunctions.widthBucket(0.0, 0.0, 10.0, 5), 1);
+    assertEquals(ArithmeticFunctions.widthBucket(1.99, 0.0, 10.0, 5), 1);
+    assertEquals(ArithmeticFunctions.widthBucket(2.0, 0.0, 10.0, 5), 2);
+    assertEquals(ArithmeticFunctions.widthBucket(9.99, 0.0, 10.0, 5), 5);
+
+    // Below range
+    assertEquals(ArithmeticFunctions.widthBucket(-1.0, 0.0, 10.0, 5), 0);
+
+    // At or above upper bound
+    assertEquals(ArithmeticFunctions.widthBucket(10.0, 0.0, 10.0, 5), 6);
+    assertEquals(ArithmeticFunctions.widthBucket(100.0, 0.0, 10.0, 5), 6);
+
+    // Infinite value (valid — not a bound)
+    assertEquals(ArithmeticFunctions.widthBucket(Double.NEGATIVE_INFINITY, 0.0, 10.0, 5), 0);
+    assertEquals(ArithmeticFunctions.widthBucket(Double.POSITIVE_INFINITY, 0.0, 10.0, 5), 6);
+
+    // Single bucket
+    assertEquals(ArithmeticFunctions.widthBucket(5.0, 0.0, 10.0, 1), 1);
+    assertEquals(ArithmeticFunctions.widthBucket(-1.0, 0.0, 10.0, 1), 0);
+    assertEquals(ArithmeticFunctions.widthBucket(10.0, 0.0, 10.0, 1), 2);
+  }
+
+  @Test
+  public void testWidthBucketInvalid() {
+    // lo >= hi
+    assertThrows(IllegalArgumentException.class, () -> ArithmeticFunctions.widthBucket(5.0, 10.0, 0.0, 5));
+    assertThrows(IllegalArgumentException.class, () -> ArithmeticFunctions.widthBucket(5.0, 5.0, 5.0, 5));
+    // numBuckets <= 0
+    assertThrows(IllegalArgumentException.class, () -> ArithmeticFunctions.widthBucket(5.0, 0.0, 10.0, 0));
+    assertThrows(IllegalArgumentException.class, () -> ArithmeticFunctions.widthBucket(5.0, 0.0, 10.0, -1));
+    // NaN values
+    assertThrows(IllegalArgumentException.class,
+        () -> ArithmeticFunctions.widthBucket(Double.NaN, 0.0, 10.0, 5));
+    assertThrows(IllegalArgumentException.class,
+        () -> ArithmeticFunctions.widthBucket(5.0, Double.NaN, 10.0, 5));
+    assertThrows(IllegalArgumentException.class,
+        () -> ArithmeticFunctions.widthBucket(5.0, 0.0, Double.NaN, 5));
+    // Infinite bounds
+    assertThrows(IllegalArgumentException.class,
+        () -> ArithmeticFunctions.widthBucket(5.0, Double.NEGATIVE_INFINITY, 10.0, 5));
+    assertThrows(IllegalArgumentException.class,
+        () -> ArithmeticFunctions.widthBucket(5.0, 0.0, Double.POSITIVE_INFINITY, 5));
   }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/common/function/scalar/IpAddressFunctionsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/function/scalar/IpAddressFunctionsTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.common.function.scalar;
 
+import inet.ipaddr.IPAddressString;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
@@ -434,5 +435,117 @@ public class IpAddressFunctionsTest {
     assertThrows(IllegalArgumentException.class, () -> IpAddressFunctions.ipv4CIDRToRange("192.168.1.0"));
     // IPv6 CIDR rejected
     assertThrows(IllegalArgumentException.class, () -> IpAddressFunctions.ipv4CIDRToRange("2001:db8::/32"));
+  }
+
+  // ==================== Tests for ipFamily ====================
+
+  @Test
+  public void testIpFamily() {
+    assertEquals(IpAddressFunctions.ipFamily("192.168.1.1"), 4);
+    assertEquals(IpAddressFunctions.ipFamily("10.0.0.1"), 4);
+    assertEquals(IpAddressFunctions.ipFamily("0.0.0.0"), 4);
+    assertEquals(IpAddressFunctions.ipFamily("2001:db8::1"), 6);
+    assertEquals(IpAddressFunctions.ipFamily("::1"), 6);
+    assertEquals(IpAddressFunctions.ipFamily("fe80::1"), 6);
+  }
+
+  @Test
+  public void testIpFamilyInvalid() {
+    assertThrows(IllegalArgumentException.class, () -> IpAddressFunctions.ipFamily("not-an-ip"));
+  }
+
+  // ==================== Tests for ipMaskLen ====================
+
+  @Test
+  public void testIpMaskLen() {
+    assertEquals(IpAddressFunctions.ipMaskLen("192.168.1.0/24"), 24);
+    assertEquals(IpAddressFunctions.ipMaskLen("10.0.0.0/8"), 8);
+    assertEquals(IpAddressFunctions.ipMaskLen("192.168.1.1/32"), 32);
+    assertEquals(IpAddressFunctions.ipMaskLen("0.0.0.0/0"), 0);
+    assertEquals(IpAddressFunctions.ipMaskLen("2001:db8::/32"), 32);
+    assertEquals(IpAddressFunctions.ipMaskLen("2001:db8::/64"), 64);
+    assertEquals(IpAddressFunctions.ipMaskLen("::1/128"), 128);
+  }
+
+  @Test
+  public void testIpMaskLenInvalid() {
+    assertThrows(IllegalArgumentException.class, () -> IpAddressFunctions.ipMaskLen("192.168.1.0"));
+  }
+
+  // ==================== Tests for ipNetmask ====================
+
+  @Test
+  public void testIpNetmask() {
+    assertEquals(IpAddressFunctions.ipNetmask("192.168.1.0/24"), "255.255.255.0");
+    assertEquals(IpAddressFunctions.ipNetmask("10.0.0.0/8"), "255.0.0.0");
+    assertEquals(IpAddressFunctions.ipNetmask("192.168.1.0/16"), "255.255.0.0");
+    assertEquals(IpAddressFunctions.ipNetmask("192.168.1.1/32"), "255.255.255.255");
+    assertEquals(IpAddressFunctions.ipNetmask("0.0.0.0/0"), "0.0.0.0");
+    assertEquals(IpAddressFunctions.ipNetmask("192.168.1.0/25"), "255.255.255.128");
+  }
+
+  @Test
+  public void testIpNetmaskIpv6() {
+    // /64 → first 8 bytes all 0xFF, rest 0
+    assertEquals(IpAddressFunctions.ipNetmask("2001:db8::/64"), "ffff:ffff:ffff:ffff::");
+    // /128 → all 0xFF
+    assertEquals(IpAddressFunctions.ipNetmask("::1/128"), "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff");
+    // /0 → all 0
+    assertEquals(IpAddressFunctions.ipNetmask("::/0"), "::");
+  }
+
+  @Test
+  public void testIpNetmaskInvalid() {
+    assertThrows(IllegalArgumentException.class, () -> IpAddressFunctions.ipNetmask("192.168.1.0"));
+  }
+
+  // ==================== Tests for ipHostmask ====================
+
+  @Test
+  public void testIpHostmask() {
+    assertEquals(IpAddressFunctions.ipHostmask("192.168.1.0/24"), "0.0.0.255");
+    assertEquals(IpAddressFunctions.ipHostmask("10.0.0.0/8"), "0.255.255.255");
+    assertEquals(IpAddressFunctions.ipHostmask("192.168.1.0/16"), "0.0.255.255");
+    assertEquals(IpAddressFunctions.ipHostmask("192.168.1.1/32"), "0.0.0.0");
+    assertEquals(IpAddressFunctions.ipHostmask("0.0.0.0/0"), "255.255.255.255");
+    assertEquals(IpAddressFunctions.ipHostmask("192.168.1.0/25"), "0.0.0.127");
+  }
+
+  @Test
+  public void testIpHostmaskIpv6() {
+    // /64 → first 8 bytes all 0, rest 0xFF
+    assertEquals(IpAddressFunctions.ipHostmask("2001:db8::/64"), "::ffff:ffff:ffff:ffff");
+    // /128 → all 0
+    assertEquals(IpAddressFunctions.ipHostmask("::1/128"), "::");
+    // /0 → all 0xFF
+    assertEquals(IpAddressFunctions.ipHostmask("::/0"), "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff");
+  }
+
+  @Test
+  public void testIpHostmaskInvalid() {
+    assertThrows(IllegalArgumentException.class, () -> IpAddressFunctions.ipHostmask("192.168.1.0"));
+  }
+
+  // ==================== Netmask/Hostmask consistency ====================
+
+  @Test
+  public void testNetmaskHostmaskConsistency() {
+    // For any CIDR, netmask and hostmask must be bitwise complements:
+    // (netmask | hostmask) == all 0xFF, (netmask & hostmask) == all 0x00
+    String[] cidrs = {"192.168.1.0/24", "10.0.0.0/8", "172.16.0.0/12", "192.168.1.0/25", "0.0.0.0/0",
+        "192.168.1.1/32"};
+    for (String cidr : cidrs) {
+      String netmask = IpAddressFunctions.ipNetmask(cidr);
+      String hostmask = IpAddressFunctions.ipHostmask(cidr);
+      byte[] netBytes = new IPAddressString(netmask).getAddress().getBytes();
+      byte[] hostBytes = new IPAddressString(hostmask).getAddress().getBytes();
+      assertEquals(netBytes.length, hostBytes.length);
+      for (int i = 0; i < netBytes.length; i++) {
+        assertEquals((byte) (netBytes[i] | hostBytes[i]), (byte) 0xFF,
+            "netmask | hostmask must be all 1s at byte " + i + " for " + cidr);
+        assertEquals((byte) (netBytes[i] & hostBytes[i]), (byte) 0x00,
+            "netmask & hostmask must be all 0s at byte " + i + " for " + cidr);
+      }
+    }
   }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/common/function/scalar/StringFunctionsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/function/scalar/StringFunctionsTest.java
@@ -501,4 +501,71 @@ public class StringFunctionsTest {
     assertFalse(StringFunctions.isValidASCII("日本語"));
     assertFalse(StringFunctions.isValidASCII("café"));
   }
+
+  // ==================== Tests for bitLength ====================
+
+  @Test
+  public void testBitLength() {
+    assertEquals(StringFunctions.bitLength(""), 0);
+    assertEquals(StringFunctions.bitLength("a"), 8);
+    assertEquals(StringFunctions.bitLength("hello"), 40);
+    // Multi-byte UTF-8: é is 2 bytes in UTF-8
+    assertEquals(StringFunctions.bitLength("é"), 16);
+    // 3-byte UTF-8 character
+    assertEquals(StringFunctions.bitLength("日"), 24);
+  }
+
+  // ==================== Tests for octetLength ====================
+
+  @Test
+  public void testOctetLength() {
+    assertEquals(StringFunctions.octetLength(""), 0);
+    assertEquals(StringFunctions.octetLength("a"), 1);
+    assertEquals(StringFunctions.octetLength("hello"), 5);
+    // Multi-byte UTF-8
+    assertEquals(StringFunctions.octetLength("é"), 2);
+    assertEquals(StringFunctions.octetLength("日"), 3);
+  }
+
+  // ==================== Tests for charLength ====================
+
+  @Test
+  public void testCharLength() {
+    assertEquals(StringFunctions.charLength(""), 0);
+    assertEquals(StringFunctions.charLength("hello"), 5);
+    // Multi-byte characters still count as 1 codepoint each
+    assertEquals(StringFunctions.charLength("é"), 1);
+    assertEquals(StringFunctions.charLength("日本語"), 3);
+    assertEquals(StringFunctions.charLength("café"), 4);
+    // Supplementary character (emoji) — 1 codepoint but 2 UTF-16 code units
+    assertEquals(StringFunctions.charLength("\uD83D\uDE00"), 1); // U+1F600 grinning face
+    // Compare with length() which would return 2 for the emoji
+    assertEquals(StringFunctions.length("\uD83D\uDE00"), 2);
+  }
+
+  // ==================== Tests for regexpCount ====================
+
+  @Test
+  public void testRegexpCount() {
+    assertEquals(StringFunctions.regexpCount("hello world hello", "hello"), 2);
+    assertEquals(StringFunctions.regexpCount("aaa", "a"), 3);
+    assertEquals(StringFunctions.regexpCount("abc", "x"), 0);
+    assertEquals(StringFunctions.regexpCount("", "a"), 0);
+    // Non-overlapping: "aa" in "aaaa" matches at positions 0 and 2
+    assertEquals(StringFunctions.regexpCount("aaaa", "aa"), 2);
+    // Regex patterns
+    assertEquals(StringFunctions.regexpCount("abc123def456", "\\d+"), 2);
+    assertEquals(StringFunctions.regexpCount("a1b2c3", "[0-9]"), 3);
+  }
+
+  // ==================== Tests for regexpSubstr ====================
+
+  @Test
+  public void testRegexpSubstr() {
+    assertEquals(StringFunctions.regexpSubstr("hello world", "w\\w+"), "world");
+    assertEquals(StringFunctions.regexpSubstr("abc123def456", "\\d+"), "123");
+    assertNull(StringFunctions.regexpSubstr("hello", "\\d+"));
+    assertEquals(StringFunctions.regexpSubstr("", "a"), null);
+    assertEquals(StringFunctions.regexpSubstr("Hello World", "[A-Z][a-z]+"), "Hello");
+  }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/common/function/scalar/TrigonometricFunctionsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/function/scalar/TrigonometricFunctionsTest.java
@@ -1,0 +1,80 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.function.scalar;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+
+/**
+ * Tests for inverse hyperbolic trigonometric functions in {@link TrigonometricFunctions}.
+ */
+public class TrigonometricFunctionsTest {
+
+  private static final double DELTA = 1e-10;
+
+  @Test
+  public void testAsinh() {
+    assertEquals(TrigonometricFunctions.asinh(0.0), 0.0, DELTA);
+    // asinh(sinh(x)) == x
+    assertEquals(TrigonometricFunctions.asinh(Math.sinh(1.0)), 1.0, DELTA);
+    assertEquals(TrigonometricFunctions.asinh(Math.sinh(5.0)), 5.0, DELTA);
+    assertEquals(TrigonometricFunctions.asinh(Math.sinh(-3.0)), -3.0, DELTA);
+    // Negative input
+    assertEquals(TrigonometricFunctions.asinh(-1.0), -TrigonometricFunctions.asinh(1.0), DELTA);
+    // Special values
+    assertTrue(Double.isNaN(TrigonometricFunctions.asinh(Double.NaN)));
+    assertEquals(TrigonometricFunctions.asinh(Double.POSITIVE_INFINITY), Double.POSITIVE_INFINITY);
+    assertEquals(TrigonometricFunctions.asinh(Double.NEGATIVE_INFINITY), Double.NEGATIVE_INFINITY);
+  }
+
+  @Test
+  public void testAcosh() {
+    assertEquals(TrigonometricFunctions.acosh(1.0), 0.0, DELTA);
+    // acosh(cosh(x)) == x for x >= 0
+    assertEquals(TrigonometricFunctions.acosh(Math.cosh(2.0)), 2.0, DELTA);
+    assertEquals(TrigonometricFunctions.acosh(Math.cosh(5.0)), 5.0, DELTA);
+    // Domain: x < 1 produces NaN
+    assertTrue(Double.isNaN(TrigonometricFunctions.acosh(0.5)));
+    assertTrue(Double.isNaN(TrigonometricFunctions.acosh(0.0)));
+    // Special values
+    assertTrue(Double.isNaN(TrigonometricFunctions.acosh(Double.NaN)));
+    assertEquals(TrigonometricFunctions.acosh(Double.POSITIVE_INFINITY), Double.POSITIVE_INFINITY);
+  }
+
+  @Test
+  public void testAtanh() {
+    assertEquals(TrigonometricFunctions.atanh(0.0), 0.0, DELTA);
+    // atanh(tanh(x)) == x for small x
+    assertEquals(TrigonometricFunctions.atanh(Math.tanh(0.5)), 0.5, DELTA);
+    assertEquals(TrigonometricFunctions.atanh(Math.tanh(-0.5)), -0.5, DELTA);
+    // Symmetry
+    assertEquals(TrigonometricFunctions.atanh(0.5), -TrigonometricFunctions.atanh(-0.5), DELTA);
+    // Boundary: atanh(1) == +Inf, atanh(-1) == -Inf
+    assertEquals(TrigonometricFunctions.atanh(1.0), Double.POSITIVE_INFINITY);
+    assertEquals(TrigonometricFunctions.atanh(-1.0), Double.NEGATIVE_INFINITY);
+    // Domain: |x| > 1 produces NaN
+    assertTrue(Double.isNaN(TrigonometricFunctions.atanh(1.5)));
+    assertTrue(Double.isNaN(TrigonometricFunctions.atanh(-1.5)));
+    // Special values
+    assertTrue(Double.isNaN(TrigonometricFunctions.atanh(Double.NaN)));
+  }
+}


### PR DESCRIPTION
## Summary

Adds 14 scalar functions to improve SQL standard compliance and close gaps with PostgreSQL. Follows up on #18409 which added the first batch of math, string, and IP address functions. No new dependencies.

| Category | Function | Aliases | Description |
|---|---|---|---|
| **Trig** | `asinh(double)` | | Inverse hyperbolic sine |
| | `acosh(double)` | | Inverse hyperbolic cosine (domain: x >= 1) |
| | `atanh(double)` | | Inverse hyperbolic tangent (domain: -1 < x < 1) |
| **Math** | `factorial(long)` | | n! via precomputed lookup (0–20) |
| | `widthBucket(v, lo, hi, n)` | `width_bucket` | SQL standard histogram bucketing |
| **String** | `octetLength(s)` | `octet_length` | Byte count of UTF-8 encoding |
| | `bitLength(s)` | `bit_length` | Bit count of UTF-8 encoding |
| | `charLength(s)` | `char_length`, `character_length` | Unicode codepoint count |
| | `regexpCount(s, pat)` | `regexp_count` | Count non-overlapping regex matches |
| | `regexpSubstr(s, pat)` | `regexp_substr` | First regex match or null |
| **IP** | `ipFamily(s)` | `ip_family` | Returns 4 or 6 |
| | `ipMaskLen(cidr)` | `ip_mask_len` | Extract prefix length from CIDR |
| | `ipNetmask(cidr)` | `ip_netmask` | Network mask (e.g., `255.255.255.0`) |
| | `ipHostmask(cidr)` | `ip_hostmask` | Host mask (e.g., `0.0.0.255`) |

## Test plan

- [ ] `./mvnw -pl pinot-common -am -Dtest="TrigonometricFunctionsTest,ArithmeticFunctionsTest,StringFunctionsTest,IpAddressFunctionsTest" -Dsurefire.failIfNoSpecifiedTests=false test`
- [ ] Verify edge cases: NaN/Infinity for widthBucket, domain violations for acosh/atanh, IPv6 netmask/hostmask
- [ ] spotless, checkstyle, license checks pass
- [ ] Zero compiler warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)