### PR TITLE
Fix null-safety and PinotFS contract violations in ADLSGen2PinotFS

### DIFF
--- a/pinot-plugins/pinot-file-system/pinot-adls/src/main/java/org/apache/pinot/plugin/filesystem/ADLSGen2PinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-adls/src/main/java/org/apache/pinot/plugin/filesystem/ADLSGen2PinotFS.java
@@ -659,16 +659,18 @@ public class ADLSGen2PinotFS extends BasePinotFS {
     try {
       DataLakeFileClient fileClient =
           _fileSystemClient.getFileClient(AzurePinotFSUtil.convertUriToAzureStylePath(uri));
+      PathProperties pathProperties;
       try {
-        PathProperties pathProperties = fileClient.getProperties();
-        fileClient.setHttpHeaders(getPathHttpHeaders(pathProperties));
+        pathProperties = fileClient.getProperties();
       } catch (DataLakeStorageException e) {
-        if (e.getStatusCode() != NOT_FOUND_STATUS_CODE) {
-          throw e;
+        if (e.getStatusCode() == NOT_FOUND_STATUS_CODE) {
+          // File does not exist — create an empty file to satisfy the PinotFS touch() contract
+          _fileSystemClient.createFile(AzurePinotFSUtil.convertUriToAzureStylePath(uri));
+          return true;
         }
-        // File does not exist — create an empty file to satisfy the PinotFS touch() contract
-        _fileSystemClient.createFile(AzurePinotFSUtil.convertUriToAzureStylePath(uri));
+        throw new IOException(e);
       }
+      fileClient.setHttpHeaders(getPathHttpHeaders(pathProperties));
       return true;
     } catch (DataLakeStorageException e) {
       throw new IOException(e);

--- a/pinot-plugins/pinot-file-system/pinot-adls/src/main/java/org/apache/pinot/plugin/filesystem/ADLSGen2PinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-adls/src/main/java/org/apache/pinot/plugin/filesystem/ADLSGen2PinotFS.java
@@ -44,6 +44,7 @@ import com.google.common.base.Preconditions;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -495,9 +496,11 @@ public class ADLSGen2PinotFS extends BasePinotFS {
         }
         final String filePath = AzurePinotFSUtil.convertAzureStylePathToUriStylePath(item.getName());
         if (pathFilter.test(filePath)) {
+          OffsetDateTime lastModified = item.getLastModified();
+          long lastModifiedTime = lastModified != null ? lastModified.toInstant().toEpochMilli() : 0L;
           result.add(new FileMetadata.Builder()
               .setFilePath(filePath)
-              .setLastModifiedTime(item.getLastModified().toInstant().toEpochMilli())
+              .setLastModifiedTime(lastModifiedTime)
               .setLength(item.getContentLength())
               .setIsDirectory(false)
               .build());
@@ -525,8 +528,10 @@ public class ADLSGen2PinotFS extends BasePinotFS {
 
   private static FileMetadata getFileMetadata(PathItem file) {
     String path = AzurePinotFSUtil.convertAzureStylePathToUriStylePath(file.getName());
+    OffsetDateTime lastModified = file.getLastModified();
+    long lastModifiedTime = lastModified != null ? lastModified.toInstant().toEpochMilli() : 0L;
     return new FileMetadata.Builder().setFilePath(path)
-        .setLastModifiedTime(file.getLastModified().toInstant().toEpochMilli()).setLength(file.getContentLength())
+        .setLastModifiedTime(lastModifiedTime).setLength(file.getContentLength())
         .setIsDirectory(file.isDirectory()).build();
   }
 
@@ -609,7 +614,7 @@ public class ADLSGen2PinotFS extends BasePinotFS {
       // TODO: need to find the other ways to check the directory if it becomes available. listFiles API returns
       // PathInfo, which includes "isDirectory" field; however, there's no API available for fetching PathInfo directly
       // from target uri.
-      return Boolean.valueOf(metadata.get(IS_DIRECTORY_KEY));
+      return metadata != null && Boolean.parseBoolean(metadata.get(IS_DIRECTORY_KEY));
     } catch (DataLakeStorageException e) {
       throw new IOException("Failed while checking isDirectory for : " + uri, e);
     }
@@ -627,8 +632,11 @@ public class ADLSGen2PinotFS extends BasePinotFS {
     try {
       PathProperties pathProperties = getPathProperties(uri);
       OffsetDateTime offsetDateTime = pathProperties.getLastModified();
-      return offsetDateTime.toInstant().toEpochMilli();
+      return offsetDateTime != null ? offsetDateTime.toInstant().toEpochMilli() : 0L;
     } catch (DataLakeStorageException e) {
+      if (e.getStatusCode() == NOT_FOUND_STATUS_CODE) {
+        return 0L;
+      }
       throw new IOException("Failed while checking lastModified time for : " + uri, e);
     }
   }
@@ -651,8 +659,16 @@ public class ADLSGen2PinotFS extends BasePinotFS {
     try {
       DataLakeFileClient fileClient =
           _fileSystemClient.getFileClient(AzurePinotFSUtil.convertUriToAzureStylePath(uri));
-      PathProperties pathProperties = fileClient.getProperties();
-      fileClient.setHttpHeaders(getPathHttpHeaders(pathProperties));
+      try {
+        PathProperties pathProperties = fileClient.getProperties();
+        fileClient.setHttpHeaders(getPathHttpHeaders(pathProperties));
+      } catch (DataLakeStorageException e) {
+        if (e.getStatusCode() != NOT_FOUND_STATUS_CODE) {
+          throw e;
+        }
+        // File does not exist — create an empty file to satisfy the PinotFS touch() contract
+        _fileSystemClient.createFile(AzurePinotFSUtil.convertUriToAzureStylePath(uri));
+      }
       return true;
     } catch (DataLakeStorageException e) {
       throw new IOException(e);
@@ -668,16 +684,30 @@ public class ADLSGen2PinotFS extends BasePinotFS {
   @Override
   public InputStream open(URI uri)
       throws IOException {
-    return _fileSystemClient.getFileClient(AzurePinotFSUtil.convertUriToAzureStylePath(uri)).openInputStream()
-        .getInputStream();
+    try {
+      return _fileSystemClient.getFileClient(AzurePinotFSUtil.convertUriToAzureStylePath(uri)).openInputStream()
+          .getInputStream();
+    } catch (DataLakeStorageException e) {
+      if (e.getStatusCode() == NOT_FOUND_STATUS_CODE) {
+        throw new FileNotFoundException("File not found: " + uri);
+      }
+      throw new IOException(e);
+    }
   }
 
   private boolean copySrcToDst(URI srcUri, URI dstUri)
       throws IOException {
-    PathProperties pathProperties =
-        _fileSystemClient.getFileClient(AzurePinotFSUtil.convertUriToAzureStylePath(srcUri)).getProperties();
-    try (InputStream inputStream = open(srcUri)) {
-      return copyInputStreamToDst(inputStream, dstUri, pathProperties.getContentMd5());
+    try {
+      PathProperties pathProperties =
+          _fileSystemClient.getFileClient(AzurePinotFSUtil.convertUriToAzureStylePath(srcUri)).getProperties();
+      try (InputStream inputStream = open(srcUri)) {
+        return copyInputStreamToDst(inputStream, dstUri, pathProperties.getContentMd5());
+      }
+    } catch (DataLakeStorageException e) {
+      if (e.getStatusCode() == NOT_FOUND_STATUS_CODE) {
+        throw new FileNotFoundException("Source file not found: " + srcUri);
+      }
+      throw new IOException(e);
     }
   }
 

--- a/pinot-plugins/pinot-file-system/pinot-adls/src/test/java/org/apache/pinot/plugin/filesystem/test/ADLSGen2PinotFSTest.java
+++ b/pinot-plugins/pinot-file-system/pinot-adls/src/test/java/org/apache/pinot/plugin/filesystem/test/ADLSGen2PinotFSTest.java
@@ -31,6 +31,7 @@ import com.azure.storage.file.datalake.models.PathItem;
 import com.azure.storage.file.datalake.models.PathProperties;
 import java.io.ByteArrayInputStream;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -604,6 +605,103 @@ public class ADLSGen2PinotFSTest {
       // Cleanup
       FileUtils.deleteQuietly(tempFile);
     }
+  }
+
+  @Test
+  public void testOpenFileNotFound() {
+    when(_mockFileSystemClient.getFileClient(any())).thenReturn(_mockFileClient);
+    when(_mockFileClient.openInputStream()).thenThrow(_mockDataLakeStorageException);
+    when(_mockDataLakeStorageException.getStatusCode()).thenReturn(404);
+
+    expectThrows(FileNotFoundException.class, () -> _adlsGen2PinotFsUnderTest.open(_mockURI));
+
+    verify(_mockFileSystemClient).getFileClient(any());
+    verify(_mockFileClient).openInputStream();
+    verify(_mockDataLakeStorageException).getStatusCode();
+  }
+
+  @Test
+  public void testLastModifiedFileNotFound()
+      throws IOException {
+    when(_mockFileSystemClient.getDirectoryClient(any())).thenReturn(_mockDirectoryClient);
+    when(_mockDirectoryClient.getProperties()).thenThrow(_mockDataLakeStorageException);
+    when(_mockDataLakeStorageException.getStatusCode()).thenReturn(404);
+
+    long actual = _adlsGen2PinotFsUnderTest.lastModified(_mockURI);
+    assertEquals(actual, 0L);
+
+    verify(_mockFileSystemClient).getDirectoryClient(any());
+    verify(_mockDirectoryClient).getProperties();
+    verify(_mockDataLakeStorageException).getStatusCode();
+  }
+
+  @Test
+  public void testLastModifiedNullDateTime()
+      throws IOException {
+    when(_mockFileSystemClient.getDirectoryClient(any())).thenReturn(_mockDirectoryClient);
+    when(_mockDirectoryClient.getProperties()).thenReturn(_mockPathProperties);
+    when(_mockPathProperties.getLastModified()).thenReturn(null);
+
+    long actual = _adlsGen2PinotFsUnderTest.lastModified(_mockURI);
+    assertEquals(actual, 0L);
+
+    verify(_mockFileSystemClient).getDirectoryClient(any());
+    verify(_mockDirectoryClient).getProperties();
+    verify(_mockPathProperties).getLastModified();
+  }
+
+  @Test
+  public void testIsDirectoryNullMetadata()
+      throws IOException {
+    when(_mockFileSystemClient.getDirectoryClient(any())).thenReturn(_mockDirectoryClient);
+    when(_mockDirectoryClient.getProperties()).thenReturn(_mockPathProperties);
+    when(_mockPathProperties.getMetadata()).thenReturn(null);
+
+    boolean actual = _adlsGen2PinotFsUnderTest.isDirectory(_mockURI);
+    assertFalse(actual);
+
+    verify(_mockFileSystemClient).getDirectoryClient(any());
+    verify(_mockDirectoryClient).getProperties();
+    verify(_mockPathProperties).getMetadata();
+  }
+
+  @Test
+  public void testListFilesWithMetadataNullLastModified()
+      throws IOException {
+    when(_mockFileSystemClient.listPaths(any(), any())).thenReturn(_mockPagedIterable);
+    when(_mockPagedIterable.stream()).thenReturn(Stream.of(_mockPathItem));
+    when(_mockPathItem.getName()).thenReturn("foo");
+    when(_mockPathItem.isDirectory()).thenReturn(false);
+    when(_mockPathItem.getContentLength()).thenReturn(1024L);
+    when(_mockPathItem.getLastModified()).thenReturn(null);
+
+    List<FileMetadata> actual = _adlsGen2PinotFsUnderTest.listFilesWithMetadata(_mockURI, true);
+    FileMetadata fm = actual.get(0);
+    assertEquals(fm.getFilePath(), "/foo");
+    assertEquals(fm.getLastModifiedTime(), 0L);
+
+    verify(_mockFileSystemClient).listPaths(any(), any());
+    verify(_mockPagedIterable).stream();
+    verify(_mockPathItem).getName();
+    verify(_mockPathItem).isDirectory();
+    verify(_mockPathItem).getContentLength();
+    verify(_mockPathItem).getLastModified();
+  }
+
+  @Test
+  public void testTouchFileNotFound()
+      throws IOException {
+    when(_mockFileSystemClient.getFileClient(any())).thenReturn(_mockFileClient);
+    when(_mockFileClient.getProperties()).thenThrow(_mockDataLakeStorageException);
+    when(_mockDataLakeStorageException.getStatusCode()).thenReturn(404);
+
+    boolean actual = _adlsGen2PinotFsUnderTest.touch(_mockURI);
+    assertTrue(actual);
+
+    verify(_mockFileSystemClient).getFileClient(any());
+    verify(_mockFileClient).getProperties();
+    verify(_mockDataLakeStorageException).getStatusCode();
+    verify(_mockFileSystemClient).createFile(any());
   }
 
   @Test


### PR DESCRIPTION
## Summary

Multiple null-safety and `PinotFS` contract violations in `ADLSGen2PinotFS`:

- **`isDirectory()`**: `pathProperties.getMetadata()` can return `null`, causing NPE when accessing `IS_DIRECTORY_KEY`. Added a null guard; returns `false` when metadata is absent.
- **`lastModified()`**: propagated a `DataLakeStorageException` for 404 (missing file) and called `.toInstant()` on a potentially null `OffsetDateTime`. Now returns `0L` for 404 and for a null timestamp, matching the `PinotFS` contract.
- **`touch()`**: threw an exception when the file did not exist instead of creating it. The `PinotFS` contract requires `touch()` to create an empty file if missing. Now creates the file on 404.
- **`open()`**: no error handling — a missing file produced an opaque SDK exception. Now throws `FileNotFoundException` for 404, matching the `PinotFS` contract.
- **`copySrcToDst()`**: similarly throws `FileNotFoundException` when the source is missing (404).
- **`listFilesWithMetadata()` (both overloads)**: `PathItem.getLastModified()` can be null; calling `.toInstant()` on it caused NPE. Added null check defaulting to `0L`.

## Test plan

- [ ] Existing unit/integration tests for `ADLSGen2PinotFS` pass
- [ ] `touch()` on a non-existent path creates an empty file (consistent with `GcsPinotFS`)
- [ ] `lastModified()` returns `0L` for a missing path (consistent with `PinotFS` contract)
- [ ] `open()` on a missing path throws `FileNotFoundException`