### PR TITLE
Preserve queryableDocIds tracking when preloading upsert segment with no valid docs

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -437,7 +437,11 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
     if (validDocIds.isEmpty()) {
       _logger.info("Skip preloading segment: {} without valid doc, current primary key count: {}",
           segment.getSegmentName(), getNumPrimaryKeys());
-      segment.enableUpsert(this, new ThreadSafeMutableRoaringBitmap(), null);
+      ThreadSafeMutableRoaringBitmap queryableDocIds = null;
+      if (_deleteRecordColumn != null) {
+        queryableDocIds = new ThreadSafeMutableRoaringBitmap();
+      }
+      segment.enableUpsert(this, new ThreadSafeMutableRoaringBitmap(), queryableDocIds);
       return;
     }
     if (isTTLEnabled() && !_comparisonColumns.isEmpty()) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -437,10 +437,8 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
     if (validDocIds.isEmpty()) {
       _logger.info("Skip preloading segment: {} without valid doc, current primary key count: {}",
           segment.getSegmentName(), getNumPrimaryKeys());
-      ThreadSafeMutableRoaringBitmap queryableDocIds = null;
-      if (_deleteRecordColumn != null) {
-        queryableDocIds = new ThreadSafeMutableRoaringBitmap();
-      }
+      ThreadSafeMutableRoaringBitmap queryableDocIds =
+          (_deleteRecordColumn == null) ? null : new ThreadSafeMutableRoaringBitmap();
       segment.enableUpsert(this, new ThreadSafeMutableRoaringBitmap(), queryableDocIds);
       return;
     }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerTest.java
@@ -71,6 +71,7 @@ import org.apache.pinot.spi.utils.ReadMode;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.util.TestUtils;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedConstruction;
 import org.roaringbitmap.buffer.MutableRoaringBitmap;
 import org.testng.annotations.AfterClass;
@@ -85,6 +86,7 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.mockConstruction;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.*;
 
@@ -1354,6 +1356,64 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
       assertFalse(recordLocationMap.containsKey(HashUtils.hashPrimaryKey(makePrimaryKey(key), hashFunction)),
           String.valueOf(key));
     }
+  }
+
+  /**
+   * Regression test: when preloading an immutable segment whose validDocIds snapshot is empty and the table is
+   * configured with a deleteRecordColumn, doPreloadSegment's fast path must initialize queryableDocIds to an
+   * empty bitmap (not null). Passing null would set _queryableDocIds = null on the segment, causing subsequent
+   * doTakeSnapshot rounds to skip persisting the queryableDocIds bitmap file and leaving the on-disk snapshot
+   * frozen at its pre-restart contents.
+   */
+  @Test
+  public void testPreloadSegmentEmptyValidDocIdsWithDeleteColumn() {
+    _contextBuilder.setEnableSnapshot(true).setDeleteRecordColumn(DELETE_RECORD_COLUMN);
+    ConcurrentMapPartitionUpsertMetadataManager upsertMetadataManager =
+        new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0, _contextBuilder.build());
+
+    ImmutableSegmentImpl segment = mock(ImmutableSegmentImpl.class);
+    when(segment.getSegmentName()).thenReturn("emptyValidDocIdsSegment");
+    when(segment.loadDocIdsFromSnapshot(V1Constants.VALID_DOC_IDS_SNAPSHOT_FILE_NAME)).thenReturn(
+        new MutableRoaringBitmap());
+
+    upsertMetadataManager.preloadSegment(segment);
+
+    ArgumentCaptor<ThreadSafeMutableRoaringBitmap> validDocIdsCaptor =
+        ArgumentCaptor.forClass(ThreadSafeMutableRoaringBitmap.class);
+    ArgumentCaptor<ThreadSafeMutableRoaringBitmap> queryableDocIdsCaptor =
+        ArgumentCaptor.forClass(ThreadSafeMutableRoaringBitmap.class);
+    verify(segment).enableUpsert(eq(upsertMetadataManager), validDocIdsCaptor.capture(),
+        queryableDocIdsCaptor.capture());
+    assertNotNull(validDocIdsCaptor.getValue());
+    assertTrue(validDocIdsCaptor.getValue().getMutableRoaringBitmap().isEmpty());
+    assertNotNull(queryableDocIdsCaptor.getValue(),
+        "queryableDocIds must be non-null when deleteRecordColumn is configured");
+    assertTrue(queryableDocIdsCaptor.getValue().getMutableRoaringBitmap().isEmpty());
+  }
+
+  /**
+   * Companion to {@link #testPreloadSegmentEmptyValidDocIdsWithDeleteColumn}: when deleteRecordColumn is not
+   * configured, the fast path should still pass null for queryableDocIds since queryable tracking is disabled.
+   */
+  @Test
+  public void testPreloadSegmentEmptyValidDocIdsWithoutDeleteColumn() {
+    _contextBuilder.setEnableSnapshot(true);
+    ConcurrentMapPartitionUpsertMetadataManager upsertMetadataManager =
+        new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0, _contextBuilder.build());
+
+    ImmutableSegmentImpl segment = mock(ImmutableSegmentImpl.class);
+    when(segment.getSegmentName()).thenReturn("emptyValidDocIdsSegment");
+    when(segment.loadDocIdsFromSnapshot(V1Constants.VALID_DOC_IDS_SNAPSHOT_FILE_NAME)).thenReturn(
+        new MutableRoaringBitmap());
+
+    upsertMetadataManager.preloadSegment(segment);
+
+    ArgumentCaptor<ThreadSafeMutableRoaringBitmap> queryableDocIdsCaptor =
+        ArgumentCaptor.forClass(ThreadSafeMutableRoaringBitmap.class);
+    verify(segment).enableUpsert(eq(upsertMetadataManager), any(ThreadSafeMutableRoaringBitmap.class),
+        queryableDocIdsCaptor.capture());
+    assertNull(queryableDocIdsCaptor.getValue(),
+        "queryableDocIds must be null when deleteRecordColumn is not configured");
   }
 
   @Test


### PR DESCRIPTION
**Context:**
When an immutable upsert segment is preloaded via BasePartitionUpsertMetadataManager.doPreloadSegment() and its validdocids.bitmap.snapshot file deserializes to an empty bitmap, the fast-path early-return calls:

`segment.enableUpsert(this, new ThreadSafeMutableRoaringBitmap(), null);`

For tables that track queryable docs (i.e. deleteRecordColumn is configured), passing null for queryableDocIds sets _queryableDocIds = null on ImmutableSegmentImpl. This violates the invariant held everywhere else in upsert: when queryable tracking is enabled, the bitmap must be non-null (empty is fine, null is not).