### PR TITLE
Backfill lengthOfLongestElement when dictionaryElementSize is zero

### DIFF
--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/readers/ImmutableDictionaryTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/readers/ImmutableDictionaryTest.java
@@ -30,14 +30,18 @@ import java.util.HashSet;
 import java.util.Random;
 import java.util.Set;
 import java.util.TreeSet;
+import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.pinot.segment.local.PinotBuffersAfterMethodCheckRule;
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentDictionaryCreator;
 import org.apache.pinot.segment.spi.V1Constants;
+import org.apache.pinot.segment.spi.V1Constants.MetadataKeys.Column;
+import org.apache.pinot.segment.spi.index.metadata.ColumnMetadataImpl;
 import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
 import org.apache.pinot.spi.data.DimensionFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.data.FieldSpec.FieldType;
 import org.apache.pinot.spi.data.MetricFieldSpec;
 import org.apache.pinot.spi.utils.BigDecimalUtils;
 import org.apache.pinot.spi.utils.ByteArray;
@@ -463,6 +467,50 @@ public class ImmutableDictionaryTest implements PinotBuffersAfterMethodCheckRule
       RANDOM.nextBytes(randomBytes);
       assertEquals(bytesDictionary.insertionIndexOf(BytesUtils.toHexString(randomBytes)),
           Arrays.binarySearch(_bytesValues, new ByteArray(randomBytes)));
+    }
+  }
+
+  /**
+   * Regression test for old segments (pre-1.6.0) that have a STRING column with all-empty values:
+   * the segment lacks LENGTH_OF_LONGEST_ELEMENT (introduced in 1.6.0) and has DICTIONARY_ELEMENT_SIZE=0
+   * (the longest entry length is zero when every entry is empty). The metadata loader must canonicalize
+   * the longest-element length to 0 here; otherwise it leaves the field at the UNAVAILABLE sentinel
+   * (-1), which propagates into StringDictionary.getBuffer() as `new byte[-1]` and fails query
+   * execution with NegativeArraySizeException.
+   */
+  @Test
+  public void testStringDictionaryReadOnPre16OldSegmentMetadata()
+      throws Exception {
+    String columnName = "emptyStringCol";
+    // Build a real var-length string dictionary on disk holding a single empty value.
+    try (SegmentDictionaryCreator dictCreator = new SegmentDictionaryCreator(
+        new DimensionFieldSpec(columnName, DataType.STRING, true), TEMP_DIR, true)) {
+      dictCreator.build(new String[]{""});
+      assertEquals(dictCreator.getNumBytesPerEntry(), 0);
+    }
+
+    // Simulate pre-1.6.0 metadata: HAS_DICTIONARY=true, DICTIONARY_ELEMENT_SIZE=0, no LENGTH_OF_LONGEST_ELEMENT.
+    PropertiesConfiguration config = new PropertiesConfiguration();
+    config.setProperty(Column.getKeyFor(columnName, Column.COLUMN_NAME), columnName);
+    config.setProperty(Column.getKeyFor(columnName, Column.COLUMN_TYPE), FieldType.DIMENSION.name());
+    config.setProperty(Column.getKeyFor(columnName, Column.DATA_TYPE), DataType.STRING.name());
+    config.setProperty(Column.getKeyFor(columnName, Column.IS_SINGLE_VALUED), true);
+    config.setProperty(Column.getKeyFor(columnName, Column.CARDINALITY), 1);
+    config.setProperty(Column.getKeyFor(columnName, Column.HAS_DICTIONARY), true);
+    config.setProperty(Column.getKeyFor(columnName, Column.DICTIONARY_ELEMENT_SIZE), 0);
+    // LENGTH_OF_LONGEST_ELEMENT intentionally NOT set.
+
+    ColumnMetadataImpl metadata = ColumnMetadataImpl.fromPropertiesConfiguration(config, 1, columnName);
+
+    // Reproduce the production code path: DictionaryIndexType passes metadata.getLengthOfLongestElement()
+    // as numBytesPerValue. Without the canonicalization fix this is -1, and StringDictionary.readStringValues
+    // throws NegativeArraySizeException at BaseImmutableDictionary.getBuffer().
+    try (PinotDataBuffer buffer = PinotDataBuffer.mapReadOnlyBigEndianFile(
+        new File(TEMP_DIR, columnName + V1Constants.Dict.FILE_EXTENSION));
+        StringDictionary dict = new StringDictionary(buffer, 1, metadata.getLengthOfLongestElement())) {
+      String[] outValues = new String[1];
+      dict.readStringValues(new int[]{0}, 1, outValues);
+      assertEquals(outValues[0], "");
     }
   }
 

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/metadata/ColumnMetadataImpl.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/metadata/ColumnMetadataImpl.java
@@ -571,11 +571,11 @@ public class ColumnMetadataImpl implements ColumnMetadata {
         _lengthOfShortestElement = size;
         _lengthOfLongestElement = size;
       } else {
-        // Pre-1.6.0 segments don't write LENGTH_OF_LONGEST_ELEMENT; fall back to DICTIONARY_ELEMENT_SIZE
-        // (which is non-negative for any dictionary-encoded column, including columns where every value
-        // is empty and the longest entry is zero bytes). Leaving the field at the UNAVAILABLE sentinel
-        // would propagate as `numBytesPerValue = -1` into BaseImmutableDictionary.getBuffer().
-        if (_lengthOfLongestElement < 0 && _dictionaryElementSize >= 0) {
+        // Pre-1.6.0 segments don't write LENGTH_OF_LONGEST_ELEMENT; fall back to DICTIONARY_ELEMENT_SIZE,
+        // which has been written for dictionary-encoded columns since well before 1.6.0 (including the
+        // zero-length case where every entry is an empty string). Leaving the field at the UNAVAILABLE
+        // sentinel would propagate as `numBytesPerValue = -1` into BaseImmutableDictionary.getBuffer().
+        if (_lengthOfLongestElement < 0 && _hasDictionary) {
           _lengthOfLongestElement = _dictionaryElementSize;
         }
       }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/metadata/ColumnMetadataImpl.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/metadata/ColumnMetadataImpl.java
@@ -571,7 +571,11 @@ public class ColumnMetadataImpl implements ColumnMetadata {
         _lengthOfShortestElement = size;
         _lengthOfLongestElement = size;
       } else {
-        if (_lengthOfLongestElement < 0 && _dictionaryElementSize > 0) {
+        // Pre-1.6.0 segments don't write LENGTH_OF_LONGEST_ELEMENT; fall back to DICTIONARY_ELEMENT_SIZE
+        // (which is non-negative for any dictionary-encoded column, including columns where every value
+        // is empty and the longest entry is zero bytes). Leaving the field at the UNAVAILABLE sentinel
+        // would propagate as `numBytesPerValue = -1` into BaseImmutableDictionary.getBuffer().
+        if (_lengthOfLongestElement < 0 && _dictionaryElementSize >= 0) {
           _lengthOfLongestElement = _dictionaryElementSize;
         }
       }


### PR DESCRIPTION
## Summary
Pre-1.6.0 segments don't write the `lengthOfLongestElement` metadata key. The loader in `ColumnMetadataImpl.Builder.build()` backfills it from `dictionaryElementSize`, but only when the latter is strictly positive. For dictionary-encoded STRING columns where every value is empty (e.g. an empty-string default column added via schema evolution), `dictionaryElementSize` is `0`, so the fallback is skipped and `lengthOfLongestElement` is left at the `UNAVAILABLE` sentinel (`-1`). That `-1` then propagates into `StringDictionary` as `numBytesPerValue`, and `BaseImmutableDictionary.getBuffer()` throws `NegativeArraySizeException` at query time:

```
java.lang.NegativeArraySizeException: -1
  at BaseImmutableDictionary.getBuffer(BaseImmutableDictionary.java:295)
  at StringDictionary.getBuffer(StringDictionary.java:85)
  at StringDictionary.readStringValues(StringDictionary.java:164)
```

Regression introduced in #18280, which switched `DictionaryIndexType` from reading the legacy `lengthOfEachEntry` (always present) to the new `lengthOfLongestElement` (only present on segments built >= 1.6.0).

Fix: relax the backfill guard to `>= 0` so a zero-length longest entry still canonicalizes correctly. The added test reproduces the exact production stack trace before the fix and passes after.

## Test plan
- [x] New `ImmutableDictionaryTest#testStringDictionaryReadOnPre16OldSegmentMetadata` reproduces the original `NegativeArraySizeException` on the pre-fix code path and passes after the fix
- [x] Full `ImmutableDictionaryTest`, `ColumnMetadataImplTest`, `ColumnMetadataTest` pass
- [x] spotless / checkstyle / license clean