### PR TITLE
Add mask scalar function for partition normalizer

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/bitwise/MaskScalarFunction.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/bitwise/MaskScalarFunction.java
@@ -1,0 +1,70 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.function.scalar.bitwise;
+
+import org.apache.pinot.common.function.FunctionInfo;
+import org.apache.pinot.spi.annotations.ScalarFunction;
+
+
+/// Polymorphic scalar function for the
+/// [org.apache.pinot.segment.spi.partition.PartitionIdNormalizer#MASK] normalization step.
+///
+/// The function strips the sign bit from an integral value.
+///
+/// This implementation is stateless and thread-safe.
+@ScalarFunction
+public class MaskScalarFunction extends BaseUnaryIntegralScalarFunction {
+  private static final FunctionInfo INT_FUNCTION_INFO;
+  private static final FunctionInfo LONG_FUNCTION_INFO;
+
+  static {
+    try {
+      INT_FUNCTION_INFO =
+          new FunctionInfo(MaskScalarFunction.class.getMethod("intMask", int.class), MaskScalarFunction.class, false);
+      LONG_FUNCTION_INFO =
+          new FunctionInfo(MaskScalarFunction.class.getMethod("longMask", long.class), MaskScalarFunction.class,
+              false);
+    } catch (NoSuchMethodException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public String getName() {
+    return "mask";
+  }
+
+  @Override
+  protected FunctionInfo intFunctionInfo() {
+    return INT_FUNCTION_INFO;
+  }
+
+  @Override
+  protected FunctionInfo longFunctionInfo() {
+    return LONG_FUNCTION_INFO;
+  }
+
+  public static int intMask(int value) {
+    return value & Integer.MAX_VALUE;
+  }
+
+  public static long longMask(long value) {
+    return value & Long.MAX_VALUE;
+  }
+}

--- a/pinot-common/src/test/java/org/apache/pinot/common/function/scalar/bitwise/BitwiseScalarFunctionTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/function/scalar/bitwise/BitwiseScalarFunctionTest.java
@@ -1,0 +1,58 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.function.scalar.bitwise;
+
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+
+/// Tests for bitwise scalar function edge cases.
+public class BitwiseScalarFunctionTest {
+  private static final int[] INT_VALUES = {
+      0, 10, -10, Integer.MIN_VALUE, Integer.MAX_VALUE
+  };
+  private static final long[] LONG_VALUES = {
+      0L, 10L, -10L, Long.MIN_VALUE, Long.MAX_VALUE
+  };
+
+  @Test
+  public void testMaskScalarFunctionStripsSignBit() {
+    for (int value : INT_VALUES) {
+      assertEquals(MaskScalarFunction.intMask(value), value & Integer.MAX_VALUE);
+    }
+    for (long value : LONG_VALUES) {
+      assertEquals(MaskScalarFunction.longMask(value), value & Long.MAX_VALUE);
+    }
+  }
+
+  @Test
+  public void testPolymorphicMaskScalarFunction() {
+    assertEquals(MaskScalarFunction.intMask(Integer.MIN_VALUE), 0);
+    assertEquals(MaskScalarFunction.longMask(Long.MIN_VALUE), 0L);
+
+    MaskScalarFunction mask = new MaskScalarFunction();
+    assertEquals(mask.getFunctionInfo(new ColumnDataType[]{ColumnDataType.INT}).getMethod().getName(), "intMask");
+    assertEquals(mask.getFunctionInfo(new ColumnDataType[]{ColumnDataType.LONG}).getMethod().getName(), "longMask");
+    assertEquals(mask.getFunctionInfo(1).getMethod().getName(), "longMask");
+    assertNull(mask.getFunctionInfo(new ColumnDataType[]{ColumnDataType.FLOAT}));
+  }
+}

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -1089,7 +1089,8 @@ public class CalciteSqlCompilerTest {
   @Test
   public void testPolymorphicArithmeticScalarFunctionsCompile() {
     PinotQuery pinotQuery = compileToPinotQuery("SELECT least(col1, col2), greatest(col3, col4), negate(col5), "
-        + "positiveModulo(col6, col7), moduloOrZero(col8, col9) FROM myTable WHERE least(col1, col2) = 1 "
+        + "positiveModulo(col6, col7), moduloOrZero(col8, col9) "
+        + "FROM myTable WHERE least(col1, col2) = 1 "
         + "AND greatest(col3, col4) = 2 AND negate(col5) = -1 AND positiveModulo(col6, col7) = 0 "
         + "AND moduloOrZero(col8, col9) = 0");
 
@@ -1099,6 +1100,16 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(selectList.get(2).getFunctionCall().getOperator(), "negate");
     Assert.assertEquals(selectList.get(3).getFunctionCall().getOperator(), "positivemodulo");
     Assert.assertEquals(selectList.get(4).getFunctionCall().getOperator(), "moduloorzero");
+  }
+
+  @Test
+  public void testPolymorphicBitwiseScalarFunctionsCompile() {
+    PinotQuery pinotQuery =
+        compileToPinotQuery("SELECT mask(col1) FROM myTable WHERE mask(col1) = 0");
+
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "mask");
+    Assert.assertEquals(pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getFunctionCall()
+        .getOperator(), "mask");
   }
 
   @Test

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/function/BitFunctionsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/function/BitFunctionsTest.java
@@ -71,6 +71,14 @@ public class BitFunctionsTest {
     inputs.add(new Object[]{"bitNot(value)", Lists.newArrayList("value"), unaryRow, -7L});
     inputs.add(new Object[]{"bitMask(value)", Lists.newArrayList("value"), unaryRow, 64L});
 
+    GenericRow signMaskRow = new GenericRow();
+    signMaskRow.putValue("value", -10);
+    inputs.add(new Object[]{"mask(value)", Lists.newArrayList("value"), signMaskRow, Long.MAX_VALUE - 9L});
+
+    GenericRow minValueMaskRow = new GenericRow();
+    minValueMaskRow.putValue("value", Long.MIN_VALUE);
+    inputs.add(new Object[]{"mask(value)", Lists.newArrayList("value"), minValueMaskRow, 0L});
+
     GenericRow highBitMaskRow = new GenericRow();
     highBitMaskRow.putValue("value", 40);
     inputs.add(new Object[]{"bitMask(value)", Lists.newArrayList("value"), highBitMaskRow, 1L << 40});

--- a/pinot-integration-tests/src/test/resources/udf-test-results/all-functions.yaml
+++ b/pinot-integration-tests/src/test/resources/udf-test-results/all-functions.yaml
@@ -1113,6 +1113,10 @@ mapvalue:
   scalar: null
   transform: "org.apache.pinot.core.operator.transform.function.MapValueTransformFunction"
   udf: null
+mask:
+  scalar: "org.apache.pinot.common.function.scalar.bitwise.MaskScalarFunction"
+  transform: null
+  udf: null
 max:
   scalar: null
   transform: null

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryCompilationTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryCompilationTest.java
@@ -73,6 +73,13 @@ public class QueryCompilationTest extends QueryEnvironmentTestBase {
     assertNotNull(dispatchableSubPlan);
   }
 
+  @Test
+  public void testPolymorphicBitwiseScalarFunctionsPlanQuery() {
+    DispatchableSubPlan dispatchableSubPlan = _queryEnvironment.planQuery(
+        "SELECT mask(col3) FROM a WHERE mask(col3) = 0");
+    assertNotNull(dispatchableSubPlan);
+  }
+
   @Test(dataProvider = "testQueryExceptionDataProvider")
   public void testQueryWithException(String query, String exceptionSnippet) {
     try {


### PR DESCRIPTION
## Summary
- Add integral `mask(value)` scalar function for the `PartitionIdNormalizer.MASK` logic by stripping the sign bit.
- Cover scalar registration, SQL parsing, ingestion evaluator, and MSQ planner paths.

## User Manual
`mask(value)` supports `INT` and `LONG` inputs and clears the sign bit, matching `PartitionIdNormalizer.MASK`. Callers can apply modulo separately when they want a partition id.

## Sample Data
Assume a table `normalizer_demo` with:

| `hash_int` | `hash_long` |
| ---: | ---: |
| `-2147483648` | `-9223372036854775808` |
| `-10` | `-10` |
| `10` | `10` |

## Sample Queries And Results
```sql
SELECT
  hash_int,
  mask(hash_int) AS masked_int,
  hash_long,
  mask(hash_long) AS masked_long
FROM normalizer_demo;
```

| `hash_int` | `masked_int` | `hash_long` | `masked_long` |
| ---: | ---: | ---: | ---: |
| `-2147483648` | `0` | `-9223372036854775808` | `0` |
| `-10` | `2147483638` | `-10` | `9223372036854775798` |
| `10` | `10` | `10` | `10` |

Callers can apply modulo separately:

```sql
SELECT
  hash_int,
  mask(hash_int) % 16 AS masked_partition
FROM normalizer_demo;
```

| `hash_int` | `masked_partition` |
| ---: | ---: |
| `-2147483648` | `0` |
| `-10` | `6` |
| `10` | `10` |

## Tests
- `./mvnw -pl pinot-common -am -Dtest=BitwiseScalarFunctionTest,CalciteSqlCompilerTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -pl pinot-core -am -Dtest=org.apache.pinot.core.data.function.BitFunctionsTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -pl pinot-query-planner -am -Dtest=org.apache.pinot.query.QueryCompilationTest#testPolymorphicBitwiseScalarFunctionsPlanQuery -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw spotless:apply checkstyle:check license:format license:check -pl pinot-common,pinot-core,pinot-query-planner,pinot-integration-tests`
- `git diff --check`