### PR TITLE
Emit topic name in ingestion delay metrics

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/AbstractMetrics.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/AbstractMetrics.java
@@ -570,6 +570,21 @@ public abstract class AbstractMetrics<QP extends AbstractMetrics.QueryPhase, M e
   }
 
   /**
+   * Install a per-partition topic table gauge.
+   *
+   * @param tableName The table name
+   * @param partitionId The partition id
+   * @param topicName The topic name
+   * @param gauge The gauge to use
+   * @param valueSupplier The supplier function used to retrieve the value of the gauge.
+   */
+  public void setOrUpdatePartitionTopicGauge(final String tableName, final int partitionId,
+      final String topicName, final G gauge, final Supplier<Long> valueSupplier) {
+    final String fullGaugeName = composeTableTopicGaugeName(tableName, String.valueOf(partitionId), topicName, gauge);
+    setOrUpdateGauge(fullGaugeName, valueSupplier);
+  }
+
+  /**
    * @deprecated please use setOrUpdateGauge(final String metricName, final Supplier<Long> valueSupplier) instead.
    *
    * Adds a new gauge whose values are retrieved from a callback function.
@@ -765,6 +780,20 @@ public abstract class AbstractMetrics<QP extends AbstractMetrics.QueryPhase, M e
   }
 
   /**
+   * Removes a table gauge given the table name, the partition id, topic name and the gauge.
+   * The add/remove is expected to work correctly in case of being invoked across multiple threads.
+   * @param tableName table name
+   * @param partitionId The partition id
+   * @param topicName The topic name
+   * @param gauge the gauge to be removed
+   */
+  public void removePartitionTopicGauge(final String tableName, final int partitionId,
+      final String topicName, final G gauge) {
+    final String fullGaugeName = composeTableTopicGaugeName(tableName, String.valueOf(partitionId), topicName, gauge);
+    removeGauge(fullGaugeName);
+  }
+
+  /**
    * Removes a table gauge given the table name, the key and the gauge.
    * The add/remove is expected to work correctly in case of being invoked across multiple threads.
    * @param tableName table name
@@ -786,6 +815,11 @@ public abstract class AbstractMetrics<QP extends AbstractMetrics.QueryPhase, M e
 
   private String composeTableGaugeName(final String tableName, final String key, final G gauge) {
     return gauge.getGaugeName() + "." + getTableName(tableName) + "." + key;
+  }
+
+  private String composeTableTopicGaugeName(final String tableName, final String key,
+      final String topicName, final G gauge) {
+    return gauge.getGaugeName() + "." + getTableName(tableName) + "." + key + "." + topicName;
   }
 
   public String composePluginGaugeName(String pluginName, Gauge gauge) {

--- a/pinot-common/src/test/java/org/apache/pinot/common/metrics/AbstractMetricsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/metrics/AbstractMetricsTest.java
@@ -408,6 +408,27 @@ public abstract class AbstractMetricsTest {
   }
 
   @Test
+  public void testPartitionTopicGauges() {
+    ControllerMetrics controllerMetrics = buildTestMetrics();
+    String table = "test_table";
+    int partitionId = 7;
+    String topicName = "test_topic";
+
+    controllerMetrics.setOrUpdatePartitionTopicGauge(table, partitionId, topicName, ControllerGauge.VERSION, () -> 1L);
+    Assert.assertEquals(
+        getGaugeValue(controllerMetrics,
+            ControllerGauge.VERSION.getGaugeName() + "." + table + "." + partitionId + "." + topicName), 1);
+
+    controllerMetrics.setOrUpdatePartitionTopicGauge(table, partitionId, topicName, ControllerGauge.VERSION, () -> 2L);
+    Assert.assertEquals(
+        getGaugeValue(controllerMetrics,
+            ControllerGauge.VERSION.getGaugeName() + "." + table + "." + partitionId + "." + topicName), 2);
+
+    controllerMetrics.removePartitionTopicGauge(table, partitionId, topicName, ControllerGauge.VERSION);
+    Assert.assertTrue(controllerMetrics.getMetricsRegistry().allMetrics().isEmpty());
+  }
+
+  @Test
   public void testAddCallbackGauges() {
     ControllerMetrics controllerMetrics = buildTestMetrics();
     String table = "test_table";

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTracker.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTracker.java
@@ -372,43 +372,52 @@ public class IngestionDelayTracker {
   @VisibleForTesting
   void createMetrics(int partitionId) {
     int streamConfigIndex = IngestionConfigUtils.getStreamConfigIndexFromPinotPartitionId(partitionId);
+    List<StreamConfig> streamConfigs =
+        IngestionConfigUtils.getStreamConfigs(_realTimeTableDataManager.getCachedTableConfigAndSchema().getLeft());
+    String topicName = streamConfigs.get(streamConfigIndex).getTopicName();
     StreamMetadataProvider streamMetadataProvider = _streamConfigIndexToStreamMetadataProvider.get(streamConfigIndex);
 
     if (streamMetadataProvider != null && streamMetadataProvider.supportsOffsetLag()) {
-      _serverMetrics.setOrUpdatePartitionGauge(_metricName, partitionId, ServerGauge.REALTIME_INGESTION_OFFSET_LAG,
-          () -> getPartitionIngestionOffsetLag(partitionId));
+      _serverMetrics.setOrUpdatePartitionTopicGauge(_metricName, partitionId, topicName,
+          ServerGauge.REALTIME_INGESTION_OFFSET_LAG, () -> getPartitionIngestionOffsetLag(partitionId));
 
-      _serverMetrics.setOrUpdatePartitionGauge(_metricName, partitionId,
+      _serverMetrics.setOrUpdatePartitionTopicGauge(_metricName, partitionId, topicName,
           ServerGauge.REALTIME_INGESTION_CONSUMING_OFFSET, () -> getPartitionIngestionConsumingOffset(partitionId));
 
-      _serverMetrics.setOrUpdatePartitionGauge(_metricName, partitionId,
+      _serverMetrics.setOrUpdatePartitionTopicGauge(_metricName, partitionId, topicName,
           ServerGauge.REALTIME_INGESTION_UPSTREAM_OFFSET, () -> getLatestPartitionOffset(partitionId));
     }
-    _serverMetrics.setOrUpdatePartitionGauge(_metricName, partitionId, ServerGauge.REALTIME_INGESTION_DELAY_MS,
-        () -> getPartitionIngestionDelayMs(partitionId));
-    _serverMetrics.setOrUpdatePartitionGauge(_metricName, partitionId,
+    _serverMetrics.setOrUpdatePartitionTopicGauge(_metricName, partitionId, topicName,
+        ServerGauge.REALTIME_INGESTION_DELAY_MS, () -> getPartitionIngestionDelayMs(partitionId));
+    _serverMetrics.setOrUpdatePartitionTopicGauge(_metricName, partitionId, topicName,
         ServerGauge.END_TO_END_REALTIME_INGESTION_DELAY_MS, () -> getPartitionEndToEndIngestionDelayMs(partitionId));
-    _serverMetrics.setOrUpdatePartitionGauge(_metricName, partitionId,
+    _serverMetrics.setOrUpdatePartitionTopicGauge(_metricName, partitionId, topicName,
         ServerGauge.REALTIME_INGESTION_DELAY_REPORTING_STATUS, () -> getPartitionIngestionReportingStatus(partitionId));
 
     LOGGER.info("Successfully created ingestion metrics for partition id: {}", partitionId);
   }
 
-  private void removeMetrics(int partitionId) {
+  @VisibleForTesting
+  void removeMetrics(int partitionId) {
     int streamConfigIndex = IngestionConfigUtils.getStreamConfigIndexFromPinotPartitionId(partitionId);
-    StreamMetadataProvider streamMetadataProvider =
-        _streamConfigIndexToStreamMetadataProvider.get(streamConfigIndex);
-    // Remove all metrics associated with this partition
+    List<StreamConfig> streamConfigs =
+        IngestionConfigUtils.getStreamConfigs(_realTimeTableDataManager.getCachedTableConfigAndSchema().getLeft());
+    String topicName = streamConfigs.get(streamConfigIndex).getTopicName();
+    StreamMetadataProvider streamMetadataProvider = _streamConfigIndexToStreamMetadataProvider.get(streamConfigIndex);
+
     if (streamMetadataProvider != null && streamMetadataProvider.supportsOffsetLag()) {
-      _serverMetrics.removePartitionGauge(_metricName, partitionId, ServerGauge.REALTIME_INGESTION_OFFSET_LAG);
-      _serverMetrics.removePartitionGauge(_metricName, partitionId, ServerGauge.REALTIME_INGESTION_UPSTREAM_OFFSET);
-      _serverMetrics.removePartitionGauge(_metricName, partitionId,
+      _serverMetrics.removePartitionTopicGauge(_metricName, partitionId, topicName,
+          ServerGauge.REALTIME_INGESTION_OFFSET_LAG);
+      _serverMetrics.removePartitionTopicGauge(_metricName, partitionId, topicName,
+          ServerGauge.REALTIME_INGESTION_UPSTREAM_OFFSET);
+      _serverMetrics.removePartitionTopicGauge(_metricName, partitionId, topicName,
           ServerGauge.REALTIME_INGESTION_CONSUMING_OFFSET);
     }
-    _serverMetrics.removePartitionGauge(_metricName, partitionId, ServerGauge.REALTIME_INGESTION_DELAY_MS);
-    _serverMetrics.removePartitionGauge(_metricName, partitionId,
+    _serverMetrics.removePartitionTopicGauge(_metricName, partitionId, topicName,
+        ServerGauge.REALTIME_INGESTION_DELAY_MS);
+    _serverMetrics.removePartitionTopicGauge(_metricName, partitionId, topicName,
         ServerGauge.END_TO_END_REALTIME_INGESTION_DELAY_MS);
-    _serverMetrics.removePartitionGauge(_metricName, partitionId,
+    _serverMetrics.removePartitionTopicGauge(_metricName, partitionId, topicName,
         ServerGauge.REALTIME_INGESTION_DELAY_REPORTING_STATUS);
 
     LOGGER.info("Successfully removed ingestion metrics for partition id: {}", partitionId);
@@ -503,26 +512,26 @@ public class IngestionDelayTracker {
     // involves network traffic and may be inefficient.
     List<Integer> partitionsToVerify = getPartitionsToBeVerified();
     if (partitionsToVerify.isEmpty()) {
-      // Don't make the call to getHostedPartitionsGroupIds() as it involves checking ideal state.
+      // Don't make the call to getHostedConsumingPartitionsGroupIds() as it involves checking ideal state.
       return;
     }
-    Set<Integer> partitionsHostedByThisServer;
+    Set<Integer> consumingPartitionsHostedByThisServer;
     try {
-      partitionsHostedByThisServer = _realTimeTableDataManager.getHostedPartitionsGroupIds();
+      consumingPartitionsHostedByThisServer = _realTimeTableDataManager.getHostedConsumingPartitionsGroupIds();
     } catch (Exception e) {
       LOGGER.error("Failed to get partitions hosted by this server, table={}, exception={}:{}", _tableNameWithType,
           e.getClass(), e.getMessage());
       return;
     }
     for (int partitionId : partitionsToVerify) {
-      if (!partitionsHostedByThisServer.contains(partitionId)) {
-        // Partition is not hosted in this server anymore, stop tracking it
+      if (!consumingPartitionsHostedByThisServer.contains(partitionId)) {
+        // Partition is not hosted in this server anymore or is not consuming anymore, stop tracking it
         removePartitionId(partitionId);
       }
     }
 
     ConcurrentHashMap<Integer, Boolean> newMap = new ConcurrentHashMap<>();
-    partitionsHostedByThisServer.forEach(p -> newMap.put(p, true));
+    consumingPartitionsHostedByThisServer.forEach(p -> newMap.put(p, true));
     _partitionsHostedByThisServer = newMap;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -398,7 +398,7 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
    * Returns all partitionGroupIds for the partitions hosted by this server for current table.
    * @apiNote this involves Zookeeper read and should not be used frequently due to efficiency concerns.
    */
-  public Set<Integer> getHostedPartitionsGroupIds() {
+  public Set<Integer> getHostedConsumingPartitionsGroupIds() {
     Set<Integer> partitionsHostedByThisServer = new HashSet<>();
     List<String> segments = TableStateUtils.getSegmentsInGivenStateForThisInstance(_helixManager, _tableNameWithType,
         CommonConstants.Helix.StateModel.SegmentStateModel.CONSUMING);

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTrackerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTrackerTest.java
@@ -51,7 +51,10 @@ import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 
 
 public class IngestionDelayTrackerTest {
@@ -571,5 +574,75 @@ public class IngestionDelayTrackerTest {
   private void assertIncreasing(Map<String, List<Long>> metrics, String key) {
     List<Long> values = metrics.get(key);
     Assert.assertTrue(values.get(values.size() - 1) > values.get(0), key + " not increasing");
+  }
+
+  @Test
+  public void testCreateMetricsUsesTopicName() {
+    // The stream config in REALTIME_TABLE_DATA_MANAGER uses topic name "test"
+    String expectedTopicName = "test";
+    int partitionId = 0;
+
+    // Use a fresh ServerMetrics mock so we can verify calls on it
+    ServerMetrics serverMetricsMock = mock(ServerMetrics.class);
+    IngestionDelayTracker tracker =
+        new IngestionDelayTracker(serverMetricsMock, REALTIME_TABLE_NAME, REALTIME_TABLE_DATA_MANAGER, () -> true);
+    tracker.createMetrics(partitionId);
+
+    // Verify that all ingestion gauges include the topic name
+    verify(serverMetricsMock).setOrUpdatePartitionTopicGauge(
+        eq(REALTIME_TABLE_NAME), eq(partitionId), eq(expectedTopicName),
+        eq(ServerGauge.REALTIME_INGESTION_DELAY_MS), any());
+    verify(serverMetricsMock).setOrUpdatePartitionTopicGauge(
+        eq(REALTIME_TABLE_NAME), eq(partitionId), eq(expectedTopicName),
+        eq(ServerGauge.END_TO_END_REALTIME_INGESTION_DELAY_MS), any());
+    verify(serverMetricsMock).setOrUpdatePartitionTopicGauge(
+        eq(REALTIME_TABLE_NAME), eq(partitionId), eq(expectedTopicName),
+        eq(ServerGauge.REALTIME_INGESTION_DELAY_REPORTING_STATUS), any());
+    // FakeStreamMetadataProvider.supportsOffsetLag() returns true, so these should also be called
+    verify(serverMetricsMock).setOrUpdatePartitionTopicGauge(
+        eq(REALTIME_TABLE_NAME), eq(partitionId), eq(expectedTopicName),
+        eq(ServerGauge.REALTIME_INGESTION_OFFSET_LAG), any());
+    verify(serverMetricsMock).setOrUpdatePartitionTopicGauge(
+        eq(REALTIME_TABLE_NAME), eq(partitionId), eq(expectedTopicName),
+        eq(ServerGauge.REALTIME_INGESTION_CONSUMING_OFFSET), any());
+    verify(serverMetricsMock).setOrUpdatePartitionTopicGauge(
+        eq(REALTIME_TABLE_NAME), eq(partitionId), eq(expectedTopicName),
+        eq(ServerGauge.REALTIME_INGESTION_UPSTREAM_OFFSET), any());
+
+    tracker.shutdown();
+  }
+
+  @Test
+  public void testRemoveMetricsUsesTopicName() {
+    String expectedTopicName = "test";
+    int partitionId = 0;
+
+    ServerMetrics serverMetricsMock = mock(ServerMetrics.class);
+    IngestionDelayTracker tracker =
+        new IngestionDelayTracker(serverMetricsMock, REALTIME_TABLE_NAME, REALTIME_TABLE_DATA_MANAGER, () -> true);
+    // createMetrics must be called first so the stream metadata provider is set up
+    tracker.createMetrics(partitionId);
+    tracker.removeMetrics(partitionId);
+
+    verify(serverMetricsMock).removePartitionTopicGauge(
+        eq(REALTIME_TABLE_NAME), eq(partitionId), eq(expectedTopicName),
+        eq(ServerGauge.REALTIME_INGESTION_DELAY_MS));
+    verify(serverMetricsMock).removePartitionTopicGauge(
+        eq(REALTIME_TABLE_NAME), eq(partitionId), eq(expectedTopicName),
+        eq(ServerGauge.END_TO_END_REALTIME_INGESTION_DELAY_MS));
+    verify(serverMetricsMock).removePartitionTopicGauge(
+        eq(REALTIME_TABLE_NAME), eq(partitionId), eq(expectedTopicName),
+        eq(ServerGauge.REALTIME_INGESTION_DELAY_REPORTING_STATUS));
+    verify(serverMetricsMock).removePartitionTopicGauge(
+        eq(REALTIME_TABLE_NAME), eq(partitionId), eq(expectedTopicName),
+        eq(ServerGauge.REALTIME_INGESTION_OFFSET_LAG));
+    verify(serverMetricsMock).removePartitionTopicGauge(
+        eq(REALTIME_TABLE_NAME), eq(partitionId), eq(expectedTopicName),
+        eq(ServerGauge.REALTIME_INGESTION_UPSTREAM_OFFSET));
+    verify(serverMetricsMock).removePartitionTopicGauge(
+        eq(REALTIME_TABLE_NAME), eq(partitionId), eq(expectedTopicName),
+        eq(ServerGauge.REALTIME_INGESTION_CONSUMING_OFFSET));
+
+    tracker.shutdown();
   }
 }


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Emit topic name in ingestion delay metrics by creating gauges with table, partition, and topic in the name\.

```mermaid
flowchart TD
  N0["IngestionDelayTracker#46;createMetrics #40;F2#41;"]:::stModified
  N1["IngestionDelayTracker#58; extract topic name #40;F2#41;"]:::stModified
  N2["AbstractMetrics#46;setOrUpdatePartitionTopicGauge #40;F1#41;"]:::stAdded
  N3["AbstractMetrics#46;composeTableTopicGaugeName #40;F1#41;"]:::stAdded
  N4["AbstractMetrics#46;setOrUpdateGauge #40;F1#41;"]:::stModified
  N0 -->|"calls"| N1
  N1 -->|"passes topic name"| N2
  N2 -->|"calls"| N3
  N3 -->|"passes gauge name"| N4
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-common/src/main/java/org/apache/pinot/common/metrics/AbstractMetrics\.java — [before](https://github.com/apache/pinot/blob/5f9d23b0f428f711bb5477d0bd1def1943439610/pinot-common/src/main/java/org/apache/pinot/common/metrics/AbstractMetrics.java) · [after](https://github.com/apache/pinot/blob/20b402f24ed54cd139c9c1b90be557af916bb259/pinot-common/src/main/java/org/apache/pinot/common/metrics/AbstractMetrics.java)
- F2: pinot\-core/src/main/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTracker\.java — [before](https://github.com/apache/pinot/blob/5f9d23b0f428f711bb5477d0bd1def1943439610/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTracker.java) · [after](https://github.com/apache/pinot/blob/20b402f24ed54cd139c9c1b90be557af916bb259/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTracker.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjVmOWQyM2IwZjQyOGY3MTFiYjU0NzdkMGJkMWRlZjE5NDM0Mzk2MTAiLCJjb250ZXh0X2hhc2giOiIwOWI2YjcxNTZkMjNmOGI1ZDM1N2ViNDRlMzBkY2VmOTBiNzU2ZmY0MDI4OGE3NjI2NWViYTRmOTAzMWI5OWRjIiwiZ2VuZXJhdGVkX2F0IjoxNzg5MjA4ODQzLCJoZWFkX3NoYSI6IjIwYjQwMmYyNGVkNTRjZDEzOWM5YzFiOTBiZTU1N2FmOTE2YmIyNTkiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiI1MWJjZWMzYjg4ZmUxNTEzNjJlZjc5YmRlYTFiMjY1MTVlNmZmM2NhIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 3e6865b5572bcfc3d3ff6bcb89f4a351719fed90af9efbefd6cfb8800e7997ab -->
<!-- pinot-pr-flow:end -->

Include the Kafka topic name as part of the ingestion delay gauge metric name so that operators can distinguish metrics by topic when a table has multiple upstream streams.

- Add `setOrUpdatePartitionTopicGauge` / `removePartitionTopicGauge` to AbstractMetrics, composing the metric name as <gauge>.<table>.<partition>.<topic>.
- Update IngestionDelayTracker.createMetrics / removeMetrics to use the new topic-aware APIs, looking up the topic name from the StreamConfig.
- Rename RealtimeTableDataManager.getHostedPartitionsGroupIds → getHostedConsumingPartitionsGroupIds to clarify that only CONSUMING segments are returned.
- Add unit tests in AbstractMetricsTest and IngestionDelayTrackerTest covering the new APIs and verifying the topic name appears in the metric name.
