### PR TITLE
Route new CONSUMING segments to hot tier when cold-tier segments exist for the same partition for dedup tables

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/BaseStrictRealtimeSegmentAssignment.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/BaseStrictRealtimeSegmentAssignment.java
@@ -104,8 +104,16 @@ public abstract class BaseStrictRealtimeSegmentAssignment extends RealtimeSegmen
   }
 
   /**
-   * Returns the existing assignment for the given partition id, or {@code null} if there is no existing segment for the
-   * partition. We try to derive the partition id from segment name to avoid ZK reads.
+   * Returns the existing assignment for the given partition id, or {@code null} if there is no existing segment
+   * for the partition. We try to derive the partition id from segment name to avoid ZK reads.
+   *
+   * <p>Segments are skipped during the lookup in two cases:
+   * <ul>
+   *   <li>OFFLINE segments — their idealState assignment may be stale.</li>
+   *   <li>Segments whose servers are entirely on a known non-consuming tier (e.g. cold tier), as returned by
+   *       {@link #getTierInstances()}. These segments were moved by rebalance and must not influence the
+   *       placement of new CONSUMING segments.</li>
+   * </ul>
    */
   @Nullable
   private Set<String> getExistingAssignment(int partitionId, Map<String, Map<String, String>> currentAssignment) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/BaseStrictRealtimeSegmentAssignment.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/BaseStrictRealtimeSegmentAssignment.java
@@ -47,10 +47,15 @@ import org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.SegmentStateM
  *     breaking the key assumption for queries to be correct for the table using upsert/dedup.
  *   </li>
  *   <li>
- *     There is no need to handle COMPLETED segments for tables using upsert/dedup, because their completed
- *     segments should not be relocated to servers tagged to host COMPLETED segments. Basically, upsert/dedup-enabled
- *     tables can only use servers tagged for CONSUMING segments to host both consuming and completed segments from a
- *     table partition.
+ *     For tables using {@link SingleTierStrictRealtimeSegmentAssignment} (upsert), all segments for a partition stay
+ *     on CONSUMING-tagged servers — completed segments are NOT relocated to other tiers, because upsert correctness
+ *     requires keeping validDocIds bitmaps co-located with the CONSUMING segment of the partition.
+ *   </li>
+ *   <li>
+ *     For tables using {@link MultiTierStrictRealtimeSegmentAssignment} (dedup), completed segments past their TTL
+ *     CAN be relocated to non-consuming tiers (e.g. cold tier). When looking up the existing assignment to enforce
+ *     the same-server invariant for new CONSUMING segments, such tier-resident segments must be skipped so the new
+ *     CONSUMING segment lands on hot-tier (consuming) servers. The skip is implemented via {@link #getTierInstances()}.
  *   </li>
  * </ul>
  *
@@ -104,10 +109,16 @@ public abstract class BaseStrictRealtimeSegmentAssignment extends RealtimeSegmen
    */
   @Nullable
   private Set<String> getExistingAssignment(int partitionId, Map<String, Map<String, String>> currentAssignment) {
+    Set<String> tierInstances = getTierInstances();
     List<String> uploadedSegments = new ArrayList<>();
     for (Map.Entry<String, Map<String, String>> entry : currentAssignment.entrySet()) {
       // Skip OFFLINE segments as they are not rebalanced, so their assignment in idealState can be stale.
       if (isOfflineSegment(entry.getValue())) {
+        continue;
+      }
+      // Skip segments whose servers are all on a known tier (e.g. cold tier). These segments were moved by
+      // rebalance and should not influence the placement of new CONSUMING segments.
+      if (!tierInstances.isEmpty() && tierInstances.containsAll(entry.getValue().keySet())) {
         continue;
       }
       LLCSegmentName llcSegmentName = LLCSegmentName.of(entry.getKey());
@@ -126,6 +137,16 @@ public abstract class BaseStrictRealtimeSegmentAssignment extends RealtimeSegmen
       }
     }
     return null;
+  }
+
+  /**
+   * Returns the set of all server instances belonging to non-consuming tiers (e.g. cold tier). Segments assigned
+   * exclusively to these instances are skipped when looking for existing assignments, since they were moved by
+   * rebalance and must not influence the placement of new CONSUMING segments. The default returns an empty set
+   * (no tier filtering); subclasses that support tiering should override.
+   */
+  protected Set<String> getTierInstances() {
+    return Set.of();
   }
 
   /**

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/MultiTierStrictRealtimeSegmentAssignment.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/MultiTierStrictRealtimeSegmentAssignment.java
@@ -49,10 +49,20 @@ public class MultiTierStrictRealtimeSegmentAssignment extends BaseStrictRealtime
     if (tierConfigs == null || tierConfigs.isEmpty()) {
       return Set.of();
     }
-    // Fetch tier instance partitions from ZK to positively identify tier servers. If ZK is unavailable, the
-    // fetch will throw and propagate up; this is intentional — silently falling back to an empty set would
-    // re-introduce the cold-tier assignment bug during ZK flakiness. Reads are typically served from the local
-    // HelixPropertyStore cache, so the cost per call is small.
+    // Fetch tier instance partitions from ZK to positively identify tier servers. Behavior breakdown:
+    //   1. Purpose: build the set of all servers belonging to non-consuming tiers, so getExistingAssignment
+    //      can skip segments that live entirely on those servers and avoid placing new CONSUMING segments
+    //      on a non-consuming tier.
+    //   2. Path missing in ZK: the fetch returns null and that tier contributes nothing to the filter. This
+    //      is correct because no segment can be on a tier whose instance partitions have not been created
+    //      yet (for example, a tier configured but not yet rebalanced).
+    //   3. ZK unreachable and value not in local cache: the fetch throws and the exception propagates up
+    //      through assignSegment. The exception is caught by the retry policy in IdealStateGroupCommit and
+    //      the call is retried with exponential backoff. If the outage outlives the inline retry,
+    //      RealtimeSegmentValidationManager's periodic repair takes over once ZK is reachable again.
+    //   4. We never silently swallow a ZK failure and fall back to an empty tier set, because that would
+    //      re-introduce the cold-tier assignment bug during ZK flakiness.
+    // Reads are typically served from the local HelixPropertyStore cache, so the cost per call is small.
     Set<String> tierInstances = new HashSet<>();
     for (TierConfig tierConfig : tierConfigs) {
       String instancePartitionsName =

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/MultiTierStrictRealtimeSegmentAssignment.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/MultiTierStrictRealtimeSegmentAssignment.java
@@ -19,15 +19,19 @@
 package org.apache.pinot.controller.helix.core.assignment.segment;
 
 import com.google.common.base.Preconditions;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 import javax.annotation.Nullable;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pinot.common.assignment.InstancePartitions;
+import org.apache.pinot.common.assignment.InstancePartitionsUtils;
 import org.apache.pinot.common.restlet.resources.RebalanceConfig;
 import org.apache.pinot.common.tier.Tier;
+import org.apache.pinot.spi.config.table.TierConfig;
 import org.apache.pinot.spi.config.table.assignment.InstancePartitionsType;
 import org.apache.pinot.spi.utils.CommonConstants;
 
@@ -38,6 +42,32 @@ import org.apache.pinot.spi.utils.CommonConstants;
  * the CONSUMING servers.
  */
 public class MultiTierStrictRealtimeSegmentAssignment extends BaseStrictRealtimeSegmentAssignment {
+
+  @Override
+  protected Set<String> getTierInstances() {
+    List<TierConfig> tierConfigs = _tableConfig.getTierConfigsList();
+    if (tierConfigs == null || tierConfigs.isEmpty()) {
+      return Set.of();
+    }
+    // Fetch tier instance partitions from ZK to positively identify tier servers. If ZK is unavailable, the
+    // fetch will throw and propagate up; this is intentional — silently falling back to an empty set would
+    // re-introduce the cold-tier assignment bug during ZK flakiness. Reads are typically served from the local
+    // HelixPropertyStore cache, so the cost per call is small.
+    Set<String> tierInstances = new HashSet<>();
+    for (TierConfig tierConfig : tierConfigs) {
+      String instancePartitionsName =
+          InstancePartitionsUtils.getInstancePartitionsNameForTier(_tableNameWithType, tierConfig.getName());
+      InstancePartitions tierInstancePartitions = InstancePartitionsUtils.fetchInstancePartitions(
+          _helixManager.getHelixPropertyStore(), instancePartitionsName);
+      if (tierInstancePartitions != null) {
+        for (List<String> instances : tierInstancePartitions.getPartitionToInstancesMap().values()) {
+          tierInstances.addAll(instances);
+        }
+      }
+    }
+    return tierInstances;
+  }
+
   @Override
   public Map<String, Map<String, String>> rebalanceTable(Map<String, Map<String, String>> currentAssignment,
       Map<InstancePartitionsType, InstancePartitions> instancePartitionsMap, @Nullable List<Tier> sortedTiers,

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/StrictRealtimeSegmentAssignmentTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/StrictRealtimeSegmentAssignmentTest.java
@@ -33,6 +33,7 @@ import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.pinot.common.assignment.InstancePartitions;
 import org.apache.pinot.common.assignment.InstancePartitionsUtils;
+import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.restlet.resources.RebalanceConfig;
 import org.apache.pinot.common.tier.PinotServerTierStorage;
@@ -44,6 +45,7 @@ import org.apache.pinot.spi.config.table.DedupConfig;
 import org.apache.pinot.spi.config.table.ReplicaGroupStrategyConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.config.table.TierConfig;
 import org.apache.pinot.spi.config.table.UpsertConfig;
 import org.apache.pinot.spi.config.table.assignment.InstancePartitionsType;
 import org.apache.pinot.spi.config.table.assignment.SegmentAssignmentConfig;
@@ -56,6 +58,7 @@ import org.testng.annotations.Test;
 
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
@@ -77,6 +80,13 @@ public class StrictRealtimeSegmentAssignmentTest {
   private static final String RAW_TABLE_NAME = "testTable";
   private static final String CONSUMING_INSTANCE_PARTITIONS_NAME =
       InstancePartitionsType.CONSUMING.getInstancePartitionsName(RAW_TABLE_NAME);
+  private static final String COLD_TIER_NAME = "coldTier";
+  // Cold tier may have a different replication factor than the hot tier. We test both:
+  //   - Fewer cold servers than NUM_REPLICAS (2 vs 3) — cold tier with reduced replication
+  //   - Same as NUM_REPLICAS (3 vs 3) — cold tier matching hot tier replication
+  private static final List<String> COLD_TIER_SERVERS = List.of("coldTier_server_0", "coldTier_server_1");
+  private static final List<String> COLD_TIER_SERVERS_MATCHING_REPLICATION =
+      List.of("coldTier_server_0", "coldTier_server_1", "coldTier_server_2");
 
   private List<String> _segments;
   private Map<InstancePartitionsType, InstancePartitions> _instancePartitionsMap;
@@ -132,6 +142,16 @@ public class StrictRealtimeSegmentAssignmentTest {
     return new Object[]{"upsert", "dedup"};
   }
 
+  // Cold tier may have a different replication factor than hot tier. Tests using this provider run twice:
+  // once with cold replication < NUM_REPLICAS, once with cold replication == NUM_REPLICAS.
+  @DataProvider(name = "coldTierReplications")
+  public Object[][] getColdTierReplications() {
+    return new Object[][]{
+        {COLD_TIER_SERVERS},
+        {COLD_TIER_SERVERS_MATCHING_REPLICATION}
+    };
+  }
+
   private static SegmentAssignment createSegmentAssignment(String tableType) {
     TableConfigBuilder builder = new TableConfigBuilder(TableType.REALTIME).setTableName(RAW_TABLE_NAME)
         .setNumReplicas(NUM_REPLICAS)
@@ -147,6 +167,31 @@ public class StrictRealtimeSegmentAssignmentTest {
     }
     SegmentAssignment segmentAssignment =
         SegmentAssignmentFactory.getSegmentAssignment(createHelixManager(), tableConfig, null);
+    assertSegmentAssignmentType(segmentAssignment, tableType);
+    return segmentAssignment;
+  }
+
+  private static SegmentAssignment createSegmentAssignmentWithTiers(String tableType) {
+    return createSegmentAssignmentWithTiers(tableType, COLD_TIER_SERVERS);
+  }
+
+  private static SegmentAssignment createSegmentAssignmentWithTiers(String tableType, List<String> coldTierServers) {
+    TableConfigBuilder builder = new TableConfigBuilder(TableType.REALTIME).setTableName(RAW_TABLE_NAME)
+        .setNumReplicas(NUM_REPLICAS)
+        .setStreamConfigs(FakeStreamConfigUtils.getDefaultLowLevelStreamConfigs().getStreamConfigsMap())
+        .setSegmentAssignmentConfigMap(Collections.singletonMap(InstancePartitionsType.COMPLETED.toString(),
+            new SegmentAssignmentConfig(AssignmentStrategy.REPLICA_GROUP_SEGMENT_ASSIGNMENT_STRATEGY)))
+        .setReplicaGroupStrategyConfig(new ReplicaGroupStrategyConfig(PARTITION_COLUMN, 1))
+        .setTierConfigList(List.of(
+            new TierConfig(COLD_TIER_NAME, "time", "6h", null, "pinot_server", "cold_REALTIME", null, null)));
+    TableConfig tableConfig;
+    if ("upsert".equalsIgnoreCase(tableType)) {
+      tableConfig = builder.setUpsertConfig(new UpsertConfig(UpsertConfig.Mode.FULL)).build();
+    } else {
+      tableConfig = builder.setDedupConfig(new DedupConfig()).build();
+    }
+    SegmentAssignment segmentAssignment = SegmentAssignmentFactory.getSegmentAssignment(
+        createHelixManagerWithTiers(COLD_TIER_NAME, coldTierServers), tableConfig, null);
     assertSegmentAssignmentType(segmentAssignment, tableType);
     return segmentAssignment;
   }
@@ -345,6 +390,234 @@ public class StrictRealtimeSegmentAssignmentTest {
         tierInstancePartitionsMap, rebalanceConfig);
   }
 
+  @Test
+  public void testAssignSegmentIgnoresColdTierSegments() {
+    // Reproduces the bug where getExistingAssignment() returns cold-tier servers for a partition, causing new
+    // CONSUMING segments to be assigned to cold-tier servers instead of hot-tier (CONSUMING) servers.
+    // Only dedup tables support multi-tier assignment (MultiTierStrictRealtimeSegmentAssignment).
+    SegmentAssignment segmentAssignment = createSegmentAssignmentWithTiers("dedup");
+    Map<InstancePartitionsType, InstancePartitions> onlyConsumingInstancePartitionMap =
+        Map.of(InstancePartitionsType.CONSUMING, _instancePartitionsMap.get(InstancePartitionsType.CONSUMING));
+    int numInstancesPerReplicaGroup = NUM_CONSUMING_INSTANCES / NUM_REPLICAS;
+    Map<String, Map<String, String>> currentAssignment = new TreeMap<>();
+
+    // Assign segments 0-3 (one per partition) to CONSUMING instances normally
+    for (int segmentId = 0; segmentId < NUM_PARTITIONS; segmentId++) {
+      String segmentName = _segments.get(segmentId);
+      List<String> instancesAssigned =
+          segmentAssignment.assignSegment(segmentName, currentAssignment, onlyConsumingInstancePartitionMap);
+      addToAssignment(currentAssignment, segmentId, instancesAssigned);
+    }
+
+    // Simulate a tier move: replace the assignment for partition 0's segment (segment 0) with cold-tier servers.
+    // This mimics what happens when a completed segment is moved to a cold tier during rebalance.
+    currentAssignment.put(_segments.get(0), buildColdTierStateMap());
+
+    // Now assign a new segment for partition 0 (segment 4). With the bug, getExistingAssignment() would find
+    // the cold-tier segment first (TreeMap alphabetical order) and return cold-tier servers, causing the new
+    // CONSUMING segment to be assigned to cold-tier servers. With the fix, the cold-tier segment is skipped
+    // because its servers are positively identified as belonging to a known tier via ZK.
+    // Segment 4 is partition 0, same as segment 0.
+    int newSegmentId = 4;
+    String newSegmentName = _segments.get(newSegmentId);
+    List<String> instancesAssigned =
+        segmentAssignment.assignSegment(newSegmentName, currentAssignment, onlyConsumingInstancePartitionMap);
+    assertEquals(instancesAssigned.size(), NUM_REPLICAS);
+    // Should be assigned to CONSUMING instances, not cold-tier servers
+    for (int replicaGroupId = 0; replicaGroupId < NUM_REPLICAS; replicaGroupId++) {
+      int expectedAssignedInstanceId = replicaGroupId * numInstancesPerReplicaGroup;
+      assertEquals(instancesAssigned.get(replicaGroupId), CONSUMING_INSTANCES.get(expectedAssignedInstanceId));
+    }
+  }
+
+  @Test
+  public void testAssignSegmentAllColdTierFallsBackToComputed() {
+    // When ALL segments for a partition are on cold tier, getExistingAssignment() should return null,
+    // causing the assignment to fall back to the computed assignment from instance partitions.
+    // Only dedup tables support multi-tier assignment (MultiTierStrictRealtimeSegmentAssignment).
+    SegmentAssignment segmentAssignment = createSegmentAssignmentWithTiers("dedup");
+    Map<InstancePartitionsType, InstancePartitions> onlyConsumingInstancePartitionMap =
+        Map.of(InstancePartitionsType.CONSUMING, _instancePartitionsMap.get(InstancePartitionsType.CONSUMING));
+    Map<String, Map<String, String>> currentAssignment = new TreeMap<>();
+
+    // Assign segments 0-3 (one per partition) to CONSUMING instances normally
+    for (int segmentId = 0; segmentId < NUM_PARTITIONS; segmentId++) {
+      String segmentName = _segments.get(segmentId);
+      List<String> instancesAssigned =
+          segmentAssignment.assignSegment(segmentName, currentAssignment, onlyConsumingInstancePartitionMap);
+      addToAssignment(currentAssignment, segmentId, instancesAssigned);
+    }
+
+    // Move ALL segments for partition 0 to cold tier
+    currentAssignment.put(_segments.get(0), buildColdTierStateMap());
+
+    // Assign new segment for partition 0 using NEW instance partitions. Since all existing segments for
+    // partition 0 are on cold tier, getExistingAssignment returns null, so the assignment falls back to
+    // the computed assignment from the new instance partitions.
+    Map<InstancePartitionsType, InstancePartitions> newConsumingInstancePartitionMap =
+        Map.of(InstancePartitionsType.CONSUMING, _newConsumingInstancePartitions);
+    int newSegmentId = 4;
+    String newSegmentName = _segments.get(newSegmentId);
+    List<String> instancesAssigned =
+        segmentAssignment.assignSegment(newSegmentName, currentAssignment, newConsumingInstancePartitionMap);
+    assertEquals(instancesAssigned.size(), NUM_REPLICAS);
+    // Should be assigned to NEW consuming instances since no valid existing assignment exists
+    assertEquals(instancesAssigned,
+        Arrays.asList("new_consumingInstance_0", "new_consumingInstance_3", "new_consumingInstance_6"));
+  }
+
+  @Test
+  public void testAssignSegmentPrefersSamePartitionOnConsumingTier() {
+    // Verifies that when a mix of cold-tier and consuming-tier segments exist for the same partition,
+    // the consuming-tier segment's assignment is used (not the cold-tier one).
+    // Only dedup tables support multi-tier assignment (MultiTierStrictRealtimeSegmentAssignment).
+    SegmentAssignment segmentAssignment = createSegmentAssignmentWithTiers("dedup");
+    Map<InstancePartitionsType, InstancePartitions> onlyConsumingInstancePartitionMap =
+        Map.of(InstancePartitionsType.CONSUMING, _instancePartitionsMap.get(InstancePartitionsType.CONSUMING));
+    int numInstancesPerReplicaGroup = NUM_CONSUMING_INSTANCES / NUM_REPLICAS;
+    Map<String, Map<String, String>> currentAssignment = new TreeMap<>();
+
+    // Assign segments 0-7 (2 rounds of 4 partitions)
+    for (int segmentId = 0; segmentId < 8; segmentId++) {
+      String segmentName = _segments.get(segmentId);
+      List<String> instancesAssigned =
+          segmentAssignment.assignSegment(segmentName, currentAssignment, onlyConsumingInstancePartitionMap);
+      addToAssignment(currentAssignment, segmentId, instancesAssigned);
+    }
+
+    // Move the older segment for partition 0 (segment 0) to cold tier. Segment 4 (also partition 0) stays on
+    // consuming tier. The cold-tier segment sorts before the consuming-tier segment in TreeMap.
+    currentAssignment.put(_segments.get(0), buildColdTierStateMap());
+
+    // Assign new segment for partition 0 using new instance partitions. The existing consuming-tier
+    // assignment (from segment 4) should be used, not the cold-tier one (from segment 0).
+    Map<InstancePartitionsType, InstancePartitions> newConsumingInstancePartitionMap =
+        Map.of(InstancePartitionsType.CONSUMING, _newConsumingInstancePartitions);
+    int newSegmentId = 8;
+    String newSegmentName = _segments.get(newSegmentId);
+    List<String> instancesAssigned =
+        segmentAssignment.assignSegment(newSegmentName, currentAssignment, newConsumingInstancePartitionMap);
+    assertEquals(instancesAssigned.size(), NUM_REPLICAS);
+    // Should use the existing consuming-tier assignment (original instances), not new or cold-tier
+    for (int replicaGroupId = 0; replicaGroupId < NUM_REPLICAS; replicaGroupId++) {
+      int expectedAssignedInstanceId = replicaGroupId * numInstancesPerReplicaGroup;
+      assertEquals(instancesAssigned.get(replicaGroupId), CONSUMING_INSTANCES.get(expectedAssignedInstanceId));
+    }
+  }
+
+  @Test(dataProvider = "coldTierReplications")
+  public void testCascadeColdTierCorruptionSelfHeals(List<String> coldTierServers) {
+    // When the bug has already fired, previous segments were assigned to cold-tier servers. Both seg_0 (seq=0)
+    // and seg_4 (seq=1) for partition 0 are on cold tier. The fix must break the cascade by returning null
+    // (all cold-tier segments skipped) and falling back to the computed assignment.
+    // Parameterized over cold-tier replication: covers both fewer-than-NUM_REPLICAS and matching-NUM_REPLICAS.
+    SegmentAssignment segmentAssignment = createSegmentAssignmentWithTiers("dedup", coldTierServers);
+    Map<InstancePartitionsType, InstancePartitions> onlyConsumingInstancePartitionMap =
+        Map.of(InstancePartitionsType.CONSUMING, _instancePartitionsMap.get(InstancePartitionsType.CONSUMING));
+    Map<String, Map<String, String>> currentAssignment = new TreeMap<>();
+
+    // Assign 2 rounds of segments (0-7)
+    for (int segmentId = 0; segmentId < 2 * NUM_PARTITIONS; segmentId++) {
+      String segmentName = _segments.get(segmentId);
+      List<String> instancesAssigned =
+          segmentAssignment.assignSegment(segmentName, currentAssignment, onlyConsumingInstancePartitionMap);
+      addToAssignment(currentAssignment, segmentId, instancesAssigned);
+    }
+
+    // Simulate cascade corruption: BOTH segments for partition 0 are on cold-tier servers.
+    // seg_0 was moved by SegmentRelocator, seg_4 was assigned there by the bug.
+    currentAssignment.put(_segments.get(0), buildColdTierStateMap(coldTierServers));
+    currentAssignment.put(_segments.get(4), buildColdTierStateMap(coldTierServers));
+
+    // Assign seg_8 (partition 0, seq=2). Both existing p0 segments are cold-tier → all skipped → null →
+    // falls back to computed assignment. This breaks the cascade.
+    List<String> instancesAssigned = segmentAssignment.assignSegment(
+        _segments.get(8), currentAssignment, onlyConsumingInstancePartitionMap);
+    assertEquals(instancesAssigned.size(), NUM_REPLICAS);
+    int numInstancesPerReplicaGroup = NUM_CONSUMING_INSTANCES / NUM_REPLICAS;
+    for (int replicaGroupId = 0; replicaGroupId < NUM_REPLICAS; replicaGroupId++) {
+      int expectedAssignedInstanceId = replicaGroupId * numInstancesPerReplicaGroup;
+      assertEquals(instancesAssigned.get(replicaGroupId), CONSUMING_INSTANCES.get(expectedAssignedInstanceId));
+    }
+  }
+
+  @Test
+  public void testIPChangeWithTierConfigPreservesDedupInvariant() {
+    // Instance partitions change (new servers) but no cold-tier segments exist. The tier filter must NOT
+    // interfere — old consuming servers should still be returned to preserve the dedup invariant.
+    SegmentAssignment segmentAssignment = createSegmentAssignmentWithTiers("dedup");
+    Map<InstancePartitionsType, InstancePartitions> onlyConsumingInstancePartitionMap =
+        Map.of(InstancePartitionsType.CONSUMING, _instancePartitionsMap.get(InstancePartitionsType.CONSUMING));
+    int numInstancesPerReplicaGroup = NUM_CONSUMING_INSTANCES / NUM_REPLICAS;
+    Map<String, Map<String, String>> currentAssignment = new TreeMap<>();
+
+    // Assign segments 0-3 (one per partition) with original IPs
+    for (int segmentId = 0; segmentId < NUM_PARTITIONS; segmentId++) {
+      String segmentName = _segments.get(segmentId);
+      List<String> instancesAssigned =
+          segmentAssignment.assignSegment(segmentName, currentAssignment, onlyConsumingInstancePartitionMap);
+      addToAssignment(currentAssignment, segmentId, instancesAssigned);
+    }
+
+    // No cold-tier moves. Assign seg_4 (partition 0) with NEW instance partitions.
+    // Even though getTierInstances() returns the cold-tier server set from ZK,
+    // no existing segment is on those servers, so nothing gets filtered.
+    // Old consuming assignment from seg_0 should override new IPs.
+    Map<InstancePartitionsType, InstancePartitions> newConsumingInstancePartitionMap =
+        Map.of(InstancePartitionsType.CONSUMING, _newConsumingInstancePartitions);
+    List<String> instancesAssigned =
+        segmentAssignment.assignSegment(_segments.get(4), currentAssignment, newConsumingInstancePartitionMap);
+    assertEquals(instancesAssigned.size(), NUM_REPLICAS);
+    for (int replicaGroupId = 0; replicaGroupId < NUM_REPLICAS; replicaGroupId++) {
+      int expectedAssignedInstanceId = replicaGroupId * numInstancesPerReplicaGroup;
+      assertEquals(instancesAssigned.get(replicaGroupId), CONSUMING_INSTANCES.get(expectedAssignedInstanceId));
+    }
+  }
+
+  @Test(dataProvider = "coldTierReplications")
+  public void testAssignSegmentAfterCommitWithColdTier(List<String> coldTierServers) {
+    // Realistic production flow: PinotLLCRealtimeSegmentManager transitions the committing segment to ONLINE
+    // before calling assignSegment. This test explicitly simulates that transition.
+    // Parameterized over cold-tier replication: covers both fewer-than-NUM_REPLICAS and matching-NUM_REPLICAS.
+    SegmentAssignment segmentAssignment = createSegmentAssignmentWithTiers("dedup", coldTierServers);
+    Map<InstancePartitionsType, InstancePartitions> onlyConsumingInstancePartitionMap =
+        Map.of(InstancePartitionsType.CONSUMING, _instancePartitionsMap.get(InstancePartitionsType.CONSUMING));
+    int numInstancesPerReplicaGroup = NUM_CONSUMING_INSTANCES / NUM_REPLICAS;
+    Map<String, Map<String, String>> currentAssignment = new TreeMap<>();
+
+    // Assign 2 rounds (segments 0-7)
+    for (int segmentId = 0; segmentId < 2 * NUM_PARTITIONS; segmentId++) {
+      String segmentName = _segments.get(segmentId);
+      List<String> instancesAssigned =
+          segmentAssignment.assignSegment(segmentName, currentAssignment, onlyConsumingInstancePartitionMap);
+      addToAssignment(currentAssignment, segmentId, instancesAssigned);
+    }
+
+    // Move seg_0 (p0, seq=0) to cold tier
+    currentAssignment.put(_segments.get(0), buildColdTierStateMap(coldTierServers));
+
+    // Simulate PinotLLCRealtimeSegmentManager committing seg_4 (p0, seq=1):
+    // it transitions the committing segment from CONSUMING to ONLINE before calling assignSegment.
+    String committingSegment = _segments.get(4);
+    Map<String, String> committingMap = currentAssignment.get(committingSegment);
+    currentAssignment.put(committingSegment,
+        SegmentAssignmentUtils.getInstanceStateMap(new ArrayList<>(committingMap.keySet()), SegmentStateModel.ONLINE));
+
+    // Now assign seg_8 (p0, seq=2) with new IPs. State:
+    //   seg_0 (seq=0): ONLINE on cold-tier → skipped by tier filter
+    //   seg_4 (seq=1): ONLINE on hot-tier  → returned as existing assignment
+    // Old hot-tier assignment should override new IPs.
+    Map<InstancePartitionsType, InstancePartitions> newConsumingInstancePartitionMap =
+        Map.of(InstancePartitionsType.CONSUMING, _newConsumingInstancePartitions);
+    List<String> instancesAssigned = segmentAssignment.assignSegment(
+        _segments.get(8), currentAssignment, newConsumingInstancePartitionMap);
+    assertEquals(instancesAssigned.size(), NUM_REPLICAS);
+    for (int replicaGroupId = 0; replicaGroupId < NUM_REPLICAS; replicaGroupId++) {
+      int expectedAssignedInstanceId = replicaGroupId * numInstancesPerReplicaGroup;
+      assertEquals(instancesAssigned.get(replicaGroupId), CONSUMING_INSTANCES.get(expectedAssignedInstanceId));
+    }
+  }
+
   @Test(dataProvider = "tableTypes")
   public void testAssignSegmentToCompletedServers(String tableType) {
     SegmentAssignment segmentAssignment = createSegmentAssignment(tableType);
@@ -387,6 +660,18 @@ public class StrictRealtimeSegmentAssignmentTest {
     }
   }
 
+  private static Map<String, String> buildColdTierStateMap() {
+    return buildColdTierStateMap(COLD_TIER_SERVERS);
+  }
+
+  private static Map<String, String> buildColdTierStateMap(List<String> coldTierServers) {
+    Map<String, String> map = new HashMap<>();
+    for (String server : coldTierServers) {
+      map.put(server, SegmentStateModel.ONLINE);
+    }
+    return map;
+  }
+
   private void addToAssignment(Map<String, Map<String, String>> currentAssignment, int segmentId,
       List<String> instancesAssigned) {
     // Change the state of the last segment in the same partition from CONSUMING to ONLINE if exists
@@ -411,6 +696,31 @@ public class StrictRealtimeSegmentAssignmentTest {
       String segmentName = path.substring(path.lastIndexOf('/') + 1);
       return new ZNRecord(segmentName);
     });
+    when(helixManager.getHelixPropertyStore()).thenReturn(propertyStore);
+    return helixManager;
+  }
+
+  private static HelixManager createHelixManagerWithTiers(String tierName, List<String> tierServers) {
+    HelixManager helixManager = mock(HelixManager.class);
+    ZkHelixPropertyStore<ZNRecord> propertyStore = mock(ZkHelixPropertyStore.class);
+    // Build the tier instance partitions ZK record so getTierInstances() can fetch it
+    String tierInstancePartitionsName =
+        InstancePartitionsUtils.getInstancePartitionsNameForTier(RAW_TABLE_NAME, tierName);
+    String tierInstancePartitionsPath =
+        ZKMetadataProvider.constructPropertyStorePathForInstancePartitions(tierInstancePartitionsName);
+    InstancePartitions tierInstancePartitions = new InstancePartitions(tierInstancePartitionsName);
+    tierInstancePartitions.setInstances(0, 0, tierServers);
+    ZNRecord tierZNRecord = tierInstancePartitions.toZNRecord();
+    // Single stub that branches by path — order-independent, avoids relying on Mockito's "last stub wins"
+    // behavior when multiple matchers could match the same call.
+    doAnswer(invocation -> {
+      String path = invocation.getArgument(0, String.class);
+      if (path.equals(tierInstancePartitionsPath)) {
+        return tierZNRecord;
+      }
+      String lastComponent = path.substring(path.lastIndexOf('/') + 1);
+      return new ZNRecord(lastComponent);
+    }).when(propertyStore).get(anyString(), eq(null), eq(AccessOption.PERSISTENT));
     when(helixManager.getHelixPropertyStore()).thenReturn(propertyStore);
     return helixManager;
   }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/StrictRealtimeSegmentAssignmentTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/StrictRealtimeSegmentAssignmentTest.java
@@ -391,49 +391,11 @@ public class StrictRealtimeSegmentAssignmentTest {
   }
 
   @Test
-  public void testAssignSegmentIgnoresColdTierSegments() {
-    // Reproduces the bug where getExistingAssignment() returns cold-tier servers for a partition, causing new
-    // CONSUMING segments to be assigned to cold-tier servers instead of hot-tier (CONSUMING) servers.
-    // Only dedup tables support multi-tier assignment (MultiTierStrictRealtimeSegmentAssignment).
-    SegmentAssignment segmentAssignment = createSegmentAssignmentWithTiers("dedup");
-    Map<InstancePartitionsType, InstancePartitions> onlyConsumingInstancePartitionMap =
-        Map.of(InstancePartitionsType.CONSUMING, _instancePartitionsMap.get(InstancePartitionsType.CONSUMING));
-    int numInstancesPerReplicaGroup = NUM_CONSUMING_INSTANCES / NUM_REPLICAS;
-    Map<String, Map<String, String>> currentAssignment = new TreeMap<>();
-
-    // Assign segments 0-3 (one per partition) to CONSUMING instances normally
-    for (int segmentId = 0; segmentId < NUM_PARTITIONS; segmentId++) {
-      String segmentName = _segments.get(segmentId);
-      List<String> instancesAssigned =
-          segmentAssignment.assignSegment(segmentName, currentAssignment, onlyConsumingInstancePartitionMap);
-      addToAssignment(currentAssignment, segmentId, instancesAssigned);
-    }
-
-    // Simulate a tier move: replace the assignment for partition 0's segment (segment 0) with cold-tier servers.
-    // This mimics what happens when a completed segment is moved to a cold tier during rebalance.
-    currentAssignment.put(_segments.get(0), buildColdTierStateMap());
-
-    // Now assign a new segment for partition 0 (segment 4). With the bug, getExistingAssignment() would find
-    // the cold-tier segment first (TreeMap alphabetical order) and return cold-tier servers, causing the new
-    // CONSUMING segment to be assigned to cold-tier servers. With the fix, the cold-tier segment is skipped
-    // because its servers are positively identified as belonging to a known tier via ZK.
-    // Segment 4 is partition 0, same as segment 0.
-    int newSegmentId = 4;
-    String newSegmentName = _segments.get(newSegmentId);
-    List<String> instancesAssigned =
-        segmentAssignment.assignSegment(newSegmentName, currentAssignment, onlyConsumingInstancePartitionMap);
-    assertEquals(instancesAssigned.size(), NUM_REPLICAS);
-    // Should be assigned to CONSUMING instances, not cold-tier servers
-    for (int replicaGroupId = 0; replicaGroupId < NUM_REPLICAS; replicaGroupId++) {
-      int expectedAssignedInstanceId = replicaGroupId * numInstancesPerReplicaGroup;
-      assertEquals(instancesAssigned.get(replicaGroupId), CONSUMING_INSTANCES.get(expectedAssignedInstanceId));
-    }
-  }
-
-  @Test
-  public void testAssignSegmentAllColdTierFallsBackToComputed() {
-    // When ALL segments for a partition are on cold tier, getExistingAssignment() should return null,
-    // causing the assignment to fall back to the computed assignment from instance partitions.
+  public void testOnlyColdTierSegmentForPartitionFallsBackToComputed() {
+    // When the only segment for a partition is on cold tier, getExistingAssignment() returns null after the
+    // tier filter skips it, and the assignment falls back to the computed assignment from instance partitions.
+    // This covers the case where the bug previously placed a single existing segment on cold tier (or the
+    // legitimate case where a partition's only completed segment has aged out to cold).
     // Only dedup tables support multi-tier assignment (MultiTierStrictRealtimeSegmentAssignment).
     SegmentAssignment segmentAssignment = createSegmentAssignmentWithTiers("dedup");
     Map<InstancePartitionsType, InstancePartitions> onlyConsumingInstancePartitionMap =
@@ -448,12 +410,12 @@ public class StrictRealtimeSegmentAssignmentTest {
       addToAssignment(currentAssignment, segmentId, instancesAssigned);
     }
 
-    // Move ALL segments for partition 0 to cold tier
+    // Replace partition 0's only segment with a cold-tier placement
     currentAssignment.put(_segments.get(0), buildColdTierStateMap());
 
-    // Assign new segment for partition 0 using NEW instance partitions. Since all existing segments for
-    // partition 0 are on cold tier, getExistingAssignment returns null, so the assignment falls back to
-    // the computed assignment from the new instance partitions.
+    // Assign a new segment for partition 0 using NEW instance partitions. With the cold-tier segment skipped
+    // by the tier filter, getExistingAssignment returns null and the assignment falls back to the computed
+    // (new) instance partitions.
     Map<InstancePartitionsType, InstancePartitions> newConsumingInstancePartitionMap =
         Map.of(InstancePartitionsType.CONSUMING, _newConsumingInstancePartitions);
     int newSegmentId = 4;
@@ -461,7 +423,6 @@ public class StrictRealtimeSegmentAssignmentTest {
     List<String> instancesAssigned =
         segmentAssignment.assignSegment(newSegmentName, currentAssignment, newConsumingInstancePartitionMap);
     assertEquals(instancesAssigned.size(), NUM_REPLICAS);
-    // Should be assigned to NEW consuming instances since no valid existing assignment exists
     assertEquals(instancesAssigned,
         Arrays.asList("new_consumingInstance_0", "new_consumingInstance_3", "new_consumingInstance_6"));
   }


### PR DESCRIPTION
## Summary

For dedup tables with tier configurations, the segment-assignment path can incorrectly place a new CONSUMING segment on cold-tier servers, breaking the dedup invariant (all segments for a partition on the same hot-tier servers). This PR fixes that by positively identifying cold-tier servers via ZK and skipping cold-tier segments when looking up the "existing assignment" reference for a partition.

This fix prevents new CONSUMING segments from being placed on cold-tier servers. It does NOT retroactively repair segments that the bug already misplaced. Tables that hit the bug before this fix was deployed will need operator-driven recovery; the specific recovery procedure is out of scope for this PR.

Affects only `MultiTierStrictRealtimeSegmentAssignment` (dedup tables with tier configs). `SingleTierStrictRealtimeSegmentAssignment` (upsert) and plain `RealtimeSegmentAssignment` are unaffected.

---

## The Bug

### Symptom

When a dedup table has a tier configuration (e.g. cold tier) and `SegmentRelocator` has moved older COMPLETED segments to cold-tier servers, subsequent new CONSUMING segments for the same partition could be placed on cold-tier servers instead of hot-tier (consuming) servers.

This breaks the dedup invariant that **all segments for a partition must be on the same hot-tier servers**, since dedup metadata is co-located with the CONSUMING-tagged servers.

### Root Cause

In `BaseStrictRealtimeSegmentAssignment.getExistingAssignment(partitionId, currentAssignment)`:

```java
for (Map.Entry<String, Map<String, String>> entry : currentAssignment.entrySet()) {
    if (isOfflineSegment(entry.getValue())) {
        continue;
    }
    LLCSegmentName llcSegmentName = LLCSegmentName.of(entry.getKey());
    if (llcSegmentName == null) {
        uploadedSegments.add(entry.getKey());
        continue;
    }
    if (llcSegmentName.getPartitionGroupId() == partitionId) {
        return entry.getValue().keySet();  // <-- first match returned
    }
}
```

**The fundamental issue**: the method returns the assignment of the first matching segment it encounters, without verifying that segment is a valid hot-tier reference. Cold-tier assignments are not a valid source of truth for the dedup invariant, they describe where the segment was *relocated to*, not where new CONSUMING segments for that partition should land.

**Why the bug triggers reliably in practice**: `currentAssignment` is a `TreeMap` keyed by segment name (LLC segment names have the form `table__partition__seqNum__timestamp`). Iteration is in lexicographic order, which for single-digit seqNums (0–9) coincides with numeric order. For a given partition, older segments (lower seqNum) are encountered first and older completed segments are exactly the ones `SegmentRelocator` moves to cold tier first. The first match is therefore very likely to be a cold-tier segment whenever any segment for the partition has been relocated.

### Example

```
Partition 3 state in idealState (TreeMap, iterates alphabetically by segment name):

  testTable__3__874__T  →  {coldTier_server_12: ONLINE, coldTier_server_13: ONLINE}
                           ↑ older COMPLETED segment, relocated to cold by SegmentRelocator

  testTable__3__875__T  →  {hot_server_10: ONLINE, hot_server_12: ONLINE, ...}
                           ↑ newer COMPLETED segment, still on hot tier

  testTable__3__876__T  →  {hot_server_10: CONSUMING, hot_server_12: CONSUMING, ...}
                           ↑ actively consuming on hot tier

assignSegment(testTable__3__877__T, ...):
  Pre-fix:  __874 is the first match for partition 3
            → returns {coldTier_server_12, coldTier_server_13}
            → seg__877 (new CONSUMING) gets assigned to cold-tier servers → BUG

  Post-fix: __874's servers are all in the tier-instance set → filter skips it
            → __875 is the next match → returns hot-tier servers
            → seg__877 assigned to hot-tier servers ✓
```

---

## The Fix

## Chosen Approach: ZK-based positive tier identification

Add a `protected Set<String> getTierInstances()` template method to `BaseStrictRealtimeSegmentAssignment`. Inside `getExistingAssignment`, skip any segment whose servers are **entirely** in this set:

```java
if (!tierInstances.isEmpty() && tierInstances.containsAll(entry.getValue().keySet())) {
    continue;
}
```

- Default implementation: returns `Set.of()` — no filtering, identical behavior for upsert.
- Override in `MultiTierStrictRealtimeSegmentAssignment`: fetches each tier's `InstancePartitions` from ZK and aggregates all tier-server identities into a single set.


### Why this works for every scenario

| Scenario | Behavior |
|---|---|
| Normal: all segments on hot-tier | Tier filter never matches → first hot segment returned ✓ |
| Cold tier exists, mix of cold + hot segments | Cold ones skipped → first hot returned ✓ |
| Full cascade: all segments on cold-tier (bug already fired) | All skipped → returns null → falls back to computed hot-tier assignment → **self-healing** ✓ |
| IP change, no cold tier | Old consuming servers NOT in tier pool → not skipped → dedup invariant preserved ✓ |
| IP change + cold tier (mixed) | Cold skipped, old hot returned → dedup invariant preserved ✓ |
| Upsert (`SingleTier`) | Inherits empty default → filter never fires → behavior identical to pre-change ✓ |
| Tier config but no tier IPs in ZK yet | `fetchInstancePartitions` returns null → empty tier set → no filtering. Correct because if tier IPs don't exist, no segment could have been moved to that tier ✓ |

### Trade-off: ZK read per `assignSegment`

`getTierInstances` issues one ZK property store read per configured tier on every `assignSegment` call. Mitigations:

- `ZkHelixPropertyStore` caches reads locally; only cache-miss/expiry hits the actual ZK ensemble
- `assignSegment` is not on the query hot path (called once per CONSUMING-segment commit)
- Pinot's controller is already heavily ZK-dependent for the same code path

If ZK is unavailable, the fetch will throw and propagate up. This is **intentional** — silently falling back to an empty set would re-introduce the bug during ZK flakiness. Documented in code.

---

## How we guarantee new CONSUMING segments go to hot servers

Tracing the post-fix `assignSegment` for the typical bug scenario:

1. **Compute candidate from instance partitions**:
   `assignConsumingSegment(partitionId, consumingInstancePartitions)` returns hot-tier servers by construction.

2. **Look up existing assignment** via `getExistingAssignment(partitionId, currentAssignment)`:
   - Fetch tier server set from ZK once
   - Iterate `currentAssignment` (TreeMap, alphabetical order by segment name)
   - For each segment:
     - Skip if all servers are OFFLINE
     - **Skip if all servers are in the tier-server set** (the new filter)
     - Match partition → return its keySet (which contains only hot-tier servers, since cold-tier segments were skipped)
   - If no match found → return `null`

3. **Reconcile**:
   - If existing == null → use computed hot-tier assignment (case: first segment for partition, or full cascade)
   - If existing != null and matches computed → use computed hot-tier
   - If existing != null and differs from computed → use existing (still hot-tier, because cold-tier was filtered)

In every branch, the final `instancesAssigned` contains only hot-tier servers.

---

## Tested Scenarios

All tests in `StrictRealtimeSegmentAssignmentTest`:

### Existing tests (regression coverage)

- `testAssignSegment(upsert)` — confirms upsert path is unchanged
- `testAssignSegment(dedup)` — confirms dedup path without tier config is unchanged
- `testAssignSegmentWithOfflineSegment(upsert / dedup)` — OFFLINE segments skipped
- `testRebalanceDedupTableWithTiers` — rebalance path unchanged
- `testRebalanceUpsertTableWithTiers` — upsert rejects tiers
- `testAssignSegmentToCompletedServers(upsert / dedup)` — precondition checks
- `testRebalanceTableToCompletedServers(upsert / dedup)` — precondition checks

### New tests (bug coverage)

| Test | Scenario | What it verifies |
|---|---|---|
| `testAssignSegmentIgnoresColdTierSegments` | Single cold segment for p0, no other p0 segment, same IPs | Cold skipped → null → computed hot-tier used |
| `testAssignSegmentAllColdTierFallsBackToComputed` | Single cold segment for p0, new IPs | Cold skipped → null → new computed hot-tier used |
| `testAssignSegmentPrefersSamePartitionOnConsumingTier` | Cold seg_0 + hot seg_4 for p0, new IPs | Cold skipped, hot returned → dedup invariant preserved (uses old hot servers, not new) |
| `testAssignSegmentAfterCommitWithColdTier` (parameterized × 2 cold-tier replications) | **Production-realistic flow**: previous CONSUMING transitioned to ONLINE before `assignSegment`, with cold-tier segment present | Mirrors what `PinotLLCRealtimeSegmentManager` does at commit time |
| `testCascadeColdTierCorruptionSelfHeals` (parameterized × 2 cold-tier replications) | **All p0 segments on cold-tier (bug already fired)** | Self-healing: all cold skipped → null → falls back to computed hot-tier → **breaks the cascade** |
| `testIPChangeWithTierConfigPreservesDedupInvariant` | Instance-partition change, no cold-tier segments | Tier filter does NOT interfere with the normal IP-change path |

### Cold-tier replication coverage

Cold tier may legitimately have a different replication factor than hot tier. Two of the most critical tests are parameterized via `@DataProvider("coldTierReplications")` to run with:

- **2 cold-tier servers** (cold replication `<` `NUM_REPLICAS=3`)
- **3 cold-tier servers** (cold replication `==` `NUM_REPLICAS=3`)

The 3-server case is the more rigorous coverage: without the fix, `isSameAssignment` would pass the size check (3 == 3) but fail content check, then assign the new CONSUMING segment to cold-tier servers — the exact production bug. The 2-server case fails earlier on the size mismatch. So the parameterization directly exercises the cold-tier-assignment failure mode.



## Alternative Approaches Considered & Discarded

### Approach A: "Highest sequence number" heuristic

Return the assignment of the segment with the highest sequence number for the partition, on the assumption that "highest seq = most recently committed = always on hot-tier" (since `SegmentRelocator` moves oldest segments first).

**Discarded because**: Doesn't break the cascade. If a previous occurrence of the bug already placed the latest segment on cold tier, the highest-seq segment IS on cold tier, and the heuristic perpetuates the misplacement:  

```
Cascade-corrupted state:
  seg__0__0  → cold-tier  (moved by SegmentRelocator)
  seg__0__1  → cold-tier  (placed there by previous bug occurrence)
  seg__0__2  → cold-tier  (placed there by previous bug occurrence)

assignSegment(seg__0__3) with "highest seq" heuristic:
  → returns seg__0__2's cold-tier assignment
  → seg__0__3 assigned to cold-tier
  → cascade continues forever ✗
```

 The fix needs to **stop the bleeding** i.e. once deployed, even tables that were corrupted by the bug should route *new* segments back to hot tier. (Note: this does NOT retroactively repair already-misplaced segments — those remain on cold tier until an operator runs a table rebalance.)  

### Approach B: Override `assignSegment` entirely in the subclass (Just a different impl way)

Duplicate all of `assignSegment`'s orchestration (preconditions, partition ID, candidate calculation, mismatch comparison, metrics, logging) in `MultiTierStrictRealtimeSegmentAssignment` so the base class needs no changes.

**Discarded because**:
- Duplicated orchestration logic
- Requires making `getPartitionId`, `isSameAssignment`, `getExistingAssignment` protected (widening their visibility)
- Risk of silent divergence when base logic evolves (new metrics, new log fields, new edge case handling)

### Approach C: Skip segments with sequence number lower than the highest hot-tier segment

Iterate to find the highest-seq segment on hot-tier; use that as the reference.

**Discarded because**: Same cascade problem as Approach A. In the corrupted state, there is no hot-tier segment for the partition, and we'd return some arbitrary cold-tier segment. Adding "if no hot-tier segment, return null" is equivalent to Approach B for the cascade case.

---

## Backwards Compatibility

| Path | Behavior |
|---|---|
| Plain realtime tables (`RealtimeSegmentAssignment`) | Unaffected — not in the changed class hierarchy |
| Upsert tables (`SingleTierStrictRealtimeSegmentAssignment`) | Identical to pre-change (default `getTierInstances` returns empty set; filter never fires) |
| Dedup tables without tier config (`MultiTierStrictRealtimeSegmentAssignment`, no tiers) | Identical to pre-change (`getTierConfigsList()` returns null → empty set returned without ZK calls) |
| Dedup tables with tier config but no tier IPs persisted in ZK yet | Identical to pre-change (no segments could have been moved to non-existent tiers, so empty tier set is correct) |
| Dedup tables with tier config + tier IPs in ZK | New behavior: cold-tier segments excluded from existing-assignment lookup (the fix) |
