### PR TITLE
Expose DataSource from TransformFunction

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/ColumnContext.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/ColumnContext.java
@@ -68,6 +68,6 @@ public class ColumnContext {
   public static ColumnContext fromTransformFunction(TransformFunction transformFunction) {
     TransformResultMetadata resultMetadata = transformFunction.getResultMetadata();
     return new ColumnContext(resultMetadata.getDataType(), resultMetadata.isSingleValue(),
-        transformFunction.getDictionary(), null);
+        transformFunction.getDictionary(), transformFunction.getDataSource());
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ArrayLiteralTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ArrayLiteralTransformFunction.java
@@ -23,11 +23,13 @@ import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.LiteralContext;
 import org.apache.pinot.core.operator.ColumnContext;
 import org.apache.pinot.core.operator.blocks.ValueBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
+import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.roaringbitmap.RoaringBitmap;
@@ -223,6 +225,12 @@ public class ArrayLiteralTransformFunction implements TransformFunction {
 
   @Override
   public Dictionary getDictionary() {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public DataSource getDataSource() {
     return null;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/BaseTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/BaseTransformFunction.java
@@ -26,6 +26,7 @@ import javax.annotation.Nullable;
 import org.apache.pinot.core.operator.ColumnContext;
 import org.apache.pinot.core.operator.blocks.ValueBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
+import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.ArrayCopyUtils;
@@ -123,6 +124,12 @@ public abstract class BaseTransformFunction implements TransformFunction {
 
   @Override
   public Dictionary getDictionary() {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public DataSource getDataSource() {
     return null;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/GenerateArrayTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/GenerateArrayTransformFunction.java
@@ -28,6 +28,7 @@ import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.operator.ColumnContext;
 import org.apache.pinot.core.operator.blocks.ValueBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
+import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.roaringbitmap.RoaringBitmap;
@@ -194,6 +195,12 @@ public class GenerateArrayTransformFunction implements TransformFunction {
   @Nullable
   @Override
   public Dictionary getDictionary() {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public DataSource getDataSource() {
     return null;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IdentifierTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IdentifierTransformFunction.java
@@ -25,6 +25,7 @@ import javax.annotation.Nullable;
 import org.apache.pinot.core.operator.ColumnContext;
 import org.apache.pinot.core.operator.blocks.ValueBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
+import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.roaringbitmap.RoaringBitmap;
 
@@ -36,11 +37,13 @@ import org.roaringbitmap.RoaringBitmap;
 public class IdentifierTransformFunction implements TransformFunction {
   private final String _columnName;
   private final Dictionary _dictionary;
+  private final DataSource _dataSource;
   private final TransformResultMetadata _resultMetadata;
 
   public IdentifierTransformFunction(String columnName, ColumnContext columnContext) {
     _columnName = columnName;
     _dictionary = columnContext.getDictionary();
+    _dataSource = columnContext.getDataSource();
     _resultMetadata =
         new TransformResultMetadata(columnContext.getDataType(), columnContext.isSingleValue(), _dictionary != null);
   }
@@ -68,6 +71,12 @@ public class IdentifierTransformFunction implements TransformFunction {
   @Override
   public Dictionary getDictionary() {
     return _dictionary;
+  }
+
+  @Nullable
+  @Override
+  public DataSource getDataSource() {
+    return _dataSource;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ItemTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ItemTransformFunction.java
@@ -21,6 +21,7 @@ package org.apache.pinot.core.operator.transform.function;
 import com.google.common.base.Preconditions;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.pinot.core.operator.ColumnContext;
 import org.apache.pinot.core.operator.blocks.ValueBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
@@ -41,6 +42,7 @@ public class ItemTransformFunction extends BaseTransformFunction {
   TransformFunction _mapValue;
   TransformFunction _keyValue;
   Dictionary _keyDictionary;
+  private DataSource _dataSource;
   private TransformResultMetadata _resultMetadata;
 
   @Override
@@ -72,11 +74,12 @@ public class ItemTransformFunction extends BaseTransformFunction {
 
     // The metadata about the values that this operation will resolve to is determined by the type of the data
     // under the key, not by the Map column.  So we need to look up the Key's Metadata.
-    DataSource dataSource = columnContextMap.get(_column).getDataSource();
+    DataSource dataSource = _mapValue.getDataSource();
 
     if (dataSource instanceof MapDataSource) {
       MapDataSource mapDS = (MapDataSource) dataSource;
       DataSource keyDS = mapDS.getKeyDataSource(_key);
+      _dataSource = keyDS;
       FieldSpec.DataType keyType = keyDS.getDataSourceMetadata().getDataType().getStoredType();
       _keyDictionary = keyDS.getDictionary();
       _resultMetadata =
@@ -101,6 +104,12 @@ public class ItemTransformFunction extends BaseTransformFunction {
   @Override
   public Dictionary getDictionary() {
     return _keyDictionary;
+  }
+
+  @Nullable
+  @Override
+  public DataSource getDataSource() {
+    return _dataSource;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/JsonExtractIndexTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/JsonExtractIndexTransformFunction.java
@@ -28,6 +28,7 @@ import org.apache.pinot.common.function.JsonPathCache;
 import org.apache.pinot.core.operator.ColumnContext;
 import org.apache.pinot.core.operator.blocks.ValueBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
+import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.segment.spi.index.IndexService;
 import org.apache.pinot.segment.spi.index.IndexType;
 import org.apache.pinot.segment.spi.index.reader.JsonIndexReader;
@@ -70,22 +71,21 @@ public class JsonExtractIndexTransformFunction extends BaseTransformFunction {
     }
 
     TransformFunction firstArgument = arguments.get(0);
-    if (firstArgument instanceof IdentifierTransformFunction) {
-      String columnName = ((IdentifierTransformFunction) firstArgument).getColumnName();
-      _jsonIndexReader = columnContextMap.get(columnName).getDataSource().getJsonIndex();
-      if (_jsonIndexReader == null) { //TODO: rework
-        Optional<IndexType<?, ?, ?>> compositeIndex =
-            IndexService.getInstance().getOptional("composite_json_index");
+    DataSource dataSource = firstArgument.getDataSource();
+    if (dataSource != null) {
+      _jsonIndexReader = dataSource.getJsonIndex();
+      if (_jsonIndexReader == null) { // TODO: rework
+        Optional<IndexType<?, ?, ?>> compositeIndex = IndexService.getInstance().getOptional("composite_json_index");
         if (compositeIndex.isPresent()) {
-          _jsonIndexReader = (JsonIndexReader) columnContextMap.get(columnName)
-              .getDataSource().getIndex(compositeIndex.get());
+          _jsonIndexReader = (JsonIndexReader) dataSource.getIndex(compositeIndex.get());
         }
       }
       if (_jsonIndexReader == null) {
         throw new IllegalStateException("jsonExtractIndex can only be applied on a column with JSON index");
       }
     } else {
-      throw new IllegalArgumentException("jsonExtractIndex can only be applied to a raw column");
+      throw new IllegalArgumentException(
+          "The first argument of jsonExtractIndex must be backed by a segment DataSource");
     }
     _jsonFieldTransformFunction = firstArgument;
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LiteralTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LiteralTransformFunction.java
@@ -27,6 +27,7 @@ import org.apache.pinot.common.request.context.LiteralContext;
 import org.apache.pinot.core.operator.ColumnContext;
 import org.apache.pinot.core.operator.blocks.ValueBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
+import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.roaringbitmap.RoaringBitmap;
 
@@ -112,6 +113,12 @@ public class LiteralTransformFunction implements TransformFunction {
 
   @Override
   public Dictionary getDictionary() {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public DataSource getDataSource() {
     return null;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TextMatchTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TextMatchTransformFunction.java
@@ -50,15 +50,16 @@ public class TextMatchTransformFunction extends BaseTransformFunction {
     super.init(arguments, columnContextMap);
 
     TransformFunction columnArg = arguments.get(0);
-    if (!(columnArg instanceof IdentifierTransformFunction && columnArg.getResultMetadata().isSingleValue())) {
+    if (!columnArg.getResultMetadata().isSingleValue()) {
       throw new IllegalArgumentException(
           "The first argument of TEXT_MATCH transform function must be a single-valued column");
     }
-    String columnName = ((IdentifierTransformFunction) columnArg).getColumnName();
-    DataSource dataSource = columnContextMap.get(columnName).getDataSource();
+    DataSource dataSource = columnArg.getDataSource();
     if (dataSource == null) {
-      throw new IllegalArgumentException("Cannot apply TEXT_MATCH on column: " + columnName + " without text index");
+      throw new IllegalArgumentException(
+          "The first argument of TEXT_MATCH transform function must be backed by a segment data source");
     }
+    String columnName = dataSource.getDataSourceMetadata().getFieldSpec().getName();
     TextIndexReader indexReader = dataSource.getTextIndex();
     if (indexReader == null) {
       indexReader = dataSource.getMultiColumnTextIndex();

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunction.java
@@ -25,6 +25,7 @@ import javax.annotation.Nullable;
 import org.apache.pinot.core.operator.ColumnContext;
 import org.apache.pinot.core.operator.blocks.ValueBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
+import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.roaringbitmap.RoaringBitmap;
 
@@ -78,6 +79,13 @@ public interface TransformFunction {
    */
   @Nullable
   Dictionary getDictionary();
+
+  /**
+   * Returns the data source backing the transform result when the result maps directly to a segment data source, or
+   * {@code null} otherwise.
+   */
+  @Nullable
+  DataSource getDataSource();
 
   /**
    * Transforms the data from the given value block to single-valued dictionary ids.

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/DateTimeConversionTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/DateTimeConversionTransformFunctionTest.java
@@ -32,6 +32,7 @@ import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.operator.ColumnContext;
 import org.apache.pinot.core.operator.blocks.ValueBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
+import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.spi.data.DateTimeFieldSpec;
 import org.apache.pinot.spi.data.DateTimeFormatPatternSpec;
@@ -923,6 +924,12 @@ public class DateTimeConversionTransformFunctionTest extends BaseTransformFuncti
     @Nullable
     @Override
     public Dictionary getDictionary() {
+      return null;
+    }
+
+    @Nullable
+    @Override
+    public DataSource getDataSource() {
       return null;
     }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/IdentifierTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/IdentifierTransformFunctionTest.java
@@ -83,6 +83,9 @@ public class IdentifierTransformFunctionTest {
     when(_blockValSet.getIntValuesSV()).thenReturn(INT_VALUES);
     when(_blockValSet.getNullBitmap()).thenReturn(NULL_BITMAP);
     when(_projectionBlock.getBlockValueSet(TEST_COLUMN_NAME)).thenReturn(_blockValSet);
+    when(_columnContext.getDataType()).thenReturn(FieldSpec.DataType.INT);
+    when(_columnContext.isSingleValue()).thenReturn(true);
+    when(_columnContext.getDictionary()).thenReturn(_dictionary);
     when(_columnContext.getDataSource()).thenReturn(_dataSource);
     when(_dataSource.getDictionary()).thenReturn(_dictionary);
     when(_dataSource.getDataSourceMetadata()).thenReturn(_metadata);
@@ -103,5 +106,18 @@ public class IdentifierTransformFunctionTest {
     RoaringBitmap bitmap = identifierTransformFunction.getNullBitmap(_projectionBlock);
     Assert.assertEquals(bitmap, NULL_BITMAP);
     Assert.assertEquals(identifierTransformFunction.transformToIntValuesSV(_projectionBlock), INT_VALUES);
+  }
+
+  @Test
+  public void testDataSource() {
+    IdentifierTransformFunction identifierTransformFunction =
+        new IdentifierTransformFunction(TEST_COLUMN_NAME, _columnContext);
+
+    Assert.assertSame(identifierTransformFunction.getDataSource(), _dataSource);
+    ColumnContext transformColumnContext = ColumnContext.fromTransformFunction(identifierTransformFunction);
+    Assert.assertSame(transformColumnContext.getDataSource(), _dataSource);
+    Assert.assertSame(transformColumnContext.getDictionary(), _dictionary);
+    Assert.assertEquals(transformColumnContext.getDataType(), FieldSpec.DataType.INT);
+    Assert.assertTrue(transformColumnContext.isSingleValue());
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/JsonExtractIndexTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/JsonExtractIndexTransformFunctionTest.java
@@ -33,6 +33,7 @@ import org.apache.pinot.common.function.JsonPathCache;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.RequestContextUtils;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.exception.BadQueryRequestException;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -162,6 +163,17 @@ public class JsonExtractIndexTransformFunctionTest extends BaseTransformFunction
           throw new UnsupportedOperationException("Not support data type - " + resultsDataType);
       }
     }
+  }
+
+  @Test
+  public void testJsonExtractIndexRequiresSegmentDataSource() {
+    ExpressionContext expression =
+        RequestContextUtils.getExpression("jsonExtractIndex('jsonSV','$.intVal','INT')");
+    BadQueryRequestException exception =
+        Assert.expectThrows(BadQueryRequestException.class, () -> TransformFunctionFactory.get(expression,
+            _dataSourceMap));
+    Assert.assertEquals(exception.getCause().getMessage(),
+        "The first argument of jsonExtractIndex must be backed by a segment DataSource");
   }
 
   @DataProvider(name = "testJsonExtractIndexTransformFunction")

--- a/pinot-core/src/test/java/org/apache/pinot/queries/TextMatchTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/TextMatchTransformFunctionTest.java
@@ -117,7 +117,7 @@ public class TextMatchTransformFunctionTest {
       Assert.fail();
     } catch (BadQueryRequestException e) {
       Assert.assertEquals(e.getCause().getMessage(),
-          "The first argument of TEXT_MATCH transform function must be a single-valued column");
+          "The first argument of TEXT_MATCH transform function must be backed by a segment data source");
     }
 
     try {


### PR DESCRIPTION
## Summary
- Add `TransformFunction#getDataSource()` so transform functions can explicitly expose a backing segment `DataSource` when one exists.
- Wire `ColumnContext.fromTransformFunction(...)` to preserve exposed data sources across transform operator chains.
- Update identifier, literal, array literal, generated array, base, and map item transform implementations to implement the new method explicitly.
- Switch `jsonExtractIndex` and `TEXT_MATCH` to consume the source from their input transform instead of re-looking up raw identifiers in `columnContextMap`.

## Why
Some index-backed transform functions need access to the segment `DataSource` for the expression they consume. Before this change, that access was only available through `ColumnContext` for raw columns, which made transform-to-transform chains lose the data source even when a transform result still mapped directly to a segment source.

## DataSource vs Dictionary Contract
`DataSource` and `Dictionary` are related, but neither strictly derives from the other in the general `TransformFunction` API.

- `getDataSource()` answers whether the transform result can expose a backing segment source and its indexes.
- `getDictionary()` answers whether the transform result can be read through dictionary ids.
- `getDataSource() != null` does not imply `getDictionary() != null`; raw columns can have a data source without dictionary encoding.
- `getDictionary() != null` does not imply `getDataSource() != null`; computed transforms can expose dictionary-backed output without being a direct physical data source.
- When a transform result directly maps to a physical source, `getDictionary()` should match `getDataSource().getDictionary()`.

## User Manual
For transform function authors:
- Implement `getDataSource()` explicitly on every `TransformFunction` implementation.
- Return the backing `DataSource` only when the transform output maps directly to a segment data source, such as an identifier or a map item key source.
- Return `null` for computed expressions and literals.
- Prefer `argument.getDataSource()` when a function needs indexes from its input expression.

## Sample Queries
These existing index-backed forms continue to work, with the data source now flowing through the transform-function API:

```sql
SELECT TEXT_MATCH(skills, 'sewing') AS match
FROM testTable;
```

```sql
SELECT jsonExtractIndex(jsonSV, '$.intVal', 'INT')
FROM testTable;
```

## Validation
- `./mvnw -pl pinot-core -am -DskipTests compile`
- `./mvnw -pl pinot-core -am -Dtest=IdentifierTransformFunctionTest,DateTimeConversionTransformFunctionTest,JsonExtractIndexTransformFunctionTest -Dsurefire.failIfNoSpecifiedTests=false -DfailIfNoTests=false test`
- `./mvnw -pl pinot-core -am -Dtest=TextMatchTransformFunctionTest -Dsurefire.failIfNoSpecifiedTests=false -DfailIfNoTests=false test`
