### PR TITLE
[bugfix] Fixing instance partition assignments for multi-stream realtime tables

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/RealtimeSegmentAssignment.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/RealtimeSegmentAssignment.java
@@ -38,6 +38,7 @@ import org.apache.pinot.controller.helix.core.assignment.segment.strategy.Segmen
 import org.apache.pinot.controller.helix.core.realtime.PinotLLCRealtimeSegmentManager;
 import org.apache.pinot.spi.config.table.assignment.InstancePartitionsType;
 import org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.SegmentStateModel;
+import org.apache.pinot.spi.utils.IngestionConfigUtils;
 
 
 /**
@@ -115,6 +116,11 @@ public class RealtimeSegmentAssignment extends BaseSegmentAssignment {
   }
 
   protected List<String> assignConsumingSegment(int segmentPartitionId, InstancePartitions instancePartitions) {
+    // For multi-stream tables, Pinot partition IDs are encoded as (streamIndex * 10000 + streamPartitionId).
+    // Extract the stream-level partition id before computing the instance index to avoid incorrect slot mapping.
+    segmentPartitionId =
+        IngestionConfigUtils.getStreamPartitionIdFromPinotPartitionId(_tableConfig, segmentPartitionId);
+
     int numReplicaGroups = instancePartitions.getNumReplicaGroups();
     int numPartitions = instancePartitions.getNumPartitions();
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/ReplicaGroupSegmentAssignmentStrategy.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/ReplicaGroupSegmentAssignmentStrategy.java
@@ -33,7 +33,6 @@ import org.apache.pinot.controller.helix.core.assignment.segment.SegmentAssignme
 import org.apache.pinot.segment.local.utils.TableConfigUtils;
 import org.apache.pinot.spi.config.table.SegmentsValidationAndRetentionConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
-import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.utils.IngestionConfigUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -130,9 +129,8 @@ public class ReplicaGroupSegmentAssignmentStrategy implements SegmentAssignmentS
         SegmentUtils.getSegmentPartitionIdOrDefault(segmentName, _tableName, _helixManager, _partitionColumn);
     // For multi-stream realtime tables, translate the Pinot partition ID (which encodes stream index and stream
     // partition as streamIndex * 10000 + streamPartitionId) to the stream partition id before computing the slot.
-    if (_tableConfig.getTableType() == TableType.REALTIME) {
-      rawPartitionId = IngestionConfigUtils.getStreamPartitionIdFromPinotPartitionId(_tableConfig, rawPartitionId);
-    }
+    // getStreamPartitionIdFromPinotPartitionId is a no-op for offline tables and single-stream realtime tables.
+    rawPartitionId = IngestionConfigUtils.getStreamPartitionIdFromPinotPartitionId(_tableConfig, rawPartitionId);
     return rawPartitionId % numPartitions;
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/ReplicaGroupSegmentAssignmentStrategy.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/ReplicaGroupSegmentAssignmentStrategy.java
@@ -33,6 +33,8 @@ import org.apache.pinot.controller.helix.core.assignment.segment.SegmentAssignme
 import org.apache.pinot.segment.local.utils.TableConfigUtils;
 import org.apache.pinot.spi.config.table.SegmentsValidationAndRetentionConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.utils.IngestionConfigUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,6 +43,7 @@ public class ReplicaGroupSegmentAssignmentStrategy implements SegmentAssignmentS
   private static final Logger LOGGER = LoggerFactory.getLogger(ReplicaGroupSegmentAssignmentStrategy.class);
 
   protected HelixManager _helixManager;
+  protected TableConfig _tableConfig;
   protected String _tableName;
   protected String _partitionColumn;
   protected int _replication;
@@ -48,6 +51,7 @@ public class ReplicaGroupSegmentAssignmentStrategy implements SegmentAssignmentS
   @Override
   public void init(HelixManager helixManager, TableConfig tableConfig) {
     _helixManager = helixManager;
+    _tableConfig = tableConfig;
     _tableName = tableConfig.getTableName();
     SegmentsValidationAndRetentionConfig validationAndRetentionConfig = tableConfig.getValidationConfig();
     Preconditions.checkState(validationAndRetentionConfig != null, "segmentsConfig is null");
@@ -77,9 +81,7 @@ public class ReplicaGroupSegmentAssignmentStrategy implements SegmentAssignmentS
     if (numPartitions == 1) {
       partitionId = 0;
     } else {
-      partitionId =
-          SegmentUtils.getSegmentPartitionIdOrDefault(segmentName, _tableName, _helixManager, _partitionColumn)
-              % numPartitions;
+      partitionId = getPartitionIdFromSegmentName(segmentName, numPartitions);
     }
     return SegmentAssignmentUtils.assignSegmentWithReplicaGroup(currentAssignment, instancePartitions, partitionId);
   }
@@ -106,9 +108,7 @@ public class ReplicaGroupSegmentAssignmentStrategy implements SegmentAssignmentS
     } else {
       Map<Integer, List<String>> instancePartitionIdToSegmentsMap = Maps.newHashMapWithExpectedSize(numPartitions);
       for (String segmentName : currentAssignment.keySet()) {
-        int instancePartitionId =
-            SegmentUtils.getSegmentPartitionIdOrDefault(segmentName, _tableName, _helixManager, _partitionColumn)
-                % numPartitions;
+        int instancePartitionId = getPartitionIdFromSegmentName(segmentName, numPartitions);
         instancePartitionIdToSegmentsMap.computeIfAbsent(instancePartitionId, k -> new ArrayList<>()).add(segmentName);
       }
 
@@ -123,6 +123,17 @@ public class ReplicaGroupSegmentAssignmentStrategy implements SegmentAssignmentS
       return SegmentAssignmentUtils
           .rebalanceReplicaGroupBasedTable(currentAssignment, instancePartitions, instancePartitionIdToSegmentsMap);
     }
+  }
+
+  private int getPartitionIdFromSegmentName(String segmentName, int numPartitions) {
+    int rawPartitionId =
+        SegmentUtils.getSegmentPartitionIdOrDefault(segmentName, _tableName, _helixManager, _partitionColumn);
+    // For multi-stream realtime tables, translate the Pinot partition ID (which encodes stream index and stream
+    // partition as streamIndex * 10000 + streamPartitionId) to the stream partition id before computing the slot.
+    if (_tableConfig.getTableType() == TableType.REALTIME) {
+      rawPartitionId = IngestionConfigUtils.getStreamPartitionIdFromPinotPartitionId(_tableConfig, rawPartitionId);
+    }
+    return rawPartitionId % numPartitions;
   }
 
   /**

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/IngestionConfigUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/IngestionConfigUtils.java
@@ -102,6 +102,11 @@ public final class IngestionConfigUtils {
     return new StreamConfig(tableConfig.getTableName(), getFirstStreamConfigMap(tableConfig));
   }
 
+  /// Returns `true` if the table contains multiple streams.
+  public static boolean hasMultipleStreams(TableConfig tableConfig) {
+    return getStreamConfigMaps(tableConfig).size() > 1;
+  }
+
   /**
    * Getting the Pinot segment level partition id from the stream partition id.
    * @param partitionId the partition id from the stream

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/IngestionConfigUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/IngestionConfigUtils.java
@@ -102,9 +102,16 @@ public final class IngestionConfigUtils {
     return new StreamConfig(tableConfig.getTableName(), getFirstStreamConfigMap(tableConfig));
   }
 
-  /// Returns `true` if the table contains multiple streams.
+  /// Returns {@code true} if the table has multiple streams configured.
+  /// Safe to call for any table type: returns {@code false} for OFFLINE tables and REALTIME tables that lack stream
+  /// configs.
   public static boolean hasMultipleStreams(TableConfig tableConfig) {
-    return getStreamConfigMaps(tableConfig).size() > 1;
+    IngestionConfig ingestionConfig = tableConfig.getIngestionConfig();
+    if (ingestionConfig == null || ingestionConfig.getStreamIngestionConfig() == null) {
+      return false;
+    }
+    List<Map<String, String>> streamConfigMaps = ingestionConfig.getStreamIngestionConfig().getStreamConfigMaps();
+    return streamConfigMaps != null && streamConfigMaps.size() > 1;
   }
 
   /**
@@ -117,19 +124,9 @@ public final class IngestionConfigUtils {
   }
 
   /// Returns the stream partition id from the Pinot segment partition id.
-  /// Safe to call for any table type: returns `partitionId` unchanged for OFFLINE tables or REALTIME tables
-  /// that lack stream configs (treat as single-stream).
+  /// Returns {@code partitionId} unchanged for tables without multiple streams.
   public static int getStreamPartitionIdFromPinotPartitionId(TableConfig tableConfig, int partitionId) {
-    if (tableConfig.getTableType() != TableType.REALTIME) {
-      return partitionId;
-    }
-    IngestionConfig ingestionConfig = tableConfig.getIngestionConfig();
-    if (ingestionConfig == null || ingestionConfig.getStreamIngestionConfig() == null) {
-      return partitionId;
-    }
-    List<Map<String, String>> streamConfigMaps = ingestionConfig.getStreamIngestionConfig().getStreamConfigMaps();
-    return streamConfigMaps != null && streamConfigMaps.size() > 1
-        ? getStreamPartitionIdFromPinotPartitionId(partitionId) : partitionId;
+    return hasMultipleStreams(tableConfig) ? getStreamPartitionIdFromPinotPartitionId(partitionId) : partitionId;
   }
 
   /// Returns the stream partition id from the Pinot segment partition id.

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/IngestionConfigUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/IngestionConfigUtils.java
@@ -102,11 +102,6 @@ public final class IngestionConfigUtils {
     return new StreamConfig(tableConfig.getTableName(), getFirstStreamConfigMap(tableConfig));
   }
 
-  /// Returns `true` if the table contains multiple streams.
-  public static boolean hasMultipleStreams(TableConfig tableConfig) {
-    return getStreamConfigMaps(tableConfig).size() > 1;
-  }
-
   /**
    * Getting the Pinot segment level partition id from the stream partition id.
    * @param partitionId the partition id from the stream
@@ -117,8 +112,19 @@ public final class IngestionConfigUtils {
   }
 
   /// Returns the stream partition id from the Pinot segment partition id.
+  /// Safe to call for any table type: returns `partitionId` unchanged for OFFLINE tables or REALTIME tables
+  /// that lack stream configs (treat as single-stream).
   public static int getStreamPartitionIdFromPinotPartitionId(TableConfig tableConfig, int partitionId) {
-    return hasMultipleStreams(tableConfig) ? getStreamPartitionIdFromPinotPartitionId(partitionId) : partitionId;
+    if (tableConfig.getTableType() != TableType.REALTIME) {
+      return partitionId;
+    }
+    IngestionConfig ingestionConfig = tableConfig.getIngestionConfig();
+    if (ingestionConfig == null || ingestionConfig.getStreamIngestionConfig() == null) {
+      return partitionId;
+    }
+    List<Map<String, String>> streamConfigMaps = ingestionConfig.getStreamIngestionConfig().getStreamConfigMaps();
+    return streamConfigMaps != null && streamConfigMaps.size() > 1
+        ? getStreamPartitionIdFromPinotPartitionId(partitionId) : partitionId;
   }
 
   /// Returns the stream partition id from the Pinot segment partition id.

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/utils/IngestionConfigUtilsTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/utils/IngestionConfigUtilsTest.java
@@ -161,6 +161,54 @@ public class IngestionConfigUtilsTest {
   }
 
   @Test
+  public void testHasMultipleStreams() {
+    // OFFLINE table — must not throw, must return false
+    TableConfig offlineTable = new TableConfigBuilder(TableType.OFFLINE).setTableName("myTable").build();
+    Assert.assertFalse(IngestionConfigUtils.hasMultipleStreams(offlineTable));
+
+    // REALTIME, no ingestionConfig
+    TableConfig realtimeTable =
+        new TableConfigBuilder(TableType.REALTIME).setTableName("myTable").setTimeColumnName("timeColumn").build();
+    Assert.assertFalse(IngestionConfigUtils.hasMultipleStreams(realtimeTable));
+
+    // REALTIME, single stream
+    Map<String, String> streamConfigMap1 = Collections.singletonMap("streamType", "kafka");
+    IngestionConfig ingestionConfig = new IngestionConfig();
+    ingestionConfig.setStreamIngestionConfig(new StreamIngestionConfig(Collections.singletonList(streamConfigMap1)));
+    realtimeTable.setIngestionConfig(ingestionConfig);
+    Assert.assertFalse(IngestionConfigUtils.hasMultipleStreams(realtimeTable));
+
+    // REALTIME, two streams
+    Map<String, String> streamConfigMap2 = Collections.singletonMap("streamType", "kinesis");
+    ingestionConfig.setStreamIngestionConfig(new StreamIngestionConfig(List.of(streamConfigMap1, streamConfigMap2)));
+    Assert.assertTrue(IngestionConfigUtils.hasMultipleStreams(realtimeTable));
+  }
+
+  @Test
+  public void testGetStreamPartitionIdFromPinotPartitionId() {
+    // OFFLINE table — must return partitionId unchanged
+    TableConfig offlineTable = new TableConfigBuilder(TableType.OFFLINE).setTableName("myTable").build();
+    Assert.assertEquals(IngestionConfigUtils.getStreamPartitionIdFromPinotPartitionId(offlineTable, 42), 42);
+
+    // REALTIME, single stream — must return partitionId unchanged
+    Map<String, String> streamConfigMap = Collections.singletonMap("streamType", "kafka");
+    IngestionConfig ingestionConfig = new IngestionConfig();
+    ingestionConfig.setStreamIngestionConfig(new StreamIngestionConfig(Collections.singletonList(streamConfigMap)));
+    TableConfig realtimeTable =
+        new TableConfigBuilder(TableType.REALTIME).setTableName("myTable").setTimeColumnName("timeColumn").build();
+    realtimeTable.setIngestionConfig(ingestionConfig);
+    Assert.assertEquals(IngestionConfigUtils.getStreamPartitionIdFromPinotPartitionId(realtimeTable, 42), 42);
+
+    // REALTIME, multi-stream — encoded partition id 10003 (stream 1, partition 3) must decode to 3
+    Map<String, String> streamConfigMap2 = Collections.singletonMap("streamType", "kinesis");
+    ingestionConfig.setStreamIngestionConfig(
+        new StreamIngestionConfig(List.of(streamConfigMap, streamConfigMap2)));
+    int pinotPartitionId = IngestionConfigUtils.getPinotPartitionIdFromStreamPartitionId(3, 1);
+    Assert.assertEquals(IngestionConfigUtils.getStreamPartitionIdFromPinotPartitionId(realtimeTable, pinotPartitionId),
+        3);
+  }
+
+  @Test
   public void testGetStreamConfigIndexToStreamPartitions() {
     Set<Integer> pinotPartitionIds = new HashSet<>(2);
     pinotPartitionIds.add(0);


### PR DESCRIPTION
## Summary

Multi-stream realtime tables encode Pinot partition IDs as `streamIndex * 10000 + streamPartitionId`. Before this fix, RealtimeSegmentAssignment and ReplicaGroupSegmentAssignmentStrategy used the raw (encoded) partition ID directly when computing instance slots, causing incorrect slot mapping and breaking colocation of segments belonging to the same partition.

### Changes:
  - In `RealtimeSegmentAssignment.assignConsumingSegment`, decode the Pinot partition ID to the stream-level partition ID via `IngestionConfigUtils.getStreamPartitionIdFromPinotPartitionId` before
  computing the instance index.                                                                                                                                                                      
  - In `ReplicaGroupSegmentAssignmentStrategy`, extract a `getPartitionIdFromSegmentName` helper that applies the same decoding for REALTIME tables before `% numPartitions`, fixing both single-segment assignment and rebalance paths. 

## Testing
Deployed this on an internal cluster containing a multi-topic table and verified by setting the `instanceAssignmentConfig` as:
```
"instanceAssignmentConfigMap": {
  "CONSUMING": {
    "tagPoolConfig": {
      "tag": "cluster_REALTIME",
      "poolBased": false,
      "numPools": 0
    },
    "replicaGroupPartitionConfig": {
      "replicaGroupBased": true,
      "numInstances": 0,
      "numReplicaGroups": 2,
      "numInstancesPerReplicaGroup": 3,
      "numPartitions": 3,
      "numInstancesPerPartition": 1,
      "minimizeDataMovement": true,
      "partitionColumn": "trace_id"
    },
    "partitionSelector": "INSTANCE_REPLICA_GROUP_PARTITION_SELECTOR",
    "minimizeDataMovement": false
  },
  "COMPLETED": {
    "tagPoolConfig": {
      "tag": "cluster_REALTIME",
      "poolBased": false,
      "numPools": 0
    },
    "replicaGroupPartitionConfig": {
      "replicaGroupBased": true,
      "numInstances": 0,
      "numReplicaGroups": 2,
      "numInstancesPerReplicaGroup": 3,
      "numPartitions": 3,
      "numInstancesPerPartition": 1,
      "minimizeDataMovement": true,
      "partitionColumn": "trace_id"
    },
    "partitionSelector": "INSTANCE_REPLICA_GROUP_PARTITION_SELECTOR",
    "minimizeDataMovement": false
  }
},
```

For this setup, the raw partition ID `0` and `10000` would map to instance partition `0 % 3 = 0` and `10000 % 3 = 1` without the fix which meant different servers for the same stream partition ID which breaks colocation of data.

```
"traces_instance_partitions__0__8__20260505T0158Z": {
  "68456b84-25be-48f4-98ee-8ce8999dbc02": "ONLINE",
  "79225964-ca5b-4ffc-9e05-f41300a9d20a": "ONLINE"
},
"traces_instance_partitions__0__9__20260505T0233Z": {
  "68456b84-25be-48f4-98ee-8ce8999dbc02": "ONLINE",
  "79225964-ca5b-4ffc-9e05-f41300a9d20a": "ONLINE"
},
"traces_instance_partitions__10000__0__20260505T0119Z": {
  "89369471-20ad-413e-a439-39d6e9b1f4f2": "ONLINE",
  "b1550ff3-051d-425b-8884-3c7b3d75335b": "ONLINE"
},
"traces_instance_partitions__10000__10__20260505T0257Z": {
  "89369471-20ad-413e-a439-39d6e9b1f4f2": "ONLINE",
  "b1550ff3-051d-425b-8884-3c7b3d75335b": "ONLINE"
},
```

After the fix, both `0` and `10000` would map to the correct instance partition `0 % 3 = 0` and `(10000 % 10000) % 3 = 0`.

```
"traces_instance_partitions__0__8__20260505T0236Z": {
  "24c00225-df6b-493e-aa87-df9c17f1b4bd": "ONLINE",
  "2e1ccdfa-5b7e-4bd6-8118-c195a4eb6ead": "ONLINE"
},
"traces_instance_partitions__0__9__20260505T0300Z": {
  "24c00225-df6b-493e-aa87-df9c17f1b4bd": "ONLINE",
  "2e1ccdfa-5b7e-4bd6-8118-c195a4eb6ead": "ONLINE"
},
"traces_instance_partitions__10000__0__20260505T0146Z": {
  "24c00225-df6b-493e-aa87-df9c17f1b4bd": "ONLINE",
  "2e1ccdfa-5b7e-4bd6-8118-c195a4eb6ead": "ONLINE"
},
"traces_instance_partitions__10000__10__20260505T0338Z": {
  "24c00225-df6b-493e-aa87-df9c17f1b4bd": "ONLINE",
  "2e1ccdfa-5b7e-4bd6-8118-c195a4eb6ead": "ONLINE"
},
```
                   
                                                                                       