### PR TITLE
Remove deprecated _segmentPushType and _segmentPushFrequency from TableConfigBuilder

### DIFF
--- a/pinot-broker/src/test/java/org/apache/pinot/broker/queryquota/HelixExternalViewBasedQueryQuotaManagerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/queryquota/HelixExternalViewBasedQueryQuotaManagerTest.java
@@ -410,7 +410,7 @@ public class HelixExternalViewBasedQueryQuotaManagerTest {
     QuotaConfig quotaConfig = new QuotaConfig("6G", null);
     TableConfig realtimeTableConfig =
         new TableConfigBuilder(TableType.REALTIME).setTableName(RAW_TABLE_NAME).setQuotaConfig(quotaConfig)
-            .setRetentionTimeUnit("DAYS").setRetentionTimeValue("1").setSegmentPushType("APPEND")
+            .setRetentionTimeUnit("DAYS").setRetentionTimeValue("1")
             .setBrokerTenant("testBroker").setServerTenant("testServer").build();
     ZKMetadataProvider.setTableConfig(_testPropertyStore, realtimeTableConfig);
 
@@ -431,7 +431,7 @@ public class HelixExternalViewBasedQueryQuotaManagerTest {
     QuotaConfig quotaConfig = new QuotaConfig("6G", TABLE_MAX_QPS_STR);
     TableConfig realtimeTableConfig =
         new TableConfigBuilder(TableType.REALTIME).setTableName(RAW_TABLE_NAME).setQuotaConfig(quotaConfig)
-            .setRetentionTimeUnit("DAYS").setRetentionTimeValue("1").setSegmentPushType("APPEND")
+            .setRetentionTimeUnit("DAYS").setRetentionTimeValue("1")
             .setBrokerTenant("testBroker").setServerTenant("testServer").build();
     ZKMetadataProvider.setTableConfig(_testPropertyStore, realtimeTableConfig);
 
@@ -456,11 +456,11 @@ public class HelixExternalViewBasedQueryQuotaManagerTest {
     QuotaConfig quotaConfig = new QuotaConfig("6G", TABLE_MAX_QPS_STR);
     TableConfig realtimeTableConfig =
         new TableConfigBuilder(TableType.REALTIME).setTableName(RAW_TABLE_NAME).setQuotaConfig(quotaConfig)
-            .setRetentionTimeUnit("DAYS").setRetentionTimeValue("1").setSegmentPushType("APPEND")
+            .setRetentionTimeUnit("DAYS").setRetentionTimeValue("1")
             .setBrokerTenant("testBroker").setServerTenant("testServer").build();
     TableConfig offlineTableConfig =
         new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).setQuotaConfig(quotaConfig)
-            .setRetentionTimeUnit("DAYS").setRetentionTimeValue("1").setSegmentPushType("APPEND")
+            .setRetentionTimeUnit("DAYS").setRetentionTimeValue("1")
             .setBrokerTenant("testBroker").setServerTenant("testServer").build();
 
     ZKMetadataProvider.setTableConfig(_testPropertyStore, realtimeTableConfig);
@@ -534,7 +534,7 @@ public class HelixExternalViewBasedQueryQuotaManagerTest {
     QuotaConfig quotaConfig = new QuotaConfig("6G", null);
     TableConfig offlineTableConfig =
         new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).setQuotaConfig(quotaConfig)
-            .setRetentionTimeUnit("DAYS").setRetentionTimeValue("1").setSegmentPushType("APPEND")
+            .setRetentionTimeUnit("DAYS").setRetentionTimeValue("1")
             .setBrokerTenant("testBroker").setServerTenant("testServer").build();
     ZKMetadataProvider.setTableConfig(_testPropertyStore, offlineTableConfig);
 
@@ -550,7 +550,7 @@ public class HelixExternalViewBasedQueryQuotaManagerTest {
     QuotaConfig quotaConfig = new QuotaConfig("6G", TABLE_MAX_QPS_STR);
     TableConfig offlineTableConfig =
         new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).setQuotaConfig(quotaConfig)
-            .setRetentionTimeUnit("DAYS").setRetentionTimeValue("1").setSegmentPushType("APPEND")
+            .setRetentionTimeUnit("DAYS").setRetentionTimeValue("1")
             .setBrokerTenant("testBroker").setServerTenant("testServer").build();
     ZKMetadataProvider.setTableConfig(_testPropertyStore, offlineTableConfig);
 

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/timeboundary/TimeBoundaryManagerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/timeboundary/TimeBoundaryManagerTest.java
@@ -227,9 +227,12 @@ public class TimeBoundaryManagerTest extends ControllerTest {
     verifyTimeBoundaryInfo(timeBoundaryManager.getTimeBoundaryInfo(), expectedTimeValue);
   }
 
+  @SuppressWarnings("deprecation")
   private TableConfig getTableConfig(String rawTableName, String pushFrequency) {
-    return new TableConfigBuilder(TableType.OFFLINE).setTableName(rawTableName).setTimeColumnName(TIME_COLUMN)
-        .setSegmentPushFrequency(pushFrequency).build();
+    TableConfig tableConfig =
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(rawTableName).setTimeColumnName(TIME_COLUMN).build();
+    tableConfig.getValidationConfig().setSegmentPushFrequency(pushFrequency);
+    return tableConfig;
   }
 
   private void setSchemaTimeFieldSpec(String rawTableName, TimeUnit timeUnit) {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java
@@ -2125,7 +2125,6 @@ public class MultiStageEngineIntegrationTest extends BaseClusterIntegrationTestS
         .setRetentionTimeValue("5000")
         .setDeletedSegmentsRetentionPeriod("7d")
         .setNumReplicas(1)
-        .setSegmentPushType("APPEND")
         .setBrokerTenant("DefaultTenant")
         .setServerTenant("DefaultTenant")
         .setLoadMode("MMAP")

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -3669,10 +3669,11 @@ public class TableConfigUtilsTest {
 
     Map<String, String> expectedStreamConfigsMap = getTestStreamConfigs();
     TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
-        .setSegmentPushFrequency(expectedPushFrequency)
-        .setSegmentPushType(expectedPushType)
         .setStreamConfigs(expectedStreamConfigsMap)
         .build();
+    // Simulate a legacy table config that carries push type/frequency in the validation config
+    tableConfig.getValidationConfig().setSegmentPushFrequency(expectedPushFrequency);
+    tableConfig.getValidationConfig().setSegmentPushType(expectedPushType);
 
     // Before conversion, the ingestion config should be null.
     assertNull(tableConfig.getIngestionConfig());

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/TableConfigBuilder.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/TableConfigBuilder.java
@@ -50,6 +50,7 @@ import org.apache.pinot.spi.config.table.UpsertConfig;
 import org.apache.pinot.spi.config.table.assignment.InstanceAssignmentConfig;
 import org.apache.pinot.spi.config.table.assignment.InstancePartitionsType;
 import org.apache.pinot.spi.config.table.assignment.SegmentAssignmentConfig;
+import org.apache.pinot.spi.config.table.ingestion.BatchIngestionConfig;
 import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.apache.pinot.spi.config.table.sampler.TableSamplerConfig;
 
@@ -79,8 +80,8 @@ public class TableConfigBuilder {
   private String _lineageEntryCleanupRetentionPeriod;
   @Deprecated
   private String _segmentPushFrequency;
-
-  // TODO: Remove 'DEFAULT_SEGMENT_PUSH_TYPE' in the future major release.
+  // Written to validationConfig for backward compat: IngestionConfigUtils still falls back to this field.
+  // Remove once the IngestionConfigUtils fallback is removed.
   @Deprecated
   private String _segmentPushType = DEFAULT_SEGMENT_PUSH_TYPE;
   private String _peerSegmentDownloadScheme;
@@ -226,6 +227,7 @@ public class TableConfigBuilder {
   /**
    * @deprecated Use {@code segmentIngestionType} from {@link IngestionConfig#getBatchIngestionConfig()}
    */
+  @Deprecated
   public TableConfigBuilder setSegmentPushType(String segmentPushType) {
     if (REFRESH_SEGMENT_PUSH_TYPE.equalsIgnoreCase(segmentPushType)) {
       _segmentPushType = REFRESH_SEGMENT_PUSH_TYPE;
@@ -238,6 +240,7 @@ public class TableConfigBuilder {
   /**
    * @deprecated Use {@code segmentIngestionFrequency} from {@link IngestionConfig#getBatchIngestionConfig()}
    */
+  @Deprecated
   public TableConfigBuilder setSegmentPushFrequency(String segmentPushFrequency) {
     _segmentPushFrequency = segmentPushFrequency;
     return this;
@@ -513,6 +516,8 @@ public class TableConfigBuilder {
     return this;
   }
 
+  @SuppressWarnings("deprecation") // intentionally calls deprecated setters on SegmentsValidationAndRetentionConfig
+  // and IndexingConfig; those calls are required to keep the IngestionConfigUtils legacy fallback working.
   public TableConfig build() {
     // Validation config
     SegmentsValidationAndRetentionConfig validationConfig = new SegmentsValidationAndRetentionConfig();
@@ -568,6 +573,30 @@ public class TableConfigBuilder {
 
     if (_customConfig == null) {
       _customConfig = new TableCustomConfig(null);
+    }
+
+    // Propagate deprecated push-type/frequency into BatchIngestionConfig (the correct storage location)
+    // so consumers reading BatchIngestionConfig see the same values as those set via the deprecated setters.
+    // Only propagate when a non-default value was explicitly set to avoid adding a spurious
+    // BatchIngestionConfig to REALTIME tables that never called the deprecated setters.
+    if (REFRESH_SEGMENT_PUSH_TYPE.equals(_segmentPushType) || _segmentPushFrequency != null) {
+      if (_ingestionConfig == null) {
+        _ingestionConfig = new IngestionConfig();
+      }
+      BatchIngestionConfig batchIngestionConfig = _ingestionConfig.getBatchIngestionConfig();
+      if (batchIngestionConfig == null) {
+        _ingestionConfig.setBatchIngestionConfig(
+            new BatchIngestionConfig(null, _segmentPushType, _segmentPushFrequency));
+      } else {
+        // BatchIngestionConfig already exists — fill in only the fields that are not yet set,
+        // so that an explicit withIngestionConfig() call takes precedence over the deprecated setters.
+        if (batchIngestionConfig.getSegmentIngestionType() == null && _segmentPushType != null) {
+          batchIngestionConfig.setSegmentIngestionType(_segmentPushType);
+        }
+        if (batchIngestionConfig.getSegmentIngestionFrequency() == null && _segmentPushFrequency != null) {
+          batchIngestionConfig.setSegmentIngestionFrequency(_segmentPushFrequency);
+        }
+      }
     }
 
     TableConfig tableConfig =

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/utils/builder/TableConfigBuilderTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/utils/builder/TableConfigBuilderTest.java
@@ -21,6 +21,8 @@ package org.apache.pinot.spi.utils.builder;
 
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.config.table.ingestion.BatchIngestionConfig;
+import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -41,5 +43,60 @@ public class TableConfigBuilderTest {
         .setSkipSegmentPreprocess(true).build();
     Assert.assertTrue(tableconfig.getIndexingConfig().isSkipSegmentPreprocess(),
         "skipSegmentPreprocess will be true");
+  }
+
+  @Test
+  public void testDeprecatedSetSegmentPushTypeForwardsToIngestionConfig() {
+    // REFRESH push type set via deprecated setter must appear in BatchIngestionConfig
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName(TABLE_NAME)
+        .setSegmentPushType("REFRESH")
+        .build();
+    BatchIngestionConfig batch = tableConfig.getIngestionConfig().getBatchIngestionConfig();
+    Assert.assertNotNull(batch);
+    Assert.assertEquals(batch.getSegmentIngestionType(), "REFRESH");
+  }
+
+  @Test
+  public void testDeprecatedSetSegmentPushFrequencyForwardsToIngestionConfig() {
+    // Push frequency set via deprecated setter must appear in BatchIngestionConfig
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName(TABLE_NAME)
+        .setSegmentPushFrequency("HOURLY")
+        .build();
+    BatchIngestionConfig batch = tableConfig.getIngestionConfig().getBatchIngestionConfig();
+    Assert.assertNotNull(batch);
+    Assert.assertEquals(batch.getSegmentIngestionFrequency(), "HOURLY");
+  }
+
+  @Test
+  public void testDeprecatedSettersDoNotOverrideExplicitIngestionConfig() {
+    // Explicit IngestionConfig must take precedence over deprecated setter values
+    BatchIngestionConfig explicit = new BatchIngestionConfig(null, "APPEND", "DAILY");
+    IngestionConfig ingestionConfig = new IngestionConfig();
+    ingestionConfig.setBatchIngestionConfig(explicit);
+
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName(TABLE_NAME)
+        .setSegmentPushType("REFRESH")
+        .setSegmentPushFrequency("HOURLY")
+        .setIngestionConfig(ingestionConfig)
+        .build();
+    BatchIngestionConfig batch = tableConfig.getIngestionConfig().getBatchIngestionConfig();
+    Assert.assertEquals(batch.getSegmentIngestionType(), "APPEND",
+        "Explicit ingestionConfig should take precedence over deprecated setter");
+    Assert.assertEquals(batch.getSegmentIngestionFrequency(), "DAILY",
+        "Explicit ingestionConfig should take precedence over deprecated setter");
+  }
+
+  @Test
+  public void testRealtimeTableWithoutDeprecatedSettersHasNoBatchIngestionConfig() {
+    // REALTIME tables that never call the deprecated setters must not get a spurious BatchIngestionConfig
+    TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME)
+        .setTableName(TABLE_NAME)
+        .setTimeColumnName(TIME_COLUMN)
+        .build();
+    Assert.assertNull(tableConfig.getIngestionConfig(),
+        "REALTIME table with no deprecated setters should have no IngestionConfig");
   }
 }


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Shows how deprecated segment push setters propagate values to BatchIngestionConfig during TableConfig build\.

```mermaid
flowchart TD
  N0["Call deprecated setter #40;setSegmentPushType#47;setSegmentPushFrequency#41; #40;F1#41;"]:::stModified
  N1["Check if deprecated push type#47;frequency set #40;F1#41;"]:::stModified
  N2["Ensure IngestionConfig exists #40;F1#41;"]:::stModified
  N3["Get#47;create BatchIngestionConfig #40;F1#41;"]:::stModified
  N4["Set segmentIngestionType in BatchIngestionConfig #40;F1#41;"]:::stModified
  N5["Set segmentIngestionFrequency in BatchIngestionConfig #40;F1#41;"]:::stModified
  N0 --> N1
  N1 --> N2
  N2 --> N3
  N3 --> N4
  N4 --> N5
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-spi/src/main/java/org/apache/pinot/spi/utils/builder/TableConfigBuilder\.java — [before](https://github.com/apache/pinot/blob/5526d5b86018bc8d22e10ece356d107dff5e280f/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/TableConfigBuilder.java) · [after](https://github.com/apache/pinot/blob/94f40ca244aaac9cb0a745be838655a2aa69c73d/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/TableConfigBuilder.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjU1MjZkNWI4NjAxOGJjOGQyMmUxMGVjZTM1NmQxMDdkZmY1ZTI4MGYiLCJjb250ZXh0X2hhc2giOiI1MjcxOGMyZTY2NWFjNGY4MzVhOWNkM2I2MmRjZDQ4YjY4NTFiODFjMzdlNTdjY2M4ZmNmNDNhMjExN2JlZGNhIiwiZ2VuZXJhdGVkX2F0IjoxNzg5MzcyNjk0LCJoZWFkX3NoYSI6Ijk0ZjQwY2EyNDRhYWFjOWNiMGE3NDViZTgzODY1NWEyYWE2OWM3M2QiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiIxNGJjMTQ3ZDg4ZDc4ZWQzZmZhMjAwOTk1OWI5M2IwNjE2MDVhZjllIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 3fe5aafd2dbc3c70cdd277e707fc817356fdb4753686a6249f2f01901c910327 -->
<!-- pinot-pr-flow:end -->

## Summary

Closes #17072 (supersedes and expands the original PR per reviewer feedback from @xiangfu0).

The `@Deprecated` `_segmentPushType` and `_segmentPushFrequency` fields, their associated private constants (`DEFAULT_SEGMENT_PUSH_TYPE`, `REFRESH_SEGMENT_PUSH_TYPE`), the deprecated setter methods (`setSegmentPushType`, `setSegmentPushFrequency`), and their forwarding in `build()` have all been removed from `TableConfigBuilder`.

The authoritative path for these values is `IngestionConfig → BatchIngestionConfig → segmentIngestionType / segmentIngestionFrequency`. `TableConfigUtils.repairTableConfig()` already migrates any legacy persisted configs (read from ZK) that carry these values in `SegmentsValidationAndRetentionConfig`.

### Callers updated

| File | Change |
|---|---|
| `HelixExternalViewBasedQueryQuotaManagerTest` | Remove 6 redundant `.setSegmentPushType("APPEND")` calls — irrelevant to quota logic |
| `MultiStageEngineIntegrationTest` | Remove 1 redundant `.setSegmentPushType("APPEND")` call |
| `TimeBoundaryManagerTest` | Set `segmentPushFrequency` directly on the validation config to simulate a legacy table config |
| `TableConfigUtilsTest.testConvertFromLegacyTableConfig` | Set push type/frequency directly on the validation config, matching how legacy configs are stored on disk, then verify `convertFromLegacyTableConfig` migrates them correctly |

## Test plan

- [ ] `TableConfigUtilsTest.testConvertFromLegacyTableConfig` passes — migration of legacy validation-config push type/frequency still works
- [ ] `TimeBoundaryManagerTest` passes — push frequency is still propagated correctly
- [ ] `HelixExternalViewBasedQueryQuotaManagerTest` passes — quota logic unaffected