### PR TITLE
Add Custom partition function for expression-based partitioning

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/manager/BaseBrokerRoutingManager.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/manager/BaseBrokerRoutingManager.java
@@ -809,7 +809,8 @@ public abstract class BaseBrokerRoutingManager implements RoutingManager, Cluste
                 tableNameWithType, partitionConfig.getKey());
             partitionMetadataManager =
                 new SegmentPartitionMetadataManager(tableNameWithType, partitionConfig.getKey(),
-                    partitionConfig.getValue().getFunctionName(), partitionConfig.getValue().getNumPartitions());
+                    partitionConfig.getValue().getFunctionName(), partitionConfig.getValue().getNumPartitions(),
+                    partitionConfig.getValue().getFunctionConfig());
           } else {
             LOGGER.warn(
                 "Cannot enable SegmentPartitionMetadataManager for table: {} with multiple partition columns: {}",

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpartition/SegmentPartitionMetadataManager.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpartition/SegmentPartitionMetadataManager.java
@@ -24,6 +24,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.tuple.Pair;
@@ -39,6 +40,7 @@ import org.apache.pinot.core.routing.TablePartitionInfo;
 import org.apache.pinot.core.routing.TablePartitionReplicatedServersInfo;
 import org.apache.pinot.core.routing.TablePartitionReplicatedServersInfo.PartitionInfo;
 import org.apache.pinot.segment.spi.partition.PartitionFunction;
+import org.apache.pinot.segment.spi.partition.PartitionFunctionFactory;
 import org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.SegmentStateModel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -54,6 +56,7 @@ import org.slf4j.LoggerFactory;
  */
 public class SegmentPartitionMetadataManager implements SegmentZkMetadataFetchListener {
   private static final Logger LOGGER = LoggerFactory.getLogger(SegmentPartitionMetadataManager.class);
+  private static final String CUSTOM_PARTITION_FUNCTION_NAME = "Custom";
   private static final int INVALID_PARTITION_ID = -1;
   private static final long INVALID_CREATION_TIME_MS = -1L;
 
@@ -63,6 +66,7 @@ public class SegmentPartitionMetadataManager implements SegmentZkMetadataFetchLi
   private final String _partitionColumn;
   private final String _partitionFunctionName;
   private final int _numPartitions;
+  private final PartitionFunction _partitionFunction;
 
   // cache-able content, only follow changes if onlineSegments list (of ideal-state) is changed.
   private final Map<String, SegmentInfo> _segmentInfoMap = new HashMap<>();
@@ -73,10 +77,18 @@ public class SegmentPartitionMetadataManager implements SegmentZkMetadataFetchLi
 
   public SegmentPartitionMetadataManager(String tableNameWithType, String partitionColumn, String partitionFunctionName,
       int numPartitions) {
+    this(tableNameWithType, partitionColumn, partitionFunctionName, numPartitions, null);
+  }
+
+  public SegmentPartitionMetadataManager(String tableNameWithType, String partitionColumn, String partitionFunctionName,
+      int numPartitions, @Nullable Map<String, String> functionConfig) {
     _tableNameWithType = tableNameWithType;
     _partitionColumn = partitionColumn;
     _partitionFunctionName = partitionFunctionName;
     _numPartitions = numPartitions;
+    _partitionFunction =
+        PartitionFunctionFactory.getPartitionFunction(partitionColumn, partitionFunctionName, numPartitions,
+            functionConfig);
   }
 
   @Override
@@ -109,11 +121,19 @@ public class SegmentPartitionMetadataManager implements SegmentZkMetadataFetchLi
     if (_numPartitions != partitionFunction.getNumPartitions()) {
       return INVALID_PARTITION_ID;
     }
+    if (isCustomPartitionFunction(partitionFunction) && !Objects.equals(_partitionFunction.getFunctionConfig(),
+        partitionFunction.getFunctionConfig())) {
+      return INVALID_PARTITION_ID;
+    }
     Set<Integer> partitions = segmentPartitionInfo.getPartitions();
     if (partitions.size() != 1) {
       return INVALID_PARTITION_ID;
     }
     return partitions.iterator().next();
+  }
+
+  private static boolean isCustomPartitionFunction(PartitionFunction partitionFunction) {
+    return CUSTOM_PARTITION_FUNCTION_NAME.equalsIgnoreCase(partitionFunction.getName());
   }
 
   private static long getCreationTimeMs(@Nullable ZNRecord znRecord) {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpartition/SegmentPartitionUtils.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpartition/SegmentPartitionUtils.java
@@ -41,13 +41,11 @@ public class SegmentPartitionUtils {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(SegmentPartitionUtils.class);
 
-  /**
-   * Returns the partition info for a given segment with single partition column.
-   *
-   * NOTE: Returns {@code null} when the ZNRecord is missing (could be transient Helix issue). Returns
-   *       {@link #INVALID_PARTITION_INFO} when the segment does not have valid partition metadata in its ZK metadata,
-   *       in which case we won't retry later.
-   */
+  /// Returns the partition info for a given segment with single partition column.
+  ///
+  /// NOTE: Returns `null` when the ZNRecord is missing (could be transient Helix issue). Returns
+  /// [SegmentPartitionUtils#INVALID_PARTITION_INFO] when the segment does not have valid partition metadata in its ZK
+  /// metadata, in which case we won't retry later.
   @Nullable
   public static SegmentPartitionInfo extractPartitionInfo(String tableNameWithType, String partitionColumn,
       String segment, @Nullable ZNRecord znRecord) {
@@ -79,18 +77,16 @@ public class SegmentPartitionUtils {
       return INVALID_PARTITION_INFO;
     }
 
-    return new SegmentPartitionInfo(partitionColumn,
-        PartitionFunctionFactory.getPartitionFunction(columnPartitionMetadata),
-        columnPartitionMetadata.getPartitions());
+    SegmentPartitionInfo segmentPartitionInfo =
+        getSegmentPartitionInfo(tableNameWithType, segment, partitionColumn, columnPartitionMetadata);
+    return segmentPartitionInfo != null ? segmentPartitionInfo : INVALID_PARTITION_INFO;
   }
 
-  /**
-   * Returns a map from partition column name to partition info for a given segment with multiple partition columns.
-   *
-   * NOTE: Returns {@code null} when the ZNRecord is missing (could be transient Helix issue). Returns
-   *       {@link #INVALID_COLUMN_PARTITION_INFO_MAP} when the segment does not have valid partition metadata in its ZK
-   *       metadata, in which case we won't retry later.
-   */
+  /// Returns a map from partition column name to partition info for a given segment with multiple partition columns.
+  ///
+  /// NOTE: Returns `null` when the ZNRecord is missing (could be transient Helix issue). Returns
+  /// [SegmentPartitionUtils#INVALID_COLUMN_PARTITION_INFO_MAP] when the segment does not have valid partition metadata
+  /// in its ZK metadata, in which case we won't retry later.
   @Nullable
   public static Map<String, SegmentPartitionInfo> extractPartitionInfoMap(String tableNameWithType,
       Set<String> partitionColumns, String segment, @Nullable ZNRecord znRecord) {
@@ -123,15 +119,44 @@ public class SegmentPartitionUtils {
             segment, tableNameWithType);
         continue;
       }
-      SegmentPartitionInfo segmentPartitionInfo = new SegmentPartitionInfo(partitionColumn,
-          PartitionFunctionFactory.getPartitionFunction(columnPartitionMetadata),
-          columnPartitionMetadata.getPartitions());
-      columnSegmentPartitionInfoMap.put(partitionColumn, segmentPartitionInfo);
+      SegmentPartitionInfo segmentPartitionInfo =
+          getSegmentPartitionInfo(tableNameWithType, segment, partitionColumn, columnPartitionMetadata);
+      if (segmentPartitionInfo != null) {
+        columnSegmentPartitionInfoMap.put(partitionColumn, segmentPartitionInfo);
+      }
     }
     if (columnSegmentPartitionInfoMap.size() == 1) {
       String partitionColumn = columnSegmentPartitionInfoMap.keySet().iterator().next();
       return Collections.singletonMap(partitionColumn, columnSegmentPartitionInfoMap.get(partitionColumn));
     }
     return columnSegmentPartitionInfoMap.isEmpty() ? INVALID_COLUMN_PARTITION_INFO_MAP : columnSegmentPartitionInfoMap;
+  }
+
+  @Nullable
+  private static SegmentPartitionInfo getSegmentPartitionInfo(String tableNameWithType, String segment,
+      String partitionColumn, ColumnPartitionMetadata columnPartitionMetadata) {
+    try {
+      return new SegmentPartitionInfo(partitionColumn,
+          PartitionFunctionFactory.getPartitionFunction(partitionColumn, columnPartitionMetadata),
+          validPartitions(columnPartitionMetadata) ? columnPartitionMetadata.getPartitions() : Collections.emptySet());
+    } catch (RuntimeException e) {
+      LOGGER.warn("Caught exception while extracting partition info for column: {}, segment: {}, table: {}",
+          partitionColumn, segment, tableNameWithType, e);
+      return null;
+    }
+  }
+
+  private static boolean validPartitions(ColumnPartitionMetadata columnPartitionMetadata) {
+    Set<Integer> partitions = columnPartitionMetadata.getPartitions();
+    if (partitions == null || partitions.isEmpty()) {
+      return false;
+    }
+    int numPartitions = columnPartitionMetadata.getNumPartitions();
+    for (int partition : partitions) {
+      if (partition < 0 || partition >= numPartitions) {
+        return false;
+      }
+    }
+    return true;
   }
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/MultiPartitionColumnsSegmentPruner.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/MultiPartitionColumnsSegmentPruner.java
@@ -35,6 +35,7 @@ import org.apache.pinot.common.request.Expression;
 import org.apache.pinot.common.request.Function;
 import org.apache.pinot.common.request.Identifier;
 import org.apache.pinot.common.request.context.RequestContextUtils;
+import org.apache.pinot.segment.spi.partition.PartitionFunction;
 import org.apache.pinot.sql.FilterKind;
 
 
@@ -140,8 +141,8 @@ public class MultiPartitionColumnsSegmentPruner implements SegmentPruner {
         Identifier identifier = operands.get(0).getIdentifier();
         if (identifier != null) {
           SegmentPartitionInfo partitionInfo = columnPartitionInfoMap.get(identifier.getName());
-          return partitionInfo == null || partitionInfo.getPartitions().contains(
-              partitionInfo.getPartitionFunction().getPartition(RequestContextUtils.getStringValue(operands.get(1))));
+          return partitionInfo == null || isPartitionMatch(partitionInfo,
+              RequestContextUtils.getStringValue(operands.get(1)));
         } else {
           return true;
         }
@@ -155,8 +156,7 @@ public class MultiPartitionColumnsSegmentPruner implements SegmentPruner {
           }
           int numOperands = operands.size();
           for (int i = 1; i < numOperands; i++) {
-            if (partitionInfo.getPartitions().contains(partitionInfo.getPartitionFunction()
-                .getPartition(RequestContextUtils.getStringValue(operands.get(i))))) {
+            if (isPartitionMatch(partitionInfo, RequestContextUtils.getStringValue(operands.get(i)))) {
               return true;
             }
           }
@@ -168,5 +168,15 @@ public class MultiPartitionColumnsSegmentPruner implements SegmentPruner {
       default:
         return true;
     }
+  }
+
+  private static boolean isPartitionMatch(SegmentPartitionInfo partitionInfo, String value) {
+    Set<Integer> partitions = partitionInfo.getPartitions();
+    if (partitions.isEmpty()) {
+      return true;
+    }
+    PartitionFunction partitionFunction = partitionInfo.getPartitionFunction();
+    int partitionId = partitionFunction.getPartition(value);
+    return partitionId < 0 || partitionId >= partitionFunction.getNumPartitions() || partitions.contains(partitionId);
   }
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/SinglePartitionColumnSegmentPruner.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/SinglePartitionColumnSegmentPruner.java
@@ -34,6 +34,7 @@ import org.apache.pinot.common.request.Expression;
 import org.apache.pinot.common.request.Function;
 import org.apache.pinot.common.request.Identifier;
 import org.apache.pinot.common.request.context.RequestContextUtils;
+import org.apache.pinot.segment.spi.partition.PartitionFunction;
 import org.apache.pinot.sql.FilterKind;
 
 
@@ -129,8 +130,7 @@ public class SinglePartitionColumnSegmentPruner implements SegmentPruner {
       case EQUALS: {
         Identifier identifier = operands.get(0).getIdentifier();
         if (identifier != null && identifier.getName().equals(_partitionColumn)) {
-          return partitionInfo.getPartitions().contains(partitionInfo.getPartitionFunction()
-              .getPartition(RequestContextUtils.getStringValue(operands.get(1))));
+          return isPartitionMatch(partitionInfo, RequestContextUtils.getStringValue(operands.get(1)));
         } else {
           return true;
         }
@@ -140,8 +140,7 @@ public class SinglePartitionColumnSegmentPruner implements SegmentPruner {
         if (identifier != null && identifier.getName().equals(_partitionColumn)) {
           int numOperands = operands.size();
           for (int i = 1; i < numOperands; i++) {
-            if (partitionInfo.getPartitions().contains(partitionInfo.getPartitionFunction()
-                .getPartition(RequestContextUtils.getStringValue(operands.get(i))))) {
+            if (isPartitionMatch(partitionInfo, RequestContextUtils.getStringValue(operands.get(i)))) {
               return true;
             }
           }
@@ -153,5 +152,15 @@ public class SinglePartitionColumnSegmentPruner implements SegmentPruner {
       default:
         return true;
     }
+  }
+
+  private static boolean isPartitionMatch(SegmentPartitionInfo partitionInfo, String value) {
+    Set<Integer> partitions = partitionInfo.getPartitions();
+    if (partitions.isEmpty()) {
+      return true;
+    }
+    PartitionFunction partitionFunction = partitionInfo.getPartitionFunction();
+    int partitionId = partitionFunction.getPartition(value);
+    return partitionId < 0 || partitionId >= partitionFunction.getNumPartitions() || partitions.contains(partitionId);
   }
 }

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentpartition/SegmentPartitionMetadataManagerFunctionConfigTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentpartition/SegmentPartitionMetadataManagerFunctionConfigTest.java
@@ -1,0 +1,102 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.routing.segmentpartition;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.IdealState;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.pinot.common.metadata.segment.SegmentPartitionMetadata;
+import org.apache.pinot.common.partition.function.CustomPartitionFunction;
+import org.apache.pinot.core.routing.TablePartitionReplicatedServersInfo;
+import org.apache.pinot.segment.spi.partition.metadata.ColumnPartitionMetadata;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.testng.annotations.Test;
+
+import static org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.SegmentStateModel.ONLINE;
+import static org.testng.Assert.*;
+
+
+/// Tests table-vs-segment partition function config matching in [SegmentPartitionMetadataManager].
+public class SegmentPartitionMetadataManagerFunctionConfigTest {
+  private static final String OFFLINE_TABLE_NAME = "testTable_OFFLINE";
+  private static final String PARTITION_COLUMN = "memberId";
+  private static final String PARTITION_COLUMN_FUNC = "Murmur";
+  private static final int NUM_PARTITIONS = 2;
+  private static final String SERVER_0 = "server0";
+
+  @Test
+  public void testBuiltInPartitionFunctionIgnoresEmptyConfigWhenSegmentMetadataHasNoConfig()
+      throws IOException {
+    SegmentPartitionMetadataManager partitionMetadataManager =
+        new SegmentPartitionMetadataManager(OFFLINE_TABLE_NAME, PARTITION_COLUMN, PARTITION_COLUMN_FUNC,
+            NUM_PARTITIONS, Collections.emptyMap());
+    String segment = "segmentWithNullFunctionConfig";
+    partitionMetadataManager.init(new IdealState(OFFLINE_TABLE_NAME), getExternalView(segment),
+        Collections.singletonList(segment), Collections.singletonList(
+            getSegmentZKMetadataRecord(segment, PARTITION_COLUMN_FUNC, NUM_PARTITIONS, 0, null)));
+
+    TablePartitionReplicatedServersInfo tablePartitionReplicatedServersInfo = partitionMetadataManager
+        .getTablePartitionReplicatedServersInfo();
+    assertTrue(tablePartitionReplicatedServersInfo.getSegmentsWithInvalidPartition().isEmpty());
+    TablePartitionReplicatedServersInfo.PartitionInfo[] partitionInfoMap = tablePartitionReplicatedServersInfo
+        .getPartitionInfoMap();
+    assertEquals(partitionInfoMap[0]._fullyReplicatedServers, Collections.singleton(SERVER_0));
+    assertEquals(partitionInfoMap[0]._segments, Collections.singleton(segment));
+  }
+
+  @Test
+  public void testCustomPartitionFunctionComparesFunctionConfig()
+      throws IOException {
+    Map<String, String> tableFunctionConfig =
+        Map.of(CustomPartitionFunction.PARTITION_EXPRESSION_CONFIG_KEY, "plus(memberId,0)");
+    Map<String, String> segmentFunctionConfig =
+        Map.of(CustomPartitionFunction.PARTITION_EXPRESSION_CONFIG_KEY, "plus(memberId,1)");
+    SegmentPartitionMetadataManager partitionMetadataManager =
+        new SegmentPartitionMetadataManager(OFFLINE_TABLE_NAME, PARTITION_COLUMN, CustomPartitionFunction.NAME,
+            NUM_PARTITIONS, tableFunctionConfig);
+    String segment = "segmentWithDifferentCustomFunctionConfig";
+    partitionMetadataManager.init(new IdealState(OFFLINE_TABLE_NAME), getExternalView(segment),
+        Collections.singletonList(segment), Collections.singletonList(
+            getSegmentZKMetadataRecord(segment, CustomPartitionFunction.NAME, NUM_PARTITIONS, 0,
+                segmentFunctionConfig)));
+
+    assertEquals(partitionMetadataManager.getTablePartitionReplicatedServersInfo().getSegmentsWithInvalidPartition(),
+        Collections.singletonList(segment));
+  }
+
+  private static ExternalView getExternalView(String segment) {
+    ExternalView externalView = new ExternalView(OFFLINE_TABLE_NAME);
+    externalView.getRecord().getMapFields().put(segment, Collections.singletonMap(SERVER_0, ONLINE));
+    return externalView;
+  }
+
+  private static ZNRecord getSegmentZKMetadataRecord(String segment, String partitionFunction, int numPartitions,
+      int partitionId, Map<String, String> functionConfig)
+      throws IOException {
+    ZNRecord znRecord = new ZNRecord(segment);
+    znRecord.setSimpleField(CommonConstants.Segment.PARTITION_METADATA,
+        new SegmentPartitionMetadata(Collections.singletonMap(PARTITION_COLUMN,
+            new ColumnPartitionMetadata(partitionFunction, numPartitions, Collections.singleton(partitionId),
+                functionConfig))).toJsonString());
+    return znRecord;
+  }
+}

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentpartition/SegmentPartitionUtilsTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentpartition/SegmentPartitionUtilsTest.java
@@ -1,0 +1,82 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.routing.segmentpartition;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.pinot.common.metadata.segment.SegmentPartitionMetadata;
+import org.apache.pinot.common.partition.function.CustomPartitionFunction;
+import org.apache.pinot.segment.spi.partition.metadata.ColumnPartitionMetadata;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+
+public class SegmentPartitionUtilsTest {
+  private static final String TABLE_NAME_WITH_TYPE = "testTable_OFFLINE";
+  private static final String SEGMENT_NAME = "testSegment";
+
+  @Test
+  public void testExtractPartitionInfoReturnsInvalidForInvalidPartitionFunction()
+      throws IOException {
+    ZNRecord znRecord =
+        getZnRecord(Map.of("memberId", getInvalidCustomPartitionMetadata("plus(otherColumn, 1)", Set.of(0))));
+
+    SegmentPartitionInfo segmentPartitionInfo =
+        SegmentPartitionUtils.extractPartitionInfo(TABLE_NAME_WITH_TYPE, "memberId", SEGMENT_NAME, znRecord);
+
+    assertSame(segmentPartitionInfo, SegmentPartitionUtils.INVALID_PARTITION_INFO);
+  }
+
+  @Test
+  public void testExtractPartitionInfoMapSkipsInvalidPartitionFunction()
+      throws IOException {
+    ZNRecord znRecord = getZnRecord(Map.of("memberId",
+        getInvalidCustomPartitionMetadata("plus(otherColumn, 1)", Set.of(0)), "accountId",
+        new ColumnPartitionMetadata("Modulo", 4, Set.of(2), null)));
+
+    Map<String, SegmentPartitionInfo> partitionInfoMap = SegmentPartitionUtils.extractPartitionInfoMap(
+        TABLE_NAME_WITH_TYPE, Set.of("memberId", "accountId"), SEGMENT_NAME, znRecord);
+
+    assertNotSame(partitionInfoMap, SegmentPartitionUtils.INVALID_COLUMN_PARTITION_INFO_MAP);
+    assertFalse(partitionInfoMap.containsKey("memberId"));
+    SegmentPartitionInfo accountPartitionInfo = partitionInfoMap.get("accountId");
+    assertNotNull(accountPartitionInfo);
+    assertEquals(accountPartitionInfo.getPartitionColumn(), "accountId");
+    assertEquals(accountPartitionInfo.getPartitionFunction().getName(), "Modulo");
+    assertEquals(accountPartitionInfo.getPartitions(), Set.of(2));
+  }
+
+  private static ZNRecord getZnRecord(Map<String, ColumnPartitionMetadata> columnPartitionMap)
+      throws IOException {
+    ZNRecord znRecord = new ZNRecord(SEGMENT_NAME);
+    znRecord.setSimpleField(CommonConstants.Segment.PARTITION_METADATA,
+        new SegmentPartitionMetadata(columnPartitionMap).toJsonString());
+    return znRecord;
+  }
+
+  private static ColumnPartitionMetadata getInvalidCustomPartitionMetadata(String partitionExpression,
+      Set<Integer> partitions) {
+    return new ColumnPartitionMetadata(CustomPartitionFunction.NAME, 4, partitions,
+        Map.of(CustomPartitionFunction.PARTITION_EXPRESSION_CONFIG_KEY, partitionExpression));
+  }
+}

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentpruner/CustomPartitionFunctionSegmentPrunerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentpruner/CustomPartitionFunctionSegmentPrunerTest.java
@@ -1,0 +1,133 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.routing.segmentpruner;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.IdealState;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.pinot.common.metadata.segment.SegmentPartitionMetadata;
+import org.apache.pinot.common.partition.function.CustomPartitionFunction;
+import org.apache.pinot.common.request.BrokerRequest;
+import org.apache.pinot.segment.spi.partition.metadata.ColumnPartitionMetadata;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.sql.parsers.CalciteSqlCompiler;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+
+/// Tests broker-side pruning for [CustomPartitionFunction] with segment partition metadata encoded in the broker
+/// metadata format.
+public class CustomPartitionFunctionSegmentPrunerTest {
+  private static final String TABLE_NAME_WITH_TYPE = "testTable_OFFLINE";
+  private static final String PARTITION_COLUMN = "memberId";
+  private static final int NUM_PARTITIONS = 5;
+  private static final Map<String, String> FUNCTION_CONFIG =
+      Map.of(CustomPartitionFunction.PARTITION_EXPRESSION_CONFIG_KEY, "plus(memberId,0)");
+
+  @Test
+  public void testPruningUsesCustomPartitionFunction()
+      throws IOException {
+    BrokerRequest noFilterBrokerRequest = CalciteSqlCompiler.compileToBrokerRequest("SELECT * FROM testTable");
+    BrokerRequest prunedBrokerRequest =
+        CalciteSqlCompiler.compileToBrokerRequest("SELECT * FROM testTable WHERE memberId = 0");
+    BrokerRequest singlePartitionBrokerRequest =
+        CalciteSqlCompiler.compileToBrokerRequest("SELECT * FROM testTable WHERE memberId = 7");
+    BrokerRequest multiPartitionBrokerRequest =
+        CalciteSqlCompiler.compileToBrokerRequest("SELECT * FROM testTable WHERE memberId IN (7, 8)");
+
+    SinglePartitionColumnSegmentPruner segmentPruner =
+        new SinglePartitionColumnSegmentPruner(TABLE_NAME_WITH_TYPE, PARTITION_COLUMN);
+    String segmentWithPartition2 = "segmentWithPartition2";
+    String segmentWithPartition3 = "segmentWithPartition3";
+    segmentPruner.init(Mockito.mock(IdealState.class), Mockito.mock(ExternalView.class),
+        List.of(segmentWithPartition2, segmentWithPartition3),
+        List.of(createPartitionMetadataRecord(segmentWithPartition2, 2, FUNCTION_CONFIG),
+            createPartitionMetadataRecord(segmentWithPartition3, 3, FUNCTION_CONFIG)));
+
+    Set<String> segments = Set.of(segmentWithPartition2, segmentWithPartition3);
+    assertEquals(segmentPruner.prune(noFilterBrokerRequest, segments), segments);
+    assertEquals(segmentPruner.prune(prunedBrokerRequest, segments), Set.of());
+    assertEquals(segmentPruner.prune(singlePartitionBrokerRequest, segments), Set.of(segmentWithPartition2));
+    assertEquals(segmentPruner.prune(multiPartitionBrokerRequest, segments), segments);
+  }
+
+  @Test
+  public void testInvalidCustomPartitionIdDoesNotPrune()
+      throws IOException {
+    BrokerRequest invalidPartitionIdBrokerRequest =
+        CalciteSqlCompiler.compileToBrokerRequest("SELECT * FROM testTable WHERE memberId = 'not-a-number'");
+
+    SinglePartitionColumnSegmentPruner segmentPruner =
+        new SinglePartitionColumnSegmentPruner(TABLE_NAME_WITH_TYPE, PARTITION_COLUMN);
+    String segmentWithPartition2 = "segmentWithPartition2";
+    String segmentWithPartition3 = "segmentWithPartition3";
+    Map<String, String> functionConfig =
+        Map.of(CustomPartitionFunction.PARTITION_EXPRESSION_CONFIG_KEY, "plus(memberId,0)");
+    segmentPruner.init(Mockito.mock(IdealState.class), Mockito.mock(ExternalView.class),
+        List.of(segmentWithPartition2, segmentWithPartition3),
+        List.of(createPartitionMetadataRecord(segmentWithPartition2, 2, functionConfig),
+            createPartitionMetadataRecord(segmentWithPartition3, 3, functionConfig)));
+
+    Set<String> segments = Set.of(segmentWithPartition2, segmentWithPartition3);
+    assertEquals(segmentPruner.prune(invalidPartitionIdBrokerRequest, segments), segments);
+  }
+
+  @Test
+  public void testOutOfRangeCustomPartitionIdDoesNotPrune()
+      throws IOException {
+    BrokerRequest outOfRangePartitionIdBrokerRequest =
+        CalciteSqlCompiler.compileToBrokerRequest("SELECT * FROM testTable WHERE memberId = 99");
+
+    SinglePartitionColumnSegmentPruner singleColumnPruner =
+        new SinglePartitionColumnSegmentPruner(TABLE_NAME_WITH_TYPE, PARTITION_COLUMN);
+    MultiPartitionColumnsSegmentPruner multiColumnPruner =
+        new MultiPartitionColumnsSegmentPruner(TABLE_NAME_WITH_TYPE, Set.of(PARTITION_COLUMN, "accountId"));
+    String segmentWithPartition2 = "segmentWithPartition2";
+    Map<String, String> functionConfig =
+        Map.of(CustomPartitionFunction.PARTITION_EXPRESSION_CONFIG_KEY, "plus(memberId,0)", "partitionIdNormalizer",
+            "NO_OP");
+    ZNRecord znRecord = createPartitionMetadataRecord(segmentWithPartition2, 2, functionConfig);
+    singleColumnPruner.init(Mockito.mock(IdealState.class), Mockito.mock(ExternalView.class),
+        List.of(segmentWithPartition2), List.of(znRecord));
+    multiColumnPruner.init(Mockito.mock(IdealState.class), Mockito.mock(ExternalView.class),
+        List.of(segmentWithPartition2), List.of(znRecord));
+
+    Set<String> segments = Set.of(segmentWithPartition2);
+    assertEquals(singleColumnPruner.prune(outOfRangePartitionIdBrokerRequest, segments), segments);
+    assertEquals(multiColumnPruner.prune(outOfRangePartitionIdBrokerRequest, segments), segments);
+  }
+
+  private static ZNRecord createPartitionMetadataRecord(String segmentName, int partitionId,
+      Map<String, String> functionConfig)
+      throws IOException {
+    SegmentPartitionMetadata segmentPartitionMetadata = new SegmentPartitionMetadata(
+        Map.of(PARTITION_COLUMN,
+            new ColumnPartitionMetadata(CustomPartitionFunction.NAME, NUM_PARTITIONS, Set.of(partitionId),
+                functionConfig), "accountId", new ColumnPartitionMetadata("Modulo", NUM_PARTITIONS, Set.of(0), null)));
+    ZNRecord znRecord = new ZNRecord(segmentName);
+    znRecord.setSimpleField(CommonConstants.Segment.PARTITION_METADATA, segmentPartitionMetadata.toJsonString());
+    return znRecord;
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/evaluator/InbuiltFunctionEvaluator.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/evaluator/InbuiltFunctionEvaluator.java
@@ -48,6 +48,7 @@ public class InbuiltFunctionEvaluator implements FunctionEvaluator {
   private final ExecutableNode _rootNode;
   private final List<String> _arguments;
   private final String _functionExpression;
+  private boolean _deterministic = true;
 
   public InbuiltFunctionEvaluator(String functionExpression) {
     _functionExpression = functionExpression;
@@ -99,6 +100,9 @@ public class InbuiltFunctionEvaluator implements FunctionEvaluator {
                 throw new IllegalStateException(String.format("Unsupported function: %s", functionName));
               }
             }
+            if (!functionInfo.isDeterministic()) {
+              _deterministic = false;
+            }
             return new FunctionExecutionNode(functionInfo, childNodes);
         }
       default:
@@ -109,6 +113,14 @@ public class InbuiltFunctionEvaluator implements FunctionEvaluator {
   @Override
   public List<String> getArguments() {
     return _arguments;
+  }
+
+  public boolean isDeterministic() {
+    return _deterministic;
+  }
+
+  public Class<?> getResultClass() {
+    return _rootNode.getResultClass();
   }
 
   @Override
@@ -131,6 +143,8 @@ public class InbuiltFunctionEvaluator implements FunctionEvaluator {
     Object execute(GenericRow row);
 
     Object execute(Object[] values);
+
+    Class<?> getResultClass();
   }
 
   private static class NotExecutionNode implements ExecutableNode {
@@ -158,6 +172,11 @@ public class InbuiltFunctionEvaluator implements FunctionEvaluator {
       } else {
         return !res;
       }
+    }
+
+    @Override
+    public Class<?> getResultClass() {
+      return Boolean.class;
     }
   }
 
@@ -203,6 +222,11 @@ public class InbuiltFunctionEvaluator implements FunctionEvaluator {
 
       return hasNull ? null : false;
     }
+
+    @Override
+    public Class<?> getResultClass() {
+      return Boolean.class;
+    }
   }
 
   private static class AndExecutionNode implements ExecutableNode {
@@ -247,6 +271,11 @@ public class InbuiltFunctionEvaluator implements FunctionEvaluator {
 
       return hasNull ? null : true;
     }
+
+    @Override
+    public Class<?> getResultClass() {
+      return Boolean.class;
+    }
   }
 
   private static class FunctionExecutionNode implements ExecutableNode {
@@ -269,20 +298,7 @@ public class InbuiltFunctionEvaluator implements FunctionEvaluator {
         for (int i = 0; i < numArguments; i++) {
           _arguments[i] = _argumentNodes[i].execute(row);
         }
-        if (!_functionInfo.hasNullableParameters()) {
-          // Preserve null values during ingestion transformation if function is an inbuilt
-          // scalar function that cannot handle nulls, and invoked with null parameter(s).
-          for (Object argument : _arguments) {
-            if (argument == null) {
-              return null;
-            }
-          }
-        }
-        if (_functionInvoker.getMethod().isVarArgs()) {
-          return _functionInvoker.invoke(new Object[]{_arguments});
-        }
-        _functionInvoker.convertTypes(_arguments);
-        return _functionInvoker.invoke(_arguments);
+        return invoke();
       } catch (Exception e) {
         throw new RuntimeException("Caught exception while executing function: " + this + ": " + e.getMessage(), e);
       }
@@ -295,23 +311,32 @@ public class InbuiltFunctionEvaluator implements FunctionEvaluator {
         for (int i = 0; i < numArguments; i++) {
           _arguments[i] = _argumentNodes[i].execute(values);
         }
-        if (!_functionInfo.hasNullableParameters()) {
-          // Preserve null values during ingestion transformation if function is an inbuilt
-          // scalar function that cannot handle nulls, and invoked with null parameter(s).
-          for (Object argument : _arguments) {
-            if (argument == null) {
-              return null;
-            }
-          }
-        }
-        if (_functionInvoker.getMethod().isVarArgs()) {
-          return _functionInvoker.invoke(new Object[]{_arguments});
-        }
-        _functionInvoker.convertTypes(_arguments);
-        return _functionInvoker.invoke(_arguments);
+        return invoke();
       } catch (Exception e) {
         throw new RuntimeException("Caught exception while executing function: " + this + ": " + e.getMessage(), e);
       }
+    }
+
+    private Object invoke() {
+      if (!_functionInfo.hasNullableParameters()) {
+        // Preserve null values during ingestion transformation if function is an inbuilt
+        // scalar function that cannot handle nulls, and invoked with null parameter(s).
+        for (Object argument : _arguments) {
+          if (argument == null) {
+            return null;
+          }
+        }
+      }
+      if (_functionInvoker.getMethod().isVarArgs()) {
+        return _functionInvoker.invoke(new Object[]{_arguments});
+      }
+      _functionInvoker.convertTypes(_arguments);
+      return _functionInvoker.invoke(_arguments);
+    }
+
+    @Override
+    public Class<?> getResultClass() {
+      return _functionInvoker.getResultClass();
     }
 
     @Override
@@ -338,6 +363,11 @@ public class InbuiltFunctionEvaluator implements FunctionEvaluator {
     }
 
     @Override
+    public Class<?> getResultClass() {
+      return _value != null ? _value.getClass() : Object.class;
+    }
+
+    @Override
     public String toString() {
       return String.format("'%s'", _value);
     }
@@ -358,6 +388,11 @@ public class InbuiltFunctionEvaluator implements FunctionEvaluator {
     @Override
     public Object[] execute(Object[] values) {
       return _value;
+    }
+
+    @Override
+    public Class<?> getResultClass() {
+      return Object[].class;
     }
 
     @Override
@@ -383,6 +418,11 @@ public class InbuiltFunctionEvaluator implements FunctionEvaluator {
     @Override
     public Object execute(Object[] values) {
       return values[_id];
+    }
+
+    @Override
+    public Class<?> getResultClass() {
+      return Object.class;
     }
 
     @Override

--- a/pinot-common/src/main/java/org/apache/pinot/common/partition/function/CustomPartitionFunction.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/partition/function/CustomPartitionFunction.java
@@ -1,0 +1,186 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.partition.function;
+
+import com.google.common.base.Preconditions;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.apache.pinot.common.evaluator.InbuiltFunctionEvaluator;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.common.request.context.RequestContextUtils;
+import org.apache.pinot.segment.spi.partition.PartitionFunction;
+import org.apache.pinot.segment.spi.partition.PartitionIdNormalizer;
+
+
+/// [PartitionFunction] that evaluates a scalar-function expression to produce a raw partition value.
+///
+/// The expression is configured with `functionConfig.partitionExpression` and can only reference the partition column
+/// configured in the table's `columnPartitionMap`. The expression must return a numeric value, and this
+/// function applies the configured [PartitionIdNormalizer] (default [PartitionIdNormalizer#POSITIVE_MODULO]) to map it
+/// into `[0, numPartitions)`.
+///
+/// Runtime evaluation errors return `-1` so callers can treat the partition as unknown.
+@SuppressWarnings("serial")
+public class CustomPartitionFunction implements PartitionFunction {
+  public static final String NAME = "Custom";
+  public static final String PARTITION_EXPRESSION_CONFIG_KEY = "partitionExpression";
+  private static final String PARTITION_ID_NORMALIZER_KEY = "partitionIdNormalizer";
+
+  private static final PartitionIdNormalizer DEFAULT_NORMALIZER = PartitionIdNormalizer.POSITIVE_MODULO;
+  private static final int INVALID_PARTITION_ID = -1;
+
+  private final int _numPartitions;
+  private final Map<String, String> _functionConfig;
+  private final PartitionIdNormalizer _normalizer;
+  private final String _partitionExpression;
+  private final List<String> _arguments;
+  @Nullable
+  private transient volatile InbuiltFunctionEvaluator _evaluator;
+
+  public CustomPartitionFunction(@Nullable String columnName, int numPartitions, Map<String, String> functionConfig) {
+    Preconditions.checkArgument(numPartitions > 0, "Number of partitions must be > 0");
+    Preconditions.checkArgument(functionConfig != null,
+        "'functionConfig' must be configured for custom partition function");
+    _numPartitions = numPartitions;
+
+    _partitionExpression = getPartitionExpression(functionConfig);
+    _functionConfig = Collections.unmodifiableMap(new HashMap<>(functionConfig));
+    _normalizer = normalizer(functionConfig, DEFAULT_NORMALIZER);
+    InbuiltFunctionEvaluator evaluator = new InbuiltFunctionEvaluator(_partitionExpression);
+    Preconditions.checkArgument(evaluator.isDeterministic(),
+        "Custom partition function expression must be deterministic: %s", _partitionExpression);
+    validatePartitionExpression(RequestContextUtils.getExpression(_partitionExpression), evaluator.getResultClass());
+    _arguments = Collections.unmodifiableList(new ArrayList<>(evaluator.getArguments()));
+    validatePartitionColumnReferences(_arguments, getPartitionColumn(columnName));
+    _evaluator = evaluator;
+  }
+
+  @Override
+  public int getPartition(String value) {
+    try {
+      return toPartitionId(evaluate(value));
+    } catch (RuntimeException e) {
+      return INVALID_PARTITION_ID;
+    }
+  }
+
+  @Override
+  public String getName() {
+    return NAME;
+  }
+
+  @Override
+  public int getNumPartitions() {
+    return _numPartitions;
+  }
+
+  @Override
+  public Map<String, String> getFunctionConfig() {
+    return _functionConfig;
+  }
+
+  @Override
+  public PartitionIdNormalizer getPartitionIdNormalizer() {
+    return _normalizer;
+  }
+
+  @Override
+  public String toString() {
+    return _partitionExpression;
+  }
+
+  private Object evaluate(String value) {
+    InbuiltFunctionEvaluator evaluator = evaluator();
+    Object[] values = new Object[_arguments.size()];
+    int numArguments = _arguments.size();
+    for (int i = 0; i < numArguments; i++) {
+      values[i] = value;
+    }
+    synchronized (evaluator) {
+      return evaluator.evaluate(values);
+    }
+  }
+
+  private InbuiltFunctionEvaluator evaluator() {
+    InbuiltFunctionEvaluator evaluator = _evaluator;
+    if (evaluator == null) {
+      synchronized (this) {
+        evaluator = _evaluator;
+        if (evaluator == null) {
+          evaluator = new InbuiltFunctionEvaluator(_partitionExpression);
+          _evaluator = evaluator;
+        }
+      }
+    }
+    return evaluator;
+  }
+
+  private int toPartitionId(Object result) {
+    Preconditions.checkArgument(result instanceof Number,
+        "Partition expression result must be numeric, got: %s", result == null ? null : result.getClass().getName());
+    return _normalizer.getPartitionId(((Number) result).longValue(), _numPartitions);
+  }
+
+  private static void validatePartitionColumnReferences(List<String> arguments, String partitionColumn) {
+    boolean hasPartitionColumn = false;
+    for (String argument : arguments) {
+      Preconditions.checkArgument(partitionColumn.equalsIgnoreCase(argument),
+          "Custom partition function expression can only reference partition column '%s', found: %s",
+          partitionColumn, argument);
+      hasPartitionColumn = true;
+    }
+    Preconditions.checkArgument(hasPartitionColumn,
+        "Custom partition function expression must reference partition column '%s'", partitionColumn);
+  }
+
+  private static void validatePartitionExpression(ExpressionContext expression, Class<?> resultClass) {
+    Preconditions.checkArgument(expression.getType() == ExpressionContext.Type.FUNCTION,
+        "Custom partition function expression must be a scalar function expression: %s", expression);
+    Preconditions.checkArgument(resultClass == Object.class || Number.class.isAssignableFrom(resultClass)
+            || resultClass == byte.class || resultClass == short.class || resultClass == int.class
+            || resultClass == long.class || resultClass == float.class || resultClass == double.class,
+        "Custom partition function expression must return a numeric value, got: %s", resultClass.getName());
+  }
+
+  private static String getPartitionExpression(Map<String, String> functionConfig) {
+    String partitionExpression = functionConfig.get(PARTITION_EXPRESSION_CONFIG_KEY);
+    Preconditions.checkArgument(partitionExpression != null && !partitionExpression.trim().isEmpty(),
+        "'%s' must be configured", PARTITION_EXPRESSION_CONFIG_KEY);
+    return partitionExpression;
+  }
+
+  private static PartitionIdNormalizer normalizer(Map<String, String> functionConfig,
+      PartitionIdNormalizer defaultNormalizer) {
+    String rawNormalizer = functionConfig.get(PARTITION_ID_NORMALIZER_KEY);
+    if (rawNormalizer == null || rawNormalizer.trim().isEmpty()) {
+      return defaultNormalizer;
+    }
+    return PartitionIdNormalizer.fromConfigString(rawNormalizer);
+  }
+
+  private static String getPartitionColumn(@Nullable String partitionColumn) {
+    Preconditions.checkArgument(partitionColumn != null && !partitionColumn.trim().isEmpty(),
+        "Partition column must be provided for custom partition function");
+    return partitionColumn.trim();
+  }
+}

--- a/pinot-common/src/test/java/org/apache/pinot/common/partition/function/CustomPartitionFunctionTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/partition/function/CustomPartitionFunctionTest.java
@@ -1,0 +1,163 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.partition.function;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+import org.apache.pinot.common.function.scalar.HashFunctions;
+import org.apache.pinot.segment.spi.partition.PartitionFunction;
+import org.apache.pinot.segment.spi.partition.PartitionFunctionFactory;
+import org.apache.pinot.segment.spi.partition.PartitionIdNormalizer;
+import org.apache.pinot.spi.config.table.ColumnPartitionConfig;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
+
+
+public class CustomPartitionFunctionTest {
+  private static final int NUM_PARTITIONS = 128;
+  private static final String PARTITION_COLUMN = "id";
+
+  @Test
+  public void testPartitionExpressionWithScalarFunctions() {
+    String expression = "fnv1aHash32UTF8(md5(toUtf8(id)))";
+    PartitionFunction partitionFunction = getPartitionFunction(expression);
+
+    String value = "user-1";
+    int expected = PartitionIdNormalizer.POSITIVE_MODULO.getPartitionId(
+        HashFunctions.fnv1aHash32UTF8(HashFunctions.md5(value.getBytes(StandardCharsets.UTF_8))), NUM_PARTITIONS);
+
+    assertTrue(partitionFunction instanceof CustomPartitionFunction);
+    assertEquals(partitionFunction.getName(), CustomPartitionFunction.NAME);
+    assertEquals(partitionFunction.getFunctionConfig().get(CustomPartitionFunction.PARTITION_EXPRESSION_CONFIG_KEY),
+        expression);
+    assertEquals(partitionFunction.getPartition(value), expected);
+  }
+
+  @Test
+  public void testPartitionExpressionNormalizesRawResults() {
+    String expression = "plus(id, 0)";
+    PartitionFunction partitionFunction = getPartitionFunction(expression);
+
+    assertEquals(partitionFunction.getFunctionConfig().get(CustomPartitionFunction.PARTITION_EXPRESSION_CONFIG_KEY),
+        expression);
+    assertEquals(partitionFunction.getPartition("-1"), NUM_PARTITIONS - 1);
+    assertEquals(partitionFunction.getPartition("128"), 0);
+  }
+
+  @Test
+  public void testPartitionExpressionUsesConfiguredNormalizer() {
+    int numPartitions = 127;
+    PartitionFunction partitionFunction = PartitionFunctionFactory.getPartitionFunction(PARTITION_COLUMN,
+        CustomPartitionFunction.NAME, numPartitions,
+        Map.of(CustomPartitionFunction.PARTITION_EXPRESSION_CONFIG_KEY, "plus(id,0)",
+            "partitionIdNormalizer", "MASK"));
+
+    assertEquals(partitionFunction.getFunctionConfig().get(CustomPartitionFunction.PARTITION_EXPRESSION_CONFIG_KEY),
+        "plus(id,0)");
+    assertEquals(partitionFunction.getFunctionConfig().get("partitionIdNormalizer"), "MASK");
+    assertEquals(partitionFunction.getPartition("-3"), PartitionIdNormalizer.MASK.getPartitionId(-3L, numPartitions));
+  }
+
+  @Test
+  public void testRejectsNumPartitionsIdentifier() {
+    assertThrows(IllegalArgumentException.class, () -> getPartitionFunction("plus(id, numPartitions)"));
+  }
+
+  @Test
+  public void testPartitionExpressionReturnsInvalidPartitionForInvalidRuntimeResults() {
+    assertEquals(getPartition("plus(id,0)", "not-a-number"), -1);
+  }
+
+  @Test
+  public void testRejectsNonNumericPartitionExpression() {
+    assertThrows(IllegalArgumentException.class, () -> getPartitionFunction("md5(id)"));
+  }
+
+  @Test
+  public void testRejectsNonFunctionPartitionExpression() {
+    assertThrows(IllegalArgumentException.class, () -> getPartitionFunction("id"));
+  }
+
+  @Test
+  public void testCanUseCustomFunctionNameDirectly() {
+    PartitionFunction partitionFunction = PartitionFunctionFactory.getPartitionFunction(PARTITION_COLUMN,
+        CustomPartitionFunction.NAME, NUM_PARTITIONS, Map.of(CustomPartitionFunction.PARTITION_EXPRESSION_CONFIG_KEY,
+            "plus(id,0)"));
+
+    assertTrue(partitionFunction instanceof CustomPartitionFunction);
+    assertEquals(partitionFunction.getFunctionConfig().get(CustomPartitionFunction.PARTITION_EXPRESSION_CONFIG_KEY),
+        "plus(id,0)");
+    assertEquals(partitionFunction.getPartition("-1"), NUM_PARTITIONS - 1);
+  }
+
+  @Test
+  public void testRejectsMissingConfigForCustomFunction() {
+    assertThrows(IllegalArgumentException.class,
+        () -> PartitionFunctionFactory.getPartitionFunction(PARTITION_COLUMN, CustomPartitionFunction.NAME,
+            NUM_PARTITIONS, null));
+    assertThrows(IllegalArgumentException.class,
+        () -> PartitionFunctionFactory.getPartitionFunction(CustomPartitionFunction.NAME, NUM_PARTITIONS,
+            Map.of(CustomPartitionFunction.PARTITION_EXPRESSION_CONFIG_KEY, "plus(id,0)")));
+  }
+
+  @Test
+  public void testRejectsColumnThatDoesNotMatchColumnPartitionMapKey() {
+    assertThrows(IllegalArgumentException.class, () -> getPartitionFunction("plus(other,0)"));
+  }
+
+  @Test
+  public void testRejectsExpressionWithoutPartitionColumn() {
+    assertThrows(IllegalArgumentException.class, () -> getPartitionFunction("plus(1, 0)"));
+  }
+
+  @Test
+  public void testRejectsMultiplePartitionColumns() {
+    assertThrows(IllegalArgumentException.class,
+        () -> PartitionFunctionFactory.getPartitionFunction(PARTITION_COLUMN, CustomPartitionFunction.NAME,
+            NUM_PARTITIONS,
+            Map.of(CustomPartitionFunction.PARTITION_EXPRESSION_CONFIG_KEY, "plus(id,other)")));
+  }
+
+  @Test
+  public void testDelegatesFunctionBindingToInbuiltFunctionEvaluator() {
+    assertTrue(getPartitionFunction("fnv1aHash32UTF8(md5(id))") instanceof CustomPartitionFunction);
+    assertThrows(RuntimeException.class, () -> getPartitionFunction("missingScalarFunction(id)"));
+  }
+
+  @Test
+  public void testRejectsNonDeterministicExpression() {
+    assertThrows(IllegalArgumentException.class, () -> getPartitionFunction("plus(id, rand())"));
+  }
+
+  private static int getPartition(String expression, String value) {
+    return getPartitionFunction(expression).getPartition(value);
+  }
+
+  private static PartitionFunction getPartitionFunction(String expression) {
+    return PartitionFunctionFactory.getPartitionFunction(PARTITION_COLUMN, getColumnPartitionConfig(expression));
+  }
+
+  private static ColumnPartitionConfig getColumnPartitionConfig(String expression) {
+    return new ColumnPartitionConfig(CustomPartitionFunction.NAME, NUM_PARTITIONS,
+        Map.of(CustomPartitionFunction.PARTITION_EXPRESSION_CONFIG_KEY, expression));
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -104,6 +104,7 @@ import org.apache.pinot.segment.spi.loader.SegmentDirectoryLoader;
 import org.apache.pinot.segment.spi.loader.SegmentDirectoryLoaderContext;
 import org.apache.pinot.segment.spi.loader.SegmentDirectoryLoaderRegistry;
 import org.apache.pinot.segment.spi.partition.PartitionFunction;
+import org.apache.pinot.segment.spi.partition.PartitionFunctionFactory;
 import org.apache.pinot.segment.spi.store.SegmentDirectory;
 import org.apache.pinot.spi.auth.AuthProvider;
 import org.apache.pinot.spi.config.instance.InstanceDataManagerConfig;
@@ -1794,21 +1795,19 @@ public abstract class BaseTableDataManager implements TableDataManager {
 
       // Partition changed or segment not properly partitioned
       if (columnName.equals(partitionColumn)) {
+        assert partitionConfig != null;
         PartitionFunction partitionFunction = columnMetadata.getPartitionFunction();
         if (partitionFunction == null) {
           LOGGER.debug("tableNameWithType: {}, columnName: {}, segmentName: {}, change: partition function",
               tableNameWithType, columnName, segmentName);
           return new StaleSegment(segmentName, true, "partition function added: " + columnName);
         }
-        if (!partitionFunction.getName().equalsIgnoreCase(partitionConfig.getFunctionName())) {
+        PartitionFunction configuredPartitionFunction =
+            PartitionFunctionFactory.getPartitionFunction(columnName, partitionConfig);
+        if (!isPartitionFunctionCompatible(partitionFunction, configuredPartitionFunction)) {
           LOGGER.debug("tableNameWithType: {}, columnName: {}, segmentName: {}, change: partition function name",
               tableNameWithType, columnName, segmentName);
-          return new StaleSegment(segmentName, true, "partition function name changed: " + columnName);
-        }
-        if (partitionFunction.getNumPartitions() != partitionConfig.getNumPartitions()) {
-          LOGGER.debug("tableNameWithType: {}, columnName: {},, segmentName: {}, change: num partitions",
-              tableNameWithType, columnName, segmentName);
-          return new StaleSegment(segmentName, true, "num partitions changed: " + columnName);
+          return new StaleSegment(segmentName, true, "partition function changed: " + columnName);
         }
         Set<Integer> partitions = columnMetadata.getPartitions();
         if (partitions == null || partitions.size() != 1) {
@@ -1820,6 +1819,14 @@ public abstract class BaseTableDataManager implements TableDataManager {
     }
 
     return new StaleSegment(segmentName, false, null);
+  }
+
+  private static boolean isPartitionFunctionCompatible(PartitionFunction segmentPartitionFunction,
+      PartitionFunction configuredPartitionFunction) {
+    return segmentPartitionFunction.getName().equalsIgnoreCase(configuredPartitionFunction.getName())
+        && segmentPartitionFunction.getNumPartitions() == configuredPartitionFunction.getNumPartitions()
+        && Objects.equals(segmentPartitionFunction.getFunctionConfig(),
+            configuredPartitionFunction.getFunctionConfig());
   }
 
   protected SegmentDirectory initSegmentDirectory(String segmentName, String segmentCrc,

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -2046,7 +2046,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
 
         realtimeSegmentConfigBuilder.setPartitionColumn(partitionColumn);
         realtimeSegmentConfigBuilder.setPartitionFunction(
-            PartitionFunctionFactory.getPartitionFunction(partitionFunctionName, numPartitions,
+            PartitionFunctionFactory.getPartitionFunction(partitionColumn, partitionFunctionName, numPartitions,
                 columnPartitionConfig.getFunctionConfig()));
         realtimeSegmentConfigBuilder.setPartitionId(_partitionGroupId);
       } else {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/ColumnValueSegmentPruner.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/ColumnValueSegmentPruner.java
@@ -115,8 +115,9 @@ public class ColumnValueSegmentPruner extends ValueBasedSegmentPruner {
     PartitionFunction partitionFunction = dataSourceMetadata.getPartitionFunction();
     if (partitionFunction != null) {
       Set<Integer> partitions = dataSourceMetadata.getPartitions();
-      assert partitions != null;
-      if (!partitions.contains(partitionFunction.getPartition(cachedValue.getValue()))) {
+      int partitionId = partitionFunction.getPartition(cachedValue.getValue());
+      if (partitions != null && !partitions.isEmpty() && partitionId >= 0
+          && partitionId < partitionFunction.getNumPartitions() && !partitions.contains(partitionId)) {
         return true;
       }
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/partitioner/TableConfigPartitioner.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/partitioner/TableConfigPartitioner.java
@@ -34,7 +34,7 @@ public class TableConfigPartitioner implements Partitioner {
 
   public TableConfigPartitioner(String columnName, ColumnPartitionConfig columnPartitionConfig) {
     _column = columnName;
-    _partitionFunction = PartitionFunctionFactory.getPartitionFunction(columnPartitionConfig);
+    _partitionFunction = PartitionFunctionFactory.getPartitionFunction(columnName, columnPartitionConfig);
   }
 
   @Override

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerNeedRefreshTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerNeedRefreshTest.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.io.FileUtils;
+import org.apache.pinot.common.partition.function.CustomPartitionFunction;
 import org.apache.pinot.core.data.manager.offline.ImmutableSegmentDataManager;
 import org.apache.pinot.segment.local.data.manager.StaleSegment;
 import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
@@ -174,6 +175,14 @@ public class BaseTableDataManagerNeedRefreshTest {
     row2.putValue(CARRIER_COLUMN_NAME, "c0");
 
     return List.of(row0, row2, row1);
+  }
+
+  protected static List<GenericRow> generateRowsInSinglePartition() {
+    List<GenericRow> rows = generateRows();
+    for (GenericRow row : rows) {
+      row.putValue(PARTITIONED_COLUMN_NAME, 0);
+    }
+    return rows;
   }
 
   private static File createSegment(IndexLoadingConfig indexLoadingConfig, String segmentName, List<GenericRow> rows)
@@ -393,7 +402,7 @@ public class BaseTableDataManagerNeedRefreshTest {
     response = BASE_TABLE_DATA_MANAGER.isSegmentStale(new IndexLoadingConfig(partitionedTableConfig40, SCHEMA),
         segmentWithPartition);
     assertTrue(response.isStale());
-    assertEquals(response.getReason(), "num partitions changed: partitionedColumn");
+    assertEquals(response.getReason(), "partition function changed: partitionedColumn");
 
     // when partition function is different, then needRefresh = true
     TableConfig partitionedTableConfigMurmur = getTableConfigBuilder().setSegmentPartitionConfig(
@@ -402,7 +411,37 @@ public class BaseTableDataManagerNeedRefreshTest {
     response = BASE_TABLE_DATA_MANAGER.isSegmentStale(new IndexLoadingConfig(partitionedTableConfigMurmur, SCHEMA),
         segmentWithPartition);
     assertTrue(response.isStale());
-    assertEquals(response.getReason(), "partition function name changed: partitionedColumn");
+    assertEquals(response.getReason(), "partition function changed: partitionedColumn");
+
+    Map<String, String> customFunctionConfig =
+        Map.of(CustomPartitionFunction.PARTITION_EXPRESSION_CONFIG_KEY, "plus(partitionedColumn,0)",
+            "partitionIdNormalizer", "POSITIVE_MODULO");
+    TableConfig partitionedTableConfigWithCustomFunction = getTableConfigBuilder().setSegmentPartitionConfig(
+        new SegmentPartitionConfig(
+            Map.of(PARTITIONED_COLUMN_NAME,
+                new ColumnPartitionConfig(CustomPartitionFunction.NAME, NUM_PARTITIONS, customFunctionConfig))))
+        .build();
+    IndexLoadingConfig indexLoadingConfigWithCustomFunction =
+        new IndexLoadingConfig(partitionedTableConfigWithCustomFunction, SCHEMA);
+    ImmutableSegmentDataManager segmentWithCustomPartition =
+        createImmutableSegmentDataManager(indexLoadingConfigWithCustomFunction, "partitionWithCustomFunction",
+            generateRowsInSinglePartition());
+
+    // when partition function config matches, then needRefresh = false
+    assertFalse(BASE_TABLE_DATA_MANAGER.isSegmentStale(indexLoadingConfigWithCustomFunction,
+        segmentWithCustomPartition).isStale());
+
+    // when partition function config is different, then needRefresh = true
+    TableConfig partitionedTableConfigWithChangedCustomFunction = getTableConfigBuilder().setSegmentPartitionConfig(
+        new SegmentPartitionConfig(
+            Map.of(PARTITIONED_COLUMN_NAME,
+                new ColumnPartitionConfig(CustomPartitionFunction.NAME, NUM_PARTITIONS,
+                    Map.of(CustomPartitionFunction.PARTITION_EXPRESSION_CONFIG_KEY, "plus(partitionedColumn,1)",
+                        "partitionIdNormalizer", "POSITIVE_MODULO"))))).build();
+    response = BASE_TABLE_DATA_MANAGER.isSegmentStale(
+        new IndexLoadingConfig(partitionedTableConfigWithChangedCustomFunction, SCHEMA), segmentWithCustomPartition);
+    assertTrue(response.isStale());
+    assertEquals(response.getReason(), "partition function changed: partitionedColumn");
   }
 
   @Test

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/pruner/ColumnValueSegmentPrunerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/pruner/ColumnValueSegmentPrunerTest.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import org.apache.pinot.common.partition.function.CustomPartitionFunction;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
 import org.apache.pinot.segment.spi.IndexSegment;
@@ -140,6 +141,62 @@ public class ColumnValueSegmentPrunerTest {
     assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column = 0 OR column = 2"));
     assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column = 0 OR column < 10"));
     assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column = 0 OR column = 10"));
+  }
+
+  @Test
+  public void testPartitionPruningWithCustomPartitionFunction() {
+    IndexSegment indexSegment = mockIndexSegment();
+
+    DataSource dataSource = mock(DataSource.class);
+    when(indexSegment.getDataSource(eq("column"), any(Schema.class))).thenReturn(dataSource);
+
+    DataSourceMetadata dataSourceMetadata = mock(DataSourceMetadata.class);
+    when(dataSourceMetadata.getDataType()).thenReturn(DataType.INT);
+    when(dataSourceMetadata.getPartitionFunction()).thenReturn(
+        PartitionFunctionFactory.getPartitionFunction("column", CustomPartitionFunction.NAME, 5,
+            Map.of(CustomPartitionFunction.PARTITION_EXPRESSION_CONFIG_KEY, "plus(column,0)")));
+    when(dataSourceMetadata.getPartitions()).thenReturn(Collections.singleton(2));
+    when(dataSource.getDataSourceMetadata()).thenReturn(dataSourceMetadata);
+
+    assertTrue(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column = 0"));
+    assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column = 7"));
+  }
+
+  @Test
+  public void testPartitionPruningWithInvalidCustomPartitionId() {
+    IndexSegment indexSegment = mockIndexSegment();
+
+    DataSource dataSource = mock(DataSource.class);
+    when(indexSegment.getDataSource(eq("column"), any(Schema.class))).thenReturn(dataSource);
+
+    DataSourceMetadata dataSourceMetadata = mock(DataSourceMetadata.class);
+    when(dataSourceMetadata.getDataType()).thenReturn(DataType.STRING);
+    when(dataSourceMetadata.getPartitionFunction()).thenReturn(
+        PartitionFunctionFactory.getPartitionFunction("column", CustomPartitionFunction.NAME, 5,
+            Map.of(CustomPartitionFunction.PARTITION_EXPRESSION_CONFIG_KEY, "plus(column,0)")));
+    when(dataSourceMetadata.getPartitions()).thenReturn(Collections.singleton(2));
+    when(dataSource.getDataSourceMetadata()).thenReturn(dataSourceMetadata);
+
+    assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column = 'not-a-number'"));
+  }
+
+  @Test
+  public void testPartitionPruningWithOutOfRangeCustomPartitionId() {
+    IndexSegment indexSegment = mockIndexSegment();
+
+    DataSource dataSource = mock(DataSource.class);
+    when(indexSegment.getDataSource(eq("column"), any(Schema.class))).thenReturn(dataSource);
+
+    DataSourceMetadata dataSourceMetadata = mock(DataSourceMetadata.class);
+    when(dataSourceMetadata.getDataType()).thenReturn(DataType.INT);
+    when(dataSourceMetadata.getPartitionFunction()).thenReturn(
+        PartitionFunctionFactory.getPartitionFunction("column", CustomPartitionFunction.NAME, 5,
+            Map.of(CustomPartitionFunction.PARTITION_EXPRESSION_CONFIG_KEY, "plus(column,0)", "partitionIdNormalizer",
+                "NO_OP")));
+    when(dataSourceMetadata.getPartitions()).thenReturn(Collections.singleton(2));
+    when(dataSource.getDataSourceMetadata()).thenReturn(dataSourceMetadata);
+
+    assertFalse(runPruner(indexSegment, "SELECT COUNT(*) FROM testTable WHERE column = 99"));
   }
 
   @Test

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
@@ -642,7 +642,7 @@ public class MutableSegmentImpl implements MutableSegment {
       IndexContainer indexContainer = _indexContainerMap.get(_partitionColumn);
       String stringValue = indexContainer._fieldSpec.getDataType().toString(value);
       int partition = _partitionFunction.getPartition(stringValue);
-      if (partition != _mainPartitionId) {
+      if (partition >= 0 && partition < _partitionFunction.getNumPartitions() && partition != _mainPartitionId) {
         if (_serverMetrics != null) {
           _serverMetrics.addMeteredTableValue(_realtimeTableName, ServerMeter.REALTIME_PARTITION_MISMATCH, 1);
         }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/writer/StatelessRealtimeSegmentWriter.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/writer/StatelessRealtimeSegmentWriter.java
@@ -439,7 +439,7 @@ public class StatelessRealtimeSegmentWriter implements Closeable {
 
         realtimeSegmentConfigBuilder.setPartitionColumn(partitionColumn);
         realtimeSegmentConfigBuilder.setPartitionFunction(
-            PartitionFunctionFactory.getPartitionFunction(partitionFunctionName, numPartitions,
+            PartitionFunctionFactory.getPartitionFunction(partitionColumn, partitionFunctionName, numPartitions,
                 columnPartitionConfig.getFunctionConfig()));
         realtimeSegmentConfigBuilder.setPartitionId(_partitionGroupId);
       } else {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/AbstractColumnStatisticsCollector.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/AbstractColumnStatisticsCollector.java
@@ -162,6 +162,9 @@ public abstract class AbstractColumnStatisticsCollector implements ColumnStatist
   }
 
   protected void updatePartition(String value) {
-    _partitions.add(_partitionFunction.getPartition(value));
+    int partitionId = _partitionFunction.getPartition(value);
+    if (partitionId >= 0 && partitionId < _partitionFunction.getNumPartitions()) {
+      _partitions.add(partitionId);
+    }
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -58,6 +58,7 @@ import org.apache.pinot.segment.spi.index.IndexType;
 import org.apache.pinot.segment.spi.index.StandardIndexes;
 import org.apache.pinot.segment.spi.index.multicolumntext.MultiColumnTextMetadata;
 import org.apache.pinot.segment.spi.index.startree.AggregationFunctionColumnPair;
+import org.apache.pinot.segment.spi.partition.PartitionFunctionFactory;
 import org.apache.pinot.spi.config.table.ColumnPartitionConfig;
 import org.apache.pinot.spi.config.table.DedupConfig;
 import org.apache.pinot.spi.config.table.FieldConfig;
@@ -1563,11 +1564,17 @@ public final class TableConfigUtils {
     if (segmentPartitionConfig != null) {
       Map<String, ColumnPartitionConfig> columnPartitionMap = segmentPartitionConfig.getColumnPartitionMap();
       if (MapUtils.isNotEmpty(columnPartitionMap)) {
-        for (String column : columnPartitionMap.keySet()) {
+        for (Map.Entry<String, ColumnPartitionConfig> entry : columnPartitionMap.entrySet()) {
+          String column = entry.getKey();
           FieldSpec fieldSpec = schema.getFieldSpecFor(column);
           Preconditions.checkState(fieldSpec != null, "Failed to find partition column: %s in schema", column);
           Preconditions.checkState(fieldSpec.isSingleValueField(), "Cannot partition on multi-value column: %s",
               column);
+          try {
+            PartitionFunctionFactory.getPartitionFunction(column, entry.getValue());
+          } catch (RuntimeException e) {
+            throw new IllegalStateException("Invalid partition config for column: " + column, e);
+          }
         }
       }
     }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplDropRecordOnPartitionMismatchTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplDropRecordOnPartitionMismatchTest.java
@@ -19,7 +19,10 @@
 package org.apache.pinot.segment.local.indexsegment.mutable;
 
 import java.io.IOException;
+import java.util.Map;
+import org.apache.pinot.common.partition.function.CustomPartitionFunction;
 import org.apache.pinot.common.partition.function.ModuloPartitionFunction;
+import org.apache.pinot.segment.spi.partition.PartitionFunctionFactory;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
@@ -40,6 +43,10 @@ public class MutableSegmentImplDropRecordOnPartitionMismatchTest {
 
   private static final Schema SCHEMA = new Schema.SchemaBuilder()
       .addSingleValueDimension(PARTITION_COLUMN, FieldSpec.DataType.INT)
+      .addSingleValueDimension(VALUE_COLUMN, FieldSpec.DataType.INT)
+      .build();
+  private static final Schema STRING_PARTITION_SCHEMA = new Schema.SchemaBuilder()
+      .addSingleValueDimension(PARTITION_COLUMN, FieldSpec.DataType.STRING)
       .addSingleValueDimension(VALUE_COLUMN, FieldSpec.DataType.INT)
       .build();
 
@@ -109,6 +116,33 @@ public class MutableSegmentImplDropRecordOnPartitionMismatchTest {
     assertEquals(_segment.getNumDocsIndexed(), 4);
   }
 
+  @Test
+  public void testInvalidCustomPartitionIdDoesNotDropRecord()
+      throws IOException {
+    _segment = MutableSegmentImplTestUtils.createMutableSegmentImpl(STRING_PARTITION_SCHEMA, PARTITION_COLUMN,
+        PartitionFunctionFactory.getPartitionFunction(PARTITION_COLUMN, CustomPartitionFunction.NAME, NUM_PARTITIONS,
+            Map.of(CustomPartitionFunction.PARTITION_EXPRESSION_CONFIG_KEY, "plus(memberId,0)")),
+        MAIN_PARTITION_ID, true);
+
+    indexRow(_segment, "not-a-number", 200);
+
+    assertEquals(_segment.getNumDocsIndexed(), 1);
+  }
+
+  @Test
+  public void testOutOfRangeCustomPartitionIdDoesNotDropRecord()
+      throws IOException {
+    _segment = MutableSegmentImplTestUtils.createMutableSegmentImpl(SCHEMA, PARTITION_COLUMN,
+        PartitionFunctionFactory.getPartitionFunction(PARTITION_COLUMN, CustomPartitionFunction.NAME, NUM_PARTITIONS,
+            Map.of(CustomPartitionFunction.PARTITION_EXPRESSION_CONFIG_KEY, "plus(memberId,0)", "partitionIdNormalizer",
+                "NO_OP")),
+        MAIN_PARTITION_ID, true);
+
+    indexRow(_segment, 99, 300);
+
+    assertEquals(_segment.getNumDocsIndexed(), 1);
+  }
+
   @Test(expectedExceptions = IllegalStateException.class)
   public void testNullPartitionColumnValueThrowsException()
       throws IOException {
@@ -121,7 +155,7 @@ public class MutableSegmentImplDropRecordOnPartitionMismatchTest {
     _segment.index(row, null);
   }
 
-  private void indexRow(MutableSegmentImpl segment, int partitionColumnValue, int valueColumnValue)
+  private void indexRow(MutableSegmentImpl segment, Object partitionColumnValue, int valueColumnValue)
       throws IOException {
     GenericRow row = new GenericRow();
     row.putValue(PARTITION_COLUMN, partitionColumnValue);

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/SegmentPartitionTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/SegmentPartitionTest.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.Set;
 import org.apache.commons.io.FileUtils;
+import org.apache.pinot.common.partition.function.CustomPartitionFunction;
 import org.apache.pinot.common.partition.function.ModuloPartitionFunction;
 import org.apache.pinot.segment.local.PinotBuffersAfterClassCheckRule;
 import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
@@ -37,6 +38,8 @@ import org.apache.pinot.segment.spi.ColumnMetadata;
 import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.SegmentMetadata;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
+import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;
+import org.apache.pinot.segment.spi.partition.PartitionFunction;
 import org.apache.pinot.spi.config.table.ColumnPartitionConfig;
 import org.apache.pinot.spi.config.table.SegmentPartitionConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -70,6 +73,8 @@ public class SegmentPartitionTest implements PinotBuffersAfterClassCheckRule {
 
   private static final int NUM_ROWS = 1001;
   private static final String PARTITIONED_COLUMN_NAME = "partitionedColumn";
+  private static final String CUSTOM_PARTITIONED_COLUMN_NAME = "customPartitionedColumn";
+  private static final String CUSTOM_PARTITION_EXPRESSION = "plus(" + CUSTOM_PARTITIONED_COLUMN_NAME + ",0)";
 
   private static final String NON_PARTITIONED_COLUMN_NAME = "nonPartitionedColumn";
   private static final int NUM_PARTITIONS = 20; // For modulo function
@@ -77,6 +82,7 @@ public class SegmentPartitionTest implements PinotBuffersAfterClassCheckRule {
   private static final String PARTITION_FUNCTION_NAME = "MoDuLo";
 
   private final Set<Integer> _expectedPartitions = new HashSet<>();
+  private final Set<Integer> _expectedCustomPartitions = new HashSet<>();
   private IndexSegment _segment;
 
   @BeforeClass
@@ -115,6 +121,20 @@ public class SegmentPartitionTest implements PinotBuffersAfterClassCheckRule {
     columnMetadata = segmentMetadata.getColumnMetadataFor(NON_PARTITIONED_COLUMN_NAME);
     Assert.assertNull(columnMetadata.getPartitionFunction());
     Assert.assertNull(columnMetadata.getPartitions());
+  }
+
+  @Test
+  public void testPartitionExpressionMetadataAfterPersist()
+      throws Exception {
+    SegmentMetadata persistedSegmentMetadata = new SegmentMetadataImpl(new File(SEGMENT_PATH));
+    ColumnMetadata columnMetadata = persistedSegmentMetadata.getColumnMetadataFor(CUSTOM_PARTITIONED_COLUMN_NAME);
+
+    PartitionFunction partitionFunction = columnMetadata.getPartitionFunction();
+    Assert.assertTrue(partitionFunction instanceof CustomPartitionFunction);
+    Assert.assertEquals(partitionFunction.getFunctionConfig(),
+        Map.of(CustomPartitionFunction.PARTITION_EXPRESSION_CONFIG_KEY, CUSTOM_PARTITION_EXPRESSION));
+    Assert.assertEquals(columnMetadata.getPartitions(), _expectedCustomPartitions);
+    Assert.assertEquals(partitionFunction.getPartition(Integer.toString(NUM_PARTITIONS + 3)), 3);
   }
 
   /**
@@ -174,6 +194,7 @@ public class SegmentPartitionTest implements PinotBuffersAfterClassCheckRule {
       throws Exception {
     Schema schema = new Schema();
     schema.addField(new DimensionFieldSpec(PARTITIONED_COLUMN_NAME, FieldSpec.DataType.INT, true));
+    schema.addField(new DimensionFieldSpec(CUSTOM_PARTITIONED_COLUMN_NAME, FieldSpec.DataType.INT, true));
     schema.addField(new DimensionFieldSpec(NON_PARTITIONED_COLUMN_NAME, FieldSpec.DataType.INT, true));
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).build();
 
@@ -182,6 +203,8 @@ public class SegmentPartitionTest implements PinotBuffersAfterClassCheckRule {
 
     partitionFunctionMap.put(PARTITIONED_COLUMN_NAME,
         new ColumnPartitionConfig(PARTITION_FUNCTION_NAME, NUM_PARTITIONS));
+    partitionFunctionMap.put(CUSTOM_PARTITIONED_COLUMN_NAME, new ColumnPartitionConfig(CustomPartitionFunction.NAME,
+        NUM_PARTITIONS, Map.of(CustomPartitionFunction.PARTITION_EXPRESSION_CONFIG_KEY, CUSTOM_PARTITION_EXPRESSION)));
 
     SegmentPartitionConfig segmentPartitionConfig = new SegmentPartitionConfig(partitionFunctionMap);
     SegmentGeneratorConfig config = new SegmentGeneratorConfig(tableConfig, schema);
@@ -197,7 +220,9 @@ public class SegmentPartitionTest implements PinotBuffersAfterClassCheckRule {
       int partition = random.nextInt(PARTITION_DIVISOR);
       int validPartitionedValue = random.nextInt(100) * 20 + partition;
       _expectedPartitions.add(partition);
+      _expectedCustomPartitions.add(partition);
       row.putValue(PARTITIONED_COLUMN_NAME, validPartitionedValue);
+      row.putValue(CUSTOM_PARTITIONED_COLUMN_NAME, validPartitionedValue);
       row.putValue(NON_PARTITIONED_COLUMN_NAME, validPartitionedValue);
       rows.add(row);
     }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.function.BiConsumer;
 import javax.annotation.Nullable;
+import org.apache.pinot.common.partition.function.CustomPartitionFunction;
 import org.apache.pinot.common.tier.TierFactory;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.segment.spi.Constants;
@@ -1807,6 +1808,53 @@ public class TableConfigUtilsTest {
     } catch (Exception e) {
       // expected
     }
+
+    partitionConfigMap = Map.of("intCol",
+        new ColumnPartitionConfig(CustomPartitionFunction.NAME, 4,
+            Map.of(CustomPartitionFunction.PARTITION_EXPRESSION_CONFIG_KEY, "plus(intCol,0)")));
+    partitionConfig = new SegmentPartitionConfig(partitionConfigMap);
+    tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
+        .setSegmentPartitionConfig(partitionConfig)
+        .build();
+    TableConfigUtils.validate(tableConfig, schema);
+
+    partitionConfigMap = Map.of("myCol",
+        new ColumnPartitionConfig(CustomPartitionFunction.NAME, 4,
+            Map.of(CustomPartitionFunction.PARTITION_EXPRESSION_CONFIG_KEY, "plus(otherCol,0)")));
+    partitionConfig = new SegmentPartitionConfig(partitionConfigMap);
+    tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
+        .setSegmentPartitionConfig(partitionConfig)
+        .build();
+    TableConfig invalidReferenceTableConfig = tableConfig;
+    assertThrows(IllegalStateException.class, () -> TableConfigUtils.validate(invalidReferenceTableConfig, schema));
+
+    partitionConfigMap = Map.of("myCol", new ColumnPartitionConfig(CustomPartitionFunction.NAME, 4, Map.of()));
+    partitionConfig = new SegmentPartitionConfig(partitionConfigMap);
+    tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
+        .setSegmentPartitionConfig(partitionConfig)
+        .build();
+    TableConfig missingExpressionTableConfig = tableConfig;
+    assertThrows(IllegalStateException.class, () -> TableConfigUtils.validate(missingExpressionTableConfig, schema));
+
+    partitionConfigMap = Map.of("myCol",
+        new ColumnPartitionConfig(CustomPartitionFunction.NAME, 4,
+            Map.of(CustomPartitionFunction.PARTITION_EXPRESSION_CONFIG_KEY, "md5(myCol)")));
+    partitionConfig = new SegmentPartitionConfig(partitionConfigMap);
+    tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
+        .setSegmentPartitionConfig(partitionConfig)
+        .build();
+    TableConfig nonNumericExpressionTableConfig = tableConfig;
+    assertThrows(IllegalStateException.class, () -> TableConfigUtils.validate(nonNumericExpressionTableConfig, schema));
+
+    partitionConfigMap = Map.of("myCol",
+        new ColumnPartitionConfig(CustomPartitionFunction.NAME, 4,
+            Map.of(CustomPartitionFunction.PARTITION_EXPRESSION_CONFIG_KEY, "myCol")));
+    partitionConfig = new SegmentPartitionConfig(partitionConfigMap);
+    tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
+        .setSegmentPartitionConfig(partitionConfig)
+        .build();
+    TableConfig bareColumnExpressionTableConfig = tableConfig;
+    assertThrows(IllegalStateException.class, () -> TableConfigUtils.validate(bareColumnExpressionTableConfig, schema));
 
     // Although this config makes no sense, it should pass the validation phase
     StarTreeIndexConfig starTreeIndexConfig =

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/StatsCollectorConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/StatsCollectorConfig.java
@@ -85,7 +85,7 @@ public class StatsCollectorConfig {
     if (_segmentPartitionConfig != null) {
       ColumnPartitionConfig columnPartitionConfig = _segmentPartitionConfig.getColumnPartitionConfig(column);
       if (columnPartitionConfig != null) {
-        return PartitionFunctionFactory.getPartitionFunction(columnPartitionConfig);
+        return PartitionFunctionFactory.getPartitionFunction(column, columnPartitionConfig);
       }
     }
     return null;

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/metadata/ColumnMetadataImpl.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/metadata/ColumnMetadataImpl.java
@@ -357,7 +357,7 @@ public class ColumnMetadataImpl implements ColumnMetadata {
         partitionFunctionConfigMap = null;
       }
       PartitionFunction partitionFunction =
-          PartitionFunctionFactory.getPartitionFunction(partitionFunctionName, numPartitions,
+          PartitionFunctionFactory.getPartitionFunction(column, partitionFunctionName, numPartitions,
               partitionFunctionConfigMap);
       builder.setPartitionFunction(partitionFunction);
       builder.setPartitions(

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/PartitionFunctionFactory.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/PartitionFunctionFactory.java
@@ -20,6 +20,7 @@ package org.apache.pinot.segment.spi.partition;
 
 import com.google.common.base.Preconditions;
 import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
 import java.util.Collections;
 import java.util.HashMap;
@@ -60,6 +61,9 @@ public class PartitionFunctionFactory {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(PartitionFunctionFactory.class);
   private static final String SCAN_PACKAGE = "org.apache.pinot";
+  private static final String CUSTOM_PARTITION_FUNCTION_NAME = "Custom";
+  private static final String CUSTOM_PARTITION_FUNCTION_CLASS_NAME =
+      "org.apache.pinot.common.partition.function.CustomPartitionFunction";
 
   private static final Map<String, Constructor<? extends PartitionFunction>> REGISTRY;
 
@@ -76,6 +80,9 @@ public class PartitionFunctionFactory {
       try {
         constructor = clazz.getConstructor(int.class, Map.class);
       } catch (NoSuchMethodException e) {
+        if (CUSTOM_PARTITION_FUNCTION_CLASS_NAME.equals(clazz.getName())) {
+          continue;
+        }
         LOGGER.warn("Skipping {}: missing public constructor (int, Map<String, String>)", clazz.getName());
         continue;
       }
@@ -147,6 +154,14 @@ public class PartitionFunctionFactory {
   /// @param functionConfig optional, function-specific configuration; may be `null`
   public static PartitionFunction getPartitionFunction(String functionName, int numPartitions,
       @Nullable Map<String, String> functionConfig) {
+    return getPartitionFunction(null, functionName, numPartitions, functionConfig);
+  }
+
+  public static PartitionFunction getPartitionFunction(@Nullable String columnName, String functionName,
+      int numPartitions, @Nullable Map<String, String> functionConfig) {
+    if (CUSTOM_PARTITION_FUNCTION_NAME.equalsIgnoreCase(functionName)) {
+      return getCustomPartitionFunction(columnName, numPartitions, functionConfig);
+    }
     Constructor<? extends PartitionFunction> constructor = REGISTRY.get(canonicalize(functionName));
     Preconditions.checkArgument(constructor != null, "No partition function registered for name: %s", functionName);
     try {
@@ -162,12 +177,49 @@ public class PartitionFunctionFactory {
     }
   }
 
+  public static PartitionFunction getPartitionFunction(String columnName, ColumnPartitionConfig config) {
+    return getPartitionFunction(columnName, config.getFunctionName(), config.getNumPartitions(),
+        config.getFunctionConfig());
+  }
+
+  public static PartitionFunction getPartitionFunction(String columnName, ColumnPartitionMetadata metadata) {
+    return getPartitionFunction(columnName, metadata.getFunctionName(), metadata.getNumPartitions(),
+        metadata.getFunctionConfig());
+  }
+
+  /// Compatibility shim for callers that do not need column-aware validation.
+  ///
+  /// @deprecated use [#getPartitionFunction(String, ColumnPartitionConfig)].
+  @Deprecated
   public static PartitionFunction getPartitionFunction(ColumnPartitionConfig config) {
     return getPartitionFunction(config.getFunctionName(), config.getNumPartitions(), config.getFunctionConfig());
   }
 
+  /// Compatibility shim for callers that do not need column-aware validation.
+  ///
+  /// @deprecated use [#getPartitionFunction(String, ColumnPartitionMetadata)].
+  @Deprecated
   public static PartitionFunction getPartitionFunction(ColumnPartitionMetadata metadata) {
     return getPartitionFunction(metadata.getFunctionName(), metadata.getNumPartitions(), metadata.getFunctionConfig());
+  }
+
+  private static PartitionFunction getCustomPartitionFunction(@Nullable String columnName, int numPartitions,
+      @Nullable Map<String, String> functionConfig) {
+    try {
+      Class<?> clazz = Class.forName(CUSTOM_PARTITION_FUNCTION_CLASS_NAME);
+      Constructor<?> constructor = clazz.getConstructor(String.class, int.class, Map.class);
+      return (PartitionFunction) constructor.newInstance(columnName, numPartitions, functionConfig);
+    } catch (ClassNotFoundException e) {
+      throw new IllegalArgumentException("Custom partition function is not available on the classpath", e);
+    } catch (NoSuchMethodException | IllegalAccessException | InstantiationException e) {
+      throw new IllegalStateException("Failed to instantiate custom partition function", e);
+    } catch (InvocationTargetException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof RuntimeException) {
+        throw (RuntimeException) cause;
+      }
+      throw new IllegalStateException("Failed to instantiate custom partition function", cause);
+    }
   }
 
   private static String canonicalize(String name) {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/LaunchBackfillIngestionJobCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/LaunchBackfillIngestionJobCommand.java
@@ -227,6 +227,7 @@ public class LaunchBackfillIngestionJobCommand extends LaunchDataIngestionJobCom
 
       // Compute partition ID for the specified partition column value
       int partitionId = PartitionFunctionFactory.getPartitionFunction(
+          _partitionColumn,
           columnMetadata.getFunctionName(),
           columnMetadata.getNumPartitions(),
           columnMetadata.getFunctionConfig()


### PR DESCRIPTION
## Summary
- Add `CustomPartitionFunction`, registered as `functionName: "Custom"`, for expression-based segment partitioning.
- Keep the existing `ColumnPartitionConfig` shape: `functionName`, `numPartitions`, and `functionConfig`; no top-level `partitionExpression` field is added.
- Require `functionConfig.partitionExpression` for `Custom`, with optional `functionConfig.partitionIdNormalizer` defaulting to `POSITIVE_MODULO`.
- Reuse `InbuiltFunctionEvaluator` to evaluate deterministic Pinot scalar-function expressions without expression rewriting or special evaluator logic.
- Persist `functionName`, `numPartitions`, and `functionConfig` into segment metadata, including the custom expression and normalizer.
- Add coverage for table validation, persisted segment metadata, broker/server pruning, and realtime partition mismatch handling.

## User Manual
Existing partition functions continue to work unchanged:

```json
{
  "functionName": "Murmur",
  "numPartitions": 128,
  "functionConfig": {
    "partitionIdNormalizer": "MASK"
  }
}
```

For ad hoc expression-based partitioning, configure the column with `functionName: "Custom"` and put both the required expression and optional normalizer under `functionConfig`:

```json
{
  "indexingConfig": {
    "segmentPartitionConfig": {
      "columnPartitionMap": {
        "memberId": {
          "functionName": "Custom",
          "numPartitions": 16,
          "functionConfig": {
            "partitionExpression": "fnv1aHash32UTF8(memberId)",
            "partitionIdNormalizer": "POSITIVE_MODULO"
          }
        }
      }
    }
  }
}
```

The expression computes a raw numeric partition value, usually a hash of the partition column. Pinot maps that raw value into `[0, numPartitions)` with `partitionIdNormalizer`. If omitted, `Custom` uses `POSITIVE_MODULO`:

```text
partitionId = ((rawValue % numPartitions) + numPartitions) % numPartitions
```

Example with a composed scalar expression and explicit normalizer:

```json
{
  "functionName": "Custom",
  "numPartitions": 128,
  "functionConfig": {
    "partitionExpression": "fnv1aHash32UTF8(md5(toUtf8(id)))",
    "partitionIdNormalizer": "MASK"
  }
}
```

## Expression Rules
- `functionConfig` is required for `functionName: "Custom"`.
- `functionConfig.partitionExpression` is required.
- The expression must be a scalar function expression; a bare column such as `memberId` is rejected.
- The expression may reference only the partition column named by the enclosing `columnPartitionMap` key.
- `numPartitions` is not an expression variable; it remains the `ColumnPartitionConfig` field used by the partition function.
- The expression must produce a numeric raw value for the configured normalizer.
- Only deterministic Pinot scalar functions are accepted.
- Runtime evaluation errors return `-1`; pruning and realtime mismatch handling fail open for invalid or out-of-range custom partition ids.

## Segment Metadata And Pruning Scenarios
- Built-in partition functions remain on the existing partition-function path.
- `functionName: "Custom"` uses the same table config and segment metadata fields as existing partition functions.
- Segment metadata stores `functionName`, `numPartitions`, and `functionConfig`, so `partitionExpression` and `partitionIdNormalizer` are persisted with each segment.
- When a segment is loaded, Pinot reconstructs `CustomPartitionFunction` from the persisted segment metadata and the partition column name.
- If table config changes the expression or normalizer, old segments keep the old persisted config while new segments use the new config.
- Broker-side and server-side pruning use each segment's persisted partition function config, so mixed old/new expression segments are evaluated independently.
- Invalid persisted custom partition metadata is ignored for pruning instead of destabilizing routing updates.

## Implementation Notes
- `CustomPartitionFunction` has one constructor: `(String columnName, int numPartitions, Map<String, String> functionConfig)`.
- `functionConfig.partitionExpression` is required by the constructor.
- `PartitionFunctionFactory` passes the `columnPartitionMap` key into `CustomPartitionFunction` for validation; it is not persisted in `functionConfig`.
- Deprecated no-column `PartitionFunctionFactory` overloads remain only as binary-compatibility shims; new Pinot call sites use the column-aware overloads.
- `InbuiltFunctionEvaluator` exposes deterministic/result metadata for validation and keeps the existing reusable argument-buffer execution model.
- The PR does not change `PartitionFunction.java`, add scalar normalizer functions, or add a separate partition-expression config field.

## Testing
- `./mvnw -pl pinot-common -am -Dtest=CustomPartitionFunctionTest,InbuiltFunctionEvaluatorTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -pl pinot-segment-local -am -Dtest=MutableSegmentImplDropRecordOnPartitionMismatchTest,SegmentPartitionTest,TableConfigUtilsTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -pl pinot-core -am -Dtest=BaseTableDataManagerNeedRefreshTest,ColumnValueSegmentPrunerTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -pl pinot-segment-spi -Dtest=PartitionFunctionFactoryTest,PartitionFunctionTest,PartitionIdNormalizerTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -pl pinot-segment-spi,pinot-common,pinot-broker,pinot-core,pinot-segment-local -am -Dtest=PartitionFunctionFactoryTest,PartitionFunctionTest,PartitionIdNormalizerTest,CustomPartitionFunctionTest,InbuiltFunctionEvaluatorTest,SegmentPartitionUtilsTest,CustomPartitionFunctionSegmentPrunerTest,ColumnValueSegmentPrunerTest,SegmentPartitionTest,BaseTableDataManagerNeedRefreshTest,MutableSegmentImplDropRecordOnPartitionMismatchTest,TableConfigUtilsTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw spotless:apply -pl pinot-segment-spi,pinot-common,pinot-broker,pinot-core,pinot-segment-local,pinot-tools`
- `./mvnw license:format -pl pinot-segment-spi,pinot-common,pinot-broker,pinot-core,pinot-segment-local,pinot-tools`
- `./mvnw checkstyle:check -pl pinot-segment-spi,pinot-common,pinot-broker,pinot-core,pinot-segment-local,pinot-tools`
- `./mvnw license:check -pl pinot-segment-spi,pinot-common,pinot-broker,pinot-core,pinot-segment-local,pinot-tools`
- `git diff --cached --check`
