### PR TITLE
[multi-stage] Introduce MseMetricsEmitter for MSE engine metric emission

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -140,10 +140,20 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
   protected final long _extraPassiveTimeoutMs;
   protected final boolean _enableQueryFingerprinting;
 
-  protected final PinotMeter _stagesStartedMeter = BrokerMeter.MSE_STAGES_STARTED.getGlobalMeter();
-  protected final PinotMeter _stagesFinishedMeter = BrokerMeter.MSE_STAGES_COMPLETED.getGlobalMeter();
-  protected final PinotMeter _opchainsStartedMeter = BrokerMeter.MSE_OPCHAINS_STARTED.getGlobalMeter();
-  protected final PinotMeter _opchainsCompletedMeter = BrokerMeter.MSE_OPCHAINS_COMPLETED.getGlobalMeter();
+  // Each volatile field caches the PinotMeter resolved on first emission against the live BrokerMetrics
+  // registry. Caching avoids a per-emission ConcurrentHashMap lookup on the hot path. The fields are
+  // volatile rather than final, and lazily populated (vs. eagerly initialized in the field initializer)
+  // to defeat the NOOP-binding hazard: if construction races BrokerMetrics.register(...), an eagerly
+  // initialized field would be bound to the NOOP registry for the lifetime of this handler.
+  //
+  // A small race is possible where two threads each resolve the meter handle the first time around;
+  // both end up calling addMeteredGlobalValue(..., null) which mints a fresh handle from the live
+  // registry and records the unit count exactly once. The "lost" cache write costs at most one extra
+  // registry lookup on a future emission — never correctness.
+  protected volatile PinotMeter _stagesStartedMeter;
+  protected volatile PinotMeter _stagesFinishedMeter;
+  protected volatile PinotMeter _opchainsStartedMeter;
+  protected volatile PinotMeter _opchainsCompletedMeter;
 
   public MultiStageBrokerRequestHandler(PinotConfiguration config, String brokerId,
       BrokerRequestIdGenerator requestIdGenerator, RoutingManager routingManager,
@@ -652,8 +662,10 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
       onQueryStart(requestId, clientRequestId, query.getTextQuery());
       long executionStartTimeNs = System.nanoTime();
 
-      _stagesStartedMeter.mark(stageCount);
-      _opchainsStartedMeter.mark(opChainCount);
+      _stagesStartedMeter =
+          _brokerMetrics.addMeteredGlobalValue(BrokerMeter.MSE_STAGES_STARTED, stageCount, _stagesStartedMeter);
+      _opchainsStartedMeter =
+          _brokerMetrics.addMeteredGlobalValue(BrokerMeter.MSE_OPCHAINS_STARTED, opChainCount, _opchainsStartedMeter);
 
       QueryDispatcher.QueryResult queryResults;
       try {
@@ -668,8 +680,10 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
         requestContext.setErrorCode(queryErrorCode);
         return new BrokerResponseNative(queryErrorCode, consolidatedMessage);
       } finally {
-        _stagesFinishedMeter.mark(stageCount);
-        _opchainsCompletedMeter.mark(opChainCount);
+        _stagesFinishedMeter =
+            _brokerMetrics.addMeteredGlobalValue(BrokerMeter.MSE_STAGES_COMPLETED, stageCount, _stagesFinishedMeter);
+        _opchainsCompletedMeter = _brokerMetrics.addMeteredGlobalValue(BrokerMeter.MSE_OPCHAINS_COMPLETED, opChainCount,
+            _opchainsCompletedMeter);
         onQueryFinish(requestId);
       }
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -140,16 +140,9 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
   protected final long _extraPassiveTimeoutMs;
   protected final boolean _enableQueryFingerprinting;
 
-  // Each volatile field caches the PinotMeter resolved on first emission against the live BrokerMetrics
-  // registry. Caching avoids a per-emission ConcurrentHashMap lookup on the hot path. The fields are
-  // volatile rather than final, and lazily populated (vs. eagerly initialized in the field initializer)
-  // to defeat the NOOP-binding hazard: if construction races BrokerMetrics.register(...), an eagerly
-  // initialized field would be bound to the NOOP registry for the lifetime of this handler.
-  //
-  // A small race is possible where two threads each resolve the meter handle the first time around;
-  // both end up calling addMeteredGlobalValue(..., null) which mints a fresh handle from the live
-  // registry and records the unit count exactly once. The "lost" cache write costs at most one extra
-  // registry lookup on a future emission — never correctness.
+  // Volatile + lazy: PinotMeter resolved against the live BrokerMetrics on first emission via
+  // addMeteredGlobalValue(..., previousHandle) which returns the resolved handle for caching.
+  // Eager final init would bind to the NOOP registry if construction races BrokerMetrics.register().
   protected volatile PinotMeter _stagesStartedMeter;
   protected volatile PinotMeter _stagesFinishedMeter;
   protected volatile PinotMeter _opchainsStartedMeter;

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerMeter.java
@@ -242,7 +242,22 @@ public class BrokerMeter implements AbstractMetrics.Meter {
 
   public static final BrokerMeter MSE_STAGES_STARTED = create("MSE_STAGES_STARTED", "stages", true);
   public static final BrokerMeter MSE_STAGES_COMPLETED = create("MSE_STAGES_COMPLETED", "stages", true);
+  /**
+   * Number of MSE op-chains that the broker has planned and started dispatching for execution.
+   * <p>
+   * This is a dispatch-side counter: it counts op-chains as the broker plans and dispatches them, not
+   * as they are executed on workers. The execution-side counterpart is
+   * {@link ServerMeter#MSE_OPCHAINS_STARTED}.
+   */
   public static final BrokerMeter MSE_OPCHAINS_STARTED = create("MSE_OPCHAINS_STARTED", "opchains", true);
+  /**
+   * Number of MSE op-chains for which dispatch has completed on the broker (either successfully or
+   * with an error).
+   * <p>
+   * This is a dispatch-side counter: it counts op-chains as the broker observes their dispatch
+   * complete, not as they finish execution on workers. The execution-side counterpart is
+   * {@link ServerMeter#MSE_OPCHAINS_COMPLETED}.
+   */
   public static final BrokerMeter MSE_OPCHAINS_COMPLETED = create("MSE_OPCHAINS_COMPLETED", "opchains", true);
 
   /**

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/MseMetricsEmitter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/MseMetricsEmitter.java
@@ -28,94 +28,38 @@ import org.apache.pinot.spi.metrics.PinotMeter;
  * {@code pinot-query-runtime} to report query-engine metrics, instead of binding directly to
  * {@link ServerMetrics#get()}.
  *
- * <p>The indirection exists to solve two concrete correctness problems present in the
- * pre-existing code:
- * <ol>
- *   <li>The NOOP-binding hazard. Several MSE call sites cached {@link PinotMeter} handles at
- *       construction by calling something like {@code ServerMeter.X.getGlobalMeter()}, which
- *       resolves against the current {@code ServerMetrics} instance at field-init time. If the
- *       construction happens before {@code ServerMetrics.register(...)} runs, the cached handle
- *       is permanently bound to the NOOP registry and the metric silently emits zero for the
- *       lifetime of the JVM. The default emitter defers registry resolution to call time, which
- *       eliminates the hazard.</li>
- *   <li>Test isolation. Tests can install a recording emitter without standing up a full
- *       {@link ServerMetrics} singleton, and can reset state between methods via
- *       {@link #deregister}.</li>
- * </ol>
- *
- * <p>The interface is keyed on the existing {@link ServerMeter} and {@link ServerTimer} enum
- * constants because those are the canonical names already used by MSE engine metrics in this
- * codebase. The default implementation, {@link ServerMetricsEmitter}, forwards every emission
- * to {@link ServerMetrics#get()} so the existing {@code pinot.server.*} Prometheus output is
- * preserved exactly.
- *
- * <p>Thread-safety: the active emitter is held in an {@link java.util.concurrent.atomic.AtomicReference}
- * inside {@link MseMetricsEmitterHolder}, mirroring the pattern used by {@link ServerMetrics}.
- * {@link #get()} always returns a non-null emitter (NOOP if none has been registered).
- * {@link #register(MseMetricsEmitter)} performs a first-write-wins compare-and-set against the
- * NOOP sentinel.
+ * <p>This exists to fix a NOOP-binding hazard. Several MSE call sites historically cached
+ * {@link PinotMeter} handles at construction by calling {@code ServerMeter.X.getGlobalMeter()},
+ * which resolved against the current {@link ServerMetrics} instance at field-init time. When
+ * construction ordered ahead of {@code ServerMetrics.register(...)}, the cached handle was
+ * permanently bound to the NOOP registry and the metric silently emitted zero for the lifetime
+ * of the JVM. The default implementation, {@link ServerMetricsEmitter}, defers registry
+ * resolution to call time and forwards to {@code ServerMetrics.get()}, preserving the existing
+ * {@code pinot.server.*} Prometheus output.
  */
 public interface MseMetricsEmitter {
 
-  /**
-   * Records {@code unitCount} units against the given MSE meter.
-   *
-   * @param meter the meter to update; keys are the canonical {@link ServerMeter} entries
-   * @param unitCount the number of units to add
-   */
   void addMeteredGlobalValue(ServerMeter meter, long unitCount);
 
   /**
-   * Returns a {@link PinotMeter} handle bound to the active backing registry for the given
-   * MSE meter. Used by {@code MetricsExecutor} and similar wrappers that need a pre-resolved
-   * meter handle.
-   *
-   * <p>Note: the returned handle is bound to the registry resolved at the moment of this call.
-   * Callers that cache the handle and later replace the active emitter will continue to emit
-   * against the original handle's registry (or NOOP, if the registry has been deregistered).
-   *
-   * @param meter the meter to resolve
-   * @return a non-null {@link PinotMeter}; for the NOOP emitter this is a no-op meter
+   * Returns a {@link PinotMeter} handle bound to the active backing registry at the moment of
+   * this call. Callers that cache the handle (e.g. {@code MetricsExecutor}) and later replace
+   * the active emitter will continue to emit against the original handle's registry.
    */
   PinotMeter getMeteredValue(ServerMeter meter);
 
-  /**
-   * Records a timed value against the given MSE timer.
-   *
-   * @param timer the timer to update; keys are the canonical {@link ServerTimer} entries
-   * @param duration the duration to record
-   * @param timeUnit the unit of {@code duration}
-   */
   void addTimedValue(ServerTimer timer, long duration, TimeUnit timeUnit);
 
-  // -----------------------------------------------------------------------------------
-  // Static holder mirroring ServerMetrics#register / #get / #deregister.
-  // -----------------------------------------------------------------------------------
-
-  /**
-   * Returns the currently active {@link MseMetricsEmitter}. Never returns {@code null};
-   * if no emitter has been registered, the NOOP sentinel is returned.
-   */
+  /** Returns the active emitter; never {@code null} (NOOP sentinel if none registered). */
   static MseMetricsEmitter get() {
     return MseMetricsEmitterHolder.INSTANCE.get();
   }
 
-  /**
-   * Registers the given emitter as the active one. First-write-wins: subsequent registrations
-   * return {@code false} and leave the existing emitter untouched.
-   *
-   * @return {@code true} if the emitter was installed; {@code false} if another emitter was
-   *         already registered
-   */
+  /** First-write-wins; subsequent calls return {@code false} and leave the existing emitter. */
   static boolean register(MseMetricsEmitter emitter) {
     return MseMetricsEmitterHolder.INSTANCE.compareAndSet(MseMetricsEmitterHolder.NOOP, emitter);
   }
 
-  /**
-   * Resets the active emitter to the NOOP sentinel. Visible only for tests that need to
-   * exercise registration ordering or isolated assertions across multiple {@link ServerMetrics}
-   * instances.
-   */
   @VisibleForTesting
   static void deregister() {
     MseMetricsEmitterHolder.INSTANCE.set(MseMetricsEmitterHolder.NOOP);

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/MseMetricsEmitter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/MseMetricsEmitter.java
@@ -1,0 +1,123 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.metrics;
+
+import com.google.common.annotations.VisibleForTesting;
+import java.util.concurrent.TimeUnit;
+import org.apache.pinot.spi.metrics.PinotMeter;
+
+
+/**
+ * Indirection used by the Multi-Stage Engine (MSE) intermediate-stage code in
+ * {@code pinot-query-runtime} to report query-engine metrics, instead of binding directly to
+ * {@link ServerMetrics#get()}.
+ *
+ * <p>The indirection exists to solve two concrete correctness problems present in the
+ * pre-existing code:
+ * <ol>
+ *   <li>The NOOP-binding hazard. Several MSE call sites cached {@link PinotMeter} handles at
+ *       construction by calling something like {@code ServerMeter.X.getGlobalMeter()}, which
+ *       resolves against the current {@code ServerMetrics} instance at field-init time. If the
+ *       construction happens before {@code ServerMetrics.register(...)} runs, the cached handle
+ *       is permanently bound to the NOOP registry and the metric silently emits zero for the
+ *       lifetime of the JVM. The default emitter defers registry resolution to call time, which
+ *       eliminates the hazard.</li>
+ *   <li>Test isolation. Tests can install a recording emitter without standing up a full
+ *       {@link ServerMetrics} singleton, and can reset state between methods via
+ *       {@link #deregister}.</li>
+ * </ol>
+ *
+ * <p>The interface is keyed on the existing {@link ServerMeter} and {@link ServerTimer} enum
+ * constants because those are the canonical names already used by MSE engine metrics in this
+ * codebase. The default implementation, {@link ServerMetricsEmitter}, forwards every emission
+ * to {@link ServerMetrics#get()} so the existing {@code pinot.server.*} Prometheus output is
+ * preserved exactly.
+ *
+ * <p>Thread-safety: the active emitter is held in an {@link java.util.concurrent.atomic.AtomicReference}
+ * inside {@link MseMetricsEmitterHolder}, mirroring the pattern used by {@link ServerMetrics}.
+ * {@link #get()} always returns a non-null emitter (NOOP if none has been registered).
+ * {@link #register(MseMetricsEmitter)} performs a first-write-wins compare-and-set against the
+ * NOOP sentinel.
+ */
+public interface MseMetricsEmitter {
+
+  /**
+   * Records {@code unitCount} units against the given MSE meter.
+   *
+   * @param meter the meter to update; keys are the canonical {@link ServerMeter} entries
+   * @param unitCount the number of units to add
+   */
+  void addMeteredGlobalValue(ServerMeter meter, long unitCount);
+
+  /**
+   * Returns a {@link PinotMeter} handle bound to the active backing registry for the given
+   * MSE meter. Used by {@code MetricsExecutor} and similar wrappers that need a pre-resolved
+   * meter handle.
+   *
+   * <p>Note: the returned handle is bound to the registry resolved at the moment of this call.
+   * Callers that cache the handle and later replace the active emitter will continue to emit
+   * against the original handle's registry (or NOOP, if the registry has been deregistered).
+   *
+   * @param meter the meter to resolve
+   * @return a non-null {@link PinotMeter}; for the NOOP emitter this is a no-op meter
+   */
+  PinotMeter getMeteredValue(ServerMeter meter);
+
+  /**
+   * Records a timed value against the given MSE timer.
+   *
+   * @param timer the timer to update; keys are the canonical {@link ServerTimer} entries
+   * @param duration the duration to record
+   * @param timeUnit the unit of {@code duration}
+   */
+  void addTimedValue(ServerTimer timer, long duration, TimeUnit timeUnit);
+
+  // -----------------------------------------------------------------------------------
+  // Static holder mirroring ServerMetrics#register / #get / #deregister.
+  // -----------------------------------------------------------------------------------
+
+  /**
+   * Returns the currently active {@link MseMetricsEmitter}. Never returns {@code null};
+   * if no emitter has been registered, the NOOP sentinel is returned.
+   */
+  static MseMetricsEmitter get() {
+    return MseMetricsEmitterHolder.INSTANCE.get();
+  }
+
+  /**
+   * Registers the given emitter as the active one. First-write-wins: subsequent registrations
+   * return {@code false} and leave the existing emitter untouched.
+   *
+   * @return {@code true} if the emitter was installed; {@code false} if another emitter was
+   *         already registered
+   */
+  static boolean register(MseMetricsEmitter emitter) {
+    return MseMetricsEmitterHolder.INSTANCE.compareAndSet(MseMetricsEmitterHolder.NOOP, emitter);
+  }
+
+  /**
+   * Resets the active emitter to the NOOP sentinel. Visible only for tests that need to
+   * exercise registration ordering or isolated assertions across multiple {@link ServerMetrics}
+   * instances.
+   */
+  @VisibleForTesting
+  static void deregister() {
+    MseMetricsEmitterHolder.INSTANCE.set(MseMetricsEmitterHolder.NOOP);
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/MseMetricsEmitterHolder.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/MseMetricsEmitterHolder.java
@@ -1,0 +1,117 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.metrics;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.pinot.spi.metrics.PinotMeter;
+
+
+/**
+ * Package-private holder for the {@link MseMetricsEmitter} singleton and its NOOP sentinel.
+ * Keeping these in a non-interface class prevents external code from bypassing
+ * {@link MseMetricsEmitter#register(MseMetricsEmitter)} by mutating the reference directly.
+ */
+final class MseMetricsEmitterHolder {
+
+  /** NOOP sentinel — all three emission methods are no-ops. */
+  static final MseMetricsEmitter NOOP = new NoopMseMetricsEmitter();
+
+  /** Active emitter. Initialized to {@link #NOOP}; updated only via the static methods on
+   * {@link MseMetricsEmitter}. */
+  static final AtomicReference<MseMetricsEmitter> INSTANCE = new AtomicReference<>(NOOP);
+
+  private MseMetricsEmitterHolder() {
+  }
+
+  /**
+   * NOOP implementation. {@link #getMeteredValue} returns a non-null no-op {@link PinotMeter}
+   * so callers that immediately invoke {@code mark()} on the returned handle (e.g.
+   * {@code MetricsExecutor}) do not need a null check.
+   */
+  private static final class NoopMseMetricsEmitter implements MseMetricsEmitter {
+    private static final PinotMeter NOOP_METER = new PinotMeter() {
+      @Override
+      public void mark() {
+      }
+
+      @Override
+      public void mark(long unitCount) {
+      }
+
+      @Override
+      public long count() {
+        return 0L;
+      }
+
+      @Override
+      public Object getMetered() {
+        return null;
+      }
+
+      @Override
+      public TimeUnit rateUnit() {
+        return TimeUnit.SECONDS;
+      }
+
+      @Override
+      public String eventType() {
+        return "";
+      }
+
+      @Override
+      public double fifteenMinuteRate() {
+        return 0.0d;
+      }
+
+      @Override
+      public double fiveMinuteRate() {
+        return 0.0d;
+      }
+
+      @Override
+      public double meanRate() {
+        return 0.0d;
+      }
+
+      @Override
+      public double oneMinuteRate() {
+        return 0.0d;
+      }
+
+      @Override
+      public Object getMetric() {
+        return null;
+      }
+    };
+
+    @Override
+    public void addMeteredGlobalValue(ServerMeter meter, long unitCount) {
+    }
+
+    @Override
+    public PinotMeter getMeteredValue(ServerMeter meter) {
+      return NOOP_METER;
+    }
+
+    @Override
+    public void addTimedValue(ServerTimer timer, long duration, TimeUnit timeUnit) {
+    }
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMetricsEmitter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMetricsEmitter.java
@@ -23,16 +23,8 @@ import org.apache.pinot.spi.metrics.PinotMeter;
 
 
 /**
- * Default {@link MseMetricsEmitter} implementation that forwards every emission to the
- * live {@link ServerMetrics} singleton.
- *
- * <p>The {@link ServerMetrics} singleton is resolved at call time via
- * {@link ServerMetrics#get()}, so the order in which {@link ServerMetrics#register} and
- * {@link MseMetricsEmitter#register} are invoked does not affect correctness. This is
- * intentional: it eliminates the NOOP-binding hazard that previously affected MSE call
- * sites which cached {@link PinotMeter} handles at construction time.
- *
- * <p>This class is stateless and safe to share across threads.
+ * Default {@link MseMetricsEmitter} that forwards every emission to {@link ServerMetrics#get()}
+ * resolved at call time. Stateless; safe to share across threads.
  */
 public class ServerMetricsEmitter implements MseMetricsEmitter {
 

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMetricsEmitter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMetricsEmitter.java
@@ -1,0 +1,53 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.metrics;
+
+import java.util.concurrent.TimeUnit;
+import org.apache.pinot.spi.metrics.PinotMeter;
+
+
+/**
+ * Default {@link MseMetricsEmitter} implementation that forwards every emission to the
+ * live {@link ServerMetrics} singleton.
+ *
+ * <p>The {@link ServerMetrics} singleton is resolved at call time via
+ * {@link ServerMetrics#get()}, so the order in which {@link ServerMetrics#register} and
+ * {@link MseMetricsEmitter#register} are invoked does not affect correctness. This is
+ * intentional: it eliminates the NOOP-binding hazard that previously affected MSE call
+ * sites which cached {@link PinotMeter} handles at construction time.
+ *
+ * <p>This class is stateless and safe to share across threads.
+ */
+public class ServerMetricsEmitter implements MseMetricsEmitter {
+
+  @Override
+  public void addMeteredGlobalValue(ServerMeter meter, long unitCount) {
+    ServerMetrics.get().addMeteredGlobalValue(meter, unitCount);
+  }
+
+  @Override
+  public PinotMeter getMeteredValue(ServerMeter meter) {
+    return ServerMetrics.get().getMeteredValue(meter);
+  }
+
+  @Override
+  public void addTimedValue(ServerTimer timer, long duration, TimeUnit timeUnit) {
+    ServerMetrics.get().addTimedValue(timer, duration, timeUnit);
+  }
+}

--- a/pinot-common/src/test/java/org/apache/pinot/common/metrics/MseMetricsEmitterTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/metrics/MseMetricsEmitterTest.java
@@ -1,0 +1,111 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.metrics;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.pinot.spi.metrics.PinotMeter;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertTrue;
+
+
+/**
+ * Unit tests for the {@link MseMetricsEmitter} singleton lifecycle and NOOP behavior.
+ */
+public class MseMetricsEmitterTest {
+
+  @AfterMethod
+  public void tearDown() {
+    MseMetricsEmitter.deregister();
+  }
+
+  @Test
+  public void testGetReturnsNonNullNoopBeforeRegistration() {
+    MseMetricsEmitter.deregister();
+    MseMetricsEmitter emitter = MseMetricsEmitter.get();
+    assertNotNull(emitter, "get() must return a non-null emitter even before registration");
+    assertSame(emitter, MseMetricsEmitterHolder.NOOP, "Pre-registration get() should return the NOOP sentinel");
+  }
+
+  @Test
+  public void testRegisterFirstWriteWins() {
+    MseMetricsEmitter first = new RecordingEmitter();
+    MseMetricsEmitter second = new RecordingEmitter();
+    assertTrue(MseMetricsEmitter.register(first), "first register() must succeed");
+    assertFalse(MseMetricsEmitter.register(second), "subsequent register() must return false");
+    assertSame(MseMetricsEmitter.get(), first, "get() must return the first registered emitter");
+  }
+
+  @Test
+  public void testDeregisterResetsToNoop() {
+    MseMetricsEmitter emitter = new RecordingEmitter();
+    MseMetricsEmitter.register(emitter);
+    assertSame(MseMetricsEmitter.get(), emitter);
+    MseMetricsEmitter.deregister();
+    assertSame(MseMetricsEmitter.get(), MseMetricsEmitterHolder.NOOP);
+  }
+
+  @Test
+  public void testNoopEmissionDoesNotThrow() {
+    MseMetricsEmitter.deregister();
+    MseMetricsEmitter emitter = MseMetricsEmitter.get();
+    emitter.addMeteredGlobalValue(ServerMeter.MSE_QUERIES, 42L);
+    emitter.addTimedValue(ServerTimer.MULTI_STAGE_SERIALIZATION_CPU_TIME_MS, 100L, TimeUnit.MILLISECONDS);
+  }
+
+  @Test
+  public void testNoopGetMeteredValueReturnsUsableMeter() {
+    MseMetricsEmitter.deregister();
+    PinotMeter meter = MseMetricsEmitter.get().getMeteredValue(ServerMeter.MULTI_STAGE_RUNNER_STARTED_TASKS);
+    assertNotNull(meter, "NOOP getMeteredValue() must return a non-null meter handle");
+    // Should be safe to call mark()/count() — values are ignored but no exception expected
+    meter.mark();
+    meter.mark(7L);
+    assertEquals(meter.count(), 0L, "NOOP meter count() always returns 0");
+  }
+
+  /**
+   * Minimal {@link MseMetricsEmitter} that records the last invocation arguments for assertions.
+   */
+  private static final class RecordingEmitter implements MseMetricsEmitter {
+    final AtomicLong _lastUnitCount = new AtomicLong();
+    final AtomicLong _lastTimedDuration = new AtomicLong();
+
+    @Override
+    public void addMeteredGlobalValue(ServerMeter meter, long unitCount) {
+      _lastUnitCount.set(unitCount);
+    }
+
+    @Override
+    public PinotMeter getMeteredValue(ServerMeter meter) {
+      return MseMetricsEmitterHolder.NOOP.getMeteredValue(meter);
+    }
+
+    @Override
+    public void addTimedValue(ServerTimer timer, long duration, TimeUnit timeUnit) {
+      _lastTimedDuration.set(duration);
+    }
+  }
+}

--- a/pinot-common/src/test/java/org/apache/pinot/common/metrics/MseMetricsEmitterTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/metrics/MseMetricsEmitterTest.java
@@ -42,14 +42,6 @@ public class MseMetricsEmitterTest {
   }
 
   @Test
-  public void testGetReturnsNonNullNoopBeforeRegistration() {
-    MseMetricsEmitter.deregister();
-    MseMetricsEmitter emitter = MseMetricsEmitter.get();
-    assertNotNull(emitter, "get() must return a non-null emitter even before registration");
-    assertSame(emitter, MseMetricsEmitterHolder.NOOP, "Pre-registration get() should return the NOOP sentinel");
-  }
-
-  @Test
   public void testRegisterFirstWriteWins() {
     MseMetricsEmitter first = new RecordingEmitter();
     MseMetricsEmitter second = new RecordingEmitter();
@@ -65,14 +57,6 @@ public class MseMetricsEmitterTest {
     assertSame(MseMetricsEmitter.get(), emitter);
     MseMetricsEmitter.deregister();
     assertSame(MseMetricsEmitter.get(), MseMetricsEmitterHolder.NOOP);
-  }
-
-  @Test
-  public void testNoopEmissionDoesNotThrow() {
-    MseMetricsEmitter.deregister();
-    MseMetricsEmitter emitter = MseMetricsEmitter.get();
-    emitter.addMeteredGlobalValue(ServerMeter.MSE_QUERIES, 42L);
-    emitter.addTimedValue(ServerTimer.MULTI_STAGE_SERIALIZATION_CPU_TIME_MS, 100L, TimeUnit.MILLISECONDS);
   }
 
   @Test

--- a/pinot-common/src/test/java/org/apache/pinot/common/metrics/ServerMetricsEmitterTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/metrics/ServerMetricsEmitterTest.java
@@ -1,0 +1,135 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.metrics;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.apache.pinot.plugin.metrics.fake.FakeMetricsFactory;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.metrics.PinotMeter;
+import org.apache.pinot.spi.metrics.PinotMetricUtils;
+import org.apache.pinot.spi.metrics.PinotTimer;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.apache.pinot.spi.utils.CommonConstants.CONFIG_OF_METRICS_FACTORY_CLASS_NAME;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+
+/**
+ * Verifies that {@link ServerMetricsEmitter} forwards emissions to the live {@link ServerMetrics}
+ * singleton, resolving the singleton at call time so registration order between the two does not
+ * affect correctness.
+ */
+public class ServerMetricsEmitterTest {
+
+  @BeforeClass
+  public void initMetricsFactory() {
+    Map<String, Object> properties = new HashMap<>();
+    properties.put(CONFIG_OF_METRICS_FACTORY_CLASS_NAME, FakeMetricsFactory.class.getName());
+    PinotMetricUtils.init(new PinotConfiguration(properties));
+  }
+
+  @AfterClass
+  public void cleanUpMetricsFactory() {
+    PinotMetricUtils.cleanUp();
+  }
+
+  @BeforeMethod
+  public void setUp() {
+    ServerMetrics.deregister();
+    ServerMetrics.register(new ServerMetrics(PinotMetricUtils.getPinotMetricsRegistry()));
+    MseMetricsEmitter.deregister();
+    MseMetricsEmitter.register(new ServerMetricsEmitter());
+  }
+
+  @AfterMethod
+  public void tearDown() {
+    MseMetricsEmitter.deregister();
+    ServerMetrics.deregister();
+  }
+
+  @Test
+  public void testAddMeteredGlobalValueForwardsToServerMetrics() {
+    long before = ServerMetrics.get().getMeteredValue(ServerMeter.MSE_QUERIES).count();
+    MseMetricsEmitter.get().addMeteredGlobalValue(ServerMeter.MSE_QUERIES, 3L);
+    long after = ServerMetrics.get().getMeteredValue(ServerMeter.MSE_QUERIES).count();
+    assertEquals(after - before, 3L, "ServerMetricsEmitter should forward to the live ServerMetrics registry");
+  }
+
+  @Test
+  public void testAddTimedValueForwardsToServerMetrics() {
+    ServerMetrics serverMetrics = ServerMetrics.get();
+    ServerTimer timerKey = ServerTimer.MULTI_STAGE_SERIALIZATION_CPU_TIME_MS;
+    String fullTimerName = "pinot.server." + timerKey.getTimerName();
+
+    // Resolve the same timer handle the emitter writes to. PinotMetricUtils#makePinotTimer is
+    // idempotent — it returns the existing timer if one is registered under the name.
+    PinotTimer timer = PinotMetricUtils.makePinotTimer(serverMetrics.getMetricsRegistry(),
+        PinotMetricUtils.makePinotMetricName(ServerMetrics.class, fullTimerName),
+        TimeUnit.MILLISECONDS, TimeUnit.SECONDS);
+    long before = timer.count();
+
+    MseMetricsEmitter.get().addTimedValue(timerKey, 50L, TimeUnit.MILLISECONDS);
+
+    assertEquals(timer.count() - before, 1L,
+        "ServerMetricsEmitter should forward addTimedValue to the live ServerMetrics timer");
+  }
+
+  @Test
+  public void testGetMeteredValueIsBoundToActiveRegistry() {
+    PinotMeter meter = MseMetricsEmitter.get().getMeteredValue(ServerMeter.MSE_OPCHAINS_STARTED);
+    assertNotNull(meter, "getMeteredValue must return a non-null handle");
+
+    long before = ServerMetrics.get().getMeteredValue(ServerMeter.MSE_OPCHAINS_STARTED).count();
+    meter.mark();
+    meter.mark(4L);
+    long after = ServerMetrics.get().getMeteredValue(ServerMeter.MSE_OPCHAINS_STARTED).count();
+    assertEquals(after - before, 5L,
+        "Marking the meter handle returned by the emitter must increment the live ServerMetrics counter");
+  }
+
+  @Test
+  public void testLateServerMetricsRegistrationStillEmitsCorrectly() {
+    // Deregister both, install ONLY the emitter, then register a fresh ServerMetrics.
+    // The emitter resolves ServerMetrics.get() at call time, so the late registration must take
+    // effect transparently. This is the test that protects against the NOOP-binding hazard.
+    MseMetricsEmitter.deregister();
+    ServerMetrics.deregister();
+    MseMetricsEmitter.register(new ServerMetricsEmitter());
+
+    // No ServerMetrics registered yet — emission should silently land on the NOOP registry.
+    MseMetricsEmitter.get().addMeteredGlobalValue(ServerMeter.MSE_QUERIES, 99L);
+
+    // Register a real ServerMetrics now.
+    ServerMetrics late = new ServerMetrics(PinotMetricUtils.getPinotMetricsRegistry());
+    ServerMetrics.register(late);
+
+    long before = ServerMetrics.get().getMeteredValue(ServerMeter.MSE_QUERIES).count();
+    MseMetricsEmitter.get().addMeteredGlobalValue(ServerMeter.MSE_QUERIES, 11L);
+    long after = ServerMetrics.get().getMeteredValue(ServerMeter.MSE_QUERIES).count();
+    assertEquals(after - before, 11L,
+        "Emissions after late ServerMetrics registration must land on the new registry");
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
@@ -37,6 +37,7 @@ import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pinot.common.config.TlsConfig;
+import org.apache.pinot.common.metrics.MseMetricsEmitter;
 import org.apache.pinot.common.metrics.ServerMeter;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.proto.Worker;
@@ -192,10 +193,10 @@ public class QueryRunner {
         ExecutorServiceUtils.create(serverConf, Server.MULTISTAGE_EXECUTOR_CONFIG_PREFIX, "query-runner-on-" + port,
             Server.DEFAULT_MULTISTAGE_EXECUTOR_TYPE);
 
-    ServerMetrics serverMetrics = ServerMetrics.get();
+    MseMetricsEmitter emitter = MseMetricsEmitter.get();
     MetricsExecutor metricsExecutor = new MetricsExecutor(baseExecutorService,
-        serverMetrics.getMeteredValue(ServerMeter.MULTI_STAGE_RUNNER_STARTED_TASKS),
-        serverMetrics.getMeteredValue(ServerMeter.MULTI_STAGE_RUNNER_COMPLETED_TASKS));
+        emitter.getMeteredValue(ServerMeter.MULTI_STAGE_RUNNER_STARTED_TASKS),
+        emitter.getMeteredValue(ServerMeter.MULTI_STAGE_RUNNER_COMPLETED_TASKS));
     _executorService = QueryThreadContext.contextAwareExecutorService(metricsExecutor);
 
     int hardLimit = HardLimitExecutor.getMultiStageExecutorHardLimit(serverConf);
@@ -223,6 +224,8 @@ public class QueryRunner {
     }
 
     if (instanceDataManager != null) {
+      // SSE leaf-stage execution is server-only and stays on ServerMetrics directly.
+      ServerMetrics serverMetrics = ServerMetrics.get();
       try {
         _leafQueryExecutor = new ServerQueryExecutorV1Impl();
         _leafQueryExecutor.init(serverConf.subset(Server.QUERY_EXECUTOR_CONFIG_PREFIX), instanceDataManager,

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/executor/OpChainSchedulerService.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/executor/OpChainSchedulerService.java
@@ -279,14 +279,9 @@ public class OpChainSchedulerService {
     private static final String EXECUTION_TIME_MS = "EXECUTION_TIME_MS";
     private static final String ALLOCATED_MEMORY_BYTES = "ALLOCATED_MEMORY_BYTES";
 
-    /**
-     * Resolve the active {@link MseMetricsEmitter} at call time rather than caching a
-     * {@link org.apache.pinot.spi.metrics.PinotMeter} handle at construction. Opchain lifecycle
-     * events are coarse (one per stage worker, not per row), so the additional indirection is
-     * unmeasurable; resolving lazily eliminates the NOOP-binding hazard that arises when this
-     * class is constructed before {@code ServerMetrics.register(...)} has installed a real
-     * {@link ServerMetrics} instance.
-     */
+    // Resolve the emitter at call time rather than caching a PinotMeter at construction. OpChain
+    // lifecycle events are coarse, so the indirection cost is unmeasurable; lazy resolution avoids
+    // the NOOP-binding hazard when this class is constructed before ServerMetrics.register(...).
     public void onOpChainStarted() {
       MseMetricsEmitter.get().addMeteredGlobalValue(ServerMeter.MSE_OPCHAINS_STARTED, 1L);
     }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/executor/OpChainSchedulerService.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/executor/OpChainSchedulerService.java
@@ -35,6 +35,7 @@ import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pinot.common.datatable.StatMap;
+import org.apache.pinot.common.metrics.MseMetricsEmitter;
 import org.apache.pinot.common.metrics.ServerMeter;
 import org.apache.pinot.core.util.trace.TraceRunnable;
 import org.apache.pinot.query.runtime.blocks.ErrorMseBlock;
@@ -48,7 +49,6 @@ import org.apache.pinot.spi.exception.QueryCancelledException;
 import org.apache.pinot.spi.exception.QueryErrorCode;
 import org.apache.pinot.spi.exception.QueryException;
 import org.apache.pinot.spi.exception.TerminationException;
-import org.apache.pinot.spi.metrics.PinotMeter;
 import org.apache.pinot.spi.query.QueryExecutionContext;
 import org.apache.pinot.spi.query.QueryThreadContext;
 import org.apache.pinot.spi.utils.CommonConstants.MultiStageQueryRunner;
@@ -275,26 +275,31 @@ public class OpChainSchedulerService {
   }
 
   private static class Metrics {
-    private final PinotMeter _startedOpchains = ServerMeter.MSE_OPCHAINS_STARTED.getGlobalMeter();
-    private final PinotMeter _competedOpchains = ServerMeter.MSE_OPCHAINS_COMPLETED.getGlobalMeter();
-    private final PinotMeter _emittedRows = ServerMeter.MSE_EMITTED_ROWS.getGlobalMeter();
-    private final PinotMeter _cpuExecutionTimeMs = ServerMeter.MSE_CPU_EXECUTION_TIME_MS.getGlobalMeter();
-    private final PinotMeter _memoryAllocatedBytes = ServerMeter.MSE_MEMORY_ALLOCATED_BYTES.getGlobalMeter();
-
     private static final String EMITTED_ROWS = "EMITTED_ROWS";
     private static final String EXECUTION_TIME_MS = "EXECUTION_TIME_MS";
     private static final String ALLOCATED_MEMORY_BYTES = "ALLOCATED_MEMORY_BYTES";
 
+    /**
+     * Resolve the active {@link MseMetricsEmitter} at call time rather than caching a
+     * {@link org.apache.pinot.spi.metrics.PinotMeter} handle at construction. Opchain lifecycle
+     * events are coarse (one per stage worker, not per row), so the additional indirection is
+     * unmeasurable; resolving lazily eliminates the NOOP-binding hazard that arises when this
+     * class is constructed before {@code ServerMetrics.register(...)} has installed a real
+     * {@link ServerMetrics} instance.
+     */
     public void onOpChainStarted() {
-      _startedOpchains.mark();
+      MseMetricsEmitter.get().addMeteredGlobalValue(ServerMeter.MSE_OPCHAINS_STARTED, 1L);
     }
 
     public void onOpChainFinished(MultiStageOperator rootOperator) {
-      _competedOpchains.mark();
+      MseMetricsEmitter emitter = MseMetricsEmitter.get();
+      emitter.addMeteredGlobalValue(ServerMeter.MSE_OPCHAINS_COMPLETED, 1L);
       StatMap<?> operatorStats = rootOperator.copyStatMaps();
-      _emittedRows.mark(operatorStats.getUnsafe(EMITTED_ROWS, 0L));
-      _cpuExecutionTimeMs.mark(operatorStats.getUnsafe(EXECUTION_TIME_MS, 0L));
-      _memoryAllocatedBytes.mark(operatorStats.getUnsafe(ALLOCATED_MEMORY_BYTES, 0L));
+      emitter.addMeteredGlobalValue(ServerMeter.MSE_EMITTED_ROWS, operatorStats.getUnsafe(EMITTED_ROWS, 0L));
+      emitter.addMeteredGlobalValue(ServerMeter.MSE_CPU_EXECUTION_TIME_MS,
+          operatorStats.getUnsafe(EXECUTION_TIME_MS, 0L));
+      emitter.addMeteredGlobalValue(ServerMeter.MSE_MEMORY_ALLOCATED_BYTES,
+          operatorStats.getUnsafe(ALLOCATED_MEMORY_BYTES, 0L));
     }
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java
@@ -28,7 +28,7 @@ import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.apache.calcite.rel.RelDistribution;
 import org.apache.pinot.common.datatable.StatMap;
-import org.apache.pinot.common.metrics.ServerMetrics;
+import org.apache.pinot.common.metrics.MseMetricsEmitter;
 import org.apache.pinot.query.mailbox.MailboxService;
 import org.apache.pinot.query.mailbox.SendingMailbox;
 import org.apache.pinot.query.planner.physical.MailboxIdUtils;
@@ -308,17 +308,17 @@ public class MailboxSendOperator extends MultiStageOperator {
   }
 
   private void updateMetrics(MultiStageQueryStats queryStats) {
-    ServerMetrics serverMetrics = ServerMetrics.get();
+    MseMetricsEmitter emitter = MseMetricsEmitter.get();
     if (queryStats == null) {
       LOGGER.info("Query stats not found in the EOS block.");
     } else {
       for (MultiStageQueryStats.StageStats.Closed closed : queryStats.getClosedStats()) {
         if (closed != null) {
-          closed.forEach((type, stats) -> type.updateServerMetrics(stats, serverMetrics));
+          closed.forEach((type, stats) -> type.updateMseMetrics(stats, emitter));
         }
       }
       queryStats.getCurrentStats().forEach((type, stats) -> {
-        type.updateServerMetrics(stats, serverMetrics);
+        type.updateMseMetrics(stats, emitter);
       });
     }
   }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java
@@ -29,8 +29,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.datatable.StatMap;
+import org.apache.pinot.common.metrics.MseMetricsEmitter;
 import org.apache.pinot.common.metrics.ServerMeter;
-import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.metrics.ServerTimer;
 import org.apache.pinot.common.proto.Plan;
 import org.apache.pinot.common.response.broker.BrokerResponseNativeV2;
@@ -259,7 +259,7 @@ public abstract class MultiStageOperator implements Operator<MseBlock>, AutoClos
       /// So far this keys do not need to be modified from here because they are incremented in a per-worker basis:
       /// ServerMeter.AGGREGATE_TIMES_NUM_GROUPS_LIMIT_REACHED
       /// ServerMeter.AGGREGATE_TIMES_NUM_GROUPS_WARNING_LIMIT_REACHED
-      /// public void updateServerMetrics(StatMap<?> map, ServerMetrics serverMetrics);
+      /// public void updateMseMetrics(StatMap<?> map, MseMetricsEmitter emitter);
     },
     FILTER(1, FilterOperator.StatKey.class) {
       @Override
@@ -280,15 +280,15 @@ public abstract class MultiStageOperator implements Operator<MseBlock>, AutoClos
       }
 
       @Override
-      public void updateServerMetrics(StatMap<?> map, ServerMetrics serverMetrics) {
-        super.updateServerMetrics(map, serverMetrics);
+      public void updateMseMetrics(StatMap<?> map, MseMetricsEmitter emitter) {
+        super.updateMseMetrics(map, emitter);
         @SuppressWarnings("unchecked")
         StatMap<HashJoinOperator.StatKey> stats = (StatMap<HashJoinOperator.StatKey>) map;
         boolean maxRowsInJoinReached = stats.getBoolean(HashJoinOperator.StatKey.MAX_ROWS_IN_JOIN_REACHED);
         if (maxRowsInJoinReached) {
-          serverMetrics.addMeteredGlobalValue(ServerMeter.HASH_JOIN_TIMES_MAX_ROWS_REACHED, 1);
+          emitter.addMeteredGlobalValue(ServerMeter.HASH_JOIN_TIMES_MAX_ROWS_REACHED, 1);
         }
-        serverMetrics.addTimedValue(ServerTimer.HASH_JOIN_BUILD_TABLE_CPU_TIME_MS,
+        emitter.addTimedValue(ServerTimer.HASH_JOIN_BUILD_TABLE_CPU_TIME_MS,
             stats.getLong(HashJoinOperator.StatKey.TIME_BUILDING_HASH_TABLE_MS), TimeUnit.MILLISECONDS);
       }
     },
@@ -329,23 +329,23 @@ public abstract class MultiStageOperator implements Operator<MseBlock>, AutoClos
       }
 
       @Override
-      public void updateServerMetrics(StatMap<?> map, ServerMetrics serverMetrics) {
-        super.updateServerMetrics(map, serverMetrics);
+      public void updateMseMetrics(StatMap<?> map, MseMetricsEmitter emitter) {
+        super.updateMseMetrics(map, emitter);
         @SuppressWarnings("unchecked")
         StatMap<BaseMailboxReceiveOperator.StatKey> stats = (StatMap<BaseMailboxReceiveOperator.StatKey>) map;
 
-        serverMetrics.addMeteredGlobalValue(ServerMeter.MULTI_STAGE_IN_MEMORY_MESSAGES,
+        emitter.addMeteredGlobalValue(ServerMeter.MULTI_STAGE_IN_MEMORY_MESSAGES,
             stats.getInt(BaseMailboxReceiveOperator.StatKey.IN_MEMORY_MESSAGES));
-        serverMetrics.addMeteredGlobalValue(ServerMeter.MULTI_STAGE_RAW_MESSAGES,
+        emitter.addMeteredGlobalValue(ServerMeter.MULTI_STAGE_RAW_MESSAGES,
             stats.getInt(BaseMailboxReceiveOperator.StatKey.RAW_MESSAGES));
-        serverMetrics.addMeteredGlobalValue(ServerMeter.MULTI_STAGE_RAW_BYTES,
+        emitter.addMeteredGlobalValue(ServerMeter.MULTI_STAGE_RAW_BYTES,
             stats.getLong(BaseMailboxReceiveOperator.StatKey.DESERIALIZED_BYTES));
 
-        serverMetrics.addTimedValue(ServerTimer.MULTI_STAGE_DESERIALIZATION_CPU_TIME_MS,
+        emitter.addTimedValue(ServerTimer.MULTI_STAGE_DESERIALIZATION_CPU_TIME_MS,
             stats.getLong(BaseMailboxReceiveOperator.StatKey.DESERIALIZATION_TIME_MS), TimeUnit.MILLISECONDS);
-        serverMetrics.addTimedValue(ServerTimer.RECEIVE_DOWNSTREAM_WAIT_CPU_TIME_MS,
+        emitter.addTimedValue(ServerTimer.RECEIVE_DOWNSTREAM_WAIT_CPU_TIME_MS,
             stats.getLong(BaseMailboxReceiveOperator.StatKey.DOWNSTREAM_WAIT_MS), TimeUnit.MILLISECONDS);
-        serverMetrics.addTimedValue(ServerTimer.RECEIVE_UPSTREAM_WAIT_CPU_TIME_MS,
+        emitter.addTimedValue(ServerTimer.RECEIVE_UPSTREAM_WAIT_CPU_TIME_MS,
             stats.getLong(BaseMailboxReceiveOperator.StatKey.UPSTREAM_WAIT_MS), TimeUnit.MILLISECONDS);
       }
     },
@@ -358,10 +358,10 @@ public abstract class MultiStageOperator implements Operator<MseBlock>, AutoClos
       }
 
       @Override
-      public void updateServerMetrics(StatMap<?> map, ServerMetrics serverMetrics) {
+      public void updateMseMetrics(StatMap<?> map, MseMetricsEmitter emitter) {
         @SuppressWarnings("unchecked")
         StatMap<MailboxSendOperator.StatKey> stats = (StatMap<MailboxSendOperator.StatKey>) map;
-        serverMetrics.addTimedValue(ServerTimer.MULTI_STAGE_SERIALIZATION_CPU_TIME_MS,
+        emitter.addTimedValue(ServerTimer.MULTI_STAGE_SERIALIZATION_CPU_TIME_MS,
             stats.getLong(MailboxSendOperator.StatKey.SERIALIZATION_TIME_MS), TimeUnit.MILLISECONDS);
       }
     },
@@ -417,11 +417,11 @@ public abstract class MultiStageOperator implements Operator<MseBlock>, AutoClos
       }
 
       @Override
-      public void updateServerMetrics(StatMap<?> map, ServerMetrics serverMetrics) {
+      public void updateMseMetrics(StatMap<?> map, MseMetricsEmitter emitter) {
         @SuppressWarnings("unchecked")
         StatMap<WindowAggregateOperator.StatKey> stats = (StatMap<WindowAggregateOperator.StatKey>) map;
         if (stats.getBoolean(WindowAggregateOperator.StatKey.MAX_ROWS_IN_WINDOW_REACHED)) {
-          serverMetrics.addMeteredGlobalValue(ServerMeter.WINDOW_TIMES_MAX_ROWS_REACHED, 1);
+          emitter.addMeteredGlobalValue(ServerMeter.WINDOW_TIMES_MAX_ROWS_REACHED, 1);
         }
       }
     },
@@ -508,7 +508,7 @@ public abstract class MultiStageOperator implements Operator<MseBlock>, AutoClos
      */
     public abstract void mergeInto(BrokerResponseNativeV2 response, StatMap<?> map);
 
-    public void updateServerMetrics(StatMap<?> map, ServerMetrics serverMetrics) {
+    public void updateMseMetrics(StatMap<?> map, MseMetricsEmitter emitter) {
       // Do nothing by default
     }
   }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/server/QueryServer.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/server/QueryServer.java
@@ -39,8 +39,8 @@ import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 import org.apache.commons.io.output.UnsynchronizedByteArrayOutputStream;
 import org.apache.pinot.common.config.TlsConfig;
+import org.apache.pinot.common.metrics.MseMetricsEmitter;
 import org.apache.pinot.common.metrics.ServerMeter;
-import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.proto.PinotQueryWorkerGrpc;
 import org.apache.pinot.common.proto.Worker;
 import org.apache.pinot.common.utils.NamedThreadFactory;
@@ -163,10 +163,10 @@ public class QueryServer extends PinotQueryWorkerGrpc.PinotQueryWorkerImplBase {
             "query_submission_executor_on_" + _port + "_port",
             CommonConstants.Server.DEFAULT_MULTISTAGE_SUBMISSION_EXEC_TYPE);
 
-    ServerMetrics serverMetrics = ServerMetrics.get();
+    MseMetricsEmitter emitter = MseMetricsEmitter.get();
     _submissionExecutorService = new MetricsExecutor(baseExecutorService,
-        serverMetrics.getMeteredValue(ServerMeter.MULTI_STAGE_SUBMISSION_STARTED_TASKS),
-        serverMetrics.getMeteredValue(ServerMeter.MULTI_STAGE_SUBMISSION_COMPLETED_TASKS));
+        emitter.getMeteredValue(ServerMeter.MULTI_STAGE_SUBMISSION_STARTED_TASKS),
+        emitter.getMeteredValue(ServerMeter.MULTI_STAGE_SUBMISSION_COMPLETED_TASKS));
 
     NamedThreadFactory explainThreadFactory = new NamedThreadFactory("query_explain_on_" + _port + "_port");
     _explainExecutorService = Executors.newSingleThreadExecutor(explainThreadFactory);
@@ -260,7 +260,7 @@ public class QueryServer extends PinotQueryWorkerGrpc.PinotQueryWorkerImplBase {
   @Override
   public void submit(Worker.QueryRequest request, StreamObserver<Worker.QueryResponse> responseObserver) {
     // Match the SSE QUERIES counter semantics by counting requests as soon as they reach the handler.
-    ServerMetrics.get().addMeteredGlobalValue(ServerMeter.MSE_QUERIES, 1L);
+    MseMetricsEmitter.get().addMeteredGlobalValue(ServerMeter.MSE_QUERIES, 1L);
     Map<String, String> reqMetadata;
     try {
       reqMetadata = QueryPlanSerDeUtils.fromProtoProperties(request.getMetadata());

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/executor/OpChainSchedulerServiceMetricsTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/executor/OpChainSchedulerServiceMetricsTest.java
@@ -1,0 +1,175 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.executor;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.apache.pinot.common.datatable.StatMap;
+import org.apache.pinot.common.metrics.MseMetricsEmitter;
+import org.apache.pinot.common.metrics.ServerMeter;
+import org.apache.pinot.common.metrics.ServerMetrics;
+import org.apache.pinot.common.metrics.ServerMetricsEmitter;
+import org.apache.pinot.common.utils.NamedThreadFactory;
+import org.apache.pinot.query.mailbox.MailboxService;
+import org.apache.pinot.query.routing.StageMetadata;
+import org.apache.pinot.query.routing.WorkerMetadata;
+import org.apache.pinot.query.runtime.blocks.SuccessMseBlock;
+import org.apache.pinot.query.runtime.operator.MailboxSendOperator;
+import org.apache.pinot.query.runtime.operator.MultiStageOperator;
+import org.apache.pinot.query.runtime.operator.OpChain;
+import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
+import org.apache.pinot.spi.executor.ExecutorServiceUtils;
+import org.apache.pinot.spi.metrics.PinotMetricUtils;
+import org.apache.pinot.spi.query.QueryThreadContext;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+
+/**
+ * Regression test for the NOOP-binding fix in {@link OpChainSchedulerService}'s inner {@code Metrics}
+ * class.
+ *
+ * <p>Before the fix, the inner class cached {@link org.apache.pinot.spi.metrics.PinotMeter} handles at
+ * construction by calling {@code ServerMeter.MSE_OPCHAINS_STARTED.getGlobalMeter()}. When the scheduler
+ * was constructed before {@code ServerMetrics.register(...)} was invoked, the captured meter was
+ * permanently bound to the NOOP registry and emitted zero for the lifetime of the JVM.
+ *
+ * <p>The fix routes emissions through {@link MseMetricsEmitter}, which resolves the active registry
+ * at call time. This test:
+ *
+ * <ol>
+ *   <li>Deregisters {@code ServerMetrics} and {@code MseMetricsEmitter}.</li>
+ *   <li>Constructs an {@link OpChainSchedulerService} (the moment at which the legacy code captured
+ *       its meter handles).</li>
+ *   <li>Registers a fresh {@code ServerMetrics} + {@link ServerMetricsEmitter}.</li>
+ *   <li>Schedules an op-chain through the scheduler and waits for completion.</li>
+ *   <li>Asserts that {@code ServerMeter.MSE_OPCHAINS_STARTED} was incremented on the freshly
+ *       registered {@code ServerMetrics}.</li>
+ * </ol>
+ */
+public class OpChainSchedulerServiceMetricsTest {
+
+  private AutoCloseable _mocks;
+  private ExecutorService _executor;
+  private MultiStageOperator _operator;
+
+  @BeforeClass
+  public void beforeClass() {
+    _mocks = MockitoAnnotations.openMocks(this);
+    _executor = QueryThreadContext.contextAwareExecutorService(
+        Executors.newCachedThreadPool(new NamedThreadFactory("worker_on_" + getClass().getSimpleName())));
+  }
+
+  @AfterClass
+  public void afterClass()
+      throws Exception {
+    _mocks.close();
+    ExecutorServiceUtils.close(_executor);
+  }
+
+  @BeforeMethod
+  public void beforeMethod() {
+    // Critical: clear any prior registration so the scheduler is constructed against the NOOP.
+    MseMetricsEmitter.deregister();
+    ServerMetrics.deregister();
+    _operator = Mockito.mock(MultiStageOperator.class);
+    Mockito.when(_operator.copyStatMaps()).thenAnswer(inv -> new StatMap<>(MailboxSendOperator.StatKey.class));
+  }
+
+  @AfterMethod
+  public void afterMethod() {
+    MseMetricsEmitter.deregister();
+    ServerMetrics.deregister();
+  }
+
+  @Test
+  public void testOpChainMetricsEmittedAfterLateRegistration()
+      throws InterruptedException {
+    // Step 2: construct the scheduler BEFORE registering metrics. With the buggy code path this
+    // would have bound the meter handles to the NOOP registry permanently.
+    OpChainSchedulerService schedulerService = new OpChainSchedulerService(_executor);
+
+    // Step 3: register a fresh ServerMetrics + ServerMetricsEmitter AFTER construction.
+    ServerMetrics serverMetrics = new ServerMetrics(PinotMetricUtils.getPinotMetricsRegistry());
+    ServerMetrics.register(serverMetrics);
+    MseMetricsEmitter.register(new ServerMetricsEmitter());
+
+    // Snapshot baseline counts on the live registry.
+    long startedBefore = ServerMetrics.get().getMeteredValue(ServerMeter.MSE_OPCHAINS_STARTED).count();
+    long completedBefore = ServerMetrics.get().getMeteredValue(ServerMeter.MSE_OPCHAINS_COMPLETED).count();
+
+    // Step 4: run an op-chain to completion.
+    CountDownLatch closeLatch = new CountDownLatch(1);
+    when(_operator.nextBlock()).thenReturn(SuccessMseBlock.INSTANCE);
+    Mockito.doAnswer(inv -> {
+      closeLatch.countDown();
+      return null;
+    }).when(_operator).close();
+
+    try (QueryThreadContext ignore = QueryThreadContext.openForMseTest()) {
+      schedulerService.register(buildOpChain(_operator));
+    }
+    assertTrue(closeLatch.await(10, TimeUnit.SECONDS), "op-chain did not complete within 10 seconds");
+
+    // Step 5: assert that BOTH the started and completed counters were incremented on the live
+    // ServerMetrics. If the NOOP-binding bug were present, both deltas would be zero.
+    waitForCountToReach(ServerMeter.MSE_OPCHAINS_STARTED, startedBefore + 1L,
+        "MSE_OPCHAINS_STARTED was not incremented — NOOP-binding regression detected");
+    waitForCountToReach(ServerMeter.MSE_OPCHAINS_COMPLETED, completedBefore + 1L,
+        "MSE_OPCHAINS_COMPLETED was not incremented — NOOP-binding regression detected");
+  }
+
+  private static OpChain buildOpChain(MultiStageOperator operator) {
+    MailboxService mailboxService = mock(MailboxService.class);
+    when(mailboxService.getHostname()).thenReturn("localhost");
+    when(mailboxService.getPort()).thenReturn(1234);
+    WorkerMetadata workerMetadata = new WorkerMetadata(0, Map.of(), Map.of());
+    OpChainExecutionContext context = OpChainExecutionContext.fromQueryContext(mailboxService, Map.of(),
+        new StageMetadata(0, List.of(workerMetadata), Map.of()), workerMetadata, null, true, true);
+    return new OpChain(context, operator);
+  }
+
+  private static void waitForCountToReach(ServerMeter meter, long target, String failureMessage)
+      throws InterruptedException {
+    long deadline = System.currentTimeMillis() + 5_000L;
+    while (System.currentTimeMillis() < deadline) {
+      long current = ServerMetrics.get().getMeteredValue(meter).count();
+      if (current >= target) {
+        return;
+      }
+      Thread.sleep(25L);
+    }
+    fail(failureMessage + " (target=" + target + ", actual="
+        + ServerMetrics.get().getMeteredValue(meter).count() + ")");
+  }
+}

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/server/QueryServerTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/server/QueryServerTest.java
@@ -33,8 +33,10 @@ import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import org.apache.calcite.rel.RelDistribution;
 import org.apache.pinot.calcite.rel.logical.PinotRelExchangeType;
+import org.apache.pinot.common.metrics.MseMetricsEmitter;
 import org.apache.pinot.common.metrics.ServerMeter;
 import org.apache.pinot.common.metrics.ServerMetrics;
+import org.apache.pinot.common.metrics.ServerMetricsEmitter;
 import org.apache.pinot.common.proto.PinotQueryWorkerGrpc;
 import org.apache.pinot.common.proto.Plan;
 import org.apache.pinot.common.proto.Worker;
@@ -95,6 +97,8 @@ public class QueryServerTest extends QueryTestSet {
       throws Exception {
     ServerMetrics.deregister();
     ServerMetrics.register(new ServerMetrics(PinotMetricUtils.getPinotMetricsRegistry()));
+    MseMetricsEmitter.deregister();
+    MseMetricsEmitter.register(new ServerMetricsEmitter());
     for (int i = 0; i < QUERY_SERVER_COUNT; i++) {
       int availablePort = QueryTestUtils.getAvailablePort();
       QueryRunner queryRunner = mock(QueryRunner.class);
@@ -117,6 +121,7 @@ public class QueryServerTest extends QueryTestSet {
     for (QueryServer worker : _queryServerMap.values()) {
       worker.shutdown();
     }
+    MseMetricsEmitter.deregister();
     ServerMetrics.deregister();
   }
 

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
@@ -666,13 +666,8 @@ public abstract class BaseServerStarter implements ServiceStartable {
     _serverMetrics.initializeGlobalMeters();
     _serverMetrics.setValueOfGlobalGauge(ServerGauge.VERSION, PinotVersion.VERSION_METRIC_NAME, 1);
     ServerMetrics.register(_serverMetrics);
-    // Register the MSE metrics emitter on the server side. MSE intermediate-stage execution code
-    // in pinot-query-runtime emits through this emitter; the default ServerMetricsEmitter forwards
-    // every call to ServerMetrics so the pinot.server.* output is unchanged. Broker-side
-    // MSE-related counters in MultiStageBrokerRequestHandler use BrokerMetrics directly and do not
-    // go through this emitter. compareAndSet semantics mean a second startup attempt in the same
-    // JVM (e.g. integration tests that restart the server) leaves the previously registered emitter
-    // in place rather than throwing.
+    // Route MSE engine metrics through the default emitter; forwards to ServerMetrics. compareAndSet
+    // semantics: a second start() in the same JVM (integration tests) leaves the prior emitter installed.
     if (!MseMetricsEmitter.register(new ServerMetricsEmitter())) {
       LOGGER.info("MseMetricsEmitter already registered; leaving the existing emitter in place");
     }

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
@@ -62,9 +62,11 @@ import org.apache.pinot.common.Utils;
 import org.apache.pinot.common.config.DefaultClusterConfigChangeHandler;
 import org.apache.pinot.common.config.TlsConfig;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
+import org.apache.pinot.common.metrics.MseMetricsEmitter;
 import org.apache.pinot.common.metrics.ServerGauge;
 import org.apache.pinot.common.metrics.ServerMeter;
 import org.apache.pinot.common.metrics.ServerMetrics;
+import org.apache.pinot.common.metrics.ServerMetricsEmitter;
 import org.apache.pinot.common.metrics.ServerTimer;
 import org.apache.pinot.common.restlet.resources.SystemResourceInfo;
 import org.apache.pinot.common.utils.PinotAppConfigs;
@@ -664,6 +666,16 @@ public abstract class BaseServerStarter implements ServiceStartable {
     _serverMetrics.initializeGlobalMeters();
     _serverMetrics.setValueOfGlobalGauge(ServerGauge.VERSION, PinotVersion.VERSION_METRIC_NAME, 1);
     ServerMetrics.register(_serverMetrics);
+    // Register the MSE metrics emitter on the server side. MSE intermediate-stage execution code
+    // in pinot-query-runtime emits through this emitter; the default ServerMetricsEmitter forwards
+    // every call to ServerMetrics so the pinot.server.* output is unchanged. Broker-side
+    // MSE-related counters in MultiStageBrokerRequestHandler use BrokerMetrics directly and do not
+    // go through this emitter. compareAndSet semantics mean a second startup attempt in the same
+    // JVM (e.g. integration tests that restart the server) leaves the previously registered emitter
+    // in place rather than throwing.
+    if (!MseMetricsEmitter.register(new ServerMetricsEmitter())) {
+      LOGGER.info("MseMetricsEmitter already registered; leaving the existing emitter in place");
+    }
 
     LOGGER.info("Initializing reload job status cache");
     _reloadJobStatusCache = new ServerReloadJobStatusCache(_instanceId);


### PR DESCRIPTION
## Background

The Multi-Stage Engine intermediate-stage code in `pinot-query-runtime` emits engine metrics by directly calling `ServerMetrics.get()`. `ServerMetrics` is registered only in `BaseServerStarter`. Two concrete bugs follow from this coupling:

1. **`OpChainSchedulerService.Metrics` NOOP-binding** (`pinot-query-runtime/.../executor/OpChainSchedulerService.java`). The inner class field-initializes five `PinotMeter` handles via `ServerMeter.X.getGlobalMeter()`, which resolves against whichever `ServerMetrics` is registered at that moment. If construction happens before `ServerMetrics.register(...)` runs — which happens in unit tests, embedded query-runtime harnesses, and any non-server context that constructs the scheduler directly — the captured handles are permanently bound to the NOOP registry. The op-chain started/completed counters and the per-op-chain CPU/memory/row counters then silently emit zero for the lifetime of the JVM. No later \`ServerMetrics.register()\` call can fix the captured references.

2. **`MultiStageBrokerRequestHandler` NOOP-binding** (`pinot-broker/.../requesthandler/MultiStageBrokerRequestHandler.java`). Same field-init-time anti-pattern for four `BrokerMeter.MSE_STAGES_*` and `BrokerMeter.MSE_OPCHAINS_*` handles, resolved before `BrokerMetrics.register(...)` is guaranteed to have run.

Beyond the bug fixes, the static-singleton coupling makes the MSE engine layer hard to test in isolation: every test that wants to assert metric emission must stand up a full `ServerMetrics` singleton and remember to deregister it. There is no way to install a recording fixture without touching global state.

## Change

This PR introduces `MseMetricsEmitter`, a thin pluggable interface in `pinot-common`, that MSE engine code calls instead of `ServerMetrics.get()` directly. The interface is keyed on the existing `ServerMeter` / `ServerTimer` enum constants — no new metric names, no new enums, no new Prometheus namespaces.

- `MseMetricsEmitter` exposes three methods: `addMeteredGlobalValue(ServerMeter, long)`, `getMeteredValue(ServerMeter)` (for `MetricsExecutor` handles), `addTimedValue(ServerTimer, long, TimeUnit)`.
- `ServerMetricsEmitter` is the default implementation. It forwards every call to `ServerMetrics.get()` at *call time* (not at construction). This eliminates the NOOP-binding hazard.
- `BaseServerStarter` registers `ServerMetricsEmitter` immediately after `ServerMetrics.register(_serverMetrics)`. A second `register(...)` call (e.g. an integration test that restarts the server in the same JVM) silently no-ops with an INFO log, matching the `ServerMetrics.register` pattern.
- MSE emission sites — `QueryServer.submit()`, `QueryServer` constructor, `QueryRunner.init()`, `OpChainSchedulerService.Metrics`, `MultiStageOperator.Type.updateServerMetrics`, `MailboxSendOperator.updateMetrics` — switch from `ServerMetrics.get()` to `MseMetricsEmitter.get()`.
- `OpChainSchedulerService.Metrics` is rewritten to drop the field-cached `PinotMeter` handles entirely; each emission resolves the emitter at call time. Op-chain lifecycle events are coarse (once per stage worker, not per row), so the additional indirection is unmeasurable.
- `MultiStageBrokerRequestHandler` is fixed independently of the emitter — the four field-cached handles are replaced with `volatile` fields populated lazily via `BrokerMetrics.get().addMeteredGlobalValue(meter, count, reusedMeter)`. These are broker dispatch counters that stay on `BrokerMetrics`; they do not go through `MseMetricsEmitter`.

## What does NOT change

- No metric names change. \`pinot.server.mse*\` Prometheus output is identical.
- No JMX exporter rules change.
- No new enum entries on `ServerMeter`, `BrokerMeter`, `ServerTimer`, `BrokerTimer`, `ServerGauge`, `BrokerGauge`.
- No new Prometheus namespace.
- No new feature flag.
- `GrpcMailboxServer` is untouched — its existing `InstanceType.BROKER`/`SERVER` branch correctly routes the mailbox memory gauges through `BrokerMetrics` / `ServerMetrics` respectively.

## Compatibility

- Source and binary compatible — the only public class signatures touched are on `MultiStageOperator.Type` (a public enum nested inside a `pinot-query-runtime` class; the `updateServerMetrics` method signature changes from `(StatMap, ServerMetrics)` to `(StatMap, MseMetricsEmitter)`). This is an internal execution-layer API; no external caller in the OSS tree exercises it.
- Rolling-upgrade safe — registration happens before any MSE code runs; no wire-protocol or schema changes.

## Tests

- `MseMetricsEmitterTest` — singleton lifecycle (NOOP fallback, first-write-wins, deregister).
- `ServerMetricsEmitterTest` — default impl correctly forwards meter, timer, and `MetricsExecutor` handle lookups to `ServerMetrics`. Includes \`testLateServerMetricsRegistrationStillEmitsCorrectly\` which proves the NOOP-binding hazard is gone (construct emitter → emit → register fresh `ServerMetrics` → re-emit → assert the new registry sees the increment).
- `OpChainSchedulerServiceMetricsTest` — regression test for the field-cached NOOP-binding bug. Constructs the scheduler before any metrics registration; registers; drives an op-chain to completion; asserts the live registry sees `MSE_OPCHAINS_STARTED`.
- `QueryServerTest` — existing tests pass unchanged, exercising the full `QueryServer.submit()` → `MseMetricsEmitter` → `ServerMetrics` path. Test setup registers `ServerMetricsEmitter` alongside the existing `ServerMetrics` setup.