### PR TITLE
Add IndexType.shouldCreateIndex hook to filter columns at dispatch time

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/BaseSegmentCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/BaseSegmentCreator.java
@@ -342,7 +342,8 @@ public abstract class BaseSegmentCreator implements SegmentCreator {
       IndexType<C, ?, ?> index, IndexCreationContext.Common context, FieldIndexConfigs fieldIndexConfigs)
       throws Exception {
     C config = fieldIndexConfigs.getConfig(index);
-    if (config.isEnabled()) {
+    if (config.isEnabled() && index.shouldCreateIndex(context, config)) {
+      //noinspection resource
       creatorsByIndex.put(index, index.createIndexCreator(context, config));
     }
   }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/IndexType.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/IndexType.java
@@ -87,6 +87,16 @@ public interface IndexType<C extends IndexConfig, IR extends IndexReader, IC ext
     return getId();
   }
 
+  /// Returns whether this index should be built for the given column at segment-creation time. Default `true`. The
+  /// segment-creator dispatch loop calls this after confirming `indexConfig.isEnabled()`; if this returns `false`,
+  /// [#createIndexCreator] is not invoked. Implementations should inspect column-shape signals on `context` (e.g.
+  /// `isSorted`, `isSingleValueField`, stored type) to filter out columns that are not candidates for this index even
+  /// when the config is enabled. Use this when the inability to build is a runtime property of the column rather than
+  /// a config issue (config-level invalidity should still throw from [#validate]).
+  default boolean shouldCreateIndex(IndexCreationContext context, C indexConfig) {
+    return true;
+  }
+
   /**
    * Returns the {@link IndexCreator} that can should be used to create an index of this type with the given context
    * and configuration.


### PR DESCRIPTION
## Summary

Adds a default-true `shouldCreateIndex(IndexCreationContext, C)` hook on `IndexType`. `BaseSegmentCreator.tryCreateIndexCreator` consults it after confirming `indexConfig.isEnabled()`; if the hook returns `false`, the index is skipped without invoking `createIndexCreator`.

## Motivation

Today the dispatch loop only filters by `IndexConfig#isEnabled()`. Indexes that have runtime column-shape preconditions (e.g. min-max requires a sorted single-value column) must either return a no-op creator from `createIndexCreator` or rely on every external caller to duplicate the shape check. Both patterns push column-shape logic into the wrong place.

This hook lets the index declare its runtime ineligibility in one method that the dispatcher consults once, so:

- `createIndexCreator` can `Preconditions.checkArgument` the precondition holds, instead of silently no-op'ing.
- External callers (e.g. plugin index handlers that build post-segment-creation) can call the same hook to share the filter.
- Config-level invalidity remains the responsibility of `validate(...)`; this hook is strictly for runtime column-shape signals (`isSorted`, `isSingleValueField`, stored type, etc.).

## Compatibility

Default returns `true`, so existing index types are unaffected. New plugin index types can opt in.