### PR TITLE
[feature] MATERIALIZED VIEW DDL — CREATE / SHOW MATERIALIZED VIEWS / SHOW CREATE / DROP

### DIFF
--- a/pinot-common/src/main/codegen/config.fmpp
+++ b/pinot-common/src/main/codegen/config.fmpp
@@ -62,6 +62,13 @@ data: {
       "PROPERTIES"
       "TABLES"
       "TABLE_TYPE"
+      # Pinot DDL (CREATE / SHOW / DROP MATERIALIZED VIEW(S)) keywords.
+      # MATERIALIZED is shared by every MV verb; VIEWS is the plural-form lexeme used by the
+      # Catalog-listing verb `SHOW MATERIALIZED VIEWS [FROM db]`. VIEW (singular) is a core
+      # Calcite keyword and is not redeclared here.
+      "MATERIALIZED"
+      "REFRESH"
+      "VIEWS"
       # IF is not a SQL reserved word but Calcite core does not declare it as a token; we need it
       # for DDL "IF [NOT] EXISTS" clauses.
       "IF"
@@ -92,6 +99,9 @@ data: {
       "TABLES"
       "TABLE_TYPE"
       "IF"
+      "MATERIALIZED"
+      "REFRESH"
+      "VIEWS"
 
       # The following keywords are reserved in core Calcite,
       # are reserved in some version of SQL,
@@ -590,8 +600,9 @@ data: {
     statementParserMethods: [
       "SqlInsertFromFile()"
       "SqlPhysicalExplain()"
+      "SqlPinotCreateMaterializedView()"
       "SqlPinotCreateTable()"
-      "SqlPinotDropTable()"
+      "SqlPinotDrop()"
       "SqlPinotShow()"
     ]
 

--- a/pinot-common/src/main/codegen/includes/parserImpls.ftl
+++ b/pinot-common/src/main/codegen/includes/parserImpls.ftl
@@ -108,6 +108,115 @@ SqlNode SqlPhysicalExplain() :
     }
 }
 
+/// CREATE MATERIALIZED VIEW [IF NOT EXISTS] [db.]name ( ... )
+/// [ REFRESH [INTERVAL] EVERY <period> ]
+/// [ PROPERTIES ( 'k' = 'v', ... ) ]
+/// AS <query>
+///
+/// The optional REFRESH clause registers a per-table cron schedule for the MV
+/// minion task. When omitted, the task scheduler picks up the MV under the
+/// cluster-wide default cron (`controller.task.frequencyInSeconds` /
+/// `controller.task.taskTypeFrequenciesInSeconds.MaterializedViewTask`).
+///
+/// The `AS <query>` clause accepts only SELECT/VALUES/WITH/UNION/etc. queries
+/// — NOT DML (INSERT/UPDATE/DELETE/MERGE). We invoke `OrderedQueryOrExpr` with
+/// `ACCEPT_QUERY` rather than `SqlQueryOrDml` (the default Calcite production
+/// that also accepts DML) because a materialized view's body is always a
+/// projection-style query whose output rows are persisted; routing a DML
+/// statement here would either be silently ignored by the downstream MV
+/// analyzer or fail with a non-actionable error well below the grammar.
+SqlNode SqlPinotCreateMaterializedView() :
+{
+    SqlParserPos pos;
+    SqlIdentifier name;
+    boolean ifNotExists = false;
+    // Column list is optional. When absent, the DDL compiler infers the columns from
+    // the AS <query> projection via SingleStageMaterializedViewSchemaInferer. We model
+    // the absent case as an empty SqlNodeList so downstream consumers can branch on
+    // emptiness rather than nullability — keeps the consumer's public API stable.
+    SqlNodeList columns = SqlNodeList.EMPTY;
+    SqlPinotRefreshClause refresh = null;
+    SqlNodeList properties = null;
+    SqlNode query;
+}
+{
+    <CREATE> { pos = getPos(); }
+    <MATERIALIZED> <VIEW>
+    [ LOOKAHEAD(3) <IF> <NOT> <EXISTS> { ifNotExists = true; } ]
+    name = CompoundIdentifier()
+    [ LOOKAHEAD(2) columns = PinotColumnList() ]
+    [ refresh = PinotRefreshClause() ]
+    [ <PROPERTIES> properties = PinotPropertyList() ]
+    <AS> query = OrderedQueryOrExpr(ExprContext.ACCEPT_QUERY)
+    {
+        return new SqlPinotCreateMaterializedView(pos, name, ifNotExists, columns, refresh,
+            properties, query);
+    }
+}
+
+SqlPinotRefreshClause PinotRefreshClause() :
+{
+    SqlParserPos pos;
+    SqlLiteral refreshPeriod;
+}
+{
+    <REFRESH> { pos = getPos(); }
+    [ <INTERVAL> ]
+    <EVERY> refreshPeriod = PinotRefreshEveryPeriod()
+    {
+        return new SqlPinotRefreshClause(pos, refreshPeriod);
+    }
+}
+
+/// EVERY period. Two forms are accepted:
+///   1. Quoted Pinot period literal, e.g. `'1d'`, `'6h'`, `'15m'` — passes through verbatim.
+///   2. Sugared `N <UNIT>`, where `UNIT` is one of `MINUTE / MINUTES / HOUR / HOURS / DAY /
+///      DAYS`, normalized to `Nm`, `Nh`, `Nd` respectively.
+///
+/// Common-but-unsupported units (`SECOND[S]`, `WEEK[S]`, `MONTH[S]`, `YEAR[S]`) are
+/// explicitly matched and rejected here with a message listing the supported units, rather
+/// than left to fall off the parser's default "Encountered ..." path which prints an empty
+/// expected-tokens list and offers no hint about the supported set.
+SqlLiteral PinotRefreshEveryPeriod() :
+{
+    SqlLiteral n;
+    SqlParserPos pos;
+    String unitSuffix = null;
+    String unsupportedUnit = null;
+}
+{
+    (
+        n = NumericLiteral()
+        (
+            <DAY> { unitSuffix = "d"; pos = getPos(); }
+        |   <DAYS> { unitSuffix = "d"; pos = getPos(); }
+        |   <HOUR> { unitSuffix = "h"; pos = getPos(); }
+        |   <HOURS> { unitSuffix = "h"; pos = getPos(); }
+        |   <MINUTE> { unitSuffix = "m"; pos = getPos(); }
+        |   <MINUTES> { unitSuffix = "m"; pos = getPos(); }
+        |   <SECOND>  { unsupportedUnit = "SECOND";  pos = getPos(); }
+        |   <SECONDS> { unsupportedUnit = "SECONDS"; pos = getPos(); }
+        |   <WEEK>    { unsupportedUnit = "WEEK";    pos = getPos(); }
+        |   <WEEKS>   { unsupportedUnit = "WEEKS";   pos = getPos(); }
+        |   <MONTH>   { unsupportedUnit = "MONTH";   pos = getPos(); }
+        |   <MONTHS>  { unsupportedUnit = "MONTHS";  pos = getPos(); }
+        |   <YEAR>    { unsupportedUnit = "YEAR";    pos = getPos(); }
+        |   <YEARS>   { unsupportedUnit = "YEARS";   pos = getPos(); }
+        )
+        {
+            if (unsupportedUnit != null) {
+                throw new RuntimeException(
+                    "REFRESH EVERY: unit '" + unsupportedUnit + "' is not supported. "
+                        + "Supported units: MINUTE / MINUTES, HOUR / HOURS, DAY / DAYS. "
+                        + "Alternatively use the quoted Pinot period form, e.g. '15m', '6h', '1d'.");
+            }
+            return SqlLiteral.createCharString(n.toValue() + unitSuffix, pos);
+        }
+    |
+        { return (SqlLiteral) StringLiteral(); }
+    )
+}
+
 /// CREATE TABLE [IF NOT EXISTS] [db.]name (
 /// col TYPE [NULL | NOT NULL] [DEFAULT literal]
 /// [ DIMENSION | METRIC | DATETIME FORMAT 'fmt' GRANULARITY 'gran' ],
@@ -260,7 +369,18 @@ SqlPinotProperty PinotProperty() :
 }
 
 /// DROP TABLE [IF EXISTS] [db.]name [TYPE OFFLINE | REALTIME]
-SqlNode SqlPinotDropTable() :
+/// | DROP MATERIALIZED VIEW [IF EXISTS] [db.]name
+///
+/// Both branches share the leading `DROP` token; combining them into a single entry point keeps
+/// the JavaCC choice unambiguous (no need for LOOKAHEAD across multiple statementParser methods
+/// that all start with DROP).
+///
+/// `DROP MATERIALIZED VIEW` does NOT take a `TYPE` clause: an MV is always realized as an
+/// OFFLINE physical table, so accepting `TYPE REALTIME` would be confusing and `TYPE OFFLINE`
+/// would be redundant. The controller refuses the bare `DROP TABLE` form on an MV (see
+/// `PinotDdlRestletResource#executeDrop`) and refuses the MV form on a plain table — the two
+/// statements are strictly partitioned by underlying TableConfig shape (Q2=B contract).
+SqlNode SqlPinotDrop() :
 {
     SqlParserPos pos;
     SqlIdentifier name;
@@ -269,21 +389,49 @@ SqlNode SqlPinotDropTable() :
 }
 {
     <DROP> { pos = getPos(); }
-    <TABLE>
-    [ LOOKAHEAD(2) <IF> <EXISTS> { ifExists = true; } ]
-    name = CompoundIdentifier()
-    [ <TYPE> tableType = PinotTableTypeLiteral() ]
-    {
-        return new SqlPinotDropTable(pos, name, ifExists, tableType);
-    }
+    (
+        <TABLE>
+        [ LOOKAHEAD(2) <IF> <EXISTS> { ifExists = true; } ]
+        name = CompoundIdentifier()
+        [ <TYPE> tableType = PinotTableTypeLiteral() ]
+        {
+            return new SqlPinotDropTable(pos, name, ifExists, tableType);
+        }
+    |
+        <MATERIALIZED> <VIEW>
+        [ LOOKAHEAD(2) <IF> <EXISTS> { ifExists = true; } ]
+        name = CompoundIdentifier()
+        {
+            return new SqlPinotDropMaterializedView(pos, name, ifExists);
+        }
+    )
 }
 
 /// SHOW TABLES [FROM db]
+/// | SHOW MATERIALIZED VIEWS [FROM db]
 /// | SHOW CREATE TABLE [db.]name [TYPE OFFLINE | REALTIME]
+/// | SHOW CREATE MATERIALIZED VIEW [db.]name
 ///
-/// Both grammar branches share a leading `SHOW` token; combining them into a single entry point
-/// keeps the JavaCC choice unambiguous (no need for LOOKAHEAD across multiple statementParser
-/// methods that all start with SHOW).
+/// All four grammar branches share a leading `SHOW` token; combining them into a single entry
+/// point keeps the JavaCC choice unambiguous (no need for LOOKAHEAD across multiple
+/// statementParser methods that all start with SHOW).
+///
+/// `SHOW CREATE MATERIALIZED VIEW` does NOT take a `TYPE` clause: an MV is always backed by an
+/// OFFLINE table, so accepting `TYPE REALTIME` would be confusing and accepting `TYPE OFFLINE`
+/// would be redundant. The controller refuses the bare `SHOW CREATE TABLE` form on an MV (see
+/// `PinotDdlRestletResource#executeShowCreate`) — callers always use this dedicated form so the
+/// reverse DDL output is unambiguous (`CREATE MATERIALIZED VIEW`, not `CREATE TABLE`).
+///
+/// `SHOW MATERIALIZED VIEWS` is the MV-listing peer of `SHOW TABLES`: it returns the raw names
+/// (no `_OFFLINE` suffix) of every TableConfig in the resolved database whose
+/// `isMaterializedView` flag is true (PR #18564 is the canonical MV identity contract).
+/// Choosing the plural lexeme `VIEWS` keeps the form aligned with `SHOW TABLES` and matches
+/// the established Snowflake-style catalog-listing convention; the resulting names are
+/// directly reusable as input to `SHOW CREATE MATERIALIZED VIEW` / `DROP MATERIALIZED VIEW`.
+/// `SHOW TABLES` and `SHOW MATERIALIZED VIEWS` are intentionally NOT mutually exclusive at the
+/// listing level — an MV physically is an OFFLINE table, and a user who runs `SHOW TABLES`
+/// today sees it. Separating the two views at the DDL surface lets callers pick the verb that
+/// matches their intent without renaming what `SHOW TABLES` has always meant.
 SqlNode SqlPinotShow() :
 {
     SqlParserPos pos;
@@ -300,11 +448,26 @@ SqlNode SqlPinotShow() :
             return new SqlPinotShowTables(pos, database);
         }
     |
-        <CREATE> <TABLE>
-        name = CompoundIdentifier()
-        [ <TYPE> tableType = PinotTableTypeLiteral() ]
+        <MATERIALIZED> <VIEWS>
+        [ <FROM> database = SimpleIdentifier() ]
         {
-            return new SqlPinotShowCreateTable(pos, name, tableType);
+            return new SqlPinotShowMaterializedViews(pos, database);
         }
+    |
+        <CREATE>
+        (
+            <TABLE>
+            name = CompoundIdentifier()
+            [ <TYPE> tableType = PinotTableTypeLiteral() ]
+            {
+                return new SqlPinotShowCreateTable(pos, name, tableType);
+            }
+        |
+            <MATERIALIZED> <VIEW>
+            name = CompoundIdentifier()
+            {
+                return new SqlPinotShowCreateMaterializedView(pos, name);
+            }
+        )
     )
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/materializedview/MaterializedViewAggregationCatalog.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/materializedview/MaterializedViewAggregationCatalog.java
@@ -1,0 +1,129 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.materializedview;
+
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+
+
+/// Single source of truth for the aggregation functions an MV definedSQL is allowed to use,
+/// and the {@link DataType} the MV's storage column for that aggregation MUST be declared as.
+///
+/// This catalog is consumed by:
+///
+///   - the MV analyzer (allow-list check at create / update time), and
+///   - the MV schema inferer (picks the column DataType when the user omits explicit column
+///     definitions in {@code CREATE MATERIALIZED VIEW}).
+///
+/// Both consumers must agree on the supported set, otherwise an MV that the inferer happily
+/// builds could later be rejected by the analyzer (or, worse, accepted and then never picked
+/// up by the rewrite engine because the MV column type doesn't match what the rewrite expects).
+///
+/// <h3>Why it lives in {@code pinot-common}</h3>
+///
+/// The schema inferer lives in {@code pinot-sql-ddl}, which must not depend on
+/// {@code pinot-materialized-view} in production code. {@code pinot-common} is the
+/// lowest-level module both consumers already depend on.
+///
+/// <h3>Sketch types: deliberate divergence from both engines' surface types</h3>
+///
+/// Both Pinot engines surface {@code STRING} for raw-sketch aggregations:
+///
+///   - The v1 (single-stage) engine's {@code DistinctCountRaw{HLL,HLLPlus,ThetaSketch}AggregationFunction}
+///     return {@code STRING} from {@code getFinalResultColumnType()}.
+///   - The v2 (multi-stage) engine's Calcite return-type inference (via
+///     {@code PinotReturnTypeInferenceUtils} / {@code SqlReturnTypeInference}) likewise reports
+///     {@code STRING} for these aggregations.
+///
+/// In both cases the {@code STRING} is the *display* type — the hex-encoded scalar response a
+/// SQL client receives. It is not the type of the underlying sketch the MV needs to store.
+///
+/// For an MV column the right type is {@code BYTES}: that is the only shape the rewrite engine
+/// can re-aggregate (each row's stored value is a serialized sketch that gets merged with the
+/// running accumulator). Storing {@code STRING} would silently route the rewrite through the
+/// "hash the literal" branch of {@code DistinctCountHLLAggregationFunction}, producing wrong
+/// answers without any error.
+///
+/// This is the source of truth: the
+/// {@code MaterializedViewSchemaInferer} consults this catalog rather than reading
+/// the engine's surface type for each aggregation, so the inferer is correct even though the
+/// MSE validator would naively report {@code STRING} for these three operators.
+///
+/// {@code MaterializedViewTaskExecutor#decodeBytesValue} already converts the incoming
+/// hex-encoded string from the source query response into raw bytes when the destination
+/// schema column is {@code BYTES}, so this divergence is end-to-end consistent — but it is
+/// load-bearing and must not be "fixed" to match either engine's surface type.
+///
+/// The static regression test on this class pins both the supported-set and the type mapping
+/// so that the divergence cannot be silently undone by a future refactor.
+public final class MaterializedViewAggregationCatalog {
+
+  private MaterializedViewAggregationCatalog() {
+  }
+
+  /// Maps canonical (uppercase) aggregation operator name to the {@link DataType} an MV
+  /// schema column produced by that aggregation MUST be declared as, for MV ingestion AND
+  /// rewrite to remain semantically correct.
+  ///
+  /// Iteration order is insertion order (see {@link Map#of} on Java 11+: no guarantee, but
+  /// callers should not rely on it). Use {@link #getSupportedOperators()} for the allow-list
+  /// check, {@link #getInferredDataType(String)} for the type lookup.
+  ///
+  /// See the class javadoc for the BYTES-vs-STRING explanation on the sketch entries.
+  public static final Map<String, DataType> SUPPORTED_AGGREGATIONS = Map.of(
+      "SUM", DataType.DOUBLE,
+      "MIN", DataType.DOUBLE,
+      "MAX", DataType.DOUBLE,
+      "COUNT", DataType.LONG,
+      "DISTINCTCOUNTRAWHLL", DataType.BYTES,
+      "DISTINCTCOUNTRAWHLLPLUS", DataType.BYTES,
+      "DISTINCTCOUNTRAWTHETASKETCH", DataType.BYTES
+  );
+
+  /// Returns the canonicalised set of aggregation operator names this catalog supports.
+  /// Suitable as the allow-list for an MV analyzer's "is this aggregation re-aggregatable?"
+  /// check.
+  public static Set<String> getSupportedOperators() {
+    return SUPPORTED_AGGREGATIONS.keySet();
+  }
+
+  /// Returns true iff {@code operator} (case-insensitive) is one of the catalog's supported
+  /// aggregation function names.
+  public static boolean isSupported(String operator) {
+    if (operator == null) {
+      return false;
+    }
+    return SUPPORTED_AGGREGATIONS.containsKey(operator.toUpperCase(Locale.ROOT));
+  }
+
+  /// Returns the {@link DataType} an MV schema column produced by {@code operator} must be
+  /// declared as, or {@code null} if {@code operator} is not in the catalog.
+  ///
+  /// Callers should typically pre-check membership with {@link #isSupported(String)} so the
+  /// "unsupported aggregation" error path can carry a clear, single-shot message rather than
+  /// a downstream {@link NullPointerException}.
+  public static DataType getInferredDataType(String operator) {
+    if (operator == null) {
+      return null;
+    }
+    return SUPPORTED_AGGREGATIONS.get(operator.toUpperCase(Locale.ROOT));
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/request/RequestUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/request/RequestUtils.java
@@ -38,6 +38,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
+import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNumericLiteral;
 import org.apache.commons.lang3.StringUtils;
@@ -549,6 +550,61 @@ public class RequestUtils {
   public static String canonicalizeFunctionNamePreservingSpecialKey(String functionName) {
     String canonicalName = canonicalizeFunctionName(functionName);
     return CANONICAL_NAME_TO_SPECIAL_KEY_MAP.getOrDefault(canonicalName, canonicalName);
+  }
+
+  /// Returns true iff {@code expression} is an {@code AS}-wrapped function call
+  /// (i.e. shaped like {@code expr AS alias} after Calcite parsing).
+  ///
+  /// Centralises the shape check that was previously open-coded in several places
+  /// (alias appliers, MV analyzer, query-context converters).  Callers that need the
+  /// alias name or the underlying expression should use {@link #unwrapAlias(Expression)}
+  /// or {@link #extractAliasOrIdentifierName(Expression)} rather than re-implementing
+  /// this check inline.
+  public static boolean isAliased(@Nullable Expression expression) {
+    if (expression == null) {
+      return false;
+    }
+    Function function = expression.getFunctionCall();
+    return function != null && SqlKind.AS.lowerName.equals(function.getOperator());
+  }
+
+  /// Strips the {@code AS alias} wrapper from a SELECT-list expression and returns the
+  /// underlying source expression.  When {@code expression} is not aliased the original
+  /// expression is returned unchanged, so this method is safe to call unconditionally
+  /// while iterating SELECT items.
+  ///
+  /// Mirrors the local helper that previously lived in
+  /// {@code MaterializedViewAnalyzer#extractSourceExpression}; callers that walk a
+  /// SELECT list to inspect the aggregate / transform under each alias should use this
+  /// method instead of re-implementing the same operand-zero indirection.
+  public static Expression unwrapAlias(Expression expression) {
+    return isAliased(expression) ? expression.getFunctionCall().getOperands().get(0) : expression;
+  }
+
+  /// Extracts the user-facing column name a SELECT-list expression resolves to:
+  ///
+  ///   - {@code expr AS alias} ⇒ {@code alias}
+  ///   - bare identifier ({@code col}) ⇒ {@code col}
+  ///   - any other shape (function/literal without an alias) ⇒
+  ///     {@link IllegalStateException}
+  ///
+  /// Used by callers that need to map SELECT items to schema columns (e.g. MV schema
+  /// coverage checks, MV column inference).  The error message lists the offending
+  /// expression in pretty-printed form so the operator can fix their SQL without
+  /// reaching for AST internals.
+  public static String extractAliasOrIdentifierName(Expression expression) {
+    if (isAliased(expression)) {
+      Expression aliasExpr = expression.getFunctionCall().getOperands().get(1);
+      Preconditions.checkState(aliasExpr.getType() == ExpressionType.IDENTIFIER,
+          "AS alias must be an identifier, got: %s", prettyPrint(aliasExpr));
+      return aliasExpr.getIdentifier().getName();
+    }
+    if (expression.getType() == ExpressionType.IDENTIFIER) {
+      return expression.getIdentifier().getName();
+    }
+    throw new IllegalStateException(
+        "Expression '" + prettyPrint(expression)
+            + "' must be a bare column or use AS <alias> to map to a schema column");
   }
 
   public static String prettyPrint(@Nullable Expression expression) {

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -67,9 +67,13 @@ import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.sql.FilterKind;
 import org.apache.pinot.sql.parsers.parser.SqlInsertFromFile;
 import org.apache.pinot.sql.parsers.parser.SqlParserImpl;
+import org.apache.pinot.sql.parsers.parser.SqlPinotCreateMaterializedView;
 import org.apache.pinot.sql.parsers.parser.SqlPinotCreateTable;
+import org.apache.pinot.sql.parsers.parser.SqlPinotDropMaterializedView;
 import org.apache.pinot.sql.parsers.parser.SqlPinotDropTable;
+import org.apache.pinot.sql.parsers.parser.SqlPinotShowCreateMaterializedView;
 import org.apache.pinot.sql.parsers.parser.SqlPinotShowCreateTable;
+import org.apache.pinot.sql.parsers.parser.SqlPinotShowMaterializedViews;
 import org.apache.pinot.sql.parsers.parser.SqlPinotShowTables;
 import org.apache.pinot.sql.parsers.rewriter.QueryRewriter;
 import org.apache.pinot.sql.parsers.rewriter.QueryRewriterFactory;
@@ -142,11 +146,17 @@ public class CalciteSqlParser {
         } else {
           throw new SqlCompilationException("SqlNode with executable statement already exist with type: " + sqlType);
         }
-      } else if (sqlNode instanceof SqlPinotCreateTable
+      } else if (sqlNode instanceof SqlPinotShowTables
+          || sqlNode instanceof SqlPinotShowMaterializedViews
+          || sqlNode instanceof SqlPinotCreateTable
+          || sqlNode instanceof SqlPinotShowCreateTable
           || sqlNode instanceof SqlPinotDropTable
-          || sqlNode instanceof SqlPinotShowTables
-          || sqlNode instanceof SqlPinotShowCreateTable) {
+          || sqlNode instanceof SqlPinotCreateMaterializedView
+          || sqlNode instanceof SqlPinotShowCreateMaterializedView
+          || sqlNode instanceof SqlPinotDropMaterializedView) {
         // Pinot-native DDL statements; the controller dispatches these via the DDL endpoint.
+        // Ordering: Catalog → Table → Materialized View, lifecycle CREATE → SHOW CREATE → DROP,
+        // matching `DdlOperation` and `DdlCompiler#compile`.
         if (sqlType == null) {
           sqlType = PinotSqlType.DDL;
           statementNode = sqlNode;

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/parser/SqlPinotCreateMaterializedView.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/parser/SqlPinotCreateMaterializedView.java
@@ -1,0 +1,148 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.sql.parsers.parser;
+
+import java.util.Arrays;
+import java.util.List;
+import javax.annotation.Nullable;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+
+/// Pinot-native `CREATE MATERIALIZED VIEW` DDL statement.
+///
+/// Syntax:
+/// ```
+///   CREATE MATERIALIZED VIEW [IF NOT EXISTS] [db.]name (
+///     col TYPE [NULL | NOT NULL] [DEFAULT literal] [DIMENSION | METRIC | DATETIME ...],
+///     ...
+///   )
+///   [ REFRESH [INTERVAL] EVERY <period> ]
+///   [ PROPERTIES ( 'key' = 'value', ... ) ]
+///   AS <query>
+/// ```
+///
+/// The `REFRESH ... EVERY <period>` clause is optional. When present, it is compiled to a
+/// per-table Quartz cron expression stored under `task.MaterializedViewTask.schedule`.
+/// When omitted, no `schedule` entry is written and the MV task runs under the
+/// cluster-wide MV task cron.
+///
+/// Semantic validation and compilation to `Schema` + `TableConfig` happen in `pinot-sql-ddl`.
+public class SqlPinotCreateMaterializedView extends SqlCall {
+  private static final SqlSpecialOperator OPERATOR =
+      new SqlSpecialOperator("CREATE_MATERIALIZED_VIEW", SqlKind.OTHER_DDL);
+
+  private final SqlIdentifier _name;
+  private final boolean _ifNotExists;
+  private final SqlNodeList _columns;
+  @Nullable
+  private final SqlPinotRefreshClause _refresh;
+  private final SqlNodeList _properties;
+  private final SqlNode _query;
+
+  public SqlPinotCreateMaterializedView(SqlParserPos pos, SqlIdentifier name, boolean ifNotExists,
+      SqlNodeList columns, @Nullable SqlPinotRefreshClause refresh, @Nullable SqlNodeList properties,
+      SqlNode query) {
+    super(pos);
+    _name = name;
+    _ifNotExists = ifNotExists;
+    _columns = columns;
+    _refresh = refresh;
+    _properties = properties == null ? SqlNodeList.EMPTY : properties;
+    _query = query;
+  }
+
+  public SqlIdentifier getName() {
+    return _name;
+  }
+
+  public boolean isIfNotExists() {
+    return _ifNotExists;
+  }
+
+  public SqlNodeList getColumns() {
+    return _columns;
+  }
+
+  /// Returns the parsed `REFRESH` clause, or `null` if the DDL omitted it (use cluster cron).
+  @Nullable
+  public SqlPinotRefreshClause getRefresh() {
+    return _refresh;
+  }
+
+  public SqlNodeList getProperties() {
+    return _properties;
+  }
+
+  public SqlNode getQuery() {
+    return _query;
+  }
+
+  @Override
+  public SqlOperator getOperator() {
+    return OPERATOR;
+  }
+
+  @Override
+  public List<SqlNode> getOperandList() {
+    return Arrays.asList(_name, _columns, _refresh, _properties, _query);
+  }
+
+  @Override
+  public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+    writer.keyword("CREATE MATERIALIZED VIEW");
+    if (_ifNotExists) {
+      writer.keyword("IF NOT EXISTS");
+    }
+    _name.unparse(writer, leftPrec, rightPrec);
+    // Column list is optional: when the DDL omitted it (column inference path), unparse
+    // must NOT emit empty `()` because the round-trip parser then parses `()` as an
+    // explicit-but-empty list which the grammar rejects (PinotColumnList requires at
+    // least one declaration).
+    if (!_columns.isEmpty()) {
+      SqlWriter.Frame columnFrame = writer.startList("(", ")");
+      for (SqlNode column : _columns) {
+        writer.sep(",");
+        column.unparse(writer, 0, 0);
+      }
+      writer.endList(columnFrame);
+    }
+    if (_refresh != null) {
+      _refresh.unparse(writer, 0, 0);
+    }
+    if (!_properties.isEmpty()) {
+      writer.keyword("PROPERTIES");
+      SqlWriter.Frame propFrame = writer.startList("(", ")");
+      for (SqlNode property : _properties) {
+        writer.sep(",");
+        property.unparse(writer, 0, 0);
+      }
+      writer.endList(propFrame);
+    }
+    writer.keyword("AS");
+    _query.unparse(writer, 0, 0);
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/parser/SqlPinotDropMaterializedView.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/parser/SqlPinotDropMaterializedView.java
@@ -1,0 +1,84 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.sql.parsers.parser;
+
+import java.util.Collections;
+import java.util.List;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+
+/// Pinot-native `DROP MATERIALIZED VIEW [IF EXISTS] [db.]name` DDL statement.
+///
+/// Parse-time AST node only. Unlike [SqlPinotDropTable] this form has no `TYPE` clause —
+/// an MV is always realized as an OFFLINE physical table, so a `TYPE` choice would either be
+/// redundant (`OFFLINE`) or contradictory (`REALTIME`). The controller dispatches on this AST
+/// type and asserts the target really is an MV before delegating to the table-delete path; if
+/// it is a plain OFFLINE table the controller returns 400 with a pointer at `DROP TABLE`.
+/// Conversely, `DROP TABLE` on an MV-backed table also returns 400 — the two forms are
+/// strictly partitioned by underlying TableConfig shape (the Q2=B contract that PR4
+/// established for `SHOW CREATE`).
+///
+/// This class is not thread-safe; instances should not be mutated after construction.
+public class SqlPinotDropMaterializedView extends SqlCall {
+  private static final SqlSpecialOperator OPERATOR =
+      new SqlSpecialOperator("DROP_MATERIALIZED_VIEW", SqlKind.OTHER_DDL);
+
+  private final SqlIdentifier _name;
+  private final boolean _ifExists;
+
+  public SqlPinotDropMaterializedView(SqlParserPos pos, SqlIdentifier name, boolean ifExists) {
+    super(pos);
+    _name = name;
+    _ifExists = ifExists;
+  }
+
+  public SqlIdentifier getName() {
+    return _name;
+  }
+
+  public boolean isIfExists() {
+    return _ifExists;
+  }
+
+  @Override
+  public SqlOperator getOperator() {
+    return OPERATOR;
+  }
+
+  @Override
+  public List<SqlNode> getOperandList() {
+    return Collections.singletonList(_name);
+  }
+
+  @Override
+  public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+    writer.keyword("DROP MATERIALIZED VIEW");
+    if (_ifExists) {
+      writer.keyword("IF EXISTS");
+    }
+    _name.unparse(writer, leftPrec, rightPrec);
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/parser/SqlPinotRefreshClause.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/parser/SqlPinotRefreshClause.java
@@ -1,0 +1,78 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.sql.parsers.parser;
+
+import java.util.Collections;
+import java.util.List;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlLiteral;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+
+/// Pinot-native `REFRESH` clause on `CREATE MATERIALIZED VIEW`.
+///
+/// Syntax:
+/// ```
+///   REFRESH [INTERVAL] EVERY <period>
+/// ```
+///
+/// `<period>` is either a quoted period literal (e.g. `'1d'`) or `N DAY|HOUR|MINUTE` tokens
+/// normalized to Pinot period strings (e.g. `1d`, `1h`, `1m`) at parse time.
+///
+/// Compilation in `pinot-sql-ddl` maps `<period>` to the Quartz cron expression
+/// stored under `task.MaterializedViewTask.schedule`. When the entire REFRESH clause
+/// is omitted on the parent `CREATE MATERIALIZED VIEW`, no `schedule` is written and the
+/// cluster-wide MV task cron drives execution.
+public class SqlPinotRefreshClause extends SqlCall {
+  private static final SqlSpecialOperator OPERATOR =
+      new SqlSpecialOperator("REFRESH", SqlKind.OTHER);
+
+  private final SqlLiteral _refreshPeriod;
+
+  public SqlPinotRefreshClause(SqlParserPos pos, SqlLiteral refreshPeriod) {
+    super(pos);
+    _refreshPeriod = refreshPeriod;
+  }
+
+  public SqlLiteral getRefreshPeriod() {
+    return _refreshPeriod;
+  }
+
+  @Override
+  public SqlOperator getOperator() {
+    return OPERATOR;
+  }
+
+  @Override
+  public List<SqlNode> getOperandList() {
+    return Collections.singletonList(_refreshPeriod);
+  }
+
+  @Override
+  public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+    writer.keyword("REFRESH");
+    writer.keyword("EVERY");
+    _refreshPeriod.unparse(writer, 0, 0);
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/parser/SqlPinotShowCreateMaterializedView.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/parser/SqlPinotShowCreateMaterializedView.java
@@ -1,0 +1,73 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.sql.parsers.parser;
+
+import java.util.Collections;
+import java.util.List;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+
+/// Pinot-native `SHOW CREATE MATERIALIZED VIEW [db.]name` DDL statement.
+///
+/// Parse-time AST node only. Unlike [SqlPinotShowCreateTable] this form has no `TYPE` clause —
+/// an MV is always backed by an OFFLINE table, so a `TYPE` choice would either be redundant
+/// (`OFFLINE`) or contradictory (`REALTIME`). The controller dispatches on this AST type and
+/// asserts the target really is an MV before rendering reverse DDL via
+/// `CanonicalDdlEmitter#emit`; if it isn't, the controller returns 400 with a pointer at the
+/// regular `SHOW CREATE TABLE` form.
+///
+/// This class is not thread-safe; instances should not be mutated after construction.
+public class SqlPinotShowCreateMaterializedView extends SqlCall {
+  private static final SqlSpecialOperator OPERATOR =
+      new SqlSpecialOperator("SHOW_CREATE_MATERIALIZED_VIEW", SqlKind.OTHER_DDL);
+
+  private final SqlIdentifier _name;
+
+  public SqlPinotShowCreateMaterializedView(SqlParserPos pos, SqlIdentifier name) {
+    super(pos);
+    _name = name;
+  }
+
+  public SqlIdentifier getName() {
+    return _name;
+  }
+
+  @Override
+  public SqlOperator getOperator() {
+    return OPERATOR;
+  }
+
+  @Override
+  public List<SqlNode> getOperandList() {
+    return Collections.singletonList(_name);
+  }
+
+  @Override
+  public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+    writer.keyword("SHOW CREATE MATERIALIZED VIEW");
+    _name.unparse(writer, leftPrec, rightPrec);
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/parser/SqlPinotShowMaterializedViews.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/parser/SqlPinotShowMaterializedViews.java
@@ -1,0 +1,78 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.sql.parsers.parser;
+
+import java.util.Collections;
+import java.util.List;
+import javax.annotation.Nullable;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.SqlSpecialOperator;
+import org.apache.calcite.sql.SqlWriter;
+import org.apache.calcite.sql.parser.SqlParserPos;
+
+
+/// Pinot-native `SHOW MATERIALIZED VIEWS [FROM db]` DDL statement. Lists the raw names of
+/// every materialized view in the given database (or the default database when none is
+/// specified). The Catalog-listing peer of [SqlPinotShowTables] for the MV object family.
+///
+/// MV identity is decided by [TableConfig#isMaterializedView()] (the canonical flag added in
+/// PR #18564); the controller filters OFFLINE tables by that flag rather than inferring MV-ness
+/// from the presence of a `MaterializedViewTask` block.
+///
+/// This class is not thread-safe; instances should not be mutated after construction.
+public class SqlPinotShowMaterializedViews extends SqlCall {
+  private static final SqlSpecialOperator OPERATOR =
+      new SqlSpecialOperator("SHOW_MATERIALIZED_VIEWS", SqlKind.OTHER_DDL);
+
+  @Nullable private final SqlIdentifier _database;
+
+  public SqlPinotShowMaterializedViews(SqlParserPos pos, @Nullable SqlIdentifier database) {
+    super(pos);
+    _database = database;
+  }
+
+  /// @return the explicit database identifier when ``FROM db`` is supplied, else `null`.
+  @Nullable
+  public SqlIdentifier getDatabase() {
+    return _database;
+  }
+
+  @Override
+  public SqlOperator getOperator() {
+    return OPERATOR;
+  }
+
+  @Override
+  public List<SqlNode> getOperandList() {
+    return _database == null ? Collections.emptyList() : Collections.singletonList(_database);
+  }
+
+  @Override
+  public void unparse(SqlWriter writer, int leftPrec, int rightPrec) {
+    writer.keyword("SHOW MATERIALIZED VIEWS");
+    if (_database != null) {
+      writer.keyword("FROM");
+      _database.unparse(writer, leftPrec, rightPrec);
+    }
+  }
+}

--- a/pinot-common/src/test/java/org/apache/pinot/common/materializedview/MaterializedViewAggregationCatalogTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/materializedview/MaterializedViewAggregationCatalogTest.java
@@ -1,0 +1,128 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.materializedview;
+
+import java.util.Map;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+
+
+/// L1 — Static regression on the MV aggregation catalog.
+///
+/// These tests pin the supported-set and the type mapping so a future refactor cannot
+/// silently drop or remap an entry without a test failure. In particular:
+///
+///   - the {@code DISTINCTCOUNTRAW*} entries are pinned to {@link DataType#BYTES} even
+///     though the v1 aggregation functions return {@code STRING} from
+///     {@code getFinalResultColumnType()} — this divergence is intentional (see catalog
+///     class javadoc) and load-bearing for MV ingestion / rewrite correctness.
+public class MaterializedViewAggregationCatalogTest {
+
+  @Test
+  public void testSupportedAggregationsExactSet() {
+    // Snapshot the exact contents.  A future refactor that adds or removes an entry must
+    // update this assertion deliberately, which forces a code-review conversation about
+    // whether the rewrite engine and the schema inferer have been updated in lockstep.
+    Map<String, DataType> expected = Map.of(
+        "SUM", DataType.DOUBLE,
+        "MIN", DataType.DOUBLE,
+        "MAX", DataType.DOUBLE,
+        "COUNT", DataType.LONG,
+        "DISTINCTCOUNTRAWHLL", DataType.BYTES,
+        "DISTINCTCOUNTRAWHLLPLUS", DataType.BYTES,
+        "DISTINCTCOUNTRAWTHETASKETCH", DataType.BYTES);
+    assertEquals(MaterializedViewAggregationCatalog.SUPPORTED_AGGREGATIONS, expected);
+  }
+
+  @Test
+  public void testSupportedOperatorsAllUpperCase() {
+    for (String op : MaterializedViewAggregationCatalog.getSupportedOperators()) {
+      assertEquals(op, op.toUpperCase(java.util.Locale.ROOT),
+          "Catalog operator '" + op + "' must be canonical (uppercase); the catalog's lookup "
+              + "methods normalise the caller's input to upper-case so the keys MUST be stored "
+              + "upper-case to match.");
+    }
+  }
+
+  @Test
+  public void testGetInferredDataTypeNumericAggregations() {
+    assertEquals(MaterializedViewAggregationCatalog.getInferredDataType("sum"), DataType.DOUBLE);
+    assertEquals(MaterializedViewAggregationCatalog.getInferredDataType("SUM"), DataType.DOUBLE);
+    assertEquals(MaterializedViewAggregationCatalog.getInferredDataType("Min"), DataType.DOUBLE);
+    assertEquals(MaterializedViewAggregationCatalog.getInferredDataType("max"), DataType.DOUBLE);
+  }
+
+  @Test
+  public void testGetInferredDataTypeCount() {
+    assertEquals(MaterializedViewAggregationCatalog.getInferredDataType("count"), DataType.LONG);
+  }
+
+  @Test
+  public void testGetInferredDataTypeSketches() {
+    // CRITICAL: see catalog class javadoc.  These MUST be BYTES even though the v1 engine's
+    // getFinalResultColumnType() reports STRING — the MV's stored column is the serialized
+    // sketch, not the hex-encoded scalar response.  Storing STRING would silently route the
+    // rewrite through the "hash the literal" branch of DistinctCountHLLAggregationFunction
+    // and produce wrong answers.
+    assertEquals(MaterializedViewAggregationCatalog.getInferredDataType("DISTINCTCOUNTRAWHLL"),
+        DataType.BYTES);
+    assertEquals(MaterializedViewAggregationCatalog.getInferredDataType("DISTINCTCOUNTRAWHLLPLUS"),
+        DataType.BYTES);
+    assertEquals(MaterializedViewAggregationCatalog.getInferredDataType("DISTINCTCOUNTRAWTHETASKETCH"),
+        DataType.BYTES);
+  }
+
+  @Test
+  public void testIsSupportedCaseInsensitive() {
+    assertTrue(MaterializedViewAggregationCatalog.isSupported("sum"));
+    assertTrue(MaterializedViewAggregationCatalog.isSupported("SUM"));
+    assertTrue(MaterializedViewAggregationCatalog.isSupported("Sum"));
+  }
+
+  @Test
+  public void testIsSupportedRejectsUnknownAggregation() {
+    // Pinot aggregations the MV rewrite engine cannot re-aggregate (PR 2).  A future PR may
+    // add re-aggregation support for some of these — when it does, it MUST update both the
+    // catalog and this test in the same commit.
+    assertFalse(MaterializedViewAggregationCatalog.isSupported("DISTINCTCOUNTHLL"));
+    assertFalse(MaterializedViewAggregationCatalog.isSupported("AVG"));
+    assertFalse(MaterializedViewAggregationCatalog.isSupported("PERCENTILE"));
+    assertFalse(MaterializedViewAggregationCatalog.isSupported("HISTOGRAM"));
+  }
+
+  @Test
+  public void testIsSupportedNullOperator() {
+    assertFalse(MaterializedViewAggregationCatalog.isSupported(null));
+  }
+
+  @Test
+  public void testGetInferredDataTypeNullOperator() {
+    assertNull(MaterializedViewAggregationCatalog.getInferredDataType(null));
+  }
+
+  @Test
+  public void testGetInferredDataTypeUnknownOperator() {
+    assertNull(MaterializedViewAggregationCatalog.getInferredDataType("avg"));
+  }
+}

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/request/RequestUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/request/RequestUtilsTest.java
@@ -18,12 +18,16 @@
  */
 package org.apache.pinot.common.utils.request;
 
+import java.util.List;
 import java.util.Set;
 import org.apache.calcite.sql.SqlDialect;
+import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.pinot.common.request.Expression;
 import org.apache.pinot.common.request.ExpressionType;
+import org.apache.pinot.common.request.Function;
+import org.apache.pinot.common.request.Identifier;
 import org.apache.pinot.sql.parsers.CalciteSqlParser;
 import org.apache.pinot.sql.parsers.PinotSqlType;
 import org.apache.pinot.sql.parsers.SqlNodeAndOptions;
@@ -31,7 +35,10 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertSame;
+import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
 
 
@@ -82,5 +89,118 @@ public class RequestUtilsTest {
     } else {
       assertEquals(tableNames, expectedSet);
     }
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Alias helpers: isAliased / unwrapAlias / extractAliasOrIdentifierName
+  // ---------------------------------------------------------------------------------------------
+
+  @Test
+  public void testIsAliasedAliasedFunctionReturnsTrue() {
+    Expression expr = aliased(sumOf("amount"), "total");
+    assertTrue(RequestUtils.isAliased(expr));
+  }
+
+  @Test
+  public void testIsAliasedBareIdentifierReturnsFalse() {
+    Expression expr = RequestUtils.getIdentifierExpression("country");
+    assertFalse(RequestUtils.isAliased(expr));
+  }
+
+  @Test
+  public void testIsAliasedAggregationWithoutAsReturnsFalse() {
+    // SUM(x) without AS — the operator is "sum", not "as".
+    Expression expr = sumOf("amount");
+    assertFalse(RequestUtils.isAliased(expr));
+  }
+
+  @Test
+  public void testIsAliasedNullReturnsFalse() {
+    assertFalse(RequestUtils.isAliased(null));
+  }
+
+  @Test
+  public void testIsAliasedLiteralReturnsFalse() {
+    Expression expr = RequestUtils.getLiteralExpression(42L);
+    assertFalse(RequestUtils.isAliased(expr));
+  }
+
+  @Test
+  public void testUnwrapAliasAliasedReturnsUnderlyingExpression() {
+    Expression sum = sumOf("amount");
+    Expression aliased = aliased(sum, "total");
+    Expression unwrapped = RequestUtils.unwrapAlias(aliased);
+    // Same Expression instance returned (we store it in operands, no copy).
+    assertSame(unwrapped, sum);
+  }
+
+  @Test
+  public void testUnwrapAliasBareIdentifierReturnsExpressionUnchanged() {
+    Expression expr = RequestUtils.getIdentifierExpression("country");
+    Expression unwrapped = RequestUtils.unwrapAlias(expr);
+    assertSame(unwrapped, expr);
+  }
+
+  @Test
+  public void testUnwrapAliasAggregationWithoutAsReturnsExpressionUnchanged() {
+    Expression expr = sumOf("amount");
+    Expression unwrapped = RequestUtils.unwrapAlias(expr);
+    assertSame(unwrapped, expr);
+  }
+
+  @Test
+  public void testExtractAliasOrIdentifierNameAliasedFunctionReturnsAliasName() {
+    Expression expr = aliased(sumOf("amount"), "total");
+    assertEquals(RequestUtils.extractAliasOrIdentifierName(expr), "total");
+  }
+
+  @Test
+  public void testExtractAliasOrIdentifierNameBareIdentifierReturnsIdentifierName() {
+    Expression expr = RequestUtils.getIdentifierExpression("country");
+    assertEquals(RequestUtils.extractAliasOrIdentifierName(expr), "country");
+  }
+
+  @Test
+  public void testExtractAliasOrIdentifierNameAggregationWithoutAsThrows() {
+    Expression expr = sumOf("amount");
+    assertThrows(IllegalStateException.class, () -> RequestUtils.extractAliasOrIdentifierName(expr));
+  }
+
+  @Test
+  public void testExtractAliasOrIdentifierNameLiteralThrows() {
+    Expression expr = RequestUtils.getLiteralExpression(42L);
+    assertThrows(IllegalStateException.class, () -> RequestUtils.extractAliasOrIdentifierName(expr));
+  }
+
+  @Test
+  public void testExtractAliasOrIdentifierNameAliasOperandNotIdentifierThrows() {
+    // Construct a malformed `as` call whose alias operand is a literal — should throw.
+    Function asFunc = new Function(SqlKind.AS.lowerName);
+    asFunc.addToOperands(RequestUtils.getIdentifierExpression("amount"));
+    asFunc.addToOperands(RequestUtils.getLiteralExpression(99L));
+    Expression expr = new Expression(ExpressionType.FUNCTION);
+    expr.setFunctionCall(asFunc);
+    assertThrows(IllegalStateException.class, () -> RequestUtils.extractAliasOrIdentifierName(expr));
+  }
+
+  // ---------- helpers ----------
+
+  private static Expression sumOf(String column) {
+    Function func = new Function("sum");
+    func.setOperands(List.of(RequestUtils.getIdentifierExpression(column)));
+    Expression expr = new Expression(ExpressionType.FUNCTION);
+    expr.setFunctionCall(func);
+    return expr;
+  }
+
+  private static Expression aliased(Expression expression, String alias) {
+    Function asFunc = new Function(SqlKind.AS.lowerName);
+    asFunc.addToOperands(expression);
+    Expression aliasExpr = new Expression(ExpressionType.IDENTIFIER);
+    aliasExpr.setIdentifier(new Identifier(alias));
+    asFunc.addToOperands(aliasExpr);
+    Expression result = new Expression(ExpressionType.FUNCTION);
+    result.setFunctionCall(asFunc);
+    return result;
   }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/PinotDdlParserTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/PinotDdlParserTest.java
@@ -22,10 +22,15 @@ import java.util.Locale;
 import org.apache.calcite.sql.SqlIdentifier;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.pinot.sql.parsers.parser.SqlPinotColumnDeclaration;
+import org.apache.pinot.sql.parsers.parser.SqlPinotCreateMaterializedView;
 import org.apache.pinot.sql.parsers.parser.SqlPinotCreateTable;
+import org.apache.pinot.sql.parsers.parser.SqlPinotDropMaterializedView;
 import org.apache.pinot.sql.parsers.parser.SqlPinotDropTable;
 import org.apache.pinot.sql.parsers.parser.SqlPinotProperty;
+import org.apache.pinot.sql.parsers.parser.SqlPinotRefreshClause;
+import org.apache.pinot.sql.parsers.parser.SqlPinotShowCreateMaterializedView;
 import org.apache.pinot.sql.parsers.parser.SqlPinotShowCreateTable;
+import org.apache.pinot.sql.parsers.parser.SqlPinotShowMaterializedViews;
 import org.apache.pinot.sql.parsers.parser.SqlPinotShowTables;
 import org.testng.annotations.Test;
 
@@ -38,7 +43,8 @@ import static org.testng.Assert.expectThrows;
 import static org.testng.Assert.fail;
 
 
-/// Parser-layer tests for the new Pinot DDL grammar (CREATE TABLE / DROP TABLE / SHOW TABLES).
+/// Parser-layer tests for the new Pinot DDL grammar (CREATE TABLE / CREATE MATERIALIZED VIEW /
+/// DROP TABLE / SHOW TABLES / SHOW MATERIALIZED VIEWS).
 /// Verifies that statements parse, produce the expected AST shape, and that [CalciteSqlParser]
 /// classifies them as [PinotSqlType#DDL].
 public class PinotDdlParserTest {
@@ -149,6 +155,164 @@ public class PinotDdlParserTest {
   }
 
   // -------------------------------------------------------------------------------------------
+  // CREATE MATERIALIZED VIEW
+  // -------------------------------------------------------------------------------------------
+
+  @Test
+  public void minimalCreateMaterializedView() {
+    SqlPinotCreateMaterializedView node = parseCreateMaterializedView(
+        "CREATE MATERIALIZED VIEW eventsMv ("
+            + "  ts TIMESTAMP DATETIME FORMAT 'TIMESTAMP' GRANULARITY '1:MILLISECONDS',"
+            + "  cnt LONG METRIC"
+            + ") REFRESH EVERY '1d' "
+            + "AS SELECT COUNT(*) AS cnt FROM events GROUP BY ts");
+    assertEquals(node.getName().getSimple(), "eventsMv");
+    assertFalse(node.isIfNotExists());
+    assertEquals(node.getColumns().size(), 2);
+    assertEquals(node.getRefresh().getRefreshPeriod().toValue(), "1d");
+    assertTrue(node.getProperties().isEmpty());
+    assertNotNull(node.getQuery());
+  }
+
+  @Test
+  public void createMaterializedViewWithIfNotExists() {
+    SqlPinotCreateMaterializedView node = parseCreateMaterializedView(
+        "CREATE MATERIALIZED VIEW IF NOT EXISTS eventsMv (id INT METRIC) "
+            + "REFRESH EVERY 1 DAY AS SELECT id FROM events");
+    assertTrue(node.isIfNotExists());
+    assertEquals(node.getRefresh().getRefreshPeriod().toValue(), "1d");
+  }
+
+  @Test
+  public void createMaterializedViewQualifiedName() {
+    SqlPinotCreateMaterializedView node = parseCreateMaterializedView(
+        "CREATE MATERIALIZED VIEW myDb.eventsMv (id INT METRIC) "
+            + "REFRESH EVERY 1 HOUR AS SELECT id FROM events");
+    assertEquals(node.getName().names.size(), 2);
+    assertEquals(node.getName().names.get(0), "myDb");
+    assertEquals(node.getRefresh().getRefreshPeriod().toValue(), "1h");
+  }
+
+  @Test
+  public void createMaterializedViewWithIntervalKeywordAndProperties() {
+    // The optional `INTERVAL` keyword is a syntactic sweetener that reads more naturally
+    // ("REFRESH INTERVAL EVERY 1 MINUTE"). It carries no semantic weight — the resulting AST
+    // is identical to the non-INTERVAL form, so the schedule and properties round-trip the
+    // same way as the canonical form parsed by `minimalCreateMaterializedView`.
+    SqlPinotCreateMaterializedView node = parseCreateMaterializedView(
+        "CREATE MATERIALIZED VIEW eventsMv ("
+            + "  ts TIMESTAMP DATETIME FORMAT 'TIMESTAMP' GRANULARITY '1:MILLISECONDS'"
+            + ") REFRESH INTERVAL EVERY 1 MINUTE "
+            + "PROPERTIES ('timeColumnName' = 'ts', 'bucketTimePeriod' = '1d') "
+            + "AS SELECT ts FROM events");
+    SqlPinotRefreshClause refresh = node.getRefresh();
+    assertNotNull(refresh);
+    assertEquals(refresh.getRefreshPeriod().toValue(), "1m");
+    assertEquals(node.getProperties().size(), 2);
+    SqlPinotProperty timeColumn = (SqlPinotProperty) node.getProperties().get(0);
+    assertEquals(timeColumn.getKey().toValue(), "timeColumnName");
+    assertEquals(timeColumn.getValue().toValue(), "ts");
+  }
+
+  @Test
+  public void createMaterializedViewEveryPeriodUnits() {
+    SqlPinotCreateMaterializedView day = parseCreateMaterializedView(
+        "CREATE MATERIALIZED VIEW mv (id INT METRIC) REFRESH EVERY 2 DAYS AS SELECT id FROM t");
+    assertEquals(day.getRefresh().getRefreshPeriod().toValue(), "2d");
+
+    SqlPinotCreateMaterializedView hour = parseCreateMaterializedView(
+        "CREATE MATERIALIZED VIEW mv (id INT METRIC) REFRESH EVERY 30 MINUTES AS SELECT id FROM t");
+    assertEquals(hour.getRefresh().getRefreshPeriod().toValue(), "30m");
+  }
+
+  /// Unsupported `REFRESH EVERY` granularities (SECOND[S], WEEK[S], MONTH[S], YEAR[S]) must
+  /// fail with an actionable message that names the supported units. Without this branch the
+  /// parser falls off into Calcite's default error path, which prints an empty expected-tokens
+  /// list and gives the operator no hint that `MINUTE / HOUR / DAY` are the right alternatives.
+  /// Submitting the value as a quoted Pinot period (`'15m'`, `'6h'`, `'1d'`) remains the
+  /// supported escape hatch when the sugared form does not apply.
+  @Test
+  public void createMaterializedViewUnsupportedRefreshUnitRejected() {
+    // One representative per unsupported family — singular and plural share the same
+    // alternative in the grammar so testing both forms for every family would only pin
+    // generated-parser scaffolding, not behaviour.
+    for (String unit : new String[]{"SECOND", "SECONDS", "WEEK", "WEEKS", "MONTH", "MONTHS",
+        "YEAR", "YEARS"}) {
+      SqlCompilationException e = expectThrows(SqlCompilationException.class,
+          () -> CalciteSqlParser.compileToSqlNodeAndOptions(
+              "CREATE MATERIALIZED VIEW mv (id INT METRIC) "
+                  + "REFRESH EVERY 1 " + unit + " AS SELECT id FROM t"));
+      assertTrue(e.getMessage().contains("not supported"),
+          "Unit " + unit + ": expected 'not supported' guidance; got: " + e.getMessage());
+      assertTrue(e.getMessage().contains("MINUTE")
+              && e.getMessage().contains("HOUR")
+              && e.getMessage().contains("DAY"),
+          "Unit " + unit + ": message must enumerate the supported units; got: " + e.getMessage());
+    }
+  }
+
+  /// Defense-in-depth: the unsupported-unit guard MUST NOT interfere with the quoted-period
+  /// escape hatch, which is the recommended workaround called out in the rejection message
+  /// itself. Otherwise the user is told to do X and X also fails, which is worse than the
+  /// original empty-expected-tokens error.
+  @Test
+  public void createMaterializedViewQuotedPeriodSurvivesAlongsideUnitGuard() {
+    SqlPinotCreateMaterializedView node = parseCreateMaterializedView(
+        "CREATE MATERIALIZED VIEW mv (id INT METRIC) REFRESH EVERY '15m' AS SELECT id FROM t");
+    assertEquals(node.getRefresh().getRefreshPeriod().toValue(), "15m");
+  }
+
+  @Test
+  public void createMaterializedViewWithoutRefreshClauseUsesClusterCron() {
+    // Omitting REFRESH is legal: the MV minion task falls back to the cluster-wide MV
+    // task cron (controller.task.frequencyInSeconds or
+    // controller.task.taskTypeFrequenciesInSeconds.MaterializedViewTask). The AST records
+    // this by leaving `getRefresh()` null; the compiler then skips writing a per-table
+    // `task.MaterializedViewTask.schedule` entry. Without this branch the parser would have
+    // to invent a synthetic default cron — exactly the leaky abstraction we want to avoid.
+    SqlPinotCreateMaterializedView node = parseCreateMaterializedView(
+        "CREATE MATERIALIZED VIEW eventsMv ("
+            + "  ts TIMESTAMP DATETIME FORMAT 'TIMESTAMP' GRANULARITY '1:MILLISECONDS',"
+            + "  cnt LONG METRIC"
+            + ") PROPERTIES ('timeColumnName' = 'ts', 'bucketTimePeriod' = '1d') "
+            + "AS SELECT COUNT(*) AS cnt FROM events GROUP BY ts");
+    assertNull(node.getRefresh(),
+        "REFRESH-less MV must surface a null clause so the compiler can elide the schedule.");
+    assertEquals(node.getProperties().size(), 2,
+        "PROPERTIES must still parse when REFRESH is absent — the two clauses are independent.");
+  }
+
+  @Test
+  public void createMaterializedViewMissingAsQueryFails() {
+    expectThrows(SqlCompilationException.class,
+        () -> CalciteSqlParser.compileToSqlNodeAndOptions(
+            "CREATE MATERIALIZED VIEW mv (id INT METRIC) REFRESH EVERY '1d'"));
+  }
+
+  /// The `AS <query>` clause is restricted to query forms (SELECT/VALUES/WITH/UNION/…);
+  /// DML (INSERT/UPDATE/DELETE/MERGE) must NOT parse. The grammar pins this by invoking
+  /// `OrderedQueryOrExpr(ACCEPT_QUERY)` instead of Calcite's default `SqlQueryOrDml()`
+  /// production. Without this restriction, an `AS INSERT ...` body would parse and only fail
+  /// downstream in the MV analyzer with a non-actionable error — a materialized view's body
+  /// must always be a projection-style query whose output rows are persisted, never a write
+  /// statement.
+  @Test
+  public void createMaterializedViewWithDmlBodyFails() {
+    // INSERT body — the canonical DML form that `SqlQueryOrDml()` would accept and our
+    // tighter `ACCEPT_QUERY` production must reject.
+    expectThrows(SqlCompilationException.class,
+        () -> CalciteSqlParser.compileToSqlNodeAndOptions(
+            "CREATE MATERIALIZED VIEW mv (id INT METRIC) REFRESH EVERY '1d' "
+                + "AS INSERT INTO t VALUES (1)"));
+    // DELETE body — defensive coverage so a future grammar change that accidentally widens
+    // the AS clause back to DML is caught by this test, not only by the INSERT case.
+    expectThrows(SqlCompilationException.class,
+        () -> CalciteSqlParser.compileToSqlNodeAndOptions(
+            "CREATE MATERIALIZED VIEW mv (id INT METRIC) REFRESH EVERY '1d' "
+                + "AS DELETE FROM t"));
+  }
+
+  // -------------------------------------------------------------------------------------------
   // DROP TABLE
   // -------------------------------------------------------------------------------------------
 
@@ -182,6 +346,44 @@ public class PinotDdlParserTest {
   }
 
   // -------------------------------------------------------------------------------------------
+  // DROP MATERIALIZED VIEW
+  // -------------------------------------------------------------------------------------------
+
+  @Test
+  public void dropMaterializedViewMinimal() {
+    SqlPinotDropMaterializedView node = parseDropMaterializedView("DROP MATERIALIZED VIEW mv");
+    assertEquals(node.getName().getSimple(), "mv");
+    assertFalse(node.isIfExists());
+  }
+
+  @Test
+  public void dropMaterializedViewIfExists() {
+    SqlPinotDropMaterializedView node =
+        parseDropMaterializedView("DROP MATERIALIZED VIEW IF EXISTS mv");
+    assertTrue(node.isIfExists());
+  }
+
+  @Test
+  public void dropMaterializedViewQualifiedName() {
+    SqlPinotDropMaterializedView node =
+        parseDropMaterializedView("DROP MATERIALIZED VIEW IF EXISTS analytics.mv");
+    assertEquals(node.getName().names.size(), 2);
+    assertEquals(node.getName().names.get(0), "analytics");
+    assertEquals(node.getName().names.get(1), "mv");
+    assertTrue(node.isIfExists());
+  }
+
+  /// Locks the Q2=B contract at the parser layer: the MV-specific DROP form has no `TYPE`
+  /// clause (MV is always realized as an OFFLINE table). A trailing `TYPE OFFLINE` must fail
+  /// parsing rather than be silently accepted and ignored — silent acceptance would let a
+  /// future grammar add the clause without anyone realizing the controller never read it.
+  @Test
+  public void dropMaterializedViewRejectsTypeClause() {
+    expectThrows(SqlCompilationException.class,
+        () -> CalciteSqlParser.compileToSqlNodeAndOptions("DROP MATERIALIZED VIEW mv TYPE OFFLINE"));
+  }
+
+  // -------------------------------------------------------------------------------------------
   // SHOW TABLES
   // -------------------------------------------------------------------------------------------
 
@@ -196,6 +398,48 @@ public class PinotDdlParserTest {
     SqlPinotShowTables node = parseShow("SHOW TABLES FROM analytics");
     assertNotNull(node.getDatabase());
     assertEquals(node.getDatabase().getSimple(), "analytics");
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // SHOW MATERIALIZED VIEWS
+  // -------------------------------------------------------------------------------------------
+
+  @Test
+  public void showMaterializedViews() {
+    SqlPinotShowMaterializedViews node = parseShowMaterializedViews("SHOW MATERIALIZED VIEWS");
+    assertNull(node.getDatabase());
+  }
+
+  @Test
+  public void showMaterializedViewsFromDatabase() {
+    SqlPinotShowMaterializedViews node = parseShowMaterializedViews(
+        "SHOW MATERIALIZED VIEWS FROM analytics");
+    assertNotNull(node.getDatabase());
+    assertEquals(node.getDatabase().getSimple(), "analytics");
+  }
+
+  /// Lock the lexeme: the verb is `SHOW MATERIALIZED VIEWS` (plural, matching SHOW TABLES and
+  /// the Snowflake convention), not the singular `VIEW`. The singular form is the
+  /// SHOW CREATE peer and must NOT be re-routed here — confusion between the two would mean
+  /// `SHOW MATERIALIZED VIEW foo` could either fail or accidentally list MVs depending on how
+  /// the parser breaks the tie. Pin it to a parse failure so a future grammar change cannot
+  /// silently re-bind the lexeme.
+  @Test
+  public void showMaterializedViewSingularFailsWithoutName() {
+    // `SHOW MATERIALIZED VIEW` (singular) without a name is the SHOW CREATE form missing its
+    // identifier — the parser must reject it rather than match SHOW MATERIALIZED VIEWS.
+    expectThrows(SqlCompilationException.class,
+        () -> CalciteSqlParser.compileToSqlNodeAndOptions("SHOW MATERIALIZED VIEW"));
+  }
+
+  /// SHOW MATERIALIZED VIEWS has no TYPE / IF EXISTS / IF NOT EXISTS clause — those make no
+  /// sense for a multi-object listing. Lock that surface so a future grammar change cannot
+  /// silently accept and ignore them.
+  @Test
+  public void showMaterializedViewsRejectsTypeClause() {
+    expectThrows(SqlCompilationException.class,
+        () -> CalciteSqlParser.compileToSqlNodeAndOptions(
+            "SHOW MATERIALIZED VIEWS TYPE OFFLINE"));
   }
 
   @Test
@@ -217,6 +461,37 @@ public class PinotDdlParserTest {
   }
 
   // -------------------------------------------------------------------------------------------
+  // SHOW CREATE MATERIALIZED VIEW
+  // -------------------------------------------------------------------------------------------
+
+  @Test
+  public void showCreateMaterializedViewMinimal() {
+    SqlPinotShowCreateMaterializedView node = parseShowCreateMaterializedView(
+        "SHOW CREATE MATERIALIZED VIEW mv");
+    assertEquals(node.getName().getSimple(), "mv");
+  }
+
+  @Test
+  public void showCreateMaterializedViewQualifiedName() {
+    SqlPinotShowCreateMaterializedView node = parseShowCreateMaterializedView(
+        "SHOW CREATE MATERIALIZED VIEW analytics.mv");
+    assertEquals(node.getName().names.size(), 2);
+    assertEquals(node.getName().names.get(0), "analytics");
+    assertEquals(node.getName().names.get(1), "mv");
+  }
+
+  /// Lock the Q2=B contract at the parser layer: the MV-specific form has no `TYPE` clause
+  /// (MV is always OFFLINE). A trailing `TYPE OFFLINE` must fail parsing rather than be
+  /// silently accepted and ignored — silent acceptance would let a future grammar add the
+  /// clause without anyone realizing the controller never read it.
+  @Test
+  public void showCreateMaterializedViewRejectsTypeClause() {
+    expectThrows(SqlCompilationException.class,
+        () -> CalciteSqlParser.compileToSqlNodeAndOptions(
+            "SHOW CREATE MATERIALIZED VIEW mv TYPE OFFLINE"));
+  }
+
+  // -------------------------------------------------------------------------------------------
   // PinotSqlType classification
   // -------------------------------------------------------------------------------------------
 
@@ -224,10 +499,17 @@ public class PinotDdlParserTest {
   public void allDdlNodesClassifyAsDdl() {
     String[] ddlStatements = {
         "CREATE TABLE t (id INT) TABLE_TYPE = OFFLINE",
+        "CREATE MATERIALIZED VIEW mv (id INT METRIC) REFRESH EVERY '1d' AS SELECT id FROM t",
         "DROP TABLE t",
         "DROP TABLE IF EXISTS t TYPE OFFLINE",
+        "DROP MATERIALIZED VIEW mv",
+        "DROP MATERIALIZED VIEW IF EXISTS mv",
         "SHOW TABLES",
-        "SHOW TABLES FROM db"
+        "SHOW TABLES FROM db",
+        "SHOW MATERIALIZED VIEWS",
+        "SHOW MATERIALIZED VIEWS FROM db",
+        "SHOW CREATE TABLE t",
+        "SHOW CREATE MATERIALIZED VIEW mv"
     };
     for (String sql : ddlStatements) {
       SqlNodeAndOptions parsed = CalciteSqlParser.compileToSqlNodeAndOptions(sql);
@@ -362,6 +644,14 @@ public class PinotDdlParserTest {
   // Helpers
   // -------------------------------------------------------------------------------------------
 
+  private static SqlPinotCreateMaterializedView parseCreateMaterializedView(String sql) {
+    SqlNode node = parseSingle(sql);
+    if (!(node instanceof SqlPinotCreateMaterializedView)) {
+      fail("Expected SqlPinotCreateMaterializedView; got " + node.getClass().getSimpleName());
+    }
+    return (SqlPinotCreateMaterializedView) node;
+  }
+
   private static SqlPinotCreateTable parseCreate(String sql) {
     SqlNode node = parseSingle(sql);
     if (!(node instanceof SqlPinotCreateTable)) {
@@ -378,6 +668,14 @@ public class PinotDdlParserTest {
     return (SqlPinotDropTable) node;
   }
 
+  private static SqlPinotDropMaterializedView parseDropMaterializedView(String sql) {
+    SqlNode node = parseSingle(sql);
+    if (!(node instanceof SqlPinotDropMaterializedView)) {
+      fail("Expected SqlPinotDropMaterializedView; got " + node.getClass().getSimpleName());
+    }
+    return (SqlPinotDropMaterializedView) node;
+  }
+
   private static SqlPinotShowTables parseShow(String sql) {
     SqlNode node = parseSingle(sql);
     if (!(node instanceof SqlPinotShowTables)) {
@@ -386,12 +684,28 @@ public class PinotDdlParserTest {
     return (SqlPinotShowTables) node;
   }
 
+  private static SqlPinotShowMaterializedViews parseShowMaterializedViews(String sql) {
+    SqlNode node = parseSingle(sql);
+    if (!(node instanceof SqlPinotShowMaterializedViews)) {
+      fail("Expected SqlPinotShowMaterializedViews; got " + node.getClass().getSimpleName());
+    }
+    return (SqlPinotShowMaterializedViews) node;
+  }
+
   private static SqlPinotShowCreateTable parseShowCreate(String sql) {
     SqlNode node = parseSingle(sql);
     if (!(node instanceof SqlPinotShowCreateTable)) {
       fail("Expected SqlPinotShowCreateTable; got " + node.getClass().getSimpleName());
     }
     return (SqlPinotShowCreateTable) node;
+  }
+
+  private static SqlPinotShowCreateMaterializedView parseShowCreateMaterializedView(String sql) {
+    SqlNode node = parseSingle(sql);
+    if (!(node instanceof SqlPinotShowCreateMaterializedView)) {
+      fail("Expected SqlPinotShowCreateMaterializedView; got " + node.getClass().getSimpleName());
+    }
+    return (SqlPinotShowCreateMaterializedView) node;
   }
 
   private static SqlNode parseSingle(String sql) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
@@ -633,6 +633,15 @@ public abstract class BaseControllerStarter implements ServiceStartable {
         return null;
       }
     });
+    // Backfill the reverse index against the authoritative TableConfig list before exposing
+    // the consistency manager to controller-side notify paths.  init() above only seeds the
+    // index from existing definition znodes, so MVs whose znode is missing — best-effort
+    // persist failures, znodes lost to manual ZK surgery, or MVs created on a controller
+    // version older than definition znodes — would be invisible to the DROP TABLE delete-guard
+    // and an operator could silently orphan them by dropping their base table.  Backfill must
+    // run BEFORE the register* calls below so segment / table notifies that begin firing as
+    // soon as `_materializedViewConsistencyManager` is non-null already see a complete index.
+    _helixResourceManager.backfillMaterializedViewReverseIndex(_materializedViewConsistencyManager);
     _helixResourceManager.registerMaterializedViewConsistencyManager(_materializedViewConsistencyManager);
     _helixResourceManager.getSegmentDeletionManager()
         .registerMaterializedViewConsistencyManager(_materializedViewConsistencyManager);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotDdlRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotDdlRestletResource.java
@@ -81,11 +81,15 @@ import org.apache.pinot.spi.exception.DatabaseConflictException;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+import org.apache.pinot.sql.ddl.compile.CompiledCreateMaterializedView;
 import org.apache.pinot.sql.ddl.compile.CompiledCreateTable;
 import org.apache.pinot.sql.ddl.compile.CompiledDdl;
+import org.apache.pinot.sql.ddl.compile.CompiledDropMaterializedView;
 import org.apache.pinot.sql.ddl.compile.CompiledDropTable;
+import org.apache.pinot.sql.ddl.compile.CompiledShowCreateMaterializedView;
 import org.apache.pinot.sql.ddl.compile.CompiledShowCreateTable;
 import org.apache.pinot.sql.ddl.compile.DdlCompilationException;
+import org.apache.pinot.sql.ddl.compile.DdlCompileContext;
 import org.apache.pinot.sql.ddl.compile.DdlCompiler;
 import org.apache.pinot.sql.ddl.compile.DdlOperation;
 import org.apache.pinot.sql.ddl.reverse.CanonicalDdlEmitter;
@@ -98,7 +102,8 @@ import static org.apache.pinot.spi.utils.CommonConstants.SWAGGER_AUTHORIZATION_K
 
 
 /// Controller endpoint for executing Pinot SQL DDL statements. Currently supports CREATE TABLE,
-/// DROP TABLE, SHOW TABLES, and SHOW CREATE TABLE.
+/// CREATE MATERIALIZED VIEW, DROP TABLE, DROP MATERIALIZED VIEW, SHOW TABLES,
+/// SHOW MATERIALIZED VIEWS, SHOW CREATE TABLE, and SHOW CREATE MATERIALIZED VIEW.
 ///
 /// Pipeline:
 /// 1. [DdlCompiler] parses + compiles the SQL into a [CompiledDdl].
@@ -150,14 +155,17 @@ public class PinotDdlRestletResource {
   @Path("/sql/ddl")
   @ManualAuthorization // permission check is done after parsing the DDL so we know the operation
   @ApiOperation(value = "Execute a Pinot SQL DDL statement",
-      notes = "Supports CREATE TABLE, DROP TABLE, SHOW TABLES, and SHOW CREATE TABLE. Returns the "
-          + "generated Schema/TableConfig (CREATE), operation outcome (DROP/SHOW TABLES), or "
-          + "canonical DDL string (SHOW CREATE TABLE).")
+      notes = "Supports CREATE TABLE, CREATE MATERIALIZED VIEW, DROP TABLE, DROP MATERIALIZED VIEW, SHOW TABLES, "
+          + "SHOW MATERIALIZED VIEWS, SHOW CREATE TABLE, and SHOW CREATE MATERIALIZED VIEW. Returns the generated "
+          + "Schema/TableConfig (CREATE), operation outcome (DROP/SHOW TABLES/SHOW MATERIALIZED VIEWS), or canonical "
+          + "DDL string (SHOW CREATE TABLE / SHOW CREATE MATERIALIZED VIEW).")
   @ApiResponses(value = {
-      @ApiResponse(code = 200, message = "Success (DROP, SHOW TABLES, SHOW CREATE TABLE, dry-run, IF NOT EXISTS)"),
-      @ApiResponse(code = 201, message = "Table created"),
+      @ApiResponse(code = 200, message = "Success (DROP, SHOW TABLES, SHOW MATERIALIZED VIEWS, "
+          + "SHOW CREATE TABLE, SHOW CREATE MATERIALIZED VIEW, dry-run, IF NOT EXISTS / IF EXISTS)"),
+      @ApiResponse(code = 201, message = "Table or materialized view created"),
       @ApiResponse(code = 400, message = "Bad request (parse error, semantic error, oversize input, "
-          + "unsupported emitter type, or type-incompatible default value)"),
+          + "unsupported emitter type, type-incompatible default value, or DROP/SHOW CREATE form does "
+          + "not match the underlying table shape)"),
       @ApiResponse(code = 404, message = "Table or schema not found (DROP without IF EXISTS, SHOW CREATE)"),
       @ApiResponse(code = 409, message = "Conflict (duplicate CREATE without IF NOT EXISTS, logical-table "
           + "reference blocking DROP, or race lost to a concurrent writer)"),
@@ -178,15 +186,26 @@ public class PinotDdlRestletResource {
       throw badRequest("DDL statement exceeds maximum length of " + MAX_DDL_SQL_CHARS + " characters.");
     }
 
+    // Compile context carries the TableCache (for the MV schema inferer's Calcite catalog)
+    // and the request-header database (so an unqualified `FROM <src>` resolves under the
+    // operator's intended database). The `_pinotHelixResourceManager == null` branch is the
+    // unit-test escape hatch for non-inferer DDL forms (CREATE TABLE, DROP, SHOW, SHOW CREATE,
+    // explicit-column CREATE MATERIALIZED VIEW). The inferer surfaces a clear "no TableCache
+    // configured" error if it ever runs under STATELESS in production.
+    String requestDatabase = httpHeaders == null ? null : httpHeaders.getHeaderString(DATABASE);
+    DdlCompileContext compileCtx = (_pinotHelixResourceManager == null)
+        ? DdlCompileContext.STATELESS
+        : new DdlCompileContext(_pinotHelixResourceManager.getTableCache(), requestDatabase);
+
     CompiledDdl compiled;
     try {
-      compiled = DdlCompiler.compile(request.getSql());
+      compiled = DdlCompiler.compile(request.getSql(), compileCtx);
     } catch (DdlCompilationException e) {
       throw badRequest(e.getMessage());
-    } catch (RuntimeException e) {
-      LOGGER.warn("Unexpected DDL compilation failure", e);
-      throw badRequest("DDL compilation failed: " + e.getMessage());
     }
+    // Any other RuntimeException is a programmer error or unexpected upstream failure;
+    // let it propagate to the JAX-RS default handler as 500 so monitoring fires on it
+    // instead of seeing it as a user-facing 400.
 
     DdlOperation op = compiled.getOperation();
     String requestedDatabase = compiled.getDatabaseName();
@@ -195,20 +214,39 @@ public class PinotDdlRestletResource {
     // Authorization is performed inside each execute*() method, AFTER the target table name has
     // been DB-translated. Authorizing on the pre-translation name would let a header-supplied
     // database substitute past the auth check.
+    //
+    // Dispatch order mirrors `DdlOperation`: Catalog → Table → Materialized View, lifecycle
+    // CREATE → SHOW CREATE → DROP within each object-level family.
     switch (op) {
+      // Catalog DDL.
+      case SHOW_TABLES:
+        return Response.ok(executeShow(effectiveDatabase, httpHeaders, httpRequest)).build();
+      case SHOW_MATERIALIZED_VIEWS:
+        return Response.ok(executeShowMaterializedViews(effectiveDatabase, httpHeaders, httpRequest)).build();
+      // Table DDL.
       case CREATE_TABLE:
         return executeCreate((CompiledCreateTable) compiled, effectiveDatabase, dryRun,
             httpHeaders, httpRequest);
-      case DROP_TABLE:
-        return Response.ok(
-            executeDrop((CompiledDropTable) compiled, effectiveDatabase, dryRun,
-                httpHeaders, httpRequest)).build();
-      case SHOW_TABLES:
-        return Response.ok(executeShow(effectiveDatabase, httpHeaders, httpRequest)).build();
       case SHOW_CREATE_TABLE:
         return Response.ok(
             executeShowCreate((CompiledShowCreateTable) compiled, effectiveDatabase,
                 httpHeaders, httpRequest)).build();
+      case DROP_TABLE:
+        return Response.ok(
+            executeDrop((CompiledDropTable) compiled, effectiveDatabase, dryRun,
+                httpHeaders, httpRequest)).build();
+      // Materialized View DDL.
+      case CREATE_MATERIALIZED_VIEW:
+        return executeCreateMaterializedView((CompiledCreateMaterializedView) compiled,
+            effectiveDatabase, dryRun, httpHeaders, httpRequest);
+      case SHOW_CREATE_MATERIALIZED_VIEW:
+        return Response.ok(
+            executeShowCreateMaterializedView((CompiledShowCreateMaterializedView) compiled,
+                effectiveDatabase, httpHeaders, httpRequest)).build();
+      case DROP_MATERIALIZED_VIEW:
+        return Response.ok(
+            executeDropMaterializedView((CompiledDropMaterializedView) compiled, effectiveDatabase,
+                dryRun, httpHeaders, httpRequest)).build();
       default:
         throw new ControllerApplicationException(LOGGER, "Unhandled DDL operation: " + op,
             Response.Status.INTERNAL_SERVER_ERROR);
@@ -216,7 +254,7 @@ public class PinotDdlRestletResource {
   }
 
   // -------------------------------------------------------------------------------------------
-  // CREATE
+  // Table DDL: CREATE TABLE
   // -------------------------------------------------------------------------------------------
 
   private Response executeCreate(CompiledCreateTable create, String database,
@@ -254,6 +292,44 @@ public class PinotDdlRestletResource {
         .setSchema(toJson(create.getSchema()))
         .setTableConfig(toJson(create.getTableConfig()))
         .setWarnings(create.getWarnings());
+
+    // Q2=B preflight (raw-name exclusivity rule, mirror of `executeCreateMaterializedView`):
+    // an MV must not share its raw name with EITHER a plain OFFLINE table OR a REALTIME table
+    // at the same name. The two checks together — split across the CREATE TABLE and CREATE
+    // MATERIALIZED VIEW endpoints — enforce a symmetric invariant: any given raw name is
+    // exclusively owned by one of {plain OFFLINE table, REALTIME table, hybrid pair,
+    // materialized view}, regardless of the creation order.
+    //
+    // On the OFFLINE create path: if an MV occupies the OFFLINE znode, refuse with 400. Without
+    // this guard a CREATE TABLE could 409 with the generic "already exists" message — true but
+    // unhelpful, because the operator would not know they were colliding with a derived MV that
+    // has its own DROP form, refresh schedule, and minion task wiring.
+    //
+    // On the REALTIME create path: an MV at the OFFLINE half would form a hybrid pair whose
+    // OFFLINE half is a materialized view — a state with no defined semantics in the broker
+    // rewrite, minion task generator, or consistency manager. Refuse symmetrically with 400.
+    //
+    // IF NOT EXISTS does not suppress these type-mismatch errors: IF NOT EXISTS suppresses
+    // "object not found at the requested type", not "wrong DDL verb for the conflicting
+    // object". Mirror of `executeDrop`'s Q2=B preflight.
+    String rawTableName = TableNameBuilder.extractRawTableName(tableNameWithType);
+    TableConfig conflictingOfflineConfig = null;
+    if (create.getTableConfig().getTableType() == TableType.OFFLINE) {
+      conflictingOfflineConfig = _pinotHelixResourceManager.getTableConfig(tableNameWithType);
+    } else {
+      String offlineNameWithType = TableNameBuilder.OFFLINE.tableNameWithType(rawTableName);
+      conflictingOfflineConfig = _pinotHelixResourceManager.getTableConfig(offlineNameWithType);
+    }
+    if (conflictingOfflineConfig != null && conflictingOfflineConfig.isMaterializedView()) {
+      String tableTypeLabel = create.getTableConfig().getTableType().toString();
+      throw new ControllerApplicationException(LOGGER,
+          "Cannot create " + tableTypeLabel + " table '" + rawTableName
+              + "': a materialized view already exists at this name. A "
+              + (create.getTableConfig().getTableType() == TableType.OFFLINE ? "plain" : tableTypeLabel)
+              + " table cannot share its name with a materialized view — pick a different name "
+              + "for the table, or drop the existing materialized view first.",
+          Response.Status.BAD_REQUEST);
+    }
 
     // Existence check runs first so CREATE TABLE IF NOT EXISTS is a successful no-op when the
     // table already exists, matching the SQL-standard semantics (PostgreSQL, MySQL, SQLite,
@@ -545,7 +621,282 @@ public class PinotDdlRestletResource {
   }
 
   // -------------------------------------------------------------------------------------------
-  // DROP
+  // Materialized View DDL: CREATE MATERIALIZED VIEW
+  // -------------------------------------------------------------------------------------------
+
+  /// Persists a `CREATE MATERIALIZED VIEW` DDL. Mirrors [#executeCreate] but is hard-wired
+  /// to OFFLINE: MVs have no realtime form, so the hybrid-pair coordination in the regular
+  /// CREATE TABLE path does not apply.
+  ///
+  /// The MV runtime watermark znode is intentionally NOT seeded by this endpoint. The
+  /// scheduler's cold-start path (see `MaterializedViewTaskScheduler#getWatermarkMs`) derives
+  /// the watermark from the source table's earliest segment on the first tick, which is the
+  /// only durable source of truth a user can rely on; piping a user-supplied watermark
+  /// through DDL added a second, easily-out-of-sync writer and tied the DDL contract to a
+  /// runtime znode lifecycle. The grammar accordingly has no `REFRESH START(...)` clause.
+  ///
+  /// MV-specific semantic validation (source table existence, time-column TIMESTAMP contract,
+  /// `bucketTimePeriod` alignment with any `DATETRUNC` in the SELECT, definedSQL parseability,
+  /// nested-SELECT rejection) is performed inside [#validateTableConfig] via
+  /// `TaskConfigUtils.validateTaskConfigs` → `MaterializedViewTaskGenerator.validateTaskConfigs`
+  /// → `MaterializedViewAnalyzer.analyze`. The DDL endpoint does not call the analyzer
+  /// directly — the same validation pipeline POST `/tables` uses governs DDL-created MVs.
+  private Response executeCreateMaterializedView(CompiledCreateMaterializedView create,
+      String database, boolean dryRun, HttpHeaders headers, Request httpRequest) {
+    // MV is always OFFLINE: the compiler enforces this. Don't read getTableType() because the
+    // compiler-set value would shadow that contract for any reader of this method.
+    String tableNameWithType = translateTableNameForDdl(
+        TableNameBuilder.OFFLINE.tableNameWithType(create.getTableConfig().getTableName()), headers);
+    create.getTableConfig().setTableName(tableNameWithType);
+
+    String compiledSchemaName = create.getSchema().getSchemaName();
+    String dottedSchemaName = create.getDatabaseName() == null
+        ? compiledSchemaName
+        : create.getDatabaseName() + "." + compiledSchemaName;
+    String schemaName = translateTableNameForDdl(dottedSchemaName, headers);
+    create.getSchema().setSchemaName(schemaName);
+
+    // Authorize against the FULLY-QUALIFIED, post-translation table name. Re-use the
+    // CREATE_TABLE action because the MV is implemented as an OFFLINE Pinot table — operators
+    // who own the table-create surface should be able to materialize a view over data they
+    // already manage. Introducing a separate Actions.Table.CREATE_MATERIALIZED_VIEW would
+    // silently lock existing privileged callers out of the new endpoint.
+    ResourceUtils.checkPermissionAndAccess(tableNameWithType, httpRequest, headers,
+        AccessType.CREATE, Actions.Table.CREATE_TABLE, _accessControlFactory, LOGGER);
+
+    DdlExecutionResponse response = new DdlExecutionResponse()
+        .setOperation(DdlOperation.CREATE_MATERIALIZED_VIEW)
+        .setDryRun(dryRun)
+        .setDatabaseName(database)
+        .setTableName(tableNameWithType)
+        .setTableType(TableType.OFFLINE.toString())
+        .setIfNotExists(create.isIfNotExists())
+        .setSchema(toJson(create.getSchema()))
+        .setTableConfig(toJson(create.getTableConfig()))
+        .setWarnings(create.getWarnings());
+
+    // Q2=B preflight (raw-name exclusivity rule): a materialized view occupies the entire raw
+    // name, so it must not collide with EITHER an existing plain OFFLINE table at the same name
+    // OR an existing REALTIME table at the same raw name. The two checks together form the
+    // CREATE-MV side of the symmetric invariant that `executeCreate` enforces from the
+    // CREATE-TABLE side: any given raw name is exclusively owned by one of {plain OFFLINE table,
+    // REALTIME table, hybrid pair, materialized view}, never two at once, regardless of the
+    // order in which the operator runs CREATE statements.
+    //
+    // The OFFLINE check runs first because the OFFLINE znode is where an existing MV would live
+    // — if we find an MV there, `IF NOT EXISTS` legitimately resolves to a no-op (idempotent
+    // re-deployment), matching the CREATE TABLE policy. A plain OFFLINE table at the same name
+    // is a type mismatch and is rejected with 400 (NOT 409) so the operator gets a pointer at
+    // the resolution rather than a generic "already exists" — mirroring `executeDrop`'s Q2=B
+    // preflight on the symmetric DROP side. IF NOT EXISTS does NOT suppress the type-mismatch
+    // error: IF NOT EXISTS suppresses "object not found", not "wrong DDL verb for this object".
+    String rawTableName = TableNameBuilder.extractRawTableName(tableNameWithType);
+    TableConfig existingOfflineConfig = _pinotHelixResourceManager.getTableConfig(tableNameWithType);
+    if (existingOfflineConfig != null) {
+      if (existingOfflineConfig.isMaterializedView()) {
+        if (create.isIfNotExists()) {
+          // Echo the persisted state, not the client-attempted body: an idempotent re-run
+          // must not advertise the new (rejected) config as if it had been applied.
+          populateNoOpResponseFromPersisted(response, existingOfflineConfig, schemaName);
+          response.setMessage("Materialized view " + tableNameWithType
+              + " already exists; CREATE IF NOT EXISTS is a no-op.");
+          return Response.ok(response).build();
+        }
+        throw new ControllerApplicationException(LOGGER,
+            "Materialized view " + tableNameWithType + " already exists.", Response.Status.CONFLICT);
+      }
+      // Existing OFFLINE config is a plain table (or a corrupted MV missing `definedSQL`):
+      // either way, the raw name is held by a non-MV resource and creating an MV here is
+      // refused. The 400 message is intentional and identical regardless of IF NOT EXISTS.
+      throw new ControllerApplicationException(LOGGER,
+          "Cannot create materialized view '" + rawTableName + "': a plain OFFLINE table already "
+              + "exists at this name. A materialized view cannot share its name with a plain "
+              + "table — pick a different name for the materialized view, or drop the existing "
+              + "table first.",
+          Response.Status.BAD_REQUEST);
+    }
+    // No OFFLINE config: check the REALTIME side. REALTIME tables and MVs live in disjoint
+    // znodes (foo_REALTIME vs foo_OFFLINE) and would not collide physically, but the contract
+    // says raw-name exclusivity is whole-namespace so an MV cannot squat on a name that already
+    // has a base-table half. Without this guard, an operator could legitimately end up with
+    // both an MV at foo_OFFLINE and a base REALTIME at foo_REALTIME — the resulting "hybrid
+    // table whose OFFLINE half is an MV" has no well-defined semantics in the broker rewrite,
+    // minion task generator, or consistency manager.
+    String realtimeNameWithType = TableNameBuilder.REALTIME.tableNameWithType(rawTableName);
+    if (_pinotHelixResourceManager.hasTable(realtimeNameWithType)) {
+      throw new ControllerApplicationException(LOGGER,
+          "Cannot create materialized view '" + rawTableName + "': a REALTIME table already "
+              + "exists at this name. A materialized view cannot share its name with a base "
+              + "table — pick a different name for the materialized view, or drop the existing "
+              + "REALTIME table first.",
+          Response.Status.BAD_REQUEST);
+    }
+
+    // A pre-existing schema can survive a prior failed CREATE (addSchema succeeded but
+    // addTable failed). Accept it iff the column shape matches; otherwise 409 so the
+    // operator can clean up the stale schema explicitly rather than silently mutate it.
+    Schema storedSchema = _pinotHelixResourceManager.getSchema(schemaName);
+    boolean schemaPreexisted = storedSchema != null;
+    if (schemaPreexisted) {
+      String mismatch = describeColumnShapeMismatch(storedSchema, create.getSchema());
+      if (mismatch != null) {
+        throw new ControllerApplicationException(LOGGER,
+            "Schema '" + schemaName + "' already exists and does not match the column list in the DDL: "
+                + mismatch
+                + ". Either omit the column list to reuse the existing schema, or drop the stale schema "
+                + "and recreate the materialized view.",
+            Response.Status.CONFLICT);
+      }
+    }
+
+    Schema schemaForValidation = schemaPreexisted ? storedSchema : create.getSchema();
+    response.setSchema(toJson(schemaForValidation));
+    // Apply tuner configs before validation so the validators see the post-tuner shape, matching
+    // POST /tables. The MV TableConfig already carries the MaterializedViewTask wiring set up
+    // by the compiler; tuners only fill in defaulted index/segment configs.
+    TableConfigTunerUtils.applyTunerConfigs(_pinotHelixResourceManager, create.getTableConfig(),
+        schemaForValidation, Collections.emptyMap());
+    response.setTableConfig(toJson(create.getTableConfig()));
+
+    // validateTableConfig fans out to TaskConfigUtils.validateTaskConfigs which triggers
+    // MaterializedViewTaskGenerator → MaterializedViewAnalyzer.analyze. That path enforces:
+    // source-table existence, source/MV time column TIMESTAMP contract, bucketTimePeriod
+    // alignment with DATETRUNC unit, SELECT-list coverage of MV schema, no nested SELECTs,
+    // and parseable LIMIT injection. There is no need for the DDL endpoint to call
+    // MaterializedViewAnalyzer directly — doing so would duplicate the validation and
+    // create a code path that drifts from the JSON /tables endpoint over time.
+    validateTableConfig(schemaForValidation, create.getTableConfig());
+    PinotTableRestletResource.tableTasksValidation(create.getTableConfig(), _pinotHelixTaskResourceManager);
+
+    if (dryRun) {
+      response.setMessage("Dry run: validated CREATE MATERIALIZED VIEW without persisting.");
+      return Response.ok(response).build();
+    }
+
+    try {
+      if (!schemaPreexisted) {
+        _pinotHelixResourceManager.addSchema(create.getSchema(), false, false);
+      }
+      _pinotHelixResourceManager.addTable(create.getTableConfig());
+    } catch (TableAlreadyExistsException e) {
+      Response noOp = mvIfNotExistsNoOpResponse(create.isIfNotExists(), tableNameWithType, schemaName, response);
+      if (noOp != null) {
+        return noOp;
+      }
+      throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.CONFLICT, e);
+    } catch (SchemaAlreadyExistsException e) {
+      // Schema-create race: another writer beat us. Validate-then-retry against the raced
+      // schema, mirroring the CREATE TABLE recovery path so the two endpoints behave the same
+      // under concurrent provisioning.
+      return retryCreateMaterializedViewAfterSchemaRace(create, response, schemaName,
+          tableNameWithType, e);
+    } catch (Exception e) {
+      // Same intentional decision as CREATE TABLE: do not roll back the schema on a generic
+      // addTable failure. A concurrent sibling CREATE may already be reusing the schema and
+      // a non-atomic orphan-check + deleteSchema would race with it. Operators can DELETE
+      // stale schemas explicitly via /schemas.
+      throw new ControllerApplicationException(LOGGER,
+          "Failed to create materialized view " + tableNameWithType + ": " + e.getMessage(),
+          Response.Status.INTERNAL_SERVER_ERROR, e);
+    }
+
+    response.setMessage("Successfully created materialized view " + tableNameWithType);
+    LOGGER.info("DDL created materialized view {}", tableNameWithType);
+    return Response.status(Response.Status.CREATED).entity(response).build();
+  }
+
+  private Response retryCreateMaterializedViewAfterSchemaRace(CompiledCreateMaterializedView create,
+      DdlExecutionResponse response, String schemaName, String tableNameWithType,
+      SchemaAlreadyExistsException schemaFailure) {
+    Response noOp = mvIfNotExistsNoOpResponse(create.isIfNotExists(), tableNameWithType, schemaName, response);
+    if (noOp != null) {
+      return noOp;
+    }
+    Schema racedSchema = _pinotHelixResourceManager.getSchema(schemaName);
+    if (racedSchema == null) {
+      throw new ControllerApplicationException(LOGGER, schemaFailure.getMessage(), Response.Status.CONFLICT,
+          schemaFailure);
+    }
+    String mismatch = describeColumnShapeMismatch(racedSchema, create.getSchema());
+    if (mismatch != null) {
+      throw new ControllerApplicationException(LOGGER,
+          "Schema '" + schemaName + "' was concurrently created and does not match the column list in the DDL: "
+              + mismatch,
+          Response.Status.CONFLICT, schemaFailure);
+    }
+    response.setSchema(toJson(racedSchema));
+    validateTableConfig(racedSchema, create.getTableConfig());
+    PinotTableRestletResource.tableTasksValidation(create.getTableConfig(), _pinotHelixTaskResourceManager);
+    try {
+      _pinotHelixResourceManager.addTable(create.getTableConfig());
+    } catch (TableAlreadyExistsException e) {
+      Response noOp2 = mvIfNotExistsNoOpResponse(create.isIfNotExists(), tableNameWithType, schemaName, response);
+      if (noOp2 != null) {
+        return noOp2;
+      }
+      throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.CONFLICT, e);
+    } catch (Exception e) {
+      throw new ControllerApplicationException(LOGGER,
+          "Failed to create materialized view " + tableNameWithType
+              + " after concurrent schema create: " + e.getMessage(),
+          Response.Status.INTERNAL_SERVER_ERROR, e);
+    }
+    response.setMessage("Successfully created materialized view " + tableNameWithType);
+    LOGGER.info("DDL created materialized view {} after concurrent schema create", tableNameWithType);
+    return Response.status(Response.Status.CREATED).entity(response).build();
+  }
+
+  /// Overload: takes an already-fetched [TableConfig] (the fast-path pre-check has it in
+  /// hand) and only re-fetches the schema. Avoids a redundant ZK read while preserving the
+  /// "echo persisted, not client-attempted" contract documented on the other overload.
+  private void populateNoOpResponseFromPersisted(DdlExecutionResponse response,
+      TableConfig persistedTableConfig, String schemaName) {
+    if (persistedTableConfig != null) {
+      response.setTableConfig(toJson(persistedTableConfig));
+    }
+    Schema persistedSchema = _pinotHelixResourceManager.getSchema(schemaName);
+    if (persistedSchema != null) {
+      response.setSchema(toJson(persistedSchema));
+    }
+  }
+
+  /// Rewrites `response.tableConfig` and `response.schema` to reflect what is currently
+  /// persisted in Helix/ZK rather than what the client submitted. Without this rewrite, a
+  /// `CREATE MATERIALIZED VIEW IF NOT EXISTS` that lands on an existing MV returns 200 with
+  /// the client-attempted body echoed back — leading an operator running an idempotent
+  /// deployment script to believe their drifted body was applied when in fact the persisted
+  /// MV is unchanged. If either ZK read returns null (transient blip, raced DROP, etc.) the
+  /// corresponding response field is left as-is so the operator never sees an empty payload.
+  private void populateNoOpResponseFromPersisted(DdlExecutionResponse response,
+      String tableNameWithType, String schemaName) {
+    populateNoOpResponseFromPersisted(response,
+        _pinotHelixResourceManager.getTableConfig(tableNameWithType), schemaName);
+  }
+
+  /// CREATE MATERIALIZED VIEW IF NOT EXISTS no-op helper for `addTable` retry catches. Returns
+  /// a 200 response built from the already-persisted state when the raced table at this name
+  /// is itself an MV. Returns null when `ifNotExists` is false, when no config is present, or
+  /// when a non-MV plain OFFLINE table raced in (in which case the caller must throw CONFLICT
+  /// rather than silently report success). Centralizes the three identical retry checks
+  /// (`executeCreateMaterializedView` main path, schema-race retry, and inner addTable retry).
+  @Nullable
+  private Response mvIfNotExistsNoOpResponse(boolean ifNotExists, String tableNameWithType,
+      String schemaName, DdlExecutionResponse response) {
+    if (!ifNotExists) {
+      return null;
+    }
+    TableConfig raced = _pinotHelixResourceManager.getTableConfig(tableNameWithType);
+    if (raced == null || !raced.isMaterializedView()) {
+      return null;
+    }
+    populateNoOpResponseFromPersisted(response, tableNameWithType, schemaName);
+    response.setMessage("Materialized view " + tableNameWithType
+        + " already exists; CREATE IF NOT EXISTS is a no-op.");
+    return Response.ok(response).build();
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // Table DDL: DROP TABLE
   // -------------------------------------------------------------------------------------------
 
   private DdlExecutionResponse executeDrop(CompiledDropTable drop, String database, boolean dryRun,
@@ -612,6 +963,28 @@ public class PinotDdlRestletResource {
         .setTableType(drop.getTableType() == null ? null : drop.getTableType().toString())
         .setDeletedTables(targets);
 
+    // Q2=B contract enforcement (mirror of `executeShowCreate`): the user wrote `DROP TABLE`
+    // but the target is actually a materialized view. The two DROP forms are strictly
+    // partitioned by underlying TableConfig shape — silently allowing this would mean
+    // operators could destroy an MV with a copy/paste of a vanilla `DROP TABLE` from a
+    // sibling-table runbook, with no syntactic signal that they were dropping a derived
+    // asset (and, in the future, cascading dependent views). Returning 400 with a pointer at
+    // the correct form forces an explicit acknowledgement that the target is an MV.
+    //
+    // Important: the check happens BEFORE the IF EXISTS short-circuit above resolves to a
+    // no-op for a missing target — `targets` is non-empty here, so we know at least one
+    // candidate table really exists, and we can compare its shape against the requested form.
+    for (String target : targets) {
+      TableConfig tableConfig = _pinotHelixResourceManager.getTableConfig(target);
+      if (tableConfig != null && tableConfig.isMaterializedView()) {
+        throw new ControllerApplicationException(LOGGER,
+            "Table " + target + " is a materialized view. "
+                + "Use 'DROP MATERIALIZED VIEW " + fullyQualifiedRaw
+                + "' to drop it.",
+            Response.Status.BAD_REQUEST);
+      }
+    }
+
     // Reject drop if any target is referenced by a logical table, matching the safeguard in
     // the existing /tables and /tableConfigs DELETE endpoints.
     assertNoLogicalTableReferences(targets);
@@ -625,8 +998,9 @@ public class PinotDdlRestletResource {
     List<String> dropped = new ArrayList<>();
     for (String target : targets) {
       boolean tasksCleaned = false;
+      TaskCleanupRestorer restorer = null;
       try {
-        cleanupTableTasksBeforeDrop(target);
+        restorer = cleanupTableTasksBeforeDrop(target);
         tasksCleaned = true;
         // deleteTable(rawName, type, retention) takes the raw name and re-derives the typed
         // name internally via TableNameBuilder.forType(type).tableNameWithType(rawName); see
@@ -637,9 +1011,15 @@ public class PinotDdlRestletResource {
         dropped.add(target);
         LOGGER.info("DDL dropped table {}", target);
       } catch (ControllerApplicationException e) {
+        if (restorer != null && restorer.restore()) {
+          tasksCleaned = false;
+        }
         LOGGER.warn("DROP TABLE on {} failed: {}", target, e.getMessage());
         throw dropFailed(target, dropped, tasksCleaned, e.getResponse().getStatus(), e);
       } catch (Exception e) {
+        if (restorer != null && restorer.restore()) {
+          tasksCleaned = false;
+        }
         LOGGER.warn("DROP TABLE on {} failed unexpectedly: {}", target, e.toString());
         throw dropFailed(target, dropped, tasksCleaned,
             Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), e);
@@ -653,6 +1033,148 @@ public class PinotDdlRestletResource {
     response.setMessage("Dropped " + dropped.size() + " table metadata target(s).");
     LOGGER.info("DDL dropped tables {}", dropped);
     return response;
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // Materialized View DDL: DROP MATERIALIZED VIEW
+  // -------------------------------------------------------------------------------------------
+
+  /// Drops a materialized view. MVs are always realized as OFFLINE Pinot tables (the grammar
+  /// has no `TYPE` clause for this form, see `SqlPinotDrop`), so the resolve step skips the
+  /// dual-variant handshake that [#executeDrop] needs.
+  ///
+  /// Q2=B contract: this form refuses any target whose TableConfig is **not** an MV (no
+  /// `task.MaterializedViewTask.definedSQL` marker), even under `IF EXISTS`. We deliberately do
+  /// NOT collapse a type-mismatched target to a 200 no-op: `IF EXISTS` exists to make repeated
+  /// runs of an idempotent provisioning script tolerate "already gone" — not to silently accept
+  /// a name that resolves to a different kind of object. Returning 200 in that case would
+  /// silently leave a plain table in place that the operator expected to be either an MV or
+  /// missing; surfacing 400 forces them to inspect the cluster before acting.
+  ///
+  /// Cleanup is delegated entirely to [PinotHelixResourceManager#deleteTable], which already
+  /// (a) blocks the drop when other MVs depend on this base/MV (matching the legacy
+  /// `DELETE /materializedViews/{name}` endpoint), (b) removes the MV definition and runtime
+  /// znodes via `MaterializedViewDefinitionMetadataUtils.delete` /
+  /// `MaterializedViewRuntimeMetadataUtils.delete`, and (c) unregisters from the consistency
+  /// manager. Adding any of those steps here would be a maintenance hazard (two doors, one
+  /// state machine, drift over time).
+  private DdlExecutionResponse executeDropMaterializedView(CompiledDropMaterializedView drop,
+      String database, boolean dryRun, HttpHeaders headers, Request httpRequest) {
+    String dottedRaw = drop.getDatabaseName() == null
+        ? drop.getRawTableName()
+        : drop.getDatabaseName() + "." + drop.getRawTableName();
+    String fullyQualifiedRaw = translateTableNameForDdl(dottedRaw, headers);
+    String tableNameWithType = TableNameBuilder.OFFLINE.tableNameWithType(fullyQualifiedRaw);
+
+    // Authorize BEFORE existence-revealing branches so 403 and 404 are indistinguishable to an
+    // unauthorized caller — same pattern as executeDrop / executeShowCreate. MVs reuse the
+    // regular table DELETE permission because MV-as-OFFLINE-table is the underlying realization
+    // model and operators already authorized to delete tables should be able to delete MVs.
+    ResourceUtils.checkPermissionAndAccess(tableNameWithType, httpRequest, headers,
+        AccessType.DELETE, Actions.Table.DELETE_TABLE, _accessControlFactory, LOGGER);
+
+    boolean exists = _pinotHelixResourceManager.hasTable(tableNameWithType)
+        || _pinotHelixResourceManager.getTableConfig(tableNameWithType) != null;
+
+    DdlExecutionResponse response = new DdlExecutionResponse()
+        .setOperation(DdlOperation.DROP_MATERIALIZED_VIEW)
+        .setDryRun(dryRun)
+        .setDatabaseName(database)
+        .setTableName(tableNameWithType)
+        .setTableType(TableType.OFFLINE.toString())
+        .setIfExists(drop.isIfExists());
+
+    if (!exists) {
+      if (drop.isIfExists()) {
+        return response
+            .setDeletedTables(Collections.emptyList())
+            .setMessage("No matching materialized view to drop; IF EXISTS satisfied.");
+      }
+      throw new ControllerApplicationException(LOGGER,
+          "Materialized view not found: " + fullyQualifiedRaw,
+          Response.Status.NOT_FOUND);
+    }
+
+    TableConfig tableConfig = _pinotHelixResourceManager.getTableConfig(tableNameWithType);
+    if (tableConfig == null) {
+      // hasTable was true but the config disappeared between the two reads. Same diagnosis as
+      // the SHOW CREATE path: ZK torn write or concurrent delete. Surface as 500 so monitoring
+      // catches the inconsistency.
+      throw new ControllerApplicationException(LOGGER,
+          "Table " + tableNameWithType + " has IdealState but no TableConfig in ZK; "
+              + "possible torn write or concurrent delete.",
+          Response.Status.INTERNAL_SERVER_ERROR);
+    }
+
+    // Q2=B contract enforcement: a plain OFFLINE table is not an MV. We refuse to drop it
+    // through this form because the request explicitly said "MATERIALIZED VIEW" — silently
+    // accepting plain-table drops here would make the two DROP forms interchangeable, the same
+    // pitfall the SHOW CREATE Q2=B prevents on the read side. We refuse even under IF EXISTS
+    // for the reason called out in the Javadoc above.
+    if (!tableConfig.isMaterializedView()) {
+      throw new ControllerApplicationException(LOGGER,
+          "Table " + tableNameWithType + " is not a materialized view. "
+              + "Use 'DROP TABLE " + fullyQualifiedRaw + "' to drop it.",
+          Response.Status.BAD_REQUEST);
+    }
+
+    List<String> targets = Collections.singletonList(tableNameWithType);
+
+    // Reuse the same logical-table and active-task safeguards as executeDrop. An MV is realized
+    // as an OFFLINE table, so it is reachable from a logical-table union and may be a target of
+    // active MaterializedViewTask runs; the two checks apply for the same reasons.
+    assertNoLogicalTableReferences(targets);
+    assertNoActiveTasksBeforeDrop(targets);
+
+    if (dryRun) {
+      return response
+          .setDeletedTables(targets)
+          .setMessage("Dry run: would drop materialized view " + tableNameWithType + ".");
+    }
+
+    boolean tasksCleaned = false;
+    TaskCleanupRestorer restorer = null;
+    try {
+      restorer = cleanupTableTasksBeforeDrop(tableNameWithType);
+      tasksCleaned = true;
+      // deleteTable already handles MV znode cleanup (definition + runtime) and consistency-
+      // manager unregister; see PinotHelixResourceManager.deleteTable for the full flow. Pass
+      // the raw DB-qualified name + explicit OFFLINE type so the call is unambiguous.
+      _pinotHelixResourceManager.deleteTable(fullyQualifiedRaw, TableType.OFFLINE, null);
+      LOGGER.info("DDL dropped materialized view {}", tableNameWithType);
+    } catch (ControllerApplicationException e) {
+      if (restorer != null && restorer.restore()) {
+        tasksCleaned = false;
+      }
+      LOGGER.warn("DROP MATERIALIZED VIEW on {} failed: {}", tableNameWithType, e.getMessage());
+      throw dropFailed(tableNameWithType, Collections.emptyList(), tasksCleaned,
+          e.getResponse().getStatus(), e);
+    } catch (IllegalStateException e) {
+      // Thrown by deleteTable when a dependent MV blocks the delete (matches the legacy
+      // DELETE /materializedViews/{name} contract). Surface as 409 so the caller sees the same
+      // status code that endpoint returns for the same condition.
+      if (restorer != null && restorer.restore()) {
+        tasksCleaned = false;
+      }
+      LOGGER.warn("DROP MATERIALIZED VIEW on {} blocked: {}", tableNameWithType, e.getMessage());
+      throw dropFailed(tableNameWithType, Collections.emptyList(), tasksCleaned,
+          Response.Status.CONFLICT.getStatusCode(), e);
+    } catch (Exception e) {
+      if (restorer != null && restorer.restore()) {
+        tasksCleaned = false;
+      }
+      LOGGER.warn("DROP MATERIALIZED VIEW on {} failed unexpectedly: {}",
+          tableNameWithType, e.toString());
+      throw dropFailed(tableNameWithType, Collections.emptyList(), tasksCleaned,
+          Response.Status.INTERNAL_SERVER_ERROR.getStatusCode(), e);
+    }
+
+    // Schema is intentionally NOT deleted, matching the DROP TABLE contract and the legacy
+    // DELETE /materializedViews/{name} endpoint. A caller who wants to remove the schema can
+    // issue an explicit DELETE /schemas/{name} afterwards.
+    return response
+        .setDeletedTables(targets)
+        .setMessage("Dropped materialized view " + tableNameWithType + ".");
   }
 
   /// Rejects the DROP when any target physical table is currently referenced by a logical table.
@@ -711,11 +1233,15 @@ public class PinotDdlRestletResource {
     }
   }
 
-  private void cleanupTableTasksBeforeDrop(String tableWithType)
+  /// Removes task schedules + completed task entities ahead of a DROP. Returns a token the
+  /// caller can use to restore schedules if the subsequent `deleteTable` call rejects the
+  /// drop (e.g. blocked by a dependent MV). Returns null if nothing was changed.
+  @Nullable
+  private TaskCleanupRestorer cleanupTableTasksBeforeDrop(String tableWithType)
       throws Exception {
     TableConfig tableConfig = _pinotHelixResourceManager.getTableConfig(tableWithType);
     if (tableConfig == null || tableConfig.getTaskConfig() == null) {
-      return;
+      return null;
     }
     Map<String, Map<String, String>> taskTypeConfigsMap = tableConfig.getTaskConfig().getTaskTypeConfigsMap();
     Set<String> taskTypes = new HashSet<>(taskTypeConfigsMap.keySet());
@@ -755,6 +1281,34 @@ public class PinotDdlRestletResource {
         }
       }
       throw e;
+    }
+    return schedulesPersisted ? new TaskCleanupRestorer(tableWithType, tableConfig, removedSchedules) : null;
+  }
+
+  /// Captures the state needed to undo `cleanupTableTasksBeforeDrop` if a downstream
+  /// `deleteTable` rejects the drop (e.g. dependent MV blocks deletion).
+  private final class TaskCleanupRestorer {
+    private final String _tableWithType;
+    private final TableConfig _tableConfig;
+    private final Map<String, String> _removedSchedules;
+
+    TaskCleanupRestorer(String tableWithType, TableConfig tableConfig, Map<String, String> removedSchedules) {
+      _tableWithType = tableWithType;
+      _tableConfig = tableConfig;
+      _removedSchedules = removedSchedules;
+    }
+
+    /// Returns true iff the restore succeeded; callers use this to decide whether the
+    /// "schedules need manual restoration" hint should still appear in the error response.
+    boolean restore() {
+      try {
+        restoreTaskSchedules(_tableWithType, _tableConfig, _removedSchedules);
+        return true;
+      } catch (ControllerApplicationException restoreFailure) {
+        LOGGER.warn("DROP TABLE on {} could not restore task schedules after deleteTable rejected the drop: {}",
+            _tableWithType, restoreFailure.getMessage());
+        return false;
+      }
     }
   }
 
@@ -848,11 +1402,17 @@ public class PinotDdlRestletResource {
   }
 
   // -------------------------------------------------------------------------------------------
-  // SHOW
+  // SHOW sections begin here.
+  //
+  // Physical section order in this file is historical (CREATE → DROP → SHOW). The canonical
+  // logical grouping — mirrored by `DdlOperation`, `executeDdl`'s switch above, and
+  // `DESIGN.md` §3/§4 — is Catalog → Table → Materialized View, lifecycle CREATE → SHOW CREATE
+  // → DROP inside each object-level family. Banner prefixes on every section below name the
+  // family explicitly so navigation by section is unambiguous regardless of physical position.
   // -------------------------------------------------------------------------------------------
 
   // -------------------------------------------------------------------------------------------
-  // SHOW CREATE TABLE
+  // Table DDL: SHOW CREATE TABLE
   // -------------------------------------------------------------------------------------------
 
   private DdlExecutionResponse executeShowCreate(CompiledShowCreateTable show, String database,
@@ -925,6 +1485,27 @@ public class PinotDdlRestletResource {
               + "possible torn write or concurrent delete.",
           Response.Status.INTERNAL_SERVER_ERROR);
     }
+
+    // Q2=B contract enforcement: an MV-backed OFFLINE table must be inspected via
+    // `SHOW CREATE MATERIALIZED VIEW`, not `SHOW CREATE TABLE`. The two emit different DDL
+    // (CREATE MATERIALIZED VIEW vs CREATE TABLE) and silently emitting the wrong header would
+    // produce DDL that, when replayed, recreates the MV as a plain table (the parser refuses
+    // to compile `CREATE TABLE` with an `AS <query>` clause, so the round-trip would simply
+    // fail at apply-time — long after the operator copied the wrong text). 400 here points
+    // the caller at the correct form before they can act on the misleading output.
+    //
+    // The check delegates to the canonical `TableConfig#isMaterializedView` flag (single source
+    // of truth per PR #18564) — the same predicate the emitter dispatches on — so a config that
+    // the SHOW CREATE TABLE path would have routed through the MV branch anyway is caught here
+    // before any rendering happens.
+    if (tableConfig != null && tableConfig.isMaterializedView()) {
+      throw new ControllerApplicationException(LOGGER,
+          "Table " + tableNameWithType + " is a materialized view. "
+              + "Use 'SHOW CREATE MATERIALIZED VIEW " + fullyQualifiedRaw
+              + "' to render its canonical DDL.",
+          Response.Status.BAD_REQUEST);
+    }
+
     Schema schema = _pinotHelixResourceManager.getTableSchema(tableNameWithType);
     if (schema == null) {
       // Unlike a missing TableConfig (which would indicate a torn-write inconsistency since
@@ -974,6 +1555,110 @@ public class PinotDdlRestletResource {
         .setMessage("Rendered canonical CREATE TABLE for " + tableNameWithType + ".");
   }
 
+  // -------------------------------------------------------------------------------------------
+  // Materialized View DDL: SHOW CREATE MATERIALIZED VIEW
+  // -------------------------------------------------------------------------------------------
+
+  /// Renders canonical DDL for a materialized view. MVs are always backed by an OFFLINE Pinot
+  /// table (the grammar has no `TYPE` clause for this form, see `SqlPinotShow`), so the resolve
+  /// step skips the dual-variant handshake that [#executeShowCreate] needs.
+  ///
+  /// Symmetric guard to the Q2=B enforcement on the regular `SHOW CREATE TABLE` path: a
+  /// `SHOW CREATE MATERIALIZED VIEW` against a plain OFFLINE table — i.e. a config whose
+  /// canonical `isMaterializedView` flag is false (per PR #18564) — is a 400. We do not
+  /// silently fall back to the table emitter because the caller asked for the MV view of the
+  /// world; returning a `CREATE TABLE` statement in response would mislead any tooling that
+  /// compares the response DDL header against the request.
+  private DdlExecutionResponse executeShowCreateMaterializedView(
+      CompiledShowCreateMaterializedView show, String database, HttpHeaders headers,
+      Request httpRequest) {
+    String dottedRaw = show.getDatabaseName() == null
+        ? show.getRawTableName()
+        : show.getDatabaseName() + "." + show.getRawTableName();
+    String fullyQualifiedRaw = translateTableNameForDdl(dottedRaw, headers);
+    String tableNameWithType = TableNameBuilder.OFFLINE.tableNameWithType(fullyQualifiedRaw);
+
+    // Authorize before any existence check so 403 and 404 are indistinguishable to an
+    // unauthorized caller (same pattern as executeShowCreate). MVs reuse the regular
+    // table READ permission for the same reason CREATE_MATERIALIZED_VIEW reuses CREATE_TABLE:
+    // an MV is realized as an OFFLINE Pinot table, and operators already authorized to inspect
+    // tables should be able to inspect MVs through this dedicated form without an additional
+    // grant.
+    ResourceUtils.checkPermissionAndAccess(tableNameWithType, httpRequest, headers,
+        AccessType.READ, Actions.Table.GET_TABLE_CONFIG, _accessControlFactory, LOGGER);
+
+    if (!_pinotHelixResourceManager.hasTable(tableNameWithType)) {
+      throw new ControllerApplicationException(LOGGER,
+          "Materialized view not found: " + fullyQualifiedRaw,
+          Response.Status.NOT_FOUND);
+    }
+
+    TableConfig tableConfig = _pinotHelixResourceManager.getTableConfig(tableNameWithType);
+    if (tableConfig == null) {
+      throw new ControllerApplicationException(LOGGER,
+          "Table " + tableNameWithType + " has IdealState but no TableConfig in ZK; "
+              + "possible torn write or concurrent delete.",
+          Response.Status.INTERNAL_SERVER_ERROR);
+    }
+
+    // Q2=B mirror: refuse the MV form for a plain OFFLINE table. The error is symmetric to the
+    // one `executeShowCreate` throws when handed an MV — together they keep the two DDL forms
+    // strictly partitioned by what the underlying TableConfig actually is.
+    //
+    // A previous version of this method also handled the "MaterializedViewTask block present
+    // but definedSQL missing" corrupted shape with a distinct 400 / fix hint. That state is no
+    // longer reachable for any persisted config: the SPI invariant introduced in PR #18564
+    // (TableConfigUtils#validateMaterializedViewInvariants) rejects it at addTable / updateTable
+    // time, and the canonical isMaterializedView flag — not the task block — is the identity
+    // source. Anything still failing this branch is a plain table that was never an MV.
+    if (!tableConfig.isMaterializedView()) {
+      throw new ControllerApplicationException(LOGGER,
+          "Table " + tableNameWithType + " is not a materialized view. "
+              + "Use 'SHOW CREATE TABLE " + fullyQualifiedRaw + "' to render its canonical DDL.",
+          Response.Status.BAD_REQUEST);
+    }
+
+    Schema schema = _pinotHelixResourceManager.getTableSchema(tableNameWithType);
+    if (schema == null) {
+      throw new ControllerApplicationException(LOGGER,
+          "Schema '" + tableNameWithType
+              + "' not found; SHOW CREATE MATERIALIZED VIEW requires the schema to exist. "
+              + "Re-create it via POST /schemas if it was deleted.",
+          Response.Status.NOT_FOUND);
+    }
+
+    String ddl;
+    try {
+      ddl = CanonicalDdlEmitter.emit(schema, tableConfig, database);
+    } catch (IllegalArgumentException e) {
+      // IllegalArgumentException from the MV branch of CanonicalDdlEmitter covers the
+      // caller-actionable failure modes: non-round-trippable cron schedule (Q1=A —
+      // a hand-typed cron that `cronToPeriod` cannot invert), schema/config columns the
+      // grammar cannot express, or PROPERTIES collisions. All are 400.
+      throw new ControllerApplicationException(LOGGER,
+          "SHOW CREATE MATERIALIZED VIEW is not supported for " + tableNameWithType
+              + ": " + e.getMessage(),
+          Response.Status.BAD_REQUEST, e);
+    } catch (RuntimeException e) {
+      throw new ControllerApplicationException(LOGGER,
+          "Internal error rendering SHOW CREATE MATERIALIZED VIEW for " + tableNameWithType
+              + ": " + e.getMessage(),
+          Response.Status.INTERNAL_SERVER_ERROR, e);
+    }
+
+    return new DdlExecutionResponse()
+        .setOperation(DdlOperation.SHOW_CREATE_MATERIALIZED_VIEW)
+        .setDatabaseName(database)
+        .setTableName(tableNameWithType)
+        .setTableType(TableType.OFFLINE.toString())
+        .setDdl(ddl)
+        .setMessage("Rendered canonical CREATE MATERIALIZED VIEW for " + tableNameWithType + ".");
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // Catalog DDL: SHOW TABLES
+  // -------------------------------------------------------------------------------------------
+
   private DdlExecutionResponse executeShow(String database, HttpHeaders headers, Request httpRequest) {
     // SHOW TABLES is scoped to a single database to prevent silently leaking table names across
     // databases the caller may not have access to. The database resolution chain (SQL FROM
@@ -997,6 +1682,46 @@ public class PinotDdlRestletResource {
         .setDatabaseName(scopedDatabase)
         .setTableNames(tables)
         .setMessage("Found " + tables.size() + " table(s).");
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // Catalog DDL: SHOW MATERIALIZED VIEWS
+  // -------------------------------------------------------------------------------------------
+
+  private DdlExecutionResponse executeShowMaterializedViews(String database, HttpHeaders headers,
+      Request httpRequest) {
+    // Same database-scoping convention as SHOW TABLES: SQL `FROM db` -> Database header ->
+    // DEFAULT_DATABASE. A scoped listing prevents silently leaking MV names across databases
+    // the caller may not have access to.
+    String scopedDatabase = database == null ? CommonConstants.DEFAULT_DATABASE : database;
+    // Authorization parity with SHOW TABLES and the existing GET /materializedViews REST: an
+    // MV is physically an OFFLINE table, so the cluster-level GET_TABLE action is the
+    // appropriate scope. Introducing a new `GET_MATERIALIZED_VIEW` action would split the
+    // listing auth surface for what is the same underlying read, and would also diverge from
+    // the existing REST endpoint without a behaviour change to justify it.
+    String endpointUrl = httpRequest.getRequestURL().toString();
+    AccessControl accessControl = _accessControlFactory.create();
+    AccessControlUtils.validatePermission(null, AccessType.READ, headers, endpointUrl, accessControl);
+    if (!accessControl.hasAccess(headers, TargetType.CLUSTER, scopedDatabase,
+        Actions.Cluster.GET_TABLE)) {
+      throw new ControllerApplicationException(LOGGER, "Permission denied", Response.Status.FORBIDDEN);
+    }
+    // The lister returns raw names (no `_OFFLINE` suffix) — matching SHOW TABLES and the MV
+    // DDL input surface (CREATE / SHOW CREATE / DROP MATERIALIZED VIEW all take raw names
+    // because the MV form has no TYPE clause). Returning suffixed names here would mean the
+    // listing output could not be copy-pasted back into any other MV DDL.
+    //
+    // NOTE: An MV may also appear in SHOW TABLES because the underlying TableConfig is an
+    // OFFLINE resource. The two listings are intentionally not mutually exclusive — SHOW
+    // TABLES has always returned every OFFLINE/REALTIME resource, and we preserve that
+    // contract rather than mutate the meaning of SHOW TABLES post-merge.
+    List<String> materializedViews =
+        _pinotHelixResourceManager.getAllRawMaterializedViewNames(scopedDatabase);
+    return new DdlExecutionResponse()
+        .setOperation(DdlOperation.SHOW_MATERIALIZED_VIEWS)
+        .setDatabaseName(scopedDatabase)
+        .setTableNames(materializedViews)
+        .setMessage("Found " + materializedViews.size() + " materialized view(s).");
   }
 
   // -------------------------------------------------------------------------------------------

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/ddl/DdlExecutionResponse.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/ddl/DdlExecutionResponse.java
@@ -31,8 +31,13 @@ import org.apache.pinot.sql.ddl.compile.DdlOperation;
 /// the wire payload focused on the fields that actually apply to the operation that ran.
 ///
 /// - CREATE_TABLE: `tableName, tableType, schema, tableConfig, ifNotExists, warnings, dryRun`
+/// - CREATE_MATERIALIZED_VIEW: same as CREATE_TABLE; `tableType` is always `OFFLINE`.
 /// - DROP_TABLE: `tableName, tableType, deletedTables, ifExists, dryRun`
-/// - SHOW_TABLES: `tableNames`
+/// - SHOW_TABLES: `tableNames` (raw names of every OFFLINE/REALTIME table in scope, including
+///   any that are materialized views — see `tableNames` field doc).
+/// - SHOW_MATERIALIZED_VIEWS: `tableNames` (raw names of every materialized view in scope;
+///   shape is identical to SHOW_TABLES so the wire payload stays uniform across the two
+///   Catalog-listing verbs).
 /// - SHOW_CREATE_TABLE: `tableName, tableType, ddl`
 ///
 /// `dryRun` is emitted only for operations that have dry-run semantics (CREATE, DROP); it is
@@ -166,6 +171,19 @@ public class DdlExecutionResponse {
     return this;
   }
 
+  /// Names returned by Catalog-listing DDLs.
+  ///
+  /// Populated by both `SHOW TABLES` and `SHOW MATERIALIZED VIEWS` — the underlying storage
+  /// substrate is the same (an MV is physically an OFFLINE table), so the wire field is shared
+  /// and the `operation` discriminator tells the client what the names represent. Names are
+  /// raw (no `_OFFLINE` / `_REALTIME` suffix) so they round-trip directly into subsequent
+  /// `SHOW CREATE ...` or `DROP ...` statements.
+  ///
+  /// `SHOW TABLES` returns every OFFLINE/REALTIME table in scope including MVs (an MV is
+  /// physically an OFFLINE table); `SHOW MATERIALIZED VIEWS` returns only the MVs. The two
+  /// listings are intentionally not mutually exclusive — separating them at the DDL surface
+  /// lets callers pick the verb that matches their intent without mutating what `SHOW TABLES`
+  /// has historically meant.
   @Nullable
   public List<String> getTableNames() {
     return _tableNames;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -166,6 +166,7 @@ import org.apache.pinot.core.util.NumericException;
 import org.apache.pinot.materializedview.analysis.MaterializedViewAnalyzer;
 import org.apache.pinot.materializedview.consistency.MaterializedViewConsistencyManager;
 import org.apache.pinot.materializedview.metadata.MaterializedViewDefinitionMetadata;
+import org.apache.pinot.materializedview.metadata.MaterializedViewDefinitionMetadataBuilder;
 import org.apache.pinot.materializedview.metadata.MaterializedViewDefinitionMetadataUtils;
 import org.apache.pinot.materializedview.metadata.MaterializedViewRuntimeMetadataUtils;
 import org.apache.pinot.segment.local.utils.TableConfigUtils;
@@ -889,6 +890,58 @@ public class PinotHelixResourceManager {
     return getAllResources().stream().filter(
         resourceName -> TableNameBuilder.isTableResource(resourceName) && DatabaseUtils.isPartOfDatabase(resourceName,
             databaseName)).map(TableNameBuilder::extractRawTableName).distinct().collect(Collectors.toList());
+  }
+
+  /**
+   * Get all raw materialized view names from provided database name. Backs
+   * {@code SHOW MATERIALIZED VIEWS [FROM db]}.
+   *
+   * <p>Identity is decided by {@link org.apache.pinot.spi.config.table.TableConfig#isMaterializedView()},
+   * the canonical MV flag (PR #18564), rather than by inferring MV-ness from the presence of a
+   * {@code MaterializedViewTask} block. Reading the flag from TableConfig keeps this listing
+   * aligned with every other MV-aware code site in the controller and surfaces corruption
+   * (e.g. a definition znode that was created without its TableConfig) instead of hiding it.
+   *
+   * <p>An MV is always realized as an OFFLINE physical table, so only OFFLINE resources are
+   * considered; REALTIME resources are skipped without a ZK round-trip. Resources whose
+   * TableConfig fetch fails or returns null are dropped silently — a single corrupted znode
+   * must not break the entire listing for an operator running SHOW MATERIALIZED VIEWS to
+   * diagnose cluster state.
+   *
+   * <p>Returned names are raw (no {@code _OFFLINE} suffix), matching {@link #getAllRawTables}
+   * so callers can pipe the result directly into {@code SHOW CREATE MATERIALIZED VIEW} or
+   * {@code DROP MATERIALIZED VIEW} (neither of which accepts a type suffix).
+   *
+   * @param databaseName database name; {@code null} returns MVs from every database (callers
+   *                     scoping by database should pass an explicit name).
+   * @return List of raw materialized view names in the provided database, in resource-iteration
+   *         order; deduplicated by raw name.
+   */
+  public List<String> getAllRawMaterializedViewNames(@Nullable String databaseName) {
+    return getAllResources().stream()
+        .filter(TableNameBuilder::isOfflineTableResource)
+        .filter(resourceName -> DatabaseUtils.isPartOfDatabase(resourceName, databaseName))
+        .filter(this::isMaterializedViewResource)
+        .map(TableNameBuilder::extractRawTableName)
+        .distinct()
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * Returns true iff {@code tableNameWithType} is an OFFLINE resource whose stored TableConfig
+   * has {@code isMaterializedView=true}. Returns false (rather than throwing) when the
+   * TableConfig is missing or the read fails — the caller is a best-effort listing that must
+   * tolerate a single broken znode without aborting.
+   */
+  private boolean isMaterializedViewResource(String tableNameWithType) {
+    try {
+      TableConfig tableConfig = ZKMetadataProvider.getTableConfig(_propertyStore, tableNameWithType);
+      return tableConfig != null && tableConfig.isMaterializedView();
+    } catch (Exception e) {
+      LOGGER.warn("Failed to read TableConfig for {} while filtering MVs; treating as non-MV",
+          tableNameWithType, e);
+      return false;
+    }
   }
 
   /**
@@ -2040,6 +2093,13 @@ public class PinotHelixResourceManager {
       return is;
     });
     _queryWorkloadManager.propagateWorkloadFor(tableNameWithType);
+    // Persist the MV definition znode BEFORE notify so the consistency manager registration
+    // below reads the authoritative `baseTables` list rather than relying on its
+    // `extractSourceTableName(definedSQL)` fallback. The write is best-effort: a transient
+    // ZK glitch must not undo a successfully created table, and the notify fallback path
+    // remains correct because every MV that reaches this method has already passed
+    // `MaterializedViewAnalyzer.analyze` (single-FROM, simple-name source).
+    persistMaterializedViewDefinitionMetadataBestEffort(tableConfig);
     notifyMaterializedViewConsistencyManagerForTableCreate(tableConfig);
     LOGGER.info("Adding table {}: Successfully added table", tableNameWithType);
   }
@@ -5374,6 +5434,254 @@ public class PinotHelixResourceManager {
 
   // ── MV Consistency Manager helpers ──
 
+  /// Persists [MaterializedViewDefinitionMetadata] to ZooKeeper for an MV table at create
+  /// time so [#notifyMaterializedViewConsistencyManagerForTableCreate] can register the MV
+  /// against the authoritative `baseTables` list rather than depending on its `definedSQL`
+  /// re-parse fallback. The scheduler's cold-start path will also find the znode and skip
+  /// its own lazy initialisation (see
+  /// [org.apache.pinot.materializedview.scheduler.MaterializedViewTaskScheduler#getWatermarkMs]).
+  ///
+  /// Write semantics:
+  ///
+  ///   - **Best-effort**: this runs after the table is otherwise fully set up
+  ///       (TableConfig persisted, ideal state assigned, BrokerResource updated). Throwing
+  ///       here would leave the cluster in a half-committed state — the table is already
+  ///       visible to brokers and the rollback handler at the top of `addTable` has been
+  ///       passed. Any exception is logged at WARN and we continue; the notify path's
+  ///       `extractSourceTableName` fallback keeps registration correct.
+  ///   - **`createIfAbsent`**: an existing znode from a prior scheduler cold-start or a
+  ///       prior CREATE retry is left in place. The scheduler's createIfAbsent uses the same
+  ///       contract, and the
+  ///       [MaterializedViewDefinitionMetadataBuilder] produces byte-identical content for
+  ///       the same MV, so an existing znode is by construction equivalent to what we would
+  ///       write.
+  ///   - **Non-MV tables**: early-returns without any ZK round-trips.
+  private void persistMaterializedViewDefinitionMetadataBestEffort(TableConfig tableConfig) {
+    if (!tableConfig.isMaterializedView()) {
+      return;
+    }
+    String tableNameWithType = tableConfig.getTableName();
+    try {
+      Map<String, String> taskConfigs = tableConfig.getMaterializedViewTaskConfigs();
+      if (taskConfigs == null) {
+        LOGGER.warn("MV table {} has no MaterializedViewTask config; skipping definition metadata persist",
+            tableNameWithType);
+        return;
+      }
+      String definedSql = taskConfigs.get(CommonConstants.MaterializedViewTask.DEFINED_SQL_KEY);
+      if (definedSql == null || definedSql.isEmpty()) {
+        LOGGER.warn("MV table {} has no definedSQL; skipping definition metadata persist", tableNameWithType);
+        return;
+      }
+      // The source table name MUST be a simple identifier — `MaterializedViewAnalyzer` rejects
+      // anything else at validate time, so this call is safe for any MV that reached addTable.
+      String sourceRawTableName = MaterializedViewAnalyzer.extractSourceTableName(definedSql);
+
+      String sourceTableWithType = TableNameBuilder.OFFLINE.tableNameWithType(sourceRawTableName);
+      TableConfig sourceTableConfig = ZKMetadataProvider.getTableConfig(_propertyStore, sourceTableWithType);
+      if (sourceTableConfig == null) {
+        sourceTableWithType = TableNameBuilder.REALTIME.tableNameWithType(sourceRawTableName);
+        sourceTableConfig = ZKMetadataProvider.getTableConfig(_propertyStore, sourceTableWithType);
+      }
+      if (sourceTableConfig == null) {
+        LOGGER.warn("MV table {} source table '{}' not found in OFFLINE or REALTIME variants; "
+            + "skipping definition metadata persist", tableNameWithType, sourceRawTableName);
+        return;
+      }
+      Schema sourceSchema = ZKMetadataProvider.getSchema(_propertyStore, sourceRawTableName);
+      if (sourceSchema == null) {
+        LOGGER.warn("MV table {} source table '{}' has no schema; skipping definition metadata persist",
+            tableNameWithType, sourceRawTableName);
+        return;
+      }
+      String viewRawTableName = TableNameBuilder.extractRawTableName(tableNameWithType);
+      Schema viewSchema = ZKMetadataProvider.getSchema(_propertyStore, viewRawTableName);
+      if (viewSchema == null) {
+        LOGGER.warn("MV table {} has no schema; skipping definition metadata persist", tableNameWithType);
+        return;
+      }
+
+      // partitionExprMaps comes from analyzer post-validation; we re-extract from the
+      // already-validated definedSQL + viewSchema, which is cheap (single Calcite parse).
+      Map<String, String> partitionExprMaps =
+          MaterializedViewAnalyzer.extractPartitionExprMaps(definedSql, viewSchema);
+
+      MaterializedViewDefinitionMetadata definition = MaterializedViewDefinitionMetadataBuilder.build(
+          tableNameWithType, tableConfig, viewSchema, sourceTableConfig, sourceSchema,
+          sourceRawTableName, definedSql, partitionExprMaps);
+      if (MaterializedViewDefinitionMetadataUtils.createIfAbsent(_propertyStore, definition)) {
+        LOGGER.info("Adding table {}: Persisted MV definition metadata (baseTables={})",
+            tableNameWithType, definition.getBaseTables());
+      } else {
+        LOGGER.info("Adding table {}: MV definition metadata already exists; leaving in place",
+            tableNameWithType);
+      }
+    } catch (Exception e) {
+      LOGGER.warn("Adding table {}: Best-effort MV definition metadata persist failed; "
+              + "consistency manager will fall back to extractSourceTableName",
+          tableNameWithType, e);
+    }
+  }
+
+  /// Backfills the {@link MaterializedViewConsistencyManager}'s reverse index against the
+  /// authoritative TableConfig list at controller startup, closing the post-restart orphan
+  /// window for MVs whose definition znode is missing.
+  ///
+  /// <h3>Why this is needed</h3>
+  ///
+  /// The consistency manager's startup `rebuildReverseIndex` only scans existing definition
+  /// znodes, while the in-session {@link #persistMaterializedViewDefinitionMetadataBestEffort}
+  /// is best-effort: a transient ZK failure at create time leaves an MV with
+  /// `tableConfig.isMaterializedView()=true` but no definition znode.  Same controller session
+  /// is fine — {@link #notifyMaterializedViewConsistencyManagerForTableCreate} also
+  /// `extractSourceTableName`-falls back into the in-memory reverse index.  But on restart
+  /// `rebuildReverseIndex` would not see that MV at all, and the {@code DROP TABLE} delete-guard
+  /// (which consults only the in-memory reverse index) would let an operator silently orphan
+  /// the MV by dropping its base table.  The same hole applies to MVs created on a controller
+  /// version older than definition znodes (none ever existed for them) and to znodes lost
+  /// to manual ZK surgery.
+  ///
+  /// <h3>What it does</h3>
+  ///
+  /// Walks {@link #getAllRawMaterializedViewNames} (filtered by
+  /// {@code TableConfig.isMaterializedView()}) and, for every MV missing a definition znode:
+  ///
+  ///   1. Resolves `baseTables` via {@link MaterializedViewAnalyzer#extractSourceTableName} on
+  ///      the persisted `definedSQL` — same fallback used by the in-session create path, so
+  ///      post-restart and same-session reverse indexes are by construction byte-identical.
+  ///   2. Registers the MV with the consistency manager in memory.  Idempotent: the manager
+  ///      dedupes inside {@code onMaterializedViewTableCreated}.
+  ///   3. Best-effort writes the definition znode via
+  ///      {@link #persistMaterializedViewDefinitionMetadataBestEffort} so the next restart
+  ///      doesn't have to backfill again, and so the listener-driven rebuilds stay self-healing.
+  ///
+  /// <h3>Two-phase ordering</h3>
+  ///
+  /// In-memory registration runs to completion BEFORE any znode write — phase 2's writes fire
+  /// {@code DefinitionChangeListener.handleChildChange} which clears+rebuilds the reverse index
+  /// from znodes, so kicking off znode writes mid-iteration would race against partially
+  /// rebuilt in-memory state and force MVs with missing source tables out of the index. By
+  /// finishing phase 1 first, even MVs that ultimately can't have their znode written keep the
+  /// in-memory protection until the next listener-driven rebuild (and that rebuild only wipes
+  /// MVs whose source is gone — for which the DROP-base-table orphan path is moot anyway).
+  ///
+  /// <h3>Failure isolation</h3>
+  ///
+  /// Per-MV try/catch.  A single corrupt `definedSQL`, missing source, or ZK glitch logs WARN
+  /// and continues — controller startup must not be held hostage by one broken MV.
+  ///
+  /// <h3>Caller contract</h3>
+  ///
+  /// Must be called exactly once at controller startup, AFTER
+  /// {@link MaterializedViewConsistencyManager#init} and BEFORE
+  /// {@link #registerMaterializedViewConsistencyManager} so the reverse index is fully
+  /// populated before any segment / table notify path can short-circuit on a missing entry.
+  public void backfillMaterializedViewReverseIndex(MaterializedViewConsistencyManager mgr) {
+    if (mgr == null) {
+      return;
+    }
+    List<String> mvRawNames;
+    try {
+      mvRawNames = getAllRawMaterializedViewNames(null);
+    } catch (Exception e) {
+      LOGGER.error("MV reverse-index backfill: failed to enumerate MVs; skipping backfill", e);
+      return;
+    }
+    if (mvRawNames.isEmpty()) {
+      LOGGER.info("MV reverse-index backfill: no MVs in cluster; nothing to do");
+      return;
+    }
+
+    // Phase 1: register every missing-znode MV in memory using the same extractSourceTableName
+    // fallback the in-session create path uses.  No znode writes here, so no listener firings,
+    // so phase 1's in-memory state is fully built before any clear+rebuild can interleave.
+    List<TableConfig> mvsNeedingZnodePersist = new ArrayList<>();
+    int registered = 0;
+    for (String rawName : mvRawNames) {
+      String tableNameWithType = TableNameBuilder.OFFLINE.tableNameWithType(rawName);
+      try {
+        TableConfig cfg = ZKMetadataProvider.getTableConfig(_propertyStore, tableNameWithType);
+        // Defensive re-check — getAllRawMaterializedViewNames already filtered, but the
+        // TableConfig could have flipped (or been deleted) between that scan and here.
+        if (cfg == null || !cfg.isMaterializedView()) {
+          continue;
+        }
+        // Skip MVs whose authoritative definition znode is already present — the manager's
+        // init() already picked them up via rebuildReverseIndex.  Avoid the redundant
+        // in-memory register and the redundant phase-2 znode build.
+        if (MaterializedViewDefinitionMetadataUtils.fetch(_propertyStore, tableNameWithType) != null) {
+          continue;
+        }
+        List<String> baseTables = resolveBaseTablesForBackfill(cfg);
+        if (baseTables == null || baseTables.isEmpty()) {
+          continue;
+        }
+        mgr.onMaterializedViewTableCreated(tableNameWithType, baseTables);
+        mvsNeedingZnodePersist.add(cfg);
+        registered++;
+      } catch (Exception e) {
+        LOGGER.warn("MV reverse-index backfill: failed to register {} in memory; skipping",
+            tableNameWithType, e);
+      }
+    }
+    LOGGER.info("MV reverse-index backfill phase 1: scanned {} MV(s), registered {} missing entries",
+        mvRawNames.size(), registered);
+
+    if (mvsNeedingZnodePersist.isEmpty()) {
+      return;
+    }
+
+    // Phase 2: best-effort persist the definition znode so the next restart doesn't have to
+    // re-backfill, and so MVs whose source is intact transition cleanly to "znode-backed".
+    // persistMaterializedViewDefinitionMetadataBestEffort handles the source-missing /
+    // schema-missing cases internally and is itself try/catch-wrapped, so a single MV's
+    // failure here cannot abort the loop.
+    int znodeAttempted = 0;
+    for (TableConfig cfg : mvsNeedingZnodePersist) {
+      try {
+        persistMaterializedViewDefinitionMetadataBestEffort(cfg);
+        znodeAttempted++;
+      } catch (Exception e) {
+        LOGGER.warn("MV reverse-index backfill: best-effort znode persist threw for {}; continuing",
+            cfg.getTableName(), e);
+      }
+    }
+    LOGGER.info("MV reverse-index backfill phase 2: attempted znode persist for {} MV(s)",
+        znodeAttempted);
+  }
+
+  /// Resolves the {@code baseTables} list for an MV during reverse-index backfill, using the
+  /// same {@link MaterializedViewAnalyzer#extractSourceTableName} fallback as the in-session
+  /// create path so post-restart and same-session reverse indexes are byte-identical.
+  ///
+  /// Returns {@code null} when the MV is not currently registerable (no taskConfigs, no
+  /// `definedSQL`, or unparseable SQL) — the caller logs and skips.  The caller has already
+  /// checked the authoritative znode path; this helper is only the fallback.
+  @Nullable
+  private List<String> resolveBaseTablesForBackfill(TableConfig cfg) {
+    String tableNameWithType = cfg.getTableName();
+    Map<String, String> taskCfg = cfg.getMaterializedViewTaskConfigs();
+    if (taskCfg == null) {
+      LOGGER.warn("MV reverse-index backfill: MV table {} has no MaterializedViewTask config; skipping",
+          tableNameWithType);
+      return null;
+    }
+    String definedSql = taskCfg.get(CommonConstants.MaterializedViewTask.DEFINED_SQL_KEY);
+    if (definedSql == null || definedSql.isEmpty()) {
+      LOGGER.warn("MV reverse-index backfill: MV table {} has no definedSQL; skipping",
+          tableNameWithType);
+      return null;
+    }
+    try {
+      String sourceTable = MaterializedViewAnalyzer.extractSourceTableName(definedSql);
+      return Collections.singletonList(sourceTable);
+    } catch (Exception e) {
+      LOGGER.warn("MV reverse-index backfill: failed to extract source table from definedSQL "
+          + "for MV table {}; skipping", tableNameWithType, e);
+      return null;
+    }
+  }
+
   private void notifyMaterializedViewConsistencyManagerForTableCreate(TableConfig tableConfig) {
     MaterializedViewConsistencyManager mgr = _materializedViewConsistencyManager;
     if (mgr == null || !tableConfig.isMaterializedView()) {
@@ -5419,8 +5727,30 @@ public class PinotHelixResourceManager {
           && !materializedViewDefinition.getBaseTables().isEmpty()) {
         mgr.onMaterializedViewTableDropped(tableNameWithType, materializedViewDefinition.getBaseTables());
       } else if (tableConfig != null && tableConfig.isMaterializedView()) {
-        LOGGER.warn("MV table {} dropped without definition metadata; consistency reverse index may be stale",
-            tableNameWithType);
+        // Definition znode missing but the MV exists — fall back to extractSourceTableName
+        // from the persisted definedSQL, mirroring the symmetric in-session fallback used by
+        // notifyMaterializedViewConsistencyManagerForTableCreate.  Without this, an MV whose
+        // znode persist failed at create time (best-effort path) would be unregisterable on
+        // drop, leaking a ghost reverse-index entry that subsequently blocks legitimate
+        // DROP TABLE on its (now genuinely independent) base table.
+        Map<String, String> mvTaskCfgs = tableConfig.getMaterializedViewTaskConfigs();
+        String definedSqlForDrop = mvTaskCfgs == null
+            ? null : mvTaskCfgs.get(CommonConstants.MaterializedViewTask.DEFINED_SQL_KEY);
+        if (definedSqlForDrop != null && !definedSqlForDrop.isEmpty()) {
+          try {
+            String src = MaterializedViewAnalyzer.extractSourceTableName(definedSqlForDrop);
+            mgr.onMaterializedViewTableDropped(tableNameWithType, Collections.singletonList(src));
+            LOGGER.info("MV table {} dropped via definedSQL fallback (definition znode absent)",
+                tableNameWithType);
+            return;
+          } catch (Exception ignore) {
+            // fall through to the warn below — the SQL is unparseable so the in-memory entry
+            // (if any) was registered with a different key and we cannot deterministically
+            // reverse it.  Operator action required.
+          }
+        }
+        LOGGER.warn("MV table {} dropped without recoverable definition; "
+            + "consistency reverse index may be stale", tableNameWithType);
       }
     } catch (Exception e) {
       LOGGER.warn("Failed to unregister MV table {} from consistency manager", tableNameWithType, e);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/PinotDdlRestletResourceMaterializedViewUnitTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/PinotDdlRestletResourceMaterializedViewUnitTest.java
@@ -1,0 +1,1129 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.api.resources;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.Collections;
+import java.util.Map;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Response;
+import org.apache.helix.task.TaskState;
+import org.apache.pinot.common.exception.SchemaAlreadyExistsException;
+import org.apache.pinot.common.metadata.ZKMetadataProvider;
+import org.apache.pinot.controller.ControllerConf;
+import org.apache.pinot.controller.api.access.AccessControl;
+import org.apache.pinot.controller.api.access.AccessControlFactory;
+import org.apache.pinot.controller.api.exception.ControllerApplicationException;
+import org.apache.pinot.controller.api.exception.TableAlreadyExistsException;
+import org.apache.pinot.controller.api.resources.ddl.DdlExecutionRequest;
+import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
+import org.apache.pinot.controller.helix.core.minion.PinotHelixTaskResourceManager;
+import org.apache.pinot.controller.helix.core.minion.PinotTaskManager;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableTaskConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.CommonConstants.MaterializedViewTask;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.apache.pinot.sql.ddl.compile.CompiledCreateMaterializedView;
+import org.apache.pinot.sql.ddl.compile.DdlCompiler;
+import org.glassfish.grizzly.http.server.Request;
+import org.mockito.ArgumentCaptor;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+
+
+/// Unit tests for the MV-specific paths on [PinotDdlRestletResource].
+///
+/// Covers (a) `CREATE MATERIALIZED VIEW`: authorization, idempotent CREATE,
+/// pre-existing-schema reuse, dry-run, and the schedule-key contract (present iff DDL had
+/// `REFRESH EVERY`); (b) `SHOW CREATE MATERIALIZED VIEW`: happy path, 404, and both halves
+/// of the Q2=B contract (SHOW CREATE TABLE on MV → 400, SHOW CREATE MV on plain table →
+/// 400); (c) `DROP MATERIALIZED VIEW`: happy path, 404 with and without `IF EXISTS`,
+/// both halves of the Q2=B contract (DROP TABLE on MV → 400, DROP MV on plain table →
+/// 400 even under IF EXISTS), dry-run, and the active-task short-circuit; and
+/// (d) `SHOW MATERIALIZED VIEWS`: happy path, empty cluster, FROM-database scoping, and
+/// permission denied.
+///
+/// These tests use mocks rather than a live controller because the real validation chain
+/// pulls in `MaterializedViewTaskGenerator`, which lives in `pinot-minion-builtin-tasks`
+/// and is NOT on the `pinot-controller` test classpath. Mocking
+/// [TableConfigValidationUtils] / [PinotTableRestletResource] / [TableConfigTunerUtils]
+/// lets the tests focus purely on the controller's own logic.
+///
+/// Integration coverage that runs `MaterializedViewAnalyzer.analyze` end-to-end lives
+/// in `pinot-integration-tests` once the MV plugin is on the classpath.
+public class PinotDdlRestletResourceMaterializedViewUnitTest {
+
+  private static final String MATERIALIZED_VIEW_RAW = "mv_orders";
+  private static final String MATERIALIZED_VIEW_WITH_TYPE = MATERIALIZED_VIEW_RAW + "_OFFLINE";
+  private static final String SOURCE = "orders";
+
+  /// Happy path: REFRESH EVERY supplied → schedule key set on persisted TableConfig,
+  /// addSchema + addTable called, 201 CREATED.
+  @Test
+  public void happyPathPersistsTableWithSchedule()
+      throws Exception {
+    PinotDdlRestletResource resource = newResource();
+    when(resource._pinotHelixResourceManager.hasTable(MATERIALIZED_VIEW_WITH_TYPE)).thenReturn(false);
+    when(resource._pinotHelixResourceManager.getSchema(MATERIALIZED_VIEW_RAW)).thenReturn(null);
+
+    try (QuietValidationMocks ignored = new QuietValidationMocks()) {
+      Response response = resource.executeDdl(
+          new DdlExecutionRequest(buildCreateMaterializedViewSql(true)), false, mockHeaders(),
+          mockRequest());
+
+      assertEquals(response.getStatus(), Response.Status.CREATED.getStatusCode(),
+          "Successful MV CREATE must return 201.");
+      JsonNode body = readBody(response);
+      assertEquals(body.get("operation").asText(), "CREATE_MATERIALIZED_VIEW");
+      assertEquals(body.get("tableName").asText(), MATERIALIZED_VIEW_WITH_TYPE);
+      assertEquals(body.get("tableType").asText(), "OFFLINE");
+      assertNull(body.get("warnings"),
+          "Successful create has no warnings; got " + body);
+      // PR3.5 contract: the response surface must NOT advertise a watermark field — that
+      // concept lives entirely in the scheduler now.
+      assertNull(body.get("watermarkStartMs"),
+          "PR3.5 removed the watermark seed path; response must omit watermarkStartMs.");
+
+      verify(resource._pinotHelixResourceManager).addSchema(any(Schema.class), eq(false), eq(false));
+      ArgumentCaptor<TableConfig> tableCaptor = ArgumentCaptor.forClass(TableConfig.class);
+      verify(resource._pinotHelixResourceManager).addTable(tableCaptor.capture());
+
+      TableTaskConfig taskConfig = tableCaptor.getValue().getTaskConfig();
+      assertTrue(taskConfig.getConfigsForTaskType(MaterializedViewTask.TASK_TYPE)
+              .containsKey(PinotTaskManager.SCHEDULE_KEY),
+          "REFRESH EVERY must surface as a schedule key on the persisted TableConfig; got "
+              + taskConfig.getConfigsForTaskType(MaterializedViewTask.TASK_TYPE));
+    }
+  }
+
+  /// REFRESH-less DDL: persisted TableConfig must NOT contain a `schedule` key, so the
+  /// PinotTaskManager falls back to the cluster-wide MV cron. Without this contract the
+  /// compiler/router would have to invent a default cron, exactly the leaky abstraction
+  /// the optional-REFRESH design is meant to avoid.
+  @Test
+  public void omittingRefreshClausePersistsTableWithoutSchedule()
+      throws Exception {
+    PinotDdlRestletResource resource = newResource();
+    when(resource._pinotHelixResourceManager.hasTable(MATERIALIZED_VIEW_WITH_TYPE)).thenReturn(false);
+    when(resource._pinotHelixResourceManager.getSchema(MATERIALIZED_VIEW_RAW)).thenReturn(null);
+
+    try (QuietValidationMocks ignored = new QuietValidationMocks()) {
+      Response response = resource.executeDdl(
+          new DdlExecutionRequest(buildCreateMaterializedViewSql(false)), false, mockHeaders(),
+          mockRequest());
+
+      assertEquals(response.getStatus(), Response.Status.CREATED.getStatusCode());
+      ArgumentCaptor<TableConfig> tableCaptor = ArgumentCaptor.forClass(TableConfig.class);
+      verify(resource._pinotHelixResourceManager).addTable(tableCaptor.capture());
+
+      assertFalse(tableCaptor.getValue().getTaskConfig()
+              .getConfigsForTaskType(MaterializedViewTask.TASK_TYPE)
+              .containsKey(PinotTaskManager.SCHEDULE_KEY),
+          "Without REFRESH the persisted TableConfig must NOT contain a schedule key — "
+              + "PinotTaskManager.getTaskToCronExpressionMap relies on key-absence to "
+              + "fall back to the cluster-wide MV cron.");
+    }
+  }
+
+  /// Dry-run must validate but never call `addTable` or `addSchema`. This regression-pins the
+  /// contract that a dry-run can be safely re-issued in CI.
+  @Test
+  public void dryRunValidatesButNeverPersists()
+      throws Exception {
+    PinotDdlRestletResource resource = newResource();
+    when(resource._pinotHelixResourceManager.hasTable(MATERIALIZED_VIEW_WITH_TYPE)).thenReturn(false);
+    when(resource._pinotHelixResourceManager.getSchema(MATERIALIZED_VIEW_RAW)).thenReturn(null);
+
+    try (QuietValidationMocks ignored = new QuietValidationMocks()) {
+      Response response = resource.executeDdl(
+          new DdlExecutionRequest(buildCreateMaterializedViewSql(true)), true, mockHeaders(),
+          mockRequest());
+
+      assertEquals(response.getStatus(), Response.Status.OK.getStatusCode(),
+          "Dry-run must return 200 (no resource was created).");
+      JsonNode body = readBody(response);
+      assertTrue(body.get("dryRun").asBoolean(),
+          "Response must echo dryRun=true so the caller can distinguish from a live CREATE.");
+      verify(resource._pinotHelixResourceManager, never()).addSchema(any(), any(Boolean.class), any(Boolean.class));
+      verify(resource._pinotHelixResourceManager, never()).addTable(any(TableConfig.class));
+    }
+  }
+
+  /// IF NOT EXISTS + table already present AS A MATERIALIZED VIEW → 200 no-op (matches
+  /// SQL-standard semantics). Without this, idempotent deployment scripts break on the second
+  /// pass. The preflight is type-aware: we seed an MV-shaped TableConfig (not just a hasTable
+  /// stub) because the rewritten Q2=B preflight reads `getTableConfig` first and dispatches by
+  /// `isMaterializedView`. The plain-table-at-same-name case is covered by the symmetric
+  /// `createMvIfNotExistsOnExistingPlainOfflineTableReturns400` test below.
+  @Test
+  public void ifNotExistsIsNoOpWhenTableAlreadyExists()
+      throws Exception {
+    PinotDdlRestletResource resource = newResource();
+    seedStoredMaterializedView(resource);
+
+    try (QuietValidationMocks ignored = new QuietValidationMocks()) {
+      Response response = resource.executeDdl(
+          new DdlExecutionRequest(
+              "CREATE MATERIALIZED VIEW IF NOT EXISTS " + commonMaterializedViewBody(true)),
+          false, mockHeaders(), mockRequest());
+
+      assertEquals(response.getStatus(), Response.Status.OK.getStatusCode(),
+          "IF NOT EXISTS on an existing MV must be a successful no-op (200).");
+      JsonNode body = readBody(response);
+      assertTrue(body.get("message").asText().toLowerCase().contains("already exists"),
+          "Message must communicate idempotent no-op; got " + body.get("message"));
+      verify(resource._pinotHelixResourceManager, never()).addTable(any(TableConfig.class));
+    }
+  }
+
+  /// IF NOT EXISTS no-op response shape: the `tableConfig` and `schema` fields must echo
+  /// what is *persisted* in ZK, not what the client submitted. Without this contract an
+  /// operator running an idempotent deployment script who has since drifted the local DDL
+  /// body sees their drifted body echoed back with HTTP 200 and incorrectly concludes the
+  /// drift was applied — the actual persisted MV has not changed. The seeded MV is
+  /// compiled from `REFRESH EVERY '1d'`; the client re-submission below uses
+  /// `REFRESH EVERY '6h'`, so reading `task.taskTypeConfigsMap.MaterializedViewTask.schedule`
+  /// off the response disambiguates persisted vs. client-attempted unambiguously.
+  @Test
+  public void ifNotExistsNoOpEchoesPersistedConfigNotClientAttempted()
+      throws Exception {
+    PinotDdlRestletResource resource = newResource();
+    seedStoredMaterializedView(resource);
+
+    TableConfig persisted = resource._pinotHelixResourceManager
+        .getTableConfig(MATERIALIZED_VIEW_WITH_TYPE);
+    String persistedCron = persisted.getTaskConfig()
+        .getConfigsForTaskType(MaterializedViewTask.TASK_TYPE)
+        .get(PinotTaskManager.SCHEDULE_KEY);
+
+    try (QuietValidationMocks ignored = new QuietValidationMocks()) {
+      String driftedBody = "CREATE MATERIALIZED VIEW IF NOT EXISTS " + MATERIALIZED_VIEW_RAW + " ("
+          + "  ts TIMESTAMP DATETIME FORMAT '1:MILLISECONDS:TIMESTAMP' GRANULARITY '1:MILLISECONDS',"
+          + "  city STRING DIMENSION,"
+          + "  cnt LONG METRIC"
+          + ") REFRESH EVERY '6h' "
+          + "PROPERTIES ('timeColumnName' = 'ts', 'bucketTimePeriod' = '1d', 'replication' = '1') "
+          + "AS SELECT ts, city, count(*) AS cnt FROM " + SOURCE + " GROUP BY ts, city";
+
+      Response response = resource.executeDdl(new DdlExecutionRequest(driftedBody),
+          false, mockHeaders(), mockRequest());
+
+      assertEquals(response.getStatus(), Response.Status.OK.getStatusCode());
+      JsonNode body = readBody(response);
+      JsonNode echoedSchedule = body.path("tableConfig").path("task").path("taskTypeConfigsMap")
+          .path(MaterializedViewTask.TASK_TYPE).path(PinotTaskManager.SCHEDULE_KEY);
+      assertFalse(echoedSchedule.isMissingNode(),
+          "Response.tableConfig must carry the persisted task config; got " + body.get("tableConfig"));
+      assertEquals(echoedSchedule.asText(), persistedCron,
+          "No-op response must echo the persisted schedule, not the client-attempted one. "
+              + "Persisted=" + persistedCron + ", got=" + echoedSchedule.asText());
+      // The persisted schema name must also be present, not the (potentially drifted)
+      // client-attempted one. The seeder stubs `getSchema(MATERIALIZED_VIEW_RAW)` to the
+      // persisted instance, so the schemaName field is a sufficient marker.
+      assertEquals(body.path("schema").path("schemaName").asText(), MATERIALIZED_VIEW_RAW,
+          "Response.schema must echo the persisted schema; got " + body.get("schema"));
+    }
+  }
+
+  /// Without IF NOT EXISTS a duplicate CREATE MATERIALIZED VIEW against an existing MV must
+  /// surface as 409 Conflict — silent overwrite would hide a real operator mistake (drift
+  /// between two checked-in CREATE scripts). The plain-table-at-same-name case is a 400 (type
+  /// mismatch, not idempotency) and is covered separately by
+  /// `createMvWithoutIfNotExistsOnExistingPlainOfflineTableReturns400`.
+  @Test
+  public void duplicateCreateWithoutIfNotExistsReturns409() {
+    PinotDdlRestletResource resource = newResource();
+    seedStoredMaterializedView(resource);
+
+    try (QuietValidationMocks ignored = new QuietValidationMocks()) {
+      ControllerApplicationException e = expectThrows(ControllerApplicationException.class,
+          () -> resource.executeDdl(new DdlExecutionRequest(buildCreateMaterializedViewSql(true)),
+              false, mockHeaders(), mockRequest()));
+      assertEquals(e.getResponse().getStatus(), Response.Status.CONFLICT.getStatusCode(),
+          "Duplicate CREATE without IF NOT EXISTS must be 409.");
+      assertTrue(e.getMessage().contains("already exists"), e.getMessage());
+    }
+  }
+
+  /// Q2=B mirror on the CREATE side: a plain OFFLINE table at the same name as the MV must
+  /// 400 even under IF NOT EXISTS. IF NOT EXISTS suppresses "object not found at the
+  /// requested type", not "wrong DDL verb for the conflicting object" — the same policy that
+  /// keeps `DROP MATERIALIZED VIEW IF EXISTS` from silently leaving a plain table in place.
+  /// Without this guard the preflight would fall through to the legacy `hasTable` check and
+  /// either silently no-op (under IF NOT EXISTS) or report a generic 409 "already exists"
+  /// that does not name the actual blocker.
+  @Test
+  public void createMvIfNotExistsOnExistingPlainOfflineTableReturns400()
+      throws Exception {
+    PinotDdlRestletResource resource = newResource();
+    TableConfig plainTable = new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName(MATERIALIZED_VIEW_WITH_TYPE)
+        .build();
+    when(resource._pinotHelixResourceManager.getTableConfig(MATERIALIZED_VIEW_WITH_TYPE))
+        .thenReturn(plainTable);
+
+    try (QuietValidationMocks ignored = new QuietValidationMocks()) {
+      ControllerApplicationException e = expectThrows(ControllerApplicationException.class,
+          () -> resource.executeDdl(
+              new DdlExecutionRequest(
+                  "CREATE MATERIALIZED VIEW IF NOT EXISTS " + commonMaterializedViewBody(true)),
+              false, mockHeaders(), mockRequest()));
+
+      assertEquals(e.getResponse().getStatus(), Response.Status.BAD_REQUEST.getStatusCode(),
+          "Type-mismatched target must 400 even under IF NOT EXISTS — IF NOT EXISTS handles "
+              + "absence, not type confusion.");
+      assertTrue(e.getMessage().contains("plain OFFLINE table"), e.getMessage());
+      assertTrue(e.getMessage().contains("pick a different name")
+              && e.getMessage().contains("drop the existing table"),
+          "Error must surface both actionable resolutions; got: " + e.getMessage());
+      verify(resource._pinotHelixResourceManager, never()).addTable(any(TableConfig.class));
+    }
+  }
+
+  /// Q2=B mirror on the CREATE side, without IF NOT EXISTS: same 400 outcome, distinct from
+  /// the 409 we return when the existing object is itself an MV. The two contrasting tests
+  /// pin the contract that the response code maps to the kind of conflict (type mismatch =
+  /// 400, same-kind duplicate = 409), not to whether IF NOT EXISTS was present.
+  @Test
+  public void createMvWithoutIfNotExistsOnExistingPlainOfflineTableReturns400()
+      throws Exception {
+    PinotDdlRestletResource resource = newResource();
+    TableConfig plainTable = new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName(MATERIALIZED_VIEW_WITH_TYPE)
+        .build();
+    when(resource._pinotHelixResourceManager.getTableConfig(MATERIALIZED_VIEW_WITH_TYPE))
+        .thenReturn(plainTable);
+
+    try (QuietValidationMocks ignored = new QuietValidationMocks()) {
+      ControllerApplicationException e = expectThrows(ControllerApplicationException.class,
+          () -> resource.executeDdl(new DdlExecutionRequest(buildCreateMaterializedViewSql(true)),
+              false, mockHeaders(), mockRequest()));
+
+      assertEquals(e.getResponse().getStatus(), Response.Status.BAD_REQUEST.getStatusCode(),
+          "Plain-table collision is a type mismatch (400), not a same-kind duplicate (409).");
+      assertTrue(e.getMessage().contains("plain OFFLINE table"), e.getMessage());
+      verify(resource._pinotHelixResourceManager, never()).addTable(any(TableConfig.class));
+    }
+  }
+
+  /// Raw-name exclusivity: an MV cannot squat on a name whose REALTIME half is already taken
+  /// by a base table. Without this guard an MV CREATE at `foo` while `foo_REALTIME` exists
+  /// would succeed, producing a hybrid pair whose OFFLINE half is a materialized view — a
+  /// state with no defined semantics in the broker rewrite, minion task generator, or
+  /// consistency manager. The check runs even when the OFFLINE znode is empty.
+  @Test
+  public void createMvWhenRealtimeTableExistsReturns400()
+      throws Exception {
+    PinotDdlRestletResource resource = newResource();
+    String realtimeNameWithType = MATERIALIZED_VIEW_RAW + "_REALTIME";
+    when(resource._pinotHelixResourceManager.getTableConfig(MATERIALIZED_VIEW_WITH_TYPE))
+        .thenReturn(null);
+    when(resource._pinotHelixResourceManager.hasTable(realtimeNameWithType)).thenReturn(true);
+
+    try (QuietValidationMocks ignored = new QuietValidationMocks()) {
+      ControllerApplicationException e = expectThrows(ControllerApplicationException.class,
+          () -> resource.executeDdl(new DdlExecutionRequest(buildCreateMaterializedViewSql(true)),
+              false, mockHeaders(), mockRequest()));
+
+      assertEquals(e.getResponse().getStatus(), Response.Status.BAD_REQUEST.getStatusCode(),
+          "Raw-name collision with a REALTIME base table must 400.");
+      assertTrue(e.getMessage().contains("REALTIME table"), e.getMessage());
+      assertTrue(e.getMessage().contains("pick a different name")
+              && e.getMessage().contains("drop the existing REALTIME table"),
+          "Error must surface both actionable resolutions; got: " + e.getMessage());
+      verify(resource._pinotHelixResourceManager, never()).addTable(any(TableConfig.class));
+    }
+  }
+
+  /// A schema left behind from a prior failed CREATE with the SAME column shape must be
+  /// reused (no addSchema attempt), and addTable must still be invoked. Without this, a
+  /// retry after a partial failure would always 409 on the schema name.
+  @Test
+  public void preExistingMatchingSchemaIsReused()
+      throws Exception {
+    PinotDdlRestletResource resource = newResource();
+    when(resource._pinotHelixResourceManager.hasTable(MATERIALIZED_VIEW_WITH_TYPE)).thenReturn(false);
+    Schema storedSchema = buildExpectedMaterializedViewSchema();
+    when(resource._pinotHelixResourceManager.getSchema(MATERIALIZED_VIEW_RAW)).thenReturn(storedSchema);
+
+    try (QuietValidationMocks ignored = new QuietValidationMocks()) {
+      Response response = resource.executeDdl(
+          new DdlExecutionRequest(buildCreateMaterializedViewSql(true)), false, mockHeaders(),
+          mockRequest());
+
+      assertEquals(response.getStatus(), Response.Status.CREATED.getStatusCode());
+      verify(resource._pinotHelixResourceManager, never())
+          .addSchema(any(Schema.class), any(Boolean.class), any(Boolean.class));
+      verify(resource._pinotHelixResourceManager).addTable(any(TableConfig.class));
+    }
+  }
+
+  /// A schema left behind with a DIFFERENT column shape must 409 — silently mutating the
+  /// stored schema would change the contract for any other reader.
+  @Test
+  public void preExistingMismatchedSchemaReturns409() {
+    PinotDdlRestletResource resource = newResource();
+    when(resource._pinotHelixResourceManager.hasTable(MATERIALIZED_VIEW_WITH_TYPE)).thenReturn(false);
+    Schema mismatchedSchema = new Schema.SchemaBuilder()
+        .setSchemaName(MATERIALIZED_VIEW_RAW)
+        .addSingleValueDimension("unexpected_column", FieldSpec.DataType.STRING)
+        .build();
+    when(resource._pinotHelixResourceManager.getSchema(MATERIALIZED_VIEW_RAW))
+        .thenReturn(mismatchedSchema);
+
+    try (QuietValidationMocks ignored = new QuietValidationMocks()) {
+      ControllerApplicationException e = expectThrows(ControllerApplicationException.class,
+          () -> resource.executeDdl(new DdlExecutionRequest(buildCreateMaterializedViewSql(true)),
+              false, mockHeaders(), mockRequest()));
+      assertEquals(e.getResponse().getStatus(), Response.Status.CONFLICT.getStatusCode());
+      assertTrue(e.getMessage().contains("Schema") && e.getMessage().contains("does not match"),
+          "Mismatch error must call out the schema and the diff; got " + e.getMessage());
+    }
+  }
+
+  /// Race-catch path: `addTable` throws `TableAlreadyExistsException` but the raced winner
+  /// is a plain OFFLINE table (not an MV). IF NOT EXISTS must NOT silently report success —
+  /// it suppresses "already exists at this type", not "wrong type collided with us". The
+  /// caller should see a 409 so a follow-up retry hits the preflight (which 400s with a
+  /// detailed plain-table message).
+  @Test
+  public void tableRaceIfNotExistsAgainstPlainOfflineReturns409()
+      throws Exception {
+    PinotDdlRestletResource resource = newResource();
+    // Preflight returns null (no MV yet), so we enter the addTable path; addTable races and
+    // throws; the race-recovery getTableConfig call sees the plain OFFLINE winner.
+    TableConfig plainTable = new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName(MATERIALIZED_VIEW_WITH_TYPE)
+        .build();
+    when(resource._pinotHelixResourceManager.getTableConfig(MATERIALIZED_VIEW_WITH_TYPE))
+        .thenReturn(null)
+        .thenReturn(plainTable);
+    when(resource._pinotHelixResourceManager.hasTable(MATERIALIZED_VIEW_WITH_TYPE)).thenReturn(false);
+    when(resource._pinotHelixResourceManager.getSchema(MATERIALIZED_VIEW_RAW)).thenReturn(null);
+    Mockito.doThrow(new TableAlreadyExistsException("race"))
+        .when(resource._pinotHelixResourceManager).addTable(any(TableConfig.class));
+
+    try (QuietValidationMocks ignored = new QuietValidationMocks()) {
+      ControllerApplicationException e = expectThrows(ControllerApplicationException.class,
+          () -> resource.executeDdl(
+              new DdlExecutionRequest(
+                  "CREATE MATERIALIZED VIEW IF NOT EXISTS " + commonMaterializedViewBody(true)),
+              false, mockHeaders(), mockRequest()));
+      assertEquals(e.getResponse().getStatus(), Response.Status.CONFLICT.getStatusCode(),
+          "IF NOT EXISTS must NOT collapse a plain-table type mismatch in the race-catch path "
+              + "into a silent 200 — only same-kind (MV) duplicates are no-ops.");
+    }
+  }
+
+  /// `addTable` losing a CREATE race must surface as 409 (not 500). The caller can then
+  /// retry IF NOT EXISTS or accept that someone else won the race.
+  @Test
+  public void tableRaceWithoutIfNotExistsReturns409()
+      throws Exception {
+    PinotDdlRestletResource resource = newResource();
+    when(resource._pinotHelixResourceManager.hasTable(MATERIALIZED_VIEW_WITH_TYPE)).thenReturn(false);
+    when(resource._pinotHelixResourceManager.getSchema(MATERIALIZED_VIEW_RAW)).thenReturn(null);
+    Mockito.doThrow(new TableAlreadyExistsException("race"))
+        .when(resource._pinotHelixResourceManager).addTable(any(TableConfig.class));
+
+    try (QuietValidationMocks ignored = new QuietValidationMocks()) {
+      ControllerApplicationException e = expectThrows(ControllerApplicationException.class,
+          () -> resource.executeDdl(new DdlExecutionRequest(buildCreateMaterializedViewSql(true)),
+              false, mockHeaders(), mockRequest()));
+      assertEquals(e.getResponse().getStatus(), Response.Status.CONFLICT.getStatusCode(),
+          "TableAlreadyExistsException without IF NOT EXISTS must surface as 409.");
+    }
+  }
+
+  /// A schema-create race recoverable via the retry path: the racing schema matches, so the
+  /// retry should validate-then-addTable and ultimately succeed with 201. Without this, an
+  /// otherwise-compatible CREATE would always lose to a concurrent winner.
+  @Test
+  public void schemaRaceWithMatchingRacedSchemaRecoversTo201()
+      throws Exception {
+    PinotDdlRestletResource resource = newResource();
+    when(resource._pinotHelixResourceManager.hasTable(MATERIALIZED_VIEW_WITH_TYPE)).thenReturn(false);
+    // First lookup: nothing stored (so addSchema runs and races). Second lookup (recovery
+    // path): the racing writer's schema, which matches the DDL.
+    when(resource._pinotHelixResourceManager.getSchema(MATERIALIZED_VIEW_RAW))
+        .thenReturn(null)
+        .thenReturn(buildExpectedMaterializedViewSchema());
+    Mockito.doThrow(new SchemaAlreadyExistsException("racing"))
+        .when(resource._pinotHelixResourceManager).addSchema(any(Schema.class), eq(false), eq(false));
+
+    try (QuietValidationMocks ignored = new QuietValidationMocks()) {
+      Response response = resource.executeDdl(
+          new DdlExecutionRequest(buildCreateMaterializedViewSql(true)), false, mockHeaders(),
+          mockRequest());
+
+      assertEquals(response.getStatus(), Response.Status.CREATED.getStatusCode(),
+          "Recovery path must succeed when the raced schema is compatible.");
+      // Both addSchema (which threw) and the recovery's addTable must have been attempted.
+      verify(resource._pinotHelixResourceManager, times(1))
+          .addSchema(any(Schema.class), eq(false), eq(false));
+      verify(resource._pinotHelixResourceManager, times(1)).addTable(any(TableConfig.class));
+    }
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // SHOW CREATE MATERIALIZED VIEW
+  //
+  // These tests exercise the controller's `executeShowCreateMaterializedView` path plus the
+  // Q2=B contract enforcement on the regular `executeShowCreate` path (an MV must always be
+  // inspected via its dedicated SHOW form, never via SHOW CREATE TABLE — and the inverse).
+  //
+  // TableConfig + Schema fixtures are built by compiling a real `CREATE MATERIALIZED VIEW`
+  // DDL. Mocking them by hand would either drift from what the compiler actually persists or
+  // would silently bypass the canonical `TableConfig#isMaterializedView` flag (PR #18564) the
+  // Q2=B dispatch reads, defeating the point of the Q2=B test.
+  // -------------------------------------------------------------------------------------------
+
+  @Test
+  public void showCreateMaterializedViewHappyPath() {
+    PinotDdlRestletResource resource = newResource();
+    seedStoredMaterializedView(resource);
+
+    Response response = resource.executeDdl(
+        new DdlExecutionRequest("SHOW CREATE MATERIALIZED VIEW " + MATERIALIZED_VIEW_RAW),
+        false, mockHeaders(), mockRequest());
+
+    assertEquals(response.getStatus(), Response.Status.OK.getStatusCode());
+    JsonNode body = readBody(response);
+    assertEquals(body.get("operation").asText(), "SHOW_CREATE_MATERIALIZED_VIEW");
+    assertEquals(body.get("tableName").asText(), MATERIALIZED_VIEW_WITH_TYPE);
+    assertEquals(body.get("tableType").asText(), "OFFLINE",
+        "SHOW CREATE MATERIALIZED VIEW must always advertise OFFLINE (MVs have no realtime form).");
+    String ddl = body.get("ddl").asText();
+    assertTrue(ddl.startsWith("CREATE MATERIALIZED VIEW "),
+        "Emitted DDL must lead with the MV header so a copy-paste reproduces the right shape; got:\n"
+            + ddl);
+    assertTrue(ddl.contains("AS SELECT"),
+        "MV DDL must carry the AS <query> clause; got:\n" + ddl);
+  }
+
+  /// Without a stored table the endpoint must 404 — and the message must name the MV-specific
+  /// form rather than the generic "Table not found" so tooling can distinguish missing-MV
+  /// from missing-table errors when both DDLs run side by side.
+  @Test
+  public void showCreateMaterializedViewNotFoundReturns404() {
+    PinotDdlRestletResource resource = newResource();
+    when(resource._pinotHelixResourceManager.hasTable(MATERIALIZED_VIEW_WITH_TYPE)).thenReturn(false);
+
+    ControllerApplicationException e = expectThrows(ControllerApplicationException.class,
+        () -> resource.executeDdl(
+            new DdlExecutionRequest("SHOW CREATE MATERIALIZED VIEW " + MATERIALIZED_VIEW_RAW),
+            false, mockHeaders(), mockRequest()));
+
+    assertEquals(e.getResponse().getStatus(), Response.Status.NOT_FOUND.getStatusCode());
+    assertTrue(e.getMessage().toLowerCase().contains("materialized view"),
+        "404 must name the MV-specific form so callers see which DDL endpoint missed; got: "
+            + e.getMessage());
+  }
+
+  /// Q2=B mirror: handing the MV-specific form a plain OFFLINE table must 400 and point the
+  /// caller at SHOW CREATE TABLE. Silently emitting `CREATE TABLE` would mislead any tooling
+  /// that compares response DDL headers against the request shape.
+  @Test
+  public void showCreateMaterializedViewOnPlainTableReturns400() {
+    PinotDdlRestletResource resource = newResource();
+    TableConfig plainTable = new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName(MATERIALIZED_VIEW_WITH_TYPE)
+        .build();
+    Schema plainSchema = new Schema.SchemaBuilder()
+        .setSchemaName(MATERIALIZED_VIEW_RAW)
+        .addSingleValueDimension("id", FieldSpec.DataType.INT)
+        .build();
+    when(resource._pinotHelixResourceManager.hasTable(MATERIALIZED_VIEW_WITH_TYPE)).thenReturn(true);
+    when(resource._pinotHelixResourceManager.getTableConfig(MATERIALIZED_VIEW_WITH_TYPE))
+        .thenReturn(plainTable);
+    when(resource._pinotHelixResourceManager.getTableSchema(MATERIALIZED_VIEW_WITH_TYPE))
+        .thenReturn(plainSchema);
+
+    ControllerApplicationException e = expectThrows(ControllerApplicationException.class,
+        () -> resource.executeDdl(
+            new DdlExecutionRequest("SHOW CREATE MATERIALIZED VIEW " + MATERIALIZED_VIEW_RAW),
+            false, mockHeaders(), mockRequest()));
+
+    assertEquals(e.getResponse().getStatus(), Response.Status.BAD_REQUEST.getStatusCode());
+    assertTrue(e.getMessage().contains("not a materialized view"), e.getMessage());
+    assertTrue(e.getMessage().contains("SHOW CREATE TABLE"),
+        "Error must redirect the caller to the correct DDL form; got: " + e.getMessage());
+  }
+
+  /// Q2=B primary: handing the regular SHOW CREATE TABLE form an MV table must 400 and point
+  /// the caller at SHOW CREATE MATERIALIZED VIEW. This is the bug the contract closes —
+  /// without the check, the emitter's dispatch would happily render `CREATE MATERIALIZED VIEW`
+  /// even though the caller asked for `SHOW CREATE TABLE`, and the response DDL header would
+  /// no longer match the request shape.
+  @Test
+  public void showCreateTableOnMaterializedViewReturns400() {
+    PinotDdlRestletResource resource = newResource();
+    seedStoredMaterializedView(resource);
+
+    ControllerApplicationException e = expectThrows(ControllerApplicationException.class,
+        () -> resource.executeDdl(
+            new DdlExecutionRequest(
+                "SHOW CREATE TABLE " + MATERIALIZED_VIEW_RAW + " TYPE OFFLINE"),
+            false, mockHeaders(), mockRequest()));
+
+    assertEquals(e.getResponse().getStatus(), Response.Status.BAD_REQUEST.getStatusCode());
+    assertTrue(e.getMessage().contains("materialized view"),
+        "Error must call out that the table is an MV; got: " + e.getMessage());
+    assertTrue(e.getMessage().contains("SHOW CREATE MATERIALIZED VIEW"),
+        "Error must redirect the caller to the MV-specific form; got: " + e.getMessage());
+  }
+
+  // NOTE: The "corrupted MV" preflight (MaterializedViewTask block present but definedSQL
+  // missing) is no longer reachable for any persisted config. PR #18564 added the SPI invariant
+  // `TableConfigUtils.validateMaterializedViewInvariants` which rejects this shape at addTable /
+  // updateTable time. Identity is now decided by the canonical `TableConfig#isMaterializedView`
+  // flag, so anything that fails the SHOW CREATE MATERIALIZED VIEW dispatch is just a plain
+  // table — exercised by `showCreateMaterializedViewOnPlainTableReturns400` above.
+
+  // -------------------------------------------------------------------------------------------
+  // DROP MATERIALIZED VIEW
+  //
+  // These tests exercise `executeDropMaterializedView` plus the Q2=B contract enforcement on
+  // the regular `executeDrop` path. The underlying `PinotHelixResourceManager#deleteTable`
+  // call is the same code the legacy `DELETE /materializedViews/{name}` REST endpoint uses,
+  // so znode cleanup is verified at that layer; here we pin the controller's own contract
+  // (dispatch, authorization, IF EXISTS, Q2=B partitioning, active-task guard).
+  // -------------------------------------------------------------------------------------------
+
+  /// Happy path: real MV → 200, `deleteTable(rawName, OFFLINE, null)` invoked exactly once.
+  /// We don't double-assert znode cleanup here because that lives inside `deleteTable`; this
+  /// test instead pins the wiring from `executeDropMaterializedView` to the underlying call
+  /// (the same call the legacy DELETE endpoint makes).
+  @Test
+  public void dropMaterializedViewHappyPath()
+      throws Exception {
+    PinotDdlRestletResource resource = newResource();
+    seedStoredMaterializedView(resource);
+    quietActiveTaskScan(resource);
+
+    try (MockedStatic<ZKMetadataProvider> ignored = stubNoLogicalTableConfigs()) {
+      Response response = resource.executeDdl(
+          new DdlExecutionRequest("DROP MATERIALIZED VIEW " + MATERIALIZED_VIEW_RAW),
+          false, mockHeaders(), mockRequest());
+
+      assertEquals(response.getStatus(), Response.Status.OK.getStatusCode());
+      JsonNode body = readBody(response);
+      assertEquals(body.get("operation").asText(), "DROP_MATERIALIZED_VIEW");
+      assertEquals(body.get("tableName").asText(), MATERIALIZED_VIEW_WITH_TYPE);
+      assertEquals(body.get("tableType").asText(), "OFFLINE",
+          "DROP MATERIALIZED VIEW must always advertise OFFLINE.");
+      // Delegate target: deleteTable(rawName, OFFLINE, null). The raw name (not the typed one)
+      // is required so PinotHelixResourceManager.deleteTable re-derives the typed form via
+      // TableNameBuilder; we explicitly check that signature so a refactor to pass the typed
+      // name fails the test.
+      verify(resource._pinotHelixResourceManager, times(1))
+          .deleteTable(MATERIALIZED_VIEW_RAW, TableType.OFFLINE, null);
+    }
+  }
+
+  /// Missing MV without IF EXISTS → 404, no delete call.
+  @Test
+  public void dropMaterializedViewMissingWithoutIfExistsReturns404()
+      throws Exception {
+    PinotDdlRestletResource resource = newResource();
+    when(resource._pinotHelixResourceManager.hasTable(MATERIALIZED_VIEW_WITH_TYPE)).thenReturn(false);
+    when(resource._pinotHelixResourceManager.getTableConfig(MATERIALIZED_VIEW_WITH_TYPE)).thenReturn(null);
+
+    ControllerApplicationException e = expectThrows(ControllerApplicationException.class,
+        () -> resource.executeDdl(
+            new DdlExecutionRequest("DROP MATERIALIZED VIEW " + MATERIALIZED_VIEW_RAW),
+            false, mockHeaders(), mockRequest()));
+
+    assertEquals(e.getResponse().getStatus(), Response.Status.NOT_FOUND.getStatusCode());
+    assertTrue(e.getMessage().toLowerCase().contains("materialized view"),
+        "404 must name the MV-specific form so callers see which DDL endpoint missed; got: "
+            + e.getMessage());
+    verify(resource._pinotHelixResourceManager, never())
+        .deleteTable(anyString(), any(TableType.class), any());
+  }
+
+  /// Missing MV WITH IF EXISTS → 200 no-op, no delete call.
+  @Test
+  public void dropMaterializedViewMissingWithIfExistsIsNoOp()
+      throws Exception {
+    PinotDdlRestletResource resource = newResource();
+    when(resource._pinotHelixResourceManager.hasTable(MATERIALIZED_VIEW_WITH_TYPE)).thenReturn(false);
+    when(resource._pinotHelixResourceManager.getTableConfig(MATERIALIZED_VIEW_WITH_TYPE)).thenReturn(null);
+
+    Response response = resource.executeDdl(
+        new DdlExecutionRequest("DROP MATERIALIZED VIEW IF EXISTS " + MATERIALIZED_VIEW_RAW),
+        false, mockHeaders(), mockRequest());
+
+    assertEquals(response.getStatus(), Response.Status.OK.getStatusCode(),
+        "IF EXISTS on a missing MV must be a successful no-op (200) — matches the SQL-standard "
+            + "DROP TABLE IF EXISTS contract.");
+    JsonNode body = readBody(response);
+    assertTrue(body.get("ifExists").asBoolean(),
+        "Response must echo ifExists=true so the caller can distinguish from a real delete.");
+    assertTrue(body.get("message").asText().toLowerCase().contains("if exists satisfied"),
+        "Message must communicate idempotent no-op; got: " + body.get("message"));
+    verify(resource._pinotHelixResourceManager, never())
+        .deleteTable(anyString(), any(TableType.class), any());
+  }
+
+  /// Q2=B mirror: DROP MATERIALIZED VIEW handed a plain OFFLINE table must 400 — even under
+  /// IF EXISTS. The opposite policy (silently treat a type-mismatched target as "absent")
+  /// would let `DROP MATERIALIZED VIEW IF EXISTS foo` silently leave a real OFFLINE table
+  /// named foo in place, surprising any operator whose script assumed the IF EXISTS clause
+  /// converted "wrong kind of object" into "already gone". 400 forces them to inspect.
+  @Test
+  public void dropMaterializedViewOnPlainTableReturns400EvenUnderIfExists() {
+    PinotDdlRestletResource resource = newResource();
+    TableConfig plainTable = new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName(MATERIALIZED_VIEW_WITH_TYPE)
+        .build();
+    when(resource._pinotHelixResourceManager.hasTable(MATERIALIZED_VIEW_WITH_TYPE)).thenReturn(true);
+    when(resource._pinotHelixResourceManager.getTableConfig(MATERIALIZED_VIEW_WITH_TYPE))
+        .thenReturn(plainTable);
+
+    ControllerApplicationException e = expectThrows(ControllerApplicationException.class,
+        () -> resource.executeDdl(
+            new DdlExecutionRequest(
+                "DROP MATERIALIZED VIEW IF EXISTS " + MATERIALIZED_VIEW_RAW),
+            false, mockHeaders(), mockRequest()));
+
+    assertEquals(e.getResponse().getStatus(), Response.Status.BAD_REQUEST.getStatusCode(),
+        "Type-mismatched target must 400 even under IF EXISTS — IF EXISTS handles absence, "
+            + "not type confusion.");
+    assertTrue(e.getMessage().contains("not a materialized view"), e.getMessage());
+    assertTrue(e.getMessage().contains("DROP TABLE"),
+        "Error must redirect to the correct DROP form; got: " + e.getMessage());
+  }
+
+  /// Q2=B primary: DROP TABLE on an MV table must 400 with a pointer at DROP MATERIALIZED
+  /// VIEW. This closes the symmetry gap with SHOW CREATE TABLE / SHOW CREATE MATERIALIZED
+  /// VIEW — all three DDL verbs (CREATE/DROP/SHOW CREATE) now strictly partition table vs
+  /// MV at the REST boundary.
+  @Test
+  public void dropTableOnMaterializedViewReturns400() {
+    PinotDdlRestletResource resource = newResource();
+    seedStoredMaterializedView(resource);
+
+    ControllerApplicationException e = expectThrows(ControllerApplicationException.class,
+        () -> resource.executeDdl(
+            new DdlExecutionRequest("DROP TABLE " + MATERIALIZED_VIEW_RAW + " TYPE OFFLINE"),
+            false, mockHeaders(), mockRequest()));
+
+    assertEquals(e.getResponse().getStatus(), Response.Status.BAD_REQUEST.getStatusCode());
+    assertTrue(e.getMessage().contains("materialized view"),
+        "Error must call out that the table is an MV; got: " + e.getMessage());
+    assertTrue(e.getMessage().contains("DROP MATERIALIZED VIEW"),
+        "Error must redirect to the MV-specific DROP form; got: " + e.getMessage());
+  }
+
+  /// Dry-run must validate (existence + Q2=B + active-task scan) but never call deleteTable.
+  /// This pins the contract that an MV DROP dry-run can be safely re-issued in CI.
+  @Test
+  public void dropMaterializedViewDryRunNeverDeletes()
+      throws Exception {
+    PinotDdlRestletResource resource = newResource();
+    seedStoredMaterializedView(resource);
+    quietActiveTaskScan(resource);
+
+    try (MockedStatic<ZKMetadataProvider> ignored = stubNoLogicalTableConfigs()) {
+      Response response = resource.executeDdl(
+          new DdlExecutionRequest("DROP MATERIALIZED VIEW " + MATERIALIZED_VIEW_RAW),
+          true, mockHeaders(), mockRequest());
+
+      assertEquals(response.getStatus(), Response.Status.OK.getStatusCode());
+      JsonNode body = readBody(response);
+      assertTrue(body.get("dryRun").asBoolean(),
+          "Response must echo dryRun=true so the caller can distinguish from a live DROP.");
+      assertTrue(body.get("message").asText().toLowerCase().startsWith("dry run"),
+          "Dry-run message must lead with 'Dry run'; got: " + body.get("message"));
+      verify(resource._pinotHelixResourceManager, never())
+          .deleteTable(anyString(), any(TableType.class), any());
+    }
+  }
+
+  /// Active running MV task → 400 with the pending-task list. Without this, an in-flight
+  /// `MaterializedViewTask` would race the drop and orphan the partial output. Mirrors the
+  /// same guard that DROP TABLE applies (and is enforced via the shared
+  /// `assertNoActiveTasksBeforeDrop` helper, which makes this test the regression pin for
+  /// the helper being invoked on the DROP MV path at all).
+  @Test
+  public void dropMaterializedViewBlockedByActiveTaskReturns400() {
+    PinotDdlRestletResource resource = newResource();
+    seedStoredMaterializedView(resource);
+
+    PinotHelixTaskResourceManager.TaskCount runningCount =
+        mock(PinotHelixTaskResourceManager.TaskCount.class);
+    when(runningCount.getRunning()).thenReturn(1);
+    when(resource._pinotHelixTaskResourceManager.getTaskStatesByTable(
+        eq(MaterializedViewTask.TASK_TYPE), eq(MATERIALIZED_VIEW_WITH_TYPE)))
+        .thenReturn(Map.of("Task_MaterializedViewTask_inflight", TaskState.IN_PROGRESS));
+    when(resource._pinotHelixTaskResourceManager.getTaskCount("Task_MaterializedViewTask_inflight"))
+        .thenReturn(runningCount);
+
+    try (MockedStatic<ZKMetadataProvider> ignored = stubNoLogicalTableConfigs()) {
+      ControllerApplicationException e = expectThrows(ControllerApplicationException.class,
+          () -> resource.executeDdl(
+              new DdlExecutionRequest("DROP MATERIALIZED VIEW " + MATERIALIZED_VIEW_RAW),
+              false, mockHeaders(), mockRequest()));
+
+      assertEquals(e.getResponse().getStatus(), Response.Status.BAD_REQUEST.getStatusCode());
+      assertTrue(e.getMessage().contains("active running tasks"),
+          "Error must call out the active-task block; got: " + e.getMessage());
+      assertTrue(e.getMessage().contains("Task_MaterializedViewTask_inflight"),
+          "Error must name the offending task so the operator can find it; got: "
+              + e.getMessage());
+    }
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // SHOW MATERIALIZED VIEWS
+  //
+  // The controller dispatches SHOW MATERIALIZED VIEWS to
+  // `_pinotHelixResourceManager.getAllRawMaterializedViewNames(scopedDatabase)` and returns
+  // the result on the shared `tableNames` field with the SHOW_MATERIALIZED_VIEWS operation
+  // discriminator. The helper itself is exercised by
+  // `PinotHelixResourceManagerMaterializedViewListingTest` — these tests pin the controller
+  // contract (operation, scoping, message, auth) without re-asserting the filter logic.
+  // -------------------------------------------------------------------------------------------
+
+  @Test
+  public void showMaterializedViewsHappyPath() {
+    PinotDdlRestletResource resource = newResource();
+    when(resource._pinotHelixResourceManager.getAllRawMaterializedViewNames("default"))
+        .thenReturn(java.util.Arrays.asList("mv_orders", "mv_clicks"));
+
+    Response response = resource.executeDdl(new DdlExecutionRequest("SHOW MATERIALIZED VIEWS"),
+        false, mockHeaders(), mockRequest());
+
+    assertEquals(response.getStatus(), Response.Status.OK.getStatusCode());
+    JsonNode body = readBody(response);
+    assertEquals(body.get("operation").asText(), "SHOW_MATERIALIZED_VIEWS");
+    // The scoped database must default to DEFAULT_DATABASE when neither SQL FROM nor the
+    // Database header supplies one. Asserting on the wire field rather than the constant
+    // because the field is what tooling actually reads.
+    assertEquals(body.get("databaseName").asText(), "default");
+    JsonNode names = body.get("tableNames");
+    assertEquals(names.size(), 2);
+    assertEquals(names.get(0).asText(), "mv_orders");
+    assertEquals(names.get(1).asText(), "mv_clicks");
+    // The message must use the MV-specific wording so an operator reading the response in
+    // logs can tell SHOW MATERIALIZED VIEWS apart from SHOW TABLES at a glance.
+    assertEquals(body.get("message").asText(), "Found 2 materialized view(s).");
+  }
+
+  @Test
+  public void showMaterializedViewsEmptyCluster() {
+    PinotDdlRestletResource resource = newResource();
+    when(resource._pinotHelixResourceManager.getAllRawMaterializedViewNames("default"))
+        .thenReturn(Collections.emptyList());
+
+    Response response = resource.executeDdl(new DdlExecutionRequest("SHOW MATERIALIZED VIEWS"),
+        false, mockHeaders(), mockRequest());
+
+    assertEquals(response.getStatus(), Response.Status.OK.getStatusCode());
+    JsonNode body = readBody(response);
+    assertEquals(body.get("operation").asText(), "SHOW_MATERIALIZED_VIEWS");
+    // The wire field is present even when empty so clients can iterate without a null check.
+    // Asserting `size()==0` rather than the field's absence pins this Jackson behaviour.
+    assertEquals(body.get("tableNames").size(), 0);
+    assertEquals(body.get("message").asText(), "Found 0 materialized view(s).");
+  }
+
+  /// `SHOW MATERIALIZED VIEWS FROM analytics` must propagate the explicit database into the
+  /// helper call. Without this scoping the listing would silently default to the Database
+  /// header (or DEFAULT_DATABASE) and leak MV names from the wrong database.
+  @Test
+  public void showMaterializedViewsExplicitFromDatabaseScopesListing() {
+    PinotDdlRestletResource resource = newResource();
+    when(resource._pinotHelixResourceManager.getAllRawMaterializedViewNames("analytics"))
+        .thenReturn(java.util.Arrays.asList("mv_revenue"));
+
+    Response response = resource.executeDdl(
+        new DdlExecutionRequest("SHOW MATERIALIZED VIEWS FROM analytics"),
+        false, mockHeaders(), mockRequest());
+
+    assertEquals(response.getStatus(), Response.Status.OK.getStatusCode());
+    JsonNode body = readBody(response);
+    assertEquals(body.get("databaseName").asText(), "analytics");
+    assertEquals(body.get("tableNames").get(0).asText(), "mv_revenue");
+    verify(resource._pinotHelixResourceManager).getAllRawMaterializedViewNames("analytics");
+    // Sanity: the default-database listing must NOT have been called — otherwise an explicit
+    // FROM clause would still leak names from the caller's header-scoped database.
+    verify(resource._pinotHelixResourceManager, never()).getAllRawMaterializedViewNames("default");
+  }
+
+  /// A custom AccessControl that denies the cluster-level GET_TABLE check must surface as a
+  /// 403. The MV listing must use the SAME action pair (CLUSTER, GET_TABLE) as SHOW TABLES
+  /// and the existing GET /materializedViews REST endpoint — using a different action would
+  /// fork the listing auth surface for what is the same underlying read.
+  @Test
+  public void showMaterializedViewsPermissionDeniedReturns403() {
+    PinotDdlRestletResource resource = newResource();
+    when(resource._accessControlFactory.create()).thenReturn(new AccessControl() {
+      @Override
+      public boolean hasAccess(javax.ws.rs.core.HttpHeaders headers,
+          org.apache.pinot.core.auth.TargetType targetType, String targetId, String action) {
+        return false;
+      }
+    });
+
+    ControllerApplicationException e = expectThrows(ControllerApplicationException.class,
+        () -> resource.executeDdl(new DdlExecutionRequest("SHOW MATERIALIZED VIEWS"),
+            false, mockHeaders(), mockRequest()));
+
+    assertEquals(e.getResponse().getStatus(), Response.Status.FORBIDDEN.getStatusCode());
+    // The listing must NOT have been invoked when auth fails — otherwise we leak MV names
+    // through the error path or accidentally hit ZK on every denied request.
+    verify(resource._pinotHelixResourceManager, never()).getAllRawMaterializedViewNames(anyString());
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // Helpers
+  // -------------------------------------------------------------------------------------------
+
+  /// Builds a `CREATE MATERIALIZED VIEW` SQL string. When `withRefresh=true` the DDL emits
+  /// `REFRESH EVERY '1d'`; when false the DDL omits the entire REFRESH clause so the test
+  /// can pin the cluster-cron-fallback contract end to end.
+  private static String buildCreateMaterializedViewSql(boolean withRefresh) {
+    return "CREATE MATERIALIZED VIEW " + commonMaterializedViewBody(withRefresh);
+  }
+
+  /// Common MV CREATE body shared by the `CREATE MATERIALIZED VIEW` and `... IF NOT EXISTS`
+  /// variants. Crafted to satisfy the compiler's MV consistency checks (timeColumnName is a
+  /// DATETIME column, bucketTimePeriod is provided).
+  ///
+  /// The AS clause intentionally omits `LIMIT N`: the compiler's `extractDefinedSql` slices
+  /// `originalSql` using `queryNode.getParserPosition()`, which Calcite reports as the
+  /// LIMIT-only span when LIMIT is present at the top level; that quirk is a separate
+  /// compiler-side bug to address later. These tests rely on the analyzer's
+  /// auto-LIMIT-injection path.
+  private static String commonMaterializedViewBody(boolean withRefresh) {
+    String refreshClause = withRefresh ? "REFRESH EVERY '1d' " : "";
+    return MATERIALIZED_VIEW_RAW + " ("
+        + "  ts TIMESTAMP DATETIME FORMAT '1:MILLISECONDS:TIMESTAMP' GRANULARITY '1:MILLISECONDS',"
+        + "  city STRING DIMENSION,"
+        + "  cnt LONG METRIC"
+        + ") "
+        + refreshClause
+        + "PROPERTIES ("
+        + "  'timeColumnName' = 'ts',"
+        + "  'bucketTimePeriod' = '1d',"
+        + "  'replication' = '1'"
+        + ") "
+        + "AS SELECT ts, city, count(*) AS cnt FROM " + SOURCE + " GROUP BY ts, city";
+  }
+
+  /// Builds the schema the compiler will produce for [#commonMaterializedViewBody]. Used by
+  /// the pre-existing-matching-schema and schema-race-recovery tests where the test mocks a
+  /// "stored" schema that must be byte-for-byte compatible with the DDL-compiled one.
+  private static Schema buildExpectedMaterializedViewSchema() {
+    return new Schema.SchemaBuilder()
+        .setSchemaName(MATERIALIZED_VIEW_RAW)
+        .addDateTime("ts", FieldSpec.DataType.TIMESTAMP, "1:MILLISECONDS:TIMESTAMP", "1:MILLISECONDS")
+        .addSingleValueDimension("city", FieldSpec.DataType.STRING)
+        .addMetric("cnt", FieldSpec.DataType.LONG)
+        .build();
+  }
+
+  /// Compiles a real `CREATE MATERIALIZED VIEW` and wires the resulting Schema + TableConfig
+  /// (with the canonical `TableConfig#isMaterializedView` flag set, plus the
+  /// `task.MaterializedViewTask.definedSQL` body the emitter renders) into the resource's
+  /// mocked Helix manager. Mocking the identity directly via Mockito would be equivalent to
+  /// asserting the contract on itself; compiling a real DDL keeps these tests honest if a
+  /// future refactor changes how the compiler stamps a config as an MV.
+  private static void seedStoredMaterializedView(PinotDdlRestletResource resource) {
+    CompiledCreateMaterializedView compiled = (CompiledCreateMaterializedView) DdlCompiler.compile(
+        "CREATE MATERIALIZED VIEW " + commonMaterializedViewBody(true));
+    TableConfig mvConfig = compiled.getTableConfig();
+    // The compiler stores the raw name; the Helix layer always reads/writes the typed name.
+    // Rename in place so getTableConfig(...) and the controller's TableNameBuilder agree.
+    mvConfig.setTableName(MATERIALIZED_VIEW_WITH_TYPE);
+    Schema mvSchema = compiled.getSchema();
+    when(resource._pinotHelixResourceManager.hasTable(MATERIALIZED_VIEW_WITH_TYPE)).thenReturn(true);
+    when(resource._pinotHelixResourceManager.getTableConfig(MATERIALIZED_VIEW_WITH_TYPE))
+        .thenReturn(mvConfig);
+    when(resource._pinotHelixResourceManager.getTableSchema(MATERIALIZED_VIEW_WITH_TYPE))
+        .thenReturn(mvSchema);
+    // CREATE MV IF NOT EXISTS no-op path: the controller re-reads the persisted schema via
+    // `getSchema(rawName)` to echo the actual (not client-attempted) state back. Without
+    // this stub the helper would see null and silently leave the response.schema field as
+    // the client-attempted body, defeating the "echo persisted" contract under test.
+    when(resource._pinotHelixResourceManager.getSchema(MATERIALIZED_VIEW_RAW))
+        .thenReturn(mvSchema);
+  }
+
+  /// Stubs the active-task scan to return no tasks for every task type. This is the default
+  /// shape both `assertNoActiveTasksBeforeDrop` and `cleanupTableTasksBeforeDrop` expect; a
+  /// raw mock would return `null` and NPE inside the helpers, masking the contract under
+  /// test. Tests that want to exercise the active-task short-circuit override the relevant
+  /// stub on a per-test basis after seeding (Mockito's last-stubbing-wins semantics).
+  private static void quietActiveTaskScan(PinotDdlRestletResource resource) {
+    when(resource._pinotHelixTaskResourceManager.getTaskStatesByTable(anyString(), anyString()))
+        .thenReturn(Collections.emptyMap());
+  }
+
+  /// Returns an open [MockedStatic] that stubs
+  /// [ZKMetadataProvider#getAllLogicalTableConfigs] to an empty list. `assertNoLogicalTable\
+  /// References` calls into ZKMetadataProvider directly with the property store from
+  /// `PinotHelixResourceManager#getPropertyStore`; in a unit test the property store is null
+  /// and the call NPEs. Static-mocking the lookup is cheaper than wiring a real `ZkClient`
+  /// stack and keeps these tests focused on controller logic. Callers wrap in
+  /// try-with-resources to scope the override to a single test.
+  private static MockedStatic<ZKMetadataProvider> stubNoLogicalTableConfigs() {
+    MockedStatic<ZKMetadataProvider> stub = Mockito.mockStatic(ZKMetadataProvider.class);
+    stub.when(() -> ZKMetadataProvider.getAllLogicalTableConfigs(any()))
+        .thenReturn(Collections.emptyList());
+    return stub;
+  }
+
+  /// Constructs a [PinotDdlRestletResource] with a permissive access control plugin and
+  /// stub-only dependencies. Tests then layer their own behaviour onto the per-field mocks.
+  private static PinotDdlRestletResource newResource() {
+    PinotDdlRestletResource resource = new PinotDdlRestletResource();
+    resource._pinotHelixResourceManager = mock(PinotHelixResourceManager.class);
+    resource._pinotHelixTaskResourceManager = mock(PinotHelixTaskResourceManager.class);
+    resource._pinotTaskManager = mock(PinotTaskManager.class);
+    resource._controllerConf = mock(ControllerConf.class);
+    resource._accessControlFactory = mock(AccessControlFactory.class);
+    when(resource._accessControlFactory.create()).thenReturn(new AccessControl() {
+    });
+    return resource;
+  }
+
+  /// Builds an HttpHeaders mock that does not advertise a Database header — DDL paths
+  /// then take the `database = null` (default) branch and skip translation conflicts.
+  private static HttpHeaders mockHeaders() {
+    return mock(HttpHeaders.class);
+  }
+
+  private static Request mockRequest() {
+    Request request = mock(Request.class);
+    when(request.getRequestURL()).thenReturn(new StringBuilder("http://localhost/sql/ddl"));
+    return request;
+  }
+
+  private static JsonNode readBody(Response response) {
+    Object entity = response.getEntity();
+    assertTrue(entity instanceof org.apache.pinot.controller.api.resources.ddl.DdlExecutionResponse,
+        "Expected a DdlExecutionResponse entity; got " + (entity == null ? "null" : entity.getClass()));
+    try {
+      return org.apache.pinot.spi.utils.JsonUtils.objectToJsonNode(entity);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /// Holds the three [MockedStatic] handles that quiet the controller's validation chain so
+  /// the executor logic can be tested without `MaterializedViewTaskGenerator` on the
+  /// classpath. Implements [AutoCloseable] so callers can use try-with-resources; close()
+  /// closes each child mock individually and aggregates any failures so a misbehaving Mockito
+  /// session never silently leaks into a sibling test.
+  private static final class QuietValidationMocks implements AutoCloseable {
+    private final MockedStatic<TableConfigValidationUtils> _validation;
+    private final MockedStatic<PinotTableRestletResource> _tableResource;
+    private final MockedStatic<org.apache.pinot.controller.tuner.TableConfigTunerUtils> _tuner;
+
+    private QuietValidationMocks() {
+      MockedStatic<TableConfigValidationUtils> validation = null;
+      MockedStatic<PinotTableRestletResource> tableResource = null;
+      MockedStatic<org.apache.pinot.controller.tuner.TableConfigTunerUtils> tuner = null;
+      try {
+        validation = Mockito.mockStatic(TableConfigValidationUtils.class);
+        validation.when(() -> TableConfigValidationUtils.validateTableConfig(
+            any(), any(), any(), any(), any(), any())).then(invocation -> null);
+
+        tableResource = Mockito.mockStatic(PinotTableRestletResource.class);
+        tableResource.when(() -> PinotTableRestletResource.tableTasksValidation(any(), any()))
+            .then(invocation -> null);
+
+        tuner = Mockito.mockStatic(org.apache.pinot.controller.tuner.TableConfigTunerUtils.class);
+        tuner.when(() -> org.apache.pinot.controller.tuner.TableConfigTunerUtils.applyTunerConfigs(
+            any(), any(), any(), any())).then(invocation -> null);
+
+        _validation = validation;
+        _tableResource = tableResource;
+        _tuner = tuner;
+        // Transfer ownership to fields — the catch block must not close them now.
+        validation = null;
+        tableResource = null;
+        tuner = null;
+      } catch (RuntimeException | Error e) {
+        // Half-built mock session: close anything successfully opened so a follow-up test
+        // does not blow up trying to mock the same static class a second time.
+        closeQuietly(validation, e);
+        closeQuietly(tableResource, e);
+        closeQuietly(tuner, e);
+        throw e;
+      }
+    }
+
+    @Override
+    public void close() {
+      RuntimeException agg = null;
+      agg = closeChained(_validation, agg);
+      agg = closeChained(_tableResource, agg);
+      agg = closeChained(_tuner, agg);
+      if (agg != null) {
+        throw agg;
+      }
+    }
+
+    private static RuntimeException closeChained(MockedStatic<?> mock, RuntimeException carry) {
+      try {
+        mock.close();
+        return carry;
+      } catch (RuntimeException e) {
+        if (carry == null) {
+          return e;
+        }
+        carry.addSuppressed(e);
+        return carry;
+      }
+    }
+
+    private static void closeQuietly(MockedStatic<?> mock, Throwable carry) {
+      if (mock == null) {
+        return;
+      }
+      try {
+        mock.close();
+      } catch (RuntimeException e) {
+        carry.addSuppressed(e);
+      }
+    }
+  }
+}

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/PinotDdlRestletResourceUnitTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/PinotDdlRestletResourceUnitTest.java
@@ -46,6 +46,7 @@ import org.apache.pinot.spi.data.MetricFieldSpec;
 import org.apache.pinot.spi.data.PhysicalTableConfig;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.CommonConstants.MaterializedViewTask;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.glassfish.grizzly.http.server.Request;
 import org.mockito.MockedStatic;
@@ -150,6 +151,126 @@ public class PinotDdlRestletResourceUnitTest {
     verify(resource._pinotHelixResourceManager, never()).deleteTable("events", TableType.OFFLINE, null);
     assertEquals(tableConfig.getTaskConfig().getTaskTypeConfigsMap()
         .get("SegmentRefreshTask").get(PinotTaskManager.SCHEDULE_KEY), "0 0 * * * ?");
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // CREATE TABLE Q2=B preflight (raw-name exclusivity with materialized views)
+  //
+  // These three tests pin the CREATE-TABLE side of the symmetric Q2=B contract that splits
+  // raw-name ownership cleanly between plain tables, REALTIME tables, hybrid pairs, and
+  // materialized views. The MV-side of the symmetric contract is covered in
+  // PinotDdlRestletResourceMaterializedViewUnitTest's `createMv*` family.
+  // -------------------------------------------------------------------------------------------
+
+  /// CREATE TABLE OFFLINE handed a name whose OFFLINE znode is already a materialized view
+  /// must 400 with a pointer at CREATE MATERIALIZED VIEW. Without this preflight the request
+  /// would fall through to the legacy `hasTable` check and report a generic 409 "already
+  /// exists" — true but unhelpful because the operator would not know they were colliding with
+  /// a derived MV that has its own DROP form, refresh schedule, and minion task wiring.
+  @Test
+  public void createTableOfflineOnExistingMaterializedViewReturns400() {
+    PinotDdlRestletResource resource = new PinotDdlRestletResource();
+    resource._pinotHelixResourceManager = mock(PinotHelixResourceManager.class);
+    resource._accessControlFactory = mock(AccessControlFactory.class);
+    when(resource._accessControlFactory.create()).thenReturn(new AccessControl() {
+    });
+
+    TableConfig mvConfig = newMaterializedViewShapedConfig("events_OFFLINE");
+    when(resource._pinotHelixResourceManager.getTableConfig("events_OFFLINE")).thenReturn(mvConfig);
+
+    Request request = mock(Request.class);
+    when(request.getRequestURL()).thenReturn(new StringBuilder("http://localhost/sql/ddl"));
+
+    ControllerApplicationException e = expectThrows(ControllerApplicationException.class,
+        () -> resource.executeDdl(
+            new DdlExecutionRequest("CREATE TABLE events (id INT) TABLE_TYPE = OFFLINE"), false,
+            mock(HttpHeaders.class), request));
+
+    assertEquals(e.getResponse().getStatus(), Response.Status.BAD_REQUEST.getStatusCode());
+    assertTrue(e.getMessage().contains("materialized view"),
+        "Error must call out that the colliding object is an MV; got: " + e.getMessage());
+    assertTrue(e.getMessage().contains("pick a different name")
+            && e.getMessage().contains("drop the existing materialized view"),
+        "Error must surface both actionable resolutions; got: " + e.getMessage());
+  }
+
+  /// IF NOT EXISTS does not suppress the type-mismatch — it suppresses "object not found",
+  /// not "wrong DDL verb for the conflicting object". Same outcome as the non-IF-NOT-EXISTS
+  /// case above. Mirror of the `DROP MATERIALIZED VIEW IF EXISTS on plain table → 400` policy.
+  @Test
+  public void createTableOfflineIfNotExistsOnExistingMaterializedViewReturns400() {
+    PinotDdlRestletResource resource = new PinotDdlRestletResource();
+    resource._pinotHelixResourceManager = mock(PinotHelixResourceManager.class);
+    resource._accessControlFactory = mock(AccessControlFactory.class);
+    when(resource._accessControlFactory.create()).thenReturn(new AccessControl() {
+    });
+
+    TableConfig mvConfig = newMaterializedViewShapedConfig("events_OFFLINE");
+    when(resource._pinotHelixResourceManager.getTableConfig("events_OFFLINE")).thenReturn(mvConfig);
+
+    Request request = mock(Request.class);
+    when(request.getRequestURL()).thenReturn(new StringBuilder("http://localhost/sql/ddl"));
+
+    ControllerApplicationException e = expectThrows(ControllerApplicationException.class,
+        () -> resource.executeDdl(
+            new DdlExecutionRequest(
+                "CREATE TABLE IF NOT EXISTS events (id INT) TABLE_TYPE = OFFLINE"),
+            false, mock(HttpHeaders.class), request));
+
+    assertEquals(e.getResponse().getStatus(), Response.Status.BAD_REQUEST.getStatusCode(),
+        "Type-mismatched target must 400 even under IF NOT EXISTS — IF NOT EXISTS handles "
+            + "absence, not type confusion.");
+    assertTrue(e.getMessage().contains("materialized view"), e.getMessage());
+  }
+
+  /// CREATE TABLE REALTIME at a raw name whose OFFLINE half is already an MV must 400. An
+  /// MV occupies its raw name exclusively across both type halves — letting the REALTIME side
+  /// proceed would create a hybrid pair whose OFFLINE half is a materialized view, a state
+  /// with no defined semantics in the broker rewrite, minion task generator, or consistency
+  /// manager. This test pins the REALTIME-side preflight: even though the REALTIME znode is
+  /// empty, the OFFLINE-half lookup must still happen and rebuke the request.
+  @Test
+  public void createTableRealtimeOnExistingMaterializedViewReturns400() {
+    PinotDdlRestletResource resource = new PinotDdlRestletResource();
+    resource._pinotHelixResourceManager = mock(PinotHelixResourceManager.class);
+    resource._accessControlFactory = mock(AccessControlFactory.class);
+    when(resource._accessControlFactory.create()).thenReturn(new AccessControl() {
+    });
+
+    TableConfig mvConfig = newMaterializedViewShapedConfig("events_OFFLINE");
+    when(resource._pinotHelixResourceManager.getTableConfig("events_OFFLINE")).thenReturn(mvConfig);
+    when(resource._pinotHelixResourceManager.getTableConfig("events_REALTIME")).thenReturn(null);
+
+    Request request = mock(Request.class);
+    when(request.getRequestURL()).thenReturn(new StringBuilder("http://localhost/sql/ddl"));
+
+    ControllerApplicationException e = expectThrows(ControllerApplicationException.class,
+        () -> resource.executeDdl(
+            new DdlExecutionRequest("CREATE TABLE events (id INT) TABLE_TYPE = REALTIME"), false,
+            mock(HttpHeaders.class), request));
+
+    assertEquals(e.getResponse().getStatus(), Response.Status.BAD_REQUEST.getStatusCode());
+    assertTrue(e.getMessage().contains("REALTIME"), e.getMessage());
+    assertTrue(e.getMessage().contains("materialized view"),
+        "Error must call out that the colliding object is an MV; got: " + e.getMessage());
+  }
+
+  /// Hand-built minimal materialized-view-shaped TableConfig: an OFFLINE table with the
+  /// canonical `isMaterializedView` flag set (per PR #18564 — this is the single source of
+  /// truth the Q2=B dispatch reads) plus a `task.MaterializedViewTask.definedSQL` body so
+  /// the SPI invariant `TableConfigUtils.validateMaterializedViewInvariants` is satisfied.
+  /// We construct this inline rather than compiling a real `CREATE MATERIALIZED VIEW` DDL
+  /// because the Table-DDL unit test class deliberately stays free of the MV compilation
+  /// toolchain.
+  private static TableConfig newMaterializedViewShapedConfig(String tableNameWithType) {
+    return new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName(tableNameWithType)
+        .setIsMaterializedView(true)
+        .setTaskConfig(new TableTaskConfig(Collections.singletonMap(
+            MaterializedViewTask.TASK_TYPE,
+            Collections.singletonMap(MaterializedViewTask.DEFINED_SQL_KEY,
+                "SELECT id FROM source"))))
+        .build();
   }
 
   /// SQL database qualifiers and the Database header must agree; conflicts are caller input

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerMaterializedViewBackfillTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerMaterializedViewBackfillTest.java
@@ -1,0 +1,376 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.helix.AccessOption;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.pinot.common.metadata.ZKMetadataProvider;
+import org.apache.pinot.materializedview.consistency.MaterializedViewConsistencyManager;
+import org.apache.pinot.materializedview.metadata.MaterializedViewDefinitionMetadata;
+import org.apache.pinot.materializedview.metadata.MaterializedViewDefinitionMetadataUtils;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+
+/// Unit tests for the {@code MaterializedViewConsistencyManager} reverse-index backfill on
+/// {@link PinotHelixResourceManager#backfillMaterializedViewReverseIndex} and the symmetric
+/// DROP-MV `extractSourceTableName` fallback inside
+/// {@code notifyMaterializedViewConsistencyManagerForTableDrop}.
+///
+/// Together these close the post-restart orphan window xiangfu0 flagged in #18544: an MV
+/// whose definition znode is missing (best-effort persist failed at create, znode removed by
+/// manual ZK surgery, or pre-existing from a controller version before definition znodes
+/// existed) was previously invisible to the in-memory reverse index after restart, so the
+/// `DROP TABLE` delete-guard would let an operator silently orphan the MV by dropping its
+/// base. The contract under test is:
+///
+///   1. Backfill registers every authoritative-MV (`tableConfig.isMaterializedView()=true`)
+///      whose definition znode is missing, using the same `extractSourceTableName` fallback
+///      as the in-session create path so post-restart and same-session reverse indexes are
+///      byte-identical.
+///   2. Backfill is fail-isolated per MV — one corrupt `definedSQL` does not break startup
+///      for the rest of the cluster's MVs.
+///   3. Backfill skips MVs that already have a znode (the manager's `init()` rebuilt those)
+///      and never double-registers.
+///   4. The DROP path's znode-missing branch falls back to the same `extractSourceTableName`
+///      mechanism so an MV whose znode persist failed at create still cleans up its in-memory
+///      reverse-index entry on drop, instead of leaking a ghost that blocks legitimate
+///      `DROP TABLE` on its base.
+///
+/// Helix wiring is mocked: a partial mock of `PinotHelixResourceManager` selectively calls
+/// real methods, `_propertyStore` is reflection-injected, `ZKMetadataProvider` and
+/// `MaterializedViewDefinitionMetadataUtils` are static-mocked. The
+/// `MaterializedViewConsistencyManager` is real (so we observe the in-memory reverse index
+/// directly via `getDependentMaterializedViews`).
+public class PinotHelixResourceManagerMaterializedViewBackfillTest {
+
+  private static final String SOURCE_RAW = "orders";
+  private static final String DEFINED_SQL = "SELECT a FROM " + SOURCE_RAW;
+
+  // ── backfill ────────────────────────────────────────────────────────────────────────────
+
+  /// The canonical recovery scenario: an MV whose definition znode never made it to ZK (the
+  /// in-session best-effort persist swallowed an exception). After a restart, the manager's
+  /// `rebuildReverseIndex` finds nothing for this MV, but backfill must catch it via the
+  /// authoritative TableConfig list and the persisted `definedSQL` fallback. Without this,
+  /// `DROP TABLE orders` after the restart would silently orphan `mv_OFFLINE`.
+  @Test
+  public void registersMvWithMissingDefinitionZnode()
+      throws Exception {
+    String mvWithType = "mv_OFFLINE";
+    PinotHelixResourceManager prm = newPartialMock(Collections.singletonList(mvWithType));
+    ZkHelixPropertyStore<ZNRecord> propertyStore = mock(ZkHelixPropertyStore.class);
+    injectPropertyStore(prm, propertyStore);
+    MaterializedViewConsistencyManager mgr = newConsistencyManagerWithEmptyZk();
+
+    TableConfig mvConfig = mvTableConfig(mvWithType, DEFINED_SQL);
+    try (MockedStatic<ZKMetadataProvider> zk = Mockito.mockStatic(ZKMetadataProvider.class);
+         MockedStatic<MaterializedViewDefinitionMetadataUtils> def =
+             Mockito.mockStatic(MaterializedViewDefinitionMetadataUtils.class)) {
+      zk.when(() -> ZKMetadataProvider.getTableConfig(propertyStore, mvWithType)).thenReturn(mvConfig);
+      // Source TableConfig missing — phase 2's persistMaterializedViewDefinitionMetadataBestEffort
+      // bails out internally with a logged WARN. Phase 1's in-memory registration is still
+      // expected to succeed (that is the orphan-protection that matters here).
+      zk.when(() -> ZKMetadataProvider.getTableConfig(eq(propertyStore), Mockito.argThat(
+          arg -> arg != null && arg.startsWith(SOURCE_RAW)))).thenReturn(null);
+      def.when(() -> MaterializedViewDefinitionMetadataUtils.fetch(propertyStore, mvWithType))
+          .thenReturn(null);
+
+      prm.backfillMaterializedViewReverseIndex(mgr);
+
+      assertEquals(mgr.getDependentMaterializedViews(SOURCE_RAW), Collections.singletonList(mvWithType),
+          "Backfill must register the missing-znode MV in the reverse index using the "
+              + "definedSQL fallback so DROP TABLE on its base table is blocked.");
+    }
+  }
+
+  /// MVs whose definition znode is already present must be skipped — the manager's init()
+  /// rebuildReverseIndex already covered them, and re-registering would waste a ZK round-trip
+  /// per MV (multiplied by every controller restart on every cluster). The check is structural
+  /// (znode-existence), not state-based, so a regression that drops the skip would also leak
+  /// CPU on the hot startup path.
+  @Test
+  public void skipsMvWithExistingDefinitionZnode()
+      throws Exception {
+    String mvWithType = "mv_OFFLINE";
+    PinotHelixResourceManager prm = newPartialMock(Collections.singletonList(mvWithType));
+    ZkHelixPropertyStore<ZNRecord> propertyStore = mock(ZkHelixPropertyStore.class);
+    injectPropertyStore(prm, propertyStore);
+    MaterializedViewConsistencyManager mgr = newConsistencyManagerWithEmptyZk();
+
+    TableConfig mvConfig = mvTableConfig(mvWithType, DEFINED_SQL);
+    MaterializedViewDefinitionMetadata existingDef = new MaterializedViewDefinitionMetadata(
+        mvWithType, Collections.singletonList(SOURCE_RAW), DEFINED_SQL,
+        new HashMap<>(), null);
+    try (MockedStatic<ZKMetadataProvider> zk = Mockito.mockStatic(ZKMetadataProvider.class);
+         MockedStatic<MaterializedViewDefinitionMetadataUtils> def =
+             Mockito.mockStatic(MaterializedViewDefinitionMetadataUtils.class)) {
+      zk.when(() -> ZKMetadataProvider.getTableConfig(propertyStore, mvWithType)).thenReturn(mvConfig);
+      def.when(() -> MaterializedViewDefinitionMetadataUtils.fetch(propertyStore, mvWithType))
+          .thenReturn(existingDef);
+
+      prm.backfillMaterializedViewReverseIndex(mgr);
+
+      // Backfill must NOT register: that is the manager-init's job for znode-backed MVs.
+      // Critically, no ZK write was attempted either — verifying createIfAbsent is unnecessary
+      // because the existing-znode early-return is upstream of phase 2 entirely.
+      def.verify(() -> MaterializedViewDefinitionMetadataUtils.createIfAbsent(any(), any()), never());
+      assertTrue(mgr.getDependentMaterializedViews(SOURCE_RAW).isEmpty(),
+          "Backfill must not double-register an MV whose authoritative definition znode "
+              + "already exists; rebuildReverseIndex inside init() owns that entry.");
+    }
+  }
+
+  /// One corrupt definedSQL must not block startup for the rest of the cluster's MVs. This
+  /// is the failure-isolation contract: backfill is best-effort precisely so an unparseable
+  /// SQL on a single MV (operator hand-edited the znode, version skew, etc.) cannot wedge
+  /// the controller. The healthy MV must still register.
+  @Test
+  public void corruptDefinedSqlDoesNotBlockOtherMvs()
+      throws Exception {
+    String healthyMv = "mv_healthy_OFFLINE";
+    String brokenMv = "mv_broken_OFFLINE";
+    PinotHelixResourceManager prm = newPartialMock(Arrays.asList(healthyMv, brokenMv));
+    ZkHelixPropertyStore<ZNRecord> propertyStore = mock(ZkHelixPropertyStore.class);
+    injectPropertyStore(prm, propertyStore);
+    MaterializedViewConsistencyManager mgr = newConsistencyManagerWithEmptyZk();
+
+    TableConfig healthyConfig = mvTableConfig(healthyMv, DEFINED_SQL);
+    TableConfig brokenConfig = mvTableConfig(brokenMv, "this is not valid SQL");
+    try (MockedStatic<ZKMetadataProvider> zk = Mockito.mockStatic(ZKMetadataProvider.class);
+         MockedStatic<MaterializedViewDefinitionMetadataUtils> def =
+             Mockito.mockStatic(MaterializedViewDefinitionMetadataUtils.class)) {
+      zk.when(() -> ZKMetadataProvider.getTableConfig(propertyStore, healthyMv)).thenReturn(healthyConfig);
+      zk.when(() -> ZKMetadataProvider.getTableConfig(propertyStore, brokenMv)).thenReturn(brokenConfig);
+      // Source TableConfig lookup for the healthy MV's source returns null so phase 2 bails
+      // out inside the existing best-effort persist — keeps the test focused on phase 1.
+      zk.when(() -> ZKMetadataProvider.getTableConfig(eq(propertyStore), Mockito.argThat(
+          arg -> arg != null && arg.startsWith(SOURCE_RAW)))).thenReturn(null);
+      def.when(() -> MaterializedViewDefinitionMetadataUtils.fetch(eq(propertyStore), any()))
+          .thenReturn(null);
+
+      prm.backfillMaterializedViewReverseIndex(mgr);
+
+      assertEquals(mgr.getDependentMaterializedViews(SOURCE_RAW), Collections.singletonList(healthyMv),
+          "The healthy MV must register despite a sibling MV's unparseable definedSQL — a "
+              + "single corrupt SQL must not wedge the rest of the cluster's reverse index.");
+    }
+  }
+
+  /// MVs whose `MaterializedViewTask` task config is absent (a malformed TableConfig that
+  /// somehow has `isMaterializedView=true` but no task configs) are skipped silently rather
+  /// than throwing. This is an unreachable shape under the current DDL but tests the
+  /// defensive guard in `resolveBaseTablesForBackfill` — operators applying TableConfig via
+  /// raw JSON could produce it, and a NullPointerException at startup is a non-starter.
+  @Test
+  public void skipsMvWithMissingTaskConfigs()
+      throws Exception {
+    String mvWithType = "mv_OFFLINE";
+    PinotHelixResourceManager prm = newPartialMock(Collections.singletonList(mvWithType));
+    ZkHelixPropertyStore<ZNRecord> propertyStore = mock(ZkHelixPropertyStore.class);
+    injectPropertyStore(prm, propertyStore);
+    MaterializedViewConsistencyManager mgr = newConsistencyManagerWithEmptyZk();
+
+    // Declared as MV but task configs absent — TableConfigBuilder leaves task type map null
+    // when no task config is added.
+    TableConfig mvConfig = new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName(mvWithType)
+        .setIsMaterializedView(true)
+        .build();
+    try (MockedStatic<ZKMetadataProvider> zk = Mockito.mockStatic(ZKMetadataProvider.class);
+         MockedStatic<MaterializedViewDefinitionMetadataUtils> def =
+             Mockito.mockStatic(MaterializedViewDefinitionMetadataUtils.class)) {
+      zk.when(() -> ZKMetadataProvider.getTableConfig(propertyStore, mvWithType)).thenReturn(mvConfig);
+      def.when(() -> MaterializedViewDefinitionMetadataUtils.fetch(propertyStore, mvWithType))
+          .thenReturn(null);
+
+      prm.backfillMaterializedViewReverseIndex(mgr);
+
+      assertTrue(mgr.getDependentMaterializedViews(SOURCE_RAW).isEmpty(),
+          "MV with no MaterializedViewTask task configs must be skipped, not throw.");
+    }
+  }
+
+  /// Empty cluster: backfill must short-circuit cleanly. Tests the fast-path log line so
+  /// regressions that turn it into an exception (e.g. a future "let me also write the
+  /// listener-debounce config znode here" change) get caught.
+  @Test
+  public void emptyClusterIsNoOp()
+      throws Exception {
+    PinotHelixResourceManager prm = newPartialMock(Collections.emptyList());
+    ZkHelixPropertyStore<ZNRecord> propertyStore = mock(ZkHelixPropertyStore.class);
+    injectPropertyStore(prm, propertyStore);
+    MaterializedViewConsistencyManager mgr = newConsistencyManagerWithEmptyZk();
+
+    try (MockedStatic<ZKMetadataProvider> zk = Mockito.mockStatic(ZKMetadataProvider.class);
+         MockedStatic<MaterializedViewDefinitionMetadataUtils> def =
+             Mockito.mockStatic(MaterializedViewDefinitionMetadataUtils.class)) {
+      prm.backfillMaterializedViewReverseIndex(mgr);
+
+      def.verify(() -> MaterializedViewDefinitionMetadataUtils.fetch(any(), any()), never());
+      def.verify(() -> MaterializedViewDefinitionMetadataUtils.createIfAbsent(any(), any()), never());
+      assertTrue(mgr.getDependentMaterializedViews(SOURCE_RAW).isEmpty());
+    }
+  }
+
+  /// A null consistency manager argument must be a fast no-op rather than NPE. Defensive
+  /// against future refactors that wire backfill into a code path where the manager hasn't
+  /// been constructed yet.
+  @Test
+  public void nullConsistencyManagerIsNoOp()
+      throws Exception {
+    PinotHelixResourceManager prm = newPartialMock(Collections.singletonList("mv_OFFLINE"));
+    prm.backfillMaterializedViewReverseIndex(null);
+    // No assertion needed — the test passes iff no NPE is thrown.
+  }
+
+  // ── DROP MV symmetric fallback ──────────────────────────────────────────────────────────
+
+  /// The matching half of the backfill: when a DROP MV runs against an MV whose definition
+  /// znode is absent (the same failure mode backfill recovers from), the drop path must
+  /// also fall back to `extractSourceTableName` so the in-memory reverse-index entry —
+  /// whether registered by backfill, by the in-session create-fallback, or by a future code
+  /// path — is cleaned up. Without this, dropping a backfilled MV whose phase-2 znode write
+  /// also failed would leak a ghost reverse-index entry that subsequently blocks legitimate
+  /// `DROP TABLE` on its (now genuinely independent) base table. Asymmetry between create
+  /// and drop fallback paths is the bug this test pins.
+  @Test
+  public void dropFallbackUnregistersViaDefinedSqlWhenZnodeAbsent()
+      throws Exception {
+    String mvWithType = "mv_OFFLINE";
+    PinotHelixResourceManager prm = mock(PinotHelixResourceManager.class);
+    ZkHelixPropertyStore<ZNRecord> propertyStore = mock(ZkHelixPropertyStore.class);
+    injectPropertyStore(prm, propertyStore);
+    MaterializedViewConsistencyManager mgr = newConsistencyManagerWithEmptyZk();
+    injectConsistencyManager(prm, mgr);
+
+    // Pre-state: the MV is in the reverse index pointing at SOURCE_RAW.  This is what
+    // backfill leaves behind, or what the in-session fallback at create time leaves behind.
+    mgr.onMaterializedViewTableCreated(mvWithType, Collections.singletonList(SOURCE_RAW));
+    assertFalse(mgr.getDependentMaterializedViews(SOURCE_RAW).isEmpty(),
+        "Pre-condition: reverse index must hold an entry for the MV before drop.");
+
+    TableConfig mvConfig = mvTableConfig(mvWithType, DEFINED_SQL);
+    try (MockedStatic<ZKMetadataProvider> zk = Mockito.mockStatic(ZKMetadataProvider.class);
+         MockedStatic<MaterializedViewDefinitionMetadataUtils> def =
+             Mockito.mockStatic(MaterializedViewDefinitionMetadataUtils.class)) {
+      zk.when(() -> ZKMetadataProvider.getTableConfig(propertyStore, mvWithType)).thenReturn(mvConfig);
+      // Definition znode absent — the failure mode the new fallback covers.
+      def.when(() -> MaterializedViewDefinitionMetadataUtils.fetch(propertyStore, mvWithType))
+          .thenReturn(null);
+
+      invokeDropNotify(prm, mvWithType);
+
+      assertTrue(mgr.getDependentMaterializedViews(SOURCE_RAW).isEmpty(),
+          "DROP MV with znode missing must fall back to extractSourceTableName(definedSQL) "
+              + "and unregister the in-memory entry; otherwise the reverse index leaks a "
+              + "ghost dependency on the base table.");
+    }
+  }
+
+  // ── helpers ─────────────────────────────────────────────────────────────────────────────
+
+  private static TableConfig mvTableConfig(String tableNameWithType, String definedSql) {
+    Map<String, Map<String, String>> taskTypeConfigsMap = new HashMap<>();
+    Map<String, String> mvTaskConfigs = new HashMap<>();
+    mvTaskConfigs.put(CommonConstants.MaterializedViewTask.DEFINED_SQL_KEY, definedSql);
+    taskTypeConfigsMap.put(CommonConstants.MaterializedViewTask.TASK_TYPE, mvTaskConfigs);
+    return new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName(tableNameWithType)
+        .setIsMaterializedView(true)
+        .setTaskConfig(new org.apache.pinot.spi.config.table.TableTaskConfig(taskTypeConfigsMap))
+        .build();
+  }
+
+  /// Returns a partial-mock `PinotHelixResourceManager` whose `getAllResources`/
+  /// `getAllRawMaterializedViewNames` and `backfillMaterializedViewReverseIndex` call the
+  /// real implementation while leaving everything else mocked. Mirrors the partial-mock
+  /// pattern in `PinotHelixResourceManagerMaterializedViewListingTest` — a real construction
+  /// of `PinotHelixResourceManager` requires a live cluster and is the wrong layer for this
+  /// targeted unit test.
+  private static PinotHelixResourceManager newPartialMock(List<String> offlineResources) {
+    PinotHelixResourceManager prm = mock(PinotHelixResourceManager.class);
+    when(prm.getAllResources()).thenReturn(offlineResources);
+    when(prm.getAllRawMaterializedViewNames(Mockito.any())).thenCallRealMethod();
+    Mockito.doCallRealMethod().when(prm).backfillMaterializedViewReverseIndex(Mockito.any());
+    return prm;
+  }
+
+  /// Builds a real `MaterializedViewConsistencyManager` whose `init` reads an empty children
+  /// list, so its initial reverse index is empty and tests can observe registrations
+  /// happening exclusively from the path under test.
+  private static MaterializedViewConsistencyManager newConsistencyManagerWithEmptyZk() {
+    @SuppressWarnings("unchecked")
+    ZkHelixPropertyStore<ZNRecord> mgrStore = mock(ZkHelixPropertyStore.class);
+    String defParent = ZKMetadataProvider.getPropertyStorePathForMaterializedViewDefinitionPrefix();
+    when(mgrStore.getChildNames(eq(defParent), eq(AccessOption.PERSISTENT)))
+        .thenReturn(Collections.emptyList());
+    MaterializedViewConsistencyManager mgr = new MaterializedViewConsistencyManager();
+    mgr.init(mgrStore);
+    return mgr;
+  }
+
+  private static void injectPropertyStore(PinotHelixResourceManager prm,
+      ZkHelixPropertyStore<ZNRecord> propertyStore) throws Exception {
+    Field field = PinotHelixResourceManager.class.getDeclaredField("_propertyStore");
+    field.setAccessible(true);
+    field.set(prm, propertyStore);
+  }
+
+  private static void injectConsistencyManager(PinotHelixResourceManager prm,
+      MaterializedViewConsistencyManager mgr) throws Exception {
+    Field field = PinotHelixResourceManager.class.getDeclaredField("_materializedViewConsistencyManager");
+    field.setAccessible(true);
+    field.set(prm, mgr);
+  }
+
+  /// Invokes the private `notifyMaterializedViewConsistencyManagerForTableDrop` via reflection
+  /// so the test can target the symmetric fallback branch directly without going through the
+  /// full `deleteTable` path (which would require a live Helix cluster). Reflection keeps the
+  /// production visibility minimal.
+  private static void invokeDropNotify(PinotHelixResourceManager prm, String tableNameWithType)
+      throws Exception {
+    Method m = PinotHelixResourceManager.class
+        .getDeclaredMethod("notifyMaterializedViewConsistencyManagerForTableDrop", String.class);
+    m.setAccessible(true);
+    m.invoke(prm, tableNameWithType);
+  }
+}

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerMaterializedViewListingTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerMaterializedViewListingTest.java
@@ -1,0 +1,191 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core;
+
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.pinot.common.metadata.ZKMetadataProvider;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+
+/// Focused unit tests for {@link PinotHelixResourceManager#getAllRawMaterializedViewNames}.
+///
+/// The filter is a five-line pipeline over `getAllResources()` whose correctness hinges on three
+/// contracts: (1) skipping REALTIME resources without a ZK fetch, (2) reading the canonical
+/// `TableConfig#isMaterializedView` flag rather than inferring MV-ness from the task block, and
+/// (3) honouring the database scope. Each test exercises one of those contracts in isolation
+/// so a regression names the broken rule rather than just "listing returned the wrong list".
+///
+/// Helix wiring is mocked: the test replaces `getAllResources()` on a partial mock and stubs
+/// `_propertyStore` via reflection, then static-mocks `ZKMetadataProvider.getTableConfig` so
+/// the helper sees deterministic TableConfigs without spinning up a real ZK / Helix stack.
+/// Integration coverage for the end-to-end Helix path lives with the rest of the
+/// resource-manager integration tests under `helix/core/PinotHelixResourceManager*Test`.
+public class PinotHelixResourceManagerMaterializedViewListingTest {
+
+  @Test
+  public void filtersByIsMaterializedViewFlagAndSkipsRealtime()
+      throws Exception {
+    PinotHelixResourceManager prm = mock(PinotHelixResourceManager.class);
+    when(prm.getAllRawMaterializedViewNames(Mockito.any())).thenCallRealMethod();
+    when(prm.getAllResources()).thenReturn(Arrays.asList(
+        "mv_orders_OFFLINE",        // MV → kept
+        "plain_orders_OFFLINE",     // OFFLINE but no MV flag → dropped
+        "mv_orders_REALTIME",       // REALTIME → dropped (and never fetched)
+        "ghost_OFFLINE"));          // TableConfig missing (corrupted znode) → dropped
+
+    ZkHelixPropertyStore<ZNRecord> propertyStore = mock(ZkHelixPropertyStore.class);
+    injectPropertyStore(prm, propertyStore);
+
+    TableConfig mvConfig = new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName("mv_orders_OFFLINE")
+        .setIsMaterializedView(true)
+        .build();
+    TableConfig plainConfig = new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName("plain_orders_OFFLINE")
+        .build();
+
+    try (MockedStatic<ZKMetadataProvider> staticZk = Mockito.mockStatic(ZKMetadataProvider.class)) {
+      staticZk.when(() -> ZKMetadataProvider.getTableConfig(propertyStore, "mv_orders_OFFLINE"))
+          .thenReturn(mvConfig);
+      staticZk.when(() -> ZKMetadataProvider.getTableConfig(propertyStore, "plain_orders_OFFLINE"))
+          .thenReturn(plainConfig);
+      // `ghost_OFFLINE`: TableConfig fetch returns null (corruption). The helper must silently
+      // drop it rather than throw — a single broken znode must not blank the entire listing.
+      staticZk.when(() -> ZKMetadataProvider.getTableConfig(propertyStore, "ghost_OFFLINE"))
+          .thenReturn(null);
+
+      List<String> result = prm.getAllRawMaterializedViewNames(null);
+
+      assertEquals(result, java.util.Collections.singletonList("mv_orders"),
+          "Only the OFFLINE resource whose TableConfig has isMaterializedView=true must be "
+              + "returned, and the raw name must be stripped of its _OFFLINE suffix so the "
+              + "result is reusable as input to SHOW CREATE / DROP MATERIALIZED VIEW.");
+      // Critical: the REALTIME resource must NEVER trigger a TableConfig fetch — that would
+      // be a wasted ZK round-trip on every realtime table in the cluster.
+      staticZk.verify(() -> ZKMetadataProvider.getTableConfig(propertyStore, "mv_orders_REALTIME"),
+          Mockito.never());
+    }
+  }
+
+  @Test
+  public void scopesListingToProvidedDatabase()
+      throws Exception {
+    PinotHelixResourceManager prm = mock(PinotHelixResourceManager.class);
+    when(prm.getAllRawMaterializedViewNames(Mockito.any())).thenCallRealMethod();
+    when(prm.getAllResources()).thenReturn(Arrays.asList(
+        "mv_global_OFFLINE",        // default db
+        "analytics.mv_revenue_OFFLINE",   // 'analytics' db → kept
+        "marketing.mv_funnel_OFFLINE"));  // 'marketing' db → dropped
+
+    ZkHelixPropertyStore<ZNRecord> propertyStore = mock(ZkHelixPropertyStore.class);
+    injectPropertyStore(prm, propertyStore);
+
+    TableConfig analyticsMv = new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName("analytics.mv_revenue_OFFLINE")
+        .setIsMaterializedView(true)
+        .build();
+
+    try (MockedStatic<ZKMetadataProvider> staticZk = Mockito.mockStatic(ZKMetadataProvider.class)) {
+      staticZk.when(() -> ZKMetadataProvider.getTableConfig(propertyStore,
+          "analytics.mv_revenue_OFFLINE")).thenReturn(analyticsMv);
+      // marketing.mv_funnel is filtered by the database predicate BEFORE we hit ZK, so no stub
+      // is needed; if the database filter regresses this test will fail with an
+      // `UnnecessaryStubbingException`-equivalent (an unstubbed call returning null) which
+      // makes the regression obvious rather than passing silently.
+
+      List<String> result = prm.getAllRawMaterializedViewNames("analytics");
+
+      // The "raw" name strips the type suffix but RETAINS the database prefix — exactly what
+      // SHOW TABLES does. Keeping the qualifier means a caller running
+      // `SHOW MATERIALIZED VIEWS FROM analytics` from a session with no Database header still
+      // sees the fully-qualified name and can pipe it straight into
+      // `SHOW CREATE MATERIALIZED VIEW analytics.mv_revenue` without guessing the qualifier.
+      assertEquals(result, java.util.Collections.singletonList("analytics.mv_revenue"),
+          "Only MVs whose qualified name starts with 'analytics.' must be returned; cross-database "
+              + "leaks would let a caller scoped to one database enumerate another database's MVs.");
+      // The default-database MV must NOT have been read either — a regression in the database
+      // filter that lets default-db resources through would also let a header substitution
+      // attack discover MVs the caller cannot read.
+      staticZk.verify(() -> ZKMetadataProvider.getTableConfig(propertyStore, "mv_global_OFFLINE"),
+          Mockito.never());
+      staticZk.verify(() -> ZKMetadataProvider.getTableConfig(propertyStore,
+          "marketing.mv_funnel_OFFLINE"), Mockito.never());
+    }
+  }
+
+  /// A ZK fetch that throws must NOT break the entire listing — a single corrupted znode is
+  /// expected during operator investigation of broken state, and SHOW MATERIALIZED VIEWS is
+  /// exactly the verb an operator would run to diagnose it.
+  @Test
+  public void corruptedZnodeDoesNotBreakListing()
+      throws Exception {
+    PinotHelixResourceManager prm = mock(PinotHelixResourceManager.class);
+    when(prm.getAllRawMaterializedViewNames(Mockito.any())).thenCallRealMethod();
+    when(prm.getAllResources()).thenReturn(Arrays.asList(
+        "mv_healthy_OFFLINE",
+        "mv_broken_OFFLINE"));
+
+    ZkHelixPropertyStore<ZNRecord> propertyStore = mock(ZkHelixPropertyStore.class);
+    injectPropertyStore(prm, propertyStore);
+
+    TableConfig healthy = new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName("mv_healthy_OFFLINE")
+        .setIsMaterializedView(true)
+        .build();
+
+    try (MockedStatic<ZKMetadataProvider> staticZk = Mockito.mockStatic(ZKMetadataProvider.class)) {
+      staticZk.when(() -> ZKMetadataProvider.getTableConfig(propertyStore, "mv_healthy_OFFLINE"))
+          .thenReturn(healthy);
+      staticZk.when(() -> ZKMetadataProvider.getTableConfig(propertyStore, "mv_broken_OFFLINE"))
+          .thenThrow(new RuntimeException("Simulated ZK read failure on broken znode"));
+
+      List<String> result = prm.getAllRawMaterializedViewNames(null);
+
+      assertEquals(result.size(), 1,
+          "The healthy MV must still appear despite a broken sibling — operators need this "
+              + "listing to remain usable while diagnosing corruption.");
+      assertTrue(result.contains("mv_healthy"));
+    }
+  }
+
+  /// Sets `PinotHelixResourceManager#_propertyStore` via reflection. Required because the
+  /// real Helix-backed constructor would need a live cluster to populate the field, and the
+  /// helper under test reads `_propertyStore` to look up TableConfigs. Using reflection keeps
+  /// the test focused on the filter pipeline rather than the manager's construction story.
+  private static void injectPropertyStore(PinotHelixResourceManager prm,
+      ZkHelixPropertyStore<ZNRecord> propertyStore) throws Exception {
+    Field field = PinotHelixResourceManager.class.getDeclaredField("_propertyStore");
+    field.setAccessible(true);
+    field.set(prm, propertyStore);
+  }
+}

--- a/pinot-materialized-view/src/main/java/org/apache/pinot/materializedview/analysis/MaterializedViewAnalyzer.java
+++ b/pinot-materialized-view/src/main/java/org/apache/pinot/materializedview/analysis/MaterializedViewAnalyzer.java
@@ -23,14 +23,15 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.SqlSelect;
 import org.apache.calcite.sql.util.SqlBasicVisitor;
+import org.apache.pinot.common.materializedview.MaterializedViewAggregationCatalog;
 import org.apache.pinot.common.request.DataSource;
 import org.apache.pinot.common.request.Expression;
 import org.apache.pinot.common.request.ExpressionType;
@@ -312,6 +313,15 @@ public final class MaterializedViewAnalyzer {
     DataSource dataSource = pinotQuery.getDataSource();
     Preconditions.checkState(dataSource != null, "Could not extract data source from SQL: %s", definedSql);
 
+    // CalciteSqlParser leaves dataSource.tableName unset when the FROM clause is a JOIN — the
+    // join structure is stashed under dataSource.join instead.  Without this explicit check the
+    // null tableName falls into the generic "Could not extract source table name" branch below,
+    // which misleadingly suggests a parser failure when the actual cause is "MV does not support
+    // JOIN".  Reject up front with a message that names the unsupported construct directly.
+    Preconditions.checkState(!dataSource.isSetJoin(),
+        "Materialized views over JOIN queries are not supported. Use a single FROM table. SQL: %s",
+        definedSql);
+
     String sourceTableName = dataSource.getTableName();
     Preconditions.checkState(sourceTableName != null && !sourceTableName.isEmpty(),
         "Could not extract source table name from SQL: %s", definedSql);
@@ -397,15 +407,52 @@ public final class MaterializedViewAnalyzer {
     return sourceTableConfig.getValidationConfig().getSegmentPushType();
   }
 
-  /// Resolves the full table name with type suffix. Tries OFFLINE first, then REALTIME.
-  private static String resolveSourceTableWithType(String rawSourceTableName,
+  /// Resolves a raw source-table name to its fully-qualified `_OFFLINE` / `_REALTIME` form.
+  ///
+  /// Hybrid (OFFLINE + REALTIME both exist) is rejected: the raw name is ambiguous and
+  /// accepting it would let an MV silently drift.  The stored `definedSQL` retains the raw
+  /// name and is replayed via broker hybrid routing at task time, which fans out to BOTH
+  /// halves of the base table.  Fingerprinting and STALE-marking, however, only cover the
+  /// OFFLINE half (LLC realtime commits go through `PinotLLCRealtimeSegmentManager`, which
+  /// does not notify the MV consistency manager), so any change on the REALTIME half is
+  /// invisible to staleness tracking — VALID partitions become silently incorrect.  Fail
+  /// fast at the resolver itself so neither the analyzer (create time) nor the scheduler
+  /// (task generation time) can ever bind an MV to a hybrid base table.
+  ///
+  /// Returns:
+  ///
+  ///   - `xxx_OFFLINE` when only OFFLINE exists
+  ///   - `xxx_REALTIME` when only REALTIME exists (the REALTIME-only guard in
+  ///       [#validateSourceTable] rejects it from MV creation, but the resolver itself
+  ///       returns the name so downstream error messages can refer to the typed form)
+  ///
+  ///
+  /// Throws when both exist (hybrid) or neither exists.
+  ///
+  /// Public because [org.apache.pinot.materializedview.scheduler.MaterializedViewTaskScheduler]
+  /// reuses the same logic at task-generation time.  Keeping one resolver guarantees the
+  /// analyzer (create gate) and scheduler (runtime gate) never drift on the hybrid rule.
+  public static String resolveSourceTableWithType(String rawSourceTableName,
       MaterializedViewTaskGeneratorContext context) {
     String offlineName = TableNameBuilder.OFFLINE.tableNameWithType(rawSourceTableName);
-    if (context.tableExists(offlineName)) {
+    String realtimeName = TableNameBuilder.REALTIME.tableNameWithType(rawSourceTableName);
+    boolean hasOffline = context.tableExists(offlineName);
+    boolean hasRealtime = context.tableExists(realtimeName);
+
+    Preconditions.checkState(!(hasOffline && hasRealtime),
+        "Source table '%s' is a hybrid table (both OFFLINE and REALTIME variants exist). "
+            + "Materialized views over hybrid tables are not supported: the stored definedSQL "
+            + "would be replayed against the raw name and the broker would silently merge both "
+            + "halves at query time, while STALE-marking only covers OFFLINE (LLC realtime "
+            + "commits bypass the MV consistency manager). Drop the unwanted variant — or wait "
+            + "for hybrid MV support in a follow-up that wires the LLC commit notify hook — "
+            + "before creating this MV.",
+        rawSourceTableName);
+
+    if (hasOffline) {
       return offlineName;
     }
-    String realtimeName = TableNameBuilder.REALTIME.tableNameWithType(rawSourceTableName);
-    Preconditions.checkState(context.tableExists(realtimeName),
+    Preconditions.checkState(hasRealtime,
         "Source table '%s' does not exist (tried OFFLINE and REALTIME)", rawSourceTableName);
     return realtimeName;
   }
@@ -430,6 +477,17 @@ public final class MaterializedViewAnalyzer {
         collectIdentifiers(expr, referencedIdentifiers);
       }
     }
+    // WHERE / HAVING were previously skipped, so a typo in a filter predicate (e.g. `WHERE
+    // custome_id = 42` where the actual column is `customer_id`) would slip past create-time
+    // validation, succeed at addTable, and only surface at task-execution time as a broker
+    // failure with no clear pointer back to the DDL. Walking the filter trees here keeps the
+    // diagnostic at controller create time where the operator can immediately fix the SQL.
+    if (pinotQuery.getFilterExpression() != null) {
+      collectIdentifiers(pinotQuery.getFilterExpression(), referencedIdentifiers);
+    }
+    if (pinotQuery.getHavingExpression() != null) {
+      collectIdentifiers(pinotQuery.getHavingExpression(), referencedIdentifiers);
+    }
 
     for (String identifier : referencedIdentifiers) {
       Preconditions.checkState(sourceColumns.contains(identifier),
@@ -446,9 +504,22 @@ public final class MaterializedViewAnalyzer {
     List<Expression> selectList = pinotQuery.getSelectList();
     Preconditions.checkState(selectList != null && !selectList.isEmpty(), "SELECT list is empty");
 
+    // Reject `SELECT *` up front.  Without this guard the star identifier (name = "*") would
+    // flow through RequestUtils#extractAliasOrIdentifierName as the literal field name "*",
+    // and the downstream schema-coverage check (Check 1 below) would fail with the misleading
+    // message "MV schema column 'X' is not produced by any SELECT expression" — sending the
+    // operator chasing a schema mismatch when the real cause is "MV does not support SELECT *".
+    for (Expression expr : selectList) {
+      if (expr.getType() == ExpressionType.IDENTIFIER && "*".equals(expr.getIdentifier().getName())) {
+        throw new IllegalStateException(
+            "Materialized view definedSQL does not support `SELECT *`. List each output "
+                + "column explicitly with an `AS <alias>` matching an MV schema column.");
+      }
+    }
+
     Set<String> selectFields = new HashSet<>();
     for (Expression expr : selectList) {
-      String fieldName = extractOutputFieldName(expr);
+      String fieldName = RequestUtils.extractAliasOrIdentifierName(expr);
       selectFields.add(fieldName);
     }
 
@@ -476,65 +547,33 @@ public final class MaterializedViewAnalyzer {
     return selectFields;
   }
 
-  /// Extracts the output field name from a SELECT expression:
-  ///
-  ///   - Alias expressions (`expr AS alias`): returns the alias name
-  ///   - Bare identifiers (`columnName`): returns the column name
-  ///   - Aggregate/function without alias: throws
-  ///
-  private static String extractOutputFieldName(Expression expr) {
-    Function func = expr.getFunctionCall();
-    if (func != null) {
-      if (func.getOperator().equals("as")) {
-        Expression aliasExpr = func.getOperands().get(1);
-        Preconditions.checkState(aliasExpr.getType() == ExpressionType.IDENTIFIER,
-            "AS alias must be an identifier, got: %s", RequestUtils.prettyPrint(aliasExpr));
-        return aliasExpr.getIdentifier().getName();
-      }
-      throw new IllegalStateException(
-          "Expression '" + RequestUtils.prettyPrint(expr)
-              + "' must have an AS alias to map to an MV schema column");
-    }
-    if (expr.getType() == ExpressionType.IDENTIFIER) {
-      return expr.getIdentifier().getName();
-    }
-    throw new IllegalStateException(
-        "Unsupported expression type in SELECT list: " + RequestUtils.prettyPrint(expr));
-  }
-
-  /// MV-side aggregation functions the broker rewrite engine (lands in PR 2) will know how to
-  /// re-aggregate. Mirrored from the equivalence registry that ships alongside the rewrite
-  /// engine; kept here as a static set so PR 1's analyzer can reject misconfigured MVs at
-  /// create time without dragging the rewrite-engine internals into the ingestion module.
-  /// When PR 2 lands its full {@code AggregationEquivalenceRegistry}, this set MUST stay in
-  /// sync — adding a function to the registry without adding it here would silently let a
-  /// usable MV definition slip through create-time validation (still fine in practice, just
-  /// slightly less helpful as a config-error message).
-  private static final Set<String> SUPPORTED_MATERIALIZED_VIEW_AGGREGATIONS = Set.of(
-      "SUM", "MIN", "MAX", "COUNT",
-      "DISTINCTCOUNTRAWHLL", "DISTINCTCOUNTRAWHLLPLUS", "DISTINCTCOUNTRAWTHETASKETCH");
-
   /// Recursively validates that all aggregation functions used are recognized by Pinot AND
   /// can be re-aggregated by the broker rewrite engine (PR 2). An MV defined with an
   /// aggregation that the rewrite engine cannot use would silently never produce rewrites;
   /// surfacing the rejection at create/update time gives the operator a clear error.
+  ///
+  /// The allow-list of "MV-side re-aggregatable" functions is sourced from
+  /// {@link MaterializedViewAggregationCatalog} — the same catalog the MV schema inferer
+  /// uses to pick column types. Both consumers MUST agree on the supported set so an MV
+  /// produced by the inferer cannot be later rejected here, and conversely so this analyzer
+  /// cannot accept an MV the rewrite engine can't use.
   private static void validateAggregationFunctions(Expression expr) {
     Function func = expr.getFunctionCall();
     if (func == null) {
       return;
     }
     String operator = func.getOperator();
-    if (!operator.equals("as") && AggregationFunctionType.isAggregationFunction(operator)) {
+    if (!operator.equals(SqlKind.AS.lowerName) && AggregationFunctionType.isAggregationFunction(operator)) {
       // Known aggregation — verify the rewrite engine knows how to re-aggregate it.  Without
       // re-aggregation support, MaterializedViewQueryRewriteEngine (PR 2) would never select
       // this MV (the strategy returns null on the projection-subsumption check), and the
       // operator would observe an MV that is configured but never hit.
       Preconditions.checkState(
-          SUPPORTED_MATERIALIZED_VIEW_AGGREGATIONS.contains(operator.toUpperCase(Locale.ROOT)),
+          MaterializedViewAggregationCatalog.isSupported(operator),
           "MV definedSQL uses aggregation '%s' for which no MV-side re-aggregation is supported. "
               + "Supported MV-side aggregations: %s. Replace '%s' with a supported aggregation.",
-          operator, SUPPORTED_MATERIALIZED_VIEW_AGGREGATIONS, operator);
-    } else if (!operator.equals("as") && isLikelyAggregation(func)) {
+          operator, MaterializedViewAggregationCatalog.getSupportedOperators(), operator);
+    } else if (!operator.equals(SqlKind.AS.lowerName) && isLikelyAggregation(func)) {
       throw new IllegalStateException(
           "Aggregation function '" + operator + "' is not a recognized Pinot aggregation function");
     }
@@ -623,6 +662,23 @@ public final class MaterializedViewAnalyzer {
             "Invalid maxTasksPerBatch '" + maxTasksPerBatch + "': must be a positive integer", e);
       }
     }
+
+    // stalenessThresholdMs — optional. Accept any non-negative long: 0 is the documented
+    // default ("no SLO"; rewrite engine treats `<= 0` as disabled) and an operator who
+    // wants to disable explicitly should be allowed to write it. Reject malformed values so
+    // a typo like '60s' surfaces at CREATE time rather than silently falling back to default
+    // and disabling the operator's intended freshness behavior.
+    String staleness = taskConfigs.get(MaterializedViewTask.STALENESS_THRESHOLD_MS_KEY);
+    if (staleness != null && !staleness.isEmpty()) {
+      try {
+        long value = Long.parseLong(staleness);
+        Preconditions.checkState(value >= 0,
+            "stalenessThresholdMs must be non-negative milliseconds, got: %s", staleness);
+      } catch (NumberFormatException e) {
+        throw new IllegalStateException(
+            "Invalid stalenessThresholdMs '" + staleness + "': must be a non-negative long (milliseconds)", e);
+      }
+    }
     return bucketMs;
   }
 
@@ -663,11 +719,11 @@ public final class MaterializedViewAnalyzer {
     Map<String, Expression> materializedViewColToSourceExpr = new HashMap<>();
 
     for (Expression expr : selectList) {
-      String outputName = extractOutputFieldName(expr);
+      String outputName = RequestUtils.extractAliasOrIdentifierName(expr);
       if (!dateTimeNames.contains(outputName)) {
         continue;
       }
-      Expression sourceExpr = extractSourceExpression(expr);
+      Expression sourceExpr = RequestUtils.unwrapAlias(expr);
       String exprString = RequestUtils.prettyPrint(sourceExpr);
       partitionExprMaps.put(exprString, outputName);
       materializedViewColToSourceExpr.put(outputName, sourceExpr);
@@ -693,15 +749,6 @@ public final class MaterializedViewAnalyzer {
     }
 
     return new PartitionExprData(partitionExprMaps, materializedViewColToSourceExpr);
-  }
-
-  /// Extracts the source expression from a SELECT item, stripping any AS alias wrapper.
-  private static Expression extractSourceExpression(Expression expr) {
-    Function func = expr.getFunctionCall();
-    if (func != null && func.getOperator().equals("as")) {
-      return func.getOperands().get(0);
-    }
-    return expr;
   }
 
   /// Convenience overload that parses the SQL and extracts partition expression maps

--- a/pinot-materialized-view/src/main/java/org/apache/pinot/materializedview/analysis/timeexpr/TimeExprValidator.java
+++ b/pinot-materialized-view/src/main/java/org/apache/pinot/materializedview/analysis/timeexpr/TimeExprValidator.java
@@ -32,33 +32,46 @@ import org.apache.pinot.spi.data.DateTimeFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
-/// Opinionated validator for the MV time column SELECT expression.  The MV-side column type is
-/// strict — it MUST be [DataType#TIMESTAMP] (epoch millis stored canonically).  The base side
+/// Opinionated validator for the MV time column SELECT expression. The MV-side column type is
+/// strict — it MUST be [DataType#TIMESTAMP] (epoch millis stored canonically). The base side
 /// is unconstrained: any base-table dateTime column is acceptable so long as the SELECT
 /// expression produces a millis-epoch value the MV can store as TIMESTAMP.
 ///
-/// ### Accepted MV time-column SELECT shapes
+/// <h3>Accepted MV time-column SELECT shapes</h3>
 ///
 ///   - **Identity passthrough**: a bare identifier equal to the base table's primary time
-///       column.  Allowed only when the base column is itself TIMESTAMP — otherwise the value
+///       column. Allowed only when the base column is itself TIMESTAMP — otherwise the value
 ///       would not be a millis-epoch in the MV.
 ///   - **`DATETRUNC('<unit>', baseTimeCol [, MILLISECONDS [, UTC [, MILLISECONDS]]])`** — the
-///       unit literal must match the table's declared `bucketTimePeriod`.  Allowed only when
-///       the base column is TIMESTAMP.  Optional trailing args, if present, must be the
+///       unit literal must match the table's declared `bucketTimePeriod`. Allowed only when
+///       the base column is TIMESTAMP. Optional trailing args, if present, must be the
 ///       defaults; non-default values are rejected to keep the semantic surface minimal.
 ///   - **Arithmetic scaling**: a chain of multiplications whose only identifier leaf is the
-///       base time column, with the remaining operands being positive integer literals.  The
-///       chain may be nested (`base * 24 * 60 * 60 * 1000`) or flat (`base * 86400000`).  This
+///       base time column, with the remaining operands being positive integer literals. The
+///       chain may be nested (`base * 24 * 60 * 60 * 1000`) or flat (`base * 86400000`). This
 ///       is the recommended form when the base column stores a coarser unit (e.g. days, seconds)
-///       and the user wants the MV to hold millis-epoch values.  The validator does NOT verify
+///       and the user wants the MV to hold millis-epoch values. The validator does NOT verify
 ///       the multiplied constants actually convert the base unit to millis — that responsibility
 ///       sits with the user, but the MV column being TIMESTAMP gives a clear contract.
 ///
 /// Anything else (DATETIMECONVERT, TODATETIME, mixed addition/subtraction, nested DATETRUNC,
 /// non-TIMESTAMP MV column type) is rejected at table-create time with an actionable message.
+///
+/// <h3>Structure</h3>
+///
+/// The file is logically two layers:
+///
+///   1. **Shape recognition** (the {@link #parse} pipeline and the
+///      {@link TimeExpression} ADT) — pure structural recognition that emits one of the three
+///      variants with literal arguments attached. No policy, no TIMESTAMP-ness check, no
+///      bucket-alignment check. {@link ParseException} surfaces structural violations.
+///   2. **Policy validation** (the {@link #validate} entry point and its helpers) — maps the
+///      recognised shape onto the TIMESTAMP / `bucketTimePeriod` / base-column-type rules
+///      above and rethrows {@link IllegalStateException} on any violation so the analyzer has
+///      a single exception type to catch.
 public final class TimeExprValidator {
 
-  /// `DATETRUNC` units that map to a fixed-size [TimeUnit].  WEEK/MONTH/QUARTER/YEAR are
+  /// `DATETRUNC` units that map to a fixed-size [TimeUnit]. WEEK/MONTH/QUARTER/YEAR are
   /// intentionally absent because their bucket size is calendar-dependent (28/29/30/31 days,
   /// etc.) and cannot be reconciled with the millis-based `bucketTimePeriod` config.
   private static final Map<String, TimeUnit> DATETRUNC_UNIT_TO_TIMEUNIT = Map.ofEntries(
@@ -68,13 +81,32 @@ public final class TimeExprValidator {
       Map.entry("HOUR", TimeUnit.HOURS),
       Map.entry("DAY", TimeUnit.DAYS));
 
+  /// Canonical name produced by [FunctionRegistry#canonicalize] for `DATETRUNC` calls.
+  /// {@code FunctionRegistry.canonicalize} strips underscores and lower-cases, so
+  /// `DATETRUNC`, `date_trunc`, `DateTrunc` all collapse to {@code "datetrunc"}.
   private static final String DATETRUNC_CANONICAL = "datetrunc";
+
+  /// Canonical name for the `*` operator (Calcite's `times` function). Pinot's parser emits
+  /// the operator name `times` for binary `*`; chained multiplications surface as nested
+  /// `times(...)` calls.
   private static final String TIMES_CANONICAL = "times";
-  private static final String DEFAULT_TIME_UNIT = TimeUnit.MILLISECONDS.name();
+
+  /// The single value the optional `DATETRUNC` `inputTimeUnit` and `outputTimeUnit`
+  /// arguments are allowed to hold. Compared case-insensitively. Non-default values would
+  /// change the result's units relative to the MV column contract (millis-epoch) and are
+  /// rejected so the inferer cannot produce an MV that the validator will later refuse —
+  /// and conversely.
+  private static final String DEFAULT_TIME_UNIT = "MILLISECONDS";
+
+  /// The single value the optional `DATETRUNC` `timeZone` argument is allowed to hold.
+  /// Compared case-insensitively. Non-UTC truncation would shift bucket boundaries relative
+  /// to `bucketTimePeriod` and is rejected.
   private static final String DEFAULT_TIMEZONE = "UTC";
 
   private TimeExprValidator() {
   }
+
+  // ─── Policy layer ──────────────────────────────────────────────────────────────────────
 
   /// Validates the MV time-column SELECT expression and the data types on both sides.
   ///
@@ -99,188 +131,344 @@ public final class TimeExprValidator {
             + "Declare the column with dataType=TIMESTAMP and format='1:MILLISECONDS:TIMESTAMP'.",
         viewTimeColName, viewTimeFieldSpec.getDataType());
 
-    ExpressionType exprType = sourceExpr.getType();
-    if (exprType == ExpressionType.IDENTIFIER) {
-      String actual = sourceExpr.getIdentifier().getName();
-      Preconditions.checkState(baseTimeColName.equals(actual),
-          "MV time column must derive from base time column '%s' (identity, DATETRUNC, or "
-              + "arithmetic scaling), got identifier '%s'.",
-          baseTimeColName, actual);
-      Preconditions.checkState(baseTimeFieldSpec.getDataType() == DataType.TIMESTAMP,
-          "Identity passthrough requires the base time column '%s' to be TIMESTAMP-typed. "
-              + "Base column data type is %s; use arithmetic scaling (e.g. '%s * 86400000') to "
-              + "convert into millis-epoch.",
-          baseTimeColName, baseTimeFieldSpec.getDataType(), baseTimeColName);
+    TimeExpression parsed;
+    try {
+      parsed = parse(sourceExpr);
+    } catch (ParseException e) {
+      // Translate the parser's domain exception into the validator's IllegalStateException
+      // contract so callers (currently only MaterializedViewAnalyzer) keep a single
+      // exception type to catch. The parser's message is preserved so it surfaces in the
+      // operator-facing error verbatim.
+      throw new IllegalStateException(e.getMessage(), e);
+    }
+
+    // The parser does NOT verify the identifier matches the base time column — that is
+    // policy, surfaced here so the error message is consistent with the validator's
+    // historical "must derive from base time column 'X'" wording.
+    Preconditions.checkState(baseTimeColName.equals(parsed.baseTimeColumnName()),
+        "MV time column must derive from base time column '%s' (identity, DATETRUNC, or "
+            + "arithmetic scaling), got identifier '%s'.",
+        baseTimeColName, parsed.baseTimeColumnName());
+
+    if (parsed instanceof IdentityPassthrough) {
+      validateIdentityPolicy(baseTimeColName, baseTimeFieldSpec);
+    } else if (parsed instanceof DateTrunc) {
+      validateDateTruncPolicy((DateTrunc) parsed,
+          baseTimeColName, baseTimeFieldSpec, bucketMs);
+    } else if (parsed instanceof ArithmeticScaling) {
+      // Arithmetic scaling is the recommended path when the base column is NOT TIMESTAMP
+      // (e.g. INT-days), so unlike identity / DATETRUNC there is no base-type guard here.
+      // The parser already verified positivity / overflow / single-identifier; nothing
+      // further to enforce.
       return;
-    }
-
-    if (exprType == ExpressionType.FUNCTION) {
-      Function func = sourceExpr.getFunctionCall();
-      Preconditions.checkState(func != null,
-          "MV time column expression is a FUNCTION but has no function call payload");
-      String canonical = FunctionRegistry.canonicalize(func.getOperator());
-      if (DATETRUNC_CANONICAL.equals(canonical)) {
-        Preconditions.checkState(baseTimeFieldSpec.getDataType() == DataType.TIMESTAMP,
-            "DATETRUNC on the MV time column requires the base time column '%s' to be "
-                + "TIMESTAMP-typed. Base column data type is %s; use arithmetic scaling instead.",
-            baseTimeColName, baseTimeFieldSpec.getDataType());
-        validateDateTrunc(func, baseTimeColName, bucketMs);
-        return;
-      }
-      if (TIMES_CANONICAL.equals(canonical)) {
-        validateArithmeticScaling(func, baseTimeColName);
-        return;
-      }
+    } else {
+      // Unreachable: the three concrete subtypes are the only inhabitants of the closed-set
+      // ADT. Defensive throw guards against a future ADT extension that forgets a branch.
       throw new IllegalStateException(
-          "MV time column expression uses unsupported function '" + func.getOperator()
-              + "'. The MV feature accepts only identity passthrough, DATETRUNC, or arithmetic "
-              + "scaling (multiplication of the base time column by integer constants).");
+          "Internal error: unhandled MV time expression variant " + parsed.getClass().getName());
     }
-
-    throw new IllegalStateException(
-        "MV time column expression must be either the base time column '" + baseTimeColName
-            + "' (identity), a DATETRUNC call, or arithmetic scaling. Got expression type: " + exprType);
   }
 
-  private static void validateDateTrunc(Function func, String baseTimeColName, long bucketMs) {
-    List<Expression> operands = func.getOperands();
-    int operandsSize = operands.size();
-    Preconditions.checkState(operandsSize >= 2 && operandsSize <= 5,
-        "DATETRUNC must be called with 2 to 5 arguments, got %s.", operandsSize);
+  private static void validateIdentityPolicy(String baseTimeColName, DateTimeFieldSpec baseTimeFieldSpec) {
+    Preconditions.checkState(baseTimeFieldSpec.getDataType() == DataType.TIMESTAMP,
+        "Identity passthrough requires the base time column '%s' to be TIMESTAMP-typed. "
+            + "Base column data type is %s; use arithmetic scaling (e.g. '%s * 86400000') to "
+            + "convert into millis-epoch.",
+        baseTimeColName, baseTimeFieldSpec.getDataType(), baseTimeColName);
+  }
 
-    String unit = requireStringLiteral(operands.get(0), "unit");
-    requireIdentifier(operands.get(1), baseTimeColName,
-        "DATETRUNC second argument must be the base time column");
+  private static void validateDateTruncPolicy(DateTrunc dt,
+      String baseTimeColName, DateTimeFieldSpec baseTimeFieldSpec, long bucketMs) {
+    Preconditions.checkState(baseTimeFieldSpec.getDataType() == DataType.TIMESTAMP,
+        "DATETRUNC on the MV time column requires the base time column '%s' to be "
+            + "TIMESTAMP-typed. Base column data type is %s; use arithmetic scaling instead.",
+        baseTimeColName, baseTimeFieldSpec.getDataType());
 
-    if (operandsSize >= 3) {
-      String inputTimeUnit = requireStringLiteral(operands.get(2), "inputTimeUnit");
-      Preconditions.checkState(DEFAULT_TIME_UNIT.equalsIgnoreCase(inputTimeUnit),
-          "DATETRUNC inputTimeUnit must be %s (base column is TIMESTAMP / millis), got '%s'.",
-          DEFAULT_TIME_UNIT, inputTimeUnit);
-    }
-    if (operandsSize >= 4) {
-      String timeZone = requireStringLiteral(operands.get(3), "timeZone");
-      Preconditions.checkState(DEFAULT_TIMEZONE.equalsIgnoreCase(timeZone),
-          "DATETRUNC timeZone must be %s, got '%s'. Non-UTC truncation would shift bucket boundaries "
-              + "relative to the bucketTimePeriod and is rejected.",
-          DEFAULT_TIMEZONE, timeZone);
-    }
-    if (operandsSize == 5) {
-      String outputTimeUnit = requireStringLiteral(operands.get(4), "outputTimeUnit");
-      Preconditions.checkState(DEFAULT_TIME_UNIT.equalsIgnoreCase(outputTimeUnit),
-          "DATETRUNC outputTimeUnit must be %s (MV column is TIMESTAMP / millis), got '%s'.",
-          DEFAULT_TIME_UNIT, outputTimeUnit);
-    }
-
-    String unitUpper = unit.toUpperCase(Locale.ROOT);
+    String unitUpper = dt.unit().toUpperCase(Locale.ROOT);
     TimeUnit truncTimeUnit = DATETRUNC_UNIT_TO_TIMEUNIT.get(unitUpper);
     Preconditions.checkState(truncTimeUnit != null,
         "DATETRUNC unit '%s' is not supported by MV. Supported units: %s. WEEK/MONTH/QUARTER/YEAR "
             + "have calendar-variable bucket sizes incompatible with bucketTimePeriod.",
-        unit, DATETRUNC_UNIT_TO_TIMEUNIT.keySet());
+        dt.unit(), DATETRUNC_UNIT_TO_TIMEUNIT.keySet());
     long truncBucketMs = truncTimeUnit.toMillis(1);
     Preconditions.checkState(truncBucketMs == bucketMs,
         "DATETRUNC unit '%s' (%s ms) does not match the declared bucketTimePeriod (%s ms). "
             + "Either change DATETRUNC to a matching unit or update bucketTimePeriod.",
-        unit, truncBucketMs, bucketMs);
+        dt.unit(), truncBucketMs, bucketMs);
   }
 
-  /// Walks a (possibly nested) chain of `times(...)` calls and verifies that exactly one leaf is
-  /// the base time column and every other leaf is a positive integer literal.  Computes the
-  /// effective scale factor as the product of all literal operands and rejects overflow.
-  private static void validateArithmeticScaling(Function root, String baseTimeColName) {
+  // ─── Structural layer: ADT + parser ────────────────────────────────────────────────────
+
+  /// Closed-set ADT for the three SELECT-list expression shapes a Materialized View accepts
+  /// as its time-column expression. Produced by {@link #parse}. Does not carry policy: it
+  /// reports the shape and the literal arguments the user wrote.
+  public abstract static class TimeExpression {
+    private final String _baseTimeColumnName;
+
+    private TimeExpression(String baseTimeColumnName) {
+      _baseTimeColumnName = baseTimeColumnName;
+    }
+
+    /// The base-table column name the user referenced, exactly as written.
+    public final String baseTimeColumnName() {
+      return _baseTimeColumnName;
+    }
+  }
+
+  /// `<baseTimeColumn>` — the SELECT item is the base time column itself.
+  public static final class IdentityPassthrough extends TimeExpression {
+    public IdentityPassthrough(String baseTimeColumnName) {
+      super(baseTimeColumnName);
+    }
+  }
+
+  /// `DATETRUNC('<unit>', <baseTimeColumn>[, ...])`. The optional trailing args, if present,
+  /// were validated by the parser to equal their defaults (MILLISECONDS / UTC / MILLISECONDS);
+  /// only `unit` varies. The unit is preserved with the user's casing.
+  public static final class DateTrunc extends TimeExpression {
+    private final String _unit;
+
+    public DateTrunc(String baseTimeColumnName, String unit) {
+      super(baseTimeColumnName);
+      _unit = unit;
+    }
+
+    public String unit() {
+      return _unit;
+    }
+  }
+
+  /// `<baseTimeColumn> * lit1 * lit2 * ...` — chained or flat multiplication. `scaleFactor`
+  /// is the product of all literal multiplicands and is guaranteed by the parser to be
+  /// strictly positive and overflow-free.
+  public static final class ArithmeticScaling extends TimeExpression {
+    private final long _scaleFactor;
+
+    public ArithmeticScaling(String baseTimeColumnName, long scaleFactor) {
+      super(baseTimeColumnName);
+      _scaleFactor = scaleFactor;
+    }
+
+    public long scaleFactor() {
+      return _scaleFactor;
+    }
+  }
+
+  /// Thrown when the input expression does not match any of the three accepted MV
+  /// time-column shapes or carries a structural violation (negative literal, non-default
+  /// DATETRUNC inputTimeUnit, etc.). Unchecked; {@link #validate} catches this and rethrows
+  /// as {@link IllegalStateException} so the analyzer has a single exception type to catch.
+  public static class ParseException extends RuntimeException {
+    public ParseException(String message) {
+      super(message);
+    }
+  }
+
+  /// Parses the alias-stripped SELECT-list expression for an MV time column into the
+  /// {@link TimeExpression} ADT.
+  ///
+  /// @param sourceExpr the [Expression] tree, with any wrapping {@code AS} already removed
+  ///                   by the caller (e.g. via {@code RequestUtils.unwrapAlias}). Must not
+  ///                   be {@code null}.
+  /// @return the recognised shape with literal arguments attached.
+  /// @throws ParseException if the expression is none of the three accepted shapes or
+  ///         violates a structural constraint of one of them (non-default DATETRUNC arg,
+  ///         non-positive literal, repeated base column reference, etc.).
+  /// @throws NullPointerException if {@code sourceExpr} is {@code null}.
+  public static TimeExpression parse(Expression sourceExpr) {
+    if (sourceExpr == null) {
+      throw new NullPointerException("sourceExpr");
+    }
+    ExpressionType exprType = sourceExpr.getType();
+    if (exprType == ExpressionType.IDENTIFIER) {
+      return new IdentityPassthrough(sourceExpr.getIdentifier().getName());
+    }
+    if (exprType == ExpressionType.FUNCTION) {
+      Function func = sourceExpr.getFunctionCall();
+      if (func == null) {
+        throw new ParseException(
+            "MV time column expression is a FUNCTION but has no function-call payload.");
+      }
+      String canonical = FunctionRegistry.canonicalize(func.getOperator());
+      if (DATETRUNC_CANONICAL.equals(canonical)) {
+        return parseDateTrunc(func);
+      }
+      if (TIMES_CANONICAL.equals(canonical)) {
+        return parseArithmeticScaling(sourceExpr);
+      }
+      throw new ParseException(
+          "MV time column expression uses unsupported function '" + func.getOperator()
+              + "'. The MV feature accepts only identity passthrough, DATETRUNC, or arithmetic "
+              + "scaling (multiplication of the base time column by integer constants).");
+    }
+    throw new ParseException(
+        "MV time column expression must be an identifier (identity passthrough), a DATETRUNC "
+            + "call, or arithmetic scaling. Got expression type: " + exprType);
+  }
+
+  /// Recognises the `DATETRUNC` shape and validates the optional trailing arguments equal
+  /// their defaults. Note: this method does NOT enforce the unit is among the MILLISECOND /
+  /// SECOND / MINUTE / HOUR / DAY whitelist — that is policy and lives in
+  /// {@link #validateDateTruncPolicy} (calendar units are rejected because their bucket size
+  /// is calendar-dependent and incompatible with `bucketTimePeriod`).
+  private static DateTrunc parseDateTrunc(Function func) {
+    List<Expression> operands = func.getOperands();
+    int operandsSize = operands == null ? 0 : operands.size();
+    if (operandsSize < 2 || operandsSize > 5) {
+      throw new ParseException(
+          "DATETRUNC must be called with 2 to 5 arguments, got " + operandsSize + ".");
+    }
+
+    String unit = requireStringLiteral(operands.get(0), "unit");
+
+    // Second arg must be a bare base-column identifier. Nested expressions
+    // (DATETRUNC('DAY', ts*1000)) are rejected because they would mix arithmetic scaling
+    // and truncation in a way the consumer's bucket-alignment check does not handle.
+    if (operands.get(1).getType() != ExpressionType.IDENTIFIER) {
+      throw new ParseException(
+          "DATETRUNC second argument must be a bare base-table time-column identifier, not a "
+              + "nested expression.");
+    }
+    String baseColumnName = operands.get(1).getIdentifier().getName();
+
+    if (operandsSize >= 3) {
+      String inputTimeUnit = requireStringLiteral(operands.get(2), "inputTimeUnit");
+      if (!DEFAULT_TIME_UNIT.equalsIgnoreCase(inputTimeUnit)) {
+        throw new ParseException(
+            "DATETRUNC inputTimeUnit must be " + DEFAULT_TIME_UNIT + " (base column is TIMESTAMP "
+                + "/ millis); got '" + inputTimeUnit + "'.");
+      }
+    }
+    if (operandsSize >= 4) {
+      String timeZone = requireStringLiteral(operands.get(3), "timeZone");
+      if (!DEFAULT_TIMEZONE.equalsIgnoreCase(timeZone)) {
+        throw new ParseException(
+            "DATETRUNC timeZone must be " + DEFAULT_TIMEZONE + ", got '" + timeZone + "'. "
+                + "Non-UTC truncation would shift bucket boundaries relative to "
+                + "bucketTimePeriod and is rejected.");
+      }
+    }
+    if (operandsSize == 5) {
+      String outputTimeUnit = requireStringLiteral(operands.get(4), "outputTimeUnit");
+      if (!DEFAULT_TIME_UNIT.equalsIgnoreCase(outputTimeUnit)) {
+        throw new ParseException(
+            "DATETRUNC outputTimeUnit must be " + DEFAULT_TIME_UNIT + " (MV column is TIMESTAMP "
+                + "/ millis); got '" + outputTimeUnit + "'.");
+      }
+    }
+
+    return new DateTrunc(baseColumnName, unit);
+  }
+
+  /// Walks a (possibly nested) chain of `times(...)` calls and verifies that exactly one
+  /// leaf is an identifier (the base time column) and every other leaf is a positive
+  /// integer literal. Computes the effective scale factor as the product of all literal
+  /// operands and rejects multiplicative overflow.
+  private static ArithmeticScaling parseArithmeticScaling(Expression sourceExpr) {
     long[] scaleHolder = {1L};
-    boolean[] sawBase = {false};
-    walkMultiplicationChain(asExpression(root), baseTimeColName, scaleHolder, sawBase);
-    Preconditions.checkState(sawBase[0],
-        "Arithmetic scaling for the MV time column must reference the base time column '%s' "
-            + "exactly once as one of the multiplicands.", baseTimeColName);
-    Preconditions.checkState(scaleHolder[0] > 0,
-        "Arithmetic scaling for the MV time column must produce a positive scale factor; "
-            + "got %s.", scaleHolder[0]);
+    String[] baseColumnHolder = {null};
+    walkMultiplicationChain(sourceExpr, scaleHolder, baseColumnHolder);
+    if (baseColumnHolder[0] == null) {
+      throw new ParseException(
+          "Arithmetic scaling for the MV time column must reference exactly one base-table "
+              + "identifier as one of the multiplicands; got none.");
+    }
+    if (scaleHolder[0] <= 0) {
+      throw new ParseException(
+          "Arithmetic scaling for the MV time column must produce a positive scale factor; got "
+              + scaleHolder[0] + ".");
+    }
+    return new ArithmeticScaling(baseColumnHolder[0], scaleHolder[0]);
   }
 
-  private static Expression asExpression(Function func) {
-    Expression expr = new Expression(ExpressionType.FUNCTION);
-    expr.setFunctionCall(func);
-    return expr;
-  }
-
-  private static void walkMultiplicationChain(Expression node, String baseTimeColName,
-      long[] scaleHolder, boolean[] sawBase) {
+  /// Recursive helper: walks any node in the `times` chain. Identifier leaves are recorded
+  /// as the base column (rejected on second sighting); literal leaves are folded into the
+  /// running product (overflow-checked); nested function nodes must be further `times(...)`
+  /// calls.
+  private static void walkMultiplicationChain(Expression node, long[] scaleHolder, String[] baseColumnHolder) {
     ExpressionType type = node.getType();
     if (type == ExpressionType.IDENTIFIER) {
       String name = node.getIdentifier().getName();
-      Preconditions.checkState(baseTimeColName.equals(name),
-          "Arithmetic scaling for the MV time column may only reference the base time column "
-              + "'%s'; got identifier '%s'.",
-          baseTimeColName, name);
-      Preconditions.checkState(!sawBase[0],
-          "Arithmetic scaling for the MV time column must reference the base time column '%s' "
-              + "exactly once; saw it more than once.",
-          baseTimeColName);
-      sawBase[0] = true;
+      if (baseColumnHolder[0] != null) {
+        throw new ParseException(
+            "Arithmetic scaling for the MV time column must reference exactly one base-table "
+                + "identifier; saw both '" + baseColumnHolder[0] + "' and '" + name + "'.");
+      }
+      baseColumnHolder[0] = name;
       return;
     }
     if (type == ExpressionType.LITERAL) {
       long literal = requirePositiveIntegerLiteral(node);
-      // Multiplicative overflow guard — bucketTimePeriod*days*hours*... must stay positive.
-      Preconditions.checkState(scaleHolder[0] <= Long.MAX_VALUE / literal,
-          "Arithmetic scaling for the MV time column overflows; literal operand %s pushes the "
-              + "running product past Long.MAX_VALUE.", literal);
+      // Multiplicative overflow guard — `scaleHolder * literal` must stay below
+      // Long.MAX_VALUE. Using division avoids the well-known signed-overflow trap of
+      // checking `> 0` on the post-multiply result.
+      if (scaleHolder[0] > Long.MAX_VALUE / literal) {
+        throw new ParseException(
+            "Arithmetic scaling for the MV time column overflows; literal operand " + literal
+                + " pushes the running product past Long.MAX_VALUE.");
+      }
       scaleHolder[0] *= literal;
       return;
     }
-    Preconditions.checkState(type == ExpressionType.FUNCTION,
-        "Arithmetic scaling for the MV time column accepts only identifier or literal operands "
-            + "at the leaves, got expression type: %s",
-        type);
+    if (type != ExpressionType.FUNCTION) {
+      throw new ParseException(
+          "Arithmetic scaling for the MV time column accepts only identifier or literal operands "
+              + "at the leaves; got expression type: " + type);
+    }
     Function func = node.getFunctionCall();
     String canonical = FunctionRegistry.canonicalize(func.getOperator());
-    Preconditions.checkState(TIMES_CANONICAL.equals(canonical),
-        "Arithmetic scaling for the MV time column accepts only chained multiplication; got '%s'. "
-            + "Use a single `times` chain such as `%s * 86400000`.",
-        func.getOperator(), baseTimeColName);
+    if (!TIMES_CANONICAL.equals(canonical)) {
+      throw new ParseException(
+          "Arithmetic scaling for the MV time column accepts only chained multiplication; got '"
+              + func.getOperator() + "'. Use a single `times` chain such as "
+              + "'<baseTimeColumn> * 86400000'.");
+    }
     for (Expression operand : func.getOperands()) {
-      walkMultiplicationChain(operand, baseTimeColName, scaleHolder, sawBase);
+      walkMultiplicationChain(operand, scaleHolder, baseColumnHolder);
     }
   }
 
+  /// Coerces a positive integer literal (INT or LONG) into a `long`. Rejects floating point,
+  /// decimal, string, etc., as well as zero / negative values — both because negative
+  /// scaling is meaningless for a millis-epoch MV column and because zero would collapse
+  /// the range to a constant.
   private static long requirePositiveIntegerLiteral(Expression expr) {
     Literal literal = expr.getLiteral();
-    Preconditions.checkState(literal != null,
-        "Arithmetic scaling for the MV time column requires positive integer literal operands.");
+    if (literal == null) {
+      throw new ParseException(
+          "Arithmetic scaling for the MV time column requires positive integer literal operands.");
+    }
     long value;
     if (literal.isSetLongValue()) {
       value = literal.getLongValue();
     } else if (literal.isSetIntValue()) {
       value = literal.getIntValue();
     } else {
-      throw new IllegalStateException(
+      throw new ParseException(
           "Arithmetic scaling for the MV time column requires positive integer literal operands; "
               + "non-integer literal: " + literal);
     }
-    Preconditions.checkState(value > 0,
-        "Arithmetic scaling for the MV time column requires positive integer literal operands; "
-            + "got %s.", value);
+    if (value <= 0) {
+      throw new ParseException(
+          "Arithmetic scaling for the MV time column requires positive integer literal operands; "
+              + "got " + value + ".");
+    }
     return value;
   }
 
+  /// Coerces a string-literal expression into its raw `String` value. Rejects any other
+  /// literal kind (int / long / boolean / etc.) so DATETRUNC's string-typed arguments cannot
+  /// be silently confused with their integer counterparts.
   private static String requireStringLiteral(Expression expr, String argName) {
-    Preconditions.checkState(expr.getType() == ExpressionType.LITERAL,
-        "DATETRUNC argument '%s' must be a string literal.", argName);
+    if (expr.getType() != ExpressionType.LITERAL) {
+      throw new ParseException(
+          "DATETRUNC argument '" + argName + "' must be a string literal.");
+    }
     Literal literal = expr.getLiteral();
-    Preconditions.checkState(literal != null && literal.isSetStringValue(),
-        "DATETRUNC argument '%s' must be a string literal.", argName);
+    if (literal == null || !literal.isSetStringValue()) {
+      throw new ParseException(
+          "DATETRUNC argument '" + argName + "' must be a string literal.");
+    }
     return literal.getStringValue();
-  }
-
-  private static void requireIdentifier(Expression expr, String baseTimeColName, String contextMessage) {
-    Preconditions.checkState(expr.getType() == ExpressionType.IDENTIFIER,
-        "%s '%s' as a bare identifier, not a nested expression.",
-        contextMessage, baseTimeColName);
-    String actual = expr.getIdentifier().getName();
-    Preconditions.checkState(baseTimeColName.equals(actual),
-        "%s '%s', got '%s'.", contextMessage, baseTimeColName, actual);
   }
 }

--- a/pinot-materialized-view/src/main/java/org/apache/pinot/materializedview/consistency/MaterializedViewConsistencyManager.java
+++ b/pinot-materialized-view/src/main/java/org/apache/pinot/materializedview/consistency/MaterializedViewConsistencyManager.java
@@ -532,6 +532,18 @@ public class MaterializedViewConsistencyManager {
 
     for (String viewTableName : children) {
       try {
+        // Verify the MV's TableConfig still exists and is an MV. A previous DROP that
+        // succeeded at removing the TableConfig but failed best-effort znode cleanup would
+        // leave a stale definition znode here; re-registering it would resurrect a ghost
+        // MV that source-table updates would chase. Skip the orphan and surface a WARN so
+        // operators can clean up the stranded znode.
+        TableConfig viewConfig = ZKMetadataProvider.getTableConfig(_propertyStore, viewTableName);
+        if (viewConfig == null || !viewConfig.isMaterializedView()) {
+          LOGGER.warn("Skipping orphan MV definition znode '{}': underlying TableConfig is "
+              + "missing or no longer an MV. Operator should DELETE /materializedViewDefinitions "
+              + "to remove the stale znode.", viewTableName);
+          continue;
+        }
         String fullPath = defBasePath + "/" + viewTableName;
         ZNRecord record = _propertyStore.get(fullPath, null, AccessOption.PERSISTENT);
         if (record == null) {

--- a/pinot-materialized-view/src/main/java/org/apache/pinot/materializedview/metadata/MaterializedViewDefinitionMetadata.java
+++ b/pinot-materialized-view/src/main/java/org/apache/pinot/materializedview/metadata/MaterializedViewDefinitionMetadata.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import javax.annotation.Nullable;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.pinot.spi.utils.JsonUtils;
@@ -197,6 +198,50 @@ public class MaterializedViewDefinitionMetadata {
     }
   }
 
+  /// Value equality used by the controller-side DDL endpoint to distinguish "idempotent retry"
+  /// (same content as existing znode → proceed) from "stale orphan from a different definedSQL"
+  /// (mismatch → fail 409).
+  ///
+  /// Coverage at this outer level: every direct field of
+  /// [MaterializedViewDefinitionMetadata] is compared
+  /// (`_materializedViewTableNameWithType`, `_baseTables`, `_definedSql`, `_partitionExprMaps`,
+  /// `_splitSpec`, `_stalenessThresholdMs`, `_rewriteEnabled`).
+  ///
+  /// Caveat about the nested [MaterializedViewSplitSpec]: its own equals/hashCode currently
+  /// covers only `sourceTimeColumn`, `sourceTimeFormat`, `materializedViewTimeColumn`, and
+  /// `bucketMs`. `materializedViewTimeFormat` is persisted in the ZNRecord but intentionally
+  /// excluded from equality today (it was added after the existing equals/hashCode and is
+  /// tracked as a separate follow-up — see `MaterializedViewMetadataTest#testSplitSpecEquals
+  /// AndHashCode` which pins the current contract). Two definitions that differ ONLY in
+  /// `splitSpec.materializedViewTimeFormat` will therefore compare equal here. This is by
+  /// design and acceptable because the controller's idempotency check (`createIfAbsent`) only
+  /// uses this comparison to short-circuit a redundant write; differing time formats with
+  /// otherwise identical SplitSpecs cannot occur for the same MV produced by today's compiler
+  /// pipeline.
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+    if (!(o instanceof MaterializedViewDefinitionMetadata)) {
+      return false;
+    }
+    MaterializedViewDefinitionMetadata other = (MaterializedViewDefinitionMetadata) o;
+    return _stalenessThresholdMs == other._stalenessThresholdMs
+        && _rewriteEnabled == other._rewriteEnabled
+        && Objects.equals(_materializedViewTableNameWithType, other._materializedViewTableNameWithType)
+        && Objects.equals(_baseTables, other._baseTables)
+        && Objects.equals(_definedSql, other._definedSql)
+        && Objects.equals(_partitionExprMaps, other._partitionExprMaps)
+        && Objects.equals(_splitSpec, other._splitSpec);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(_materializedViewTableNameWithType, _baseTables, _definedSql,
+        _partitionExprMaps, _splitSpec, _stalenessThresholdMs, _rewriteEnabled);
+  }
+
   /// Specifies the time columns used to express the split boundary `watermarkMs`:
   ///
   ///   - Source (base) side: filter `sourceTimeColumn >= watermarkMs`. The base column may use
@@ -241,6 +286,26 @@ public class MaterializedViewDefinitionMetadata {
 
     public long getBucketMs() {
       return _bucketMs;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof MaterializedViewSplitSpec)) {
+        return false;
+      }
+      MaterializedViewSplitSpec other = (MaterializedViewSplitSpec) o;
+      return _bucketMs == other._bucketMs
+          && Objects.equals(_sourceTimeColumn, other._sourceTimeColumn)
+          && Objects.equals(_sourceTimeFormat, other._sourceTimeFormat)
+          && Objects.equals(_materializedViewTimeColumn, other._materializedViewTimeColumn);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(_sourceTimeColumn, _sourceTimeFormat, _materializedViewTimeColumn, _bucketMs);
     }
   }
 }

--- a/pinot-materialized-view/src/main/java/org/apache/pinot/materializedview/metadata/MaterializedViewDefinitionMetadataBuilder.java
+++ b/pinot-materialized-view/src/main/java/org/apache/pinot/materializedview/metadata/MaterializedViewDefinitionMetadataBuilder.java
@@ -1,0 +1,183 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.materializedview.metadata;
+
+import com.google.common.base.Preconditions;
+import java.util.Collections;
+import java.util.Map;
+import org.apache.pinot.materializedview.metadata.MaterializedViewDefinitionMetadata.MaterializedViewSplitSpec;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableTaskConfig;
+import org.apache.pinot.spi.data.DateTimeFieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.CommonConstants.MaterializedViewTask;
+import org.apache.pinot.spi.utils.TimeUtils;
+
+
+/// Single source of truth for constructing a [MaterializedViewDefinitionMetadata] from a
+/// fully-validated `(viewTableConfig, viewSchema, sourceTableConfig, sourceSchema)` quadruple
+/// plus the `definedSQL` and analyzer-derived `partitionExprMaps`.
+///
+/// Two call sites use this builder, and they MUST produce byte-identical metadata for the
+/// same MV so the "create-if-absent" idempotence in
+/// [MaterializedViewDefinitionMetadataUtils#createIfAbsent] is safe across both paths:
+///
+///   1. The controller-side `CREATE MATERIALIZED VIEW` DDL endpoint persists the znode
+///      immediately so `notifyMaterializedViewConsistencyManagerForTableCreate` finds it
+///      during the same `addTable` call and registers the MV with its authoritative
+///      `baseTables` list (the fallback path is fragile under any future relaxation of the
+///      analyzer's single-FROM contract).
+///   2. The minion-side `MaterializedViewTaskScheduler` lazy-initialises the znode on
+///      cold-start when the controller-side write did not happen — e.g. an MV created before
+///      this builder existed, or an MV whose CREATE failed midway and was recovered.
+///
+/// This class does NOT re-run MV validation: every caller MUST have already invoked
+/// [org.apache.pinot.materializedview.analysis.MaterializedViewAnalyzer#analyze] (directly
+/// or transitively via `TaskConfigUtils.validateTaskConfigs`) against the same inputs.
+/// Preconditions here are tight invariants that a successful `analyze()` guarantees; failing
+/// them indicates a bug or hand-edited cluster state, not a user-facing error.
+public final class MaterializedViewDefinitionMetadataBuilder {
+
+  private MaterializedViewDefinitionMetadataBuilder() {
+  }
+
+  /// Builds the definition metadata for an MV.
+  ///
+  /// @param viewTableNameWithType  the MV's fully-qualified name (must end with `_OFFLINE`)
+  /// @param viewTableConfig        the MV's [TableConfig] (must have
+  ///                               `isMaterializedView=true` and a configured
+  ///                               `MaterializedViewTask` task config with `bucketTimePeriod`)
+  /// @param viewSchema             the MV's [Schema] (must declare a [DateTimeFieldSpec] for
+  ///                               the MV's time column). Required so the persisted split spec
+  ///                               carries the MV-side `getFormat()` value alongside the
+  ///                               source-side one — base and MV time columns may use
+  ///                               different `DateTimeFieldSpec` formats, and broker-side
+  ///                               split-query rewriting needs both to convert window
+  ///                               boundaries into each side's native unit.
+  /// @param sourceTableConfig      the source/base table's [TableConfig] (must have
+  ///                               `validationConfig.timeColumnName` set)
+  /// @param sourceSchema           the source/base table's [Schema] (must declare a
+  ///                               [DateTimeFieldSpec] for the source's time column)
+  /// @param sourceRawTableName     the raw source table name as it appears in the MV's
+  ///                               `FROM` clause. This is the key the consistency manager
+  ///                               indexes by (it strips the `_OFFLINE`/`_REALTIME` suffix
+  ///                               internally), so we persist the raw name here even when the
+  ///                               resolved source happens to be a hybrid pair — the
+  ///                               consistency manager reverse-index entry is per raw name.
+  /// @param definedSql             the MV's `AS <query>` body, exactly as persisted under
+  ///                               `task.MaterializedViewTask.definedSQL`
+  /// @param partitionExprMaps      analyzer-derived `exprString -> mvColumn` map
+  public static MaterializedViewDefinitionMetadata build(String viewTableNameWithType,
+      TableConfig viewTableConfig, Schema viewSchema, TableConfig sourceTableConfig,
+      Schema sourceSchema, String sourceRawTableName, String definedSql,
+      Map<String, String> partitionExprMaps) {
+    Preconditions.checkArgument(viewTableNameWithType != null && !viewTableNameWithType.isEmpty(),
+        "viewTableNameWithType must be set");
+    Preconditions.checkArgument(viewTableConfig != null, "viewTableConfig must be set");
+    Preconditions.checkArgument(viewTableConfig.isMaterializedView(),
+        "viewTableConfig.isMaterializedView must be true for: %s", viewTableNameWithType);
+    Preconditions.checkArgument(viewSchema != null, "viewSchema must be set");
+    Preconditions.checkArgument(sourceTableConfig != null, "sourceTableConfig must be set");
+    Preconditions.checkArgument(sourceSchema != null, "sourceSchema must be set");
+    Preconditions.checkArgument(sourceRawTableName != null && !sourceRawTableName.isEmpty(),
+        "sourceRawTableName must be set");
+    Preconditions.checkArgument(definedSql != null && !definedSql.isEmpty(),
+        "definedSql must be set");
+    Preconditions.checkArgument(partitionExprMaps != null, "partitionExprMaps must be set");
+
+    TableTaskConfig viewTaskConfig = viewTableConfig.getTaskConfig();
+    Preconditions.checkState(viewTaskConfig != null,
+        "MV table %s must have a TableTaskConfig", viewTableNameWithType);
+    Map<String, String> mvTaskConfigs =
+        viewTaskConfig.getConfigsForTaskType(MaterializedViewTask.TASK_TYPE);
+    Preconditions.checkState(mvTaskConfigs != null,
+        "MV table %s must have MaterializedViewTask configs", viewTableNameWithType);
+
+    // Bucket — required. `validateMaterializedViewConsistency` (compile-side) and
+    // `MaterializedViewAnalyzer.validateTaskConfigs` (controller-side) both enforce this is
+    // present and parseable before we get here; re-checking returns the same Pinot period
+    // representation so the value reaches the znode unchanged.
+    String bucketTimePeriod = mvTaskConfigs.get(MaterializedViewTask.BUCKET_TIME_PERIOD_KEY);
+    Preconditions.checkState(bucketTimePeriod != null && !bucketTimePeriod.isEmpty(),
+        "MV table %s missing %s in MaterializedViewTask configs",
+        viewTableNameWithType, MaterializedViewTask.BUCKET_TIME_PERIOD_KEY);
+    long bucketMs = TimeUtils.convertPeriodToMillis(bucketTimePeriod);
+    Preconditions.checkState(bucketMs > 0,
+        "MV table %s bucketTimePeriod must produce positive ms, got: %s",
+        viewTableNameWithType, bucketTimePeriod);
+
+    // Staleness — optional, defaults to the constant. Validation happens up-front in
+    // `MaterializedViewAnalyzer.validateTaskConfigs`; this fallback exists for the
+    // backfill/recovery path that runs on already-persisted znodes (which may predate the
+    // analyzer-side check), so silent fallback is the right behavior here.
+    long stalenessThresholdMs = parseLongOrDefault(
+        mvTaskConfigs.get(MaterializedViewTask.STALENESS_THRESHOLD_MS_KEY),
+        MaterializedViewTask.DEFAULT_STALENESS_THRESHOLD_MS);
+
+    // Source side: time column + format. `MaterializedViewAnalyzer.validateSourceTable`
+    // guarantees the source has a non-empty `timeColumnName` and a `DateTimeFieldSpec`.
+    String sourceTimeColumn = sourceTableConfig.getValidationConfig().getTimeColumnName();
+    Preconditions.checkState(sourceTimeColumn != null && !sourceTimeColumn.isEmpty(),
+        "Source table %s missing timeColumnName (MV: %s)",
+        sourceTableConfig.getTableName(), viewTableNameWithType);
+    DateTimeFieldSpec sourceTimeFieldSpec = sourceSchema.getSpecForTimeColumn(sourceTimeColumn);
+    Preconditions.checkState(sourceTimeFieldSpec != null,
+        "Source table %s has no DateTimeFieldSpec for time column '%s' (MV: %s)",
+        sourceTableConfig.getTableName(), sourceTimeColumn, viewTableNameWithType);
+
+    // MV side: time column + format. `MaterializedViewAnalyzer.validateMaterializedViewTimeColumnAlignment`
+    // guarantees the column is set, exists in the MV schema as a DateTimeFieldSpec, and is
+    // produced by the SELECT. We resolve the format here from the MV schema (mirroring the
+    // scheduler's `resolveMaterializedViewTimeFormat`) so the persisted split spec carries
+    // both source and MV `getFormat()` values — broker-side split-query rewriting needs each
+    // side independently because base and MV time columns may use different formats.
+    String viewTimeColumn = viewTableConfig.getValidationConfig().getTimeColumnName();
+    Preconditions.checkState(viewTimeColumn != null && !viewTimeColumn.isEmpty(),
+        "MV table %s missing timeColumnName", viewTableNameWithType);
+    DateTimeFieldSpec viewTimeFieldSpec = viewSchema.getSpecForTimeColumn(viewTimeColumn);
+    Preconditions.checkState(viewTimeFieldSpec != null,
+        "MV table %s has no DateTimeFieldSpec for time column '%s'",
+        viewTableNameWithType, viewTimeColumn);
+
+    MaterializedViewSplitSpec splitSpec = new MaterializedViewSplitSpec(
+        sourceTimeColumn, sourceTimeFieldSpec.getFormat(),
+        viewTimeColumn, viewTimeFieldSpec.getFormat(),
+        bucketMs);
+
+    return new MaterializedViewDefinitionMetadata(
+        viewTableNameWithType,
+        Collections.singletonList(sourceRawTableName),
+        definedSql,
+        partitionExprMaps,
+        splitSpec,
+        stalenessThresholdMs,
+        /*rewriteEnabled=*/ true);
+  }
+
+  private static long parseLongOrDefault(String value, long defaultValue) {
+    if (value == null || value.isEmpty()) {
+      return defaultValue;
+    }
+    try {
+      return Long.parseLong(value);
+    } catch (NumberFormatException e) {
+      return defaultValue;
+    }
+  }
+}

--- a/pinot-materialized-view/src/test/java/org/apache/pinot/materializedview/analysis/MaterializedViewAnalyzerTest.java
+++ b/pinot-materialized-view/src/test/java/org/apache/pinot/materializedview/analysis/MaterializedViewAnalyzerTest.java
@@ -464,6 +464,24 @@ public class MaterializedViewAnalyzerTest {
     expectError(sql, viewSchema, "No DateTimeFieldSpec found");
   }
 
+  @Test
+  public void testRejectsJoinInFromClause() {
+    // CalciteSqlParser routes JOIN into DataSource.join rather than DataSource.tableName.
+    // Without the explicit JOIN guard the test would still fail, but with the misleading
+    // "Could not extract source table name from SQL" message. The new guard surfaces the
+    // actual unsupported-construct cause directly.
+    String sql = "SELECT DaysSinceEpoch, city, count(*) AS cnt FROM orders "
+        + "JOIN products ON orders.product_id = products.id "
+        + "GROUP BY DaysSinceEpoch, city";
+    Schema viewSchema = new Schema.SchemaBuilder()
+        .addSingleValueDimension("city", FieldSpec.DataType.STRING)
+        .addMetric("cnt", FieldSpec.DataType.LONG)
+        .addDateTime(TIME_COLUMN, FieldSpec.DataType.TIMESTAMP, "1:MILLISECONDS:TIMESTAMP", "1:MILLISECONDS")
+        .build();
+
+    expectError(sql, viewSchema, "JOIN queries are not supported");
+  }
+
   // -----------------------------------------------------------------------
   //  Source-table type eligibility (Step 2): MV's coverage model assumes the base table is
   //  append-only with monotonically advancing time. Tables whose contents can be replaced or
@@ -608,6 +626,40 @@ public class MaterializedViewAnalyzerTest {
     expectError(sql, viewSchema, "does not exist in source table");
   }
 
+  @Test
+  public void testWhereClauseColumnNotExist() {
+    // A typo in a WHERE predicate (here `nonexistent_col` instead of an actual source column)
+    // would previously slip past create-time validation because validateSourceColumns only
+    // walked SELECT + GROUP BY, then surface as a broker error at task-execution time. The
+    // analyzer now walks the filter tree so the operator sees the diagnostic at DDL time.
+    String sql = "SELECT DaysSinceEpoch, city, count(*) AS cnt FROM orders "
+        + "WHERE nonexistent_col = 42 "
+        + "GROUP BY DaysSinceEpoch, city";
+    Schema viewSchema = new Schema.SchemaBuilder()
+        .addSingleValueDimension("city", FieldSpec.DataType.STRING)
+        .addMetric("cnt", FieldSpec.DataType.LONG)
+        .addDateTime(TIME_COLUMN, FieldSpec.DataType.TIMESTAMP, "1:MILLISECONDS:TIMESTAMP", "1:MILLISECONDS")
+        .build();
+
+    expectError(sql, viewSchema, "does not exist in source table");
+  }
+
+  @Test
+  public void testHavingClauseColumnNotExist() {
+    // Same hazard as the WHERE case but for HAVING — exercised separately because the
+    // analyzer reads HAVING from a different PinotQuery accessor.
+    String sql = "SELECT DaysSinceEpoch, city, count(*) AS cnt FROM orders "
+        + "GROUP BY DaysSinceEpoch, city "
+        + "HAVING sum(nonexistent_col) > 0";
+    Schema viewSchema = new Schema.SchemaBuilder()
+        .addSingleValueDimension("city", FieldSpec.DataType.STRING)
+        .addMetric("cnt", FieldSpec.DataType.LONG)
+        .addDateTime(TIME_COLUMN, FieldSpec.DataType.TIMESTAMP, "1:MILLISECONDS:TIMESTAMP", "1:MILLISECONDS")
+        .build();
+
+    expectError(sql, viewSchema, "does not exist in source table");
+  }
+
   // -----------------------------------------------------------------------
   //  Step 3: MV schema column validation
   // -----------------------------------------------------------------------
@@ -669,7 +721,26 @@ public class MaterializedViewAnalyzerTest {
         .addDateTime(TIME_COLUMN, FieldSpec.DataType.TIMESTAMP, "1:MILLISECONDS:TIMESTAMP", "1:MILLISECONDS")
         .build();
 
-    expectError(sql, viewSchema, "must have an AS alias");
+    // Helper now lives in RequestUtils and emits a slightly broader message that covers
+    // both accepted shapes (bare column or AS <alias>).
+    expectError(sql, viewSchema, "use AS <alias>");
+  }
+
+  @Test
+  public void testRejectsSelectStar() {
+    // `SELECT *` would otherwise reach the schema-coverage check with a single SELECT field
+    // literally named "*", producing the misleading "MV schema column 'X' is not produced
+    // by any SELECT expression" error. The explicit guard names the unsupported construct
+    // so the operator immediately knows to enumerate columns with aliases.
+    String sql = "SELECT * FROM orders";
+    Schema viewSchema = new Schema.SchemaBuilder()
+        .addSingleValueDimension("city", FieldSpec.DataType.STRING)
+        .addSingleValueDimension("status", FieldSpec.DataType.STRING)
+        .addMetric("amount", FieldSpec.DataType.DOUBLE)
+        .addDateTime(TIME_COLUMN, FieldSpec.DataType.TIMESTAMP, "1:MILLISECONDS:TIMESTAMP", "1:MILLISECONDS")
+        .build();
+
+    expectError(sql, viewSchema, "does not support `SELECT *`");
   }
 
   // -----------------------------------------------------------------------
@@ -769,6 +840,50 @@ public class MaterializedViewAnalyzerTest {
     expectError(sql, viewSchema, taskConfigs, "Invalid maxNumRecordsPerSegment");
   }
 
+  @Test
+  public void testNonNumericStalenessThresholdMs() {
+    // A typo like '60s' would silently fall back to the default at the builder/scheduler
+    // level, masking the operator's intent. Analyzer must reject loudly at CREATE time.
+    String sql = "SELECT DaysSinceEpoch, city, count(*) AS cnt FROM orders GROUP BY DaysSinceEpoch, city";
+    Schema viewSchema = new Schema.SchemaBuilder()
+        .addSingleValueDimension("city", FieldSpec.DataType.STRING)
+        .addMetric("cnt", FieldSpec.DataType.LONG)
+        .addDateTime(TIME_COLUMN, FieldSpec.DataType.TIMESTAMP, "1:MILLISECONDS:TIMESTAMP", "1:MILLISECONDS")
+        .build();
+    Map<String, String> taskConfigs = buildTaskConfigs(sql);
+    taskConfigs.put(MaterializedViewTask.STALENESS_THRESHOLD_MS_KEY, "60s");
+    expectError(sql, viewSchema, taskConfigs, "Invalid stalenessThresholdMs");
+  }
+
+  @Test
+  public void testNegativeStalenessThresholdMsRejected() {
+    String sql = "SELECT DaysSinceEpoch, city, count(*) AS cnt FROM orders GROUP BY DaysSinceEpoch, city";
+    Schema viewSchema = new Schema.SchemaBuilder()
+        .addSingleValueDimension("city", FieldSpec.DataType.STRING)
+        .addMetric("cnt", FieldSpec.DataType.LONG)
+        .addDateTime(TIME_COLUMN, FieldSpec.DataType.TIMESTAMP, "1:MILLISECONDS:TIMESTAMP", "1:MILLISECONDS")
+        .build();
+    Map<String, String> taskConfigs = buildTaskConfigs(sql);
+    taskConfigs.put(MaterializedViewTask.STALENESS_THRESHOLD_MS_KEY, "-1");
+    expectError(sql, viewSchema, taskConfigs, "stalenessThresholdMs must be non-negative");
+  }
+
+  @Test
+  public void testZeroStalenessThresholdMsAccepted() {
+    // 0 is the documented "no SLO" sentinel — the rewrite engine treats <= 0 as disabled.
+    // An explicit '0' must round-trip without rejection.
+    String sql = "SELECT DaysSinceEpoch, city, count(*) AS cnt FROM orders GROUP BY DaysSinceEpoch, city";
+    Schema viewSchema = new Schema.SchemaBuilder()
+        .addSingleValueDimension("city", FieldSpec.DataType.STRING)
+        .addMetric("cnt", FieldSpec.DataType.LONG)
+        .addDateTime(TIME_COLUMN, FieldSpec.DataType.TIMESTAMP, "1:MILLISECONDS:TIMESTAMP", "1:MILLISECONDS")
+        .build();
+    TableConfig viewTableConfig = buildMaterializedViewTableConfig();
+    Map<String, String> taskConfigs = buildTaskConfigs(sql);
+    taskConfigs.put(MaterializedViewTask.STALENESS_THRESHOLD_MS_KEY, "0");
+    MaterializedViewAnalyzer.analyze(withLimit(sql), viewTableConfig, viewSchema, taskConfigs, _mockAccessor);
+  }
+
   // -----------------------------------------------------------------------
   //  Complex SQL
   // -----------------------------------------------------------------------
@@ -831,6 +946,72 @@ public class MaterializedViewAnalyzerTest {
       assertTrue(e.getMessage().contains("REALTIME"),
           "Unexpected message: " + e.getMessage());
     }
+  }
+
+  @Test
+  public void testRejectsHybridSourceTable() {
+    // When both `_OFFLINE` and `_REALTIME` variants exist, the raw source name is ambiguous:
+    // the broker would silently hybrid-route the persisted definedSQL at query time while
+    // STALE-marking only covered the OFFLINE half (LLC realtime commits bypass the MV
+    // consistency manager).  The resolver MUST fail fast so a misconfigured MV never reaches
+    // cluster metadata — the OFFLINE-first preference that used to silently let hybrid bases
+    // through is exactly the silent-drift trap this guard closes.
+    String hybridTable = "hybrid_orders";
+    TableConfig offlineCfg = new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName(hybridTable + "_OFFLINE")
+        .setTimeColumnName(TIME_COLUMN)
+        .build();
+    TableConfig realtimeCfg = new TableConfigBuilder(TableType.REALTIME)
+        .setTableName(hybridTable + "_REALTIME")
+        .setTimeColumnName(TIME_COLUMN)
+        .build();
+    Schema hybridSchema = new Schema.SchemaBuilder()
+        .addSingleValueDimension("city", FieldSpec.DataType.STRING)
+        .addDateTime(TIME_COLUMN, FieldSpec.DataType.TIMESTAMP, "1:MILLISECONDS:TIMESTAMP", "1:MILLISECONDS")
+        .build();
+    stubTable(hybridTable + "_OFFLINE", offlineCfg, hybridSchema);
+    stubTable(hybridTable + "_REALTIME", realtimeCfg, hybridSchema);
+
+    String sql = "SELECT DaysSinceEpoch, city FROM " + hybridTable;
+    Schema viewSchema = new Schema.SchemaBuilder()
+        .addSingleValueDimension("city", FieldSpec.DataType.STRING)
+        .addDateTime(TIME_COLUMN, FieldSpec.DataType.TIMESTAMP, "1:MILLISECONDS:TIMESTAMP", "1:MILLISECONDS")
+        .build();
+    TableConfig viewTableConfig = buildMaterializedViewTableConfig();
+    Map<String, String> taskConfigs = buildTaskConfigs(sql);
+
+    try {
+      MaterializedViewAnalyzer.analyze(withLimit(sql), viewTableConfig, viewSchema, taskConfigs, _mockAccessor);
+      fail("Expected IllegalStateException for hybrid source table");
+    } catch (IllegalStateException e) {
+      assertTrue(e.getMessage().contains("hybrid"),
+          "Expected 'hybrid' in error message, got: " + e.getMessage());
+      assertTrue(e.getMessage().contains(hybridTable),
+          "Expected source table name in error message, got: " + e.getMessage());
+    }
+  }
+
+  @Test
+  public void testAcceptsOfflineOnlySource() {
+    // Regression guard for the hybrid-rejection change: when only the OFFLINE variant exists,
+    // the resolver must still succeed.  The default `setUp()` already stubs SOURCE_TABLE_OFFLINE
+    // only; explicitly stub the REALTIME variant as absent to make the OFFLINE-only intent
+    // unambiguous against future mock setup churn.
+    stubTable(SOURCE_TABLE + "_REALTIME", null, null);
+
+    String sql = "SELECT DaysSinceEpoch, city, count(*) AS cnt FROM orders GROUP BY DaysSinceEpoch, city";
+    Schema viewSchema = new Schema.SchemaBuilder()
+        .addSingleValueDimension("city", FieldSpec.DataType.STRING)
+        .addMetric("cnt", FieldSpec.DataType.LONG)
+        .addDateTime(TIME_COLUMN, FieldSpec.DataType.TIMESTAMP, "1:MILLISECONDS:TIMESTAMP", "1:MILLISECONDS")
+        .build();
+    TableConfig viewTableConfig = buildMaterializedViewTableConfig();
+    Map<String, String> taskConfigs = buildTaskConfigs(sql);
+
+    MaterializedViewAnalyzer.AnalysisResult result =
+        MaterializedViewAnalyzer.analyze(withLimit(sql), viewTableConfig, viewSchema, taskConfigs, _mockAccessor);
+    assertNotNull(result);
+    assertEquals(result.getSourceTableName(), SOURCE_TABLE);
   }
 
   // -----------------------------------------------------------------------
@@ -1102,8 +1283,12 @@ public class MaterializedViewAnalyzerTest {
         .build();
     Map<String, String> taskConfigs = buildTaskConfigs(sql);
 
+    // Wording comes from MaterializedViewTimeExpressionParser, which the validator delegates
+    // to for shape recognition; matching on the substring
+    // "second argument" keeps this test stable across parser-message wording tweaks while
+    // still asserting the rejection lands on the right argument.
     expectErrorRaw(withLimit(sql), viewSchema, viewTableConfig, taskConfigs,
-        "second argument must be the base time column");
+        "second argument");
   }
 
 

--- a/pinot-materialized-view/src/test/java/org/apache/pinot/materializedview/analysis/timeexpr/TimeExprParserTest.java
+++ b/pinot-materialized-view/src/test/java/org/apache/pinot/materializedview/analysis/timeexpr/TimeExprParserTest.java
@@ -1,0 +1,294 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.materializedview.analysis.timeexpr;
+
+import org.apache.pinot.common.request.Expression;
+import org.apache.pinot.materializedview.analysis.timeexpr.TimeExprValidator.ArithmeticScaling;
+import org.apache.pinot.materializedview.analysis.timeexpr.TimeExprValidator.DateTrunc;
+import org.apache.pinot.materializedview.analysis.timeexpr.TimeExprValidator.IdentityPassthrough;
+import org.apache.pinot.materializedview.analysis.timeexpr.TimeExprValidator.ParseException;
+import org.apache.pinot.materializedview.analysis.timeexpr.TimeExprValidator.TimeExpression;
+import org.apache.pinot.sql.parsers.CalciteSqlParser;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+
+
+/// Structural tests for {@link TimeExprValidator#parse}.  Pin both the
+/// happy paths (each accepted shape parses to the expected ADT variant with the right
+/// literal arguments) and the error paths (each rejected construct surfaces a
+/// {@link ParseException} with a message that names the
+/// offending construct).  No policy is asserted here — TIMESTAMP-ness, base-column-name
+/// matching, and bucket alignment are tested at the consumer (validator / inferer) level.
+public class TimeExprParserTest {
+
+  /// Parses a SELECT-list item from the SQL `SELECT <item> FROM t` and returns the
+  /// alias-stripped Thrift {@link Expression}.  The SQL helper is the same shape the MV
+  /// validator and inferer use in production, so tests exercise the parser against
+  /// realistic Calcite output rather than hand-built Expression trees that might drift
+  /// from what Pinot's parser actually emits.
+  private static Expression parseSelectExpr(String selectListItem) {
+    String sql = "SELECT " + selectListItem + " FROM t";
+    return CalciteSqlParser.compileToPinotQuery(sql).getSelectList().get(0);
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Identity passthrough
+  // ---------------------------------------------------------------------------------------------
+
+  @Test
+  public void identityPassthroughParses() {
+    TimeExpression expr = TimeExprValidator.parse(parseSelectExpr("ts"));
+    assertTrue(expr instanceof IdentityPassthrough);
+    assertEquals(expr.baseTimeColumnName(), "ts");
+  }
+
+  @Test
+  public void identityPassthroughPreservesUserCasing() {
+    // The parser does not canonicalise identifier casing — it surfaces what the user
+    // wrote so the consumer can compare against the table's case-correct column name.
+    TimeExpression expr = TimeExprValidator.parse(parseSelectExpr("DaysSinceEpoch"));
+    assertEquals(expr.baseTimeColumnName(), "DaysSinceEpoch");
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // DATETRUNC
+  // ---------------------------------------------------------------------------------------------
+
+  @Test
+  public void dateTruncTwoArgsParses() {
+    TimeExpression expr =
+        TimeExprValidator.parse(parseSelectExpr("DATETRUNC('DAY', ts)"));
+    assertTrue(expr instanceof DateTrunc);
+    DateTrunc dt = (DateTrunc) expr;
+    assertEquals(dt.baseTimeColumnName(), "ts");
+    assertEquals(dt.unit(), "DAY");
+  }
+
+  @Test
+  public void dateTruncWithDefaultOptionalArgsParses() {
+    // Each optional arg, when present, must equal its default.  Three / four / five
+    // operand variants all parse so long as the optionals are at their defaults.
+    TimeExpression three =
+        TimeExprValidator.parse(parseSelectExpr("DATETRUNC('HOUR', ts, 'MILLISECONDS')"));
+    assertEquals(((DateTrunc) three).unit(), "HOUR");
+
+    TimeExpression four = TimeExprValidator.parse(
+        parseSelectExpr("DATETRUNC('HOUR', ts, 'MILLISECONDS', 'UTC')"));
+    assertEquals(((DateTrunc) four).unit(), "HOUR");
+
+    TimeExpression five = TimeExprValidator.parse(
+        parseSelectExpr("DATETRUNC('HOUR', ts, 'MILLISECONDS', 'UTC', 'MILLISECONDS')"));
+    assertEquals(((DateTrunc) five).unit(), "HOUR");
+  }
+
+  @Test
+  public void dateTruncPreservesUnitCasing() {
+    // The parser surfaces the user's casing so the consumer can echo it in error
+    // messages or normalise as needed.  Both lower-case and upper-case forms must reach
+    // the consumer unchanged.
+    TimeExpression upper =
+        TimeExprValidator.parse(parseSelectExpr("DATETRUNC('DAY', ts)"));
+    assertEquals(((DateTrunc) upper).unit(), "DAY");
+    TimeExpression lower =
+        TimeExprValidator.parse(parseSelectExpr("DATETRUNC('day', ts)"));
+    assertEquals(((DateTrunc) lower).unit(), "day");
+  }
+
+  @Test
+  public void dateTruncRejectsNonDefaultInputTimeUnit() {
+    ParseException ex = expectThrows(
+        ParseException.class,
+        () -> TimeExprValidator.parse(parseSelectExpr("DATETRUNC('DAY', ts, 'SECONDS')")));
+    assertTrue(ex.getMessage().contains("inputTimeUnit"), ex.getMessage());
+  }
+
+  @Test
+  public void dateTruncRejectsNonDefaultTimeZone() {
+    ParseException ex = expectThrows(
+        ParseException.class,
+        () -> TimeExprValidator.parse(
+            parseSelectExpr("DATETRUNC('DAY', ts, 'MILLISECONDS', 'America/Los_Angeles')")));
+    assertTrue(ex.getMessage().contains("UTC"), ex.getMessage());
+  }
+
+  @Test
+  public void dateTruncRejectsNonDefaultOutputTimeUnit() {
+    ParseException ex = expectThrows(
+        ParseException.class,
+        () -> TimeExprValidator.parse(
+            parseSelectExpr("DATETRUNC('DAY', ts, 'MILLISECONDS', 'UTC', 'SECONDS')")));
+    assertTrue(ex.getMessage().contains("outputTimeUnit"), ex.getMessage());
+  }
+
+  @Test
+  public void dateTruncRejectsBadArity() {
+    ParseException one = expectThrows(
+        ParseException.class,
+        () -> TimeExprValidator.parse(parseSelectExpr("DATETRUNC('DAY')")));
+    assertTrue(one.getMessage().contains("2 to 5 arguments"), one.getMessage());
+  }
+
+  @Test
+  public void dateTruncRejectsNonIdentifierSecondArg() {
+    // Nested expression as DATETRUNC's column position would mix shape recognition with
+    // arithmetic and break the consumer's bucket-alignment check.  Reject up front with
+    // a clear message instead of letting the consumer chase a bogus mismatch.
+    ParseException ex = expectThrows(
+        ParseException.class,
+        () -> TimeExprValidator.parse(parseSelectExpr("DATETRUNC('DAY', ts * 1000)")));
+    assertTrue(ex.getMessage().contains("bare base-table time-column identifier"), ex.getMessage());
+  }
+
+  @Test
+  public void dateTruncRejectsNonStringUnit() {
+    ParseException ex = expectThrows(
+        ParseException.class,
+        () -> TimeExprValidator.parse(parseSelectExpr("DATETRUNC(86400000, ts)")));
+    assertTrue(ex.getMessage().contains("string literal"), ex.getMessage());
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Arithmetic scaling
+  // ---------------------------------------------------------------------------------------------
+
+  @Test
+  public void arithmeticScalingFlatParses() {
+    TimeExpression expr =
+        TimeExprValidator.parse(parseSelectExpr("ts * 86400000"));
+    assertTrue(expr instanceof ArithmeticScaling);
+    ArithmeticScaling arith =
+        (ArithmeticScaling) expr;
+    assertEquals(arith.baseTimeColumnName(), "ts");
+    assertEquals(arith.scaleFactor(), 86400000L);
+  }
+
+  @Test
+  public void arithmeticScalingChainedParses() {
+    // Chained multiplication folds left-to-right: `ts * 24 * 60 * 60 * 1000` → product
+    // 86_400_000.  The parser collapses the entire chain into a single ArithmeticScaling
+    // record with the multiplied value, so consumers don't need to walk further.
+    TimeExpression expr =
+        TimeExprValidator.parse(parseSelectExpr("ts * 24 * 60 * 60 * 1000"));
+    ArithmeticScaling arith =
+        (ArithmeticScaling) expr;
+    assertEquals(arith.baseTimeColumnName(), "ts");
+    assertEquals(arith.scaleFactor(), 86400000L);
+  }
+
+  @Test
+  public void arithmeticScalingLiteralFirstStillParses() {
+    // Order of operands is irrelevant — `1000 * ts` is the same shape as `ts * 1000`.
+    // The parser uses identifier-vs-literal type inspection rather than positional rules.
+    TimeExpression expr =
+        TimeExprValidator.parse(parseSelectExpr("1000 * ts"));
+    ArithmeticScaling arith =
+        (ArithmeticScaling) expr;
+    assertEquals(arith.baseTimeColumnName(), "ts");
+    assertEquals(arith.scaleFactor(), 1000L);
+  }
+
+  @Test
+  public void arithmeticScalingRejectsNoIdentifier() {
+    // Calcite constant-folds `100 * 200 * 300` to a single literal `6000000` before the
+    // expression reaches the parser, so the rejection surfaces as "must be an identifier"
+    // (the top-level shape) rather than the chain-walker's "exactly one identifier"
+    // message. Either is correct — the literal IS not a recognised shape — and pinning
+    // the test to the actual error path documents the constant-folding interaction.
+    ParseException ex = expectThrows(
+        ParseException.class,
+        () -> TimeExprValidator.parse(parseSelectExpr("100 * 200 * 300")));
+    assertTrue(ex.getMessage().contains("must be an identifier")
+            || ex.getMessage().contains("exactly one base-table identifier"),
+        ex.getMessage());
+  }
+
+  @Test
+  public void arithmeticScalingRejectsTwoIdentifiers() {
+    ParseException ex = expectThrows(
+        ParseException.class,
+        () -> TimeExprValidator.parse(parseSelectExpr("ts * other_col")));
+    assertTrue(ex.getMessage().contains("exactly one base-table identifier"), ex.getMessage());
+  }
+
+  @Test
+  public void arithmeticScalingRejectsZeroLiteral() {
+    ParseException ex = expectThrows(
+        ParseException.class,
+        () -> TimeExprValidator.parse(parseSelectExpr("ts * 0")));
+    assertTrue(ex.getMessage().contains("positive"), ex.getMessage());
+  }
+
+  @Test
+  public void arithmeticScalingRejectsNegativeLiteral() {
+    // Negative literal is parsed by Calcite as `-N` (a function call to negate), so the
+    // walker hits an unsupported function leaf rather than a Literal.  The error message
+    // names the operator so the user can correct it.
+    ParseException ex = expectThrows(
+        ParseException.class,
+        () -> TimeExprValidator.parse(parseSelectExpr("ts * (-1000)")));
+    assertTrue(ex.getMessage().contains("chained multiplication") || ex.getMessage().contains("positive"),
+        ex.getMessage());
+  }
+
+  @Test
+  public void arithmeticScalingRejectsAddition() {
+    ParseException ex = expectThrows(
+        ParseException.class,
+        () -> TimeExprValidator.parse(parseSelectExpr("ts + 86400000")));
+    // `+` is `plus`, not `times`, so the parser treats the top-level call as an
+    // unsupported function.  The error message names the shape requirement.
+    assertTrue(ex.getMessage().contains("unsupported function") || ex.getMessage().contains("plus"),
+        ex.getMessage());
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Unsupported shapes
+  // ---------------------------------------------------------------------------------------------
+
+  @Test
+  public void rejectsDateTimeConvert() {
+    ParseException ex = expectThrows(
+        ParseException.class,
+        () -> TimeExprValidator.parse(
+            parseSelectExpr("dateTimeConvert(ts, '1:MILLISECONDS:EPOCH', '1:DAYS:EPOCH', '1:DAYS')")));
+    assertTrue(ex.getMessage().contains("unsupported function"), ex.getMessage());
+  }
+
+  @Test
+  public void rejectsToDateTime() {
+    ParseException ex = expectThrows(
+        ParseException.class,
+        () -> TimeExprValidator.parse(parseSelectExpr("toDateTime(ts, 'yyyy-MM-dd')")));
+    assertTrue(ex.getMessage().contains("unsupported function"), ex.getMessage());
+  }
+
+  @Test
+  public void rejectsLiteralExpression() {
+    // A bare literal is not even a possible time-column shape; the SELECT-list is
+    // expected to project an expression.  Pin the rejection so a future refactor can't
+    // silently start emitting a constant TIMESTAMP for the MV time column.
+    ParseException ex = expectThrows(
+        ParseException.class,
+        () -> TimeExprValidator.parse(parseSelectExpr("12345")));
+    assertTrue(ex.getMessage().contains("must be an identifier"), ex.getMessage());
+  }
+}

--- a/pinot-materialized-view/src/test/java/org/apache/pinot/materializedview/consistency/MaterializedViewConsistencyManagerTest.java
+++ b/pinot-materialized-view/src/test/java/org/apache/pinot/materializedview/consistency/MaterializedViewConsistencyManagerTest.java
@@ -25,11 +25,15 @@ import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.helix.zookeeper.zkclient.IZkChildListener;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
+import org.apache.pinot.common.utils.config.TableConfigSerDeUtils;
 import org.apache.pinot.materializedview.metadata.MaterializedViewDefinitionMetadata;
 import org.apache.pinot.materializedview.metadata.MaterializedViewRuntimeMetadata;
 import org.apache.pinot.materializedview.metadata.PartitionFingerprint;
 import org.apache.pinot.materializedview.metadata.PartitionInfo;
 import org.apache.pinot.materializedview.metadata.PartitionState;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.apache.zookeeper.data.Stat;
 import org.mockito.ArgumentCaptor;
 import org.testng.annotations.Test;
@@ -37,6 +41,7 @@ import org.testng.annotations.Test;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
@@ -92,6 +97,13 @@ public class MaterializedViewConsistencyManagerTest {
         MV_TABLE, List.of(BASE_TABLE), "SELECT count(*) FROM baseTable", Map.of(), null);
     when(propertyStore.get(eq(definitionPath), any(), eq(AccessOption.PERSISTENT)))
         .thenReturn(definition.toZNRecord());
+    // rebuildReverseIndex verifies the MV's TableConfig still exists and is an MV; mock a
+    // matching znode so the orphan-skip check doesn't drop this MV.
+    String tableConfigPath = ZKMetadataProvider.constructPropertyStorePathForResourceConfig(MV_TABLE);
+    TableConfig mvTableConfig = new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName(MV_TABLE).setIsMaterializedView(true).build();
+    when(propertyStore.get(eq(tableConfigPath), any(), eq(AccessOption.PERSISTENT)))
+        .thenReturn(TableConfigSerDeUtils.toZNRecord(mvTableConfig));
 
     MaterializedViewRuntimeMetadata runtime = new MaterializedViewRuntimeMetadata(
         MV_TABLE, 2 * BUCKET_MS,
@@ -120,6 +132,39 @@ public class MaterializedViewConsistencyManagerTest {
         MaterializedViewRuntimeMetadata.fromZNRecord(recordCaptor.getValue());
     assertEquals(updated.getPartitions().get(0L).getState(), PartitionState.STALE);
     assertEquals(updated.getPartitions().get(BUCKET_MS).getState(), PartitionState.VALID);
+  }
+
+  /// Regression: a stale definition znode whose TableConfig was already removed (best-effort
+  /// delete failed mid-DROP) must NOT be re-registered into the reverse index — the rebuild
+  /// path must skip the orphan so DROP-followed-by-CREATE doesn't resurrect a ghost MV.
+  @Test
+  public void testOrphanDefinitionZnodeWithoutTableConfigIsSkipped()
+      throws Exception {
+    ZkHelixPropertyStore<ZNRecord> propertyStore = mock(ZkHelixPropertyStore.class);
+    String definitionParentPath = ZKMetadataProvider.getPropertyStorePathForMaterializedViewDefinitionPrefix();
+    String definitionPath = ZKMetadataProvider.constructPropertyStorePathForMaterializedViewDefinition(MV_TABLE);
+    String tableConfigPath = ZKMetadataProvider.constructPropertyStorePathForResourceConfig(MV_TABLE);
+    String runtimePath = ZKMetadataProvider.constructPropertyStorePathForMaterializedViewRuntime(MV_TABLE);
+
+    when(propertyStore.getChildNames(eq(definitionParentPath), eq(AccessOption.PERSISTENT)))
+        .thenReturn(List.of(MV_TABLE));
+    MaterializedViewDefinitionMetadata definition = new MaterializedViewDefinitionMetadata(
+        MV_TABLE, List.of(BASE_TABLE), "SELECT count(*) FROM baseTable", Map.of(), null);
+    when(propertyStore.get(eq(definitionPath), any(), eq(AccessOption.PERSISTENT)))
+        .thenReturn(definition.toZNRecord());
+    // TableConfig is gone — the prior DROP succeeded at removing the config but failed the
+    // best-effort znode cleanup, leaving the definition orphaned.
+    when(propertyStore.get(eq(tableConfigPath), any(), eq(AccessOption.PERSISTENT))).thenReturn(null);
+
+    MaterializedViewConsistencyManager manager = new MaterializedViewConsistencyManager();
+    manager.init(propertyStore);
+    // Orphan was skipped, so the reverse index has no mapping for BASE_TABLE; an event for
+    // BASE_TABLE must produce no runtime znode writes.
+    manager.onBaseTableDataChange(BASE_TABLE, 0L, BUCKET_MS - 1);
+    manager.flush(BASE_TABLE);
+    manager.stop();
+    verify(propertyStore, never())
+        .set(eq(runtimePath), any(ZNRecord.class), eq(0), eq(AccessOption.PERSISTENT));
   }
 
   /// Regression test for M1: full-range invalidation must NOT create synthetic STALE entries

--- a/pinot-materialized-view/src/test/java/org/apache/pinot/materializedview/metadata/MaterializedViewDefinitionMetadataBuilderTest.java
+++ b/pinot-materialized-view/src/test/java/org/apache/pinot/materializedview/metadata/MaterializedViewDefinitionMetadataBuilderTest.java
@@ -1,0 +1,239 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.materializedview.metadata;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.pinot.materializedview.metadata.MaterializedViewDefinitionMetadata.MaterializedViewSplitSpec;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableTaskConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.CommonConstants.MaterializedViewTask;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.assertTrue;
+
+
+/// Pins the shared definition-metadata builder used by both the controller-side
+/// `CREATE MATERIALIZED VIEW` DDL path and the minion-side scheduler cold-start. Both call
+/// sites MUST produce byte-identical metadata for the same MV so the `createIfAbsent`
+/// idempotency contract holds — these tests fail if the two ever diverge.
+public class MaterializedViewDefinitionMetadataBuilderTest {
+
+  private static final String VIEW_TABLE_NAME = "mv_orders_daily";
+  private static final String VIEW_TABLE_WITH_TYPE = TableNameBuilder.OFFLINE.tableNameWithType(VIEW_TABLE_NAME);
+  private static final String SOURCE_RAW = "orders";
+  private static final String SOURCE_OFFLINE = TableNameBuilder.OFFLINE.tableNameWithType(SOURCE_RAW);
+  private static final String DEFINED_SQL = "SELECT ts, city, count(*) AS cnt FROM orders GROUP BY ts, city";
+
+  @Test
+  public void testBuildHappyPath() {
+    TableConfig viewConfig = mvConfigBuilder()
+        .setTaskConfig(taskConfig(Map.of(
+            MaterializedViewTask.DEFINED_SQL_KEY, DEFINED_SQL,
+            MaterializedViewTask.BUCKET_TIME_PERIOD_KEY, "1d")))
+        .build();
+    Schema viewSchema = viewSchema();
+    TableConfig sourceConfig = sourceConfigBuilder().build();
+    Schema sourceSchema = sourceSchema();
+    Map<String, String> partitionExprMaps = Map.of("ts", "ts");
+
+    MaterializedViewDefinitionMetadata def = MaterializedViewDefinitionMetadataBuilder.build(
+        VIEW_TABLE_WITH_TYPE, viewConfig, viewSchema, sourceConfig, sourceSchema, SOURCE_RAW,
+        DEFINED_SQL, partitionExprMaps);
+
+    assertEquals(def.getMaterializedViewTableNameWithType(), VIEW_TABLE_WITH_TYPE);
+    assertEquals(def.getBaseTables(), Collections.singletonList(SOURCE_RAW),
+        "baseTables must be the RAW source name — the consistency manager's reverse index "
+            + "is keyed by raw name and the scheduler's `notifyMaterializedViewConsistencyManager` "
+            + "extracts raw names before lookup.");
+    assertEquals(def.getDefinedSql(), DEFINED_SQL);
+    assertEquals(def.getPartitionExprMaps(), partitionExprMaps);
+    assertEquals(def.getStalenessThresholdMs(), MaterializedViewTask.DEFAULT_STALENESS_THRESHOLD_MS,
+        "Staleness defaults to the constant when the task config key is absent.");
+    assertTrue(def.isRewriteEnabled(),
+        "Rewrite enabled defaults to true; toggling false is opt-in per MV.");
+
+    MaterializedViewSplitSpec splitSpec = def.getSplitSpec();
+    assertNotNull(splitSpec, "Split spec must be populated for any time-windowed MV.");
+    assertEquals(splitSpec.getSourceTimeColumn(), "ts");
+    // DateTimeFieldSpec normalises TIMESTAMP format down to the canonical "TIMESTAMP" tag.
+    // Whatever the source schema actually round-trips through getFormat() is what the
+    // builder MUST persist — pinning the live value here means a refactor to the source's
+    // format handling would surface here rather than as a silent broker-rewrite divergence.
+    assertEquals(splitSpec.getSourceTimeFormat(),
+        sourceSchema.getSpecForTimeColumn("ts").getFormat(),
+        "Source time format must come from the source schema's DateTimeFieldSpec, not the MV's.");
+    assertEquals(splitSpec.getMaterializedViewTimeColumn(), "ts",
+        "MV time column comes from viewTableConfig.validationConfig.timeColumnName.");
+    assertEquals(splitSpec.getMaterializedViewTimeFormat(),
+        viewSchema.getSpecForTimeColumn("ts").getFormat(),
+        "MV time format must come from the MV schema's DateTimeFieldSpec, not the source's. "
+            + "Base and MV time columns may use different formats (e.g. source 1:DAYS:EPOCH "
+            + "vs MV 1:MILLISECONDS:TIMESTAMP); the persisted split spec must carry both so "
+            + "broker-side split-query rewriting can convert window boundaries into each side's "
+            + "native unit.");
+    assertEquals(splitSpec.getBucketMs(), 86400000L,
+        "bucketTimePeriod '1d' must convert to ms via TimeUtils.");
+  }
+
+  /// Two builder invocations against the same inputs must produce equal metadata so the
+  /// controller-DDL and scheduler-cold-start call sites are interchangeable for createIfAbsent
+  /// idempotency.
+  @Test
+  public void testBuildIsDeterministic() {
+    TableConfig viewConfig = mvConfigBuilder()
+        .setTaskConfig(taskConfig(Map.of(
+            MaterializedViewTask.DEFINED_SQL_KEY, DEFINED_SQL,
+            MaterializedViewTask.BUCKET_TIME_PERIOD_KEY, "1d",
+            MaterializedViewTask.STALENESS_THRESHOLD_MS_KEY, "300000")))
+        .build();
+    Schema viewSchema = viewSchema();
+    TableConfig sourceConfig = sourceConfigBuilder().build();
+    Schema sourceSchema = sourceSchema();
+    Map<String, String> partitionExprMaps = new HashMap<>();
+    partitionExprMaps.put("ts", "ts");
+
+    MaterializedViewDefinitionMetadata first = MaterializedViewDefinitionMetadataBuilder.build(
+        VIEW_TABLE_WITH_TYPE, viewConfig, viewSchema, sourceConfig, sourceSchema, SOURCE_RAW,
+        DEFINED_SQL, partitionExprMaps);
+    MaterializedViewDefinitionMetadata second = MaterializedViewDefinitionMetadataBuilder.build(
+        VIEW_TABLE_WITH_TYPE, viewConfig, viewSchema, sourceConfig, sourceSchema, SOURCE_RAW,
+        DEFINED_SQL, new HashMap<>(partitionExprMaps));
+
+    assertEquals(first, second,
+        "Two builder invocations against equal inputs MUST produce equal metadata so "
+            + "MaterializedViewDefinitionMetadataUtils#createIfAbsent's idempotency contract "
+            + "holds across the controller DDL path and the scheduler cold-start path.");
+    assertEquals(first.getStalenessThresholdMs(), 300000L,
+        "Staleness override must round-trip from the task config string.");
+  }
+
+  /// `isMaterializedView=true` is the SPI-level identity invariant
+  /// ([TableConfigUtils#validateMaterializedViewInvariants]); a TableConfig that fails this
+  /// check should never reach the builder, so the precondition fail-fast is the wedge
+  /// guarding against a hand-built TableConfig sneaking through a non-DDL caller.
+  @Test
+  public void testBuildRejectsNonMaterializedViewTableConfig() {
+    TableConfig regularOffline = new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName(VIEW_TABLE_WITH_TYPE)
+        .setTimeColumnName("ts")
+        .build();
+    Schema viewSchema = viewSchema();
+    TableConfig sourceConfig = sourceConfigBuilder().build();
+    Schema sourceSchema = sourceSchema();
+
+    assertThrows(IllegalArgumentException.class, () ->
+        MaterializedViewDefinitionMetadataBuilder.build(VIEW_TABLE_WITH_TYPE, regularOffline,
+            viewSchema, sourceConfig, sourceSchema, SOURCE_RAW, DEFINED_SQL,
+            Collections.emptyMap()));
+  }
+
+  /// bucketTimePeriod is hard-required by `MaterializedViewAnalyzer.validateTaskConfigs`; the
+  /// builder must NOT silently fall back to a default if the key is missing — it would write
+  /// inconsistent split specs across the controller and scheduler paths and silently produce
+  /// wrong split queries.
+  @Test
+  public void testBuildRejectsMissingBucketTimePeriod() {
+    TableConfig viewConfig = mvConfigBuilder()
+        .setTaskConfig(taskConfig(Map.of(
+            MaterializedViewTask.DEFINED_SQL_KEY, DEFINED_SQL)))
+        .build();
+    Schema viewSchema = viewSchema();
+    TableConfig sourceConfig = sourceConfigBuilder().build();
+    Schema sourceSchema = sourceSchema();
+
+    assertThrows(IllegalStateException.class, () ->
+        MaterializedViewDefinitionMetadataBuilder.build(VIEW_TABLE_WITH_TYPE, viewConfig,
+            viewSchema, sourceConfig, sourceSchema, SOURCE_RAW, DEFINED_SQL,
+            Collections.emptyMap()));
+  }
+
+  /// Malformed staleness in a persisted znode (i.e. one that bypassed the analyzer-side
+  /// validation) must NOT throw — the builder is also called from the backfill / recovery
+  /// path on already-persisted configs, where silently falling back to the default keeps
+  /// the cluster running. Validation of malformed values is the analyzer's job at CREATE
+  /// time; see MaterializedViewAnalyzer.validateTaskConfigs.
+  @Test
+  public void testBuildFallsBackOnMalformedStaleness() {
+    TableConfig viewConfig = mvConfigBuilder()
+        .setTaskConfig(taskConfig(Map.of(
+            MaterializedViewTask.DEFINED_SQL_KEY, DEFINED_SQL,
+            MaterializedViewTask.BUCKET_TIME_PERIOD_KEY, "1d",
+            MaterializedViewTask.STALENESS_THRESHOLD_MS_KEY, "not-a-number")))
+        .build();
+    Schema viewSchema = viewSchema();
+    TableConfig sourceConfig = sourceConfigBuilder().build();
+    Schema sourceSchema = sourceSchema();
+
+    MaterializedViewDefinitionMetadata def = MaterializedViewDefinitionMetadataBuilder.build(
+        VIEW_TABLE_WITH_TYPE, viewConfig, viewSchema, sourceConfig, sourceSchema, SOURCE_RAW,
+        DEFINED_SQL, Collections.emptyMap());
+    assertEquals(def.getStalenessThresholdMs(), MaterializedViewTask.DEFAULT_STALENESS_THRESHOLD_MS);
+  }
+
+  // ── helpers ──
+
+  private static TableConfigBuilder mvConfigBuilder() {
+    return new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName(VIEW_TABLE_WITH_TYPE)
+        .setIsMaterializedView(true)
+        .setTimeColumnName("ts");
+  }
+
+  private static TableConfigBuilder sourceConfigBuilder() {
+    return new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName(SOURCE_OFFLINE)
+        .setTimeColumnName("ts");
+  }
+
+  private static TableTaskConfig taskConfig(Map<String, String> configs) {
+    return new TableTaskConfig(Map.of(MaterializedViewTask.TASK_TYPE, configs));
+  }
+
+  private static Schema sourceSchema() {
+    return new Schema.SchemaBuilder()
+        .setSchemaName(SOURCE_RAW)
+        .addDateTime("ts", DataType.TIMESTAMP, "1:MILLISECONDS:TIMESTAMP", "1:MILLISECONDS")
+        .addSingleValueDimension("city", DataType.STRING)
+        .build();
+  }
+
+  /// MV-side schema. Deliberately uses a DIFFERENT `DateTimeFieldSpec` format than the source
+  /// schema so the happy-path test can independently assert that source-side and MV-side time
+  /// formats end up on the right field of [MaterializedViewSplitSpec]. A wiring swap in the
+  /// builder would surface here as the source format leaking into the MV slot or vice versa.
+  /// The choice of `1:DAYS:EPOCH` mirrors a realistic MV that buckets a TIMESTAMP source into
+  /// daily granularity (e.g. `DATETRUNC('DAY', ts)` or `ts / 86400000`).
+  private static Schema viewSchema() {
+    return new Schema.SchemaBuilder()
+        .setSchemaName(VIEW_TABLE_NAME)
+        .addDateTime("ts", DataType.LONG, "1:DAYS:EPOCH", "1:DAYS")
+        .addSingleValueDimension("city", DataType.STRING)
+        .build();
+  }
+}

--- a/pinot-materialized-view/src/test/java/org/apache/pinot/materializedview/metadata/MaterializedViewMetadataTest.java
+++ b/pinot-materialized-view/src/test/java/org/apache/pinot/materializedview/metadata/MaterializedViewMetadataTest.java
@@ -27,6 +27,7 @@ import org.apache.pinot.materializedview.metadata.MaterializedViewDefinitionMeta
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
@@ -153,5 +154,99 @@ public class MaterializedViewMetadataTest {
     ZNRecord znRecord = metadata.toZNRecord();
     assertTrue(znRecord.getSimpleFields().containsKey("watermarkMs"),
         "watermarkMs key must always be written");
+  }
+
+  /// Definition equality is the controller's idempotency check at CREATE MV time: a second
+  /// CREATE with the same definedSQL must hash/compare equal to the first so a stale orphan
+  /// znode from a prior failed CREATE doesn't get classified as "different content".
+  ///
+  /// Verifies that every direct field of [MaterializedViewDefinitionMetadata] independently
+  /// flips equality (so an equals() that silently drops a comparison is caught here). The
+  /// nested SplitSpec's own field-by-field coverage is pinned separately in
+  /// [#testSplitSpecEqualsAndHashCode]; that test also documents the one persisted-but-not-
+  /// compared field (`materializedViewTimeFormat`), which is intentional and tracked as a
+  /// separate follow-up. A regression that adds a new direct field on
+  /// [MaterializedViewDefinitionMetadata] without wiring it through equals/hashCode must add
+  /// a matching `assertNotEquals` line below — otherwise the controller's idempotency check
+  /// would silently treat two distinct definitions as the same.
+  @Test
+  public void testDefinitionEqualsAndHashCodeAllFields() {
+    Map<String, String> partitionExprMaps = new HashMap<>();
+    partitionExprMaps.put("ts", "ts");
+    MaterializedViewSplitSpec splitSpec =
+        new MaterializedViewSplitSpec("ts", "1:MILLISECONDS:TIMESTAMP", "ts",
+            "1:MILLISECONDS:TIMESTAMP", 86400000L);
+    MaterializedViewDefinitionMetadata a = new MaterializedViewDefinitionMetadata(
+        "mv_OFFLINE", Collections.singletonList("orders"),
+        "SELECT ts FROM orders", partitionExprMaps, splitSpec, 0L, true);
+    MaterializedViewDefinitionMetadata b = new MaterializedViewDefinitionMetadata(
+        "mv_OFFLINE", Collections.singletonList("orders"),
+        "SELECT ts FROM orders", new HashMap<>(partitionExprMaps),
+        new MaterializedViewSplitSpec("ts", "1:MILLISECONDS:TIMESTAMP", "ts",
+            "1:MILLISECONDS:TIMESTAMP", 86400000L),
+        0L, true);
+    assertEquals(a, b);
+    assertEquals(a.hashCode(), b.hashCode());
+
+    // Each field independently flips equality — guards against an equals() that silently
+    // omits a field. Use a fresh `a` baseline for each delta so order in the chain doesn't
+    // matter.
+    MaterializedViewDefinitionMetadata diffName = new MaterializedViewDefinitionMetadata(
+        "mv_other_OFFLINE", Collections.singletonList("orders"),
+        "SELECT ts FROM orders", partitionExprMaps, splitSpec, 0L, true);
+    assertNotEquals(a, diffName);
+
+    MaterializedViewDefinitionMetadata diffBase = new MaterializedViewDefinitionMetadata(
+        "mv_OFFLINE", Collections.singletonList("products"),
+        "SELECT ts FROM orders", partitionExprMaps, splitSpec, 0L, true);
+    assertNotEquals(a, diffBase);
+
+    MaterializedViewDefinitionMetadata diffSql = new MaterializedViewDefinitionMetadata(
+        "mv_OFFLINE", Collections.singletonList("orders"),
+        "SELECT ts FROM other", partitionExprMaps, splitSpec, 0L, true);
+    assertNotEquals(a, diffSql);
+
+    Map<String, String> diffExprMap = new HashMap<>();
+    diffExprMap.put("ts", "renamed_ts");
+    MaterializedViewDefinitionMetadata diffExpr = new MaterializedViewDefinitionMetadata(
+        "mv_OFFLINE", Collections.singletonList("orders"),
+        "SELECT ts FROM orders", diffExprMap, splitSpec, 0L, true);
+    assertNotEquals(a, diffExpr);
+
+    MaterializedViewSplitSpec diffSpec =
+        new MaterializedViewSplitSpec("ts", "1:HOURS:EPOCH", "ts", "1:HOURS:EPOCH", 86400000L);
+    MaterializedViewDefinitionMetadata diffSplit = new MaterializedViewDefinitionMetadata(
+        "mv_OFFLINE", Collections.singletonList("orders"),
+        "SELECT ts FROM orders", partitionExprMaps, diffSpec, 0L, true);
+    assertNotEquals(a, diffSplit);
+
+    MaterializedViewDefinitionMetadata diffStaleness = new MaterializedViewDefinitionMetadata(
+        "mv_OFFLINE", Collections.singletonList("orders"),
+        "SELECT ts FROM orders", partitionExprMaps, splitSpec, 60000L, true);
+    assertNotEquals(a, diffStaleness);
+
+    MaterializedViewDefinitionMetadata diffRewrite = new MaterializedViewDefinitionMetadata(
+        "mv_OFFLINE", Collections.singletonList("orders"),
+        "SELECT ts FROM orders", partitionExprMaps, splitSpec, 0L, false);
+    assertNotEquals(a, diffRewrite);
+  }
+
+  /// SplitSpec equality covers `sourceTimeColumn`, `sourceTimeFormat`,
+  /// `materializedViewTimeColumn`, and `bucketMs` — the same four fields whose Δ flips
+  /// definition equality (so a regression that drops a field comparison is caught here too).
+  /// `materializedViewTimeFormat` is intentionally NOT part of this contract today (it was
+  /// added later, and the existing equals/hashCode predates it); changing that is tracked as a
+  /// separate follow-up since it would alter the `createIfAbsent` idempotency surface.
+  @Test
+  public void testSplitSpecEqualsAndHashCode() {
+    MaterializedViewSplitSpec a = new MaterializedViewSplitSpec("ts", "fmt", "v", "vfmt", 1000L);
+    MaterializedViewSplitSpec b = new MaterializedViewSplitSpec("ts", "fmt", "v", "vfmt", 1000L);
+    assertEquals(a, b);
+    assertEquals(a.hashCode(), b.hashCode());
+
+    assertNotEquals(a, new MaterializedViewSplitSpec("other", "fmt", "v", "vfmt", 1000L));
+    assertNotEquals(a, new MaterializedViewSplitSpec("ts", "other", "v", "vfmt", 1000L));
+    assertNotEquals(a, new MaterializedViewSplitSpec("ts", "fmt", "other", "vfmt", 1000L));
+    assertNotEquals(a, new MaterializedViewSplitSpec("ts", "fmt", "v", "vfmt", 2000L));
   }
 }

--- a/pinot-sql-ddl/DESIGN.md
+++ b/pinot-sql-ddl/DESIGN.md
@@ -107,7 +107,18 @@ generated into `SqlParserImpl` by the existing JavaCC + FMPP build chain.
 
 ### 3.1 Productions
 
+Productions are listed in the canonical grouping (Catalog → Table → Materialized View)
+where the JavaCC LL(*) unification (`SqlPinotShow`, `SqlPinotDrop` — both single
+entries that branch internally on `TABLE` vs `MATERIALIZED VIEW`) permits.
+
 ```
+SqlPinotShow :=                                                ── unified entry under one SHOW token
+    SHOW (
+        TABLES [FROM SimpleIdentifier]                          ── Catalog DDL
+      | CREATE TABLE CompoundIdentifier [TYPE (OFFLINE | REALTIME)]
+      | CREATE MATERIALIZED VIEW CompoundIdentifier             ── no TYPE clause: MV is always OFFLINE
+    )
+
 SqlPinotCreateTable :=
     CREATE TABLE [IF NOT EXISTS] CompoundIdentifier
     PinotColumnList
@@ -115,20 +126,30 @@ SqlPinotCreateTable :=
     TABLE_TYPE = (OFFLINE | REALTIME)
     [PROPERTIES (PinotPropertyList)]
 
-SqlPinotDropTable :=
-    DROP TABLE [IF EXISTS] CompoundIdentifier
-    [TYPE (OFFLINE | REALTIME)]
-
-SqlPinotShow :=
-    SHOW (
-        TABLES [FROM SimpleIdentifier]
-      | CREATE TABLE CompoundIdentifier [TYPE (OFFLINE | REALTIME)]
+SqlPinotDrop :=                                                ── unified entry under one DROP token
+    DROP (
+        TABLE [IF EXISTS] CompoundIdentifier [TYPE (OFFLINE | REALTIME)]
+      | MATERIALIZED VIEW [IF EXISTS] CompoundIdentifier        ── no TYPE clause: MV is always OFFLINE
     )
+
+SqlPinotCreateMaterializedView :=
+    CREATE MATERIALIZED VIEW [IF NOT EXISTS] CompoundIdentifier
+    PinotColumnList
+    [REFRESH EVERY StringLiteral]
+    [PROPERTIES (PinotPropertyList)]
+    AS Query                                                   ── query-only: SELECT/VALUES/WITH/UNION/…; NOT DML
 
 PinotColumnDeclaration :=
     SimpleIdentifier DataType [NOT NULL | NULL] [DEFAULT Literal]
     [ DIMENSION [ARRAY] | METRIC | DATETIME FORMAT StringLiteral GRANULARITY StringLiteral ]
 ```
+
+The MV `AS <query>` clause is bound to Calcite's `OrderedQueryOrExpr(ACCEPT_QUERY)` production,
+**not** the default `SqlQueryOrDml()`. DML (`INSERT`/`UPDATE`/`DELETE`/`MERGE`) is rejected at
+parse time so an `AS INSERT ...` body never reaches the MV analyzer (where it would either be
+silently ignored or fail with a non-actionable error well below the grammar). A materialized
+view's body is always a projection-style query whose output rows are persisted; widening this
+clause back to DML would mean two different storage semantics behind one statement form.
 
 ### 3.2 New tokens (config.fmpp)
 
@@ -145,19 +166,26 @@ identifiers using these names continue to parse — they remain usable as table/
   body fails clearly with "expected `(`" on malformed `PRIMARY KEY id` syntax rather
   than backtracking to a misleading "expected TABLE_TYPE").
 - The `SHOW` branches are united under a single `SqlPinotShow` entry so JavaCC choice
-  logic doesn't need cross-statement lookahead.
+  logic doesn't need cross-statement lookahead. The same pattern applies to `DROP`:
+  `SqlPinotDrop` is a single entry that branches on `TABLE` vs `MATERIALIZED VIEW`, so JavaCC
+  never needs cross-statement lookahead across two productions that both start with `DROP`.
 
 ## 4. Compile path: AST → (Schema, TableConfig)
 
 ### 4.1 DdlCompiler entry points
 
 `DdlCompiler.compile(String sql)` — single static entry point, returns a `CompiledDdl`
-discriminated by `DdlOperation`:
+discriminated by `DdlOperation`. Entries below follow the canonical ordering
+(Catalog → Table → Materialized View; lifecycle CREATE → SHOW CREATE → DROP inside each
+object-level family):
 
-- `CREATE_TABLE → CompiledCreateTable { Schema, TableConfig, isIfNotExists, warnings }`
-- `DROP_TABLE → CompiledDropTable { rawTableName, databaseName?, tableType?, ifExists }`
 - `SHOW_TABLES → CompiledShowTables { databaseName? }`
+- `CREATE_TABLE → CompiledCreateTable { Schema, TableConfig, isIfNotExists, warnings }`
 - `SHOW_CREATE_TABLE → CompiledShowCreateTable { rawTableName, databaseName?, tableType? }`
+- `DROP_TABLE → CompiledDropTable { rawTableName, databaseName?, tableType?, ifExists }`
+- `CREATE_MATERIALIZED_VIEW → CompiledCreateMaterializedView { Schema, TableConfig, isIfNotExists, warnings }`
+- `SHOW_CREATE_MATERIALIZED_VIEW → CompiledShowCreateMaterializedView { rawTableName, databaseName? }` — no `tableType` field because the grammar has no `TYPE` clause for this form.
+- `DROP_MATERIALIZED_VIEW → CompiledDropMaterializedView { rawTableName, databaseName?, ifExists }` — no `tableType` field; the grammar has no `TYPE` clause for this form because an MV is always realized as an OFFLINE table.
 
 ### 4.2 Resolved IR
 
@@ -327,6 +355,104 @@ that would shadow a promoted scalar or JSON-blob key on round-trip, SHOW CREATE 
 returns 400 with a clear message naming the offending key. This is preferable to a
 silent corruption where the DDL replay would route the value to a different field.
 
+### 5.2 Materialized View reverse path
+
+`CanonicalDdlEmitter.emit` dispatches on the canonical `TableConfig#isMaterializedView`
+flag (single source of truth, introduced in PR #18564). A config whose flag is set always
+emits `CREATE MATERIALIZED VIEW`; everything else emits `CREATE TABLE`. The SPI invariant
+`TableConfigUtils.validateMaterializedViewInvariants` keeps the flag and the
+`task.MaterializedViewTask.definedSQL` body consistent, so the dispatch never has to
+inspect the task block to decide identity.
+
+The MV branch emits:
+
+```
+CREATE MATERIALIZED VIEW [db.]name (
+  <column block>           ── same SchemaEmitter output the table form uses
+)
+[REFRESH EVERY '<period>'] ── emitted iff schedule is round-trippable (see Q1=A below)
+[PROPERTIES (
+  '<key>' = '<value>',     ── lexicographic order, MV-extractor output (see §5.2.2)
+  …
+)]
+AS <definedSQL>;           ── verbatim substring captured at CREATE time (see §5.2.3)
+```
+
+#### 5.2.1 Cron ↔ period inversion (Q1=A: reject non-round-trippable schedules)
+
+`MaterializedViewPropertyRouter.periodToCron` rewrites every accepted
+`REFRESH EVERY '<N><unit>'` value into a Quartz cron expression that the scheduler
+ingests. The reverse direction (`cronToPeriod`) must be the **exact inverse**:
+
+| period string | Quartz cron |
+|---|---|
+| `<N>m` (1 ≤ N ≤ 59)   | `0 0/N * * * ?` (N=1 collapses to `0 * * * * ?`) |
+| `<N>h` (1 ≤ N ≤ 23)   | `0 0 0/N * * ?` (N=1 collapses to `0 0 * * * ?`) |
+| `<N>d` (1 ≤ N ≤ 28)   | `0 0 0 1/N * ?` (N=1 collapses to `0 0 0 * * ?`) |
+
+Any cron that does **not** match one of these patterns (a hand-typed
+`0 30 9 * * MON-FRI`, an N=60 minute interval, etc.) makes `cronToPeriod` return null;
+the MV branch then throws `IllegalArgumentException` mapped to **HTTP 400** rather than
+silently dropping the schedule. The DDL grammar has no syntax for raw cron, so emitting
+DDL without `REFRESH EVERY` for a non-standard schedule would re-parse into a config
+that runs on the cluster-wide cron — a user-invisible behavioural change. The 400
+response points the operator at the JSON `/tables` API for inspection until either the
+grammar grows raw-cron support or the MV is recreated with a `REFRESH EVERY '<period>'`
+clause.
+
+#### 5.2.2 `PROPERTIES` flattening — `CanonicalDdlEmitter.extractMaterializedViewProperties`
+
+The MV-emission helper wraps the regular `PropertyExtractor` and applies three MV-specific
+transformations:
+
+1. **Drop synthetic clause keys.** `task.MaterializedViewTask.definedSQL` and
+   `task.MaterializedViewTask.schedule` are rendered by dedicated DDL clauses (`AS` and
+   `REFRESH EVERY`). Leaving them in `PROPERTIES` would make the re-parse refuse the DDL
+   because the forward router treats both keys as reserved-by-clause.
+2. **Flatten canonical task knobs.**
+   `task.MaterializedViewTask.<bucketTimePeriod|bufferTimePeriod|maxNumRecordsPerSegment>`
+   are flattened back to the bare DDL form the forward router accepts. Keeping them
+   prefixed would still round-trip semantically but cycle the canonical form between two
+   equivalent strings — breaking any caller (config-drift detector, golden-file tests)
+   that diffs `SHOW CREATE` output.
+3. **Keep arbitrary task entries verbatim.** Any other `task.MaterializedViewTask.<key>`
+   or `task.<otherTaskType>.<key>` survives as-is so a hand-authored experimental knob
+   (or a future task type composed onto an MV table) does not silently disappear on
+   round-trip. Adding a knob to `MaterializedViewPropertyRouter.TASK_CONFIG_KEYS` (the
+   forward-router map; the reverse extractor consults it via `canonicalKnobName(...)`)
+   is the **only** edit needed to promote a future knob to bare-DDL form.
+
+#### 5.2.3 `AS <query>` substring capture
+
+The compiler stores the user's `definedSQL` as the **verbatim substring** of the
+original DDL covered by the `AS <query>` parser node (see
+`DdlCompiler.extractDefinedSql`). The MV emitter reproduces that text exactly — comments,
+identifier casing, and whitespace are preserved — rather than re-unparsing the parsed
+SELECT. Re-unparsing would normalize all of those things and would also strip top-level
+`LIMIT` / `ORDER BY` clauses because Calcite wraps them in a `SqlOrderBy` whose
+parser position covers only the `LIMIT` token. `extractDefinedSql` therefore walks the
+AST (`SqlCall` + `SqlNodeList`) and unions every descendant position via
+`SqlParserPos.sum`, capturing the full span across `SqlOrderBy`, `SqlWith`, and
+`SqlExplain` wrappers.
+
+#### 5.2.4 Q2=B contract: `SHOW CREATE TABLE` refuses an MV; the inverse also holds
+
+The two reverse DDLs are **strictly partitioned by what the underlying TableConfig is**:
+
+- `SHOW CREATE MATERIALIZED VIEW <mv>` is the only way to inspect an MV.
+- `SHOW CREATE TABLE <mv>` returns **HTTP 400** with a message pointing at the
+  MV-specific form. Silent fallback to the MV emitter is forbidden because the response
+  DDL header (`CREATE TABLE` vs `CREATE MATERIALIZED VIEW`) must always match the
+  request shape — otherwise any tooling that compares the two would see a phantom drift.
+- The inverse is symmetric: `SHOW CREATE MATERIALIZED VIEW <plain-table>` also returns
+  **HTTP 400** with a message pointing at the plain-table form.
+
+The check lives in the controller (`PinotDdlRestletResource.executeShowCreate` /
+`executeShowCreateMaterializedView`) and delegates to the canonical
+`TableConfig#isMaterializedView` flag — the same predicate the emitter dispatches on —
+so a config that the emitter would have routed through the MV branch is caught before
+any rendering happens.
+
 ## 6. REST endpoint
 
 ```
@@ -348,12 +474,35 @@ Database: <optional database name>
    conflicts).
 4. **Authorize.** `ResourceUtils.checkPermissionAndAccess` against the **post-translation**
    resource name, with the operation-appropriate `AccessType` and `Action`.
-5. **Dispatch.** Switch on `DdlOperation` to `executeCreate`, `executeDrop`, `executeShow`,
-   or `executeShowCreate`.
+5. **Dispatch.** Switch on `DdlOperation` to one of `executeShow`, `executeCreate`,
+   `executeShowCreate`, `executeDrop`, `executeCreateMaterializedView`,
+   `executeShowCreateMaterializedView`, `executeDropMaterializedView`.
 
-### 6.2 CREATE flow
+Sub-sections below follow the same Catalog → Table → Materialized View grouping as
+`DdlOperation`, with lifecycle CREATE → SHOW CREATE → DROP inside each object-level family.
+
+### 6.2 Catalog DDL: SHOW TABLES
 
 ```
+scopedDatabase = sqlDatabase ?: Database-header ?: DEFAULT_DATABASE
+authorize(TargetType.CLUSTER, scopedDatabase, Actions.Cluster.GET_TABLE)
+return PinotHelixResourceManager.getAllRawTables(scopedDatabase)
+```
+
+Single-database scope is deliberate: returning the union across all databases would
+silently leak table names from databases the caller may not have access to. The
+authorization pair (`CLUSTER` + `GET_TABLE`) matches the existing
+`@Authorize`-annotated `GET /tables` endpoint, so secured deployments grant SHOW TABLES
+to callers who already have cluster-level table-listing access rather than requiring a
+fictitious per-table READ on a resource named after the database.
+
+### 6.3 Table DDL: CREATE TABLE
+
+```
+Q2=B preflight (raw-name exclusivity with MVs):
+    offlineConfigOfRawName = getTableConfig(<raw>_OFFLINE)      ── checked for OFFLINE OR REALTIME create
+    isMaterializedView(offlineConfigOfRawName)? -> 400 "drop the existing materialized view first"
+                                                  (applies under IF NOT EXISTS too — type mismatch ≠ absence)
 hasTable(typed)? --yes IF NOT EXISTS --> 200 no-op
               \-- yes !IF NOT EXISTS --> 409
               \-- no --> readStoredSchema(rawName)
@@ -365,30 +514,23 @@ hasTable(typed)? --yes IF NOT EXISTS --> 200 no-op
                          else: addSchema (if not preexisted) → addTable → 201
 ```
 
+**Q2=B preflight.** The MV-marker check is the CREATE-TABLE symmetric twin of §6.6's CREATE-MV
+checks. Without it, a `CREATE TABLE OFFLINE foo` against a name whose OFFLINE znode is already
+an MV would 409 with a generic "already exists" — true but unhelpful, because the operator
+would not know they were colliding with a derived MV that has its own DROP form, refresh
+schedule, and minion task wiring. The same check fires for `CREATE TABLE REALTIME foo` against
+an existing MV at `foo_OFFLINE`: the resulting "hybrid pair whose OFFLINE half is a materialized
+view" has no defined semantics in the broker rewrite, minion task generator, or consistency
+manager. `IF NOT EXISTS` does **not** suppress these errors — it suppresses "object not found
+at the requested type", not "wrong DDL verb for the conflicting object" (mirror of `DROP TABLE`
+IF EXISTS on an MV → 400 in §6.5).
+
 On `addTable` failure: do **not** roll back `addSchema`. The two-read race window
 (`hasOfflineTable + hasRealtimeTable` to decide if the schema is orphaned) could orphan
 a sibling's live table. Pinot already lets schemas outlive tables; stale schemas can be
 removed via `DELETE /schemas/{name}` if needed.
 
-### 6.3 DROP flow
-
-```
-candidates = [foo_OFFLINE, foo_REALTIME]   ── from TYPE clause or both
-authorize(candidates) up-front              ── preserves no-fingerprinting
-targets = candidates.filter(hasTable)
-if targets empty: IF EXISTS? 200 : 404
-checkLogicalTableReferences(targets)        ── 409 if any target referenced
-for target in targets:
-    tableTasksCleanup(target)              ── may throw CAE (e.g. active tasks → 400)
-    deleteTable(rawName, type)
-    track success/failure + tasksCleared
-if all success: 200
-else: surface partial-failure error with first-failure status code preserved,
-      list of dropped/failed targets, and a recovery hint pointing at
-      task-schedule restoration if tasksCleared is non-empty
-```
-
-### 6.4 SHOW CREATE TABLE flow
+### 6.4 Table DDL: SHOW CREATE TABLE
 
 ```
 resolvedType = TYPE clause? : auto
@@ -403,11 +545,136 @@ else:                                       ── no-TYPE: authorize BOTH varia
     rt?    -> resolved = REALTIME
     none?  -> 404
 fetch tableConfig (null after hasTable=true => 500 ZK inconsistency)
+isMaterializedView(tableConfig)? -> 400 "use SHOW CREATE MATERIALIZED VIEW"  (Q2=B primary)
 fetch schema     (null  -> 404; schemas can be deleted independently)
 emit canonical DDL
 ```
 
-### 6.5 Authorization contract
+### 6.5 Table DDL: DROP TABLE
+
+```
+candidates = [foo_OFFLINE, foo_REALTIME]   ── from TYPE clause or both
+authorize(candidates) up-front              ── preserves no-fingerprinting
+targets = candidates.filter(hasTable)
+if targets empty: IF EXISTS? 200 : 404
+for target in targets:                      ── Q2=B primary preflight (see below)
+    isMaterializedView(target.tableConfig)? -> 400 "use DROP MATERIALIZED VIEW"
+checkLogicalTableReferences(targets)        ── 409 if any target referenced
+for target in targets:
+    tableTasksCleanup(target)              ── may throw CAE (e.g. active tasks → 400)
+    deleteTable(rawName, type)
+    track success/failure + tasksCleared
+if all success: 200
+else: surface partial-failure error with first-failure status code preserved,
+      list of dropped/failed targets, and a recovery hint pointing at
+      task-schedule restoration if tasksCleared is non-empty
+```
+
+**Q2=B primary preflight.** The MV-marker check is the symmetric twin of §6.4's
+MV-in-SHOW-CREATE-TABLE rejection. Without it the DDL surface would be asymmetric —
+`SHOW CREATE TABLE` already refuses to render an MV, but a `DROP TABLE` of the same
+target would happily destroy it. The check happens **before** the logical-table-reference
+and active-task scans so a pure `DROP TABLE` typo on an MV name returns a fast,
+deterministic 400 rather than first paying for two ZK scans.
+
+### 6.6 Materialized View DDL: CREATE MATERIALIZED VIEW
+
+Inherits the §6.3 CREATE pipeline (validate → addSchema → addTable) with three deltas:
+
+1. **MV-specific compile route.** `DdlCompiler.compileCreateMaterializedView` routes
+   `REFRESH EVERY '<period>'`, `AS <query>`, and MV-specific knobs through
+   `MaterializedViewPropertyRouter` before invoking the shared
+   `validateTableConfig` (see §4 / §5.2).
+2. **MV authorization.** Same `CREATE_TABLE` action — introducing a separate
+   `CREATE_MATERIALIZED_VIEW` action would silently lock operators already granted
+   `CREATE_TABLE` out of MV creation on rolling upgrade. The action is intentionally
+   reused; future fine-grained MV permissions can layer a `CREATE_MATERIALIZED_VIEW`
+   action on top with controller config defaulting to the table grant.
+3. **MV is always OFFLINE.** No dual-variant handshake; the typed name is wired through
+   `TableNameBuilder.OFFLINE`.
+
+```
+Q2=B preflight (raw-name exclusivity, symmetric mirror of §6.3):
+    offlineConfig = getTableConfig(<raw>_OFFLINE)
+    if offlineConfig is materialized view:
+        IF NOT EXISTS? -> 200 no-op (idempotent re-deployment)
+        otherwise      -> 409 "already exists"
+    else if offlineConfig != null (a plain OFFLINE table holds the name):
+        -> 400 "drop the existing table first"   (applies under IF NOT EXISTS too)
+    else if hasTable(<raw>_REALTIME):
+        -> 400 "drop the existing REALTIME table first"
+inherited §6.3 pipeline (validate → addSchema → addTable)
+```
+
+All §6.3 invariants (idempotent `IF NOT EXISTS`, dry-run, schema-race recovery,
+mismatched-pre-existing-schema → 409) apply unchanged. The two type-mismatch errors above
+intentionally return 400 (not 409) because the response code maps to the **kind** of
+conflict (type mismatch vs same-kind duplicate), not to whether `IF NOT EXISTS` was
+present — see §6.5 for the symmetric `DROP MV IF EXISTS on plain table → 400` rule.
+
+### 6.7 Materialized View DDL: SHOW CREATE MATERIALIZED VIEW
+
+```
+typedName = TableNameBuilder.OFFLINE.tableNameWithType(rawName)  ── MV is always OFFLINE
+authorize(typedName)                         ── reuses GET_TABLE_CONFIG; an MV is realized as an OFFLINE table
+hasTable(typedName)? : 404 otherwise
+fetch tableConfig (null after hasTable=true => 500 ZK inconsistency)
+isMaterializedView(tableConfig)? : 400 "use SHOW CREATE TABLE"  (Q2=B mirror)
+fetch schema     (null  -> 404)
+emit canonical DDL via CanonicalDdlEmitter (dispatches to the MV branch)
+```
+
+Both §6.4 and §6.7 share the same canonical `TableConfig#isMaterializedView` flag the
+emitter dispatches on, so the controller never asks the emitter to render a form that
+disagrees with the underlying TableConfig shape.
+
+A previous version of this endpoint also gated on a "corrupted MV" shape (a config that
+carried a `MaterializedViewTask` block but was missing the `definedSQL` body) and
+returned a distinct 400 with a fix hint. That shape is no longer reachable for any
+persisted config: the SPI invariant
+`TableConfigUtils.validateMaterializedViewInvariants` (PR #18564) rejects it at addTable
+/ updateTable time, and the canonical `isMaterializedView` flag — not the task block —
+is now the identity source.
+
+### 6.8 Materialized View DDL: DROP MATERIALIZED VIEW
+
+```
+typedName = TableNameBuilder.OFFLINE.tableNameWithType(rawName)  ── MV is always OFFLINE
+authorize(typedName)                            ── reuses DELETE_TABLE; an MV is realized as an OFFLINE table
+exists = hasTable(typedName) || getTableConfig(typedName) != null
+if !exists:
+    ifExists?  -> 200 no-op (SQL-standard IF EXISTS semantics)
+    otherwise  -> 404 "materialized view not found"
+fetch tableConfig (null after hasTable=true => 500 ZK inconsistency)
+isMaterializedView(tableConfig)? -> proceed
+otherwise -> 400 "use DROP TABLE"  (Q2=B mirror, applies even under IF EXISTS — see below)
+assertNoLogicalTableReferences([typedName])     ── 409 if any logical table union references it
+assertNoActiveTasksBeforeDrop([typedName])      ── 400 if a MaterializedViewTask is in-flight
+if dryRun: 200 "would drop ..."
+cleanupTableTasksBeforeDrop(typedName)          ── removes the task schedule; same code path as DROP TABLE
+deleteTable(rawName, OFFLINE, null)             ── PinotHelixResourceManager.deleteTable handles MV znodes:
+                                                ──   • MaterializedViewDefinitionMetadataUtils.delete
+                                                ──   • MaterializedViewRuntimeMetadataUtils.delete
+                                                ──   • notifyMaterializedViewConsistencyManagerForTableDrop
+                                                ── plus the regular table teardown (ideal state, segments, etc.)
+return 200 with deletedTables=[typedName]
+```
+
+Cleanup is delegated entirely to `PinotHelixResourceManager#deleteTable` for the same reason
+PR4's SHOW CREATE was deliberately small: that path is already the single source of truth
+for "drop a Pinot table, including any MV metadata it carries" — adding a parallel cleanup
+in the controller would risk drift between the two doors. The legacy
+`DELETE /materializedViews/{name}` REST endpoint uses the same call.
+
+**Q2=B mirror under IF EXISTS.** A request like `DROP MATERIALIZED VIEW IF EXISTS foo` against
+a name that exists as a plain OFFLINE table returns 400, not 200. `IF EXISTS` exists to make
+idempotent provisioning scripts tolerate "already gone"; it is not a license to silently
+accept a name that resolves to a different kind of object. Returning 200 in that case would
+leave a real OFFLINE table named `foo` standing while the script thinks it cleaned up an
+MV — an actively dangerous failure mode. 400 forces the operator to inspect cluster state
+before acting.
+
+### 6.9 Authorization contract
 
 - All authorization runs **after** database-name translation, against the
   post-translation `db.tableName_TYPE` resource. This prevents a Database header from
@@ -486,19 +753,36 @@ artifacts it produces (Schema + TableConfig in ZK) are the same shape that
 
 ## 10. Testing strategy
 
-| Suite | LOC | Focus |
-|---|---|---|
-| `PinotDdlParserTest` | 399 | Grammar — every syntax variant, `IF NOT EXISTS`, `IF EXISTS`, `SHOW CREATE TABLE`, `SHOW TABLES FROM`, keyword-as-identifier, malformed `PRIMARY KEY` error |
-| `DdlCompilerTest` | 483 | Compile pipeline — every property routing rule, all data type aliases, role inference, default-value type compatibility, negative cases, DECIMAL precision warning, JSON-blob round-trip |
-| `CanonicalDdlEmitterTest` | 433 | Reverse path golden-output — canonical clause order, lexicographic property order, BIG_DECIMAL plain-string, BOOLEAN literals, TIMESTAMP ISO-8601, BYTES hex, ComplexFieldSpec rejection, custom-config key shadowing rejection |
-| `RoundTripTest` | 441 | `emit → parse → compile → emit` idempotence across stream/task/custom configs, ingestion JSON-blob, MV dimensions, primary keys, identifiers needing quoting, kitchen-sink promoted-scalars |
-| `PinotDdlRestletResourceUnitTest` | 290 | `describeColumnShapeMismatch` — every column attribute, BYTES content equality, BIG_DECIMAL `compareTo` equivalence, DATETIME format/granularity |
-| `PinotDdlRestletResourceTest` | 362 | Controller integration on a real `ControllerTest` cluster — CREATE/DROP/SHOW round-trip, dry-run, IF [NOT] EXISTS, 201/200/404/409/400 status codes, DB-qualified DDL, oversize input rejection |
+| Suite | Focus |
+|---|---|
+| `PinotDdlParserTest` | Grammar — every syntax variant, `IF NOT EXISTS`, `IF EXISTS`, `SHOW CREATE TABLE`, `SHOW CREATE MATERIALIZED VIEW` (rejects `TYPE` clause), `DROP MATERIALIZED VIEW` (rejects `TYPE` clause), `SHOW TABLES FROM`, keyword-as-identifier, malformed `PRIMARY KEY` error |
+| `DdlCompilerTest` | Compile pipeline for tables — every property routing rule, all data type aliases, role inference, default-value type compatibility, negative cases, DECIMAL precision warning, JSON-blob round-trip |
+| `DdlCompilerMaterializedViewTest` | Compile pipeline for MVs — `REFRESH EVERY` ↔ cron forward routing, `cronToPeriod` inversion (every period the forward table can produce + non-standard cron rejection), `definedSQL` extraction regressions for top-level `LIMIT` and `ORDER BY` (SqlOrderBy wrapper), `SHOW CREATE MATERIALIZED VIEW` compile, `DROP MATERIALIZED VIEW` compile (+ `IF EXISTS`, database-qualified) |
+| `CanonicalDdlEmitterTest` | Reverse path golden-output for tables — canonical clause order, lexicographic property order, BIG_DECIMAL plain-string, BOOLEAN literals, TIMESTAMP ISO-8601, BYTES hex, ComplexFieldSpec rejection, custom-config key shadowing rejection |
+| `CanonicalDdlEmitterMaterializedViewTest` | Reverse path golden-output for MVs — `REFRESH EVERY` emitted only when round-trippable, non-standard cron 400, MV canonical knobs flattened bare, non-canonical MV task knobs kept under `task.*` prefix, `definedSQL` rendered only in `AS` clause, dispatch sanity check |
+| `RoundTripTest` | `emit → parse → compile → emit` idempotence — tables (stream/task/custom configs, ingestion JSON-blob, MV dimensions, primary keys, identifiers needing quoting, kitchen-sink promoted-scalars) plus MVs (no REFRESH, REFRESH EVERY `'1d'`/`'15m'`, full canonical-knob set, database-qualified) |
+| `PinotDdlRestletResourceUnitTest` | `describeColumnShapeMismatch` — every column attribute, BYTES content equality, BIG_DECIMAL `compareTo` equivalence, DATETIME format/granularity |
+| `PinotDdlRestletResourceMaterializedViewUnitTest` | MV-specific controller wiring — CREATE MV happy path (schedule key present iff REFRESH EVERY), idempotent CREATE on existing MV, dry-run, pre-existing-schema reuse/mismatch, schema race recovery, **CREATE MV on plain OFFLINE table → 400 ± IF NOT EXISTS (Q2=B)**, **CREATE MV when REALTIME half exists → 400 (Q2=B raw-name exclusivity)**, **SHOW CREATE MATERIALIZED VIEW** happy / 404 / 400-on-plain-table, **SHOW CREATE MATERIALIZED VIEW on corrupted MV (task block but no `definedSQL`) → 400 with fix hint**, **SHOW CREATE TABLE on MV → 400 (Q2=B)**, **DROP MATERIALIZED VIEW** happy / 404 ± IF EXISTS / 400-on-plain-table-even-under-IF-EXISTS / dry-run / active-task block, **DROP TABLE on MV → 400 (Q2=B)** |
+| `PinotDdlRestletResourceUnitTest` (Q2=B Table side) | **CREATE TABLE OFFLINE on existing MV → 400 ± IF NOT EXISTS (Q2=B)**, **CREATE TABLE REALTIME when MV occupies OFFLINE half → 400 (Q2=B raw-name exclusivity)** |
+| `PinotDdlRestletResourceTest` | Controller integration on a real `ControllerTest` cluster — CREATE/DROP/SHOW round-trip, dry-run, IF [NOT] EXISTS, 201/200/404/409/400 status codes, DB-qualified DDL, oversize input rejection |
+| `MaterializedViewDdlAnalyzerIntegrationTest` | End-to-end DDL → analyzer hand-off — happy path proving DDL-compiled `(definedSql, TableConfig, Schema, taskConfigs)` reach `MaterializedViewAnalyzer.analyze` in a shape the analyzer accepts; analyzer-reject path proving the analyzer's own error message ("is not produced by any SELECT expression") survives the compile-then-analyze hop unwrapped |
 
 ## 11. Known limitations and future work
 
 - **No `ALTER TABLE`.** Schema/config evolution still goes through `PUT /tables` and
   `PUT /schemas`. Adding `ALTER TABLE` is a natural follow-up slice.
+- **MV schema ↔ SELECT-projection consistency (column type / role / nullability /
+  cardinality).** `MaterializedViewAnalyzer` validates source-table existence,
+  time-column TIMESTAMP contract, `bucketTimePeriod` alignment with any `DATETRUNC` in
+  the SELECT, definedSQL parseability, nested-SELECT rejection, and column-name coverage
+  between the MV schema and the SELECT projection — but does **not** today validate that
+  the MV schema's declared per-column types, roles (DIMENSION / METRIC / DATETIME),
+  nullability flags, or cardinality (single- vs multi-value) match the corresponding
+  SELECT-expression results. This gap exists in the existing JSON `POST /tables` MV
+  flow too, but the DDL surface makes it more visible because the schema is declared
+  inline in the column list and the query is one clause away. A follow-up should
+  thread the projection type information back through the analyzer; until then,
+  operators are responsible for keeping the two sides aligned manually.
 - **PropertyExtractor long-tail.** Some `IndexingConfig` /
   `SegmentsValidationAndRetentionConfig` fields are not yet emitted by the reverse
   path. When those fields are set to non-default values, SHOW CREATE TABLE fails fast

--- a/pinot-sql-ddl/pom.xml
+++ b/pinot-sql-ddl/pom.xml
@@ -45,6 +45,22 @@
       <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-spi</artifactId>
     </dependency>
+    <!--
+      pinot-query-planner gives the MV schema inferer access to Calcite's full validator
+      via QueryEnvironment.  The validator surfaces SQL-shape errors (column typos,
+      function arity, type compatibility, multi-source FROM, etc.) at DDL-compile time
+      instead of letting them through to the analyzer's create-time checks, which is the
+      "MSE-aligned inference" decision recorded in DESIGN.md.
+
+      Note: pinot-controller — the only production caller of pinot-sql-ddl — already
+      depends on pinot-query-planner, so this is not a new transitive at deploy time.
+      Tests in this module instantiate QueryEnvironment with a Mockito-backed TableCache,
+      which keeps unit tests free of the heavy controller test fixtures.
+    -->
+    <dependency>
+      <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-query-planner</artifactId>
+    </dependency>
     <dependency>
       <groupId>org.apache.calcite</groupId>
       <artifactId>calcite-babel</artifactId>
@@ -59,6 +75,23 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <!-- Test-only: the MaterializedViewDdlAnalyzerIntegrationTest needs the real
+         MaterializedViewAnalyzer to validate that DDL-compiled artifacts (TableConfig,
+         Schema, taskConfigs, definedSQL) reach the analyzer's full validation chain
+         without the controller's stubbing layer that sits in front of it. Production code
+         in pinot-sql-ddl never references pinot-materialized-view — the analyzer is
+         invoked at runtime by the controller via TaskConfigUtils, not from the DDL
+         compiler itself. -->
+    <dependency>
+      <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-materialized-view</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/pinot-sql-ddl/src/main/java/org/apache/pinot/sql/ddl/compile/CompiledCreateMaterializedView.java
+++ b/pinot-sql-ddl/src/main/java/org/apache/pinot/sql/ddl/compile/CompiledCreateMaterializedView.java
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.sql.ddl.compile;
+
+import java.util.List;
+import javax.annotation.Nullable;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.data.Schema;
+
+
+/// Result of compiling `CREATE MATERIALIZED VIEW ...`.
+///
+/// Carries the same `(Schema, TableConfig)` pair as a regular OFFLINE CREATE TABLE. All
+/// MV-specific task wiring (`task.MaterializedViewTask.definedSQL`,
+/// `task.MaterializedViewTask.schedule` when REFRESH was supplied,
+/// `task.MaterializedViewTask.bucketTimePeriod`, ...) is already injected into
+/// [#getTableConfig()] by [MaterializedViewPropertyRouter]. The MV runtime watermark is
+/// owned by the scheduler — the compiler intentionally never produces, persists, or seeds it.
+public final class CompiledCreateMaterializedView extends CompiledDdl {
+  private final Schema _schema;
+  private final TableConfig _tableConfig;
+  private final boolean _ifNotExists;
+
+  public CompiledCreateMaterializedView(@Nullable String databaseName, Schema schema,
+      TableConfig tableConfig, boolean ifNotExists, List<String> warnings) {
+    super(DdlOperation.CREATE_MATERIALIZED_VIEW, databaseName, warnings);
+    _schema = schema;
+    _tableConfig = tableConfig;
+    _ifNotExists = ifNotExists;
+  }
+
+  public Schema getSchema() {
+    return _schema;
+  }
+
+  public TableConfig getTableConfig() {
+    return _tableConfig;
+  }
+
+  public boolean isIfNotExists() {
+    return _ifNotExists;
+  }
+}

--- a/pinot-sql-ddl/src/main/java/org/apache/pinot/sql/ddl/compile/CompiledDdl.java
+++ b/pinot-sql-ddl/src/main/java/org/apache/pinot/sql/ddl/compile/CompiledDdl.java
@@ -41,7 +41,9 @@ public abstract class CompiledDdl {
     return _operation;
   }
 
-  /// Database name from `db.table` or `SHOW TABLES FROM db`; may be `null`.
+  /// Database name from `db.table` or `SHOW TABLES FROM db` / `SHOW MATERIALIZED VIEWS FROM db`;
+  /// may be `null` when no database qualifier is present at the DDL layer (the controller then
+  /// falls back to the `Database` HTTP header and finally to `DEFAULT_DATABASE`).
   @Nullable
   public String getDatabaseName() {
     return _databaseName;

--- a/pinot-sql-ddl/src/main/java/org/apache/pinot/sql/ddl/compile/CompiledDropMaterializedView.java
+++ b/pinot-sql-ddl/src/main/java/org/apache/pinot/sql/ddl/compile/CompiledDropMaterializedView.java
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.sql.ddl.compile;
+
+import java.util.Collections;
+import javax.annotation.Nullable;
+
+
+/// Result of compiling `DROP MATERIALIZED VIEW [IF EXISTS] [db.]name`.
+///
+/// Mirrors [CompiledDropTable] but intentionally carries no `TableType`: a Pinot MV is always
+/// realized as an OFFLINE physical table (the compiler enforces this in
+/// [DdlCompiler#compileCreateMaterializedView]), so a `TYPE` clause would be either redundant
+/// (`OFFLINE`) or contradictory (`REALTIME`). The controller resolves the OFFLINE variant,
+/// asserts it really is an MV (presence of `task.MaterializedViewTask.definedSQL`), and routes
+/// through the same `PinotHelixResourceManager#deleteTable` path the legacy
+/// `DELETE /materializedViews/{name}` REST endpoint uses — that path already removes the MV
+/// definition + runtime znodes and unregisters from the consistency manager, so no extra
+/// cleanup is required at this layer.
+///
+/// A target that is *not* an MV produces 400 with a pointer at the plain `DROP TABLE` form
+/// (the Q2=B contract: MV-vs-table is a one-way mapping enforced at the REST boundary, mirror
+/// of the same contract `SHOW CREATE MATERIALIZED VIEW` enforces).
+public final class CompiledDropMaterializedView extends CompiledDdl {
+  private final String _rawTableName;
+  private final boolean _ifExists;
+
+  public CompiledDropMaterializedView(@Nullable String databaseName, String rawTableName,
+      boolean ifExists) {
+    super(DdlOperation.DROP_MATERIALIZED_VIEW, databaseName, Collections.emptyList());
+    _rawTableName = rawTableName;
+    _ifExists = ifExists;
+  }
+
+  /// Bare MV name with no database prefix and no `_OFFLINE` suffix.
+  public String getRawTableName() {
+    return _rawTableName;
+  }
+
+  public boolean isIfExists() {
+    return _ifExists;
+  }
+}

--- a/pinot-sql-ddl/src/main/java/org/apache/pinot/sql/ddl/compile/CompiledShowCreateMaterializedView.java
+++ b/pinot-sql-ddl/src/main/java/org/apache/pinot/sql/ddl/compile/CompiledShowCreateMaterializedView.java
@@ -1,0 +1,48 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.sql.ddl.compile;
+
+import java.util.Collections;
+import javax.annotation.Nullable;
+
+
+/// Result of compiling `SHOW CREATE MATERIALIZED VIEW [db.]name`.
+///
+/// Mirrors [CompiledShowCreateTable] but intentionally carries no `TableType`: a Pinot MV is
+/// always OFFLINE-only (the compiler enforces this) so a `TYPE` clause would be either
+/// redundant (`OFFLINE`) or contradictory (`REALTIME`). The controller looks up the OFFLINE
+/// variant, asserts it really is an MV (presence of `task.MaterializedViewTask.definedSQL`),
+/// and reverse-renders the `CREATE MATERIALIZED VIEW` statement via
+/// [org.apache.pinot.sql.ddl.reverse.CanonicalDdlEmitter#emit]. A non-MV target produces a 400
+/// with a pointer at the plain `SHOW CREATE TABLE` form (this is the Q2=B contract:
+/// MV-vs-table is a one-way mapping — the new statement is MV-only, the old statement is
+/// table-only).
+public final class CompiledShowCreateMaterializedView extends CompiledDdl {
+  private final String _rawTableName;
+
+  public CompiledShowCreateMaterializedView(@Nullable String databaseName, String rawTableName) {
+    super(DdlOperation.SHOW_CREATE_MATERIALIZED_VIEW, databaseName, Collections.emptyList());
+    _rawTableName = rawTableName;
+  }
+
+  /// Bare MV name with no database prefix and no `_OFFLINE` suffix.
+  public String getRawTableName() {
+    return _rawTableName;
+  }
+}

--- a/pinot-sql-ddl/src/main/java/org/apache/pinot/sql/ddl/compile/CompiledShowMaterializedViews.java
+++ b/pinot-sql-ddl/src/main/java/org/apache/pinot/sql/ddl/compile/CompiledShowMaterializedViews.java
@@ -1,0 +1,32 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.sql.ddl.compile;
+
+import java.util.Collections;
+import javax.annotation.Nullable;
+
+
+/// Result of compiling `SHOW MATERIALIZED VIEWS [FROM db]`. Carries no payload beyond the
+/// database scope; the controller filters TableConfigs by `isMaterializedView()` and returns the
+/// raw MV names. Catalog-listing mirror of [CompiledShowTables].
+public final class CompiledShowMaterializedViews extends CompiledDdl {
+  public CompiledShowMaterializedViews(@Nullable String databaseName) {
+    super(DdlOperation.SHOW_MATERIALIZED_VIEWS, databaseName, Collections.emptyList());
+  }
+}

--- a/pinot-sql-ddl/src/main/java/org/apache/pinot/sql/ddl/compile/DdlCompileContext.java
+++ b/pinot-sql-ddl/src/main/java/org/apache/pinot/sql/ddl/compile/DdlCompileContext.java
@@ -1,0 +1,71 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.sql.ddl.compile;
+
+import javax.annotation.Nullable;
+import org.apache.pinot.common.config.provider.TableCache;
+
+
+/// Carries the side-channel collaborators that the new {@link DdlCompiler#compile(String,
+/// DdlCompileContext)} entry point needs but the legacy stateless entry never had.
+///
+/// {@link TableCache} backs Calcite's catalog so {@code QueryEnvironment} can validate the
+/// {@code AS definedSQL} of {@code CREATE MATERIALIZED VIEW} (with an inferred column list)
+/// against the live cluster catalog. Nullable so unit tests for non-MV DDL forms need not
+/// supply one; the inferer surfaces a clear error if it is invoked without a `TableCache`.
+///
+/// {@code requestDatabase} is the HTTP-header database for the current request. When the
+/// DDL itself does not qualify a table reference, the inferer uses this as the default
+/// catalog name so a `CREATE ... AS SELECT ts FROM src` issued with header `database: foo`
+/// resolves `src` in `foo`, not the cluster default.
+public final class DdlCompileContext {
+
+  /// Singleton stateless context — used by {@link DdlCompiler#compile(String)} and by
+  /// callers that don't need cluster-side metadata (or are explicitly compiling
+  /// purely-textual DDL).
+  public static final DdlCompileContext STATELESS = new DdlCompileContext(null, null);
+
+  @Nullable
+  private final TableCache _tableCache;
+  @Nullable
+  private final String _requestDatabase;
+
+  public DdlCompileContext(@Nullable TableCache tableCache) {
+    this(tableCache, null);
+  }
+
+  public DdlCompileContext(@Nullable TableCache tableCache, @Nullable String requestDatabase) {
+    _tableCache = tableCache;
+    _requestDatabase = requestDatabase;
+  }
+
+  /// Returns the {@link TableCache} backing Calcite's catalog, or {@code null} if this
+  /// context was not configured with one. Only the MV schema-inference path requires it.
+  @Nullable
+  public TableCache tableCache() {
+    return _tableCache;
+  }
+
+  /// Returns the HTTP-header database for the current request, or {@code null} when none
+  /// was supplied. Used as the Calcite default catalog for source-table lookups.
+  @Nullable
+  public String requestDatabase() {
+    return _requestDatabase;
+  }
+}

--- a/pinot-sql-ddl/src/main/java/org/apache/pinot/sql/ddl/compile/DdlCompiler.java
+++ b/pinot-sql-ddl/src/main/java/org/apache/pinot/sql/ddl/compile/DdlCompiler.java
@@ -28,9 +28,13 @@ import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.sql.SqlBasicTypeNameSpec;
+import org.apache.calcite.sql.SqlCall;
 import org.apache.calcite.sql.SqlIdentifier;
+import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.SqlNodeList;
+import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.DateTimeFieldSpec;
@@ -39,7 +43,10 @@ import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.MetricFieldSpec;
 import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.CommonConstants.MaterializedViewTask;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.apache.pinot.sql.ddl.inferer.MaterializedViewInferenceInput;
+import org.apache.pinot.sql.ddl.inferer.MaterializedViewSchemaInferer;
 import org.apache.pinot.sql.ddl.resolved.ColumnRole;
 import org.apache.pinot.sql.ddl.resolved.ResolvedColumnDefinition;
 import org.apache.pinot.sql.ddl.resolved.ResolvedTableDefinition;
@@ -47,10 +54,15 @@ import org.apache.pinot.sql.parsers.CalciteSqlParser;
 import org.apache.pinot.sql.parsers.SqlCompilationException;
 import org.apache.pinot.sql.parsers.SqlNodeAndOptions;
 import org.apache.pinot.sql.parsers.parser.SqlPinotColumnDeclaration;
+import org.apache.pinot.sql.parsers.parser.SqlPinotCreateMaterializedView;
 import org.apache.pinot.sql.parsers.parser.SqlPinotCreateTable;
+import org.apache.pinot.sql.parsers.parser.SqlPinotDropMaterializedView;
 import org.apache.pinot.sql.parsers.parser.SqlPinotDropTable;
 import org.apache.pinot.sql.parsers.parser.SqlPinotProperty;
+import org.apache.pinot.sql.parsers.parser.SqlPinotRefreshClause;
+import org.apache.pinot.sql.parsers.parser.SqlPinotShowCreateMaterializedView;
 import org.apache.pinot.sql.parsers.parser.SqlPinotShowCreateTable;
+import org.apache.pinot.sql.parsers.parser.SqlPinotShowMaterializedViews;
 import org.apache.pinot.sql.parsers.parser.SqlPinotShowTables;
 
 
@@ -60,11 +72,18 @@ import org.apache.pinot.sql.parsers.parser.SqlPinotShowTables;
 /// ```
 ///   SQL String
 ///     → CalciteSqlParser (in pinot-common, generated parser)
-///     → SqlNode (one of SqlPinot{CreateTable,DropTable,ShowTables})
+///     → SqlNode (one of SqlPinot{ShowTables,ShowMaterializedViews,CreateTable,ShowCreateTable,
+///                                DropTable,CreateMaterializedView,ShowCreateMaterializedView,
+///                                DropMaterializedView})
 ///     → ResolvedTableDefinition (CREATE only)
-///     → Schema + TableConfig (CREATE only) via [PropertyMapping]
+///     → Schema + TableConfig (CREATE only) via [PropertyMapping] /
+///       [MaterializedViewPropertyRouter]
 ///     → CompiledDdl
 /// ```
+///
+/// Both the dispatch in [#compile] and the section ordering below follow [DdlOperation]:
+/// Catalog → Table → Materialized View, lifecycle CREATE → SHOW CREATE → DROP within each
+/// object-level family.
 ///
 /// Stateless and thread-safe. All entry points are static.
 public final class DdlCompiler {
@@ -72,36 +91,74 @@ public final class DdlCompiler {
   private DdlCompiler() {
   }
 
-  /// Parses and compiles a DDL statement.
+  /// Parses and compiles a DDL statement using a stateless {@link DdlCompileContext}.
+  ///
+  /// @deprecated Use {@link #compile(String, DdlCompileContext)} and supply a real context.
+  ///   The stateless overload is preserved as a thin shim so existing call sites keep
+  ///   compiling, but DDL forms that need cluster-side metadata (e.g.
+  ///   {@code CREATE MATERIALIZED VIEW} with an inferred column list, when that feature
+  ///   ships in the follow-up commit) will fail with a clear "no source catalog resolver
+  ///   configured" error. Production callers should migrate; the shim will be removed in
+  ///   a future release.
   ///
   /// @param sql the raw SQL string (single statement)
   /// @return a [CompiledDdl] subclass appropriate for the operation
   /// @throws DdlCompilationException for parse failures or semantic errors
+  @Deprecated
   public static CompiledDdl compile(String sql) {
+    return compile(sql, DdlCompileContext.STATELESS);
+  }
+
+  /// Parses and compiles a DDL statement.
+  ///
+  /// Dispatch order mirrors [DdlOperation]: Catalog → Table → Materialized View, lifecycle
+  /// CREATE → SHOW CREATE → DROP within each family.
+  ///
+  /// @param sql the raw SQL string (single statement)
+  /// @param ctx side-channel collaborators (source-catalog lookup, etc.). Use
+  ///            {@link DdlCompileContext#STATELESS} when no cluster state is available;
+  ///            DDL forms that require it (currently only future MV schema inference) will
+  ///            surface a clear error. Must not be {@code null}.
+  /// @return a [CompiledDdl] subclass appropriate for the operation
+  /// @throws DdlCompilationException for parse failures or semantic errors
+  public static CompiledDdl compile(String sql, DdlCompileContext ctx) {
+    if (ctx == null) {
+      // Defensive: a null ctx would NPE deep in compileCreateMaterializedView once the
+      // schema inferer lands; surface the misuse here instead so callers see a clear
+      // message rather than a stack trace through the static dispatch chain.
+      throw new DdlCompilationException(
+          "DdlCompileContext must not be null; pass DdlCompileContext.STATELESS for purely "
+              + "textual DDL or supply a configured context for inference-capable DDL.");
+    }
     SqlNode node = parse(sql);
-    if (node instanceof SqlPinotCreateTable) {
-      return compileCreate((SqlPinotCreateTable) node);
-    }
-    if (node instanceof SqlPinotDropTable) {
-      return compileDrop((SqlPinotDropTable) node);
-    }
     if (node instanceof SqlPinotShowTables) {
       return compileShow((SqlPinotShowTables) node);
+    }
+    if (node instanceof SqlPinotShowMaterializedViews) {
+      return compileShowMaterializedViews((SqlPinotShowMaterializedViews) node);
+    }
+    if (node instanceof SqlPinotCreateTable) {
+      return compileCreate((SqlPinotCreateTable) node);
     }
     if (node instanceof SqlPinotShowCreateTable) {
       return compileShowCreate((SqlPinotShowCreateTable) node);
     }
+    if (node instanceof SqlPinotDropTable) {
+      return compileDrop((SqlPinotDropTable) node);
+    }
+    if (node instanceof SqlPinotCreateMaterializedView) {
+      return compileCreateMaterializedView(sql, (SqlPinotCreateMaterializedView) node, ctx);
+    }
+    if (node instanceof SqlPinotShowCreateMaterializedView) {
+      return compileShowCreateMaterializedView((SqlPinotShowCreateMaterializedView) node);
+    }
+    if (node instanceof SqlPinotDropMaterializedView) {
+      return compileDropMaterializedView((SqlPinotDropMaterializedView) node);
+    }
     throw new DdlCompilationException(
-        "Unsupported DDL statement; expected CREATE TABLE, DROP TABLE, SHOW TABLES, "
-            + "or SHOW CREATE TABLE.");
-  }
-
-  private static CompiledShowCreateTable compileShowCreate(SqlPinotShowCreateTable node) {
-    QualifiedName name = parseQualifiedName(node.getName());
-    TableType tableType = node.getTableType() == null
-        ? null
-        : parseTableType(node.getTableType().toValue());
-    return new CompiledShowCreateTable(name._databaseName, name._tableName, tableType);
+        "Unsupported DDL statement; expected SHOW TABLES, SHOW MATERIALIZED VIEWS, "
+            + "CREATE TABLE, SHOW CREATE TABLE, DROP TABLE, CREATE MATERIALIZED VIEW, "
+            + "SHOW CREATE MATERIALIZED VIEW, or DROP MATERIALIZED VIEW.");
   }
 
   private static SqlNode parse(String sql) {
@@ -118,7 +175,26 @@ public final class DdlCompiler {
   }
 
   // -------------------------------------------------------------------------------------------
-  // CREATE TABLE
+  // Catalog DDL: SHOW TABLES
+  // -------------------------------------------------------------------------------------------
+
+  private static CompiledShowTables compileShow(SqlPinotShowTables node) {
+    SqlIdentifier db = node.getDatabase();
+    return new CompiledShowTables(db == null ? null : db.getSimple());
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // Catalog DDL: SHOW MATERIALIZED VIEWS
+  // -------------------------------------------------------------------------------------------
+
+  private static CompiledShowMaterializedViews compileShowMaterializedViews(
+      SqlPinotShowMaterializedViews node) {
+    SqlIdentifier db = node.getDatabase();
+    return new CompiledShowMaterializedViews(db == null ? null : db.getSimple());
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // Table DDL: CREATE TABLE
   // -------------------------------------------------------------------------------------------
 
   private static CompiledCreateTable compileCreate(SqlPinotCreateTable node) {
@@ -416,7 +492,19 @@ public final class DdlCompiler {
   }
 
   // -------------------------------------------------------------------------------------------
-  // DROP TABLE
+  // Table DDL: SHOW CREATE TABLE
+  // -------------------------------------------------------------------------------------------
+
+  private static CompiledShowCreateTable compileShowCreate(SqlPinotShowCreateTable node) {
+    QualifiedName name = parseQualifiedName(node.getName());
+    TableType tableType = node.getTableType() == null
+        ? null
+        : parseTableType(node.getTableType().toValue());
+    return new CompiledShowCreateTable(name._databaseName, name._tableName, tableType);
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // Table DDL: DROP TABLE
   // -------------------------------------------------------------------------------------------
 
   private static CompiledDropTable compileDrop(SqlPinotDropTable node) {
@@ -428,12 +516,326 @@ public final class DdlCompiler {
   }
 
   // -------------------------------------------------------------------------------------------
-  // SHOW TABLES
+  // Materialized View DDL: CREATE MATERIALIZED VIEW
   // -------------------------------------------------------------------------------------------
 
-  private static CompiledShowTables compileShow(SqlPinotShowTables node) {
-    SqlIdentifier db = node.getDatabase();
-    return new CompiledShowTables(db == null ? null : db.getSimple());
+  private static CompiledCreateMaterializedView compileCreateMaterializedView(String originalSql,
+      SqlPinotCreateMaterializedView node, DdlCompileContext ctx) {
+    QualifiedName name = parseQualifiedName(node.getName());
+
+    List<String> warnings = new ArrayList<>();
+    Map<String, String> properties = resolveProperties(node.getProperties().getList());
+
+    // Reject JOIN early so the inferer's single-source assumption (and the analyzer's
+    // downstream check) cannot be violated by a definedSql we haven't validated yet.
+    rejectJoinInDefinedSql(node.getQuery());
+    String definedSql = extractDefinedSql(originalSql, node.getQuery());
+    verifyDefinedSqlIsParseable(definedSql);
+
+    // Two paths:
+    //   1) Explicit column list — legacy path, will be deprecated once the inferer matures.
+    //   2) Empty column list — column definitions are derived from `AS definedSql` via the
+    //      MV schema inferer. Requires a configured TableCache on `ctx`; the inferer
+    //      surfaces a clear message when it's absent.
+    List<ResolvedColumnDefinition> columns;
+    if (node.getColumns().getList().isEmpty()) {
+      // Fall back to the request-header database when the DDL itself does not qualify the
+      // MV name — Calcite needs SOME database to resolve `FROM src` against, and the
+      // header's intent ("operate on database X") matches where the MV will be created.
+      String databaseForLookup = name._databaseName != null ? name._databaseName : ctx.requestDatabase();
+      MaterializedViewInferenceInput inferInput = new MaterializedViewInferenceInput(
+          definedSql, databaseForLookup, name._tableName, properties, ctx.tableCache());
+      try {
+        columns = MaterializedViewSchemaInferer.infer(inferInput);
+      } catch (DdlCompilationException e) {
+        // Inferer's exceptions already carry user-actionable messages — surface as-is.
+        throw e;
+      } catch (RuntimeException e) {
+        // Defensive: any RuntimeException from the inferer is a programming error or an
+        // unexpected upstream change. Wrap so the controller surfaces a 400 instead of a
+        // 500 stack trace.
+        throw new DdlCompilationException(
+            "MV column inference failed unexpectedly: " + e.getMessage(), e);
+      }
+      if (columns.isEmpty()) {
+        throw new DdlCompilationException(
+            "MV column inference produced an empty column list. Either supply an explicit "
+                + "column list in CREATE MATERIALIZED VIEW or fix the AS <query> projection.");
+      }
+    } else {
+      columns = resolveColumns(node.getColumns().getList(), warnings);
+    }
+
+    // REFRESH clause is optional. When present, the EVERY <period> is converted to a Quartz
+    // cron expression and stored under `task.MaterializedViewTask.schedule`. When omitted,
+    // no per-table schedule is written and the MV minion task runs under the cluster-wide
+    // default cron (controller.task.frequencyInSeconds /
+    // controller.task.taskTypeFrequenciesInSeconds.MaterializedViewTask). PinotTaskManager
+    // already handles the missing-schedule case by skipping per-table cron registration.
+    //
+    // Note: JOIN rejection, definedSQL extraction, and re-parse verification all run earlier
+    // in this method now (before column resolution) so the inferer can rely on a
+    // single-source, parseable AS clause without re-doing the work.
+    SqlPinotRefreshClause refresh = node.getRefresh();
+    String schedule = refresh == null
+        ? null
+        : MaterializedViewPropertyRouter.periodToCron(refresh.getRefreshPeriod().toValue());
+
+    // Schema is constructed identically to CREATE TABLE; an MV's storage is a regular
+    // OFFLINE table from the data plane's perspective.
+    ResolvedTableDefinition resolved = new ResolvedTableDefinition(name._databaseName,
+        name._tableName, TableType.OFFLINE, node.isIfNotExists(), columns, properties);
+    Schema schema = buildSchema(resolved);
+
+    String tableNameForConfig = resolved.getDatabaseName() == null
+        ? resolved.getRawTableName()
+        : resolved.getDatabaseName() + "." + resolved.getRawTableName();
+    // MV identity is declared via the canonical TableConfig#isMaterializedView flag (PR #18564);
+    // task.MaterializedViewTask.definedSQL is implementation detail consumed by the scheduler /
+    // executor.  Without this flag, TableConfigUtils#validateMaterializedViewInvariants rejects
+    // the config at addTable time ("MaterializedViewTask is configured but isMaterializedView is
+    // not true"), so every DDL-created MV would fail to persist.
+    TableConfigBuilder builder = new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName(tableNameForConfig)
+        .setIsMaterializedView(true);
+    MaterializedViewPropertyRouter.apply(properties, definedSql, schedule, builder);
+    TableConfig tableConfig = builder.build();
+
+    validateMaterializedViewConsistency(schema, tableConfig);
+
+    return new CompiledCreateMaterializedView(resolved.getDatabaseName(), schema, tableConfig,
+        node.isIfNotExists(), warnings);
+  }
+
+  /// Extracts the raw user-typed SQL text for the `AS <query>` clause using the parser
+  /// position information attached to the query node. We deliberately avoid
+  /// `SqlNode#toString()` / `SqlNode#toSqlString(...)` here because Calcite's unparsers
+  /// rewrite identifier quoting and erase comments / whitespace; the downstream
+  /// `MaterializedViewTaskScheduler#appendTimeRange` is a text-based rewrite that is
+  /// sensitive to such drift.
+  ///
+  /// Wrapper handling: Calcite reports `getParserPosition()` for wrapping nodes
+  /// (`SqlOrderBy`, `SqlWith`, `SqlExplain`, ...) as the position of the wrapper-introducing
+  /// token only — for `SELECT ... LIMIT 1000` the outermost `SqlOrderBy.getParserPosition()`
+  /// spans just the `LIMIT 1000` substring, not the wrapped `SELECT`. Naively slicing on the
+  /// outermost node would store a truncated `definedSQL` ("LIMIT 1000") and the scheduler's
+  /// auto-LIMIT injection would re-parse garbage. To recover the full user-typed span we walk
+  /// every descendant and take the union of all attached, non-zero parser positions
+  /// (`SqlParserPos#sum`). This is wrapper-agnostic: any future Calcite wrapper that follows
+  /// the same "operator-only position" convention is handled without further code change.
+  private static String extractDefinedSql(String originalSql, SqlNode queryNode) {
+    SqlParserPos pos = fullSpan(queryNode);
+    if (pos == null || pos == SqlParserPos.ZERO) {
+      throw new DdlCompilationException(
+          "Unable to extract AS <query>: parser did not attach position information.");
+    }
+    int startOffset = lineColToOffset(originalSql, pos.getLineNum(), pos.getColumnNum());
+    // SqlParserPos end is inclusive (1-based on the last char); convert to exclusive.
+    int endOffsetInclusive = lineColToOffset(originalSql,
+        pos.getEndLineNum(), pos.getEndColumnNum());
+    int endOffsetExclusive = Math.min(endOffsetInclusive + 1, originalSql.length());
+    if (endOffsetExclusive <= startOffset) {
+      throw new DdlCompilationException(
+          "Unable to extract AS <query>: empty parser-position range.");
+    }
+    String slice = originalSql.substring(startOffset, endOffsetExclusive).trim();
+    // Trim any trailing semicolons so a `; ` at the statement tail does not leak into the
+    // stored definedSQL (the JSON /tables endpoint also rejects a leading/trailing ';' here).
+    while (slice.endsWith(";")) {
+      slice = slice.substring(0, slice.length() - 1).trim();
+    }
+    if (slice.isEmpty()) {
+      throw new DdlCompilationException("Extracted AS <query> is empty after trimming.");
+    }
+    return slice;
+  }
+
+  /// Returns the smallest [SqlParserPos] that covers `node` and every descendant whose own
+  /// position is attached (non-null, non-zero). See [#extractDefinedSql] for the wrapper-node
+  /// motivation. Returns `null` only when the entire subtree carries no position info.
+  ///
+  /// Implementation: we recursively collect positions into a list and then call
+  /// [SqlParserPos#sum] once at the end. `sum` is O(n) in list length and walks all
+  /// (start,end) pairs to find the global (min, max); doing this in one shot avoids the
+  /// quadratic blow-up of pairwise unions, which would matter for wide GROUP BY / SELECT
+  /// lists in a real-world MV body.
+  @Nullable
+  private static SqlParserPos fullSpan(@Nullable SqlNode node) {
+    if (node == null) {
+      return null;
+    }
+    List<SqlParserPos> positions = new ArrayList<>();
+    collectPositions(node, positions);
+    if (positions.isEmpty()) {
+      return null;
+    }
+    if (positions.size() == 1) {
+      return positions.get(0);
+    }
+    return SqlParserPos.sum(positions);
+  }
+
+  private static void collectPositions(@Nullable SqlNode node, List<SqlParserPos> out) {
+    if (node == null) {
+      return;
+    }
+    SqlParserPos pos = node.getParserPosition();
+    if (pos != null && pos != SqlParserPos.ZERO) {
+      out.add(pos);
+    }
+    // Only `SqlCall` and `SqlNodeList` carry child nodes; literals (`SqlLiteral`,
+    // `SqlIdentifier`, etc.) are leaves and the recursion terminates naturally on them. Pulling
+    // children through `getOperandList()` (the only entry point on SqlCall) keeps us agnostic
+    // to specific wrapper subclasses (SqlOrderBy, SqlWith, SqlExplain, ...).
+    if (node instanceof SqlCall) {
+      for (SqlNode child : ((SqlCall) node).getOperandList()) {
+        collectPositions(child, out);
+      }
+    } else if (node instanceof SqlNodeList) {
+      for (SqlNode child : (SqlNodeList) node) {
+        collectPositions(child, out);
+      }
+    }
+  }
+
+  /// 1-based (line, col) → 0-based char offset in `sql`. Used by [#extractDefinedSql] to
+  /// convert Calcite parser positions into absolute byte offsets in the original SQL string.
+  private static int lineColToOffset(String sql, int line, int col) {
+    int currentLine = 1;
+    int currentCol = 1;
+    int i = 0;
+    while (i < sql.length()) {
+      if (currentLine == line && currentCol == col) {
+        return i;
+      }
+      char c = sql.charAt(i);
+      if (c == '\n') {
+        currentLine++;
+        currentCol = 1;
+        i++;
+      } else if (c == '\r') {
+        // Treat \r\n and a bare \r as a single line terminator. Calcite's tokenizer does
+        // the same; without this an editor that saved the file with Windows line endings
+        // would shift every position one byte per line.
+        currentLine++;
+        currentCol = 1;
+        i = (i + 1 < sql.length() && sql.charAt(i + 1) == '\n') ? i + 2 : i + 1;
+      } else {
+        currentCol++;
+        i++;
+      }
+    }
+    // Final position (one past the last char): allowed for an end-of-stream pointer.
+    if (currentLine == line && currentCol == col) {
+      return sql.length();
+    }
+    throw new DdlCompilationException(
+        "Unable to map parser position (" + line + ":" + col + ") into SQL of length "
+            + sql.length() + ".");
+  }
+
+  /// Walks the parsed AS-clause AST and throws a clear, MV-specific error if any JOIN node
+  /// is found at any depth (top-level FROM, subquery FROM, lateral join, etc.). See the
+  /// call-site comment in [#compileCreateMaterializedView] for *why* we do this against the
+  /// AST rather than letting the downstream re-parse / analyzer surface the limitation.
+  private static void rejectJoinInDefinedSql(SqlNode queryNode) {
+    if (containsJoin(queryNode)) {
+      throw new DdlCompilationException(
+          "CREATE MATERIALIZED VIEW does not support JOIN in the AS clause. "
+              + "Materialized views currently read from a single source table; "
+              + "pre-join the inputs into a base table and reference that single table "
+              + "in the MV definition.");
+    }
+  }
+
+  /// Returns true iff `node` or any descendant is a [SqlKind#JOIN] call. We walk via the
+  /// `SqlCall#getOperandList` / `SqlNodeList` axes so the traversal stays wrapper-agnostic
+  /// (SqlOrderBy, SqlWith, SqlExplain) — mirroring how [#collectPositions] walks the tree.
+  /// Leaves (SqlLiteral, SqlIdentifier, ...) terminate the recursion naturally.
+  private static boolean containsJoin(@Nullable SqlNode node) {
+    if (node == null) {
+      return false;
+    }
+    if (node.getKind() == SqlKind.JOIN) {
+      return true;
+    }
+    if (node instanceof SqlCall) {
+      for (SqlNode child : ((SqlCall) node).getOperandList()) {
+        if (containsJoin(child)) {
+          return true;
+        }
+      }
+    } else if (node instanceof SqlNodeList) {
+      for (SqlNode child : (SqlNodeList) node) {
+        if (containsJoin(child)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  }
+
+  /// Sanity check: the substring we extracted must be a standalone parseable Pinot query.
+  /// This guards against DDL-layer slicing bugs (off-by-one in [#lineColToOffset], parser
+  /// position quirks) so the error surfaces in the DDL layer rather than at first scheduler
+  /// tick or at create-time analysis (PR 3).
+  private static void verifyDefinedSqlIsParseable(String definedSql) {
+    try {
+      CalciteSqlParser.compileToPinotQuery(definedSql);
+    } catch (Exception e) {
+      throw new DdlCompilationException(
+          "AS <query> did not re-parse as a Pinot query: " + e.getMessage()
+              + " (extracted text: " + definedSql + ")", e);
+    }
+  }
+
+  /// Cross-checks: `timeColumnName` must reference a declared DATETIME column, and
+  /// `bucketTimePeriod` must be present so the scheduler has a window size.
+  private static void validateMaterializedViewConsistency(Schema schema, TableConfig tableConfig) {
+    String timeColumnName = tableConfig.getValidationConfig().getTimeColumnName();
+    if (timeColumnName == null || timeColumnName.isEmpty()) {
+      throw new DdlCompilationException(
+          "CREATE MATERIALIZED VIEW requires a 'timeColumnName' property naming a declared "
+              + "DATETIME column (the MV's bucket column).");
+    }
+    FieldSpec spec = schema.getFieldSpecFor(timeColumnName);
+    if (spec == null) {
+      throw new DdlCompilationException(
+          "timeColumnName '" + timeColumnName + "' does not match any declared column.");
+    }
+    if (!(spec instanceof DateTimeFieldSpec)) {
+      throw new DdlCompilationException(
+          "timeColumnName '" + timeColumnName + "' must reference a DATETIME column.");
+    }
+    Map<String, String> mvTaskConfig = tableConfig.getTaskConfig() == null
+        ? null
+        : tableConfig.getTaskConfig().getConfigsForTaskType(MaterializedViewTask.TASK_TYPE);
+    if (mvTaskConfig == null
+        || !mvTaskConfig.containsKey(MaterializedViewTask.BUCKET_TIME_PERIOD_KEY)) {
+      throw new DdlCompilationException(
+          "CREATE MATERIALIZED VIEW requires a 'bucketTimePeriod' property (e.g. '1d', '1h'); "
+              + "it defines the time window each refresh tick materializes.");
+    }
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // Materialized View DDL: SHOW CREATE MATERIALIZED VIEW
+  // -------------------------------------------------------------------------------------------
+
+  private static CompiledShowCreateMaterializedView compileShowCreateMaterializedView(
+      SqlPinotShowCreateMaterializedView node) {
+    QualifiedName name = parseQualifiedName(node.getName());
+    return new CompiledShowCreateMaterializedView(name._databaseName, name._tableName);
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // Materialized View DDL: DROP MATERIALIZED VIEW
+  // -------------------------------------------------------------------------------------------
+
+  private static CompiledDropMaterializedView compileDropMaterializedView(
+      SqlPinotDropMaterializedView node) {
+    QualifiedName name = parseQualifiedName(node.getName());
+    return new CompiledDropMaterializedView(name._databaseName, name._tableName, node.isIfExists());
   }
 
   // -------------------------------------------------------------------------------------------

--- a/pinot-sql-ddl/src/main/java/org/apache/pinot/sql/ddl/compile/DdlOperation.java
+++ b/pinot-sql-ddl/src/main/java/org/apache/pinot/sql/ddl/compile/DdlOperation.java
@@ -19,9 +19,30 @@
 package org.apache.pinot.sql.ddl.compile;
 
 /// Discriminator for the operation a [CompiledDdl] represents.
+///
+/// Ordering convention (mirrored by `DdlCompiler#compile`, `PinotDdlRestletResource#executeDdl`,
+/// and §3/§4 of `DESIGN.md`): Catalog → Table → Materialized View. Within each object-level
+/// family (Table, Materialized View) the lifecycle order CREATE → SHOW CREATE → DROP is used,
+/// so the two families read as mirror images of each other — making it obvious at a glance that
+/// every Table verb has a Materialized View counterpart (the "Q2=B" strict-type-partitioning
+/// contract). Catalog-level operations (multi-object reads like SHOW TABLES and
+/// SHOW MATERIALIZED VIEWS) are grouped first because they have no object lifecycle and are
+/// typically the first call a user makes against a fresh database. Future schema-level verbs
+/// (e.g. SHOW DATABASES, SHOW FUNCTIONS) belong in the Catalog group, not in the object-level
+/// Table/MV groups.
 public enum DdlOperation {
-  CREATE_TABLE,
-  DROP_TABLE,
+  // Catalog (schema-level, multi-object reads). Listed in object-family order to mirror the
+  // Table → Materialized View grouping of the object-level lifecycle verbs below.
   SHOW_TABLES,
-  SHOW_CREATE_TABLE
+  SHOW_MATERIALIZED_VIEWS,
+
+  // Table (single-object lifecycle).
+  CREATE_TABLE,
+  SHOW_CREATE_TABLE,
+  DROP_TABLE,
+
+  // Materialized View (single-object lifecycle, mirrors Table).
+  CREATE_MATERIALIZED_VIEW,
+  SHOW_CREATE_MATERIALIZED_VIEW,
+  DROP_MATERIALIZED_VIEW
 }

--- a/pinot-sql-ddl/src/main/java/org/apache/pinot/sql/ddl/compile/MaterializedViewPropertyRouter.java
+++ b/pinot-sql-ddl/src/main/java/org/apache/pinot/sql/ddl/compile/MaterializedViewPropertyRouter.java
@@ -1,0 +1,432 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.sql.ddl.compile;
+
+import com.google.common.collect.ImmutableSet;
+import java.util.LinkedHashMap;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import javax.annotation.Nullable;
+import org.apache.pinot.spi.config.table.TableCustomConfig;
+import org.apache.pinot.spi.config.table.TableTaskConfig;
+import org.apache.pinot.spi.utils.CommonConstants.MaterializedViewTask;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+
+
+/// Routes Pinot DDL `PROPERTIES (...)` entries onto a [TableConfigBuilder] for
+/// `CREATE MATERIALIZED VIEW`.
+///
+/// Routing rules (applied in order, case-insensitive on the key):
+/// 1. **Synthetic keys reserved by DDL clauses are rejected.** `schedule` (from
+///    `REFRESH EVERY`), `definedSQL` (from `AS <query>`), and the
+///    `streamType` / `stream.*` / `realtime.*` family (MV is OFFLINE) all return 400
+///    with a message naming the offending key and pointing at the correct clause.
+/// 1. **Promoted scalar.** Lower-cased key matches a known table-level field
+///    (`timeColumnName`, `timeType`, `replication`, `brokerTenant`, `serverTenant`) —
+///    call the corresponding [TableConfigBuilder] setter directly.
+/// 1. **MaterializedViewTask-specific scalar.** Lower-cased key matches one of the
+///    well-known MV task knobs (`bucketTimePeriod`, `bufferTimePeriod`,
+///    `maxNumRecordsPerSegment`, `maxTasksPerBatch`, `taskMode`, `stalenessThresholdMs`) —
+///    route into `task.MaterializedViewTask.<originalKey>` with the user-provided value.
+///    **Key names are preserved verbatim**, never aliased.
+/// 1. **Task prefix.** Key starts with `task.<taskType>.` — route the remainder into
+///    `TableTaskConfig.taskTypeConfigsMap[taskType]`. Mirrors
+///    [PropertyMapping#apply]'s rule 4 so any current or future minion task type composes
+///    with MV without grammar changes.
+/// 1. **Custom (fallback).** Anything else — store verbatim in
+///    [TableCustomConfig#getCustomConfigs()].
+///
+/// After routing the user-provided properties, one or two synthetic entries are merged
+/// into `task.MaterializedViewTask.*`:
+///   * `definedSQL` — always written; the raw user-typed query substring extracted by
+///     the compiler from the `AS <query>` clause.
+///   * `schedule` — written iff the DDL supplied a `REFRESH EVERY <period>` clause. The
+///     value is the Quartz cron expression produced by [#periodToCron(String)]. When the
+///     entire REFRESH clause is omitted, the key is absent and `PinotTaskManager` falls
+///     back to the cluster-wide MV task cron.
+///
+/// The router is stateless; all entry points are `public static`.
+public final class MaterializedViewPropertyRouter {
+
+  /// PinotTaskManager.SCHEDULE_KEY lives in `pinot-controller`. We duplicate the literal
+  /// here (rather than introducing a back-dependency) and pin the contract with a unit test.
+  /// Exposed for the reverse-DDL extractor in the sibling `reverse` package so it can identify
+  /// (and exclude) the schedule entry that the forward router writes — the schedule round-trips
+  /// via the `REFRESH EVERY` clause, never via `PROPERTIES`.
+  public static final String SCHEDULE_KEY = "schedule";
+
+  private static final String TASK_PREFIX = "task.";
+  private static final String STREAM_PREFIX = "stream.";
+  private static final String STREAM_TYPE_KEY = "streamtype";
+  private static final String REALTIME_PREFIX = "realtime.";
+
+  /// MV-promoted scalar property names (lower-cased).
+  private static final Set<String> PROMOTED_KEYS = ImmutableSet.of(
+      "timecolumnname",
+      "timecolumn",
+      "timetype",
+      "replication",
+      "brokertenant",
+      "servertenant");
+
+  /// MV task-config scalar property names. Lower-cased lookup key → canonical-cased on-wire
+  /// key from [MaterializedViewTask] constants. Used both by [#apply] (forward routing) and
+  /// by [#canonicalKnobName] (reverse DDL emission).
+  private static final Map<String, String> TASK_CONFIG_KEYS;
+  static {
+    Map<String, String> keys = new LinkedHashMap<>();
+    keys.put(MaterializedViewTask.BUCKET_TIME_PERIOD_KEY.toLowerCase(Locale.ROOT),
+        MaterializedViewTask.BUCKET_TIME_PERIOD_KEY);
+    keys.put(MaterializedViewTask.BUFFER_TIME_PERIOD_KEY.toLowerCase(Locale.ROOT),
+        MaterializedViewTask.BUFFER_TIME_PERIOD_KEY);
+    keys.put(MaterializedViewTask.MAX_NUM_RECORDS_PER_SEGMENT_KEY.toLowerCase(Locale.ROOT),
+        MaterializedViewTask.MAX_NUM_RECORDS_PER_SEGMENT_KEY);
+    keys.put(MaterializedViewTask.MAX_TASKS_PER_BATCH_KEY.toLowerCase(Locale.ROOT),
+        MaterializedViewTask.MAX_TASKS_PER_BATCH_KEY);
+    keys.put(MaterializedViewTask.TASK_MODE_KEY.toLowerCase(Locale.ROOT),
+        MaterializedViewTask.TASK_MODE_KEY);
+    keys.put(MaterializedViewTask.STALENESS_THRESHOLD_MS_KEY.toLowerCase(Locale.ROOT),
+        MaterializedViewTask.STALENESS_THRESHOLD_MS_KEY);
+    TASK_CONFIG_KEYS = keys;
+  }
+
+  /// Returns the canonical (CommonConstants.MaterializedViewTask) casing for a knob name
+  /// that the DDL grammar lets users write bare in `PROPERTIES (...)` — or null when the
+  /// name is not a recognized MV task knob. The reverse-DDL emitter uses this to flatten
+  /// `task.MaterializedViewTask.<knob>` back to `<knob>` while normalizing legacy off-case
+  /// keys to canonical casing on the way out.
+  @Nullable
+  public static String canonicalKnobName(String lowerCasedKnob) {
+    return TASK_CONFIG_KEYS.get(lowerCasedKnob);
+  }
+
+  /// Keys reserved by DDL clauses. Setting these in PROPERTIES is a user error because
+  /// the same value already arrives through a first-class clause (`REFRESH EVERY`,
+  /// `AS <query>`).
+  private static final Set<String> RESERVED_BY_CLAUSE_KEYS = ImmutableSet.of(
+      SCHEDULE_KEY,
+      MaterializedViewTask.DEFINED_SQL_KEY.toLowerCase(Locale.ROOT));
+
+  private MaterializedViewPropertyRouter() {
+  }
+
+  /// Applies `properties` plus the synthetic `definedSql` / `schedule` onto `builder`.
+  ///
+  /// Pre-conditions:
+  ///   * `definedSql` is non-null and non-empty (the compiler guarantees this).
+  ///   * `schedule` is non-null iff the DDL had a `REFRESH EVERY` clause; when `null`, no
+  ///     `task.MaterializedViewTask.schedule` entry is written and the MV minion task runs
+  ///     under the cluster-wide cron registered in `PinotTaskManager`.
+  ///   * The caller has already validated `properties` keys do not duplicate (case-insensitive).
+  public static void apply(Map<String, String> properties, String definedSql,
+      @Nullable String schedule, TableConfigBuilder builder) {
+    Map<String, Map<String, String>> taskConfigs = new LinkedHashMap<>();
+    Map<String, String> customConfigs = new LinkedHashMap<>();
+    Map<String, String> mvTaskConfig = new LinkedHashMap<>();
+
+    for (Map.Entry<String, String> entry : properties.entrySet()) {
+      String rawKey = entry.getKey();
+      String value = entry.getValue();
+      String lower = rawKey.toLowerCase(Locale.ROOT);
+
+      if (RESERVED_BY_CLAUSE_KEYS.contains(lower)) {
+        throw new DdlCompilationException(
+            "Property '" + rawKey + "' is reserved for the corresponding DDL clause "
+                + "(REFRESH EVERY for 'schedule', AS <query> for 'definedSQL'); "
+                + "remove it from PROPERTIES.");
+      }
+
+      // Reserved by the table-DDL clause family. MV doesn't expose TABLE_TYPE / TABLE_NAME
+      // clauses (always OFFLINE, name from the statement head) but rejecting these keys
+      // here keeps the user-visible error message consistent with CREATE TABLE.
+      if ("tabletype".equals(lower) || "tablename".equals(lower) || "ifnotexists".equals(lower)) {
+        throw new DdlCompilationException(
+            "Property '" + rawKey + "' is reserved and not valid on CREATE MATERIALIZED VIEW.");
+      }
+
+      // The materialized-view flag is identity, not configuration: the compiler stamps it
+      // automatically on this path (see DdlCompiler#compileCreateMaterializedView and PR #18564).
+      // Accepting it here as a user-typed PROPERTY would silently land in TableCustomConfig
+      // (the fallback below treats unknown keys as custom) — harmless for identity but a
+      // confusing knob to leave dangling. Reject explicitly so the operator does not believe
+      // the value affected anything.
+      if ("ismaterializedview".equals(lower)) {
+        throw new DdlCompilationException(
+            "Property 'isMaterializedView' is reserved: CREATE MATERIALIZED VIEW already stamps "
+                + "the canonical TableConfig#isMaterializedView flag on the resulting config. "
+                + "Remove the PROPERTY entry.");
+      }
+
+      if (STREAM_TYPE_KEY.equals(lower) || lower.startsWith(STREAM_PREFIX)
+          || lower.startsWith(REALTIME_PREFIX)) {
+        throw new DdlCompilationException(
+            "Property '" + rawKey + "' is REALTIME-only and not valid on CREATE MATERIALIZED VIEW "
+                + "(materialized views are always OFFLINE).");
+      }
+
+      if (PROMOTED_KEYS.contains(lower)) {
+        applyPromoted(lower, value, builder);
+        continue;
+      }
+
+      if (TASK_CONFIG_KEYS.containsKey(lower)) {
+        // Re-canonicalize the on-wire key from the CommonConstants definition. This avoids
+        // case drift when users write 'BUCKETTIMEPERIOD' but downstream consumers
+        // (MaterializedViewTaskScheduler / Analyzer) read the exact constant casing.
+        mvTaskConfig.put(TASK_CONFIG_KEYS.get(lower), value);
+        continue;
+      }
+
+      if (lower.startsWith(TASK_PREFIX)) {
+        // task.<taskType>.<key> = value
+        // Pass-through for arbitrary task types (forward-compat: a future task type
+        // composed onto an MV table just works). For MaterializedViewTask itself we accept
+        // both the prefixed form ('task.MaterializedViewTask.bucketTimePeriod') and the
+        // bare form ('bucketTimePeriod'); the bare form is preferred and documented.
+        String afterPrefix = rawKey.substring(TASK_PREFIX.length());
+        int dot = afterPrefix.indexOf('.');
+        if (dot <= 0 || dot == afterPrefix.length() - 1) {
+          throw new DdlCompilationException(
+              "Task property '" + rawKey + "' must follow the form task.<taskType>.<key>");
+        }
+        String taskType = afterPrefix.substring(0, dot);
+        String taskKey = afterPrefix.substring(dot + 1);
+        if (MaterializedViewTask.TASK_TYPE.equals(taskType)
+            && (SCHEDULE_KEY.equals(taskKey.toLowerCase(Locale.ROOT))
+                || MaterializedViewTask.DEFINED_SQL_KEY.equalsIgnoreCase(taskKey))) {
+          throw new DdlCompilationException(
+              "Property '" + rawKey + "' is reserved for the corresponding DDL clause "
+                  + "(REFRESH EVERY for 'schedule', AS <query> for 'definedSQL'); "
+                  + "remove it from PROPERTIES.");
+        }
+        if (MaterializedViewTask.TASK_TYPE.equals(taskType)) {
+          // Canonicalize the knob casing the same way the bare-form branch does, so
+          // `task.MaterializedViewTask.BUCKETTIMEPERIOD` and bare `BUCKETTIMEPERIOD` end up
+          // under the same on-wire key (the constant casing in CommonConstants).
+          String canonical = TASK_CONFIG_KEYS.getOrDefault(taskKey.toLowerCase(Locale.ROOT), taskKey);
+          mvTaskConfig.put(canonical, value);
+        } else {
+          taskConfigs.computeIfAbsent(taskType, k -> new LinkedHashMap<>()).put(taskKey, value);
+        }
+        continue;
+      }
+
+      customConfigs.put(rawKey, value);
+    }
+
+    // Synthetic keys from AS <query> (always) and REFRESH EVERY (when supplied). Always
+    // last so they overwrite any user-supplied collision detected above (we already rejected
+    // those, so this is purely belt-and-braces for future contributors). Omitting `schedule`
+    // entirely is a documented contract — `PinotTaskManager#getTaskToCronExpressionMap`
+    // skips per-table cron registration when the key is absent, leaving the task to run on
+    // the cluster-wide schedule.
+    mvTaskConfig.put(MaterializedViewTask.DEFINED_SQL_KEY, definedSql);
+    if (schedule != null) {
+      mvTaskConfig.put(SCHEDULE_KEY, schedule);
+    }
+
+    taskConfigs.put(MaterializedViewTask.TASK_TYPE, mvTaskConfig);
+    builder.setTaskConfig(new TableTaskConfig(taskConfigs));
+
+    if (!customConfigs.isEmpty()) {
+      builder.setCustomConfig(new TableCustomConfig(customConfigs));
+    }
+  }
+
+  private static void applyPromoted(String lowerKey, String value, TableConfigBuilder builder) {
+    switch (lowerKey) {
+      case "timecolumnname":
+      case "timecolumn":
+        builder.setTimeColumnName(value);
+        return;
+      case "timetype":
+        builder.setTimeType(value);
+        return;
+      case "replication":
+        builder.setNumReplicas(parseInt("replication", value));
+        return;
+      case "brokertenant":
+        builder.setBrokerTenant(value);
+        return;
+      case "servertenant":
+        builder.setServerTenant(value);
+        return;
+      default:
+        throw new IllegalStateException("Unreachable: applyPromoted called with non-promoted key " + lowerKey);
+    }
+  }
+
+  // ------------------------------------------------------------------------------------------
+  // Period → Quartz cron translation
+  // ------------------------------------------------------------------------------------------
+
+  /// Translates a Pinot period string (`'Nd'`, `'Nh'`, `'Nm'`) into a Quartz cron expression
+  /// for the `task.MaterializedViewTask.schedule` field. The grammar in pinot-common already
+  /// normalizes `EVERY 2 DAYS` → `'2d'`; this method is the only consumer of the normalized
+  /// form on the compile side.
+  ///
+  /// Mapping (all in cluster-local time, i.e. whatever the controller JVM's default zone is):
+  /// | Input    | Output cron        | Semantics                                  |
+  /// | -------- | ------------------ | ------------------------------------------ |
+  /// | `1m`     | `0 * * * * ?`      | every minute at second 0                   |
+  /// | `Nm`     | `0 0/N * * * ?`    | every N minutes starting at minute 0       |
+  /// | `1h`     | `0 0 * * * ?`      | every hour at minute 0                     |
+  /// | `Nh`     | `0 0 0/N * * ?`    | every N hours starting at hour 0           |
+  /// | `1d`     | `0 0 0 * * ?`      | every day at 00:00:00                      |
+  /// | `Nd`     | `0 0 0 1/N * ?`    | every N days starting day 1 of each month  |
+  ///
+  /// Caveat for `Nd` with `N > 1`: the day-of-month cycle resets at the start of each month
+  /// (Quartz semantics). With `N ≤ 28` this is well-defined; larger values are rejected.
+  /// Operators needing irregular schedules can use the raw `task.MaterializedViewTask.schedule`
+  /// escape hatch via PROPERTIES — currently disallowed for safety; tracked as a follow-up.
+  public static String periodToCron(String period) {
+    if (period == null) {
+      throw new DdlCompilationException(
+          "REFRESH EVERY <period> is required (e.g. '1d', '15m', or '6 HOURS').");
+    }
+    String trimmed = period.trim().toLowerCase(Locale.ROOT);
+    if (trimmed.isEmpty()) {
+      throw new DdlCompilationException("REFRESH EVERY <period> must not be empty.");
+    }
+    char unit = trimmed.charAt(trimmed.length() - 1);
+    if (unit != 'd' && unit != 'h' && unit != 'm') {
+      throw new DdlCompilationException(
+          "REFRESH EVERY '" + period + "' must end with 'd' (days), 'h' (hours), or 'm' (minutes).");
+    }
+    String numericPart = trimmed.substring(0, trimmed.length() - 1);
+    int n;
+    try {
+      n = Integer.parseInt(numericPart);
+    } catch (NumberFormatException e) {
+      throw new DdlCompilationException(
+          "REFRESH EVERY '" + period + "' has a non-integer count; expected e.g. '15m', '6h', or '1d'.");
+    }
+    if (n < 1) {
+      throw new DdlCompilationException(
+          "REFRESH EVERY period must be ≥ 1; got '" + period + "'.");
+    }
+    switch (unit) {
+      case 'm':
+        if (n > 59) {
+          throw new DdlCompilationException(
+              "REFRESH EVERY '" + period + "' exceeds 59 minutes; use '1h' or larger.");
+        }
+        return n == 1 ? "0 * * * * ?" : "0 0/" + n + " * * * ?";
+      case 'h':
+        if (n > 23) {
+          throw new DdlCompilationException(
+              "REFRESH EVERY '" + period + "' exceeds 23 hours; use '1d' or larger.");
+        }
+        return n == 1 ? "0 0 * * * ?" : "0 0 0/" + n + " * * ?";
+      case 'd':
+        if (n > 28) {
+          throw new DdlCompilationException(
+              "REFRESH EVERY '" + period + "' exceeds 28 days; daily cycles must be at most 28 "
+                  + "days to remain well-defined under the monthly day-of-month wrap.");
+        }
+        return n == 1 ? "0 0 0 * * ?" : "0 0 0 1/" + n + " * ?";
+      default:
+        throw new IllegalStateException("unreachable");
+    }
+  }
+
+  private static int parseInt(String key, String value) {
+    try {
+      return Integer.parseInt(value.trim());
+    } catch (NumberFormatException e) {
+      throw new DdlCompilationException(
+          "Property '" + key + "' must be an integer; got '" + value + "'.");
+    }
+  }
+
+  // ------------------------------------------------------------------------------------------
+  // Quartz cron -> period (inverse of periodToCron, used by reverse DDL emission)
+  // ------------------------------------------------------------------------------------------
+
+  /// Exact patterns produced by [#periodToCron]. Reverse DDL emission matches the persisted
+  /// `task.MaterializedViewTask.schedule` value against these patterns; anything not produced
+  /// by a `REFRESH EVERY '<period>'` round-trip is treated as a non-standard cron the user
+  /// must have written by hand via the JSON API, and emission rejects it (the DDL grammar has
+  /// no syntax to express arbitrary cron). Pinning the inverse mapping in the same file as
+  /// the forward mapping makes it a single edit to add or correct a period unit.
+  private static final Pattern EVERY_ONE_MINUTE = Pattern.compile("0 \\* \\* \\* \\* \\?");
+  private static final Pattern EVERY_N_MINUTES = Pattern.compile("0 0/(\\d+) \\* \\* \\* \\?");
+  private static final Pattern EVERY_ONE_HOUR = Pattern.compile("0 0 \\* \\* \\* \\?");
+  private static final Pattern EVERY_N_HOURS = Pattern.compile("0 0 0/(\\d+) \\* \\* \\?");
+  private static final Pattern EVERY_ONE_DAY = Pattern.compile("0 0 0 \\* \\* \\?");
+  private static final Pattern EVERY_N_DAYS = Pattern.compile("0 0 0 1/(\\d+) \\* \\?");
+
+  /// Inverse of [#periodToCron]: turns a persisted Quartz cron expression back into the
+  /// `'Nd'` / `'Nh'` / `'Nm'` period string the DDL `REFRESH EVERY` clause produces.
+  /// Returns `null` when `cron` is null/blank or when the expression is not one of the six
+  /// patterns this router itself emits. The reverse DDL emitter consults this method and
+  /// rejects MVs whose schedule it cannot express — silently dropping a schedule on
+  /// SHOW CREATE would let `emit -> parse -> emit` produce a config that re-runs against the
+  /// cluster-wide cron instead of the operator-chosen one (an invisible behavioural change).
+  @Nullable
+  public static String cronToPeriod(@Nullable String cron) {
+    if (cron == null) {
+      return null;
+    }
+    String trimmed = cron.trim();
+    if (trimmed.isEmpty()) {
+      return null;
+    }
+    if (EVERY_ONE_MINUTE.matcher(trimmed).matches()) {
+      return "1m";
+    }
+    Matcher m = EVERY_N_MINUTES.matcher(trimmed);
+    if (m.matches()) {
+      // Round-trip safety: only return the inverse if the forward direction would re-produce
+      // this exact cron. Guards against an operator-typed `0 0/60 * * * ?` (legal Quartz but
+      // rejected by periodToCron as >59 minutes) silently round-tripping through the DDL form.
+      int n = Integer.parseInt(m.group(1));
+      if (n >= 2 && n <= 59) {
+        return n + "m";
+      }
+      return null;
+    }
+    if (EVERY_ONE_HOUR.matcher(trimmed).matches()) {
+      return "1h";
+    }
+    m = EVERY_N_HOURS.matcher(trimmed);
+    if (m.matches()) {
+      int n = Integer.parseInt(m.group(1));
+      if (n >= 2 && n <= 23) {
+        return n + "h";
+      }
+      return null;
+    }
+    if (EVERY_ONE_DAY.matcher(trimmed).matches()) {
+      return "1d";
+    }
+    m = EVERY_N_DAYS.matcher(trimmed);
+    if (m.matches()) {
+      int n = Integer.parseInt(m.group(1));
+      if (n >= 2 && n <= 28) {
+        return n + "d";
+      }
+      return null;
+    }
+    return null;
+  }
+}

--- a/pinot-sql-ddl/src/main/java/org/apache/pinot/sql/ddl/compile/PropertyMapping.java
+++ b/pinot-sql-ddl/src/main/java/org/apache/pinot/sql/ddl/compile/PropertyMapping.java
@@ -301,8 +301,19 @@ public final class PropertyMapping {
         builder.setIsDimTable(parseBool(lowerKey, value));
         return true;
       case "ismaterializedview":
-        builder.setIsMaterializedView(parseBool(lowerKey, value));
-        return true;
+        // The materialized-view flag is identity, not configuration: per PR #18564 the canonical
+        // way to mark a table as an MV is the dedicated `CREATE MATERIALIZED VIEW` statement,
+        // and the compiler stamps `TableConfig#isMaterializedView` on that path automatically.
+        // Allowing it as a CREATE TABLE PROPERTY would either (a) construct a config whose flag
+        // is true but task block is empty — rejected at addTable time by the SPI invariant
+        // `TableConfigUtils.validateMaterializedViewInvariants` with a confusing message, or
+        // (b) flip the flag off underneath a CREATE MV path. Reject it up front in both
+        // directions so the operator gets a clear pointer to the right DDL form.
+        throw new DdlCompilationException(
+            "Property 'isMaterializedView' is reserved: materialized views must be created via "
+                + "'CREATE MATERIALIZED VIEW ...' rather than 'CREATE TABLE ... PROPERTIES "
+                + "(\"isMaterializedView\" = ...)'. The flag is stamped on the TableConfig "
+                + "automatically by the MV compiler path.");
       case "invertedindexcolumns":
         builder.setInvertedIndexColumns(splitCsv(value));
         return true;

--- a/pinot-sql-ddl/src/main/java/org/apache/pinot/sql/ddl/inferer/MaterializedViewInferenceInput.java
+++ b/pinot-sql-ddl/src/main/java/org/apache/pinot/sql/ddl/inferer/MaterializedViewInferenceInput.java
@@ -1,0 +1,82 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.sql.ddl.inferer;
+
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.apache.pinot.common.config.provider.TableCache;
+
+
+/// Bundle of inputs the {@link MaterializedViewSchemaInferer} needs to derive the MV
+/// column list from {@code AS definedSQL}. Immutable struct so future stateful collaborators
+/// can be added without breaking the inferer's public API.
+public final class MaterializedViewInferenceInput {
+
+  private final String _definedSql;
+  @Nullable
+  private final String _databaseName;
+  private final String _viewTableName;
+  private final Map<String, String> _properties;
+  @Nullable
+  private final TableCache _tableCache;
+
+  public MaterializedViewInferenceInput(String definedSql, @Nullable String databaseName,
+      String viewTableName, Map<String, String> properties, @Nullable TableCache tableCache) {
+    _definedSql = definedSql;
+    _databaseName = databaseName;
+    _viewTableName = viewTableName;
+    _properties = properties;
+    _tableCache = tableCache;
+  }
+
+  /// The raw user-typed text of the {@code AS <query>} clause. Already extracted by
+  /// {@link org.apache.pinot.sql.ddl.compile.DdlCompiler} so the inferer never needs to do
+  /// substring slicing itself.
+  public String definedSql() {
+    return _definedSql;
+  }
+
+  /// The MV's database scope (from a {@code db.mvName} reference), or {@code null} when
+  /// the MV is in the cluster's default database. Threaded into Calcite's
+  /// {@code QueryEnvironment} as the default-catalog name for validator lookups.
+  @Nullable
+  public String databaseName() {
+    return _databaseName;
+  }
+
+  /// The MV's own (raw, non-type-suffixed) table name. Used only for error messages today.
+  public String viewTableName() {
+    return _viewTableName;
+  }
+
+  /// User-supplied {@code PROPERTIES (...)} entries, with original casing preserved.
+  /// The inferer reads {@code timeColumnName} (case-insensitively) to decide which SELECT
+  /// alias becomes the MV's primary time column.
+  public Map<String, String> properties() {
+    return _properties;
+  }
+
+  /// {@link TableCache} backing Calcite's catalog. Required so {@code QueryEnvironment}
+  /// can validate {@code definedSql} against the live cluster catalog. The inferer
+  /// surfaces a {@code DdlCompilationException} when this is null.
+  @Nullable
+  public TableCache tableCache() {
+    return _tableCache;
+  }
+}

--- a/pinot-sql-ddl/src/main/java/org/apache/pinot/sql/ddl/inferer/MaterializedViewSchemaInferer.java
+++ b/pinot-sql-ddl/src/main/java/org/apache/pinot/sql/ddl/inferer/MaterializedViewSchemaInferer.java
@@ -1,0 +1,249 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.sql.ddl.inferer;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import org.apache.calcite.rel.RelRoot;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.pinot.common.materializedview.MaterializedViewAggregationCatalog;
+import org.apache.pinot.common.request.Expression;
+import org.apache.pinot.common.request.ExpressionType;
+import org.apache.pinot.common.request.Function;
+import org.apache.pinot.common.request.PinotQuery;
+import org.apache.pinot.common.utils.request.RequestUtils;
+import org.apache.pinot.query.QueryEnvironment;
+import org.apache.pinot.query.planner.logical.RelToPlanNodeConverter;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.exception.QueryException;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.sql.ddl.compile.DdlCompilationException;
+import org.apache.pinot.sql.ddl.resolved.ColumnRole;
+import org.apache.pinot.sql.ddl.resolved.ResolvedColumnDefinition;
+import org.apache.pinot.sql.parsers.CalciteSqlParser;
+import org.apache.pinot.sql.parsers.SqlCompilationException;
+
+
+/// MV schema inferer. Validates {@code AS definedSQL} via Calcite's
+/// {@link QueryEnvironment} and emits a {@link ResolvedColumnDefinition} per output
+/// column. Scope is deliberately narrow:
+///
+/// - **Data type** comes from Calcite's validated row type (multi-stage engine semantics).
+/// - **Time column** (the projection alias matching `timeColumnName`) is always pinned to
+///   {@link DataType#TIMESTAMP} with format `1:MILLISECONDS:TIMESTAMP` and granularity
+///   `1:MILLISECONDS`. The inferer does not try to derive granularity from the SELECT
+///   expression — the table-create-time analyzer handles base-column / `bucketTimePeriod`
+///   alignment. Users who need a different time-column shape must use the explicit column
+///   list form.
+/// - **Aggregations on the MV-supported allow-list** ({@link MaterializedViewAggregationCatalog})
+///   take their {@link DataType} from the catalog so the sketch `BYTES` override that the
+///   rewrite engine relies on is preserved.
+/// - All other columns are emitted as {@link ColumnRole#DIMENSION} with the Calcite-derived
+///   `DataType`, NOT NULL, no format / no default. Users who need different defaults,
+///   nullability, multi-value, or a non-DIMENSION role should fall back to an explicit
+///   column list.
+///
+/// Calcite's validator is also responsible for catching SQL-shape errors (column typos,
+/// function arity, JOIN, multi-FROM, multi-value source, etc.) at DDL-compile time —
+/// the inferer simply surfaces those as {@link DdlCompilationException}.
+public final class MaterializedViewSchemaInferer {
+
+  /// MV time columns are pinned to millis-epoch TIMESTAMP. The downstream analyzer enforces
+  /// `bucketTimePeriod` alignment against this canonical granularity.
+  private static final String DATETIME_TIMESTAMP_FORMAT = "1:MILLISECONDS:TIMESTAMP";
+  private static final String DATETIME_MILLIS_GRANULARITY = "1:MILLISECONDS";
+
+  private MaterializedViewSchemaInferer() {
+  }
+
+  public static List<ResolvedColumnDefinition> infer(MaterializedViewInferenceInput input) {
+    if (input.tableCache() == null) {
+      throw new DdlCompilationException(
+          "Cannot infer MV columns: no TableCache is configured. The DDL endpoint must "
+              + "construct a DdlCompileContext with the cluster's TableCache so Calcite's "
+              + "catalog can validate the AS <query>. Or supply an explicit column list in "
+              + "the CREATE MATERIALIZED VIEW statement.");
+    }
+
+    // Parse to Pinot's Thrift representation (for SELECT-list shape inspection) and
+    // validate through Calcite (for SQL-shape errors + per-output-column data types).
+    PinotQuery pinotQuery;
+    try {
+      pinotQuery = CalciteSqlParser.compileToPinotQuery(input.definedSql());
+    } catch (SqlCompilationException e) {
+      throw new DdlCompilationException(
+          "Could not parse AS <query> for MV column inference: " + e.getMessage(), e);
+    }
+
+    String calciteDatabase = input.databaseName() != null ? input.databaseName()
+        : CommonConstants.DEFAULT_DATABASE;
+    RelRoot relRoot;
+    try {
+      QueryEnvironment env = new QueryEnvironment(calciteDatabase, input.tableCache(), null);
+      try (QueryEnvironment.CompiledQuery compiled = env.compile(input.definedSql())) {
+        relRoot = compiled.getRelRoot();
+      }
+    } catch (QueryException e) {
+      throw new DdlCompilationException(
+          "MV column inference: AS <query> failed Calcite validation: " + e.getMessage(), e);
+    } catch (RuntimeException e) {
+      // Defensive: any other RuntimeException out of QueryEnvironment is a programming
+      // error or upstream change. Wrap so the controller surfaces a 400 instead of a 500.
+      throw new DdlCompilationException(
+          "MV column inference: AS <query> compilation failed unexpectedly: " + e.getMessage(), e);
+    }
+
+    String timeColumnName = lookupTimeColumnName(input.properties());
+
+    List<Expression> selectList = pinotQuery.getSelectList();
+    if (selectList == null || selectList.isEmpty()) {
+      throw new DdlCompilationException(
+          "MV column inference requires a non-empty SELECT list in AS <query>.");
+    }
+    List<RelDataTypeField> calciteFields = relRoot.validatedRowType.getFieldList();
+    if (calciteFields.size() != selectList.size()) {
+      throw new DdlCompilationException(
+          "MV column inference: parser and Calcite validator produced different SELECT "
+              + "list sizes (" + selectList.size() + " vs " + calciteFields.size()
+              + "). This is a parser/validator skew that should not happen for well-formed "
+              + "SQL; please report.");
+    }
+
+    List<ResolvedColumnDefinition> columns = new ArrayList<>(selectList.size());
+    Set<String> seenLower = new HashSet<>();
+    boolean timeColumnSeen = false;
+    for (int i = 0; i < selectList.size(); i++) {
+      Expression item = selectList.get(i);
+      RelDataTypeField calciteField = calciteFields.get(i);
+
+      if (item.getType() == ExpressionType.IDENTIFIER
+          && "*".equals(item.getIdentifier().getName())) {
+        throw new DdlCompilationException(
+            "MV column inference does not support 'SELECT *'. Either list each output "
+                + "column explicitly with 'expr AS alias' or supply a full CREATE "
+                + "MATERIALIZED VIEW column list.");
+      }
+
+      String columnName;
+      try {
+        columnName = RequestUtils.extractAliasOrIdentifierName(item);
+      } catch (IllegalStateException e) {
+        throw new DdlCompilationException(
+            "MV column inference requires every non-bare SELECT item to be written as "
+                + "'expr AS alias' (e.g. 'SUM(x) AS total'). Either add an AS alias for each "
+                + "computed expression or supply a full CREATE MATERIALIZED VIEW column list.", e);
+      }
+      if (!seenLower.add(columnName.toLowerCase(Locale.ROOT))) {
+        throw new DdlCompilationException("MV inference produced duplicate column name '"
+            + columnName + "'. Distinct AS aliases are required.");
+      }
+
+      ResolvedColumnDefinition column = inferColumn(item, columnName, calciteField, timeColumnName);
+      if (column.getRole() == ColumnRole.DATETIME && columnName.equalsIgnoreCase(timeColumnName)) {
+        timeColumnSeen = true;
+      }
+      columns.add(column);
+    }
+
+    if (!timeColumnSeen) {
+      throw new DdlCompilationException(
+          "MV's timeColumnName '" + timeColumnName + "' must be produced as one of the "
+              + "SELECT-list aliases. No matching projection found.");
+    }
+    return columns;
+  }
+
+  /// Selects the column shape:
+  ///
+  ///   1. Time column (alias matches `timeColumnName`) → canonical TIMESTAMP DATETIME.
+  ///   2. Recognised MV aggregation (operator on the catalog allow-list) → catalog
+  ///      {@link DataType}, METRIC role. Sketch aggregations land as BYTES per the
+  ///      catalog's load-bearing override.
+  ///   3. Everything else → Calcite-derived {@link DataType}, DIMENSION role.
+  private static ResolvedColumnDefinition inferColumn(Expression item, String columnName,
+      RelDataTypeField calciteField, String timeColumnName) {
+    if (columnName.equalsIgnoreCase(timeColumnName)) {
+      return new ResolvedColumnDefinition(columnName, DataType.TIMESTAMP, ColumnRole.DATETIME,
+          /* singleValue = */ true, /* notNull = */ true, /* defaultValue = */ null,
+          DATETIME_TIMESTAMP_FORMAT, DATETIME_MILLIS_GRANULARITY);
+    }
+
+    Expression source = RequestUtils.unwrapAlias(item);
+    if (source.getType() == ExpressionType.FUNCTION) {
+      Function func = source.getFunctionCall();
+      String op = func.getOperator();
+      if (MaterializedViewAggregationCatalog.isSupported(op)) {
+        DataType dt = MaterializedViewAggregationCatalog.getInferredDataType(op);
+        return new ResolvedColumnDefinition(columnName, dt, ColumnRole.METRIC,
+            /* singleValue = */ true, /* notNull = */ true, /* defaultValue = */ null,
+            /* dateTimeFormat = */ null, /* dateTimeGranularity = */ null);
+      }
+    }
+
+    // Default: trust Calcite's validated type for this output column. Used for bare
+    // identifier passthroughs, scalar transforms, and any aggregation not on the MV
+    // catalog allow-list. Multi-value / DATETIME-typed source columns flow through here
+    // as DIMENSION; users who need a different role / format must use the explicit form.
+    return new ResolvedColumnDefinition(columnName, calciteDataType(calciteField, columnName),
+        ColumnRole.DIMENSION, /* singleValue = */ true, /* notNull = */ true,
+        /* defaultValue = */ null, /* dateTimeFormat = */ null, /* dateTimeGranularity = */ null);
+  }
+
+  private static DataType calciteDataType(RelDataTypeField field, String columnName) {
+    try {
+      return RelToPlanNodeConverter.convertToColumnDataType(field.getType()).toDataType();
+    } catch (IllegalArgumentException | UnsupportedOperationException e) {
+      throw new DdlCompilationException(
+          "MV column inference: Calcite type '" + field.getType() + "' for column '"
+              + columnName + "' has no Pinot equivalent. Supply an explicit column list.", e);
+    }
+  }
+
+  private static String lookupTimeColumnName(Map<String, String> properties) {
+    if (properties == null) {
+      throw new DdlCompilationException(
+          "MV column inference requires a 'timeColumnName' property; PROPERTIES clause "
+              + "is missing.");
+    }
+    for (Map.Entry<String, String> e : properties.entrySet()) {
+      String key = e.getKey();
+      if (key == null) {
+        continue;
+      }
+      String lower = key.toLowerCase(Locale.ROOT);
+      if ("timecolumnname".equals(lower) || "timecolumn".equals(lower)) {
+        String value = e.getValue();
+        if (value == null || value.isEmpty()) {
+          throw new DdlCompilationException(
+              "MV property 'timeColumnName' is empty; supply the SELECT-list alias that "
+                  + "produces the MV's primary time column.");
+        }
+        return value;
+      }
+    }
+    throw new DdlCompilationException(
+        "MV column inference requires an explicit 'timeColumnName' property in PROPERTIES "
+            + "clause naming the SELECT-list alias that produces the MV's primary time "
+            + "column.");
+  }
+}

--- a/pinot-sql-ddl/src/main/java/org/apache/pinot/sql/ddl/reverse/CanonicalDdlEmitter.java
+++ b/pinot-sql-ddl/src/main/java/org/apache/pinot/sql/ddl/reverse/CanonicalDdlEmitter.java
@@ -18,25 +18,49 @@
  */
 package org.apache.pinot.sql.ddl.reverse;
 
+import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
+import java.util.TreeMap;
 import javax.annotation.Nullable;
 import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableTaskConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.CommonConstants.MaterializedViewTask;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+import org.apache.pinot.sql.ddl.compile.MaterializedViewPropertyRouter;
 
 
-/// Renders a `CREATE TABLE` statement in canonical Pinot DDL form from a [Schema] and
-/// [TableConfig]. Designed so that `parse(emit(schema, config))` round-trips back to
-/// a semantically-equivalent (Schema, TableConfig) pair.
+/// Renders a `CREATE TABLE` or `CREATE MATERIALIZED VIEW` statement in canonical Pinot DDL
+/// form from a [Schema] and [TableConfig]. Designed so that
+/// `parse(emit(schema, config))` round-trips back to a semantically-equivalent
+/// (Schema, TableConfig) pair.
 ///
-/// Canonical formatting rules:
+/// Dispatch rule: an MV is identified by the canonical [TableConfig#isMaterializedView] flag
+/// (single source of truth per PR #18564). The dispatch is
+/// **strict and one-way** (the Q2=B contract): a config that the dispatch identifies as MV
+/// always emits `CREATE MATERIALIZED VIEW`, and the controller-side `SHOW CREATE TABLE`
+/// endpoint refuses MV inputs (callers must use the dedicated `SHOW CREATE MATERIALIZED VIEW`
+/// form). The emitter itself is happy to render either form for either DDL request shape; the
+/// "can't use SHOW CREATE TABLE on an MV" rule is enforced by the controller, not here, so
+/// `pinot-sql-ddl` tests can still emit either form directly when verifying round-trip
+/// fidelity.
+///
+/// Canonical formatting rules (apply to both forms):
 /// - Two-space indentation, one column per line, trailing comma between entries.
-/// - Clause order: column block, `TABLE_TYPE`, `PROPERTIES`.
-/// - Property keys in lexicographic order (provided by [PropertyExtractor]).
+/// - Property keys in lexicographic order (provided by [PropertyExtractor];
+///   MV emission adds [#extractMaterializedViewProperties] on top to strip synthetic
+///   clause keys and flatten canonical task knobs to bare DDL form).
 /// - Identifiers double-quoted only when required (reserved words, special chars).
 /// - String literals always single-quoted; embedded single quotes doubled.
+///
+/// Clause order:
+/// - `CREATE TABLE`: column block, `TABLE_TYPE`, `PROPERTIES`.
+/// - `CREATE MATERIALIZED VIEW`: column block, `REFRESH EVERY` (when present and
+///   round-trippable), `PROPERTIES`, `AS <definedSQL>`.
 ///
 /// Stateless and thread-safe.
 public final class CanonicalDdlEmitter {
@@ -59,30 +83,152 @@ public final class CanonicalDdlEmitter {
   /// Renders the canonical DDL, scoped under `databaseName` when non-null. The database name
   /// is rendered as a leading `db.` qualifier on the table name; this matches the parser's
   /// `[db.]name` grammar.
+  ///
+  /// Dispatches to [#emitMaterializedView] when `config.isMaterializedView()` is true; otherwise
+  /// renders a regular `CREATE TABLE`.
   public static String emit(Schema schema, TableConfig config, @Nullable String databaseName) {
+    if (config != null && config.isMaterializedView()) {
+      return emitMaterializedView(schema, config, databaseName);
+    }
+    return emitTable(schema, config, databaseName);
+  }
+
+  private static String emitTable(Schema schema, TableConfig config, @Nullable String databaseName) {
     rejectUnsupportedSchemaMetadata(schema);
     StringBuilder sb = new StringBuilder(512);
 
-    String rawTableName = TableNameBuilder.extractRawTableName(config.getTableName());
-
-    // Derive the effective database: explicit argument wins; fall back to any db. prefix already
-    // embedded in the raw table name (e.g. analytics.events_OFFLINE → "analytics"). This ensures
-    // the no-database overload emit(schema, config) preserves a db-qualified table name rather
-    // than silently stripping it to a bare name that would land in the wrong database on replay.
-    String effectiveDb = databaseName;
-    if ((effectiveDb == null || effectiveDb.isEmpty()) && rawTableName.contains(".")) {
-      int dot = rawTableName.indexOf('.');
-      effectiveDb = rawTableName.substring(0, dot);
-    }
-    String displayName = rawTableName.contains(".") ? rawTableName.substring(rawTableName.indexOf('.') + 1)
-        : rawTableName;
+    QualifiedName name = resolveQualifiedName(config, databaseName);
 
     sb.append("CREATE TABLE ");
-    if (effectiveDb != null && !effectiveDb.isEmpty()) {
-      sb.append(SqlIdentifiers.quote(effectiveDb)).append('.');
-    }
-    sb.append(SqlIdentifiers.quote(displayName));
+    appendQualifiedName(sb, name);
     sb.append(" (\n");
+    appendColumnBlock(sb, schema);
+    sb.append(")\n");
+    appendPrimaryKey(sb, schema);
+
+    sb.append("TABLE_TYPE = ").append(emitTableType(config.getTableType())).append('\n');
+
+    Map<String, String> props = PropertyExtractor.extract(config);
+    appendPropertiesAndTerminate(sb, props);
+    return sb.toString();
+  }
+
+  /// Renders `CREATE MATERIALIZED VIEW [db.]name ( ... ) [REFRESH EVERY '<period>']
+  /// [PROPERTIES (...)] AS <definedSQL>;`.
+  ///
+  /// Failure modes (all surfaced as IllegalArgumentException so the controller returns a 400
+  /// with the cause routed back to the caller, never a 500/NPE):
+  /// - The dispatch in [#emit] reaches us via [TableConfig#isMaterializedView], which is just
+  ///   a flag read on `_materializedView` and does NOT validate the task-config block itself.
+  ///   So a TableConfig with `isMaterializedView=true` is structurally allowed to also have:
+  ///       (a) `getTaskConfig() == null` — operator-typed JSON or a half-written config;
+  ///       (b) `getConfigsForTaskType(MaterializedViewTask.TASK_TYPE) == null` — task block
+  ///           present but missing the MV-specific entry; or
+  ///       (c) the entry present but with no/empty `definedSQL` value.
+  ///   Any of (a)/(b)/(c) → IllegalArgumentException with a message that pinpoints which
+  ///   layer is missing, so the operator can target the right znode field without guessing.
+  ///   The forward-direction validator
+  ///   `org.apache.pinot.sql.ddl.compile.DdlCompiler#compileMaterializedViewBucketRequirement`
+  ///   uses the same null-guard shape — keeping these symmetric prevents drift if either side
+  ///   evolves.
+  /// - `task.MaterializedViewTask.schedule` present but [MaterializedViewPropertyRouter#cronToPeriod]
+  ///   returns null (non-standard / hand-typed cron) → IllegalArgumentException (Q1=A
+  ///   contract). The DDL grammar has no syntax for raw cron, so silently dropping the
+  ///   schedule on `SHOW CREATE MATERIALIZED VIEW` would let `emit → parse → emit` produce a
+  ///   config that runs on the cluster-wide cron instead of the operator-chosen one — a
+  ///   user-invisible behavioural change.
+  private static String emitMaterializedView(Schema schema, TableConfig config,
+      @Nullable String databaseName) {
+    rejectUnsupportedSchemaMetadata(schema);
+    StringBuilder sb = new StringBuilder(512);
+
+    QualifiedName name = resolveQualifiedName(config, databaseName);
+    // Three-stage null-guard mirroring `DdlCompiler.compileMaterializedViewBucketRequirement`.
+    // The previous shape collapsed both upstream nulls into a single `definedSql == null` check
+    // AFTER the chained dereference — a TableConfig whose `getTaskConfig()` is null or whose
+    // task-type map lacks the MV entry would NPE on the chain itself, surfacing as a 500
+    // instead of the actionable 400 we want.  Splitting the layers also lets the error message
+    // tell the operator exactly which znode field to repair.
+    TableTaskConfig taskConfig = config.getTaskConfig();
+    Map<String, String> mvTaskConfig = (taskConfig == null) ? null
+        : taskConfig.getConfigsForTaskType(MaterializedViewTask.TASK_TYPE);
+    String definedSql = (mvTaskConfig == null) ? null : mvTaskConfig.get(MaterializedViewTask.DEFINED_SQL_KEY);
+    if (definedSql == null || definedSql.isEmpty()) {
+      String missingLayer;
+      if (taskConfig == null) {
+        missingLayer = "the entire taskConfig block is null";
+      } else if (mvTaskConfig == null) {
+        missingLayer = "no '" + MaterializedViewTask.TASK_TYPE + "' entry in taskConfig";
+      } else {
+        missingLayer = "'task." + MaterializedViewTask.TASK_TYPE + "."
+            + MaterializedViewTask.DEFINED_SQL_KEY + "' is missing/empty";
+      }
+      throw new IllegalArgumentException(
+          "SHOW CREATE MATERIALIZED VIEW on '" + config.getTableName()
+              + "': TableConfig has isMaterializedView=true but " + missingLayer
+              + "; cannot reverse-render the view.");
+    }
+
+    sb.append("CREATE MATERIALIZED VIEW ");
+    appendQualifiedName(sb, name);
+    sb.append(" (\n");
+    appendColumnBlock(sb, schema);
+    sb.append(")\n");
+
+    String schedule = mvTaskConfig.get(MaterializedViewPropertyRouter.SCHEDULE_KEY);
+    if (schedule != null && !schedule.isEmpty()) {
+      String period = MaterializedViewPropertyRouter.cronToPeriod(schedule);
+      if (period == null) {
+        throw new IllegalArgumentException(
+            "SHOW CREATE MATERIALIZED VIEW cannot emit non-standard cron schedule '" + schedule
+                + "' on table " + config.getTableName() + ": the DDL grammar only supports the "
+                + "EVERY '<N>m|h|d' patterns produced by REFRESH EVERY. Use the JSON table "
+                + "config API to inspect this MV until the grammar supports raw cron, or "
+                + "re-create the MV with REFRESH EVERY '<period>' to make it round-trippable.");
+      }
+      sb.append("REFRESH EVERY ").append(SqlIdentifiers.quoteString(period)).append('\n');
+    }
+
+    Map<String, String> props = extractMaterializedViewProperties(config);
+    if (!props.isEmpty()) {
+      sb.append("PROPERTIES (\n");
+      int idx = 0;
+      int last = props.size() - 1;
+      for (Map.Entry<String, String> e : props.entrySet()) {
+        sb.append(INDENT)
+            .append(SqlIdentifiers.quoteString(e.getKey()))
+            .append(" = ")
+            .append(SqlIdentifiers.quoteString(e.getValue()));
+        if (idx++ < last) {
+          sb.append(',');
+        }
+        sb.append('\n');
+      }
+      sb.append(")\n");
+    }
+
+    // AS <query>: emit the stored definedSQL exactly as captured at CREATE time. We do NOT
+    // re-parse/unparse the SELECT — preserving user-typed comments, identifier casing, and
+    // whitespace matches the forward-direction substring-capture contract enforced by the
+    // compiler (extractDefinedSql). The DDL spec terminates every statement with exactly one
+    // `;`, but legacy MV configs (created via the JSON API before this DDL existed) may have
+    // been seeded from a `definedSQL` that already carries one or more trailing semicolons.
+    // Strip any trailing `;` (and surrounding whitespace) from the stored SQL before appending
+    // our own terminator so the emitted DDL is always exactly one `;` regardless of the
+    // upstream storage shape — otherwise a re-parse would have to tolerate `;;` which is not
+    // standard SQL.
+    sb.append("AS ").append(stripTrailingSemicolons(definedSql)).append(";\n");
+    return sb.toString();
+  }
+
+  private static void appendQualifiedName(StringBuilder sb, QualifiedName name) {
+    if (name._databaseName != null && !name._databaseName.isEmpty()) {
+      sb.append(SqlIdentifiers.quote(name._databaseName)).append('.');
+    }
+    sb.append(SqlIdentifiers.quote(name._displayName));
+  }
+
+  private static void appendColumnBlock(StringBuilder sb, Schema schema) {
     List<String> columns = SchemaEmitter.emitColumns(schema);
     for (int i = 0; i < columns.size(); i++) {
       sb.append(INDENT).append(columns.get(i));
@@ -91,22 +237,29 @@ public final class CanonicalDdlEmitter {
       }
       sb.append('\n');
     }
-    sb.append(")\n");
+  }
+
+  private static void appendPrimaryKey(StringBuilder sb, Schema schema) {
     List<String> primaryKeyColumns = schema.getPrimaryKeyColumns();
-    if (primaryKeyColumns != null && !primaryKeyColumns.isEmpty()) {
-      sb.append("PRIMARY KEY (");
-      for (int i = 0; i < primaryKeyColumns.size(); i++) {
-        sb.append(SqlIdentifiers.quote(primaryKeyColumns.get(i)));
-        if (i < primaryKeyColumns.size() - 1) {
-          sb.append(", ");
-        }
-      }
-      sb.append(")\n");
+    if (primaryKeyColumns == null || primaryKeyColumns.isEmpty()) {
+      return;
     }
+    sb.append("PRIMARY KEY (");
+    for (int i = 0; i < primaryKeyColumns.size(); i++) {
+      sb.append(SqlIdentifiers.quote(primaryKeyColumns.get(i)));
+      if (i < primaryKeyColumns.size() - 1) {
+        sb.append(", ");
+      }
+    }
+    sb.append(")\n");
+  }
 
-    sb.append("TABLE_TYPE = ").append(emitTableType(config.getTableType())).append('\n');
-
-    Map<String, String> props = PropertyExtractor.extract(config);
+  /// Appends `PROPERTIES (...)` (when `props` is non-empty) and terminates the statement with
+  /// `;\n`. Mirrors the regular-table emit so a missing-PROPERTIES path does not leave a
+  /// trailing blank line before the semicolon. Used only by the CREATE TABLE path; the MV path
+  /// always has at least one PROPERTIES entry (`timeColumnName` / `bucketTimePeriod` are
+  /// compiler-required) but trims unconditionally for symmetry.
+  private static void appendPropertiesAndTerminate(StringBuilder sb, Map<String, String> props) {
     if (!props.isEmpty()) {
       sb.append("PROPERTIES (\n");
       int idx = 0;
@@ -127,7 +280,57 @@ public final class CanonicalDdlEmitter {
       sb.setLength(sb.length() - 1);
     }
     sb.append(";\n");
-    return sb.toString();
+  }
+
+  /// Returns `sql` with any combination of trailing whitespace and `;` characters removed.
+  /// Pinot's `definedSQL` storage predates DDL and historically captured the raw user input
+  /// verbatim — some legacy MV configs carry a trailing `;` (sometimes more than one) that
+  /// would otherwise become `;;` after the emitter appends its own statement terminator.
+  /// Returns an empty string if `sql` is null or entirely whitespace/semicolons.
+  static String stripTrailingSemicolons(@Nullable String sql) {
+    if (sql == null) {
+      return "";
+    }
+    int end = sql.length();
+    while (end > 0) {
+      char c = sql.charAt(end - 1);
+      if (c == ';' || Character.isWhitespace(c)) {
+        end--;
+      } else {
+        break;
+      }
+    }
+    return sql.substring(0, end);
+  }
+
+  private static QualifiedName resolveQualifiedName(TableConfig config,
+      @Nullable String databaseName) {
+    String rawTableName = TableNameBuilder.extractRawTableName(config.getTableName());
+
+    // Derive the effective database: explicit argument wins; fall back to any db. prefix already
+    // embedded in the raw table name (e.g. analytics.events_OFFLINE → "analytics"). This ensures
+    // the no-database overload emit(schema, config) preserves a db-qualified table name rather
+    // than silently stripping it to a bare name that would land in the wrong database on replay.
+    String effectiveDb = databaseName;
+    if ((effectiveDb == null || effectiveDb.isEmpty()) && rawTableName.contains(".")) {
+      int dot = rawTableName.indexOf('.');
+      effectiveDb = rawTableName.substring(0, dot);
+    }
+    String displayName = rawTableName.contains(".")
+        ? rawTableName.substring(rawTableName.indexOf('.') + 1)
+        : rawTableName;
+    return new QualifiedName(effectiveDb, displayName);
+  }
+
+  private static final class QualifiedName {
+    @Nullable
+    final String _databaseName;
+    final String _displayName;
+
+    QualifiedName(@Nullable String databaseName, String displayName) {
+      _databaseName = databaseName;
+      _displayName = displayName;
+    }
   }
 
   private static void rejectUnsupportedSchemaMetadata(Schema schema) {
@@ -144,8 +347,8 @@ public final class CanonicalDdlEmitter {
   }
 
   private static void rejectUnsupportedSchemaField(String field) {
-    throw new IllegalArgumentException("SHOW CREATE TABLE cannot emit schema field '" + field
-        + "' in canonical DDL yet; replaying the emitted DDL would silently drop that setting. "
+    throw new IllegalArgumentException("Canonical DDL emission cannot represent schema field '"
+        + field + "' yet; replaying the emitted DDL would silently drop that setting. "
         + "Use the JSON schema API for this table until the DDL grammar supports it.");
   }
 
@@ -161,5 +364,69 @@ public final class CanonicalDdlEmitter {
       default:
         throw new IllegalArgumentException("Unsupported TableType for DDL emission: " + tableType);
     }
+  }
+
+  /// Reverse-DDL analogue of {@link MaterializedViewPropertyRouter} for the MV's
+  /// `PROPERTIES (...)` block. Starts from the shared {@link PropertyExtractor} output and
+  /// applies three MV-specific transforms:
+  ///
+  /// 1. **Drop synthetic clause keys.** `task.MaterializedViewTask.definedSQL` is rendered
+  ///    via the trailing `AS <query>` clause; `task.MaterializedViewTask.schedule` via the
+  ///    `REFRESH EVERY` clause. Both keys must be removed or re-parse rejects them as
+  ///    "reserved for the corresponding DDL clause".
+  /// 1. **Flatten canonical task knobs.** `task.MaterializedViewTask.<bucketTimePeriod>`
+  ///    and the other entries recognized by
+  ///    {@link MaterializedViewPropertyRouter#canonicalKnobName} are flattened back to the
+  ///    bare DDL form the forward router accepts. Preserves the user's preferred input
+  ///    shape across `emit → parse → emit`.
+  /// 1. **Keep arbitrary task entries verbatim.** Any other `task.MaterializedViewTask.<key>`
+  ///    or `task.<otherTaskType>.<key>` survives as-is so a hand-authored experimental knob
+  ///    (or a future task type composed onto an MV) does not silently disappear on round-trip.
+  private static final String MV_TASK_PREFIX = "task." + MaterializedViewTask.TASK_TYPE + ".";
+
+  private static Map<String, String> extractMaterializedViewProperties(TableConfig config) {
+    // Start from the shared extractor; it handles tenant, indexing, validation, custom
+    // configs, and JSON-blob fallback for nested configs (ingestion, upsert, etc.).
+    Map<String, String> base = new TreeMap<>(PropertyExtractor.extract(config));
+
+    // Two-pass to keep iteration safe: collect what to flatten / remove first, mutate after.
+    Map<String, String> flattened = new LinkedHashMap<>();
+    Iterator<Map.Entry<String, String>> it = base.entrySet().iterator();
+    while (it.hasNext()) {
+      Map.Entry<String, String> entry = it.next();
+      String key = entry.getKey();
+      if (!key.startsWith(MV_TASK_PREFIX)) {
+        continue;
+      }
+      // TreeMap.deleteEntry() for an internal node with two children mutates the *current*
+      // entry's key/value fields with its in-order successor's payload before unlinking the
+      // successor node. The Map.Entry handed back by the iterator is the same node object,
+      // so any access via `entry.getKey()` / `entry.getValue()` AFTER `it.remove()` reads the
+      // successor's data — that's how `task.MaterializedViewTask.maxNumRecordsPerSegment`
+      // ended up emitted with the value of the next key (`timeColumnName`) in production.
+      // Snapshot both before mutating the map.
+      String value = entry.getValue();
+      String knob = key.substring(MV_TASK_PREFIX.length());
+      String lowerKnob = knob.toLowerCase(Locale.ROOT);
+
+      // Synthetic clause keys must be dropped; re-parse rejects them in PROPERTIES.
+      if (MaterializedViewTask.DEFINED_SQL_KEY.toLowerCase(Locale.ROOT).equals(lowerKnob)
+          || MaterializedViewPropertyRouter.SCHEDULE_KEY.equals(lowerKnob)) {
+        it.remove();
+        continue;
+      }
+
+      // Flatten canonical task knobs to bare form. Lowercased lookup so legacy hand-edited
+      // configs with off-case keys round-trip the same as router-produced entries.
+      String canonical = MaterializedViewPropertyRouter.canonicalKnobName(lowerKnob);
+      if (canonical != null) {
+        it.remove();
+        flattened.put(canonical, value);
+      }
+      // Unrecognized knobs stay prefixed so they survive round-trip via the router's
+      // "task prefix" rule. Add to TASK_CONFIG_KEYS to promote to bare DDL form.
+    }
+    base.putAll(flattened);
+    return base;
   }
 }

--- a/pinot-sql-ddl/src/main/java/org/apache/pinot/sql/ddl/reverse/PropertyExtractor.java
+++ b/pinot-sql-ddl/src/main/java/org/apache/pinot/sql/ddl/reverse/PropertyExtractor.java
@@ -332,9 +332,11 @@ public final class PropertyExtractor {
     if (config.isDimTable()) {
       props.put("isDimTable", "true");
     }
-    if (config.isMaterializedView()) {
-      props.put("isMaterializedView", "true");
-    }
+    // `isMaterializedView` is intentionally NOT emitted here. The flag (introduced in
+    // PR #18564) is identity, not configuration: it decides whether CanonicalDdlEmitter
+    // renders `CREATE TABLE` or `CREATE MATERIALIZED VIEW`, and round-tripping it through a
+    // PROPERTIES entry would only confuse users — both forward routers reject the key
+    // explicitly. The compiler stamps the flag automatically on the MV path.
     putIfPresent(props, "description", config.getDescription());
     List<String> tags = config.getTags();
     if (tags != null && !tags.isEmpty()) {

--- a/pinot-sql-ddl/src/main/java/org/apache/pinot/sql/ddl/reverse/SqlIdentifiers.java
+++ b/pinot-sql-ddl/src/main/java/org/apache/pinot/sql/ddl/reverse/SqlIdentifiers.java
@@ -36,6 +36,13 @@ final class SqlIdentifiers {
       // grammar keywords introduced by Pinot DDL that could appear as user identifiers
       "DIMENSION", "METRIC", "DATETIME", "FORMAT", "GRANULARITY", "OFFLINE", "REALTIME",
       "PROPERTIES", "TABLES", "TABLE_TYPE", "IF", "TYPE", "FROM",
+      // additional keywords introduced by the CREATE / SHOW CREATE / SHOW MATERIALIZED VIEW(S)
+      // grammar. Both `VIEW` (singular, used by CREATE/DROP/SHOW CREATE MATERIALIZED VIEW) and
+      // `VIEWS` (plural, declared as a parser keyword in `pinot-common/.../config.fmpp` for the
+      // catalog-listing verb `SHOW MATERIALIZED VIEWS`) must be quoted: an identifier `views`
+      // would otherwise round-trip into the `VIEWS` token slot and break re-parse the same way
+      // an identifier `tables` collides with `TABLES` (already in this set).
+      "MATERIALIZED", "VIEW", "VIEWS", "REFRESH", "EVERY",
       // standard SQL keywords that round-trip incorrectly when bare
       "TABLE", "CREATE", "DROP", "SHOW", "NOT", "NULL", "DEFAULT", "EXISTS", "AS", "BY",
       "ORDER", "PRIMARY", "KEY", "WITH", "ON", "AND", "OR", "SELECT", "WHERE",

--- a/pinot-sql-ddl/src/test/java/org/apache/pinot/sql/ddl/compile/DdlCompileContextTest.java
+++ b/pinot-sql-ddl/src/test/java/org/apache/pinot/sql/ddl/compile/DdlCompileContextTest.java
@@ -1,0 +1,79 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.sql.ddl.compile;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.expectThrows;
+
+
+/// Behavioural tests for the new stateful {@link DdlCompiler#compile(String,
+/// DdlCompileContext)} entry point and its STATELESS shim.
+public class DdlCompileContextTest {
+
+  @Test
+  public void statelessSingletonHasNullTableCache() {
+    assertNull(DdlCompileContext.STATELESS.tableCache(),
+        "STATELESS context must report a null TableCache so DDL paths that need one can "
+            + "produce an actionable error rather than NPE-ing inside the inferer.");
+  }
+
+  // ----------------------------------------------------------------------------------------------
+  // DdlCompiler entry-point semantics
+  // ----------------------------------------------------------------------------------------------
+
+  @Test
+  public void newEntryRejectsNullContext() {
+    DdlCompilationException ex = expectThrows(DdlCompilationException.class,
+        () -> DdlCompiler.compile("DROP TABLE foo", null));
+    org.assertj.core.api.Assertions.assertThat(ex.getMessage())
+        .contains("DdlCompileContext must not be null")
+        .contains("DdlCompileContext.STATELESS");
+  }
+
+  @Test
+  public void newEntryAcceptsTextualDdlWithStatelessContext() {
+    // Sanity-check that the DDL forms which never need cluster state (every form except
+    // future MV inference) still compile cleanly with the migration target STATELESS.
+    CompiledDdl compiled = DdlCompiler.compile("DROP TABLE IF EXISTS foo", DdlCompileContext.STATELESS);
+    assertNotNull(compiled);
+  }
+
+  @SuppressWarnings("deprecation")
+  @Test
+  public void deprecatedEntryDelegatesToStatelessContext() {
+    // The deprecated overload exists purely as a compatibility shim. Its behaviour MUST
+    // match `compile(sql, STATELESS)` exactly so existing callers can migrate without
+    // any observable change. We compare on the operation type rather than equality
+    // because CompiledDdl subclasses don't override equals().
+    CompiledDdl viaDeprecated = DdlCompiler.compile("DROP TABLE IF EXISTS foo");
+    CompiledDdl viaStateless = DdlCompiler.compile("DROP TABLE IF EXISTS foo", DdlCompileContext.STATELESS);
+    org.testng.Assert.assertEquals(viaDeprecated.getOperation(), viaStateless.getOperation());
+  }
+
+  @Test
+  public void newEntryRejectsEmptySql() {
+    // The original entry point's failure modes must stay reachable through the new entry.
+    assertThrows(DdlCompilationException.class,
+        () -> DdlCompiler.compile("", DdlCompileContext.STATELESS));
+  }
+}

--- a/pinot-sql-ddl/src/test/java/org/apache/pinot/sql/ddl/compile/DdlCompilerMaterializedViewInferenceTest.java
+++ b/pinot-sql-ddl/src/test/java/org/apache/pinot/sql/ddl/compile/DdlCompilerMaterializedViewInferenceTest.java
@@ -1,0 +1,92 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.sql.ddl.compile;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+
+
+/// End-to-end DDL-compiler tests for the inferred-column path of `CREATE MATERIALIZED
+/// VIEW` that exercise wiring without requiring the full Calcite/TableCache fixture.
+///
+/// Verifies that:
+///
+///   1. Errors from the inferer surface as {@link DdlCompilationException} (not raw
+///      RuntimeException) so the controller layer can return a clean 400.
+///   2. The legacy explicit-column path still works under the new entry point — i.e.
+///      the dispatch in `compileCreateMaterializedView` is "branches on emptiness of
+///      the column list" and not "always go through the inferer".
+///
+/// Happy-path inferred-column tests with full Calcite validation live alongside the
+/// {@code MaterializedViewSchemaInferer} unit tests; they require a
+/// {@code TableCache}-backed Calcite catalog that is too heavyweight for these
+/// DDL-compiler entry-point smoke tests.
+public class DdlCompilerMaterializedViewInferenceTest {
+
+  // --------------------------------------------------------------------------------------------
+  // Error surfaces
+  // --------------------------------------------------------------------------------------------
+
+  @Test
+  public void missingTableCacheProducesActionableError() {
+    DdlCompilationException ex = expectThrows(DdlCompilationException.class,
+        () -> compileMv(
+            "CREATE MATERIALIZED VIEW mv"
+                + " REFRESH EVERY 1 DAY"
+                + " PROPERTIES ('timeColumnName' = 'ts', 'bucketTimePeriod' = '1d')"
+                + " AS SELECT ts FROM src", DdlCompileContext.STATELESS));
+    // The inferer's "no TableCache" path produces a guidance message that points users at
+    // either the TableCache wiring (controller bug) or the explicit column list (user bug).
+    assertTrue(ex.getMessage().contains("TableCache")
+        || ex.getMessage().contains("explicit column list"), ex.getMessage());
+  }
+
+  // --------------------------------------------------------------------------------------------
+  // Dispatch: explicit-column path still works under the new entry point
+  // --------------------------------------------------------------------------------------------
+
+  /// Sanity check: an MV with an explicit column list must NOT touch the TableCache. The
+  /// DDL must still compile under the STATELESS context (which has no TableCache), proving
+  /// the inferer branch is gated on column-list emptiness.
+  @Test
+  public void explicitColumnListBypassesInferer() {
+    CompiledCreateMaterializedView c = compileMv(
+        "CREATE MATERIALIZED VIEW mv ("
+            + "  ts TIMESTAMP DATETIME FORMAT '1:MILLISECONDS:TIMESTAMP' GRANULARITY '1:DAYS',"
+            + "  carrier STRING"
+            + ")"
+            + " REFRESH EVERY 1 DAY"
+            + " PROPERTIES ('timeColumnName' = 'ts', 'bucketTimePeriod' = '1d')"
+            + " AS SELECT ts, carrier FROM src", DdlCompileContext.STATELESS);
+    assertEquals(c.getSchema().size(), 2);
+  }
+
+  // --------------------------------------------------------------------------------------------
+  // Helpers
+  // --------------------------------------------------------------------------------------------
+
+  private static CompiledCreateMaterializedView compileMv(String sql, DdlCompileContext ctx) {
+    CompiledDdl c = DdlCompiler.compile(sql, ctx);
+    assertEquals(c.getOperation(), DdlOperation.CREATE_MATERIALIZED_VIEW);
+    return (CompiledCreateMaterializedView) c;
+  }
+}

--- a/pinot-sql-ddl/src/test/java/org/apache/pinot/sql/ddl/compile/DdlCompilerMaterializedViewTest.java
+++ b/pinot-sql-ddl/src/test/java/org/apache/pinot/sql/ddl/compile/DdlCompilerMaterializedViewTest.java
@@ -1,0 +1,678 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.sql.ddl.compile;
+
+import java.util.Map;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.DateTimeFieldSpec;
+import org.apache.pinot.spi.utils.CommonConstants.MaterializedViewTask;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+
+
+/// End-to-end compiler tests for `CREATE MATERIALIZED VIEW` → `(Schema, OFFLINE TableConfig)`.
+public class DdlCompilerMaterializedViewTest {
+
+  // -------------------------------------------------------------------------------------------
+  // Happy path: shape & defaults
+  // -------------------------------------------------------------------------------------------
+
+  @Test
+  public void minimalCreateMaterializedView() {
+    CompiledCreateMaterializedView c = compileMaterializedView(
+        "CREATE MATERIALIZED VIEW mv ("
+            + "  ts TIMESTAMP DATETIME FORMAT '1:MILLISECONDS:TIMESTAMP' GRANULARITY '1:DAYS',"
+            + "  carrier STRING"
+            + ")"
+            + " REFRESH EVERY 1 DAY"
+            + " PROPERTIES ('timeColumnName' = 'ts', 'bucketTimePeriod' = '1d')"
+            + " AS SELECT ts, carrier FROM src");
+    assertEquals(c.getOperation(), DdlOperation.CREATE_MATERIALIZED_VIEW);
+    assertEquals(c.getTableConfig().getTableType(), TableType.OFFLINE);
+    assertEquals(c.getTableConfig().getTableName(), "mv_OFFLINE");
+    assertEquals(c.getSchema().getSchemaName(), "mv");
+
+    Map<String, String> mv = materializedViewTaskConfig(c.getTableConfig());
+    assertEquals(mv.get(MaterializedViewTask.DEFINED_SQL_KEY), "SELECT ts, carrier FROM src");
+    assertEquals(mv.get(MaterializedViewPropertyRouter.SCHEDULE_KEY), "0 0 0 * * ?");
+    assertEquals(mv.get(MaterializedViewTask.BUCKET_TIME_PERIOD_KEY), "1d");
+    assertEquals(c.getTableConfig().getValidationConfig().getTimeColumnName(), "ts");
+    assertTrue(c.getSchema().getFieldSpecFor("ts") instanceof DateTimeFieldSpec);
+  }
+
+  /// Omitting REFRESH entirely must elide the per-table schedule. Without this contract a
+  /// REFRESH-less MV would silently default to a synthesized cron, which is exactly the
+  /// invisible behaviour the schema/optionality redesign was meant to avoid: callers who
+  /// want the cluster-wide cron must be able to ask for it by saying nothing.
+  @Test
+  public void omittingRefreshClauseElidesScheduleKey() {
+    CompiledCreateMaterializedView c = compileMaterializedView(
+        "CREATE MATERIALIZED VIEW mv ("
+            + "  ts TIMESTAMP DATETIME FORMAT '1:MILLISECONDS:TIMESTAMP' GRANULARITY '1:DAYS',"
+            + "  carrier STRING"
+            + ")"
+            + " PROPERTIES ('timeColumnName' = 'ts', 'bucketTimePeriod' = '1d')"
+            + " AS SELECT ts, carrier FROM src");
+    Map<String, String> mv = materializedViewTaskConfig(c.getTableConfig());
+    // `definedSQL` must still be present — the AS clause is independent of REFRESH. Same for
+    // the unrelated `bucketTimePeriod`, which is owned by the PROPERTIES path.
+    assertEquals(mv.get(MaterializedViewTask.DEFINED_SQL_KEY), "SELECT ts, carrier FROM src");
+    assertEquals(mv.get(MaterializedViewTask.BUCKET_TIME_PERIOD_KEY), "1d");
+    assertFalse(mv.containsKey(MaterializedViewPropertyRouter.SCHEDULE_KEY),
+        "Without REFRESH the schedule key must not appear; PinotTaskManager falls back to "
+            + "the cluster-wide MV task cron when the key is absent. Found: " + mv);
+  }
+
+  @Test
+  public void databaseQualifiedNamePreservedInTableConfig() {
+    CompiledCreateMaterializedView c = compileMaterializedView(
+        "CREATE MATERIALIZED VIEW analytics.mv ("
+            + "  ts TIMESTAMP DATETIME FORMAT '1:MILLISECONDS:TIMESTAMP' GRANULARITY '1:DAYS'"
+            + ")"
+            + " REFRESH EVERY 1 DAY"
+            + " PROPERTIES ('timeColumnName' = 'ts', 'bucketTimePeriod' = '1d')"
+            + " AS SELECT ts FROM src");
+    assertEquals(c.getDatabaseName(), "analytics");
+    assertEquals(c.getTableConfig().getTableName(), "analytics.mv_OFFLINE");
+    assertEquals(c.getSchema().getSchemaName(), "mv");
+  }
+
+  @Test
+  public void ifNotExistsPropagates() {
+    CompiledCreateMaterializedView c = compileMaterializedView(
+        "CREATE MATERIALIZED VIEW IF NOT EXISTS mv ("
+            + "  ts TIMESTAMP DATETIME FORMAT '1:MILLISECONDS:TIMESTAMP' GRANULARITY '1:DAYS'"
+            + ")"
+            + " REFRESH EVERY 1 DAY"
+            + " PROPERTIES ('timeColumnName' = 'ts', 'bucketTimePeriod' = '1d')"
+            + " AS SELECT ts FROM src");
+    assertTrue(c.isIfNotExists());
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // REFRESH EVERY → Quartz cron
+  //
+  // Forward-mapping happy paths (every standard period: 1m..28d) are exercised by
+  // {@link #cronToPeriodRoundTripsEveryForwardOutput} below, which round-trips every
+  // period periodToCron supports through cronToPeriod and back. Per-period unit tests
+  // here would only re-assert that subset.
+  // -------------------------------------------------------------------------------------------
+
+  @Test
+  public void everySixtyMinutesRejected() {
+    DdlCompilationException e = expectThrows(DdlCompilationException.class,
+        () -> MaterializedViewPropertyRouter.periodToCron("60m"));
+    assertTrue(e.getMessage().contains("exceeds 59 minutes"),
+        "Expected hint to use '1h', got: " + e.getMessage());
+  }
+
+  @Test
+  public void everyTwentyFourHoursRejected() {
+    DdlCompilationException e = expectThrows(DdlCompilationException.class,
+        () -> MaterializedViewPropertyRouter.periodToCron("24h"));
+    assertTrue(e.getMessage().contains("exceeds 23 hours"));
+  }
+
+  @Test
+  public void everyTwentyNineDaysRejected() {
+    DdlCompilationException e = expectThrows(DdlCompilationException.class,
+        () -> MaterializedViewPropertyRouter.periodToCron("29d"));
+    assertTrue(e.getMessage().contains("28 days"));
+  }
+
+  @Test
+  public void everyZeroRejected() {
+    expectThrows(DdlCompilationException.class,
+        () -> MaterializedViewPropertyRouter.periodToCron("0d"));
+  }
+
+  @Test
+  public void everyUnknownUnitRejected() {
+    expectThrows(DdlCompilationException.class,
+        () -> MaterializedViewPropertyRouter.periodToCron("1y"));
+  }
+
+  @Test
+  public void everyNumericPeriodFromDdlNormalizesToCron() {
+    // EVERY 15 MINUTES → parser normalizes to '15m' → periodToCron → "0 0/15 * * * ?"
+    CompiledCreateMaterializedView c = compileMaterializedView(
+        "CREATE MATERIALIZED VIEW mv ("
+            + "  ts TIMESTAMP DATETIME FORMAT '1:MILLISECONDS:TIMESTAMP' GRANULARITY '1:HOURS'"
+            + ")"
+            + " REFRESH EVERY 15 MINUTES"
+            + " PROPERTIES ('timeColumnName' = 'ts', 'bucketTimePeriod' = '15m')"
+            + " AS SELECT ts FROM src");
+    assertEquals(materializedViewTaskConfig(c.getTableConfig())
+        .get(MaterializedViewPropertyRouter.SCHEDULE_KEY), "0 0/15 * * * ?");
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // PROPERTIES routing
+  // -------------------------------------------------------------------------------------------
+
+  @Test
+  public void taskKnobsRouteToMaterializedViewTaskConfig() {
+    CompiledCreateMaterializedView c = compileMaterializedView(
+        "CREATE MATERIALIZED VIEW mv ("
+            + "  ts TIMESTAMP DATETIME FORMAT '1:MILLISECONDS:TIMESTAMP' GRANULARITY '1:DAYS'"
+            + ")"
+            + " REFRESH EVERY 1 DAY"
+            + " PROPERTIES ("
+            + "   'timeColumnName' = 'ts',"
+            + "   'bucketTimePeriod' = '1d',"
+            + "   'bufferTimePeriod' = '2h',"
+            + "   'maxNumRecordsPerSegment' = '500000',"
+            + "   'maxTasksPerBatch' = '8',"
+            + "   'taskMode' = 'APPEND',"
+            + "   'stalenessThresholdMs' = '60000'"
+            + " )"
+            + " AS SELECT ts FROM src");
+    Map<String, String> mv = materializedViewTaskConfig(c.getTableConfig());
+    assertEquals(mv.get(MaterializedViewTask.BUCKET_TIME_PERIOD_KEY), "1d");
+    assertEquals(mv.get(MaterializedViewTask.BUFFER_TIME_PERIOD_KEY), "2h");
+    assertEquals(mv.get(MaterializedViewTask.MAX_NUM_RECORDS_PER_SEGMENT_KEY), "500000");
+    assertEquals(mv.get(MaterializedViewTask.MAX_TASKS_PER_BATCH_KEY), "8");
+    assertEquals(mv.get(MaterializedViewTask.TASK_MODE_KEY), "APPEND");
+    assertEquals(mv.get(MaterializedViewTask.STALENESS_THRESHOLD_MS_KEY), "60000");
+  }
+
+  @Test
+  public void taskKeysAreCaseInsensitiveButOnWireKeysAreCanonical() {
+    // The user writes 'BUCKETTIMEPERIOD' / 'maxtasksperbatch'; downstream consumers read
+    // the canonical-cased constants. Router must re-canonicalize.
+    CompiledCreateMaterializedView c = compileMaterializedView(
+        "CREATE MATERIALIZED VIEW mv ("
+            + "  ts TIMESTAMP DATETIME FORMAT '1:MILLISECONDS:TIMESTAMP' GRANULARITY '1:DAYS'"
+            + ")"
+            + " REFRESH EVERY 1 DAY"
+            + " PROPERTIES ('timeColumnName' = 'ts', 'BUCKETTIMEPERIOD' = '1d',"
+            + "   'maxtasksperbatch' = '4')"
+            + " AS SELECT ts FROM src");
+    Map<String, String> mv = materializedViewTaskConfig(c.getTableConfig());
+    assertEquals(mv.get(MaterializedViewTask.BUCKET_TIME_PERIOD_KEY), "1d");
+    assertEquals(mv.get(MaterializedViewTask.MAX_TASKS_PER_BATCH_KEY), "4");
+  }
+
+  @Test
+  public void prefixedFormCanonicalizesCaseLikeBareForm() {
+    // task.MaterializedViewTask.BUCKETTIMEPERIOD must land under the same canonical-cased
+    // on-wire key as the bare 'BUCKETTIMEPERIOD' form; otherwise downstream consumers that
+    // read MaterializedViewTask.BUCKET_TIME_PERIOD_KEY miss the value.
+    CompiledCreateMaterializedView c = compileMaterializedView(
+        "CREATE MATERIALIZED VIEW mv ("
+            + "  ts TIMESTAMP DATETIME FORMAT '1:MILLISECONDS:TIMESTAMP' GRANULARITY '1:DAYS'"
+            + ")"
+            + " REFRESH EVERY 1 DAY"
+            + " PROPERTIES ('timeColumnName' = 'ts',"
+            + "   'task.MaterializedViewTask.BUCKETTIMEPERIOD' = '1d')"
+            + " AS SELECT ts FROM src");
+    Map<String, String> mv = materializedViewTaskConfig(c.getTableConfig());
+    assertEquals(mv.get(MaterializedViewTask.BUCKET_TIME_PERIOD_KEY), "1d");
+  }
+
+  @Test
+  public void rawTaskPrefixOnMaterializedViewTaskIsAccepted() {
+    CompiledCreateMaterializedView c = compileMaterializedView(
+        "CREATE MATERIALIZED VIEW mv ("
+            + "  ts TIMESTAMP DATETIME FORMAT '1:MILLISECONDS:TIMESTAMP' GRANULARITY '1:DAYS'"
+            + ")"
+            + " REFRESH EVERY 1 DAY"
+            + " PROPERTIES ('timeColumnName' = 'ts', 'bucketTimePeriod' = '1d',"
+            + "   'task.MaterializedViewTask.someExperimentalKnob' = 'on')"
+            + " AS SELECT ts FROM src");
+    assertEquals(materializedViewTaskConfig(c.getTableConfig()).get("someExperimentalKnob"), "on");
+  }
+
+  @Test
+  public void otherTaskTypePassesThroughForForwardCompat() {
+    CompiledCreateMaterializedView c = compileMaterializedView(
+        "CREATE MATERIALIZED VIEW mv ("
+            + "  ts TIMESTAMP DATETIME FORMAT '1:MILLISECONDS:TIMESTAMP' GRANULARITY '1:DAYS'"
+            + ")"
+            + " REFRESH EVERY 1 DAY"
+            + " PROPERTIES ('timeColumnName' = 'ts', 'bucketTimePeriod' = '1d',"
+            + "   'task.SegmentGenerationAndPushTask.foo' = 'bar')"
+            + " AS SELECT ts FROM src");
+    Map<String, String> other = c.getTableConfig().getTaskConfig()
+        .getConfigsForTaskType("SegmentGenerationAndPushTask");
+    assertNotNull(other);
+    assertEquals(other.get("foo"), "bar");
+  }
+
+  @Test
+  public void unknownPropertyFallsBackToCustomConfig() {
+    CompiledCreateMaterializedView c = compileMaterializedView(
+        "CREATE MATERIALIZED VIEW mv ("
+            + "  ts TIMESTAMP DATETIME FORMAT '1:MILLISECONDS:TIMESTAMP' GRANULARITY '1:DAYS'"
+            + ")"
+            + " REFRESH EVERY 1 DAY"
+            + " PROPERTIES ('timeColumnName' = 'ts', 'bucketTimePeriod' = '1d',"
+            + "   'org.example.tag' = 'experimental')"
+            + " AS SELECT ts FROM src");
+    assertNotNull(c.getTableConfig().getCustomConfig());
+    assertEquals(c.getTableConfig().getCustomConfig().getCustomConfigs().get("org.example.tag"),
+        "experimental");
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // Reserved-key / conflict rejections
+  // -------------------------------------------------------------------------------------------
+
+  @Test
+  public void streamPropertyOnMvRejected() {
+    DdlCompilationException e = expectThrows(DdlCompilationException.class,
+        () -> compileMaterializedView(
+            "CREATE MATERIALIZED VIEW mv ("
+                + "  ts TIMESTAMP DATETIME FORMAT '1:MILLISECONDS:TIMESTAMP' GRANULARITY '1:DAYS'"
+                + ")"
+                + " REFRESH EVERY 1 DAY"
+                + " PROPERTIES ('timeColumnName' = 'ts', 'bucketTimePeriod' = '1d',"
+                + "   'stream.kafka.topic.name' = 't')"
+                + " AS SELECT ts FROM src"));
+    assertTrue(e.getMessage().contains("REALTIME-only"), e.getMessage());
+  }
+
+  @Test
+  public void scheduleInPropertiesConflictsWithRefreshEvery() {
+    DdlCompilationException e = expectThrows(DdlCompilationException.class,
+        () -> compileMaterializedView(
+            "CREATE MATERIALIZED VIEW mv ("
+                + "  ts TIMESTAMP DATETIME FORMAT '1:MILLISECONDS:TIMESTAMP' GRANULARITY '1:DAYS'"
+                + ")"
+                + " REFRESH EVERY 1 DAY"
+                + " PROPERTIES ('timeColumnName' = 'ts', 'bucketTimePeriod' = '1d',"
+                + "   'schedule' = '0 0 * * * ?')"
+                + " AS SELECT ts FROM src"));
+    assertTrue(e.getMessage().contains("reserved"), e.getMessage());
+  }
+
+  @Test
+  public void definedSqlInPropertiesConflictsWithAsQuery() {
+    DdlCompilationException e = expectThrows(DdlCompilationException.class,
+        () -> compileMaterializedView(
+            "CREATE MATERIALIZED VIEW mv ("
+                + "  ts TIMESTAMP DATETIME FORMAT '1:MILLISECONDS:TIMESTAMP' GRANULARITY '1:DAYS'"
+                + ")"
+                + " REFRESH EVERY 1 DAY"
+                + " PROPERTIES ('timeColumnName' = 'ts', 'bucketTimePeriod' = '1d',"
+                + "   'definedSQL' = 'SELECT * FROM src')"
+                + " AS SELECT ts FROM src"));
+    assertTrue(e.getMessage().contains("reserved"), e.getMessage());
+  }
+
+  @Test
+  public void taskPrefixedScheduleAlsoRejected() {
+    DdlCompilationException e = expectThrows(DdlCompilationException.class,
+        () -> compileMaterializedView(
+            "CREATE MATERIALIZED VIEW mv ("
+                + "  ts TIMESTAMP DATETIME FORMAT '1:MILLISECONDS:TIMESTAMP' GRANULARITY '1:DAYS'"
+                + ")"
+                + " REFRESH EVERY 1 DAY"
+                + " PROPERTIES ('timeColumnName' = 'ts', 'bucketTimePeriod' = '1d',"
+                + "   'task.MaterializedViewTask.schedule' = '0 0 * * * ?')"
+                + " AS SELECT ts FROM src"));
+    assertTrue(e.getMessage().contains("reserved"), e.getMessage());
+  }
+
+  /// `isMaterializedView` is identity (decided by the CREATE statement choice + the canonical
+  /// flag on TableConfig, PR #18564), not a knob. The compiler stamps the flag automatically
+  /// on this path. Accepting it again as a user PROPERTY would silently land in
+  /// TableCustomConfig (harmless for identity but a confusing knob to leave dangling) — reject
+  /// up front for symmetry with the CREATE TABLE rejection, so the operator does not believe
+  /// the value affected anything.
+  @Test
+  public void isMaterializedViewPropertyRejectedOnCreateMv() {
+    DdlCompilationException e = expectThrows(DdlCompilationException.class,
+        () -> compileMaterializedView(
+            "CREATE MATERIALIZED VIEW mv ("
+                + "  ts TIMESTAMP DATETIME FORMAT '1:MILLISECONDS:TIMESTAMP' GRANULARITY '1:DAYS'"
+                + ")"
+                + " REFRESH EVERY 1 DAY"
+                + " PROPERTIES ('timeColumnName' = 'ts', 'bucketTimePeriod' = '1d',"
+                + "   'isMaterializedView' = 'true')"
+                + " AS SELECT ts FROM src"));
+    assertTrue(e.getMessage().contains("isMaterializedView"), e.getMessage());
+    assertTrue(e.getMessage().contains("reserved"), e.getMessage());
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // Consistency
+  // -------------------------------------------------------------------------------------------
+
+  @Test
+  public void missingTimeColumnNameRejected() {
+    DdlCompilationException e = expectThrows(DdlCompilationException.class,
+        () -> compileMaterializedView(
+            "CREATE MATERIALIZED VIEW mv ("
+                + "  ts TIMESTAMP DATETIME FORMAT '1:MILLISECONDS:TIMESTAMP' GRANULARITY '1:DAYS'"
+                + ")"
+                + " REFRESH EVERY 1 DAY"
+                + " PROPERTIES ('bucketTimePeriod' = '1d')"
+                + " AS SELECT ts FROM src"));
+    assertTrue(e.getMessage().contains("timeColumnName"), e.getMessage());
+  }
+
+  @Test
+  public void timeColumnNameMustReferenceDatetimeColumn() {
+    DdlCompilationException e = expectThrows(DdlCompilationException.class,
+        () -> compileMaterializedView(
+            "CREATE MATERIALIZED VIEW mv ("
+                + "  ts STRING,"
+                + "  carrier STRING"
+                + ")"
+                + " REFRESH EVERY 1 DAY"
+                + " PROPERTIES ('timeColumnName' = 'ts', 'bucketTimePeriod' = '1d')"
+                + " AS SELECT ts, carrier FROM src"));
+    assertTrue(e.getMessage().contains("DATETIME"), e.getMessage());
+  }
+
+  @Test
+  public void missingBucketTimePeriodRejected() {
+    DdlCompilationException e = expectThrows(DdlCompilationException.class,
+        () -> compileMaterializedView(
+            "CREATE MATERIALIZED VIEW mv ("
+                + "  ts TIMESTAMP DATETIME FORMAT '1:MILLISECONDS:TIMESTAMP' GRANULARITY '1:DAYS'"
+                + ")"
+                + " REFRESH EVERY 1 DAY"
+                + " PROPERTIES ('timeColumnName' = 'ts')"
+                + " AS SELECT ts FROM src"));
+    assertTrue(e.getMessage().contains("bucketTimePeriod"), e.getMessage());
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // AS <query> raw-substring extraction
+  // -------------------------------------------------------------------------------------------
+
+  @Test
+  public void definedSqlPreservesUserOriginalText() {
+    // Mixed case keywords, block comment, and explicit aliases should all survive intact
+    // because we substring the raw user SQL rather than re-printing the AST.
+    String sql =
+        "CREATE MATERIALIZED VIEW mv ("
+            + "  ts TIMESTAMP DATETIME FORMAT '1:MILLISECONDS:TIMESTAMP' GRANULARITY '1:DAYS',"
+            + "  carrier STRING"
+            + ")"
+            + " REFRESH EVERY 1 DAY"
+            + " PROPERTIES ('timeColumnName' = 'ts', 'bucketTimePeriod' = '1d')"
+            + " AS Select Carrier /* hot column */, ts From src";
+    CompiledCreateMaterializedView c = compileMaterializedView(sql);
+    assertEquals(materializedViewTaskConfig(c.getTableConfig()).get(MaterializedViewTask.DEFINED_SQL_KEY),
+        "Select Carrier /* hot column */, ts From src");
+  }
+
+  @Test
+  public void definedSqlAcrossMultipleLinesPreserved() {
+    String sql =
+        "CREATE MATERIALIZED VIEW mv (\n"
+            + "  ts TIMESTAMP DATETIME FORMAT '1:MILLISECONDS:TIMESTAMP' GRANULARITY '1:DAYS',\n"
+            + "  carrier STRING\n"
+            + ") REFRESH EVERY 1 DAY\n"
+            + "PROPERTIES ('timeColumnName' = 'ts', 'bucketTimePeriod' = '1d')\n"
+            + "AS SELECT ts, carrier\n"
+            + "   FROM src\n"
+            + "   GROUP BY ts, carrier";
+    CompiledCreateMaterializedView c = compileMaterializedView(sql);
+    String definedSql = materializedViewTaskConfig(c.getTableConfig())
+        .get(MaterializedViewTask.DEFINED_SQL_KEY);
+    assertTrue(definedSql.startsWith("SELECT ts, carrier"), definedSql);
+    assertTrue(definedSql.contains("GROUP BY ts, carrier"), definedSql);
+    // No "AS " keyword leaked into the captured slice.
+    assertTrue(!definedSql.toUpperCase().startsWith("AS "), definedSql);
+  }
+
+  @Test
+  public void trailingSemicolonStrippedFromDefinedSql() {
+    CompiledCreateMaterializedView c = compileMaterializedView(
+        "CREATE MATERIALIZED VIEW mv ("
+            + "  ts TIMESTAMP DATETIME FORMAT '1:MILLISECONDS:TIMESTAMP' GRANULARITY '1:DAYS'"
+            + ")"
+            + " REFRESH EVERY 1 DAY"
+            + " PROPERTIES ('timeColumnName' = 'ts', 'bucketTimePeriod' = '1d')"
+            + " AS SELECT ts FROM src;");
+    assertEquals(materializedViewTaskConfig(c.getTableConfig()).get(MaterializedViewTask.DEFINED_SQL_KEY),
+        "SELECT ts FROM src");
+  }
+
+  /// Regression for the SqlOrderBy wrapper bug: when the AS clause carries a top-level LIMIT,
+  /// Calcite wraps the SqlSelect in a SqlOrderBy whose parser position covers only the LIMIT
+  /// substring. A naive `queryNode.getParserPosition()` slice would store `LIMIT 1000` as the
+  /// `definedSQL` and the scheduler's auto-LIMIT injection would re-parse garbage. The fixed
+  /// extractor walks the AST and unions every descendant position, so the captured slice spans
+  /// the whole `SELECT ... LIMIT 1000`.
+  @Test
+  public void definedSqlPreservesTopLevelLimitWrapper() {
+    CompiledCreateMaterializedView c = compileMaterializedView(
+        "CREATE MATERIALIZED VIEW mv ("
+            + "  ts TIMESTAMP DATETIME FORMAT '1:MILLISECONDS:TIMESTAMP' GRANULARITY '1:DAYS',"
+            + "  carrier STRING"
+            + ")"
+            + " REFRESH EVERY 1 DAY"
+            + " PROPERTIES ('timeColumnName' = 'ts', 'bucketTimePeriod' = '1d')"
+            + " AS SELECT ts, carrier FROM src LIMIT 1000");
+    String definedSql = materializedViewTaskConfig(c.getTableConfig())
+        .get(MaterializedViewTask.DEFINED_SQL_KEY);
+    assertEquals(definedSql, "SELECT ts, carrier FROM src LIMIT 1000",
+        "Top-level LIMIT must be included in the captured definedSQL (SqlOrderBy wrapper "
+            + "regression). Got: " + definedSql);
+  }
+
+  /// Sibling regression: ORDER BY also wraps the SELECT in a SqlOrderBy. Without the AST walk
+  /// the captured definedSQL would just be the ORDER BY clause.
+  @Test
+  public void definedSqlPreservesTopLevelOrderByWrapper() {
+    CompiledCreateMaterializedView c = compileMaterializedView(
+        "CREATE MATERIALIZED VIEW mv ("
+            + "  ts TIMESTAMP DATETIME FORMAT '1:MILLISECONDS:TIMESTAMP' GRANULARITY '1:DAYS',"
+            + "  carrier STRING"
+            + ")"
+            + " REFRESH EVERY 1 DAY"
+            + " PROPERTIES ('timeColumnName' = 'ts', 'bucketTimePeriod' = '1d')"
+            + " AS SELECT ts, carrier FROM src ORDER BY ts");
+    String definedSql = materializedViewTaskConfig(c.getTableConfig())
+        .get(MaterializedViewTask.DEFINED_SQL_KEY);
+    assertEquals(definedSql, "SELECT ts, carrier FROM src ORDER BY ts");
+  }
+
+  // NOTE on `WITH` (CTE) and `EXPLAIN` wrappers: the AST walker in `extractDefinedSql` handles
+  // `SqlWith` and `SqlExplain` exactly like `SqlOrderBy` (collect every descendant position,
+  // union via `SqlParserPos.sum`). We deliberately do NOT add round-trip tests for those forms
+  // because `verifyDefinedSqlIsParseable` calls `CalciteSqlParser.compileToPinotQuery`, which
+  // does not accept CTEs today (it casts the root to `SqlSelect`) and `EXPLAIN` is parsed as
+  // its own statement (it can't appear after `AS`). The walker's generality is intentional —
+  // the day Pinot's query layer grows CTE support, MV `definedSQL` extraction needs no edit.
+
+  // -------------------------------------------------------------------------------------------
+  // AS <query>: JOIN is not supported (compile-time pre-scan)
+  // -------------------------------------------------------------------------------------------
+
+  /// JOIN in the AS clause must be rejected at compile time with a clear, MV-specific
+  /// message. Without the AST pre-scan in `DdlCompiler#rejectJoinInDefinedSql` the
+  /// downstream substring-reparse path (`verifyDefinedSqlIsParseable` →
+  /// `CalciteSqlParser#compileToPinotQuery` → `compileToDataSource`) trips a latent
+  /// `ClassCastException` (SqlIdentifier → SqlSelect) the moment the JOIN operands carry
+  /// table aliases, which would surface to the operator as an opaque 500.
+  @Test
+  public void joinWithoutAliasRejected() {
+    DdlCompilationException e = expectThrows(DdlCompilationException.class,
+        () -> compileMaterializedView(
+            "CREATE MATERIALIZED VIEW mv ("
+                + "  ts TIMESTAMP DATETIME FORMAT '1:MILLISECONDS:TIMESTAMP' GRANULARITY '1:DAYS'"
+                + ")"
+                + " REFRESH EVERY 1 DAY"
+                + " PROPERTIES ('timeColumnName' = 'ts', 'bucketTimePeriod' = '1d')"
+                + " AS SELECT a.ts FROM a JOIN b ON a.id = b.id"));
+    assertTrue(e.getMessage().contains("JOIN"), e.getMessage());
+    assertTrue(e.getMessage().contains("single source table")
+            || e.getMessage().contains("pre-join"),
+        "Message must guide the operator to the supported pattern; got: " + e.getMessage());
+  }
+
+  /// The aliased variant is the one that previously surfaced as `ClassCastException` from
+  /// the downstream re-parse path; pinning it here guards against a regression that would
+  /// re-expose the CCE if the pre-scan were ever removed or weakened.
+  @Test
+  public void joinWithTableAliasRejected() {
+    DdlCompilationException e = expectThrows(DdlCompilationException.class,
+        () -> compileMaterializedView(
+            "CREATE MATERIALIZED VIEW mv ("
+                + "  ts TIMESTAMP DATETIME FORMAT '1:MILLISECONDS:TIMESTAMP' GRANULARITY '1:DAYS'"
+                + ")"
+                + " REFRESH EVERY 1 DAY"
+                + " PROPERTIES ('timeColumnName' = 'ts', 'bucketTimePeriod' = '1d')"
+                + " AS SELECT x.ts FROM a AS x JOIN b AS y ON x.id = y.id"));
+    assertTrue(e.getMessage().contains("JOIN"), e.getMessage());
+  }
+
+  /// LEFT / RIGHT / FULL OUTER / CROSS all parse as the same `SqlKind.JOIN` and so flow
+  /// through the same rejection. One representative is enough; if a future Calcite upgrade
+  /// changes any of these to a different SqlKind, this test will start passing for the wrong
+  /// reason — but the `joinWithoutAlias` / `joinWithTableAlias` cases above will catch the
+  /// regression of the *primary* INNER JOIN case.
+  @Test
+  public void leftJoinRejected() {
+    DdlCompilationException e = expectThrows(DdlCompilationException.class,
+        () -> compileMaterializedView(
+            "CREATE MATERIALIZED VIEW mv ("
+                + "  ts TIMESTAMP DATETIME FORMAT '1:MILLISECONDS:TIMESTAMP' GRANULARITY '1:DAYS'"
+                + ")"
+                + " REFRESH EVERY 1 DAY"
+                + " PROPERTIES ('timeColumnName' = 'ts', 'bucketTimePeriod' = '1d')"
+                + " AS SELECT a.ts FROM a LEFT JOIN b ON a.id = b.id"));
+    assertTrue(e.getMessage().contains("JOIN"), e.getMessage());
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // cronToPeriod (inverse of periodToCron)
+  //
+  // Inverse-mapping happy paths are covered by
+  // {@link #cronToPeriodRoundTripsEveryForwardOutput} below; per-period inverse tests
+  // here would only re-assert that same subset.
+  // -------------------------------------------------------------------------------------------
+
+  @Test
+  public void cronToPeriodReturnsNullForNonStandardCron() {
+    // 0 0/60 * * * ? is legal Quartz (every 60 minutes ≈ hourly) but the forward direction
+    // would have rejected `60m` as out-of-range, so the inverse must refuse it too — otherwise
+    // round-trip would silently change semantics.
+    assertNull(MaterializedViewPropertyRouter.cronToPeriod("0 0/60 * * * ?"));
+    assertNull(MaterializedViewPropertyRouter.cronToPeriod("0 0 0/24 * * ?"));
+    assertNull(MaterializedViewPropertyRouter.cronToPeriod("0 0 0 1/29 * ?"));
+  }
+
+  @Test
+  public void cronToPeriodReturnsNullForHandTypedCron() {
+    // Cron expressions that look nothing like the patterns periodToCron produces.
+    assertNull(MaterializedViewPropertyRouter.cronToPeriod("0 30 9 * * MON-FRI"));
+    assertNull(MaterializedViewPropertyRouter.cronToPeriod("not a cron"));
+    assertNull(MaterializedViewPropertyRouter.cronToPeriod(""));
+    assertNull(MaterializedViewPropertyRouter.cronToPeriod(null));
+  }
+
+  /// Belt-and-braces: every cron periodToCron can produce must invert cleanly. If a future
+  /// edit adds a row to the forward mapping table without adding a matching pattern to
+  /// cronToPeriod, this round-trip test will catch the asymmetry.
+  @Test
+  public void cronToPeriodRoundTripsEveryForwardOutput() {
+    String[] periods = {"1m", "2m", "5m", "15m", "30m", "59m", "1h", "2h", "6h", "12h", "23h",
+        "1d", "2d", "7d", "14d", "28d"};
+    for (String period : periods) {
+      String cron = MaterializedViewPropertyRouter.periodToCron(period);
+      String back = MaterializedViewPropertyRouter.cronToPeriod(cron);
+      assertEquals(back, period,
+          "Round-trip lost period '" + period + "' (cron='" + cron + "', back='" + back + "')");
+    }
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // SHOW CREATE MATERIALIZED VIEW
+  // -------------------------------------------------------------------------------------------
+
+  @Test
+  public void showCreateMaterializedViewCompiles() {
+    CompiledDdl compiled = DdlCompiler.compile("SHOW CREATE MATERIALIZED VIEW mv");
+    assertEquals(compiled.getOperation(), DdlOperation.SHOW_CREATE_MATERIALIZED_VIEW);
+    CompiledShowCreateMaterializedView show = (CompiledShowCreateMaterializedView) compiled;
+    assertEquals(show.getRawTableName(), "mv");
+    assertNull(show.getDatabaseName());
+  }
+
+  @Test
+  public void showCreateMaterializedViewPreservesDatabaseQualifier() {
+    CompiledDdl compiled = DdlCompiler.compile("SHOW CREATE MATERIALIZED VIEW analytics.mv");
+    CompiledShowCreateMaterializedView show = (CompiledShowCreateMaterializedView) compiled;
+    assertEquals(show.getDatabaseName(), "analytics");
+    assertEquals(show.getRawTableName(), "mv");
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // DROP MATERIALIZED VIEW
+  // -------------------------------------------------------------------------------------------
+
+  @Test
+  public void dropMaterializedViewCompiles() {
+    CompiledDdl compiled = DdlCompiler.compile("DROP MATERIALIZED VIEW mv");
+    assertEquals(compiled.getOperation(), DdlOperation.DROP_MATERIALIZED_VIEW);
+    CompiledDropMaterializedView drop = (CompiledDropMaterializedView) compiled;
+    assertEquals(drop.getRawTableName(), "mv");
+    assertNull(drop.getDatabaseName());
+    assertFalse(drop.isIfExists());
+  }
+
+  @Test
+  public void dropMaterializedViewIfExistsCompiles() {
+    CompiledDdl compiled = DdlCompiler.compile("DROP MATERIALIZED VIEW IF EXISTS mv");
+    CompiledDropMaterializedView drop = (CompiledDropMaterializedView) compiled;
+    assertTrue(drop.isIfExists());
+    assertEquals(drop.getRawTableName(), "mv");
+  }
+
+  @Test
+  public void dropMaterializedViewPreservesDatabaseQualifier() {
+    CompiledDdl compiled =
+        DdlCompiler.compile("DROP MATERIALIZED VIEW IF EXISTS analytics.mv");
+    CompiledDropMaterializedView drop = (CompiledDropMaterializedView) compiled;
+    assertEquals(drop.getDatabaseName(), "analytics");
+    assertEquals(drop.getRawTableName(), "mv");
+    assertTrue(drop.isIfExists());
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // Helpers
+  // -------------------------------------------------------------------------------------------
+
+  private static CompiledCreateMaterializedView compileMaterializedView(String sql) {
+    CompiledDdl c = DdlCompiler.compile(sql);
+    assertEquals(c.getOperation(), DdlOperation.CREATE_MATERIALIZED_VIEW);
+    return (CompiledCreateMaterializedView) c;
+  }
+
+  private static Map<String, String> materializedViewTaskConfig(TableConfig tableConfig) {
+    Map<String, String> mv = tableConfig.getTaskConfig() == null ? null
+        : tableConfig.getTaskConfig().getConfigsForTaskType(MaterializedViewTask.TASK_TYPE);
+    assertNotNull(mv, "MaterializedViewTask config block should be present after compile");
+    return mv;
+  }
+}

--- a/pinot-sql-ddl/src/test/java/org/apache/pinot/sql/ddl/compile/DdlCompilerTest.java
+++ b/pinot-sql-ddl/src/test/java/org/apache/pinot/sql/ddl/compile/DdlCompilerTest.java
@@ -297,6 +297,39 @@ public class DdlCompilerTest {
     assertEquals(custom.get("org.example.flag"), "true");
   }
 
+  /// `isMaterializedView` is identity (decides which CREATE statement to use), not a
+  /// PROPERTY. Routing it via CREATE TABLE PROPERTIES would either land in a config that the
+  /// SPI invariant `TableConfigUtils.validateMaterializedViewInvariants` rejects at addTable
+  /// time (flag=true with no MaterializedViewTask body) or silently no-op (flag=false is the
+  /// default). Reject up front so the operator gets a clear pointer to the dedicated
+  /// `CREATE MATERIALIZED VIEW` DDL form. Identity-source is the canonical
+  /// `TableConfig#isMaterializedView` flag introduced in PR #18564.
+  @Test
+  public void isMaterializedViewPropertyRejectedOnCreateTable() {
+    DdlCompilationException ex = expectThrows(DdlCompilationException.class, () -> compileCreate(
+        "CREATE TABLE t (id INT) TABLE_TYPE = OFFLINE PROPERTIES ("
+            + "  'isMaterializedView' = 'true'"
+            + ")"));
+    assertTrue(ex.getMessage() != null && ex.getMessage().contains("isMaterializedView"),
+        "expected error to name the offending property, got: " + ex.getMessage());
+    assertTrue(ex.getMessage().contains("CREATE MATERIALIZED VIEW"),
+        "expected error to point at the dedicated MV DDL form, got: " + ex.getMessage());
+  }
+
+  /// Case-insensitive variant of the above — the property routing is case-insensitive
+  /// throughout, so the rejection must be too. Without this we would reject only the
+  /// camelCase form and silently accept the lower-cased one (the latter would then route
+  /// through the same handler but be matched at the switch level via `lowerKey`).
+  @Test
+  public void isMaterializedViewPropertyRejectedCaseInsensitive() {
+    DdlCompilationException ex = expectThrows(DdlCompilationException.class, () -> compileCreate(
+        "CREATE TABLE t (id INT) TABLE_TYPE = OFFLINE PROPERTIES ("
+            + "  'ISMATERIALIZEDVIEW' = 'false'"
+            + ")"));
+    assertTrue(ex.getMessage() != null && ex.getMessage().contains("isMaterializedView"),
+        "expected error to canonicalise the key in its message, got: " + ex.getMessage());
+  }
+
   // -------------------------------------------------------------------------------------------
   // CREATE TABLE: validation
   // -------------------------------------------------------------------------------------------
@@ -474,6 +507,33 @@ public class DdlCompilerTest {
   public void compileShowFromDatabase() {
     CompiledShowTables s = (CompiledShowTables) DdlCompiler.compile("SHOW TABLES FROM analytics");
     assertEquals(s.getDatabaseName(), "analytics");
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // SHOW MATERIALIZED VIEWS
+  //
+  // Compile-layer mirror of SHOW TABLES. The controller is responsible for the actual MV
+  // filtering against TableConfig#isMaterializedView; here we only verify the compile result
+  // carries the right operation discriminator and the database scope is plumbed through
+  // (null when omitted, explicit string when `FROM db` is given).
+  // -------------------------------------------------------------------------------------------
+
+  @Test
+  public void compileShowMaterializedViewsDefault() {
+    CompiledShowMaterializedViews s = (CompiledShowMaterializedViews) DdlCompiler.compile(
+        "SHOW MATERIALIZED VIEWS");
+    assertNull(s.getDatabaseName(),
+        "Database must remain null when omitted so the controller falls back to the Database "
+            + "header rather than substituting a default at compile time.");
+    assertEquals(s.getOperation(), DdlOperation.SHOW_MATERIALIZED_VIEWS);
+  }
+
+  @Test
+  public void compileShowMaterializedViewsFromDatabase() {
+    CompiledShowMaterializedViews s = (CompiledShowMaterializedViews) DdlCompiler.compile(
+        "SHOW MATERIALIZED VIEWS FROM analytics");
+    assertEquals(s.getDatabaseName(), "analytics");
+    assertEquals(s.getOperation(), DdlOperation.SHOW_MATERIALIZED_VIEWS);
   }
 
   // -------------------------------------------------------------------------------------------

--- a/pinot-sql-ddl/src/test/java/org/apache/pinot/sql/ddl/inferer/MaterializedViewSchemaInfererTest.java
+++ b/pinot-sql-ddl/src/test/java/org/apache/pinot/sql/ddl/inferer/MaterializedViewSchemaInfererTest.java
@@ -1,0 +1,322 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.sql.ddl.inferer;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.common.config.provider.TableCache;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.sql.ddl.compile.DdlCompilationException;
+import org.apache.pinot.sql.ddl.resolved.ColumnRole;
+import org.apache.pinot.sql.ddl.resolved.ResolvedColumnDefinition;
+import org.testng.annotations.Test;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+
+
+/// Unit tests for [MaterializedViewSchemaInferer]. The inferer is deliberately narrow:
+/// data type comes from Calcite's validated row type, the time column is pinned to
+/// canonical TIMESTAMP, and recognised aggregations use the MV catalog (so sketches
+/// land as BYTES). Non-recognised shapes flow through as DIMENSION with the Calcite
+/// type; users who need a different role / format must use the explicit column list.
+public class MaterializedViewSchemaInfererTest {
+
+  // ---------------------------------------------------------------------------------------------
+  // Happy paths
+  // ---------------------------------------------------------------------------------------------
+
+  @Test
+  public void passthroughColumnTakesCalciteType() {
+    Schema source = new Schema.SchemaBuilder()
+        .setSchemaName("src")
+        .addDateTime("ts", DataType.TIMESTAMP, "1:MILLISECONDS:TIMESTAMP", "1:DAYS")
+        .addSingleValueDimension("city", DataType.STRING)
+        .build();
+    List<ResolvedColumnDefinition> cols = infer(
+        "SELECT ts, city AS region FROM src", "ts", source);
+
+    assertEquals(cols.size(), 2);
+
+    ResolvedColumnDefinition tsCol = cols.get(0);
+    assertEquals(tsCol.getName(), "ts");
+    assertEquals(tsCol.getRole(), ColumnRole.DATETIME,
+        "The MV time column is always DATETIME / TIMESTAMP regardless of SELECT shape.");
+    assertEquals(tsCol.getDataType(), DataType.TIMESTAMP);
+    assertEquals(tsCol.getDateTimeFormat(), "1:MILLISECONDS:TIMESTAMP");
+    assertEquals(tsCol.getDateTimeGranularity(), "1:MILLISECONDS");
+
+    ResolvedColumnDefinition city = cols.get(1);
+    assertEquals(city.getName(), "region", "AS alias must be the output column name");
+    assertEquals(city.getRole(), ColumnRole.DIMENSION,
+        "Non-time / non-aggregation columns default to DIMENSION.");
+    assertEquals(city.getDataType(), DataType.STRING, "Calcite-derived data type");
+    assertTrue(city.isNotNull(), "Inferred columns are NOT NULL by default.");
+    assertNull(city.getDefaultValue(), "Inferred columns have no default.");
+  }
+
+  @Test
+  public void timeColumnAlwaysCanonicalTimestamp() {
+    // The time column is the canonical TIMESTAMP regardless of how the SELECT derives it.
+    Schema source = new Schema.SchemaBuilder()
+        .setSchemaName("src")
+        .addDateTime("DaysSinceEpoch", DataType.LONG, "1:DAYS:EPOCH", "1:DAYS")
+        .build();
+    List<ResolvedColumnDefinition> cols = infer(
+        "SELECT DaysSinceEpoch * 86400000 AS ts FROM src", "ts", source);
+
+    assertEquals(cols.size(), 1);
+    ResolvedColumnDefinition ts = cols.get(0);
+    assertEquals(ts.getRole(), ColumnRole.DATETIME);
+    assertEquals(ts.getDataType(), DataType.TIMESTAMP);
+    assertEquals(ts.getDateTimeFormat(), "1:MILLISECONDS:TIMESTAMP");
+    assertEquals(ts.getDateTimeGranularity(), "1:MILLISECONDS");
+    assertTrue(ts.isNotNull());
+  }
+
+  @Test
+  public void aggregationsLandAsCatalogTypes() {
+    Schema source = new Schema.SchemaBuilder()
+        .setSchemaName("src")
+        .addDateTime("ts", DataType.TIMESTAMP, "1:MILLISECONDS:TIMESTAMP", "1:DAYS")
+        .addMetric("amount", DataType.DOUBLE)
+        .build();
+    List<ResolvedColumnDefinition> cols = infer(
+        "SELECT ts, SUM(amount) AS total, COUNT(*) AS cnt FROM src GROUP BY ts",
+        "ts", source);
+
+    assertEquals(cols.size(), 3);
+
+    ResolvedColumnDefinition total = cols.get(1);
+    assertEquals(total.getName(), "total");
+    assertEquals(total.getRole(), ColumnRole.METRIC);
+    assertEquals(total.getDataType(), DataType.DOUBLE,
+        "SUM must land as DOUBLE per the aggregation catalog");
+
+    ResolvedColumnDefinition cnt = cols.get(2);
+    assertEquals(cnt.getName(), "cnt");
+    assertEquals(cnt.getRole(), ColumnRole.METRIC);
+    assertEquals(cnt.getDataType(), DataType.LONG, "COUNT must land as LONG per the catalog");
+  }
+
+  /// The most subtle inferer contract — sketches must serialize as BYTES end-to-end, NOT
+  /// the STRING that either engine surfaces. Pinned here so a future refactor that mistakes
+  /// "engine return type" for "MV storage type" cannot silently regress correctness.
+  @Test
+  public void sketchAggregationLandsAsBytes() {
+    Schema source = new Schema.SchemaBuilder()
+        .setSchemaName("src")
+        .addDateTime("ts", DataType.TIMESTAMP, "1:MILLISECONDS:TIMESTAMP", "1:DAYS")
+        .addSingleValueDimension("user_id", DataType.LONG)
+        .build();
+    List<ResolvedColumnDefinition> cols = infer(
+        "SELECT ts, DISTINCTCOUNTRAWHLL(user_id) AS u_hll FROM src GROUP BY ts",
+        "ts", source);
+
+    assertEquals(cols.size(), 2);
+    ResolvedColumnDefinition sketch = cols.get(1);
+    assertEquals(sketch.getName(), "u_hll");
+    assertEquals(sketch.getRole(), ColumnRole.METRIC);
+    assertEquals(sketch.getDataType(), DataType.BYTES,
+        "DISTINCTCOUNTRAWHLL must serialize as BYTES so the MV rewrite engine can re-aggregate "
+            + "the raw sketch on the query side. STRING would silently break re-aggregation.");
+  }
+
+  @Test
+  public void columnOrderMirrorsSelectListOrder() {
+    Schema source = new Schema.SchemaBuilder()
+        .setSchemaName("src")
+        .addDateTime("ts", DataType.TIMESTAMP, "1:MILLISECONDS:TIMESTAMP", "1:DAYS")
+        .addSingleValueDimension("a", DataType.STRING)
+        .addSingleValueDimension("b", DataType.STRING)
+        .addSingleValueDimension("c", DataType.STRING)
+        .build();
+    List<ResolvedColumnDefinition> cols = infer(
+        "SELECT c, a, ts, b FROM src", "ts", source);
+
+    assertEquals(cols.size(), 4);
+    assertEquals(cols.get(0).getName(), "c");
+    assertEquals(cols.get(1).getName(), "a");
+    assertEquals(cols.get(2).getName(), "ts");
+    assertEquals(cols.get(3).getName(), "b",
+        "Column order must mirror SELECT-list order so SHOW CREATE round-trips stably.");
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Validation rejections
+  // ---------------------------------------------------------------------------------------------
+
+  @Test
+  public void selectStarRejectedWithRecoveryGuidance() {
+    Schema source = new Schema.SchemaBuilder()
+        .setSchemaName("src")
+        .addDateTime("ts", DataType.TIMESTAMP, "1:MILLISECONDS:TIMESTAMP", "1:DAYS")
+        .build();
+    DdlCompilationException ex = expectThrows(DdlCompilationException.class,
+        () -> infer("SELECT * FROM src", "ts", source));
+    assertTrue(ex.getMessage().contains("SELECT *"), ex.getMessage());
+    assertTrue(ex.getMessage().contains("explicit"), ex.getMessage());
+  }
+
+  @Test
+  public void unaliasedAggregationRejectedAsDdlCompilationException() {
+    // RequestUtils.extractAliasOrIdentifierName throws IllegalStateException for non-bare
+    // SELECT items without an AS alias. The inferer must translate that into a user-facing
+    // DdlCompilationException so the controller renders a 400 with guidance, not a 500.
+    Schema source = new Schema.SchemaBuilder()
+        .setSchemaName("src")
+        .addDateTime("ts", DataType.TIMESTAMP, "1:MILLISECONDS:TIMESTAMP", "1:DAYS")
+        .addMetric("amount", DataType.DOUBLE)
+        .build();
+    DdlCompilationException ex = expectThrows(DdlCompilationException.class,
+        () -> infer("SELECT ts, SUM(amount) FROM src GROUP BY ts", "ts", source));
+    assertTrue(ex.getMessage().contains("AS alias"), ex.getMessage());
+  }
+
+  @Test
+  public void missingTimeColumnPropertyRejected() {
+    Schema source = new Schema.SchemaBuilder()
+        .setSchemaName("src")
+        .addDateTime("ts", DataType.TIMESTAMP, "1:MILLISECONDS:TIMESTAMP", "1:DAYS")
+        .build();
+    DdlCompilationException ex = expectThrows(DdlCompilationException.class,
+        () -> inferWithProperties("SELECT ts FROM src",
+            Collections.singletonMap("bucketTimePeriod", "1d"), source));
+    assertTrue(ex.getMessage().contains("timeColumnName"), ex.getMessage());
+  }
+
+  @Test
+  public void timeColumnNotProducedBySelectRejected() {
+    Schema source = new Schema.SchemaBuilder()
+        .setSchemaName("src")
+        .addDateTime("ts", DataType.TIMESTAMP, "1:MILLISECONDS:TIMESTAMP", "1:DAYS")
+        .addSingleValueDimension("city", DataType.STRING)
+        .build();
+    // timeColumnName='bucket' but no SELECT alias produces it.
+    DdlCompilationException ex = expectThrows(DdlCompilationException.class,
+        () -> infer("SELECT ts, city FROM src", "bucket", source));
+    assertTrue(ex.getMessage().contains("bucket"), ex.getMessage());
+  }
+
+  @Test
+  public void duplicateColumnAliasRejected() {
+    Schema source = new Schema.SchemaBuilder()
+        .setSchemaName("src")
+        .addDateTime("ts", DataType.TIMESTAMP, "1:MILLISECONDS:TIMESTAMP", "1:DAYS")
+        .addSingleValueDimension("a", DataType.STRING)
+        .addSingleValueDimension("b", DataType.STRING)
+        .build();
+    DdlCompilationException ex = expectThrows(DdlCompilationException.class,
+        () -> infer("SELECT ts, a AS dup, b AS dup FROM src", "ts", source));
+    assertTrue(ex.getMessage().contains("duplicate"), ex.getMessage());
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Calcite validation surface — proves the QueryEnvironment is being consulted
+  // ---------------------------------------------------------------------------------------------
+
+  @Test
+  public void calciteValidatorCatchesUnknownColumn() {
+    Schema source = new Schema.SchemaBuilder()
+        .setSchemaName("src")
+        .addDateTime("ts", DataType.TIMESTAMP, "1:MILLISECONDS:TIMESTAMP", "1:DAYS")
+        .addSingleValueDimension("city", DataType.STRING)
+        .build();
+    // 'no_such_column' does not exist in the source. Calcite's validator must catch this
+    // at DDL-compile time rather than letting it pass to MV-create time.
+    DdlCompilationException ex = expectThrows(DdlCompilationException.class,
+        () -> infer("SELECT ts, no_such_column FROM src", "ts", source));
+    assertTrue(ex.getMessage().toLowerCase().contains("no_such_column")
+        || ex.getMessage().toLowerCase().contains("not found")
+        || ex.getMessage().toLowerCase().contains("calcite"),
+        "Calcite validator must surface the unknown column; got: " + ex.getMessage());
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Wiring errors
+  // ---------------------------------------------------------------------------------------------
+
+  @Test
+  public void missingTableCacheProducesActionableError() {
+    MaterializedViewInferenceInput input = new MaterializedViewInferenceInput(
+        "SELECT ts FROM src", null, "mv",
+        Collections.singletonMap("timeColumnName", "ts"),
+        /* tableCache = */ null);
+    DdlCompilationException ex = expectThrows(DdlCompilationException.class,
+        () -> MaterializedViewSchemaInferer.infer(input));
+    assertTrue(ex.getMessage().contains("TableCache"), ex.getMessage());
+  }
+
+  // ---------------------------------------------------------------------------------------------
+  // Helpers
+  // ---------------------------------------------------------------------------------------------
+
+  private static List<ResolvedColumnDefinition> infer(String sql, String timeColumnName,
+      Schema source) {
+    return inferWithProperties(sql, Collections.singletonMap("timeColumnName", timeColumnName),
+        source);
+  }
+
+  private static List<ResolvedColumnDefinition> inferWithProperties(String sql,
+      Map<String, String> properties, Schema source) {
+    MaterializedViewInferenceInput input = new MaterializedViewInferenceInput(
+        sql, null, "mv", properties, buildTableCache(source));
+    return MaterializedViewSchemaInferer.infer(input);
+  }
+
+  /// Builds a [TableCache] backed by Mockito stubs that satisfy the surface that
+  /// {@code PinotCatalog} consults: name canonicalization, no logical tables, schema
+  /// lookup keyed on the source table name. Mocking only these methods avoids pulling
+  /// pinot-core's MockRoutingManagerFactory into pinot-sql-ddl tests.
+  private static TableCache buildTableCache(Schema schema) {
+    String schemaName = schema.getSchemaName();
+    TableCache cache = mock(TableCache.class);
+    when(cache.isIgnoreCase()).thenReturn(false);
+    when(cache.getActualTableName(schemaName)).thenReturn(schemaName);
+    when(cache.getActualTableName(schemaName.toLowerCase())).thenReturn(schemaName);
+    when(cache.getActualLogicalTableName(anyString())).thenReturn(null);
+    when(cache.getSchema(schemaName)).thenReturn(schema);
+    Map<String, String> tableNameMap = new HashMap<>();
+    tableNameMap.put(schemaName, schemaName);
+    when(cache.getTableNameMap()).thenReturn(tableNameMap);
+    when(cache.getLogicalTableNameMap()).thenReturn(Collections.emptyMap());
+    when(cache.getColumnNameMap(schemaName)).thenReturn(buildColumnNameMap(schema));
+    return cache;
+  }
+
+  /// Pinot's catalog uses a column-name map for case-insensitive lookups even when
+  /// `isIgnoreCase()` is false; supplying a verbatim identity map keeps lookups
+  /// well-defined without exercising case-insensitive routing.
+  private static Map<String, String> buildColumnNameMap(Schema schema) {
+    Map<String, String> m = new HashMap<>();
+    for (FieldSpec spec : schema.getAllFieldSpecs()) {
+      m.put(spec.getName(), spec.getName());
+    }
+    return m;
+  }
+}

--- a/pinot-sql-ddl/src/test/java/org/apache/pinot/sql/ddl/integration/MaterializedViewDdlAnalyzerIntegrationTest.java
+++ b/pinot-sql-ddl/src/test/java/org/apache/pinot/sql/ddl/integration/MaterializedViewDdlAnalyzerIntegrationTest.java
@@ -1,0 +1,192 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.sql.ddl.integration;
+
+import java.util.Map;
+import org.apache.pinot.materializedview.analysis.MaterializedViewAnalyzer;
+import org.apache.pinot.materializedview.context.MaterializedViewTaskGeneratorContext;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.CommonConstants.MaterializedViewTask;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.apache.pinot.sql.ddl.compile.CompiledCreateMaterializedView;
+import org.apache.pinot.sql.ddl.compile.DdlCompiler;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.expectThrows;
+import static org.testng.Assert.fail;
+
+
+/// End-to-end test that exercises the full `CREATE MATERIALIZED VIEW` DDL pipeline against the
+/// production [MaterializedViewAnalyzer]. The pipeline under test is:
+///
+/// `SQL string → DdlCompiler.compile(...) → CompiledCreateMaterializedView → extract
+/// (definedSql, TableConfig, Schema, taskConfigs) → MaterializedViewAnalyzer.analyze(...)`.
+///
+/// This closes a coverage gap that the unit-test surfaces deliberately leave open: the
+/// [PinotDdlRestletResourceMaterializedViewUnitTest] suite stubs out the entire validation
+/// chain (TableConfigValidationUtils, PinotTableRestletResource.tableTasksValidation,
+/// TableConfigTunerUtils) because the controller's test classpath does not transitively
+/// include `pinot-minion-builtin-tasks` and therefore cannot resolve
+/// `MaterializedViewTaskGenerator.validateTaskConfigs`. The trade-off is that those tests
+/// pin the controller's own dispatch / authorization / Q2=B behaviour without touching the
+/// analyzer; this test fills the gap from the opposite side.
+///
+/// The MaterializedViewAnalyzer itself has dense unit coverage in
+/// `MaterializedViewAnalyzerTest` (over 50 cases, every error branch), so this integration
+/// test deliberately stays minimal: one happy path proving the compiled artifacts reach the
+/// analyzer in a shape the analyzer accepts, and one analyzer-reject path proving that a
+/// genuine validation error (an MV column declared in the schema but absent from the SELECT
+/// projection) surfaces up the stack with the analyzer's own message — i.e. the DDL layer
+/// neither swallows nor rewraps the validation result.
+///
+/// We invoke the analyzer directly rather than going through
+/// `MaterializedViewTaskGenerator.validateTaskConfigs` (which would route through SPI plugin
+/// loading) because the wrapper is a thin pass-through whose own contract is pinned by
+/// `MaterializedViewTaskGeneratorTest`. The boundary this test pins is the data shape
+/// flowing OUT of the DDL compiler INTO the analyzer.
+public class MaterializedViewDdlAnalyzerIntegrationTest {
+
+  private static final String SOURCE_TABLE_RAW = "orders";
+  private static final String SOURCE_TABLE_OFFLINE = "orders_OFFLINE";
+
+  private MaterializedViewTaskGeneratorContext _stubContext;
+
+  @BeforeMethod
+  public void setUp() {
+    _stubContext = mock(MaterializedViewTaskGeneratorContext.class);
+
+    TableConfig sourceConfig = new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName(SOURCE_TABLE_OFFLINE)
+        .setTimeColumnName("ts")
+        .build();
+    Schema sourceSchema = new Schema.SchemaBuilder()
+        .setSchemaName(SOURCE_TABLE_RAW)
+        .addDateTime("ts", FieldSpec.DataType.TIMESTAMP, "1:MILLISECONDS:TIMESTAMP", "1:MILLISECONDS")
+        .addSingleValueDimension("city", FieldSpec.DataType.STRING)
+        .addMetric("amount", FieldSpec.DataType.DOUBLE)
+        .build();
+
+    when(_stubContext.tableExists(SOURCE_TABLE_OFFLINE)).thenReturn(true);
+    when(_stubContext.getTableConfig(SOURCE_TABLE_OFFLINE)).thenReturn(sourceConfig);
+    when(_stubContext.getTableSchema(SOURCE_TABLE_OFFLINE)).thenReturn(sourceSchema);
+  }
+
+  /// Happy path: a DDL whose SELECT projection covers every column declared in the MV column
+  /// list (and whose time column / bucket period match the analyzer's contract) round-trips
+  /// through compile → analyze without error. Assertions focus on the analyzer's own outputs
+  /// (the resolved source table and the SELECT-field list) rather than re-asserting fields
+  /// that the DDL compiler tests already cover, so this test only fails if the DDL-to-
+  /// analyzer hand-off itself regresses.
+  @Test
+  public void compiledMaterializedViewDdlPassesRealAnalyzer() {
+    CompiledCreateMaterializedView compiled = (CompiledCreateMaterializedView) DdlCompiler.compile(
+        "CREATE MATERIALIZED VIEW mv_orders ("
+            + "  ts TIMESTAMP DATETIME FORMAT '1:MILLISECONDS:TIMESTAMP' GRANULARITY '1:MILLISECONDS',"
+            + "  city STRING DIMENSION,"
+            + "  cnt LONG METRIC"
+            + ") REFRESH EVERY '1d' "
+            + "PROPERTIES ("
+            + "  'timeColumnName' = 'ts',"
+            + "  'bucketTimePeriod' = '1d',"
+            + "  'replication' = '1'"
+            + ") "
+            + "AS SELECT ts, city, count(*) AS cnt FROM orders GROUP BY ts, city LIMIT 100000");
+
+    TableConfig viewConfig = compiled.getTableConfig();
+    Schema viewSchema = compiled.getSchema();
+    Map<String, String> taskConfigs = viewConfig.getTaskConfig()
+        .getConfigsForTaskType(MaterializedViewTask.TASK_TYPE);
+    String definedSql = taskConfigs.get(MaterializedViewTask.DEFINED_SQL_KEY);
+    assertNotNull(definedSql,
+        "DDL compiler must populate task.MaterializedViewTask.definedSQL — the analyzer "
+            + "rejects null/empty inputs with 'definedSQL must be specified'.");
+
+    MaterializedViewAnalyzer.AnalysisResult result = MaterializedViewAnalyzer.analyze(
+        definedSql, viewConfig, viewSchema, taskConfigs, _stubContext);
+
+    assertNotNull(result, "Analyzer must produce a non-null result for valid compiled DDL.");
+    assertEquals(result.getSourceTableName(), SOURCE_TABLE_RAW,
+        "Source-table resolution must yield the raw name parsed from the SELECT FROM clause.");
+    assertTrue(result.getSelectFields().contains("ts")
+            && result.getSelectFields().contains("city")
+            && result.getSelectFields().contains("cnt"),
+        "Select-field list must round-trip every column the MV schema declares; got: "
+            + result.getSelectFields());
+  }
+
+  /// Analyzer-reject path: an MV schema declares a time column (`ts`) that the SELECT
+  /// projection does not produce. The DDL compiler accepts this — schema/projection
+  /// cross-validation is deferred to the analyzer (the open follow-up tracked in the PR
+  /// description under "Open for Discussion") — and the analyzer rejects it via the
+  /// `validateSchemaCoveredBySelect` branch with the stable phrase "is not produced by any
+  /// SELECT expression". The point of this test is NOT to re-cover every analyzer error
+  /// branch (the unit-level `MaterializedViewAnalyzerTest` does that comprehensively),
+  /// but to prove:
+  ///
+  /// 1. DDL compilation does not pre-empt the analyzer with its own cross-validation —
+  ///    callers must rely on the analyzer for column-coverage checks, both today and after
+  ///    any future tightening of the DDL grammar.
+  /// 1. The analyzer's own message survives the compile-then-analyze hop unwrapped — i.e.
+  ///    the DDL layer never silently swallows or rewraps a validation result.
+  ///
+  /// The SQL deliberately omits the time column from SELECT (the closest analog of the
+  /// `MaterializedViewAnalyzerTest#testTimeColumnMissingFromSelect` unit case), because
+  /// that error branch has a stable, well-tested wording the analyzer has carried since
+  /// the original MV PR; matching on it keeps this test from going brittle when the
+  /// analyzer is extended with new validation messages over time.
+  @Test
+  public void compiledMaterializedViewDdlSurfacesAnalyzerRejection() {
+    CompiledCreateMaterializedView compiled = (CompiledCreateMaterializedView) DdlCompiler.compile(
+        "CREATE MATERIALIZED VIEW mv_orders ("
+            + "  ts TIMESTAMP DATETIME FORMAT '1:MILLISECONDS:TIMESTAMP' GRANULARITY '1:MILLISECONDS',"
+            + "  city STRING DIMENSION,"
+            + "  cnt LONG METRIC"
+            + ") REFRESH EVERY '1d' "
+            + "PROPERTIES ("
+            + "  'timeColumnName' = 'ts',"
+            + "  'bucketTimePeriod' = '1d',"
+            + "  'replication' = '1'"
+            + ") "
+            + "AS SELECT city, count(*) AS cnt FROM orders GROUP BY city LIMIT 100000");
+
+    TableConfig viewConfig = compiled.getTableConfig();
+    Schema viewSchema = compiled.getSchema();
+    Map<String, String> taskConfigs = viewConfig.getTaskConfig()
+        .getConfigsForTaskType(MaterializedViewTask.TASK_TYPE);
+    String definedSql = taskConfigs.get(MaterializedViewTask.DEFINED_SQL_KEY);
+
+    IllegalStateException e = expectThrows(IllegalStateException.class,
+        () -> MaterializedViewAnalyzer.analyze(definedSql, viewConfig, viewSchema, taskConfigs,
+            _stubContext));
+    if (!e.getMessage().contains("is not produced by any SELECT expression")) {
+      fail("Expected the analyzer's `validateSchemaCoveredBySelect` phrasing ('is not "
+          + "produced by any SELECT expression') to survive the compile-then-analyze hop "
+          + "unwrapped, got: " + e.getMessage());
+    }
+  }
+}

--- a/pinot-sql-ddl/src/test/java/org/apache/pinot/sql/ddl/reverse/CanonicalDdlEmitterMaterializedViewTest.java
+++ b/pinot-sql-ddl/src/test/java/org/apache/pinot/sql/ddl/reverse/CanonicalDdlEmitterMaterializedViewTest.java
@@ -1,0 +1,473 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.sql.ddl.reverse;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableTaskConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.CommonConstants.MaterializedViewTask;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+
+/// Golden-output unit tests for [CanonicalDdlEmitter] on Materialized View configs.
+///
+/// Mirrors the table-side [CanonicalDdlEmitterTest]: every assertion locks in the exact
+/// emitted text (or a clearly motivated substring) so any drift in MV canonical formatting
+/// forces a paired edit to the emitter and the test. TableConfig fixtures are built directly
+/// (no detour through the compiler) so a regression here is unambiguously the emitter's
+/// fault; full emit → parse → emit fidelity is exercised separately in `RoundTripTest`.
+public class CanonicalDdlEmitterMaterializedViewTest {
+
+  // -------------------------------------------------------------------------------------------
+  // No REFRESH clause (cluster-wide cron path)
+  // -------------------------------------------------------------------------------------------
+
+  /// PR3.5 contract: a CREATE MATERIALIZED VIEW without `REFRESH EVERY` produces a TableConfig
+  /// with no `schedule` knob, falling back to the cluster-wide MV cron. Round-trip must keep
+  /// the REFRESH clause absent — emitting `REFRESH EVERY ''` or any default would silently
+  /// pin the MV to a fixed period on re-parse.
+  @Test
+  public void noScheduleElidesRefreshClause() {
+    Schema schema = mvSchema();
+    Map<String, String> mvTask = new LinkedHashMap<>();
+    mvTask.put(MaterializedViewTask.DEFINED_SQL_KEY, "SELECT ts, carrier FROM src");
+    mvTask.put(MaterializedViewTask.BUCKET_TIME_PERIOD_KEY, "1d");
+    TableConfig config = mvConfig("mv", mvTask);
+
+    String emitted = CanonicalDdlEmitter.emit(schema, config);
+
+    assertTrue(emitted.startsWith("CREATE MATERIALIZED VIEW mv ("), emitted);
+    assertFalse(emitted.contains("REFRESH"),
+        "no schedule knob must NOT emit a REFRESH clause; got:\n" + emitted);
+    assertTrue(emitted.contains("AS SELECT ts, carrier FROM src;"), emitted);
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // REFRESH EVERY (cron → period inverse)
+  // -------------------------------------------------------------------------------------------
+
+  /// Schedule = `0 0 0 * * ?` (daily at midnight) — periodToCron's exact daily template.
+  /// cronToPeriod recovers `'1d'` so the canonical form carries the user-friendly period
+  /// string rather than the raw cron expression.
+  @Test
+  public void scheduleEmittedAsRefreshEveryPeriodWhenRoundTrippable() {
+    Schema schema = mvSchema();
+    Map<String, String> mvTask = new LinkedHashMap<>();
+    mvTask.put(MaterializedViewTask.DEFINED_SQL_KEY, "SELECT ts, carrier FROM src");
+    mvTask.put(MaterializedViewTask.BUCKET_TIME_PERIOD_KEY, "1d");
+    mvTask.put("schedule", "0 0 0 * * ?");
+    TableConfig config = mvConfig("mv", mvTask);
+
+    String emitted = CanonicalDdlEmitter.emit(schema, config);
+
+    assertTrue(emitted.contains("REFRESH EVERY '1d'\n"),
+        "REFRESH EVERY clause must use the recovered period; got:\n" + emitted);
+    // The flatten + dedupe path must remove `schedule` from PROPERTIES — leaving it would
+    // make the re-parse refuse the DDL (RESERVED_BY_CLAUSE_KEYS).
+    assertFalse(emitted.contains("'schedule'"),
+        "schedule key must be consumed by REFRESH EVERY, not also surface in PROPERTIES; got:\n"
+            + emitted);
+  }
+
+  /// Q1=A contract: any cron that `cronToPeriod` does not recognise must hard-fail rather
+  /// than silently lose the schedule on the round-trip. The DDL grammar today has no syntax
+  /// for raw cron, so dropping the field would re-emit a config that runs on the cluster cron
+  /// instead of the operator's chosen schedule — a behaviour change with no user-visible
+  /// signal. Surface as IllegalArgumentException so the controller returns 400 with the cause.
+  @Test
+  public void nonStandardCronRejected() {
+    Schema schema = mvSchema();
+    Map<String, String> mvTask = new LinkedHashMap<>();
+    mvTask.put(MaterializedViewTask.DEFINED_SQL_KEY, "SELECT ts, carrier FROM src");
+    mvTask.put(MaterializedViewTask.BUCKET_TIME_PERIOD_KEY, "1d");
+    mvTask.put("schedule", "0 30 9 * * MON-FRI");
+    TableConfig config = mvConfig("mv", mvTask);
+
+    try {
+      CanonicalDdlEmitter.emit(schema, config);
+      fail("Expected non-standard cron to be rejected on SHOW CREATE MATERIALIZED VIEW");
+    } catch (IllegalArgumentException expected) {
+      assertTrue(expected.getMessage().contains("0 30 9 * * MON-FRI"), expected.getMessage());
+      assertTrue(expected.getMessage().contains("REFRESH EVERY"),
+          "error must point the user at the supported form (REFRESH EVERY); got: "
+              + expected.getMessage());
+    }
+  }
+
+  /// `isMaterializedView()` is just a flag read on `_materializedView`; it does NOT validate
+  /// the task-config block.  A TableConfig with the flag set but `getTaskConfig() == null`
+  /// (operator-typed JSON, half-written config, znode written by a tool that doesn't go
+  /// through the SPI invariant validator) reaches the emitter as legal-shaped input.  The
+  /// previous `getTaskConfig().getConfigsForTaskType(...)` chain would NPE here and surface
+  /// to the controller as a 500; the fix must produce a 400 with a message that names the
+  /// missing layer so the operator can target the right znode field.
+  @Test
+  public void missingTaskConfigRejected() {
+    Schema schema = mvSchema();
+    // Deliberately do NOT call setTaskConfig — this is the "operator left the task block off
+    // entirely" shape.  setIsMaterializedView(true) is what makes the dispatch route here, so
+    // omitting it would not exercise the regression.
+    TableConfig config = new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName("mv_no_task")
+        .setIsMaterializedView(true)
+        .setTimeColumnName("ts")
+        .build();
+
+    try {
+      CanonicalDdlEmitter.emit(schema, config);
+      fail("Expected IllegalArgumentException when MV TableConfig has null taskConfig");
+    } catch (IllegalArgumentException expected) {
+      // The message must (1) be operator-actionable — naming the missing layer so they know
+      // which znode field to repair, (2) include the table name so a noisy log can be grepped,
+      // and (3) explicitly mention the isMaterializedView flag so the operator understands
+      // why this code path was reached at all.
+      assertTrue(expected.getMessage().contains("taskConfig block is null"), expected.getMessage());
+      assertTrue(expected.getMessage().contains("mv_no_task"), expected.getMessage());
+      assertTrue(expected.getMessage().contains("isMaterializedView=true"), expected.getMessage());
+    } catch (NullPointerException npe) {
+      // Pin the regression vector reviewer flagged: a future refactor that drops the upstream
+      // null-guard must fail this test with a clear message rather than slip through.
+      fail("Regression: NPE leaked through the emitter — must surface as 400/IllegalArgumentException, not 500. "
+          + "Cause: " + npe);
+    }
+  }
+
+  /// Sibling of [#missingTaskConfigRejected]: the task block exists (and may even carry other
+  /// task types like `SegmentRefreshTask`) but the MV-specific `MaterializedViewTask` entry is
+  /// absent.  This is the second of the two upstream NPE sites the chained
+  /// `getTaskConfig().getConfigsForTaskType(MaterializedViewTask.TASK_TYPE).get(...)`
+  /// dereference would have hit — `getConfigsForTaskType` returns the raw `Map.get` of the
+  /// task-type map and so returns null when the MV task type isn't registered.
+  @Test
+  public void missingMaterializedViewTaskBlockRejected() {
+    Schema schema = mvSchema();
+    Map<String, Map<String, String>> tasks = new LinkedHashMap<>();
+    Map<String, String> unrelatedTask = new LinkedHashMap<>();
+    unrelatedTask.put("schedule", "0 0 * * * ?");
+    // A non-MV task type — the MV entry is completely absent.  This is the shape a TableConfig
+    // takes if `setIsMaterializedView(true)` was applied to a config that already had a
+    // SegmentRefreshTask schedule but never had its MV task block populated.
+    tasks.put("SegmentRefreshTask", unrelatedTask);
+    TableConfig config = new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName("mv_no_mv_block")
+        .setIsMaterializedView(true)
+        .setTimeColumnName("ts")
+        .setTaskConfig(new TableTaskConfig(tasks))
+        .build();
+
+    try {
+      CanonicalDdlEmitter.emit(schema, config);
+      fail("Expected IllegalArgumentException when MV TableConfig has no MaterializedViewTask block");
+    } catch (IllegalArgumentException expected) {
+      assertTrue(expected.getMessage().contains("no '" + MaterializedViewTask.TASK_TYPE + "' entry"),
+          expected.getMessage());
+      assertTrue(expected.getMessage().contains("mv_no_mv_block"), expected.getMessage());
+      // Distinct message from the null-taskConfig case — the operator must be able to tell
+      // these two repair paths apart from the log line alone.
+      assertFalse(expected.getMessage().contains("taskConfig block is null"),
+          "Layer-specific messaging must distinguish `taskConfig is null` from `MV entry "
+              + "missing inside taskConfig`; got: " + expected.getMessage());
+    } catch (NullPointerException npe) {
+      fail("Regression: NPE leaked through the emitter — must surface as 400/IllegalArgumentException, not 500. "
+          + "Cause: " + npe);
+    }
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // PROPERTIES flattening for canonical MV task knobs
+  // -------------------------------------------------------------------------------------------
+
+  /// MV canonical knobs (`bucketTimePeriod`, `bufferTimePeriod`, `maxNumRecordsPerSegment`)
+  /// live under the `MaterializedViewTask` block on disk but are accepted bare by the forward
+  /// router. The reverse path must emit them bare so emit → parse → emit produces identical
+  /// canonical text — emitting them as `task.MaterializedViewTask.<key>` would still round-
+  /// trip semantically but cycle the canonical form between two equivalent strings, breaking
+  /// any caller (e.g. a config-drift detector) that diffs `SHOW CREATE` output.
+  @Test
+  public void canonicalKnobsFlattenedBareNotPrefixed() {
+    Schema schema = mvSchema();
+    Map<String, String> mvTask = new LinkedHashMap<>();
+    mvTask.put(MaterializedViewTask.DEFINED_SQL_KEY, "SELECT ts, carrier FROM src");
+    mvTask.put(MaterializedViewTask.BUCKET_TIME_PERIOD_KEY, "1d");
+    mvTask.put(MaterializedViewTask.BUFFER_TIME_PERIOD_KEY, "2h");
+    mvTask.put(MaterializedViewTask.MAX_NUM_RECORDS_PER_SEGMENT_KEY, "5000000");
+    TableConfig config = mvConfig("mv", mvTask);
+
+    String emitted = CanonicalDdlEmitter.emit(schema, config);
+
+    assertTrue(emitted.contains("'bucketTimePeriod' = '1d'"), emitted);
+    assertTrue(emitted.contains("'bufferTimePeriod' = '2h'"), emitted);
+    assertTrue(emitted.contains("'maxNumRecordsPerSegment' = '5000000'"), emitted);
+    assertFalse(emitted.contains("'task.MaterializedViewTask.bucketTimePeriod'"),
+        "canonical knob must be flattened, not double-emitted under task.* prefix; got:\n"
+            + emitted);
+    assertFalse(emitted.contains("'task.MaterializedViewTask.bufferTimePeriod'"), emitted);
+    assertFalse(emitted.contains("'task.MaterializedViewTask.maxNumRecordsPerSegment'"), emitted);
+  }
+
+  /// Experimental / future MV task knobs (anything not recognized by
+  /// [MaterializedViewPropertyRouter#canonicalKnobName]) are kept under the
+  /// `task.MaterializedViewTask.*` prefix on emit. The forward router's task-prefix rule
+  /// will route them back into the same MV task block on re-parse, so the round-trip is
+  /// preserved even though the canonical form is not bare.
+  @Test
+  public void unknownMvTaskKnobRetainsTaskPrefix() {
+    Schema schema = mvSchema();
+    Map<String, String> mvTask = new LinkedHashMap<>();
+    mvTask.put(MaterializedViewTask.DEFINED_SQL_KEY, "SELECT ts, carrier FROM src");
+    mvTask.put(MaterializedViewTask.BUCKET_TIME_PERIOD_KEY, "1d");
+    mvTask.put("experimentalKnob", "value42");
+    TableConfig config = mvConfig("mv", mvTask);
+
+    String emitted = CanonicalDdlEmitter.emit(schema, config);
+
+    assertTrue(emitted.contains("'task.MaterializedViewTask.experimentalKnob' = 'value42'"),
+        "non-canonical MV task knob must keep its task.* prefix so re-parse routes it back; "
+            + "got:\n" + emitted);
+    assertFalse(emitted.contains("'experimentalKnob' = "),
+        "non-canonical knob must NOT be flattened; that would re-parse as an unknown bare "
+            + "property; got:\n" + emitted);
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // Synthetic-key suppression
+  // -------------------------------------------------------------------------------------------
+
+  /// `definedSQL` is rendered by the trailing `AS <query>` clause; surfacing it in PROPERTIES
+  /// would (a) double-render the query body in canonical form and (b) make the re-parse fail
+  /// because the forward router rejects `definedSQL` in PROPERTIES.
+  @Test
+  public void definedSqlNeverAppearsInProperties() {
+    Schema schema = mvSchema();
+    Map<String, String> mvTask = new LinkedHashMap<>();
+    mvTask.put(MaterializedViewTask.DEFINED_SQL_KEY, "SELECT ts, carrier FROM src");
+    mvTask.put(MaterializedViewTask.BUCKET_TIME_PERIOD_KEY, "1d");
+    TableConfig config = mvConfig("mv", mvTask);
+
+    String emitted = CanonicalDdlEmitter.emit(schema, config);
+
+    assertFalse(emitted.contains("'definedSQL'"),
+        "definedSQL must only appear inside the AS clause; got:\n" + emitted);
+    assertFalse(emitted.contains("'task.MaterializedViewTask.definedSQL'"), emitted);
+    assertTrue(emitted.endsWith("AS SELECT ts, carrier FROM src;\n"), emitted);
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // Database-qualified name
+  // -------------------------------------------------------------------------------------------
+
+  @Test
+  public void databaseQualifiedNameRendered() {
+    Schema schema = mvSchema();
+    Map<String, String> mvTask = new LinkedHashMap<>();
+    mvTask.put(MaterializedViewTask.DEFINED_SQL_KEY, "SELECT ts, carrier FROM src");
+    mvTask.put(MaterializedViewTask.BUCKET_TIME_PERIOD_KEY, "1d");
+    TableConfig config = mvConfig("analytics.mv", mvTask);
+
+    String emitted = CanonicalDdlEmitter.emit(schema, config, "analytics");
+
+    assertTrue(emitted.startsWith("CREATE MATERIALIZED VIEW analytics.mv ("), emitted);
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // Dispatch
+  // -------------------------------------------------------------------------------------------
+
+  /// Sanity check that the MV dispatch in [CanonicalDdlEmitter#emit] does NOT fire for a
+  /// regular OFFLINE table that happens to carry some other task (e.g.
+  /// RealtimeToOfflineSegmentsTask). Symmetric guard against the inverse failure of
+  /// [#canonicalKnobsFlattenedBareNotPrefixed].
+  @Test
+  public void nonMaterializedViewWithOtherTaskEmittedAsCreateTable() {
+    Schema schema = mvSchema();
+    Map<String, String> rto = new LinkedHashMap<>();
+    rto.put("bucketTimePeriod", "1d");
+    Map<String, Map<String, String>> tasks = new LinkedHashMap<>();
+    tasks.put("RealtimeToOfflineSegmentsTask", rto);
+    TableConfig config = new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName("events")
+        .setTimeColumnName("ts")
+        .setTaskConfig(new TableTaskConfig(tasks))
+        .build();
+
+    String emitted = CanonicalDdlEmitter.emit(schema, config);
+
+    assertTrue(emitted.startsWith("CREATE TABLE events ("),
+        "with isMaterializedView=false (default) the dispatch must stay on CREATE TABLE "
+            + "regardless of other task blocks; got:\n" + emitted);
+    assertFalse(emitted.contains("MATERIALIZED VIEW"), emitted);
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // Regression: TreeMap delete-with-two-children corrupted canonical knob values
+  // -------------------------------------------------------------------------------------------
+
+  /// Caught on live cluster traffic, fixed in `CanonicalDdlEmitter.extractMaterializedViewProperties`:
+  /// `TreeMap.deleteEntry` for an internal node with two children copies the in-order
+  /// successor's key+value INTO the current Entry node before unlinking the successor — so
+  /// the `Map.Entry` reference handed back by the iterator has its `value` field mutated by
+  /// the time you call `entry.getValue()` after `it.remove()`. The visible symptom on
+  /// `SHOW CREATE MATERIALIZED VIEW` was `'maxNumRecordsPerSegment' = 'dayMillis'` — i.e. the
+  /// successor `timeColumnName`'s value bleeding into the canonical knob.
+  ///
+  /// The repro fixture mirrors the production `orders_daily_mv` shape: enough entries above
+  /// and below the canonical knob in lexicographic order that the doomed TreeMap node ends up
+  /// internal with two children at deletion time. Each canonical knob is asserted with a
+  /// strict `'<knob>' = '<value>'` substring so a single character of value drift fails the
+  /// test loudly. The bare `contains("'<value>'")` style would let `'10000'` masquerade as
+  /// `'dayMillis'` and miss the corruption entirely.
+  @Test
+  public void canonicalKnobValuesSurviveTreeMapDeleteRebalance() {
+    Schema schema = mvSchema();
+    Map<String, String> mvTask = new LinkedHashMap<>();
+    mvTask.put(MaterializedViewTask.DEFINED_SQL_KEY,
+        "SELECT ts, carrier, COUNT(*) AS c FROM src GROUP BY ts, carrier");
+    mvTask.put(MaterializedViewTask.BUCKET_TIME_PERIOD_KEY, "1d");
+    mvTask.put(MaterializedViewTask.MAX_NUM_RECORDS_PER_SEGMENT_KEY, "10000");
+
+    // Production-shaped sibling fields: each adds an entry to the top-level TreeMap so the
+    // canonical knob nodes end up internal (not leaf) at iteration time. Without these the
+    // tree is shallow enough that deletes hit only leaf nodes and never trigger the swap.
+    TableConfig config = new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName("mv_repro")
+        .setIsMaterializedView(true)
+        .setTimeColumnName("dayMillis")  // alphabetically later than maxNumRecordsPerSegment
+        .setRetentionTimeUnit("DAYS")
+        .setRetentionTimeValue("365")
+        .setBrokerTenant("DefaultTenant")
+        .setServerTenant("DefaultTenant")
+        .setTaskConfig(new TableTaskConfig(java.util.Collections.singletonMap(
+            MaterializedViewTask.TASK_TYPE, mvTask)))
+        .build();
+
+    String emitted = CanonicalDdlEmitter.emit(schema, config);
+
+    assertTrue(emitted.contains("'bucketTimePeriod' = '1d'"),
+        "bucketTimePeriod value must survive TreeMap delete rebalance; got:\n" + emitted);
+    assertTrue(emitted.contains("'maxNumRecordsPerSegment' = '10000'"),
+        "maxNumRecordsPerSegment must keep its real value '10000', not a sibling's; got:\n"
+            + emitted);
+    assertTrue(emitted.contains("'timeColumnName' = 'dayMillis'"),
+        "timeColumnName must still be emitted normally; got:\n" + emitted);
+    assertFalse(emitted.contains("'maxNumRecordsPerSegment' = 'dayMillis'"),
+        "REGRESSION: TreeMap.Entry mutation after it.remove() bled timeColumnName's value "
+            + "into the canonical knob; got:\n" + emitted);
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // Regression: trailing semicolon doubling in AS <query>
+  // -------------------------------------------------------------------------------------------
+
+  /// Legacy MV configs stored a `definedSQL` ending in `;` (operators copy-pasted the full
+  /// SQL into the JSON table-config API, semicolon and all). The emitter unconditionally
+  /// appends its own `;` so the canonical DDL ended in `;;\n`, which fails strict SQL parsing
+  /// on replay. Strip any trailing `;` / whitespace before terminating with exactly one `;`.
+  @Test
+  public void trailingSemicolonInDefinedSqlNotDoubledOnEmit() {
+    Schema schema = mvSchema();
+    Map<String, String> mvTask = new LinkedHashMap<>();
+    mvTask.put(MaterializedViewTask.DEFINED_SQL_KEY,
+        "select ts, carrier from src group by ts, carrier;");
+    mvTask.put(MaterializedViewTask.BUCKET_TIME_PERIOD_KEY, "1d");
+    TableConfig config = mvConfig("mv", mvTask);
+
+    String emitted = CanonicalDdlEmitter.emit(schema, config);
+
+    assertFalse(emitted.contains(";;\n"),
+        "trailing `;` in stored definedSQL must be normalised to exactly one; got:\n" + emitted);
+    assertTrue(emitted.endsWith("AS select ts, carrier from src group by ts, carrier;\n"),
+        "canonical DDL must end with a single `;\\n`; got:\n" + emitted);
+  }
+
+  /// Defensive variant: multiple trailing `;` and whitespace must all be stripped, then
+  /// re-terminated with one `;`.
+  @Test
+  public void multipleTrailingSemicolonsAndWhitespaceNormalisedToOne() {
+    Schema schema = mvSchema();
+    Map<String, String> mvTask = new LinkedHashMap<>();
+    mvTask.put(MaterializedViewTask.DEFINED_SQL_KEY,
+        "select ts, carrier from src;  ; \n; ");
+    mvTask.put(MaterializedViewTask.BUCKET_TIME_PERIOD_KEY, "1d");
+    TableConfig config = mvConfig("mv", mvTask);
+
+    String emitted = CanonicalDdlEmitter.emit(schema, config);
+
+    assertTrue(emitted.endsWith("AS select ts, carrier from src;\n"),
+        "got:\n" + emitted);
+  }
+
+  /// Round-trip determinism for the MV path: two `emit` calls on the same (schema, config)
+  /// must produce byte-identical strings. PropertyExtractor uses a TreeMap so iteration order
+  /// is stable, but the MV extractor adds a LinkedHashMap pass on top — this test locks the
+  /// invariant in case anyone introduces a HashMap downstream.
+  @Test
+  public void deterministicOutputAcrossRepeatedCalls() {
+    Schema schema = mvSchema();
+    Map<String, String> mvTask = new LinkedHashMap<>();
+    mvTask.put(MaterializedViewTask.DEFINED_SQL_KEY, "SELECT ts, carrier FROM src");
+    mvTask.put(MaterializedViewTask.BUCKET_TIME_PERIOD_KEY, "1d");
+    mvTask.put(MaterializedViewTask.BUFFER_TIME_PERIOD_KEY, "2h");
+    mvTask.put("schedule", "0 0 0 * * ?");
+    TableConfig config = mvConfig("mv", mvTask);
+
+    String first = CanonicalDdlEmitter.emit(schema, config);
+    String second = CanonicalDdlEmitter.emit(schema, config);
+    assertEquals(first, second, "MV canonical emit must be deterministic");
+  }
+
+  // -------------------------------------------------------------------------------------------
+  // Helpers
+  // -------------------------------------------------------------------------------------------
+
+  /// Minimal MV-shaped schema: one datetime column (used as the MV time column) and one
+  /// dimension. Kept identical across every test so per-test deltas land squarely on the
+  /// emitter's MV-specific branches.
+  private static Schema mvSchema() {
+    return new Schema.SchemaBuilder()
+        .setSchemaName("mv")
+        .addDateTime("ts", DataType.TIMESTAMP, "1:MILLISECONDS:TIMESTAMP", "1:DAYS")
+        .addSingleValueDimension("carrier", DataType.STRING)
+        .build();
+  }
+
+  /// Builds an OFFLINE TableConfig with the given MV task block plus the canonical
+  /// `isMaterializedView` identity flag (PR #18564 — the single source of truth the emitter
+  /// dispatches on). The `timeColumnName` is fixed to `ts` to match [#mvSchema]; tests that
+  /// need a different time column should rebuild directly and remember to set the flag too.
+  private static TableConfig mvConfig(String tableName, Map<String, String> mvTask) {
+    Map<String, Map<String, String>> tasks = new LinkedHashMap<>();
+    tasks.put(MaterializedViewTask.TASK_TYPE, mvTask);
+    return new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName(tableName)
+        .setIsMaterializedView(true)
+        .setTimeColumnName("ts")
+        .setTaskConfig(new TableTaskConfig(tasks))
+        .build();
+  }
+}

--- a/pinot-sql-ddl/src/test/java/org/apache/pinot/sql/ddl/roundtrip/RoundTripTest.java
+++ b/pinot-sql-ddl/src/test/java/org/apache/pinot/sql/ddl/roundtrip/RoundTripTest.java
@@ -40,6 +40,7 @@ import org.apache.pinot.spi.data.TimeFieldSpec;
 import org.apache.pinot.spi.data.TimeGranularitySpec;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.apache.pinot.sql.ddl.compile.CompiledCreateMaterializedView;
 import org.apache.pinot.sql.ddl.compile.CompiledCreateTable;
 import org.apache.pinot.sql.ddl.compile.DdlCompiler;
 import org.apache.pinot.sql.ddl.reverse.CanonicalDdlEmitter;
@@ -500,6 +501,92 @@ public class RoundTripTest {
   }
 
   // -------------------------------------------------------------------------------------------
+  // Materialized View round-trip cases
+  //
+  // The end-to-end shape for an MV is `CREATE MATERIALIZED VIEW` DDL → compile → emit (via
+  // CanonicalDdlEmitter dispatching to the MV branch) → recompile → assert byte- and JSON-
+  // equivalent (schema + table config + canonical text). Together these tests pin the four
+  // MV-only fidelity guarantees:
+  //
+  //   1. omitted REFRESH stays omitted (PR3.5 cluster-cron fallback),
+  //   2. `REFRESH EVERY '<period>'` round-trips through the cron ↔ period inversion,
+  //   3. canonical MV task knobs (`bucketTimePeriod`, `bufferTimePeriod`,
+  //      `maxNumRecordsPerSegment`) survive as bare PROPERTIES,
+  //   4. a database-qualified MV name survives the qualifier stripping in resolveQualifiedName.
+  // -------------------------------------------------------------------------------------------
+
+  @Test
+  public void materializedViewWithoutRefreshClauseRoundTrips() {
+    // PR3.5 contract: no REFRESH clause => no `schedule` knob on disk => emit must NOT add one.
+    // If a future change ever defaulted the schedule on the parser side, this test would catch
+    // the silent insertion because the second compile would carry a `schedule` the first did not.
+    String ddl = "CREATE MATERIALIZED VIEW mv (\n"
+        + "  ts TIMESTAMP DATETIME FORMAT '1:MILLISECONDS:TIMESTAMP' GRANULARITY '1:DAYS',\n"
+        + "  carrier STRING\n"
+        + ")\n"
+        + "PROPERTIES (\n"
+        + "  'timeColumnName' = 'ts',\n"
+        + "  'bucketTimePeriod' = '1d'\n"
+        + ")\n"
+        + "AS SELECT ts, carrier FROM src;\n";
+    assertMaterializedViewRoundTrip(ddl);
+  }
+
+  @Test
+  public void materializedViewWithRefreshEveryOneDayRoundTrips() {
+    // Daily schedule exercises the `0 0 0 * * ?` ↔ `1d` cron/period inverse.
+    String ddl = "CREATE MATERIALIZED VIEW mv (\n"
+        + "  ts TIMESTAMP DATETIME FORMAT '1:MILLISECONDS:TIMESTAMP' GRANULARITY '1:DAYS',\n"
+        + "  carrier STRING\n"
+        + ")\n"
+        + "REFRESH EVERY '1d'\n"
+        + "PROPERTIES (\n"
+        + "  'timeColumnName' = 'ts',\n"
+        + "  'bucketTimePeriod' = '1d'\n"
+        + ")\n"
+        + "AS SELECT ts, carrier FROM src;\n";
+    assertMaterializedViewRoundTrip(ddl);
+  }
+
+  @Test
+  public void materializedViewWithFullKnobSetRoundTrips() {
+    // Exercises every canonical task knob in one go so the flatten-on-extract /
+    // route-on-parse symmetry is locked down in a single test. Also uses the 15-minute cron
+    // template (`0 0/15 * * * ?`) to vary the schedule cell.
+    String ddl = "CREATE MATERIALIZED VIEW mv (\n"
+        + "  ts TIMESTAMP DATETIME FORMAT '1:MILLISECONDS:TIMESTAMP' GRANULARITY '1:DAYS',\n"
+        + "  carrier STRING,\n"
+        + "  amount DOUBLE METRIC\n"
+        + ")\n"
+        + "REFRESH EVERY '15m'\n"
+        + "PROPERTIES (\n"
+        + "  'timeColumnName' = 'ts',\n"
+        + "  'bucketTimePeriod' = '1h',\n"
+        + "  'bufferTimePeriod' = '2h',\n"
+        + "  'maxNumRecordsPerSegment' = '500000'\n"
+        + ")\n"
+        + "AS SELECT ts, carrier, amount FROM src;\n";
+    assertMaterializedViewRoundTrip(ddl);
+  }
+
+  @Test
+  public void databaseQualifiedMaterializedViewRoundTrips() {
+    // Mirrors the table-side database-qualified case (`databaseQualifiedNameRendered`) — pins
+    // the `<db>.<name>` qualifier through the emitter's MV branch.
+    String ddl = "CREATE MATERIALIZED VIEW analytics.mv (\n"
+        + "  ts TIMESTAMP DATETIME FORMAT '1:MILLISECONDS:TIMESTAMP' GRANULARITY '1:DAYS',\n"
+        + "  carrier STRING\n"
+        + ")\n"
+        + "REFRESH EVERY '1d'\n"
+        + "PROPERTIES (\n"
+        + "  'timeColumnName' = 'ts',\n"
+        + "  'bucketTimePeriod' = '1d'\n"
+        + ")\n"
+        + "AS SELECT ts, carrier FROM src;\n";
+    assertMaterializedViewRoundTrip(ddl, "analytics");
+  }
+
+  // -------------------------------------------------------------------------------------------
   // Equivalence machinery
   // -------------------------------------------------------------------------------------------
 
@@ -526,6 +613,44 @@ public class RoundTripTest {
     // Idempotency: emit-parse-emit should yield the same canonical text.
     String secondEmit = CanonicalDdlEmitter.emit(round.getSchema(), round.getTableConfig());
     assertEquals(secondEmit, ddl, "Canonical DDL must be idempotent across round-trip:\n" + ddl);
+  }
+
+  private static void assertMaterializedViewRoundTrip(String ddl) {
+    assertMaterializedViewRoundTrip(ddl, null);
+  }
+
+  /// MV variant of [#assertRoundTrip]. The starting point is a `CREATE MATERIALIZED VIEW`
+  /// DDL string (rather than a programmatically-built TableConfig) because constructing an
+  /// MV TableConfig by hand reproduces the compiler's bucketing / definedSQL / cron logic in
+  /// every test fixture — fragile and a tautology. Starting from the DDL we compile, emit
+  /// (which dispatches to the MV branch via [TableConfig#isMaterializedView]),
+  /// recompile, and assert the second (schema, table config) pair is JSON-equivalent to the
+  /// first and that the canonical text is byte-stable across the second emit.
+  ///
+  /// `databaseName` is passed straight through to [CanonicalDdlEmitter#emit] so the
+  /// db-qualified test exercises the same code path the controller's
+  /// `executeShowCreateMaterializedView` will use.
+  private static void assertMaterializedViewRoundTrip(String ddl, @javax.annotation.Nullable String databaseName) {
+    CompiledCreateMaterializedView first =
+        (CompiledCreateMaterializedView) DdlCompiler.compile(ddl);
+    assertNotNull(first, "Source DDL should compile: " + ddl);
+
+    String firstEmit =
+        CanonicalDdlEmitter.emit(first.getSchema(), first.getTableConfig(), databaseName);
+    assertTrue(firstEmit.startsWith("CREATE MATERIALIZED VIEW "),
+        "MV dispatch must produce a `CREATE MATERIALIZED VIEW` statement; got:\n" + firstEmit);
+
+    CompiledCreateMaterializedView second =
+        (CompiledCreateMaterializedView) DdlCompiler.compile(firstEmit);
+    assertNotNull(second, "Round-tripped MV DDL should compile:\n" + firstEmit);
+
+    assertSchemaEquivalent(first.getSchema(), second.getSchema(), firstEmit);
+    assertTableConfigEquivalent(first.getTableConfig(), second.getTableConfig(), firstEmit);
+
+    String secondEmit =
+        CanonicalDdlEmitter.emit(second.getSchema(), second.getTableConfig(), databaseName);
+    assertEquals(secondEmit, firstEmit,
+        "Canonical MV DDL must be idempotent across round-trip:\n" + firstEmit);
   }
 
   private static void assertSchemaEquivalent(Schema a, Schema b, String ddl) {


### PR DESCRIPTION
# Materialized View DDL — CREATE / SHOW / SHOW CREATE / DROP

## TL;DR

Adds Pinot-native SQL DDL for managing **Materialized Views (MV)** end-to-end, served through the existing `POST /sql/ddl` controller endpoint introduced by the Table DDL PR. Four new statements:

```sql
-- Column list is OPTIONAL. When omitted, the storage schema is inferred from the
-- AS <query> projection (recommended). When present, all columns must be declared
-- explicitly. Mixing (partial column list) is not allowed.
CREATE MATERIALIZED VIEW [IF NOT EXISTS] [db.]name
[ ( col TYPE [DIMENSION|METRIC|DATETIME FORMAT '..' GRANULARITY '..']
        [NOT NULL|NULL] [DEFAULT lit], ... ) ]
[REFRESH [INTERVAL] EVERY <period>]
PROPERTIES ('timeColumnName' = 't', 'bucketTimePeriod' = '1d', ...)
AS <Pinot SELECT>

SHOW MATERIALIZED VIEWS [FROM db]              -- list MVs in the (database-scoped) cluster
SHOW CREATE MATERIALIZED VIEW [db.]name        -- no TYPE clause (MV is always OFFLINE)
DROP MATERIALIZED VIEW [IF EXISTS] [db.]name   -- no TYPE clause
```

Before this PR, MVs could only be authored / inspected / torn down via the JSON `POST /tables` path — verbose, error-prone, and impossible to copy-paste between environments. This PR makes MVs a first-class SQL DDL surface with a deterministic round-trip: `CREATE` → ZK → `SHOW CREATE` produces a statement that re-parses to the same `TableConfig`.

Labels: `feature`, `release-notes` (new SQL grammar + new controller error contracts), `sql-compliance`, `materialized-view`.

## Scope & alignment with prior PRs

This MV DDL is implemented on top of the following two PRs. Its functional scope is intentionally kept aligned with theirs — anything outside that joint baseline is out of scope here and tracked on the respective upstream layer instead.

- Materialized View Creation: https://github.com/apache/pinot/pull/18528
- Table DDL: https://github.com/apache/pinot/pull/18241

---

## DDL 1: `CREATE MATERIALIZED VIEW`

There are two ways to author the column list. **`AS`-driven inference is the recommended path.** Use the explicit form only when you need to override the inferred type/role of a specific column (e.g. tighten a `LONG` to `INT`, or declare a non-time column as `DATETIME` with an explicit format).

### Two ways, same MV

The following two statements produce a byte-identical persisted `TableConfig` + `Schema`:

| Inferred (recommended) | Explicit |
| --- | --- |
| <pre>CREATE MATERIALIZED VIEW clickstream_daily_event_counts<br>REFRESH EVERY '15m'<br>PROPERTIES (<br>    'timeColumnName'   = 'event_day',<br>    'bucketTimePeriod' = '1d'<br>)<br>AS<br>SELECT DATETRUNC('DAY', ts) AS event_day,<br>       event_name,<br>       COUNT(*)            AS cnt<br>FROM clickstreamFunnel<br>GROUP BY event_day, event_name;</pre> | <pre>CREATE MATERIALIZED VIEW clickstream_daily_event_counts (<br>    event_day  TIMESTAMP DATETIME FORMAT '1:MILLISECONDS:TIMESTAMP'<br>                                  GRANULARITY '1:MILLISECONDS' NOT NULL,<br>    event_name STRING    NOT NULL,<br>    cnt        LONG      METRIC   NOT NULL<br>)<br>REFRESH EVERY '15m'<br>PROPERTIES (<br>    'timeColumnName'   = 'event_day',<br>    'bucketTimePeriod' = '1d'<br>)<br>AS<br>SELECT DATETRUNC('DAY', ts) AS event_day,<br>       event_name,<br>       COUNT(*)            AS cnt<br>FROM clickstreamFunnel<br>GROUP BY event_day, event_name;</pre> |

### No mixing

The column list is **all-or-nothing**:

- **All inferred** — omit the `(...)` column list entirely; every column is derived from the `AS <query>` projection.
- **All explicit** — declare every projected column; the projection arity, names, and ordering must line up exactly.

A column list that covers only some of the projection columns (or that adds extra columns the projection does not produce) is rejected at compile time with HTTP 400 and a clear pointer to either drop the column list or complete it.

### Inferred type & role mapping

Inference is intentionally narrow — it derives the **data type** and assigns the **time column**; everything else is a deliberately conservative default. When the column list is omitted, each `SELECT` projection alias maps to an MV column as follows:

| Projection alias | Inferred role | Inferred data type | Notes |
| --- | --- | --- | --- |
| The alias equal to `timeColumnName` (case-insensitive) | `DATETIME` | `TIMESTAMP` | Always pinned to format `1:MILLISECONDS:TIMESTAMP`, granularity `1:MILLISECONDS`, `NOT NULL`. The SELECT may derive it any way (identity passthrough, `DATETRUNC`, arithmetic scaling, …) — the inferred MV column shape is the same canonical millis-epoch TIMESTAMP. The table-create-time analyzer enforces base-column / `bucketTimePeriod` alignment. |
| `SUM(expr)` / `MIN(expr)` / `MAX(expr)` | `METRIC` | `DOUBLE` | from `MaterializedViewAggregationCatalog`; `NOT NULL` |
| `COUNT(expr)` / `COUNT(*)` | `METRIC` | `LONG` | `NOT NULL` |
| `DISTINCTCOUNTRAWHLL` / `DISTINCTCOUNTRAWHLLPLUS` / `DISTINCTCOUNTRAWTHETASKETCH` | `METRIC` | `BYTES` | `NOT NULL`. Raw sketches are stored as serialized bytes; both engines surface them as a hex `STRING` to query clients, but the MV column **must** be `BYTES` for the rewrite engine to re-aggregate them. This catalog is the single source of truth for that override. |
| Any other projection (bare identifier, scalar transform, aggregation not in the catalog above) | `DIMENSION` | Calcite's validated row type | `NOT NULL`, no format, no default. The inferer trusts the multi-stage engine's column type and makes no attempt to inherit the source column's role / nullability / default / format. If you need a different role (e.g. a non-time `DATETIME` column) or a non-default nullability/default, supply an explicit column list. |

Aggregations not on the catalog allow-list (e.g. `AVG`, `DISTINCTCOUNT`, custom UDAFs) are **not** auto-rejected by the inferer (they fall through as DIMENSION) — but the table-create-time `MaterializedViewAnalyzer` rejects any aggregation the rewrite engine cannot re-aggregate, so a non-re-aggregatable MV never reaches storage. Unaliased non-bare SELECT items (`SELECT SUM(x) FROM …` with no `AS`) and `SELECT *` are rejected at compile time with HTTP 400.

### `REFRESH [INTERVAL] EVERY <period>`

Optional. Registers a per-MV Quartz cron under `task.MaterializedViewTask.schedule`. When omitted, the MV runs under the cluster-wide `PinotTaskManager` schedule. The optional `INTERVAL` keyword is pure syntactic sugar (`REFRESH INTERVAL EVERY 1 MINUTE` ≡ `REFRESH EVERY 1 MINUTE`).

Two equivalent value forms:

- **Quoted period** — a single positive integer + unit char `m` / `h` / `d` (e.g. `'15m'`, `'6h'`, `'1d'`).
- **Sugared** — `EVERY <N> { MINUTE[S] | HOUR[S] | DAY[S] }` (e.g. `REFRESH EVERY 15 MINUTES`), normalized to the quoted form internally.

| Period | Range | Notes |
| --- | --- | --- |
| `'Nm'` / `EVERY N MINUTES` | 1 – 59 | Every N minutes, fires at second 0. |
| `'Nh'` / `EVERY N HOURS` | 1 – 23 | Every N hours, fires at minute 0. |
| `'Nd'` / `EVERY N DAYS` | 1 – 28 | Every N days; cycle resets at day 1 of each month. |

Rejected at parse / compile time (HTTP 400):

- `'60m'`, `'24h'`, `'29d'` and above — use the next-larger unit.
- `'0d'` / `'-1m'` / `'1.5h'` — non-positive or non-integer.
- Sugared `SECOND[S]` / `WEEK[S]` / `MONTH[S]` / `YEAR[S]` — unsupported granularity (minute is the floor).
- Hand-written cron expressions — there is no DDL syntax for arbitrary cron. Operators needing irregular schedules use the JSON API; `SHOW CREATE MATERIALIZED VIEW` on such an MV returns 400 rather than silently emitting an un-round-trippable DDL.

### `PROPERTIES`

Single flat string-to-string map. Keys are case-insensitive on input; canonical casing is restored on the wire. MV task knobs may be written either bare (`bucketTimePeriod`, preferred) or prefixed (`task.MaterializedViewTask.bucketTimePeriod`); both canonicalize to the same on-wire key, and `SHOW CREATE` always emits the bare form.

#### Required

| Key | Type / format | Description |
| --- | --- | --- |
| `timeColumnName` | identifier | The MV column used for watermark progression. Must match one of the SELECT-list aliases. |
| `bucketTimePeriod` | period (`'1h'`, `'1d'`, `'7d'`, …) | Width of the materialization window. Determines watermark advance step and per-task time-range filter. Must be `> 0`. |

#### Optional MV task knobs

| Key | Type | Default | Description |
| --- | --- | --- | --- |
| `bufferTimePeriod` | period | empty (no buffer) | Lag between wall clock and the watermark when scheduling new APPEND windows. Must be `≥ 0`. |
| `maxNumRecordsPerSegment` | integer | `5000000` | Max rows per generated MV segment. Must be `> 0`. |
| `maxTasksPerBatch` | integer | `4` (hard cap `1000`) | How many APPEND windows the scheduler dispatches per generator cycle. Must be `≥ 1`. |
| `stalenessThresholdMs` | long ms | `0` (SLO disabled) | Per-MV freshness SLO. When `(now - watermarkMs) > stalenessThresholdMs`, the broker excludes this MV from query-rewrite. `0` means no check. Malformed values like `'60s'` and negatives are rejected at CREATE time; explicit `0` is accepted as the "no SLO" sentinel. |
| `taskMode` | string | scheduler-managed | Reserved. Setting it has no effect on scheduling; kept on the allow-list so existing JSON-API tables round-trip. |

#### Optional table-level promoted knobs

| Key | Type | Default | Description |
| --- | --- | --- | --- |
| `replication` | integer | cluster default | Number of OFFLINE replicas. |
| `brokerTenant` | identifier | `DefaultTenant` | Broker tenant. |
| `serverTenant` | identifier | `DefaultTenant` | Server tenant. |
| `timeColumn` | identifier | — | Alias for `timeColumnName`. |
| `timeType` | string | inferred from column-level `FORMAT '..'` | Almost never needed. Accepted for parity with `CREATE TABLE`. |

Any other `task.<otherTaskType>.<key>` is preserved verbatim (forward-compat for a future task type composed onto an MV). Any other bare key lands in `TableCustomConfig`.

#### Rejected at compile time (HTTP 400)

| Key | Why |
| --- | --- |
| `schedule` (bare or `task.MaterializedViewTask.schedule`) | Reserved; use `REFRESH EVERY <period>`. |
| `definedSQL` (bare or `task.MaterializedViewTask.definedSQL`) | Reserved; written from the `AS <query>` clause. |
| `streamType`, `stream.*`, `realtime.*` | MV is always OFFLINE. |
| `tableType`, `tableName`, `ifNotExists`, `isMaterializedView` | Reserved DDL-clause / identity names. |

### Limitations enforced at compile time

| Restriction | Why |
| --- | --- |
| MV cannot share a name with an existing OFFLINE or REALTIME table | An MV *is* an OFFLINE table; collisions would create undefined behavior. |
| MV source table cannot be REALTIME (or the REALTIME half of a hybrid) | MV consistency tracking does not yet observe realtime commits. |
| `AS <query>` rejects `JOIN`, `SELECT *`, and DML (`INSERT` / `UPDATE` / `DELETE` / `MERGE`) | Not currently supported by the MV task generator and the broker rewrite engine. |
| Sub-minute `REFRESH EVERY` and arbitrary cron expressions | Sub-minute cadence is operationally hostile; arbitrary cron has no DDL syntax — use the JSON API. |

---

## DDL 2: `SHOW MATERIALIZED VIEWS [FROM db]`

Lists raw MV names (no `_OFFLINE` suffix) in the database scope. Identification is driven by the canonical `TableConfig.isMaterializedView()` flag. MVs continue to appear in `SHOW TABLES` (they are physically OFFLINE tables); `SHOW MATERIALIZED VIEWS` is the type-narrowed view of the same catalog.

```sql
SHOW MATERIALIZED VIEWS;                -- current database (defaults to "default")
SHOW MATERIALIZED VIEWS FROM analytics; -- override the database
```

---

## DDL 3: `SHOW CREATE MATERIALIZED VIEW [db.]name`

Returns the canonical, re-parseable DDL for the named MV. **Always emits the explicit-column form** for round-trip stability — the output is byte-identical regardless of whether the MV was originally created with an inferred or explicit column list.

```sql
SHOW CREATE MATERIALIZED VIEW analytics.clickstream_daily_funnel;
```

Emission rules:

- Properties emitted in lexicographic order.
- MV task knobs flattened back to bare form (matches the canonical input shape).
- `REFRESH EVERY '<period>'` emitted only when the stored cron round-trips via the inverse mapping; non-standard hand-crafted cron expressions trigger HTTP 400 with a pointer back to the JSON API rather than silently dropping the schedule.
- `task.MaterializedViewTask.definedSQL` is preserved as the **raw user-typed substring** of `AS <query>` and re-emitted verbatim — no Calcite re-rendering, no dialect drift.
- No `TYPE` clause is accepted (a trailing `TYPE OFFLINE` fails parsing rather than being silently swallowed).

`emit → parse → emit` is exercised end-to-end.

---

## DDL 4: `DROP MATERIALIZED VIEW [IF EXISTS] [db.]name`

Tears down the MV, including its definition znode, runtime watermark znode, and Helix resource. No `TYPE` clause.

`IF EXISTS` swallows a **missing** MV (200 no-op). It does **not** swallow type confusion: if the name resolves to a plain OFFLINE table, the call returns 400 pointing at `DROP TABLE`. If `deleteTable` rejects the drop (e.g. blocked by a dependent MV), any task schedules that were preemptively cleared are restored.

```sql
DROP MATERIALIZED VIEW IF EXISTS analytics.clickstream_daily_funnel;
```

---

## Examples

The examples below cover every supported shape. Each is a single statement you can send as the `sql` field to `POST /sql/ddl`.

### A. Minimal inferred MV

```sql
CREATE MATERIALIZED VIEW daily_counts
REFRESH EVERY '1d'
PROPERTIES ('timeColumnName' = 'day', 'bucketTimePeriod' = '1d')
AS
SELECT DATETRUNC('DAY', ts) AS day, COUNT(*) AS cnt
FROM events
GROUP BY day;
```

### B. Idempotent re-deploy with `IF NOT EXISTS`

```sql
CREATE MATERIALIZED VIEW IF NOT EXISTS analytics.daily_counts
REFRESH EVERY 1 DAY
PROPERTIES ('timeColumnName' = 'day', 'bucketTimePeriod' = '1d')
AS
SELECT DATETRUNC('DAY', ts) AS day, COUNT(*) AS cnt
FROM analytics.events
GROUP BY day;
```

### C. Time column via arithmetic scaling (base column stored as epoch-days)

```sql
CREATE MATERIALIZED VIEW dau
REFRESH EVERY 1 DAY
PROPERTIES ('timeColumnName' = 'ts', 'bucketTimePeriod' = '1d')
AS
SELECT DaysSinceEpoch * 86400000 AS ts, COUNT(*) AS dau
FROM clickstreamFunnel
GROUP BY ts;
```

### D. Identity passthrough of a TIMESTAMP base column

```sql
CREATE MATERIALIZED VIEW per_event
REFRESH EVERY 1 HOUR
PROPERTIES ('timeColumnName' = 'ts', 'bucketTimePeriod' = '1h')
AS
SELECT ts, event_name, SUM(dwell_ms) AS dwell
FROM clickstreamFunnel
GROUP BY ts, event_name;
```

### E. All supported aggregations (incl. raw sketches → BYTES)

```sql
CREATE MATERIALIZED VIEW agg_rollup
REFRESH EVERY 15 MINUTE
PROPERTIES ('timeColumnName' = 'm', 'bucketTimePeriod' = '1d')
AS
SELECT DATETRUNC('DAY', ts) AS m,
       COUNT(*)                             AS cnt,      -- LONG
       SUM(amount)                          AS total,    -- DOUBLE
       MIN(amount)                          AS min_amt,  -- DOUBLE
       MAX(amount)                          AS max_amt,  -- DOUBLE
       DISTINCTCOUNTRAWHLL(user_id)         AS u_hll,    -- BYTES
       DISTINCTCOUNTRAWTHETASKETCH(user_id) AS u_theta   -- BYTES
FROM clickstreamFunnel
GROUP BY m;
```

### F. Sub-hour refresh + bounded staleness SLO

```sql
CREATE MATERIALIZED VIEW analytics.minute_dau
REFRESH EVERY 1 MINUTE
PROPERTIES (
    'timeColumnName'       = 'minute_ts',
    'bucketTimePeriod'     = '1m',
    'bufferTimePeriod'     = '30s',
    'stalenessThresholdMs' = '60000'
)
AS
SELECT DATETRUNC('MINUTE', ts) AS minute_ts, COUNT(*) AS dau
FROM clickstreamFunnel
GROUP BY minute_ts;
```

### G. Heavy daily roll-up with back-fill and segment sizing

```sql
CREATE MATERIALIZED VIEW analytics.daily_funnel
REFRESH EVERY '15m'
PROPERTIES (
    'timeColumnName'          = 'event_day',
    'bucketTimePeriod'        = '1d',
    'bufferTimePeriod'        = '1h',
    'maxNumRecordsPerSegment' = '2000000',
    'maxTasksPerBatch'        = '16',
    'replication'             = '2'
)
AS
SELECT DATETRUNC('DAY', ts) AS event_day,
       event_name,
       user_id,
       COUNT(*)              AS event_count,
       SUM(dwell_ms)         AS total_dwell_ms
FROM clickstreamFunnel
GROUP BY event_day, event_name, user_id;
```

### H. Explicit column list (override an inferred type)

```sql
CREATE MATERIALIZED VIEW typed_rollup (
    day        TIMESTAMP DATETIME FORMAT '1:MILLISECONDS:TIMESTAMP'
                                  GRANULARITY '1:MILLISECONDS' NOT NULL,
    region     STRING    NOT NULL DEFAULT 'unknown',
    cnt        INT       METRIC   NOT NULL          -- tightened from inferred LONG
)
REFRESH EVERY '1d'
PROPERTIES ('timeColumnName' = 'day', 'bucketTimePeriod' = '1d')
AS
SELECT DATETRUNC('DAY', ts) AS day, region, COUNT(*) AS cnt
FROM events
GROUP BY day, region;
```

### I. `INTERVAL` sugar + prefixed task knob

```sql
CREATE MATERIALIZED VIEW sugar_mv
REFRESH INTERVAL EVERY 6 HOURS
PROPERTIES (
    'timeColumnName' = 'h',
    'bucketTimePeriod' = '1d',
    'task.MaterializedViewTask.maxTasksPerBatch' = '8'   -- prefixed form; canonicalizes to bare
)
AS
SELECT DATETRUNC('HOUR', ts) AS h, COUNT(*) AS cnt
FROM events
GROUP BY h;
```

### J. No `REFRESH` clause (runs on the cluster-wide MV cron)

```sql
CREATE MATERIALIZED VIEW cluster_cron_mv
PROPERTIES ('timeColumnName' = 'day', 'bucketTimePeriod' = '1d')
AS
SELECT DATETRUNC('DAY', ts) AS day, COUNT(*) AS cnt
FROM events
GROUP BY day;
```

### K. Inspect & drop

```sql
SHOW MATERIALIZED VIEWS;
SHOW MATERIALIZED VIEWS FROM analytics;
SHOW CREATE MATERIALIZED VIEW analytics.daily_funnel;
DROP MATERIALIZED VIEW analytics.daily_funnel;
DROP MATERIALIZED VIEW IF EXISTS analytics.maybe_missing;
```

### L. POSTing DDL to the controller

Pinot SQL uses single-quoted string literals, which collide with shell quoting inside an
inline `curl -d`. The cleanest path is to put the request body in a file. `create_mv.json`:

```json
{
  "sql": "CREATE MATERIALIZED VIEW daily_counts REFRESH EVERY 1 DAY PROPERTIES ('timeColumnName' = 'day', 'bucketTimePeriod' = '1d') AS SELECT DATETRUNC('DAY', ts) AS day, COUNT(*) AS cnt FROM events GROUP BY day"
}
```

```bash
# Create (inferred MV, recommended)
curl -sS -u "$PINOT_USER:$PINOT_PASS" \
     -H 'Content-Type: application/json' \
     -H 'Database: analytics' \
     -d @create_mv.json \
     "$PINOT_CONTROLLER/sql/ddl"

# Dry-run: compile + validate (and resolve the inferred schema) without persisting
curl -sS ... -d @create_mv.json "$PINOT_CONTROLLER/sql/ddl?dryRun=true"

# Inspect / drop (short statements inline; note the single quotes inside the JSON string)
curl -sS ... -d '{"sql": "SHOW CREATE MATERIALIZED VIEW analytics.daily_counts"}' "$PINOT_CONTROLLER/sql/ddl"
curl -sS ... -d '{"sql": "DROP MATERIALIZED VIEW IF EXISTS analytics.daily_counts"}'  "$PINOT_CONTROLLER/sql/ddl"
```

---

## Strict TABLE / MATERIALIZED VIEW partitioning at the REST boundary

The DDL verbs refuse to act on the wrong target type — enforced symmetrically:

| Verb on wrong target | HTTP | Error message |
| --- | --- | --- |
| `SHOW CREATE TABLE` on an MV | **400** | *"… is a materialized view. Use 'SHOW CREATE MATERIALIZED VIEW …'"* |
| `SHOW CREATE MATERIALIZED VIEW` on a plain table | **400** | *"… is not a materialized view. Use 'SHOW CREATE TABLE …'"* |
| `DROP TABLE` on an MV | **400** | *"… is a materialized view. Use 'DROP MATERIALIZED VIEW …'"* |
| `DROP MATERIALIZED VIEW` on a plain table | **400** | *"… is not a materialized view. Use 'DROP TABLE …'"* |
| `DROP MATERIALIZED VIEW IF EXISTS` on a plain table | **400** | `IF EXISTS` is about absence, not type confusion. |
| `CREATE MATERIALIZED VIEW IF NOT EXISTS` racing a plain OFFLINE create | **409** | Type-mismatch wins over `IF NOT EXISTS` even in the race-catch path. |

---

## REST endpoint contract

All MV DDL operations are sent to the same endpoint as the Table DDL PR:

```
POST /sql/ddl[?dryRun=true|false]
Content-Type: application/json
Authorization: <Bearer | Basic …>
Database: <optional database name — threaded into the compile context so an unqualified
           FROM <src> in an inferred MV resolves under this database>

{ "sql": "<single DDL statement>" }
```

### Response codes (MV-specific outcomes)

| Code | Operation | Meaning |
| --- | --- | --- |
| `200 OK` | DROP / SHOW / `IF [NOT] EXISTS` no-op / dry-run | Operation succeeded. |
| `201 Created` | CREATE MATERIALIZED VIEW | MV was created and persisted to ZK. |
| `400 Bad Request` | All | Parse / semantic error; period out of range; type confusion; REALTIME source; unsupported `AS <query>` shape; unaliased / `SELECT *`; mixed (partial-explicit) column list; non-round-trippable cron on `SHOW CREATE`; malformed / negative `stalenessThresholdMs`. |
| `404 Not Found` | DROP / SHOW CREATE | MV not found (DROP without `IF EXISTS`, or `SHOW CREATE` on a missing MV). |
| `409 Conflict` | CREATE | Same-name table/MV already exists without `IF NOT EXISTS`; race lost to a concurrent writer (including a plain-OFFLINE writer under `IF NOT EXISTS`). |
| `500 Internal Server Error` | All | Helix/ZK inconsistency or controller defect. |

The full response shape (`operation`, `tableName`, `databaseName`, `schema`, `tableConfig`, `warnings`, `message`, …) is the same as the Table DDL PR. `SHOW MATERIALIZED VIEWS` populates the existing `tableNames` field.

### Dry-run

`?dryRun=true` compiles + validates and returns the would-be `Schema` + `TableConfig`, but persists nothing. Inferred column lists are fully resolved during dry-run, so operators can preview the inferred `Schema` before committing.

---

## Authorization

MV DDLs reuse the **same action constants** as their Table DDL counterparts (`CREATE_TABLE`, `GET_TABLE_CONFIG`, `DELETE_TABLE`). Introducing new MV-specific actions would silently lock operators with `CREATE_TABLE` out of MV creation during rolling upgrade. Authorization happens **after** database-name translation, against the post-translation resource.

---

## Rolling-upgrade safety

The DDL feature is purely additive. No SPI signature, no enum, no `TableConfig` / `Schema` field, and no ZK property-store path is renamed or removed. Persisted artifacts produced by `POST /sql/ddl` are shape-identical to those produced by the existing `POST /tables` and `POST /schemas` endpoints — old brokers, servers, and controllers read DDL-created MVs exactly as they read JSON-API-created MVs.

- Pre-DDL controllers return 404 on `POST /sql/ddl`. There is no half-state.
- New SQL keywords (`MATERIALIZED`, `REFRESH`, `VIEWS`) are added under `nonReservedKeywordsToAdd`. Existing DQL queries using them as identifiers continue to parse on the new binary.
- Rollback to a pre-DDL controller continues to serve DDL-created MVs identically to JSON-API MVs.
- Stale MV definition znodes (left by a failed best-effort cleanup in a prior DROP) are skipped during reverse-index rebuild with a WARN log, preventing ghost MVs after a partial DROP.

---

## Test plan

- [x] **Parser tests** (`PinotDdlParserTest`) — `CREATE MATERIALIZED VIEW` all syntactic variants, including the optional column list (present / empty / mixed-rejection); `REFRESH [INTERVAL] EVERY` quoted-period and sugared (`N MINUTES` / `N HOURS` / `N DAYS`) forms; rejection of `SECOND/WEEK/MONTH/YEAR` sugar; `SHOW MATERIALIZED VIEWS [FROM db]`; `SHOW CREATE MATERIALIZED VIEW`; `DROP MATERIALIZED VIEW [IF EXISTS]`; rejection of `TYPE` on MV-specific SHOW/DROP.
- [x] **Compiler tests** (`DdlCompilerMaterializedViewTest`, `DdlCompilerMaterializedViewInferenceTest`) — every `PROPERTIES` routing rule (incl. bare/prefix case canonicalization); period → Quartz cron mapping including boundary rejections; `AS <query>` raw-substring preservation; rejection of `JOIN`, `SELECT *`, undefined-column references; partial-column-list rejection; explicit-column path bypasses the inferer.
- [x] **Inferer tests** (`MaterializedViewSchemaInfererTest`) — time column → canonical TIMESTAMP regardless of SELECT shape; all 7 catalog aggregations (sketches assert `BYTES`); passthrough/scalar → DIMENSION with the Calcite type; `SELECT *`, unaliased aggregation, duplicate alias, missing/absent `timeColumnName`, and the unknown-column Calcite-validation surface all rejected; column order mirrors SELECT order.
- [x] **Reverse-DDL tests** (`CanonicalDdlEmitterMaterializedViewTest`) — canonical clause order; lexicographic property ordering; non-round-trippable cron rejection; MV task knob flattening (incl. the TreeMap iterator-mutation regression); `SHOW CREATE` always emits the explicit-column form.
- [x] **Round-trip tests** (`RoundTripTest`) — `emit → parse → compile → emit` idempotence across all PROPERTIES routing rules + the `REFRESH EVERY` clause + both column-list forms.
- [x] **Time-expression tests** (`TimeExprParserTest`, `TimeExprValidatorTest`) — identity / DATETRUNC / arithmetic-scaling shape recognition + the TIMESTAMP / `bucketTimePeriod` / base-column policy layer.
- [x] **Analyzer tests** (`MaterializedViewAnalyzerTest`) — task-config validation (`bucketTimePeriod`, `bufferTimePeriod`, `maxNumRecordsPerSegment`, `maxTasksPerBatch`, `stalenessThresholdMs`) including malformed / negative rejection and the `stalenessThresholdMs=0` "no SLO" sentinel.
- [x] **Controller unit tests** (`PinotDdlRestletResourceMaterializedViewUnitTest`, `PinotDdlRestletResourceUnitTest`) — CREATE / SHOW CREATE / SHOW MATERIALIZED VIEWS / DROP dispatch, response shape, authorization (403 on permission deny), 400 on strict type-partitioning violations, `IF NOT EXISTS` race-catch returning 409 when the race-winner is a plain OFFLINE table.
- [x] **Resource manager tests** (`PinotHelixResourceManagerMaterializedViewListingTest`, `PinotHelixResourceManagerMaterializedViewBackfillTest`) — `getAllRawMaterializedViewNames` filters by `isMaterializedView()`, skips REALTIME, tolerates corrupted znodes, scopes by database; backfill recovers MVs whose in-session znode persist failed.
- [x] **Consistency-manager tests** (`MaterializedViewConsistencyManagerTest`) — orphan MV definition znodes (TableConfig missing or non-MV) skipped during reverse-index rebuild.
- [x] **Integration tests** (`MaterializedViewDdlAnalyzerIntegrationTest`) — DDL creates an MV that the real `MaterializedViewAnalyzer` accepts on a live cluster, for both inferred and explicit column-list forms.

All tests pass. `./mvnw spotless:apply checkstyle:check license:check` clean across `pinot-common`, `pinot-sql-ddl`, `pinot-controller`, and `pinot-materialized-view`.
