### PR TITLE
Add a latch to allow ingestion pause during startup

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/InstanceDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/InstanceDataManager.java
@@ -193,20 +193,19 @@ public interface InstanceDataManager {
   void forceCommit(String tableNameWithType, Set<String> segmentNames);
 
   /**
+   * Installs a supplier that gates consuming-segment ingestion. While the supplier returns {@code false}, newly created
+   * realtime consumers wait at the entry of their consumer thread before pulling any data. The supplier is consulted
+   * per consumer; once it returns {@code true} for a given consumer, that consumer should proceed and should
+   * not be gated again. Implementations default to a no-op so subclasses opt in explicitly.
+   */
+  void setSupplierOfIsServerReadyToConsumeData(BooleanSupplier isServerReadyToConsumeData);
+
+  /**
    * Enables the installation of a method to determine if a server is ready to server queries.
    *
    * @param isServerReadyToServeQueries supplier to retrieve state of server.
    */
   void setSupplierOfIsServerReadyToServeQueries(BooleanSupplier isServerReadyToServeQueries);
-
-  /**
-   * Installs a supplier that gates consuming-segment ingestion. While the supplier returns {@code true}, newly created
-   * realtime consumers wait at the entry of their consumer thread before pulling any data. The supplier is consulted
-   * per consumer; once it returns {@code false} for a given consumer, that consumer should proceed and should
-   * not be gated again. Implementations default to a no-op so subclasses opt in explicitly.
-   */
-  default void setSupplierOfIsIngestionPausedDueToStartUp(BooleanSupplier isIngestionPausedDueToStartUp) {
-  }
 
   /**
    * Returns consumer directory paths on the instance

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/InstanceDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/InstanceDataManager.java
@@ -200,6 +200,15 @@ public interface InstanceDataManager {
   void setSupplierOfIsServerReadyToServeQueries(BooleanSupplier isServerReadyToServeQueries);
 
   /**
+   * Installs a supplier that gates consuming-segment ingestion. While the supplier returns {@code true}, newly created
+   * realtime consumers wait at the entry of their consumer thread before pulling any data. The supplier is consulted
+   * once per consumer at startup; once it returns {@code false} for a given consumer, that consumer proceeds and is
+   * not gated again. Implementations default to a no-op so subclasses opt in explicitly.
+   */
+  default void setSupplierOfIsIngestionPausedDueToStartUp(BooleanSupplier isIngestionPausedDueToStartUp) {
+  }
+
+  /**
    * Returns consumer directory paths on the instance
    */
   List<File> getConsumerDirPaths();

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/InstanceDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/InstanceDataManager.java
@@ -202,8 +202,8 @@ public interface InstanceDataManager {
   /**
    * Installs a supplier that gates consuming-segment ingestion. While the supplier returns {@code true}, newly created
    * realtime consumers wait at the entry of their consumer thread before pulling any data. The supplier is consulted
-   * once per consumer at startup; once it returns {@code false} for a given consumer, that consumer proceeds and is
-   * not gated again. Implementations default to a no-op so subclasses opt in explicitly.
+   * per consumer; once it returns {@code false} for a given consumer, that consumer should proceed and should
+   * not be gated again. Implementations default to a no-op so subclasses opt in explicitly.
    */
   default void setSupplierOfIsIngestionPausedDueToStartUp(BooleanSupplier isIngestionPausedDueToStartUp) {
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/provider/DefaultTableDataManagerProvider.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/provider/DefaultTableDataManagerProvider.java
@@ -75,8 +75,8 @@ public class DefaultTableDataManagerProvider implements TableDataManagerProvider
       SegmentReloadSemaphore segmentReloadSemaphore, ExecutorService segmentReloadRefreshExecutor,
       @Nullable ExecutorService segmentPreloadExecutor,
       @Nullable Cache<Pair<String, String>, SegmentErrorInfo> errorCache,
-      BooleanSupplier isServerReadyToServeQueries, boolean enableAsyncSegmentRefresh,
-      ServerReloadJobStatusCache reloadJobStatusCache) {
+      BooleanSupplier isServerReadyToServeQueries, BooleanSupplier isIngestionPausedDueToStartUp,
+      boolean enableAsyncSegmentRefresh, ServerReloadJobStatusCache reloadJobStatusCache) {
     TableDataManager tableDataManager;
     switch (tableConfig.getTableType()) {
       case OFFLINE:
@@ -94,7 +94,8 @@ public class DefaultTableDataManagerProvider implements TableDataManagerProvider
                   + "configured the segmentstore uri. Configure the server config %s",
               StreamConfigProperties.SERVER_UPLOAD_TO_DEEPSTORE, CommonConstants.Server.CONFIG_OF_SEGMENT_STORE_URI));
         }
-        tableDataManager = new RealtimeTableDataManager(_segmentBuildSemaphore, isServerReadyToServeQueries);
+        tableDataManager = new RealtimeTableDataManager(_segmentBuildSemaphore, isServerReadyToServeQueries,
+            isIngestionPausedDueToStartUp);
         break;
       default:
         throw new IllegalStateException();

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/provider/DefaultTableDataManagerProvider.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/provider/DefaultTableDataManagerProvider.java
@@ -75,7 +75,7 @@ public class DefaultTableDataManagerProvider implements TableDataManagerProvider
       SegmentReloadSemaphore segmentReloadSemaphore, ExecutorService segmentReloadRefreshExecutor,
       @Nullable ExecutorService segmentPreloadExecutor,
       @Nullable Cache<Pair<String, String>, SegmentErrorInfo> errorCache,
-      BooleanSupplier isServerReadyToServeQueries, BooleanSupplier isIngestionPausedDueToStartUp,
+      BooleanSupplier isServerReadyToConsumeData, BooleanSupplier isServerReadyToServeQueries,
       boolean enableAsyncSegmentRefresh, ServerReloadJobStatusCache reloadJobStatusCache) {
     TableDataManager tableDataManager;
     switch (tableConfig.getTableType()) {
@@ -94,8 +94,8 @@ public class DefaultTableDataManagerProvider implements TableDataManagerProvider
                   + "configured the segmentstore uri. Configure the server config %s",
               StreamConfigProperties.SERVER_UPLOAD_TO_DEEPSTORE, CommonConstants.Server.CONFIG_OF_SEGMENT_STORE_URI));
         }
-        tableDataManager = new RealtimeTableDataManager(_segmentBuildSemaphore, isServerReadyToServeQueries,
-            isIngestionPausedDueToStartUp);
+        tableDataManager = new RealtimeTableDataManager(_segmentBuildSemaphore, isServerReadyToConsumeData,
+            isServerReadyToServeQueries);
         break;
       default:
         throw new IllegalStateException();

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/provider/TableDataManagerProvider.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/provider/TableDataManagerProvider.java
@@ -55,6 +55,7 @@ public interface TableDataManagerProvider {
       @Nullable ExecutorService segmentPreloadExecutor,
       @Nullable Cache<Pair<String, String>, SegmentErrorInfo> errorCache,
       BooleanSupplier isServerReadyToServeQueries,
+      BooleanSupplier isIngestionPausedDueToStartUp,
       boolean enableAsyncSegmentRefresh,
       ServerReloadJobStatusCache reloadJobStatusCache);
 
@@ -64,6 +65,6 @@ public interface TableDataManagerProvider {
   @VisibleForTesting
   default TableDataManager getTableDataManager(TableConfig tableConfig, Schema schema) {
     return getTableDataManager(tableConfig, schema, new SegmentReloadSemaphore(1), Executors.newSingleThreadExecutor(),
-        null, null, () -> true, false, new ServerReloadJobStatusCache("testInstance"));
+        null, null, () -> true, () -> false, false, new ServerReloadJobStatusCache("testInstance"));
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/provider/TableDataManagerProvider.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/provider/TableDataManagerProvider.java
@@ -54,28 +54,10 @@ public interface TableDataManagerProvider {
       ExecutorService segmentReloadRefreshExecutor,
       @Nullable ExecutorService segmentPreloadExecutor,
       @Nullable Cache<Pair<String, String>, SegmentErrorInfo> errorCache,
+      BooleanSupplier isServerReadyToConsumeData,
       BooleanSupplier isServerReadyToServeQueries,
-      BooleanSupplier isIngestionPausedDueToStartUp,
       boolean enableAsyncSegmentRefresh,
       ServerReloadJobStatusCache reloadJobStatusCache);
-
-  /**
-   * Backward-compatible overload that does not gate ingestion at startup. Delegates to the full overload with
-   * {@code isIngestionPausedDueToStartUp = () -> false}.
-   */
-  default TableDataManager getTableDataManager(TableConfig tableConfig,
-      Schema schema,
-      SegmentReloadSemaphore segmentRefreshSemaphore,
-      ExecutorService segmentReloadRefreshExecutor,
-      @Nullable ExecutorService segmentPreloadExecutor,
-      @Nullable Cache<Pair<String, String>, SegmentErrorInfo> errorCache,
-      BooleanSupplier isServerReadyToServeQueries,
-      boolean enableAsyncSegmentRefresh,
-      ServerReloadJobStatusCache reloadJobStatusCache) {
-    return getTableDataManager(tableConfig, schema, segmentRefreshSemaphore, segmentReloadRefreshExecutor,
-        segmentPreloadExecutor, errorCache, isServerReadyToServeQueries, () -> false, enableAsyncSegmentRefresh,
-        reloadJobStatusCache);
-  }
 
   /**
    * This util is only used in test code. do not use in prod code.
@@ -83,6 +65,6 @@ public interface TableDataManagerProvider {
   @VisibleForTesting
   default TableDataManager getTableDataManager(TableConfig tableConfig, Schema schema) {
     return getTableDataManager(tableConfig, schema, new SegmentReloadSemaphore(1), Executors.newSingleThreadExecutor(),
-        null, null, () -> true, () -> false, false, new ServerReloadJobStatusCache("testInstance"));
+        null, null, () -> true, () -> true, false, new ServerReloadJobStatusCache("testInstance"));
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/provider/TableDataManagerProvider.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/provider/TableDataManagerProvider.java
@@ -60,6 +60,24 @@ public interface TableDataManagerProvider {
       ServerReloadJobStatusCache reloadJobStatusCache);
 
   /**
+   * Backward-compatible overload that does not gate ingestion at startup. Delegates to the full overload with
+   * {@code isIngestionPausedDueToStartUp = () -> false}.
+   */
+  default TableDataManager getTableDataManager(TableConfig tableConfig,
+      Schema schema,
+      SegmentReloadSemaphore segmentRefreshSemaphore,
+      ExecutorService segmentReloadRefreshExecutor,
+      @Nullable ExecutorService segmentPreloadExecutor,
+      @Nullable Cache<Pair<String, String>, SegmentErrorInfo> errorCache,
+      BooleanSupplier isServerReadyToServeQueries,
+      boolean enableAsyncSegmentRefresh,
+      ServerReloadJobStatusCache reloadJobStatusCache) {
+    return getTableDataManager(tableConfig, schema, segmentRefreshSemaphore, segmentReloadRefreshExecutor,
+        segmentPreloadExecutor, errorCache, isServerReadyToServeQueries, () -> false, enableAsyncSegmentRefresh,
+        reloadJobStatusCache);
+  }
+
+  /**
    * This util is only used in test code. do not use in prod code.
    */
   @VisibleForTesting

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -138,6 +138,7 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
   protected Cache<String, StreamMetadataProvider> _streamMetadataProviderCache;
 
   private final BooleanSupplier _isServerReadyToServeQueries;
+  private final BooleanSupplier _isIngestionPausedDueToStartUp;
 
   // Object to track ingestion delay for all partitions
   private IngestionDelayTracker _ingestionDelayTracker;
@@ -151,8 +152,19 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
   }
 
   public RealtimeTableDataManager(Semaphore segmentBuildSemaphore, BooleanSupplier isServerReadyToServeQueries) {
+    this(segmentBuildSemaphore, isServerReadyToServeQueries, () -> false);
+  }
+
+  /**
+   * @param isIngestionPausedDueToStartUp returns {@code true} when consuming-segment ingestion should be held off
+   *     (e.g. while the server is still draining startup-time work). Each consuming segment checks this gate at the
+   *     entry of its consumer thread; once the gate clears, it is not consulted again for that segment.
+   */
+  public RealtimeTableDataManager(Semaphore segmentBuildSemaphore, BooleanSupplier isServerReadyToServeQueries,
+      BooleanSupplier isIngestionPausedDueToStartUp) {
     _segmentBuildSemaphore = segmentBuildSemaphore;
     _isServerReadyToServeQueries = isServerReadyToServeQueries;
+    _isIngestionPausedDueToStartUp = isIngestionPausedDueToStartUp;
   }
 
   @Override
@@ -221,8 +233,9 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
     _streamMetadataProviderCache = getStreamMetadataProviderCache();
 
     // For dedup and partial-upsert, need to wait for all segments loaded before starting consuming data
+    BooleanSupplier readyForDedupOrPartialUpsert;
     if (isDedupEnabled() || isPartialUpsertEnabled()) {
-      _isTableReadyToConsumeData = new BooleanSupplier() {
+      readyForDedupOrPartialUpsert = new BooleanSupplier() {
         volatile boolean _allSegmentsLoaded;
         long _lastCheckTimeMs;
 
@@ -247,8 +260,10 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
         }
       };
     } else {
-      _isTableReadyToConsumeData = () -> true;
+      readyForDedupOrPartialUpsert = () -> true;
     }
+    _isTableReadyToConsumeData = () -> readyForDedupOrPartialUpsert.getAsBoolean()
+        && !_isIngestionPausedDueToStartUp.getAsBoolean();
   }
 
   @VisibleForTesting

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -137,8 +137,8 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
 
   protected Cache<String, StreamMetadataProvider> _streamMetadataProviderCache;
 
+  private final BooleanSupplier _isServerReadyToConsumeData;
   private final BooleanSupplier _isServerReadyToServeQueries;
-  private final BooleanSupplier _isIngestionPausedDueToStartUp;
 
   // Object to track ingestion delay for all partitions
   private IngestionDelayTracker _ingestionDelayTracker;
@@ -152,19 +152,19 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
   }
 
   public RealtimeTableDataManager(Semaphore segmentBuildSemaphore, BooleanSupplier isServerReadyToServeQueries) {
-    this(segmentBuildSemaphore, isServerReadyToServeQueries, () -> false);
+    this(segmentBuildSemaphore, () -> true, isServerReadyToServeQueries);
   }
 
   /**
-   * @param isIngestionPausedDueToStartUp returns {@code true} when consuming-segment ingestion should be held off
+   * @param isServerReadyToConsumeData returns {@code false} when consuming-segment ingestion should be held off
    *     (e.g. while the server is still draining startup-time work). Each consuming segment checks this gate at the
    *     entry of its consumer thread; once the gate clears, it is not consulted again for that segment.
    */
-  public RealtimeTableDataManager(Semaphore segmentBuildSemaphore, BooleanSupplier isServerReadyToServeQueries,
-      BooleanSupplier isIngestionPausedDueToStartUp) {
+  public RealtimeTableDataManager(Semaphore segmentBuildSemaphore, BooleanSupplier isServerReadyToConsumeData,
+      BooleanSupplier isServerReadyToServeQueries) {
     _segmentBuildSemaphore = segmentBuildSemaphore;
+    _isServerReadyToConsumeData = isServerReadyToConsumeData;
     _isServerReadyToServeQueries = isServerReadyToServeQueries;
-    _isIngestionPausedDueToStartUp = isIngestionPausedDueToStartUp;
   }
 
   @Override
@@ -263,7 +263,7 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
       readyForDedupOrPartialUpsert = () -> true;
     }
     _isTableReadyToConsumeData = () -> readyForDedupOrPartialUpsert.getAsBoolean()
-        && !_isIngestionPausedDueToStartUp.getAsBoolean();
+        && _isServerReadyToConsumeData.getAsBoolean();
   }
 
   @VisibleForTesting

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/realtime/utils/FailureInjectingTableDataManagerProvider.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/realtime/utils/FailureInjectingTableDataManagerProvider.java
@@ -83,6 +83,7 @@ public class FailureInjectingTableDataManagerProvider implements TableDataManage
       @Nullable ExecutorService segmentPreloadExecutor,
       @Nullable Cache<Pair<String, String>, SegmentErrorInfo> errorCache,
       BooleanSupplier isServerReadyToServeQueries,
+      BooleanSupplier isIngestionPausedDueToStartUp,
       boolean enableAsyncSegmentRefresh,
       ServerReloadJobStatusCache reloadJobStatusCache) {
     TableDataManager tableDataManager;

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/realtime/utils/FailureInjectingTableDataManagerProvider.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/realtime/utils/FailureInjectingTableDataManagerProvider.java
@@ -82,8 +82,8 @@ public class FailureInjectingTableDataManagerProvider implements TableDataManage
       ExecutorService segmentReloadRefreshExecutor,
       @Nullable ExecutorService segmentPreloadExecutor,
       @Nullable Cache<Pair<String, String>, SegmentErrorInfo> errorCache,
+      BooleanSupplier isServerReadyToConsumeData,
       BooleanSupplier isServerReadyToServeQueries,
-      BooleanSupplier isIngestionPausedDueToStartUp,
       boolean enableAsyncSegmentRefresh,
       ServerReloadJobStatusCache reloadJobStatusCache) {
     TableDataManager tableDataManager;

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
@@ -767,8 +767,8 @@ public abstract class BaseServerStarter implements ServiceStartable {
             _threadAccountant, sendStatsPredicate, keepPipelineBreakerStatsPredicate, _reloadJobStatusCache);
 
     InstanceDataManager instanceDataManager = _serverInstance.getInstanceDataManager();
-    instanceDataManager.setSupplierOfIsServerReadyToServeQueries(() -> _isServerReadyToServeQueries);
-    instanceDataManager.setSupplierOfIsIngestionPausedDueToStartUp(this::isIngestionPausedDueToStartUp);
+    instanceDataManager.setSupplierOfIsServerReadyToConsumeData(this::isServerReadyToConsumeData);
+    instanceDataManager.setSupplierOfIsServerReadyToServeQueries(this::isServerReadyToServeQueries);
 
     // Enable Server level realtime ingestion rate limier
     RealtimeConsumptionRateManager.getInstance().createServerRateLimiter(_serverConf, _serverMetrics);
@@ -947,8 +947,12 @@ public abstract class BaseServerStarter implements ServiceStartable {
     NettyInspector.registerMetrics(_serverMetrics);
   }
 
-  protected boolean isIngestionPausedDueToStartUp() {
-    return false;
+  protected boolean isServerReadyToConsumeData() {
+    return true;
+  }
+
+  protected boolean isServerReadyToServeQueries() {
+    return _isServerReadyToServeQueries;
   }
 
   protected SegmentOperationsThrottler createMultiColumnIndexPreprocessThrottler() {

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
@@ -768,6 +768,7 @@ public abstract class BaseServerStarter implements ServiceStartable {
 
     InstanceDataManager instanceDataManager = _serverInstance.getInstanceDataManager();
     instanceDataManager.setSupplierOfIsServerReadyToServeQueries(() -> _isServerReadyToServeQueries);
+    instanceDataManager.setSupplierOfIsIngestionPausedDueToStartUp(this::isIngestionPausedDueToStartUp);
 
     // Enable Server level realtime ingestion rate limier
     RealtimeConsumptionRateManager.getInstance().createServerRateLimiter(_serverConf, _serverMetrics);
@@ -944,6 +945,10 @@ public abstract class BaseServerStarter implements ServiceStartable {
     }
 
     NettyInspector.registerMetrics(_serverMetrics);
+  }
+
+  protected boolean isIngestionPausedDueToStartUp() {
+    return false;
   }
 
   protected SegmentOperationsThrottler createMultiColumnIndexPreprocessThrottler() {

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
@@ -105,8 +105,8 @@ public class HelixInstanceDataManager implements InstanceDataManager {
   private HelixManager _helixManager;
   private ZkHelixPropertyStore<ZNRecord> _propertyStore;
   private SegmentUploader _segmentUploader;
+  private BooleanSupplier _isServerReadyToConsumeData = () -> false;
   private BooleanSupplier _isServerReadyToServeQueries = () -> false;
-  private BooleanSupplier _isIngestionPausedDueToStartUp = () -> false;
 
   // Fixed size LRU cache for storing last N errors on the instance.
   // Key is TableNameWithType-SegmentName pair.
@@ -124,13 +124,13 @@ public class HelixInstanceDataManager implements InstanceDataManager {
   private ExecutorService _segmentPreloadExecutor;
 
   @Override
-  public void setSupplierOfIsServerReadyToServeQueries(BooleanSupplier isServingQueries) {
-    _isServerReadyToServeQueries = isServingQueries;
+  public void setSupplierOfIsServerReadyToConsumeData(BooleanSupplier isServerReadyToConsumeData) {
+    _isServerReadyToConsumeData = isServerReadyToConsumeData;
   }
 
   @Override
-  public void setSupplierOfIsIngestionPausedDueToStartUp(BooleanSupplier isIngestionPausedDueToStartUp) {
-    _isIngestionPausedDueToStartUp = isIngestionPausedDueToStartUp;
+  public void setSupplierOfIsServerReadyToServeQueries(BooleanSupplier isServingQueries) {
+    _isServerReadyToServeQueries = isServingQueries;
   }
 
   @Override
@@ -348,8 +348,8 @@ public class HelixInstanceDataManager implements InstanceDataManager {
     TimestampIndexUtils.applyTimestampIndex(tableConfig, schema);
     TableDataManager tableDataManager =
         _tableDataManagerProvider.getTableDataManager(tableConfig, schema, _segmentReloadSemaphore,
-            _segmentReloadRefreshExecutor, _segmentPreloadExecutor, _errorCache, _isServerReadyToServeQueries,
-            _isIngestionPausedDueToStartUp, _enableAsyncSegmentRefresh, _reloadJobStatusCache);
+            _segmentReloadRefreshExecutor, _segmentPreloadExecutor, _errorCache, _isServerReadyToConsumeData,
+            _isServerReadyToServeQueries, _enableAsyncSegmentRefresh, _reloadJobStatusCache);
     tableDataManager.start();
     LOGGER.info("Created table data manager for table: {}", tableNameWithType);
     return tableDataManager;

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
@@ -106,6 +106,7 @@ public class HelixInstanceDataManager implements InstanceDataManager {
   private ZkHelixPropertyStore<ZNRecord> _propertyStore;
   private SegmentUploader _segmentUploader;
   private BooleanSupplier _isServerReadyToServeQueries = () -> false;
+  private BooleanSupplier _isIngestionPausedDueToStartUp = () -> false;
 
   // Fixed size LRU cache for storing last N errors on the instance.
   // Key is TableNameWithType-SegmentName pair.
@@ -125,6 +126,11 @@ public class HelixInstanceDataManager implements InstanceDataManager {
   @Override
   public void setSupplierOfIsServerReadyToServeQueries(BooleanSupplier isServingQueries) {
     _isServerReadyToServeQueries = isServingQueries;
+  }
+
+  @Override
+  public void setSupplierOfIsIngestionPausedDueToStartUp(BooleanSupplier isIngestionPausedDueToStartUp) {
+    _isIngestionPausedDueToStartUp = isIngestionPausedDueToStartUp;
   }
 
   @Override
@@ -343,7 +349,7 @@ public class HelixInstanceDataManager implements InstanceDataManager {
     TableDataManager tableDataManager =
         _tableDataManagerProvider.getTableDataManager(tableConfig, schema, _segmentReloadSemaphore,
             _segmentReloadRefreshExecutor, _segmentPreloadExecutor, _errorCache, _isServerReadyToServeQueries,
-            _enableAsyncSegmentRefresh, _reloadJobStatusCache);
+            _isIngestionPausedDueToStartUp, _enableAsyncSegmentRefresh, _reloadJobStatusCache);
     tableDataManager.start();
     LOGGER.info("Created table data manager for table: {}", tableNameWithType);
     return tableDataManager;


### PR DESCRIPTION
## Description
Depends on use cases, server starter might need to pause ingestion during start up for a better performance.

## Changes

### New boolean supplier for ingestion readiness
Add a new boolean supplier `boolean isIngestionPausedDueToStartUp()` in `BaseServerStarter` that will be hooked into `TableDataManagerProvider` to construct `RealtimeTableDataManager`. This new boolean supplier, and the existing boolean supplier in `RealtimeTableDataManager` that signals whether it's ready to ingest on dedup or paritial upsert table,  they together will determine if the ingestion loop should start in `RealtimeSegmentDataManager`