### PR TITLE
Fix NPE in HelixHelper.getOfflineInstanceFromExternalView when ExternalView is null

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/HelixHelper.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/HelixHelper.java
@@ -324,11 +324,13 @@ public class HelixHelper {
    */
   public static Set<String> getOfflineInstanceFromExternalView(ExternalView resourceExternalView) {
     Set<String> instanceSet = new HashSet<String>();
-    for (String partition : resourceExternalView.getPartitionSet()) {
-      Map<String, String> stateMap = resourceExternalView.getStateMap(partition);
-      for (String instance : stateMap.keySet()) {
-        if (stateMap.get(instance).equalsIgnoreCase(OFFLINE)) {
-          instanceSet.add(instance);
+    if (resourceExternalView != null) {
+      for (String partition : resourceExternalView.getPartitionSet()) {
+        Map<String, String> stateMap = resourceExternalView.getStateMap(partition);
+        for (String instance : stateMap.keySet()) {
+          if (stateMap.get(instance).equalsIgnoreCase(OFFLINE)) {
+            instanceSet.add(instance);
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary

`getOfflineInstanceFromExternalView()` iterates directly over `resourceExternalView.getPartitionSet()` without a null guard. Passing a `null` `ExternalView` (e.g. when the resource has not yet been created in Helix) throws a `NullPointerException`.

The sibling method `getOnlineInstanceFromExternalView()` already has the correct null guard:
```java
if (resourceExternalView != null) { ... }
```
This PR applies the same pattern to `getOfflineInstanceFromExternalView()` so both methods are consistent and callers get an empty set instead of an NPE.

## Test plan

- [ ] Existing unit tests pass
- [ ] Passing `null` returns an empty set (matches `getOnlineInstanceFromExternalView` behaviour)