### PR TITLE
[pinot-segment-spi] Preserve user new-format FieldConfig.indexes JsonNode through migration

### DIFF
--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/ConvertToNewFormatPreservesSlimTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/ConvertToNewFormatPreservesSlimTest.java
@@ -120,7 +120,7 @@ public class ConvertToNewFormatPreservesSlimTest {
   public void newFormatExplicitDisabledTruePreserved() {
     // User opts out of forward by setting disabled=true. Migration must keep that exact shape,
     // not overwrite with the typed POJO's disabled=false default — silent re-enable would be a
-    // correctness bug.
+    // correctness bug. Non-default typed POJO → gap-fill branch fires.
     ObjectNode slim = MAPPER.createObjectNode();
     slim.putObject("forward").put("disabled", true);
     TableConfig tc = withFieldConfig("c1", EncodingType.RAW, slim);
@@ -130,6 +130,25 @@ public class ConvertToNewFormatPreservesSlimTest {
     JsonNode forward = indexesOf(migrated, "c1").get("forward");
     assertEquals(forward.size(), 1);
     assertTrue(forward.get("disabled").asBoolean(), "Explicit disabled=true preserved");
+  }
+
+  @Test
+  public void newFormatExplicitNullValueRejectedByIndexTypeValidator() {
+    // Pin the actual handling of {"forward": null}: per-index-type validators (here
+    // ForwardIndexType.createDeserializer's lambda) reject NullNode as an invalid forward index
+    // config and raise IllegalStateException. The gap-fill loop is never reached. Users wanting
+    // "enabled with defaults" must use {} (empty object), not null.
+    ObjectNode slim = MAPPER.createObjectNode();
+    slim.set("forward", com.fasterxml.jackson.databind.node.NullNode.getInstance());
+    TableConfig tc = withFieldConfig("c1", EncodingType.DICTIONARY, slim);
+
+    try {
+      TableConfigUtils.createTableConfigFromOldFormat(tc, schemaWith("c1"));
+      org.testng.Assert.fail("Expected IllegalStateException from ForwardIndexType validator");
+    } catch (IllegalStateException expected) {
+      assertTrue(expected.getMessage() != null && expected.getMessage().contains("forward index"),
+          "Expected forward-index validation error; got: " + expected.getMessage());
+    }
   }
 
   @Test

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/ConvertToNewFormatPreservesSlimTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/ConvertToNewFormatPreservesSlimTest.java
@@ -117,6 +117,22 @@ public class ConvertToNewFormatPreservesSlimTest {
   }
 
   @Test
+  public void newFormatExplicitDisabledTruePreserved() {
+    // User opts out of forward by setting disabled=true. Migration must keep that exact shape,
+    // not overwrite with the typed POJO's disabled=false default — silent re-enable would be a
+    // correctness bug.
+    ObjectNode slim = MAPPER.createObjectNode();
+    slim.putObject("forward").put("disabled", true);
+    TableConfig tc = withFieldConfig("c1", EncodingType.RAW, slim);
+
+    TableConfig migrated = TableConfigUtils.createTableConfigFromOldFormat(tc, schemaWith("c1"));
+
+    JsonNode forward = indexesOf(migrated, "c1").get("forward");
+    assertEquals(forward.size(), 1);
+    assertTrue(forward.get("disabled").asBoolean(), "Explicit disabled=true preserved");
+  }
+
+  @Test
   public void newFormatEmptyObjectPreserved() {
     // {"inverted": {}} means "enabled with no settings" — must remain an empty object, not be
     // replaced with the typed POJO default.

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/ConvertToNewFormatPreservesSlimTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/ConvertToNewFormatPreservesSlimTest.java
@@ -1,0 +1,441 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.utils;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.pinot.segment.spi.index.MergedColumnConfigDeserializer.ConfigDeclaredTwiceException;
+import org.apache.pinot.spi.config.table.FieldConfig;
+import org.apache.pinot.spi.config.table.FieldConfig.EncodingType;
+import org.apache.pinot.spi.config.table.IndexingConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+
+
+/**
+ * Pins the gap-filling contract for {@link TableConfigUtils#createTableConfigFromOldFormat} /
+ * {@code AbstractIndexType#convertToNewFormat}: <b>migration only writes
+ * {@code FieldConfig.indexes[prettyName]} when the column does not already carry a JsonNode for
+ * that index type</b>. Columns already in new format keep their slim shape verbatim; legacy-only
+ * inputs are translated as before; both-format coexistence resolves "new format wins".
+ *
+ * <p>This contract is load-bearing for downstream APIs (e.g. StarTree Preview / InferIndex) that
+ * round-trip user-supplied {@code FieldConfig.indexes} JsonNodes through the migration step and
+ * back into a response: without the gap-filling rule the user's slim shape gets fattened on
+ * every round-trip because the typed-POJO bean serializer always emits all keys.
+ */
+public class ConvertToNewFormatPreservesSlimTest {
+
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
+  // ---- Pure new-format input survives byte-for-byte ----
+
+  @Test
+  public void newFormatForwardSlimPreservedVerbatim() {
+    ObjectNode slim = MAPPER.createObjectNode();
+    slim.putObject("forward").put("compressionCodec", "SNAPPY");
+    TableConfig tc = withFieldConfig("c1", EncodingType.RAW, slim);
+
+    TableConfig migrated = TableConfigUtils.createTableConfigFromOldFormat(tc, schemaWith("c1"));
+
+    JsonNode forward = indexesOf(migrated, "c1").get("forward");
+    assertNotNull(forward);
+    assertEquals(forward.size(), 1, "Single user key survives verbatim. Got: " + forward);
+    assertEquals(forward.get("compressionCodec").asText(), "SNAPPY");
+  }
+
+  @Test
+  public void newFormatBloomSlimPreservedVerbatim() {
+    ObjectNode slim = MAPPER.createObjectNode();
+    slim.putObject("bloom").put("fpp", 0.1);
+    TableConfig tc = withFieldConfig("c1", EncodingType.DICTIONARY, slim);
+
+    TableConfig migrated = TableConfigUtils.createTableConfigFromOldFormat(tc, schemaWith("c1"));
+
+    JsonNode bloom = indexesOf(migrated, "c1").get("bloom");
+    assertNotNull(bloom);
+    assertEquals(bloom.size(), 1);
+    assertEquals(bloom.get("fpp").asDouble(), 0.1);
+  }
+
+  @Test
+  public void newFormatExplicitDefaultValuePreserved() {
+    // User explicitly sets a value that happens to equal today's default. Migration must keep
+    // the explicit key so a future default flip cannot silently swallow user intent.
+    ObjectNode slim = MAPPER.createObjectNode();
+    slim.putObject("forward").put("rawIndexWriterVersion", 4);
+    TableConfig tc = withFieldConfig("c1", EncodingType.RAW, slim);
+
+    TableConfig migrated = TableConfigUtils.createTableConfigFromOldFormat(tc, schemaWith("c1"));
+
+    JsonNode forward = indexesOf(migrated, "c1").get("forward");
+    assertEquals(forward.size(), 1);
+    assertEquals(forward.get("rawIndexWriterVersion").asInt(), 4);
+  }
+
+  @Test
+  public void newFormatExplicitFalsePreserved() {
+    ObjectNode slim = MAPPER.createObjectNode();
+    slim.putObject("forward").put("deriveNumDocsPerChunk", false);
+    TableConfig tc = withFieldConfig("c1", EncodingType.RAW, slim);
+
+    TableConfig migrated = TableConfigUtils.createTableConfigFromOldFormat(tc, schemaWith("c1"));
+
+    JsonNode forward = indexesOf(migrated, "c1").get("forward");
+    assertEquals(forward.size(), 1);
+    assertFalse(forward.get("deriveNumDocsPerChunk").asBoolean());
+  }
+
+  @Test
+  public void newFormatEmptyObjectPreserved() {
+    // {"inverted": {}} means "enabled with no settings" — must remain an empty object, not be
+    // replaced with the typed POJO default.
+    ObjectNode slim = MAPPER.createObjectNode();
+    slim.putObject("inverted");
+    TableConfig tc = withFieldConfig("c1", EncodingType.DICTIONARY, slim);
+
+    TableConfig migrated = TableConfigUtils.createTableConfigFromOldFormat(tc, schemaWith("c1"));
+
+    JsonNode inverted = indexesOf(migrated, "c1").get("inverted");
+    assertNotNull(inverted);
+    assertTrue(inverted.isObject());
+    assertEquals(inverted.size(), 0);
+  }
+
+  // ---- Pure legacy input still translates to new format (back-compat) ----
+
+  @Test
+  public void legacyBloomFilterColumnsTranslatedToNewFormat() {
+    TableConfig tc = baseTc();
+    tc.getIndexingConfig().setBloomFilterColumns(new ArrayList<>(Arrays.asList("c1")));
+
+    TableConfig migrated = TableConfigUtils.createTableConfigFromOldFormat(tc, schemaWith("c1"));
+
+    JsonNode indexes = indexesOf(migrated, "c1");
+    assertNotNull(indexes.get("bloom"), "Legacy bloomFilterColumns translates to new format");
+  }
+
+  @Test
+  public void legacyNoDictionaryColumnsTranslatedToRawEncoding() {
+    TableConfig tc = baseTc();
+    tc.getIndexingConfig().setNoDictionaryColumns(new ArrayList<>(Arrays.asList("c1")));
+
+    TableConfig migrated = TableConfigUtils.createTableConfigFromOldFormat(tc, schemaWith("c1"));
+
+    FieldConfig fc = findFieldConfig(migrated, "c1");
+    assertEquals(fc.getEncodingType(), EncodingType.RAW);
+  }
+
+  // ---- Both-formats coexistence ----
+
+  @Test
+  public void bothFormatsDifferentIndexTypesCoexist() {
+    // User: slim new-format bloom on c1. Legacy: noDictionaryColumns=[c1] (i.e. RAW encoding).
+    // Different index types in different surfaces — both translate independently, each obeying the
+    // gap-fill rule for its own type.
+    ObjectNode slim = MAPPER.createObjectNode();
+    slim.putObject("bloom").put("fpp", 0.1);
+    TableConfig tc = withFieldConfig("c1", EncodingType.DICTIONARY, slim);
+    tc.getIndexingConfig().setNoDictionaryColumns(new ArrayList<>(Arrays.asList("c1")));
+
+    TableConfig migrated = TableConfigUtils.createTableConfigFromOldFormat(tc, schemaWith("c1"));
+
+    // bloom: user slim shape preserved verbatim.
+    JsonNode bloom = indexesOf(migrated, "c1").get("bloom");
+    assertEquals(bloom.size(), 1, "User slim shape preserved. Got: " + bloom);
+    assertEquals(bloom.get("fpp").asDouble(), 0.1);
+    // encoding flipped to RAW by legacy translation.
+    assertEquals(findFieldConfig(migrated, "c1").getEncodingType(), EncodingType.RAW);
+  }
+
+  @Test
+  public void bothFormatsSameIndexTypeThrowsConfigDeclaredTwice() {
+    // User: new-format bloom on c1. Legacy: bloomFilterColumns=[c1]. Same column + same index type
+    // declared in both legacy and new format → existing deserializer raises ConfigDeclaredTwice.
+    // Pin this behavior — gap-fill must not paper over the conflict.
+    ObjectNode slim = MAPPER.createObjectNode();
+    slim.putObject("bloom").put("fpp", 0.1);
+    TableConfig tc = withFieldConfig("c1", EncodingType.DICTIONARY, slim);
+    tc.getIndexingConfig().setBloomFilterColumns(new ArrayList<>(Arrays.asList("c1")));
+
+    expectThrows(ConfigDeclaredTwiceException.class,
+        () -> TableConfigUtils.createTableConfigFromOldFormat(tc, schemaWith("c1")));
+  }
+
+  // ---- Idempotency: running migration twice == running it once ----
+
+  @Test
+  public void migrationIsIdempotentOnNewFormatInput() {
+    ObjectNode slim = MAPPER.createObjectNode();
+    slim.putObject("forward").put("compressionCodec", "SNAPPY");
+    TableConfig tc = withFieldConfig("c1", EncodingType.RAW, slim);
+
+    TableConfig once = TableConfigUtils.createTableConfigFromOldFormat(tc, schemaWith("c1"));
+    TableConfig twice = TableConfigUtils.createTableConfigFromOldFormat(once, schemaWith("c1"));
+
+    assertEquals(
+        indexesOf(twice, "c1").toString(),
+        indexesOf(once, "c1").toString(),
+        "Running migration twice produces the same FieldConfig.indexes as once");
+  }
+
+  @Test
+  public void migrationIsIdempotentOnLegacyInput() {
+    TableConfig tc = baseTc();
+    tc.getIndexingConfig().setBloomFilterColumns(new ArrayList<>(Arrays.asList("c1")));
+
+    TableConfig once = TableConfigUtils.createTableConfigFromOldFormat(tc, schemaWith("c1"));
+    TableConfig twice = TableConfigUtils.createTableConfigFromOldFormat(once, schemaWith("c1"));
+
+    assertEquals(
+        indexesOf(twice, "c1").toString(),
+        indexesOf(once, "c1").toString());
+  }
+
+  // ---- Multi-column independence ----
+
+  @Test
+  public void mixedColumnsEachShapeIndependent() {
+    // c1: slim new format. c2: legacy only. c3: column not in field config (added by legacy).
+    ObjectNode slim = MAPPER.createObjectNode();
+    slim.putObject("forward").put("compressionCodec", "SNAPPY");
+    TableConfig tc = baseTc();
+    List<FieldConfig> fcl = new ArrayList<>();
+    fcl.add(new FieldConfig.Builder("c1").withEncodingType(EncodingType.RAW).withIndexes(slim).build());
+    tc.setFieldConfigList(fcl);
+    tc.getIndexingConfig().setBloomFilterColumns(new ArrayList<>(Arrays.asList("c2", "c3")));
+
+    TableConfig migrated = TableConfigUtils.createTableConfigFromOldFormat(tc, schemaWith("c1", "c2", "c3"));
+
+    // c1: slim survives.
+    JsonNode c1Forward = indexesOf(migrated, "c1").get("forward");
+    assertEquals(c1Forward.size(), 1);
+    assertEquals(c1Forward.get("compressionCodec").asText(), "SNAPPY");
+
+    // c2 + c3: legacy translated to new format.
+    assertNotNull(indexesOf(migrated, "c2").get("bloom"));
+    assertNotNull(indexesOf(migrated, "c3").get("bloom"));
+  }
+
+  // ---- Multiple index types on one column ----
+
+  @Test
+  public void multipleIndexTypesOneColumnEachSlimShapePreserved() {
+    ObjectNode slim = MAPPER.createObjectNode();
+    slim.putObject("forward").put("compressionCodec", "LZ4");
+    slim.putObject("bloom").put("fpp", 0.05);
+    slim.putObject("inverted");
+    TableConfig tc = withFieldConfig("c1", EncodingType.RAW, slim);
+
+    TableConfig migrated = TableConfigUtils.createTableConfigFromOldFormat(tc, schemaWith("c1"));
+
+    JsonNode indexes = indexesOf(migrated, "c1");
+    assertEquals(indexes.get("forward").size(), 1);
+    assertEquals(indexes.get("forward").get("compressionCodec").asText(), "LZ4");
+    assertEquals(indexes.get("bloom").size(), 1);
+    assertEquals(indexes.get("bloom").get("fpp").asDouble(), 0.05);
+    assertEquals(indexes.get("inverted").size(), 0);
+  }
+
+  // ---- Cross-type inference still fires (dictionary auto-create for inverted, etc.) ----
+
+  @Test
+  public void invertedIndexLegacyOnlyTranslatedWithoutFattening() {
+    // Pure legacy invertedIndexColumns. No FieldConfig.indexes yet → migration writes the inverted
+    // entry. Verbose form is acceptable here because the user did not supply a slim shape.
+    TableConfig tc = baseTc();
+    tc.getIndexingConfig().setInvertedIndexColumns(new ArrayList<>(Arrays.asList("c1")));
+
+    TableConfig migrated = TableConfigUtils.createTableConfigFromOldFormat(tc, schemaWith("c1"));
+
+    JsonNode inverted = indexesOf(migrated, "c1").get("inverted");
+    assertNotNull(inverted, "Legacy invertedIndexColumns translates to new format");
+  }
+
+  // ---- Legacy cleanup ----
+
+  @Test
+  public void legacyFieldsClearedAfterMigration() {
+    TableConfig tc = baseTc();
+    tc.getIndexingConfig().setBloomFilterColumns(new ArrayList<>(Arrays.asList("c1")));
+    tc.getIndexingConfig().setNoDictionaryColumns(new ArrayList<>(Arrays.asList("c2")));
+
+    TableConfig migrated = TableConfigUtils.createTableConfigFromOldFormat(tc, schemaWith("c1", "c2"));
+    IndexingConfig ic = migrated.getIndexingConfig();
+
+    assertTrue(ic.getBloomFilterColumns() == null || ic.getBloomFilterColumns().isEmpty(),
+        "Legacy bloomFilterColumns cleared post-migration");
+    assertTrue(ic.getNoDictionaryColumns() == null || ic.getNoDictionaryColumns().isEmpty(),
+        "Legacy noDictionaryColumns cleared post-migration");
+  }
+
+  @Test
+  public void legacyCleanupRunsEvenWhenUserSlimShapePreserved() {
+    // User has slim new-format bloom on c1 (new format) AND legacy invertedIndexColumns=[c1]
+    // (different index type, so no ConfigDeclaredTwice). Migration preserves user slim bloom and
+    // also translates legacy inverted → new format. Legacy cleanup must still drop
+    // invertedIndexColumns from indexingConfig so ZK doesn't carry both representations.
+    ObjectNode slim = MAPPER.createObjectNode();
+    slim.putObject("bloom").put("fpp", 0.1);
+    TableConfig tc = withFieldConfig("c1", EncodingType.DICTIONARY, slim);
+    tc.getIndexingConfig().setInvertedIndexColumns(new ArrayList<>(Arrays.asList("c1")));
+
+    TableConfig migrated = TableConfigUtils.createTableConfigFromOldFormat(tc, schemaWith("c1"));
+
+    assertTrue(
+        migrated.getIndexingConfig().getInvertedIndexColumns() == null
+            || migrated.getIndexingConfig().getInvertedIndexColumns().isEmpty(),
+        "Legacy invertedIndexColumns dropped post-migration");
+    assertEquals(indexesOf(migrated, "c1").get("bloom").size(), 1,
+        "User slim bloom shape preserved untouched");
+    assertNotNull(indexesOf(migrated, "c1").get("inverted"),
+        "Legacy inverted translated into new format");
+  }
+
+  // ---- Default-config skip path ----
+
+  @Test
+  public void defaultConfigInNewFormatKeptVerbatim() {
+    // User supplies a config that equals the type's default. Today's code: skipped (continue).
+    // Behavior preserved with the gap-fill change.
+    ObjectNode slim = MAPPER.createObjectNode();
+    // disabled=false matches IndexConfig default → typed value equals default → skipped.
+    slim.putObject("inverted").put("disabled", false);
+    TableConfig tc = withFieldConfig("c1", EncodingType.DICTIONARY, slim);
+
+    TableConfig migrated = TableConfigUtils.createTableConfigFromOldFormat(tc, schemaWith("c1"));
+
+    // The original JsonNode is preserved verbatim because we never wrote (skipped).
+    JsonNode inverted = indexesOf(migrated, "c1").get("inverted");
+    assertNotNull(inverted);
+    assertTrue(inverted.has("disabled"));
+    assertFalse(inverted.get("disabled").asBoolean(), "User's explicit disabled=false preserved");
+  }
+
+  // ---- Cross-type coverage: gap-fill applies uniformly to every AbstractIndexType subclass ----
+
+  @Test
+  public void newFormatRangeSlimPreservedVerbatim() {
+    ObjectNode slim = MAPPER.createObjectNode();
+    slim.putObject("range").put("version", 1);
+    TableConfig tc = withFieldConfig("c1", EncodingType.DICTIONARY, slim);
+
+    TableConfig migrated = TableConfigUtils.createTableConfigFromOldFormat(tc, schemaWith("c1"));
+
+    JsonNode range = indexesOf(migrated, "c1").get("range");
+    assertEquals(range.size(), 1, "Range slim preserved. Got: " + range);
+    assertEquals(range.get("version").asInt(), 1);
+  }
+
+  @Test
+  public void newFormatTextSlimPreservedVerbatim() {
+    ObjectNode slim = MAPPER.createObjectNode();
+    slim.putObject("text").put("luceneAnalyzerClass", "org.example.MyAnalyzer");
+    TableConfig tc = withFieldConfig("c1", EncodingType.DICTIONARY, slim);
+
+    TableConfig migrated = TableConfigUtils.createTableConfigFromOldFormat(tc, schemaWith("c1"));
+
+    JsonNode text = indexesOf(migrated, "c1").get("text");
+    assertEquals(text.size(), 1, "Text slim preserved. Got: " + text);
+    assertEquals(text.get("luceneAnalyzerClass").asText(), "org.example.MyAnalyzer");
+  }
+
+  @Test
+  public void newFormatJsonSlimPreservedVerbatim() {
+    ObjectNode slim = MAPPER.createObjectNode();
+    slim.putObject("json").put("maxLevels", 5);
+    TableConfig tc = withFieldConfig("c1", EncodingType.DICTIONARY, slim);
+
+    TableConfig migrated = TableConfigUtils.createTableConfigFromOldFormat(tc, schemaWith("c1"));
+
+    JsonNode json = indexesOf(migrated, "c1").get("json");
+    assertEquals(json.size(), 1, "Json slim preserved. Got: " + json);
+    assertEquals(json.get("maxLevels").asInt(), 5);
+  }
+
+  // ---- End-to-end Jackson round-trip: slim shape survives serialize → deserialize ----
+
+  @Test
+  public void slimShapeSurvivesJacksonRoundTrip() throws Exception {
+    // Production failure mode: user POSTs slim JSON → service deserializes → migration → service
+    // re-serializes the result → response gets fattened with bean-serializer defaults. Pin the
+    // full round-trip so a regression in FieldConfig serialization or IndexConfig.toJsonNode
+    // would break this test, not just the in-memory checks above.
+    ObjectNode slim = MAPPER.createObjectNode();
+    slim.putObject("forward").put("compressionCodec", "SNAPPY");
+    TableConfig tc = withFieldConfig("c1", EncodingType.RAW, slim);
+
+    TableConfig migrated = TableConfigUtils.createTableConfigFromOldFormat(tc, schemaWith("c1"));
+    String serialized = MAPPER.writeValueAsString(migrated);
+    TableConfig deserialized = MAPPER.readValue(serialized, TableConfig.class);
+
+    JsonNode forward = indexesOf(deserialized, "c1").get("forward");
+    assertNotNull(forward, "forward survives Jackson round-trip");
+    assertEquals(forward.size(), 1,
+        "Slim shape survives serialize → deserialize. Got: " + forward);
+    assertEquals(forward.get("compressionCodec").asText(), "SNAPPY");
+  }
+
+  // ---- Helpers ----
+
+  private static TableConfig baseTc() {
+    return new TableConfigBuilder(TableType.OFFLINE).setTableName("t").build();
+  }
+
+  private static TableConfig withFieldConfig(String name, EncodingType encoding, JsonNode indexes) {
+    TableConfig tc = baseTc();
+    List<FieldConfig> fcl = new ArrayList<>();
+    fcl.add(new FieldConfig.Builder(name).withEncodingType(encoding).withIndexes(indexes).build());
+    tc.setFieldConfigList(fcl);
+    return tc;
+  }
+
+  private static Schema schemaWith(String... cols) {
+    Schema.SchemaBuilder b = new Schema.SchemaBuilder().setSchemaName("t");
+    for (String c : cols) {
+      b.addSingleValueDimension(c, DataType.STRING);
+    }
+    return b.build();
+  }
+
+  private static FieldConfig findFieldConfig(TableConfig tc, String col) {
+    return tc.getFieldConfigList().stream()
+        .filter(fc -> fc.getName().equals(col))
+        .findFirst()
+        .orElseThrow();
+  }
+
+  private static JsonNode indexesOf(TableConfig tc, String col) {
+    return findFieldConfig(tc, col).getIndexes();
+  }
+}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/ConvertToNewFormatPreservesSlimTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/ConvertToNewFormatPreservesSlimTest.java
@@ -20,6 +20,7 @@ package org.apache.pinot.segment.local.utils;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -40,6 +41,7 @@ import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 import static org.testng.Assert.expectThrows;
+import static org.testng.Assert.fail;
 
 
 /**
@@ -139,12 +141,12 @@ public class ConvertToNewFormatPreservesSlimTest {
     // config and raise IllegalStateException. The gap-fill loop is never reached. Users wanting
     // "enabled with defaults" must use {} (empty object), not null.
     ObjectNode slim = MAPPER.createObjectNode();
-    slim.set("forward", com.fasterxml.jackson.databind.node.NullNode.getInstance());
+    slim.set("forward", NullNode.getInstance());
     TableConfig tc = withFieldConfig("c1", EncodingType.DICTIONARY, slim);
 
     try {
       TableConfigUtils.createTableConfigFromOldFormat(tc, schemaWith("c1"));
-      org.testng.Assert.fail("Expected IllegalStateException from ForwardIndexType validator");
+      fail("Expected IllegalStateException from ForwardIndexType validator");
     } catch (IllegalStateException expected) {
       assertTrue(expected.getMessage() != null && expected.getMessage().contains("forward index"),
           "Expected forward-index validation error; got: " + expected.getMessage());

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/ConvertToNewFormatPreservesSlimTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/ConvertToNewFormatPreservesSlimTest.java
@@ -49,7 +49,9 @@ import static org.testng.Assert.fail;
  * {@code AbstractIndexType#convertToNewFormat}: <b>migration only writes
  * {@code FieldConfig.indexes[prettyName]} when the column does not already carry a JsonNode for
  * that index type</b>. Columns already in new format keep their slim shape verbatim; legacy-only
- * inputs are translated as before; both-format coexistence resolves "new format wins".
+ * inputs are translated as before. Same-column same-type coexistence is rejected upstream with
+ * {@code ConfigDeclaredTwiceException}; different index types on the same column translate
+ * independently.
  *
  * <p>This contract is load-bearing for downstream APIs (e.g. StarTree Preview / InferIndex) that
  * round-trip user-supplied {@code FieldConfig.indexes} JsonNodes through the migration step and
@@ -148,8 +150,41 @@ public class ConvertToNewFormatPreservesSlimTest {
       TableConfigUtils.createTableConfigFromOldFormat(tc, schemaWith("c1"));
       fail("Expected IllegalStateException from ForwardIndexType validator");
     } catch (IllegalStateException expected) {
-      assertTrue(expected.getMessage() != null && expected.getMessage().contains("forward index"),
-          "Expected forward-index validation error; got: " + expected.getMessage());
+      assertTrue(expected.getMessage() != null && expected.getMessage().contains("column: c1"),
+          "Expected validation error naming column c1; got: " + expected.getMessage());
+    }
+  }
+
+  @Test
+  public void newFormatPrimitiveAtPrettyNameRejected() {
+    // Adversarial input: {"forward": 42}. ForwardIndexType's createDeserializer rejects
+    // non-object values; pin the loud failure path.
+    ObjectNode slim = MAPPER.createObjectNode();
+    slim.put("forward", 42);
+    TableConfig tc = withFieldConfig("c1", EncodingType.DICTIONARY, slim);
+
+    try {
+      TableConfigUtils.createTableConfigFromOldFormat(tc, schemaWith("c1"));
+      fail("Expected IllegalStateException for primitive at prettyName");
+    } catch (IllegalStateException expected) {
+      assertTrue(expected.getMessage() != null && expected.getMessage().contains("column: c1"),
+          "Expected validation error naming column c1; got: " + expected.getMessage());
+    }
+  }
+
+  @Test
+  public void newFormatArrayAtPrettyNameRejected() {
+    // Adversarial input: {"forward": [1,2,3]}. Same validator path as above.
+    ObjectNode slim = MAPPER.createObjectNode();
+    slim.putArray("forward").add(1).add(2).add(3);
+    TableConfig tc = withFieldConfig("c1", EncodingType.DICTIONARY, slim);
+
+    try {
+      TableConfigUtils.createTableConfigFromOldFormat(tc, schemaWith("c1"));
+      fail("Expected IllegalStateException for array at prettyName");
+    } catch (IllegalStateException expected) {
+      assertTrue(expected.getMessage() != null && expected.getMessage().contains("column: c1"),
+          "Expected validation error naming column c1; got: " + expected.getMessage());
     }
   }
 

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/AbstractIndexType.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/AbstractIndexType.java
@@ -38,6 +38,7 @@ import org.apache.pinot.spi.data.Schema;
 public abstract class AbstractIndexType<C extends IndexConfig, IR extends IndexReader, IC extends IndexCreator>
     implements IndexType<C, IR, IC> {
 
+  // ObjectMapper is thread-safe after construction; share across invocations.
   private static final ObjectMapper MAPPER = new ObjectMapper();
 
   private final String _id;
@@ -96,16 +97,31 @@ public abstract class AbstractIndexType<C extends IndexConfig, IR extends IndexR
    *
    * <p>The migration is <i>gap-filling</i>: for each column whose typed config is non-default, this
    * method writes the typed config's verbose JsonNode into {@code FieldConfig.indexes} <b>only when
-   * the column does not already carry a new-format JsonNode for this index type</b>. Columns
-   * already supplied in new format keep their original (possibly slim) JsonNode shape — this
-   * preserves user-supplied keys verbatim through the round-trip and avoids fattening pure
+   * the column does not already carry a JsonNode at {@code prettyName} for this index type</b>.
+   * Columns already supplied in new format keep their original (possibly slim) JsonNode shape —
+   * this preserves user-supplied keys verbatim through the round-trip and avoids fattening pure
    * new-format inputs with the typed-POJO bean-serializer defaults.
    *
-   * <p>Both-formats coexistence resolves "new format wins": if the user supplied both a legacy
-   * {@code indexingConfig.*} entry and a new-format {@code FieldConfig.indexes[prettyName]}
-   * JsonNode for the same column + type, the new-format JsonNode is the source of truth. The
-   * legacy entry is dropped by {@link #handleIndexSpecificCleanup} below, matching the documented
-   * migration intent.
+   * <p>Same-column + same-type conflict resolution is <b>not</b> handled here. If a column declares
+   * the same index type in both legacy {@code indexingConfig.*} and new-format
+   * {@code FieldConfig.indexes[prettyName]}, {@link #getConfig(TableConfig, Schema)} raises
+   * {@link MergedColumnConfigDeserializer.ConfigDeclaredTwiceException} <i>before</i> the gap-fill
+   * loop is reached. This method is only entered for non-conflicting inputs:
+   *
+   * <ul>
+   *   <li><b>Only new format set</b> — typed POJO comes from {@code fromIndexes};
+   *       {@code existing} is the user's JsonNode → {@code continue} → user shape preserved.
+   *   <li><b>Only legacy set</b> — typed POJO comes from {@code fromLegacyConfigs};
+   *       {@code existing} is {@code null} → falls through to {@code set()} → typed-POJO unwrap
+   *       written; legacy entry is then dropped by {@link #handleIndexSpecificCleanup}.
+   *   <li><b>Different index types on the same column</b> — independent loop iterations; each
+   *       follows one of the rules above.
+   * </ul>
+   *
+   * <p>An explicit Jackson {@code NullNode} at {@code prettyName} (i.e. {@code "forward": null})
+   * is not a valid input shape — per-index-type validators (called from {@code getConfig}) reject
+   * it before the gap-fill loop runs. Use an empty object {@code {}} to mean "enabled with
+   * defaults", not {@code null}.
    */
   public void convertToNewFormat(TableConfig tableConfig, Schema schema) {
     Map<String, C> deserialize = getConfig(tableConfig, schema);
@@ -126,9 +142,10 @@ public abstract class AbstractIndexType<C extends IndexConfig, IR extends IndexR
             : MAPPER.valueToTree(fieldConfig.getIndexes());
         JsonNode existing = currentIndexes.get(getPrettyName());
         if (existing != null && !existing.isNull()) {
-          // Column already carries a new-format JsonNode for this index type — preserve the
-          // user's shape verbatim. Legacy-only inputs fall through to the set() branch below;
-          // both-formats coexistence resolves to "new format wins".
+          // Column already carries a JsonNode at prettyName for this index type — preserve the
+          // user's shape verbatim. Legacy-only inputs (existing == null) fall through to the
+          // set() branch below. Same-column + same-type conflicts are surfaced as
+          // ConfigDeclaredTwiceException by getConfig() before this loop is reached.
           continue;
         }
         currentIndexes.set(getPrettyName(), configValue.toJsonNode());

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/AbstractIndexType.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/AbstractIndexType.java
@@ -38,6 +38,8 @@ import org.apache.pinot.spi.data.Schema;
 public abstract class AbstractIndexType<C extends IndexConfig, IR extends IndexReader, IC extends IndexCreator>
     implements IndexType<C, IR, IC> {
 
+  private static final ObjectMapper MAPPER = new ObjectMapper();
+
   private final String _id;
   private ColumnConfigDeserializer<C> _deserializer;
   private IndexReaderFactory<IR> _readerFactory;
@@ -88,6 +90,23 @@ public abstract class AbstractIndexType<C extends IndexConfig, IR extends IndexR
     return _readerFactory;
   }
 
+  /**
+   * Migrates legacy {@link org.apache.pinot.spi.config.table.IndexingConfig} index settings into
+   * the new {@code FieldConfig.indexes} JsonNode format.
+   *
+   * <p>The migration is <i>gap-filling</i>: for each column whose typed config is non-default, this
+   * method writes the typed config's verbose JsonNode into {@code FieldConfig.indexes} <b>only when
+   * the column does not already carry a new-format JsonNode for this index type</b>. Columns
+   * already supplied in new format keep their original (possibly slim) JsonNode shape — this
+   * preserves user-supplied keys verbatim through the round-trip and avoids fattening pure
+   * new-format inputs with the typed-POJO bean-serializer defaults.
+   *
+   * <p>Both-formats coexistence resolves "new format wins": if the user supplied both a legacy
+   * {@code indexingConfig.*} entry and a new-format {@code FieldConfig.indexes[prettyName]}
+   * JsonNode for the same column + type, the new-format JsonNode is the source of truth. The
+   * legacy entry is dropped by {@link #handleIndexSpecificCleanup} below, matching the documented
+   * migration intent.
+   */
   public void convertToNewFormat(TableConfig tableConfig, Schema schema) {
     Map<String, C> deserialize = getConfig(tableConfig, schema);
     List<FieldConfig> fieldConfigList = tableConfig.getFieldConfigList() == null
@@ -103,15 +122,22 @@ public abstract class AbstractIndexType<C extends IndexConfig, IR extends IndexR
       FieldConfig fieldConfig = fieldConfigMap.get(entry.getKey());
       if (fieldConfig != null) {
         ObjectNode currentIndexes = fieldConfig.getIndexes().isNull()
-            ? new ObjectMapper().createObjectNode()
-            : new ObjectMapper().valueToTree(fieldConfig.getIndexes());
-        JsonNode indexes = currentIndexes.set(getPrettyName(), configValue.toJsonNode());
+            ? MAPPER.createObjectNode()
+            : MAPPER.valueToTree(fieldConfig.getIndexes());
+        JsonNode existing = currentIndexes.get(getPrettyName());
+        if (existing != null && !existing.isNull()) {
+          // Column already carries a new-format JsonNode for this index type — preserve the
+          // user's shape verbatim. Legacy-only inputs fall through to the set() branch below;
+          // both-formats coexistence resolves to "new format wins".
+          continue;
+        }
+        currentIndexes.set(getPrettyName(), configValue.toJsonNode());
         FieldConfig.Builder builder = new FieldConfig.Builder(fieldConfig);
-        builder.withIndexes(indexes);
+        builder.withIndexes(currentIndexes);
         fieldConfigList.remove(fieldConfig);
         fieldConfigList.add(builder.build());
       } else {
-        JsonNode indexes = new ObjectMapper().createObjectNode().set(getPrettyName(), configValue.toJsonNode());
+        JsonNode indexes = MAPPER.createObjectNode().set(getPrettyName(), configValue.toJsonNode());
         FieldConfig.Builder builder = new FieldConfig.Builder(entry.getKey());
         builder.withIndexes(indexes);
         builder.withEncodingType(FieldConfig.EncodingType.DICTIONARY);

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/AbstractIndexType.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/AbstractIndexType.java
@@ -118,10 +118,13 @@ public abstract class AbstractIndexType<C extends IndexConfig, IR extends IndexR
    *       follows one of the rules above.
    * </ul>
    *
-   * <p>An explicit Jackson {@code NullNode} at {@code prettyName} (i.e. {@code "forward": null})
-   * is not a valid input shape — per-index-type validators (called from {@code getConfig}) reject
-   * it before the gap-fill loop runs. Use an empty object {@code {}} to mean "enabled with
-   * defaults", not {@code null}.
+   * <p>An explicit Jackson {@code NullNode} at {@code prettyName} (e.g. {@code "forward": null})
+   * is handled by two layers: (1) some index types (e.g. {@code ForwardIndexType}) reject
+   * non-object values via a {@code Preconditions.checkState(...)} in their
+   * {@code createDeserializer} lambda before the gap-fill loop runs; (2) for types without that
+   * upstream check, the gap-fill predicate itself treats {@code NullNode} as absent
+   * ({@code !existing.isNull()}) and falls through to {@code set()}. Use an empty object
+   * {@code {}} to mean "enabled with defaults", not {@code null}.
    */
   public void convertToNewFormat(TableConfig tableConfig, Schema schema) {
     Map<String, C> deserialize = getConfig(tableConfig, schema);


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Preserve user\-supplied slim FieldConfig\.indexes during migration by gap\-filling only when missing\.

```mermaid
flowchart TD
  N0["convertToNewFormat #40;F1#41;"]:::stModified
  N1["Get configs #38; field list #40;F1#41;"]:::stModified
  N2["Iterate over columns #40;F1#41;"]:::stModified
  N3["FieldConfig exists#63; #40;F1#41;"]:::stModified
  N4["Handle existing FieldConfig #40;F1#41;"]:::stModified
  N5["Handle missing FieldConfig #40;F1#41;"]:::stModified
  N6["Update FieldConfig list #40;F1#41;"]:::stModified
  N7["static final ObjectMapper MAPPER #40;F1#41;"]:::stModified
  N0 -->|"calls"| N1
  N0 -->|"starts loop"| N2
  N1 -->|"provides data"| N2
  N2 -->|"each column"| N3
  N3 -->|"true"| N4
  N3 -->|"false"| N5
  N4 -->|"set indexes #40;when missing#41;"| N6
  N4 -->|"continue #40;preserve#41;"| N2
  N5 -->|"build new FieldConfig"| N6
  N6 -->|"list updated#44; next column"| N2
  N4 -->|"uses MAPPER"| N7
  N5 -->|"uses MAPPER"| N7
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-segment\-spi/src/main/java/org/apache/pinot/segment/spi/index/AbstractIndexType\.java — [before](https://github.com/apache/pinot/blob/21c88f716f376bb7a0238e0feeeff12b088f55f7/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/AbstractIndexType.java) · [after](https://github.com/apache/pinot/blob/0ee367ad228db0f84614c0182ce67a2db3fe92b0/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/AbstractIndexType.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjIxYzg4ZjcxNmYzNzZiYjdhMDIzOGUwZmVlZWZmMTJiMDg4ZjU1ZjciLCJjb250ZXh0X2hhc2giOiJhMmE0ZjhjMjBiNzlmMmEyOWI3N2Q4MjFjNzI0ZjRmNDIyYjEwYjc4YzliNjg1ZjZhYjBmYTllMGYyODE3ZjgyIiwiZ2VuZXJhdGVkX2F0IjoxNzg5NTQ0NzE2LCJoZWFkX3NoYSI6IjBlZTM2N2FkMjI4ZGIwZjg0NjE0YzAxODJjZTY3YTJkYjNmZTkyYjAiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiIyMWM4OGY3MTZmMzc2YmI3YTAyMzhlMGZlZWVmZjEyYjA4OGY1NWY3IiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature c464952af05e8ea2b301bbd6baf0b14003a58195048d2b1b5eeb91735ae9cce4 -->
<!-- pinot-pr-flow:end -->

### Issue(s)

`AbstractIndexType#convertToNewFormat` (called via `TableConfigUtils.createTableConfigFromOldFormat`) unconditionally overwrites every `FieldConfig.indexes[prettyName]` with the verbose typed-POJO unwrap — even on columns the user already supplied in new-format slim shape.

This is load-bearing for downstream surfaces (e.g. StarTree Preview / InferIndex APIs) that round-trip user-supplied `FieldConfig.indexes` JsonNodes through migration and back to the client / ZK — the slim shape never survives.

---

### Problem

`getConfig(...)` deserializes the user's slim JSON → typed POJO (Jackson fills missing primitive `@JsonCreator` params with `0` / `false`). `configValue.toJsonNode()` then re-serializes via the bean serializer, which emits every key. `currentIndexes.set(prettyName, …)` clobbers the user's slim shape with the verbose blob:

```diff
  FieldConfig.indexes.forward (user posted: {"compressionCodec":"SNAPPY"}):
- {"disabled":false,"encodingType":"DICTIONARY","compressionCodec":"SNAPPY",
-  "deriveNumDocsPerChunk":false,"rawIndexWriterVersion":4,
-  "targetMaxChunkSize":"1MB","targetDocsPerChunk":1000}     // 7 keys, today
```

Root cause: the overwrite at [`AbstractIndexType.java`](https://github.com/apache/pinot/blob/master/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/AbstractIndexType.java) was unconditional — it fired even when the column already carried a new-format JsonNode for that index type.

---

### Solution

Make the write **gap-filling**: when the column already carries a JsonNode at `FieldConfig.indexes[prettyName]`, preserve it verbatim. Pure-legacy inputs still translate to new format unchanged.

```diff
-      ObjectNode currentIndexes = fieldConfig.getIndexes().isNull()
-          ? new ObjectMapper().createObjectNode()
-          : new ObjectMapper().valueToTree(fieldConfig.getIndexes());
-      currentIndexes.set(getPrettyName(), configValue.toJsonNode());
+      ObjectNode currentIndexes = fieldConfig.getIndexes().isNull()
+          ? MAPPER.createObjectNode()
+          : MAPPER.valueToTree(fieldConfig.getIndexes());
+      JsonNode existing = currentIndexes.get(getPrettyName());
+      if (existing != null && !existing.isNull()) {
+        // Column already carries a new-format JsonNode for this index type — preserve the
+        // user's shape verbatim. Legacy-only inputs fall through to the set() branch below.
+        continue;
+      }
+      currentIndexes.set(getPrettyName(), configValue.toJsonNode());
```

`ObjectMapper` is also hoisted to `private static final` (was allocated per-column).

After:

```diff
  FieldConfig.indexes.forward (user posted: {"compressionCodec":"SNAPPY"}):
+ {"compressionCodec":"SNAPPY"}                              // 1 key, preserved
```

---

### Backward compatibility

| Case | Before | After |
|---|---|---|
| Pure legacy (e.g. `bloomFilterColumns=[c1]`) | Translated to new format (verbose). | Same — falls through to the `set()` branch. |
| Pure new-format slim (e.g. `{"forward":{"compressionCodec":"SNAPPY"}}`) | **Overwritten** with verbose typed-POJO unwrap. | Preserved verbatim. |
| Both formats, different index types (e.g. slim `bloom` + legacy `noDictionaryColumns`) | Both translate; legacy fattens its own entry. | Both translate independently; user's slim shape stays slim. |
| Both formats, same column + same index type | `ConfigDeclaredTwiceException` (merged deserializer). | Same — gap-fill runs after the deserializer, so the throw still fires. |
| Cross-type inference (e.g. inverted → dictionary auto-create) | Verbose written. | Verbose written (key was absent). Same. |

No SPI signature changes. No config-key renames. Strictly more conservative than today.

**Rolling upgrade.** Mixed-version controllers may produce different (but semantically equivalent) `FieldConfig.indexes` JSON shapes for the same `TableConfig` during a rolling upgrade — an older controller will still re-fatten a slim entry, a newer controller preserves it. Both shapes are accepted by all readers, so no downtime or data migration is required.

---

### Testing

New test class `ConvertToNewFormatPreservesSlimTest` (21 tests) pins the full contract:

- **Pure new-format preservation:** `forward` / `bloom` slim shapes preserved; explicit value equal to today's default preserved; explicit `false` preserved; empty `{}` object preserved.
- **Pure-legacy translation (back-compat):** `bloomFilterColumns`, `noDictionaryColumns`, `invertedIndexColumns` all still translate.
- **Both-formats coexistence:** different index types coexist with each shape independent; same column + same type still raises `ConfigDeclaredTwiceException`.
- **Idempotency:** migration twice == migration once, for both new-format and legacy inputs.
- **Multi-column independence** + **multiple index types on one column** + **legacy cleanup** + **default-config skip**.
- **Cross-type coverage:** `range`, `text`, `json` slim shapes preserved (each subclass shares the base codepath).
- **End-to-end Jackson round-trip:** serialize → deserialize the migrated `TableConfig` and confirm the slim shape survives.

Adjacent suites still green: `TableConfigUtilsTest` (56), `DictionaryIndexConfigTest` (10), `IndexServiceTest` (1), plus the 120-test index-type sweep across `VectorIndexTest`, `H3IndexTest`, `JsonIndexTest`, `RangeIndexTest`, `TextIndexTest`, `FstIndexTest`, `ForwardIndexTypeTest`, `DictionaryIndexTypeTest`, `BloomFilterTypeTest`, `InvertedIndexTypeTest`, `NullValueIndexTest`.

`./mvnw spotless:apply checkstyle:check license:format license:check -pl pinot-segment-spi,pinot-segment-local` clean.
