### PR TITLE
Fix master compile: missing IOException import in TableConfigsRestletResourceTest

### DIFF
--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/TableConfigsRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/TableConfigsRestletResourceTest.java
@@ -21,6 +21,7 @@ package org.apache.pinot.controller.api;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.Sets;
+import java.io.IOException;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;


### PR DESCRIPTION
## Summary
- PR #18056 added `throws IOException` to a new test method `testTuneConfig()` in `TableConfigsRestletResourceTest` without importing `java.io.IOException`, breaking the master test-compile.
- Adds the missing import.

## Test plan
- [x] `./mvnw test-compile -pl pinot-controller` passes locally.