### PR TITLE
Fix NPE in StaticTokenAuthProvider and UrlAuthProvider when required config property is absent

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/auth/StaticTokenAuthProvider.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/auth/StaticTokenAuthProvider.java
@@ -43,7 +43,11 @@ public class StaticTokenAuthProvider implements AuthProvider {
   public StaticTokenAuthProvider(AuthConfig authConfig) {
     String header = AuthProviderUtils.getOrDefault(authConfig, HEADER, HttpHeaders.AUTHORIZATION);
     String prefix = AuthProviderUtils.getOrDefault(authConfig, PREFIX, "Basic");
-    String userToken = authConfig.getProperties().get(TOKEN).toString();
+    Object tokenValue = authConfig.getProperties().get(TOKEN);
+    if (tokenValue == null) {
+      throw new IllegalArgumentException("Missing required auth config property: " + TOKEN);
+    }
+    String userToken = tokenValue.toString();
 
     _taskToken = makeToken(prefix, userToken);
     _requestHeaders = Collections.singletonMap(header, _taskToken);

--- a/pinot-common/src/main/java/org/apache/pinot/common/auth/UrlAuthProvider.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/auth/UrlAuthProvider.java
@@ -54,13 +54,13 @@ public class UrlAuthProvider implements AuthProvider {
   }
 
   public UrlAuthProvider(AuthConfig authConfig) {
+    _header = AuthProviderUtils.getOrDefault(authConfig, HEADER, HttpHeaders.AUTHORIZATION);
+    _prefix = AuthProviderUtils.getOrDefault(authConfig, PREFIX, "Bearer");
+    Object urlValue = authConfig.getProperties().get(URL);
+    if (urlValue == null) {
+      throw new IllegalArgumentException("Missing required auth config property: " + URL);
+    }
     try {
-      _header = AuthProviderUtils.getOrDefault(authConfig, HEADER, HttpHeaders.AUTHORIZATION);
-      _prefix = AuthProviderUtils.getOrDefault(authConfig, PREFIX, "Bearer");
-      Object urlValue = authConfig.getProperties().get(URL);
-      if (urlValue == null) {
-        throw new IllegalArgumentException("Missing required auth config property: " + URL);
-      }
       _url = new URL(urlValue.toString());
     } catch (MalformedURLException e) {
       throw new IllegalArgumentException(e);

--- a/pinot-common/src/main/java/org/apache/pinot/common/auth/UrlAuthProvider.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/auth/UrlAuthProvider.java
@@ -57,7 +57,11 @@ public class UrlAuthProvider implements AuthProvider {
     try {
       _header = AuthProviderUtils.getOrDefault(authConfig, HEADER, HttpHeaders.AUTHORIZATION);
       _prefix = AuthProviderUtils.getOrDefault(authConfig, PREFIX, "Bearer");
-      _url = new URL(authConfig.getProperties().get(URL).toString());
+      Object urlValue = authConfig.getProperties().get(URL);
+      if (urlValue == null) {
+        throw new IllegalArgumentException("Missing required auth config property: " + URL);
+      }
+      _url = new URL(urlValue.toString());
     } catch (MalformedURLException e) {
       throw new IllegalArgumentException(e);
     }


### PR DESCRIPTION
## Summary

Both `StaticTokenAuthProvider(AuthConfig)` and `UrlAuthProvider(AuthConfig)` call `.toString()` directly on `authConfig.getProperties().get(...)` without a null check. When the required property (`token` or `url`) is absent from the config the result is an opaque `NullPointerException` with no indication of which property is missing.

This PR replaces the implicit null deref with an explicit check that throws `IllegalArgumentException` naming the missing property, giving operators an actionable error message.

```java
// Before
String userToken = authConfig.getProperties().get(TOKEN).toString();  // NPE if TOKEN absent

// After
Object tokenValue = authConfig.getProperties().get(TOKEN);
if (tokenValue == null) {
    throw new IllegalArgumentException("Missing required auth config property: " + TOKEN);
}
String userToken = tokenValue.toString();
```

The same pattern is applied to `UrlAuthProvider`.

## Test plan

- [ ] Existing auth provider unit tests pass
- [ ] Constructing either provider with a config missing the required property throws `IllegalArgumentException` with a clear message instead of `NullPointerException`