### PR TITLE
Fix chained-transform schema validation error to list conflicting col…

### DIFF
--- a/pinot-core/src/test/java/org/apache/pinot/core/util/SchemaUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/util/SchemaUtilsTest.java
@@ -246,6 +246,31 @@ public class SchemaUtilsTest {
     checkValidationFails(pinotSchema);
   }
 
+  /**
+   * Regression test: when a transformed column is reused as an argument to another transform, the validation error
+   * must list the actual conflicting columns. Historically this message reported a boolean ("true"/"false") because
+   * {@link java.util.Set#retainAll} was passed as the format argument.
+   */
+  @Test
+  public void testChainedTransformErrorMessageListsConflictingColumns() {
+    Schema pinotSchema =
+        new Schema.SchemaBuilder().addSingleValueDimension("x", DataType.INT).addSingleValueDimension("z", DataType.INT)
+            .build();
+    pinotSchema.getFieldSpecFor("x").setTransformFunction("Groovy({y + 10}, y)");
+    pinotSchema.getFieldSpecFor("z").setTransformFunction("Groovy({x*w*20}, x, w)");
+
+    try {
+      SchemaUtils.validate(pinotSchema);
+      Assert.fail("Schema validation should have failed for chained transforms.");
+    } catch (IllegalStateException e) {
+      String message = e.getMessage();
+      Assert.assertNotNull(message);
+      // The chained column set has a single deterministic element here, so the formatted set form is "[x]".
+      Assert.assertEquals(message,
+          "Columns: [x] are a result of transformations, and cannot be used as arguments to other transform functions");
+    }
+  }
+
   @Test
   public void testValidateTimeFieldSpec() {
     Schema pinotSchema;

--- a/pinot-core/src/test/java/org/apache/pinot/core/util/SchemaUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/util/SchemaUtilsTest.java
@@ -289,6 +289,29 @@ public class SchemaUtilsTest {
     checkValidationFails(pinotSchema);
   }
 
+  /// Regression test: when a transformed column is reused as an argument to another transform, the validation error
+  /// must list the actual conflicting columns. Historically this message reported a boolean ("true"/"false") because
+  /// {@link java.util.Set#retainAll} was passed as the format argument.
+  @Test
+  public void testChainedTransformErrorMessageListsConflictingColumns() {
+    Schema pinotSchema =
+        new Schema.SchemaBuilder().addSingleValueDimension("x", DataType.INT).addSingleValueDimension("z", DataType.INT)
+            .build();
+    pinotSchema.getFieldSpecFor("x").setTransformFunction("Groovy({y + 10}, y)");
+    pinotSchema.getFieldSpecFor("z").setTransformFunction("Groovy({x*w*20}, x, w)");
+
+    try {
+      SchemaUtils.validate(pinotSchema);
+      Assert.fail("Schema validation should have failed for chained transforms.");
+    } catch (IllegalStateException e) {
+      String message = e.getMessage();
+      Assert.assertNotNull(message);
+      // The chained column set has a single deterministic element here, so the formatted set form is "[x]".
+      Assert.assertEquals(message,
+          "Columns: [x] are a result of transformations, and cannot be used as arguments to other transform functions");
+    }
+  }
+
   @Test
   public void testValidateTimeFieldSpec() {
     Schema pinotSchema;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SchemaUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SchemaUtils.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.segment.local.utils;
 
 import com.google.common.base.Preconditions;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -151,9 +150,14 @@ public class SchemaUtils {
         validateMultiValueCompatibility(fieldSpec);
       }
     }
-    Preconditions.checkState(Collections.disjoint(transformedColumns, argumentColumns),
+    // Compute the intersection in a fresh set so the error message lists the actual conflicting columns and we do not
+    // mutate transformedColumns. Previously, Set#retainAll's boolean return value was passed as the format argument,
+    // producing a useless "Columns: true ..." message.
+    Set<String> chainedTransformColumns = new HashSet<>(transformedColumns);
+    chainedTransformColumns.retainAll(argumentColumns);
+    Preconditions.checkState(chainedTransformColumns.isEmpty(),
         "Columns: %s are a result of transformations, and cannot be used as arguments to other transform functions",
-        transformedColumns.retainAll(argumentColumns));
+        chainedTransformColumns);
     if (schema.getPrimaryKeyColumns() != null) {
       for (String primaryKeyColumn : schema.getPrimaryKeyColumns()) {
         Preconditions.checkState(primaryKeyColumnCandidates.contains(primaryKeyColumn),

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SchemaUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SchemaUtils.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.segment.local.utils;
 
 import com.google.common.base.Preconditions;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -201,9 +200,14 @@ public class SchemaUtils {
         validateMultiValueCompatibility(fieldSpec);
       }
     }
-    Preconditions.checkState(Collections.disjoint(transformedColumns, argumentColumns),
+    // Compute the intersection in a fresh set so the error message lists the actual conflicting columns and we do not
+    // mutate transformedColumns. Previously, Set#retainAll's boolean return value was passed as the format argument,
+    // producing a useless "Columns: true ..." message.
+    Set<String> chainedTransformColumns = new HashSet<>(transformedColumns);
+    chainedTransformColumns.retainAll(argumentColumns);
+    Preconditions.checkState(chainedTransformColumns.isEmpty(),
         "Columns: %s are a result of transformations, and cannot be used as arguments to other transform functions",
-        transformedColumns.retainAll(argumentColumns));
+        chainedTransformColumns);
     if (schema.getPrimaryKeyColumns() != null) {
       for (String primaryKeyColumn : schema.getPrimaryKeyColumns()) {
         Preconditions.checkState(primaryKeyColumnCandidates.contains(primaryKeyColumn),


### PR DESCRIPTION
## Summary

`SchemaUtils.validate(...)` correctly rejects a schema where a column produced by one transform function is reused as an argument to another transform, but the error message previously rendered as `"Columns: true are a result of transformations, and cannot be used as arguments to other transform functions"` (or `false`). The cause: `Set#retainAll` returns a `boolean`, and that boolean was passed where the formatted intersection set should have been.

The message is surfaced through the controller's schema REST endpoint, so operators currently see `"Invalid schema: <name>. Reason: Columns: true ..."` and have no way to tell which columns actually conflict.

## What this PR changes

- Compute the intersection into a fresh `HashSet` and pass that set to `Preconditions.checkState`, producing `"Columns: [x] are a result of transformations, ..."`.
- Removes a latent side effect (`retainAll` was mutating `transformedColumns` regardless of validation outcome).
- Drops the now-unused `import java.util.Collections`.

## Testing

- Added `SchemaUtilsTest#testChainedTransformErrorMessageListsConflictingColumns`, which asserts the full expected error message so the bug cannot regress silently.
- Pre-existing `testValidateTransformFunctionArguments` continues to cover the validation outcome.
- Local: `./mvnw -pl pinot-core -Dtest=SchemaUtilsTest test` — `Tests run: 12, Failures: 0, Errors: 0`.

## Risk

- Low: change is one static utility method in `pinot-segment-local` plus one new test in `pinot-core`.
- No public API changes, no dependency changes, no wire-format / rolling-upgrade implications. Only the human-readable error text changes for an already-failing input.