### PR TITLE
Add circuit breaking mechanisms for offset auto-reset backfill

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
@@ -226,7 +226,9 @@ public enum ControllerGauge implements AbstractMetrics.Gauge {
   // HTTP thread utilization
   HTTP_THREAD_UTILIZATION("httpThreadUtilization", true),
   // Track the concurrent executions of the API resources that use @ManagedAsync
-  MANAGED_ASYNC_ACTIVE_THREADS("threads", true);
+  MANAGED_ASYNC_ACTIVE_THREADS("threads", true),
+  // Backfill circuit breaking: number of active backfill Kafka topics currently running for this table
+  BACKFILL_TOPICS_IN_PROGRESS("backfillTopicsInProgress", false);
 
 
   private final String _gaugeName;

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerMeter.java
@@ -82,6 +82,9 @@ public enum ControllerMeter implements AbstractMetrics.Meter {
   OFFSET_AUTO_RESET_BACKFILL_SKIPPED_MAX_SEGMENTS("BackfillSkippedMaxSegments", false),
   OFFSET_AUTO_RESET_BACKFILL_SKIPPED_MAX_CONCURRENT("BackfillSkippedMaxConcurrent", false),
   OFFSET_AUTO_RESET_BACKFILL_SKIPPED_IN_FLIGHT("BackfillSkippedInFlight", false),
+  OFFSET_AUTO_RESET_HANDLER_INIT_FAILURE("BackfillHandlerInitFailure", false),
+  OFFSET_AUTO_RESET_AUTO_PAUSE_FAILURE("BackfillAutoPauseFailure", false),
+  OFFSET_AUTO_RESET_BACKFILL_CLEANUP_COMPLETED("BackfillCleanupCompleted", false),
   // Audit logging metrics
   AUDIT_REQUEST_FAILURES("failures", true),
   AUDIT_RESPONSE_FAILURES("failures", true),

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerMeter.java
@@ -78,6 +78,10 @@ public enum ControllerMeter implements AbstractMetrics.Meter {
   PARTITION_GROUP_METADATA_FETCH_ERROR("failures", true),
   OFFSET_AUTO_RESET_SKIPPED_OFFSETS("autoResetSkippedOffsets", false),
   OFFSET_AUTO_RESET_BACKFILL_OFFSETS("autoResetBackfillOffsets", false),
+  OFFSET_AUTO_RESET_BACKFILL_SKIPPED_PAUSED("BackfillSkippedPaused", false),
+  OFFSET_AUTO_RESET_BACKFILL_SKIPPED_MAX_SEGMENTS("BackfillSkippedMaxSegments", false),
+  OFFSET_AUTO_RESET_BACKFILL_SKIPPED_MAX_CONCURRENT("BackfillSkippedMaxConcurrent", false),
+  OFFSET_AUTO_RESET_BACKFILL_SKIPPED_IN_FLIGHT("BackfillSkippedInFlight", false),
   // Audit logging metrics
   AUDIT_REQUEST_FAILURES("failures", true),
   AUDIT_RESPONSE_FAILURES("failures", true),

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -117,6 +117,10 @@ public class ControllerConf extends PinotConfiguration {
         "controller.realtime.offsetAutoReset.backfill.frequencyPeriod";
     public static final String REALTIME_OFFSET_AUTO_RESET_BACKFILL_INITIAL_DELAY_IN_SECONDS =
         "controller.realtime.offsetAutoReset.backfill.initialDelayInSeconds";
+    public static final String MAX_CONCURRENT_BACKFILLS_PER_CONTROLLER =
+        "controller.realtime.offsetAutoReset.maxConcurrentBackfillsPerController";
+    public static final String MAX_BACKFILL_COLLISIONS_BEFORE_AUTO_PAUSE =
+        "controller.realtime.offsetAutoReset.maxBackfillCollisionsBeforeAutoPause";
     public static final String BROKER_RESOURCE_VALIDATION_FREQUENCY_PERIOD =
         "controller.broker.resource.validation.frequencyPeriod";
     public static final String BROKER_RESOURCE_VALIDATION_INITIAL_DELAY_IN_SECONDS =
@@ -1206,6 +1210,14 @@ public class ControllerConf extends PinotConfiguration {
   public long getRealtimeOffsetAutoResetBackfillInitialDelaySeconds() {
     return getProperty(ControllerPeriodicTasksConf.REALTIME_OFFSET_AUTO_RESET_BACKFILL_INITIAL_DELAY_IN_SECONDS,
         getPeriodicTaskInitialDelayInSeconds());
+  }
+
+  public int getMaxConcurrentBackfillsPerController() {
+    return getProperty(ControllerPeriodicTasksConf.MAX_CONCURRENT_BACKFILLS_PER_CONTROLLER, -1);
+  }
+
+  public int getMaxBackfillCollisionsBeforeAutoPause() {
+    return getProperty(ControllerPeriodicTasksConf.MAX_BACKFILL_COLLISIONS_BEFORE_AUTO_PAUSE, 3);
   }
 
   public boolean isDeepStoreRetryUploadLLCSegmentEnabled() {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -1077,13 +1077,13 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
     if (!streamConfig.isEnableOffsetAutoReset() || streamConfig.isBackfillTopic()) {
       return nextOffset;
     }
-    // CB1: pause flag per topic
+    // Skip if backfill is manually paused for this topic
     if (streamConfig.isOffsetAutoResetPaused()) {
       LOGGER.info("Skipping offset auto reset for table {} topic {} — backfill is paused",
           streamConfig.getTableNameWithType(), streamConfig.getTopicName());
       return nextOffset;
     }
-    // CB2: max segments guard (lightweight ZK child-name list, no data deserialization)
+    // Skip if the table already has too many segments (lightweight ZK child-name list, no data deserialization)
     int maxSegments = streamConfig.getOffsetAutoResetMaxSegmentsBeforeSkip();
     if (maxSegments > 0) {
       int segmentCount = ZKMetadataProvider.getSegments(_propertyStore, streamConfig.getTableNameWithType()).size();

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -1077,6 +1077,24 @@ public class PinotLLCRealtimeSegmentManager implements PinotClusterConfigChangeL
     if (!streamConfig.isEnableOffsetAutoReset() || streamConfig.isBackfillTopic()) {
       return nextOffset;
     }
+    // CB1: pause flag per topic
+    if (streamConfig.isOffsetAutoResetPaused()) {
+      LOGGER.info("Skipping offset auto reset for table {} topic {} — backfill is paused",
+          streamConfig.getTableNameWithType(), streamConfig.getTopicName());
+      return nextOffset;
+    }
+    // CB2: max segments guard (lightweight ZK child-name list, no data deserialization)
+    int maxSegments = streamConfig.getOffsetAutoResetMaxSegmentsBeforeSkip();
+    if (maxSegments > 0) {
+      int segmentCount = ZKMetadataProvider.getSegments(_propertyStore, streamConfig.getTableNameWithType()).size();
+      if (segmentCount >= maxSegments) {
+        LOGGER.info("Skipping offset auto reset for table {} topic {} — segment count {} >= maxSegmentsBeforeSkip {}",
+            streamConfig.getTableNameWithType(), streamConfig.getTopicName(), segmentCount, maxSegments);
+        _controllerMetrics.addMeteredTableValue(streamConfig.getTableNameWithType(),
+            ControllerMeter.OFFSET_AUTO_RESET_BACKFILL_SKIPPED_MAX_SEGMENTS, 1L);
+        return nextOffset;
+      }
+    }
     long timeThreshold = streamConfig.getOffsetAutoResetTimeSecThreshold();
     int offsetThreshold = streamConfig.getOffsetAutoResetOffsetThreshold();
     if (timeThreshold <= 0 && offsetThreshold <= 0) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeOffsetAutoResetManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeOffsetAutoResetManager.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import org.apache.pinot.common.metrics.ControllerGauge;
 import org.apache.pinot.common.metrics.ControllerMeter;
 import org.apache.pinot.common.metrics.ControllerMetrics;
 import org.apache.pinot.controller.ControllerConf;
@@ -111,7 +112,7 @@ public class RealtimeOffsetAutoResetManager extends ControllerPeriodicTask<Realt
       return;
     }
 
-    // CB3: Max concurrent backfills across all tables on this controller
+    // Skip triggering if the controller is already handling the maximum number of concurrent backfills
     int maxConcurrent = _controllerConf.getMaxConcurrentBackfillsPerController();
     if (context._shouldTriggerBackfillJobs && maxConcurrent > 0
         && _tableBackfillTopics.size() >= maxConcurrent) {
@@ -128,9 +129,9 @@ public class RealtimeOffsetAutoResetManager extends ControllerPeriodicTask<Realt
       String partitionStr = context._backfillJobProperties.get(Constants.RESET_OFFSET_TOPIC_PARTITION);
       _tableTopicsUnderBackfill.get(tableNameWithType).add(topicName);
 
-      // CB4: Per-partition in-flight collision guard.
-      // _tableBackfillTopics contains the backfill Kafka topic names (not the main topic names),
-      // so any non-empty set indicates a backfill is already in flight for this table.
+      // Per-partition in-flight guard: _tableBackfillTopics contains the backfill Kafka topic names
+      // (not the main topic names), so any non-empty set indicates a backfill is already in flight.
+      // Track collisions per (table, topic, partition); auto-pause if collisions exceed the threshold.
       String partitionKey = tableNameWithType + ":" + topicName + ":" + partitionStr;
       Set<String> activeBackfillTopics = _tableBackfillTopics.get(tableNameWithType);
       boolean anyBackfillInFlight = activeBackfillTopics != null && !activeBackfillTopics.isEmpty();
@@ -181,6 +182,11 @@ public class RealtimeOffsetAutoResetManager extends ControllerPeriodicTask<Realt
 
     ensureBackfillJobsRunning(tableNameWithType);
     ensureCompletedBackfillJobsCleanedUp(tableConfig);
+
+    Set<String> activeTopics = _tableBackfillTopics.get(tableNameWithType);
+    _controllerMetrics.setValueOfTableGauge(tableNameWithType,
+        ControllerGauge.BACKFILL_TOPICS_IN_PROGRESS,
+        activeTopics != null ? activeTopics.size() : 0L);
   }
 
   /**
@@ -232,6 +238,8 @@ public class RealtimeOffsetAutoResetManager extends ControllerPeriodicTask<Realt
     }
     if (cleanedUpTopics.size() > 0) {
       LOGGER.info("Cleaned up complete backfill topics {} for table {}", cleanedUpTopics, tableNameWithType);
+      _controllerMetrics.addMeteredTableValue(tableNameWithType,
+          ControllerMeter.OFFSET_AUTO_RESET_BACKFILL_CLEANUP_COMPLETED, cleanedUpTopics.size());
     }
   }
 
@@ -249,7 +257,10 @@ public class RealtimeOffsetAutoResetManager extends ControllerPeriodicTask<Realt
     List<Map<String, String>> streamConfigMaps =
         tableConfig.getIngestionConfig().getStreamIngestionConfig().getStreamConfigMaps();
     for (Map<String, String> map : streamConfigMaps) {
-      if (topicName.equals(map.get(StreamConfigProperties.STREAM_TOPIC_NAME))) {
+      // Topic name is stored under the prefixed key "stream.<type>.topic.name"
+      String streamType = map.get(StreamConfigProperties.STREAM_TYPE);
+      String topicKey = StreamConfigProperties.constructStreamProperty(streamType, StreamConfigProperties.STREAM_TOPIC_NAME);
+      if (topicName.equals(map.get(topicKey))) {
         map.put(StreamConfigProperties.OFFSET_AUTO_RESET_PAUSE, "true");
         break;
       }
@@ -259,6 +270,8 @@ public class RealtimeOffsetAutoResetManager extends ControllerPeriodicTask<Realt
       LOGGER.info("Set offset auto reset pause flag for table {} topic {}", tableNameWithType, topicName);
     } catch (Exception e) {
       LOGGER.error("Failed to set pause flag for table {} topic {}", tableNameWithType, topicName, e);
+      _controllerMetrics.addMeteredTableValue(tableNameWithType,
+          ControllerMeter.OFFSET_AUTO_RESET_AUTO_PAUSE_FAILURE, 1L);
     }
   }
 
@@ -301,6 +314,8 @@ public class RealtimeOffsetAutoResetManager extends ControllerPeriodicTask<Realt
       return handler;
     } catch (Exception e) {
       LOGGER.error("Cannot create RealtimeOffsetAutoResetHandler", e);
+      _controllerMetrics.addMeteredTableValue(tableConfig.getTableName(),
+          ControllerMeter.OFFSET_AUTO_RESET_HANDLER_INIT_FAILURE, 1L);
       return null;
     }
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeOffsetAutoResetManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeOffsetAutoResetManager.java
@@ -37,6 +37,7 @@ import org.apache.pinot.controller.helix.core.periodictask.RealtimeOffsetAutoRes
 import org.apache.pinot.controller.helix.core.realtime.PinotLLCRealtimeSegmentManager;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.stream.StreamConfig;
+import org.apache.pinot.spi.stream.StreamConfigProperties;
 import org.apache.pinot.spi.utils.IngestionConfigUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.slf4j.Logger;
@@ -48,9 +49,12 @@ public class RealtimeOffsetAutoResetManager extends ControllerPeriodicTask<Realt
   private static final Logger LOGGER = LoggerFactory.getLogger(RealtimeOffsetAutoResetManager.class);
   private final PinotLLCRealtimeSegmentManager _llcRealtimeSegmentManager;
   private final PinotHelixResourceManager _pinotHelixResourceManager;
+  private final ControllerConf _controllerConf;
   private final Map<String, RealtimeOffsetAutoResetHandler> _tableToHandler;
   private final Map<String, Set<String>> _tableTopicsUnderBackfill;
   private final Map<String, Set<String>> _tableBackfillTopics;
+  // Key: "tableNameWithType:topicName:partitionId" — tracks consecutive in-flight collisions per partition
+  private final Map<String, Integer> _partitionInFlightCollisionCount;
 
   public RealtimeOffsetAutoResetManager(ControllerConf config, PinotHelixResourceManager pinotHelixResourceManager,
       LeadControllerManager leadControllerManager, PinotLLCRealtimeSegmentManager llcRealtimeSegmentManager,
@@ -60,9 +64,11 @@ public class RealtimeOffsetAutoResetManager extends ControllerPeriodicTask<Realt
         leadControllerManager, controllerMetrics);
     _llcRealtimeSegmentManager = llcRealtimeSegmentManager;
     _pinotHelixResourceManager = pinotHelixResourceManager;
+    _controllerConf = config;
     _tableToHandler = new ConcurrentHashMap<>();
     _tableTopicsUnderBackfill = new ConcurrentHashMap<>();
     _tableBackfillTopics = new ConcurrentHashMap<>();
+    _partitionInFlightCollisionCount = new ConcurrentHashMap<>();
   }
 
   @Override
@@ -105,31 +111,71 @@ public class RealtimeOffsetAutoResetManager extends ControllerPeriodicTask<Realt
       return;
     }
 
+    // CB3: Max concurrent backfills across all tables on this controller
+    int maxConcurrent = _controllerConf.getMaxConcurrentBackfillsPerController();
+    if (context._shouldTriggerBackfillJobs && maxConcurrent > 0
+        && _tableBackfillTopics.size() >= maxConcurrent) {
+      LOGGER.warn("Skipping backfill trigger for table {} — max concurrent backfills ({}) reached",
+          tableNameWithType, maxConcurrent);
+      _controllerMetrics.addMeteredTableValue(tableNameWithType,
+          ControllerMeter.OFFSET_AUTO_RESET_BACKFILL_SKIPPED_MAX_CONCURRENT, 1L);
+      context._shouldTriggerBackfillJobs = false;
+    }
+
     if (context._shouldTriggerBackfillJobs) {
       _tableTopicsUnderBackfill.putIfAbsent(tableNameWithType, ConcurrentHashMap.newKeySet());
       String topicName = context._backfillJobProperties.get(Constants.RESET_OFFSET_TOPIC_NAME);
+      String partitionStr = context._backfillJobProperties.get(Constants.RESET_OFFSET_TOPIC_PARTITION);
       _tableTopicsUnderBackfill.get(tableNameWithType).add(topicName);
+
+      // CB4: Per-partition in-flight collision guard.
+      // _tableBackfillTopics contains the backfill Kafka topic names (not the main topic names),
+      // so any non-empty set indicates a backfill is already in flight for this table.
+      String partitionKey = tableNameWithType + ":" + topicName + ":" + partitionStr;
+      Set<String> activeBackfillTopics = _tableBackfillTopics.get(tableNameWithType);
+      boolean anyBackfillInFlight = activeBackfillTopics != null && !activeBackfillTopics.isEmpty();
+      if (anyBackfillInFlight) {
+        int collisions = _partitionInFlightCollisionCount.merge(partitionKey, 1, Integer::sum);
+        int maxCollisions = _controllerConf.getMaxBackfillCollisionsBeforeAutoPause();
+        _controllerMetrics.addMeteredTableValue(tableNameWithType,
+            ControllerMeter.OFFSET_AUTO_RESET_BACKFILL_SKIPPED_IN_FLIGHT, 1L);
+        LOGGER.warn("In-flight backfill collision #{} for partition key {} (active backfill topics: {})",
+            collisions, partitionKey, activeBackfillTopics);
+        if (maxCollisions > 0 && collisions >= maxCollisions) {
+          LOGGER.warn("Auto-pausing backfill for table {} topic {} after {} collisions",
+              tableNameWithType, topicName, collisions);
+          _controllerMetrics.addMeteredTableValue(tableNameWithType,
+              ControllerMeter.OFFSET_AUTO_RESET_BACKFILL_SKIPPED_PAUSED, 1L);
+          setPauseFlag(tableNameWithType, tableConfig, topicName);
+          context._shouldTriggerBackfillJobs = false;
+        }
+        // Below threshold: allow trigger to proceed (new backfill coexists with the ongoing one)
+      } else {
+        _partitionInFlightCollisionCount.remove(partitionKey);
+      }
 
       StreamConfig topicStreamConfig = IngestionConfigUtils.getStreamConfigs(tableConfig).stream()
           .filter(config -> topicName.equals(config.getTopicName()))
           .findFirst().orElseThrow(() -> new RuntimeException("No matching topic found"));
-      LOGGER.info("Triggering backfill jobs with StreamConfig {}, topicName {}, properties {}",
-          topicStreamConfig, topicName, context._backfillJobProperties);
-      try {
-        long startOffset = Long.parseLong(context._backfillJobProperties.get(Constants.RESET_OFFSET_FROM));
-        long endOffset = Long.parseLong(context._backfillJobProperties.get(Constants.RESET_OFFSET_TO));
-        if (_tableToHandler.get(tableNameWithType).triggerBackfillJob(tableNameWithType,
-            topicStreamConfig,
-            topicName,
-            Integer.parseInt(context._backfillJobProperties.get(Constants.RESET_OFFSET_TOPIC_PARTITION)),
-            startOffset,
-            endOffset)) {
-          _controllerMetrics.addMeteredTableValue(tableNameWithType, ControllerMeter.OFFSET_AUTO_RESET_BACKFILL_OFFSETS,
-              endOffset - startOffset);
+      if (context._shouldTriggerBackfillJobs) {
+        LOGGER.info("Triggering backfill jobs with StreamConfig {}, topicName {}, properties {}",
+            topicStreamConfig, topicName, context._backfillJobProperties);
+        try {
+          long startOffset = Long.parseLong(context._backfillJobProperties.get(Constants.RESET_OFFSET_FROM));
+          long endOffset = Long.parseLong(context._backfillJobProperties.get(Constants.RESET_OFFSET_TO));
+          if (_tableToHandler.get(tableNameWithType).triggerBackfillJob(tableNameWithType,
+              topicStreamConfig,
+              topicName,
+              Integer.parseInt(partitionStr),
+              startOffset,
+              endOffset)) {
+            _controllerMetrics.addMeteredTableValue(tableNameWithType,
+                ControllerMeter.OFFSET_AUTO_RESET_BACKFILL_OFFSETS, endOffset - startOffset);
+          }
+        } catch (NumberFormatException e) {
+          LOGGER.error("Invalid backfill job properties for table: {}, properties: {}, error: {}",
+              tableNameWithType, context._backfillJobProperties, e.getMessage(), e);
         }
-      } catch (NumberFormatException e) {
-        LOGGER.error("Invalid backfill job properties for table: {}, properties: {}, error: {}",
-            tableNameWithType, context._backfillJobProperties, e.getMessage(), e);
       }
     }
 
@@ -175,6 +221,8 @@ public class RealtimeOffsetAutoResetManager extends ControllerPeriodicTask<Realt
     if (cleanedUpTopics.containsAll(_tableBackfillTopics.get(tableNameWithType))) {
       _tableTopicsUnderBackfill.remove(tableNameWithType);
       _tableBackfillTopics.remove(tableNameWithType);
+      // Remove all per-partition collision counters for this table
+      _partitionInFlightCollisionCount.keySet().removeIf(k -> k.startsWith(tableNameWithType + ":"));
       if (_tableToHandler.get(tableNameWithType) != null) {
         _tableToHandler.get(tableNameWithType).close();
         _tableToHandler.remove(tableNameWithType);
@@ -193,6 +241,24 @@ public class RealtimeOffsetAutoResetManager extends ControllerPeriodicTask<Realt
       _tableTopicsUnderBackfill.remove(tableNameWithType);
       _tableBackfillTopics.remove(tableNameWithType);
       _tableToHandler.remove(tableNameWithType);
+      _partitionInFlightCollisionCount.keySet().removeIf(k -> k.startsWith(tableNameWithType + ":"));
+    }
+  }
+
+  private void setPauseFlag(String tableNameWithType, TableConfig tableConfig, String topicName) {
+    List<Map<String, String>> streamConfigMaps =
+        tableConfig.getIngestionConfig().getStreamIngestionConfig().getStreamConfigMaps();
+    for (Map<String, String> map : streamConfigMaps) {
+      if (topicName.equals(map.get(StreamConfigProperties.STREAM_TOPIC_NAME))) {
+        map.put(StreamConfigProperties.OFFSET_AUTO_RESET_PAUSE, "true");
+        break;
+      }
+    }
+    try {
+      _pinotHelixResourceManager.updateTableConfig(tableConfig);
+      LOGGER.info("Set offset auto reset pause flag for table {} topic {}", tableNameWithType, topicName);
+    } catch (Exception e) {
+      LOGGER.error("Failed to set pause flag for table {} topic {}", tableNameWithType, topicName, e);
     }
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeOffsetAutoResetManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeOffsetAutoResetManager.java
@@ -52,10 +52,11 @@ public class RealtimeOffsetAutoResetManager extends ControllerPeriodicTask<Realt
   private final PinotHelixResourceManager _pinotHelixResourceManager;
   private final ControllerConf _controllerConf;
   private final Map<String, RealtimeOffsetAutoResetHandler> _tableToHandler;
-  private final Map<String, Set<String>> _tableTopicsUnderBackfill;
-  private final Map<String, Set<String>> _tableBackfillTopics;
-  // Key: "tableNameWithType:topicName:partitionId" — tracks consecutive in-flight collisions per partition
-  private final Map<String, Integer> _partitionInFlightCollisionCount;
+  private final Map<String, Set<String>> _sourceTopicsByTable;
+  private final Map<String, Set<String>> _backfillTopicsByTable;
+  // Key: "tableNameWithType:topicName:partitionId" — counts how many times this partition triggered
+  // a backfill while a prior one for that same partition was still in flight.
+  private final Map<String, Integer> _partitionsInFlightCount;
 
   public RealtimeOffsetAutoResetManager(ControllerConf config, PinotHelixResourceManager pinotHelixResourceManager,
       LeadControllerManager leadControllerManager, PinotLLCRealtimeSegmentManager llcRealtimeSegmentManager,
@@ -67,9 +68,9 @@ public class RealtimeOffsetAutoResetManager extends ControllerPeriodicTask<Realt
     _pinotHelixResourceManager = pinotHelixResourceManager;
     _controllerConf = config;
     _tableToHandler = new ConcurrentHashMap<>();
-    _tableTopicsUnderBackfill = new ConcurrentHashMap<>();
-    _tableBackfillTopics = new ConcurrentHashMap<>();
-    _partitionInFlightCollisionCount = new ConcurrentHashMap<>();
+    _sourceTopicsByTable = new ConcurrentHashMap<>();
+    _backfillTopicsByTable = new ConcurrentHashMap<>();
+    _partitionsInFlightCount = new ConcurrentHashMap<>();
   }
 
   @Override
@@ -115,7 +116,7 @@ public class RealtimeOffsetAutoResetManager extends ControllerPeriodicTask<Realt
     // Skip triggering if the controller is already handling the maximum number of concurrent backfills
     int maxConcurrent = _controllerConf.getMaxConcurrentBackfillsPerController();
     if (context._shouldTriggerBackfillJobs && maxConcurrent > 0
-        && _tableBackfillTopics.size() >= maxConcurrent) {
+        && _backfillTopicsByTable.size() >= maxConcurrent) {
       LOGGER.warn("Skipping backfill trigger for table {} — max concurrent backfills ({}) reached",
           tableNameWithType, maxConcurrent);
       _controllerMetrics.addMeteredTableValue(tableNameWithType,
@@ -124,35 +125,30 @@ public class RealtimeOffsetAutoResetManager extends ControllerPeriodicTask<Realt
     }
 
     if (context._shouldTriggerBackfillJobs) {
-      _tableTopicsUnderBackfill.putIfAbsent(tableNameWithType, ConcurrentHashMap.newKeySet());
+      _sourceTopicsByTable.putIfAbsent(tableNameWithType, ConcurrentHashMap.newKeySet());
       String topicName = context._backfillJobProperties.get(Constants.RESET_OFFSET_TOPIC_NAME);
       String partitionStr = context._backfillJobProperties.get(Constants.RESET_OFFSET_TOPIC_PARTITION);
-      _tableTopicsUnderBackfill.get(tableNameWithType).add(topicName);
+      String metricKey = topicName + "." + partitionStr;
+      _sourceTopicsByTable.get(tableNameWithType).add(topicName);
 
-      // Per-partition in-flight guard: _tableBackfillTopics contains the backfill Kafka topic names
-      // (not the main topic names), so any non-empty set indicates a backfill is already in flight.
-      // Track collisions per (table, topic, partition); auto-pause if collisions exceed the threshold.
+      // Per-partition in-flight guard: if this partition previously triggered a backfill that is
+      // still running, increment its collision counter. Auto-pause when the threshold is exceeded.
       String partitionKey = tableNameWithType + ":" + topicName + ":" + partitionStr;
-      Set<String> activeBackfillTopics = _tableBackfillTopics.get(tableNameWithType);
-      boolean anyBackfillInFlight = activeBackfillTopics != null && !activeBackfillTopics.isEmpty();
-      if (anyBackfillInFlight) {
-        int collisions = _partitionInFlightCollisionCount.merge(partitionKey, 1, Integer::sum);
+      if (_partitionsInFlightCount.containsKey(partitionKey)) {
+        int collisions = _partitionsInFlightCount.merge(partitionKey, 1, Integer::sum);
         int maxCollisions = _controllerConf.getMaxBackfillCollisionsBeforeAutoPause();
-        _controllerMetrics.addMeteredTableValue(tableNameWithType,
+        _controllerMetrics.addMeteredTableValue(tableNameWithType, metricKey,
             ControllerMeter.OFFSET_AUTO_RESET_BACKFILL_SKIPPED_IN_FLIGHT, 1L);
-        LOGGER.warn("In-flight backfill collision #{} for partition key {} (active backfill topics: {})",
-            collisions, partitionKey, activeBackfillTopics);
+        LOGGER.warn("In-flight backfill collision #{} for partition key {}", collisions, partitionKey);
         if (maxCollisions > 0 && collisions >= maxCollisions) {
-          LOGGER.warn("Auto-pausing backfill for table {} topic {} after {} collisions",
-              tableNameWithType, topicName, collisions);
-          _controllerMetrics.addMeteredTableValue(tableNameWithType,
+          LOGGER.warn("Auto-pausing backfill for table {} topic {} partition {} after {} collisions",
+              tableNameWithType, topicName, partitionStr, collisions);
+          _controllerMetrics.addMeteredTableValue(tableNameWithType, metricKey,
               ControllerMeter.OFFSET_AUTO_RESET_BACKFILL_SKIPPED_PAUSED, 1L);
           setPauseFlag(tableNameWithType, tableConfig, topicName);
           context._shouldTriggerBackfillJobs = false;
         }
         // Below threshold: allow trigger to proceed (new backfill coexists with the ongoing one)
-      } else {
-        _partitionInFlightCollisionCount.remove(partitionKey);
       }
 
       StreamConfig topicStreamConfig = IngestionConfigUtils.getStreamConfigs(tableConfig).stream()
@@ -170,7 +166,9 @@ public class RealtimeOffsetAutoResetManager extends ControllerPeriodicTask<Realt
               Integer.parseInt(partitionStr),
               startOffset,
               endOffset)) {
-            _controllerMetrics.addMeteredTableValue(tableNameWithType,
+            // Mark this partition as having an in-flight backfill (collision count starts at 1)
+            _partitionsInFlightCount.put(partitionKey, 1);
+            _controllerMetrics.addMeteredTableValue(tableNameWithType, metricKey,
                 ControllerMeter.OFFSET_AUTO_RESET_BACKFILL_OFFSETS, endOffset - startOffset);
           }
         } catch (NumberFormatException e) {
@@ -183,7 +181,7 @@ public class RealtimeOffsetAutoResetManager extends ControllerPeriodicTask<Realt
     ensureBackfillJobsRunning(tableNameWithType);
     ensureCompletedBackfillJobsCleanedUp(tableConfig);
 
-    Set<String> activeTopics = _tableBackfillTopics.get(tableNameWithType);
+    Set<String> activeTopics = _backfillTopicsByTable.get(tableNameWithType);
     _controllerMetrics.setValueOfTableGauge(tableNameWithType,
         ControllerGauge.BACKFILL_TOPICS_IN_PROGRESS,
         activeTopics != null ? activeTopics.size() : 0L);
@@ -200,41 +198,41 @@ public class RealtimeOffsetAutoResetManager extends ControllerPeriodicTask<Realt
     for (int i = 0; i < streamConfigs.size(); i++) {
       if (streamConfigs.get(i).isBackfillTopic() && !_llcRealtimeSegmentManager.isTopicConsumptionPaused(
           tableConfig.getTableName(), i)) {
-        _tableBackfillTopics.putIfAbsent(tableNameWithType, ConcurrentHashMap.newKeySet());
-        _tableBackfillTopics.get(tableNameWithType).add(streamConfigs.get(i).getTopicName());
+        _backfillTopicsByTable.putIfAbsent(tableNameWithType, ConcurrentHashMap.newKeySet());
+        _backfillTopicsByTable.get(tableNameWithType).add(streamConfigs.get(i).getTopicName());
       }
     }
-    if (!_tableTopicsUnderBackfill.containsKey(tableNameWithType)
-        || _tableTopicsUnderBackfill.get(tableNameWithType).isEmpty()) {
+    if (!_sourceTopicsByTable.containsKey(tableNameWithType)
+        || _sourceTopicsByTable.get(tableNameWithType).isEmpty()) {
       return;
     }
     RealtimeOffsetAutoResetHandler handler = getOrConstructHandler(tableConfig);
     if (handler == null) {
       return;
     }
-    handler.ensureBackfillJobsRunning(tableNameWithType, _tableTopicsUnderBackfill.get(tableNameWithType));
+    handler.ensureBackfillJobsRunning(tableNameWithType, _sourceTopicsByTable.get(tableNameWithType));
   }
 
   private void ensureCompletedBackfillJobsCleanedUp(TableConfig tableConfig) {
     String tableNameWithType = tableConfig.getTableName();
-    if (!_tableBackfillTopics.containsKey(tableNameWithType)) {
+    if (!_backfillTopicsByTable.containsKey(tableNameWithType)) {
       return;
     }
     LOGGER.info("Trying to clean up backfill jobs on {}", tableNameWithType);
     RealtimeOffsetAutoResetHandler handler = getOrConstructHandler(tableConfig);
     Collection<String> cleanedUpTopics = handler.cleanupCompletedBackfillJobs(
-        tableNameWithType, _tableBackfillTopics.get(tableNameWithType));
-    if (cleanedUpTopics.containsAll(_tableBackfillTopics.get(tableNameWithType))) {
-      _tableTopicsUnderBackfill.remove(tableNameWithType);
-      _tableBackfillTopics.remove(tableNameWithType);
+        tableNameWithType, _backfillTopicsByTable.get(tableNameWithType));
+    if (cleanedUpTopics.containsAll(_backfillTopicsByTable.get(tableNameWithType))) {
+      _sourceTopicsByTable.remove(tableNameWithType);
+      _backfillTopicsByTable.remove(tableNameWithType);
       // Remove all per-partition collision counters for this table
-      _partitionInFlightCollisionCount.keySet().removeIf(k -> k.startsWith(tableNameWithType + ":"));
+      _partitionsInFlightCount.keySet().removeIf(k -> k.startsWith(tableNameWithType + ":"));
       if (_tableToHandler.get(tableNameWithType) != null) {
         _tableToHandler.get(tableNameWithType).close();
         _tableToHandler.remove(tableNameWithType);
       }
     } else {
-      _tableBackfillTopics.get(tableNameWithType).removeAll(cleanedUpTopics);
+      _backfillTopicsByTable.get(tableNameWithType).removeAll(cleanedUpTopics);
     }
     if (cleanedUpTopics.size() > 0) {
       LOGGER.info("Cleaned up complete backfill topics {} for table {}", cleanedUpTopics, tableNameWithType);
@@ -246,10 +244,10 @@ public class RealtimeOffsetAutoResetManager extends ControllerPeriodicTask<Realt
   @Override
   protected void nonLeaderCleanup(List<String> tableNamesWithType) {
     for (String tableNameWithType : tableNamesWithType) {
-      _tableTopicsUnderBackfill.remove(tableNameWithType);
-      _tableBackfillTopics.remove(tableNameWithType);
+      _sourceTopicsByTable.remove(tableNameWithType);
+      _backfillTopicsByTable.remove(tableNameWithType);
       _tableToHandler.remove(tableNameWithType);
-      _partitionInFlightCollisionCount.keySet().removeIf(k -> k.startsWith(tableNameWithType + ":"));
+      _partitionsInFlightCount.keySet().removeIf(k -> k.startsWith(tableNameWithType + ":"));
     }
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeOffsetAutoResetManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeOffsetAutoResetManager.java
@@ -259,7 +259,8 @@ public class RealtimeOffsetAutoResetManager extends ControllerPeriodicTask<Realt
     for (Map<String, String> map : streamConfigMaps) {
       // Topic name is stored under the prefixed key "stream.<type>.topic.name"
       String streamType = map.get(StreamConfigProperties.STREAM_TYPE);
-      String topicKey = StreamConfigProperties.constructStreamProperty(streamType, StreamConfigProperties.STREAM_TOPIC_NAME);
+      String topicKey =
+          StreamConfigProperties.constructStreamProperty(streamType, StreamConfigProperties.STREAM_TOPIC_NAME);
       if (topicName.equals(map.get(topicKey))) {
         map.put(StreamConfigProperties.OFFSET_AUTO_RESET_PAUSE, "true");
         break;

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/validation/RealtimeOffsetAutoResetManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/validation/RealtimeOffsetAutoResetManagerTest.java
@@ -37,6 +37,7 @@ import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
 import org.apache.pinot.spi.config.table.ingestion.StreamIngestionConfig;
 import org.apache.pinot.spi.stream.StreamConfig;
+import org.apache.pinot.spi.stream.StreamConfigProperties;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -46,6 +47,7 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -250,6 +252,127 @@ public class RealtimeOffsetAutoResetManagerTest {
 
     // Handler should be created only once and reused
     // We can verify this by checking that the process completes without exception
+  }
+
+  // ---- Circuit Breaker Tests ----
+
+  @Test
+  public void testCB3MaxConcurrentBackfillsSkipsNewTrigger() {
+    // Set max concurrent to 1
+    _controllerConf.setProperty(
+        ControllerConf.ControllerPeriodicTasksConf.MAX_CONCURRENT_BACKFILLS_PER_CONTROLLER, "1");
+
+    String secondTableName = "anotherTable_REALTIME";
+    TableConfig secondTableConfig = createTableConfigWithValidHandlerClass(secondTableName, "secondTopic");
+    when(_pinotHelixResourceManager.getTableConfig(secondTableName)).thenReturn(secondTableConfig);
+
+    // Trigger a backfill on the second table so _tableBackfillTopics gets a "secondTopic" entry
+    // The TestRealtimeOffsetAutoResetHandler.cleanupCompletedBackfillJobs returns empty list,
+    // so ensureCompletedBackfillJobsCleanedUp will not clean it up.
+    // We need the handler to report active backfill topics via ensureBackfillJobsRunning.
+    // Simplest: configure the stream config of the second table with isBackfillTopic=true
+    // so ensureBackfillJobsRunning picks it up as an active backfill topic.
+    Map<String, String> backfillStreamMap = new HashMap<>();
+    backfillStreamMap.put("streamType", "kafka");
+    backfillStreamMap.put("stream.kafka.topic.name", "secondTopic-backfill");
+    backfillStreamMap.put("stream.kafka.consumer.type", "simple");
+    backfillStreamMap.put("realtime.segment.isBackfillTopic", "true");
+    backfillStreamMap.put("stream.kafka.decoder.class.name", "testDecoder");
+    IngestionConfig ingestionConfig = secondTableConfig.getIngestionConfig();
+    List<Map<String, String>> streamMaps = new java.util.ArrayList<>(
+        ingestionConfig.getStreamIngestionConfig().getStreamConfigMaps());
+    streamMaps.add(backfillStreamMap);
+    ingestionConfig.setStreamIngestionConfig(
+        new StreamIngestionConfig(streamMaps));
+    ingestionConfig.getStreamIngestionConfig().setRealtimeOffsetAutoResetHandlerClass(TEST_HANDLER_CLASS_NAME);
+    when(_llcRealtimeSegmentManager.isTopicConsumptionPaused(secondTableName, 1)).thenReturn(false);
+
+    // Run processTable on second table with no trigger to populate _tableBackfillTopics via ensureBackfillJobsRunning
+    RealtimeOffsetAutoResetManager.Context noTriggerCtx = _realtimeOffsetAutoResetManager.preprocess(new Properties());
+    _realtimeOffsetAutoResetManager.processTable(secondTableName, noTriggerCtx);
+
+    // Now try to trigger backfill on the first table — CB3 should block it (1 table already backfilling)
+    TableConfig firstTableConfig = createTableConfigWithValidHandlerClass();
+    when(_pinotHelixResourceManager.getTableConfig(REALTIME_TABLE_NAME)).thenReturn(firstTableConfig);
+    RealtimeOffsetAutoResetManager.Context firstCtx = _realtimeOffsetAutoResetManager.preprocess(_properties);
+    _realtimeOffsetAutoResetManager.processTable(REALTIME_TABLE_NAME, firstCtx);
+
+    RealtimeOffsetAutoResetHandler handler = _realtimeOffsetAutoResetManager.getTableHandler(REALTIME_TABLE_NAME);
+    Assert.assertNotNull(handler);
+    Assert.assertFalse(((TestRealtimeOffsetAutoResetHandler) handler)._triggedBackfillJob,
+        "CB3: backfill should be skipped when max concurrent limit is reached");
+  }
+
+  @Test
+  public void testCB4InFlightCollisionAtThresholdAutopauses() {
+    // threshold=1 means: the 1st collision triggers auto-pause
+    _controllerConf.setProperty(
+        ControllerConf.ControllerPeriodicTasksConf.MAX_BACKFILL_COLLISIONS_BEFORE_AUTO_PAUSE, "1");
+
+    // Set up a table config that has an active backfill topic (isBackfillTopic=true, not paused)
+    // so that _tableBackfillTopics contains TOPIC_NAME after the first processTable call.
+    Map<String, String> mainStreamMap = new HashMap<>();
+    mainStreamMap.put("streamType", "kafka");
+    mainStreamMap.put("stream.kafka.topic.name", TOPIC_NAME);
+    mainStreamMap.put("stream.kafka.consumer.type", "simple");
+    mainStreamMap.put("realtime.segment.offsetAutoReset.timeSecThreshold", "1800");
+    mainStreamMap.put("stream.kafka.decoder.class.name", "testDecoder");
+
+    Map<String, String> backfillStreamMap = new HashMap<>();
+    backfillStreamMap.put("streamType", "kafka");
+    backfillStreamMap.put("stream.kafka.topic.name", TOPIC_NAME + "-backfill");
+    backfillStreamMap.put("stream.kafka.consumer.type", "simple");
+    backfillStreamMap.put("realtime.segment.isBackfillTopic", "true");
+    backfillStreamMap.put("stream.kafka.decoder.class.name", "testDecoder");
+
+    List<Map<String, String>> maps = Arrays.asList(mainStreamMap, backfillStreamMap);
+    IngestionConfig ingestionConfig = new IngestionConfig();
+    StreamIngestionConfig streamIngestionConfig = new StreamIngestionConfig(maps);
+    streamIngestionConfig.setRealtimeOffsetAutoResetHandlerClass(TEST_HANDLER_CLASS_NAME);
+    ingestionConfig.setStreamIngestionConfig(streamIngestionConfig);
+    TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(REALTIME_TABLE_NAME).build();
+    tableConfig.setIngestionConfig(ingestionConfig);
+
+    when(_pinotHelixResourceManager.getTableConfig(REALTIME_TABLE_NAME)).thenReturn(tableConfig);
+    // backfill topic at index 1 is not paused → will be added to _tableBackfillTopics
+    when(_llcRealtimeSegmentManager.isTopicConsumptionPaused(REALTIME_TABLE_NAME, 1)).thenReturn(false);
+
+    // First processTable (no trigger) — populates _tableBackfillTopics with TOPIC_NAME via ensureBackfillJobsRunning
+    RealtimeOffsetAutoResetManager.Context noTriggerCtx = _realtimeOffsetAutoResetManager.preprocess(new Properties());
+    _realtimeOffsetAutoResetManager.processTable(REALTIME_TABLE_NAME, noTriggerCtx);
+
+    // Second processTable with trigger — collision #1, at threshold=1 → should auto-pause and skip
+    try {
+      doNothing().when(_pinotHelixResourceManager).updateTableConfig(tableConfig);
+    } catch (Exception ignored) {
+    }
+    RealtimeOffsetAutoResetManager.Context triggerCtx = _realtimeOffsetAutoResetManager.preprocess(_properties);
+    _realtimeOffsetAutoResetManager.processTable(REALTIME_TABLE_NAME, triggerCtx);
+
+    TestRealtimeOffsetAutoResetHandler handler =
+        (TestRealtimeOffsetAutoResetHandler) _realtimeOffsetAutoResetManager.getTableHandler(REALTIME_TABLE_NAME);
+    Assert.assertNotNull(handler);
+    Assert.assertFalse(handler._triggedBackfillJob,
+        "CB4: collision at threshold should skip the backfill trigger");
+    // Verify pause flag set on the main topic's stream config map
+    Assert.assertEquals(mainStreamMap.get(StreamConfigProperties.OFFSET_AUTO_RESET_PAUSE), "true",
+        "CB4: pause flag should be set on the main topic stream config");
+  }
+
+  private TableConfig createTableConfigWithValidHandlerClass(String tableName, String topicName) {
+    TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(tableName).build();
+    IngestionConfig ingestionConfig = new IngestionConfig();
+    Map<String, String> streamConfigMap = new HashMap<>();
+    streamConfigMap.put("streamType", "kafka");
+    streamConfigMap.put("stream.kafka.topic.name", topicName);
+    streamConfigMap.put("stream.kafka.consumer.type", "simple");
+    streamConfigMap.put("realtime.segment.offsetAutoReset.timeSecThreshold", "1800");
+    streamConfigMap.put("stream.kafka.decoder.class.name", "testDecoder");
+    StreamIngestionConfig streamIngestionConfig = new StreamIngestionConfig(Collections.singletonList(streamConfigMap));
+    streamIngestionConfig.setRealtimeOffsetAutoResetHandlerClass(TEST_HANDLER_CLASS_NAME);
+    ingestionConfig.setStreamIngestionConfig(streamIngestionConfig);
+    tableConfig.setIngestionConfig(ingestionConfig);
+    return tableConfig;
   }
 
   private TableConfig createTableConfigWithoutHandlerClass() {

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/validation/RealtimeOffsetAutoResetManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/validation/RealtimeOffsetAutoResetManagerTest.java
@@ -266,7 +266,7 @@ public class RealtimeOffsetAutoResetManagerTest {
     TableConfig secondTableConfig = createTableConfigWithValidHandlerClass(secondTableName, "secondTopic");
     when(_pinotHelixResourceManager.getTableConfig(secondTableName)).thenReturn(secondTableConfig);
 
-    // Trigger a backfill on the second table so _tableBackfillTopics gets a "secondTopic" entry
+    // Trigger a backfill on the second table so _backfillTopicsByTable gets a "secondTopic" entry
     // The TestRealtimeOffsetAutoResetHandler.cleanupCompletedBackfillJobs returns empty list,
     // so ensureCompletedBackfillJobsCleanedUp will not clean it up.
     // We need the handler to report active backfill topics via ensureBackfillJobsRunning.
@@ -287,7 +287,7 @@ public class RealtimeOffsetAutoResetManagerTest {
     ingestionConfig.getStreamIngestionConfig().setRealtimeOffsetAutoResetHandlerClass(TEST_HANDLER_CLASS_NAME);
     when(_llcRealtimeSegmentManager.isTopicConsumptionPaused(secondTableName, 1)).thenReturn(false);
 
-    // Run processTable on second table with no trigger to populate _tableBackfillTopics via ensureBackfillJobsRunning
+    // Run processTable on second table with no trigger to populate _backfillTopicsByTable via ensureBackfillJobsRunning
     RealtimeOffsetAutoResetManager.Context noTriggerCtx = _realtimeOffsetAutoResetManager.preprocess(new Properties());
     _realtimeOffsetAutoResetManager.processTable(secondTableName, noTriggerCtx);
 
@@ -305,12 +305,10 @@ public class RealtimeOffsetAutoResetManagerTest {
 
   @Test
   public void testInFlightCollisionAtThresholdAutopauses() {
-    // threshold=1 means: the 1st collision triggers auto-pause
+    // threshold=1: on the 2nd trigger for the same partition, auto-pause fires
     _controllerConf.setProperty(
         ControllerConf.ControllerPeriodicTasksConf.MAX_BACKFILL_COLLISIONS_BEFORE_AUTO_PAUSE, "1");
 
-    // Set up a table config that has an active backfill topic (isBackfillTopic=true, not paused)
-    // so that _tableBackfillTopics contains TOPIC_NAME after the first processTable call.
     Map<String, String> mainStreamMap = new HashMap<>();
     mainStreamMap.put("streamType", "kafka");
     mainStreamMap.put("stream.kafka.topic.name", TOPIC_NAME);
@@ -318,14 +316,7 @@ public class RealtimeOffsetAutoResetManagerTest {
     mainStreamMap.put("realtime.segment.offsetAutoReset.timeSecThreshold", "1800");
     mainStreamMap.put("stream.kafka.decoder.class.name", "testDecoder");
 
-    Map<String, String> backfillStreamMap = new HashMap<>();
-    backfillStreamMap.put("streamType", "kafka");
-    backfillStreamMap.put("stream.kafka.topic.name", TOPIC_NAME + "-backfill");
-    backfillStreamMap.put("stream.kafka.consumer.type", "simple");
-    backfillStreamMap.put("realtime.segment.isBackfillTopic", "true");
-    backfillStreamMap.put("stream.kafka.decoder.class.name", "testDecoder");
-
-    List<Map<String, String>> maps = Arrays.asList(mainStreamMap, backfillStreamMap);
+    List<Map<String, String>> maps = Collections.singletonList(mainStreamMap);
     IngestionConfig ingestionConfig = new IngestionConfig();
     StreamIngestionConfig streamIngestionConfig = new StreamIngestionConfig(maps);
     streamIngestionConfig.setRealtimeOffsetAutoResetHandlerClass(TEST_HANDLER_CLASS_NAME);
@@ -334,27 +325,29 @@ public class RealtimeOffsetAutoResetManagerTest {
     tableConfig.setIngestionConfig(ingestionConfig);
 
     when(_pinotHelixResourceManager.getTableConfig(REALTIME_TABLE_NAME)).thenReturn(tableConfig);
-    // backfill topic at index 1 is not paused → will be added to _tableBackfillTopics
-    when(_llcRealtimeSegmentManager.isTopicConsumptionPaused(REALTIME_TABLE_NAME, 1)).thenReturn(false);
-
-    // First processTable (no trigger) — populates _tableBackfillTopics with TOPIC_NAME via ensureBackfillJobsRunning
-    RealtimeOffsetAutoResetManager.Context noTriggerCtx = _realtimeOffsetAutoResetManager.preprocess(new Properties());
-    _realtimeOffsetAutoResetManager.processTable(REALTIME_TABLE_NAME, noTriggerCtx);
-
-    // Second processTable with trigger — collision #1, at threshold=1 → should auto-pause and skip
     try {
       doNothing().when(_pinotHelixResourceManager).updateTableConfig(tableConfig);
     } catch (Exception ignored) {
     }
-    RealtimeOffsetAutoResetManager.Context triggerCtx = _realtimeOffsetAutoResetManager.preprocess(_properties);
-    _realtimeOffsetAutoResetManager.processTable(REALTIME_TABLE_NAME, triggerCtx);
+
+    // First trigger — succeeds, sets _partitionsInFlightCount[partition]=1
+    RealtimeOffsetAutoResetManager.Context firstCtx = _realtimeOffsetAutoResetManager.preprocess(_properties);
+    _realtimeOffsetAutoResetManager.processTable(REALTIME_TABLE_NAME, firstCtx);
 
     TestRealtimeOffsetAutoResetHandler handler =
         (TestRealtimeOffsetAutoResetHandler) _realtimeOffsetAutoResetManager.getTableHandler(REALTIME_TABLE_NAME);
     Assert.assertNotNull(handler);
+    Assert.assertTrue(handler._triggedBackfillJob, "first trigger should succeed");
+
+    // Reset flag to detect whether second trigger fires
+    handler._triggedBackfillJob = false;
+
+    // Second trigger for the same partition — collision #1 >= threshold=1 → auto-pause, skip trigger
+    RealtimeOffsetAutoResetManager.Context secondCtx = _realtimeOffsetAutoResetManager.preprocess(_properties);
+    _realtimeOffsetAutoResetManager.processTable(REALTIME_TABLE_NAME, secondCtx);
+
     Assert.assertFalse(handler._triggedBackfillJob,
         "collision at threshold should skip the backfill trigger");
-    // Verify pause flag set on the main topic's stream config map
     Assert.assertEquals(mainStreamMap.get(StreamConfigProperties.OFFSET_AUTO_RESET_PAUSE), "true",
         "pause flag should be set on the main topic stream config");
   }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/validation/RealtimeOffsetAutoResetManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/validation/RealtimeOffsetAutoResetManagerTest.java
@@ -257,7 +257,7 @@ public class RealtimeOffsetAutoResetManagerTest {
   // ---- Circuit Breaker Tests ----
 
   @Test
-  public void testCB3MaxConcurrentBackfillsSkipsNewTrigger() {
+  public void testMaxConcurrentBackfillsSkipsNewTrigger() {
     // Set max concurrent to 1
     _controllerConf.setProperty(
         ControllerConf.ControllerPeriodicTasksConf.MAX_CONCURRENT_BACKFILLS_PER_CONTROLLER, "1");
@@ -291,7 +291,7 @@ public class RealtimeOffsetAutoResetManagerTest {
     RealtimeOffsetAutoResetManager.Context noTriggerCtx = _realtimeOffsetAutoResetManager.preprocess(new Properties());
     _realtimeOffsetAutoResetManager.processTable(secondTableName, noTriggerCtx);
 
-    // Now try to trigger backfill on the first table — CB3 should block it (1 table already backfilling)
+    // Now try to trigger backfill on the first table — should be blocked (1 table already backfilling)
     TableConfig firstTableConfig = createTableConfigWithValidHandlerClass();
     when(_pinotHelixResourceManager.getTableConfig(REALTIME_TABLE_NAME)).thenReturn(firstTableConfig);
     RealtimeOffsetAutoResetManager.Context firstCtx = _realtimeOffsetAutoResetManager.preprocess(_properties);
@@ -300,11 +300,11 @@ public class RealtimeOffsetAutoResetManagerTest {
     RealtimeOffsetAutoResetHandler handler = _realtimeOffsetAutoResetManager.getTableHandler(REALTIME_TABLE_NAME);
     Assert.assertNotNull(handler);
     Assert.assertFalse(((TestRealtimeOffsetAutoResetHandler) handler)._triggedBackfillJob,
-        "CB3: backfill should be skipped when max concurrent limit is reached");
+        "backfill should be skipped when max concurrent limit is reached");
   }
 
   @Test
-  public void testCB4InFlightCollisionAtThresholdAutopauses() {
+  public void testInFlightCollisionAtThresholdAutopauses() {
     // threshold=1 means: the 1st collision triggers auto-pause
     _controllerConf.setProperty(
         ControllerConf.ControllerPeriodicTasksConf.MAX_BACKFILL_COLLISIONS_BEFORE_AUTO_PAUSE, "1");
@@ -353,10 +353,10 @@ public class RealtimeOffsetAutoResetManagerTest {
         (TestRealtimeOffsetAutoResetHandler) _realtimeOffsetAutoResetManager.getTableHandler(REALTIME_TABLE_NAME);
     Assert.assertNotNull(handler);
     Assert.assertFalse(handler._triggedBackfillJob,
-        "CB4: collision at threshold should skip the backfill trigger");
+        "collision at threshold should skip the backfill trigger");
     // Verify pause flag set on the main topic's stream config map
     Assert.assertEquals(mainStreamMap.get(StreamConfigProperties.OFFSET_AUTO_RESET_PAUSE), "true",
-        "CB4: pause flag should be set on the main topic stream config");
+        "pause flag should be set on the main topic stream config");
   }
 
   private TableConfig createTableConfigWithValidHandlerClass(String tableName, String topicName) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfig.java
@@ -438,6 +438,22 @@ public class StreamConfig {
     return Boolean.TRUE.equals(_backfillTopic);
   }
 
+  public boolean isOffsetAutoResetPaused() {
+    return Boolean.parseBoolean(_streamConfigMap.get(StreamConfigProperties.OFFSET_AUTO_RESET_PAUSE));
+  }
+
+  public int getOffsetAutoResetMaxSegmentsBeforeSkip() {
+    String val = _streamConfigMap.get(StreamConfigProperties.OFFSET_AUTO_RESET_MAX_SEGMENTS_BEFORE_SKIP);
+    if (val == null) {
+      return -1;
+    }
+    try {
+      return Integer.parseInt(val);
+    } catch (NumberFormatException e) {
+      return -1;
+    }
+  }
+
   public String getTableNameWithType() {
     return _tableNameWithType;
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfigProperties.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfigProperties.java
@@ -164,6 +164,19 @@ public class StreamConfigProperties {
   public static final String BACKFILL_TOPIC = "realtime.segment.isBackfillTopic";
 
   /**
+   * When true, skip triggering offset auto-reset backfill for this stream/topic.
+   * Can be set per stream config entry (per topic). Cleared by the operator via normal table config update.
+   */
+  public static final String OFFSET_AUTO_RESET_PAUSE = "realtime.segment.offsetAutoReset.pause";
+
+  /**
+   * If the segment count for the table >= this value, skip triggering a backfill.
+   * -1 or absent means disabled. Prevents znode limit pressure when ingestion is permanently high.
+   */
+  public static final String OFFSET_AUTO_RESET_MAX_SEGMENTS_BEFORE_SKIP =
+      "realtime.segment.offsetAutoReset.maxSegmentsBeforeBackfillSkip";
+
+  /**
    * Helper method to create a stream specific property
    */
   public static String constructStreamProperty(String streamType, String property) {


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Flow of offset auto\-reset backfill triggering with circuit breakers for concurrent limits and in\-flight collisions\.

```mermaid
flowchart TD
  N0["Initial skip check #40;F5#41;"]:::stModified
  N1["Max concurrent check #40;F5#41;"]:::stModified
  N2["Prepare trigger #40;F5#41;"]:::stModified
  N3["In#45;flight check#63; #40;F5#41;"]:::stModified
  N4["Handle collision #40;F5#41;"]:::stModified
  N5["Flag check for trigger #40;F5#41;"]:::stModified
  N6["Trigger backfill job #40;F5#41;"]:::stModified
  N7["Ensure backfill running #40;F5#41;"]:::stModified
  N8["Ensure cleanup #40;F5#41;"]:::stModified
  N0 -->|"not skipped"| N1
  N1 -->|"skipped by concurrent"| N7
  N1 -->|"not skipped"| N2
  N2 --> N3
  N3 -->|"in#45;flight"| N4
  N3 -->|"not in#45;flight"| N5
  N4 --> N5
  N5 -->|"flag true"| N6
  N5 -->|"flag false"| N7
  N6 --> N7
  N7 --> N8
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F5: pinot\-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeOffsetAutoResetManager\.java — [before](https://github.com/apache/pinot/blob/5f9d23b0f428f711bb5477d0bd1def1943439610/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeOffsetAutoResetManager.java) · [after](https://github.com/apache/pinot/blob/f8717c39b3f7a679bf18e8deac019b4c951487ec/pinot-controller/src/main/java/org/apache/pinot/controller/validation/RealtimeOffsetAutoResetManager.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjVmOWQyM2IwZjQyOGY3MTFiYjU0NzdkMGJkMWRlZjE5NDM0Mzk2MTAiLCJjb250ZXh0X2hhc2giOiJjN2VhNGMzMWU1OGVkNDdkNDY3ZDQ0MjEzNjJlZmY5YmU1YmJkNDI2MWRmMDg4ZjBjMzQwN2EzNmY1OGUwNjZlIiwiZ2VuZXJhdGVkX2F0IjoxNzg5NTQ1Mjc3LCJoZWFkX3NoYSI6ImY4NzE3YzM5YjNmN2E2NzliZjE4ZThkZWFjMDE5YjRjOTUxNDg3ZWMiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJhMGNiYTdiMjgzOGM2ZjkwYmZlODNjOGE2ZGNmZGVkZDMzZmJkMjRlIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 7d7b14c73b2af3c37b8e7d47575e93458967b88e92efa14d80d1f7070e237cb6 -->
<!-- pinot-pr-flow:end -->

Introduces four independent circuit breakers to prevent unbounded backfill triggering when a cluster is overwhelmed or restarts after prolonged downtime:

1. Pause flag per topic (`realtime.segment.offsetAutoReset.pause`): operator-set boolean in stream config; checked in computeStartOffset() before any backfill decision is made.

2. Max segments guard (`realtime.segment.offsetAutoReset.maxSegmentsBeforeBackfillSkip`): skips backfill trigger if table's segment count >= configured limit, preventing znode exhaustion when ingestion is permanently elevated.

3. Max concurrent backfills per controller (`controller.realtime.offsetAutoReset.maxConcurrentBackfillsPerController`): caps the number of tables that can simultaneously backfill on a single controller instance, guarding against cluster-restart storms.

4. Per-partition in-flight collision threshold (`controller.realtime.offsetAutoReset.maxBackfillCollisionsBeforeAutoPause`, default 3): tracks consecutive backfill-trigger attempts on a partition that already has an active backfill. Below the threshold the new trigger is allowed; at or above the threshold the topic's pause flag is set automatically and a metric is emitted requiring operator intervention.

New ControllerMeter entries are added for each skipped-backfill scenario to enable alerting on all circuit breaker activations.

Fixes: https://github.com/apache/pinot/issues/18314

Deployed and tested.
<img width="1200" height="582" alt="Screenshot 2026-05-20 at 11 06 32 PM" src="https://github.com/user-attachments/assets/c01b850d-e2cb-4fa9-b7bb-e6e40aabd715" />



`bugfix` 