### PR TITLE
Add controller support for rejecting out-of-retention segment uploads

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerMeter.java
@@ -93,7 +93,9 @@ public enum ControllerMeter implements AbstractMetrics.Meter {
   QUERY_WORKLOAD_REQUEST_DROPPED("count", true),
   QUERY_WORKLOAD_HTTP_CALLBACK_DROPPED("count", true),
   // Number of segment-delete requests rejected because the targets participate in a live segment lineage entry.
-  LINEAGE_BLOCKED_DELETE_COUNT("LineageBlockedDeleteCount", false);
+  LINEAGE_BLOCKED_DELETE_COUNT("LineageBlockedDeleteCount", false),
+  // Segment uploads rejected for being outside the table retention window.
+  OUT_OF_RETENTION_SEGMENT_UPLOAD_REJECTED("OutOfRetentionSegmentUploadRejected", true);
 
   private final String _brokerMeterName;
   private final String _unit;

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerMeter.java
@@ -95,7 +95,9 @@ public enum ControllerMeter implements AbstractMetrics.Meter {
   QUERY_WORKLOAD_REQUEST_DROPPED("count", true),
   QUERY_WORKLOAD_HTTP_CALLBACK_DROPPED("count", true),
   // Number of segment-delete requests rejected because the targets participate in a live segment lineage entry.
-  LINEAGE_BLOCKED_DELETE_COUNT("LineageBlockedDeleteCount", false);
+  LINEAGE_BLOCKED_DELETE_COUNT("LineageBlockedDeleteCount", false),
+  // Segment uploads rejected for being outside the table retention window.
+  OUT_OF_RETENTION_SEGMENT_UPLOAD_REJECTED("OutOfRetentionSegmentUploadRejected", true);
 
   private final String _brokerMeterName;
   private final String _unit;

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/RetentionUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/RetentionUtils.java
@@ -18,54 +18,88 @@
  */
 package org.apache.pinot.common.utils;
 
+import java.util.OptionalLong;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
+import org.apache.pinot.segment.spi.SegmentMetadata;
+import org.apache.pinot.spi.config.table.SegmentsValidationAndRetentionConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.utils.IngestionConfigUtils;
 import org.apache.pinot.spi.utils.TimeUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
-/**
- * Utility methods for evaluating segment retention eligibility.
- */
+/// Utility methods for evaluating segment retention eligibility and parsing table data retention from config.
 public class RetentionUtils {
   private static final Logger LOGGER = LoggerFactory.getLogger(RetentionUtils.class);
 
   private RetentionUtils() {
   }
 
-  /**
-   * Implements the time-comparison and creation-time fallback logic used by {@code TimeRetentionStrategy} for
-   * completed segments. Does NOT check segment completion status — callers must guarantee that only completed
-   * segments (DONE or UPLOADED) are passed in.
-   * <ul>
-   *   <li>If end time is valid: expired when {@code currentTimeMs - endTimeMs > retentionMs}.</li>
-   *   <li>If end time is invalid and {@code useCreationTimeFallback} is true and creation time is valid:
-   *       expired when {@code currentTimeMs - creationTimeMs > retentionMs}.</li>
-   *   <li>Otherwise: not expired (fail-open).</li>
-   * </ul>
-   *
-   * @param tableNameWithType        table name with type suffix, used for logging
-   * @param segmentZKMetadata        segment metadata
-   * @param retentionMs              retention period in milliseconds (must be positive)
-   * @param currentTimeMs            current wall-clock time in milliseconds
-   * @param useCreationTimeFallback  when true, fall back to creation time if end time is invalid
-   *                                 (must match {@code controller.retentionManager.enableCreationTimeFallback})
-   * @return true if the segment is past the retention boundary, false otherwise
-   */
+  /// Whether time-based data retention should run for this table's segments, matching the controller retention manager:
+  /// for {@link TableType#OFFLINE} tables, retention applies only when batch segment ingestion type is {@code APPEND}.
+  public static boolean shouldManageTimeBasedDataRetention(TableConfig tableConfig) {
+    if (tableConfig.getTableType() == TableType.OFFLINE && !"APPEND"
+        .equalsIgnoreCase(IngestionConfigUtils.getBatchSegmentIngestionType(tableConfig))) {
+      return false;
+    }
+    return true;
+  }
+
+  /// Implements the time-comparison and creation-time fallback logic used by `TimeRetentionStrategy` for completed
+  /// segments. Does **not** check segment completion status — callers must guarantee that only completed segments (DONE
+  /// or UPLOADED) are passed in.
+  ///
+  /// - If end time is valid: expired when `currentTimeMs - endTimeMs > retentionMs`.
+  /// - If end time is invalid and `useCreationTimeFallback` is true and creation time is valid: expired when
+  ///   `currentTimeMs - creationTimeMs > retentionMs`.
+  /// - Otherwise: not expired (fail-open).
+  ///
+  /// @param tableNameWithType table name with type suffix, used for logging
+  /// @param segmentZKMetadata segment metadata
+  /// @param retentionMs retention period in milliseconds (must be positive)
+  /// @param currentTimeMs current wall-clock time in milliseconds
+  /// @param useCreationTimeFallback when true, fall back to creation time if end time is invalid (must match
+  ///        `controller.retentionManager.enableCreationTimeFallback`)
+  /// @return `true` if the segment is past the retention boundary, `false` otherwise
   public static boolean isPurgeable(String tableNameWithType, SegmentZKMetadata segmentZKMetadata, long retentionMs,
       long currentTimeMs, boolean useCreationTimeFallback) {
-    String segmentName = segmentZKMetadata.getSegmentName();
-    long endTimeMs = segmentZKMetadata.getEndTimeMs();
+    return isPurgeableInternal(segmentZKMetadata.getEndTimeMs(), segmentZKMetadata.getCreationTime(), retentionMs,
+        currentTimeMs, useCreationTimeFallback, tableNameWithType, segmentZKMetadata.getSegmentName());
+  }
+
+  /// Whether segment file metadata is past the retention window, using end time from
+  /// {@link #getSegmentMetadataEndTimeMillis(SegmentMetadata)} and
+  /// {@link SegmentMetadata#getIndexCreationTime()} as the optional fallback clock. Invalid-end paths emit the same
+  /// style of debug/warn lines as the ZK overload, using
+  /// {@link SegmentMetadata#getName()} for the segment in log messages.
+  ///
+  /// - If end time is valid: purgeable when `currentTimeMs - endTimeMs > retentionMs`.
+  /// - If end time is invalid and `useCreationTimeFallback` is true and index creation time is valid: purgeable when
+  ///   `currentTimeMs - creationTimeMs > retentionMs`.
+  /// - Otherwise: not purgeable (fail-open).
+  public static boolean isPurgeable(String tableNameWithType, SegmentMetadata segmentMetadata, long retentionMs,
+      long currentTimeMs, boolean useCreationTimeFallback) {
+    return isPurgeableInternal(getSegmentMetadataEndTimeMillis(segmentMetadata), segmentMetadata.getIndexCreationTime(),
+        retentionMs, currentTimeMs, useCreationTimeFallback, tableNameWithType, segmentMetadata.getName());
+  }
+
+  private static boolean isPurgeableInternal(long endTimeMs, long creationTimeMs, long retentionMs,
+      long currentTimeMs, boolean useCreationTimeFallback, String tableNameWithType,
+      String segmentName) {
     if (TimeUtils.timeValueInValidRange(endTimeMs)) {
       return currentTimeMs - endTimeMs > retentionMs;
     }
+    if (useCreationTimeFallback && TimeUtils.timeValueInValidRange(creationTimeMs)) {
+      LOGGER.debug("Segment: {} of table: {} has invalid end time: {}. Using creation time: {} as fallback",
+          segmentName, tableNameWithType, endTimeMs, creationTimeMs);
+      return currentTimeMs - creationTimeMs > retentionMs;
+    }
     if (useCreationTimeFallback) {
-      long creationTimeMs = segmentZKMetadata.getCreationTime();
-      if (TimeUtils.timeValueInValidRange(creationTimeMs)) {
-        LOGGER.debug("Segment: {} of table: {} has invalid end time: {}. Using creation time: {} as fallback",
-            segmentName, tableNameWithType, endTimeMs, creationTimeMs);
-        return currentTimeMs - creationTimeMs > retentionMs;
-      }
       LOGGER.warn("Segment: {} of table: {} has invalid end time: {} and invalid creation time: {}. "
           + "Cannot determine retention, skipping", segmentName, tableNameWithType, endTimeMs, creationTimeMs);
     } else {
@@ -73,5 +107,44 @@ public class RetentionUtils {
           + "Creation time fallback is disabled", segmentName, tableNameWithType, endTimeMs);
     }
     return false;
+  }
+
+  /// Parses {@link SegmentsValidationAndRetentionConfig#getRetentionTimeUnit()} and
+  /// {@link SegmentsValidationAndRetentionConfig#getRetentionTimeValue()} into table data retention duration in
+  /// milliseconds (same interpretation as controller time-based retention).
+  ///
+  /// @return millis, or empty if unset or not parseable
+  public static OptionalLong parseTableDataRetentionMillis(
+      @Nullable SegmentsValidationAndRetentionConfig validationConfig) {
+    if (validationConfig == null) {
+      return OptionalLong.empty();
+    }
+    String retentionTimeUnit = validationConfig.getRetentionTimeUnit();
+    String retentionTimeValue = validationConfig.getRetentionTimeValue();
+    if (StringUtils.isEmpty(retentionTimeUnit) || StringUtils.isEmpty(retentionTimeValue)) {
+      return OptionalLong.empty();
+    }
+    try {
+      return OptionalLong.of(TimeUnit.valueOf(retentionTimeUnit.toUpperCase())
+          .toMillis(Long.parseLong(retentionTimeValue)));
+    } catch (Exception e) {
+      LOGGER.warn("Failed to parse table data retention: unit='{}' value='{}'", retentionTimeUnit, retentionTimeValue,
+          e);
+      return OptionalLong.empty();
+    }
+  }
+
+  /// Returns segment end time in epoch millis from on-disk {@link SegmentMetadata} for retention comparison, using
+  /// {@link SegmentMetadata#getTimeUnit()} and {@link SegmentMetadata#getEndTime()} (same raw fields minion task
+  /// executors pass when configuring generation from segment files). When `timeUnit` is non-null and raw end time is
+  /// not {@link Long#MIN_VALUE}, returns `timeUnit.toMillis(endTime)`; otherwise returns the raw end time (typically
+  /// `Long.MIN_VALUE` when unset).
+  public static long getSegmentMetadataEndTimeMillis(SegmentMetadata segmentMetadata) {
+    TimeUnit timeUnit = segmentMetadata.getTimeUnit();
+    long endTime = segmentMetadata.getEndTime();
+    if (timeUnit != null && endTime != Long.MIN_VALUE) {
+      return timeUnit.toMillis(endTime);
+    }
+    return endTime;
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/RetentionUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/RetentionUtils.java
@@ -18,17 +18,37 @@
  */
 package org.apache.pinot.common.utils;
 
+import java.util.Locale;
+import java.util.OptionalLong;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
+import org.apache.pinot.segment.spi.SegmentMetadata;
+import org.apache.pinot.spi.config.table.SegmentsValidationAndRetentionConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.utils.IngestionConfigUtils;
 import org.apache.pinot.spi.utils.TimeUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
-/// Utility methods for evaluating segment retention eligibility.
+/// Utility methods for evaluating segment retention eligibility and parsing table data retention from config.
 public class RetentionUtils {
   private static final Logger LOGGER = LoggerFactory.getLogger(RetentionUtils.class);
 
   private RetentionUtils() {
+  }
+
+  /// Whether time-based data retention should run for this table's segments, matching the controller retention manager:
+  /// for {@link TableType#OFFLINE} tables, retention applies only when batch segment ingestion type is {@code APPEND}.
+  public static boolean shouldManageTimeBasedDataRetention(TableConfig tableConfig) {
+    if (tableConfig.getTableType() == TableType.OFFLINE && !"APPEND"
+        .equalsIgnoreCase(IngestionConfigUtils.getBatchSegmentIngestionType(tableConfig))) {
+      return false;
+    }
+    return true;
   }
 
   /// Implements the time-comparison and creation-time fallback logic used by `TimeRetentionStrategy` for
@@ -49,18 +69,38 @@ public class RetentionUtils {
   /// @return true if the segment is past the retention boundary, false otherwise
   public static boolean isPurgeable(String tableNameWithType, SegmentZKMetadata segmentZKMetadata, long retentionMs,
       long currentTimeMs, boolean useCreationTimeFallback) {
-    String segmentName = segmentZKMetadata.getSegmentName();
-    long endTimeMs = segmentZKMetadata.getEndTimeMs();
+    return isPurgeableInternal(segmentZKMetadata.getEndTimeMs(), segmentZKMetadata.getCreationTime(), retentionMs,
+        currentTimeMs, useCreationTimeFallback, tableNameWithType, segmentZKMetadata.getSegmentName());
+  }
+
+  /// Whether segment file metadata is past the retention window, using end time from
+  /// {@link #getSegmentMetadataEndTimeMillis(SegmentMetadata)} and
+  /// {@link SegmentMetadata#getIndexCreationTime()} as the optional fallback clock. Invalid-end paths emit the same
+  /// style of debug/warn lines as the ZK overload, using
+  /// {@link SegmentMetadata#getName()} for the segment in log messages.
+  ///
+  /// - If end time is valid: purgeable when `currentTimeMs - endTimeMs > retentionMs`.
+  /// - If end time is invalid and `useCreationTimeFallback` is true and index creation time is valid: purgeable when
+  ///   `currentTimeMs - creationTimeMs > retentionMs`.
+  /// - Otherwise: not purgeable (fail-open).
+  public static boolean isPurgeable(String tableNameWithType, SegmentMetadata segmentMetadata, long retentionMs,
+      long currentTimeMs, boolean useCreationTimeFallback) {
+    return isPurgeableInternal(getSegmentMetadataEndTimeMillis(segmentMetadata), segmentMetadata.getIndexCreationTime(),
+        retentionMs, currentTimeMs, useCreationTimeFallback, tableNameWithType, segmentMetadata.getName());
+  }
+
+  private static boolean isPurgeableInternal(long endTimeMs, long creationTimeMs, long retentionMs,
+      long currentTimeMs, boolean useCreationTimeFallback, String tableNameWithType,
+      String segmentName) {
     if (TimeUtils.timeValueInValidRange(endTimeMs)) {
       return currentTimeMs - endTimeMs > retentionMs;
     }
+    if (useCreationTimeFallback && TimeUtils.timeValueInValidRange(creationTimeMs)) {
+      LOGGER.debug("Segment: {} of table: {} has invalid end time: {}. Using creation time: {} as fallback",
+          segmentName, tableNameWithType, endTimeMs, creationTimeMs);
+      return currentTimeMs - creationTimeMs > retentionMs;
+    }
     if (useCreationTimeFallback) {
-      long creationTimeMs = segmentZKMetadata.getCreationTime();
-      if (TimeUtils.timeValueInValidRange(creationTimeMs)) {
-        LOGGER.debug("Segment: {} of table: {} has invalid end time: {}. Using creation time: {} as fallback",
-            segmentName, tableNameWithType, endTimeMs, creationTimeMs);
-        return currentTimeMs - creationTimeMs > retentionMs;
-      }
       LOGGER.warn("Segment: {} of table: {} has invalid end time: {} and invalid creation time: {}. "
           + "Cannot determine retention, skipping", segmentName, tableNameWithType, endTimeMs, creationTimeMs);
     } else {
@@ -68,5 +108,44 @@ public class RetentionUtils {
           + "Creation time fallback is disabled", segmentName, tableNameWithType, endTimeMs);
     }
     return false;
+  }
+
+  /// Parses {@link SegmentsValidationAndRetentionConfig#getRetentionTimeUnit()} and
+  /// {@link SegmentsValidationAndRetentionConfig#getRetentionTimeValue()} into table data retention duration in
+  /// milliseconds (same interpretation as controller time-based retention).
+  ///
+  /// @return millis, or empty if unset or not parseable
+  public static OptionalLong parseTableDataRetentionMillis(
+      @Nullable SegmentsValidationAndRetentionConfig validationConfig) {
+    if (validationConfig == null) {
+      return OptionalLong.empty();
+    }
+    String retentionTimeUnit = validationConfig.getRetentionTimeUnit();
+    String retentionTimeValue = validationConfig.getRetentionTimeValue();
+    if (StringUtils.isEmpty(retentionTimeUnit) || StringUtils.isEmpty(retentionTimeValue)) {
+      return OptionalLong.empty();
+    }
+    try {
+      return OptionalLong.of(TimeUnit.valueOf(retentionTimeUnit.toUpperCase(Locale.ROOT))
+          .toMillis(Long.parseLong(retentionTimeValue)));
+    } catch (Exception e) {
+      LOGGER.warn("Failed to parse table data retention: unit='{}' value='{}'", retentionTimeUnit, retentionTimeValue,
+          e);
+      return OptionalLong.empty();
+    }
+  }
+
+  /// Returns segment end time in epoch millis from on-disk {@link SegmentMetadata} for retention comparison, using
+  /// {@link SegmentMetadata#getTimeUnit()} and {@link SegmentMetadata#getEndTime()} (same raw fields minion task
+  /// executors pass when configuring generation from segment files). When `timeUnit` is non-null and raw end time is
+  /// not {@link Long#MIN_VALUE}, returns `timeUnit.toMillis(endTime)`; otherwise returns the raw end time (typically
+  /// `Long.MIN_VALUE` when unset).
+  public static long getSegmentMetadataEndTimeMillis(SegmentMetadata segmentMetadata) {
+    TimeUnit timeUnit = segmentMetadata.getTimeUnit();
+    long endTime = segmentMetadata.getEndTime();
+    if (timeUnit != null && endTime != Long.MIN_VALUE) {
+      return timeUnit.toMillis(endTime);
+    }
+    return endTime;
   }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/RetentionUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/RetentionUtilsTest.java
@@ -18,10 +18,23 @@
  */
 package org.apache.pinot.common.utils;
 
+import java.util.OptionalLong;
 import java.util.concurrent.TimeUnit;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
+import org.apache.pinot.segment.spi.SegmentMetadata;
+import org.apache.pinot.spi.config.table.SegmentsValidationAndRetentionConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.joda.time.DateTimeZone;
+import org.joda.time.Interval;
+import org.mockito.Mockito;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
@@ -45,6 +58,77 @@ public class RetentionUtilsTest {
     segment.setTimeUnit(TimeUnit.MILLISECONDS);
     segment.setCreationTime(creationTimeMs);
     return segment;
+  }
+
+  private static SegmentMetadata mockSegmentMetadataMillis(long endTimeRaw, long indexCreationTimeMs) {
+    SegmentMetadata metadata = Mockito.mock(SegmentMetadata.class);
+    Mockito.when(metadata.getName()).thenReturn("seg");
+    Mockito.when(metadata.getTimeInterval()).thenReturn(null);
+    Mockito.when(metadata.getTimeUnit()).thenReturn(TimeUnit.MILLISECONDS);
+    Mockito.when(metadata.getEndTime()).thenReturn(endTimeRaw);
+    Mockito.when(metadata.getIndexCreationTime()).thenReturn(indexCreationTimeMs);
+    return metadata;
+  }
+
+  @Test
+  public void getSegmentMetadataEndTimeMillisFromTimeUnitAndEndTime() {
+    SegmentMetadata metadata = Mockito.mock(SegmentMetadata.class);
+    Mockito.when(metadata.getTimeUnit()).thenReturn(TimeUnit.MILLISECONDS);
+    Mockito.when(metadata.getEndTime()).thenReturn(5000L);
+    Assert.assertEquals(RetentionUtils.getSegmentMetadataEndTimeMillis(metadata), 5000L);
+  }
+
+  @Test
+  public void getSegmentMetadataEndTimeMillisConvertsWithTimeUnit() {
+    SegmentMetadata metadata = Mockito.mock(SegmentMetadata.class);
+    Mockito.when(metadata.getTimeUnit()).thenReturn(TimeUnit.DAYS);
+    Mockito.when(metadata.getEndTime()).thenReturn(2L);
+    Assert.assertEquals(RetentionUtils.getSegmentMetadataEndTimeMillis(metadata), TimeUnit.DAYS.toMillis(2));
+  }
+
+  @Test
+  public void getSegmentMetadataEndTimeMillisUnsetReturnsRawEndTime() {
+    SegmentMetadata metadata = Mockito.mock(SegmentMetadata.class);
+    Mockito.when(metadata.getTimeUnit()).thenReturn(null);
+    Mockito.when(metadata.getEndTime()).thenReturn(Long.MIN_VALUE);
+    Assert.assertEquals(RetentionUtils.getSegmentMetadataEndTimeMillis(metadata), Long.MIN_VALUE);
+  }
+
+  @Test
+  public void getSegmentMetadataEndTimeMillisNullTimeUnitReturnsRawEndTime() {
+    SegmentMetadata metadata = Mockito.mock(SegmentMetadata.class);
+    Mockito.when(metadata.getTimeUnit()).thenReturn(null);
+    Mockito.when(metadata.getEndTime()).thenReturn(12_345L);
+    Assert.assertEquals(RetentionUtils.getSegmentMetadataEndTimeMillis(metadata), 12_345L);
+  }
+
+  @Test
+  public void getSegmentMetadataEndTimeMillisMinRawEndTimeReturnsMinWithoutConversion() {
+    SegmentMetadata metadata = Mockito.mock(SegmentMetadata.class);
+    Mockito.when(metadata.getTimeUnit()).thenReturn(TimeUnit.DAYS);
+    Mockito.when(metadata.getEndTime()).thenReturn(Long.MIN_VALUE);
+    Assert.assertEquals(RetentionUtils.getSegmentMetadataEndTimeMillis(metadata), Long.MIN_VALUE);
+  }
+
+  @Test
+  public void getSegmentMetadataEndTimeMillisDoesNotReadTimeInterval() {
+    SegmentMetadata metadata = Mockito.mock(SegmentMetadata.class);
+    Mockito.when(metadata.getTimeUnit()).thenReturn(TimeUnit.DAYS);
+    Mockito.when(metadata.getEndTime()).thenReturn(1L);
+    Assert.assertEquals(RetentionUtils.getSegmentMetadataEndTimeMillis(metadata), TimeUnit.DAYS.toMillis(1));
+    verify(metadata, never()).getTimeInterval();
+  }
+
+  @Test
+  public void getSegmentMetadataEndTimeMillisIgnoresTimeIntervalWhenRawFieldsDiffer() {
+    Interval interval = new Interval(1000L, 9000L, DateTimeZone.UTC);
+    SegmentMetadata metadata = Mockito.mock(SegmentMetadata.class);
+    Mockito.when(metadata.getTimeInterval()).thenReturn(interval);
+    Mockito.when(metadata.getTimeUnit()).thenReturn(TimeUnit.MILLISECONDS);
+    Mockito.when(metadata.getEndTime()).thenReturn(5000L);
+    clearInvocations(metadata);
+    Assert.assertEquals(RetentionUtils.getSegmentMetadataEndTimeMillis(metadata), 5000L);
+    verify(metadata, never()).getTimeInterval();
   }
 
   @Test
@@ -126,5 +210,113 @@ public class RetentionUtilsTest {
     long now = System.currentTimeMillis();
     SegmentZKMetadata segment = makeSegmentWithCreationTime(now - 2 * ONE_DAY_MS, now - 10 * ONE_DAY_MS);
     assertFalse(RetentionUtils.isPurgeable(TABLE_NAME, segment, RETENTION_MS, now, true));
+  }
+
+  @Test
+  public void testSegmentMetadataPurgeableExactBoundaryNotOutside() {
+    long now = System.currentTimeMillis();
+    assertFalse(RetentionUtils.isPurgeable(TABLE_NAME, mockSegmentMetadataMillis(now - RETENTION_MS, 0L),
+        RETENTION_MS, now, false));
+  }
+
+  @Test
+  public void testSegmentMetadataInvalidEndNoFallback() {
+    long now = System.currentTimeMillis();
+    assertFalse(RetentionUtils.isPurgeable(TABLE_NAME, mockSegmentMetadataMillis(-1, now - 10 * ONE_DAY_MS),
+        RETENTION_MS, now, false));
+  }
+
+  @Test
+  public void testSegmentMetadataInvalidEndWithFallback() {
+    long now = System.currentTimeMillis();
+    long creation = now - 10 * ONE_DAY_MS;
+    assertTrue(RetentionUtils.isPurgeable(TABLE_NAME, mockSegmentMetadataMillis(-1, creation),
+        RETENTION_MS, now, true));
+  }
+
+  @Test
+  public void shouldManageTimeBasedDataRetentionRealtime() {
+    TableConfig cfg = new TableConfigBuilder(TableType.REALTIME).setTableName("t").build();
+    assertTrue(RetentionUtils.shouldManageTimeBasedDataRetention(cfg));
+  }
+
+  @Test
+  public void shouldManageTimeBasedDataRetentionOfflineAppendDefault() {
+    TableConfig cfg = new TableConfigBuilder(TableType.OFFLINE).setTableName("t_OFFLINE").build();
+    assertTrue(RetentionUtils.shouldManageTimeBasedDataRetention(cfg));
+  }
+
+  @Test
+  public void shouldManageTimeBasedDataRetentionOfflineRefreshSkipped() {
+    TableConfig cfg = new TableConfigBuilder(TableType.OFFLINE).setTableName("t_OFFLINE").setSegmentPushType("REFRESH")
+        .build();
+    assertFalse(RetentionUtils.shouldManageTimeBasedDataRetention(cfg));
+  }
+
+  @Test
+  public void testParseTableDataRetentionMillisValidDays() {
+    SegmentsValidationAndRetentionConfig cfg = new SegmentsValidationAndRetentionConfig();
+    cfg.setRetentionTimeUnit("DAYS");
+    cfg.setRetentionTimeValue("7");
+    Assert.assertTrue(RetentionUtils.parseTableDataRetentionMillis(cfg).isPresent());
+    Assert.assertEquals(RetentionUtils.parseTableDataRetentionMillis(cfg).getAsLong(), TimeUnit.DAYS.toMillis(7));
+  }
+
+  @Test
+  public void testParseTableDataRetentionMillisMissingReturnsEmpty() {
+    assertFalse(RetentionUtils.parseTableDataRetentionMillis(new SegmentsValidationAndRetentionConfig()).isPresent());
+    assertFalse(RetentionUtils.parseTableDataRetentionMillis(null).isPresent());
+  }
+
+  @Test
+  public void testParseTableDataRetentionMillisInvalidUnitReturnsEmpty() {
+    SegmentsValidationAndRetentionConfig cfg = new SegmentsValidationAndRetentionConfig();
+    cfg.setRetentionTimeUnit("FORTNIGHTS");
+    cfg.setRetentionTimeValue("1");
+    assertFalse(RetentionUtils.parseTableDataRetentionMillis(cfg).isPresent());
+  }
+
+  @Test
+  public void testParseTableDataRetentionMillisEmptyUnitReturnsEmpty() {
+    SegmentsValidationAndRetentionConfig cfg = new SegmentsValidationAndRetentionConfig();
+    cfg.setRetentionTimeUnit("");
+    cfg.setRetentionTimeValue("7");
+    assertFalse(RetentionUtils.parseTableDataRetentionMillis(cfg).isPresent());
+  }
+
+  @Test
+  public void testParseTableDataRetentionMillisEmptyValueReturnsEmpty() {
+    SegmentsValidationAndRetentionConfig cfg = new SegmentsValidationAndRetentionConfig();
+    cfg.setRetentionTimeUnit("DAYS");
+    cfg.setRetentionTimeValue("");
+    assertFalse(RetentionUtils.parseTableDataRetentionMillis(cfg).isPresent());
+  }
+
+  @Test
+  public void testParseTableDataRetentionMillisInvalidValueReturnsEmpty() {
+    SegmentsValidationAndRetentionConfig cfg = new SegmentsValidationAndRetentionConfig();
+    cfg.setRetentionTimeUnit("DAYS");
+    cfg.setRetentionTimeValue("not-a-number");
+    assertFalse(RetentionUtils.parseTableDataRetentionMillis(cfg).isPresent());
+  }
+
+  @Test
+  public void testParseTableDataRetentionMillisLowerCaseUnitParses() {
+    SegmentsValidationAndRetentionConfig cfg = new SegmentsValidationAndRetentionConfig();
+    cfg.setRetentionTimeUnit("days");
+    cfg.setRetentionTimeValue("7");
+    OptionalLong parsed = RetentionUtils.parseTableDataRetentionMillis(cfg);
+    Assert.assertTrue(parsed.isPresent());
+    Assert.assertEquals(parsed.getAsLong(), TimeUnit.DAYS.toMillis(7));
+  }
+
+  @Test
+  public void testParseTableDataRetentionMillisValidHours() {
+    SegmentsValidationAndRetentionConfig cfg = new SegmentsValidationAndRetentionConfig();
+    cfg.setRetentionTimeUnit("HOURS");
+    cfg.setRetentionTimeValue("12");
+    OptionalLong parsed = RetentionUtils.parseTableDataRetentionMillis(cfg);
+    Assert.assertTrue(parsed.isPresent());
+    Assert.assertEquals(parsed.getAsLong(), TimeUnit.HOURS.toMillis(12));
   }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/RetentionUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/RetentionUtilsTest.java
@@ -18,10 +18,24 @@
  */
 package org.apache.pinot.common.utils;
 
+import java.util.Locale;
+import java.util.OptionalLong;
 import java.util.concurrent.TimeUnit;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
+import org.apache.pinot.segment.spi.SegmentMetadata;
+import org.apache.pinot.spi.config.table.SegmentsValidationAndRetentionConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.joda.time.DateTimeZone;
+import org.joda.time.Interval;
+import org.mockito.Mockito;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import static org.mockito.Mockito.clearInvocations;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
@@ -45,6 +59,77 @@ public class RetentionUtilsTest {
     segment.setTimeUnit(TimeUnit.MILLISECONDS);
     segment.setCreationTime(creationTimeMs);
     return segment;
+  }
+
+  private static SegmentMetadata mockSegmentMetadataMillis(long endTimeRaw, long indexCreationTimeMs) {
+    SegmentMetadata metadata = Mockito.mock(SegmentMetadata.class);
+    Mockito.when(metadata.getName()).thenReturn("seg");
+    Mockito.when(metadata.getTimeInterval()).thenReturn(null);
+    Mockito.when(metadata.getTimeUnit()).thenReturn(TimeUnit.MILLISECONDS);
+    Mockito.when(metadata.getEndTime()).thenReturn(endTimeRaw);
+    Mockito.when(metadata.getIndexCreationTime()).thenReturn(indexCreationTimeMs);
+    return metadata;
+  }
+
+  @Test
+  public void getSegmentMetadataEndTimeMillisFromTimeUnitAndEndTime() {
+    SegmentMetadata metadata = Mockito.mock(SegmentMetadata.class);
+    Mockito.when(metadata.getTimeUnit()).thenReturn(TimeUnit.MILLISECONDS);
+    Mockito.when(metadata.getEndTime()).thenReturn(5000L);
+    Assert.assertEquals(RetentionUtils.getSegmentMetadataEndTimeMillis(metadata), 5000L);
+  }
+
+  @Test
+  public void getSegmentMetadataEndTimeMillisConvertsWithTimeUnit() {
+    SegmentMetadata metadata = Mockito.mock(SegmentMetadata.class);
+    Mockito.when(metadata.getTimeUnit()).thenReturn(TimeUnit.DAYS);
+    Mockito.when(metadata.getEndTime()).thenReturn(2L);
+    Assert.assertEquals(RetentionUtils.getSegmentMetadataEndTimeMillis(metadata), TimeUnit.DAYS.toMillis(2));
+  }
+
+  @Test
+  public void getSegmentMetadataEndTimeMillisUnsetReturnsRawEndTime() {
+    SegmentMetadata metadata = Mockito.mock(SegmentMetadata.class);
+    Mockito.when(metadata.getTimeUnit()).thenReturn(null);
+    Mockito.when(metadata.getEndTime()).thenReturn(Long.MIN_VALUE);
+    Assert.assertEquals(RetentionUtils.getSegmentMetadataEndTimeMillis(metadata), Long.MIN_VALUE);
+  }
+
+  @Test
+  public void getSegmentMetadataEndTimeMillisNullTimeUnitReturnsRawEndTime() {
+    SegmentMetadata metadata = Mockito.mock(SegmentMetadata.class);
+    Mockito.when(metadata.getTimeUnit()).thenReturn(null);
+    Mockito.when(metadata.getEndTime()).thenReturn(12_345L);
+    Assert.assertEquals(RetentionUtils.getSegmentMetadataEndTimeMillis(metadata), 12_345L);
+  }
+
+  @Test
+  public void getSegmentMetadataEndTimeMillisMinRawEndTimeReturnsMinWithoutConversion() {
+    SegmentMetadata metadata = Mockito.mock(SegmentMetadata.class);
+    Mockito.when(metadata.getTimeUnit()).thenReturn(TimeUnit.DAYS);
+    Mockito.when(metadata.getEndTime()).thenReturn(Long.MIN_VALUE);
+    Assert.assertEquals(RetentionUtils.getSegmentMetadataEndTimeMillis(metadata), Long.MIN_VALUE);
+  }
+
+  @Test
+  public void getSegmentMetadataEndTimeMillisDoesNotReadTimeInterval() {
+    SegmentMetadata metadata = Mockito.mock(SegmentMetadata.class);
+    Mockito.when(metadata.getTimeUnit()).thenReturn(TimeUnit.DAYS);
+    Mockito.when(metadata.getEndTime()).thenReturn(1L);
+    Assert.assertEquals(RetentionUtils.getSegmentMetadataEndTimeMillis(metadata), TimeUnit.DAYS.toMillis(1));
+    verify(metadata, never()).getTimeInterval();
+  }
+
+  @Test
+  public void getSegmentMetadataEndTimeMillisIgnoresTimeIntervalWhenRawFieldsDiffer() {
+    Interval interval = new Interval(1000L, 9000L, DateTimeZone.UTC);
+    SegmentMetadata metadata = Mockito.mock(SegmentMetadata.class);
+    Mockito.when(metadata.getTimeInterval()).thenReturn(interval);
+    Mockito.when(metadata.getTimeUnit()).thenReturn(TimeUnit.MILLISECONDS);
+    Mockito.when(metadata.getEndTime()).thenReturn(5000L);
+    clearInvocations(metadata);
+    Assert.assertEquals(RetentionUtils.getSegmentMetadataEndTimeMillis(metadata), 5000L);
+    verify(metadata, never()).getTimeInterval();
   }
 
   @Test
@@ -126,5 +211,129 @@ public class RetentionUtilsTest {
     long now = System.currentTimeMillis();
     SegmentZKMetadata segment = makeSegmentWithCreationTime(now - 2 * ONE_DAY_MS, now - 10 * ONE_DAY_MS);
     assertFalse(RetentionUtils.isPurgeable(TABLE_NAME, segment, RETENTION_MS, now, true));
+  }
+
+  @Test
+  public void testSegmentMetadataPurgeableExactBoundaryNotOutside() {
+    long now = System.currentTimeMillis();
+    assertFalse(RetentionUtils.isPurgeable(TABLE_NAME, mockSegmentMetadataMillis(now - RETENTION_MS, 0L),
+        RETENTION_MS, now, false));
+  }
+
+  @Test
+  public void testSegmentMetadataInvalidEndNoFallback() {
+    long now = System.currentTimeMillis();
+    assertFalse(RetentionUtils.isPurgeable(TABLE_NAME, mockSegmentMetadataMillis(-1, now - 10 * ONE_DAY_MS),
+        RETENTION_MS, now, false));
+  }
+
+  @Test
+  public void testSegmentMetadataInvalidEndWithFallback() {
+    long now = System.currentTimeMillis();
+    long creation = now - 10 * ONE_DAY_MS;
+    assertTrue(RetentionUtils.isPurgeable(TABLE_NAME, mockSegmentMetadataMillis(-1, creation),
+        RETENTION_MS, now, true));
+  }
+
+  @Test
+  public void shouldManageTimeBasedDataRetentionRealtime() {
+    TableConfig cfg = new TableConfigBuilder(TableType.REALTIME).setTableName("t").build();
+    assertTrue(RetentionUtils.shouldManageTimeBasedDataRetention(cfg));
+  }
+
+  @Test
+  public void shouldManageTimeBasedDataRetentionOfflineAppendDefault() {
+    TableConfig cfg = new TableConfigBuilder(TableType.OFFLINE).setTableName("t_OFFLINE").build();
+    assertTrue(RetentionUtils.shouldManageTimeBasedDataRetention(cfg));
+  }
+
+  @Test
+  public void shouldManageTimeBasedDataRetentionOfflineRefreshSkipped() {
+    TableConfig cfg = new TableConfigBuilder(TableType.OFFLINE).setTableName("t_OFFLINE").setSegmentPushType("REFRESH")
+        .build();
+    assertFalse(RetentionUtils.shouldManageTimeBasedDataRetention(cfg));
+  }
+
+  @Test
+  public void testParseTableDataRetentionMillisValidDays() {
+    SegmentsValidationAndRetentionConfig cfg = new SegmentsValidationAndRetentionConfig();
+    cfg.setRetentionTimeUnit("DAYS");
+    cfg.setRetentionTimeValue("7");
+    Assert.assertTrue(RetentionUtils.parseTableDataRetentionMillis(cfg).isPresent());
+    Assert.assertEquals(RetentionUtils.parseTableDataRetentionMillis(cfg).getAsLong(), TimeUnit.DAYS.toMillis(7));
+  }
+
+  @Test
+  public void testParseTableDataRetentionMillisMissingReturnsEmpty() {
+    assertFalse(RetentionUtils.parseTableDataRetentionMillis(new SegmentsValidationAndRetentionConfig()).isPresent());
+    assertFalse(RetentionUtils.parseTableDataRetentionMillis(null).isPresent());
+  }
+
+  @Test
+  public void testParseTableDataRetentionMillisInvalidUnitReturnsEmpty() {
+    SegmentsValidationAndRetentionConfig cfg = new SegmentsValidationAndRetentionConfig();
+    cfg.setRetentionTimeUnit("FORTNIGHTS");
+    cfg.setRetentionTimeValue("1");
+    assertFalse(RetentionUtils.parseTableDataRetentionMillis(cfg).isPresent());
+  }
+
+  @Test
+  public void testParseTableDataRetentionMillisEmptyUnitReturnsEmpty() {
+    SegmentsValidationAndRetentionConfig cfg = new SegmentsValidationAndRetentionConfig();
+    cfg.setRetentionTimeUnit("");
+    cfg.setRetentionTimeValue("7");
+    assertFalse(RetentionUtils.parseTableDataRetentionMillis(cfg).isPresent());
+  }
+
+  @Test
+  public void testParseTableDataRetentionMillisEmptyValueReturnsEmpty() {
+    SegmentsValidationAndRetentionConfig cfg = new SegmentsValidationAndRetentionConfig();
+    cfg.setRetentionTimeUnit("DAYS");
+    cfg.setRetentionTimeValue("");
+    assertFalse(RetentionUtils.parseTableDataRetentionMillis(cfg).isPresent());
+  }
+
+  @Test
+  public void testParseTableDataRetentionMillisInvalidValueReturnsEmpty() {
+    SegmentsValidationAndRetentionConfig cfg = new SegmentsValidationAndRetentionConfig();
+    cfg.setRetentionTimeUnit("DAYS");
+    cfg.setRetentionTimeValue("not-a-number");
+    assertFalse(RetentionUtils.parseTableDataRetentionMillis(cfg).isPresent());
+  }
+
+  @Test
+  public void testParseTableDataRetentionMillisLowerCaseUnitParses() {
+    SegmentsValidationAndRetentionConfig cfg = new SegmentsValidationAndRetentionConfig();
+    cfg.setRetentionTimeUnit("days");
+    cfg.setRetentionTimeValue("7");
+    OptionalLong parsed = RetentionUtils.parseTableDataRetentionMillis(cfg);
+    Assert.assertTrue(parsed.isPresent());
+    Assert.assertEquals(parsed.getAsLong(), TimeUnit.DAYS.toMillis(7));
+  }
+
+  @Test
+  public void testParseTableDataRetentionMillisLowerCaseUnitUsesLocaleRoot() {
+    Locale previous = Locale.getDefault();
+    try {
+      Locale.setDefault(Locale.forLanguageTag("tr-TR"));
+      SegmentsValidationAndRetentionConfig cfg = new SegmentsValidationAndRetentionConfig();
+      cfg.setRetentionTimeUnit("minutes");
+      cfg.setRetentionTimeValue("5");
+      OptionalLong parsed = RetentionUtils.parseTableDataRetentionMillis(cfg);
+      Assert.assertTrue(parsed.isPresent());
+      Assert.assertEquals(parsed.getAsLong(), TimeUnit.MINUTES.toMillis(5));
+    } finally {
+      Locale.setDefault(previous);
+    }
+  }
+
+  @Test
+  public void testParseTableDataRetentionMillisValidHours() {
+    SegmentsValidationAndRetentionConfig cfg = new SegmentsValidationAndRetentionConfig();
+    cfg.setRetentionTimeUnit("HOURS");
+    cfg.setRetentionTimeValue("12");
+    OptionalLong parsed = RetentionUtils.parseTableDataRetentionMillis(cfg);
+    Assert.assertTrue(parsed.isPresent());
+    Assert.assertEquals(parsed.getAsLong(), TimeUnit.HOURS.toMillis(12));
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -369,6 +369,10 @@ public class ControllerConf extends PinotConfiguration {
   // Amount of the time the segment can take from the beginning of upload to the end of upload. Used when parallel push
   // protection is enabled. If the upload does not finish within the timeout, next upload can override the previous one.
   public static final String SEGMENT_UPLOAD_TIMEOUT_IN_MILLIS = "controller.segment.upload.timeoutInMillis";
+  /// If true, the controller may reject single-segment uploads with HTTP 403 when segment data end is past the table
+  /// data retention window (see {@link org.apache.pinot.controller.api.upload.SegmentValidationUtils}).
+  public static final String SEGMENT_UPLOAD_REJECT_OUT_OF_RETENTION_ENABLED =
+      "controller.segment.upload.rejectOutOfRetention.enabled";
   public static final String REALTIME_SEGMENT_METADATA_COMMIT_NUMLOCKS =
       "controller.realtime.segment.metadata.commit.numLocks";
   public static final String ENABLE_STORAGE_QUOTA_CHECK = "controller.enable.storage.quota.check";
@@ -418,6 +422,8 @@ public class ControllerConf extends PinotConfiguration {
   public static final String DEFAULT_REBALANCE_PRE_CHECKER =
       "org.apache.pinot.controller.helix.core.rebalance.DefaultRebalancePreChecker";
   public static final long DEFAULT_SEGMENT_UPLOAD_TIMEOUT_IN_MILLIS = 600_000L; // 10 minutes
+  /// Default for {@link #SEGMENT_UPLOAD_REJECT_OUT_OF_RETENTION_ENABLED}: disabled until explicitly enabled.
+  public static final boolean DEFAULT_SEGMENT_UPLOAD_REJECT_OUT_OF_RETENTION_ENABLED = false;
   public static final int DEFAULT_MIN_NUM_CHARS_IN_IS_TO_TURN_ON_COMPRESSION = -1;
   public static final int DEFAULT_REALTIME_SEGMENT_METADATA_COMMIT_NUMLOCKS = 64;
   public static final boolean DEFAULT_ENABLE_STORAGE_QUOTA_CHECK = true;
@@ -1233,6 +1239,17 @@ public class ControllerConf extends PinotConfiguration {
 
   public void setSegmentUploadTimeoutInMillis(long segmentUploadTimeoutInMillis) {
     setProperty(SEGMENT_UPLOAD_TIMEOUT_IN_MILLIS, segmentUploadTimeoutInMillis);
+  }
+
+  /// @return whether out-of-retention single-segment upload rejection is enabled
+  public boolean isSegmentUploadRejectOutOfRetentionEnabled() {
+    return getProperty(SEGMENT_UPLOAD_REJECT_OUT_OF_RETENTION_ENABLED,
+        DEFAULT_SEGMENT_UPLOAD_REJECT_OUT_OF_RETENTION_ENABLED);
+  }
+
+  /// @param enabled value for {@link #SEGMENT_UPLOAD_REJECT_OUT_OF_RETENTION_ENABLED}
+  public void setSegmentUploadRejectOutOfRetentionEnabled(boolean enabled) {
+    setProperty(SEGMENT_UPLOAD_REJECT_OUT_OF_RETENTION_ENABLED, enabled);
   }
 
   public int getRealtimeSegmentMetadataCommitNumLocks() {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -364,6 +364,10 @@ public class ControllerConf extends PinotConfiguration {
   // Amount of the time the segment can take from the beginning of upload to the end of upload. Used when parallel push
   // protection is enabled. If the upload does not finish within the timeout, next upload can override the previous one.
   public static final String SEGMENT_UPLOAD_TIMEOUT_IN_MILLIS = "controller.segment.upload.timeoutInMillis";
+  /// If true, the controller may reject single-segment uploads with HTTP 403 when segment data end is past the table
+  /// data retention window (see {@link org.apache.pinot.controller.api.upload.SegmentValidationUtils}).
+  public static final String SEGMENT_UPLOAD_REJECT_OUT_OF_RETENTION_ENABLED =
+      "controller.segment.upload.rejectOutOfRetention.enabled";
   public static final String REALTIME_SEGMENT_METADATA_COMMIT_NUMLOCKS =
       "controller.realtime.segment.metadata.commit.numLocks";
   public static final String ENABLE_STORAGE_QUOTA_CHECK = "controller.enable.storage.quota.check";
@@ -413,6 +417,8 @@ public class ControllerConf extends PinotConfiguration {
   public static final String DEFAULT_REBALANCE_PRE_CHECKER =
       "org.apache.pinot.controller.helix.core.rebalance.DefaultRebalancePreChecker";
   public static final long DEFAULT_SEGMENT_UPLOAD_TIMEOUT_IN_MILLIS = 600_000L; // 10 minutes
+  /// Default for {@link #SEGMENT_UPLOAD_REJECT_OUT_OF_RETENTION_ENABLED}: disabled until explicitly enabled.
+  public static final boolean DEFAULT_SEGMENT_UPLOAD_REJECT_OUT_OF_RETENTION_ENABLED = false;
   public static final int DEFAULT_MIN_NUM_CHARS_IN_IS_TO_TURN_ON_COMPRESSION = -1;
   public static final int DEFAULT_REALTIME_SEGMENT_METADATA_COMMIT_NUMLOCKS = 64;
   public static final boolean DEFAULT_ENABLE_STORAGE_QUOTA_CHECK = true;
@@ -1248,6 +1254,17 @@ public class ControllerConf extends PinotConfiguration {
 
   public void setSegmentUploadTimeoutInMillis(long segmentUploadTimeoutInMillis) {
     setProperty(SEGMENT_UPLOAD_TIMEOUT_IN_MILLIS, segmentUploadTimeoutInMillis);
+  }
+
+  /// @return whether out-of-retention single-segment upload rejection is enabled
+  public boolean isSegmentUploadRejectOutOfRetentionEnabled() {
+    return getProperty(SEGMENT_UPLOAD_REJECT_OUT_OF_RETENTION_ENABLED,
+        DEFAULT_SEGMENT_UPLOAD_REJECT_OUT_OF_RETENTION_ENABLED);
+  }
+
+  /// @param enabled value for {@link #SEGMENT_UPLOAD_REJECT_OUT_OF_RETENTION_ENABLED}
+  public void setSegmentUploadRejectOutOfRetentionEnabled(boolean enabled) {
+    setProperty(SEGMENT_UPLOAD_REJECT_OUT_OF_RETENTION_ENABLED, enabled);
   }
 
   public int getRealtimeSegmentMetadataCommitNumLocks() {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
@@ -401,6 +401,8 @@ public class PinotSegmentUploadDownloadRestletResource {
         SegmentValidationUtils.validateTimeInterval(segmentMetadata, tableConfig);
       }
       SegmentValidationUtils.validateUpsertSegmentPartitionMetadata(segmentMetadata, tableConfig);
+      SegmentValidationUtils.rejectUploadIfOutOfRetention(segmentMetadata, tableConfig, System.currentTimeMillis(),
+          _controllerConf.isSegmentUploadRejectOutOfRetentionEnabled(), _controllerMetrics);
       long untarredSegmentSizeInBytes;
       if (uploadType == FileUploadType.METADATA && segmentSizeInBytes > 0) {
         // TODO: Include the untarred segment size when using the METADATA push rest API. Currently we can only use the

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/upload/SegmentValidationUtils.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/upload/SegmentValidationUtils.java
@@ -173,7 +173,7 @@ public class SegmentValidationUtils {
         controllerMetrics.addMeteredGlobalValue(ControllerMeter.OUT_OF_RETENTION_SEGMENT_UPLOAD_REJECTED, 1L);
       }
       throw new ControllerApplicationException(LOGGER, String.format(
-          "Segment %s of table %s is outside the retention window (%s %s); upload rejected.",
+          "Segment %s of table %s is outside the retention window (%s %s); upload rejected",
           segmentMetadata.getName(), tableConfig.getTableName(), validationConfig.getRetentionTimeValue(),
           validationConfig.getRetentionTimeUnit()),
           Response.Status.FORBIDDEN);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/upload/SegmentValidationUtils.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/upload/SegmentValidationUtils.java
@@ -19,10 +19,15 @@
 package org.apache.pinot.controller.api.upload;
 
 import java.util.Map;
+import java.util.OptionalLong;
 import java.util.Set;
+import javax.annotation.Nullable;
 import javax.ws.rs.core.Response;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.pinot.common.metrics.ControllerMeter;
+import org.apache.pinot.common.metrics.ControllerMetrics;
+import org.apache.pinot.common.utils.RetentionUtils;
 import org.apache.pinot.controller.api.exception.ControllerApplicationException;
 import org.apache.pinot.controller.validation.StorageQuotaChecker;
 import org.apache.pinot.segment.spi.ColumnMetadata;
@@ -130,6 +135,51 @@ public class SegmentValidationUtils {
     InstanceReplicaGroupPartitionConfig replicaGroupPartitionConfig =
         instanceAssignmentConfig.getReplicaGroupPartitionConfig();
     return replicaGroupPartitionConfig != null ? replicaGroupPartitionConfig.getPartitionColumn() : null;
+  }
+
+  /// When `controller.segment.upload.rejectOutOfRetention.enabled` is true on the controller, rejects the upload if
+  /// the segment's data end time (from segment file metadata) is past the table's `retentionTimeValue` /
+  /// `retentionTimeUnit` window, using the same boundary as the controller retention manager. **Index creation time is
+  /// not** used as a fallback here: it can reflect upstream segment timestamps (for example upsert compaction) and is a
+  /// poor proxy for the data window at upload time.
+  ///
+  /// Rejection uses HTTP 403 so callers that enable the controller flag can treat the response as a hard failure.
+  /// Clients that do not enable the flag see no behavior change.
+  ///
+  /// Controller wiring: {@link org.apache.pinot.controller.api.resources.PinotSegmentUploadDownloadRestletResource}
+  /// invokes this for single-segment upload only. METADATA batch upload (`POST /segments/batchUpload`) and
+  /// reingested-segment upload do not call it.
+  ///
+  /// For tables where the retention manager does not apply time-based retention to completed segments (offline tables
+  /// whose batch ingestion type is not `APPEND`), this method returns without evaluating retention.
+  public static void rejectUploadIfOutOfRetention(SegmentMetadata segmentMetadata, TableConfig tableConfig,
+      long currentTimeMs, boolean controllerRejectOutOfRetentionEnabled,
+      @Nullable ControllerMetrics controllerMetrics) {
+    if (!controllerRejectOutOfRetentionEnabled) {
+      return;
+    }
+    SegmentsValidationAndRetentionConfig validationConfig = tableConfig.getValidationConfig();
+    if (validationConfig == null) {
+      return;
+    }
+    if (!RetentionUtils.shouldManageTimeBasedDataRetention(tableConfig)) {
+      return;
+    }
+    OptionalLong retentionMsOpt = RetentionUtils.parseTableDataRetentionMillis(validationConfig);
+    if (retentionMsOpt.isEmpty()) {
+      return;
+    }
+    long retentionMs = retentionMsOpt.getAsLong();
+    if (RetentionUtils.isPurgeable(tableConfig.getTableName(), segmentMetadata, retentionMs, currentTimeMs, false)) {
+      if (controllerMetrics != null) {
+        controllerMetrics.addMeteredGlobalValue(ControllerMeter.OUT_OF_RETENTION_SEGMENT_UPLOAD_REJECTED, 1L);
+      }
+      throw new ControllerApplicationException(LOGGER, String.format(
+          "Segment %s of table %s is outside the retention window (%s %s); upload rejected.",
+          segmentMetadata.getName(), tableConfig.getTableName(), validationConfig.getRetentionTimeValue(),
+          validationConfig.getRetentionTimeUnit()),
+          Response.Status.FORBIDDEN);
+    }
   }
 
   public static void checkStorageQuota(String segmentName, long tarSegmentSizeInBytes, long untarredSegmentSizeInBytes,

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/upload/SegmentValidationUtils.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/upload/SegmentValidationUtils.java
@@ -19,10 +19,15 @@
 package org.apache.pinot.controller.api.upload;
 
 import java.util.Map;
+import java.util.OptionalLong;
 import java.util.Set;
+import javax.annotation.Nullable;
 import javax.ws.rs.core.Response;
 import org.apache.commons.collections4.MapUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.pinot.common.metrics.ControllerMeter;
+import org.apache.pinot.common.metrics.ControllerMetrics;
+import org.apache.pinot.common.utils.RetentionUtils;
 import org.apache.pinot.controller.api.exception.ControllerApplicationException;
 import org.apache.pinot.controller.validation.StorageQuotaChecker;
 import org.apache.pinot.segment.spi.ColumnMetadata;
@@ -128,6 +133,51 @@ public class SegmentValidationUtils {
     InstanceReplicaGroupPartitionConfig replicaGroupPartitionConfig =
         instanceAssignmentConfig.getReplicaGroupPartitionConfig();
     return replicaGroupPartitionConfig != null ? replicaGroupPartitionConfig.getPartitionColumn() : null;
+  }
+
+  /// When `controller.segment.upload.rejectOutOfRetention.enabled` is true on the controller, rejects the upload if
+  /// the segment's data end time (from segment file metadata) is past the table's `retentionTimeValue` /
+  /// `retentionTimeUnit` window, using the same boundary as the controller retention manager. **Index creation time is
+  /// not** used as a fallback here: it can reflect upstream segment timestamps (for example upsert compaction) and is a
+  /// poor proxy for the data window at upload time.
+  ///
+  /// Rejection uses HTTP 403 so callers that enable the controller flag can treat the response as a hard failure.
+  /// Clients that do not enable the flag see no behavior change.
+  ///
+  /// Controller wiring: {@link org.apache.pinot.controller.api.resources.PinotSegmentUploadDownloadRestletResource}
+  /// invokes this for single-segment upload only. METADATA batch upload (`POST /segments/batchUpload`) and
+  /// reingested-segment upload do not call it.
+  ///
+  /// For tables where the retention manager does not apply time-based retention to completed segments (offline tables
+  /// whose batch ingestion type is not `APPEND`), this method returns without evaluating retention.
+  public static void rejectUploadIfOutOfRetention(SegmentMetadata segmentMetadata, TableConfig tableConfig,
+      long currentTimeMs, boolean controllerRejectOutOfRetentionEnabled,
+      @Nullable ControllerMetrics controllerMetrics) {
+    if (!controllerRejectOutOfRetentionEnabled) {
+      return;
+    }
+    SegmentsValidationAndRetentionConfig validationConfig = tableConfig.getValidationConfig();
+    if (validationConfig == null) {
+      return;
+    }
+    if (!RetentionUtils.shouldManageTimeBasedDataRetention(tableConfig)) {
+      return;
+    }
+    OptionalLong retentionMsOpt = RetentionUtils.parseTableDataRetentionMillis(validationConfig);
+    if (retentionMsOpt.isEmpty()) {
+      return;
+    }
+    long retentionMs = retentionMsOpt.getAsLong();
+    if (RetentionUtils.isPurgeable(tableConfig.getTableName(), segmentMetadata, retentionMs, currentTimeMs, false)) {
+      if (controllerMetrics != null) {
+        controllerMetrics.addMeteredGlobalValue(ControllerMeter.OUT_OF_RETENTION_SEGMENT_UPLOAD_REJECTED, 1L);
+      }
+      throw new ControllerApplicationException(LOGGER, String.format(
+          "Segment %s of table %s is outside the retention window (%s %s); upload rejected.",
+          segmentMetadata.getName(), tableConfig.getTableName(), validationConfig.getRetentionTimeValue(),
+          validationConfig.getRetentionTimeUnit()),
+          Response.Status.FORBIDDEN);
+    }
   }
 
   public static void checkStorageQuota(String segmentName, long tarSegmentSizeInBytes, long untarredSegmentSizeInBytes,

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/retention/RetentionManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/retention/RetentionManager.java
@@ -42,6 +42,7 @@ import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.metrics.ControllerGauge;
 import org.apache.pinot.common.metrics.ControllerMetrics;
+import org.apache.pinot.common.utils.RetentionUtils;
 import org.apache.pinot.common.utils.TarCompressionUtils;
 import org.apache.pinot.common.utils.URIUtils;
 import org.apache.pinot.controller.ControllerConf;
@@ -54,7 +55,6 @@ import org.apache.pinot.controller.util.BrokerServiceHelper;
 import org.apache.pinot.core.routing.timeboundary.TimeBoundaryInfo;
 import org.apache.pinot.spi.config.table.SegmentsValidationAndRetentionConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
-import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.DateTimeFieldSpec;
 import org.apache.pinot.spi.data.DateTimeFormatSpec;
 import org.apache.pinot.spi.data.Schema;
@@ -63,7 +63,6 @@ import org.apache.pinot.spi.filesystem.PinotFS;
 import org.apache.pinot.spi.filesystem.PinotFSFactory;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.CommonConstants.Segment.Realtime.Status;
-import org.apache.pinot.spi.utils.IngestionConfigUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.spi.utils.retry.RetryPolicies;
 import org.apache.pinot.spi.utils.retry.RetryPolicy;
@@ -135,11 +134,10 @@ public class RetentionManager extends ControllerPeriodicTask<Void> {
     String tableNameWithType = tableConfig.getTableName();
     LOGGER.info("Start managing retention for table: {}", tableNameWithType);
 
-    // For offline tables, ensure that the segmentPushType is APPEND.
     SegmentsValidationAndRetentionConfig validationConfig = tableConfig.getValidationConfig();
-    String segmentPushType = IngestionConfigUtils.getBatchSegmentIngestionType(tableConfig);
-    if (tableConfig.getTableType() == TableType.OFFLINE && !"APPEND".equalsIgnoreCase(segmentPushType)) {
-      LOGGER.info("Segment push type is not APPEND for table: {}, skip managing retention", tableNameWithType);
+    if (!RetentionUtils.shouldManageTimeBasedDataRetention(tableConfig)) {
+      LOGGER.info("Skipping time-based retention for table: {} (offline tables require APPEND batch ingestion)",
+          tableNameWithType);
       return;
     }
     int untrackedSegmentsDeletionBatchSize =

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/retention/RetentionManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/retention/RetentionManager.java
@@ -42,6 +42,7 @@ import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.metrics.ControllerGauge;
 import org.apache.pinot.common.metrics.ControllerMetrics;
+import org.apache.pinot.common.utils.RetentionUtils;
 import org.apache.pinot.common.utils.TarCompressionUtils;
 import org.apache.pinot.common.utils.URIUtils;
 import org.apache.pinot.controller.ControllerConf;
@@ -54,7 +55,6 @@ import org.apache.pinot.controller.util.BrokerServiceHelper;
 import org.apache.pinot.core.routing.timeboundary.TimeBoundaryInfo;
 import org.apache.pinot.spi.config.table.SegmentsValidationAndRetentionConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
-import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.DateTimeFieldSpec;
 import org.apache.pinot.spi.data.DateTimeFormatSpec;
 import org.apache.pinot.spi.data.Schema;
@@ -63,7 +63,6 @@ import org.apache.pinot.spi.filesystem.PinotFS;
 import org.apache.pinot.spi.filesystem.PinotFSFactory;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.CommonConstants.Segment.Realtime.Status;
-import org.apache.pinot.spi.utils.IngestionConfigUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.spi.utils.retry.RetryPolicies;
 import org.apache.pinot.spi.utils.retry.RetryPolicy;
@@ -136,11 +135,10 @@ public class RetentionManager extends ControllerPeriodicTask<Void> {
     String tableNameWithType = tableConfig.getTableName();
     LOGGER.info("Start managing retention for table: {}", tableNameWithType);
 
-    // For offline tables, ensure that the segmentPushType is APPEND.
     SegmentsValidationAndRetentionConfig validationConfig = tableConfig.getValidationConfig();
-    String segmentPushType = IngestionConfigUtils.getBatchSegmentIngestionType(tableConfig);
-    if (tableConfig.getTableType() == TableType.OFFLINE && !"APPEND".equalsIgnoreCase(segmentPushType)) {
-      LOGGER.info("Segment push type is not APPEND for table: {}, skip managing retention", tableNameWithType);
+    if (!RetentionUtils.shouldManageTimeBasedDataRetention(tableConfig)) {
+      LOGGER.info("Skipping time-based retention for table: {} (offline tables require APPEND batch ingestion)",
+          tableNameWithType);
       return;
     }
     int untrackedSegmentsDeletionBatchSize =

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/ControllerConfTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/ControllerConfTest.java
@@ -245,4 +245,19 @@ public class ControllerConfTest {
     Assert.assertEquals(conf.getPinotTaskQueueCapacity(), 10000);
     Assert.assertEquals(conf.getPinotTaskQueueWarningThreshold(), 8000);
   }
+
+  @Test
+  public void testSegmentUploadRejectOutOfRetentionDefault() {
+    ControllerConf conf = new ControllerConf();
+    Assert.assertFalse(conf.isSegmentUploadRejectOutOfRetentionEnabled());
+  }
+
+  @Test
+  public void testSegmentUploadRejectOutOfRetentionOverride() {
+    ControllerConf conf = new ControllerConf();
+    conf.setSegmentUploadRejectOutOfRetentionEnabled(true);
+    Assert.assertTrue(conf.isSegmentUploadRejectOutOfRetentionEnabled());
+    conf.setSegmentUploadRejectOutOfRetentionEnabled(false);
+    Assert.assertFalse(conf.isSegmentUploadRejectOutOfRetentionEnabled());
+  }
 }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/ControllerConfTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/ControllerConfTest.java
@@ -252,4 +252,19 @@ public class ControllerConfTest {
     controllerConf.setProperty(ControllerConf.INGEST_FROM_URI_ALLOW_LOCAL_FILE_SYSTEM, true);
     Assert.assertTrue(controllerConf.isIngestFromUriLocalFileSystemAllowed());
   }
+
+  @Test
+  public void testSegmentUploadRejectOutOfRetentionDefault() {
+    ControllerConf conf = new ControllerConf();
+    Assert.assertFalse(conf.isSegmentUploadRejectOutOfRetentionEnabled());
+  }
+
+  @Test
+  public void testSegmentUploadRejectOutOfRetentionOverride() {
+    ControllerConf conf = new ControllerConf();
+    conf.setSegmentUploadRejectOutOfRetentionEnabled(true);
+    Assert.assertTrue(conf.isSegmentUploadRejectOutOfRetentionEnabled());
+    conf.setSegmentUploadRejectOutOfRetentionEnabled(false);
+    Assert.assertFalse(conf.isSegmentUploadRejectOutOfRetentionEnabled());
+  }
 }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/upload/SegmentValidationUtilsTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/upload/SegmentValidationUtilsTest.java
@@ -20,7 +20,10 @@ package org.apache.pinot.controller.api.upload;
 
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 import javax.ws.rs.core.Response;
+import org.apache.pinot.common.metrics.ControllerMeter;
+import org.apache.pinot.common.metrics.ControllerMetrics;
 import org.apache.pinot.controller.api.exception.ControllerApplicationException;
 import org.apache.pinot.segment.spi.ColumnMetadata;
 import org.apache.pinot.segment.spi.SegmentMetadata;
@@ -37,7 +40,11 @@ import org.apache.pinot.spi.config.table.assignment.InstanceTagPoolConfig;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.annotations.Test;
 
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.expectThrows;
@@ -136,6 +143,115 @@ public class SegmentValidationUtilsTest {
     SegmentValidationUtils.validateUpsertSegmentPartitionMetadata(mockSegmentMetadata(Set.of(1)), tableConfig);
   }
 
+  @Test
+  public void testRejectUploadSkippedWhenDisabled() {
+    long now = System.currentTimeMillis();
+    TableConfig tableConfig = getRetentionTableConfig(TableType.OFFLINE);
+    SegmentValidationUtils.rejectUploadIfOutOfRetention(mockRetentionSegmentMetadata(now - TimeUnit.DAYS.toMillis(30),
+        0L), tableConfig, now, false, null);
+  }
+
+  @Test
+  public void testRejectUploadSkippedForOfflineRefresh() {
+    long now = System.currentTimeMillis();
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName(RAW_TABLE_NAME)
+        .setRetentionTimeUnit("DAYS")
+        .setRetentionTimeValue("7")
+        .setSegmentPushType("REFRESH")
+        .build();
+    SegmentValidationUtils.rejectUploadIfOutOfRetention(mockRetentionSegmentMetadata(now - TimeUnit.DAYS.toMillis(30),
+        0L), tableConfig, now, true, null);
+  }
+
+  @Test
+  public void testRejectUploadSkippedWhenRetentionInvalid() {
+    long now = System.currentTimeMillis();
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName(RAW_TABLE_NAME)
+        .setRetentionTimeUnit("BAD")
+        .setRetentionTimeValue("7")
+        .build();
+    SegmentValidationUtils.rejectUploadIfOutOfRetention(mockRetentionSegmentMetadata(now - TimeUnit.DAYS.toMillis(30),
+        0L), tableConfig, now, true, null);
+  }
+
+  @Test
+  public void testRejectUploadWhenEnabledAndSegmentOutOfRetention() {
+    long now = System.currentTimeMillis();
+    TableConfig tableConfig = getRetentionTableConfig(TableType.OFFLINE);
+    ControllerMetrics controllerMetrics = mock(ControllerMetrics.class);
+    ControllerApplicationException exception = expectThrows(ControllerApplicationException.class,
+        () -> SegmentValidationUtils.rejectUploadIfOutOfRetention(
+            mockRetentionSegmentMetadata(now - TimeUnit.DAYS.toMillis(30), 0L), tableConfig, now, true,
+            controllerMetrics));
+    assertEquals(exception.getResponse().getStatus(), Response.Status.FORBIDDEN.getStatusCode());
+    verify(controllerMetrics).addMeteredGlobalValue(ControllerMeter.OUT_OF_RETENTION_SEGMENT_UPLOAD_REJECTED, 1L);
+  }
+
+  @Test
+  public void testRejectUploadAllowsRecentSegment() {
+    long now = System.currentTimeMillis();
+    TableConfig tableConfig = getRetentionTableConfig(TableType.OFFLINE);
+    SegmentValidationUtils.rejectUploadIfOutOfRetention(mockRetentionSegmentMetadata(now - TimeUnit.DAYS.toMillis(1),
+        0L), tableConfig, now, true, null);
+  }
+
+  @Test
+  public void testRejectUploadDoesNotUseIndexCreationTimeFallback() {
+    long now = System.currentTimeMillis();
+    TableConfig tableConfig = getRetentionTableConfig(TableType.OFFLINE);
+    SegmentValidationUtils.rejectUploadIfOutOfRetention(
+        mockRetentionSegmentMetadata(-1, now - TimeUnit.DAYS.toMillis(30)), tableConfig, now, true, null);
+  }
+
+  @Test
+  public void testRejectUploadSkippedWhenValidationConfigNull() {
+    long now = System.currentTimeMillis();
+    TableConfig tableConfig = mock(TableConfig.class);
+    when(tableConfig.getValidationConfig()).thenReturn(null);
+    ControllerMetrics controllerMetrics = mock(ControllerMetrics.class);
+    SegmentValidationUtils.rejectUploadIfOutOfRetention(mockRetentionSegmentMetadata(now - TimeUnit.DAYS.toMillis(30),
+        0L), tableConfig, now, true, controllerMetrics);
+    verify(controllerMetrics, never()).addMeteredGlobalValue(any(ControllerMeter.class), anyLong());
+  }
+
+  @Test
+  public void testRejectUploadSkippedWhenRetentionNotConfigured() {
+    long now = System.currentTimeMillis();
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).build();
+    SegmentValidationUtils.rejectUploadIfOutOfRetention(mockRetentionSegmentMetadata(now - TimeUnit.DAYS.toMillis(30),
+        0L), tableConfig, now, true, null);
+  }
+
+  @Test
+  public void testRejectUploadThrowsWhenOutOfRetentionAndMetricsNull() {
+    long now = System.currentTimeMillis();
+    TableConfig tableConfig = getRetentionTableConfig(TableType.OFFLINE);
+    ControllerApplicationException exception = expectThrows(ControllerApplicationException.class,
+        () -> SegmentValidationUtils.rejectUploadIfOutOfRetention(
+            mockRetentionSegmentMetadata(now - TimeUnit.DAYS.toMillis(30), 0L), tableConfig, now, true, null));
+    assertEquals(exception.getResponse().getStatus(), Response.Status.FORBIDDEN.getStatusCode());
+  }
+
+  @Test
+  public void testRejectUploadRealtimeOutOfRetentionThrows() {
+    long now = System.currentTimeMillis();
+    TableConfig tableConfig = getRetentionTableConfig(TableType.REALTIME);
+    ControllerApplicationException exception = expectThrows(ControllerApplicationException.class,
+        () -> SegmentValidationUtils.rejectUploadIfOutOfRetention(
+            mockRetentionSegmentMetadata(now - TimeUnit.DAYS.toMillis(30), 0L), tableConfig, now, true, null));
+    assertEquals(exception.getResponse().getStatus(), Response.Status.FORBIDDEN.getStatusCode());
+  }
+
+  private static TableConfig getRetentionTableConfig(TableType tableType) {
+    return new TableConfigBuilder(tableType)
+        .setTableName(RAW_TABLE_NAME)
+        .setRetentionTimeUnit("DAYS")
+        .setRetentionTimeValue("7")
+        .build();
+  }
+
   private static TableConfig getOfflineUpsertTableConfig() {
     return new TableConfigBuilder(TableType.OFFLINE)
         .setTableName(RAW_TABLE_NAME)
@@ -165,6 +281,16 @@ public class SegmentValidationUtilsTest {
     SegmentMetadata segmentMetadata = mock(SegmentMetadata.class);
     when(segmentMetadata.getName()).thenReturn(SEGMENT_NAME);
     when(segmentMetadata.getColumnMetadataFor(PARTITION_COLUMN)).thenReturn(null);
+    return segmentMetadata;
+  }
+
+  private static SegmentMetadata mockRetentionSegmentMetadata(long endTimeMs, long indexCreationTimeMs) {
+    SegmentMetadata segmentMetadata = mock(SegmentMetadata.class);
+    when(segmentMetadata.getTimeInterval()).thenReturn(null);
+    when(segmentMetadata.getTimeUnit()).thenReturn(TimeUnit.MILLISECONDS);
+    when(segmentMetadata.getEndTime()).thenReturn(endTimeMs);
+    when(segmentMetadata.getIndexCreationTime()).thenReturn(indexCreationTimeMs);
+    when(segmentMetadata.getName()).thenReturn(SEGMENT_NAME);
     return segmentMetadata;
   }
 


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Controller rejects out\-of\-retention single\-segment uploads when feature flag is enabled\.

```mermaid
flowchart TD
  N0["uploadSegment #40;resource#41; #40;F7#41;"]:::stAdded
  N1["rejectUploadIfOutOfRetention #40;F4#41;"]:::stAdded
  N2["flag enabled#63; #40;F4#41;"]:::stAdded
  N3["get validation config #40;F4#41;"]:::stAdded
  N4["config not null#63; #40;F4#41;"]:::stAdded
  N5["should manage retention#63; #40;F4#44; F2#41;"]:::stAdded
  N6["parse retention ms #40;F4#44; F2#41;"]:::stAdded
  N7["retention parsed#63; #40;F4#41;"]:::stAdded
  N8["segment purgeable#63; #40;F4#44; F2#41;"]:::stAdded
  N9["record metric and throw 403 #40;F4#44; F1#41;"]:::stAdded
  N0 -->|"calls"| N1
  N1 -->|"entry"| N2
  N2 -->|"true"| N3
  N3 -->|"got config"| N4
  N4 -->|"true"| N5
  N5 -->|"true"| N6
  N6 -->|"parsed"| N7
  N7 -->|"true"| N8
  N8 -->|"true"| N9
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-common/src/main/java/org/apache/pinot/common/metrics/ControllerMeter\.java — [before](https://github.com/apache/pinot/blob/210c2951e720b72cbcb87224ff5e46237e098acd/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerMeter.java) · [after](https://github.com/apache/pinot/blob/42201f72517dd5e063fa80e2a7d5b7ee2700a333/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerMeter.java)
- F2: pinot\-common/src/main/java/org/apache/pinot/common/utils/RetentionUtils\.java — [before](https://github.com/apache/pinot/blob/210c2951e720b72cbcb87224ff5e46237e098acd/pinot-common/src/main/java/org/apache/pinot/common/utils/RetentionUtils.java) · [after](https://github.com/apache/pinot/blob/42201f72517dd5e063fa80e2a7d5b7ee2700a333/pinot-common/src/main/java/org/apache/pinot/common/utils/RetentionUtils.java)
- F4: pinot\-controller/src/main/java/org/apache/pinot/controller/api/upload/SegmentValidationUtils\.java — [before](https://github.com/apache/pinot/blob/210c2951e720b72cbcb87224ff5e46237e098acd/pinot-controller/src/main/java/org/apache/pinot/controller/api/upload/SegmentValidationUtils.java) · [after](https://github.com/apache/pinot/blob/42201f72517dd5e063fa80e2a7d5b7ee2700a333/pinot-controller/src/main/java/org/apache/pinot/controller/api/upload/SegmentValidationUtils.java)
- F7: pinot\-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource\.java — [before](https://github.com/apache/pinot/blob/210c2951e720b72cbcb87224ff5e46237e098acd/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java) · [after](https://github.com/apache/pinot/blob/42201f72517dd5e063fa80e2a7d5b7ee2700a333/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjIxMGMyOTUxZTcyMGI3MmNiY2I4NzIyNGZmNWU0NjIzN2UwOThhY2QiLCJjb250ZXh0X2hhc2giOiJmYmJmZmYzYjI1NzM0OGFjZGNhZTM0NmM4ODIxYmMwY2JlZmU3OTdiZjEyYzE3MTQ2OWU4MTllNzM5MWFmZWVhIiwiZ2VuZXJhdGVkX2F0IjoxNzg5NTQ0Mjk4LCJoZWFkX3NoYSI6IjQyMjAxZjcyNTE3ZGQ1ZTA2M2ZhODBlMmE3ZDViN2VlMjcwMGEzMzMiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiIyMTBjMjk1MWU3MjBiNzJjYmNiODcyMjRmZjVlNDYyMzdlMDk4YWNkIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 9dc31fb7f39e13275c194d4f099b5735a44ec6e70e8880da735c11a7118bdc75 -->
<!-- pinot-pr-flow:end -->

Fixes https://github.com/apache/pinot/issues/18485

## Summary

Add controller capability to reject segment uploads when the segment is already outside the table’s configured **data retention** window (time-based retention), using `RetentionUtils` so the boundary matches retention manager behavior.

- New controller property: `controller.segment.upload.rejectOutOfRetention.enabled` (default `false`). No behavior change until it is set to `true`.
- Wired on **single-segment upload** only (`PinotSegmentUploadDownloadRestletResource` → `SegmentValidationUtils.rejectUploadIfOutOfRetention`). **METADATA** batch upload and **reingest** upload paths are unchanged.
- Retention check is **skipped** for **OFFLINE** tables whose batch segment ingestion type is **not** `APPEND` (completed-segment semantics). **REALTIME** and **OFFLINE** with **APPEND** ingestion are evaluated when the flag is on and retention parses successfully.
- Shared parsing / purgeability helpers live in `RetentionUtils` (`parseTableDataRetentionMillis`, `SegmentMetadata`-based `isPurgeable`, `getSegmentMetadataEndTimeMillis`). Configuration is surfaced via `ControllerConf`.

## Release notes

- New controller configuration: `controller.segment.upload.rejectOutOfRetention.enabled` (default `false`). When `true`, single-segment upload may return **403** if the segment is outside the table data retention window as defined by `SegmentsValidationAndRetentionConfig` retention time value/unit.