### PR TITLE
Use latest LLC segment (not first) for partition assignment; skip if it is on tier

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/BaseStrictRealtimeSegmentAssignment.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/BaseStrictRealtimeSegmentAssignment.java
@@ -26,8 +26,6 @@ import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.assignment.InstancePartitions;
-import org.apache.pinot.common.metadata.ZKMetadataProvider;
-import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.metrics.ControllerMeter;
 import org.apache.pinot.common.utils.LLCSegmentName;
 import org.apache.pinot.common.utils.SegmentUtils;
@@ -105,10 +103,8 @@ public abstract class BaseStrictRealtimeSegmentAssignment extends RealtimeSegmen
    * partition. We try to derive the partition id from segment name to avoid ZK reads.
    */
   @Nullable
-  private Set<String> getExistingAssignment(int partitionId, Map<String, Map<String, String>> currentAssignment) {
+  protected Set<String> getExistingAssignment(int partitionId, Map<String, Map<String, String>> currentAssignment) {
     List<String> uploadedSegments = new ArrayList<>();
-    LLCSegmentName latestLLCSegmentName = null;
-    Set<String> latestAssignment = null;
     for (Map.Entry<String, Map<String, String>> entry : currentAssignment.entrySet()) {
       // Skip OFFLINE segments as they are not rebalanced, so their assignment in idealState can be stale.
       if (isOfflineSegment(entry.getValue())) {
@@ -120,25 +116,8 @@ public abstract class BaseStrictRealtimeSegmentAssignment extends RealtimeSegmen
         continue;
       }
       if (llcSegmentName.getPartitionGroupId() == partitionId) {
-        if (latestLLCSegmentName == null
-            || llcSegmentName.getSequenceNumber() > latestLLCSegmentName.getSequenceNumber()) {
-          latestLLCSegmentName = llcSegmentName;
-          latestAssignment = entry.getValue().keySet();
-        }
+        return entry.getValue().keySet();
       }
-    }
-    if (latestAssignment != null) {
-      // If the latest segment for the partition has been moved to a tier, it lives on a different instance pool than
-      // a new CONSUMING segment, so its assignment must not be reused.
-      SegmentZKMetadata segmentZKMetadata =
-          ZKMetadataProvider.getSegmentZKMetadata(_helixManager.getHelixPropertyStore(), _tableNameWithType,
-              latestLLCSegmentName.getSegmentName());
-      if (segmentZKMetadata != null && segmentZKMetadata.getTier() != null) {
-        _logger.info("Latest segment: {} for partition: {} is on tier: {}, skipping existing assignment",
-            latestLLCSegmentName.getSegmentName(), partitionId, segmentZKMetadata.getTier());
-        return null;
-      }
-      return latestAssignment;
     }
     // Check ZK metadata for uploaded segments to look for a segment that's in the same partition
     for (String uploadedSegment : uploadedSegments) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/BaseStrictRealtimeSegmentAssignment.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/BaseStrictRealtimeSegmentAssignment.java
@@ -26,6 +26,8 @@ import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.assignment.InstancePartitions;
+import org.apache.pinot.common.metadata.ZKMetadataProvider;
+import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.metrics.ControllerMeter;
 import org.apache.pinot.common.utils.LLCSegmentName;
 import org.apache.pinot.common.utils.SegmentUtils;
@@ -105,6 +107,8 @@ public abstract class BaseStrictRealtimeSegmentAssignment extends RealtimeSegmen
   @Nullable
   private Set<String> getExistingAssignment(int partitionId, Map<String, Map<String, String>> currentAssignment) {
     List<String> uploadedSegments = new ArrayList<>();
+    LLCSegmentName latestLLCSegmentName = null;
+    Set<String> latestAssignment = null;
     for (Map.Entry<String, Map<String, String>> entry : currentAssignment.entrySet()) {
       // Skip OFFLINE segments as they are not rebalanced, so their assignment in idealState can be stale.
       if (isOfflineSegment(entry.getValue())) {
@@ -116,8 +120,25 @@ public abstract class BaseStrictRealtimeSegmentAssignment extends RealtimeSegmen
         continue;
       }
       if (llcSegmentName.getPartitionGroupId() == partitionId) {
-        return entry.getValue().keySet();
+        if (latestLLCSegmentName == null
+            || llcSegmentName.getSequenceNumber() > latestLLCSegmentName.getSequenceNumber()) {
+          latestLLCSegmentName = llcSegmentName;
+          latestAssignment = entry.getValue().keySet();
+        }
       }
+    }
+    if (latestAssignment != null) {
+      // If the latest segment for the partition has been moved to a tier, it lives on a different instance pool than
+      // a new CONSUMING segment, so its assignment must not be reused.
+      SegmentZKMetadata segmentZKMetadata =
+          ZKMetadataProvider.getSegmentZKMetadata(_helixManager.getHelixPropertyStore(), _tableNameWithType,
+              latestLLCSegmentName.getSegmentName());
+      if (segmentZKMetadata != null && segmentZKMetadata.getTier() != null) {
+        _logger.info("Latest segment: {} for partition: {} is on tier: {}, skipping existing assignment",
+            latestLLCSegmentName.getSegmentName(), partitionId, segmentZKMetadata.getTier());
+        return null;
+      }
+      return latestAssignment;
     }
     // Check ZK metadata for uploaded segments to look for a segment that's in the same partition
     for (String uploadedSegment : uploadedSegments) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/MultiTierStrictRealtimeSegmentAssignment.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/MultiTierStrictRealtimeSegmentAssignment.java
@@ -19,15 +19,20 @@
 package org.apache.pinot.controller.helix.core.assignment.segment;
 
 import com.google.common.base.Preconditions;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.TreeMap;
 import javax.annotation.Nullable;
 import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pinot.common.assignment.InstancePartitions;
+import org.apache.pinot.common.metadata.ZKMetadataProvider;
+import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.restlet.resources.RebalanceConfig;
 import org.apache.pinot.common.tier.Tier;
+import org.apache.pinot.common.utils.LLCSegmentName;
 import org.apache.pinot.spi.config.table.assignment.InstancePartitionsType;
 import org.apache.pinot.spi.utils.CommonConstants;
 
@@ -82,5 +87,49 @@ public class MultiTierStrictRealtimeSegmentAssignment extends BaseStrictRealtime
     _logger.info("Rebalanced table: {}, number of segments to be added/removed for each instance: {}",
         _tableNameWithType, SegmentAssignmentUtils.getNumSegmentsToMovePerInstance(currentAssignment, newAssignment));
     return newAssignment;
+  }
+
+  /**
+   * Multi-tier override: pick the latest LLC segment in the partition (highest sequence number) and skip it if it has
+   * already been moved to a tier, since tiered segments live on a different instance pool than CONSUMING segments.
+   */
+  @Nullable
+  @Override
+  protected Set<String> getExistingAssignment(int partitionId, Map<String, Map<String, String>> currentAssignment) {
+    List<String> uploadedSegments = new ArrayList<>();
+    LLCSegmentName latestLLCSegmentName = null;
+    Set<String> latestAssignment = null;
+    for (Map.Entry<String, Map<String, String>> entry : currentAssignment.entrySet()) {
+      if (isOfflineSegment(entry.getValue())) {
+        continue;
+      }
+      LLCSegmentName llcSegmentName = LLCSegmentName.of(entry.getKey());
+      if (llcSegmentName == null) {
+        uploadedSegments.add(entry.getKey());
+        continue;
+      }
+      if (llcSegmentName.getPartitionGroupId() == partitionId && (latestLLCSegmentName == null
+          || llcSegmentName.getSequenceNumber() > latestLLCSegmentName.getSequenceNumber())) {
+        latestLLCSegmentName = llcSegmentName;
+        latestAssignment = entry.getValue().keySet();
+      }
+    }
+    if (latestAssignment != null) {
+      SegmentZKMetadata segmentZKMetadata =
+          ZKMetadataProvider.getSegmentZKMetadata(_helixManager.getHelixPropertyStore(), _tableNameWithType,
+              latestLLCSegmentName.getSegmentName());
+      if (segmentZKMetadata != null && segmentZKMetadata.getTier() != null) {
+        _logger.info("Latest segment: {} for partition: {} is on tier: {}, skipping existing assignment",
+            latestLLCSegmentName.getSegmentName(), partitionId, segmentZKMetadata.getTier());
+        return null;
+      }
+      return latestAssignment;
+    }
+    for (String uploadedSegment : uploadedSegments) {
+      if (getPartitionIdUsingCache(uploadedSegment) == partitionId) {
+        return currentAssignment.get(uploadedSegment).keySet();
+      }
+    }
+    return null;
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/MultiTierStrictRealtimeSegmentAssignment.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/MultiTierStrictRealtimeSegmentAssignment.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.controller.helix.core.assignment.segment;
 
 import com.google.common.base.Preconditions;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -90,13 +89,14 @@ public class MultiTierStrictRealtimeSegmentAssignment extends BaseStrictRealtime
   }
 
   /**
-   * Multi-tier override: pick the latest LLC segment in the partition (highest sequence number) and skip it if it has
-   * already been moved to a tier, since tiered segments live on a different instance pool than CONSUMING segments.
+   * Multi-tier override: pick the latest committed LLC segment in the partition (highest sequence number) and return
+   * its assignment only if the segment is still on the CONSUMING instance pool. If the latest segment has been moved
+   * to a tier (or its ZK metadata is unavailable), return {@code null} so the new CONSUMING segment falls back to the
+   * assignment derived from instance partitions.
    */
   @Nullable
   @Override
   protected Set<String> getExistingAssignment(int partitionId, Map<String, Map<String, String>> currentAssignment) {
-    List<String> uploadedSegments = new ArrayList<>();
     LLCSegmentName latestLLCSegmentName = null;
     Set<String> latestAssignment = null;
     for (Map.Entry<String, Map<String, String>> entry : currentAssignment.entrySet()) {
@@ -105,7 +105,6 @@ public class MultiTierStrictRealtimeSegmentAssignment extends BaseStrictRealtime
       }
       LLCSegmentName llcSegmentName = LLCSegmentName.of(entry.getKey());
       if (llcSegmentName == null) {
-        uploadedSegments.add(entry.getKey());
         continue;
       }
       if (llcSegmentName.getPartitionGroupId() == partitionId && (latestLLCSegmentName == null
@@ -114,22 +113,23 @@ public class MultiTierStrictRealtimeSegmentAssignment extends BaseStrictRealtime
         latestAssignment = entry.getValue().keySet();
       }
     }
-    if (latestAssignment != null) {
-      SegmentZKMetadata segmentZKMetadata =
-          ZKMetadataProvider.getSegmentZKMetadata(_helixManager.getHelixPropertyStore(), _tableNameWithType,
-              latestLLCSegmentName.getSegmentName());
-      if (segmentZKMetadata != null && segmentZKMetadata.getTier() != null) {
-        _logger.info("Latest segment: {} for partition: {} is on tier: {}, skipping existing assignment",
-            latestLLCSegmentName.getSegmentName(), partitionId, segmentZKMetadata.getTier());
-        return null;
-      }
-      return latestAssignment;
+    if (latestAssignment == null) {
+      return null;
     }
-    for (String uploadedSegment : uploadedSegments) {
-      if (getPartitionIdUsingCache(uploadedSegment) == partitionId) {
-        return currentAssignment.get(uploadedSegment).keySet();
-      }
+    String latestSegmentName = latestLLCSegmentName.getSegmentName();
+    SegmentZKMetadata segmentZKMetadata =
+        ZKMetadataProvider.getSegmentZKMetadata(_helixManager.getHelixPropertyStore(), _tableNameWithType,
+            latestSegmentName);
+    if (segmentZKMetadata == null) {
+      _logger.warn("Failed to find ZK metadata for latest segment: {} of partition: {}, skipping existing assignment",
+          latestSegmentName, partitionId);
+      return null;
     }
-    return null;
+    if (segmentZKMetadata.getTier() != null) {
+      _logger.warn("Latest segment: {} for partition: {} is on tier: {}, skipping existing assignment",
+          latestSegmentName, partitionId, segmentZKMetadata.getTier());
+      return null;
+    }
+    return latestAssignment;
   }
 }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/StrictRealtimeSegmentAssignmentTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/StrictRealtimeSegmentAssignmentTest.java
@@ -48,6 +48,7 @@ import org.apache.pinot.spi.config.table.UpsertConfig;
 import org.apache.pinot.spi.config.table.assignment.InstancePartitionsType;
 import org.apache.pinot.spi.config.table.assignment.SegmentAssignmentConfig;
 import org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.SegmentStateModel;
+import org.apache.pinot.spi.utils.CommonConstants.Segment;
 import org.apache.pinot.spi.utils.CommonConstants.Segment.AssignmentStrategy;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.annotations.BeforeClass;
@@ -133,6 +134,10 @@ public class StrictRealtimeSegmentAssignmentTest {
   }
 
   private static SegmentAssignment createSegmentAssignment(String tableType) {
+    return createSegmentAssignment(tableType, createHelixManager());
+  }
+
+  private static SegmentAssignment createSegmentAssignment(String tableType, HelixManager helixManager) {
     TableConfigBuilder builder = new TableConfigBuilder(TableType.REALTIME).setTableName(RAW_TABLE_NAME)
         .setNumReplicas(NUM_REPLICAS)
         .setStreamConfigs(FakeStreamConfigUtils.getDefaultLowLevelStreamConfigs().getStreamConfigsMap())
@@ -146,7 +151,7 @@ public class StrictRealtimeSegmentAssignmentTest {
       tableConfig = builder.setDedupConfig(new DedupConfig()).build();
     }
     SegmentAssignment segmentAssignment =
-        SegmentAssignmentFactory.getSegmentAssignment(createHelixManager(), tableConfig, null);
+        SegmentAssignmentFactory.getSegmentAssignment(helixManager, tableConfig, null);
     assertSegmentAssignmentType(segmentAssignment, tableType);
     return segmentAssignment;
   }
@@ -387,6 +392,76 @@ public class StrictRealtimeSegmentAssignmentTest {
     }
   }
 
+  /**
+   * Verifies the MultiTierStrictRealtimeSegmentAssignment override picks the LATEST LLC segment (highest sequence
+   * number) for the partition rather than the first one encountered, so a new CONSUMING segment is aligned with the
+   * current location of the partition after a rebalance.
+   */
+  @Test
+  public void testMultiTierAssignSegmentUsesLatestExistingAssignment() {
+    SegmentAssignment segmentAssignment = createSegmentAssignment("dedup");
+    Map<InstancePartitionsType, InstancePartitions> newConsumingInstancePartitionMap =
+        Map.of(InstancePartitionsType.CONSUMING, _newConsumingInstancePartitions);
+
+    // Pre-seed currentAssignment for partition 0 with two segments:
+    //   - older sequence (seq 0) on the OLD CONSUMING instances (ONLINE),
+    //   - newer sequence (seq 1) on the NEW CONSUMING instances (CONSUMING).
+    // Picking the FIRST entry would return the old instances and cause the new CONSUMING segment to land on stale
+    // instances; picking the LATEST returns the new instances, which matches what new instancePartitions decides.
+    Map<String, Map<String, String>> currentAssignment = new TreeMap<>();
+    String olderSegment = _segments.get(0); // partition 0, sequence 0
+    String latestSegment = _segments.get(4); // partition 0, sequence 1
+    List<String> oldInstances = Arrays.asList(CONSUMING_INSTANCES.get(0), CONSUMING_INSTANCES.get(3),
+        CONSUMING_INSTANCES.get(6));
+    List<String> newInstances = Arrays.asList(NEW_CONSUMING_INSTANCES.get(0), NEW_CONSUMING_INSTANCES.get(3),
+        NEW_CONSUMING_INSTANCES.get(6));
+    currentAssignment.put(olderSegment, SegmentAssignmentUtils.getInstanceStateMap(oldInstances,
+        SegmentStateModel.ONLINE));
+    currentAssignment.put(latestSegment, SegmentAssignmentUtils.getInstanceStateMap(newInstances,
+        SegmentStateModel.CONSUMING));
+
+    // Now assign the next CONSUMING segment for partition 0 (sequence 2). With the override picking the latest
+    // existing segment, idealAssignment matches the candidate decided by new instancePartitions, so we end up on
+    // the new instances.
+    String nextSegment = _segments.get(8); // partition 0, sequence 2
+    List<String> instancesAssigned =
+        segmentAssignment.assignSegment(nextSegment, currentAssignment, newConsumingInstancePartitionMap);
+    assertEquals(instancesAssigned, newInstances);
+  }
+
+  /**
+   * Verifies the MultiTierStrictRealtimeSegmentAssignment override returns null when the latest LLC segment for the
+   * partition has been moved to a tier (ZK metadata getTier() != null). In that case the existing assignment must not
+   * be reused because tiered segments live on a different instance pool than CONSUMING segments.
+   */
+  @Test
+  public void testMultiTierAssignSegmentSkipsExistingWhenLatestOnTier() {
+    String olderSegment = _segments.get(0); // partition 0, sequence 0
+    String tieredSegment = _segments.get(4); // partition 0, sequence 1 — marked as tiered
+    HelixManager helixManager = createHelixManager(Collections.singleton(tieredSegment));
+    SegmentAssignment segmentAssignment = createSegmentAssignment("dedup", helixManager);
+
+    Map<InstancePartitionsType, InstancePartitions> newConsumingInstancePartitionMap =
+        Map.of(InstancePartitionsType.CONSUMING, _newConsumingInstancePartitions);
+
+    Map<String, Map<String, String>> currentAssignment = new TreeMap<>();
+    // Older segment still on the original consuming instances.
+    currentAssignment.put(olderSegment, SegmentAssignmentUtils.getInstanceStateMap(
+        Arrays.asList(CONSUMING_INSTANCES.get(0), CONSUMING_INSTANCES.get(3), CONSUMING_INSTANCES.get(6)),
+        SegmentStateModel.ONLINE));
+    // Latest segment has been moved to a cold tier (lives on different instances that we don't even reuse here).
+    currentAssignment.put(tieredSegment, SegmentAssignmentUtils.getInstanceStateMap(
+        Arrays.asList("coldTier_server_0", "coldTier_server_1", "coldTier_server_2"),
+        SegmentStateModel.ONLINE));
+
+    String nextSegment = _segments.get(8); // partition 0, sequence 2
+    List<String> instancesAssigned =
+        segmentAssignment.assignSegment(nextSegment, currentAssignment, newConsumingInstancePartitionMap);
+    // Override returned null -> assignSegment falls back to the assignment decided by new instancePartitions.
+    assertEquals(instancesAssigned, Arrays.asList(NEW_CONSUMING_INSTANCES.get(0), NEW_CONSUMING_INSTANCES.get(3),
+        NEW_CONSUMING_INSTANCES.get(6)));
+  }
+
   private void addToAssignment(Map<String, Map<String, String>> currentAssignment, int segmentId,
       List<String> instancesAssigned) {
     // Change the state of the last segment in the same partition from CONSUMING to ONLINE if exists
@@ -404,12 +479,20 @@ public class StrictRealtimeSegmentAssignmentTest {
   }
 
   private static HelixManager createHelixManager() {
+    return createHelixManager(Collections.emptySet());
+  }
+
+  private static HelixManager createHelixManager(Set<String> tieredSegments) {
     HelixManager helixManager = mock(HelixManager.class);
     ZkHelixPropertyStore<ZNRecord> propertyStore = mock(ZkHelixPropertyStore.class);
     when(propertyStore.get(anyString(), eq(null), eq(AccessOption.PERSISTENT))).thenAnswer(invocation -> {
       String path = invocation.getArgument(0, String.class);
       String segmentName = path.substring(path.lastIndexOf('/') + 1);
-      return new ZNRecord(segmentName);
+      ZNRecord record = new ZNRecord(segmentName);
+      if (tieredSegments.contains(segmentName)) {
+        record.setSimpleField(Segment.TIER, "coldTier");
+      }
+      return record;
     });
     when(helixManager.getHelixPropertyStore()).thenReturn(propertyStore);
     return helixManager;

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/StrictRealtimeSegmentAssignmentTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/StrictRealtimeSegmentAssignmentTest.java
@@ -479,7 +479,7 @@ public class StrictRealtimeSegmentAssignmentTest {
   }
 
   private static HelixManager createHelixManager() {
-    return createHelixManager(Collections.emptySet());
+    return createHelixManager(Set.of());
   }
 
   private static HelixManager createHelixManager(Set<String> tieredSegments) {


### PR DESCRIPTION
  ## Summary

  `BaseStrictRealtimeSegmentAssignment.getExistingAssignment` returned the **first** LLC
  segment it found for a partition. When multi-tier dedup tables rebalance and a partition's
  CONSUMING segment moves to a new instance pool, the older segment lingering in
  `idealState` can be picked first — causing the next CONSUMING segment to land on
  cold tier instead of hot tiers.

  This PR, scoped to `MultiTierStrictRealtimeSegmentAssignment`, changes the behavior to:

  1. **Pick the latest LLC segment** for the partition (highest sequence number),
     not the first one encountered. Iteration order of `currentAssignment` is
     lexicographic on segment name (Helix `ZNRecord.getMapFields()` is a `TreeMap`),
     which diverges from numeric sequence order — so explicit comparison is required.
  2. **Honor tier placement**: if the chosen segment has been moved to a tier
     (`SegmentZKMetadata.getTier() != null`), it lives on a different instance pool
     than the CONSUMING segment, so return `null` and let `assignSegment` fall back
     to the assignment derived from instance partitions.

  The base class is unchanged in behavior — the only modification is visibility
  (`private` → `protected`) to allow the subclass override. Single-tier strict
  realtime assignment is untouched.