### PR TITLE
Support consuming tier overrides for realtime consuming segments

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -69,6 +69,7 @@ import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
 import org.apache.pinot.segment.local.upsert.PartitionUpsertMetadataManager;
 import org.apache.pinot.segment.local.upsert.UpsertContext;
 import org.apache.pinot.segment.local.utils.IngestionUtils;
+import org.apache.pinot.segment.local.utils.TableConfigUtils;
 import org.apache.pinot.segment.spi.MutableSegment;
 import org.apache.pinot.segment.spi.V1Constants;
 import org.apache.pinot.segment.spi.creator.SegmentVersion;
@@ -1821,9 +1822,12 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
     _isOffHeap = indexLoadingConfig.isRealtimeOffHeapAllocation();
     _defaultNullHandlingEnabled = indexingConfig.isNullHandlingEnabled();
 
-    // Start new realtime segment
+    // Start new realtime segment. The dispatch helper keeps the existing IndexLoadingConfig-driven path when no
+    // consuming tier overrides are configured, and builds a mutable-only tier-overwritten view when they are.
     String consumerDir = realtimeTableDataManager.getConsumerDir();
-    RealtimeSegmentConfig.Builder realtimeSegmentConfigBuilder = new RealtimeSegmentConfig.Builder(indexLoadingConfig)
+    RealtimeSegmentConfig.Builder realtimeSegmentConfigBuilder =
+        TableConfigUtils.buildConsumingSegmentConfigBuilder(_tableConfig, _schema, indexLoadingConfig);
+    realtimeSegmentConfigBuilder
         .setTableNameWithType(_tableNameWithType)
         .setSegmentName(_segmentNameStr)
         .setStreamName(streamTopic)

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/ConsumingSegmentTierOverrideRealtimeTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/ConsumingSegmentTierOverrideRealtimeTest.java
@@ -1,0 +1,363 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.integration.tests.custom;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.File;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.generic.GenericData;
+import org.apache.helix.model.IdealState;
+import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
+import org.apache.pinot.common.utils.LLCSegmentName;
+import org.apache.pinot.segment.local.data.manager.SegmentDataManager;
+import org.apache.pinot.segment.local.data.manager.TableDataManager;
+import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentImpl;
+import org.apache.pinot.segment.local.indexsegment.mutable.MutableSegmentImpl;
+import org.apache.pinot.segment.local.segment.store.SegmentLocalFSDirectory;
+import org.apache.pinot.segment.spi.ColumnMetadata;
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.SegmentMetadata;
+import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.segment.spi.index.StandardIndexes;
+import org.apache.pinot.segment.spi.store.SegmentDirectory;
+import org.apache.pinot.server.starter.helix.BaseServerStarter;
+import org.apache.pinot.spi.config.table.FieldConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.apache.pinot.spi.utils.ReadMode;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+import org.apache.pinot.util.TestUtils;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+
+/// End-to-end coverage for the synthetic `consuming` tier override on a realtime table.
+///
+/// The table persists `profiledString` as RAW with no inverted index. `tierOverwrites.consuming` upgrades that column
+/// to DICTIONARY + INVERTED only while the segment is mutable and consuming. After force-commit, the immutable segment
+/// must retain the persisted RAW/no-inverted shape on disk.
+@Test(suiteName = "CustomClusterIntegrationTest")
+public class ConsumingSegmentTierOverrideRealtimeTest extends CustomDataQueryClusterIntegrationTest {
+  private static final String TABLE_NAME = "ConsumingSegmentTierOverrideRealtimeTest";
+  private static final int NUM_DOCS = 200;
+  private static final String PROFILED_STRING_COLUMN = "profiledString";
+  private static final String CONTROL_STRING_COLUMN = "controlString";
+  private static final String INT_COLUMN = "intCol";
+  private static final String TIME_COLUMN = "tsMillis";
+  private static final String[] STRING_VALUES = {"alpha", "beta", "gamma", "delta"};
+
+  @Override
+  public String getTableName() {
+    return TABLE_NAME;
+  }
+
+  @Override
+  public boolean isRealtimeTable() {
+    return true;
+  }
+
+  @Override
+  protected long getCountStarResult() {
+    return NUM_DOCS;
+  }
+
+  @Override
+  protected int getRealtimeSegmentFlushSize() {
+    return NUM_DOCS * 10;
+  }
+
+  @Override
+  public Schema createSchema() {
+    return new Schema.SchemaBuilder().setSchemaName(getTableName())
+        .addSingleValueDimension(PROFILED_STRING_COLUMN, FieldSpec.DataType.STRING)
+        .addSingleValueDimension(CONTROL_STRING_COLUMN, FieldSpec.DataType.STRING)
+        .addMetric(INT_COLUMN, FieldSpec.DataType.INT)
+        .addDateTimeField(TIME_COLUMN, FieldSpec.DataType.LONG, "1:MILLISECONDS:EPOCH", "1:MILLISECONDS")
+        .build();
+  }
+
+  @Override
+  public String getTimeColumnName() {
+    return TIME_COLUMN;
+  }
+
+  @Override
+  protected String getSortedColumn() {
+    return null;
+  }
+
+  @Override
+  protected List<String> getNoDictionaryColumns() {
+    return List.of(PROFILED_STRING_COLUMN);
+  }
+
+  @Override
+  protected List<String> getInvertedIndexColumns() {
+    return List.of();
+  }
+
+  @Override
+  protected List<FieldConfig> getFieldConfigs() {
+    return List.of(new FieldConfig.Builder(PROFILED_STRING_COLUMN)
+        .withEncodingType(FieldConfig.EncodingType.RAW)
+        .withTierOverwrites(jsonNode("{\"consuming\":{\"encodingType\":\"DICTIONARY\","
+            + "\"indexes\":{\"inverted\":{\"enabled\":true}}}}"))
+        .build());
+  }
+
+  @Override
+  protected TableConfig createRealtimeTableConfig(File sampleAvroFile) {
+    AvroFileSchemaKafkaAvroMessageDecoder._avroFile = sampleAvroFile;
+    return getTableConfigBuilder(TableType.REALTIME)
+        .setTierOverwrites(jsonNode("{\"consuming\":{\"noDictionaryColumns\":[]}}"))
+        .build();
+  }
+
+  @Override
+  public List<File> createAvroFiles()
+      throws Exception {
+    org.apache.avro.Schema avroSchema = org.apache.avro.Schema.createRecord("myRecord", null, null, false);
+    org.apache.avro.Schema stringSchema = org.apache.avro.Schema.create(org.apache.avro.Schema.Type.STRING);
+    org.apache.avro.Schema intSchema = org.apache.avro.Schema.create(org.apache.avro.Schema.Type.INT);
+    org.apache.avro.Schema longSchema = org.apache.avro.Schema.create(org.apache.avro.Schema.Type.LONG);
+    avroSchema.setFields(List.of(
+        new org.apache.avro.Schema.Field(PROFILED_STRING_COLUMN, stringSchema, null, null),
+        new org.apache.avro.Schema.Field(CONTROL_STRING_COLUMN, stringSchema, null, null),
+        new org.apache.avro.Schema.Field(INT_COLUMN, intSchema, null, null),
+        new org.apache.avro.Schema.Field(TIME_COLUMN, longSchema, null, null)));
+
+    long now = System.currentTimeMillis();
+    try (AvroFilesAndWriters avroFilesAndWriters = createAvroFilesAndWriters(avroSchema)) {
+      List<DataFileWriter<GenericData.Record>> writers = avroFilesAndWriters.getWriters();
+      for (int i = 0; i < NUM_DOCS; i++) {
+        GenericData.Record record = new GenericData.Record(avroSchema);
+        record.put(PROFILED_STRING_COLUMN, STRING_VALUES[i % STRING_VALUES.length]);
+        record.put(CONTROL_STRING_COLUMN, "fixed");
+        record.put(INT_COLUMN, i);
+        record.put(TIME_COLUMN, now + i);
+        writers.get(i % getNumAvroFiles()).append(record);
+      }
+      return avroFilesAndWriters.getAvroFiles();
+    }
+  }
+
+  @Test
+  public void testConsumingSegmentTierOverrideEndToEnd()
+      throws Exception {
+    String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(getTableName());
+    waitForAllDocsLoaded(60_000L);
+
+    long alphaCountBeforeCommit = queryStringCount();
+    assertEquals(alphaCountBeforeCommit, (NUM_DOCS + STRING_VALUES.length - 1) / STRING_VALUES.length);
+
+    int consumingSegmentsInspected = inspectConsumingSegments(realtimeTableName);
+    assertTrue(consumingSegmentsInspected > 0,
+        "Expected at least one consuming segment before forceCommit, got " + consumingSegmentsInspected);
+
+    forceCommitAndWait(realtimeTableName);
+    long alphaCountAfterCommit = queryStringCount();
+    assertEquals(alphaCountAfterCommit, alphaCountBeforeCommit,
+        "Consuming tier override must not change query semantics after commit");
+
+    int immutableSegmentsInspected = inspectImmutableSegments(realtimeTableName);
+    assertTrue(immutableSegmentsInspected > 0,
+        "Expected at least one immutable segment after forceCommit, got " + immutableSegmentsInspected);
+  }
+
+  private int inspectConsumingSegments(String realtimeTableName) {
+    int inspected = 0;
+    for (BaseServerStarter serverStarter : getSharedServerStarters()) {
+      TableDataManager tableDataManager = serverStarter.getServerInstance().getInstanceDataManager()
+          .getTableDataManager(realtimeTableName);
+      assertNotNull(tableDataManager, "Missing table data manager on server");
+      List<SegmentDataManager> segmentDataManagers = tableDataManager.acquireAllSegments();
+      try {
+        for (SegmentDataManager segmentDataManager : segmentDataManagers) {
+          IndexSegment segment = segmentDataManager.getSegment();
+          if (!(segment instanceof MutableSegmentImpl)) {
+            continue;
+          }
+          DataSource profiled = segment.getDataSource(PROFILED_STRING_COLUMN);
+          assertNotNull(profiled.getDictionary(),
+              PROFILED_STRING_COLUMN + " must have a consuming-segment dictionary");
+          assertNotNull(profiled.getInvertedIndex(),
+              PROFILED_STRING_COLUMN + " must have a consuming-segment inverted index");
+
+          DataSource control = segment.getDataSource(CONTROL_STRING_COLUMN);
+          assertNotNull(control.getDictionary(), CONTROL_STRING_COLUMN + " should keep default dictionary encoding");
+          inspected++;
+        }
+      } finally {
+        for (SegmentDataManager segmentDataManager : segmentDataManagers) {
+          tableDataManager.releaseSegment(segmentDataManager);
+        }
+      }
+    }
+    return inspected;
+  }
+
+  private int inspectImmutableSegments(String realtimeTableName)
+      throws Exception {
+    int inspected = 0;
+    for (BaseServerStarter serverStarter : getSharedServerStarters()) {
+      TableDataManager tableDataManager = serverStarter.getServerInstance().getInstanceDataManager()
+          .getTableDataManager(realtimeTableName);
+      assertNotNull(tableDataManager, "Missing table data manager on server");
+      List<SegmentDataManager> segmentDataManagers = tableDataManager.acquireAllSegments();
+      try {
+        for (SegmentDataManager segmentDataManager : segmentDataManagers) {
+          IndexSegment segment = segmentDataManager.getSegment();
+          if (!(segment instanceof ImmutableSegmentImpl)) {
+            continue;
+          }
+          SegmentMetadata metadata = segment.getSegmentMetadata();
+          ColumnMetadata profiledMetadata = metadata.getColumnMetadataFor(PROFILED_STRING_COLUMN);
+          assertNotNull(profiledMetadata, "Missing metadata for " + PROFILED_STRING_COLUMN);
+          assertFalse(profiledMetadata.hasDictionary(),
+              PROFILED_STRING_COLUMN + " must remain RAW/no-dictionary after commit");
+          assertEquals(profiledMetadata.getForwardIndexEncoding(), FieldConfig.EncodingType.RAW,
+              PROFILED_STRING_COLUMN + " must persist with RAW forward-index encoding after commit");
+
+          ColumnMetadata controlMetadata = metadata.getColumnMetadataFor(CONTROL_STRING_COLUMN);
+          assertNotNull(controlMetadata, "Missing metadata for " + CONTROL_STRING_COLUMN);
+          assertTrue(controlMetadata.hasDictionary(), CONTROL_STRING_COLUMN + " must keep default dictionary encoding");
+
+          try (SegmentDirectory directory = new SegmentLocalFSDirectory(metadata.getIndexDir(), ReadMode.mmap);
+              SegmentDirectory.Reader reader = directory.createReader()) {
+            assertTrue(reader.hasIndexFor(PROFILED_STRING_COLUMN, StandardIndexes.forward()),
+                PROFILED_STRING_COLUMN + " RAW forward index must be persisted");
+            assertFalse(reader.hasIndexFor(PROFILED_STRING_COLUMN, StandardIndexes.dictionary()),
+                PROFILED_STRING_COLUMN + " dictionary must not be persisted");
+            assertFalse(reader.hasIndexFor(PROFILED_STRING_COLUMN, StandardIndexes.inverted()),
+                PROFILED_STRING_COLUMN + " inverted index must not be persisted");
+          }
+          inspected++;
+        }
+      } finally {
+        for (SegmentDataManager segmentDataManager : segmentDataManagers) {
+          tableDataManager.releaseSegment(segmentDataManager);
+        }
+      }
+    }
+    return inspected;
+  }
+
+  private void forceCommitAndWait(String realtimeTableName)
+      throws Exception {
+    Set<String> consumingSegments = getConsumingSegments(realtimeTableName);
+    assertFalse(consumingSegments.isEmpty(), "Expected consuming segments before forceCommit");
+    String response = getOrCreateAdminClient().getTableClient().forceCommit(realtimeTableName);
+    String jobId = JsonUtils.stringToJsonNode(response).get("forceCommitJobId").asText();
+
+    TestUtils.waitForCondition(aVoid -> {
+      try {
+        String jobStatusResponse = getOrCreateAdminClient().getTableClient().getForceCommitJobStatus(jobId);
+        JsonNode jobStatus = JsonUtils.stringToJsonNode(jobStatusResponse);
+        return jobStatus.get(CommonConstants.ControllerJob.NUM_CONSUMING_SEGMENTS_YET_TO_BE_COMMITTED).asInt(-1) == 0;
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }, 120_000L, "Timed out waiting for forceCommit job: " + jobId);
+
+    TestUtils.waitForCondition(aVoid -> {
+      for (String segmentName : consumingSegments) {
+        SegmentZKMetadata metadata = getSharedHelixResourceManager().getSegmentZKMetadata(realtimeTableName,
+            segmentName);
+        if (metadata == null || metadata.getStatus() != CommonConstants.Segment.Realtime.Status.DONE) {
+          return false;
+        }
+      }
+      return true;
+    }, 120_000L, "Timed out waiting for force-committed segments to become DONE");
+
+    TestUtils.waitForCondition(aVoid -> areSegmentsImmutableOnServers(realtimeTableName, consumingSegments),
+        120_000L, "Timed out waiting for force-committed segments to load as immutable on servers");
+  }
+
+  private boolean areSegmentsImmutableOnServers(String realtimeTableName, Set<String> segmentNames) {
+    Set<String> immutableSegments = new HashSet<>();
+    for (BaseServerStarter serverStarter : getSharedServerStarters()) {
+      TableDataManager tableDataManager = serverStarter.getServerInstance().getInstanceDataManager()
+          .getTableDataManager(realtimeTableName);
+      if (tableDataManager == null) {
+        continue;
+      }
+      List<SegmentDataManager> segmentDataManagers = tableDataManager.acquireAllSegments();
+      try {
+        for (SegmentDataManager segmentDataManager : segmentDataManagers) {
+          IndexSegment segment = segmentDataManager.getSegment();
+          if (segment instanceof ImmutableSegmentImpl && segmentNames.contains(segment.getSegmentName())) {
+            immutableSegments.add(segment.getSegmentName());
+          }
+        }
+      } finally {
+        for (SegmentDataManager segmentDataManager : segmentDataManagers) {
+          tableDataManager.releaseSegment(segmentDataManager);
+        }
+      }
+    }
+    return immutableSegments.containsAll(segmentNames);
+  }
+
+  private Set<String> getConsumingSegments(String realtimeTableName) {
+    IdealState idealState = getSharedHelixResourceManager().getTableIdealState(realtimeTableName);
+    Set<String> consumingSegments = new HashSet<>();
+    if (idealState == null) {
+      return consumingSegments;
+    }
+    for (String segmentName : idealState.getPartitionSet()) {
+      if (!LLCSegmentName.isLLCSegment(segmentName)) {
+        continue;
+      }
+      Map<String, String> stateMap = idealState.getInstanceStateMap(segmentName);
+      if (stateMap != null && stateMap.containsValue(CommonConstants.Helix.StateModel.SegmentStateModel.CONSUMING)) {
+        consumingSegments.add(segmentName);
+      }
+    }
+    return consumingSegments;
+  }
+
+  private long queryStringCount() {
+    return Long.parseLong(getPinotConnection()
+        .execute("SELECT COUNT(*) FROM " + getTableName() + " WHERE " + PROFILED_STRING_COLUMN + " = '"
+            + STRING_VALUES[0] + "'")
+        .getResultSet(0).getString(0));
+  }
+
+  private static JsonNode jsonNode(String json) {
+    try {
+      return JsonUtils.stringToJsonNode(json);
+    } catch (IOException e) {
+      throw new IllegalStateException("Invalid test JSON: " + json, e);
+    }
+  }
+}

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/CustomDataQueryClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/CustomDataQueryClusterIntegrationTest.java
@@ -46,6 +46,7 @@ import org.apache.pinot.controller.helix.core.minion.PinotTaskManager;
 import org.apache.pinot.integration.tests.BaseClusterIntegrationTest;
 import org.apache.pinot.integration.tests.ClusterIntegrationTestUtils;
 import org.apache.pinot.plugin.stream.kafka.KafkaStreamConfigProperties;
+import org.apache.pinot.server.starter.helix.BaseServerStarter;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.Schema;
@@ -303,6 +304,11 @@ public abstract class CustomDataQueryClusterIntegrationTest extends BaseClusterI
    */
   protected BaseControllerStarter getSharedControllerStarter() {
     return _sharedClusterTestSuite._controllerStarter;
+  }
+
+  /// Returns server starters from the shared suite instance.
+  protected List<BaseServerStarter> getSharedServerStarters() {
+    return _sharedClusterTestSuite._serverStarters;
   }
 
   /**

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/writer/StatelessRealtimeSegmentWriter.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/writer/StatelessRealtimeSegmentWriter.java
@@ -43,6 +43,7 @@ import org.apache.pinot.segment.local.realtime.impl.RealtimeSegmentStatsHistory;
 import org.apache.pinot.segment.local.segment.creator.TransformPipeline;
 import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
 import org.apache.pinot.segment.local.utils.IngestionUtils;
+import org.apache.pinot.segment.local.utils.TableConfigUtils;
 import org.apache.pinot.segment.spi.partition.PartitionFunctionFactory;
 import org.apache.pinot.spi.config.table.ColumnPartitionConfig;
 import org.apache.pinot.spi.config.table.SegmentPartitionConfig;
@@ -180,9 +181,11 @@ public class StatelessRealtimeSegmentWriter implements Closeable {
     File statsHistoryFile = new File(tableDataDir, SEGMENT_STATS_FILE_NAME);
     RealtimeSegmentStatsHistory statsHistory = RealtimeSegmentStatsHistory.deserializeFrom(statsHistoryFile);
 
-    // Initialize mutable segment with configurations
+    // Initialize mutable segment with configurations.
     IngestionConfig ingestionConfig = _tableConfig.getIngestionConfig();
-    RealtimeSegmentConfig.Builder realtimeSegmentConfigBuilder = new RealtimeSegmentConfig.Builder(indexLoadingConfig)
+    RealtimeSegmentConfig.Builder realtimeSegmentConfigBuilder =
+        TableConfigUtils.buildConsumingSegmentConfigBuilder(_tableConfig, _schema, indexLoadingConfig);
+    realtimeSegmentConfigBuilder
         .setTableNameWithType(_tableNameWithType)
         .setSegmentName(_segmentName)
         .setStreamName(_streamConfig.getTopicName())

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfig.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfig.java
@@ -221,7 +221,9 @@ public class IndexLoadingConfig {
   }
 
   private TableConfig getTableConfigWithTierOverwrites() {
-    return (_segmentTier == null || _tableConfig == null) ? _tableConfig
+    return (_segmentTier == null || _tableConfig == null
+        || TableConfigUtils.isSyntheticConsumingSegmentTier(_tableConfig, _segmentTier))
+        ? _tableConfig
         : TableConfigUtils.overwriteTableConfigForTier(_tableConfig, _segmentTier);
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -48,7 +48,9 @@ import org.apache.pinot.common.tier.TierFactory;
 import org.apache.pinot.common.utils.config.TagNameUtils;
 import org.apache.pinot.segment.local.aggregator.ValueAggregator;
 import org.apache.pinot.segment.local.aggregator.ValueAggregatorFactory;
+import org.apache.pinot.segment.local.realtime.impl.RealtimeSegmentConfig;
 import org.apache.pinot.segment.local.recordtransformer.SchemaConformingTransformer;
+import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.segment.spi.index.DictionaryIndexConfig;
 import org.apache.pinot.segment.spi.index.FieldIndexConfigs;
@@ -134,6 +136,12 @@ public final class TableConfigUtils {
   // this is duplicate with KinesisConfig.STREAM_TYPE, while instead of use KinesisConfig.STREAM_TYPE directly, we
   // hardcode the value here to avoid pulling the entire pinot-kinesis module as dependency.
   private static final String KINESIS_STREAM_TYPE = "kinesis";
+  private static final String CONSUMING_SEGMENT_TIER = "consuming";
+  private static final Set<String> CONSUMING_SEGMENT_TIER_INDEXING_CONFIG_KEYS = ImmutableSet.of(
+      "invertedIndexColumns", "rangeIndexColumns", "rangeIndexVersion", "jsonIndexColumns", "jsonIndexConfigs",
+      "sortedColumn", "bloomFilterColumns", "bloomFilterConfigs", "noDictionaryColumns", "noDictionaryConfig",
+      "onHeapDictionaryColumns", "varLengthDictionaryColumns", "optimizeDictionary", "optimizeDictionaryForMetrics",
+      "optimizeDictionaryType", "noDictionarySizeRatioThreshold", "noDictionaryCardinalityRatioThreshold");
 
   private static final Set<String> UPSERT_DEDUP_ALLOWED_ROUTING_STRATEGIES =
       ImmutableSet.of(RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE,
@@ -187,6 +195,7 @@ public final class TableConfigUtils {
     }
     validateTierConfigList(tableConfig.getTierConfigsList());
     validateIndexingConfigAndFieldConfigList(tableConfig, schema);
+    validateConsumingTierOverwrites(tableConfig, schema);
     validateInstancePartitionsTypeMapConfig(tableConfig);
     validatePartitionedReplicaGroupInstance(tableConfig);
     validateInstanceAssignmentConfigs(tableConfig);
@@ -2124,6 +2133,121 @@ public final class TableConfigUtils {
     for (Map.Entry<String, JsonNode> cfgEntry : newCfg.properties()) {
       ((ObjectNode) oldCfg).set(cfgEntry.getKey(), cfgEntry.getValue());
     }
+  }
+
+  public static boolean isConsumingSegmentTier(@Nullable String tier) {
+    return CONSUMING_SEGMENT_TIER.equals(tier);
+  }
+
+  public static boolean isSyntheticConsumingSegmentTier(@Nullable TableConfig tableConfig, @Nullable String tier) {
+    return isConsumingSegmentTier(tier) && !hasTierConfig(tableConfig, tier);
+  }
+
+  private static void validateConsumingTierOverwrites(TableConfig tableConfig, Schema schema) {
+    if (tableConfig.getTableType() != TableType.REALTIME
+        || !hasTierOverwritesForTier(tableConfig, CONSUMING_SEGMENT_TIER)
+        || hasTierConfig(tableConfig, CONSUMING_SEGMENT_TIER)) {
+      return;
+    }
+    validateConsumingTierOverwriteScope(tableConfig);
+    TableConfig consumingTableConfig = overwriteTableConfigForTier(tableConfig, CONSUMING_SEGMENT_TIER);
+    Preconditions.checkState(consumingTableConfig != tableConfig,
+        "Failed to apply tierOverwrites.%s for table: %s", CONSUMING_SEGMENT_TIER, tableConfig.getTableName());
+    try {
+      validateIndexingConfigAndFieldConfigList(consumingTableConfig, schema);
+    } catch (RuntimeException e) {
+      throw new IllegalStateException(
+          "tierOverwrites." + CONSUMING_SEGMENT_TIER + " produces an invalid mutable consuming segment config: "
+              + e.getMessage(), e);
+    }
+  }
+
+  private static void validateConsumingTierOverwriteScope(TableConfig tableConfig) {
+    IndexingConfig indexingConfig = tableConfig.getIndexingConfig();
+    if (indexingConfig == null) {
+      return;
+    }
+    JsonNode consumingIndexingOverwrite = getTierOverwrite(indexingConfig.getTierOverwrites(), CONSUMING_SEGMENT_TIER);
+    if (consumingIndexingOverwrite == null) {
+      return;
+    }
+    Preconditions.checkState(consumingIndexingOverwrite.isObject(),
+        "tableIndexConfig.tierOverwrites.%s must be a JSON object", CONSUMING_SEGMENT_TIER);
+    Iterator<String> keys = consumingIndexingOverwrite.fieldNames();
+    while (keys.hasNext()) {
+      String key = keys.next();
+      Preconditions.checkState(CONSUMING_SEGMENT_TIER_INDEXING_CONFIG_KEYS.contains(key),
+          "Unsupported tableIndexConfig.tierOverwrites.%s key: %s; supported keys: %s", CONSUMING_SEGMENT_TIER,
+          key, CONSUMING_SEGMENT_TIER_INDEXING_CONFIG_KEYS);
+    }
+  }
+
+  /// Builds the [RealtimeSegmentConfig.Builder] for a mutable consuming segment. If the table config contains
+  /// `tierOverwrites.consuming` under `tableIndexConfig` or a `fieldConfigList` entry, the builder is created from the
+  /// existing tier-overwrite view for that synthetic tier. Only index-loading settings are supported for
+  /// `tableIndexConfig.tierOverwrites.consuming`; settings that control row shape or ingestion behavior must stay on
+  /// the persisted table config. If `consuming` is already configured as a real storage tier, storage-tier semantics
+  /// take precedence for backward compatibility. The original [IndexLoadingConfig] is left untouched so the commit path
+  /// and immutable segment load path continue to use the persisted table config and real segment tier.
+  public static RealtimeSegmentConfig.Builder buildConsumingSegmentConfigBuilder(TableConfig tableConfig, Schema schema,
+      IndexLoadingConfig indexLoadingConfig) {
+    if (!hasTierOverwritesForTier(tableConfig, CONSUMING_SEGMENT_TIER)
+        || hasTierConfig(tableConfig, CONSUMING_SEGMENT_TIER)) {
+      return new RealtimeSegmentConfig.Builder(indexLoadingConfig);
+    }
+    TableConfig consumingTableConfig = overwriteTableConfigForTier(tableConfig, CONSUMING_SEGMENT_TIER);
+    if (consumingTableConfig == tableConfig) {
+      return new RealtimeSegmentConfig.Builder(indexLoadingConfig);
+    }
+    Schema schemaCopy;
+    try {
+      schemaCopy = JsonUtils.jsonNodeToObject(schema.toJsonObject(), Schema.class);
+    } catch (IOException e) {
+      throw new IllegalStateException(
+          "Failed to clone schema while applying consuming tier overrides for table: " + tableConfig.getTableName(), e);
+    }
+    IndexLoadingConfig consumingIndexLoadingConfig =
+        new IndexLoadingConfig(indexLoadingConfig.getInstanceDataManagerConfig(), consumingTableConfig, schemaCopy);
+    return new RealtimeSegmentConfig.Builder(consumingIndexLoadingConfig);
+  }
+
+  private static boolean hasTierOverwritesForTier(TableConfig tableConfig, String tier) {
+    IndexingConfig indexingConfig = tableConfig.getIndexingConfig();
+    if (indexingConfig != null && hasTierOverwrite(indexingConfig.getTierOverwrites(), tier)) {
+      return true;
+    }
+    List<FieldConfig> fieldConfigList = tableConfig.getFieldConfigList();
+    if (fieldConfigList == null) {
+      return false;
+    }
+    for (FieldConfig fieldConfig : fieldConfigList) {
+      if (hasTierOverwrite(fieldConfig.getTierOverwrites(), tier)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean hasTierConfig(@Nullable TableConfig tableConfig, String tier) {
+    if (tableConfig == null || tableConfig.getTierConfigsList() == null) {
+      return false;
+    }
+    for (TierConfig tierConfig : tableConfig.getTierConfigsList()) {
+      if (tier.equals(tierConfig.getName())) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static boolean hasTierOverwrite(@Nullable JsonNode tierOverwrites, String tier) {
+    JsonNode tierOverwrite = getTierOverwrite(tierOverwrites, tier);
+    return tierOverwrite != null && !tierOverwrite.isNull();
+  }
+
+  @Nullable
+  private static JsonNode getTierOverwrite(@Nullable JsonNode tierOverwrites, String tier) {
+    return tierOverwrites != null && tierOverwrites.isObject() ? tierOverwrites.get(tier) : null;
   }
 
   /**

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfigTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfigTest.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import org.apache.pinot.common.tier.TierFactory;
 import org.apache.pinot.segment.spi.index.FieldIndexConfigs;
 import org.apache.pinot.segment.spi.index.ForwardIndexConfig;
 import org.apache.pinot.segment.spi.index.StandardIndexes;
@@ -32,6 +33,7 @@ import org.apache.pinot.spi.config.table.FieldConfig;
 import org.apache.pinot.spi.config.table.StarTreeIndexConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.config.table.TierConfig;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.env.PinotConfiguration;
@@ -155,6 +157,72 @@ public class IndexLoadingConfigTest {
     assertFalse(fieldCfgs.getConfig(StandardIndexes.inverted()).isEnabled());
     assertFalse(fieldCfgs.getConfig(StandardIndexes.bloomFilter()).isEnabled());
     assertFalse(fieldCfgs.getConfig(StandardIndexes.dictionary()).isEnabled());
+  }
+
+  @Test
+  public void testSyntheticConsumingTierIsNotAppliedAsStorageTier()
+      throws IOException {
+    Schema schema =
+        new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension("col1", FieldSpec.DataType.STRING)
+            .build();
+    FieldConfig col1Cfg = JsonUtils.stringToObject("{"
+        + "  \"name\": \"col1\","
+        + "  \"encodingType\": \"RAW\","
+        + "  \"tierOverwrites\": {"
+        + "    \"consuming\": {"
+        + "      \"encodingType\": \"DICTIONARY\","
+        + "      \"indexes\": {"
+        + "        \"inverted\": {\"enabled\": \"true\"}"
+        + "      }"
+        + "    }"
+        + "  }"
+        + "}", FieldConfig.class);
+    TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
+        .setNoDictionaryColumns(List.of("col1"))
+        .setTierOverwrites(JsonUtils.stringToJsonNode("{\"consuming\": {\"noDictionaryColumns\": []}}"))
+        .setFieldConfigList(List.of(col1Cfg))
+        .build();
+
+    IndexLoadingConfig ilc = new IndexLoadingConfig(tableConfig, schema);
+    ilc.setSegmentTier("consuming");
+
+    FieldIndexConfigs fieldCfgs = ilc.getFieldIndexConfig("col1");
+    assertFalse(fieldCfgs.getConfig(StandardIndexes.dictionary()).isEnabled());
+    assertFalse(fieldCfgs.getConfig(StandardIndexes.inverted()).isEnabled());
+  }
+
+  @Test
+  public void testRealConsumingStorageTierIsAppliedAsStorageTier()
+      throws IOException {
+    Schema schema =
+        new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension("col1", FieldSpec.DataType.STRING)
+            .build();
+    FieldConfig col1Cfg = JsonUtils.stringToObject("{"
+        + "  \"name\": \"col1\","
+        + "  \"encodingType\": \"RAW\","
+        + "  \"tierOverwrites\": {"
+        + "    \"consuming\": {"
+        + "      \"encodingType\": \"DICTIONARY\","
+        + "      \"indexes\": {"
+        + "        \"inverted\": {\"enabled\": \"true\"}"
+        + "      }"
+        + "    }"
+        + "  }"
+        + "}", FieldConfig.class);
+    TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
+        .setNoDictionaryColumns(List.of("col1"))
+        .setTierOverwrites(JsonUtils.stringToJsonNode("{\"consuming\": {\"noDictionaryColumns\": []}}"))
+        .setFieldConfigList(List.of(col1Cfg))
+        .setTierConfigList(List.of(new TierConfig("consuming", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "30d", null,
+            TierFactory.PINOT_SERVER_STORAGE_TYPE, "consuming_tag_REALTIME", null, null)))
+        .build();
+
+    IndexLoadingConfig ilc = new IndexLoadingConfig(tableConfig, schema);
+    ilc.setSegmentTier("consuming");
+
+    FieldIndexConfigs fieldCfgs = ilc.getFieldIndexConfig("col1");
+    assertTrue(fieldCfgs.getConfig(StandardIndexes.dictionary()).isEnabled());
+    assertTrue(fieldCfgs.getConfig(StandardIndexes.inverted()).isEnabled());
   }
 
   @Test

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigConsumingSegmentTierOverrideTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigConsumingSegmentTierOverrideTest.java
@@ -1,0 +1,241 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.utils;
+
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.common.tier.TierFactory;
+import org.apache.pinot.segment.local.realtime.impl.RealtimeSegmentConfig;
+import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
+import org.apache.pinot.segment.spi.index.FieldIndexConfigs;
+import org.apache.pinot.segment.spi.index.StandardIndexes;
+import org.apache.pinot.spi.config.table.FieldConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.config.table.TierConfig;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+
+/// Tests for the synthetic `consuming` tier override used while constructing mutable realtime consuming segments.
+public class TableConfigConsumingSegmentTierOverrideTest {
+  private static final String TABLE_NAME = "consumingTierOverrideTest";
+  private static final String PROFILED_COLUMN = "profiledString";
+  private static final String CONTROL_COLUMN = "controlString";
+  private static final String TIME_COLUMN = "tsMillis";
+  private static final String CONSUMING_TIER = "consuming";
+  private static final String COLD_TIER = "coldTier";
+
+  @Test
+  public void consumingTierOverrideAppliesToMutableBuilderOnly()
+      throws Exception {
+    Schema schema = schema();
+    TableConfig tableConfig = tableWithConsumingOverride();
+    IndexLoadingConfig persistedConfig = new IndexLoadingConfig(tableConfig, schema);
+
+    FieldIndexConfigs persistedColumnConfig = persistedConfig.getFieldIndexConfig(PROFILED_COLUMN);
+    assertFalse(persistedColumnConfig.getConfig(StandardIndexes.dictionary()).isEnabled());
+    assertFalse(persistedColumnConfig.getConfig(StandardIndexes.inverted()).isEnabled());
+
+    RealtimeSegmentConfig consumingConfig =
+        TableConfigUtils.buildConsumingSegmentConfigBuilder(tableConfig, schema, persistedConfig).build();
+    FieldIndexConfigs consumingColumnConfig = consumingConfig.getIndexConfigByCol().get(PROFILED_COLUMN);
+    assertTrue(consumingColumnConfig.getConfig(StandardIndexes.dictionary()).isEnabled());
+    assertTrue(consumingColumnConfig.getConfig(StandardIndexes.inverted()).isEnabled());
+
+    FieldIndexConfigs controlColumnConfig = consumingConfig.getIndexConfigByCol().get(CONTROL_COLUMN);
+    assertTrue(controlColumnConfig.getConfig(StandardIndexes.dictionary()).isEnabled());
+    assertFalse(controlColumnConfig.getConfig(StandardIndexes.inverted()).isEnabled());
+
+    assertSame(persistedConfig.getTableConfig(), tableConfig);
+    assertEquals(tableConfig.getIndexingConfig().getNoDictionaryColumns(), List.of(PROFILED_COLUMN));
+    assertEquals(tableConfig.getFieldConfigList().get(0).getEncodingType(), FieldConfig.EncodingType.RAW);
+  }
+
+  @Test
+  public void storageTierOverridesDoNotApplyToConsumingBuilder()
+      throws Exception {
+    Schema schema = schema();
+    TableConfig tableConfig = tableWithOnlyColdTierOverride();
+    IndexLoadingConfig indexLoadingConfig = new IndexLoadingConfig(tableConfig, schema);
+
+    RealtimeSegmentConfig consumingConfig =
+        TableConfigUtils.buildConsumingSegmentConfigBuilder(tableConfig, schema, indexLoadingConfig).build();
+
+    FieldIndexConfigs profiledColumnConfig = consumingConfig.getIndexConfigByCol().get(PROFILED_COLUMN);
+    assertFalse(profiledColumnConfig.getConfig(StandardIndexes.dictionary()).isEnabled());
+    assertFalse(profiledColumnConfig.getConfig(StandardIndexes.inverted()).isEnabled());
+  }
+
+  @Test
+  public void realConsumingStorageTierKeepsStorageTierSemantics()
+      throws Exception {
+    Schema schema = schema();
+    TableConfig tableConfig = tableWithRealConsumingTierOverride();
+    IndexLoadingConfig indexLoadingConfig = new IndexLoadingConfig(tableConfig, schema);
+
+    RealtimeSegmentConfig consumingConfig =
+        TableConfigUtils.buildConsumingSegmentConfigBuilder(tableConfig, schema, indexLoadingConfig).build();
+    FieldIndexConfigs mutableColumnConfig = consumingConfig.getIndexConfigByCol().get(PROFILED_COLUMN);
+    assertFalse(mutableColumnConfig.getConfig(StandardIndexes.dictionary()).isEnabled());
+    assertFalse(mutableColumnConfig.getConfig(StandardIndexes.inverted()).isEnabled());
+
+    indexLoadingConfig.setSegmentTier(CONSUMING_TIER);
+    FieldIndexConfigs storageTierColumnConfig = indexLoadingConfig.getFieldIndexConfig(PROFILED_COLUMN);
+    assertTrue(storageTierColumnConfig.getConfig(StandardIndexes.dictionary()).isEnabled());
+    assertTrue(storageTierColumnConfig.getConfig(StandardIndexes.inverted()).isEnabled());
+  }
+
+  @Test
+  public void existingTierOverrideHelperBuildsTheConsumingView()
+      throws Exception {
+    TableConfig tableConfig = tableWithConsumingOverride();
+    TableConfig consumingView = TableConfigUtils.overwriteTableConfigForTier(tableConfig, CONSUMING_TIER);
+
+    assertEquals(consumingView.getIndexingConfig().getNoDictionaryColumns(), List.of());
+    FieldConfig consumingFieldConfig = consumingView.getFieldConfigList().get(0);
+    assertEquals(consumingFieldConfig.getEncodingType(), FieldConfig.EncodingType.DICTIONARY);
+    assertTrue(consumingFieldConfig.getIndexes().has("inverted"));
+
+    TableConfig coldView = TableConfigUtils.overwriteTableConfigForTier(tableConfig, COLD_TIER);
+    assertSame(coldView, tableConfig);
+  }
+
+  @Test
+  public void validationRejectsInvalidConsumingView()
+      throws Exception {
+    FieldConfig profiledFieldConfig = new FieldConfig.Builder(PROFILED_COLUMN)
+        .withEncodingType(FieldConfig.EncodingType.RAW)
+        .withTierOverwrites(JsonUtils.stringToJsonNode("{\"consuming\":{\"encodingType\":\"DICTIONARY\","
+            + "\"indexes\":{\"inverted\":{\"enabled\":true}}}}"))
+        .build();
+    TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
+        .setTimeColumnName(TIME_COLUMN)
+        .setStreamConfigs(streamConfigs())
+        .setNoDictionaryColumns(List.of(PROFILED_COLUMN))
+        .setFieldConfigList(List.of(profiledFieldConfig))
+        .build();
+
+    try {
+      TableConfigUtils.validate(tableConfig, schemaWithTime());
+      fail("Should reject consuming override that does not clear persisted noDictionaryColumns");
+    } catch (IllegalStateException e) {
+      assertTrue(e.getMessage().contains("tierOverwrites.consuming"),
+          "Expected consuming override validation error, got: " + e.getMessage());
+    }
+  }
+
+  @Test
+  public void validationRejectsUnsupportedConsumingTableIndexOverwrite()
+      throws Exception {
+    FieldConfig profiledFieldConfig = new FieldConfig.Builder(PROFILED_COLUMN)
+        .withEncodingType(FieldConfig.EncodingType.RAW)
+        .withTierOverwrites(JsonUtils.stringToJsonNode("{\"consuming\":{\"encodingType\":\"DICTIONARY\"}}"))
+        .build();
+    TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
+        .setTimeColumnName(TIME_COLUMN)
+        .setStreamConfigs(streamConfigs())
+        .setNoDictionaryColumns(List.of(PROFILED_COLUMN))
+        .setTierOverwrites(JsonUtils.stringToJsonNode("{\"consuming\":{\"noDictionaryColumns\":[],"
+            + "\"aggregateMetrics\":true}}"))
+        .setFieldConfigList(List.of(profiledFieldConfig))
+        .build();
+
+    try {
+      TableConfigUtils.validate(tableConfig, schemaWithTime());
+      fail("Should reject consuming override for tableIndexConfig keys not used by mutable index loading");
+    } catch (IllegalStateException e) {
+      assertTrue(e.getMessage().contains("aggregateMetrics"),
+          "Expected unsupported consuming tableIndexConfig key validation error, got: " + e.getMessage());
+    }
+  }
+
+  private static Schema schema() {
+    return new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
+        .addSingleValueDimension(PROFILED_COLUMN, FieldSpec.DataType.STRING)
+        .addSingleValueDimension(CONTROL_COLUMN, FieldSpec.DataType.STRING)
+        .build();
+  }
+
+  private static TableConfig tableWithConsumingOverride()
+      throws Exception {
+    FieldConfig profiledFieldConfig = new FieldConfig.Builder(PROFILED_COLUMN)
+        .withEncodingType(FieldConfig.EncodingType.RAW)
+        .withTierOverwrites(JsonUtils.stringToJsonNode("{\"consuming\":{\"encodingType\":\"DICTIONARY\","
+            + "\"indexes\":{\"inverted\":{\"enabled\":true}}}}"))
+        .build();
+    return new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
+        .setNoDictionaryColumns(List.of(PROFILED_COLUMN))
+        .setTierOverwrites(JsonUtils.stringToJsonNode("{\"consuming\":{\"noDictionaryColumns\":[]}}"))
+        .setFieldConfigList(List.of(profiledFieldConfig))
+        .build();
+  }
+
+  private static TableConfig tableWithOnlyColdTierOverride()
+      throws Exception {
+    FieldConfig profiledFieldConfig = new FieldConfig.Builder(PROFILED_COLUMN)
+        .withEncodingType(FieldConfig.EncodingType.RAW)
+        .withTierOverwrites(JsonUtils.stringToJsonNode("{\"coldTier\":{\"encodingType\":\"DICTIONARY\","
+            + "\"indexes\":{\"inverted\":{\"enabled\":true}}}}"))
+        .build();
+    return new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
+        .setNoDictionaryColumns(List.of(PROFILED_COLUMN))
+        .setTierOverwrites(JsonUtils.stringToJsonNode("{\"coldTier\":{\"noDictionaryColumns\":[]}}"))
+        .setFieldConfigList(List.of(profiledFieldConfig))
+        .build();
+  }
+
+  private static TableConfig tableWithRealConsumingTierOverride()
+      throws Exception {
+    FieldConfig profiledFieldConfig = new FieldConfig.Builder(PROFILED_COLUMN)
+        .withEncodingType(FieldConfig.EncodingType.RAW)
+        .withTierOverwrites(JsonUtils.stringToJsonNode("{\"consuming\":{\"encodingType\":\"DICTIONARY\","
+            + "\"indexes\":{\"inverted\":{\"enabled\":true}}}}"))
+        .build();
+    return new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
+        .setNoDictionaryColumns(List.of(PROFILED_COLUMN))
+        .setTierOverwrites(JsonUtils.stringToJsonNode("{\"consuming\":{\"noDictionaryColumns\":[]}}"))
+        .setFieldConfigList(List.of(profiledFieldConfig))
+        .setTierConfigList(List.of(new TierConfig(CONSUMING_TIER, TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "30d", null,
+            TierFactory.PINOT_SERVER_STORAGE_TYPE, "consuming_tag_REALTIME", null, null)))
+        .build();
+  }
+
+  private static Schema schemaWithTime() {
+    return new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
+        .addSingleValueDimension(PROFILED_COLUMN, FieldSpec.DataType.STRING)
+        .addSingleValueDimension(CONTROL_COLUMN, FieldSpec.DataType.STRING)
+        .addDateTime(TIME_COLUMN, FieldSpec.DataType.LONG, "1:MILLISECONDS:EPOCH", "1:MILLISECONDS")
+        .build();
+  }
+
+  private static Map<String, String> streamConfigs() {
+    return Map.of("streamType", "kafka", "stream.kafka.topic.name", "test", "stream.kafka.decoder.class.name",
+        "org.apache.pinot.plugin.stream.kafka.KafkaJSONMessageDecoder");
+  }
+}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -1104,6 +1104,16 @@ public class TableConfigUtilsTest {
       // expected
     }
 
+    // `consuming` remains valid as a real storage tier name for backward compatibility
+    tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
+        .setTimeColumnName(TIME_COLUMN)
+        .setStreamConfigs(getStreamConfigs())
+        .setTierConfigList(Lists.newArrayList(
+            new TierConfig("consuming", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "30d", null,
+                TierFactory.PINOT_SERVER_STORAGE_TYPE, "consuming_tag_REALTIME", null, null)))
+        .build();
+    TableConfigUtils.validate(tableConfig, schema);
+
     // fixedSegmentSelector
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setTierConfigList(Lists.newArrayList(

--- a/pinot-tools/src/main/resources/examples/stream/consumingSegmentTierOverride/README.md
+++ b/pinot-tools/src/main/resources/examples/stream/consumingSegmentTierOverride/README.md
@@ -1,0 +1,89 @@
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+# Realtime consuming segment tier override
+
+Realtime tables can use `tierOverwrites.consuming` to apply a richer index shape only while a segment is mutable and
+consuming. The committed immutable segment still uses the persisted table config unless it is later assigned to a real
+storage tier.
+
+Use this when recent data is queried heavily but long-term storage should stay compact. For example, keep `userId` RAW
+on disk, but add a dictionary and inverted index in the consuming segment so equality filters on fresh rows are fast.
+
+Example query:
+
+```sql
+SELECT COUNT(*)
+FROM userEvents
+WHERE userId = 'u123';
+```
+
+In `userEvents_realtime_table_config.json`, the persisted shape is RAW and has no inverted index:
+
+```json
+"tableIndexConfig": {
+  "noDictionaryColumns": ["userId"]
+},
+"fieldConfigList": [
+  {
+    "name": "userId",
+    "encodingType": "RAW"
+  }
+]
+```
+
+The synthetic `consuming` tier override applies only to mutable consuming segments:
+
+```json
+"tableIndexConfig": {
+  "noDictionaryColumns": ["userId"],
+  "tierOverwrites": {
+    "consuming": {
+      "noDictionaryColumns": []
+    }
+  }
+},
+"fieldConfigList": [
+  {
+    "name": "userId",
+    "encodingType": "RAW",
+    "tierOverwrites": {
+      "consuming": {
+        "encodingType": "DICTIONARY",
+        "indexes": {
+          "inverted": {"enabled": true}
+        }
+      }
+    }
+  }
+]
+```
+
+You normally do not need a `tierConfigs` entry named `consuming`. If a table already uses `consuming` as a real storage
+tier name, Pinot keeps the existing storage-tier behavior and does not treat `tierOverwrites.consuming` as the synthetic
+mutable consuming override for that table. Rename the real storage tier if the table should use this mutable-only
+override.
+
+When the persisted column is listed in `tableIndexConfig.noDictionaryColumns` or `noDictionaryConfig`, clear that
+setting in `tableIndexConfig.tierOverwrites.consuming` so the consuming view can enable the dictionary.
+
+`tableIndexConfig.tierOverwrites.consuming` is limited to index-loading settings such as dictionary, inverted, range,
+JSON, Bloom filter, and related dictionary optimization options. Settings that change ingestion or row shape, such as
+`aggregateMetrics` or `segmentPartitionConfig`, are not supported for the synthetic `consuming` tier.

--- a/pinot-tools/src/main/resources/examples/stream/consumingSegmentTierOverride/userEvents_realtime_table_config.json
+++ b/pinot-tools/src/main/resources/examples/stream/consumingSegmentTierOverride/userEvents_realtime_table_config.json
@@ -1,0 +1,51 @@
+{
+  "tableName": "userEvents",
+  "tableType": "REALTIME",
+  "tenants": {},
+  "segmentsConfig": {
+    "timeColumnName": "tsMillis",
+    "retentionTimeUnit": "DAYS",
+    "retentionTimeValue": "7",
+    "replication": "1"
+  },
+  "tableIndexConfig": {
+    "noDictionaryColumns": [
+      "userId"
+    ],
+    "tierOverwrites": {
+      "consuming": {
+        "noDictionaryColumns": []
+      }
+    }
+  },
+  "fieldConfigList": [
+    {
+      "name": "userId",
+      "encodingType": "RAW",
+      "tierOverwrites": {
+        "consuming": {
+          "encodingType": "DICTIONARY",
+          "indexes": {
+            "inverted": {
+              "enabled": true
+            }
+          }
+        }
+      }
+    }
+  ],
+  "ingestionConfig": {
+    "streamIngestionConfig": {
+      "streamConfigMaps": [
+        {
+          "streamType": "kafka",
+          "stream.kafka.topic.name": "userEvents",
+          "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.stream.kafka.KafkaJSONMessageDecoder",
+          "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka30.KafkaConsumerFactory",
+          "stream.kafka.consumer.prop.auto.offset.reset": "smallest",
+          "stream.kafka.broker.list": "localhost:19092"
+        }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Reuse existing `tierOverwrites` support for mutable realtime consuming segments by applying `tierOverwrites.consuming` when building `RealtimeSegmentConfig`.
- Keep committed/immutable segment generation and real storage-tier loading on the persisted table config or the actual segment tier.
- Treat `consuming` as a synthetic mutable-consuming tier only when the table does not already define a real storage tier with that name, preserving existing storage-tier behavior.
- Validate the effective consuming view and reject unsupported `tableIndexConfig.tierOverwrites.consuming` keys that do not flow through mutable index loading.

## User Manual
Configure the committed segment shape as usual, then add `tierOverwrites.consuming` where the mutable consuming segment should differ.

Example: keep `userId` RAW and without an inverted index after commit, but use dictionary encoding plus an inverted index while the segment is consuming:

```json
{
  "tableIndexConfig": {
    "noDictionaryColumns": ["userId"],
    "tierOverwrites": {
      "consuming": {
        "noDictionaryColumns": []
      }
    }
  },
  "fieldConfigList": [
    {
      "name": "userId",
      "encodingType": "RAW",
      "tierOverwrites": {
        "consuming": {
          "encodingType": "DICTIONARY",
          "indexes": {
            "inverted": {
              "enabled": true
            }
          }
        }
      }
    }
  ]
}
```

Query example that can benefit while rows are still in consuming segments:

```sql
SELECT COUNT(*)
FROM userEvents
WHERE userId = 'u123';
```

Notes:
- You normally do not need a `tierConfigs` entry named `consuming` for this feature.
- If a table already uses `consuming` as a real storage tier name, Pinot keeps existing storage-tier semantics and does not treat `tierOverwrites.consuming` as the synthetic mutable-consuming override for that table.
- If the persisted column is listed in `tableIndexConfig.noDictionaryColumns` or `noDictionaryConfig`, clear that setting under `tableIndexConfig.tierOverwrites.consuming` so the consuming view can enable dictionary.
- `tableIndexConfig.tierOverwrites.consuming` is limited to index-loading settings such as dictionary, inverted, range, JSON, Bloom filter, and dictionary optimization options. Row-shape or ingestion settings such as `aggregateMetrics` and `segmentPartitionConfig` are rejected for the synthetic consuming tier.
- Real storage-tier overrides are unchanged and still apply through actual immutable segment tiers.

A complete sample config and walkthrough are included under `pinot-tools/src/main/resources/examples/stream/consumingSegmentTierOverride/`.

## Validation
- `./mvnw -pl pinot-segment-local -am -Dtest=TableConfigConsumingSegmentTierOverrideTest,TableConfigUtilsTest,IndexLoadingConfigTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -pl pinot-common -am -Dtest=TableConfigSerDeUtilsTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw -pl pinot-integration-tests -am -Dskip.npm=true -Dtest=ConsumingSegmentTierOverrideRealtimeTest -Dsurefire.failIfNoSpecifiedTests=false test`
- `./mvnw spotless:apply -pl pinot-common,pinot-core,pinot-segment-local,pinot-spi,pinot-integration-tests,pinot-tools`
- `./mvnw license:format -pl pinot-common,pinot-core,pinot-segment-local,pinot-spi,pinot-integration-tests,pinot-tools`
- `./mvnw checkstyle:check -pl pinot-common,pinot-core,pinot-segment-local,pinot-spi,pinot-integration-tests,pinot-tools`
- `./mvnw license:check -pl pinot-common,pinot-core,pinot-segment-local,pinot-spi,pinot-integration-tests,pinot-tools`
- `git diff --cached --check`
