### PR TITLE
Make RangeIndexBasedFilterOperator canEvaluate public

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/RangeIndexBasedFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/RangeIndexBasedFilterOperator.java
@@ -55,7 +55,7 @@ public class RangeIndexBasedFilterOperator extends BaseColumnFilterOperator {
   private final PredicateEvaluator _predicateEvaluator;
   private final FieldSpec.DataType _parameterType;
 
-  static boolean canEvaluate(PredicateEvaluator predicateEvaluator, DataSource dataSource) {
+  public static boolean canEvaluate(PredicateEvaluator predicateEvaluator, DataSource dataSource) {
     RangeIndexReader<?> rangeIndex = dataSource.getRangeIndex();
     if (rangeIndex == null) {
       return false;


### PR DESCRIPTION
## Summary
- Make `RangeIndexBasedFilterOperator.canEvaluate` a `public static` helper so callers outside the package can reuse the existing range-index eligibility logic.

## User manual / examples
- Not applicable. This is a Java API visibility change only; it does not alter table config, query syntax, or runtime behavior.

## Validation
- `./mvnw -pl pinot-core -am -DskipTests compile`