### PR TITLE
Fix testCommitTimeCompactionPreservesDeletedRecords ignoring delete record column

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/CommitTimeCompactionIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/CommitTimeCompactionIntegrationTest.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.client.ExecutionStats;
 import org.apache.pinot.client.ResultSet;
@@ -957,6 +958,13 @@ public class CommitTimeCompactionIntegrationTest extends BaseClusterIntegrationT
   private TableConfig createUpsertTable(String tableName, String kafkaTopicName, UpsertConfig.Mode upsertMode,
       boolean enableCommitTimeCompaction, boolean enableColumnMajorSegmentBuilder)
       throws Exception {
+    return createUpsertTable(tableName, kafkaTopicName, upsertMode, enableCommitTimeCompaction,
+        enableColumnMajorSegmentBuilder, null);
+  }
+
+  private TableConfig createUpsertTable(String tableName, String kafkaTopicName, UpsertConfig.Mode upsertMode,
+      boolean enableCommitTimeCompaction, boolean enableColumnMajorSegmentBuilder, @Nullable String deleteRecordColumn)
+      throws Exception {
     // Create schema
     Schema schema = createSchema();
     schema.setSchemaName(tableName);
@@ -965,6 +973,9 @@ public class CommitTimeCompactionIntegrationTest extends BaseClusterIntegrationT
     // Create upsert config
     UpsertConfig upsertConfig = new UpsertConfig(upsertMode);
     upsertConfig.setEnableCommitTimeCompaction(enableCommitTimeCompaction);
+    if (deleteRecordColumn != null) {
+      upsertConfig.setDeleteRecordColumn(deleteRecordColumn);
+    }
 
     // Create table config
     Map<String, String> csvDecoderProperties = getCSVDecoderProperties(CSV_DELIMITER, CSV_SCHEMA_HEADER);
@@ -1264,27 +1275,16 @@ public class CommitTimeCompactionIntegrationTest extends BaseClusterIntegrationT
 
     // TABLE 1: With commit-time compaction DISABLED (baseline) and delete record column configured
     String tableNameWithoutCompaction = "gameScoresDeletedRecordsCompactionDisabled";
-    TableConfig tableConfigWithoutCompaction = createUpsertTable(tableNameWithoutCompaction, kafkaTopicName,
-        UpsertConfig.Mode.FULL, false, false);
-    // Configure delete record column for soft deletes
-    tableConfigWithoutCompaction.getUpsertConfig().setDeleteRecordColumn("deleted");
-    updateTableConfig(tableConfigWithoutCompaction);
+    createUpsertTable(tableNameWithoutCompaction, kafkaTopicName, UpsertConfig.Mode.FULL, false, false, "deleted");
 
     // TABLE 2: With commit-time compaction ENABLED + row-major build and delete record column configured
     String tableNameWithCompaction = "gameScoresDeletedRecordsCompactionEnabled";
-    TableConfig tableConfigWithCompaction = createUpsertTable(tableNameWithCompaction, kafkaTopicName,
-        UpsertConfig.Mode.FULL, true, false);
-    // Configure delete record column for soft deletes
-    tableConfigWithCompaction.getUpsertConfig().setDeleteRecordColumn("deleted");
-    updateTableConfig(tableConfigWithCompaction);
+    createUpsertTable(tableNameWithCompaction, kafkaTopicName, UpsertConfig.Mode.FULL, true, false, "deleted");
 
     // TABLE 3: With commit-time compaction ENABLED + column-major build and delete record column configured
     String tableNameWithCompactionColumnMajor = "gameScoresDeletedRecordsCompactionColumnMajor";
-    TableConfig tableConfigWithCompactionColumnMajor = createUpsertTable(tableNameWithCompactionColumnMajor,
-        kafkaTopicName, UpsertConfig.Mode.FULL, true, true);
-    // Configure delete record column for soft deletes
-    tableConfigWithCompactionColumnMajor.getUpsertConfig().setDeleteRecordColumn("deleted");
-    updateTableConfig(tableConfigWithCompactionColumnMajor);
+    createUpsertTable(tableNameWithCompactionColumnMajor, kafkaTopicName, UpsertConfig.Mode.FULL, true, true,
+        "deleted");
 
     // Wait for all three tables to load the same initial data (3 unique records after upserts)
     waitForAllDocsLoaded(tableNameWithoutCompaction, tableNameWithCompaction,


### PR DESCRIPTION
## Summary

`testCommitTimeCompactionPreservesDeletedRecords` in `CommitTimeCompactionIntegrationTest` configured `deleteRecordColumn` via `updateTableConfig` *after* `addTableConfig` had already created each of the three tables. The pre-commit assertion at line 1126 (`validatePreCommitState`) expects 2 logical records but observes 4, because soft-deleted rows are never filtered out.

## Root cause

The upsert metadata manager captures `_deleteRecordColumn` once at construction time — it is a `final` field on `BasePartitionUpsertMetadataManager` (line 89), populated from `UpsertContext` in `BaseTableUpsertMetadataManager#init` (`BaseTableUpsertMetadataManager.java:125-146`). A subsequent `updateTableConfig` writes the new value to ZooKeeper but does **not** rebuild the in-memory manager, so the consumer never recognizes the `deleted` column and the valid-doc bitmap is not narrowed.

This regression dates back to commit `93de8f0dc7` (Add support for commit time compaction with columnMajorBuild, #16769), which refactored the test from setting the delete column on `UpsertConfig` *before* `setUpTable(...)` (the pattern still used in `UpsertTableIntegrationTest`) to the `createUpsertTable(...)` + post-create `updateTableConfig(...)` pattern that doesn't take effect.

## Fix

Add an overload of `createUpsertTable` that accepts an optional `deleteRecordColumn` and threads it onto the `UpsertConfig` before `addTableConfig`. Route the three table-setup blocks in `testCommitTimeCompactionPreservesDeletedRecords` through the new overload and drop the now-unnecessary post-create `setDeleteRecordColumn` + `updateTableConfig` calls. The other tests in the file are unaffected.