### PR TITLE
Fix InputStream leak in RenewableTlsUtils.createSSLFactory

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/tls/RenewableTlsUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/tls/RenewableTlsUtils.java
@@ -118,15 +118,14 @@ public class RenewableTlsUtils {
       String sslContextProtocol, SecureRandom secureRandom, boolean keyAndTrustMaterialSwappable, boolean isInsecure) {
     try {
       SSLFactory.Builder sslFactoryBuilder = SSLFactory.builder();
-      InputStream keyStoreStream = null;
-      InputStream trustStoreStream = null;
       if (keyStorePath != null) {
         Preconditions.checkNotNull(keyStorePassword, "key store password must not be null");
-        keyStoreStream = TlsUtils.makeKeyOrTrustStoreUrl(keyStorePath).openStream();
         if (keyAndTrustMaterialSwappable) {
           sslFactoryBuilder.withSwappableIdentityMaterial();
         }
-        sslFactoryBuilder.withIdentityMaterial(keyStoreStream, keyStorePassword.toCharArray(), keyStoreType);
+        try (InputStream keyStoreStream = TlsUtils.makeKeyOrTrustStoreUrl(keyStorePath).openStream()) {
+          sslFactoryBuilder.withIdentityMaterial(keyStoreStream, keyStorePassword.toCharArray(), keyStoreType);
+        }
       }
       if (isInsecure) {
         if (keyAndTrustMaterialSwappable) {
@@ -135,11 +134,12 @@ public class RenewableTlsUtils {
         sslFactoryBuilder.withUnsafeTrustMaterial();
       } else if (trustStorePath != null) {
         Preconditions.checkNotNull(trustStorePassword, "trust store password must not be null");
-        trustStoreStream = TlsUtils.makeKeyOrTrustStoreUrl(trustStorePath).openStream();
         if (keyAndTrustMaterialSwappable) {
           sslFactoryBuilder.withSwappableTrustMaterial();
         }
-        sslFactoryBuilder.withTrustMaterial(trustStoreStream, trustStorePassword.toCharArray(), trustStoreType);
+        try (InputStream trustStoreStream = TlsUtils.makeKeyOrTrustStoreUrl(trustStorePath).openStream()) {
+          sslFactoryBuilder.withTrustMaterial(trustStoreStream, trustStorePassword.toCharArray(), trustStoreType);
+        }
       }
       if (sslContextProtocol != null) {
         sslFactoryBuilder.withSslContextAlgorithm(sslContextProtocol);
@@ -148,12 +148,6 @@ public class RenewableTlsUtils {
         sslFactoryBuilder.withSecureRandom(secureRandom);
       }
       SSLFactory sslFactory = sslFactoryBuilder.build();
-      if (keyStoreStream != null) {
-        keyStoreStream.close();
-      }
-      if (trustStoreStream != null) {
-        trustStoreStream.close();
-      }
       LOGGER.info("Successfully created SSLFactory {} with key store {} and trust store {}. "
               + "Key and trust material swappable: {}",
           sslFactory, keyStorePath, trustStorePath, keyAndTrustMaterialSwappable);


### PR DESCRIPTION
## What
Switch the key store and trust store `InputStream`s in `RenewableTlsUtils.createSSLFactory` to try-with-resources.
## Why
The streams were closed only on the success path, after `SSLFactory.builder().build()` returned. Any exception thrown in between — null trust-store password, malformed keystore, failure in `nl.altindag.ssl`'s builder, etc. — was caught and rewrapped as `IllegalStateException`, but the open stream was never closed. The leak is most likely to trigger during cert rotation (`reloadSslFactory` retries 3x and the file watcher catches mid-write states), which compounds it on long-running broker/server/controller/minion processes.
`TlsUtils.createKeyManagerFactory` and `TlsUtils.createTrustManagerFactory` in the same package already use this idiom, so the change also removes inconsistency.
## Safety
- `withIdentityMaterial(InputStream, char[], String)` and `withTrustMaterial(InputStream, char[], String)` consume the stream synchronously into a `KeyStore`; the stream is not retained for `build()`. Closing right after the `with...` call is equivalent to the prior post-`build()` close on the success path.
- No public API, wire-format, or config change.
- Exception type on failure is unchanged (`IllegalStateException` wrapping the cause).
## Test plan
- [ ] `./mvnw -pl pinot-common -am -Dtest=RenewableTlsUtilsTest -Dsurefire.failIfNoSpecifiedTests=false test`
- [ ] `./mvnw spotless:apply -pl pinot-common`
- [ ] `./mvnw checkstyle:check -pl pinot-common`
- [ ] `./mvnw license:check -pl pinot-common`