### PR TITLE
Make concurrent-scheduling dispatch helpers protected for subclass extension

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
@@ -780,7 +780,6 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
    * If no specific tables are targeted (i.e., "schedule for every table"), the check iterates the full
    * table list so that per-table opt-outs are still honored.
    */
-  @VisibleForTesting
   protected boolean shouldUseConcurrentPath(TaskSchedulingContext context) {
     Set<String> targetTables = context.getTablesToSchedule();
     Set<String> targetDatabases = context.getDatabasesToSchedule();
@@ -814,7 +813,6 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
    * Resolves the effective concurrent-scheduling flag for a single table: table-level override if
    * set, otherwise the cluster-level default.
    */
-  @VisibleForTesting
   protected boolean resolveConcurrentScheduling(TableConfig tableConfig) {
     TableTaskConfig taskConfig = tableConfig.getTaskConfig();
     if (taskConfig != null) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
@@ -781,7 +781,7 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
    * table list so that per-table opt-outs are still honored.
    */
   @VisibleForTesting
-  boolean shouldUseConcurrentPath(TaskSchedulingContext context) {
+  protected boolean shouldUseConcurrentPath(TaskSchedulingContext context) {
     Set<String> targetTables = context.getTablesToSchedule();
     Set<String> targetDatabases = context.getDatabasesToSchedule();
     Set<String> consolidatedTables = new HashSet<>();
@@ -815,7 +815,7 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
    * set, otherwise the cluster-level default.
    */
   @VisibleForTesting
-  boolean resolveConcurrentScheduling(TableConfig tableConfig) {
+  protected boolean resolveConcurrentScheduling(TableConfig tableConfig) {
     TableTaskConfig taskConfig = tableConfig.getTaskConfig();
     if (taskConfig != null) {
       Boolean tableFlag = taskConfig.getConcurrentSchedulingEnabled();


### PR DESCRIPTION
## Summary

Bump `PinotTaskManager#shouldUseConcurrentPath` and `#resolveConcurrentScheduling` from package-private `@VisibleForTesting` to `protected @VisibleForTesting`, so subclasses in other packages can integrate with the concurrent scheduling path introduced in #18272.
