### PR TITLE
refactor: rename MapDataSource getKeyXXX → getXXX for clarity

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/ProjectionBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/ProjectionBlock.java
@@ -67,7 +67,7 @@ public class ProjectionBlock implements ValueBlock {
     // TODO: only support one level of path for now, e.g. `map.key`
     assert paths.length == 2;
     MapDataSource mapDataSource = (MapDataSource) _dataSourceMap.get(paths[0]);
-    DataSource keyDataSource = mapDataSource.getKeyDataSource(paths[1]);
+    DataSource keyDataSource = mapDataSource.getDataSource(paths[1]);
     String fullColumnKeyName = ComplexFieldSpec.getFullChildName(paths);
     _dataSourceMap.put(fullColumnKeyName, keyDataSource);
     _dataBlockCache.addDataSource(fullColumnKeyName, keyDataSource);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ItemTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ItemTransformFunction.java
@@ -60,7 +60,7 @@ public class ItemTransformFunction extends BaseTransformFunction {
     DataSource dataSource = columnContextMap.get(column).getDataSource();
     Preconditions.checkState(dataSource instanceof MapDataSource, "Column: %s must be a MAP column", column);
     MapDataSource mapDataSource = (MapDataSource) dataSource;
-    DataSource valueDataSource = mapDataSource.getKeyDataSource(key);
+    DataSource valueDataSource = mapDataSource.getDataSource(key);
     // Only expose the dictionary when the forward index is dict-encoded. A column can have a dictionary alongside
     // a RAW forward index (e.g. dict + inverted/range), in which case transformToDictIdsSV would fail because
     // BlockValueSet.getDictionaryIdsSV requires a dict-encoded forward index.

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/map/BaseMapDataSource.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/map/BaseMapDataSource.java
@@ -68,7 +68,7 @@ public abstract class BaseMapDataSource extends BaseDataSource implements MapDat
    * @param key to get the DataSource for
    * @return DataSource for the key
    */
-  public DataSource getKeyDataSource(String key) {
+  public DataSource getDataSource(String key) {
     if (_keyDataSources.containsKey(key)) {
       return _keyDataSources.get(key);
     }
@@ -92,22 +92,22 @@ public abstract class BaseMapDataSource extends BaseDataSource implements MapDat
 
   public abstract MapIndexReader getMapIndexReader();
 
-  public Map<String, DataSource> getKeyDataSources() {
+  public Map<String, DataSource> getDataSources() {
     MapIndexReader mapIndexReader = (MapIndexReader) getForwardIndex();
     assert mapIndexReader != null;
     Map<String, DataSource> keyDataSources = new HashMap<>();
     Set<String> allKeys = mapIndexReader.getKeys();
-    allKeys.forEach(key -> keyDataSources.put(key, getKeyDataSource(key)));
+    allKeys.forEach(key -> keyDataSources.put(key, getDataSource(key)));
     return keyDataSources;
   }
 
   @Override
-  public DataSourceMetadata getKeyDataSourceMetadata(String key) {
+  public DataSourceMetadata getDataSourceMetadata(String key) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public ColumnIndexContainer getKeyIndexContainer(String key) {
+  public ColumnIndexContainer getIndexContainer(String key) {
     throw new UnsupportedOperationException();
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/map/BaseMapDataSource.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/map/BaseMapDataSource.java
@@ -68,8 +68,7 @@ public abstract class BaseMapDataSource extends BaseDataSource implements MapDat
    * @param key to get the DataSource for
    * @return DataSource for the key
    */
-  @Override
-  public DataSource getKeyDataSource(String key) {
+  public DataSource getDataSource(String key) {
     if (_keyDataSources.containsKey(key)) {
       return _keyDataSources.get(key);
     }
@@ -93,23 +92,22 @@ public abstract class BaseMapDataSource extends BaseDataSource implements MapDat
 
   public abstract MapIndexReader getMapIndexReader();
 
-  @Override
-  public Map<String, DataSource> getKeyDataSources() {
+  public Map<String, DataSource> getDataSources() {
     MapIndexReader mapIndexReader = (MapIndexReader) getForwardIndex();
     assert mapIndexReader != null;
     Map<String, DataSource> keyDataSources = new HashMap<>();
     Set<String> allKeys = mapIndexReader.getKeys();
-    allKeys.forEach(key -> keyDataSources.put(key, getKeyDataSource(key)));
+    allKeys.forEach(key -> keyDataSources.put(key, getDataSource(key)));
     return keyDataSources;
   }
 
   @Override
-  public DataSourceMetadata getKeyDataSourceMetadata(String key) {
+  public DataSourceMetadata getDataSourceMetadata(String key) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public ColumnIndexContainer getKeyIndexContainer(String key) {
+  public ColumnIndexContainer getIndexContainer(String key) {
     throw new UnsupportedOperationException();
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/map/BaseMapDataSource.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/map/BaseMapDataSource.java
@@ -68,7 +68,8 @@ public abstract class BaseMapDataSource extends BaseDataSource implements MapDat
    * @param key to get the DataSource for
    * @return DataSource for the key
    */
-  public DataSource getDataSource(String key) {
+  @Override
+  public DataSource getKeyDataSource(String key) {
     if (_keyDataSources.containsKey(key)) {
       return _keyDataSources.get(key);
     }
@@ -92,22 +93,23 @@ public abstract class BaseMapDataSource extends BaseDataSource implements MapDat
 
   public abstract MapIndexReader getMapIndexReader();
 
-  public Map<String, DataSource> getDataSources() {
+  @Override
+  public Map<String, DataSource> getKeyDataSources() {
     MapIndexReader mapIndexReader = (MapIndexReader) getForwardIndex();
     assert mapIndexReader != null;
     Map<String, DataSource> keyDataSources = new HashMap<>();
     Set<String> allKeys = mapIndexReader.getKeys();
-    allKeys.forEach(key -> keyDataSources.put(key, getDataSource(key)));
+    allKeys.forEach(key -> keyDataSources.put(key, getKeyDataSource(key)));
     return keyDataSources;
   }
 
   @Override
-  public DataSourceMetadata getDataSourceMetadata(String key) {
+  public DataSourceMetadata getKeyDataSourceMetadata(String key) {
     throw new UnsupportedOperationException();
   }
 
   @Override
-  public ColumnIndexContainer getIndexContainer(String key) {
+  public ColumnIndexContainer getKeyIndexContainer(String key) {
     throw new UnsupportedOperationException();
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/map/ImmutableMapDataSource.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/map/ImmutableMapDataSource.java
@@ -53,12 +53,12 @@ public class ImmutableMapDataSource extends BaseMapDataSource {
   }
 
   @Override
-  public DataSourceMetadata getKeyDataSourceMetadata(String key) {
+  public DataSourceMetadata getDataSourceMetadata(String key) {
     return null;
   }
 
   @Override
-  public ColumnIndexContainer getKeyIndexContainer(String key) {
+  public ColumnIndexContainer getIndexContainer(String key) {
     return null;
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/map/ImmutableMapDataSource.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/map/ImmutableMapDataSource.java
@@ -53,12 +53,12 @@ public class ImmutableMapDataSource extends BaseMapDataSource {
   }
 
   @Override
-  public DataSourceMetadata getDataSourceMetadata(String key) {
+  public DataSourceMetadata getKeyDataSourceMetadata(String key) {
     return null;
   }
 
   @Override
-  public ColumnIndexContainer getIndexContainer(String key) {
+  public ColumnIndexContainer getKeyIndexContainer(String key) {
     return null;
   }
 

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/datasource/MapDataSource.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/datasource/MapDataSource.java
@@ -23,30 +23,22 @@ import org.apache.pinot.segment.spi.index.column.ColumnIndexContainer;
 import org.apache.pinot.spi.data.ComplexFieldSpec;
 
 
+/// DataSource for a MAP column. Provides per-key DataSources that can be used for filtering,
+/// aggregation, and projection on individual MAP keys.
 public interface MapDataSource extends DataSource {
 
-  /**
-   * Get the map FieldSpec.
-   */
+  /// Returns the map FieldSpec.
   ComplexFieldSpec.MapFieldSpec getFieldSpec();
 
-  /**
-   * Get the Data Source representation of a single key within this map column.
-   */
-  DataSource getKeyDataSource(String key);
+  /// Returns the DataSource for the given map key's values.
+  DataSource getDataSource(String key);
 
-  /**
-   * Get the Data Source representation of all keys within this map column.
-   */
-  Map<String, DataSource> getKeyDataSources();
+  /// Returns DataSources for all keys present in this segment.
+  Map<String, DataSource> getDataSources();
 
-  /**
-   * Get the DataSourceMetadata of a single key within this map column.
-   */
-  DataSourceMetadata getKeyDataSourceMetadata(String key);
+  /// Returns the DataSourceMetadata for the given key's values.
+  DataSourceMetadata getDataSourceMetadata(String key);
 
-  /**
-   * Get the IndexContainer of a single key within this map column.
-   */
-  ColumnIndexContainer getKeyIndexContainer(String key);
+  /// Returns the ColumnIndexContainer for the given key's values.
+  ColumnIndexContainer getIndexContainer(String key);
 }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/datasource/MapDataSource.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/datasource/MapDataSource.java
@@ -25,20 +25,53 @@ import org.apache.pinot.spi.data.ComplexFieldSpec;
 
 /// DataSource for a MAP column. Provides per-key DataSources that can be used for filtering,
 /// aggregation, and projection on individual MAP keys.
+///
+/// **Migration note:** the `getKeyXXX` methods are deprecated in favor of shorter names without
+/// the `Key` infix (e.g. `getDataSource`, `getDataSources`). New implementations should override
+/// the new names and leave the deprecated ones alone. Existing implementations that override only
+/// the old names will continue to work — the new-name defaults delegate to the deprecated methods.
 public interface MapDataSource extends DataSource {
 
   /// Returns the map FieldSpec.
   ComplexFieldSpec.MapFieldSpec getFieldSpec();
 
+  // ---- Preferred API (new names) — override these in new implementations ----
+
   /// Returns the DataSource for the given map key's values.
-  DataSource getDataSource(String key);
+  default DataSource getDataSource(String key) {
+    return getKeyDataSource(key);
+  }
 
   /// Returns DataSources for all keys present in this segment.
-  Map<String, DataSource> getDataSources();
+  default Map<String, DataSource> getDataSources() {
+    return getKeyDataSources();
+  }
 
   /// Returns the DataSourceMetadata for the given key's values.
-  DataSourceMetadata getDataSourceMetadata(String key);
+  default DataSourceMetadata getDataSourceMetadata(String key) {
+    return getKeyDataSourceMetadata(key);
+  }
 
   /// Returns the ColumnIndexContainer for the given key's values.
-  ColumnIndexContainer getIndexContainer(String key);
+  default ColumnIndexContainer getIndexContainer(String key) {
+    return getKeyIndexContainer(key);
+  }
+
+  // ---- Deprecated API (old names) — still abstract for backward compatibility ----
+
+  /// @deprecated Use {@link #getDataSource(String)} instead.
+  @Deprecated
+  DataSource getKeyDataSource(String key);
+
+  /// @deprecated Use {@link #getDataSources()} instead.
+  @Deprecated
+  Map<String, DataSource> getKeyDataSources();
+
+  /// @deprecated Use {@link #getDataSourceMetadata(String)} instead.
+  @Deprecated
+  DataSourceMetadata getKeyDataSourceMetadata(String key);
+
+  /// @deprecated Use {@link #getIndexContainer(String)} instead.
+  @Deprecated
+  ColumnIndexContainer getKeyIndexContainer(String key);
 }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/datasource/MapDataSource.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/datasource/MapDataSource.java
@@ -25,53 +25,20 @@ import org.apache.pinot.spi.data.ComplexFieldSpec;
 
 /// DataSource for a MAP column. Provides per-key DataSources that can be used for filtering,
 /// aggregation, and projection on individual MAP keys.
-///
-/// **Migration note:** the `getKeyXXX` methods are deprecated in favor of shorter names without
-/// the `Key` infix (e.g. `getDataSource`, `getDataSources`). New implementations should override
-/// the new names and leave the deprecated ones alone. Existing implementations that override only
-/// the old names will continue to work — the new-name defaults delegate to the deprecated methods.
 public interface MapDataSource extends DataSource {
 
   /// Returns the map FieldSpec.
   ComplexFieldSpec.MapFieldSpec getFieldSpec();
 
-  // ---- Preferred API (new names) — override these in new implementations ----
-
   /// Returns the DataSource for the given map key's values.
-  default DataSource getDataSource(String key) {
-    return getKeyDataSource(key);
-  }
+  DataSource getDataSource(String key);
 
   /// Returns DataSources for all keys present in this segment.
-  default Map<String, DataSource> getDataSources() {
-    return getKeyDataSources();
-  }
+  Map<String, DataSource> getDataSources();
 
   /// Returns the DataSourceMetadata for the given key's values.
-  default DataSourceMetadata getDataSourceMetadata(String key) {
-    return getKeyDataSourceMetadata(key);
-  }
+  DataSourceMetadata getDataSourceMetadata(String key);
 
   /// Returns the ColumnIndexContainer for the given key's values.
-  default ColumnIndexContainer getIndexContainer(String key) {
-    return getKeyIndexContainer(key);
-  }
-
-  // ---- Deprecated API (old names) — still abstract for backward compatibility ----
-
-  /// @deprecated Use {@link #getDataSource(String)} instead.
-  @Deprecated
-  DataSource getKeyDataSource(String key);
-
-  /// @deprecated Use {@link #getDataSources()} instead.
-  @Deprecated
-  Map<String, DataSource> getKeyDataSources();
-
-  /// @deprecated Use {@link #getDataSourceMetadata(String)} instead.
-  @Deprecated
-  DataSourceMetadata getKeyDataSourceMetadata(String key);
-
-  /// @deprecated Use {@link #getIndexContainer(String)} instead.
-  @Deprecated
-  ColumnIndexContainer getKeyIndexContainer(String key);
+  ColumnIndexContainer getIndexContainer(String key);
 }


### PR DESCRIPTION
The Key prefix in getKeyDataSource/getKeyDataSources/getKeyDataSourceMetadata/ getKeyIndexContainer was misleading: all four methods take a String key and return value-oriented objects. Rename to getDataSource/getDataSources/getDataSourceMetadata/ getIndexContainer to describe what is returned, not what the parameter is.

