### PR TITLE
Bump org.codehaus.groovy:groovy-all from 2.4.21 to 3.0.25

### DIFF
--- a/pinot-spi/pom.xml
+++ b/pinot-spi/pom.xml
@@ -291,6 +291,7 @@
     <dependency>
       <groupId>org.codehaus.groovy</groupId>
       <artifactId>groovy-all</artifactId>
+      <type>pom</type>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -204,7 +204,7 @@
     <protobuf-dynamic.version>1.0.1</protobuf-dynamic.version>
     <localstack-utils.version>0.2.23</localstack-utils.version>
     <checker-qual.version>4.1.0</checker-qual.version>
-    <groovy-all.version>2.4.21</groovy-all.version>
+    <groovy.version>3.0.25</groovy.version>
     <xml-apis.version>2.0.2</xml-apis.version>
     <roaring-bitmap.version>1.6.14</roaring-bitmap.version>
     <prometheus.jmx-exporter.version>1.5.0</prometheus.jmx-exporter.version>
@@ -1007,10 +1007,31 @@
         <artifactId>checker-qual</artifactId>
         <version>${checker-qual.version}</version>
       </dependency>
+      <!-- Groovy 3.x publishes groovy-all as a POM aggregator that pulls in every sub-module.
+           We exclude groovy-testng/groovy-test-junit5/groovy-test because their transitive TestNG and
+           JUnit jars collide with Surefire's TestNG fork classpath and cause NoClassDefFoundError on
+           unrelated test classes. Everything else (groovy core, templates, json, xml, sql, jmx, swing,
+           ant, cli-picocli, datetime, nio, jsr223, console, etc.) is kept to preserve the runtime
+           Groovy stdlib surface user transform/filter scripts may rely on from the old 2.4.21 fat jar. -->
       <dependency>
         <groupId>org.codehaus.groovy</groupId>
         <artifactId>groovy-all</artifactId>
-        <version>${groovy-all.version}</version>
+        <version>${groovy.version}</version>
+        <type>pom</type>
+        <exclusions>
+          <exclusion>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-testng</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-test-junit5</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.codehaus.groovy</groupId>
+            <artifactId>groovy-test</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>xml-apis</groupId>


### PR DESCRIPTION
Supersedes #18461, which fails because Groovy 3.x publishes `groovy-all` as a POM aggregator rather than a fat JAR — Dependabot's straight version bump leaves Maven looking for `groovy-all-3.0.25.jar` on Central, which 404s.

## Changes
- `pom.xml`: bump `groovy-all` 2.4.21 → 3.0.25, rename property to `groovy.version`, add `<type>pom</type>` so Maven resolves the aggregator.
- `pinot-spi/pom.xml`: mirror `<type>pom</type>` on the consumer dep.
- Add `<exclusions>` for `groovy-testng`, `groovy-test-junit5`, and `groovy-test`. These three transitively drag in TestNG/JUnit jars that collide with Surefire's TestNG fork on the unit-test runner and crash unrelated test classes with `NoClassDefFoundError: org/apache/pinot/client/admin/PinotAdminException` (which an earlier revision of this PR reproduced — see commit history).

Everything else the 3.x aggregator pulls in is kept so the runtime Groovy stdlib surface user transform/filter scripts may rely on from the old 2.4.21 fat jar — `groovy.util.CliBuilder` (now in `groovy-cli-picocli`), `groovy.jmx.builder.JmxBuilder` (now in `groovy-jmx`), `groovy.swing.*`, `groovy.servlet.*`, `groovy.ant.*`, `groovy.console.*`, JsonSlurper, XmlSlurper, `groovy.sql.Sql`, date/time helpers, etc. — keeps working.

Confirmed via `mvn dependency:tree` on `pinot-spi`:
- present: groovy, groovy-ant, groovy-astbuilder, groovy-cli-picocli, groovy-console, groovy-datetime, groovy-docgenerator, groovy-groovydoc, groovy-groovysh, groovy-jmx, groovy-json, groovy-jsr223, groovy-macro, groovy-nio, groovy-servlet, groovy-sql, groovy-swing, groovy-templates, groovy-xml
- excluded: groovy-testng, groovy-test-junit5, groovy-test

## Test plan
Groovy-touching tests across affected modules:

| Module | Test | Result |
|---|---|---|
| pinot-spi | `GroovyTemplateUtilsTest`, `IngestionJobLauncherTest` | 10/10 |
| pinot-core | `GroovyFunctionEvaluatorTest`, `SchemaUtilsTest`, `PartitionerTest`, `TransformQueriesTest` | 36/36 |
| pinot-broker | full module test suite | 239 tests, no `SurefireBooterForkException`/`NoClassDefFoundError` — the CI failure pattern from the previous push is gone |

`SecureASTCustomizer` API surface (`setImportsWhitelist`, `setReceiversWhiteList`, `addExpressionCheckers`, `MethodCallExpression`, `ImportCustomizer`, …) is unchanged between Groovy 2.4 and 3.0; the malicious-script blocklist (`System.exit`, `.execute()`, metaClass tricks, `PinotAdministrator.main`) continues to be rejected.